### PR TITLE
feat(desktop): add credential deletion to settings

### DIFF
--- a/.changeset/local-credential-deletion.md
+++ b/.changeset/local-credential-deletion.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Settings can now delete locally saved provider, ChatGPT, and intervals.icu credentials, immediately stop active use, and guide you back to Setup to sign in again.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -11,6 +11,9 @@ interface EnduragentAuth {
     readonly value: string;
     readonly selection?: OnboardingLlmSelection;
   }): Promise<CredentialWriteResult>;
+  deleteCredential(input: {
+    readonly credential: DesktopCredentialId;
+  }): Promise<CredentialDeleteResult>;
   llmConfiguration(): Promise<OnboardingLlmConfiguration>;
   applyLlmSelection(input: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
   chatgptStatus(): Promise<ChatGptStatus>;
@@ -56,6 +59,8 @@ type DesktopCredentialSlot =
   | "kimi"
   | "zai"
   | "intervals-icu";
+
+type DesktopCredentialId = DesktopCredentialSlot | "openai-codex";
 
 type LlmProvider = Exclude<DesktopCredentialSlot, "intervals-icu"> | "openai-codex";
 
@@ -143,6 +148,23 @@ type CredentialWriteResult =
         | "storage-failed"
         | "runtime-unavailable"
         | "training-account-mismatch";
+    };
+
+type CredentialDeleteResult =
+  | {
+      readonly credential: DesktopCredentialId;
+      readonly status: "deleted";
+      readonly cleanupPending: boolean;
+    }
+  | {
+      readonly credential: DesktopCredentialId;
+      readonly status: "refused";
+      readonly reason:
+        | "not-found"
+        | "managed-by-environment"
+        | "storage-failed"
+        | "runtime-unavailable"
+        | "runtime-state-diverged";
     };
 
 interface Window {

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -36,6 +36,8 @@ import { createAthleteSettingsView } from "./settings/athlete-view.js";
 import { createResidentSettingsShell } from "./settings/shell.js";
 import { createSessionSettingsController } from "./settings/session-controller.js";
 import { createSessionSettingsView } from "./settings/session-view.js";
+import { createCredentialSettingsController } from "./settings/credential-controller.js";
+import { createCredentialSettingsView } from "./settings/credential-view.js";
 import {
   createRideImportController,
   mountResidentRideImport,
@@ -299,6 +301,7 @@ const providerModelSettingsView = createProviderModelSettingsView({
   document,
   shell: settingsShell,
 });
+const credentialSettingsView = createCredentialSettingsView({ document, shell: settingsShell });
 const athleteSettingsView = createAthleteSettingsView({ document, shell: settingsShell });
 const sessionSettingsView = createSessionSettingsView({ document, shell: settingsShell });
 const sessionSettingsController = createSessionSettingsController({
@@ -306,10 +309,27 @@ const sessionSettingsController = createSessionSettingsController({
   beginMutation: () => settingsShell.beginMutation("session"),
   view: sessionSettingsView,
 });
+const credentialSettingsController = createCredentialSettingsController({
+  clients,
+  loadStatuses: () => window.enduragentAuth.credentialStatuses(),
+  loadChatGptStatus: () => window.enduragentAuth.chatgptStatus(),
+  deleteCredential: (value) => window.enduragentAuth.deleteCredential(value),
+  openSetup: () => {
+    providerModelSettingsController.close();
+    credentialSettingsController.close();
+    athleteSettingsController.close();
+    sessionSettingsController.close();
+    settingsShell.close();
+    setup.click();
+  },
+  beginMutation: () => settingsShell.beginMutation("credential"),
+  view: credentialSettingsView,
+});
 const athleteSettingsController = createAthleteSettingsController({
   clients,
   openSetup: () => {
     providerModelSettingsController.close();
+    credentialSettingsController.close();
     athleteSettingsController.close();
     sessionSettingsController.close();
     settingsShell.close();
@@ -323,6 +343,7 @@ const providerModelSettingsController = createProviderModelSettingsController({
   apply: (selection) => window.enduragentAuth.applyLlmSelection(selection),
   openSetup: () => {
     providerModelSettingsController.close();
+    credentialSettingsController.close();
     athleteSettingsController.close();
     sessionSettingsController.close();
     settingsShell.close();
@@ -334,11 +355,13 @@ const providerModelSettingsController = createProviderModelSettingsController({
 settingsShell.bind({
   onOpen() {
     void providerModelSettingsController.activate();
+    void credentialSettingsController.activate();
     void athleteSettingsController.activate();
     void sessionSettingsController.activate();
   },
   onClose() {
     providerModelSettingsController.close();
+    credentialSettingsController.close();
     athleteSettingsController.close();
     sessionSettingsController.close();
     settingsShell.close();
@@ -371,6 +394,7 @@ window.addEventListener(
     releaseNotesController.dispose();
     desktopUpdateController.dispose();
     providerModelSettingsController.dispose();
+    credentialSettingsController.dispose();
     athleteSettingsController.dispose();
     sessionSettingsController.dispose();
     settingsShell.dispose();

--- a/apps/desktop-renderer/src/onboarding/bridge.ts
+++ b/apps/desktop-renderer/src/onboarding/bridge.ts
@@ -29,6 +29,25 @@ export type CredentialWriteResult =
         | "training-account-mismatch";
     };
 
+export type DesktopCredentialId = DesktopCredentialSlot | "openai-codex";
+
+export type CredentialDeleteResult =
+  | {
+      readonly credential: DesktopCredentialId;
+      readonly status: "deleted";
+      readonly cleanupPending: boolean;
+    }
+  | {
+      readonly credential: DesktopCredentialId;
+      readonly status: "refused";
+      readonly reason:
+        | "not-found"
+        | "managed-by-environment"
+        | "storage-failed"
+        | "runtime-unavailable"
+        | "runtime-state-diverged";
+    };
+
 export interface OnboardingLlmModelOption {
   readonly value: string;
   readonly label: string;

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -1,0 +1,431 @@
+import { CoachClientDisconnectedError, type CoachClient } from "@enduragent/coach-client";
+import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../coach-client.js";
+import type { CredentialDeleteResult, DesktopCredentialId } from "../onboarding/bridge.js";
+import type { ChatGptStatus, CredentialSlotStatus } from "../onboarding/machine.js";
+
+export type CredentialKind = "Provider API key" | "ChatGPT profile" | "Training account key";
+
+export interface CredentialSettingsEntry {
+  readonly credential: DesktopCredentialId;
+  readonly provider: string;
+  readonly kind: CredentialKind;
+  readonly runtimeState: "active" | "stored-inactive" | "failed";
+}
+
+export type CredentialSettingsFocus =
+  | { readonly target: "confirmation-cancel" | "confirmation-delete" | "setup" }
+  | { readonly target: "delete"; readonly credential: DesktopCredentialId }
+  | null;
+
+interface CredentialSettingsContent {
+  readonly entries: readonly CredentialSettingsEntry[];
+  readonly confirmation: DesktopCredentialId | null;
+  readonly announcement: string;
+  readonly recoveryAvailable: boolean;
+  readonly focus: CredentialSettingsFocus;
+}
+
+export type CredentialSettingsState =
+  | { readonly status: "closed" }
+  | { readonly status: "loading" }
+  | ({
+      readonly status: "ready" | "confirming" | "deleting" | "deleted";
+    } & CredentialSettingsContent)
+  | ({
+      readonly status: "error";
+      readonly kind: "delete";
+      readonly reason: Extract<CredentialDeleteResult, { readonly status: "refused" }>["reason"];
+    } & CredentialSettingsContent)
+  | {
+      readonly status: "error";
+      readonly kind: "load";
+      readonly announcement: string;
+      readonly recoveryAvailable: boolean;
+      readonly focus: CredentialSettingsFocus;
+    };
+
+export interface CredentialSettingsView {
+  bind(handlers: {
+    readonly onRetry: () => void;
+    readonly onRequestDelete: (credential: DesktopCredentialId) => void;
+    readonly onCancelDelete: () => void;
+    readonly onConfirmDelete: () => void;
+    readonly onOpenSetup: () => void;
+  }): void;
+  render(state: Exclude<CredentialSettingsState, { readonly status: "closed" }>): void;
+  dispose(): void;
+}
+
+export interface CredentialSettingsController {
+  activate(): Promise<void>;
+  close(): void;
+  state(): CredentialSettingsState;
+  dispose(): void;
+}
+
+const PROVIDER_NAMES: Readonly<Record<DesktopCredentialId, string>> = {
+  anthropic: "Anthropic",
+  openrouter: "OpenRouter",
+  openai: "OpenAI",
+  google: "Google",
+  deepseek: "DeepSeek",
+  qwen: "Qwen",
+  minimax: "MiniMax",
+  kimi: "Kimi",
+  zai: "Z.AI",
+  "openai-codex": "ChatGPT",
+  "intervals-icu": "intervals.icu",
+};
+
+const CREDENTIAL_ORDER: readonly DesktopCredentialId[] = [
+  "anthropic",
+  "openai",
+  "google",
+  "openai-codex",
+  "deepseek",
+  "qwen",
+  "minimax",
+  "kimi",
+  "zai",
+  "openrouter",
+  "intervals-icu",
+];
+
+function kind(credential: DesktopCredentialId): CredentialKind {
+  if (credential === "openai-codex") return "ChatGPT profile";
+  if (credential === "intervals-icu") return "Training account key";
+  return "Provider API key";
+}
+
+function entriesFrom(
+  statuses: readonly CredentialSlotStatus[],
+  chatGpt: ChatGptStatus,
+  runtime: RuntimeConfigSnapshot,
+): readonly CredentialSettingsEntry[] {
+  const entries = new Map<DesktopCredentialId, CredentialSettingsEntry>();
+  for (const status of statuses) {
+    if (status.state === "missing") continue;
+    const runtimeActive =
+      status.slot === "intervals-icu"
+        ? runtime.intervals.credential_configured
+        : runtime.llm.credential_configured && runtime.llm.provider === status.slot;
+    entries.set(status.slot, {
+      credential: status.slot,
+      provider: PROVIDER_NAMES[status.slot],
+      kind: kind(status.slot),
+      runtimeState: runtimeActive
+        ? "active"
+        : status.state === "re-prompt" || status.runtimeState === "failed"
+          ? "failed"
+          : "stored-inactive",
+    });
+  }
+  if (chatGpt.state === "configured") {
+    entries.set("openai-codex", {
+      credential: "openai-codex",
+      provider: PROVIDER_NAMES["openai-codex"],
+      kind: kind("openai-codex"),
+      runtimeState: chatGpt.runtimeReady ? "active" : "stored-inactive",
+    });
+  }
+  if (runtime.llm.credential_configured && !entries.has(runtime.llm.provider)) {
+    const credential = runtime.llm.provider satisfies DesktopCredentialId;
+    entries.set(credential, {
+      credential,
+      provider: PROVIDER_NAMES[credential],
+      kind: kind(credential),
+      runtimeState: "active",
+    });
+  }
+  if (runtime.intervals.credential_configured && !entries.has("intervals-icu")) {
+    entries.set("intervals-icu", {
+      credential: "intervals-icu",
+      provider: PROVIDER_NAMES["intervals-icu"],
+      kind: kind("intervals-icu"),
+      runtimeState: "active",
+    });
+  }
+  return CREDENTIAL_ORDER.flatMap((credential) => {
+    const entry = entries.get(credential);
+    return entry === undefined ? [] : [entry];
+  });
+}
+
+function refusalCopy(
+  reason: Extract<CredentialDeleteResult, { readonly status: "refused" }>["reason"],
+): string {
+  if (reason === "managed-by-environment") {
+    return "This credential is managed outside Settings and can’t be deleted here.";
+  }
+  if (reason === "not-found") {
+    return "That credential is no longer stored. Reload to refresh the list.";
+  }
+  if (reason === "storage-failed") {
+    return "The credential remains stored. No deletion was completed. Try again.";
+  }
+  if (reason === "runtime-state-diverged") {
+    return "The saved and active credential states could not be reconciled. Reconnect and reload before trying again.";
+  }
+  return "The coach could not stop using this credential safely. It was not deleted.";
+}
+
+export function createCredentialSettingsController(input: {
+  readonly clients: DesktopCoachClientProvider;
+  readonly loadStatuses: () => Promise<readonly CredentialSlotStatus[]>;
+  readonly loadChatGptStatus: () => Promise<ChatGptStatus>;
+  readonly deleteCredential: (input: {
+    readonly credential: DesktopCredentialId;
+  }) => Promise<CredentialDeleteResult>;
+  readonly openSetup: () => void;
+  readonly beginMutation: () => (() => void) | null;
+  readonly view: CredentialSettingsView;
+}): CredentialSettingsController {
+  let currentState: CredentialSettingsState = { status: "closed" };
+  let generation = 0;
+  let disposed = false;
+  let operation: Promise<void> | undefined;
+  let reconnectRequired = false;
+  let failedClient: CoachClient | undefined;
+
+  const render = (state: Exclude<CredentialSettingsState, { readonly status: "closed" }>): void => {
+    currentState = state;
+    input.view.render(state);
+  };
+
+  const runtimeClient = async (): Promise<CoachClient> => {
+    if (!reconnectRequired) return input.clients.getClient();
+    const current = await input.clients.getClient();
+    const client =
+      failedClient !== undefined && current === failedClient
+        ? await input.clients.reconnect()
+        : current;
+    reconnectRequired = false;
+    failedClient = undefined;
+    return client;
+  };
+
+  const loadEntries = async (): Promise<readonly CredentialSettingsEntry[]> => {
+    const client = await runtimeClient();
+    try {
+      const [statuses, chatGpt, runtime] = await Promise.all([
+        input.loadStatuses(),
+        input.loadChatGptStatus(),
+        client.call("getRuntimeConfig", {}),
+      ]);
+      return entriesFrom(statuses, chatGpt, runtime);
+    } catch (error) {
+      if (error instanceof CoachClientDisconnectedError) {
+        reconnectRequired = true;
+        failedClient = client;
+      }
+      throw error;
+    }
+  };
+
+  const startLoad = (): Promise<void> => {
+    if (disposed || operation !== undefined) return operation ?? Promise.resolve();
+    const operationGeneration = ++generation;
+    render({ status: "loading" });
+    const pending = loadEntries()
+      .then(
+        (entries) => {
+          if (disposed || generation !== operationGeneration) return;
+          render({
+            status: "ready",
+            entries,
+            confirmation: null,
+            announcement: "",
+            recoveryAvailable: false,
+            focus: null,
+          });
+        },
+        () => {
+          if (disposed || generation !== operationGeneration) return;
+          render({
+            status: "error",
+            kind: "load",
+            announcement: "Saved credentials aren’t available. Reconnect and reload.",
+            recoveryAvailable: false,
+            focus: null,
+          });
+        },
+      )
+      .finally(() => {
+        if (operation === pending) operation = undefined;
+      });
+    operation = pending;
+    return pending;
+  };
+
+  const contentState = (): CredentialSettingsContent | null => {
+    if (
+      currentState.status === "ready" ||
+      currentState.status === "confirming" ||
+      currentState.status === "deleting" ||
+      currentState.status === "deleted" ||
+      (currentState.status === "error" && currentState.kind === "delete")
+    ) {
+      return currentState;
+    }
+    return null;
+  };
+
+  const requestDelete = (credential: DesktopCredentialId): void => {
+    if (disposed || operation !== undefined) return;
+    const content = contentState();
+    if (content === null || !content.entries.some((entry) => entry.credential === credential)) {
+      return;
+    }
+    render({
+      status: "confirming",
+      entries: content.entries,
+      confirmation: credential,
+      announcement: `Confirm deletion of the ${PROVIDER_NAMES[credential]} credential.`,
+      recoveryAvailable: content.recoveryAvailable,
+      focus: { target: "confirmation-cancel" },
+    });
+  };
+
+  const cancelDelete = (): void => {
+    if (disposed || operation !== undefined) return;
+    const content = contentState();
+    if (content === null || content.confirmation === null) return;
+    const credential = content.confirmation;
+    render({
+      status: "ready",
+      entries: content.entries,
+      confirmation: null,
+      announcement: "Credential deletion cancelled.",
+      recoveryAvailable: content.recoveryAvailable,
+      focus: { target: "delete", credential },
+    });
+  };
+
+  const confirmDelete = (): Promise<void> => {
+    if (disposed || operation !== undefined) return operation ?? Promise.resolve();
+    const content = contentState();
+    if (content === null || content.confirmation === null) return Promise.resolve();
+    const target = content.entries.find((entry) => entry.credential === content.confirmation);
+    if (target === undefined) return Promise.resolve();
+    const releaseMutation = input.beginMutation();
+    if (releaseMutation === null) return Promise.resolve();
+    const credential = target.credential;
+    const operationGeneration = ++generation;
+    render({
+      status: "deleting",
+      entries: content.entries,
+      confirmation: credential,
+      announcement: `Deleting the ${target.provider} credential locally…`,
+      recoveryAvailable: content.recoveryAvailable,
+      focus: { target: "confirmation-delete" },
+    });
+    const pending = input
+      .deleteCredential({ credential })
+      .then(async (result) => {
+        let entries = content.entries;
+        let refreshFailed = false;
+        try {
+          entries = await loadEntries();
+        } catch {
+          refreshFailed = true;
+          if (result.status === "deleted") {
+            entries = entries.filter((entry) => entry.credential !== credential);
+          }
+        }
+        if (disposed || generation !== operationGeneration) return;
+        if (result.status === "refused") {
+          render({
+            status: "error",
+            kind: "delete",
+            reason: result.reason,
+            entries,
+            confirmation: null,
+            announcement: refusalCopy(result.reason),
+            recoveryAvailable:
+              content.recoveryAvailable || result.reason === "runtime-state-diverged",
+            focus: { target: "delete", credential },
+          });
+          return;
+        }
+        const recoveryAvailable = content.recoveryAvailable || target.runtimeState === "active";
+        const nextDelete = entries[0]?.credential;
+        render({
+          status: "deleted",
+          entries,
+          confirmation: null,
+          announcement: result.cleanupPending
+            ? "Credential deleted locally. Secure storage cleanup will be retried."
+            : refreshFailed
+              ? "Credential deleted locally. Current credential status couldn’t be refreshed."
+              : "Credential deleted locally.",
+          recoveryAvailable,
+          focus: recoveryAvailable
+            ? { target: "setup" }
+            : nextDelete === undefined
+              ? null
+              : { target: "delete", credential: nextDelete },
+        });
+      })
+      .catch(() => {
+        if (disposed || generation !== operationGeneration) return;
+        render({
+          status: "error",
+          kind: "delete",
+          reason: "runtime-unavailable",
+          entries: content.entries,
+          confirmation: null,
+          announcement:
+            "The credential state could not be confirmed. Reconnect and reload before trying again.",
+          recoveryAvailable: content.recoveryAvailable,
+          focus: { target: "delete", credential },
+        });
+      })
+      .finally(() => {
+        releaseMutation();
+        if (operation === pending) operation = undefined;
+      });
+    operation = pending;
+    return pending;
+  };
+
+  const openSetup = (): void => {
+    const content = contentState();
+    if (disposed || operation !== undefined || content?.recoveryAvailable !== true) return;
+    currentState = { status: "closed" };
+    input.openSetup();
+  };
+
+  const close = (): void => {
+    if (disposed) return;
+    ++generation;
+    operation = undefined;
+    currentState = { status: "closed" };
+  };
+
+  input.view.bind({
+    onRetry: () => void startLoad(),
+    onRequestDelete: requestDelete,
+    onCancelDelete: cancelDelete,
+    onConfirmDelete: () => void confirmDelete(),
+    onOpenSetup: openSetup,
+  });
+
+  return {
+    activate() {
+      if (disposed) return Promise.resolve();
+      if (currentState.status !== "closed") return operation ?? Promise.resolve();
+      return startLoad();
+    },
+    close,
+    state: () => currentState,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      ++generation;
+      operation = undefined;
+      currentState = { status: "closed" };
+      input.view.dispose();
+    },
+  };
+}

--- a/apps/desktop-renderer/src/settings/credential-view.ts
+++ b/apps/desktop-renderer/src/settings/credential-view.ts
@@ -1,0 +1,261 @@
+import type { DesktopCredentialId } from "../onboarding/bridge.js";
+import type {
+  CredentialSettingsEntry,
+  CredentialSettingsState,
+  CredentialSettingsView,
+} from "./credential-controller.js";
+import type { ResidentSettingsShell } from "./shell.js";
+
+function element<K extends keyof HTMLElementTagNameMap>(
+  document: Document,
+  name: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const value = document.createElement(name);
+  if (className !== undefined) value.className = className;
+  if (text !== undefined) value.textContent = text;
+  return value;
+}
+
+function stateLabel(state: CredentialSettingsEntry["runtimeState"]): string {
+  if (state === "active") return "Active";
+  if (state === "stored-inactive") return "Saved, not active";
+  return "Needs attention";
+}
+
+export function createCredentialSettingsView(input: {
+  readonly document: Document;
+  readonly shell: ResidentSettingsShell;
+}): CredentialSettingsView {
+  const section = element(
+    input.document,
+    "fieldset",
+    "settings-section credential-settings__section",
+  );
+  const legend = element(input.document, "legend", "settings-section__legend", "Credentials");
+  const intro = element(
+    input.document,
+    "p",
+    "settings-section__intro",
+    "Review credentials saved on this Mac. Credential values are never shown.",
+  );
+  const list = element(input.document, "ul", "credential-settings__list");
+  const empty = element(
+    input.document,
+    "p",
+    "credential-settings__empty",
+    "No local credentials are stored.",
+  );
+  const feedback = element(input.document, "p", "credential-settings__feedback");
+  feedback.setAttribute("role", "status");
+  feedback.setAttribute("aria-live", "polite");
+  feedback.setAttribute("aria-atomic", "true");
+  const actions = element(input.document, "footer", "credential-settings__actions");
+  const retry = element(
+    input.document,
+    "button",
+    "credential-settings__retry",
+    "Reconnect & reload",
+  );
+  retry.type = "button";
+  const openSetup = element(input.document, "button", "credential-settings__setup", "Open Setup");
+  openSetup.type = "button";
+  actions.append(retry, openSetup);
+  section.append(legend, intro, list, empty, feedback, actions);
+  input.shell.body.append(section);
+
+  let disposed = false;
+  let anyMutation = input.shell.mutationActive;
+  let lastState: Exclude<CredentialSettingsState, { readonly status: "closed" }> | undefined;
+  let handlers:
+    | {
+        readonly onRetry: () => void;
+        readonly onRequestDelete: (credential: DesktopCredentialId) => void;
+        readonly onCancelDelete: () => void;
+        readonly onConfirmDelete: () => void;
+        readonly onOpenSetup: () => void;
+      }
+    | undefined;
+  const deleteButtons = new Map<DesktopCredentialId, HTMLButtonElement>();
+  let confirmationCancel: HTMLButtonElement | undefined;
+  let confirmationDelete: HTMLButtonElement | undefined;
+
+  const applyInteractivity = (): void => {
+    const deleting = lastState?.status === "deleting";
+    for (const button of deleteButtons.values()) button.disabled = anyMutation;
+    retry.disabled = anyMutation || lastState?.status === "loading";
+    openSetup.disabled = anyMutation;
+    if (confirmationCancel !== undefined) confirmationCancel.disabled = anyMutation;
+    if (confirmationDelete !== undefined) {
+      if (deleting) {
+        confirmationDelete.disabled = false;
+        confirmationDelete.setAttribute("aria-disabled", "true");
+      } else {
+        confirmationDelete.disabled = anyMutation;
+        confirmationDelete.removeAttribute("aria-disabled");
+      }
+    }
+  };
+
+  const renderEntries = (
+    entries: readonly CredentialSettingsEntry[],
+    confirmation: DesktopCredentialId | null,
+  ): void => {
+    deleteButtons.clear();
+    confirmationCancel = undefined;
+    confirmationDelete = undefined;
+    const rows = entries.map((entry) => {
+      const row = element(input.document, "li", "credential-settings__item");
+      row.dataset.credential = entry.credential;
+      const identity = element(input.document, "div", "credential-settings__identity");
+      const provider = element(
+        input.document,
+        "span",
+        "credential-settings__provider",
+        entry.provider,
+      );
+      const kind = element(input.document, "span", "credential-settings__kind", entry.kind);
+      identity.append(provider, kind);
+      const runtime = element(
+        input.document,
+        "span",
+        "credential-settings__runtime",
+        stateLabel(entry.runtimeState),
+      );
+      runtime.dataset.state = entry.runtimeState;
+      if (confirmation === entry.credential) {
+        const confirm = element(input.document, "div", "credential-settings__confirmation");
+        confirm.setAttribute("role", "group");
+        const title = element(
+          input.document,
+          "p",
+          "credential-settings__confirmation-title",
+          `Delete the ${entry.provider} credential?`,
+        );
+        title.id = `credential-settings-confirm-${entry.credential}`;
+        confirm.setAttribute("aria-labelledby", title.id);
+        const copy = element(
+          input.document,
+          "p",
+          "credential-settings__confirmation-copy",
+          "This removes it from this Mac only. Enduragent will stop using it if it is active. Your provider account is unchanged.",
+        );
+        const controls = element(
+          input.document,
+          "div",
+          "credential-settings__confirmation-actions",
+        );
+        confirmationCancel = element(
+          input.document,
+          "button",
+          "credential-settings__cancel-delete",
+          "Cancel",
+        );
+        confirmationCancel.type = "button";
+        confirmationDelete = element(
+          input.document,
+          "button",
+          "credential-settings__confirm-delete",
+          "Delete credential",
+        );
+        confirmationDelete.type = "button";
+        confirmationDelete.setAttribute(
+          "aria-label",
+          `Confirm deletion of the ${entry.provider} credential`,
+        );
+        confirmationCancel.addEventListener("click", () => handlers?.onCancelDelete());
+        confirmationDelete.addEventListener("click", () => {
+          if (confirmationDelete?.getAttribute("aria-disabled") !== "true") {
+            handlers?.onConfirmDelete();
+          }
+        });
+        controls.append(confirmationCancel, confirmationDelete);
+        confirm.append(title, copy, controls);
+        row.append(identity, runtime, confirm);
+      } else {
+        const remove = element(input.document, "button", "credential-settings__delete", "Delete");
+        remove.type = "button";
+        remove.setAttribute("aria-label", `Delete the ${entry.provider} credential`);
+        remove.addEventListener("click", () => handlers?.onRequestDelete(entry.credential));
+        deleteButtons.set(entry.credential, remove);
+        row.append(identity, runtime, remove);
+      }
+      return row;
+    });
+    list.replaceChildren(...rows);
+  };
+
+  const focus = (): void => {
+    const target = lastState !== undefined && "focus" in lastState ? lastState.focus : null;
+    if (target === null || target === undefined) return;
+    if (target.target === "confirmation-cancel") confirmationCancel?.focus();
+    else if (target.target === "confirmation-delete") confirmationDelete?.focus();
+    else if (target.target === "setup") openSetup.focus();
+    else if (target.target === "delete") deleteButtons.get(target.credential)?.focus();
+  };
+
+  const onRetry = (): void => {
+    if (!retry.disabled && !disposed) handlers?.onRetry();
+  };
+  const onOpenSetup = (): void => {
+    if (!openSetup.disabled && !disposed) handlers?.onOpenSetup();
+  };
+  retry.addEventListener("click", onRetry);
+  openSetup.addEventListener("click", onOpenSetup);
+
+  const unregisterFocusables = input.shell.registerFocusables(() => [
+    ...deleteButtons.values(),
+    ...(confirmationCancel === undefined ? [] : [confirmationCancel]),
+    ...(confirmationDelete === undefined ? [] : [confirmationDelete]),
+    retry,
+    openSetup,
+  ]);
+  const unsubscribeMutation = input.shell.subscribeToMutation((active) => {
+    anyMutation = active;
+    applyInteractivity();
+  });
+
+  return {
+    bind(nextHandlers) {
+      handlers = nextHandlers;
+    },
+    render(state) {
+      if (disposed) return;
+      lastState = state;
+      const content =
+        state.status === "ready" ||
+        state.status === "confirming" ||
+        state.status === "deleting" ||
+        state.status === "deleted" ||
+        (state.status === "error" && state.kind === "delete")
+          ? state
+          : null;
+      renderEntries(content?.entries ?? [], content?.confirmation ?? null);
+      list.hidden = content === null || content.entries.length === 0;
+      empty.hidden = content === null || content.entries.length > 0;
+      retry.hidden = !(state.status === "error" && state.kind === "load");
+      const recoveryAvailable = "recoveryAvailable" in state && state.recoveryAvailable;
+      const announcement = "announcement" in state ? state.announcement : "";
+      openSetup.hidden = !recoveryAvailable;
+      feedback.hidden = announcement.length === 0;
+      feedback.textContent =
+        state.status === "loading" ? "Loading saved credentials…" : announcement;
+      if (state.status === "loading") feedback.hidden = false;
+      applyInteractivity();
+      focus();
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      handlers = undefined;
+      lastState = undefined;
+      deleteButtons.clear();
+      unsubscribeMutation();
+      unregisterFocusables();
+      retry.removeEventListener("click", onRetry);
+      openSetup.removeEventListener("click", onOpenSetup);
+      section.remove();
+    },
+  };
+}

--- a/apps/desktop-renderer/src/settings/shell.ts
+++ b/apps/desktop-renderer/src/settings/shell.ts
@@ -68,7 +68,7 @@ export function createResidentSettingsShell(input: {
     input.document,
     "p",
     "provider-model-settings__intro",
-    "Choose the coach route and conversation rhythm, and review the currently connected training account.",
+    "Choose the coach route and conversation rhythm, manage local credentials, and review the currently connected training account.",
   );
   intro.id = "provider-model-settings-intro";
   heading.append(kicker, title, intro);

--- a/apps/desktop-renderer/src/settings/styles.css
+++ b/apps/desktop-renderer/src/settings/styles.css
@@ -46,6 +46,7 @@
 }
 
 .provider-model-settings__section,
+.credential-settings__section,
 .athlete-settings,
 .session-settings {
   min-width: 0;
@@ -546,6 +547,155 @@
   display: none;
 }
 
+.credential-settings__list {
+  display: grid;
+  gap: 10px;
+  margin: 18px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.credential-settings__item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 13px 14px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface-solid);
+}
+
+.credential-settings__identity {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.credential-settings__provider {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.credential-settings__kind,
+.credential-settings__runtime,
+.credential-settings__empty,
+.credential-settings__feedback,
+.credential-settings__confirmation-copy {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.credential-settings__runtime {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--surface-soft);
+  font-size: 10px;
+  font-weight: 720;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.credential-settings__runtime[data-state="active"] {
+  color: var(--moss-strong);
+  background: var(--moss-soft);
+}
+
+.credential-settings__runtime[data-state="failed"] {
+  color: var(--coral);
+}
+
+.credential-settings__delete,
+.credential-settings__retry,
+.credential-settings__setup,
+.credential-settings__cancel-delete,
+.credential-settings__confirm-delete {
+  min-height: 36px;
+  padding: 0 13px;
+  white-space: nowrap;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.credential-settings__delete,
+.credential-settings__retry,
+.credential-settings__cancel-delete {
+  border: 1px solid var(--line-strong);
+  color: var(--ink);
+  background: var(--surface-solid);
+}
+
+.credential-settings__setup {
+  border: 1px solid var(--moss);
+  color: var(--surface-solid);
+  background: var(--moss);
+}
+
+.credential-settings__confirm-delete {
+  border: 1px solid var(--coral);
+  color: var(--surface-solid);
+  background: var(--coral);
+}
+
+.credential-settings__delete:disabled,
+.credential-settings__retry:disabled,
+.credential-settings__setup:disabled,
+.credential-settings__cancel-delete:disabled,
+.credential-settings__confirm-delete:disabled,
+.credential-settings__confirm-delete[aria-disabled="true"] {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.credential-settings__confirmation {
+  display: grid;
+  grid-column: 1 / -1;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.credential-settings__confirmation-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.credential-settings__confirmation-actions,
+.credential-settings__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.credential-settings__feedback {
+  min-height: 18px;
+  margin-top: 14px;
+}
+
+.credential-settings__empty {
+  margin-top: 18px;
+}
+
+.credential-settings__actions {
+  margin-top: 12px;
+}
+
+.credential-settings__retry {
+  margin-right: auto;
+}
+
+.credential-settings__list[hidden],
+.credential-settings__empty[hidden],
+.credential-settings__feedback[hidden],
+.credential-settings__retry[hidden],
+.credential-settings__setup[hidden] {
+  display: none;
+}
+
 @keyframes provider-model-settings-enter {
   from {
     opacity: 0;
@@ -594,6 +744,15 @@
 }
 
 @media (max-width: 560px) {
+  .credential-settings__item {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .credential-settings__delete {
+    grid-column: 1 / -1;
+    justify-self: end;
+  }
+
   .session-settings__fields {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
+import type { CredentialDeleteResult, DesktopCredentialId } from "../src/onboarding/bridge.js";
+import type { ChatGptStatus, CredentialSlotStatus } from "../src/onboarding/machine.js";
+import {
+  createCredentialSettingsController,
+  type CredentialSettingsState,
+  type CredentialSettingsView,
+} from "../src/settings/credential-controller.js";
+import { createCredentialSettingsView } from "../src/settings/credential-view.js";
+import { createResidentSettingsShell } from "../src/settings/shell.js";
+
+function runtime(
+  llm: RuntimeConfigSnapshot["llm"] = {
+    provider: "anthropic",
+    model: "synthetic-model",
+    credential_configured: true,
+  },
+  intervals: RuntimeConfigSnapshot["intervals"] = {
+    athlete_id: "synthetic-athlete",
+    credential_configured: true,
+    managedByEnvironment: { athleteId: false },
+  },
+): RuntimeConfigSnapshot {
+  return {
+    schemaVersion: 3,
+    llm,
+    intervals,
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+      managedByEnvironment: {
+        historyTokenBudgetRatio: false,
+        idleMinutes: false,
+        dailyResetHour: false,
+        resetArchiveRetentionDays: false,
+        timezone: false,
+      },
+    },
+  };
+}
+
+function fakeView() {
+  let handlers:
+    | {
+        readonly onRetry: () => void;
+        readonly onRequestDelete: (credential: DesktopCredentialId) => void;
+        readonly onCancelDelete: () => void;
+        readonly onConfirmDelete: () => void;
+        readonly onOpenSetup: () => void;
+      }
+    | undefined;
+  const view: CredentialSettingsView = {
+    bind: vi.fn((next) => {
+      handlers = next;
+    }),
+    render: vi.fn(),
+    dispose: vi.fn(),
+  };
+  return {
+    view,
+    requestDelete: (credential: DesktopCredentialId) => handlers?.onRequestDelete(credential),
+    cancelDelete: () => handlers?.onCancelDelete(),
+    confirmDelete: () => handlers?.onConfirmDelete(),
+    openSetup: () => handlers?.onOpenSetup(),
+  };
+}
+
+function createSubject(input: {
+  readonly runtime?: RuntimeConfigSnapshot;
+  readonly statuses?: readonly CredentialSlotStatus[];
+  readonly chatGpt?: ChatGptStatus;
+  readonly deletion?: CredentialDeleteResult;
+  readonly openSetup?: () => void;
+}) {
+  let activeRuntime = input.runtime ?? runtime();
+  let statuses =
+    input.statuses ??
+    ([
+      { slot: "anthropic", state: "configured", runtimeState: "active" },
+      { slot: "openrouter", state: "configured", runtimeState: "stored-inactive" },
+    ] satisfies readonly CredentialSlotStatus[]);
+  const chatGpt = input.chatGpt ?? { state: "configured", runtimeReady: false };
+  const subject = fakeView();
+  const client = {
+    call: vi.fn(async () => activeRuntime),
+  };
+  const clients = {
+    getClient: vi.fn(async () => client),
+    reconnect: vi.fn(async () => client),
+  } as unknown as DesktopCoachClientProvider;
+  const deleteCredential = vi.fn(async ({ credential }: { credential: DesktopCredentialId }) => {
+    const result =
+      input.deletion ??
+      ({
+        credential,
+        status: "deleted",
+        cleanupPending: false,
+      } satisfies CredentialDeleteResult);
+    if (result.status === "deleted") {
+      statuses = statuses.filter((status) => status.slot !== credential);
+      if (credential === activeRuntime.llm.provider) {
+        activeRuntime = runtime(
+          { ...activeRuntime.llm, credential_configured: false },
+          activeRuntime.intervals,
+        );
+      }
+    }
+    return result;
+  });
+  const controller = createCredentialSettingsController({
+    clients,
+    loadStatuses: async () => statuses,
+    loadChatGptStatus: async () => chatGpt,
+    deleteCredential,
+    openSetup: input.openSetup ?? vi.fn(),
+    beginMutation: () => vi.fn(),
+    view: subject.view,
+  });
+  return { controller, subject, deleteCredential };
+}
+
+function content(state: CredentialSettingsState) {
+  if (
+    state.status === "ready" ||
+    state.status === "confirming" ||
+    state.status === "deleting" ||
+    state.status === "deleted" ||
+    (state.status === "error" && state.kind === "delete")
+  ) {
+    return state;
+  }
+  throw new Error(`Expected credential content, received ${state.status}`);
+}
+
+describe("credential settings controller", () => {
+  it("builds a provider, kind, and coarse-state-only list for every stored credential kind", async () => {
+    const { controller } = createSubject({});
+
+    await controller.activate();
+
+    expect(content(controller.state()).entries).toEqual([
+      {
+        credential: "anthropic",
+        provider: "Anthropic",
+        kind: "Provider API key",
+        runtimeState: "active",
+      },
+      {
+        credential: "openai-codex",
+        provider: "ChatGPT",
+        kind: "ChatGPT profile",
+        runtimeState: "stored-inactive",
+      },
+      {
+        credential: "openrouter",
+        provider: "OpenRouter",
+        kind: "Provider API key",
+        runtimeState: "stored-inactive",
+      },
+      {
+        credential: "intervals-icu",
+        provider: "intervals.icu",
+        kind: "Training account key",
+        runtimeState: "active",
+      },
+    ]);
+    const serialized = JSON.stringify(content(controller.state()).entries);
+    expect(serialized).not.toContain("synthetic-model");
+    expect(serialized).not.toContain("synthetic-athlete");
+    expect(serialized).not.toContain("length");
+    expect(serialized).not.toContain("hash");
+  });
+
+  it("confirmation-gates active deletion, announces the cutover, and exposes Setup recovery", async () => {
+    const openSetup = vi.fn();
+    const { controller, subject, deleteCredential } = createSubject({ openSetup });
+    await controller.activate();
+
+    subject.requestDelete("anthropic");
+    expect(controller.state()).toMatchObject({
+      status: "confirming",
+      confirmation: "anthropic",
+      focus: { target: "confirmation-cancel" },
+    });
+    subject.cancelDelete();
+    expect(controller.state()).toMatchObject({
+      status: "ready",
+      confirmation: null,
+      announcement: "Credential deletion cancelled.",
+      focus: { target: "delete", credential: "anthropic" },
+    });
+
+    subject.requestDelete("anthropic");
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(controller.state().status).toBe("deleted"));
+
+    expect(deleteCredential).toHaveBeenCalledOnce();
+    expect(controller.state()).toMatchObject({
+      status: "deleted",
+      announcement: "Credential deleted locally.",
+      recoveryAvailable: true,
+      focus: { target: "setup" },
+    });
+    subject.openSetup();
+    expect(openSetup).toHaveBeenCalledOnce();
+    expect(controller.state()).toEqual({ status: "closed" });
+  });
+
+  it("keeps an externally managed credential listed and announces the fixed refusal", async () => {
+    const { controller, subject } = createSubject({
+      statuses: [],
+      chatGpt: { state: "absent", runtimeReady: false },
+      deletion: {
+        credential: "anthropic",
+        status: "refused",
+        reason: "managed-by-environment",
+      },
+    });
+    await controller.activate();
+
+    subject.requestDelete("anthropic");
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(controller.state().status).toBe("error"));
+
+    expect(controller.state()).toMatchObject({
+      status: "error",
+      kind: "delete",
+      reason: "managed-by-environment",
+      confirmation: null,
+      announcement: "This credential is managed outside Settings and can’t be deleted here.",
+      focus: { target: "delete", credential: "anthropic" },
+    });
+  });
+});
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly attributes = new Map<string, string>();
+  readonly dataset: Record<string, string> = {};
+  readonly listeners = new Map<string, Set<(event: never) => void>>();
+  parent: FakeElement | undefined;
+  className = "";
+  disabled = false;
+  hidden = false;
+  open = false;
+  id = "";
+  type = "";
+  private ownText = "";
+
+  constructor(
+    readonly tagName: string,
+    private readonly document: FakeDocument,
+  ) {}
+
+  get parentElement(): FakeElement | null {
+    return this.parent ?? null;
+  }
+
+  get textContent(): string {
+    return this.ownText + this.children.map((child) => child.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children.splice(0);
+  }
+
+  append(...nodes: FakeElement[]): void {
+    for (const node of nodes) {
+      node.remove();
+      node.parent = this;
+      this.children.push(node);
+    }
+  }
+
+  insertBefore(node: FakeElement, before: FakeElement | null): void {
+    node.remove();
+    node.parent = this;
+    const index = before === null ? -1 : this.children.indexOf(before);
+    if (index === -1) this.children.push(node);
+    else this.children.splice(index, 0, node);
+  }
+
+  replaceChildren(...nodes: FakeElement[]): void {
+    this.children.splice(0);
+    this.ownText = "";
+    this.append(...nodes);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+
+  addEventListener(name: string, listener: (event: never) => void): void {
+    const listeners = this.listeners.get(name) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(name, listeners);
+  }
+
+  removeEventListener(name: string, listener: (event: never) => void): void {
+    this.listeners.get(name)?.delete(listener);
+  }
+
+  dispatch(name: string, event: Record<string, unknown> = {}): void {
+    const value = {
+      target: this,
+      preventDefault() {},
+      shiftKey: false,
+      ...event,
+    };
+    for (const listener of this.listeners.get(name) ?? []) listener(value as never);
+  }
+
+  click(): void {
+    if (!this.disabled) this.dispatch("click");
+  }
+
+  focus(): void {
+    if (!this.disabled) this.document.activeElement = this;
+  }
+
+  showModal(): void {
+    this.open = true;
+  }
+
+  close(): void {
+    this.open = false;
+  }
+
+  remove(): void {
+    if (this.parent === undefined) return;
+    const index = this.parent.children.indexOf(this);
+    if (index >= 0) this.parent.children.splice(index, 1);
+    this.parent = undefined;
+  }
+}
+
+class FakeDocument {
+  readonly body = new FakeElement("body", this);
+  activeElement: FakeElement | null = this.body;
+
+  createElement(name: string): FakeElement {
+    return new FakeElement(name, this);
+  }
+}
+
+function descendants(root: FakeElement): FakeElement[] {
+  return root.children.flatMap((child) => [child, ...descendants(child)]);
+}
+
+function find(root: FakeElement, className: string): FakeElement {
+  const value = [root, ...descendants(root)].find((node) => node.className === className);
+  if (value === undefined) throw new Error(`Missing ${className}`);
+  return value;
+}
+
+describe("credential settings view", () => {
+  it("uses accessible confirmation roles, deterministic focus, announcements, and the shell trap", () => {
+    const document = new FakeDocument();
+    const actionHost = new FakeElement("div", document);
+    document.body.append(actionHost);
+    const shell = createResidentSettingsShell({
+      document: document as never,
+      actionHost: actionHost as never,
+    });
+    const view = createCredentialSettingsView({
+      document: document as never,
+      shell,
+    });
+    const handlers = {
+      onRetry: vi.fn(),
+      onRequestDelete: vi.fn(),
+      onCancelDelete: vi.fn(),
+      onConfirmDelete: vi.fn(),
+      onOpenSetup: vi.fn(),
+    };
+    view.bind(handlers);
+    shell.open();
+    const entry = {
+      credential: "anthropic" as const,
+      provider: "Anthropic",
+      kind: "Provider API key" as const,
+      runtimeState: "active" as const,
+    };
+
+    view.render({
+      status: "confirming",
+      entries: [entry],
+      confirmation: "anthropic",
+      announcement: "Confirm deletion of the Anthropic credential.",
+      recoveryAvailable: false,
+      focus: { target: "confirmation-cancel" },
+    });
+
+    const confirmation = find(document.body, "credential-settings__confirmation");
+    const cancel = find(document.body, "credential-settings__cancel-delete");
+    const remove = find(document.body, "credential-settings__confirm-delete");
+    const feedback = find(document.body, "credential-settings__feedback");
+    expect(confirmation.attributes.get("role")).toBe("group");
+    expect(confirmation.attributes.get("aria-labelledby")).toBe(
+      "credential-settings-confirm-anthropic",
+    );
+    expect(remove.attributes.get("aria-label")).toBe(
+      "Confirm deletion of the Anthropic credential",
+    );
+    expect(feedback.attributes.get("role")).toBe("status");
+    expect(feedback.attributes.get("aria-live")).toBe("polite");
+    expect(document.activeElement).toBe(cancel);
+
+    shell.setSectionSaving("credential", true);
+    view.render({
+      status: "deleting",
+      entries: [entry],
+      confirmation: "anthropic",
+      announcement: "Deleting the Anthropic credential locally…",
+      recoveryAvailable: false,
+      focus: { target: "confirmation-delete" },
+    });
+    const deleting = find(document.body, "credential-settings__confirm-delete");
+    expect(document.activeElement).toBe(deleting);
+    expect(deleting.attributes.get("aria-disabled")).toBe("true");
+    deleting.click();
+    expect(handlers.onConfirmDelete).not.toHaveBeenCalled();
+
+    shell.setSectionSaving("credential", false);
+    view.render({
+      status: "deleted",
+      entries: [],
+      confirmation: null,
+      announcement: "Credential deleted locally.",
+      recoveryAvailable: true,
+      focus: { target: "setup" },
+    });
+    const setup = find(document.body, "credential-settings__setup");
+    expect(document.activeElement).toBe(setup);
+    const dialog = descendants(document.body).find((node) => node.tagName === "dialog")!;
+    const preventDefault = vi.fn();
+    dialog.dispatch("keydown", { key: "Tab", preventDefault });
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(find(document.body, "provider-model-settings__close"));
+  });
+});

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -279,6 +279,7 @@ async function security() {
             "checkForUpdates",
             "chooseImportFiles",
             "credentialStatuses",
+            "deleteCredential",
             "getDaemonConnection",
             "getUpdateState",
             "llmConfiguration",

--- a/apps/desktop/src/main/chatgpt-auth.ts
+++ b/apps/desktop/src/main/chatgpt-auth.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import {
+  deleteStoredProfile,
   loadStoredProfileSnapshot,
   loginCodex,
   recoverAndSaveStoredProfile,
@@ -35,21 +36,37 @@ export type ChatGptLoginResult =
   | { readonly status: "configured"; readonly runtimeReady: true }
   | { readonly status: "refused"; readonly reason: ChatGptLoginRefusalReason };
 
+export type ChatGptDeleteResult =
+  | { readonly status: "deleted"; readonly cleanupPending: false }
+  | {
+      readonly status: "refused";
+      readonly reason:
+        | "not-found"
+        | "storage-failed"
+        | "runtime-unavailable"
+        | "runtime-state-diverged";
+    };
+
 export interface ChatGptAuthController {
   status(): Promise<ChatGptStatus>;
   login(selection: OnboardingLlmSelection): Promise<ChatGptLoginResult>;
   activate(selection: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
+  deleteCredential(): Promise<ChatGptDeleteResult>;
 }
 
 interface ChatGptAuthDependencies {
   readonly loginCodex?: (options: CodexLoginOptions) => Promise<CodexCredentials>;
   readonly writeProfile?: (configDir: string, credentials: CodexCredentials) => Promise<void>;
+  readonly deleteProfile?: (configDir: string) => void;
 }
 
 interface CreateChatGptAuthOptions {
   readonly configDir: string;
   readonly applyRuntimeConfig: (request: ConfigureRuntimeRpcParams) => Promise<void>;
   readonly getRuntimeConfig: () => Promise<RuntimeConfigSnapshot>;
+  readonly clearRuntimeCredential?: () => Promise<
+    "cleared" | "not-active" | "managed-by-environment"
+  >;
   readonly openExternal: (url: string) => Promise<void>;
   readonly signal?: AbortSignal;
   readonly timeoutMs?: number;
@@ -108,6 +125,10 @@ export async function writeChatGptProfile(
   });
 }
 
+export function deleteChatGptProfile(configDir: string): void {
+  deleteStoredProfile(join(configDir, "auth-profiles.json"), CHATGPT_PROFILE_NAME);
+}
+
 async function configuredRuntime(
   getRuntimeConfig: () => Promise<RuntimeConfigSnapshot>,
 ): Promise<boolean | undefined> {
@@ -134,6 +155,7 @@ function classifyLoginFailure(
 export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAuthController {
   const runLogin = options.dependencies?.loginCodex ?? loginCodex;
   const storeProfile = options.dependencies?.writeProfile ?? writeChatGptProfile;
+  const removeProfile = options.dependencies?.deleteProfile ?? deleteChatGptProfile;
   let activeLogin: Promise<ChatGptLoginResult> | undefined;
 
   const applySelection = async (
@@ -221,5 +243,42 @@ export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAut
       }
     },
     activate: applySelection,
+    async deleteCredential() {
+      const stored = await hasChatGptProfile(options.configDir);
+      const runtimeReady = await configuredRuntime(options.getRuntimeConfig);
+      if (!stored) {
+        return runtimeReady === true
+          ? { status: "refused", reason: "runtime-state-diverged" }
+          : { status: "refused", reason: "not-found" };
+      }
+      if (runtimeReady === undefined) {
+        return { status: "refused", reason: "runtime-unavailable" };
+      }
+      if (runtimeReady) {
+        if (options.clearRuntimeCredential === undefined) {
+          return { status: "refused", reason: "runtime-unavailable" };
+        }
+        try {
+          const cleared = await options.clearRuntimeCredential();
+          if (cleared === "not-active") {
+            removeProfile(options.configDir);
+          } else if (cleared !== "cleared") {
+            throw new TypeError();
+          }
+        } catch {
+          return { status: "refused", reason: "runtime-state-diverged" };
+        }
+      } else {
+        try {
+          removeProfile(options.configDir);
+        } catch {
+          return { status: "refused", reason: "storage-failed" };
+        }
+      }
+      if (await hasChatGptProfile(options.configDir)) {
+        return { status: "refused", reason: "runtime-state-diverged" };
+      }
+      return { status: "deleted", cleanupPending: false };
+    },
   };
 }

--- a/apps/desktop/src/main/credential-runtime.ts
+++ b/apps/desktop/src/main/credential-runtime.ts
@@ -8,6 +8,8 @@ import { CHATGPT_PROFILE_NAME } from "./chatgpt-auth.js";
 import type { CredentialRuntimeState, DesktopCredentialSlot } from "./credential-vault.js";
 import { runtimeConfigurationForCredential } from "./onboarding-ipc.js";
 
+export type DesktopManagedCredential = DesktopCredentialSlot | typeof CHATGPT_PROFILE_NAME;
+
 export interface LlmProviderSelectionEvidence {
   readonly chatGptProfilePresent: boolean;
   readonly storedCredentialSlots: readonly DesktopCredentialSlot[];
@@ -24,6 +26,9 @@ export interface CredentialRuntimeApplication {
     value: string,
     storedCredentialSlots: readonly DesktopCredentialSlot[],
   ): Promise<Exclude<CredentialRuntimeState, "failed">>;
+  clearCredential(
+    credential: DesktopManagedCredential,
+  ): Promise<"cleared" | "not-active" | "managed-by-environment">;
 }
 
 interface CredentialRuntimeApplicationOptions {
@@ -31,11 +36,25 @@ interface CredentialRuntimeApplicationOptions {
     storedCredentialSlots: readonly DesktopCredentialSlot[],
   ) => Promise<LlmProvider | undefined>;
   readonly configureRuntime: (request: ConfigureRuntimeRpcParams) => Promise<void>;
+  readonly clearRuntimeCredential?: (
+    credential: DesktopManagedCredential,
+  ) => Promise<"cleared" | "not-active" | "managed-by-environment">;
 }
 
 export interface RuntimeConfigurationAuthority {
   configureRuntime(request: ConfigureRuntimeRpcParams): Promise<void>;
+  clearCredential(
+    credential: DesktopManagedCredential,
+  ): Promise<"cleared" | "not-active" | "managed-by-environment">;
   getRuntimeConfig(): Promise<RuntimeConfigSnapshot>;
+}
+
+export function runtimeConfigurationForCredentialDeletion(
+  credential: DesktopManagedCredential,
+): ConfigureRuntimeRpcParams {
+  return credential === "intervals-icu"
+    ? { intervals: { clear_credential: true } }
+    : { llm: { provider: credential, clear_credential: true } };
 }
 
 export function intervalsAthleteIdForOwnership(snapshot: RuntimeConfigSnapshot): string {
@@ -79,6 +98,25 @@ export function createConnectionRuntimeAuthority(
         throw new TypeError();
       }
     },
+    async clearCredential(credential) {
+      const request = runtimeConfigurationForCredentialDeletion(credential);
+      const result = await call((client) => client.call("configureRuntime", request));
+      if ("status" in result && result.status === "refused") {
+        if (result.reason === "managed-by-environment") return "managed-by-environment";
+        if (result.reason === "credential-required") return "not-active";
+        throw new TypeError();
+      }
+      if (
+        !("status" in result) ||
+        result.status !== "applied" ||
+        result.applied.llm !== (request.llm !== undefined) ||
+        result.applied.intervals !== (request.intervals !== undefined) ||
+        result.applied.session
+      ) {
+        throw new TypeError();
+      }
+      return "cleared";
+    },
     getRuntimeConfig() {
       return call((client) => client.call("getRuntimeConfig", {}));
     },
@@ -121,6 +159,12 @@ export function createCredentialRuntimeApplication(
         }
         await options.configureRuntime(request);
         return "active";
+      });
+    },
+    clearCredential(credential) {
+      return serialize(() => {
+        if (options.clearRuntimeCredential === undefined) throw new TypeError();
+        return options.clearRuntimeCredential(credential);
       });
     },
   };

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { lstat, mkdir, open, readFile, readdir, rename, rm } from "node:fs/promises";
 import { join } from "node:path";
 import {
   parseOnboardingLlmSelection,
@@ -48,6 +48,23 @@ export type CredentialWriteResult =
         | "runtime-unavailable";
     };
 
+export type CredentialDeleteResult =
+  | {
+      readonly slot: DesktopCredentialSlot;
+      readonly status: "deleted";
+      readonly cleanupPending: boolean;
+    }
+  | {
+      readonly slot: DesktopCredentialSlot;
+      readonly status: "refused";
+      readonly reason:
+        | "not-found"
+        | "managed-by-environment"
+        | "storage-failed"
+        | "runtime-unavailable"
+        | "runtime-state-diverged";
+    };
+
 export const CREDENTIAL_DIRECTORY_NAME = "credentials-v1" as const;
 export const CREDENTIAL_DIRECTORY_MODE = 0o700;
 export const CREDENTIAL_FILE_MODE = 0o600;
@@ -73,6 +90,7 @@ export interface CredentialVault {
   ): Promise<CredentialWriteResult>;
   applyLlmSelection(input: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
+  deleteCredential(slot: DesktopCredentialSlot): Promise<CredentialDeleteResult>;
   reapplyConfigured(): Promise<void>;
   retryFailed(): Promise<void>;
 }
@@ -93,6 +111,12 @@ interface CredentialVaultOptions {
     value: string,
     storedCredentialSlots: readonly DesktopCredentialSlot[],
   ) => Promise<Exclude<CredentialRuntimeState, "failed">>;
+  readonly clearCredential?: (
+    slot: DesktopCredentialSlot,
+  ) => Promise<"cleared" | "not-active" | "managed-by-environment">;
+  readonly renameCredentialFile?: typeof rename;
+  readonly removeCredentialFile?: typeof rm;
+  readonly syncCredentialDirectory?: (root: string) => Promise<void>;
 }
 
 export function replaceCredentialRuntimeStates(
@@ -182,6 +206,75 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     runtimeState.set(slot, state);
     options.onRuntimeStateChange?.(slot);
   };
+  const clearRuntimeState = (slot: DesktopCredentialSlot): void => {
+    runtimeState.delete(slot);
+    options.onRuntimeStateChange?.(slot);
+  };
+  const syncCredentialDirectory =
+    options.syncCredentialDirectory ??
+    (async (root: string): Promise<void> => {
+      const directory = await open(root, "r");
+      try {
+        await directory.sync();
+      } finally {
+        await directory.close();
+      }
+    });
+  const renameCredentialFile = options.renameCredentialFile ?? rename;
+  const removeCredentialFile = options.removeCredentialFile ?? rm;
+
+  const removeStoredCredential = async (
+    slot: DesktopCredentialSlot,
+  ): Promise<"deleted" | "cleanup-pending" | "retained" | "uncertain"> => {
+    const target = join(options.root, `${slot}.bin`);
+    const tombstone = join(options.root, `.${slot}.${randomUUID()}.deleted`);
+    try {
+      await renameCredentialFile(target, tombstone);
+    } catch {
+      return "retained";
+    }
+    try {
+      await syncCredentialDirectory(options.root);
+    } catch {
+      try {
+        await renameCredentialFile(tombstone, target);
+        await syncCredentialDirectory(options.root);
+        return "retained";
+      } catch {
+        return "uncertain";
+      }
+    }
+    try {
+      await removeCredentialFile(tombstone, { force: true });
+      await syncCredentialDirectory(options.root);
+      return "deleted";
+    } catch {
+      return "cleanup-pending";
+    }
+  };
+  const cleanupDeletedCredentials = async (): Promise<void> => {
+    let cleaned = false;
+    let entries: readonly string[];
+    try {
+      entries = await readdir(options.root);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (
+        !DESKTOP_CREDENTIAL_SLOTS.some(
+          (slot) => entry.startsWith(`.${slot}.`) && entry.endsWith(".deleted"),
+        )
+      ) {
+        continue;
+      }
+      try {
+        await removeCredentialFile(join(options.root, entry), { force: true });
+        cleaned = true;
+      } catch {}
+    }
+    if (cleaned) await syncCredentialDirectory(options.root).catch(() => undefined);
+  };
 
   const readSlot = async (slot: DesktopCredentialSlot): Promise<ReadCredential> => {
     const path = join(options.root, `${slot}.bin`);
@@ -219,6 +312,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
   };
 
   const readAll = async (): Promise<readonly ReadCredential[]> => {
+    await cleanupDeletedCredentials();
     const entries: ReadCredential[] = [];
     for (const slot of DESKTOP_CREDENTIAL_SLOTS) entries.push(await readSlot(slot));
     return entries;
@@ -395,6 +489,59 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
         runtimeState:
           entry.state === "configured" ? (runtimeState.get(entry.slot) ?? "stored-inactive") : null,
       }));
+    },
+
+    async deleteCredential(slot): Promise<CredentialDeleteResult> {
+      if (!isCredentialSlot(slot)) {
+        return { slot: "anthropic", status: "refused", reason: "not-found" };
+      }
+      const credential = await readSlot(slot);
+      if (credential.state === "missing") {
+        return { slot, status: "refused", reason: "not-found" };
+      }
+      const runtimeStatus = runtimeState.get(slot);
+      const shouldClearRuntime = runtimeStatus === "active" || runtimeStatus === "failed";
+      let runtimeCleared = false;
+      if (shouldClearRuntime) {
+        if (options.clearCredential === undefined) {
+          return { slot, status: "refused", reason: "runtime-unavailable" };
+        }
+        try {
+          const cleared = await options.clearCredential(slot);
+          if (cleared === "managed-by-environment") {
+            return { slot, status: "refused", reason: "managed-by-environment" };
+          }
+          if (cleared !== "cleared" && cleared !== "not-active") throw new TypeError();
+          runtimeCleared = cleared === "cleared";
+        } catch {
+          setRuntimeState(slot, "failed");
+          return { slot, status: "refused", reason: "runtime-state-diverged" };
+        }
+      }
+      const removed = await removeStoredCredential(slot);
+      if (removed === "deleted" || removed === "cleanup-pending") {
+        clearRuntimeState(slot);
+        return {
+          slot,
+          status: "deleted",
+          cleanupPending: removed === "cleanup-pending",
+        };
+      }
+      if (runtimeCleared && credential.value !== undefined && removed === "retained") {
+        try {
+          await options.applyCredential(slot, credential.value);
+          setRuntimeState(slot, "active");
+          return { slot, status: "refused", reason: "storage-failed" };
+        } catch {
+          setRuntimeState(slot, "failed");
+          return { slot, status: "refused", reason: "runtime-state-diverged" };
+        }
+      }
+      if (runtimeCleared) {
+        setRuntimeState(slot, "failed");
+        return { slot, status: "refused", reason: "runtime-state-diverged" };
+      }
+      return { slot, status: "refused", reason: "storage-failed" };
     },
 
     reapplyConfigured,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -301,6 +301,7 @@ async function runDesktop(): Promise<void> {
         authority,
         credentials: createCredentialRuntimeApplication({
           configureRuntime: authority.configureRuntime,
+          clearRuntimeCredential: authority.clearCredential,
           selectedLlmProvider: async (storedCredentialSlots) =>
             readSelectedLlmProvider(await authority.getRuntimeConfig(), {
               chatGptProfilePresent: await hasChatGptProfile(configDir),
@@ -386,6 +387,22 @@ async function runDesktop(): Promise<void> {
         }
         return status;
       },
+      async clearCredential(slot) {
+        const binding = activeRuntimeBinding!;
+        const lifecycleState = daemonLifecycle?.snapshot();
+        if (lifecycleState?.status !== "ready") throw new TypeError();
+        const result = await binding.credentials.clearCredential(slot);
+        const currentLifecycleState = daemonLifecycle?.snapshot();
+        if (
+          activeRuntimeBinding !== binding ||
+          currentLifecycleState?.status !== "ready" ||
+          currentLifecycleState.generation !== lifecycleState.generation
+        ) {
+          if (slot !== "intervals-icu") failModelCredentialRuntimeStates();
+          throw new TypeError();
+        }
+        return result;
+      },
     });
     reapplyCredentials = async (connection, signal) => {
       if (signal.aborted) return;
@@ -436,6 +453,29 @@ async function runDesktop(): Promise<void> {
           undefined,
           markCredentialRuntimeChange,
         );
+      },
+      async clearRuntimeCredential() {
+        const binding = activeRuntimeBinding!;
+        const lifecycleState = daemonLifecycle?.snapshot();
+        if (lifecycleState?.status !== "ready") throw new TypeError();
+        const result = await binding.credentials.clearCredential("openai-codex");
+        const currentLifecycleState = daemonLifecycle?.snapshot();
+        if (
+          activeRuntimeBinding !== binding ||
+          currentLifecycleState?.status !== "ready" ||
+          currentLifecycleState.generation !== lifecycleState.generation
+        ) {
+          failModelCredentialRuntimeStates();
+          throw new TypeError();
+        }
+        if (result === "cleared") {
+          markUnselectedModelCredentialsInactive(
+            credentialRuntimeState,
+            undefined,
+            markCredentialRuntimeChange,
+          );
+        }
+        return result;
       },
       getRuntimeConfig: readActiveRuntimeConfig,
       openExternal: (url) => shell.openExternal(url),

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -6,6 +6,7 @@ import type {
 } from "@enduragent/coach-contract";
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent, OpenDialogOptions } from "electron";
 import {
+  CHATGPT_PROFILE_NAME,
   type ChatGptAuthController,
   type ChatGptLoginResult,
   type ChatGptStatus,
@@ -13,6 +14,7 @@ import {
 import {
   DESKTOP_CREDENTIAL_SLOTS,
   type CredentialSlotStatus,
+  type CredentialDeleteResult,
   type CredentialVault,
   type CredentialWriteResult,
   type DesktopCredentialSlot,
@@ -30,6 +32,7 @@ import {
 export const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status" as const;
 export const DESKTOP_CREDENTIAL_RETRY_CHANNEL = "enduragent:onboarding:credential-retry" as const;
 export const DESKTOP_CREDENTIAL_WRITE_CHANNEL = "enduragent:onboarding:credential-write" as const;
+export const DESKTOP_CREDENTIAL_DELETE_CHANNEL = "enduragent:settings:credential-delete" as const;
 export const DESKTOP_LLM_CONFIGURATION_CHANNEL = "enduragent:onboarding:llm-configuration" as const;
 export const DESKTOP_LLM_SELECTION_APPLY_CHANNEL =
   "enduragent:onboarding:llm-selection-apply" as const;
@@ -128,6 +131,50 @@ function minimizeWrite(value: CredentialWriteResult): CredentialWriteResult {
   return { slot: value.slot, status: "refused", reason: value.reason };
 }
 
+export type DesktopCredentialId = DesktopCredentialSlot | typeof CHATGPT_PROFILE_NAME;
+
+export type DesktopCredentialDeleteResult =
+  | {
+      readonly credential: DesktopCredentialId;
+      readonly status: "deleted";
+      readonly cleanupPending: boolean;
+    }
+  | {
+      readonly credential: DesktopCredentialId;
+      readonly status: "refused";
+      readonly reason:
+        | "not-found"
+        | "managed-by-environment"
+        | "storage-failed"
+        | "runtime-unavailable"
+        | "runtime-state-diverged";
+    };
+
+function parseDeleteInput(value: unknown): DesktopCredentialId {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    Object.keys(value).length !== 1 ||
+    !Object.hasOwn(value, "credential")
+  ) {
+    throw new TypeError();
+  }
+  const credential = (value as Record<string, unknown>).credential;
+  if (credential === CHATGPT_PROFILE_NAME || isSlot(credential)) return credential;
+  throw new TypeError();
+}
+
+function minimizeDelete(
+  credential: DesktopCredentialId,
+  value: CredentialDeleteResult | Awaited<ReturnType<ChatGptAuthController["deleteCredential"]>>,
+): DesktopCredentialDeleteResult {
+  if (value.status === "deleted") {
+    return { credential, status: "deleted", cleanupPending: value.cleanupPending };
+  }
+  return { credential, status: "refused", reason: value.reason };
+}
+
 function minimizeSelection(value: OnboardingLlmSelectionResult): OnboardingLlmSelectionResult {
   if (value.status === "configured") return { status: "configured", runtimeReady: true };
   return { status: "refused", reason: value.reason };
@@ -208,6 +255,38 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
       return { slot: input.slot, status: "refused", reason: "storage-failed" };
     }
   });
+  options.ipcMain.handle(DESKTOP_CREDENTIAL_DELETE_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 1) throw new TypeError();
+    const credential = parseDeleteInput(args[0]);
+    if (credential === CHATGPT_PROFILE_NAME) {
+      return minimizeDelete(credential, await options.chatGptAuth.deleteCredential());
+    }
+    const statuses = await options.vault.credentialStatuses();
+    const local = statuses.find((status) => status.slot === credential);
+    if (local?.state === "missing") {
+      let active = false;
+      try {
+        const snapshot = await options.getRuntimeConfig();
+        active =
+          credential === "intervals-icu"
+            ? snapshot.intervals.credential_configured
+            : snapshot.llm.provider === credential && snapshot.llm.credential_configured;
+      } catch {
+        return {
+          credential,
+          status: "refused",
+          reason: "runtime-unavailable",
+        };
+      }
+      return {
+        credential,
+        status: "refused",
+        reason: active ? "managed-by-environment" : "not-found",
+      };
+    }
+    return minimizeDelete(credential, await options.vault.deleteCredential(credential));
+  });
   options.ipcMain.handle(DESKTOP_LLM_CONFIGURATION_CHANNEL, async (event, ...args) => {
     requireTrusted(event);
     if (args.length !== 0) throw new TypeError();
@@ -271,6 +350,7 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
     options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_STATUS_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_RETRY_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_WRITE_CHANNEL);
+    options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_DELETE_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_LLM_CONFIGURATION_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_LLM_SELECTION_APPLY_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CHATGPT_STATUS_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -13,6 +13,7 @@ import {
 const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status";
 const DESKTOP_CREDENTIAL_RETRY_CHANNEL = "enduragent:onboarding:credential-retry";
 const DESKTOP_CREDENTIAL_WRITE_CHANNEL = "enduragent:onboarding:credential-write";
+const DESKTOP_CREDENTIAL_DELETE_CHANNEL = "enduragent:settings:credential-delete";
 const DESKTOP_LLM_CONFIGURATION_CHANNEL = "enduragent:onboarding:llm-configuration";
 const DESKTOP_LLM_SELECTION_APPLY_CHANNEL = "enduragent:onboarding:llm-selection-apply";
 const DESKTOP_CHATGPT_STATUS_CHANNEL = "enduragent:onboarding:chatgpt-status";
@@ -31,6 +32,7 @@ const SLOTS = new Set([
   "zai",
   "intervals-icu",
 ]);
+const CREDENTIALS = new Set([...SLOTS, "openai-codex"]);
 const LLM_PROVIDER_ORDER = [
   "anthropic",
   "openai",
@@ -61,6 +63,13 @@ const REASONS = new Set([
   "storage-failed",
   "runtime-unavailable",
   "training-account-mismatch",
+]);
+const DELETE_REASONS = new Set([
+  "not-found",
+  "managed-by-environment",
+  "storage-failed",
+  "runtime-unavailable",
+  "runtime-state-diverged",
 ]);
 const CHATGPT_REASONS = new Set([
   "already-in-progress",
@@ -220,6 +229,18 @@ function parseCredentialWriteInput(value: unknown): {
   return { slot: value.slot as string, value: value.value, selection };
 }
 
+function parseCredentialDeleteInput(value: unknown): { readonly credential: string } {
+  if (
+    !record(value) ||
+    !exactKeys(value, ["credential"]) ||
+    typeof value.credential !== "string" ||
+    !CREDENTIALS.has(value.credential)
+  ) {
+    throw new TypeError();
+  }
+  return { credential: value.credential };
+}
+
 function releaseVersion(value: unknown): value is string {
   return safeString(value, 64) && RELEASE_VERSION_RE.test(value);
 }
@@ -347,6 +368,35 @@ function parseWriteResult(value: unknown): unknown {
     REASONS.has(value.reason as string)
   ) {
     return { slot: value.slot, status: "refused", reason: value.reason };
+  }
+  throw new TypeError();
+}
+
+function parseDeleteResult(value: unknown): unknown {
+  if (
+    !record(value) ||
+    typeof value.credential !== "string" ||
+    !CREDENTIALS.has(value.credential)
+  ) {
+    throw new TypeError();
+  }
+  if (
+    value.status === "deleted" &&
+    exactKeys(value, ["credential", "status", "cleanupPending"]) &&
+    typeof value.cleanupPending === "boolean"
+  ) {
+    return {
+      credential: value.credential,
+      status: "deleted",
+      cleanupPending: value.cleanupPending,
+    };
+  }
+  if (
+    value.status === "refused" &&
+    exactKeys(value, ["credential", "status", "reason"]) &&
+    DELETE_REASONS.has(value.reason as string)
+  ) {
+    return { credential: value.credential, status: "refused", reason: value.reason };
   }
   throw new TypeError();
 }
@@ -582,6 +632,10 @@ contextBridge.exposeInMainWorld(
     writeCredential: async (input: unknown) => {
       const parsed = parseCredentialWriteInput(input);
       return parseWriteResult(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, parsed));
+    },
+    deleteCredential: async (input: unknown) => {
+      const parsed = parseCredentialDeleteInput(input);
+      return parseDeleteResult(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_DELETE_CHANNEL, parsed));
     },
     llmConfiguration: async () =>
       parseLlmConfiguration(await ipcRenderer.invoke(DESKTOP_LLM_CONFIGURATION_CHANNEL)),

--- a/apps/desktop/tests/chatgpt-auth.test.ts
+++ b/apps/desktop/tests/chatgpt-auth.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LlmProvider, RuntimeConfigSnapshot } from "@enduragent/coach-contract";
 import {
   createChatGptAuth as createChatGptAuthSubject,
+  deleteChatGptProfile,
   hasChatGptProfile,
   writeChatGptProfile,
 } from "../src/main/chatgpt-auth.js";
@@ -91,6 +92,94 @@ afterEach(async () => {
 });
 
 describe("desktop ChatGPT auth", () => {
+  it("deletes an inactive local profile without a runtime cutover", async () => {
+    const directory = await configDir();
+    await writeChatGptProfile(directory, credentials());
+    const clearRuntimeCredential = vi.fn(async () => "cleared" as const);
+    const auth = createChatGptAuth({
+      configDir: directory,
+      applyRuntimeConfig: vi.fn(async () => {}),
+      clearRuntimeCredential,
+      getRuntimeConfig: async () => runtimeSnapshot("anthropic", true),
+      openExternal: vi.fn(async () => {}),
+    });
+
+    await expect(auth.deleteCredential()).resolves.toEqual({
+      status: "deleted",
+      cleanupPending: false,
+    });
+
+    expect(clearRuntimeCredential).not.toHaveBeenCalled();
+    await expect(hasChatGptProfile(directory)).resolves.toBe(false);
+  });
+
+  it("deletes an active profile through the serialized runtime cutover", async () => {
+    const directory = await configDir();
+    await writeChatGptProfile(directory, credentials());
+    const clearRuntimeCredential = vi.fn(async () => {
+      deleteChatGptProfile(directory);
+      return "cleared" as const;
+    });
+    const auth = createChatGptAuth({
+      configDir: directory,
+      applyRuntimeConfig: vi.fn(async () => {}),
+      clearRuntimeCredential,
+      openExternal: vi.fn(async () => {}),
+    });
+
+    await expect(auth.deleteCredential()).resolves.toEqual({
+      status: "deleted",
+      cleanupPending: false,
+    });
+
+    expect(clearRuntimeCredential).toHaveBeenCalledOnce();
+    await expect(hasChatGptProfile(directory)).resolves.toBe(false);
+  });
+
+  it("fails closed and surfaces profile/runtime divergence during deletion", async () => {
+    const directory = await configDir();
+    await writeChatGptProfile(directory, credentials());
+    const unavailable = createChatGptAuth({
+      configDir: directory,
+      applyRuntimeConfig: vi.fn(async () => {}),
+      getRuntimeConfig: vi.fn(async () => {
+        throw new TypeError();
+      }),
+      openExternal: vi.fn(async () => {}),
+    });
+
+    await expect(unavailable.deleteCredential()).resolves.toEqual({
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+    await expect(hasChatGptProfile(directory)).resolves.toBe(true);
+
+    const ambiguous = createChatGptAuth({
+      configDir: directory,
+      applyRuntimeConfig: vi.fn(async () => {}),
+      clearRuntimeCredential: vi.fn(async () => {
+        throw new TypeError();
+      }),
+      openExternal: vi.fn(async () => {}),
+    });
+    await expect(ambiguous.deleteCredential()).resolves.toEqual({
+      status: "refused",
+      reason: "runtime-state-diverged",
+    });
+    await expect(hasChatGptProfile(directory)).resolves.toBe(true);
+
+    const divergent = createChatGptAuth({
+      configDir: directory,
+      applyRuntimeConfig: vi.fn(async () => {}),
+      clearRuntimeCredential: vi.fn(async () => "cleared" as const),
+      openExternal: vi.fn(async () => {}),
+    });
+    await expect(divergent.deleteCredential()).resolves.toEqual({
+      status: "refused",
+      reason: "runtime-state-diverged",
+    });
+  });
+
   it("atomically merges the profile with mode 0600 and validates its shape", async () => {
     const directory = await configDir();
     await writeChatGptProfile(directory, credentials());

--- a/apps/desktop/tests/credential-runtime.test.ts
+++ b/apps/desktop/tests/credential-runtime.test.ts
@@ -13,6 +13,7 @@ import {
   createCredentialRuntimeApplication,
   intervalsAthleteIdForOwnership,
   readSelectedLlmProvider,
+  runtimeConfigurationForCredentialDeletion,
   type CredentialRuntimeApplication,
 } from "../src/main/credential-runtime.js";
 import {
@@ -128,6 +129,10 @@ function fakeVault(initialRuntime: CredentialRuntimeApplication) {
         runtimeState: "stored-inactive" as const,
       }));
     },
+    async deleteCredential(slot) {
+      slots.delete(slot);
+      return { slot, status: "deleted", cleanupPending: false };
+    },
     async reapplyConfigured() {
       for (const slot of slots) {
         await runtime.reapplyStoredCredential(slot, randomUUID(), [...slots]);
@@ -165,6 +170,7 @@ async function pollCredentialStatuses(vault: CredentialVault): Promise<void> {
       status: async () => ({ state: "absent", runtimeReady: false }),
       login: async () => ({ status: "refused", reason: "cancelled" }),
       activate: async () => ({ status: "refused", reason: "credential-required" }),
+      deleteCredential: async () => ({ status: "refused", reason: "not-found" }),
     },
     getRuntimeConfig: async () => runtimeSnapshot("anthropic"),
     applyExistingLlmSelection: async () => false,
@@ -180,6 +186,54 @@ async function pollCredentialStatuses(vault: CredentialVault): Promise<void> {
 }
 
 describe("desktop credential runtime precedence", () => {
+  it("builds fixed credential-clear requests and preserves managed refusals", async () => {
+    expect(runtimeConfigurationForCredentialDeletion("anthropic")).toEqual({
+      llm: { provider: "anthropic", clear_credential: true },
+    });
+    expect(runtimeConfigurationForCredentialDeletion("openai-codex")).toEqual({
+      llm: { provider: "openai-codex", clear_credential: true },
+    });
+    expect(runtimeConfigurationForCredentialDeletion("intervals-icu")).toEqual({
+      intervals: { clear_credential: true },
+    });
+    const results = [
+      {
+        schemaVersion: 3,
+        status: "refused",
+        reason: "credential-required",
+      },
+      {
+        schemaVersion: 3,
+        status: "refused",
+        reason: "managed-by-environment",
+      },
+      {
+        schemaVersion: 3,
+        status: "applied",
+        applied: { llm: true, intervals: false, session: false },
+      },
+    ];
+    const call = vi.fn(async () => results.shift());
+    const authority = createConnectionRuntimeAuthority(
+      {
+        url: "ws://127.0.0.1:45005/rpc",
+        token: "x".repeat(43),
+      },
+      vi.fn(async () => ({
+        handshake: {} as never,
+        call,
+        close: vi.fn(async () => {}),
+      })) as never,
+    );
+
+    await expect(authority.clearCredential("anthropic")).resolves.toBe("not-active");
+    await expect(authority.clearCredential("anthropic")).resolves.toBe("managed-by-environment");
+    await expect(authority.clearCredential("anthropic")).resolves.toBe("cleared");
+    expect(call).toHaveBeenNthCalledWith(1, "configureRuntime", {
+      llm: { provider: "anthropic", clear_credential: true },
+    });
+  });
+
   it("uses the current-account sentinel only for a blank ownership preflight", () => {
     expect(intervalsAthleteIdForOwnership(runtimeSnapshot("anthropic", undefined, false, ""))).toBe(
       "0",

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -117,6 +117,173 @@ describe("desktop credential vault", () => {
     });
   });
 
+  it("clears an active runtime credential before atomically deleting its vault entry", async () => {
+    const root = await temporaryRoot();
+    const clearCredential = vi.fn(async () => {
+      expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
+      return "cleared" as const;
+    });
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential: vi.fn(async () => {}),
+      clearCredential,
+    });
+    await vault.writeCredential({ slot: "anthropic", value: randomUUID() });
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+      slot: "anthropic",
+      status: "deleted",
+      cleanupPending: false,
+    });
+
+    expect(clearCredential).toHaveBeenCalledOnce();
+    await expect(lstat(join(root, "anthropic.bin"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "missing",
+      runtimeState: null,
+    });
+  });
+
+  it("deletes a stored-inactive credential without replacing the active runtime", async () => {
+    const root = await temporaryRoot();
+    const clearCredential = vi.fn(async () => "cleared" as const);
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential: vi.fn(async () => {}),
+      clearCredential,
+    });
+    await vault.writeCredential({ slot: "openrouter", value: randomUUID() }, { activate: false });
+
+    await expect(vault.deleteCredential("openrouter")).resolves.toMatchObject({
+      status: "deleted",
+      cleanupPending: false,
+    });
+
+    expect(clearCredential).not.toHaveBeenCalled();
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "openrouter",
+      state: "missing",
+      runtimeState: null,
+    });
+  });
+
+  it("refuses an environment-managed active deletion without mutating the vault", async () => {
+    const root = await temporaryRoot();
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential: vi.fn(async () => {}),
+      clearCredential: vi.fn(async () => "managed-by-environment" as const),
+    });
+    await vault.writeCredential({ slot: "intervals-icu", value: randomUUID() });
+
+    await expect(vault.deleteCredential("intervals-icu")).resolves.toEqual({
+      slot: "intervals-icu",
+      status: "refused",
+      reason: "managed-by-environment",
+    });
+
+    expect((await lstat(join(root, "intervals-icu.bin"))).isFile()).toBe(true);
+  });
+
+  it("surfaces an ambiguous runtime clear without mutating the vault", async () => {
+    const root = await temporaryRoot();
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential: vi.fn(async () => {}),
+      clearCredential: vi.fn(async () => {
+        throw new TypeError();
+      }),
+    });
+    await vault.writeCredential({ slot: "anthropic", value: randomUUID() });
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "runtime-state-diverged",
+    });
+
+    expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "failed",
+    });
+  });
+
+  it("restores runtime after a retained vault delete failure and surfaces failed reconciliation", async () => {
+    const root = await temporaryRoot();
+    let applyCount = 0;
+    let restoreFails = false;
+    const applyCredential = vi.fn(async () => {
+      applyCount += 1;
+      if (restoreFails && applyCount > 1) throw new TypeError();
+    });
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential,
+      clearCredential: vi.fn(async () => "cleared" as const),
+      renameCredentialFile: vi.fn(async () => {
+        throw new TypeError();
+      }) as never,
+    });
+    await vault.writeCredential({ slot: "anthropic", value: randomUUID() });
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "storage-failed",
+    });
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "active",
+    });
+
+    restoreFails = true;
+    await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "runtime-state-diverged",
+    });
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "failed",
+    });
+  });
+
+  it("commits logical deletion while truthfully reporting pending tombstone cleanup", async () => {
+    const root = await temporaryRoot();
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential: vi.fn(async () => {}),
+      removeCredentialFile: vi.fn(async () => {
+        throw new TypeError();
+      }) as never,
+    });
+    await vault.writeCredential({ slot: "openrouter", value: randomUUID() }, { activate: false });
+
+    await expect(vault.deleteCredential("openrouter")).resolves.toEqual({
+      slot: "openrouter",
+      status: "deleted",
+      cleanupPending: true,
+    });
+
+    expect((await readdir(root)).some((entry) => entry.endsWith(".deleted"))).toBe(true);
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "openrouter",
+      state: "missing",
+      runtimeState: null,
+    });
+  });
+
   it("fails closed for insecure directories and targets", async () => {
     const root = await temporaryRoot();
     await mkdir(root, { mode: 0o755 });

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -5,6 +5,7 @@ import {
   DESKTOP_CHATGPT_LOGIN_CHANNEL,
   DESKTOP_CHATGPT_STATUS_CHANNEL,
   DESKTOP_CREDENTIAL_RETRY_CHANNEL,
+  DESKTOP_CREDENTIAL_DELETE_CHANNEL,
   DESKTOP_CREDENTIAL_STATUS_CHANNEL,
   DESKTOP_CREDENTIAL_WRITE_CHANNEL,
   DESKTOP_LLM_CONFIGURATION_CHANNEL,
@@ -45,6 +46,11 @@ function harness(
         runtimeState: "active" as const,
       },
     ]),
+    deleteCredential: vi.fn(async (slot) => ({
+      slot,
+      status: "deleted" as const,
+      cleanupPending: false,
+    })),
     reapplyConfigured: vi.fn(async () => {}),
     retryFailed: vi.fn(async () => {}),
   };
@@ -58,6 +64,10 @@ function harness(
     status: vi.fn(async () => ({ state: "configured" as const, runtimeReady: true })),
     login: vi.fn(async () => ({ status: "configured" as const, runtimeReady: true as const })),
     activate: vi.fn(async () => ({ status: "configured" as const, runtimeReady: true as const })),
+    deleteCredential: vi.fn(async () => ({
+      status: "deleted" as const,
+      cleanupPending: false as const,
+    })),
   };
   const getRuntimeConfig = vi.fn(async () => ({
     schemaVersion: 3 as const,
@@ -259,6 +269,7 @@ describe("desktop onboarding IPC", () => {
         DESKTOP_CREDENTIAL_STATUS_CHANNEL,
         DESKTOP_CREDENTIAL_RETRY_CHANNEL,
         DESKTOP_CREDENTIAL_WRITE_CHANNEL,
+        DESKTOP_CREDENTIAL_DELETE_CHANNEL,
         DESKTOP_LLM_CONFIGURATION_CHANNEL,
         DESKTOP_LLM_SELECTION_APPLY_CHANNEL,
         DESKTOP_CHATGPT_STATUS_CHANNEL,
@@ -286,6 +297,59 @@ describe("desktop onboarding IPC", () => {
     ).resolves.toEqual([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
     expect(subject.vault.credentialStatuses).toHaveBeenCalledOnce();
     expect(subject.vault.reapplyConfigured).not.toHaveBeenCalled();
+  });
+
+  it("routes strict redacted credential deletion and refuses externally managed runtime state", async () => {
+    const subject = harness();
+
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_DELETE_CHANNEL, subject.trustedEvent, {
+        credential: "anthropic",
+      }),
+    ).resolves.toEqual({
+      credential: "anthropic",
+      status: "deleted",
+      cleanupPending: false,
+    });
+    expect(subject.vault.deleteCredential).toHaveBeenCalledWith("anthropic");
+
+    vi.mocked(subject.vault.credentialStatuses).mockResolvedValueOnce([
+      { slot: "anthropic", state: "missing", runtimeState: null },
+    ]);
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_DELETE_CHANNEL, subject.trustedEvent, {
+        credential: "anthropic",
+      }),
+    ).resolves.toEqual({
+      credential: "anthropic",
+      status: "refused",
+      reason: "managed-by-environment",
+    });
+
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_DELETE_CHANNEL, subject.trustedEvent, {
+        credential: "openai-codex",
+      }),
+    ).resolves.toEqual({
+      credential: "openai-codex",
+      status: "deleted",
+      cleanupPending: false,
+    });
+    expect(subject.chatGptAuth.deleteCredential).toHaveBeenCalledOnce();
+  });
+
+  it("rejects untrusted, widened, and unknown credential deletion inputs", async () => {
+    const subject = harness();
+    for (const [event, input] of [
+      [{} as IpcMainInvokeEvent, { credential: "anthropic" }],
+      [subject.trustedEvent, { credential: "unknown" }],
+      [subject.trustedEvent, { credential: "anthropic", extra: true }],
+    ] as const) {
+      await expect(
+        subject.invoke(DESKTOP_CREDENTIAL_DELETE_CHANNEL, event, input),
+      ).rejects.toBeInstanceOf(TypeError);
+    }
+    expect(subject.vault.deleteCredential).not.toHaveBeenCalled();
   });
 
   it("fails closed to re-entry metadata when stored status cannot be read", async () => {
@@ -640,10 +704,10 @@ describe("desktop onboarding IPC", () => {
     ).resolves.toEqual([]);
   });
 
-  it("disposes only its eight handlers", () => {
+  it("disposes only its nine handlers", () => {
     const subject = harness();
     subject.dispose();
     expect(subject.handlers.size).toBe(0);
-    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(8);
+    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(9);
   });
 });

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -40,6 +40,7 @@ vi.mock("electron", () => ({
 interface AuthBridge {
   getDaemonConnection(failedGeneration?: number): Promise<unknown>;
   credentialStatuses(): Promise<unknown>;
+  deleteCredential(input: unknown): Promise<unknown>;
   retryFailedCredentials(): Promise<unknown>;
   writeCredential(input: unknown): Promise<unknown>;
   llmConfiguration(): Promise<unknown>;
@@ -153,6 +154,7 @@ describe("desktop preload ChatGPT auth", () => {
         "chatgptStatus",
         "chooseImportFiles",
         "credentialStatuses",
+        "deleteCredential",
         "getUpdateState",
         "getDaemonConnection",
         "llmConfiguration",
@@ -469,6 +471,42 @@ describe("desktop preload ChatGPT auth", () => {
       "enduragent:onboarding:credential-status",
       "enduragent:onboarding:credential-retry",
     ]);
+  });
+
+  it("validates and copies deletion metadata without accepting widened shapes", async () => {
+    const result = {
+      credential: "anthropic",
+      status: "deleted",
+      cleanupPending: false,
+    };
+    mocks.invoke.mockResolvedValueOnce(result);
+
+    const copied = await bridge.deleteCredential({ credential: "anthropic" });
+
+    expect(copied).toEqual(result);
+    expect(copied).not.toBe(result);
+    expect(mocks.invoke).toHaveBeenCalledWith("enduragent:settings:credential-delete", {
+      credential: "anthropic",
+    });
+
+    for (const input of [
+      { credential: "unknown" },
+      { credential: "anthropic", extra: true },
+      "anthropic",
+    ]) {
+      await expect(bridge.deleteCredential(input)).rejects.toBeInstanceOf(TypeError);
+    }
+    expect(mocks.invoke).toHaveBeenCalledTimes(1);
+
+    mocks.invoke.mockResolvedValueOnce({
+      credential: "anthropic",
+      status: "deleted",
+      cleanupPending: false,
+      extra: true,
+    });
+    await expect(bridge.deleteCredential({ credential: "anthropic" })).rejects.toBeInstanceOf(
+      TypeError,
+    );
   });
 
   it("copies the bounded model catalogue and active selection from its private channel", async () => {

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -284,6 +284,7 @@ const RuntimeLlmSchema = z
     provider: LlmProviderSchema.optional(),
     model: z.string().min(1).max(512).optional(),
     api_key: z.string().min(1).max(16_384).optional(),
+    clear_credential: z.literal(true).optional(),
     base_url: z.string().min(1).max(4_096).nullable().optional(),
     flush_model: RuntimeOptionalStringSchema.optional(),
     compact_model: RuntimeOptionalStringSchema.optional(),
@@ -293,6 +294,22 @@ const RuntimeLlmSchema = z
     if (value.provider === "openai-codex" && value.api_key !== undefined) {
       context.addIssue({ code: "custom", path: ["api_key"], message: "api_key must be absent" });
     }
+    if (value.clear_credential === true) {
+      if (value.provider === undefined) {
+        context.addIssue({
+          code: "custom",
+          path: ["provider"],
+          message: "provider is required for credential deletion",
+        });
+      }
+      if (Object.keys(value).some((key) => key !== "provider" && key !== "clear_credential")) {
+        context.addIssue({
+          code: "custom",
+          path: ["clear_credential"],
+          message: "credential deletion must contain only provider and clear_credential",
+        });
+      }
+    }
     if (Object.keys(value).length === 0) {
       context.addIssue({ code: "custom", message: "llm patch must not be empty" });
     }
@@ -301,10 +318,18 @@ const RuntimeLlmSchema = z
 const RuntimeIntervalsSchema = z
   .object({
     api_key: z.string().min(1).max(16_384).optional(),
+    clear_credential: z.literal(true).optional(),
     athlete_id: z.string().min(1).max(512).optional(),
   })
   .strict()
   .superRefine((value, context) => {
+    if (value.clear_credential === true && Object.keys(value).length !== 1) {
+      context.addIssue({
+        code: "custom",
+        path: ["clear_credential"],
+        message: "clear_credential must be the only intervals patch field",
+      });
+    }
     if (Object.keys(value).length === 0) {
       context.addIssue({ code: "custom", message: "intervals patch must not be empty" });
     }
@@ -353,6 +378,15 @@ export const ConfigureRuntimeRpcParamsSchema = z
   .superRefine((value, context) => {
     if (value.llm === undefined && value.intervals === undefined && value.session === undefined) {
       context.addIssue({ code: "custom", message: "at least one runtime slot is required" });
+    }
+    if (
+      (value.llm?.clear_credential === true || value.intervals?.clear_credential === true) &&
+      Object.keys(value).length !== 1
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "credential deletion must be the only runtime patch",
+      });
     }
   });
 export type ConfigureRuntimeRpcParams = z.infer<typeof ConfigureRuntimeRpcParamsSchema>;

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -407,8 +407,10 @@ describe("coach request and event projection", () => {
       { llm },
       { llm: codex },
       { llm: { model: "model-only" } },
+      { llm: { provider: "anthropic", clear_credential: true } },
       { intervals },
       { intervals: { athlete_id: "athlete-a" } },
+      { intervals: { clear_credential: true } },
       {
         session: {
           historyTokenBudgetRatio: 0.4,
@@ -445,7 +447,18 @@ describe("coach request and event projection", () => {
       { session: { timezone: "a".repeat(513) } },
       { llm: { ...llm, extra: true } },
       { llm: { provider: "openai-codex", api_key: "placeholder" } },
+      { llm: { clear_credential: true } },
+      { llm: { provider: "anthropic", clear_credential: true, model: "model-a" } },
+      {
+        llm: { provider: "anthropic", clear_credential: true },
+        session: { timezone: "UTC" },
+      },
       { intervals: { api_key: "" } },
+      { intervals: { clear_credential: true, athlete_id: "athlete-a" } },
+      {
+        llm: { provider: "anthropic", clear_credential: true },
+        intervals: { clear_credential: true },
+      },
       { intervals: { athlete_id: "" } },
       { llm, extra: true },
     ]) {

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -21,6 +21,7 @@ import {
   createMissingPlatformCalendarMutations,
   createPlatformCalendarMutations,
   createSubsystemLogger,
+  deleteStoredProfile,
   engineConfigFromConfig,
   extractRetryAfterMs,
   loadStoredProfileSnapshot,
@@ -154,7 +155,7 @@ function copyConfig(config: Config): Config {
   };
 }
 
-function runtimePatch(request: ConfigureRuntimeRpcParams): RuntimeConfigPatch {
+function runtimePatch(request: ConfigureRuntimeRpcParams, config: Config): RuntimeConfigPatch {
   return {
     ...(request.llm === undefined
       ? {}
@@ -162,7 +163,10 @@ function runtimePatch(request: ConfigureRuntimeRpcParams): RuntimeConfigPatch {
           llm: {
             provider: request.llm.provider,
             model: request.llm.model,
-            apiKey: request.llm.api_key,
+            apiKey:
+              request.llm.clear_credential === true && config.llm.provider !== "openai-codex"
+                ? ""
+                : request.llm.api_key,
             baseUrl: request.llm.base_url,
             flushModel: request.llm.flush_model,
             compactModel: request.llm.compact_model,
@@ -172,7 +176,7 @@ function runtimePatch(request: ConfigureRuntimeRpcParams): RuntimeConfigPatch {
       ? {}
       : {
           intervals: {
-            apiKey: request.intervals.api_key,
+            apiKey: request.intervals.clear_credential === true ? "" : request.intervals.api_key,
             athleteId: request.intervals.athlete_id,
           },
         }),
@@ -181,7 +185,37 @@ function runtimePatch(request: ConfigureRuntimeRpcParams): RuntimeConfigPatch {
 }
 
 function mergedRuntimeConfig(config: Config, request: ConfigureRuntimeRpcParams): Config {
-  return { ...config, ...resolveRuntimeConfig(runtimePatch(request), config) };
+  return { ...config, ...resolveRuntimeConfig(runtimePatch(request, config), config) };
+}
+
+const LLM_CREDENTIAL_ENVIRONMENT_KEYS = {
+  anthropic: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  google: "GOOGLE_GENERATIVE_AI_API_KEY",
+  "openai-codex": undefined,
+  deepseek: "DEEPSEEK_API_KEY",
+  qwen: "ALIBABA_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  kimi: "MOONSHOT_API_KEY",
+  zai: "ZAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+} as const;
+
+function nonemptyEnvironmentValue(
+  environment: Readonly<Record<string, string | undefined>>,
+  key: string | undefined,
+): boolean {
+  return key !== undefined && environment[key] !== undefined && environment[key] !== "";
+}
+
+function llmCredentialManagedByEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+  provider: Config["llm"]["provider"],
+): boolean {
+  return (
+    nonemptyEnvironmentValue(environment, LLM_CREDENTIAL_ENVIRONMENT_KEYS[provider]) ||
+    (provider !== "openai-codex" && nonemptyEnvironmentValue(environment, "LLM_API_KEY"))
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -722,6 +756,24 @@ export async function createLocalCoachComposition(
     ): Promise<ConfigureRuntimeRpcRefusalReason | void> => {
       signal.throwIfAborted();
       if (
+        request.llm?.clear_credential === true &&
+        request.llm.provider !== activeConfig.llm.provider
+      ) {
+        return "credential-required";
+      }
+      if (
+        request.llm?.clear_credential === true &&
+        llmCredentialManagedByEnvironment(input.env, activeConfig.llm.provider)
+      ) {
+        return "managed-by-environment";
+      }
+      if (
+        request.intervals?.clear_credential === true &&
+        nonemptyEnvironmentValue(input.env, "INTERVALS_API_KEY")
+      ) {
+        return "managed-by-environment";
+      }
+      if (
         request.intervals?.athlete_id !== undefined &&
         input.env.INTERVALS_ATHLETE_ID !== undefined
       ) {
@@ -749,10 +801,11 @@ export async function createLocalCoachComposition(
       const athleteIdChanged =
         request.intervals?.athlete_id !== undefined && candidateAthleteId !== activeAthleteId;
       const apiKeyChanged =
-        request.intervals?.api_key !== undefined &&
+        (request.intervals?.api_key !== undefined ||
+          request.intervals?.clear_credential === true) &&
         candidate.intervals.apiKey !== activeConfig.intervals.apiKey;
       let pendingOwnerClaim: RuntimeAthleteOwnerClaim | undefined;
-      if (athleteIdChanged || apiKeyChanged) {
+      if (athleteIdChanged || (apiKeyChanged && request.intervals?.clear_credential !== true)) {
         if (
           apiKeyChanged &&
           input.env.INTERVALS_API_KEY !== undefined &&
@@ -774,7 +827,11 @@ export async function createLocalCoachComposition(
           return "ownership-unavailable";
         }
       }
-      if (request.llm !== undefined && candidate.llm.provider === "openai-codex") {
+      if (
+        request.llm !== undefined &&
+        request.llm.clear_credential !== true &&
+        candidate.llm.provider === "openai-codex"
+      ) {
         credential(
           loadStoredProfileSnapshot(
             join(input.home.configDir, "auth-profiles.json"),
@@ -783,15 +840,20 @@ export async function createLocalCoachComposition(
         );
       }
       const replacement = buildBundle(candidate);
+      const chatGptProfileClear =
+        request.llm?.clear_credential === true && activeConfig.llm.provider === "openai-codex";
       signal.throwIfAborted();
       await reconfigurable.replace(async () => {
         signal.throwIfAborted();
         const previousConfigFile =
-          pendingOwnerClaim === undefined
+          pendingOwnerClaim === undefined && !chatGptProfileClear
             ? undefined
             : captureRuntimeConfigFile(input.home.configDir);
         try {
           persistConfig(input.home.configDir, candidate, request, activeConfig);
+          if (chatGptProfileClear) {
+            deleteStoredProfile(join(input.home.configDir, "auth-profiles.json"), "openai-codex");
+          }
           await pendingOwnerClaim?.claim();
         } catch (error) {
           if (previousConfigFile !== undefined) {

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -9,6 +9,7 @@ import {
   RefreshTokenReusedError,
   engineConfigFromConfig,
   loadConfig,
+  loadStoredProfileSnapshot,
   saveStoredProfile,
   type Config,
 } from "@enduragent/core";
@@ -1165,6 +1166,262 @@ describe("local coach composition", () => {
         resetArchiveRetentionDays: 9,
         timezone: "America/Los_Angeles",
       },
+    });
+    await lifecycle.close();
+  });
+
+  it("drains the active turn before clearing an LLM credential and reports truthful readiness", async () => {
+    const home = await freshHome();
+    let buildCount = 0;
+    const readiness: boolean[] = [];
+    let enterOld!: () => void;
+    let releaseOld!: () => void;
+    const oldEntered = new Promise<void>((resolve) => {
+      enterOld = resolve;
+    });
+    const oldRelease = new Promise<void>((resolve) => {
+      releaseOld = resolve;
+    });
+    const initial: Config = {
+      ...config(home),
+      llm: { ...config(home).llm, apiKey: "synthetic" },
+    };
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: (input) => {
+          buildCount += 1;
+          const generation = buildCount;
+          readiness.push(input.ports.config.llm.apiKey.length > 0);
+          return backend({
+            chat: async () => {
+              if (generation === 1) {
+                enterOld();
+                await oldRelease;
+              }
+              return { text: String(input.ports.config.llm.apiKey.length > 0) };
+            },
+          });
+        },
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    const oldTurn = lifecycle.engine.chat({ chatId: "credential", message: "hold" });
+    await oldEntered;
+    let deletionSettled = false;
+    const deletion = lifecycle.operations
+      .configureRuntime({ llm: { provider: "anthropic", clear_credential: true } })
+      .then((result) => {
+        deletionSettled = true;
+        return result;
+      });
+    for (let attempt = 0; attempt < 20 && buildCount < 2; attempt += 1) {
+      await Promise.resolve();
+    }
+    expect(readiness).toEqual([true, false]);
+    await Promise.resolve();
+    expect(deletionSettled).toBe(false);
+
+    releaseOld();
+    await expect(oldTurn).resolves.toEqual({ text: "true" });
+    await expect(deletion).resolves.toMatchObject({
+      status: "applied",
+      applied: { llm: true, intervals: false },
+    });
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      llm: { credential_configured: false },
+    });
+    await expect(
+      lifecycle.engine.chat({ chatId: "credential", message: "after" }),
+    ).resolves.toEqual({ text: "false" });
+    await lifecycle.close();
+  });
+
+  it("refuses to clear a different active LLM credential", async () => {
+    const home = await freshHome();
+    const initial: Config = {
+      ...config(home),
+      llm: { ...config(home).llm, apiKey: "synthetic" },
+    };
+    const createBackend = vi.fn(() => backend());
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend,
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    await expect(
+      lifecycle.operations.configureRuntime({
+        llm: { provider: "openai", clear_credential: true },
+      }),
+    ).resolves.toEqual({
+      schemaVersion: 3,
+      status: "refused",
+      reason: "credential-required",
+    });
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      llm: { provider: "anthropic", credential_configured: true },
+    });
+    expect(createBackend).toHaveBeenCalledOnce();
+    await lifecycle.close();
+  });
+
+  it("clears the intervals credential without changing or reclaiming the training-store owner", async () => {
+    const home = await freshHome();
+    const assertOwner = vi.fn(async () => {});
+    const selectedRuntime = runtime();
+    const runWindowAfter = vi.fn(selectedRuntime.runWindowAfter);
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => ({ ...selectedRuntime, runWindowAfter }),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        assertRuntimeAthleteOwner: assertOwner,
+      },
+      fakeContext(home),
+      { apiKey: "synthetic", athleteId: "fixed-athlete" },
+    );
+    const ownerChecksBefore = assertOwner.mock.calls.length;
+
+    await expect(
+      lifecycle.operations.configureRuntime({ intervals: { clear_credential: true } }),
+    ).resolves.toMatchObject({
+      status: "applied",
+      applied: { llm: false, intervals: true },
+    });
+
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      intervals: {
+        athlete_id: "fixed-athlete",
+        credential_configured: false,
+      },
+    });
+    expect(assertOwner).toHaveBeenCalledTimes(ownerChecksBefore);
+    expect(runWindowAfter).not.toHaveBeenCalled();
+    await lifecycle.close();
+  });
+
+  it.each([
+    {
+      request: { llm: { provider: "anthropic", clear_credential: true } },
+      env: { ANTHROPIC_API_KEY: "synthetic" },
+      slot: "llm",
+    },
+    {
+      request: { intervals: { clear_credential: true } },
+      env: { INTERVALS_API_KEY: "synthetic" },
+      slot: "intervals",
+    },
+  ] as const)("refuses environment-managed $slot credential deletion", async ({ request, env }) => {
+    const home = await freshHome();
+    const initial: Config = {
+      ...config(home, { apiKey: "synthetic", athleteId: "fixed-athlete" }),
+      llm: { ...config(home).llm, apiKey: "synthetic" },
+    };
+    const createBackend = vi.fn(() => backend());
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend,
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+      { ENDURAGENT_HOME: home.root, ...env },
+    );
+
+    await expect(lifecycle.operations.configureRuntime(request)).resolves.toEqual({
+      schemaVersion: 3,
+      status: "refused",
+      reason: "managed-by-environment",
+    });
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      [request.llm === undefined ? "intervals" : "llm"]: {
+        credential_configured: true,
+      },
+    });
+    expect(createBackend).toHaveBeenCalledOnce();
+    await lifecycle.close();
+  });
+
+  it("deletes an active ChatGPT profile inside the drained credential cutover", async () => {
+    const home = await freshHome();
+    saveStoredProfile(join(home.configDir, "auth-profiles.json"), "openai-codex", {
+      type: "oauth",
+      access: "synthetic",
+      refresh: "synthetic",
+      expires: 4_102_444_800_000,
+    });
+    const initial: Config = {
+      ...config(home),
+      llm: {
+        ...config(home).llm,
+        provider: "openai-codex",
+        apiKey: "",
+        authProfile: "openai-codex",
+      },
+    };
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    await expect(
+      lifecycle.operations.configureRuntime({
+        llm: { provider: "openai-codex", clear_credential: true },
+      }),
+    ).resolves.toMatchObject({ status: "applied", applied: { llm: true } });
+    expect(
+      loadStoredProfileSnapshot(join(home.configDir, "auth-profiles.json"), "openai-codex"),
+    ).toBeNull();
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      llm: { provider: "openai-codex", credential_configured: false },
     });
     await lifecycle.close();
   });

--- a/packages/core/src/auth/profile-store.ts
+++ b/packages/core/src/auth/profile-store.ts
@@ -34,6 +34,8 @@ export type CompareAndSaveStoredProfileResult =
   | { readonly status: "superseded"; readonly profile: StoredProfile }
   | { readonly status: "missing" };
 
+export type DeleteStoredProfileResult = { readonly status: "deleted" | "missing" };
+
 type ProfilesDocument = Record<string, StoredProfile>;
 
 interface RecoverableProfilesDocument {
@@ -216,6 +218,17 @@ export function recoverAndSaveStoredProfile(
     }
     recovered.profiles[name] = profile;
     writeProfiles(profilesPath, recovered.profiles);
+  });
+}
+
+export function deleteStoredProfile(profilesPath: string, name: string): DeleteStoredProfileResult {
+  mkdirSync(dirname(profilesPath), { recursive: true, mode: 0o700 });
+  return withInterprocessFileLockSync(lockPathFor(profilesPath), () => {
+    const profiles = readProfiles(profilesPath);
+    if (profileAt(profiles, name) === undefined) return { status: "missing" };
+    delete profiles[name];
+    writeProfiles(profilesPath, profiles);
+    return { status: "deleted" };
   });
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,12 +127,14 @@ export {
 export type { OAuthCredential } from "./auth/profiles.js";
 export {
   compareAndSaveStoredProfile,
+  deleteStoredProfile,
   loadStoredProfileSnapshot,
   recoverAndSaveStoredProfile,
   saveStoredProfile,
 } from "./auth/profile-store.js";
 export type {
   CompareAndSaveStoredProfileResult,
+  DeleteStoredProfileResult,
   StoredProfile,
   StoredProfileSnapshot,
 } from "./auth/profile-store.js";
@@ -155,11 +157,7 @@ export {
   resolveConfigSecrets,
   sessionConfigEnvironmentOwnership,
 } from "./config.js";
-export type {
-  Config,
-  LoadConfigOptions,
-  SessionConfigEnvironmentOwnership,
-} from "./config.js";
+export type { Config, LoadConfigOptions, SessionConfigEnvironmentOwnership } from "./config.js";
 export { DATA_SOURCES, resolveDataSource } from "./config.js";
 export type { DataSource } from "./config.js";
 export {

--- a/packages/core/tests/profile-store.test.ts
+++ b/packages/core/tests/profile-store.test.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   compareAndSaveStoredProfile,
+  deleteStoredProfile,
   loadStoredProfileSnapshot,
   recoverAndSaveStoredProfile,
   saveStoredProfile,
@@ -141,6 +142,18 @@ afterEach(async () => {
 });
 
 describe("profile store", () => {
+  it("atomically deletes one profile while preserving unrelated entries", () => {
+    const profilesPath = freshProfilesPath();
+    saveStoredProfile(profilesPath, "alpha", profile("alpha"));
+    saveStoredProfile(profilesPath, "beta", profile("beta"));
+
+    expect(deleteStoredProfile(profilesPath, "alpha")).toEqual({ status: "deleted" });
+    expect(deleteStoredProfile(profilesPath, "alpha")).toEqual({ status: "missing" });
+    expect(loadStoredProfileSnapshot(profilesPath, "alpha")).toBeNull();
+    expect(loadStoredProfileSnapshot(profilesPath, "beta")).not.toBeNull();
+    expect(statSync(profilesPath).mode & 0o777).toBe(0o600);
+  });
+
   it("saves synchronously under the sibling lock and preserves unrelated profiles", () => {
     const profilesPath = freshProfilesPath();
     saveStoredProfile(profilesPath, "alpha", profile("alpha"));


### PR DESCRIPTION
## Summary

Final Settings slice for parity issue 231: credential deletion. Deleting a credential removes it from the local vault AND immediately clears the matching active runtime credential, then guides the athlete to sign in again. Deletion is strictly local — no remote or provider-side revocation — and account switching remains out of scope.

- Settings lists stored credentials in redacted form only (provider/kind and coarse runtime state; never a value, fragment, length, or hash)
- Deletion is confirmation-gated destructive UI with accessible roles/names, polite live-region announcements, and deterministic focus, consistent with the shipped Settings slices
- Active-credential deletion goes through the serialized drained runtime replacement boundary; readiness truthfully reports the needs-credential state afterward and the Setup recovery path is reachable and focused
- Stored-inactive deletion touches only the vault plus a status refresh
- Vault mutation is atomic and crash-safe: rename-to-tombstone, directory fsync, rollback re-apply, and a tombstone reaper; every crash window converges to deletion or retention, and ambiguous partial failures surface a truthful divergence state instead of silently retaining or dropping the credential
- Environment-managed credentials refuse deletion without revealing configuration details
- IPC routes through the existing strict validated redacted runtime authority; the packaged bridge pin gains exactly the one new key
- Store-owner immutability and the same-owner athlete-ID boundaries are preserved; the RPC schema forbids combining a credential clear with any other slot

## Verification

- 13 focused test files, 324 tests, plus renderer/desktop-main/contract/core/coach coverage for redaction, confirmation and focus, refusals, drained cutover, inactive deletion, mismatch protection, and partial failures
- Root `pnpm check` and `pnpm check:types` pass; affected package typechecks and builds pass
- Three independent read-only reviews (credential security, vault persistence/atomicity, concurrency/runtime cutover and UX) found zero blocking issues
- Changeset included with a User-facing line
