### PR TITLE
feat(coach): add paginated transcript reads

### DIFF
--- a/.changeset/desktop-transcript-pagination.md
+++ b/.changeset/desktop-transcript-pagination.md
@@ -1,0 +1,11 @@
+---
+"cycling-coach": patch
+"@enduragent/core": patch
+"@enduragent/coach": patch
+"@enduragent/coach-contract": patch
+"@enduragent/coach-client": patch
+"@enduragent/desktop": patch
+"@enduragent/desktop-renderer": patch
+---
+
+Add bounded, cursor-stable transcript pagination for the canonical Desktop conversation across the durable store, daemon RPC, main-process IPC, and validated preload bridge.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -4,6 +4,10 @@ interface EnduragentAuth {
     readonly token: string;
     readonly generation: number;
   }>;
+  getTranscriptPage(input: {
+    readonly cursor: string | null;
+    readonly limit: number;
+  }): Promise<DesktopTranscriptPage>;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
   retryFailedCredentials(): Promise<readonly CredentialSlotStatus[]>;
   writeCredential(input: {
@@ -26,6 +30,27 @@ interface EnduragentAuth {
   restartToUpdate(): Promise<DesktopUpdateState>;
   onUpdateState(listener: (state: DesktopUpdateState) => void): () => void;
 }
+
+interface DesktopTranscriptTurn {
+  readonly turnId: string;
+  readonly completedAt: string;
+  readonly athleteText: string;
+  readonly coachText: string;
+}
+
+type DesktopTranscriptPage =
+  | {
+      readonly schemaVersion: 1;
+      readonly status: "page";
+      readonly turns: readonly DesktopTranscriptTurn[];
+      readonly nextCursor: string | null;
+    }
+  | {
+      readonly schemaVersion: 1;
+      readonly status: "restart-required";
+      readonly turns: readonly [];
+      readonly nextCursor: null;
+    };
 
 type DesktopUpdateState =
   | { readonly status: "disabled" | "idle" | "checking" | "current" }

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -281,6 +281,7 @@ async function security() {
             "credentialStatuses",
             "deleteCredential",
             "getDaemonConnection",
+            "getTranscriptPage",
             "getUpdateState",
             "llmConfiguration",
             "onDroppedImportFiles",

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -3,6 +3,7 @@ export const DESKTOP_HOST = "app" as const;
 export const DESKTOP_RENDERER_ORIGIN = "enduragent://app" as const;
 export const DESKTOP_RENDERER_URL = "enduragent://app/index.html" as const;
 export const DESKTOP_CONNECTION_CHANNEL = "desktop:get-daemon-connection" as const;
+export const DESKTOP_TRANSCRIPT_PAGE_CHANNEL = "desktop:get-transcript-page" as const;
 export const DESKTOP_RELEASE_NOTES_CHANNEL = "desktop:get-release-notes" as const;
 export const DESKTOP_UPDATE_GET_CHANNEL = "desktop:update:get" as const;
 export const DESKTOP_UPDATE_CHECK_CHANNEL = "desktop:update:check" as const;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -68,6 +68,11 @@ import { createDesktopQuitCoordinator } from "./quit-coordinator.js";
 import { createDesktopUpdateController } from "./update-controller.js";
 import { isDesktopUpdateReleaseEligible } from "./update-eligibility.js";
 import { installDesktopUpdateIpc } from "./update-ipc.js";
+import {
+  createConnectionTranscriptReader,
+  installDesktopTranscriptIpc,
+  type DesktopTranscriptReader,
+} from "./transcript-ipc.js";
 
 registerDesktopScheme();
 
@@ -129,6 +134,7 @@ async function runDesktop(): Promise<void> {
   let quitRequested = false;
   let protocolInstalled = false;
   let disposeConnectionIpc: (() => void) | undefined;
+  let disposeTranscriptIpc: (() => void) | undefined;
   let disposeExternalLinkIpc: (() => void) | undefined;
   let disposeReleaseNotesIpc: (() => void) | undefined;
   let disposeUpdateIpc: (() => void) | undefined;
@@ -155,6 +161,8 @@ async function runDesktop(): Promise<void> {
       controller.abort();
       disposeConnectionIpc?.();
       disposeConnectionIpc = undefined;
+      disposeTranscriptIpc?.();
+      disposeTranscriptIpc = undefined;
       disposeExternalLinkIpc?.();
       disposeExternalLinkIpc = undefined;
       disposeReleaseNotesIpc?.();
@@ -200,6 +208,7 @@ async function runDesktop(): Promise<void> {
     type RuntimeBinding = {
       readonly authority: RuntimeConfigurationAuthority;
       readonly credentials: CredentialRuntimeApplication;
+      readonly transcript: DesktopTranscriptReader;
     };
     let activeRuntimeBinding: RuntimeBinding | undefined;
     const preparedRuntimeBindings = new Map<
@@ -299,6 +308,7 @@ async function runDesktop(): Promise<void> {
       const authority = createConnectionRuntimeAuthority(connection, connectCoachClient);
       return {
         authority,
+        transcript: createConnectionTranscriptReader(connection),
         credentials: createCredentialRuntimeApplication({
           configureRuntime: authority.configureRuntime,
           clearRuntimeCredential: authority.clearCredential,
@@ -328,6 +338,23 @@ async function runDesktop(): Promise<void> {
         throw new TypeError();
       }
       return snapshot;
+    };
+    const readActiveTranscriptPage = async (
+      request: Parameters<DesktopTranscriptReader["getTranscriptPage"]>[0],
+    ) => {
+      const binding = activeRuntimeBinding;
+      const lifecycleState = daemonLifecycle?.snapshot();
+      if (binding === undefined || lifecycleState?.status !== "ready") throw new TypeError();
+      const page = await binding.transcript.getTranscriptPage(request);
+      const currentLifecycleState = daemonLifecycle?.snapshot();
+      if (
+        activeRuntimeBinding !== binding ||
+        currentLifecycleState?.status !== "ready" ||
+        currentLifecycleState.generation !== lifecycleState.generation
+      ) {
+        throw new TypeError();
+      }
+      return page;
     };
     const credentialRoot = join(app.getPath("userData"), CREDENTIAL_DIRECTORY_NAME);
     const vault = createCredentialVault({
@@ -572,6 +599,11 @@ async function runDesktop(): Promise<void> {
       ipcMain,
       currentWindow: () => mainWindow.current() ?? undefined,
       runtime: daemonLifecycle,
+    });
+    disposeTranscriptIpc = installDesktopTranscriptIpc({
+      ipcMain,
+      currentWindow: () => mainWindow.current() ?? undefined,
+      readPage: readActiveTranscriptPage,
     });
     disposeExternalLinkIpc = installDesktopExternalLinkIpc({
       ipcMain,

--- a/apps/desktop/src/main/transcript-ipc.ts
+++ b/apps/desktop/src/main/transcript-ipc.ts
@@ -1,0 +1,61 @@
+import { connectCoachClient, type CoachClient } from "@enduragent/coach-client";
+import {
+  GetTranscriptPageRpcParamsSchema,
+  GetTranscriptPageRpcResultSchema,
+  type GetTranscriptPageRpcParams,
+  type GetTranscriptPageRpcResult,
+} from "@enduragent/coach-contract";
+import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from "electron";
+import { DESKTOP_TRANSCRIPT_PAGE_CHANNEL } from "./constants.js";
+import { isTrustedConnectionRequest } from "./security.js";
+
+export interface DesktopTranscriptReader {
+  getTranscriptPage(request: GetTranscriptPageRpcParams): Promise<GetTranscriptPageRpcResult>;
+}
+
+export function createConnectionTranscriptReader(
+  connection: Readonly<{ url: `ws://127.0.0.1:${number}/rpc`; token: string }>,
+  connect: typeof connectCoachClient = connectCoachClient,
+): DesktopTranscriptReader {
+  const call = async <T>(operation: (client: CoachClient) => Promise<T>): Promise<T> => {
+    const client = await connect({ url: connection.url, token: connection.token });
+    try {
+      return await operation(client);
+    } finally {
+      await client.close();
+    }
+  };
+  return {
+    getTranscriptPage(request) {
+      return call((client) => client.call("getTranscriptPage", request));
+    },
+  };
+}
+
+export function installDesktopTranscriptIpc(input: {
+  readonly ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
+  readonly currentWindow: () => BrowserWindow | undefined;
+  readonly readPage: (request: GetTranscriptPageRpcParams) => Promise<GetTranscriptPageRpcResult>;
+}): () => void {
+  input.ipcMain.handle(
+    DESKTOP_TRANSCRIPT_PAGE_CHANNEL,
+    async (event: IpcMainInvokeEvent, ...args: unknown[]) => {
+      if (!isTrustedConnectionRequest(event, input.currentWindow())) {
+        throw new Error("untrusted desktop transcript request");
+      }
+      const parsed =
+        args.length === 1 ? GetTranscriptPageRpcParamsSchema.safeParse(args[0]) : undefined;
+      if (parsed === undefined || !parsed.success) {
+        throw new TypeError("invalid desktop transcript request");
+      }
+      try {
+        return GetTranscriptPageRpcResultSchema.parse(await input.readPage(parsed.data));
+      } catch {
+        throw new TypeError("desktop transcript unavailable");
+      }
+    },
+  );
+  return () => {
+    input.ipcMain.removeHandler(DESKTOP_TRANSCRIPT_PAGE_CHANNEL);
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -4,6 +4,7 @@ import {
   DESKTOP_LIFECYCLE_CHANNEL,
   DESKTOP_OPEN_EXTERNAL_CHANNEL,
   DESKTOP_RELEASE_NOTES_CHANNEL,
+  DESKTOP_TRANSCRIPT_PAGE_CHANNEL,
   DESKTOP_UPDATE_CHECK_CHANNEL,
   DESKTOP_UPDATE_GET_CHANNEL,
   DESKTOP_UPDATE_RESTART_CHANNEL,
@@ -83,6 +84,11 @@ const CHATGPT_REASONS = new Set([
 const IMPORT_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
 const RELEASES_URL = "https://github.com/yerzhansa/cycling-coach/releases";
 const RELEASE_NOTES_MAX_TOTAL_BYTES = 64 * 1024;
+const TRANSCRIPT_PAGE_MAX_TURNS = 50;
+const TRANSCRIPT_PAGE_MAX_RESPONSE_BYTES = 266_240;
+const TRANSCRIPT_CURSOR_LENGTH = 152;
+const TRANSCRIPT_CURSOR_PATTERN = /^[A-Za-z0-9_-]{152}$/;
+const BASE64URL_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 const RELEASE_VERSION_RE =
   /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const STABLE_VERSION_RE = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
@@ -94,6 +100,123 @@ function record(value: unknown): value is Record<string, unknown> {
 
 function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
   return JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+}
+
+function decodedBase64Url(value: string): Uint8Array | null {
+  let accumulator = 0;
+  let bits = 0;
+  const decoded: number[] = [];
+  for (const character of value) {
+    const digit = BASE64URL_ALPHABET.indexOf(character);
+    if (digit < 0) return null;
+    accumulator = (accumulator << 6) | digit;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      decoded.push((accumulator >> bits) & 0xff);
+      accumulator &= (1 << bits) - 1;
+    }
+  }
+  return bits === 0 ? Uint8Array.from(decoded) : null;
+}
+
+function safeCursorOffset(bytes: Uint8Array, offset: number): number | null {
+  let value = 0;
+  for (let index = offset; index < offset + 8; index += 1) {
+    value = value * 256 + bytes[index]!;
+    if (!Number.isSafeInteger(value)) return null;
+  }
+  return value;
+}
+
+function transcriptCursor(value: unknown): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length !== TRANSCRIPT_CURSOR_LENGTH ||
+    !TRANSCRIPT_CURSOR_PATTERN.test(value)
+  ) {
+    return false;
+  }
+  const bytes = decodedBase64Url(value);
+  if (bytes === null || bytes.length !== 114 || bytes[0] !== 1) return false;
+  const fenceKind = bytes[1];
+  if (fenceKind !== 0 && fenceKind !== 1) return false;
+  if (fenceKind === 0 && bytes.slice(34, 66).some((byte) => byte !== 0)) return false;
+  const snapshotEnd = safeCursorOffset(bytes, 98);
+  const before = safeCursorOffset(bytes, 106);
+  return snapshotEnd !== null && before !== null && before <= snapshotEnd;
+}
+
+function parseTranscriptPageRequest(value: unknown): {
+  readonly cursor: string | null;
+  readonly limit: number;
+} {
+  if (
+    !record(value) ||
+    !exactKeys(value, ["cursor", "limit"]) ||
+    (value.cursor !== null && !transcriptCursor(value.cursor)) ||
+    !Number.isSafeInteger(value.limit) ||
+    (value.limit as number) < 1 ||
+    (value.limit as number) > TRANSCRIPT_PAGE_MAX_TURNS
+  ) {
+    throw new TypeError();
+  }
+  return { cursor: value.cursor as string | null, limit: value.limit as number };
+}
+
+function canonicalIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}
+
+function parseTranscriptPage(value: unknown): unknown {
+  if (
+    !record(value) ||
+    !exactKeys(value, ["schemaVersion", "status", "turns", "nextCursor"]) ||
+    value.schemaVersion !== 1 ||
+    (value.status !== "page" && value.status !== "restart-required") ||
+    !Array.isArray(value.turns) ||
+    value.turns.length > TRANSCRIPT_PAGE_MAX_TURNS ||
+    (value.nextCursor !== null && !transcriptCursor(value.nextCursor)) ||
+    textEncoder.encode(JSON.stringify(value)).byteLength > TRANSCRIPT_PAGE_MAX_RESPONSE_BYTES
+  ) {
+    throw new TypeError();
+  }
+  const turns = value.turns.map((turn) => {
+    if (
+      !record(turn) ||
+      !exactKeys(turn, ["turnId", "completedAt", "athleteText", "coachText"]) ||
+      typeof turn.turnId !== "string" ||
+      turn.turnId.length === 0 ||
+      !canonicalIsoTimestamp(turn.completedAt) ||
+      typeof turn.athleteText !== "string" ||
+      typeof turn.coachText !== "string"
+    ) {
+      throw new TypeError();
+    }
+    return {
+      turnId: turn.turnId,
+      completedAt: turn.completedAt,
+      athleteText: turn.athleteText,
+      coachText: turn.coachText,
+    };
+  });
+  if (value.status === "restart-required" && (turns.length !== 0 || value.nextCursor !== null)) {
+    throw new TypeError();
+  }
+  if (value.status === "page" && turns.length === 0 && value.nextCursor !== null) {
+    throw new TypeError();
+  }
+  return {
+    schemaVersion: 1,
+    status: value.status,
+    turns,
+    nextCursor: value.nextCursor,
+  };
 }
 
 function safeString(value: unknown, maximumLength: number): value is string {
@@ -623,6 +746,12 @@ contextBridge.exposeInMainWorld(
       return ipcRenderer.invoke(
         DESKTOP_CONNECTION_CHANNEL,
         ...(failedGeneration === undefined ? [] : [{ generation: failedGeneration }]),
+      );
+    },
+    getTranscriptPage: async (input: unknown) => {
+      const request = parseTranscriptPageRequest(input);
+      return parseTranscriptPage(
+        await ipcRenderer.invoke(DESKTOP_TRANSCRIPT_PAGE_CHANNEL, request),
       );
     },
     credentialStatuses: async () =>

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -307,6 +307,11 @@ export async function launchDesktopFixture(input: {
         ReturnType<CoachOperations["saveIntake"]>
       >;
     },
+    async getTranscriptPage(request) {
+      return finalFrame(await invoke("getTranscriptPage", request)) as Awaited<
+        ReturnType<CoachOperations["getTranscriptPage"]>
+      >;
+    },
     async configureRuntime(request) {
       return finalFrame(await invoke("configureRuntime", request)) as Awaited<
         ReturnType<CoachOperations["configureRuntime"]>

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -39,6 +39,7 @@ vi.mock("electron", () => ({
 
 interface AuthBridge {
   getDaemonConnection(failedGeneration?: number): Promise<unknown>;
+  getTranscriptPage(input: unknown): Promise<unknown>;
   credentialStatuses(): Promise<unknown>;
   deleteCredential(input: unknown): Promise<unknown>;
   retryFailedCredentials(): Promise<unknown>;
@@ -52,6 +53,12 @@ interface AuthBridge {
   checkForUpdates(): Promise<unknown>;
   restartToUpdate(): Promise<unknown>;
   onUpdateState(listener: (state: unknown) => void): () => void;
+}
+
+function validTranscriptCursor(): string {
+  const bytes = Buffer.alloc(114);
+  bytes[0] = 1;
+  return bytes.toString("base64url");
 }
 
 const chatGptSelection = {
@@ -157,6 +164,7 @@ describe("desktop preload ChatGPT auth", () => {
         "deleteCredential",
         "getUpdateState",
         "getDaemonConnection",
+        "getTranscriptPage",
         "llmConfiguration",
         "checkForUpdates",
         "onDroppedImportFiles",
@@ -168,6 +176,81 @@ describe("desktop preload ChatGPT auth", () => {
       ].sort(),
     );
     expect(bridge).not.toHaveProperty("openExternal");
+  });
+
+  it("validates and copies strict bounded transcript pages", async () => {
+    const cursor = validTranscriptCursor();
+    const response = {
+      schemaVersion: 1,
+      status: "page",
+      turns: [
+        {
+          turnId: "turn-1",
+          completedAt: "1998-07-06T00:00:00.000Z",
+          athleteText: "a",
+          coachText: "b",
+        },
+      ],
+      nextCursor: cursor,
+    };
+    mocks.invoke.mockResolvedValueOnce(response);
+
+    const page = await bridge.getTranscriptPage({ cursor: null, limit: 25 });
+
+    expect(page).toEqual(response);
+    expect(page).not.toBe(response);
+    expect(mocks.invoke).toHaveBeenCalledWith("desktop:get-transcript-page", {
+      cursor: null,
+      limit: 25,
+    });
+  });
+
+  it("rejects malformed transcript requests before IPC and redacts malformed responses", async () => {
+    for (const request of [
+      null,
+      {},
+      { cursor: null, limit: 0 },
+      { cursor: null, limit: 51 },
+      { cursor: "a".repeat(152), limit: 10 },
+      { cursor: null, limit: 10, path: "/private/transcript" },
+    ]) {
+      await expect(bridge.getTranscriptPage(request)).rejects.toBeInstanceOf(TypeError);
+    }
+    expect(mocks.invoke).not.toHaveBeenCalled();
+
+    for (const response of [
+      {
+        schemaVersion: 1,
+        status: "restart-required",
+        turns: [],
+        nextCursor: validTranscriptCursor(),
+      },
+      {
+        schemaVersion: 1,
+        status: "page",
+        turns: [],
+        nextCursor: null,
+        transcriptPath: "/private/transcript",
+      },
+      {
+        schemaVersion: 1,
+        status: "page",
+        turns: [
+          {
+            turnId: "turn-1",
+            completedAt: "not-a-timestamp",
+            athleteText: "a",
+            coachText: "b",
+          },
+        ],
+        nextCursor: null,
+      },
+    ]) {
+      mocks.invoke.mockResolvedValueOnce(response);
+      await expect(bridge.getTranscriptPage({ cursor: null, limit: 10 })).rejects.toBeInstanceOf(
+        TypeError,
+      );
+    }
   });
 
   it("returns strict copied update states from zero-argument channels", async () => {

--- a/apps/desktop/tests/transcript-ipc.test.ts
+++ b/apps/desktop/tests/transcript-ipc.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CoachClientCallTimeoutError } from "@enduragent/coach-client";
+
+vi.mock("electron", () => ({
+  BrowserWindow: class {},
+  net: { fetch: vi.fn() },
+  protocol: { registerSchemesAsPrivileged: vi.fn() },
+}));
+
+import {
+  createConnectionTranscriptReader,
+  installDesktopTranscriptIpc,
+} from "../src/main/transcript-ipc.js";
+import { DESKTOP_RENDERER_URL, DESKTOP_TRANSCRIPT_PAGE_CHANNEL } from "../src/main/constants.js";
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const page = {
+  schemaVersion: 1 as const,
+  status: "page" as const,
+  turns: [
+    {
+      turnId: "turn-1",
+      completedAt: "1998-07-06T00:00:00.000Z",
+      athleteText: "a",
+      coachText: "b",
+    },
+  ],
+  nextCursor: null,
+};
+
+function setup(readPage = vi.fn(async () => page)) {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: vi.fn((channel: string, handler: Handler) => handlers.set(channel, handler)),
+    removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+  };
+  const mainFrame = { url: DESKTOP_RENDERER_URL };
+  const webContents = { isDestroyed: () => false, mainFrame };
+  const window = { isDestroyed: () => false, webContents };
+  const dispose = installDesktopTranscriptIpc({
+    ipcMain: ipcMain as never,
+    currentWindow: () => window as never,
+    readPage,
+  });
+  return {
+    dispose,
+    handlers,
+    ipcMain,
+    readPage,
+    trusted: { sender: webContents, senderFrame: mainFrame },
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("desktop transcript IPC", () => {
+  it("forwards one strict request from the trusted main frame and returns a parsed copy", async () => {
+    const subject = setup();
+    const handler = subject.handlers.get(DESKTOP_TRANSCRIPT_PAGE_CHANNEL)!;
+    const result = await handler(subject.trusted, { cursor: null, limit: 25 });
+
+    expect(result).toEqual(page);
+    expect(result).not.toBe(page);
+    expect(subject.readPage).toHaveBeenCalledWith({ cursor: null, limit: 25 });
+  });
+
+  it("refuses untrusted and malformed requests before invoking the daemon reader", async () => {
+    const subject = setup();
+    const handler = subject.handlers.get(DESKTOP_TRANSCRIPT_PAGE_CHANNEL)!;
+    await expect(
+      handler(
+        { sender: {}, senderFrame: { url: DESKTOP_RENDERER_URL } },
+        { cursor: null, limit: 25 },
+      ),
+    ).rejects.toThrow("untrusted desktop transcript request");
+
+    for (const args of [
+      [],
+      [{ cursor: null, limit: 0 }],
+      [{ cursor: null, limit: 51 }],
+      [{ cursor: null, limit: 25, chatId: "other" }],
+      [{ cursor: "a".repeat(152), limit: 25 }],
+      [{ cursor: null, limit: 25 }, { extra: true }],
+    ]) {
+      await expect(handler(subject.trusted, ...args)).rejects.toThrow(
+        "invalid desktop transcript request",
+      );
+    }
+    expect(subject.readPage).not.toHaveBeenCalled();
+  });
+
+  it("redacts deadline failures and malformed daemon responses", async () => {
+    const timeout = setup(
+      vi.fn(async () => {
+        throw new CoachClientCallTimeoutError("getTranscriptPage", 30_000);
+      }),
+    );
+    const timeoutHandler = timeout.handlers.get(DESKTOP_TRANSCRIPT_PAGE_CHANNEL)!;
+    await expect(timeoutHandler(timeout.trusted, { cursor: null, limit: 25 })).rejects.toThrow(
+      "desktop transcript unavailable",
+    );
+
+    const malformed = setup(
+      vi.fn(async () => ({
+        ...page,
+        transcriptPath: "/synthetic/private/transcript",
+      })),
+    );
+    const malformedHandler = malformed.handlers.get(DESKTOP_TRANSCRIPT_PAGE_CHANNEL)!;
+    await expect(malformedHandler(malformed.trusted, { cursor: null, limit: 25 })).rejects.toThrow(
+      "desktop transcript unavailable",
+    );
+  });
+
+  it("uses a terminal deadline-aware coach client and closes it after each read", async () => {
+    const client = {
+      call: vi.fn(async () => page),
+      close: vi.fn(async () => {}),
+    };
+    const connect = vi.fn(async () => client);
+    const reader = createConnectionTranscriptReader(
+      {
+        url: "ws://127.0.0.1:45001/rpc",
+        token: "s".repeat(43),
+      },
+      connect as never,
+    );
+
+    await expect(reader.getTranscriptPage({ cursor: null, limit: 25 })).resolves.toEqual(page);
+    expect(client.call).toHaveBeenCalledWith("getTranscriptPage", {
+      cursor: null,
+      limit: 25,
+    });
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it("removes the transcript channel during shutdown", () => {
+    const subject = setup();
+    subject.dispose();
+    expect(subject.handlers.has(DESKTOP_TRANSCRIPT_PAGE_CHANNEL)).toBe(false);
+    expect(subject.ipcMain.removeHandler).toHaveBeenCalledWith(DESKTOP_TRANSCRIPT_PAGE_CHANNEL);
+  });
+});

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -110,6 +110,7 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   chat: 11 * 60_000,
   resetSession: 11 * 60_000,
   hasSession: 30_000,
+  getTranscriptPage: 30_000,
   getAthleteState: 30_000,
   importFiles: 60 * 60_000,
   sync: 24 * 60 * 60_000,

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -36,6 +36,7 @@ const rpcDeadlineCases = [
   ["chat", { chatId: "chat-1", message: "deadline" }, 660_000],
   ["resetSession", { chatId: "chat-1" }, 660_000],
   ["hasSession", { chatId: "chat-1" }, 30_000],
+  ["getTranscriptPage", { cursor: null, limit: 25 }, 30_000],
   ["getAthleteState", {}, 30_000],
   ["importFiles", { paths: ["/synthetic/ride.fit"] }, 3_600_000],
   ["sync", {}, 86_400_000],
@@ -594,6 +595,12 @@ describe("RPC receive and observers", () => {
         chat: { text: "answer" },
         resetSession: { memoryFlushed: true },
         hasSession: { hasSession: true },
+        getTranscriptPage: {
+          schemaVersion: 1,
+          status: "page",
+          turns: [],
+          nextCursor: null,
+        },
         getAthleteState: {
           schemaVersion: "1",
           lastUpdated: "2020-01-01T00:00:00.000Z",
@@ -715,6 +722,12 @@ describe("RPC receive and observers", () => {
     await expect(client.call("hasSession", { chatId: "chat-1" })).resolves.toEqual({
       hasSession: true,
     });
+    await expect(client.call("getTranscriptPage", { cursor: null, limit: 25 })).resolves.toEqual({
+      schemaVersion: 1,
+      status: "page",
+      turns: [],
+      nextCursor: null,
+    });
     await expect(client.call("getAthleteState", {})).resolves.toMatchObject({ schemaVersion: "1" });
     await expect(
       client.call("importFiles", { paths: ["/synthetic/ride.fit"] }),
@@ -743,12 +756,13 @@ describe("RPC receive and observers", () => {
       llm: { provider: "anthropic", model: "synthetic-model" },
     });
     expect(received.map((value) => (value as { id: number }).id)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8, 9,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
     ]);
     expect(received.map((value) => (value as { method: string }).method)).toEqual([
       "chat",
       "resetSession",
       "hasSession",
+      "getTranscriptPage",
       "getAthleteState",
       "importFiles",
       "sync",
@@ -764,7 +778,7 @@ describe("RPC receive and observers", () => {
       value: "imperial",
       source: "cycling",
     });
-    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([10, 11]);
+    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([11, 12]);
     expect(received.slice(-2).map((value) => (value as { method: string }).method)).toEqual([
       "getUnitsPreference",
       "setUnitsPreference",
@@ -775,7 +789,7 @@ describe("RPC receive and observers", () => {
     await expect(client.call("setDailySpendCap", { dailyCapUsd: 0.75 })).resolves.toMatchObject({
       dailyCapUsd: 0.75,
     });
-    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([12, 13]);
+    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([13, 14]);
     expect(received.slice(-2).map((value) => (value as { method: string }).method)).toEqual([
       "getSpendSummary",
       "setDailySpendCap",

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -116,6 +116,7 @@ export const COACH_RPC_METHOD_NAMES = [
   "chat",
   "resetSession",
   "hasSession",
+  "getTranscriptPage",
   "getAthleteState",
   "importFiles",
   "sync",
@@ -146,6 +147,125 @@ export type ChatRpcParams = z.infer<typeof ChatRpcParamsSchema>;
 
 export const EmptyRpcParamsSchema = z.object({}).strict();
 export type EmptyRpcParams = z.infer<typeof EmptyRpcParamsSchema>;
+
+export const MAX_TRANSCRIPT_PAGE_TURNS = 50;
+export const MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES = 266_240;
+const TRANSCRIPT_CURSOR_LENGTH = 152;
+const TRANSCRIPT_CURSOR_PATTERN = /^[A-Za-z0-9_-]{152}$/;
+const BASE64URL_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+const RPC_TEXT_ENCODER = new TextEncoder();
+
+function decodedBase64Url(value: string): Uint8Array | null {
+  let accumulator = 0;
+  let bits = 0;
+  const decoded: number[] = [];
+  for (const character of value) {
+    const digit = BASE64URL_ALPHABET.indexOf(character);
+    if (digit < 0) return null;
+    accumulator = (accumulator << 6) | digit;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      decoded.push((accumulator >> bits) & 0xff);
+      accumulator &= (1 << bits) - 1;
+    }
+  }
+  return bits === 0 ? Uint8Array.from(decoded) : null;
+}
+
+function safeCursorOffset(bytes: Uint8Array, offset: number): number | null {
+  let value = 0;
+  for (let index = offset; index < offset + 8; index += 1) {
+    value = value * 256 + bytes[index]!;
+    if (!Number.isSafeInteger(value)) return null;
+  }
+  return value;
+}
+
+function validTranscriptCursor(value: string): boolean {
+  if (value.length !== TRANSCRIPT_CURSOR_LENGTH || !TRANSCRIPT_CURSOR_PATTERN.test(value)) {
+    return false;
+  }
+  const bytes = decodedBase64Url(value);
+  if (bytes === null || bytes.length !== 114 || bytes[0] !== 1) return false;
+  const fenceKind = bytes[1];
+  if (fenceKind !== 0 && fenceKind !== 1) return false;
+  if (fenceKind === 0 && bytes.slice(34, 66).some((byte) => byte !== 0)) return false;
+  const snapshotEnd = safeCursorOffset(bytes, 98);
+  const before = safeCursorOffset(bytes, 106);
+  return snapshotEnd !== null && before !== null && before <= snapshotEnd;
+}
+
+export const TranscriptCursorSchema = z
+  .string()
+  .length(TRANSCRIPT_CURSOR_LENGTH)
+  .regex(TRANSCRIPT_CURSOR_PATTERN)
+  .refine(validTranscriptCursor);
+export type TranscriptCursor = z.infer<typeof TranscriptCursorSchema>;
+
+export const GetTranscriptPageRpcParamsSchema = z
+  .object({
+    cursor: TranscriptCursorSchema.nullable(),
+    limit: z.number().int().min(1).max(MAX_TRANSCRIPT_PAGE_TURNS),
+  })
+  .strict();
+export type GetTranscriptPageRpcParams = z.infer<typeof GetTranscriptPageRpcParamsSchema>;
+
+function canonicalTranscriptTimestamp(value: string): boolean {
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}
+
+export const TranscriptPageTurnSchema = z
+  .object({
+    turnId: z.string().min(1),
+    completedAt: z.string().refine(canonicalTranscriptTimestamp),
+    athleteText: z.string(),
+    coachText: z.string(),
+  })
+  .strict();
+export type TranscriptPageTurn = z.infer<typeof TranscriptPageTurnSchema>;
+
+const TranscriptPageResultSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    status: z.literal("page"),
+    turns: z.array(TranscriptPageTurnSchema).max(MAX_TRANSCRIPT_PAGE_TURNS),
+    nextCursor: TranscriptCursorSchema.nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.turns.length === 0 && value.nextCursor !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["nextCursor"],
+        message: "empty transcript page cannot continue",
+      });
+    }
+  });
+
+const TranscriptRestartRequiredResultSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    status: z.literal("restart-required"),
+    turns: z.array(TranscriptPageTurnSchema).length(0),
+    nextCursor: z.null(),
+  })
+  .strict();
+
+export const GetTranscriptPageRpcResultSchema = z
+  .discriminatedUnion("status", [TranscriptPageResultSchema, TranscriptRestartRequiredResultSchema])
+  .superRefine((value, context) => {
+    if (
+      RPC_TEXT_ENCODER.encode(JSON.stringify(value)).byteLength > MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES
+    ) {
+      context.addIssue({ code: "custom", message: "transcript page exceeds response budget" });
+    }
+  });
+export type GetTranscriptPageRpcResult = z.infer<typeof GetTranscriptPageRpcResultSchema>;
 
 export const AbsoluteImportPathSchema = z
   .string()
@@ -533,6 +653,7 @@ export interface CoachOperations {
     onEvent?: (event: OperationProgressEvent) => void,
   ): Promise<SyncRpcResult>;
   saveIntake(request: SaveIntakeRpcParams): Promise<SaveIntakeRpcResult>;
+  getTranscriptPage(request: GetTranscriptPageRpcParams): Promise<GetTranscriptPageRpcResult>;
   configureRuntime(request: ConfigureRuntimeRpcParams): Promise<ConfigureRuntimeRpcResult>;
   getRuntimeConfig(request: GetRuntimeConfigRpcParams): Promise<GetRuntimeConfigRpcResult>;
   getUnitsPreference?(request: GetUnitsPreferenceRpcParams): Promise<GetUnitsPreferenceRpcResult>;
@@ -571,6 +692,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("hasSession"),
       params: HasSessionRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("getTranscriptPage"),
+      params: GetTranscriptPageRpcParamsSchema,
     })
     .strict(),
   z
@@ -762,6 +891,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "hasSession",
     requestSchema: HasSessionRequestSchema,
     responseSchema: HasSessionResponseSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  getTranscriptPage: {
+    wireName: "getTranscriptPage",
+    requestSchema: GetTranscriptPageRpcParamsSchema,
+    responseSchema: GetTranscriptPageRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
   getAthleteState: {

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 9;
+export const PROTOCOL_VERSION = 10;

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -84,8 +84,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 9", () => {
-    expect(PROTOCOL_VERSION).toBe(9);
+  it("is 10", () => {
+    expect(PROTOCOL_VERSION).toBe(10);
   });
 });
 

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -19,6 +19,8 @@ import {
   ConfigureRuntimeRpcResultSchema,
   GetRuntimeConfigRpcParamsSchema,
   GetRuntimeConfigRpcResultSchema,
+  GetTranscriptPageRpcParamsSchema,
+  GetTranscriptPageRpcResultSchema,
   GetUnitsPreferenceRpcParamsSchema,
   GetUnitsPreferenceRpcResultSchema,
   ImportFilesRpcParamsSchema,
@@ -86,6 +88,12 @@ const progressNotification = {
     event: { phase: "started", completed: 0, total: 1 },
   },
 } as const;
+
+function transcriptCursor(): string {
+  const bytes = Buffer.alloc(114);
+  bytes[0] = 1;
+  return bytes.toString("base64url");
+}
 
 function roundTrip(value: unknown): CoachRpcEnvelope {
   const serialized = serializeCoachRpcEnvelope(value);
@@ -185,7 +193,7 @@ const spendSummary = SpendSummarySchema.parse({
 });
 
 describe("coach request and event projection", () => {
-  it("admits exactly the fourteen strict method requests", () => {
+  it("admits exactly the fifteen strict method requests", () => {
     const requests = [
       { jsonrpc: "2.0", id: 1, method: "chat", params: { chatId: "chat-1", message: "hello" } },
       { jsonrpc: "2.0", id: 2, method: "resetSession", params: { chatId: "chat-1" } },
@@ -228,6 +236,12 @@ describe("coach request and event projection", () => {
         params: { dailyCapUsd: 0.75 },
       },
       { jsonrpc: "2.0", id: 14, method: "selfTest", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 15,
+        method: "getTranscriptPage",
+        params: { cursor: null, limit: 25 },
+      },
     ];
     for (const request of requests) {
       expect(CoachRpcRequestEnvelopeSchema.parse(request)).toEqual(request);
@@ -253,6 +267,54 @@ describe("coach request and event projection", () => {
         params: {},
       }).success,
     ).toBe(false);
+  });
+
+  it("enforces the exact bounded transcript page wire shape", () => {
+    const cursor = transcriptCursor();
+    expect(GetTranscriptPageRpcParamsSchema.parse({ cursor, limit: 50 })).toEqual({
+      cursor,
+      limit: 50,
+    });
+    expect(
+      GetTranscriptPageRpcResultSchema.parse({
+        schemaVersion: 1,
+        status: "page",
+        turns: [
+          {
+            turnId: "turn-1",
+            completedAt: "1998-07-06T00:00:00.000Z",
+            athleteText: "a",
+            coachText: "b",
+          },
+        ],
+        nextCursor: cursor,
+      }),
+    ).toMatchObject({ status: "page", nextCursor: cursor });
+    for (const request of [
+      { cursor: null, limit: 0 },
+      { cursor: null, limit: 51 },
+      { cursor: "a".repeat(152), limit: 25 },
+      { cursor: null, limit: 25, chatId: "other" },
+    ]) {
+      expect(GetTranscriptPageRpcParamsSchema.safeParse(request).success).toBe(false);
+    }
+    for (const result of [
+      {
+        schemaVersion: 1,
+        status: "restart-required",
+        turns: [],
+        nextCursor: cursor,
+      },
+      {
+        schemaVersion: 1,
+        status: "page",
+        turns: [],
+        nextCursor: null,
+        path: "/synthetic/private/transcript",
+      },
+    ]) {
+      expect(GetTranscriptPageRpcResultSchema.safeParse(result).success).toBe(false);
+    }
   });
 
   it("rejects every nested non-JSON resolvedCs value at every wire boundary", () => {
@@ -624,6 +686,12 @@ describe("coach request and event projection", () => {
       chat: async () => ({ text: "ok" }),
       resetSession: async () => ({ memoryFlushed: true }),
       hasSession: async () => ({ hasSession: false }),
+      getTranscriptPage: async () => ({
+        schemaVersion: 1,
+        status: "page",
+        turns: [],
+        nextCursor: null,
+      }),
       getAthleteState: async () =>
         AthleteStateSchema.parse({
           schemaVersion: "1",
@@ -719,6 +787,12 @@ describe("coach request and event projection", () => {
       responseSchema: HasSessionResponseSchema,
       eventSchema: NoRpcEventSchema,
     });
+    expect(COACH_RPC_METHOD_REGISTRY.getTranscriptPage).toEqual({
+      wireName: "getTranscriptPage",
+      requestSchema: GetTranscriptPageRpcParamsSchema,
+      responseSchema: GetTranscriptPageRpcResultSchema,
+      eventSchema: NoRpcEventSchema,
+    });
     expect(COACH_RPC_METHOD_REGISTRY.getAthleteState).toEqual({
       wireName: "getAthleteState",
       requestSchema: EmptyRpcParamsSchema,
@@ -788,6 +862,7 @@ describe("coach request and event projection", () => {
     for (const method of [
       "resetSession",
       "hasSession",
+      "getTranscriptPage",
       "getAthleteState",
       "saveIntake",
       "configureRuntime",
@@ -1011,7 +1086,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version nine", () => {
-    expect(PROTOCOL_VERSION).toBe(9);
+  it("uses protocol version ten", () => {
+    expect(PROTOCOL_VERSION).toBe(10);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -59,6 +59,8 @@ import {
   type CoachOperations,
   type ConfigureRuntimeRpcParams,
   type ConfigureRuntimeRpcRefusalReason,
+  type GetTranscriptPageRpcParams,
+  type GetTranscriptPageRpcResult,
   type GetRuntimeConfigRpcResult,
 } from "@enduragent/coach-contract";
 import { cyclingSport } from "@enduragent/sport-cycling";
@@ -378,6 +380,9 @@ interface RuntimeBundle {
 function createReconfigurableRuntimeBundle(initial: RuntimeBundle): {
   readonly engine: CoachEngine;
   readonly spendMeter: SpendMeterService;
+  readonly getTranscriptPage: (
+    request: GetTranscriptPageRpcParams,
+  ) => Promise<GetTranscriptPageRpcResult>;
   replace(create: () => RuntimeBundle | Promise<RuntimeBundle>): Promise<void>;
 } {
   let active = initial;
@@ -412,6 +417,8 @@ function createReconfigurableRuntimeBundle(initial: RuntimeBundle): {
       setDailySpendCap: (dailyCapUsd) =>
         run((bundle) => bundle.spendMeter.setDailySpendCap(dailyCapUsd)),
     },
+    getTranscriptPage: (request) =>
+      run(async (bundle) => bundle.chatStore.readCurrentConversationPage("desktop", request)),
     async replace(create) {
       const previousAdmission = admission;
       let release!: () => void;
@@ -894,6 +901,7 @@ export async function createLocalCoachComposition(
         runtime,
         intervalsCredentials: options.liveIntervals,
         historyNewestDate: () => new Date(now()).toISOString().slice(0, 10),
+        readTranscriptPage: (request) => reconfigurable.getTranscriptPage(request),
         applyRuntimeConfig,
         readRuntimeConfig: () =>
           runtimeConfigSnapshot(input.home.configDir, activeConfig, input.env, activeTimezone),

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -628,6 +628,16 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               invocationFailure = { error };
             }
             break;
+          case "getTranscriptPage":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.getTranscriptPage.requestSchema.parse(
+                generic.data.params,
+              );
+              result = await input.operations.getTranscriptPage(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
           case "getAthleteState":
             try {
               COACH_RPC_METHOD_REGISTRY.getAthleteState.requestSchema.parse(generic.data.params);

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -3,6 +3,8 @@ import {
   ConfigureRuntimeRpcResultSchema,
   GetRuntimeConfigRpcParamsSchema,
   GetRuntimeConfigRpcResultSchema,
+  GetTranscriptPageRpcParamsSchema,
+  GetTranscriptPageRpcResultSchema,
   GetUnitsPreferenceRpcParamsSchema,
   GetUnitsPreferenceRpcResultSchema,
   ImportFilesRpcParamsSchema,
@@ -19,6 +21,8 @@ import {
   type ConfigureRuntimeRpcResult,
   type GetRuntimeConfigRpcParams,
   type GetRuntimeConfigRpcResult,
+  type GetTranscriptPageRpcParams,
+  type GetTranscriptPageRpcResult,
   type GetUnitsPreferenceRpcParams,
   type GetUnitsPreferenceRpcResult,
   type CoachOperations,
@@ -53,6 +57,9 @@ export interface CreateCoachOperationsInput {
     read(): Promise<Readonly<{ apiKey: string; athleteId: string }>>;
   }>;
   readonly historyNewestDate: () => string;
+  readonly readTranscriptPage?: (
+    request: GetTranscriptPageRpcParams,
+  ) => Promise<GetTranscriptPageRpcResult>;
   readonly applyRuntimeConfig: (
     request: ConfigureRuntimeRpcParams,
     signal: AbortSignal,
@@ -226,6 +233,15 @@ export function createCoachOperations(
         });
         return SaveIntakeRpcResultSchema.parse({ schemaVersion: 1, saved: true });
       });
+    },
+    getTranscriptPage(request: GetTranscriptPageRpcParams): Promise<GetTranscriptPageRpcResult> {
+      const parsedRequest = GetTranscriptPageRpcParamsSchema.parse(request);
+      if (input.readTranscriptPage === undefined) {
+        throw new TypeError("Transcript page read is unavailable.");
+      }
+      return input
+        .readTranscriptPage(parsedRequest)
+        .then((result) => GetTranscriptPageRpcResultSchema.parse(result));
     },
     configureRuntime(request: ConfigureRuntimeRpcParams): Promise<ConfigureRuntimeRpcResult> {
       const parsedRequest = ConfigureRuntimeRpcParamsSchema.parse(request);

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -46,6 +46,12 @@ const operations: CoachOperations = {
     requests: { store: 1, reference: 1, total: 2 },
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+  getTranscriptPage: async () => ({
+    schemaVersion: 1,
+    status: "page",
+    turns: [],
+    nextCursor: null,
+  }),
   configureRuntime: async ({ llm, intervals, session }) => ({
     schemaVersion: 3,
     status: "applied",

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -481,6 +481,27 @@ describe("local coach composition", () => {
       timezone: "UTC",
       dailyCapUsd: 0.5,
     });
+    received!.ports.transcriptWriter.appendCompletedTurn({
+      chatId: "other",
+      turnId: "other-turn",
+      completedAt: "1998-07-06T00:00:00.000Z",
+      athleteText: "a",
+      coachText: "b",
+    });
+    received!.ports.transcriptWriter.appendCompletedTurn({
+      chatId: "desktop",
+      turnId: "desktop-turn",
+      completedAt: "1998-07-06T00:00:01.000Z",
+      athleteText: "c",
+      coachText: "d",
+    });
+    await expect(
+      lifecycle.operations.getTranscriptPage({ cursor: null, limit: 25 }),
+    ).resolves.toMatchObject({
+      status: "page",
+      turns: [{ turnId: "desktop-turn" }],
+      nextCursor: null,
+    });
     await lifecycle.close();
   });
 

--- a/packages/coach/tests/daemon-handshake.test.ts
+++ b/packages/coach/tests/daemon-handshake.test.ts
@@ -167,6 +167,12 @@ describe.skipIf(!hasLoopback)("production peer observations", () => {
           requests: { store: 0, reference: 0, total: 0 },
         }),
         saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+        getTranscriptPage: async () => ({
+          schemaVersion: 1,
+          status: "page",
+          turns: [],
+          nextCursor: null,
+        }),
         configureRuntime: async ({ llm, intervals, session }) => ({
           schemaVersion: 3,
           status: "applied",

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -74,6 +74,12 @@ const operations: CoachOperations = {
     requests: { store: 1, reference: 1, total: 2 },
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+  getTranscriptPage: async () => ({
+    schemaVersion: 1,
+    status: "page",
+    turns: [],
+    nextCursor: null,
+  }),
   configureRuntime: async ({ llm, intervals, session }) => ({
     schemaVersion: 3,
     status: "applied",
@@ -685,6 +691,70 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       id: "units-invalid",
       error: { code: -32602, message: "Invalid params" },
     });
+    await client.close();
+  });
+
+  it("dispatches bounded transcript reads and refuses malformed hydration requests", async () => {
+    const token = "x".repeat(43);
+    const getTranscriptPage = vi.fn(async () => ({
+      schemaVersion: 1 as const,
+      status: "page" as const,
+      turns: [
+        {
+          turnId: "turn-1",
+          completedAt: "1998-07-06T00:00:00.000Z",
+          athleteText: "a",
+          coachText: "b",
+        },
+      ],
+      nextCursor: null,
+    }));
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: { ...operations, getTranscriptPage },
+      token,
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "transcript-page",
+        method: "getTranscriptPage",
+        params: { cursor: null, limit: 25 },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "transcript-page",
+      result: await getTranscriptPage.mock.results[0]!.value,
+    });
+    expect(getTranscriptPage).toHaveBeenCalledWith({ cursor: null, limit: 25 });
+
+    for (const [index, params] of [
+      {},
+      { cursor: null, limit: 0 },
+      { cursor: null, limit: 51 },
+      { cursor: "a".repeat(152), limit: 25 },
+      { cursor: null, limit: 25, chatId: "other" },
+    ].entries()) {
+      client.ws.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: `transcript-invalid-${index}`,
+          method: "getTranscriptPage",
+          params,
+        }),
+      );
+      expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+        jsonrpc: "2.0",
+        id: `transcript-invalid-${index}`,
+        error: { code: -32602, message: "Invalid params" },
+      });
+    }
+    expect(getTranscriptPage).toHaveBeenCalledTimes(1);
     await client.close();
   });
 

--- a/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
+++ b/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
@@ -165,6 +165,12 @@ async function startRpc(coachEngine: CoachEngine): Promise<RunningRpc> {
         requests: { store: 0, reference: 0, total: 0 },
       }),
       saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+      getTranscriptPage: async () => ({
+        schemaVersion: 1,
+        status: "page",
+        turns: [],
+        nextCursor: null,
+      }),
       configureRuntime: async ({ llm, intervals, session }) => ({
         schemaVersion: 3,
         status: "applied",

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -76,6 +76,12 @@ const operations: CoachOperations = {
     requests: { store: 0, reference: 0, total: 0 },
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+  getTranscriptPage: async () => ({
+    schemaVersion: 1,
+    status: "page",
+    turns: [],
+    nextCursor: null,
+  }),
   configureRuntime: async ({ llm, intervals, session }) => ({
     schemaVersion: 3,
     status: "applied",

--- a/packages/coach/tests/enduragent-redaction.test.ts
+++ b/packages/coach/tests/enduragent-redaction.test.ts
@@ -158,6 +158,12 @@ describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
               requests: { store: 0, reference: 0, total: 0 },
             }),
             saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+            getTranscriptPage: async () => ({
+              schemaVersion: 1,
+              status: "page",
+              turns: [],
+              nextCursor: null,
+            }),
             configureRuntime: async ({ llm, intervals, session }) => ({
               schemaVersion: 3,
               status: "applied",

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -75,6 +75,12 @@ const operations: CoachOperations = {
     requests: { store: 0, reference: 0, total: 0 },
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+  getTranscriptPage: async () => ({
+    schemaVersion: 1,
+    status: "page",
+    turns: [],
+    nextCursor: null,
+  }),
   configureRuntime: async ({ llm, intervals, session }) => ({
     schemaVersion: 3,
     status: "applied",

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -85,6 +85,34 @@ function operationRuntime(
 }
 
 describe("coach operations", () => {
+  it("validates transcript requests and responses around the read-only composition lane", async () => {
+    const readTranscriptPage = vi.fn(async () => ({
+      schemaVersion: 1 as const,
+      status: "page" as const,
+      turns: [],
+      nextCursor: null,
+    }));
+    const operations = createCoachOperations({
+      home,
+      context: context(),
+      runtime: operationRuntime(),
+      intervalsCredentials: intervalsCredentials(),
+      historyNewestDate: () => "1998-07-18",
+      readTranscriptPage,
+      applyRuntimeConfig: async () => {},
+    });
+
+    await expect(operations.getTranscriptPage({ cursor: null, limit: 25 })).resolves.toEqual({
+      schemaVersion: 1,
+      status: "page",
+      turns: [],
+      nextCursor: null,
+    });
+    expect(readTranscriptPage).toHaveBeenCalledWith({ cursor: null, limit: 25 });
+    expect(() => operations.getTranscriptPage({ cursor: null, limit: 51 } as never)).toThrow();
+    expect(readTranscriptPage).toHaveBeenCalledOnce();
+  });
+
   it("imports synthetic activity files through the live store and deduplicates reruns", async () => {
     const root = await mkdtemp(join(await realpath(tmpdir()), "coach-operations-"));
     const liveHome: AthleteHome = {

--- a/packages/coach/tests/serve.test.ts
+++ b/packages/coach/tests/serve.test.ts
@@ -72,6 +72,12 @@ const operations: CoachOperations = {
     requests: { store: 0, reference: 0, total: 0 },
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+  getTranscriptPage: async () => ({
+    schemaVersion: 1,
+    status: "page",
+    turns: [],
+    nextCursor: null,
+  }),
   configureRuntime: async ({ llm, intervals, session }) => ({
     schemaVersion: 3,
     status: "applied",

--- a/packages/core/src/agent/conversation-store.ts
+++ b/packages/core/src/agent/conversation-store.ts
@@ -13,10 +13,13 @@ import {
   TranscriptStore,
   type ResetIntentRecord,
   type TranscriptCompletedTurnRecord,
+  type TranscriptPageRequest,
+  type TranscriptPageResult,
 } from "./transcript-store.js";
 
 export interface ConversationStorePort extends ChatStorePort, TranscriptWriterPort {
   readCurrentConversation(chatId: string): TranscriptCompletedTurnRecord[];
+  readCurrentConversationPage(chatId: string, request: TranscriptPageRequest): TranscriptPageResult;
 }
 
 export function createConversationStore(
@@ -97,6 +100,10 @@ export class ConversationStore implements ConversationStorePort {
   readCurrentConversation(chatId: string) {
     this.recoverBeforeAccess(chatId);
     return this.transcriptStore.readCurrentConversation(chatId);
+  }
+
+  readCurrentConversationPage(chatId: string, request: TranscriptPageRequest) {
+    return this.transcriptStore.readCurrentConversationPage(chatId, request);
   }
 
   resetConversation(input: ConversationResetInput): void {

--- a/packages/core/src/agent/transcript-store.ts
+++ b/packages/core/src/agent/transcript-store.ts
@@ -28,10 +28,16 @@ import type {
 const TRANSCRIPT_SCHEMA_VERSION = 1 as const;
 const RESET_INTENT_SCHEMA_VERSION = 1 as const;
 export const MAX_TRANSCRIPT_RECORD_BYTES = 262_144;
+export const MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES = MAX_TRANSCRIPT_RECORD_BYTES + 4_096;
+export const MAX_TRANSCRIPT_PAGE_TURNS = 50;
 const STRICT_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 const RESET_ID_PATTERN = /^[a-f0-9]{64}$/;
 const INTENT_TARGET_PATTERN = /^([a-f0-9]{64})\.reset-intent\.json$/;
 const INTENT_TEMP_PATTERN = /^([a-f0-9]{64})\.([a-f0-9]{64})\.reset-intent\.tmp$/;
+const TRANSCRIPT_CURSOR_BYTES = 114;
+const TRANSCRIPT_CURSOR_LENGTH = 152;
+const TRANSCRIPT_CURSOR_PATTERN = /^[A-Za-z0-9_-]{152}$/;
+const TRANSCRIPT_CURSOR_VERSION = 1;
 
 type TranscriptWrite = (
   descriptor: number,
@@ -88,6 +94,54 @@ export interface ResetIntentRecord extends ConversationResetInput {
 }
 
 export type TranscriptRecord = TranscriptCompletedTurnRecord | TranscriptConversationBoundaryRecord;
+
+export interface TranscriptPageTurn {
+  readonly turnId: string;
+  readonly completedAt: string;
+  readonly athleteText: string;
+  readonly coachText: string;
+}
+
+export interface TranscriptPageRequest {
+  readonly cursor: string | null;
+  readonly limit: number;
+}
+
+export type TranscriptPageResult =
+  | {
+      readonly schemaVersion: 1;
+      readonly status: "page";
+      readonly turns: TranscriptPageTurn[];
+      readonly nextCursor: string | null;
+    }
+  | {
+      readonly schemaVersion: 1;
+      readonly status: "restart-required";
+      readonly turns: [];
+      readonly nextCursor: null;
+    };
+
+interface IndexedTranscriptTurn {
+  readonly record: TranscriptCompletedTurnRecord;
+  readonly start: number;
+  readonly end: number;
+}
+
+interface CurrentTranscriptWindow {
+  readonly trusted: boolean;
+  readonly fenceKind: 0 | 1;
+  readonly fence: Buffer;
+  readonly turns: readonly IndexedTranscriptTurn[];
+}
+
+interface DecodedTranscriptCursor {
+  readonly fenceKind: 0 | 1;
+  readonly chatDigest: Buffer;
+  readonly fence: Buffer;
+  readonly snapshotHash: Buffer;
+  readonly snapshotEnd: number;
+  readonly before: number;
+}
 
 export class UnsafeTranscriptTargetError extends Error {
   readonly code = "TRANSCRIPT_UNSAFE_TARGET";
@@ -316,6 +370,119 @@ function serializeTranscriptRecord(record: TranscriptRecord): Buffer {
   return bytes;
 }
 
+function parseCurrentWindow(contents: Buffer, chatId: string): CurrentTranscriptWindow {
+  let trusted = true;
+  let fenceKind: 0 | 1 = 0;
+  let fence = Buffer.alloc(32);
+  let turns: IndexedTranscriptTurn[] = [];
+  let lineStart = 0;
+  for (let index = 0; index < contents.length; index += 1) {
+    if (contents[index] !== 0x0a) continue;
+    const lineBytes = contents.subarray(lineStart, index);
+    const recordStart = lineStart;
+    lineStart = index + 1;
+    const record = lineBytes.length === 0 ? null : parseRecordBytes(lineBytes);
+    if (record === null || record.chatId !== chatId) {
+      trusted = false;
+      turns = [];
+      continue;
+    }
+    if (record.kind === "conversation-boundary") {
+      trusted = true;
+      fenceKind = 1;
+      fence = Buffer.from(record.resetId, "hex");
+      turns = [];
+    } else if (trusted) {
+      turns.push({ record, start: recordStart, end: lineStart });
+    }
+  }
+  if (lineStart !== contents.length) {
+    trusted = false;
+    turns = [];
+  }
+  return { trusted, fenceKind, fence, turns };
+}
+
+function decodeSafeOffset(bytes: Buffer, offset: number): number | null {
+  const value = bytes.readBigUInt64BE(offset);
+  return value <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(value) : null;
+}
+
+function decodeTranscriptCursor(value: string): DecodedTranscriptCursor | null {
+  if (!TRANSCRIPT_CURSOR_PATTERN.test(value) || value.length !== TRANSCRIPT_CURSOR_LENGTH) {
+    return null;
+  }
+  const bytes = Buffer.from(value, "base64url");
+  if (
+    bytes.length !== TRANSCRIPT_CURSOR_BYTES ||
+    bytes.toString("base64url") !== value ||
+    bytes[0] !== TRANSCRIPT_CURSOR_VERSION ||
+    (bytes[1] !== 0 && bytes[1] !== 1)
+  ) {
+    return null;
+  }
+  const fenceKind = bytes[1] as 0 | 1;
+  const fence = Buffer.from(bytes.subarray(34, 66));
+  if (fenceKind === 0 && fence.some((byte) => byte !== 0)) return null;
+  const snapshotEnd = decodeSafeOffset(bytes, 98);
+  const before = decodeSafeOffset(bytes, 106);
+  if (snapshotEnd === null || before === null || before > snapshotEnd) return null;
+  return {
+    fenceKind,
+    chatDigest: Buffer.from(bytes.subarray(2, 34)),
+    fence,
+    snapshotHash: Buffer.from(bytes.subarray(66, 98)),
+    snapshotEnd,
+    before,
+  };
+}
+
+function encodeTranscriptCursor(input: DecodedTranscriptCursor): string {
+  const bytes = Buffer.alloc(TRANSCRIPT_CURSOR_BYTES);
+  bytes[0] = TRANSCRIPT_CURSOR_VERSION;
+  bytes[1] = input.fenceKind;
+  input.chatDigest.copy(bytes, 2);
+  input.fence.copy(bytes, 34);
+  input.snapshotHash.copy(bytes, 66);
+  bytes.writeBigUInt64BE(BigInt(input.snapshotEnd), 98);
+  bytes.writeBigUInt64BE(BigInt(input.before), 106);
+  return bytes.toString("base64url");
+}
+
+function transcriptPageTurn(record: TranscriptCompletedTurnRecord): TranscriptPageTurn {
+  return {
+    turnId: record.turnId,
+    completedAt: record.completedAt,
+    athleteText: record.athleteText,
+    coachText: record.coachText,
+  };
+}
+
+function restartRequiredPage(): TranscriptPageResult {
+  return {
+    schemaVersion: 1,
+    status: "restart-required",
+    turns: [],
+    nextCursor: null,
+  };
+}
+
+function pageResult(
+  turns: readonly IndexedTranscriptTurn[],
+  nextCursor: string | null,
+): TranscriptPageResult {
+  return {
+    schemaVersion: 1,
+    status: "page",
+    turns: turns.map(({ record }) => transcriptPageTurn(record)),
+    nextCursor,
+  };
+}
+
+function encodedPageBytes(result: TranscriptPageResult): number {
+  return Buffer.byteLength(JSON.stringify(result), "utf8");
+}
+
 export class TranscriptStore implements TranscriptWriterPort {
   private readonly transcriptsDir: string;
   private readonly directoryIdentity: FileIdentity;
@@ -377,31 +544,134 @@ export class TranscriptStore implements TranscriptWriterPort {
       const descriptor = this.openExistingFile(directoryDescriptor, path, constants.O_RDONLY, true);
       if (descriptor === null) return [];
       try {
-        const contents = readFileSync(descriptor);
-        let trusted = true;
-        let current: TranscriptCompletedTurnRecord[] = [];
-        let lineStart = 0;
-        for (let index = 0; index < contents.length; index += 1) {
-          if (contents[index] !== 0x0a) continue;
-          const lineBytes = contents.subarray(lineStart, index);
-          lineStart = index + 1;
-          const record = lineBytes.length === 0 ? null : parseRecordBytes(lineBytes);
-          if (record === null || record.chatId !== chatId) {
-            trusted = false;
-            current = [];
-            continue;
-          }
-          if (record.kind === "conversation-boundary") {
-            trusted = true;
-            current = [];
-          } else if (trusted) {
-            current.push(record);
-          }
-        }
-        if (lineStart !== contents.length) current = [];
+        const contents = this.readSnapshot(descriptor);
+        const window = parseCurrentWindow(contents, chatId);
         this.assertOpenedFileSafe(descriptor);
         this.assertDirectoryStable(directoryDescriptor);
-        return current;
+        return window.trusted ? window.turns.map(({ record }) => record) : [];
+      } finally {
+        closeSync(descriptor);
+      }
+    });
+  }
+
+  readCurrentConversationPage(
+    chatId: string,
+    request: TranscriptPageRequest,
+  ): TranscriptPageResult {
+    if (
+      typeof chatId !== "string" ||
+      request === null ||
+      typeof request !== "object" ||
+      Array.isArray(request) ||
+      Object.keys(request).length !== 2 ||
+      !Object.hasOwn(request, "cursor") ||
+      !Object.hasOwn(request, "limit") ||
+      (request.cursor !== null && decodeTranscriptCursor(request.cursor) === null) ||
+      !Number.isSafeInteger(request.limit) ||
+      request.limit < 1 ||
+      request.limit > MAX_TRANSCRIPT_PAGE_TURNS
+    ) {
+      throw new TypeError("Transcript page request is invalid.");
+    }
+    return this.withDirectory((directoryDescriptor) => {
+      const path = this.transcriptPath(chatId);
+      const descriptor = this.openExistingFile(directoryDescriptor, path, constants.O_RDONLY, true);
+      if (descriptor === null) {
+        return request.cursor === null ? pageResult([], null) : restartRequiredPage();
+      }
+      try {
+        const contents = this.readSnapshot(descriptor);
+        const current = parseCurrentWindow(contents, chatId);
+        const chatDigest = Buffer.from(this.chatDigest(chatId), "hex");
+        let snapshot = contents;
+        let snapshotWindow = current;
+        let cursor: DecodedTranscriptCursor;
+        if (request.cursor === null) {
+          if (!current.trusted) {
+            this.assertOpenedFileSafe(descriptor);
+            this.assertDirectoryStable(directoryDescriptor);
+            return pageResult([], null);
+          }
+          cursor = {
+            fenceKind: current.fenceKind,
+            chatDigest,
+            fence: current.fence,
+            snapshotHash: createHash("sha256").update(contents).digest(),
+            snapshotEnd: contents.length,
+            before: contents.length,
+          };
+        } else {
+          const decoded = decodeTranscriptCursor(request.cursor);
+          if (decoded === null || !decoded.chatDigest.equals(chatDigest)) {
+            throw new TypeError("Transcript page cursor is invalid.");
+          }
+          if (
+            !current.trusted ||
+            current.fenceKind !== decoded.fenceKind ||
+            !current.fence.equals(decoded.fence)
+          ) {
+            this.assertOpenedFileSafe(descriptor);
+            this.assertDirectoryStable(directoryDescriptor);
+            return restartRequiredPage();
+          }
+          if (decoded.snapshotEnd > contents.length) {
+            throw new TypeError("Transcript page cursor is invalid.");
+          }
+          snapshot = contents.subarray(0, decoded.snapshotEnd);
+          if (!createHash("sha256").update(snapshot).digest().equals(decoded.snapshotHash)) {
+            throw new TypeError("Transcript page cursor is invalid.");
+          }
+          snapshotWindow = parseCurrentWindow(snapshot, chatId);
+          if (
+            !snapshotWindow.trusted ||
+            snapshotWindow.fenceKind !== decoded.fenceKind ||
+            !snapshotWindow.fence.equals(decoded.fence)
+          ) {
+            throw new TypeError("Transcript page cursor is invalid.");
+          }
+          cursor = decoded;
+        }
+        const beforeIsValid =
+          cursor.before === cursor.snapshotEnd ||
+          snapshotWindow.turns.some((turn) => turn.start === cursor.before);
+        if (!beforeIsValid) throw new TypeError("Transcript page cursor is invalid.");
+        let index = snapshotWindow.turns.length - 1;
+        while (index >= 0 && snapshotWindow.turns[index]!.end > cursor.before) index -= 1;
+        let selected: readonly IndexedTranscriptTurn[] = [];
+        while (index >= 0 && selected.length < request.limit) {
+          const tentative = [snapshotWindow.turns[index]!, ...selected];
+          const hasMore = index > 0;
+          const nextCursor = hasMore
+            ? encodeTranscriptCursor({
+                ...cursor,
+                before: tentative[0]!.start,
+              })
+            : null;
+          const tentativeResult = pageResult(tentative, nextCursor);
+          if (encodedPageBytes(tentativeResult) > MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES) {
+            if (selected.length === 0) {
+              throw new Error("Transcript page record exceeds the response budget.");
+            }
+            break;
+          }
+          selected = tentative;
+          index -= 1;
+        }
+        const nextCursor =
+          index >= 0
+            ? encodeTranscriptCursor({
+                ...cursor,
+                before: selected[0]!.start,
+              })
+            : null;
+        const result = pageResult(selected, nextCursor);
+        if (encodedPageBytes(result) > MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES) {
+          throw new Error("Transcript page exceeds the response budget.");
+        }
+        this.assertOpenedFileSafe(descriptor);
+        this.assertDirectoryStable(directoryDescriptor);
+        return result;
       } finally {
         closeSync(descriptor);
       }
@@ -627,6 +897,19 @@ export class TranscriptStore implements TranscriptWriterPort {
         closeSync(descriptor);
       }
     });
+  }
+
+  private readSnapshot(descriptor: number): Buffer {
+    const size = fstatSync(descriptor).size;
+    if (!Number.isSafeInteger(size) || size < 0) throw new UnsafeTranscriptTargetError();
+    const contents = Buffer.allocUnsafe(size);
+    let offset = 0;
+    while (offset < size) {
+      const bytesRead = readSync(descriptor, contents, offset, size - offset, offset);
+      if (bytesRead <= 0) throw new Error("Transcript snapshot could not be read.");
+      offset += bytesRead;
+    }
+    return contents;
   }
 
   private openForAppend(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,8 +120,15 @@ export {
   type ConversationStorePort,
 } from "./agent/conversation-store.js";
 export {
+  MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES,
+  MAX_TRANSCRIPT_PAGE_TURNS,
   MAX_TRANSCRIPT_RECORD_BYTES,
   UnsafeTranscriptTargetError,
+} from "./agent/transcript-store.js";
+export type {
+  TranscriptPageRequest,
+  TranscriptPageResult,
+  TranscriptPageTurn,
 } from "./agent/transcript-store.js";
 export { engineConfigFromConfig } from "./agent/engine-host-adapter.js";
 export { classifyFailure, extractRetryAfterMs } from "./agent/token-utils.js";

--- a/packages/core/tests/conversation-store.test.ts
+++ b/packages/core/tests/conversation-store.test.ts
@@ -106,6 +106,72 @@ afterEach(() => {
 });
 
 describe("ConversationStore reset transaction recovery", () => {
+  it("keeps transcript pagination read-only when a reset intent is pending", () => {
+    const dataDir = makeDataDir();
+    const chatId = "read-only-page";
+    const chat = new ChatStore(dataDir);
+    const transcript = new TranscriptStore(dataDir);
+    const store = new ConversationStore(chat, transcript);
+    store.appendCompletedTurn({
+      chatId,
+      turnId: "turn-1",
+      completedAt: "2026-07-22T00:00:00.000Z",
+      athleteText: "a",
+      coachText: "b",
+    });
+    const pending = resetIntent(chatId);
+    transcript.createResetIntent(pending);
+    const before = readFileSync(transcriptPath(dataDir, chatId));
+
+    const page = store.readCurrentConversationPage(chatId, { cursor: null, limit: 1 });
+
+    expect(page.turns.map((turn) => turn.turnId)).toEqual(["turn-1"]);
+    expect(transcript.readResetIntent(chatId)).toEqual(pending);
+    expect(readFileSync(transcriptPath(dataDir, chatId))).toEqual(before);
+    expect(boundaryCount(dataDir, chatId)).toBe(0);
+  });
+
+  it("fences a pagination cursor after the reset transaction completes", () => {
+    const dataDir = makeDataDir();
+    const chatId = "completed-reset-page";
+    const chat = new ChatStore(dataDir);
+    const transcript = new TranscriptStore(dataDir);
+    const store = new ConversationStore(chat, transcript, () => RESET_ID);
+    store.appendCompletedTurn({
+      chatId,
+      turnId: "turn-1",
+      completedAt: "2026-07-22T00:00:00.000Z",
+      athleteText: "a",
+      coachText: "b",
+    });
+    store.appendCompletedTurn({
+      chatId,
+      turnId: "turn-2",
+      completedAt: "2026-07-22T00:00:01.000Z",
+      athleteText: "c",
+      coachText: "d",
+    });
+    const page = store.readCurrentConversationPage(chatId, { cursor: null, limit: 1 });
+
+    store.resetConversation({
+      chatId,
+      boundaryAt: "2026-07-22T01:02:03.000Z",
+      reason: "explicit-reset",
+    });
+
+    expect(
+      store.readCurrentConversationPage(chatId, {
+        cursor: page.nextCursor,
+        limit: 1,
+      }),
+    ).toEqual({
+      schemaVersion: 1,
+      status: "restart-required",
+      turns: [],
+      nextCursor: null,
+    });
+  });
+
   it("recovers intent-only by ensuring one boundary and archiving the active session", () => {
     const dataDir = makeDataDir();
     const chat = new ChatStore(dataDir);

--- a/packages/core/tests/transcript-store.test.ts
+++ b/packages/core/tests/transcript-store.test.ts
@@ -20,6 +20,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES,
+  MAX_TRANSCRIPT_PAGE_TURNS,
   MAX_TRANSCRIPT_RECORD_BYTES,
   TranscriptRecordTooLargeError,
   TranscriptStore,
@@ -176,6 +178,152 @@ describe("TranscriptStore append and corruption handling", () => {
     ]);
   });
 
+  it("walks newest pages backward within only the latest trusted conversation", () => {
+    const dataDir = makeDataDir();
+    const chatId = "paginated-boundary";
+    const store = new TranscriptStore(dataDir);
+    store.appendCompletedTurn(turn(chatId, "turn-8"));
+    store.appendCompletedTurn(turn(chatId, "turn-9"));
+    store.ensureConversationBoundary(intent(chatId));
+    for (let index = 1; index <= 5; index += 1) {
+      store.appendCompletedTurn(turn(chatId, `turn-${index}`));
+    }
+
+    const newest = store.readCurrentConversationPage(chatId, { cursor: null, limit: 2 });
+    expect(newest.status).toBe("page");
+    expect(newest.turns.map((record) => record.turnId)).toEqual(["turn-4", "turn-5"]);
+    expect(newest.nextCursor).not.toBeNull();
+
+    const middle = store.readCurrentConversationPage(chatId, {
+      cursor: newest.nextCursor,
+      limit: 2,
+    });
+    expect(middle.turns.map((record) => record.turnId)).toEqual(["turn-2", "turn-3"]);
+    expect(middle.nextCursor).not.toBeNull();
+
+    const oldest = store.readCurrentConversationPage(chatId, {
+      cursor: middle.nextCursor,
+      limit: 2,
+    });
+    expect(oldest.turns.map((record) => record.turnId)).toEqual(["turn-1"]);
+    expect(oldest.nextCursor).toBeNull();
+  });
+
+  it("keeps a cursor snapshot stable while completed turns append concurrently", () => {
+    const dataDir = makeDataDir();
+    const chatId = "append-stability";
+    const store = new TranscriptStore(dataDir);
+    for (let index = 1; index <= 4; index += 1) {
+      store.appendCompletedTurn(turn(chatId, `turn-${index}`));
+    }
+
+    const newest = store.readCurrentConversationPage(chatId, { cursor: null, limit: 2 });
+    store.appendCompletedTurn(turn(chatId, "turn-5"));
+    const older = store.readCurrentConversationPage(chatId, {
+      cursor: newest.nextCursor,
+      limit: 2,
+    });
+    const refreshed = store.readCurrentConversationPage(chatId, { cursor: null, limit: 2 });
+
+    expect(older.turns.map((record) => record.turnId)).toEqual(["turn-1", "turn-2"]);
+    expect(older.nextCursor).toBeNull();
+    expect(refreshed.turns.map((record) => record.turnId)).toEqual(["turn-4", "turn-5"]);
+  });
+
+  it("returns a fixed restart signal when a completed boundary supersedes a cursor", () => {
+    const dataDir = makeDataDir();
+    const chatId = "reset-between-pages";
+    const store = new TranscriptStore(dataDir);
+    for (let index = 1; index <= 3; index += 1) {
+      store.appendCompletedTurn(turn(chatId, `turn-${index}`));
+    }
+    const first = store.readCurrentConversationPage(chatId, { cursor: null, limit: 1 });
+    store.ensureConversationBoundary(intent(chatId));
+    store.appendCompletedTurn(turn(chatId, "turn-4"));
+
+    expect(
+      store.readCurrentConversationPage(chatId, {
+        cursor: first.nextCursor,
+        limit: 1,
+      }),
+    ).toEqual({
+      schemaVersion: 1,
+      status: "restart-required",
+      turns: [],
+      nextCursor: null,
+    });
+  });
+
+  it("enforces turn and encoded response budgets without losing pagination progress", () => {
+    const dataDir = makeDataDir();
+    const chatId = "page-budgets";
+    const store = new TranscriptStore(dataDir);
+    for (let index = 1; index <= MAX_TRANSCRIPT_PAGE_TURNS + 5; index += 1) {
+      store.appendCompletedTurn(turn(chatId, `turn-${index}`));
+    }
+    expect(() =>
+      store.readCurrentConversationPage(chatId, {
+        cursor: null,
+        limit: MAX_TRANSCRIPT_PAGE_TURNS + 1,
+      }),
+    ).toThrow(TypeError);
+    const capped = store.readCurrentConversationPage(chatId, {
+      cursor: null,
+      limit: MAX_TRANSCRIPT_PAGE_TURNS,
+    });
+    expect(capped.turns).toHaveLength(MAX_TRANSCRIPT_PAGE_TURNS);
+    expect(capped.nextCursor).not.toBeNull();
+
+    const largeChatId = "page-byte-budget";
+    for (let index = 1; index <= 3; index += 1) {
+      store.appendCompletedTurn({
+        ...turnWithSerializedBytes(140_000, largeChatId),
+        turnId: `turn-${index}`,
+      });
+    }
+    const large = store.readCurrentConversationPage(largeChatId, {
+      cursor: null,
+      limit: MAX_TRANSCRIPT_PAGE_TURNS,
+    });
+    expect(Buffer.byteLength(JSON.stringify(large), "utf8")).toBeLessThanOrEqual(
+      MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES,
+    );
+    expect(large.turns).toHaveLength(1);
+    expect(large.nextCursor).not.toBeNull();
+    const remaining = store.readCurrentConversationPage(largeChatId, {
+      cursor: large.nextCursor,
+      limit: MAX_TRANSCRIPT_PAGE_TURNS,
+    });
+    expect(remaining.turns).toHaveLength(1);
+    expect(remaining.nextCursor).not.toBeNull();
+  });
+
+  it("applies fail-closed corruption recovery semantics to every pagination path", () => {
+    const dataDir = makeDataDir();
+    const chatId = "page-corruption";
+    const store = new TranscriptStore(dataDir);
+    const path = transcriptPath(dataDir, chatId);
+    store.appendCompletedTurn(turn(chatId, "turn-1"));
+    appendFileSync(path, Buffer.from([0xff, 0x0a]));
+    store.appendCompletedTurn(turn(chatId, "turn-2"));
+
+    expect(store.readCurrentConversationPage(chatId, { cursor: null, limit: 10 })).toEqual({
+      schemaVersion: 1,
+      status: "page",
+      turns: [],
+      nextCursor: null,
+    });
+
+    store.ensureConversationBoundary(intent(chatId));
+    store.appendCompletedTurn(turn(chatId, "turn-3"));
+    const recovered = store.readCurrentConversationPage(chatId, {
+      cursor: null,
+      limit: 10,
+    });
+    expect(recovered.turns.map((record) => record.turnId)).toEqual(["turn-3"]);
+    expect(recovered.nextCursor).toBeNull();
+  });
+
   it("accepts an exact 262,144-byte serialized Unicode and escaped record", () => {
     const dataDir = makeDataDir();
     const store = new TranscriptStore(dataDir);
@@ -188,6 +336,11 @@ describe("TranscriptStore append and corruption handling", () => {
     store.appendCompletedTurn(input);
 
     expect(readFileSync(transcriptPath(dataDir, input.chatId))).toEqual(bytes);
+    const page = store.readCurrentConversationPage(input.chatId, { cursor: null, limit: 1 });
+    expect(page.turns).toHaveLength(1);
+    expect(Buffer.byteLength(JSON.stringify(page), "utf8")).toBeLessThanOrEqual(
+      MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES,
+    );
   });
 
   it("rejects an exact 262,145-byte record before target access or mutation", () => {


### PR DESCRIPTION
## Summary

Second slice of the Desktop persistent-conversation parity work (parity issue 229): a paginated, strictly bounded, read-only transcript page RPC from the daemon through the Desktop main process to a validated preload bridge method. Renderer hydration UI follows as the final slice.

- Cursor-based pagination over the canonical desktop chat's current conversation, newest page first with stable backward cursors; cursors embed the conversation-boundary fence and a hash-pinned snapshot prefix, so they stay deterministic under concurrent appends
- Conversation-boundary fencing is absolute: any cursor spanning a completed reset returns a fixed restart-required signal, and fabricated cursors cannot reach pre-boundary turns
- Strict bounds at store, contract, and preload layers: fixed 50-turn page cap and a byte budget derived from the transcript record cap; corrupt regions fail closed to an empty page or restart signal with a single bounded read
- The read path is strictly read-only (no recovery or repair side effects) and admission uses the existing drained runtime-bundle lane, so settings or credential cutovers between pages stay safe
- Finite method-aware client deadline with the established terminal behavior; daemon, main-process IPC, and preload all validate request and response shapes independently, with fixed redacted error strings (a test proves a path-smuggling daemon response is redacted)
- PROTOCOL_VERSION bumped with coherent handshake enforcement; the packaged bridge pin gains exactly the one new preload key

## Verification

- 420 focused tests across contract wire shapes, store pagination/fencing/cursor stability/reset signal/budgets/corruption, daemon dispatch and validation refusals, main IPC, preload validation, and client deadline expiry
- Root `pnpm check` and `pnpm check:types` pass; the complete s8a replay suite passes
- Three independent read-only reviews (boundary/pagination semantics, contract/protocol security, lifecycle/deadline admission) found zero blocking issues
- Patch changeset included without a User-facing line; athlete-visible behavior arrives with the hydration slice
