### PR TITLE
feat(desktop): hydrate conversation history on restart

### DIFF
--- a/.changeset/desktop-transcript-hydration.md
+++ b/.changeset/desktop-transcript-hydration.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: The Desktop conversation now survives app restarts, with earlier messages available on demand.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -14,6 +14,14 @@ import {
   reduceChatState,
   type ChatState,
 } from "../turn-state.js";
+import {
+  createTranscriptHydrator,
+  emptyTranscriptHydration,
+  mergeHydratedMessages,
+  type TranscriptHydrationChange,
+  type TranscriptHydrationStatus,
+  type TranscriptPage,
+} from "./hydration.js";
 import { COACH_RESPONSE_CODE_UNIT_LIMIT, COACH_TURN_EVENT_LIMIT } from "./limits.js";
 
 export const CHAT_CONNECTION_INTERRUPTED_COPY =
@@ -39,6 +47,12 @@ export interface ChatViewControls {
   readonly newConversationDisabled: boolean;
   readonly workBlocked: boolean;
   readonly appendDelta?: ChatAppendDelta;
+  readonly hydration?: {
+    readonly status: TranscriptHydrationStatus;
+    readonly hasEarlier: boolean;
+    readonly revision: number;
+    readonly change: TranscriptHydrationChange;
+  };
 }
 
 export interface ChatView {
@@ -49,6 +63,8 @@ export interface ChatController {
   start(): Promise<void>;
   submit(message: string): Promise<void>;
   retryInterrupted(): Promise<void>;
+  loadEarlier(): Promise<void>;
+  retryHydration(): Promise<void>;
   openNewConversation(): boolean;
   cancelNewConversation(): void;
   confirmNewConversation(): Promise<void>;
@@ -66,10 +82,16 @@ export function createChatController(input: {
   readonly view: ChatView;
   readonly refreshTrainingContext: () => Promise<void>;
   readonly refreshSpend: () => Promise<void>;
+  readonly readTranscriptPage?: (request: {
+    readonly cursor: string | null;
+    readonly limit: number;
+  }) => Promise<TranscriptPage>;
 }): ChatController {
   let state = EMPTY_CHAT_STATE;
+  let hydration = emptyTranscriptHydration();
   let sequence = 0;
   let disposed = false;
+  let hydrationRenderSuppressed = false;
   let activeTask: Promise<void> | undefined;
   const outstandingChatTasks = new Set<Promise<void>>();
   let queuedRetry: QueuedRetry | undefined;
@@ -83,7 +105,7 @@ export function createChatController(input: {
     state.session.resetPhase === "confirming" || state.session.resetPhase === "resetting";
   const canOpenNewConversation = (): boolean =>
     !disposed &&
-    hasClearableConversation(state) &&
+    (hasClearableConversation(state) || hydration.turns.length > 0) &&
     state.session.resetPhase === "idle" &&
     state.status !== "streaming" &&
     activeTask === undefined &&
@@ -93,11 +115,22 @@ export function createChatController(input: {
   const render = (appendDelta?: ChatAppendDelta): void => {
     if (disposed) return;
     try {
-      input.view.render(state, {
-        newConversationDisabled: !canOpenNewConversation(),
-        workBlocked: resetBlocksWork(),
-        ...(appendDelta === undefined ? {} : { appendDelta }),
-      });
+      input.view.render(
+        hydration.turns.length === 0
+          ? state
+          : { ...state, messages: mergeHydratedMessages(hydration.turns, state.messages) },
+        {
+          newConversationDisabled: !canOpenNewConversation(),
+          workBlocked: resetBlocksWork(),
+          ...(appendDelta === undefined ? {} : { appendDelta }),
+          hydration: {
+            status: hydration.status,
+            hasEarlier: hydration.nextCursor !== null,
+            revision: hydration.revision,
+            change: hydration.change,
+          },
+        },
+      );
     } catch {}
   };
   const reduce = (
@@ -106,6 +139,33 @@ export function createChatController(input: {
   ): void => {
     state = reduceChatState(state, action);
     render(appendDelta);
+  };
+  const hydrator = createTranscriptHydrator({
+    readPage:
+      input.readTranscriptPage ??
+      (async () => ({
+        schemaVersion: 1,
+        status: "page",
+        turns: [],
+        nextCursor: null,
+      })),
+    onChange(next) {
+      hydration = next;
+      if (!hydrationRenderSuppressed) render();
+    },
+  });
+  const updateReset = (
+    hydrate: () => void,
+    action: Parameters<typeof reduceChatState>[1],
+  ): void => {
+    hydrationRenderSuppressed = true;
+    try {
+      hydrate();
+      state = reduceChatState(state, action);
+    } finally {
+      hydrationRenderSuppressed = false;
+    }
+    render();
   };
 
   const run = (userMessage: string, includeUser: boolean, reconnect: boolean): Promise<void> => {
@@ -302,6 +362,7 @@ export function createChatController(input: {
   render();
   return {
     start() {
+      void hydrator.start();
       if (probeTask !== undefined) return probeTask;
       const probeEpoch = epoch;
       const task = (async () => {
@@ -356,10 +417,20 @@ export function createChatController(input: {
       reduce({ type: "retry-pending", requestKey });
       return pending;
     },
+    loadEarlier() {
+      return hydrator.loadEarlier();
+    },
+    retryHydration() {
+      return hydrator.retry();
+    },
     openNewConversation() {
       if (!canOpenNewConversation()) return false;
       epoch += 1;
-      reduce({ type: "open-new-conversation" });
+      state = reduceChatState(state, {
+        type: "open-new-conversation",
+        hasHydratedHistory: hydration.turns.length > 0,
+      });
+      render();
       return true;
     },
     cancelNewConversation() {
@@ -369,7 +440,7 @@ export function createChatController(input: {
     confirmNewConversation() {
       if (resetTask !== undefined) return resetTask;
       if (disposed || state.session.resetPhase !== "confirming") return Promise.resolve();
-      reduce({ type: "begin-reset" });
+      updateReset(() => hydrator.beginReset(), { type: "begin-reset" });
       const resetEpoch = ++epoch;
       const task = (async () => {
         try {
@@ -379,7 +450,7 @@ export function createChatController(input: {
           sequence += 1;
           retryClient = undefined;
           queuedRetry = undefined;
-          reduce({
+          updateReset(() => hydrator.resetSucceeded(), {
             type: "reset-succeeded",
             announcement: result.memoryFlushed
               ? NEW_CONVERSATION_SUCCESS_COPY
@@ -387,7 +458,10 @@ export function createChatController(input: {
           });
         } catch {
           if (disposed || epoch !== resetEpoch) return;
-          reduce({ type: "reset-failed", announcement: NEW_CONVERSATION_UNCERTAIN_COPY });
+          updateReset(() => hydrator.resetFailed(), {
+            type: "reset-failed",
+            announcement: NEW_CONVERSATION_UNCERTAIN_COPY,
+          });
         } finally {
           if (!disposed && epoch === resetEpoch) {
             try {
@@ -407,6 +481,7 @@ export function createChatController(input: {
     },
     dispose() {
       disposed = true;
+      hydrator.dispose();
       epoch += 1;
       sequence += 1;
     },

--- a/apps/desktop-renderer/src/chat/hydration.ts
+++ b/apps/desktop-renderer/src/chat/hydration.ts
@@ -1,0 +1,267 @@
+import type { ChatTranscriptMessage } from "../turn-state.js";
+
+export const TRANSCRIPT_HYDRATION_PAGE_LIMIT = 25;
+export const TRANSCRIPT_HYDRATION_FAILURE_COPY = "Conversation history is temporarily unavailable.";
+
+export interface TranscriptTurn {
+  readonly turnId: string;
+  readonly completedAt: string;
+  readonly athleteText: string;
+  readonly coachText: string;
+}
+
+export type TranscriptPage =
+  | {
+      readonly schemaVersion: 1;
+      readonly status: "page";
+      readonly turns: readonly TranscriptTurn[];
+      readonly nextCursor: string | null;
+    }
+  | {
+      readonly schemaVersion: 1;
+      readonly status: "restart-required";
+      readonly turns: readonly [];
+      readonly nextCursor: null;
+    };
+
+export type TranscriptHydrationStatus = "idle" | "loading" | "ready" | "failed";
+export type TranscriptHydrationChange = "none" | "initial" | "prepend" | "clear";
+
+export interface TranscriptHydrationSnapshot {
+  readonly turns: readonly TranscriptTurn[];
+  readonly nextCursor: string | null;
+  readonly status: TranscriptHydrationStatus;
+  readonly revision: number;
+  readonly change: TranscriptHydrationChange;
+}
+
+export interface TranscriptHydrator {
+  start(): Promise<void>;
+  loadEarlier(): Promise<void>;
+  retry(): Promise<void>;
+  beginReset(): void;
+  resetSucceeded(): void;
+  resetFailed(): void;
+  dispose(): void;
+}
+
+interface FailedRequest {
+  readonly cursor: string | null;
+  readonly mode: "initial" | "earlier";
+}
+
+const EMPTY_HYDRATION: TranscriptHydrationSnapshot = Object.freeze({
+  turns: Object.freeze([]),
+  nextCursor: null,
+  status: "idle",
+  revision: 0,
+  change: "none",
+});
+
+export function emptyTranscriptHydration(): TranscriptHydrationSnapshot {
+  return EMPTY_HYDRATION;
+}
+
+function uniqueTurns(
+  incoming: readonly TranscriptTurn[],
+  existing: readonly TranscriptTurn[] = [],
+): readonly TranscriptTurn[] {
+  const seen = new Set(existing.map((turn) => turn.turnId));
+  return incoming.filter((turn) => {
+    if (seen.has(turn.turnId)) return false;
+    seen.add(turn.turnId);
+    return true;
+  });
+}
+
+export function mergeHydratedMessages(
+  turns: readonly TranscriptTurn[],
+  liveMessages: readonly ChatTranscriptMessage[],
+): readonly ChatTranscriptMessage[] {
+  const liveTurnIds = new Set(
+    liveMessages.flatMap((message) => (message.turnId === undefined ? [] : [message.turnId])),
+  );
+  const history = turns
+    .filter((turn) => !liveTurnIds.has(turn.turnId))
+    .flatMap((turn): readonly ChatTranscriptMessage[] => [
+      {
+        id: `history:athlete:${turn.turnId}`,
+        turnId: turn.turnId,
+        role: "athlete",
+        text: turn.athleteText,
+        delivery: "complete",
+        historical: true,
+      },
+      {
+        id: `history:coach:${turn.turnId}`,
+        turnId: turn.turnId,
+        role: "coach",
+        text: turn.coachText,
+        delivery: "complete",
+        historical: true,
+      },
+    ]);
+  return [...history, ...liveMessages];
+}
+
+export function createTranscriptHydrator(input: {
+  readonly readPage: (request: {
+    readonly cursor: string | null;
+    readonly limit: number;
+  }) => Promise<TranscriptPage>;
+  readonly onChange: (snapshot: TranscriptHydrationSnapshot) => void;
+}): TranscriptHydrator {
+  let snapshot = EMPTY_HYDRATION;
+  let disposed = false;
+  let resetPending = false;
+  let epoch = 0;
+  let task: Promise<void> | undefined;
+  let failedRequest: FailedRequest | undefined;
+  let interruptedRequest: FailedRequest | undefined;
+
+  const publish = (next: TranscriptHydrationSnapshot): void => {
+    snapshot = next;
+    input.onChange(snapshot);
+  };
+  const fail = (request: FailedRequest): void => {
+    failedRequest = request;
+    publish({ ...snapshot, status: "failed", change: "none" });
+  };
+  const applyPage = (
+    page: Extract<TranscriptPage, { readonly status: "page" }>,
+    mode: FailedRequest["mode"],
+  ): void => {
+    const turns =
+      mode === "initial"
+        ? uniqueTurns(page.turns)
+        : [...uniqueTurns(page.turns, snapshot.turns), ...snapshot.turns];
+    failedRequest = undefined;
+    publish({
+      turns,
+      nextCursor: page.nextCursor,
+      status: "ready",
+      revision: snapshot.revision + 1,
+      change: mode === "initial" ? "initial" : "prepend",
+    });
+  };
+  const load = (request: FailedRequest, recoverRestart: boolean): Promise<void> => {
+    if (disposed || resetPending) return Promise.resolve();
+    if (task !== undefined) return task;
+    const requestEpoch = epoch;
+    publish({ ...snapshot, status: "loading", change: "none" });
+    const current = (): boolean => !disposed && !resetPending && epoch === requestEpoch;
+    const pending = (async () => {
+      let failureRequest = request;
+      try {
+        const page = await input.readPage({
+          cursor: request.cursor,
+          limit: TRANSCRIPT_HYDRATION_PAGE_LIMIT,
+        });
+        if (!current()) return;
+        if (page.status === "page") {
+          applyPage(page, request.mode);
+          return;
+        }
+        publish({
+          turns: [],
+          nextCursor: null,
+          status: "loading",
+          revision: snapshot.revision + 1,
+          change: "clear",
+        });
+        if (!recoverRestart) {
+          fail({ cursor: null, mode: "initial" });
+          return;
+        }
+        failureRequest = { cursor: null, mode: "initial" };
+        const newest = await input.readPage({
+          cursor: null,
+          limit: TRANSCRIPT_HYDRATION_PAGE_LIMIT,
+        });
+        if (!current()) return;
+        if (newest.status === "restart-required") {
+          fail({ cursor: null, mode: "initial" });
+          return;
+        }
+        applyPage(newest, "initial");
+      } catch {
+        if (current()) fail(failureRequest);
+      }
+    })();
+    task = pending;
+    void pending.finally(() => {
+      if (task === pending) task = undefined;
+    });
+    return pending;
+  };
+
+  return {
+    start() {
+      if (snapshot.status !== "idle") return task ?? Promise.resolve();
+      return load({ cursor: null, mode: "initial" }, true);
+    },
+    loadEarlier() {
+      if (snapshot.status === "failed") return Promise.resolve();
+      const cursor = snapshot.nextCursor;
+      return cursor === null ? Promise.resolve() : load({ cursor, mode: "earlier" }, true);
+    },
+    retry() {
+      const request = failedRequest;
+      return request === undefined ? Promise.resolve() : load(request, true);
+    },
+    beginReset() {
+      if (disposed || resetPending) return;
+      resetPending = true;
+      epoch += 1;
+      interruptedRequest =
+        snapshot.status === "loading"
+          ? (failedRequest ?? {
+              cursor: snapshot.turns.length === 0 ? null : snapshot.nextCursor,
+              mode: snapshot.turns.length === 0 ? "initial" : "earlier",
+            })
+          : undefined;
+      task = undefined;
+      if (snapshot.status === "loading") {
+        publish({
+          ...snapshot,
+          status: snapshot.turns.length === 0 ? "idle" : "ready",
+          change: "none",
+        });
+      }
+    },
+    resetSucceeded() {
+      if (disposed) return;
+      resetPending = false;
+      epoch += 1;
+      failedRequest = undefined;
+      interruptedRequest = undefined;
+      task = undefined;
+      publish({
+        turns: [],
+        nextCursor: null,
+        status: "ready",
+        revision: snapshot.revision + 1,
+        change: "clear",
+      });
+    },
+    resetFailed() {
+      if (disposed) return;
+      resetPending = false;
+      epoch += 1;
+      task = undefined;
+      if (interruptedRequest !== undefined) {
+        failedRequest = interruptedRequest;
+        interruptedRequest = undefined;
+        publish({ ...snapshot, status: "failed", change: "none" });
+      }
+    },
+    dispose() {
+      disposed = true;
+      resetPending = false;
+      epoch += 1;
+      task = undefined;
+      failedRequest = undefined;
+      interruptedRequest = undefined;
+    },
+  };
+}

--- a/apps/desktop-renderer/src/chat/styles.css
+++ b/apps/desktop-renderer/src/chat/styles.css
@@ -13,6 +13,19 @@
   gap: 28px;
 }
 
+.chat-history-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+}
+
+.chat-history-failure {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
 .chat-message {
   display: grid;
   gap: 7px;
@@ -168,7 +181,9 @@
   font-size: 13px;
 }
 
-.chat-retry {
+.chat-retry,
+.chat-history-load,
+.chat-history-retry {
   justify-self: start;
   padding: 8px 13px;
   border: 1px solid var(--line-strong);
@@ -190,7 +205,9 @@
 }
 
 .new-conversation-button:disabled,
-.chat-retry:disabled {
+.chat-retry:disabled,
+.chat-history-load:disabled,
+.chat-history-retry:disabled {
   cursor: default;
   opacity: 0.5;
 }

--- a/apps/desktop-renderer/src/chat/view.ts
+++ b/apps/desktop-renderer/src/chat/view.ts
@@ -1,5 +1,6 @@
 import type { ChatView } from "./controller.js";
 import type { ChatTranscriptMessage } from "../turn-state.js";
+import { TRANSCRIPT_HYDRATION_FAILURE_COPY } from "./hydration.js";
 import { renderCoachMarkdown } from "./markdown.js";
 
 interface RenderedMessage {
@@ -10,6 +11,7 @@ interface RenderedMessage {
   role: ChatTranscriptMessage["role"];
   text: string;
   delivery: ChatTranscriptMessage["delivery"];
+  historical: boolean;
 }
 
 interface PendingShortcutFocus {
@@ -32,6 +34,8 @@ export interface MountedChatView {
   bind(input: {
     readonly onSubmit: (message: string) => void;
     readonly onRetry: () => void;
+    readonly onLoadEarlier?: () => void;
+    readonly onRetryHydration?: () => void;
     readonly onOpenNewConversation: () => void;
     readonly onCancelNewConversation: () => void;
     readonly onConfirmNewConversation: () => void;
@@ -85,6 +89,25 @@ export function mountChatView(input: {
   transcript.setAttribute("aria-label", "Coach conversation");
   const messages = document.createElement("div");
   messages.className = "chat-messages";
+  const historyControls = document.createElement("div");
+  historyControls.className = "chat-history-controls";
+  historyControls.setAttribute("aria-live", "off");
+  historyControls.hidden = true;
+  const loadEarlier = document.createElement("button");
+  loadEarlier.type = "button";
+  loadEarlier.className = "chat-history-load";
+  loadEarlier.textContent = "Load earlier messages";
+  loadEarlier.hidden = true;
+  const historyFailure = document.createElement("p");
+  historyFailure.className = "chat-history-failure";
+  historyFailure.textContent = TRANSCRIPT_HYDRATION_FAILURE_COPY;
+  historyFailure.hidden = true;
+  const retryHydration = document.createElement("button");
+  retryHydration.type = "button";
+  retryHydration.className = "chat-history-retry";
+  retryHydration.textContent = "Retry history";
+  retryHydration.hidden = true;
+  historyControls.append(loadEarlier, historyFailure, retryHydration);
   const notice = document.createElement("p");
   notice.className = "chat-notice";
   notice.hidden = true;
@@ -93,7 +116,7 @@ export function mountChatView(input: {
   retry.className = "chat-retry";
   retry.textContent = "Retry message";
   retry.hidden = true;
-  transcript.append(messages, notice, retry);
+  transcript.append(historyControls, messages, notice, retry);
   input.thread.append(transcript);
 
   input.composerHost.replaceChildren();
@@ -146,6 +169,8 @@ export function mountChatView(input: {
     | {
         readonly onSubmit: (message: string) => void;
         readonly onRetry: () => void;
+        readonly onLoadEarlier?: () => void;
+        readonly onRetryHydration?: () => void;
         readonly onOpenNewConversation: () => void;
         readonly onCancelNewConversation: () => void;
         readonly onConfirmNewConversation: () => void;
@@ -157,6 +182,10 @@ export function mountChatView(input: {
   const renderedMessages = new Map<string, RenderedMessage>();
   let renderedNotice: string | null = null;
   let pendingShortcutFocus: PendingShortcutFocus | undefined;
+  let renderedHydrationRevision = 0;
+  let hydrationStatus: "idle" | "loading" | "ready" | "failed" = "idle";
+  let hydrationHasEarlier = false;
+  let hydrationWorkBlocked = false;
 
   const updateComposerClearance = (): void => {
     if (disposed) return;
@@ -185,6 +214,25 @@ export function mountChatView(input: {
     }
   };
   const onRetry = (): void => handlers?.onRetry();
+  const onLoadEarlier = (): void => {
+    if (loadEarlier.disabled || loadEarlier.hidden) return;
+    handlers?.onLoadEarlier?.();
+  };
+  const onRetryHydration = (): void => {
+    if (retryHydration.disabled || retryHydration.hidden) return;
+    handlers?.onRetryHydration?.();
+  };
+  const onConversationScroll = (): void => {
+    if (
+      input.conversation.scrollTop <= 32 &&
+      hydrationHasEarlier &&
+      hydrationStatus !== "loading" &&
+      hydrationStatus !== "failed" &&
+      !hydrationWorkBlocked
+    ) {
+      handlers?.onLoadEarlier?.();
+    }
+  };
   const onOpenNewConversation = (): void => {
     if (newConversation.disabled || newConversation.getAttribute("aria-disabled") === "true")
       return;
@@ -224,6 +272,9 @@ export function mountChatView(input: {
   form.addEventListener("submit", onSubmit);
   textarea.addEventListener("keydown", onKeydown);
   retry.addEventListener("click", onRetry);
+  loadEarlier.addEventListener("click", onLoadEarlier);
+  retryHydration.addEventListener("click", onRetryHydration);
+  input.conversation.addEventListener("scroll", onConversationScroll);
   newConversation.addEventListener("click", onOpenNewConversation);
   cancelReset.addEventListener("click", onCancelNewConversation);
   confirmReset.addEventListener("click", onConfirmNewConversation);
@@ -261,6 +312,17 @@ export function mountChatView(input: {
         cancelReset.disabled = resetPending;
         confirmReset.disabled = resetPending;
         retry.disabled = workBlocked;
+        const hydrationControls = controls?.hydration;
+        hydrationStatus = hydrationControls?.status ?? "idle";
+        hydrationHasEarlier = hydrationControls?.hasEarlier ?? false;
+        hydrationWorkBlocked = workBlocked;
+        const hydrationFailed = hydrationStatus === "failed";
+        historyControls.hidden = !hydrationHasEarlier && !hydrationFailed;
+        loadEarlier.hidden = !hydrationHasEarlier || hydrationFailed;
+        loadEarlier.disabled = hydrationStatus === "loading" || workBlocked;
+        historyFailure.hidden = !hydrationFailed;
+        retryHydration.hidden = !hydrationFailed;
+        retryHydration.disabled = workBlocked;
         const composerDisabled = state.status === "streaming" || workBlocked;
         for (const { button } of shortcutControls) button.disabled = composerDisabled;
         submit.disabled = composerDisabled;
@@ -312,6 +374,11 @@ export function mountChatView(input: {
             input.conversation.scrollTop -
             input.conversation.clientHeight <=
           80;
+        const previousScrollHeight = input.conversation.scrollHeight;
+        const previousScrollTop = input.conversation.scrollTop;
+        const hydrationChanged =
+          hydrationControls !== undefined &&
+          hydrationControls.revision !== renderedHydrationRevision;
         if (nextMessages.length === 0 && renderedMessages.size > 0) {
           messages.textContent = "";
           renderedMessages.clear();
@@ -340,12 +407,15 @@ export function mountChatView(input: {
                 role: message.role,
                 text: message.text,
                 delivery: message.delivery,
+                historical: message.historical === true,
               };
               renderedMessages.set(message.id, rendered);
               article.className = `chat-message chat-message--${message.role}`;
               article.dataset.delivery = message.delivery;
               roleNode.textContent = message.role === "athlete" ? "You" : "Coach";
-              if (message.role === "athlete") article.setAttribute("aria-live", "off");
+              if (message.historical === true || message.role === "athlete") {
+                article.setAttribute("aria-live", "off");
+              }
               article.setAttribute("aria-atomic", message.role === "coach" ? "true" : "false");
               if (message.role === "coach" && message.delivery === "streaming") {
                 article.setAttribute("aria-busy", "true");
@@ -360,14 +430,16 @@ export function mountChatView(input: {
               }
             } else {
               const roleChanged = message.role !== rendered.role;
+              const historyChanged = (message.historical === true) !== rendered.historical;
               const wasBusy = rendered.role === "coach" && rendered.delivery === "streaming";
               const isBusy = message.role === "coach" && message.delivery === "streaming";
               if (!wasBusy && isBusy) rendered.article.setAttribute("aria-busy", "true");
-              if (roleChanged) {
+              if (roleChanged || historyChanged) {
                 rendered.article.className = `chat-message chat-message--${message.role}`;
                 rendered.roleNode.textContent = message.role === "athlete" ? "You" : "Coach";
-                if (message.role === "athlete") rendered.article.setAttribute("aria-live", "off");
-                else rendered.article.removeAttribute("aria-live");
+                if (message.historical === true || message.role === "athlete") {
+                  rendered.article.setAttribute("aria-live", "off");
+                } else rendered.article.removeAttribute("aria-live");
                 rendered.article.setAttribute(
                   "aria-atomic",
                   message.role === "coach" ? "true" : "false",
@@ -405,6 +477,7 @@ export function mountChatView(input: {
               rendered.role = message.role;
               rendered.text = message.text;
               rendered.delivery = message.delivery;
+              rendered.historical = message.historical === true;
             }
             const currentAtIndex = messages.children.item(index);
             if (currentAtIndex !== rendered.article) {
@@ -412,7 +485,17 @@ export function mountChatView(input: {
             }
           });
         }
-        if (followsLatest) input.conversation.scrollTop = input.conversation.scrollHeight;
+        if (hydrationChanged && hydrationControls.change === "initial") {
+          input.conversation.scrollTop = input.conversation.scrollHeight;
+        } else if (hydrationChanged && hydrationControls.change === "prepend") {
+          input.conversation.scrollTop =
+            previousScrollTop + Math.max(0, input.conversation.scrollHeight - previousScrollHeight);
+        } else if (followsLatest) {
+          input.conversation.scrollTop = input.conversation.scrollHeight;
+        }
+        if (hydrationControls !== undefined) {
+          renderedHydrationRevision = hydrationControls.revision;
+        }
         const contractCopy = state.activeTurn?.error?.athleteMessage ?? null;
         const visibleNotice = contractCopy ?? state.progress;
         notice.hidden = visibleNotice === null;
@@ -437,6 +520,9 @@ export function mountChatView(input: {
       form.removeEventListener("submit", onSubmit);
       textarea.removeEventListener("keydown", onKeydown);
       retry.removeEventListener("click", onRetry);
+      loadEarlier.removeEventListener("click", onLoadEarlier);
+      retryHydration.removeEventListener("click", onRetryHydration);
+      input.conversation.removeEventListener("scroll", onConversationScroll);
       newConversation.removeEventListener("click", onOpenNewConversation);
       cancelReset.removeEventListener("click", onCancelNewConversation);
       confirmReset.removeEventListener("click", onConfirmNewConversation);

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -133,10 +133,13 @@ const chatController = createChatController({
   view: mountedChat.view,
   refreshTrainingContext: () => trainingContextController.refresh(),
   refreshSpend: () => spendController.refresh(),
+  readTranscriptPage: (request) => window.enduragentAuth.getTranscriptPage(request),
 });
 mountedChat.bind({
   onSubmit: (message) => void chatController.submit(message),
   onRetry: () => void chatController.retryInterrupted(),
+  onLoadEarlier: () => void chatController.loadEarlier(),
+  onRetryHydration: () => void chatController.retryHydration(),
   onOpenNewConversation: () => void chatController.openNewConversation(),
   onCancelNewConversation: () => chatController.cancelNewConversation(),
   onConfirmNewConversation: () => void chatController.confirmNewConversation(),

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -23,6 +23,7 @@ export interface ActiveTurn {
   readonly requestKey: number;
   readonly turnId: string | null;
   readonly userMessage: string;
+  readonly userMessageId: string | null;
   readonly assistantMessageId: string;
   readonly draft: string;
   readonly finalText: string | null;
@@ -31,9 +32,11 @@ export interface ActiveTurn {
 
 export interface ChatTranscriptMessage {
   readonly id: string;
+  readonly turnId?: string;
   readonly role: "athlete" | "coach";
   readonly text: string;
   readonly delivery: "complete" | "streaming" | "interrupted";
+  readonly historical?: boolean;
 }
 
 export interface ChatState {
@@ -73,7 +76,7 @@ export type ChatAction =
   | { readonly type: "retry-pending"; readonly requestKey: number }
   | { readonly type: "fail"; readonly requestKey: number; readonly copy: string }
   | { readonly type: "session-probe"; readonly hasSession: boolean }
-  | { readonly type: "open-new-conversation" }
+  | { readonly type: "open-new-conversation"; readonly hasHydratedHistory?: boolean }
   | { readonly type: "cancel-new-conversation" }
   | { readonly type: "begin-reset" }
   | { readonly type: "reset-succeeded"; readonly announcement: string }
@@ -144,6 +147,7 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
           requestKey: action.requestKey,
           turnId: null,
           userMessage: action.userMessage,
+          userMessageId: action.includeUser ? action.userMessageId : null,
           assistantMessageId: action.assistantMessageId,
           draft: "",
           finalText: null,
@@ -155,7 +159,15 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
       const active = current(state, action.requestKey);
       return active === null
         ? state
-        : { ...state, activeTurn: { ...active, turnId: action.turnId } };
+        : {
+            ...state,
+            messages: state.messages.map((message) =>
+              message.id === active.userMessageId || message.id === active.assistantMessageId
+                ? { ...message, turnId: action.turnId }
+                : message,
+            ),
+            activeTurn: { ...active, turnId: action.turnId },
+          };
     }
     case "event": {
       const active = current(state, action.requestKey);
@@ -263,7 +275,7 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
       };
     }
     case "open-new-conversation":
-      return !hasClearableConversation(state) ||
+      return (!action.hasHydratedHistory && !hasClearableConversation(state)) ||
         state.session.resetPhase !== "idle" ||
         state.status === "streaming"
         ? state

--- a/apps/desktop-renderer/tests/chat-hydration-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-hydration-controller.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CoachClient, CoachClientCallOptions } from "@enduragent/coach-client";
+import type { TurnEvent } from "@enduragent/coach-contract";
+import { createChatController } from "../src/chat/controller.js";
+import type { TranscriptPage } from "../src/chat/hydration.js";
+import { CHAT_WORKING_COPY, type ChatState } from "../src/turn-state.js";
+
+function transcriptPage(turnId: string, nextCursor: string | null = null): TranscriptPage {
+  return {
+    schemaVersion: 1,
+    status: "page",
+    turns: [
+      {
+        turnId,
+        completedAt: "2001-01-01T00:00:00.000Z",
+        athleteText: `Athlete ${turnId}`,
+        coachText: `Coach ${turnId}`,
+      },
+    ],
+    nextCursor,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((onResolve) => {
+    resolve = onResolve;
+  });
+  return { promise, resolve };
+}
+
+function coachClient(input: {
+  readonly hasSession?: boolean;
+  readonly resetSession?: () => Promise<{ memoryFlushed: boolean }>;
+  readonly chat?: (
+    options: CoachClientCallOptions<"chat"> | undefined,
+  ) => Promise<{ text: string }>;
+}): CoachClient {
+  return {
+    handshake: {} as CoachClient["handshake"],
+    call: vi.fn((method, _request, options) => {
+      if (method === "hasSession") {
+        return Promise.resolve({ hasSession: input.hasSession ?? false }) as never;
+      }
+      if (method === "resetSession") {
+        return (input.resetSession?.() ?? Promise.resolve({ memoryFlushed: true })) as never;
+      }
+      if (method === "chat" && input.chat !== undefined) {
+        return input.chat(options as CoachClientCallOptions<"chat">) as never;
+      }
+      throw new TypeError();
+    }),
+    close: vi.fn(async () => {}),
+  };
+}
+
+function deliver(options: CoachClientCallOptions<"chat"> | undefined, event: TurnEvent): void {
+  options?.onNotificationEnvelope?.({
+    jsonrpc: "2.0",
+    method: "coach.turnEvent",
+    params: {
+      requestId: 1,
+      requestMethod: "chat",
+      turnId: event.turnId,
+      event,
+    },
+  });
+  options?.onEvent?.(event);
+}
+
+function subject(input: {
+  readonly client: CoachClient;
+  readonly readTranscriptPage: (request: {
+    cursor: string | null;
+    limit: number;
+  }) => Promise<TranscriptPage>;
+}) {
+  const states: ChatState[] = [];
+  const controls: Array<
+    Parameters<Parameters<typeof createChatController>[0]["view"]["render"]>[1]
+  > = [];
+  const controller = createChatController({
+    clients: {
+      getClient: vi.fn(async () => input.client),
+      reconnect: vi.fn(async () => input.client),
+      close: vi.fn(async () => {}),
+    },
+    view: {
+      render(state, nextControls) {
+        states.push(structuredClone(state));
+        controls.push(structuredClone(nextControls));
+      },
+    },
+    refreshTrainingContext: vi.fn(async () => {}),
+    refreshSpend: vi.fn(async () => {}),
+    readTranscriptPage: input.readTranscriptPage,
+  });
+  return { controller, states, controls };
+}
+
+describe("chat controller transcript hydration", () => {
+  it("renders the first persisted page alongside a still-pending live readiness probe", async () => {
+    const session = deferred<{ hasSession: boolean }>();
+    const client = coachClient({});
+    vi.mocked(client.call).mockImplementation((method) => {
+      if (method === "hasSession") return session.promise as never;
+      throw new TypeError();
+    });
+    const { controller, states } = subject({
+      client,
+      readTranscriptPage: async () => transcriptPage("turn-1"),
+    });
+
+    const readiness = controller.start();
+    await vi.waitFor(() => expect(states.at(-1)?.messages).toHaveLength(2));
+
+    expect(states.at(-1)?.messages).toMatchObject([
+      { id: "history:athlete:turn-1", historical: true },
+      { id: "history:coach:turn-1", historical: true },
+    ]);
+    session.resolve({ hasSession: true });
+    await readiness;
+  });
+
+  it("does not delay sending and deduplicates the completed live turn after hydration settles", async () => {
+    const hydration = deferred<TranscriptPage>();
+    const client = coachClient({
+      chat: async (options) => {
+        deliver(options, { type: "final-text", turnId: "turn-live", text: "Live coach" });
+        options?.onTerminalEnvelope?.({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { text: "Live coach" },
+        });
+        return { text: "Live coach" };
+      },
+    });
+    const { controller, states } = subject({
+      client,
+      readTranscriptPage: () => hydration.promise,
+    });
+    void controller.start();
+
+    await expect(controller.submit("Live athlete")).resolves.toBeUndefined();
+    expect(states.at(-1)?.messages).toHaveLength(2);
+
+    hydration.resolve(transcriptPage("turn-live"));
+    await vi.waitFor(() => {
+      expect(states.at(-1)?.messages).toHaveLength(2);
+      expect(states.at(-1)?.messages.every((message) => message.historical !== true)).toBe(true);
+    });
+  });
+
+  it("keeps a live in-flight turn visible while a reset signal refreshes persisted history", async () => {
+    const recovery = deferred<TranscriptPage>();
+    const finishChat = deferred<void>();
+    const restart: TranscriptPage = {
+      schemaVersion: 1,
+      status: "restart-required",
+      turns: [],
+      nextCursor: null,
+    };
+    const readTranscriptPage = vi
+      .fn()
+      .mockResolvedValueOnce(transcriptPage("turn-old", "older"))
+      .mockResolvedValueOnce(restart)
+      .mockImplementationOnce(() => recovery.promise);
+    const client = coachClient({
+      chat: async (options) => {
+        await finishChat.promise;
+        deliver(options, { type: "final-text", turnId: "turn-live", text: "Live coach" });
+        options?.onTerminalEnvelope?.({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { text: "Live coach" },
+        });
+        return { text: "Live coach" };
+      },
+    });
+    const { controller, states } = subject({ client, readTranscriptPage });
+    await controller.start();
+    const submission = controller.submit("Live athlete");
+
+    const pagination = controller.loadEarlier();
+    await vi.waitFor(() => expect(readTranscriptPage).toHaveBeenCalledTimes(3));
+
+    expect(states.at(-1)).toMatchObject({
+      status: "streaming",
+      progress: CHAT_WORKING_COPY,
+      messages: [
+        { role: "athlete", text: "Live athlete" },
+        { role: "coach", text: "" },
+      ],
+    });
+
+    recovery.resolve({
+      schemaVersion: 1,
+      status: "page",
+      turns: [],
+      nextCursor: null,
+    });
+    await pagination;
+    finishChat.resolve();
+    await submission;
+  });
+
+  it("clears history-only state on success and rejects a stale in-flight page afterward", async () => {
+    const stale = deferred<TranscriptPage>();
+    const reset = deferred<{ memoryFlushed: boolean }>();
+    const client = coachClient({
+      hasSession: true,
+      resetSession: () => reset.promise,
+    });
+    const { controller, states } = subject({
+      client,
+      readTranscriptPage: () => stale.promise,
+    });
+    await controller.start();
+
+    expect(controller.openNewConversation()).toBe(true);
+    const resetting = controller.confirmNewConversation();
+    reset.resolve({ memoryFlushed: true });
+    await resetting;
+    expect(states.at(-1)?.messages).toEqual([]);
+
+    stale.resolve(transcriptPage("turn-stale"));
+    await vi.waitFor(() => expect(states.at(-1)?.messages).toEqual([]));
+  });
+
+  it("opens and clears a new conversation when persisted history is the only visible state", async () => {
+    const client = coachClient({ hasSession: false });
+    const { controller, states } = subject({
+      client,
+      readTranscriptPage: async () => transcriptPage("turn-persisted"),
+    });
+    await controller.start();
+    await vi.waitFor(() => expect(states.at(-1)?.messages).toHaveLength(2));
+
+    expect(controller.openNewConversation()).toBe(true);
+    await controller.confirmNewConversation();
+
+    expect(states.at(-1)?.messages).toEqual([]);
+    expect(states.at(-1)?.session.resetCount).toBe(1);
+  });
+});

--- a/apps/desktop-renderer/tests/chat-hydration.test.ts
+++ b/apps/desktop-renderer/tests/chat-hydration.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  TRANSCRIPT_HYDRATION_PAGE_LIMIT,
+  createTranscriptHydrator,
+  mergeHydratedMessages,
+  type TranscriptHydrationSnapshot,
+  type TranscriptPage,
+  type TranscriptTurn,
+} from "../src/chat/hydration.js";
+import type { ChatTranscriptMessage } from "../src/turn-state.js";
+
+function turn(turnId: string): TranscriptTurn {
+  return {
+    turnId,
+    completedAt: "2001-01-01T00:00:00.000Z",
+    athleteText: `Athlete ${turnId}`,
+    coachText: `Coach ${turnId}`,
+  };
+}
+
+function page(turns: readonly TranscriptTurn[], nextCursor: string | null): TranscriptPage {
+  return { schemaVersion: 1, status: "page", turns, nextCursor };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function subject(
+  readPage: (request: { cursor: string | null; limit: number }) => Promise<TranscriptPage>,
+) {
+  const snapshots: TranscriptHydrationSnapshot[] = [];
+  const hydrator = createTranscriptHydrator({
+    readPage,
+    onChange: (snapshot) => snapshots.push(snapshot),
+  });
+  return { hydrator, snapshots };
+}
+
+describe("chat transcript hydration", () => {
+  it("loads the newest bounded page and exposes only its backward cursor", async () => {
+    const readPage = vi.fn(async () => page([turn("turn-3"), turn("turn-4")], "older"));
+    const { hydrator, snapshots } = subject(readPage);
+
+    await hydrator.start();
+
+    expect(readPage).toHaveBeenCalledWith({
+      cursor: null,
+      limit: TRANSCRIPT_HYDRATION_PAGE_LIMIT,
+    });
+    expect(snapshots.at(-1)).toMatchObject({
+      status: "ready",
+      turns: [{ turnId: "turn-3" }, { turnId: "turn-4" }],
+      nextCursor: "older",
+      revision: 1,
+      change: "initial",
+    });
+  });
+
+  it("prepends one explicit page at a time without replacing stable newer turns", async () => {
+    const newest = [turn("turn-3"), turn("turn-4")];
+    const earlier = [turn("turn-1"), turn("turn-2")];
+    const readPage = vi
+      .fn()
+      .mockResolvedValueOnce(page(newest, "older"))
+      .mockResolvedValueOnce(page(earlier, null));
+    const { hydrator, snapshots } = subject(readPage);
+
+    await hydrator.start();
+    const newerReferences = snapshots.at(-1)!.turns;
+    await hydrator.loadEarlier();
+
+    expect(readPage).toHaveBeenCalledTimes(2);
+    expect(readPage.mock.calls[1]?.[0]).toEqual({
+      cursor: "older",
+      limit: TRANSCRIPT_HYDRATION_PAGE_LIMIT,
+    });
+    expect(snapshots.at(-1)?.turns.map(({ turnId }) => turnId)).toEqual([
+      "turn-1",
+      "turn-2",
+      "turn-3",
+      "turn-4",
+    ]);
+    expect(snapshots.at(-1)?.turns[2]).toBe(newerReferences[0]);
+    expect(snapshots.at(-1)?.turns[3]).toBe(newerReferences[1]);
+    expect(snapshots.at(-1)).toMatchObject({ nextCursor: null, change: "prepend" });
+  });
+
+  it("deduplicates a hydrated turn against live rows by turn identity", () => {
+    const live: readonly ChatTranscriptMessage[] = [
+      {
+        id: "message-1",
+        turnId: "turn-2",
+        role: "athlete",
+        text: "Live athlete",
+        delivery: "complete",
+      },
+      {
+        id: "message-2",
+        turnId: "turn-2",
+        role: "coach",
+        text: "Live coach",
+        delivery: "complete",
+      },
+    ];
+
+    const merged = mergeHydratedMessages([turn("turn-1"), turn("turn-2")], live);
+
+    expect(merged.map(({ id }) => id)).toEqual([
+      "history:athlete:turn-1",
+      "history:coach:turn-1",
+      "message-1",
+      "message-2",
+    ]);
+    expect(merged.slice(2)).toEqual(live);
+  });
+
+  it("clears stale history and restarts from newest once after a reset signal", async () => {
+    const recovery = deferred<TranscriptPage>();
+    const readPage = vi
+      .fn()
+      .mockResolvedValueOnce(page([turn("turn-3"), turn("turn-4")], "older"))
+      .mockResolvedValueOnce({
+        schemaVersion: 1,
+        status: "restart-required",
+        turns: [],
+        nextCursor: null,
+      })
+      .mockImplementationOnce(() => recovery.promise);
+    const { hydrator, snapshots } = subject(readPage);
+    await hydrator.start();
+
+    const loading = hydrator.loadEarlier();
+    await vi.waitFor(() => {
+      expect(snapshots.at(-1)).toMatchObject({
+        turns: [],
+        status: "loading",
+        change: "clear",
+      });
+    });
+    expect(readPage).toHaveBeenCalledTimes(3);
+    expect(readPage.mock.calls[2]?.[0]).toMatchObject({ cursor: null });
+
+    recovery.resolve(page([turn("turn-8")], null));
+    await loading;
+
+    expect(snapshots.at(-1)).toMatchObject({
+      turns: [{ turnId: "turn-8" }],
+      status: "ready",
+      change: "initial",
+    });
+  });
+
+  it("does not loop when the one newest-page recovery also requests a restart", async () => {
+    const restart: TranscriptPage = {
+      schemaVersion: 1,
+      status: "restart-required",
+      turns: [],
+      nextCursor: null,
+    };
+    const readPage = vi.fn(async () => restart);
+    const { hydrator, snapshots } = subject(readPage);
+
+    await hydrator.start();
+
+    expect(readPage).toHaveBeenCalledTimes(2);
+    expect(snapshots.at(-1)).toMatchObject({ status: "failed", turns: [] });
+  });
+
+  it("retries the newest page after reset recovery fails", async () => {
+    const restart: TranscriptPage = {
+      schemaVersion: 1,
+      status: "restart-required",
+      turns: [],
+      nextCursor: null,
+    };
+    const readPage = vi
+      .fn()
+      .mockResolvedValueOnce(page([turn("turn-2")], "older"))
+      .mockResolvedValueOnce(restart)
+      .mockRejectedValueOnce(new Error("internal detail"))
+      .mockResolvedValueOnce(page([turn("turn-8")], null));
+    const { hydrator, snapshots } = subject(readPage);
+    await hydrator.start();
+
+    await hydrator.loadEarlier();
+    expect(snapshots.at(-1)).toMatchObject({ status: "failed", turns: [] });
+
+    await hydrator.retry();
+
+    expect(readPage.mock.calls[3]?.[0]).toMatchObject({ cursor: null });
+    expect(snapshots.at(-1)).toMatchObject({
+      status: "ready",
+      turns: [{ turnId: "turn-8" }],
+    });
+  });
+
+  it("ignores an in-flight page after a successful new-conversation reset", async () => {
+    const pending = deferred<TranscriptPage>();
+    const { hydrator, snapshots } = subject(() => pending.promise);
+    const loading = hydrator.start();
+
+    hydrator.beginReset();
+    hydrator.resetSucceeded();
+    pending.resolve(page([turn("turn-stale")], null));
+    await loading;
+
+    expect(snapshots.at(-1)).toMatchObject({
+      status: "ready",
+      turns: [],
+      change: "clear",
+    });
+    expect(snapshots.some((snapshot) => snapshot.turns[0]?.turnId === "turn-stale")).toBe(false);
+  });
+
+  it("keeps failures non-fatal and retries only the failed page", async () => {
+    const readPage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("internal detail"))
+      .mockResolvedValueOnce(page([turn("turn-1")], null));
+    const { hydrator, snapshots } = subject(readPage);
+
+    await hydrator.start();
+    expect(snapshots.at(-1)).toMatchObject({ status: "failed", turns: [] });
+
+    await hydrator.retry();
+
+    expect(readPage).toHaveBeenCalledTimes(2);
+    expect(readPage.mock.calls[1]?.[0]).toMatchObject({ cursor: null });
+    expect(snapshots.at(-1)).toMatchObject({
+      status: "ready",
+      turns: [{ turnId: "turn-1" }],
+    });
+  });
+});

--- a/apps/desktop-renderer/tests/chat-view.test.ts
+++ b/apps/desktop-renderer/tests/chat-view.test.ts
@@ -9,6 +9,7 @@ import {
   CHAT_EMPTY_RESPONSE_COPY,
   createChatController,
 } from "../src/chat/controller.js";
+import { TRANSCRIPT_HYDRATION_FAILURE_COPY } from "../src/chat/hydration.js";
 import { mountChatView } from "../src/chat/view.js";
 import {
   CHAT_WORKING_COPY,
@@ -62,7 +63,8 @@ class FakeElement {
   htmlFor = "";
   removed = false;
   open = false;
-  scrollHeight = 0;
+  private currentScrollHeight = 0;
+  readonly scrollHeightSequence: number[] = [];
   scrollTop = 0;
   clientHeight = 0;
   textContentMutationCount = 0;
@@ -76,6 +78,14 @@ class FakeElement {
   private ownText = "";
 
   constructor(readonly tagName: string) {}
+
+  get scrollHeight(): number {
+    return this.scrollHeightSequence.shift() ?? this.currentScrollHeight;
+  }
+
+  set scrollHeight(value: number) {
+    this.currentScrollHeight = value;
+  }
 
   get firstChild(): FakeElement | null {
     return this.children[0] ?? null;
@@ -2149,6 +2159,243 @@ describe("chat view", () => {
     expect(status.textContent).toBe(
       "We couldn’t confirm whether the new conversation started. Your visible conversation is preserved.",
     );
+  });
+
+  it("offers accessible one-page history loading by button or upward scroll", () => {
+    const conversation = new FakeElement("main");
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: conversation as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    const onLoadEarlier = vi.fn();
+    mounted.bind({
+      onSubmit: vi.fn(),
+      onRetry: vi.fn(),
+      onLoadEarlier,
+      onRetryHydration: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    mounted.view.render(emptyState, {
+      newConversationDisabled: false,
+      workBlocked: false,
+      hydration: {
+        status: "ready",
+        hasEarlier: true,
+        revision: 1,
+        change: "initial",
+      },
+    });
+
+    const controls = find(thread, (node) => node.className === "chat-history-controls");
+    const load = find(controls, (node) => node.className === "chat-history-load");
+    expect(controls.attributes.get("aria-live")).toBe("off");
+    expect(load.textContent).toBe("Load earlier messages");
+    expect(load.hidden).toBe(false);
+
+    load.dispatch("click");
+    conversation.scrollTop = 20;
+    conversation.dispatch("scroll");
+
+    expect(onLoadEarlier).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows fixed quiet hydration failure copy with a retry that never disables chat", () => {
+    const thread = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: composerHost as never,
+    });
+    const onRetryHydration = vi.fn();
+    mounted.bind({
+      onSubmit: vi.fn(),
+      onRetry: vi.fn(),
+      onLoadEarlier: vi.fn(),
+      onRetryHydration,
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    mounted.view.render(emptyState, {
+      newConversationDisabled: true,
+      workBlocked: false,
+      hydration: {
+        status: "failed",
+        hasEarlier: false,
+        revision: 0,
+        change: "none",
+      },
+    });
+
+    const failure = find(thread, (node) => node.className === "chat-history-failure");
+    const retryHistory = find(thread, (node) => node.className === "chat-history-retry");
+    const textarea = find(composerHost, (node) => node.tagName === "textarea");
+    const submit = find(
+      composerHost,
+      (node) => node.attributes.get("aria-label") === "Send message",
+    );
+    expect(failure.textContent).toBe(TRANSCRIPT_HYDRATION_FAILURE_COPY);
+    expect(failure.attributes.has("aria-live")).toBe(false);
+    expect(retryHistory.hidden).toBe(false);
+    expect(textarea.disabled).toBe(false);
+    expect(submit.disabled).toBe(false);
+
+    retryHistory.dispatch("click");
+    expect(onRetryHydration).toHaveBeenCalledOnce();
+  });
+
+  it("renders hydrated history silently with literal athlete text and bounded coach Markdown", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    mounted.view.render({
+      ...emptyState,
+      messages: [
+        {
+          id: "history:athlete:turn-1",
+          turnId: "turn-1",
+          role: "athlete",
+          text: "**literal athlete**",
+          delivery: "complete",
+          historical: true,
+        },
+        {
+          id: "history:coach:turn-1",
+          turnId: "turn-1",
+          role: "coach",
+          text: "**formatted coach**",
+          delivery: "complete",
+          historical: true,
+        },
+        {
+          id: "message-live",
+          role: "coach",
+          text: "New coach activity",
+          delivery: "complete",
+        },
+      ],
+    });
+
+    const historyRows = findAll(
+      thread,
+      (node) =>
+        node.className.startsWith("chat-message ") && node.attributes.get("aria-live") === "off",
+    );
+    const athlete = historyRows.find((node) => node.className.includes("--athlete"))!;
+    const coach = historyRows.find((node) => node.className.includes("--coach"))!;
+    const live = find(thread, (node) => node.dataset.messageId === "message-live");
+    expect(historyRows).toHaveLength(2);
+    expect(findAll(athlete, (node) => node.tagName === "strong")).toHaveLength(0);
+    expect(athlete.textContent).toContain("**literal athlete**");
+    expect(findAll(coach, (node) => node.tagName === "strong")[0]?.textContent).toBe(
+      "formatted coach",
+    );
+    expect(live.attributes.has("aria-live")).toBe(false);
+  });
+
+  it("keeps focus and newer row nodes stable while preserving scroll across a prepend", () => {
+    const conversation = new FakeElement("main");
+    conversation.clientHeight = 100;
+    const thread = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: conversation as never,
+      thread: thread as never,
+      composerHost: composerHost as never,
+    });
+    const textarea = find(composerHost, (node) => node.tagName === "textarea");
+    textarea.focus();
+    const newerMessages = [
+      {
+        id: "history:athlete:turn-2",
+        turnId: "turn-2",
+        role: "athlete" as const,
+        text: "Newer athlete",
+        delivery: "complete" as const,
+        historical: true,
+      },
+      {
+        id: "history:coach:turn-2",
+        turnId: "turn-2",
+        role: "coach" as const,
+        text: "Newer coach",
+        delivery: "complete" as const,
+        historical: true,
+      },
+    ];
+    conversation.scrollHeightSequence.push(300, 300, 300);
+    mounted.view.render(
+      { ...emptyState, messages: newerMessages },
+      {
+        newConversationDisabled: false,
+        workBlocked: false,
+        hydration: {
+          status: "ready",
+          hasEarlier: true,
+          revision: 1,
+          change: "initial",
+        },
+      },
+    );
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    const newerAthlete = messages.children[0]!;
+    const newerCoach = messages.children[1]!;
+    const insertions = messages.insertBeforeMutationCount;
+    expect(conversation.scrollTop).toBe(300);
+    expect((globalThis.document as unknown as FakeDocument).activeElement).toBe(textarea);
+
+    conversation.scrollTop = 40;
+    conversation.scrollHeightSequence.push(300, 300, 460);
+    mounted.view.render(
+      {
+        ...emptyState,
+        messages: [
+          {
+            id: "history:athlete:turn-1",
+            turnId: "turn-1",
+            role: "athlete",
+            text: "Earlier athlete",
+            delivery: "complete",
+            historical: true,
+          },
+          {
+            id: "history:coach:turn-1",
+            turnId: "turn-1",
+            role: "coach",
+            text: "Earlier coach",
+            delivery: "complete",
+            historical: true,
+          },
+          ...newerMessages,
+        ],
+      },
+      {
+        newConversationDisabled: false,
+        workBlocked: false,
+        hydration: {
+          status: "ready",
+          hasEarlier: false,
+          revision: 2,
+          change: "prepend",
+        },
+      },
+    );
+
+    expect(messages.children[2]).toBe(newerAthlete);
+    expect(messages.children[3]).toBe(newerCoach);
+    expect(messages.insertBeforeMutationCount).toBe(insertions + 2);
+    expect(newerAthlete.removeMutationCount).toBe(0);
+    expect(newerCoach.removeMutationCount).toBe(0);
+    expect(conversation.scrollTop).toBe(200);
+    expect((globalThis.document as unknown as FakeDocument).activeElement).toBe(textarea);
   });
 
   it("removes shortcut listeners and detached controls stay inert after dispose", () => {

--- a/apps/desktop-renderer/tests/turn-state.test.ts
+++ b/apps/desktop-renderer/tests/turn-state.test.ts
@@ -154,6 +154,22 @@ describe("desktop turn state", () => {
     });
   });
 
+  it("binds both live row identities to the durable turn without changing row keys", () => {
+    const state = started();
+
+    const bound = reduceChatState(state, {
+      type: "bind-turn",
+      requestKey: 1,
+      turnId: "turn-1",
+    });
+
+    expect(bound.messages).toMatchObject([
+      { id: "message-1", turnId: "turn-1", role: "athlete" },
+      { id: "message-2", turnId: "turn-1", role: "coach" },
+    ]);
+    expect(bound.activeTurn?.turnId).toBe("turn-1");
+  });
+
   it("clears a contract error only for a matching interrupted retry", () => {
     let state = reduceChatState(started(), {
       type: "event",

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -18,6 +18,9 @@ const hasLoopback = await new Promise<boolean>((resolveAvailability) => {
 });
 
 const token = "t".repeat(43);
+const transcriptCursorBytes = Buffer.alloc(114);
+transcriptCursorBytes[0] = 1;
+const transcriptCursor = transcriptCursorBytes.toString("base64url");
 const fixtures: RunningDesktopFixture[] = [];
 const scratchPaths: string[] = [];
 
@@ -106,7 +109,11 @@ function response(value: unknown): readonly string[] {
 
 type SyncOutcome = "no-change" | "partial";
 
-function makeScript(calls: ScriptRequest[], syncOutcome: SyncOutcome): DesktopFixtureScript {
+function makeScript(
+  calls: ScriptRequest[],
+  syncOutcome: SyncOutcome,
+  transcriptHistory: boolean,
+): DesktopFixtureScript {
   let units: "metric" | "imperial" = "metric";
   let hasSession = false;
   let lastSynced: string = athleteState.lastSynced;
@@ -156,6 +163,52 @@ ${"nonwrapping".repeat(36)}
         ];
       }
       if (request.method === "hasSession") return response({ hasSession });
+      if (request.method === "getTranscriptPage") {
+        if (!transcriptHistory) {
+          return response({
+            schemaVersion: 1,
+            status: "page",
+            turns: [],
+            nextCursor: null,
+          });
+        }
+        const cursor = (request.params as { readonly cursor: string | null }).cursor;
+        return response({
+          schemaVersion: 1,
+          status: "page",
+          turns:
+            cursor === null
+              ? [
+                  {
+                    turnId: "persisted-turn-3",
+                    completedAt: "2001-01-03T00:00:00.000Z",
+                    athleteText: "Persisted athlete 3",
+                    coachText: "**Persisted coach 3**",
+                  },
+                  {
+                    turnId: "persisted-turn-4",
+                    completedAt: "2001-01-04T00:00:00.000Z",
+                    athleteText: "Persisted athlete 4",
+                    coachText: "Persisted coach 4",
+                  },
+                ]
+              : [
+                  {
+                    turnId: "persisted-turn-1",
+                    completedAt: "2001-01-01T00:00:00.000Z",
+                    athleteText: "Persisted athlete 1",
+                    coachText: "Persisted coach 1",
+                  },
+                  {
+                    turnId: "persisted-turn-2",
+                    completedAt: "2001-01-02T00:00:00.000Z",
+                    athleteText: "Persisted athlete 2",
+                    coachText: "Persisted coach 2",
+                  },
+                ],
+          nextCursor: cursor === null ? transcriptCursor : null,
+        });
+      }
       if (request.method === "resetSession") {
         hasSession = false;
         return response({ memoryFlushed: true });
@@ -240,10 +293,11 @@ async function launch(input: {
   readonly height: number;
   readonly reducedMotion: boolean;
   readonly syncOutcome?: SyncOutcome;
+  readonly transcriptHistory?: boolean;
 }): Promise<{ readonly fixture: RunningDesktopFixture; readonly calls: ScriptRequest[] }> {
   const calls: ScriptRequest[] = [];
   const fixture = await launchDesktopFixture({
-    script: makeScript(calls, input.syncOutcome ?? "no-change"),
+    script: makeScript(calls, input.syncOutcome ?? "no-change", input.transcriptHistory ?? false),
     token,
     width: input.width,
     height: input.height,
@@ -269,6 +323,96 @@ afterEach(async () => {
 });
 
 describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat panels", () => {
+  it("hydrates persisted conversation pages without replay, focus loss, or row churn", async () => {
+    const { fixture, calls } = await launch({
+      width: 1440,
+      height: 900,
+      reducedMotion: false,
+      transcriptHistory: true,
+    });
+    const hydrated = await fixture.evaluate<{
+      readonly initialRows: number;
+      readonly allRows: number;
+      readonly initialAtNewest: boolean;
+      readonly newerRowsStable: boolean;
+      readonly anchorPreserved: boolean;
+      readonly focusPreserved: boolean;
+      readonly historySilent: boolean;
+      readonly athleteLiteral: boolean;
+      readonly coachMarkdown: boolean;
+      readonly loadEarlierHidden: boolean;
+    }>(`
+      const conversation = document.querySelector(".conversation");
+      const textarea = document.querySelector("#message");
+      const loadEarlier = document.querySelector(".chat-history-load");
+      const deadline = Date.now() + 5000;
+      while (
+        (document.querySelectorAll(".chat-message").length !== 4 || loadEarlier.hidden) &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const initialRows = [...document.querySelectorAll(".chat-message")];
+      const initialAtNewest =
+        conversation.scrollHeight - conversation.scrollTop - conversation.clientHeight <= 1;
+      conversation.scrollTop = Math.max(0, initialRows[0].offsetTop - 40);
+      const anchorTop = initialRows[0].getBoundingClientRect().top;
+      textarea.focus();
+      loadEarlier.click();
+      while (
+        document.querySelectorAll(".chat-message").length !== 8 &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const allRows = [...document.querySelectorAll(".chat-message")];
+      return {
+        initialRows: initialRows.length,
+        allRows: allRows.length,
+        initialAtNewest,
+        newerRowsStable:
+          allRows[4] === initialRows[0] &&
+          allRows[5] === initialRows[1] &&
+          allRows[6] === initialRows[2] &&
+          allRows[7] === initialRows[3],
+        anchorPreserved: Math.abs(initialRows[0].getBoundingClientRect().top - anchorTop) <= 1,
+        focusPreserved: document.activeElement === textarea,
+        historySilent: allRows.every((row) => row.getAttribute("aria-live") === "off"),
+        athleteLiteral:
+          allRows[4].querySelectorAll("strong").length === 0 &&
+          allRows[4].querySelector(".chat-message__text").textContent === "Persisted athlete 3",
+        coachMarkdown:
+          allRows[5].querySelector("strong")?.textContent === "Persisted coach 3",
+        loadEarlierHidden: loadEarlier.hidden,
+      };
+    `);
+
+    expect(hydrated).toEqual({
+      initialRows: 4,
+      allRows: 8,
+      initialAtNewest: true,
+      newerRowsStable: true,
+      anchorPreserved: true,
+      focusPreserved: true,
+      historySilent: true,
+      athleteLiteral: true,
+      coachMarkdown: true,
+      loadEarlierHidden: true,
+    });
+    expect(calls.filter((call) => call.method === "getTranscriptPage")).toEqual([
+      {
+        jsonrpc: "2.0",
+        method: "getTranscriptPage",
+        params: { cursor: null, limit: 25 },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "getTranscriptPage",
+        params: { cursor: transcriptCursor, limit: 25 },
+      },
+    ]);
+  }, 30_000);
+
   it("preserves IME composition until committed Enter", async () => {
     const { fixture, calls } = await launch({ width: 1440, height: 900, reducedMotion: false });
     const composingDraft = "回復走を";


### PR DESCRIPTION
Closes the third and final slice of issue 229 (transcript persistence): the renderer now hydrates conversation history from the daemon's paginated transcript-read RPC on startup and after a daemon restart.

## What this does

- On chat mount, the controller requests the newest transcript page and renders historical turns above any live conversation, oldest-first, with a "Load earlier" control that walks the cursor chain until the daemon reports the beginning of history.
- Historical rows get stable `history:<role>:<turnId>` identities; live rows now carry their `turnId` from `bind-turn`, so a turn that exists both live and in history renders exactly once (the live copy wins). Prepending older pages moves no existing DOM nodes and compensates the scroll anchor by height delta, so the viewport never jumps.
- Hydrated coach messages render through the existing safe-Markdown path; athlete messages stay literal. All historical rows and the history controls are `aria-live="off"` — assistive tech never replays old conversation.
- The RPC's restart-required signal clears hydration state and re-reads the newest page exactly once; a second signal fails closed rather than looping. Conversation reset discards in-flight history pages via an epoch guard, and a history-only chat can still open a new conversation.
- Hydration failure is non-fatal: fixed generic copy plus an accessible retry control; the composer is never gated by hydration status.

## Scope

Renderer-only — no preload, IPC, main-process, daemon, or protocol changes. Adds a synthetic Electron integration scenario (not executed in workers) and a user-facing changeset.

## Verification

- Focused renderer suites: 122 tests green; complete renderer suite: 26 files / 387 tests green.
- Renderer + desktop typechecks, renderer production build, workspace build, root `pnpm check` all green.
- Independent read-only review against the 10-requirement slice spec returned CLEAN (dedup identity, AT silence, restart-required single-shot, reset interplay, failure copy, scroll/focus discipline, Markdown safety, scope, changeset, coverage all verified).
