### PR TITLE
Add strength workout variant to intervals_create_workout

### DIFF
--- a/.changeset/strength-workout-variant.md
+++ b/.changeset/strength-workout-variant.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Coach can now create strength sessions on your intervals.icu calendar — free-text exercises, sets, reps, and RPE go in the description.

--- a/packages/core/src/agent/confirmation-gate.ts
+++ b/packages/core/src/agent/confirmation-gate.ts
@@ -115,11 +115,15 @@ export function createProposalSummarizers(opts: {
     intervals_create_workout: async (input) => {
       if (opts.intervals === null) return { block: { error: "intervals_not_configured" } };
       const date = stringField(input, "date");
-      const workout = objectField(input, "workout");
-      const name = stringField(workout, "name");
+      const type = stringField(input, "type");
+      const name =
+        type === "strength"
+          ? stringField(input, "name")
+          : stringField(objectField(input, "workout"), "name");
+      const label = type === "strength" ? "strength workout" : "workout";
       return date !== undefined && name !== undefined
-        ? { summary: `Create workout "${name}" on ${date}` }
-        : { summary: "Create a workout" };
+        ? { summary: `Create ${label} "${name}" on ${date}` }
+        : { summary: `Create a ${label}` };
     },
     intervals_delete_workout: async (input) => {
       if (opts.intervals === null) return { block: { error: "intervals_not_configured" } };

--- a/packages/core/tests/confirmation-gate.test.ts
+++ b/packages/core/tests/confirmation-gate.test.ts
@@ -202,12 +202,26 @@ describe("proposal summarizers and guard reuse", () => {
     const summarizers = createProposalSummarizers({ intervals: client, tz: "UTC" });
     await expect(
       summarizers.intervals_create_workout!({
+        type: "cycling",
         date: "2030-04-05",
         workout: { name: "Tempo build" },
       }),
     ).resolves.toEqual({ summary: 'Create workout "Tempo build" on 2030-04-05' });
     await expect(summarizers.intervals_create_workout!({})).resolves.toEqual({
       summary: "Create a workout",
+    });
+    await expect(
+      summarizers.intervals_create_workout!({
+        type: "strength",
+        date: "2030-04-06",
+        name: "Lower body 45min",
+        description: "Squat, deadlift",
+      }),
+    ).resolves.toEqual({
+      summary: 'Create strength workout "Lower body 45min" on 2030-04-06',
+    });
+    await expect(summarizers.intervals_create_workout!({ type: "strength" })).resolves.toEqual({
+      summary: "Create a strength workout",
     });
     await expect(summarizers.plan_save!({ plan: {} })).resolves.toEqual({
       summary: "Save the training plan — replaces the current saved plan",

--- a/packages/sport-cycling/src/tools.ts
+++ b/packages/sport-cycling/src/tools.ts
@@ -45,25 +45,61 @@ export const buildPlanSkeletonInputSchema = z.object({
   generalGoalTarget: z.string().optional(),
 });
 
-export const cyclingCreateWorkoutInputSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("cycling"),
+// Flat object rather than a discriminated union: OpenAI-compatible providers
+// (DeepSeek, OpenAI, Qwen, Kimi, …) require every tool's parameters to be a
+// top-level `type: "object"` JSON Schema and reject the root-level `anyOf` that
+// a discriminated union serializes to. Per-`type` field requirements are
+// enforced by the superRefine below instead of by the type-level union.
+export const cyclingCreateWorkoutInputSchema = z
+  .object({
+    type: z
+      .enum(["cycling", "strength"])
+      .describe('"cycling" for structured power steps, "strength" for a free-text session'),
     date: dateKeySchema.describe("Workout date (YYYY-MM-DD)"),
-    workout: intervalsWorkoutInputSchema.describe(
-      "Structured workout: name + ordered steps — simple steps or repeat sets. Use value for a single power target, or low+high for ranges; ramps require low+high. Durations are seconds or minutes only.",
-    ),
-  }),
-  z.object({
-    type: z.literal("strength"),
-    date: dateKeySchema.describe("Workout date (YYYY-MM-DD)"),
-    name: z.string().min(1).max(120).describe("Calendar card title, e.g. 'Lower body 45min'"),
+    workout: intervalsWorkoutInputSchema
+      .optional()
+      .describe(
+        'Required when type is "cycling". Structured workout: name + ordered steps — simple steps or repeat sets. Use value for a single power target, or low+high for ranges; ramps require low+high. Durations are seconds or minutes only.',
+      ),
+    name: z
+      .string()
+      .min(1)
+      .max(120)
+      .optional()
+      .describe('Required when type is "strength". Calendar card title, e.g. \'Lower body 45min\''),
     description: z
       .string()
       .min(1)
       .max(4000)
-      .describe("Free-text session — exercises, sets, reps, weight/RPE."),
-  }),
-]);
+      .optional()
+      .describe('Required when type is "strength". Free-text session — exercises, sets, reps, weight/RPE.'),
+  })
+  .superRefine((val, ctx) => {
+    if (val.type === "cycling") {
+      if (val.workout === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: 'workout is required when type is "cycling"',
+          path: ["workout"],
+        });
+      }
+    } else {
+      if (val.name === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: 'name is required when type is "strength"',
+          path: ["name"],
+        });
+      }
+      if (val.description === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: 'description is required when type is "strength"',
+          path: ["description"],
+        });
+      }
+    }
+  });
 
 export type CyclingCreateWorkoutInput = z.infer<typeof cyclingCreateWorkoutInputSchema>;
 
@@ -182,6 +218,12 @@ export function createCyclingTools(
               const dateError = validateWorkoutCreationDate(input.date, tz);
               if (dateError) return dateError;
               if (input.type === "strength") {
+                if (input.name === undefined || input.description === undefined) {
+                  return {
+                    error: "invalid_workout",
+                    details: 'strength workout requires "name" and "description"',
+                  };
+                }
                 const result = await intervals.events.create({
                   start_date_local: `${input.date}T00:00:00`,
                   category: "WORKOUT",
@@ -192,6 +234,12 @@ export function createCyclingTools(
                 });
                 if (!result.ok) return { error: result.error.kind };
                 return { created: true, event: result.value };
+              }
+              if (input.workout === undefined) {
+                return {
+                  error: "invalid_workout",
+                  details: 'cycling workout requires "workout"',
+                };
               }
               let serialized: ReturnType<typeof serializeIntervalsWorkout>;
               try {

--- a/packages/sport-cycling/src/tools.ts
+++ b/packages/sport-cycling/src/tools.ts
@@ -22,7 +22,6 @@ import type {
   VolumeTier,
   DayOfWeek,
   RaceType,
-  IntervalsWorkoutInput,
 } from "./index.js";
 
 const daysEnum = z.enum(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
@@ -46,12 +45,27 @@ export const buildPlanSkeletonInputSchema = z.object({
   generalGoalTarget: z.string().optional(),
 });
 
-export const cyclingCreateWorkoutInputSchema = z.object({
-  date: dateKeySchema.describe("Workout date (YYYY-MM-DD)"),
-  workout: intervalsWorkoutInputSchema.describe(
-    "Structured workout: name + ordered steps — simple steps or repeat sets. Use value for a single power target, or low+high for ranges; ramps require low+high. Durations are seconds or minutes only.",
-  ),
-});
+export const cyclingCreateWorkoutInputSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("cycling"),
+    date: dateKeySchema.describe("Workout date (YYYY-MM-DD)"),
+    workout: intervalsWorkoutInputSchema.describe(
+      "Structured workout: name + ordered steps — simple steps or repeat sets. Use value for a single power target, or low+high for ranges; ramps require low+high. Durations are seconds or minutes only.",
+    ),
+  }),
+  z.object({
+    type: z.literal("strength"),
+    date: dateKeySchema.describe("Workout date (YYYY-MM-DD)"),
+    name: z.string().min(1).max(120).describe("Calendar card title, e.g. 'Lower body 45min'"),
+    description: z
+      .string()
+      .min(1)
+      .max(4000)
+      .describe("Free-text session — exercises, sets, reps, weight/RPE."),
+  }),
+]);
+
+export type CyclingCreateWorkoutInput = z.infer<typeof cyclingCreateWorkoutInputSchema>;
 
 /**
  * Pure-Sport cycling tools per ADR-0004 — sport-specific math (FTP zones,
@@ -162,11 +176,23 @@ export function createCyclingTools(
       ? {
           intervals_create_workout: tool({
             description:
-              "Create a structured workout on the intervals.icu calendar (auto-syncs to Garmin/Wahoo). Supply structured steps — they serialize into intervals.icu's native syntax so the power chart renders. Put athlete-facing coaching narrative (feel, notes, hydration) in your chat reply, not in this tool. Past dates are refused — workouts can only be created for today or later.",
+              "Create a workout on intervals.icu (auto-syncs to Garmin/Wahoo). type: \"cycling\" — structured steps render as a power chart; put coaching narrative (feel, notes) in your chat reply. type: \"strength\" — free-text description (exercises, sets, reps, weight/RPE) can itself carry the coaching narrative. Past dates refused.",
             inputSchema: zodSchema(cyclingCreateWorkoutInputSchema),
-            execute: async (input: { date: string; workout: IntervalsWorkoutInput }) => {
+            execute: async (input: CyclingCreateWorkoutInput) => {
               const dateError = validateWorkoutCreationDate(input.date, tz);
               if (dateError) return dateError;
+              if (input.type === "strength") {
+                const result = await intervals.events.create({
+                  start_date_local: `${input.date}T00:00:00`,
+                  category: "WORKOUT",
+                  name: input.name,
+                  type: "WeightTraining",
+                  ...buildCoachEventProvenance(input.date, input.name),
+                  description: input.description,
+                });
+                if (!result.ok) return { error: result.error.kind };
+                return { created: true, event: result.value };
+              }
               let serialized: ReturnType<typeof serializeIntervalsWorkout>;
               try {
                 serialized = serializeIntervalsWorkout(input.workout);

--- a/packages/sport-cycling/tests/tools.test.ts
+++ b/packages/sport-cycling/tests/tools.test.ts
@@ -61,7 +61,7 @@ describe("intervals_create_workout provenance", () => {
     const tool = createWorkoutTool(client)!;
     const date = tomorrowISODate();
 
-    const out = await tool.execute({ date, workout: validWorkout }, {});
+    const out = await tool.execute({ type: "cycling", date, workout: validWorkout }, {});
 
     expect(out).toEqual({ created: true, event: { id: 42 } });
     expect(calls).toHaveLength(1);
@@ -74,7 +74,7 @@ describe("intervals_create_workout provenance", () => {
     const { client, calls } = fakeIntervals({ ok: true, value: { id: 1 } });
     const tool = createWorkoutTool(client)!;
 
-    await tool.execute({ date: tomorrowISODate(), workout: validWorkout }, {});
+    await tool.execute({ type: "cycling", date: tomorrowISODate(), workout: validWorkout }, {});
 
     const payload = calls[0];
     expect(payload.type).toBe("Ride");
@@ -94,7 +94,7 @@ describe("intervals_create_workout payload (calendar-payload group)", () => {
     const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
     const tool = createWorkoutTool(client)!;
 
-    await tool.execute({ date: tomorrowISODate(), workout: validWorkout }, {});
+    await tool.execute({ type: "cycling", date: tomorrowISODate(), workout: validWorkout }, {});
 
     const payload = calls[0];
     expect(payload.type).toBe("Ride");
@@ -119,7 +119,7 @@ describe("intervals_create_workout payload (calendar-payload group)", () => {
       ],
     };
 
-    await tool.execute({ date: tomorrowISODate(), workout }, {});
+    await tool.execute({ type: "cycling", date: tomorrowISODate(), workout }, {});
 
     expect(calls[0].description).toContain("ramp 45-65%");
   });
@@ -138,7 +138,7 @@ describe("intervals_create_workout payload (calendar-payload group)", () => {
       ],
     };
 
-    const result = await tool.execute({ date: tomorrowISODate(), workout }, {});
+    const result = await tool.execute({ type: "cycling", date: tomorrowISODate(), workout }, {});
 
     expect(result).toMatchObject({ error: "invalid_workout" });
     expect(calls).toHaveLength(0);
@@ -152,7 +152,7 @@ describe("intervals_create_workout payload (calendar-payload group)", () => {
     const tool = createWorkoutTool(client)!;
 
     const result = await tool.execute(
-      { date: tomorrowISODate(), workout: validWorkout },
+      { type: "cycling", date: tomorrowISODate(), workout: validWorkout },
       {},
     );
 
@@ -228,10 +228,10 @@ describe("intervals_create_workout date guard", () => {
     const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
     const tool = createWorkoutTool(client)!;
     expect(
-      await tool.execute({ date: tomorrowISODate(), workout: validWorkout }, {}),
+      await tool.execute({ type: "cycling", date: tomorrowISODate(), workout: validWorkout }, {}),
     ).toMatchObject({ created: true });
     expect(
-      await tool.execute({ date: todayInTZ("UTC"), workout: validWorkout }, {}),
+      await tool.execute({ type: "cycling", date: todayInTZ("UTC"), workout: validWorkout }, {}),
     ).toMatchObject({ created: true });
     expect(calls).toHaveLength(2);
   });
@@ -239,7 +239,7 @@ describe("intervals_create_workout date guard", () => {
   it("refuses a past date without calling events.create", async () => {
     const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
     const result = await createWorkoutTool(client)!.execute(
-      { date: "2020-01-01", workout: validWorkout },
+      { type: "cycling", date: "2020-01-01", workout: validWorkout },
       {},
     );
     expect(result).toMatchObject({ error: "past_date_refused" });
@@ -251,14 +251,17 @@ describe("intervals_create_workout date guard", () => {
   it("refuses an impossible date and rejects non-YYYY-MM-DD schema input", async () => {
     const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
     const result = await createWorkoutTool(client)!.execute(
-      { date: "2026-02-31", workout: validWorkout },
+      { type: "cycling", date: "2026-02-31", workout: validWorkout },
       {},
     );
     expect(result).toMatchObject({ error: "invalid_date" });
     expect(calls).toHaveLength(0);
     expect(
-      cyclingCreateWorkoutInputSchema.safeParse({ date: "June 15", workout: validWorkout })
-        .success,
+      cyclingCreateWorkoutInputSchema.safeParse({
+        type: "cycling",
+        date: "June 15",
+        workout: validWorkout,
+      }).success,
     ).toBe(false);
   });
 
@@ -269,15 +272,85 @@ describe("intervals_create_workout date guard", () => {
 
     expect(
       await createWorkoutTool(midway.client, "Pacific/Midway")!.execute(
-        { date, workout: validWorkout },
+        { type: "cycling", date, workout: validWorkout },
         {},
       ),
     ).toMatchObject({ created: true });
     expect(
       await createWorkoutTool(kiritimati.client, "Pacific/Kiritimati")!.execute(
-        { date, workout: validWorkout },
+        { type: "cycling", date, workout: validWorkout },
         {},
       ),
     ).toMatchObject({ error: "past_date_refused" });
+  });
+});
+
+describe("intervals_create_workout strength variant", () => {
+  const strengthInput = {
+    type: "strength" as const,
+    name: "Lower body 45min",
+    description: [
+      "Warmup",
+      "- 5m cycling activation",
+      "",
+      "Main",
+      "- Back Squat: 4x6 @ 80kg, rest 2m",
+      "- Romanian Deadlift: 3x8 @ 60kg, rest 90s",
+      "",
+      "Cooldown",
+      "- 5m stretching",
+    ].join("\n"),
+  };
+
+  it("posts type WeightTraining with coach provenance", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 7 } });
+    const tool = createWorkoutTool(client)!;
+    const date = tomorrowISODate();
+
+    const out = await tool.execute({ date, ...strengthInput }, {});
+
+    expect(out).toEqual({ created: true, event: { id: 7 } });
+    expect(calls).toHaveLength(1);
+    const payload = calls[0];
+    expect(payload.type).toBe("WeightTraining");
+    expect(payload.category).toBe("WORKOUT");
+    expect(payload.name).toBe("Lower body 45min");
+    expect(payload.description).toBe(strengthInput.description);
+    expect(payload.external_id).toBe(`cycling-coach:${date}:lower-body-45min`);
+    expect(payload.tags).toEqual(["cycling-coach"]);
+    expect(payload.start_date_local).toBe(`${date}T00:00:00`);
+  });
+
+  it("refuses a past date without calling events.create", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 1 } });
+    const result = await createWorkoutTool(client)!.execute(
+      { date: "2020-01-01", ...strengthInput },
+      {},
+    );
+    expect(result).toMatchObject({ error: "past_date_refused" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("refuses an impossible calendar date", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 1 } });
+    const result = await createWorkoutTool(client)!.execute(
+      { date: "2026-02-31", ...strengthInput },
+      {},
+    );
+    expect(result).toMatchObject({ error: "invalid_date" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("surfaces the API error kind when events.create fails", async () => {
+    const { client, calls } = fakeIntervals({
+      ok: false,
+      error: { kind: "rate_limited" },
+    });
+    const result = await createWorkoutTool(client)!.execute(
+      { date: tomorrowISODate(), ...strengthInput },
+      {},
+    );
+    expect(result).toEqual({ error: "rate_limited" });
+    expect(calls).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Adds a **strength-workout** path to `intervals_create_workout` so the coach can post free-text weights sessions to your intervals.icu calendar, not just structured cycling intervals.

- One tool, two workout kinds, selected by a top-level `type` field (`"cycling" | "strength"`):
  - **cycling** — keeps the structured steps and posts sport type `Ride`.
  - **strength** — takes a free-text `description` (exercises, sets, reps, weight/RPE) and posts type `WeightTraining`.
- The confirmation-gate summarizer branches on `type` to render the correct label. Static-prefix token count stays under its ceiling — no new skill section needed, since the tool description already carries the routing and the coaching-in-description rule for strength.

### Schema shape: flat object, not a discriminated union

The variant is expressed as a **single `z.object`** with `type` as an enum and the per-variant fields optional, with per-`type` requirements enforced by `superRefine` (plus defensive guards in `execute`).

An earlier iteration used a top-level `z.discriminatedUnion`, but that serializes to a root-level `anyOf` with no `type`. OpenAI-compatible providers (DeepSeek, OpenAI, Qwen, Kimi, …) require every tool's parameters to be a top-level `type: "object"` and reject the union with HTTP 400 — `"schema must be a JSON Schema of type object, got type null"` — which breaks **every** tool-bearing turn (not just workout creation, since the schema is sent on every request). Anthropic tolerates the union, so it only surfaced under a non-Anthropic provider. The flat object emits an object-typed, provider-portable schema while preserving identical behavior and validation.

## Test plan

- [x] `pnpm test packages/sport-cycling/tests/tools.test.ts` — routing + validation for both the cycling and strength branches
- [x] `pnpm test packages/core/tests/confirmation-gate.test.ts` — the type-aware summarizer label
- [x] `pnpm check:types` — clean
- [x] Emitted JSON Schema verified to be top-level `type: "object"` (no root `anyOf`), i.e. accepted by OpenAI-compatible providers
- [x] `pnpm run check`
- [x] Manual: exercise a cycling workout create end-to-end (structured steps → Ride)
- [x] Manual: exercise a strength workout create end-to-end (free-text → WeightTraining)

## Notes

- Changeset added (`.changeset/strength-workout-variant.md`, `cycling-coach` patch): _"Coach can now create strength sessions on your intervals.icu calendar — free-text exercises, sets, reps, and RPE go in the description."_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
