### PR TITLE
feat(desktop): rebuild settings in React

### DIFF
--- a/apps/desktop-renderer/app-version.d.mts
+++ b/apps/desktop-renderer/app-version.d.mts
@@ -1,0 +1,2 @@
+export declare function desktopAppVersion(): string;
+export declare function appVersionDefine(): Readonly<Record<string, string>>;

--- a/apps/desktop-renderer/app-version.mjs
+++ b/apps/desktop-renderer/app-version.mjs
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const DESKTOP_PACKAGE_JSON = resolve(import.meta.dirname, "../desktop/package.json");
+
+export function desktopAppVersion() {
+  try {
+    const parsed = JSON.parse(readFileSync(DESKTOP_PACKAGE_JSON, "utf8"));
+    return typeof parsed.version === "string" && parsed.version.length > 0
+      ? parsed.version
+      : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+export function appVersionDefine() {
+  return { __ENDURAGENT_APP_VERSION__: JSON.stringify(desktopAppVersion()) };
+}

--- a/apps/desktop-renderer/src/app-version.ts
+++ b/apps/desktop-renderer/src/app-version.ts
@@ -1,0 +1,2 @@
+export const APP_VERSION: string =
+  typeof __ENDURAGENT_APP_VERSION__ === "string" ? __ENDURAGENT_APP_VERSION__ : "unknown";

--- a/apps/desktop-renderer/src/app/Shell.tsx
+++ b/apps/desktop-renderer/src/app/Shell.tsx
@@ -10,18 +10,14 @@ export function Shell(props: {
   readonly onHostsReady: (hosts: LegacyHosts) => void;
 }): ReactElement {
   const activeView = useEnduragentStore((state) => state.activeView);
-  const noticeHost = useRef<HTMLDivElement>(null);
   const topbar = useRef<HTMLElement>(null);
-  const spendRoot = useRef<HTMLDivElement>(null);
   const spine = useRef<HTMLElement>(null);
   const drawer = useRef<HTMLDialogElement>(null);
   const onHostsReady = props.onHostsReady;
 
   useEffect(() => {
     const hosts = {
-      noticeHost: noticeHost.current,
       topbar: topbar.current,
-      spendRoot: spendRoot.current,
       spine: spine.current,
       drawer: drawer.current,
     };
@@ -33,12 +29,10 @@ export function Shell(props: {
     <div className={styles.win}>
       <Sidebar />
       <div className={styles.main}>
-        <header className={`topbar ${styles.strip}`} ref={topbar}>
-          <div className="spend-meter" ref={spendRoot} />
-        </header>
+        <header className={`topbar ${styles.strip}`} ref={topbar} />
         <div className={styles.views}>
           <div className={activeView === "chat" ? styles.chatRegion : styles.away}>
-            <ChatView noticeHostRef={noticeHost} />
+            <ChatView />
           </div>
           {VIEWS.filter((view) => view.id === activeView && view.page !== REACT_CHAT_REGION).map(
             (view) => {

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -203,6 +203,8 @@ interface WindowEventMap {
   }>;
 }
 
+declare const __ENDURAGENT_APP_VERSION__: string;
+
 declare module "*.module.css" {
   const classes: Readonly<Record<string, string>>;
   export default classes;

--- a/apps/desktop-renderer/src/legacy-boot.ts
+++ b/apps/desktop-renderer/src/legacy-boot.ts
@@ -8,10 +8,6 @@ import { flushSync } from "react-dom";
 import "./styles.css";
 import "./chat/styles.css";
 import "./training-context/styles.css";
-import "./spend-meter/styles.css";
-import "./release-notes/styles.css";
-import "./update/styles.css";
-import "./settings/styles.css";
 import "./onboarding/onboarding.css";
 import "./ride-import.css";
 import { createChatController } from "./chat/controller.js";
@@ -19,29 +15,33 @@ import { createDesktopCoachClientProvider } from "./coach-client.js";
 import { createFirstSyncController } from "./first-sync.js";
 import { createChatViewAdapter } from "./state/adapters/chat.js";
 import { createFirstSyncViewAdapter } from "./state/adapters/first-sync.js";
+import { createReleaseNotesSettingsAdapter } from "./state/adapters/release-notes.js";
+import {
+  createAthleteSettingsAdapter,
+  createConversationSettingsAdapter,
+  createCoachSettingsAdapter,
+  createCredentialSettingsAdapter,
+} from "./state/adapters/settings.js";
+import { createSpendSettingsAdapter } from "./state/adapters/spend.js";
+import { createUpdateSettingsAdapter } from "./state/adapters/update.js";
 import { useEnduragentStore } from "./state/store.js";
 import { validateImportPaths, type OnboardingBridge } from "./onboarding/bridge.js";
 import { createOnboardingCompletionController } from "./onboarding/completion.js";
 import { mountOnboarding } from "./onboarding/mount.js";
-import { createTrainingContextController } from "./training-context/controller.js";
+import {
+  createTrainingContextController,
+  type TrainingContextView,
+} from "./training-context/controller.js";
 import { createManualSyncController } from "./training-context/manual-sync.js";
 import { mountTrainingContextView } from "./training-context/view.js";
 import { createTrainingSyncCoordinator } from "./training-sync.js";
 import { createSpendMeterController } from "./spend-meter/controller.js";
-import { createSpendMeterView } from "./spend-meter/view.js";
 import { createReleaseNotesController } from "./release-notes/controller.js";
-import { createReleaseNotesView } from "./release-notes/view.js";
 import { createDesktopUpdateController } from "./update/controller.js";
-import { createDesktopUpdateView } from "./update/view.js";
 import { createProviderModelSettingsController } from "./settings/provider-model-controller.js";
-import { createProviderModelSettingsView } from "./settings/provider-model-view.js";
 import { createAthleteSettingsController } from "./settings/athlete-controller.js";
-import { createAthleteSettingsView } from "./settings/athlete-view.js";
-import { createResidentSettingsShell } from "./settings/shell.js";
 import { createSessionSettingsController } from "./settings/session-controller.js";
-import { createSessionSettingsView } from "./settings/session-view.js";
 import { createCredentialSettingsController } from "./settings/credential-controller.js";
-import { createCredentialSettingsView } from "./settings/credential-view.js";
 import {
   createRideImportController,
   mountResidentRideImport,
@@ -49,9 +49,7 @@ import {
 } from "./ride-import.js";
 
 export interface LegacyHosts {
-  readonly noticeHost: HTMLElement;
   readonly topbar: HTMLElement;
-  readonly spendRoot: HTMLElement;
   readonly spine: HTMLElement;
   readonly drawer: HTMLDialogElement;
 }
@@ -64,16 +62,17 @@ function focusComposer(): void {
 }
 
 export function bootLegacy(hosts: LegacyHosts): Disposer {
-  const { noticeHost, topbar, spendRoot, spine, drawer } = hosts;
+  const { topbar, spine, drawer } = hosts;
+  const store = useEnduragentStore;
 
   const topbarActions = document.createElement("div");
   topbarActions.className = "topbar-actions";
-  topbar.insertBefore(topbarActions, spendRoot);
+  topbar.append(topbarActions);
   const connectionStatus = document.createElement("span");
   connectionStatus.className = "connection-status";
   connectionStatus.setAttribute("role", "status");
   connectionStatus.textContent = "Connecting…";
-  topbarActions.append(connectionStatus, spendRoot);
+  topbarActions.append(connectionStatus);
   const onLifecycle = (event: WindowEventMap["enduragent-lifecycle"]): void => {
     document.documentElement.dataset.rpc = event.detail.status;
     connectionStatus.textContent =
@@ -86,21 +85,19 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
             : "Closing…";
   };
   window.addEventListener("enduragent-lifecycle", onLifecycle);
+  const releaseNotesAdapter = createReleaseNotesSettingsAdapter({
+    publish: (patch) => store.getState().patchSettings(patch),
+  });
   const releaseNotesController = createReleaseNotesController({
     request: () => window.enduragentAuth.releaseNotes(),
-    view: createReleaseNotesView({
-      document,
-      actionHost: topbarActions,
-      before: connectionStatus,
-    }),
+    view: releaseNotesAdapter.view,
+  });
+  const updateAdapter = createUpdateSettingsAdapter({
+    publish: (next) => store.getState().patchSettings({ update: next }),
   });
   const desktopUpdateController = createDesktopUpdateController({
     bridge: window.enduragentAuth,
-    view: createDesktopUpdateView({
-      document,
-      actionHost: topbarActions,
-      before: connectionStatus,
-    }),
+    view: updateAdapter.view,
   });
   void desktopUpdateController.start();
 
@@ -111,9 +108,23 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     return current === failedClient ? clients.reconnect() : current;
   };
   const mountedTrainingContext = mountTrainingContextView({ spine, drawer });
+  const trainingContextView: TrainingContextView = {
+    render(state) {
+      mountedTrainingContext.view.render(state);
+      const current = store.getState().settings.units;
+      const next = state.unitsPreference;
+      if (
+        current.status !== next.status ||
+        current.value !== next.value ||
+        current.source !== next.source
+      ) {
+        store.getState().patchSettings({ units: next });
+      }
+    },
+  };
   const trainingContextController = createTrainingContextController({
     clients,
-    view: mountedTrainingContext.view,
+    view: trainingContextView,
   });
   const trainingSyncCoordinator = createTrainingSyncCoordinator({
     clients,
@@ -123,14 +134,18 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     coordinator: trainingSyncCoordinator,
     view: mountedTrainingContext.syncView,
   });
+  const spendAdapter = createSpendSettingsAdapter({
+    read: () => store.getState().settings.spend,
+    publish: (next) => store.getState().patchSettings({ spend: next }),
+  });
   const spendController = createSpendMeterController({
     clients,
-    view: createSpendMeterView({ root: spendRoot, noticeHost }),
+    view: spendAdapter.view,
   });
   const chatAdapter = createChatViewAdapter({
     publish: (next) =>
       flushSync(() => {
-        useEnduragentStore.getState().setChatSurface(next);
+        store.getState().setChatSurface(next);
       }),
   });
   const chatController = createChatController({
@@ -149,10 +164,10 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     coordinator: trainingSyncCoordinator,
     focusComposer,
     render: createFirstSyncViewAdapter({
-      publish: (next) => useEnduragentStore.getState().setFirstSync(next),
+      publish: (next) => store.getState().setFirstSync(next),
     }).render,
   });
-  useEnduragentStore.getState().bindChatActions({
+  store.getState().bindChatActions({
     submit: (message) => void chatController.submit(message),
     retry: () => void chatController.retryInterrupted(),
     loadEarlier: () => void chatController.loadEarlier(),
@@ -240,84 +255,81 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     opener: setup,
     onComplete: (completion) => onboardingCompletion.complete(completion),
   });
-  setup.addEventListener(
-    "click",
-    () => void onboardingCompletion.openManually(() => onboarding.open()),
-  );
-  const settingsShell = createResidentSettingsShell({
-    document,
-    actionHost: topbarActions,
-    before: setup,
+  const openSetupFlow = (): void => {
+    void onboardingCompletion.openManually(() => onboarding.open());
+  };
+  setup.addEventListener("click", openSetupFlow);
+  const closePanes = (): void => {
+    providerModelSettingsController.close();
+    credentialSettingsController.close();
+    athleteSettingsController.close();
+    sessionSettingsController.close();
+  };
+  const openSetupFromSettings = (): void => {
+    closePanes();
+    store.getState().leaveSettings();
+    openSetupFlow();
+  };
+  const coachAdapter = createCoachSettingsAdapter({
+    publish: (state) => store.getState().patchSettings({ coach: state }),
   });
-  const providerModelSettingsView = createProviderModelSettingsView({
-    document,
-    shell: settingsShell,
+  const credentialAdapter = createCredentialSettingsAdapter({
+    publish: (state) => store.getState().patchSettings({ credentials: state }),
   });
-  const credentialSettingsView = createCredentialSettingsView({ document, shell: settingsShell });
-  const athleteSettingsView = createAthleteSettingsView({ document, shell: settingsShell });
-  const sessionSettingsView = createSessionSettingsView({ document, shell: settingsShell });
+  const athleteAdapter = createAthleteSettingsAdapter({
+    publish: (state) => store.getState().patchSettings({ athlete: state }),
+  });
+  const conversationAdapter = createConversationSettingsAdapter({
+    publish: (state) => store.getState().patchSettings({ conversation: state }),
+  });
   const sessionSettingsController = createSessionSettingsController({
     clients,
-    beginMutation: () => settingsShell.beginMutation("session"),
-    view: sessionSettingsView,
+    beginMutation: () => store.getState().beginSettingsMutation("session"),
+    view: conversationAdapter.view,
   });
   const credentialSettingsController = createCredentialSettingsController({
     clients,
     loadStatuses: () => window.enduragentAuth.credentialStatuses(),
     loadChatGptStatus: () => window.enduragentAuth.chatgptStatus(),
     deleteCredential: (value) => window.enduragentAuth.deleteCredential(value),
-    openSetup: () => {
-      providerModelSettingsController.close();
-      credentialSettingsController.close();
-      athleteSettingsController.close();
-      sessionSettingsController.close();
-      settingsShell.close();
-      setup.click();
-    },
-    beginMutation: () => settingsShell.beginMutation("credential"),
-    view: credentialSettingsView,
+    openSetup: openSetupFromSettings,
+    beginMutation: () => store.getState().beginSettingsMutation("credential"),
+    view: credentialAdapter.view,
   });
   const athleteSettingsController = createAthleteSettingsController({
     clients,
-    openSetup: () => {
-      providerModelSettingsController.close();
-      credentialSettingsController.close();
-      athleteSettingsController.close();
-      sessionSettingsController.close();
-      settingsShell.close();
-      setup.click();
-    },
-    beginMutation: () => settingsShell.beginMutation("athlete"),
-    view: athleteSettingsView,
+    openSetup: openSetupFromSettings,
+    beginMutation: () => store.getState().beginSettingsMutation("athlete"),
+    view: athleteAdapter.view,
   });
   const providerModelSettingsController = createProviderModelSettingsController({
     load: () => window.enduragentAuth.llmConfiguration(),
     apply: (selection) => window.enduragentAuth.applyLlmSelection(selection),
-    openSetup: () => {
-      providerModelSettingsController.close();
-      credentialSettingsController.close();
-      athleteSettingsController.close();
-      sessionSettingsController.close();
-      settingsShell.close();
-      setup.click();
-    },
-    beginMutation: () => settingsShell.beginMutation("provider-model"),
-    view: providerModelSettingsView,
+    openSetup: openSetupFromSettings,
+    beginMutation: () => store.getState().beginSettingsMutation("provider-model"),
+    view: coachAdapter.view,
   });
-  settingsShell.bind({
-    onOpen() {
-      void providerModelSettingsController.activate();
-      void credentialSettingsController.activate();
-      void athleteSettingsController.activate();
-      void sessionSettingsController.activate();
+  store.getState().bindSettingsPorts({
+    panes: {
+      activate() {
+        void providerModelSettingsController.activate();
+        void credentialSettingsController.activate();
+        void athleteSettingsController.activate();
+        void sessionSettingsController.activate();
+      },
+      close: closePanes,
     },
-    onClose() {
-      providerModelSettingsController.close();
-      credentialSettingsController.close();
-      athleteSettingsController.close();
-      sessionSettingsController.close();
-      settingsShell.close();
+    coach: coachAdapter.port,
+    credentials: credentialAdapter.port,
+    athlete: athleteAdapter.port,
+    conversation: conversationAdapter.port,
+    spend: spendAdapter.port,
+    update: updateAdapter.port,
+    releaseNotes: releaseNotesAdapter.port,
+    units: {
+      set: (value) => void trainingContextController.setUnitsPreference(value),
     },
+    openSetup: openSetupFromSettings,
   });
   const disposeDroppedRideImports = subscribeToDroppedRideImports({
     subscribe: onboardingBridge.onDroppedImportFiles,
@@ -344,7 +356,8 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
   const dispose = (): void => {
     if (disposed) return;
     disposed = true;
-    useEnduragentStore.getState().bindChatActions(null);
+    store.getState().bindChatActions(null);
+    store.getState().bindSettingsPorts(null);
     window.removeEventListener("enduragent-lifecycle", onLifecycle);
     window.removeEventListener("pagehide", dispose);
     releaseNotesController.dispose();
@@ -353,7 +366,6 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     credentialSettingsController.dispose();
     athleteSettingsController.dispose();
     sessionSettingsController.dispose();
-    settingsShell.dispose();
     disposeDroppedRideImports();
     onboarding.dispose();
     residentRideImport.dispose();

--- a/apps/desktop-renderer/src/state/adapters/release-notes.ts
+++ b/apps/desktop-renderer/src/state/adapters/release-notes.ts
@@ -1,0 +1,59 @@
+import type { ReleaseNotesView } from "../../release-notes/controller.js";
+import type { ReleaseNotesSettingsPort, ReleaseNotesSurfaceState } from "../settings-slice.js";
+
+export interface ReleaseNotesSettingsAdapter {
+  readonly view: ReleaseNotesView;
+  readonly port: ReleaseNotesSettingsPort;
+}
+
+export function createReleaseNotesSettingsAdapter(input: {
+  readonly publish: (patch: {
+    readonly releaseNotes?: ReleaseNotesSurfaceState;
+    readonly releaseNotesOpen?: boolean;
+  }) => void;
+}): ReleaseNotesSettingsAdapter {
+  let handlers: Parameters<ReleaseNotesView["bind"]>[0] | undefined;
+  let disposed = false;
+  return {
+    view: {
+      bind(next) {
+        handlers = next;
+      },
+      open() {
+        if (!disposed) input.publish({ releaseNotesOpen: true });
+      },
+      close() {
+        if (!disposed) input.publish({ releaseNotesOpen: false });
+      },
+      renderLoading() {
+        if (!disposed) input.publish({ releaseNotes: { status: "loading" } });
+      },
+      renderAvailable(result) {
+        if (disposed) return;
+        input.publish({
+          releaseNotes: {
+            status: "available",
+            version: result.version,
+            notes: result.notes,
+            releaseUrl: result.releaseUrl,
+          },
+        });
+      },
+      renderUnavailable({ version, releaseUrl }) {
+        if (disposed) return;
+        input.publish({ releaseNotes: { status: "unavailable", version, releaseUrl } });
+      },
+      dispose() {
+        if (disposed) return;
+        disposed = true;
+        handlers = undefined;
+        input.publish({ releaseNotes: { status: "idle" }, releaseNotesOpen: false });
+      },
+    },
+    port: {
+      open: () => handlers?.onOpen(),
+      retry: () => handlers?.onRetry(),
+      close: () => handlers?.onClose(),
+    },
+  };
+}

--- a/apps/desktop-renderer/src/state/adapters/settings.ts
+++ b/apps/desktop-renderer/src/state/adapters/settings.ts
@@ -1,0 +1,153 @@
+import type {
+  AthleteSettingsState,
+  AthleteSettingsView,
+} from "../../settings/athlete-controller.js";
+import type {
+  CredentialSettingsState,
+  CredentialSettingsView,
+} from "../../settings/credential-controller.js";
+import type {
+  ProviderModelSettingsState,
+  ProviderModelSettingsView,
+} from "../../settings/provider-model-controller.js";
+import type {
+  SessionSettingsState,
+  SessionSettingsView,
+} from "../../settings/session-controller.js";
+import {
+  CLOSED_PANE,
+  type AthleteSettingsPort,
+  type CoachSettingsPort,
+  type ConversationSettingsPort,
+  type CredentialSettingsPort,
+} from "../settings-slice.js";
+
+export interface CoachSettingsAdapter {
+  readonly view: ProviderModelSettingsView;
+  readonly port: CoachSettingsPort;
+}
+
+export interface CredentialSettingsAdapter {
+  readonly view: CredentialSettingsView;
+  readonly port: CredentialSettingsPort;
+}
+
+export interface AthleteSettingsAdapter {
+  readonly view: AthleteSettingsView;
+  readonly port: AthleteSettingsPort;
+}
+
+export interface ConversationSettingsAdapter {
+  readonly view: SessionSettingsView;
+  readonly port: ConversationSettingsPort;
+}
+
+export function createCoachSettingsAdapter(input: {
+  readonly publish: (state: ProviderModelSettingsState) => void;
+}): CoachSettingsAdapter {
+  let handlers: Parameters<ProviderModelSettingsView["bind"]>[0] | undefined;
+  return {
+    view: {
+      bind(next) {
+        handlers = next;
+      },
+      open() {},
+      close() {
+        input.publish(CLOSED_PANE);
+      },
+      render(state) {
+        input.publish(state);
+      },
+      dispose() {
+        handlers = undefined;
+        input.publish(CLOSED_PANE);
+      },
+    },
+    port: {
+      retry: () => handlers?.onRetry(),
+      changeProvider: (provider) => handlers?.onProviderChange(provider),
+      changeModel: (model) => handlers?.onModelChange(model),
+      changeCustomModel: (model) => handlers?.onCustomModelChange(model),
+      save: () => handlers?.onSave(),
+      openSetup: () => handlers?.onOpenSetup(),
+    },
+  };
+}
+
+export function createCredentialSettingsAdapter(input: {
+  readonly publish: (state: CredentialSettingsState) => void;
+}): CredentialSettingsAdapter {
+  let handlers: Parameters<CredentialSettingsView["bind"]>[0] | undefined;
+  return {
+    view: {
+      bind(next) {
+        handlers = next;
+      },
+      render(state) {
+        input.publish(state);
+      },
+      dispose() {
+        handlers = undefined;
+        input.publish(CLOSED_PANE);
+      },
+    },
+    port: {
+      retry: () => handlers?.onRetry(),
+      requestDelete: (credential) => handlers?.onRequestDelete(credential),
+      cancelDelete: () => handlers?.onCancelDelete(),
+      confirmDelete: () => handlers?.onConfirmDelete(),
+      openSetup: () => handlers?.onOpenSetup(),
+    },
+  };
+}
+
+export function createAthleteSettingsAdapter(input: {
+  readonly publish: (state: AthleteSettingsState) => void;
+}): AthleteSettingsAdapter {
+  let handlers: Parameters<AthleteSettingsView["bind"]>[0] | undefined;
+  return {
+    view: {
+      bind(next) {
+        handlers = next;
+      },
+      render(state) {
+        input.publish(state);
+      },
+      dispose() {
+        handlers = undefined;
+        input.publish(CLOSED_PANE);
+      },
+    },
+    port: {
+      retry: () => handlers?.onRetry(),
+      change: (value) => handlers?.onChange(value),
+      save: () => handlers?.onSave(),
+      openSetup: () => handlers?.onOpenSetup(),
+    },
+  };
+}
+
+export function createConversationSettingsAdapter(input: {
+  readonly publish: (state: SessionSettingsState) => void;
+}): ConversationSettingsAdapter {
+  let handlers: Parameters<SessionSettingsView["bind"]>[0] | undefined;
+  return {
+    view: {
+      bind(next) {
+        handlers = next;
+      },
+      render(state) {
+        input.publish(state);
+      },
+      dispose() {
+        handlers = undefined;
+        input.publish(CLOSED_PANE);
+      },
+    },
+    port: {
+      retry: () => handlers?.onRetry(),
+      change: (field, value) => handlers?.onChange(field, value),
+      save: () => handlers?.onSave(),
+    },
+  };
+}

--- a/apps/desktop-renderer/src/state/adapters/spend.ts
+++ b/apps/desktop-renderer/src/state/adapters/spend.ts
@@ -1,0 +1,104 @@
+import type { SpendSummary } from "@enduragent/coach-contract";
+import type { SpendMeterView } from "../../spend-meter/controller.js";
+import type { SpendSettingsPort, SpendSurfaceState } from "../settings-slice.js";
+
+export const SPEND_CAP_REACHED_PREFIX = "You’ve reached today’s ";
+
+export function currency(value: number, detail = false): string {
+  if (value === 0) return "$0.00";
+  if (value > 0 && value < 0.01) return detail ? `$${value.toFixed(4)}` : "<$0.01";
+  return `$${value.toFixed(2)}`;
+}
+
+export function capWarningCopy(summary: SpendSummary): string | null {
+  if (summary.capStatus !== "reached") return null;
+  return `${SPEND_CAP_REACHED_PREFIX}${currency(summary.dailyCapUsd)} spend cap. You can keep chatting; this is a warning, not a block.`;
+}
+
+export interface SpendSettingsAdapter {
+  readonly view: SpendMeterView;
+  readonly port: SpendSettingsPort;
+}
+
+export function createSpendSettingsAdapter(input: {
+  readonly read: () => SpendSurfaceState;
+  readonly publish: (next: SpendSurfaceState) => void;
+}): SpendSettingsAdapter {
+  let saveHandler: (() => void) | undefined;
+  let disposed = false;
+  let lastSummary: SpendSummary | undefined;
+
+  const renderSummary = (summary: SpendSummary, options: { readonly stale: boolean }): void => {
+    if (disposed) return;
+    lastSummary = summary;
+    const current = input.read();
+    const keepDraft = current.capDirty && Number(current.capDraft) !== summary.dailyCapUsd;
+    input.publish({
+      ...current,
+      status: "ready",
+      summary,
+      stale: options.stale,
+      capDraft: keepDraft ? current.capDraft : String(summary.dailyCapUsd),
+      capDirty: keepDraft,
+      warning: capWarningCopy(summary),
+    });
+  };
+
+  return {
+    view: {
+      renderLoading() {
+        if (disposed) return;
+        input.publish({
+          ...input.read(),
+          status: "loading",
+          summary: null,
+          stale: false,
+          warning: null,
+        });
+      },
+      renderSummary,
+      renderUnavailable({ hadSummary }) {
+        if (disposed) return;
+        if (hadSummary && lastSummary !== undefined) {
+          renderSummary(lastSummary, { stale: true });
+          return;
+        }
+        input.publish({
+          ...input.read(),
+          status: "unavailable",
+          summary: null,
+          stale: false,
+          warning: null,
+        });
+      },
+      bindSave(handler) {
+        saveHandler = handler;
+      },
+      readDailyCapUsd() {
+        return Number(input.read().capDraft);
+      },
+      setSaving(saving) {
+        if (disposed) return;
+        input.publish({ ...input.read(), saving });
+      },
+      showCapInputError(message) {
+        if (disposed) return;
+        input.publish({ ...input.read(), capError: message });
+      },
+      dispose() {
+        if (disposed) return;
+        disposed = true;
+        saveHandler = undefined;
+        input.publish({ ...input.read(), warning: null });
+      },
+    },
+    port: {
+      changeCap(value) {
+        input.publish({ ...input.read(), capDraft: value, capDirty: true });
+      },
+      save() {
+        saveHandler?.();
+      },
+    },
+  };
+}

--- a/apps/desktop-renderer/src/state/adapters/update.ts
+++ b/apps/desktop-renderer/src/state/adapters/update.ts
@@ -1,0 +1,33 @@
+import type { DesktopUpdateView } from "../../update/controller.js";
+import type { UpdateSettingsPort, UpdateSurfaceState } from "../settings-slice.js";
+
+export interface UpdateSettingsAdapter {
+  readonly view: DesktopUpdateView;
+  readonly port: UpdateSettingsPort;
+}
+
+export function createUpdateSettingsAdapter(input: {
+  readonly publish: (next: UpdateSurfaceState) => void;
+}): UpdateSettingsAdapter {
+  let handler: (() => void) | undefined;
+  let disposed = false;
+  return {
+    view: {
+      bind(next) {
+        handler = next;
+      },
+      render(state, options) {
+        if (disposed) return;
+        input.publish({ state, actionDisabled: options?.actionDisabled === true });
+      },
+      dispose() {
+        if (disposed) return;
+        disposed = true;
+        handler = undefined;
+      },
+    },
+    port: {
+      activate: () => handler?.(),
+    },
+  };
+}

--- a/apps/desktop-renderer/src/state/settings-slice.ts
+++ b/apps/desktop-renderer/src/state/settings-slice.ts
@@ -1,0 +1,214 @@
+import type { SpendSummary, UnitsPreference } from "@enduragent/coach-contract";
+import type { StateCreator } from "zustand";
+import type { DesktopCredentialId } from "../onboarding/bridge.js";
+import type { AthleteSettingsState } from "../settings/athlete-controller.js";
+import type { CredentialSettingsState } from "../settings/credential-controller.js";
+import type { ProviderModelSettingsState } from "../settings/provider-model-controller.js";
+import type { SessionSettingField, SessionSettingsState } from "../settings/session-controller.js";
+import type { UnitsPreferenceViewState } from "../training-context/controller.js";
+import type { DesktopUpdateState } from "../update/controller.js";
+import type { EnduragentState } from "./store.js";
+
+export interface SettingsPanesPort {
+  activate(): void;
+  close(): void;
+}
+
+export interface CoachSettingsPort {
+  retry(): void;
+  changeProvider(provider: string): void;
+  changeModel(model: string): void;
+  changeCustomModel(model: string): void;
+  save(): void;
+  openSetup(): void;
+}
+
+export interface CredentialSettingsPort {
+  retry(): void;
+  requestDelete(credential: DesktopCredentialId): void;
+  cancelDelete(): void;
+  confirmDelete(): void;
+  openSetup(): void;
+}
+
+export interface AthleteSettingsPort {
+  retry(): void;
+  change(value: string): void;
+  save(): void;
+  openSetup(): void;
+}
+
+export interface ConversationSettingsPort {
+  retry(): void;
+  change(field: SessionSettingField, value: string): void;
+  save(): void;
+}
+
+export interface SpendSettingsPort {
+  changeCap(value: string): void;
+  save(): void;
+}
+
+export interface UpdateSettingsPort {
+  activate(): void;
+}
+
+export interface ReleaseNotesSettingsPort {
+  open(): void;
+  retry(): void;
+  close(): void;
+}
+
+export interface UnitsSettingsPort {
+  set(value: UnitsPreference): void;
+}
+
+export interface SettingsPorts {
+  readonly panes: SettingsPanesPort;
+  readonly coach: CoachSettingsPort;
+  readonly credentials: CredentialSettingsPort;
+  readonly athlete: AthleteSettingsPort;
+  readonly conversation: ConversationSettingsPort;
+  readonly spend: SpendSettingsPort;
+  readonly update: UpdateSettingsPort;
+  readonly releaseNotes: ReleaseNotesSettingsPort;
+  readonly units: UnitsSettingsPort;
+  openSetup(): void;
+}
+
+export interface SpendSurfaceState {
+  readonly status: "loading" | "ready" | "unavailable";
+  readonly summary: SpendSummary | null;
+  readonly stale: boolean;
+  readonly capDraft: string;
+  readonly capDirty: boolean;
+  readonly saving: boolean;
+  readonly capError: string | null;
+  readonly warning: string | null;
+}
+
+export interface UpdateSurfaceState {
+  readonly state: DesktopUpdateState;
+  readonly actionDisabled: boolean;
+}
+
+export type ReleaseNotesSurfaceState =
+  | { readonly status: "idle" | "loading" }
+  | {
+      readonly status: "available";
+      readonly version: string;
+      readonly notes: readonly string[];
+      readonly releaseUrl: string;
+    }
+  | {
+      readonly status: "unavailable";
+      readonly version: string | null;
+      readonly releaseUrl: string | null;
+    };
+
+export interface SettingsSurfaceState {
+  readonly savingOwners: readonly string[];
+  readonly coach: ProviderModelSettingsState;
+  readonly credentials: CredentialSettingsState;
+  readonly athlete: AthleteSettingsState;
+  readonly conversation: SessionSettingsState;
+  readonly spend: SpendSurfaceState;
+  readonly update: UpdateSurfaceState;
+  readonly releaseNotes: ReleaseNotesSurfaceState;
+  readonly releaseNotesOpen: boolean;
+  readonly units: UnitsPreferenceViewState;
+}
+
+export const CLOSED_PANE = Object.freeze({ status: "closed" } as const);
+
+export const EMPTY_SPEND_SURFACE: SpendSurfaceState = Object.freeze({
+  status: "loading",
+  summary: null,
+  stale: false,
+  capDraft: "",
+  capDirty: false,
+  saving: false,
+  capError: null,
+  warning: null,
+});
+
+export const EMPTY_UPDATE_SURFACE: UpdateSurfaceState = Object.freeze({
+  state: Object.freeze({ status: "idle" as const }),
+  actionDisabled: false,
+});
+
+export const EMPTY_SETTINGS_SURFACE: SettingsSurfaceState = Object.freeze({
+  savingOwners: Object.freeze([]),
+  coach: CLOSED_PANE,
+  credentials: CLOSED_PANE,
+  athlete: CLOSED_PANE,
+  conversation: CLOSED_PANE,
+  spend: EMPTY_SPEND_SURFACE,
+  update: EMPTY_UPDATE_SURFACE,
+  releaseNotes: Object.freeze({ status: "idle" as const }),
+  releaseNotesOpen: false,
+  units: Object.freeze({
+    status: "loading" as const,
+    value: "metric" as const,
+    source: "default" as const,
+  }),
+});
+
+export interface SettingsSlice {
+  readonly settings: SettingsSurfaceState;
+  readonly settingsPorts: SettingsPorts | null;
+  bindSettingsPorts: (ports: SettingsPorts | null) => void;
+  patchSettings: (patch: Partial<SettingsSurfaceState>) => void;
+  beginSettingsMutation: (owner: string) => (() => void) | null;
+  closeSettingsPanes: () => void;
+  leaveSettings: () => void;
+}
+
+export function settingsMutationActive(state: SettingsSurfaceState): boolean {
+  return state.savingOwners.length > 0;
+}
+
+export const createSettingsSlice: StateCreator<EnduragentState, [], [], SettingsSlice> = (
+  set,
+  get,
+) => ({
+  settings: EMPTY_SETTINGS_SURFACE,
+  settingsPorts: null,
+  bindSettingsPorts(ports) {
+    set({ settingsPorts: ports });
+  },
+  patchSettings(patch) {
+    set({ settings: { ...get().settings, ...patch } });
+  },
+  beginSettingsMutation(owner) {
+    if (settingsMutationActive(get().settings)) return null;
+    set({ settings: { ...get().settings, savingOwners: [owner] } });
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const settings = get().settings;
+      set({
+        settings: {
+          ...settings,
+          savingOwners: settings.savingOwners.filter((entry) => entry !== owner),
+        },
+      });
+    };
+  },
+  closeSettingsPanes() {
+    get().settingsPorts?.panes.close();
+    set({
+      settings: {
+        ...get().settings,
+        coach: CLOSED_PANE,
+        credentials: CLOSED_PANE,
+        athlete: CLOSED_PANE,
+        conversation: CLOSED_PANE,
+      },
+    });
+  },
+  leaveSettings() {
+    set({ activeView: "chat" });
+  },
+});

--- a/apps/desktop-renderer/src/state/store.ts
+++ b/apps/desktop-renderer/src/state/store.ts
@@ -14,8 +14,13 @@ import {
   writeStoredPaletteId,
 } from "../theme/preferences.js";
 import { createChatSlice, type ChatSlice } from "./chat-slice.js";
+import {
+  createSettingsSlice,
+  settingsMutationActive,
+  type SettingsSlice,
+} from "./settings-slice.js";
 
-export interface EnduragentState extends ChatSlice {
+export interface EnduragentState extends ChatSlice, SettingsSlice {
   readonly activeView: ViewId;
   readonly paletteId: string;
   readonly appearance: Appearance;
@@ -39,12 +44,15 @@ function stamp(paletteId: string, appearance: Appearance): ResolvedTheme {
 
 export const useEnduragentStore = create<EnduragentState>((set, get, api) => ({
   ...createChatSlice(set, get, api),
+  ...createSettingsSlice(set, get, api),
   activeView: "chat",
   paletteId: readStoredPaletteId(),
   appearance: readStoredAppearance(),
   theme: resolveTheme(readStoredAppearance()),
   legacyReady: false,
   setActiveView(view) {
+    const current = get();
+    if (current.activeView === "settings" && settingsMutationActive(current.settings)) return;
     set({ activeView: view });
   },
   setPaletteId(paletteId) {

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -93,16 +93,6 @@ input:focus-visible {
   letter-spacing: -0.02em;
 }
 
-.spend-meter {
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.spend-meter strong {
-  margin-left: 8px;
-  color: var(--ink);
-}
-
 .conversation {
   grid-column: 1;
   overflow: auto;

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, type ReactElement, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useRef, type ReactElement } from "react";
 import {
   CHAT_AUTO_LOAD_EARLIER_THRESHOLD,
   chatScrollAnchor,
@@ -8,13 +8,12 @@ import { Composer, type ComposerHandle } from "./Composer.js";
 import { FirstSyncCard } from "./FirstSyncCard.js";
 import { NewConversationDialog } from "./NewConversationDialog.js";
 import { QuickActions } from "./QuickActions.js";
+import { SpendNotice } from "./SpendNotice.js";
 import { Transcript } from "./Transcript.js";
 
 const COMPOSER_CLEARANCE_PROPERTY = "--chat-composer-clearance";
 
-export function ChatView(props: {
-  readonly noticeHostRef: RefObject<HTMLDivElement | null>;
-}): ReactElement {
+export function ChatView(): ReactElement {
   const conversation = useRef<HTMLElement>(null);
   const composerWrap = useRef<HTMLDivElement>(null);
   const composer = useRef<ComposerHandle>(null);
@@ -99,7 +98,7 @@ export function ChatView(props: {
           <p className="new-conversation-status" role="status" aria-live="polite">
             {announcement ?? ""}
           </p>
-          <div className="chat-notice-host__slot" ref={props.noticeHostRef} />
+          <SpendNotice />
         </div>
         <QuickActions />
         <Composer handle={composer} />

--- a/apps/desktop-renderer/src/ui/chat/SpendNotice.module.css
+++ b/apps/desktop-renderer/src/ui/chat/SpendNotice.module.css
@@ -1,0 +1,8 @@
+.notice {
+  margin: 0 0 10px;
+  padding: 10px 12px;
+  border-left: 3px solid var(--danger);
+  border-radius: 8px;
+  color: var(--ink);
+  background: var(--surface);
+}

--- a/apps/desktop-renderer/src/ui/chat/SpendNotice.tsx
+++ b/apps/desktop-renderer/src/ui/chat/SpendNotice.tsx
@@ -1,0 +1,19 @@
+import type { ReactElement } from "react";
+import { useEnduragentStore } from "../../state/store.js";
+import styles from "./SpendNotice.module.css";
+
+export function SpendNotice(): ReactElement {
+  const warning = useEnduragentStore((store) => store.settings.spend.warning);
+
+  return (
+    <p
+      id="spend-cap-warning"
+      className={styles.notice}
+      role="status"
+      aria-live="polite"
+      hidden={warning === null}
+    >
+      {warning ?? ""}
+    </p>
+  );
+}

--- a/apps/desktop-renderer/src/ui/settings/ApplicationSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/ApplicationSection.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useRef, type ReactElement } from "react";
+import { APP_VERSION } from "../../app-version.js";
+import type { DesktopUpdateState } from "../../update/controller.js";
+import { settingsMutationActive } from "../../state/settings-slice.js";
+import { useEnduragentStore } from "../../state/store.js";
+import { RELEASE_NOTES_UNAVAILABLE_COPY } from "./copy.js";
+import styles from "./SettingsView.module.css";
+
+interface UpdateCopy {
+  readonly action: string;
+  readonly label: string;
+  readonly announcement: string;
+}
+
+function updateCopy(state: DesktopUpdateState): UpdateCopy {
+  switch (state.status) {
+    case "disabled":
+      return {
+        action: "Updates unavailable",
+        label: "Updates unavailable",
+        announcement: "Updates unavailable",
+      };
+    case "current":
+      return {
+        action: "Check for updates",
+        label: "Check for updates",
+        announcement: "Enduragent is up to date",
+      };
+    case "checking":
+      return {
+        action: "Checking…",
+        label: "Checking for updates",
+        announcement: "Checking for updates",
+      };
+    case "downloading":
+      return {
+        action: "Downloading…",
+        label: `Downloading update ${state.version}`,
+        announcement: `Downloading update ${state.version}`,
+      };
+    case "downloaded":
+      return {
+        action: "Restart to update",
+        label: `Restart to update to version ${state.version}`,
+        announcement: `Restart to update to version ${state.version}`,
+      };
+    case "installing":
+      return {
+        action: "Restarting…",
+        label: `Restarting to install version ${state.version}`,
+        announcement: `Restarting to install version ${state.version}`,
+      };
+    case "failed":
+      return {
+        action: "Try update again",
+        label: "Try update again",
+        announcement:
+          state.stage === "download"
+            ? "Update download failed. Try again"
+            : "Update check failed. Try again",
+      };
+    default:
+      return {
+        action: "Check for updates",
+        label: "Check for updates",
+        announcement: "Check for updates",
+      };
+  }
+}
+
+export function ApplicationSection(): ReactElement {
+  const update = useEnduragentStore((store) => store.settings.update);
+  const releaseNotes = useEnduragentStore((store) => store.settings.releaseNotes);
+  const releaseNotesOpen = useEnduragentStore((store) => store.settings.releaseNotesOpen);
+  const mutating = useEnduragentStore((store) => settingsMutationActive(store.settings));
+  const ports = useEnduragentStore((store) => store.settingsPorts);
+  const chatActions = useEnduragentStore((store) => store.chatActions);
+  const setActiveView = useEnduragentStore((store) => store.setActiveView);
+  const dialog = useRef<HTMLDialogElement>(null);
+  const closeDialog = useRef<HTMLButtonElement>(null);
+  const opener = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const element = dialog.current;
+    if (element === null) return;
+    if (releaseNotesOpen && !element.open) {
+      element.showModal();
+      closeDialog.current?.focus();
+      return;
+    }
+    if (!releaseNotesOpen && element.open) {
+      element.close();
+      opener.current?.focus();
+    }
+  }, [releaseNotesOpen]);
+
+  const copy = updateCopy(update.state);
+  const updateBusy =
+    update.actionDisabled ||
+    ["disabled", "checking", "downloading", "installing"].includes(update.state.status);
+  const releaseUrl =
+    releaseNotes.status === "available" || releaseNotes.status === "unavailable"
+      ? releaseNotes.releaseUrl
+      : null;
+
+  return (
+    <>
+      <h2 className={styles.heading}>Application</h2>
+      <section className={styles.group} aria-label="Application">
+        <div className={styles.row}>
+          <div className={styles.label}>
+            <div className={styles.rowTitle}>Version {APP_VERSION}</div>
+            <div className={styles.rowDetail}>{copy.announcement}</div>
+            <span className={styles.srOnly} role="status" aria-live="polite" aria-atomic="true">
+              {copy.announcement}
+            </span>
+          </div>
+          {update.state.status === "disabled" ? null : (
+            <button
+              type="button"
+              className={styles.button}
+              title={copy.label}
+              aria-label={copy.label}
+              disabled={updateBusy}
+              onClick={() => {
+                ports?.update.activate();
+              }}
+            >
+              {copy.action}
+            </button>
+          )}
+        </div>
+        <div className={styles.row}>
+          <div className={styles.label}>
+            <div className={styles.rowTitle}>What’s new</div>
+            <div className={styles.rowDetail}>Athlete-facing changes in the latest release</div>
+          </div>
+          <button
+            type="button"
+            ref={opener}
+            className={styles.button}
+            aria-haspopup="dialog"
+            aria-expanded={releaseNotesOpen}
+            onClick={() => {
+              ports?.releaseNotes.open();
+            }}
+          >
+            What’s new
+          </button>
+        </div>
+        <div className={styles.row}>
+          <div className={styles.label}>
+            <div className={styles.rowTitle}>Re-run setup</div>
+            <div className={styles.rowDetail}>
+              Walk through coach keys, training data and the safety intake again
+            </div>
+          </div>
+          <button
+            type="button"
+            className={styles.button}
+            disabled={mutating}
+            onClick={() => {
+              ports?.openSetup();
+            }}
+          >
+            Open setup
+          </button>
+        </div>
+      </section>
+      <h2 className={styles.heading}>Danger</h2>
+      <section className={styles.group} aria-label="Danger">
+        <div className={styles.row}>
+          <div className={styles.label}>
+            <div className={`${styles.rowTitle} ${styles.dangerTitle}`}>Reset conversation</div>
+            <div className={styles.rowDetail}>
+              Clears the visible conversation. Training data and saved coach memory remain.
+            </div>
+          </div>
+          <button
+            type="button"
+            className={`${styles.button} ${styles.danger}`}
+            disabled={chatActions === null || mutating}
+            onClick={() => {
+              setActiveView("chat");
+              chatActions?.openNewConversation();
+            }}
+          >
+            Reset conversation
+          </button>
+        </div>
+      </section>
+      <dialog
+        ref={dialog}
+        className={styles.dialog}
+        aria-labelledby="release-notes-title"
+        aria-modal="true"
+        aria-busy={releaseNotes.status === "loading" ? "true" : undefined}
+        onCancel={(event) => {
+          event.preventDefault();
+          ports?.releaseNotes.close();
+        }}
+      >
+        <header className={styles.dialogHeader}>
+          <h2 id="release-notes-title">
+            {releaseNotes.status === "available"
+              ? `What’s new in ${releaseNotes.version}`
+              : "What’s new"}
+          </h2>
+          <button
+            type="button"
+            ref={closeDialog}
+            className={styles.button}
+            aria-label="Close release notes"
+            onClick={() => {
+              ports?.releaseNotes.close();
+            }}
+          >
+            Close
+          </button>
+        </header>
+        <div className={styles.dialogContent} role="status" aria-live="polite" aria-atomic="true">
+          {releaseNotes.status === "loading" ? <p>Loading release notes…</p> : null}
+          {releaseNotes.status === "idle" ? <p>Loading release notes…</p> : null}
+          {releaseNotes.status === "unavailable" ? <p>{RELEASE_NOTES_UNAVAILABLE_COPY}</p> : null}
+          {releaseNotes.status === "available" ? (
+            releaseNotes.notes.length === 0 ? (
+              <p>No athlete-facing changes were listed for this release.</p>
+            ) : (
+              <ol>
+                {releaseNotes.notes.map((note) => (
+                  <li key={note}>{note}</li>
+                ))}
+              </ol>
+            )
+          ) : null}
+        </div>
+        <footer className={styles.dialogActions}>
+          {releaseNotes.status === "unavailable" ? (
+            <button
+              type="button"
+              className={styles.button}
+              onClick={() => {
+                ports?.releaseNotes.retry();
+              }}
+            >
+              Retry
+            </button>
+          ) : null}
+          {releaseUrl === null ? null : (
+            <a href={releaseUrl} target="_blank" rel="noopener noreferrer">
+              View full release
+            </a>
+          )}
+        </footer>
+      </dialog>
+    </>
+  );
+}

--- a/apps/desktop-renderer/src/ui/settings/CoachSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CoachSection.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useRef, type ReactElement } from "react";
+import {
+  CUSTOM_MODEL_SELECTION,
+  ONBOARDING_LLM_PROVIDER_LABELS,
+} from "../../onboarding/constants.js";
+import type {
+  ProviderModelFormState,
+  ProviderModelSettingsState,
+} from "../../settings/provider-model-controller.js";
+import { settingsMutationActive } from "../../state/settings-slice.js";
+import { useEnduragentStore } from "../../state/store.js";
+import { COACH_SAVE_ERROR_COPY, COACH_VALIDATION_COPY } from "./copy.js";
+import styles from "./SettingsView.module.css";
+
+function formState(state: ProviderModelSettingsState): ProviderModelFormState | null {
+  if (
+    state.status === "ready" ||
+    state.status === "saving" ||
+    state.status === "saved" ||
+    (state.status === "error" && state.kind === "save")
+  ) {
+    return state;
+  }
+  return null;
+}
+
+function modelLabel(form: ProviderModelFormState): string {
+  const draft = form.draft;
+  if (draft === null) return "";
+  if (draft.modelChoice === CUSTOM_MODEL_SELECTION) {
+    return draft.customModel.trim() || "Choose a model";
+  }
+  return (
+    draft.provider.models.find((model) => model.value === draft.modelChoice)?.label ??
+    draft.modelChoice
+  );
+}
+
+function feedbackCopy(state: ProviderModelSettingsState): string | null {
+  if (state.status === "closed" || state.status === "loading") return "Loading coach settings…";
+  if (state.status === "error" && state.kind === "load") {
+    return "Coach settings aren’t available right now. Try again.";
+  }
+  if (state.status === "saving") return "Saving coach settings…";
+  if (state.status === "saved") return "Coach settings saved.";
+  if (state.status === "error" && state.kind === "save") return COACH_SAVE_ERROR_COPY[state.reason];
+  return null;
+}
+
+export function CoachSection(): ReactElement {
+  const state = useEnduragentStore((store) => store.settings.coach);
+  const mutating = useEnduragentStore((store) => settingsMutationActive(store.settings));
+  const port = useEnduragentStore((store) => store.settingsPorts?.coach ?? null);
+  const customModel = useRef<HTMLInputElement>(null);
+  const focusCustomModel = useRef(false);
+
+  const editable = formState(state);
+  const draft = editable?.draft ?? null;
+  const custom = draft?.modelChoice === CUSTOM_MODEL_SELECTION;
+
+  useEffect(() => {
+    if (!focusCustomModel.current) return;
+    focusCustomModel.current = false;
+    if (custom) customModel.current?.focus();
+  }, [custom]);
+
+  const loadError = state.status === "error" && state.kind === "load";
+  const credentialRequired =
+    state.status === "error" && state.kind === "save" && state.reason === "credential-required";
+  const saving = state.status === "saving";
+  const canSave =
+    editable !== null && draft !== null && editable.dirty && editable.validationError === null;
+  const feedback = feedbackCopy(state);
+  const route =
+    editable === null || draft === null
+      ? "Not configured"
+      : `${ONBOARDING_LLM_PROVIDER_LABELS[draft.provider.provider]} → ${modelLabel(editable)}`;
+  const routeState =
+    draft === null ? "Not active" : editable?.dirty === true ? "Unsaved" : "Active";
+  const validation =
+    editable?.validationError == null ? "" : COACH_VALIDATION_COPY[editable.validationError];
+
+  return (
+    <>
+      <h2 className={styles.heading}>Coach</h2>
+      <section className={styles.group} aria-label="Coach">
+        <div className={styles.row}>
+          <div className={styles.label}>
+            <div className={styles.rowTitle}>Coach route</div>
+            <div className={styles.rowDetail}>{route}</div>
+          </div>
+          <span className={styles.runtime} data-state={draft === null ? "failed" : "active"}>
+            {routeState}
+          </span>
+        </div>
+        {editable === null ? null : (
+          <>
+            <div className={styles.row}>
+              <label className={styles.label} htmlFor="coach-provider">
+                <span className={styles.rowTitle}>Provider</span>
+                <span className={styles.rowDetail}>
+                  {editable.active === null
+                    ? "Active coach settings are unavailable or not configured."
+                    : `Currently active: ${ONBOARDING_LLM_PROVIDER_LABELS[editable.active.provider]} · ${editable.active.model}`}
+                </span>
+              </label>
+              <select
+                id="coach-provider"
+                className={styles.control}
+                value={draft?.provider.provider ?? ""}
+                disabled={mutating}
+                onChange={(event) => {
+                  port?.changeProvider(event.target.value);
+                }}
+              >
+                {draft === null ? (
+                  <option value="" disabled>
+                    Choose a provider
+                  </option>
+                ) : null}
+                {editable.providers.map((entry) => (
+                  <option key={entry.provider} value={entry.provider}>
+                    {ONBOARDING_LLM_PROVIDER_LABELS[entry.provider]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className={styles.row}>
+              <label className={styles.label} htmlFor="coach-model">
+                <span className={styles.rowTitle}>Model</span>
+              </label>
+              <select
+                id="coach-model"
+                className={styles.control}
+                value={draft?.modelChoice ?? ""}
+                disabled={mutating || draft === null}
+                onChange={(event) => {
+                  focusCustomModel.current = event.target.value === CUSTOM_MODEL_SELECTION;
+                  port?.changeModel(event.target.value);
+                }}
+              >
+                {draft === null ? (
+                  <option value="">Choose a provider first</option>
+                ) : (
+                  <>
+                    {draft.provider.models.map((entry) => (
+                      <option key={entry.value} value={entry.value}>
+                        {entry.hint === undefined ? entry.label : `${entry.label} · ${entry.hint}`}
+                      </option>
+                    ))}
+                    <option value={CUSTOM_MODEL_SELECTION}>Other model…</option>
+                  </>
+                )}
+              </select>
+            </div>
+            {custom && draft !== null ? (
+              <div className={`${styles.row} ${styles.rowStacked}`}>
+                <label className={styles.rowTitle} htmlFor="coach-custom-model">
+                  Custom model name
+                </label>
+                <input
+                  id="coach-custom-model"
+                  ref={customModel}
+                  type="text"
+                  autoComplete="off"
+                  spellCheck={false}
+                  className={`${styles.control} ${styles.controlWide}`}
+                  value={draft.customModel}
+                  disabled={mutating}
+                  aria-invalid={editable.validationError === null ? undefined : "true"}
+                  aria-describedby="coach-model-validation"
+                  onChange={(event) => {
+                    port?.changeCustomModel(event.target.value);
+                  }}
+                />
+                <p className={styles.error} id="coach-model-validation" aria-live="polite">
+                  {validation}
+                </p>
+              </div>
+            ) : null}
+            <div className={styles.row}>
+              <div className={styles.label}>
+                <div className={styles.rowTitle}>Endpoint</div>
+                <div className={styles.rowDetail}>
+                  Enduragent picks the provider’s endpoint for this route.
+                </div>
+              </div>
+              <span className={styles.amount}>Automatic</span>
+            </div>
+          </>
+        )}
+        {feedback === null ? null : (
+          <p className={styles.feedback} role="status" aria-live="polite" aria-atomic="true">
+            {feedback}
+          </p>
+        )}
+        <div className={styles.actions}>
+          {loadError ? (
+            <button
+              type="button"
+              className={styles.button}
+              disabled={mutating}
+              onClick={() => {
+                port?.retry();
+              }}
+            >
+              Retry
+            </button>
+          ) : null}
+          {credentialRequired ? (
+            <button
+              type="button"
+              className={styles.button}
+              disabled={mutating}
+              onClick={() => {
+                port?.openSetup();
+              }}
+            >
+              Open Setup
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className={`${styles.button} ${styles.primary}`}
+            disabled={mutating || !canSave}
+            onClick={() => {
+              port?.save();
+            }}
+          >
+            {saving ? "Saving…" : "Save coach route"}
+          </button>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/desktop-renderer/src/ui/settings/ConversationSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/ConversationSection.tsx
@@ -1,0 +1,151 @@
+import type { ReactElement } from "react";
+import type {
+  SessionSettingsFormState,
+  SessionSettingsState,
+} from "../../settings/session-controller.js";
+import { settingsMutationActive } from "../../state/settings-slice.js";
+import { useEnduragentStore } from "../../state/store.js";
+import {
+  CONVERSATION_FIELDS,
+  MANAGED_BY_ENVIRONMENT_COPY,
+  conversationSaveErrorCopy,
+} from "./copy.js";
+import styles from "./SettingsView.module.css";
+
+function formState(state: SessionSettingsState): SessionSettingsFormState | null {
+  if (
+    state.status === "ready" ||
+    state.status === "refreshing" ||
+    state.status === "saving" ||
+    state.status === "saved" ||
+    (state.status === "error" && state.kind === "save")
+  ) {
+    return state;
+  }
+  return null;
+}
+
+function feedbackCopy(state: SessionSettingsState): string | null {
+  if (state.status === "closed" || state.status === "loading") {
+    return "Loading conversation settings…";
+  }
+  if (state.status === "refreshing") return "Reconnecting and checking current settings…";
+  if (state.status === "error" && state.kind === "load") {
+    return "Conversation settings aren’t available. Reconnect and reload.";
+  }
+  if (state.status === "saving") return "Saving conversation settings…";
+  if (state.status === "saved") return "Conversation settings saved.";
+  if (state.status === "error" && state.kind === "save") {
+    return conversationSaveErrorCopy(state.reason);
+  }
+  return null;
+}
+
+export function ConversationSection(): ReactElement {
+  const state = useEnduragentStore((store) => store.settings.conversation);
+  const mutating = useEnduragentStore((store) => settingsMutationActive(store.settings));
+  const port = useEnduragentStore((store) => store.settingsPorts?.conversation ?? null);
+
+  const editable = formState(state);
+  const busy =
+    mutating ||
+    state.status === "refreshing" ||
+    state.status === "loading" ||
+    state.status === "closed";
+  const saving = state.status === "saving";
+  const retryVisible = state.status === "error" && (state.kind === "load" || state.kind === "save");
+  const feedback = feedbackCopy(state);
+  const canSave =
+    editable !== null &&
+    editable.dirtyFields.size > 0 &&
+    Object.keys(editable.validationErrors).length === 0;
+
+  return (
+    <>
+      <h2 className={styles.heading}>Conversation &amp; time</h2>
+      <section className={styles.group} aria-label="Conversation and time">
+        <p className={styles.note}>
+          Set when conversations renew and how much recent context your coach carries forward.
+        </p>
+        {editable === null
+          ? null
+          : CONVERSATION_FIELDS.map((definition) => {
+              const managed = editable.effective.managedByEnvironment[definition.field];
+              const error = editable.validationErrors[definition.field];
+              const id = `conversation-${definition.field}`;
+              const describedBy = [
+                `${id}-help`,
+                ...(managed ? [`${id}-managed`] : []),
+                ...(error === undefined ? [] : [`${id}-error`]),
+              ].join(" ");
+              return (
+                <div key={definition.field} className={`${styles.row} ${styles.rowStacked}`}>
+                  <label className={styles.rowTitle} htmlFor={id}>
+                    {definition.label}
+                    {definition.suffix === undefined ? "" : ` (${definition.suffix})`}
+                  </label>
+                  <input
+                    id={id}
+                    type={definition.type}
+                    autoComplete="off"
+                    inputMode={definition.type === "number" ? "decimal" : undefined}
+                    spellCheck={definition.field === "timezone" ? false : undefined}
+                    min={definition.min}
+                    max={definition.max}
+                    step={definition.step}
+                    className={`${styles.control} ${styles.controlWide}`}
+                    value={editable.draft[definition.field]}
+                    disabled={busy || managed}
+                    aria-invalid={error === undefined ? undefined : "true"}
+                    aria-describedby={describedBy}
+                    onChange={(event) => {
+                      port?.change(definition.field, event.target.value);
+                    }}
+                  />
+                  <p className={styles.help} id={`${id}-help`}>
+                    {definition.help}
+                  </p>
+                  {managed ? (
+                    <p className={styles.help} id={`${id}-managed`}>
+                      {MANAGED_BY_ENVIRONMENT_COPY}
+                    </p>
+                  ) : null}
+                  <p className={styles.error} id={`${id}-error`} aria-live="polite">
+                    {error ?? ""}
+                  </p>
+                </div>
+              );
+            })}
+        {feedback === null ? null : (
+          <p className={styles.feedback} role="status" aria-live="polite" aria-atomic="true">
+            {feedback}
+          </p>
+        )}
+        <div className={styles.actions}>
+          {retryVisible ? (
+            <button
+              type="button"
+              className={styles.button}
+              disabled={busy}
+              onClick={() => {
+                port?.retry();
+              }}
+            >
+              Reconnect &amp; reload
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className={`${styles.button} ${styles.primary}`}
+            disabled={busy || !canSave}
+            onClick={() => {
+              port?.save();
+            }}
+          >
+            {saving ? "Saving…" : "Save conversation settings"}
+          </button>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, type ReactElement } from "react";
+import type { DesktopCredentialId } from "../../onboarding/bridge.js";
+import type { CredentialSettingsState } from "../../settings/credential-controller.js";
+import { settingsMutationActive } from "../../state/settings-slice.js";
+import { useEnduragentStore } from "../../state/store.js";
+import { credentialRuntimeLabel } from "./copy.js";
+import styles from "./SettingsView.module.css";
+
+function content(state: CredentialSettingsState) {
+  if (
+    state.status === "ready" ||
+    state.status === "confirming" ||
+    state.status === "deleting" ||
+    state.status === "deleted" ||
+    (state.status === "error" && state.kind === "delete")
+  ) {
+    return state;
+  }
+  return null;
+}
+
+export function CredentialsSection(): ReactElement {
+  const state = useEnduragentStore((store) => store.settings.credentials);
+  const mutating = useEnduragentStore((store) => settingsMutationActive(store.settings));
+  const port = useEnduragentStore((store) => store.settingsPorts?.credentials ?? null);
+  const deleteButtons = useRef(new Map<DesktopCredentialId, HTMLButtonElement>());
+  const confirmationCancel = useRef<HTMLButtonElement>(null);
+  const confirmationDelete = useRef<HTMLButtonElement>(null);
+  const openSetup = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const target = "focus" in state ? state.focus : null;
+    if (target === null || target === undefined) return;
+    if (target.target === "confirmation-cancel") confirmationCancel.current?.focus();
+    else if (target.target === "confirmation-delete") confirmationDelete.current?.focus();
+    else if (target.target === "setup") openSetup.current?.focus();
+    else if (target.target === "delete") deleteButtons.current.get(target.credential)?.focus();
+  }, [state]);
+
+  const entries = content(state)?.entries ?? [];
+  const confirmation = content(state)?.confirmation ?? null;
+  const deleting = state.status === "deleting";
+  const loading = state.status === "closed" || state.status === "loading";
+  const loadError = state.status === "error" && state.kind === "load";
+  const recoveryAvailable = "recoveryAvailable" in state && state.recoveryAvailable;
+  const announcement = loading
+    ? "Loading saved credentials…"
+    : "announcement" in state
+      ? state.announcement
+      : "";
+
+  return (
+    <>
+      <h2 className={styles.heading}>Credentials</h2>
+      <section className={styles.group} aria-label="Credentials">
+        <p className={styles.note}>
+          Review credentials saved on this Mac. Credential values are never shown.
+        </p>
+        {entries.length === 0 ? (
+          <p className={styles.empty}>
+            {loading || loadError ? "" : "No local credentials are stored."}
+          </p>
+        ) : (
+          <ul className={styles.list}>
+            {entries.map((entry) => (
+              <li key={entry.credential} className={styles.item} data-credential={entry.credential}>
+                <div className={styles.itemIdentity}>
+                  <div className={styles.rowTitle}>{entry.provider}</div>
+                  <div className={styles.itemKind}>{entry.kind}</div>
+                </div>
+                <span className={styles.runtime} data-state={entry.runtimeState}>
+                  {credentialRuntimeLabel(entry.runtimeState)}
+                </span>
+                {confirmation === entry.credential ? (
+                  <div
+                    className={styles.confirmation}
+                    role="group"
+                    aria-labelledby={`credential-confirm-${entry.credential}`}
+                  >
+                    <p
+                      className={styles.confirmationTitle}
+                      id={`credential-confirm-${entry.credential}`}
+                    >
+                      Delete the {entry.provider} credential?
+                    </p>
+                    <p className={styles.confirmationCopy}>
+                      This removes it from this Mac only. Enduragent will stop using it if it is
+                      active. Your provider account is unchanged.
+                    </p>
+                    <div className={styles.confirmationActions}>
+                      <button
+                        type="button"
+                        ref={confirmationCancel}
+                        className={styles.button}
+                        disabled={mutating}
+                        onClick={() => {
+                          port?.cancelDelete();
+                        }}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        ref={confirmationDelete}
+                        className={`${styles.button} ${styles.danger}`}
+                        disabled={deleting ? false : mutating}
+                        aria-disabled={deleting ? "true" : undefined}
+                        aria-label={`Confirm deletion of the ${entry.provider} credential`}
+                        onClick={() => {
+                          if (deleting) return;
+                          port?.confirmDelete();
+                        }}
+                      >
+                        Delete credential
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    ref={(element) => {
+                      if (element === null) deleteButtons.current.delete(entry.credential);
+                      else deleteButtons.current.set(entry.credential, element);
+                    }}
+                    className={styles.button}
+                    disabled={mutating}
+                    aria-label={`Delete the ${entry.provider} credential`}
+                    onClick={() => {
+                      port?.requestDelete(entry.credential);
+                    }}
+                  >
+                    Delete
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+        {announcement.length === 0 ? null : (
+          <p className={styles.feedback} role="status" aria-live="polite" aria-atomic="true">
+            {announcement}
+          </p>
+        )}
+        {loadError || recoveryAvailable ? (
+          <div className={styles.actions}>
+            {loadError ? (
+              <button
+                type="button"
+                className={styles.button}
+                disabled={mutating}
+                onClick={() => {
+                  port?.retry();
+                }}
+              >
+                Reconnect &amp; reload
+              </button>
+            ) : null}
+            {recoveryAvailable ? (
+              <button
+                type="button"
+                ref={openSetup}
+                className={styles.button}
+                disabled={mutating}
+                onClick={() => {
+                  port?.openSetup();
+                }}
+              >
+                Open Setup
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </section>
+    </>
+  );
+}

--- a/apps/desktop-renderer/src/ui/settings/PreferencesSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/PreferencesSection.tsx
@@ -1,0 +1,50 @@
+import type { ReactElement } from "react";
+import { useEnduragentStore } from "../../state/store.js";
+import { AppearanceControl } from "./AppearanceControl.js";
+import { PalettePicker } from "./PalettePicker.js";
+import styles from "./SettingsView.module.css";
+import { UnitsControl } from "./UnitsControl.js";
+
+export function PreferencesSection(): ReactElement {
+  const units = useEnduragentStore((store) => store.settings.units);
+
+  return (
+    <>
+      <h2 className={styles.heading}>Preferences</h2>
+      <section className={styles.group} aria-label="Preferences">
+        <div className={styles.row}>
+          <div className={styles.label}>
+            <div className={styles.rowTitle}>Units</div>
+            <div className={styles.rowDetail}>
+              {units.status === "saving"
+                ? "Saving units…"
+                : units.status === "unavailable"
+                  ? "Units preference unavailable"
+                  : "Distance and body mass follow this setting. Cycling power-to-weight remains W/kg."}
+            </div>
+          </div>
+          <UnitsControl />
+        </div>
+        <div className={styles.row}>
+          <div className={styles.label}>
+            <div className={styles.rowTitle}>Appearance</div>
+            <div className={styles.rowDetail}>System follows your macOS light and dark setting</div>
+          </div>
+          <AppearanceControl />
+        </div>
+      </section>
+      <h2 className={styles.heading}>Palette</h2>
+      <section className={styles.group} aria-label="Palette">
+        <div className={styles.row}>
+          <div className={styles.label}>
+            <div className={styles.rowTitle}>App palette</div>
+            <div className={styles.rowDetail}>
+              Changes both themes immediately · Patrol is the default
+            </div>
+          </div>
+        </div>
+        <PalettePicker />
+      </section>
+    </>
+  );
+}

--- a/apps/desktop-renderer/src/ui/settings/SettingsView.module.css
+++ b/apps/desktop-renderer/src/ui/settings/SettingsView.module.css
@@ -24,6 +24,12 @@
   border-bottom: 1px solid var(--line);
 }
 
+.rowStacked {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+
 .row:last-child {
   border-bottom: 0;
 }
@@ -42,4 +48,347 @@
   margin-top: 1px;
   color: var(--ink-2);
   font-size: 12.5px;
+}
+
+.dangerTitle {
+  color: var(--danger);
+}
+
+.status {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ok);
+}
+
+.dot[data-tone="warn"] {
+  background: var(--warn);
+}
+
+.dot[data-tone="danger"] {
+  background: var(--danger);
+}
+
+.button {
+  flex: none;
+  padding: 6px 13px;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--ink);
+  background: var(--surface-2);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.button:hover:not(:disabled) {
+  border-color: var(--ink-3);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.primary {
+  border-color: var(--brand);
+  color: var(--brand-ink);
+  background: var(--brand);
+}
+
+.danger {
+  border-color: var(--danger);
+  color: var(--danger);
+  background: none;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+  padding: 13px 16px;
+  border-top: 1px solid var(--line);
+}
+
+.control {
+  flex: none;
+  min-width: 0;
+  max-width: 260px;
+  padding: 6px 10px;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--ink);
+  background: var(--surface-2);
+  font: inherit;
+  font-size: 13px;
+}
+
+.control:disabled {
+  opacity: 0.55;
+}
+
+.controlWide {
+  max-width: none;
+  width: 100%;
+}
+
+.feedback {
+  margin: 0;
+  padding: 11px 16px;
+  border-top: 1px solid var(--line);
+  color: var(--ink-2);
+  font-size: 12.5px;
+}
+
+.error {
+  margin: 4px 0 0;
+  color: var(--danger);
+  font-size: 12.5px;
+}
+
+.help {
+  margin: 4px 0 0;
+  color: var(--ink-2);
+  font-size: 12.5px;
+}
+
+.note {
+  margin: 0;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink-2);
+  font-size: 13px;
+}
+
+.empty {
+  margin: 0;
+  padding: 13px 16px;
+  color: var(--ink-2);
+  font-size: 13px;
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.item:last-child {
+  border-bottom: 0;
+}
+
+.itemIdentity {
+  flex: 1;
+  min-width: 0;
+}
+
+.itemKind {
+  color: var(--ink-2);
+  font-size: 12.5px;
+}
+
+.runtime {
+  flex: none;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: var(--sunk);
+  color: var(--ink-2);
+  font-size: 11.5px;
+}
+
+.runtime[data-state="active"] {
+  color: var(--ok);
+}
+
+.runtime[data-state="failed"] {
+  color: var(--danger);
+}
+
+.confirmation {
+  flex: 1 0 100%;
+  padding: 12px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r);
+  background: var(--sunk);
+}
+
+.confirmationTitle {
+  margin: 0;
+  font-size: 13.5px;
+  font-weight: 560;
+}
+
+.confirmationCopy {
+  margin: 4px 0 10px;
+  color: var(--ink-2);
+  font-size: 12.5px;
+}
+
+.confirmationActions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.bareRow {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  width: 100%;
+}
+
+.meter {
+  appearance: none;
+  display: block;
+  overflow: hidden;
+  width: 100%;
+  height: 3px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--line);
+}
+
+.meter::-webkit-progress-bar {
+  border-radius: 999px;
+  background: var(--line);
+}
+
+.meter::-webkit-progress-value {
+  border-radius: 999px;
+  background: var(--ok);
+}
+
+.group[data-cap-status="reached"] .meter::-webkit-progress-value {
+  background: var(--danger);
+}
+
+.capError {
+  flex: 1 0 100%;
+}
+
+.amount {
+  flex: none;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+
+.routes {
+  padding: 0 16px 4px;
+}
+
+.route {
+  padding: 11px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.route:last-child {
+  border-bottom: 0;
+}
+
+.routeHeading {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 560;
+}
+
+.routeDetail {
+  margin: 3px 0 0;
+  color: var(--ink-2);
+  font-size: 12.5px;
+}
+
+.capEditor {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  padding: 13px 16px;
+  border-top: 1px solid var(--line);
+}
+
+.capLabel {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 560;
+}
+
+.srOnly {
+  position: absolute;
+  overflow: hidden;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  white-space: nowrap;
+}
+
+.dialog {
+  width: min(520px, calc(100vw - 48px));
+  max-height: min(70vh, 620px);
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  color: var(--ink);
+  background: var(--surface);
+}
+
+.dialog::backdrop {
+  background: rgb(0 0 0 / 38%);
+}
+
+.dialogHeader {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.dialogHeader h2 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.dialogContent {
+  margin-top: 12px;
+  color: var(--ink-2);
+  font-size: 13.5px;
+}
+
+.dialogContent ol {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.dialogContent li {
+  margin-bottom: 6px;
+}
+
+.dialogActions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.dialogActions a {
+  color: var(--brand);
+  font-size: 13px;
 }

--- a/apps/desktop-renderer/src/ui/settings/SettingsView.tsx
+++ b/apps/desktop-renderer/src/ui/settings/SettingsView.tsx
@@ -1,36 +1,37 @@
-import type { ReactElement } from "react";
+import { useEffect, type ReactElement } from "react";
+import { settingsMutationActive } from "../../state/settings-slice.js";
+import { useEnduragentStore } from "../../state/store.js";
 import { Page } from "../shared/Page.js";
-import { AppearanceControl } from "./AppearanceControl.js";
-import { PalettePicker } from "./PalettePicker.js";
-import styles from "./SettingsView.module.css";
+import { ApplicationSection } from "./ApplicationSection.js";
+import { CoachSection } from "./CoachSection.js";
+import { ConversationSection } from "./ConversationSection.js";
+import { CredentialsSection } from "./CredentialsSection.js";
+import { PreferencesSection } from "./PreferencesSection.js";
+import { SpendSection } from "./SpendSection.js";
+import { TrainingAccountSection } from "./TrainingAccountSection.js";
 
 export function SettingsView(): ReactElement {
+  const ports = useEnduragentStore((store) => store.settingsPorts);
+  const busy = useEnduragentStore((store) => settingsMutationActive(store.settings));
+  const closeSettingsPanes = useEnduragentStore((store) => store.closeSettingsPanes);
+
+  useEffect(() => {
+    if (ports === null) return;
+    ports.panes.activate();
+    return () => {
+      closeSettingsPanes();
+    };
+  }, [closeSettingsPanes, ports]);
+
   return (
-    <Page title="Settings">
-      <div className={styles.heading}>Preferences</div>
-      <div className={styles.group}>
-        <div className={styles.row}>
-          <div className={styles.label}>
-            <div className={styles.rowTitle}>Appearance</div>
-            <div className={styles.rowDetail}>
-              System follows your macOS light and dark setting
-            </div>
-          </div>
-          <AppearanceControl />
-        </div>
-      </div>
-      <div className={styles.heading}>Palette</div>
-      <div className={styles.group}>
-        <div className={styles.row}>
-          <div className={styles.label}>
-            <div className={styles.rowTitle}>App palette</div>
-            <div className={styles.rowDetail}>
-              Changes both themes immediately · Patrol is the default
-            </div>
-          </div>
-        </div>
-        <PalettePicker />
-      </div>
+    <Page title="Settings" subtitle={busy ? "Saving…" : undefined} busy={busy}>
+      <CoachSection />
+      <CredentialsSection />
+      <TrainingAccountSection />
+      <ConversationSection />
+      <SpendSection />
+      <PreferencesSection />
+      <ApplicationSection />
     </Page>
   );
 }

--- a/apps/desktop-renderer/src/ui/settings/SpendSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/SpendSection.tsx
@@ -1,0 +1,141 @@
+import type { SpendRouteSummary, SpendSummary } from "@enduragent/coach-contract";
+import type { ReactElement } from "react";
+import { currency } from "../../state/adapters/spend.js";
+import { useEnduragentStore } from "../../state/store.js";
+import styles from "./SettingsView.module.css";
+
+function localDateLabel(value: string): string {
+  const [, month, day] = value.split("-").map(Number);
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(Date.UTC(2000, (month ?? 1) - 1, day ?? 1)));
+}
+
+function routeCache(route: SpendRouteSummary): string {
+  if (route.cacheReadTokens === 0) return "No cache reads";
+  if (route.cacheReadSavingsUsd === null) {
+    return `${route.cacheReadTokens.toLocaleString("en-US")} cache-read tokens · savings unavailable`;
+  }
+  return `${route.cacheReadTokens.toLocaleString("en-US")} cache-read tokens · Saved ${currency(route.cacheReadSavingsUsd, true)}`;
+}
+
+function routeCaching(route: SpendRouteSummary): string {
+  if (route.caching === "explicit") return "Explicit caching on this route.";
+  if (route.caching === "provider-dependent") {
+    return "Provider-dependent caching; no explicit breakpoint on this route.";
+  }
+  return route.disclosure ?? "";
+}
+
+function notices(summary: SpendSummary, stale: boolean): readonly string[] {
+  const messages: string[] = [];
+  if (!summary.spendComplete) {
+    messages.push("Some provider costs are unavailable, so today’s total is a known minimum.");
+  }
+  if (summary.malformedLineCount > 0) messages.push("Some usage records could not be read.");
+  messages.push(
+    `${summary.cacheSavingsComplete ? "Saved" : "Saved at least"} ${currency(summary.knownCacheReadSavingsUsd, true)} with cache reads`,
+  );
+  if (stale) messages.push("Spend data may be out of date.");
+  return messages;
+}
+
+export function SpendSection(): ReactElement {
+  const spend = useEnduragentStore((store) => store.settings.spend);
+  const port = useEnduragentStore((store) => store.settingsPorts?.spend ?? null);
+  const summary = spend.summary;
+  const known =
+    summary === null
+      ? "—"
+      : `${currency(summary.knownSpendUsd)}${summary.spendComplete ? "" : "+"}`;
+  const cap = summary === null ? "—" : currency(summary.dailyCapUsd);
+
+  return (
+    <>
+      <h2 className={styles.heading}>Spending</h2>
+      <section
+        className={styles.group}
+        aria-label="Spending"
+        data-spend-meter=""
+        data-cap-status={summary?.capStatus}
+      >
+        <div className={`${styles.row} ${styles.rowStacked}`}>
+          <div className={styles.bareRow}>
+            <div className={styles.label}>
+              <div className={styles.rowTitle}>
+                {summary === null ? "Today" : `Today · ${localDateLabel(summary.localDate)}`}
+              </div>
+              <div className={styles.rowDetail}>
+                {spend.status === "unavailable"
+                  ? "Spend data unavailable."
+                  : "Language model spend against today’s cap"}
+              </div>
+            </div>
+            <strong className={styles.amount}>{`${known} / ${cap}`}</strong>
+          </div>
+          <progress
+            className={styles.meter}
+            aria-label="Daily spend cap"
+            aria-valuetext={summary === null ? undefined : `${known} of ${cap}`}
+            max={summary?.dailyCapUsd ?? 1}
+            value={summary === null ? 0 : Math.min(summary.knownSpendUsd, summary.dailyCapUsd)}
+          />
+        </div>
+        {summary === null
+          ? null
+          : notices(summary, spend.stale).map((message) => (
+              <p key={message} className={styles.note}>
+                {message}
+              </p>
+            ))}
+        {summary === null || summary.routes.length === 0 ? null : (
+          <div className={styles.routes} aria-label="Spend details">
+            {summary.routes.map((route) => (
+              <article key={`${route.provider}/${route.model}`} className={styles.route}>
+                <p className={styles.routeHeading}>{`${route.provider} · ${route.model}`}</p>
+                <p className={styles.routeDetail}>
+                  {`${currency(route.knownSpendUsd, true)} · ${route.pricedGenerationCount}/${route.generationCount} generations priced`}
+                </p>
+                <p className={styles.routeDetail}>{routeCache(route)}</p>
+                <p className={styles.routeDetail}>{routeCaching(route)}</p>
+              </article>
+            ))}
+          </div>
+        )}
+        <div className={styles.capEditor}>
+          <label className={styles.capLabel} htmlFor="daily-spend-cap">
+            Daily cap (USD)
+          </label>
+          <input
+            id="daily-spend-cap"
+            type="number"
+            step="any"
+            inputMode="decimal"
+            className={styles.control}
+            value={spend.capDraft}
+            onChange={(event) => {
+              port?.changeCap(event.target.value);
+            }}
+          />
+          <button
+            type="button"
+            className={`${styles.button} ${styles.primary}`}
+            disabled={spend.saving}
+            onClick={() => {
+              port?.save();
+            }}
+          >
+            Save cap
+          </button>
+          {spend.capError === null ? null : (
+            <p className={`${styles.error} ${styles.capError}`} role="status">
+              {spend.capError}
+            </p>
+          )}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/desktop-renderer/src/ui/settings/TrainingAccountSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/TrainingAccountSection.tsx
@@ -1,0 +1,170 @@
+import type { ReactElement } from "react";
+import type {
+  AthleteSettingsFormState,
+  AthleteSettingsState,
+} from "../../settings/athlete-controller.js";
+import { settingsMutationActive } from "../../state/settings-slice.js";
+import { useEnduragentStore } from "../../state/store.js";
+import {
+  ATHLETE_SAVE_ERROR_COPY,
+  ATHLETE_VALIDATION_COPY,
+  MANAGED_BY_ENVIRONMENT_COPY,
+} from "./copy.js";
+import styles from "./SettingsView.module.css";
+
+function formState(state: AthleteSettingsState): AthleteSettingsFormState | null {
+  if (
+    state.status === "ready" ||
+    state.status === "refreshing" ||
+    state.status === "saving" ||
+    state.status === "saved" ||
+    (state.status === "error" && state.kind === "save")
+  ) {
+    return state;
+  }
+  return null;
+}
+
+function feedbackCopy(state: AthleteSettingsState): string | null {
+  if (state.status === "closed" || state.status === "loading") {
+    return "Loading training account settings…";
+  }
+  if (state.status === "refreshing") {
+    return "Reconnecting and checking the current training account…";
+  }
+  if (state.status === "error" && state.kind === "load") {
+    return "Training account settings aren’t available. Reconnect and reload.";
+  }
+  if (state.status === "saving") return "Saving athlete ID…";
+  if (state.status === "saved") return "Athlete ID saved.";
+  if (state.status === "error" && state.kind === "save") {
+    return ATHLETE_SAVE_ERROR_COPY[state.reason];
+  }
+  return null;
+}
+
+export function TrainingAccountSection(): ReactElement {
+  const state = useEnduragentStore((store) => store.settings.athlete);
+  const mutating = useEnduragentStore((store) => settingsMutationActive(store.settings));
+  const port = useEnduragentStore((store) => store.settingsPorts?.athlete ?? null);
+
+  const editable = formState(state);
+  const busy =
+    mutating ||
+    state.status === "refreshing" ||
+    state.status === "loading" ||
+    state.status === "closed";
+  const externallyManaged = editable?.effective.managedByEnvironment.athleteId === true;
+  const credentialMissing = editable !== null && !editable.effective.credential_configured;
+  const locked = editable === null || credentialMissing || externallyManaged;
+  const saving = state.status === "saving";
+  const retryVisible = state.status === "error" && (state.kind === "load" || state.kind === "save");
+  const credentialRequired =
+    credentialMissing ||
+    (state.status === "error" && state.kind === "save" && state.reason === "credential-required");
+  const validation =
+    editable?.validationError == null ? "" : ATHLETE_VALIDATION_COPY[editable.validationError];
+  const feedback = feedbackCopy(state);
+  const describedBy = [
+    "athlete-id-help",
+    ...(externallyManaged ? ["athlete-id-managed"] : []),
+    ...(credentialMissing ? ["athlete-id-credential"] : []),
+    ...(validation.length > 0 ? ["athlete-id-validation"] : []),
+  ].join(" ");
+
+  return (
+    <>
+      <h2 className={styles.heading}>Training account</h2>
+      <section className={styles.group} aria-label="Training account">
+        <p className={styles.note}>
+          This may only identify the currently connected training account. It cannot switch
+          accounts.
+        </p>
+        {editable === null ? null : (
+          <div className={`${styles.row} ${styles.rowStacked}`}>
+            <label className={styles.rowTitle} htmlFor="athlete-id">
+              Athlete ID
+            </label>
+            <input
+              id="athlete-id"
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              className={`${styles.control} ${styles.controlWide}`}
+              value={editable.draft}
+              disabled={busy || locked}
+              aria-invalid={editable.validationError === null ? undefined : "true"}
+              aria-describedby={describedBy}
+              onChange={(event) => {
+                port?.change(event.target.value);
+              }}
+            />
+            <p className={styles.help} id="athlete-id-help">
+              Use the exact identifier associated with the credential already connected in Setup.
+            </p>
+            {externallyManaged ? (
+              <p className={styles.help} id="athlete-id-managed">
+                {MANAGED_BY_ENVIRONMENT_COPY}
+              </p>
+            ) : null}
+            {credentialMissing ? (
+              <p className={styles.help} id="athlete-id-credential">
+                No training account credential is connected. Open Setup to connect one.
+              </p>
+            ) : null}
+            <p className={styles.error} id="athlete-id-validation" aria-live="polite">
+              {validation}
+            </p>
+          </div>
+        )}
+        {feedback === null ? null : (
+          <p className={styles.feedback} role="status" aria-live="polite" aria-atomic="true">
+            {feedback}
+          </p>
+        )}
+        <div className={styles.actions}>
+          {retryVisible ? (
+            <button
+              type="button"
+              className={styles.button}
+              disabled={busy}
+              onClick={() => {
+                port?.retry();
+              }}
+            >
+              Reconnect &amp; reload
+            </button>
+          ) : null}
+          {credentialRequired ? (
+            <button
+              type="button"
+              className={styles.button}
+              disabled={busy}
+              onClick={() => {
+                port?.openSetup();
+              }}
+            >
+              Open Setup
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className={`${styles.button} ${styles.primary}`}
+            disabled={
+              busy ||
+              editable === null ||
+              !editable.dirty ||
+              editable.validationError !== null ||
+              locked
+            }
+            onClick={() => {
+              port?.save();
+            }}
+          >
+            {saving ? "Saving…" : "Save athlete ID"}
+          </button>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/desktop-renderer/src/ui/settings/UnitsControl.tsx
+++ b/apps/desktop-renderer/src/ui/settings/UnitsControl.tsx
@@ -1,0 +1,39 @@
+import type { UnitsPreference } from "@enduragent/coach-contract";
+import type { ReactElement } from "react";
+import { useEnduragentStore } from "../../state/store.js";
+import AppearanceStyles from "./AppearanceControl.module.css";
+
+const OPTIONS: readonly { readonly value: UnitsPreference; readonly label: string }[] =
+  Object.freeze([
+    { value: "metric", label: "Metric" },
+    { value: "imperial", label: "Imperial" },
+  ]);
+
+export function UnitsControl(): ReactElement {
+  const units = useEnduragentStore((store) => store.settings.units);
+  const port = useEnduragentStore((store) => store.settingsPorts?.units ?? null);
+  const disabled = port === null || units.status === "loading" || units.status === "saving";
+
+  return (
+    <div className={AppearanceStyles.seg} role="group" aria-label="Display units">
+      {OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          className={
+            option.value === units.value
+              ? `${AppearanceStyles.option} ${AppearanceStyles.on}`
+              : AppearanceStyles.option
+          }
+          aria-pressed={option.value === units.value}
+          disabled={disabled}
+          onClick={() => {
+            port?.set(option.value);
+          }}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop-renderer/src/ui/settings/copy.ts
+++ b/apps/desktop-renderer/src/ui/settings/copy.ts
@@ -1,0 +1,122 @@
+import type {
+  AthleteSettingsSaveError,
+  AthleteSettingsValidationError,
+} from "../../settings/athlete-controller.js";
+import type { CredentialSettingsEntry } from "../../settings/credential-controller.js";
+import type { ProviderModelValidationError } from "../../settings/provider-model-controller.js";
+import type { SessionSettingField } from "../../settings/session-controller.js";
+
+export const COACH_VALIDATION_COPY: Readonly<Record<ProviderModelValidationError, string>> = {
+  "model-required": "Enter a model name.",
+  "model-too-long": "Model names must be 512 characters or fewer.",
+  "model-control-characters": "Model names can’t contain control characters.",
+};
+
+export const COACH_SAVE_ERROR_COPY = {
+  "invalid-input": "That provider or model wasn’t accepted. Check the model name and try again.",
+  "credential-required":
+    "This provider needs a saved credential before it can coach you. Open Setup to add one.",
+  "runtime-unavailable": "Coach settings couldn’t become active. Try saving again.",
+  "request-failed": "Coach settings couldn’t be saved right now. Try again.",
+} as const;
+
+export const ATHLETE_VALIDATION_COPY: Readonly<Record<AthleteSettingsValidationError, string>> = {
+  "athlete-required": "Enter the athlete ID for the connected training account.",
+  "athlete-whitespace": "Athlete IDs cannot begin or end with whitespace.",
+  "athlete-too-long": "Athlete IDs must be 512 characters or fewer.",
+  "athlete-control-characters": "Athlete IDs can’t contain control characters.",
+};
+
+export const ATHLETE_SAVE_ERROR_COPY: Readonly<Record<AthleteSettingsSaveError, string>> = {
+  "credential-required": "Connect the training account in Setup before saving its athlete ID.",
+  "ownership-unavailable":
+    "The connected training account couldn’t be verified. Reconnect and reload before trying again.",
+  "training-account-mismatch":
+    "That athlete ID does not identify the currently connected training account.",
+  "managed-by-environment": "The athlete ID is managed outside Enduragent and wasn’t changed.",
+  "request-failed": "The athlete ID couldn’t be saved. Your edit is still here.",
+  "not-applied": "The athlete ID wasn’t applied. Reconnect and reload before trying again.",
+  "runtime-unavailable":
+    "The current training account couldn’t be reloaded. Your edit is still here.",
+};
+
+export const MANAGED_BY_ENVIRONMENT_COPY =
+  "Managed by an environment variable. Change it outside Enduragent.";
+
+export interface ConversationFieldDefinition {
+  readonly field: SessionSettingField;
+  readonly label: string;
+  readonly help: string;
+  readonly type: "text" | "number";
+  readonly min?: string;
+  readonly max?: string;
+  readonly step?: string;
+  readonly suffix?: string;
+}
+
+export const CONVERSATION_FIELDS: readonly ConversationFieldDefinition[] = [
+  {
+    field: "timezone",
+    label: "Timezone",
+    help: "Use an IANA timezone, such as Europe/London. This is the current system truth.",
+    type: "text",
+  },
+  {
+    field: "dailyResetHour",
+    label: "Daily reset hour",
+    help: "Athlete-local hour, from 0 to 23. A change may make your next message start a fresh conversation.",
+    type: "number",
+    min: "0",
+    max: "23",
+    step: "1",
+  },
+  {
+    field: "idleMinutes",
+    label: "Idle reset",
+    help: "Whole minutes without a message before the conversation resets. Use 0 to turn this off.",
+    type: "number",
+    min: "0",
+    step: "1",
+    suffix: "minutes",
+  },
+  {
+    field: "resetArchiveRetentionDays",
+    label: "Archive retention",
+    help: "Whole days to keep reset archives. Use 0 to keep them forever; changes apply only to future pruning.",
+    type: "number",
+    min: "0",
+    step: "1",
+    suffix: "days",
+  },
+  {
+    field: "historyTokenBudgetRatio",
+    label: "History budget",
+    help: "Share of the model context reserved for conversation history, above 0% and up to 100%.",
+    type: "number",
+    min: "0",
+    max: "100",
+    step: "any",
+    suffix: "%",
+  },
+] as const;
+
+export function conversationSaveErrorCopy(
+  reason: "request-failed" | "not-applied" | "runtime-unavailable",
+): string {
+  if (reason === "not-applied") {
+    return "Conversation settings weren’t applied. Reconnect and reload before trying again.";
+  }
+  if (reason === "runtime-unavailable") {
+    return "Current conversation settings couldn’t be reloaded. Your edits are still here.";
+  }
+  return "Conversation settings couldn’t be saved. Your edits are still here.";
+}
+
+export function credentialRuntimeLabel(state: CredentialSettingsEntry["runtimeState"]): string {
+  if (state === "active") return "Active";
+  if (state === "stored-inactive") return "Saved, not active";
+  return "Needs attention";
+}
+
+export const RELEASE_NOTES_UNAVAILABLE_COPY =
+  "Release notes aren’t available right now. Check your connection and try again.";

--- a/apps/desktop-renderer/src/ui/shared/Page.tsx
+++ b/apps/desktop-renderer/src/ui/shared/Page.tsx
@@ -4,10 +4,15 @@ import styles from "./Page.module.css";
 export function Page(props: {
   readonly title: string;
   readonly subtitle?: string;
+  readonly busy?: boolean;
   readonly children: ReactNode;
 }): ReactElement {
   return (
-    <section className={styles.page} aria-label={props.title}>
+    <section
+      className={styles.page}
+      aria-label={props.title}
+      aria-busy={props.busy === true ? "true" : undefined}
+    >
       <div className={styles.bar}>
         <h1 className={styles.title}>{props.title}</h1>
         {props.subtitle === undefined ? null : (

--- a/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, type ReactElement } from "react";
 import { VIEWS } from "../../app/views.js";
 import { registerNewConversationOpener } from "../../state/new-conversation-opener.js";
+import { settingsMutationActive } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
 import styles from "./Sidebar.module.css";
 
@@ -10,7 +11,9 @@ export function Sidebar(): ReactElement {
   const unavailable = useEnduragentStore((state) => state.chat.newConversationUnavailable);
   const resetPhase = useEnduragentStore((state) => state.chat.resetPhase);
   const actions = useEnduragentStore((state) => state.chatActions);
+  const settingsBusy = useEnduragentStore((state) => settingsMutationActive(state.settings));
   const opener = useRef<HTMLButtonElement>(null);
+  const navigationLocked = activeView === "settings" && settingsBusy;
 
   useEffect(() => {
     registerNewConversationOpener(opener.current);
@@ -29,7 +32,7 @@ export function Sidebar(): ReactElement {
           type="button"
           ref={opener}
           className={`${styles.newButton} new-conversation-button`}
-          disabled={actions === null || (unavailable && !focusableUncertain)}
+          disabled={navigationLocked || actions === null || (unavailable && !focusableUncertain)}
           aria-disabled={focusableUncertain ? "true" : undefined}
           onClick={() => {
             if (focusableUncertain) return;
@@ -50,6 +53,7 @@ export function Sidebar(): ReactElement {
             type="button"
             className={view.id === activeView ? `${styles.navItem} ${styles.on}` : styles.navItem}
             aria-current={view.id === activeView ? "page" : undefined}
+            disabled={navigationLocked && view.id !== activeView}
             onClick={() => {
               setActiveView(view.id);
             }}
@@ -66,6 +70,7 @@ export function Sidebar(): ReactElement {
         <button
           type="button"
           className={activeView === "chat" ? `${styles.histItem} ${styles.on}` : styles.histItem}
+          disabled={navigationLocked}
           onClick={() => {
             setActiveView("chat");
           }}

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -1,5 +1,5 @@
 import { act, render } from "@testing-library/react";
-import { useRef, type ReactElement } from "react";
+import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ChatView, ChatViewControls } from "../src/chat/controller.js";
 import { mergeHydratedMessages } from "../src/chat/hydration.js";
@@ -291,10 +291,9 @@ function Probe(): null {
 }
 
 function Harness(): ReactElement {
-  const noticeHost = useRef<HTMLDivElement>(null);
   return (
     <>
-      <ChatSurface noticeHostRef={noticeHost} />
+      <ChatSurface />
       <Probe />
     </>
   );

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useRef, type ReactElement } from "react";
+import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Shell } from "../src/app/Shell.js";
 import {
@@ -37,8 +37,7 @@ function setChat(patch: Partial<ChatSurfaceState>): void {
 }
 
 function Harness(): ReactElement {
-  const noticeHost = useRef<HTMLDivElement>(null);
-  return <ChatView noticeHostRef={noticeHost} />;
+  return <ChatView />;
 }
 
 function composer(): HTMLTextAreaElement {

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -1,0 +1,607 @@
+import type { CoachClient } from "@enduragent/coach-client";
+import type { RuntimeConfigSnapshot, SpendSummary } from "@enduragent/coach-contract";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
+import type {
+  CredentialDeleteResult,
+  OnboardingLlmConfiguration,
+  OnboardingLlmSelection,
+  OnboardingLlmSelectionResult,
+} from "../src/onboarding/bridge.js";
+import type { ChatGptStatus, CredentialSlotStatus } from "../src/onboarding/machine.js";
+import { createReleaseNotesController } from "../src/release-notes/controller.js";
+import { createAthleteSettingsController } from "../src/settings/athlete-controller.js";
+import { createCredentialSettingsController } from "../src/settings/credential-controller.js";
+import { createProviderModelSettingsController } from "../src/settings/provider-model-controller.js";
+import { createSessionSettingsController } from "../src/settings/session-controller.js";
+import { createSpendMeterController } from "../src/spend-meter/controller.js";
+import { createReleaseNotesSettingsAdapter } from "../src/state/adapters/release-notes.js";
+import {
+  createAthleteSettingsAdapter,
+  createCoachSettingsAdapter,
+  createConversationSettingsAdapter,
+  createCredentialSettingsAdapter,
+} from "../src/state/adapters/settings.js";
+import { createSpendSettingsAdapter } from "../src/state/adapters/spend.js";
+import { createUpdateSettingsAdapter } from "../src/state/adapters/update.js";
+import { EMPTY_SETTINGS_SURFACE } from "../src/state/settings-slice.js";
+import { useEnduragentStore } from "../src/state/store.js";
+import type { DesktopUpdateState } from "../src/update/controller.js";
+import { createDesktopUpdateController } from "../src/update/controller.js";
+import { SettingsView } from "../src/ui/settings/SettingsView.js";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function snapshot(overrides: Partial<RuntimeConfigSnapshot> = {}): RuntimeConfigSnapshot {
+  return {
+    schemaVersion: 3,
+    llm: { provider: "anthropic", model: "synthetic-model", credential_configured: true },
+    intervals: {
+      athlete_id: "i1",
+      credential_configured: true,
+      managedByEnvironment: { athleteId: false },
+    },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+      managedByEnvironment: {
+        historyTokenBudgetRatio: false,
+        idleMinutes: false,
+        dailyResetHour: false,
+        resetArchiveRetentionDays: false,
+        timezone: false,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function llmConfiguration(): OnboardingLlmConfiguration {
+  return {
+    schemaVersion: 1,
+    providers: [
+      {
+        provider: "anthropic",
+        defaultModel: "synthetic-model",
+        models: [
+          { value: "synthetic-model", label: "Synthetic" },
+          { value: "synthetic-fast", label: "Synthetic fast", hint: "cheap" },
+        ],
+      },
+      {
+        provider: "openrouter",
+        defaultModel: "vendor/synthetic",
+        models: [{ value: "vendor/synthetic", label: "Vendor synthetic" }],
+      },
+    ],
+    active: { provider: "anthropic", model: "synthetic-model" },
+  };
+}
+
+function spendSummary(overrides: Partial<SpendSummary> = {}): SpendSummary {
+  return {
+    localDate: "1998-07-06",
+    timezone: "UTC",
+    dailyCapUsd: 0.5,
+    knownSpendUsd: 0.6,
+    generationCount: 2,
+    pricedGenerationCount: 1,
+    unpricedGenerationCount: 1,
+    malformedLineCount: 0,
+    spendComplete: false,
+    capStatus: "reached",
+    cacheReadTokens: 400,
+    knownCacheReadSavingsUsd: 0,
+    cacheSavingsComplete: false,
+    routes: [
+      {
+        provider: "openrouter",
+        model: "anthropic/synthetic",
+        generationCount: 2,
+        pricedGenerationCount: 1,
+        unpricedGenerationCount: 1,
+        providerReportedGenerationCount: 1,
+        knownSpendUsd: 0.6,
+        cacheReadTokens: 400,
+        cacheReadSavingsUsd: null,
+        caching: "unavailable",
+        disclosure: "caching unavailable on this route",
+      },
+    ],
+    ...overrides,
+  } as SpendSummary;
+}
+
+interface HarnessOptions {
+  readonly runtime?: () => RuntimeConfigSnapshot;
+  readonly configureRuntime?: (params: unknown) => Promise<unknown>;
+  readonly applyLlmSelection?: (
+    selection: OnboardingLlmSelection,
+  ) => Promise<OnboardingLlmSelectionResult>;
+  readonly credentialStatuses?: readonly CredentialSlotStatus[];
+  readonly chatGptStatus?: ChatGptStatus;
+  readonly deleteCredential?: () => Promise<CredentialDeleteResult>;
+  readonly releaseNotes?: () => Promise<ReleaseNotesResult>;
+  readonly updateState?: DesktopUpdateState;
+  readonly spend?: () => Promise<SpendSummary>;
+}
+
+function createHarness(options: HarnessOptions = {}) {
+  const store = useEnduragentStore;
+  const calls: { readonly method: string; readonly params: unknown }[] = [];
+  const runtime = options.runtime ?? (() => snapshot());
+  const client = {
+    call: vi.fn(async (method: string, params: unknown) => {
+      calls.push({ method, params });
+      if (method === "getRuntimeConfig") return runtime();
+      if (method === "configureRuntime") {
+        return options.configureRuntime === undefined
+          ? {
+              schemaVersion: 3,
+              status: "applied",
+              applied: { llm: true, intervals: true, session: true },
+            }
+          : await options.configureRuntime(params);
+      }
+      if (method === "getSpendSummary") {
+        return options.spend === undefined ? spendSummary() : await options.spend();
+      }
+      if (method === "setDailySpendCap") {
+        const cap = (params as { readonly dailyCapUsd: number }).dailyCapUsd;
+        return spendSummary({ dailyCapUsd: cap, capStatus: "unknown" });
+      }
+      throw new TypeError(`unexpected rpc ${method}`);
+    }),
+  } as unknown as CoachClient;
+  const clients: DesktopCoachClientProvider = {
+    getClient: async () => client,
+    reconnect: async () => client,
+    close: async () => {},
+  };
+
+  const restartToUpdate = vi.fn(
+    async (): Promise<DesktopUpdateState> => ({ status: "installing", version: "9.9.9" }),
+  );
+  const checkForUpdates = vi.fn(async (): Promise<DesktopUpdateState> => ({ status: "current" }));
+  const applyLlmSelection = vi.fn(
+    options.applyLlmSelection ??
+      (async (): Promise<OnboardingLlmSelectionResult> => ({
+        status: "configured",
+        runtimeReady: true,
+      })),
+  );
+  const deleteCredential = vi.fn(
+    options.deleteCredential ??
+      (async (): Promise<CredentialDeleteResult> => ({
+        credential: "openrouter",
+        status: "deleted",
+        cleanupPending: false,
+      })),
+  );
+  const openSetup = vi.fn();
+
+  const coachAdapter = createCoachSettingsAdapter({
+    publish: (state) => store.getState().patchSettings({ coach: state }),
+  });
+  const credentialAdapter = createCredentialSettingsAdapter({
+    publish: (state) => store.getState().patchSettings({ credentials: state }),
+  });
+  const athleteAdapter = createAthleteSettingsAdapter({
+    publish: (state) => store.getState().patchSettings({ athlete: state }),
+  });
+  const conversationAdapter = createConversationSettingsAdapter({
+    publish: (state) => store.getState().patchSettings({ conversation: state }),
+  });
+  const spendAdapter = createSpendSettingsAdapter({
+    read: () => store.getState().settings.spend,
+    publish: (next) => store.getState().patchSettings({ spend: next }),
+  });
+  const updateAdapter = createUpdateSettingsAdapter({
+    publish: (next) => store.getState().patchSettings({ update: next }),
+  });
+  const releaseNotesAdapter = createReleaseNotesSettingsAdapter({
+    publish: (patch) => store.getState().patchSettings(patch),
+  });
+
+  const conversationController = createSessionSettingsController({
+    clients,
+    beginMutation: () => store.getState().beginSettingsMutation("session"),
+    view: conversationAdapter.view,
+  });
+  const credentialController = createCredentialSettingsController({
+    clients,
+    loadStatuses: async () =>
+      options.credentialStatuses ?? [
+        { slot: "anthropic", state: "configured", runtimeState: "active" },
+        { slot: "openrouter", state: "configured", runtimeState: "stored-inactive" },
+      ],
+    loadChatGptStatus: async () =>
+      options.chatGptStatus ?? { state: "absent", runtimeReady: false },
+    deleteCredential,
+    openSetup,
+    beginMutation: () => store.getState().beginSettingsMutation("credential"),
+    view: credentialAdapter.view,
+  });
+  const athleteController = createAthleteSettingsController({
+    clients,
+    openSetup,
+    beginMutation: () => store.getState().beginSettingsMutation("athlete"),
+    view: athleteAdapter.view,
+  });
+  const coachController = createProviderModelSettingsController({
+    load: async () => llmConfiguration(),
+    apply: applyLlmSelection,
+    openSetup,
+    beginMutation: () => store.getState().beginSettingsMutation("provider-model"),
+    view: coachAdapter.view,
+  });
+  const spendController = createSpendMeterController({
+    clients,
+    view: spendAdapter.view,
+    setInterval: (() => 0) as unknown as typeof globalThis.setInterval,
+    clearInterval: (() => {}) as unknown as typeof globalThis.clearInterval,
+  });
+  const updateController = createDesktopUpdateController({
+    bridge: {
+      getUpdateState: async () => options.updateState ?? { status: "idle" },
+      checkForUpdates,
+      restartToUpdate,
+      onUpdateState: () => () => {},
+    },
+    view: updateAdapter.view,
+  });
+  const releaseNotesController = createReleaseNotesController({
+    request:
+      options.releaseNotes ??
+      (async () => ({
+        status: "available",
+        version: "1998.7.6",
+        notes: ["Added a synthetic quick action."],
+        releaseUrl: "https://example.invalid/release",
+      })),
+    view: releaseNotesAdapter.view,
+  });
+
+  store.getState().bindSettingsPorts({
+    panes: {
+      activate() {
+        void coachController.activate();
+        void credentialController.activate();
+        void athleteController.activate();
+        void conversationController.activate();
+      },
+      close() {
+        coachController.close();
+        credentialController.close();
+        athleteController.close();
+        conversationController.close();
+      },
+    },
+    coach: coachAdapter.port,
+    credentials: credentialAdapter.port,
+    athlete: athleteAdapter.port,
+    conversation: conversationAdapter.port,
+    spend: spendAdapter.port,
+    update: updateAdapter.port,
+    releaseNotes: releaseNotesAdapter.port,
+    units: { set: vi.fn() },
+    openSetup,
+  });
+
+  return {
+    calls,
+    applyLlmSelection,
+    deleteCredential,
+    restartToUpdate,
+    checkForUpdates,
+    openSetup,
+    spendController,
+    startUpdate: () => updateController.start(),
+    dispose() {
+      coachController.dispose();
+      credentialController.dispose();
+      athleteController.dispose();
+      conversationController.dispose();
+      spendController.dispose();
+      updateController.dispose();
+      releaseNotesController.dispose();
+      store.getState().bindSettingsPorts(null);
+    },
+  };
+}
+
+let harness: ReturnType<typeof createHarness> | undefined;
+
+beforeEach(() => {
+  useEnduragentStore.setState({
+    activeView: "settings",
+    settings: EMPTY_SETTINGS_SURFACE,
+    settingsPorts: null,
+    chatActions: null,
+  });
+});
+
+afterEach(() => {
+  harness?.dispose();
+  harness = undefined;
+  useEnduragentStore.setState({
+    activeView: "chat",
+    settings: EMPTY_SETTINGS_SURFACE,
+    settingsPorts: null,
+  });
+});
+
+async function renderSettings(options: HarnessOptions = {}) {
+  harness = createHarness(options);
+  render(<SettingsView />);
+  await screen.findByRole("button", { name: "Save coach route" });
+  await waitFor(() => {
+    expect(useEnduragentStore.getState().settings.coach.status).toBe("ready");
+    expect(useEnduragentStore.getState().settings.conversation.status).toBe("ready");
+    expect(useEnduragentStore.getState().settings.credentials.status).toBe("ready");
+  });
+  return harness;
+}
+
+describe("settings mutation lock", () => {
+  it("disables other panes and blocks leaving Settings while one pane saves", async () => {
+    const user = userEvent.setup();
+    const pending = deferred<unknown>();
+    const subject = await renderSettings({
+      configureRuntime: () => pending.promise,
+    });
+
+    await user.clear(screen.getByLabelText("Idle reset (minutes)"));
+    await user.type(screen.getByLabelText("Idle reset (minutes)"), "45");
+    await user.click(screen.getByRole("button", { name: "Save conversation settings" }));
+
+    await waitFor(() => {
+      expect(useEnduragentStore.getState().settings.savingOwners).toEqual(["session"]);
+    });
+    expect(screen.getByRole("region", { name: "Settings" })).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByRole("button", { name: "Save athlete ID" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: /Provider/u })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Open setup" })).toBeDisabled();
+
+    act(() => {
+      useEnduragentStore.getState().setActiveView("chat");
+    });
+    expect(useEnduragentStore.getState().activeView).toBe("settings");
+
+    await act(async () => {
+      pending.resolve({
+        schemaVersion: 3,
+        status: "applied",
+        applied: { llm: true, intervals: true, session: true },
+      });
+      await pending.promise;
+    });
+    await waitFor(() => {
+      expect(useEnduragentStore.getState().settings.savingOwners).toEqual([]);
+    });
+    expect(screen.getByRole("region", { name: "Settings" })).not.toHaveAttribute("aria-busy");
+    expect(subject.calls.some((call) => call.method === "configureRuntime")).toBe(true);
+  });
+});
+
+describe("conversation settings", () => {
+  it("sends only the dirty fields", async () => {
+    const user = userEvent.setup();
+    const subject = await renderSettings();
+
+    await user.clear(screen.getByLabelText("Idle reset (minutes)"));
+    await user.type(screen.getByLabelText("Idle reset (minutes)"), "45");
+    await user.click(screen.getByRole("button", { name: "Save conversation settings" }));
+
+    await waitFor(() => {
+      expect(subject.calls.filter((call) => call.method === "configureRuntime")).toHaveLength(1);
+    });
+    expect(subject.calls.find((call) => call.method === "configureRuntime")?.params).toEqual({
+      session: { idleMinutes: 45 },
+    });
+  });
+
+  it("keeps a managed field read-only", async () => {
+    await renderSettings({
+      runtime: () =>
+        snapshot({
+          session: {
+            ...snapshot().session,
+            managedByEnvironment: {
+              ...snapshot().session.managedByEnvironment,
+              timezone: true,
+            },
+          },
+        }),
+    });
+
+    expect(screen.getByLabelText("Timezone")).toBeDisabled();
+    expect(
+      screen.getAllByText("Managed by an environment variable. Change it outside Enduragent."),
+    ).not.toHaveLength(0);
+  });
+});
+
+describe("credential deletion", () => {
+  it("confirms in two steps and restores focus when cancelled", async () => {
+    const user = userEvent.setup();
+    const subject = await renderSettings();
+
+    const remove = screen.getByRole("button", { name: "Delete the OpenRouter credential" });
+    await user.click(remove);
+
+    expect(screen.getByText("Delete the OpenRouter credential?")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+    });
+    expect(subject.deleteCredential).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Delete the OpenRouter credential" }),
+      ).toHaveFocus();
+    });
+    expect(screen.getByText("Credential deletion cancelled.")).toBeInTheDocument();
+  });
+
+  it("deletes on the second confirmation and announces the outcome", async () => {
+    const user = userEvent.setup();
+    const subject = await renderSettings();
+
+    await user.click(screen.getByRole("button", { name: "Delete the OpenRouter credential" }));
+    await user.click(
+      screen.getByRole("button", { name: "Confirm deletion of the OpenRouter credential" }),
+    );
+
+    await waitFor(() => {
+      expect(subject.deleteCredential).toHaveBeenCalledWith({ credential: "openrouter" });
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Credential deleted locally.")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("coach route", () => {
+  it("saves a custom model through the sentinel option", async () => {
+    const user = userEvent.setup();
+    const subject = await renderSettings();
+
+    await user.selectOptions(screen.getByRole("combobox", { name: /^Model$/u }), "__custom__");
+    const custom = await screen.findByLabelText("Custom model name");
+    await waitFor(() => {
+      expect(custom).toHaveFocus();
+    });
+    await user.type(custom, "vendor/experimental");
+    await user.click(screen.getByRole("button", { name: "Save coach route" }));
+
+    await waitFor(() => {
+      expect(subject.applyLlmSelection).toHaveBeenCalledWith({
+        provider: "anthropic",
+        model: "vendor/experimental",
+        endpoint: { mode: "automatic" },
+      });
+    });
+    expect(await screen.findByText("Coach settings saved.")).toBeInTheDocument();
+  });
+
+  it("offers Open Setup when the provider needs a credential", async () => {
+    const user = userEvent.setup();
+    const subject = await renderSettings({
+      applyLlmSelection: async () => ({ status: "refused", reason: "credential-required" }),
+    });
+
+    await user.selectOptions(screen.getByRole("combobox", { name: /Provider/u }), "openrouter");
+    await user.click(screen.getByRole("button", { name: "Save coach route" }));
+
+    const openSetup = await screen.findByRole("button", { name: "Open Setup" });
+    await user.click(openSetup);
+    expect(subject.openSetup).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("application section", () => {
+  it("runs the update action the state calls for", async () => {
+    const user = userEvent.setup();
+    const subject = await renderSettings({
+      updateState: { status: "downloaded", version: "1998.7.7" },
+    });
+    await act(async () => {
+      await subject.startUpdate();
+    });
+
+    const action = await screen.findByRole("button", {
+      name: "Restart to update to version 1998.7.7",
+    });
+    await user.click(action);
+
+    await waitFor(() => {
+      expect(subject.restartToUpdate).toHaveBeenCalledTimes(1);
+    });
+    expect(subject.checkForUpdates).not.toHaveBeenCalled();
+  });
+
+  it("opens release notes and offers a retry when they are unavailable", async () => {
+    const user = userEvent.setup();
+    let attempts = 0;
+    await renderSettings({
+      releaseNotes: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("synthetic release notes failure");
+        return {
+          status: "available",
+          version: "1998.7.6",
+          notes: ["Added a synthetic quick action."],
+          releaseUrl: "https://example.invalid/release",
+        };
+      },
+    });
+
+    await user.click(screen.getByRole("button", { name: "What’s new" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      await within(dialog).findByText(
+        "Release notes aren’t available right now. Check your connection and try again.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("button", { name: "Retry" }));
+    expect(await within(dialog).findByText("Added a synthetic quick action.")).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "What’s new in 1998.7.6" })).toBeVisible();
+
+    await user.click(within(dialog).getByRole("button", { name: "Close release notes" }));
+    await waitFor(() => {
+      expect(useEnduragentStore.getState().settings.releaseNotesOpen).toBe(false);
+    });
+  });
+});
+
+describe("spending", () => {
+  it("publishes the cap warning for the chat surface and saves a new cap", async () => {
+    const user = userEvent.setup();
+    const subject = await renderSettings();
+    act(() => {
+      subject.spendController.start();
+    });
+    await waitFor(() => {
+      expect(useEnduragentStore.getState().settings.spend.summary).not.toBeNull();
+    });
+
+    expect(useEnduragentStore.getState().settings.spend.warning).toBe(
+      "You’ve reached today’s $0.50 spend cap. You can keep chatting; this is a warning, not a block.",
+    );
+    expect(screen.getByText("$0.60+ / $0.50")).toBeInTheDocument();
+
+    const cap = screen.getByLabelText("Daily cap (USD)");
+    await user.clear(cap);
+    await user.type(cap, "0.75");
+    await user.click(screen.getByRole("button", { name: "Save cap" }));
+
+    await waitFor(() => {
+      expect(subject.calls.filter((call) => call.method === "setDailySpendCap")).toEqual([
+        { method: "setDailySpendCap", params: { dailyCapUsd: 0.75 } },
+      ]);
+    });
+    await waitFor(() => {
+      expect(useEnduragentStore.getState().settings.spend.warning).toBeNull();
+    });
+  });
+});

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -56,9 +56,7 @@ describe("shell", () => {
 
     expect(onHostsReady).toHaveBeenCalledTimes(1);
     const hosts = onHostsReady.mock.calls[0][0];
-    expect(hosts.noticeHost.classList.contains("chat-notice-host__slot")).toBe(true);
     expect(hosts.topbar.classList.contains("topbar")).toBe(true);
-    expect(hosts.spendRoot.classList.contains("spend-meter")).toBe(true);
     expect(hosts.spine.classList.contains("data-spine")).toBe(true);
     expect(hosts.drawer).toBeInstanceOf(HTMLDialogElement);
     expect(hosts.drawer.getAttribute("aria-label")).toBe("Training data");
@@ -87,13 +85,13 @@ describe("shell", () => {
     const onHostsReady = vi.fn<(hosts: LegacyHosts) => void>();
     render(<Shell onHostsReady={onHostsReady} />);
     const thread = document.querySelector("div.thread");
-    const noticeHost = onHostsReady.mock.calls[0][0].noticeHost;
+    const noticeHost = document.querySelector("div.chat-notice-host");
 
     await user.click(screen.getByRole("button", { name: "Settings" }));
     await screen.findByRole("region", { name: "Settings" });
 
     expect(thread?.isConnected).toBe(true);
-    expect(noticeHost.isConnected).toBe(true);
+    expect(noticeHost?.isConnected).toBe(true);
     expect(document.querySelector("textarea#message")).not.toBeNull();
     expect(onHostsReady).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop-renderer/vite.config.ts
+++ b/apps/desktop-renderer/vite.config.ts
@@ -2,11 +2,13 @@ import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { configDefaults } from "vitest/config";
+import { appVersionDefine } from "./app-version.mjs";
 
 const rendererRoot = import.meta.dirname;
 
 export default defineConfig({
   plugins: [react()],
+  define: appVersionDefine(),
   build: {
     outDir: "dist",
     emptyOutDir: true,

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+import { appVersionDefine } from "../desktop-renderer/app-version.mjs";
 
 const desktopRoot = import.meta.dirname;
 
@@ -28,6 +29,7 @@ export default defineConfig({
   renderer: {
     root: resolve(desktopRoot, "../desktop-renderer"),
     plugins: [react()],
+    define: appVersionDefine(),
     build: {
       outDir: resolve(desktopRoot, "out/renderer"),
       emptyOutDir: true,

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1189,7 +1189,6 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly settingsResident: boolean;
       readonly settingsReachable: boolean;
       readonly settingsAccessibleLabel: string;
-      readonly settingsCompactLabel: string;
       readonly drawerOpen: boolean;
       readonly buttonResident: boolean;
       readonly buttonReachable: boolean;
@@ -1201,26 +1200,28 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       compactOpener.click();
       await new Promise((resolve) => setTimeout(resolve, 250));
       const topbar = document.querySelector(".topbar");
-      const settings = document.querySelector(".provider-model-settings-button");
+      const rail = document.querySelector('nav[aria-label="Main navigation"]');
+      const settings = Array.from(rail.querySelectorAll("button")).find(
+        (entry) => entry.textContent.includes("Settings"),
+      );
       const compactDrawer = document.querySelector("#training-context-drawer");
       const compactButton = compactDrawer.querySelector(".training-sync__button");
       const compactStatus = compactDrawer.querySelector(".training-sync__status");
       const compactRegion = compactDrawer.querySelector(".training-sync");
       const drawerRect = compactDrawer.getBoundingClientRect();
       const buttonRect = compactButton.getBoundingClientRect();
-      const topbarRect = topbar.getBoundingClientRect();
+      const railRect = rail.getBoundingClientRect();
       const settingsRect = settings.getBoundingClientRect();
       return {
         documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
         topbarFits: topbar.scrollWidth <= topbar.clientWidth,
-        settingsResident: topbar.contains(settings),
+        settingsResident: rail.contains(settings),
         settingsReachable:
-          settingsRect.left >= topbarRect.left &&
-          settingsRect.right <= topbarRect.right &&
-          settingsRect.top >= topbarRect.top &&
-          settingsRect.bottom <= topbarRect.bottom,
-        settingsAccessibleLabel: settings.getAttribute("aria-label"),
-        settingsCompactLabel: getComputedStyle(settings, "::before").content.replace(/['"]/gu, ""),
+          settingsRect.left >= railRect.left &&
+          settingsRect.right <= railRect.right &&
+          settingsRect.top >= railRect.top &&
+          settingsRect.bottom <= railRect.bottom,
+        settingsAccessibleLabel: settings.textContent.trim(),
         drawerOpen: compactDrawer.open,
         buttonResident: compactDrawer.querySelectorAll(".training-sync__button").length === 1,
         buttonReachable:
@@ -1241,8 +1242,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       topbarFits: true,
       settingsResident: true,
       settingsReachable: true,
-      settingsAccessibleLabel: "Coach settings",
-      settingsCompactLabel: "Coach",
+      settingsAccessibleLabel: "⚙Settings",
       drawerOpen: true,
       buttonResident: true,
       buttonReachable: true,
@@ -1255,8 +1255,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     ).length;
     const compactSettingsGeometry = await fixture.evaluate<{
       readonly open: boolean;
-      readonly oneDialog: boolean;
-      readonly hasThreeSections: boolean;
+      readonly onePage: boolean;
+      readonly hasEverySection: boolean;
       readonly horizontalOverflow: boolean;
       readonly withinViewport: boolean;
       readonly saveReachableAfterScroll: boolean;
@@ -1264,27 +1264,39 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly retentionWarningVisible: boolean;
     }>(`
       document.querySelector(".drawer-toggle").click();
-      const settings = document.querySelector(".provider-model-settings-button");
+      const settings = Array.from(
+        document.querySelectorAll('nav[aria-label="Main navigation"] button'),
+      ).find((entry) => entry.textContent.includes("Settings"));
       settings.click();
-      await new Promise((resolve) => setTimeout(resolve, 250));
-      const dialog = document.querySelector("#provider-model-settings-dialog");
-      const sessionSave = dialog.querySelector(".session-settings__save");
-      const rect = dialog.getBoundingClientRect();
+      const deadline = Date.now() + 5000;
+      while (
+        !document.querySelector('section[aria-label="Conversation and time"] input') &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      const page = document.querySelector('section[aria-label="Settings"]');
+      const sessionSave = Array.from(page.querySelectorAll("button")).find(
+        (entry) => entry.textContent === "Save conversation settings",
+      );
+      const rect = page.getBoundingClientRect();
       sessionSave.scrollIntoView({ block: "nearest" });
       await new Promise((resolve) => requestAnimationFrame(resolve));
       const saveRect = sessionSave.getBoundingClientRect();
-      const copy = dialog.textContent;
+      const copy = page.textContent;
       return {
-        open: dialog.open,
-        oneDialog: document.querySelectorAll("#provider-model-settings-dialog").length === 1,
-        hasThreeSections:
-          dialog.querySelectorAll("fieldset").length === 3 &&
-          copy.includes("Provider & model") &&
-          copy.includes("Training account") &&
-          copy.includes("Conversation & time"),
+        open: page.getAttribute("aria-hidden") === null,
+        onePage: document.querySelectorAll('section[aria-label="Settings"]').length === 1,
+        hasEverySection:
+          ["Coach", "Credentials", "Training account", "Conversation and time", "Spending", "Preferences", "Application"].every(
+            (label) => document.querySelectorAll('section[aria-label="' + label + '"]').length === 1,
+          ) &&
+          copy.includes("Coach route") &&
+          copy.includes("Athlete ID") &&
+          copy.includes("Daily reset hour"),
         horizontalOverflow:
-          dialog.scrollWidth > dialog.clientWidth ||
-          Array.from(dialog.querySelectorAll("form, fieldset")).some(
+          document.documentElement.scrollWidth > document.documentElement.clientWidth ||
+          Array.from(page.querySelectorAll("section, div")).some(
             (node) => node.scrollWidth > node.clientWidth,
           ),
         withinViewport:
@@ -1305,8 +1317,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     `);
     expect(compactSettingsGeometry).toEqual({
       open: true,
-      oneDialog: true,
-      hasThreeSections: true,
+      onePage: true,
+      hasEverySection: true,
       horizontalOverflow: false,
       withinViewport: true,
       saveReachableAfterScroll: true,

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -184,6 +184,30 @@ function script(calls: ScriptRequest[], initial: "reached" | "complete") {
   };
 }
 
+const NAVIGATE = `
+  const navigate = async (label) => {
+    const button = Array.from(
+      document.querySelectorAll('nav[aria-label="Main navigation"] button'),
+    ).find((entry) => entry.textContent.includes(label));
+    button.click();
+    const deadline = Date.now() + 5000;
+    while (!document.querySelector('section[aria-label="' + label + '"]') && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  };
+  const openSpending = async (expected) => {
+    await navigate("Settings");
+    const deadline = Date.now() + 5000;
+    while (
+      document.querySelector("[data-spend-meter] strong")?.textContent !== expected &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return document.querySelector("[data-spend-meter]");
+  };
+`;
+
 async function launch(initial: "reached" | "complete" = "reached") {
   const calls: ScriptRequest[] = [];
   const scripted = script(calls, initial);
@@ -198,7 +222,7 @@ async function launch(initial: "reached" | "complete" = "reached") {
   fixtures.push(fixture);
   await fixture.evaluate<void>(`
     const deadline = Date.now() + 10000;
-    while ((document.documentElement.dataset.rpc !== "connected" || document.querySelector(".spend-copy strong")?.textContent !== "$0.60+ / $0.50") && Date.now() < deadline) {
+    while (document.documentElement.dataset.rpc !== "connected" && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 20));
     }
     document.querySelector(".onboarding")?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
@@ -212,7 +236,7 @@ afterEach(async () => {
 });
 
 describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend meter", () => {
-  it("keeps the anchored rail visible at both viewport bands and never blocks reached-cap chat", async () => {
+  it("keeps the spending surface visible at both viewport bands and never blocks reached-cap chat", async () => {
     const { fixture, calls } = await launch();
     const desktop = await fixture.evaluate<{
       readonly visible: boolean;
@@ -224,19 +248,20 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       readonly submitDisabled: boolean;
       readonly final: string;
     }>(`
-      const details = document.querySelector(".spend-meter__details");
-      details.open = true;
+      ${NAVIGATE}
+      const spending = await openSpending("$0.60+ / $0.50");
+      const before = {
+        visible: spending.getBoundingClientRect().width >= 132,
+        trackHeight: spending.querySelector("progress").getBoundingClientRect().height,
+        disclosure: spending.textContent,
+        overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      };
+      await navigate("Chat");
       const textarea = document.querySelector("#message");
       const submit = textarea.closest("form").querySelector('button[type="submit"]');
-      const before = {
-        visible: document.querySelector(".spend-meter").getBoundingClientRect().width >= 132,
-        trackHeight: document.querySelector(".meter-track").getBoundingClientRect().height,
-        warning: document.querySelector("#spend-cap-warning").textContent,
-        disclosure: document.querySelector(".spend-disclosure").textContent,
-        overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
-        composerDisabled: textarea.disabled,
-        submitDisabled: submit.disabled,
-      };
+      const warning = document.querySelector("#spend-cap-warning").textContent;
+      const composerDisabled = textarea.disabled;
+      const submitDisabled = submit.disabled;
       textarea.value = "Can I keep chatting?";
       textarea.closest("form").requestSubmit();
       const deadline = Date.now() + 5000;
@@ -245,7 +270,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
         await new Promise((resolve) => setTimeout(resolve, 10));
         final = document.querySelector(".chat-message--coach .chat-message__text")?.textContent ?? "";
       }
-      return { ...before, final };
+      return { ...before, warning, composerDisabled, submitDisabled, final };
     `);
     expect(desktop.visible).toBe(true);
     expect(desktop.trackHeight).toBe(3);
@@ -268,13 +293,15 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       readonly visible: boolean;
       readonly overflow: boolean;
     }>(`
+      ${NAVIGATE}
+      await navigate("Settings");
       return {
-        visible: document.querySelector(".spend-meter").getBoundingClientRect().width >= 132,
+        visible: document.querySelector("[data-spend-meter]").getBoundingClientRect().width >= 132,
         overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
       };
     `);
     expect(narrow).toEqual({ visible: true, overflow: false });
-  });
+  }, 20_000);
 
   it("preserves the closed bridge, training-data drawer, hardened renderer, and token containment", async () => {
     const { fixture } = await launch();
@@ -341,12 +368,13 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       readonly warningHidden: boolean;
       readonly disclosure: string;
     }>(`
-      document.querySelector(".spend-meter__details").open = true;
+      ${NAVIGATE}
+      const spending = await openSpending("$0.14 / $0.50");
       return {
-        amount: document.querySelector(".spend-copy strong").textContent,
-        status: document.querySelector(".spend-meter").dataset.capStatus,
+        amount: spending.querySelector("strong").textContent,
+        status: spending.dataset.capStatus,
         warningHidden: document.querySelector("#spend-cap-warning").hidden,
-        disclosure: document.querySelector(".spend-disclosure").textContent,
+        disclosure: spending.textContent,
       };
     `);
     expect(complete).toMatchObject({
@@ -364,19 +392,22 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       readonly warningHidden: boolean;
       readonly disclosure: string;
     }>(`
+      const spending = document.querySelector("[data-spend-meter]");
       const cap = document.querySelector("#daily-spend-cap");
-      cap.value = "0.75";
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value").set;
+      setter.call(cap, "0.75");
       cap.dispatchEvent(new Event("input", { bubbles: true }));
-      document.querySelector(".spend-cap-editor button").click();
+      Array.from(spending.querySelectorAll("button")).find((entry) => entry.textContent === "Save cap").click();
       const deadline = Date.now() + 5000;
-      while (document.querySelector(".spend-meter").dataset.capStatus !== "unknown" && Date.now() < deadline) {
+      while (document.querySelector("[data-spend-meter]").dataset.capStatus !== "unknown" && Date.now() < deadline) {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
+      const current = document.querySelector("[data-spend-meter]");
       return {
-        amount: document.querySelector(".spend-copy strong").textContent,
-        status: document.querySelector(".spend-meter").dataset.capStatus,
+        amount: current.querySelector("strong").textContent,
+        status: current.dataset.capStatus,
         warningHidden: document.querySelector("#spend-cap-warning").hidden,
-        disclosure: document.querySelector(".spend-disclosure").textContent,
+        disclosure: current.textContent,
       };
     `);
     expect(saved).toMatchObject({
@@ -397,10 +428,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       textarea.value = "Refresh the spend display";
       textarea.closest("form").requestSubmit();
       const deadline = Date.now() + 5000;
-      while (!document.querySelector(".spend-disclosure").textContent.includes("Spend data may be out of date.") && Date.now() < deadline) {
+      while (!document.querySelector("[data-spend-meter]").textContent.includes("Spend data may be out of date.") && Date.now() < deadline) {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
-      return document.querySelector(".spend-disclosure").textContent;
+      return document.querySelector("[data-spend-meter]").textContent;
     `);
     expect(stale).toContain("Spend data may be out of date.");
     expect(calls.filter((call) => call.method === "chat")).toHaveLength(1);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { configDefaults, coverageConfigDefaults, defineConfig } from "vitest/config";
+import { appVersionDefine } from "./apps/desktop-renderer/app-version.mjs";
 
 /**
  * Vite (which vitest is built on) doesn't natively handle `import x from "*.md"`
@@ -71,6 +72,7 @@ export default defineConfig({
       },
       {
         root: fileURLToPath(new URL("apps/desktop-renderer", import.meta.url)),
+        define: appVersionDefine(),
         test: {
           name: "renderer-dom",
           pool: "forks",


### PR DESCRIPTION
Settings is now a real page inside the React shell, replacing the legacy settings dialog along with the separate spend disclosure, release-notes and update buttons that used to sit in the topbar. The topbar shrinks to setup, ride import and connection status. A new settings slice ports the resident shell's semantics: one owner holds the app-wide mutation lock, every other pane's controls disable while it is held, and navigating away is refused until an in-flight save settles, with the page region marked busy in the meantime.

Each section is a thin adapter over the controller it already had, so no controller, reducer or validator changed. Coach keeps the provider and model selects with the custom-model sentinel, the route breadcrumb and the credential-required setup path. Credentials keeps its two-step delete with the same announcements and focus restore. Training account and Conversation keep their read-only, managed-by-environment and per-field dirty rules, so only dirty fields are patched. Spending renders the usage meter, route breakdown and daily cap editor on the page, while the reached-cap warning still renders in the chat notice host so chat-side spend notices survive the move. Preferences gains a units control alongside the palette picker and appearance control, and Application carries the version, update action, release notes, re-run setup and the reset-conversation danger action. The displayed version comes from a build-time define fed by the app manifest, which is the same value the runtime reports; the preload bridge is untouched.

Verified with type checks on both desktop packages and with the renderer and desktop test suites, including a new settings-surface suite covering the mutation lock, the navigation guard, per-section dirty tracking and the delete and reset confirmations. The spend integration test now drives the surface at its new location, and the chat panel geometry assertions follow the settings page instead of the retired dialog.

One follow-up worth flagging: the scroll-anchor assertion in the chat panel hydration test fails locally on macOS, but it fails identically on the base branch with none of this change applied, so it is pre-existing rather than a regression from this work. It deserves a separate look at whether the anchoring behaviour or the assertion is what drifted.
