### PR TITLE
feat(desktop): rebuild training view and sidebar data in React

### DIFF
--- a/apps/desktop-renderer/src/app/App.tsx
+++ b/apps/desktop-renderer/src/app/App.tsx
@@ -1,12 +1,9 @@
 import { useEffect, type ReactElement } from "react";
-import type { LegacyHosts } from "../legacy-boot.js";
 import { useEnduragentStore } from "../state/store.js";
 import { DARK_MEDIA_QUERY } from "../theme/applyPalette.js";
 import { Shell } from "./Shell.js";
 
-export function App(props: {
-  readonly onHostsReady: (hosts: LegacyHosts) => void;
-}): ReactElement {
+export function App(props: { readonly onReady: () => void }): ReactElement {
   const appearance = useEnduragentStore((state) => state.appearance);
   const refreshTheme = useEnduragentStore((state) => state.refreshTheme);
 
@@ -22,5 +19,5 @@ export function App(props: {
     };
   }, [appearance, refreshTheme]);
 
-  return <Shell onHostsReady={props.onHostsReady} />;
+  return <Shell onReady={props.onReady} />;
 }

--- a/apps/desktop-renderer/src/app/Shell.module.css
+++ b/apps/desktop-renderer/src/app/Shell.module.css
@@ -9,38 +9,18 @@
 }
 
 .main {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 48px;
-  grid-template-rows: auto minmax(0, 1fr);
-  min-width: 0;
-  min-height: 0;
-}
-
-.main > .strip {
-  grid-column: 1;
-  grid-row: 1;
-  border-bottom: 1px solid var(--line);
-  background: var(--surface);
-}
-
-.main > .views {
   display: flex;
   flex-direction: column;
-  grid-column: 1;
-  grid-row: 2;
   min-width: 0;
   min-height: 0;
 }
 
-.main > .spineHost {
+.views {
   display: flex;
-  grid-column: 2;
-  grid-row: 1 / -1;
-  min-height: 0;
-}
-
-.spineHost > :global(.data-spine) {
   flex: 1;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
 }
 
 .chatRegion {
@@ -68,5 +48,11 @@
 @media (max-width: 1100px) {
   .win {
     grid-template-columns: 208px minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 860px) {
+  .win {
+    grid-template-columns: 184px minmax(0, 1fr);
   }
 }

--- a/apps/desktop-renderer/src/app/Shell.tsx
+++ b/apps/desktop-renderer/src/app/Shell.tsx
@@ -1,35 +1,22 @@
-import { Suspense, useEffect, useRef, type ReactElement } from "react";
-import type { LegacyHosts } from "../legacy-boot.js";
+import { Suspense, useEffect, type ReactElement } from "react";
 import { useEnduragentStore } from "../state/store.js";
 import { ChatView } from "../ui/chat/ChatView.js";
 import { Sidebar } from "../ui/sidebar/Sidebar.js";
 import styles from "./Shell.module.css";
 import { REACT_CHAT_REGION, VIEWS } from "./views.js";
 
-export function Shell(props: {
-  readonly onHostsReady: (hosts: LegacyHosts) => void;
-}): ReactElement {
+export function Shell(props: { readonly onReady: () => void }): ReactElement {
   const activeView = useEnduragentStore((state) => state.activeView);
-  const topbar = useRef<HTMLElement>(null);
-  const spine = useRef<HTMLElement>(null);
-  const drawer = useRef<HTMLDialogElement>(null);
-  const onHostsReady = props.onHostsReady;
+  const onReady = props.onReady;
 
   useEffect(() => {
-    const hosts = {
-      topbar: topbar.current,
-      spine: spine.current,
-      drawer: drawer.current,
-    };
-    if (Object.values(hosts).some((host) => host === null)) return;
-    onHostsReady(hosts as LegacyHosts);
-  }, [onHostsReady]);
+    onReady();
+  }, [onReady]);
 
   return (
-    <div className={styles.win}>
+    <div className={styles.win} data-view={activeView}>
       <Sidebar />
       <div className={styles.main}>
-        <header className={`topbar ${styles.strip}`} ref={topbar} />
         <div className={styles.views}>
           <div className={activeView === "chat" ? styles.chatRegion : styles.away}>
             <ChatView />
@@ -47,10 +34,6 @@ export function Shell(props: {
               );
             },
           )}
-        </div>
-        <div className={styles.spineHost}>
-          <aside className="data-spine" aria-label="Training data drawer" ref={spine} />
-          <dialog className="drawer" aria-label="Training data" ref={drawer} />
         </div>
       </div>
     </div>

--- a/apps/desktop-renderer/src/legacy-boot.ts
+++ b/apps/desktop-renderer/src/legacy-boot.ts
@@ -16,6 +16,7 @@ import { createFirstSyncController } from "./first-sync.js";
 import { createChatViewAdapter } from "./state/adapters/chat.js";
 import { createFirstSyncViewAdapter } from "./state/adapters/first-sync.js";
 import { createReleaseNotesSettingsAdapter } from "./state/adapters/release-notes.js";
+import { createRideImportAdapter } from "./state/adapters/ride-import.js";
 import {
   createAthleteSettingsAdapter,
   createConversationSettingsAdapter,
@@ -23,17 +24,18 @@ import {
   createCredentialSettingsAdapter,
 } from "./state/adapters/settings.js";
 import { createSpendSettingsAdapter } from "./state/adapters/spend.js";
+import { createManualSyncViewAdapter } from "./state/adapters/sync.js";
+import { createTrainingViewAdapter } from "./state/adapters/training.js";
 import { createUpdateSettingsAdapter } from "./state/adapters/update.js";
+import { observeConnectionLifecycle } from "./state/connection-slice.js";
+import { restoreManualSyncFocus } from "./state/manual-sync-focus.js";
+import { focusSetupOpener } from "./state/setup-opener.js";
 import { useEnduragentStore } from "./state/store.js";
 import { validateImportPaths, type OnboardingBridge } from "./onboarding/bridge.js";
 import { createOnboardingCompletionController } from "./onboarding/completion.js";
 import { mountOnboarding } from "./onboarding/mount.js";
-import {
-  createTrainingContextController,
-  type TrainingContextView,
-} from "./training-context/controller.js";
+import { createTrainingContextController } from "./training-context/controller.js";
 import { createManualSyncController } from "./training-context/manual-sync.js";
-import { mountTrainingContextView } from "./training-context/view.js";
 import { createTrainingSyncCoordinator } from "./training-sync.js";
 import { createSpendMeterController } from "./spend-meter/controller.js";
 import { createReleaseNotesController } from "./release-notes/controller.js";
@@ -42,17 +44,7 @@ import { createProviderModelSettingsController } from "./settings/provider-model
 import { createAthleteSettingsController } from "./settings/athlete-controller.js";
 import { createSessionSettingsController } from "./settings/session-controller.js";
 import { createCredentialSettingsController } from "./settings/credential-controller.js";
-import {
-  createRideImportController,
-  mountResidentRideImport,
-  subscribeToDroppedRideImports,
-} from "./ride-import.js";
-
-export interface LegacyHosts {
-  readonly topbar: HTMLElement;
-  readonly spine: HTMLElement;
-  readonly drawer: HTMLDialogElement;
-}
+import { createRideImportController, subscribeToDroppedRideImports } from "./ride-import.js";
 
 export type Disposer = () => void;
 
@@ -61,30 +53,12 @@ function focusComposer(): void {
   if (composer instanceof HTMLTextAreaElement) composer.focus();
 }
 
-export function bootLegacy(hosts: LegacyHosts): Disposer {
-  const { topbar, spine, drawer } = hosts;
+export function bootLegacy(): Disposer {
   const store = useEnduragentStore;
 
-  const topbarActions = document.createElement("div");
-  topbarActions.className = "topbar-actions";
-  topbar.append(topbarActions);
-  const connectionStatus = document.createElement("span");
-  connectionStatus.className = "connection-status";
-  connectionStatus.setAttribute("role", "status");
-  connectionStatus.textContent = "Connecting…";
-  topbarActions.append(connectionStatus);
-  const onLifecycle = (event: WindowEventMap["enduragent-lifecycle"]): void => {
-    document.documentElement.dataset.rpc = event.detail.status;
-    connectionStatus.textContent =
-      event.detail.status === "ready"
-        ? "Connected"
-        : event.detail.status === "recovering"
-          ? "Reconnecting…"
-          : event.detail.status === "terminal"
-            ? "Connection unavailable"
-            : "Closing…";
-  };
-  window.addEventListener("enduragent-lifecycle", onLifecycle);
+  const disposeLifecycle = observeConnectionLifecycle((status) => {
+    store.getState().setConnection(status);
+  });
   const releaseNotesAdapter = createReleaseNotesSettingsAdapter({
     publish: (patch) => store.getState().patchSettings(patch),
   });
@@ -107,32 +81,32 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     const current = await clients.getClient();
     return current === failedClient ? clients.reconnect() : current;
   };
-  const mountedTrainingContext = mountTrainingContextView({ spine, drawer });
-  const trainingContextView: TrainingContextView = {
-    render(state) {
-      mountedTrainingContext.view.render(state);
-      const current = store.getState().settings.units;
-      const next = state.unitsPreference;
-      if (
-        current.status !== next.status ||
-        current.value !== next.value ||
-        current.source !== next.source
-      ) {
-        store.getState().patchSettings({ units: next });
-      }
-    },
-  };
+  const trainingAdapter = createTrainingViewAdapter({
+    readUnits: () => store.getState().settings.units,
+    publish: (next) => store.getState().setTraining(next),
+    publishUnits: (units) => store.getState().patchSettings({ units }),
+  });
   const trainingContextController = createTrainingContextController({
     clients,
-    view: trainingContextView,
+    view: trainingAdapter.view,
   });
   const trainingSyncCoordinator = createTrainingSyncCoordinator({
     clients,
     refreshTrainingContext: () => trainingContextController.refresh(),
   });
+  const syncAdapter = createManualSyncViewAdapter({
+    publish: (next) =>
+      flushSync(() => {
+        store.getState().setSync(next);
+      }),
+    restoreFocus: restoreManualSyncFocus,
+  });
   const manualSyncController = createManualSyncController({
     coordinator: trainingSyncCoordinator,
-    view: mountedTrainingContext.syncView,
+    view: syncAdapter.view,
+  });
+  store.getState().bindSyncActions({
+    request: (kind) => void manualSyncController.activate(kind),
   });
   const spendAdapter = createSpendSettingsAdapter({
     read: () => store.getState().settings.spend,
@@ -154,10 +128,6 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     refreshTrainingContext: () => trainingContextController.refresh(),
     refreshSpend: () => spendController.refresh(),
     readTranscriptPage: (request) => window.enduragentAuth.getTranscriptPage(request),
-  });
-  mountedTrainingContext.bind({
-    onUnitsPreferenceChange: (value) => void trainingContextController.setUnitsPreference(value),
-    onSyncRequest: (kind) => void manualSyncController.activate(kind),
   });
 
   const firstSyncController = createFirstSyncController({
@@ -231,18 +201,12 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     },
   };
 
-  const setup = document.createElement("button");
-  setup.type = "button";
-  setup.className = "setup-button";
-  setup.textContent = "Setup";
-  topbarActions.insertBefore(setup, connectionStatus);
   const rideImports = createRideImportController(onboardingBridge);
-  const residentRideImport = mountResidentRideImport({
-    document,
-    actionHost: topbarActions,
-    before: connectionStatus,
+  const rideImportAdapter = createRideImportAdapter({
     imports: rideImports,
+    publish: (next) => store.getState().setRideImport(next),
   });
+  store.getState().bindRideImportActions(rideImportAdapter.port);
   const onboardingCompletion = createOnboardingCompletionController({
     storage: () => window.localStorage,
     onComplete: (completion) => void firstSyncController.start(completion),
@@ -251,14 +215,14 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     document,
     bridge: onboardingBridge,
     rideImports,
-    onRideImportPresentationChange: (presenting) => residentRideImport.setSuppressed(presenting),
-    opener: setup,
+    onRideImportPresentationChange: (presenting) =>
+      store.getState().setRideImportSuppressed(presenting),
+    opener: { focus: focusSetupOpener },
     onComplete: (completion) => onboardingCompletion.complete(completion),
   });
   const openSetupFlow = (): void => {
     void onboardingCompletion.openManually(() => onboarding.open());
   };
-  setup.addEventListener("click", openSetupFlow);
   const closePanes = (): void => {
     providerModelSettingsController.close();
     credentialSettingsController.close();
@@ -334,7 +298,9 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
   const disposeDroppedRideImports = subscribeToDroppedRideImports({
     subscribe: onboardingBridge.onDroppedImportFiles,
     onboarding,
-    resident: residentRideImport,
+    resident: {
+      importDroppedFiles: (paths) => void rideImports.importPaths("resident", paths),
+    },
   });
 
   void trainingContextController.start();
@@ -342,14 +308,8 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
   void chatController.start();
   void onboardingCompletion.openOnStartup(() => onboarding.open());
   void clients.getClient().then(
-    () => {
-      document.documentElement.dataset.rpc = "connected";
-      connectionStatus.textContent = "Connected";
-    },
-    () => {
-      document.documentElement.dataset.rpc = "failed";
-      connectionStatus.textContent = "Connection unavailable";
-    },
+    () => store.getState().setConnection("connected"),
+    () => store.getState().setConnection("failed"),
   );
 
   let disposed = false;
@@ -358,7 +318,9 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     disposed = true;
     store.getState().bindChatActions(null);
     store.getState().bindSettingsPorts(null);
-    window.removeEventListener("enduragent-lifecycle", onLifecycle);
+    store.getState().bindSyncActions(null);
+    store.getState().bindRideImportActions(null);
+    disposeLifecycle();
     window.removeEventListener("pagehide", dispose);
     releaseNotesController.dispose();
     desktopUpdateController.dispose();
@@ -368,14 +330,13 @@ export function bootLegacy(hosts: LegacyHosts): Disposer {
     sessionSettingsController.dispose();
     disposeDroppedRideImports();
     onboarding.dispose();
-    residentRideImport.dispose();
+    rideImportAdapter.dispose();
     firstSyncController.dispose();
     manualSyncController.dispose();
     trainingSyncCoordinator.dispose();
     chatController.dispose();
     spendController.dispose();
     trainingContextController.dispose();
-    mountedTrainingContext.dispose();
     void clients.close();
   };
   window.addEventListener("pagehide", dispose, { once: true });

--- a/apps/desktop-renderer/src/main.tsx
+++ b/apps/desktop-renderer/src/main.tsx
@@ -3,7 +3,7 @@ import "@fontsource-variable/source-serif-4";
 import "@fontsource-variable/source-serif-4/wght-italic.css";
 import { createRoot } from "react-dom/client";
 import { App } from "./app/App.js";
-import { bootLegacy, type Disposer, type LegacyHosts } from "./legacy-boot.js";
+import { bootLegacy, type Disposer } from "./legacy-boot.js";
 import { bootTheme, useEnduragentStore } from "./state/store.js";
 
 bootTheme();
@@ -16,13 +16,13 @@ if (!(container instanceof HTMLElement)) {
 let legacy: Disposer | undefined;
 let booting = false;
 
-function onHostsReady(hosts: LegacyHosts): void {
+function onReady(): void {
   if (booting || legacy !== undefined) return;
   booting = true;
   queueMicrotask(() => {
-    legacy = bootLegacy(hosts);
+    legacy = bootLegacy();
     useEnduragentStore.getState().markLegacyReady();
   });
 }
 
-createRoot(container).render(<App onHostsReady={onHostsReady} />);
+createRoot(container).render(<App onReady={onReady} />);

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -60,7 +60,7 @@ interface MountOnboardingOptions {
   readonly bridge: OnboardingBridge;
   readonly rideImports?: RideImportController;
   readonly onRideImportPresentationChange?: (presenting: boolean) => void;
-  readonly opener: HTMLElement;
+  readonly opener: Pick<HTMLElement, "focus">;
   readonly onComplete: (completion: OnboardingCompletion) => void;
 }
 

--- a/apps/desktop-renderer/src/state/adapters/ride-import.ts
+++ b/apps/desktop-renderer/src/state/adapters/ride-import.ts
@@ -1,0 +1,31 @@
+import type { RideImportController, RideImportState } from "../../ride-import.js";
+import type { RideImportActions } from "../ride-import-slice.js";
+
+export interface RideImportAdapter {
+  readonly port: RideImportActions;
+  dispose(): void;
+}
+
+export function createRideImportAdapter(input: {
+  readonly imports: RideImportController;
+  readonly publish: (next: RideImportState) => void;
+}): RideImportAdapter {
+  let disposed = false;
+  const unsubscribe = input.imports.subscribe((state) => {
+    if (!disposed) input.publish(state);
+  });
+
+  return {
+    port: {
+      choose() {
+        if (disposed) return;
+        void input.imports.chooseAndImport("resident");
+      },
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      unsubscribe();
+    },
+  };
+}

--- a/apps/desktop-renderer/src/state/adapters/sync.ts
+++ b/apps/desktop-renderer/src/state/adapters/sync.ts
@@ -1,0 +1,21 @@
+import type { ManualSyncView, ManualSyncViewState } from "../../training-context/manual-sync.js";
+
+export interface ManualSyncViewAdapter {
+  readonly view: ManualSyncView;
+}
+
+export function createManualSyncViewAdapter(input: {
+  readonly publish: (next: ManualSyncViewState) => void;
+  readonly restoreFocus: () => void;
+}): ManualSyncViewAdapter {
+  return {
+    view: {
+      render(state) {
+        input.publish(state);
+      },
+      restoreKeyboardFocus() {
+        input.restoreFocus();
+      },
+    },
+  };
+}

--- a/apps/desktop-renderer/src/state/adapters/training.ts
+++ b/apps/desktop-renderer/src/state/adapters/training.ts
@@ -1,0 +1,32 @@
+import type {
+  TrainingContextView,
+  TrainingContextViewState,
+  UnitsPreferenceViewState,
+} from "../../training-context/controller.js";
+
+export interface TrainingViewAdapter {
+  readonly view: TrainingContextView;
+}
+
+export function createTrainingViewAdapter(input: {
+  readonly readUnits: () => UnitsPreferenceViewState;
+  readonly publish: (next: TrainingContextViewState) => void;
+  readonly publishUnits: (next: UnitsPreferenceViewState) => void;
+}): TrainingViewAdapter {
+  return {
+    view: {
+      render(state) {
+        input.publish(state);
+        const current = input.readUnits();
+        const next = state.unitsPreference;
+        if (
+          current.status !== next.status ||
+          current.value !== next.value ||
+          current.source !== next.source
+        ) {
+          input.publishUnits(next);
+        }
+      },
+    },
+  };
+}

--- a/apps/desktop-renderer/src/state/connection-slice.ts
+++ b/apps/desktop-renderer/src/state/connection-slice.ts
@@ -1,0 +1,68 @@
+import type { StateCreator } from "zustand";
+import type { EnduragentState } from "./store.js";
+
+export type ConnectionStatus =
+  | "connecting"
+  | "ready"
+  | "connected"
+  | "recovering"
+  | "terminal"
+  | "failed"
+  | "closing";
+
+export type ConnectionTone = "pending" | "connected" | "recovering" | "unavailable";
+
+const TONES: Readonly<Record<ConnectionStatus, ConnectionTone>> = {
+  connecting: "pending",
+  ready: "connected",
+  connected: "connected",
+  recovering: "recovering",
+  terminal: "unavailable",
+  failed: "unavailable",
+  closing: "pending",
+};
+
+const COPY: Readonly<Record<ConnectionStatus, string>> = {
+  connecting: "Connecting…",
+  ready: "Connected",
+  connected: "Connected",
+  recovering: "Reconnecting…",
+  terminal: "Connection unavailable",
+  failed: "Connection unavailable",
+  closing: "Closing…",
+};
+
+export function connectionTone(status: ConnectionStatus): ConnectionTone {
+  return TONES[status];
+}
+
+export function connectionCopy(status: ConnectionStatus): string {
+  return COPY[status];
+}
+
+export interface ConnectionSlice {
+  readonly connection: ConnectionStatus;
+  setConnection: (status: ConnectionStatus) => void;
+}
+
+export const createConnectionSlice: StateCreator<EnduragentState, [], [], ConnectionSlice> = (
+  set,
+) => ({
+  connection: "connecting",
+  setConnection(status) {
+    if (typeof document !== "undefined") document.documentElement.dataset.rpc = status;
+    set({ connection: status });
+  },
+});
+
+export function observeConnectionLifecycle(
+  publish: (status: ConnectionStatus) => void,
+): () => void {
+  const onLifecycle = (event: WindowEventMap["enduragent-lifecycle"]): void => {
+    publish(event.detail.status);
+  };
+  window.addEventListener("enduragent-lifecycle", onLifecycle);
+  return () => {
+    window.removeEventListener("enduragent-lifecycle", onLifecycle);
+  };
+}

--- a/apps/desktop-renderer/src/state/manual-sync-focus.ts
+++ b/apps/desktop-renderer/src/state/manual-sync-focus.ts
@@ -1,0 +1,20 @@
+let target: HTMLElement | null = null;
+
+export function setManualSyncFocusTarget(element: HTMLElement | null): void {
+  target = element;
+}
+
+export function restoreManualSyncFocus(): void {
+  const element = target;
+  if (element === null || !element.isConnected || element.hidden) return;
+  if (element instanceof HTMLButtonElement && element.disabled) return;
+  const owner = element.ownerDocument;
+  const active = owner.activeElement;
+  const focusWasLost =
+    active === null ||
+    active === owner.body ||
+    active === owner.documentElement ||
+    active === element;
+  if (!focusWasLost) return;
+  element.focus();
+}

--- a/apps/desktop-renderer/src/state/ride-import-slice.ts
+++ b/apps/desktop-renderer/src/state/ride-import-slice.ts
@@ -1,0 +1,40 @@
+import type { StateCreator } from "zustand";
+import type { RideImportState } from "../ride-import.js";
+import type { EnduragentState } from "./store.js";
+
+export interface RideImportActions {
+  choose(): void;
+}
+
+export const IDLE_RIDE_IMPORT: RideImportState = Object.freeze({
+  status: "idle" as const,
+  owner: null,
+  progress: null,
+  result: null,
+});
+
+export interface RideImportSlice {
+  readonly rideImport: RideImportState;
+  readonly rideImportSuppressed: boolean;
+  readonly rideImportActions: RideImportActions | null;
+  setRideImport: (next: RideImportState) => void;
+  setRideImportSuppressed: (suppressed: boolean) => void;
+  bindRideImportActions: (actions: RideImportActions | null) => void;
+}
+
+export const createRideImportSlice: StateCreator<EnduragentState, [], [], RideImportSlice> = (
+  set,
+) => ({
+  rideImport: IDLE_RIDE_IMPORT,
+  rideImportSuppressed: false,
+  rideImportActions: null,
+  setRideImport(next) {
+    set({ rideImport: next });
+  },
+  setRideImportSuppressed(suppressed) {
+    set({ rideImportSuppressed: suppressed });
+  },
+  bindRideImportActions(actions) {
+    set({ rideImportActions: actions });
+  },
+});

--- a/apps/desktop-renderer/src/state/setup-opener.ts
+++ b/apps/desktop-renderer/src/state/setup-opener.ts
@@ -1,0 +1,9 @@
+let opener: HTMLElement | null = null;
+
+export function registerSetupOpener(element: HTMLElement | null): void {
+  opener = element;
+}
+
+export function focusSetupOpener(): void {
+  opener?.focus();
+}

--- a/apps/desktop-renderer/src/state/store.ts
+++ b/apps/desktop-renderer/src/state/store.ts
@@ -14,13 +14,23 @@ import {
   writeStoredPaletteId,
 } from "../theme/preferences.js";
 import { createChatSlice, type ChatSlice } from "./chat-slice.js";
+import { createConnectionSlice, type ConnectionSlice } from "./connection-slice.js";
+import { createRideImportSlice, type RideImportSlice } from "./ride-import-slice.js";
 import {
   createSettingsSlice,
   settingsMutationActive,
   type SettingsSlice,
 } from "./settings-slice.js";
+import { createSyncSlice, type SyncSlice } from "./sync-slice.js";
+import { createTrainingSlice, type TrainingSlice } from "./training-slice.js";
 
-export interface EnduragentState extends ChatSlice, SettingsSlice {
+export interface EnduragentState
+  extends ChatSlice,
+    SettingsSlice,
+    TrainingSlice,
+    SyncSlice,
+    ConnectionSlice,
+    RideImportSlice {
   readonly activeView: ViewId;
   readonly paletteId: string;
   readonly appearance: Appearance;
@@ -45,6 +55,10 @@ function stamp(paletteId: string, appearance: Appearance): ResolvedTheme {
 export const useEnduragentStore = create<EnduragentState>((set, get, api) => ({
   ...createChatSlice(set, get, api),
   ...createSettingsSlice(set, get, api),
+  ...createTrainingSlice(set, get, api),
+  ...createSyncSlice(set, get, api),
+  ...createConnectionSlice(set, get, api),
+  ...createRideImportSlice(set, get, api),
   activeView: "chat",
   paletteId: readStoredPaletteId(),
   appearance: readStoredAppearance(),

--- a/apps/desktop-renderer/src/state/sync-slice.ts
+++ b/apps/desktop-renderer/src/state/sync-slice.ts
@@ -1,0 +1,33 @@
+import type { StateCreator } from "zustand";
+import type { ManualSyncViewState } from "../training-context/manual-sync.js";
+import type { EnduragentState } from "./store.js";
+
+export interface SyncActions {
+  request(kind: "keyboard" | "pointer"): void;
+}
+
+export const IDLE_MANUAL_SYNC: ManualSyncViewState = Object.freeze({
+  label: "Sync now" as const,
+  message: "",
+  disabled: false,
+  busy: false,
+  tone: "idle" as const,
+});
+
+export interface SyncSlice {
+  readonly sync: ManualSyncViewState;
+  readonly syncActions: SyncActions | null;
+  setSync: (next: ManualSyncViewState) => void;
+  bindSyncActions: (actions: SyncActions | null) => void;
+}
+
+export const createSyncSlice: StateCreator<EnduragentState, [], [], SyncSlice> = (set) => ({
+  sync: IDLE_MANUAL_SYNC,
+  syncActions: null,
+  setSync(next) {
+    set({ sync: next });
+  },
+  bindSyncActions(actions) {
+    set({ syncActions: actions });
+  },
+});

--- a/apps/desktop-renderer/src/state/training-slice.ts
+++ b/apps/desktop-renderer/src/state/training-slice.ts
@@ -1,0 +1,27 @@
+import { UNKNOWN_CYCLING_TRAINING_CONTEXT } from "@enduragent/coach-contract";
+import type { StateCreator } from "zustand";
+import type { TrainingContextViewState } from "../training-context/controller.js";
+import type { EnduragentState } from "./store.js";
+
+export const EMPTY_TRAINING_SURFACE: TrainingContextViewState = Object.freeze({
+  status: "loading" as const,
+  metadata: null,
+  trainingContext: UNKNOWN_CYCLING_TRAINING_CONTEXT,
+  unitsPreference: Object.freeze({
+    status: "loading" as const,
+    value: "metric" as const,
+    source: "default" as const,
+  }),
+});
+
+export interface TrainingSlice {
+  readonly training: TrainingContextViewState;
+  setTraining: (next: TrainingContextViewState) => void;
+}
+
+export const createTrainingSlice: StateCreator<EnduragentState, [], [], TrainingSlice> = (set) => ({
+  training: EMPTY_TRAINING_SURFACE,
+  setTraining(next) {
+    set({ training: next });
+  },
+});

--- a/apps/desktop-renderer/src/ui/sidebar/ConnectionStatus.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/ConnectionStatus.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from "react";
+import { connectionCopy, connectionTone } from "../../state/connection-slice.js";
+import { useEnduragentStore } from "../../state/store.js";
+import styles from "./Sidebar.module.css";
+
+export function ConnectionStatus(): ReactElement {
+  const connection = useEnduragentStore((store) => store.connection);
+  const tone = connectionTone(connection);
+
+  return (
+    <p className={`${styles.connection} connection-status`} data-tone={tone} role="status">
+      <span className={styles.dot} data-tone={tone} aria-hidden="true" />
+      {connectionCopy(connection)}
+    </p>
+  );
+}

--- a/apps/desktop-renderer/src/ui/sidebar/HistoryList.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/HistoryList.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement } from "react";
+import { useEnduragentStore } from "../../state/store.js";
+import styles from "./Sidebar.module.css";
+
+export interface ConversationEntry {
+  readonly id: string;
+  readonly title: string;
+  readonly when: string;
+}
+
+export const LIVE_CONVERSATION_ID = "desktop";
+
+export const SINGLE_CONVERSATION_NOTE = "Enduragent keeps one conversation on this Mac.";
+
+export function HistoryList(props: { readonly locked: boolean }): ReactElement {
+  const activeView = useEnduragentStore((store) => store.activeView);
+  const setActiveView = useEnduragentStore((store) => store.setActiveView);
+  const entries: readonly ConversationEntry[] = [
+    { id: LIVE_CONVERSATION_ID, title: "Current conversation", when: "Live" },
+  ];
+
+  return (
+    <div className={styles.hist}>
+      {entries.map((entry) => (
+        <button
+          key={entry.id}
+          type="button"
+          className={activeView === "chat" ? `${styles.histItem} ${styles.on}` : styles.histItem}
+          aria-current={activeView === "chat" ? "true" : undefined}
+          disabled={props.locked}
+          onClick={() => {
+            setActiveView("chat");
+          }}
+        >
+          <span className={styles.histTitle}>{entry.title}</span>
+          <span className={styles.histWhen}>{entry.when}</span>
+        </button>
+      ))}
+      <p className={styles.histNote}>{SINGLE_CONVERSATION_NOTE}</p>
+    </div>
+  );
+}

--- a/apps/desktop-renderer/src/ui/sidebar/Sidebar.module.css
+++ b/apps/desktop-renderer/src/ui/sidebar/Sidebar.module.css
@@ -143,8 +143,17 @@
   font: 11px var(--f-mono);
 }
 
+.histNote {
+  margin: 8px 10px 0;
+  color: var(--ink-3);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
 .railFoot {
-  padding: 11px 14px;
+  display: grid;
+  gap: 2px;
+  padding: 9px 12px;
   border-top: 1px solid var(--line);
 }
 
@@ -152,10 +161,64 @@
   display: flex;
   gap: 8px;
   align-items: center;
+  width: 100%;
   padding: 6px 8px;
+  border: 0;
   border-radius: 8px;
   color: var(--ink-2);
+  background: none;
+  font: inherit;
   font-size: 12.5px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sync:hover:not(:disabled) {
+  color: var(--ink);
+  background: var(--surface);
+}
+
+.sync:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.syncCopy {
+  flex: 1;
+  min-width: 0;
+}
+
+.syncHeadline {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.syncWhen {
+  display: block;
+  margin-top: 1px;
+  overflow: hidden;
+  color: var(--ink-3);
+  font: 11px var(--f-mono);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.syncAction {
+  flex: none;
+  color: var(--ink-3);
+  font-size: 12px;
+}
+
+.connection {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin: 0;
+  padding: 4px 8px;
+  color: var(--ink-3);
+  font-size: 12px;
 }
 
 .dot {
@@ -164,4 +227,29 @@
   height: 7px;
   border-radius: 50%;
   background: var(--ink-3);
+}
+
+.dot[data-status="synced"] {
+  background: var(--ok);
+}
+
+.dot[data-status="syncing"] {
+  background: var(--brand);
+}
+
+.dot[data-status="attention"],
+.dot[data-status="unavailable"] {
+  background: var(--warn);
+}
+
+.dot[data-tone="connected"] {
+  background: var(--ok);
+}
+
+.dot[data-tone="recovering"] {
+  background: var(--warn);
+}
+
+.dot[data-tone="unavailable"] {
+  background: var(--danger);
 }

--- a/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useRef, type ReactElement } from "react";
 import { VIEWS } from "../../app/views.js";
 import { registerNewConversationOpener } from "../../state/new-conversation-opener.js";
+import { registerSetupOpener } from "../../state/setup-opener.js";
 import { settingsMutationActive } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
+import { ConnectionStatus } from "./ConnectionStatus.js";
+import { HistoryList } from "./HistoryList.js";
 import styles from "./Sidebar.module.css";
+import { SyncChip } from "./SyncChip.js";
 
 export function Sidebar(): ReactElement {
   const activeView = useEnduragentStore((state) => state.activeView);
@@ -13,12 +17,15 @@ export function Sidebar(): ReactElement {
   const actions = useEnduragentStore((state) => state.chatActions);
   const settingsBusy = useEnduragentStore((state) => settingsMutationActive(state.settings));
   const opener = useRef<HTMLButtonElement>(null);
+  const settingsNav = useRef<HTMLButtonElement>(null);
   const navigationLocked = activeView === "settings" && settingsBusy;
 
   useEffect(() => {
     registerNewConversationOpener(opener.current);
+    registerSetupOpener(settingsNav.current);
     return () => {
       registerNewConversationOpener(null);
+      registerSetupOpener(null);
     };
   }, []);
 
@@ -51,6 +58,7 @@ export function Sidebar(): ReactElement {
           <button
             key={view.id}
             type="button"
+            ref={view.id === "settings" ? settingsNav : undefined}
             className={view.id === activeView ? `${styles.navItem} ${styles.on}` : styles.navItem}
             aria-current={view.id === activeView ? "page" : undefined}
             disabled={navigationLocked && view.id !== activeView}
@@ -66,24 +74,10 @@ export function Sidebar(): ReactElement {
         ))}
       </nav>
       <div className={styles.sec}>Conversations</div>
-      <div className={styles.hist}>
-        <button
-          type="button"
-          className={activeView === "chat" ? `${styles.histItem} ${styles.on}` : styles.histItem}
-          disabled={navigationLocked}
-          onClick={() => {
-            setActiveView("chat");
-          }}
-        >
-          <span className={styles.histTitle}>Current conversation</span>
-          <span className={styles.histWhen}>Live</span>
-        </button>
-      </div>
+      <HistoryList locked={navigationLocked} />
       <div className={styles.railFoot}>
-        <p className={styles.sync}>
-          <span className={styles.dot} aria-hidden="true" />
-          Sync status moves here with the training page
-        </p>
+        <SyncChip />
+        <ConnectionStatus />
       </div>
     </aside>
   );

--- a/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
@@ -1,0 +1,70 @@
+import { useRef, type ReactElement } from "react";
+import { setManualSyncFocusTarget } from "../../state/manual-sync-focus.js";
+import { useEnduragentStore } from "../../state/store.js";
+import type { TrainingContextViewState } from "../../training-context/controller.js";
+import type { ManualSyncViewState } from "../../training-context/manual-sync.js";
+import { formatUtcTimestamp } from "../../training-context/format.js";
+import styles from "./Sidebar.module.css";
+
+export type SyncChipStatus =
+  | "loading"
+  | "syncing"
+  | "attention"
+  | "synced"
+  | "never"
+  | "unavailable";
+
+export function syncChipStatus(
+  training: TrainingContextViewState,
+  sync: ManualSyncViewState,
+): SyncChipStatus {
+  if (sync.busy) return "syncing";
+  if (sync.tone === "failure" || sync.tone === "partial") return "attention";
+  if (training.status === "loading") return "loading";
+  if (training.metadata !== null && training.metadata.lastSynced !== null) return "synced";
+  return training.status === "unavailable" ? "unavailable" : "never";
+}
+
+const HEADLINE: Readonly<Record<SyncChipStatus, string>> = {
+  loading: "Loading training data",
+  syncing: "Syncing",
+  attention: "Sync needs attention",
+  synced: "Synced",
+  never: "Not synced yet",
+  unavailable: "Training data unavailable",
+};
+
+export function SyncChip(): ReactElement {
+  const training = useEnduragentStore((store) => store.training);
+  const sync = useEnduragentStore((store) => store.sync);
+  const actions = useEnduragentStore((store) => store.syncActions);
+  const chip = useRef<HTMLButtonElement>(null);
+  const status = syncChipStatus(training, sync);
+  const synced = training.metadata?.lastSynced ?? null;
+  const detail = status === "synced" && synced !== null ? formatUtcTimestamp(synced) : null;
+
+  return (
+    <button
+      type="button"
+      ref={chip}
+      className={`${styles.sync} sync-chip`}
+      data-status={status}
+      disabled={sync.disabled || actions === null}
+      aria-label={`${sync.label} · ${HEADLINE[status]}`}
+      onClick={(event) => {
+        const keyboard = event.detail === 0;
+        setManualSyncFocusTarget(keyboard ? chip.current : null);
+        actions?.request(keyboard ? "keyboard" : "pointer");
+      }}
+    >
+      <span className={styles.dot} data-status={status} aria-hidden="true" />
+      <span className={styles.syncCopy}>
+        <span className={styles.syncHeadline}>{HEADLINE[status]}</span>
+        {detail === null ? null : <span className={styles.syncWhen}>{detail}</span>}
+      </span>
+      <span className={styles.syncAction} aria-hidden="true">
+        {sync.label}
+      </span>
+    </button>
+  );
+}

--- a/apps/desktop-renderer/src/ui/training/TrainingView.module.css
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.module.css
@@ -1,9 +1,257 @@
-.note {
-  margin: 0;
-  padding: 18px 20px;
+.status {
+  margin: 0 0 14px;
+  color: var(--ink-2);
+  font-size: 13px;
+}
+
+.panel {
+  margin-bottom: 14px;
+  padding: 16px 18px;
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
-  color: var(--ink-2);
   background: var(--surface);
-  font: 16px/1.6 var(--f-prose);
+}
+
+.panel:last-child {
+  margin-bottom: 0;
+}
+
+.panelTitle {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.panelBody {
+  margin-top: 12px;
+  min-width: 0;
+}
+
+.subheading {
+  margin: 18px 0 0;
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 560;
+}
+
+.value {
+  margin: 0 0 6px;
+  font: 600 34px/1 var(--f-dis);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.meta {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-2);
+  font: 11px/1.45 var(--f-mono);
+}
+
+.support {
+  margin: 8px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.empty {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  margin: 4px 0 8px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  color: var(--brand);
+  background: var(--brand-soft);
+  font: 600 10px/1 var(--f-mono);
+  text-transform: capitalize;
+}
+
+.badge[data-band="aging"],
+.badge[data-band="stale"],
+.badge[data-band="very-stale"] {
+  color: var(--warn);
+  background: color-mix(in srgb, var(--warn) 14%, transparent);
+}
+
+.metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+}
+
+.metadata:empty {
+  display: none;
+}
+
+.metadata .badge {
+  margin: 0;
+}
+
+.syncRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+  align-items: center;
+  margin-top: 14px;
+  min-width: 0;
+}
+
+.action {
+  flex: none;
+  min-height: 32px;
+  padding: 6px 13px;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--ink);
+  background: var(--surface-2);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.action:hover:not(:disabled) {
+  border-color: var(--ink-3);
+}
+
+.action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.syncMessage {
+  flex: 1 1 220px;
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-2);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.syncRow[data-tone="success"] .syncMessage {
+  color: var(--ok);
+}
+
+.syncRow[data-tone="partial"] .syncMessage,
+.syncRow[data-tone="failure"] .syncMessage {
+  color: var(--warn);
+}
+
+.zones {
+  display: grid;
+  gap: 8px 16px;
+  margin: 10px 0 0;
+  font-size: 12.5px;
+}
+
+.zone {
+  display: flex;
+  gap: 16px;
+  align-items: baseline;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.zoneName {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.zoneName[data-overlaps="true"]::after {
+  color: var(--ink-3);
+  content: " · overlaps";
+}
+
+.zoneRange {
+  flex: none;
+  margin: 0;
+  font-family: var(--f-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.plan {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.planItem {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  padding: 10px 12px;
+  border-radius: var(--r);
+  background: var(--sunk);
+}
+
+.planItem strong {
+  overflow-wrap: anywhere;
+  font-size: 13px;
+  font-weight: 560;
+}
+
+.planItem span {
+  color: var(--ink-2);
+  font: 11px/1.4 var(--f-mono);
+}
+
+.wellness {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.wellnessRow {
+  display: grid;
+  grid-template-columns: 76px 78px minmax(60px, 1fr);
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+  font-size: 12.5px;
+}
+
+.wellnessValue,
+.wellnessEmpty {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-2);
+  font-family: var(--f-mono);
+  font-size: 10.5px;
+}
+
+.sparkline {
+  width: 100%;
+  height: 30px;
+  overflow: visible;
+}
+
+.sparkline polyline {
+  fill: none;
+  stroke: var(--brand);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+@media (max-width: 760px) {
+  .wellnessRow {
+    grid-template-columns: 62px 70px minmax(50px, 1fr);
+  }
 }

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -1,14 +1,303 @@
-import type { ReactElement } from "react";
+import type {
+  AdherencePanel,
+  AnchorZonesPanel,
+  CyclingLoadPanel,
+  PlanPanel,
+  WellnessTrendPanel,
+} from "@enduragent/coach-contract";
+import { useRef, type ReactElement, type ReactNode } from "react";
+import { rideImportStatusCopy } from "../../ride-import.js";
+import { setManualSyncFocusTarget } from "../../state/manual-sync-focus.js";
+import { useEnduragentStore } from "../../state/store.js";
+import {
+  formatDateLabel,
+  formatPercentage,
+  formatSleepDuration,
+  formatUtcTimestamp,
+  formatWholeNumber,
+} from "../../training-context/format.js";
 import { Page } from "../shared/Page.js";
+import {
+  MAX_VISIBLE_PLAN_ITEMS,
+  RIDE_IMPORT_DESCRIPTION,
+  TRAINING_UNKNOWN_COPY,
+  WELLNESS_LABELS,
+  stalenessCopy,
+  trainingStatusCopy,
+} from "./copy.js";
 import styles from "./TrainingView.module.css";
+import { WellnessSparkline } from "./WellnessSparkline.js";
+
+function Panel(props: {
+  readonly name: string;
+  readonly title: string;
+  readonly children: ReactNode;
+}): ReactElement {
+  return (
+    <section className={styles.panel} data-panel={props.name} aria-label={props.title}>
+      <h2 className={styles.panelTitle}>{props.title}</h2>
+      <div className={styles.panelBody}>{props.children}</div>
+    </section>
+  );
+}
+
+function Unknown(props: { readonly reason: keyof typeof TRAINING_UNKNOWN_COPY }): ReactElement {
+  return <p className={styles.empty}>{TRAINING_UNKNOWN_COPY[props.reason]}</p>;
+}
+
+function SyncPanel(): ReactElement {
+  const metadata = useEnduragentStore((store) => store.training.metadata);
+  const sync = useEnduragentStore((store) => store.sync);
+  const actions = useEnduragentStore((store) => store.syncActions);
+  const action = useRef<HTMLButtonElement>(null);
+  const synced = metadata?.lastSynced ?? null;
+  const syncedCopy = synced === null ? null : formatUtcTimestamp(synced);
+  const syncedInstant =
+    synced === null || syncedCopy === "Unknown sync time" ? null : new Date(synced).toISOString();
+
+  return (
+    <Panel name="sync" title="Sync">
+      <div className={`${styles.metadata} training-metadata`}>
+        {metadata === null ? null : (
+          <>
+            <p className={`${styles.meta} training-metadata-item`}>
+              As of {formatDateLabel(metadata.lastUpdated)}
+            </p>
+            <p className={styles.badge}>{metadata.freshness}</p>
+            {metadata.degraded ? (
+              <p className={`${styles.meta} training-metadata-item`}>Data may be incomplete</p>
+            ) : null}
+            {syncedCopy === null ? null : (
+              <p className={`${styles.meta} training-metadata-item`}>
+                Last synced{" "}
+                {syncedInstant === null ? (
+                  syncedCopy
+                ) : (
+                  <time dateTime={syncedInstant}>{syncedCopy}</time>
+                )}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+      <div className={styles.syncRow} data-tone={sync.tone}>
+        <button
+          type="button"
+          ref={action}
+          className={`${styles.action} training-sync-action`}
+          disabled={sync.disabled || actions === null}
+          aria-busy={sync.busy ? "true" : undefined}
+          onClick={(event) => {
+            const keyboard = event.detail === 0;
+            setManualSyncFocusTarget(keyboard ? action.current : null);
+            actions?.request(keyboard ? "keyboard" : "pointer");
+          }}
+        >
+          {sync.label}
+        </button>
+        <p
+          className={`${styles.syncMessage} training-sync-message`}
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {sync.message}
+        </p>
+      </div>
+    </Panel>
+  );
+}
+
+function AnchorPanel(props: { readonly panel: AnchorZonesPanel }): ReactElement {
+  if (props.panel.kind === "unknown") {
+    return (
+      <Panel name="anchor" title="Current cycling anchor">
+        <Unknown reason={props.panel.reason} />
+      </Panel>
+    );
+  }
+  const { anchor, asOf, zones } = props.panel;
+  return (
+    <Panel name="anchor" title="Current cycling anchor">
+      <p className={styles.value}>{formatWholeNumber(anchor.watts)} W</p>
+      <p className={styles.badge} data-band={anchor.stalenessBand}>
+        {stalenessCopy(anchor.stalenessBand, anchor.ageDays)}
+      </p>
+      <p className={styles.meta}>
+        As of {formatDateLabel(asOf)} · {anchor.source} · {anchor.confidence}
+      </p>
+      <h3 className={styles.subheading}>Power zones</h3>
+      <dl className={styles.zones}>
+        {zones.map((zone) => (
+          <div className={styles.zone} key={zone.name}>
+            <dt className={styles.zoneName} data-overlaps={zone.overlaps ? "true" : undefined}>
+              {zone.name}
+            </dt>
+            <dd className={styles.zoneRange}>{zone.range}</dd>
+          </div>
+        ))}
+      </dl>
+    </Panel>
+  );
+}
+
+function LoadPanel(props: { readonly panel: CyclingLoadPanel }): ReactElement {
+  if (props.panel.kind === "unknown") {
+    return (
+      <Panel name="load" title="Cycling Load">
+        <Unknown reason={props.panel.reason} />
+      </Panel>
+    );
+  }
+  return (
+    <Panel name="load" title="Cycling Load">
+      <p className={styles.value}>{formatWholeNumber(props.panel.value)}</p>
+      <p className={styles.meta}>From intervals.icu · 7 days</p>
+      <p className={styles.support}>{props.panel.activityCount} cycling activities</p>
+      {props.panel.missingLoadCount > 0 ? (
+        <p className={styles.support}>
+          {props.panel.missingLoadCount} cycling activities have no platform Load
+        </p>
+      ) : null}
+    </Panel>
+  );
+}
+
+function UpcomingPlanPanel(props: { readonly panel: PlanPanel }): ReactElement {
+  if (props.panel.kind === "unknown") {
+    return (
+      <Panel name="plan" title="Plan">
+        <Unknown reason={props.panel.reason} />
+      </Panel>
+    );
+  }
+  return (
+    <Panel name="plan" title="Plan">
+      <ol className={styles.plan}>
+        {props.panel.items.slice(0, MAX_VISIBLE_PLAN_ITEMS).map((item) => (
+          <li className={styles.planItem} key={item.id}>
+            <strong>{item.name ?? "Cycling workout"}</strong>
+            <span>
+              {formatDateLabel(item.date)} · {item.workoutType}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </Panel>
+  );
+}
+
+function AdherenceStatePanel(props: { readonly panel: AdherencePanel }): ReactElement {
+  if (props.panel.kind === "unknown") {
+    return (
+      <Panel name="adherence" title="Adherence">
+        <Unknown reason={props.panel.reason} />
+      </Panel>
+    );
+  }
+  return (
+    <Panel name="adherence" title="Adherence">
+      <p className={styles.value}>{formatPercentage(props.panel.ratio)}</p>
+      <p className={styles.support}>
+        {props.panel.matchedDays}/{props.panel.plannedDays} planned days matched
+      </p>
+      <p className={styles.meta}>
+        {props.panel.completedDays} completed days · As of {formatDateLabel(props.panel.asOf)}
+      </p>
+    </Panel>
+  );
+}
+
+function WellnessPanel(props: { readonly panel: WellnessTrendPanel }): ReactElement {
+  if (props.panel.kind === "unknown") {
+    return (
+      <Panel name="wellness" title="Wellness trend">
+        <Unknown reason={props.panel.reason} />
+      </Panel>
+    );
+  }
+  return (
+    <Panel name="wellness" title="Wellness trend">
+      <p className={styles.meta}>As of {formatDateLabel(props.panel.asOf)} · 7 mornings</p>
+      <div className={styles.wellness}>
+        {props.panel.series.map((series, index) => {
+          const latest = series.points.at(-1);
+          return (
+            <div className={styles.wellnessRow} key={series.metric}>
+              <strong>{WELLNESS_LABELS[index]}</strong>
+              <span className={styles.wellnessValue}>
+                {latest === undefined
+                  ? "No readings"
+                  : series.metric === "sleep"
+                    ? formatSleepDuration(latest.value)
+                    : `${formatWholeNumber(latest.value)} ${series.unit}`}
+              </span>
+              <WellnessSparkline series={series} />
+            </div>
+          );
+        })}
+      </div>
+    </Panel>
+  );
+}
+
+function RideImportPanel(): ReactElement {
+  const state = useEnduragentStore((store) => store.rideImport);
+  const suppressed = useEnduragentStore((store) => store.rideImportSuppressed);
+  const actions = useEnduragentStore((store) => store.rideImportActions);
+  const copy = suppressed ? "" : rideImportStatusCopy(state);
+  const progress = state.status === "running" ? state.progress : null;
+
+  return (
+    <Panel name="ride-import" title="Import ride files">
+      <p className={styles.support}>{RIDE_IMPORT_DESCRIPTION}</p>
+      <button
+        type="button"
+        className={`${styles.action} ride-import-action`}
+        disabled={actions === null || state.status === "running"}
+        aria-describedby="ride-import-status"
+        onClick={() => {
+          actions?.choose();
+        }}
+      >
+        Import ride files
+      </button>
+      {progress === null ? null : (
+        <p className={styles.meta}>
+          {progress.params.event.completed} of {progress.params.event.total} files processed
+        </p>
+      )}
+      <p
+        id="ride-import-status"
+        className={`${styles.support} ride-import-status`}
+        data-state={suppressed ? "idle" : state.status}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        hidden={copy.length === 0}
+      >
+        {copy}
+      </p>
+    </Panel>
+  );
+}
 
 export function TrainingView(): ReactElement {
+  const training = useEnduragentStore((store) => store.training);
+  const status = trainingStatusCopy(training.status);
+
   return (
-    <Page title="Training">
-      <p className={styles.note}>
-        Your wellness, zones, plan and sync still live in the training data drawer on the chat
-        page; they move onto this page later in the renderer rebuild.
+    <Page title="Training" busy={training.status === "loading"}>
+      <p className={`${styles.status} training-status`} hidden={training.status === "ready"}>
+        {status}
       </p>
+      <SyncPanel />
+      <AnchorPanel panel={training.trainingContext.anchorZones} />
+      <LoadPanel panel={training.trainingContext.cyclingLoad} />
+      <UpcomingPlanPanel panel={training.trainingContext.plan} />
+      <AdherenceStatePanel panel={training.trainingContext.adherence} />
+      <WellnessPanel panel={training.trainingContext.wellnessTrend} />
+      <RideImportPanel />
     </Page>
   );
 }

--- a/apps/desktop-renderer/src/ui/training/WellnessSparkline.tsx
+++ b/apps/desktop-renderer/src/ui/training/WellnessSparkline.tsx
@@ -1,0 +1,29 @@
+import type { WellnessSeries } from "@enduragent/coach-contract";
+import type { ReactElement } from "react";
+import styles from "./TrainingView.module.css";
+
+export function WellnessSparkline(props: {
+  readonly series: WellnessSeries;
+}): ReactElement {
+  const points = props.series.points;
+  if (points.length === 0) {
+    return <span className={styles.wellnessEmpty}>No readings</span>;
+  }
+  const values = points.map((point) => point.value);
+  const minimum = Math.min(...values);
+  const maximum = Math.max(...values);
+  const denominator = Math.max(1, points.length - 1);
+  const path = points
+    .map((point, index) => {
+      const x = (index / denominator) * 116 + 2;
+      const y = minimum === maximum ? 15 : 27 - ((point.value - minimum) / (maximum - minimum)) * 24;
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return (
+    <svg className={styles.sparkline} viewBox="0 0 120 30" aria-hidden="true">
+      <polyline points={path} />
+    </svg>
+  );
+}

--- a/apps/desktop-renderer/src/ui/training/copy.ts
+++ b/apps/desktop-renderer/src/ui/training/copy.ts
@@ -1,0 +1,33 @@
+import type { CyclingAnchor, TrainingContextUnknownReason } from "@enduragent/coach-contract";
+import type { TrainingContextStatus } from "../../training-context/controller.js";
+
+export const MAX_VISIBLE_PLAN_ITEMS = 7;
+
+export const TRAINING_UNKNOWN_COPY: Readonly<Record<TrainingContextUnknownReason, string>> = {
+  "not-synced": "Not synced yet",
+  "missing-anchor": "No cycling FTP anchor is available",
+  "no-platform-load": "No platform Load is available for the last 7 days",
+  "no-plan": "No planned cycling workouts are available",
+  "insufficient-data": "Not enough persisted data to show this yet",
+  "no-wellness": "No wellness readings are available",
+};
+
+export const WELLNESS_LABELS: readonly string[] = ["HRV", "Sleep", "Resting HR"];
+
+export const RIDE_IMPORT_DESCRIPTION =
+  "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.";
+
+export function trainingStatusCopy(status: TrainingContextStatus): string {
+  if (status === "loading") return "Loading training data…";
+  if (status === "unavailable") return "Training data unavailable";
+  if (status === "refresh-unavailable") return "Refresh unavailable";
+  return "";
+}
+
+export function stalenessCopy(band: CyclingAnchor["stalenessBand"], ageDays: number): string {
+  const days = Math.floor(ageDays);
+  if (band === "fresh") return "Fresh";
+  if (band === "aging") return `Aging · ${days}d`;
+  if (band === "stale") return `Stale · ${days}d`;
+  return `Very stale · ${days}d`;
+}

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -312,7 +312,7 @@ describe("chat surface", () => {
   describe("new conversation dialog", () => {
     it("walks the confirm flow and hands focus back to the composer", async () => {
       const user = userEvent.setup();
-      render(<Shell onHostsReady={() => {}} />);
+      render(<Shell onReady={() => {}} />);
       const dialog = document.querySelector(".new-conversation-dialog");
       if (!(dialog instanceof HTMLDialogElement)) throw new TypeError("dialog missing");
       expect(dialog.open).toBe(false);
@@ -341,7 +341,7 @@ describe("chat surface", () => {
       useEnduragentStore.setState({
         chat: { ...EMPTY_CHAT_SURFACE, newConversationUnavailable: false },
       });
-      render(<Shell onHostsReady={() => {}} />);
+      render(<Shell onReady={() => {}} />);
 
       setChat({ resetPhase: "confirming" });
       await user.click(screen.getByRole("button", { name: "Cancel" }));

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Shell } from "../src/app/Shell.js";
-import type { LegacyHosts } from "../src/legacy-boot.js";
 import { EMPTY_CHAT_SURFACE, type ChatActions } from "../src/state/chat-slice.js";
 import { resetChatStream } from "../src/state/chat-stream.js";
 import { useEnduragentStore } from "../src/state/store.js";
@@ -36,7 +35,7 @@ describe("shell", () => {
   });
 
   it("renders the sidebar and the chat region by default", () => {
-    render(<Shell onHostsReady={() => {}} />);
+    render(<Shell onReady={() => {}} />);
 
     expect(screen.getByText("Enduragent")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "New chat" })).toBeEnabled();
@@ -45,26 +44,31 @@ describe("shell", () => {
     expect(document.querySelector("div.thread")).not.toBeNull();
     expect(document.querySelector("div.composer-wrap")).not.toBeNull();
     expect(document.querySelector("textarea#message")).not.toBeNull();
-    expect(document.querySelector('.drawer[aria-label="Training data"]')).not.toBeNull();
+    expect(document.querySelector("button.sync-chip")).not.toBeNull();
+    expect(document.querySelector('[data-view="chat"]')).not.toBeNull();
   });
 
-  it("hands every legacy host to the boot callback once", () => {
-    const onHostsReady = vi.fn<(hosts: LegacyHosts) => void>();
+  it("retires the training drawer, data spine and topbar strip", () => {
+    render(<Shell onReady={() => {}} />);
 
-    const { rerender } = render(<Shell onHostsReady={onHostsReady} />);
-    rerender(<Shell onHostsReady={onHostsReady} />);
+    expect(document.querySelector('.drawer[aria-label="Training data"]')).toBeNull();
+    expect(document.querySelector(".data-spine")).toBeNull();
+    expect(document.querySelector("header.topbar")).toBeNull();
+    expect(document.querySelector(".setup-button")).toBeNull();
+  });
 
-    expect(onHostsReady).toHaveBeenCalledTimes(1);
-    const hosts = onHostsReady.mock.calls[0][0];
-    expect(hosts.topbar.classList.contains("topbar")).toBe(true);
-    expect(hosts.spine.classList.contains("data-spine")).toBe(true);
-    expect(hosts.drawer).toBeInstanceOf(HTMLDialogElement);
-    expect(hosts.drawer.getAttribute("aria-label")).toBe("Training data");
+  it("signals boot readiness once", () => {
+    const onReady = vi.fn<() => void>();
+
+    const { rerender } = render(<Shell onReady={onReady} />);
+    rerender(<Shell onReady={onReady} />);
+
+    expect(onReady).toHaveBeenCalledTimes(1);
   });
 
   it("switches the main region between the registered views", async () => {
     const user = userEvent.setup();
-    render(<Shell onHostsReady={() => {}} />);
+    render(<Shell onReady={() => {}} />);
 
     await user.click(screen.getByRole("button", { name: "Training" }));
     expect(await screen.findByRole("region", { name: "Training" })).toBeInTheDocument();
@@ -82,8 +86,8 @@ describe("shell", () => {
 
   it("keeps the chat surface mounted while another view is shown", async () => {
     const user = userEvent.setup();
-    const onHostsReady = vi.fn<(hosts: LegacyHosts) => void>();
-    render(<Shell onHostsReady={onHostsReady} />);
+    const onReady = vi.fn<() => void>();
+    render(<Shell onReady={onReady} />);
     const thread = document.querySelector("div.thread");
     const noticeHost = document.querySelector("div.chat-notice-host");
 
@@ -93,12 +97,12 @@ describe("shell", () => {
     expect(thread?.isConnected).toBe(true);
     expect(noticeHost?.isConnected).toBe(true);
     expect(document.querySelector("textarea#message")).not.toBeNull();
-    expect(onHostsReady).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledTimes(1);
   });
 
   it("disables the new chat button until the chat controller is bound", () => {
     useEnduragentStore.setState({ chatActions: null });
-    render(<Shell onHostsReady={() => {}} />);
+    render(<Shell onReady={() => {}} />);
 
     expect(screen.getByRole("button", { name: "New chat" })).toBeDisabled();
   });
@@ -107,7 +111,7 @@ describe("shell", () => {
     const user = userEvent.setup();
     const actions = stubActions();
     useEnduragentStore.setState({ chatActions: actions, activeView: "settings" });
-    render(<Shell onHostsReady={() => {}} />);
+    render(<Shell onReady={() => {}} />);
 
     await user.click(screen.getByRole("button", { name: "New chat" }));
 
@@ -126,7 +130,7 @@ describe("shell", () => {
         resetPhase: "uncertain",
       },
     });
-    render(<Shell onHostsReady={() => {}} />);
+    render(<Shell onReady={() => {}} />);
 
     const opener = screen.getByRole("button", { name: "New chat" });
     expect(opener).toBeEnabled();

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -1,0 +1,186 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConnectionStatus } from "../src/state/connection-slice.js";
+import { EMPTY_CHAT_SURFACE, type ChatActions } from "../src/state/chat-slice.js";
+import { restoreManualSyncFocus, setManualSyncFocusTarget } from "../src/state/manual-sync-focus.js";
+import { focusSetupOpener } from "../src/state/setup-opener.js";
+import { useEnduragentStore } from "../src/state/store.js";
+import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
+import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
+import { toManualSyncViewState } from "../src/training-context/manual-sync.js";
+import { Sidebar } from "../src/ui/sidebar/Sidebar.js";
+
+function stubActions(): ChatActions {
+  return {
+    submit: vi.fn(),
+    retry: vi.fn(),
+    loadEarlier: vi.fn(),
+    retryHydration: vi.fn(),
+    openNewConversation: vi.fn(),
+    cancelNewConversation: vi.fn(),
+    confirmNewConversation: vi.fn(),
+    retryFirstSync: vi.fn(),
+  };
+}
+
+function update(patch: Partial<Parameters<typeof useEnduragentStore.setState>[0]>): void {
+  act(() => {
+    useEnduragentStore.setState(patch);
+  });
+}
+
+function chip(): HTMLElement {
+  const element = document.querySelector("button.sync-chip");
+  if (!(element instanceof HTMLElement)) throw new TypeError("sync chip missing");
+  return element;
+}
+
+beforeEach(() => {
+  useEnduragentStore.setState({
+    activeView: "chat",
+    chat: { ...EMPTY_CHAT_SURFACE, newConversationUnavailable: false },
+    chatActions: stubActions(),
+    training: EMPTY_TRAINING_SURFACE,
+    sync: IDLE_MANUAL_SYNC,
+    syncActions: null,
+    connection: "connecting",
+  });
+});
+
+afterEach(() => {
+  setManualSyncFocusTarget(null);
+  useEnduragentStore.setState({
+    chat: EMPTY_CHAT_SURFACE,
+    chatActions: null,
+    training: EMPTY_TRAINING_SURFACE,
+    sync: IDLE_MANUAL_SYNC,
+    syncActions: null,
+    connection: "connecting",
+  });
+});
+
+describe("sidebar sync chip", () => {
+  it("walks the loading, synced, syncing and attention states", () => {
+    render(<Sidebar />);
+
+    expect(chip()).toHaveAttribute("data-status", "loading");
+    expect(chip()).toHaveTextContent("Loading training data");
+
+    update({
+      training: {
+        ...EMPTY_TRAINING_SURFACE,
+        status: "ready",
+        metadata: {
+          lastUpdated: "1998-07-19T08:00:00.000Z",
+          lastSynced: "1998-07-19T07:55:00.000Z",
+          freshness: "fresh",
+          degraded: false,
+        },
+      },
+    });
+    expect(chip()).toHaveAttribute("data-status", "synced");
+    expect(chip()).toHaveTextContent("1998-07-19 07:55:00 UTC");
+
+    update({ sync: toManualSyncViewState({ status: "running", operation: 1 }) });
+    expect(chip()).toHaveAttribute("data-status", "syncing");
+    expect(chip()).toBeDisabled();
+
+    update({
+      sync: toManualSyncViewState({
+        status: "failed",
+        operation: 1,
+        kind: "partial",
+        retryable: true,
+      }),
+    });
+    expect(chip()).toHaveAttribute("data-status", "attention");
+    expect(chip()).toHaveTextContent("Try again");
+  });
+
+  it("reports never-synced and unavailable training data honestly", () => {
+    render(<Sidebar />);
+
+    update({ training: { ...EMPTY_TRAINING_SURFACE, status: "ready" } });
+    expect(chip()).toHaveAttribute("data-status", "never");
+    expect(chip()).toHaveTextContent("Not synced yet");
+
+    update({ training: { ...EMPTY_TRAINING_SURFACE, status: "unavailable" } });
+    expect(chip()).toHaveAttribute("data-status", "unavailable");
+    expect(chip()).toHaveTextContent("Training data unavailable");
+  });
+
+  it("requests a manual sync and restores keyboard focus to the activator", async () => {
+    const user = userEvent.setup();
+    const request = vi.fn();
+    useEnduragentStore.setState({ syncActions: { request } });
+    render(<Sidebar />);
+
+    await user.click(chip());
+    expect(request).toHaveBeenNthCalledWith(1, "pointer");
+    act(() => {
+      chip().blur();
+    });
+    restoreManualSyncFocus();
+    expect(document.activeElement).toBe(document.body);
+
+    fireEvent.click(chip());
+    expect(request).toHaveBeenNthCalledWith(2, "keyboard");
+    restoreManualSyncFocus();
+    expect(document.activeElement).toBe(chip());
+  });
+
+  it("stays inert until the sync controller is bound", () => {
+    render(<Sidebar />);
+
+    expect(chip()).toBeDisabled();
+  });
+});
+
+describe("sidebar conversations", () => {
+  it("lists the single live conversation and says so", async () => {
+    const user = userEvent.setup();
+    useEnduragentStore.setState({ activeView: "settings" });
+    render(<Sidebar />);
+
+    const entry = screen.getByRole("button", { name: /Current conversation/u });
+    expect(entry).not.toHaveAttribute("aria-current");
+    expect(screen.getByText("Enduragent keeps one conversation on this Mac.")).toBeInTheDocument();
+
+    await user.click(entry);
+    expect(useEnduragentStore.getState().activeView).toBe("chat");
+  });
+});
+
+describe("sidebar connection status", () => {
+  it("names each connection state at the sidebar foot", () => {
+    render(<Sidebar />);
+
+    const status = document.querySelector(".connection-status");
+    expect(status).toHaveAttribute("role", "status");
+    expect(status).toHaveTextContent("Connecting…");
+
+    const expected: readonly [ConnectionStatus, string, string][] = [
+      ["ready", "Connected", "connected"],
+      ["connected", "Connected", "connected"],
+      ["recovering", "Reconnecting…", "recovering"],
+      ["terminal", "Connection unavailable", "unavailable"],
+      ["failed", "Connection unavailable", "unavailable"],
+      ["closing", "Closing…", "pending"],
+    ];
+    for (const [connection, copy, tone] of expected) {
+      update({ connection });
+      expect(status).toHaveTextContent(copy);
+      expect(status).toHaveAttribute("data-tone", tone);
+    }
+  });
+});
+
+describe("sidebar setup opener", () => {
+  it("hands setup focus back to the settings destination", () => {
+    render(<Sidebar />);
+
+    focusSetupOpener();
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: /Settings/u }));
+  });
+});

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -1,0 +1,421 @@
+import type {
+  CoachOperationProgressNotificationEnvelope,
+  CyclingTrainingContext,
+  ImportFilesRpcResult,
+} from "@enduragent/coach-contract";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RideImportState } from "../src/ride-import.js";
+import { IDLE_RIDE_IMPORT } from "../src/state/ride-import-slice.js";
+import { useEnduragentStore } from "../src/state/store.js";
+import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
+import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
+import type { TrainingContextViewState } from "../src/training-context/controller.js";
+import { toManualSyncViewState } from "../src/training-context/manual-sync.js";
+import { TrainingView } from "../src/ui/training/TrainingView.js";
+
+function planItem(index: number) {
+  return {
+    id: `plan-${index}`,
+    date: `1998-07-${String(10 + index).padStart(2, "0")}`,
+    name: `Endurance ride ${index}`,
+    category: "WORKOUT" as const,
+    workoutType: "Ride",
+  };
+}
+
+const context: CyclingTrainingContext = {
+  anchorZones: {
+    kind: "computed",
+    asOf: "1998-07-19T08:00:00.000Z",
+    anchor: {
+      watts: 268,
+      validFrom: "1998-07-01",
+      source: "intervals.icu",
+      confidence: "platform",
+      ageDays: 18.4,
+      stalenessBand: "aging",
+      stale: true,
+    },
+    zones: [
+      { name: "Recovery", range: "0–147 W", overlaps: false },
+      { name: "Endurance", range: "148–201 W", overlaps: true },
+    ],
+  },
+  cyclingLoad: {
+    kind: "computed",
+    asOf: "1998-07-19T08:00:00.000Z",
+    source: "intervals.icu",
+    windowDays: 7,
+    value: 412,
+    activityCount: 5,
+    missingLoadCount: 2,
+  },
+  plan: {
+    kind: "computed",
+    asOf: "1998-07-19T08:00:00.000Z",
+    items: Array.from({ length: 9 }, (_, index) => planItem(index + 1)),
+  },
+  adherence: {
+    kind: "computed",
+    asOf: "1998-07-19T08:00:00.000Z",
+    ratio: 0.8,
+    plannedDays: 5,
+    completedDays: 4,
+    matchedDays: 4,
+  },
+  wellnessTrend: {
+    kind: "computed",
+    asOf: "1998-07-19T08:00:00.000Z",
+    windowDays: 7,
+    series: [
+      {
+        metric: "hrv",
+        unit: "ms",
+        points: [
+          { date: "1998-07-18", value: 60 },
+          { date: "1998-07-19", value: 70 },
+        ],
+      },
+      { metric: "sleep", unit: "seconds", points: [{ date: "1998-07-19", value: 27_000 }] },
+      { metric: "resting-hr", unit: "bpm", points: [] },
+    ],
+  },
+};
+
+const unknownContext: CyclingTrainingContext = {
+  anchorZones: { kind: "unknown", reason: "missing-anchor" },
+  cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
+  plan: { kind: "unknown", reason: "no-plan" },
+  adherence: { kind: "unknown", reason: "insufficient-data" },
+  wellnessTrend: { kind: "unknown", reason: "no-wellness" },
+};
+
+function ready(overrides: Partial<TrainingContextViewState> = {}): TrainingContextViewState {
+  return {
+    status: "ready",
+    metadata: {
+      lastUpdated: "1998-07-19T08:00:00.000Z",
+      lastSynced: "1998-07-19T07:55:00.000Z",
+      freshness: "fresh",
+      degraded: false,
+    },
+    trainingContext: context,
+    unitsPreference: { status: "ready", value: "metric", source: "default" },
+    ...overrides,
+  };
+}
+
+function importResult(imported: number, quarantined: number): ImportFilesRpcResult {
+  return {
+    schemaVersion: 2,
+    files: { total: imported + quarantined, imported, quarantined },
+    changes: {
+      rawFilesInserted: imported,
+      sourceRecordsInserted: imported,
+      sourceRecordsUpdated: 0,
+      relinkedSourceRecords: 0,
+    },
+    publication: { scope: "activities-and-streams", status: "available" },
+  };
+}
+
+function progressEnvelope(completed: number): CoachOperationProgressNotificationEnvelope {
+  return {
+    jsonrpc: "2.0",
+    method: "coach.operationProgress",
+    params: {
+      requestId: 3,
+      requestMethod: "importFiles",
+      event: { phase: completed === 0 ? "started" : "completed", completed, total: 4 },
+    },
+  };
+}
+
+function update(patch: Partial<Parameters<typeof useEnduragentStore.setState>[0]>): void {
+  act(() => {
+    useEnduragentStore.setState(patch);
+  });
+}
+
+function setRideImport(state: RideImportState): void {
+  update({ rideImport: state });
+}
+
+beforeEach(() => {
+  useEnduragentStore.setState({
+    activeView: "training",
+    training: ready(),
+    sync: IDLE_MANUAL_SYNC,
+    syncActions: null,
+    rideImport: IDLE_RIDE_IMPORT,
+    rideImportSuppressed: false,
+    rideImportActions: null,
+  });
+});
+
+afterEach(() => {
+  useEnduragentStore.setState({
+    activeView: "chat",
+    training: EMPTY_TRAINING_SURFACE,
+    sync: IDLE_MANUAL_SYNC,
+    syncActions: null,
+    rideImport: IDLE_RIDE_IMPORT,
+    rideImportSuppressed: false,
+    rideImportActions: null,
+  });
+});
+
+describe("training page", () => {
+  it("renders every panel in the pinned order with the training data as of its own timestamps", () => {
+    render(<TrainingView />);
+
+    expect(screen.getByRole("region", { name: "Training" })).toBeInTheDocument();
+    const headings = [...document.querySelectorAll("[data-panel] h2")];
+    expect(headings.map((node) => node.textContent)).toEqual([
+      "Sync",
+      "Current cycling anchor",
+      "Cycling Load",
+      "Plan",
+      "Adherence",
+      "Wellness trend",
+      "Import ride files",
+    ]);
+    expect(screen.getByText("268 W")).toBeInTheDocument();
+    expect(screen.getByText("Aging · 18d")).toBeInTheDocument();
+    expect(screen.getByText("As of 1998-07-19 · intervals.icu · platform")).toBeInTheDocument();
+    expect(screen.getByText("412")).toBeInTheDocument();
+    expect(screen.getByText("5 cycling activities")).toBeInTheDocument();
+    expect(screen.getByText("2 cycling activities have no platform Load")).toBeInTheDocument();
+    expect(screen.getByText("80%")).toBeInTheDocument();
+    expect(screen.getByText("4/5 planned days matched")).toBeInTheDocument();
+    expect(document.querySelector(".training-status")).toHaveProperty("hidden", true);
+  });
+
+  it("renders the power zones and caps the plan at seven upcoming workouts", () => {
+    render(<TrainingView />);
+
+    const zones = within(screen.getByRole("region", { name: "Current cycling anchor" }));
+    expect(zones.getByText("Recovery")).toBeInTheDocument();
+    expect(zones.getByText("148–201 W")).toBeInTheDocument();
+    expect(zones.getByText("Endurance")).toHaveAttribute("data-overlaps", "true");
+
+    const plan = within(screen.getByRole("region", { name: "Plan" }));
+    expect(plan.getAllByRole("listitem")).toHaveLength(7);
+    expect(plan.getByText("Endurance ride 1")).toBeInTheDocument();
+    expect(plan.queryByText("Endurance ride 8")).toBeNull();
+  });
+
+  it("draws a sparkline per wellness series from the athlete-state readings", () => {
+    render(<TrainingView />);
+
+    const wellness = screen.getByRole("region", { name: "Wellness trend" });
+    const lines = [...wellness.querySelectorAll("svg polyline")];
+    expect(lines).toHaveLength(2);
+    expect(lines[0]?.getAttribute("points")).toBe("2,27 118,3");
+    expect(lines[1]?.getAttribute("points")).toBe("2,15");
+    expect(within(wellness).getByText("70 ms")).toBeInTheDocument();
+    expect(within(wellness).getByText("7h 30m")).toBeInTheDocument();
+    expect(within(wellness).getAllByText("No readings")).toHaveLength(2);
+  });
+
+  it("explains every unknown panel and announces the loading status", () => {
+    useEnduragentStore.setState({
+      training: ready({ status: "loading", metadata: null, trainingContext: unknownContext }),
+    });
+    render(<TrainingView />);
+
+    expect(screen.getByText("Loading training data…")).toBeVisible();
+    expect(screen.getByRole("region", { name: "Training" })).toHaveAttribute("aria-busy", "true");
+    for (const copy of [
+      "No cycling FTP anchor is available",
+      "No platform Load is available for the last 7 days",
+      "No planned cycling workouts are available",
+      "Not enough persisted data to show this yet",
+      "No wellness readings are available",
+    ]) {
+      expect(screen.getByText(copy)).toBeInTheDocument();
+    }
+    expect(document.querySelector(".training-metadata")?.children).toHaveLength(0);
+  });
+});
+
+describe("training page sync", () => {
+  it("shows the sync metadata with a machine-readable last-synced instant", () => {
+    render(<TrainingView />);
+
+    const metadata = document.querySelector(".training-metadata");
+    expect([...(metadata?.children ?? [])].map((node) => node.textContent)).toEqual([
+      "As of 1998-07-19",
+      "fresh",
+      "Last synced 1998-07-19 07:55:00 UTC",
+    ]);
+    expect(metadata?.querySelector("time")).toHaveAttribute(
+      "datetime",
+      "1998-07-19T07:55:00.000Z",
+    );
+  });
+
+  it("keeps an unparsable sync instant out of the markup", () => {
+    useEnduragentStore.setState({
+      training: ready({
+        metadata: {
+          lastUpdated: "1998-07-19T08:00:00.000Z",
+          lastSynced: "private-invalid-sync-value",
+          freshness: "flag",
+          degraded: true,
+        },
+      }),
+    });
+    render(<TrainingView />);
+
+    const metadata = document.querySelector(".training-metadata");
+    expect([...(metadata?.children ?? [])].map((node) => node.textContent)).toEqual([
+      "As of 1998-07-19",
+      "flag",
+      "Data may be incomplete",
+      "Last synced Unknown sync time",
+    ]);
+    expect(metadata?.querySelector("time")).toBeNull();
+    expect(metadata?.textContent).not.toContain("private-invalid-sync-value");
+  });
+
+  it("routes pointer and keyboard activation at the manual sync controller", async () => {
+    const user = userEvent.setup();
+    const request = vi.fn();
+    useEnduragentStore.setState({ syncActions: { request } });
+    render(<TrainingView />);
+
+    const action = screen.getByRole("button", { name: "Sync now" });
+    await user.click(action);
+    expect(request).toHaveBeenNthCalledWith(1, "pointer");
+
+    fireEvent.click(action);
+    expect(request).toHaveBeenNthCalledWith(2, "keyboard");
+  });
+
+  it("walks the queued, running and terminal sync states", () => {
+    useEnduragentStore.setState({ syncActions: { request: vi.fn() } });
+    render(<TrainingView />);
+
+    const message = document.querySelector(".training-sync-message");
+    expect(message).toHaveAttribute("role", "status");
+    expect(message).toHaveAttribute("aria-live", "polite");
+    expect(message).toHaveAttribute("aria-atomic", "true");
+
+    update({ sync: toManualSyncViewState({ status: "queued", operation: 1 }) });
+    expect(screen.getByRole("button", { name: "Sync now" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Sync now" })).toHaveAttribute("aria-busy", "true");
+    expect(message).toHaveTextContent("Sync queued.");
+
+    update({ sync: toManualSyncViewState({ status: "running", operation: 1 }) });
+    expect(message).toHaveTextContent("Syncing training data…");
+
+    update({
+      sync: toManualSyncViewState({ status: "succeeded", operation: 1, kind: "no-change" }),
+    });
+    const settled = screen.getByRole("button", { name: "Sync again" });
+    expect(settled).toBeEnabled();
+    expect(settled).not.toHaveAttribute("aria-busy");
+    expect(message).toHaveTextContent("Local training-data processing completed.");
+
+    update({
+      sync: toManualSyncViewState({
+        status: "failed",
+        operation: 1,
+        kind: "protocol",
+        retryable: false,
+      }),
+    });
+    expect(screen.getByRole("button", { name: "Sync unavailable" })).toBeDisabled();
+    expect(message).toHaveTextContent("Enduragent couldn’t verify the sync result.");
+  });
+
+  it("disables the sync action until the controller is bound", () => {
+    render(<TrainingView />);
+
+    expect(screen.getByRole("button", { name: "Sync now" })).toBeDisabled();
+  });
+});
+
+describe("training page ride import", () => {
+  it("hands the import request to the resident controller", async () => {
+    const user = userEvent.setup();
+    const choose = vi.fn();
+    useEnduragentStore.setState({ rideImportActions: { choose } });
+    render(<TrainingView />);
+
+    await user.click(screen.getByRole("button", { name: "Import ride files" }));
+    expect(choose).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the picker, progress, success and failure stages", () => {
+    useEnduragentStore.setState({ rideImportActions: { choose: vi.fn() } });
+    render(<TrainingView />);
+
+    const status = document.querySelector(".ride-import-status");
+    expect(status).toHaveProperty("hidden", true);
+    expect(screen.getByRole("button", { name: "Import ride files" })).toHaveAttribute(
+      "aria-describedby",
+      "ride-import-status",
+    );
+
+    setRideImport({
+      status: "running",
+      owner: "resident",
+      stage: "choosing",
+      progress: null,
+      result: null,
+    });
+    expect(status).toHaveTextContent("Waiting for ride file selection…");
+    expect(screen.getByRole("button", { name: "Import ride files" })).toBeDisabled();
+
+    setRideImport({
+      status: "running",
+      owner: "resident",
+      stage: "importing",
+      progress: progressEnvelope(3),
+      result: null,
+    });
+    expect(status).toHaveTextContent("Importing ride files…");
+    expect(screen.getByText("3 of 4 files processed")).toBeInTheDocument();
+
+    setRideImport({
+      status: "succeeded",
+      owner: "resident",
+      progress: null,
+      result: importResult(2, 1),
+    });
+    expect(status).toHaveTextContent(
+      "Local library import: 2 ride files imported. 1 ride file quarantined. Coaching access to activities and streams is available.",
+    );
+    expect(status).toHaveAttribute("data-state", "succeeded");
+
+    setRideImport({ status: "failed", owner: "resident", progress: null, result: null });
+    expect(status).toHaveTextContent(
+      "Local library import failed. The result could not be confirmed; check the library before trying again.",
+    );
+    expect(status).toHaveAttribute("data-state", "failed");
+  });
+
+  it("suppresses the resident status while onboarding owns the import surface", () => {
+    render(<TrainingView />);
+    setRideImport({
+      status: "running",
+      owner: "onboarding",
+      stage: "importing",
+      progress: null,
+      result: null,
+    });
+    update({ rideImportSuppressed: true });
+
+    const status = document.querySelector(".ride-import-status");
+    expect(status).toHaveProperty("hidden", true);
+    expect(status).toHaveAttribute("data-state", "idle");
+
+    update({ rideImportSuppressed: false });
+    expect(status).toHaveProperty("hidden", false);
+    expect(status).toHaveTextContent("Importing ride files…");
+  });
+});

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -295,7 +295,7 @@ async function security() {
       },
       url: ready.url,
       blockedOffPort: ready.blockedOffPort,
-      drawerPresent: ready.drawerPresent,
+      syncChipPresent: ready.syncChipPresent,
       tokenAbsent:
         ready.tokenAbsentInRendererSurfaces === true &&
         !JSON.stringify(running.args).includes(token) &&
@@ -308,7 +308,7 @@ async function security() {
     if (
       Object.values(summary.passes).some((value) => value !== true) ||
       summary.blockedOffPort !== true ||
-      summary.drawerPresent !== true ||
+      summary.syncChipPresent !== true ||
       summary.tokenAbsent !== true ||
       !existsSync(environment.screenshotPath)
     ) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -660,7 +660,7 @@ async function runDesktop(): Promise<void> {
         noNodeGlobals: ["process", "require", "Buffer", "global", "module"].every((key) => typeof window[key] === "undefined"),
         rpcConnected: document.documentElement.dataset.rpc === "connected",
         blockedOffPort: blocked,
-        drawerPresent: document.querySelector('.drawer[aria-label="Training data"]') !== null,
+        syncChipPresent: document.querySelector("button.sync-chip") !== null,
         rendererSurfaces: {
           dom: document.documentElement.outerHTML,
           localStorage: Object.entries(localStorage),
@@ -682,7 +682,7 @@ async function runDesktop(): Promise<void> {
         noNodeGlobals: rendererResult.noNodeGlobals,
         rpcConnected: rendererResult.rpcConnected,
         blockedOffPort: rendererResult.blockedOffPort,
-        drawerPresent: rendererResult.drawerPresent,
+        syncChipPresent: rendererResult.syncChipPresent,
         credentialStatuses: rendererResult.credentialStatuses,
         credentialStatusesMetadataOnly:
           Array.isArray(rendererResult.credentialStatuses) &&

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -103,6 +103,9 @@ const athleteState = {
   trainingContext,
 } as const;
 
+const tallTurn =
+  "Long ride notes that make the newest restored turn taller than the window. ".repeat(52);
+
 function response(value: unknown): readonly string[] {
   return [JSON.stringify(value)];
 }
@@ -188,7 +191,7 @@ ${"nonwrapping".repeat(36)}
                   {
                     turnId: "persisted-turn-4",
                     completedAt: "2001-01-04T00:00:00.000Z",
-                    athleteText: "Persisted athlete 4",
+                    athleteText: `Persisted athlete 4 ${tallTurn}`,
                     coachText: "Persisted coach 4",
                   },
                 ]
@@ -307,7 +310,9 @@ async function launch(input: {
   fixtures.push(fixture);
   await fixture.evaluate<void>(`
     const deadline = Date.now() + 10000;
-    while ((document.documentElement.dataset.rpc !== "connected" || document.querySelector(".drawer-status")?.textContent !== "") && Date.now() < deadline) {
+    await document.fonts.ready;
+    const chipStatus = () => document.querySelector(".sync-chip")?.dataset.status;
+    while ((document.documentElement.dataset.rpc !== "connected" || chipStatus() === undefined || chipStatus() === "loading") && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 20));
     }
     document.querySelector(".onboarding")?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
@@ -597,9 +602,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         readonly rel: string | null;
         readonly referrerPolicy: string | null;
       };
-      readonly drawerStatus: string;
-      readonly anchorValue: string;
-      readonly wellnessValue: string;
+      readonly syncChip: { readonly status: string; readonly text: string };
       readonly documentOverflow: boolean;
     }>(`
       const bridgeKeys = Object.keys(window.enduragentAuth).sort();
@@ -701,7 +704,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       controlObserver.disconnect();
       const coach = document.querySelector(".chat-message--coach");
       const link = coach?.querySelector("a");
-      const panels = [...document.querySelectorAll(".context-panel__body")];
+      const syncChip = document.querySelector(".sync-chip");
       return {
         location: location.href,
         bridgeKeys,
@@ -726,9 +729,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
           rel: link?.getAttribute("rel") ?? null,
           referrerPolicy: link?.getAttribute("referrerpolicy") ?? null,
         },
-        drawerStatus: document.querySelector(".drawer-status")?.textContent ?? "missing",
-        anchorValue: panels[0]?.querySelector(".context-panel__value")?.textContent ?? "",
-        wellnessValue: panels[4]?.querySelector(".wellness-row__value")?.textContent ?? "",
+        syncChip: {
+          status: syncChip?.dataset.status ?? "missing",
+          text: syncChip?.textContent ?? "missing",
+        },
         documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
       };
     `);
@@ -774,9 +778,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         rel: "noopener noreferrer",
         referrerPolicy: "no-referrer",
       },
-      drawerStatus: "",
-      anchorValue: "300 W",
-      wellnessValue: "65 ms",
+      syncChip: {
+        status: "synced",
+        text: "Synced2026-07-19 07:55:00 UTCSync now",
+      },
       documentOverflow: false,
     });
     expect(calls.filter((call) => call.method === "hasSession")).toEqual([
@@ -978,15 +983,15 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         params: { chatId: "desktop" },
       },
     ]);
-    const drawer = await fixture.evaluate<{
-      readonly open: boolean;
-      readonly focused: string | null;
-      readonly label: string | null;
+    const training = await fixture.evaluate<{
+      readonly current: string | null;
       readonly order: readonly string[];
-      readonly spineWidth: number;
-      readonly closedFocus: string | null;
-      readonly overflow: boolean;
-      readonly units: string;
+      readonly status: string;
+      readonly statusHidden: boolean;
+      readonly anchorValue: string;
+      readonly wellnessValue: string;
+      readonly pageOverflow: boolean;
+      readonly documentOverflow: boolean;
       readonly sync: {
         readonly buttonResident: boolean;
         readonly queued: string;
@@ -1006,27 +1011,39 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         readonly asOfAfter: string;
         readonly lastSyncedBefore: string;
         readonly lastSyncedAfter: string;
+        readonly chipStatus: string;
         readonly statusWraps: boolean;
         readonly buttonReachable: boolean;
-        readonly drawerOverflow: boolean;
       };
     }>(`
-      const opener = document.querySelector(".drawer-toggle");
-      opener.click();
-      const drawer = document.querySelector("#training-context-drawer");
+      const rail = document.querySelector('nav[aria-label="Main navigation"]');
+      const trainingNav = Array.from(rail.querySelectorAll("button")).find(
+        (entry) => entry.textContent.includes("Training"),
+      );
+      trainingNav.click();
+      const mountDeadline = Date.now() + 5000;
+      while (!document.querySelector('[data-panel="wellness"]') && Date.now() < mountDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      const page = document.querySelector('section[aria-label="Training"]');
+      const panels = [...page.querySelectorAll("[data-panel]")];
+      const panel = (name) => panels.find((entry) => entry.dataset.panel === name);
+      const statusLine = page.querySelector(".training-status");
       const opened = {
-        open: drawer.open,
-        focused: document.activeElement?.getAttribute("aria-label") ?? null,
-        label: drawer.getAttribute("aria-label"),
-        order: [...drawer.querySelectorAll(".context-panel > h3")].map((node) => node.textContent),
-        spineWidth: document.querySelector(".data-spine").getBoundingClientRect().width,
+        current: trainingNav.getAttribute("aria-current"),
+        order: panels.map((entry) => entry.querySelector("h2").textContent),
+        status: statusLine.textContent,
+        statusHidden: statusLine.hidden,
+        anchorValue: panel("anchor").querySelector("p").textContent,
+        wellnessValue: panel("wellness").querySelector("span").textContent,
       };
-      const syncButton = drawer.querySelector(".training-sync__button");
-      const syncStatus = drawer.querySelector(".training-sync__status");
-      const metadataText = () => [...drawer.querySelectorAll(".drawer-metadata__item")].map((node) => node.textContent ?? "");
-      const metadataChildrenText = () => [...drawer.querySelector(".drawer-metadata").children].map((node) => node.textContent ?? "");
+      const dataPanels = ["anchor", "load", "plan", "adherence", "wellness"];
+      const syncButton = page.querySelector(".training-sync-action");
+      const syncStatus = page.querySelector(".training-sync-message");
+      const metadataText = () => [...page.querySelectorAll(".training-metadata-item")].map((node) => node.textContent ?? "");
+      const metadataChildrenText = () => [...page.querySelector(".training-metadata").children].map((node) => node.textContent ?? "");
       const metadataBefore = metadataChildrenText();
-      const panelsBefore = [...drawer.querySelectorAll(".context-panel__body")].map((node) => node.textContent ?? "");
+      const panelsBefore = dataPanels.map((name) => panel(name).textContent ?? "");
       const asOfBefore = metadataText().find((value) => value.startsWith("As of ")) ?? "";
       const lastSyncedBefore = metadataText().find((value) => value.startsWith("Last synced ")) ?? "";
       const liveValues = [];
@@ -1058,12 +1075,12 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       const asOfAfter = metadataText().find((value) => value.startsWith("As of ")) ?? "";
       const lastSyncedAfter = metadataText().find((value) => value.startsWith("Last synced ")) ?? "";
       const metadataAfter = metadataChildrenText();
-      const panelsAfter = [...drawer.querySelectorAll(".context-panel__body")].map((node) => node.textContent ?? "");
+      const panelsAfter = dataPanels.map((name) => panel(name).textContent ?? "");
       syncStatus.scrollIntoView({ block: "nearest" });
       const syncButtonRect = syncButton.getBoundingClientRect();
-      const drawerRect = drawer.getBoundingClientRect();
+      const pageRect = page.getBoundingClientRect();
       const syncResult = {
-        buttonResident: syncButton === drawer.querySelector(".training-sync__button"),
+        buttonResident: syncButton === page.querySelector(".training-sync-action"),
         queued,
         runningObserved: liveValues.includes("Syncing training data…"),
         terminal: syncStatus.textContent ?? "",
@@ -1091,35 +1108,37 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         asOfAfter,
         lastSyncedBefore,
         lastSyncedAfter,
+        chipStatus: document.querySelector(".sync-chip").dataset.status,
         statusWraps: syncStatus.scrollWidth <= syncStatus.clientWidth,
         buttonReachable:
-          syncButtonRect.top >= drawerRect.top && syncButtonRect.bottom <= drawerRect.bottom,
-        drawerOverflow: drawer.scrollWidth > drawer.clientWidth,
+          syncButtonRect.top >= pageRect.top && syncButtonRect.bottom <= pageRect.bottom,
       };
-      const imperial = drawer.querySelector('input[value="imperial"]');
-      imperial.click();
-      const unitsDeadline = Date.now() + 5000;
-      while ((!imperial.checked || imperial.disabled) && Date.now() < unitsDeadline) {
-        await new Promise((resolve) => setTimeout(resolve, 5));
-      }
-      drawer.querySelector(".drawer-close").click();
       return {
         ...opened,
-        closedFocus: document.activeElement?.getAttribute("aria-label") ?? null,
-        overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
-        units: imperial.checked ? imperial.value : "",
+        pageOverflow: Array.from(page.querySelectorAll("section, div, ol, dl")).some(
+          (node) => node.scrollWidth > node.clientWidth,
+        ),
+        documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
         sync: syncResult,
       };
     `);
-    expect(drawer).toEqual({
-      open: true,
-      focused: "Close training data",
-      label: "Training data",
-      order: ["Current cycling anchor", "Cycling Load", "Plan", "Adherence", "Wellness trend"],
-      spineWidth: 48,
-      closedFocus: "Open training data",
-      overflow: false,
-      units: "imperial",
+    expect(training).toEqual({
+      current: "page",
+      order: [
+        "Sync",
+        "Current cycling anchor",
+        "Cycling Load",
+        "Plan",
+        "Adherence",
+        "Wellness trend",
+        "Import ride files",
+      ],
+      status: "",
+      statusHidden: true,
+      anchorValue: "300 W",
+      wellnessValue: "65 ms",
+      pageOverflow: false,
+      documentOverflow: false,
       sync: {
         buttonResident: true,
         queued: "Sync queued.",
@@ -1139,11 +1158,44 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         asOfAfter: "As of 2026-07-19",
         lastSyncedBefore: "Last synced 2026-07-19 07:55:00 UTC",
         lastSyncedAfter: "Last synced 2026-07-19 07:55:01 UTC",
+        chipStatus: "synced",
         statusWraps: true,
         buttonReachable: true,
-        drawerOverflow: false,
       },
     });
+    const units = await fixture.evaluate<{
+      readonly pressed: string | null;
+      readonly enabled: boolean;
+    }>(`
+      const rail = document.querySelector('nav[aria-label="Main navigation"]');
+      Array.from(rail.querySelectorAll("button"))
+        .find((entry) => entry.textContent.includes("Settings"))
+        .click();
+      const mountDeadline = Date.now() + 5000;
+      while (!document.querySelector('[role="group"][aria-label="Display units"]') && Date.now() < mountDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      const group = document.querySelector('[role="group"][aria-label="Display units"]');
+      const imperial = Array.from(group.querySelectorAll("button")).find(
+        (entry) => entry.textContent === "Imperial",
+      );
+      imperial.click();
+      const unitsDeadline = Date.now() + 5000;
+      while (imperial.getAttribute("aria-pressed") !== "true" && Date.now() < unitsDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const settled = Array.from(
+        document.querySelectorAll('[role="group"][aria-label="Display units"] button'),
+      ).find((entry) => entry.textContent === "Imperial");
+      Array.from(document.querySelectorAll('nav[aria-label="Main navigation"] button'))
+        .find((entry) => entry.textContent.includes("Chat"))
+        .click();
+      return {
+        pressed: settled.getAttribute("aria-pressed"),
+        enabled: !settled.disabled,
+      };
+    `);
+    expect(units).toEqual({ pressed: "true", enabled: true });
     const syncCallIndex = calls.findIndex((call) => call.method === "sync");
     expect(syncCallIndex).toBeGreaterThan(-1);
     expect(calls.filter((call) => call.method === "sync")).toEqual([
@@ -1183,38 +1235,43 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       { jsonrpc: "2.0", method: "setUnitsPreference", params: { value: "imperial" } },
     ]);
     await fixture.setViewport(720, 800);
-    const compactDrawerGeometry = await fixture.evaluate<{
+    const compactTrainingGeometry = await fixture.evaluate<{
       readonly documentOverflow: boolean;
-      readonly topbarFits: boolean;
       readonly settingsResident: boolean;
       readonly settingsReachable: boolean;
       readonly settingsAccessibleLabel: string;
-      readonly drawerOpen: boolean;
+      readonly chipReachable: boolean;
+      readonly trainingOpen: boolean;
       readonly buttonResident: boolean;
       readonly buttonReachable: boolean;
       readonly noChangeStatus: boolean;
       readonly statusFits: boolean;
       readonly horizontalOverflow: boolean;
     }>(`
-      const compactOpener = document.querySelector(".drawer-toggle");
-      compactOpener.click();
-      await new Promise((resolve) => setTimeout(resolve, 250));
-      const topbar = document.querySelector(".topbar");
       const rail = document.querySelector('nav[aria-label="Main navigation"]');
+      Array.from(rail.querySelectorAll("button"))
+        .find((entry) => entry.textContent.includes("Training"))
+        .click();
+      const mountDeadline = Date.now() + 5000;
+      while (!document.querySelector('[data-panel="wellness"]') && Date.now() < mountDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
       const settings = Array.from(rail.querySelectorAll("button")).find(
         (entry) => entry.textContent.includes("Settings"),
       );
-      const compactDrawer = document.querySelector("#training-context-drawer");
-      const compactButton = compactDrawer.querySelector(".training-sync__button");
-      const compactStatus = compactDrawer.querySelector(".training-sync__status");
-      const compactRegion = compactDrawer.querySelector(".training-sync");
-      const drawerRect = compactDrawer.getBoundingClientRect();
+      const page = document.querySelector('section[aria-label="Training"]');
+      const compactButton = page.querySelector(".training-sync-action");
+      const compactStatus = page.querySelector(".training-sync-message");
+      const chip = document.querySelector(".sync-chip");
+      const pageRect = page.getBoundingClientRect();
       const buttonRect = compactButton.getBoundingClientRect();
       const railRect = rail.getBoundingClientRect();
       const settingsRect = settings.getBoundingClientRect();
+      const chipRect = chip.getBoundingClientRect();
+      compactButton.scrollIntoView({ block: "nearest" });
       return {
         documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
-        topbarFits: topbar.scrollWidth <= topbar.clientWidth,
         settingsResident: rail.contains(settings),
         settingsReachable:
           settingsRect.left >= railRect.left &&
@@ -1222,28 +1279,31 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
           settingsRect.top >= railRect.top &&
           settingsRect.bottom <= railRect.bottom,
         settingsAccessibleLabel: settings.textContent.trim(),
-        drawerOpen: compactDrawer.open,
-        buttonResident: compactDrawer.querySelectorAll(".training-sync__button").length === 1,
+        chipReachable:
+          chipRect.left >= 0 &&
+          chipRect.right <= window.innerWidth &&
+          chipRect.bottom <= window.innerHeight,
+        trainingOpen: page.getAttribute("aria-hidden") === null,
+        buttonResident: page.querySelectorAll(".training-sync-action").length === 1,
         buttonReachable:
-          buttonRect.left >= drawerRect.left &&
-          buttonRect.right <= drawerRect.right &&
-          buttonRect.top >= drawerRect.top &&
-          buttonRect.bottom <= Math.min(drawerRect.bottom, window.innerHeight),
+          buttonRect.left >= pageRect.left &&
+          buttonRect.right <= pageRect.right &&
+          buttonRect.top >= pageRect.top &&
+          buttonRect.bottom <= Math.min(pageRect.bottom, window.innerHeight),
         noChangeStatus: compactStatus.textContent === "Local training-data processing completed.",
         statusFits: compactStatus.scrollWidth <= compactStatus.clientWidth,
-        horizontalOverflow:
-          compactDrawer.scrollWidth > compactDrawer.clientWidth ||
-          compactRegion.scrollWidth > compactRegion.clientWidth ||
-          compactStatus.scrollWidth > compactStatus.clientWidth,
+        horizontalOverflow: Array.from(page.querySelectorAll("section, div, ol, dl, p")).some(
+          (node) => node.scrollWidth > node.clientWidth,
+        ),
       };
     `);
-    expect(compactDrawerGeometry).toEqual({
+    expect(compactTrainingGeometry).toEqual({
       documentOverflow: false,
-      topbarFits: true,
       settingsResident: true,
       settingsReachable: true,
       settingsAccessibleLabel: "⚙Settings",
-      drawerOpen: true,
+      chipReachable: true,
+      trainingOpen: true,
       buttonResident: true,
       buttonReachable: true,
       noChangeStatus: true,
@@ -1263,7 +1323,6 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly resetWarningVisible: boolean;
       readonly retentionWarningVisible: boolean;
     }>(`
-      document.querySelector(".drawer-toggle").click();
       const settings = Array.from(
         document.querySelectorAll('nav[aria-label="Main navigation"] button'),
       ).find((entry) => entry.textContent.includes("Settings"));
@@ -1357,21 +1416,26 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       syncOutcome: "partial",
     });
     const compact = await fixture.evaluate<{
-      readonly drawerOpen: boolean;
+      readonly trainingOpen: boolean;
       readonly buttonResident: boolean;
       readonly buttonReachable: boolean;
       readonly terminal: string;
       readonly label: string;
+      readonly chipStatus: string;
       readonly statusWrapped: boolean;
       readonly keyboardFocusRestored: boolean;
       readonly horizontalOverflow: boolean;
     }>(`
-      const opener = document.querySelector(".drawer-toggle");
-      opener.click();
-      const drawer = document.querySelector("#training-context-drawer");
-      const syncButton = drawer.querySelector(".training-sync__button");
-      const syncStatus = drawer.querySelector(".training-sync__status");
-      const syncRegion = drawer.querySelector(".training-sync");
+      Array.from(document.querySelectorAll('nav[aria-label="Main navigation"] button'))
+        .find((entry) => entry.textContent.includes("Training"))
+        .click();
+      const mountDeadline = Date.now() + 5000;
+      while (!document.querySelector(".training-sync-action") && Date.now() < mountDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      const page = document.querySelector('section[aria-label="Training"]');
+      const syncButton = page.querySelector(".training-sync-action");
+      const syncStatus = page.querySelector(".training-sync-message");
       syncButton.focus();
       syncButton.click();
       syncButton.blur();
@@ -1381,37 +1445,39 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       }
       await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
       syncStatus.scrollIntoView({ block: "nearest" });
-      const drawerRect = drawer.getBoundingClientRect();
+      const pageRect = page.getBoundingClientRect();
       const buttonRect = syncButton.getBoundingClientRect();
       const statusRect = syncStatus.getBoundingClientRect();
       const lineHeight = Number.parseFloat(getComputedStyle(syncStatus).lineHeight);
       return {
-        drawerOpen: drawer.open,
-        buttonResident: drawer.querySelectorAll(".training-sync__button").length === 1,
+        trainingOpen: page.getAttribute("aria-hidden") === null,
+        buttonResident: page.querySelectorAll(".training-sync-action").length === 1,
         buttonReachable:
-          buttonRect.left >= drawerRect.left &&
-          buttonRect.right <= drawerRect.right &&
-          buttonRect.top >= drawerRect.top &&
-          buttonRect.bottom <= Math.min(drawerRect.bottom, window.innerHeight),
+          buttonRect.left >= pageRect.left &&
+          buttonRect.right <= pageRect.right &&
+          buttonRect.top >= pageRect.top &&
+          buttonRect.bottom <= Math.min(pageRect.bottom, window.innerHeight),
         terminal: syncStatus.textContent ?? "",
         label: syncButton.textContent ?? "",
+        chipStatus: document.querySelector(".sync-chip").dataset.status,
         statusWrapped:
           statusRect.height >= lineHeight * 1.9 &&
           syncStatus.scrollWidth <= syncStatus.clientWidth,
         keyboardFocusRestored: document.activeElement === syncButton,
         horizontalOverflow:
           document.documentElement.scrollWidth > document.documentElement.clientWidth ||
-          drawer.scrollWidth > drawer.clientWidth ||
-          syncRegion.scrollWidth > syncRegion.clientWidth ||
-          syncStatus.scrollWidth > syncStatus.clientWidth,
+          Array.from(page.querySelectorAll("section, div, ol, dl, p")).some(
+            (node) => node.scrollWidth > node.clientWidth,
+          ),
       };
     `);
     expect(compact).toEqual({
-      drawerOpen: true,
+      trainingOpen: true,
       buttonResident: true,
       buttonReachable: true,
       terminal: "Training-data processing partially completed. Try again to finish.",
       label: "Try again",
+      chipStatus: "attention",
       statusWrapped: true,
       keyboardFocusRestored: true,
       horizontalOverflow: false,
@@ -1434,15 +1500,15 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       await fixture.evaluate<{
         readonly reduced: boolean;
         readonly overflow: boolean;
-        readonly spineWidth: number;
+        readonly railWidth: number;
       }>(`
       return {
         reduced: matchMedia("(prefers-reduced-motion: reduce)").matches,
         overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
-        spineWidth: document.querySelector(".data-spine").getBoundingClientRect().width,
+        railWidth: document.querySelector('nav[aria-label="Main navigation"]').closest("aside").getBoundingClientRect().width,
       };
     `),
-    ).toEqual({ reduced: true, overflow: false, spineWidth: 48 });
+    ).toEqual({ reduced: true, overflow: false, railWidth: 184 });
     expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
     fixtures.splice(fixtures.indexOf(fixture), 1);
   }, 30_000);

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -303,7 +303,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
     expect(narrow).toEqual({ visible: true, overflow: false });
   }, 20_000);
 
-  it("preserves the closed bridge, training-data drawer, hardened renderer, and token containment", async () => {
+  it("preserves the closed bridge, sidebar sync chip, hardened renderer, and token containment", async () => {
     const { fixture } = await launch();
     const screenshotRoot = await mkdtemp(join(await realpath(tmpdir()), "spend-shot-"));
     scratch.push(screenshotRoot);
@@ -311,14 +311,14 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
     await fixture.screenshot(screenshot);
     const state = await fixture.evaluate<{
       readonly bridgeKeys: readonly string[];
-      readonly drawer: boolean;
+      readonly syncChip: boolean;
       readonly node: string;
       readonly location: string;
       readonly dom: string;
     }>(`
       return {
         bridgeKeys: Object.keys(window.enduragentAuth).sort(),
-        drawer: document.querySelectorAll('.drawer[aria-label="Training data"]').length === 1,
+        syncChip: document.querySelectorAll("button.sync-chip").length === 1,
         node: typeof process + ":" + typeof require,
         location: location.href,
         dom: document.documentElement.outerHTML,
@@ -343,7 +343,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "retryFailedCredentials",
       "writeCredential",
     ]);
-    expect(state.drawer).toBe(true);
+    expect(state.syncChip).toBe(true);
     expect(state.node).toBe("undefined:undefined");
     expect(state.location).toBe("enduragent://app/index.html");
     for (const surface of [


### PR DESCRIPTION
The training view and the sidebar's data surfaces are now real React components instead of imperatively mounted DOM. The training panel, wellness sparkline, ride history list, connection status, and the manual sync chip all render from the shared store, backed by four new slices for training, sync, connection, and ride-import state. The existing controllers are untouched — thin adapters bridge their view callbacks into store writes, so fetching, refresh, and sync orchestration behave exactly as before. The boot path drops its hand-built topbar, spine, and drawer scaffolding and now only wires controllers to adapters.

Two details worth calling out. Manual sync publishes through `flushSync` and restores focus to the sync control afterwards, so keyboard users don't lose their place when the chip re-renders mid-request. Connection lifecycle still stamps `data-rpc` on the document element, which keeps the main process readiness probe working against the new markup.

Verified with the full type, lint, and test gates plus the Electron smoke run. New coverage adds training-surface and sidebar-surface test suites, with the shell and chat-panel integration tests updated for the new component tree. The smoke security assertion moved from probing the old drawer to probing the sync chip, since that element is what now proves the renderer reached an interactive state.

Follow-up: the previous imperative implementations are still on disk but no longer mounted. `training-context/view.ts` and the resident ride-import mount are referenced only by their own tests, and the old training-context stylesheet is still imported by the boot module. Deleting them and folding any still-relevant assertions into the new surface tests is a clean separate change.
