### PR TITLE
fix(desktop): unblock React dev tooling with a development-only CSP

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -30,6 +30,12 @@ export default defineConfig({
     root: resolve(desktopRoot, "../desktop-renderer"),
     plugins: [react()],
     define: appVersionDefine(),
+    server: {
+      host: "127.0.0.1",
+      port: 5173,
+      strictPort: true,
+      hmr: { protocol: "ws", host: "127.0.0.1", port: 5173 },
+    },
     build: {
       outDir: resolve(desktopRoot, "out/renderer"),
       emptyOutDir: true,

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -26,3 +26,17 @@ export function createDesktopContentSecurityPolicy(port: number): string {
   }
   return `default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src ws://127.0.0.1:${port}; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'`;
 }
+
+export function createDesktopDevelopmentContentSecurityPolicy(
+  port: number,
+  developmentUrl: string,
+): string {
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new TypeError("invalid daemon port");
+  }
+  const parsed = new URL(developmentUrl);
+  if (parsed.protocol !== "http:") throw new TypeError("invalid development url");
+  const devPort = parsed.port === "" ? "80" : parsed.port;
+  const devSources = `ws://127.0.0.1:${devPort} ws://localhost:${devPort} http://127.0.0.1:${devPort} http://localhost:${devPort}`;
+  return `default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src ws://127.0.0.1:${port} ${devSources}; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'`;
+}

--- a/apps/desktop/src/main/security.ts
+++ b/apps/desktop/src/main/security.ts
@@ -18,6 +18,7 @@ import {
   DESKTOP_WINDOW_MIN_WIDTH,
   DESKTOP_WINDOW_WIDTH,
   createDesktopContentSecurityPolicy,
+  createDesktopDevelopmentContentSecurityPolicy,
 } from "./constants.js";
 
 export function registerDesktopScheme(): void {
@@ -89,7 +90,15 @@ export async function installDesktopProtocol(input: {
   readonly rendererSource: DesktopRendererSource;
 }): Promise<void> {
   const withCurrentPolicy = (response: Response): Response =>
-    responseWithPolicy(response, createDesktopContentSecurityPolicy(input.currentDaemonPort()));
+    responseWithPolicy(
+      response,
+      input.rendererSource.kind === "development"
+        ? createDesktopDevelopmentContentSecurityPolicy(
+            input.currentDaemonPort(),
+            input.rendererSource.developmentUrl,
+          )
+        : createDesktopContentSecurityPolicy(input.currentDaemonPort()),
+    );
   await input.session.protocol.handle(DESKTOP_SCHEME, async (request) => {
     const requested = new URL(request.url);
     if (requested.host !== DESKTOP_HOST)

--- a/apps/desktop/tests/security.test.ts
+++ b/apps/desktop/tests/security.test.ts
@@ -24,6 +24,7 @@ import {
   DESKTOP_WINDOW_MIN_WIDTH,
   DESKTOP_WINDOW_WIDTH,
   createDesktopContentSecurityPolicy,
+  createDesktopDevelopmentContentSecurityPolicy,
 } from "../src/main/constants.js";
 import {
   createDesktopRendererConsoleCapture,
@@ -94,6 +95,9 @@ describe("desktop security boundary", () => {
       "http://127.0.0.1:5173/assets/renderer.js?cache=synthetic",
     );
     expect(await response.text()).toBe("synthetic-proxied-renderer");
+    expect(response.headers.get("Content-Security-Policy")).toBe(
+      createDesktopDevelopmentContentSecurityPolicy(45_001, "http://127.0.0.1:5173/root"),
+    );
   });
 
   it("serves packaged renderer requests without fetching the override", async () => {
@@ -182,6 +186,20 @@ describe("desktop security boundary", () => {
     expect(createDesktopContentSecurityPolicy(45_001)).toBe(
       "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src ws://127.0.0.1:45001; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'",
     );
+  });
+
+  it("relaxes only inline execution and dev-server connections in the development policy", () => {
+    expect(
+      createDesktopDevelopmentContentSecurityPolicy(45_001, "http://localhost:5173/"),
+    ).toBe(
+      "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src ws://127.0.0.1:45001 ws://127.0.0.1:5173 ws://localhost:5173 http://127.0.0.1:5173 http://localhost:5173; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'",
+    );
+    expect(() =>
+      createDesktopDevelopmentContentSecurityPolicy(0, "http://localhost:5173/"),
+    ).toThrow(TypeError);
+    expect(() =>
+      createDesktopDevelopmentContentSecurityPolicy(45_001, "https://example.com/"),
+    ).toThrow(TypeError);
   });
 
   it("uses the exact hardened BrowserWindow preferences", () => {


### PR DESCRIPTION
Development mode (`electron-vite dev`) has been unusable since the React renderer landed: the window never appeared and the renderer console showed the app dying at boot. The React dev plugin injects an inline preamble script, and the renderer CSP (`script-src 'self'`) blocks inline execution, so React never mounted and the ready-to-show signal never fired. The Vite HMR client was doubly broken: it derived its websocket endpoint from the custom-scheme page origin (yielding a garbage host with no port) and the CSP's `connect-src` did not allow the dev server anyway. None of this was visible in CI because every automated gate exercises the built renderer, which is unaffected.

The fix introduces a development-only content security policy stamped by the protocol handler when the renderer source is the dev-server proxy: it adds `'unsafe-inline'` to `script-src`/`style-src` and allows websocket plus http connections to the dev server's port (derived from the configured development URL). The production policy is byte-for-byte unchanged and its existing exact-string test still pins it. The renderer dev server is now bound to `127.0.0.1:5173` with a strict port and an explicit HMR endpoint, so the Vite client connects to a real address instead of deriving one from the page origin (which also sidesteps a localhost/IPv6 binding mismatch).

Verified end to end: `electron-vite dev` now boots to a visible window with React mounted and `[vite] connected.` in the renderer console, with zero CSP violations. Security suite (17 tests, including a new exact-string pin for the development policy and a header assertion on the proxied response), desktop typecheck, root check, full test suite, and the Electron security smoke all pass.
