### PR TITLE
chore(desktop): align focus rings and sweep renderer hygiene

### DIFF
--- a/apps/desktop-renderer/app-version.d.mts
+++ b/apps/desktop-renderer/app-version.d.mts
@@ -1,2 +1,1 @@
-export declare function desktopAppVersion(): string;
 export declare function appVersionDefine(): Readonly<Record<string, string>>;

--- a/apps/desktop-renderer/app-version.mjs
+++ b/apps/desktop-renderer/app-version.mjs
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 
 const DESKTOP_PACKAGE_JSON = resolve(import.meta.dirname, "../desktop/package.json");
 
-export function desktopAppVersion() {
+function desktopAppVersion() {
   try {
     const parsed = JSON.parse(readFileSync(DESKTOP_PACKAGE_JSON, "utf8"));
     return typeof parsed.version === "string" && parsed.version.length > 0

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -20,7 +20,6 @@ type StreamAction =
 
 export interface ChatViewAdapter {
   readonly view: ChatView;
-  reset(): void;
 }
 
 function isStreamingCoach(message: {
@@ -126,9 +125,6 @@ export function createChatViewAdapter(input: {
         published = next;
         input.publish(next);
       },
-    },
-    reset() {
-      published = EMPTY_CHAT_SURFACE;
     },
   };
 }

--- a/apps/desktop-renderer/src/state/adapters/spend.ts
+++ b/apps/desktop-renderer/src/state/adapters/spend.ts
@@ -2,7 +2,7 @@ import type { SpendSummary } from "@enduragent/coach-contract";
 import type { SpendMeterView } from "../../spend-meter/controller.js";
 import type { SpendSettingsPort, SpendSurfaceState } from "../settings-slice.js";
 
-export const SPEND_CAP_REACHED_PREFIX = "You’ve reached today’s ";
+const SPEND_CAP_REACHED_PREFIX = "You’ve reached today’s ";
 
 export function currency(value: number, detail = false): string {
   if (value === 0) return "$0.00";
@@ -10,7 +10,7 @@ export function currency(value: number, detail = false): string {
   return `$${value.toFixed(2)}`;
 }
 
-export function capWarningCopy(summary: SpendSummary): string | null {
+function capWarningCopy(summary: SpendSummary): string | null {
   if (summary.capStatus !== "reached") return null;
   return `${SPEND_CAP_REACHED_PREFIX}${currency(summary.dailyCapUsd)} spend cap. You can keep chatting; this is a warning, not a block.`;
 }

--- a/apps/desktop-renderer/src/state/chat-stream.ts
+++ b/apps/desktop-renderer/src/state/chat-stream.ts
@@ -82,7 +82,6 @@ export const CHAT_ANCHOR_ROW_SELECTOR = ".chat-message";
 
 export interface ChatScrollAnchor {
   attach(element: HTMLElement | null): void;
-  element(): HTMLElement | null;
   capture(): void;
   apply(input: ChatScrollApply): void;
 }
@@ -103,9 +102,6 @@ export function createChatScrollAnchor(): ChatScrollAnchor {
     attach(element) {
       host = element;
       captured = null;
-    },
-    element() {
-      return host;
     },
     capture() {
       if (host === null) {

--- a/apps/desktop-renderer/src/state/connection-slice.ts
+++ b/apps/desktop-renderer/src/state/connection-slice.ts
@@ -10,7 +10,7 @@ export type ConnectionStatus =
   | "failed"
   | "closing";
 
-export type ConnectionTone = "pending" | "connected" | "recovering" | "unavailable";
+type ConnectionTone = "pending" | "connected" | "recovering" | "unavailable";
 
 const TONES: Readonly<Record<ConnectionStatus, ConnectionTone>> = {
   connecting: "pending",

--- a/apps/desktop-renderer/src/state/settings-slice.ts
+++ b/apps/desktop-renderer/src/state/settings-slice.ts
@@ -9,7 +9,7 @@ import type { UnitsPreferenceViewState } from "../training-context/controller.js
 import type { DesktopUpdateState } from "../update/controller.js";
 import type { EnduragentState } from "./store.js";
 
-export interface SettingsPanesPort {
+interface SettingsPanesPort {
   activate(): void;
   close(): void;
 }
@@ -59,11 +59,11 @@ export interface ReleaseNotesSettingsPort {
   close(): void;
 }
 
-export interface UnitsSettingsPort {
+interface UnitsSettingsPort {
   set(value: UnitsPreference): void;
 }
 
-export interface SettingsPorts {
+interface SettingsPorts {
   readonly panes: SettingsPanesPort;
   readonly coach: CoachSettingsPort;
   readonly credentials: CredentialSettingsPort;
@@ -106,7 +106,7 @@ export type ReleaseNotesSurfaceState =
       readonly releaseUrl: string | null;
     };
 
-export interface SettingsSurfaceState {
+interface SettingsSurfaceState {
   readonly savingOwners: readonly string[];
   readonly coach: ProviderModelSettingsState;
   readonly credentials: CredentialSettingsState;
@@ -121,7 +121,7 @@ export interface SettingsSurfaceState {
 
 export const CLOSED_PANE = Object.freeze({ status: "closed" } as const);
 
-export const EMPTY_SPEND_SURFACE: SpendSurfaceState = Object.freeze({
+const EMPTY_SPEND_SURFACE: SpendSurfaceState = Object.freeze({
   status: "loading",
   summary: null,
   stale: false,
@@ -132,7 +132,7 @@ export const EMPTY_SPEND_SURFACE: SpendSurfaceState = Object.freeze({
   warning: null,
 });
 
-export const EMPTY_UPDATE_SURFACE: UpdateSurfaceState = Object.freeze({
+const EMPTY_UPDATE_SURFACE: UpdateSurfaceState = Object.freeze({
   state: Object.freeze({ status: "idle" as const }),
   actionDisabled: false,
 });

--- a/apps/desktop-renderer/src/ui/chat/Composer.module.css
+++ b/apps/desktop-renderer/src/ui/chat/Composer.module.css
@@ -17,9 +17,11 @@
   gap: 8px;
   padding: 9px 9px 9px 17px;
   border: 1px solid var(--line-2);
-  border-radius: 20px;
+  border-radius: 16px;
   background: var(--surface);
-  box-shadow: 0 12px 38px color-mix(in srgb, var(--ink) 10%, transparent);
+  box-shadow:
+    0 1px 2px rgb(0 0 0 / 4%),
+    0 8px 24px -12px rgb(0 0 0 / 18%);
 }
 
 .controls textarea {

--- a/apps/desktop-renderer/src/ui/chat/NewConversationDialog.module.css
+++ b/apps/desktop-renderer/src/ui/chat/NewConversationDialog.module.css
@@ -3,7 +3,7 @@
   max-width: none;
   padding: 24px;
   border: 1px solid var(--line-2);
-  border-radius: var(--r-lg);
+  border-radius: 16px;
   color: var(--ink);
   background: var(--surface);
   box-shadow: 0 24px 70px color-mix(in srgb, var(--ink) 24%, transparent);

--- a/apps/desktop-renderer/src/ui/chat/QuickActions.module.css
+++ b/apps/desktop-renderer/src/ui/chat/QuickActions.module.css
@@ -21,11 +21,6 @@
   cursor: pointer;
 }
 
-.shortcut:focus-visible {
-  outline: 3px solid var(--brand);
-  outline-offset: 2px;
-}
-
 .shortcut:disabled {
   cursor: default;
   opacity: 0.5;

--- a/apps/desktop-renderer/src/ui/chat/commands.ts
+++ b/apps/desktop-renderer/src/ui/chat/commands.ts
@@ -6,7 +6,7 @@ export interface SlashCommand {
 export const SLASH_COMMANDS: readonly SlashCommand[] = Object.freeze([
   Object.freeze({ command: "/start", description: "Start a fresh session" }),
   Object.freeze({ command: "/plan", description: "Generate a training plan" }),
-  Object.freeze({ command: "/workout", description: "Get today’s workout" }),
+  Object.freeze({ command: "/workout", description: "Get today's workout" }),
   Object.freeze({ command: "/status", description: "Check current fitness, fatigue, and form" }),
   Object.freeze({ command: "/review", description: "Review your last session" }),
   Object.freeze({

--- a/apps/desktop-renderer/src/ui/onboarding/CredentialField.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/CredentialField.tsx
@@ -5,7 +5,7 @@ import type { CredentialSlotStatus } from "../../onboarding/machine.js";
 import { registerCredentialDraft, releaseCredentialDraft } from "../../state/credential-drafts.js";
 import styles from "./OnboardingWizard.module.css";
 
-export function CredentialBadge(props: { readonly status: CredentialSlotStatus }): ReactElement {
+function CredentialBadge(props: { readonly status: CredentialSlotStatus }): ReactElement {
   const presentation = credentialPresentation(props.status);
   return (
     <span

--- a/apps/desktop-renderer/src/ui/settings/CoachSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CoachSection.tsx
@@ -216,7 +216,7 @@ export function CoachSection(): ReactElement {
                 port?.openSetup();
               }}
             >
-              Open Setup
+              Open setup
             </button>
           ) : null}
           <button

--- a/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
@@ -165,7 +165,7 @@ export function CredentialsSection(): ReactElement {
                   port?.openSetup();
                 }}
               >
-                Open Setup
+                Open setup
               </button>
             ) : null}
           </div>

--- a/apps/desktop-renderer/src/ui/settings/SettingsView.module.css
+++ b/apps/desktop-renderer/src/ui/settings/SettingsView.module.css
@@ -2,6 +2,7 @@
   margin: 26px 4px 8px;
   color: var(--ink-3);
   font-size: 11px;
+  font-weight: 400;
   letter-spacing: 0.07em;
   text-transform: uppercase;
 }
@@ -52,28 +53,6 @@
 
 .dangerTitle {
   color: var(--danger);
-}
-
-.status {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.dot {
-  flex: none;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--ok);
-}
-
-.dot[data-tone="warn"] {
-  background: var(--warn);
-}
-
-.dot[data-tone="danger"] {
-  background: var(--danger);
 }
 
 .button {

--- a/apps/desktop-renderer/src/ui/settings/TrainingAccountSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/TrainingAccountSection.tsx
@@ -109,7 +109,7 @@ export function TrainingAccountSection(): ReactElement {
             ) : null}
             {credentialMissing ? (
               <p className={styles.help} id="athlete-id-credential">
-                No training account credential is connected. Open Setup to connect one.
+                No training account credential is connected. Open setup to connect one.
               </p>
             ) : null}
             <p className={styles.error} id="athlete-id-validation" aria-live="polite">
@@ -144,7 +144,7 @@ export function TrainingAccountSection(): ReactElement {
                 port?.openSetup();
               }}
             >
-              Open Setup
+              Open setup
             </button>
           ) : null}
           <button

--- a/apps/desktop-renderer/src/ui/settings/copy.ts
+++ b/apps/desktop-renderer/src/ui/settings/copy.ts
@@ -15,7 +15,7 @@ export const COACH_VALIDATION_COPY: Readonly<Record<ProviderModelValidationError
 export const COACH_SAVE_ERROR_COPY = {
   "invalid-input": "That provider or model wasn’t accepted. Check the model name and try again.",
   "credential-required":
-    "This provider needs a saved credential before it can coach you. Open Setup to add one.",
+    "This provider needs a saved credential before it can coach you. Open setup to add one.",
   "runtime-unavailable": "Coach settings couldn’t become active. Try saving again.",
   "request-failed": "Coach settings couldn’t be saved right now. Try again.",
 } as const;

--- a/apps/desktop-renderer/src/ui/sidebar/HistoryList.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/HistoryList.tsx
@@ -2,15 +2,15 @@ import type { ReactElement } from "react";
 import { useEnduragentStore } from "../../state/store.js";
 import styles from "./Sidebar.module.css";
 
-export interface ConversationEntry {
+interface ConversationEntry {
   readonly id: string;
   readonly title: string;
   readonly when: string;
 }
 
-export const LIVE_CONVERSATION_ID = "desktop";
+const LIVE_CONVERSATION_ID = "desktop";
 
-export const SINGLE_CONVERSATION_NOTE = "Enduragent keeps one conversation on this Mac.";
+const SINGLE_CONVERSATION_NOTE = "Enduragent keeps one conversation on this Mac.";
 
 export function HistoryList(props: { readonly locked: boolean }): ReactElement {
   const activeView = useEnduragentStore((store) => store.activeView);

--- a/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
@@ -6,7 +6,7 @@ import type { ManualSyncViewState } from "../../training-context/manual-sync.js"
 import { formatUtcTimestamp } from "../../training-context/format.js";
 import styles from "./Sidebar.module.css";
 
-export type SyncChipStatus =
+type SyncChipStatus =
   | "loading"
   | "syncing"
   | "attention"
@@ -14,7 +14,7 @@ export type SyncChipStatus =
   | "never"
   | "unavailable";
 
-export function syncChipStatus(
+function syncChipStatus(
   training: TrainingContextViewState,
   sync: ManualSyncViewState,
 ): SyncChipStatus {

--- a/apps/desktop-renderer/tests/athlete-settings.test.ts
+++ b/apps/desktop-renderer/tests/athlete-settings.test.ts
@@ -4,10 +4,7 @@ import {
   CoachClientProtocolError,
   type CoachClient,
 } from "@enduragent/coach-client";
-import type {
-  ConfigureRuntimeRpcRefusalReason,
-  RuntimeConfigSnapshot,
-} from "@enduragent/coach-contract";
+import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
 import type { DesktopCoachClientProvider } from "../src/coach-client.js";
 import {
   createAthleteSettingsController,

--- a/apps/desktop-renderer/tests/provider-model-settings.test.ts
+++ b/apps/desktop-renderer/tests/provider-model-settings.test.ts
@@ -7,7 +7,6 @@ import type {
 import { CUSTOM_MODEL_SELECTION } from "../src/onboarding/constants.js";
 import {
   createProviderModelSettingsController,
-  type ProviderModelFormState,
   type ProviderModelSettingsController,
   type ProviderModelSettingsView,
 } from "../src/settings/provider-model-controller.js";

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -377,7 +377,11 @@ describe("settings mutation lock", () => {
     expect(screen.getByRole("region", { name: "Settings" })).toHaveAttribute("aria-busy", "true");
     expect(screen.getByRole("button", { name: "Save athlete ID" })).toBeDisabled();
     expect(screen.getByRole("combobox", { name: /Provider/u })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Open setup" })).toBeDisabled();
+    expect(
+      within(screen.getByRole("region", { name: "Application" })).getByRole("button", {
+        name: "Open setup",
+      }),
+    ).toBeDisabled();
 
     act(() => {
       useEnduragentStore.getState().setActiveView("chat");
@@ -503,7 +507,7 @@ describe("coach route", () => {
     expect(await screen.findByText("Coach settings saved.")).toBeInTheDocument();
   });
 
-  it("offers Open Setup when the provider needs a credential", async () => {
+  it("offers Open setup when the provider needs a credential", async () => {
     const user = userEvent.setup();
     const subject = await renderSettings({
       applyLlmSelection: async () => ({ status: "refused", reason: "credential-required" }),
@@ -512,7 +516,10 @@ describe("coach route", () => {
     await user.selectOptions(screen.getByRole("combobox", { name: /Provider/u }), "openrouter");
     await user.click(screen.getByRole("button", { name: "Save coach route" }));
 
-    const openSetup = await screen.findByRole("button", { name: "Open Setup" });
+    const openSetup = await within(screen.getByRole("region", { name: "Coach" })).findByRole(
+      "button",
+      { name: "Open setup" },
+    );
     await user.click(openSetup);
     expect(subject.openSetup).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop-renderer/tests/spend-meter.test.ts
+++ b/apps/desktop-renderer/tests/spend-meter.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { CoachClient } from "@enduragent/coach-client";
 import type { SpendSummary } from "@enduragent/coach-contract";
 import type { DesktopCoachClientProvider } from "../src/coach-client.js";

--- a/apps/desktop-renderer/tests/theme-palette.test.tsx
+++ b/apps/desktop-renderer/tests/theme-palette.test.tsx
@@ -18,6 +18,8 @@ import {
 } from "../src/theme/preferences.js";
 import { setPrefersDark } from "./matchmedia.js";
 
+const RADIUS_TOKENS = new Set(["--r", "--r-lg"]);
+
 function expectedProperties(paletteId: string, theme: ResolvedTheme): Map<string, string> {
   const palette = paletteById(paletteId);
   const ramp = theme === "dark" ? palette.d : palette.l;
@@ -105,7 +107,7 @@ describe("palette engine", () => {
     );
     const declared = [...tokens.slice(0, tokens.indexOf("}")).matchAll(/(--[\w-]+)\s*:/gu)]
       .map((match) => match[1])
-      .filter((property) => !property.startsWith("--f-") && !property.startsWith("--r"));
+      .filter((property) => !property.startsWith("--f-") && !RADIUS_TOKENS.has(property));
     const stamped = new Set(paletteCustomProperties(PALETTES[0], "light").keys());
 
     expect(declared.length).toBeGreaterThan(0);

--- a/apps/desktop-renderer/tests/training-context.test.ts
+++ b/apps/desktop-renderer/tests/training-context.test.ts
@@ -13,17 +13,6 @@ import {
   formatUtcTimestamp,
   formatWholeNumber,
 } from "../src/training-context/format.js";
-import {
-  SYNC_INDETERMINATE_COPY,
-  SYNC_NO_CHANGE_COPY,
-  SYNC_OPERATION_FAILURE_COPY,
-  SYNC_PARTIAL_COPY,
-  SYNC_PROTOCOL_COPY,
-  SYNC_PUBLISHED_COPY,
-  SYNC_QUEUED_COPY,
-  SYNC_RUNNING_COPY,
-  toManualSyncViewState,
-} from "../src/training-context/manual-sync.js";
 
 const context: CyclingTrainingContext = {
   anchorZones: { kind: "unknown", reason: "missing-anchor" },

--- a/apps/desktop-renderer/tsconfig.tests.json
+++ b/apps/desktop-renderer/tsconfig.tests.json
@@ -3,10 +3,5 @@
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": [
-    "src/global.d.ts",
-    "tests/dom-setup.ts",
-    "tests/matchmedia.ts",
-    "tests/**/*.tsx"
-  ]
+  "include": ["src/global.d.ts", "tests/**/*.ts", "tests/**/*.tsx"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,12 +32,6 @@ const rawAssetPlugins = [
   },
 ];
 
-/**
- * Two projects, one environment each. The desktop renderer's React component
- * tests need a DOM; every other test in the workspace runs on plain Node and
- * must keep doing so, and vitest 4 removed the per-file `environmentMatchGlobs`
- * escape hatch that used to express that split in one project.
- */
 export default defineConfig({
   test: {
     // Pinned (not relying on vitest defaults): the parallel-safety contract —


### PR DESCRIPTION
Cleans up the React renderer after the rebuild. The quick-action shortcuts carried their own `:focus-visible` outline that diverged from the shared ring defined in the theme tokens, so the local rule is gone and those buttons now pick up the same focus treatment as every other control. Alongside that, the composer and the new-conversation dialog settle on a consistent 16px corner radius, the composer's drop shadow drops to a lighter two-layer stack, the settings section headings pin an explicit font weight, and a handful of button labels and help strings move to sentence case ("Open setup"), with one stray curly apostrophe normalized in the slash-command list.

The rest is dead-weight removal. Unused exports across the state slices, adapters, sidebar, and onboarding surfaces become module-private or are deleted outright: `ChatViewAdapter.reset`, `ChatScrollAnchor.element`, several settings-surface constants and port interfaces, `desktopAppVersion` as a public export, and an orphaned status/dot rule block in the settings stylesheet. The renderer test tsconfig now globs `tests/**/*.ts` and `tests/**/*.tsx` instead of enumerating individual helper files, which is why a few test files needed small adjustments to typecheck under the wider include.

Verified with the full workspace test run and the root type and lint check, both green. No behavior change is intended beyond the visual alignment described above. Remaining items from the renderer residual-findings ticket (252) are untouched and stay open.
