### PR TITLE
fix(desktop): keep startup alive when the tray icon path cannot resolve

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -623,7 +623,7 @@ async function runDesktop(): Promise<void> {
     residency = createDesktopResidency({
       app,
       mainWindow,
-      trayIconPath: join(app.getAppPath(), "resources", "trayTemplate.png"),
+      trayIconPath: resolve(mainDirectory, "../../resources/trayTemplate.png"),
       trayPopoverUrl: rendererSource.trayPopoverUrl,
       reportFailure(operation) {
         process.stderr.write(`desktop-residency-failure ${operation}\n`);
@@ -722,7 +722,8 @@ if (!primaryInstance) {
   const runPrimaryDesktop = process.argv.includes("--desktop-runtime-smoke")
     ? runRuntimeSmoke
     : runDesktop;
-  void runPrimaryDesktop().catch(() => {
+  void runPrimaryDesktop().catch((error: unknown) => {
+    console.error("desktop startup failed", error);
     if (!desktopIsClosing) {
       dialog.showErrorBox(unexpectedStartupCopy.title, unexpectedStartupCopy.content);
     }

--- a/apps/desktop/src/main/residency.ts
+++ b/apps/desktop/src/main/residency.ts
@@ -38,7 +38,9 @@ export interface DesktopResidencyInput {
   readonly mainWindow: MainWindowResidencyPort;
   readonly trayIconPath: string;
   readonly trayPopoverUrl: string;
-  readonly reportFailure: (operation: "read-login-item" | "set-login-item" | "show-window") => void;
+  readonly reportFailure: (
+    operation: "read-login-item" | "set-login-item" | "show-window" | "tray-start",
+  ) => void;
   readonly observe?: (event: DesktopResidencyEvent) => void;
 }
 
@@ -122,17 +124,21 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
   };
   const residency: DesktopResidency = {
     start() {
-      startPromise ??= Promise.resolve().then(() => {
-        if (closed || tray !== undefined) return;
-        const image = nativeImage.createFromPath(input.trayIconPath);
-        if (image.isEmpty()) throw new TypeError();
-        image.setTemplateImage(true);
-        tray = new Tray(image);
-        tray.setToolTip(TRAY_TOOLTIP);
-        tray.on("click", () => ensurePopover().toggle());
-        tray.on("right-click", showContextMenu);
-        input.observe?.({ type: "tray-created" });
-      });
+      startPromise ??= Promise.resolve()
+        .then(() => {
+          if (closed || tray !== undefined) return;
+          const image = nativeImage.createFromPath(input.trayIconPath);
+          if (image.isEmpty()) throw new TypeError();
+          image.setTemplateImage(true);
+          tray = new Tray(image);
+          tray.setToolTip(TRAY_TOOLTIP);
+          tray.on("click", () => ensurePopover().toggle());
+          tray.on("right-click", showContextMenu);
+          input.observe?.({ type: "tray-created" });
+        })
+        .catch(() => {
+          input.reportFailure("tray-start");
+        });
       return startPromise;
     },
     showMainWindow,

--- a/apps/desktop/tests/residency.test.ts
+++ b/apps/desktop/tests/residency.test.ts
@@ -293,6 +293,26 @@ describe("desktop residency", () => {
     expect(residencyStart).toBeGreaterThan(initialShow);
   });
 
+  it("reports tray-start and keeps running when the tray icon cannot load", async () => {
+    const { residency, reportFailure, events } = setup();
+    mocks.image.isEmpty.mockReturnValue(true);
+    await expect(residency.start()).resolves.toBeUndefined();
+    expect(mocks.FakeTray.instances).toHaveLength(0);
+    expect(reportFailure).toHaveBeenCalledWith("tray-start");
+    expect(events).toEqual([]);
+    residency.close();
+    residency.quit();
+    expect(mocks.app.quit).toHaveBeenCalledOnce();
+  });
+
+  it("anchors the tray icon to the build output instead of the launch-dependent app path", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+    expect(source).toContain(
+      'trayIconPath: resolve(mainDirectory, "../../resources/trayTemplate.png")',
+    );
+    expect(source).not.toContain('join(app.getAppPath(), "resources"');
+  });
+
   it("keeps the production failure adapter closed and gates the loser before bootstrap", async () => {
     const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
     expect(source).toContain("desktop-residency-failure ${operation}\\n");


### PR DESCRIPTION
## Symptom

Launching the app from a build-output entry (`electron out/main/index.js` — the form dev sessions use) died on every launch: full UI renders, then the generic "Enduragent couldn't open" dialog appears and the process exits 1. The installed app and `electron .` launches were unaffected, so smokes and CI stayed green for four days while dev launches crashed 100% of the time.

## Root cause

`app.getAppPath()` is launch-form dependent: for a file-form launch it returns the entry file's directory (`out/main`), not the package root. The tray icon path was anchored to it, so `nativeImage.createFromPath` returned an empty image and `residency.start()` threw a bare `TypeError` that rejected `runDesktop`. Two amplifiers hid the cause: the startup catch swallowed the error without logging, and a cosmetic tray failure was fatal to the whole app.

## Fix

- Anchor the tray icon to `mainDirectory` (module-relative, same idiom as `utilityEntry`/`preloadEntry`) — correct for packaged, directory-form, and file-form launches.
- Make tray creation failure non-fatal: `residency.start()` now reports `tray-start` through the existing `reportFailure` channel instead of rejecting startup.
- Log the real error in the startup catch so the next startup failure is never silent.

## Verification

- Deterministic repro before the fix: file-form launch under CPU stress died in 12s with the tray `TypeError`; after the fix, 10/10 launches survive.
- Packaged app (`package:dir`) rebuilt and launched: healthy, no residency failures (asar layout `out/main` → `../../resources` verified).
- `tests/residency.test.ts`: two new regression tests (non-fatal empty-icon start; source-shape lock on the `mainDirectory` anchor). 12/12 pass.
- Desktop `tsc --noEmit` clean; full desktop suite 607/609 — the two `chat-panels.integration.test.ts` failures are the known full-suite load flake and pass in isolation.

Follow-ups filed in the local tracker: file-form smoke coverage gap (253), boot double-sync duplicate records (254).
