### PR TITLE
fix(desktop): keep the chat composer typeable while the coach streams

### DIFF
--- a/.changeset/desktop-streaming-composer.md
+++ b/.changeset/desktop-streaming-composer.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop chat now lets you write your next message while the coach is still replying.

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -22,10 +22,7 @@ export interface ChatViewAdapter {
   readonly view: ChatView;
 }
 
-function isStreamingCoach(message: {
-  readonly role: string;
-  readonly delivery: string;
-}): boolean {
+function isStreamingCoach(message: { readonly role: string; readonly delivery: string }): boolean {
   return message.role === "coach" && message.delivery === "streaming";
 }
 
@@ -64,7 +61,8 @@ export function createChatViewAdapter(input: {
       notice: state.activeTurn?.error?.athleteMessage ?? state.progress,
       interrupted: state.status === "interrupted",
       workBlocked,
-      composerDisabled: state.status === "streaming" || workBlocked,
+      sendDisabled: state.status === "streaming" || workBlocked,
+      inputDisabled: workBlocked,
       newConversationUnavailable,
       resetPhase: state.session.resetPhase,
       resetCount: state.session.resetCount,

--- a/apps/desktop-renderer/src/state/chat-slice.ts
+++ b/apps/desktop-renderer/src/state/chat-slice.ts
@@ -18,7 +18,8 @@ export interface ChatSurfaceState {
   readonly notice: string | null;
   readonly interrupted: boolean;
   readonly workBlocked: boolean;
-  readonly composerDisabled: boolean;
+  readonly sendDisabled: boolean;
+  readonly inputDisabled: boolean;
   readonly newConversationUnavailable: boolean;
   readonly resetPhase: SessionResetPhase;
   readonly resetCount: number;
@@ -47,7 +48,8 @@ export const EMPTY_CHAT_SURFACE: ChatSurfaceState = Object.freeze({
   notice: null,
   interrupted: false,
   workBlocked: false,
-  composerDisabled: false,
+  sendDisabled: false,
+  inputDisabled: false,
   newConversationUnavailable: true,
   resetPhase: "idle",
   resetCount: 0,
@@ -95,7 +97,8 @@ export function sameChatSurface(left: ChatSurfaceState, right: ChatSurfaceState)
     left.notice === right.notice &&
     left.interrupted === right.interrupted &&
     left.workBlocked === right.workBlocked &&
-    left.composerDisabled === right.composerDisabled &&
+    left.sendDisabled === right.sendDisabled &&
+    left.inputDisabled === right.inputDisabled &&
     left.newConversationUnavailable === right.newConversationUnavailable &&
     left.resetPhase === right.resetPhase &&
     left.resetCount === right.resetCount &&

--- a/apps/desktop-renderer/src/ui/chat/Composer.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Composer.tsx
@@ -23,7 +23,8 @@ export function Composer(props: {
   const [draft, setDraft] = useState("");
   const [selected, setSelected] = useState(0);
   const [dismissed, setDismissed] = useState(false);
-  const disabled = useEnduragentStore((state) => state.chat.composerDisabled);
+  const sendDisabled = useEnduragentStore((state) => state.chat.sendDisabled);
+  const inputDisabled = useEnduragentStore((state) => state.chat.inputDisabled);
   const actions = useEnduragentStore((state) => state.chatActions);
 
   const matches = useMemo(() => filterSlashCommands(draft), [draft]);
@@ -49,7 +50,7 @@ export function Composer(props: {
 
   const submit = (): void => {
     const input = textarea.current;
-    if (input === null || disabled) return;
+    if (input === null || sendDisabled) return;
     const value = input.value;
     if (!/\S/u.test(value)) return;
     input.value = "";
@@ -121,7 +122,7 @@ export function Composer(props: {
           id="message"
           ref={textarea}
           rows={2}
-          disabled={disabled}
+          disabled={inputDisabled}
           onChange={(event) => {
             setDraft(event.currentTarget.value);
             setSelected(0);
@@ -132,7 +133,7 @@ export function Composer(props: {
             setDismissed(true);
           }}
         />
-        <button type="submit" aria-label="Send message" disabled={disabled}>
+        <button type="submit" aria-label="Send message" disabled={sendDisabled}>
           ↑
         </button>
       </div>

--- a/apps/desktop-renderer/src/ui/chat/QuickActions.tsx
+++ b/apps/desktop-renderer/src/ui/chat/QuickActions.tsx
@@ -27,7 +27,7 @@ function reclaimable(button: HTMLButtonElement): boolean {
 }
 
 export function QuickActions(): ReactElement {
-  const disabled = useEnduragentStore((state) => state.chat.composerDisabled);
+  const disabled = useEnduragentStore((state) => state.chat.sendDisabled);
   const resetPhase = useEnduragentStore((state) => state.chat.resetPhase);
   const resetCount = useEnduragentStore((state) => state.chat.resetCount);
   const actions = useEnduragentStore((state) => state.chatActions);

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -90,7 +90,8 @@ describe("chat view adapter", () => {
       notice: CHAT_WORKING_COPY,
       interrupted: false,
       workBlocked: true,
-      composerDisabled: true,
+      sendDisabled: true,
+      inputDisabled: true,
       newConversationUnavailable: false,
       resetPhase: "idle",
       resetCount: 0,
@@ -112,11 +113,28 @@ describe("chat view adapter", () => {
     expect(published[0]).toMatchObject({
       workBlocked: false,
       newConversationUnavailable: true,
-      composerDisabled: true,
+      sendDisabled: true,
+      inputDisabled: false,
       hydrationStatus: "idle",
       hydrationHasEarlier: false,
       hydrationRevision: 0,
       hydrationChange: "none",
+    });
+  });
+
+  it("fully blocks input while a session reset is being confirmed", () => {
+    const published: ChatSurfaceState[] = [];
+    const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
+
+    adapter.view.render({
+      ...EMPTY_CHAT_STATE,
+      session: { ...EMPTY_CHAT_STATE.session, resetPhase: "confirming" },
+    });
+
+    expect(published[0]).toMatchObject({
+      workBlocked: true,
+      sendDisabled: true,
+      inputDisabled: true,
     });
   });
 

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -128,6 +128,7 @@ describe("chat surface", () => {
 
       await user.click(composer());
       await user.keyboard("/rev");
+      setChat({ status: "streaming", sendDisabled: true });
       await user.click(screen.getByRole("option", { name: /\/review/u }));
 
       expect(composer()).toHaveValue("/review ");
@@ -206,9 +207,39 @@ describe("chat surface", () => {
       expect(actions.submit).toHaveBeenCalledWith("   ride");
     });
 
-    it("locks the composer and the quick actions while a turn is in flight", () => {
+    it("keeps the focused draft typeable but blocks sends while a turn streams", async () => {
+      const user = userEvent.setup();
       render(<Harness />);
-      setChat({ composerDisabled: true });
+      const textarea = composer();
+      await user.click(textarea);
+      await user.keyboard("Plan tomorrow");
+      setChat({ status: "streaming", sendDisabled: true, inputDisabled: false });
+
+      expect(textarea).toBeEnabled();
+      expect(textarea).toHaveFocus();
+      expect(textarea).toHaveValue("Plan tomorrow");
+      expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
+      for (const button of screen.getAllByRole("button", { name: /command$/u })) {
+        expect(button).toBeDisabled();
+      }
+
+      await user.keyboard("{Enter}");
+
+      expect(actions.submit).not.toHaveBeenCalled();
+      expect(textarea).toHaveValue("Plan tomorrow");
+      expect(textarea).toHaveFocus();
+
+      setChat({ status: "idle", sendDisabled: false });
+
+      expect(textarea).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
+      expect(textarea).toHaveValue("Plan tomorrow");
+      expect(textarea).toHaveFocus();
+    });
+
+    it("locks the composer and the quick actions while work is blocked", () => {
+      render(<Harness />);
+      setChat({ sendDisabled: true, inputDisabled: true });
 
       expect(composer()).toBeDisabled();
       expect(screen.getByRole("button", { name: "Send message" })).toBeDisabled();
@@ -227,11 +258,11 @@ describe("chat surface", () => {
       });
       expect(actions.submit).toHaveBeenCalledWith("/status");
 
-      setChat({ composerDisabled: true });
+      setChat({ sendDisabled: true });
       act(() => {
         (document.activeElement as HTMLElement | null)?.blur();
       });
-      setChat({ composerDisabled: false });
+      setChat({ sendDisabled: false });
 
       await waitFor(() => {
         expect(document.activeElement).toBe(shortcut);

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -590,6 +590,15 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly busyCleared: boolean;
       readonly partialWhiteSpace: string | null;
       readonly partialSourcePreserved: boolean;
+      readonly streamingInputEnabled: boolean;
+      readonly streamingSendBlocked: boolean;
+      readonly streamingQuickActionsBlocked: boolean;
+      readonly streamingEnterBlocked: boolean;
+      readonly streamingDraftPreserved: boolean;
+      readonly streamingFocusPreserved: boolean;
+      readonly settledSendEnabled: boolean;
+      readonly settledDraftPreserved: boolean;
+      readonly settledFocusPreserved: boolean;
       readonly controlExercised: boolean;
       readonly controlOnlyMutations: number;
       readonly heading: string;
@@ -661,6 +670,30 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       });
       textarea.value = "What should I ride?";
       textarea.closest("form").requestSubmit();
+      const submit = textarea.closest("form").querySelector('button[type="submit"]');
+      const quickActions = [...document.querySelectorAll(".coaching-shortcut")];
+      const streamingDeadline = Date.now() + 5000;
+      while (
+        document.querySelector(".conversation").dataset.chatStatus !== "streaming" &&
+        Date.now() < streamingDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      textarea.value = "How should I recover?";
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      textarea.focus();
+      const streamingInputEnabled = !textarea.disabled;
+      const streamingSendBlocked = submit.disabled;
+      const streamingQuickActionsBlocked = quickActions.every((button) => button.disabled);
+      const streamingEnter = new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      });
+      textarea.dispatchEvent(streamingEnter);
+      const streamingEnterBlocked = streamingEnter.defaultPrevented;
+      const streamingDraftPreserved = textarea.value === "How should I recover?";
+      const streamingFocusPreserved = document.activeElement === textarea;
       athleteRow ??= document.querySelector(".chat-message--athlete");
       const finalDeadline = Date.now() + 5000;
       let final = "";
@@ -676,6 +709,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       }
       await new Promise((resolve) => setTimeout(resolve, 0));
       observer.disconnect();
+      const settledSendEnabled = !submit.disabled;
+      const settledDraftPreserved = textarea.value === "How should I recover?";
+      const settledFocusPreserved = document.activeElement === textarea;
       const partial = observed.find(
         (value) => value.includes("Hold   **ste") && !value.includes("ady**"),
       ) ?? "";
@@ -717,6 +753,15 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         busyCleared,
         partialWhiteSpace,
         partialSourcePreserved,
+        streamingInputEnabled,
+        streamingSendBlocked,
+        streamingQuickActionsBlocked,
+        streamingEnterBlocked,
+        streamingDraftPreserved,
+        streamingFocusPreserved,
+        settledSendEnabled,
+        settledDraftPreserved,
+        settledFocusPreserved,
         controlExercised,
         controlOnlyMutations: controlRecords.length,
         heading: coach?.querySelector("h2")?.textContent ?? "",
@@ -766,6 +811,15 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       busyCleared: true,
       partialWhiteSpace: "pre-wrap",
       partialSourcePreserved: true,
+      streamingInputEnabled: true,
+      streamingSendBlocked: true,
+      streamingQuickActionsBlocked: true,
+      streamingEnterBlocked: true,
+      streamingDraftPreserved: true,
+      streamingFocusPreserved: true,
+      settledSendEnabled: true,
+      settledDraftPreserved: true,
+      settledFocusPreserved: true,
       controlExercised: true,
       controlOnlyMutations: 0,
       heading: "Today’s ride",
@@ -930,7 +984,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly dialogOpen: boolean;
       readonly transcriptEmpty: boolean;
       readonly composerValue: string;
-      readonly composerDisabled: boolean;
+      readonly composerInputDisabled: boolean;
       readonly resetDisabled: boolean;
       readonly focused: string | null;
       readonly transcriptClearMutations: number;
@@ -960,7 +1014,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         dialogOpen,
         transcriptEmpty: document.querySelectorAll(".chat-message").length === 0,
         composerValue: textarea.value,
-        composerDisabled: textarea.disabled,
+        composerInputDisabled: textarea.disabled,
         resetDisabled: opener.disabled,
         focused: document.activeElement?.id ?? null,
         transcriptClearMutations: clearRecords.filter((record) => record.type === "childList").length,
@@ -971,7 +1025,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       dialogOpen: true,
       transcriptEmpty: true,
       composerValue: "",
-      composerDisabled: false,
+      composerInputDisabled: false,
       resetDisabled: true,
       focused: "message",
       transcriptClearMutations: 1,

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -250,7 +250,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       readonly warning: string;
       readonly disclosure: string;
       readonly overflow: boolean;
-      readonly composerDisabled: boolean;
+      readonly composerInputDisabled: boolean;
       readonly submitDisabled: boolean;
       readonly final: string;
     }>(`
@@ -266,7 +266,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       const textarea = document.querySelector("#message");
       const submit = textarea.closest("form").querySelector('button[type="submit"]');
       const warning = document.querySelector("#spend-cap-warning").textContent;
-      const composerDisabled = textarea.disabled;
+      const composerInputDisabled = textarea.disabled;
       const submitDisabled = submit.disabled;
       textarea.value = "Can I keep chatting?";
       textarea.closest("form").requestSubmit();
@@ -276,7 +276,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
         await new Promise((resolve) => setTimeout(resolve, 10));
         final = document.querySelector(".chat-message--coach .chat-message__text")?.textContent ?? "";
       }
-      return { ...before, warning, composerDisabled, submitDisabled, final };
+      return { ...before, warning, composerInputDisabled, submitDisabled, final };
     `);
     expect(desktop.visible).toBe(true);
     expect(desktop.trackHeight).toBe(3);
@@ -286,7 +286,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
     expect(desktop.disclosure).toContain("Some provider costs are unavailable");
     expect(desktop.disclosure).toContain("caching unavailable on this route");
     expect(desktop.overflow).toBe(false);
-    expect(desktop.composerDisabled).toBe(false);
+    expect(desktop.composerInputDisabled).toBe(false);
     expect(desktop.submitDisabled).toBe(false);
     expect(desktop.final).toBe("Keep riding.");
     expect(calls.filter((call) => call.method === "chat")).toHaveLength(1);


### PR DESCRIPTION
## Summary

While a coach reply streamed, the renderer disabled the entire composer — textarea, send button, and quick actions all shared one `composerDisabled` flag, so the athlete could not even type their next message until the turn finished.

This splits the flag into two:

- `inputDisabled` (work-blocked only: session reset confirming/resetting, controller override) — disables the textarea.
- `sendDisabled` (streaming or work-blocked) — disables the send button and quick actions, and gates the submit path so Enter during streaming is a no-op that preserves the draft and focus.

Net behavior: the athlete can keep typing while the coach answers; sending re-enables the moment the stream settles, with draft and focus intact. Session-reset phases still lock everything exactly as before. Engine/controller turn-serialization semantics are untouched — the gate stays in the UI submit path.

## Changes

- `state/chat-slice.ts` — `composerDisabled` replaced by `sendDisabled` + `inputDisabled` (state, empty surface, equality).
- `state/adapters/chat.ts` — projects `sendDisabled: streaming || workBlocked`, `inputDisabled: workBlocked`.
- `ui/chat/Composer.tsx` — textarea keyed to `inputDisabled`, send button and submit guard keyed to `sendDisabled`.
- `ui/chat/QuickActions.tsx` — keyed to `sendDisabled` (quick actions dispatch sends).
- Changeset with user-facing note.

## Tests

- Adapter: streaming projects `sendDisabled` true / `inputDisabled` false; reset-confirming projects both true.
- Surface: new test that during streaming the textarea stays enabled, focused, and keeps the draft; send button disabled; Enter does not submit or clear; everything re-enables on settle. Work-blocked full-lock test retained.
- `chat-panels.integration.test.ts` (real app): nine new assertions covering typing/send/quick-action/Enter/draft/focus during streaming and after settle.
- `spend-meter.integration.test.ts`: probe renamed to the input-disabled semantics.

Verification (package scope): renderer `check` and `test` (440/440), desktop `check`, `chat-panels.integration.test.ts` 5/5, `spend-meter.integration.test.ts` 3/3.
