### PR TITLE
feat(desktop): replace the onboarding modal with a derived Setup page

### DIFF
--- a/.changeset/desktop-setup-page.md
+++ b/.changeset/desktop-setup-page.md
@@ -1,0 +1,6 @@
+---
+"cycling-coach": patch
+"@enduragent/desktop-renderer": patch
+---
+
+User-facing: Desktop Setup now opens as a normal page instead of covering the current view with a modal.

--- a/apps/desktop-renderer/src/app/Shell.tsx
+++ b/apps/desktop-renderer/src/app/Shell.tsx
@@ -1,28 +1,39 @@
 import { Suspense, useEffect, type ReactElement } from "react";
 import { useEnduragentStore } from "../state/store.js";
 import { ChatView } from "../ui/chat/ChatView.js";
-import { OnboardingWizard } from "../ui/onboarding/OnboardingWizard.js";
 import { Sidebar } from "../ui/sidebar/Sidebar.js";
 import styles from "./Shell.module.css";
 import { REACT_CHAT_REGION, VIEWS } from "./views.js";
 
 export function Shell(props: { readonly onReady: () => void }): ReactElement {
   const activeView = useEnduragentStore((state) => state.activeView);
+  const onboardingOpen = useEnduragentStore((state) => state.onboarding.open);
+  const onboardingStartupSettled = useEnduragentStore(
+    (state) => state.onboardingStartupSettled,
+  );
   const onReady = props.onReady;
+  const effectiveView = onboardingOpen ? "setup" : activeView;
+  const onboardingState = onboardingStartupSettled
+    ? onboardingOpen
+      ? "open"
+      : "closed"
+    : "pending";
 
   useEffect(() => {
     onReady();
   }, [onReady]);
 
   return (
-    <div className={styles.win} data-view={activeView}>
+    <div className={styles.win} data-view={effectiveView} data-onboarding={onboardingState}>
       <Sidebar />
       <div className={styles.main}>
         <div className={styles.views}>
-          <div className={activeView === "chat" ? styles.chatRegion : styles.away}>
+          <div className={effectiveView === "chat" ? styles.chatRegion : styles.away}>
             <ChatView />
           </div>
-          {VIEWS.filter((view) => view.id === activeView && view.page !== REACT_CHAT_REGION).map(
+          {VIEWS.filter(
+            (view) => view.id === effectiveView && view.page !== REACT_CHAT_REGION,
+          ).map(
             (view) => {
               const Page = view.page as Exclude<typeof view.page, typeof REACT_CHAT_REGION>;
               return (
@@ -37,7 +48,6 @@ export function Shell(props: { readonly onReady: () => void }): ReactElement {
           )}
         </div>
       </div>
-      <OnboardingWizard />
     </div>
   );
 }

--- a/apps/desktop-renderer/src/app/views.ts
+++ b/apps/desktop-renderer/src/app/views.ts
@@ -1,6 +1,7 @@
 import { lazy, type ComponentType, type LazyExoticComponent } from "react";
 
-export type ViewId = "chat" | "training" | "settings";
+export type ViewId = "chat" | "training" | "setup" | "settings";
+export type StoredViewId = Exclude<ViewId, "setup">;
 
 export const REACT_CHAT_REGION = "react-chat-region";
 
@@ -27,6 +28,15 @@ export const VIEWS: readonly ViewDefinition[] = Object.freeze([
     title: "Training",
     page: lazy(async () => ({
       default: (await import("../ui/training/TrainingView.js")).TrainingView,
+    })),
+  },
+  {
+    id: "setup",
+    label: "Setup",
+    glyph: "●",
+    title: "Setup",
+    page: lazy(async () => ({
+      default: (await import("../ui/onboarding/OnboardingWizard.js")).OnboardingWizard,
     })),
   },
   {

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -26,7 +26,6 @@ import { createUpdateSettingsAdapter } from "./state/adapters/update.js";
 import { observeConnectionLifecycle } from "./state/connection-slice.js";
 import { credentialDrafts } from "./state/credential-drafts.js";
 import { restoreManualSyncFocus } from "./state/manual-sync-focus.js";
-import { focusSetupOpener } from "./state/setup-opener.js";
 import { useEnduragentStore } from "./state/store.js";
 import { validateImportPaths, type OnboardingBridge } from "./onboarding/bridge.js";
 import { createOnboardingCompletionController } from "./onboarding/completion.js";
@@ -52,6 +51,7 @@ function focusComposer(): void {
 
 export function bootRenderer(): Disposer {
   const store = useEnduragentStore;
+  store.getState().setOnboardingStartupSettled(false);
 
   const disposeLifecycle = observeConnectionLifecycle((status) => {
     store.getState().setConnection(status);
@@ -218,7 +218,7 @@ export function bootRenderer(): Disposer {
     rideImports,
     onRideImportPresentationChange: (presenting) =>
       store.getState().setRideImportSuppressed(presenting),
-    focusOpener: focusSetupOpener,
+    focusOpener: () => {},
     onComplete: (completion) => onboardingCompletion.complete(completion),
   });
   store.getState().bindOnboardingActions(onboarding);
@@ -308,7 +308,13 @@ export function bootRenderer(): Disposer {
   void trainingContextController.start();
   spendController.start();
   void chatController.start();
-  void onboardingCompletion.openOnStartup(() => onboarding.open());
+  if (onboardingCompletion.isCompleted()) {
+    store.getState().setOnboardingStartupSettled(true);
+  } else {
+    void onboardingCompletion
+      .openOnStartup(() => onboarding.open())
+      .then(() => store.getState().setOnboardingStartupSettled(true));
+  }
   void clients.getClient().then(
     () => store.getState().setConnection("connected"),
     () => store.getState().setConnection("failed"),

--- a/apps/desktop-renderer/src/onboarding/completion.ts
+++ b/apps/desktop-renderer/src/onboarding/completion.ts
@@ -9,6 +9,7 @@ export interface OnboardingCompletionStorage {
 }
 
 export interface OnboardingCompletionController {
+  isCompleted(): boolean;
   openOnStartup(openSetup: () => Promise<void>): Promise<void>;
   openManually(openSetup: () => Promise<void>): Promise<void>;
   complete(completion: OnboardingCompletion): void;
@@ -27,6 +28,7 @@ export function createOnboardingCompletionController(options: {
   };
 
   return {
+    isCompleted: completed,
     openOnStartup(openSetup) {
       return completed() ? Promise.resolve() : openSetup();
     },

--- a/apps/desktop-renderer/src/state/chat-stream.ts
+++ b/apps/desktop-renderer/src/state/chat-stream.ts
@@ -84,6 +84,7 @@ export interface ChatScrollAnchor {
   attach(element: HTMLElement | null): void;
   capture(): void;
   apply(input: ChatScrollApply): void;
+  reanchor(): void;
 }
 
 interface ScrollMetrics {
@@ -97,11 +98,13 @@ interface ScrollMetrics {
 export function createChatScrollAnchor(): ChatScrollAnchor {
   let host: HTMLElement | null = null;
   let captured: ScrollMetrics | null = null;
+  let initialPending = false;
 
   return {
     attach(element) {
       host = element;
       captured = null;
+      initialPending = false;
     },
     capture() {
       if (host === null) {
@@ -124,6 +127,7 @@ export function createChatScrollAnchor(): ChatScrollAnchor {
       if (host === null || metrics === null) return;
       if (input.hydrationChanged && input.hydrationChange === "initial") {
         host.scrollTop = host.scrollHeight;
+        initialPending = host.clientHeight === 0 && host.scrollHeight === 0;
         return;
       }
       if (input.hydrationChanged && input.hydrationChange === "prepend") {
@@ -138,6 +142,11 @@ export function createChatScrollAnchor(): ChatScrollAnchor {
         metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight <=
         CHAT_FOLLOW_LATEST_THRESHOLD;
       if (followsLatest) host.scrollTop = host.scrollHeight;
+    },
+    reanchor() {
+      if (host === null || !initialPending || host.scrollHeight === 0) return;
+      host.scrollTop = host.scrollHeight;
+      initialPending = false;
     },
   };
 }

--- a/apps/desktop-renderer/src/state/onboarding-slice.ts
+++ b/apps/desktop-renderer/src/state/onboarding-slice.ts
@@ -1,5 +1,5 @@
 import type { StateCreator } from "zustand";
-import type { OnboardingActions, OnboardingSurfaceState } from "../onboarding/controller.js";
+import type { OnboardingController, OnboardingSurfaceState } from "../onboarding/controller.js";
 import { createOnboardingState } from "../onboarding/machine.js";
 import { IDLE_RIDE_IMPORT } from "./ride-import-slice.js";
 import type { EnduragentState } from "./store.js";
@@ -16,9 +16,11 @@ export const CLOSED_ONBOARDING: OnboardingSurfaceState = Object.freeze({
 
 export interface OnboardingSlice {
   readonly onboarding: OnboardingSurfaceState;
-  readonly onboardingActions: OnboardingActions | null;
+  readonly onboardingActions: OnboardingController | null;
+  readonly onboardingStartupSettled: boolean;
   setOnboarding: (next: OnboardingSurfaceState) => void;
-  bindOnboardingActions: (actions: OnboardingActions | null) => void;
+  bindOnboardingActions: (actions: OnboardingController | null) => void;
+  setOnboardingStartupSettled: (settled: boolean) => void;
 }
 
 export const createOnboardingSlice: StateCreator<EnduragentState, [], [], OnboardingSlice> = (
@@ -26,10 +28,14 @@ export const createOnboardingSlice: StateCreator<EnduragentState, [], [], Onboar
 ) => ({
   onboarding: CLOSED_ONBOARDING,
   onboardingActions: null,
+  onboardingStartupSettled: false,
   setOnboarding(next) {
     set({ onboarding: next });
   },
   bindOnboardingActions(actions) {
     set({ onboardingActions: actions });
+  },
+  setOnboardingStartupSettled(settled) {
+    set({ onboardingStartupSettled: settled });
   },
 });

--- a/apps/desktop-renderer/src/state/setup-opener.ts
+++ b/apps/desktop-renderer/src/state/setup-opener.ts
@@ -1,9 +1,0 @@
-let opener: HTMLElement | null = null;
-
-export function registerSetupOpener(element: HTMLElement | null): void {
-  opener = element;
-}
-
-export function focusSetupOpener(): void {
-  opener?.focus();
-}

--- a/apps/desktop-renderer/src/state/store.ts
+++ b/apps/desktop-renderer/src/state/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { ViewId } from "../app/views.js";
+import type { StoredViewId } from "../app/views.js";
 import {
   applyPalette,
   resolveTheme,
@@ -33,12 +33,12 @@ export interface EnduragentState
     ConnectionSlice,
     RideImportSlice,
     OnboardingSlice {
-  readonly activeView: ViewId;
+  readonly activeView: StoredViewId;
   readonly paletteId: string;
   readonly appearance: Appearance;
   readonly theme: ResolvedTheme;
   readonly runtimeReady: boolean;
-  setActiveView: (view: ViewId) => void;
+  setActiveView: (view: StoredViewId) => void;
   setPaletteId: (paletteId: string) => void;
   setAppearance: (appearance: Appearance) => void;
   refreshTheme: () => void;

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -31,6 +31,8 @@ export function ChatView(): ReactElement {
   const conversation = useRef<HTMLElement>(null);
   const composerWrap = useRef<HTMLDivElement>(null);
   const composer = useRef<ComposerHandle>(null);
+  const activeView = useEnduragentStore((state) => state.activeView);
+  const onboardingOpen = useEnduragentStore((state) => state.onboarding.open);
   const status = useEnduragentStore((state) => state.chat.status);
   const announcement = useEnduragentStore((state) => state.chat.announcement);
   const hydrationStatus = useEnduragentStore((state) => state.chat.hydrationStatus);
@@ -44,6 +46,10 @@ export function ChatView(): ReactElement {
       chatScrollAnchor.attach(null);
     };
   }, []);
+
+  useLayoutEffect(() => {
+    if (activeView === "chat" && !onboardingOpen) chatScrollAnchor.reanchor();
+  }, [activeView, onboardingOpen]);
 
   useLayoutEffect(() => {
     const host = composerWrap.current;
@@ -69,6 +75,7 @@ export function ChatView(): ReactElement {
     const target = conversation.current;
     if (target === null) return;
     const onScroll = (): void => {
+      if (target.offsetParent === null) return;
       if (
         target.scrollTop <= CHAT_AUTO_LOAD_EARLIER_THRESHOLD &&
         hasEarlier &&

--- a/apps/desktop-renderer/src/ui/onboarding/CoachKeysStep.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/CoachKeysStep.tsx
@@ -86,9 +86,9 @@ export function CoachKeysStep(props: {
   return (
     <>
       <p className={styles.kicker}>Coach keys</p>
-      <h1 id="onboarding-title" className={styles.title} tabIndex={-1}>
+      <h2 id="onboarding-title" className={styles.title} tabIndex={-1}>
         Choose how your coach thinks
-      </h1>
+      </h2>
       <p className={`${styles.copy} onboarding-copy`}>
         ChatGPT sign-in is saved in a local profile file. API keys are encrypted by macOS. The local
         coaching service uses your choice to contact the provider.

--- a/apps/desktop-renderer/src/ui/onboarding/OnboardingWizard.module.css
+++ b/apps/desktop-renderer/src/ui/onboarding/OnboardingWizard.module.css
@@ -1,46 +1,17 @@
-.scrim {
-  position: fixed;
-  z-index: 40;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  padding: max(44px, env(safe-area-inset-top)) 18px 18px;
-  background: rgb(9 14 20 / 42%);
-  backdrop-filter: blur(9px);
-}
-
-.dialog {
-  width: min(510px, 100%);
-  max-height: 100%;
-  overflow: auto;
-  border: 1px solid var(--line-2);
-  border-radius: 22px;
-  color: var(--ink);
-  background: var(--surface);
-  box-shadow: 0 28px 80px rgb(9 20 30 / 24%);
-  animation: enter 180ms ease-out;
-}
-
-.header,
 .footer {
   display: flex;
   gap: 12px;
   align-items: center;
   justify-content: space-between;
-  padding: 18px 24px;
-}
-
-.header {
-  border-bottom: 1px solid var(--line);
-}
-
-.footer {
+  margin-top: 10px;
+  padding: 18px 0;
   border-top: 1px solid var(--line);
 }
 
 .progress {
   display: flex;
   gap: 7px;
+  margin-bottom: 28px;
 }
 
 .progress span {
@@ -55,7 +26,18 @@
   background: var(--brand);
 }
 
-.dismiss,
+.dismiss {
+  min-height: 30px;
+  padding: 0 11px;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  color: var(--ink-2);
+  background: var(--surface-2);
+  font: inherit;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
 .textButton {
   padding: 0;
   border: 0;
@@ -73,7 +55,6 @@
 
 .body {
   min-height: 310px;
-  padding: 38px 42px 34px;
 }
 
 .kicker {
@@ -367,23 +348,8 @@
   opacity: 0.5;
 }
 
-@keyframes enter {
-  from {
-    opacity: 0;
-    transform: translateY(8px) scale(0.99);
-  }
-}
-
-@media (max-width: 720px) {
-  .body {
-    padding: 30px 24px;
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .dialog,
   .progress span {
-    animation: none;
     transition: none;
   }
 }

--- a/apps/desktop-renderer/src/ui/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/OnboardingWizard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, type KeyboardEvent, type ReactElement } from "react"
 import { ONBOARDING_STEP_IDS } from "../../onboarding/constants.js";
 import { rideImportStatusCopy } from "../../ride-import.js";
 import { useEnduragentStore } from "../../state/store.js";
+import { Page } from "../shared/Page.js";
 import { CoachKeysStep } from "./CoachKeysStep.js";
 import { ERROR_COPY } from "./copy.js";
 import styles from "./OnboardingWizard.module.css";
@@ -9,21 +10,10 @@ import { ReadyStep } from "./ReadyStep.js";
 import { SafetyIntakeStep } from "./SafetyIntakeStep.js";
 import { TrainingDataStep } from "./TrainingDataStep.js";
 
-const FOCUSABLE =
-  'button:not([disabled]), input:not([disabled]), select:not([disabled]), summary, [tabindex]:not([tabindex="-1"])';
-
-function focusableElements(root: HTMLElement): readonly HTMLElement[] {
-  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE)).filter((element) => {
-    if (element.hasAttribute("hidden")) return false;
-    const closedDetails = element.closest("details:not([open])");
-    return closedDetails === null || element.tagName === "SUMMARY";
-  });
-}
-
 export function OnboardingWizard(): ReactElement | null {
   const surface = useEnduragentStore((state) => state.onboarding);
   const actions = useEnduragentStore((state) => state.onboardingActions);
-  const dialog = useRef<HTMLElement>(null);
+  const page = useRef<HTMLElement>(null);
   const focused = useRef(-1);
 
   const open = surface.open;
@@ -36,8 +26,16 @@ export function OnboardingWizard(): ReactElement | null {
     }
     if (focused.current === focusSeq) return;
     focused.current = focusSeq;
-    dialog.current?.querySelector<HTMLElement>("#onboarding-title")?.focus();
+    page.current?.querySelector<HTMLElement>("#onboarding-title")?.focus();
   }, [open, focusSeq]);
+
+  useEffect(
+    () => () => {
+      const current = useEnduragentStore.getState();
+      if (current.onboarding.open) current.onboardingActions?.dismiss();
+    },
+    [],
+  );
 
   if (!open) return null;
 
@@ -49,11 +47,6 @@ export function OnboardingWizard(): ReactElement | null {
 
   const onKeyDown = (event: KeyboardEvent<HTMLElement>): void => {
     const targetTagName = (event.target as HTMLElement | null)?.tagName;
-    if (event.key === "Escape") {
-      event.preventDefault();
-      actions?.dismiss();
-      return;
-    }
     if (
       event.key === "Enter" &&
       targetTagName !== "BUTTON" &&
@@ -62,117 +55,98 @@ export function OnboardingWizard(): ReactElement | null {
     ) {
       event.preventDefault();
       actions?.submit();
-      return;
-    }
-    if (event.key !== "Tab") return;
-    const root = dialog.current;
-    if (root === null) return;
-    const focusable = focusableElements(root);
-    if (focusable.length === 0) return;
-    const first = focusable[0]!;
-    const last = focusable[focusable.length - 1]!;
-    if (event.shiftKey && document.activeElement === first) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && document.activeElement === last) {
-      event.preventDefault();
-      first.focus();
     }
   };
 
   return (
-    <div className={`${styles.scrim} onboarding-scrim`}>
-      <section
-        ref={dialog}
-        className={`${styles.dialog} onboarding`}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="onboarding-title"
-        onKeyDown={onKeyDown}
+    <Page
+      ref={page}
+      title="Setup"
+      className="onboarding"
+      onKeyDown={onKeyDown}
+      action={
+        <button
+          type="button"
+          className={`${styles.dismiss} onboarding-dismiss`}
+          onClick={() => {
+            actions?.dismiss();
+          }}
+        >
+          Dismiss
+        </button>
+      }
+    >
+      <div
+        className={`${styles.progress} onboarding-progress`}
+        aria-label={`Step ${activeIndex + 1} of ${ONBOARDING_STEP_IDS.length}`}
       >
-        <header className={styles.header}>
-          <div
-            className={`${styles.progress} onboarding-progress`}
-            aria-label={`Step ${activeIndex + 1} of ${ONBOARDING_STEP_IDS.length}`}
-          >
-            {ONBOARDING_STEP_IDS.map((step, index) => (
-              <span
-                key={step}
-                className={index <= activeIndex ? styles.progressOn : undefined}
-                aria-current={step === wizard.step ? "step" : undefined}
-              />
-            ))}
-          </div>
+        {ONBOARDING_STEP_IDS.map((step, index) => (
+          <span
+            key={step}
+            className={index <= activeIndex ? styles.progressOn : undefined}
+            aria-current={step === wizard.step ? "step" : undefined}
+          />
+        ))}
+      </div>
+      <div className={styles.body}>
+        {wizard.step === "coach-keys" ? (
+          <CoachKeysStep surface={surface} actions={actions} disabled={disabled} />
+        ) : null}
+        {wizard.step === "training-data" ? (
+          <TrainingDataStep surface={surface} actions={actions} disabled={disabled} />
+        ) : null}
+        {wizard.step === "safety-intake" ? (
+          <SafetyIntakeStep surface={surface} actions={actions} />
+        ) : null}
+        {wizard.step === "ready" ? <ReadyStep surface={surface} /> : null}
+        <p
+          className={`${styles.importStatus} import-status`}
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          hidden={importCopy.length === 0}
+          data-state={surface.rideImport.status}
+        >
+          {importCopy}
+        </p>
+        <p id="onboarding-error" className={styles.error} aria-live="polite">
+          {wizard.fixedError === null ? "" : ERROR_COPY[wizard.fixedError]}
+        </p>
+        <p
+          className={`${styles.actionStatus} onboarding-action-status`}
+          role="status"
+          aria-live="polite"
+          hidden={!wizard.busy}
+        >
+          {wizard.busy ? "Working…" : ""}
+        </p>
+      </div>
+      <footer className={styles.footer}>
+        {activeIndex > 0 ? (
           <button
             type="button"
-            className={`${styles.dismiss} onboarding-dismiss`}
-            onClick={() => {
-              actions?.dismiss();
-            }}
-          >
-            Dismiss
-          </button>
-        </header>
-        <div className={styles.body}>
-          {wizard.step === "coach-keys" ? (
-            <CoachKeysStep surface={surface} actions={actions} disabled={disabled} />
-          ) : null}
-          {wizard.step === "training-data" ? (
-            <TrainingDataStep surface={surface} actions={actions} disabled={disabled} />
-          ) : null}
-          {wizard.step === "safety-intake" ? (
-            <SafetyIntakeStep surface={surface} actions={actions} />
-          ) : null}
-          {wizard.step === "ready" ? <ReadyStep surface={surface} /> : null}
-          <p
-            className={`${styles.importStatus} import-status`}
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-            hidden={importCopy.length === 0}
-            data-state={surface.rideImport.status}
-          >
-            {importCopy}
-          </p>
-          <p id="onboarding-error" className={styles.error} aria-live="polite">
-            {wizard.fixedError === null ? "" : ERROR_COPY[wizard.fixedError]}
-          </p>
-          <p
-            className={`${styles.actionStatus} onboarding-action-status`}
-            role="status"
-            aria-live="polite"
-            hidden={!wizard.busy}
-          >
-            {wizard.busy ? "Working…" : ""}
-          </p>
-        </div>
-        <footer className={styles.footer}>
-          {activeIndex > 0 ? (
-            <button
-              type="button"
-              className={styles.secondaryButton}
-              disabled={disabled}
-              onClick={() => {
-                actions?.back();
-              }}
-            >
-              Back
-            </button>
-          ) : (
-            <span />
-          )}
-          <button
-            type="button"
-            className={styles.primaryButton}
+            className={styles.secondaryButton}
             disabled={disabled}
             onClick={() => {
-              actions?.submit();
+              actions?.back();
             }}
           >
-            {wizard.step === "ready" ? "Finish setup" : "Continue"}
+            Back
           </button>
-        </footer>
-      </section>
-    </div>
+        ) : (
+          <span />
+        )}
+        <button
+          type="button"
+          className={styles.primaryButton}
+          disabled={disabled}
+          onClick={() => {
+            actions?.submit();
+          }}
+        >
+          {wizard.step === "ready" ? "Finish setup" : "Continue"}
+        </button>
+      </footer>
+    </Page>
   );
 }

--- a/apps/desktop-renderer/src/ui/onboarding/ReadyStep.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/ReadyStep.tsx
@@ -8,9 +8,9 @@ export function ReadyStep(props: { readonly surface: OnboardingSurfaceState }): 
   return (
     <>
       <p className={styles.kicker}>Ready</p>
-      <h1 id="onboarding-title" className={styles.title} tabIndex={-1}>
+      <h2 id="onboarding-title" className={styles.title} tabIndex={-1}>
         Your coach is ready
-      </h1>
+      </h2>
       <p className={`${styles.copy} onboarding-copy`}>
         Start with what you are training for, how the last week felt, or what you want help
         deciding.

--- a/apps/desktop-renderer/src/ui/onboarding/SafetyIntakeStep.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/SafetyIntakeStep.tsx
@@ -40,9 +40,9 @@ export function SafetyIntakeStep(props: {
   return (
     <>
       <p className={styles.kicker}>Safety intake</p>
-      <h1 id="onboarding-title" className={styles.title} tabIndex={-1}>
+      <h2 id="onboarding-title" className={styles.title} tabIndex={-1}>
         A few safety checks
-      </h1>
+      </h2>
       <p className={`${styles.copy} onboarding-copy`}>
         These answers record context for your coach. They are not a diagnosis.
       </p>

--- a/apps/desktop-renderer/src/ui/onboarding/TrainingDataStep.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/TrainingDataStep.tsx
@@ -22,9 +22,9 @@ export function TrainingDataStep(props: {
   return (
     <>
       <p className={styles.kicker}>Training data</p>
-      <h1 id="onboarding-title" className={styles.title} tabIndex={-1}>
+      <h2 id="onboarding-title" className={styles.title} tabIndex={-1}>
         Bring your riding history
-      </h1>
+      </h2>
       <p className={`${styles.copy} onboarding-copy`} aria-label={INTERVALS_GUIDANCE}>
         Connect your device platform to intervals.icu <strong>directly</strong>, not via Strava.
       </p>

--- a/apps/desktop-renderer/src/ui/shared/Page.module.css
+++ b/apps/desktop-renderer/src/ui/shared/Page.module.css
@@ -26,6 +26,12 @@
   font-size: 12.5px;
 }
 
+.action {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
 .scroll {
   flex: 1;
   padding: 28px 0 40px;

--- a/apps/desktop-renderer/src/ui/shared/Page.tsx
+++ b/apps/desktop-renderer/src/ui/shared/Page.tsx
@@ -1,23 +1,37 @@
-import type { ReactElement, ReactNode } from "react";
+import type {
+  KeyboardEventHandler,
+  ReactElement,
+  ReactNode,
+  Ref,
+} from "react";
 import styles from "./Page.module.css";
 
 export function Page(props: {
   readonly title: string;
   readonly subtitle?: string;
   readonly busy?: boolean;
+  readonly action?: ReactNode;
+  readonly className?: string;
+  readonly onKeyDown?: KeyboardEventHandler<HTMLElement>;
+  readonly ref?: Ref<HTMLElement>;
   readonly children: ReactNode;
 }): ReactElement {
   return (
     <section
-      className={styles.page}
+      ref={props.ref}
+      className={
+        props.className === undefined ? styles.page : `${styles.page} ${props.className}`
+      }
       aria-label={props.title}
       aria-busy={props.busy === true ? "true" : undefined}
+      onKeyDown={props.onKeyDown}
     >
       <div className={styles.bar}>
         <h1 className={styles.title}>{props.title}</h1>
         {props.subtitle === undefined ? null : (
           <span className={styles.subtitle}>{props.subtitle}</span>
         )}
+        {props.action === undefined ? null : <div className={styles.action}>{props.action}</div>}
       </div>
       <div className={styles.scroll}>
         <div className={styles.column}>{props.children}</div>

--- a/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, type ReactElement } from "react";
 import { VIEWS } from "../../app/views.js";
 import { registerNewConversationOpener } from "../../state/new-conversation-opener.js";
-import { registerSetupOpener } from "../../state/setup-opener.js";
 import { settingsMutationActive } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
 import { ConnectionStatus } from "./ConnectionStatus.js";
@@ -15,17 +14,16 @@ export function Sidebar(): ReactElement {
   const unavailable = useEnduragentStore((state) => state.chat.newConversationUnavailable);
   const resetPhase = useEnduragentStore((state) => state.chat.resetPhase);
   const actions = useEnduragentStore((state) => state.chatActions);
+  const onboardingOpen = useEnduragentStore((state) => state.onboarding.open);
+  const onboardingActions = useEnduragentStore((state) => state.onboardingActions);
   const settingsBusy = useEnduragentStore((state) => settingsMutationActive(state.settings));
   const opener = useRef<HTMLButtonElement>(null);
-  const settingsNav = useRef<HTMLButtonElement>(null);
   const navigationLocked = activeView === "settings" && settingsBusy;
 
   useEffect(() => {
     registerNewConversationOpener(opener.current);
-    registerSetupOpener(settingsNav.current);
     return () => {
       registerNewConversationOpener(null);
-      registerSetupOpener(null);
     };
   }, []);
 
@@ -54,24 +52,35 @@ export function Sidebar(): ReactElement {
         </button>
       </div>
       <nav className={styles.nav} aria-label="Main navigation">
-        {VIEWS.map((view) => (
-          <button
-            key={view.id}
-            type="button"
-            ref={view.id === "settings" ? settingsNav : undefined}
-            className={view.id === activeView ? `${styles.navItem} ${styles.on}` : styles.navItem}
-            aria-current={view.id === activeView ? "page" : undefined}
-            disabled={navigationLocked && view.id !== activeView}
-            onClick={() => {
-              setActiveView(view.id);
-            }}
-          >
-            <span className={styles.glyph} aria-hidden="true">
-              {view.glyph}
-            </span>
-            {view.label}
-          </button>
-        ))}
+        {VIEWS.map((view) => {
+          const active =
+            view.id === "setup" ? onboardingOpen : view.id === activeView && !onboardingOpen;
+          return (
+            <button
+              key={view.id}
+              type="button"
+              className={active ? `${styles.navItem} ${styles.on}` : styles.navItem}
+              aria-current={active ? "page" : undefined}
+              disabled={
+                (navigationLocked && !onboardingOpen && view.id !== activeView) ||
+                (view.id === "setup" && onboardingActions === null)
+              }
+              onClick={() => {
+                if (view.id === "setup") {
+                  void onboardingActions?.open();
+                } else {
+                  if (onboardingOpen) onboardingActions?.dismiss();
+                  setActiveView(view.id);
+                }
+              }}
+            >
+              <span className={styles.glyph} aria-hidden="true">
+                {view.glyph}
+              </span>
+              {view.label}
+            </button>
+          );
+        })}
       </nav>
       <div className={styles.sec}>Conversations</div>
       <HistoryList locked={navigationLocked} />

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -215,12 +215,21 @@ describe("chat scroll anchor", () => {
   function host(scrollHeight: number, clientHeight: number, scrollTop: number): HTMLElement {
     const element = document.createElement("div");
     let height = scrollHeight;
+    let viewportHeight = clientHeight;
     Object.defineProperty(element, "scrollHeight", { get: () => height, configurable: true });
-    Object.defineProperty(element, "clientHeight", { get: () => clientHeight, configurable: true });
+    Object.defineProperty(element, "clientHeight", {
+      get: () => viewportHeight,
+      configurable: true,
+    });
     element.scrollTop = scrollTop;
     Object.defineProperty(element, "grow", {
       value: (next: number) => {
         height = next;
+      },
+    });
+    Object.defineProperty(element, "resize", {
+      value: (next: number) => {
+        viewportHeight = next;
       },
     });
     return element;
@@ -228,6 +237,10 @@ describe("chat scroll anchor", () => {
 
   function grow(element: HTMLElement, next: number): void {
     (element as HTMLElement & { grow: (value: number) => void }).grow(next);
+  }
+
+  function resize(element: HTMLElement, next: number): void {
+    (element as HTMLElement & { resize: (value: number) => void }).resize(next);
   }
 
   it("follows the newest message when the athlete is already at the bottom", () => {
@@ -264,6 +277,39 @@ describe("chat scroll anchor", () => {
     anchor.apply({ hydrationChanged: true, hydrationChange: "initial" });
 
     expect(element.scrollTop).toBe(2000);
+  });
+
+  it("reanchors a hidden initial hydration after the host becomes visible", () => {
+    const anchor = createChatScrollAnchor();
+    const element = host(0, 0, 0);
+    anchor.attach(element);
+
+    anchor.capture();
+    anchor.apply({ hydrationChanged: true, hydrationChange: "initial" });
+    grow(element, 2000);
+    resize(element, 400);
+    anchor.reanchor();
+
+    expect(element.scrollTop).toBe(2000);
+
+    element.scrollTop = 600;
+    anchor.reanchor();
+
+    expect(element.scrollTop).toBe(600);
+  });
+
+  it("does not reanchor a visible initial hydration", () => {
+    const anchor = createChatScrollAnchor();
+    const element = host(1000, 400, 0);
+    anchor.attach(element);
+
+    anchor.capture();
+    anchor.apply({ hydrationChanged: true, hydrationChange: "initial" });
+    element.scrollTop = 300;
+    grow(element, 2000);
+    anchor.reanchor();
+
+    expect(element.scrollTop).toBe(300);
   });
 
   it("holds the anchor row in place when the layout above it shifts", () => {

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -12,6 +12,7 @@ import {
   type ChatSurfaceState,
 } from "../src/state/chat-slice.js";
 import { resetChatStream } from "../src/state/chat-stream.js";
+import { CLOSED_ONBOARDING } from "../src/state/onboarding-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { ChatView } from "../src/ui/chat/ChatView.js";
 import { SLASH_COMMANDS } from "../src/ui/chat/commands.js";
@@ -58,6 +59,7 @@ describe("chat surface", () => {
       chat: EMPTY_CHAT_SURFACE,
       firstSync: { status: "idle" },
       chatActions: actions,
+      onboarding: CLOSED_ONBOARDING,
     });
   });
 
@@ -66,6 +68,7 @@ describe("chat surface", () => {
       chat: EMPTY_CHAT_SURFACE,
       firstSync: { status: "idle" },
       chatActions: null,
+      onboarding: CLOSED_ONBOARDING,
     });
     resetChatStream();
   });
@@ -440,6 +443,10 @@ describe("chat surface", () => {
       setChat({ hydrationHasEarlier: true, hydrationStatus: "ready" });
       const conversation = document.querySelector(".conversation");
       if (!(conversation instanceof HTMLElement)) throw new TypeError("conversation missing");
+      Object.defineProperty(conversation, "offsetParent", {
+        configurable: true,
+        value: document.body,
+      });
 
       conversation.scrollTop = 0;
       act(() => {
@@ -452,6 +459,20 @@ describe("chat surface", () => {
         conversation.dispatchEvent(new Event("scroll"));
       });
       expect(actions.loadEarlier).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores scroll resets while the transcript is hidden", () => {
+      render(<Harness />);
+      setChat({ hydrationHasEarlier: true, hydrationStatus: "ready" });
+      const conversation = document.querySelector(".conversation");
+      if (!(conversation instanceof HTMLElement)) throw new TypeError("conversation missing");
+
+      conversation.scrollTop = 0;
+      act(() => {
+        conversation.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(actions.loadEarlier).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop-renderer/tests/onboarding-completion.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-completion.test.ts
@@ -63,6 +63,7 @@ describe("onboarding completion", () => {
       storage: () => storage,
       onComplete: vi.fn(),
     });
+    expect(nextWindow.isCompleted()).toBe(true);
     await nextWindow.openOnStartup(openSetup);
 
     expect(openSetup).not.toHaveBeenCalled();

--- a/apps/desktop-renderer/tests/onboarding-surface.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-surface.test.tsx
@@ -85,55 +85,51 @@ describe("mounted onboarding", () => {
     resetOnboardingStore();
   });
 
-  it("presents the modal dialog, its progress hooks, and restores focus on dismissal", async () => {
+  it("presents the setup page, its progress hooks, and dismisses through the controller", async () => {
     const user = userEvent.setup();
     const bridge = testBridge(async () => ({ status: "refused", reason: "cancelled" }));
     const wizard = mountWizard({ bridge });
     await wizard.open();
 
-    const dialog = screen.getByRole("dialog");
-    expect(dialog).toHaveAttribute("aria-modal", "true");
-    expect(dialog).toHaveAttribute("aria-labelledby", "onboarding-title");
-    expect(dialog).toHaveClass("onboarding");
+    const page = screen.getByRole("region", { name: "Setup" });
+    expect(page).toHaveClass("onboarding");
+    expect(control("onboarding-title")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(document.querySelector(".onboarding-scrim")).toBeNull();
     expect(screen.getByLabelText("Step 1 of 4")).toBeInTheDocument();
     expect(document.activeElement).toBe(control("onboarding-title"));
 
     await user.click(button("Dismiss"));
 
-    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByRole("region", { name: "Setup" })).toBeNull();
     expect(wizard.focusOpener).toHaveBeenCalledTimes(1);
     wizard.controller.dispose();
   });
 
-  it("closes on Escape and restores focus to the opener", async () => {
+  it("does not close the setup page on Escape", async () => {
     const bridge = testBridge(async () => ({ status: "refused", reason: "cancelled" }));
     const wizard = mountWizard({ bridge });
     await wizard.open();
 
-    const dialog = screen.getByRole("dialog");
-    expect(fireEvent.keyDown(dialog, { key: "Escape" })).toBe(false);
+    const page = screen.getByRole("region", { name: "Setup" });
+    expect(fireEvent.keyDown(page, { key: "Escape" })).toBe(true);
 
-    expect(screen.queryByRole("dialog")).toBeNull();
-    expect(wizard.focusOpener).toHaveBeenCalledTimes(1);
+    expect(page).toBeInTheDocument();
+    expect(wizard.focusOpener).not.toHaveBeenCalled();
     wizard.controller.dispose();
   });
 
-  it("traps Tab inside the dialog and skips collapsed advanced providers", async () => {
+  it("does not trap Tab inside the setup page", async () => {
     const bridge = testBridge(async () => ({ status: "refused", reason: "cancelled" }));
     const wizard = mountWizard({ bridge });
     await wizard.open();
 
-    const dialog = screen.getByRole("dialog");
-    const dismiss = button("Dismiss");
+    const page = screen.getByRole("region", { name: "Setup" });
     const submit = button("Continue");
     expect(passwordInput("openai").closest("details")?.hasAttribute("open")).toBe(false);
 
     submit.focus();
-    expect(fireEvent.keyDown(dialog, { key: "Tab" })).toBe(false);
-    expect(document.activeElement).toBe(dismiss);
-
-    dismiss.focus();
-    expect(fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true })).toBe(false);
+    expect(fireEvent.keyDown(page, { key: "Tab" })).toBe(true);
     expect(document.activeElement).toBe(submit);
     wizard.controller.dispose();
   });

--- a/apps/desktop-renderer/tests/onboarding-wizard.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-wizard.test.ts
@@ -215,22 +215,26 @@ describe("desktop onboarding wizard", () => {
     expect(connect).toHaveBeenCalledTimes(1);
   });
 
-  it("ships the exact dialog and responsive accessibility hooks", async () => {
+  it("ships the setup page and responsive accessibility hooks", async () => {
     const [wizard, coachKeys, styles] = await Promise.all([
       readFile(new URL("../src/ui/onboarding/OnboardingWizard.tsx", import.meta.url), "utf8"),
       readFile(new URL("../src/ui/onboarding/CoachKeysStep.tsx", import.meta.url), "utf8"),
       readFile(new URL("../src/ui/onboarding/OnboardingWizard.module.css", import.meta.url), "utf8"),
     ]);
-    expect(wizard).toContain('role="dialog"');
-    expect(wizard).toContain('aria-modal="true"');
-    expect(wizard).toContain('event.key === "Escape"');
-    expect(wizard).toContain('event.key !== "Tab"');
+    expect(wizard).toContain("<Page");
+    expect(wizard).toContain('title="Setup"');
+    expect(wizard).toContain('className="onboarding"');
+    expect(wizard).not.toContain('role="dialog"');
+    expect(wizard).not.toContain('aria-modal="true"');
+    expect(wizard).not.toContain('event.key === "Escape"');
+    expect(wizard).not.toContain('event.key !== "Tab"');
     expect(wizard).toContain('aria-live="polite"');
     expect(coachKeys).toContain("Sign in with ChatGPT");
     expect(coachKeys).toContain("Requires a paid ChatGPT plan. No API key needed.");
     expect(coachKeys).toContain("Finish signing in in your browser…");
-    expect(styles).toContain("@media (max-width: 720px)");
-    expect(styles).toContain("padding: 30px 24px");
+    expect(styles).not.toContain("border-radius: 22px");
+    expect(styles).not.toContain("width: min(680px");
     expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(styles).not.toContain("backdrop-filter");
   });
 });

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Shell } from "../src/app/Shell.js";
 import { EMPTY_CHAT_SURFACE, type ChatActions } from "../src/state/chat-slice.js";
 import { resetChatStream } from "../src/state/chat-stream.js";
+import { CLOSED_ONBOARDING } from "../src/state/onboarding-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 
 function stubActions(): ChatActions {
@@ -26,11 +27,20 @@ describe("shell", () => {
       runtimeReady: true,
       chat: { ...EMPTY_CHAT_SURFACE, newConversationUnavailable: false },
       chatActions: stubActions(),
+      onboarding: CLOSED_ONBOARDING,
+      onboardingActions: null,
+      onboardingStartupSettled: true,
     });
   });
 
   afterEach(() => {
-    useEnduragentStore.setState({ chat: EMPTY_CHAT_SURFACE, chatActions: null });
+    useEnduragentStore.setState({
+      chat: EMPTY_CHAT_SURFACE,
+      chatActions: null,
+      onboarding: CLOSED_ONBOARDING,
+      onboardingActions: null,
+      onboardingStartupSettled: false,
+    });
     resetChatStream();
   });
 
@@ -46,6 +56,7 @@ describe("shell", () => {
     expect(document.querySelector("textarea#message")).not.toBeNull();
     expect(document.querySelector("button.sync-chip")).not.toBeNull();
     expect(document.querySelector('[data-view="chat"]')).not.toBeNull();
+    expect(document.querySelector('[data-onboarding="closed"]')).not.toBeNull();
   });
 
   it("retires the training drawer, data spine and topbar strip", () => {
@@ -98,6 +109,57 @@ describe("shell", () => {
     expect(noticeHost?.isConnected).toBe(true);
     expect(document.querySelector("textarea#message")).not.toBeNull();
     expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("derives Setup from onboarding and returns to the stored view when it closes", async () => {
+    const dismiss = vi.fn();
+    useEnduragentStore.setState({
+      activeView: "training",
+      onboarding: { ...CLOSED_ONBOARDING, open: true },
+      onboardingActions: { dismiss } as never,
+    });
+    render(<Shell onReady={() => {}} />);
+
+    expect(await screen.findByRole("region", { name: "Setup" })).toBeInTheDocument();
+    expect(document.querySelector('[data-view="setup"]')).not.toBeNull();
+    expect(document.querySelector('[data-onboarding="open"]')).not.toBeNull();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(document.querySelector(".onboarding-scrim")).toBeNull();
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+
+    act(() => {
+      useEnduragentStore.getState().setOnboarding(CLOSED_ONBOARDING);
+    });
+
+    expect(await screen.findByRole("region", { name: "Training" })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Setup" })).toBeNull();
+    expect(document.querySelector('[data-view="setup"]')).toBeNull();
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(dismiss).not.toHaveBeenCalled();
+  });
+
+  it("never renders Setup while onboarding is closed", async () => {
+    useEnduragentStore.setState({
+      activeView: "settings",
+      onboarding: CLOSED_ONBOARDING,
+    });
+    render(<Shell onReady={() => {}} />);
+
+    expect(await screen.findByRole("region", { name: "Settings" })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Setup" })).toBeNull();
+    expect(document.querySelector('[data-view="setup"]')).toBeNull();
+  });
+
+  it("reports onboarding startup as pending until the decision settles", () => {
+    useEnduragentStore.setState({ onboardingStartupSettled: false });
+    render(<Shell onReady={() => {}} />);
+
+    expect(document.querySelector('[data-onboarding="pending"]')).not.toBeNull();
+
+    act(() => {
+      useEnduragentStore.getState().setOnboardingStartupSettled(true);
+    });
+    expect(document.querySelector('[data-onboarding="closed"]')).not.toBeNull();
   });
 
   it("disables the new chat button until the chat controller is bound", () => {

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConnectionStatus } from "../src/state/connection-slice.js";
 import { EMPTY_CHAT_SURFACE, type ChatActions } from "../src/state/chat-slice.js";
 import { restoreManualSyncFocus, setManualSyncFocusTarget } from "../src/state/manual-sync-focus.js";
-import { focusSetupOpener } from "../src/state/setup-opener.js";
+import { CLOSED_ONBOARDING } from "../src/state/onboarding-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
 import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
@@ -44,6 +44,8 @@ beforeEach(() => {
     training: EMPTY_TRAINING_SURFACE,
     sync: IDLE_MANUAL_SYNC,
     syncActions: null,
+    onboarding: CLOSED_ONBOARDING,
+    onboardingActions: null,
     connection: "connecting",
   });
 });
@@ -56,6 +58,8 @@ afterEach(() => {
     training: EMPTY_TRAINING_SURFACE,
     sync: IDLE_MANUAL_SYNC,
     syncActions: null,
+    onboarding: CLOSED_ONBOARDING,
+    onboardingActions: null,
     connection: "connecting",
   });
 });
@@ -176,11 +180,43 @@ describe("sidebar connection status", () => {
   });
 });
 
-describe("sidebar setup opener", () => {
-  it("hands setup focus back to the settings destination", () => {
+describe("sidebar setup navigation", () => {
+  it("opens Setup through the onboarding controller", async () => {
+    const user = userEvent.setup();
+    const open = vi.fn(async () => {});
+    useEnduragentStore.setState({ onboardingActions: { open } as never });
     render(<Sidebar />);
 
-    focusSetupOpener();
-    expect(document.activeElement).toBe(screen.getByRole("button", { name: /Settings/u }));
+    await user.click(screen.getByRole("button", { name: "Setup" }));
+
+    expect(open).toHaveBeenCalledOnce();
+  });
+
+  it("highlights Setup from onboarding state and dismisses it before navigating away", async () => {
+    const user = userEvent.setup();
+    const dismiss = vi.fn(() => {
+      useEnduragentStore.getState().setOnboarding(CLOSED_ONBOARDING);
+    });
+    useEnduragentStore.setState({
+      activeView: "chat",
+      onboarding: { ...CLOSED_ONBOARDING, open: true },
+      onboardingActions: { dismiss } as never,
+    });
+    render(<Sidebar />);
+
+    expect(screen.getByRole("button", { name: "Setup" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("button", { name: "Chat" })).not.toHaveAttribute("aria-current");
+
+    await user.click(screen.getByRole("button", { name: "Training" }));
+
+    expect(dismiss).toHaveBeenCalledOnce();
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(screen.getByRole("button", { name: "Training" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
   });
 });

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -315,7 +315,38 @@ async function launch(input: {
     while ((document.documentElement.dataset.rpc !== "connected" || chipStatus() === undefined || chipStatus() === "loading") && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 20));
     }
-    document.querySelector(".onboarding")?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    const onboardingDeadline = Date.now() + 10000;
+    const onboardingState = () =>
+      document.querySelector("[data-onboarding]")?.getAttribute("data-onboarding") ?? null;
+    while (
+      (onboardingState() === null || onboardingState() === "pending") &&
+      Date.now() < onboardingDeadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (onboardingState() === null || onboardingState() === "pending") {
+      throw new Error("onboarding startup decision did not settle");
+    }
+    if (onboardingState() === "open") {
+      const dismissDeadline = Date.now() + 10000;
+      while (
+        document.querySelector(".onboarding-dismiss") === null &&
+        onboardingState() === "open" &&
+        Date.now() < dismissDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      if (onboardingState() === "open") {
+        const dismiss = document.querySelector(".onboarding-dismiss");
+        if (!(dismiss instanceof HTMLButtonElement)) throw new Error("setup dismiss did not mount");
+        dismiss.click();
+      }
+      const closedDeadline = Date.now() + 10000;
+      while (onboardingState() !== "closed" && Date.now() < closedDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      if (onboardingState() !== "closed") throw new Error("setup dismiss did not close onboarding");
+    }
   `);
   return { fixture, calls };
 }

--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -17,9 +17,91 @@ const hasLoopback = await new Promise<boolean>((resolveAvailability) => {
 const token = "t".repeat(43);
 const fixtures: RunningDesktopFixture[] = [];
 
+interface ScriptRequest {
+  readonly method: string;
+  readonly params: unknown;
+}
+
+function response(value: unknown): readonly string[] {
+  return [JSON.stringify(value)];
+}
+
 const script: DesktopFixtureScript = {
-  onRequest() {
-    throw new TypeError("unexpected fixture request");
+  onRequest(value) {
+    const request = value as ScriptRequest;
+    if (request.method === "getRuntimeConfig") {
+      return response({
+        schemaVersion: 3,
+        llm: {
+          provider: "anthropic",
+          model: "fixture",
+          credential_configured: true,
+        },
+        intervals: {
+          athlete_id: "0",
+          credential_configured: false,
+          managedByEnvironment: { athleteId: false },
+        },
+        session: {
+          historyTokenBudgetRatio: 0.3,
+          idleMinutes: 0,
+          dailyResetHour: 4,
+          timezone: "UTC",
+        },
+      });
+    }
+    if (request.method === "configureRuntime") {
+      const params = request.params as {
+        readonly llm?: unknown;
+        readonly intervals?: unknown;
+        readonly session?: unknown;
+      };
+      return response({
+        schemaVersion: 3,
+        status: "applied",
+        applied: {
+          llm: params.llm !== undefined,
+          intervals: params.intervals !== undefined,
+          session: params.session !== undefined,
+        },
+      });
+    }
+    if (request.method === "saveIntake") {
+      return response({ schemaVersion: 1, saved: true });
+    }
+    if (request.method === "sync") {
+      return response({
+        schemaVersion: 1,
+        published: false,
+        referenceSucceeded: true,
+        requests: { store: 0, reference: 0, total: 0 },
+      });
+    }
+    if (request.method === "getAthleteState") {
+      return response({
+        schemaVersion: "1",
+        lastUpdated: "1998-07-19T08:00:00.000Z",
+        freshness: "fresh",
+        degraded: false,
+        lastSynced: null,
+        athleteProfile: {},
+        currentStatus: {},
+        derivedMetrics: {},
+        recentActivities: [],
+        plannedWorkouts: [],
+        wellness: {},
+      });
+    }
+    if (request.method === "getTranscriptPage") {
+      return response({ schemaVersion: 1, status: "page", turns: [], nextCursor: null });
+    }
+    if (request.method === "getUnitsPreference") {
+      return response({ value: "metric", source: "default" });
+    }
+    if (request.method === "hasSession") {
+      return response({ hasSession: false });
+    }
+    throw new TypeError(`unexpected fixture request: ${request.method}`);
   },
 };
 
@@ -28,7 +110,7 @@ afterEach(async () => {
 });
 
 describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live", () => {
-  it("opens the setup wizard on first run and dismisses it with Escape", async () => {
+  it("opens Setup as a first-run page and finishes into a working chat", async () => {
     const fixture = await launchDesktopFixture({
       script,
       token,
@@ -40,41 +122,93 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
     fixtures.push(fixture);
     const observed = await fixture.evaluate<{
       readonly present: boolean;
-      readonly covers: boolean;
+      readonly setupView: boolean;
+      readonly scrimAbsent: boolean;
+      readonly modalAbsent: boolean;
       readonly title: string;
-      readonly dismissed: boolean;
-      readonly focusRestored: boolean;
+      readonly escapeStayed: boolean;
+      readonly finished: boolean;
+      readonly chatWorking: boolean;
     }>(`
       const deadline = Date.now() + 10000;
       while (!document.querySelector(".onboarding") && Date.now() < deadline) {
         await new Promise((resolve) => setTimeout(resolve, 20));
       }
-      const dialog = document.querySelector(".onboarding");
-      const scrim = document.querySelector(".onboarding-scrim");
-      const rect = scrim ? scrim.getBoundingClientRect() : { width: 0, height: 0 };
-      const midpoint = document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2);
-      const present = dialog !== null;
-      const covers =
-        rect.width >= window.innerWidth &&
-        rect.height >= window.innerHeight &&
-        (midpoint === scrim || scrim.contains(midpoint));
+      const page = document.querySelector(".onboarding");
+      const present = page !== null;
+      const setupView =
+        document.querySelector('[data-view="setup"][data-onboarding="open"]') !== null;
+      const scrimAbsent = document.querySelector(".onboarding-scrim") === null;
+      const modalAbsent =
+        page?.getAttribute("role") !== "dialog" && page?.hasAttribute("aria-modal") !== true;
       const title = document.querySelector("#onboarding-title")?.textContent ?? "";
-      dialog?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      page?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
       await new Promise((resolve) => setTimeout(resolve, 60));
+      const escapeStayed =
+        document.querySelector('[data-view="setup"][data-onboarding="open"]') !== null &&
+        document.querySelector(".onboarding") !== null;
+      const button = (label) =>
+        Array.from(document.querySelectorAll(".onboarding button")).find(
+          (entry) => entry.textContent?.trim() === label,
+        );
+      const waitForTitle = async (expected) => {
+        const stepDeadline = Date.now() + 10000;
+        while (
+          document.querySelector("#onboarding-title")?.textContent !== expected &&
+          Date.now() < stepDeadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+      };
+      const anthropic = document.querySelector('input[data-slot="anthropic"]');
+      if (anthropic) anthropic.value = "synthetic-model-key";
+      button("Continue")?.click();
+      await waitForTitle("Bring your riding history");
+      const intervals = document.querySelector('input[data-slot="intervals-icu"]');
+      if (intervals) intervals.value = "synthetic-training-key";
+      button("Continue")?.click();
+      await waitForTitle("A few safety checks");
+      const labels = Array.from(document.querySelectorAll(".onboarding label"));
+      labels.find((entry) => entry.textContent?.trim() === "No")?.querySelector("input")?.click();
+      labels
+        .find((entry) => entry.textContent?.trim() === "No current injury")
+        ?.querySelector("input")
+        ?.click();
+      button("Continue")?.click();
+      await waitForTitle("Your coach is ready");
+      button("Finish setup")?.click();
+      const chatDeadline = Date.now() + 10000;
+      while (
+        document.querySelector(
+          '[data-view="chat"][data-onboarding="closed"] textarea#message',
+        ) === null &&
+        Date.now() < chatDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      const composer = document.querySelector(
+        '[data-view="chat"][data-onboarding="closed"] textarea#message',
+      );
       return {
         present,
-        covers,
+        setupView,
+        scrimAbsent,
+        modalAbsent,
         title,
-        dismissed: document.querySelector(".onboarding") === null,
-        focusRestored: document.activeElement?.textContent?.includes("Settings") === true,
+        escapeStayed,
+        finished: document.querySelector(".onboarding") === null,
+        chatWorking: composer !== null && composer.disabled === false,
       };
     `);
     expect(observed).toEqual({
       present: true,
-      covers: true,
+      setupView: true,
+      scrimAbsent: true,
+      modalAbsent: true,
       title: "Choose how your coach thinks",
-      dismissed: true,
-      focusRestored: true,
+      escapeStayed: true,
+      finished: true,
+      chatWorking: true,
     });
   });
 });

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -231,7 +231,38 @@ async function launch(initial: "reached" | "complete" = "reached") {
     while (document.documentElement.dataset.rpc !== "connected" && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 20));
     }
-    document.querySelector(".onboarding")?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    const onboardingDeadline = Date.now() + 10000;
+    const onboardingState = () =>
+      document.querySelector("[data-onboarding]")?.getAttribute("data-onboarding") ?? null;
+    while (
+      (onboardingState() === null || onboardingState() === "pending") &&
+      Date.now() < onboardingDeadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (onboardingState() === null || onboardingState() === "pending") {
+      throw new Error("onboarding startup decision did not settle");
+    }
+    if (onboardingState() === "open") {
+      const dismissDeadline = Date.now() + 10000;
+      while (
+        document.querySelector(".onboarding-dismiss") === null &&
+        onboardingState() === "open" &&
+        Date.now() < dismissDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      if (onboardingState() === "open") {
+        const dismiss = document.querySelector(".onboarding-dismiss");
+        if (!(dismiss instanceof HTMLButtonElement)) throw new Error("setup dismiss did not mount");
+        dismiss.click();
+      }
+      const closedDeadline = Date.now() + 10000;
+      while (onboardingState() !== "closed" && Date.now() < closedDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      if (onboardingState() !== "closed") throw new Error("setup dismiss did not close onboarding");
+    }
   `);
   return { fixture, calls, failSpend: scripted.failSpend };
 }


### PR DESCRIPTION
## Summary

The onboarding wizard was a scrim + `role="dialog"` modal floating over the shell. It is now a first-class Setup page rendered through the shared `Page` component — the same title bar, centered column, and section flow as Training and Settings. No scrim, no focus trap, no Escape-to-close; the Dismiss control is a quiet action in the page title bar and the step-progress dots are a slim strip at the top of the content column. Step machine, bridge, and IPC are untouched.

## Design: the Setup view is derived, never stored

An earlier draft steered navigation imperatively (publish callbacks calling `setActiveView("setup")` / back to chat). Live instrumentation of the real app under the integration harness proved that racy: the async startup auto-open flips the view at an unpredictable moment; in configured apps the wizard closes itself ~25ms after mounting (captured timeline `chat@226 → setup@425 → wizard@735 → chat@759`); and some interleavings wedged the app on a blank Setup view with chat hidden and the composer unfocusable. While chat sat `display: none` its scroll state reset, which fired the auto-load-earlier handler and broke newest-anchoring.

The landed design removes the hazard class instead of patching instances:

- `Shell` computes `effectiveView = onboarding.open ? "setup" : activeView`. The stored view type is `StoredViewId = Exclude<ViewId, "setup">`, so a wedge is unrepresentable.
- The onboarding publish hook only publishes state; nothing navigates imperatively.
- Sidebar: Setup highlights from `onboarding.open`; clicking Setup opens the wizard; clicking any other entry while Setup is open dismisses it and navigates.
- Dismissing or completing reveals the previously stored view (chat by default).
- The shell exposes `data-onboarding="pending | open | closed"`, settled once the startup auto-open decision is known — a deterministic signal for the integration harnesses, which previously raced the async decision.
- Chat scroll hardening: the transcript re-anchors to newest when chat becomes visible after hydrating hidden, and the auto-load-earlier scroll handler ignores events while the conversation is hidden (display-toggle scroll resets can no longer trigger history loads).

The first-run integration test was upgraded from "Escape closes the dialog" to a full walkthrough: first run boots into the Setup page (no scrim, no dialog semantics, Escape stays), completes all four steps against a scripted fixture, and lands in a working chat.

## Verification

- Renderer `check` and `test` (447/447), desktop `check`.
- `onboarding-first-run.integration.test.ts` 1/1, `spend-meter.integration.test.ts` 3/3.
- `chat-panels.integration.test.ts` 5/5 on five consecutive runs (it could not pass at all under the imperative-navigation draft).
