### PR TITLE
test(desktop): add removeQueued to the archive surface chat-actions stub

### DIFF
--- a/apps/desktop-renderer/tests/archive-surface.test.tsx
+++ b/apps/desktop-renderer/tests/archive-surface.test.tsx
@@ -30,6 +30,7 @@ function chatActions(): ChatActions {
   return {
     submit: vi.fn(),
     retry: vi.fn(),
+    removeQueued: vi.fn(),
     loadEarlier: vi.fn(),
     retryHydration: vi.fn(),
     openNewConversation: vi.fn(),


### PR DESCRIPTION
## Summary

Repairs the `desktop` CI break from run 30517247944: PRs #471 and #472 were each green against the pre-merge base, but #471 added `removeQueued` to `ChatActions` while #472's new `archive-surface.test.tsx` stubbed the old interface shape — a semantic conflict that only surfaced once both merged. One-line stub addition.

## Test plan

- `pnpm run check` in apps/desktop-renderer (the exact failing CI step) → clean.
- Full renderer suite: 491/491 passing with both features together.