### PR TITLE
chore: update repo references after the rename to enduragent

### DIFF
--- a/.changeset/repo-rename-enduragent.md
+++ b/.changeset/repo-rename-enduragent.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: The project's GitHub home moved to https://github.com/yerzhansa/enduragent (formerly cycling-coach); old links redirect.

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -71,7 +71,7 @@ jobs:
             echo "labels<<EOF"
             echo "org.opencontainers.image.title=Cycling Coach"
             echo "org.opencontainers.image.description=Single-tenant AI cycling coach for Telegram and intervals.icu"
-            echo "org.opencontainers.image.source=https://github.com/yerzhansa/cycling-coach"
+            echo "org.opencontainers.image.source=https://github.com/yerzhansa/enduragent"
             echo "org.opencontainers.image.revision=${GITHUB_SHA}"
             if [[ -n "$version" ]]; then
               echo "org.opencontainers.image.version=${version}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
         # OIDC is negotiated automatically by npm 11+ when id-token: write
         # is granted (no NPM_TOKEN secret needed). The trusted publisher
         # must be configured per-package on npmjs.com (one-time operator
-        # action; matches repo `yerzhansa/cycling-coach` + workflow
+        # action; matches repo `yerzhansa/enduragent` + workflow
         # `release.yml`).
         run: |
           set -euo pipefail

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -50,7 +50,7 @@ modifications were applied during the port:
 - **Trademark substitution.** Section-11 was authored against TrainingPeaks
   vocabulary. This codebase uses intervals.icu's plain-English alternatives
   throughout — the substitution is enforced by `pnpm check:trademarks` and
-  documented in [`CONTRIBUTING.md`](https://github.com/yerzhansa/cycling-coach/blob/main/CONTRIBUTING.md#trademark-hygiene).
+  documented in [`CONTRIBUTING.md`](https://github.com/yerzhansa/enduragent/blob/main/CONTRIBUTING.md#trademark-hygiene).
 - **Multi-sport adapter pattern.** Per ADR-0010, the Reference layer gains a
   per-sport seam — sports plug in via an optional `referenceAdapters?()`
   method on the `Sport` interface, returning an array of layer-owned adapters
@@ -84,7 +84,7 @@ modifications were applied during the port:
 
 ### Canonical attribution surfaces
 
-This file (`NOTICE.md`) and the [`README.md` Credits section](https://github.com/yerzhansa/cycling-coach#credits)
+This file (`NOTICE.md`) and the [`README.md` Credits section](https://github.com/yerzhansa/enduragent#credits)
 are the canonical attribution surfaces. The full upstream repository is at
 https://github.com/CrankAddict/section-11.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AI cycling coaching agent. Bring your own LLM API key **or sign in with a ChatGPT Plus subscription**, connect [intervals.icu](https://intervals.icu) for real athlete data, chat via Telegram or CLI.
 
+This project was formerly known as cycling-coach.
+
 Training data and coaching insights may include data from Garmin devices.
 
 Want the bot running 24/7 without keeping your computer on? Deploy the Railway template: https://railway.com/deploy/cycling-coach
@@ -97,8 +99,8 @@ Anthropic's Claude Pro/Max subscription does **not** support OAuth for third-par
 ### From source (development)
 
 ```bash
-git clone git@github.com:yerzhansa/cycling-coach.git
-cd cycling-coach
+git clone git@github.com:yerzhansa/enduragent.git
+cd enduragent
 
 npm install
 npm run build

--- a/apps/desktop-renderer/tests/release-notes.test.ts
+++ b/apps/desktop-renderer/tests/release-notes.test.ts
@@ -23,7 +23,7 @@ function available(overrides: Partial<Extract<ReleaseNotesResult, { status: "ava
     status: "available",
     version: "2026.7.23",
     notes: ["Improved Desktop reliability."],
-    releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+    releaseUrl: "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23",
     ...overrides,
   } as const;
 }
@@ -93,7 +93,7 @@ describe("release notes controller", () => {
       .mockResolvedValueOnce({
         status: "unavailable",
         version: "2026.7.23",
-        releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+        releaseUrl: "https://github.com/yerzhansa/enduragent/releases",
       })
       .mockRejectedValueOnce(rawError);
     const subject = fakeView();
@@ -104,7 +104,7 @@ describe("release notes controller", () => {
     await vi.waitFor(() =>
       expect(subject.view.renderUnavailable).toHaveBeenLastCalledWith({
         version: "2026.7.23",
-        releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+        releaseUrl: "https://github.com/yerzhansa/enduragent/releases",
       }),
     );
     subject.retry();

--- a/apps/desktop/src/main/release-notes-ipc.ts
+++ b/apps/desktop/src/main/release-notes-ipc.ts
@@ -5,9 +5,9 @@ import { isTrustedConnectionRequest } from "./security.js";
 
 const RELEASE_NOTES_REPO = Object.freeze({
   owner: "yerzhansa",
-  name: "cycling-coach",
+  name: "enduragent",
 });
-const RELEASES_URL = "https://github.com/yerzhansa/cycling-coach/releases";
+const RELEASES_URL = "https://github.com/yerzhansa/enduragent/releases";
 
 function unavailableReleaseNotes(): ReleaseNotesResult {
   return {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -84,7 +84,7 @@ const CHATGPT_REASONS = new Set([
   "runtime-unavailable",
 ]);
 const IMPORT_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
-const RELEASES_URL = "https://github.com/yerzhansa/cycling-coach/releases";
+const RELEASES_URL = "https://github.com/yerzhansa/enduragent/releases";
 const RELEASE_NOTES_MAX_TOTAL_BYTES = 64 * 1024;
 const TRANSCRIPT_PAGE_MAX_TURNS = 50;
 const TRANSCRIPT_PAGE_MAX_RESPONSE_BYTES = 266_240;

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -451,12 +451,12 @@ describe("desktop preload ChatGPT auth", () => {
       status: "available",
       version: "2026.7.23",
       notes,
-      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+      releaseUrl: "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23",
     };
     mocks.invoke.mockResolvedValueOnce(available).mockResolvedValueOnce({
       status: "unavailable",
       version: null,
-      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+      releaseUrl: "https://github.com/yerzhansa/enduragent/releases",
     });
 
     const availableCopy = (await bridge.releaseNotes()) as typeof available;
@@ -466,7 +466,7 @@ describe("desktop preload ChatGPT auth", () => {
     await expect(bridge.releaseNotes()).resolves.toEqual({
       status: "unavailable",
       version: null,
-      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+      releaseUrl: "https://github.com/yerzhansa/enduragent/releases",
     });
     expect(mocks.invoke.mock.calls).toEqual([
       ["desktop:get-release-notes"],
@@ -478,19 +478,19 @@ describe("desktop preload ChatGPT auth", () => {
     mocks.invoke.mockResolvedValueOnce({
       status: "unavailable",
       version: "2026.7.23",
-      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+      releaseUrl: "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23",
     });
 
     await expect(bridge.releaseNotes()).resolves.toEqual({
       status: "unavailable",
       version: "2026.7.23",
-      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+      releaseUrl: "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23",
     });
   });
 
   it("rejects malformed release note unions, strings, counts, and totals", async () => {
     const tagUrl =
-      "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23";
+      "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23";
     const malformed = [
       null,
       {
@@ -504,7 +504,7 @@ describe("desktop preload ChatGPT auth", () => {
         status: "unavailable",
         version: null,
         notes: [],
-        releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+        releaseUrl: "https://github.com/yerzhansa/enduragent/releases",
       },
       {
         status: "available",
@@ -563,18 +563,18 @@ describe("desktop preload ChatGPT auth", () => {
         version: "2026.7.23",
         notes: [],
         releaseUrl:
-          "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.22",
+          "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.22",
       },
       {
         status: "unavailable",
         version: "2026.7.23",
-        releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+        releaseUrl: "https://github.com/yerzhansa/enduragent/releases",
       },
       {
         status: "unavailable",
         version: null,
         releaseUrl:
-          "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+          "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23",
       },
     ];
 
@@ -585,14 +585,15 @@ describe("desktop preload ChatGPT auth", () => {
   });
 
   it.each([
-    "http://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
-    "https://user:secret@github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
-    "https://github.com:444/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
-    "https://github.com/other/cycling-coach/releases/tag/cycling-coach@2026.7.23",
-    "https://github.com/yerzhansa/cycling-coach/releases/latest",
-    "https://github.com/yerzhansa/cycling-coach/releases/tag/",
-    "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23?token=secret",
-    "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23#notes",
+    "http://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23",
+    "https://user:secret@github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23",
+    "https://github.com:444/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23",
+    "https://github.com/other/enduragent/releases/tag/cycling-coach@2026.7.23",
+    "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+    "https://github.com/yerzhansa/enduragent/releases/latest",
+    "https://github.com/yerzhansa/enduragent/releases/tag/",
+    "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23?token=secret",
+    "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23#notes",
   ])("rejects a noncanonical or out-of-repository release URL: %s", async (releaseUrl) => {
     mocks.invoke.mockResolvedValueOnce({
       status: "available",

--- a/apps/desktop/tests/release-notes-ipc.test.ts
+++ b/apps/desktop/tests/release-notes-ipc.test.ts
@@ -23,7 +23,7 @@ const availableResult = {
   status: "available",
   version: "2026.7.23",
   notes: ["Added release notes to the desktop."],
-  releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+  releaseUrl: "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23",
 } as const;
 
 function setup(loadReleaseNotes: LoadReleaseNotes = vi.fn(async () => availableResult)) {
@@ -67,7 +67,7 @@ describe("desktop release notes IPC", () => {
     expect(state.loadReleaseNotes).toHaveBeenCalledOnce();
     expect(state.loadReleaseNotes).toHaveBeenCalledWith("cycling-coach", {
       owner: "yerzhansa",
-      name: "cycling-coach",
+      name: "enduragent",
     });
   });
 
@@ -77,7 +77,7 @@ describe("desktop release notes IPC", () => {
       status: "available" as const,
       version: "2026.7.23",
       notes,
-      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+      releaseUrl: "https://github.com/yerzhansa/enduragent/releases/tag/cycling-coach@2026.7.23",
       internalFeedUrl: "https://example.invalid/private-feed",
     }));
     const state = setup(loadReleaseNotes);
@@ -126,7 +126,7 @@ describe("desktop release notes IPC", () => {
     await expect(releaseNotes(state.trusted)).resolves.toEqual({
       status: "unavailable",
       version: null,
-      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+      releaseUrl: "https://github.com/yerzhansa/enduragent/releases",
     });
     await expect(releaseNotes(state.trusted)).resolves.toEqual(availableResult);
     expect(loadReleaseNotes).toHaveBeenCalledTimes(2);

--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yerzhansa/cycling-coach.git"
+    "url": "https://github.com/yerzhansa/enduragent.git"
   }
 }

--- a/packages/core/tests/release-notes.test.ts
+++ b/packages/core/tests/release-notes.test.ts
@@ -7,8 +7,8 @@ import {
   type ReleaseNotesFetch,
 } from "../src/release-notes.js";
 
-const REPO = { owner: "yerzhansa", name: "cycling-coach" };
-const RELEASES_URL = "https://github.com/yerzhansa/cycling-coach/releases";
+const REPO = { owner: "yerzhansa", name: "enduragent" };
+const RELEASES_URL = "https://github.com/yerzhansa/enduragent/releases";
 
 function jsonResponse(value: unknown, status = 200): Response {
   return new Response(JSON.stringify(value), {
@@ -125,7 +125,7 @@ describe("fetchLatestReleaseNotes", () => {
     });
     expect(requests.map(({ url }) => url)).toEqual([
       "https://registry.npmjs.org/cycling-coach/latest",
-      "https://api.github.com/repos/yerzhansa/cycling-coach/releases/tags/cycling-coach@2026.7.23",
+      "https://api.github.com/repos/yerzhansa/enduragent/releases/tags/cycling-coach@2026.7.23",
     ]);
     expect(requests[1].init?.headers).toEqual({ Accept: "application/vnd.github+json" });
     expect(requests.every(({ init }) => init?.redirect === "error")).toBe(true);

--- a/packages/cycling-coach/NOTICE.md
+++ b/packages/cycling-coach/NOTICE.md
@@ -50,7 +50,7 @@ modifications were applied during the port:
 - **Trademark substitution.** Section-11 was authored against TrainingPeaks
   vocabulary. This codebase uses intervals.icu's plain-English alternatives
   throughout — the substitution is enforced by `pnpm check:trademarks` and
-  documented in [`CONTRIBUTING.md`](https://github.com/yerzhansa/cycling-coach/blob/main/CONTRIBUTING.md#trademark-hygiene).
+  documented in [`CONTRIBUTING.md`](https://github.com/yerzhansa/enduragent/blob/main/CONTRIBUTING.md#trademark-hygiene).
 - **Multi-sport adapter pattern.** Per ADR-0010, the Reference layer gains a
   per-sport seam — sports plug in via an optional `referenceAdapters?()`
   method on the `Sport` interface, returning an array of layer-owned adapters
@@ -84,7 +84,7 @@ modifications were applied during the port:
 
 ### Canonical attribution surfaces
 
-This file (`NOTICE.md`) and the [`README.md` Credits section](https://github.com/yerzhansa/cycling-coach#credits)
+This file (`NOTICE.md`) and the [`README.md` Credits section](https://github.com/yerzhansa/enduragent#credits)
 are the canonical attribution surfaces. The full upstream repository is at
 https://github.com/CrankAddict/section-11.
 

--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -114,8 +114,8 @@ npx cycling-coach
 ## More
 
 - Follow [@yerzhansa](https://x.com/yerzhansa) on X.com for updates, or drop a question/feedback anytime.
-- **Secrets backends** (1Password, macOS Keychain, Vault, AWS/GCP Secret Manager, age, env), **architecture diagram**, and **development setup** — see the [GitHub repo](https://github.com/yerzhansa/cycling-coach#readme).
-- **Issues**: <https://github.com/yerzhansa/cycling-coach/issues>
+- **Secrets backends** (1Password, macOS Keychain, Vault, AWS/GCP Secret Manager, age, env), **architecture diagram**, and **development setup** — see the [GitHub repo](https://github.com/yerzhansa/enduragent#readme).
+- **Issues**: <https://github.com/yerzhansa/enduragent/issues>
 - **License**: MIT
 
 ## Notices

--- a/packages/cycling-coach/package.json
+++ b/packages/cycling-coach/package.json
@@ -14,12 +14,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/yerzhansa/cycling-coach.git",
+    "url": "git+https://github.com/yerzhansa/enduragent.git",
     "directory": "packages/cycling-coach"
   },
-  "homepage": "https://github.com/yerzhansa/cycling-coach#readme",
+  "homepage": "https://github.com/yerzhansa/enduragent#readme",
   "bugs": {
-    "url": "https://github.com/yerzhansa/cycling-coach/issues"
+    "url": "https://github.com/yerzhansa/enduragent/issues"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/sport-duathlon/README.md
+++ b/packages/sport-duathlon/README.md
@@ -1,5 +1,5 @@
 # @enduragent/sport-duathlon
 
-Duathlon coordinator sport package for the [enduragent](https://github.com/yerzhansa/cycling-coach) coaching agents. Composes sport-cycling + sport-running per ADR-0002.
+Duathlon coordinator sport package for the [enduragent](https://github.com/yerzhansa/enduragent) coaching agents. Composes sport-cycling + sport-running per ADR-0002.
 
 > **Status: alpha — empty stub.** Real implementation imminent.

--- a/packages/sport-running/README.md
+++ b/packages/sport-running/README.md
@@ -1,5 +1,5 @@
 # @enduragent/sport-running
 
-Running sport package for the [enduragent](https://github.com/yerzhansa/cycling-coach) coaching agents.
+Running sport package for the [enduragent](https://github.com/yerzhansa/enduragent) coaching agents.
 
 > **Status: alpha — empty stub.** Real implementation imminent.


### PR DESCRIPTION
## Summary

The GitHub repository was renamed from `yerzhansa/cycling-coach` to `yerzhansa/enduragent` (stars, issues, PRs, and releases carried over; the old URL redirects). This PR updates every in-repo reference to the old repo path.

- `package.json` (root) and `packages/cycling-coach/package.json`: `repository`, `homepage`, and `bugs` URLs. The published package's `repository.url` is what release-notes lookup derives its GitHub API target from, so this is functional, not cosmetic.
- `apps/desktop/src/main/release-notes-ipc.ts`: `RELEASE_NOTES_REPO.name` and `RELEASES_URL`.
- `apps/desktop/src/preload/index.ts`: `RELEASES_URL` (tag construction unchanged).
- Test files pinning release URLs (`preload-auth`, `release-notes-ipc`, renderer `release-notes`, core `release-notes`): repo paths updated, tag segments preserved. The rejected-URL table now also asserts the stale old repo path is rejected.
- `.github/workflows/publish-image.yml`: `org.opencontainers.image.source` label. `IMAGE_NAME` is intentionally unchanged.
- `.github/workflows/release.yml`: trusted-publisher comment.
- `NOTICE.md` (root + package): the two repo links only.
- `README.md`: clone instructions, a "formerly known as cycling-coach" note.
- `packages/cycling-coach/README.md`, `packages/sport-running/README.md`, `packages/sport-duathlon/README.md`: repo links.
- Changeset (patch) with a User-facing line announcing the move.

## Intentionally unchanged

- npm package name `cycling-coach` and the `cycling-coach@*` release tag namespace.
- GHCR image name `ghcr.io/yerzhansa/cycling-coach` (the Railway template and existing deployments pull this path; migration is tracked separately).
- Railway template link `railway.com/deploy/cycling-coach`.

## Test plan

- `pnpm check` green (all static gates including changeset-userfacing).
- Full `pnpm test`: 462 test files passed; 2 timeout flakes under full-suite load (`chat-panels.integration`, `run-binary-allowlist`) pass in isolation.
- `apps/desktop/tests/preload-auth.test.ts` re-run after the rejected-URL table update: 35/35.
- Sweep: every remaining `yerzhansa/cycling-coach` match in the repo contains `ghcr.io/yerzhansa/cycling-coach`.

Note for the release flow: the npm trusted publisher on npmjs.com must be updated to repo `yerzhansa/enduragent` before the next Version Packages merge, or the OIDC publish will fail.
