### PR TITLE
ci: dual-publish npm package and container image as enduragent

### DIFF
--- a/.changeset/enduragent-dual-publish.md
+++ b/.changeset/enduragent-dual-publish.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: The coach is now also published as enduragent — npm i -g enduragent installs the enduragent command, and container images additionally ship as ghcr.io/yerzhansa/enduragent; existing cycling-coach installs keep working unchanged.

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,7 +1,9 @@
 name: Publish Docker image
 
-# First run creates the GHCR package. Before publishing the Railway marketplace
-# template, confirm the package visibility is Public in GitHub Packages.
+# First run creates each GHCR package, private by default. Before publishing the
+# Railway marketplace template, confirm the visibility of BOTH packages named in
+# the env block below is Public in GitHub Packages — a private package answers
+# `docker pull` with 401 for everyone.
 
 # The bot image and the desktop shell share one branch. Desktop-only surfaces
 # are excluded rather than bot-relevant ones allowlisted, so a new package in
@@ -24,6 +26,7 @@ permissions:
 
 env:
   IMAGE_NAME: ghcr.io/yerzhansa/cycling-coach
+  ALIAS_IMAGE_NAME: ghcr.io/yerzhansa/enduragent
 
 jobs:
   image:
@@ -63,6 +66,11 @@ jobs:
             echo "${IMAGE_NAME}:main-${short_sha}"
             if [[ -n "$version" ]]; then
               echo "${IMAGE_NAME}:${version}"
+            fi
+            echo "${ALIAS_IMAGE_NAME}:stable"
+            echo "${ALIAS_IMAGE_NAME}:main-${short_sha}"
+            if [[ -n "$version" ]]; then
+              echo "${ALIAS_IMAGE_NAME}:${version}"
             fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,3 +236,33 @@ jobs:
             gh release create "$TAG" --title "$TAG" --notes "$BODY"
             echo "::notice::Created GitHub Release $TAG"
           fi
+
+      - name: Publish enduragent alias to npm via OIDC
+        run: |
+          set -euo pipefail
+          PACKAGE="${{ needs.parse-tag.outputs.package }}"
+          if [ "$PACKAGE" != "cycling-coach" ]; then
+            echo "::notice::No enduragent alias for $PACKAGE — skipping"
+            exit 0
+          fi
+          VERSION="${{ needs.parse-tag.outputs.version }}"
+          PACK_DIR="/tmp/publish-pack-$PACKAGE"
+          TARBALL=$(find "$PACK_DIR" -maxdepth 1 -name '*.tgz' -print -quit)
+          ALIAS_DIR="/tmp/publish-pack-enduragent"
+          rm -rf "$ALIAS_DIR"
+          mkdir -p "$ALIAS_DIR/extract"
+          tar -xzf "$TARBALL" -C "$ALIAS_DIR/extract"
+          node -e 'const fs=require("fs");const p=process.argv[1];const pkg=JSON.parse(fs.readFileSync(p,"utf8"));pkg.name="enduragent";pkg.bin={enduragent:"dist/index.js"};fs.writeFileSync(p,JSON.stringify(pkg,null,2)+"\n");' "$ALIAS_DIR/extract/package/package.json"
+          ALIAS_TARBALL="$ALIAS_DIR/enduragent-$VERSION.tgz"
+          COPYFILE_DISABLE=1 tar -czf "$ALIAS_TARBALL" -C "$ALIAS_DIR/extract" package
+          pnpm check:published-package -- "$ALIAS_TARBALL"
+          EXPECTED_REPO=$(node -p "require('./packages/$PACKAGE/package.json').repository.url")
+          PUBLISHED_REPO=$(npm view "enduragent@$VERSION" repository.url 2>/dev/null || true)
+          if [ -z "$PUBLISHED_REPO" ]; then
+            npm publish "$ALIAS_TARBALL" --access public
+          elif [ "$PUBLISHED_REPO" = "$EXPECTED_REPO" ]; then
+            echo "::notice::enduragent@$VERSION already published from $EXPECTED_REPO — skipping publish"
+          else
+            echo "::error::enduragent@$VERSION exists on npm but was published from $PUBLISHED_REPO (expected $EXPECTED_REPO)"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

The release pipeline now dual-publishes under the `enduragent` name, with the existing `cycling-coach` artifacts fully untouched.

- **npm**: after the primary publish and GitHub Release steps, `release.yml` derives an `enduragent` tarball from the already-verified primary tarball (package.json `name` → `enduragent`, `bin` → `{"enduragent": "dist/index.js"}`; every other byte identical), re-runs the `check:published-package` legal/hygiene gate on it, and publishes via OIDC (the `enduragent` trusted publisher is configured for this repo + workflow). The step is last in the job so an alias failure can never leave the primary release half-done.
- **Idempotency with squatter detection**: before publishing, the step checks `npm view enduragent@<version> repository.url` — publishes when absent, skips when it matches this repo, and fails loudly if the version exists but was published from elsewhere.
- **GHCR**: `publish-image.yml` pushes every image additionally as `ghcr.io/yerzhansa/enduragent` (`stable`, `main-<sha>`, and the release version tag), same build, same labels. `IMAGE_NAME` and all `ghcr.io/yerzhansa/cycling-coach` tags unchanged.
- Changeset (patch) with a User-facing line announcing the new install name.

Nothing under `packages/` changed: the `cycling-coach` npm package, bin, Dockerfile, tag namespace (`cycling-coach@*`), and triggers are all untouched. The first real `enduragent` version publishes with the next release; until then npm serves the 0.0.0 placeholder.

## Test plan

- Local end-to-end proof of the tarball rewrite: built the workspace closure, packed the primary tarball, ran the exact step commands from `release.yml` against it — `check:published-package` passes on the variant, `npm publish --dry-run` accepts it, and `diff -r` of both extracted tarballs shows `package.json` as the only differing file with deltas limited to `name` and `bin`.
- `pnpm check` green (all static gates including the changeset gate).
- Both workflow files parse (yaml.safe_load) with the expected step order: Verify tag version → Pack/verify/publish → Create GitHub Release → Publish enduragent alias.

## Post-merge operator steps

1. The first image push creates `ghcr.io/yerzhansa/enduragent` **private by default** — flip it to Public in GitHub Packages before repointing the Railway template.
2. Repoint the Railway template image to `ghcr.io/yerzhansa/enduragent:stable` when renaming the listing.
