### PR TITLE
docs: point Railway template references at the enduragent image

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ Deploy: https://railway.com/deploy/cycling-coach
 
 Railway hosts the container and volume in your Railway account. The bot reads your Railway variables, talks to Telegram, intervals.icu, and your chosen LLM provider from inside your Railway project. We do not host a shared backend, store your secrets, store your athlete data, or receive your Telegram messages. Your hosting and billing relationship is with Railway. Railway currently lists Hobby as the practical minimum for always-on apps: $5 minimum usage/month, including $5 monthly usage credits.
 
-The template uses `ghcr.io/yerzhansa/cycling-coach:stable`, mounts persistent state at `/data`, and has image auto-updates enabled.
+The template uses `ghcr.io/yerzhansa/enduragent:stable`, mounts persistent state at `/data`, and has image auto-updates enabled.
 
 Before you click **Deploy**, prepare three accounts: one LLM provider account, intervals.icu, and Telegram.
 

--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -58,7 +58,7 @@ Want the bot running 24/7 without keeping your computer on? Use the Railway temp
 
 https://railway.com/deploy/cycling-coach
 
-Railway deploys your own private container from `ghcr.io/yerzhansa/cycling-coach:stable` with persistent `/data` storage and image auto-updates. The bot runs inside your Railway project and uses your Railway variables to call Telegram, intervals.icu, and your chosen LLM provider. We do not run a shared backend or store your secrets, athlete data, or Telegram messages. Your hosting and billing relationship is with Railway. Railway currently lists Hobby as the practical minimum for always-on apps: $5 minimum usage/month, including $5 monthly usage credits.
+Railway deploys your own private container from `ghcr.io/yerzhansa/enduragent:stable` with persistent `/data` storage and image auto-updates. The bot runs inside your Railway project and uses your Railway variables to call Telegram, intervals.icu, and your chosen LLM provider. We do not run a shared backend or store your secrets, athlete data, or Telegram messages. Your hosting and billing relationship is with Railway. Railway currently lists Hobby as the practical minimum for always-on apps: $5 minimum usage/month, including $5 monthly usage credits.
 
 Before you click **Deploy**, prepare three accounts: one LLM provider account, intervals.icu, and Telegram.
 


### PR DESCRIPTION
## Summary

The Railway template's image was repointed to `ghcr.io/yerzhansa/enduragent:stable` in the Railway dashboard (template listing keeps its Cycling Coach naming and slug). This updates the two README lines that describe the template's image so they match the live template. The manual `docker pull` instructions keep the original image name — both names publish the identical digest every release.

## Test plan

Docs-only change; both image paths verified live and digest-identical.