### PR TITLE
feat(desktop): claude-cli desktop lane with status controller and onboarding

### DIFF
--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -182,6 +182,8 @@ export function bootRenderer(): Disposer {
     applyLlmSelection: (value) => window.enduragentAuth.applyLlmSelection(value),
     chatGptStatus: () => window.enduragentAuth.chatgptStatus(),
     chatGptLogin: (value) => window.enduragentAuth.chatgptLogin(value),
+    claudeCliStatus: () => window.enduragentAuth.claudeCliStatus(),
+    claudeCliRecheck: () => window.enduragentAuth.claudeCliRecheck(),
     chooseImportFiles: () => window.enduragentAuth.chooseImportFiles(),
     onDroppedImportFiles: (listener) => window.enduragentAuth.onDroppedImportFiles(listener),
     async importFiles(paths, onProgress) {
@@ -276,6 +278,7 @@ export function bootRenderer(): Disposer {
     clients,
     loadStatuses: () => window.enduragentAuth.credentialStatuses(),
     loadChatGptStatus: () => window.enduragentAuth.chatgptStatus(),
+    loadClaudeCliStatus: () => window.enduragentAuth.claudeCliStatus(),
     deleteCredential: (value) => window.enduragentAuth.deleteCredential(value),
     openSetup: openSetupFromSettings,
     beginMutation: () => store.getState().beginSettingsMutation("credential"),

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -28,6 +28,8 @@ interface EnduragentAuth {
   applyLlmSelection(input: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
   chatgptStatus(): Promise<ChatGptStatus>;
   chatgptLogin(input: OnboardingLlmSelection): Promise<ChatGptLoginResult>;
+  claudeCliStatus(): Promise<ClaudeCliStatus>;
+  claudeCliRecheck(): Promise<ClaudeCliStatus>;
   chooseImportFiles(): Promise<readonly string[]>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
   releaseNotes(): Promise<ReleaseNotesResult>;
@@ -163,6 +165,21 @@ interface CredentialSlotStatus {
 interface ChatGptStatus {
   readonly state: "configured" | "absent";
   readonly runtimeReady: boolean;
+}
+
+type ClaudeCliState =
+  | "absent-binary"
+  | "not-logged-in"
+  | "api-key-token"
+  | "ready"
+  | "ready-api-key"
+  | "disabled";
+
+interface ClaudeCliStatus {
+  readonly state: ClaudeCliState;
+  readonly email?: string;
+  readonly plan?: string;
+  readonly version?: string;
 }
 
 type ChatGptLoginResult =

--- a/apps/desktop-renderer/src/onboarding/bridge.ts
+++ b/apps/desktop-renderer/src/onboarding/bridge.ts
@@ -9,7 +9,12 @@ import {
   type SaveIntakeRpcParams,
 } from "@enduragent/coach-contract";
 import { SUPPORTED_IMPORT_EXTENSIONS, type DesktopCredentialSlot } from "./constants.js";
-import type { ChatGptLoginResult, ChatGptStatus, CredentialSlotStatus } from "./machine.js";
+import type {
+  ChatGptLoginResult,
+  ChatGptStatus,
+  ClaudeCliStatus,
+  CredentialSlotStatus,
+} from "./machine.js";
 
 export type CredentialWriteResult =
   | {
@@ -102,6 +107,8 @@ export interface OnboardingBridge {
   applyLlmSelection(input: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
   chatGptStatus(): Promise<ChatGptStatus>;
   chatGptLogin(input: OnboardingLlmSelection): Promise<ChatGptLoginResult>;
+  claudeCliStatus(): Promise<ClaudeCliStatus>;
+  claudeCliRecheck(): Promise<ClaudeCliStatus>;
   chooseImportFiles(): Promise<readonly string[]>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
   importFiles(
@@ -123,6 +130,8 @@ export interface DesktopOnboardingAuth {
   applyLlmSelection(input: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
   chatgptStatus(): Promise<ChatGptStatus>;
   chatgptLogin(input: OnboardingLlmSelection): Promise<ChatGptLoginResult>;
+  claudeCliStatus(): Promise<ClaudeCliStatus>;
+  claudeCliRecheck(): Promise<ClaudeCliStatus>;
   chooseImportFiles(): Promise<readonly string[]>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
 }
@@ -194,6 +203,8 @@ export function createOnboardingBridge(
     applyLlmSelection: (input) => auth.applyLlmSelection(input),
     chatGptStatus: () => auth.chatgptStatus(),
     chatGptLogin: (input) => auth.chatgptLogin(input),
+    claudeCliStatus: () => auth.claudeCliStatus(),
+    claudeCliRecheck: () => auth.claudeCliRecheck(),
     chooseImportFiles: () => auth.chooseImportFiles(),
     onDroppedImportFiles: (listener) => auth.onDroppedImportFiles(listener),
     async importFiles(paths, onProgress) {

--- a/apps/desktop-renderer/src/onboarding/constants.ts
+++ b/apps/desktop-renderer/src/onboarding/constants.ts
@@ -67,6 +67,17 @@ export const CHATGPT_LOGIN_REFUSAL_REASONS = [
 
 export type ChatGptLoginRefusalReason = (typeof CHATGPT_LOGIN_REFUSAL_REASONS)[number];
 
+export const CLAUDE_CLI_STATES = [
+  "absent-binary",
+  "not-logged-in",
+  "api-key-token",
+  "ready",
+  "ready-api-key",
+  "disabled",
+] as const;
+
+export type ClaudeCliState = (typeof CLAUDE_CLI_STATES)[number];
+
 export const SUPPORTED_IMPORT_EXTENSIONS = [".fit", ".tcx", ".gpx"] as const;
 
 export const INTERVALS_GUIDANCE =

--- a/apps/desktop-renderer/src/onboarding/controller.ts
+++ b/apps/desktop-renderer/src/onboarding/controller.ts
@@ -24,6 +24,7 @@ import {
   withChatGptLoginResult,
   withChatGptPending,
   withChatGptStatus,
+  withClaudeCliStatus,
   withCredentialStatuses,
   withError,
   withImportedRideFileCount,
@@ -62,6 +63,7 @@ export interface OnboardingActions {
   dismiss(): void;
   retrySavedKeys(): void;
   startChatGptLogin(): void;
+  recheckClaudeCli(): void;
   chooseImportFiles(): void;
   selectProvider(provider: string): void;
   selectModel(model: string): void;
@@ -190,7 +192,9 @@ export function createOnboardingController(
     if (provider === "openai-codex") {
       return state.chatGptState === "configured" && state.chatGptRuntimeReady;
     }
-    if (provider === "claude-cli") return false;
+    if (provider === "claude-cli") {
+      return state.claudeCliState === "ready" || state.claudeCliState === "ready-api-key";
+    }
     return status(provider).state === "configured" && status(provider).runtimeState === "active";
   };
 
@@ -201,6 +205,17 @@ export function createOnboardingController(
     setRideImportPresentation(false);
     publish();
     options.focusOpener();
+  };
+
+  const loadClaudeCliStatus = (expectedVisit: number): void => {
+    void options.bridge.claudeCliStatus().then(
+      (status) => {
+        if (disposed || visit !== expectedVisit || !presenting) return;
+        state = withClaudeCliStatus(state, status);
+        publish();
+      },
+      () => undefined,
+    );
   };
 
   const refreshStatuses = async (expectedVisit: number): Promise<boolean> => {
@@ -481,6 +496,7 @@ export function createOnboardingController(
       focusTitle();
       publish();
       opening = false;
+      loadClaudeCliStatus(openVisit);
     },
     close,
     dispose(): void {
@@ -590,6 +606,24 @@ export function createOnboardingController(
             reason: "exchange-failed",
           });
           focusTitle();
+          publish();
+        },
+      );
+    },
+    recheckClaudeCli(): void {
+      if (disposed || !presenting || state.busy) return;
+      const recheckVisit = visit;
+      state = withBusy(state, true);
+      publish();
+      void options.bridge.claudeCliRecheck().then(
+        (status) => {
+          if (disposed || visit !== recheckVisit || !presenting) return;
+          state = withBusy(withClaudeCliStatus(state, status), false);
+          publish();
+        },
+        () => {
+          if (disposed || visit !== recheckVisit || !presenting) return;
+          state = withBusy(state, false);
           publish();
         },
       );

--- a/apps/desktop-renderer/src/onboarding/credential-presentation.ts
+++ b/apps/desktop-renderer/src/onboarding/credential-presentation.ts
@@ -1,4 +1,63 @@
-import type { CredentialSlotStatus } from "./machine.js";
+import type { ClaudeCliState } from "./constants.js";
+import type { ClaudeCliStatus, CredentialSlotStatus } from "./machine.js";
+
+export const CLAUDE_CLI_API_KEY_IDENTITY =
+  "Using Anthropic API key billing - usage is charged to your API account.";
+
+export interface ClaudeCliPresentation {
+  readonly runtimeState: "active" | "stored-inactive" | "failed";
+  readonly badge: string;
+  readonly detail: string | null;
+}
+
+const CLAUDE_CLI_PRESENTATION: Readonly<Record<ClaudeCliState, ClaudeCliPresentation>> = {
+  ready: { runtimeState: "active", badge: "Signed in", detail: null },
+  "ready-api-key": { runtimeState: "active", badge: "API key billing", detail: null },
+  "absent-binary": {
+    runtimeState: "failed",
+    badge: "Not installed",
+    detail:
+      "Claude Code CLI was not found, or the installed version is too old. Install or update it, then choose Check again.",
+  },
+  "not-logged-in": {
+    runtimeState: "failed",
+    badge: "Not signed in",
+    detail:
+      "Claude Code CLI is not signed in. Open a terminal, run claude, and sign in with your Claude subscription. Enduragent never signs in for you.",
+  },
+  "api-key-token": {
+    runtimeState: "failed",
+    badge: "API key, not a subscription",
+    detail:
+      "Claude Code CLI is authenticated with an API key or token, not a subscription. Sign in with your subscription in claude, or opt in to API key billing in your configuration.",
+  },
+  disabled: {
+    runtimeState: "stored-inactive",
+    badge: "Turned off",
+    detail: "The Claude subscription lane is turned off on this Mac. Choose another provider.",
+  },
+};
+
+const CLAUDE_CLI_UNKNOWN_PRESENTATION: ClaudeCliPresentation = {
+  runtimeState: "stored-inactive",
+  badge: "Checking",
+  detail: "Checking the Claude Code CLI sign-in on this Mac…",
+};
+
+export function claudeCliPresentation(state: ClaudeCliState | null): ClaudeCliPresentation {
+  return state === null ? CLAUDE_CLI_UNKNOWN_PRESENTATION : CLAUDE_CLI_PRESENTATION[state];
+}
+
+export function claudeCliIdentityLine(status: ClaudeCliStatus): string | null {
+  if (status.state === "ready-api-key") return CLAUDE_CLI_API_KEY_IDENTITY;
+  if (status.state !== "ready") return null;
+  const email = status.email?.trim() ?? "";
+  const plan = status.plan?.trim() ?? "";
+  if (plan.length === 0) return email.length === 0 ? "Signed in" : `Signed in as ${email}`;
+  return email.length === 0
+    ? `Signed in - Claude ${plan} subscription`
+    : `Signed in as ${email} - Claude ${plan} subscription`;
+}
 
 export interface CredentialPresentation {
   readonly className: string;

--- a/apps/desktop-renderer/src/onboarding/machine.ts
+++ b/apps/desktop-renderer/src/onboarding/machine.ts
@@ -2,10 +2,12 @@ import { SaveIntakeRpcParamsSchema, type SaveIntakeRpcParams } from "@enduragent
 import {
   DESKTOP_CREDENTIAL_SLOTS,
   ONBOARDING_STEP_IDS,
+  type ClaudeCliState,
   type DesktopCredentialSlot,
   type ChatGptLoginRefusalReason,
   type OnboardingStepId,
 } from "./constants.js";
+import { claudeCliIdentityLine } from "./credential-presentation.js";
 
 export type CredentialState = "missing" | "configured" | "re-prompt";
 export type CredentialRuntimeState = "active" | "stored-inactive" | "failed";
@@ -19,6 +21,13 @@ export interface CredentialSlotStatus {
 export interface ChatGptStatus {
   readonly state: "configured" | "absent";
   readonly runtimeReady: boolean;
+}
+
+export interface ClaudeCliStatus {
+  readonly state: ClaudeCliState;
+  readonly email?: string;
+  readonly plan?: string;
+  readonly version?: string;
 }
 
 export type ChatGptLoginResult =
@@ -56,6 +65,8 @@ export interface OnboardingState {
   readonly chatGptState: "absent" | "pending" | "configured" | "refused";
   readonly chatGptRuntimeReady: boolean;
   readonly chatGptRefusal: ChatGptLoginRefusalReason | null;
+  readonly claudeCliState: ClaudeCliState | null;
+  readonly claudeCliIdentity: string | null;
   readonly importedRideFileCount: number;
   readonly intake: DesktopIntakeDraft;
   readonly busy: boolean;
@@ -79,6 +90,7 @@ function statusRecord<T>(initial: T): Record<DesktopCredentialSlot, T> {
 export function createOnboardingState(
   statuses: readonly CredentialSlotStatus[] = [],
   chatGptStatus: ChatGptStatus = { state: "absent", runtimeReady: false },
+  claudeCliStatus: ClaudeCliStatus | null = null,
 ): OnboardingState {
   const credentialStatus = statusRecord<CredentialState>("missing");
   for (const status of statuses) {
@@ -90,6 +102,8 @@ export function createOnboardingState(
     chatGptState: chatGptStatus.state,
     chatGptRuntimeReady: chatGptStatus.runtimeReady,
     chatGptRefusal: null,
+    claudeCliState: claudeCliStatus === null ? null : claudeCliStatus.state,
+    claudeCliIdentity: claudeCliStatus === null ? null : claudeCliIdentityLine(claudeCliStatus),
     importedRideFileCount: 0,
     intake: { priorBsi: null, injuryStatus: null, clinicianCleared: null },
     busy: false,
@@ -104,6 +118,21 @@ export function withChatGptStatus(state: OnboardingState, status: ChatGptStatus)
     chatGptRuntimeReady: status.runtimeReady,
     chatGptRefusal: null,
   };
+}
+
+export function withClaudeCliStatus(
+  state: OnboardingState,
+  status: ClaudeCliStatus | null,
+): OnboardingState {
+  return {
+    ...state,
+    claudeCliState: status === null ? null : status.state,
+    claudeCliIdentity: status === null ? null : claudeCliIdentityLine(status),
+  };
+}
+
+export function claudeCliReady(state: OnboardingState): boolean {
+  return state.claudeCliState === "ready" || state.claudeCliState === "ready-api-key";
 }
 
 export function withChatGptPending(state: OnboardingState): OnboardingState {
@@ -153,6 +182,7 @@ export function withCredentialStatuses(
 export function hasConfiguredModel(state: OnboardingState): boolean {
   return (
     state.chatGptState === "configured" ||
+    claudeCliReady(state) ||
     DESKTOP_CREDENTIAL_SLOTS.some(
       (slot) => slot !== "intervals-icu" && state.credentialStatus[slot] === "configured",
     )

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -2,7 +2,12 @@ import { CoachClientDisconnectedError, type CoachClient } from "@enduragent/coac
 import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
 import type { DesktopCoachClientProvider } from "../coach-client.js";
 import type { CredentialDeleteResult, DesktopCredentialId } from "../onboarding/bridge.js";
-import type { ChatGptStatus, CredentialSlotStatus } from "../onboarding/machine.js";
+import type { ClaudeCliState } from "../onboarding/constants.js";
+import {
+  claudeCliIdentityLine,
+  claudeCliPresentation,
+} from "../onboarding/credential-presentation.js";
+import type { ChatGptStatus, ClaudeCliStatus, CredentialSlotStatus } from "../onboarding/machine.js";
 
 export type CredentialKind = "Provider API key" | "ChatGPT profile" | "Training account key";
 
@@ -23,16 +28,19 @@ export interface ProviderStatusEntry {
   readonly provider: NonCredentialProviderId;
   readonly label: string;
   readonly kind: NonCredentialProviderKind;
+  readonly state: ClaudeCliState | null;
+  readonly identity: string | null;
 }
 
-const NON_CREDENTIAL_PROVIDER_ROWS: Readonly<Record<NonCredentialProviderId, ProviderStatusEntry>> =
-  {
-    "claude-cli": {
-      provider: "claude-cli",
-      label: "Claude subscription",
-      kind: "Claude Code CLI",
-    },
-  };
+const NON_CREDENTIAL_PROVIDER_ROWS: Readonly<
+  Record<NonCredentialProviderId, Pick<ProviderStatusEntry, "provider" | "label" | "kind">>
+> = {
+  "claude-cli": {
+    provider: "claude-cli",
+    label: "Claude subscription",
+    kind: "Claude Code CLI",
+  },
+};
 
 function isNonCredentialProvider(provider: string): provider is NonCredentialProviderId {
   return (NON_CREDENTIAL_PROVIDERS as readonly string[]).includes(provider);
@@ -184,9 +192,19 @@ function entriesFrom(
 
 export function providerStatusesFrom(
   runtime: RuntimeConfigSnapshot,
+  claudeCli: ClaudeCliStatus | null = null,
 ): readonly ProviderStatusEntry[] {
   const provider = runtime.llm.provider;
-  return isNonCredentialProvider(provider) ? [NON_CREDENTIAL_PROVIDER_ROWS[provider]] : [];
+  if (!isNonCredentialProvider(provider)) return [];
+  const state = claudeCli?.state ?? null;
+  const identity = claudeCli === null ? null : claudeCliIdentityLine(claudeCli);
+  return [
+    {
+      ...NON_CREDENTIAL_PROVIDER_ROWS[provider],
+      state,
+      identity: identity ?? claudeCliPresentation(state).detail,
+    },
+  ];
 }
 
 function refusalCopy(
@@ -211,6 +229,7 @@ export function createCredentialSettingsController(input: {
   readonly clients: DesktopCoachClientProvider;
   readonly loadStatuses: () => Promise<readonly CredentialSlotStatus[]>;
   readonly loadChatGptStatus: () => Promise<ChatGptStatus>;
+  readonly loadClaudeCliStatus?: () => Promise<ClaudeCliStatus>;
   readonly deleteCredential: (input: {
     readonly credential: DesktopCredentialId;
   }) => Promise<CredentialDeleteResult>;
@@ -253,9 +272,14 @@ export function createCredentialSettingsController(input: {
         input.loadChatGptStatus(),
         client.call("getRuntimeConfig", {}),
       ]);
+      const loadClaudeCli = input.loadClaudeCliStatus;
+      const claudeCli =
+        loadClaudeCli === undefined || !isNonCredentialProvider(runtime.llm.provider)
+          ? null
+          : await loadClaudeCli().catch(() => null);
       return {
         entries: entriesFrom(statuses, chatGpt, runtime),
-        providerStatuses: providerStatusesFrom(runtime),
+        providerStatuses: providerStatusesFrom(runtime, claudeCli),
       };
     } catch (error) {
       if (error instanceof CoachClientDisconnectedError) {

--- a/apps/desktop-renderer/src/state/adapters/spend.ts
+++ b/apps/desktop-renderer/src/state/adapters/spend.ts
@@ -1,4 +1,4 @@
-import type { SpendSummary } from "@enduragent/coach-contract";
+import type { SpendRouteSummary, SpendSummary } from "@enduragent/coach-contract";
 import type { SpendMeterView } from "../../spend-meter/controller.js";
 import type { SpendSettingsPort, SpendSurfaceState } from "../settings-slice.js";
 
@@ -13,6 +13,21 @@ export function currency(value: number, detail = false): string {
 function capWarningCopy(summary: SpendSummary): string | null {
   if (summary.capStatus !== "reached") return null;
   return `${SPEND_CAP_REACHED_PREFIX}${currency(summary.dailyCapUsd)} spend cap. You can keep chatting; this is a warning, not a block.`;
+}
+
+export function notionalSpendCopy(summary: SpendSummary): string | null {
+  const notional = summary.notionalSpendUsd ?? 0;
+  if (notional <= 0) return null;
+  return `Subscription usage would have cost ${currency(notional, true)} on the API. No money moved, and it does not count toward your cap.`;
+}
+
+export function routeSpendCopy(route: SpendRouteSummary): string {
+  const notional = route.notionalSpendUsd ?? 0;
+  const parts: string[] = [];
+  if (notional === 0 || route.knownSpendUsd > 0) parts.push(currency(route.knownSpendUsd, true));
+  if (notional > 0) parts.push(`would have cost ${currency(notional, true)} on the API`);
+  parts.push(`${route.pricedGenerationCount}/${route.generationCount} generations priced`);
+  return parts.join(" · ");
 }
 
 export interface SpendSettingsAdapter {

--- a/apps/desktop-renderer/src/ui/onboarding/CoachKeysStep.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/CoachKeysStep.tsx
@@ -8,7 +8,8 @@ import {
   type OnboardingActions,
   type OnboardingSurfaceState,
 } from "../../onboarding/controller.js";
-import { CHATGPT_REFUSAL_COPY } from "./copy.js";
+import { claudeCliPresentation } from "../../onboarding/credential-presentation.js";
+import { CHATGPT_REFUSAL_COPY, CLAUDE_CLI_LANE_COPY, CLAUDE_CLI_RECHECK_LABEL } from "./copy.js";
 import { CredentialField } from "./CredentialField.js";
 import { LlmSelectionPanel } from "./LlmSelectionPanel.js";
 import styles from "./OnboardingWizard.module.css";
@@ -76,12 +77,60 @@ function ChatGptLane(props: {
   );
 }
 
+function ClaudeCliLane(props: {
+  readonly surface: OnboardingSurfaceState;
+  readonly actions: OnboardingActions | null;
+  readonly disabled: boolean;
+}): ReactElement {
+  const wizard = props.surface.wizard;
+  const presentation = claudeCliPresentation(wizard.claudeCliState);
+  const badgeState = presentation.runtimeState === "active" ? "configured" : "stored-inactive";
+
+  return (
+    <section className={styles.lane}>
+      <div className={`${styles.laneHeading} claude-cli-lane-heading`}>
+        <strong>Claude subscription</strong>
+        <span
+          className={`${styles.badge} claude-cli-state`}
+          data-state={presentation.runtimeState === "failed" ? "failed" : badgeState}
+        >
+          {presentation.badge}
+        </span>
+      </div>
+      <p className={styles.laneCopy}>{CLAUDE_CLI_LANE_COPY}</p>
+      {wizard.claudeCliIdentity === null ? null : (
+        <p className={styles.laneReady} data-claude-cli-identity="">
+          {wizard.claudeCliIdentity}
+        </p>
+      )}
+      {presentation.detail === null ? null : (
+        <p className={styles.laneRefused} aria-live="polite">
+          {presentation.detail}
+        </p>
+      )}
+      <button
+        type="button"
+        className={`${styles.primaryButton} ${styles.laneButton}`}
+        disabled={props.disabled}
+        onClick={() => {
+          props.actions?.recheckClaudeCli();
+        }}
+      >
+        {CLAUDE_CLI_RECHECK_LABEL}
+      </button>
+    </section>
+  );
+}
+
 export function CoachKeysStep(props: {
   readonly surface: OnboardingSurfaceState;
   readonly actions: OnboardingActions | null;
   readonly disabled: boolean;
 }): ReactElement {
   const surface = props.surface;
+  const claudeCliOffered =
+    surface.configuration?.providers.some((provider) => provider.provider === "claude-cli") ??
+    false;
 
   return (
     <>
@@ -95,6 +144,9 @@ export function CoachKeysStep(props: {
       </p>
       <LlmSelectionPanel surface={surface} actions={props.actions} />
       <ChatGptLane surface={surface} actions={props.actions} disabled={props.disabled} />
+      {claudeCliOffered ? (
+        <ClaudeCliLane surface={surface} actions={props.actions} disabled={props.disabled} />
+      ) : null}
       <div className={styles.divider}>or use an API key</div>
       <div className={styles.credentials}>
         {PRIMARY_MODEL_CREDENTIAL_SLOTS.map((provider) => (

--- a/apps/desktop-renderer/src/ui/onboarding/copy.ts
+++ b/apps/desktop-renderer/src/ui/onboarding/copy.ts
@@ -28,6 +28,11 @@ export const ERROR_COPY: Readonly<Record<OnboardingErrorCode, string>> = {
   "intake-save-failed": "Your answers could not be saved. Please try again.",
 };
 
+export const CLAUDE_CLI_LANE_COPY =
+  "Uses the Claude Code CLI already installed and signed in on this Mac. No API key needed.";
+
+export const CLAUDE_CLI_RECHECK_LABEL = "Check again";
+
 export const CHATGPT_REFUSAL_COPY: Readonly<Record<ChatGptLoginRefusalReason, string>> = {
   "already-in-progress": "A ChatGPT sign-in is already in progress.",
   "callback-unavailable":

--- a/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, type ReactElement } from "react";
 import type { DesktopCredentialId } from "../../onboarding/bridge.js";
+import { claudeCliPresentation } from "../../onboarding/credential-presentation.js";
 import type { CredentialSettingsState } from "../../settings/credential-controller.js";
 import { settingsMutationActive } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
@@ -38,6 +39,7 @@ export function CredentialsSection(): ReactElement {
   }, [state]);
 
   const entries = content(state)?.entries ?? [];
+  const providerStatuses = content(state)?.providerStatuses ?? [];
   const confirmation = content(state)?.confirmation ?? null;
   const deleting = state.status === "deleting";
   const loading = state.status === "closed" || state.status === "loading";
@@ -134,6 +136,29 @@ export function CredentialsSection(): ReactElement {
                 )}
               </li>
             ))}
+          </ul>
+        )}
+        {providerStatuses.length === 0 ? null : (
+          <ul className={styles.list} aria-label="Keyless providers">
+            {providerStatuses.map((entry) => {
+              const presentation = claudeCliPresentation(entry.state);
+              return (
+                <li key={entry.provider} className={styles.item} data-provider={entry.provider}>
+                  <div className={styles.itemIdentity}>
+                    <div className={styles.rowTitle}>{entry.label}</div>
+                    <div className={styles.itemKind}>{entry.kind}</div>
+                    {entry.identity === null ? null : (
+                      <div className={styles.itemKind} data-provider-identity="">
+                        {entry.identity}
+                      </div>
+                    )}
+                  </div>
+                  <span className={styles.runtime} data-state={presentation.runtimeState}>
+                    {presentation.badge}
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         )}
         {announcement.length === 0 ? null : (

--- a/apps/desktop-renderer/src/ui/settings/SpendSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/SpendSection.tsx
@@ -1,6 +1,6 @@
 import type { SpendRouteSummary, SpendSummary } from "@enduragent/coach-contract";
 import type { ReactElement } from "react";
-import { currency } from "../../state/adapters/spend.js";
+import { currency, notionalSpendCopy, routeSpendCopy } from "../../state/adapters/spend.js";
 import { useEnduragentStore } from "../../state/store.js";
 import styles from "./SettingsView.module.css";
 
@@ -35,6 +35,8 @@ function notices(summary: SpendSummary, stale: boolean): readonly string[] {
     messages.push("Some provider costs are unavailable, so today’s total is a known minimum.");
   }
   if (summary.malformedLineCount > 0) messages.push("Some usage records could not be read.");
+  const notional = notionalSpendCopy(summary);
+  if (notional !== null) messages.push(notional);
   messages.push(
     `${summary.cacheSavingsComplete ? "Saved" : "Saved at least"} ${currency(summary.knownCacheReadSavingsUsd, true)} with cache reads`,
   );
@@ -95,9 +97,7 @@ export function SpendSection(): ReactElement {
             {summary.routes.map((route) => (
               <article key={`${route.provider}/${route.model}`} className={styles.route}>
                 <p className={styles.routeHeading}>{`${route.provider} · ${route.model}`}</p>
-                <p className={styles.routeDetail}>
-                  {`${currency(route.knownSpendUsd, true)} · ${route.pricedGenerationCount}/${route.generationCount} generations priced`}
-                </p>
+                <p className={styles.routeDetail}>{routeSpendCopy(route)}</p>
                 <p className={styles.routeDetail}>{routeCache(route)}</p>
                 <p className={styles.routeDetail}>{routeCaching(route)}</p>
               </article>

--- a/apps/desktop-renderer/tests/credential-presentation.test.ts
+++ b/apps/desktop-renderer/tests/credential-presentation.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { credentialPresentation } from "../src/onboarding/credential-presentation.js";
+import { CLAUDE_CLI_STATES } from "../src/onboarding/constants.js";
+import {
+  claudeCliIdentityLine,
+  claudeCliPresentation,
+  credentialPresentation,
+} from "../src/onboarding/credential-presentation.js";
 import type { CredentialSlotStatus } from "../src/onboarding/machine.js";
 
 describe("credential status presentation", () => {
@@ -38,5 +43,52 @@ describe("credential status presentation", () => {
     expect(presentation.copy).toBe("Saved · Not in use");
     expect(presentation.retryable).toBe(false);
     expect(presentation.copy).not.toMatch(/error|failed|retry/iu);
+  });
+});
+
+describe("claude subscription status presentation", () => {
+  it("renders the signed-in identity with the plan, and never an undefined plan", () => {
+    expect(
+      claudeCliIdentityLine({ state: "ready", email: "athlete@example.test", plan: "Max" }),
+    ).toBe("Signed in as athlete@example.test - Claude Max subscription");
+    expect(claudeCliIdentityLine({ state: "ready", email: "athlete@example.test" })).toBe(
+      "Signed in as athlete@example.test",
+    );
+    expect(claudeCliIdentityLine({ state: "ready", plan: "Pro" })).toBe(
+      "Signed in - Claude Pro subscription",
+    );
+    expect(claudeCliIdentityLine({ state: "ready" })).toBe("Signed in");
+    expect(claudeCliIdentityLine({ state: "ready", email: "  ", plan: "  " })).toBe("Signed in");
+  });
+
+  it("names api-key billing instead of claiming a subscription", () => {
+    expect(claudeCliIdentityLine({ state: "ready-api-key", email: "athlete@example.test" })).toBe(
+      "Using Anthropic API key billing - usage is charged to your API account.",
+    );
+  });
+
+  it("withholds an identity for every unready state", () => {
+    for (const state of CLAUDE_CLI_STATES) {
+      if (state === "ready" || state === "ready-api-key") continue;
+      expect(claudeCliIdentityLine({ state, email: "athlete@example.test", plan: "Max" })).toBeNull();
+    }
+  });
+
+  it("gives every state a badge, and a detail only when the lane cannot coach", () => {
+    for (const state of CLAUDE_CLI_STATES) {
+      const presentation = claudeCliPresentation(state);
+      expect(presentation.badge.length).toBeGreaterThan(0);
+      if (state === "ready" || state === "ready-api-key") {
+        expect(presentation.runtimeState).toBe("active");
+        expect(presentation.detail).toBeNull();
+      } else {
+        expect(presentation.runtimeState).not.toBe("active");
+        expect(presentation.detail).not.toBeNull();
+      }
+    }
+    expect(claudeCliPresentation("disabled").runtimeState).toBe("stored-inactive");
+    expect(claudeCliPresentation(null).detail).toBe(
+      "Checking the Claude Code CLI sign-in on this Mac…",
+    );
   });
 });

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
 import type { DesktopCoachClientProvider } from "../src/coach-client.js";
 import type { CredentialDeleteResult, DesktopCredentialId } from "../src/onboarding/bridge.js";
-import type { ChatGptStatus, CredentialSlotStatus } from "../src/onboarding/machine.js";
+import type {
+  ChatGptStatus,
+  ClaudeCliStatus,
+  CredentialSlotStatus,
+} from "../src/onboarding/machine.js";
 import {
   createCredentialSettingsController,
   type CredentialSettingsState,
@@ -74,6 +78,7 @@ function createSubject(input: {
   readonly chatGpt?: ChatGptStatus;
   readonly deletion?: CredentialDeleteResult;
   readonly openSetup?: () => void;
+  readonly claudeCli?: () => Promise<ClaudeCliStatus>;
 }) {
   let activeRuntime = input.runtime ?? runtime();
   let statuses =
@@ -114,6 +119,7 @@ function createSubject(input: {
     clients,
     loadStatuses: async () => statuses,
     loadChatGptStatus: async () => chatGpt,
+    ...(input.claudeCli === undefined ? {} : { loadClaudeCliStatus: input.claudeCli }),
     deleteCredential,
     openSetup: input.openSetup ?? vi.fn(),
     beginMutation: () => vi.fn(),
@@ -183,24 +189,78 @@ describe("credential settings controller", () => {
       }),
       statuses: [],
       chatGpt: { state: "absent", runtimeReady: false },
+      claudeCli: async () => ({ state: "ready", email: "athlete@example.test", plan: "Max" }),
     });
 
     await controller.activate();
 
     expect(content(controller.state()).providerStatuses).toEqual([
-      { provider: "claude-cli", label: "Claude subscription", kind: "Claude Code CLI" },
+      {
+        provider: "claude-cli",
+        label: "Claude subscription",
+        kind: "Claude Code CLI",
+        state: "ready",
+        identity: "Signed in as athlete@example.test - Claude Max subscription",
+      },
     ]);
-    expect(
-      content(controller.state()).entries.map((entry) => entry.credential),
-    ).not.toContain("claude-cli");
+    expect(content(controller.state()).entries.map((entry) => entry.credential)).not.toContain(
+      "claude-cli",
+    );
   });
 
-  it("emits no status rows for credential-backed providers", async () => {
-    const { controller } = createSubject({});
+  it("shows api-key billing on the status row instead of a subscription claim", async () => {
+    const { controller } = createSubject({
+      runtime: runtime({ provider: "claude-cli", model: "sonnet", credential_configured: false }),
+      statuses: [],
+      chatGpt: { state: "absent", runtimeReady: false },
+      claudeCli: async () => ({ state: "ready-api-key" }),
+    });
+
+    await controller.activate();
+
+    expect(content(controller.state()).providerStatuses[0]?.identity).toBe(
+      "Using Anthropic API key billing - usage is charged to your API account.",
+    );
+  });
+
+  it("explains a turned-off lane and a failed probe without inventing an identity", async () => {
+    const disabled = createSubject({
+      runtime: runtime({ provider: "claude-cli", model: "sonnet", credential_configured: false }),
+      statuses: [],
+      chatGpt: { state: "absent", runtimeReady: false },
+      claudeCli: async () => ({ state: "disabled" }),
+    });
+    await disabled.controller.activate();
+    expect(content(disabled.controller.state()).providerStatuses[0]).toEqual({
+      provider: "claude-cli",
+      label: "Claude subscription",
+      kind: "Claude Code CLI",
+      state: "disabled",
+      identity: "The Claude subscription lane is turned off on this Mac. Choose another provider.",
+    });
+
+    const unavailable = createSubject({
+      runtime: runtime({ provider: "claude-cli", model: "sonnet", credential_configured: false }),
+      statuses: [],
+      chatGpt: { state: "absent", runtimeReady: false },
+      claudeCli: async () => {
+        throw new Error("probe unavailable");
+      },
+    });
+    await unavailable.controller.activate();
+    const row = content(unavailable.controller.state()).providerStatuses[0];
+    expect(row?.state).toBeNull();
+    expect(row?.identity).toBe("Checking the Claude Code CLI sign-in on this Mac…");
+  });
+
+  it("emits no status rows and never probes for credential-backed providers", async () => {
+    const claudeCli = vi.fn(async () => ({ state: "ready" }) as ClaudeCliStatus);
+    const { controller } = createSubject({ claudeCli });
 
     await controller.activate();
 
     expect(content(controller.state()).providerStatuses).toEqual([]);
+    expect(claudeCli).not.toHaveBeenCalled();
   });
 
   it("confirmation-gates active deletion, announces the cutover, and exposes Setup recovery", async () => {

--- a/apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx
@@ -1,0 +1,279 @@
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OnboardingBridge, OnboardingLlmConfiguration } from "../src/onboarding/bridge.js";
+import type { ClaudeCliStatus } from "../src/onboarding/machine.js";
+import {
+  control,
+  credentialBadges,
+  mountWizard,
+  resetOnboardingStore,
+  testBridge,
+  type TestBridge,
+} from "./onboarding-harness.js";
+
+const CLAUDE_CLI_CONFIGURATION: OnboardingLlmConfiguration = {
+  schemaVersion: 1,
+  providers: [
+    {
+      provider: "anthropic",
+      defaultModel: "claude-sonnet-4-6",
+      models: [{ value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" }],
+    },
+    {
+      provider: "claude-cli",
+      defaultModel: "sonnet",
+      models: [{ value: "sonnet", label: "Claude Sonnet" }],
+    },
+  ],
+  active: null,
+};
+
+function claudeBridge(status: ClaudeCliStatus, overrides: Partial<OnboardingBridge> = {}) {
+  const bridge: TestBridge = testBridge(async () => ({
+    status: "refused",
+    reason: "cancelled",
+  }));
+  bridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+  bridge.llmConfiguration.mockResolvedValue(CLAUDE_CLI_CONFIGURATION);
+  bridge.claudeCliStatus.mockResolvedValue(status);
+  bridge.claudeCliRecheck.mockResolvedValue(status);
+  return Object.assign(bridge, overrides);
+}
+
+function laneBadge(): HTMLElement {
+  const badge = document.querySelector<HTMLElement>(".claude-cli-state");
+  if (badge === null) throw new Error("Claude subscription badge not found");
+  return badge;
+}
+
+function identityLine(): string | null {
+  return document.querySelector<HTMLElement>("[data-claude-cli-identity]")?.textContent ?? null;
+}
+
+async function openLane(bridge: TestBridge): Promise<ReturnType<typeof mountWizard>> {
+  const wizard = mountWizard({ bridge });
+  await wizard.open();
+  await waitFor(() => {
+    expect(bridge.claudeCliStatus).toHaveBeenCalled();
+    expect(laneBadge().textContent).not.toBe("Checking");
+  });
+  return wizard;
+}
+
+describe("claude-cli onboarding lane", () => {
+  afterEach(() => {
+    resetOnboardingStore();
+  });
+
+  it("opens the wizard before the account probe answers", async () => {
+    let settle: ((status: ClaudeCliStatus) => void) | undefined;
+    const bridge = claudeBridge({ state: "ready" });
+    bridge.claudeCliStatus.mockReturnValue(
+      new Promise<ClaudeCliStatus>((resolve) => {
+        settle = resolve;
+      }),
+    );
+    const wizard = mountWizard({ bridge });
+
+    await wizard.open();
+
+    expect(screen.getByRole("heading", { name: "Choose how your coach thinks" })).toBeDefined();
+    expect(laneBadge().textContent).toBe("Checking");
+    expect(identityLine()).toBeNull();
+    expect(document.body.textContent).toContain("Checking the Claude Code CLI sign-in on this Mac");
+
+    await act(async () => {
+      settle?.({ state: "ready", email: "athlete@example.test", plan: "Max" });
+    });
+
+    await waitFor(() => {
+      expect(identityLine()).toBe("Signed in as athlete@example.test - Claude Max subscription");
+    });
+    wizard.controller.dispose();
+  });
+
+  it("renders the signed-in identity with the plan and email from the probe", async () => {
+    const wizard = await openLane(
+      claudeBridge({
+        state: "ready",
+        email: "athlete@example.test",
+        plan: "Max",
+        version: "2.1.0",
+      }),
+    );
+
+    expect(identityLine()).toBe("Signed in as athlete@example.test - Claude Max subscription");
+    expect(laneBadge().textContent).toBe("Signed in");
+    expect(laneBadge().dataset.state).toBe("configured");
+    expect(document.body.textContent).not.toContain("undefined");
+    wizard.controller.dispose();
+  });
+
+  it("falls back to the email alone when the probe reports no plan", async () => {
+    const wizard = await openLane(claudeBridge({ state: "ready", email: "athlete@example.test" }));
+
+    expect(identityLine()).toBe("Signed in as athlete@example.test");
+    expect(document.body.textContent).not.toContain("Claude undefined subscription");
+    wizard.controller.dispose();
+  });
+
+  it("keeps the plan when the email is unavailable", async () => {
+    const wizard = await openLane(claudeBridge({ state: "ready", plan: "Pro" }));
+
+    expect(identityLine()).toBe("Signed in - Claude Pro subscription");
+    wizard.controller.dispose();
+  });
+
+  it("names API key billing instead of claiming a subscription", async () => {
+    const wizard = await openLane(claudeBridge({ state: "ready-api-key" }));
+
+    expect(identityLine()).toBe(
+      "Using Anthropic API key billing - usage is charged to your API account.",
+    );
+    expect(identityLine()).not.toContain("subscription");
+    expect(laneBadge().textContent).toBe("API key billing");
+    wizard.controller.dispose();
+  });
+
+  it("guides a signed-out athlete to sign in from their own terminal", async () => {
+    const wizard = await openLane(claudeBridge({ state: "not-logged-in" }));
+
+    expect(identityLine()).toBeNull();
+    expect(document.body.textContent).toContain(
+      "Claude Code CLI is not signed in. Open a terminal, run claude, and sign in with your Claude subscription. Enduragent never signs in for you.",
+    );
+    expect(laneBadge().dataset.state).toBe("failed");
+    wizard.controller.dispose();
+  });
+
+  it("reports a missing binary and an api-key token distinctly", async () => {
+    const absent = await openLane(claudeBridge({ state: "absent-binary" }));
+    expect(document.body.textContent).toContain("Claude Code CLI was not found");
+    absent.controller.dispose();
+    absent.rendered.unmount();
+    resetOnboardingStore();
+
+    const apiKeyToken = await openLane(claudeBridge({ state: "api-key-token" }));
+    expect(document.body.textContent).toContain(
+      "Claude Code CLI is authenticated with an API key or token, not a subscription.",
+    );
+    expect(laneBadge().textContent).toBe("API key, not a subscription");
+    apiKeyToken.controller.dispose();
+  });
+
+  it("renders the kill switch as a turned-off lane", async () => {
+    const wizard = await openLane(claudeBridge({ state: "disabled" }));
+
+    expect(document.body.textContent).toContain(
+      "The Claude subscription lane is turned off on this Mac. Choose another provider.",
+    );
+    expect(laneBadge().textContent).toBe("Turned off");
+    expect(laneBadge().dataset.state).toBe("stored-inactive");
+    expect(identityLine()).toBeNull();
+    wizard.controller.dispose();
+  });
+
+  it("rechecks the account on demand and never shows a credential field for the lane", async () => {
+    const user = userEvent.setup();
+    const bridge = claudeBridge({ state: "not-logged-in" });
+    bridge.claudeCliRecheck.mockResolvedValue({
+      state: "ready",
+      email: "athlete@example.test",
+      plan: "Pro",
+    });
+    const wizard = await openLane(bridge);
+
+    await user.click(screen.getByRole("button", { name: "Check again" }));
+
+    await waitFor(() => {
+      expect(bridge.claudeCliRecheck).toHaveBeenCalledOnce();
+      expect(identityLine()).toBe("Signed in as athlete@example.test - Claude Pro subscription");
+    });
+    expect(bridge.claudeCliStatus).toHaveBeenCalledOnce();
+    expect(credentialBadges()).toHaveLength(10);
+    expect(document.querySelector('input[data-slot="claude-cli"]')).toBeNull();
+    wizard.controller.dispose();
+  });
+
+  it("keeps the last known identity when a recheck fails", async () => {
+    const user = userEvent.setup();
+    const bridge = claudeBridge({ state: "ready", email: "athlete@example.test", plan: "Max" });
+    bridge.claudeCliRecheck.mockRejectedValue(new Error("probe unavailable"));
+    const wizard = await openLane(bridge);
+
+    await user.click(screen.getByRole("button", { name: "Check again" }));
+
+    await waitFor(() => {
+      expect(bridge.claudeCliRecheck).toHaveBeenCalledOnce();
+    });
+    expect(identityLine()).toBe("Signed in as athlete@example.test - Claude Max subscription");
+    expect(document.body.textContent).not.toContain("probe unavailable");
+    wizard.controller.dispose();
+  });
+
+  it("advances a probe-ready lane without any credential entry", async () => {
+    const user = userEvent.setup();
+    const ready = claudeBridge({ state: "ready", email: "athlete@example.test", plan: "Max" });
+    const wizard = await openLane(ready);
+    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "claude-cli");
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(ready.applyLlmSelection).toHaveBeenCalledOnce();
+      expect(wizard.controller.state().step).toBe("training-data");
+    });
+    expect(ready.applyLlmSelection.mock.calls[0]?.[0]?.provider).toBe("claude-cli");
+    expect(ready.writeCredential).not.toHaveBeenCalled();
+    wizard.controller.dispose();
+  });
+
+  it("holds a signed-out lane on the coach step when the daemon refuses it", async () => {
+    const user = userEvent.setup();
+    const signedOut = claudeBridge({ state: "not-logged-in" });
+    signedOut.applyLlmSelection.mockResolvedValue({
+      status: "refused",
+      reason: "credential-required",
+    });
+    const wizard = await openLane(signedOut);
+    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "claude-cli");
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(signedOut.applyLlmSelection).toHaveBeenCalledOnce();
+    });
+    expect(wizard.controller.state().step).toBe("coach-keys");
+    expect(document.body.textContent).toContain("Claude Code CLI is not signed in.");
+    wizard.controller.dispose();
+  });
+
+  it("never renders the lane when the daemon does not offer the provider", async () => {
+    const bridge = testBridge(async () => ({ status: "refused", reason: "cancelled" }));
+    bridge.claudeCliStatus.mockResolvedValue({ state: "ready", plan: "Max" });
+    const wizard = mountWizard({ bridge });
+
+    await wizard.open();
+
+    expect(document.querySelector(".claude-cli-state")).toBeNull();
+    expect(document.body.textContent).not.toContain("Claude subscription");
+    wizard.controller.dispose();
+  });
+
+  it("never leaks probe fields other than the rendered identity", async () => {
+    const wizard = await openLane(
+      claudeBridge({
+        state: "ready",
+        email: "athlete@example.test",
+        plan: "Max",
+        version: "2.1.0",
+      }),
+    );
+
+    const rendered = document.body.textContent ?? "";
+    expect(rendered).not.toContain("2.1.0");
+    expect(rendered).not.toMatch(/sk-|oauth/iu);
+    wizard.controller.dispose();
+  });
+});

--- a/apps/desktop-renderer/tests/onboarding-harness.tsx
+++ b/apps/desktop-renderer/tests/onboarding-harness.tsx
@@ -173,6 +173,8 @@ export type TestBridge = OnboardingBridge & {
   readonly applyLlmSelection: ReturnType<typeof vi.fn<OnboardingBridge["applyLlmSelection"]>>;
   readonly chatGptStatus: ReturnType<typeof vi.fn<OnboardingBridge["chatGptStatus"]>>;
   readonly chatGptLogin: ReturnType<typeof vi.fn<OnboardingBridge["chatGptLogin"]>>;
+  readonly claudeCliStatus: ReturnType<typeof vi.fn<OnboardingBridge["claudeCliStatus"]>>;
+  readonly claudeCliRecheck: ReturnType<typeof vi.fn<OnboardingBridge["claudeCliRecheck"]>>;
   readonly writeCredential: ReturnType<typeof vi.fn<OnboardingBridge["writeCredential"]>>;
   readonly importFiles: ReturnType<typeof vi.fn<OnboardingBridge["importFiles"]>>;
   readonly chooseImportFiles: ReturnType<typeof vi.fn<OnboardingBridge["chooseImportFiles"]>>;
@@ -201,6 +203,12 @@ export function testBridge(login: () => Promise<ChatGptLoginResult>): TestBridge
       runtimeReady: true,
     })),
     chatGptLogin: vi.fn<OnboardingBridge["chatGptLogin"]>(login),
+    claudeCliStatus: vi.fn<OnboardingBridge["claudeCliStatus"]>(async () => ({
+      state: "not-logged-in",
+    })),
+    claudeCliRecheck: vi.fn<OnboardingBridge["claudeCliRecheck"]>(async () => ({
+      state: "not-logged-in",
+    })),
     chooseImportFiles: vi.fn<OnboardingBridge["chooseImportFiles"]>(async () => []),
     onDroppedImportFiles: vi.fn<OnboardingBridge["onDroppedImportFiles"]>(() => () => {}),
     importFiles: vi.fn<OnboardingBridge["importFiles"]>(async () => ({

--- a/apps/desktop-renderer/tests/onboarding-machine.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-machine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  claudeCliReady,
   createOnboardingState,
   nextStep,
   previousStep,
@@ -9,6 +10,7 @@ import {
   withChatGptLoginResult,
   withChatGptPending,
   withChatGptStatus,
+  withClaudeCliStatus,
   withIntake,
   withImportedRideFileCount,
 } from "../src/onboarding/machine.js";
@@ -21,6 +23,8 @@ describe("desktop onboarding machine", () => {
       "chatGptRefusal",
       "chatGptRuntimeReady",
       "chatGptState",
+      "claudeCliIdentity",
+      "claudeCliState",
       "credentialStatus",
       "fixedError",
       "importedRideFileCount",
@@ -71,6 +75,38 @@ describe("desktop onboarding machine", () => {
     expect(nextStep(state).step).toBe("training-data");
     state = withChatGptStatus(state, { state: "absent", runtimeReady: false });
     expect(state.chatGptState).toBe("absent");
+  });
+
+  it("treats only a probe-ready Claude subscription lane as a configured model", () => {
+    let state = createOnboardingState([], { state: "absent", runtimeReady: false }, null);
+    expect(state.claudeCliState).toBeNull();
+    expect(state.claudeCliIdentity).toBeNull();
+    expect(nextStep(state).fixedError).toBe("credential-required");
+
+    state = withClaudeCliStatus(state, { state: "not-logged-in" });
+    expect(claudeCliReady(state)).toBe(false);
+    expect(nextStep(state).fixedError).toBe("credential-required");
+
+    state = withClaudeCliStatus(state, {
+      state: "ready",
+      email: "athlete@example.test",
+      plan: "Max",
+    });
+    expect(claudeCliReady(state)).toBe(true);
+    expect(state.claudeCliIdentity).toBe(
+      "Signed in as athlete@example.test - Claude Max subscription",
+    );
+    expect(nextStep(state).step).toBe("training-data");
+
+    state = withClaudeCliStatus(state, { state: "ready-api-key" });
+    expect(claudeCliReady(state)).toBe(true);
+    expect(state.claudeCliIdentity).toBe(
+      "Using Anthropic API key billing - usage is charged to your API account.",
+    );
+
+    state = withClaudeCliStatus(state, null);
+    expect(state.claudeCliState).toBeNull();
+    expect(claudeCliReady(state)).toBe(false);
   });
 
   it("preserves configured metadata and successful imports while moving back", () => {

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -10,7 +10,11 @@ import type {
   OnboardingLlmSelection,
   OnboardingLlmSelectionResult,
 } from "../src/onboarding/bridge.js";
-import type { ChatGptStatus, CredentialSlotStatus } from "../src/onboarding/machine.js";
+import type {
+  ChatGptStatus,
+  ClaudeCliStatus,
+  CredentialSlotStatus,
+} from "../src/onboarding/machine.js";
 import { createReleaseNotesController } from "../src/release-notes/controller.js";
 import { createAthleteSettingsController } from "../src/settings/athlete-controller.js";
 import { createCredentialSettingsController } from "../src/settings/credential-controller.js";
@@ -137,6 +141,7 @@ interface HarnessOptions {
   ) => Promise<OnboardingLlmSelectionResult>;
   readonly credentialStatuses?: readonly CredentialSlotStatus[];
   readonly chatGptStatus?: ChatGptStatus;
+  readonly claudeCliStatus?: () => Promise<ClaudeCliStatus>;
   readonly deleteCredential?: () => Promise<CredentialDeleteResult>;
   readonly releaseNotes?: () => Promise<ReleaseNotesResult>;
   readonly updateState?: DesktopUpdateState;
@@ -234,6 +239,9 @@ function createHarness(options: HarnessOptions = {}) {
       ],
     loadChatGptStatus: async () =>
       options.chatGptStatus ?? { state: "absent", runtimeReady: false },
+    ...(options.claudeCliStatus === undefined
+      ? {}
+      : { loadClaudeCliStatus: options.claudeCliStatus }),
     deleteCredential,
     openSetup,
     beginMutation: () => store.getState().beginSettingsMutation("credential"),
@@ -541,6 +549,56 @@ describe("credential deletion", () => {
     await waitFor(() => {
       expect(screen.getByText("Credential deleted locally.")).toBeInTheDocument();
     });
+  });
+});
+
+describe("keyless provider status", () => {
+  it("shows the signed-in identity with no credential value and no delete control", async () => {
+    await renderSettings({
+      runtime: () =>
+        snapshot({
+          llm: { provider: "claude-cli", model: "sonnet", credential_configured: false },
+        }),
+      credentialStatuses: [],
+      claudeCliStatus: async () => ({
+        state: "ready",
+        email: "athlete@example.test",
+        plan: "Max",
+        version: "2.1.0",
+      }),
+    });
+
+    const row = document.querySelector<HTMLElement>('[data-provider="claude-cli"]');
+    expect(row).not.toBeNull();
+    expect(row?.textContent).toContain("Claude subscription");
+    expect(row?.textContent).toContain("Claude Code CLI");
+    expect(row?.textContent).toContain(
+      "Signed in as athlete@example.test - Claude Max subscription",
+    );
+    expect(row?.textContent).not.toContain("2.1.0");
+    expect(within(row as HTMLElement).queryByRole("button")).toBeNull();
+  });
+
+  it("renders api-key billing honestly and never as a subscription", async () => {
+    await renderSettings({
+      runtime: () =>
+        snapshot({
+          llm: { provider: "claude-cli", model: "sonnet", credential_configured: false },
+        }),
+      credentialStatuses: [],
+      claudeCliStatus: async () => ({ state: "ready-api-key" }),
+    });
+
+    const row = document.querySelector<HTMLElement>('[data-provider="claude-cli"]');
+    expect(row?.querySelector("[data-provider-identity]")?.textContent).toBe(
+      "Using Anthropic API key billing - usage is charged to your API account.",
+    );
+  });
+
+  it("keeps credential-backed providers free of status rows", async () => {
+    await renderSettings();
+
+    expect(document.querySelector('[data-provider="claude-cli"]')).toBeNull();
   });
 });
 

--- a/apps/desktop-renderer/tests/spend-notional.test.tsx
+++ b/apps/desktop-renderer/tests/spend-notional.test.tsx
@@ -1,0 +1,119 @@
+import type { SpendRouteSummary, SpendSummary } from "@enduragent/coach-contract";
+import { describe, expect, it } from "vitest";
+import {
+  createSpendSettingsAdapter,
+  notionalSpendCopy,
+  routeSpendCopy,
+} from "../src/state/adapters/spend.js";
+import { EMPTY_SETTINGS_SURFACE } from "../src/state/settings-slice.js";
+
+function route(overrides: Partial<SpendRouteSummary> = {}): SpendRouteSummary {
+  return {
+    provider: "claude-cli",
+    model: "sonnet",
+    generationCount: 3,
+    pricedGenerationCount: 3,
+    unpricedGenerationCount: 0,
+    providerReportedGenerationCount: 0,
+    knownSpendUsd: 0,
+    notionalSpendUsd: 1.2345,
+    cacheReadTokens: 0,
+    cacheReadSavingsUsd: 0,
+    caching: "provider-dependent",
+    disclosure: null,
+    ...overrides,
+  };
+}
+
+function summary(overrides: Partial<SpendSummary> = {}): SpendSummary {
+  return {
+    localDate: "1998-07-06",
+    timezone: "UTC",
+    dailyCapUsd: 0.5,
+    knownSpendUsd: 0,
+    notionalSpendUsd: 1.2345,
+    generationCount: 3,
+    pricedGenerationCount: 3,
+    unpricedGenerationCount: 0,
+    malformedLineCount: 0,
+    spendComplete: true,
+    capStatus: "below",
+    cacheReadTokens: 0,
+    knownCacheReadSavingsUsd: 0,
+    cacheSavingsComplete: true,
+    routes: [route()],
+    ...overrides,
+  };
+}
+
+function adapter() {
+  let state = EMPTY_SETTINGS_SURFACE.spend;
+  const created = createSpendSettingsAdapter({
+    read: () => state,
+    publish: (next) => {
+      state = next;
+    },
+  });
+  return { view: created.view, current: () => state };
+}
+
+describe("notional spend copy", () => {
+  it("renders subscription usage as a would-have-cost line, never as spend", () => {
+    const copy = notionalSpendCopy(summary());
+
+    expect(copy).toBe(
+      "Subscription usage would have cost $1.23 on the API. No money moved, and it does not count toward your cap.",
+    );
+    expect(copy).not.toMatch(/spent|you paid/iu);
+  });
+
+  it("stays silent when no notional usage was recorded", () => {
+    expect(notionalSpendCopy(summary({ notionalSpendUsd: 0 }))).toBeNull();
+    const withoutField = summary();
+    const { notionalSpendUsd: _omitted, ...rest } = withoutField;
+    expect(notionalSpendCopy(rest as SpendSummary)).toBeNull();
+  });
+
+  it("prices a notional route without claiming money moved", () => {
+    expect(routeSpendCopy(route())).toBe(
+      "would have cost $1.23 on the API · 3/3 generations priced",
+    );
+  });
+
+  it("shows both real and notional amounts when one route carries each", () => {
+    expect(routeSpendCopy(route({ knownSpendUsd: 0.42 }))).toBe(
+      "$0.42 · would have cost $1.23 on the API · 3/3 generations priced",
+    );
+  });
+
+  it("keeps the plain spend line for routes that moved real money", () => {
+    const { notionalSpendUsd: _omitted, ...actual } = route({ knownSpendUsd: 0.42 });
+    expect(routeSpendCopy(actual as SpendRouteSummary)).toBe("$0.42 · 3/3 generations priced");
+  });
+
+  it("never raises the cap warning for a notional-only day above the cap", () => {
+    const subject = adapter();
+
+    subject.view.renderSummary(summary(), { stale: false });
+
+    expect(subject.current().warning).toBeNull();
+    expect(subject.current().summary?.knownSpendUsd).toBe(0);
+  });
+
+  it("still warns when real spend reaches the cap", () => {
+    const subject = adapter();
+
+    subject.view.renderSummary(
+      summary({
+        knownSpendUsd: 0.5,
+        capStatus: "reached",
+        routes: [route({ knownSpendUsd: 0.5 })],
+      }),
+      { stale: false },
+    );
+
+    expect(subject.current().warning).toBe(
+      "You’ve reached today’s $0.50 spend cap. You can keep chatting; this is a warning, not a block.",
+    );
+  });
+});

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -16,6 +16,8 @@ files:
   - "!**/vitest.workspace.{js,cjs,mjs,ts,cts,mts}"
   - "!**/node_modules/vitest/**"
   - "!**/node_modules/@vitest/**"
+  - "!**/node_modules/@anthropic-ai/claude-agent-sdk-*"
+  - "!**/node_modules/@anthropic-ai/claude-agent-sdk-*/**"
   - from: resources
     to: resources
     filter:

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -278,6 +278,8 @@ async function security() {
             "chatgptStatus",
             "checkForUpdates",
             "chooseImportFiles",
+            "claudeCliRecheck",
+            "claudeCliStatus",
             "credentialStatuses",
             "deleteCredential",
             "getArchivedTranscriptPage",

--- a/apps/desktop/scripts/verify-package-layout.mjs
+++ b/apps/desktop/scripts/verify-package-layout.mjs
@@ -35,6 +35,12 @@ const requiredFilePatterns = [
   "!**/vitest.workspace.{js,cjs,mjs,ts,cts,mts}",
   "!**/node_modules/vitest/**",
   "!**/node_modules/@vitest/**",
+  "!**/node_modules/@anthropic-ai/claude-agent-sdk-*",
+  "!**/node_modules/@anthropic-ai/claude-agent-sdk-*/**",
+];
+const vendoredAgentCliPatterns = [
+  /(?:^|\/)@anthropic-ai\/claude-agent-sdk-[a-z0-9-]+(?:\/|$)/u,
+  /(?:^|\/)@anthropic-ai\/claude-agent-sdk\/(?:.*\/)?(?:vendor\/|claude$|cli\.js$)/u,
 ];
 const reservedResourceNames = new Set([
   "app.asar",
@@ -178,6 +184,7 @@ function forbiddenPathReason(path) {
   const lower = path.toLowerCase();
   const segments = lower.split("/");
   const base = segments.at(-1) ?? "";
+  if (vendoredAgentCliPatterns.some((pattern) => pattern.test(lower))) return "vendored agent CLI";
   if (base.endsWith(".map")) return "source map";
   if (base.startsWith(".env")) return "environment file";
   if (segments.some((segment) => forbiddenDirectoryNames.has(segment))) {

--- a/apps/desktop/scripts/verify-packaged-self-test.mjs
+++ b/apps/desktop/scripts/verify-packaged-self-test.mjs
@@ -278,6 +278,7 @@ async function main() {
     "@enduragent/desktop",
     "package:dir",
     "--config.mac.identity=-",
+    "--config.mac.hardenedRuntime=false",
   ]);
   const { SelfTestCommandTerminalSchema } = await import("@enduragent/coach-contract");
   const base = await realpath("/tmp");

--- a/apps/desktop/src/main/claude-cli-status.ts
+++ b/apps/desktop/src/main/claude-cli-status.ts
@@ -1,0 +1,209 @@
+import { readFile } from "node:fs/promises";
+import {
+  ClaudeCliConfigError,
+  claudeCliPatchFrom,
+  ensureClaudeCliReady,
+  invalidateClaudeAccountProbeCache,
+  type ClaudeCliBilling,
+  type ClaudeCliReadiness,
+  type EnsureClaudeCliReadyDeps,
+} from "@enduragent/core";
+import type { ConfigureRuntimeRpcParams } from "@enduragent/coach-contract";
+import { parse } from "yaml";
+import {
+  isClaudeCliLaneEligible,
+  parseClaudeCliLlmSelection,
+  runtimeConfigurationForSelection,
+  type OnboardingLlmSelection,
+  type OnboardingLlmSelectionResult,
+} from "./llm-selection.js";
+
+export const CLAUDE_CLI_STATUS_STATES = [
+  "ready",
+  "ready-api-key",
+  "absent-binary",
+  "not-logged-in",
+  "api-key-token",
+  "disabled",
+] as const;
+
+export type ClaudeCliStatusState = (typeof CLAUDE_CLI_STATUS_STATES)[number];
+
+export interface ClaudeCliStatus {
+  readonly state: ClaudeCliStatusState;
+  readonly email?: string;
+  readonly plan?: string;
+  readonly version?: string;
+}
+
+export interface ClaudeCliSettings {
+  readonly enabled: boolean;
+  readonly binaryPath?: string;
+  readonly configDir?: string;
+  readonly billing: ClaudeCliBilling;
+}
+
+export interface ClaudeCliStatusController {
+  status(): Promise<ClaudeCliStatus>;
+  recheck(): Promise<ClaudeCliStatus>;
+  invalidateProbeCache(): void;
+  activate(selection: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
+}
+
+export type ClaudeCliStatusDependencies = Pick<
+  EnsureClaudeCliReadyDeps,
+  "resolveBinary" | "probeVersion" | "probeAccount"
+> & {
+  readonly ensureReady?: typeof ensureClaudeCliReady;
+  readonly invalidateProbeCache?: () => void;
+};
+
+export interface CreateClaudeCliStatusOptions {
+  readonly settings: () => ClaudeCliSettings | Promise<ClaudeCliSettings>;
+  readonly environment?: () => Readonly<Record<string, string | undefined>>;
+  readonly applyRuntimeConfig: (request: ConfigureRuntimeRpcParams) => Promise<void>;
+  readonly dependencies?: ClaudeCliStatusDependencies;
+}
+
+export interface ReadClaudeCliSettingsInput {
+  readonly configPath: string;
+  readonly environment?: Readonly<Record<string, string | undefined>>;
+  readonly readConfigFile?: (path: string) => Promise<string>;
+  readonly parseConfigFile?: (source: string) => unknown;
+}
+
+const CONFIG_FILE_LIMIT = 256 * 1024;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function claudeCliYamlBlock(document: unknown): unknown {
+  if (!isRecord(document) || !isRecord(document.llm)) return undefined;
+  return document.llm.claude_cli;
+}
+
+export async function readClaudeCliSettings(
+  input: ReadClaudeCliSettingsInput,
+): Promise<ClaudeCliSettings> {
+  const environment = input.environment ?? process.env;
+  const read = input.readConfigFile ?? ((path: string) => readFile(path, "utf8"));
+  const parseDocument = input.parseConfigFile ?? ((source: string) => parse(source) as unknown);
+  let block: unknown;
+  try {
+    const source = await read(input.configPath);
+    if (source.length <= CONFIG_FILE_LIMIT) block = claudeCliYamlBlock(parseDocument(source));
+  } catch {
+    block = undefined;
+  }
+  const patch = claudeCliPatchFrom(block, environment);
+  const binaryPath = typeof patch.binaryPath === "string" ? patch.binaryPath : undefined;
+  const configDir = typeof patch.configDir === "string" ? patch.configDir : undefined;
+  return {
+    enabled: patch.enabled !== false,
+    ...(binaryPath === undefined ? {} : { binaryPath }),
+    ...(configDir === undefined ? {} : { configDir }),
+    billing: patch.billing === "api-key" ? "api-key" : "subscription",
+  };
+}
+
+function statusForReadiness(readiness: ClaudeCliReadiness): ClaudeCliStatus {
+  return {
+    state: readiness.accountClass === "api-key-token" ? "ready-api-key" : "ready",
+    ...(readiness.email === undefined ? {} : { email: readiness.email }),
+    ...(readiness.plan === undefined ? {} : { plan: readiness.plan }),
+    version: readiness.version,
+  };
+}
+
+function stateForFailure(error: unknown): ClaudeCliStatusState {
+  if (!(error instanceof ClaudeCliConfigError)) return "not-logged-in";
+  switch (error.kind) {
+    case "binary-missing":
+    case "version-below-floor":
+      return "absent-binary";
+    case "api-key-identity":
+    case "api-key-unapproved":
+    case "unrecognized-auth-source":
+      return "api-key-token";
+    default:
+      return "not-logged-in";
+  }
+}
+
+export function createClaudeCliStatus(
+  options: CreateClaudeCliStatusOptions,
+): ClaudeCliStatusController {
+  const ensureReady = options.dependencies?.ensureReady ?? ensureClaudeCliReady;
+  const invalidate =
+    options.dependencies?.invalidateProbeCache ?? invalidateClaudeAccountProbeCache;
+  const environment = options.environment ?? (() => process.env);
+  const probeDependencies: EnsureClaudeCliReadyDeps = {
+    ...(options.dependencies?.resolveBinary === undefined
+      ? {}
+      : { resolveBinary: options.dependencies.resolveBinary }),
+    ...(options.dependencies?.probeVersion === undefined
+      ? {}
+      : { probeVersion: options.dependencies.probeVersion }),
+    ...(options.dependencies?.probeAccount === undefined
+      ? {}
+      : { probeAccount: options.dependencies.probeAccount }),
+  };
+
+  const read = async (forceRecheck: boolean): Promise<ClaudeCliStatus> => {
+    let settings: ClaudeCliSettings;
+    try {
+      settings = await options.settings();
+    } catch {
+      return { state: "not-logged-in" };
+    }
+    if (!isClaudeCliLaneEligible({ environment: environment(), enabled: settings.enabled })) {
+      return { state: "disabled" };
+    }
+    try {
+      return statusForReadiness(
+        await ensureReady(
+          {
+            ...(settings.binaryPath === undefined ? {} : { binaryPath: settings.binaryPath }),
+            ...(settings.configDir === undefined ? {} : { configDir: settings.configDir }),
+            billing: settings.billing,
+            ...(forceRecheck ? { forceRecheck: true } : {}),
+          },
+          probeDependencies,
+        ),
+      );
+    } catch (error) {
+      return { state: stateForFailure(error) };
+    }
+  };
+
+  return {
+    status: () => read(false),
+    async recheck() {
+      invalidate();
+      return await read(true);
+    },
+    invalidateProbeCache: () => invalidate(),
+    async activate(input) {
+      let selection: ReturnType<typeof parseClaudeCliLlmSelection>;
+      try {
+        selection = parseClaudeCliLlmSelection(input);
+      } catch {
+        return { status: "refused", reason: "invalid-input" };
+      }
+      const current = await read(false);
+      if (current.state === "disabled") {
+        return { status: "refused", reason: "runtime-unavailable" };
+      }
+      if (current.state !== "ready" && current.state !== "ready-api-key") {
+        return { status: "refused", reason: "credential-required" };
+      }
+      try {
+        await options.applyRuntimeConfig(runtimeConfigurationForSelection(selection));
+      } catch {
+        return { status: "refused", reason: "runtime-unavailable" };
+      }
+      return { status: "configured", runtimeReady: true };
+    },
+  };
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,6 +14,7 @@ import {
   utilityProcess,
 } from "electron";
 import { createChatGptAuth, hasChatGptProfile } from "./chatgpt-auth.js";
+import { createClaudeCliStatus, readClaudeCliSettings } from "./claude-cli-status.js";
 import { installDesktopConnectionIpc } from "./connection-ipc.js";
 import { installDesktopExternalLinkIpc } from "./external-link-ipc.js";
 import { DESKTOP_LIFECYCLE_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
@@ -508,6 +509,30 @@ async function runDesktop(): Promise<void> {
       openExternal: (url) => shell.openExternal(url),
       signal: controller.signal,
     });
+    const claudeCli = createClaudeCliStatus({
+      settings: () => readClaudeCliSettings({ configPath: join(configDir, "config.yaml") }),
+      environment: () => process.env,
+      async applyRuntimeConfig(request) {
+        const binding = activeRuntimeBinding!;
+        const lifecycleState = daemonLifecycle?.snapshot();
+        if (lifecycleState?.status !== "ready") throw new TypeError();
+        await binding.credentials.applyExplicit(request);
+        const currentLifecycleState = daemonLifecycle?.snapshot();
+        if (
+          activeRuntimeBinding !== binding ||
+          currentLifecycleState?.status !== "ready" ||
+          currentLifecycleState.generation !== lifecycleState.generation
+        ) {
+          failModelCredentialRuntimeStates();
+          throw new TypeError();
+        }
+        markUnselectedModelCredentialsInactive(
+          credentialRuntimeState,
+          undefined,
+          markCredentialRuntimeChange,
+        );
+      },
+    });
     daemonLifecycle.start();
     await vault.reapplyConfigured();
     await installDesktopProtocol({
@@ -540,6 +565,7 @@ async function runDesktop(): Promise<void> {
             window: created,
             vault,
             chatGptAuth,
+            claudeCli,
             getRuntimeConfig: readActiveRuntimeConfig,
             applyExistingLlmSelection: async (selection: OnboardingLlmSelection) => {
               const binding = activeRuntimeBinding;

--- a/apps/desktop/src/main/llm-selection.ts
+++ b/apps/desktop/src/main/llm-selection.ts
@@ -1,4 +1,9 @@
-import { LLM_MODEL_CATALOGUE, LLM_PROVIDERS, type LlmProvider } from "@enduragent/core";
+import {
+  claudeCliDisabledByEnvironment,
+  LLM_MODEL_CATALOGUE,
+  LLM_PROVIDERS,
+  type LlmProvider,
+} from "@enduragent/core";
 import type { ConfigureRuntimeRpcParams } from "@enduragent/coach-contract";
 
 export interface OnboardingLlmModelOption {
@@ -149,6 +154,27 @@ export function parseChatGptLlmSelection(value: unknown): OnboardingLlmSelection
     readonly provider: "openai-codex";
     readonly endpoint: { readonly mode: "automatic" };
   };
+}
+
+export type ClaudeCliLlmSelection = OnboardingLlmSelection & {
+  readonly provider: "claude-cli";
+  readonly endpoint: { readonly mode: "automatic" };
+};
+
+export function parseClaudeCliLlmSelection(value: unknown): ClaudeCliLlmSelection {
+  const selection = parseOnboardingLlmSelection(value);
+  if (selection.provider !== "claude-cli" || selection.endpoint.mode !== "automatic") {
+    throw new TypeError();
+  }
+  return selection as ClaudeCliLlmSelection;
+}
+
+export function isClaudeCliLaneEligible(input: {
+  readonly environment: Readonly<Record<string, string | undefined>>;
+  readonly enabled?: boolean;
+}): boolean {
+  if (input.enabled === false) return false;
+  return !claudeCliDisabledByEnvironment(input.environment);
 }
 
 export function runtimeConfigurationForSelection(

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -21,6 +21,7 @@ import {
 } from "./credential-vault.js";
 import {
   parseChatGptLlmSelection,
+  parseClaudeCliLlmSelection,
   parseOnboardingLlmSelection,
   publicLlmProviderConfiguration,
   runtimeConfigurationForSelection,
@@ -28,6 +29,7 @@ import {
   type OnboardingLlmSelection,
   type OnboardingLlmSelectionResult,
 } from "./llm-selection.js";
+import type { ClaudeCliStatus, ClaudeCliStatusController } from "./claude-cli-status.js";
 
 export const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status" as const;
 export const DESKTOP_CREDENTIAL_RETRY_CHANNEL = "enduragent:onboarding:credential-retry" as const;
@@ -38,6 +40,9 @@ export const DESKTOP_LLM_SELECTION_APPLY_CHANNEL =
   "enduragent:onboarding:llm-selection-apply" as const;
 export const DESKTOP_CHATGPT_STATUS_CHANNEL = "enduragent:onboarding:chatgpt-status" as const;
 export const DESKTOP_CHATGPT_LOGIN_CHANNEL = "enduragent:onboarding:chatgpt-login" as const;
+export const DESKTOP_CLAUDE_CLI_STATUS_CHANNEL = "enduragent:onboarding:claude-cli-status" as const;
+export const DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL =
+  "enduragent:onboarding:claude-cli-recheck" as const;
 export const DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL =
   "enduragent:onboarding:choose-import-files" as const;
 
@@ -54,6 +59,7 @@ interface RegisterOnboardingIpcOptions {
   readonly window: BrowserWindow;
   readonly vault: CredentialVault;
   readonly chatGptAuth: ChatGptAuthController;
+  readonly claudeCli: ClaudeCliStatusController;
   readonly getRuntimeConfig: () => Promise<RuntimeConfigSnapshot>;
   readonly applyExistingLlmSelection: (selection: OnboardingLlmSelection) => Promise<boolean>;
   readonly isTrusted: (event: IpcMainInvokeEvent) => boolean;
@@ -184,6 +190,15 @@ function minimizeChatGptStatus(value: ChatGptStatus): ChatGptStatus {
   return { state: value.state, runtimeReady: value.runtimeReady };
 }
 
+function minimizeClaudeCliStatus(value: ClaudeCliStatus): ClaudeCliStatus {
+  return {
+    state: value.state,
+    ...(value.email === undefined ? {} : { email: value.email }),
+    ...(value.plan === undefined ? {} : { plan: value.plan }),
+    ...(value.version === undefined ? {} : { version: value.version }),
+  };
+}
+
 function minimizeChatGptLogin(value: ChatGptLoginResult): ChatGptLoginResult {
   if (value.status === "configured") return { status: "configured", runtimeReady: true };
   return { status: "refused", reason: value.reason };
@@ -213,6 +228,7 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
   options.ipcMain.handle(DESKTOP_CREDENTIAL_STATUS_CHANNEL, async (event, ...args) => {
     requireTrusted(event);
     if (args.length !== 0) throw new TypeError();
+    options.claudeCli.invalidateProbeCache();
     try {
       return minimizeStatuses(await options.vault.credentialStatuses());
     } catch {
@@ -305,11 +321,17 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
       if (await options.applyExistingLlmSelection(selection)) {
         return { status: "configured", runtimeReady: true };
       }
-      const result =
-        selection.provider === "openai-codex"
-          ? await options.chatGptAuth.activate(parseChatGptLlmSelection(selection))
-          : await options.vault.applyLlmSelection(selection);
-      return minimizeSelection(result);
+      if (selection.provider === "openai-codex") {
+        return minimizeSelection(
+          await options.chatGptAuth.activate(parseChatGptLlmSelection(selection)),
+        );
+      }
+      if (selection.provider === "claude-cli") {
+        return minimizeSelection(
+          await options.claudeCli.activate(parseClaudeCliLlmSelection(selection)),
+        );
+      }
+      return minimizeSelection(await options.vault.applyLlmSelection(selection));
     } catch {
       return { status: "refused", reason: "runtime-unavailable" };
     }
@@ -324,6 +346,16 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
     if (args.length !== 1) throw new TypeError();
     const selection = parseChatGptLlmSelection(args[0]);
     return minimizeChatGptLogin(await options.chatGptAuth.login(selection));
+  });
+  options.ipcMain.handle(DESKTOP_CLAUDE_CLI_STATUS_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 0) throw new TypeError();
+    return minimizeClaudeCliStatus(await options.claudeCli.status());
+  });
+  options.ipcMain.handle(DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 0) throw new TypeError();
+    return minimizeClaudeCliStatus(await options.claudeCli.recheck());
   });
   options.ipcMain.handle(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL, async (event, ...args) => {
     requireTrusted(event);
@@ -355,6 +387,8 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
     options.ipcMain.removeHandler(DESKTOP_LLM_SELECTION_APPLY_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CHATGPT_STATUS_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CHATGPT_LOGIN_CHANNEL);
+    options.ipcMain.removeHandler(DESKTOP_CLAUDE_CLI_STATUS_CHANNEL);
+    options.ipcMain.removeHandler(DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL);
   };
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -21,6 +21,8 @@ const DESKTOP_LLM_CONFIGURATION_CHANNEL = "enduragent:onboarding:llm-configurati
 const DESKTOP_LLM_SELECTION_APPLY_CHANNEL = "enduragent:onboarding:llm-selection-apply";
 const DESKTOP_CHATGPT_STATUS_CHANNEL = "enduragent:onboarding:chatgpt-status";
 const DESKTOP_CHATGPT_LOGIN_CHANNEL = "enduragent:onboarding:chatgpt-login";
+const DESKTOP_CLAUDE_CLI_STATUS_CHANNEL = "enduragent:onboarding:claude-cli-status";
+const DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL = "enduragent:onboarding:claude-cli-recheck";
 const DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL = "enduragent:onboarding:choose-import-files";
 
 const SLOTS = new Set([
@@ -83,6 +85,14 @@ const CHATGPT_REASONS = new Set([
   "exchange-failed",
   "storage-failed",
   "runtime-unavailable",
+]);
+const CLAUDE_CLI_STATES = new Set([
+  "ready",
+  "ready-api-key",
+  "absent-binary",
+  "not-logged-in",
+  "api-key-token",
+  "disabled",
 ]);
 const IMPORT_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
 const RELEASES_URL = "https://github.com/yerzhansa/enduragent/releases";
@@ -747,6 +757,28 @@ function parseChatGptLogin(value: unknown): unknown {
   throw new TypeError();
 }
 
+function parseClaudeCliStatus(value: unknown): unknown {
+  if (!record(value) || typeof value.state !== "string" || !CLAUDE_CLI_STATES.has(value.state)) {
+    throw new TypeError();
+  }
+  const keys = ["state"];
+  for (const field of ["email", "plan", "version"]) {
+    if (Object.hasOwn(value, field)) keys.push(field);
+  }
+  if (
+    !exactKeys(value, keys) ||
+    keys.some((field) => field !== "state" && !safeString(value[field], 512))
+  ) {
+    throw new TypeError();
+  }
+  return {
+    state: value.state,
+    ...(Object.hasOwn(value, "email") ? { email: value.email } : {}),
+    ...(Object.hasOwn(value, "plan") ? { plan: value.plan } : {}),
+    ...(Object.hasOwn(value, "version") ? { version: value.version } : {}),
+  };
+}
+
 function parsePaths(value: unknown): readonly string[] {
   if (!Array.isArray(value) || value.length > 256) {
     throw new TypeError();
@@ -878,6 +910,10 @@ contextBridge.exposeInMainWorld(
       const selection = parseChatGptSelection(input);
       return parseChatGptLogin(await ipcRenderer.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL, selection));
     },
+    claudeCliStatus: async () =>
+      parseClaudeCliStatus(await ipcRenderer.invoke(DESKTOP_CLAUDE_CLI_STATUS_CHANNEL)),
+    claudeCliRecheck: async () =>
+      parseClaudeCliStatus(await ipcRenderer.invoke(DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL)),
     chooseImportFiles: async () =>
       parsePaths(await ipcRenderer.invoke(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL)),
     releaseNotes: async () =>

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -834,6 +834,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "chatgptStatus",
         "checkForUpdates",
         "chooseImportFiles",
+        "claudeCliRecheck",
+        "claudeCliStatus",
         "credentialStatuses",
         "deleteCredential",
         "getArchivedTranscriptPage",

--- a/apps/desktop/tests/claude-cli-status.test.ts
+++ b/apps/desktop/tests/claude-cli-status.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ClaudeAccountProbeResult } from "@enduragent/core";
+import {
+  createClaudeCliStatus,
+  readClaudeCliSettings,
+  type ClaudeCliSettings,
+  type ClaudeCliStatusDependencies,
+} from "../src/main/claude-cli-status.js";
+import {
+  DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL,
+  DESKTOP_CLAUDE_CLI_STATUS_CHANNEL,
+} from "../src/main/onboarding-ipc.js";
+
+const BINARY = "/opt/homebrew/bin/claude";
+
+function settings(overrides: Partial<ClaudeCliSettings> = {}): ClaudeCliSettings {
+  return { enabled: true, billing: "subscription", ...overrides };
+}
+
+function subscriptionProbe(): ClaudeAccountProbeResult {
+  return {
+    verified: true,
+    accountClass: "subscription",
+    email: "athlete@synthetic.test",
+    plan: "Max",
+  };
+}
+
+function harness(input: {
+  readonly settings?: ClaudeCliSettings;
+  readonly probe?: ClaudeAccountProbeResult;
+  readonly binary?: string | null;
+  readonly version?: string;
+  readonly environment?: Record<string, string | undefined>;
+  readonly applyRuntimeConfig?: (request: unknown) => Promise<void>;
+}) {
+  const resolveBinary = vi.fn(async () => (input.binary === undefined ? BINARY : input.binary));
+  const probeVersion = vi.fn(async () => input.version ?? "2.9.0");
+  const probeAccount = vi.fn(async () => input.probe ?? subscriptionProbe());
+  const invalidateProbeCache = vi.fn();
+  const applyRuntimeConfig = vi.fn(input.applyRuntimeConfig ?? (async () => {}));
+  const dependencies: ClaudeCliStatusDependencies = {
+    resolveBinary,
+    probeVersion,
+    probeAccount,
+    invalidateProbeCache,
+  };
+  const readSettings = vi.fn(async () => input.settings ?? settings());
+  const controller = createClaudeCliStatus({
+    settings: readSettings,
+    environment: () => input.environment ?? {},
+    applyRuntimeConfig,
+    dependencies,
+  });
+  return {
+    controller,
+    resolveBinary,
+    probeVersion,
+    probeAccount,
+    invalidateProbeCache,
+    applyRuntimeConfig,
+    readSettings,
+  };
+}
+
+describe("desktop claude-cli status controller", () => {
+  it("reports a verified subscription identity as ready", async () => {
+    const subject = harness({});
+
+    await expect(subject.controller.status()).resolves.toEqual({
+      state: "ready",
+      email: "athlete@synthetic.test",
+      plan: "Max",
+      version: "2.9.0",
+    });
+  });
+
+  it("reports probe-confirmed api-key billing as ready-api-key", async () => {
+    const subject = harness({
+      settings: settings({ billing: "api-key" }),
+      probe: { verified: true, accountClass: "api-key-token" },
+    });
+
+    await expect(subject.controller.status()).resolves.toEqual({
+      state: "ready-api-key",
+      version: "2.9.0",
+    });
+  });
+
+  it.each([
+    [
+      "an api-key identity in subscription mode",
+      { verified: true, accountClass: "api-key-token" } as ClaudeAccountProbeResult,
+      "subscription" as const,
+      "api-key-token",
+    ],
+    [
+      "an unrecognized auth source",
+      {
+        verified: false,
+        accountClass: "unrecognized",
+        rawAuthSource: "synthetic-source",
+      } as ClaudeAccountProbeResult,
+      "subscription" as const,
+      "api-key-token",
+    ],
+    [
+      "an unapproved api key",
+      { verified: true, accountClass: "subscription", plan: "Max" } as ClaudeAccountProbeResult,
+      "api-key" as const,
+      "api-key-token",
+    ],
+    [
+      "a signed-out CLI",
+      {
+        verified: false,
+        accountClass: "not-signed-in",
+        reason: "no-account",
+      } as ClaudeAccountProbeResult,
+      "subscription" as const,
+      "not-logged-in",
+    ],
+    [
+      "a probe timeout",
+      {
+        verified: false,
+        accountClass: "unrecognized",
+        reason: "timeout",
+      } as ClaudeAccountProbeResult,
+      "subscription" as const,
+      "not-logged-in",
+    ],
+  ])("refuses %s", async (_case, probe, billing, state) => {
+    const subject = harness({ probe, settings: settings({ billing }) });
+
+    await expect(subject.controller.status()).resolves.toEqual({ state });
+  });
+
+  it("reports a missing binary as absent-binary", async () => {
+    const subject = harness({ binary: null });
+
+    await expect(subject.controller.status()).resolves.toEqual({ state: "absent-binary" });
+    expect(subject.probeVersion).not.toHaveBeenCalled();
+  });
+
+  it("reports a below-floor CLI version as absent-binary", async () => {
+    const subject = harness({ version: "1.0.0" });
+
+    await expect(subject.controller.status()).resolves.toEqual({ state: "absent-binary" });
+    expect(subject.probeAccount).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["the environment kill switch", { ENDURAGENT_CLAUDE_CLI_DISABLED: "TRUE" }, settings()],
+    ["the configuration flag", {}, settings({ enabled: false })],
+  ])("reports %s as disabled without probing", async (_case, environment, current) => {
+    const subject = harness({ environment, settings: current });
+
+    await expect(subject.controller.status()).resolves.toEqual({ state: "disabled" });
+    expect(subject.resolveBinary).not.toHaveBeenCalled();
+    expect(subject.probeAccount).not.toHaveBeenCalled();
+  });
+
+  it("re-evaluates eligibility on every status poll", async () => {
+    const environment: Record<string, string | undefined> = {};
+    const controller = createClaudeCliStatus({
+      settings: () => settings(),
+      environment: () => environment,
+      applyRuntimeConfig: async () => {},
+      dependencies: {
+        resolveBinary: async () => BINARY,
+        probeVersion: async () => "2.9.0",
+        probeAccount: async () => subscriptionProbe(),
+      },
+    });
+
+    await expect(controller.status()).resolves.toMatchObject({ state: "ready" });
+    environment.ENDURAGENT_CLAUDE_CLI_DISABLED = "1";
+    await expect(controller.status()).resolves.toEqual({ state: "disabled" });
+    delete environment.ENDURAGENT_CLAUDE_CLI_DISABLED;
+    await expect(controller.status()).resolves.toMatchObject({ state: "ready" });
+  });
+
+  it("busts the probe cache on recheck but not on a plain status read", async () => {
+    const subject = harness({});
+
+    await subject.controller.status();
+    expect(subject.invalidateProbeCache).not.toHaveBeenCalled();
+
+    await expect(subject.controller.recheck()).resolves.toMatchObject({ state: "ready" });
+    expect(subject.invalidateProbeCache).toHaveBeenCalledOnce();
+  });
+
+  it("busts the probe cache when the settings credentials surface opens", () => {
+    const subject = harness({});
+
+    subject.controller.invalidateProbeCache();
+
+    expect(subject.invalidateProbeCache).toHaveBeenCalledOnce();
+  });
+
+  it("activates a claude-cli selection once the lane is ready", async () => {
+    const subject = harness({});
+
+    await expect(
+      subject.controller.activate({
+        provider: "claude-cli",
+        model: "sonnet",
+        endpoint: { mode: "automatic" },
+      }),
+    ).resolves.toEqual({ status: "configured", runtimeReady: true });
+    expect(subject.applyRuntimeConfig).toHaveBeenCalledWith({
+      llm: { provider: "claude-cli", model: "sonnet" },
+    });
+  });
+
+  it.each([
+    [
+      "a foreign provider",
+      { provider: "anthropic", model: "sonnet", endpoint: { mode: "automatic" } },
+      "invalid-input",
+    ],
+    [
+      "a custom endpoint",
+      {
+        provider: "claude-cli",
+        model: "sonnet",
+        endpoint: { mode: "custom", value: "http://127.0.0.1:1234" },
+      },
+      "invalid-input",
+    ],
+  ])("refuses activation for %s", async (_case, selection, reason) => {
+    const subject = harness({});
+
+    await expect(subject.controller.activate(selection as never)).resolves.toEqual({
+      status: "refused",
+      reason,
+    });
+    expect(subject.applyRuntimeConfig).not.toHaveBeenCalled();
+  });
+
+  it("refuses activation while the lane is not signed in", async () => {
+    const subject = harness({
+      probe: { verified: false, accountClass: "not-signed-in", reason: "no-account" },
+    });
+
+    await expect(
+      subject.controller.activate({
+        provider: "claude-cli",
+        model: "sonnet",
+        endpoint: { mode: "automatic" },
+      }),
+    ).resolves.toEqual({ status: "refused", reason: "credential-required" });
+    expect(subject.applyRuntimeConfig).not.toHaveBeenCalled();
+  });
+
+  it("refuses activation while the lane is disabled", async () => {
+    const subject = harness({ settings: settings({ enabled: false }) });
+
+    await expect(
+      subject.controller.activate({
+        provider: "claude-cli",
+        model: "sonnet",
+        endpoint: { mode: "automatic" },
+      }),
+    ).resolves.toEqual({ status: "refused", reason: "runtime-unavailable" });
+  });
+
+  it("refuses activation when the runtime rejects the selection", async () => {
+    const subject = harness({
+      applyRuntimeConfig: async () => {
+        throw new TypeError();
+      },
+    });
+
+    await expect(
+      subject.controller.activate({
+        provider: "claude-cli",
+        model: "sonnet",
+        endpoint: { mode: "automatic" },
+      }),
+    ).resolves.toEqual({ status: "refused", reason: "runtime-unavailable" });
+  });
+});
+
+describe("desktop claude-cli settings reader", () => {
+  it("reads the yaml block and applies the environment overrides", async () => {
+    await expect(
+      readClaudeCliSettings({
+        configPath: "/synthetic/config.yaml",
+        environment: { CLAUDE_CLI_PATH: "/synthetic/bin/claude" },
+        readConfigFile: async () =>
+          [
+            "llm:",
+            "  provider: claude-cli",
+            "  claude_cli:",
+            "    enabled: true",
+            "    binary_path: /ignored/claude",
+            "    config_dir: /synthetic/claude-config",
+            "    billing: api-key",
+          ].join("\n"),
+      }),
+    ).resolves.toEqual({
+      enabled: true,
+      binaryPath: "/synthetic/bin/claude",
+      configDir: "/synthetic/claude-config",
+      billing: "api-key",
+    });
+  });
+
+  it("disables the lane when the environment kill switch is set", async () => {
+    await expect(
+      readClaudeCliSettings({
+        configPath: "/synthetic/config.yaml",
+        environment: { ENDURAGENT_CLAUDE_CLI_DISABLED: "1" },
+        readConfigFile: async () => "llm:\n  claude_cli:\n    enabled: true\n",
+      }),
+    ).resolves.toEqual({ enabled: false, billing: "subscription" });
+  });
+
+  it("falls back to defaults when the configuration file is unreadable", async () => {
+    await expect(
+      readClaudeCliSettings({
+        configPath: "/synthetic/missing.yaml",
+        environment: {},
+        readConfigFile: async () => {
+          throw new Error("ENOENT");
+        },
+      }),
+    ).resolves.toEqual({ enabled: true, billing: "subscription" });
+  });
+});
+
+describe("desktop claude-cli channels", () => {
+  it("pins the onboarding channel names", () => {
+    expect(DESKTOP_CLAUDE_CLI_STATUS_CHANNEL).toBe("enduragent:onboarding:claude-cli-status");
+    expect(DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL).toBe("enduragent:onboarding:claude-cli-recheck");
+  });
+});

--- a/apps/desktop/tests/credential-runtime.test.ts
+++ b/apps/desktop/tests/credential-runtime.test.ts
@@ -172,6 +172,12 @@ async function pollCredentialStatuses(vault: CredentialVault): Promise<void> {
       activate: async () => ({ status: "refused", reason: "credential-required" }),
       deleteCredential: async () => ({ status: "refused", reason: "not-found" }),
     },
+    claudeCli: {
+      status: async () => ({ state: "absent-binary" }),
+      recheck: async () => ({ state: "absent-binary" }),
+      invalidateProbeCache: () => {},
+      activate: async () => ({ status: "refused", reason: "credential-required" }),
+    },
     getRuntimeConfig: async () => runtimeSnapshot("anthropic"),
     applyExistingLlmSelection: async () => false,
     isTrusted: () => true,

--- a/apps/desktop/tests/llm-selection.test.ts
+++ b/apps/desktop/tests/llm-selection.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  isClaudeCliLaneEligible,
+  parseChatGptLlmSelection,
+  parseClaudeCliLlmSelection,
+  runtimeConfigurationForSelection,
+} from "../src/main/llm-selection.js";
+
+describe("desktop claude-cli selection parsing", () => {
+  it("accepts a claude-cli selection with an automatic endpoint", () => {
+    expect(
+      parseClaudeCliLlmSelection({
+        provider: "claude-cli",
+        model: "  sonnet  ",
+        endpoint: { mode: "automatic" },
+      }),
+    ).toEqual({ provider: "claude-cli", model: "sonnet", endpoint: { mode: "automatic" } });
+  });
+
+  it("builds a keyless runtime request for the lane", () => {
+    expect(
+      runtimeConfigurationForSelection(
+        parseClaudeCliLlmSelection({
+          provider: "claude-cli",
+          model: "opus",
+          endpoint: { mode: "automatic" },
+        }),
+      ),
+    ).toEqual({ llm: { provider: "claude-cli", model: "opus" } });
+  });
+
+  it.each([
+    [
+      "another provider",
+      { provider: "openai-codex", model: "gpt-5.5", endpoint: { mode: "automatic" } },
+    ],
+    [
+      "a default endpoint",
+      { provider: "claude-cli", model: "sonnet", endpoint: { mode: "default" } },
+    ],
+    [
+      "a custom endpoint",
+      {
+        provider: "claude-cli",
+        model: "sonnet",
+        endpoint: { mode: "custom", value: "http://127.0.0.1:4321" },
+      },
+    ],
+    ["an unknown key", { provider: "claude-cli", model: "sonnet" }],
+  ])("rejects %s", (_case, selection) => {
+    expect(() => parseClaudeCliLlmSelection(selection)).toThrow(TypeError);
+  });
+
+  it("keeps the ChatGPT parser pinned to its own provider", () => {
+    expect(() =>
+      parseChatGptLlmSelection({
+        provider: "claude-cli",
+        model: "sonnet",
+        endpoint: { mode: "automatic" },
+      }),
+    ).toThrow(TypeError);
+  });
+});
+
+describe("desktop claude-cli lane eligibility", () => {
+  it.each([
+    ["an empty environment", {}, undefined, true],
+    ["an enabled flag", {}, true, true],
+    ["a disabled flag", {}, false, false],
+    ["the kill switch set to 1", { ENDURAGENT_CLAUDE_CLI_DISABLED: "1" }, true, false],
+    ["the kill switch set to TRUE", { ENDURAGENT_CLAUDE_CLI_DISABLED: " TRUE " }, undefined, false],
+    ["an unrelated kill-switch value", { ENDURAGENT_CLAUDE_CLI_DISABLED: "no" }, undefined, true],
+  ])("resolves %s", (_case, environment, enabled, expected) => {
+    expect(
+      isClaudeCliLaneEligible({
+        environment,
+        ...(enabled === undefined ? {} : { enabled }),
+      }),
+    ).toBe(expected);
+  });
+});

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -4,6 +4,8 @@ import {
   DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL,
   DESKTOP_CHATGPT_LOGIN_CHANNEL,
   DESKTOP_CHATGPT_STATUS_CHANNEL,
+  DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL,
+  DESKTOP_CLAUDE_CLI_STATUS_CHANNEL,
   DESKTOP_CREDENTIAL_RETRY_CHANNEL,
   DESKTOP_CREDENTIAL_DELETE_CHANNEL,
   DESKTOP_CREDENTIAL_STATUS_CHANNEL,
@@ -69,6 +71,17 @@ function harness(
       cleanupPending: false as const,
     })),
   };
+  const claudeCli = {
+    status: vi.fn(async () => ({
+      state: "ready" as const,
+      email: "athlete@synthetic.test",
+      plan: "Max",
+      version: "2.9.0",
+    })),
+    recheck: vi.fn(async () => ({ state: "not-logged-in" as const })),
+    invalidateProbeCache: vi.fn(),
+    activate: vi.fn(async () => ({ status: "configured" as const, runtimeReady: true as const })),
+  };
   const getRuntimeConfig = vi.fn(async () => ({
     schemaVersion: 3 as const,
     llm: {
@@ -104,6 +117,7 @@ function harness(
     window: {} as never,
     vault,
     chatGptAuth,
+    claudeCli,
     getRuntimeConfig,
     applyExistingLlmSelection,
     isTrusted: (event) => event === trustedEvent,
@@ -116,6 +130,7 @@ function harness(
     ipcMain,
     vault,
     chatGptAuth,
+    claudeCli,
     getRuntimeConfig,
     applyExistingLlmSelection,
     dialog,
@@ -274,6 +289,8 @@ describe("desktop onboarding IPC", () => {
         DESKTOP_LLM_SELECTION_APPLY_CHANNEL,
         DESKTOP_CHATGPT_STATUS_CHANNEL,
         DESKTOP_CHATGPT_LOGIN_CHANNEL,
+        DESKTOP_CLAUDE_CLI_STATUS_CHANNEL,
+        DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL,
         DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL,
       ].sort(),
     );
@@ -612,6 +629,81 @@ describe("desktop onboarding IPC", () => {
     ).rejects.toBeInstanceOf(TypeError);
   });
 
+  it("gates strict claude-cli status and recheck invokes", async () => {
+    const subject = harness();
+    await expect(
+      subject.invoke(DESKTOP_CLAUDE_CLI_STATUS_CHANNEL, subject.trustedEvent),
+    ).resolves.toEqual({
+      state: "ready",
+      email: "athlete@synthetic.test",
+      plan: "Max",
+      version: "2.9.0",
+    });
+    await expect(
+      subject.invoke(DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL, subject.trustedEvent),
+    ).resolves.toEqual({ state: "not-logged-in" });
+    await expect(
+      subject.invoke(DESKTOP_CLAUDE_CLI_STATUS_CHANNEL, {} as IpcMainInvokeEvent),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      subject.invoke(DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL, {} as IpcMainInvokeEvent),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      subject.invoke(DESKTOP_CLAUDE_CLI_STATUS_CHANNEL, subject.trustedEvent, null),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      subject.invoke(DESKTOP_CLAUDE_CLI_RECHECK_CHANNEL, subject.trustedEvent, {}),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(subject.claudeCli.status).toHaveBeenCalledOnce();
+    expect(subject.claudeCli.recheck).toHaveBeenCalledOnce();
+  });
+
+  it("re-minimizes the claude-cli status payload to its exact keys", async () => {
+    const subject = harness();
+    subject.claudeCli.status.mockResolvedValueOnce({
+      state: "ready",
+      email: "athlete@synthetic.test",
+      plan: "Max",
+      version: "2.9.0",
+      probeSecret: "must-not-cross",
+    } as never);
+
+    const status = (await subject.invoke(
+      DESKTOP_CLAUDE_CLI_STATUS_CHANNEL,
+      subject.trustedEvent,
+    )) as Record<string, unknown>;
+
+    expect(Object.keys(status).sort()).toEqual(["email", "plan", "state", "version"]);
+    expect(JSON.stringify(status)).not.toContain("must-not-cross");
+  });
+
+  it("busts the claude-cli probe cache when the credentials surface opens", async () => {
+    const subject = harness();
+
+    await subject.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL, subject.trustedEvent);
+
+    expect(subject.claudeCli.invalidateProbeCache).toHaveBeenCalledOnce();
+  });
+
+  it("routes a claude-cli selection through the claude-cli controller", async () => {
+    const subject = harness();
+    const selection = {
+      provider: "claude-cli",
+      model: "  sonnet  ",
+      endpoint: { mode: "automatic" },
+    };
+
+    await expect(
+      subject.invoke(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, subject.trustedEvent, selection),
+    ).resolves.toEqual({ status: "configured", runtimeReady: true });
+    expect(subject.claudeCli.activate).toHaveBeenCalledWith({
+      provider: "claude-cli",
+      model: "sonnet",
+      endpoint: { mode: "automatic" },
+    });
+    expect(subject.vault.applyLlmSelection).not.toHaveBeenCalled();
+  });
+
   it("gates strict ChatGPT status and login invokes", async () => {
     const subject = harness();
     await expect(
@@ -705,10 +797,10 @@ describe("desktop onboarding IPC", () => {
     ).resolves.toEqual([]);
   });
 
-  it("disposes only its nine handlers", () => {
+  it("disposes only its eleven handlers", () => {
     const subject = harness();
     subject.dispose();
     expect(subject.handlers.size).toBe(0);
-    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(9);
+    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(11);
   });
 });

--- a/apps/desktop/tests/package-layout.test.ts
+++ b/apps/desktop/tests/package-layout.test.ts
@@ -24,6 +24,8 @@ const exclusions = [
   "!**/vitest.workspace.{js,cjs,mjs,ts,cts,mts}",
   "!**/node_modules/vitest/**",
   "!**/node_modules/@vitest/**",
+  "!**/node_modules/@anthropic-ai/claude-agent-sdk-*",
+  "!**/node_modules/@anthropic-ai/claude-agent-sdk-*/**",
 ];
 
 afterEach(async () => {
@@ -458,6 +460,48 @@ describe("desktop package layout", () => {
     await expect(
       verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
     ).rejects.toThrow(/forbidden/u);
+  });
+
+  it.each([
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude",
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude",
+    "node_modules/@enduragent/engine/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/x.js",
+    "node_modules/@anthropic-ai/claude-agent-sdk/vendor/claude-code/cli.js",
+    "node_modules/@anthropic-ai/claude-agent-sdk/cli.js",
+  ])("rejects the vendored agent CLI at ASAR path %s", async (path) => {
+    const fixture = await syntheticPackage();
+    await fixture.writeArchive(path);
+    await fixture.rebuild();
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("forbidden vendored agent CLI");
+  });
+
+  it("keeps the agent SDK itself packageable", async () => {
+    const fixture = await syntheticPackage();
+    await fixture.writeArchive("node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs");
+    await fixture.rebuild();
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a vendored agent CLI staged as an external resource", async () => {
+    const fixture = await syntheticPackage();
+    await mkdir(
+      join(fixture.externalPackaged, "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64"),
+      { recursive: true },
+    );
+    await writeFile(
+      join(
+        fixture.externalPackaged,
+        "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude",
+      ),
+      "synthetic runtime\n",
+    );
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("forbidden vendored agent CLI");
   });
 
   it("rejects forbidden paths in external and unpacked resources", async () => {

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -52,6 +52,8 @@ interface AuthBridge {
   releaseNotes(): Promise<unknown>;
   chatgptStatus(): Promise<unknown>;
   chatgptLogin(input: unknown): Promise<unknown>;
+  claudeCliStatus(): Promise<unknown>;
+  claudeCliRecheck(): Promise<unknown>;
   getUpdateState(): Promise<unknown>;
   checkForUpdates(): Promise<unknown>;
   restartToUpdate(): Promise<unknown>;
@@ -185,6 +187,8 @@ describe("desktop preload ChatGPT auth", () => {
         "chatgptLogin",
         "chatgptStatus",
         "chooseImportFiles",
+        "claudeCliRecheck",
+        "claudeCliStatus",
         "credentialStatuses",
         "deleteCredential",
         "getUpdateState",
@@ -918,6 +922,42 @@ describe("desktop preload ChatGPT auth", () => {
       "enduragent:onboarding:chatgpt-status",
       "enduragent:onboarding:chatgpt-login",
     ]);
+  });
+
+  it("copies claude-cli status payloads with their exact optional keys", async () => {
+    mocks.invoke
+      .mockResolvedValueOnce({
+        state: "ready",
+        email: "athlete@synthetic.test",
+        plan: "Max",
+        version: "2.9.0",
+      })
+      .mockResolvedValueOnce({ state: "disabled" });
+    await expect(bridge.claudeCliStatus()).resolves.toEqual({
+      state: "ready",
+      email: "athlete@synthetic.test",
+      plan: "Max",
+      version: "2.9.0",
+    });
+    await expect(bridge.claudeCliRecheck()).resolves.toEqual({ state: "disabled" });
+    expect(mocks.invoke.mock.calls.map(([channel]) => channel)).toEqual([
+      "enduragent:onboarding:claude-cli-status",
+      "enduragent:onboarding:claude-cli-recheck",
+    ]);
+  });
+
+  it("rejects claude-cli status payloads outside the closed state set", async () => {
+    for (const value of [
+      { state: "signed-in" },
+      { state: "ready", identity: "athlete@synthetic.test" },
+      { state: "ready", email: "" },
+      { state: "ready-api-key", version: 2 },
+      { email: "athlete@synthetic.test" },
+      [],
+    ]) {
+      mocks.invoke.mockResolvedValueOnce(value);
+      await expect(bridge.claudeCliStatus()).rejects.toBeInstanceOf(TypeError);
+    }
   });
 
   it("accepts only closed refusal reasons and exact keys", async () => {

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -367,6 +367,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "chatgptStatus",
       "checkForUpdates",
       "chooseImportFiles",
+      "claudeCliRecheck",
+      "claudeCliStatus",
       "credentialStatuses",
       "deleteCredential",
       "getArchivedTranscriptPage",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,17 @@
     ],
     "patchedDependencies": {
       "fit-file-parser@3.0.2": "patches/fit-file-parser@3.0.2.patch"
-    }
+    },
+    "ignoredOptionalDependencies": [
+      "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+      "@anthropic-ai/claude-agent-sdk-darwin-x64",
+      "@anthropic-ai/claude-agent-sdk-linux-arm64",
+      "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
+      "@anthropic-ai/claude-agent-sdk-linux-x64",
+      "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
+      "@anthropic-ai/claude-agent-sdk-win32-arm64",
+      "@anthropic-ai/claude-agent-sdk-win32-x64"
+    ]
   },
   "license": "MIT",
   "repository": {

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -30,6 +30,7 @@ import {
   resolveRuntimeConfig,
   resolveSecretRef,
   sessionConfigEnvironmentOwnership,
+  type ClaudeCliRuntimeConfigPatch,
   type Config,
   type ConversationStorePort,
   type ReferenceRuntime,
@@ -162,6 +163,17 @@ function copyConfig(config: Config): Config {
   };
 }
 
+function claudeCliPatch(
+  block: NonNullable<NonNullable<ConfigureRuntimeRpcParams["llm"]>["claude_cli"]>,
+): ClaudeCliRuntimeConfigPatch {
+  return {
+    ...(block.enabled === undefined ? {} : { enabled: block.enabled }),
+    ...(block.binary_path === undefined ? {} : { binaryPath: block.binary_path }),
+    ...(block.config_dir === undefined ? {} : { configDir: block.config_dir }),
+    ...(block.billing === undefined ? {} : { billing: block.billing }),
+  };
+}
+
 function runtimePatch(request: ConfigureRuntimeRpcParams, config: Config): RuntimeConfigPatch {
   return {
     ...(request.llm === undefined
@@ -177,6 +189,9 @@ function runtimePatch(request: ConfigureRuntimeRpcParams, config: Config): Runti
             baseUrl: request.llm.base_url,
             flushModel: request.llm.flush_model,
             compactModel: request.llm.compact_model,
+            ...(request.llm.claude_cli === undefined
+              ? {}
+              : { claudeCli: claudeCliPatch(request.llm.claude_cli) }),
           },
         }),
     ...(request.intervals === undefined
@@ -305,6 +320,14 @@ function persistRuntimeConfig(
     assignOptionalField(llm, "base_url", candidate.llm.baseUrl);
     assignOptionalField(llm, "flush_model", candidate.llm.flushModel);
     assignOptionalField(llm, "compact_model", candidate.llm.compactModel);
+    if (request.llm.claude_cli !== undefined) {
+      const block: Record<string, unknown> = isRecord(llm.claude_cli) ? { ...llm.claude_cli } : {};
+      for (const [field, value] of Object.entries(request.llm.claude_cli)) {
+        if (value === null) delete block[field];
+        else block[field] = value;
+      }
+      llm.claude_cli = block;
+    }
     next.llm = llm;
   }
   if (request.intervals !== undefined) {

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -2958,6 +2958,58 @@ describe("local coach composition", () => {
     await lifecycle.close();
   });
 
+  it("forwards a claude-cli runtime block into the resolved and persisted configuration", async () => {
+    const home = await freshHome();
+    const initial = config(home);
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    await lifecycle.operations.configureRuntime({
+      llm: {
+        provider: "claude-cli",
+        model: "sonnet",
+        claude_cli: {
+          enabled: true,
+          binary_path: "/synthetic/bin/claude",
+          billing: "api-key",
+        },
+      },
+    });
+
+    const persisted = parseYaml(
+      await readFile(join(home.configDir, "config.yaml"), "utf8"),
+    ) as Record<string, Record<string, unknown>>;
+    expect(persisted.llm!.claude_cli).toEqual({
+      enabled: true,
+      binary_path: "/synthetic/bin/claude",
+      billing: "api-key",
+    });
+    expect(loadConfig(home.configDir).llm).toMatchObject({
+      provider: "claude-cli",
+      model: "sonnet",
+      claudeCli: {
+        enabled: true,
+        binaryPath: "/synthetic/bin/claude",
+        billing: "api-key",
+      },
+    });
+    await lifecycle.close();
+  });
+
   it("starts and snapshots the Desktop seeded blank athlete ID", async () => {
     const home = await freshHome();
     const initial = config(home, { apiKey: "", athleteId: "" });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -193,6 +193,8 @@ export { createTelegramBot, notifyUpdate } from "./channels/telegram.js";
 export {
   CONFIG_DIR,
   CONFIG_FILE,
+  claudeCliDisabledByEnvironment,
+  claudeCliPatchFrom,
   loadConfig,
   loadConfigFromYaml,
   readConfigYaml,
@@ -213,6 +215,9 @@ export {
   resolveRuntimeConfig,
 } from "./runtime-config.js";
 export type {
+  ClaudeCliBilling,
+  ClaudeCliRuntimeConfigPatch,
+  ClaudeCliRuntimeSettings,
   EffectiveRuntimeConfig,
   LlmModelCatalogueEntry,
   LlmModelOption,
@@ -220,6 +225,21 @@ export type {
   RuntimeConfigPatch,
   RuntimeConfigResolverOptions,
 } from "./runtime-config.js";
+export { CLAUDE_CLI_DISABLED_MESSAGE } from "./runtime-config.js";
+export {
+  ClaudeCliConfigError,
+  ensureClaudeCliReady,
+  invalidateClaudeAccountProbeCache,
+} from "@enduragent/engine";
+export type {
+  ClaudeAccountClass,
+  ClaudeAccountProbeResult,
+  ClaudeCliConfigErrorKind,
+  ClaudeCliReadiness,
+  EnsureClaudeCliReadyDeps,
+  EnsureClaudeCliReadyInput,
+  ProbeClaudeAccountInput,
+} from "@enduragent/engine";
 export {
   createPlatformAthleteDataReader,
   createPlatformCalendarMutations,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,46 +751,6 @@ packages:
     resolution: {integrity: sha512-/ngMKqKdL9dSlY/eQ3NFDzzFyw0Hix+cbFFlyuKEKcOgpHdBt/spKUvX/i0wGrDLFPYJeVvv3N0j92LxWRL7yQ==}
     engines: {node: '>=18'}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.220':
-    resolution: {integrity: sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.220':
-    resolution: {integrity: sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.220':
-    resolution: {integrity: sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.220':
-    resolution: {integrity: sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.220':
-    resolution: {integrity: sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.220':
-    resolution: {integrity: sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==}
-    cpu: [x64]
-    os: [linux]
-
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.220':
-    resolution: {integrity: sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.220':
-    resolution: {integrity: sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==}
-    cpu: [x64]
-    os: [win32]
-
   '@anthropic-ai/claude-agent-sdk@0.3.220':
     resolution: {integrity: sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==}
     engines: {node: '>=18.0.0'}
@@ -4492,6 +4452,16 @@ packages:
       use-sync-external-store:
         optional: true
 
+ignoredOptionalDependencies:
+  - '@anthropic-ai/claude-agent-sdk-darwin-arm64'
+  - '@anthropic-ai/claude-agent-sdk-darwin-x64'
+  - '@anthropic-ai/claude-agent-sdk-linux-arm64'
+  - '@anthropic-ai/claude-agent-sdk-linux-arm64-musl'
+  - '@anthropic-ai/claude-agent-sdk-linux-x64'
+  - '@anthropic-ai/claude-agent-sdk-linux-x64-musl'
+  - '@anthropic-ai/claude-agent-sdk-win32-arm64'
+  - '@anthropic-ai/claude-agent-sdk-win32-x64'
+
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
@@ -4555,44 +4525,11 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.220':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.220':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.220':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.220':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.220':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.220':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.220':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.220':
-    optional: true
-
   '@anthropic-ai/claude-agent-sdk@0.3.220(@anthropic-ai/sdk@0.115.0(zod@4.4.1))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.1))(zod@4.4.1)':
     dependencies:
       '@anthropic-ai/sdk': 0.115.0(zod@4.4.1)
       '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.1)
       zod: 4.4.1
-    optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.220
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.220
 
   '@anthropic-ai/sdk@0.115.0(zod@4.4.1)':
     dependencies:


### PR DESCRIPTION
Third PR of the Claude subscription lane (follows #479, #480): the desktop surface. After this PR the lane is fully usable from the desktop app — detected, labeled with the signed-in identity, selectable, and honestly rendered in every refusal state.

## Status controller + IPC

- `claude-cli-status.ts`: detection-only controller modeled on the ChatGPT auth controller — no login flow, no credential storage, no token ever read or logged. Delegates to the engine's cached probe (5-minute TTL keyed on binary + config dir + cwd); `recheck()` busts the cache and re-probes; the settings credentials surface busts it on open.
- Status payload is a closed six-state union (`ready`, `ready-api-key`, `absent-binary`, `not-logged-in`, `api-key-token`, `disabled`) with identity fields; preload parsers are exact-key, and all four pinned bridge-key lists (preload test, electron smoke, two integration pins) stay byte-identical.
- Kill-switch eligibility is re-evaluated on every `status()` call, so a mid-session flag flip renders `disabled` on the next fetch without a restart; selecting the provider routes through a dedicated keyless selection parser instead of the vault (which never sees this provider).
- Closes the two seams left by #480: the `claude_cli` RPC block now forwards into runtime resolution (and persists back only the fields a request carried), and renderer readiness is probe-driven instead of hard-false.

## Onboarding lane + settings row

- `ClaudeCliLane` in the setup wizard: badge, identity line, refusal detail, and a "Check again" button — no OAuth, no credential field. Identity strings render exactly per spec with graceful fallbacks (never "Claude undefined subscription"); `ready-api-key` always renders the API-key billing line, never as a subscription.
- Settings gets the non-credential status row (provider "Claude subscription", kind "Claude Code CLI") — no secret exists to show.
- Notional spend copy: subscription-lane usage renders as "would have cost $X on the API" and can never produce the cap-reached message (display half of the accrual exclusion shipped in #479).
- The wizard's probe is fire-and-forget with a checking state so Setup never blocks on a CLI spawn.

## Packaging (vendored-CLI exclusion)

- The Agent SDK's vendored CLI platform packages are excluded at the dependency layer (`pnpm.ignoredOptionalDependencies` for all eight platform packages — the ~256 MB vendored binary is no longer even resolved) plus an electron-builder exclusion as belt-and-braces.
- `verify-package-layout` now fails any packaged path matching a vendored CLI (platform package, vendor tree, `cli.js`, bare `claude` binary) across asar + external + unpacked trees, with a negative fixture proving the SDK proper stays packageable.
- Verified on the real packaged app: layout verification green, packaged self-test 602/602 parity + 84/84 differential with the new bridge methods exposed.

## Verification

- Full root suite green (6,832 tests), root `pnpm check` clean, replay suite 11/11 plus self-test, desktop 692/692, renderer suites green.
- The third commit fixes a pre-existing packaged-self-test harness defect (ad-hoc `identity: '-'` builds refused to launch under hardened-runtime library validation — dyld, before any app code). The fix passes `hardenedRuntime=false` only to the ad-hoc harness build; the release path builds its own config with hardened runtime + entitlements and is unaffected.

## Notes for review

- A probe timeout currently renders the not-signed-in copy on desktop (the six-state payload has no timeout member; the CLI wizard does distinguish it). Follow-up candidate if slow first launches show up in practice.
- No periodic status poll: a kill-switch flip renders on the next fetch (wizard open, Check again, settings open). The without-restart property holds via per-call eligibility evaluation.
- Renderer refusal copy paraphrases the CLI taxonomy strings (drops the yaml-key pointer, which is meaningless in the desktop UI).
