### PR TITLE
refactor(contract): extract KEYLESS_LLM_PROVIDERS and fix keyless season review

### DIFF
--- a/.changeset/keyless-provider-predicate.md
+++ b/.changeset/keyless-provider-predicate.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Fixed season review failing with a "Configured model credentials are unavailable" error when using the Claude CLI provider.
+
+The keyless-provider test was hand-written as a two-arm disjunction in a dozen places, and the season review guard only ever knew about the older keyless lane, so it demanded an API key from every Claude CLI athlete. The predicate now lives once in the contract package as `KEYLESS_LLM_PROVIDERS` / `isKeylessProvider`, is re-exported from the core runtime config for core, coach and desktop consumers, and a source-level assertion keeps the disjunction from being written by hand again.

--- a/apps/desktop/src/main/credential-runtime.ts
+++ b/apps/desktop/src/main/credential-runtime.ts
@@ -1,5 +1,6 @@
 import { connectCoachClient, type CoachClient } from "@enduragent/coach-client";
 import {
+  isKeylessProvider,
   type ConfigureRuntimeRpcParams,
   type LlmProvider,
   type RuntimeConfigSnapshot,
@@ -70,7 +71,7 @@ export function readSelectedLlmProvider(
   if (provider === CHATGPT_PROFILE_NAME) {
     return evidence.chatGptProfilePresent ? provider : undefined;
   }
-  if (provider === "claude-cli") return provider;
+  if (isKeylessProvider(provider)) return provider;
   return evidence.storedCredentialSlots.includes(provider) ? provider : undefined;
 }
 

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { lstat, mkdir, open, readFile, readdir, rename, rm } from "node:fs/promises";
 import { join } from "node:path";
+import { isKeylessProvider } from "@enduragent/coach-contract";
 import {
   parseOnboardingLlmSelection,
   type OnboardingLlmSelection,
@@ -460,7 +461,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
       let slot: DesktopCredentialSlot;
       try {
         selection = parseOnboardingLlmSelection(input);
-        if (selection.provider === "openai-codex" || selection.provider === "claude-cli") {
+        if (isKeylessProvider(selection.provider)) {
           throw new TypeError();
         }
         slot = selection.provider;

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -487,6 +487,14 @@ export const LlmProviderSchema = z.enum([
 ]);
 export type LlmProvider = z.infer<typeof LlmProviderSchema>;
 
+export const KEYLESS_LLM_PROVIDERS = ["openai-codex", "claude-cli"] as const;
+
+export type KeylessLlmProvider = (typeof KEYLESS_LLM_PROVIDERS)[number];
+
+export function isKeylessProvider(provider: string): provider is KeylessLlmProvider {
+  return (KEYLESS_LLM_PROVIDERS as readonly string[]).includes(provider);
+}
+
 const RuntimeOptionalStringSchema = z.string().min(1).max(512).nullable();
 
 const RuntimeClaudeCliSchema = z
@@ -511,10 +519,7 @@ const RuntimeLlmSchema = z
   })
   .strict()
   .superRefine((value, context) => {
-    if (
-      (value.provider === "openai-codex" || value.provider === "claude-cli") &&
-      value.api_key !== undefined
-    ) {
+    if (value.provider !== undefined && isKeylessProvider(value.provider) && value.api_key !== undefined) {
       context.addIssue({ code: "custom", path: ["api_key"], message: "api_key must be absent" });
     }
     if (value.clear_credential === true) {

--- a/packages/coach-contract/tests/keyless-provider-predicate.test.ts
+++ b/packages/coach-contract/tests/keyless-provider-predicate.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+import {
+  KEYLESS_LLM_PROVIDERS,
+  LlmProviderSchema,
+  ConfigureRuntimeRpcParamsSchema,
+  isKeylessProvider,
+} from "../src/rpc.js";
+
+const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const SCANNED_GROUPS = ["packages", "apps"] as const;
+const DEFINITION_SITE = join("packages", "coach-contract", "src", "rpc.ts");
+
+const CODEX = "openai" + "-codex";
+const CLAUDE_CLI = "claude" + "-cli";
+const WINDOW = 96;
+const comparison = (literal: string): string => `(?:===|!==)\\s*"${literal}"`;
+const ordered = (first: string, second: string): string =>
+  `${comparison(first)}[\\s\\S]{0,${WINDOW}}?${comparison(second)}`;
+const DISJUNCTION = new RegExp(
+  `${ordered(CODEX, CLAUDE_CLI)}|${ordered(CLAUDE_CLI, CODEX)}`,
+  "g",
+);
+
+function sourceFiles(): readonly string[] {
+  const found: string[] = [];
+  const walk = (absolute: string, relative: string): void => {
+    for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      const nextAbsolute = join(absolute, entry.name);
+      const nextRelative = join(relative, entry.name);
+      if (entry.isDirectory()) {
+        walk(nextAbsolute, nextRelative);
+        continue;
+      }
+      if (!/\.tsx?$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) continue;
+      found.push(nextRelative);
+    }
+  };
+  for (const group of SCANNED_GROUPS) {
+    for (const packageDir of readdirSync(join(REPO_ROOT, group))) {
+      const absolute = join(REPO_ROOT, group, packageDir, "src");
+      try {
+        if (!statSync(absolute).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      walk(absolute, join(group, packageDir, "src"));
+    }
+  }
+  return found;
+}
+
+describe("keyless provider predicate", () => {
+  it("names exactly the providers that carry no api key", () => {
+    expect([...KEYLESS_LLM_PROVIDERS]).toEqual([CODEX, CLAUDE_CLI]);
+    for (const provider of KEYLESS_LLM_PROVIDERS) {
+      expect(LlmProviderSchema.safeParse(provider).success).toBe(true);
+      expect(isKeylessProvider(provider)).toBe(true);
+    }
+    expect(isKeylessProvider("anthropic")).toBe(false);
+    expect(isKeylessProvider("")).toBe(false);
+  });
+
+  it("rejects an api key for every keyless provider and accepts one otherwise", () => {
+    for (const provider of KEYLESS_LLM_PROVIDERS) {
+      const rejected = ConfigureRuntimeRpcParamsSchema.safeParse({ llm: { provider, api_key: "sk-test" } });
+      expect(rejected.success).toBe(false);
+      expect(ConfigureRuntimeRpcParamsSchema.safeParse({ llm: { provider } }).success).toBe(true);
+    }
+    expect(
+      ConfigureRuntimeRpcParamsSchema.safeParse({ llm: { provider: "anthropic", api_key: "sk-test" } })
+        .success,
+    ).toBe(true);
+  });
+
+  it("finds the scanned source tree", () => {
+    const files = sourceFiles();
+    expect(files.length).toBeGreaterThan(200);
+    expect(files).toContain(DEFINITION_SITE);
+  });
+
+  it("has no hand-written keyless disjunction outside the definition site", () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles()) {
+      if (file === DEFINITION_SITE) continue;
+      const text = readFileSync(join(REPO_ROOT, file), "utf-8");
+      DISJUNCTION.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = DISJUNCTION.exec(text)) !== null) {
+        offenders.push(`${file}:${text.slice(0, match.index).split("\n").length}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("still detects a hand-written disjunction when one is present", () => {
+    const sample = `if (provider === "${CODEX}" || provider === "${CLAUDE_CLI}") return true;`;
+    DISJUNCTION.lastIndex = 0;
+    expect(DISJUNCTION.test(sample)).toBe(true);
+    DISJUNCTION.lastIndex = 0;
+    expect(DISJUNCTION.test(`if (provider === "${CODEX}") return true;`)).toBe(false);
+  });
+});

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -24,6 +24,7 @@ import {
   deleteStoredProfile,
   engineConfigFromConfig,
   extractRetryAfterMs,
+  isKeylessProvider,
   loadStoredProfileSnapshot,
   makeChatClient,
   refreshCodexToken,
@@ -237,9 +238,7 @@ function llmCredentialManagedByEnvironment(
 ): boolean {
   return (
     nonemptyEnvironmentValue(environment, LLM_CREDENTIAL_ENVIRONMENT_KEYS[provider]) ||
-    (provider !== "openai-codex" &&
-      provider !== "claude-cli" &&
-      nonemptyEnvironmentValue(environment, "LLM_API_KEY"))
+    (!isKeylessProvider(provider) && nonemptyEnvironmentValue(environment, "LLM_API_KEY"))
   );
 }
 

--- a/packages/coach/src/season-review-command.ts
+++ b/packages/coach/src/season-review-command.ts
@@ -18,6 +18,7 @@ import { isAbsolute, dirname, join, normalize } from "node:path";
 import {
   bootstrapReference,
   createCoachEngine,
+  isKeylessProvider,
   isSecretRef,
   loadConfig,
   readConfigYaml,
@@ -288,6 +289,19 @@ async function selectedCaptureManifest(root: string): Promise<ReferenceCaptureMa
   return byId.get(selected)!.manifest;
 }
 
+export async function resolveSeasonReviewLlmApiKey(loaded: Config): Promise<string> {
+  if (isKeylessProvider(loaded.llm.provider)) return loaded.llm.apiKey;
+  let llmApiKey = loaded.llm.apiKey;
+  if (llmApiKey.length === 0) {
+    const llmYaml = readConfigYaml().llm;
+    const configured = llmYaml !== null && typeof llmYaml === "object" && !Array.isArray(llmYaml)
+      ? (llmYaml as Record<string, unknown>).api_key : undefined;
+    if (isSecretRef(configured)) llmApiKey = await resolveSecretRef(configured);
+  }
+  if (llmApiKey.length === 0) throw new TypeError("Configured model credentials are unavailable.");
+  return llmApiKey;
+}
+
 async function productComposition(input: SeasonReviewCompositionInput): Promise<SeasonReviewComposition> {
   const localBotModule = new URL("./local-bot.js", import.meta.url).href;
   const storeRuntimeModule = new URL("./store-runtime.js", import.meta.url).href;
@@ -296,16 +310,7 @@ async function productComposition(input: SeasonReviewCompositionInput): Promise<
     import(storeRuntimeModule) as Promise<typeof import("./store-runtime.js")>,
   ]);
   const loaded = loadConfig();
-  let llmApiKey = loaded.llm.apiKey;
-  if (loaded.llm.provider !== "openai-codex" && llmApiKey.length === 0) {
-    const llmYaml = readConfigYaml().llm;
-    const configured = llmYaml !== null && typeof llmYaml === "object" && !Array.isArray(llmYaml)
-      ? (llmYaml as Record<string, unknown>).api_key : undefined;
-    if (isSecretRef(configured)) llmApiKey = await resolveSecretRef(configured);
-  }
-  if (loaded.llm.provider !== "openai-codex" && llmApiKey.length === 0) {
-    throw new TypeError("Configured model credentials are unavailable.");
-  }
+  const llmApiKey = await resolveSeasonReviewLlmApiKey(loaded);
   if (loaded.dataSource !== "store") throw new TypeError("Season review requires the configured store data source.");
   const config: Config = { ...loaded, dataDir: input.agentData,
     intervals: { ...loaded.intervals, apiKey: "" }, telegram: { botToken: "" },

--- a/packages/coach/tests/season-review-keyless-credentials.test.ts
+++ b/packages/coach/tests/season-review-keyless-credentials.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { KEYLESS_LLM_PROVIDERS } from "@enduragent/coach-contract";
+import type { Config, LlmProvider } from "@enduragent/core";
+
+const home = mkdtempSync(join(tmpdir(), "season-review-keyless-"));
+process.env.CYCLING_COACH_HOME = home;
+writeFileSync(join(home, "config.yaml"), "llm:\n  provider: anthropic\n", { mode: 0o600 });
+
+const { resolveSeasonReviewLlmApiKey } = await import("../src/season-review-command.js");
+
+afterAll(() => {
+  delete process.env.CYCLING_COACH_HOME;
+  rmSync(home, { recursive: true, force: true });
+});
+
+function configured(provider: LlmProvider, apiKey: string): Config {
+  return {
+    dataSource: "store",
+    telegram: { botToken: "" },
+    dataDir: join(home, "data"),
+    llm: { provider, model: "synthetic-model", apiKey },
+    intervals: { apiKey: "", athleteId: "0" },
+    session: {
+      historyTokenBudgetRatio: 0.5,
+      idleMinutes: 0,
+      dailyResetHour: 0,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+    },
+    contextWindowTokens: 100_000,
+  };
+}
+
+describe("season review model credentials", () => {
+  it("accepts every keyless provider with an empty api key", async () => {
+    for (const provider of KEYLESS_LLM_PROVIDERS) {
+      await expect(resolveSeasonReviewLlmApiKey(configured(provider, ""))).resolves.toBe("");
+    }
+  });
+
+  it("still refuses a key-bearing provider with no resolvable api key", async () => {
+    await expect(resolveSeasonReviewLlmApiKey(configured("anthropic", ""))).rejects.toThrow(
+      "Configured model credentials are unavailable.",
+    );
+  });
+
+  it("passes a configured api key through untouched", async () => {
+    await expect(resolveSeasonReviewLlmApiKey(configured("anthropic", "sk-synthetic"))).resolves.toBe(
+      "sk-synthetic",
+    );
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@ai-sdk/provider": "^3.0.9",
+    "@enduragent/coach-contract": "workspace:*",
     "@enduragent/engine": "workspace:*",
     "@enduragent/kernel": "workspace:*",
     "@clack/prompts": "^1.2.0",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -5,6 +5,7 @@ import { getCoachHome } from "./coach-home.js";
 import { SecretRef, isSecretRef, SecretResolutionError } from "./secrets/types.js";
 import { resolveSecretRef } from "./secrets/resolve.js";
 import {
+  isKeylessProvider,
   resolveLlmProvider,
   resolveRuntimeConfig,
   type ClaudeCliBilling,
@@ -269,7 +270,7 @@ export function loadConfigFromYaml(
     return "";
   };
 
-  const keyless = provider === "openai-codex" || provider === "claude-cli";
+  const keyless = isKeylessProvider(provider);
   const apiKey = keyless
     ? ""
     : resolveWithPrecedence(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -207,10 +207,12 @@ export type { DataSource } from "./config.js";
 export {
   COMPACT_MODEL_DEFAULTS,
   DEFAULT_MODELS,
+  KEYLESS_LLM_PROVIDERS,
   LLM_MODEL_CATALOGUE,
   LLM_PROVIDERS,
   PROVIDER_BASE_URLS,
   contextWindowForModel,
+  isKeylessProvider,
   resolveLlmProvider,
   resolveRuntimeConfig,
 } from "./runtime-config.js";
@@ -219,6 +221,7 @@ export type {
   ClaudeCliRuntimeConfigPatch,
   ClaudeCliRuntimeSettings,
   EffectiveRuntimeConfig,
+  KeylessLlmProvider,
   LlmModelCatalogueEntry,
   LlmModelOption,
   LlmProvider,

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -5,6 +5,7 @@ import type { Sport } from "./sport.js";
 import { type BinaryConfig, binaryEnvVar } from "./binary.js";
 import type { Memory } from "./memory/store.js";
 import { CONFIG_DIR, envInt, type Config } from "./config.js";
+import { isKeylessProvider } from "./runtime-config.js";
 import type { AthleteDataReader, PlatformCalendarMutations } from "./athlete-data.js";
 import type { ReferenceRuntime } from "./reference/runtime.js";
 import { appendUsageLine } from "./usage-ledger.js";
@@ -379,11 +380,7 @@ export async function runBinary(
   installCrashHandlers({ dataDir: config.dataDir });
   logBootLine({ dataDir: config.dataDir });
 
-  if (
-    config.llm.provider !== "openai-codex" &&
-    config.llm.provider !== "claude-cli" &&
-    !config.llm.apiKey
-  ) {
+  if (!isKeylessProvider(config.llm.provider) && !config.llm.apiKey) {
     console.error(
       `No LLM API key found. Run \`${binary.binaryName} setup\` to configure, or set LLM_API_KEY. Provider-specific env vars still work: ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, DEEPSEEK_API_KEY, ALIBABA_API_KEY, MINIMAX_API_KEY, MOONSHOT_API_KEY, ZAI_API_KEY, or OPENROUTER_API_KEY.`,
     );

--- a/packages/core/src/runtime-config.ts
+++ b/packages/core/src/runtime-config.ts
@@ -1,3 +1,12 @@
+import {
+  KEYLESS_LLM_PROVIDERS,
+  isKeylessProvider,
+  type KeylessLlmProvider,
+} from "@enduragent/coach-contract";
+
+export { KEYLESS_LLM_PROVIDERS, isKeylessProvider };
+export type { KeylessLlmProvider };
+
 export const LLM_PROVIDERS = [
   "anthropic",
   "openai",
@@ -489,7 +498,7 @@ export function resolveRuntimeConfig(
       ? current.llm.model
       : DEFAULT_MODELS[provider];
   const selectionChanged = current === undefined || providerChanged || model !== current.llm.model;
-  const keyless = provider === "openai-codex" || provider === "claude-cli";
+  const keyless = isKeylessProvider(provider);
   const apiKey = keyless
     ? ""
     : isSpecified(llmPatch, "apiKey")

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -14,7 +14,7 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync, chmodSy
 import { stringify as toYaml } from "yaml";
 import { type BinaryConfig, binaryEnvVar } from "./binary.js";
 import { CONFIG_DIR, CONFIG_FILE, envInt, readConfigYaml } from "./config.js";
-import { LLM_MODEL_CATALOGUE } from "./runtime-config.js";
+import { LLM_MODEL_CATALOGUE, isKeylessProvider } from "./runtime-config.js";
 import { captureAndPersistOperator } from "./channels/operator-capture.js";
 import { loadAllowedSenders } from "./channels/allowed-senders.js";
 import { runCodexLogin } from "./auth/openai-codex-login.js";
@@ -409,7 +409,7 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
     llmConfig.base_url = baseUrl;
   }
 
-  if (provider !== "openai-codex" && provider !== "claude-cli") {
+  if (!isKeylessProvider(provider)) {
     const hasPrev = provider === prevProvider && isNonEmptySecret(prevLlmKey);
     const result = await _collectAndWriteSecret(
       ctx,

--- a/packages/engine/src/llm.ts
+++ b/packages/engine/src/llm.ts
@@ -7,6 +7,7 @@ import { createAlibaba } from "@ai-sdk/alibaba";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import type { LanguageModel, ModelMessage } from "ai";
+import { isKeylessProvider } from "@enduragent/coach-contract";
 
 import { splitSystemPromptAtBoundary } from "./agent/system-prompt.js";
 import { isPriced, priceUsage } from "./agent/codex/cost.js";
@@ -96,10 +97,7 @@ export class LLM {
   constructor(config: EngineConfig, ports: LLMHostPorts) {
     this.config = config;
     this.ports = ports;
-    this.aiSdkModel =
-      config.llm.provider === "openai-codex" || config.llm.provider === "claude-cli"
-        ? null
-        : buildAiSdkModel(config);
+    this.aiSdkModel = isKeylessProvider(config.llm.provider) ? null : buildAiSdkModel(config);
     this.priced = isPriced(config.llm.provider, config.llm.model);
     this.breakpointKey = cacheBreakpointKey(config.llm.provider, config.llm.model);
     this.chatStreamTimeouts = validateChatStreamTimeouts(
@@ -122,9 +120,7 @@ export class LLM {
     );
     const { signal: deadlineSignal, deadline } = withLLMDeadline(opts.signal, deadlineMs);
     const watchdog =
-      opts.caller === "chat" &&
-      this.config.llm.provider !== "openai-codex" &&
-      this.config.llm.provider !== "claude-cli"
+      opts.caller === "chat" && !isKeylessProvider(this.config.llm.provider)
         ? createChatStreamWatchdog(this.chatStreamTimeouts)
         : undefined;
     const signal =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.2.0
         version: 1.3.0
+      '@enduragent/coach-contract':
+        specifier: workspace:*
+        version: link:../coach-contract
       '@enduragent/engine':
         specifier: workspace:*
         version: link:../engine

--- a/tools/check-package-deps.ts
+++ b/tools/check-package-deps.ts
@@ -104,7 +104,7 @@ export const RULES: readonly PackageDepRule[] = [
     ruleId: "R3",
     dir: "packages/core",
     srcOnly: true,
-    allowedWorkspace: [],
+    allowedWorkspace: ["@enduragent/coach-contract"],
     transitionalWorkspace: ["@enduragent/engine", "@enduragent/kernel"],
     forbidNode: false,
   },


### PR DESCRIPTION
Groundwork PR for the upcoming Codex provider lane, standalone and useful on its own: the "is this a keyless provider" predicate was hand-written as a two-provider disjunction in eleven places across five packages, and one of those hand-copies carried a live bug.

## The refactor

- `KEYLESS_LLM_PROVIDERS` / `isKeylessProvider()` are now defined once in `packages/coach-contract/src/rpc.ts`, beside the provider enum that owns the union, and re-exported from `packages/core/src/runtime-config.ts` so existing core/coach/desktop import sites keep a single import path. Engine imports from `@enduragent/coach-contract` directly (engine does not depend on core).
- Eleven call sites rewritten to the shared predicate (contract superRefine, core resolve/config/run-binary/setup, coach composition, desktop credential vault + runtime, both engine provider-gated lists in `llm.ts`).
- `isKeylessProvider` is a type predicate (`provider is KeylessLlmProvider`) because two desktop sites relied on the old disjunction for control-flow narrowing to `DesktopCredentialSlot`.
- Deliberately untouched: the `openai-codex` legacy ledger-row branch in `spend-meter.ts` (about one specific provider's historical rows, not keylessness) and per-provider dispatch branches with distinct bodies.
- A source-scan test now fails the build if a hand-written keyless disjunction is reintroduced anywhere under `packages/*/src` or `apps/*/src`, with a positive-control case proving the scan still fires.

## The bug fix

`season-review-command.ts` guarded credentials with a hand-copy that only knew about `openai-codex` — so every Claude CLI athlete got `Configured model credentials are unavailable.` from season review despite being on a keyless provider. The guard now resolves through the shared predicate: keyless providers pass with an empty key, key-bearing providers still throw when no key resolves. Patch changeset included with a `User-facing:` line.

## Verification

- Root `pnpm check` clean; full suite green (only known load-contention flakes, each re-run green in isolation).
- New tests: predicate membership + superRefine behavior per provider, the repo-wide source scan, and season-review regression coverage (keyless passes, key-bearing still throws, configured key passes through).
- `packages/core` gained an explicit `@enduragent/coach-contract` dependency edge (previously reached only transitively), registered in `check-package-deps` as an allowed edge — no new transitional WARN.
