### PR TITLE
feat: register the flag-off codex-agent provider

### DIFF
--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -111,7 +111,8 @@ type DesktopCredentialId = DesktopCredentialSlot | "openai-codex";
 type LlmProvider =
   | Exclude<DesktopCredentialSlot, "intervals-icu">
   | "openai-codex"
-  | "claude-cli";
+  | "claude-cli"
+  | "codex-agent";
 
 interface OnboardingLlmModelOption {
   readonly value: string;

--- a/apps/desktop-renderer/src/onboarding/constants.ts
+++ b/apps/desktop-renderer/src/onboarding/constants.ts
@@ -45,6 +45,7 @@ export const ONBOARDING_LLM_PROVIDER_LABELS = {
   google: "Google",
   "openai-codex": "ChatGPT subscription",
   "claude-cli": "Claude subscription",
+  "codex-agent": "Codex agent (experimental)",
   deepseek: "DeepSeek",
   qwen: "Qwen",
   minimax: "MiniMax",

--- a/apps/desktop-renderer/src/onboarding/controller.ts
+++ b/apps/desktop-renderer/src/onboarding/controller.ts
@@ -195,6 +195,7 @@ export function createOnboardingController(
     if (provider === "claude-cli") {
       return state.claudeCliState === "ready" || state.claudeCliState === "ready-api-key";
     }
+    if (provider === "codex-agent") return false;
     return status(provider).state === "configured" && status(provider).runtimeState === "active";
   };
 

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -18,11 +18,11 @@ export interface CredentialSettingsEntry {
   readonly runtimeState: "active" | "stored-inactive" | "failed";
 }
 
-export const NON_CREDENTIAL_PROVIDERS = ["claude-cli"] as const;
+export const NON_CREDENTIAL_PROVIDERS = ["claude-cli", "codex-agent"] as const;
 
 export type NonCredentialProviderId = (typeof NON_CREDENTIAL_PROVIDERS)[number];
 
-export type NonCredentialProviderKind = "Claude Code CLI";
+export type NonCredentialProviderKind = "Claude Code CLI" | "Codex CLI";
 
 export interface ProviderStatusEntry {
   readonly provider: NonCredentialProviderId;
@@ -39,6 +39,11 @@ const NON_CREDENTIAL_PROVIDER_ROWS: Readonly<
     provider: "claude-cli",
     label: "Claude subscription",
     kind: "Claude Code CLI",
+  },
+  "codex-agent": {
+    provider: "codex-agent",
+    label: "Codex agent",
+    kind: "Codex CLI",
   },
 };
 
@@ -196,6 +201,9 @@ export function providerStatusesFrom(
 ): readonly ProviderStatusEntry[] {
   const provider = runtime.llm.provider;
   if (!isNonCredentialProvider(provider)) return [];
+  if (provider === "codex-agent") {
+    return [{ ...NON_CREDENTIAL_PROVIDER_ROWS[provider], state: null, identity: null }];
+  }
   const state = claudeCli?.state ?? null;
   const identity = claudeCli === null ? null : claudeCliIdentityLine(claudeCli);
   return [

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -44,6 +44,7 @@ const LLM_PROVIDER_ORDER = [
   "google",
   "openai-codex",
   "claude-cli",
+  "codex-agent",
   "deepseek",
   "qwen",
   "minimax",
@@ -52,6 +53,10 @@ const LLM_PROVIDER_ORDER = [
   "openrouter",
 ] as const;
 const LLM_PROVIDERS = new Set<string>(LLM_PROVIDER_ORDER);
+const OFF_CATALOGUE_LLM_PROVIDERS = new Set<string>(["codex-agent"]);
+const LLM_CATALOGUE_PROVIDER_ORDER = LLM_PROVIDER_ORDER.filter(
+  (provider) => !OFF_CATALOGUE_LLM_PROVIDERS.has(provider),
+);
 const DEFAULT_ENDPOINT_PROVIDERS = new Set([
   "deepseek",
   "qwen",
@@ -627,14 +632,14 @@ function parseLlmConfiguration(value: unknown): unknown {
     !exactKeys(value, ["schemaVersion", "providers", "active"]) ||
     value.schemaVersion !== 1 ||
     !Array.isArray(value.providers) ||
-    value.providers.length !== LLM_PROVIDER_ORDER.length
+    value.providers.length !== LLM_CATALOGUE_PROVIDER_ORDER.length
   ) {
     throw new TypeError();
   }
   const providers = value.providers.map((entry, index) => {
     if (
       !record(entry) ||
-      entry.provider !== LLM_PROVIDER_ORDER[index] ||
+      entry.provider !== LLM_CATALOGUE_PROVIDER_ORDER[index] ||
       typeof entry.provider !== "string"
     ) {
       throw new TypeError();

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -426,6 +426,7 @@ describe("desktop onboarding IPC", () => {
       "zai",
       "openrouter",
     ]);
+    expect(result.providers.map((provider) => provider.provider)).not.toContain("codex-agent");
     expect(result.active).toEqual({
       provider: "anthropic",
       model: "athlete-selected-model",

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { LLM_MODEL_CATALOGUE } from "../../../packages/core/src/runtime-config.js";
+
 const mocks = vi.hoisted(() => {
   const exposed: Record<string, unknown> = {};
   class FakeAnchor {
@@ -88,6 +90,7 @@ const providerOrder = [
   "google",
   "openai-codex",
   "claude-cli",
+  "codex-agent",
   "deepseek",
   "qwen",
   "minimax",
@@ -95,6 +98,8 @@ const providerOrder = [
   "zai",
   "openrouter",
 ] as const;
+
+const catalogueProviderOrder = providerOrder.filter((provider) => provider !== "codex-agent");
 
 const defaultEndpointProviders = new Set([
   "deepseek",
@@ -105,10 +110,28 @@ const defaultEndpointProviders = new Set([
   "openrouter",
 ]);
 
+function pinnedPreloadProviderOrder(): string[] {
+  const source = readFileSync(new URL("../src/preload/index.ts", import.meta.url), "utf8");
+  const open = source.indexOf("const LLM_PROVIDER_ORDER = [");
+  if (open === -1) throw new Error("preload provider order missing");
+  const close = source.indexOf("] as const;", open);
+  if (close === -1) throw new Error("preload provider order unterminated");
+  return [...source.slice(open, close).matchAll(/"([^"]+)"/g)].map((match) => match[1]!);
+}
+
+function pinnedPreloadOffCatalogueProviders(): string[] {
+  const source = readFileSync(new URL("../src/preload/index.ts", import.meta.url), "utf8");
+  const open = source.indexOf("const OFF_CATALOGUE_LLM_PROVIDERS = new Set<string>([");
+  if (open === -1) throw new Error("preload off-catalogue set missing");
+  const close = source.indexOf("]);", open);
+  if (close === -1) throw new Error("preload off-catalogue set unterminated");
+  return [...source.slice(open, close).matchAll(/"([^"]+)"/g)].map((match) => match[1]!);
+}
+
 function llmConfiguration() {
   return {
     schemaVersion: 1,
-    providers: providerOrder.map((provider) => {
+    providers: catalogueProviderOrder.map((provider) => {
       const defaultModel = `${provider}-default`;
       return {
         provider,
@@ -727,6 +750,30 @@ describe("desktop preload ChatGPT auth", () => {
     });
     await expect(bridge.deleteCredential({ credential: "anthropic" })).rejects.toBeInstanceOf(
       TypeError,
+    );
+  });
+
+  it("pins the provider union order and keeps the off-catalogue lane out of the catalogue payload", () => {
+    expect(pinnedPreloadProviderOrder()).toEqual([...providerOrder]);
+    expect(providerOrder.indexOf("codex-agent")).toBe(providerOrder.indexOf("claude-cli") + 1);
+    expect(catalogueProviderOrder).not.toContain("codex-agent");
+    expect(llmConfiguration().providers).toHaveLength(catalogueProviderOrder.length);
+  });
+
+  it("keeps the preload's off-catalogue set in step with the catalogue the payload is built from", () => {
+    const cataloguedProviders = LLM_MODEL_CATALOGUE.map((entry) => entry.provider);
+    const offCatalogue = pinnedPreloadOffCatalogueProviders();
+
+    expect(offCatalogue.length).toBeGreaterThan(0);
+    for (const provider of offCatalogue) {
+      expect(providerOrder).toContain(provider);
+      expect(cataloguedProviders).not.toContain(provider);
+    }
+    expect([...providerOrder].filter((provider) => !cataloguedProviders.includes(provider))).toEqual(
+      offCatalogue,
+    );
+    expect(cataloguedProviders).toEqual(
+      [...providerOrder].filter((provider) => !offCatalogue.includes(provider)),
     );
   });
 

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -478,6 +478,7 @@ export const LlmProviderSchema = z.enum([
   "google",
   "openai-codex",
   "claude-cli",
+  "codex-agent",
   "deepseek",
   "qwen",
   "minimax",
@@ -487,13 +488,19 @@ export const LlmProviderSchema = z.enum([
 ]);
 export type LlmProvider = z.infer<typeof LlmProviderSchema>;
 
-export const KEYLESS_LLM_PROVIDERS = ["openai-codex", "claude-cli"] as const;
+export const KEYLESS_LLM_PROVIDERS = ["openai-codex", "claude-cli", "codex-agent"] as const;
 
 export type KeylessLlmProvider = (typeof KEYLESS_LLM_PROVIDERS)[number];
 
 export function isKeylessProvider(provider: string): provider is KeylessLlmProvider {
   return (KEYLESS_LLM_PROVIDERS as readonly string[]).includes(provider);
 }
+
+export const CODEX_AGENT_DISABLED_MESSAGE =
+  "The Codex agent provider is not enabled on this instance (set llm.codex_agent.enabled: true in config.yaml). It is experimental and off by default.";
+
+export const CODEX_AGENT_WINDOWS_MESSAGE =
+  "The Codex agent provider is not supported on Windows yet (macOS and Linux only). Track the Windows lane in the project backlog.";
 
 const RuntimeOptionalStringSchema = z.string().min(1).max(512).nullable();
 
@@ -503,6 +510,14 @@ const RuntimeClaudeCliSchema = z
     binary_path: z.string().min(1).max(4_096).nullable().optional(),
     config_dir: z.string().min(1).max(4_096).nullable().optional(),
     billing: z.enum(["subscription", "api-key"]).optional(),
+  })
+  .strict();
+
+const RuntimeCodexAgentSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    binary_path: z.string().min(1).max(4_096).nullable().optional(),
+    reasoning_effort: z.enum(["low", "medium", "high", "ultra"]).optional(),
   })
   .strict();
 
@@ -516,6 +531,7 @@ const RuntimeLlmSchema = z
     flush_model: RuntimeOptionalStringSchema.optional(),
     compact_model: RuntimeOptionalStringSchema.optional(),
     claude_cli: RuntimeClaudeCliSchema.optional(),
+    codex_agent: RuntimeCodexAgentSchema.optional(),
   })
   .strict()
   .superRefine((value, context) => {

--- a/packages/coach-contract/tests/keyless-provider-predicate.test.ts
+++ b/packages/coach-contract/tests/keyless-provider-predicate.test.ts
@@ -16,6 +16,7 @@ const DEFINITION_SITE = join("packages", "coach-contract", "src", "rpc.ts");
 
 const CODEX = "openai" + "-codex";
 const CLAUDE_CLI = "claude" + "-cli";
+const CODEX_AGENT = "codex" + "-agent";
 const WINDOW = 96;
 const comparison = (literal: string): string => `(?:===|!==)\\s*"${literal}"`;
 const ordered = (first: string, second: string): string =>
@@ -56,7 +57,7 @@ function sourceFiles(): readonly string[] {
 
 describe("keyless provider predicate", () => {
   it("names exactly the providers that carry no api key", () => {
-    expect([...KEYLESS_LLM_PROVIDERS]).toEqual([CODEX, CLAUDE_CLI]);
+    expect([...KEYLESS_LLM_PROVIDERS]).toEqual([CODEX, CLAUDE_CLI, CODEX_AGENT]);
     for (const provider of KEYLESS_LLM_PROVIDERS) {
       expect(LlmProviderSchema.safeParse(provider).success).toBe(true);
       expect(isKeylessProvider(provider)).toBe(true);

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -789,6 +789,7 @@ describe("coach request and event projection", () => {
       "google",
       "openai-codex",
       "claude-cli",
+      "codex-agent",
       "deepseek",
       "qwen",
       "minimax",

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -32,6 +32,7 @@ import {
   resolveSecretRef,
   sessionConfigEnvironmentOwnership,
   type ClaudeCliRuntimeConfigPatch,
+  type CodexAgentRuntimeConfigPatch,
   type Config,
   type ConversationStorePort,
   type ReferenceRuntime,
@@ -175,6 +176,16 @@ function claudeCliPatch(
   };
 }
 
+function codexAgentPatch(
+  block: NonNullable<NonNullable<ConfigureRuntimeRpcParams["llm"]>["codex_agent"]>,
+): CodexAgentRuntimeConfigPatch {
+  return {
+    ...(block.enabled === undefined ? {} : { enabled: block.enabled }),
+    ...(block.binary_path === undefined ? {} : { binaryPath: block.binary_path }),
+    ...(block.reasoning_effort === undefined ? {} : { reasoningEffort: block.reasoning_effort }),
+  };
+}
+
 function runtimePatch(request: ConfigureRuntimeRpcParams, config: Config): RuntimeConfigPatch {
   return {
     ...(request.llm === undefined
@@ -193,6 +204,9 @@ function runtimePatch(request: ConfigureRuntimeRpcParams, config: Config): Runti
             ...(request.llm.claude_cli === undefined
               ? {}
               : { claudeCli: claudeCliPatch(request.llm.claude_cli) }),
+            ...(request.llm.codex_agent === undefined
+              ? {}
+              : { codexAgent: codexAgentPatch(request.llm.codex_agent) }),
           },
         }),
     ...(request.intervals === undefined
@@ -217,6 +231,7 @@ const LLM_CREDENTIAL_ENVIRONMENT_KEYS = {
   google: "GOOGLE_GENERATIVE_AI_API_KEY",
   "openai-codex": undefined,
   "claude-cli": undefined,
+  "codex-agent": undefined,
   deepseek: "DEEPSEEK_API_KEY",
   qwen: "ALIBABA_API_KEY",
   minimax: "MINIMAX_API_KEY",
@@ -326,6 +341,14 @@ function persistRuntimeConfig(
         else block[field] = value;
       }
       llm.claude_cli = block;
+    }
+    if (request.llm.codex_agent !== undefined) {
+      const block: Record<string, unknown> = isRecord(llm.codex_agent) ? { ...llm.codex_agent } : {};
+      for (const [field, value] of Object.entries(request.llm.codex_agent)) {
+        if (value === null) delete block[field];
+        else block[field] = value;
+      }
+      llm.codex_agent = block;
     }
     next.llm = llm;
   }

--- a/packages/core/src/agent/engine-host-adapter.ts
+++ b/packages/core/src/agent/engine-host-adapter.ts
@@ -43,20 +43,21 @@ export interface EngineHostAdapterOverrides {
 
 export function engineConfigFromConfig(config: Config): EngineConfig {
   const compactModel = config.llm.compactModel ?? config.llm.model;
-  const { claudeCli, ...llm } = config.llm;
+  const { claudeCli, codexAgent, ...llm } = config.llm;
   return Object.freeze({
     dataSource: config.dataSource,
-    llm: Object.freeze(
-      claudeCli === undefined
-        ? llm
+    llm: Object.freeze({
+      ...llm,
+      ...(claudeCli === undefined
+        ? {}
         : {
-            ...llm,
             claudeCli: Object.freeze({
               ...claudeCli,
               cursorStorePath: join(config.dataDir, "claude-cli-sessions.json"),
             }),
-          },
-    ),
+          }),
+      ...(codexAgent === undefined ? {} : { codexAgent: Object.freeze({ ...codexAgent }) }),
+    }),
     session: Object.freeze({ ...config.session }),
     contextWindowTokens: config.contextWindowTokens,
     compactContextWindowTokens:

--- a/packages/core/src/codex-agent-startup.ts
+++ b/packages/core/src/codex-agent-startup.ts
@@ -1,0 +1,80 @@
+import {
+  CodexAgentConfigError,
+  ensureCodexAgentReady,
+  type CodexAgentReadinessReport,
+  type CodexAgentReadinessResult,
+} from "@enduragent/engine";
+
+import {
+  CODEX_AGENT_DISABLED_MESSAGE,
+  CODEX_AGENT_WINDOWS_MESSAGE,
+  type CodexAgentRuntimeSettings,
+} from "./runtime-config.js";
+
+export interface CodexAgentStartupGateInput {
+  readonly settings: CodexAgentRuntimeSettings | undefined;
+  readonly model: string;
+}
+
+export interface CodexAgentStartupGateDeps {
+  readonly ensureReady?: typeof ensureCodexAgentReady;
+  readonly log?: (line: string) => void;
+  readonly refuse?: (message: string) => void;
+  readonly baseEnv?: NodeJS.ProcessEnv;
+  readonly platform?: NodeJS.Platform;
+}
+
+function refusalMessage(err: unknown): string {
+  if (err instanceof CodexAgentConfigError) return err.message;
+  const detail = err instanceof Error ? err.message : String(err);
+  return `Codex CLI startup check failed: ${detail}`;
+}
+
+export async function runCodexAgentStartupGate(
+  input: CodexAgentStartupGateInput,
+  deps: CodexAgentStartupGateDeps = {},
+): Promise<CodexAgentReadinessReport | null> {
+  const ensureReady = deps.ensureReady ?? ensureCodexAgentReady;
+  const log = deps.log ?? ((line: string) => console.log(line));
+  const refuse =
+    deps.refuse ??
+    ((message: string) => {
+      console.error(message);
+      process.exit(1);
+    });
+
+  const platform = deps.platform ?? process.platform;
+  if (platform === "win32") {
+    refuse(CODEX_AGENT_WINDOWS_MESSAGE);
+    return null;
+  }
+
+  const settings = input.settings;
+  if (settings?.enabled !== true) {
+    refuse(CODEX_AGENT_DISABLED_MESSAGE);
+    return null;
+  }
+
+  let result: CodexAgentReadinessResult;
+  try {
+    result = await ensureReady(
+      {
+        ...(settings.binaryPath === undefined ? {} : { binaryPath: settings.binaryPath }),
+        model: input.model,
+        ...(deps.baseEnv === undefined ? {} : { baseEnv: deps.baseEnv }),
+      },
+      {},
+    );
+  } catch (err) {
+    refuse(refusalMessage(err));
+    return null;
+  }
+
+  if (result.status === "refused") {
+    refuse(refusalMessage(result.error));
+    return null;
+  }
+
+  log(result.identityLine);
+  return result;
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -10,6 +10,8 @@ import {
   resolveRuntimeConfig,
   type ClaudeCliBilling,
   type ClaudeCliRuntimeConfigPatch,
+  type CodexAgentReasoningEffort,
+  type CodexAgentRuntimeConfigPatch,
   type EffectiveRuntimeConfig,
 } from "./runtime-config.js";
 
@@ -179,6 +181,22 @@ export function claudeCliPatchFrom(
   };
 }
 
+export function codexAgentPatchFrom(
+  yaml: unknown,
+  environment: RuntimeEnvironment,
+): CodexAgentRuntimeConfigPatch {
+  const block = isYamlRecord(yaml) ? yaml : {};
+  const enabled = block.enabled as boolean | undefined;
+  const binaryPath =
+    envFrom(environment, "CODEX_CLI_PATH") ?? (block.binary_path as string | undefined);
+  const reasoningEffort = block.reasoning_effort as CodexAgentReasoningEffort | undefined;
+  return {
+    ...(enabled === undefined ? {} : { enabled }),
+    ...(binaryPath === undefined ? {} : { binaryPath }),
+    ...(reasoningEffort === undefined ? {} : { reasoningEffort }),
+  };
+}
+
 // ============================================================================
 // SECRET REF HANDLING
 // ============================================================================
@@ -237,6 +255,7 @@ export function loadConfigFromYaml(
     google: "GOOGLE_GENERATIVE_AI_API_KEY",
     "openai-codex": undefined,
     "claude-cli": undefined,
+    "codex-agent": undefined,
     deepseek: "DEEPSEEK_API_KEY",
     qwen: "ALIBABA_API_KEY",
     minimax: "MINIMAX_API_KEY",
@@ -303,6 +322,9 @@ export function loadConfigFromYaml(
         baseUrl: env("LLM_BASE_URL") ?? (llmYaml.base_url as string | undefined),
         ...(provider === "claude-cli"
           ? { claudeCli: claudeCliPatchFrom(llmYaml.claude_cli, process.env) }
+          : {}),
+        ...(provider === "codex-agent"
+          ? { codexAgent: codexAgentPatchFrom(llmYaml.codex_agent, process.env) }
           : {}),
       },
       intervals: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -195,6 +195,7 @@ export {
   CONFIG_FILE,
   claudeCliDisabledByEnvironment,
   claudeCliPatchFrom,
+  codexAgentPatchFrom,
   loadConfig,
   loadConfigFromYaml,
   readConfigYaml,
@@ -220,6 +221,9 @@ export type {
   ClaudeCliBilling,
   ClaudeCliRuntimeConfigPatch,
   ClaudeCliRuntimeSettings,
+  CodexAgentReasoningEffort,
+  CodexAgentRuntimeConfigPatch,
+  CodexAgentRuntimeSettings,
   EffectiveRuntimeConfig,
   KeylessLlmProvider,
   LlmModelCatalogueEntry,
@@ -228,7 +232,12 @@ export type {
   RuntimeConfigPatch,
   RuntimeConfigResolverOptions,
 } from "./runtime-config.js";
-export { CLAUDE_CLI_DISABLED_MESSAGE } from "./runtime-config.js";
+export {
+  CLAUDE_CLI_DISABLED_MESSAGE,
+  CODEX_AGENT_DISABLED_MESSAGE,
+  CODEX_AGENT_REASONING_EFFORTS,
+  CODEX_AGENT_WINDOWS_MESSAGE,
+} from "./runtime-config.js";
 export {
   ClaudeCliConfigError,
   ensureClaudeCliReady,

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -392,6 +392,11 @@ export async function runBinary(
     await runClaudeCliStartupGate({ settings: config.llm.claudeCli, model: config.llm.model });
   }
 
+  if (config.llm.provider === "codex-agent") {
+    const { runCodexAgentStartupGate } = await import("./codex-agent-startup.js");
+    await runCodexAgentStartupGate({ settings: config.llm.codexAgent, model: config.llm.model });
+  }
+
   const bootStart = Date.now();
   const prepared = await hooks.prepare?.({ config, sport }) ?? {};
   const { createCoachEngine } = await import("./agent/coach-engine.js");

--- a/packages/core/src/runtime-config.ts
+++ b/packages/core/src/runtime-config.ts
@@ -1,4 +1,6 @@
 import {
+  CODEX_AGENT_DISABLED_MESSAGE,
+  CODEX_AGENT_WINDOWS_MESSAGE,
   KEYLESS_LLM_PROVIDERS,
   isKeylessProvider,
   type KeylessLlmProvider,
@@ -13,6 +15,7 @@ export const LLM_PROVIDERS = [
   "google",
   "openai-codex",
   "claude-cli",
+  "codex-agent",
   "deepseek",
   "qwen",
   "minimax",
@@ -29,6 +32,7 @@ export const DEFAULT_MODELS = {
   google: "gemini-3.6-flash",
   "openai-codex": "gpt-5.6-sol",
   "claude-cli": "sonnet",
+  "codex-agent": "gpt-5.6-sol",
   deepseek: "deepseek-v4-flash",
   qwen: "qwen3.7-plus",
   minimax: "MiniMax-M3",
@@ -245,6 +249,18 @@ export interface ClaudeCliRuntimeSettings {
 export const CLAUDE_CLI_DISABLED_MESSAGE =
   "The Claude CLI provider is disabled on this instance (ENDURAGENT_CLAUDE_CLI_DISABLED or llm.claude_cli.enabled: false). Choose another provider or re-enable it.";
 
+export const CODEX_AGENT_REASONING_EFFORTS = ["low", "medium", "high", "ultra"] as const;
+
+export type CodexAgentReasoningEffort = (typeof CODEX_AGENT_REASONING_EFFORTS)[number];
+
+export interface CodexAgentRuntimeSettings {
+  enabled: boolean;
+  binaryPath?: string;
+  reasoningEffort?: CodexAgentReasoningEffort;
+}
+
+export { CODEX_AGENT_DISABLED_MESSAGE, CODEX_AGENT_WINDOWS_MESSAGE };
+
 export interface EffectiveRuntimeConfig {
   llm: {
     provider: LlmProvider;
@@ -255,6 +271,7 @@ export interface EffectiveRuntimeConfig {
     compactModel?: string;
     baseUrl?: string;
     claudeCli?: ClaudeCliRuntimeSettings;
+    codexAgent?: CodexAgentRuntimeSettings;
   };
   intervals: {
     apiKey: string;
@@ -277,6 +294,12 @@ export interface ClaudeCliRuntimeConfigPatch {
   readonly billing?: ClaudeCliBilling;
 }
 
+export interface CodexAgentRuntimeConfigPatch {
+  readonly enabled?: boolean;
+  readonly binaryPath?: string | null;
+  readonly reasoningEffort?: CodexAgentReasoningEffort | null;
+}
+
 export interface RuntimeConfigPatch {
   readonly llm?: {
     readonly provider?: LlmProvider;
@@ -286,6 +309,7 @@ export interface RuntimeConfigPatch {
     readonly compactModel?: string | null;
     readonly baseUrl?: string | null;
     readonly claudeCli?: ClaudeCliRuntimeConfigPatch;
+    readonly codexAgent?: CodexAgentRuntimeConfigPatch;
   };
   readonly intervals?: {
     readonly apiKey?: string;
@@ -308,8 +332,10 @@ const LLM_FIELDS = new Set([
   "compactModel",
   "baseUrl",
   "claudeCli",
+  "codexAgent",
 ]);
 const CLAUDE_CLI_FIELDS = new Set(["enabled", "binaryPath", "configDir", "billing"]);
+const CODEX_AGENT_FIELDS = new Set(["enabled", "binaryPath", "reasoningEffort"]);
 const INTERVALS_FIELDS = new Set(["apiKey", "athleteId"]);
 const SESSION_FIELDS = new Set([
   "historyTokenBudgetRatio",
@@ -475,6 +501,42 @@ function resolveClaudeCli(
   };
 }
 
+function requireCodexAgentReasoningEffort(value: unknown): CodexAgentReasoningEffort {
+  if (
+    typeof value === "string" &&
+    (CODEX_AGENT_REASONING_EFFORTS as readonly string[]).includes(value)
+  ) {
+    return value as CodexAgentReasoningEffort;
+  }
+  throw new TypeError(
+    'llm.codexAgent.reasoningEffort must be "low", "medium", "high", or "ultra".',
+  );
+}
+
+function resolveCodexAgent(
+  patch: CodexAgentRuntimeConfigPatch,
+  current: CodexAgentRuntimeSettings | undefined,
+): CodexAgentRuntimeSettings {
+  assertKnownFields(patch, CODEX_AGENT_FIELDS, "llm.codexAgent");
+  const binaryPath = !isSpecified(patch, "binaryPath")
+    ? current?.binaryPath
+    : patch.binaryPath === null
+      ? undefined
+      : requireString(patch.binaryPath, "llm.codexAgent.binaryPath");
+  const reasoningEffort = !isSpecified(patch, "reasoningEffort")
+    ? current?.reasoningEffort
+    : patch.reasoningEffort === null
+      ? undefined
+      : requireCodexAgentReasoningEffort(patch.reasoningEffort);
+  return {
+    enabled: isSpecified(patch, "enabled")
+      ? requireBoolean(patch.enabled, "llm.codexAgent.enabled")
+      : (current?.enabled ?? false),
+    ...(binaryPath === undefined ? {} : { binaryPath }),
+    ...(reasoningEffort === undefined ? {} : { reasoningEffort }),
+  };
+}
+
 export function resolveRuntimeConfig(
   patch: RuntimeConfigPatch = {},
   current?: EffectiveRuntimeConfig,
@@ -519,6 +581,16 @@ export function resolveRuntimeConfig(
           providerChanged ? undefined : current?.llm.claudeCli,
         )
       : undefined;
+  if (provider !== "codex-agent" && isSpecified(llmPatch, "codexAgent")) {
+    throw new TypeError("llm.codexAgent must be absent unless the provider is codex-agent.");
+  }
+  const codexAgent =
+    provider === "codex-agent"
+      ? resolveCodexAgent(
+          isSpecified(llmPatch, "codexAgent") ? (llmPatch.codexAgent ?? {}) : {},
+          providerChanged ? undefined : current?.llm.codexAgent,
+        )
+      : undefined;
 
   const requestedFlushModel = optionalModel(llmPatch, "flushModel");
   const flushModel =
@@ -549,6 +621,16 @@ export function resolveRuntimeConfig(
   ) {
     throw new TypeError(
       "llm.baseUrl must be absent for claude-cli — the Claude Code CLI owns its endpoint.",
+    );
+  }
+  if (
+    provider === "codex-agent" &&
+    isSpecified(llmPatch, "baseUrl") &&
+    llmPatch.baseUrl !== null &&
+    llmPatch.baseUrl !== ""
+  ) {
+    throw new TypeError(
+      "llm.baseUrl must be absent for codex-agent — the Codex CLI owns its endpoint.",
     );
   }
   if (isSpecified(llmPatch, "baseUrl")) {
@@ -628,6 +710,7 @@ export function resolveRuntimeConfig(
       compactModel,
       baseUrl,
       ...(claudeCli === undefined ? {} : { claudeCli }),
+      ...(codexAgent === undefined ? {} : { codexAgent }),
     },
     intervals,
     session,

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -240,17 +240,21 @@ export async function runSetup(binary: BinaryConfig): Promise<void> {
   }
 }
 
-async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<void> {
-  intro(`${binary.displayName} — Setup`);
+interface LlmPromptOutcome {
+  readonly provider: string;
+  readonly model: string;
+  readonly baseUrl: string | undefined;
+  readonly claudeCliBlock: Record<string, unknown> | undefined;
+  readonly freshCodexCreds: OAuthCredential | null;
+}
 
-  const previous = readConfigYaml();
-  const prevProvider = getString(previous, "llm", "provider");
-  const prevModel = getString(previous, "llm", "model");
-  const prevLlmKey = readFieldValue(previous, "llm", "api_key");
-  const prevIntervalsKey = readFieldValue(previous, "intervals", "api_key");
-  const prevIntervalsId = getString(previous, "intervals", "athlete_id");
-  const prevTelegramToken = readFieldValue(previous, "telegram", "bot_token");
-
+async function _runLlmPrompts(
+  ctx: WizardCtx,
+  binary: BinaryConfig,
+  previous: Record<string, unknown>,
+  prevProvider: string | undefined,
+  prevModel: string | undefined,
+): Promise<LlmPromptOutcome> {
   // Provider
   const providerResp = await select({
     message: "LLM provider",
@@ -386,6 +390,44 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
     };
   }
 
+  return { provider, model, baseUrl, claudeCliBlock, freshCodexCreds };
+}
+
+async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<void> {
+  intro(`${binary.displayName} — Setup`);
+
+  const previous = readConfigYaml();
+  const prevProvider = getString(previous, "llm", "provider");
+  const prevModel = getString(previous, "llm", "model");
+  const prevLlmKey = readFieldValue(previous, "llm", "api_key");
+  const prevIntervalsKey = readFieldValue(previous, "intervals", "api_key");
+  const prevIntervalsId = getString(previous, "intervals", "athlete_id");
+  const prevTelegramToken = readFieldValue(previous, "telegram", "bot_token");
+
+  let keepLlmBlock = false;
+  if (
+    prevProvider !== undefined &&
+    !LLM_MODEL_CATALOGUE.some((entry) => entry.provider === prevProvider)
+  ) {
+    log.warn(
+      `Your current provider \`${prevProvider}\` is not offered by the wizard; re-running setup will replace it.`,
+    );
+    const replaceProvider = await confirm({
+      message: `Replace \`${prevProvider}\` with a provider from this list?`,
+      initialValue: false,
+    });
+    handleCancel(replaceProvider, ctx, binary);
+    keepLlmBlock = !replaceProvider;
+    if (keepLlmBlock) {
+      log.info(`Keeping \`${prevProvider}\`; the rest of setup continues.`);
+    }
+  }
+
+  const llm = keepLlmBlock
+    ? null
+    : await _runLlmPrompts(ctx, binary, previous, prevProvider, prevModel);
+  const freshCodexCreds = llm?.freshCodexCreds ?? null;
+
   // Detect backends + pick secret backend (D12 + D9)
   let backend = await _pickBackend(ctx, binary);
 
@@ -398,42 +440,44 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
   // vs previous backend, potentially apply D13 migration prompt, and write to
   // the chosen backend. The merged config is mutated in place.
   const merged: Record<string, unknown> = { ...previous };
-  const llmConfig: Record<string, unknown> = { provider, model };
-  if (provider === "openai-codex") {
-    llmConfig.auth_profile = "openai-codex";
-  }
-  if (claudeCliBlock !== undefined) {
-    llmConfig.claude_cli = claudeCliBlock;
-  }
-  if (baseUrl !== undefined) {
-    llmConfig.base_url = baseUrl;
-  }
-
-  if (!isKeylessProvider(provider)) {
-    const hasPrev = provider === prevProvider && isNonEmptySecret(prevLlmKey);
-    const result = await _collectAndWriteSecret(
-      ctx,
-      {
-        field: "llm.api_key",
-        label: `${API_KEY_LABELS[provider]}`,
-        required: !hasPrev,
-        prevValue: provider === prevProvider ? prevLlmKey : undefined,
-        backend,
-        chosenVaultRef: { current: chosenVault },
-        opAbsPathRef: { current: opAbsPath },
-        keychainPathRef: { current: keychainPath },
-      },
-      binary,
-    );
-    chosenVault = result.chosenVault;
-    opAbsPath = result.opAbsPath;
-    keychainPath = result.keychainPath;
-    backend = result.backend;
-    if (result.yamlValue !== undefined) {
-      llmConfig.api_key = result.yamlValue;
+  if (llm !== null) {
+    const llmConfig: Record<string, unknown> = { provider: llm.provider, model: llm.model };
+    if (llm.provider === "openai-codex") {
+      llmConfig.auth_profile = "openai-codex";
     }
+    if (llm.claudeCliBlock !== undefined) {
+      llmConfig.claude_cli = llm.claudeCliBlock;
+    }
+    if (llm.baseUrl !== undefined) {
+      llmConfig.base_url = llm.baseUrl;
+    }
+
+    if (!isKeylessProvider(llm.provider)) {
+      const hasPrev = llm.provider === prevProvider && isNonEmptySecret(prevLlmKey);
+      const result = await _collectAndWriteSecret(
+        ctx,
+        {
+          field: "llm.api_key",
+          label: `${API_KEY_LABELS[llm.provider]}`,
+          required: !hasPrev,
+          prevValue: llm.provider === prevProvider ? prevLlmKey : undefined,
+          backend,
+          chosenVaultRef: { current: chosenVault },
+          opAbsPathRef: { current: opAbsPath },
+          keychainPathRef: { current: keychainPath },
+        },
+        binary,
+      );
+      chosenVault = result.chosenVault;
+      opAbsPath = result.opAbsPath;
+      keychainPath = result.keychainPath;
+      backend = result.backend;
+      if (result.yamlValue !== undefined) {
+        llmConfig.api_key = result.yamlValue;
+      }
+    }
+    merged.llm = llmConfig;
   }
-  merged.llm = llmConfig;
 
   // intervals.api_key (optional)
   let intervalsAthleteId = prevIntervalsId ?? "";

--- a/packages/core/tests/claude-cli-config.test.ts
+++ b/packages/core/tests/claude-cli-config.test.ts
@@ -55,7 +55,9 @@ function load(llm: Record<string, unknown>): Config {
 describe("claude-cli provider registry", () => {
   it("registers the provider immediately after openai-codex", () => {
     expect(LLM_PROVIDERS.indexOf("claude-cli")).toBe(LLM_PROVIDERS.indexOf("openai-codex") + 1);
-    expect(LLM_MODEL_CATALOGUE.map((entry) => entry.provider)).toEqual(LLM_PROVIDERS);
+    expect(LLM_MODEL_CATALOGUE.map((entry) => entry.provider)).toEqual(
+      LLM_PROVIDERS.filter((provider) => provider !== "codex-agent"),
+    );
   });
 
   it("publishes the subscription catalogue entry", () => {

--- a/packages/core/tests/codex-agent-config.test.ts
+++ b/packages/core/tests/codex-agent-config.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LlmProviderSchema } from "@enduragent/coach-contract";
+import { engineConfigFromConfig } from "../src/agent/engine-host-adapter.js";
+import { codexAgentPatchFrom, loadConfigFromYaml, type Config } from "../src/config.js";
+import {
+  CODEX_AGENT_DISABLED_MESSAGE,
+  CODEX_AGENT_WINDOWS_MESSAGE,
+  COMPACT_MODEL_DEFAULTS,
+  DEFAULT_MODELS,
+  KEYLESS_LLM_PROVIDERS,
+  LLM_MODEL_CATALOGUE,
+  LLM_PROVIDERS,
+  PROVIDER_BASE_URLS,
+  contextWindowForModel,
+  isKeylessProvider,
+  resolveRuntimeConfig,
+} from "../src/runtime-config.js";
+
+const MANAGED_ENV = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "LLM_API_KEY",
+  "LLM_PROVIDER",
+  "LLM_MODEL",
+  "LLM_FLUSH_MODEL",
+  "LLM_COMPACT_MODEL",
+  "LLM_BASE_URL",
+  "CONTEXT_WINDOW_TOKENS",
+  "INTERVALS_API_KEY",
+  "INTERVALS_ATHLETE_ID",
+  "TELEGRAM_BOT_TOKEN",
+  "CODEX_CLI_PATH",
+];
+
+let configDir: string;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  configDir = mkdtempSync(join(tmpdir(), "cc-codex-agent-"));
+  for (const key of MANAGED_ENV) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of MANAGED_ENV) {
+    if (savedEnv[key] !== undefined) process.env[key] = savedEnv[key];
+    else delete process.env[key];
+  }
+  rmSync(configDir, { recursive: true, force: true });
+});
+
+function load(llm: Record<string, unknown>): Config {
+  return loadConfigFromYaml({ llm }, configDir);
+}
+
+describe("codex-agent provider union", () => {
+  it("registers the provider immediately after claude-cli in every copy", () => {
+    expect(LLM_PROVIDERS.indexOf("codex-agent")).toBe(LLM_PROVIDERS.indexOf("claude-cli") + 1);
+    expect(LlmProviderSchema.options.indexOf("codex-agent")).toBe(
+      LlmProviderSchema.options.indexOf("claude-cli") + 1,
+    );
+    expect([...LlmProviderSchema.options]).toEqual([...LLM_PROVIDERS]);
+  });
+
+  it("is keyless and carries no api key", () => {
+    expect(isKeylessProvider("codex-agent")).toBe(true);
+    expect([...KEYLESS_LLM_PROVIDERS]).toContain("codex-agent");
+  });
+});
+
+describe("codex-agent flag-off registry", () => {
+  it("is absent from the model catalogue so neither picker can offer it", () => {
+    expect(LLM_MODEL_CATALOGUE.map((entry) => entry.provider)).not.toContain("codex-agent");
+    expect(LLM_MODEL_CATALOGUE.map((entry) => entry.provider)).toEqual(
+      LLM_PROVIDERS.filter((provider) => provider !== "codex-agent"),
+    );
+  });
+
+  it("keeps the registry deltas minimal", () => {
+    expect(DEFAULT_MODELS["codex-agent"]).toBe("gpt-5.6-sol");
+    expect(COMPACT_MODEL_DEFAULTS).not.toHaveProperty("codex-agent");
+    expect(PROVIDER_BASE_URLS).not.toHaveProperty("codex-agent");
+    expect(contextWindowForModel("gpt-5.6-sol", "codex-agent")).toBe(1_050_000);
+  });
+
+  it("publishes the flag-off refusal messages", () => {
+    expect(CODEX_AGENT_DISABLED_MESSAGE).toBe(
+      "The Codex agent provider is not enabled on this instance (set llm.codex_agent.enabled: true in config.yaml). It is experimental and off by default.",
+    );
+    expect(CODEX_AGENT_WINDOWS_MESSAGE).toBe(
+      "The Codex agent provider is not supported on Windows yet (macOS and Linux only). Track the Windows lane in the project backlog.",
+    );
+  });
+});
+
+describe("codex-agent runtime resolution", () => {
+  it("refuses an api key", () => {
+    expect(() =>
+      resolveRuntimeConfig({ llm: { provider: "codex-agent", apiKey: "obviously-fake-key" } }),
+    ).toThrow(/llm.apiKey must be absent for codex-agent/);
+  });
+
+  it("refuses a base url because the CLI owns its endpoint", () => {
+    expect(() =>
+      resolveRuntimeConfig({
+        llm: { provider: "codex-agent", baseUrl: "https://api.example.invalid/v1" },
+      }),
+    ).toThrow(/llm.baseUrl must be absent for codex-agent/);
+  });
+
+  it("refuses the codexAgent block under any other provider", () => {
+    expect(() =>
+      resolveRuntimeConfig({ llm: { provider: "anthropic", codexAgent: { enabled: true } } }),
+    ).toThrow(/llm.codexAgent must be absent/);
+  });
+
+  it("attaches a disabled block by default", () => {
+    const resolved = resolveRuntimeConfig({ llm: { provider: "codex-agent" } });
+    expect(resolved.llm.apiKey).toBe("");
+    expect(resolved.llm.baseUrl).toBeUndefined();
+    expect(resolved.llm.authProfile).toBeUndefined();
+    expect(resolved.llm.model).toBe("gpt-5.6-sol");
+    expect(resolved.llm.compactModel).toBe("gpt-5.6-sol");
+    expect(resolved.llm.codexAgent).toEqual({ enabled: false });
+    expect(resolved.contextWindowTokens).toBe(1_050_000);
+  });
+
+  it("takes an explicit opt-in without inventing other fields", () => {
+    const resolved = resolveRuntimeConfig({
+      llm: {
+        provider: "codex-agent",
+        codexAgent: {
+          enabled: true,
+          binaryPath: "/opt/synthetic/bin/codex",
+          reasoningEffort: "medium",
+        },
+      },
+    });
+    expect(resolved.llm.codexAgent).toEqual({
+      enabled: true,
+      binaryPath: "/opt/synthetic/bin/codex",
+      reasoningEffort: "medium",
+    });
+  });
+
+  it("rejects unknown fields and out-of-enum values", () => {
+    expect(() =>
+      resolveRuntimeConfig({
+        llm: {
+          provider: "codex-agent",
+          codexAgent: { billing: "subscription" } as unknown as { enabled: boolean },
+        },
+      }),
+    ).toThrow(/Unknown llm.codexAgent field: billing/);
+    expect(() =>
+      resolveRuntimeConfig({
+        llm: {
+          provider: "codex-agent",
+          codexAgent: { enabled: "yes" as unknown as boolean },
+        },
+      }),
+    ).toThrow(/llm.codexAgent.enabled must be a boolean/);
+    expect(() =>
+      resolveRuntimeConfig({
+        llm: {
+          provider: "codex-agent",
+          codexAgent: { reasoningEffort: "extreme" as unknown as "high" },
+        },
+      }),
+    ).toThrow(/llm.codexAgent.reasoningEffort/);
+  });
+
+  it("carries the block across a patch that keeps the provider", () => {
+    const current = resolveRuntimeConfig({
+      llm: { provider: "codex-agent", codexAgent: { enabled: true, reasoningEffort: "high" } },
+    });
+    const next = resolveRuntimeConfig({ llm: { model: "gpt-5.6-terra" } }, current);
+    expect(next.llm.codexAgent).toEqual({ enabled: true, reasoningEffort: "high" });
+  });
+
+  it("drops the block when the provider changes away", () => {
+    const current = resolveRuntimeConfig({
+      llm: { provider: "codex-agent", codexAgent: { enabled: true } },
+    });
+    const next = resolveRuntimeConfig(
+      { llm: { provider: "anthropic", apiKey: "obviously-fake-key" } },
+      current,
+    );
+    expect(next.llm.codexAgent).toBeUndefined();
+  });
+
+  it("omits the block for every other provider", () => {
+    expect(
+      resolveRuntimeConfig({ llm: { provider: "anthropic", apiKey: "obviously-fake-key" } }).llm
+        .codexAgent,
+    ).toBeUndefined();
+  });
+});
+
+describe("codex-agent config loading", () => {
+  it("defaults enabled to false when the yaml block is absent", () => {
+    expect(load({ provider: "codex-agent" }).llm.codexAgent).toEqual({ enabled: false });
+  });
+
+  it("defaults enabled to false when the yaml block omits the flag", () => {
+    expect(
+      load({ provider: "codex-agent", codex_agent: { binary_path: "/opt/synthetic/bin/codex" } })
+        .llm.codexAgent,
+    ).toEqual({ enabled: false, binaryPath: "/opt/synthetic/bin/codex" });
+  });
+
+  it("reads the opt-in yaml block without requiring a key", () => {
+    const config = load({
+      provider: "codex-agent",
+      codex_agent: {
+        enabled: true,
+        binary_path: "/opt/synthetic/bin/codex",
+        reasoning_effort: "high",
+      },
+    });
+    expect(config.llm.apiKey).toBe("");
+    expect(config.llm.codexAgent).toEqual({
+      enabled: true,
+      binaryPath: "/opt/synthetic/bin/codex",
+      reasoningEffort: "high",
+    });
+  });
+
+  it("ignores llm api key env for the keyless lane", () => {
+    process.env.LLM_API_KEY = "obviously-fake-key";
+    process.env.OPENAI_API_KEY = "obviously-fake-key";
+    expect(load({ provider: "codex-agent" }).llm.apiKey).toBe("");
+  });
+
+  it("refuses LLM_BASE_URL for this provider", () => {
+    process.env.LLM_BASE_URL = "https://api.example.invalid/v1";
+    expect(() => load({ provider: "codex-agent" })).toThrow(/llm.baseUrl must be absent/);
+  });
+
+  it("lets CODEX_CLI_PATH override the yaml binary path", () => {
+    process.env.CODEX_CLI_PATH = "/synthetic/override/codex";
+    const config = load({
+      provider: "codex-agent",
+      codex_agent: { enabled: true, binary_path: "/opt/synthetic/bin/codex" },
+    });
+    expect(config.llm.codexAgent?.binaryPath).toBe("/synthetic/override/codex");
+  });
+
+  it("has no enable or disable environment override", () => {
+    const patch = codexAgentPatchFrom(
+      { enabled: false },
+      { ENDURAGENT_CODEX_AGENT_DISABLED: "1", ENDURAGENT_CODEX_AGENT_ENABLED: "1" },
+    );
+    expect(patch).toEqual({ enabled: false });
+  });
+
+  it("reads the binary path only from the injected environment", () => {
+    process.env.CODEX_CLI_PATH = "/synthetic/process-env/codex";
+    expect(codexAgentPatchFrom({}, {})).toEqual({});
+    expect(codexAgentPatchFrom({}, { CODEX_CLI_PATH: "/synthetic/injected/codex" })).toEqual({
+      binaryPath: "/synthetic/injected/codex",
+    });
+  });
+});
+
+describe("codex-agent engine config mapping", () => {
+  it("maps the block with no derived on-disk path", () => {
+    const config = loadConfigFromYaml(
+      {
+        data_dir: join(configDir, "data"),
+        llm: {
+          provider: "codex-agent",
+          codex_agent: {
+            enabled: true,
+            binary_path: "/opt/synthetic/bin/codex",
+            reasoning_effort: "low",
+          },
+        },
+      },
+      configDir,
+    );
+    expect(engineConfigFromConfig(config).llm.codexAgent).toEqual({
+      enabled: true,
+      binaryPath: "/opt/synthetic/bin/codex",
+      reasoningEffort: "low",
+    });
+    expect(engineConfigFromConfig(config).llm.claudeCli).toBeUndefined();
+  });
+
+  it("omits the engine block for other providers", () => {
+    process.env.ANTHROPIC_API_KEY = "obviously-fake-key";
+    const config = loadConfigFromYaml({ llm: { provider: "anthropic" } }, configDir);
+    expect(engineConfigFromConfig(config).llm.codexAgent).toBeUndefined();
+  });
+});

--- a/packages/core/tests/codex-agent-startup.test.ts
+++ b/packages/core/tests/codex-agent-startup.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { CodexAgentConfigError } from "@enduragent/engine";
+
+import { runCodexAgentStartupGate } from "../src/codex-agent-startup.js";
+import {
+  CODEX_AGENT_DISABLED_MESSAGE,
+  CODEX_AGENT_WINDOWS_MESSAGE,
+} from "../src/runtime-config.js";
+
+function collector(): { lines: string[]; refusals: string[] } {
+  return { lines: [], refusals: [] };
+}
+
+function readyReport() {
+  return {
+    status: "ready" as const,
+    binaryPath: "/opt/synthetic/bin/codex",
+    version: "0.146.0",
+    account: { type: "chatgpt" as const, email: "rider@example.test", planType: "pro" },
+    identityLine: "Signed in as rider@example.test - ChatGPT Pro plan",
+    foreignServers: [] as readonly string[],
+    models: ["gpt-5.6-sol"] as readonly string[],
+    warnings: [] as readonly string[],
+  };
+}
+
+describe("codex-agent startup gate", () => {
+  it("refuses on windows before any binary resolution or enablement check", async () => {
+    const sink = collector();
+    const result = await runCodexAgentStartupGate(
+      { settings: { enabled: true }, model: "gpt-5.6-sol" },
+      {
+        platform: "win32",
+        ensureReady: async () => {
+          throw new Error("probe must not run on win32");
+        },
+        log: (line) => sink.lines.push(line),
+        refuse: (message) => sink.refusals.push(message),
+      },
+    );
+    expect(result).toBeNull();
+    expect(sink.refusals).toEqual([CODEX_AGENT_WINDOWS_MESSAGE]);
+    expect(sink.lines).toEqual([]);
+  });
+
+  it("refuses when the lane was never enabled", async () => {
+    const sink = collector();
+    const result = await runCodexAgentStartupGate(
+      { settings: { enabled: false }, model: "gpt-5.6-sol" },
+      {
+        platform: "darwin",
+        ensureReady: async () => {
+          throw new Error("probe must not run when disabled");
+        },
+        log: (line) => sink.lines.push(line),
+        refuse: (message) => sink.refusals.push(message),
+      },
+    );
+    expect(result).toBeNull();
+    expect(sink.refusals).toEqual([CODEX_AGENT_DISABLED_MESSAGE]);
+  });
+
+  it("refuses when the block is absent entirely", async () => {
+    const sink = collector();
+    await runCodexAgentStartupGate(
+      { settings: undefined, model: "gpt-5.6-sol" },
+      {
+        platform: "linux",
+        ensureReady: async () => {
+          throw new Error("probe must not run when the block is absent");
+        },
+        log: (line) => sink.lines.push(line),
+        refuse: (message) => sink.refusals.push(message),
+      },
+    );
+    expect(sink.refusals).toEqual([CODEX_AGENT_DISABLED_MESSAGE]);
+  });
+
+  it("logs the identity line on a verified chatgpt sign-in", async () => {
+    const sink = collector();
+    const result = await runCodexAgentStartupGate(
+      {
+        settings: { enabled: true, binaryPath: "/opt/synthetic/bin/codex" },
+        model: "gpt-5.6-sol",
+      },
+      {
+        platform: "darwin",
+        ensureReady: async (input) => {
+          expect(input.binaryPath).toBe("/opt/synthetic/bin/codex");
+          expect(input.model).toBe("gpt-5.6-sol");
+          return readyReport();
+        },
+        log: (line) => sink.lines.push(line),
+        refuse: (message) => sink.refusals.push(message),
+      },
+    );
+    expect(sink.refusals).toEqual([]);
+    expect(sink.lines).toEqual(["Signed in as rider@example.test - ChatGPT Pro plan"]);
+    expect(result?.version).toBe("0.146.0");
+  });
+
+  it("refuses with the taxonomy message when the probe returns a refusal", async () => {
+    const sink = collector();
+    const result = await runCodexAgentStartupGate(
+      { settings: { enabled: true }, model: "gpt-5.6-sol" },
+      {
+        platform: "darwin",
+        ensureReady: async () => ({
+          status: "refused" as const,
+          error: new CodexAgentConfigError("not-signed-in", "codex is not signed in"),
+        }),
+        log: (line) => sink.lines.push(line),
+        refuse: (message) => sink.refusals.push(message),
+      },
+    );
+    expect(result).toBeNull();
+    expect(sink.refusals).toEqual(["codex is not signed in"]);
+    expect(sink.lines).toEqual([]);
+  });
+
+  it("refuses on an unexpected probe failure instead of serving", async () => {
+    const sink = collector();
+    await runCodexAgentStartupGate(
+      { settings: { enabled: true }, model: "gpt-5.6-sol" },
+      {
+        platform: "darwin",
+        ensureReady: async () => {
+          throw new Error("spawn blew up");
+        },
+        log: (line) => sink.lines.push(line),
+        refuse: (message) => sink.refusals.push(message),
+      },
+    );
+    expect(sink.refusals).toHaveLength(1);
+    expect(sink.refusals[0]).toContain("spawn blew up");
+    expect(sink.lines).toEqual([]);
+  });
+});

--- a/packages/core/tests/model-catalogue.test.ts
+++ b/packages/core/tests/model-catalogue.test.ts
@@ -9,7 +9,9 @@ import {
 
 describe("LLM model catalogue", () => {
   it("covers providers in setup order with every default among its advisory options", () => {
-    expect(LLM_MODEL_CATALOGUE.map((entry) => entry.provider)).toEqual(LLM_PROVIDERS);
+    expect(LLM_MODEL_CATALOGUE.map((entry) => entry.provider)).toEqual(
+      LLM_PROVIDERS.filter((provider) => provider !== "codex-agent"),
+    );
     for (const entry of LLM_MODEL_CATALOGUE) {
       expect(entry.defaultModel).toBe(DEFAULT_MODELS[entry.provider]);
       expect(entry.models.map((model) => model.value)).toContain(entry.defaultModel);

--- a/packages/core/tests/setup-providers.test.ts
+++ b/packages/core/tests/setup-providers.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, readFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as toYaml } from "yaml";
 
 import { scriptedPrompts } from "./helpers/scripted-prompts.js";
 import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
@@ -102,5 +102,72 @@ describe("setup — new providers", () => {
     expect(cfg.llm.provider).toBe("openrouter");
     expect(cfg.llm.model).toBe("deepseek/deepseek-chat");
     expect(cfg.llm.base_url).toBe("https://openrouter.ai/api/v1");
+  });
+});
+
+describe("setup — off-catalogue provider guard", () => {
+  function seedOffCatalogue(): void {
+    writeFileSync(
+      CONFIG(),
+      toYaml({
+        llm: { provider: "codex-agent", model: "gpt-5.6-sol", codex_agent: { enabled: true } },
+        intervals: { athlete_id: "i1" },
+      }),
+    );
+  }
+
+  it("warns, keeps the provider and still runs the rest of the wizard when the operator declines", async () => {
+    seedOffCatalogue();
+    const prompts = scriptedPrompts({
+      selects: ["plain"],
+      texts: [""],
+      passwords: ["sk-intervals-test", ""],
+      confirms: [false, true],
+    });
+    vi.doMock("@clack/prompts", () => prompts);
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup(cyclingBinary);
+
+    expect(prompts.log.warn).toHaveBeenCalledWith(
+      "Your current provider `codex-agent` is not offered by the wizard; re-running setup will replace it.",
+    );
+
+    const promptMessages = (calls: unknown[][]): string[] =>
+      calls.map(([options]) => (options as { message: string }).message);
+
+    const selectMessages = promptMessages(prompts.select.mock.calls);
+    expect(selectMessages).not.toContain("LLM provider");
+    expect(selectMessages).not.toContain("Model");
+    expect(selectMessages).toContain("Where to store secrets?");
+
+    const passwordMessages = promptMessages(prompts.password.mock.calls);
+    expect(passwordMessages.some((message) => message.includes("intervals.icu API key"))).toBe(true);
+    expect(passwordMessages.some((message) => message.includes("Telegram bot token"))).toBe(true);
+
+    const cfg = parseYaml(readFileSync(CONFIG(), "utf-8")) as Record<string, any>;
+    expect(cfg.llm.provider).toBe("codex-agent");
+    expect(cfg.llm.model).toBe("gpt-5.6-sol");
+    expect(cfg.llm.codex_agent).toEqual({ enabled: true });
+    expect(cfg.intervals.api_key).toBe("sk-intervals-test");
+  });
+
+  it("replaces the provider once the operator confirms", async () => {
+    seedOffCatalogue();
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["zai", "glm-4.6", "plain"],
+        texts: [""],
+        passwords: ["sk-zai-test", "", ""],
+        confirms: [true, true],
+      }),
+    );
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup(cyclingBinary);
+
+    const cfg = parseYaml(readFileSync(CONFIG(), "utf-8")) as Record<string, any>;
+    expect(cfg.llm.provider).toBe("zai");
+    expect(cfg.llm.codex_agent).toBeUndefined();
   });
 });

--- a/packages/engine/src/agent/codex-agent/bridge.ts
+++ b/packages/engine/src/agent/codex-agent/bridge.ts
@@ -8,7 +8,7 @@ import {
   CODEX_MCP_SERVER_NAME,
   type CodexMcpEndpointOverride,
 } from "./config-overrides.js";
-import { mcpIsolationError, normalizeCodexAgentError } from "./errors.js";
+import { disabledLaneError, mcpIsolationError, normalizeCodexAgentError } from "./errors.js";
 import { startCoachMcpEndpoint, type CoachMcpEndpoint } from "./mcp-endpoint.js";
 import { ensureCodexAgentReady, invalidateCodexAgentProbeCache } from "./probe.js";
 import {
@@ -687,6 +687,8 @@ export async function codexAgentGenerateText(
   opts: CodexAgentGenerateOpts,
   ports: CodexAgentBridgePorts,
 ): Promise<GenerateResult> {
+  if (ports.runtime.enabled !== true) throw disabledLaneError();
+
   const baseEnv = ports.baseEnv ?? process.env;
   const stateless = isStatelessCaller(opts.caller);
   const ensureReady = ports.ensureReady ?? defaultEnsureReady;

--- a/packages/engine/src/agent/codex-agent/errors.ts
+++ b/packages/engine/src/agent/codex-agent/errors.ts
@@ -1,9 +1,15 @@
+import {
+  CODEX_AGENT_DISABLED_MESSAGE,
+  CODEX_AGENT_WINDOWS_MESSAGE,
+} from "@enduragent/coach-contract";
+
 import { markProviderAuthFailure } from "../../provider-auth-failure.js";
 import { CodexProcessExitError, CodexRequestError } from "./protocol.js";
 
 export const CODEX_OVERLOADED_CODE = -32001;
 
 export type CodexAgentConfigErrorKind =
+  | "disabled"
   | "binary-missing"
   | "unsupported-platform"
   | "version-below-floor"
@@ -26,9 +32,6 @@ export class CodexAgentConfigError extends Error {
 
 const LAUNCHD_PATH_HINT =
   "(Mac launchd users: set an absolute path like '/opt/homebrew/bin/codex'.)";
-
-export const WINDOWS_UNSUPPORTED_MESSAGE =
-  "The Codex agent provider is not supported on Windows yet (macOS and Linux only). Track the Windows lane in the project backlog.";
 
 export const NOT_SIGNED_IN_MESSAGE =
   "Codex CLI is not signed in. Open a terminal, run codex login, and sign in with your ChatGPT plan. Enduragent never signs in for you.";
@@ -64,8 +67,12 @@ export function binaryMissingError(binaryPath: string): CodexAgentConfigError {
   return new CodexAgentConfigError("binary-missing", binaryMissingMessage(binaryPath));
 }
 
+export function disabledLaneError(): CodexAgentConfigError {
+  return new CodexAgentConfigError("disabled", CODEX_AGENT_DISABLED_MESSAGE);
+}
+
 export function unsupportedPlatformError(): CodexAgentConfigError {
-  return new CodexAgentConfigError("unsupported-platform", WINDOWS_UNSUPPORTED_MESSAGE);
+  return new CodexAgentConfigError("unsupported-platform", CODEX_AGENT_WINDOWS_MESSAGE);
 }
 
 export function versionBelowFloorError(version: string, floor: string): CodexAgentConfigError {

--- a/packages/engine/src/llm.ts
+++ b/packages/engine/src/llm.ts
@@ -62,7 +62,7 @@ type LLMHostPorts = Pick<
 // ============================================================================
 
 export function usesKeylessTransport(provider: string): boolean {
-  return isKeylessProvider(provider) || provider === "codex-agent";
+  return isKeylessProvider(provider);
 }
 
 // Most providers cache the stable system prefix automatically server-side and

--- a/packages/engine/tests/codex-agent/bridge.test.ts
+++ b/packages/engine/tests/codex-agent/bridge.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { tool } from "ai";
 import { z } from "zod";
 import type { ToolSet } from "ai";
+import { CODEX_AGENT_DISABLED_MESSAGE } from "@enduragent/coach-contract";
 
 import { classifyFailure } from "../../../core/src/agent/token-utils.js";
 import {
@@ -109,6 +110,49 @@ function frameParams(
   const frame = frames.find((entry) => entry.method === method);
   return frame === undefined ? undefined : (frame.params as Record<string, unknown>);
 }
+
+describe("codexAgentGenerateText flag-off gate", () => {
+  it(
+    "refuses without spawning a child when the runtime is not enabled",
+    async () => {
+      const staged = await stage("turn-happy");
+
+      await expect(
+        codexAgentGenerateText(chatOpts(), {
+          runtime: { enabled: false, binaryPath: staged.binaryPath },
+          baseEnv: baseEnv(),
+          startEndpoint: async (options) => stubEndpoint(Object.keys(options.tools)),
+        }),
+      ).rejects.toMatchObject({
+        name: "CodexAgentConfigError",
+        kind: "disabled",
+        message: CODEX_AGENT_DISABLED_MESSAGE,
+      });
+
+      expect(await staged.spawnCount()).toBe(0);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "refuses without spawning a child when the runtime omits the flag entirely",
+    async () => {
+      const staged = await stage("turn-happy");
+      const runtime = { binaryPath: staged.binaryPath } as CodexAgentBridgePorts["runtime"];
+
+      await expect(
+        codexAgentGenerateText(chatOpts(), {
+          runtime,
+          baseEnv: baseEnv(),
+          startEndpoint: async (options) => stubEndpoint(Object.keys(options.tools)),
+        }),
+      ).rejects.toMatchObject({ kind: "disabled", message: CODEX_AGENT_DISABLED_MESSAGE });
+
+      expect(await staged.spawnCount()).toBe(0);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});
 
 describe("codexAgentGenerateText params construction", () => {
   it(

--- a/packages/engine/tests/codex-agent/errors.test.ts
+++ b/packages/engine/tests/codex-agent/errors.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CODEX_AGENT_DISABLED_MESSAGE,
+  CODEX_AGENT_WINDOWS_MESSAGE,
+} from "@enduragent/coach-contract";
+
+import {
   CODEX_OVERLOADED_CODE,
   CodexAgentConfigError,
   NOT_SIGNED_IN_MESSAGE,
   PROBE_TIMEOUT_MESSAGE,
-  WINDOWS_UNSUPPORTED_MESSAGE,
   accountNotChatgptError,
   binaryMissingError,
+  disabledLaneError,
   endpointNotPinnedError,
   mcpIsolationError,
   normalizeCodexAgentError,
@@ -53,8 +58,15 @@ describe("user-facing configuration messages", () => {
   it("names the Windows deferral before anything is spawned", () => {
     const err = unsupportedPlatformError();
     expect(err.kind).toBe("unsupported-platform");
-    expect(err.message).toBe(WINDOWS_UNSUPPORTED_MESSAGE);
+    expect(err.message).toBe(CODEX_AGENT_WINDOWS_MESSAGE);
     expect(err.message).toContain("macOS and Linux only");
+  });
+
+  it("refuses the disabled lane with the message the startup gate prints", () => {
+    const err = disabledLaneError();
+    expect(err.kind).toBe("disabled");
+    expect(err.message).toBe(CODEX_AGENT_DISABLED_MESSAGE);
+    expect(err.message).toContain("llm.codex_agent.enabled: true");
   });
 
   it("advises the upgrade below the floor", () => {

--- a/packages/engine/tests/llm-dispatch.test.ts
+++ b/packages/engine/tests/llm-dispatch.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CODEX_AGENT_DISABLED_MESSAGE } from "@enduragent/coach-contract";
 
 import type { EngineConfig } from "../src/host-ports.js";
 import { llmTestPorts } from "./helpers/base-agent-config.js";
+import { createFakeCodex } from "./codex-agent/helpers/fake-codex.js";
 
 const MINIMAL_RESULT = { text: "ok", toolCalls: [], finishReason: "stop", usage: {}, totalUsage: {}, steps: [] };
 
@@ -555,6 +557,36 @@ describe("LLM dispatch — codex-agent provider gating (AC-3)", () => {
       binaryPath: "/never/spawned/codex",
       reasoningEffort: "medium",
     });
+  });
+
+  it("refuses the turn and spawns no child when the lane is not enabled", async () => {
+    vi.doUnmock("../src/agent/codex-agent/bridge.js");
+    vi.resetModules();
+    const staged = await createFakeCodex({ script: "turn-happy" });
+    try {
+      const base = codexAgentConfig();
+      const disabled: EngineConfig = {
+        ...base,
+        llm: {
+          ...base.llm,
+          codexAgent: { enabled: false, binaryPath: staged.binaryPath },
+        },
+      };
+
+      const { LLM } = await import("../src/llm.js");
+      const llm = new LLM(disabled, llmTestPorts());
+
+      await expect(
+        llm.generate({ messages: [{ role: "user", content: "hi" }], caller: "chat" }),
+      ).rejects.toMatchObject({
+        name: "CodexAgentConfigError",
+        kind: "disabled",
+        message: CODEX_AGENT_DISABLED_MESSAGE,
+      });
+      expect(await staged.spawnCount()).toBe(0);
+    } finally {
+      await staged.cleanup();
+    }
   });
 
   it("is excluded from the chat-stream watchdog so a silent thinking turn survives", async () => {


### PR DESCRIPTION
Second implementation PR of the Codex agent-delegation lane (follows #483, #484). #484 landed the engine transport with nothing able to select it; this makes the provider selectable, still **off by default**.

## Flag-off, enforced in three places

Naming `llm.provider: codex-agent` without `llm.codex_agent.enabled: true` must never serve a turn. That holds at three independent layers, because one of them alone did not:

1. **No catalogue entry.** The lane is absent from `LLM_MODEL_CATALOGUE`, so it cannot be picked in the setup wizard or the desktop onboarding UI. Config-file only. A test pins the absence rather than the presence.
2. **The startup gate** refuses early on the CLI surface, with `win32` refusing *before* the enabled check so a Windows user gets the accurate message rather than "not enabled".
3. **The engine bridge refuses** on the first statement of its only entrypoint.

Layer 3 exists because layers 1 and 2 were not enough, and it is worth being explicit about why. The startup gate lives in `run-binary.ts`, which is reached only from the three CLI entrypoints. The daemon that `apps/desktop` supervises takes a different path — `enduragent.ts` → `local-runner.ts` → `composition.ts` → `createCoachEngine` — and never touched it. The bridge declared `readonly enabled: boolean` and nothing read it. So on desktop, the flag was decorative.

The fix refuses in the engine rather than adding a second copy of the gate to the daemon path: it closes every current and future surface at once, and it makes the declared field mean something. It runs before the readiness probe spawns anything, before the MCP endpoint opens, before any env or token work. Verified end-to-end by driving the real daemon composition with a spy binary on `PATH` and asserting the spawn marker never appears.

## Deliberate omissions

The registry deltas are minimal by design, and each omission is a decision rather than an oversight: no catalogue entry, no compact-model default, no base URL, no context-window entry, no `contextWindowForModel` arm, no `authProfile`. `llm.api_key` and `LLM_BASE_URL` are both rejected at resolve time — the lane is keyless and its endpoint is pinned in the engine.

No desktop status controller or IPC surface this wave. The renderer shows the provider as a non-credential row; a real readiness surface with a "Check again" button is deferred.

## Three places the spec was stale

- **`credential-vault.ts` and `credential-runtime.ts` needed no edit.** #483 already routed both through `isKeylessProvider`, so appending to `KEYLESS_LLM_PROVIDERS` covers them. Following the plan literally would have re-introduced the hand-written disjunction that `keyless-provider-predicate.test.ts` now bans.
- **The preload's `LLM_PROVIDER_ORDER` was serving two roles** — the membership set for provider ids, and a positional length-exact pin against a payload that is *catalogue*-derived. Adding an off-catalogue provider to it made the preload reject every real payload, 11 entries against 12 expected. The two roles are now separate lists; the positional pin still runs, against the correct one, and a test cross-checks the off-catalogue set against what the catalogue actually contains, so a future graduation fails loudly instead of silently breaking the preload.
- **Two tests asserted `LLM_MODEL_CATALOGUE === LLM_PROVIDERS`.** That equality is deliberately false now — the catalogue omission *is* the primary flag-off mechanism. They were restated to exclude this provider, preserving order and totality over every other one, with the absence separately pinned.

## Also in here

Declining the off-catalogue provider confirmation used to abort the whole setup wizard, which would have left an operator on this lane unable to change their intervals key or telegram token. It now skips only the LLM prompts and carries on.

## Verification

Root `pnpm check` green. Full suite green — every failure classified as either another session's worktree or a load flake, each re-run green in isolation. `pnpm s8a` 11/11 plus the drift and determinism self-tests.

Both new gate tests were checked for load: with the bridge guard temporarily replaced by a no-op, both fail. A fresh-context audit of the first draft is what found the daemon hole, and a second fresh-context pass verified the fix by execution rather than by reading the diff.
