### PR TITLE
docs: document the flag-off codex-agent provider lane

### DIFF
--- a/.changeset/codex-agent-lane.md
+++ b/.changeset/codex-agent-lane.md
@@ -1,0 +1,11 @@
+---
+"cycling-coach": minor
+---
+
+User-facing: Experimental (off by default): a Codex provider that drives your locally installed, ChatGPT-signed-in codex CLI as the coaching agent. Enable it in config.yaml with llm.provider: codex-agent and llm.codex_agent.enabled: true.
+
+Config-file only — deliberately absent from the setup wizard, the model catalogue and the desktop onboarding UI, so it can only be reached by editing `config.yaml`. macOS and Linux only; win32 is refused before the enabled check so a Windows user gets the accurate message.
+
+Architecturally this is agent delegation rather than CLI-as-transport: `turn/start` runs Codex's own agentic loop, the 18 coaching tools are injected over a loopback MCP endpoint, and the coach persona is applied as developer instructions rather than as a system prompt. One coaching turn is one billed call against the subscription regardless of how many model calls Codex makes internally, so every ledger row is stamped notional and excluded from the spending cap.
+
+Safety posture: the child environment is allowlist-built from an empty object rather than filtered from the parent, `account/read` must report a ChatGPT account on every turn-carrying child and not just the cached readiness census, the model provider and endpoint are pinned, and the user's own `~/.codex/config.toml` MCP servers, plugins, hooks, shell execution, multi-agent, browser use and web search are all disabled for the duration of a coaching turn. Verification reads the effective config back from the spawned child and refuses rather than degrading. No CLI binary is bundled and no native module is added — the user installs `codex` and signs in themselves.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Cycling Coach (CLI mode). Type your message:
 - **OpenAI Codex (ChatGPT subscription) — experimental** — browser OAuth sign-in with your ChatGPT Plus / Pro / Business / Edu / Enterprise account. No API key needed; the bot uses your subscription quota. Minimum tier: ChatGPT Plus ($20/mo). Select it in `cycling-coach setup` to start the OAuth flow. Models offered in the wizard: `gpt-5.4` (balanced, recommended) and `gpt-5.4-mini` (faster, smaller context). Cost is covered by the subscription regardless of which model you pick — the choice is speed vs capability, not price. On hard rate-limit failures the bot retries up to 4× with backoff (~35s total) before reporting the error to the chat.
 - **Claude subscription (Claude Code CLI) — experimental** — drives the [Claude Code CLI](https://claude.com/claude-code) installed on your own machine, so your Claude subscription covers the usage and no API key is involved. Sign in once yourself: run `claude` in your terminal and complete the sign-in there. The app never signs you in, never reads or stores your tokens. Select it in `cycling-coach setup`; the wizard checks the CLI and prints `Signed in as <email> - Claude <plan> subscription`. Models offered in the wizard: `sonnet` (default), `opus`, and `haiku`. **macOS and Linux only this wave — Windows is not supported for this lane.** Because it needs a locally installed, signed-in CLI, it does not work in containers or on Railway (see below).
 
+- **Codex agent (ChatGPT subscription, config-file only) — experimental, off by default** — delegates the whole coaching turn to the [Codex CLI](https://developers.openai.com/codex/cli) installed on your own machine, so your ChatGPT subscription covers the usage. Unlike every other option this one is **not offered in the setup wizard** and cannot be selected from the desktop app; you enable it by editing `config.yaml` (see below). Install `codex` (≥ 0.46.0) and sign in once yourself with `codex login` — the app never signs you in, never reads or stores your tokens. **macOS and Linux only; Windows is refused.** Because it needs a locally installed, signed-in CLI, it does not work in containers or on Railway.
+
 Anthropic's Claude Pro/Max subscription does **not** support OAuth for third-party tools (per Anthropic ToS), and Cycling Coach never brokers a Claude login. The two supported Anthropic paths are the console API key and the Claude Code CLI lane above, which delegates to the CLI you signed in yourself.
 
 **Where to get other keys:**
@@ -248,6 +250,26 @@ llm:
 
 **Kill switch:** set `ENDURAGENT_CLAUDE_CLI_DISABLED=1` (or `true`, case-insensitive) to disable this provider on an instance; `llm.claude_cli.enabled: false` does the same from YAML. A running daemon does not need a restart — it re-checks the switch every turn, so a flip takes effect on the **next turn**, which is then refused with an explanation. `CLAUDE_CLI_PATH` overrides `llm.claude_cli.binary_path`.
 
+#### Codex agent (experimental, off by default)
+
+This lane is config-file only — the setup wizard does not offer it, and it stays disabled until you write `enabled: true` yourself:
+
+```yaml
+llm:
+  provider: codex-agent
+  model: gpt-5.6-sol
+  codex_agent:
+    enabled: true                          # required — the lane refuses without it
+    binary_path: /opt/homebrew/bin/codex   # optional; resolved automatically when omitted
+    reasoning_effort: medium               # optional; low / medium / high / ultra
+```
+
+There is no `api_key` and no `base_url` — both are rejected, because the CLI owns the endpoint and your subscription covers the usage. `CODEX_CLI_PATH` overrides `binary_path`.
+
+**This lane works differently from every other provider, and the difference is worth understanding before you enable it.** The others send a prompt and get a reply back; here your turn is handed to Codex's own agent loop. Cycling Coach injects its coaching tools into that loop over a local MCP endpoint — 18 of them for cycling with intervals.icu connected, fewer without — and supplies the coach persona as *developer instructions* — steering the agent rather than replacing its system prompt. Practically: the retry loop, the tool wrapper stack, the ledger and your stored history all still work, but Cycling Coach gives up in-context prompt control and per-model-call accounting. One coaching turn is billed as one call against your subscription no matter how many model calls Codex makes internally, so ledger rows for this lane are marked notional and excluded from the spending cap. That trade is why it ships off by default.
+
+For the duration of a coaching turn, your own `~/.codex/config.toml` is neutralized: every MCP server you have configured is disabled, along with shell execution, multi-agent, plugins, apps, hooks, browser and computer use, and web search. The model provider and endpoint are pinned, sandboxing is read-only, and no approval can be requested or interactively granted — the coach's own tools carry standing pre-approval so they can run unattended, and a turn is refused if that pre-approval has been widened to anything else. If any of that cannot be verified on the spawned process, the turn is refused rather than run in a degraded configuration.
+
 Env vars take precedence over YAML.
 
 ### Cheaper model for memory tidy-up
@@ -385,7 +407,7 @@ Cycling Coach is a single Node process holding a long-polling connection to Tele
 - A persistent volume mounted at `/data` (or wherever you point `CYCLING_COACH_HOME`).
 - Secrets injected as env vars, referenced from `config.yaml` via `source: env` (see [Storing secrets outside config.yaml](#storing-secrets-outside-configyaml)).
 - One instance only — sessions are sharded by Telegram chat ID on local disk; do not enable autoscaling.
-- A BYOK API-key provider (`anthropic` / `openai` / `google` / `deepseek` / `qwen` / `minimax` / `kimi` / `zai` / `openrouter`). `LLM_PROVIDER=openai-codex` is **not supported in containers** — it depends on an interactive OAuth flow that writes to the data dir, which can't run headless. `LLM_PROVIDER=claude-cli` is **not supported in containers** either — it requires a locally installed Claude Code CLI that you have signed into, which a headless image does not have.
+- A BYOK API-key provider (`anthropic` / `openai` / `google` / `deepseek` / `qwen` / `minimax` / `kimi` / `zai` / `openrouter`). `LLM_PROVIDER=openai-codex` is **not supported in containers** — it depends on an interactive OAuth flow that writes to the data dir, which can't run headless. `LLM_PROVIDER=claude-cli` is **not supported in containers** either — it requires a locally installed Claude Code CLI that you have signed into, which a headless image does not have. `LLM_PROVIDER=codex-agent` is **not supported in containers** for the same reason, and cannot be enabled by environment variable at all — it needs `llm.codex_agent.enabled: true` in `config.yaml`.
 
 ### Docker
 
@@ -451,7 +473,7 @@ Fill these Railway variables:
 
 | Variable | What to enter | Where to get it |
 | --- | --- | --- |
-| `LLM_PROVIDER` | One lower-case provider id: `anthropic`, `openai`, `google`, `deepseek`, `qwen`, `minimax`, `kimi`, `zai`, or `openrouter`. Start with `anthropic` if unsure. | Pick the provider that issued your `LLM_API_KEY`. ChatGPT Plus login is not supported in Railway because it needs an interactive browser login. `LLM_PROVIDER=claude-cli` is not supported on Railway either — it needs a locally signed-in Claude Code CLI. |
+| `LLM_PROVIDER` | One lower-case provider id: `anthropic`, `openai`, `google`, `deepseek`, `qwen`, `minimax`, `kimi`, `zai`, or `openrouter`. Start with `anthropic` if unsure. | Pick the provider that issued your `LLM_API_KEY`. ChatGPT Plus login is not supported in Railway because it needs an interactive browser login. `LLM_PROVIDER=claude-cli` is not supported on Railway either — it needs a locally signed-in Claude Code CLI, and neither is `codex-agent`, which additionally cannot be enabled by environment variable. |
 | `LLM_API_KEY` | API key for the provider in `LLM_PROVIDER`. | [Anthropic Console](https://console.anthropic.com/), [OpenAI Platform](https://platform.openai.com/), [Google AI Studio](https://aistudio.google.com/), [DeepSeek Platform](https://platform.deepseek.com/), Alibaba Cloud DashScope, [MiniMax Platform](https://platform.minimaxi.com/), [Moonshot AI](https://platform.moonshot.ai/), [Z.AI](https://z.ai/), or [OpenRouter](https://openrouter.ai/). |
 | `INTERVALS_API_KEY` | Your intervals.icu API key. | [intervals.icu/settings](https://intervals.icu/settings) > Developer Settings. |
 | `INTERVALS_ATHLETE_ID` | Your intervals.icu athlete id, usually like `i12345`. Include the leading `i` when intervals.icu shows one. | Open your intervals.icu profile/settings URL and copy the athlete id from the URL or profile details. |

--- a/packages/engine/src/agent/codex-agent/bridge.ts
+++ b/packages/engine/src/agent/codex-agent/bridge.ts
@@ -8,7 +8,12 @@ import {
   CODEX_MCP_SERVER_NAME,
   type CodexMcpEndpointOverride,
 } from "./config-overrides.js";
-import { disabledLaneError, mcpIsolationError, normalizeCodexAgentError } from "./errors.js";
+import {
+  disabledLaneError,
+  mcpIsolationError,
+  normalizeCodexAgentError,
+  unsupportedPlatformError,
+} from "./errors.js";
 import { startCoachMcpEndpoint, type CoachMcpEndpoint } from "./mcp-endpoint.js";
 import { ensureCodexAgentReady, invalidateCodexAgentProbeCache } from "./probe.js";
 import {
@@ -81,6 +86,7 @@ export type EnsureCodexAgentReady = (
 
 export interface CodexAgentBridgePorts {
   readonly runtime: CodexAgentRuntime;
+  readonly platform?: NodeJS.Platform;
   readonly baseEnv?: NodeJS.ProcessEnv;
   readonly ensureReady?: EnsureCodexAgentReady;
   readonly invalidateProbeCache?: () => void;
@@ -687,6 +693,7 @@ export async function codexAgentGenerateText(
   opts: CodexAgentGenerateOpts,
   ports: CodexAgentBridgePorts,
 ): Promise<GenerateResult> {
+  if ((ports.platform ?? process.platform) === "win32") throw unsupportedPlatformError();
   if (ports.runtime.enabled !== true) throw disabledLaneError();
 
   const baseEnv = ports.baseEnv ?? process.env;

--- a/packages/engine/tests/codex-agent/bridge.test.ts
+++ b/packages/engine/tests/codex-agent/bridge.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { tool } from "ai";
 import { z } from "zod";
 import type { ToolSet } from "ai";
-import { CODEX_AGENT_DISABLED_MESSAGE } from "@enduragent/coach-contract";
+import {
+  CODEX_AGENT_DISABLED_MESSAGE,
+  CODEX_AGENT_WINDOWS_MESSAGE,
+} from "@enduragent/coach-contract";
 
 import { classifyFailure } from "../../../core/src/agent/token-utils.js";
 import {
@@ -149,6 +152,63 @@ describe("codexAgentGenerateText flag-off gate", () => {
       ).rejects.toMatchObject({ kind: "disabled", message: CODEX_AGENT_DISABLED_MESSAGE });
 
       expect(await staged.spawnCount()).toBe(0);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});
+
+describe("codexAgentGenerateText platform gate", () => {
+  it(
+    "refuses without spawning a child when the turn runs on win32",
+    async () => {
+      const staged = await stage("turn-happy");
+
+      await expect(
+        codexAgentGenerateText(chatOpts(), ports(staged.binaryPath, { platform: "win32" })),
+      ).rejects.toMatchObject({
+        name: "CodexAgentConfigError",
+        kind: "unsupported-platform",
+        message: CODEX_AGENT_WINDOWS_MESSAGE,
+      });
+
+      expect(await staged.spawnCount()).toBe(0);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "names the platform before the flag when an enabled-less runtime runs on win32",
+    async () => {
+      const staged = await stage("turn-happy");
+
+      await expect(
+        codexAgentGenerateText(chatOpts(), {
+          runtime: { enabled: false, binaryPath: staged.binaryPath },
+          platform: "win32",
+          baseEnv: baseEnv(),
+          startEndpoint: async (options) => stubEndpoint(Object.keys(options.tools)),
+        }),
+      ).rejects.toMatchObject({
+        kind: "unsupported-platform",
+        message: CODEX_AGENT_WINDOWS_MESSAGE,
+      });
+
+      expect(await staged.spawnCount()).toBe(0);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "runs the turn on a supported platform",
+    async () => {
+      const staged = await stage("turn-happy");
+      const result = await codexAgentGenerateText(
+        chatOpts(),
+        ports(staged.binaryPath, { platform: "darwin" }),
+      );
+
+      expect(result.finishReason).toBe("stop");
+      expect(await staged.spawnCount()).toBe(1);
     },
     TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
Final PR of the Codex agent-delegation lane (follows #483, #484, #485): the user-facing documentation and the changeset — plus one engine fix the documentation turned up.

## Docs

A provider bullet, a config section, and the container/Railway caveats. The section leads with the thing a reader most needs to know before enabling it: **this lane works differently from every other provider.** The others send a prompt and get a reply; here the turn is handed to Codex's own agent loop, with our coaching tools injected over a local MCP endpoint and the coach persona supplied as developer instructions rather than as a system prompt. The retry loop, tool wrapper stack, ledger and stored history all still work; in-context prompt control and per-model-call accounting do not. One coaching turn bills as one call against the subscription however many model calls Codex makes internally, so ledger rows are notional and excluded from the spending cap.

It also documents what gets neutralized for the duration of a coaching turn — every configured MCP server, shell execution, multi-agent, plugins, apps, hooks, browser and computer use, web search — and that a turn is refused rather than degraded if any of it cannot be verified on the spawned child.

## The fix

Documenting the Windows claim exposed that it wasn't true where it mattered. `unsupportedPlatformError()` was defined in the engine and unit-tested, but no production code path ever threw it; the only win32 refusal was the boot-time gate in `run-binary.ts`, and the runtime provider switch neither checks the platform nor re-runs that gate.

This is the third time this lane has produced the same shape — a check that exists, has a test, and isn't on the path a turn takes. The readiness probe was a stub behind the dispatch (#484); the `enabled` flag was declared in the bridge and never read (#485). Each was fixed in the same place and for the same reason: the bridge is the single choke point every surface passes through, so enforcing there covers CLI, daemon, desktop, and whatever comes next.

The guard goes ahead of the `enabled` check, matching the boot gate's ordering, so a Windows user gets "not supported on Windows yet" rather than advice to set a flag that cannot help them. Proven load-bearing: with the guard neutered, the simulated win32 turn runs to completion and spawns a child.

One residual, disclosed rather than papered over: the runtime provider switch still *persists* `codex-agent` on Windows, so the refusal lands at the first message instead of at the switch. Nothing spawns — the only two spawn entrypoints are both post-guard or already win32-gated — so this is a validation gap, not a safety one. It is covered by the deferred Windows-support ticket.

## Fact-check

Every factual claim in the docs was verified against the code by a fresh-context read-only pass — seventeen of them individually, each requiring its own citation. Fifteen held. Two did not, and both were corrected before this PR was pushed:

- **"No approval can be granted"** was overstated. The lane grants standing pre-approval to its own tools so they can run unattended, and refuses the turn if that pre-approval has been widened — a required invariant, not an oversight. A reader would have concluded nothing runs that needs approval. It now says no approval can be *requested or interactively* granted, and names the exception.
- **"Nothing is vendored"** was literally false. No binary and no dependency, but the repo does check in Codex-generated JSON schemas. They never reach users (`files: ["dist"]`), so the intent was right and the wording wasn't. It now says no CLI binary is bundled and no native module is added.

The same pass also corrected "18 coaching tools" to note the count is cycling-with-intervals.icu specific and lower without.

## Verification

Root `pnpm check` green. Full engine suite green (1275 passed). Full suite green — every failure classified as another session's worktree or a load flake, each re-run in isolation. Changeset and trademark gates green.
