### PR TITLE
fix(desktop): stop macOS privacy prompts for music and Desktop

### DIFF
--- a/.changeset/quiet-macos-privacy-prompts.md
+++ b/.changeset/quiet-macos-privacy-prompts.md
@@ -1,0 +1,13 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: The desktop app no longer triggers macOS prompts asking for your music library or your Desktop folder.
+
+Two unrelated causes, both incidental rather than intentional access.
+
+Chromium registers with the macOS Now Playing / media-key integration on startup, which macOS reports as a media-library access request even though the app has no audio surface at all. `disableChromiumMediaSessionIntegration()` appends `MediaSessionService` and `HardwareMediaKeyHandling` to Chromium's `disable-features`, merging with Electron's own defaults rather than replacing them.
+
+The ride-file chooser called `showOpenDialog` without a `defaultPath`, so the non-sandboxed `NSOpenPanel` opened at the system default — the Desktop — and the app itself was the accessing process. The chooser now opens at the home root, which is not a protected location. Navigating into Desktop or Documents still asks, which is the correct consent-in-context behaviour.
+
+Neither the app nor its entitlements ever requested this access; the prompts became visible only because code signing changed the app's privacy identity.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -77,6 +77,16 @@ import {
 
 registerDesktopScheme();
 
+function disableChromiumMediaSessionIntegration(): void {
+  const alreadyDisabled = app.commandLine.getSwitchValue("disable-features");
+  app.commandLine.appendSwitch(
+    "disable-features",
+    [alreadyDisabled, "MediaSessionService", "HardwareMediaKeyHandling"]
+      .filter((feature) => feature.length > 0)
+      .join(","),
+  );
+}
+
 let desktopIsClosing = false;
 
 const mainDirectory = dirname(fileURLToPath(import.meta.url));
@@ -750,6 +760,7 @@ const primaryInstance = app.requestSingleInstanceLock();
 if (!primaryInstance) {
   app.exit(0);
 } else {
+  disableChromiumMediaSessionIntegration();
   const runPrimaryDesktop = process.argv.includes("--desktop-runtime-smoke")
     ? runRuntimeSmoke
     : runDesktop;

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -1,3 +1,4 @@
+import { homedir } from "node:os";
 import { extname, isAbsolute } from "node:path";
 import type {
   ConfigureRuntimeRpcParams,
@@ -363,6 +364,7 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
     let result: Awaited<ReturnType<OnboardingDialogPort["showOpenDialog"]>>;
     try {
       result = await options.dialog.showOpenDialog(options.window, {
+        defaultPath: homedir(),
         properties: ["openFile", "multiSelections"],
         filters: [{ name: "Ride files", extensions: ["fit", "tcx", "gpx"] }],
       });

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -1,3 +1,4 @@
+import { homedir } from "node:os";
 import type { IpcMainInvokeEvent } from "electron";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -788,7 +789,10 @@ describe("desktop onboarding IPC", () => {
     await expect(
       subject.invoke(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL, subject.trustedEvent),
     ).resolves.toEqual(["/synthetic/ride.fit"]);
+    const chooserDefaultPath = homedir();
+    expect(chooserDefaultPath).not.toMatch(/\/(Desktop|Documents|Downloads)(\/|$)/);
     expect(subject.dialog.showOpenDialog).toHaveBeenCalledWith(expect.anything(), {
+      defaultPath: chooserDefaultPath,
       properties: ["openFile", "multiSelections"],
       filters: [{ name: "Ride files", extensions: ["fit", "tcx", "gpx"] }],
     });

--- a/apps/desktop/tests/residency.test.ts
+++ b/apps/desktop/tests/residency.test.ts
@@ -56,6 +56,7 @@ const mocks = vi.hoisted(() => {
     getVersion: vi.fn(() => "0.0.1"),
     getPath: vi.fn(() => "/synthetic/user-data"),
     getAppPath: vi.fn(() => "/synthetic/app"),
+    commandLine: { getSwitchValue: vi.fn(() => ""), appendSwitch: vi.fn() },
   });
   return {
     order,
@@ -322,6 +323,7 @@ describe("desktop residency", () => {
     await import("../src/main/index.js");
     expect(mocks.app.exit).toHaveBeenCalledWith(0);
     expect(mocks.app.whenReady).not.toHaveBeenCalled();
+    expect(mocks.app.commandLine.appendSwitch).not.toHaveBeenCalled();
     expect(mocks.BrowserWindow).not.toHaveBeenCalled();
     expect(mocks.FakeTray.instances).toHaveLength(0);
     expect(mocks.app.getLoginItemSettings).not.toHaveBeenCalled();


### PR DESCRIPTION
The first launch of the signed build produced three macOS privacy dialogs: Apple Music / media library, Desktop folder, and files on a network volume. A training app asking for the user's music library reads as malware, so this is a first-run trust problem rather than a data-access one.

## Nothing was actually being requested

- `build/entitlements.mac.plist` carries one entitlement, `com.apple.security.cs.allow-jit`.
- The packaged `Info.plist` has only electron-builder's boilerplate usage strings; no music, desktop, or volume keys.
- No source under `apps/desktop/src`, `apps/desktop-renderer/src`, `packages/sync-file-import/src`, or `packages/core/src` references `~/Desktop`, `~/Music`, or `/Volumes`. The only `app.getPath` call in main is `getPath("userData")`; the only `readdir` is over the credential vault.
- `lsof` across the live process tree shows the app's entire non-Electron file footprint is `~/.enduragent/store/store.db{,-shm,-wal}`.
- Resetting the grants with `tccutil reset` and relaunching produced no prompt, so nothing on a startup path triggers them.

They became visible now only because code signing changed the app's privacy identity. Earlier dev launches inherited the terminal's existing grants; a Finder-launched signed app is its own responsible process.

## Two incidental causes

**Media library.** `Electron Framework` links `MediaPlayer.framework`. Chromium's media-session integration registers with `MPNowPlayingInfoCenter`/`MPRemoteCommandCenter` for hardware media-key handling, and macOS attributes that to the media-library service. Every Electron app inherits this whether or not it plays audio; this one plays none.

**Desktop folder.** The ride-file chooser called `showOpenDialog` with no `defaultPath`. In a non-sandboxed app `NSOpenPanel` runs in-process, so the app is the accessing process for whatever directory the panel opens at — the system default, Desktop.

## Changes

- `index.ts` gains `disableChromiumMediaSessionIntegration()`, appending `MediaSessionService` and `HardwareMediaKeyHandling` to `disable-features`. It reads the existing value first and merges, so Electron's own six defaults survive. It runs after the single-instance gate, so a losing instance still exits before doing any work.
- `onboarding-ipc.ts` passes `defaultPath: homedir()`. The home root is not protected, so opening the picker no longer trips the prompt. Navigating into Desktop or Documents still asks, which is the consent-in-context behaviour macOS intends.

## Verification

Live-checked against a built app: the helper processes now carry

```
--disable-features=DropInputEventsWhilePaintHolding,HardwareMediaKeyHandling,LocalNetworkAccessChecks,MediaSessionService,ScreenAIOCREnabled,SpareRendererForSitePerProcess,TimeoutHangingVideoCaptureStarts,TraceSiteInstanceGetProcessCreation
```

confirming both additions and that the merge preserved every Electron default.

`residency.test.ts` gains a `commandLine` mock and asserts a losing instance never appends a switch. `onboarding-ipc.test.ts` pins the chooser's `defaultPath` and asserts it is not a protected folder. Desktop suite green (736 tests); root `check:types`, `check:trademarks`, and `check:changeset-userfacing` clean.

## Not fixed here

The network-volume prompt comes from `NSOpenPanel`'s sidebar enumerating mounted volumes — AppKit behaviour with no Electron-side switch. It fires only when a non-boot volume is mounted and only when the picker opens, which is why it appeared while the install disk image was still attached. Drag-and-drop already exists as a complete alternative and triggers nothing. Options are tracked in the local issue notes.