### PR TITLE
fix(coach): report keyless providers as credential configured

### DIFF
--- a/.changeset/keyless-provider-credential-configured.md
+++ b/.changeset/keyless-provider-credential-configured.md
@@ -1,0 +1,11 @@
+---
+"cycling-coach": patch
+"@enduragent/coach": patch
+"@enduragent/desktop-renderer": patch
+---
+
+User-facing: Setup now remembers the Claude subscription lane instead of showing Anthropic when you reopen it.
+
+`credential_configured` was derived from a non-empty `llm.api_key` for every provider except `openai-codex`, so the keyless lanes that never write a key — `claude-cli` and `codex-agent` — were structurally false forever. That nulled the onboarding wizard's active provider, and the Setup draft then fell through to the first entry in the provider catalogue. The runtime check now short-circuits on `isKeylessProvider` and only falls through to the key-length test for providers that actually hold a key. The `openai-codex` branch stays ahead of that short-circuit, so the ChatGPT lane still depends on a stored auth profile rather than reporting itself configured with nothing on disk.
+
+Populating the active provider exposed a latent assumption in the Settings coach panel: it treated an active provider that is absent from the public model catalogue as an unloadable configuration. `codex-agent` is deliberately absent from the catalogue, so that path became reachable for the first time and would have left those athletes on a dead error screen with no way to switch away. The panel now loads with the provider list intact and no draft selection, and the coach route row reads the active provider off the runtime snapshot instead of the draft, so it no longer reports "Not configured" for a provider that is actually serving turns. An empty catalogue is still a genuine load error.

--- a/apps/desktop-renderer/src/settings/provider-model-controller.ts
+++ b/apps/desktop-renderer/src/settings/provider-model-controller.ts
@@ -174,10 +174,7 @@ export function createProviderModelSettingsController(input: {
               : configuration.providers.find(
                   (provider) => provider.provider === configuration.active?.provider,
                 );
-          if (
-            configuration.providers.length === 0 ||
-            (configuration.active !== null && !activeProvider)
-          ) {
+          if (configuration.providers.length === 0) {
             render({
               status: "error",
               kind: "load",
@@ -187,9 +184,9 @@ export function createProviderModelSettingsController(input: {
           }
           providerDrafts = new Map();
           const draft =
-            configuration.active === null
+            configuration.active === null || activeProvider === undefined
               ? null
-              : draftFor(activeProvider!, configuration.active.model);
+              : draftFor(activeProvider, configuration.active.model);
           if (draft !== null) providerDrafts.set(draft.provider.provider, draft);
           render({
             status: "ready",

--- a/apps/desktop-renderer/src/ui/settings/CoachSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CoachSection.tsx
@@ -36,6 +36,14 @@ function modelLabel(form: ProviderModelFormState): string {
   );
 }
 
+function routeLabel(form: ProviderModelFormState): string | null {
+  if (form.draft !== null) {
+    return `${ONBOARDING_LLM_PROVIDER_LABELS[form.draft.provider.provider]} → ${modelLabel(form)}`;
+  }
+  if (form.active === null) return null;
+  return `${ONBOARDING_LLM_PROVIDER_LABELS[form.active.provider]} → ${form.active.model}`;
+}
+
 function feedbackCopy(state: ProviderModelSettingsState): string | null {
   if (state.status === "closed" || state.status === "loading") return "Loading coach settings…";
   if (state.status === "error" && state.kind === "load") {
@@ -71,12 +79,10 @@ export function CoachSection(): ReactElement {
   const canSave =
     editable !== null && draft !== null && editable.dirty && editable.validationError === null;
   const feedback = feedbackCopy(state);
-  const route =
-    editable === null || draft === null
-      ? "Not configured"
-      : `${ONBOARDING_LLM_PROVIDER_LABELS[draft.provider.provider]} → ${modelLabel(editable)}`;
+  const routeSummary = editable === null ? null : routeLabel(editable);
+  const route = routeSummary ?? "Not configured";
   const routeState =
-    draft === null ? "Not active" : editable?.dirty === true ? "Unsaved" : "Active";
+    routeSummary === null ? "Not active" : editable?.dirty === true ? "Unsaved" : "Active";
   const validation =
     editable?.validationError == null ? "" : COACH_VALIDATION_COPY[editable.validationError];
 
@@ -89,7 +95,7 @@ export function CoachSection(): ReactElement {
             <div className={styles.rowTitle}>Coach route</div>
             <div className={styles.rowDetail}>{route}</div>
           </div>
-          <span className={styles.runtime} data-state={draft === null ? "failed" : "active"}>
+          <span className={styles.runtime} data-state={routeSummary === null ? "failed" : "active"}>
             {routeState}
           </span>
         </div>

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -185,7 +185,7 @@ describe("credential settings controller", () => {
       runtime: runtime({
         provider: "claude-cli",
         model: "sonnet",
-        credential_configured: false,
+        credential_configured: true,
       }),
       statuses: [],
       chatGpt: { state: "absent", runtimeReady: false },
@@ -210,7 +210,7 @@ describe("credential settings controller", () => {
 
   it("shows api-key billing on the status row instead of a subscription claim", async () => {
     const { controller } = createSubject({
-      runtime: runtime({ provider: "claude-cli", model: "sonnet", credential_configured: false }),
+      runtime: runtime({ provider: "claude-cli", model: "sonnet", credential_configured: true }),
       statuses: [],
       chatGpt: { state: "absent", runtimeReady: false },
       claudeCli: async () => ({ state: "ready-api-key" }),
@@ -225,7 +225,7 @@ describe("credential settings controller", () => {
 
   it("explains a turned-off lane and a failed probe without inventing an identity", async () => {
     const disabled = createSubject({
-      runtime: runtime({ provider: "claude-cli", model: "sonnet", credential_configured: false }),
+      runtime: runtime({ provider: "claude-cli", model: "sonnet", credential_configured: true }),
       statuses: [],
       chatGpt: { state: "absent", runtimeReady: false },
       claudeCli: async () => ({ state: "disabled" }),
@@ -240,7 +240,7 @@ describe("credential settings controller", () => {
     });
 
     const unavailable = createSubject({
-      runtime: runtime({ provider: "claude-cli", model: "sonnet", credential_configured: false }),
+      runtime: runtime({ provider: "claude-cli", model: "sonnet", credential_configured: true }),
       statuses: [],
       chatGpt: { state: "absent", runtimeReady: false },
       claudeCli: async () => {

--- a/apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx
@@ -29,6 +29,11 @@ const CLAUDE_CLI_CONFIGURATION: OnboardingLlmConfiguration = {
   active: null,
 };
 
+const ACTIVE_CLAUDE_CLI_CONFIGURATION: OnboardingLlmConfiguration = {
+  ...CLAUDE_CLI_CONFIGURATION,
+  active: { provider: "claude-cli", model: "sonnet" },
+};
+
 function claudeBridge(status: ClaudeCliStatus, overrides: Partial<OnboardingBridge> = {}) {
   const bridge: TestBridge = testBridge(async () => ({
     status: "refused",
@@ -209,6 +214,26 @@ describe("claude-cli onboarding lane", () => {
     });
     expect(identityLine()).toBe("Signed in as athlete@example.test - Claude Max subscription");
     expect(document.body.textContent).not.toContain("probe unavailable");
+    wizard.controller.dispose();
+  });
+
+  it("preselects the lane when the daemon reports it as the active provider", async () => {
+    const bridge = claudeBridge({ state: "ready", email: "athlete@example.test", plan: "Max" });
+    bridge.llmConfiguration.mockResolvedValue(ACTIVE_CLAUDE_CLI_CONFIGURATION);
+    const wizard = await openLane(bridge);
+
+    expect(control<HTMLSelectElement>("onboarding-llm-provider").value).toBe("claude-cli");
+    expect(control<HTMLSelectElement>("onboarding-llm-model").value).toBe("sonnet");
+    wizard.controller.dispose();
+  });
+
+  it("falls back to the first provider when the daemon reports no active provider", async () => {
+    const wizard = await openLane(
+      claudeBridge({ state: "ready", email: "athlete@example.test", plan: "Max" }),
+    );
+
+    expect(control<HTMLSelectElement>("onboarding-llm-provider").value).toBe("anthropic");
+    expect(control<HTMLSelectElement>("onboarding-llm-model").value).toBe("claude-sonnet-4-6");
     wizard.controller.dispose();
   });
 

--- a/apps/desktop-renderer/tests/provider-model-settings.test.ts
+++ b/apps/desktop-renderer/tests/provider-model-settings.test.ts
@@ -189,6 +189,57 @@ describe("provider and model settings controller", () => {
     });
   });
 
+  it("keeps the panel usable when the active provider is absent from the catalogue", async () => {
+    const { controller, subject, apply } = createSubject({
+      load: vi.fn(async () => configuration({ provider: "codex-agent", model: "gpt-codex" })),
+    });
+
+    await controller.activate();
+    expect(formState(controller)).toMatchObject({
+      status: "ready",
+      active: { provider: "codex-agent", model: "gpt-codex" },
+      draft: null,
+      dirty: false,
+      validationError: null,
+    });
+    expect(formState(controller).providers).toEqual(PROVIDERS);
+
+    subject.provider("openai");
+    expect(formState(controller)).toMatchObject({
+      draft: {
+        provider: { provider: "openai" },
+        modelChoice: "gpt-standard",
+      },
+      dirty: true,
+    });
+
+    subject.save();
+    await vi.waitFor(() => expect(controller.state().status).toBe("saved"));
+    expect(apply).toHaveBeenCalledWith({
+      provider: "openai",
+      model: "gpt-standard",
+      endpoint: { mode: "automatic" },
+    });
+    expect(formState(controller)).toMatchObject({
+      active: { provider: "openai", model: "gpt-standard" },
+      dirty: false,
+    });
+  });
+
+  it("treats an empty provider catalogue as an unavailable configuration", async () => {
+    const { controller } = createSubject({
+      load: vi.fn(async () => ({ schemaVersion: 1 as const, providers: [], active: null })),
+    });
+
+    await controller.activate();
+
+    expect(controller.state()).toEqual({
+      status: "error",
+      kind: "load",
+      reason: "configuration-unavailable",
+    });
+  });
+
   it("uses each provider default first and retains a previously edited provider draft", async () => {
     const { controller, subject } = createSubject({});
     await controller.activate();

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -139,6 +139,7 @@ interface HarnessOptions {
   readonly applyLlmSelection?: (
     selection: OnboardingLlmSelection,
   ) => Promise<OnboardingLlmSelectionResult>;
+  readonly llm?: () => OnboardingLlmConfiguration;
   readonly credentialStatuses?: readonly CredentialSlotStatus[];
   readonly chatGptStatus?: ChatGptStatus;
   readonly claudeCliStatus?: () => Promise<ClaudeCliStatus>;
@@ -254,7 +255,7 @@ function createHarness(options: HarnessOptions = {}) {
     view: athleteAdapter.view,
   });
   const coachController = createProviderModelSettingsController({
-    load: async () => llmConfiguration(),
+    load: async () => (options.llm ?? llmConfiguration)(),
     apply: applyLlmSelection,
     openSetup,
     beginMutation: () => store.getState().beginSettingsMutation("provider-model"),
@@ -557,7 +558,7 @@ describe("keyless provider status", () => {
     await renderSettings({
       runtime: () =>
         snapshot({
-          llm: { provider: "claude-cli", model: "sonnet", credential_configured: false },
+          llm: { provider: "claude-cli", model: "sonnet", credential_configured: true },
         }),
       credentialStatuses: [],
       claudeCliStatus: async () => ({
@@ -583,7 +584,7 @@ describe("keyless provider status", () => {
     await renderSettings({
       runtime: () =>
         snapshot({
-          llm: { provider: "claude-cli", model: "sonnet", credential_configured: false },
+          llm: { provider: "claude-cli", model: "sonnet", credential_configured: true },
         }),
       credentialStatuses: [],
       claudeCliStatus: async () => ({ state: "ready-api-key" }),
@@ -640,6 +641,34 @@ describe("coach route", () => {
     );
     await user.click(openSetup);
     expect(subject.openSetup).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the route active when the active provider is outside the catalogue", async () => {
+    await renderSettings({
+      llm: () => ({
+        ...llmConfiguration(),
+        active: { provider: "codex-agent", model: "synthetic-codex" },
+      }),
+    });
+
+    const coach = within(screen.getByRole("region", { name: "Coach" }));
+    expect(coach.getByText("Codex agent (experimental) → synthetic-codex")).toBeInTheDocument();
+    expect(coach.getByText("Active")).toHaveAttribute("data-state", "active");
+    expect(
+      coach.getByText("Currently active: Codex agent (experimental) · synthetic-codex"),
+    ).toBeInTheDocument();
+    expect(coach.queryByText("Not configured")).toBeNull();
+  });
+
+  it("marks the route not configured when no provider is active", async () => {
+    await renderSettings({ llm: () => ({ ...llmConfiguration(), active: null }) });
+
+    const coach = within(screen.getByRole("region", { name: "Coach" }));
+    expect(coach.getByText("Not configured")).toBeInTheDocument();
+    expect(coach.getByText("Not active")).toHaveAttribute("data-state", "failed");
+    expect(
+      coach.getByText("Active coach settings are unavailable or not configured."),
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import type { IpcMainInvokeEvent } from "electron";
 import { describe, expect, it, vi } from "vitest";
+import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
 import {
   DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL,
   DESKTOP_CHATGPT_LOGIN_CHANNEL,
@@ -83,7 +84,7 @@ function harness(
     invalidateProbeCache: vi.fn(),
     activate: vi.fn(async () => ({ status: "configured" as const, runtimeReady: true as const })),
   };
-  const getRuntimeConfig = vi.fn(async () => ({
+  const getRuntimeConfig = vi.fn(async (): Promise<RuntimeConfigSnapshot> => ({
     schemaVersion: 3 as const,
     llm: {
       provider: "anthropic" as const,
@@ -440,6 +441,49 @@ describe("desktop onboarding IPC", () => {
     await expect(
       subject.invoke(DESKTOP_LLM_CONFIGURATION_CHANNEL, subject.trustedEvent, null),
     ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("keeps a keyless subscription lane as the minimized active selection", async () => {
+    const subject = harness();
+    subject.getRuntimeConfig.mockResolvedValueOnce({
+      schemaVersion: 3,
+      llm: {
+        provider: "claude-cli",
+        model: "athlete-selected-model",
+        credential_configured: true,
+      },
+      intervals: {
+        athlete_id: "synthetic-athlete",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: false },
+      },
+      session: {
+        historyTokenBudgetRatio: 0.3,
+        idleMinutes: 0,
+        dailyResetHour: 4,
+        resetArchiveRetentionDays: 0,
+        timezone: "UTC",
+        managedByEnvironment: {
+          historyTokenBudgetRatio: false,
+          idleMinutes: false,
+          dailyResetHour: false,
+          resetArchiveRetentionDays: false,
+          timezone: false,
+        },
+      },
+    });
+
+    const result = (await subject.invoke(
+      DESKTOP_LLM_CONFIGURATION_CHANNEL,
+      subject.trustedEvent,
+    )) as { readonly active: Record<string, unknown> };
+
+    expect(result.active).toEqual({
+      provider: "claude-cli",
+      model: "athlete-selected-model",
+    });
+    expect(Object.keys(result.active).sort()).toEqual(["model", "provider"]);
+    expect(JSON.stringify(result)).not.toMatch(/credential|api[_-]?key|path|error/i);
   });
 
   it("keeps the catalogue available with a null active selection when snapshotting fails", async () => {

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -379,18 +379,21 @@ function persistRuntimeConfig(
 }
 
 function runtimeCredentialConfigured(configDir: string, config: Config): boolean {
-  if (config.llm.provider !== "openai-codex") return config.llm.apiKey.length > 0;
-  try {
-    const snapshot = loadStoredProfileSnapshot(
-      join(configDir, "auth-profiles.json"),
-      config.llm.authProfile ?? "openai-codex",
-    );
-    if (snapshot === null) return false;
-    credential(snapshot.profile);
-    return true;
-  } catch {
-    return false;
+  if (config.llm.provider === "openai-codex") {
+    try {
+      const snapshot = loadStoredProfileSnapshot(
+        join(configDir, "auth-profiles.json"),
+        config.llm.authProfile ?? "openai-codex",
+      );
+      if (snapshot === null) return false;
+      credential(snapshot.profile);
+      return true;
+    } catch {
+      return false;
+    }
   }
+  if (isKeylessProvider(config.llm.provider)) return true;
+  return config.llm.apiKey.length > 0;
 }
 
 function runtimeConfigSnapshot(

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
-import { unlinkSync } from "node:fs";
+import { existsSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -1469,6 +1469,110 @@ describe("local coach composition", () => {
     ).toBeNull();
     await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
       llm: { provider: "openai-codex", credential_configured: false },
+    });
+    await lifecycle.close();
+  });
+
+  it.each(["claude-cli", "codex-agent"] as const)(
+    "reports %s as credential configured without an API key",
+    async (provider) => {
+      const home = await freshHome();
+      const initial: Config = {
+        ...config(home),
+        llm: { ...config(home).llm, provider, model: "sonnet", apiKey: "" },
+      };
+      const lifecycle = await compose(
+        home,
+        {
+          bootstrap: async () => reference(),
+          createRuntime: () => runtime(),
+          createBackend: () => backend(),
+          createRepository: () => ({
+            insertIfAbsent: async () => false,
+            readCurrent: async () => undefined,
+          }),
+          createResolver: () => missingResolver(),
+        },
+        fakeContext(home),
+        undefined,
+        initial,
+      );
+
+      await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+        llm: { provider, model: "sonnet", credential_configured: true },
+      });
+      await lifecycle.close();
+    },
+  );
+
+  it("keeps the ChatGPT profile check ahead of the keyless short circuit", async () => {
+    const home = await freshHome();
+    const initial: Config = {
+      ...config(home),
+      llm: {
+        ...config(home).llm,
+        provider: "openai-codex",
+        apiKey: "",
+        authProfile: "openai-codex",
+      },
+    };
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    expect(existsSync(join(home.configDir, "auth-profiles.json"))).toBe(false);
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      llm: { provider: "openai-codex", credential_configured: false },
+    });
+    await lifecycle.close();
+  });
+
+  it("still reports a keyed provider from its stored API key alone", async () => {
+    const home = await freshHome();
+    const initial: Config = {
+      ...config(home),
+      llm: { ...config(home).llm, provider: "anthropic", apiKey: "" },
+    };
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      llm: { provider: "anthropic", credential_configured: false },
+    });
+
+    await lifecycle.operations.configureRuntime({
+      llm: { provider: "anthropic", api_key: "obviously-fake-anthropic-key" },
+    });
+
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      llm: { provider: "anthropic", credential_configured: true },
     });
     await lifecycle.close();
   });


### PR DESCRIPTION
## Problem

`runtimeCredentialConfigured()` decided `credential_configured` by asking "is there a non-empty `llm.api_key`?" for every provider except `openai-codex`. The keyless lanes — `claude-cli` and `codex-agent` — never write an api_key by design, so the flag was **structurally false for them, permanently**.

The onboarding wizard gates its "which provider is currently active" answer on that flag. With the flag false the wizard reported *no active provider*, and its dropdown fell back to the first catalogue entry, Anthropic. Activate the Claude subscription lane, reopen Setup, and it showed Anthropic with "Claude Sonnet 5 · recommended" — as if you never chose the lane. Pressing Continue there re-applies Anthropic, silently moving the athlete off the lane they picked.

The same hole had already been recognised and patched one layer down, in `readSelectedLlmProvider()` (`credential-runtime.ts`), which carries its own `isKeylessProvider` guard. `llmConfiguration()` never got the equivalent. Fixed at the source rather than by adding a third compensating guard.

## The fix

`packages/coach/src/composition.ts` — the `openai-codex` branch keeps its real auth-profile check, then the remaining keyless lanes short-circuit to `true`, then keyed providers fall back to the key-length test.

**Ordering is load-bearing.** `openai-codex` is itself in `KEYLESS_LLM_PROVIDERS`, so a naive leading `if (isKeylessProvider(p)) return true` would delete the ChatGPT lane's profile validation and report it configured with no profile on disk. There is a regression test for exactly this.

## A second defect this surfaced

Populating `active` made a previously unreachable path reachable in the Settings coach panel. `provider-model-controller.ts` treated an active provider absent from the public catalogue as an unloadable configuration:

```ts
if (configuration.providers.length === 0 || (configuration.active !== null && !activeProvider)) {
  render({ status: "error", kind: "load", reason: "configuration-unavailable" });
```

`codex-agent` is deliberately absent from `LLM_MODEL_CATALOGUE`, so an athlete on that lane would have gone from a working panel to a dead error screen — with the provider dropdown being the only way off the lane. Every other provider that can be active is in the catalogue, which is why the branch was dead before.

The panel now loads with the provider list intact and `draft: null` (the shape the `active === null` path already produced), so switching away still works. An empty catalogue is still a genuine load error. `CoachSection` then needed the route row read off `active` rather than `draft`, or the screen would have said "Not configured / Not active" directly above "Currently active: Codex agent (experimental)".

`isDirty()` and `validationError()` already guard `draft === null` before touching `active`, and `CoachSection`'s `canSave` plus `save()` both already require a non-null draft — so no downstream null-draft assumption needed changing.

## Blast radius

Every reader of `llm.credential_configured` was re-derived from scratch, not taken from a list.

| Consumer | Effect | Verdict |
|---|---|---|
| `onboarding-ipc.ts:214` | `active` now populated for keyless lanes | this is the fix |
| `credential-runtime.ts:70` | returns provider at `:70` instead of `:73` | same result, shorter path |
| `onboarding-ipc.ts:291` | compares against `DESKTOP_CREDENTIAL_SLOTS`, which holds no keyless provider | unreachable |
| `chatgpt-auth.ts:137` | guards on `openai-codex`, whose branch is unchanged | safe |
| `provider-model-controller.ts` | out-of-catalogue active provider | **fixed here** |
| `settings/athlete-controller.ts` | reads `intervals.credential_configured`, a different field | unaffected |

One further claim was investigated and **refuted by experiment**: that populating `active` lets the wizard skip the Claude CLI host check in `selectedProviderIsReady()`. It does not. That gate is only consulted when `saveError === null` — i.e. after the daemon accepted the selection — and the success branch overwrites `llmConfiguration.active` with the just-applied selection, so the short-circuit already returned true on that path before this change. `claude-cli` has no password input, so `selectedApplied` is never set and `applyLlmSelection` always runs; a daemon refusal still blocks advancement. A throwaway four-way test (active populated vs null × daemon refusing vs accepting, host probe signed-out throughout) produced identical observable outcomes before and after.

## Tests

- `packages/coach/tests/composition.test.ts` — `claude-cli` and `codex-agent` report configured with an empty api_key; `openai-codex` still reports false with no `auth-profiles.json` (the ordering guard); keyed providers unchanged. **This is the real regression pin** — it drives the actual producer.
- `apps/desktop/tests/onboarding-ipc.test.ts` — the channel returns `active: { provider: "claude-cli", model }`. Required widening the harness mock's return type to `RuntimeConfigSnapshot`; its inferred literal type had pinned `provider` to `"anthropic"`.
- `apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx` — dropdown preselects the lane, and still falls back to Anthropic when nothing is active.
- `apps/desktop-renderer/tests/provider-model-settings.test.ts` — out-of-catalogue active provider loads ready and stays recoverable through select + save; empty catalogue still errors.
- `apps/desktop-renderer/tests/settings-surface.test.tsx` — route row renders the active provider, and still reads "Not configured" when nothing is active.

Stale fixtures hard-coding `credential_configured: false` alongside a `claude-cli` provider were flipped in `settings-surface.test.tsx` and `credential-settings.test.ts`. They fed hand-built snapshots to stubs so they passed either way, but that combination is no longer emittable. `intervals.credential_configured` and keyed-provider fixtures were left alone.

## Verification

`pnpm check` clean. `apps/desktop-renderer` 530/530, `apps/desktop` 741/741, `packages/coach/tests/composition.test.ts` 90/90.

The coach package has 5 pre-existing failures (`backfill`, `backfill-sigkill`, `reference-capture-gate`, `upgrade-fence`) that are load-dependent — 14 at full worker concurrency, 5 at `--maxWorkers=3`. Confirmed identical on stock `main` with the branch stashed; unrelated to this change.

## Note on the ticket's import instruction

The ticket asked for `isKeylessProvider` to come from `@enduragent/coach-contract` rather than `@enduragent/core`'s re-export. It was already imported from `@enduragent/core` in this file and used at line 256, so a second import would collide. `packages/core/src/runtime-config.ts:9` is a pure pass-through, and the changeset that introduced the predicate states it is "re-exported from the core runtime config for core, coach and desktop consumers" — so the existing import is the intended path.
