### PR TITLE
fix(desktop): isolate development package identity

### DIFF
--- a/.changeset/desktop-development-identity.md
+++ b/.changeset/desktop-development-identity.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Isolate local Desktop packages and packaged security checks from the production macOS application identity so development verification cannot alter production Keychain access state.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,7 +8,7 @@
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "check": "tsc --noEmit",
-    "package:dir": "pnpm build:self-test-resources && electron-vite build && electron-builder --dir",
+    "package:dir": "pnpm build:self-test-resources && electron-vite build && node scripts/development-package-plan.mjs",
     "package:mac": "pnpm build:self-test-resources && electron-vite build && node scripts/macos-release-plan.mjs",
     "build:self-test-resources": "tsx scripts/build-self-test-resources.ts",
     "stage:extra-resources": "node scripts/stage-extra-resources.mjs",

--- a/apps/desktop/scripts/development-package-plan.d.mts
+++ b/apps/desktop/scripts/development-package-plan.d.mts
@@ -1,0 +1,61 @@
+export interface DevelopmentPackageInput {
+  readonly desktopRoot?: string;
+}
+
+export interface DevelopmentPackageBuilderOptions {
+  readonly projectDir: string;
+  readonly publish: "never";
+  readonly config: {
+    readonly extends: string;
+    readonly appId: "icu.enduragent.desktop.development";
+    readonly productName: "Enduragent Development";
+    readonly directories: {
+      readonly output: "dist/development";
+    };
+    readonly forceCodeSigning: false;
+    readonly extraMetadata: {
+      readonly name: "enduragent-desktop-development";
+      readonly enduragentDesktopDevelopment: true;
+    };
+    readonly mac: {
+      readonly identity: null;
+      readonly target: readonly [{ readonly target: "dir"; readonly arch: readonly ["arm64"] }];
+    };
+  };
+}
+
+export interface DevelopmentPackagePlan {
+  readonly applicationPath: string;
+  readonly executablePath: string;
+  readonly outputPath: string;
+  readonly builderOptions: DevelopmentPackageBuilderOptions;
+}
+
+export interface DevelopmentPackageDependencies {
+  readonly rm?: (
+    path: string,
+    options: { readonly recursive: true; readonly force: true },
+  ) => Promise<void>;
+  readonly build?: (options: DevelopmentPackageBuilderOptions) => Promise<readonly string[]>;
+  readonly verifyPackageLayout?: (
+    application: string,
+    options: { readonly desktopRoot: string; readonly development: true },
+  ) => Promise<void>;
+}
+
+export const DEVELOPMENT_APP_ID: "icu.enduragent.desktop.development";
+export const DEVELOPMENT_PRODUCT_NAME: "Enduragent Development";
+export const DEVELOPMENT_PACKAGE_NAME: "enduragent-desktop-development";
+export const DEVELOPMENT_OUTPUT_DIRECTORY: "dist/development";
+
+export function createDevelopmentPackagePlan(
+  input?: DevelopmentPackageInput,
+): DevelopmentPackagePlan;
+
+export function runDevelopmentPackage(
+  input?: DevelopmentPackageInput,
+  dependencies?: DevelopmentPackageDependencies,
+): Promise<{
+  readonly artifacts: readonly string[];
+  readonly plan: DevelopmentPackagePlan;
+}>;

--- a/apps/desktop/scripts/development-package-plan.mjs
+++ b/apps/desktop/scripts/development-package-plan.mjs
@@ -1,0 +1,75 @@
+import { rm } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const canonicalDesktopRoot = resolve(scriptDirectory, "..");
+
+export const DEVELOPMENT_APP_ID = "icu.enduragent.desktop.development";
+export const DEVELOPMENT_PRODUCT_NAME = "Enduragent Development";
+export const DEVELOPMENT_PACKAGE_NAME = "enduragent-desktop-development";
+export const DEVELOPMENT_OUTPUT_DIRECTORY = "dist/development";
+
+export function createDevelopmentPackagePlan(input = {}) {
+  const desktopRoot = input.desktopRoot ?? canonicalDesktopRoot;
+  if (!isAbsolute(desktopRoot)) {
+    throw new TypeError("desktop root must be absolute");
+  }
+  const outputPath = join(desktopRoot, DEVELOPMENT_OUTPUT_DIRECTORY);
+  const applicationPath = join(outputPath, "mac-arm64", `${DEVELOPMENT_PRODUCT_NAME}.app`);
+  return Object.freeze({
+    applicationPath,
+    executablePath: join(applicationPath, "Contents", "MacOS", DEVELOPMENT_PRODUCT_NAME),
+    outputPath,
+    builderOptions: {
+      projectDir: desktopRoot,
+      publish: "never",
+      config: {
+        extends: join(desktopRoot, "electron-builder.yml"),
+        appId: DEVELOPMENT_APP_ID,
+        productName: DEVELOPMENT_PRODUCT_NAME,
+        directories: { output: DEVELOPMENT_OUTPUT_DIRECTORY },
+        forceCodeSigning: false,
+        extraMetadata: {
+          name: DEVELOPMENT_PACKAGE_NAME,
+          enduragentDesktopDevelopment: true,
+        },
+        mac: {
+          identity: null,
+          target: [{ target: "dir", arch: ["arm64"] }],
+        },
+      },
+    },
+  });
+}
+
+export async function runDevelopmentPackage(input = {}, dependencies = {}) {
+  const plan = createDevelopmentPackagePlan(input);
+  const remove = dependencies.rm ?? rm;
+  await remove(plan.outputPath, { recursive: true, force: true });
+  const build = dependencies.build ?? (await import("electron-builder")).build;
+  const artifacts = await build(plan.builderOptions);
+  const verifyPackageLayout =
+    dependencies.verifyPackageLayout ??
+    (await import("./verify-package-layout.mjs")).verifyPackageLayout;
+  await verifyPackageLayout(plan.applicationPath, {
+    desktopRoot: plan.builderOptions.projectDir,
+    development: true,
+  });
+  return Object.freeze({ artifacts, plan });
+}
+
+async function main() {
+  if (process.argv.length !== 2) throw new TypeError("arguments are not supported");
+  const result = await runDevelopmentPackage();
+  process.stdout.write(`development application: ${result.plan.applicationPath}\n`);
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch {
+    process.stderr.write("development package build failed\n");
+    process.exitCode = 1;
+  }
+}

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { connect } from "node:net";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, readdir, realpath, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -14,9 +14,11 @@ import {
   createSecuritySmokeEnvironment,
   createSecuritySmokeLaunchEnvironment,
 } from "../smoke/security-smoke-environment.mjs";
+import { createDevelopmentPackagePlan } from "./development-package-plan.mjs";
 
 const require = createRequire(import.meta.url);
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const developmentPackagePlan = createDevelopmentPackagePlan({ desktopRoot });
 const command = process.argv[2];
 const options = Object.fromEntries(
   process.argv
@@ -29,18 +31,12 @@ const options = Object.fromEntries(
 );
 const mode = options.mode ?? "development";
 
-async function packagedExecutable() {
-  const root = join(desktopRoot, "dist");
-  const entries = await readdir(root, { recursive: true });
-  const relative = entries.find((entry) =>
-    entry.endsWith("Enduragent.app/Contents/MacOS/Enduragent"),
-  );
-  if (relative === undefined) throw new Error("packaged Enduragent executable not found");
-  return join(root, relative);
+function packagedExecutable() {
+  return developmentPackagePlan.executablePath;
 }
 
 async function startElectron(flag, env, extraArgs = []) {
-  const executable = mode === "packaged" ? await packagedExecutable() : require("electron");
+  const executable = mode === "packaged" ? packagedExecutable() : require("electron");
   const args = createElectronLaunchArguments(mode, desktopRoot, flag, extraArgs);
   const child = spawn(executable, args, { env, stdio: ["pipe", "pipe", "pipe"] });
   let stdout = "";

--- a/apps/desktop/scripts/test-safe-storage-packaged.mjs
+++ b/apps/desktop/scripts/test-safe-storage-packaged.mjs
@@ -12,9 +12,11 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { requireDisposableSafeStorageContext } from "../smoke/safe-storage-test-context.mjs";
 
 delete process.env.FORCE_COLOR;
 delete process.env.CLICOLOR_FORCE;
+requireDisposableSafeStorageContext(process.env, process.platform);
 const { build } = await import("esbuild");
 
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -22,6 +24,9 @@ const base = await realpath(process.platform === "darwin" ? "/tmp" : tmpdir());
 const scratch = await mkdtemp(join(base, "eav-"));
 const staging = join(scratch, "fixture");
 const userData = join(scratch, "user-data");
+const electronUserData = join(scratch, "electron-user-data");
+const operatorHome = join(scratch, "operator-home");
+const athleteHome = join(scratch, "athlete-home");
 const commandPath = join(scratch, "command.json");
 const resultPath = join(scratch, "result.json");
 const sentinel = "synthetic-packaged-safe-storage-sentinel";
@@ -134,6 +139,9 @@ try {
   await Promise.all([
     mkdir(staging, { recursive: true, mode: 0o700 }),
     mkdir(userData, { recursive: true, mode: 0o700 }),
+    mkdir(electronUserData, { recursive: true, mode: 0o700 }),
+    mkdir(operatorHome, { recursive: true, mode: 0o700 }),
+    mkdir(athleteHome, { recursive: true, mode: 0o700 }),
   ]);
   await writeFile(join(staging, "main.cjs"), fixtureMain);
   await writeFile(
@@ -217,6 +225,8 @@ try {
   const appExecutable = await executable();
   const launchEnvironment = {
     ...process.env,
+    HOME: operatorHome,
+    ENDURAGENT_HOME: athleteHome,
     W9_SAFE_STORAGE_COMMAND: commandPath,
     FORCE_COLOR: undefined,
     CLICOLOR_FORCE: undefined,
@@ -227,7 +237,11 @@ try {
     { mode: 0o600 },
   );
   await chmod(commandPath, 0o600);
-  const firstExit = await run(appExecutable, [], { env: launchEnvironment, timeoutMs: 20_000 });
+  const launchArguments = [`--user-data-dir=${electronUserData}`];
+  const firstExit = await run(appExecutable, launchArguments, {
+    env: launchEnvironment,
+    timeoutMs: 20_000,
+  });
   if (firstExit.timedOut || firstExit.code !== 0 || firstExit.signal !== null) {
     throw new Error(firstExit.stderr || firstExit.stdout || "first fixture launch failed");
   }
@@ -240,7 +254,10 @@ try {
     JSON.stringify({ mode: "read", userData, resultPath, sentinel, unaffected }),
     { mode: 0o600 },
   );
-  const secondExit = await run(appExecutable, [], { env: launchEnvironment, timeoutMs: 20_000 });
+  const secondExit = await run(appExecutable, launchArguments, {
+    env: launchEnvironment,
+    timeoutMs: 20_000,
+  });
   if (secondExit.timedOut || secondExit.code !== 0 || secondExit.signal !== null) {
     throw new Error(secondExit.stderr || secondExit.stdout || "second fixture launch failed");
   }

--- a/apps/desktop/scripts/verify-package-layout.d.mts
+++ b/apps/desktop/scripts/verify-package-layout.d.mts
@@ -5,6 +5,7 @@ export interface BuilderAuthority {
 
 export interface PackageLayoutOptions {
   readonly desktopRoot?: string;
+  readonly development?: true;
   readonly release?: {
     readonly version: string;
     readonly feedUrl: string;

--- a/apps/desktop/scripts/verify-package-layout.mjs
+++ b/apps/desktop/scripts/verify-package-layout.mjs
@@ -10,10 +10,16 @@ import {
   requireGenericFeedUrl,
   requireStableCalVer,
 } from "./macos-release-plan.mjs";
+import {
+  DEVELOPMENT_PACKAGE_NAME,
+  createDevelopmentPackagePlan,
+} from "./development-package-plan.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const canonicalDesktopRoot = resolve(scriptDirectory, "..");
-const canonicalApplication = join(canonicalDesktopRoot, "dist/mac-arm64/Enduragent.app");
+const canonicalApplication = createDevelopmentPackagePlan({
+  desktopRoot: canonicalDesktopRoot,
+}).applicationPath;
 const requiredAsarFiles = [
   "out/main/index.js",
   "out/main/daemon-utility.js",
@@ -579,19 +585,26 @@ function validateSandboxedPreloads(asar) {
   }
 }
 
-function validateManifest(asar, sourceBytes, release) {
+function validateManifest(asar, sourceBytes, release, development) {
   const packagedBytes = asar.get("package.json").bytes;
   const source = parseManifest(sourceBytes, "package.json");
   const packaged = parseManifest(packagedBytes, "app.asar/package.json");
   if (Object.hasOwn(source, "enduragentDesktopRelease")) {
     fail("source manifest contains a release marker", "package.json");
   }
+  if (Object.hasOwn(source, "enduragentDesktopDevelopment")) {
+    fail("source manifest contains a development marker", "package.json");
+  }
   const expected = structuredClone(source);
   if (release !== undefined) {
     expected.version = release.version;
     expected.enduragentDesktopRelease = true;
   }
-  let transformed = release !== undefined;
+  if (development) {
+    expected.name = DEVELOPMENT_PACKAGE_NAME;
+    expected.enduragentDesktopDevelopment = true;
+  }
+  let transformed = release !== undefined || development;
   for (const key of Object.keys(expected)) {
     if (key.startsWith("_") || removedMainManifestKeys.has(key)) {
       delete expected[key];
@@ -608,6 +621,9 @@ function validateManifest(asar, sourceBytes, release) {
   }
   const expectedBytes = transformed ? Buffer.from(JSON.stringify(expected, null, 2)) : sourceBytes;
   if (!expectedBytes.equals(packagedBytes) || !isDeepStrictEqual(packaged, expected)) {
+    if (development) {
+      fail("development packaged manifest has unexpected drift", "app.asar/package.json");
+    }
     if (release === undefined) {
       fail("ordinary packaged manifest differs from source", "app.asar/package.json");
     }
@@ -615,7 +631,7 @@ function validateManifest(asar, sourceBytes, release) {
   }
 }
 
-function validateRequiredAsarFiles(asar, sourceManifest, release) {
+function validateRequiredAsarFiles(asar, sourceManifest, release, development) {
   for (const path of requiredAsarFiles) {
     const entry = asar.get(path);
     if (entry === undefined || entry.type !== "file" || entry.unpacked === true) {
@@ -628,7 +644,7 @@ function validateRequiredAsarFiles(asar, sourceManifest, release) {
     }
   }
 
-  validateManifest(asar, sourceManifest, release);
+  validateManifest(asar, sourceManifest, release, development);
   validateTelegramRuntimeClosure(asar);
   validateSandboxedPreloads(asar);
 
@@ -696,6 +712,10 @@ export async function verifyPackageLayout(application, options = {}) {
   }
   const desktopRoot = options.desktopRoot ?? canonicalDesktopRoot;
   if (!isAbsolute(desktopRoot)) fail("desktop root must be absolute");
+  const development = options.development === true;
+  if (options.development !== undefined && options.development !== true) {
+    fail("invalid development package-layout option");
+  }
   let release;
   if (options.release !== undefined) {
     if (
@@ -710,6 +730,9 @@ export async function verifyPackageLayout(application, options = {}) {
       version: requireStableCalVer(options.release.version),
       feedUrl: requireGenericFeedUrl(options.release.feedUrl),
     };
+  }
+  if (development && release !== undefined) {
+    fail("package layout cannot be both development and release");
   }
 
   try {
@@ -734,7 +757,7 @@ export async function verifyPackageLayout(application, options = {}) {
     const archiveStat = await safeLstat(archivePath, "Contents/Resources/app.asar");
     assertRegularFile(archiveStat, "Contents/Resources/app.asar");
     const asar = collectAsar(archivePath);
-    validateRequiredAsarFiles(asar, sourceManifest, release);
+    validateRequiredAsarFiles(asar, sourceManifest, release, development);
     compareAsarStaging(asarStaging, asar);
 
     const externalPackaged = new Map();
@@ -778,7 +801,10 @@ function applicationArgument(args) {
 
 async function main() {
   try {
-    await verifyPackageLayout(applicationArgument(process.argv.slice(2)));
+    const arguments_ = process.argv.slice(2);
+    await verifyPackageLayout(applicationArgument(arguments_), {
+      development: arguments_.length === 0 ? true : undefined,
+    });
     process.stdout.write("package layout verified\n");
   } catch (error) {
     const message =

--- a/apps/desktop/scripts/verify-packaged-self-test.mjs
+++ b/apps/desktop/scripts/verify-packaged-self-test.mjs
@@ -3,6 +3,10 @@ import { connect } from "node:net";
 import { cp, mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  DEVELOPMENT_PRODUCT_NAME,
+  createDevelopmentPackagePlan,
+} from "./development-package-plan.mjs";
 
 const APP_READY_TIMEOUT_MS = 30_000;
 const SELF_TEST_TIMEOUT_MS = 120_000;
@@ -12,6 +16,7 @@ const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(scriptDirectory, "..");
 const repositoryRoot = resolve(desktopRoot, "../..");
 const cliEntry = join(repositoryRoot, "packages/coach/dist/enduragent.js");
+const developmentPackagePlan = createDevelopmentPackagePlan({ desktopRoot });
 
 function delay(ms) {
   return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
@@ -111,15 +116,12 @@ async function createAthleteHome(root, name) {
   return athleteHome;
 }
 
-async function packagedApplication() {
-  const entries = await readdir(join(desktopRoot, "dist"), { recursive: true });
-  const relative = entries.find((entry) => entry.endsWith("Enduragent.app"));
-  if (relative === undefined) throw new Error("packaged application was not found");
-  return join(desktopRoot, "dist", relative);
+function packagedApplication() {
+  return developmentPackagePlan.applicationPath;
 }
 
 function executableFor(application) {
-  return join(application, "Contents/MacOS/Enduragent");
+  return join(application, "Contents", "MacOS", DEVELOPMENT_PRODUCT_NAME);
 }
 
 function launchApplication(application, athleteHome, screenshotPath) {
@@ -273,18 +275,12 @@ async function main() {
   checked(process.platform === "darwin", "packaged self-test verification requires macOS");
   checked(process.argv.length === 2, "arguments are not supported");
   await runChecked("pnpm", ["--filter", "@enduragent/desktop...", "build"]);
-  await runChecked("pnpm", [
-    "--filter",
-    "@enduragent/desktop",
-    "package:dir",
-    "--config.mac.identity=-",
-    "--config.mac.hardenedRuntime=false",
-  ]);
+  await runChecked("pnpm", ["--filter", "@enduragent/desktop", "package:dir"]);
   const { SelfTestCommandTerminalSchema } = await import("@enduragent/coach-contract");
   const base = await realpath("/tmp");
   const scratch = await mkdtemp(join(base, "ea7-"));
   try {
-    const originalApplication = await packagedApplication();
+    const originalApplication = packagedApplication();
     const firstHome = await createAthleteHome(scratch, "h1");
     const success = await runApplicationCase({
       name: "success",
@@ -301,7 +297,7 @@ async function main() {
       "packaged Node version was unexpected",
     );
 
-    const copiedApplication = join(scratch, "c/Enduragent.app");
+    const copiedApplication = join(scratch, `c/${DEVELOPMENT_PRODUCT_NAME}.app`);
     await mkdir(dirname(copiedApplication), { recursive: true });
     await cp(originalApplication, copiedApplication, {
       recursive: true,

--- a/apps/desktop/smoke/safe-storage-test-context.d.mts
+++ b/apps/desktop/smoke/safe-storage-test-context.d.mts
@@ -1,0 +1,10 @@
+export const DISPOSABLE_SAFE_STORAGE_CONTEXT_ENV: "ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT";
+
+export function isDisposableSafeStorageContext(
+  environment?: Readonly<Record<string, string | undefined>>,
+): boolean;
+
+export function requireDisposableSafeStorageContext(
+  environment?: Readonly<Record<string, string | undefined>>,
+  platform?: NodeJS.Platform,
+): void;

--- a/apps/desktop/smoke/safe-storage-test-context.mjs
+++ b/apps/desktop/smoke/safe-storage-test-context.mjs
@@ -1,0 +1,19 @@
+export const DISPOSABLE_SAFE_STORAGE_CONTEXT_ENV = "ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT";
+
+export function isDisposableSafeStorageContext(environment = process.env) {
+  return environment.CI === "true" || environment[DISPOSABLE_SAFE_STORAGE_CONTEXT_ENV] === "1";
+}
+
+export function requireDisposableSafeStorageContext(
+  environment = process.env,
+  platform = process.platform,
+) {
+  if (platform !== "darwin") {
+    throw new TypeError("packaged Safe Storage verification requires macOS");
+  }
+  if (!isDisposableSafeStorageContext(environment)) {
+    throw new TypeError(
+      `packaged Safe Storage verification requires CI or ${DISPOSABLE_SAFE_STORAGE_CONTEXT_ENV}=1 in a disposable macOS user`,
+    );
+  }
+}

--- a/apps/desktop/tests/development-package-plan.test.ts
+++ b/apps/desktop/tests/development-package-plan.test.ts
@@ -1,0 +1,116 @@
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
+import {
+  DEVELOPMENT_APP_ID,
+  DEVELOPMENT_OUTPUT_DIRECTORY,
+  DEVELOPMENT_PACKAGE_NAME,
+  DEVELOPMENT_PRODUCT_NAME,
+  createDevelopmentPackagePlan,
+  runDevelopmentPackage,
+} from "../scripts/development-package-plan.mjs";
+import { createMacosReleasePlan } from "../scripts/macos-release-plan.mjs";
+
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(desktopRoot, "../..");
+
+describe("Desktop development package plan", () => {
+  it("seals the exact non-production identity and deterministic output", () => {
+    const plan = createDevelopmentPackagePlan({ desktopRoot });
+    expect(plan).toEqual({
+      applicationPath: join(desktopRoot, "dist/development/mac-arm64/Enduragent Development.app"),
+      executablePath: join(
+        desktopRoot,
+        "dist/development/mac-arm64/Enduragent Development.app/Contents/MacOS/Enduragent Development",
+      ),
+      outputPath: join(desktopRoot, "dist/development"),
+      builderOptions: {
+        projectDir: desktopRoot,
+        publish: "never",
+        config: {
+          extends: join(desktopRoot, "electron-builder.yml"),
+          appId: DEVELOPMENT_APP_ID,
+          productName: DEVELOPMENT_PRODUCT_NAME,
+          directories: { output: DEVELOPMENT_OUTPUT_DIRECTORY },
+          forceCodeSigning: false,
+          extraMetadata: {
+            name: DEVELOPMENT_PACKAGE_NAME,
+            enduragentDesktopDevelopment: true,
+          },
+          mac: {
+            identity: null,
+            target: [{ target: "dir", arch: ["arm64"] }],
+          },
+        },
+      },
+    });
+    expect(Object.isFrozen(plan)).toBe(true);
+    expect(() => createDevelopmentPackagePlan({ desktopRoot: "relative" })).toThrow(
+      "desktop root must be absolute",
+    );
+  });
+
+  it("removes only development output, builds, and verifies the exact app", async () => {
+    const remove = vi.fn(async () => undefined);
+    const build = vi.fn(async () => ["synthetic-artifact"]);
+    const verifyPackageLayout = vi.fn(async () => undefined);
+    const result = await runDevelopmentPackage(
+      { desktopRoot },
+      { rm: remove, build, verifyPackageLayout },
+    );
+    expect(remove).toHaveBeenCalledWith(join(desktopRoot, "dist/development"), {
+      recursive: true,
+      force: true,
+    });
+    expect(build).toHaveBeenCalledWith(result.plan.builderOptions);
+    expect(verifyPackageLayout).toHaveBeenCalledWith(result.plan.applicationPath, {
+      desktopRoot,
+      development: true,
+    });
+    expect(remove.mock.invocationCallOrder[0]).toBeLessThan(build.mock.invocationCallOrder[0]);
+    expect(build.mock.invocationCallOrder[0]).toBeLessThan(
+      verifyPackageLayout.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("keeps the checked-in and signed-release identities production-authoritative", async () => {
+    const builder = parse(await readFile(join(desktopRoot, "electron-builder.yml"), "utf8"));
+    expect(builder).toMatchObject({
+      appId: "icu.enduragent.desktop",
+      productName: "Enduragent",
+      directories: { output: "dist" },
+    });
+    const release = await createMacosReleasePlan(
+      {
+        repositoryRoot,
+        desktopRoot,
+        feedUrl: "https://updates.example.test/stable/",
+        identity: "Enduragent Test (ABCDE12345)",
+      },
+      { readFile: async () => JSON.stringify({ version: "2026.8.6" }) },
+    );
+    expect(release.builderOptions.config.extends).toBe(join(desktopRoot, "electron-builder.yml"));
+    expect(release.builderOptions.config.forceCodeSigning).toBe(true);
+    expect(release.builderOptions.config.extraMetadata).toEqual({
+      version: "2026.8.6",
+      enduragentDesktopRelease: true,
+    });
+    expect(DEVELOPMENT_APP_ID).not.toBe(builder.appId);
+    expect(DEVELOPMENT_PRODUCT_NAME).not.toBe(builder.productName);
+    expect(DEVELOPMENT_OUTPUT_DIRECTORY).not.toBe(builder.directories.output);
+  });
+
+  it("rejects package:dir arguments before loading the builder", () => {
+    const script = join(desktopRoot, "scripts/development-package-plan.mjs");
+    const result = spawnSync(process.execPath, [script, "--config.appId=icu.invalid"], {
+      cwd: desktopRoot,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("development package build failed\n");
+  });
+});

--- a/apps/desktop/tests/package-layout.test.ts
+++ b/apps/desktop/tests/package-layout.test.ts
@@ -6,6 +6,7 @@ import { finished } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import { createPackage, createPackageWithOptions } from "@electron/asar";
 import { afterEach, describe, expect, it } from "vitest";
+import { DEVELOPMENT_PACKAGE_NAME } from "../scripts/development-package-plan.mjs";
 import { readBuilderAuthority, verifyPackageLayout } from "../scripts/verify-package-layout.mjs";
 
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -323,6 +324,37 @@ describe("desktop package layout", () => {
     await expect(
       verifyPackageLayout(configured.app, { desktopRoot: configured.desktop }),
     ).rejects.toThrow("undeclared package resource");
+  });
+
+  it("accepts only the sealed development manifest overlay", async () => {
+    const development = await syntheticPackage();
+    await development.writeArchive(
+      "package.json",
+      JSON.stringify(
+        {
+          ...sourceManifest,
+          name: DEVELOPMENT_PACKAGE_NAME,
+          enduragentDesktopDevelopment: true,
+        },
+        null,
+        2,
+      ),
+    );
+    await development.rebuild();
+    await expect(
+      verifyPackageLayout(development.app, {
+        desktopRoot: development.desktop,
+        development: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    const production = await syntheticPackage();
+    await expect(
+      verifyPackageLayout(production.app, {
+        desktopRoot: production.desktop,
+        development: true,
+      }),
+    ).rejects.toThrow("development packaged manifest has unexpected drift");
   });
 
   it("accepts only the exact release manifest and app-update overlay", async () => {

--- a/apps/desktop/tests/safe-storage-test-context.test.ts
+++ b/apps/desktop/tests/safe-storage-test-context.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  DISPOSABLE_SAFE_STORAGE_CONTEXT_ENV,
+  isDisposableSafeStorageContext,
+  requireDisposableSafeStorageContext,
+} from "../smoke/safe-storage-test-context.mjs";
+
+describe("packaged Safe Storage test context", () => {
+  it("accepts only an explicit disposable marker or CI", () => {
+    expect(isDisposableSafeStorageContext({})).toBe(false);
+    expect(isDisposableSafeStorageContext({ CI: "1" })).toBe(false);
+    expect(isDisposableSafeStorageContext({ CI: "true" })).toBe(true);
+    expect(isDisposableSafeStorageContext({ [DISPOSABLE_SAFE_STORAGE_CONTEXT_ENV]: "1" })).toBe(
+      true,
+    );
+    expect(isDisposableSafeStorageContext({ [DISPOSABLE_SAFE_STORAGE_CONTEXT_ENV]: "true" })).toBe(
+      false,
+    );
+  });
+
+  it("fails closed outside a disposable macOS context", () => {
+    expect(() => requireDisposableSafeStorageContext({}, "darwin")).toThrow(
+      DISPOSABLE_SAFE_STORAGE_CONTEXT_ENV,
+    );
+    expect(() =>
+      requireDisposableSafeStorageContext({ [DISPOSABLE_SAFE_STORAGE_CONTEXT_ENV]: "1" }, "linux"),
+    ).toThrow("requires macOS");
+    expect(() => requireDisposableSafeStorageContext({ CI: "true" }, "darwin")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- isolate development Desktop package identity from the production application
- keep smoke, safe-storage, layout, and self-test tooling aligned with the development identity
- prevent development packaging from contaminating production storage and OS identity surfaces

## Verification

- 108 focused tests passed
- Desktop TypeScript check passed
- changed-file lint, formatting, and diff checks passed
