### PR TITLE
test: exclude local worktree artifacts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
     // to shared-globals `threads` would silently break it.
     pool: "forks",
     isolate: true,
-    exclude: [...configDefaults.exclude, "**/.claude/**"],
+    exclude: [...configDefaults.exclude, "**/.claude/**", "**/.pnpm-store/**", "**/.worktrees/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary"],
@@ -61,7 +61,13 @@ export default defineConfig({
           pool: "forks",
           isolate: true,
           environment: "node",
-          exclude: [...configDefaults.exclude, "**/.claude/**", "**/*.test.tsx"],
+          exclude: [
+            ...configDefaults.exclude,
+            "**/.claude/**",
+            "**/.pnpm-store/**",
+            "**/.worktrees/**",
+            "**/*.test.tsx",
+          ],
         },
       },
       {


### PR DESCRIPTION
## Summary

- exclude nested local Git worktrees from Vitest discovery
- keep repository test runs scoped to the active checkout

## Verification

- 124 focused configuration tests passed
- confirmed local worktree tests are not collected
- `git diff --check` passed
