### PR TITLE
fix(telegram): keep explicit off intent durable

### DIFF
--- a/.changeset/telegram-durable-off.md
+++ b/.changeset/telegram-durable-off.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"cycling-coach": patch
+---
+
+User-facing: Fixed Desktop Telegram turning itself back on after the user chose Turn off.
+
+Treat the stored power choice as authoritative across status polling, reconciliation, restart recovery, pairing cancellation, and pairing-lease races while preserving the configured bot and paired primary user for a later explicit Turn on.

--- a/apps/desktop/src/main/telegram-control.ts
+++ b/apps/desktop/src/main/telegram-control.ts
@@ -995,6 +995,7 @@ export function createTelegramControlCoordinator(
         if (disabled?.channel.state !== "disabled") return uncertain("control-uncertain");
         return refused("polling-conflict", await project(disabled, checked.active));
       }
+      if (!next && response.channel.state === "disabled") clearPairingLease();
       return applied(await project(response, checked.active));
     });
 
@@ -1158,8 +1159,18 @@ export function createTelegramControlCoordinator(
       return undefined;
     }
     const coherent = loaded.current;
-    const desired = await persistPairingDesired(active, true);
-    if (desired !== "applied" || !isCurrent(active)) return undefined;
+    const desired = await resolveDesired(coherent);
+    if (desired.state === "repair-required" || !isCurrent(active)) return undefined;
+    if (desired.desiredState === "disabled") {
+      clearPairingLease();
+      if (coherent.channel.desiredState === "disabled" && coherent.channel.state === "disabled") {
+        return coherent;
+      }
+      const disabled = await restoreDaemonDesired(active, false);
+      return disabled?.pairing.state === "paired" && disabled.channel.state === "disabled"
+        ? disabled
+        : undefined;
+    }
     if (isEnabledRuntimeCoherent(coherent)) {
       if (!isCurrent(active)) return undefined;
       clearPairingLease();
@@ -1181,6 +1192,9 @@ export function createTelegramControlCoordinator(
     const cleanup = await cleanupUnpaired(active);
     if (!isCurrent(active)) return { state: "uncertain" };
     if (cleanup === "paired" || cleanup === "primary") {
+      if ((await persistPairingDesired(active, true)) !== "applied") {
+        return { state: "uncertain" };
+      }
       const terminal = await guardedSnapshotCall(active, () =>
         cleanup === "paired" ? active.getTelegramStatus({}) : active.reconcileTelegram({}),
       );
@@ -1365,7 +1379,21 @@ export function createTelegramControlCoordinator(
   const repairPairingTruth = async (
     active: TelegramDaemonBinding,
     daemonSnapshot: TelegramControlSnapshot,
+    desiredState: "disabled" | "enabled",
   ): Promise<TelegramControlSnapshot | undefined> => {
+    if (desiredState === "disabled") {
+      clearPairingLease();
+      if (
+        daemonSnapshot.channel.desiredState === "disabled" &&
+        daemonSnapshot.channel.state === "disabled"
+      ) {
+        return daemonSnapshot;
+      }
+      const disabled = await guardedSnapshotCall(active, () => active.disableTelegram({}));
+      return disabled?.channel.desiredState === "disabled" && disabled.channel.state === "disabled"
+        ? disabled
+        : undefined;
+    }
     if (
       daemonSnapshot.pairing.state === "failed" &&
       daemonSnapshot.pairing.errorCode === "telegram-pairing-storage-uncertain"
@@ -1558,7 +1586,7 @@ export function createTelegramControlCoordinator(
             daemonStatus.pairing,
           );
         }
-        const repaired = await repairPairingTruth(active, loaded.current);
+        const repaired = await repairPairingTruth(active, loaded.current, desired.desiredState);
         if (!isCurrent(active)) throw new TypeError("stale Telegram daemon status");
         return repaired === undefined
           ? failure(
@@ -1599,7 +1627,11 @@ export function createTelegramControlCoordinator(
         const loaded = await loadStoredProfile(checked.active, daemonStatus);
         if (loaded.outcome === "uncertain") return uncertain(loaded.reason);
         if (loaded.outcome === "refused") return refused(loaded.reason);
-        const repaired = await repairPairingTruth(checked.active, loaded.current);
+        const repaired = await repairPairingTruth(
+          checked.active,
+          loaded.current,
+          checked.desiredState,
+        );
         if (repaired === undefined) return uncertain("control-uncertain");
         const desiredAfterRepair = await readDesired();
         const final =
@@ -1631,7 +1663,15 @@ export function createTelegramControlCoordinator(
         );
         if (daemonStatus === undefined) return refused("stale-operation");
         if (daemonStatus.pairing.state === "paired") {
-          const preserved = await preservePaired(checked.active, daemonStatus);
+          const coherent = await preservePaired(checked.active, daemonStatus);
+          if (coherent === undefined) return uncertain("control-uncertain");
+          const desiredWrite = await persistPairingDesired(checked.active, true);
+          if (desiredWrite !== "applied") {
+            return uncertain(
+              desiredWrite === "uncertain" ? "storage-uncertain" : "control-uncertain",
+            );
+          }
+          const preserved = await preservePaired(checked.active, coherent);
           return preserved === undefined
             ? uncertain("control-uncertain")
             : applied(await project(preserved, checked.active));
@@ -1728,8 +1768,14 @@ export function createTelegramControlCoordinator(
             : applied(await project(preserved, checked.active));
         }
         if (cancelled.pairing.state === "awaiting-code") {
-          if (!priorDesired && (await persistPairingDesired(checked.active, true)) !== "applied") {
-            return uncertain();
+          if (!priorDesired) {
+            clearPairingLease();
+            const disabled = await restoreDaemonDesired(checked.active, false);
+            if (disabled === undefined) return uncertain("control-uncertain");
+            if (disabled.pairing.state === "paired") {
+              return applied(await project(disabled, checked.active));
+            }
+            return refused("invalid-state", await project(disabled, checked.active));
           }
           if (!isCurrent(checked.active)) return uncertain("control-uncertain");
           armPairingLease(checked.active, cancelled.pairing);
@@ -1739,9 +1785,6 @@ export function createTelegramControlCoordinator(
         const primary = await hasPrimarySender(checked.active);
         if (primary === undefined) return uncertain("control-uncertain");
         if (primary) {
-          if ((await persistPairingDesired(checked.active, true)) !== "applied") {
-            return uncertain();
-          }
           if (!isCurrent(checked.active)) return uncertain("control-uncertain");
           const reconciled = await guardedSnapshotCall(checked.active, () =>
             checked.active.reconcileTelegram({}),

--- a/apps/desktop/tests/desktop-telegram-release-chain.integration.test.ts
+++ b/apps/desktop/tests/desktop-telegram-release-chain.integration.test.ts
@@ -733,6 +733,120 @@ afterEach(async () => {
 });
 
 describe.skipIf(!hasLoopback)("Desktop Telegram release chain", () => {
+  it("keeps paired identity durably off across polling and coordinator reconstruction", async () => {
+    const fixture = await createFixture();
+    const started = await startPairingA(fixture);
+    const active = await pairAOnline(fixture, started);
+    const profileBefore = await fixture.vault.profileStatus();
+    const accessBefore = await fixture.coordinator.listAllowedSenders();
+    const inspectionsBefore = [...fixture.inspections];
+
+    await expect(fixture.coordinator.disable()).resolves.toMatchObject({
+      outcome: "applied",
+      current: {
+        channel: { desiredState: "disabled", state: "disabled" },
+        bot: { state: "ready", username: BOT.username },
+        pairing: { state: "paired" },
+      },
+    });
+    expect(active.stopCalls).toBe(1);
+    expect(active.rawApiCalls).toContainEqual({
+      method: "getUpdates",
+      payload: { phase: "final-offset" },
+    });
+    await expect(fixture.telegram.drainPending()).resolves.toMatchObject({
+      channel: { desiredState: "disabled", state: "disabled" },
+      pairing: { state: "paired" },
+    });
+    await expect(fixture.vault.desiredState()).resolves.toEqual({
+      state: "configured",
+      enabled: false,
+    });
+
+    const callsAfterDisable = [...active.rawApiCalls];
+    await active.dispatch(
+      messageContext({
+        bot: active,
+        updateId: 2,
+        senderId: PRIMARY_SENDER,
+        text: "/version",
+      }),
+    );
+
+    for (let pass = 0; pass < 3; pass += 1) {
+      await expect(fixture.coordinator.status()).resolves.toMatchObject({
+        channel: { desiredState: "disabled", state: "disabled" },
+        pairing: { state: "paired" },
+      });
+      await expect(fixture.coordinator.reconcile()).resolves.toMatchObject({
+        outcome: "applied",
+        current: {
+          channel: { desiredState: "disabled", state: "disabled" },
+          pairing: { state: "paired" },
+        },
+      });
+    }
+
+    const reconstructed = fixture.coordinatorFor("app-supervised");
+    await expect(reconstructed.status()).resolves.toMatchObject({
+      channel: { desiredState: "disabled", state: "disabled" },
+      pairing: { state: "paired" },
+    });
+    await expect(reconstructed.reconcile()).resolves.toMatchObject({
+      outcome: "applied",
+      current: {
+        channel: { desiredState: "disabled", state: "disabled" },
+        pairing: { state: "paired" },
+      },
+    });
+
+    expect(active.rawApiCalls).toEqual(callsAfterDisable);
+    expect(fixture.network.bots.map(({ token }) => token)).toEqual([TELEGRAM_TOKEN_A]);
+    expect(fixture.network.bots[0]).toBe(active);
+    expect(await storedToken(fixture)).toBe(TELEGRAM_TOKEN_A);
+    await expect(fixture.vault.profileStatus()).resolves.toEqual(profileBefore);
+    await expect(reconstructed.listAllowedSenders()).resolves.toEqual(accessBefore);
+    await expect(fixture.vault.desiredState()).resolves.toEqual({
+      state: "configured",
+      enabled: false,
+    });
+    expect(fixture.inspections).toEqual(inspectionsBefore);
+
+    await expect(reconstructed.enable()).resolves.toMatchObject({ outcome: "applied" });
+    await waitUntil(
+      () =>
+        fixture.network.bots.length === 2 &&
+        fixture.telegram.getStatus().channel.state === "online",
+      "re-enabled paired generation",
+    );
+    const resumed = fixture.network.bot(TELEGRAM_TOKEN_A, 1);
+    await expect(reconstructed.status()).resolves.toMatchObject({
+      channel: { desiredState: "enabled", state: "online" },
+      bot: { state: "ready", username: BOT.username },
+      pairing: { state: "paired" },
+    });
+    expect(await storedToken(fixture)).toBe(TELEGRAM_TOKEN_A);
+    await expect(fixture.vault.profileStatus()).resolves.toEqual(profileBefore);
+    await expect(reconstructed.listAllowedSenders()).resolves.toEqual(accessBefore);
+    expect(fixture.inspections).toEqual(inspectionsBefore);
+
+    await resumed.dispatch(
+      messageContext({
+        bot: resumed,
+        updateId: 3,
+        senderId: PRIMARY_SENDER,
+        text: "/version",
+      }),
+    );
+    expect(resumed.rawApiCalls).toContainEqual({
+      method: "sendMessage",
+      payload: expect.objectContaining({
+        chat_id: PRIMARY_SENDER,
+        text: "Cycling Coach Desktop v2098.1.1",
+      }),
+    });
+  }, 30_000);
+
   it("refuses invalid token B while coherent token A stays stored and online", async () => {
     const fixture = await createFixture();
     const started = await startPairingA(fixture);

--- a/apps/desktop/tests/telegram-control.test.ts
+++ b/apps/desktop/tests/telegram-control.test.ts
@@ -1260,10 +1260,13 @@ describe("Telegram main-process control coordinator", () => {
     expect(runtime.binding.beginTelegramPairing).not.toHaveBeenCalled();
   });
 
-  it("preserves prior intent when pairing becomes paired after preflight", async () => {
+  it("enables a successful explicit pairing settlement from disabled intent", async () => {
     const runtime = harness({
-      enabled: true,
-      daemonSnapshot: snapshot(undefined, { pairing: { state: "unpaired" } }),
+      enabled: false,
+      daemonSnapshot: snapshot(
+        { desiredState: "disabled", state: "disabled" },
+        { pairing: { state: "unpaired" } },
+      ),
     });
     const paired = snapshot(undefined, { pairing: { state: "paired" } });
     vi.mocked(runtime.binding.beginTelegramPairing).mockImplementationOnce(async () => {
@@ -1416,7 +1419,7 @@ describe("Telegram main-process control coordinator", () => {
     expect(runtime.vault.setDesiredState).not.toHaveBeenCalledWith(false);
   });
 
-  it("repairs durable enabled intent when cancellation leaves pairing active", async () => {
+  it("keeps durable disabled intent when cancellation leaves pairing active", async () => {
     const awaiting = {
       state: "awaiting-code" as const,
       code: "ABCDEF",
@@ -1433,10 +1436,15 @@ describe("Telegram main-process control coordinator", () => {
     await expect(runtime.coordinator.cancelPairing()).resolves.toMatchObject({
       outcome: "refused",
       reason: "invalid-state",
-      current: { channel: { desiredState: "enabled" }, pairing: awaiting },
+      current: {
+        channel: { desiredState: "disabled", state: "disabled" },
+        pairing: awaiting,
+      },
     });
-    expect(runtime.desired()).toBe(true);
-    expect(runtime.vault.setDesiredState).toHaveBeenCalledWith(true);
+    expect(runtime.desired()).toBe(false);
+    expect(runtime.vault.setDesiredState).not.toHaveBeenCalled();
+    expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.disableTelegram).toHaveBeenCalledOnce();
   });
 
   it("fences new work, clears pairing timers, and drains an accepted removal on close", async () => {
@@ -1565,6 +1573,51 @@ describe("Telegram main-process control coordinator", () => {
     expect(runtime.desired()).toBe(true);
     expect(runtime.binding.cancelTelegramPairing).not.toHaveBeenCalled();
     expect(runtime.binding.disableTelegram).not.toHaveBeenCalled();
+  });
+
+  it("prevents a cancelled pairing lease from re-enabling an explicitly disabled bot", async () => {
+    const clock = leaseScheduler();
+    const awaiting = snapshot(undefined, {
+      pairing: {
+        state: "awaiting-code",
+        code: "ABCDEF",
+        expiresAt: "2026-08-05T12:01:00.000Z",
+      },
+    });
+    const runtime = harness({
+      enabled: false,
+      pairingLease: clock.port,
+      daemonSnapshot: snapshot(
+        { desiredState: "disabled", state: "disabled" },
+        { pairing: { state: "unpaired" } },
+      ),
+    });
+    vi.mocked(runtime.binding.beginTelegramPairing).mockImplementationOnce(async () => {
+      runtime.setSnapshot(awaiting);
+      return awaiting;
+    });
+
+    await runtime.coordinator.beginPairing();
+    expect(clock.entries).toHaveLength(1);
+    vi.mocked(runtime.vault.setDesiredState).mockClear();
+    vi.mocked(runtime.binding.enableTelegram).mockClear();
+    vi.mocked(runtime.binding.disableTelegram).mockClear();
+
+    await runtime.coordinator.disable();
+    expect(clock.entries[0]?.cancelled).toBe(true);
+    runtime.setSnapshot(
+      snapshot({ desiredState: "disabled", state: "disabled" }, { pairing: { state: "paired" } }),
+    );
+    clock.fire(0, true);
+
+    await expect(runtime.coordinator.status()).resolves.toMatchObject({
+      channel: { desiredState: "disabled", state: "disabled" },
+      pairing: { state: "paired" },
+    });
+    expect(runtime.desired()).toBe(false);
+    expect(vi.mocked(runtime.vault.setDesiredState).mock.calls).toEqual([[false]]);
+    expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.disableTelegram).toHaveBeenCalledOnce();
   });
 
   it("consumes a failed paired-lease expiry and retries until the lease is cleared", async () => {
@@ -1699,91 +1752,47 @@ describe("Telegram main-process control coordinator", () => {
     expect(setDesired.mock.calls).toEqual([[false], [true]]);
   });
 
-  it("reasserts paired intent after a stale coordinator compensates across a shared vault", async () => {
+  it("keeps shared durable disabled intent during a paired coordinator takeover", async () => {
     const runtime = harness({ enabled: false });
-    const staleWriteStarted = deferred<void>();
-    const releaseStaleWrite = deferred<void>();
-    const successorProfileReady = deferred<void>();
-    const releaseSuccessorProfile = deferred<void>();
-    const successorDesiredQueued = deferred<void>();
-    let vaultTail: Promise<void> = Promise.resolve();
-    let profileReads = 0;
-    let desiredReads = 0;
-    let holdFirstEnabledWrite = true;
-    const exclusive = <T>(operation: () => Promise<T>): Promise<T> => {
-      const result = vaultTail.then(operation, operation);
-      vaultTail = result.then(
-        () => undefined,
-        () => undefined,
-      );
-      return result;
-    };
-    const sharedVault: TelegramCredentialVault = {
-      profileStatus() {
-        profileReads += 1;
-        const result = exclusive(() => runtime.vault.profileStatus());
-        if (profileReads !== 2) return result;
-        return result.then(async (status) => {
-          successorProfileReady.resolve();
-          await releaseSuccessorProfile.promise;
-          return status;
-        });
-      },
-      replaceProfile(input) {
-        return exclusive(() => runtime.vault.replaceProfile(input));
-      },
-      applyStoredProfile(home, apply) {
-        return exclusive(() => runtime.vault.applyStoredProfile(home, apply));
-      },
-      deleteProfile() {
-        return exclusive(() => runtime.vault.deleteProfile());
-      },
-      desiredState() {
-        desiredReads += 1;
-        if (desiredReads === 2) successorDesiredQueued.resolve();
-        return exclusive(() => runtime.vault.desiredState());
-      },
-      setDesiredState(enabled) {
-        return exclusive(async () => {
-          const result = await runtime.vault.setDesiredState(enabled);
-          if (enabled && holdFirstEnabledWrite) {
-            holdFirstEnabledWrite = false;
-            staleWriteStarted.resolve();
-            await releaseStaleWrite.promise;
-          }
-          return result;
-        });
-      },
-    };
+    const profileReadStarted = deferred<void>();
+    const releaseProfileRead = deferred<void>();
+    const profileStatus = vi.mocked(runtime.vault.profileStatus);
+    const readProfile = profileStatus.getMockImplementation()!;
+    profileStatus.mockImplementationOnce(async () => {
+      profileReadStarted.resolve();
+      await releaseProfileRead.promise;
+      return readProfile();
+    });
     const successor = { ...runtime.binding, generation: 2 };
     let staleCurrent: TelegramDaemonBinding | undefined = runtime.binding;
     const stale = createTelegramControlCoordinator({
       selectedAthleteHome: () => HOME,
-      vault: sharedVault,
+      vault: runtime.vault,
       daemon: { current: () => staleCurrent },
     });
     const current = createTelegramControlCoordinator({
       selectedAthleteHome: () => HOME,
-      vault: sharedVault,
+      vault: runtime.vault,
       daemon: { current: () => successor },
     });
 
-    const successorStatus = current.status();
-    await successorProfileReady.promise;
     const staleStatus = stale.status();
-    await staleWriteStarted.promise;
+    await profileReadStarted.promise;
     staleCurrent = successor;
-    releaseSuccessorProfile.resolve();
-    await successorDesiredQueued.promise;
-    releaseStaleWrite.resolve();
+    releaseProfileRead.resolve();
 
-    await staleStatus;
-    await expect(successorStatus).resolves.toMatchObject({
-      channel: { desiredState: "enabled", state: "online" },
+    await expect(staleStatus).resolves.toMatchObject({
+      channel: { desiredState: "disabled", state: "disabled" },
       pairing: { state: "paired" },
     });
-    expect(runtime.desired()).toBe(true);
-    expect(vi.mocked(runtime.vault.setDesiredState).mock.calls).toEqual([[true], [false], [true]]);
+    await expect(current.status()).resolves.toMatchObject({
+      channel: { desiredState: "disabled", state: "disabled" },
+      pairing: { state: "paired" },
+    });
+    expect(runtime.desired()).toBe(false);
+    expect(runtime.vault.setDesiredState).not.toHaveBeenCalled();
+    expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.disableTelegram).toHaveBeenCalledOnce();
   });
 
   it("repairs a restart crash window with no primary or live pairing", async () => {
@@ -1889,7 +1898,7 @@ describe("Telegram main-process control coordinator", () => {
     },
   );
 
-  it("reconciles paired daemon truth into durable enabled intent", async () => {
+  it("reconciles a paired online daemon to durable disabled intent", async () => {
     const runtime = harness({
       enabled: false,
       daemonSnapshot: snapshot(undefined, { pairing: { state: "paired" } }),
@@ -1898,12 +1907,14 @@ describe("Telegram main-process control coordinator", () => {
     await expect(runtime.coordinator.reconcile()).resolves.toMatchObject({
       outcome: "applied",
       current: {
-        channel: { desiredState: "enabled", state: "online" },
+        channel: { desiredState: "disabled", state: "disabled" },
         pairing: { state: "paired" },
       },
     });
-    expect(runtime.desired()).toBe(true);
-    expect(runtime.vault.setDesiredState).toHaveBeenCalledWith(true);
+    expect(runtime.desired()).toBe(false);
+    expect(runtime.vault.setDesiredState).not.toHaveBeenCalled();
+    expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.disableTelegram).toHaveBeenCalledOnce();
   });
 
   it("reconciles stale enabled intent to disabled when no pairing or primary exists", async () => {
@@ -1951,6 +1962,25 @@ describe("Telegram main-process control coordinator", () => {
     expect(runtime.desired()).toBe(true);
     expect(runtime.vault.setDesiredState).not.toHaveBeenCalledWith(false);
     expect(runtime.binding.disableTelegram).not.toHaveBeenCalled();
+  });
+
+  it("keeps durable disabled intent when cancellation observes a paired bot", async () => {
+    const runtime = harness({
+      enabled: false,
+      daemonSnapshot: snapshot(undefined, { pairing: { state: "paired" } }),
+    });
+
+    await expect(runtime.coordinator.cancelPairing()).resolves.toMatchObject({
+      outcome: "applied",
+      current: {
+        channel: { desiredState: "disabled", state: "disabled" },
+        pairing: { state: "paired" },
+      },
+    });
+    expect(runtime.desired()).toBe(false);
+    expect(runtime.vault.setDesiredState).not.toHaveBeenCalled();
+    expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.disableTelegram).toHaveBeenCalledOnce();
   });
 
   it("restores prior durable intent after an uncertain pairing profile load", async () => {
@@ -2426,6 +2456,69 @@ describe("Telegram main-process control coordinator", () => {
     expect(runtime.binding.disableTelegram).toHaveBeenCalledWith({});
     expect(runtime.binding.suspendTelegramPolling).not.toHaveBeenCalled();
     expect(runtime.trace).toEqual(["vault:desired:false", "daemon:disable"]);
+  });
+
+  it("keeps a paired bot durably disabled across repeated status polls", async () => {
+    const runtime = harness();
+
+    await runtime.coordinator.disable();
+
+    await expect(runtime.coordinator.status()).resolves.toMatchObject({
+      channel: { desiredState: "disabled", state: "disabled" },
+      pairing: { state: "paired" },
+    });
+    await expect(runtime.coordinator.status()).resolves.toMatchObject({
+      channel: { desiredState: "disabled", state: "disabled" },
+      pairing: { state: "paired" },
+    });
+
+    expect(runtime.desired()).toBe(false);
+    expect(runtime.vault.setDesiredState).toHaveBeenCalledOnce();
+    expect(runtime.vault.setDesiredState).toHaveBeenCalledWith(false);
+    expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.disableTelegram).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a paired bot durably disabled when the coordinator reconciles", async () => {
+    const runtime = harness();
+
+    await runtime.coordinator.disable();
+
+    await expect(runtime.coordinator.reconcile()).resolves.toMatchObject({
+      outcome: "applied",
+      current: {
+        channel: { desiredState: "disabled", state: "disabled" },
+        bot: { state: "ready", username: USERNAME },
+        pairing: { state: "paired" },
+      },
+    });
+
+    expect(runtime.desired()).toBe(false);
+    expect(runtime.vault.setDesiredState).toHaveBeenCalledOnce();
+    expect(runtime.vault.setDesiredState).toHaveBeenCalledWith(false);
+    expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.disableTelegram).toHaveBeenCalledOnce();
+  });
+
+  it("preserves durable disabled intent after coordinator reconstruction", async () => {
+    const runtime = harness({
+      enabled: false,
+      daemonSnapshot: snapshot(
+        { desiredState: "disabled", state: "disabled" },
+        { pairing: { state: "paired" } },
+      ),
+    });
+
+    await expect(runtime.coordinator.status()).resolves.toMatchObject({
+      channel: { desiredState: "disabled", state: "disabled" },
+      bot: { state: "ready", username: USERNAME },
+      pairing: { state: "paired" },
+    });
+
+    expect(runtime.desired()).toBe(false);
+    expect(runtime.vault.setDesiredState).not.toHaveBeenCalled();
+    expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.disableTelegram).not.toHaveBeenCalled();
   });
 
   it.each([true, false])(


### PR DESCRIPTION
## Summary

- preserve an explicit user-selected Telegram Off state when paired daemon truth is repaired
- prevent status, reconciliation, reconstruction, and lease callbacks from silently re-enabling the bot
- add unit and real cross-package regression coverage for durable Off behavior

## Verification

- 124 focused Desktop tests passed
- the final cross-branch regression run passed 459 tests across 11 files
- the packaged lifecycle preserved Off across restart and background residency
- Desktop TypeScript check passed
