### PR TITLE
fix(desktop): reconcile Telegram pairing feedback

### DIFF
--- a/.changeset/paired-feedback-truth.md
+++ b/.changeset/paired-feedback-truth.md
@@ -1,0 +1,8 @@
+---
+"cycling-coach": patch
+"@enduragent/desktop-renderer": patch
+---
+
+User-facing: Telegram settings now replace expired pairing instructions with the bot's current pairing state.
+
+Reconcile action feedback against semantic bot, power, channel, and pairing state so successful instructions cannot outlive the state that produced them, while preserving warnings and errors across health polls.

--- a/apps/desktop-renderer/src/settings/telegram-controller.ts
+++ b/apps/desktop-renderer/src/settings/telegram-controller.ts
@@ -176,6 +176,11 @@ interface TelegramSettingsHandlers {
   readonly onRemoveSender: (senderId: number) => void;
 }
 
+interface TelegramFeedbackProvenance {
+  readonly kind: "pairing-instruction" | "success";
+  readonly telegram: TelegramControlStatus | null;
+}
+
 export interface TelegramSettingsView {
   bind(handlers: TelegramSettingsHandlers): void;
   close(): void;
@@ -268,27 +273,35 @@ function mutationFailureCopy(
   return failureCopy(action);
 }
 
-function resultCopy(action: TelegramSettingsAction, status: TelegramControlStatus): string {
-  if (status.gapWarning.state === "possible-message-loss") {
-    return "Telegram reconnected after a long gap. Some messages may not have arrived.";
-  }
-  if (status.bot.state === "webhook-removal-required") {
-    return "Bot verified. Remove its webhook before pairing it with this Mac.";
-  }
-  if (status.pairing.state === "awaiting-code") {
-    return "Pairing code ready. Send it to the bot in Telegram.";
-  }
-  if (status.pairing.state === "paired" && action === "begin-pairing") {
-    return "Telegram is paired with its primary user.";
-  }
+type ActiveTelegramPairingStatus = TelegramControlStatus & {
+  readonly bot: { readonly state: "ready"; readonly username: string };
+  readonly pairing: {
+    readonly state: "awaiting-code";
+    readonly code: string;
+    readonly expiresAt: string;
+  };
+};
+
+export function hasActiveTelegramPairingCode(
+  status: TelegramControlStatus,
+): status is ActiveTelegramPairingStatus {
+  if (status.bot.state !== "ready" || status.pairing.state !== "awaiting-code") return false;
+  if (!status.credentialConfigured || status.channel.desiredState !== "enabled") return false;
+  return (
+    status.channel.state === "starting" ||
+    status.channel.state === "online" ||
+    status.channel.state === "offline-retrying" ||
+    status.channel.state === "suspended"
+  );
+}
+
+function channelHealthCopy(status: TelegramControlStatus): string {
   if (status.channel.state === "online") return "Telegram is online.";
   if (status.channel.state === "starting") return "Telegram is connecting.";
   if (status.channel.state === "suspended") {
     return "Telegram polling is paused while this Mac sleeps.";
   }
-  if (status.channel.state === "disabled") {
-    return action === "remove" ? "Telegram was removed from this Mac." : "Telegram is off.";
-  }
+  if (status.channel.state === "disabled") return "Telegram is off.";
   if (status.channel.state === "waiting-for-credential") {
     return "Copy a bot token from BotFather, then paste it from the clipboard.";
   }
@@ -305,6 +318,136 @@ function resultCopy(action: TelegramSettingsAction, status: TelegramControlStatu
     return "Telegram is offline. Enduragent will keep trying while this Mac is awake and online.";
   }
   return "Telegram needs attention. Keep the app open, check the connection, and try again.";
+}
+
+function resultCopy(action: TelegramSettingsAction, status: TelegramControlStatus): string {
+  if (status.gapWarning.state === "possible-message-loss") {
+    return "Telegram reconnected after a long gap. Some messages may not have arrived.";
+  }
+  if (status.bot.state === "webhook-removal-required") {
+    return "Bot verified. Remove its webhook before pairing it with this Mac.";
+  }
+  if (hasActiveTelegramPairingCode(status)) {
+    return "Pairing code ready. Send it to the bot in Telegram.";
+  }
+  if (status.pairing.state === "paired" && action === "begin-pairing") {
+    return "Telegram is paired with its primary user.";
+  }
+  if (status.channel.state === "disabled" && action === "remove") {
+    return "Telegram was removed from this Mac.";
+  }
+  return channelHealthCopy(status);
+}
+
+function sameBotTruth(left: TelegramBotStatus, right: TelegramBotStatus): boolean {
+  if (left.state === "unconfigured" || right.state === "unconfigured") {
+    return left.state === right.state;
+  }
+  return left.state === right.state && left.username === right.username;
+}
+
+function samePairingTruth(left: TelegramPairingStatus, right: TelegramPairingStatus): boolean {
+  if (left.state !== right.state) return false;
+  if (left.state === "awaiting-code" && right.state === "awaiting-code") {
+    return left.code === right.code && left.expiresAt === right.expiresAt;
+  }
+  if (left.state === "failed" && right.state === "failed") {
+    return left.errorCode === right.errorCode;
+  }
+  return true;
+}
+
+function sameFeedbackTruth(left: TelegramControlStatus, right: TelegramControlStatus): boolean {
+  return (
+    left.channel.desiredState === right.channel.desiredState &&
+    left.channel.state === right.channel.state &&
+    sameBotTruth(left.bot, right.bot) &&
+    samePairingTruth(left.pairing, right.pairing)
+  );
+}
+
+function pairingInstructionRemainsValid(
+  origin: TelegramControlStatus,
+  current: TelegramControlStatus,
+): boolean {
+  if (origin.pairing.state !== "awaiting-code" || !hasActiveTelegramPairingCode(current))
+    return false;
+  if (!sameBotTruth(origin.bot, current.bot)) return false;
+  if (origin.pairing.code !== current.pairing.code) return false;
+  if (origin.pairing.expiresAt !== current.pairing.expiresAt) return false;
+  return true;
+}
+
+function botUsername(status: TelegramBotStatus): string | null {
+  return status.state === "unconfigured" ? null : status.username;
+}
+
+function pairingFailureCopy(
+  pairing: Extract<TelegramPairingStatus, { readonly state: "failed" }>,
+): string {
+  if (pairing.errorCode === "telegram-pairing-storage-uncertain") {
+    return "The primary Telegram user may have been saved, but Enduragent could not verify storage. Restart Enduragent and check Telegram before pairing again.";
+  }
+  if (pairing.errorCode === "telegram-pairing-storage-failed") {
+    return "The primary Telegram user could not be saved. Check local disk access and try pairing again.";
+  }
+  if (pairing.errorCode === "telegram-pairing-refused") {
+    return "Pairing was refused because this bot already has a primary user.";
+  }
+  return "Pairing is unavailable until the Telegram bot can connect.";
+}
+
+function pairingTransitionCopy(
+  previous: TelegramControlStatus,
+  current: TelegramControlStatus,
+): string | null {
+  const previousBot = botUsername(previous.bot);
+  const currentBot = botUsername(current.bot);
+  if (previousBot !== currentBot) {
+    if (currentBot === null) return "Telegram bot was removed from this Mac.";
+    if (previousBot !== null) return `Telegram bot changed to @${currentBot}. Pairing was reset.`;
+  }
+  if (previous.pairing.state !== "awaiting-code") return null;
+  if (current.pairing.state === "awaiting-code") {
+    if (samePairingTruth(previous.pairing, current.pairing)) return null;
+    return hasActiveTelegramPairingCode(current)
+      ? "A new Telegram pairing code is ready. Send it to the bot in Telegram."
+      : null;
+  }
+  if (current.pairing.state === "paired") {
+    return "Telegram is paired with its primary user.";
+  }
+  if (current.pairing.state === "expired") {
+    return "The pairing code expired before it was used. Create a new code when you are ready.";
+  }
+  if (current.pairing.state === "failed") return pairingFailureCopy(current.pairing);
+  if (current.pairing.state === "unpaired") return "Telegram pairing was cancelled.";
+  return null;
+}
+
+function pollingAnnouncement(
+  previous: TelegramControlStatus,
+  current: TelegramControlStatus,
+): string {
+  return (
+    pairingTransitionCopy(previous, current) ??
+    (previous.channel.state === current.channel.state ? "" : channelHealthCopy(current))
+  );
+}
+
+function feedbackIsSuperseded(
+  feedback: TelegramSettingsFeedback | null,
+  provenance: TelegramFeedbackProvenance | null,
+  current: TelegramControlStatus,
+): boolean {
+  if (feedback === null || provenance?.telegram === null || provenance?.telegram === undefined) {
+    return false;
+  }
+  if (provenance.kind === "pairing-instruction") {
+    return !pairingInstructionRemainsValid(provenance.telegram, current);
+  }
+  if (feedback.tone !== "success") return false;
+  return !sameFeedbackTruth(provenance.telegram, current);
 }
 
 async function loadSenders(
@@ -335,6 +478,7 @@ export function createTelegramSettingsController(input: {
   let operation: Promise<void> | undefined;
   let pollTask: Promise<void> | undefined;
   let pollTimer: ReturnType<typeof globalThis.setInterval> | undefined;
+  let feedbackProvenance: TelegramFeedbackProvenance | null = null;
   const schedule = input.setInterval ?? globalThis.setInterval;
   const cancelSchedule = input.clearInterval ?? globalThis.clearInterval;
   const pollIntervalMs = input.pollIntervalMs ?? 5_000;
@@ -393,16 +537,21 @@ export function createTelegramSettingsController(input: {
           ) {
             const previous = readCurrentContent();
             const healthAnnouncement =
-              previous.telegram !== null &&
-              previous.telegram.channel.state !== content.telegram.channel.state
-                ? resultCopy("reconcile", content.telegram)
-                : "";
+              previous.telegram === null
+                ? ""
+                : pollingAnnouncement(previous.telegram, content.telegram);
+            const feedbackSuperseded = feedbackIsSuperseded(
+              previous.feedback,
+              feedbackProvenance,
+              content.telegram,
+            );
+            if (feedbackSuperseded) feedbackProvenance = null;
             render({
               status: "ready",
               ...content,
-              announcement: previous.announcement,
+              announcement: feedbackSuperseded ? "" : previous.announcement,
               healthAnnouncement,
-              feedback: previous.feedback,
+              feedback: feedbackSuperseded ? null : previous.feedback,
             });
           }
         },
@@ -425,6 +574,7 @@ export function createTelegramSettingsController(input: {
       .then(
         (content) => {
           if (!disposed && generation === operationGeneration) {
+            feedbackProvenance = null;
             render({
               status: "ready",
               ...content,
@@ -483,10 +633,23 @@ export function createTelegramSettingsController(input: {
       .then(
         ({ content, result }) => {
           if (!disposed && generation === operationGeneration) {
+            const transitionMessage =
+              result.outcome === "applied" && previous.telegram !== null
+                ? pairingTransitionCopy(previous.telegram, content.telegram)
+                : null;
             const message =
               result.outcome === "applied"
-                ? resultCopy(action, content.telegram)
+                ? (transitionMessage ?? resultCopy(action, content.telegram))
                 : mutationFailureCopy(action, result);
+            feedbackProvenance =
+              result.outcome === "applied"
+                ? {
+                    kind: hasActiveTelegramPairingCode(content.telegram)
+                      ? "pairing-instruction"
+                      : "success",
+                    telegram: content.telegram,
+                  }
+                : null;
             render({
               status: "ready",
               ...content,
@@ -506,6 +669,7 @@ export function createTelegramSettingsController(input: {
         },
         () => {
           if (!disposed && generation === operationGeneration) {
+            feedbackProvenance = null;
             render({
               status: "error",
               kind: "action",
@@ -545,6 +709,7 @@ export function createTelegramSettingsController(input: {
         (result) => {
           if (!disposed && generation === operationGeneration) {
             if (result.outcome === "uncertain") {
+              feedbackProvenance = null;
               const message =
                 result.reason === "storage-uncertain"
                   ? "The allowed-user list may have changed, but Enduragent could not verify storage. Restart Enduragent and check the list before trying again."
@@ -558,6 +723,7 @@ export function createTelegramSettingsController(input: {
               return;
             }
             if (result.outcome === "refused") {
+              feedbackProvenance = null;
               const message = failureCopy(action);
               render({
                 status: "ready",
@@ -567,6 +733,7 @@ export function createTelegramSettingsController(input: {
               });
               return;
             }
+            feedbackProvenance = { kind: "success", telegram: previous.telegram };
             render({
               status: "ready",
               ...previous,
@@ -584,6 +751,7 @@ export function createTelegramSettingsController(input: {
         },
         () => {
           if (!disposed && generation === operationGeneration) {
+            feedbackProvenance = null;
             render({
               status: "error",
               kind: "action",
@@ -631,6 +799,7 @@ export function createTelegramSettingsController(input: {
         pollTimer = undefined;
       }
       currentState = { status: "closed" };
+      feedbackProvenance = null;
       input.view.close();
     },
     state: () => currentState,
@@ -641,6 +810,7 @@ export function createTelegramSettingsController(input: {
       if (pollTimer !== undefined) cancelSchedule(pollTimer);
       pollTimer = undefined;
       currentState = { status: "closed" };
+      feedbackProvenance = null;
       input.view.dispose();
     },
   };

--- a/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState, type FormEvent, type ReactElement } from "react";
-import type {
-  TelegramControlStatus,
-  TelegramSettingsState,
+import {
+  hasActiveTelegramPairingCode,
+  type TelegramControlStatus,
+  type TelegramSettingsState,
 } from "../../settings/telegram-controller.js";
 import { settingsMutationActive } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
@@ -391,7 +392,7 @@ export function TelegramSection(): ReactElement {
           </div>
         ) : null}
 
-        {telegram?.bot.state === "ready" && telegram.pairing.state === "awaiting-code" ? (
+        {telegram !== null && hasActiveTelegramPairingCode(telegram) ? (
           <div className={styles.pairingCard}>
             <p className={styles.confirmationTitle}>Pair your Telegram account</p>
             <p className={styles.confirmationCopy}>

--- a/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
@@ -139,6 +139,35 @@ describe("Telegram settings surface", () => {
     ).toBeVisible();
   });
 
+  it.each([
+    ["disabled intent", { desiredState: "disabled" as const, state: "disabled" as const }, true],
+    ["failed channel", { desiredState: "enabled" as const, state: "failed" as const }, true],
+    ["polling conflict", { desiredState: "enabled" as const, state: "conflict" as const }, true],
+    [
+      "transfer requirement",
+      { desiredState: "enabled" as const, state: "transfer-required" as const },
+      true,
+    ],
+    ["missing credential", { desiredState: "enabled" as const, state: "starting" as const }, false],
+  ])("hides an unusable pairing code after %s", (_reason, channel, credentialConfigured) => {
+    setup(
+      readyState(
+        status({
+          channel,
+          bot: { state: "ready", username: "desktop_coach_bot" },
+          pairing: {
+            state: "awaiting-code",
+            code: "A1B2C3",
+            expiresAt: "2098-07-06T12:01:00.000Z",
+          },
+          credentialConfigured,
+        }),
+      ),
+    );
+
+    expect(screen.queryByLabelText("Telegram pairing code")).toBeNull();
+  });
+
   it("manages paired users without offering removal for the primary user", async () => {
     const user = userEvent.setup();
     const port = setup(
@@ -326,6 +355,30 @@ describe("Telegram settings surface", () => {
     expect(screen.getByText("Online")).toBeVisible();
     expect(screen.getByRole("status")).toHaveTextContent("Telegram is online.");
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("publishes one polite announcement when pairing completes", () => {
+    const message = "Telegram is paired with its primary user.";
+    setup({
+      ...readyState(
+        status({
+          channel: { desiredState: "enabled", state: "online" },
+          bot: { state: "ready", username: "desktop_coach_bot" },
+          pairing: { state: "paired" },
+          credentialConfigured: true,
+        }),
+      ),
+      healthAnnouncement: message,
+      feedback: null,
+    });
+
+    const announcements = screen
+      .getAllByRole("status")
+      .filter((element) => element.textContent === message);
+    expect(announcements).toHaveLength(1);
+    expect(announcements[0]).toHaveAttribute("aria-live", "polite");
+    expect(announcements[0]).toHaveAttribute("aria-atomic", "true");
+    expect(screen.getAllByText(message)).toHaveLength(1);
   });
 
   it("exposes uncertain replacement feedback as a polite live warning", () => {

--- a/apps/desktop-renderer/tests/telegram-settings.test.ts
+++ b/apps/desktop-renderer/tests/telegram-settings.test.ts
@@ -31,6 +31,16 @@ const OFFLINE = Object.freeze({
   channel: { desiredState: "enabled", state: "offline-retrying" },
 } as const satisfies TelegramControlStatus);
 
+const AWAITING = Object.freeze({
+  ...PAIRED,
+  channel: { desiredState: "enabled", state: "starting" },
+  pairing: {
+    state: "awaiting-code",
+    code: "A1B2C3",
+    expiresAt: "1998-07-06T12:01:00.000Z",
+  },
+} as const satisfies TelegramControlStatus);
+
 const SENDERS = Object.freeze({
   senders: Object.freeze([{ senderId: 101, role: "primary" as const }]),
 }) satisfies TelegramAllowedSenders;
@@ -83,15 +93,7 @@ function setup() {
     beginPairing: vi.fn(
       async (): Promise<TelegramMutationResult> => ({
         outcome: "applied" as const,
-        current: {
-          ...PAIRED,
-          channel: { desiredState: "enabled" as const, state: "starting" as const },
-          pairing: {
-            state: "awaiting-code" as const,
-            code: "A1B2C3",
-            expiresAt: "1998-07-06T12:01:00.000Z",
-          },
-        },
+        current: AWAITING,
       }),
     ),
     cancelPairing: vi.fn(
@@ -157,6 +159,15 @@ function setup() {
     states,
     view,
   };
+}
+
+async function beginPairing(runtime: ReturnType<typeof setup>): Promise<void> {
+  runtime.handlers.onBeginPairing();
+  await vi.waitFor(() =>
+    expect(runtime.controller.state()).toMatchObject({
+      telegram: { pairing: { state: "awaiting-code" } },
+    }),
+  );
 }
 
 describe("Telegram settings controller", () => {
@@ -281,6 +292,31 @@ describe("Telegram settings controller", () => {
     expect(runtime.controller.state()).toMatchObject({ feedback: { tone: "error" } });
   });
 
+  it("clears successful action feedback when channel truth changes", async () => {
+    const runtime = setup();
+    runtime.bridge.status.mockResolvedValueOnce(PAIRED);
+    await runtime.controller.activate();
+    runtime.handlers.onEnable();
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        feedback: { tone: "success", message: "Telegram is online." },
+      }),
+    );
+
+    runtime.bridge.status.mockResolvedValueOnce(OFFLINE);
+    runtime.poll?.();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: { channel: { state: "offline-retrying" } },
+        announcement: "",
+        healthAnnouncement:
+          "Telegram is offline. Enduragent will keep trying while this Mac is awake and online.",
+        feedback: null,
+      }),
+    );
+  });
+
   it("reports an uncertain replacement as repair-required without claiming refusal", async () => {
     const runtime = setup();
     runtime.bridge.status.mockResolvedValueOnce(PAIRED);
@@ -331,6 +367,37 @@ describe("Telegram settings controller", () => {
     expect(JSON.stringify(runtime.controller.state())).not.toContain("was not applied");
   });
 
+  it("preserves uncertain replacement warnings across health transitions", async () => {
+    const runtime = setup();
+    runtime.bridge.status.mockResolvedValueOnce(PAIRED);
+    await runtime.controller.activate();
+    runtime.bridge.pasteTokenFromClipboard.mockResolvedValueOnce({
+      outcome: "uncertain",
+      reason: "storage-uncertain",
+      current: PAIRED,
+    });
+    runtime.handlers.onPasteToken();
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({ feedback: { tone: "warning" } }),
+    );
+
+    runtime.bridge.status.mockResolvedValueOnce(OFFLINE);
+    runtime.poll?.();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: { channel: { state: "offline-retrying" } },
+        healthAnnouncement:
+          "Telegram is offline. Enduragent will keep trying while this Mac is awake and online.",
+        feedback: {
+          tone: "warning",
+          message:
+            "The copied token was not applied to the running bot because storage could not be verified. Restart Enduragent and check Telegram before trying again.",
+        },
+      }),
+    );
+  });
+
   it.each([
     ["clipboard-unavailable", "The clipboard could not be read. No Telegram token was used."],
     [
@@ -369,18 +436,43 @@ describe("Telegram settings controller", () => {
     );
   });
 
+  it.each([
+    [
+      {
+        ...DISABLED,
+        bot: { state: "ready" as const, username: "replacement_bot" },
+        credentialConfigured: true,
+      },
+      "Telegram bot changed to @replacement_bot. Pairing was reset.",
+    ],
+    [DISABLED, "Telegram bot was removed from this Mac."],
+  ])("invalidates pairing instructions when the configured bot changes", async (next, message) => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    await beginPairing(runtime);
+
+    runtime.bridge.status.mockResolvedValueOnce(next);
+    runtime.poll?.();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: next,
+        healthAnnouncement: message,
+        feedback: null,
+      }),
+    );
+  });
+
   it("publishes the short-lived pairing code and manages additional senders", async () => {
     const runtime = setup();
     runtime.bridge.status.mockResolvedValueOnce(PAIRED);
     await runtime.controller.activate();
 
-    runtime.handlers.onBeginPairing();
-    await vi.waitFor(() =>
-      expect(runtime.controller.state()).toMatchObject({
-        status: "ready",
-        telegram: { pairing: { state: "awaiting-code", code: "A1B2C3" } },
-      }),
-    );
+    await beginPairing(runtime);
+    expect(runtime.controller.state()).toMatchObject({
+      status: "ready",
+      telegram: { pairing: { state: "awaiting-code", code: "A1B2C3" } },
+    });
 
     runtime.handlers.onAddSender(202);
     await vi.waitFor(() => expect(runtime.bridge.addAllowedSender).toHaveBeenCalledWith(202));
@@ -388,6 +480,316 @@ describe("Telegram settings controller", () => {
       status: "ready",
       allowedSenders: { senders: [{ senderId: 101 }, { senderId: 202 }] },
     });
+  });
+
+  it("replaces pairing instructions when the primary user claims the bot", async () => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    await beginPairing(runtime);
+    expect(runtime.controller.state()).toMatchObject({
+      feedback: {
+        tone: "success",
+        message: "Pairing code ready. Send it to the bot in Telegram.",
+      },
+    });
+
+    runtime.bridge.status.mockResolvedValueOnce(PAIRED);
+    runtime.poll?.();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: { pairing: { state: "paired" } },
+        announcement: "",
+        healthAnnouncement: "Telegram is paired with its primary user.",
+        feedback: null,
+      }),
+    );
+
+    runtime.bridge.status.mockResolvedValueOnce(PAIRED);
+    runtime.poll?.();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: { pairing: { state: "paired" } },
+        healthAnnouncement: "",
+        feedback: null,
+      }),
+    );
+  });
+
+  it("keeps the current pairing instruction through recoverable channel transitions", async () => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    await beginPairing(runtime);
+
+    for (const [state, healthAnnouncement] of [
+      ["online", "Telegram is online."],
+      [
+        "offline-retrying",
+        "Telegram is offline. Enduragent will keep trying while this Mac is awake and online.",
+      ],
+      ["suspended", "Telegram polling is paused while this Mac sleeps."],
+    ] as const) {
+      runtime.bridge.status.mockResolvedValueOnce({
+        ...AWAITING,
+        channel: { desiredState: "enabled", state },
+      });
+      runtime.poll?.();
+      await vi.waitFor(() =>
+        expect(runtime.controller.state()).toMatchObject({
+          telegram: { channel: { state }, pairing: { state: "awaiting-code" } },
+          healthAnnouncement,
+          feedback: {
+            tone: "success",
+            message: "Pairing code ready. Send it to the bot in Telegram.",
+          },
+        }),
+      );
+    }
+  });
+
+  it("announces a replacement pairing code once", async () => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    await beginPairing(runtime);
+    const replacement = {
+      ...AWAITING,
+      pairing: {
+        state: "awaiting-code" as const,
+        code: "D4E5F6",
+        expiresAt: "1998-07-06T12:02:00.000Z",
+      },
+    };
+
+    runtime.bridge.status.mockResolvedValueOnce(replacement);
+    runtime.poll?.();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: { pairing: { state: "awaiting-code", code: "D4E5F6" } },
+        announcement: "",
+        healthAnnouncement: "A new Telegram pairing code is ready. Send it to the bot in Telegram.",
+        feedback: null,
+      }),
+    );
+
+    runtime.bridge.status.mockResolvedValueOnce(replacement);
+    runtime.poll?.();
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({ healthAnnouncement: "" }),
+    );
+  });
+
+  it("reports channel truth instead of an unusable replacement code from polling", async () => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    await beginPairing(runtime);
+    const conflictedReplacement = {
+      ...AWAITING,
+      channel: { desiredState: "enabled" as const, state: "conflict" as const },
+      pairing: {
+        state: "awaiting-code" as const,
+        code: "D4E5F6",
+        expiresAt: "1998-07-06T12:02:00.000Z",
+      },
+    };
+
+    runtime.bridge.status.mockResolvedValueOnce(conflictedReplacement);
+    runtime.poll?.();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: conflictedReplacement,
+        announcement: "",
+        healthAnnouncement:
+          "Another service is polling this bot. Stop that deployment, then check again.",
+        feedback: null,
+      }),
+    );
+    expect(JSON.stringify(runtime.controller.state())).not.toContain(
+      "A new Telegram pairing code is ready",
+    );
+  });
+
+  it("reports channel truth instead of an action-returned unusable replacement code", async () => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    await beginPairing(runtime);
+    const conflictedReplacement = {
+      ...AWAITING,
+      channel: { desiredState: "enabled" as const, state: "conflict" as const },
+      pairing: {
+        state: "awaiting-code" as const,
+        code: "D4E5F6",
+        expiresAt: "1998-07-06T12:02:00.000Z",
+      },
+    };
+    runtime.bridge.reconcile.mockResolvedValueOnce({
+      outcome: "applied",
+      current: conflictedReplacement,
+    });
+
+    runtime.handlers.onReconcile();
+
+    const message = "Another service is polling this bot. Stop that deployment, then check again.";
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: conflictedReplacement,
+        announcement: message,
+        healthAnnouncement: "",
+        feedback: { tone: "success", message },
+      }),
+    );
+    expect(JSON.stringify(runtime.controller.state())).not.toContain(
+      "A new Telegram pairing code is ready",
+    );
+  });
+
+  it.each([
+    [
+      "disabled intent",
+      { ...AWAITING, channel: { desiredState: "disabled" as const, state: "disabled" as const } },
+      "Telegram is off.",
+    ],
+    [
+      "failed channel",
+      { ...AWAITING, channel: { desiredState: "enabled" as const, state: "failed" as const } },
+      "Telegram needs attention. Keep the app open, check the connection, and try again.",
+    ],
+    [
+      "polling conflict",
+      { ...AWAITING, channel: { desiredState: "enabled" as const, state: "conflict" as const } },
+      "Another service is polling this bot. Stop that deployment, then check again.",
+    ],
+    [
+      "transfer requirement",
+      {
+        ...AWAITING,
+        channel: { desiredState: "enabled" as const, state: "transfer-required" as const },
+      },
+      "This bot is still owned by another Desktop installation. Remove it there before retrying here.",
+    ],
+    ["missing credential", { ...AWAITING, credentialConfigured: false }, ""],
+  ])("removes pairing instructions after %s", async (_reason, next, healthAnnouncement) => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    await beginPairing(runtime);
+
+    runtime.bridge.status.mockResolvedValueOnce(next);
+    runtime.poll?.();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: next,
+        announcement: "",
+        healthAnnouncement,
+        feedback: null,
+      }),
+    );
+  });
+
+  it.each([
+    [
+      "expired",
+      { state: "expired" as const },
+      "The pairing code expired before it was used. Create a new code when you are ready.",
+    ],
+    [
+      "unavailable",
+      { state: "failed" as const, errorCode: "telegram-pairing-unavailable" as const },
+      "Pairing is unavailable until the Telegram bot can connect.",
+    ],
+    [
+      "refused",
+      { state: "failed" as const, errorCode: "telegram-pairing-refused" as const },
+      "Pairing was refused because this bot already has a primary user.",
+    ],
+    [
+      "storage failed",
+      { state: "failed" as const, errorCode: "telegram-pairing-storage-failed" as const },
+      "The primary Telegram user could not be saved. Check local disk access and try pairing again.",
+    ],
+    [
+      "storage uncertain",
+      { state: "failed" as const, errorCode: "telegram-pairing-storage-uncertain" as const },
+      "The primary Telegram user may have been saved, but Enduragent could not verify storage. Restart Enduragent and check Telegram before pairing again.",
+    ],
+    ["unpaired", { state: "unpaired" as const }, "Telegram pairing was cancelled."],
+  ])("replaces pairing instructions when pairing becomes %s", async (_state, pairing, message) => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    await beginPairing(runtime);
+
+    runtime.bridge.status.mockResolvedValueOnce({
+      ...PAIRED,
+      channel: { desiredState: "enabled", state: "starting" },
+      pairing,
+    });
+    runtime.poll?.();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: { pairing },
+        healthAnnouncement: message,
+        feedback: null,
+      }),
+    );
+  });
+
+  it.each([
+    ["paired", PAIRED, "Telegram is paired with its primary user."],
+    [
+      "expired",
+      { ...AWAITING, pairing: { state: "expired" as const } },
+      "The pairing code expired before it was used. Create a new code when you are ready.",
+    ],
+    [
+      "failed",
+      {
+        ...AWAITING,
+        pairing: { state: "failed" as const, errorCode: "telegram-pairing-refused" as const },
+      },
+      "Pairing was refused because this bot already has a primary user.",
+    ],
+    [
+      "unpaired",
+      { ...AWAITING, pairing: { state: "unpaired" as const } },
+      "Telegram pairing was cancelled.",
+    ],
+    [
+      "replacement bot",
+      {
+        ...DISABLED,
+        bot: { state: "ready" as const, username: "replacement_bot" },
+        credentialConfigured: true,
+      },
+      "Telegram bot changed to @replacement_bot. Pairing was reset.",
+    ],
+  ])("announces an action-returned %s transition once", async (_transition, next, message) => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    await beginPairing(runtime);
+    runtime.bridge.reconcile.mockResolvedValueOnce({ outcome: "applied", current: next });
+
+    runtime.handlers.onReconcile();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: next,
+        announcement: message,
+        healthAnnouncement: "",
+        feedback: { tone: "success", message },
+      }),
+    );
+
+    runtime.bridge.status.mockResolvedValueOnce(next);
+    runtime.poll?.();
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        healthAnnouncement: "",
+        feedback: { message },
+      }),
+    );
   });
 
   it("warns that a primary claim may have committed when pairing storage is uncertain", async () => {


### PR DESCRIPTION
## Summary

- keep Telegram pairing mutation feedback associated with the submitted candidate until daemon status reconciles
- prevent health polling from erasing actionable pairing feedback
- expose the feedback through the accessible settings surface

## Verification

- 73 renderer Telegram tests passed on the stacked result
- renderer source and test TypeScript checks passed
- changed-file lint, formatting, and diff checks passed
