### PR TITLE
fix(desktop): preserve Telegram secure storage truth

### DIFF
--- a/.changeset/telegram-secure-storage-recovery.md
+++ b/.changeset/telegram-secure-storage-recovery.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/desktop": patch
+"@enduragent/desktop-renderer": patch
+"cycling-coach": patch
+---
+
+User-facing: Telegram setup now explains how to recover when secure token storage or Keychain access is unavailable without changing the current bot.
+
+Preserve closed secure-storage refusal reasons across the Desktop process boundary, refuse unencrypted token storage, and emit stage-and-reason-only local diagnostics without exposing credential details.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -120,6 +120,8 @@ type DesktopUpdateState =
 type DesktopTelegramControlErrorCode =
   | "telegram-start-failed"
   | "telegram-credential-storage-failed"
+  | "telegram-credential-encryption-unavailable"
+  | "telegram-credential-unsafe-backend"
   | "telegram-credential-unavailable"
   | "telegram-settings-storage-uncertain"
   | "telegram-daemon-unavailable"
@@ -192,6 +194,8 @@ type DesktopTelegramMutationRefusalReason =
   | "invalid-token"
   | "validation-unavailable"
   | "webhook-removal-required"
+  | "encryption-unavailable"
+  | "unsafe-backend"
   | "storage-failed"
   | "stale-operation"
   | "transfer-required"

--- a/apps/desktop-renderer/src/settings/telegram-controller.ts
+++ b/apps/desktop-renderer/src/settings/telegram-controller.ts
@@ -3,6 +3,8 @@ export type TelegramControlErrorCode =
   | "telegram-polling-conflict"
   | "telegram-start-failed"
   | "telegram-credential-storage-failed"
+  | "telegram-credential-encryption-unavailable"
+  | "telegram-credential-unsafe-backend"
   | "telegram-credential-unavailable"
   | "telegram-settings-storage-uncertain"
   | "telegram-daemon-unavailable"
@@ -68,6 +70,8 @@ export type TelegramMutationReason =
   | "invalid-token"
   | "validation-unavailable"
   | "webhook-removal-required"
+  | "encryption-unavailable"
+  | "unsafe-backend"
   | "storage-failed"
   | "storage-uncertain"
   | "control-uncertain"
@@ -249,6 +253,22 @@ function mutationFailureCopy(
     return action === "paste-token"
       ? "The copied token was not applied to the running bot because storage could not be verified. Restart Enduragent and check Telegram before trying again."
       : "The change was not applied because storage could not be verified. Restart Enduragent and check this setting before trying again.";
+  }
+  if (result.reason === "encryption-unavailable") {
+    if (action !== "paste-token") {
+      return "Secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, then choose Check again.";
+    }
+    return result.current.credentialConfigured
+      ? "The current Telegram bot is unchanged because secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, copy the bot token again, then retry."
+      : "Secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, copy the bot token again, then retry.";
+  }
+  if (result.reason === "unsafe-backend") {
+    if (action !== "paste-token") {
+      return "No secure credential backend is available, so Enduragent refused to read or change the saved bot token without encryption. Quit and reopen Enduragent, then choose Check again.";
+    }
+    return result.current.credentialConfigured
+      ? "The current Telegram bot is unchanged because no secure credential backend is available. Enduragent refused to save the copied token without encryption. Quit and reopen Enduragent, copy the bot token again, then retry."
+      : "No secure credential backend is available, so Enduragent refused to save the bot token without encryption. Quit and reopen Enduragent, copy the bot token again, then retry.";
   }
   if (action === "paste-token") {
     switch (result.reason) {

--- a/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
@@ -52,8 +52,14 @@ function attentionCopy(status: TelegramControlStatus): string | null {
     return "Telegram rejected the saved token. Ask BotFather for a fresh token, copy it, then replace it from the clipboard.";
   }
   if (status.channel.state === "failed") {
+    if (status.channel.errorCode === "telegram-credential-encryption-unavailable") {
+      return "Secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, then choose Check again.";
+    }
+    if (status.channel.errorCode === "telegram-credential-unsafe-backend") {
+      return "No secure credential backend is available, so Enduragent refused to read or change the saved bot token without encryption. Quit and reopen Enduragent, then choose Check again.";
+    }
     if (status.channel.errorCode === "telegram-credential-unavailable") {
-      return "macOS could not unlock the saved bot token. Unlock the Mac, then choose Check again.";
+      return "The saved bot token could not be read from secure storage. Quit and reopen Enduragent, then choose Check again. If it still cannot be read, replace the bot token.";
     }
     if (status.channel.errorCode === "telegram-credential-storage-failed") {
       return "The encrypted bot credential could not be saved. Check local disk access and try again.";

--- a/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
@@ -256,6 +256,63 @@ describe("Telegram settings surface", () => {
     expect(screen.queryByText(/encrypted bot credential could not be saved/u)).toBeNull();
   });
 
+  it.each([
+    [
+      "telegram-credential-encryption-unavailable" as const,
+      /quit and reopen Enduragent, unlock or approve Keychain access, then choose Check again/iu,
+      /without encryption/iu,
+    ],
+    [
+      "telegram-credential-unsafe-backend" as const,
+      /refused to read or change the saved bot token without encryption.*choose Check again/iu,
+      /macOS|Keychain/iu,
+    ],
+    [
+      "telegram-credential-unavailable" as const,
+      /saved bot token could not be read from secure storage.*choose Check again/iu,
+      /macOS|Keychain/iu,
+    ],
+  ])("offers actionable recovery for %s", async (errorCode, expected, forbidden) => {
+    const user = userEvent.setup();
+    const port = setup(
+      readyState(status({ channel: { desiredState: "enabled", state: "failed", errorCode } })),
+    );
+
+    expect(screen.getByText(expected)).toBeVisible();
+    expect(screen.queryByText(forbidden)).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Check again" }));
+    expect(port.reconcile).toHaveBeenCalledWith();
+  });
+
+  it.each([
+    [
+      "telegram-credential-encryption-unavailable" as const,
+      /quit and reopen Enduragent, unlock or approve Keychain access, then choose Check again/iu,
+    ],
+    [
+      "telegram-credential-unsafe-backend" as const,
+      /refused to read or change the saved bot token without encryption.*choose Check again/iu,
+    ],
+  ])("keeps the current paired bot visible during %s recovery", (errorCode, expected) => {
+    setup(
+      readyState(
+        status({
+          channel: { desiredState: "enabled", state: "failed", errorCode },
+          bot: { state: "ready", username: "desktop_coach_bot" },
+          pairing: { state: "paired" },
+          credentialConfigured: true,
+        }),
+      ),
+    );
+
+    expect(screen.getByText(expected)).toBeVisible();
+    expect(screen.getByText("@desktop_coach_bot")).toBeVisible();
+    expect(screen.getByText("Paired with a primary Telegram user")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Check again" })).toBeVisible();
+    expect(screen.queryByText("Create a bot with BotFather")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Paste token from clipboard" })).toBeNull();
+  });
+
   it("requires confirmation before removing the encrypted bot credential", async () => {
     const user = userEvent.setup();
     const port = setup(

--- a/apps/desktop-renderer/tests/telegram-settings.test.ts
+++ b/apps/desktop-renderer/tests/telegram-settings.test.ts
@@ -220,6 +220,53 @@ describe("Telegram settings controller", () => {
     });
   });
 
+  it("gives actionable Keychain recovery when secure storage is unavailable during setup", async () => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    runtime.bridge.pasteTokenFromClipboard.mockResolvedValueOnce({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+      current: DISABLED,
+    });
+
+    runtime.handlers.onPasteToken();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: DISABLED,
+        feedback: {
+          tone: "error",
+          message:
+            "Secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, copy the bot token again, then retry.",
+        },
+      }),
+    );
+  });
+
+  it("refuses plaintext token storage without mislabeling it as a Keychain approval problem", async () => {
+    const runtime = setup();
+    await runtime.controller.activate();
+    runtime.bridge.pasteTokenFromClipboard.mockResolvedValueOnce({
+      outcome: "refused",
+      reason: "unsafe-backend",
+      current: DISABLED,
+    });
+
+    runtime.handlers.onPasteToken();
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: DISABLED,
+        feedback: {
+          tone: "error",
+          message:
+            "No secure credential backend is available, so Enduragent refused to save the bot token without encryption. Quit and reopen Enduragent, copy the bot token again, then retry.",
+        },
+      }),
+    );
+    expect(JSON.stringify(runtime.controller.state())).not.toContain("Keychain");
+  });
+
   it("keeps the old bot online while reporting a refused replacement across status polls", async () => {
     const runtime = setup();
     runtime.bridge.status.mockResolvedValueOnce(PAIRED);
@@ -416,6 +463,14 @@ describe("Telegram settings controller", () => {
       "webhook-removal-required",
       "The copied bot still uses a webhook. Remove that webhook before replacing the current Telegram bot.",
     ],
+    [
+      "encryption-unavailable",
+      "The current Telegram bot is unchanged because secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, copy the bot token again, then retry.",
+    ],
+    [
+      "unsafe-backend",
+      "The current Telegram bot is unchanged because no secure credential backend is available. Enduragent refused to save the copied token without encryption. Quit and reopen Enduragent, copy the bot token again, then retry.",
+    ],
   ] as const)("reports the closed %s replacement refusal", async (reason, message) => {
     const runtime = setup();
     runtime.bridge.status.mockResolvedValueOnce(PAIRED);
@@ -459,6 +514,38 @@ describe("Telegram settings controller", () => {
         telegram: next,
         healthAnnouncement: message,
         feedback: null,
+      }),
+    );
+  });
+
+  it.each([
+    [
+      "reconcile" as const,
+      "encryption-unavailable" as const,
+      "Secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, then choose Check again.",
+    ],
+    [
+      "remove-webhook" as const,
+      "unsafe-backend" as const,
+      "No secure credential backend is available, so Enduragent refused to read or change the saved bot token without encryption. Quit and reopen Enduragent, then choose Check again.",
+    ],
+  ])("gives %s an actionable %s recovery", async (action, reason, message) => {
+    const runtime = setup();
+    runtime.bridge.status.mockResolvedValueOnce(PAIRED);
+    await runtime.controller.activate();
+    const result = { outcome: "refused", reason, current: PAIRED } as const;
+    if (action === "reconcile") {
+      runtime.bridge.reconcile.mockResolvedValueOnce(result);
+      runtime.handlers.onReconcile();
+    } else {
+      runtime.bridge.removeWebhook.mockResolvedValueOnce(result);
+      runtime.handlers.onRemoveWebhook();
+    }
+
+    await vi.waitFor(() =>
+      expect(runtime.controller.state()).toMatchObject({
+        telegram: PAIRED,
+        feedback: { tone: "error", message },
       }),
     );
   });

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -89,6 +89,7 @@ import {
 } from "./telegram-credential-vault.js";
 import { createTelegramDaemonBinding } from "./telegram-daemon-binding.js";
 import { installDesktopTelegramIpc } from "./telegram-ipc.js";
+import { createTelegramSecureStorageDiagnostics } from "./telegram-secure-storage-diagnostics.js";
 import {
   createDesktopTelegramPowerLifecycle,
   type DesktopTelegramPowerLifecycle,
@@ -265,10 +266,12 @@ async function runDesktop(): Promise<void> {
       await realpath(resolveDesktopAthleteHome(environment)),
     );
     requireDesktopDaemonHome(selectedAthleteHome, resolution.athleteHome);
+    const telegramSecureStorageDiagnostics = createTelegramSecureStorageDiagnostics();
     const telegramVault = createTelegramCredentialVault({
       root: join(app.getPath("userData"), TELEGRAM_CREDENTIAL_DIRECTORY_NAME),
       athleteHome: selectedAthleteHome,
       encryption: safeStorage,
+      observeSecureStorageFailure: telegramSecureStorageDiagnostics,
     });
     let activeTelegramBinding: TelegramDaemonBinding | undefined;
     const preparedTelegramBindings = new Map<number, TelegramDaemonBinding>();
@@ -284,6 +287,7 @@ async function runDesktop(): Promise<void> {
             : undefined;
         },
       },
+      observeSecureStorageFailure: telegramSecureStorageDiagnostics,
     });
     closeTelegramCoordinator = () => telegramCoordinator.close();
     telegramPower = createDesktopTelegramPowerLifecycle({
@@ -558,6 +562,7 @@ async function runDesktop(): Promise<void> {
           selectedAthleteHome: () => selectedAthleteHome,
           vault: telegramVault,
           daemon: { current: () => successorTelegram },
+          observeSecureStorageFailure: telegramSecureStorageDiagnostics,
         });
         const reconciliation = await successorTelegramCoordinator.reconcile();
         const desiredState = await telegramVault.desiredState();

--- a/apps/desktop/src/main/telegram-control.ts
+++ b/apps/desktop/src/main/telegram-control.ts
@@ -19,13 +19,21 @@ import type {
   TelegramCredentialVault,
   TelegramDesiredState,
   TelegramProfileRecord,
+  TelegramProfileRePromptReason,
   TelegramProfileStatus,
 } from "./telegram-credential-vault.js";
+import {
+  emitTelegramSecureStorageFailure,
+  type TelegramSecureStorageObserver,
+  type TelegramSecureStorageReason,
+} from "./telegram-secure-storage-diagnostics.js";
 
 type EmptyRpcParams = Readonly<Record<string, never>>;
 
 export const DESKTOP_TELEGRAM_CONTROL_ERROR_CODES = [
   "telegram-credential-storage-failed",
+  "telegram-credential-encryption-unavailable",
+  "telegram-credential-unsafe-backend",
   "telegram-credential-unavailable",
   "telegram-settings-storage-uncertain",
   "telegram-daemon-unavailable",
@@ -57,6 +65,8 @@ export type DesktopTelegramMutationRefusalReason =
   | "invalid-token"
   | "validation-unavailable"
   | "webhook-removal-required"
+  | "encryption-unavailable"
+  | "unsafe-backend"
   | "storage-failed"
   | "stale-operation"
   | "transfer-required"
@@ -65,6 +75,17 @@ export type DesktopTelegramMutationRefusalReason =
   | "invalid-state";
 
 export type DesktopTelegramMutationUncertaintyReason = "storage-uncertain" | "control-uncertain";
+
+type DesktopTelegramSecureStorageRefusalReason = Extract<
+  DesktopTelegramMutationRefusalReason,
+  "encryption-unavailable" | "unsafe-backend"
+>;
+
+function isSecureStorageRefusal(
+  reason: unknown,
+): reason is DesktopTelegramSecureStorageRefusalReason {
+  return reason === "encryption-unavailable" || reason === "unsafe-backend";
+}
 
 export type DesktopTelegramMutationResult =
   | Readonly<{ outcome: "applied"; current: DesktopTelegramSnapshot }>
@@ -142,6 +163,7 @@ export interface CreateTelegramControlCoordinatorInput {
     | "setDesiredState"
   >;
   readonly daemon: TelegramDaemonAuthorityPort;
+  readonly observeSecureStorageFailure?: TelegramSecureStorageObserver;
   readonly pairingLease?: {
     readonly now: () => number;
     readonly schedule: (callback: () => void, delayMs: number) => unknown;
@@ -235,6 +257,29 @@ function profileBot(
   return { state: "ready", username: profile.bot.username };
 }
 
+function profileStatusErrorCode(
+  reason: TelegramProfileRePromptReason,
+): DesktopTelegramControlErrorCode {
+  if (reason === "encryption-unavailable") {
+    return "telegram-credential-encryption-unavailable";
+  }
+  if (reason === "unsafe-backend") return "telegram-credential-unsafe-backend";
+  return "telegram-credential-unavailable";
+}
+
+function configuredSnapshot(
+  profile: Extract<TelegramProfileStatus, { state: "configured" }>,
+  daemonSnapshot: TelegramControlSnapshot,
+  desiredState: "disabled" | "enabled",
+): DesktopTelegramSnapshot {
+  return {
+    channel: desiredState === "disabled" ? DISABLED_CHANNEL : daemonSnapshot.channel,
+    bot: profileBot(profile, daemonSnapshot.bot),
+    pairing: daemonSnapshot.pairing,
+    credentialConfigured: true,
+  };
+}
+
 function isPollingCapable(snapshot: TelegramControlSnapshot): boolean {
   return (
     snapshot.channel.desiredState === "enabled" &&
@@ -282,6 +327,20 @@ export function createTelegramControlCoordinator(
       cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
     } as const);
   let pairingLease: DesktopTelegramPairingLease | undefined;
+
+  const observeDaemonApplyFailure = (reason: TelegramSecureStorageReason): void => {
+    emitTelegramSecureStorageFailure(input.observeSecureStorageFailure, {
+      stage: "daemon-apply",
+      reason,
+    });
+  };
+
+  const profileStatusRefusal = (
+    profileStatus: TelegramProfileStatus,
+  ): TelegramProfileRePromptReason | undefined => {
+    if (profileStatus.state !== "re-prompt") return undefined;
+    return profileStatus.reason;
+  };
 
   const serialize = <T>(operation: () => Promise<T>): Promise<T> => {
     if (!accepting) return Promise.reject(new TypeError());
@@ -354,7 +413,16 @@ export function createTelegramControlCoordinator(
       );
     }
     if (profile.state === "wrong-home") return failure(desiredState, "telegram-home-mismatch");
-    if (profile.state === "re-prompt" || profile.state === "uncertain") {
+    if (profile.state === "re-prompt") {
+      return failure(
+        desiredState,
+        profileStatusErrorCode(profile.reason),
+        true,
+        daemonSnapshot?.bot ?? UNCONFIGURED_BOT,
+        daemonSnapshot?.pairing ?? UNPAIRED,
+      );
+    }
+    if (profile.state === "uncertain") {
       return failure(desiredState, "telegram-credential-unavailable");
     }
     if (profile.state !== "configured") {
@@ -532,7 +600,11 @@ export function createTelegramControlCoordinator(
     active: TelegramDaemonBinding,
   ): Promise<
     | { readonly state: "configured"; readonly profile: TelegramProfileRecord }
-    | { readonly state: "missing" | "refused" | "uncertain" }
+    | { readonly state: "missing" | "uncertain" }
+    | {
+        readonly state: "refused";
+        readonly reason: "encryption-unavailable" | "unsafe-backend" | "storage-failed";
+      }
   > => {
     let captured: TelegramProfileRecord | undefined;
     const result = await input.vault.applyStoredProfile(active.athleteHome, async (profile) => {
@@ -540,25 +612,33 @@ export function createTelegramControlCoordinator(
     });
     if (result.outcome === "uncertain") return { state: "uncertain" };
     if (result.outcome === "refused") {
-      return { state: result.reason === "missing" ? "missing" : "refused" };
+      if (result.reason === "missing") return { state: "missing" };
+      const reason = isSecureStorageRefusal(result.reason) ? result.reason : "storage-failed";
+      return {
+        state: "refused",
+        reason,
+      };
     }
-    return captured === undefined
-      ? { state: "refused" }
-      : { state: "configured", profile: captured };
+    if (captured !== undefined) return { state: "configured", profile: captured };
+    return { state: "refused", reason: "storage-failed" };
   };
 
   const replaceProfile = async (
     active: TelegramDaemonBinding,
     token: string,
     bot: TelegramProfileRecord["bot"],
-  ): Promise<"applied" | "refused" | "uncertain"> => {
+  ): Promise<
+    "applied" | "encryption-unavailable" | "unsafe-backend" | "storage-failed" | "uncertain"
+  > => {
     try {
       const result = await input.vault.replaceProfile({
         token,
         bot,
         authenticatedAthleteHome: active.athleteHome,
       });
-      return result.outcome;
+      if (result.outcome !== "refused") return result.outcome;
+      const reason = isSecureStorageRefusal(result.reason) ? result.reason : "storage-failed";
+      return reason;
     } catch {
       return "uncertain";
     }
@@ -673,17 +753,15 @@ export function createTelegramControlCoordinator(
       const checked = await checkedBinding();
       if ("result" in checked) return checked.result;
       const profileStatus = await input.vault.profileStatus();
-      if (
-        replacement ? profileStatus.state !== "configured" : profileStatus.state === "configured"
-      ) {
-        return refused("invalid-state");
-      }
+      const profileRefusal = profileStatusRefusal(profileStatus);
+      if (profileRefusal !== undefined) return refused(profileRefusal);
       if (profileStatus.state === "uncertain") return uncertain();
-      if (profileStatus.state === "wrong-home" || profileStatus.state === "re-prompt") {
-        return refused("storage-failed");
-      }
+      if (profileStatus.state === "wrong-home") return refused("storage-failed");
+      if (replacement && profileStatus.state !== "configured") return refused("invalid-state");
+      if (!replacement && profileStatus.state === "configured") return refused("invalid-state");
       const prior = replacement ? await captureProfile(checked.active) : undefined;
       if (replacement && prior?.state === "uncertain") return uncertain();
+      if (replacement && prior?.state === "refused") return refused(prior.reason);
       if (replacement && prior?.state !== "configured") return refused("storage-failed");
       const priorProfile = prior?.state === "configured" ? prior.profile : undefined;
       const inspection = await inspect(checked.active, token);
@@ -703,7 +781,7 @@ export function createTelegramControlCoordinator(
       if (inspection.status === "webhook-removal-required") {
         const stored = await replaceProfile(checked.active, token, inspection.bot);
         if (stored === "uncertain") return uncertain();
-        if (stored === "refused") return refused("storage-failed");
+        if (stored !== "applied") return refused(stored);
         const desiredWrite = await persistDesired(false);
         if (desiredWrite !== "applied") {
           const restored = await compensate(
@@ -725,10 +803,12 @@ export function createTelegramControlCoordinator(
         return refused("transfer-required");
       }
       if (replacement) {
+        if (profileStatus.state !== "configured") return refused("invalid-state");
         const before = await guardedSnapshotCall(checked.active, () =>
           checked.active.getTelegramStatus({}),
         );
         if (before === undefined) return refused("stale-operation");
+        const preMutationCurrent = configuredSnapshot(profileStatus, before, checked.desiredState);
         const wasSuspended =
           before.channel.state === "suspended" || transientSuspension === checked.active;
         let rawSuspended: unknown;
@@ -791,7 +871,9 @@ export function createTelegramControlCoordinator(
           const desiredRestored = desiredChanged ? await restoreDesired(priorDesired) : "restored";
           const resumed = await suspensionLease.release();
           if (stored === "uncertain" || desiredRestored === "uncertain") return uncertain();
-          return resumed === undefined ? uncertain("control-uncertain") : refused("storage-failed");
+          return resumed === undefined
+            ? uncertain("control-uncertain")
+            : refused(stored, preMutationCurrent);
         }
         if (!isCurrent(checked.active)) {
           await compensate(checked.active, priorProfile, priorDesired, desiredChanged);
@@ -803,6 +885,7 @@ export function createTelegramControlCoordinator(
         try {
           rawMutation = await checked.active.replaceTelegram({ token });
         } catch {
+          observeDaemonApplyFailure("control-uncertain");
           const daemonRestored = await restoreDaemonProfile(checked.active, priorProfile!.token);
           const restored = await compensate(
             checked.active,
@@ -819,11 +902,13 @@ export function createTelegramControlCoordinator(
             : uncertain("control-uncertain");
         }
         if (!isCurrent(checked.active)) {
+          observeDaemonApplyFailure("control-uncertain");
           await compensate(checked.active, priorProfile, priorDesired, desiredChanged);
           return uncertain("control-uncertain");
         }
         const mutation = parseMutation(rawMutation);
         if (mutation === undefined) {
+          observeDaemonApplyFailure("control-uncertain");
           const daemonRestored = await restoreDaemonProfile(checked.active, priorProfile!.token);
           const restored = await compensate(
             checked.active,
@@ -840,6 +925,7 @@ export function createTelegramControlCoordinator(
             : uncertain("control-uncertain");
         }
         if (mutation.outcome === "refused") {
+          observeDaemonApplyFailure("control-unavailable");
           const restored = await compensate(
             checked.active,
             priorProfile,
@@ -855,6 +941,7 @@ export function createTelegramControlCoordinator(
           );
         }
         if (!isReadyForProfile(mutation.current, { bot: inspection.bot })) {
+          observeDaemonApplyFailure("control-uncertain");
           const daemonRestored = await restoreDaemonProfile(checked.active, priorProfile!.token);
           const restored = await compensate(
             checked.active,
@@ -881,15 +968,19 @@ export function createTelegramControlCoordinator(
         } else {
           final = await suspensionLease.release();
         }
-        return final === undefined ||
+        if (
+          final === undefined ||
           !isReadyForProfile(final, { bot: inspection.bot }) ||
           !matchesDesired(final, differentBot ? false : priorDesired)
-          ? uncertain("control-uncertain")
-          : applied(await project(final, checked.active));
+        ) {
+          observeDaemonApplyFailure("control-uncertain");
+          return uncertain("control-uncertain");
+        }
+        return applied(await project(final, checked.active));
       }
       const stored = await replaceProfile(checked.active, token, inspection.bot);
       if (stored === "uncertain") return uncertain();
-      if (stored === "refused") return refused("storage-failed");
+      if (stored !== "applied") return refused(stored);
       const desiredWrite = await persistDesired(false);
       if (desiredWrite !== "applied") {
         const restored = await compensate(
@@ -908,6 +999,7 @@ export function createTelegramControlCoordinator(
       try {
         rawMutation = await checked.active.configureTelegram({ token });
       } catch {
+        observeDaemonApplyFailure("control-uncertain");
         const daemonCleared = await clearInitialDaemonProfile(checked.active);
         const restored = await compensate(checked.active, undefined, priorDesired, true);
         return daemonCleared !== undefined && restored === "restored"
@@ -915,11 +1007,13 @@ export function createTelegramControlCoordinator(
           : uncertain("control-uncertain");
       }
       if (!isCurrent(checked.active)) {
+        observeDaemonApplyFailure("control-uncertain");
         await compensate(checked.active, undefined, priorDesired, true);
         return uncertain("control-uncertain");
       }
       const mutation = parseMutation(rawMutation);
       if (mutation === undefined) {
+        observeDaemonApplyFailure("control-uncertain");
         const daemonCleared = await clearInitialDaemonProfile(checked.active);
         const restored = await compensate(checked.active, undefined, priorDesired, true);
         return daemonCleared !== undefined && restored === "restored"
@@ -927,6 +1021,7 @@ export function createTelegramControlCoordinator(
           : uncertain("control-uncertain");
       }
       if (mutation.outcome === "refused") {
+        observeDaemonApplyFailure("control-unavailable");
         const restored = await compensate(checked.active, undefined, priorDesired, true);
         return restored === "restored"
           ? refused(
@@ -939,6 +1034,7 @@ export function createTelegramControlCoordinator(
         !isReadyForProfile(mutation.current, { bot: inspection.bot }) ||
         !matchesDesired(mutation.current, false)
       ) {
+        observeDaemonApplyFailure("control-uncertain");
         const daemonCleared = await clearInitialDaemonProfile(checked.active);
         const restored = await compensate(checked.active, undefined, priorDesired, true);
         return daemonCleared !== undefined && restored === "restored"
@@ -957,6 +1053,8 @@ export function createTelegramControlCoordinator(
       if ("result" in checked) return checked.result;
       const profileStatus = await input.vault.profileStatus();
       if (next && profileStatus.state !== "configured") {
+        const profileRefusal = profileStatusRefusal(profileStatus);
+        if (profileRefusal !== undefined) return refused(profileRefusal);
         return profileStatus.state === "uncertain" ? uncertain() : refused("invalid-state");
       }
       if (checked.active.supervision === "attached" && next) {
@@ -972,11 +1070,13 @@ export function createTelegramControlCoordinator(
       if (stored === "refused") return refused("storage-failed");
       const response = await guardedSnapshotCall(checked.active, () => invoke(checked.active));
       if (response === undefined) {
+        observeDaemonApplyFailure("control-uncertain");
         await restoreDesired(previous);
         return uncertain("control-uncertain");
       }
       const responseDesired = response.channel.desiredState === "enabled";
       if (responseDesired !== next) {
+        observeDaemonApplyFailure("control-uncertain");
         const desiredRestored = await restoreDesired(previous);
         if (desiredRestored === "uncertain" || previous === next) {
           return uncertain("control-uncertain");
@@ -984,6 +1084,7 @@ export function createTelegramControlCoordinator(
         return refused("invalid-state");
       }
       if (next && response.channel.state === "conflict") {
+        observeDaemonApplyFailure("control-unavailable");
         if (previous) {
           return refused("polling-conflict", await project(response, checked.active));
         }
@@ -1027,18 +1128,32 @@ export function createTelegramControlCoordinator(
     }
     if (loaded.outcome === "refused") {
       if (loaded.reason === "runtime-unavailable") {
+        observeDaemonApplyFailure("control-uncertain");
         return { outcome: "uncertain", reason: "control-uncertain" };
+      }
+      if (isSecureStorageRefusal(loaded.reason)) {
+        return { outcome: "refused", reason: loaded.reason };
       }
       return {
         outcome: "refused",
-        reason: loaded.reason === "missing" ? "invalid-state" : "control-unavailable",
+        reason:
+          loaded.reason === "missing"
+            ? "invalid-state"
+            : loaded.reason === "re-prompt"
+              ? "storage-failed"
+              : "control-unavailable",
       };
     }
-    if (mutation === undefined) return { outcome: "refused", reason: "control-unavailable" };
+    if (mutation === undefined) {
+      observeDaemonApplyFailure("control-unavailable");
+      return { outcome: "refused", reason: "control-unavailable" };
+    }
     if (mutation.outcome === "refused") {
+      observeDaemonApplyFailure("control-unavailable");
       return { outcome: "refused", reason: mapDaemonRefusal(mutation.reason) };
     }
     if (expectedProfile === undefined || !isReadyForProfile(mutation.current, expectedProfile)) {
+      observeDaemonApplyFailure("control-uncertain");
       return { outcome: "uncertain", reason: "control-uncertain" };
     }
     return { outcome: "applied", current: mutation.current };
@@ -1463,6 +1578,7 @@ export function createTelegramControlCoordinator(
         if ("result" in checked) return checked.result;
         const prior = await captureProfile(checked.active);
         if (prior.state === "uncertain") return uncertain();
+        if (prior.state === "refused") return refused(prior.reason);
         if (prior.state !== "configured") return refused("invalid-state");
         const previousDesired = checked.desiredState === "enabled";
         const disabled = await guardedSnapshotCall(checked.active, () =>
@@ -1503,6 +1619,7 @@ export function createTelegramControlCoordinator(
         if ("result" in checked) return checked.result;
         const prior = await captureProfile(checked.active);
         if (prior.state === "uncertain") return uncertain();
+        if (prior.state === "refused") return refused(prior.reason);
         if (prior.state !== "configured") return refused("invalid-state");
         let ready: Extract<TelegramCredentialInspection, { status: "ready" }> | undefined;
         const appliedProfile = await input.vault.applyStoredProfile(
@@ -1518,6 +1635,12 @@ export function createTelegramControlCoordinator(
         );
         if (ready === undefined) {
           if (appliedProfile.outcome === "uncertain") return uncertain();
+          if (
+            appliedProfile.outcome === "refused" &&
+            isSecureStorageRefusal(appliedProfile.reason)
+          ) {
+            return refused(appliedProfile.reason);
+          }
           return appliedProfile.outcome === "refused" &&
             appliedProfile.reason !== "runtime-unavailable"
             ? refused("control-unavailable")
@@ -1576,11 +1699,15 @@ export function createTelegramControlCoordinator(
           ? ({ outcome: "applied", current: daemonStatus } as const)
           : await loadStoredProfile(active, daemonStatus);
         if (loaded.outcome !== "applied") {
+          const errorCode =
+            loaded.outcome === "refused" && isSecureStorageRefusal(loaded.reason)
+              ? profileStatusErrorCode(loaded.reason)
+              : loaded.outcome === "uncertain"
+                ? "telegram-control-failed"
+                : "telegram-credential-unavailable";
           return failure(
             await readDesired(),
-            loaded.outcome === "uncertain"
-              ? "telegram-control-failed"
-              : "telegram-credential-unavailable",
+            errorCode,
             true,
             profileBot(profileStatus),
             daemonStatus.pairing,
@@ -1615,6 +1742,8 @@ export function createTelegramControlCoordinator(
         }
         const profileStatus = await input.vault.profileStatus();
         if (profileStatus.state === "uncertain") return uncertain();
+        const profileRefusal = profileStatusRefusal(profileStatus);
+        if (profileRefusal !== undefined) return refused(profileRefusal);
         if (profileStatus.state !== "configured") {
           if (checked.desiredState === "enabled") return refused("invalid-state");
           const disabled = await guardedSnapshotCall(checked.active, () =>
@@ -1657,6 +1786,8 @@ export function createTelegramControlCoordinator(
         if (checked.active.supervision === "attached") return refused("transfer-required");
         const profileStatus = await input.vault.profileStatus();
         if (profileStatus.state === "uncertain") return uncertain();
+        const profileRefusal = profileStatusRefusal(profileStatus);
+        if (profileRefusal !== undefined) return refused(profileRefusal);
         if (profileStatus.state !== "configured") return refused("invalid-state");
         const daemonStatus = await guardedSnapshotCall(checked.active, () =>
           checked.active.getTelegramStatus({}),

--- a/apps/desktop/src/main/telegram-credential-vault.ts
+++ b/apps/desktop/src/main/telegram-credential-vault.ts
@@ -16,6 +16,11 @@ import {
   durablyReplaceReversible,
   type ReversibleDurableReplaceOutcome,
 } from "./durable-atomic-replace.js";
+import {
+  emitTelegramSecureStorageFailure,
+  type TelegramSecureStorageObserver,
+  type TelegramSecureStorageStage,
+} from "./telegram-secure-storage-diagnostics.js";
 
 export const TELEGRAM_CREDENTIAL_DIRECTORY_NAME = "telegram-channel-v1" as const;
 export const TELEGRAM_PROFILE_FILE_NAME = "profile.bin" as const;
@@ -33,13 +38,19 @@ export interface TelegramProfileRecord {
   readonly bot: Readonly<{ id: TelegramBotId; username: TelegramBotUsername }>;
 }
 
+export type TelegramProfileRePromptReason =
+  | "encryption-unavailable"
+  | "unsafe-backend"
+  | "storage-failed";
+
 export type TelegramProfileStatus =
   | Readonly<{
       state: "configured";
       profileId: string;
       bot: TelegramProfileRecord["bot"];
     }>
-  | Readonly<{ state: "missing" | "re-prompt" | "wrong-home" | "uncertain" }>;
+  | Readonly<{ state: "re-prompt"; reason: TelegramProfileRePromptReason }>
+  | Readonly<{ state: "missing" | "wrong-home" | "uncertain" }>;
 
 export type TelegramProfileReplaceResult =
   | Readonly<{
@@ -124,6 +135,7 @@ export interface TelegramCredentialVaultOptions {
   readonly removeFile?: typeof rm;
   readonly syncDirectory?: (root: string) => Promise<void>;
   readonly syncParentDirectory?: (root: string) => Promise<void>;
+  readonly observeSecureStorageFailure?: TelegramSecureStorageObserver;
 }
 
 interface TelegramDesiredStateRecord {
@@ -330,6 +342,19 @@ export function createTelegramCredentialVault(
   let desiredStateUncertain = false;
   let parentDirectoryVerified = false;
 
+  const observeFailure = (
+    stage: TelegramSecureStorageStage,
+    reason: EncryptionRefusal | "storage-failed" | "storage-uncertain",
+  ): void => {
+    emitTelegramSecureStorageFailure(options.observeSecureStorageFailure, { stage, reason });
+  };
+
+  const observedEncryptionRefusal = (): EncryptionRefusal | undefined => {
+    const reason = encryptionRefusal(options.encryption);
+    if (reason !== undefined) observeFailure("encryption-availability", reason);
+    return reason;
+  };
+
   const exclusive = <T>(operation: () => Promise<T>): Promise<T> => {
     const result = operationQueue.then(operation, operation);
     operationQueue = result.then(
@@ -372,12 +397,14 @@ export function createTelegramCredentialVault(
     if (namespaceVerification === "pending") {
       if (!(await reconcileOwnedTransients(true))) {
         namespaceVerification = "uncertain";
+        observeFailure("namespace", "storage-uncertain");
         return false;
       }
       namespaceVerification = "verified";
     }
     if (transientArtifactsMayExist && !(await reconcileOwnedTransients(false))) {
       namespaceVerification = "uncertain";
+      observeFailure("namespace", "storage-uncertain");
       return false;
     }
     return true;
@@ -386,23 +413,38 @@ export function createTelegramCredentialVault(
   const readProfile = async (): Promise<ReadProfile> => {
     const directory = await secureDirectoryState(options.root);
     if (directory === "missing") return { state: "missing" };
-    if (directory === "unsafe") return { state: "re-prompt", reason: "storage-failed" };
+    if (directory === "unsafe") {
+      observeFailure("namespace", "storage-failed");
+      return { state: "re-prompt", reason: "storage-failed" };
+    }
     const path = join(options.root, TELEGRAM_PROFILE_FILE_NAME);
     const file = await targetState(path);
     if (file === "missing") return { state: "missing" };
-    if (file === "unsafe") return { state: "re-prompt", reason: "storage-failed" };
-    const encryptionFailure = encryptionRefusal(options.encryption);
+    if (file === "unsafe") {
+      observeFailure("profile-atomic-write", "storage-failed");
+      return { state: "re-prompt", reason: "storage-failed" };
+    }
+    const encryptionFailure = observedEncryptionRefusal();
     if (encryptionFailure !== undefined) {
       return { state: "re-prompt", reason: encryptionFailure };
     }
     let encrypted: Buffer | undefined;
     try {
       encrypted = await readFile(path);
+    } catch {
+      observeFailure("profile-atomic-write", "storage-failed");
+      return { state: "re-prompt", reason: "storage-failed" };
+    }
+    try {
       const profile = parseProfileRecord(options.encryption.decryptString(encrypted));
-      if (profile === undefined) return { state: "re-prompt", reason: "decrypt-failed" };
+      if (profile === undefined) {
+        observeFailure("encryption-availability", "storage-failed");
+        return { state: "re-prompt", reason: "decrypt-failed" };
+      }
       if (profile.athleteHome !== athleteHome) return { state: "wrong-home" };
       return { state: "configured", profile };
     } catch {
+      observeFailure("encryption-availability", "storage-failed");
       return { state: "re-prompt", reason: "decrypt-failed" };
     } finally {
       encrypted?.fill(0);
@@ -412,17 +454,27 @@ export function createTelegramCredentialVault(
   const readDesiredState = async (): Promise<TelegramDesiredState> => {
     const directory = await secureDirectoryState(options.root);
     if (directory === "missing") return { state: "missing", enabled: false };
-    if (directory === "unsafe") return { state: "re-prompt", enabled: false };
+    if (directory === "unsafe") {
+      observeFailure("namespace", "storage-failed");
+      return { state: "re-prompt", enabled: false };
+    }
     const path = join(options.root, TELEGRAM_DESIRED_STATE_FILE_NAME);
     const file = await targetState(path);
     if (file === "missing") return { state: "missing", enabled: false };
-    if (file === "unsafe") return { state: "re-prompt", enabled: false };
+    if (file === "unsafe") {
+      observeFailure("desired-state-write", "storage-failed");
+      return { state: "re-prompt", enabled: false };
+    }
     try {
       const record = parseDesiredStateRecord(await readFile(path, "utf8"));
-      if (record === undefined) return { state: "re-prompt", enabled: false };
+      if (record === undefined) {
+        observeFailure("desired-state-write", "storage-failed");
+        return { state: "re-prompt", enabled: false };
+      }
       if (record.athleteHome !== athleteHome) return { state: "wrong-home", enabled: false };
       return { state: "configured", enabled: record.enabled };
     } catch {
+      observeFailure("desired-state-write", "storage-failed");
       return { state: "re-prompt", enabled: false };
     }
   };
@@ -430,24 +482,32 @@ export function createTelegramCredentialVault(
   const writeReversible = async (
     fileName: string,
     candidate: Buffer,
+    stage: Extract<TelegramSecureStorageStage, "profile-atomic-write" | "desired-state-write">,
   ): Promise<ReversibleDurableReplaceOutcome> => {
-    if (!(await ensureSecureDirectory(options.root))) return { state: "refused" };
+    if (!(await ensureSecureDirectory(options.root))) {
+      observeFailure("namespace", "storage-failed");
+      return { state: "refused" };
+    }
     if (!parentDirectoryVerified) {
       try {
         await syncParent(dirname(options.root));
         parentDirectoryVerified = true;
       } catch {
+        observeFailure("namespace", "storage-failed");
         return { state: "refused" };
       }
     }
     const target = join(options.root, fileName);
     const state = await targetState(target);
-    if (state === "unsafe") return { state: "refused" };
+    if (state === "unsafe") {
+      observeFailure(stage, "storage-failed");
+      return { state: "refused" };
+    }
     let previous: Buffer | undefined;
     try {
       if (state === "valid") previous = await readFile(target);
       transientArtifactsMayExist = true;
-      return await durablyReplaceReversible({
+      const stored = await durablyReplaceReversible({
         root: options.root,
         fileName,
         contents: candidate,
@@ -458,7 +518,15 @@ export function createTelegramCredentialVault(
         removeFile,
         syncDirectory: sync,
       });
+      if (stored.state !== "applied") {
+        observeFailure(
+          stage,
+          stored.state === "uncertain" ? "storage-uncertain" : "storage-failed",
+        );
+      }
+      return stored;
     } catch {
+      observeFailure(stage, "storage-failed");
       return { state: "refused" };
     } finally {
       previous?.fill(0);
@@ -511,13 +579,23 @@ export function createTelegramCredentialVault(
         if (!(await prepareNamespace())) return { state: "uncertain" };
         if (profileUncertain) return { state: "uncertain" };
         const profile = await readProfile();
-        return profile.state === "configured"
-          ? {
-              state: "configured",
-              profileId: profile.profile.profileId,
-              bot: profile.profile.bot,
-            }
-          : { state: profile.state };
+        if (profile.state === "configured") {
+          return {
+            state: "configured",
+            profileId: profile.profile.profileId,
+            bot: profile.profile.bot,
+          };
+        }
+        if (profile.state === "re-prompt") {
+          return {
+            state: "re-prompt",
+            reason:
+              profile.reason === "encryption-unavailable" || profile.reason === "unsafe-backend"
+                ? profile.reason
+                : "storage-failed",
+          };
+        }
+        return { state: profile.state };
       });
     },
 
@@ -533,7 +611,7 @@ export function createTelegramCredentialVault(
         if (token === undefined || id === undefined || username === undefined) {
           return { outcome: "refused", reason: "invalid-input" };
         }
-        const encryptionFailure = encryptionRefusal(options.encryption);
+        const encryptionFailure = observedEncryptionRefusal();
         if (encryptionFailure !== undefined) {
           return { outcome: "refused", reason: encryptionFailure };
         }
@@ -560,7 +638,16 @@ export function createTelegramCredentialVault(
         try {
           encrypted = options.encryption.encryptString(JSON.stringify(profile));
           if (!Buffer.isBuffer(encrypted) || encrypted.length === 0) throw new TypeError();
-          const stored = await writeReversible(TELEGRAM_PROFILE_FILE_NAME, encrypted);
+        } catch {
+          observeFailure("encryption-availability", "storage-failed");
+          return { outcome: "refused", reason: "storage-failed" };
+        }
+        try {
+          const stored = await writeReversible(
+            TELEGRAM_PROFILE_FILE_NAME,
+            encrypted,
+            "profile-atomic-write",
+          );
           profileUncertain = stored.state === "uncertain";
           if (stored.state === "applied") {
             return { outcome: "applied", profileId, bot };
@@ -569,6 +656,7 @@ export function createTelegramCredentialVault(
             ? { outcome: "refused", reason: "storage-failed" }
             : { outcome: "uncertain", reason: "storage-uncertain" };
         } catch {
+          observeFailure("profile-atomic-write", "storage-failed");
           return { outcome: "refused", reason: "storage-failed" };
         } finally {
           encrypted?.fill(0);
@@ -641,6 +729,10 @@ export function createTelegramCredentialVault(
           return { outcome: "applied", cleanupPending: removed === "cleanup-pending" };
         }
         if (removed === "uncertain") profileUncertain = true;
+        observeFailure(
+          "profile-atomic-write",
+          removed === "uncertain" ? "storage-uncertain" : "storage-failed",
+        );
         return removed === "uncertain"
           ? { outcome: "uncertain", reason: "storage-uncertain" }
           : { outcome: "refused", reason: "storage-failed" };
@@ -670,13 +762,18 @@ export function createTelegramCredentialVault(
           "utf8",
         );
         try {
-          const stored = await writeReversible(TELEGRAM_DESIRED_STATE_FILE_NAME, candidate);
+          const stored = await writeReversible(
+            TELEGRAM_DESIRED_STATE_FILE_NAME,
+            candidate,
+            "desired-state-write",
+          );
           desiredStateUncertain = stored.state === "uncertain";
           if (stored.state === "applied") return { status: "stored", enabled };
           return stored.state === "refused"
             ? { status: "refused", reason: "storage-failed" }
             : { status: "uncertain", reason: "storage-uncertain" };
         } catch {
+          observeFailure("desired-state-write", "storage-failed");
           return { status: "refused", reason: "storage-failed" };
         } finally {
           candidate.fill(0);

--- a/apps/desktop/src/main/telegram-ipc.ts
+++ b/apps/desktop/src/main/telegram-ipc.ts
@@ -41,6 +41,8 @@ const COORDINATOR_REFUSAL_REASONS = new Set([
   "invalid-token",
   "validation-unavailable",
   "webhook-removal-required",
+  "encryption-unavailable",
+  "unsafe-backend",
   "storage-failed",
   "stale-operation",
   "transfer-required",
@@ -60,6 +62,8 @@ export type DesktopTelegramMutationRefusalReason =
   | "invalid-token"
   | "validation-unavailable"
   | "webhook-removal-required"
+  | "encryption-unavailable"
+  | "unsafe-backend"
   | "storage-failed"
   | "stale-operation"
   | "transfer-required"
@@ -371,7 +375,7 @@ export function installDesktopTelegramIpc(input: {
               current: closedSnapshot(),
             } as const;
           }
-          return profile.state === "configured"
+          return profile.state === "configured" || profile.state === "re-prompt"
             ? input.coordinator.replace(captured.token)
             : input.coordinator.configure(captured.token);
         });

--- a/apps/desktop/src/main/telegram-secure-storage-diagnostics.ts
+++ b/apps/desktop/src/main/telegram-secure-storage-diagnostics.ts
@@ -1,0 +1,47 @@
+export const TELEGRAM_SECURE_STORAGE_STAGES = [
+  "namespace",
+  "encryption-availability",
+  "profile-atomic-write",
+  "desired-state-write",
+  "daemon-apply",
+] as const;
+
+export const TELEGRAM_SECURE_STORAGE_REASONS = [
+  "encryption-unavailable",
+  "unsafe-backend",
+  "storage-failed",
+  "storage-uncertain",
+  "control-unavailable",
+  "control-uncertain",
+] as const;
+
+export type TelegramSecureStorageStage = (typeof TELEGRAM_SECURE_STORAGE_STAGES)[number];
+export type TelegramSecureStorageReason = (typeof TELEGRAM_SECURE_STORAGE_REASONS)[number];
+
+export interface TelegramSecureStorageFailure {
+  readonly stage: TelegramSecureStorageStage;
+  readonly reason: TelegramSecureStorageReason;
+}
+
+export type TelegramSecureStorageObserver = (
+  failure: TelegramSecureStorageFailure,
+) => void | Promise<void>;
+
+export function emitTelegramSecureStorageFailure(
+  observer: TelegramSecureStorageObserver | undefined,
+  failure: TelegramSecureStorageFailure,
+): void {
+  if (observer === undefined) return;
+  try {
+    const result = observer(failure);
+    if (result !== undefined) void Promise.resolve(result).catch(() => undefined);
+  } catch {}
+}
+
+export function createTelegramSecureStorageDiagnostics(
+  write: (message: string) => unknown = (message) => process.stderr.write(message),
+): TelegramSecureStorageObserver {
+  return ({ stage, reason }) => {
+    write(`desktop-telegram-secure-storage-failure ${stage} ${reason}\n`);
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -115,6 +115,8 @@ const CLAUDE_CLI_STATES = new Set([
 const IMPORT_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
 const TELEGRAM_DESKTOP_ERROR_CODES = new Set([
   "telegram-credential-storage-failed",
+  "telegram-credential-encryption-unavailable",
+  "telegram-credential-unsafe-backend",
   "telegram-credential-unavailable",
   "telegram-settings-storage-uncertain",
   "telegram-daemon-unavailable",
@@ -136,6 +138,8 @@ const TELEGRAM_MUTATION_REFUSAL_REASONS = new Set([
   "invalid-token",
   "validation-unavailable",
   "webhook-removal-required",
+  "encryption-unavailable",
+  "unsafe-backend",
   "storage-failed",
   "stale-operation",
   "transfer-required",

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -343,6 +343,22 @@ describe("desktop preload ChatGPT auth", () => {
 
     await expect(bridge.pasteTelegramTokenFromClipboard()).resolves.toEqual(refusal);
 
+    const secureStorageRefusal = {
+      outcome: "refused",
+      reason: "encryption-unavailable",
+      current,
+    };
+    mocks.invoke.mockResolvedValueOnce(secureStorageRefusal);
+    await expect(bridge.pasteTelegramTokenFromClipboard()).resolves.toEqual(secureStorageRefusal);
+
+    const unsafeBackendRefusal = {
+      outcome: "refused",
+      reason: "unsafe-backend",
+      current,
+    };
+    mocks.invoke.mockResolvedValueOnce(unsafeBackendRefusal);
+    await expect(bridge.pasteTelegramTokenFromClipboard()).resolves.toEqual(unsafeBackendRefusal);
+
     const controlUncertainty = {
       outcome: "uncertain",
       reason: "control-uncertain",
@@ -467,6 +483,22 @@ describe("desktop preload ChatGPT auth", () => {
       channel: { ...status.channel, privateDetail: "private disk path" },
     });
     await expect(bridge.telegramStatus()).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it.each([
+    "telegram-credential-encryption-unavailable",
+    "telegram-credential-unsafe-backend",
+  ] as const)("accepts the closed redacted %s status code", async (errorCode) => {
+    const status = {
+      channel: { desiredState: "enabled", state: "failed", errorCode },
+      bot: { state: "unconfigured" },
+      pairing: { state: "unpaired" },
+      credentialConfigured: false,
+      gapWarning: { state: "clear" },
+    };
+    mocks.invoke.mockResolvedValueOnce(status);
+
+    await expect(bridge.telegramStatus()).resolves.toEqual(status);
   });
 
   it("accepts only the redacted pairing storage uncertainty code", async () => {

--- a/apps/desktop/tests/telegram-control.test.ts
+++ b/apps/desktop/tests/telegram-control.test.ts
@@ -1,4 +1,5 @@
 import {
+  AthleteHomeIdentitySchema,
   TelegramBotIdSchema,
   TelegramBotUsernameSchema,
   TelegramCredentialSchema,
@@ -8,7 +9,11 @@ import {
   type TelegramControlSnapshot,
   type TelegramCredentialInspection,
 } from "@enduragent/coach-contract";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import type { CredentialEncryptionPort } from "../src/main/credential-vault.js";
 import {
   createTelegramControlCoordinator,
   type CreateTelegramControlCoordinatorInput,
@@ -18,6 +23,7 @@ import type {
   TelegramCredentialVault,
   TelegramProfileRecord,
 } from "../src/main/telegram-credential-vault.js";
+import { createTelegramCredentialVault } from "../src/main/telegram-credential-vault.js";
 
 const HOME = "/synthetic/athlete" as AthleteHomeIdentity;
 const OTHER_HOME = "/synthetic/other" as AthleteHomeIdentity;
@@ -29,6 +35,25 @@ const USERNAME = TelegramBotUsernameSchema.parse("desktop_bot");
 const OTHER_USERNAME = TelegramBotUsernameSchema.parse("replacement_bot");
 const PROFILE_ID = "00000000-0000-4000-8000-000000000001";
 const REPLACEMENT_PROFILE_ID = "00000000-0000-4000-8000-000000000002";
+
+function realVaultEncryption(): CredentialEncryptionPort {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(value, "utf8").reverse(),
+    decryptString: (value) => Buffer.from(value).reverse().toString("utf8"),
+  };
+}
+
+async function realVaultFixture() {
+  const base = await mkdtemp(join(await realpath(tmpdir()), "telegram-control-secure-storage-"));
+  const homePath = join(base, "athlete-home");
+  await mkdir(homePath, { mode: 0o700 });
+  return {
+    base,
+    root: join(base, "telegram-channel-v1"),
+    athleteHome: AthleteHomeIdentitySchema.parse(await realpath(homePath)),
+  };
+}
 
 interface Deferred<T> {
   readonly promise: Promise<T>;
@@ -474,6 +499,324 @@ describe("Telegram main-process control coordinator", () => {
     expect(runtime.binding.replaceTelegram).not.toHaveBeenCalled();
     expect(runtime.binding.suspendTelegramPolling).toHaveBeenCalledOnce();
     expect(runtime.binding.resumeTelegramPolling).toHaveBeenCalledOnce();
+  });
+
+  it("preserves an encryption-unavailable refusal without applying the replacement token", async () => {
+    const runtime = harness();
+    const before = runtime.profile();
+    vi.mocked(runtime.vault.replaceProfile).mockResolvedValueOnce({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+    });
+
+    await expect(runtime.coordinator.replace(REPLACEMENT_TOKEN)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+      current: {
+        channel: { desiredState: "enabled", state: "online" },
+        bot: { state: "ready", username: USERNAME },
+        pairing: { state: "paired" },
+        credentialConfigured: true,
+      },
+    });
+    expect(runtime.profile()).toEqual(before);
+    expect(runtime.desired()).toBe(true);
+    expect(runtime.binding.replaceTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.resumeTelegramPolling).toHaveBeenCalledOnce();
+  });
+
+  it("keeps initial setup unchanged when secure encryption is unavailable", async () => {
+    const runtime = harness({
+      configured: false,
+      enabled: false,
+      daemonSnapshot: {
+        channel: { desiredState: "disabled", state: "disabled" },
+        bot: { state: "unconfigured" },
+        pairing: { state: "unpaired" },
+      },
+    });
+    vi.mocked(runtime.vault.replaceProfile).mockResolvedValueOnce({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+    });
+
+    await expect(runtime.coordinator.configure(REPLACEMENT_TOKEN)).resolves.toEqual({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+      current: {
+        channel: { desiredState: "disabled", state: "disabled" },
+        bot: { state: "unconfigured" },
+        pairing: { state: "unpaired" },
+        credentialConfigured: false,
+      },
+    });
+    expect(runtime.profile()).toBeUndefined();
+    expect(runtime.desired()).toBe(false);
+    expect(runtime.binding.configureTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.suspendTelegramPolling).not.toHaveBeenCalled();
+    expect(runtime.vault.setDesiredState).not.toHaveBeenCalled();
+  });
+
+  it("preserves an unsafe-backend refusal when the current profile cannot be read for replacement", async () => {
+    const runtime = harness();
+    const before = runtime.profile();
+    vi.mocked(runtime.vault.applyStoredProfile).mockResolvedValueOnce({
+      outcome: "refused",
+      reason: "unsafe-backend",
+    });
+
+    await expect(runtime.coordinator.replace(REPLACEMENT_TOKEN)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "unsafe-backend",
+      current: {
+        channel: { desiredState: "enabled", state: "online" },
+        bot: { state: "ready", username: USERNAME },
+        pairing: { state: "paired" },
+        credentialConfigured: true,
+      },
+    });
+    expect(runtime.profile()).toEqual(before);
+    expect(runtime.desired()).toBe(true);
+    expect(runtime.binding.inspectTelegramCredential).not.toHaveBeenCalled();
+    expect(runtime.binding.suspendTelegramPolling).not.toHaveBeenCalled();
+    expect(runtime.binding.replaceTelegram).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "encryption-unavailable" as const,
+      false,
+      undefined,
+      "telegram-credential-encryption-unavailable" as const,
+    ],
+    ["unsafe-backend" as const, true, "basic_text", "telegram-credential-unsafe-backend" as const],
+  ])(
+    "preserves a reopened real-vault %s refusal across profile-dependent actions",
+    async (reason, available, selectedBackend, errorCode) => {
+      const value = await realVaultFixture();
+      try {
+        const seed = createTelegramCredentialVault({
+          ...value,
+          encryption: realVaultEncryption(),
+          createProfileId: () => PROFILE_ID,
+        });
+        await expect(
+          seed.replaceProfile({
+            token: TOKEN,
+            bot: { id: BOT_ID, username: USERNAME },
+            authenticatedAthleteHome: value.athleteHome,
+          }),
+        ).resolves.toMatchObject({ outcome: "applied" });
+        await expect(seed.setDesiredState(true)).resolves.toEqual({
+          status: "stored",
+          enabled: true,
+        });
+        const observeSecureStorageFailure = vi.fn();
+        const reopened = createTelegramCredentialVault({
+          ...value,
+          encryption: {
+            ...realVaultEncryption(),
+            isEncryptionAvailable: () => available,
+            ...(selectedBackend === undefined
+              ? {}
+              : { getSelectedStorageBackend: () => selectedBackend }),
+          },
+          observeSecureStorageFailure,
+        });
+        const runtime = harness();
+        const realBinding = { ...runtime.binding, athleteHome: value.athleteHome };
+        const coordinator = createTelegramControlCoordinator({
+          selectedAthleteHome: () => value.athleteHome,
+          vault: reopened,
+          daemon: { current: () => realBinding },
+          observeSecureStorageFailure,
+        });
+
+        const expectedCurrent = {
+          channel: { desiredState: "enabled" as const, state: "failed" as const, errorCode },
+          bot: { state: "ready" as const, username: USERNAME },
+          pairing: { state: "paired" as const },
+          credentialConfigured: true,
+        };
+        await expect(coordinator.status()).resolves.toEqual(expectedCurrent);
+
+        for (const operation of [
+          () => coordinator.replace(REPLACEMENT_TOKEN),
+          () => coordinator.enable(),
+          () => coordinator.reconcile(),
+          () => coordinator.remove(),
+          () => coordinator.removeWebhook(),
+          () => coordinator.beginPairing(),
+        ]) {
+          await expect(operation()).resolves.toEqual({
+            outcome: "refused",
+            reason,
+            current: expectedCurrent,
+          });
+        }
+
+        expect(observeSecureStorageFailure).toHaveBeenCalledWith({
+          stage: "encryption-availability",
+          reason,
+        });
+        expect(observeSecureStorageFailure.mock.calls.flat(2)).not.toContain(TOKEN);
+        expect(runtime.binding.inspectTelegramCredential).not.toHaveBeenCalled();
+        expect(runtime.binding.replaceTelegram).not.toHaveBeenCalled();
+        expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+        expect(runtime.binding.disableTelegram).not.toHaveBeenCalled();
+        expect(runtime.binding.deleteTelegramWebhook).not.toHaveBeenCalled();
+        expect(runtime.binding.beginTelegramPairing).not.toHaveBeenCalled();
+
+        const verified = createTelegramCredentialVault({
+          ...value,
+          encryption: realVaultEncryption(),
+        });
+        const appliedProfile = vi.fn();
+        await expect(
+          verified.applyStoredProfile(value.athleteHome, appliedProfile),
+        ).resolves.toMatchObject({ outcome: "applied" });
+        expect(appliedProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ token: TOKEN, bot: { id: BOT_ID, username: USERNAME } }),
+        );
+        await expect(verified.desiredState()).resolves.toEqual({
+          state: "configured",
+          enabled: true,
+        });
+      } finally {
+        await rm(value.base, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("returns the preserved pre-mutation snapshot when a real vault backend flips during replacement", async () => {
+    const value = await realVaultFixture();
+    try {
+      const encryption = realVaultEncryption();
+      const seed = createTelegramCredentialVault({
+        ...value,
+        encryption,
+        createProfileId: () => PROFILE_ID,
+      });
+      await seed.replaceProfile({
+        token: TOKEN,
+        bot: { id: BOT_ID, username: USERNAME },
+        authenticatedAthleteHome: value.athleteHome,
+      });
+      await seed.setDesiredState(true);
+      let available = true;
+      let decryptions = 0;
+      const observeSecureStorageFailure = vi.fn();
+      const dynamic = createTelegramCredentialVault({
+        ...value,
+        encryption: {
+          ...encryption,
+          isEncryptionAvailable: () => available,
+          decryptString(value) {
+            const plaintext = encryption.decryptString(value);
+            decryptions += 1;
+            if (decryptions === 2) available = false;
+            return plaintext;
+          },
+        },
+        observeSecureStorageFailure,
+      });
+      const runtime = harness();
+      const realBinding = { ...runtime.binding, athleteHome: value.athleteHome };
+      const coordinator = createTelegramControlCoordinator({
+        selectedAthleteHome: () => value.athleteHome,
+        vault: dynamic,
+        daemon: { current: () => realBinding },
+        observeSecureStorageFailure,
+      });
+
+      await expect(coordinator.replace(REPLACEMENT_TOKEN)).resolves.toEqual({
+        outcome: "refused",
+        reason: "encryption-unavailable",
+        current: {
+          channel: { desiredState: "enabled", state: "online" },
+          bot: { state: "ready", username: USERNAME },
+          pairing: { state: "paired" },
+          credentialConfigured: true,
+        },
+      });
+      expect(runtime.binding.resumeTelegramPolling).toHaveBeenCalledOnce();
+      expect(runtime.binding.replaceTelegram).not.toHaveBeenCalled();
+      expect(observeSecureStorageFailure).toHaveBeenCalledWith({
+        stage: "encryption-availability",
+        reason: "encryption-unavailable",
+      });
+
+      const verified = createTelegramCredentialVault({ ...value, encryption });
+      const appliedProfile = vi.fn();
+      await verified.applyStoredProfile(value.athleteHome, appliedProfile);
+      expect(appliedProfile).toHaveBeenCalledWith(
+        expect.objectContaining({ token: TOKEN, bot: { id: BOT_ID, username: USERNAME } }),
+      );
+      await expect(verified.desiredState()).resolves.toEqual({
+        state: "configured",
+        enabled: true,
+      });
+    } finally {
+      await rm(value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("projects a generic unreadable profile with a closed status code", async () => {
+    const runtime = harness();
+    vi.mocked(runtime.vault.profileStatus).mockResolvedValue({
+      state: "re-prompt",
+      reason: "storage-failed",
+    });
+    const coordinator = createTelegramControlCoordinator({
+      selectedAthleteHome: () => HOME,
+      vault: runtime.vault,
+      daemon: { current: () => runtime.binding },
+    });
+
+    await expect(coordinator.status()).resolves.toMatchObject({
+      channel: {
+        desiredState: "enabled",
+        state: "failed",
+        errorCode: "telegram-credential-unavailable",
+      },
+    });
+  });
+
+  it("emits daemon-apply at the failing daemon boundary and isolates async rejection", async () => {
+    const runtime = harness({
+      daemonSnapshot: {
+        channel: { desiredState: "enabled", state: "waiting-for-credential" },
+        bot: { state: "unconfigured" },
+        pairing: { state: "unpaired" },
+      },
+    });
+    vi.mocked(runtime.binding.configureTelegram).mockRejectedValueOnce(
+      new TypeError("private daemon failure"),
+    );
+    const observeSecureStorageFailure = vi.fn(async () => {
+      throw new TypeError("private observer failure");
+    });
+    const coordinator = createTelegramControlCoordinator({
+      selectedAthleteHome: () => HOME,
+      vault: runtime.vault,
+      daemon: { current: () => runtime.binding },
+      observeSecureStorageFailure,
+    });
+
+    await expect(coordinator.reconcile()).resolves.toMatchObject({
+      outcome: "uncertain",
+      reason: "control-uncertain",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(observeSecureStorageFailure).toHaveBeenCalledWith({
+      stage: "daemon-apply",
+      reason: "control-uncertain",
+    });
+    expect(JSON.stringify(observeSecureStorageFailure.mock.calls)).not.toMatch(
+      /private daemon|private observer|synthetic-token/u,
+    );
   });
 
   it("converges to A when daemon replacement throws after B storage", async () => {
@@ -1917,6 +2260,30 @@ describe("Telegram main-process control coordinator", () => {
     expect(runtime.binding.disableTelegram).toHaveBeenCalledOnce();
   });
 
+  it("preserves an encryption-unavailable refusal while reconciling a stored profile", async () => {
+    const runtime = harness();
+    vi.mocked(runtime.vault.applyStoredProfile).mockResolvedValueOnce({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+    });
+
+    await expect(runtime.coordinator.reconcile()).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+      current: {
+        channel: { desiredState: "enabled", state: "online" },
+        bot: { state: "ready", username: USERNAME },
+        pairing: { state: "paired" },
+        credentialConfigured: true,
+      },
+    });
+    expect(runtime.desired()).toBe(true);
+    expect(runtime.binding.configureTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.replaceTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.disableTelegram).not.toHaveBeenCalled();
+  });
+
   it("reconciles stale enabled intent to disabled when no pairing or primary exists", async () => {
     const runtime = harness({
       enabled: true,
@@ -2204,6 +2571,29 @@ describe("Telegram main-process control coordinator", () => {
     expect(runtime.desired()).toBe(false);
     expect(runtime.binding.configureTelegram).not.toHaveBeenCalled();
     expect(runtime.binding.replaceTelegram).not.toHaveBeenCalled();
+  });
+
+  it("preserves an unsafe-backend refusal before attempting webhook removal", async () => {
+    const runtime = harness();
+    const applyStoredProfile = vi.mocked(runtime.vault.applyStoredProfile);
+    const readProfile = applyStoredProfile.getMockImplementation()!;
+    applyStoredProfile
+      .mockImplementationOnce(readProfile)
+      .mockResolvedValueOnce({ outcome: "refused", reason: "unsafe-backend" });
+
+    await expect(runtime.coordinator.removeWebhook()).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "unsafe-backend",
+      current: {
+        channel: { desiredState: "enabled", state: "online" },
+        bot: { state: "ready", username: USERNAME },
+        pairing: { state: "paired" },
+        credentialConfigured: true,
+      },
+    });
+    expect(runtime.binding.deleteTelegramWebhook).not.toHaveBeenCalled();
+    expect(runtime.profile()).toMatchObject({ token: TOKEN, bot: { id: BOT_ID } });
+    expect(runtime.desired()).toBe(true);
   });
 
   it.each([

--- a/apps/desktop/tests/telegram-credential-vault.test.ts
+++ b/apps/desktop/tests/telegram-credential-vault.test.ts
@@ -244,6 +244,103 @@ describe("Telegram credential vault", () => {
     });
   });
 
+  it.each([
+    [
+      "unavailable encryption",
+      {
+        isEncryptionAvailable: () => false,
+        encryptString: vi.fn(),
+        decryptString: vi.fn(),
+      } satisfies CredentialEncryptionPort,
+      "encryption-unavailable" as const,
+    ],
+    [
+      "an unsafe backend",
+      {
+        ...encryption(),
+        getSelectedStorageBackend: () => "basic_text",
+      } satisfies CredentialEncryptionPort,
+      "unsafe-backend" as const,
+    ],
+  ])("preserves %s as a closed status reason after reopen", async (_label, backend, reason) => {
+    const value = await fixture();
+    await seedProfile(value);
+    const reopened = createTelegramCredentialVault({ ...value, encryption: backend });
+
+    await expect(reopened.profileStatus()).resolves.toEqual({ state: "re-prompt", reason });
+  });
+
+  it("emits only the exact closed stages at their vault boundaries", async () => {
+    const events: unknown[] = [];
+    const observeSecureStorageFailure = vi.fn((event: unknown) => {
+      events.push(event);
+    });
+
+    const encryptionValue = await fixture();
+    await seedProfile(encryptionValue);
+    const unavailable = createTelegramCredentialVault({
+      ...encryptionValue,
+      encryption: {
+        isEncryptionAvailable: () => false,
+        encryptString: vi.fn(),
+        decryptString: vi.fn(),
+      },
+      observeSecureStorageFailure,
+    });
+    await unavailable.profileStatus();
+
+    const namespaceValue = await fixture();
+    await mkdir(namespaceValue.root, { mode: 0o755 });
+    const unsafeNamespace = createTelegramCredentialVault({
+      ...namespaceValue,
+      encryption: encryption(),
+      observeSecureStorageFailure,
+    });
+    await unsafeNamespace.profileStatus();
+
+    const profileValue = await fixture();
+    await seedProfile(profileValue);
+    const failedProfileWrite = createTelegramCredentialVault({
+      ...profileValue,
+      encryption: encryption(),
+      renameFile: vi.fn(async () => {
+        throw new TypeError("private synthetic rename failure");
+      }) as never,
+      observeSecureStorageFailure,
+    });
+    await failedProfileWrite.replaceProfile({
+      token: "synthetic-token-b",
+      bot: BOT_B,
+      authenticatedAthleteHome: profileValue.athleteHome,
+    });
+
+    const desiredValue = await fixture();
+    const desiredSeed = createTelegramCredentialVault({
+      ...desiredValue,
+      encryption: encryption(),
+    });
+    await desiredSeed.setDesiredState(false);
+    const failedDesiredWrite = createTelegramCredentialVault({
+      ...desiredValue,
+      encryption: encryption(),
+      renameFile: vi.fn(async () => {
+        throw new TypeError("private synthetic desired-state failure");
+      }) as never,
+      observeSecureStorageFailure,
+    });
+    await failedDesiredWrite.setDesiredState(true);
+
+    expect(events).toEqual([
+      { stage: "encryption-availability", reason: "encryption-unavailable" },
+      { stage: "namespace", reason: "storage-failed" },
+      { stage: "profile-atomic-write", reason: "storage-failed" },
+      { stage: "desired-state-write", reason: "storage-failed" },
+    ]);
+    expect(JSON.stringify(events)).not.toMatch(
+      /synthetic-token|private synthetic|telegram-channel-v1/u,
+    );
+  });
+
   it("anchors the profile namespace in its parent before publishing ciphertext", async () => {
     const value = await fixture();
     const syncParentDirectory = vi.fn(async (path: string) => {
@@ -352,7 +449,10 @@ describe("Telegram credential vault", () => {
         { mode: TELEGRAM_CREDENTIAL_FILE_MODE },
       );
       const vault = createTelegramCredentialVault({ ...value, encryption: encryption() });
-      await expect(vault.profileStatus()).resolves.toEqual({ state: "re-prompt" });
+      await expect(vault.profileStatus()).resolves.toEqual({
+        state: "re-prompt",
+        reason: "storage-failed",
+      });
       await expect(vault.applyStoredProfile(value.athleteHome, apply)).resolves.toEqual({
         outcome: "refused",
         reason: "re-prompt",
@@ -923,7 +1023,10 @@ describe("Telegram credential vault", () => {
     await writeFile(outside, "ciphertext", { mode: TELEGRAM_CREDENTIAL_FILE_MODE });
     await symlink(outside, join(value.root, TELEGRAM_PROFILE_FILE_NAME));
     const symlinkedFile = createTelegramCredentialVault({ ...value, encryption: encryption() });
-    await expect(symlinkedFile.profileStatus()).resolves.toEqual({ state: "re-prompt" });
+    await expect(symlinkedFile.profileStatus()).resolves.toEqual({
+      state: "re-prompt",
+      reason: "storage-failed",
+    });
     await expect(
       symlinkedFile.replaceProfile({
         token: "synthetic-token-a",
@@ -934,7 +1037,10 @@ describe("Telegram credential vault", () => {
 
     await rm(join(value.root, TELEGRAM_PROFILE_FILE_NAME));
     await chmod(value.root, 0o755);
-    await expect(symlinkedFile.profileStatus()).resolves.toEqual({ state: "re-prompt" });
+    await expect(symlinkedFile.profileStatus()).resolves.toEqual({
+      state: "re-prompt",
+      reason: "storage-failed",
+    });
   });
 
   it("deletes through a durable tombstone and cleans deferred ciphertext later", async () => {

--- a/apps/desktop/tests/telegram-ipc.test.ts
+++ b/apps/desktop/tests/telegram-ipc.test.ts
@@ -1,4 +1,12 @@
-import type { TelegramAllowedSendersResult } from "@enduragent/coach-contract";
+import {
+  AthleteHomeIdentitySchema,
+  TelegramBotIdSchema,
+  TelegramBotUsernameSchema,
+  type TelegramAllowedSendersResult,
+} from "@enduragent/coach-contract";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   DESKTOP_TELEGRAM_ADD_ALLOWED_SENDER_CHANNEL,
@@ -22,6 +30,10 @@ import type {
 } from "../src/main/telegram-control.js";
 import { installDesktopTelegramIpc } from "../src/main/telegram-ipc.js";
 import type { TelegramGapWarning } from "../src/main/telegram-power.js";
+import {
+  createTelegramCredentialVault,
+  type TelegramCredentialVault,
+} from "../src/main/telegram-credential-vault.js";
 
 const TOKEN = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
 const USERNAME = "desktop_bot";
@@ -62,7 +74,13 @@ const applied = (current: DesktopTelegramSnapshot): DesktopTelegramMutationResul
   current,
 });
 
-function setup(options: { readonly trusted?: boolean; readonly configured?: boolean } = {}) {
+function setup(
+  options: {
+    readonly trusted?: boolean;
+    readonly configured?: boolean;
+    readonly vault?: Pick<TelegramCredentialVault, "profileStatus">;
+  } = {},
+) {
   const handlers = new Map<string, (...args: unknown[]) => unknown>();
   const removed: string[] = [];
   const trace: string[] = [];
@@ -115,15 +133,17 @@ function setup(options: { readonly trusted?: boolean; readonly configured?: bool
   };
   const vault = {
     profileStatus: vi.fn(async () =>
-      configured
-        ? {
-            state: "configured" as const,
-            profileId: "00000000-0000-4000-8000-000000000001",
-            bot: { id: 10001, username: USERNAME },
-          }
-        : { state: "missing" as const },
+      options.vault === undefined
+        ? configured
+          ? {
+              state: "configured" as const,
+              profileId: "00000000-0000-4000-8000-000000000001",
+              bot: { id: 10001, username: USERNAME },
+            }
+          : { state: "missing" as const }
+        : options.vault.profileStatus(),
     ),
-  };
+  } satisfies Pick<TelegramCredentialVault, "profileStatus">;
   const clipboard = {
     readText: vi.fn(() => {
       trace.push("read");
@@ -243,6 +263,20 @@ describe("Desktop Telegram IPC", () => {
     expect(JSON.stringify(closed)).not.toContain("private daemon detail");
   });
 
+  it.each([
+    "telegram-credential-encryption-unavailable",
+    "telegram-credential-unsafe-backend",
+  ] as const)("passes through the closed redacted %s status code", async (errorCode) => {
+    const runtime = setup();
+    const current = snapshot(false, { desiredState: "enabled", state: "failed", errorCode });
+    vi.mocked(runtime.coordinator.status).mockResolvedValueOnce(current);
+
+    await expect(runtime.invoke(DESKTOP_TELEGRAM_STATUS_CHANNEL)).resolves.toEqual({
+      ...current,
+      gapWarning: { state: "clear" },
+    });
+  });
+
   it("reads and clears the clipboard synchronously before any credential await", async () => {
     const runtime = setup();
 
@@ -265,6 +299,65 @@ describe("Desktop Telegram IPC", () => {
     expect(runtime.coordinator.configure).not.toHaveBeenCalled();
     expect(runtime.coordinator.replace).toHaveBeenCalledWith(TOKEN);
   });
+
+  it.each([
+    ["encryption-unavailable" as const, false, undefined],
+    ["unsafe-backend" as const, true, "basic_text"],
+  ])(
+    "routes a reopened real-vault %s paste through replacement",
+    async (reason, available, backend) => {
+      const base = await mkdtemp(join(await realpath(tmpdir()), "telegram-ipc-secure-storage-"));
+      try {
+        const homePath = join(base, "athlete-home");
+        await mkdir(homePath, { mode: 0o700 });
+        const value = {
+          root: join(base, "telegram-channel-v1"),
+          athleteHome: AthleteHomeIdentitySchema.parse(await realpath(homePath)),
+        };
+        const encryption = {
+          isEncryptionAvailable: () => true,
+          encryptString: (plaintext: string) => Buffer.from(plaintext, "utf8").reverse(),
+          decryptString: (ciphertext: Buffer) => Buffer.from(ciphertext).reverse().toString("utf8"),
+        };
+        const seed = createTelegramCredentialVault({ ...value, encryption });
+        await expect(
+          seed.replaceProfile({
+            token: TOKEN,
+            bot: {
+              id: TelegramBotIdSchema.parse(10001),
+              username: TelegramBotUsernameSchema.parse(USERNAME),
+            },
+            authenticatedAthleteHome: value.athleteHome,
+          }),
+        ).resolves.toMatchObject({ outcome: "applied" });
+        const reopened = createTelegramCredentialVault({
+          ...value,
+          encryption: {
+            ...encryption,
+            isEncryptionAvailable: () => available,
+            ...(backend === undefined ? {} : { getSelectedStorageBackend: () => backend }),
+          },
+        });
+        await expect(reopened.profileStatus()).resolves.toEqual({ state: "re-prompt", reason });
+        const runtime = setup({ configured: true, vault: reopened });
+        vi.mocked(runtime.coordinator.replace).mockResolvedValueOnce({
+          outcome: "refused",
+          reason,
+          current: snapshot(true),
+        });
+
+        await expect(runtime.invoke(DESKTOP_TELEGRAM_PASTE_CREDENTIAL_CHANNEL)).resolves.toEqual({
+          outcome: "refused",
+          reason,
+          current: ipcSnapshot(true),
+        });
+        expect(runtime.coordinator.replace).toHaveBeenCalledWith(TOKEN);
+        expect(runtime.coordinator.configure).not.toHaveBeenCalled();
+      } finally {
+        await rm(base, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("passes through refused and uncertain credential outcomes without inferring success from health", async () => {
     const refused = setup({ configured: true });
@@ -304,6 +397,27 @@ describe("Desktop Telegram IPC", () => {
       current: ipcSnapshot(true, { desiredState: "enabled", state: "online" }),
     });
   });
+
+  it.each(["encryption-unavailable", "unsafe-backend"] as const)(
+    "passes through the closed %s refusal without credential details",
+    async (reason) => {
+      const runtime = setup();
+      vi.mocked(runtime.coordinator.configure).mockResolvedValueOnce({
+        outcome: "refused",
+        reason,
+        current: snapshot(false),
+      });
+
+      const result = await runtime.invoke(DESKTOP_TELEGRAM_PASTE_CREDENTIAL_CHANNEL);
+
+      expect(result).toEqual({
+        outcome: "refused",
+        reason,
+        current: ipcSnapshot(false),
+      });
+      expect(JSON.stringify(result)).not.toContain(TOKEN);
+    },
+  );
 
   it("closes malformed coordinator mutation envelopes instead of copying private fields", async () => {
     const runtime = setup({ configured: true });

--- a/apps/desktop/tests/telegram-secure-storage-diagnostics.test.ts
+++ b/apps/desktop/tests/telegram-secure-storage-diagnostics.test.ts
@@ -1,0 +1,77 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTelegramSecureStorageDiagnostics,
+  emitTelegramSecureStorageFailure,
+  TELEGRAM_SECURE_STORAGE_REASONS,
+  TELEGRAM_SECURE_STORAGE_STAGES,
+} from "../src/main/telegram-secure-storage-diagnostics.js";
+
+describe("Telegram secure-storage diagnostics", () => {
+  it("writes only the closed stage and reason vocabulary", () => {
+    expect(TELEGRAM_SECURE_STORAGE_STAGES).toEqual([
+      "namespace",
+      "encryption-availability",
+      "profile-atomic-write",
+      "desired-state-write",
+      "daemon-apply",
+    ]);
+    expect(TELEGRAM_SECURE_STORAGE_REASONS).toEqual([
+      "encryption-unavailable",
+      "unsafe-backend",
+      "storage-failed",
+      "storage-uncertain",
+      "control-unavailable",
+      "control-uncertain",
+    ]);
+    const write = vi.fn();
+    const observe = createTelegramSecureStorageDiagnostics(write);
+
+    observe({
+      stage: "encryption-availability",
+      reason: "unsafe-backend",
+      token: "must-not-cross",
+      path: "/private/credential",
+      error: "private backend detail",
+    } as never);
+
+    expect(write).toHaveBeenCalledWith(
+      "desktop-telegram-secure-storage-failure encryption-availability unsafe-backend\n",
+    );
+    expect(JSON.stringify(write.mock.calls)).not.toMatch(
+      /must-not-cross|private\/credential|private backend detail/u,
+    );
+  });
+
+  it("isolates asynchronously rejecting observers", async () => {
+    const observe = vi.fn(async () => {
+      throw new TypeError("private observer failure");
+    });
+
+    expect(() =>
+      emitTelegramSecureStorageFailure(observe, {
+        stage: "daemon-apply",
+        reason: "control-uncertain",
+      }),
+    ).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(observe).toHaveBeenCalledWith({
+      stage: "daemon-apply",
+      reason: "control-uncertain",
+    });
+  });
+
+  it("wires one production diagnostic into the vault and both coordinator lifetimes", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+
+    expect(source).toContain(
+      "const telegramSecureStorageDiagnostics = createTelegramSecureStorageDiagnostics();",
+    );
+    expect(
+      source.match(/observeSecureStorageFailure: telegramSecureStorageDiagnostics/gu),
+    ).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve fail-closed Telegram credential truth when secure storage is unavailable or recovers
- keep diagnostics bounded and redacted across main, IPC, preload, and renderer boundaries
- retain both pairing-feedback and secure-storage recovery regression groups in the stacked branch

## Verification

- 241 focused Desktop tests passed across five files
- 73 focused renderer tests passed across two files
- Desktop and renderer source/test TypeScript checks passed
- changed-file lint, formatting, and diff checks passed
