### PR TITLE
fix(desktop): enforce macOS release identity

### DIFF
--- a/apps/desktop/scripts/macos-release-plan.d.mts
+++ b/apps/desktop/scripts/macos-release-plan.d.mts
@@ -1,6 +1,8 @@
 import type { NotarizeOptions } from "@electron/notarize";
 import type {
+  VerifiedMacosBaselineApplication,
   VerifiedMacosIdentityContinuity,
+  VerifiedMacosReleaseArtifacts,
   VerifyMacosReleaseApplicationContentsOptions,
 } from "./verify-macos-release.mjs";
 
@@ -106,6 +108,10 @@ export interface MacosReleaseDependencies {
       };
     },
   ) => Promise<void>;
+  readonly verifyBaselineApplication?: (
+    baselineApplication: string,
+    options: { readonly candidateVersion: string },
+  ) => Promise<VerifiedMacosBaselineApplication>;
   readonly verifyIdentityContinuity?: (
     baselineApplication: string,
     candidateApplication: string,
@@ -128,7 +134,7 @@ export interface MacosReleaseDependencies {
         arguments_: readonly string[],
       ) => Promise<unknown>;
     },
-  ) => Promise<unknown>;
+  ) => Promise<VerifiedMacosReleaseArtifacts>;
   readonly verifyReleaseApplicationContents?: (
     artifactDirectory: string,
     baselineApplication: string,

--- a/apps/desktop/scripts/macos-release-plan.d.mts
+++ b/apps/desktop/scripts/macos-release-plan.d.mts
@@ -1,4 +1,8 @@
 import type { NotarizeOptions } from "@electron/notarize";
+import type {
+  VerifiedMacosIdentityContinuity,
+  VerifyMacosReleaseApplicationContentsOptions,
+} from "./verify-macos-release.mjs";
 
 export interface ReleaseArtifactNames {
   readonly dmg: string;
@@ -10,6 +14,7 @@ export interface ReleaseArtifactNames {
 export interface MacosReleaseInput {
   readonly feedUrl: string | undefined;
   readonly identity: string | undefined;
+  readonly baselineApplication: string | undefined;
   readonly repositoryRoot?: string;
   readonly desktopRoot?: string;
 }
@@ -54,6 +59,7 @@ export interface MacosReleaseBuilderOptions {
 export interface MacosReleasePlan {
   readonly version: string;
   readonly feedUrl: string;
+  readonly baselineApplication: string;
   readonly artifactNames: ReleaseArtifactNames;
   readonly builderOptions: MacosReleaseBuilderOptions;
 }
@@ -100,7 +106,11 @@ export interface MacosReleaseDependencies {
       };
     },
   ) => Promise<void>;
-  readonly verifyApplication?: (application: string) => Promise<void>;
+  readonly verifyIdentityContinuity?: (
+    baselineApplication: string,
+    candidateApplication: string,
+    options: { readonly candidateVersion: string },
+  ) => Promise<VerifiedMacosIdentityContinuity>;
   readonly verifyDmg?: (dmgPath: string) => Promise<void>;
   readonly promoteReleaseEnvelope?: (
     plan: MacosReleasePlan,
@@ -119,6 +129,21 @@ export interface MacosReleaseDependencies {
       ) => Promise<unknown>;
     },
   ) => Promise<unknown>;
+  readonly verifyReleaseApplicationContents?: (
+    artifactDirectory: string,
+    baselineApplication: string,
+    options: VerifyMacosReleaseApplicationContentsOptions,
+    dependencies: {
+      readonly executeFile?: (
+        executable: string,
+        arguments_: readonly string[],
+      ) => Promise<unknown>;
+    },
+  ) => Promise<void>;
+}
+
+export interface PromoteMacosReleaseEnvelopeDependencies {
+  readonly rename?: (oldPath: string, newPath: string) => Promise<void>;
 }
 
 export const DESKTOP_UPDATER_CACHE_DIRECTORY: "@enduragentdesktop-updater";
@@ -128,6 +153,7 @@ export function requireNotarizationCredentials(
 export function requireStableCalVer(value: unknown): string;
 export function requireGenericFeedUrl(value: unknown): string;
 export function requireDeveloperIdIdentity(value: unknown): string;
+export function requireMacosBaselineApplication(value: unknown): string;
 export function releaseArtifactNames(version: string): ReleaseArtifactNames;
 export function readCyclingCoachVersion(options?: {
   readonly repositoryRoot?: string;
@@ -142,6 +168,7 @@ export function macosReleaseEnvelopePath(plan: MacosReleasePlan): string;
 export function promoteMacosReleaseEnvelope(
   plan: MacosReleasePlan,
   verifyEnvelope: (artifactDirectory: string) => Promise<unknown>,
+  dependencies?: PromoteMacosReleaseEnvelopeDependencies,
 ): Promise<string>;
 export function notarizeMacosDmg(
   dmgPath: string,

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -65,6 +65,14 @@ function sameReleaseFileIdentity(left, right) {
   );
 }
 
+function releaseDirectoryIdentity(stat) {
+  return Object.freeze({ dev: stat.dev, ino: stat.ino, mode: stat.mode });
+}
+
+function sameReleaseDirectoryIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino && left.mode === right.mode;
+}
+
 async function readRegularReleaseFile(path, label) {
   let before;
   try {
@@ -265,6 +273,26 @@ export function requireDeveloperIdIdentity(value) {
   return value;
 }
 
+export function requireMacosBaselineApplication(value) {
+  const hasControlCharacter =
+    typeof value === "string" &&
+    Array.from(value).some((character) => {
+      const code = character.codePointAt(0);
+      return code !== undefined && (code < 32 || code === 127);
+    });
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > 4_096 ||
+    value !== value.trim() ||
+    !isAbsolute(value) ||
+    hasControlCharacter
+  ) {
+    throw new TypeError("signed baseline application path is invalid");
+  }
+  return value;
+}
+
 export async function readCyclingCoachVersion(options = {}) {
   const repositoryRoot = options.repositoryRoot ?? canonicalRepositoryRoot;
   if (!isAbsolute(repositoryRoot)) {
@@ -307,6 +335,11 @@ export async function createMacosReleasePlan(input, dependencies = {}) {
   });
   const feedUrl = requireGenericFeedUrl(input.feedUrl);
   const identity = requireDeveloperIdIdentity(input.identity);
+  const baselineApplication = requireMacosBaselineApplication(input.baselineApplication);
+  const candidateApplication = join(desktopRoot, "dist/mac-arm64/Enduragent.app");
+  if (resolve(baselineApplication) === resolve(candidateApplication)) {
+    throw new TypeError("signed baseline application must differ from candidate");
+  }
   const builderOptions = {
     projectDir: desktopRoot,
     publish: "never",
@@ -346,6 +379,7 @@ export async function createMacosReleasePlan(input, dependencies = {}) {
   return Object.freeze({
     version,
     feedUrl,
+    baselineApplication,
     artifactNames: releaseArtifactNames(version),
     builderOptions,
   });
@@ -414,6 +448,29 @@ async function requireReleaseDirectory(path, label) {
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw new TypeError(`invalid ${label}`);
   }
+  return releaseDirectoryIdentity(stat);
+}
+
+async function removeBoundReleaseDirectory(path, expectedIdentity) {
+  let stat;
+  try {
+    stat = await lstat(path);
+  } catch (error) {
+    if (missingPathError(error)) return;
+    throw new TypeError("release envelope cleanup failed");
+  }
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isDirectory() ||
+    !sameReleaseDirectoryIdentity(releaseDirectoryIdentity(stat), expectedIdentity)
+  ) {
+    throw new TypeError("release envelope cleanup target changed");
+  }
+  try {
+    await rm(path, { recursive: true, force: true });
+  } catch {
+    throw new TypeError("release envelope cleanup failed");
+  }
 }
 
 async function requireMissingReleasePath(path) {
@@ -430,12 +487,13 @@ export function macosReleaseEnvelopePath(plan) {
   return join(plan.builderOptions.projectDir, "dist", `release-envelope-${plan.version}-mac-arm64`);
 }
 
-export async function promoteMacosReleaseEnvelope(plan, verifyEnvelope) {
+export async function promoteMacosReleaseEnvelope(plan, verifyEnvelope, overrides = {}) {
   if (typeof verifyEnvelope !== "function") {
     throw new TypeError("release envelope verifier is required");
   }
   const artifactDirectory = join(plan.builderOptions.projectDir, "dist");
   await requireReleaseDirectory(artifactDirectory, "release build directory");
+  const dependencies = { rename: overrides.rename ?? rename };
   const envelopePath = macosReleaseEnvelopePath(plan);
   await requireMissingReleasePath(envelopePath);
   const sourceEntries = [
@@ -466,11 +524,17 @@ export async function promoteMacosReleaseEnvelope(plan, verifyEnvelope) {
       snapshot: await readRegularReleaseFile(entry.path, entry.label),
     })),
   );
-  let temporaryDirectory;
+  let cleanupPath;
+  let cleanupIdentity;
   try {
-    temporaryDirectory = await mkdtemp(
+    const temporaryDirectory = await mkdtemp(
       join(artifactDirectory, `.release-envelope-${plan.version}-mac-arm64-`),
     );
+    cleanupIdentity = await requireReleaseDirectory(
+      temporaryDirectory,
+      "temporary release envelope",
+    );
+    cleanupPath = temporaryDirectory;
     await Promise.all(
       snapshots.map(({ name, snapshot }) =>
         writeFile(join(temporaryDirectory, name), snapshot.bytes, {
@@ -499,7 +563,10 @@ export async function promoteMacosReleaseEnvelope(plan, verifyEnvelope) {
     ) {
       throw new TypeError("promoted release artifact envelope differs");
     }
-    await verifyEnvelope(temporaryDirectory);
+    await requireMissingReleasePath(envelopePath);
+    await dependencies.rename(temporaryDirectory, envelopePath);
+    cleanupPath = envelopePath;
+    await verifyEnvelope(envelopePath);
     const currentSources = await Promise.all(
       snapshots.map(({ path, label }) => readRegularReleaseFile(path, label)),
     );
@@ -514,7 +581,7 @@ export async function promoteMacosReleaseEnvelope(plan, verifyEnvelope) {
     }
     const verifiedSnapshots = await Promise.all(
       snapshots.map(({ name, label }) =>
-        readRegularReleaseFile(join(temporaryDirectory, name), `verified ${label}`),
+        readRegularReleaseFile(join(envelopePath, name), `verified ${label}`),
       ),
     );
     if (
@@ -526,20 +593,25 @@ export async function promoteMacosReleaseEnvelope(plan, verifyEnvelope) {
     ) {
       throw new TypeError("release envelope changed during verification");
     }
-    const verifiedNames = (await readdir(temporaryDirectory)).sort();
+    const verifiedNames = (await readdir(envelopePath)).sort();
     if (
       verifiedNames.length !== expectedNames.length ||
       verifiedNames.some((name, index) => name !== expectedNames[index])
     ) {
       throw new TypeError("release envelope changed during verification");
     }
-    await requireMissingReleasePath(envelopePath);
-    await rename(temporaryDirectory, envelopePath);
-    temporaryDirectory = undefined;
+    const verifiedDirectoryIdentity = await requireReleaseDirectory(
+      envelopePath,
+      "verified release envelope",
+    );
+    if (!sameReleaseDirectoryIdentity(verifiedDirectoryIdentity, cleanupIdentity)) {
+      throw new TypeError("release envelope changed during verification");
+    }
+    cleanupPath = undefined;
     return envelopePath;
   } finally {
-    if (temporaryDirectory !== undefined) {
-      await rm(temporaryDirectory, { recursive: true, force: true });
+    if (cleanupPath !== undefined && cleanupIdentity !== undefined) {
+      await removeBoundReleaseDirectory(cleanupPath, cleanupIdentity);
     }
   }
 }
@@ -589,10 +661,10 @@ export async function runMacosRelease(input, dependencies = {}) {
     },
   });
   const verification = await import("./verify-macos-release.mjs");
-  const verifyApplication =
-    dependencies.verifyApplication ??
-    ((path) =>
-      verification.verifyMacosApplication(path, {
+  const verifyIdentityContinuity =
+    dependencies.verifyIdentityContinuity ??
+    ((baseline, candidate, options) =>
+      verification.verifyMacosIdentityContinuity(baseline, candidate, options, {
         executeFile: dependencies.executeFile,
       }));
   const verifyDmg =
@@ -601,7 +673,13 @@ export async function runMacosRelease(input, dependencies = {}) {
       verification.verifyMacosDmg(path, {
         executeFile: dependencies.executeFile,
       }));
-  await verifyApplication(application);
+  const looseIdentityContinuity = await verifyIdentityContinuity(
+    plan.baselineApplication,
+    application,
+    {
+      candidateVersion: plan.version,
+    },
+  );
   const dmgPath = join(plan.builderOptions.projectDir, "dist", plan.artifactNames.dmg);
   await notarizeMacosDmg(dmgPath, notarizationCredentials, {
     notarize: dependencies.notarize,
@@ -611,8 +689,11 @@ export async function runMacosRelease(input, dependencies = {}) {
   await sealReleaseMetadata(plan);
   const verifyReleaseArtifacts =
     dependencies.verifyReleaseArtifacts ?? verification.verifyMacosReleaseArtifacts;
-  const verifyEnvelope = (artifactDirectory) =>
-    verifyReleaseArtifacts(
+  const verifyReleaseApplicationContents =
+    dependencies.verifyReleaseApplicationContents ??
+    verification.verifyMacosReleaseApplicationContents;
+  const verifyEnvelope = async (artifactDirectory) => {
+    await verifyReleaseArtifacts(
       artifactDirectory,
       {
         repositoryRoot: input.repositoryRoot ?? canonicalRepositoryRoot,
@@ -622,6 +703,18 @@ export async function runMacosRelease(input, dependencies = {}) {
         executeFile: dependencies.executeFile,
       },
     );
+    await verifyReleaseApplicationContents(
+      artifactDirectory,
+      plan.baselineApplication,
+      {
+        candidateVersion: plan.version,
+        looseCandidateCodeIdentity: looseIdentityContinuity?.candidateCodeIdentity,
+      },
+      {
+        executeFile: dependencies.executeFile,
+      },
+    );
+  };
   const promoteReleaseEnvelope = dependencies.promoteReleaseEnvelope ?? promoteMacosReleaseEnvelope;
   const envelopePath = await promoteReleaseEnvelope(plan, verifyEnvelope);
   return { plan, artifacts, envelopePath };
@@ -632,6 +725,7 @@ async function main() {
   const result = await runMacosRelease({
     feedUrl: process.env.ENDURAGENT_DESKTOP_UPDATE_URL,
     identity: process.env.ENDURAGENT_DEVELOPER_ID_IDENTITY,
+    baselineApplication: process.env.ENDURAGENT_MACOS_BASELINE_APP,
   });
   process.stdout.write(`macOS release envelope: ${result.envelopePath}\n`);
 }

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -647,6 +647,16 @@ export async function runMacosRelease(input, dependencies = {}) {
   const notarizationCredentials = requireNotarizationCredentials(
     dependencies.environment ?? process.env,
   );
+  const verification = await import("./verify-macos-release.mjs");
+  const verifyBaselineApplication =
+    dependencies.verifyBaselineApplication ??
+    ((baseline, options) =>
+      verification.verifyMacosBaselineApplication(baseline, options, {
+        executeFile: dependencies.executeFile,
+      }));
+  await verifyBaselineApplication(plan.baselineApplication, {
+    candidateVersion: plan.version,
+  });
   const build = dependencies.build ?? (await import("electron-builder")).build;
   const artifacts = await build(plan.builderOptions);
   const application = join(plan.builderOptions.projectDir, "dist/mac-arm64/Enduragent.app");
@@ -660,7 +670,6 @@ export async function runMacosRelease(input, dependencies = {}) {
       feedUrl: plan.feedUrl,
     },
   });
-  const verification = await import("./verify-macos-release.mjs");
   const verifyIdentityContinuity =
     dependencies.verifyIdentityContinuity ??
     ((baseline, candidate, options) =>
@@ -673,13 +682,9 @@ export async function runMacosRelease(input, dependencies = {}) {
       verification.verifyMacosDmg(path, {
         executeFile: dependencies.executeFile,
       }));
-  const looseIdentityContinuity = await verifyIdentityContinuity(
-    plan.baselineApplication,
-    application,
-    {
-      candidateVersion: plan.version,
-    },
-  );
+  await verifyIdentityContinuity(plan.baselineApplication, application, {
+    candidateVersion: plan.version,
+  });
   const dmgPath = join(plan.builderOptions.projectDir, "dist", plan.artifactNames.dmg);
   await notarizeMacosDmg(dmgPath, notarizationCredentials, {
     notarize: dependencies.notarize,
@@ -687,34 +692,22 @@ export async function runMacosRelease(input, dependencies = {}) {
   await verifyDmg(dmgPath);
   const sealReleaseMetadata = dependencies.sealReleaseMetadata ?? sealMacosReleaseMetadata;
   await sealReleaseMetadata(plan);
-  const verifyReleaseArtifacts =
-    dependencies.verifyReleaseArtifacts ?? verification.verifyMacosReleaseArtifacts;
-  const verifyReleaseApplicationContents =
-    dependencies.verifyReleaseApplicationContents ??
-    verification.verifyMacosReleaseApplicationContents;
-  const verifyEnvelope = async (artifactDirectory) => {
-    await verifyReleaseArtifacts(
+  const verifyEnvelope = (artifactDirectory) =>
+    verification.verifyMacosReleaseEnvelope(
       artifactDirectory,
+      plan.baselineApplication,
+      application,
       {
         repositoryRoot: input.repositoryRoot ?? canonicalRepositoryRoot,
         readVersionFile: dependencies.readFile,
       },
       {
         executeFile: dependencies.executeFile,
+        verifyIdentityContinuity,
+        verifyReleaseApplicationContents: dependencies.verifyReleaseApplicationContents,
+        verifyReleaseArtifacts: dependencies.verifyReleaseArtifacts,
       },
     );
-    await verifyReleaseApplicationContents(
-      artifactDirectory,
-      plan.baselineApplication,
-      {
-        candidateVersion: plan.version,
-        looseCandidateCodeIdentity: looseIdentityContinuity?.candidateCodeIdentity,
-      },
-      {
-        executeFile: dependencies.executeFile,
-      },
-    );
-  };
   const promoteReleaseEnvelope = dependencies.promoteReleaseEnvelope ?? promoteMacosReleaseEnvelope;
   const envelopePath = await promoteReleaseEnvelope(plan, verifyEnvelope);
   return { plan, artifacts, envelopePath };

--- a/apps/desktop/scripts/verify-macos-release.d.mts
+++ b/apps/desktop/scripts/verify-macos-release.d.mts
@@ -68,6 +68,11 @@ export interface VerifiedMacosIdentityContinuity {
   readonly candidateCodeIdentity: MacosCodeIdentity;
 }
 
+export interface VerifiedMacosBaselineApplication {
+  readonly baselineVersion: string;
+  readonly teamIdentifier: string;
+}
+
 export interface MacosCodeIdentity {
   readonly codeDirectory: string;
   readonly cdHash: string;
@@ -92,6 +97,17 @@ export interface VerifyMacosReleaseApplicationContentsDependencies extends Verif
   readonly verifyIdentityContinuity?: typeof verifyMacosIdentityContinuity;
 }
 
+export interface VerifyMacosReleaseEnvelopeDependencies
+  extends VerifyMacosReleaseDependencies, VerifyMacosReleaseApplicationContentsDependencies {
+  readonly verifyReleaseArtifacts?: typeof verifyMacosReleaseArtifacts;
+  readonly verifyReleaseApplicationContents?: typeof verifyMacosReleaseApplicationContents;
+}
+
+export interface VerifiedMacosReleaseEnvelope {
+  readonly artifacts: VerifiedMacosReleaseArtifacts;
+  readonly identityContinuity: VerifiedMacosIdentityContinuity;
+}
+
 export function verifyMacosApplication(
   application: string,
   dependencies?: Pick<VerifyMacosReleaseDependencies, "executeFile">,
@@ -106,6 +122,11 @@ export function verifyMacosIdentityContinuity(
   options: VerifyMacosIdentityContinuityOptions,
   dependencies?: VerifyMacosIdentityContinuityDependencies,
 ): Promise<VerifiedMacosIdentityContinuity>;
+export function verifyMacosBaselineApplication(
+  baselineApplication: string,
+  options: VerifyMacosIdentityContinuityOptions,
+  dependencies?: VerifyMacosIdentityContinuityDependencies,
+): Promise<VerifiedMacosBaselineApplication>;
 export function verifyMacosReleaseApplicationContents(
   artifactDirectory: string,
   baselineApplication: string,
@@ -117,3 +138,10 @@ export function verifyMacosReleaseArtifacts(
   options?: VerifyMacosReleaseOptions,
   dependencies?: VerifyMacosReleaseDependencies,
 ): Promise<VerifiedMacosReleaseArtifacts>;
+export function verifyMacosReleaseEnvelope(
+  artifactDirectory: string,
+  baselineApplication: string,
+  looseCandidateApplication: string,
+  options?: VerifyMacosReleaseOptions,
+  dependencies?: VerifyMacosReleaseEnvelopeDependencies,
+): Promise<VerifiedMacosReleaseEnvelope>;

--- a/apps/desktop/scripts/verify-macos-release.d.mts
+++ b/apps/desktop/scripts/verify-macos-release.d.mts
@@ -44,6 +44,54 @@ export interface VerifyMacosReleaseDependencies {
   readonly verifyNotarization?: (artifacts: VerifiedMacosReleaseArtifacts) => Promise<void>;
 }
 
+export interface VerifyMacosIdentityContinuityOptions {
+  readonly candidateVersion: string;
+}
+
+export interface VerifyMacosIdentityContinuityDependencies {
+  readonly executeFile?: (executable: string, arguments_: readonly string[]) => Promise<unknown>;
+  readonly extractAsarFile?: (archivePath: string, filename: string) => Buffer | Promise<Buffer>;
+  readonly lstat?: (path: string) => Promise<Stats>;
+  readonly mkdtemp?: (prefix: string) => Promise<string>;
+  readonly realpath?: (path: string) => Promise<string>;
+  readonly rm?: (
+    path: string,
+    options: { readonly recursive: true; readonly force: true },
+  ) => Promise<void>;
+  readonly tmpdir?: () => string;
+}
+
+export interface VerifiedMacosIdentityContinuity {
+  readonly baselineVersion: string;
+  readonly candidateVersion: string;
+  readonly teamIdentifier: string;
+  readonly candidateCodeIdentity: MacosCodeIdentity;
+}
+
+export interface MacosCodeIdentity {
+  readonly codeDirectory: string;
+  readonly cdHash: string;
+}
+
+export interface VerifyMacosReleaseApplicationContentsOptions {
+  readonly candidateVersion: string;
+  readonly looseCandidateCodeIdentity: MacosCodeIdentity;
+}
+
+export interface VerifyMacosReleaseApplicationContentsDependencies extends VerifyMacosIdentityContinuityDependencies {
+  readonly mkdir?: (path: string, options: { readonly mode: 0o700 }) => Promise<unknown>;
+  readonly readFile?: (path: string) => Promise<Buffer>;
+  readonly readlink?: (path: string) => Promise<string>;
+  readonly readdir?: (path: string) => Promise<string[]>;
+  readonly rmdir?: (path: string) => Promise<void>;
+  readonly writeFile?: (
+    path: string,
+    data: string,
+    options: { readonly flag: "wx"; readonly mode: 0o600 },
+  ) => Promise<unknown>;
+  readonly verifyIdentityContinuity?: typeof verifyMacosIdentityContinuity;
+}
+
 export function verifyMacosApplication(
   application: string,
   dependencies?: Pick<VerifyMacosReleaseDependencies, "executeFile">,
@@ -51,6 +99,18 @@ export function verifyMacosApplication(
 export function verifyMacosDmg(
   dmgPath: string,
   dependencies?: Pick<VerifyMacosReleaseDependencies, "executeFile">,
+): Promise<void>;
+export function verifyMacosIdentityContinuity(
+  baselineApplication: string,
+  candidateApplication: string,
+  options: VerifyMacosIdentityContinuityOptions,
+  dependencies?: VerifyMacosIdentityContinuityDependencies,
+): Promise<VerifiedMacosIdentityContinuity>;
+export function verifyMacosReleaseApplicationContents(
+  artifactDirectory: string,
+  baselineApplication: string,
+  options: VerifyMacosReleaseApplicationContentsOptions,
+  dependencies?: VerifyMacosReleaseApplicationContentsDependencies,
 ): Promise<void>;
 export function verifyMacosReleaseArtifacts(
   artifactDirectory: string,

--- a/apps/desktop/scripts/verify-macos-release.mjs
+++ b/apps/desktop/scripts/verify-macos-release.mjs
@@ -321,6 +321,36 @@ function olderStableCalVer(left, right) {
   return false;
 }
 
+export async function verifyMacosBaselineApplication(baselineApplication, options, overrides = {}) {
+  let candidateVersion;
+  try {
+    candidateVersion = requireStableCalVer(options?.candidateVersion);
+  } catch {
+    fail("candidate release version is invalid");
+  }
+  if (typeof baselineApplication !== "string" || !isAbsolute(baselineApplication)) {
+    fail("baseline application path must be absolute");
+  }
+  const dependencies = {
+    executeFile: overrides.executeFile ?? executeSystemFile,
+    extractAsarFile: overrides.extractAsarFile ?? extractFile,
+    lstat: overrides.lstat ?? lstat,
+    mkdtemp: overrides.mkdtemp ?? mkdtemp,
+    realpath: overrides.realpath ?? realpath,
+    rm: overrides.rm ?? rm,
+    tmpdir: overrides.tmpdir ?? tmpdir,
+  };
+  const bundle = await requireApplicationBundle(baselineApplication, "baseline", dependencies);
+  const baseline = await inspectMacosApplicationIdentity(baselineApplication, bundle, dependencies);
+  if (!olderStableCalVer(baseline.version, candidateVersion)) {
+    fail("baseline application is not older than candidate");
+  }
+  return Object.freeze({
+    baselineVersion: baseline.version,
+    teamIdentifier: baseline.teamIdentifier,
+  });
+}
+
 export async function verifyMacosIdentityContinuity(
   baselineApplication,
   candidateApplication,
@@ -1410,13 +1440,53 @@ export async function verifyMacosReleaseArtifacts(artifactDirectory, options = {
   return artifacts;
 }
 
+export async function verifyMacosReleaseEnvelope(
+  artifactDirectory,
+  baselineApplication,
+  looseCandidateApplication,
+  options = {},
+  overrides = {},
+) {
+  const verifyReleaseArtifacts = overrides.verifyReleaseArtifacts ?? verifyMacosReleaseArtifacts;
+  const artifacts = await verifyReleaseArtifacts(artifactDirectory, options, overrides);
+  let candidateVersion;
+  try {
+    candidateVersion = requireStableCalVer(artifacts?.version);
+  } catch {
+    fail("verified release version is invalid");
+  }
+  const verifyIdentityContinuity =
+    overrides.verifyIdentityContinuity ?? verifyMacosIdentityContinuity;
+  const identityContinuity = await verifyIdentityContinuity(
+    baselineApplication,
+    looseCandidateApplication,
+    { candidateVersion },
+    overrides,
+  );
+  if (identityContinuity?.candidateVersion !== candidateVersion) {
+    fail("loose candidate release identity is invalid");
+  }
+  const looseCandidateCodeIdentity = requireCandidateCodeIdentity(
+    identityContinuity.candidateCodeIdentity,
+  );
+  const verifyReleaseApplicationContents =
+    overrides.verifyReleaseApplicationContents ?? verifyMacosReleaseApplicationContents;
+  await verifyReleaseApplicationContents(
+    artifactDirectory,
+    baselineApplication,
+    { candidateVersion, looseCandidateCodeIdentity },
+    overrides,
+  );
+  return Object.freeze({ artifacts, identityContinuity });
+}
+
 async function main() {
   const args = process.argv.slice(2);
-  if (args.length !== 1 || !isAbsolute(args[0])) {
-    fail("expected one absolute release artifact directory");
+  if (args.length !== 3 || args.some((argument) => !isAbsolute(argument))) {
+    fail("expected absolute artifact, baseline, and loose candidate paths");
   }
-  await verifyMacosReleaseArtifacts(args[0]);
-  process.stdout.write("macOS release artifacts verified\n");
+  await verifyMacosReleaseEnvelope(args[0], args[1], args[2]);
+  process.stdout.write("macOS release envelope verified\n");
 }
 
 if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/apps/desktop/scripts/verify-macos-release.mjs
+++ b/apps/desktop/scripts/verify-macos-release.mjs
@@ -1,17 +1,41 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { lstat, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  readdir,
+  realpath,
+  rm,
+  rmdir,
+  writeFile,
+} from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { extractFile } from "@electron/asar";
 import { parse } from "yaml";
-import { readCyclingCoachVersion, releaseArtifactNames } from "./macos-release-plan.mjs";
+import {
+  readCyclingCoachVersion,
+  releaseArtifactNames,
+  requireStableCalVer,
+} from "./macos-release-plan.mjs";
 
 const localRequire = createRequire(import.meta.url);
 const supportedElectronBuilderVersion = "26.15.3";
 const execFileAsync = promisify(execFile);
+const canonicalBundleIdentifier = "icu.enduragent.desktop";
+const canonicalProductName = "Enduragent";
+const canonicalPackageName = "@enduragent/desktop";
+const canonicalTeamIdentifier = "FA494ACVTF";
+const canonicalEntitlements = JSON.stringify({ "com.apple.security.cs.allow-jit": true });
+const canonicalDesignatedRequirement = `identifier "${canonicalBundleIdentifier}" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = ${canonicalTeamIdentifier}`;
+const canonicalDesignatedRequirementPattern =
+  /^identifier "icu\.enduragent\.desktop" and anchor apple generic and certificate 1\[field\.1\.2\.840\.113635\.100\.6\.2\.6\] (?:exists|\/\* exists \*\/) and certificate leaf\[field\.1\.2\.840\.113635\.100\.6\.1\.13\] (?:exists|\/\* exists \*\/) and certificate leaf\[subject\.OU\] = (?:FA494ACVTF|"FA494ACVTF")$/u;
 
 class MacosReleaseVerificationError extends Error {
   constructor(message) {
@@ -25,10 +49,1072 @@ function fail(message) {
 }
 
 async function executeSystemFile(executable, arguments_) {
-  await execFileAsync(executable, [...arguments_], {
+  return execFileAsync(executable, [...arguments_], {
     encoding: "utf8",
     maxBuffer: 1024 * 1024,
   });
+}
+
+function outputStream(result, name) {
+  if (typeof result === "string" || Buffer.isBuffer(result)) {
+    return name === "stdout" ? String(result) : "";
+  }
+  if (result === null || typeof result !== "object") return "";
+  const value = result[name];
+  return typeof value === "string" || Buffer.isBuffer(value) ? String(value) : "";
+}
+
+function allCommandOutput(result) {
+  return `${outputStream(result, "stdout")}\n${outputStream(result, "stderr")}`;
+}
+
+async function inspectSystemFile(executeFile, executable, arguments_) {
+  try {
+    return await executeFile(executable, arguments_);
+  } catch {
+    fail("macOS signed identity inspection failed");
+  }
+}
+
+function exactLine(text, pattern) {
+  const values = Array.from(text.matchAll(pattern), (match) => match[1]);
+  return values.length === 1 ? values[0] : undefined;
+}
+
+function normalizeJson(value) {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (Array.isArray(value)) return value.map(normalizeJson);
+  if (!exactObject(value)) fail("macOS signed entitlements are invalid");
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, normalizeJson(value[key])]),
+  );
+}
+
+function parseJsonOutput(result, failureMessage) {
+  const stdout = outputStream(result, "stdout");
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    fail(failureMessage);
+  }
+}
+
+function isExpectedIdentityTemporaryDirectory(path, prefix) {
+  return (
+    isAbsolute(path) &&
+    dirname(path) === dirname(prefix) &&
+    path !== prefix &&
+    basename(path).startsWith(basename(prefix))
+  );
+}
+
+async function readNormalizedEntitlements(application, dependencies) {
+  const prefix = join(dependencies.tmpdir(), "enduragent-signed-entitlements-");
+  let temporaryDirectory;
+  try {
+    const candidate = await dependencies.mkdtemp(prefix);
+    if (!isExpectedIdentityTemporaryDirectory(candidate, prefix)) {
+      fail("macOS signed entitlements are invalid");
+    }
+    temporaryDirectory = candidate;
+    const derPath = join(temporaryDirectory, "entitlements.der");
+    const plistPath = join(temporaryDirectory, "entitlements.plist");
+    await inspectSystemFile(dependencies.executeFile, "/usr/bin/codesign", [
+      "--display",
+      "--entitlements",
+      derPath,
+      "--der",
+      application,
+    ]);
+    await inspectSystemFile(dependencies.executeFile, "/usr/bin/derq", [
+      "query",
+      "--xml",
+      "-i",
+      derPath,
+      "-o",
+      plistPath,
+    ]);
+    const converted = await inspectSystemFile(dependencies.executeFile, "/usr/bin/plutil", [
+      "-convert",
+      "json",
+      "-o",
+      "-",
+      "--",
+      plistPath,
+    ]);
+    return JSON.stringify(
+      normalizeJson(parseJsonOutput(converted, "macOS signed entitlements are invalid")),
+    );
+  } catch (error) {
+    if (error instanceof MacosReleaseVerificationError) throw error;
+    fail("macOS signed entitlements are invalid");
+  } finally {
+    if (temporaryDirectory !== undefined) {
+      try {
+        await dependencies.rm(temporaryDirectory, { recursive: true, force: true });
+      } catch {
+        fail("macOS signed entitlements cleanup failed");
+      }
+    }
+  }
+}
+
+async function requireApplicationBundle(application, label, dependencies) {
+  if (!isAbsolute(application)) fail(`${label} application path must be absolute`);
+  let applicationStat;
+  let canonicalPath;
+  try {
+    [applicationStat, canonicalPath] = await Promise.all([
+      dependencies.lstat(application),
+      dependencies.realpath(application),
+    ]);
+  } catch {
+    fail(`${label} application bundle is invalid`);
+  }
+  if (applicationStat.isSymbolicLink() || !applicationStat.isDirectory()) {
+    fail(`${label} application bundle is invalid`);
+  }
+  const infoPath = join(application, "Contents/Info.plist");
+  const archivePath = join(application, "Contents/Resources/app.asar");
+  let entries;
+  try {
+    entries = await Promise.all([dependencies.lstat(infoPath), dependencies.lstat(archivePath)]);
+  } catch {
+    fail(`${label} application bundle is invalid`);
+  }
+  if (entries.some((stat) => stat.isSymbolicLink() || !stat.isFile())) {
+    fail(`${label} application bundle is invalid`);
+  }
+  return { canonicalPath, infoPath, archivePath };
+}
+
+function parseSignatureMetadata(result) {
+  const output = allCommandOutput(result);
+  const identifier = exactLine(output, /^Identifier=([^\r\n]+)$/gmu);
+  const teamIdentifier = exactLine(output, /^TeamIdentifier=([^\r\n]+)$/gmu);
+  const codeDirectory = exactLine(output, /^CodeDirectory ([^\r\n]+)$/gmu);
+  const cdHash = exactLine(output, /^CDHash=([0-9a-f]{40,128})$/gimu)?.toLowerCase();
+  const flags = exactLine(output, /^CodeDirectory [^\r\n]* flags=0x[0-9a-f]+\(([^\r\n)]*)\)/gimu);
+  const authorities = Array.from(output.matchAll(/^Authority=([^\r\n]+)$/gmu), (match) => match[1]);
+  if (
+    identifier !== canonicalBundleIdentifier ||
+    teamIdentifier !== canonicalTeamIdentifier ||
+    codeDirectory === undefined ||
+    cdHash === undefined ||
+    flags === undefined ||
+    !flags
+      .split(",")
+      .map((flag) => flag.trim())
+      .includes("runtime") ||
+    authorities.length !== 3 ||
+    !authorities[0].startsWith("Developer ID Application: ") ||
+    !authorities[0].endsWith(` (${canonicalTeamIdentifier})`) ||
+    authorities[1] !== "Developer ID Certification Authority" ||
+    authorities[2] !== "Apple Root CA"
+  ) {
+    fail("macOS signed identity is invalid");
+  }
+  return { identifier, teamIdentifier, codeDirectory, cdHash };
+}
+
+function parseDesignatedRequirement(result) {
+  const requirement = exactLine(allCommandOutput(result), /^designated => ([^\r\n]+)$/gmu)
+    ?.replaceAll(/\s+/gu, " ")
+    .trim();
+  if (
+    requirement === undefined ||
+    requirement.length === 0 ||
+    requirement.length > 16_384 ||
+    !canonicalDesignatedRequirementPattern.test(requirement)
+  ) {
+    fail("macOS designated requirement is invalid");
+  }
+  return canonicalDesignatedRequirement;
+}
+
+function parseBundleMetadata(result) {
+  const info = parseJsonOutput(result, "macOS product identity is invalid");
+  if (
+    !exactObject(info) ||
+    info.CFBundleIdentifier !== canonicalBundleIdentifier ||
+    info.CFBundleName !== canonicalProductName ||
+    info.CFBundleDisplayName !== canonicalProductName ||
+    info.CFBundleExecutable !== canonicalProductName ||
+    info.CFBundlePackageType !== "APPL" ||
+    info.CFBundleShortVersionString !== info.CFBundleVersion
+  ) {
+    fail("macOS product identity is invalid");
+  }
+  try {
+    return requireStableCalVer(info.CFBundleShortVersionString);
+  } catch {
+    fail("macOS product identity is invalid");
+  }
+}
+
+async function readPackagedManifest(archivePath, dependencies) {
+  let manifest;
+  try {
+    const bytes = await dependencies.extractAsarFile(archivePath, "package.json");
+    manifest = JSON.parse(Buffer.from(bytes).toString("utf8"));
+  } catch {
+    fail("macOS package identity is invalid");
+  }
+  if (!exactObject(manifest) || manifest.name !== canonicalPackageName) {
+    fail("macOS package identity is invalid");
+  }
+  return manifest.version;
+}
+
+async function inspectMacosApplicationIdentity(application, bundle, dependencies) {
+  await verifyMacosApplication(application, { executeFile: dependencies.executeFile });
+  const [signatureResult, requirementResult, infoResult, entitlements, packageVersion] =
+    await Promise.all([
+      inspectSystemFile(dependencies.executeFile, "/usr/bin/codesign", [
+        "--display",
+        "--verbose=4",
+        application,
+      ]),
+      inspectSystemFile(dependencies.executeFile, "/usr/bin/codesign", [
+        "--display",
+        "--requirements",
+        "-",
+        application,
+      ]),
+      inspectSystemFile(dependencies.executeFile, "/usr/bin/plutil", [
+        "-convert",
+        "json",
+        "-o",
+        "-",
+        "--",
+        bundle.infoPath,
+      ]),
+      readNormalizedEntitlements(application, dependencies),
+      readPackagedManifest(bundle.archivePath, dependencies),
+    ]);
+  const signature = parseSignatureMetadata(signatureResult);
+  const designatedRequirement = parseDesignatedRequirement(requirementResult);
+  const version = parseBundleMetadata(infoResult);
+  if (packageVersion !== version) fail("macOS package identity is invalid");
+  if (entitlements !== canonicalEntitlements) fail("macOS signed entitlements are invalid");
+  return Object.freeze({
+    version,
+    identifier: signature.identifier,
+    teamIdentifier: signature.teamIdentifier,
+    designatedRequirement,
+    entitlements,
+    codeDirectory: signature.codeDirectory,
+    cdHash: signature.cdHash,
+  });
+}
+
+function olderStableCalVer(left, right) {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (const [index, part] of leftParts.entries()) {
+    if (part < rightParts[index]) return true;
+    if (part > rightParts[index]) return false;
+  }
+  return false;
+}
+
+export async function verifyMacosIdentityContinuity(
+  baselineApplication,
+  candidateApplication,
+  options,
+  overrides = {},
+) {
+  let candidateVersion;
+  try {
+    candidateVersion = requireStableCalVer(options?.candidateVersion);
+  } catch {
+    fail("candidate release version is invalid");
+  }
+  if (typeof baselineApplication !== "string" || !isAbsolute(baselineApplication)) {
+    fail("baseline application path must be absolute");
+  }
+  if (typeof candidateApplication !== "string" || !isAbsolute(candidateApplication)) {
+    fail("candidate application path must be absolute");
+  }
+  if (resolve(baselineApplication) === resolve(candidateApplication)) {
+    fail("baseline application must differ from candidate");
+  }
+  const dependencies = {
+    executeFile: overrides.executeFile ?? executeSystemFile,
+    extractAsarFile: overrides.extractAsarFile ?? extractFile,
+    lstat: overrides.lstat ?? lstat,
+    mkdtemp: overrides.mkdtemp ?? mkdtemp,
+    realpath: overrides.realpath ?? realpath,
+    rm: overrides.rm ?? rm,
+    tmpdir: overrides.tmpdir ?? tmpdir,
+  };
+  const [baselineBundle, candidateBundle] = await Promise.all([
+    requireApplicationBundle(baselineApplication, "baseline", dependencies),
+    requireApplicationBundle(candidateApplication, "candidate", dependencies),
+  ]);
+  if (baselineBundle.canonicalPath === candidateBundle.canonicalPath) {
+    fail("baseline application must differ from candidate");
+  }
+  const [baseline, candidate] = await Promise.all([
+    inspectMacosApplicationIdentity(baselineApplication, baselineBundle, dependencies),
+    inspectMacosApplicationIdentity(candidateApplication, candidateBundle, dependencies),
+  ]);
+  if (candidate.version !== candidateVersion) fail("candidate release identity is invalid");
+  if (!olderStableCalVer(baseline.version, candidate.version)) {
+    fail("baseline application is not older than candidate");
+  }
+  if (
+    baseline.identifier !== candidate.identifier ||
+    baseline.teamIdentifier !== candidate.teamIdentifier ||
+    baseline.designatedRequirement !== candidate.designatedRequirement ||
+    baseline.entitlements !== candidate.entitlements
+  ) {
+    fail("macOS signed identity differs from baseline");
+  }
+  return Object.freeze({
+    baselineVersion: baseline.version,
+    candidateVersion: candidate.version,
+    teamIdentifier: candidate.teamIdentifier,
+    candidateCodeIdentity: Object.freeze({
+      codeDirectory: candidate.codeDirectory,
+      cdHash: candidate.cdHash,
+    }),
+  });
+}
+
+function requireCandidateCodeIdentity(value) {
+  if (
+    !exactObject(value) ||
+    typeof value.codeDirectory !== "string" ||
+    value.codeDirectory.length === 0 ||
+    value.codeDirectory.length > 16_384 ||
+    typeof value.cdHash !== "string" ||
+    !/^[0-9a-f]{40,128}$/u.test(value.cdHash)
+  ) {
+    fail("loose candidate code identity is invalid");
+  }
+  return value;
+}
+
+async function requireSecureTemporaryDirectory(path, prefix, dependencies) {
+  if (!isExpectedTemporaryDirectory(path, prefix) || resolve(path) !== path) {
+    fail("macOS release application temporary directory is invalid");
+  }
+  let stat;
+  try {
+    stat = await dependencies.lstat(path);
+  } catch {
+    fail("macOS release application temporary directory is invalid");
+  }
+  if (stat.isSymbolicLink() || !stat.isDirectory() || (stat.mode & 0o777) !== 0o700) {
+    fail("macOS release application temporary directory is invalid");
+  }
+  return filesystemObjectIdentity(stat);
+}
+
+async function createSecureChildDirectory(path, dependencies) {
+  try {
+    await dependencies.mkdir(path, { mode: 0o700 });
+    const stat = await dependencies.lstat(path);
+    if (stat.isSymbolicLink() || !stat.isDirectory() || (stat.mode & 0o777) !== 0o700) {
+      fail("macOS release application temporary directory is invalid");
+    }
+    return filesystemObjectIdentity(stat);
+  } catch (error) {
+    if (error instanceof MacosReleaseVerificationError) throw error;
+    fail("macOS release application temporary directory is invalid");
+  }
+}
+
+async function requireSingleRootApplication(directory, label, dependencies) {
+  let entries;
+  let canonicalDirectory;
+  try {
+    const [stat, resolvedDirectory, directoryEntries] = await Promise.all([
+      dependencies.lstat(directory),
+      dependencies.realpath(directory),
+      dependencies.readdir(directory),
+    ]);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      fail(`${label} root application is invalid`);
+    }
+    canonicalDirectory = resolvedDirectory;
+    entries = directoryEntries;
+  } catch {
+    fail(`${label} root application is invalid`);
+  }
+  const applicationName = `${canonicalProductName}.app`;
+  const applicationEntries = entries.filter((entry) => entry.toLowerCase().endsWith(".app"));
+  const allowedDmgPresentationEntries = new Set([
+    applicationName,
+    "Applications",
+    ".background.tiff",
+    ".DS_Store",
+    ".VolumeIcon.icns",
+  ]);
+  if (
+    applicationEntries.length !== 1 ||
+    applicationEntries[0] !== applicationName ||
+    (label === "ZIP" && (entries.length !== 1 || entries[0] !== applicationName)) ||
+    (label === "DMG" && entries.some((entry) => !allowedDmgPresentationEntries.has(entry)))
+  ) {
+    fail(`${label} root application is invalid`);
+  }
+  if (label === "DMG") {
+    try {
+      await Promise.all(
+        entries
+          .filter((entry) => entry !== applicationName)
+          .map(async (entry) => {
+            const path = join(directory, entry);
+            const stat = await dependencies.lstat(path);
+            if (entry === "Applications") {
+              if (
+                !stat.isSymbolicLink() ||
+                (await dependencies.readlink(path)) !== "/Applications"
+              ) {
+                fail("DMG root application is invalid");
+              }
+              return;
+            }
+            if (stat.isSymbolicLink() || !stat.isFile() || stat.size <= 0) {
+              fail("DMG root application is invalid");
+            }
+          }),
+      );
+    } catch (error) {
+      if (error instanceof MacosReleaseVerificationError) throw error;
+      fail("DMG root application is invalid");
+    }
+  }
+  const application = join(directory, applicationName);
+  let stat;
+  let canonicalApplication;
+  try {
+    [stat, canonicalApplication] = await Promise.all([
+      dependencies.lstat(application),
+      dependencies.realpath(application),
+    ]);
+  } catch {
+    fail(`${label} root application is invalid`);
+  }
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isDirectory() ||
+    dirname(canonicalApplication) !== canonicalDirectory ||
+    basename(canonicalApplication) !== applicationName
+  ) {
+    fail(`${label} root application is invalid`);
+  }
+  return application;
+}
+
+function validHdiutilPath(path) {
+  return (
+    typeof path === "string" &&
+    isAbsolute(path) &&
+    path.length > 0 &&
+    path.length <= 4_096 &&
+    path === path.trim() &&
+    Array.from(path).every((character) => {
+      const code = character.codePointAt(0);
+      return code !== undefined && code >= 32 && code !== 127;
+    })
+  );
+}
+
+function parseHdiutilSystemEntities(value, failureMessage) {
+  const entities = exactObject(value) ? value["system-entities"] : undefined;
+  if (!Array.isArray(entities) || entities.some((entry) => !exactObject(entry))) {
+    fail(failureMessage);
+  }
+  for (const entry of entities) {
+    const device = entry["dev-entry"];
+    if (
+      typeof device !== "string" ||
+      !/^\/dev\/disk[1-9]\d*(?:s[1-9]\d*)?$/u.test(device) ||
+      (Object.hasOwn(entry, "mount-point") && !validHdiutilPath(entry["mount-point"]))
+    ) {
+      fail(failureMessage);
+    }
+  }
+  return entities;
+}
+
+async function mountedDeviceAtMountPoint(
+  result,
+  mountPoint,
+  dependencies,
+  failureMessage,
+  requireOnlyMountedEntity,
+) {
+  const mounted = parseHdiutilSystemEntities(
+    parseJsonOutput(result, failureMessage),
+    failureMessage,
+  ).filter((entry) => Object.hasOwn(entry, "mount-point"));
+  if (requireOnlyMountedEntity && mounted.length !== 1) fail(failureMessage);
+  let canonicalExpectedMountPoint;
+  try {
+    canonicalExpectedMountPoint = await dependencies.realpath(mountPoint);
+  } catch {
+    fail(failureMessage);
+  }
+  const matches = [];
+  for (const entry of mounted) {
+    let canonicalReportedMountPoint;
+    try {
+      canonicalReportedMountPoint = await dependencies.realpath(entry["mount-point"]);
+    } catch {
+      fail(failureMessage);
+    }
+    if (canonicalExpectedMountPoint === canonicalReportedMountPoint) matches.push(entry);
+  }
+  if (matches.length !== 1) {
+    if (!requireOnlyMountedEntity && matches.length === 0) return undefined;
+    fail(failureMessage);
+  }
+  return matches[0]["dev-entry"];
+}
+
+async function inspectHdiutilState(result, dependencies, failureMessage) {
+  const value = parseJsonOutput(result, failureMessage);
+  const images = exactObject(value) ? value.images : undefined;
+  if (!Array.isArray(images) || images.some((image) => !exactObject(image))) {
+    fail(failureMessage);
+  }
+  const state = [];
+  for (const image of images) {
+    const imagePath = image["image-path"];
+    if (!validHdiutilPath(imagePath)) fail(failureMessage);
+    let canonicalImagePath;
+    try {
+      canonicalImagePath = await dependencies.realpath(imagePath);
+    } catch {
+      fail(failureMessage);
+    }
+    const entities = parseHdiutilSystemEntities(image, failureMessage);
+    const normalizedEntities = [];
+    for (const entity of entities) {
+      let canonicalMountPoint;
+      if (Object.hasOwn(entity, "mount-point")) {
+        try {
+          canonicalMountPoint = await dependencies.realpath(entity["mount-point"]);
+        } catch {
+          fail(failureMessage);
+        }
+      }
+      normalizedEntities.push({
+        device: entity["dev-entry"],
+        canonicalMountPoint,
+      });
+    }
+    state.push({ canonicalImagePath, entities: normalizedEntities });
+  }
+  return state;
+}
+
+async function runRedactedSystemFile(dependencies, executable, arguments_, failureMessage) {
+  try {
+    return await dependencies.executeFile(executable, arguments_);
+  } catch {
+    fail(failureMessage);
+  }
+}
+
+async function convertHdiutilPlist(result, path, dependencies, failureMessage) {
+  const bytes = outputStream(result, "stdout");
+  if (bytes.length === 0 || Buffer.byteLength(bytes) > 1024 * 1024) fail(failureMessage);
+  try {
+    await dependencies.writeFile(path, bytes, { flag: "wx", mode: 0o600 });
+  } catch {
+    fail(failureMessage);
+  }
+  return runRedactedSystemFile(
+    dependencies,
+    "/usr/bin/plutil",
+    ["-convert", "json", "-o", "-", "--", path],
+    failureMessage,
+  );
+}
+
+async function inspectCurrentHdiutilState(temporaryDirectory, sequence, dependencies) {
+  const failureMessage = "macOS release DMG detach state verification failed";
+  const result = await runRedactedSystemFile(
+    dependencies,
+    "/usr/bin/hdiutil",
+    ["info", "-plist"],
+    failureMessage,
+  );
+  const converted = await convertHdiutilPlist(
+    result,
+    join(temporaryDirectory, `hdiutil-info-${sequence}.plist`),
+    dependencies,
+    failureMessage,
+  );
+  return inspectHdiutilState(converted, dependencies, failureMessage);
+}
+
+function mountedImageAssociations(state) {
+  return state.flatMap((image) =>
+    image.entities
+      .filter((entity) => entity.canonicalMountPoint !== undefined)
+      .map((entity) => ({
+        canonicalImagePath: image.canonicalImagePath,
+        canonicalMountPoint: entity.canonicalMountPoint,
+        device: entity.device,
+      })),
+  );
+}
+
+function findAttachedImageIdentity(
+  state,
+  canonicalImagePath,
+  canonicalMountPoint,
+  deviceFromAttach,
+) {
+  const associations = mountedImageAssociations(state);
+  const atMountPoint = associations.filter(
+    (association) => association.canonicalMountPoint === canonicalMountPoint,
+  );
+  const imageRecords = state.filter((image) => image.canonicalImagePath === canonicalImagePath);
+  const forImage = associations.filter(
+    (association) => association.canonicalImagePath === canonicalImagePath,
+  );
+  const matchingDeviceEntries =
+    deviceFromAttach === undefined
+      ? []
+      : state.flatMap((image) =>
+          image.entities.filter((entity) => entity.device === deviceFromAttach),
+        );
+  if (
+    atMountPoint.length === 0 &&
+    imageRecords.length === 0 &&
+    matchingDeviceEntries.length === 0
+  ) {
+    return undefined;
+  }
+  if (
+    atMountPoint.length !== 1 ||
+    imageRecords.length !== 1 ||
+    forImage.length !== 1 ||
+    atMountPoint[0] !== forImage[0] ||
+    (deviceFromAttach !== undefined &&
+      (atMountPoint[0].device !== deviceFromAttach || matchingDeviceEntries.length !== 1))
+  ) {
+    fail("macOS release DMG detach state verification failed");
+  }
+  return Object.freeze({
+    canonicalImagePath,
+    canonicalMountPoint,
+    device: atMountPoint[0].device,
+    instanceDevices: Object.freeze(imageRecords[0].entities.map((entity) => entity.device).sort()),
+  });
+}
+
+function requireNewImageInstance(attachment, previousState) {
+  const previousDevices = new Set(
+    previousState.flatMap((image) => image.entities.map((entity) => entity.device)),
+  );
+  if (attachment.instanceDevices.some((device) => previousDevices.has(device))) {
+    fail("macOS release DMG detach state verification failed");
+  }
+}
+
+function requireSameImageInstance(actual, expected) {
+  if (
+    actual === undefined ||
+    actual.canonicalImagePath !== expected.canonicalImagePath ||
+    actual.canonicalMountPoint !== expected.canonicalMountPoint ||
+    actual.device !== expected.device ||
+    actual.instanceDevices.length !== expected.instanceDevices.length ||
+    actual.instanceDevices.some((device, index) => device !== expected.instanceDevices[index])
+  ) {
+    fail("macOS release DMG detach state verification failed");
+  }
+  return actual;
+}
+
+function requireDetachedImageIdentity(state, canonicalImagePath, canonicalMountPoint, devices) {
+  const associations = mountedImageAssociations(state);
+  const expectedDevices = Array.isArray(devices) ? devices : devices === undefined ? [] : [devices];
+  if (
+    state.some((image) => image.canonicalImagePath === canonicalImagePath) ||
+    state.some((image) =>
+      image.entities.some((entity) => expectedDevices.includes(entity.device)),
+    ) ||
+    associations.some((association) => association.canonicalMountPoint === canonicalMountPoint)
+  ) {
+    fail("macOS release DMG detach state verification failed");
+  }
+}
+
+function missingPathError(error) {
+  return error !== null && typeof error === "object" && error.code === "ENOENT";
+}
+
+function filesystemObjectIdentity(stat) {
+  return Object.freeze({ dev: stat.dev, ino: stat.ino, mode: stat.mode });
+}
+
+function sameFilesystemObject(left, right) {
+  return left.dev === right.dev && left.ino === right.ino && left.mode === right.mode;
+}
+
+async function requireSameSecureDirectory(path, expectedIdentity, dependencies, failureMessage) {
+  let stat;
+  try {
+    stat = await dependencies.lstat(path);
+  } catch {
+    fail(failureMessage);
+  }
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isDirectory() ||
+    (stat.mode & 0o777) !== 0o700 ||
+    !sameFilesystemObject(filesystemObjectIdentity(stat), expectedIdentity)
+  ) {
+    fail(failureMessage);
+  }
+}
+
+async function inspectPackagedApplication(
+  baselineApplication,
+  application,
+  candidateVersion,
+  expectedCodeIdentity,
+  dependencies,
+) {
+  let continuity;
+  try {
+    continuity = await dependencies.verifyIdentityContinuity(
+      baselineApplication,
+      application,
+      { candidateVersion },
+      dependencies,
+    );
+  } catch (error) {
+    if (error instanceof MacosReleaseVerificationError) throw error;
+    fail("packaged macOS application identity verification failed");
+  }
+  const actualCodeIdentity = requireCandidateCodeIdentity(continuity?.candidateCodeIdentity);
+  if (
+    actualCodeIdentity.codeDirectory !== expectedCodeIdentity.codeDirectory ||
+    actualCodeIdentity.cdHash !== expectedCodeIdentity.cdHash
+  ) {
+    fail("packaged macOS application differs from the loose candidate");
+  }
+}
+
+export async function verifyMacosReleaseApplicationContents(
+  artifactDirectory,
+  baselineApplication,
+  options,
+  overrides = {},
+) {
+  if (!isAbsolute(artifactDirectory)) fail("artifact directory must be absolute");
+  if (typeof baselineApplication !== "string" || !isAbsolute(baselineApplication)) {
+    fail("baseline application path must be absolute");
+  }
+  let candidateVersion;
+  try {
+    candidateVersion = requireStableCalVer(options?.candidateVersion);
+  } catch {
+    fail("candidate release version is invalid");
+  }
+  const expectedCodeIdentity = requireCandidateCodeIdentity(options?.looseCandidateCodeIdentity);
+  const dependencies = {
+    executeFile: overrides.executeFile ?? executeSystemFile,
+    extractAsarFile: overrides.extractAsarFile ?? extractFile,
+    lstat: overrides.lstat ?? lstat,
+    mkdir: overrides.mkdir ?? mkdir,
+    mkdtemp: overrides.mkdtemp ?? mkdtemp,
+    readFile: overrides.readFile ?? readFile,
+    readlink: overrides.readlink ?? readlink,
+    readdir: overrides.readdir ?? readdir,
+    realpath: overrides.realpath ?? realpath,
+    rm: overrides.rm ?? rm,
+    rmdir: overrides.rmdir ?? rmdir,
+    tmpdir: overrides.tmpdir ?? tmpdir,
+    writeFile: overrides.writeFile ?? writeFile,
+    verifyIdentityContinuity: overrides.verifyIdentityContinuity ?? verifyMacosIdentityContinuity,
+  };
+  const names = releaseArtifactNames(candidateVersion);
+  const zipPath = join(artifactDirectory, names.zip);
+  const dmgPath = join(artifactDirectory, names.dmg);
+  for (const [path, label] of [
+    [zipPath, "ZIP artifact"],
+    [dmgPath, "DMG artifact"],
+  ]) {
+    let stat;
+    try {
+      stat = await dependencies.lstat(path);
+    } catch {
+      fail(`missing ${label}`);
+    }
+    if (stat.isSymbolicLink() || !stat.isFile() || stat.size <= 0) fail(`invalid ${label}`);
+  }
+
+  let temporaryBase;
+  try {
+    temporaryBase = dependencies.tmpdir();
+  } catch {
+    fail("macOS release application temporary directory is invalid");
+  }
+  if (
+    typeof temporaryBase !== "string" ||
+    !isAbsolute(temporaryBase) ||
+    temporaryBase.length === 0 ||
+    temporaryBase.length > 4_096 ||
+    temporaryBase !== temporaryBase.trim()
+  ) {
+    fail("macOS release application temporary directory is invalid");
+  }
+  const temporaryPrefix = join(temporaryBase, "enduragent-release-applications-");
+  let temporaryDirectory;
+  let mountPoint;
+  let canonicalDmgPath;
+  let canonicalMountPoint;
+  let deviceFromAttach;
+  let hdiutilBeforeAttach;
+  let attachmentIdentity;
+  let temporaryDirectoryIdentity;
+  let mountPointIdentity;
+  let attachmentAttempted = false;
+  let failure = null;
+  try {
+    const candidateTemporaryDirectory = await dependencies.mkdtemp(temporaryPrefix);
+    temporaryDirectoryIdentity = await requireSecureTemporaryDirectory(
+      candidateTemporaryDirectory,
+      temporaryPrefix,
+      dependencies,
+    );
+    temporaryDirectory = candidateTemporaryDirectory;
+    const zipDirectory = join(temporaryDirectory, "zip");
+    mountPoint = join(temporaryDirectory, "dmg");
+    await createSecureChildDirectory(zipDirectory, dependencies);
+    mountPointIdentity = await createSecureChildDirectory(mountPoint, dependencies);
+    try {
+      [canonicalDmgPath, canonicalMountPoint] = await Promise.all([
+        dependencies.realpath(dmgPath),
+        dependencies.realpath(mountPoint),
+      ]);
+    } catch {
+      fail("macOS release DMG mount metadata is invalid");
+    }
+
+    await runRedactedSystemFile(
+      dependencies,
+      "/usr/bin/ditto",
+      ["-x", "-k", zipPath, zipDirectory],
+      "macOS release ZIP extraction failed",
+    );
+    const zipApplication = await requireSingleRootApplication(zipDirectory, "ZIP", dependencies);
+    await inspectPackagedApplication(
+      baselineApplication,
+      zipApplication,
+      candidateVersion,
+      expectedCodeIdentity,
+      dependencies,
+    );
+
+    hdiutilBeforeAttach = await inspectCurrentHdiutilState(
+      temporaryDirectory,
+      "before-attach",
+      dependencies,
+    );
+    requireDetachedImageIdentity(
+      hdiutilBeforeAttach,
+      canonicalDmgPath,
+      canonicalMountPoint,
+      undefined,
+    );
+
+    attachmentAttempted = true;
+    const attachResult = await runRedactedSystemFile(
+      dependencies,
+      "/usr/bin/hdiutil",
+      [
+        "attach",
+        "-readonly",
+        "-nobrowse",
+        "-noautoopen",
+        "-plist",
+        "-mountpoint",
+        mountPoint,
+        dmgPath,
+      ],
+      "macOS release DMG mount failed",
+    );
+    const converted = await convertHdiutilPlist(
+      attachResult,
+      join(temporaryDirectory, "hdiutil-attach.plist"),
+      dependencies,
+      "macOS release DMG mount metadata is invalid",
+    );
+    deviceFromAttach = await mountedDeviceAtMountPoint(
+      converted,
+      mountPoint,
+      dependencies,
+      "macOS release DMG mount metadata is invalid",
+      true,
+    );
+    const afterAttach = await inspectCurrentHdiutilState(
+      temporaryDirectory,
+      "after-attach",
+      dependencies,
+    );
+    const candidateAttachmentIdentity = findAttachedImageIdentity(
+      afterAttach,
+      canonicalDmgPath,
+      canonicalMountPoint,
+      deviceFromAttach,
+    );
+    if (candidateAttachmentIdentity === undefined) {
+      fail("macOS release DMG mount metadata is invalid");
+    }
+    requireNewImageInstance(candidateAttachmentIdentity, hdiutilBeforeAttach);
+    attachmentIdentity = candidateAttachmentIdentity;
+    const dmgApplication = await requireSingleRootApplication(mountPoint, "DMG", dependencies);
+    await inspectPackagedApplication(
+      baselineApplication,
+      dmgApplication,
+      candidateVersion,
+      expectedCodeIdentity,
+      dependencies,
+    );
+  } catch (error) {
+    failure =
+      error instanceof MacosReleaseVerificationError
+        ? error
+        : new MacosReleaseVerificationError("macOS release application verification failed");
+  }
+
+  let cleanupFailure;
+  let safeToRemove = false;
+  if (
+    attachmentAttempted &&
+    mountPoint !== undefined &&
+    canonicalDmgPath !== undefined &&
+    canonicalMountPoint !== undefined &&
+    temporaryDirectory !== undefined
+  ) {
+    let attachment;
+    try {
+      const beforeDetach = await inspectCurrentHdiutilState(
+        temporaryDirectory,
+        "before-detach",
+        dependencies,
+      );
+      const observedAttachment = findAttachedImageIdentity(
+        beforeDetach,
+        canonicalDmgPath,
+        canonicalMountPoint,
+        deviceFromAttach,
+      );
+      if (attachmentIdentity === undefined) {
+        if (observedAttachment !== undefined && hdiutilBeforeAttach !== undefined) {
+          requireNewImageInstance(observedAttachment, hdiutilBeforeAttach);
+        }
+        attachment = observedAttachment;
+      } else {
+        attachment = requireSameImageInstance(observedAttachment, attachmentIdentity);
+      }
+    } catch {
+      cleanupFailure = new MacosReleaseVerificationError(
+        "macOS release DMG detach state verification failed",
+      );
+    }
+    if (cleanupFailure === undefined && attachment !== undefined) {
+      try {
+        await dependencies.executeFile("/usr/bin/hdiutil", ["detach", attachment.device]);
+      } catch {
+        cleanupFailure = new MacosReleaseVerificationError("macOS release DMG detach failed");
+      }
+    }
+    if (cleanupFailure === undefined) {
+      try {
+        const afterDetach = await inspectCurrentHdiutilState(
+          temporaryDirectory,
+          "after-detach",
+          dependencies,
+        );
+        requireDetachedImageIdentity(
+          afterDetach,
+          canonicalDmgPath,
+          canonicalMountPoint,
+          attachment?.instanceDevices ?? deviceFromAttach,
+        );
+      } catch {
+        cleanupFailure = new MacosReleaseVerificationError(
+          "macOS release DMG detach state verification failed",
+        );
+      }
+    }
+  }
+  if (cleanupFailure === undefined && mountPoint !== undefined) {
+    if (mountPointIdentity === undefined) {
+      cleanupFailure = new MacosReleaseVerificationError(
+        "macOS release DMG mountpoint cleanup failed",
+      );
+    } else {
+      try {
+        await requireSameSecureDirectory(
+          mountPoint,
+          mountPointIdentity,
+          dependencies,
+          "macOS release DMG mountpoint cleanup failed",
+        );
+        await dependencies.rmdir(mountPoint);
+      } catch {
+        cleanupFailure = new MacosReleaseVerificationError(
+          "macOS release DMG mountpoint cleanup failed",
+        );
+      }
+    }
+    if (cleanupFailure === undefined) {
+      try {
+        await dependencies.lstat(mountPoint);
+        cleanupFailure = new MacosReleaseVerificationError(
+          "macOS release DMG mountpoint cleanup failed",
+        );
+      } catch (error) {
+        if (!missingPathError(error)) {
+          cleanupFailure = new MacosReleaseVerificationError(
+            "macOS release DMG mountpoint cleanup failed",
+          );
+        }
+      }
+    }
+    safeToRemove = cleanupFailure === undefined;
+  } else if (cleanupFailure === undefined && mountPoint === undefined) {
+    safeToRemove = true;
+  }
+  if (cleanupFailure === undefined && safeToRemove && temporaryDirectory !== undefined) {
+    if (temporaryDirectoryIdentity === undefined) {
+      cleanupFailure = new MacosReleaseVerificationError(
+        "macOS release application cleanup failed",
+      );
+    } else {
+      try {
+        await requireSameSecureDirectory(
+          temporaryDirectory,
+          temporaryDirectoryIdentity,
+          dependencies,
+          "macOS release application cleanup failed",
+        );
+        await dependencies.rm(temporaryDirectory, { recursive: true, force: true });
+      } catch {
+        cleanupFailure = new MacosReleaseVerificationError(
+          "macOS release application cleanup failed",
+        );
+      }
+    }
+  }
+  if (cleanupFailure !== undefined) throw cleanupFailure;
+  if (failure !== null) throw failure;
 }
 
 async function runSystemVerification(executeFile, executable, arguments_, failureMessage) {

--- a/apps/desktop/tests/development-package-plan.test.ts
+++ b/apps/desktop/tests/development-package-plan.test.ts
@@ -89,6 +89,7 @@ describe("Desktop development package plan", () => {
         desktopRoot,
         feedUrl: "https://updates.example.test/stable/",
         identity: "Enduragent Test (ABCDE12345)",
+        baselineApplication: join(desktopRoot, "dist/baseline/Enduragent.app"),
       },
       { readFile: async () => JSON.stringify({ version: "2026.8.6" }) },
     );

--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -1,12 +1,25 @@
 import { createHash } from "node:crypto";
-import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  rmdir,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse, stringify } from "yaml";
 import {
   verifyMacosApplication,
+  verifyMacosIdentityContinuity,
+  verifyMacosReleaseApplicationContents,
   verifyMacosReleaseArtifacts,
 } from "../scripts/verify-macos-release.mjs";
 
@@ -92,6 +105,1260 @@ function deterministicTemporaryDirectory(root: string) {
     }),
   };
 }
+
+interface SignedApplicationMetadata {
+  version: string;
+  teamIdentifier: string;
+  identifier: string;
+  requirement: string;
+  flags: string;
+  info: Record<string, unknown>;
+  manifest: Record<string, unknown>;
+  entitlements: Record<string, unknown>;
+  extraAuthorities: string[];
+  codeDirectory: string;
+  cdHash: string;
+}
+
+const canonicalDesignatedRequirement =
+  'identifier "icu.enduragent.desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = FA494ACVTF';
+
+function signedApplicationMetadata(version: string, cdHash: string): SignedApplicationMetadata {
+  return {
+    version,
+    teamIdentifier: "FA494ACVTF",
+    identifier: "icu.enduragent.desktop",
+    requirement: canonicalDesignatedRequirement,
+    flags: "runtime",
+    codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+    cdHash,
+    info: {
+      CFBundleIdentifier: "icu.enduragent.desktop",
+      CFBundleName: "Enduragent",
+      CFBundleDisplayName: "Enduragent",
+      CFBundleExecutable: "Enduragent",
+      CFBundlePackageType: "APPL",
+      CFBundleShortVersionString: version,
+      CFBundleVersion: version,
+    },
+    manifest: {
+      name: "@enduragent/desktop",
+      version,
+      enduragentDesktopRelease: true,
+    },
+    entitlements: { "com.apple.security.cs.allow-jit": true },
+    extraAuthorities: [],
+  };
+}
+
+async function signedIdentityFixture() {
+  const root = await mkdtemp(join(tmpdir(), "desktop-signed-identity-"));
+  roots.push(root);
+  const baseline = join(root, "baseline/Enduragent.app");
+  const candidate = join(root, "candidate/Enduragent.app");
+  for (const application of [baseline, candidate]) {
+    await mkdir(join(application, "Contents/Resources"), { recursive: true });
+    await Promise.all([
+      writeFile(join(application, "Contents/Info.plist"), "synthetic plist authority\n"),
+      writeFile(join(application, "Contents/Resources/app.asar"), "synthetic ASAR authority\n"),
+    ]);
+  }
+  const metadata = new Map<string, SignedApplicationMetadata>([
+    [baseline, signedApplicationMetadata("2026.7.1", "a".repeat(40))],
+    [candidate, signedApplicationMetadata("2026.7.2", "b".repeat(40))],
+  ]);
+  const applicationForPath = (path: string) =>
+    path.startsWith(baseline) ? baseline : path.startsWith(candidate) ? candidate : undefined;
+  const temporaryEntitlements = new Map<string, Record<string, unknown>>();
+  const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+    const finalArgument = arguments_.at(-1);
+    if (typeof finalArgument !== "string") throw new Error("synthetic command shape rejected");
+    if (executable === "/usr/bin/xcrun" || executable === "/usr/sbin/spctl") {
+      return { stdout: "", stderr: "" };
+    }
+    if (executable === "/usr/bin/codesign" && arguments_.includes("--verify")) {
+      return { stdout: "", stderr: "" };
+    }
+    const application = applicationForPath(finalArgument);
+    if (executable === "/usr/bin/codesign" && application !== undefined) {
+      const selected = metadata.get(application)!;
+      if (arguments_.includes("--verbose=4")) {
+        return {
+          stdout: "",
+          stderr: [
+            `Executable=${application}/Contents/MacOS/Enduragent`,
+            `Identifier=${selected.identifier}`,
+            `CodeDirectory ${selected.codeDirectory.replace(`(${selected.codeDirectory.includes("runtime") ? "runtime" : "none"})`, `(${selected.flags})`)}`,
+            `CDHash=${selected.cdHash}`,
+            `Authority=Developer ID Application: Enduragent Test (${selected.teamIdentifier})`,
+            "Authority=Developer ID Certification Authority",
+            "Authority=Apple Root CA",
+            ...selected.extraAuthorities.map((authority) => `Authority=${authority}`),
+            `TeamIdentifier=${selected.teamIdentifier}`,
+          ].join("\n"),
+        };
+      }
+      if (arguments_.includes("--requirements")) {
+        return {
+          stdout: "",
+          stderr: `Executable=${application}/Contents/MacOS/Enduragent\ndesignated => ${selected.requirement}\n`,
+        };
+      }
+      if (arguments_.includes("--entitlements")) {
+        const entitlementPath = arguments_[arguments_.indexOf("--entitlements") + 1];
+        if (
+          typeof entitlementPath !== "string" ||
+          entitlementPath === "-" ||
+          !arguments_.includes("--der")
+        ) {
+          throw new Error("synthetic entitlement extraction shape rejected");
+        }
+        temporaryEntitlements.set(entitlementPath, selected.entitlements);
+        await writeFile(entitlementPath, Buffer.from([0x70, 0x2b, 0x02, 0x01, 0x01]));
+        return {
+          stdout: "",
+          stderr: `Executable=${application}/Contents/MacOS/Enduragent\n`,
+        };
+      }
+    }
+    if (executable === "/usr/bin/derq") {
+      const inputPath = arguments_[arguments_.indexOf("-i") + 1];
+      const outputPath = arguments_[arguments_.indexOf("-o") + 1];
+      if (
+        arguments_.join(" ").startsWith("query --xml ") === false ||
+        typeof inputPath !== "string" ||
+        typeof outputPath !== "string"
+      ) {
+        throw new Error("synthetic DER query shape rejected");
+      }
+      const entitlements = temporaryEntitlements.get(inputPath);
+      if (entitlements === undefined) throw new Error("synthetic DER authority rejected");
+      temporaryEntitlements.set(outputPath, entitlements);
+      await writeFile(outputPath, '<?xml version="1.0"?><plist><dict/></plist>');
+      return { stdout: "", stderr: "" };
+    }
+    if (executable === "/usr/bin/plutil" && finalArgument.endsWith("Info.plist")) {
+      const selectedApplication = applicationForPath(finalArgument);
+      if (selectedApplication === undefined) throw new Error("synthetic plist path rejected");
+      return { stdout: JSON.stringify(metadata.get(selectedApplication)!.info), stderr: "" };
+    }
+    if (executable === "/usr/bin/plutil" && finalArgument.endsWith("entitlements.plist")) {
+      const entitlements = temporaryEntitlements.get(finalArgument);
+      if (entitlements === undefined) throw new Error("synthetic plist authority rejected");
+      return { stdout: JSON.stringify(entitlements), stderr: "" };
+    }
+    throw new Error("synthetic command rejected");
+  });
+  const extractAsarFile = vi.fn(async (archivePath: string) => {
+    const application = applicationForPath(archivePath);
+    if (application === undefined) throw new Error("synthetic ASAR path rejected");
+    return Buffer.from(JSON.stringify(metadata.get(application)!.manifest));
+  });
+  return { baseline, candidate, executeFile, extractAsarFile, metadata };
+}
+
+describe("macOS signed identity continuity", () => {
+  it("accepts only an older baseline with the same canonical signed identity", async () => {
+    const fixture = await signedIdentityFixture();
+
+    await expect(
+      verifyMacosIdentityContinuity(
+        fixture.baseline,
+        fixture.candidate,
+        { candidateVersion: version },
+        {
+          executeFile: fixture.executeFile,
+          extractAsarFile: fixture.extractAsarFile,
+        },
+      ),
+    ).resolves.toEqual({
+      baselineVersion: "2026.7.1",
+      candidateVersion: version,
+      teamIdentifier: "FA494ACVTF",
+      candidateCodeIdentity: {
+        codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+        cdHash: "b".repeat(40),
+      },
+    });
+
+    for (const application of [fixture.baseline, fixture.candidate]) {
+      expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/codesign", [
+        "--verify",
+        "--deep",
+        "--strict",
+        "--verbose=2",
+        application,
+      ]);
+      expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/xcrun", [
+        "stapler",
+        "validate",
+        "-v",
+        application,
+      ]);
+      expect(fixture.executeFile).toHaveBeenCalledWith("/usr/sbin/spctl", [
+        "--assess",
+        "--type",
+        "execute",
+        "--verbose=4",
+        application,
+      ]);
+      expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/codesign", [
+        "--display",
+        "--verbose=4",
+        application,
+      ]);
+      expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/codesign", [
+        "--display",
+        "--requirements",
+        "-",
+        application,
+      ]);
+    }
+    const entitlementExtractions = fixture.executeFile.mock.calls.filter(
+      ([executable, arguments_]) =>
+        executable === "/usr/bin/codesign" && arguments_.includes("--entitlements"),
+    );
+    expect(entitlementExtractions).toHaveLength(2);
+    for (const [, arguments_] of entitlementExtractions) {
+      expect(arguments_).toEqual([
+        "--display",
+        "--entitlements",
+        expect.stringMatching(/\/entitlements\.der$/u),
+        "--der",
+        expect.stringMatching(/\/Enduragent\.app$/u),
+      ]);
+    }
+    const entitlementConversions = fixture.executeFile.mock.calls.filter(
+      ([executable]) => executable === "/usr/bin/derq",
+    );
+    expect(entitlementConversions).toHaveLength(2);
+    for (const [, arguments_] of entitlementConversions) {
+      expect(arguments_).toEqual([
+        "query",
+        "--xml",
+        "-i",
+        expect.stringMatching(/\/entitlements\.der$/u),
+        "-o",
+        expect.stringMatching(/\/entitlements\.plist$/u),
+      ]);
+    }
+    expect(fixture.extractAsarFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("normalizes canonical codesign comments and quoted or unquoted Team Identifiers", async () => {
+    const fixture = await signedIdentityFixture();
+    fixture.metadata.get(fixture.baseline)!.requirement =
+      'identifier "icu.enduragent.desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "FA494ACVTF"';
+
+    await expect(
+      verifyMacosIdentityContinuity(
+        fixture.baseline,
+        fixture.candidate,
+        { candidateVersion: version },
+        { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+      ),
+    ).resolves.toMatchObject({ teamIdentifier: "FA494ACVTF" });
+  });
+
+  it.each([
+    canonicalDesignatedRequirement.replace(" and anchor", " or anchor"),
+    `${canonicalDesignatedRequirement} and true`,
+    canonicalDesignatedRequirement.replace("anchor apple generic", "anchor apple"),
+    canonicalDesignatedRequirement.replace(
+      "certificate 1[field.1.2.840.113635.100.6.2.6] exists",
+      'certificate 1[subject.CN] = "Developer ID Certification Authority"',
+    ),
+    canonicalDesignatedRequirement.replace(
+      "certificate 1[field.1.2.840.113635.100.6.2.6] exists",
+      "certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ exists",
+    ),
+    canonicalDesignatedRequirement.replace(
+      "certificate leaf[field.1.2.840.113635.100.6.1.13] exists",
+      "/* exists */ certificate leaf[field.1.2.840.113635.100.6.1.13]",
+    ),
+  ])("rejects a permissive or alternate designated requirement: %s", async (requirement) => {
+    const fixture = await signedIdentityFixture();
+    fixture.metadata.get(fixture.candidate)!.requirement = requirement;
+
+    await expect(
+      verifyMacosIdentityContinuity(
+        fixture.baseline,
+        fixture.candidate,
+        { candidateVersion: version },
+        { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+      ),
+    ).rejects.toThrow("macOS designated requirement is invalid");
+  });
+
+  it.each([
+    "XFA494ACVTF",
+    "FA494ACVTFX",
+    "FA494ACVTE",
+    '"XFA494ACVTF"',
+    '"FA494ACVTFX"',
+    '"FA494ACVTE"',
+  ])("rejects a near-match Team Identifier in the designated requirement: %s", async (team) => {
+    const fixture = await signedIdentityFixture();
+    fixture.metadata.get(fixture.candidate)!.requirement = canonicalDesignatedRequirement.replace(
+      "FA494ACVTF",
+      team,
+    );
+
+    await expect(
+      verifyMacosIdentityContinuity(
+        fixture.baseline,
+        fixture.candidate,
+        { candidateVersion: version },
+        { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+      ),
+    ).rejects.toThrow("macOS designated requirement is invalid");
+  });
+
+  it.each([undefined, "", "Enduragent.app", " relative/Enduragent.app"])(
+    "rejects a missing or non-absolute baseline before native inspection: %s",
+    async (baseline) => {
+      const fixture = await signedIdentityFixture();
+      await expect(
+        verifyMacosIdentityContinuity(
+          baseline as never,
+          fixture.candidate,
+          { candidateVersion: version },
+          { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+        ),
+      ).rejects.toThrow("baseline application path must be absolute");
+      expect(fixture.executeFile).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects the candidate itself as its own baseline", async () => {
+    const fixture = await signedIdentityFixture();
+    await expect(
+      verifyMacosIdentityContinuity(
+        fixture.candidate,
+        fixture.candidate,
+        { candidateVersion: version },
+        { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+      ),
+    ).rejects.toThrow("baseline application must differ from candidate");
+    expect(fixture.executeFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects a candidate alias reached through a symlinked parent", async () => {
+    const fixture = await signedIdentityFixture();
+    const aliasParent = join(fixture.candidate, "../..", "candidate-alias");
+    await symlink(join(fixture.candidate, ".."), aliasParent, "dir");
+    const aliasedCandidate = join(aliasParent, "Enduragent.app");
+    await expect(
+      verifyMacosIdentityContinuity(
+        aliasedCandidate,
+        fixture.candidate,
+        { candidateVersion: version },
+        { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+      ),
+    ).rejects.toThrow("baseline application must differ from candidate");
+    expect(fixture.executeFile).not.toHaveBeenCalled();
+  });
+
+  it.each(["2026.7.2", "2026.7.3"])(
+    "rejects a baseline that is not older than the candidate: %s",
+    async (baselineVersion) => {
+      const fixture = await signedIdentityFixture();
+      const baseline = fixture.metadata.get(fixture.baseline)!;
+      baseline.version = baselineVersion;
+      baseline.info.CFBundleShortVersionString = baselineVersion;
+      baseline.info.CFBundleVersion = baselineVersion;
+      baseline.manifest.version = baselineVersion;
+      await expect(
+        verifyMacosIdentityContinuity(
+          fixture.baseline,
+          fixture.candidate,
+          { candidateVersion: version },
+          { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+        ),
+      ).rejects.toThrow("baseline application is not older than candidate");
+    },
+  );
+
+  it("rejects a mutually matching but noncanonical Team Identifier", async () => {
+    const fixture = await signedIdentityFixture();
+    for (const application of [fixture.baseline, fixture.candidate]) {
+      const metadata = fixture.metadata.get(application)!;
+      metadata.teamIdentifier = "ABCDE12345";
+      metadata.requirement =
+        'identifier "icu.enduragent.desktop" and anchor apple generic and certificate leaf[subject.OU] = "ABCDE12345"';
+    }
+    await expect(
+      verifyMacosIdentityContinuity(
+        fixture.baseline,
+        fixture.candidate,
+        { candidateVersion: version },
+        { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+      ),
+    ).rejects.toThrow("macOS signed identity is invalid");
+  });
+
+  it.each([
+    {
+      label: "Team Identifier",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.teamIdentifier = "ZZZZZ99999";
+      },
+      error: "macOS signed identity is invalid",
+    },
+    {
+      label: "designated requirement",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.requirement =
+          'identifier "icu.enduragent.desktop" and anchor apple generic and certificate leaf[subject.OU] = "FA494ACVTF" and certificate leaf[subject.CN] = "Unexpected"';
+      },
+      error: "macOS designated requirement is invalid",
+    },
+    {
+      label: "hardened runtime",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.flags = "none";
+      },
+      error: "macOS signed identity is invalid",
+    },
+    {
+      label: "certificate chain",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.extraAuthorities.push("Unexpected Extra Authority");
+      },
+      error: "macOS signed identity is invalid",
+    },
+    {
+      label: "bundle identifier",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.info.CFBundleIdentifier = "icu.example.desktop";
+      },
+      error: "macOS product identity is invalid",
+    },
+    {
+      label: "product name",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.info.CFBundleDisplayName = "Example";
+      },
+      error: "macOS product identity is invalid",
+    },
+    {
+      label: "package name",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.manifest.name = "@example/desktop";
+      },
+      error: "macOS package identity is invalid",
+    },
+    {
+      label: "signed entitlements",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.entitlements["com.apple.security.network.server"] = true;
+      },
+      error: "macOS signed entitlements are invalid",
+    },
+  ])("rejects candidate $label drift", async ({ mutate, error }) => {
+    const fixture = await signedIdentityFixture();
+    mutate(fixture.metadata.get(fixture.candidate)!);
+    await expect(
+      verifyMacosIdentityContinuity(
+        fixture.baseline,
+        fixture.candidate,
+        { candidateVersion: version },
+        { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+      ),
+    ).rejects.toThrow(error);
+  });
+
+  it("redacts native inspection failures and never returns command output or paths", async () => {
+    const fixture = await signedIdentityFixture();
+    const sentinel = `${fixture.baseline}: Developer ID Application private output`;
+    fixture.executeFile.mockRejectedValueOnce(new Error(sentinel));
+
+    let failure: unknown;
+    try {
+      await verifyMacosIdentityContinuity(
+        fixture.baseline,
+        fixture.candidate,
+        { candidateVersion: version },
+        { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+      );
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toBe("macOS application signature verification failed");
+    expect((failure as Error).message).not.toContain(sentinel);
+    expect((failure as Error).message).not.toContain(fixture.baseline);
+  });
+});
+
+type PackagedRootShape =
+  | "invalid-presentation"
+  | "missing"
+  | "multiple"
+  | "presentation"
+  | "symlink"
+  | "unrelated"
+  | "valid";
+interface PackagedCodeIdentity {
+  readonly codeDirectory: string;
+  readonly cdHash: string;
+}
+
+const looseCandidateCodeIdentity: PackagedCodeIdentity = Object.freeze({
+  codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+  cdHash: "b".repeat(40),
+});
+
+async function packagedApplicationFixture(
+  options: {
+    zipShape?: PackagedRootShape;
+    dmgShape?: PackagedRootShape;
+    zipCodeIdentity?: PackagedCodeIdentity;
+    dmgCodeIdentity?: PackagedCodeIdentity;
+    mountMetadata?: unknown;
+    privateVarMountMetadata?: boolean;
+    identityFailure?: "zip" | "dmg";
+    realpathEscape?: "zip" | "dmg";
+    attachFailureAfterMount?: boolean;
+    discoveryFailure?: boolean;
+    detachFailure?: boolean;
+    detachLeavesMounted?: boolean;
+    beforeDetachImageSwap?: boolean;
+    beforeDetachDeviceSwap?: boolean;
+    postDetachImageRemains?: boolean;
+    postDetachMountOccupied?: boolean;
+    postDetachDeviceRemains?: boolean;
+    nonHdiutilReplacementMount?: boolean;
+    mountReappearsAfterRmdir?: boolean;
+    mountPointRemovedByPeer?: boolean;
+    preexistingImage?: boolean;
+    preAttachExactCollision?: boolean;
+    reusePreexistingDevice?: boolean;
+    cleanupFailure?: boolean;
+  } = {},
+) {
+  const root = await mkdtemp(join(tmpdir(), "desktop-packaged-applications-"));
+  roots.push(root);
+  const artifactDirectory = join(root, "envelope");
+  const dmgArtifact = join(artifactDirectory, names.dmg);
+  const baseline = join(root, "baseline/Enduragent.app");
+  const symlinkTarget = join(root, "symlink-target/Enduragent.app");
+  const replacementImage = join(root, "replacement.dmg");
+  const preexistingImage = join(root, "preexisting.dmg");
+  const preexistingMount = join(root, "preexisting-mount");
+  await Promise.all([
+    mkdir(artifactDirectory, { recursive: true }),
+    mkdir(baseline, { recursive: true }),
+    mkdir(preexistingMount, { recursive: true }),
+    mkdir(symlinkTarget, { recursive: true }),
+  ]);
+  await Promise.all([
+    writeFile(join(artifactDirectory, names.zip), "synthetic ZIP authority\n"),
+    writeFile(join(artifactDirectory, names.dmg), "synthetic DMG authority\n"),
+    writeFile(replacementImage, "synthetic replacement image\n"),
+    writeFile(preexistingImage, "synthetic preexisting image\n"),
+  ]);
+  const canonicalDmgArtifact = await realpath(dmgArtifact);
+  let mountPoint = "";
+  const temporaryDirectories: string[] = [];
+  const mkdtempTracked = vi.fn(async (prefix: string) => {
+    const path = await mkdtemp(prefix);
+    temporaryDirectories.push(path);
+    mountPoint = join(path, "dmg");
+    return path;
+  });
+  const populate = async (directory: string, shape: PackagedRootShape) => {
+    if (shape === "missing") return;
+    const application = join(directory, "Enduragent.app");
+    if (shape === "symlink") {
+      await symlink(symlinkTarget, application, "dir");
+      return;
+    }
+    await mkdir(application);
+    if (shape === "multiple") await mkdir(join(directory, "Other.app"));
+    if (shape === "unrelated") await writeFile(join(directory, "unexpected.txt"), "unexpected\n");
+    if (shape === "presentation") {
+      await Promise.all([
+        symlink("/Applications", join(directory, "Applications"), "dir"),
+        writeFile(join(directory, ".background.tiff"), "synthetic background\n"),
+        writeFile(join(directory, ".DS_Store"), "synthetic presentation metadata\n"),
+        writeFile(join(directory, ".VolumeIcon.icns"), "synthetic icon\n"),
+      ]);
+    }
+    if (shape === "invalid-presentation") {
+      await mkdir(join(directory, ".background.tiff"));
+    }
+  };
+  let attached = false;
+  let attachedImage = "";
+  let infoRequestCount = 0;
+  let afterAttachStateServed = false;
+  let beforeDetachStateServed = false;
+  const pendingPlistConversions: unknown[] = [];
+  const convertedPlists: unknown[] = [];
+  const systemEntities = (device = "/dev/disk42s1", reportedMountPoint = mountPoint) => [
+    { "dev-entry": device.replace(/s[1-9]\d*$/u, "") },
+    {
+      "dev-entry": device,
+      "mount-point": options.privateVarMountMetadata
+        ? reportedMountPoint.replace(/^\/var\//u, "/private/var/")
+        : reportedMountPoint,
+    },
+  ];
+  const defaultMountMetadata = () => ({ "system-entities": systemEntities() });
+  const preexistingImageRecord = () => ({
+    "image-path": preexistingImage,
+    "system-entities": [
+      { "dev-entry": options.reusePreexistingDevice ? "/dev/disk42" : "/dev/disk90" },
+      {
+        "dev-entry": options.reusePreexistingDevice ? "/dev/disk42s9" : "/dev/disk90s1",
+        "mount-point": preexistingMount,
+      },
+    ],
+  });
+  const retainedImages = () => [
+    ...(options.preexistingImage || options.reusePreexistingDevice
+      ? [preexistingImageRecord()]
+      : []),
+    ...(options.preAttachExactCollision
+      ? [{ "image-path": canonicalDmgArtifact, "system-entities": systemEntities() }]
+      : []),
+  ];
+  const infoMetadata = (imagePath = attachedImage, device = "/dev/disk42s1") => ({
+    images: [
+      ...retainedImages(),
+      { "image-path": imagePath, "system-entities": systemEntities(device) },
+    ],
+  });
+  const emptyInfoMetadata = () => ({ images: retainedImages() });
+  const preDetachMetadata = () => {
+    if (options.beforeDetachImageSwap) return infoMetadata(replacementImage);
+    if (options.beforeDetachDeviceSwap) return infoMetadata(attachedImage, "/dev/disk43s1");
+    return infoMetadata();
+  };
+  const postDetachMetadata = () => {
+    if (options.postDetachImageRemains) {
+      return {
+        images: [
+          ...retainedImages(),
+          {
+            "image-path": attachedImage,
+            "system-entities": systemEntities("/dev/disk43s1", preexistingMount),
+          },
+        ],
+      };
+    }
+    if (options.postDetachMountOccupied) {
+      return {
+        images: [
+          ...retainedImages(),
+          {
+            "image-path": replacementImage,
+            "system-entities": systemEntities("/dev/disk43s1"),
+          },
+        ],
+      };
+    }
+    if (options.postDetachDeviceRemains) {
+      return {
+        images: [
+          ...retainedImages(),
+          {
+            "image-path": replacementImage,
+            "system-entities": [
+              { "dev-entry": "/dev/disk42" },
+              { "dev-entry": "/dev/disk43s1", "mount-point": preexistingMount },
+            ],
+          },
+        ],
+      };
+    }
+    return emptyInfoMetadata();
+  };
+  const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+    if (executable === "/usr/bin/ditto") {
+      const destination = arguments_.at(-1);
+      if (typeof destination !== "string") throw new Error("synthetic ditto path rejected");
+      await populate(destination, options.zipShape ?? "valid");
+      return { stdout: "", stderr: "" };
+    }
+    if (executable === "/usr/bin/hdiutil" && arguments_[0] === "attach") {
+      const mountPointIndex = arguments_.indexOf("-mountpoint");
+      const selected = arguments_[mountPointIndex + 1];
+      if (selected !== mountPoint || mountPoint.length === 0) {
+        throw new Error("synthetic mount path rejected");
+      }
+      attachedImage = arguments_.at(-1) ?? "";
+      await populate(mountPoint, options.dmgShape ?? "valid");
+      attached = true;
+      if (options.attachFailureAfterMount) throw new Error("private interrupted attach output");
+      pendingPlistConversions.push(options.mountMetadata ?? defaultMountMetadata());
+      return { stdout: "synthetic hdiutil plist\n", stderr: "private attach details" };
+    }
+    if (executable === "/usr/bin/hdiutil" && arguments_[0] === "info") {
+      infoRequestCount += 1;
+      if (options.discoveryFailure && infoRequestCount >= 3) {
+        throw new Error("private hdiutil info output");
+      }
+      let metadata: unknown;
+      if (infoRequestCount === 1) {
+        metadata = emptyInfoMetadata();
+      } else if (attached && !options.attachFailureAfterMount && !afterAttachStateServed) {
+        afterAttachStateServed = true;
+        metadata = infoMetadata();
+      } else if (attached && !beforeDetachStateServed) {
+        beforeDetachStateServed = true;
+        metadata = preDetachMetadata();
+      } else if (attached) {
+        metadata = preDetachMetadata();
+      } else {
+        metadata = postDetachMetadata();
+      }
+      pendingPlistConversions.push(metadata);
+      return { stdout: "synthetic hdiutil info plist\n", stderr: "private info details" };
+    }
+    if (executable === "/usr/bin/plutil") {
+      const converted = pendingPlistConversions.shift();
+      convertedPlists.push(converted);
+      return {
+        stdout: JSON.stringify(converted),
+        stderr: "",
+      };
+    }
+    if (executable === "/usr/bin/hdiutil" && arguments_[0] === "detach") {
+      if (options.detachFailure) throw new Error("private detach output");
+      if (!options.detachLeavesMounted) {
+        attached = false;
+        await Promise.all(
+          (await readdir(mountPoint)).map((entry) =>
+            rm(join(mountPoint, entry), { recursive: true, force: true }),
+          ),
+        );
+      }
+      return { stdout: "", stderr: "" };
+    }
+    throw new Error("synthetic command rejected");
+  });
+  const verifyIdentityContinuity = vi.fn(
+    async (
+      _baseline: string,
+      application: string,
+      verificationOptions: { candidateVersion: string },
+    ) => {
+      const source = application.includes("/zip/") ? "zip" : "dmg";
+      if (options.identityFailure === source) {
+        throw new Error(`${application}: private signing output`);
+      }
+      return {
+        baselineVersion: "2026.7.1",
+        candidateVersion: verificationOptions.candidateVersion,
+        teamIdentifier: "FA494ACVTF",
+        candidateCodeIdentity:
+          source === "zip"
+            ? (options.zipCodeIdentity ?? looseCandidateCodeIdentity)
+            : (options.dmgCodeIdentity ?? looseCandidateCodeIdentity),
+      };
+    },
+  );
+  const remove = vi.fn(async (path: string, removeOptions: { recursive: true; force: true }) => {
+    if (options.cleanupFailure && temporaryDirectories.includes(path)) {
+      throw new Error("private cleanup output");
+    }
+    await rm(path, removeOptions);
+  });
+  const removeMountPoint = vi.fn(async (path: string) => {
+    if (options.nonHdiutilReplacementMount || options.preAttachExactCollision) {
+      throw Object.assign(new Error("synthetic replacement mount is busy"), { code: "EBUSY" });
+    }
+    if (options.mountPointRemovedByPeer) {
+      await rmdir(path);
+      throw Object.assign(new Error("synthetic mountpoint disappeared"), { code: "ENOENT" });
+    }
+    await rmdir(path);
+    if (options.mountReappearsAfterRmdir) await mkdir(path, { mode: 0o700 });
+  });
+  const resolveRealpath = vi.fn(async (path: string) => {
+    const source = path.includes("/zip/") ? "zip" : path.includes("/dmg/") ? "dmg" : undefined;
+    if (source === options.realpathEscape && path.endsWith("/Enduragent.app")) {
+      return symlinkTarget;
+    }
+    return realpath(path);
+  });
+  const verify = () =>
+    verifyMacosReleaseApplicationContents(
+      artifactDirectory,
+      baseline,
+      { candidateVersion: version, looseCandidateCodeIdentity },
+      {
+        executeFile,
+        mkdtemp: mkdtempTracked,
+        realpath: resolveRealpath,
+        rm: remove,
+        rmdir: removeMountPoint,
+        tmpdir: () => root,
+        verifyIdentityContinuity,
+      },
+    );
+  return {
+    artifactDirectory,
+    baseline,
+    canonicalDmgArtifact,
+    convertedPlists,
+    executeFile,
+    intendedMountPoint: () => mountPoint,
+    verifyIdentityContinuity,
+    remove,
+    removeMountPoint,
+    temporaryDirectories,
+    verify,
+  };
+}
+
+describe("macOS packaged application identity binding", () => {
+  it("binds both mandatory packaged applications to the loose candidate before cleanup", async () => {
+    const fixture = await packagedApplicationFixture();
+
+    await expect(fixture.verify()).resolves.toBeUndefined();
+
+    expect(fixture.verifyIdentityContinuity).toHaveBeenCalledTimes(2);
+    for (const [baseline, application, verificationOptions] of fixture.verifyIdentityContinuity.mock
+      .calls) {
+      expect(baseline).toBe(fixture.baseline);
+      expect(application).toMatch(/\/(?:zip|dmg)\/Enduragent\.app$/u);
+      expect(verificationOptions).toEqual({ candidateVersion: version });
+    }
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/ditto", [
+      "-x",
+      "-k",
+      join(fixture.artifactDirectory, names.zip),
+      expect.stringMatching(/\/zip$/u),
+    ]);
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/hdiutil", [
+      "attach",
+      "-readonly",
+      "-nobrowse",
+      "-noautoopen",
+      "-plist",
+      "-mountpoint",
+      fixture.intendedMountPoint(),
+      join(fixture.artifactDirectory, names.dmg),
+    ]);
+    expect(fixture.intendedMountPoint()).not.toBe("");
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/hdiutil", [
+      "detach",
+      "/dev/disk42s1",
+    ]);
+    const detachCall = fixture.executeFile.mock.calls.findIndex(
+      ([executable, arguments_]) => executable === "/usr/bin/hdiutil" && arguments_[0] === "detach",
+    );
+    const infoCalls = fixture.executeFile.mock.calls
+      .map(([executable, arguments_], index) => ({ executable, arguments_, index }))
+      .filter(
+        ({ executable, arguments_ }) =>
+          executable === "/usr/bin/hdiutil" && arguments_[0] === "info",
+      );
+    expect(infoCalls).toHaveLength(4);
+    expect(infoCalls[2]!.index).toBeLessThan(detachCall);
+    expect(detachCall).toBeLessThan(infoCalls[3]!.index);
+    expect(fixture.executeFile.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      fixture.removeMountPoint.mock.invocationCallOrder[0]!,
+    );
+    expect(fixture.removeMountPoint.mock.invocationCallOrder[0]).toBeLessThan(
+      fixture.remove.mock.invocationCallOrder[0]!,
+    );
+    await expect(lstat(fixture.temporaryDirectories[0]!)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("accepts the standard electron-builder DMG presentation root", async () => {
+    const fixture = await packagedApplicationFixture({ dmgShape: "presentation" });
+    await expect(fixture.verify()).resolves.toBeUndefined();
+    expect(fixture.verifyIdentityContinuity).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["invalid-presentation", "unrelated"] as const)(
+    "rejects a DMG root with %s entries",
+    async (dmgShape) => {
+      const fixture = await packagedApplicationFixture({ dmgShape });
+      await expect(fixture.verify()).rejects.toThrow("DMG root application is invalid");
+      await expect(lstat(fixture.temporaryDirectories[0]!)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
+
+  it("accepts the canonical /private/var alias for a /var mountpoint", async () => {
+    const fixture = await packagedApplicationFixture({ privateVarMountMetadata: true });
+    await expect(fixture.verify()).resolves.toBeUndefined();
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/hdiutil", [
+      "detach",
+      "/dev/disk42s1",
+    ]);
+  });
+
+  it("leaves an unrelated preexisting disk image attached", async () => {
+    const fixture = await packagedApplicationFixture({ preexistingImage: true });
+
+    await expect(fixture.verify()).resolves.toBeUndefined();
+
+    const detachCalls = fixture.executeFile.mock.calls.filter(
+      ([executable, arguments_]) => executable === "/usr/bin/hdiutil" && arguments_[0] === "detach",
+    );
+    expect(detachCalls).toEqual([["/usr/bin/hdiutil", ["detach", "/dev/disk42s1"]]]);
+  });
+
+  it("never attaches or detaches when the exact image, mountpoint, and device preexist", async () => {
+    const fixture = await packagedApplicationFixture({ preAttachExactCollision: true });
+
+    await expect(fixture.verify()).rejects.toThrow("macOS release DMG mountpoint cleanup failed");
+
+    const intendedMountPoint = fixture.intendedMountPoint();
+    expect(intendedMountPoint).not.toBe("");
+    expect(fixture.convertedPlists).toEqual([
+      {
+        images: [
+          {
+            "image-path": fixture.canonicalDmgArtifact,
+            "system-entities": [
+              { "dev-entry": "/dev/disk42" },
+              { "dev-entry": "/dev/disk42s1", "mount-point": intendedMountPoint },
+            ],
+          },
+        ],
+      },
+    ]);
+    expect(
+      fixture.executeFile.mock.calls.some(
+        ([executable, arguments_]) =>
+          executable === "/usr/bin/hdiutil" &&
+          (arguments_[0] === "attach" || arguments_[0] === "detach"),
+      ),
+    ).toBe(false);
+    expect(fixture.removeMountPoint).toHaveBeenCalledOnce();
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it("never detaches an attachment that reuses a preexisting device", async () => {
+    const fixture = await packagedApplicationFixture({ reusePreexistingDevice: true });
+
+    await expect(fixture.verify()).rejects.toThrow(
+      "macOS release DMG detach state verification failed",
+    );
+
+    expect(
+      fixture.executeFile.mock.calls.some(
+        ([executable, arguments_]) =>
+          executable === "/usr/bin/hdiutil" && arguments_[0] === "attach",
+      ),
+    ).toBe(true);
+    expect(
+      fixture.executeFile.mock.calls.some(
+        ([executable, arguments_]) =>
+          executable === "/usr/bin/hdiutil" && arguments_[0] === "detach",
+      ),
+    ).toBe(false);
+    expect(fixture.removeMountPoint).not.toHaveBeenCalled();
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it.each([
+    ["image", { beforeDetachImageSwap: true }],
+    ["device", { beforeDetachDeviceSwap: true }],
+  ] as const)("never detaches or removes a %s-swapped mount", async (_label, options) => {
+    const fixture = await packagedApplicationFixture(options);
+
+    await expect(fixture.verify()).rejects.toThrow(
+      "macOS release DMG detach state verification failed",
+    );
+
+    expect(
+      fixture.executeFile.mock.calls.some(
+        ([executable, arguments_]) =>
+          executable === "/usr/bin/hdiutil" && arguments_[0] === "detach",
+      ),
+    ).toBe(false);
+    expect(fixture.removeMountPoint).not.toHaveBeenCalled();
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it.each([
+    ["canonical image remains", { postDetachImageRemains: true }],
+    ["canonical mountpoint is occupied", { postDetachMountOccupied: true }],
+    ["bound device remains", { postDetachDeviceRemains: true }],
+  ] as const)("preserves recovery storage when the %s after detach", async (_label, options) => {
+    const fixture = await packagedApplicationFixture(options);
+
+    await expect(fixture.verify()).rejects.toThrow(
+      "macOS release DMG detach state verification failed",
+    );
+
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/hdiutil", [
+      "detach",
+      "/dev/disk42s1",
+    ]);
+    expect(fixture.removeMountPoint).not.toHaveBeenCalled();
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it("does not trust hdiutil absence when a non-hdiutil mount keeps the mountpoint busy", async () => {
+    const fixture = await packagedApplicationFixture({ nonHdiutilReplacementMount: true });
+
+    await expect(fixture.verify()).rejects.toThrow("macOS release DMG mountpoint cleanup failed");
+
+    expect(fixture.removeMountPoint).toHaveBeenCalledOnce();
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it("detects a mountpoint that reappears after non-recursive removal", async () => {
+    const fixture = await packagedApplicationFixture({ mountReappearsAfterRmdir: true });
+
+    await expect(fixture.verify()).rejects.toThrow("macOS release DMG mountpoint cleanup failed");
+
+    expect(fixture.removeMountPoint).toHaveBeenCalledOnce();
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it("preserves recovery storage when the mountpoint disappears during non-recursive removal", async () => {
+    const fixture = await packagedApplicationFixture({ mountPointRemovedByPeer: true });
+
+    await expect(fixture.verify()).rejects.toThrow("macOS release DMG mountpoint cleanup failed");
+
+    expect(fixture.removeMountPoint).toHaveBeenCalledOnce();
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it("never recursively removes a temporary path that fails prefix validation", async () => {
+    const fixture = await packagedApplicationFixture();
+    const remove = vi.fn(async () => {});
+
+    await expect(
+      verifyMacosReleaseApplicationContents(
+        fixture.artifactDirectory,
+        fixture.baseline,
+        { candidateVersion: version, looseCandidateCodeIdentity },
+        {
+          executeFile: fixture.executeFile,
+          mkdtemp: vi.fn(async () => fixture.artifactDirectory),
+          rm: remove,
+          tmpdir: () => dirname(fixture.artifactDirectory),
+          verifyIdentityContinuity: fixture.verifyIdentityContinuity,
+        },
+      ),
+    ).rejects.toThrow("macOS release application temporary directory is invalid");
+
+    expect(remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.artifactDirectory)).isDirectory()).toBe(true);
+  });
+
+  it("redacts temporary-directory creation failures", async () => {
+    const fixture = await packagedApplicationFixture();
+    const sentinel = `${fixture.artifactDirectory}: private temporary output`;
+    let failure: unknown;
+    try {
+      await verifyMacosReleaseApplicationContents(
+        fixture.artifactDirectory,
+        fixture.baseline,
+        { candidateVersion: version, looseCandidateCodeIdentity },
+        {
+          executeFile: fixture.executeFile,
+          mkdtemp: vi.fn(async () => {
+            throw new Error(sentinel);
+          }),
+          tmpdir: () => dirname(fixture.artifactDirectory),
+          verifyIdentityContinuity: fixture.verifyIdentityContinuity,
+        },
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toBe("macOS release application verification failed");
+    expect((failure as Error).message).not.toContain(sentinel);
+  });
+
+  it.each([
+    ["ZIP", { zipCodeIdentity: { ...looseCandidateCodeIdentity, codeDirectory: "different" } }],
+    ["DMG", { dmgCodeIdentity: { ...looseCandidateCodeIdentity, codeDirectory: "different" } }],
+    [
+      "same signed identity but different CDHash",
+      { dmgCodeIdentity: { ...looseCandidateCodeIdentity, cdHash: "c".repeat(40) } },
+    ],
+  ])("rejects %s application drift", async (_label, options) => {
+    const fixture = await packagedApplicationFixture(options);
+    await expect(fixture.verify()).rejects.toThrow(
+      "packaged macOS application differs from the loose candidate",
+    );
+    await expect(lstat(fixture.temporaryDirectories[0]!)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.each(["zip", "dmg"] as const)("requires the %s artifact", async (artifact) => {
+    const fixture = await packagedApplicationFixture();
+    await rm(join(fixture.artifactDirectory, names[artifact]));
+    await expect(fixture.verify()).rejects.toThrow(`missing ${artifact.toUpperCase()} artifact`);
+    expect(fixture.executeFile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["ZIP", "zipShape", "missing"],
+    ["ZIP", "zipShape", "multiple"],
+    ["ZIP", "zipShape", "symlink"],
+    ["DMG", "dmgShape", "missing"],
+    ["DMG", "dmgShape", "multiple"],
+    ["DMG", "dmgShape", "symlink"],
+  ] as const)("rejects a %s %s root application", async (label, key, shape) => {
+    const fixture = await packagedApplicationFixture({ [key]: shape });
+    await expect(fixture.verify()).rejects.toThrow(`${label} root application is invalid`);
+    await expect(lstat(fixture.temporaryDirectories[0]!)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.each(["zip", "dmg"] as const)("rejects a %s application realpath escape", async (source) => {
+    const fixture = await packagedApplicationFixture({ realpathEscape: source });
+    await expect(fixture.verify()).rejects.toThrow(
+      `${source.toUpperCase()} root application is invalid`,
+    );
+    await expect(lstat(fixture.temporaryDirectories[0]!)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.each([
+    { "system-entities": [] },
+    {
+      "system-entities": [{ "dev-entry": "/dev/disk42s1", "mount-point": "/Volumes/Unexpected" }],
+    },
+    {
+      "system-entities": [
+        { "dev-entry": "/dev/disk42s1;touch /tmp/leak", "mount-point": "expected" },
+      ],
+    },
+    {
+      "system-entities": [
+        { "dev-entry": "/dev/disk42s1", "mount-point": "first" },
+        { "dev-entry": "/dev/disk43s1", "mount-point": "second" },
+      ],
+    },
+  ])(
+    "rejects invalid or malicious hdiutil metadata and detaches the exact mount",
+    async (metadata) => {
+      const fixture = await packagedApplicationFixture({ mountMetadata: metadata });
+      await expect(fixture.verify()).rejects.toThrow("macOS release DMG mount metadata is invalid");
+      const detach = fixture.executeFile.mock.calls.find(
+        ([executable, arguments_]) =>
+          executable === "/usr/bin/hdiutil" && arguments_[0] === "detach",
+      );
+      expect(detach?.[1]).toEqual(["detach", "/dev/disk42s1"]);
+      await expect(lstat(fixture.temporaryDirectories[0]!)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
+
+  it("detaches and removes the exact temporary root when packaged identity verification fails", async () => {
+    const fixture = await packagedApplicationFixture({ identityFailure: "dmg" });
+    await expect(fixture.verify()).rejects.toThrow(
+      "packaged macOS application identity verification failed",
+    );
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/hdiutil", [
+      "detach",
+      "/dev/disk42s1",
+    ]);
+    expect(fixture.remove).toHaveBeenCalledWith(fixture.temporaryDirectories[0], {
+      recursive: true,
+      force: true,
+    });
+    await expect(lstat(fixture.temporaryDirectories[0]!)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("discovers and detaches a device when attach populates the mount then throws", async () => {
+    const fixture = await packagedApplicationFixture({ attachFailureAfterMount: true });
+
+    await expect(fixture.verify()).rejects.toThrow("macOS release DMG mount failed");
+
+    expect(fixture.verifyIdentityContinuity).toHaveBeenCalledTimes(1);
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/hdiutil", ["info", "-plist"]);
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/hdiutil", [
+      "detach",
+      "/dev/disk42s1",
+    ]);
+    expect(fixture.remove).toHaveBeenCalledWith(fixture.temporaryDirectories[0], {
+      recursive: true,
+      force: true,
+    });
+    await expect(lstat(fixture.temporaryDirectories[0]!)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves a partially mounted root when detach fails after interrupted attach", async () => {
+    const fixture = await packagedApplicationFixture({
+      attachFailureAfterMount: true,
+      detachFailure: true,
+    });
+
+    await expect(fixture.verify()).rejects.toThrow("macOS release DMG detach failed");
+
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it("preserves a possibly mounted root when mount-state discovery fails", async () => {
+    const fixture = await packagedApplicationFixture({ discoveryFailure: true });
+
+    await expect(fixture.verify()).rejects.toThrow(
+      "macOS release DMG detach state verification failed",
+    );
+
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it("preserves a root when the device remains mounted after detach reports success", async () => {
+    const fixture = await packagedApplicationFixture({ detachLeavesMounted: true });
+
+    await expect(fixture.verify()).rejects.toThrow(
+      "macOS release DMG detach state verification failed",
+    );
+
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it("blocks promotion and preserves the mount root when exact detach fails", async () => {
+    const fixture = await packagedApplicationFixture({ detachFailure: true });
+    await expect(fixture.verify()).rejects.toThrow("macOS release DMG detach failed");
+    expect(fixture.remove).not.toHaveBeenCalled();
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it("blocks promotion when exact temporary-root removal fails", async () => {
+    const fixture = await packagedApplicationFixture({ cleanupFailure: true });
+    await expect(fixture.verify()).rejects.toThrow("macOS release application cleanup failed");
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/hdiutil", [
+      "detach",
+      "/dev/disk42s1",
+    ]);
+    expect((await lstat(fixture.temporaryDirectories[0]!)).isDirectory()).toBe(true);
+  });
+
+  it("redacts native output and application paths from packaged verification failures", async () => {
+    const fixture = await packagedApplicationFixture({ identityFailure: "zip" });
+    let failure: unknown;
+    try {
+      await fixture.verify();
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toBe(
+      "packaged macOS application identity verification failed",
+    );
+    expect((failure as Error).message).not.toContain(fixture.temporaryDirectories[0]!);
+    expect((failure as Error).message).not.toContain("private signing output");
+  });
+});
 
 describe("macOS release artifact envelope", () => {
   it("validates both artifacts and exact regenerated blockmap bytes through the seam", async () => {

--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   lstat,
@@ -13,14 +14,17 @@ import {
 } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse, stringify } from "yaml";
 import {
   verifyMacosApplication,
+  verifyMacosBaselineApplication,
   verifyMacosIdentityContinuity,
   verifyMacosReleaseApplicationContents,
   verifyMacosReleaseArtifacts,
+  verifyMacosReleaseEnvelope,
 } from "../scripts/verify-macos-release.mjs";
 
 const localRequire = createRequire(import.meta.url);
@@ -31,6 +35,7 @@ const { buildBlockMap: installedBuildBlockMap } = builderRequire(
   buildBlockMap(inputPath: string, compression: "gzip", outputPath: string): Promise<unknown>;
 };
 const roots: string[] = [];
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const version = "2026.7.2";
 const names = {
   dmg: `Enduragent-${version}-arm64.dmg`,
@@ -258,6 +263,36 @@ async function signedIdentityFixture() {
 }
 
 describe("macOS signed identity continuity", () => {
+  it("preflights the complete signed baseline before a candidate exists", async () => {
+    const fixture = await signedIdentityFixture();
+
+    await expect(
+      verifyMacosBaselineApplication(
+        fixture.baseline,
+        { candidateVersion: version },
+        {
+          executeFile: fixture.executeFile,
+          extractAsarFile: fixture.extractAsarFile,
+        },
+      ),
+    ).resolves.toEqual({
+      baselineVersion: "2026.7.1",
+      teamIdentifier: "FA494ACVTF",
+    });
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/codesign", [
+      "--verify",
+      "--deep",
+      "--strict",
+      "--verbose=2",
+      fixture.baseline,
+    ]);
+    expect(fixture.extractAsarFile).toHaveBeenCalledOnce();
+    expect(fixture.extractAsarFile).toHaveBeenCalledWith(
+      join(fixture.baseline, "Contents/Resources/app.asar"),
+      "package.json",
+    );
+  });
+
   it("accepts only an older baseline with the same canonical signed identity", async () => {
     const fixture = await signedIdentityFixture();
 
@@ -1361,6 +1396,134 @@ describe("macOS packaged application identity binding", () => {
 });
 
 describe("macOS release artifact envelope", () => {
+  it("verifies artifacts, the loose candidate, and packaged applications as one envelope", async () => {
+    const fixture = await releaseFixture();
+    const baselineApplication = "/synthetic/baseline/Enduragent.app";
+    const looseCandidateApplication = "/synthetic/candidate/Enduragent.app";
+    const artifacts = Object.freeze({
+      version,
+      names: Object.freeze({ ...names, metadata: "latest-mac.yml" as const }),
+      paths: Object.freeze({
+        dmg: join(fixture.artifactDirectory, names.dmg),
+        zip: join(fixture.artifactDirectory, names.zip),
+        blockmap: join(fixture.artifactDirectory, names.blockmap),
+        metadata: join(fixture.artifactDirectory, names.metadata),
+      }),
+      sizes: Object.freeze({
+        dmg: fixture.dmg.length,
+        zip: fixture.zip.length,
+        blockmap: fixture.blockmap.length,
+      }),
+      dmgSha512: fixture.dmgSha512,
+      zipSha512: fixture.zipSha512,
+    });
+    const identityContinuity = Object.freeze({
+      baselineVersion: "2026.7.1",
+      candidateVersion: version,
+      teamIdentifier: "FA494ACVTF",
+      candidateCodeIdentity: Object.freeze({
+        codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+        cdHash: "b".repeat(40),
+      }),
+    });
+    const verifyReleaseArtifacts = vi.fn(async () => artifacts);
+    const verifyIdentityContinuity = vi.fn(async () => identityContinuity);
+    const verifyReleaseApplicationContents = vi.fn(async () => {});
+
+    const verified = await verifyMacosReleaseEnvelope(
+      fixture.artifactDirectory,
+      baselineApplication,
+      looseCandidateApplication,
+      { repositoryRoot: fixture.repositoryRoot },
+      {
+        verifyReleaseArtifacts,
+        verifyIdentityContinuity,
+        verifyReleaseApplicationContents,
+      },
+    );
+
+    expect(verified).toEqual({ artifacts, identityContinuity });
+    expect(Object.isFrozen(verified)).toBe(true);
+    expect(verifyReleaseArtifacts).toHaveBeenCalledWith(
+      fixture.artifactDirectory,
+      { repositoryRoot: fixture.repositoryRoot },
+      expect.any(Object),
+    );
+    expect(verifyIdentityContinuity).toHaveBeenCalledWith(
+      baselineApplication,
+      looseCandidateApplication,
+      { candidateVersion: version },
+      expect.any(Object),
+    );
+    expect(verifyReleaseApplicationContents).toHaveBeenCalledWith(
+      fixture.artifactDirectory,
+      baselineApplication,
+      {
+        candidateVersion: version,
+        looseCandidateCodeIdentity: identityContinuity.candidateCodeIdentity,
+      },
+      expect.any(Object),
+    );
+    expect(verifyReleaseArtifacts.mock.invocationCallOrder[0]).toBeLessThan(
+      verifyIdentityContinuity.mock.invocationCallOrder[0]!,
+    );
+    expect(verifyIdentityContinuity.mock.invocationCallOrder[0]).toBeLessThan(
+      verifyReleaseApplicationContents.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("stops packaged-application verification when loose identity continuity fails", async () => {
+    const fixture = await releaseFixture();
+    const failure = new Error("synthetic loose identity failure");
+    const verifyReleaseApplicationContents = vi.fn(async () => {});
+
+    await expect(
+      verifyMacosReleaseEnvelope(
+        fixture.artifactDirectory,
+        "/synthetic/baseline/Enduragent.app",
+        "/synthetic/candidate/Enduragent.app",
+        { repositoryRoot: fixture.repositoryRoot },
+        {
+          verifyReleaseArtifacts: vi.fn(async () => ({
+            version,
+            names: { ...names, metadata: "latest-mac.yml" as const },
+            paths: {
+              dmg: join(fixture.artifactDirectory, names.dmg),
+              zip: join(fixture.artifactDirectory, names.zip),
+              blockmap: join(fixture.artifactDirectory, names.blockmap),
+              metadata: join(fixture.artifactDirectory, names.metadata),
+            },
+            sizes: {
+              dmg: fixture.dmg.length,
+              zip: fixture.zip.length,
+              blockmap: fixture.blockmap.length,
+            },
+            dmgSha512: fixture.dmgSha512,
+            zipSha512: fixture.zipSha512,
+          })),
+          verifyIdentityContinuity: vi.fn(async () => {
+            throw failure;
+          }),
+          verifyReleaseApplicationContents,
+        },
+      ),
+    ).rejects.toBe(failure);
+    expect(verifyReleaseApplicationContents).not.toHaveBeenCalled();
+  });
+
+  it("requires three absolute paths at the standalone verifier boundary", () => {
+    const script = join(desktopRoot, "scripts/verify-macos-release.mjs");
+    const result = spawnSync(
+      process.execPath,
+      [script, "/synthetic/artifacts", "relative-baseline.app", "/synthetic/candidate.app"],
+      { cwd: desktopRoot, encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("expected absolute artifact, baseline, and loose candidate paths\n");
+  });
+
   it("validates both artifacts and exact regenerated blockmap bytes through the seam", async () => {
     const fixture = await releaseFixture();
     const temporary = deterministicTemporaryDirectory(fixture.root);

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -1,5 +1,15 @@
 import { createHash } from "node:crypto";
-import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -13,6 +23,7 @@ import {
   notarizeMacosDmg,
   promoteMacosReleaseEnvelope,
   requireDeveloperIdIdentity,
+  requireMacosBaselineApplication,
   requireNotarizationCredentials,
   runMacosRelease,
   sealMacosReleaseMetadata,
@@ -26,11 +37,21 @@ const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(desktopRoot, "../..");
 const feedUrl = "https://updates.example.test/stable/";
 const identity = "Enduragent Test (ABCDE12345)";
+const baselineApplication = "/synthetic/prior/Enduragent.app";
 const notarizationEnvironment = {
   APPLE_API_KEY: "/synthetic/AuthKey.p8",
   APPLE_API_KEY_ID: "SYNTHETICKEY",
   APPLE_API_ISSUER: "00000000-0000-0000-0000-000000000000",
 };
+const verifiedLooseIdentity = Object.freeze({
+  baselineVersion: "2026.7.1",
+  candidateVersion: "2026.7.2",
+  teamIdentifier: "FA494ACVTF",
+  candidateCodeIdentity: Object.freeze({
+    codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+    cdHash: "b".repeat(40),
+  }),
+});
 const temporaryRoots: string[] = [];
 
 afterEach(async () => {
@@ -55,6 +76,7 @@ async function metadataSealFixture() {
       desktopRoot: fixtureDesktopRoot,
       feedUrl,
       identity,
+      baselineApplication,
     },
     { readFile: versionReader() },
   );
@@ -102,6 +124,7 @@ describe("macOS release plan", () => {
         desktopRoot: "/synthetic/repository/apps/desktop",
         feedUrl,
         identity,
+        baselineApplication,
       },
       { readFile: readVersion },
     );
@@ -111,6 +134,7 @@ describe("macOS release plan", () => {
       "utf8",
     );
     expect(plan.version).toBe("2026.7.2");
+    expect(plan.baselineApplication).toBe(baselineApplication);
     expect(plan.artifactNames).toEqual({
       dmg: "Enduragent-2026.7.2-arm64.dmg",
       zip: "Enduragent-2026.7.2-arm64.zip",
@@ -174,6 +198,55 @@ describe("macOS release plan", () => {
     }
   });
 
+  it("requires an absolute signed baseline distinct from the build candidate", async () => {
+    expect(requireMacosBaselineApplication(baselineApplication)).toBe(baselineApplication);
+    for (const invalid of [
+      undefined,
+      "",
+      "Enduragent.app",
+      " /Applications/Enduragent.app",
+      "/bad\napp",
+    ]) {
+      expect(() => requireMacosBaselineApplication(invalid)).toThrow(
+        "signed baseline application path is invalid",
+      );
+    }
+    await expect(
+      createMacosReleasePlan(
+        {
+          repositoryRoot: "/synthetic/repository",
+          desktopRoot: "/synthetic/repository/apps/desktop",
+          feedUrl,
+          identity,
+          baselineApplication:
+            "/synthetic/repository/apps/desktop/dist/mac-arm64/../mac-arm64/Enduragent.app",
+        },
+        { readFile: versionReader() },
+      ),
+    ).rejects.toThrow("signed baseline application must differ from candidate");
+  });
+
+  it("fails baseline preflight before loading or invoking electron-builder", async () => {
+    const build = vi.fn(async (_options: MacosReleaseBuilderOptions) => []);
+    await expect(
+      runMacosRelease(
+        {
+          repositoryRoot: "/synthetic/repository",
+          desktopRoot: "/synthetic/repository/apps/desktop",
+          feedUrl,
+          identity,
+          baselineApplication: undefined,
+        },
+        {
+          readFile: versionReader(),
+          environment: notarizationEnvironment,
+          build,
+        },
+      ),
+    ).rejects.toThrow("signed baseline application path is invalid");
+    expect(build).not.toHaveBeenCalled();
+  });
+
   it("matches the pinned builder identity qualifier contract without reading a keychain", async () => {
     const localRequire = createRequire(import.meta.url);
     const builderRequire = createRequire(localRequire.resolve("electron-builder"));
@@ -218,6 +291,8 @@ describe("macOS release plan", () => {
     const verifyPackageLayout = vi.fn(async () => {});
     const executeFile = vi.fn(async () => {});
     const notarize = vi.fn(async () => {});
+    const verifyIdentityContinuity = vi.fn(async () => verifiedLooseIdentity);
+    const verifyReleaseApplicationContents = vi.fn(async () => {});
     const envelopePath =
       "/synthetic/repository/apps/desktop/dist/release-envelope-2026.7.2-mac-arm64";
     const temporaryEnvelopePath =
@@ -240,6 +315,7 @@ describe("macOS release plan", () => {
         desktopRoot: "/synthetic/repository/apps/desktop",
         feedUrl,
         identity,
+        baselineApplication,
       },
       {
         readFile: versionReader(),
@@ -249,6 +325,8 @@ describe("macOS release plan", () => {
         notarize,
         sealReleaseMetadata,
         verifyPackageLayout,
+        verifyIdentityContinuity,
+        verifyReleaseApplicationContents,
         promoteReleaseEnvelope,
         verifyReleaseArtifacts,
       },
@@ -279,10 +357,10 @@ describe("macOS release plan", () => {
       appleApiKeyId: notarizationEnvironment.APPLE_API_KEY_ID,
       appleApiIssuer: notarizationEnvironment.APPLE_API_ISSUER,
     });
+    expect(verifyIdentityContinuity).toHaveBeenCalledWith(baselineApplication, application, {
+      candidateVersion: "2026.7.2",
+    });
     expect(executeFile.mock.calls).toEqual([
-      ["/usr/bin/codesign", ["--verify", "--deep", "--strict", "--verbose=2", application]],
-      ["/usr/bin/xcrun", ["stapler", "validate", "-v", application]],
-      ["/usr/sbin/spctl", ["--assess", "--type", "execute", "--verbose=4", application]],
       ["/usr/bin/codesign", ["--verify", "--verbose=2", dmg]],
       ["/usr/bin/xcrun", ["stapler", "validate", "-v", dmg]],
       [
@@ -308,18 +386,27 @@ describe("macOS release plan", () => {
       },
       { executeFile },
     );
+    expect(verifyReleaseApplicationContents).toHaveBeenCalledWith(
+      temporaryEnvelopePath,
+      baselineApplication,
+      {
+        candidateVersion: "2026.7.2",
+        looseCandidateCodeIdentity: verifiedLooseIdentity.candidateCodeIdentity,
+      },
+      { executeFile },
+    );
     expect(result.envelopePath).toBe(envelopePath);
     expect(build.mock.invocationCallOrder[0]).toBeLessThan(
       verifyPackageLayout.mock.invocationCallOrder[0]!,
     );
     expect(verifyPackageLayout.mock.invocationCallOrder[0]).toBeLessThan(
-      executeFile.mock.invocationCallOrder[0]!,
+      verifyIdentityContinuity.mock.invocationCallOrder[0]!,
     );
-    expect(executeFile.mock.invocationCallOrder[2]).toBeLessThan(
+    expect(verifyIdentityContinuity.mock.invocationCallOrder[0]).toBeLessThan(
       notarize.mock.invocationCallOrder[0]!,
     );
     expect(notarize.mock.invocationCallOrder[0]).toBeLessThan(
-      executeFile.mock.invocationCallOrder[3]!,
+      executeFile.mock.invocationCallOrder[0]!,
     );
     expect(
       executeFile.mock.invocationCallOrder[executeFile.mock.invocationCallOrder.length - 1]!,
@@ -328,6 +415,9 @@ describe("macOS release plan", () => {
       promoteReleaseEnvelope.mock.invocationCallOrder[0]!,
     );
     expect(verifyReleaseArtifacts.mock.invocationCallOrder[0]).toBeLessThan(
+      verifyReleaseApplicationContents.mock.invocationCallOrder[0]!,
+    );
+    expect(verifyReleaseApplicationContents.mock.invocationCallOrder[0]).toBeLessThan(
       promotionCommitted.mock.invocationCallOrder[0]!,
     );
   });
@@ -346,6 +436,7 @@ describe("macOS release plan", () => {
           desktopRoot: "/synthetic/repository/apps/desktop",
           feedUrl,
           identity,
+          baselineApplication,
         },
         {
           readFile: versionReader(),
@@ -370,6 +461,7 @@ describe("macOS release plan", () => {
     const verifyPackageLayout = vi.fn(async () => {});
     const executeFile = vi.fn(async () => {});
     const notarize = vi.fn(async () => {});
+    const verifyIdentityContinuity = vi.fn(async () => verifiedLooseIdentity);
     const promoteReleaseEnvelope = vi.fn(async () => "/synthetic/envelope");
     await expect(
       runMacosRelease(
@@ -378,6 +470,7 @@ describe("macOS release plan", () => {
           desktopRoot: "/synthetic/repository/apps/desktop",
           feedUrl,
           identity,
+          baselineApplication,
         },
         {
           readFile: versionReader(),
@@ -387,6 +480,7 @@ describe("macOS release plan", () => {
           notarize,
           sealReleaseMetadata,
           verifyPackageLayout,
+          verifyIdentityContinuity,
           promoteReleaseEnvelope,
         },
       ),
@@ -394,7 +488,8 @@ describe("macOS release plan", () => {
     expect(build).toHaveBeenCalledOnce();
     expect(verifyPackageLayout).toHaveBeenCalledOnce();
     expect(notarize).toHaveBeenCalledOnce();
-    expect(executeFile).toHaveBeenCalledTimes(6);
+    expect(verifyIdentityContinuity).toHaveBeenCalledOnce();
+    expect(executeFile).toHaveBeenCalledTimes(3);
     expect(sealReleaseMetadata).toHaveBeenCalledOnce();
     expect(promoteReleaseEnvelope).not.toHaveBeenCalled();
   });
@@ -550,6 +645,7 @@ describe("macOS release plan", () => {
           desktopRoot: "/synthetic/repository/apps/desktop",
           feedUrl,
           identity,
+          baselineApplication,
         },
         {
           readFile: versionReader(),
@@ -563,13 +659,15 @@ describe("macOS release plan", () => {
     expect(sealReleaseMetadata).not.toHaveBeenCalled();
   });
 
-  it("stops before envelope promotion when mandatory native verification fails", async () => {
+  it("stops before notarization and promotion when signed identity continuity fails", async () => {
     const build = vi.fn(async (_options: MacosReleaseBuilderOptions) => []);
     const sealReleaseMetadata = vi.fn(async () => {});
     const verifyPackageLayout = vi.fn(async () => {});
-    const executeFile = vi.fn(async () => {
-      throw new Error("synthetic codesign failure");
+    const failure = new Error("synthetic identity continuity failure");
+    const verifyIdentityContinuity = vi.fn(async () => {
+      throw failure;
     });
+    const notarize = vi.fn(async () => {});
     const promoteReleaseEnvelope = vi.fn(async () => "/synthetic/envelope");
     const verifyReleaseArtifacts = vi.fn(async () => {});
 
@@ -580,6 +678,7 @@ describe("macOS release plan", () => {
           desktopRoot: "/synthetic/repository/apps/desktop",
           feedUrl,
           identity,
+          baselineApplication,
         },
         {
           readFile: versionReader(),
@@ -587,13 +686,15 @@ describe("macOS release plan", () => {
           build,
           sealReleaseMetadata,
           verifyPackageLayout,
-          executeFile,
+          verifyIdentityContinuity,
+          notarize,
           promoteReleaseEnvelope,
           verifyReleaseArtifacts,
         },
       ),
-    ).rejects.toThrow("macOS application signature verification failed");
-    expect(executeFile).toHaveBeenCalledOnce();
+    ).rejects.toBe(failure);
+    expect(verifyIdentityContinuity).toHaveBeenCalledOnce();
+    expect(notarize).not.toHaveBeenCalled();
     expect(promoteReleaseEnvelope).not.toHaveBeenCalled();
     expect(verifyReleaseArtifacts).not.toHaveBeenCalled();
   });
@@ -603,6 +704,7 @@ describe("macOS release plan", () => {
     const sealReleaseMetadata = vi.fn(async () => {});
     const verifyPackageLayout = vi.fn(async () => {});
     const executeFile = vi.fn(async () => {});
+    const verifyIdentityContinuity = vi.fn(async () => verifiedLooseIdentity);
     const notarize = vi.fn(async () => {
       throw new Error(`submission failed for ${notarizationEnvironment.APPLE_API_KEY_ID}`);
     });
@@ -616,12 +718,14 @@ describe("macOS release plan", () => {
           desktopRoot: "/synthetic/repository/apps/desktop",
           feedUrl,
           identity,
+          baselineApplication,
         },
         {
           readFile: versionReader(),
           environment: notarizationEnvironment,
           build,
           verifyPackageLayout,
+          verifyIdentityContinuity,
           executeFile,
           notarize,
           sealReleaseMetadata,
@@ -635,7 +739,8 @@ describe("macOS release plan", () => {
     expect(failure).toBeInstanceOf(TypeError);
     expect((failure as Error).message).toBe("macOS DMG notarization failed");
     expect((failure as Error).message).not.toContain(notarizationEnvironment.APPLE_API_KEY_ID);
-    expect(executeFile).toHaveBeenCalledTimes(3);
+    expect(verifyIdentityContinuity).toHaveBeenCalledOnce();
+    expect(executeFile).not.toHaveBeenCalled();
     expect(sealReleaseMetadata).not.toHaveBeenCalled();
     expect(promoteReleaseEnvelope).not.toHaveBeenCalled();
   });
@@ -674,7 +779,8 @@ describe("macOS release plan", () => {
     const notarize = vi.fn(async (options: { appPath: string }) => {
       await writeFile(options.appPath, stapledDmg);
     });
-    const verifyApplication = vi.fn(async () => {});
+    const verifyIdentityContinuity = vi.fn(async () => verifiedLooseIdentity);
+    const verifyReleaseApplicationContents = vi.fn(async () => {});
     const verifyDmg = vi.fn(async (path: string) => {
       expect(await readFile(path)).toEqual(stapledDmg);
     });
@@ -686,13 +792,15 @@ describe("macOS release plan", () => {
         desktopRoot: fixture.plan.builderOptions.projectDir,
         feedUrl,
         identity,
+        baselineApplication,
       },
       {
         readFile: versionReader(),
         environment: notarizationEnvironment,
         build: vi.fn(async () => []),
         verifyPackageLayout: vi.fn(async () => {}),
-        verifyApplication,
+        verifyIdentityContinuity,
+        verifyReleaseApplicationContents,
         notarize,
         verifyDmg,
         promoteReleaseEnvelope: vi.fn(
@@ -722,6 +830,52 @@ describe("macOS release plan", () => {
       size: stapledDmg.length,
     });
     expect(metadata.files[1]?.sha512).not.toBe(fixture.dmgSha512);
+  });
+
+  it("keeps exact packaged-application inspection inside the envelope TOCTOU guard", async () => {
+    const fixture = await metadataSealFixture();
+    const verifyReleaseArtifacts = vi.fn(async () => {});
+    const verifyReleaseApplicationContents = vi.fn(async (temporaryEnvelope: string) => {
+      await writeFile(
+        join(temporaryEnvelope, fixture.plan.artifactNames.zip),
+        "mutated during packaged application inspection\n",
+      );
+    });
+
+    await expect(
+      runMacosRelease(
+        {
+          repositoryRoot: join(fixture.artifactDirectory, "repository"),
+          desktopRoot: fixture.plan.builderOptions.projectDir,
+          feedUrl,
+          identity,
+          baselineApplication,
+        },
+        {
+          readFile: versionReader(),
+          environment: notarizationEnvironment,
+          build: vi.fn(async () => []),
+          verifyPackageLayout: vi.fn(async () => {}),
+          verifyIdentityContinuity: vi.fn(async () => verifiedLooseIdentity),
+          notarize: vi.fn(async () => {}),
+          verifyDmg: vi.fn(async () => {}),
+          verifyReleaseArtifacts,
+          verifyReleaseApplicationContents,
+        },
+      ),
+    ).rejects.toThrow("release envelope changed during verification");
+
+    expect(verifyReleaseArtifacts).toHaveBeenCalledOnce();
+    expect(verifyReleaseApplicationContents).toHaveBeenCalledOnce();
+    expect(verifyReleaseArtifacts.mock.invocationCallOrder[0]).toBeLessThan(
+      verifyReleaseApplicationContents.mock.invocationCallOrder[0]!,
+    );
+    await expect(lstat(macosReleaseEnvelopePath(fixture.plan))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(await readFile(join(fixture.artifactDirectory, fixture.plan.artifactNames.zip))).toEqual(
+      fixture.zip,
+    );
   });
 
   it("leaves builder metadata untouched when zip-only authority validation fails", async () => {
@@ -759,12 +913,10 @@ describe("macOS release plan", () => {
       ),
     );
 
-    const verifyEnvelope = vi.fn(async (temporaryPath: string) => {
-      expect(temporaryPath).not.toBe(macosReleaseEnvelopePath(fixture.plan));
-      await expect(lstat(macosReleaseEnvelopePath(fixture.plan))).rejects.toMatchObject({
-        code: "ENOENT",
-      });
-      expect((await readdir(temporaryPath)).sort()).toEqual(
+    const verifyEnvelope = vi.fn(async (candidatePath: string) => {
+      expect(candidatePath).toBe(macosReleaseEnvelopePath(fixture.plan));
+      expect((await lstat(candidatePath)).isDirectory()).toBe(true);
+      expect((await readdir(candidatePath)).sort()).toEqual(
         Object.values(fixture.plan.artifactNames).sort(),
       );
     });
@@ -817,11 +969,11 @@ describe("macOS release plan", () => {
     );
     const envelopePath = macosReleaseEnvelopePath(fixture.plan);
     const failure = new Error("semantic envelope rejection");
-    const rejectEnvelope = vi.fn(async (temporaryPath: string) => {
-      expect((await readdir(temporaryPath)).sort()).toEqual(
+    const rejectEnvelope = vi.fn(async (candidatePath: string) => {
+      expect(candidatePath).toBe(envelopePath);
+      expect((await readdir(candidatePath)).sort()).toEqual(
         Object.values(fixture.plan.artifactNames).sort(),
       );
-      await expect(lstat(envelopePath)).rejects.toMatchObject({ code: "ENOENT" });
       throw failure;
     });
 
@@ -844,7 +996,7 @@ describe("macOS release plan", () => {
     expect(acceptEnvelope).toHaveBeenCalledOnce();
   });
 
-  it("rejects a temp artifact changed by semantic verification before rename", async () => {
+  it("rejects a canonical artifact changed by semantic verification", async () => {
     const fixture = await metadataSealFixture();
     await sealMacosReleaseMetadata(fixture.plan);
     const mutateEnvelope = vi.fn(async (temporaryPath: string) => {
@@ -865,6 +1017,48 @@ describe("macOS release plan", () => {
         name.startsWith(`.release-envelope-${fixture.plan.version}-mac-arm64-`),
       ),
     ).toEqual([]);
+  });
+
+  it("rejects an entry swap at the final rename seam and removes only the bound envelope", async () => {
+    const fixture = await metadataSealFixture();
+    await sealMacosReleaseMetadata(fixture.plan);
+    const envelopePath = macosReleaseEnvelopePath(fixture.plan);
+    const renameAtCommit = vi.fn(async (source: string, destination: string) => {
+      await writeFile(
+        join(source, fixture.plan.artifactNames.zip),
+        "swapped at the final rename seam\n",
+      );
+      await rename(source, destination);
+    });
+
+    await expect(
+      promoteMacosReleaseEnvelope(fixture.plan, async () => {}, { rename: renameAtCommit }),
+    ).rejects.toThrow("release envelope changed during verification");
+
+    expect(renameAtCommit).toHaveBeenCalledOnce();
+    await expect(lstat(envelopePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects a whole-directory swap at the final rename seam without deleting the substitute", async () => {
+    const fixture = await metadataSealFixture();
+    await sealMacosReleaseMetadata(fixture.plan);
+    const envelopePath = macosReleaseEnvelopePath(fixture.plan);
+    const displacedOriginal = join(fixture.artifactDirectory, ".displaced-original-envelope");
+    const sentinelPath = join(envelopePath, "substitute-sentinel");
+    const renameAtCommit = vi.fn(async (source: string, destination: string) => {
+      await rename(source, displacedOriginal);
+      await mkdir(source, { mode: 0o700 });
+      await writeFile(join(source, "substitute-sentinel"), "preserve substitute\n");
+      await rename(source, destination);
+    });
+
+    await expect(
+      promoteMacosReleaseEnvelope(fixture.plan, async () => {}, { rename: renameAtCommit }),
+    ).rejects.toThrow("release envelope cleanup target changed");
+
+    expect(renameAtCommit).toHaveBeenCalledOnce();
+    expect(await readFile(sentinelPath, "utf8")).toBe("preserve substitute\n");
+    expect((await lstat(displacedOriginal)).isDirectory()).toBe(true);
   });
 
   it("rechecks builder source identity after semantic verification", async () => {
@@ -928,6 +1122,7 @@ describe("macOS release plan", () => {
             repositoryRoot: "/synthetic/repository",
             feedUrl,
             identity,
+            baselineApplication,
           },
           { readFile: versionReader(version) },
         ),
@@ -950,6 +1145,7 @@ describe("macOS release plan", () => {
           repositoryRoot: "/synthetic/repository",
           feedUrl: invalidFeedUrl,
           identity,
+          baselineApplication,
         },
         { readFile: versionReader() },
       ),
@@ -997,6 +1193,7 @@ describe("macOS release plan", () => {
       desktopRoot,
       feedUrl,
       identity,
+      baselineApplication,
     });
     const manifest = JSON.parse(
       await readFile(join(repositoryRoot, "packages/cycling-coach/package.json"), "utf8"),

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -52,6 +52,10 @@ const verifiedLooseIdentity = Object.freeze({
     cdHash: "b".repeat(40),
   }),
 });
+const verifiedBaselineApplication = Object.freeze({
+  baselineVersion: "2026.7.1",
+  teamIdentifier: "FA494ACVTF",
+});
 const temporaryRoots: string[] = [];
 
 afterEach(async () => {
@@ -62,6 +66,32 @@ afterEach(async () => {
 
 function versionReader(version = "2026.7.2") {
   return vi.fn(async () => JSON.stringify({ version }));
+}
+
+function baselineVerifier() {
+  return vi.fn(async () => verifiedBaselineApplication);
+}
+
+function verifiedReleaseArtifactsAt(artifactDirectory: string) {
+  const artifactNames = {
+    dmg: "Enduragent-2026.7.2-arm64.dmg",
+    zip: "Enduragent-2026.7.2-arm64.zip",
+    blockmap: "Enduragent-2026.7.2-arm64.zip.blockmap",
+    metadata: "latest-mac.yml" as const,
+  };
+  return Object.freeze({
+    version: "2026.7.2",
+    names: artifactNames,
+    paths: Object.freeze({
+      dmg: join(artifactDirectory, artifactNames.dmg),
+      zip: join(artifactDirectory, artifactNames.zip),
+      blockmap: join(artifactDirectory, artifactNames.blockmap),
+      metadata: join(artifactDirectory, artifactNames.metadata),
+    }),
+    sizes: Object.freeze({ dmg: 1, zip: 1, blockmap: 1 }),
+    dmgSha512: "synthetic-dmg-sha512",
+    zipSha512: "synthetic-zip-sha512",
+  });
 }
 
 async function metadataSealFixture() {
@@ -247,6 +277,70 @@ describe("macOS release plan", () => {
     expect(build).not.toHaveBeenCalled();
   });
 
+  it("rejects a missing absolute baseline before invoking electron-builder", async () => {
+    const build = vi.fn(async (_options: MacosReleaseBuilderOptions) => []);
+
+    await expect(
+      runMacosRelease(
+        {
+          repositoryRoot: "/synthetic/repository",
+          desktopRoot: "/synthetic/repository/apps/desktop",
+          feedUrl,
+          identity,
+          baselineApplication: "/synthetic/missing/Enduragent.app",
+        },
+        {
+          readFile: versionReader(),
+          environment: notarizationEnvironment,
+          build,
+        },
+      ),
+    ).rejects.toThrow("baseline application bundle is invalid");
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid signed baseline before invoking electron-builder", async () => {
+    const root = await mkdtemp(join(tmpdir(), "desktop-invalid-release-baseline-"));
+    temporaryRoots.push(root);
+    const invalidBaseline = join(root, "Enduragent.app");
+    await mkdir(join(invalidBaseline, "Contents/Resources"), { recursive: true });
+    await Promise.all([
+      writeFile(join(invalidBaseline, "Contents/Info.plist"), "synthetic plist\n"),
+      writeFile(join(invalidBaseline, "Contents/Resources/app.asar"), "synthetic ASAR\n"),
+    ]);
+    const build = vi.fn(async (_options: MacosReleaseBuilderOptions) => []);
+    const executeFile = vi.fn(async () => {
+      throw new Error("synthetic invalid baseline signature");
+    });
+
+    await expect(
+      runMacosRelease(
+        {
+          repositoryRoot: "/synthetic/repository",
+          desktopRoot: "/synthetic/repository/apps/desktop",
+          feedUrl,
+          identity,
+          baselineApplication: invalidBaseline,
+        },
+        {
+          readFile: versionReader(),
+          environment: notarizationEnvironment,
+          build,
+          executeFile,
+        },
+      ),
+    ).rejects.toThrow("macOS application signature verification failed");
+    expect(executeFile).toHaveBeenCalledOnce();
+    expect(executeFile).toHaveBeenCalledWith("/usr/bin/codesign", [
+      "--verify",
+      "--deep",
+      "--strict",
+      "--verbose=2",
+      invalidBaseline,
+    ]);
+    expect(build).not.toHaveBeenCalled();
+  });
+
   it("matches the pinned builder identity qualifier contract without reading a keychain", async () => {
     const localRequire = createRequire(import.meta.url);
     const builderRequire = createRequire(localRequire.resolve("electron-builder"));
@@ -291,6 +385,7 @@ describe("macOS release plan", () => {
     const verifyPackageLayout = vi.fn(async () => {});
     const executeFile = vi.fn(async () => {});
     const notarize = vi.fn(async () => {});
+    const verifyBaselineApplication = baselineVerifier();
     const verifyIdentityContinuity = vi.fn(async () => verifiedLooseIdentity);
     const verifyReleaseApplicationContents = vi.fn(async () => {});
     const envelopePath =
@@ -308,7 +403,9 @@ describe("macOS release plan", () => {
         return envelopePath;
       },
     );
-    const verifyReleaseArtifacts = vi.fn(async () => {});
+    const verifyReleaseArtifacts = vi.fn(async (artifactDirectory: string) =>
+      verifiedReleaseArtifactsAt(artifactDirectory),
+    );
     const result = await runMacosRelease(
       {
         repositoryRoot: "/synthetic/repository",
@@ -324,6 +421,7 @@ describe("macOS release plan", () => {
         executeFile,
         notarize,
         sealReleaseMetadata,
+        verifyBaselineApplication,
         verifyPackageLayout,
         verifyIdentityContinuity,
         verifyReleaseApplicationContents,
@@ -349,6 +447,10 @@ describe("macOS release plan", () => {
     );
     const application = "/synthetic/repository/apps/desktop/dist/mac-arm64/Enduragent.app";
     const dmg = "/synthetic/repository/apps/desktop/dist/Enduragent-2026.7.2-arm64.dmg";
+    expect(verifyBaselineApplication).toHaveBeenCalledOnce();
+    expect(verifyBaselineApplication).toHaveBeenCalledWith(baselineApplication, {
+      candidateVersion: "2026.7.2",
+    });
     expect(notarize).toHaveBeenCalledOnce();
     expect(notarize).toHaveBeenCalledWith({
       appPath: dmg,
@@ -360,6 +462,7 @@ describe("macOS release plan", () => {
     expect(verifyIdentityContinuity).toHaveBeenCalledWith(baselineApplication, application, {
       candidateVersion: "2026.7.2",
     });
+    expect(verifyIdentityContinuity).toHaveBeenCalledTimes(2);
     expect(executeFile.mock.calls).toEqual([
       ["/usr/bin/codesign", ["--verify", "--verbose=2", dmg]],
       ["/usr/bin/xcrun", ["stapler", "validate", "-v", dmg]],
@@ -384,7 +487,7 @@ describe("macOS release plan", () => {
         repositoryRoot: "/synthetic/repository",
         readVersionFile: expect.any(Function),
       },
-      { executeFile },
+      expect.objectContaining({ executeFile }),
     );
     expect(verifyReleaseApplicationContents).toHaveBeenCalledWith(
       temporaryEnvelopePath,
@@ -393,9 +496,12 @@ describe("macOS release plan", () => {
         candidateVersion: "2026.7.2",
         looseCandidateCodeIdentity: verifiedLooseIdentity.candidateCodeIdentity,
       },
-      { executeFile },
+      expect.objectContaining({ executeFile }),
     );
     expect(result.envelopePath).toBe(envelopePath);
+    expect(verifyBaselineApplication.mock.invocationCallOrder[0]).toBeLessThan(
+      build.mock.invocationCallOrder[0]!,
+    );
     expect(build.mock.invocationCallOrder[0]).toBeLessThan(
       verifyPackageLayout.mock.invocationCallOrder[0]!,
     );
@@ -415,6 +521,9 @@ describe("macOS release plan", () => {
       promoteReleaseEnvelope.mock.invocationCallOrder[0]!,
     );
     expect(verifyReleaseArtifacts.mock.invocationCallOrder[0]).toBeLessThan(
+      verifyIdentityContinuity.mock.invocationCallOrder[1]!,
+    );
+    expect(verifyIdentityContinuity.mock.invocationCallOrder[1]).toBeLessThan(
       verifyReleaseApplicationContents.mock.invocationCallOrder[0]!,
     );
     expect(verifyReleaseApplicationContents.mock.invocationCallOrder[0]).toBeLessThan(
@@ -443,6 +552,7 @@ describe("macOS release plan", () => {
           environment: notarizationEnvironment,
           build,
           sealReleaseMetadata,
+          verifyBaselineApplication: baselineVerifier(),
           verifyPackageLayout,
         },
       ),
@@ -479,6 +589,7 @@ describe("macOS release plan", () => {
           executeFile,
           notarize,
           sealReleaseMetadata,
+          verifyBaselineApplication: baselineVerifier(),
           verifyPackageLayout,
           verifyIdentityContinuity,
           promoteReleaseEnvelope,
@@ -669,7 +780,9 @@ describe("macOS release plan", () => {
     });
     const notarize = vi.fn(async () => {});
     const promoteReleaseEnvelope = vi.fn(async () => "/synthetic/envelope");
-    const verifyReleaseArtifacts = vi.fn(async () => {});
+    const verifyReleaseArtifacts = vi.fn(async (artifactDirectory: string) =>
+      verifiedReleaseArtifactsAt(artifactDirectory),
+    );
 
     await expect(
       runMacosRelease(
@@ -685,6 +798,7 @@ describe("macOS release plan", () => {
           environment: notarizationEnvironment,
           build,
           sealReleaseMetadata,
+          verifyBaselineApplication: baselineVerifier(),
           verifyPackageLayout,
           verifyIdentityContinuity,
           notarize,
@@ -724,6 +838,7 @@ describe("macOS release plan", () => {
           readFile: versionReader(),
           environment: notarizationEnvironment,
           build,
+          verifyBaselineApplication: baselineVerifier(),
           verifyPackageLayout,
           verifyIdentityContinuity,
           executeFile,
@@ -798,6 +913,7 @@ describe("macOS release plan", () => {
         readFile: versionReader(),
         environment: notarizationEnvironment,
         build: vi.fn(async () => []),
+        verifyBaselineApplication: baselineVerifier(),
         verifyPackageLayout: vi.fn(async () => {}),
         verifyIdentityContinuity,
         verifyReleaseApplicationContents,
@@ -812,7 +928,9 @@ describe("macOS release plan", () => {
             return envelopePath;
           },
         ),
-        verifyReleaseArtifacts: vi.fn(async () => {}),
+        verifyReleaseArtifacts: vi.fn(async (artifactDirectory: string) =>
+          verifiedReleaseArtifactsAt(artifactDirectory),
+        ),
       },
     );
 
@@ -834,7 +952,9 @@ describe("macOS release plan", () => {
 
   it("keeps exact packaged-application inspection inside the envelope TOCTOU guard", async () => {
     const fixture = await metadataSealFixture();
-    const verifyReleaseArtifacts = vi.fn(async () => {});
+    const verifyReleaseArtifacts = vi.fn(async (artifactDirectory: string) =>
+      verifiedReleaseArtifactsAt(artifactDirectory),
+    );
     const verifyReleaseApplicationContents = vi.fn(async (temporaryEnvelope: string) => {
       await writeFile(
         join(temporaryEnvelope, fixture.plan.artifactNames.zip),
@@ -855,6 +975,7 @@ describe("macOS release plan", () => {
           readFile: versionReader(),
           environment: notarizationEnvironment,
           build: vi.fn(async () => []),
+          verifyBaselineApplication: baselineVerifier(),
           verifyPackageLayout: vi.fn(async () => {}),
           verifyIdentityContinuity: vi.fn(async () => verifiedLooseIdentity),
           notarize: vi.fn(async () => {}),


### PR DESCRIPTION
## Summary

- bind the loose, ZIP, and DMG applications to one signed macOS identity and candidate code identity
- securely preflight the signed baseline before invoking the expensive builder, then recheck continuity after the build
- make the standalone release verifier validate artifact integrity, loose-candidate continuity, and packaged application contents

## Verification

- 151 focused release and development-identity tests passed
- full Desktop suite passed: 1160 tests, 16 expected skips
- Desktop TypeScript, syntax, lint, formatting, and diff checks passed
- independent adversarial review found no remaining release blocker

This is a fail-closed local/release-operator guard. A genuine signed baseline and candidate remain required for the real release run.
