### PR TITLE
test(desktop): exercise packaged Telegram lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
   desktop-packaged-self-test:
     runs-on: macos-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       CI: macos
     steps:
@@ -119,3 +119,7 @@ jobs:
       - run: pnpm --filter @enduragent/desktop test:packaged-self-test
       - run: pnpm --filter @enduragent/desktop verify:package-layout
       - run: pnpm --filter @enduragent/desktop run smoke:security -- --mode=packaged --output=/tmp/desktop-security-packaged
+      - run: pnpm --filter @enduragent/desktop package:telegram-acceptance
+      - run: pnpm --filter @enduragent/desktop test:telegram-packaged
+        env:
+          ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT: "1"

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ workers/
 .DS_Store
 .idea/
 .obsidian/
-scripts/
+/scripts/
 .claude
 .codex/
 CLAUDE.local.md

--- a/apps/desktop/electron.telegram-acceptance.vite.config.ts
+++ b/apps/desktop/electron.telegram-acceptance.vite.config.ts
@@ -17,6 +17,9 @@ export default defineConfig(
           input: {
             index: resolve(desktopRoot, "tests/fixtures/packaged-telegram/main-entry.ts"),
           },
+          output: {
+            chunkFileNames: "[name]-[hash].js",
+          },
         },
       },
     },

--- a/apps/desktop/electron.telegram-acceptance.vite.config.ts
+++ b/apps/desktop/electron.telegram-acceptance.vite.config.ts
@@ -1,0 +1,24 @@
+import { resolve } from "node:path";
+import { defineConfig, mergeConfig } from "electron-vite";
+import { createDesktopViteConfig } from "./electron.vite.config.js";
+
+const desktopRoot = import.meta.dirname;
+
+const base = createDesktopViteConfig({
+  outputRoot: resolve(desktopRoot, "dist/telegram-acceptance-build/out"),
+  daemonUtilityEntry: resolve(desktopRoot, "tests/fixtures/packaged-telegram/daemon-utility.ts"),
+});
+
+export default defineConfig(
+  mergeConfig(base, {
+    main: {
+      build: {
+        rollupOptions: {
+          input: {
+            index: resolve(desktopRoot, "tests/fixtures/packaged-telegram/main-entry.ts"),
+          },
+        },
+      },
+    },
+  }),
+);

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,55 +1,70 @@
 import { resolve } from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+import { defineConfig, externalizeDepsPlugin, type UserConfig } from "electron-vite";
 import { appVersionDefine } from "../desktop-renderer/app-version.mjs";
 
 const desktopRoot = import.meta.dirname;
 
-export default defineConfig({
-  main: {
-    plugins: [externalizeDepsPlugin()],
-    build: {
-      rollupOptions: {
-        input: {
-          index: resolve(desktopRoot, "src/main/index.ts"),
-          "daemon-utility": resolve(desktopRoot, "src/utility/daemon.ts"),
+export function createDesktopViteConfig(
+  options: {
+    readonly outputRoot?: string;
+    readonly daemonUtilityEntry?: string;
+  } = {},
+): UserConfig {
+  const outputRoot = options.outputRoot ?? resolve(desktopRoot, "out");
+  const daemonUtilityEntry =
+    options.daemonUtilityEntry ?? resolve(desktopRoot, "src/utility/daemon.ts");
+
+  return {
+    main: {
+      plugins: [externalizeDepsPlugin()],
+      build: {
+        outDir: resolve(outputRoot, "main"),
+        rollupOptions: {
+          input: {
+            index: resolve(desktopRoot, "src/main/index.ts"),
+            "daemon-utility": daemonUtilityEntry,
+          },
         },
       },
     },
-  },
-  preload: {
-    plugins: [externalizeDepsPlugin()],
-    build: {
-      rollupOptions: {
-        input: {
-          index: resolve(desktopRoot, "src/preload/index.ts"),
-          tray: resolve(desktopRoot, "src/preload/tray.ts"),
-        },
-        output: { format: "cjs", entryFileNames: "[name].cjs" },
-      },
-    },
-  },
-  renderer: {
-    root: resolve(desktopRoot, "../desktop-renderer"),
-    plugins: [react(), tailwindcss()],
-    define: appVersionDefine(),
-    optimizeDeps: { include: ["lucide-react"] },
-    server: {
-      host: "127.0.0.1",
-      port: 5173,
-      strictPort: true,
-      hmr: { protocol: "ws", host: "127.0.0.1", port: 5173 },
-    },
-    build: {
-      outDir: resolve(desktopRoot, "out/renderer"),
-      emptyOutDir: true,
-      rollupOptions: {
-        input: {
-          index: resolve(desktopRoot, "../desktop-renderer/index.html"),
-          tray: resolve(desktopRoot, "../desktop-renderer/tray.html"),
+    preload: {
+      plugins: [externalizeDepsPlugin()],
+      build: {
+        outDir: resolve(outputRoot, "preload"),
+        rollupOptions: {
+          input: {
+            index: resolve(desktopRoot, "src/preload/index.ts"),
+            tray: resolve(desktopRoot, "src/preload/tray.ts"),
+          },
+          output: { format: "cjs", entryFileNames: "[name].cjs" },
         },
       },
     },
-  },
-});
+    renderer: {
+      root: resolve(desktopRoot, "../desktop-renderer"),
+      plugins: [react(), tailwindcss()],
+      define: appVersionDefine(),
+      optimizeDeps: { include: ["lucide-react"] },
+      server: {
+        host: "127.0.0.1",
+        port: 5173,
+        strictPort: true,
+        hmr: { protocol: "ws", host: "127.0.0.1", port: 5173 },
+      },
+      build: {
+        outDir: resolve(outputRoot, "renderer"),
+        emptyOutDir: true,
+        rollupOptions: {
+          input: {
+            index: resolve(desktopRoot, "../desktop-renderer/index.html"),
+            tray: resolve(desktopRoot, "../desktop-renderer/tray.html"),
+          },
+        },
+      },
+    },
+  };
+}
+
+export default defineConfig(createDesktopViteConfig());

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,6 +10,7 @@
     "check": "tsc --noEmit",
     "package:dir": "pnpm build:self-test-resources && electron-vite build && electron-builder --dir",
     "package:mac": "pnpm build:self-test-resources && electron-vite build && node scripts/macos-release-plan.mjs",
+    "package:telegram-acceptance": "pnpm build:self-test-resources && electron-vite build --config electron.telegram-acceptance.vite.config.ts && node scripts/package-telegram-acceptance.mjs",
     "build:self-test-resources": "tsx scripts/build-self-test-resources.ts",
     "stage:extra-resources": "node scripts/stage-extra-resources.mjs",
     "test:self-test-resources": "vitest run tests/self-test-resources.test.ts",
@@ -20,6 +21,7 @@
     "smoke:security": "node scripts/electron-smoke.mjs security",
     "accept:residency": "node ./scripts/accept-residency.mjs",
     "test:safe-storage-packaged": "node scripts/test-safe-storage-packaged.mjs",
+    "test:telegram-packaged": "tsx scripts/test-packaged-telegram.ts",
     "test": "vitest run"
   },
   "dependencies": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,7 +10,7 @@
     "check": "tsc --noEmit",
     "package:dir": "pnpm build:self-test-resources && electron-vite build && electron-builder --dir",
     "package:mac": "pnpm build:self-test-resources && electron-vite build && node scripts/macos-release-plan.mjs",
-    "package:telegram-acceptance": "pnpm build:self-test-resources && electron-vite build --config electron.telegram-acceptance.vite.config.ts && node scripts/package-telegram-acceptance.mjs",
+    "package:telegram-acceptance": "pnpm --filter '@enduragent/desktop^...' build && pnpm build:self-test-resources && electron-vite build --config electron.telegram-acceptance.vite.config.ts && node scripts/package-telegram-acceptance.mjs",
     "build:self-test-resources": "tsx scripts/build-self-test-resources.ts",
     "stage:extra-resources": "node scripts/stage-extra-resources.mjs",
     "test:self-test-resources": "vitest run tests/self-test-resources.test.ts",

--- a/apps/desktop/scripts/package-telegram-acceptance.mjs
+++ b/apps/desktop/scripts/package-telegram-acceptance.mjs
@@ -1,0 +1,102 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { extractFile } from "@electron/asar";
+import { parse } from "yaml";
+import {
+  createTelegramAcceptanceBuilderConfiguration,
+  TELEGRAM_ACCEPTANCE_APP_ID,
+  TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
+  verifyTelegramAcceptanceDesignatedRequirement,
+  verifyTelegramAcceptanceEntitlements,
+  verifyTelegramAcceptanceInfoPlist,
+  verifyTelegramAcceptanceManifest,
+  verifyTelegramAcceptanceSignature,
+} from "../tests/fixtures/packaged-telegram/package-acceptance.mjs";
+
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const outputDirectory = "dist/telegram-acceptance-package";
+const execute = promisify(execFile);
+
+async function verifySigningPayload(application) {
+  const scratch = await mkdtemp(join(tmpdir(), "enduragent-telegram-signature-"));
+  const entitlementsDer = join(scratch, "entitlements.der");
+  const entitlementsXml = join(scratch, "entitlements.plist");
+  const requirements = join(scratch, "requirements.txt");
+  try {
+    await execute("/usr/bin/codesign", [
+      "--display",
+      "--entitlements",
+      entitlementsDer,
+      "--der",
+      application,
+    ]);
+    await execute("/usr/bin/derq", [
+      "query",
+      "--xml",
+      "-i",
+      entitlementsDer,
+      "-o",
+      entitlementsXml,
+    ]);
+    const entitlementJson = await execute("/usr/bin/plutil", [
+      "-convert",
+      "json",
+      "-o",
+      "-",
+      entitlementsXml,
+    ]);
+    verifyTelegramAcceptanceEntitlements(JSON.parse(entitlementJson.stdout));
+    await execute("/usr/bin/codesign", ["--display", "--requirements", requirements, application]);
+    verifyTelegramAcceptanceDesignatedRequirement(await readFile(requirements, "utf8"));
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+}
+
+process.env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
+const { build } = await import("electron-builder");
+await rm(join(desktopRoot, outputDirectory), { recursive: true, force: true });
+const sourceManifest = JSON.parse(await readFile(join(desktopRoot, "package.json"), "utf8"));
+if (typeof sourceManifest.version !== "string" || sourceManifest.version.length === 0) {
+  throw new TypeError("Desktop package version is invalid");
+}
+const canonical = parse(await readFile(join(desktopRoot, "electron-builder.yml"), "utf8"));
+const artifacts = await build({
+  projectDir: desktopRoot,
+  publish: "never",
+  config: createTelegramAcceptanceBuilderConfiguration(canonical),
+});
+const application = join(
+  desktopRoot,
+  outputDirectory,
+  `mac-arm64/${TELEGRAM_ACCEPTANCE_PRODUCT_NAME}.app`,
+);
+await execute("/usr/bin/codesign", ["--verify", "--deep", "--strict", application]);
+const signature = await execute("/usr/bin/codesign", ["-d", "--verbose=4", application]);
+const signatureDescription = `${signature.stdout}\n${signature.stderr}`;
+verifyTelegramAcceptanceSignature(signatureDescription);
+await verifySigningPayload(application);
+const infoPlist = await execute("/usr/bin/plutil", [
+  "-convert",
+  "json",
+  "-o",
+  "-",
+  join(application, "Contents/Info.plist"),
+]);
+verifyTelegramAcceptanceInfoPlist(JSON.parse(infoPlist.stdout));
+const packagedManifest = JSON.parse(
+  extractFile(join(application, "Contents/Resources/app.asar"), "package.json").toString("utf8"),
+);
+verifyTelegramAcceptanceManifest(packagedManifest, sourceManifest.version);
+process.stdout.write(
+  `${JSON.stringify({
+    application,
+    appId: TELEGRAM_ACCEPTANCE_APP_ID,
+    signature: "ad-hoc",
+    artifacts: artifacts.map((path) => resolve(path)),
+  })}\n`,
+);

--- a/apps/desktop/scripts/package-telegram-acceptance.mjs
+++ b/apps/desktop/scripts/package-telegram-acceptance.mjs
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { extractFile, listPackage } from "@electron/asar";
 import { parse } from "yaml";
 import {
+  configureTelegramAcceptanceSigningEnvironment,
   createTelegramAcceptanceBuilderConfiguration,
   selectTelegramAcceptanceNestedTarget,
   TELEGRAM_ACCEPTANCE_APP_ID,
@@ -176,7 +177,7 @@ async function verifySigningPayload(application, expectedCdHash, rootDescription
   }
 }
 
-process.env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
+configureTelegramAcceptanceSigningEnvironment(process.env);
 const { build } = await import("electron-builder");
 await rm(join(desktopRoot, outputDirectory), { recursive: true, force: true });
 const sourceManifest = JSON.parse(await readFile(join(desktopRoot, "package.json"), "utf8"));

--- a/apps/desktop/scripts/package-telegram-acceptance.mjs
+++ b/apps/desktop/scripts/package-telegram-acceptance.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { extractFile } from "@electron/asar";
+import { extractFile, listPackage } from "@electron/asar";
 import { parse } from "yaml";
 import {
   createTelegramAcceptanceBuilderConfiguration,
@@ -20,6 +20,7 @@ import {
   verifyTelegramAcceptanceNestedListing,
   verifyTelegramAcceptanceNestedSignature,
   verifyTelegramAcceptanceSignature,
+  verifyTelegramAcceptanceWorkspaceRuntime,
 } from "../tests/fixtures/packaged-telegram/package-acceptance.mjs";
 
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -214,6 +215,9 @@ verifyTelegramAcceptanceInfoPlist(JSON.parse(infoPlist.stdout));
 const archive = join(application, "Contents/Resources/app.asar");
 const packagedManifest = JSON.parse(extractFile(archive, "package.json").toString("utf8"));
 verifyTelegramAcceptanceManifest(packagedManifest, sourceManifest.version);
+verifyTelegramAcceptanceWorkspaceRuntime(packagedManifest, listPackage(archive), (manifestPath) =>
+  JSON.parse(extractFile(archive, manifestPath).toString("utf8")),
+);
 const productionMain = verifyTelegramAcceptanceMainEntry(
   extractFile(archive, packagedManifest.main).toString("utf8"),
 );

--- a/apps/desktop/scripts/package-telegram-acceptance.mjs
+++ b/apps/desktop/scripts/package-telegram-acceptance.mjs
@@ -1,19 +1,24 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { extractFile } from "@electron/asar";
 import { parse } from "yaml";
 import {
   createTelegramAcceptanceBuilderConfiguration,
+  selectTelegramAcceptanceNestedTarget,
   TELEGRAM_ACCEPTANCE_APP_ID,
   TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
   verifyTelegramAcceptanceDesignatedRequirement,
   verifyTelegramAcceptanceEntitlements,
   verifyTelegramAcceptanceInfoPlist,
+  verifyTelegramAcceptanceMainEntry,
   verifyTelegramAcceptanceManifest,
+  verifyTelegramAcceptanceNestedEntitlements,
+  verifyTelegramAcceptanceNestedListing,
+  verifyTelegramAcceptanceNestedSignature,
   verifyTelegramAcceptanceSignature,
 } from "../tests/fixtures/packaged-telegram/package-acceptance.mjs";
 
@@ -21,37 +26,150 @@ const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const outputDirectory = "dist/telegram-acceptance-package";
 const execute = promisify(execFile);
 
-async function verifySigningPayload(application) {
-  const scratch = await mkdtemp(join(tmpdir(), "enduragent-telegram-signature-"));
-  const entitlementsDer = join(scratch, "entitlements.der");
-  const entitlementsXml = join(scratch, "entitlements.plist");
-  const requirements = join(scratch, "requirements.txt");
+function commandOutput(result) {
+  return `${result.stdout}\n${result.stderr}`;
+}
+
+function hasErrorCode(error, code) {
+  return error !== null && typeof error === "object" && error.code === code;
+}
+
+async function optionalReadFile(path) {
   try {
-    await execute("/usr/bin/codesign", [
-      "--display",
-      "--entitlements",
-      entitlementsDer,
-      "--der",
-      application,
-    ]);
-    await execute("/usr/bin/derq", [
-      "query",
-      "--xml",
-      "-i",
-      entitlementsDer,
-      "-o",
-      entitlementsXml,
-    ]);
-    const entitlementJson = await execute("/usr/bin/plutil", [
-      "-convert",
-      "json",
-      "-o",
-      "-",
-      entitlementsXml,
-    ]);
-    verifyTelegramAcceptanceEntitlements(JSON.parse(entitlementJson.stdout));
+    return await readFile(path);
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT")) return undefined;
+    throw error;
+  }
+}
+
+async function optionalRealpath(path) {
+  try {
+    return await realpath(path);
+  } catch (error) {
+    if (hasErrorCode(error, "ENOENT") || hasErrorCode(error, "ENOTDIR")) return undefined;
+    throw error;
+  }
+}
+
+function sameOrDescendant(root, target) {
+  const displacement = relative(root, target);
+  return (
+    displacement === "" ||
+    (!isAbsolute(displacement) && displacement !== ".." && !displacement.startsWith(`..${sep}`))
+  );
+}
+
+async function readEntitlements(target, scratch, label) {
+  const entitlementsDer = join(scratch, `${label}.der`);
+  const entitlementsXml = join(scratch, `${label}.plist`);
+  await execute("/usr/bin/codesign", [
+    "--display",
+    "--entitlements",
+    entitlementsDer,
+    "--der",
+    target,
+  ]);
+  if ((await optionalReadFile(entitlementsDer)) === undefined) return undefined;
+  await execute("/usr/bin/derq", ["query", "--xml", "-i", entitlementsDer, "-o", entitlementsXml]);
+  const entitlementJson = await execute("/usr/bin/plutil", [
+    "-convert",
+    "json",
+    "-o",
+    "-",
+    entitlementsXml,
+  ]);
+  return JSON.parse(entitlementJson.stdout);
+}
+
+async function resolveNestedTarget(applicationRoot, parentTarget, executable, nestedPath) {
+  const executablePath = await realpath(executable);
+  if (
+    !sameOrDescendant(applicationRoot, executablePath) ||
+    !sameOrDescendant(parentTarget, executablePath)
+  ) {
+    throw new TypeError("Telegram acceptance nested executable is outside its code object");
+  }
+
+  const searchRoots = [];
+  let searchRoot = dirname(executablePath);
+  while (sameOrDescendant(parentTarget, searchRoot)) {
+    searchRoots.push(searchRoot);
+    if (searchRoot === parentTarget) break;
+    const parent = dirname(searchRoot);
+    if (parent === searchRoot) break;
+    searchRoot = parent;
+  }
+  const candidates = [];
+  for (const root of searchRoots) {
+    const candidate = await optionalRealpath(join(root, nestedPath));
+    if (candidate === undefined) continue;
+    candidates.push(candidate);
+  }
+  return selectTelegramAcceptanceNestedTarget(applicationRoot, candidates);
+}
+
+async function verifyNestedSigning(application, rootDescription, scratch) {
+  const applicationRoot = await realpath(application);
+  const pending = [{ target: applicationRoot, description: rootDescription, root: true }];
+  const seen = new Set([applicationRoot]);
+  let entitlementIndex = 0;
+
+  while (pending.length > 0) {
+    const current = pending.shift();
+    const listing = verifyTelegramAcceptanceNestedListing(current.description);
+    const executable = await realpath(listing.executable);
+    if (
+      !sameOrDescendant(applicationRoot, executable) ||
+      !sameOrDescendant(current.target, executable)
+    ) {
+      throw new TypeError("Telegram acceptance nested executable is outside its code object");
+    }
+    if (!current.root) {
+      verifyTelegramAcceptanceNestedSignature(current.description);
+      verifyTelegramAcceptanceNestedEntitlements(
+        await readEntitlements(
+          current.target,
+          scratch,
+          `nested-entitlements-${entitlementIndex++}`,
+        ),
+      );
+    }
+    for (const nestedPath of listing.nested) {
+      const target = await resolveNestedTarget(
+        applicationRoot,
+        current.target,
+        listing.executable,
+        nestedPath,
+      );
+      if (seen.has(target)) {
+        throw new TypeError("Telegram acceptance nested code target is duplicated");
+      }
+      seen.add(target);
+      const displayed = await execute("/usr/bin/codesign", [
+        "--display",
+        "--deep",
+        "--verbose=4",
+        target,
+      ]);
+      pending.push({ target, description: commandOutput(displayed), root: false });
+    }
+  }
+}
+
+async function verifySigningPayload(application, expectedCdHash, rootDescription) {
+  const scratch = await mkdtemp(join(tmpdir(), "enduragent-telegram-signature-"));
+  const requirements = join(scratch, "root-requirements.txt");
+  try {
+    verifyTelegramAcceptanceEntitlements(
+      await readEntitlements(application, scratch, "root-entitlements"),
+    );
     await execute("/usr/bin/codesign", ["--display", "--requirements", requirements, application]);
-    verifyTelegramAcceptanceDesignatedRequirement(await readFile(requirements, "utf8"));
+    verifyTelegramAcceptanceDesignatedRequirement(
+      await readFile(requirements, "utf8"),
+      expectedCdHash,
+    );
+    await verifyNestedSigning(application, rootDescription, scratch);
   } finally {
     await rm(scratch, { recursive: true, force: true });
   }
@@ -76,10 +194,15 @@ const application = join(
   `mac-arm64/${TELEGRAM_ACCEPTANCE_PRODUCT_NAME}.app`,
 );
 await execute("/usr/bin/codesign", ["--verify", "--deep", "--strict", application]);
-const signature = await execute("/usr/bin/codesign", ["-d", "--verbose=4", application]);
-const signatureDescription = `${signature.stdout}\n${signature.stderr}`;
-verifyTelegramAcceptanceSignature(signatureDescription);
-await verifySigningPayload(application);
+const signature = await execute("/usr/bin/codesign", [
+  "--display",
+  "--deep",
+  "--verbose=4",
+  application,
+]);
+const signatureDescription = commandOutput(signature);
+const signatureCdHash = verifyTelegramAcceptanceSignature(signatureDescription);
+await verifySigningPayload(application, signatureCdHash, signatureDescription);
 const infoPlist = await execute("/usr/bin/plutil", [
   "-convert",
   "json",
@@ -88,10 +211,15 @@ const infoPlist = await execute("/usr/bin/plutil", [
   join(application, "Contents/Info.plist"),
 ]);
 verifyTelegramAcceptanceInfoPlist(JSON.parse(infoPlist.stdout));
-const packagedManifest = JSON.parse(
-  extractFile(join(application, "Contents/Resources/app.asar"), "package.json").toString("utf8"),
-);
+const archive = join(application, "Contents/Resources/app.asar");
+const packagedManifest = JSON.parse(extractFile(archive, "package.json").toString("utf8"));
 verifyTelegramAcceptanceManifest(packagedManifest, sourceManifest.version);
+const productionMain = verifyTelegramAcceptanceMainEntry(
+  extractFile(archive, packagedManifest.main).toString("utf8"),
+);
+if (extractFile(archive, productionMain).length === 0) {
+  throw new TypeError("Telegram acceptance production main is empty");
+}
 process.stdout.write(
   `${JSON.stringify({
     application,

--- a/apps/desktop/scripts/test-packaged-telegram.ts
+++ b/apps/desktop/scripts/test-packaged-telegram.ts
@@ -1,0 +1,1316 @@
+import { randomBytes } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { createServer as createHttpServer, type ServerResponse } from "node:http";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { connectCdp, reservePort, waitForPage } from "../tests/helpers/desktop-fixture.js";
+import {
+  prepareDisposableKeychain,
+  type DisposableKeychain,
+} from "../tests/fixtures/packaged-telegram/disposable-keychain.js";
+import {
+  classifyDarwinProcessObservation,
+  parseDarwinProcessObservation,
+  releaseAcceptanceStorage,
+  type DarwinProcessBirthIdentity,
+  type DarwinProcessObservation,
+} from "../tests/fixtures/packaged-telegram/process-safety.js";
+import {
+  ACCEPTANCE_OS_LOGIN_MARKER_ENV,
+  ACCEPTANCE_OS_LOGIN_MARKER_VALUE,
+} from "../tests/fixtures/packaged-telegram/startup-mode.js";
+
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const application = join(
+  desktopRoot,
+  "dist/telegram-acceptance-package/mac-arm64/Enduragent Telegram Acceptance.app",
+);
+const executable = join(application, "Contents/MacOS/Enduragent Telegram Acceptance");
+const TELEGRAM_VAULT_DIRECTORY = "telegram-channel-v1";
+const TELEGRAM_PROFILE_FILE = "profile.bin";
+const TELEGRAM_DESIRED_STATE_FILE = "desired-state.json";
+const BACKGROUND_PREFERENCE_DIRECTORY = "desktop-preferences-v1";
+const BACKGROUND_PREFERENCE_FILE = "background-at-login.json";
+const ONBOARDING_STORAGE_KEY = "enduragent.desktop.onboarding";
+const ONBOARDING_STORAGE_VALUE = '{"version":1,"completed":true}';
+const GENERIC_FAILURE = "Sorry, something went wrong. Please try again.";
+const BOT_USERNAME = "EnduragentAcceptanceBot";
+const BOT_ID = 71_234_567;
+const SENDER_ID = 42_424_242;
+
+interface CommandResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: Buffer;
+  readonly stderr: Buffer;
+}
+
+interface RunningApplication {
+  readonly child: ChildProcess;
+  readonly debugPort: number;
+  readonly exited: Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>;
+  readonly output: () => { readonly stdout: string; readonly stderr: string };
+}
+
+interface SentMessage {
+  readonly chatId: number;
+  readonly text: string;
+}
+
+interface GetUpdatesRequestObservation {
+  readonly sequence: number;
+  readonly offset: number;
+  readonly selectedUpdateIds: readonly number[];
+  readonly settled: boolean;
+}
+
+interface TelegramUpdate {
+  readonly update_id: number;
+  readonly message: {
+    readonly message_id: number;
+    readonly date: number;
+    readonly from: {
+      readonly id: number;
+      readonly is_bot: false;
+      readonly first_name: string;
+      readonly username: string;
+    };
+    readonly chat: {
+      readonly id: number;
+      readonly type: "private";
+      readonly first_name: string;
+      readonly username: string;
+    };
+    readonly text: string;
+    readonly entities?: readonly {
+      readonly offset: 0;
+      readonly length: number;
+      readonly type: "bot_command";
+    }[];
+  };
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}
+
+async function waitUntil(
+  description: string,
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 30_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await delay(50);
+  }
+  throw new Error(`timed out waiting for ${description}`);
+}
+
+function runCommand(
+  command: string,
+  args: readonly string[],
+  options: {
+    readonly input?: Buffer | string;
+    readonly allowFailure?: boolean;
+    readonly environment?: NodeJS.ProcessEnv;
+  } = {},
+): Promise<CommandResult> {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, {
+      env: options.environment,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.once("error", rejectRun);
+    child.once("exit", (code, signal) => {
+      const result = {
+        code,
+        signal,
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr),
+      };
+      if (!options.allowFailure && (code !== 0 || signal !== null)) {
+        rejectRun(new Error(`${command} failed`));
+      } else {
+        resolveRun(result);
+      }
+    });
+    child.stdin.end(options.input);
+  });
+}
+
+async function clipboardBytes(): Promise<Buffer> {
+  const result = await runCommand("/usr/bin/pbpaste", [], { allowFailure: true });
+  return result.stdout;
+}
+
+async function writeClipboard(value: Buffer | string): Promise<void> {
+  await runCommand("/usr/bin/pbcopy", [], { input: value });
+}
+
+function parseRequestBody(chunks: readonly Buffer[]): Record<string, unknown> {
+  const source = Buffer.concat(chunks).toString("utf8");
+  if (source.length === 0) return {};
+  const value = JSON.parse(source) as unknown;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Bot API payload is invalid");
+  }
+  return value as Record<string, unknown>;
+}
+
+function botApiResponse(response: ServerResponse, status: number, body: unknown): void {
+  const bytes = Buffer.from(JSON.stringify(body));
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": String(bytes.length),
+    connection: "close",
+  });
+  response.end(bytes);
+}
+
+function privateUpdate(updateId: number, messageId: number, text: string): TelegramUpdate {
+  const command = text.startsWith("/");
+  return {
+    update_id: updateId,
+    message: {
+      message_id: messageId,
+      date: 946_684_800 + messageId,
+      from: {
+        id: SENDER_ID,
+        is_bot: false,
+        first_name: "Acceptance",
+        username: "acceptance_athlete",
+      },
+      chat: {
+        id: SENDER_ID,
+        type: "private",
+        first_name: "Acceptance",
+        username: "acceptance_athlete",
+      },
+      text,
+      ...(command
+        ? { entities: [{ offset: 0 as const, length: text.length, type: "bot_command" as const }] }
+        : {}),
+    },
+  };
+}
+
+async function createTelegramBotApi(token: string) {
+  let updateSequence = 1_000;
+  let messageSequence = 2_000;
+  let pollRequests = 0;
+  let cancelledPolls = 0;
+  let getUpdatesSequence = 0;
+  const updates: TelegramUpdate[] = [];
+  const sentMessages: SentMessage[] = [];
+  const methods: string[] = [];
+  const contentTypes = new Set<string>();
+  const chatActions: Record<string, unknown>[] = [];
+  const getUpdatesRequests: {
+    sequence: number;
+    offset: number;
+    selectedUpdateIds: number[];
+    settled: boolean;
+  }[] = [];
+  const pending = new Set<{
+    readonly payload: Record<string, unknown>;
+    readonly response: ServerResponse;
+    readonly observation: (typeof getUpdatesRequests)[number];
+  }>();
+
+  const requestOffset = (payload: Record<string, unknown>): number =>
+    typeof payload.offset === "number" && Number.isSafeInteger(payload.offset) ? payload.offset : 0;
+  const selectUpdates = (payload: Record<string, unknown>): readonly TelegramUpdate[] => {
+    const offset = requestOffset(payload);
+    const limit =
+      typeof payload.limit === "number" && Number.isSafeInteger(payload.limit)
+        ? payload.limit
+        : 100;
+    return updates.filter((update) => update.update_id >= offset).slice(0, limit);
+  };
+  const settleGetUpdates = (
+    waiter: {
+      readonly response: ServerResponse;
+      readonly observation: (typeof getUpdatesRequests)[number];
+    },
+    selected: readonly TelegramUpdate[],
+  ): void => {
+    waiter.observation.selectedUpdateIds = selected.map((update) => update.update_id);
+    waiter.observation.settled = true;
+    if (!waiter.response.writableEnded) {
+      botApiResponse(waiter.response, 200, { ok: true, result: selected });
+    }
+  };
+  const settlePending = (): void => {
+    for (const waiter of pending) {
+      const selected = selectUpdates(waiter.payload);
+      if (selected.length === 0 && waiter.payload.limit !== 1) continue;
+      pending.delete(waiter);
+      settleGetUpdates(waiter, selected);
+    }
+  };
+
+  const http = createHttpServer((request, response) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    request.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > 1_048_576) request.destroy();
+      else chunks.push(chunk);
+    });
+    request.on("end", () => {
+      try {
+        if (request.method !== "POST" || request.url === undefined) {
+          botApiResponse(response, 405, { ok: false, error_code: 405 });
+          return;
+        }
+        const match = /^\/bot([^/]+)\/([A-Za-z][A-Za-z0-9]*)$/u.exec(request.url);
+        if (match === null || match[1] !== token) {
+          botApiResponse(response, 401, { ok: false, error_code: 401 });
+          return;
+        }
+        const method = match[2];
+        const contentType = request.headers["content-type"];
+        if (contentType !== "application/json") {
+          botApiResponse(response, 415, { ok: false, error_code: 415 });
+          return;
+        }
+        methods.push(method);
+        contentTypes.add(contentType);
+        const payload = parseRequestBody(chunks);
+        if (method === "getMe") {
+          botApiResponse(response, 200, {
+            ok: true,
+            result: {
+              id: BOT_ID,
+              is_bot: true,
+              first_name: "Enduragent Acceptance",
+              username: BOT_USERNAME,
+            },
+          });
+          return;
+        }
+        if (method === "getWebhookInfo") {
+          botApiResponse(response, 200, {
+            ok: true,
+            result: { url: "", has_custom_certificate: false, pending_update_count: 0 },
+          });
+          return;
+        }
+        if (["deleteWebhook", "setMyCommands"].includes(method)) {
+          botApiResponse(response, 200, { ok: true, result: true });
+          return;
+        }
+        if (method === "sendChatAction") {
+          chatActions.push(payload);
+          botApiResponse(response, 200, { ok: true, result: true });
+          return;
+        }
+        if (method === "getUpdates") {
+          pollRequests += 1;
+          const observation = {
+            sequence: ++getUpdatesSequence,
+            offset: requestOffset(payload),
+            selectedUpdateIds: [] as number[],
+            settled: false,
+          };
+          getUpdatesRequests.push(observation);
+          const selected = selectUpdates(payload);
+          if (selected.length > 0 || payload.limit === 1) {
+            settleGetUpdates({ response, observation }, selected);
+            return;
+          }
+          const waiter = { payload, response, observation };
+          pending.add(waiter);
+          response.once("close", () => {
+            if (pending.delete(waiter) && !response.writableEnded) cancelledPolls += 1;
+          });
+          return;
+        }
+        if (method === "sendMessage") {
+          if (typeof payload.text !== "string" || payload.text.length === 0) {
+            botApiResponse(response, 400, { ok: false, error_code: 400 });
+            return;
+          }
+          const chatId = Number(payload.chat_id);
+          if (!Number.isSafeInteger(chatId)) {
+            botApiResponse(response, 400, { ok: false, error_code: 400 });
+            return;
+          }
+          sentMessages.push({ chatId, text: payload.text });
+          botApiResponse(response, 200, {
+            ok: true,
+            result: {
+              message_id: ++messageSequence,
+              date: 946_684_800 + messageSequence,
+              chat: { id: chatId, type: "private", first_name: "Acceptance" },
+              text: payload.text,
+            },
+          });
+          return;
+        }
+        botApiResponse(response, 404, { ok: false, error_code: 404 });
+      } catch {
+        if (!response.writableEnded) {
+          botApiResponse(response, 400, { ok: false, error_code: 400 });
+        }
+      }
+    });
+  });
+  await new Promise<void>((resolveListen, rejectListen) => {
+    http.once("error", rejectListen);
+    http.listen({ host: "127.0.0.1", port: 0 }, () => resolveListen());
+  });
+  const address = http.address();
+  assert(address !== null && typeof address !== "string", "Bot API listener has no port");
+  const listenerPort = address.port;
+  return {
+    origin: `http://127.0.0.1:${listenerPort}`,
+    listenerPort,
+    enqueue(text: string): TelegramUpdate {
+      const update = privateUpdate(++updateSequence, ++messageSequence, text);
+      updates.push(update);
+      settlePending();
+      return update;
+    },
+    sentMessages,
+    chatActions,
+    pollCount: () => pollRequests,
+    cancelledPollCount: () => cancelledPolls,
+    activePollCount: () => pending.size,
+    getUpdatesRequests: (): readonly GetUpdatesRequestObservation[] =>
+      getUpdatesRequests.map((request) => ({
+        ...request,
+        selectedUpdateIds: [...request.selectedUpdateIds],
+      })),
+    methods: () => [...methods],
+    contentTypes: () => [...contentTypes],
+    async close() {
+      for (const waiter of pending) {
+        pending.delete(waiter);
+        settleGetUpdates(waiter, []);
+      }
+      http.closeAllConnections();
+      await new Promise<void>((resolveClose, rejectClose) => {
+        http.close((error) => (error === undefined ? resolveClose() : rejectClose(error)));
+      });
+    },
+  };
+}
+
+function launchApplication(
+  environment: NodeJS.ProcessEnv,
+  debugPort: number,
+  userData: string,
+): RunningApplication {
+  const args = [`--user-data-dir=${userData}`, `--remote-debugging-port=${debugPort}`];
+  const child = spawn(executable, args, {
+    env: environment,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  child.stderr?.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  const exited = new Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>((resolveExit, rejectExit) => {
+    child.once("error", rejectExit);
+    child.once("exit", (code, signal) => resolveExit({ code, signal }));
+  });
+  return { child, debugPort, exited, output: () => ({ stdout, stderr }) };
+}
+
+interface MainRendererTarget {
+  readonly type?: unknown;
+  readonly url?: unknown;
+  readonly webSocketDebuggerUrl?: unknown;
+}
+
+async function mainRendererTargets(port: number): Promise<readonly MainRendererTarget[]> {
+  const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+  if (!response.ok) throw new Error("Desktop debugging target list was unavailable");
+  const targets = (await response.json()) as readonly MainRendererTarget[];
+  return targets.filter(
+    (target) =>
+      target.type === "page" &&
+      typeof target.url === "string" &&
+      target.url.startsWith("enduragent://app/") &&
+      typeof target.webSocketDebuggerUrl === "string",
+  );
+}
+
+async function seedBackgroundAtLoginPreference(userData: string): Promise<void> {
+  const root = join(userData, BACKGROUND_PREFERENCE_DIRECTORY);
+  await mkdir(root, { recursive: true, mode: 0o700 });
+  await writeFile(
+    join(root, BACKGROUND_PREFERENCE_FILE),
+    `${JSON.stringify({
+      schemaVersion: 2,
+      enabled: true,
+      loginLaunchBehavior: "background",
+    })}\n`,
+    { mode: 0o600 },
+  );
+}
+
+async function cdpPage(port: number) {
+  const connection = await connectCdp(await waitForPage(port), () => undefined);
+  const evaluate = async <T>(expression: string): Promise<T> => {
+    const response = await connection.call("Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    if (response.exceptionDetails !== undefined) {
+      throw new Error("renderer evaluation failed");
+    }
+    const remote = response.result as { readonly value?: T } | undefined;
+    return remote?.value as T;
+  };
+  return {
+    connection,
+    evaluate,
+    async bodyText(): Promise<string> {
+      return evaluate<string>("document.body?.innerText ?? ''");
+    },
+    async domHtml(): Promise<string> {
+      return evaluate<string>("document.documentElement?.outerHTML ?? ''");
+    },
+    async telegramText(): Promise<string> {
+      return evaluate<string>(
+        "document.querySelector('section[aria-label=\"Telegram\"]')?.innerText ?? ''",
+      );
+    },
+    async clickButton(label: string): Promise<void> {
+      const clicked = await evaluate<boolean>(`(() => {
+        const label = ${JSON.stringify(label)};
+        const button = [...document.querySelectorAll("button")].find((candidate) =>
+          candidate.textContent?.trim() === label && !candidate.disabled
+        );
+        if (!(button instanceof HTMLButtonElement)) return false;
+        button.click();
+        return true;
+      })()`);
+      assert(clicked, `enabled renderer button was not found: ${label}`);
+    },
+    async screenshot(path: string): Promise<void> {
+      await connection.call("Page.enable");
+      const captured = await connection.call("Page.captureScreenshot", { format: "png" });
+      assert(typeof captured.data === "string", "renderer screenshot was not captured");
+      await writeFile(path, Buffer.from(captured.data, "base64"), { mode: 0o600 });
+    },
+    closeSocket(): void {
+      connection.socket.close();
+    },
+  };
+}
+
+async function waitForButton(
+  page: Awaited<ReturnType<typeof cdpPage>>,
+  label: string,
+): Promise<void> {
+  await waitUntil(`renderer button ${label}`, () =>
+    page.evaluate<boolean>(`[...document.querySelectorAll("button")].some((candidate) =>
+      candidate.textContent?.trim() === ${JSON.stringify(label)} && !candidate.disabled
+    )`),
+  );
+}
+
+async function telegramRendererSnapshot(
+  page: Awaited<ReturnType<typeof cdpPage>>,
+): Promise<unknown> {
+  return page.evaluate(`(async () => {
+    const bridgeStatus = await Promise.race([
+      window.enduragentAuth.telegramStatus().then(
+        (value) => ({ state: "resolved", value }),
+        (error) => ({ state: "rejected", error: String(error) }),
+      ),
+      new Promise((resolve) => setTimeout(() => resolve({ state: "timeout" }), 2_500)),
+    ]);
+    return {
+      rpc: document.documentElement.dataset.rpc ?? null,
+      telegram: document.querySelector('section[aria-label="Telegram"]')?.innerText ?? "",
+      buttons: [...document.querySelectorAll('section[aria-label="Telegram"] button')].map(
+        (button) => ({ label: button.textContent?.trim() ?? "", disabled: button.disabled }),
+      ),
+      bridgeStatus,
+    };
+  })()`);
+}
+
+async function waitForTelegramText(
+  page: Awaited<ReturnType<typeof cdpPage>>,
+  expected: string,
+): Promise<void> {
+  try {
+    await waitUntil(`Telegram UI text ${expected}`, async () =>
+      (await page.telegramText()).includes(expected),
+    );
+  } catch {
+    const visible = (await page.telegramText()).replace(/\s+/gu, " ").slice(0, 600);
+    throw new Error(`Telegram UI did not reach expected state: ${visible}`);
+  }
+}
+
+async function pairingCode(page: Awaited<ReturnType<typeof cdpPage>>): Promise<string> {
+  let code = "";
+  await waitUntil("Telegram pairing code", async () => {
+    code = await page.evaluate<string>(
+      "document.querySelector('[aria-label=\"Telegram pairing code\"]')?.textContent?.trim() ?? ''",
+    );
+    return /^[A-Z0-9]{6}$/u.test(code);
+  });
+  return code;
+}
+
+async function waitForSentMessage(
+  messages: readonly SentMessage[],
+  text: string,
+  start: number,
+): Promise<SentMessage> {
+  let found: SentMessage | undefined;
+  await waitUntil(
+    `Bot API reply ${text}`,
+    () => {
+      found = messages.slice(start).find((message) => message.text === text);
+      return found !== undefined;
+    },
+    40_000,
+  );
+  return found as SentMessage;
+}
+
+async function processTree(rootPid: number): Promise<readonly number[]> {
+  const result = await runCommand("/bin/ps", ["-axo", "pid=,ppid="]);
+  const children = new Map<number, number[]>();
+  for (const line of result.stdout.toString("utf8").split(/\r?\n/u)) {
+    const match = /^\s*(\d+)\s+(\d+)\s*$/u.exec(line);
+    if (match === null) continue;
+    const pid = Number(match[1]);
+    const parent = Number(match[2]);
+    const values = children.get(parent) ?? [];
+    values.push(pid);
+    children.set(parent, values);
+  }
+  const descendants: number[] = [];
+  const pending = [...(children.get(rootPid) ?? [])];
+  while (pending.length > 0) {
+    const pid = pending.shift() as number;
+    descendants.push(pid);
+    pending.push(...(children.get(pid) ?? []));
+  }
+  return descendants;
+}
+
+async function observeDarwinProcess(pid: number): Promise<DarwinProcessObservation> {
+  const result = await runCommand(
+    "/bin/ps",
+    ["-ww", "-p", String(pid), "-o", "pid=", "-o", "lstart=", "-o", "command="],
+    { allowFailure: true },
+  );
+  return parseDarwinProcessObservation(result, pid, application);
+}
+
+async function captureProcess(
+  pid: number,
+  trackedProcesses: Map<number, DarwinProcessBirthIdentity>,
+): Promise<boolean> {
+  const observation = await observeDarwinProcess(pid);
+  if (observation.state === "absent") return false;
+  const existing = trackedProcesses.get(pid);
+  if (
+    existing !== undefined &&
+    classifyDarwinProcessObservation(existing, observation) !== "same"
+  ) {
+    throw new TypeError(`packaged Desktop PID ${pid} was reused during capture`);
+  }
+  trackedProcesses.set(pid, observation.identity);
+  return true;
+}
+
+async function captureApplicationProcesses(
+  running: RunningApplication,
+  trackedProcesses: Map<number, DarwinProcessBirthIdentity>,
+): Promise<void> {
+  const rootPid = running.child.pid;
+  if (rootPid === undefined) return;
+  if (!(await captureProcess(rootPid, trackedProcesses))) return;
+  for (const pid of await processTree(rootPid)) {
+    await captureProcess(pid, trackedProcesses);
+  }
+}
+
+async function sameTrackedProcessRunning(identity: DarwinProcessBirthIdentity): Promise<boolean> {
+  const observation = await observeDarwinProcess(identity.pid);
+  const state = classifyDarwinProcessObservation(identity, observation);
+  if (state === "reused") {
+    throw new TypeError(`packaged Desktop PID ${identity.pid} was reused`);
+  }
+  return state === "same";
+}
+
+async function signalTrackedProcesses(
+  trackedProcesses: ReadonlyMap<number, DarwinProcessBirthIdentity>,
+  signal: NodeJS.Signals,
+): Promise<void> {
+  const errors: unknown[] = [];
+  for (const identity of trackedProcesses.values()) {
+    if (identity.pid === process.pid) {
+      errors.push(new Error("packaged Desktop process tracking included the acceptance driver"));
+      continue;
+    }
+    try {
+      if (!(await sameTrackedProcessRunning(identity))) continue;
+      try {
+        process.kill(identity.pid, signal);
+      } catch (error) {
+        if (await sameTrackedProcessRunning(identity)) errors.push(error);
+      }
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) throw new AggregateError(errors, `packaged Desktop ${signal} failed`);
+}
+
+async function waitForTrackedProcessExit(
+  trackedProcesses: ReadonlyMap<number, DarwinProcessBirthIdentity>,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    let running = false;
+    for (const identity of trackedProcesses.values()) {
+      if (await sameTrackedProcessRunning(identity)) running = true;
+    }
+    if (!running) return true;
+    await delay(50);
+  }
+  for (const identity of trackedProcesses.values()) {
+    if (await sameTrackedProcessRunning(identity)) return false;
+  }
+  return true;
+}
+
+async function terminateTrackedProcesses(
+  trackedProcesses: ReadonlyMap<number, DarwinProcessBirthIdentity>,
+): Promise<void> {
+  await signalTrackedProcesses(trackedProcesses, "SIGTERM");
+  if (await waitForTrackedProcessExit(trackedProcesses, 5_000)) return;
+  await signalTrackedProcesses(trackedProcesses, "SIGKILL");
+  if (!(await waitForTrackedProcessExit(trackedProcesses, 5_000))) {
+    throw new Error("packaged Desktop processes remained alive");
+  }
+}
+
+function portOpen(port: number): Promise<boolean> {
+  return new Promise((resolveOpen) => {
+    const socket = connect({ host: "127.0.0.1", port });
+    socket.once("connect", () => {
+      socket.destroy();
+      resolveOpen(true);
+    });
+    socket.once("error", () => resolveOpen(false));
+  });
+}
+
+async function gracefulQuit(
+  running: RunningApplication,
+  page: Awaited<ReturnType<typeof cdpPage>>,
+  debugPort: number,
+  trackedProcesses: Map<number, DarwinProcessBirthIdentity>,
+): Promise<void> {
+  await captureApplicationProcesses(running, trackedProcesses);
+  await page.connection.call("Browser.close").catch(() => undefined);
+  const exit = await Promise.race([running.exited, delay(30_000).then(() => undefined)]);
+  assert(exit !== undefined, "packaged Desktop did not quit gracefully");
+  assert(exit.code === 0 && exit.signal === null, "packaged Desktop quit was not clean");
+  assert(
+    await waitForTrackedProcessExit(trackedProcesses, 30_000),
+    "packaged Desktop process tree remained live after graceful quit",
+  );
+  await waitUntil("Desktop debugging listener exit", async () => !(await portOpen(debugPort)));
+}
+
+async function treeContains(root: string, value: string): Promise<boolean> {
+  const marker = Buffer.from(value);
+  for (const entry of await readdir(root, { recursive: true })) {
+    try {
+      if ((await readFile(join(root, entry))).includes(marker)) return true;
+    } catch {}
+  }
+  return false;
+}
+
+function modelCredentialFreeEnvironment(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const environment = { ...base };
+  for (const name of [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENAI_ACCESS_TOKEN",
+    "OPENROUTER_API_KEY",
+    "GOOGLE_GENERATIVE_AI_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "QWEN_API_KEY",
+    "MINIMAX_API_KEY",
+    "KIMI_API_KEY",
+    "ZAI_API_KEY",
+    "ENDURAGENT_LLM_API_KEY",
+  ]) {
+    delete environment[name];
+  }
+  return environment;
+}
+
+async function assertOutputSecretFree(
+  runningApplications: readonly RunningApplication[],
+  token: string,
+): Promise<void> {
+  const output = runningApplications.map((running) => JSON.stringify(running.output())).join("\n");
+  assert(!output.includes(token), "Telegram credential reached packaged process output");
+}
+
+async function main(): Promise<void> {
+  assert(process.platform === "darwin", "packaged Telegram acceptance requires macOS");
+  assert(process.arch === "arm64", "packaged Telegram acceptance requires macOS arm64");
+  assert(
+    process.env.CI === "true" || process.env.ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT === "1",
+    "packaged Telegram acceptance requires an explicit disposable safe-storage context",
+  );
+  assert(existsSync(executable), "packaged Telegram acceptance executable is missing");
+  const packageManifest = JSON.parse(await readFile(join(desktopRoot, "package.json"), "utf8")) as {
+    readonly version?: unknown;
+  };
+  assert(typeof packageManifest.version === "string", "Desktop package version is invalid");
+
+  const base = await realpath(process.platform === "darwin" ? "/tmp" : tmpdir());
+  const scratch = await mkdtemp(join(base, "eat-"));
+  const athleteHome = join(scratch, "athlete-home");
+  const configDirectory = join(athleteHome, "config");
+  const operatorHome = join(scratch, "operator-home");
+  const operatorPreferences = join(operatorHome, "Library/Preferences");
+  const operatorKeychains = join(operatorHome, "Library/Keychains");
+  const userData = join(scratch, "user-data");
+  const screenshots = join(scratch, "screenshots");
+  const results = join(scratch, "results");
+  const keychainPath = join(operatorKeychains, "acceptance.keychain-db");
+  const token = `123456789:${randomBytes(32).toString("base64url").slice(0, 35)}`;
+  const originalClipboard = await clipboardBytes();
+  const runningApplications: RunningApplication[] = [];
+  const trackedProcesses = new Map<number, DarwinProcessBirthIdentity>();
+  let keychain: DisposableKeychain | undefined;
+  let telegram: Awaited<ReturnType<typeof createTelegramBotApi>> | undefined;
+  let primary: RunningApplication | undefined;
+  let page: Awaited<ReturnType<typeof cdpPage>> | undefined;
+  let executionError: unknown;
+  let cleanupError: AggregateError | undefined;
+  let successResult:
+    | {
+        readonly ok: true;
+        readonly packagedVersion: string;
+        readonly productionChain: true;
+        readonly botApiOnlyFake: true;
+        readonly coldStartBackground: true;
+        readonly residentLifecycle: true;
+        readonly persistedDisable: true;
+        readonly removal: true;
+      }
+    | undefined;
+  try {
+    await Promise.all([
+      mkdir(configDirectory, { recursive: true, mode: 0o700 }),
+      mkdir(operatorPreferences, { recursive: true, mode: 0o700 }),
+      mkdir(operatorKeychains, { recursive: true, mode: 0o700 }),
+      mkdir(userData, { recursive: true, mode: 0o700 }),
+      mkdir(screenshots, { recursive: true, mode: 0o700 }),
+      mkdir(results, { recursive: true, mode: 0o700 }),
+    ]);
+    await writeFile(
+      join(configDirectory, "config.yaml"),
+      [
+        "data_source: store",
+        `data_dir: ${JSON.stringify(athleteHome)}`,
+        "llm:",
+        "  provider: openai-codex",
+        "  model: gpt-5.6-sol",
+        "intervals:",
+        "  api_key: ''",
+        "  athlete_id: '0'",
+        "session:",
+        "  timezone: UTC",
+        "",
+      ].join("\n"),
+      { mode: 0o600 },
+    );
+    const authProfilesPath = join(configDirectory, "auth-profiles.json");
+    assert(!existsSync(authProfilesPath), "model auth profile unexpectedly exists");
+
+    telegram = await createTelegramBotApi(token);
+    keychain = await prepareDisposableKeychain({
+      home: operatorHome,
+      path: keychainPath,
+      password: randomBytes(32).toString("base64url"),
+      environment: process.env,
+      run: (args, options) =>
+        runCommand("/usr/bin/security", args, {
+          allowFailure: true,
+          environment: options.environment,
+        }),
+    });
+    await keychain.activate();
+    assert(keychain.home === operatorHome, "keychain and application HOME differ");
+    let debugPort = await reservePort();
+    const environment = modelCredentialFreeEnvironment({
+      ...process.env,
+      HOME: operatorHome,
+      ENDURAGENT_HOME: athleteHome,
+      ENDURAGENT_ACCEPTANCE_TELEGRAM_BOT_API_ORIGIN: telegram.origin,
+      FORCE_COLOR: undefined,
+      CLICOLOR_FORCE: undefined,
+    });
+
+    primary = launchApplication(environment, debugPort, userData);
+    runningApplications.push(primary);
+    page = await cdpPage(debugPort);
+    await captureApplicationProcesses(primary, trackedProcesses);
+    await page.evaluate(
+      `localStorage.setItem(${JSON.stringify(ONBOARDING_STORAGE_KEY)}, ${JSON.stringify(ONBOARDING_STORAGE_VALUE)}); true`,
+    );
+    await waitForButton(page, "Settings");
+    await page.clickButton("Settings");
+    try {
+      await waitForButton(page, "Paste token from clipboard");
+    } catch (error) {
+      const renderer = JSON.stringify(await telegramRendererSnapshot(page)).replaceAll(
+        token,
+        "<redacted>",
+      );
+      const processOutput = JSON.stringify(primary.output()).replaceAll(token, "<redacted>");
+      throw new Error(
+        `${error instanceof Error ? error.message : "Telegram settings did not load"}; renderer=${renderer.slice(0, 2_000)}; profile=${existsSync(join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_PROFILE_FILE))}; desired-state=${existsSync(join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_DESIRED_STATE_FILE))}; Bot API methods=${telegram.methods().join(",") || "none"}; process=${processOutput.slice(0, 1_000)}`,
+      );
+    }
+
+    await writeClipboard(token);
+    await page.clickButton("Paste token from clipboard");
+    try {
+      await waitForTelegramText(page, `@${BOT_USERNAME}`);
+    } catch (error) {
+      const processOutput = JSON.stringify(primary.output()).replaceAll(token, "<redacted>");
+      throw new Error(
+        `${error instanceof Error ? error.message : "Telegram setup failed"}; Bot API methods=${telegram.methods().join(",") || "none"}; content-types=${telegram.contentTypes().join(",") || "none"}; process=${processOutput.slice(0, 1_000)}`,
+      );
+    }
+    assert((await clipboardBytes()).length === 0, "Telegram credential remained on the clipboard");
+    const profilePath = join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_PROFILE_FILE);
+    await waitUntil("encrypted Telegram profile", () => existsSync(profilePath));
+    assert(
+      !(await readFile(profilePath)).includes(Buffer.from(token)),
+      "Telegram profile is plaintext",
+    );
+    assert(!(await page.bodyText()).includes(token), "Telegram credential reached renderer text");
+    await assertOutputSecretFree(runningApplications, token);
+
+    await page.clickButton("Start pairing and turn on");
+    const code = await pairingCode(page);
+    telegram.enqueue(code);
+    await waitForTelegramText(page, "Paired with a primary Telegram user");
+    await waitForTelegramText(page, "Online");
+    await page.evaluate(`(() => {
+      const summary = [...document.querySelectorAll("summary")].find((candidate) =>
+        candidate.textContent?.trim() === "Advanced · allowed users"
+      );
+      if (!(summary instanceof HTMLElement)) return false;
+      summary.click();
+      return true;
+    })()`);
+    await waitForTelegramText(page, String(SENDER_ID));
+    await page.screenshot(join(screenshots, "paired.png"));
+
+    let messageStart = telegram.sentMessages.length;
+    telegram.enqueue("/version");
+    await waitForSentMessage(
+      telegram.sentMessages,
+      `Cycling Coach Desktop v${packageManifest.version}`,
+      messageStart,
+    );
+
+    messageStart = telegram.sentMessages.length;
+    const chatActionStart = telegram.chatActions.length;
+    telegram.enqueue("How should I train today?");
+    await waitForSentMessage(telegram.sentMessages, GENERIC_FAILURE, messageStart);
+    assert(
+      telegram.chatActions
+        .slice(chatActionStart)
+        .some((action) => action.action === "typing" && Number(action.chat_id) === SENDER_ID),
+      "free-text Telegram handling did not send a typing action",
+    );
+    assert(
+      !telegram.sentMessages
+        .slice(messageStart)
+        .some((message) => /(?:tempo|interval|recovery|ride|training plan)/iu.test(message.text)),
+      "credential-free acceptance unexpectedly produced substantive coaching",
+    );
+
+    const pairedDesired = JSON.parse(
+      await readFile(join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_DESIRED_STATE_FILE), "utf8"),
+    ) as { readonly enabled?: unknown };
+    assert(pairedDesired.enabled === true, "paired Telegram intent was not enabled before restart");
+    const pairedAllowed = JSON.parse(
+      await readFile(join(athleteHome, "allowed-senders.json"), "utf8"),
+    ) as { readonly primaryOperator?: unknown; readonly allowFrom?: unknown };
+    assert(
+      pairedAllowed.primaryOperator === String(SENDER_ID) &&
+        Array.isArray(pairedAllowed.allowFrom) &&
+        pairedAllowed.allowFrom.includes(String(SENDER_ID)),
+      "paired Telegram access state was not durable before restart",
+    );
+    await seedBackgroundAtLoginPreference(userData);
+    await gracefulQuit(primary, page, debugPort, trackedProcesses);
+    primary = undefined;
+    page = undefined;
+
+    debugPort = await reservePort();
+    const backgroundEnvironment = {
+      ...environment,
+      [ACCEPTANCE_OS_LOGIN_MARKER_ENV]: ACCEPTANCE_OS_LOGIN_MARKER_VALUE,
+    };
+    primary = launchApplication(backgroundEnvironment, debugPort, userData);
+    runningApplications.push(primary);
+    await waitUntil("cold-start Telegram long poll", () => telegram?.activePollCount() === 1);
+    await waitUntil("cold-start debugger listener", () => portOpen(debugPort));
+    await captureApplicationProcesses(primary, trackedProcesses);
+    assert(
+      (await mainRendererTargets(debugPort)).length === 0,
+      "OS-login cold start created a main renderer",
+    );
+    messageStart = telegram.sentMessages.length;
+    telegram.enqueue("/version");
+    await waitForSentMessage(
+      telegram.sentMessages,
+      `Cycling Coach Desktop v${packageManifest.version}`,
+      messageStart,
+    );
+    assert(
+      (await mainRendererTargets(debugPort)).length === 0,
+      "background Telegram handling created a main renderer",
+    );
+
+    const foregroundRequest = launchApplication(environment, debugPort, userData);
+    runningApplications.push(foregroundRequest);
+    await captureApplicationProcesses(foregroundRequest, trackedProcesses);
+    const foregroundRequestExit = await Promise.race([
+      foregroundRequest.exited,
+      delay(20_000).then(() => undefined),
+    ]);
+    assert(foregroundRequestExit !== undefined, "foreground second launch did not exit");
+    assert(
+      foregroundRequestExit.code === 0 && foregroundRequestExit.signal === null,
+      "foreground second launch exit was not clean",
+    );
+    await waitUntil(
+      "one foreground main renderer",
+      async () => (await mainRendererTargets(debugPort)).length === 1,
+    );
+    await delay(250);
+    assert(
+      (await mainRendererTargets(debugPort)).length === 1,
+      "second launch did not open exactly one main renderer",
+    );
+    page = await cdpPage(debugPort);
+
+    await page.evaluate("window.close(); true").catch(() => undefined);
+    page.closeSocket();
+    await waitUntil(
+      "resident window closure",
+      async () => {
+        try {
+          await waitForPage(debugPort);
+          return false;
+        } catch {
+          const pid = primary?.child.pid;
+          const identity = pid === undefined ? undefined : trackedProcesses.get(pid);
+          assert(identity !== undefined, "resident Desktop birth identity is missing");
+          return sameTrackedProcessRunning(identity);
+        }
+      },
+      25_000,
+    );
+    messageStart = telegram.sentMessages.length;
+    telegram.enqueue("/version");
+    await waitForSentMessage(
+      telegram.sentMessages,
+      `Cycling Coach Desktop v${packageManifest.version}`,
+      messageStart,
+    );
+
+    const secondary = launchApplication(environment, debugPort, userData);
+    runningApplications.push(secondary);
+    await delay(250);
+    await captureApplicationProcesses(secondary, trackedProcesses);
+    const secondaryExit = await Promise.race([
+      secondary.exited,
+      delay(20_000).then(() => undefined),
+    ]);
+    assert(secondaryExit !== undefined, "secondary Desktop instance did not exit");
+    assert(
+      secondaryExit.code === 0 && secondaryExit.signal === null,
+      "secondary Desktop instance exit was not clean",
+    );
+    page = await cdpPage(debugPort);
+    await waitForButton(page, "Settings");
+    await page.clickButton("Settings");
+    await waitForButton(page, "Turn off");
+    await waitUntil("active Telegram long poll", () => telegram?.activePollCount() === 1);
+    const cancelledPollCount = telegram.cancelledPollCount();
+    await page.clickButton("Turn off");
+    await waitForButton(page, "Turn on");
+    await waitUntil("Telegram polling stop", () => telegram?.activePollCount() === 0);
+    assert(
+      telegram.cancelledPollCount() > cancelledPollCount,
+      "turning Telegram off did not cancel the active long poll",
+    );
+    const disabledPollCount = telegram.pollCount();
+    messageStart = telegram.sentMessages.length;
+    const pendingUpdate = telegram.enqueue("/version");
+    await delay(1_000);
+    assert(telegram.sentMessages.length === messageStart, "disabled Telegram replied to an update");
+    assert(telegram.pollCount() === disabledPollCount, "disabled Telegram continued polling");
+
+    await gracefulQuit(primary, page, debugPort, trackedProcesses);
+    primary = undefined;
+    page = undefined;
+
+    const relaunchPort = await reservePort();
+    primary = launchApplication(environment, relaunchPort, userData);
+    runningApplications.push(primary);
+    page = await cdpPage(relaunchPort);
+    await captureApplicationProcesses(primary, trackedProcesses);
+    await waitForButton(page, "Settings");
+    await page.clickButton("Settings");
+    await waitForButton(page, "Turn on");
+    const relaunchedDisabledPollCount = telegram.pollCount();
+    await delay(1_000);
+    assert(
+      telegram.pollCount() === relaunchedDisabledPollCount,
+      "Telegram did not remain disabled after relaunch",
+    );
+    await page.clickButton("Turn on");
+    await waitForButton(page, "Turn off");
+    await waitForSentMessage(
+      telegram.sentMessages,
+      `Cycling Coach Desktop v${packageManifest.version}`,
+      messageStart,
+    );
+    await waitUntil("pending Telegram update acknowledgement progression", () => {
+      const requests = telegram?.getUpdatesRequests() ?? [];
+      const selections = requests.filter((request) =>
+        request.selectedUpdateIds.includes(pendingUpdate.update_id),
+      );
+      if (selections.length !== 1) return false;
+      return (
+        requests.some(
+          (request) =>
+            request.sequence > (selections[0]?.sequence ?? Number.MAX_SAFE_INTEGER) &&
+            request.offset > pendingUpdate.update_id &&
+            !request.settled,
+        ) && telegram?.activePollCount() === 1
+      );
+    });
+    assert(
+      telegram.sentMessages
+        .slice(messageStart)
+        .filter((message) => message.text === `Cycling Coach Desktop v${packageManifest.version}`)
+        .length === 1,
+      "pending Telegram update was not delivered exactly once",
+    );
+    const resumedRequests = telegram.getUpdatesRequests();
+    assert(
+      resumedRequests.filter((request) =>
+        request.selectedUpdateIds.includes(pendingUpdate.update_id),
+      ).length === 1 &&
+        resumedRequests.some(
+          (request) => request.offset > pendingUpdate.update_id && !request.settled,
+        ),
+      "pending Telegram update offset did not advance exactly once",
+    );
+
+    await page.clickButton("Remove bot from this Mac");
+    await waitForButton(page, "Remove Telegram bot");
+    await page.clickButton("Remove Telegram bot");
+    await waitForButton(page, "Paste token from clipboard");
+    await waitUntil("Telegram polling stop after removal", () => telegram?.activePollCount() === 0);
+    assert(!existsSync(profilePath), "Telegram profile remained after removal");
+    const desired = JSON.parse(
+      await readFile(join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_DESIRED_STATE_FILE), "utf8"),
+    ) as { readonly enabled?: unknown };
+    assert(desired.enabled === false, "Telegram desired state remained enabled after removal");
+    const allowedPath = join(athleteHome, "allowed-senders.json");
+    assert(existsSync(allowedPath), "allowed-senders.json is missing after removal");
+    const allowedSource = await readFile(allowedPath, "utf8");
+    const allowed = JSON.parse(allowedSource) as {
+      readonly dmPolicy?: unknown;
+      readonly allowFrom?: unknown;
+      readonly primaryOperator?: unknown;
+    };
+    assert(allowed.dmPolicy === "pairing", "Telegram DM policy did not reset to pairing");
+    assert(
+      Array.isArray(allowed.allowFrom) && allowed.allowFrom.length === 0,
+      "allowed users remained after removal",
+    );
+    assert(allowed.primaryOperator === null, "primary Telegram user remained after removal");
+    assert(
+      !allowedSource.includes(String(SENDER_ID)),
+      "primary Telegram sender ID remained on disk",
+    );
+    assert(!existsSync(authProfilesPath), "model auth profile unexpectedly appeared");
+    assert(
+      !(await treeContains(userData, token)),
+      "Telegram credential remained in Desktop user data",
+    );
+    assert(
+      !(await treeContains(athleteHome, token)),
+      "Telegram credential remained in the athlete home",
+    );
+    assert(!(await page.domHtml()).includes(token), "Telegram credential reached renderer DOM");
+    await page.screenshot(join(screenshots, "removed.png"));
+    await assertOutputSecretFree(runningApplications, token);
+    await writeFile(
+      join(results, "summary.json"),
+      `${JSON.stringify({
+        ok: true,
+        packagedVersion: packageManifest.version,
+        paired: true,
+        residentReply: true,
+        coldStartBackground: true,
+        remainedDisabled: true,
+        pendingDeliveredOnce: true,
+        removed: true,
+      })}\n`,
+      { mode: 0o600 },
+    );
+    await gracefulQuit(primary, page, relaunchPort, trackedProcesses);
+    primary = undefined;
+    page = undefined;
+    successResult = {
+      ok: true,
+      packagedVersion: packageManifest.version,
+      productionChain: true,
+      botApiOnlyFake: true,
+      coldStartBackground: true,
+      residentLifecycle: true,
+      persistedDisable: true,
+      removal: true,
+    };
+  } catch (error) {
+    executionError = error;
+  } finally {
+    const cleanupErrors: unknown[] = [];
+    const attempt = async (cleanup: () => void | Promise<void>): Promise<void> => {
+      try {
+        await cleanup();
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    };
+
+    await attempt(() => page?.closeSocket());
+    let processTeardownSafe = true;
+    for (const running of runningApplications) {
+      try {
+        await captureApplicationProcesses(running, trackedProcesses);
+      } catch (error) {
+        processTeardownSafe = false;
+        cleanupErrors.push(error);
+      }
+    }
+    try {
+      await terminateTrackedProcesses(trackedProcesses);
+    } catch (error) {
+      processTeardownSafe = false;
+      cleanupErrors.push(error);
+    }
+    try {
+      if (!(await waitForTrackedProcessExit(trackedProcesses, 0))) {
+        processTeardownSafe = false;
+        cleanupErrors.push(new Error("tracked packaged Desktop process remained live"));
+      }
+    } catch (error) {
+      processTeardownSafe = false;
+      cleanupErrors.push(error);
+    }
+    let debuggerListenersClosed = true;
+    for (const debugPort of new Set(runningApplications.map((running) => running.debugPort))) {
+      try {
+        await waitUntil(
+          `Desktop debugging listener ${debugPort} to close`,
+          async () => !(await portOpen(debugPort)),
+          5_000,
+        );
+      } catch (error) {
+        debuggerListenersClosed = false;
+        cleanupErrors.push(error);
+      }
+    }
+    await attempt(async () => {
+      const botApi = telegram;
+      if (botApi === undefined) return;
+      await botApi.close();
+      await waitUntil(
+        "Bot API listener to close",
+        async () => !(await portOpen(botApi.listenerPort)),
+        5_000,
+      );
+    });
+    await attempt(() => writeClipboard(originalClipboard));
+
+    try {
+      await releaseAcceptanceStorage({
+        processesStopped: processTeardownSafe,
+        debuggerListenersClosed,
+        recoveryPath: keychain?.recoveryPath ?? keychainPath,
+        restoreKeychain: async () => {
+          if (keychain === undefined) return true;
+          await keychain.restore();
+          return keychain.restored();
+        },
+        removeScratch: () => rm(scratch, { recursive: true, force: true }),
+      });
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    if (cleanupErrors.length > 0) {
+      cleanupError = new AggregateError(
+        executionError === undefined ? cleanupErrors : [executionError, ...cleanupErrors],
+        "packaged Telegram acceptance cleanup failed",
+      );
+    }
+  }
+  if (cleanupError !== undefined) throw cleanupError;
+  if (executionError !== undefined) throw executionError;
+  assert(successResult !== undefined, "packaged Telegram acceptance produced no result");
+  process.stdout.write(`${JSON.stringify(successResult)}\n`);
+}
+
+await main();

--- a/apps/desktop/scripts/test-packaged-telegram.ts
+++ b/apps/desktop/scripts/test-packaged-telegram.ts
@@ -15,10 +15,13 @@ import {
 import {
   observeTelegramAcceptanceChild,
   releaseAcceptanceStorage,
+  TELEGRAM_ACCEPTANCE_QUIT_FRAME,
   telegramAcceptanceDirectExitIsClean,
   telegramAcceptanceBundleTextIsClear,
   telegramAcceptanceDebuggerListenerOwner,
+  telegramAcceptanceJsonDiagnostic,
   telegramAcceptanceProcessTableIsClear,
+  telegramAcceptanceLaunchDiagnostic,
   telegramAcceptanceShutdownIsProven,
   type TelegramAcceptanceApplicationLaunch,
   type TelegramAcceptanceApplicationTerminal,
@@ -73,6 +76,7 @@ interface RunningApplication {
   readonly launch: Promise<TelegramAcceptanceApplicationLaunch>;
   readonly terminal: Promise<TelegramAcceptanceApplicationTerminal>;
   browserConnection: Awaited<ReturnType<typeof connectCdp>> | undefined;
+  readonly requestQuit: () => Promise<void>;
   readonly output: () => { readonly stdout: string; readonly stderr: string };
 }
 
@@ -447,7 +451,7 @@ function launchApplication(
   const args = [`--user-data-dir=${userData}`, `--remote-debugging-port=${debugPort}`];
   const child = spawn(executable, args, {
     env: environment,
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["pipe", "pipe", "pipe"],
   });
   let stdout = "";
   let stderr = "";
@@ -458,13 +462,102 @@ function launchApplication(
   child.stderr?.on("data", (chunk) => {
     stderr += String(chunk);
   });
+  let quitRequest: Promise<void> | undefined;
+  const requestQuit = (): Promise<void> => {
+    if (quitRequest !== undefined) return quitRequest;
+    quitRequest = new Promise<void>((resolveRequest) => {
+      if (
+        child.exitCode !== null ||
+        child.signalCode !== null ||
+        child.stdin === null ||
+        child.stdin.destroyed ||
+        !child.stdin.writable
+      ) {
+        resolveRequest();
+        return;
+      }
+      let settled = false;
+      const settle = (): void => {
+        if (settled) return;
+        settled = true;
+        resolveRequest();
+      };
+      child.stdin.once("error", settle);
+      try {
+        child.stdin.end(TELEGRAM_ACCEPTANCE_QUIT_FRAME, settle);
+      } catch {
+        settle();
+      }
+    });
+    return quitRequest;
+  };
   return {
     child,
     debugPort,
     ...lifecycle,
     browserConnection: undefined,
+    requestQuit,
     output: () => ({ stdout, stderr }),
   };
+}
+
+function redactSensitiveText(value: string, sensitiveValues: readonly string[]): string {
+  let redacted = value;
+  for (const sensitiveValue of sensitiveValues) {
+    if (sensitiveValue !== "") redacted = redacted.replaceAll(sensitiveValue, "<redacted>");
+  }
+  return redacted;
+}
+
+function boundedDiagnostic(value: string, maximumLength = 4_000): string {
+  if (value.length <= maximumLength) return value;
+  const retainedLength = Math.max(0, maximumLength - "<truncated>".length);
+  const headLength = Math.ceil(retainedLength / 2);
+  return `${value.slice(0, headLength)}<truncated>${value.slice(-retainedLength + headLength)}`;
+}
+
+function redactedDiagnostic(value: string, sensitiveValues: readonly string[]): string {
+  return boundedDiagnostic(redactSensitiveText(value, sensitiveValues));
+}
+
+function runningApplicationDiagnostic(
+  running: RunningApplication,
+  sensitiveValues: readonly string[],
+): string {
+  return telegramAcceptanceLaunchDiagnostic({
+    pid: running.child.pid,
+    code: running.child.exitCode,
+    signal: running.child.signalCode,
+    output: running.output(),
+    sensitiveValues,
+  });
+}
+
+function runningApplicationDiagnostics(
+  runningApplications: readonly RunningApplication[],
+  sensitiveValues: readonly string[],
+): string {
+  if (runningApplications.length === 0) return "applications=[]";
+  return `applications=[${runningApplications
+    .map(
+      (running, index) =>
+        `{index=${index}; ${runningApplicationDiagnostic(running, sensitiveValues)}}`,
+    )
+    .join(", ")}]`;
+}
+
+function errorWithRunningApplicationDiagnostics(
+  error: unknown,
+  runningApplications: readonly RunningApplication[],
+  sensitiveValues: readonly string[],
+): Error {
+  const message = redactedDiagnostic(
+    error instanceof Error ? error.message : "packaged Desktop execution failed",
+    sensitiveValues,
+  );
+  return new Error(
+    `${message}; ${runningApplicationDiagnostics(runningApplications, sensitiveValues)}`,
+  );
 }
 
 interface MainRendererTarget {
@@ -687,6 +780,25 @@ async function waitForButton(
   );
 }
 
+async function completeOnboardingBeforeNavigation(
+  page: Awaited<ReturnType<typeof cdpPage>>,
+): Promise<void> {
+  await page.evaluate(
+    `localStorage.setItem(${JSON.stringify(ONBOARDING_STORAGE_KEY)}, ${JSON.stringify(
+      ONBOARDING_STORAGE_VALUE,
+    )}); true`,
+  );
+  await page.connection.call("Page.reload", { ignoreCache: true });
+  await waitUntil("completed-onboarding renderer reload", async () =>
+    page
+      .evaluate<boolean>(`document.readyState === "complete" &&
+        performance.getEntriesByType("navigation")[0]?.type === "reload" &&
+        document.documentElement.dataset.rpc === "connected" &&
+        document.querySelector('[data-onboarding="closed"]') !== null`)
+      .catch(() => false),
+  );
+}
+
 async function telegramRendererSnapshot(
   page: Awaited<ReturnType<typeof cdpPage>>,
 ): Promise<unknown> {
@@ -836,13 +948,6 @@ async function waitForStablePackagedProcessExit(
   return false;
 }
 
-async function requestBrowserClose(
-  connection: Awaited<ReturnType<typeof connectCdp>>,
-): Promise<void> {
-  const command = connection.call("Browser.close").catch(() => undefined);
-  await Promise.race([command, delay(2_500)]);
-}
-
 function portOpen(port: number): Promise<boolean> {
   return new Promise((resolveOpen) => {
     const socket = connect({ host: "127.0.0.1", port });
@@ -859,7 +964,7 @@ async function gracefulQuit(
   page: Awaited<ReturnType<typeof cdpPage>>,
   debugPort: number,
 ): Promise<void> {
-  await requestBrowserClose(running.browserConnection ?? page.connection);
+  await running.requestQuit();
   assert(await cleanApplicationExit(running, 30_000), "packaged Desktop quit was not clean");
   await waitUntil("Desktop debugging listener exit", async () => !(await portOpen(debugPort)));
   page.closeSocket();
@@ -900,7 +1005,9 @@ async function assertOutputSecretFree(
   runningApplications: readonly RunningApplication[],
   token: string,
 ): Promise<void> {
-  const output = runningApplications.map((running) => JSON.stringify(running.output())).join("\n");
+  const output = runningApplications
+    .flatMap((running) => Object.values(running.output()))
+    .join("\n");
   assert(!output.includes(token), "Telegram credential reached packaged process output");
 }
 
@@ -1013,27 +1120,32 @@ async function main(): Promise<void> {
     try {
       page = await cdpPage(debugPort, requireDebuggerAuthority(debuggerAuthorities, debugPort));
     } catch (error) {
-      const processOutput = JSON.stringify(primary.output()).replaceAll(token, "<redacted>");
+      const processOutput = boundedDiagnostic(
+        runningApplicationDiagnostic(primary, [token]),
+        2_000,
+      );
       throw new Error(
-        `${error instanceof Error ? error.message : "Desktop renderer did not start"}; exit=${String(primary.child.exitCode)}; signal=${String(primary.child.signalCode)}; process=${processOutput.slice(0, 2_000)}`,
+        `${error instanceof Error ? error.message : "Desktop renderer did not start"}; process=${processOutput}`,
         { cause: error },
       );
     }
-    await page.evaluate(
-      `localStorage.setItem(${JSON.stringify(ONBOARDING_STORAGE_KEY)}, ${JSON.stringify(ONBOARDING_STORAGE_VALUE)}); true`,
-    );
+    await completeOnboardingBeforeNavigation(page);
     await waitForButton(page, "Settings");
     await page.clickButton("Settings");
     try {
       await waitForButton(page, "Paste token from clipboard");
     } catch (error) {
-      const renderer = JSON.stringify(await telegramRendererSnapshot(page)).replaceAll(
-        token,
-        "<redacted>",
+      const renderer = telegramAcceptanceJsonDiagnostic(
+        await telegramRendererSnapshot(page),
+        [token],
+        2_000,
       );
-      const processOutput = JSON.stringify(primary.output()).replaceAll(token, "<redacted>");
+      const processOutput = boundedDiagnostic(
+        runningApplicationDiagnostic(primary, [token]),
+        1_000,
+      );
       throw new Error(
-        `${error instanceof Error ? error.message : "Telegram settings did not load"}; renderer=${renderer.slice(0, 2_000)}; profile=${existsSync(join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_PROFILE_FILE))}; desired-state=${existsSync(join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_DESIRED_STATE_FILE))}; Bot API methods=${telegram.methods().join(",") || "none"}; process=${processOutput.slice(0, 1_000)}`,
+        `${error instanceof Error ? error.message : "Telegram settings did not load"}; renderer=${renderer}; profile=${existsSync(join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_PROFILE_FILE))}; desired-state=${existsSync(join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_DESIRED_STATE_FILE))}; Bot API methods=${telegram.methods().join(",") || "none"}; process=${processOutput}`,
       );
     }
 
@@ -1042,9 +1154,12 @@ async function main(): Promise<void> {
     try {
       await waitForTelegramText(page, `@${BOT_USERNAME}`);
     } catch (error) {
-      const processOutput = JSON.stringify(primary.output()).replaceAll(token, "<redacted>");
+      const processOutput = boundedDiagnostic(
+        runningApplicationDiagnostic(primary, [token]),
+        1_000,
+      );
       throw new Error(
-        `${error instanceof Error ? error.message : "Telegram setup failed"}; Bot API methods=${telegram.methods().join(",") || "none"}; content-types=${telegram.contentTypes().join(",") || "none"}; process=${processOutput.slice(0, 1_000)}`,
+        `${error instanceof Error ? error.message : "Telegram setup failed"}; Bot API methods=${telegram.methods().join(",") || "none"}; content-types=${telegram.contentTypes().join(",") || "none"}; process=${processOutput}`,
       );
     }
     assert((await clipboardBytes()).length === 0, "Telegram credential remained on the clipboard");
@@ -1132,22 +1247,22 @@ async function main(): Promise<void> {
     const freeTextReplies = telegram.sentMessages.slice(freeTextMessageStart);
     assert(
       freeTextReplies.every((message) => message.chatId === SENDER_ID),
-      `credential-free acceptance replied to the wrong Telegram chat: ${JSON.stringify(
+      `credential-free acceptance replied to the wrong Telegram chat: ${telegramAcceptanceJsonDiagnostic(
         freeTextReplies,
-      )
-        .replaceAll(token, "<redacted>")
-        .slice(0, 600)}`,
+        [token],
+        600,
+      )}`,
     );
     const freeTextReplyTexts = freeTextReplies.map((message) => message.text);
     assert(
       JSON.stringify(freeTextReplyTexts) === JSON.stringify([GENERIC_FAILURE]) ||
         JSON.stringify(freeTextReplyTexts) ===
           JSON.stringify([EXPECTED_WELCOME_MESSAGE, GENERIC_FAILURE]),
-      `credential-free acceptance produced an invalid response set after daemon drain: ${JSON.stringify(
+      `credential-free acceptance produced an invalid response set after daemon drain: ${telegramAcceptanceJsonDiagnostic(
         freeTextReplyTexts,
-      )
-        .replaceAll(token, "<redacted>")
-        .slice(0, 600)}`,
+        [token],
+        600,
+      )}`,
     );
     primary = undefined;
     page = undefined;
@@ -1423,7 +1538,7 @@ async function main(): Promise<void> {
       removal: true,
     };
   } catch (error) {
-    executionError = error;
+    executionError = errorWithRunningApplicationDiagnostics(error, runningApplications, [token]);
   } finally {
     const cleanupErrors: unknown[] = [];
     const attempt = async (cleanup: () => void | Promise<void>): Promise<void> => {
@@ -1434,21 +1549,19 @@ async function main(): Promise<void> {
       }
     };
 
-    const browserConnections = new Set<Awaited<ReturnType<typeof connectCdp>>>();
-    if (page !== undefined) browserConnections.add(page.connection);
-    for (const running of runningApplications) {
-      if (running.browserConnection !== undefined) {
-        browserConnections.add(running.browserConnection);
-      }
-    }
-    await Promise.all([...browserConnections].map(requestBrowserClose));
+    await Promise.all(runningApplications.map((running) => running.requestQuit()));
     const directExits = await Promise.all(
       runningApplications.map((running) => cleanApplicationExit(running, 10_000)),
     );
     const directApplicationsExitedCleanly = directExits.every(Boolean);
     if (!directApplicationsExitedCleanly) {
       cleanupErrors.push(
-        new Error("a directly launched packaged Desktop process did not exit cleanly"),
+        new Error(
+          `a directly launched packaged Desktop process did not exit cleanly; ${runningApplicationDiagnostics(
+            runningApplications,
+            [token],
+          )}`,
+        ),
       );
     }
     await attempt(() => page?.closeSocket());
@@ -1460,7 +1573,12 @@ async function main(): Promise<void> {
       processTableClear = await waitForStablePackagedProcessExit(operatorHome, 5_000);
       if (!processTableClear) {
         cleanupErrors.push(
-          new Error("a packaged Desktop executable remained in the process table"),
+          new Error(
+            `a packaged Desktop executable remained in the process table; ${runningApplicationDiagnostics(
+              runningApplications,
+              [token],
+            )}`,
+          ),
         );
       }
     } catch (error) {
@@ -1514,7 +1632,10 @@ async function main(): Promise<void> {
     if (cleanupErrors.length > 0) {
       cleanupError = new AggregateError(
         executionError === undefined ? cleanupErrors : [executionError, ...cleanupErrors],
-        "packaged Telegram acceptance cleanup failed",
+        `packaged Telegram acceptance cleanup failed; ${runningApplicationDiagnostics(
+          runningApplications,
+          [token],
+        )}`,
       );
     }
   }

--- a/apps/desktop/scripts/test-packaged-telegram.ts
+++ b/apps/desktop/scripts/test-packaged-telegram.ts
@@ -30,6 +30,13 @@ import {
   ACCEPTANCE_OS_LOGIN_MARKER_ENV,
   ACCEPTANCE_OS_LOGIN_MARKER_VALUE,
 } from "../tests/fixtures/packaged-telegram/startup-mode.js";
+import {
+  callAcceptanceCdp as callCdpWithin,
+  runAcceptanceCommand as runCommand,
+  terminateAcceptanceChild,
+  withAcceptanceDeadline,
+  type AcceptanceCommandResult as CommandResult,
+} from "../tests/fixtures/packaged-telegram/acceptance-deadline.js";
 
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const application = join(
@@ -63,12 +70,30 @@ const BOT_USERNAME = "EnduragentAcceptanceBot";
 const BOT_ID = 71_234_567;
 const SENDER_ID = 42_424_242;
 
-interface CommandResult {
-  readonly code: number | null;
-  readonly signal: NodeJS.Signals | null;
-  readonly stdout: Buffer;
-  readonly stderr: Buffer;
-}
+type AcceptancePhase =
+  | "setup"
+  | "keychain"
+  | "keychain-ready"
+  | "initial-launch"
+  | "token-configure"
+  | "token-configured"
+  | "paired"
+  | "initial-quit"
+  | "background-relaunch"
+  | "background-ready"
+  | "resident-lifecycle"
+  | "window-close"
+  | "secondary-launch"
+  | "disable"
+  | "disabled"
+  | "disabled-quit"
+  | "disabled-relaunch"
+  | "removal"
+  | "final-quit"
+  | "cleanup"
+  | "cleanup-processes"
+  | "cleanup-storage"
+  | "complete";
 
 interface RunningApplication {
   readonly child: ChildProcess;
@@ -128,6 +153,10 @@ function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
 }
 
+function reportPhase(phase: AcceptancePhase): void {
+  process.stderr.write(`[packaged-telegram] ${phase}\n`);
+}
+
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
 }
@@ -143,42 +172,6 @@ async function waitUntil(
     await delay(50);
   }
   throw new Error(`timed out waiting for ${description}`);
-}
-
-function runCommand(
-  command: string,
-  args: readonly string[],
-  options: {
-    readonly input?: Buffer | string;
-    readonly allowFailure?: boolean;
-    readonly environment?: NodeJS.ProcessEnv;
-  } = {},
-): Promise<CommandResult> {
-  return new Promise((resolveRun, rejectRun) => {
-    const child = spawn(command, args, {
-      env: options.environment,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
-    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
-    child.once("error", rejectRun);
-    child.once("close", (code, signal) => {
-      const result = {
-        code,
-        signal,
-        stdout: Buffer.concat(stdout),
-        stderr: Buffer.concat(stderr),
-      };
-      if (!options.allowFailure && (code !== 0 || signal !== null)) {
-        rejectRun(new Error(`${command} failed`));
-      } else {
-        resolveRun(result);
-      }
-    });
-    child.stdin.end(options.input);
-  });
 }
 
 async function clipboardBytes(): Promise<Buffer> {
@@ -431,13 +424,17 @@ async function createTelegramBotApi(token: string) {
     methods: () => [...methods],
     contentTypes: () => [...contentTypes],
     async close() {
+      const closed = new Promise<void>((resolveClose, rejectClose) => {
+        http.close((error) => (error === undefined ? resolveClose() : rejectClose(error)));
+      });
       for (const waiter of pending) {
         pending.delete(waiter);
         settleGetUpdates(waiter, []);
       }
       http.closeAllConnections();
-      await new Promise<void>((resolveClose, rejectClose) => {
-        http.close((error) => (error === undefined ? resolveClose() : rejectClose(error)));
+      await withAcceptanceDeadline("Bot API shutdown", closed, {
+        timeoutMs: 5_000,
+        onTimeout: () => http.closeAllConnections(),
       });
     },
   };
@@ -465,7 +462,7 @@ function launchApplication(
   let quitRequest: Promise<void> | undefined;
   const requestQuit = (): Promise<void> => {
     if (quitRequest !== undefined) return quitRequest;
-    quitRequest = new Promise<void>((resolveRequest) => {
+    const delivery = new Promise<void>((resolveRequest) => {
       if (
         child.exitCode !== null ||
         child.signalCode !== null ||
@@ -489,6 +486,10 @@ function launchApplication(
         settle();
       }
     });
+    quitRequest = withAcceptanceDeadline("packaged Desktop quit request", delivery, {
+      timeoutMs: 2_000,
+      onTimeout: () => child.stdin?.destroy(),
+    }).catch(() => undefined);
     return quitRequest;
   };
   return {
@@ -720,7 +721,7 @@ async function cdpPage(port: number, authority: DebuggerAuthority) {
     throw error;
   }
   const evaluate = async <T>(expression: string): Promise<T> => {
-    const response = await connection.call("Runtime.evaluate", {
+    const response = await callCdpWithin(connection, "Runtime.evaluate", {
       expression,
       awaitPromise: true,
       returnByValue: true,
@@ -758,8 +759,10 @@ async function cdpPage(port: number, authority: DebuggerAuthority) {
       assert(clicked, `enabled renderer button was not found: ${label}`);
     },
     async screenshot(path: string): Promise<void> {
-      await connection.call("Page.enable");
-      const captured = await connection.call("Page.captureScreenshot", { format: "png" });
+      await callCdpWithin(connection, "Page.enable");
+      const captured = await callCdpWithin(connection, "Page.captureScreenshot", {
+        format: "png",
+      });
       assert(typeof captured.data === "string", "renderer screenshot was not captured");
       await writeFile(path, Buffer.from(captured.data, "base64"), { mode: 0o600 });
     },
@@ -788,7 +791,7 @@ async function completeOnboardingBeforeNavigation(
       ONBOARDING_STORAGE_VALUE,
     )}); true`,
   );
-  await page.connection.call("Page.reload", { ignoreCache: true });
+  await callCdpWithin(page.connection, "Page.reload", { ignoreCache: true });
   await waitUntil("completed-onboarding renderer reload", async () =>
     page
       .evaluate<boolean>(`document.readyState === "complete" &&
@@ -914,14 +917,19 @@ async function cleanApplicationExit(
   return lifecycle !== undefined && telegramAcceptanceDirectExitIsClean(...lifecycle);
 }
 
-async function packagedProcessTableIsClear(operatorHome: string): Promise<boolean> {
+async function packagedProcessTableIsClear(
+  operatorHome: string,
+  timeoutMs: number,
+): Promise<boolean> {
   const [processTable, bundleText] = await Promise.all([
     runCommand("/bin/ps", ["-ww", "-axo", "pid=", "-o", "ucomm="], {
       allowFailure: true,
+      timeoutMs,
     }),
     runCommand("/usr/sbin/lsof", ["-n", "-P", "-a", "-d", "txt", "+D", application, "-F0pn"], {
       allowFailure: true,
       environment: { ...process.env, HOME: operatorHome },
+      timeoutMs,
     }),
   ]);
   return (
@@ -937,7 +945,8 @@ async function waitForStablePackagedProcessExit(
   const deadline = Date.now() + timeoutMs;
   let consecutiveClear = 0;
   while (Date.now() < deadline) {
-    if (await packagedProcessTableIsClear(operatorHome)) {
+    const remaining = Math.max(1, deadline - Date.now());
+    if (await packagedProcessTableIsClear(operatorHome, Math.min(2_000, remaining))) {
       consecutiveClear += 1;
       if (consecutiveClear === 3) return true;
     } else {
@@ -951,11 +960,18 @@ async function waitForStablePackagedProcessExit(
 function portOpen(port: number): Promise<boolean> {
   return new Promise((resolveOpen) => {
     const socket = connect({ host: "127.0.0.1", port });
-    socket.once("connect", () => {
+    let settled = false;
+    const settle = (open: boolean): void => {
+      if (settled) return;
+      settled = true;
       socket.destroy();
-      resolveOpen(true);
+      resolveOpen(open);
+    };
+    socket.once("connect", () => {
+      settle(true);
     });
-    socket.once("error", () => resolveOpen(false));
+    socket.once("error", () => settle(false));
+    socket.setTimeout(1_000, () => settle(false));
   });
 }
 
@@ -1019,6 +1035,7 @@ async function main(): Promise<void> {
     "packaged Telegram acceptance requires an explicit disposable safe-storage context",
   );
   assert(existsSync(executable), "packaged Telegram acceptance executable is missing");
+  reportPhase("setup");
   const packageManifest = JSON.parse(await readFile(join(desktopRoot, "package.json"), "utf8")) as {
     readonly version?: unknown;
   };
@@ -1087,6 +1104,7 @@ async function main(): Promise<void> {
     assert(!existsSync(authProfilesPath), "model auth profile unexpectedly exists");
 
     telegram = await createTelegramBotApi(token);
+    reportPhase("keychain");
     keychain = await prepareDisposableKeychain({
       home: operatorHome,
       path: keychainPath,
@@ -1099,6 +1117,7 @@ async function main(): Promise<void> {
         }),
     });
     await keychain.activate();
+    reportPhase("keychain-ready");
     assert(keychain.home === operatorHome, "keychain and application HOME differ");
     let debugPort = await reservePort();
     const environment = modelCredentialFreeEnvironment({
@@ -1110,6 +1129,7 @@ async function main(): Promise<void> {
       CLICOLOR_FORCE: undefined,
     });
 
+    reportPhase("initial-launch");
     primary = await launchTrackedApplication(
       environment,
       debugPort,
@@ -1149,6 +1169,7 @@ async function main(): Promise<void> {
       );
     }
 
+    reportPhase("token-configure");
     await writeClipboard(token);
     await page.clickButton("Paste token from clipboard");
     try {
@@ -1162,6 +1183,7 @@ async function main(): Promise<void> {
         `${error instanceof Error ? error.message : "Telegram setup failed"}; Bot API methods=${telegram.methods().join(",") || "none"}; content-types=${telegram.contentTypes().join(",") || "none"}; process=${processOutput}`,
       );
     }
+    reportPhase("token-configured");
     assert((await clipboardBytes()).length === 0, "Telegram credential remained on the clipboard");
     const profilePath = join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_PROFILE_FILE);
     await waitUntil("encrypted Telegram profile", () => existsSync(profilePath));
@@ -1177,6 +1199,7 @@ async function main(): Promise<void> {
     telegram.enqueue(code);
     await waitForTelegramText(page, "Paired with a primary Telegram user");
     await waitForTelegramText(page, "Online");
+    reportPhase("paired");
     await page.evaluate(`(() => {
       const summary = [...document.querySelectorAll("summary")].find((candidate) =>
         candidate.textContent?.trim() === "Advanced · allowed users"
@@ -1235,6 +1258,7 @@ async function main(): Promise<void> {
       "paired Telegram access state was not durable before restart",
     );
     await seedBackgroundAtLoginPreference(userData);
+    reportPhase("initial-quit");
     await gracefulQuit(primary, page, debugPort);
     const freeTextActions = telegram.chatActions.slice(chatActionStart);
     assert(
@@ -1267,6 +1291,7 @@ async function main(): Promise<void> {
     primary = undefined;
     page = undefined;
 
+    reportPhase("background-relaunch");
     debugPort = await reservePort();
     const backgroundEnvironment = {
       ...environment,
@@ -1293,6 +1318,7 @@ async function main(): Promise<void> {
       `Cycling Coach Desktop v${packageManifest.version}`,
       messageStart,
     );
+    reportPhase("background-ready");
     assert(
       freeTextInitialSelectionSequence !== undefined,
       "initial free-text Telegram selection was not observed",
@@ -1314,6 +1340,7 @@ async function main(): Promise<void> {
       "background Telegram handling created a main renderer",
     );
 
+    reportPhase("resident-lifecycle");
     const foregroundRequest = await launchTrackedApplication(
       environment,
       debugPort,
@@ -1336,6 +1363,7 @@ async function main(): Promise<void> {
     );
     page = await cdpPage(debugPort, requireDebuggerAuthority(debuggerAuthorities, debugPort));
 
+    reportPhase("window-close");
     await page.evaluate("window.close(); true").catch(() => undefined);
     page.closeSocket();
     await waitUntil(
@@ -1362,6 +1390,7 @@ async function main(): Promise<void> {
       messageStart,
     );
 
+    reportPhase("secondary-launch");
     const secondary = await launchTrackedApplication(
       environment,
       debugPort,
@@ -1379,10 +1408,12 @@ async function main(): Promise<void> {
     await page.clickButton("Settings");
     await waitForButton(page, "Turn off");
     await waitUntil("active Telegram long poll", () => telegram?.activePollCount() === 1);
+    reportPhase("disable");
     const cancelledPollCount = telegram.cancelledPollCount();
     await page.clickButton("Turn off");
     await waitForButton(page, "Turn on");
     await waitUntil("Telegram polling stop", () => telegram?.activePollCount() === 0);
+    reportPhase("disabled");
     assert(
       telegram.cancelledPollCount() > cancelledPollCount,
       "turning Telegram off did not cancel the active long poll",
@@ -1394,10 +1425,12 @@ async function main(): Promise<void> {
     assert(telegram.sentMessages.length === messageStart, "disabled Telegram replied to an update");
     assert(telegram.pollCount() === disabledPollCount, "disabled Telegram continued polling");
 
+    reportPhase("disabled-quit");
     await gracefulQuit(primary, page, debugPort);
     primary = undefined;
     page = undefined;
 
+    reportPhase("disabled-relaunch");
     const relaunchPort = await reservePort();
     primary = await launchTrackedApplication(
       environment,
@@ -1459,6 +1492,7 @@ async function main(): Promise<void> {
       "pending Telegram update offset did not advance exactly once",
     );
 
+    reportPhase("removal");
     await page.clickButton("Remove bot from this Mac");
     await waitForButton(page, "Remove Telegram bot");
     await page.clickButton("Remove Telegram bot");
@@ -1524,6 +1558,7 @@ async function main(): Promise<void> {
       })}\n`,
       { mode: 0o600 },
     );
+    reportPhase("final-quit");
     await gracefulQuit(primary, page, relaunchPort);
     primary = undefined;
     page = undefined;
@@ -1540,6 +1575,7 @@ async function main(): Promise<void> {
   } catch (error) {
     executionError = errorWithRunningApplicationDiagnostics(error, runningApplications, [token]);
   } finally {
+    reportPhase("cleanup");
     const cleanupErrors: unknown[] = [];
     const attempt = async (cleanup: () => void | Promise<void>): Promise<void> => {
       try {
@@ -1564,11 +1600,20 @@ async function main(): Promise<void> {
         ),
       );
     }
+    const terminatedApplications = await Promise.all(
+      runningApplications.map((running, index) =>
+        directExits[index] ? Promise.resolve(true) : terminateAcceptanceChild(running.child),
+      ),
+    );
+    if (!terminatedApplications.every(Boolean)) {
+      cleanupErrors.push(new Error("a packaged Desktop process could not be terminated"));
+    }
     await attempt(() => page?.closeSocket());
     for (const running of runningApplications) {
       await attempt(() => running.browserConnection?.socket.close());
     }
     let processTableClear = false;
+    reportPhase("cleanup-processes");
     try {
       processTableClear = await waitForStablePackagedProcessExit(operatorHome, 5_000);
       if (!processTableClear) {
@@ -1614,6 +1659,7 @@ async function main(): Promise<void> {
     });
     await attempt(() => writeClipboard(originalClipboard));
 
+    reportPhase("cleanup-storage");
     try {
       await releaseAcceptanceStorage({
         processesStopped: processTeardownSafe,
@@ -1642,6 +1688,7 @@ async function main(): Promise<void> {
   if (cleanupError !== undefined) throw cleanupError;
   if (executionError !== undefined) throw executionError;
   assert(successResult !== undefined, "packaged Telegram acceptance produced no result");
+  reportPhase("complete");
   process.stdout.write(`${JSON.stringify(successResult)}\n`);
 }
 

--- a/apps/desktop/scripts/test-packaged-telegram.ts
+++ b/apps/desktop/scripts/test-packaged-telegram.ts
@@ -616,14 +616,12 @@ async function connectCdpWithin(
     return connection;
   });
   void pending.catch(() => undefined);
-  const connection = await Promise.race([
-    pending,
-    delay(timeoutMs).then(() => {
+  const connection = await withAcceptanceDeadline("Desktop debugger connection", pending, {
+    timeoutMs,
+    onTimeout: () => {
       timedOut = true;
-      return undefined;
-    }),
-  ]);
-  if (connection === undefined) throw new Error("Desktop debugger connection timed out");
+    },
+  });
   return connection;
 }
 
@@ -783,23 +781,25 @@ async function waitForButton(
   );
 }
 
-async function completeOnboardingBeforeNavigation(
+async function seedCompletedOnboardingAfterStartup(
   page: Awaited<ReturnType<typeof cdpPage>>,
 ): Promise<void> {
-  await page.evaluate(
-    `localStorage.setItem(${JSON.stringify(ONBOARDING_STORAGE_KEY)}, ${JSON.stringify(
-      ONBOARDING_STORAGE_VALUE,
-    )}); true`,
-  );
-  await callCdpWithin(page.connection, "Page.reload", { ignoreCache: true });
-  await waitUntil("completed-onboarding renderer reload", async () =>
+  await waitUntil("initial renderer startup", async () =>
     page
       .evaluate<boolean>(`document.readyState === "complete" &&
-        performance.getEntriesByType("navigation")[0]?.type === "reload" &&
         document.documentElement.dataset.rpc === "connected" &&
-        document.querySelector('[data-onboarding="closed"]') !== null`)
+        document.querySelector('[data-onboarding="open"]') !== null`)
       .catch(() => false),
   );
+  const persisted = await page.evaluate<boolean>(
+    `(() => {
+      const key = ${JSON.stringify(ONBOARDING_STORAGE_KEY)};
+      const value = ${JSON.stringify(ONBOARDING_STORAGE_VALUE)};
+      localStorage.setItem(key, value);
+      return localStorage.getItem(key) === value;
+    })()`,
+  );
+  assert(persisted, "completed onboarding state was not persisted");
 }
 
 async function telegramRendererSnapshot(
@@ -910,10 +910,11 @@ async function cleanApplicationExit(
   running: RunningApplication,
   timeoutMs: number,
 ): Promise<boolean> {
-  const lifecycle = await Promise.race([
+  const lifecycle = await withAcceptanceDeadline(
+    "packaged Desktop clean exit",
     Promise.all([running.launch, running.terminal]),
-    delay(timeoutMs).then(() => undefined),
-  ]);
+    { timeoutMs },
+  ).catch(() => undefined);
   return lifecycle !== undefined && telegramAcceptanceDirectExitIsClean(...lifecycle);
 }
 
@@ -1149,9 +1150,16 @@ async function main(): Promise<void> {
         { cause: error },
       );
     }
-    await completeOnboardingBeforeNavigation(page);
+    await seedCompletedOnboardingAfterStartup(page);
     await waitForButton(page, "Settings");
     await page.clickButton("Settings");
+    await waitUntil("Settings after onboarding dismissal", async () =>
+      page
+        .evaluate<boolean>(
+          `document.querySelector('[data-view="settings"][data-onboarding="closed"]') !== null`,
+        )
+        .catch(() => false),
+    );
     try {
       await waitForButton(page, "Paste token from clipboard");
     } catch (error) {

--- a/apps/desktop/scripts/test-packaged-telegram.ts
+++ b/apps/desktop/scripts/test-packaged-telegram.ts
@@ -13,11 +13,15 @@ import {
   type DisposableKeychain,
 } from "../tests/fixtures/packaged-telegram/disposable-keychain.js";
 import {
-  classifyDarwinProcessObservation,
-  parseDarwinProcessObservation,
+  observeTelegramAcceptanceChild,
   releaseAcceptanceStorage,
-  type DarwinProcessBirthIdentity,
-  type DarwinProcessObservation,
+  telegramAcceptanceDirectExitIsClean,
+  telegramAcceptanceBundleTextIsClear,
+  telegramAcceptanceDebuggerListenerOwner,
+  telegramAcceptanceProcessTableIsClear,
+  telegramAcceptanceShutdownIsProven,
+  type TelegramAcceptanceApplicationLaunch,
+  type TelegramAcceptanceApplicationTerminal,
 } from "../tests/fixtures/packaged-telegram/process-safety.js";
 import {
   ACCEPTANCE_OS_LOGIN_MARKER_ENV,
@@ -38,6 +42,20 @@ const BACKGROUND_PREFERENCE_FILE = "background-at-login.json";
 const ONBOARDING_STORAGE_KEY = "enduragent.desktop.onboarding";
 const ONBOARDING_STORAGE_VALUE = '{"version":1,"completed":true}';
 const GENERIC_FAILURE = "Sorry, something went wrong. Please try again.";
+const EXPECTED_WELCOME_MESSAGE =
+  "Welcome to Cycling Coach!\n\n" +
+  "I'm your AI cycling coach. I can build training plans, suggest workouts, " +
+  "and track your fitness using intervals.icu data.\n\n" +
+  "Commands:\n" +
+  "/plan — Generate a training plan\n" +
+  "/workout — Get today's workout\n" +
+  "/status — Check current fitness, fatigue, and form\n" +
+  "/review — Review your last session\n" +
+  "/sync — Force-refresh training data from intervals.icu\n" +
+  "/version — Show current version\n" +
+  "/whatsnew — See what changed in the latest version\n" +
+  "/update — Check for updates in the Desktop app\n\n" +
+  "Or just chat with me about your training!";
 const BOT_USERNAME = "EnduragentAcceptanceBot";
 const BOT_ID = 71_234_567;
 const SENDER_ID = 42_424_242;
@@ -52,11 +70,16 @@ interface CommandResult {
 interface RunningApplication {
   readonly child: ChildProcess;
   readonly debugPort: number;
-  readonly exited: Promise<{
-    readonly code: number | null;
-    readonly signal: NodeJS.Signals | null;
-  }>;
+  readonly launch: Promise<TelegramAcceptanceApplicationLaunch>;
+  readonly terminal: Promise<TelegramAcceptanceApplicationTerminal>;
+  browserConnection: Awaited<ReturnType<typeof connectCdp>> | undefined;
   readonly output: () => { readonly stdout: string; readonly stderr: string };
+}
+
+interface DebuggerAuthority {
+  readonly pid: number;
+  readonly connection: Awaited<ReturnType<typeof connectCdp>>;
+  readonly environment: NodeJS.ProcessEnv;
 }
 
 interface SentMessage {
@@ -68,7 +91,7 @@ interface GetUpdatesRequestObservation {
   readonly sequence: number;
   readonly offset: number;
   readonly selectedUpdateIds: readonly number[];
-  readonly settled: boolean;
+  readonly state: "pending" | "settled" | "cancelled";
 }
 
 interface TelegramUpdate {
@@ -137,7 +160,7 @@ function runCommand(
     child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
     child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
     child.once("error", rejectRun);
-    child.once("exit", (code, signal) => {
+    child.once("close", (code, signal) => {
       const result = {
         code,
         signal,
@@ -225,7 +248,7 @@ async function createTelegramBotApi(token: string) {
     sequence: number;
     offset: number;
     selectedUpdateIds: number[];
-    settled: boolean;
+    state: "pending" | "settled" | "cancelled";
   }[] = [];
   const pending = new Set<{
     readonly payload: Record<string, unknown>;
@@ -251,7 +274,7 @@ async function createTelegramBotApi(token: string) {
     selected: readonly TelegramUpdate[],
   ): void => {
     waiter.observation.selectedUpdateIds = selected.map((update) => update.update_id);
-    waiter.observation.settled = true;
+    waiter.observation.state = "settled";
     if (!waiter.response.writableEnded) {
       botApiResponse(waiter.response, 200, { ok: true, result: selected });
     }
@@ -327,7 +350,7 @@ async function createTelegramBotApi(token: string) {
             sequence: ++getUpdatesSequence,
             offset: requestOffset(payload),
             selectedUpdateIds: [] as number[],
-            settled: false,
+            state: "pending" as const,
           };
           getUpdatesRequests.push(observation);
           const selected = selectUpdates(payload);
@@ -338,7 +361,10 @@ async function createTelegramBotApi(token: string) {
           const waiter = { payload, response, observation };
           pending.add(waiter);
           response.once("close", () => {
-            if (pending.delete(waiter) && !response.writableEnded) cancelledPolls += 1;
+            if (pending.delete(waiter) && !response.writableEnded) {
+              observation.state = "cancelled";
+              cancelledPolls += 1;
+            }
           });
           return;
         }
@@ -425,20 +451,20 @@ function launchApplication(
   });
   let stdout = "";
   let stderr = "";
+  const lifecycle = observeTelegramAcceptanceChild(child);
   child.stdout?.on("data", (chunk) => {
     stdout += String(chunk);
   });
   child.stderr?.on("data", (chunk) => {
     stderr += String(chunk);
   });
-  const exited = new Promise<{
-    readonly code: number | null;
-    readonly signal: NodeJS.Signals | null;
-  }>((resolveExit, rejectExit) => {
-    child.once("error", rejectExit);
-    child.once("exit", (code, signal) => resolveExit({ code, signal }));
-  });
-  return { child, debugPort, exited, output: () => ({ stdout, stderr }) };
+  return {
+    child,
+    debugPort,
+    ...lifecycle,
+    browserConnection: undefined,
+    output: () => ({ stdout, stderr }),
+  };
 }
 
 interface MainRendererTarget {
@@ -447,17 +473,132 @@ interface MainRendererTarget {
   readonly webSocketDebuggerUrl?: unknown;
 }
 
-async function mainRendererTargets(port: number): Promise<readonly MainRendererTarget[]> {
-  const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+async function mainRendererTargets(
+  port: number,
+  authority: DebuggerAuthority,
+): Promise<readonly MainRendererTarget[]> {
+  await assertDebuggerListenerOwner(port, authority.pid, authority.environment);
+  const response = await fetch(`http://127.0.0.1:${port}/json/list`, {
+    signal: AbortSignal.timeout(1_000),
+  });
   if (!response.ok) throw new Error("Desktop debugging target list was unavailable");
   const targets = (await response.json()) as readonly MainRendererTarget[];
-  return targets.filter(
+  await assertDebuggerListenerOwner(port, authority.pid, authority.environment);
+  const rendererTargets = targets.filter(
     (target) =>
       target.type === "page" &&
       typeof target.url === "string" &&
       target.url.startsWith("enduragent://app/") &&
       typeof target.webSocketDebuggerUrl === "string",
   );
+  for (const target of rendererTargets) {
+    validateDebuggerUrl(target.webSocketDebuggerUrl as string, port, "/devtools/page/");
+  }
+  return rendererTargets;
+}
+
+function validateDebuggerUrl(value: string, port: number, pathPrefix: string): void {
+  const url = new URL(value);
+  if (
+    url.protocol !== "ws:" ||
+    url.hostname !== "127.0.0.1" ||
+    url.port !== String(port) ||
+    !url.pathname.startsWith(pathPrefix)
+  ) {
+    throw new TypeError("Desktop debugger target is invalid");
+  }
+}
+
+async function connectCdpWithin(
+  url: string,
+  timeoutMs = 2_500,
+): Promise<Awaited<ReturnType<typeof connectCdp>>> {
+  let timedOut = false;
+  const pending = connectCdp(url, () => undefined).then((connection) => {
+    if (timedOut) {
+      connection.socket.close();
+      throw new Error("Desktop debugger connection timed out");
+    }
+    return connection;
+  });
+  void pending.catch(() => undefined);
+  const connection = await Promise.race([
+    pending,
+    delay(timeoutMs).then(() => {
+      timedOut = true;
+      return undefined;
+    }),
+  ]);
+  if (connection === undefined) throw new Error("Desktop debugger connection timed out");
+  return connection;
+}
+
+async function debuggerListenerOwner(
+  port: number,
+  environment: NodeJS.ProcessEnv,
+): Promise<number | undefined> {
+  if (typeof environment.HOME !== "string") {
+    throw new TypeError("Desktop debugger-listener environment is invalid");
+  }
+  const result = await runCommand(
+    "/usr/sbin/lsof",
+    ["-n", "-P", "-a", `-iTCP:${port}`, "-sTCP:LISTEN", "-F0p"],
+    {
+      allowFailure: true,
+      environment: { ...process.env, HOME: environment.HOME },
+    },
+  );
+  return telegramAcceptanceDebuggerListenerOwner(result);
+}
+
+async function assertDebuggerListenerOwner(
+  port: number,
+  expectedPid: number,
+  environment: NodeJS.ProcessEnv,
+): Promise<void> {
+  if ((await debuggerListenerOwner(port, environment)) !== expectedPid) {
+    throw new TypeError("Desktop debugger listener is outside the launched application");
+  }
+}
+
+async function connectBrowserDebugger(
+  port: number,
+  expectedPid: number,
+  environment: NodeJS.ProcessEnv,
+): Promise<Awaited<ReturnType<typeof connectCdp>>> {
+  let debuggerUrl: string | undefined;
+  await waitUntil("Desktop browser debugger", async () => {
+    const owner = await debuggerListenerOwner(port, environment);
+    if (owner === undefined) return false;
+    if (owner !== expectedPid) {
+      throw new TypeError("Desktop debugger listener is outside the launched application");
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/version`, {
+        signal: AbortSignal.timeout(1_000),
+      });
+      if (!response.ok) return false;
+      const target = (await response.json()) as { readonly webSocketDebuggerUrl?: unknown };
+      if (typeof target.webSocketDebuggerUrl !== "string") return false;
+      validateDebuggerUrl(target.webSocketDebuggerUrl, port, "/devtools/browser/");
+      debuggerUrl = target.webSocketDebuggerUrl;
+      return true;
+    } catch (error) {
+      if (error instanceof TypeError && error.message === "Desktop debugger target is invalid") {
+        throw error;
+      }
+      return false;
+    }
+  });
+  assert(debuggerUrl !== undefined, "Desktop browser debugger target is unavailable");
+  const connection = await connectCdpWithin(debuggerUrl);
+  try {
+    await assertDebuggerListenerOwner(port, expectedPid, environment);
+    return connection;
+  } catch (error) {
+    connection.socket.close();
+    throw error;
+  }
 }
 
 async function seedBackgroundAtLoginPreference(userData: string): Promise<void> {
@@ -474,8 +615,17 @@ async function seedBackgroundAtLoginPreference(userData: string): Promise<void> 
   );
 }
 
-async function cdpPage(port: number) {
-  const connection = await connectCdp(await waitForPage(port), () => undefined);
+async function cdpPage(port: number, authority: DebuggerAuthority) {
+  const debuggerUrl = await waitForPage(port);
+  validateDebuggerUrl(debuggerUrl, port, "/devtools/page/");
+  await assertDebuggerListenerOwner(port, authority.pid, authority.environment);
+  const connection = await connectCdpWithin(debuggerUrl);
+  try {
+    await assertDebuggerListenerOwner(port, authority.pid, authority.environment);
+  } catch (error) {
+    connection.socket.close();
+    throw error;
+  }
   const evaluate = async <T>(expression: string): Promise<T> => {
     const response = await connection.call("Runtime.evaluate", {
       expression,
@@ -593,7 +743,9 @@ async function waitForSentMessage(
   await waitUntil(
     `Bot API reply ${text}`,
     () => {
-      found = messages.slice(start).find((message) => message.text === text);
+      found = messages
+        .slice(start)
+        .find((message) => message.chatId === SENDER_ID && message.text === text);
       return found !== undefined;
     },
     40_000,
@@ -601,127 +753,94 @@ async function waitForSentMessage(
   return found as SentMessage;
 }
 
-async function processTree(rootPid: number): Promise<readonly number[]> {
-  const result = await runCommand("/bin/ps", ["-axo", "pid=,ppid="]);
-  const children = new Map<number, number[]>();
-  for (const line of result.stdout.toString("utf8").split(/\r?\n/u)) {
-    const match = /^\s*(\d+)\s+(\d+)\s*$/u.exec(line);
-    if (match === null) continue;
-    const pid = Number(match[1]);
-    const parent = Number(match[2]);
-    const values = children.get(parent) ?? [];
-    values.push(pid);
-    children.set(parent, values);
+async function launchTrackedApplication(
+  environment: NodeJS.ProcessEnv,
+  debugPort: number,
+  userData: string,
+  runningApplications: RunningApplication[],
+  debuggerAuthorities: Map<number, DebuggerAuthority>,
+): Promise<RunningApplication> {
+  const running = launchApplication(environment, debugPort, userData);
+  runningApplications.push(running);
+  const launch = await running.launch;
+  if (launch.state === "spawn-error") {
+    throw new Error("packaged Desktop root process did not spawn", { cause: launch.error });
   }
-  const descendants: number[] = [];
-  const pending = [...(children.get(rootPid) ?? [])];
-  while (pending.length > 0) {
-    const pid = pending.shift() as number;
-    descendants.push(pid);
-    pending.push(...(children.get(pid) ?? []));
+  const existing = debuggerAuthorities.get(debugPort);
+  if (existing !== undefined && existing.connection.socket.readyState === WebSocket.OPEN) {
+    await assertDebuggerListenerOwner(debugPort, existing.pid, existing.environment);
+    running.browserConnection = existing.connection;
+    return running;
   }
-  return descendants;
+  debuggerAuthorities.delete(debugPort);
+  const connection = await connectBrowserDebugger(debugPort, launch.pid, environment);
+  const authority = { pid: launch.pid, connection, environment };
+  debuggerAuthorities.set(debugPort, authority);
+  running.browserConnection = connection;
+  return running;
 }
 
-async function observeDarwinProcess(pid: number): Promise<DarwinProcessObservation> {
-  const result = await runCommand(
-    "/bin/ps",
-    ["-ww", "-p", String(pid), "-o", "pid=", "-o", "lstart=", "-o", "command="],
-    { allowFailure: true },
-  );
-  return parseDarwinProcessObservation(result, pid, application);
-}
-
-async function captureProcess(
-  pid: number,
-  trackedProcesses: Map<number, DarwinProcessBirthIdentity>,
-): Promise<boolean> {
-  const observation = await observeDarwinProcess(pid);
-  if (observation.state === "absent") return false;
-  const existing = trackedProcesses.get(pid);
-  if (
-    existing !== undefined &&
-    classifyDarwinProcessObservation(existing, observation) !== "same"
-  ) {
-    throw new TypeError(`packaged Desktop PID ${pid} was reused during capture`);
+function requireDebuggerAuthority(
+  debuggerAuthorities: ReadonlyMap<number, DebuggerAuthority>,
+  port: number,
+): DebuggerAuthority {
+  const authority = debuggerAuthorities.get(port);
+  if (authority === undefined || authority.connection.socket.readyState !== WebSocket.OPEN) {
+    throw new TypeError("Desktop debugger authority is unavailable");
   }
-  trackedProcesses.set(pid, observation.identity);
-  return true;
+  return authority;
 }
 
-async function captureApplicationProcesses(
+async function cleanApplicationExit(
   running: RunningApplication,
-  trackedProcesses: Map<number, DarwinProcessBirthIdentity>,
-): Promise<void> {
-  const rootPid = running.child.pid;
-  if (rootPid === undefined) return;
-  if (!(await captureProcess(rootPid, trackedProcesses))) return;
-  for (const pid of await processTree(rootPid)) {
-    await captureProcess(pid, trackedProcesses);
-  }
+  timeoutMs: number,
+): Promise<boolean> {
+  const lifecycle = await Promise.race([
+    Promise.all([running.launch, running.terminal]),
+    delay(timeoutMs).then(() => undefined),
+  ]);
+  return lifecycle !== undefined && telegramAcceptanceDirectExitIsClean(...lifecycle);
 }
 
-async function sameTrackedProcessRunning(identity: DarwinProcessBirthIdentity): Promise<boolean> {
-  const observation = await observeDarwinProcess(identity.pid);
-  const state = classifyDarwinProcessObservation(identity, observation);
-  if (state === "reused") {
-    throw new TypeError(`packaged Desktop PID ${identity.pid} was reused`);
-  }
-  return state === "same";
+async function packagedProcessTableIsClear(operatorHome: string): Promise<boolean> {
+  const [processTable, bundleText] = await Promise.all([
+    runCommand("/bin/ps", ["-ww", "-axo", "pid=", "-o", "ucomm="], {
+      allowFailure: true,
+    }),
+    runCommand("/usr/sbin/lsof", ["-n", "-P", "-a", "-d", "txt", "+D", application, "-F0pn"], {
+      allowFailure: true,
+      environment: { ...process.env, HOME: operatorHome },
+    }),
+  ]);
+  return (
+    telegramAcceptanceProcessTableIsClear(processTable) &&
+    telegramAcceptanceBundleTextIsClear(bundleText, application)
+  );
 }
 
-async function signalTrackedProcesses(
-  trackedProcesses: ReadonlyMap<number, DarwinProcessBirthIdentity>,
-  signal: NodeJS.Signals,
-): Promise<void> {
-  const errors: unknown[] = [];
-  for (const identity of trackedProcesses.values()) {
-    if (identity.pid === process.pid) {
-      errors.push(new Error("packaged Desktop process tracking included the acceptance driver"));
-      continue;
-    }
-    try {
-      if (!(await sameTrackedProcessRunning(identity))) continue;
-      try {
-        process.kill(identity.pid, signal);
-      } catch (error) {
-        if (await sameTrackedProcessRunning(identity)) errors.push(error);
-      }
-    } catch (error) {
-      errors.push(error);
-    }
-  }
-  if (errors.length > 0) throw new AggregateError(errors, `packaged Desktop ${signal} failed`);
-}
-
-async function waitForTrackedProcessExit(
-  trackedProcesses: ReadonlyMap<number, DarwinProcessBirthIdentity>,
+async function waitForStablePackagedProcessExit(
+  operatorHome: string,
   timeoutMs: number,
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
+  let consecutiveClear = 0;
   while (Date.now() < deadline) {
-    let running = false;
-    for (const identity of trackedProcesses.values()) {
-      if (await sameTrackedProcessRunning(identity)) running = true;
+    if (await packagedProcessTableIsClear(operatorHome)) {
+      consecutiveClear += 1;
+      if (consecutiveClear === 3) return true;
+    } else {
+      consecutiveClear = 0;
     }
-    if (!running) return true;
-    await delay(50);
+    await delay(100);
   }
-  for (const identity of trackedProcesses.values()) {
-    if (await sameTrackedProcessRunning(identity)) return false;
-  }
-  return true;
+  return false;
 }
 
-async function terminateTrackedProcesses(
-  trackedProcesses: ReadonlyMap<number, DarwinProcessBirthIdentity>,
+async function requestBrowserClose(
+  connection: Awaited<ReturnType<typeof connectCdp>>,
 ): Promise<void> {
-  await signalTrackedProcesses(trackedProcesses, "SIGTERM");
-  if (await waitForTrackedProcessExit(trackedProcesses, 5_000)) return;
-  await signalTrackedProcesses(trackedProcesses, "SIGKILL");
-  if (!(await waitForTrackedProcessExit(trackedProcesses, 5_000))) {
-    throw new Error("packaged Desktop processes remained alive");
-  }
+  const command = connection.call("Browser.close").catch(() => undefined);
+  await Promise.race([command, delay(2_500)]);
 }
 
 function portOpen(port: number): Promise<boolean> {
@@ -739,18 +858,12 @@ async function gracefulQuit(
   running: RunningApplication,
   page: Awaited<ReturnType<typeof cdpPage>>,
   debugPort: number,
-  trackedProcesses: Map<number, DarwinProcessBirthIdentity>,
 ): Promise<void> {
-  await captureApplicationProcesses(running, trackedProcesses);
-  await page.connection.call("Browser.close").catch(() => undefined);
-  const exit = await Promise.race([running.exited, delay(30_000).then(() => undefined)]);
-  assert(exit !== undefined, "packaged Desktop did not quit gracefully");
-  assert(exit.code === 0 && exit.signal === null, "packaged Desktop quit was not clean");
-  assert(
-    await waitForTrackedProcessExit(trackedProcesses, 30_000),
-    "packaged Desktop process tree remained live after graceful quit",
-  );
+  await requestBrowserClose(running.browserConnection ?? page.connection);
+  assert(await cleanApplicationExit(running, 30_000), "packaged Desktop quit was not clean");
   await waitUntil("Desktop debugging listener exit", async () => !(await portOpen(debugPort)));
+  page.closeSocket();
+  running.browserConnection?.socket.close();
 }
 
 async function treeContains(root: string, value: string): Promise<boolean> {
@@ -818,7 +931,7 @@ async function main(): Promise<void> {
   const token = `123456789:${randomBytes(32).toString("base64url").slice(0, 35)}`;
   const originalClipboard = await clipboardBytes();
   const runningApplications: RunningApplication[] = [];
-  const trackedProcesses = new Map<number, DarwinProcessBirthIdentity>();
+  const debuggerAuthorities = new Map<number, DebuggerAuthority>();
   let keychain: DisposableKeychain | undefined;
   let telegram: Awaited<ReturnType<typeof createTelegramBotApi>> | undefined;
   let primary: RunningApplication | undefined;
@@ -890,10 +1003,22 @@ async function main(): Promise<void> {
       CLICOLOR_FORCE: undefined,
     });
 
-    primary = launchApplication(environment, debugPort, userData);
-    runningApplications.push(primary);
-    page = await cdpPage(debugPort);
-    await captureApplicationProcesses(primary, trackedProcesses);
+    primary = await launchTrackedApplication(
+      environment,
+      debugPort,
+      userData,
+      runningApplications,
+      debuggerAuthorities,
+    );
+    try {
+      page = await cdpPage(debugPort, requireDebuggerAuthority(debuggerAuthorities, debugPort));
+    } catch (error) {
+      const processOutput = JSON.stringify(primary.output()).replaceAll(token, "<redacted>");
+      throw new Error(
+        `${error instanceof Error ? error.message : "Desktop renderer did not start"}; exit=${String(primary.child.exitCode)}; signal=${String(primary.child.signalCode)}; process=${processOutput.slice(0, 2_000)}`,
+        { cause: error },
+      );
+    }
     await page.evaluate(
       `localStorage.setItem(${JSON.stringify(ONBOARDING_STORAGE_KEY)}, ${JSON.stringify(ONBOARDING_STORAGE_VALUE)}); true`,
     );
@@ -957,21 +1082,29 @@ async function main(): Promise<void> {
     );
 
     messageStart = telegram.sentMessages.length;
+    const freeTextMessageStart = messageStart;
     const chatActionStart = telegram.chatActions.length;
-    telegram.enqueue("How should I train today?");
+    const freeTextUpdate = telegram.enqueue("How should I train today?");
+    let freeTextInitialSelectionSequence: number | undefined;
     await waitForSentMessage(telegram.sentMessages, GENERIC_FAILURE, messageStart);
-    assert(
-      telegram.chatActions
-        .slice(chatActionStart)
-        .some((action) => action.action === "typing" && Number(action.chat_id) === SENDER_ID),
-      "free-text Telegram handling did not send a typing action",
-    );
-    assert(
-      !telegram.sentMessages
-        .slice(messageStart)
-        .some((message) => /(?:tempo|interval|recovery|ride|training plan)/iu.test(message.text)),
-      "credential-free acceptance unexpectedly produced substantive coaching",
-    );
+    await waitUntil("free-text Telegram update transport progression", () => {
+      const requests = telegram?.getUpdatesRequests() ?? [];
+      const selections = requests.filter((request) =>
+        request.selectedUpdateIds.includes(freeTextUpdate.update_id),
+      );
+      const selection = selections[0];
+      const latest = requests.at(-1);
+      const progressed =
+        selections.length === 1 &&
+        selection !== undefined &&
+        latest !== undefined &&
+        latest.sequence > selection.sequence &&
+        latest.offset > freeTextUpdate.update_id &&
+        latest.state === "pending" &&
+        telegram?.activePollCount() === 1;
+      if (progressed) freeTextInitialSelectionSequence = selection.sequence;
+      return progressed;
+    });
 
     const pairedDesired = JSON.parse(
       await readFile(join(userData, TELEGRAM_VAULT_DIRECTORY, TELEGRAM_DESIRED_STATE_FILE), "utf8"),
@@ -987,7 +1120,35 @@ async function main(): Promise<void> {
       "paired Telegram access state was not durable before restart",
     );
     await seedBackgroundAtLoginPreference(userData);
-    await gracefulQuit(primary, page, debugPort, trackedProcesses);
+    await gracefulQuit(primary, page, debugPort);
+    const freeTextActions = telegram.chatActions.slice(chatActionStart);
+    assert(
+      freeTextActions.length > 0 &&
+        freeTextActions.every(
+          (action) => action.action === "typing" && Number(action.chat_id) === SENDER_ID,
+        ),
+      "free-text Telegram handling produced an invalid typing-action sequence",
+    );
+    const freeTextReplies = telegram.sentMessages.slice(freeTextMessageStart);
+    assert(
+      freeTextReplies.every((message) => message.chatId === SENDER_ID),
+      `credential-free acceptance replied to the wrong Telegram chat: ${JSON.stringify(
+        freeTextReplies,
+      )
+        .replaceAll(token, "<redacted>")
+        .slice(0, 600)}`,
+    );
+    const freeTextReplyTexts = freeTextReplies.map((message) => message.text);
+    assert(
+      JSON.stringify(freeTextReplyTexts) === JSON.stringify([GENERIC_FAILURE]) ||
+        JSON.stringify(freeTextReplyTexts) ===
+          JSON.stringify([EXPECTED_WELCOME_MESSAGE, GENERIC_FAILURE]),
+      `credential-free acceptance produced an invalid response set after daemon drain: ${JSON.stringify(
+        freeTextReplyTexts,
+      )
+        .replaceAll(token, "<redacted>")
+        .slice(0, 600)}`,
+    );
     primary = undefined;
     page = undefined;
 
@@ -996,13 +1157,18 @@ async function main(): Promise<void> {
       ...environment,
       [ACCEPTANCE_OS_LOGIN_MARKER_ENV]: ACCEPTANCE_OS_LOGIN_MARKER_VALUE,
     };
-    primary = launchApplication(backgroundEnvironment, debugPort, userData);
-    runningApplications.push(primary);
+    primary = await launchTrackedApplication(
+      backgroundEnvironment,
+      debugPort,
+      userData,
+      runningApplications,
+      debuggerAuthorities,
+    );
+    const backgroundDebuggerAuthority = requireDebuggerAuthority(debuggerAuthorities, debugPort);
     await waitUntil("cold-start Telegram long poll", () => telegram?.activePollCount() === 1);
     await waitUntil("cold-start debugger listener", () => portOpen(debugPort));
-    await captureApplicationProcesses(primary, trackedProcesses);
     assert(
-      (await mainRendererTargets(debugPort)).length === 0,
+      (await mainRendererTargets(debugPort, backgroundDebuggerAuthority)).length === 0,
       "OS-login cold start created a main renderer",
     );
     messageStart = telegram.sentMessages.length;
@@ -1013,47 +1179,63 @@ async function main(): Promise<void> {
       messageStart,
     );
     assert(
-      (await mainRendererTargets(debugPort)).length === 0,
+      freeTextInitialSelectionSequence !== undefined,
+      "initial free-text Telegram selection was not observed",
+    );
+    const initialFreeTextSelectionSequence = freeTextInitialSelectionSequence;
+    assert(
+      telegram
+        .getUpdatesRequests()
+        .some(
+          (request) =>
+            request.sequence > initialFreeTextSelectionSequence &&
+            request.state === "settled" &&
+            request.selectedUpdateIds.includes(freeTextUpdate.update_id),
+        ),
+      "cold-start Telegram polling did not replay the persisted free-text update",
+    );
+    assert(
+      (await mainRendererTargets(debugPort, backgroundDebuggerAuthority)).length === 0,
       "background Telegram handling created a main renderer",
     );
 
-    const foregroundRequest = launchApplication(environment, debugPort, userData);
-    runningApplications.push(foregroundRequest);
-    await captureApplicationProcesses(foregroundRequest, trackedProcesses);
-    const foregroundRequestExit = await Promise.race([
-      foregroundRequest.exited,
-      delay(20_000).then(() => undefined),
-    ]);
-    assert(foregroundRequestExit !== undefined, "foreground second launch did not exit");
+    const foregroundRequest = await launchTrackedApplication(
+      environment,
+      debugPort,
+      userData,
+      runningApplications,
+      debuggerAuthorities,
+    );
     assert(
-      foregroundRequestExit.code === 0 && foregroundRequestExit.signal === null,
+      await cleanApplicationExit(foregroundRequest, 20_000),
       "foreground second launch exit was not clean",
     );
     await waitUntil(
       "one foreground main renderer",
-      async () => (await mainRendererTargets(debugPort)).length === 1,
+      async () => (await mainRendererTargets(debugPort, backgroundDebuggerAuthority)).length === 1,
     );
     await delay(250);
     assert(
-      (await mainRendererTargets(debugPort)).length === 1,
+      (await mainRendererTargets(debugPort, backgroundDebuggerAuthority)).length === 1,
       "second launch did not open exactly one main renderer",
     );
-    page = await cdpPage(debugPort);
+    page = await cdpPage(debugPort, requireDebuggerAuthority(debuggerAuthorities, debugPort));
 
     await page.evaluate("window.close(); true").catch(() => undefined);
     page.closeSocket();
     await waitUntil(
       "resident window closure",
       async () => {
-        try {
-          await waitForPage(debugPort);
+        if ((await mainRendererTargets(debugPort, backgroundDebuggerAuthority)).length !== 0) {
           return false;
-        } catch {
-          const pid = primary?.child.pid;
-          const identity = pid === undefined ? undefined : trackedProcesses.get(pid);
-          assert(identity !== undefined, "resident Desktop birth identity is missing");
-          return sameTrackedProcessRunning(identity);
         }
+        if (primary === undefined) return false;
+        const launch = await primary.launch;
+        return (
+          launch.state === "spawned" &&
+          primary.child.exitCode === null &&
+          primary.child.signalCode === null
+        );
       },
       25_000,
     );
@@ -1065,20 +1247,19 @@ async function main(): Promise<void> {
       messageStart,
     );
 
-    const secondary = launchApplication(environment, debugPort, userData);
-    runningApplications.push(secondary);
+    const secondary = await launchTrackedApplication(
+      environment,
+      debugPort,
+      userData,
+      runningApplications,
+      debuggerAuthorities,
+    );
     await delay(250);
-    await captureApplicationProcesses(secondary, trackedProcesses);
-    const secondaryExit = await Promise.race([
-      secondary.exited,
-      delay(20_000).then(() => undefined),
-    ]);
-    assert(secondaryExit !== undefined, "secondary Desktop instance did not exit");
     assert(
-      secondaryExit.code === 0 && secondaryExit.signal === null,
+      await cleanApplicationExit(secondary, 20_000),
       "secondary Desktop instance exit was not clean",
     );
-    page = await cdpPage(debugPort);
+    page = await cdpPage(debugPort, requireDebuggerAuthority(debuggerAuthorities, debugPort));
     await waitForButton(page, "Settings");
     await page.clickButton("Settings");
     await waitForButton(page, "Turn off");
@@ -1098,15 +1279,19 @@ async function main(): Promise<void> {
     assert(telegram.sentMessages.length === messageStart, "disabled Telegram replied to an update");
     assert(telegram.pollCount() === disabledPollCount, "disabled Telegram continued polling");
 
-    await gracefulQuit(primary, page, debugPort, trackedProcesses);
+    await gracefulQuit(primary, page, debugPort);
     primary = undefined;
     page = undefined;
 
     const relaunchPort = await reservePort();
-    primary = launchApplication(environment, relaunchPort, userData);
-    runningApplications.push(primary);
-    page = await cdpPage(relaunchPort);
-    await captureApplicationProcesses(primary, trackedProcesses);
+    primary = await launchTrackedApplication(
+      environment,
+      relaunchPort,
+      userData,
+      runningApplications,
+      debuggerAuthorities,
+    );
+    page = await cdpPage(relaunchPort, requireDebuggerAuthority(debuggerAuthorities, relaunchPort));
     await waitForButton(page, "Settings");
     await page.clickButton("Settings");
     await waitForButton(page, "Turn on");
@@ -1128,14 +1313,16 @@ async function main(): Promise<void> {
       const selections = requests.filter((request) =>
         request.selectedUpdateIds.includes(pendingUpdate.update_id),
       );
-      if (selections.length !== 1) return false;
+      const selection = selections[0];
+      const latest = requests.at(-1);
       return (
-        requests.some(
-          (request) =>
-            request.sequence > (selections[0]?.sequence ?? Number.MAX_SAFE_INTEGER) &&
-            request.offset > pendingUpdate.update_id &&
-            !request.settled,
-        ) && telegram?.activePollCount() === 1
+        selections.length === 1 &&
+        selection !== undefined &&
+        latest !== undefined &&
+        latest.sequence > selection.sequence &&
+        latest.offset > pendingUpdate.update_id &&
+        latest.state === "pending" &&
+        telegram?.activePollCount() === 1
       );
     });
     assert(
@@ -1146,13 +1333,14 @@ async function main(): Promise<void> {
       "pending Telegram update was not delivered exactly once",
     );
     const resumedRequests = telegram.getUpdatesRequests();
+    const latestResumedRequest = resumedRequests.at(-1);
     assert(
       resumedRequests.filter((request) =>
         request.selectedUpdateIds.includes(pendingUpdate.update_id),
       ).length === 1 &&
-        resumedRequests.some(
-          (request) => request.offset > pendingUpdate.update_id && !request.settled,
-        ),
+        latestResumedRequest !== undefined &&
+        latestResumedRequest.offset > pendingUpdate.update_id &&
+        latestResumedRequest.state === "pending",
       "pending Telegram update offset did not advance exactly once",
     );
 
@@ -1196,6 +1384,17 @@ async function main(): Promise<void> {
     assert(!(await page.domHtml()).includes(token), "Telegram credential reached renderer DOM");
     await page.screenshot(join(screenshots, "removed.png"));
     await assertOutputSecretFree(runningApplications, token);
+    const postFreeTextMessages = telegram.sentMessages.slice(freeTextMessageStart);
+    const versionReply = `Cycling Coach Desktop v${packageManifest.version}`;
+    assert(
+      postFreeTextMessages.every((message) => message.chatId === SENDER_ID),
+      "packaged Telegram acceptance sent a response to the wrong chat",
+    );
+    assert(
+      JSON.stringify(postFreeTextMessages.map((message) => message.text)) ===
+        JSON.stringify([...freeTextReplyTexts, versionReply, versionReply, versionReply]),
+      "packaged Telegram acceptance produced a late, duplicate, or replayed response",
+    );
     await writeFile(
       join(results, "summary.json"),
       `${JSON.stringify({
@@ -1210,7 +1409,7 @@ async function main(): Promise<void> {
       })}\n`,
       { mode: 0o600 },
     );
-    await gracefulQuit(primary, page, relaunchPort, trackedProcesses);
+    await gracefulQuit(primary, page, relaunchPort);
     primary = undefined;
     page = undefined;
     successResult = {
@@ -1235,31 +1434,43 @@ async function main(): Promise<void> {
       }
     };
 
-    await attempt(() => page?.closeSocket());
-    let processTeardownSafe = true;
+    const browserConnections = new Set<Awaited<ReturnType<typeof connectCdp>>>();
+    if (page !== undefined) browserConnections.add(page.connection);
     for (const running of runningApplications) {
-      try {
-        await captureApplicationProcesses(running, trackedProcesses);
-      } catch (error) {
-        processTeardownSafe = false;
-        cleanupErrors.push(error);
+      if (running.browserConnection !== undefined) {
+        browserConnections.add(running.browserConnection);
       }
     }
-    try {
-      await terminateTrackedProcesses(trackedProcesses);
-    } catch (error) {
-      processTeardownSafe = false;
-      cleanupErrors.push(error);
+    await Promise.all([...browserConnections].map(requestBrowserClose));
+    const directExits = await Promise.all(
+      runningApplications.map((running) => cleanApplicationExit(running, 10_000)),
+    );
+    const directApplicationsExitedCleanly = directExits.every(Boolean);
+    if (!directApplicationsExitedCleanly) {
+      cleanupErrors.push(
+        new Error("a directly launched packaged Desktop process did not exit cleanly"),
+      );
     }
+    await attempt(() => page?.closeSocket());
+    for (const running of runningApplications) {
+      await attempt(() => running.browserConnection?.socket.close());
+    }
+    let processTableClear = false;
     try {
-      if (!(await waitForTrackedProcessExit(trackedProcesses, 0))) {
-        processTeardownSafe = false;
-        cleanupErrors.push(new Error("tracked packaged Desktop process remained live"));
+      processTableClear = await waitForStablePackagedProcessExit(operatorHome, 5_000);
+      if (!processTableClear) {
+        cleanupErrors.push(
+          new Error("a packaged Desktop executable remained in the process table"),
+        );
       }
     } catch (error) {
-      processTeardownSafe = false;
       cleanupErrors.push(error);
     }
+    const processTeardownSafe = telegramAcceptanceShutdownIsProven({
+      executionSucceeded: executionError === undefined && successResult !== undefined,
+      directApplicationsExitedCleanly,
+      processTableClear,
+    });
     let debuggerListenersClosed = true;
     for (const debugPort of new Set(runningApplications.map((running) => running.debugPort))) {
       try {

--- a/apps/desktop/scripts/verify-package-layout.mjs
+++ b/apps/desktop/scripts/verify-package-layout.mjs
@@ -81,6 +81,12 @@ const knownSecretMarkers = [
   "sentinel-my-llm-key",
   "synthetic-secret",
 ];
+const acceptanceOnlyMarkers = [
+  "enduragent_acceptance_telegram_bot_api_origin",
+  "enduragent_acceptance_os_login_launch",
+  "enduragent-desktop-telegram-acceptance",
+  "enduragentdesktoptelegramacceptance",
+];
 const removedMainManifestKeys = new Set([
   "dist",
   "gitHead",
@@ -206,6 +212,9 @@ function inspectPath(path, label) {
 
 function inspectContents(bytes, label) {
   const text = bytes.toString("latin1").toLowerCase();
+  if (acceptanceOnlyMarkers.some((marker) => text.includes(marker))) {
+    fail("acceptance-only package marker", label);
+  }
   if (
     knownSecretMarkers.some((marker) => text.includes(marker)) ||
     /obviously-fake-[a-z0-9-]{1,96}key\b/u.test(text) ||

--- a/apps/desktop/tests/desktop-fixture-wait-for-page.test.ts
+++ b/apps/desktop/tests/desktop-fixture-wait-for-page.test.ts
@@ -1,0 +1,34 @@
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { waitForPage } from "./helpers/desktop-fixture.js";
+
+describe("Desktop renderer discovery", () => {
+  const servers: ReturnType<typeof createServer>[] = [];
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    for (const server of servers.splice(0)) {
+      server.closeAllConnections();
+      await new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => (error === undefined ? resolveClose() : rejectClose(error)));
+      });
+    }
+  });
+
+  it("honors the overall deadline when a debugging probe never responds", async () => {
+    const server = createServer(() => undefined);
+    servers.push(server);
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once("error", rejectListen);
+      server.listen({ host: "127.0.0.1", port: 0 }, resolveListen);
+    });
+    const address = server.address();
+    if (address === null || typeof address === "string") throw new TypeError();
+
+    const started = performance.now();
+    await expect(waitForPage(address.port, { timeoutMs: 150, probeTimeoutMs: 25 })).rejects.toThrow(
+      "timed out waiting for the desktop renderer",
+    );
+    expect(performance.now() - started).toBeLessThan(750);
+  });
+});

--- a/apps/desktop/tests/disposable-keychain.test.ts
+++ b/apps/desktop/tests/disposable-keychain.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  prepareDisposableKeychain,
+  type KeychainCommandEnvironment,
+  type KeychainCommandResult,
+  type RunKeychainCommand,
+} from "./fixtures/packaged-telegram/disposable-keychain.js";
+
+const operatorHome = "/tmp/acceptance-home";
+const disposable = `${operatorHome}/Library/Keychains/acceptance.keychain-db`;
+const login = "/Users/athlete/Library/Keychains/login.keychain-db";
+
+function success(stdout = ""): KeychainCommandResult {
+  return {
+    code: 0,
+    signal: null,
+    stdout: Buffer.from(stdout),
+    stderr: Buffer.alloc(0),
+  };
+}
+
+function noDefault(
+  diagnostic = "security: SecKeychainCopyDefault: A default keychain could not be found.\n",
+): KeychainCommandResult {
+  return {
+    code: 1,
+    signal: null,
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.from(diagnostic),
+  };
+}
+
+function failure(): KeychainCommandResult {
+  return {
+    code: 1,
+    signal: null,
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.from("synthetic failure\n"),
+  };
+}
+
+function commandHarness(
+  input: {
+    readonly defaultPath?: string | null;
+    readonly searchPaths?: readonly string[];
+    readonly noDefaultDiagnostic?: string;
+  } = {},
+) {
+  const calls: {
+    readonly args: readonly string[];
+    readonly environment: KeychainCommandEnvironment;
+  }[] = [];
+  let defaultPath = input.defaultPath ?? null;
+  let searchPaths = [...(input.searchPaths ?? [])];
+  let created = false;
+  let failDefaultClear = false;
+  let failDelete = false;
+  let failDefaultVerificationWith: string | undefined;
+  const run = vi.fn(
+    async (
+      args: readonly string[],
+      options: { readonly environment: KeychainCommandEnvironment },
+    ): Promise<KeychainCommandResult> => {
+      calls.push({ args: [...args], environment: { ...options.environment } });
+      if (options.environment.HOME !== operatorHome) return failure();
+      if (args[0] === "default-keychain" && !args.includes("-s")) {
+        if (failDefaultVerificationWith !== undefined) {
+          defaultPath = failDefaultVerificationWith;
+          failDefaultVerificationWith = undefined;
+        }
+        return defaultPath === null
+          ? noDefault(input.noDefaultDiagnostic)
+          : success(`"${defaultPath}"\n`);
+      }
+      if (args[0] === "list-keychains" && !args.includes("-s")) {
+        return success(searchPaths.map((path) => `    "${path}"`).join("\n"));
+      }
+      if (args[0] === "create-keychain") {
+        created = true;
+        return success();
+      }
+      if (args[0] === "unlock-keychain" || args[0] === "set-keychain-settings") {
+        return created ? success() : failure();
+      }
+      if (args[0] === "default-keychain" && args.includes("-s")) {
+        if (args.length === 4 && failDefaultClear) {
+          failDefaultClear = false;
+          return failure();
+        }
+        defaultPath = args[4] ?? null;
+        return success();
+      }
+      if (args[0] === "list-keychains" && args.includes("-s")) {
+        searchPaths = args.slice(4);
+        return success();
+      }
+      if (args[0] === "delete-keychain") {
+        if (failDelete) {
+          failDelete = false;
+          return failure();
+        }
+        if (!created) return failure();
+        created = false;
+        return success();
+      }
+      return failure();
+    },
+  ) as RunKeychainCommand;
+  return {
+    calls,
+    run,
+    state: () => ({ defaultPath, searchPaths: [...searchPaths], created }),
+    failNextDefaultClear: () => {
+      failDefaultClear = true;
+    },
+    failNextDelete: () => {
+      failDelete = true;
+    },
+    failNextDefaultVerification: (path: string) => {
+      failDefaultVerificationWith = path;
+    },
+  };
+}
+
+async function prepared(commands = commandHarness()) {
+  const keychain = await prepareDisposableKeychain({
+    home: operatorHome,
+    path: disposable,
+    password: "password",
+    environment: {
+      HOME: "/Users/athlete",
+      PATH: "/usr/bin:/bin",
+      LANG: "en_US.UTF-8",
+    },
+    run: commands.run,
+  });
+  return { commands, keychain };
+}
+
+describe("disposable keychain", () => {
+  it("activates and restores an exact virgin HOME without reading another HOME", async () => {
+    const { commands, keychain } = await prepared();
+
+    await keychain.activate();
+    expect(commands.state()).toEqual({
+      defaultPath: disposable,
+      searchPaths: [disposable],
+      created: true,
+    });
+    expect(commands.calls.every((call) => call.environment.HOME === operatorHome)).toBe(true);
+    expect(
+      commands.calls.every(
+        (call) =>
+          call.environment.PATH === "/usr/bin:/bin" && call.environment.LANG === "en_US.UTF-8",
+      ),
+    ).toBe(true);
+
+    await keychain.restore();
+    expect(keychain.restored()).toBe(true);
+    expect(commands.state()).toEqual({ defaultPath: null, searchPaths: [], created: false });
+    expect(commands.calls.slice(-5).map((call) => call.args)).toEqual([
+      ["default-keychain", "-d", "user", "-s"],
+      ["list-keychains", "-d", "user", "-s"],
+      ["delete-keychain", disposable],
+      ["default-keychain", "-d", "user"],
+      ["list-keychains", "-d", "user"],
+    ]);
+  });
+
+  it("accepts a localized missing-default diagnostic for a virgin HOME", async () => {
+    const { keychain } = await prepared(
+      commandHarness({
+        noDefaultDiagnostic: "security: kein Standardschl\u00fcsselbund gefunden\n",
+      }),
+    );
+
+    await keychain.activate();
+    await keychain.restore();
+    expect(keychain.restored()).toBe(true);
+  });
+
+  it.each([
+    { defaultPath: login, searchPaths: [] },
+    { defaultPath: null, searchPaths: [login] },
+  ])("fails closed when the temporary HOME is not virgin: %o", async (state) => {
+    const commands = commandHarness(state);
+
+    await expect(
+      prepareDisposableKeychain({
+        home: operatorHome,
+        path: disposable,
+        password: "password",
+        environment: process.env,
+        run: commands.run,
+      }),
+    ).rejects.toThrow(/unexpected/u);
+    expect(commands.calls.some((call) => call.args[0] === "create-keychain")).toBe(false);
+  });
+
+  it("retains the keychain when preference restoration fails and retries idempotently", async () => {
+    const { commands, keychain } = await prepared();
+    await keychain.activate();
+    commands.failNextDefaultClear();
+
+    await expect(keychain.restore()).rejects.toThrow(`recovery retained at ${disposable}`);
+    expect(keychain.restored()).toBe(false);
+    expect(commands.state().created).toBe(true);
+
+    await keychain.restore();
+    expect(keychain.restored()).toBe(true);
+    expect(commands.state()).toEqual({ defaultPath: null, searchPaths: [], created: false });
+  });
+
+  it("retries deletion without marking restoration complete", async () => {
+    const { commands, keychain } = await prepared();
+    await keychain.activate();
+    commands.failNextDelete();
+
+    await expect(keychain.restore()).rejects.toThrow(`recovery retained at ${disposable}`);
+    expect(keychain.restored()).toBe(false);
+    expect(commands.state()).toEqual({ defaultPath: null, searchPaths: [], created: true });
+
+    await keychain.restore();
+    expect(keychain.restored()).toBe(true);
+    expect(commands.state()).toEqual({ defaultPath: null, searchPaths: [], created: false });
+  });
+
+  it("retries failed virgin-state postconditions after deletion", async () => {
+    const { commands, keychain } = await prepared();
+    await keychain.activate();
+    commands.failNextDefaultVerification(login);
+
+    await expect(keychain.restore()).rejects.toThrow(`recovery retained at ${disposable}`);
+    expect(keychain.restored()).toBe(false);
+    expect(commands.state()).toEqual({ defaultPath: login, searchPaths: [], created: false });
+
+    await keychain.restore();
+    expect(keychain.restored()).toBe(true);
+    expect(commands.state()).toEqual({ defaultPath: null, searchPaths: [], created: false });
+  });
+});

--- a/apps/desktop/tests/fixtures/packaged-telegram/acceptance-deadline.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/acceptance-deadline.ts
@@ -1,0 +1,165 @@
+import { spawn, type ChildProcess } from "node:child_process";
+
+export interface AcceptanceCommandResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: Buffer;
+  readonly stderr: Buffer;
+}
+
+interface AcceptanceDeadlineOptions {
+  readonly timeoutMs: number;
+  readonly onTimeout?: () => void;
+}
+
+interface AcceptanceCommandOptions {
+  readonly input?: Buffer | string;
+  readonly allowFailure?: boolean;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly timeoutMs?: number;
+  readonly terminationGraceMs?: number;
+}
+
+interface AcceptanceChildTerminationOptions {
+  readonly terminationGraceMs?: number;
+  readonly killGraceMs?: number;
+}
+
+interface AcceptanceCdpConnection {
+  readonly socket: { close(): void };
+  call(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+function positiveMilliseconds(value: number, description: string): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new TypeError(`${description} is invalid`);
+  }
+  return value;
+}
+
+export async function withAcceptanceDeadline<T>(
+  description: string,
+  operation: Promise<T>,
+  options: AcceptanceDeadlineOptions,
+): Promise<T> {
+  const timeoutMs = positiveMilliseconds(options.timeoutMs, "acceptance deadline");
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      try {
+        options.onTimeout?.();
+      } catch {}
+      reject(new Error(`${description} timed out`));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+export function runAcceptanceCommand(
+  command: string,
+  args: readonly string[],
+  options: AcceptanceCommandOptions = {},
+): Promise<AcceptanceCommandResult> {
+  const timeoutMs = positiveMilliseconds(options.timeoutMs ?? 10_000, "command timeout");
+  const terminationGraceMs = positiveMilliseconds(
+    options.terminationGraceMs ?? 500,
+    "command termination grace",
+  );
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, {
+      env: options.environment,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let settled = false;
+    let timedOut = false;
+    let forceKillTimer: NodeJS.Timeout | undefined;
+    let abandonTimer: NodeJS.Timeout | undefined;
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      forceKillTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+        abandonTimer = setTimeout(() => finish(new Error("command timed out")), terminationGraceMs);
+      }, terminationGraceMs);
+    }, timeoutMs);
+    const clearTimers = (): void => {
+      clearTimeout(timeoutTimer);
+      if (forceKillTimer !== undefined) clearTimeout(forceKillTimer);
+      if (abandonTimer !== undefined) clearTimeout(abandonTimer);
+    };
+    const finish = (error: Error | undefined, result?: AcceptanceCommandResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      if (error !== undefined) rejectRun(error);
+      else resolveRun(result as AcceptanceCommandResult);
+    };
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.stdin.on("error", () => undefined);
+    child.once("error", () => finish(new Error("command could not start")));
+    child.once("close", (code, signal) => {
+      if (timedOut) {
+        finish(new Error("command timed out"));
+        return;
+      }
+      const result = {
+        code,
+        signal,
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr),
+      };
+      if (!options.allowFailure && (code !== 0 || signal !== null)) {
+        finish(new Error("command failed"));
+      } else {
+        finish(undefined, result);
+      }
+    });
+    try {
+      child.stdin.end(options.input);
+    } catch {
+      child.kill("SIGKILL");
+      finish(new Error("command input failed"));
+    }
+  });
+}
+
+export async function terminateAcceptanceChild(
+  child: ChildProcess,
+  options: AcceptanceChildTerminationOptions = {},
+): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return true;
+  const terminationGraceMs = positiveMilliseconds(
+    options.terminationGraceMs ?? 2_000,
+    "child termination grace",
+  );
+  const killGraceMs = positiveMilliseconds(options.killGraceMs ?? 2_000, "child kill grace");
+  const exited = new Promise<true>((resolveExit) => child.once("exit", () => resolveExit(true)));
+  child.kill("SIGTERM");
+  const terminated = await withAcceptanceDeadline("child termination", exited, {
+    timeoutMs: terminationGraceMs,
+  }).catch(() => false as const);
+  if (terminated) return true;
+  child.kill("SIGKILL");
+  return withAcceptanceDeadline("child kill", exited, { timeoutMs: killGraceMs }).catch(
+    () => false as const,
+  );
+}
+
+export function callAcceptanceCdp(
+  connection: AcceptanceCdpConnection,
+  method: string,
+  params: Record<string, unknown> = {},
+  timeoutMs = 5_000,
+): Promise<Record<string, unknown>> {
+  return withAcceptanceDeadline("Desktop debugger command", connection.call(method, params), {
+    timeoutMs,
+    onTimeout: () => connection.socket.close(),
+  });
+}

--- a/apps/desktop/tests/fixtures/packaged-telegram/daemon-utility.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/daemon-utility.ts
@@ -1,0 +1,6 @@
+import { installTelegramFetchRoute, requireAcceptanceOrigin } from "./telegram-fetch-route.js";
+
+const origin = requireAcceptanceOrigin(process.env.ENDURAGENT_ACCEPTANCE_TELEGRAM_BOT_API_ORIGIN);
+delete process.env.ENDURAGENT_ACCEPTANCE_TELEGRAM_BOT_API_ORIGIN;
+installTelegramFetchRoute(origin);
+await import("../../../src/utility/daemon.js");

--- a/apps/desktop/tests/fixtures/packaged-telegram/disposable-keychain.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/disposable-keychain.ts
@@ -1,0 +1,172 @@
+export interface KeychainCommandResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: Buffer;
+  readonly stderr: Buffer;
+}
+
+export type KeychainCommandEnvironment = Readonly<NodeJS.ProcessEnv> & {
+  readonly HOME: string;
+};
+
+export type RunKeychainCommand = (
+  args: readonly string[],
+  options: { readonly environment: KeychainCommandEnvironment },
+) => Promise<KeychainCommandResult>;
+
+export interface DisposableKeychain {
+  readonly home: string;
+  readonly recoveryPath: string;
+  activate(): Promise<void>;
+  restore(): Promise<void>;
+  restored(): boolean;
+}
+
+function succeeded(result: KeychainCommandResult): boolean {
+  return result.code === 0 && result.signal === null;
+}
+
+function requireSuccess(result: KeychainCommandResult): void {
+  if (!succeeded(result)) throw new TypeError("disposable keychain command failed");
+}
+
+function quotedPaths(value: Buffer): readonly string[] {
+  const source = value.toString("utf8");
+  const paths = [...source.matchAll(/"([^"\r\n]+)"/gu)].map((match) => match[1]);
+  if (source.replaceAll(/"[^"\r\n]+"/gu, "").trim() !== "") {
+    throw new TypeError("keychain state output is invalid");
+  }
+  return paths;
+}
+
+function requireNoDefault(result: KeychainCommandResult): void {
+  if (result.code !== 1 || result.signal !== null || result.stdout.length !== 0) {
+    throw new TypeError("disposable keychain HOME has an unexpected default keychain");
+  }
+}
+
+function requireEmptySearch(result: KeychainCommandResult): void {
+  requireSuccess(result);
+  if (quotedPaths(result.stdout).length !== 0) {
+    throw new TypeError("disposable keychain HOME has an unexpected search list");
+  }
+}
+
+function requireExactActiveState(
+  defaultResult: KeychainCommandResult,
+  searchResult: KeychainCommandResult,
+  expectedPath: string,
+): void {
+  requireSuccess(defaultResult);
+  requireSuccess(searchResult);
+  const defaultPaths = quotedPaths(defaultResult.stdout);
+  const searchPaths = quotedPaths(searchResult.stdout);
+  if (
+    defaultPaths.length !== 1 ||
+    defaultPaths[0] !== expectedPath ||
+    searchPaths.length !== 1 ||
+    searchPaths[0] !== expectedPath
+  ) {
+    throw new TypeError("disposable keychain activation state is invalid");
+  }
+}
+
+export async function prepareDisposableKeychain(input: {
+  readonly home: string;
+  readonly path: string;
+  readonly password: string;
+  readonly environment: Readonly<NodeJS.ProcessEnv>;
+  readonly run: RunKeychainCommand;
+}): Promise<DisposableKeychain> {
+  const environment = Object.freeze({ ...input.environment, HOME: input.home });
+  const run = (args: readonly string[]): Promise<KeychainCommandResult> =>
+    input.run(args, { environment });
+  const verifyVirginState = async (): Promise<void> => {
+    const defaultResult = await run(["default-keychain", "-d", "user"]);
+    const searchResult = await run(["list-keychains", "-d", "user"]);
+    requireNoDefault(defaultResult);
+    requireEmptySearch(searchResult);
+  };
+
+  await verifyVirginState();
+  let created = false;
+  let deleted = false;
+  let active = false;
+  let restorationComplete = false;
+
+  const restore = async (): Promise<void> => {
+    if (restorationComplete) return;
+    const preferenceErrors: unknown[] = [];
+    for (const args of [
+      ["default-keychain", "-d", "user", "-s"],
+      ["list-keychains", "-d", "user", "-s"],
+    ]) {
+      try {
+        requireSuccess(await run(args));
+      } catch (error) {
+        preferenceErrors.push(error);
+      }
+    }
+    if (preferenceErrors.length > 0) {
+      throw new AggregateError(
+        preferenceErrors,
+        `keychain restoration failed; recovery retained at ${input.path}`,
+      );
+    }
+    if (created && !deleted) {
+      try {
+        requireSuccess(await run(["delete-keychain", input.path]));
+        deleted = true;
+      } catch (error) {
+        throw new AggregateError(
+          [error],
+          `keychain deletion failed; recovery retained at ${input.path}`,
+        );
+      }
+    }
+    try {
+      await verifyVirginState();
+    } catch (error) {
+      throw new AggregateError(
+        [error],
+        `keychain restoration verification failed; recovery retained at ${input.path}`,
+      );
+    }
+    restorationComplete = true;
+    active = false;
+  };
+
+  return {
+    home: input.home,
+    recoveryPath: input.path,
+    async activate() {
+      if (active) return;
+      if (restorationComplete) throw new TypeError("disposable keychain was already restored");
+      try {
+        requireSuccess(await run(["create-keychain", "-p", input.password, input.path]));
+        created = true;
+        deleted = false;
+        requireSuccess(await run(["unlock-keychain", "-p", input.password, input.path]));
+        requireSuccess(await run(["set-keychain-settings", "-lut", "21600", input.path]));
+        requireSuccess(await run(["list-keychains", "-d", "user", "-s", input.path]));
+        requireSuccess(await run(["default-keychain", "-d", "user", "-s", input.path]));
+        const defaultResult = await run(["default-keychain", "-d", "user"]);
+        const searchResult = await run(["list-keychains", "-d", "user"]);
+        requireExactActiveState(defaultResult, searchResult, input.path);
+        active = true;
+      } catch (error) {
+        try {
+          await restore();
+        } catch (restoreError) {
+          throw new AggregateError(
+            [error, restoreError],
+            `disposable keychain setup failed; recovery retained at ${input.path}`,
+          );
+        }
+        throw error;
+      }
+    },
+    restore,
+    restored: () => restorationComplete,
+  };
+}

--- a/apps/desktop/tests/fixtures/packaged-telegram/main-entry.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/main-entry.ts
@@ -1,0 +1,5 @@
+import { app } from "electron";
+import { consumeAcceptanceStartupMarker } from "./startup-mode.js";
+
+consumeAcceptanceStartupMarker(process.env, app);
+await import("../../../src/main/index.js");

--- a/apps/desktop/tests/fixtures/packaged-telegram/main-entry.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/main-entry.ts
@@ -1,5 +1,15 @@
 import { app } from "electron";
+import { runTelegramAcceptanceBootstrap } from "./process-safety.js";
 import { consumeAcceptanceStartupMarker } from "./startup-mode.js";
 
-consumeAcceptanceStartupMarker(process.env, app);
-await import("../../../src/main/index.js");
+await runTelegramAcceptanceBootstrap({
+  input: process.stdin,
+  beforeImport: () => consumeAcceptanceStartupMarker(process.env, app),
+  importProduction: () => import("../../../src/main/index.js"),
+  quit: () => app.quit(),
+  report: (diagnostic) => process.stderr.write(`${diagnostic}\n`),
+  exit: (code) => {
+    process.exitCode = code;
+    app.exit(code);
+  },
+});

--- a/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.d.mts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.d.mts
@@ -6,6 +6,9 @@ export const TELEGRAM_ACCEPTANCE_ENTITLEMENTS: Readonly<{
   readonly "com.apple.security.cs.allow-jit": true;
 }>;
 
+export function configureTelegramAcceptanceSigningEnvironment(
+  environment: Record<string, string | undefined>,
+): void;
 export function createTelegramAcceptanceBuilderConfiguration(
   canonical: Record<string, unknown>,
 ): Record<string, unknown>;

--- a/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.d.mts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.d.mts
@@ -9,8 +9,22 @@ export const TELEGRAM_ACCEPTANCE_ENTITLEMENTS: Readonly<{
 export function createTelegramAcceptanceBuilderConfiguration(
   canonical: Record<string, unknown>,
 ): Record<string, unknown>;
-export function verifyTelegramAcceptanceSignature(description: unknown): void;
+export function verifyTelegramAcceptanceSignature(description: unknown): string;
+export function verifyTelegramAcceptanceNestedSignature(description: unknown): void;
 export function verifyTelegramAcceptanceInfoPlist(value: unknown): void;
 export function verifyTelegramAcceptanceEntitlements(value: unknown): void;
-export function verifyTelegramAcceptanceDesignatedRequirement(value: unknown): void;
+export function verifyTelegramAcceptanceNestedEntitlements(value: unknown): void;
+export function verifyTelegramAcceptanceNestedListing(description: unknown): Readonly<{
+  executable: string;
+  nested: readonly string[];
+}>;
+export function selectTelegramAcceptanceNestedTarget(
+  applicationRoot: unknown,
+  candidates: unknown,
+): string;
+export function verifyTelegramAcceptanceDesignatedRequirement(
+  value: unknown,
+  expectedCdHash: unknown,
+): void;
 export function verifyTelegramAcceptanceManifest(value: unknown, expectedVersion: unknown): void;
+export function verifyTelegramAcceptanceMainEntry(value: unknown): string;

--- a/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.d.mts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.d.mts
@@ -27,4 +27,12 @@ export function verifyTelegramAcceptanceDesignatedRequirement(
   expectedCdHash: unknown,
 ): void;
 export function verifyTelegramAcceptanceManifest(value: unknown, expectedVersion: unknown): void;
+export function verifyTelegramAcceptanceWorkspaceRuntime(
+  rootManifest: unknown,
+  archiveEntries: unknown,
+  readManifest: unknown,
+): Readonly<{
+  packages: readonly string[];
+  exportTargets: readonly string[];
+}>;
 export function verifyTelegramAcceptanceMainEntry(value: unknown): string;

--- a/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.d.mts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.d.mts
@@ -1,0 +1,16 @@
+export const TELEGRAM_ACCEPTANCE_APP_ID: "icu.enduragent.desktop.telegram-acceptance";
+export const TELEGRAM_ACCEPTANCE_PACKAGE_NAME: "enduragent-desktop-telegram-acceptance";
+export const TELEGRAM_ACCEPTANCE_PRODUCT_NAME: "Enduragent Telegram Acceptance";
+export const TELEGRAM_ACCEPTANCE_MARKER: "enduragentDesktopTelegramAcceptance";
+export const TELEGRAM_ACCEPTANCE_ENTITLEMENTS: Readonly<{
+  readonly "com.apple.security.cs.allow-jit": true;
+}>;
+
+export function createTelegramAcceptanceBuilderConfiguration(
+  canonical: Record<string, unknown>,
+): Record<string, unknown>;
+export function verifyTelegramAcceptanceSignature(description: unknown): void;
+export function verifyTelegramAcceptanceInfoPlist(value: unknown): void;
+export function verifyTelegramAcceptanceEntitlements(value: unknown): void;
+export function verifyTelegramAcceptanceDesignatedRequirement(value: unknown): void;
+export function verifyTelegramAcceptanceManifest(value: unknown, expectedVersion: unknown): void;

--- a/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.mjs
+++ b/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.mjs
@@ -13,6 +13,72 @@ function exactObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+const WORKSPACE_PACKAGE_NAME = /^@enduragent\/[a-z0-9][a-z0-9._-]*$/u;
+
+function workspaceDependencies(manifest) {
+  if (!exactObject(manifest)) {
+    throw new TypeError("Telegram acceptance workspace manifest is invalid");
+  }
+  if (manifest.dependencies === undefined) return [];
+  if (!exactObject(manifest.dependencies)) {
+    throw new TypeError("Telegram acceptance workspace dependencies are invalid");
+  }
+  const dependencies = [];
+  for (const [name, version] of Object.entries(manifest.dependencies)) {
+    if (!name.startsWith("@enduragent/")) continue;
+    if (
+      !WORKSPACE_PACKAGE_NAME.test(name) ||
+      typeof version !== "string" ||
+      version.length === 0 ||
+      version.trim() !== version
+    ) {
+      throw new TypeError("Telegram acceptance workspace dependencies are invalid");
+    }
+    dependencies.push(name);
+  }
+  return dependencies.sort();
+}
+
+function exactRuntimeExportTargets(exportsValue) {
+  const targets = new Set();
+  const visited = new Set();
+  const visit = (value) => {
+    if (value === null) return;
+    if (typeof value === "string") {
+      const path = value.slice(2);
+      const segments = path.split("/");
+      if (
+        !value.startsWith("./") ||
+        value.includes("\\") ||
+        value.includes("\0") ||
+        segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")
+      ) {
+        throw new TypeError("Telegram acceptance workspace export target is invalid");
+      }
+      if (!value.includes("*")) targets.add(value);
+      return;
+    }
+    if (typeof value !== "object") {
+      throw new TypeError("Telegram acceptance workspace exports are invalid");
+    }
+    if (visited.has(value)) {
+      throw new TypeError("Telegram acceptance workspace exports are invalid");
+    }
+    visited.add(value);
+    if (Array.isArray(value)) {
+      for (const entry of value) visit(entry);
+    } else {
+      for (const [condition, entry] of Object.entries(value)) {
+        if (condition === "types" || condition.startsWith("types@")) continue;
+        visit(entry);
+      }
+    }
+    visited.delete(value);
+  };
+  visit(exportsValue);
+  return [...targets].sort();
+}
+
 function requireUniqueLine(lines, prefix, expected, message) {
   const matches = lines.filter((line) => line.startsWith(`${prefix}=`));
   if (matches.length !== 1 || matches[0] !== `${prefix}=${expected}`) {
@@ -267,6 +333,500 @@ export function verifyTelegramAcceptanceManifest(value, expectedVersion) {
   }
 }
 
+export function verifyTelegramAcceptanceWorkspaceRuntime(
+  rootManifest,
+  archiveEntries,
+  readManifest,
+) {
+  if (
+    !Array.isArray(archiveEntries) ||
+    archiveEntries.some((entry) => typeof entry !== "string") ||
+    typeof readManifest !== "function"
+  ) {
+    throw new TypeError("Telegram acceptance workspace archive is invalid");
+  }
+  const entries = new Set(
+    archiveEntries.map((entry) => (entry.startsWith("/") ? entry.slice(1) : entry)),
+  );
+  const pending = workspaceDependencies(rootManifest);
+  if (pending.length === 0) {
+    throw new TypeError("Telegram acceptance workspace dependency closure is empty");
+  }
+  const seen = new Set();
+  const exportTargets = [];
+
+  while (pending.length > 0) {
+    const packageName = pending.shift();
+    if (seen.has(packageName)) continue;
+    seen.add(packageName);
+    const packageRoot = `node_modules/${packageName}`;
+    const manifestPath = `${packageRoot}/package.json`;
+    if (!entries.has(manifestPath)) {
+      throw new TypeError(
+        `Telegram acceptance workspace package manifest is missing: ${packageName}`,
+      );
+    }
+    const manifest = readManifest(manifestPath);
+    if (!exactObject(manifest) || manifest.name !== packageName) {
+      throw new TypeError(
+        `Telegram acceptance workspace package manifest is invalid: ${packageName}`,
+      );
+    }
+    const targets = exactRuntimeExportTargets(manifest.exports);
+    for (const target of targets) {
+      const archivePath = `${packageRoot}/${target.slice(2)}`;
+      if (!entries.has(archivePath)) {
+        throw new TypeError(
+          `Telegram acceptance workspace export target is missing: ${packageName} ${target}`,
+        );
+      }
+      exportTargets.push(archivePath);
+    }
+    pending.push(...workspaceDependencies(manifest));
+  }
+
+  return {
+    packages: [...seen].sort(),
+    exportTargets: exportTargets.sort(),
+  };
+}
+
+function propertyPath(value, expected) {
+  let current = value;
+  for (let index = expected.length - 1; index > 0; index -= 1) {
+    if (!ts.isPropertyAccessExpression(current) || current.name.text !== expected[index]) {
+      return false;
+    }
+    current = current.expression;
+  }
+  return ts.isIdentifier(current) && current.text === expected[0];
+}
+
+function callExpression(value, target, argumentChecks = []) {
+  return (
+    ts.isCallExpression(value) &&
+    propertyPath(value.expression, target) &&
+    value.arguments.length === argumentChecks.length &&
+    value.arguments.every((argument, index) => argumentChecks[index](argument))
+  );
+}
+
+function expressionStatement(value, check) {
+  return ts.isExpressionStatement(value) && check(value.expression);
+}
+
+function exactPropertyAssignments(value, expectedNames) {
+  if (!ts.isObjectLiteralExpression(value) || value.properties.length !== expectedNames.length) {
+    return undefined;
+  }
+  const assignments = new Map();
+  for (const property of value.properties) {
+    if (!ts.isPropertyAssignment(property) || !ts.isIdentifier(property.name)) return undefined;
+    if (assignments.has(property.name.text)) return undefined;
+    assignments.set(property.name.text, property.initializer);
+  }
+  if (expectedNames.some((name) => !assignments.has(name))) return undefined;
+  return assignments;
+}
+
+function exactParameter(value, name) {
+  return (
+    ts.isIdentifier(value.name) &&
+    value.name.text === name &&
+    value.modifiers === undefined &&
+    value.dotDotDotToken === undefined &&
+    value.questionToken === undefined &&
+    value.type === undefined &&
+    value.initializer === undefined
+  );
+}
+
+function arrowFunction(value, parameters, bodyCheck) {
+  return (
+    ts.isArrowFunction(value) &&
+    value.modifiers === undefined &&
+    value.typeParameters === undefined &&
+    value.type === undefined &&
+    value.parameters.length === parameters.length &&
+    !value.parameters.hasTrailingComma &&
+    value.parameters.every((parameter, index) => exactParameter(parameter, parameters[index])) &&
+    bodyCheck(value.body)
+  );
+}
+
+function emptyCatchCall(value, check) {
+  return (
+    ts.isTryStatement(value) &&
+    value.finallyBlock === undefined &&
+    value.tryBlock.statements.length === 1 &&
+    expressionStatement(value.tryBlock.statements[0], check) &&
+    value.catchClause !== undefined &&
+    value.catchClause.variableDeclaration === undefined &&
+    value.catchClause.block.statements.length === 0
+  );
+}
+
+const PACKAGED_TELEGRAM_HELPERS = Object.freeze({
+  installTelegramAcceptanceQuitControl: `function installTelegramAcceptanceQuitControl(input, quit) {
+  let source = "";
+  let valid = true;
+  input.setEncoding("utf8");
+  input.on("data", (chunk) => {
+    if (!valid) return;
+    source += chunk;
+    if (source.length > TELEGRAM_ACCEPTANCE_QUIT_FRAME.length || !TELEGRAM_ACCEPTANCE_QUIT_FRAME.startsWith(source)) {
+      valid = false;
+    }
+  });
+  input.once("error", () => {
+    valid = false;
+  });
+  input.once("end", () => {
+    if (valid && source === TELEGRAM_ACCEPTANCE_QUIT_FRAME) quit();
+  });
+  input.resume();
+}`,
+  telegramAcceptanceStartupFailureDiagnostic: `function telegramAcceptanceStartupFailureDiagnostic(error) {
+  let category = "unknown";
+  try {
+    if (typeof error === "object" && error !== null && "code" in error) {
+      switch (error.code) {
+        case "ERR_INVALID_PACKAGE_CONFIG":
+        case "ERR_INVALID_PACKAGE_TARGET":
+        case "ERR_MODULE_NOT_FOUND":
+        case "ERR_PACKAGE_IMPORT_NOT_DEFINED":
+        case "ERR_PACKAGE_PATH_NOT_EXPORTED":
+        case "ERR_UNKNOWN_FILE_EXTENSION":
+        case "ERR_UNSUPPORTED_DIR_IMPORT":
+          category = "module-resolution";
+      }
+    }
+  } catch {
+  }
+  return \`packaged Desktop production startup failed; category=${"${category}"}\`;
+}`,
+  installSingleLoginLaunchObservation: `function installSingleLoginLaunchObservation(app2, wasOpenedAtLogin) {
+  const key = "getLoginItemSettings";
+  const ownDescriptor = Object.getOwnPropertyDescriptor(app2, key);
+  const original = app2.getLoginItemSettings;
+  let pending = true;
+  const restore = () => {
+    if (ownDescriptor === void 0) {
+      if (!Reflect.deleteProperty(app2, key)) {
+        throw new TypeError("Telegram acceptance startup port could not be restored");
+      }
+      return;
+    }
+    Object.defineProperty(app2, key, ownDescriptor);
+  };
+  Object.defineProperty(app2, key, {
+    configurable: true,
+    writable: true,
+    value(...args) {
+      if (!pending) throw new TypeError("Telegram acceptance startup marker was reused");
+      pending = false;
+      restore();
+      return { ...original.apply(app2, args), wasOpenedAtLogin };
+    }
+  });
+}`,
+  consumeAcceptanceStartupMarker: `function consumeAcceptanceStartupMarker(environment, app2) {
+  const marker = environment[ACCEPTANCE_OS_LOGIN_MARKER_ENV];
+  delete environment[ACCEPTANCE_OS_LOGIN_MARKER_ENV];
+  if (marker === void 0) {
+    installSingleLoginLaunchObservation(app2, false);
+    return "manual";
+  }
+  if (marker !== ACCEPTANCE_OS_LOGIN_MARKER_VALUE) {
+    throw new TypeError("Telegram acceptance startup marker is invalid");
+  }
+  installSingleLoginLaunchObservation(app2, true);
+  return "os-login";
+}`,
+});
+
+const PACKAGED_TELEGRAM_PROTECTED_BINDINGS = new Set([
+  "TELEGRAM_ACCEPTANCE_QUIT_FRAME",
+  "installTelegramAcceptanceQuitControl",
+  "telegramAcceptanceStartupFailureDiagnostic",
+  "runTelegramAcceptanceBootstrap",
+  "ACCEPTANCE_OS_LOGIN_MARKER_ENV",
+  "ACCEPTANCE_OS_LOGIN_MARKER_VALUE",
+  "installSingleLoginLaunchObservation",
+  "consumeAcceptanceStartupMarker",
+]);
+
+const PACKAGED_TELEGRAM_MUTATING_CALLS = Object.freeze([
+  ["Object", "assign"],
+  ["Object", "defineProperties"],
+  ["Object", "defineProperty"],
+  ["Object", "setPrototypeOf"],
+  ["Reflect", "defineProperty"],
+  ["Reflect", "deleteProperty"],
+  ["Reflect", "set"],
+  ["Reflect", "setPrototypeOf"],
+]);
+
+function syntaxTokens(value) {
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    true,
+    ts.LanguageVariant.Standard,
+    value,
+  );
+  const tokens = [];
+  for (let token = scanner.scan(); token !== ts.SyntaxKind.EndOfFileToken; token = scanner.scan()) {
+    tokens.push([token, scanner.getTokenText()]);
+  }
+  return tokens;
+}
+
+function sameSyntax(actual, expected) {
+  const actualTokens = syntaxTokens(actual);
+  const expectedTokens = syntaxTokens(expected);
+  return (
+    actualTokens.length === expectedTokens.length &&
+    actualTokens.every(
+      (token, index) =>
+        token[0] === expectedTokens[index][0] && token[1] === expectedTokens[index][1],
+    )
+  );
+}
+
+function verifyTelegramAcceptanceStringConstant(source, name, expectedValue) {
+  const declarations = source.statements
+    .filter(ts.isVariableStatement)
+    .filter((statement) => (statement.declarationList.flags & ts.NodeFlags.Const) !== 0)
+    .flatMap((statement) => statement.declarationList.declarations)
+    .filter((declaration) => ts.isIdentifier(declaration.name) && declaration.name.text === name);
+  const declaration = declarations.length === 1 ? declarations[0] : undefined;
+  if (
+    declaration === undefined ||
+    !ts.isStringLiteral(declaration.initializer) ||
+    declaration.initializer.text !== expectedValue
+  ) {
+    throw new TypeError("Telegram acceptance production helper constant is invalid");
+  }
+}
+
+function verifyTelegramAcceptanceHelperDeclarations(source) {
+  verifyTelegramAcceptanceStringConstant(
+    source,
+    "TELEGRAM_ACCEPTANCE_QUIT_FRAME",
+    '{"type":"enduragent-telegram-acceptance","command":"quit"}\n',
+  );
+  verifyTelegramAcceptanceStringConstant(
+    source,
+    "ACCEPTANCE_OS_LOGIN_MARKER_ENV",
+    "ENDURAGENT_ACCEPTANCE_OS_LOGIN_LAUNCH",
+  );
+  verifyTelegramAcceptanceStringConstant(source, "ACCEPTANCE_OS_LOGIN_MARKER_VALUE", "os-login");
+  for (const [name, expected] of Object.entries(PACKAGED_TELEGRAM_HELPERS)) {
+    const declarations = source.statements.filter(
+      (statement) => ts.isFunctionDeclaration(statement) && statement.name?.text === name,
+    );
+    if (declarations.length !== 1 || !sameSyntax(declarations[0].getText(source), expected)) {
+      throw new TypeError(`Telegram acceptance production helper is invalid: ${name}`);
+    }
+  }
+}
+
+function protectedTelegramBindingWriteTarget(value) {
+  if (ts.isIdentifier(value)) return PACKAGED_TELEGRAM_PROTECTED_BINDINGS.has(value.text);
+  if (
+    ts.isParenthesizedExpression(value) ||
+    ts.isSpreadElement(value) ||
+    ts.isSpreadAssignment(value)
+  ) {
+    return protectedTelegramBindingWriteTarget(value.expression);
+  }
+  if (ts.isPropertyAccessExpression(value) || ts.isElementAccessExpression(value)) {
+    return protectedTelegramBindingWriteTarget(value.expression);
+  }
+  if (ts.isArrayLiteralExpression(value)) {
+    return value.elements.some(
+      (element) => !ts.isOmittedExpression(element) && protectedTelegramBindingWriteTarget(element),
+    );
+  }
+  if (ts.isObjectLiteralExpression(value)) {
+    return value.properties.some((property) => {
+      if (ts.isShorthandPropertyAssignment(property)) {
+        return PACKAGED_TELEGRAM_PROTECTED_BINDINGS.has(property.name.text);
+      }
+      if (ts.isPropertyAssignment(property)) {
+        return protectedTelegramBindingWriteTarget(property.initializer);
+      }
+      return ts.isSpreadAssignment(property) && protectedTelegramBindingWriteTarget(property);
+    });
+  }
+  return (
+    ts.isBinaryExpression(value) &&
+    value.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    protectedTelegramBindingWriteTarget(value.left)
+  );
+}
+
+function assignmentOperator(kind) {
+  return kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
+}
+
+function verifyTelegramAcceptanceProtectedBindings(source) {
+  let invalidWrite = false;
+  const visit = (node) => {
+    if (invalidWrite) return;
+    if (
+      (ts.isBinaryExpression(node) &&
+        assignmentOperator(node.operatorToken.kind) &&
+        protectedTelegramBindingWriteTarget(node.left)) ||
+      ((ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+        (node.operator === ts.SyntaxKind.PlusPlusToken ||
+          node.operator === ts.SyntaxKind.MinusMinusToken) &&
+        protectedTelegramBindingWriteTarget(node.operand)) ||
+      (ts.isDeleteExpression(node) && protectedTelegramBindingWriteTarget(node.expression)) ||
+      ((ts.isForInStatement(node) || ts.isForOfStatement(node)) &&
+        !ts.isVariableDeclarationList(node.initializer) &&
+        protectedTelegramBindingWriteTarget(node.initializer)) ||
+      (ts.isCallExpression(node) &&
+        PACKAGED_TELEGRAM_MUTATING_CALLS.some((target) => propertyPath(node.expression, target)) &&
+        node.arguments.length > 0 &&
+        protectedTelegramBindingWriteTarget(node.arguments[0]))
+    ) {
+      invalidWrite = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  if (invalidWrite) {
+    throw new TypeError("Telegram acceptance production helper binding is mutated");
+  }
+}
+
+function topLevelConstant(value, name) {
+  const declaration = ts.isVariableStatement(value)
+    ? value.declarationList.declarations[0]
+    : undefined;
+  return (
+    ts.isVariableStatement(value) &&
+    (value.declarationList.flags & ts.NodeFlags.Const) !== 0 &&
+    value.declarationList.declarations.length === 1 &&
+    declaration !== undefined &&
+    ts.isIdentifier(declaration.name) &&
+    declaration.name.text === name
+  );
+}
+
+function topLevelFunction(value, name) {
+  return ts.isFunctionDeclaration(value) && value.name?.text === name;
+}
+
+function verifyTelegramAcceptanceTopLevelLayout(source) {
+  const statements = source.statements;
+  if (
+    statements.length !== 10 ||
+    !ts.isImportDeclaration(statements[0]) ||
+    !topLevelConstant(statements[1], "TELEGRAM_ACCEPTANCE_QUIT_FRAME") ||
+    !topLevelFunction(statements[2], "installTelegramAcceptanceQuitControl") ||
+    !topLevelFunction(statements[3], "telegramAcceptanceStartupFailureDiagnostic") ||
+    !topLevelFunction(statements[4], "runTelegramAcceptanceBootstrap") ||
+    !topLevelConstant(statements[5], "ACCEPTANCE_OS_LOGIN_MARKER_ENV") ||
+    !topLevelConstant(statements[6], "ACCEPTANCE_OS_LOGIN_MARKER_VALUE") ||
+    !topLevelFunction(statements[7], "installSingleLoginLaunchObservation") ||
+    !topLevelFunction(statements[8], "consumeAcceptanceStartupMarker") ||
+    !ts.isExpressionStatement(statements[9]) ||
+    !ts.isAwaitExpression(statements[9].expression)
+  ) {
+    throw new TypeError("Telegram acceptance production top-level layout is invalid");
+  }
+}
+
+function verifyTelegramAcceptanceBootstrapDeclaration(source) {
+  const declarations = source.statements.filter(
+    (statement) =>
+      ts.isFunctionDeclaration(statement) &&
+      statement.name?.text === "runTelegramAcceptanceBootstrap",
+  );
+  const declaration = declarations.length === 1 ? declarations[0] : undefined;
+  const inputParameter = declaration?.parameters[0];
+  const statement = declaration?.body?.statements[0];
+  if (
+    declaration === undefined ||
+    declaration.modifiers?.length !== 1 ||
+    declaration.modifiers[0].kind !== ts.SyntaxKind.AsyncKeyword ||
+    declaration.asteriskToken !== undefined ||
+    declaration.typeParameters !== undefined ||
+    declaration.type !== undefined ||
+    declaration.typeArguments !== undefined ||
+    declaration.parameters.length !== 1 ||
+    declaration.parameters.hasTrailingComma ||
+    inputParameter === undefined ||
+    !exactParameter(inputParameter, "input") ||
+    declaration.body?.statements.length !== 1 ||
+    statement === undefined ||
+    !ts.isTryStatement(statement) ||
+    statement.finallyBlock !== undefined ||
+    statement.tryBlock.statements.length !== 3 ||
+    !expressionStatement(statement.tryBlock.statements[0], (expression) =>
+      callExpression(
+        expression,
+        ["installTelegramAcceptanceQuitControl"],
+        [
+          (argument) => propertyPath(argument, ["input", "input"]),
+          (argument) => propertyPath(argument, ["input", "quit"]),
+        ],
+      ),
+    ) ||
+    !expressionStatement(statement.tryBlock.statements[1], (expression) =>
+      callExpression(expression, ["input", "beforeImport"]),
+    ) ||
+    !expressionStatement(
+      statement.tryBlock.statements[2],
+      (expression) =>
+        ts.isAwaitExpression(expression) &&
+        callExpression(expression.expression, ["input", "importProduction"]),
+    )
+  ) {
+    throw new TypeError("Telegram acceptance production bootstrap is invalid");
+  }
+  const catchClause = statement.catchClause;
+  const catchParameter = catchClause?.variableDeclaration?.name;
+  const catchStatements = catchClause?.block.statements;
+  if (
+    catchClause === undefined ||
+    catchParameter === undefined ||
+    !ts.isIdentifier(catchParameter) ||
+    catchParameter.text !== "error" ||
+    catchStatements === undefined ||
+    catchStatements.length !== 2 ||
+    !emptyCatchCall(catchStatements[0], (expression) =>
+      callExpression(
+        expression,
+        ["input", "report"],
+        [
+          (argument) =>
+            callExpression(
+              argument,
+              ["telegramAcceptanceStartupFailureDiagnostic"],
+              [
+                (diagnosticArgument) =>
+                  ts.isIdentifier(diagnosticArgument) && diagnosticArgument.text === "error",
+              ],
+            ),
+        ],
+      ),
+    ) ||
+    !emptyCatchCall(catchStatements[1], (expression) =>
+      callExpression(
+        expression,
+        ["input", "exit"],
+        [(argument) => ts.isNumericLiteral(argument) && argument.text === "1"],
+      ),
+    )
+  ) {
+    throw new TypeError("Telegram acceptance production bootstrap is invalid");
+  }
+}
+
 export function verifyTelegramAcceptanceMainEntry(value) {
   if (typeof value !== "string") {
     throw new TypeError("Telegram acceptance main entry is invalid");
@@ -278,6 +838,8 @@ export function verifyTelegramAcceptanceMainEntry(value) {
     true,
     ts.ScriptKind.JS,
   );
+  verifyTelegramAcceptanceProtectedBindings(source);
+  verifyTelegramAcceptanceTopLevelLayout(source);
   const imports = [];
   const collectImports = (node) => {
     if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
@@ -286,6 +848,10 @@ export function verifyTelegramAcceptanceMainEntry(value) {
     ts.forEachChild(node, collectImports);
   };
   collectImports(source);
+  const staticImports = source.statements.filter(ts.isImportDeclaration);
+  const electronImport = staticImports[0];
+  const electronBindings = electronImport?.importClause?.namedBindings;
+  const appImport = ts.isNamedImports(electronBindings) ? electronBindings.elements[0] : undefined;
   const finalStatement = source.statements.at(-1);
   const finalExpression =
     finalStatement !== undefined && ts.isExpressionStatement(finalStatement)
@@ -295,22 +861,127 @@ export function verifyTelegramAcceptanceMainEntry(value) {
     finalExpression !== undefined && ts.isAwaitExpression(finalExpression)
       ? finalExpression.expression
       : undefined;
-  const importPath =
+  const bootstrapCall =
     finalCall !== undefined &&
     ts.isCallExpression(finalCall) &&
-    finalCall.expression.kind === ts.SyntaxKind.ImportKeyword &&
-    finalCall.arguments.length === 1 &&
-    ts.isStringLiteral(finalCall.arguments[0])
-      ? finalCall.arguments[0].text
+    propertyPath(finalCall.expression, ["runTelegramAcceptanceBootstrap"])
+      ? finalCall
       : undefined;
+  const assignments =
+    bootstrapCall?.arguments.length === 1
+      ? exactPropertyAssignments(bootstrapCall.arguments[0], [
+          "input",
+          "beforeImport",
+          "importProduction",
+          "quit",
+          "report",
+          "exit",
+        ])
+      : undefined;
+  const importProduction = assignments?.get("importProduction");
+  const productionImport =
+    importProduction !== undefined &&
+    arrowFunction(
+      importProduction,
+      [],
+      (body) => ts.isCallExpression(body) && body.expression.kind === ts.SyntaxKind.ImportKeyword,
+    )
+      ? importProduction.body
+      : undefined;
+  const importPath =
+    productionImport !== undefined &&
+    ts.isCallExpression(productionImport) &&
+    productionImport.arguments.length === 1 &&
+    ts.isStringLiteral(productionImport.arguments[0])
+      ? productionImport.arguments[0].text
+      : undefined;
+  const beforeImport = assignments?.get("beforeImport");
+  const quit = assignments?.get("quit");
+  const report = assignments?.get("report");
+  const exit = assignments?.get("exit");
   if (
     source.parseDiagnostics.length !== 0 ||
+    staticImports.length !== 1 ||
+    electronImport === undefined ||
+    electronImport.modifiers !== undefined ||
+    electronImport.attributes !== undefined ||
+    electronImport.assertClause !== undefined ||
+    !ts.isStringLiteral(electronImport.moduleSpecifier) ||
+    electronImport.moduleSpecifier.text !== "electron" ||
+    electronImport.importClause === undefined ||
+    electronImport.importClause.isTypeOnly ||
+    electronImport.importClause.phaseModifier !== undefined ||
+    electronImport.importClause?.name !== undefined ||
+    !ts.isNamedImports(electronBindings) ||
+    electronBindings.elements.length !== 1 ||
+    electronBindings.elements.hasTrailingComma ||
+    appImport === undefined ||
+    appImport.isTypeOnly ||
+    appImport.propertyName !== undefined ||
+    appImport.name.text !== "app" ||
     imports.length !== 1 ||
-    imports[0] !== finalCall ||
+    imports[0] !== productionImport ||
+    assignments === undefined ||
+    !propertyPath(assignments.get("input"), ["process", "stdin"]) ||
+    beforeImport === undefined ||
+    !arrowFunction(beforeImport, [], (body) =>
+      callExpression(
+        body,
+        ["consumeAcceptanceStartupMarker"],
+        [
+          (argument) => propertyPath(argument, ["process", "env"]),
+          (argument) => ts.isIdentifier(argument) && argument.text === "app",
+        ],
+      ),
+    ) ||
+    quit === undefined ||
+    !arrowFunction(quit, [], (body) => callExpression(body, ["app", "quit"])) ||
+    report === undefined ||
+    !arrowFunction(report, ["diagnostic"], (body) =>
+      callExpression(
+        body,
+        ["process", "stderr", "write"],
+        [
+          (argument) =>
+            ts.isTemplateExpression(argument) &&
+            argument.head.text === "" &&
+            argument.templateSpans.length === 1 &&
+            ts.isIdentifier(argument.templateSpans[0].expression) &&
+            argument.templateSpans[0].expression.text === "diagnostic" &&
+            argument.templateSpans[0].literal.text === "\n",
+        ],
+      ),
+    ) ||
+    exit === undefined ||
+    !arrowFunction(
+      exit,
+      ["code"],
+      (body) =>
+        ts.isBlock(body) &&
+        body.statements.length === 2 &&
+        expressionStatement(
+          body.statements[0],
+          (expression) =>
+            ts.isBinaryExpression(expression) &&
+            expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+            propertyPath(expression.left, ["process", "exitCode"]) &&
+            ts.isIdentifier(expression.right) &&
+            expression.right.text === "code",
+        ) &&
+        expressionStatement(body.statements[1], (expression) =>
+          callExpression(
+            expression,
+            ["app", "exit"],
+            [(argument) => ts.isIdentifier(argument) && argument.text === "code"],
+          ),
+        ),
+    ) ||
     typeof importPath !== "string" ||
     !/^\.\/index-[A-Za-z0-9_-]+\.js$/u.test(importPath)
   ) {
     throw new TypeError("Telegram acceptance production main location is invalid");
   }
+  verifyTelegramAcceptanceHelperDeclarations(source);
+  verifyTelegramAcceptanceBootstrapDeclaration(source);
   return `out/main/${importPath.slice(2)}`;
 }

--- a/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.mjs
+++ b/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.mjs
@@ -1,0 +1,148 @@
+export const TELEGRAM_ACCEPTANCE_APP_ID = "icu.enduragent.desktop.telegram-acceptance";
+export const TELEGRAM_ACCEPTANCE_PACKAGE_NAME = "enduragent-desktop-telegram-acceptance";
+export const TELEGRAM_ACCEPTANCE_PRODUCT_NAME = "Enduragent Telegram Acceptance";
+export const TELEGRAM_ACCEPTANCE_MARKER = "enduragentDesktopTelegramAcceptance";
+export const TELEGRAM_ACCEPTANCE_ENTITLEMENTS = Object.freeze({
+  "com.apple.security.cs.allow-jit": true,
+});
+
+function exactObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireLine(lines, expected, message) {
+  if (!lines.includes(expected)) throw new TypeError(message);
+}
+
+function requirePositiveLine(lines, pattern, message) {
+  const match = lines.map((line) => pattern.exec(line)).find((candidate) => candidate !== null);
+  if (match === undefined || match.slice(1).some((value) => Number(value) < 1)) {
+    throw new TypeError(message);
+  }
+}
+
+export function createTelegramAcceptanceBuilderConfiguration(canonical) {
+  if (
+    !exactObject(canonical) ||
+    !Array.isArray(canonical.files) ||
+    !exactObject(canonical.directories) ||
+    !exactObject(canonical.mac) ||
+    (canonical.extraMetadata !== undefined && !exactObject(canonical.extraMetadata))
+  ) {
+    throw new TypeError("canonical Desktop builder configuration is invalid");
+  }
+  const matches = canonical.files.filter((entry) => entry === "out/**");
+  if (matches.length !== 1) {
+    throw new TypeError("canonical Desktop runtime FileSet is ambiguous");
+  }
+  return {
+    ...canonical,
+    appId: TELEGRAM_ACCEPTANCE_APP_ID,
+    productName: TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
+    extraMetadata: {
+      name: TELEGRAM_ACCEPTANCE_PACKAGE_NAME,
+      productName: TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
+      [TELEGRAM_ACCEPTANCE_MARKER]: true,
+    },
+    directories: {
+      ...canonical.directories,
+      output: "dist/telegram-acceptance-package",
+    },
+    files: canonical.files.map((entry) =>
+      entry === "out/**"
+        ? {
+            from: "dist/telegram-acceptance-build/out",
+            to: "out",
+            filter: ["**/*"],
+          }
+        : entry,
+    ),
+    mac: {
+      ...canonical.mac,
+      identity: "-",
+      hardenedRuntime: false,
+      entitlements: "build/entitlements.mac.plist",
+      entitlementsInherit: "build/entitlements.mac.plist",
+      target: [{ target: "dir", arch: ["arm64"] }],
+    },
+  };
+}
+
+export function verifyTelegramAcceptanceSignature(description) {
+  if (typeof description !== "string") {
+    throw new TypeError("Telegram acceptance signature description is invalid");
+  }
+  const lines = description.split(/\r?\n/u).map((line) => line.trim());
+  requireLine(
+    lines,
+    `Identifier=${TELEGRAM_ACCEPTANCE_APP_ID}`,
+    "Telegram acceptance signature identifier is invalid",
+  );
+  requireLine(lines, "Signature=adhoc", "Telegram acceptance signature is not ad-hoc");
+  requireLine(
+    lines,
+    "TeamIdentifier=not set",
+    "Telegram acceptance signature unexpectedly has a team",
+  );
+  requirePositiveLine(
+    lines,
+    /^Info\.plist entries=(\d+)$/u,
+    "Telegram acceptance signature does not bind Info.plist",
+  );
+  requirePositiveLine(
+    lines,
+    /^Sealed Resources version=(\d+) rules=(\d+) files=(\d+)$/u,
+    "Telegram acceptance signature does not seal bundle resources",
+  );
+  requirePositiveLine(
+    lines,
+    /^Internal requirements count=\d+ size=(\d+)$/u,
+    "Telegram acceptance signature has no internal requirements record",
+  );
+}
+
+export function verifyTelegramAcceptanceInfoPlist(value) {
+  if (
+    !exactObject(value) ||
+    value.CFBundleIdentifier !== TELEGRAM_ACCEPTANCE_APP_ID ||
+    value.CFBundleName !== TELEGRAM_ACCEPTANCE_PRODUCT_NAME ||
+    value.CFBundleDisplayName !== TELEGRAM_ACCEPTANCE_PRODUCT_NAME ||
+    value.CFBundleExecutable !== TELEGRAM_ACCEPTANCE_PRODUCT_NAME
+  ) {
+    throw new TypeError("Telegram acceptance Info.plist identity is invalid");
+  }
+}
+
+export function verifyTelegramAcceptanceEntitlements(value) {
+  if (
+    !exactObject(value) ||
+    Object.keys(value).length !== 1 ||
+    value["com.apple.security.cs.allow-jit"] !== true
+  ) {
+    throw new TypeError("Telegram acceptance signed entitlements are invalid");
+  }
+}
+
+export function verifyTelegramAcceptanceDesignatedRequirement(value) {
+  if (
+    typeof value !== "string" ||
+    value.trim().replaceAll(/\s+/gu, " ") !==
+      `designated => identifier "${TELEGRAM_ACCEPTANCE_APP_ID}"`
+  ) {
+    throw new TypeError("Telegram acceptance designated requirement is invalid");
+  }
+}
+
+export function verifyTelegramAcceptanceManifest(value, expectedVersion) {
+  if (
+    !exactObject(value) ||
+    typeof expectedVersion !== "string" ||
+    expectedVersion.length === 0 ||
+    value.name !== TELEGRAM_ACCEPTANCE_PACKAGE_NAME ||
+    value.productName !== TELEGRAM_ACCEPTANCE_PRODUCT_NAME ||
+    value[TELEGRAM_ACCEPTANCE_MARKER] !== true ||
+    value.version !== expectedVersion
+  ) {
+    throw new TypeError("Telegram acceptance ASAR manifest identity is invalid");
+  }
+}

--- a/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.mjs
+++ b/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.mjs
@@ -13,6 +13,14 @@ function exactObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+export function configureTelegramAcceptanceSigningEnvironment(environment) {
+  if (!exactObject(environment)) {
+    throw new TypeError("Telegram acceptance signing environment is invalid");
+  }
+  environment.CSC_FOR_PULL_REQUEST = "true";
+  environment.CSC_IDENTITY_AUTO_DISCOVERY = "false";
+}
+
 const WORKSPACE_PACKAGE_NAME = /^@enduragent\/[a-z0-9][a-z0-9._-]*$/u;
 
 function workspaceDependencies(manifest) {

--- a/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.mjs
+++ b/apps/desktop/tests/fixtures/packaged-telegram/package-acceptance.mjs
@@ -1,3 +1,6 @@
+import { isAbsolute, relative, sep } from "node:path";
+import ts from "typescript";
+
 export const TELEGRAM_ACCEPTANCE_APP_ID = "icu.enduragent.desktop.telegram-acceptance";
 export const TELEGRAM_ACCEPTANCE_PACKAGE_NAME = "enduragent-desktop-telegram-acceptance";
 export const TELEGRAM_ACCEPTANCE_PRODUCT_NAME = "Enduragent Telegram Acceptance";
@@ -10,8 +13,11 @@ function exactObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function requireLine(lines, expected, message) {
-  if (!lines.includes(expected)) throw new TypeError(message);
+function requireUniqueLine(lines, prefix, expected, message) {
+  const matches = lines.filter((line) => line.startsWith(`${prefix}=`));
+  if (matches.length !== 1 || matches[0] !== `${prefix}=${expected}`) {
+    throw new TypeError(message);
+  }
 }
 
 function requirePositiveLine(lines, pattern, message) {
@@ -73,15 +79,17 @@ export function verifyTelegramAcceptanceSignature(description) {
     throw new TypeError("Telegram acceptance signature description is invalid");
   }
   const lines = description.split(/\r?\n/u).map((line) => line.trim());
-  requireLine(
+  requireUniqueLine(
     lines,
-    `Identifier=${TELEGRAM_ACCEPTANCE_APP_ID}`,
+    "Identifier",
+    TELEGRAM_ACCEPTANCE_APP_ID,
     "Telegram acceptance signature identifier is invalid",
   );
-  requireLine(lines, "Signature=adhoc", "Telegram acceptance signature is not ad-hoc");
-  requireLine(
+  requireUniqueLine(lines, "Signature", "adhoc", "Telegram acceptance signature is not ad-hoc");
+  requireUniqueLine(
     lines,
-    "TeamIdentifier=not set",
+    "TeamIdentifier",
+    "not set",
     "Telegram acceptance signature unexpectedly has a team",
   );
   requirePositiveLine(
@@ -99,6 +107,33 @@ export function verifyTelegramAcceptanceSignature(description) {
     /^Internal requirements count=\d+ size=(\d+)$/u,
     "Telegram acceptance signature has no internal requirements record",
   );
+  const cdHashLines = lines.filter((line) => line.startsWith("CDHash="));
+  if (cdHashLines.length !== 1 || !/^CDHash=[0-9a-f]{40}$/u.test(cdHashLines[0])) {
+    throw new TypeError("Telegram acceptance signature code-directory hash is invalid");
+  }
+  return cdHashLines[0].slice("CDHash=".length);
+}
+
+export function verifyTelegramAcceptanceNestedSignature(description) {
+  if (typeof description !== "string") {
+    throw new TypeError("Telegram acceptance nested signature is invalid");
+  }
+  const lines = description.split(/\r?\n/u).map((line) => line.trim());
+  const identifiers = lines.filter((line) => /^Identifier=.+$/u.test(line));
+  const cdHashes = lines.filter((line) => line.startsWith("CDHash="));
+  const signatures = lines.filter((line) => line.startsWith("Signature="));
+  const teams = lines.filter((line) => line.startsWith("TeamIdentifier="));
+  if (
+    identifiers.length !== 1 ||
+    cdHashes.length !== 1 ||
+    !/^CDHash=[0-9a-f]{40}$/u.test(cdHashes[0]) ||
+    signatures.length !== 1 ||
+    signatures[0] !== "Signature=adhoc" ||
+    teams.length !== 1 ||
+    teams[0] !== "TeamIdentifier=not set"
+  ) {
+    throw new TypeError("Telegram acceptance nested signature is invalid");
+  }
 }
 
 export function verifyTelegramAcceptanceInfoPlist(value) {
@@ -123,11 +158,94 @@ export function verifyTelegramAcceptanceEntitlements(value) {
   }
 }
 
-export function verifyTelegramAcceptanceDesignatedRequirement(value) {
+export function verifyTelegramAcceptanceNestedEntitlements(value) {
+  if (value === undefined) return;
+  if (
+    !exactObject(value) ||
+    Object.keys(value).length !== 1 ||
+    value["com.apple.security.cs.allow-jit"] !== true
+  ) {
+    throw new TypeError("Telegram acceptance nested entitlements are invalid");
+  }
+}
+
+export function verifyTelegramAcceptanceNestedListing(description) {
+  if (typeof description !== "string") {
+    throw new TypeError("Telegram acceptance nested code listing is invalid");
+  }
+  const lines = description
+    .split(/\n/u)
+    .map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line));
+  const executableLines = lines.filter((line) => line.startsWith("Executable="));
+  if (executableLines.length !== 1) {
+    throw new TypeError("Telegram acceptance nested code listing is invalid");
+  }
+  const executable = executableLines[0].slice("Executable=".length);
+  if (
+    !executable.startsWith("/") ||
+    executable.trim() !== executable ||
+    executable.includes("\0")
+  ) {
+    throw new TypeError("Telegram acceptance nested code listing is invalid");
+  }
+  const nested = lines
+    .filter((line) => line.startsWith("Nested="))
+    .map((line) => line.slice("Nested=".length));
+  const seen = new Set();
+  for (const path of nested) {
+    const segments = path.split("/");
+    if (
+      path.length === 0 ||
+      path.startsWith("/") ||
+      path.trim() !== path ||
+      path.includes("\\") ||
+      path.includes("\0") ||
+      segments.some((segment) => segment.length === 0 || segment === "." || segment === "..") ||
+      seen.has(path)
+    ) {
+      throw new TypeError("Telegram acceptance nested code listing is invalid");
+    }
+    seen.add(path);
+  }
+  return { executable, nested };
+}
+
+export function selectTelegramAcceptanceNestedTarget(applicationRoot, candidates) {
+  if (
+    typeof applicationRoot !== "string" ||
+    !isAbsolute(applicationRoot) ||
+    !Array.isArray(candidates)
+  ) {
+    throw new TypeError("Telegram acceptance nested code resolution is invalid");
+  }
+  const resolved = new Set();
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string" || !isAbsolute(candidate)) {
+      throw new TypeError("Telegram acceptance nested code resolution is invalid");
+    }
+    const displacement = relative(applicationRoot, candidate);
+    if (displacement === ".." || displacement.startsWith(`..${sep}`) || isAbsolute(displacement)) {
+      throw new TypeError("Telegram acceptance nested code target escapes the application");
+    }
+    resolved.add(candidate);
+  }
+  if (resolved.size !== 1) {
+    throw new TypeError(
+      resolved.size === 0
+        ? "Telegram acceptance nested code target is missing"
+        : "Telegram acceptance nested code target is ambiguous",
+    );
+  }
+  return resolved.values().next().value;
+}
+
+export function verifyTelegramAcceptanceDesignatedRequirement(value, expectedCdHash) {
+  if (typeof expectedCdHash !== "string" || !/^[0-9a-f]{40}$/u.test(expectedCdHash)) {
+    throw new TypeError("Telegram acceptance code-directory hash is invalid");
+  }
   if (
     typeof value !== "string" ||
-    value.trim().replaceAll(/\s+/gu, " ") !==
-      `designated => identifier "${TELEGRAM_ACCEPTANCE_APP_ID}"`
+    value.trim().replaceAll(/\s+/gu, " ") !== `# designated => cdhash H"${expectedCdHash}"`
   ) {
     throw new TypeError("Telegram acceptance designated requirement is invalid");
   }
@@ -141,8 +259,58 @@ export function verifyTelegramAcceptanceManifest(value, expectedVersion) {
     value.name !== TELEGRAM_ACCEPTANCE_PACKAGE_NAME ||
     value.productName !== TELEGRAM_ACCEPTANCE_PRODUCT_NAME ||
     value[TELEGRAM_ACCEPTANCE_MARKER] !== true ||
-    value.version !== expectedVersion
+    value.version !== expectedVersion ||
+    value.type !== "module" ||
+    value.main !== "out/main/index.js"
   ) {
     throw new TypeError("Telegram acceptance ASAR manifest identity is invalid");
   }
+}
+
+export function verifyTelegramAcceptanceMainEntry(value) {
+  if (typeof value !== "string") {
+    throw new TypeError("Telegram acceptance main entry is invalid");
+  }
+  const source = ts.createSourceFile(
+    "telegram-acceptance-main.js",
+    value,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS,
+  );
+  const imports = [];
+  const collectImports = (node) => {
+    if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      imports.push(node);
+    }
+    ts.forEachChild(node, collectImports);
+  };
+  collectImports(source);
+  const finalStatement = source.statements.at(-1);
+  const finalExpression =
+    finalStatement !== undefined && ts.isExpressionStatement(finalStatement)
+      ? finalStatement.expression
+      : undefined;
+  const finalCall =
+    finalExpression !== undefined && ts.isAwaitExpression(finalExpression)
+      ? finalExpression.expression
+      : undefined;
+  const importPath =
+    finalCall !== undefined &&
+    ts.isCallExpression(finalCall) &&
+    finalCall.expression.kind === ts.SyntaxKind.ImportKeyword &&
+    finalCall.arguments.length === 1 &&
+    ts.isStringLiteral(finalCall.arguments[0])
+      ? finalCall.arguments[0].text
+      : undefined;
+  if (
+    source.parseDiagnostics.length !== 0 ||
+    imports.length !== 1 ||
+    imports[0] !== finalCall ||
+    typeof importPath !== "string" ||
+    !/^\.\/index-[A-Za-z0-9_-]+\.js$/u.test(importPath)
+  ) {
+    throw new TypeError("Telegram acceptance production main location is invalid");
+  }
+  return `out/main/${importPath.slice(2)}`;
 }

--- a/apps/desktop/tests/fixtures/packaged-telegram/process-safety.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/process-safety.ts
@@ -1,3 +1,5 @@
+import type { ChildProcess } from "node:child_process";
+
 export interface DarwinProcessCommandResult {
   readonly code: number | null;
   readonly signal: NodeJS.Signals | null;
@@ -5,26 +7,76 @@ export interface DarwinProcessCommandResult {
   readonly stderr: Buffer;
 }
 
-export interface DarwinProcessBirthIdentity {
-  readonly pid: number;
-  readonly startToken: string;
-  readonly command: string;
-  readonly bundleRoot: string;
+export const TELEGRAM_ACCEPTANCE_ACCOUNTING_NAME = "Enduragent Teleg";
+
+export type TelegramAcceptanceApplicationLaunch =
+  | { readonly state: "spawned"; readonly pid: number }
+  | { readonly state: "spawn-error"; readonly error: Error };
+
+export type TelegramAcceptanceApplicationTerminal =
+  | {
+      readonly state: "closed";
+      readonly code: number | null;
+      readonly signal: NodeJS.Signals | null;
+    }
+  | { readonly state: "spawn-error" | "child-error"; readonly error: Error };
+
+export function observeTelegramAcceptanceChild(child: ChildProcess): {
+  readonly launch: Promise<TelegramAcceptanceApplicationLaunch>;
+  readonly terminal: Promise<TelegramAcceptanceApplicationTerminal>;
+} {
+  let didSpawn = false;
+  let resolveLaunch!: (result: TelegramAcceptanceApplicationLaunch) => void;
+  let resolveTerminal!: (result: TelegramAcceptanceApplicationTerminal) => void;
+  const launch = new Promise<TelegramAcceptanceApplicationLaunch>((resolve) => {
+    resolveLaunch = resolve;
+  });
+  const terminal = new Promise<TelegramAcceptanceApplicationTerminal>((resolve) => {
+    resolveTerminal = resolve;
+  });
+  child.once("spawn", () => {
+    const pid = child.pid;
+    if (pid === undefined) {
+      const error = new Error("packaged Desktop spawn produced no process ID");
+      resolveLaunch({ state: "spawn-error", error });
+      resolveTerminal({ state: "spawn-error", error });
+      return;
+    }
+    didSpawn = true;
+    resolveLaunch({ state: "spawned", pid });
+  });
+  child.once("error", (error) => {
+    if (didSpawn) {
+      resolveTerminal({ state: "child-error", error });
+    } else {
+      resolveLaunch({ state: "spawn-error", error });
+      resolveTerminal({ state: "spawn-error", error });
+    }
+  });
+  child.once("close", (code, signal) => {
+    resolveTerminal({ state: "closed", code, signal });
+  });
+  return { launch, terminal };
 }
 
-export type DarwinProcessObservation =
-  | { readonly state: "absent" }
-  | { readonly state: "running"; readonly identity: DarwinProcessBirthIdentity };
+export function telegramAcceptanceDirectExitIsClean(
+  launch: TelegramAcceptanceApplicationLaunch,
+  terminal: TelegramAcceptanceApplicationTerminal,
+): boolean {
+  return (
+    launch.state === "spawned" &&
+    terminal.state === "closed" &&
+    terminal.code === 0 &&
+    terminal.signal === null
+  );
+}
 
-const DARWIN_START_TOKEN = /^[A-Z][a-z]{2} [A-Z][a-z]{2} [ 0-9][0-9] \d{2}:\d{2}:\d{2} \d{4}$/u;
-
-export function parseDarwinProcessObservation(
+export function telegramAcceptanceBundleTextIsClear(
   result: DarwinProcessCommandResult,
-  expectedPid: number,
   bundleRoot: string,
-): DarwinProcessObservation {
-  if (!Number.isSafeInteger(expectedPid) || expectedPid < 1 || !bundleRoot.endsWith(".app")) {
-    throw new TypeError("tracked process authority is invalid");
+): boolean {
+  if (typeof bundleRoot !== "string" || !bundleRoot.endsWith(".app")) {
+    throw new TypeError("packaged bundle-text authority is invalid");
   }
   if (
     result.code === 1 &&
@@ -32,45 +84,150 @@ export function parseDarwinProcessObservation(
     result.stdout.length === 0 &&
     result.stderr.length === 0
   ) {
-    return { state: "absent" };
+    return true;
   }
-  if (result.code !== 0 || result.signal !== null) {
-    throw new TypeError("tracked process observation failed");
-  }
-  const lines = result.stdout
-    .toString("utf8")
-    .split(/\r?\n/u)
-    .filter((line) => line.trim() !== "");
-  if (lines.length !== 1) throw new TypeError("tracked process observation is ambiguous");
-  const match = /^\s*(\d+)\s+(.{24})\s+(.+)$/u.exec(lines[0] as string);
-  if (match === null) throw new TypeError("tracked process observation is malformed");
-  const pid = Number(match[1]);
-  const startToken = match[2] as string;
-  const command = (match[3] as string).trim();
   if (
-    pid !== expectedPid ||
-    !DARWIN_START_TOKEN.test(startToken) ||
-    !command.startsWith(`${bundleRoot}/Contents/`)
+    result.code !== 0 ||
+    result.signal !== null ||
+    result.stderr.length !== 0 ||
+    result.stdout.length === 0
   ) {
-    throw new TypeError("tracked process identity is outside the acceptance bundle");
+    throw new TypeError("packaged bundle-text observation failed");
   }
-  return {
-    state: "running",
-    identity: { pid, startToken, command, bundleRoot },
-  };
+
+  const seen = new Set<number>();
+  let currentPid: number | undefined;
+  let currentDescriptorIsText = false;
+  let paths = 0;
+  for (const rawField of result.stdout.toString("utf8").split("\0")) {
+    const field = rawField.replace(/^[\r\n]+|[\r\n]+$/gu, "");
+    if (field === "") continue;
+    if (field.includes("\n") || field.includes("\r")) {
+      throw new TypeError("packaged bundle-text observation is malformed");
+    }
+    if (field.startsWith("p")) {
+      const pid = Number(field.slice(1));
+      if (!Number.isSafeInteger(pid) || pid < 1 || seen.has(pid)) {
+        throw new TypeError("packaged bundle-text observation is ambiguous");
+      }
+      seen.add(pid);
+      currentPid = pid;
+      currentDescriptorIsText = false;
+      continue;
+    }
+    if (field === "ftxt") {
+      if (currentPid === undefined) {
+        throw new TypeError("packaged bundle-text observation is malformed");
+      }
+      currentDescriptorIsText = true;
+      continue;
+    }
+    if (field.startsWith("n")) {
+      const path = field.slice(1);
+      if (
+        currentPid === undefined ||
+        !currentDescriptorIsText ||
+        (path !== bundleRoot && !path.startsWith(`${bundleRoot}/`))
+      ) {
+        throw new TypeError("packaged bundle-text observation is outside authority");
+      }
+      paths += 1;
+      currentDescriptorIsText = false;
+      continue;
+    }
+    throw new TypeError("packaged bundle-text observation is malformed");
+  }
+  if (seen.size === 0 || paths === 0) {
+    throw new TypeError("packaged bundle-text observation is empty");
+  }
+  return false;
 }
 
-export function classifyDarwinProcessObservation(
-  tracked: DarwinProcessBirthIdentity,
-  observation: DarwinProcessObservation,
-): "same" | "exited" | "reused" {
-  if (observation.state === "absent") return "exited";
-  return observation.identity.pid === tracked.pid &&
-    observation.identity.startToken === tracked.startToken &&
-    observation.identity.command === tracked.command &&
-    observation.identity.bundleRoot === tracked.bundleRoot
-    ? "same"
-    : "reused";
+export function telegramAcceptanceProcessTableIsClear(result: DarwinProcessCommandResult): boolean {
+  if (
+    result.code !== 0 ||
+    result.signal !== null ||
+    result.stderr.length !== 0 ||
+    result.stdout.length === 0
+  ) {
+    throw new TypeError("packaged process-table observation failed");
+  }
+
+  const seen = new Set<number>();
+  const lines = result.stdout.toString("utf8").split(/\r?\n/u);
+  let observations = 0;
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    const match = /^\s*(\d+)\s+(.+?)\s*$/u.exec(line);
+    if (match === null) throw new TypeError("packaged process-table observation is malformed");
+    const pid = Number(match[1]);
+    const accountingName = match[2];
+    if (!Number.isSafeInteger(pid) || pid < 1 || seen.has(pid) || accountingName === undefined) {
+      throw new TypeError("packaged process-table observation is ambiguous");
+    }
+    seen.add(pid);
+    observations += 1;
+    if (accountingName === TELEGRAM_ACCEPTANCE_ACCOUNTING_NAME) return false;
+  }
+  if (observations === 0) {
+    throw new TypeError("packaged process-table observation is empty");
+  }
+  return true;
+}
+
+export function telegramAcceptanceDebuggerListenerOwner(
+  result: DarwinProcessCommandResult,
+): number | undefined {
+  if (
+    result.code === 1 &&
+    result.signal === null &&
+    result.stdout.length === 0 &&
+    result.stderr.length === 0
+  ) {
+    return undefined;
+  }
+  if (
+    result.code !== 0 ||
+    result.signal !== null ||
+    result.stderr.length !== 0 ||
+    result.stdout.length === 0
+  ) {
+    throw new TypeError("Desktop debugger-listener observation failed");
+  }
+  const pids = new Set<number>();
+  const descriptors = new Set<string>();
+  for (const rawField of result.stdout.toString("utf8").split("\0")) {
+    const field = rawField.replace(/^[\r\n]+|[\r\n]+$/gu, "");
+    if (field === "") continue;
+    const processMatch = /^p(\d+)$/u.exec(field);
+    if (processMatch !== null) {
+      const pid = Number(processMatch[1]);
+      if (!Number.isSafeInteger(pid) || pid < 1 || pids.has(pid)) {
+        throw new TypeError("Desktop debugger-listener observation is ambiguous");
+      }
+      pids.add(pid);
+      continue;
+    }
+    if (/^f\d+[A-Za-z]?$/u.test(field) && pids.size === 1 && !descriptors.has(field)) {
+      descriptors.add(field);
+      continue;
+    }
+    throw new TypeError("Desktop debugger-listener observation is malformed");
+  }
+  if (pids.size !== 1 || descriptors.size === 0) {
+    throw new TypeError("Desktop debugger-listener observation is ambiguous");
+  }
+  return pids.values().next().value;
+}
+
+export function telegramAcceptanceShutdownIsProven(input: {
+  readonly executionSucceeded: boolean;
+  readonly directApplicationsExitedCleanly: boolean;
+  readonly processTableClear: boolean;
+}): boolean {
+  return (
+    input.executionSucceeded && input.directApplicationsExitedCleanly && input.processTableClear
+  );
 }
 
 export async function releaseAcceptanceStorage(input: {

--- a/apps/desktop/tests/fixtures/packaged-telegram/process-safety.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/process-safety.ts
@@ -8,6 +8,82 @@ export interface DarwinProcessCommandResult {
 }
 
 export const TELEGRAM_ACCEPTANCE_ACCOUNTING_NAME = "Enduragent Teleg";
+export const TELEGRAM_ACCEPTANCE_QUIT_FRAME =
+  '{"type":"enduragent-telegram-acceptance","command":"quit"}\n';
+
+interface TelegramAcceptanceQuitInput {
+  on(event: "data", listener: (chunk: string) => void): unknown;
+  once(event: "end" | "error", listener: () => void): unknown;
+  resume(): unknown;
+  setEncoding(encoding: BufferEncoding): unknown;
+}
+
+export function installTelegramAcceptanceQuitControl(
+  input: TelegramAcceptanceQuitInput,
+  quit: () => void,
+): void {
+  let source = "";
+  let valid = true;
+  input.setEncoding("utf8");
+  input.on("data", (chunk) => {
+    if (!valid) return;
+    source += chunk;
+    if (
+      source.length > TELEGRAM_ACCEPTANCE_QUIT_FRAME.length ||
+      !TELEGRAM_ACCEPTANCE_QUIT_FRAME.startsWith(source)
+    ) {
+      valid = false;
+    }
+  });
+  input.once("error", () => {
+    valid = false;
+  });
+  input.once("end", () => {
+    if (valid && source === TELEGRAM_ACCEPTANCE_QUIT_FRAME) quit();
+  });
+  input.resume();
+}
+
+function telegramAcceptanceStartupFailureDiagnostic(error: unknown): string {
+  let category = "unknown";
+  try {
+    if (typeof error === "object" && error !== null && "code" in error) {
+      switch (error.code) {
+        case "ERR_INVALID_PACKAGE_CONFIG":
+        case "ERR_INVALID_PACKAGE_TARGET":
+        case "ERR_MODULE_NOT_FOUND":
+        case "ERR_PACKAGE_IMPORT_NOT_DEFINED":
+        case "ERR_PACKAGE_PATH_NOT_EXPORTED":
+        case "ERR_UNKNOWN_FILE_EXTENSION":
+        case "ERR_UNSUPPORTED_DIR_IMPORT":
+          category = "module-resolution";
+      }
+    }
+  } catch {}
+  return `packaged Desktop production startup failed; category=${category}`;
+}
+
+export async function runTelegramAcceptanceBootstrap(input: {
+  readonly input: TelegramAcceptanceQuitInput;
+  readonly beforeImport: () => void;
+  readonly importProduction: () => Promise<unknown>;
+  readonly quit: () => void;
+  readonly report: (diagnostic: string) => void;
+  readonly exit: (code: number) => void;
+}): Promise<void> {
+  try {
+    installTelegramAcceptanceQuitControl(input.input, input.quit);
+    input.beforeImport();
+    await input.importProduction();
+  } catch (error) {
+    try {
+      input.report(telegramAcceptanceStartupFailureDiagnostic(error));
+    } catch {}
+    try {
+      input.exit(1);
+    } catch {}
+  }
+}
 
 export type TelegramAcceptanceApplicationLaunch =
   | { readonly state: "spawned"; readonly pid: number }
@@ -69,6 +145,63 @@ export function telegramAcceptanceDirectExitIsClean(
     terminal.code === 0 &&
     terminal.signal === null
   );
+}
+
+export function telegramAcceptanceJsonDiagnostic(
+  value: unknown,
+  sensitiveValues: readonly string[],
+  maximumLength = 4_000,
+): string {
+  const orderedSensitiveValues = [...new Set(sensitiveValues)]
+    .filter((sensitiveValue) => sensitiveValue !== "")
+    .sort((left, right) => right.length - left.length);
+  const marker = orderedSensitiveValues.some((sensitiveValue) =>
+    "<redacted>".includes(sensitiveValue),
+  )
+    ? ""
+    : "<redacted>";
+  let serialized =
+    JSON.stringify(value, (_key, candidate: unknown) => {
+      if (typeof candidate !== "string") return candidate;
+      let redacted = candidate;
+      for (const sensitiveValue of orderedSensitiveValues) {
+        redacted = redacted.replaceAll(sensitiveValue, marker);
+      }
+      return redacted;
+    }) ?? "undefined";
+  const escapedSensitiveValues = [
+    ...new Set(
+      orderedSensitiveValues.map((sensitiveValue) => JSON.stringify(sensitiveValue).slice(1, -1)),
+    ),
+  ].sort((left, right) => right.length - left.length);
+  for (const escapedSensitiveValue of escapedSensitiveValues) {
+    serialized = serialized.replaceAll(escapedSensitiveValue, marker);
+  }
+  if (serialized.length <= maximumLength) return serialized;
+  const truncationMarker = orderedSensitiveValues.some((sensitiveValue) =>
+    "<truncated>".includes(sensitiveValue),
+  )
+    ? ""
+    : "<truncated>";
+  if (maximumLength <= truncationMarker.length) return truncationMarker.slice(0, maximumLength);
+  const retainedLength = maximumLength - truncationMarker.length;
+  const headLength = Math.ceil(retainedLength / 2);
+  const tailLength = retainedLength - headLength;
+  const tail = tailLength === 0 ? "" : serialized.slice(-tailLength);
+  return `${serialized.slice(0, headLength)}${truncationMarker}${tail}`;
+}
+
+export function telegramAcceptanceLaunchDiagnostic(input: {
+  readonly pid: number | undefined;
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly output: { readonly stdout: string; readonly stderr: string };
+  readonly sensitiveValues: readonly string[];
+}): string {
+  const output = telegramAcceptanceJsonDiagnostic(input.output, input.sensitiveValues);
+  return `pid=${String(input.pid)}; exit=${String(input.code)}; signal=${String(
+    input.signal,
+  )}; output=${output}`;
 }
 
 export function telegramAcceptanceBundleTextIsClear(

--- a/apps/desktop/tests/fixtures/packaged-telegram/process-safety.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/process-safety.ts
@@ -1,0 +1,90 @@
+export interface DarwinProcessCommandResult {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stdout: Buffer;
+  readonly stderr: Buffer;
+}
+
+export interface DarwinProcessBirthIdentity {
+  readonly pid: number;
+  readonly startToken: string;
+  readonly command: string;
+  readonly bundleRoot: string;
+}
+
+export type DarwinProcessObservation =
+  | { readonly state: "absent" }
+  | { readonly state: "running"; readonly identity: DarwinProcessBirthIdentity };
+
+const DARWIN_START_TOKEN = /^[A-Z][a-z]{2} [A-Z][a-z]{2} [ 0-9][0-9] \d{2}:\d{2}:\d{2} \d{4}$/u;
+
+export function parseDarwinProcessObservation(
+  result: DarwinProcessCommandResult,
+  expectedPid: number,
+  bundleRoot: string,
+): DarwinProcessObservation {
+  if (!Number.isSafeInteger(expectedPid) || expectedPid < 1 || !bundleRoot.endsWith(".app")) {
+    throw new TypeError("tracked process authority is invalid");
+  }
+  if (
+    result.code === 1 &&
+    result.signal === null &&
+    result.stdout.length === 0 &&
+    result.stderr.length === 0
+  ) {
+    return { state: "absent" };
+  }
+  if (result.code !== 0 || result.signal !== null) {
+    throw new TypeError("tracked process observation failed");
+  }
+  const lines = result.stdout
+    .toString("utf8")
+    .split(/\r?\n/u)
+    .filter((line) => line.trim() !== "");
+  if (lines.length !== 1) throw new TypeError("tracked process observation is ambiguous");
+  const match = /^\s*(\d+)\s+(.{24})\s+(.+)$/u.exec(lines[0] as string);
+  if (match === null) throw new TypeError("tracked process observation is malformed");
+  const pid = Number(match[1]);
+  const startToken = match[2] as string;
+  const command = (match[3] as string).trim();
+  if (
+    pid !== expectedPid ||
+    !DARWIN_START_TOKEN.test(startToken) ||
+    !command.startsWith(`${bundleRoot}/Contents/`)
+  ) {
+    throw new TypeError("tracked process identity is outside the acceptance bundle");
+  }
+  return {
+    state: "running",
+    identity: { pid, startToken, command, bundleRoot },
+  };
+}
+
+export function classifyDarwinProcessObservation(
+  tracked: DarwinProcessBirthIdentity,
+  observation: DarwinProcessObservation,
+): "same" | "exited" | "reused" {
+  if (observation.state === "absent") return "exited";
+  return observation.identity.pid === tracked.pid &&
+    observation.identity.startToken === tracked.startToken &&
+    observation.identity.command === tracked.command &&
+    observation.identity.bundleRoot === tracked.bundleRoot
+    ? "same"
+    : "reused";
+}
+
+export async function releaseAcceptanceStorage(input: {
+  readonly processesStopped: boolean;
+  readonly debuggerListenersClosed: boolean;
+  readonly recoveryPath: string;
+  readonly restoreKeychain: () => Promise<boolean>;
+  readonly removeScratch: () => Promise<void>;
+}): Promise<void> {
+  if (!input.processesStopped || !input.debuggerListenersClosed) {
+    throw new Error(`acceptance storage retained for recovery at ${input.recoveryPath}`);
+  }
+  if (!(await input.restoreKeychain())) {
+    throw new Error(`acceptance keychain retained for recovery at ${input.recoveryPath}`);
+  }
+  await input.removeScratch();
+}

--- a/apps/desktop/tests/fixtures/packaged-telegram/startup-mode.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/startup-mode.ts
@@ -7,7 +7,10 @@ export interface AcceptanceLoginLaunchPort {
   getLoginItemSettings(...args: unknown[]): LoginItemSettings;
 }
 
-function installSingleOsLoginObservation(app: AcceptanceLoginLaunchPort): void {
+function installSingleLoginLaunchObservation(
+  app: AcceptanceLoginLaunchPort,
+  wasOpenedAtLogin: boolean,
+): void {
   const key = "getLoginItemSettings";
   const ownDescriptor = Object.getOwnPropertyDescriptor(app, key);
   const original = app.getLoginItemSettings;
@@ -28,7 +31,7 @@ function installSingleOsLoginObservation(app: AcceptanceLoginLaunchPort): void {
       if (!pending) throw new TypeError("Telegram acceptance startup marker was reused");
       pending = false;
       restore();
-      return { ...original.apply(app, args), wasOpenedAtLogin: true };
+      return { ...original.apply(app, args), wasOpenedAtLogin };
     },
   });
 }
@@ -39,10 +42,13 @@ export function consumeAcceptanceStartupMarker(
 ): "manual" | "os-login" {
   const marker = environment[ACCEPTANCE_OS_LOGIN_MARKER_ENV];
   delete environment[ACCEPTANCE_OS_LOGIN_MARKER_ENV];
-  if (marker === undefined) return "manual";
+  if (marker === undefined) {
+    installSingleLoginLaunchObservation(app, false);
+    return "manual";
+  }
   if (marker !== ACCEPTANCE_OS_LOGIN_MARKER_VALUE) {
     throw new TypeError("Telegram acceptance startup marker is invalid");
   }
-  installSingleOsLoginObservation(app);
+  installSingleLoginLaunchObservation(app, true);
   return "os-login";
 }

--- a/apps/desktop/tests/fixtures/packaged-telegram/startup-mode.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/startup-mode.ts
@@ -1,0 +1,48 @@
+import type { LoginItemSettings } from "electron";
+
+export const ACCEPTANCE_OS_LOGIN_MARKER_ENV = "ENDURAGENT_ACCEPTANCE_OS_LOGIN_LAUNCH" as const;
+export const ACCEPTANCE_OS_LOGIN_MARKER_VALUE = "os-login" as const;
+
+export interface AcceptanceLoginLaunchPort {
+  getLoginItemSettings(...args: unknown[]): LoginItemSettings;
+}
+
+function installSingleOsLoginObservation(app: AcceptanceLoginLaunchPort): void {
+  const key = "getLoginItemSettings";
+  const ownDescriptor = Object.getOwnPropertyDescriptor(app, key);
+  const original = app.getLoginItemSettings;
+  let pending = true;
+  const restore = (): void => {
+    if (ownDescriptor === undefined) {
+      if (!Reflect.deleteProperty(app, key)) {
+        throw new TypeError("Telegram acceptance startup port could not be restored");
+      }
+      return;
+    }
+    Object.defineProperty(app, key, ownDescriptor);
+  };
+  Object.defineProperty(app, key, {
+    configurable: true,
+    writable: true,
+    value(...args: unknown[]): LoginItemSettings {
+      if (!pending) throw new TypeError("Telegram acceptance startup marker was reused");
+      pending = false;
+      restore();
+      return { ...original.apply(app, args), wasOpenedAtLogin: true };
+    },
+  });
+}
+
+export function consumeAcceptanceStartupMarker(
+  environment: NodeJS.ProcessEnv,
+  app: AcceptanceLoginLaunchPort,
+): "manual" | "os-login" {
+  const marker = environment[ACCEPTANCE_OS_LOGIN_MARKER_ENV];
+  delete environment[ACCEPTANCE_OS_LOGIN_MARKER_ENV];
+  if (marker === undefined) return "manual";
+  if (marker !== ACCEPTANCE_OS_LOGIN_MARKER_VALUE) {
+    throw new TypeError("Telegram acceptance startup marker is invalid");
+  }
+  installSingleOsLoginObservation(app);
+  return "os-login";
+}

--- a/apps/desktop/tests/fixtures/packaged-telegram/telegram-fetch-route.ts
+++ b/apps/desktop/tests/fixtures/packaged-telegram/telegram-fetch-route.ts
@@ -1,0 +1,137 @@
+import { createRequire } from "node:module";
+
+const TELEGRAM_BOT_API_ORIGIN = "https://api.telegram.org";
+const REQUIRED_NODE_FETCH_EXPORTS = [
+  "Headers",
+  "Request",
+  "Response",
+  "FetchError",
+  "AbortError",
+] as const;
+
+export interface FetchRouteInit {
+  readonly agent?: unknown;
+  readonly signal?: unknown;
+  readonly [name: string]: unknown;
+}
+
+export interface NodeFetchV2 {
+  (input: unknown, init?: FetchRouteInit): Promise<unknown>;
+  readonly default: NodeFetchV2;
+  readonly __esModule: true;
+  readonly Headers: (...args: never[]) => unknown;
+  readonly Request: (...args: never[]) => unknown;
+  readonly Response: (...args: never[]) => unknown;
+  readonly FetchError: (...args: never[]) => unknown;
+  readonly AbortError: (...args: never[]) => unknown;
+  readonly [name: string]: unknown;
+}
+
+export function requireAcceptanceOrigin(value: string | undefined): string {
+  if (value === undefined) throw new TypeError("Telegram acceptance origin is missing");
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new TypeError("Telegram acceptance origin is invalid");
+  }
+  if (
+    parsed.protocol !== "http:" ||
+    parsed.hostname !== "127.0.0.1" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.pathname !== "/" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    parsed.port === "" ||
+    Number(parsed.port) === 0 ||
+    parsed.origin !== value
+  ) {
+    throw new TypeError("Telegram acceptance origin is invalid");
+  }
+  return parsed.origin;
+}
+
+export function requireNodeFetchV2(value: unknown): NodeFetchV2 {
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof value !== "function" ||
+    candidate.default !== value ||
+    candidate.__esModule !== true ||
+    REQUIRED_NODE_FETCH_EXPORTS.some((name) => typeof candidate[name] !== "function")
+  ) {
+    throw new TypeError("Telegram fetch export shape is invalid");
+  }
+  return value as NodeFetchV2;
+}
+
+function requestedUrl(input: unknown): string | undefined {
+  if (typeof input === "string" || input instanceof URL) return input.toString();
+  if (
+    input !== null &&
+    typeof input === "object" &&
+    "url" in input &&
+    typeof input.url === "string"
+  ) {
+    return input.url;
+  }
+  return undefined;
+}
+
+export function createTelegramRoutedFetch(
+  uncheckedFetch: unknown,
+  uncheckedOrigin: string,
+): NodeFetchV2 {
+  const originalFetch = requireNodeFetchV2(uncheckedFetch);
+  const origin = requireAcceptanceOrigin(uncheckedOrigin);
+  const routedFetch = (input: unknown, init?: FetchRouteInit): Promise<unknown> => {
+    const candidate = requestedUrl(input);
+    if (candidate === undefined) return originalFetch(input, init);
+    let requested: URL;
+    try {
+      requested = new URL(candidate);
+    } catch {
+      return originalFetch(input, init);
+    }
+    if (requested.origin !== TELEGRAM_BOT_API_ORIGIN) {
+      return originalFetch(input, init);
+    }
+    if (typeof input !== "string" && !(input instanceof URL)) {
+      throw new TypeError("Telegram fetch route does not accept Request inputs");
+    }
+    const routed = new URL(`${requested.pathname}${requested.search}`, origin);
+    return originalFetch(routed.toString(), { ...init, agent: undefined });
+  };
+
+  for (const key of Reflect.ownKeys(originalFetch)) {
+    if (["name", "length", "prototype", "arguments", "caller", "default"].includes(String(key))) {
+      continue;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(originalFetch, key);
+    if (descriptor !== undefined) Object.defineProperty(routedFetch, key, descriptor);
+  }
+  const defaultDescriptor = Object.getOwnPropertyDescriptor(originalFetch, "default");
+  if (defaultDescriptor === undefined || "value" in defaultDescriptor === false) {
+    throw new TypeError("Telegram fetch export shape is invalid");
+  }
+  Object.defineProperty(routedFetch, "default", {
+    ...defaultDescriptor,
+    value: routedFetch,
+  });
+  return requireNodeFetchV2(routedFetch);
+}
+
+export function installTelegramFetchRoute(origin: string): void {
+  const acceptanceRequire = createRequire(import.meta.url);
+  const coreEntry = acceptanceRequire.resolve("@enduragent/core");
+  const coreRequire = createRequire(coreEntry);
+  const grammyEntry = coreRequire.resolve("grammy");
+  const grammyRequire = createRequire(grammyEntry);
+  const fetchPath = grammyRequire.resolve("node-fetch");
+  const originalFetch = requireNodeFetchV2(grammyRequire(fetchPath));
+  const cached = grammyRequire.cache[fetchPath];
+  if (cached === undefined || cached.exports !== originalFetch) {
+    throw new TypeError("Telegram fetch cache identity is invalid");
+  }
+  cached.exports = createTelegramRoutedFetch(originalFetch, origin);
+}

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -148,11 +148,29 @@ function eventFrames(frames: readonly unknown[]): readonly unknown[] {
   return frames.length < 2 ? [] : frames.slice(0, -1).map(frameEvent);
 }
 
-export async function waitForPage(port: number): Promise<string> {
-  const deadline = Date.now() + 20_000;
+export interface WaitForPageOptions {
+  readonly timeoutMs?: number;
+  readonly probeTimeoutMs?: number;
+}
+
+export async function waitForPage(port: number, options: WaitForPageOptions = {}): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? 20_000;
+  const probeTimeoutMs = options.probeTimeoutMs ?? 1_000;
+  if (
+    !Number.isInteger(timeoutMs) ||
+    timeoutMs < 1 ||
+    !Number.isInteger(probeTimeoutMs) ||
+    probeTimeoutMs < 1
+  ) {
+    throw new TypeError("desktop renderer wait timing is invalid");
+  }
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+      const remaining = deadline - Date.now();
+      const response = await fetch(`http://127.0.0.1:${port}/json/list`, {
+        signal: AbortSignal.timeout(Math.max(1, Math.min(probeTimeoutMs, remaining))),
+      });
       if (response.ok) {
         const entries = (await response.json()) as readonly {
           readonly type?: unknown;
@@ -169,7 +187,10 @@ export async function waitForPage(port: number): Promise<string> {
         if (page !== undefined) return page.webSocketDebuggerUrl as string;
       }
     } catch {}
-    await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+    const remaining = deadline - Date.now();
+    if (remaining > 0) {
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, Math.min(25, remaining)));
+    }
   }
   throw new Error("timed out waiting for the desktop renderer");
 }

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -89,7 +89,7 @@ const disabledTelegram: DesktopTelegramController = {
   close: async () => disabledTelegramSnapshot,
 };
 
-function reservePort(): Promise<number> {
+export function reservePort(): Promise<number> {
   return new Promise((resolvePort, reject) => {
     const server = createServer();
     server.once("error", reject);
@@ -148,7 +148,7 @@ function eventFrames(frames: readonly unknown[]): readonly unknown[] {
   return frames.length < 2 ? [] : frames.slice(0, -1).map(frameEvent);
 }
 
-async function waitForPage(port: number): Promise<string> {
+export async function waitForPage(port: number): Promise<string> {
   const deadline = Date.now() + 20_000;
   while (Date.now() < deadline) {
     try {
@@ -174,7 +174,7 @@ async function waitForPage(port: number): Promise<string> {
   throw new Error("timed out waiting for the desktop renderer");
 }
 
-function connectCdp(
+export function connectCdp(
   url: string,
   onEvent: (message: CdpResponse) => void,
 ): Promise<{
@@ -235,7 +235,7 @@ function connectCdp(
   });
 }
 
-function processAlive(pid: number): boolean {
+export function processAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
@@ -244,7 +244,7 @@ function processAlive(pid: number): boolean {
   }
 }
 
-async function stopProcess(child: ChildProcess): Promise<void> {
+export async function stopProcess(child: ChildProcess): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) return;
   child.kill("SIGTERM");
   const exited = await Promise.race([

--- a/apps/desktop/tests/package-layout.test.ts
+++ b/apps/desktop/tests/package-layout.test.ts
@@ -711,6 +711,34 @@ describe("desktop package layout", () => {
     ).rejects.toThrow("known plaintext secret marker");
   });
 
+  it.each([
+    "ENDURAGENT_ACCEPTANCE_TELEGRAM_BOT_API_ORIGIN",
+    "ENDURAGENT_ACCEPTANCE_OS_LOGIN_LAUNCH",
+  ])("rejects acceptance-only runtime marker %s from a canonical package", async (marker) => {
+    const fixture = await syntheticPackage();
+    await fixture.writeArchive("out/main/daemon-utility.js", marker);
+    await fixture.rebuild();
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("acceptance-only package marker");
+  });
+
+  it("rejects the acceptance ASAR metadata identity from a canonical package", async () => {
+    const fixture = await syntheticPackage();
+    await fixture.writeArchive(
+      "package.json",
+      `${JSON.stringify({
+        ...sourceManifest,
+        name: "enduragent-desktop-telegram-acceptance",
+        enduragentDesktopTelegramAcceptance: true,
+      })}\n`,
+    );
+    await fixture.rebuild();
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("acceptance-only package marker");
+  });
+
   it("scans external and unpacked files for synthetic secret markers", async () => {
     const externalFixture = await syntheticPackage();
     await writeFile(

--- a/apps/desktop/tests/package-telegram-acceptance.test.ts
+++ b/apps/desktop/tests/package-telegram-acceptance.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import {
+  createTelegramAcceptanceBuilderConfiguration,
+  TELEGRAM_ACCEPTANCE_APP_ID,
+  TELEGRAM_ACCEPTANCE_ENTITLEMENTS,
+  TELEGRAM_ACCEPTANCE_MARKER,
+  TELEGRAM_ACCEPTANCE_PACKAGE_NAME,
+  TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
+  verifyTelegramAcceptanceDesignatedRequirement,
+  verifyTelegramAcceptanceEntitlements,
+  verifyTelegramAcceptanceInfoPlist,
+  verifyTelegramAcceptanceManifest,
+  verifyTelegramAcceptanceSignature,
+} from "./fixtures/packaged-telegram/package-acceptance.mjs";
+
+const version = "0.0.1";
+
+function canonicalBuilder() {
+  return {
+    appId: "icu.enduragent.desktop",
+    productName: "Enduragent",
+    directories: { output: "dist" },
+    files: ["out/**", "package.json", "!**/*.map"],
+    extraMetadata: { name: "@enduragent/desktop", retained: true },
+    mac: {
+      identity: "Developer ID Application: Production (ABCDE12345)",
+      hardenedRuntime: true,
+      target: [{ target: "dir", arch: ["arm64"] }],
+    },
+  };
+}
+
+function signature(overrides: Partial<Record<string, string>> = {}): string {
+  return [
+    `Identifier=${overrides.Identifier ?? TELEGRAM_ACCEPTANCE_APP_ID}`,
+    `Signature=${overrides.Signature ?? "adhoc"}`,
+    `TeamIdentifier=${overrides.TeamIdentifier ?? "not set"}`,
+    overrides.InfoPlist ?? "Info.plist entries=31",
+    overrides.SealedResources ?? "Sealed Resources version=2 rules=13 files=287",
+    overrides.InternalRequirements ?? "Internal requirements count=0 size=12",
+  ].join("\n");
+}
+
+function infoPlist() {
+  return {
+    CFBundleIdentifier: TELEGRAM_ACCEPTANCE_APP_ID,
+    CFBundleName: TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
+    CFBundleDisplayName: TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
+    CFBundleExecutable: TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
+  };
+}
+
+function manifest() {
+  return {
+    name: TELEGRAM_ACCEPTANCE_PACKAGE_NAME,
+    productName: TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
+    [TELEGRAM_ACCEPTANCE_MARKER]: true,
+    version,
+  };
+}
+
+describe("Telegram acceptance package", () => {
+  it("derives a distinct ad-hoc-signed acceptance identity without mutating the canonical config", () => {
+    const canonical = canonicalBuilder();
+    const derived = createTelegramAcceptanceBuilderConfiguration(canonical) as {
+      readonly appId: string;
+      readonly productName: string;
+      readonly extraMetadata: Record<string, unknown>;
+      readonly directories: Record<string, unknown>;
+      readonly files: readonly unknown[];
+      readonly mac: Record<string, unknown>;
+    };
+
+    expect(derived).toMatchObject({
+      appId: TELEGRAM_ACCEPTANCE_APP_ID,
+      productName: TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
+      extraMetadata: {
+        name: TELEGRAM_ACCEPTANCE_PACKAGE_NAME,
+        productName: TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
+        [TELEGRAM_ACCEPTANCE_MARKER]: true,
+      },
+      directories: { output: "dist/telegram-acceptance-package" },
+      mac: {
+        identity: "-",
+        hardenedRuntime: false,
+        entitlements: "build/entitlements.mac.plist",
+        entitlementsInherit: "build/entitlements.mac.plist",
+        target: [{ target: "dir", arch: ["arm64"] }],
+      },
+    });
+    expect(derived.files[0]).toEqual({
+      from: "dist/telegram-acceptance-build/out",
+      to: "out",
+      filter: ["**/*"],
+    });
+    expect(Object.keys(derived.extraMetadata).sort()).toEqual([
+      TELEGRAM_ACCEPTANCE_MARKER,
+      "name",
+      "productName",
+    ]);
+    expect(canonical).toEqual(canonicalBuilder());
+  });
+
+  it("fails closed when the canonical runtime FileSet is ambiguous", () => {
+    expect(() =>
+      createTelegramAcceptanceBuilderConfiguration({
+        ...canonicalBuilder(),
+        files: ["package.json"],
+      }),
+    ).toThrow("canonical Desktop runtime FileSet is ambiguous");
+  });
+
+  it("requires an ad-hoc, teamless signature with bound metadata and sealed resources", () => {
+    expect(() => verifyTelegramAcceptanceSignature(signature())).not.toThrow();
+    for (const invalid of [
+      signature({ Identifier: "icu.enduragent.desktop" }),
+      signature({ Signature: "Developer ID Application: Production" }),
+      signature({ TeamIdentifier: "ABCDE12345" }),
+      signature({ InfoPlist: "Info.plist entries=0" }),
+      signature({ SealedResources: "Sealed Resources version=2 rules=13 files=0" }),
+      signature({ InternalRequirements: "Internal requirements count=0 size=0" }),
+    ]) {
+      expect(() => verifyTelegramAcceptanceSignature(invalid)).toThrow();
+    }
+  });
+
+  it("requires the exact acceptance Info.plist identity", () => {
+    expect(() => verifyTelegramAcceptanceInfoPlist(infoPlist())).not.toThrow();
+    for (const [field, value] of [
+      ["CFBundleIdentifier", "icu.enduragent.desktop"],
+      ["CFBundleName", "Enduragent"],
+      ["CFBundleDisplayName", "Enduragent"],
+      ["CFBundleExecutable", "Enduragent"],
+    ] as const) {
+      expect(() => verifyTelegramAcceptanceInfoPlist({ ...infoPlist(), [field]: value })).toThrow(
+        "Telegram acceptance Info.plist identity is invalid",
+      );
+    }
+  });
+
+  it("requires the exact signed entitlement dictionary", () => {
+    expect(() =>
+      verifyTelegramAcceptanceEntitlements(TELEGRAM_ACCEPTANCE_ENTITLEMENTS),
+    ).not.toThrow();
+    for (const invalid of [
+      {},
+      { "com.apple.security.cs.allow-jit": false },
+      {
+        "com.apple.security.cs.allow-jit": true,
+        "com.apple.security.cs.disable-library-validation": true,
+      },
+      { "com.apple.application-identifier": TELEGRAM_ACCEPTANCE_APP_ID },
+    ]) {
+      expect(() => verifyTelegramAcceptanceEntitlements(invalid)).toThrow(
+        "Telegram acceptance signed entitlements are invalid",
+      );
+    }
+  });
+
+  it("requires a teamless designated requirement for only the acceptance identifier", () => {
+    const expected = `designated => identifier "${TELEGRAM_ACCEPTANCE_APP_ID}"`;
+    expect(() => verifyTelegramAcceptanceDesignatedRequirement(expected)).not.toThrow();
+    expect(() =>
+      verifyTelegramAcceptanceDesignatedRequirement(`\n  ${expected.replaceAll(" ", "  ")}\n`),
+    ).not.toThrow();
+    for (const invalid of [
+      'designated => identifier "icu.enduragent.desktop"',
+      `${expected} and anchor apple`,
+      `${expected} and certificate leaf[subject.OU] = ABCDE12345`,
+      `identifier "${TELEGRAM_ACCEPTANCE_APP_ID}"`,
+    ]) {
+      expect(() => verifyTelegramAcceptanceDesignatedRequirement(invalid)).toThrow(
+        "Telegram acceptance designated requirement is invalid",
+      );
+    }
+  });
+
+  it("requires the exact acceptance ASAR manifest identity and marker", () => {
+    expect(() => verifyTelegramAcceptanceManifest(manifest(), version)).not.toThrow();
+    for (const invalid of [
+      { ...manifest(), name: "@enduragent/desktop" },
+      { ...manifest(), productName: "Enduragent" },
+      { ...manifest(), [TELEGRAM_ACCEPTANCE_MARKER]: false },
+      { ...manifest(), version: "0.0.2" },
+    ]) {
+      expect(() => verifyTelegramAcceptanceManifest(invalid, version)).toThrow(
+        "Telegram acceptance ASAR manifest identity is invalid",
+      );
+    }
+  });
+});

--- a/apps/desktop/tests/package-telegram-acceptance.test.ts
+++ b/apps/desktop/tests/package-telegram-acceptance.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  configureTelegramAcceptanceSigningEnvironment,
   createTelegramAcceptanceBuilderConfiguration,
   selectTelegramAcceptanceNestedTarget,
   TELEGRAM_ACCEPTANCE_APP_ID,
@@ -199,6 +200,20 @@ function beforePackagedBootstrap(source: string, mutation: string): string {
 }
 
 describe("Telegram acceptance package", () => {
+  it("forces ad-hoc signing in pull-request builds without certificate discovery", () => {
+    const environment = {
+      CSC_FOR_PULL_REQUEST: "false",
+      CSC_IDENTITY_AUTO_DISCOVERY: "true",
+    };
+
+    configureTelegramAcceptanceSigningEnvironment(environment);
+
+    expect(environment).toEqual({
+      CSC_FOR_PULL_REQUEST: "true",
+      CSC_IDENTITY_AUTO_DISCOVERY: "false",
+    });
+  });
+
   it("derives a distinct ad-hoc-signed acceptance identity without mutating the canonical config", () => {
     const canonical = canonicalBuilder();
     const derived = createTelegramAcceptanceBuilderConfiguration(canonical) as {

--- a/apps/desktop/tests/package-telegram-acceptance.test.ts
+++ b/apps/desktop/tests/package-telegram-acceptance.test.ts
@@ -16,6 +16,7 @@ import {
   verifyTelegramAcceptanceNestedListing,
   verifyTelegramAcceptanceNestedSignature,
   verifyTelegramAcceptanceSignature,
+  verifyTelegramAcceptanceWorkspaceRuntime,
 } from "./fixtures/packaged-telegram/package-acceptance.mjs";
 
 const version = "0.0.1";
@@ -77,6 +78,124 @@ function manifest() {
     type: "module",
     main: "out/main/index.js",
   };
+}
+
+function productionMain(target = '"./index-DV6OlGhL.js"'): string {
+  return `import { app } from "electron";
+const TELEGRAM_ACCEPTANCE_QUIT_FRAME = '{"type":"enduragent-telegram-acceptance","command":"quit"}\\n';
+function installTelegramAcceptanceQuitControl(input, quit) {
+  let source = "";
+  let valid = true;
+  input.setEncoding("utf8");
+  input.on("data", (chunk) => {
+    if (!valid) return;
+    source += chunk;
+    if (source.length > TELEGRAM_ACCEPTANCE_QUIT_FRAME.length || !TELEGRAM_ACCEPTANCE_QUIT_FRAME.startsWith(source)) {
+      valid = false;
+    }
+  });
+  input.once("error", () => {
+    valid = false;
+  });
+  input.once("end", () => {
+    if (valid && source === TELEGRAM_ACCEPTANCE_QUIT_FRAME) quit();
+  });
+  input.resume();
+}
+function telegramAcceptanceStartupFailureDiagnostic(error) {
+  let category = "unknown";
+  try {
+    if (typeof error === "object" && error !== null && "code" in error) {
+      switch (error.code) {
+        case "ERR_INVALID_PACKAGE_CONFIG":
+        case "ERR_INVALID_PACKAGE_TARGET":
+        case "ERR_MODULE_NOT_FOUND":
+        case "ERR_PACKAGE_IMPORT_NOT_DEFINED":
+        case "ERR_PACKAGE_PATH_NOT_EXPORTED":
+        case "ERR_UNKNOWN_FILE_EXTENSION":
+        case "ERR_UNSUPPORTED_DIR_IMPORT":
+          category = "module-resolution";
+      }
+    }
+  } catch {
+  }
+  return \`packaged Desktop production startup failed; category=${"${category}"}\`;
+}
+async function runTelegramAcceptanceBootstrap(input) {
+  try {
+    installTelegramAcceptanceQuitControl(input.input, input.quit);
+    input.beforeImport();
+    await input.importProduction();
+  } catch (error) {
+    try { input.report(telegramAcceptanceStartupFailureDiagnostic(error)); } catch {}
+    try { input.exit(1); } catch {}
+  }
+}
+const ACCEPTANCE_OS_LOGIN_MARKER_ENV = "ENDURAGENT_ACCEPTANCE_OS_LOGIN_LAUNCH";
+const ACCEPTANCE_OS_LOGIN_MARKER_VALUE = "os-login";
+function installSingleLoginLaunchObservation(app2, wasOpenedAtLogin) {
+  const key = "getLoginItemSettings";
+  const ownDescriptor = Object.getOwnPropertyDescriptor(app2, key);
+  const original = app2.getLoginItemSettings;
+  let pending = true;
+  const restore = () => {
+    if (ownDescriptor === void 0) {
+      if (!Reflect.deleteProperty(app2, key)) {
+        throw new TypeError("Telegram acceptance startup port could not be restored");
+      }
+      return;
+    }
+    Object.defineProperty(app2, key, ownDescriptor);
+  };
+  Object.defineProperty(app2, key, {
+    configurable: true,
+    writable: true,
+    value(...args) {
+      if (!pending) throw new TypeError("Telegram acceptance startup marker was reused");
+      pending = false;
+      restore();
+      return { ...original.apply(app2, args), wasOpenedAtLogin };
+    }
+  });
+}
+function consumeAcceptanceStartupMarker(environment, app2) {
+  const marker = environment[ACCEPTANCE_OS_LOGIN_MARKER_ENV];
+  delete environment[ACCEPTANCE_OS_LOGIN_MARKER_ENV];
+  if (marker === void 0) {
+    installSingleLoginLaunchObservation(app2, false);
+    return "manual";
+  }
+  if (marker !== ACCEPTANCE_OS_LOGIN_MARKER_VALUE) {
+    throw new TypeError("Telegram acceptance startup marker is invalid");
+  }
+  installSingleLoginLaunchObservation(app2, true);
+  return "os-login";
+}
+await runTelegramAcceptanceBootstrap({
+  input: process.stdin,
+  beforeImport: () => consumeAcceptanceStartupMarker(process.env, app),
+  importProduction: () => import(${target}),
+  quit: () => app.quit(),
+  report: (diagnostic) => process.stderr.write(\`${"${diagnostic}"}\\n\`),
+  exit: (code) => {
+    process.exitCode = code;
+    app.exit(code);
+  },
+});`;
+}
+
+function emptyPackagedHelper(source: string, name: string, nextDeclaration: string): string {
+  const start = source.indexOf(`function ${name}(`);
+  const body = source.indexOf("{", start);
+  const end = source.indexOf(nextDeclaration, body);
+  if (start < 0 || body < 0 || end < 0) throw new TypeError("test helper boundary is invalid");
+  return `${source.slice(0, body + 1)}}\n${source.slice(end)}`;
+}
+
+function beforePackagedBootstrap(source: string, mutation: string): string {
+  const handoff = "await runTelegramAcceptanceBootstrap({";
+  if (!source.includes(handoff)) throw new TypeError("test bootstrap boundary is invalid");
+  return source.replace(handoff, `${mutation}\n${handoff}`);
 }
 
 describe("Telegram acceptance package", () => {
@@ -310,20 +429,182 @@ describe("Telegram acceptance package", () => {
     }
   });
 
-  it("keeps the wrapped production main beside its runtime-relative dependencies", () => {
-    expect(verifyTelegramAcceptanceMainEntry('await import("./index-DV6OlGhL.js");')).toBe(
-      "out/main/index-DV6OlGhL.js",
+  it("audits every exact runtime export in the packaged workspace dependency closure", () => {
+    const rootManifest = {
+      dependencies: {
+        "@enduragent/alpha": "workspace:*",
+        external: "1.0.0",
+      },
+    };
+    const manifests: Record<string, unknown> = {
+      "node_modules/@enduragent/alpha/package.json": {
+        name: "@enduragent/alpha",
+        exports: {
+          ".": {
+            types: "./dist/index.d.ts",
+            import: "./dist/index.js",
+            require: "./dist/index.cjs",
+          },
+          "./feature": "./dist/feature.js",
+          "./generated/*": "./dist/generated/*.js",
+        },
+        dependencies: { "@enduragent/beta": "workspace:*" },
+      },
+      "node_modules/@enduragent/beta/package.json": {
+        name: "@enduragent/beta",
+        exports: { ".": "./dist/index.js" },
+      },
+    };
+    const archiveEntries = [
+      ...Object.keys(manifests),
+      "node_modules/@enduragent/alpha/dist/index.js",
+      "node_modules/@enduragent/alpha/dist/index.cjs",
+      "node_modules/@enduragent/alpha/dist/feature.js",
+      "node_modules/@enduragent/beta/dist/index.js",
+    ].map((entry) => `/${entry}`);
+
+    expect(
+      verifyTelegramAcceptanceWorkspaceRuntime(
+        rootManifest,
+        archiveEntries,
+        (path: string) => manifests[path],
+      ),
+    ).toEqual({
+      packages: ["@enduragent/alpha", "@enduragent/beta"],
+      exportTargets: [
+        "node_modules/@enduragent/alpha/dist/feature.js",
+        "node_modules/@enduragent/alpha/dist/index.cjs",
+        "node_modules/@enduragent/alpha/dist/index.js",
+        "node_modules/@enduragent/beta/dist/index.js",
+      ],
+    });
+  });
+
+  it("rejects a packaged workspace dependency with any missing exact runtime export", () => {
+    const manifestPath = "node_modules/@enduragent/kernel-node/package.json";
+    const packageManifest = {
+      name: "@enduragent/kernel-node",
+      exports: {
+        "./sqlite": "./dist/sqlite.js",
+        "./archive": "./dist/archive/index.js",
+      },
+    };
+
+    expect(() =>
+      verifyTelegramAcceptanceWorkspaceRuntime(
+        { dependencies: { "@enduragent/kernel-node": "workspace:*" } },
+        [`/${manifestPath}`, "/node_modules/@enduragent/kernel-node/dist/sqlite.js"],
+        (path: string) => (path === manifestPath ? packageManifest : undefined),
+      ),
+    ).toThrow(
+      "Telegram acceptance workspace export target is missing: @enduragent/kernel-node ./dist/archive/index.js",
     );
+  });
+
+  it("rejects missing or malformed packaged workspace package metadata", () => {
+    const rootManifest = { dependencies: { "@enduragent/runtime": "workspace:*" } };
+    expect(() =>
+      verifyTelegramAcceptanceWorkspaceRuntime(rootManifest, [], () => undefined),
+    ).toThrow("Telegram acceptance workspace package manifest is missing: @enduragent/runtime");
+    expect(() =>
+      verifyTelegramAcceptanceWorkspaceRuntime(
+        rootManifest,
+        ["/node_modules/@enduragent/runtime/package.json"],
+        () => ({
+          name: "@enduragent/runtime",
+          exports: { ".": "../outside.js" },
+        }),
+      ),
+    ).toThrow("Telegram acceptance workspace export target is invalid");
+  });
+
+  it("keeps the wrapped production main beside its runtime-relative dependencies", () => {
+    expect(verifyTelegramAcceptanceMainEntry(productionMain())).toBe("out/main/index-DV6OlGhL.js");
     for (const invalid of [
-      'await import("./chunks/index-DV6OlGhL.js");',
-      'await import("../main/index-DV6OlGhL.js");',
-      'await import("./index.js");',
-      'await import("./index-first.js"); await import("./index-second.js");',
-      '// await import("./index-does-not-exist.js");',
-      '/*\nawait import("./index-does-not-exist.js");',
-      'const source = `\nawait import("./index-does-not-exist.js");',
-      'await import("./index-DV6OlGhL.js");\nprocess.stdout.write("after handoff");',
+      productionMain('"./chunks/index-DV6OlGhL.js"'),
+      productionMain('"../main/index-DV6OlGhL.js"'),
+      productionMain('"./index.js"'),
+      productionMain("`./index-${suffix}.js`"),
+      productionMain().replace("runTelegramAcceptanceBootstrap({", "arbitraryBootstrap({"),
+      productionMain().replace("input: process.stdin,", "input: process.stdout,"),
+      productionMain().replace("await input.importProduction();", "input.importProduction();"),
+      productionMain().replace("input.exit(1);", "input.exit(0);"),
+      productionMain().replace("importProduction: () =>", "productionImport: () =>"),
+      productionMain().replace("process.exitCode = code;", "process.exitCode = 0;"),
+      productionMain().replace("app.exit(code);", "app.exit(1);"),
+      emptyPackagedHelper(
+        productionMain(),
+        "installTelegramAcceptanceQuitControl",
+        "function telegramAcceptanceStartupFailureDiagnostic",
+      ),
+      emptyPackagedHelper(
+        productionMain(),
+        "telegramAcceptanceStartupFailureDiagnostic",
+        "async function runTelegramAcceptanceBootstrap",
+      ),
+      emptyPackagedHelper(
+        productionMain(),
+        "installSingleLoginLaunchObservation",
+        "function consumeAcceptanceStartupMarker",
+      ),
+      emptyPackagedHelper(
+        productionMain(),
+        "consumeAcceptanceStartupMarker",
+        "await runTelegramAcceptanceBootstrap",
+      ),
+      `${productionMain()}\nprocess.stdout.write("after handoff");`,
       undefined,
+    ]) {
+      expect(() => verifyTelegramAcceptanceMainEntry(invalid)).toThrow();
+    }
+  });
+
+  it("rejects writes to protected packaged helpers immediately before bootstrap", () => {
+    for (const mutation of [
+      "installTelegramAcceptanceQuitControl = () => {};",
+      "installTelegramAcceptanceQuitControl = installTelegramAcceptanceQuitControl;",
+      "telegramAcceptanceStartupFailureDiagnostic = telegramAcceptanceStartupFailureDiagnostic;",
+      'ACCEPTANCE_OS_LOGIN_MARKER_VALUE += "-mutated";',
+      "runTelegramAcceptanceBootstrap.prototype.apply = undefined;",
+      "({ replacement: consumeAcceptanceStartupMarker } = replacements);",
+      "[telegramAcceptanceStartupFailureDiagnostic] = replacements;",
+      "TELEGRAM_ACCEPTANCE_QUIT_FRAME++;",
+      "delete installSingleLoginLaunchObservation.prototype;",
+      'Object.defineProperty(consumeAcceptanceStartupMarker, "call", { value: undefined });',
+    ]) {
+      expect(() =>
+        verifyTelegramAcceptanceMainEntry(beforePackagedBootstrap(productionMain(), mutation)),
+      ).toThrow("Telegram acceptance production helper binding is mutated");
+    }
+  });
+
+  it("rejects extra top-level authority mutations immediately before bootstrap", () => {
+    for (const mutation of [
+      "app.quit = () => {};",
+      "process.stdin.on = () => {};",
+      'eval("installTelegramAcceptanceQuitControl = () => {}");',
+    ]) {
+      expect(() =>
+        verifyTelegramAcceptanceMainEntry(beforePackagedBootstrap(productionMain(), mutation)),
+      ).toThrow("Telegram acceptance production top-level layout is invalid");
+    }
+  });
+
+  it("rejects non-exact bootstrap parameters and Electron import syntax", () => {
+    for (const invalid of [
+      productionMain().replace(
+        "async function runTelegramAcceptanceBootstrap(input)",
+        "async function* runTelegramAcceptanceBootstrap(input)",
+      ),
+      productionMain().replace(
+        "async function runTelegramAcceptanceBootstrap(input)",
+        "async function runTelegramAcceptanceBootstrap(...input)",
+      ),
+      productionMain().replace("exit: (code) => {", "exit: (...code) => {"),
+      productionMain().replace(
+        'import { app } from "electron";',
+        'import { app } from "electron" with { type: "json" };',
+      ),
     ]) {
       expect(() => verifyTelegramAcceptanceMainEntry(invalid)).toThrow();
     }

--- a/apps/desktop/tests/package-telegram-acceptance.test.ts
+++ b/apps/desktop/tests/package-telegram-acceptance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createTelegramAcceptanceBuilderConfiguration,
+  selectTelegramAcceptanceNestedTarget,
   TELEGRAM_ACCEPTANCE_APP_ID,
   TELEGRAM_ACCEPTANCE_ENTITLEMENTS,
   TELEGRAM_ACCEPTANCE_MARKER,
@@ -9,11 +10,16 @@ import {
   verifyTelegramAcceptanceDesignatedRequirement,
   verifyTelegramAcceptanceEntitlements,
   verifyTelegramAcceptanceInfoPlist,
+  verifyTelegramAcceptanceMainEntry,
   verifyTelegramAcceptanceManifest,
+  verifyTelegramAcceptanceNestedEntitlements,
+  verifyTelegramAcceptanceNestedListing,
+  verifyTelegramAcceptanceNestedSignature,
   verifyTelegramAcceptanceSignature,
 } from "./fixtures/packaged-telegram/package-acceptance.mjs";
 
 const version = "0.0.1";
+const cdHash = "0123456789abcdef0123456789abcdef01234567";
 
 function canonicalBuilder() {
   return {
@@ -38,6 +44,18 @@ function signature(overrides: Partial<Record<string, string>> = {}): string {
     overrides.InfoPlist ?? "Info.plist entries=31",
     overrides.SealedResources ?? "Sealed Resources version=2 rules=13 files=287",
     overrides.InternalRequirements ?? "Internal requirements count=0 size=12",
+    `CDHash=${overrides.CDHash ?? cdHash}`,
+  ].join("\n");
+}
+
+function nestedSignature(overrides: Partial<Record<string, string>> = {}): string {
+  return [
+    `Executable=${overrides.Executable ?? "/Applications/Acceptance.app/Contents/Frameworks/Helper.app/Contents/MacOS/Helper"}`,
+    `Identifier=${overrides.Identifier ?? "icu.enduragent.desktop.telegram-acceptance.helper"}`,
+    `CDHash=${overrides.CDHash ?? cdHash}`,
+    `Signature=${overrides.Signature ?? "adhoc"}`,
+    `TeamIdentifier=${overrides.TeamIdentifier ?? "not set"}`,
+    ...(overrides.Nested === undefined ? [] : [overrides.Nested]),
   ].join("\n");
 }
 
@@ -56,6 +74,8 @@ function manifest() {
     productName: TELEGRAM_ACCEPTANCE_PRODUCT_NAME,
     [TELEGRAM_ACCEPTANCE_MARKER]: true,
     version,
+    type: "module",
+    main: "out/main/index.js",
   };
 }
 
@@ -111,7 +131,7 @@ describe("Telegram acceptance package", () => {
   });
 
   it("requires an ad-hoc, teamless signature with bound metadata and sealed resources", () => {
-    expect(() => verifyTelegramAcceptanceSignature(signature())).not.toThrow();
+    expect(verifyTelegramAcceptanceSignature(signature())).toBe(cdHash);
     for (const invalid of [
       signature({ Identifier: "icu.enduragent.desktop" }),
       signature({ Signature: "Developer ID Application: Production" }),
@@ -119,9 +139,101 @@ describe("Telegram acceptance package", () => {
       signature({ InfoPlist: "Info.plist entries=0" }),
       signature({ SealedResources: "Sealed Resources version=2 rules=13 files=0" }),
       signature({ InternalRequirements: "Internal requirements count=0 size=0" }),
+      signature({ CDHash: "not-a-cdhash" }),
+      `${signature()}\nSignature=Developer ID Application: Production`,
+      `${signature()}\nTeamIdentifier=not set`,
     ]) {
       expect(() => verifyTelegramAcceptanceSignature(invalid)).toThrow();
     }
+  });
+
+  it("requires every nested code object to be unambiguously ad-hoc and teamless", () => {
+    expect(() => verifyTelegramAcceptanceNestedSignature(nestedSignature())).not.toThrow();
+    for (const invalid of [
+      nestedSignature({ Signature: "Developer ID Application: Production" }),
+      nestedSignature({ TeamIdentifier: "ABCDE12345" }),
+      nestedSignature({ CDHash: "not-a-cdhash" }),
+      `${nestedSignature()}\nSignature=adhoc`,
+      `${nestedSignature()}\nTeamIdentifier=not set`,
+    ]) {
+      expect(() => verifyTelegramAcceptanceNestedSignature(invalid)).toThrow(
+        "Telegram acceptance nested signature is invalid",
+      );
+    }
+  });
+
+  it("accepts absent nested entitlements or only the allow-jit entitlement", () => {
+    expect(() => verifyTelegramAcceptanceNestedEntitlements(undefined)).not.toThrow();
+    expect(() =>
+      verifyTelegramAcceptanceNestedEntitlements(TELEGRAM_ACCEPTANCE_ENTITLEMENTS),
+    ).not.toThrow();
+    for (const invalid of [
+      null,
+      {},
+      { "com.apple.security.cs.allow-jit": false },
+      {
+        "com.apple.security.cs.allow-jit": true,
+        "com.apple.security.cs.disable-library-validation": true,
+      },
+    ]) {
+      expect(() => verifyTelegramAcceptanceNestedEntitlements(invalid)).toThrow(
+        "Telegram acceptance nested entitlements are invalid",
+      );
+    }
+  });
+
+  it("enumerates only unique, relative nested code paths from one executable", () => {
+    const description = [
+      nestedSignature(),
+      "Nested=Frameworks/Helper.app",
+      "Nested=Frameworks/Electron Framework.framework",
+    ].join("\n");
+    expect(verifyTelegramAcceptanceNestedListing(description)).toEqual({
+      executable:
+        "/Applications/Acceptance.app/Contents/Frameworks/Helper.app/Contents/MacOS/Helper",
+      nested: ["Frameworks/Helper.app", "Frameworks/Electron Framework.framework"],
+    });
+
+    for (const nested of [
+      "Nested=",
+      "Nested=/tmp/escape",
+      "Nested=../escape",
+      "Nested=Frameworks/../escape",
+      "Nested=Frameworks/./Helper.app",
+      "Nested=Frameworks//Helper.app",
+      "Nested=Frameworks\\Helper.app",
+      "Nested=Frameworks/Helper.app\nNested=Frameworks/Helper.app",
+    ]) {
+      expect(() =>
+        verifyTelegramAcceptanceNestedListing([nestedSignature(), nested].join("\n")),
+      ).toThrow("Telegram acceptance nested code listing is invalid");
+    }
+    expect(() =>
+      verifyTelegramAcceptanceNestedListing(
+        `${nestedSignature()}\nExecutable=/Applications/Other.app/Contents/MacOS/Other`,
+      ),
+    ).toThrow("Telegram acceptance nested code listing is invalid");
+  });
+
+  it("selects one canonical nested target inside the application", () => {
+    const application = "/Applications/Acceptance.app";
+    const helper = `${application}/Contents/Frameworks/Helper.app`;
+    expect(selectTelegramAcceptanceNestedTarget(application, [helper, helper])).toBe(helper);
+    expect(() => selectTelegramAcceptanceNestedTarget(application, [])).toThrow(
+      "Telegram acceptance nested code target is missing",
+    );
+    expect(() =>
+      selectTelegramAcceptanceNestedTarget(application, [
+        helper,
+        `${application}/Contents/Frameworks/Other.framework`,
+      ]),
+    ).toThrow("Telegram acceptance nested code target is ambiguous");
+    expect(() => selectTelegramAcceptanceNestedTarget(application, ["/tmp/escape"])).toThrow(
+      "Telegram acceptance nested code target escapes the application",
+    );
+    expect(() =>
+      selectTelegramAcceptanceNestedTarget(application, ["relative/Helper.app"]),
+    ).toThrow("Telegram acceptance nested code resolution is invalid");
   });
 
   it("requires the exact acceptance Info.plist identity", () => {
@@ -157,22 +269,29 @@ describe("Telegram acceptance package", () => {
     }
   });
 
-  it("requires a teamless designated requirement for only the acceptance identifier", () => {
-    const expected = `designated => identifier "${TELEGRAM_ACCEPTANCE_APP_ID}"`;
-    expect(() => verifyTelegramAcceptanceDesignatedRequirement(expected)).not.toThrow();
+  it("binds the ad-hoc designated requirement to the verified code-directory hash", () => {
+    const expected = `# designated => cdhash H"${cdHash}"`;
+    expect(() => verifyTelegramAcceptanceDesignatedRequirement(expected, cdHash)).not.toThrow();
     expect(() =>
-      verifyTelegramAcceptanceDesignatedRequirement(`\n  ${expected.replaceAll(" ", "  ")}\n`),
+      verifyTelegramAcceptanceDesignatedRequirement(
+        `\n  ${expected.replaceAll(" ", "  ")}\n`,
+        cdHash,
+      ),
     ).not.toThrow();
     for (const invalid of [
-      'designated => identifier "icu.enduragent.desktop"',
+      `designated => cdhash H"${cdHash}"`,
+      `# designated => cdhash H"1123456789abcdef0123456789abcdef01234567"`,
+      `# designated => identifier "${TELEGRAM_ACCEPTANCE_APP_ID}"`,
       `${expected} and anchor apple`,
-      `${expected} and certificate leaf[subject.OU] = ABCDE12345`,
-      `identifier "${TELEGRAM_ACCEPTANCE_APP_ID}"`,
+      `# designated => cdhash h"${cdHash}"`,
     ]) {
-      expect(() => verifyTelegramAcceptanceDesignatedRequirement(invalid)).toThrow(
+      expect(() => verifyTelegramAcceptanceDesignatedRequirement(invalid, cdHash)).toThrow(
         "Telegram acceptance designated requirement is invalid",
       );
     }
+    expect(() => verifyTelegramAcceptanceDesignatedRequirement(expected, "not-a-cdhash")).toThrow(
+      "Telegram acceptance code-directory hash is invalid",
+    );
   });
 
   it("requires the exact acceptance ASAR manifest identity and marker", () => {
@@ -182,10 +301,31 @@ describe("Telegram acceptance package", () => {
       { ...manifest(), productName: "Enduragent" },
       { ...manifest(), [TELEGRAM_ACCEPTANCE_MARKER]: false },
       { ...manifest(), version: "0.0.2" },
+      { ...manifest(), type: "commonjs" },
+      { ...manifest(), main: "out/main/not-the-wrapper.js" },
     ]) {
       expect(() => verifyTelegramAcceptanceManifest(invalid, version)).toThrow(
         "Telegram acceptance ASAR manifest identity is invalid",
       );
+    }
+  });
+
+  it("keeps the wrapped production main beside its runtime-relative dependencies", () => {
+    expect(verifyTelegramAcceptanceMainEntry('await import("./index-DV6OlGhL.js");')).toBe(
+      "out/main/index-DV6OlGhL.js",
+    );
+    for (const invalid of [
+      'await import("./chunks/index-DV6OlGhL.js");',
+      'await import("../main/index-DV6OlGhL.js");',
+      'await import("./index.js");',
+      'await import("./index-first.js"); await import("./index-second.js");',
+      '// await import("./index-does-not-exist.js");',
+      '/*\nawait import("./index-does-not-exist.js");',
+      'const source = `\nawait import("./index-does-not-exist.js");',
+      'await import("./index-DV6OlGhL.js");\nprocess.stdout.write("after handoff");',
+      undefined,
+    ]) {
+      expect(() => verifyTelegramAcceptanceMainEntry(invalid)).toThrow();
     }
   });
 });

--- a/apps/desktop/tests/packaged-process-safety.test.ts
+++ b/apps/desktop/tests/packaged-process-safety.test.ts
@@ -1,89 +1,175 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import {
-  classifyDarwinProcessObservation,
-  parseDarwinProcessObservation,
+  observeTelegramAcceptanceChild,
   releaseAcceptanceStorage,
-  type DarwinProcessBirthIdentity,
+  TELEGRAM_ACCEPTANCE_ACCOUNTING_NAME,
+  telegramAcceptanceBundleTextIsClear,
+  telegramAcceptanceDebuggerListenerOwner,
+  telegramAcceptanceDirectExitIsClean,
+  telegramAcceptanceProcessTableIsClear,
+  telegramAcceptanceShutdownIsProven,
 } from "./fixtures/packaged-telegram/process-safety.js";
 
-const bundleRoot = "/tmp/Enduragent Telegram Acceptance.app";
-const command = `${bundleRoot}/Contents/MacOS/Enduragent Telegram Acceptance --flag`;
-const startToken = "Thu Aug  6 13:45:12 2026";
-
-function running(pid = 123, token = startToken, processCommand = command) {
-  return parseDarwinProcessObservation(
-    {
-      code: 0,
-      signal: null,
-      stdout: Buffer.from(`  ${pid} ${token} ${processCommand}\n`),
-      stderr: Buffer.alloc(0),
-    },
-    pid,
-    bundleRoot,
-  );
+function processTable(source: string, overrides: { code?: number; stderr?: string } = {}) {
+  return {
+    code: overrides.code ?? 0,
+    signal: null,
+    stdout: Buffer.from(source),
+    stderr: Buffer.from(overrides.stderr ?? ""),
+  };
 }
 
-describe("packaged process identity", () => {
-  it("matches only the captured birth token and exact command identity", () => {
-    const tracked = (running() as { state: "running"; identity: DarwinProcessBirthIdentity })
-      .identity;
+const bundleRoot = "/tmp/Enduragent Telegram Acceptance.app";
 
-    expect(classifyDarwinProcessObservation(tracked, running())).toBe("same");
-    expect(classifyDarwinProcessObservation(tracked, { state: "absent" })).toBe("exited");
-    expect(
-      classifyDarwinProcessObservation(tracked, running(123, "Thu Aug  6 13:45:13 2026")),
-    ).toBe("reused");
-    expect(
-      classifyDarwinProcessObservation(
-        tracked,
-        running(123, startToken, `${bundleRoot}/Contents/Frameworks/Other Helper --flag`),
-      ),
-    ).toBe("reused");
+function fakeChild(pid: number | undefined) {
+  const emitter = new EventEmitter();
+  Object.defineProperty(emitter, "pid", { configurable: true, value: pid });
+  return { child: emitter as unknown as ChildProcess, emitter };
+}
+
+describe("packaged direct-child lifecycle", () => {
+  it("settles both observations without rejection when spawn fails", async () => {
+    const { child, emitter } = fakeChild(undefined);
+    const lifecycle = observeTelegramAcceptanceChild(child);
+    const error = new Error("spawn failed");
+    emitter.emit("error", error);
+    await expect(lifecycle.launch).resolves.toEqual({ state: "spawn-error", error });
+    await expect(lifecycle.terminal).resolves.toEqual({ state: "spawn-error", error });
   });
 
-  it("rejects a command outside the acceptance bundle", () => {
-    expect(() => running(123, startToken, "/usr/bin/other --flag")).toThrow(
-      "tracked process identity is outside the acceptance bundle",
+  it("requires spawn followed by close zero with no signal", async () => {
+    const { child, emitter } = fakeChild(123);
+    const lifecycle = observeTelegramAcceptanceChild(child);
+    emitter.emit("spawn");
+    emitter.emit("close", 0, null);
+    expect(
+      telegramAcceptanceDirectExitIsClean(await lifecycle.launch, await lifecycle.terminal),
+    ).toBe(true);
+
+    for (const terminal of [
+      { state: "closed" as const, code: 1, signal: null },
+      { state: "closed" as const, code: null, signal: "SIGTERM" as const },
+      { state: "child-error" as const, error: new Error("child error") },
+    ]) {
+      expect(telegramAcceptanceDirectExitIsClean({ state: "spawned", pid: 123 }, terminal)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("records a post-spawn child error as an unclean terminal", async () => {
+    const { child, emitter } = fakeChild(123);
+    const lifecycle = observeTelegramAcceptanceChild(child);
+    const error = new Error("child error");
+    emitter.emit("spawn");
+    emitter.emit("error", error);
+    expect(await lifecycle.launch).toEqual({ state: "spawned", pid: 123 });
+    expect(await lifecycle.terminal).toEqual({ state: "child-error", error });
+  });
+});
+
+describe("packaged process-table release proof", () => {
+  it("recognizes every packaged app and helper by the dependable accounting name", () => {
+    expect(
+      telegramAcceptanceProcessTableIsClear(
+        processTable(`1 launchd\n123 ${TELEGRAM_ACCEPTANCE_ACCOUNTING_NAME}\n456 node\n`),
+      ),
+    ).toBe(false);
+    expect(telegramAcceptanceProcessTableIsClear(processTable("1 launchd\n456 node\n"))).toBe(true);
+  });
+
+  it("fails closed on failed, diagnostic, empty, malformed, or ambiguous observations", () => {
+    for (const invalid of [
+      processTable("", { code: 1 }),
+      processTable("1 launchd\n", { stderr: "ps: diagnostic\n" }),
+      processTable(""),
+      processTable("not-a-process\n"),
+      processTable("1 launchd\n1 node\n"),
+    ]) {
+      expect(() => telegramAcceptanceProcessTableIsClear(invalid)).toThrow();
+    }
+  });
+
+  it("binds a debugger listener to exactly one kernel-reported process owner", () => {
+    expect(telegramAcceptanceDebuggerListenerOwner(processTable("p123\0\nf22\0\nf24\0\n"))).toBe(
+      123,
+    );
+    expect(telegramAcceptanceDebuggerListenerOwner(processTable("", { code: 1 }))).toBeUndefined();
+    for (const invalid of [
+      processTable(""),
+      processTable("p123\0\n"),
+      processTable("p123\0\nf22\0\np456\0\nf24\0\n"),
+      processTable("p123\0\nf22\0\np123\0\n"),
+      processTable("p123\0\nf22\0\nf22\0\n"),
+      processTable("n/tmp/socket\0\n"),
+      processTable("p123\0\nf22\0\n", { stderr: "lsof: diagnostic\n" }),
+    ]) {
+      expect(() => telegramAcceptanceDebuggerListenerOwner(invalid)).toThrow();
+    }
+  });
+
+  it("uses kernel-backed bundle text paths to catch generically named subprocesses", () => {
+    expect(
+      telegramAcceptanceBundleTextIsClear(
+        processTable(`p123\0\nftxt\0n${bundleRoot}/Contents/MacOS/chrome_crashpad_handler\0\n`),
+        bundleRoot,
+      ),
+    ).toBe(false);
+    expect(telegramAcceptanceBundleTextIsClear(processTable("", { code: 1 }), bundleRoot)).toBe(
+      true,
     );
   });
 
-  it("fails closed when an exit-1 observation carries diagnostic stderr", () => {
-    expect(() =>
-      parseDarwinProcessObservation(
-        {
-          code: 1,
-          signal: null,
-          stdout: Buffer.alloc(0),
-          stderr: Buffer.from("ps: diagnostic\n"),
-        },
-        123,
-        bundleRoot,
-      ),
-    ).toThrow("tracked process observation failed");
+  it("fails closed on malformed or outside-bundle text-path observations", () => {
+    for (const invalid of [
+      processTable("", { code: 0 }),
+      processTable("", { code: 2 }),
+      processTable(`p123\0\nftxt\0n/usr/bin/other\0\n`),
+      processTable(`p123\0\nftxt\0n${bundleRoot}/Contents/MacOS/main\0\np123\0`),
+      processTable(`ftxt\0n${bundleRoot}/Contents/MacOS/main\0`),
+    ]) {
+      expect(() => telegramAcceptanceBundleTextIsClear(invalid, bundleRoot)).toThrow();
+    }
+  });
+
+  it("permits release only after successful execution, clean direct exits, and a clear scan", () => {
+    const proven = {
+      executionSucceeded: true,
+      directApplicationsExitedCleanly: true,
+      processTableClear: true,
+    };
+    expect(telegramAcceptanceShutdownIsProven(proven)).toBe(true);
+    for (const key of Object.keys(proven) as (keyof typeof proven)[]) {
+      expect(telegramAcceptanceShutdownIsProven({ ...proven, [key]: false })).toBe(false);
+    }
   });
 });
 
 describe("packaged storage release", () => {
-  it("does not restore the keychain or remove scratch while a process remains live", async () => {
-    const restoreKeychain = vi.fn(async () => true);
-    const removeScratch = vi.fn(async () => undefined);
-
-    await expect(
-      releaseAcceptanceStorage({
-        processesStopped: false,
-        debuggerListenersClosed: true,
-        recoveryPath: "/tmp/recovery.keychain-db",
-        restoreKeychain,
-        removeScratch,
-      }),
-    ).rejects.toThrow("acceptance storage retained");
-    expect(restoreKeychain).not.toHaveBeenCalled();
-    expect(removeScratch).not.toHaveBeenCalled();
+  it("does not restore the keychain or remove scratch while cleanup is unproven", async () => {
+    for (const input of [
+      { processesStopped: false, debuggerListenersClosed: true },
+      { processesStopped: true, debuggerListenersClosed: false },
+    ]) {
+      const restoreKeychain = vi.fn(async () => true);
+      const removeScratch = vi.fn(async () => undefined);
+      await expect(
+        releaseAcceptanceStorage({
+          ...input,
+          recoveryPath: "/tmp/recovery.keychain-db",
+          restoreKeychain,
+          removeScratch,
+        }),
+      ).rejects.toThrow("acceptance storage retained");
+      expect(restoreKeychain).not.toHaveBeenCalled();
+      expect(removeScratch).not.toHaveBeenCalled();
+    }
   });
 
   it("does not remove scratch when keychain restoration is not proven", async () => {
     const removeScratch = vi.fn(async () => undefined);
-
     await expect(
       releaseAcceptanceStorage({
         processesStopped: true,
@@ -94,5 +180,22 @@ describe("packaged storage release", () => {
       }),
     ).rejects.toThrow("acceptance keychain retained");
     expect(removeScratch).not.toHaveBeenCalled();
+  });
+
+  it("restores the keychain before removing scratch after every proof succeeds", async () => {
+    const calls: string[] = [];
+    await releaseAcceptanceStorage({
+      processesStopped: true,
+      debuggerListenersClosed: true,
+      recoveryPath: "/tmp/recovery.keychain-db",
+      restoreKeychain: async () => {
+        calls.push("restore");
+        return true;
+      },
+      removeScratch: async () => {
+        calls.push("remove");
+      },
+    });
+    expect(calls).toEqual(["restore", "remove"]);
   });
 });

--- a/apps/desktop/tests/packaged-process-safety.test.ts
+++ b/apps/desktop/tests/packaged-process-safety.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  classifyDarwinProcessObservation,
+  parseDarwinProcessObservation,
+  releaseAcceptanceStorage,
+  type DarwinProcessBirthIdentity,
+} from "./fixtures/packaged-telegram/process-safety.js";
+
+const bundleRoot = "/tmp/Enduragent Telegram Acceptance.app";
+const command = `${bundleRoot}/Contents/MacOS/Enduragent Telegram Acceptance --flag`;
+const startToken = "Thu Aug  6 13:45:12 2026";
+
+function running(pid = 123, token = startToken, processCommand = command) {
+  return parseDarwinProcessObservation(
+    {
+      code: 0,
+      signal: null,
+      stdout: Buffer.from(`  ${pid} ${token} ${processCommand}\n`),
+      stderr: Buffer.alloc(0),
+    },
+    pid,
+    bundleRoot,
+  );
+}
+
+describe("packaged process identity", () => {
+  it("matches only the captured birth token and exact command identity", () => {
+    const tracked = (running() as { state: "running"; identity: DarwinProcessBirthIdentity })
+      .identity;
+
+    expect(classifyDarwinProcessObservation(tracked, running())).toBe("same");
+    expect(classifyDarwinProcessObservation(tracked, { state: "absent" })).toBe("exited");
+    expect(
+      classifyDarwinProcessObservation(tracked, running(123, "Thu Aug  6 13:45:13 2026")),
+    ).toBe("reused");
+    expect(
+      classifyDarwinProcessObservation(
+        tracked,
+        running(123, startToken, `${bundleRoot}/Contents/Frameworks/Other Helper --flag`),
+      ),
+    ).toBe("reused");
+  });
+
+  it("rejects a command outside the acceptance bundle", () => {
+    expect(() => running(123, startToken, "/usr/bin/other --flag")).toThrow(
+      "tracked process identity is outside the acceptance bundle",
+    );
+  });
+
+  it("fails closed when an exit-1 observation carries diagnostic stderr", () => {
+    expect(() =>
+      parseDarwinProcessObservation(
+        {
+          code: 1,
+          signal: null,
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.from("ps: diagnostic\n"),
+        },
+        123,
+        bundleRoot,
+      ),
+    ).toThrow("tracked process observation failed");
+  });
+});
+
+describe("packaged storage release", () => {
+  it("does not restore the keychain or remove scratch while a process remains live", async () => {
+    const restoreKeychain = vi.fn(async () => true);
+    const removeScratch = vi.fn(async () => undefined);
+
+    await expect(
+      releaseAcceptanceStorage({
+        processesStopped: false,
+        debuggerListenersClosed: true,
+        recoveryPath: "/tmp/recovery.keychain-db",
+        restoreKeychain,
+        removeScratch,
+      }),
+    ).rejects.toThrow("acceptance storage retained");
+    expect(restoreKeychain).not.toHaveBeenCalled();
+    expect(removeScratch).not.toHaveBeenCalled();
+  });
+
+  it("does not remove scratch when keychain restoration is not proven", async () => {
+    const removeScratch = vi.fn(async () => undefined);
+
+    await expect(
+      releaseAcceptanceStorage({
+        processesStopped: true,
+        debuggerListenersClosed: true,
+        recoveryPath: "/tmp/recovery.keychain-db",
+        restoreKeychain: async () => false,
+        removeScratch,
+      }),
+    ).rejects.toThrow("acceptance keychain retained");
+    expect(removeScratch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/tests/packaged-process-safety.test.ts
+++ b/apps/desktop/tests/packaged-process-safety.test.ts
@@ -1,13 +1,19 @@
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import {
+  installTelegramAcceptanceQuitControl,
   observeTelegramAcceptanceChild,
   releaseAcceptanceStorage,
+  runTelegramAcceptanceBootstrap,
   TELEGRAM_ACCEPTANCE_ACCOUNTING_NAME,
+  TELEGRAM_ACCEPTANCE_QUIT_FRAME,
   telegramAcceptanceBundleTextIsClear,
   telegramAcceptanceDebuggerListenerOwner,
   telegramAcceptanceDirectExitIsClean,
+  telegramAcceptanceJsonDiagnostic,
+  telegramAcceptanceLaunchDiagnostic,
   telegramAcceptanceProcessTableIsClear,
   telegramAcceptanceShutdownIsProven,
 } from "./fixtures/packaged-telegram/process-safety.js";
@@ -67,6 +73,149 @@ describe("packaged direct-child lifecycle", () => {
     emitter.emit("error", error);
     expect(await lifecycle.launch).toEqual({ state: "spawned", pid: 123 });
     expect(await lifecycle.terminal).toEqual({ state: "child-error", error });
+  });
+
+  it("retains lifecycle and output diagnostics without exposing sensitive values", () => {
+    const sensitive = '123456789:line one\n"quoted"\\tail';
+    const escapedSensitive = JSON.stringify(sensitive).slice(1, -1);
+    const diagnostic = telegramAcceptanceLaunchDiagnostic({
+      pid: 123,
+      code: 1,
+      signal: null,
+      output: {
+        stdout: `before ${sensitive} after`,
+        stderr: `startup ${sensitive} failed`,
+      },
+      sensitiveValues: [sensitive],
+    });
+    expect(diagnostic).toContain("pid=123; exit=1; signal=null");
+    expect(diagnostic).toContain('stdout":"before <redacted> after');
+    expect(diagnostic).toContain('stderr":"startup <redacted> failed');
+    expect(diagnostic).not.toContain(sensitive);
+    expect(diagnostic).not.toContain(escapedSensitive);
+
+    const keyedDiagnostic = telegramAcceptanceJsonDiagnostic(
+      { [`prefix ${sensitive} suffix`]: "fixed value" },
+      [sensitive],
+    );
+    expect(keyedDiagnostic).toContain('"prefix <redacted> suffix":"fixed value"');
+    expect(keyedDiagnostic).not.toContain(sensitive);
+    expect(keyedDiagnostic).not.toContain(escapedSensitive);
+
+    expect(telegramAcceptanceJsonDiagnostic({ value: "abcdef" }, ["abc", "abcdef"])).toBe(
+      '{"value":"<redacted>"}',
+    );
+    expect(telegramAcceptanceJsonDiagnostic({ value: "redacted" }, ["redacted"])).toBe(
+      '{"value":""}',
+    );
+  });
+});
+
+describe("packaged application bootstrap control", () => {
+  it("registers an exact, fragmented stdin quit frame before production startup", async () => {
+    const input = new PassThrough();
+    const quit = vi.fn();
+    const importProduction = vi.fn(async () => {
+      expect(input.listenerCount("data")).toBeGreaterThan(0);
+      expect(input.listenerCount("end")).toBeGreaterThan(0);
+    });
+
+    const bootstrap = runTelegramAcceptanceBootstrap({
+      input,
+      beforeImport: () => undefined,
+      importProduction,
+      quit,
+      report: vi.fn(),
+      exit: vi.fn(),
+    });
+    expect(importProduction).toHaveBeenCalledOnce();
+
+    input.write(TELEGRAM_ACCEPTANCE_QUIT_FRAME.slice(0, 7));
+    expect(quit).not.toHaveBeenCalled();
+    const ended = new Promise<void>((resolve) => input.once("end", resolve));
+    input.end(TELEGRAM_ACCEPTANCE_QUIT_FRAME.slice(7));
+
+    await Promise.all([bootstrap, ended]);
+    expect(quit).toHaveBeenCalledOnce();
+  });
+
+  it("ignores malformed, oversized, and repeated stdin commands", async () => {
+    for (const command of [
+      "quit\n",
+      `${TELEGRAM_ACCEPTANCE_QUIT_FRAME}again\n`,
+      "x".repeat(TELEGRAM_ACCEPTANCE_QUIT_FRAME.length + 1),
+    ]) {
+      const input = new PassThrough();
+      const quit = vi.fn();
+      installTelegramAcceptanceQuitControl(input, quit);
+      const ended = new Promise<void>((resolve) => input.once("end", resolve));
+      input.end(command);
+      await ended;
+      expect(quit).not.toHaveBeenCalled();
+    }
+  });
+
+  it("contains production import rejection, reports only a sanitized class, and exits nonzero", async () => {
+    const input = new PassThrough();
+    const secret = "/private/tmp/athlete-secret\nsecond-line";
+    const error = Object.assign(new Error(`Cannot load ${secret}`), {
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+    const report = vi.fn();
+    const exit = vi.fn();
+
+    await expect(
+      runTelegramAcceptanceBootstrap({
+        input,
+        beforeImport: () => undefined,
+        importProduction: async () => Promise.reject(error),
+        quit: vi.fn(),
+        report,
+        exit,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(report).toHaveBeenCalledOnce();
+    const diagnostic = String(report.mock.calls[0]?.[0]);
+    expect(diagnostic).toBe(
+      "packaged Desktop production startup failed; category=module-resolution",
+    );
+    expect(diagnostic).not.toContain(secret);
+    expect(diagnostic).not.toContain("athlete-secret");
+    expect(diagnostic).not.toMatch(/[\r\n]/u);
+    expect(exit).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("does not echo safe-shaped attacker-controlled failure metadata", async () => {
+    const report = vi.fn();
+    await runTelegramAcceptanceBootstrap({
+      input: new PassThrough(),
+      beforeImport: () => undefined,
+      importProduction: async () =>
+        Promise.reject({ name: "AthleteSecret", code: "ATHLETE_SECRET" }),
+      quit: vi.fn(),
+      report,
+      exit: vi.fn(),
+    });
+    expect(report).toHaveBeenCalledWith(
+      "packaged Desktop production startup failed; category=unknown",
+    );
+  });
+
+  it("does not report or exit after successful production startup", async () => {
+    const report = vi.fn();
+    const exit = vi.fn();
+    await runTelegramAcceptanceBootstrap({
+      input: new PassThrough(),
+      beforeImport: () => undefined,
+      importProduction: async () => undefined,
+      quit: vi.fn(),
+      report,
+      exit,
+    });
+    expect(report).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/tests/packaged-startup-mode.test.ts
+++ b/apps/desktop/tests/packaged-startup-mode.test.ts
@@ -6,11 +6,11 @@ import {
   type AcceptanceLoginLaunchPort,
 } from "./fixtures/packaged-telegram/startup-mode.js";
 
-function loginPort() {
+function loginPort(wasOpenedAtLogin = false) {
   const getLoginItemSettings = vi.fn(() => ({
     openAtLogin: false,
     executableWillLaunchAtLogin: false,
-    wasOpenedAtLogin: false,
+    wasOpenedAtLogin,
     status: "not-registered" as const,
   }));
   const prototype = { getLoginItemSettings };
@@ -32,12 +32,14 @@ describe("packaged startup-mode adapter", () => {
     expect(getLoginItemSettings).toHaveBeenCalledTimes(2);
   });
 
-  it("leaves an unmarked launch on the production observation", () => {
+  it("injects one manual observation for an unmarked acceptance launch", () => {
     const environment: NodeJS.ProcessEnv = {};
-    const { app } = loginPort();
+    const { app, getLoginItemSettings } = loginPort(true);
 
     expect(consumeAcceptanceStartupMarker(environment, app)).toBe("manual");
     expect(app.getLoginItemSettings()).toMatchObject({ wasOpenedAtLogin: false });
+    expect(app.getLoginItemSettings()).toMatchObject({ wasOpenedAtLogin: true });
+    expect(getLoginItemSettings).toHaveBeenCalledTimes(2);
   });
 
   it("deletes and rejects every non-exact marker", () => {

--- a/apps/desktop/tests/packaged-startup-mode.test.ts
+++ b/apps/desktop/tests/packaged-startup-mode.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ACCEPTANCE_OS_LOGIN_MARKER_ENV,
+  ACCEPTANCE_OS_LOGIN_MARKER_VALUE,
+  consumeAcceptanceStartupMarker,
+  type AcceptanceLoginLaunchPort,
+} from "./fixtures/packaged-telegram/startup-mode.js";
+
+function loginPort() {
+  const getLoginItemSettings = vi.fn(() => ({
+    openAtLogin: false,
+    executableWillLaunchAtLogin: false,
+    wasOpenedAtLogin: false,
+    status: "not-registered" as const,
+  }));
+  const prototype = { getLoginItemSettings };
+  const app = Object.create(prototype) as AcceptanceLoginLaunchPort;
+  return { app, getLoginItemSettings };
+}
+
+describe("packaged startup-mode adapter", () => {
+  it("consumes an exact marker and injects one OS-login observation", () => {
+    const environment: NodeJS.ProcessEnv = {
+      [ACCEPTANCE_OS_LOGIN_MARKER_ENV]: ACCEPTANCE_OS_LOGIN_MARKER_VALUE,
+    };
+    const { app, getLoginItemSettings } = loginPort();
+
+    expect(consumeAcceptanceStartupMarker(environment, app)).toBe("os-login");
+    expect(environment).not.toHaveProperty(ACCEPTANCE_OS_LOGIN_MARKER_ENV);
+    expect(app.getLoginItemSettings()).toMatchObject({ wasOpenedAtLogin: true });
+    expect(app.getLoginItemSettings()).toMatchObject({ wasOpenedAtLogin: false });
+    expect(getLoginItemSettings).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves an unmarked launch on the production observation", () => {
+    const environment: NodeJS.ProcessEnv = {};
+    const { app } = loginPort();
+
+    expect(consumeAcceptanceStartupMarker(environment, app)).toBe("manual");
+    expect(app.getLoginItemSettings()).toMatchObject({ wasOpenedAtLogin: false });
+  });
+
+  it("deletes and rejects every non-exact marker", () => {
+    const environment: NodeJS.ProcessEnv = {
+      [ACCEPTANCE_OS_LOGIN_MARKER_ENV]: "true",
+    };
+    const { app, getLoginItemSettings } = loginPort();
+
+    expect(() => consumeAcceptanceStartupMarker(environment, app)).toThrow(
+      "Telegram acceptance startup marker is invalid",
+    );
+    expect(environment).not.toHaveProperty(ACCEPTANCE_OS_LOGIN_MARKER_ENV);
+    expect(getLoginItemSettings).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/tests/packaged-telegram-deadline.test.ts
+++ b/apps/desktop/tests/packaged-telegram-deadline.test.ts
@@ -20,6 +20,19 @@ describe("packaged Telegram acceptance deadlines", () => {
     expect(abort).toHaveBeenCalledOnce();
   });
 
+  it("clears its timeout after an operation settles", async () => {
+    const abort = vi.fn();
+
+    await expect(
+      withAcceptanceDeadline("fast operation", Promise.resolve("done"), {
+        timeoutMs: 20,
+        onTimeout: abort,
+      }),
+    ).resolves.toBe("done");
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 30));
+    expect(abort).not.toHaveBeenCalled();
+  });
+
   it("terminates a stalled child without exposing its arguments", async () => {
     const sensitiveArgument = "telegram-token-must-not-appear";
 

--- a/apps/desktop/tests/packaged-telegram-deadline.test.ts
+++ b/apps/desktop/tests/packaged-telegram-deadline.test.ts
@@ -1,0 +1,98 @@
+import { spawn } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import {
+  callAcceptanceCdp,
+  runAcceptanceCommand,
+  terminateAcceptanceChild,
+  withAcceptanceDeadline,
+} from "./fixtures/packaged-telegram/acceptance-deadline.js";
+
+describe("packaged Telegram acceptance deadlines", () => {
+  it("rejects a stalled operation and runs its abort hook", async () => {
+    const abort = vi.fn();
+
+    await expect(
+      withAcceptanceDeadline("synthetic operation", new Promise(() => undefined), {
+        timeoutMs: 20,
+        onTimeout: abort,
+      }),
+    ).rejects.toThrow("synthetic operation timed out");
+    expect(abort).toHaveBeenCalledOnce();
+  });
+
+  it("terminates a stalled child without exposing its arguments", async () => {
+    const sensitiveArgument = "telegram-token-must-not-appear";
+
+    let failure: unknown;
+    try {
+      await runAcceptanceCommand(
+        process.execPath,
+        [
+          "-e",
+          "process.on('SIGTERM', () => undefined); setInterval(() => undefined, 1_000)",
+          sensitiveArgument,
+        ],
+        { timeoutMs: 500, terminationGraceMs: 20 },
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain("command timed out");
+    expect((failure as Error).message).not.toContain(sensitiveArgument);
+  });
+
+  it("does not expose command output or input on failure", async () => {
+    const sensitiveValue = "sensitive-command-material";
+
+    let failure: unknown;
+    try {
+      await runAcceptanceCommand(
+        process.execPath,
+        [
+          "-e",
+          `process.stdout.write(${JSON.stringify(sensitiveValue)}); process.stderr.write(${JSON.stringify(sensitiveValue)}); process.exit(2)`,
+        ],
+        { input: sensitiveValue },
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain("command failed");
+    expect((failure as Error).message).not.toContain(sensitiveValue);
+  });
+
+  it("force-kills a child that ignores graceful termination", async () => {
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        "process.on('SIGTERM', () => undefined); process.stdout.write('ready'); setInterval(() => undefined, 1_000)",
+      ],
+      { stdio: ["ignore", "pipe", "ignore"] },
+    );
+    await new Promise<void>((resolveReady, rejectReady) => {
+      child.once("error", rejectReady);
+      child.stdout?.once("data", () => resolveReady());
+    });
+
+    await expect(
+      terminateAcceptanceChild(child, { terminationGraceMs: 20, killGraceMs: 500 }),
+    ).resolves.toBe(true);
+    expect(child.signalCode).toBe("SIGKILL");
+  });
+
+  it("closes a stalled debugger connection when its command expires", async () => {
+    const close = vi.fn();
+    const call = vi.fn(() => new Promise<Record<string, unknown>>(() => undefined));
+
+    await expect(
+      callAcceptanceCdp({ socket: { close }, call }, "Runtime.evaluate", {}, 20),
+    ).rejects.toThrow("Desktop debugger command timed out");
+    expect(close).toHaveBeenCalledOnce();
+    expect(call).toHaveBeenCalledWith("Runtime.evaluate", {});
+  });
+});

--- a/apps/desktop/tests/telegram-fetch-route.test.ts
+++ b/apps/desktop/tests/telegram-fetch-route.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTelegramRoutedFetch,
+  requireAcceptanceOrigin,
+  requireNodeFetchV2,
+  type FetchRouteInit,
+  type NodeFetchV2,
+} from "./fixtures/packaged-telegram/telegram-fetch-route.js";
+
+function constructor(): never {
+  throw new Error("not called");
+}
+
+function nodeFetchV2(call: (input: unknown, init?: FetchRouteInit) => Promise<unknown>) {
+  const fetch = vi.fn(call) as unknown as NodeFetchV2;
+  Object.defineProperties(fetch, {
+    __esModule: { value: true },
+    default: { configurable: true, enumerable: true, writable: true, value: fetch },
+    Headers: { enumerable: true, value: constructor },
+    Request: { enumerable: true, value: constructor },
+    Response: { enumerable: true, value: constructor },
+    FetchError: { enumerable: true, value: constructor },
+    AbortError: { enumerable: true, value: constructor },
+  });
+  return fetch;
+}
+
+describe("packaged Telegram fetch route", () => {
+  it("rewrites only the exact Bot API origin and preserves request configuration", async () => {
+    const result = { ok: true };
+    const original = nodeFetchV2(async () => result);
+    const routed = createTelegramRoutedFetch(original, "http://127.0.0.1:43117");
+    const signal = new AbortController().signal;
+
+    await expect(
+      routed("https://api.telegram.org/bot123/getUpdates?offset=4", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: '{"offset":4}',
+        signal,
+        agent: { protocol: "https:" },
+      }),
+    ).resolves.toBe(result);
+
+    expect(original).toHaveBeenCalledWith(
+      "http://127.0.0.1:43117/bot123/getUpdates?offset=4",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: '{"offset":4}',
+        signal,
+        agent: undefined,
+      }),
+    );
+    expect(routed.default).toBe(routed);
+    for (const name of ["Headers", "Request", "Response", "FetchError", "AbortError"] as const) {
+      expect(routed[name]).toBe(original[name]);
+    }
+  });
+
+  it("delegates every non-Bot API input unchanged", async () => {
+    const original = nodeFetchV2(async () => ({ ok: true }));
+    const routed = createTelegramRoutedFetch(original, "http://127.0.0.1:43117");
+    const input = "https://example.test/bot123/getUpdates";
+    const init = { method: "GET", agent: { protocol: "https:" } };
+
+    await routed(input, init);
+
+    expect(original).toHaveBeenCalledWith(input, init);
+  });
+
+  it("rejects Bot API Request objects instead of dropping their request semantics", async () => {
+    const original = nodeFetchV2(async () => ({ ok: true }));
+    const routed = createTelegramRoutedFetch(original, "http://127.0.0.1:43117");
+    const input = {
+      url: "https://api.telegram.org/bot123/getUpdates",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"offset":4}',
+    };
+
+    expect(() => routed(input)).toThrow("Telegram fetch route does not accept Request inputs");
+    expect(original).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "",
+    "https://127.0.0.1:43117",
+    "http://localhost:43117",
+    "http://user@127.0.0.1:43117",
+    "http://127.0.0.1:43117/path",
+    "http://127.0.0.1:43117?query=1",
+    "http://127.0.0.1:43117/#fragment",
+    "http://127.0.0.1",
+    "http://127.0.0.1:0",
+  ])("rejects invalid acceptance origin %s", (origin) => {
+    expect(() => requireAcceptanceOrigin(origin)).toThrow("Telegram acceptance origin is invalid");
+  });
+
+  it("distinguishes a missing origin from malformed origins", () => {
+    expect(() => requireAcceptanceOrigin(undefined)).toThrow(
+      "Telegram acceptance origin is missing",
+    );
+  });
+
+  it.each([
+    undefined,
+    {},
+    Object.assign(() => Promise.resolve(), { __esModule: true }),
+    Object.assign(() => Promise.resolve(), { __esModule: true, default: () => Promise.resolve() }),
+  ])("fails closed on an unexpected node-fetch v2 export shape", (candidate) => {
+    expect(() => requireNodeFetchV2(candidate)).toThrow("Telegram fetch export shape is invalid");
+  });
+});


### PR DESCRIPTION
## Summary

- exercise Telegram setup, pairing, background residency, restart, exact-once delivery, durable disablement, and removal through a real packaged Desktop app
- build an isolated acceptance package that is explicitly ad-hoc signed in pull-request CI without enabling identity discovery or exposing signing credentials
- bound macOS commands, debugger calls, quit delivery, socket probes, and fake Bot API shutdown; emit secret-safe lifecycle phases and force-reap an app that cannot exit cleanly
- persist first-run onboarding completion only after the initial renderer is ready, then use normal Settings navigation instead of aborting Electron's pending initial navigation with a debugger reload
- audit the packaged dependency closure, runtime exports, shutdown proof, process accounting, disposable Keychain isolation, and redacted diagnostics

## Verification

- final hosted macOS packaged job passed package creation, ad-hoc signature verification, security smoke, and the complete Telegram lifecycle
- exact prospective merge tree `c88f06d9696e92ef55dc9cb1777fdd6d26e7af15` passed the packaged lifecycle three consecutive times with clean immediate teardown
- packaged result: production chain, fake Bot API isolation, cold-start background launch, resident lifecycle, persisted disablement, exact-once pending delivery, and removal all passed
- 31 deadline/process-safety tests passed; Desktop and renderer typechecks passed; `git diff --check` passed
- the complete Desktop suite executed 870 tests; 864 passed in the parallel run, and all six resource-contention failures passed when their three files were rerun serially (112/112)
- independent correctness, QA, security, and renderer-race reviews finished with no remaining findings

## Failure evidence resolved

- the first hosted run was cancelled after the lifecycle step waited silently for 26m59s
- bounded phases reduced the same hosted failure to 46 seconds and exposed `ERR_ABORTED` during the initial renderer load
- removing the test-induced debugger reload fixed the reproduced race without changing Desktop product behavior
