### PR TITLE
chore(reference): upgrade intervals client to 0.3.1

### DIFF
--- a/.changeset/quiet-curves-align.md
+++ b/.changeset/quiet-curves-align.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/core": patch
+"@enduragent/engine": patch
+"@enduragent/sport-cycling": patch
+"@enduragent/sport-running": patch
+"cycling-coach": patch
+---
+
+Upgrade the Intervals.icu client to 0.3.1 and keep canonical managed activities separate from the snake_case Reference persistence boundary.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@vitest/coverage-v8": "^4.1.4",
     "@xmldom/xmldom": "0.9.10",
     "ai": "^6.0.158",
-    "intervals-icu-api": "0.1.2",
+    "intervals-icu-api": "0.3.1",
     "msw": "^2.13.3",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "@grammyjs/auto-retry": "^2.0.2",
     "ai": "^6.0.158",
     "grammy": "^1.42.0",
-    "intervals-icu-api": "^0.1.2",
+    "intervals-icu-api": "^0.3.1",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -15,7 +15,7 @@
 // only, capped) and abort-aware so a slow account cannot consume the whole
 // `SYNC_OPERATION_TIMEOUT_MS` budget.
 
-import { snakeCaseKeys } from "intervals-icu-api";
+import { snakeCaseKeys, type Activity as ManagedActivity } from "intervals-icu-api";
 import { serializeError } from "../../logging/serialize-error.js";
 import {
   REFERENCE_CAPTURE_STREAM_LIMIT,
@@ -115,6 +115,10 @@ export interface LiveFetchResult {
   readonly plannedWorkouts: readonly PlannedEvent[];
   /** Full-window inputs for metric computation. */
   readonly bundle: ReferenceBundle;
+  /** Canonical managed activities for sport-adapter dispatch. Provider-facing
+   * camelCase values stay separate from the snake_case persistence/metric
+   * boundary in `bundle.activities`. */
+  readonly adapterActivities: readonly ManagedActivity[];
   /** Sync wall-clock as an ISO string — the metric date-window anchor. */
   readonly frozenNow: string;
   /** Endpoints that returned an error (athlete-profile, wellness) and were
@@ -217,8 +221,10 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
   // snake_case (start_date_local, icu_training_load, …). Reverse it here only —
   // wellness already ships in the camelCase mixed shape the schema agrees on. A
   // non-array body (ok:true but malformed) is treated as empty, not a crash.
+  let adapterActivities: ManagedActivity[] = [];
   let rawActivities: Array<Record<string, unknown>> = [];
   if (Array.isArray(actResult.value)) {
+    adapterActivities = actResult.value as ManagedActivity[];
     rawActivities = snakeCaseKeys(actResult.value) as Array<Record<string, unknown>>;
   } else {
     log("Reference: activities.list returned a non-array body; treating as empty");
@@ -336,6 +342,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
     wellnessData: wellness,
     plannedWorkouts,
     bundle,
+    adapterActivities,
     frozenNow,
     ...(fetchErrors.length > 0 ? { fetchErrors } : {}),
   };

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -122,7 +122,7 @@ async function fetchOnce(
   const runs: readonly AdapterRun[] = runAdaptersForActivities(
     adapters,
     sportTypes,
-    live.bundle.activities,
+    live.adapterActivities,
   );
   const { omitPowerFamily, meta: baseMeta } = composeProvenance(runs);
   const derivedMetrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow), {

--- a/packages/core/src/reference/sync/intervals-client-factory.ts
+++ b/packages/core/src/reference/sync/intervals-client-factory.ts
@@ -156,14 +156,13 @@ export function makeIntervalsHttpFactory(options: {
  * Per-`runSync` IntervalsClient. Wraps `globalThis.fetch` with the abortable
  * shim above (composed over the shared bucket so the per-request timeout
  * covers queue wait plus HTTP call), and disables lib-side retry
- * (`maxAttempts: 1`) so an outer-timeout abort propagates into `AbortError`
- * without the lib silently recovering. Reference's own retry-after /
+ * (`maxAttempts: 1`) so an outer-timeout resolves as a normalized managed
+ * `Network` failure without the lib silently recovering. Reference's own retry-after /
  * rate-limit handling lives at the orchestrator layer (per ADR-0011), not at
  * the client layer.
  *
- * `intervals-icu-api@0.1.2` does not expose `signal?: AbortSignal` on its
- * resource methods; the constructor's `fetch` option is the only injection
- * point.
+ * Resource methods do not expose `signal?: AbortSignal`; the constructor's
+ * `fetch` option remains the injection point for the operation-scoped signal.
  */
 export function makeAbortableClient(opts: {
   apiKey: string;

--- a/packages/core/tests/reference-fetch-live-bundle.test.ts
+++ b/packages/core/tests/reference-fetch-live-bundle.test.ts
@@ -123,6 +123,11 @@ describe("fetchLiveBundle", () => {
     expect(act.icu_ctl).toBeUndefined();
     expect(act.icu_atl).toBeUndefined();
 
+    const adapterActivity = res.adapterActivities[0]! as unknown as Record<string, unknown>;
+    expect(adapterActivity.startDateLocal).toBeTypeOf("string");
+    expect(adapterActivity.start_date_local).toBeUndefined();
+    expect(adapterActivity.icuCtl).toBe(50);
+
     const well = res.bundle.wellness[0]! as Record<string, unknown>;
     expect(well.fitness).toBe(40);
     expect(well.fatigue).toBe(45);

--- a/packages/core/tests/reference-intervals-client-factory.test.ts
+++ b/packages/core/tests/reference-intervals-client-factory.test.ts
@@ -28,7 +28,10 @@ afterEach(() => {
 function mockAbortSignalTimeout(): ReturnType<typeof vi.spyOn> {
   return vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
     const controller = new AbortController();
-    setTimeout(() => controller.abort(new Error("timeout (mock)")), ms);
+    setTimeout(
+      () => controller.abort(new DOMException("The operation was aborted due to timeout", "TimeoutError")),
+      ms,
+    );
     return controller.signal;
   });
 }
@@ -271,23 +274,29 @@ describe("makeChatClient", () => {
       fetch: hungFetch(),
     });
 
-    let rejected: unknown;
+    let result: Awaited<ReturnType<typeof client.events.create>> | undefined;
     const p = client.events
       .create({
         start_date_local: "1998-01-05T00:00:00",
         category: "WORKOUT",
         name: "Test workout",
       })
-      .catch((e: unknown) => {
-        rejected = e;
+      .then((value) => {
+        result = value;
       });
 
     await vi.advanceTimersByTimeAsync(CHAT_PER_REQUEST_TIMEOUT_MS - 1);
-    expect(rejected).toBeUndefined();
+    expect(result).toBeUndefined();
 
     await vi.advanceTimersByTimeAsync(1);
     await p;
-    expect(rejected).toBeInstanceOf(Error);
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        kind: "Network",
+        message: "Request aborted",
+      },
+    });
   });
 
   it("does not retry a POST that fails with HTTP 500", async () => {

--- a/packages/core/tests/reference-live-sync-integration.test.ts
+++ b/packages/core/tests/reference-live-sync-integration.test.ts
@@ -133,7 +133,7 @@ async function composeFetched(): Promise<FetchedReference> {
     sportTypes: SPORT_TYPES,
     throttleMs: 0,
   });
-  const runs = runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.bundle.activities);
+  const runs = runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.adapterActivities);
   const { omitPowerFamily, meta: baseMeta } = composeProvenance(runs);
   const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow), {
     omitPowerFamily,
@@ -240,7 +240,7 @@ describe("live-data bridge integration", () => {
       sportTypes: SPORT_TYPES,
       throttleMs: 0,
     });
-    runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.bundle.activities);
+    runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.adapterActivities);
     const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow));
     const fetched: FetchedReference = {
       latest: {

--- a/packages/core/tests/reference-sport-adapter-dispatcher.test.ts
+++ b/packages/core/tests/reference-sport-adapter-dispatcher.test.ts
@@ -26,7 +26,7 @@ const runningAdapter: ReferenceSportAdapter = {
 };
 
 function activity(type: string): Activity {
-  return { id: "12345", start_date_local: "1998-06-04T12:00:00", type } as Activity;
+  return { id: "12345", startDateLocal: "1998-06-04T12:00:00", type } as Activity;
 }
 
 afterEach(() => {
@@ -82,7 +82,7 @@ describe("findAdapterForActivity", () => {
 
   it("returns null without warning for a malformed row whose type is missing", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const malformed = { id: "12345", start_date_local: "1998-06-04T12:00:00" } as unknown as Activity;
+    const malformed = { id: "12345", startDateLocal: "1998-06-04T12:00:00" } as unknown as Activity;
     expect(findAdapterForActivity([cyclingAdapter], malformed)).toBeNull();
     expect(warn).not.toHaveBeenCalled();
   });
@@ -149,7 +149,7 @@ describe("runAdaptersForActivities", () => {
 
   it("silently skips a malformed row whose type is missing", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const malformed = { id: "12345", start_date_local: "1998-06-04T12:00:00" } as unknown as Activity;
+    const malformed = { id: "12345", startDateLocal: "1998-06-04T12:00:00" } as unknown as Activity;
     const runs = runAdaptersForActivities([cyclingAdapter], cyclingTypes, [malformed]);
     expect(runs).toHaveLength(0);
     expect(warn).not.toHaveBeenCalled();

--- a/packages/cycling-coach/package.json
+++ b/packages/cycling-coach/package.json
@@ -37,7 +37,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "ai": "^6.0.158",
     "grammy": "^1.42.0",
-    "intervals-icu-api": "^0.1.2",
+    "intervals-icu-api": "^0.3.1",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -36,7 +36,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "@openrouter/ai-sdk-provider": "^2.9.1",
     "ai": "^6.0.158",
-    "intervals-icu-api": "^0.1.2",
+    "intervals-icu-api": "^0.3.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/sport-cycling/package.json
+++ b/packages/sport-cycling/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@enduragent/engine": "workspace:*",
     "@enduragent/kernel": "workspace:*",
-    "intervals-icu-api": "^0.1.2",
+    "intervals-icu-api": "^0.3.1",
     "ai": "^6.0.158",
     "zod": "^4.3.6"
   },

--- a/packages/sport-running/package.json
+++ b/packages/sport-running/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@enduragent/engine": "workspace:*",
     "@enduragent/kernel": "workspace:*",
-    "intervals-icu-api": "^0.1.2",
+    "intervals-icu-api": "^0.3.1",
     "ai": "^6.0.158",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: 0.1.2
-        version: 0.1.2(typescript@6.0.3)
+        specifier: 0.3.1
+        version: 0.3.1(typescript@6.0.3)
       msw:
         specifier: ^2.13.3
         version: 2.14.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -357,8 +357,8 @@ importers:
         specifier: ^1.42.0
         version: 1.42.0
       intervals-icu-api:
-        specifier: ^0.1.2
-        version: 0.1.2(typescript@6.0.3)
+        specifier: ^0.3.1
+        version: 0.3.1(typescript@6.0.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -415,8 +415,8 @@ importers:
         specifier: ^1.42.0
         version: 1.42.0
       intervals-icu-api:
-        specifier: ^0.1.2
-        version: 0.1.2(typescript@6.0.3)
+        specifier: ^0.3.1
+        version: 0.3.1(typescript@6.0.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -501,8 +501,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: ^0.1.2
-        version: 0.1.2(typescript@6.0.3)
+        specifier: ^0.3.1
+        version: 0.3.1(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -610,8 +610,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: ^0.1.2
-        version: 0.1.2(typescript@6.0.3)
+        specifier: ^0.3.1
+        version: 0.3.1(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -660,8 +660,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: ^0.1.2
-        version: 0.1.2(typescript@6.0.3)
+        specifier: ^0.3.1
+        version: 0.3.1(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -3171,8 +3171,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  intervals-icu-api@0.1.2:
-    resolution: {integrity: sha512-HqK9WarMm6SGIpzFag4FpMo/2NgTq00B3xD6CYkqJ0+kD+BTmCTwjc3yDM7rat+1UNokEEIJneBrM4zkoJunCA==}
+  intervals-icu-api@0.3.1:
+    resolution: {integrity: sha512-W1zKgPpPTbT3TtqF/PGSaarcMxpKBC6SQnFOvRsJ5Te9Hp7LPav5pLi5lWY8lqXtXrSt2Ab74ZFHICiBOZuEqA==}
     engines: {node: '>=18'}
 
   ip-address@10.4.0:
@@ -7126,7 +7126,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  intervals-icu-api@0.1.2(typescript@6.0.3):
+  intervals-icu-api@0.3.1(typescript@6.0.3):
     dependencies:
       openapi-fetch: 0.17.0
       valibot: 1.3.1(typescript@6.0.3)


### PR DESCRIPTION
## Summary

- upgrade all direct intervals-icu-api consumers and the lockfile from 0.1.2 to 0.3.1
- keep canonical managed activities for sport-adapter dispatch while preserving the existing snake_case persistence and metric boundary
- update timeout compatibility tests for normalized Result failures
- add a release changeset for the affected packages

## Test plan

- pnpm check
- pnpm check:types
- pnpm exec vitest run packages/core/tests/reference-intervals-client-factory.test.ts packages/core/tests/reference-fetch-live-bundle.test.ts packages/core/tests/reference-live-sync-integration.test.ts packages/core/tests/reference-sport-adapter-dispatcher.test.ts (66 passed)
- pnpm --filter @enduragent/core test (2,887 passed; one unrelated filesystem benchmark timed out under suite load, then its file passed 13/13 in isolation)

## Acceptance criteria

- the workspace resolves intervals-icu-api 0.3.1 from the published npm artifact
- canonical Activity values are not cast into the snake_case Reference model
- persistence and existing metric inputs retain their current snake_case contract
- managed timeout failures resolve as normalized errors and are not expected to reject