### PR TITLE
refactor(intervals): use canonical event inputs

### DIFF
--- a/.changeset/steady-events-speak.md
+++ b/.changeset/steady-events-speak.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/core": patch
+"@enduragent/engine": patch
+"@enduragent/sport-cycling": patch
+"@enduragent/sport-running": patch
+"cycling-coach": patch
+---
+
+Migrate managed calendar writes to the Intervals.icu client's canonical camelCase request contract.

--- a/packages/core/src/athlete-data.ts
+++ b/packages/core/src/athlete-data.ts
@@ -1,4 +1,4 @@
-import type { ApiError, IntervalsClient } from "intervals-icu-api";
+import type { ApiError, EventInput, IntervalsClient } from "intervals-icu-api";
 import type { ProducedLocalBundle } from "@enduragent/kernel/reference/local-bundle";
 import type { CanonicalActivityReader } from "@enduragent/kernel/store";
 import type {
@@ -88,9 +88,7 @@ export function createPlatformAthleteDataReader(intervals: IntervalsClient): Ath
 
 export function createPlatformCalendarMutations(intervals: IntervalsClient): PlatformCalendarMutations {
   return Object.freeze({
-    createEvent: (input: unknown) => platformValue(intervals.events.create(
-      input as Parameters<typeof intervals.events.create>[0],
-    )),
+    createEvent: (input: EventInput) => platformValue(intervals.events.create(input)),
     async readEventForDelete(input: { eventId: number }) {
       const value = await platformValue(intervals.events.get(input.eventId)) as unknown as CalendarEventForDelete;
       return {

--- a/packages/core/tests/reference-intervals-client-factory.test.ts
+++ b/packages/core/tests/reference-intervals-client-factory.test.ts
@@ -167,7 +167,7 @@ describe("shared request bucket", () => {
     });
 
     const event = {
-      start_date_local: "1998-01-05T00:00:00",
+      startDateLocal: "1998-01-05T00:00:00",
       category: "WORKOUT" as const,
       name: "Test workout",
     };
@@ -255,7 +255,7 @@ describe("makeChatClient", () => {
     });
 
     await client.events.create({
-      start_date_local: "1998-01-05T00:00:00",
+      startDateLocal: "1998-01-05T00:00:00",
       category: "WORKOUT",
       name: "Test workout",
     });
@@ -277,7 +277,7 @@ describe("makeChatClient", () => {
     let result: Awaited<ReturnType<typeof client.events.create>> | undefined;
     const p = client.events
       .create({
-        start_date_local: "1998-01-05T00:00:00",
+        startDateLocal: "1998-01-05T00:00:00",
         category: "WORKOUT",
         name: "Test workout",
       })
@@ -308,7 +308,7 @@ describe("makeChatClient", () => {
     });
 
     const result = await client.events.create({
-      start_date_local: "1998-01-05T00:00:00",
+      startDateLocal: "1998-01-05T00:00:00",
       category: "WORKOUT",
       name: "Test workout",
     });
@@ -332,7 +332,7 @@ describe("makeChatClient", () => {
     });
 
     const result = await client.events.create({
-      start_date_local: "1998-01-05T00:00:00",
+      startDateLocal: "1998-01-05T00:00:00",
       category: "WORKOUT",
       name: "Test workout",
     });

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -1,6 +1,6 @@
 import type { AthleteState } from "@enduragent/coach-contract";
 import type { ModelMessage } from "ai";
-import type { IntervalsClient } from "intervals-icu-api";
+import type { EventInput, IntervalsClient } from "intervals-icu-api";
 import type { GenerateOptions, GenerateResult } from "./sport.js";
 import type { LedgerEventInput } from "./sport/ledger-event.js";
 import type { SourceProvenance } from "./provenance.js";
@@ -204,7 +204,7 @@ export interface CalendarEventForDelete {
 }
 
 export interface PlatformCalendarMutationsPort {
-  createEvent(input: unknown): Promise<unknown>;
+  createEvent(input: EventInput): Promise<unknown>;
   readEventForDelete(input: { eventId: number }): Promise<CalendarEventForDelete>;
   deleteEvent(input: { eventId: number }): Promise<unknown>;
 }

--- a/packages/engine/src/sport/event-provenance.ts
+++ b/packages/engine/src/sport/event-provenance.ts
@@ -18,9 +18,9 @@ export function buildCoachExternalId(date: string, name: string): string {
 export function buildCoachEventProvenance(
   date: string,
   name: string,
-): { external_id: string; tags: string[] } {
+): { externalId: string; tags: string[] } {
   return {
-    external_id: buildCoachExternalId(date, name),
+    externalId: buildCoachExternalId(date, name),
     tags: [COACH_EVENT_TAG],
   };
 }

--- a/packages/engine/src/sport/platform-tools.ts
+++ b/packages/engine/src/sport/platform-tools.ts
@@ -235,7 +235,7 @@ export function createPureCoreIntervalsTools(
               if (dateError) return dateError;
               try {
                 const event = await selectedMutations.createEvent({
-                  start_date_local: `${input.date}T00:00:00`,
+                  startDateLocal: `${input.date}T00:00:00`,
                   category: "WORKOUT",
                   name: input.name,
                   type: "WeightTraining",

--- a/packages/engine/tests/confirmation-injection-integration.test.ts
+++ b/packages/engine/tests/confirmation-injection-integration.test.ts
@@ -45,7 +45,7 @@ const integrationSport: Sport = {
             ),
             execute: async (input: { date: string; workout: { name: string } }) => {
               const result = await deps.intervals!.events.create({
-                start_date_local: `${input.date}T00:00:00`,
+                startDateLocal: `${input.date}T00:00:00`,
                 category: "WORKOUT",
                 name: input.workout.name,
                 type: "Ride",

--- a/packages/engine/tests/intervals-tools-events.test.ts
+++ b/packages/engine/tests/intervals-tools-events.test.ts
@@ -186,11 +186,11 @@ describe("intervals_create_strength_workout", () => {
     });
     expect(createCalls).toEqual([
       {
-        start_date_local: `${date}T00:00:00`,
+        startDateLocal: `${date}T00:00:00`,
         category: "WORKOUT",
         name: "Lower body 45min",
         type: "WeightTraining",
-        external_id: `cycling-coach:${date}:strength-lower-body-45min`,
+        externalId: `cycling-coach:${date}:strength-lower-body-45min`,
         tags: ["cycling-coach"],
         description: "Back squat 3x5 @ RPE 7",
       },

--- a/packages/sport-cycling/src/tools.ts
+++ b/packages/sport-cycling/src/tools.ts
@@ -196,7 +196,7 @@ export function createCyclingTools(
               }
               try {
                 const event = await selectedMutations.createEvent({
-                  start_date_local: `${input.date}T00:00:00`,
+                  startDateLocal: `${input.date}T00:00:00`,
                   category: "WORKOUT",
                   name: input.workout.name,
                   type: "Ride",

--- a/packages/sport-cycling/tests/create-workout-provenance.test.ts
+++ b/packages/sport-cycling/tests/create-workout-provenance.test.ts
@@ -46,7 +46,7 @@ const validWorkout = {
 };
 
 describe("intervals_create_workout provenance", () => {
-  it("payload carries external_id 'cycling-coach:<date>:<slug>' and tags ['cycling-coach']", async () => {
+  it("payload carries externalId 'cycling-coach:<date>:<slug>' and tags ['cycling-coach']", async () => {
     const { mutations, calls } = fakeMutations();
     const tool = createWorkoutTool(mutations)!;
     const date = tomorrowISODate();
@@ -56,7 +56,8 @@ describe("intervals_create_workout provenance", () => {
     expect(out).toEqual({ created: true, event: { id: 42 } });
     expect(calls).toHaveLength(1);
     const payload = calls[0];
-    expect(payload.external_id).toBe(`cycling-coach:${date}:z2-endurance-90min`);
+    expect(payload.externalId).toBe(`cycling-coach:${date}:z2-endurance-90min`);
+    expect(payload.external_id).toBeUndefined();
     expect(payload.tags).toEqual(["cycling-coach"]);
   });
 

--- a/packages/sport-cycling/tests/tools.test.ts
+++ b/packages/sport-cycling/tests/tools.test.ts
@@ -69,6 +69,8 @@ describe("intervals_create_workout payload (calendar-payload group)", () => {
     expect(payload.category).toBe("WORKOUT");
     expect(payload.name).toBe("Z2 Endurance 90min");
     expect(typeof payload.description).toBe("string");
+    expect("movingTime" in payload).toBe(false);
+    expect("icuTrainingLoad" in payload).toBe(false);
     expect("moving_time" in payload).toBe(false);
     expect("icu_training_load" in payload).toBe(false);
   });

--- a/packages/sport-running/src/tools.ts
+++ b/packages/sport-running/src/tools.ts
@@ -198,13 +198,13 @@ export function createRunningTools(
                 throw err;
               }
               const result = await intervals.events.create({
-                start_date_local: `${input.date}T00:00:00`,
+                startDateLocal: `${input.date}T00:00:00`,
                 category: "WORKOUT",
                 name: input.workout.name,
                 type: "Run",
                 ...buildCoachEventProvenance(input.date, input.workout.name),
-                moving_time: serialized.movingTime,
-                // No icu_training_load — the server derives running Pace Load from the
+                movingTime: serialized.movingTime,
+                // No icuTrainingLoad — the server derives running Pace Load from the
                 // parsed steps against the athlete's own threshold pace.
                 description: serialized.description,
               });

--- a/packages/sport-running/tests/tools.test.ts
+++ b/packages/sport-running/tests/tools.test.ts
@@ -176,7 +176,7 @@ describe("intervals_create_workout tool", () => {
     expect(tool).toBeDefined();
   });
 
-  it("posts type:'Run', WORKOUT, the serialized description, no icu_training_load", async () => {
+  it("posts type:'Run', WORKOUT, the serialized description, no icuTrainingLoad", async () => {
     const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
     const tool = createWorkoutTool(client)!;
 
@@ -199,10 +199,11 @@ describe("intervals_create_workout tool", () => {
     expect(payload.name).toBe("Easy 30");
     expect(typeof payload.description).toBe("string");
     expect(payload.description).toContain("75% Pace");
+    expect("icuTrainingLoad" in payload).toBe(false);
     expect("icu_training_load" in payload).toBe(false);
   });
 
-  it("payload carries external_id 'cycling-coach:<date>:<slug>' and tags ['cycling-coach']", async () => {
+  it("payload carries externalId 'cycling-coach:<date>:<slug>' and tags ['cycling-coach']", async () => {
     const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
     const tool = createWorkoutTool(client)!;
 
@@ -218,7 +219,8 @@ describe("intervals_create_workout tool", () => {
     );
 
     const payload = calls[0];
-    expect(payload.external_id).toBe(`cycling-coach:${tomorrowISODate()}:easy-30`);
+    expect(payload.externalId).toBe(`cycling-coach:${tomorrowISODate()}:easy-30`);
+    expect(payload.external_id).toBeUndefined();
     expect(payload.tags).toEqual(["cycling-coach"]);
   });
 
@@ -243,7 +245,8 @@ describe("intervals_create_workout tool", () => {
 
     expect(out).toEqual({ created: true, event: { id: 7 } });
     // The distance step's planned time resolved via the passed-through CS.
-    expect(calls[0].moving_time).toBe(94);
+    expect(calls[0].movingTime).toBe(94);
+    expect(calls[0].moving_time).toBeUndefined();
   });
 
   it("returns invalid_workout and does NOT call events.create on a serialization failure", async () => {


### PR DESCRIPTION
## Summary
- type the calendar-mutation boundary with the Intervals.icu `EventInput` contract
- send canonical camelCase fields for cycling, running, and strength calendar writes
- keep raw/reference read fixtures in their provider wire format and add regression assertions against legacy write aliases

## Verification
- `pnpm check`
- 85 focused tests across core, engine, cycling, and running
- `git diff --check`

## Review note
- The external autoreview helper was not run because it requires uploading the private uncommitted diff; the change received a local source-aware review instead.