### PR TITLE
fix(reference): reject duplicate stream descriptors

### DIFF
--- a/.changeset/calm-streams-listen.md
+++ b/.changeset/calm-streams-listen.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: Prevent ambiguous duplicate activity streams from producing misleading training analysis.

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -34,6 +34,7 @@ import {
   parseRenamedWellnessRow,
   renameTpFieldsOnActivity,
   renameTpFieldsOnWellnessRow,
+  StreamNormalizationError,
   type ReferenceBundle,
   type RenameSummary,
 } from "@enduragent/kernel/reference/local-bundle";
@@ -375,7 +376,17 @@ async function fetchStreams(
       log(`Reference: streams fetch failed for an activity: ${renderEndpointError(result.error)}`);
       continue;
     }
-    const parsed = ActivityStreamsSchema.safeParse(normalizeStreams(result.value));
+    let normalized: unknown;
+    try {
+      normalized = normalizeStreams(result.value);
+    } catch (error) {
+      const reason = error instanceof StreamNormalizationError
+        ? "duplicate descriptor types"
+        : "normalization rejected input";
+      log(`Reference: streams shape rejected for an activity: ${reason}`);
+      continue;
+    }
+    const parsed = ActivityStreamsSchema.safeParse(normalized);
     if (!parsed.success) {
       log(`Reference: streams shape rejected for an activity: ${parsed.error.message}`);
       continue;

--- a/packages/core/tests/reference-fetch-live-bundle.test.ts
+++ b/packages/core/tests/reference-fetch-live-bundle.test.ts
@@ -359,6 +359,38 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
     expect(res.bundle.streams?.["1"]?.watts).toEqual([200, 210]);
   });
 
+  it("skips only the ride with duplicate stream descriptors and logs a safe diagnostic", async () => {
+    const logs: string[] = [];
+    const { client } = fakeClient({
+      activities: [
+        camelActivity({ id: 1, startDateLocal: daysAgo(1) }),
+        camelActivity({ id: 2, startDateLocal: daysAgo(2) }),
+      ],
+      streamFor: (id) => id === "1"
+        ? {
+            ok: true,
+            value: [
+              { type: "athlete_custom_stream", data: [1] },
+              { type: "athlete_custom_stream", data: [2] },
+            ],
+          }
+        : STREAM_OK,
+    });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+      log: (message) => logs.push(message),
+    });
+    expect(res.bundle.streams?.["1"]).toBeUndefined();
+    expect(res.bundle.streams?.["2"]).toBeDefined();
+    expect(logs).toContain(
+      "Reference: streams shape rejected for an activity: duplicate descriptor types",
+    );
+    expect(logs.join("\n")).not.toContain("athlete_custom_stream");
+  });
+
   it("normalizes the lib's camelCased OBJECT stream shape (dfaA1 -> dfa_a1)", async () => {
     const { client } = fakeClient({
       activities: [camelActivity({ id: 1, startDateLocal: daysAgo(1) })],

--- a/packages/kernel/src/reference/projection-normalization.ts
+++ b/packages/kernel/src/reference/projection-normalization.ts
@@ -95,14 +95,50 @@ function normalizeStreamKey(key: string): string {
   return key.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
 }
 
+export interface DuplicateStreamTypeIssue {
+  readonly kind: "DuplicateType";
+  readonly type: string;
+  readonly count: number;
+}
+
+/**
+ * The canonical channel map cannot represent duplicate descriptors without
+ * choosing one and discarding the others. Raw snapshots retain every
+ * descriptor; this error makes the projection fail closed with diagnostics.
+ */
+export class StreamNormalizationError extends TypeError {
+  declare readonly issues: readonly DuplicateStreamTypeIssue[];
+
+  constructor(issues: readonly DuplicateStreamTypeIssue[]) {
+    super("duplicate stream descriptor types");
+    this.name = "StreamNormalizationError";
+    Object.defineProperty(this, "issues", {
+      configurable: false,
+      enumerable: false,
+      value: Object.freeze(issues.map((issue) => Object.freeze({ ...issue }))),
+      writable: false,
+    });
+  }
+}
+
 export function normalizeStreams(value: unknown): unknown {
   if (Array.isArray(value)) {
     const output: Record<string, unknown> = {};
+    const counts = new Map<string, number>();
     for (const entry of value) if (entry !== null && typeof entry === "object"
       && typeof (entry as Record<string, unknown>).type === "string"
       && Array.isArray((entry as Record<string, unknown>).data)) {
-      output[(entry as Record<string, unknown>).type as string] = (entry as Record<string, unknown>).data;
+      const type = normalizeStreamKey((entry as Record<string, unknown>).type as string);
+      counts.set(type, (counts.get(type) ?? 0) + 1);
+      if (!Object.hasOwn(output, type)) {
+        output[type] = (entry as Record<string, unknown>).data;
+      }
     }
+    const issues: DuplicateStreamTypeIssue[] = [];
+    for (const [type, count] of counts) {
+      if (count > 1) issues.push({ kind: "DuplicateType", type, count });
+    }
+    if (issues.length > 0) throw new StreamNormalizationError(issues);
     return output;
   }
   if (value !== null && typeof value === "object") {

--- a/packages/kernel/tests/reference-local-bundle.test.ts
+++ b/packages/kernel/tests/reference-local-bundle.test.ts
@@ -13,6 +13,7 @@ import {
   parseCanonicalProjectionValue,
   parseGenericLandingEnvelope,
   renameTpFieldsOnActivity,
+  StreamNormalizationError,
 } from "../src/reference/entry/local-bundle.js";
 import type { ActivityProjectionFilter, ReferenceBundle } from "../src/reference/local-bundle.js";
 import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
@@ -99,6 +100,26 @@ describe("kernel local bundle contracts", () => {
     );
     const shared = [1];
     expect(normalizeStreams({ dfaA1: shared, dfa_a1: shared })).toEqual({ dfa_a1: shared });
+  });
+
+  it("fails closed with structured diagnostics instead of overwriting duplicate descriptors", () => {
+    let thrown: unknown;
+    try {
+      normalizeStreams([
+        { type: "watts", data: [180, 190] },
+        { type: "watts", data: [250, 260] },
+        { type: "dfaA1", data: [0.9, 0.8] },
+        { type: "dfa_a1", data: [0.7, 0.6] },
+      ]);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(StreamNormalizationError);
+    expect((thrown as StreamNormalizationError).issues).toEqual([
+      { kind: "DuplicateType", type: "watts", count: 2 },
+      { kind: "DuplicateType", type: "dfa_a1", count: 2 },
+    ]);
+    expect(Object.keys(thrown as StreamNormalizationError)).not.toContain("issues");
   });
 
   it("uses canonical UTF-8 byte ordering including non-ASCII and prefixes", () => {


### PR DESCRIPTION
## Summary
- detect duplicate stream descriptors after canonical type normalization instead of silently overwriting one channel
- retain structured diagnostics in trusted code while keeping them out of generic serialized error fields
- skip only the affected ride in the legacy Reference fetch so other stream-backed analysis remains available
- document the athlete-visible correctness fix in a changeset

Raw transport snapshots remain archive-first and preserve every descriptor; only the ambiguous canonical projection fails closed.

## Verification
- `pnpm check`
- 44 focused kernel/core/sync tests
- affected kernel and core TypeScript checks
- `git diff --check`

## Review note
- The external autoreview helper was not run because it requires uploading the private uncommitted diff; the change received a local source-aware privacy and correctness review instead.