### PR TITLE
feat(store): add trusted activity source resolver

### DIFF
--- a/.changeset/fair-activities-resolve.md
+++ b/.changeset/fair-activities-resolve.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/kernel": patch
+"cycling-coach": patch
+---
+
+Add a trusted canonical-activity resolver and revision key for bounded ride analysis.

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -894,7 +894,7 @@ describe("incremental backfill pages", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 8 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 9 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await dumpStore(upgraded)).toBe(before);
     } finally {

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -582,7 +582,7 @@ describe("coach sync composition", () => {
           return store.get("PRAGMA user_version");
         },
       );
-      expect(value).toEqual({ user_version: 8 });
+      expect(value).toEqual({ user_version: 9 });
       expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
       expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
       expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -590,7 +590,7 @@ describe("coach sync composition", () => {
       const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
       try {
         await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-          user_version: 8,
+          user_version: 9,
         });
       } finally {
         await reopened.close();

--- a/packages/kernel-node/tests/activity-source-resolver.test.ts
+++ b/packages/kernel-node/tests/activity-source-resolver.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createTrustedActivitySourceResolver,
+  runMigrations,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/database.js";
+
+const SESSION = "a".repeat(64);
+const WORKOUT = "b".repeat(64);
+
+describe("activity source resolver over SQLite", () => {
+  let directory = "";
+  let store: SqlStore & MigratorStore;
+
+  beforeEach(async () => {
+    directory = mkdtempSync(join(realpathSync(tmpdir()), "activity-source-"));
+    store = openSqliteStorage(join(directory, "store.db"));
+    await runMigrations(store, MIGRATIONS);
+    await store.run(
+      "INSERT INTO workout(workout_key,start_utc,tz_offset_s,name,notes,is_multisport,dedup_cluster_id) VALUES(?,?,?,?,?,?,?)",
+      [WORKOUT, 900, 0, null, null, 0, "cluster"],
+    );
+    await store.run(
+      "INSERT INTO session(session_key,workout_key,session_seq,sport,sub_sport,start_utc,tz_offset_s,local_date_key,elapsed_s,timer_s,moving_s,distance_m,is_transition,summary_json) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+      [SESSION, WORKOUT, 0, "cycling", null, 900, 0, 19980704, 100, 90, 80, 1_000, 0, null],
+    );
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  async function insertSource(sequence: number, providerActivityId: string): Promise<string> {
+    const sourceRecordId = sequence.toString(16).padStart(64, "0");
+    const artifactKey = (sequence + 16).toString(16).padStart(64, "0");
+    const archiveAddress = (sequence + 32).toString(16).padStart(64, "0");
+    await store.run(
+      "INSERT INTO source_artifact(artifact_key,source,lane,external_id,artifact_kind,archive_address,archive_rel_path,archive_epoch_s) VALUES(?,?,?,?,?,?,?,?)",
+      [artifactKey, "intervals-icu", "activities", providerActivityId, "snapshot", archiveAddress,
+        `1998/01/${archiveAddress}.json.gz`, 900],
+    );
+    await store.run(
+      "INSERT INTO source_record(id,workout_key,session_key,source,external_id,raw_sha256,quality_rank,payload_json,artifact_key) VALUES(?,?,?,?,?,?,?,?,?)",
+      [sourceRecordId, WORKOUT, SESSION, "intervals-icu", providerActivityId, archiveAddress, 300, "{}", artifactKey],
+    );
+    return sourceRecordId;
+  }
+
+  it("reads the selected revision and rejects a deduplicated multi-source session as ambiguous", async () => {
+    const firstRevision = await insertSource(1, "i42");
+    const resolver = createTrustedActivitySourceResolver(store);
+
+    await expect(resolver.resolve({ canonicalActivityId: SESSION })).resolves.toEqual({
+      kind: "resolved",
+      providerActivityId: "i42",
+      sourceRevision: firstRevision,
+    });
+
+    await insertSource(2, "i43");
+    await expect(resolver.resolve({ canonicalActivityId: SESSION })).resolves.toEqual({
+      kind: "unavailable",
+      reason: "ambiguous",
+    });
+  });
+});

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -583,7 +583,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -31,9 +31,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 8", async () => {
+  it("applies the full migration list and advances user_version to 9", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -53,7 +53,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -82,11 +82,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 8", async () => {
+  it("upgrades a version-1-on-disk store to version 9", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -106,8 +106,8 @@ describe("migrator end-to-end over node:sqlite", () => {
     );
 
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 4, toVersion: 8, applied: [5, 6, 7, 8] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
+    expect(result).toEqual({ fromVersion: 4, toVersion: 9, applied: [5, 6, 7, 8, 9] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -158,14 +158,14 @@ describe("migrator end-to-end over node:sqlite", () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 6, toVersion: 8, applied: [7, 8] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
+    expect(result).toEqual({ fromVersion: 6, toVersion: 9, applied: [7, 8, 9] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 8,
-      toVersion: 8,
+      fromVersion: 9,
+      toVersion: 9,
       applied: [],
     });
   });

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -237,7 +237,7 @@ describe("sync failure repository", () => {
     const before = await dumpStore(store);
     await runMigrations(store, MIGRATIONS);
     expect(await dumpStore(store)).toBe(before);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
     expect(DUMP_TABLES).toHaveLength(32);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -9,6 +9,7 @@ export * from "./dedup-confirmation-repository.js";
 export * from "./intake-repository.js";
 export * from "./activity-repository.js";
 export * from "./canonical-activity-reader.js";
+export * from "./trusted-activity-source-resolver.js";
 export * from "./derived-key.js";
 export * from "./sync-source.js";
 export * from "./sync-state-repository.js";

--- a/packages/kernel/src/store/migrations/009_activity_source_resolver.sql
+++ b/packages/kernel/src/store/migrations/009_activity_source_resolver.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_source_record_session_source
+  ON source_record (session_key, source, id)
+  WHERE session_key IS NOT NULL;

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -6,6 +6,7 @@ import syncState005 from "./005_sync_state.sql";
 import incremental006 from "./006_incremental_ingest.sql";
 import syncFailure007 from "./007_sync_failure.sql";
 import storeOwner008 from "./008_store_owner.sql";
+import activitySourceResolver009 from "./009_activity_source_resolver.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -29,4 +30,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 6, name: "006_incremental_ingest", sql: incremental006 },
   { version: 7, name: "007_sync_failure", sql: syncFailure007 },
   { version: 8, name: "008_store_owner", sql: storeOwner008 },
+  { version: 9, name: "009_activity_source_resolver", sql: activitySourceResolver009 },
 ];

--- a/packages/kernel/src/store/trusted-activity-source-resolver.ts
+++ b/packages/kernel/src/store/trusted-activity-source-resolver.ts
@@ -1,0 +1,102 @@
+import type { Row, SqlReadStore } from "./ports.js";
+
+declare const providerActivityIdBrand: unique symbol;
+export type TrustedProviderActivityId = string & {
+  readonly [providerActivityIdBrand]: "intervals-icu-activity";
+};
+
+export type TrustedActivitySourceResolution =
+  | {
+      readonly kind: "resolved";
+      readonly providerActivityId: TrustedProviderActivityId;
+      readonly sourceRevision: string;
+    }
+  | {
+      readonly kind: "unavailable";
+      readonly reason: "not_found" | "ambiguous";
+    };
+
+export type ActivitySourceResolutionErrorCode = "invalid_input" | "invalid_row";
+
+export class ActivitySourceResolutionError extends Error {
+  readonly code: ActivitySourceResolutionErrorCode;
+
+  constructor(code: ActivitySourceResolutionErrorCode) {
+    super(`activity source resolution rejected: ${code}`);
+    this.name = "ActivitySourceResolutionError";
+    this.code = code;
+  }
+}
+
+export interface TrustedActivitySourceResolver {
+  resolve(input: {
+    readonly canonicalActivityId: string;
+  }): Promise<TrustedActivitySourceResolution>;
+}
+
+const HEX_ADDRESS = /^[0-9a-f]{64}$/;
+const MAX_PROVIDER_ACTIVITY_ID_BYTES = 256;
+
+function invalidInput(): never {
+  throw new ActivitySourceResolutionError("invalid_input");
+}
+
+function invalidRow(): never {
+  throw new ActivitySourceResolutionError("invalid_row");
+}
+
+function isSafeProviderActivityId(value: unknown): value is TrustedProviderActivityId {
+  if (typeof value !== "string" || value.length === 0
+    || new TextEncoder().encode(value).byteLength > MAX_PROVIDER_ACTIVITY_ID_BYTES) return false;
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if (codePoint <= 31 || (codePoint >= 127 && codePoint <= 159)) return false;
+  }
+  return true;
+}
+
+function resolved(row: Row): TrustedActivitySourceResolution {
+  if (!isSafeProviderActivityId(row.external_id)
+    || typeof row.revision_id !== "string" || !HEX_ADDRESS.test(row.revision_id)) invalidRow();
+  return {
+    kind: "resolved",
+    providerActivityId: row.external_id,
+    sourceRevision: row.revision_id,
+  };
+}
+
+/**
+ * Resolve a renderer-safe canonical session ID to trusted provider authority.
+ * The branded provider ID must stay inside daemon/main code; sourceRevision is
+ * the stable cache invalidation key for remote analysis derived from this row.
+ */
+export function createTrustedActivitySourceResolver(
+  store: Pick<SqlReadStore, "all">,
+): TrustedActivitySourceResolver {
+  return {
+    async resolve(input) {
+      if (input === null || typeof input !== "object"
+        || typeof input.canonicalActivityId !== "string"
+        || !HEX_ADDRESS.test(input.canonicalActivityId)) invalidInput();
+      const rows = await store.all(`SELECT
+  sr.external_id,
+  c.revision_id
+FROM session AS s
+JOIN source_record AS sr ON sr.session_key = s.session_key
+JOIN source_record_current AS c ON c.source_record_id = sr.id
+JOIN source_record_revision AS r
+  ON r.source_record_id = c.source_record_id AND r.revision_id = c.revision_id
+JOIN source_artifact AS a ON a.artifact_key = r.artifact_key
+WHERE s.session_key = ?
+  AND sr.source = 'intervals-icu'
+  AND a.source = 'intervals-icu'
+  AND a.lane = 'activities'
+  AND a.external_id = sr.external_id
+ORDER BY sr.id COLLATE BINARY ASC
+LIMIT 2`, [input.canonicalActivityId]);
+      if (rows.length === 0) return { kind: "unavailable", reason: "not_found" };
+      if (rows.length > 1) return { kind: "unavailable", reason: "ambiguous" };
+      return resolved(rows[0]!);
+    },
+  };
+}

--- a/packages/kernel/tests/activity-source-resolver.test.ts
+++ b/packages/kernel/tests/activity-source-resolver.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  ActivitySourceResolutionError,
+  createTrustedActivitySourceResolver,
+  type Row,
+  type SqlReadStore,
+} from "../src/store/index.js";
+
+const SESSION = "a".repeat(64);
+const REVISION = "b".repeat(64);
+
+function storeWith(rows: readonly Row[]) {
+  const calls: Array<{ readonly sql: string; readonly params: readonly unknown[] }> = [];
+  const store: Pick<SqlReadStore, "all"> = {
+    async all(sql, params = []) {
+      calls.push({ sql, params });
+      return [...rows];
+    },
+  };
+  return { calls, store };
+}
+
+describe("trusted activity source resolver", () => {
+  it("resolves one selected Intervals.icu activity revision", async () => {
+    const { calls, store } = storeWith([{ external_id: "i42", revision_id: REVISION }]);
+    const result = await createTrustedActivitySourceResolver(store).resolve({
+      canonicalActivityId: SESSION,
+    });
+
+    expect(result).toEqual({
+      kind: "resolved",
+      providerActivityId: "i42",
+      sourceRevision: REVISION,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.params).toEqual([SESSION]);
+    expect(calls[0]!.sql).toContain("JOIN source_record_current");
+    expect(calls[0]!.sql).toContain("JOIN source_artifact");
+    expect(calls[0]!.sql).toContain("LIMIT 2");
+  });
+
+  it("returns bounded unavailable reasons for missing and ambiguous linkage", async () => {
+    await expect(createTrustedActivitySourceResolver(storeWith([]).store).resolve({
+      canonicalActivityId: SESSION,
+    })).resolves.toEqual({ kind: "unavailable", reason: "not_found" });
+    await expect(createTrustedActivitySourceResolver(storeWith([
+      { external_id: "i42", revision_id: REVISION },
+      { external_id: "i43", revision_id: "c".repeat(64) },
+    ]).store).resolve({ canonicalActivityId: SESSION }))
+      .resolves.toEqual({ kind: "unavailable", reason: "ambiguous" });
+  });
+
+  it("rejects invalid canonical IDs before querying", async () => {
+    const { calls, store } = storeWith([]);
+    await expect(createTrustedActivitySourceResolver(store).resolve({ canonicalActivityId: "provider-id" }))
+      .rejects.toMatchObject({ code: "invalid_input" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it.each([
+    [{ external_id: "", revision_id: REVISION }],
+    [{ external_id: "line\nbreak", revision_id: REVISION }],
+    [{ external_id: "i42", revision_id: "not-a-revision" }],
+  ])("fails closed on malformed trusted rows", async (row) => {
+    await expect(createTrustedActivitySourceResolver(storeWith([row]).store).resolve({
+      canonicalActivityId: SESSION,
+    })).rejects.toBeInstanceOf(ActivitySourceResolutionError);
+  });
+});

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -162,6 +162,7 @@ describe("001_init migration", () => {
       { version: 6, name: "006_incremental_ingest" },
       { version: 7, name: "007_sync_failure" },
       { version: 8, name: "008_store_owner" },
+      { version: 9, name: "009_activity_source_resolver" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -817,6 +818,20 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     expect(() => db!.prepare("INSERT INTO store_owner VALUES(2,?)").run("b".repeat(64))).toThrow();
     expect(() => db!.prepare("UPDATE store_owner SET account_fingerprint=?").run("b".repeat(64))).toThrow();
     expect(() => db!.prepare("DELETE FROM store_owner").run()).toThrow();
+  });
+
+  it("adds the canonical-session provider lookup index", () => {
+    db = openFull();
+    expect(createHash("sha256").update(MIGRATIONS[8]!.sql).digest("hex")).toBe(
+      "4fe2e7648bbb09ad62c60a86e26ac4a9e09f4c0e24882428e12ad8722f3d420c",
+    );
+    expect(
+      db.prepare("PRAGMA index_info(idx_source_record_session_source)").all(),
+    ).toEqual([
+      expect.objectContaining({ seqno: 0, name: "session_key" }),
+      expect.objectContaining({ seqno: 1, name: "source" }),
+      expect.objectContaining({ seqno: 2, name: "id" }),
+    ]);
   });
 
   it("omits the unreleased prior bone-stress column from the baseline schema", () => {


### PR DESCRIPTION
## Summary

- resolve canonical activity IDs to Intervals.icu provider authority only inside trusted store/daemon code
- return the selected source revision as a cache invalidation key and fail closed for missing, malformed, or ambiguous provenance
- add a schema-v9 partial lookup index with checksum-pinned migration and real SQLite coverage
- keep provider IDs out of renderer, preload, and RPC surfaces

## Verification

- pnpm check
- 42 focused resolver, migration, and SQLite tests
- 28 backfill tests
- broader impacted matrix: 73 passed, 6 skipped
- local privacy and source-boundary review

The optional external autoreview helper was not run because it would upload the private uncommitted diff.