### PR TITLE
feat(sync): reserve analytics request capacity

### DIFF
--- a/.changeset/smart-requests-reserve.md
+++ b/.changeset/smart-requests-reserve.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/kernel": patch
+"cycling-coach": patch
+---
+
+Add atomic request reservations for bounded analytics refreshes.

--- a/packages/coach/src/soak-record.ts
+++ b/packages/coach/src/soak-record.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
 
 export type Attempt = {seq:number;path:"store"|"legacy";tag:
-  | "store:activities" | "store:wellness" | "store:settings" | "store:streams" | "legacy:reference";
+  | "store:activities" | "store:analytics-curves" | "store:wellness" | "store:settings"
+  | "store:streams" | "legacy:reference";
   started_ms:number;finished_ms:number;outcome:"ok"|"http-error"|"aborted"|"limit-rejected"};
 export type WindowEvidence = {attempts:Attempt[];elapsed_ms:number;completed:boolean;
   rate_limited:boolean;cancel_propagated:boolean};
@@ -115,7 +116,9 @@ function parseWindow(value: unknown, label: string): WindowEvidence {
     const outcome = attempt.outcome;
     if (seq !== index + 1 || (path !== "store" && path !== "legacy")
       || typeof tag !== "string"
-      || (path === "store" && !["store:activities", "store:wellness", "store:settings", "store:streams"].includes(tag))
+      || (path === "store" && ![
+        "store:activities", "store:analytics-curves", "store:wellness", "store:settings", "store:streams",
+      ].includes(tag))
       || (path === "legacy" && tag !== "legacy:reference")
       || !["ok", "http-error", "aborted", "limit-rejected"].includes(String(outcome))) fail("attempt is invalid");
     const started = safe(attempt.started_ms, "attempt start");

--- a/packages/coach/src/store-gate-command.ts
+++ b/packages/coach/src/store-gate-command.ts
@@ -87,18 +87,40 @@ async function scratchEvidence(headSha: string): Promise<OverlapEvidence> {
   const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
   const attempts: Attempt[] = [];
   let tick = 0;
+  const observeCharge = (
+    path: "store" | "legacy",
+    tag: RefreshRequestTag,
+    charge: () => void,
+  ): void => {
+    const seq = attempts.length + 1;
+    const started = ++tick;
+    try {
+      charge();
+      attempts.push({ seq, path, tag, started_ms: started, finished_ms: 0, outcome: "ok" });
+    } catch (error) {
+      if (!(error instanceof PhysicalRequestLimitError)) throw error;
+      attempts.push({ seq, path, tag, started_ms: started, finished_ms: ++tick, outcome: "limit-rejected" });
+      throw error;
+    }
+  };
   const observingLedger: PhysicalRequestLedger = Object.freeze({
     charge(path: "store" | "legacy", tag: RefreshRequestTag): void {
-      const seq = attempts.length + 1;
-      const started = ++tick;
-      try {
-        ledger.charge(path, tag);
-        attempts.push({ seq, path, tag, started_ms: started, finished_ms: 0, outcome: "ok" });
-      } catch (error) {
-        if (!(error instanceof PhysicalRequestLimitError)) throw error;
-        attempts.push({ seq, path, tag, started_ms: started, finished_ms: ++tick, outcome: "limit-rejected" });
-        throw error;
-      }
+      observeCharge(path, tag, () => ledger.charge(path, tag));
+    },
+    tryReserve(path: "store" | "legacy", tag: RefreshRequestTag, count: number) {
+      const reservation = ledger.tryReserve(path, tag, count);
+      if (reservation === null) return null;
+      return Object.freeze({
+        charge(): void {
+          observeCharge(path, tag, () => reservation.charge());
+        },
+        release(): void {
+          reservation.release();
+        },
+        remaining(): number {
+          return reservation.remaining();
+        },
+      });
     },
     snapshot: () => ledger.snapshot(),
   });
@@ -181,6 +203,7 @@ function attemptsFromCounts(counts: PhysicalRequestCounts): Attempt[] {
   };
   push("store", "store:settings", counts.byTag["store:settings"]);
   push("store", "store:activities", counts.byTag["store:activities"]);
+  push("store", "store:analytics-curves", counts.byTag["store:analytics-curves"]);
   push("store", "store:wellness", counts.byTag["store:wellness"]);
   push("store", "store:streams", counts.byTag["store:streams"]);
   push("legacy", "legacy:reference", counts.byTag["legacy:reference"]);

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -390,6 +390,7 @@ describe("incremental backfill pages", () => {
                 totalRequests: 0,
                 byTag: {
                   "store:activities": 0,
+                  "store:analytics-curves": 0,
                   "store:wellness": 0,
                   "store:settings": 0,
                   "store:streams": 0,

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -32,6 +32,7 @@ function requestCounts(storeRequests: number, legacyRequests: number) {
     totalRequests: storeRequests + legacyRequests,
     byTag: {
       "store:activities": 0,
+      "store:analytics-curves": 0,
       "store:wellness": 0,
       "store:settings": 0,
       "store:streams": 0,

--- a/packages/kernel/src/store/sync-source.ts
+++ b/packages/kernel/src/store/sync-source.ts
@@ -46,6 +46,7 @@ export interface SyncBudget {
 
 export type RefreshRequestTag =
   | "store:activities"
+  | "store:analytics-curves"
   | "store:wellness"
   | "store:settings"
   | "store:streams"
@@ -60,7 +61,21 @@ export interface PhysicalRequestCounts {
 
 export interface PhysicalRequestLedger {
   charge(path: "store" | "legacy", tag: RefreshRequestTag): void;
+  tryReserve(
+    path: "store" | "legacy",
+    tag: RefreshRequestTag,
+    count: number,
+  ): PhysicalRequestReservation | null;
   snapshot(): PhysicalRequestCounts;
+}
+
+export interface PhysicalRequestReservation {
+  /** Convert one held slot into one physical request charge. */
+  charge(): void;
+  /** Idempotently return every unused slot; callers should use this in finally. */
+  release(): void;
+  /** Number of held slots not yet charged or released. */
+  remaining(): number;
 }
 
 export class PhysicalRequestLimitError extends Error {
@@ -70,8 +85,16 @@ export class PhysicalRequestLimitError extends Error {
   }
 }
 
+export class PhysicalRequestReservationSettledError extends Error {
+  constructor() {
+    super("physical request reservation is settled");
+    this.name = "PhysicalRequestReservationSettledError";
+  }
+}
+
 const REFRESH_REQUEST_TAGS = Object.freeze([
   "store:activities",
+  "store:analytics-curves",
   "store:wellness",
   "store:settings",
   "store:streams",
@@ -99,6 +122,7 @@ export function createPhysicalRequestLedger(input: {
   });
   const byTag: Record<RefreshRequestTag, number> = {
     "store:activities": 0,
+    "store:analytics-curves": 0,
     "store:wellness": 0,
     "store:settings": 0,
     "store:streams": 0,
@@ -107,25 +131,75 @@ export function createPhysicalRequestLedger(input: {
   let storeRequests = 0;
   let legacyRequests = 0;
   let totalRequests = 0;
+  let reservedStoreRequests = 0;
+  let reservedLegacyRequests = 0;
+  let reservedTotalRequests = 0;
+
+  const validateCharge = (path: "store" | "legacy", tag: RefreshRequestTag): void => {
+    if (
+      (path !== "store" && path !== "legacy")
+      || !REFRESH_REQUEST_TAGS.includes(tag)
+      || (path === "store" && !tag.startsWith("store:"))
+      || (path === "legacy" && tag !== "legacy:reference")
+    ) {
+      throw new TypeError("invalid physical request charge");
+    }
+  };
+  const hasCapacity = (path: "store" | "legacy", count: number): boolean => {
+    const used = path === "store" ? storeRequests : legacyRequests;
+    const reserved = path === "store" ? reservedStoreRequests : reservedLegacyRequests;
+    return used + reserved + count <= limits[path]
+      && totalRequests + reservedTotalRequests + count <= limits.total;
+  };
+  const recordCharge = (path: "store" | "legacy", tag: RefreshRequestTag): void => {
+    if (path === "store") storeRequests += 1;
+    else legacyRequests += 1;
+    totalRequests += 1;
+    byTag[tag] += 1;
+  };
+  const changeReserved = (path: "store" | "legacy", count: number): void => {
+    if (path === "store") reservedStoreRequests += count;
+    else reservedLegacyRequests += count;
+    reservedTotalRequests += count;
+  };
 
   return Object.freeze({
     charge(path: "store" | "legacy", tag: RefreshRequestTag): void {
-      if (
-        (path !== "store" && path !== "legacy")
-        || !REFRESH_REQUEST_TAGS.includes(tag)
-        || (path === "store" && !tag.startsWith("store:"))
-        || (path === "legacy" && tag !== "legacy:reference")
-      ) {
-        throw new TypeError("invalid physical request charge");
+      validateCharge(path, tag);
+      if (!hasCapacity(path, 1)) throw new PhysicalRequestLimitError();
+      recordCharge(path, tag);
+    },
+    tryReserve(
+      path: "store" | "legacy",
+      tag: RefreshRequestTag,
+      count: number,
+    ): PhysicalRequestReservation | null {
+      validateCharge(path, tag);
+      if (!Number.isSafeInteger(count) || count <= 0) {
+        throw new TypeError("invalid physical request reservation");
       }
-      const pathCount = path === "store" ? storeRequests : legacyRequests;
-      if (pathCount >= limits[path] || totalRequests >= limits.total) {
-        throw new PhysicalRequestLimitError();
-      }
-      if (path === "store") storeRequests += 1;
-      else legacyRequests += 1;
-      totalRequests += 1;
-      byTag[tag] += 1;
+      if (!hasCapacity(path, count)) return null;
+      changeReserved(path, count);
+      let remaining = count;
+      let settled = false;
+      return Object.freeze({
+        charge(): void {
+          if (settled || remaining === 0) throw new PhysicalRequestReservationSettledError();
+          changeReserved(path, -1);
+          recordCharge(path, tag);
+          remaining -= 1;
+          if (remaining === 0) settled = true;
+        },
+        release(): void {
+          if (settled) return;
+          changeReserved(path, -remaining);
+          remaining = 0;
+          settled = true;
+        },
+        remaining(): number {
+          return remaining;
+        },
+      });
     },
     snapshot(): PhysicalRequestCounts {
       return Object.freeze({

--- a/packages/kernel/tests/sync-source.test.ts
+++ b/packages/kernel/tests/sync-source.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import {
   createPhysicalRequestLedger,
   PhysicalRequestLimitError,
+  PhysicalRequestReservationSettledError,
   SOURCE_IDS,
   SOURCE_LANES,
   type BackfillDepth,
   type PlannedWorkoutDoc,
+  type PhysicalRequestReservation,
   type PushResult,
   type RawFileSourceArtifact,
   type SnapshotSourceArtifact,
@@ -60,6 +62,9 @@ describe("sync source contract", () => {
       readonly maxRequests: number;
       readonly maxArtifacts: number;
     }>();
+    expectTypeOf<PhysicalRequestReservation["charge"]>().toBeFunction();
+    expectTypeOf<PhysicalRequestReservation["release"]>().toBeFunction();
+    expectTypeOf<PhysicalRequestReservation["remaining"]>().toBeFunction();
     expectTypeOf<SourceArtifact>().toEqualTypeOf<
       SnapshotSourceArtifact | RawFileSourceArtifact | SourceCheckpoint
     >();
@@ -116,6 +121,60 @@ describe("physical request ledger", () => {
       .toThrowError(new TypeError("invalid physical request limits"));
     const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
     expect(() => ledger.charge("store", "legacy:reference")).toThrow(TypeError);
+    expect(ledger.snapshot().totalRequests).toBe(0);
+  });
+
+  it("holds four analytics slots atomically without counting calls before they happen", () => {
+    const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
+    for (let index = 0; index < 60; index += 1) ledger.charge("store", "store:activities");
+    for (let index = 0; index < 15; index += 1) ledger.charge("legacy", "legacy:reference");
+    const before = ledger.snapshot();
+
+    const reservation = ledger.tryReserve("store", "store:analytics-curves", 4);
+    expect(reservation).not.toBeNull();
+    expect(reservation!.remaining()).toBe(4);
+    expect(ledger.snapshot()).toEqual(before);
+    expect(ledger.tryReserve("store", "store:analytics-curves", 1)).toBeNull();
+    expect(() => ledger.charge("store", "store:activities")).toThrow(PhysicalRequestLimitError);
+
+    for (let index = 0; index < 4; index += 1) reservation!.charge();
+    expect(reservation!.remaining()).toBe(0);
+    expect(ledger.snapshot()).toMatchObject({
+      storeRequests: 64,
+      legacyRequests: 15,
+      totalRequests: 79,
+      byTag: { "store:analytics-curves": 4 },
+    });
+    expect(() => reservation!.charge()).toThrow(PhysicalRequestReservationSettledError);
+  });
+
+  it("fails reservation admission without mutation and releases unused capacity", () => {
+    const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
+    for (let index = 0; index < 61; index += 1) ledger.charge("store", "store:activities");
+    const before = ledger.snapshot();
+    expect(ledger.tryReserve("store", "store:analytics-curves", 4)).toBeNull();
+    expect(ledger.snapshot()).toEqual(before);
+
+    const reservation = ledger.tryReserve("store", "store:analytics-curves", 3)!;
+    reservation.charge();
+    reservation.release();
+    reservation.release();
+    expect(reservation.remaining()).toBe(0);
+    expect(() => reservation.charge()).toThrow(PhysicalRequestReservationSettledError);
+    const replacement = ledger.tryReserve("store", "store:analytics-curves", 2);
+    expect(replacement).not.toBeNull();
+    expect(ledger.snapshot()).toMatchObject({
+      storeRequests: 62,
+      totalRequests: 62,
+      byTag: { "store:analytics-curves": 1 },
+    });
+    replacement!.release();
+  });
+
+  it("rejects invalid reservation counts and path/tag pairs without mutation", () => {
+    const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
+    expect(() => ledger.tryReserve("store", "store:analytics-curves", 0)).toThrow(TypeError);
+    expect(() => ledger.tryReserve("legacy", "store:analytics-curves", 4)).toThrow(TypeError);
     expect(ledger.snapshot().totalRequests).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- add atomic physical-request reservations that hold path and total capacity without counting requests before they occur
- convert held slots into named physical charges one call at a time and idempotently release unused capacity
- add the store:analytics-curves accounting tag across snapshots, overlap evidence, and soak validation
- keep the fixed 64 store / 15 legacy / 79 total ceilings unchanged

## Verification

- pnpm check
- 74 impacted ledger, store-gate, soak, operations, and backfill tests
- root and package TypeScript checks
- local source-aware review of admission, release, accounting, and evidence compatibility

The optional external autoreview helper was not run because it would upload the private uncommitted diff.