### PR TITLE
feat(contract): define activity analysis states

### DIFF
--- a/.changeset/calm-analysis-contract.md
+++ b/.changeset/calm-analysis-contract.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/coach-contract": patch
+"cycling-coach": patch
+---
+
+Add strict shared contracts for bounded activity analysis results.

--- a/packages/coach-contract/src/activity-analysis.ts
+++ b/packages/coach-contract/src/activity-analysis.ts
@@ -1,0 +1,240 @@
+import { z } from "zod";
+
+export const ACTIVITY_ANALYSIS_SCHEMA_VERSION = 1 as const;
+
+export const ACTIVITY_ANALYSIS_SECTIONS = [
+  "aerobic-drift",
+  "intervals",
+  "best-efforts",
+  "power-distribution",
+  "heart-rate-distribution",
+  "power-heart-rate",
+] as const;
+
+export const ActivityAnalysisSectionSchema = z.enum(ACTIVITY_ANALYSIS_SECTIONS);
+export const CanonicalActivityIdSchema = z.string().regex(/^[0-9a-f]{64}$/);
+export const ActivityAnalysisRevisionSchema = z.string().regex(/^[0-9a-f]{64}$/);
+
+export const ActivityAnalysisRequestSchema = z
+  .object({
+    canonicalActivityId: CanonicalActivityIdSchema,
+    sections: z.array(ActivityAnalysisSectionSchema).min(1).max(ACTIVITY_ANALYSIS_SECTIONS.length),
+    refresh: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (new Set(value.sections).size !== value.sections.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["sections"],
+        message: "analysis sections must be unique",
+      });
+    }
+  });
+
+function isCivilDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month - 1
+    && parsed.getUTCDate() === day;
+}
+
+function isSafeDisplayText(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if (
+      codePoint <= 31
+      || (codePoint >= 127 && codePoint <= 159)
+      || codePoint === 0x2028
+      || codePoint === 0x2029
+      || (codePoint >= 0x202a && codePoint <= 0x202e)
+      || (codePoint >= 0x2066 && codePoint <= 0x2069)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const boundedDisplayText = (maximum: number) => z.string().min(1).max(maximum)
+  .refine(isSafeDisplayText, "unsafe display text");
+
+const SafeIntegerSchema = z.number().int().min(Number.MIN_SAFE_INTEGER).max(Number.MAX_SAFE_INTEGER);
+const NonnegativeIntegerSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+const NullableDurationSchema = NonnegativeIntegerSchema.nullable();
+
+export const CanonicalActivitySummarySchema = z
+  .object({
+    id: CanonicalActivityIdSchema,
+    workoutId: CanonicalActivityIdSchema,
+    sessionSequence: NonnegativeIntegerSchema,
+    isMultisport: z.boolean(),
+    sport: boundedDisplayText(64),
+    subSport: boundedDisplayText(128).nullable(),
+    isTransition: z.boolean(),
+    startEpochSeconds: SafeIntegerSchema,
+    timezoneOffsetSeconds: z.number().int().min(-86_400).max(86_400).nullable(),
+    localDate: z.string().refine(isCivilDate, "invalid civil date"),
+    elapsedSeconds: NullableDurationSchema,
+    timerSeconds: NullableDurationSchema,
+    movingSeconds: NullableDurationSchema,
+    distanceMeters: z.number().finite().nonnegative().max(Number.MAX_SAFE_INTEGER).nullable(),
+  })
+  .strict();
+
+const OffsetInstantSchema = z.string().max(64).datetime({ offset: true });
+
+export const AnalysisProvenanceSchema = z
+  .object({
+    source: z.enum(["local-canonical", "provider"]),
+    delivery: z.enum(["live", "persisted-cache"]),
+    observedAt: OffsetInstantSchema,
+  })
+  .strict();
+
+export const AnalysisUnavailableReasonSchema = z.enum([
+  "activity-not-found",
+  "source-not-found",
+  "ambiguous-source",
+  "not-provider-backed",
+  "missing-sensor-data",
+  "duplicate-stream",
+  "misaligned-stream",
+  "invalid-timestamps",
+  "activity-too-short",
+  "insufficient-coverage",
+  "unstable-output",
+  "moving-status-unavailable",
+  "unsuitable-activity",
+  "empty-response",
+  "malformed-response",
+  "response-too-large",
+  "request-budget-exhausted",
+  "rate-limited",
+  "timeout",
+  "network",
+  "provider-unavailable",
+  "cancelled",
+  "unsupported",
+  "temporary-failure",
+]);
+
+export const AnalysisRefreshFailureCodeSchema = z.enum([
+  "request-budget-exhausted",
+  "rate-limited",
+  "timeout",
+  "network",
+  "provider-unavailable",
+  "malformed-response",
+  "response-too-large",
+  "cancelled",
+  "source-changed",
+  "temporary-failure",
+]);
+
+export const AnalysisRefreshFailureSchema = z
+  .object({
+    code: AnalysisRefreshFailureCodeSchema,
+    failedAt: OffsetInstantSchema,
+  })
+  .strict();
+
+export function createAnalysisSectionSchema<T extends z.ZodType>(data: T) {
+  const computed = z
+    .object({
+      kind: z.literal("computed"),
+      data,
+      provenance: AnalysisProvenanceSchema,
+    })
+    .strict();
+  return z.discriminatedUnion("kind", [
+    computed,
+    z
+      .object({
+        kind: z.literal("unavailable"),
+        reason: AnalysisUnavailableReasonSchema,
+      })
+      .strict(),
+    z
+      .object({
+        kind: z.literal("stale"),
+        lastGood: computed,
+        refreshFailure: AnalysisRefreshFailureSchema,
+      })
+      .strict(),
+  ]);
+}
+
+export interface ActivityAnalysisDataSchemas {
+  readonly aerobicDrift: z.ZodType;
+  readonly intervals: z.ZodType;
+  readonly bestEfforts: z.ZodType;
+  readonly powerDistribution: z.ZodType;
+  readonly heartRateDistribution: z.ZodType;
+  readonly powerHeartRate: z.ZodType;
+}
+
+export function createActivityAnalysisResultSchema<T extends ActivityAnalysisDataSchemas>(data: T) {
+  const sections = z
+    .object({
+      aerobicDrift: createAnalysisSectionSchema(data.aerobicDrift).optional(),
+      intervals: createAnalysisSectionSchema(data.intervals).optional(),
+      bestEfforts: createAnalysisSectionSchema(data.bestEfforts).optional(),
+      powerDistribution: createAnalysisSectionSchema(data.powerDistribution).optional(),
+      heartRateDistribution: createAnalysisSectionSchema(data.heartRateDistribution).optional(),
+      powerHeartRate: createAnalysisSectionSchema(data.powerHeartRate).optional(),
+    })
+    .strict()
+    .refine((value) => Object.keys(value).length > 0, "analysis result needs one section");
+  return z
+    .object({
+      schemaVersion: z.literal(ACTIVITY_ANALYSIS_SCHEMA_VERSION),
+      activity: CanonicalActivitySummarySchema,
+      revision: ActivityAnalysisRevisionSchema,
+      sections,
+    })
+    .strict();
+}
+
+export type ActivityAnalysisSection = z.infer<typeof ActivityAnalysisSectionSchema>;
+export type ActivityAnalysisRequest = z.infer<typeof ActivityAnalysisRequestSchema>;
+export type CanonicalActivitySummary = z.infer<typeof CanonicalActivitySummarySchema>;
+export type AnalysisProvenance = z.infer<typeof AnalysisProvenanceSchema>;
+export type AnalysisUnavailableReason = z.infer<typeof AnalysisUnavailableReasonSchema>;
+export type AnalysisRefreshFailureCode = z.infer<typeof AnalysisRefreshFailureCodeSchema>;
+export type AnalysisRefreshFailure = z.infer<typeof AnalysisRefreshFailureSchema>;
+
+export interface AnalysisComputed<T> {
+  readonly kind: "computed";
+  readonly data: T;
+  readonly provenance: AnalysisProvenance;
+}
+
+export type AnalysisSection<T> =
+  | AnalysisComputed<T>
+  | { readonly kind: "unavailable"; readonly reason: AnalysisUnavailableReason }
+  | {
+      readonly kind: "stale";
+      readonly lastGood: AnalysisComputed<T>;
+      readonly refreshFailure: AnalysisRefreshFailure;
+    };
+
+export interface ActivityAnalysisData {
+  readonly aerobicDrift: unknown;
+  readonly intervals: unknown;
+  readonly bestEfforts: unknown;
+  readonly powerDistribution: unknown;
+  readonly heartRateDistribution: unknown;
+  readonly powerHeartRate: unknown;
+}
+
+export type ActivityAnalysisResult<T extends ActivityAnalysisData> = {
+  readonly schemaVersion: typeof ACTIVITY_ANALYSIS_SCHEMA_VERSION;
+  readonly activity: CanonicalActivitySummary;
+  readonly revision: string;
+  readonly sections: {
+    readonly [K in keyof ActivityAnalysisData]?: AnalysisSection<T[K]>;
+  };
+};

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -8,3 +8,4 @@ export * from "./spend.js";
 export * from "./self-test.js";
 export * from "./handshake.js";
 export * from "./telegram-control.js";
+export * from "./activity-analysis.js";

--- a/packages/coach-contract/tests/activity-analysis.test.ts
+++ b/packages/coach-contract/tests/activity-analysis.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { z } from "zod";
+import {
+  ACTIVITY_ANALYSIS_SECTIONS,
+  ActivityAnalysisRequestSchema,
+  CanonicalActivitySummarySchema,
+  createActivityAnalysisResultSchema,
+  type ActivityAnalysisRequest,
+  type AnalysisSection,
+} from "../src/index.js";
+
+const ID = "a".repeat(64);
+const WORKOUT_ID = "b".repeat(64);
+const REVISION = "c".repeat(64);
+const INSTANT = "1998-07-06T12:00:00.000Z";
+
+const activity = {
+  id: ID,
+  workoutId: WORKOUT_ID,
+  sessionSequence: 0,
+  isMultisport: false,
+  sport: "cycling",
+  subSport: null,
+  isTransition: false,
+  startEpochSeconds: 899_985_600,
+  timezoneOffsetSeconds: 0,
+  localDate: "1998-07-06",
+  elapsedSeconds: 3_600,
+  timerSeconds: 3_500,
+  movingSeconds: 3_400,
+  distanceMeters: 40_000,
+} as const;
+
+const scalarData = z.object({ value: z.number().finite().min(-1_000).max(1_000) }).strict();
+const dataSchemas = {
+  aerobicDrift: scalarData,
+  intervals: z.object({ count: z.number().int().nonnegative().max(200) }).strict(),
+  bestEfforts: z.object({ count: z.number().int().nonnegative().max(10) }).strict(),
+  powerDistribution: z.object({ buckets: z.number().int().nonnegative().max(256) }).strict(),
+  heartRateDistribution: z.object({ buckets: z.number().int().nonnegative().max(256) }).strict(),
+  powerHeartRate: z.object({ rows: z.number().int().nonnegative().max(256) }).strict(),
+} as const;
+const ResultSchema = createActivityAnalysisResultSchema(dataSchemas);
+
+const provenance = {
+  source: "local-canonical",
+  delivery: "live",
+  observedAt: INSTANT,
+} as const;
+
+describe("activity analysis contract", () => {
+  it("accepts only a bounded unique semantic section request", () => {
+    const request = {
+      canonicalActivityId: ID,
+      sections: [...ACTIVITY_ANALYSIS_SECTIONS],
+      refresh: true,
+    } as const;
+    expect(ActivityAnalysisRequestSchema.parse(request)).toEqual(request);
+    expectTypeOf<ActivityAnalysisRequest["sections"][number]>()
+      .toEqualTypeOf<(typeof ACTIVITY_ANALYSIS_SECTIONS)[number]>();
+
+    for (const invalid of [
+      { canonicalActivityId: "provider-id", sections: ["intervals"] },
+      { canonicalActivityId: ID, sections: [] },
+      { canonicalActivityId: ID, sections: ["intervals", "intervals"] },
+      { canonicalActivityId: ID, sections: ["raw-provider-payload"] },
+      { canonicalActivityId: ID, sections: ["intervals"], providerActivityId: "i42" },
+    ]) {
+      expect(ActivityAnalysisRequestSchema.safeParse(invalid).success).toBe(false);
+    }
+  });
+
+  it("strictly validates the renderer-safe canonical activity summary", () => {
+    expect(CanonicalActivitySummarySchema.parse(activity)).toEqual(activity);
+    for (const invalid of [
+      { ...activity, localDate: "1998-02-30" },
+      { ...activity, sport: "" },
+      { ...activity, sport: `cycling${String.fromCharCode(10)}unsafe` },
+      { ...activity, subSport: `virtual${String.fromCodePoint(0x202e)}unsafe` },
+      { ...activity, distanceMeters: Infinity },
+      { ...activity, timezoneOffsetSeconds: 100_000 },
+      { ...activity, providerActivityId: "i42" },
+    ]) {
+      expect(CanonicalActivitySummarySchema.safeParse(invalid).success).toBe(false);
+    }
+  });
+
+  it("accepts independent computed, unavailable, and stale section states", () => {
+    const computed = { kind: "computed", data: { value: 2.5 }, provenance } as const;
+    const result = {
+      schemaVersion: 1,
+      activity,
+      revision: REVISION,
+      sections: {
+        aerobicDrift: computed,
+        intervals: { kind: "unavailable", reason: "not-provider-backed" },
+        bestEfforts: {
+          kind: "stale",
+          lastGood: {
+            kind: "computed",
+            data: { count: 3 },
+            provenance: { ...provenance, delivery: "persisted-cache" },
+          },
+          refreshFailure: { code: "timeout", failedAt: INSTANT },
+        },
+      },
+    } as const;
+    expect(ResultSchema.parse(result)).toEqual(result);
+    expectTypeOf<Extract<AnalysisSection<{ value: number }>, { kind: "computed" }>["data"]>()
+      .toEqualTypeOf<{ value: number }>();
+  });
+
+  it("rejects unbounded payloads, arbitrary errors, identity leaks, and empty results", () => {
+    const base = {
+      schemaVersion: 1,
+      activity,
+      revision: REVISION,
+      sections: {
+        aerobicDrift: { kind: "computed", data: { value: 2.5 }, provenance },
+      },
+    } as const;
+    for (const invalid of [
+      { ...base, revision: "provider-revision" },
+      { ...base, providerActivityId: "i42" },
+      { ...base, sections: {} },
+      { ...base, sections: { rawPayload: { kind: "unavailable", reason: "unsupported" } } },
+      { ...base, sections: { aerobicDrift: { ...base.sections.aerobicDrift, data: { value: 2.5, raw: {} } } } },
+      { ...base, sections: { aerobicDrift: { kind: "unavailable", reason: "network", message: "/private/path" } } },
+      { ...base, sections: { aerobicDrift: { kind: "unavailable", reason: "unknown-upstream-error" } } },
+      { ...base, sections: { aerobicDrift: { kind: "computed", data: { value: NaN }, provenance } } },
+      { ...base, sections: { aerobicDrift: { kind: "computed", data: { value: 2.5 },
+        provenance: { ...provenance, providerActivityId: "i42" } } } },
+      { ...base, sections: { aerobicDrift: { kind: "stale", lastGood: base.sections.aerobicDrift,
+        refreshFailure: { code: "timeout", failedAt: INSTANT, message: "/private/path" } } } },
+    ]) {
+      expect(ResultSchema.safeParse(invalid).success).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a strict semantic request contract for the six desktop activity-analysis sections
- add renderer-safe canonical activity summaries and opaque revision identifiers
- model each section independently as computed, unavailable, or stale with closed provenance and failure codes
- reject provider identifiers, raw payloads, arbitrary error messages, unknown fields, and unbounded values

## Verification

- pnpm check
- @enduragent/coach-contract: 23 test files, 360 tests passed
- @enduragent/coach-contract build, including declarations
- contract dependency and fixture privacy gates
- source-aware local privacy/security review

The optional external autoreview helper was not run because it would upload the private uncommitted diff; the local source-aware review found no actionable issues.