### PR TITLE
fix(desktop): harden update restart

### DIFF
--- a/.changeset/desktop-update-relaunch.md
+++ b/.changeset/desktop-update-relaunch.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop updates now reopen the app reliably after installation and remain ready to retry if restarting fails.

--- a/apps/desktop-renderer/src/update/controller.ts
+++ b/apps/desktop-renderer/src/update/controller.ts
@@ -46,8 +46,8 @@ export function createDesktopUpdateController(input: {
     ) {
       return;
     }
-    const action =
-      state.status === "downloaded" ? input.bridge.restartToUpdate : input.bridge.checkForUpdates;
+    const restarting = state.status === "downloaded";
+    const action = restarting ? input.bridge.restartToUpdate : input.bridge.checkForUpdates;
     const before = revision;
     const pending = Promise.resolve()
       .then(() => action.call(input.bridge))
@@ -56,7 +56,7 @@ export function createDesktopUpdateController(input: {
           if (!disposed && revision === before) render(next);
         },
         () => {
-          if (!disposed && revision === before) {
+          if (!disposed && revision === before && !restarting) {
             render({
               status: "failed",
               stage: state.status === "downloading" ? "download" : "check",

--- a/apps/desktop-renderer/tests/update.test.ts
+++ b/apps/desktop-renderer/tests/update.test.ts
@@ -70,6 +70,30 @@ describe("desktop update renderer controller", () => {
     expect(subject.bridge.checkForUpdates).not.toHaveBeenCalled();
   });
 
+  it("preserves a downloaded update and retries when restart fails", async () => {
+    const downloaded = { status: "downloaded", version: "2026.7.23" } as const;
+    const subject = setupController(downloaded);
+    vi.mocked(subject.bridge.restartToUpdate)
+      .mockRejectedValueOnce(new Error("synthetic restart failure"))
+      .mockResolvedValueOnce({ status: "installing", version: downloaded.version });
+    await subject.controller.start();
+
+    subject.action();
+    await vi.waitFor(() => expect(subject.bridge.restartToUpdate).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(subject.view.render).toHaveBeenLastCalledWith(downloaded));
+    expect(subject.view.render).not.toHaveBeenCalledWith({ status: "failed", stage: "check" });
+
+    subject.action();
+    await vi.waitFor(() => expect(subject.bridge.restartToUpdate).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(subject.view.render).toHaveBeenLastCalledWith({
+        status: "installing",
+        version: downloaded.version,
+      }),
+    );
+    expect(subject.bridge.checkForUpdates).not.toHaveBeenCalled();
+  });
+
   it("contains rejected diagnostics and disposes its subscription and view", async () => {
     const raw = "Authorization: secret https://private.invalid/feed";
     const subject = setupController();

--- a/apps/desktop/src/main/update-controller.ts
+++ b/apps/desktop/src/main/update-controller.ts
@@ -16,6 +16,7 @@ export type DesktopAutoUpdater = Pick<
   | "logger"
   | "autoDownload"
   | "autoInstallOnAppQuit"
+  | "autoRunAppAfterInstall"
   | "allowPrerelease"
   | "allowDowngrade"
   | "on"
@@ -190,6 +191,7 @@ export function createDesktopUpdateController(input: {
       updater.logger = null;
       updater.autoDownload = false;
       updater.autoInstallOnAppQuit = false;
+      updater.autoRunAppAfterInstall = true;
       updater.allowPrerelease = false;
       updater.allowDowngrade = false;
       updater.on("error", onError);

--- a/apps/desktop/tests/update-controller.test.ts
+++ b/apps/desktop/tests/update-controller.test.ts
@@ -31,6 +31,7 @@ function fakeUpdater() {
     logger: {} as unknown,
     autoDownload: true,
     autoInstallOnAppQuit: true,
+    autoRunAppAfterInstall: false,
     allowPrerelease: true,
     allowDowngrade: true,
     checkForUpdates: vi.fn<DesktopAutoUpdater["checkForUpdates"]>(),
@@ -111,6 +112,7 @@ describe("desktop update controller", () => {
       logger: null,
       autoDownload: false,
       autoInstallOnAppQuit: false,
+      autoRunAppAfterInstall: true,
       allowPrerelease: false,
       allowDowngrade: false,
     });


### PR DESCRIPTION
Summary
- explicitly enable automatic relaunch after installing a downloaded update
- preserve the downloaded state when restart initiation fails so the user can retry
- cover the updater controller behavior with focused tests

Verification
- pnpm check