### PR TITLE
feat(desktop): show ready update in sidebar

### DIFF
--- a/.changeset/bright-sidebar-updates.md
+++ b/.changeset/bright-sidebar-updates.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop now shows an accessible sidebar action when an update is ready to install.

--- a/apps/desktop-renderer/src/ui/sidebar/Sidebar.module.css
+++ b/apps/desktop-renderer/src/ui/sidebar/Sidebar.module.css
@@ -110,6 +110,31 @@
   border-top: 1px solid var(--line);
 }
 
+.updateButton {
+  composes: row from "../../theme/surface.module.css";
+  justify-content: center;
+  min-height: var(--ctl-h);
+  color: var(--ink);
+  background-color: var(--surface);
+  box-shadow: var(--edge), var(--elev-1);
+  font-size: 12.5px;
+  font-weight: 560;
+}
+
+.updateButton:disabled {
+  cursor: default;
+  opacity: 0.64;
+}
+
+.srOnly {
+  position: absolute;
+  overflow: hidden;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  white-space: nowrap;
+}
+
 .sync {
   composes: row from "../../theme/surface.module.css";
   min-height: var(--ctl-h);

--- a/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
@@ -8,6 +8,7 @@ import { ConnectionStatus } from "./ConnectionStatus.js";
 import { HistoryList } from "./HistoryList.js";
 import styles from "./Sidebar.module.css";
 import { SyncChip } from "./SyncChip.js";
+import { UpdateAvailableButton } from "./UpdateAvailableButton.js";
 
 export function Sidebar(): ReactElement {
   const activeView = useEnduragentStore((state) => state.activeView);
@@ -82,6 +83,7 @@ export function Sidebar(): ReactElement {
       <div className={styles.sec}>Conversations</div>
       <HistoryList locked={navigationLocked} />
       <div className={styles.railFoot}>
+        <UpdateAvailableButton locked={navigationLocked || onboardingOpen} />
         <SyncChip />
         <ConnectionStatus />
       </div>

--- a/apps/desktop-renderer/src/ui/sidebar/UpdateAvailableButton.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/UpdateAvailableButton.tsx
@@ -1,0 +1,52 @@
+import type { ReactElement } from "react";
+import { useEnduragentStore } from "../../state/store.js";
+import styles from "./Sidebar.module.css";
+
+interface UpdateAvailableButtonProps {
+  readonly locked: boolean;
+}
+
+export function UpdateAvailableButton({ locked }: UpdateAvailableButtonProps): ReactElement {
+  const update = useEnduragentStore((state) => state.settings.update);
+  const updatePort = useEnduragentStore((state) => state.settingsPorts?.update ?? null);
+  const visible = update.state.status === "downloaded" || update.state.status === "installing";
+  const restarting = update.actionDisabled || update.state.status === "installing";
+  const version = visible ? update.state.version : null;
+  const announcement =
+    version === null
+      ? ""
+      : restarting
+        ? `Restarting to install update version ${version}`
+        : `Update version ${version} is available`;
+
+  return (
+    <>
+      {visible ? (
+        <button
+          type="button"
+          className={styles.updateButton}
+          aria-label={
+            restarting
+              ? `Restarting to install update version ${version}`
+              : `Install update version ${version}`
+          }
+          aria-busy={restarting ? "true" : undefined}
+          disabled={locked || restarting || updatePort === null}
+          onClick={() => {
+            updatePort?.activate();
+          }}
+        >
+          {restarting ? "Restarting…" : "Update available"}
+        </button>
+      ) : null}
+      <span
+        className={`${styles.srOnly} update-announcement`}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {announcement}
+      </span>
+    </>
+  );
+}

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -3,8 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConnectionStatus } from "../src/state/connection-slice.js";
 import { EMPTY_CHAT_SURFACE, type ChatActions } from "../src/state/chat-slice.js";
-import { restoreManualSyncFocus, setManualSyncFocusTarget } from "../src/state/manual-sync-focus.js";
+import {
+  restoreManualSyncFocus,
+  setManualSyncFocusTarget,
+} from "../src/state/manual-sync-focus.js";
 import { CLOSED_ONBOARDING } from "../src/state/onboarding-slice.js";
+import { EMPTY_SETTINGS_SURFACE } from "../src/state/settings-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
 import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
@@ -48,6 +52,8 @@ beforeEach(() => {
     onboarding: CLOSED_ONBOARDING,
     onboardingActions: null,
     connection: "connecting",
+    settings: EMPTY_SETTINGS_SURFACE,
+    settingsPorts: null,
   });
 });
 
@@ -62,6 +68,141 @@ afterEach(() => {
     onboarding: CLOSED_ONBOARDING,
     onboardingActions: null,
     connection: "connecting",
+    settings: EMPTY_SETTINGS_SURFACE,
+    settingsPorts: null,
+  });
+});
+
+describe("sidebar update action", () => {
+  it("appears only when an update is ready and names its version", () => {
+    render(<Sidebar />);
+
+    const hiddenStates = [
+      { status: "disabled" },
+      { status: "idle" },
+      { status: "checking" },
+      { status: "current" },
+      { status: "downloading", version: "1998.7.7" },
+      { status: "failed", stage: "check" },
+      { status: "failed", stage: "download" },
+    ] as const;
+    for (const state of hiddenStates) {
+      update({
+        settings: {
+          ...EMPTY_SETTINGS_SURFACE,
+          update: { state, actionDisabled: false },
+        },
+      });
+      expect(screen.queryByText("Update available")).not.toBeInTheDocument();
+    }
+
+    update({
+      settings: {
+        ...EMPTY_SETTINGS_SURFACE,
+        update: {
+          state: { status: "downloaded", version: "1998.7.7" },
+          actionDisabled: false,
+        },
+      },
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Install update version 1998.7.7" }),
+    ).toHaveTextContent("Update available");
+  });
+
+  it("activates the existing updater port once", async () => {
+    const user = userEvent.setup();
+    const activate = vi.fn();
+    useEnduragentStore.setState({
+      settings: {
+        ...EMPTY_SETTINGS_SURFACE,
+        update: {
+          state: { status: "downloaded", version: "1998.7.7" },
+          actionDisabled: false,
+        },
+      },
+      settingsPorts: { update: { activate } } as never,
+    });
+    render(<Sidebar />);
+
+    await user.click(screen.getByRole("button", { name: "Install update version 1998.7.7" }));
+
+    expect(activate).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the restarting state visible, busy and inert", () => {
+    useEnduragentStore.setState({
+      settings: {
+        ...EMPTY_SETTINGS_SURFACE,
+        update: {
+          state: { status: "downloaded", version: "1998.7.7" },
+          actionDisabled: true,
+        },
+      },
+      settingsPorts: { update: { activate: vi.fn() } } as never,
+    });
+    render(<Sidebar />);
+
+    const restarting = screen.getByRole("button", {
+      name: "Restarting to install update version 1998.7.7",
+    });
+    expect(restarting).toHaveTextContent("Restarting…");
+    expect(restarting).toBeDisabled();
+    expect(restarting).toHaveAttribute("aria-busy", "true");
+
+    update({
+      settings: {
+        ...EMPTY_SETTINGS_SURFACE,
+        update: {
+          state: { status: "installing", version: "1998.7.8" },
+          actionDisabled: false,
+        },
+      },
+    });
+    expect(
+      screen.getByRole("button", {
+        name: "Restarting to install update version 1998.7.8",
+      }),
+    ).toBeDisabled();
+  });
+
+  it("announces availability politely and respects sidebar locks", () => {
+    useEnduragentStore.setState({ settingsPorts: { update: { activate: vi.fn() } } as never });
+    render(<Sidebar />);
+
+    const announcement = document.querySelector(".update-announcement");
+    expect(announcement).toHaveAttribute("role", "status");
+    expect(announcement).toHaveAttribute("aria-live", "polite");
+    expect(announcement).toHaveAttribute("aria-atomic", "true");
+    expect(announcement).toBeEmptyDOMElement();
+
+    update({
+      settings: {
+        ...EMPTY_SETTINGS_SURFACE,
+        update: {
+          state: { status: "downloaded", version: "1998.7.7" },
+          actionDisabled: false,
+        },
+      },
+      onboarding: { ...CLOSED_ONBOARDING, open: true },
+    });
+    expect(announcement).toHaveTextContent("Update version 1998.7.7 is available");
+    expect(screen.getByRole("button", { name: "Install update version 1998.7.7" })).toBeDisabled();
+
+    update({
+      onboarding: CLOSED_ONBOARDING,
+      activeView: "settings",
+      settings: {
+        ...EMPTY_SETTINGS_SURFACE,
+        savingOwners: ["synthetic-lock"],
+        update: {
+          state: { status: "downloaded", version: "1998.7.7" },
+          actionDisabled: false,
+        },
+      },
+    });
+    expect(screen.getByRole("button", { name: "Install update version 1998.7.7" })).toBeDisabled();
   });
 });
 
@@ -205,10 +346,7 @@ describe("sidebar setup navigation", () => {
     });
     render(<Sidebar />);
 
-    expect(screen.getByRole("button", { name: "Setup" })).toHaveAttribute(
-      "aria-current",
-      "page",
-    );
+    expect(screen.getByRole("button", { name: "Setup" })).toHaveAttribute("aria-current", "page");
     expect(screen.getByRole("button", { name: "Chat" })).not.toHaveAttribute("aria-current");
 
     await user.click(screen.getByRole("button", { name: "Training" }));


### PR DESCRIPTION
Summary
- add an accessible Update available sidebar action only after the update is fully downloaded
- reuse the existing updater IPC install action
- disable the action as Restarting while installation begins

Dependency
- stacked on #507

Verification
- pnpm check