### PR TITLE
fix(desktop): drain cleanly on macos termination

### DIFF
--- a/.changeset/graceful-desktop-termination.md
+++ b/.changeset/graceful-desktop-termination.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop now shuts down cleanly when macOS terminates it during an update or normal quit.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -75,7 +75,10 @@ import {
   resolveDesktopRendererSource,
 } from "./security.js";
 import { DesktopDaemonSupervisor, isUtilityTerminalFrame } from "./supervisor.js";
-import { createDesktopQuitCoordinator } from "./quit-coordinator.js";
+import {
+  createDesktopQuitCoordinator,
+  installDesktopTerminationSignalHandler,
+} from "./quit-coordinator.js";
 import { createDesktopUpdateController } from "./update-controller.js";
 import { isDesktopUpdateReleaseEligible } from "./update-eligibility.js";
 import { installDesktopUpdateIpc } from "./update-ipc.js";
@@ -255,6 +258,12 @@ async function runDesktop(): Promise<void> {
     void residency?.close();
     if (quitCoordinator.beforeQuit(event) === "draining") quitRequested = true;
   });
+  if (process.platform === "darwin") {
+    installDesktopTerminationSignalHandler({
+      signalSource: process,
+      requestQuit: () => app.quit(),
+    });
+  }
   try {
     const resolution = await supervisor.resolve();
     if (resolution.status === "refused") {

--- a/apps/desktop/src/main/quit-coordinator.ts
+++ b/apps/desktop/src/main/quit-coordinator.ts
@@ -4,6 +4,23 @@ export interface DesktopBeforeQuitEvent {
   preventDefault(): void;
 }
 
+export interface DesktopTerminationSignalSource {
+  on(event: "SIGTERM", listener: () => void): unknown;
+}
+
+export function installDesktopTerminationSignalHandler(input: {
+  readonly signalSource: DesktopTerminationSignalSource;
+  readonly requestQuit: () => void;
+}): void {
+  let quitRequested = false;
+  const requestQuit = (): void => {
+    if (quitRequested) return;
+    quitRequested = true;
+    input.requestQuit();
+  };
+  input.signalSource.on("SIGTERM", requestQuit);
+}
+
 export async function completeDesktopShutdown(input: {
   readonly drain: () => Promise<void>;
   readonly updateController: Pick<DesktopUpdateController, "completeInstallAfterDrain">;

--- a/apps/desktop/tests/quit-coordinator.test.ts
+++ b/apps/desktop/tests/quit-coordinator.test.ts
@@ -1,7 +1,9 @@
+import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import {
   completeDesktopShutdown,
   createDesktopQuitCoordinator,
+  installDesktopTerminationSignalHandler,
 } from "../src/main/quit-coordinator.js";
 
 function deferred<T>() {
@@ -15,6 +17,32 @@ function deferred<T>() {
 }
 
 describe("desktop quit coordinator", () => {
+  it("routes repeated termination signals through one coordinated quit", async () => {
+    const signalSource = new EventEmitter();
+    const drain = vi.fn(async () => undefined);
+    const exit = vi.fn();
+    const beforeQuitEvent = { preventDefault: vi.fn() };
+    const coordinator = createDesktopQuitCoordinator({
+      drain,
+      updateController: {
+        completeInstallAfterDrain: () => "not-requested",
+      },
+      exit,
+    });
+    const application = new EventEmitter();
+    application.on("before-quit", (event) => coordinator.beforeQuit(event));
+    const requestQuit = vi.fn(() => application.emit("before-quit", beforeQuitEvent));
+    installDesktopTerminationSignalHandler({ signalSource, requestQuit });
+
+    signalSource.emit("SIGTERM");
+    signalSource.emit("SIGTERM");
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+
+    expect(requestQuit).toHaveBeenCalledOnce();
+    expect(beforeQuitEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(drain).toHaveBeenCalledOnce();
+  });
+
   it("blocks repeated pre-drain quits and permits only the updater-generated post-drain quit", async () => {
     const gate = deferred<void>();
     const drain = vi.fn(() => gate.promise);


### PR DESCRIPTION
Summary
- route macOS termination through the existing shutdown drain
- preserve clean process exit for updater-driven relaunch
- cover the signal lifecycle with focused tests

Dependency
- stacked on #508

Verification
- pnpm check