### PR TITLE
feat(desktop): add signed release genesis

### DIFF
--- a/.changeset/macos-signed-genesis.md
+++ b/.changeset/macos-signed-genesis.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Add a one-time, fail-closed macOS release genesis path that proves the signed, notarized updater envelope without weakening routine baseline continuity checks.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,6 +10,7 @@
     "check": "tsc --noEmit",
     "package:dir": "pnpm build:self-test-resources && electron-vite build && node scripts/development-package-plan.mjs",
     "package:mac": "pnpm build:self-test-resources && electron-vite build && node scripts/macos-release-plan.mjs",
+    "package:mac:genesis": "pnpm build:self-test-resources && electron-vite build && node scripts/macos-genesis-release.mjs",
     "package:telegram-acceptance": "pnpm --filter '@enduragent/desktop^...' build && pnpm build:self-test-resources && electron-vite build --config electron.telegram-acceptance.vite.config.ts && node scripts/package-telegram-acceptance.mjs",
     "build:self-test-resources": "tsx scripts/build-self-test-resources.ts",
     "stage:extra-resources": "node scripts/stage-extra-resources.mjs",

--- a/apps/desktop/scripts/macos-genesis-release.d.mts
+++ b/apps/desktop/scripts/macos-genesis-release.d.mts
@@ -1,0 +1,45 @@
+import type {
+  MacosGenesisReleaseInput,
+  MacosGenesisReleasePlan,
+  MacosReleaseDependencies,
+} from "./macos-release-plan.mjs";
+import type { VerifiedMacosReleaseCandidateApplication } from "./verify-macos-release.mjs";
+
+export interface MacosGenesisReleaseDependencies extends Omit<
+  MacosReleaseDependencies,
+  | "verifyBaselineApplication"
+  | "verifyIdentityContinuity"
+  | "verifyReleaseApplicationContents"
+  | "sealReleaseMetadata"
+  | "promoteReleaseEnvelope"
+> {
+  readonly sealReleaseMetadata?: (plan: MacosGenesisReleasePlan) => Promise<void>;
+  readonly promoteReleaseEnvelope?: (
+    plan: MacosGenesisReleasePlan,
+    verifyEnvelope: (artifactDirectory: string) => Promise<unknown>,
+  ) => Promise<string>;
+  readonly verifyCandidateApplication?: (
+    candidateApplication: string,
+    options: { readonly candidateVersion: string },
+  ) => Promise<VerifiedMacosReleaseCandidateApplication>;
+  readonly verifyReleaseApplicationContents?: (
+    artifactDirectory: string,
+    options: {
+      readonly candidateVersion: string;
+      readonly looseCandidateCodeIdentity: {
+        readonly codeDirectory: string;
+        readonly cdHash: string;
+      };
+    },
+    dependencies: { readonly executeFile?: MacosReleaseDependencies["executeFile"] },
+  ) => Promise<void>;
+}
+
+export function runMacosGenesisRelease(
+  input: MacosGenesisReleaseInput,
+  dependencies?: MacosGenesisReleaseDependencies,
+): Promise<{
+  readonly plan: MacosGenesisReleasePlan;
+  readonly artifacts: readonly string[];
+  readonly envelopePath: string;
+}>;

--- a/apps/desktop/scripts/macos-genesis-release.mjs
+++ b/apps/desktop/scripts/macos-genesis-release.mjs
@@ -1,0 +1,90 @@
+import { resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createMacosGenesisReleasePlan,
+  notarizeMacosDmg,
+  promoteMacosReleaseEnvelope,
+  requireNotarizationCredentials,
+  sealMacosReleaseMetadata,
+} from "./macos-release-plan.mjs";
+
+export async function runMacosGenesisRelease(input, dependencies = {}) {
+  const plan = await createMacosGenesisReleasePlan(input, dependencies);
+  if (input.genesisVersion !== plan.version) {
+    throw new TypeError("macOS genesis release version acknowledgement is invalid");
+  }
+  const notarizationCredentials = requireNotarizationCredentials(
+    dependencies.environment ?? process.env,
+  );
+  const verification = await import("./verify-macos-release.mjs");
+  const build = dependencies.build ?? (await import("electron-builder")).build;
+  const artifacts = await build(plan.builderOptions);
+  const application = join(plan.builderOptions.projectDir, "dist/mac-arm64/Enduragent.app");
+  const verifyPackageLayout =
+    dependencies.verifyPackageLayout ??
+    (await import("./verify-package-layout.mjs")).verifyPackageLayout;
+  await verifyPackageLayout(application, {
+    desktopRoot: plan.builderOptions.projectDir,
+    release: {
+      version: plan.version,
+      feedUrl: plan.feedUrl,
+    },
+  });
+  const verifyCandidateApplication =
+    dependencies.verifyCandidateApplication ??
+    ((candidate, options) =>
+      verification.verifyMacosReleaseCandidateApplication(candidate, options, {
+        executeFile: dependencies.executeFile,
+      }));
+  await verifyCandidateApplication(application, { candidateVersion: plan.version });
+  const dmgPath = join(plan.builderOptions.projectDir, "dist", plan.artifactNames.dmg);
+  await notarizeMacosDmg(dmgPath, notarizationCredentials, {
+    notarize: dependencies.notarize,
+  });
+  const verifyDmg =
+    dependencies.verifyDmg ??
+    ((path) =>
+      verification.verifyMacosDmg(path, {
+        executeFile: dependencies.executeFile,
+      }));
+  await verifyDmg(dmgPath);
+  const sealReleaseMetadata = dependencies.sealReleaseMetadata ?? sealMacosReleaseMetadata;
+  await sealReleaseMetadata(plan);
+  const verifyEnvelope = (artifactDirectory) =>
+    verification.verifyMacosGenesisReleaseEnvelope(
+      artifactDirectory,
+      application,
+      {
+        repositoryRoot: input.repositoryRoot,
+        readVersionFile: dependencies.readFile,
+      },
+      {
+        executeFile: dependencies.executeFile,
+        verifyCandidateApplication,
+        verifyReleaseApplicationContents: dependencies.verifyReleaseApplicationContents,
+        verifyReleaseArtifacts: dependencies.verifyReleaseArtifacts,
+      },
+    );
+  const promoteReleaseEnvelope = dependencies.promoteReleaseEnvelope ?? promoteMacosReleaseEnvelope;
+  const envelopePath = await promoteReleaseEnvelope(plan, verifyEnvelope);
+  return { plan, artifacts, envelopePath };
+}
+
+async function main() {
+  if (process.argv.length !== 2) throw new TypeError("arguments are not supported");
+  const result = await runMacosGenesisRelease({
+    feedUrl: process.env.ENDURAGENT_DESKTOP_UPDATE_URL,
+    identity: process.env.ENDURAGENT_DEVELOPER_ID_IDENTITY,
+    genesisVersion: process.env.ENDURAGENT_MACOS_GENESIS_VERSION,
+  });
+  process.stdout.write(`macOS genesis release envelope: ${result.envelopePath}\n`);
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch {
+    process.stderr.write("macOS genesis release build failed\n");
+    process.exitCode = 1;
+  }
+}

--- a/apps/desktop/scripts/macos-release-plan.d.mts
+++ b/apps/desktop/scripts/macos-release-plan.d.mts
@@ -21,6 +21,14 @@ export interface MacosReleaseInput {
   readonly desktopRoot?: string;
 }
 
+export interface MacosGenesisReleaseInput {
+  readonly feedUrl: string | undefined;
+  readonly identity: string | undefined;
+  readonly genesisVersion: string | undefined;
+  readonly repositoryRoot?: string;
+  readonly desktopRoot?: string;
+}
+
 export interface MacosReleaseBuilderOptions {
   readonly projectDir: string;
   readonly publish: "never";
@@ -65,6 +73,8 @@ export interface MacosReleasePlan {
   readonly artifactNames: ReleaseArtifactNames;
   readonly builderOptions: MacosReleaseBuilderOptions;
 }
+
+export type MacosGenesisReleasePlan = Omit<MacosReleasePlan, "baselineApplication">;
 
 export type NotarizationCredentialSelection =
   | {
@@ -169,6 +179,10 @@ export function createMacosReleasePlan(
   input: MacosReleaseInput,
   dependencies?: Pick<MacosReleaseDependencies, "readFile">,
 ): Promise<MacosReleasePlan>;
+export function createMacosGenesisReleasePlan(
+  input: MacosGenesisReleaseInput,
+  dependencies?: Pick<MacosReleaseDependencies, "readFile">,
+): Promise<MacosGenesisReleasePlan>;
 export function sealMacosReleaseMetadata(plan: MacosReleasePlan): Promise<void>;
 export function macosReleaseEnvelopePath(plan: MacosReleasePlan): string;
 export function promoteMacosReleaseEnvelope(

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -323,7 +323,7 @@ export function releaseArtifactNames(version) {
   });
 }
 
-export async function createMacosReleasePlan(input, dependencies = {}) {
+async function createMacosReleasePlanCore(input, dependencies = {}) {
   const repositoryRoot = input.repositoryRoot ?? canonicalRepositoryRoot;
   const desktopRoot = input.desktopRoot ?? join(repositoryRoot, "apps/desktop");
   if (!isAbsolute(desktopRoot)) {
@@ -335,11 +335,6 @@ export async function createMacosReleasePlan(input, dependencies = {}) {
   });
   const feedUrl = requireGenericFeedUrl(input.feedUrl);
   const identity = requireDeveloperIdIdentity(input.identity);
-  const baselineApplication = requireMacosBaselineApplication(input.baselineApplication);
-  const candidateApplication = join(desktopRoot, "dist/mac-arm64/Enduragent.app");
-  if (resolve(baselineApplication) === resolve(candidateApplication)) {
-    throw new TypeError("signed baseline application must differ from candidate");
-  }
   const builderOptions = {
     projectDir: desktopRoot,
     publish: "never",
@@ -379,10 +374,26 @@ export async function createMacosReleasePlan(input, dependencies = {}) {
   return Object.freeze({
     version,
     feedUrl,
-    baselineApplication,
     artifactNames: releaseArtifactNames(version),
     builderOptions,
   });
+}
+
+export async function createMacosReleasePlan(input, dependencies = {}) {
+  const plan = await createMacosReleasePlanCore(input, dependencies);
+  const baselineApplication = requireMacosBaselineApplication(input.baselineApplication);
+  const candidateApplication = join(
+    plan.builderOptions.projectDir,
+    "dist/mac-arm64/Enduragent.app",
+  );
+  if (resolve(baselineApplication) === resolve(candidateApplication)) {
+    throw new TypeError("signed baseline application must differ from candidate");
+  }
+  return Object.freeze({ ...plan, baselineApplication });
+}
+
+export async function createMacosGenesisReleasePlan(input, dependencies = {}) {
+  return createMacosReleasePlanCore(input, dependencies);
 }
 
 export async function sealMacosReleaseMetadata(plan) {

--- a/apps/desktop/scripts/verify-macos-release.d.mts
+++ b/apps/desktop/scripts/verify-macos-release.d.mts
@@ -78,6 +78,23 @@ export interface MacosCodeIdentity {
   readonly cdHash: string;
 }
 
+export interface VerifiedMacosReleaseCandidateApplication {
+  readonly version: string;
+  readonly identifier: "icu.enduragent.desktop";
+  readonly productName: "Enduragent";
+  readonly packageName: "@enduragent/desktop";
+  readonly teamIdentifier: "FA494ACVTF";
+  readonly designatedRequirement: string;
+  readonly hardenedRuntime: true;
+  readonly authorities: readonly [
+    `Developer ID Application: ${string} (FA494ACVTF)`,
+    "Developer ID Certification Authority",
+    "Apple Root CA",
+  ];
+  readonly entitlements: string;
+  readonly candidateCodeIdentity: MacosCodeIdentity;
+}
+
 export interface VerifyMacosReleaseApplicationContentsOptions {
   readonly candidateVersion: string;
   readonly looseCandidateCodeIdentity: MacosCodeIdentity;
@@ -95,6 +112,7 @@ export interface VerifyMacosReleaseApplicationContentsDependencies extends Verif
     options: { readonly flag: "wx"; readonly mode: 0o600 },
   ) => Promise<unknown>;
   readonly verifyIdentityContinuity?: typeof verifyMacosIdentityContinuity;
+  readonly verifyCandidateApplication?: typeof verifyMacosReleaseCandidateApplication;
 }
 
 export interface VerifyMacosReleaseEnvelopeDependencies
@@ -103,9 +121,21 @@ export interface VerifyMacosReleaseEnvelopeDependencies
   readonly verifyReleaseApplicationContents?: typeof verifyMacosReleaseApplicationContents;
 }
 
+export interface VerifyMacosGenesisReleaseEnvelopeDependencies extends Omit<
+  VerifyMacosReleaseEnvelopeDependencies,
+  "verifyReleaseApplicationContents"
+> {
+  readonly verifyReleaseApplicationContents?: typeof verifyMacosGenesisReleaseApplicationContents;
+}
+
 export interface VerifiedMacosReleaseEnvelope {
   readonly artifacts: VerifiedMacosReleaseArtifacts;
   readonly identityContinuity: VerifiedMacosIdentityContinuity;
+}
+
+export interface VerifiedMacosGenesisReleaseEnvelope {
+  readonly artifacts: VerifiedMacosReleaseArtifacts;
+  readonly candidateIdentity: VerifiedMacosReleaseCandidateApplication;
 }
 
 export function verifyMacosApplication(
@@ -127,9 +157,19 @@ export function verifyMacosBaselineApplication(
   options: VerifyMacosIdentityContinuityOptions,
   dependencies?: VerifyMacosIdentityContinuityDependencies,
 ): Promise<VerifiedMacosBaselineApplication>;
+export function verifyMacosReleaseCandidateApplication(
+  candidateApplication: string,
+  options: VerifyMacosIdentityContinuityOptions,
+  dependencies?: VerifyMacosIdentityContinuityDependencies,
+): Promise<VerifiedMacosReleaseCandidateApplication>;
 export function verifyMacosReleaseApplicationContents(
   artifactDirectory: string,
   baselineApplication: string,
+  options: VerifyMacosReleaseApplicationContentsOptions,
+  dependencies?: VerifyMacosReleaseApplicationContentsDependencies,
+): Promise<void>;
+export function verifyMacosGenesisReleaseApplicationContents(
+  artifactDirectory: string,
   options: VerifyMacosReleaseApplicationContentsOptions,
   dependencies?: VerifyMacosReleaseApplicationContentsDependencies,
 ): Promise<void>;
@@ -145,3 +185,9 @@ export function verifyMacosReleaseEnvelope(
   options?: VerifyMacosReleaseOptions,
   dependencies?: VerifyMacosReleaseEnvelopeDependencies,
 ): Promise<VerifiedMacosReleaseEnvelope>;
+export function verifyMacosGenesisReleaseEnvelope(
+  artifactDirectory: string,
+  looseCandidateApplication: string,
+  options?: VerifyMacosReleaseOptions,
+  dependencies?: VerifyMacosGenesisReleaseEnvelopeDependencies,
+): Promise<VerifiedMacosGenesisReleaseEnvelope>;

--- a/apps/desktop/scripts/verify-macos-release.mjs
+++ b/apps/desktop/scripts/verify-macos-release.mjs
@@ -217,7 +217,14 @@ function parseSignatureMetadata(result) {
   ) {
     fail("macOS signed identity is invalid");
   }
-  return { identifier, teamIdentifier, codeDirectory, cdHash };
+  return {
+    identifier,
+    teamIdentifier,
+    codeDirectory,
+    cdHash,
+    hardenedRuntime: true,
+    authorities: Object.freeze([...authorities]),
+  };
 }
 
 function parseDesignatedRequirement(result) {
@@ -303,9 +310,13 @@ async function inspectMacosApplicationIdentity(application, bundle, dependencies
   return Object.freeze({
     version,
     identifier: signature.identifier,
+    productName: canonicalProductName,
+    packageName: canonicalPackageName,
     teamIdentifier: signature.teamIdentifier,
     designatedRequirement,
     entitlements,
+    hardenedRuntime: signature.hardenedRuntime,
+    authorities: signature.authorities,
     codeDirectory: signature.codeDirectory,
     cdHash: signature.cdHash,
   });
@@ -351,6 +362,67 @@ export async function verifyMacosBaselineApplication(baselineApplication, option
   });
 }
 
+async function verifyMacosReleaseCandidateBundle(
+  candidateApplication,
+  candidateVersion,
+  bundle,
+  dependencies,
+) {
+  const candidate = await inspectMacosApplicationIdentity(
+    candidateApplication,
+    bundle,
+    dependencies,
+  );
+  if (candidate.version !== candidateVersion) fail("candidate release identity is invalid");
+  return Object.freeze({
+    version: candidate.version,
+    identifier: candidate.identifier,
+    productName: candidate.productName,
+    packageName: candidate.packageName,
+    teamIdentifier: candidate.teamIdentifier,
+    designatedRequirement: candidate.designatedRequirement,
+    hardenedRuntime: candidate.hardenedRuntime,
+    authorities: candidate.authorities,
+    entitlements: candidate.entitlements,
+    candidateCodeIdentity: Object.freeze({
+      codeDirectory: candidate.codeDirectory,
+      cdHash: candidate.cdHash,
+    }),
+  });
+}
+
+export async function verifyMacosReleaseCandidateApplication(
+  candidateApplication,
+  options,
+  overrides = {},
+) {
+  let candidateVersion;
+  try {
+    candidateVersion = requireStableCalVer(options?.candidateVersion);
+  } catch {
+    fail("candidate release version is invalid");
+  }
+  if (typeof candidateApplication !== "string" || !isAbsolute(candidateApplication)) {
+    fail("candidate application path must be absolute");
+  }
+  const dependencies = {
+    executeFile: overrides.executeFile ?? executeSystemFile,
+    extractAsarFile: overrides.extractAsarFile ?? extractFile,
+    lstat: overrides.lstat ?? lstat,
+    mkdtemp: overrides.mkdtemp ?? mkdtemp,
+    realpath: overrides.realpath ?? realpath,
+    rm: overrides.rm ?? rm,
+    tmpdir: overrides.tmpdir ?? tmpdir,
+  };
+  const bundle = await requireApplicationBundle(candidateApplication, "candidate", dependencies);
+  return verifyMacosReleaseCandidateBundle(
+    candidateApplication,
+    candidateVersion,
+    bundle,
+    dependencies,
+  );
+}
+
 export async function verifyMacosIdentityContinuity(
   baselineApplication,
   candidateApplication,
@@ -388,11 +460,20 @@ export async function verifyMacosIdentityContinuity(
   if (baselineBundle.canonicalPath === candidateBundle.canonicalPath) {
     fail("baseline application must differ from candidate");
   }
-  const [baseline, candidate] = await Promise.all([
+  const [baseline, candidateIdentity] = await Promise.all([
     inspectMacosApplicationIdentity(baselineApplication, baselineBundle, dependencies),
-    inspectMacosApplicationIdentity(candidateApplication, candidateBundle, dependencies),
+    verifyMacosReleaseCandidateBundle(
+      candidateApplication,
+      candidateVersion,
+      candidateBundle,
+      dependencies,
+    ),
   ]);
-  if (candidate.version !== candidateVersion) fail("candidate release identity is invalid");
+  const candidate = {
+    ...candidateIdentity,
+    codeDirectory: candidateIdentity.candidateCodeIdentity.codeDirectory,
+    cdHash: candidateIdentity.candidateCodeIdentity.cdHash,
+  };
   if (!olderStableCalVer(baseline.version, candidate.version)) {
     fail("baseline application is not older than candidate");
   }
@@ -810,26 +891,15 @@ async function requireSameSecureDirectory(path, expectedIdentity, dependencies, 
   }
 }
 
-async function inspectPackagedApplication(
-  baselineApplication,
-  application,
-  candidateVersion,
-  expectedCodeIdentity,
-  dependencies,
-) {
-  let continuity;
+async function inspectPackagedApplication(application, expectedCodeIdentity, verifyCandidate) {
+  let verifiedCandidate;
   try {
-    continuity = await dependencies.verifyIdentityContinuity(
-      baselineApplication,
-      application,
-      { candidateVersion },
-      dependencies,
-    );
+    verifiedCandidate = await verifyCandidate(application);
   } catch (error) {
     if (error instanceof MacosReleaseVerificationError) throw error;
     fail("packaged macOS application identity verification failed");
   }
-  const actualCodeIdentity = requireCandidateCodeIdentity(continuity?.candidateCodeIdentity);
+  const actualCodeIdentity = requireCandidateCodeIdentity(verifiedCandidate?.candidateCodeIdentity);
   if (
     actualCodeIdentity.codeDirectory !== expectedCodeIdentity.codeDirectory ||
     actualCodeIdentity.cdHash !== expectedCodeIdentity.cdHash
@@ -838,16 +908,13 @@ async function inspectPackagedApplication(
   }
 }
 
-export async function verifyMacosReleaseApplicationContents(
+async function verifyMacosReleaseApplicationContentsWithCandidate(
   artifactDirectory,
-  baselineApplication,
   options,
-  overrides = {},
+  overrides,
+  verifyCandidate,
 ) {
   if (!isAbsolute(artifactDirectory)) fail("artifact directory must be absolute");
-  if (typeof baselineApplication !== "string" || !isAbsolute(baselineApplication)) {
-    fail("baseline application path must be absolute");
-  }
   let candidateVersion;
   try {
     candidateVersion = requireStableCalVer(options?.candidateVersion);
@@ -869,7 +936,6 @@ export async function verifyMacosReleaseApplicationContents(
     rmdir: overrides.rmdir ?? rmdir,
     tmpdir: overrides.tmpdir ?? tmpdir,
     writeFile: overrides.writeFile ?? writeFile,
-    verifyIdentityContinuity: overrides.verifyIdentityContinuity ?? verifyMacosIdentityContinuity,
   };
   const names = releaseArtifactNames(candidateVersion);
   const zipPath = join(artifactDirectory, names.zip);
@@ -942,13 +1008,7 @@ export async function verifyMacosReleaseApplicationContents(
       "macOS release ZIP extraction failed",
     );
     const zipApplication = await requireSingleRootApplication(zipDirectory, "ZIP", dependencies);
-    await inspectPackagedApplication(
-      baselineApplication,
-      zipApplication,
-      candidateVersion,
-      expectedCodeIdentity,
-      dependencies,
-    );
+    await inspectPackagedApplication(zipApplication, expectedCodeIdentity, verifyCandidate);
 
     hdiutilBeforeAttach = await inspectCurrentHdiutilState(
       temporaryDirectory,
@@ -1008,13 +1068,7 @@ export async function verifyMacosReleaseApplicationContents(
     requireNewImageInstance(candidateAttachmentIdentity, hdiutilBeforeAttach);
     attachmentIdentity = candidateAttachmentIdentity;
     const dmgApplication = await requireSingleRootApplication(mountPoint, "DMG", dependencies);
-    await inspectPackagedApplication(
-      baselineApplication,
-      dmgApplication,
-      candidateVersion,
-      expectedCodeIdentity,
-      dependencies,
-    );
+    await inspectPackagedApplication(dmgApplication, expectedCodeIdentity, verifyCandidate);
   } catch (error) {
     failure =
       error instanceof MacosReleaseVerificationError
@@ -1145,6 +1199,51 @@ export async function verifyMacosReleaseApplicationContents(
   }
   if (cleanupFailure !== undefined) throw cleanupFailure;
   if (failure !== null) throw failure;
+}
+
+export async function verifyMacosReleaseApplicationContents(
+  artifactDirectory,
+  baselineApplication,
+  options,
+  overrides = {},
+) {
+  if (typeof baselineApplication !== "string" || !isAbsolute(baselineApplication)) {
+    fail("baseline application path must be absolute");
+  }
+  const verifyIdentityContinuity =
+    overrides.verifyIdentityContinuity ?? verifyMacosIdentityContinuity;
+  return verifyMacosReleaseApplicationContentsWithCandidate(
+    artifactDirectory,
+    options,
+    overrides,
+    (application) =>
+      verifyIdentityContinuity(
+        baselineApplication,
+        application,
+        { candidateVersion: options?.candidateVersion },
+        overrides,
+      ),
+  );
+}
+
+export async function verifyMacosGenesisReleaseApplicationContents(
+  artifactDirectory,
+  options,
+  overrides = {},
+) {
+  const verifyCandidateApplication =
+    overrides.verifyCandidateApplication ?? verifyMacosReleaseCandidateApplication;
+  return verifyMacosReleaseApplicationContentsWithCandidate(
+    artifactDirectory,
+    options,
+    overrides,
+    (application) =>
+      verifyCandidateApplication(
+        application,
+        { candidateVersion: options?.candidateVersion },
+        overrides,
+      ),
+  );
 }
 
 async function runSystemVerification(executeFile, executable, arguments_, failureMessage) {
@@ -1478,6 +1577,43 @@ export async function verifyMacosReleaseEnvelope(
     overrides,
   );
   return Object.freeze({ artifacts, identityContinuity });
+}
+
+export async function verifyMacosGenesisReleaseEnvelope(
+  artifactDirectory,
+  looseCandidateApplication,
+  options = {},
+  overrides = {},
+) {
+  const verifyReleaseArtifacts = overrides.verifyReleaseArtifacts ?? verifyMacosReleaseArtifacts;
+  const artifacts = await verifyReleaseArtifacts(artifactDirectory, options, overrides);
+  let candidateVersion;
+  try {
+    candidateVersion = requireStableCalVer(artifacts?.version);
+  } catch {
+    fail("verified release version is invalid");
+  }
+  const verifyCandidateApplication =
+    overrides.verifyCandidateApplication ?? verifyMacosReleaseCandidateApplication;
+  const candidateIdentity = await verifyCandidateApplication(
+    looseCandidateApplication,
+    { candidateVersion },
+    overrides,
+  );
+  if (candidateIdentity?.version !== candidateVersion) {
+    fail("loose candidate release identity is invalid");
+  }
+  const looseCandidateCodeIdentity = requireCandidateCodeIdentity(
+    candidateIdentity.candidateCodeIdentity,
+  );
+  const verifyReleaseApplicationContents =
+    overrides.verifyReleaseApplicationContents ?? verifyMacosGenesisReleaseApplicationContents;
+  await verifyReleaseApplicationContents(
+    artifactDirectory,
+    { candidateVersion, looseCandidateCodeIdentity },
+    overrides,
+  );
+  return Object.freeze({ artifacts, candidateIdentity });
 }
 
 async function main() {

--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -21,7 +21,10 @@ import { parse, stringify } from "yaml";
 import {
   verifyMacosApplication,
   verifyMacosBaselineApplication,
+  verifyMacosGenesisReleaseApplicationContents,
+  verifyMacosGenesisReleaseEnvelope,
   verifyMacosIdentityContinuity,
+  verifyMacosReleaseCandidateApplication,
   verifyMacosReleaseApplicationContents,
   verifyMacosReleaseArtifacts,
   verifyMacosReleaseEnvelope,
@@ -263,6 +266,74 @@ async function signedIdentityFixture() {
 }
 
 describe("macOS signed identity continuity", () => {
+  it("proves a canonical candidate without requiring an older baseline", async () => {
+    const fixture = await signedIdentityFixture();
+
+    await expect(
+      verifyMacosReleaseCandidateApplication(
+        fixture.candidate,
+        { candidateVersion: version },
+        {
+          executeFile: fixture.executeFile,
+          extractAsarFile: fixture.extractAsarFile,
+        },
+      ),
+    ).resolves.toEqual({
+      version,
+      identifier: "icu.enduragent.desktop",
+      productName: "Enduragent",
+      packageName: "@enduragent/desktop",
+      teamIdentifier: "FA494ACVTF",
+      designatedRequirement: canonicalDesignatedRequirement,
+      hardenedRuntime: true,
+      authorities: [
+        "Developer ID Application: Enduragent Test (FA494ACVTF)",
+        "Developer ID Certification Authority",
+        "Apple Root CA",
+      ],
+      entitlements: JSON.stringify({ "com.apple.security.cs.allow-jit": true }),
+      candidateCodeIdentity: {
+        codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+        cdHash: "b".repeat(40),
+      },
+    });
+  });
+
+  it.each([
+    {
+      label: "bundle name",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.info.CFBundleName = "Alternate";
+      },
+      error: "macOS product identity is invalid",
+    },
+    {
+      label: "package version",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.manifest.version = "2026.7.1";
+      },
+      error: "macOS package identity is invalid",
+    },
+    {
+      label: "certificate authority",
+      mutate(metadata: SignedApplicationMetadata) {
+        metadata.extraAuthorities.push("Alternate Root");
+      },
+      error: "macOS signed identity is invalid",
+    },
+  ])("rejects a genesis candidate with alternate $label", async ({ mutate, error }) => {
+    const fixture = await signedIdentityFixture();
+    mutate(fixture.metadata.get(fixture.candidate)!);
+
+    await expect(
+      verifyMacosReleaseCandidateApplication(
+        fixture.candidate,
+        { candidateVersion: version },
+        { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
+      ),
+    ).rejects.toThrow(error);
+  });
+
   it("preflights the complete signed baseline before a candidate exists", async () => {
     const fixture = await signedIdentityFixture();
 
@@ -895,6 +966,33 @@ async function packagedApplicationFixture(
       };
     },
   );
+  const verifyCandidateApplication = vi.fn(
+    async (application: string, verificationOptions: { candidateVersion: string }) => {
+      const source = application.includes("/zip/") ? "zip" : "dmg";
+      if (options.identityFailure === source) {
+        throw new Error(`${application}: private signing output`);
+      }
+      return {
+        version: verificationOptions.candidateVersion,
+        identifier: "icu.enduragent.desktop" as const,
+        productName: "Enduragent" as const,
+        packageName: "@enduragent/desktop" as const,
+        teamIdentifier: "FA494ACVTF" as const,
+        designatedRequirement: canonicalDesignatedRequirement,
+        hardenedRuntime: true as const,
+        authorities: [
+          "Developer ID Application: Enduragent Test (FA494ACVTF)",
+          "Developer ID Certification Authority",
+          "Apple Root CA",
+        ] as const,
+        entitlements: JSON.stringify({ "com.apple.security.cs.allow-jit": true }),
+        candidateCodeIdentity:
+          source === "zip"
+            ? (options.zipCodeIdentity ?? looseCandidateCodeIdentity)
+            : (options.dmgCodeIdentity ?? looseCandidateCodeIdentity),
+      };
+    },
+  );
   const remove = vi.fn(async (path: string, removeOptions: { recursive: true; force: true }) => {
     if (options.cleanupFailure && temporaryDirectories.includes(path)) {
       throw new Error("private cleanup output");
@@ -934,6 +1032,20 @@ async function packagedApplicationFixture(
         verifyIdentityContinuity,
       },
     );
+  const verifyGenesis = () =>
+    verifyMacosGenesisReleaseApplicationContents(
+      artifactDirectory,
+      { candidateVersion: version, looseCandidateCodeIdentity },
+      {
+        executeFile,
+        mkdtemp: mkdtempTracked,
+        realpath: resolveRealpath,
+        rm: remove,
+        rmdir: removeMountPoint,
+        tmpdir: () => root,
+        verifyCandidateApplication,
+      },
+    );
   return {
     artifactDirectory,
     baseline,
@@ -941,15 +1053,79 @@ async function packagedApplicationFixture(
     convertedPlists,
     executeFile,
     intendedMountPoint: () => mountPoint,
+    verifyCandidateApplication,
     verifyIdentityContinuity,
     remove,
     removeMountPoint,
     temporaryDirectories,
     verify,
+    verifyGenesis,
   };
 }
 
 describe("macOS packaged application identity binding", () => {
+  it("runs the secure genesis ZIP and DMG path and verifies both embedded candidates", async () => {
+    const fixture = await packagedApplicationFixture();
+
+    await expect(fixture.verifyGenesis()).resolves.toBeUndefined();
+
+    expect(fixture.verifyCandidateApplication).toHaveBeenCalledTimes(2);
+    expect(
+      fixture.verifyCandidateApplication.mock.calls.map(([application]) => application),
+    ).toEqual([
+      expect.stringMatching(/\/zip\/Enduragent\.app$/u),
+      expect.stringMatching(/\/dmg\/Enduragent\.app$/u),
+    ]);
+    for (const [, verificationOptions] of fixture.verifyCandidateApplication.mock.calls) {
+      expect(verificationOptions).toEqual({ candidateVersion: version });
+    }
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/ditto", [
+      "-x",
+      "-k",
+      join(fixture.artifactDirectory, names.zip),
+      expect.stringMatching(/\/zip$/u),
+    ]);
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/hdiutil", [
+      "attach",
+      "-readonly",
+      "-nobrowse",
+      "-noautoopen",
+      "-plist",
+      "-mountpoint",
+      fixture.intendedMountPoint(),
+      join(fixture.artifactDirectory, names.dmg),
+    ]);
+    expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/hdiutil", [
+      "detach",
+      "/dev/disk42s1",
+    ]);
+    await expect(lstat(fixture.temporaryDirectories[0]!)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.each(["zip", "dmg"] as const)(
+    "rejects a genesis %s application whose CDHash differs from the loose candidate",
+    async (source) => {
+      const mismatchedCodeIdentity = {
+        ...looseCandidateCodeIdentity,
+        cdHash: "c".repeat(40),
+      };
+      const fixture = await packagedApplicationFixture(
+        source === "zip"
+          ? { zipCodeIdentity: mismatchedCodeIdentity }
+          : { dmgCodeIdentity: mismatchedCodeIdentity },
+      );
+
+      await expect(fixture.verifyGenesis()).rejects.toThrow(
+        "packaged macOS application differs from the loose candidate",
+      );
+      expect(
+        fixture.verifyCandidateApplication.mock.calls.some(([application]) =>
+          application.includes(`/${source}/Enduragent.app`),
+        ),
+      ).toBe(true);
+    },
+  );
+
   it("binds both mandatory packaged applications to the loose candidate before cleanup", async () => {
     const fixture = await packagedApplicationFixture();
 
@@ -1396,6 +1572,64 @@ describe("macOS packaged application identity binding", () => {
 });
 
 describe("macOS release artifact envelope", () => {
+  it("verifies a genesis envelope against the proved loose candidate without a baseline", async () => {
+    const fixture = await releaseFixture();
+    const looseCandidateApplication = "/synthetic/candidate/Enduragent.app";
+    const artifacts = Object.freeze({
+      version,
+      names: Object.freeze({ ...names, metadata: "latest-mac.yml" as const }),
+      paths: Object.freeze({
+        dmg: join(fixture.artifactDirectory, names.dmg),
+        zip: join(fixture.artifactDirectory, names.zip),
+        blockmap: join(fixture.artifactDirectory, names.blockmap),
+        metadata: join(fixture.artifactDirectory, names.metadata),
+      }),
+      sizes: Object.freeze({
+        dmg: fixture.dmg.length,
+        zip: fixture.zip.length,
+        blockmap: fixture.blockmap.length,
+      }),
+      dmgSha512: fixture.dmgSha512,
+      zipSha512: fixture.zipSha512,
+    });
+    const candidateIdentity = Object.freeze({
+      version,
+      candidateCodeIdentity: Object.freeze({
+        codeDirectory: looseCandidateCodeIdentity.codeDirectory,
+        cdHash: looseCandidateCodeIdentity.cdHash,
+      }),
+    });
+    const verifyReleaseArtifacts = vi.fn(async () => artifacts);
+    const verifyCandidateApplication = vi.fn(async () => candidateIdentity);
+    const verifyReleaseApplicationContents = vi.fn(async () => {});
+
+    await expect(
+      verifyMacosGenesisReleaseEnvelope(
+        fixture.artifactDirectory,
+        looseCandidateApplication,
+        { repositoryRoot: fixture.repositoryRoot },
+        {
+          verifyReleaseArtifacts,
+          verifyCandidateApplication,
+          verifyReleaseApplicationContents,
+        },
+      ),
+    ).resolves.toEqual({ artifacts, candidateIdentity });
+    expect(verifyCandidateApplication).toHaveBeenCalledWith(
+      looseCandidateApplication,
+      { candidateVersion: version },
+      expect.any(Object),
+    );
+    expect(verifyReleaseApplicationContents).toHaveBeenCalledWith(
+      fixture.artifactDirectory,
+      {
+        candidateVersion: version,
+        looseCandidateCodeIdentity,
+      },
+      expect.any(Object),
+    );
+  });
+
   it("verifies artifacts, the loose candidate, and packaged applications as one envelope", async () => {
     const fixture = await releaseFixture();
     const baselineApplication = "/synthetic/baseline/Enduragent.app";

--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -1594,6 +1594,18 @@ describe("macOS release artifact envelope", () => {
     });
     const candidateIdentity = Object.freeze({
       version,
+      identifier: "icu.enduragent.desktop" as const,
+      productName: "Enduragent" as const,
+      packageName: "@enduragent/desktop" as const,
+      teamIdentifier: "FA494ACVTF" as const,
+      designatedRequirement: canonicalDesignatedRequirement,
+      hardenedRuntime: true as const,
+      authorities: [
+        "Developer ID Application: Enduragent Test (FA494ACVTF)",
+        "Developer ID Certification Authority",
+        "Apple Root CA",
+      ] as const,
+      entitlements: JSON.stringify({ "com.apple.security.cs.allow-jit": true }),
       candidateCodeIdentity: Object.freeze({
         codeDirectory: looseCandidateCodeIdentity.codeDirectory,
         cdHash: looseCandidateCodeIdentity.cdHash,

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
 import {
   DESKTOP_UPDATER_CACHE_DIRECTORY,
+  createMacosGenesisReleasePlan,
   createMacosReleasePlan,
   macosReleaseEnvelopePath,
   notarizeMacosDmg,
@@ -28,7 +29,9 @@ import {
   runMacosRelease,
   sealMacosReleaseMetadata,
 } from "../scripts/macos-release-plan.mjs";
+import { runMacosGenesisRelease } from "../scripts/macos-genesis-release.mjs";
 import type {
+  MacosGenesisReleasePlan,
   MacosReleaseBuilderOptions,
   MacosReleasePlan,
 } from "../scripts/macos-release-plan.mjs";
@@ -55,6 +58,22 @@ const verifiedLooseIdentity = Object.freeze({
 const verifiedBaselineApplication = Object.freeze({
   baselineVersion: "2026.7.1",
   teamIdentifier: "FA494ACVTF",
+});
+const verifiedCandidateApplication = Object.freeze({
+  version: "2026.7.2",
+  identifier: "icu.enduragent.desktop" as const,
+  productName: "Enduragent" as const,
+  packageName: "@enduragent/desktop" as const,
+  teamIdentifier: "FA494ACVTF" as const,
+  designatedRequirement: "synthetic canonical designated requirement",
+  hardenedRuntime: true as const,
+  authorities: Object.freeze([
+    "Developer ID Application: Enduragent Test (FA494ACVTF)",
+    "Developer ID Certification Authority",
+    "Apple Root CA",
+  ] as const),
+  entitlements: JSON.stringify({ "com.apple.security.cs.allow-jit": true }),
+  candidateCodeIdentity: verifiedLooseIdentity.candidateCodeIdentity,
 });
 const temporaryRoots: string[] = [];
 
@@ -256,6 +275,34 @@ describe("macOS release plan", () => {
     ).rejects.toThrow("signed baseline application must differ from candidate");
   });
 
+  it("creates a genesis plan without weakening the routine baseline contract", async () => {
+    const genesisPlan = await createMacosGenesisReleasePlan(
+      {
+        repositoryRoot: "/synthetic/repository",
+        desktopRoot: "/synthetic/repository/apps/desktop",
+        feedUrl,
+        identity,
+        genesisVersion: "2026.7.2",
+      },
+      { readFile: versionReader() },
+    );
+
+    expect(genesisPlan).not.toHaveProperty("baselineApplication");
+    expect(genesisPlan.version).toBe("2026.7.2");
+    await expect(
+      createMacosReleasePlan(
+        {
+          repositoryRoot: "/synthetic/repository",
+          desktopRoot: "/synthetic/repository/apps/desktop",
+          feedUrl,
+          identity,
+          baselineApplication: undefined,
+        },
+        { readFile: versionReader() },
+      ),
+    ).rejects.toThrow("signed baseline application path is invalid");
+  });
+
   it("fails baseline preflight before loading or invoking electron-builder", async () => {
     const build = vi.fn(async (_options: MacosReleaseBuilderOptions) => []);
     await expect(
@@ -275,6 +322,112 @@ describe("macOS release plan", () => {
       ),
     ).rejects.toThrow("signed baseline application path is invalid");
     expect(build).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, "2026.7.1", "2026.7.3"])(
+    "fails genesis acknowledgement before loading or invoking electron-builder: %s",
+    async (genesisVersion) => {
+      const build = vi.fn(async (_options: MacosReleaseBuilderOptions) => []);
+
+      await expect(
+        runMacosGenesisRelease(
+          {
+            repositoryRoot: "/synthetic/repository",
+            desktopRoot: "/synthetic/repository/apps/desktop",
+            feedUrl,
+            identity,
+            genesisVersion,
+          },
+          {
+            readFile: versionReader(),
+            environment: notarizationEnvironment,
+            build,
+          },
+        ),
+      ).rejects.toThrow("macOS genesis release version acknowledgement is invalid");
+      expect(build).not.toHaveBeenCalled();
+    },
+  );
+
+  it("builds genesis only through canonical candidate and embedded-app verification", async () => {
+    const build = vi.fn(async (_options: MacosReleaseBuilderOptions) => [
+      "/synthetic/Enduragent-2026.7.2-arm64.dmg",
+    ]);
+    const verifyPackageLayout = vi.fn(async () => {});
+    const verifyCandidateApplication = vi.fn(async () => verifiedCandidateApplication);
+    const notarize = vi.fn(async () => {});
+    const verifyDmg = vi.fn(async () => {});
+    const sealReleaseMetadata = vi.fn(async () => {});
+    const verifyReleaseArtifacts = vi.fn(async (artifactDirectory: string) =>
+      verifiedReleaseArtifactsAt(artifactDirectory),
+    );
+    const verifyReleaseApplicationContents = vi.fn(async () => {});
+    const envelopePath =
+      "/synthetic/repository/apps/desktop/dist/release-envelope-2026.7.2-mac-arm64";
+    const temporaryEnvelopePath =
+      "/synthetic/repository/apps/desktop/dist/.release-envelope-2026.7.2-mac-arm64-test";
+    const promoteReleaseEnvelope = vi.fn(
+      async (
+        _plan: MacosGenesisReleasePlan,
+        verifyEnvelope: (artifactDirectory: string) => Promise<unknown>,
+      ) => {
+        await verifyEnvelope(temporaryEnvelopePath);
+        return envelopePath;
+      },
+    );
+
+    const result = await runMacosGenesisRelease(
+      {
+        repositoryRoot: "/synthetic/repository",
+        desktopRoot: "/synthetic/repository/apps/desktop",
+        feedUrl,
+        identity,
+        genesisVersion: "2026.7.2",
+      },
+      {
+        readFile: versionReader(),
+        environment: notarizationEnvironment,
+        build,
+        verifyPackageLayout,
+        verifyCandidateApplication,
+        notarize,
+        verifyDmg,
+        sealReleaseMetadata,
+        verifyReleaseArtifacts,
+        verifyReleaseApplicationContents,
+        promoteReleaseEnvelope,
+      },
+    );
+
+    const application = "/synthetic/repository/apps/desktop/dist/mac-arm64/Enduragent.app";
+    expect(result.envelopePath).toBe(envelopePath);
+    expect(verifyCandidateApplication).toHaveBeenCalledTimes(2);
+    expect(verifyCandidateApplication).toHaveBeenNthCalledWith(1, application, {
+      candidateVersion: "2026.7.2",
+    });
+    expect(verifyCandidateApplication).toHaveBeenNthCalledWith(
+      2,
+      application,
+      { candidateVersion: "2026.7.2" },
+      expect.any(Object),
+    );
+    expect(verifyReleaseApplicationContents).toHaveBeenCalledWith(
+      temporaryEnvelopePath,
+      {
+        candidateVersion: "2026.7.2",
+        looseCandidateCodeIdentity: verifiedCandidateApplication.candidateCodeIdentity,
+      },
+      expect.any(Object),
+    );
+    expect(build.mock.invocationCallOrder[0]).toBeLessThan(
+      verifyCandidateApplication.mock.invocationCallOrder[0]!,
+    );
+    expect(verifyCandidateApplication.mock.invocationCallOrder[0]).toBeLessThan(
+      notarize.mock.invocationCallOrder[0]!,
+    );
+    expect(sealReleaseMetadata.mock.invocationCallOrder[0]).toBeLessThan(
+      promoteReleaseEnvelope.mock.invocationCallOrder[0]!,
+    );
   });
 
   it("rejects a missing absolute baseline before invoking electron-builder", async () => {


### PR DESCRIPTION
Summary
- add a one-time signed and notarized macOS release genesis path
- fail closed on bundle, Team, signing, notarization, and exact-four updater envelope identity
- characterize genesis identity continuity with dedicated fixtures and tests

Dependency
- stacked on #509

Verification
- pnpm check