### PR TITLE
test(desktop): inspect signed updater applications

### DIFF
--- a/apps/desktop/scripts/macos-release-plan.d.mts
+++ b/apps/desktop/scripts/macos-release-plan.d.mts
@@ -13,6 +13,13 @@ export interface ReleaseArtifactNames {
   readonly metadata: "latest-mac.yml";
 }
 
+export interface MacosReleaseUpdaterMetadata {
+  readonly provider: "generic";
+  readonly url: string;
+  readonly channel: "latest";
+  readonly updaterCacheDirName: "@enduragentdesktop-updater";
+}
+
 export interface MacosReleaseInput {
   readonly feedUrl: string | undefined;
   readonly identity: string | undefined;
@@ -168,6 +175,9 @@ export function requireNotarizationCredentials(
 ): NotarizationCredentialSelection;
 export function requireStableCalVer(value: unknown): string;
 export function requireGenericFeedUrl(value: unknown): string;
+export function parseMacosReleaseUpdaterMetadata(
+  value: string | Uint8Array,
+): MacosReleaseUpdaterMetadata;
 export function requireDeveloperIdIdentity(value: unknown): string;
 export function requireMacosBaselineApplication(value: unknown): string;
 export function releaseArtifactNames(version: string): ReleaseArtifactNames;

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -253,6 +253,43 @@ export function requireGenericFeedUrl(value) {
   return value;
 }
 
+export function parseMacosReleaseUpdaterMetadata(value) {
+  let metadata;
+  try {
+    const source =
+      typeof value === "string"
+        ? value
+        : value instanceof Uint8Array
+          ? Buffer.from(value).toString("utf8")
+          : undefined;
+    if (source === undefined) throw new TypeError();
+    metadata = parse(source);
+  } catch {
+    throw new TypeError("release updater metadata is invalid");
+  }
+  if (
+    !exactObject(metadata) ||
+    !hasExactKeys(metadata, ["provider", "url", "channel", "updaterCacheDirName"]) ||
+    metadata.provider !== "generic" ||
+    metadata.channel !== "latest" ||
+    metadata.updaterCacheDirName !== DESKTOP_UPDATER_CACHE_DIRECTORY
+  ) {
+    throw new TypeError("release updater metadata is invalid");
+  }
+  let url;
+  try {
+    url = requireGenericFeedUrl(metadata.url);
+  } catch {
+    throw new TypeError("release updater metadata is invalid");
+  }
+  return Object.freeze({
+    provider: "generic",
+    url,
+    channel: "latest",
+    updaterCacheDirName: DESKTOP_UPDATER_CACHE_DIRECTORY,
+  });
+}
+
 export function requireDeveloperIdIdentity(value) {
   const hasControlCharacter =
     typeof value === "string" &&

--- a/apps/desktop/scripts/verify-macos-release.d.mts
+++ b/apps/desktop/scripts/verify-macos-release.d.mts
@@ -58,7 +58,9 @@ export interface VerifyMacosIdentityContinuityDependencies {
     path: string,
     options: { readonly recursive: true; readonly force: true },
   ) => Promise<void>;
+  readonly statAsarFile?: (archivePath: string, filename: string, followLinks: false) => unknown;
   readonly tmpdir?: () => string;
+  readonly uncacheAsar?: (archivePath: string) => boolean;
 }
 
 export interface VerifiedMacosIdentityContinuity {
@@ -75,7 +77,23 @@ export interface VerifiedMacosBaselineApplication {
 
 export interface MacosCodeIdentity {
   readonly codeDirectory: string;
+  readonly codeDirectorySha256: string;
   readonly cdHash: string;
+}
+
+export interface VerifiedMacosReleaseApplication {
+  readonly version: string;
+  readonly enduragentDesktopRelease: true;
+  readonly feedUrl: string;
+  readonly bundleIdentifier: "icu.enduragent.desktop";
+  readonly teamIdentifier: "FA494ACVTF";
+  readonly designatedRequirementSha256: string;
+  readonly codeDirectorySha256: string;
+  readonly cdHash: string;
+}
+
+export interface InspectMacosReleaseApplicationDependencies extends VerifyMacosIdentityContinuityDependencies {
+  readonly readFile?: (path: string) => Promise<Buffer>;
 }
 
 export interface VerifiedMacosReleaseCandidateApplication {
@@ -162,6 +180,10 @@ export function verifyMacosReleaseCandidateApplication(
   options: VerifyMacosIdentityContinuityOptions,
   dependencies?: VerifyMacosIdentityContinuityDependencies,
 ): Promise<VerifiedMacosReleaseCandidateApplication>;
+export function inspectMacosReleaseApplication(
+  application: string,
+  dependencies?: InspectMacosReleaseApplicationDependencies,
+): Promise<VerifiedMacosReleaseApplication>;
 export function verifyMacosReleaseApplicationContents(
   artifactDirectory: string,
   baselineApplication: string,

--- a/apps/desktop/scripts/verify-macos-release.mjs
+++ b/apps/desktop/scripts/verify-macos-release.mjs
@@ -17,9 +17,10 @@ import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { extractFile } from "@electron/asar";
+import { extractFile, statFile, uncache as uncacheAsarFile } from "@electron/asar";
 import { parse } from "yaml";
 import {
+  parseMacosReleaseUpdaterMetadata,
   readCyclingCoachVersion,
   releaseArtifactNames,
   requireStableCalVer,
@@ -32,8 +33,13 @@ const canonicalBundleIdentifier = "icu.enduragent.desktop";
 const canonicalProductName = "Enduragent";
 const canonicalPackageName = "@enduragent/desktop";
 const canonicalTeamIdentifier = "FA494ACVTF";
+const maximumPackageManifestBytes = 16_384;
+const maximumUpdaterMetadataBytes = 16_384;
 const canonicalEntitlements = JSON.stringify({ "com.apple.security.cs.allow-jit": true });
 const canonicalDesignatedRequirement = `identifier "${canonicalBundleIdentifier}" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = ${canonicalTeamIdentifier}`;
+const canonicalDesignatedRequirementSha256 = createHash("sha256")
+  .update(canonicalDesignatedRequirement)
+  .digest("hex");
 const canonicalDesignatedRequirementPattern =
   /^identifier "icu\.enduragent\.desktop" and anchor apple generic and certificate 1\[field\.1\.2\.840\.113635\.100\.6\.2\.6\] (?:exists|\/\* exists \*\/) and certificate leaf\[field\.1\.2\.840\.113635\.100\.6\.1\.13\] (?:exists|\/\* exists \*\/) and certificate leaf\[subject\.OU\] = (?:FA494ACVTF|"FA494ACVTF")$/u;
 
@@ -196,7 +202,16 @@ function parseSignatureMetadata(result) {
   const identifier = exactLine(output, /^Identifier=([^\r\n]+)$/gmu);
   const teamIdentifier = exactLine(output, /^TeamIdentifier=([^\r\n]+)$/gmu);
   const codeDirectory = exactLine(output, /^CodeDirectory ([^\r\n]+)$/gmu);
-  const cdHash = exactLine(output, /^CDHash=([0-9a-f]{40,128})$/gimu)?.toLowerCase();
+  const cdHash = exactLine(output, /^CDHash=([0-9a-f]{40})$/gimu)?.toLowerCase();
+  const candidateCDHashFullLines = Array.from(
+    output.matchAll(/^CandidateCDHashFull[^\r\n]*$/gmu),
+    (match) => match[0],
+  );
+  const candidateCDHashFullMatch =
+    candidateCDHashFullLines.length === 1
+      ? /^CandidateCDHashFull sha256=([0-9a-f]{64})$/iu.exec(candidateCDHashFullLines[0])
+      : null;
+  const codeDirectorySha256 = candidateCDHashFullMatch?.[1].toLowerCase();
   const flags = exactLine(output, /^CodeDirectory [^\r\n]* flags=0x[0-9a-f]+\(([^\r\n)]*)\)/gimu);
   const authorities = Array.from(output.matchAll(/^Authority=([^\r\n]+)$/gmu), (match) => match[1]);
   if (
@@ -204,6 +219,8 @@ function parseSignatureMetadata(result) {
     teamIdentifier !== canonicalTeamIdentifier ||
     codeDirectory === undefined ||
     cdHash === undefined ||
+    codeDirectorySha256 === undefined ||
+    cdHash !== codeDirectorySha256.slice(0, 40) ||
     flags === undefined ||
     !flags
       .split(",")
@@ -221,6 +238,7 @@ function parseSignatureMetadata(result) {
     identifier,
     teamIdentifier,
     codeDirectory,
+    codeDirectorySha256,
     cdHash,
     hardenedRuntime: true,
     authorities: Object.freeze([...authorities]),
@@ -263,61 +281,110 @@ function parseBundleMetadata(result) {
 }
 
 async function readPackagedManifest(archivePath, dependencies) {
+  let entry;
   let manifest;
+  let cacheReadAttempted = false;
+  let failure = null;
   try {
+    dependencies.uncacheAsar(archivePath);
+    cacheReadAttempted = true;
+    entry = dependencies.statAsarFile(archivePath, "package.json", false);
+    if (
+      !exactObject(entry) ||
+      "files" in entry ||
+      "link" in entry ||
+      entry.unpacked === true ||
+      !Number.isSafeInteger(entry.size) ||
+      entry.size <= 0 ||
+      entry.size > maximumPackageManifestBytes
+    ) {
+      fail("macOS package identity is invalid");
+    }
     const bytes = await dependencies.extractAsarFile(archivePath, "package.json");
+    if (
+      !(bytes instanceof Uint8Array) ||
+      bytes.length !== entry.size ||
+      bytes.length > maximumPackageManifestBytes
+    ) {
+      fail("macOS package identity is invalid");
+    }
     manifest = JSON.parse(Buffer.from(bytes).toString("utf8"));
-  } catch {
-    fail("macOS package identity is invalid");
+  } catch (error) {
+    failure =
+      error instanceof MacosReleaseVerificationError
+        ? error
+        : new MacosReleaseVerificationError("macOS package identity is invalid");
   }
+
+  let cleanupFailure;
+  if (cacheReadAttempted) {
+    try {
+      const removed = dependencies.uncacheAsar(archivePath);
+      if (entry !== undefined && removed !== true) {
+        cleanupFailure = new MacosReleaseVerificationError(
+          "macOS package identity cache cleanup failed",
+        );
+      }
+    } catch {
+      cleanupFailure = new MacosReleaseVerificationError(
+        "macOS package identity cache cleanup failed",
+      );
+    }
+  }
+  if (cleanupFailure !== undefined) throw cleanupFailure;
+  if (failure !== null) throw failure;
   if (!exactObject(manifest) || manifest.name !== canonicalPackageName) {
     fail("macOS package identity is invalid");
   }
-  return manifest.version;
+  return Object.freeze({
+    version: manifest.version,
+    enduragentDesktopRelease: manifest.enduragentDesktopRelease,
+  });
 }
 
 async function inspectMacosApplicationIdentity(application, bundle, dependencies) {
   await verifyMacosApplication(application, { executeFile: dependencies.executeFile });
-  const [signatureResult, requirementResult, infoResult, entitlements, packageVersion] =
-    await Promise.all([
-      inspectSystemFile(dependencies.executeFile, "/usr/bin/codesign", [
-        "--display",
-        "--verbose=4",
-        application,
-      ]),
-      inspectSystemFile(dependencies.executeFile, "/usr/bin/codesign", [
-        "--display",
-        "--requirements",
-        "-",
-        application,
-      ]),
-      inspectSystemFile(dependencies.executeFile, "/usr/bin/plutil", [
-        "-convert",
-        "json",
-        "-o",
-        "-",
-        "--",
-        bundle.infoPath,
-      ]),
-      readNormalizedEntitlements(application, dependencies),
-      readPackagedManifest(bundle.archivePath, dependencies),
-    ]);
+  const signatureResult = await inspectSystemFile(dependencies.executeFile, "/usr/bin/codesign", [
+    "--display",
+    "--verbose=4",
+    application,
+  ]);
   const signature = parseSignatureMetadata(signatureResult);
+  const [requirementResult, infoResult, entitlements, packageMetadata] = await Promise.all([
+    inspectSystemFile(dependencies.executeFile, "/usr/bin/codesign", [
+      "--display",
+      "--requirements",
+      "-",
+      application,
+    ]),
+    inspectSystemFile(dependencies.executeFile, "/usr/bin/plutil", [
+      "-convert",
+      "json",
+      "-o",
+      "-",
+      "--",
+      bundle.infoPath,
+    ]),
+    readNormalizedEntitlements(application, dependencies),
+    readPackagedManifest(bundle.archivePath, dependencies),
+  ]);
   const designatedRequirement = parseDesignatedRequirement(requirementResult);
   const version = parseBundleMetadata(infoResult);
-  if (packageVersion !== version) fail("macOS package identity is invalid");
+  if (packageMetadata.version !== version) fail("macOS package identity is invalid");
   if (entitlements !== canonicalEntitlements) fail("macOS signed entitlements are invalid");
   return Object.freeze({
     version,
     identifier: signature.identifier,
     productName: canonicalProductName,
     packageName: canonicalPackageName,
+    enduragentDesktopRelease: packageMetadata.enduragentDesktopRelease,
     teamIdentifier: signature.teamIdentifier,
     designatedRequirement,
     entitlements,
     hardenedRuntime: signature.hardenedRuntime,
     authorities: signature.authorities,
     codeDirectory: signature.codeDirectory,
+    codeDirectorySha256: signature.codeDirectorySha256,
     cdHash: signature.cdHash,
   });
 }
@@ -349,7 +416,9 @@ export async function verifyMacosBaselineApplication(baselineApplication, option
     mkdtemp: overrides.mkdtemp ?? mkdtemp,
     realpath: overrides.realpath ?? realpath,
     rm: overrides.rm ?? rm,
+    statAsarFile: overrides.statAsarFile ?? statFile,
     tmpdir: overrides.tmpdir ?? tmpdir,
+    uncacheAsar: overrides.uncacheAsar ?? uncacheAsarFile,
   };
   const bundle = await requireApplicationBundle(baselineApplication, "baseline", dependencies);
   const baseline = await inspectMacosApplicationIdentity(baselineApplication, bundle, dependencies);
@@ -386,6 +455,7 @@ async function verifyMacosReleaseCandidateBundle(
     entitlements: candidate.entitlements,
     candidateCodeIdentity: Object.freeze({
       codeDirectory: candidate.codeDirectory,
+      codeDirectorySha256: candidate.codeDirectorySha256,
       cdHash: candidate.cdHash,
     }),
   });
@@ -412,7 +482,9 @@ export async function verifyMacosReleaseCandidateApplication(
     mkdtemp: overrides.mkdtemp ?? mkdtemp,
     realpath: overrides.realpath ?? realpath,
     rm: overrides.rm ?? rm,
+    statAsarFile: overrides.statAsarFile ?? statFile,
     tmpdir: overrides.tmpdir ?? tmpdir,
+    uncacheAsar: overrides.uncacheAsar ?? uncacheAsarFile,
   };
   const bundle = await requireApplicationBundle(candidateApplication, "candidate", dependencies);
   return verifyMacosReleaseCandidateBundle(
@@ -421,6 +493,167 @@ export async function verifyMacosReleaseCandidateApplication(
     bundle,
     dependencies,
   );
+}
+
+async function readMacosReleaseUpdaterMetadata(application, dependencies) {
+  const path = join(application, "Contents/Resources/app-update.yml");
+  let before;
+  let bytes;
+  try {
+    before = await dependencies.lstat(path);
+  } catch {
+    fail("macOS release updater metadata is invalid");
+  }
+  if (
+    before.isSymbolicLink() ||
+    !before.isFile() ||
+    !Number.isSafeInteger(before.size) ||
+    before.size <= 0 ||
+    before.size > maximumUpdaterMetadataBytes
+  ) {
+    fail("macOS release updater metadata is invalid");
+  }
+  try {
+    bytes = await dependencies.readFile(path);
+  } catch {
+    fail("macOS release updater metadata is invalid");
+  }
+  let after;
+  try {
+    after = await dependencies.lstat(path);
+  } catch {
+    fail("macOS release updater metadata is invalid");
+  }
+  if (
+    after.isSymbolicLink() ||
+    !after.isFile() ||
+    !(bytes instanceof Uint8Array) ||
+    bytes.length !== before.size ||
+    after.dev !== before.dev ||
+    after.ino !== before.ino ||
+    after.mode !== before.mode ||
+    after.size !== before.size ||
+    after.mtimeMs !== before.mtimeMs ||
+    after.ctimeMs !== before.ctimeMs
+  ) {
+    fail("macOS release updater metadata is invalid");
+  }
+  try {
+    return parseMacosReleaseUpdaterMetadata(bytes);
+  } catch {
+    fail("macOS release updater metadata is invalid");
+  }
+}
+
+async function copyMacosReleaseApplication(source, destination, dependencies) {
+  try {
+    await dependencies.executeFile("/usr/bin/ditto", [
+      "--rsrc",
+      "--extattr",
+      "--qtn",
+      "--acl",
+      source,
+      destination,
+    ]);
+  } catch {
+    fail("macOS release application snapshot failed");
+  }
+}
+
+export async function inspectMacosReleaseApplication(application, overrides = {}) {
+  if (
+    typeof application !== "string" ||
+    !isAbsolute(application) ||
+    !application.endsWith(".app")
+  ) {
+    fail("release application path must be one absolute .app path");
+  }
+  const dependencies = {
+    executeFile: overrides.executeFile ?? executeSystemFile,
+    extractAsarFile: overrides.extractAsarFile ?? extractFile,
+    lstat: overrides.lstat ?? lstat,
+    mkdtemp: overrides.mkdtemp ?? mkdtemp,
+    readFile: overrides.readFile ?? readFile,
+    realpath: overrides.realpath ?? realpath,
+    rm: overrides.rm ?? rm,
+    statAsarFile: overrides.statAsarFile ?? statFile,
+    tmpdir: overrides.tmpdir ?? tmpdir,
+    uncacheAsar: overrides.uncacheAsar ?? uncacheAsarFile,
+  };
+
+  await requireApplicationBundle(application, "release", dependencies);
+  await verifyMacosApplication(application, { executeFile: dependencies.executeFile });
+
+  const temporaryPrefix = join(dependencies.tmpdir(), "enduragent-release-inspector-");
+  let temporaryDirectory;
+  let temporaryDirectoryIdentity;
+  let result;
+  let failure = null;
+  try {
+    const candidate = await dependencies.mkdtemp(temporaryPrefix);
+    temporaryDirectoryIdentity = await requireSecureTemporaryDirectory(
+      candidate,
+      temporaryPrefix,
+      dependencies,
+    );
+    temporaryDirectory = candidate;
+    const snapshot = join(temporaryDirectory, `${canonicalProductName}.app`);
+    await copyMacosReleaseApplication(application, snapshot, dependencies);
+    const bundle = await requireApplicationBundle(snapshot, "release snapshot", dependencies);
+    const identity = await inspectMacosApplicationIdentity(snapshot, bundle, dependencies);
+    if (identity.enduragentDesktopRelease !== true) {
+      fail("macOS release marker is invalid");
+    }
+    const updater = await readMacosReleaseUpdaterMetadata(snapshot, dependencies);
+    result = Object.freeze({
+      version: identity.version,
+      enduragentDesktopRelease: true,
+      feedUrl: updater.url,
+      bundleIdentifier: identity.identifier,
+      teamIdentifier: identity.teamIdentifier,
+      designatedRequirementSha256: canonicalDesignatedRequirementSha256,
+      codeDirectorySha256: identity.codeDirectorySha256,
+      cdHash: identity.cdHash,
+    });
+  } catch (error) {
+    failure =
+      error instanceof MacosReleaseVerificationError
+        ? error
+        : new MacosReleaseVerificationError("macOS release application inspection failed");
+  }
+
+  let cleanupFailure;
+  if (temporaryDirectory !== undefined && temporaryDirectoryIdentity !== undefined) {
+    try {
+      await requireSameSecureDirectory(
+        temporaryDirectory,
+        temporaryDirectoryIdentity,
+        dependencies,
+        "macOS release application snapshot cleanup failed",
+      );
+      await dependencies.rm(temporaryDirectory, { recursive: true, force: true });
+      try {
+        await dependencies.lstat(temporaryDirectory);
+        cleanupFailure = new MacosReleaseVerificationError(
+          "macOS release application snapshot cleanup failed",
+        );
+      } catch (error) {
+        if (!missingPathError(error)) {
+          cleanupFailure = new MacosReleaseVerificationError(
+            "macOS release application snapshot cleanup failed",
+          );
+        }
+      }
+    } catch {
+      cleanupFailure = new MacosReleaseVerificationError(
+        "macOS release application snapshot cleanup failed",
+      );
+    }
+  }
+  if (cleanupFailure !== undefined) throw cleanupFailure;
+  if (failure !== null) throw failure;
+  if (result === undefined) fail("macOS release application inspection failed");
+  return result;
 }
 
 export async function verifyMacosIdentityContinuity(
@@ -451,7 +684,9 @@ export async function verifyMacosIdentityContinuity(
     mkdtemp: overrides.mkdtemp ?? mkdtemp,
     realpath: overrides.realpath ?? realpath,
     rm: overrides.rm ?? rm,
+    statAsarFile: overrides.statAsarFile ?? statFile,
     tmpdir: overrides.tmpdir ?? tmpdir,
+    uncacheAsar: overrides.uncacheAsar ?? uncacheAsarFile,
   };
   const [baselineBundle, candidateBundle] = await Promise.all([
     requireApplicationBundle(baselineApplication, "baseline", dependencies),
@@ -472,6 +707,7 @@ export async function verifyMacosIdentityContinuity(
   const candidate = {
     ...candidateIdentity,
     codeDirectory: candidateIdentity.candidateCodeIdentity.codeDirectory,
+    codeDirectorySha256: candidateIdentity.candidateCodeIdentity.codeDirectorySha256,
     cdHash: candidateIdentity.candidateCodeIdentity.cdHash,
   };
   if (!olderStableCalVer(baseline.version, candidate.version)) {
@@ -491,6 +727,7 @@ export async function verifyMacosIdentityContinuity(
     teamIdentifier: candidate.teamIdentifier,
     candidateCodeIdentity: Object.freeze({
       codeDirectory: candidate.codeDirectory,
+      codeDirectorySha256: candidate.codeDirectorySha256,
       cdHash: candidate.cdHash,
     }),
   });
@@ -502,8 +739,11 @@ function requireCandidateCodeIdentity(value) {
     typeof value.codeDirectory !== "string" ||
     value.codeDirectory.length === 0 ||
     value.codeDirectory.length > 16_384 ||
+    typeof value.codeDirectorySha256 !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(value.codeDirectorySha256) ||
     typeof value.cdHash !== "string" ||
-    !/^[0-9a-f]{40,128}$/u.test(value.cdHash)
+    !/^[0-9a-f]{40}$/u.test(value.cdHash) ||
+    value.cdHash !== value.codeDirectorySha256.slice(0, 40)
   ) {
     fail("loose candidate code identity is invalid");
   }
@@ -902,6 +1142,7 @@ async function inspectPackagedApplication(application, expectedCodeIdentity, ver
   const actualCodeIdentity = requireCandidateCodeIdentity(verifiedCandidate?.candidateCodeIdentity);
   if (
     actualCodeIdentity.codeDirectory !== expectedCodeIdentity.codeDirectory ||
+    actualCodeIdentity.codeDirectorySha256 !== expectedCodeIdentity.codeDirectorySha256 ||
     actualCodeIdentity.cdHash !== expectedCodeIdentity.cdHash
   ) {
     fail("packaged macOS application differs from the loose candidate");

--- a/apps/desktop/scripts/verify-package-layout.mjs
+++ b/apps/desktop/scripts/verify-package-layout.mjs
@@ -6,7 +6,7 @@ import { isDeepStrictEqual } from "node:util";
 import { extractFile, listPackage, statFile, uncache } from "@electron/asar";
 import { parse } from "yaml";
 import {
-  DESKTOP_UPDATER_CACHE_DIRECTORY,
+  parseMacosReleaseUpdaterMetadata,
   requireGenericFeedUrl,
   requireStableCalVer,
 } from "./macos-release-plan.mjs";
@@ -668,17 +668,11 @@ function validateRequiredAsarFiles(asar, sourceManifest, release, development) {
 function validateAppUpdate(bytes, release) {
   let update;
   try {
-    update = parse(bytes.toString("utf8"));
+    update = parseMacosReleaseUpdaterMetadata(bytes);
   } catch {
     fail("invalid release app-update.yml", "Contents/Resources/app-update.yml");
   }
-  const expected = {
-    provider: "generic",
-    url: release.feedUrl,
-    channel: "latest",
-    updaterCacheDirName: DESKTOP_UPDATER_CACHE_DIRECTORY,
-  };
-  if (!exactObject(update) || !isDeepStrictEqual(update, expected)) {
+  if (update.url !== release.feedUrl) {
     fail("invalid release app-update.yml", "Contents/Resources/app-update.yml");
   }
 }

--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  cp,
   lstat,
   mkdir,
   mkdtemp,
@@ -15,10 +16,13 @@ import {
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { finished } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
+import { createPackage, uncache } from "@electron/asar";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse, stringify } from "yaml";
 import {
+  inspectMacosReleaseApplication,
   verifyMacosApplication,
   verifyMacosBaselineApplication,
   verifyMacosGenesisReleaseApplicationContents,
@@ -125,13 +129,16 @@ interface SignedApplicationMetadata {
   entitlements: Record<string, unknown>;
   extraAuthorities: string[];
   codeDirectory: string;
+  candidateCDHashFullLines: string[];
   cdHash: string;
 }
 
 const canonicalDesignatedRequirement =
   'identifier "icu.enduragent.desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] exists and certificate leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = FA494ACVTF';
+const syntheticPackageManifestBytes = 8_192;
 
 function signedApplicationMetadata(version: string, cdHash: string): SignedApplicationMetadata {
+  const codeDirectorySha256 = `${cdHash}${cdHash.slice(0, 24)}`;
   return {
     version,
     teamIdentifier: "FA494ACVTF",
@@ -139,6 +146,7 @@ function signedApplicationMetadata(version: string, cdHash: string): SignedAppli
     requirement: canonicalDesignatedRequirement,
     flags: "runtime",
     codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+    candidateCDHashFullLines: [`CandidateCDHashFull sha256=${codeDirectorySha256}`],
     cdHash,
     info: {
       CFBundleIdentifier: "icu.enduragent.desktop",
@@ -164,23 +172,59 @@ async function signedIdentityFixture() {
   roots.push(root);
   const baseline = join(root, "baseline/Enduragent.app");
   const candidate = join(root, "candidate/Enduragent.app");
-  for (const application of [baseline, candidate]) {
+  for (const [index, application] of [baseline, candidate].entries()) {
     await mkdir(join(application, "Contents/Resources"), { recursive: true });
+    const archiveSource = join(root, `archive-source-${index}`);
+    await mkdir(archiveSource);
     await Promise.all([
       writeFile(join(application, "Contents/Info.plist"), "synthetic plist authority\n"),
-      writeFile(join(application, "Contents/Resources/app.asar"), "synthetic ASAR authority\n"),
+      writeFile(
+        join(archiveSource, "package.json"),
+        "{}".padEnd(syntheticPackageManifestBytes, " "),
+      ),
+      writeFile(
+        join(application, "Contents/Resources/app-update.yml"),
+        [
+          "provider: generic",
+          "url: https://github.com/yerzhansa/enduragent/releases/latest/download/",
+          "channel: latest",
+          "updaterCacheDirName: '@enduragentdesktop-updater'",
+          "",
+        ].join("\n"),
+      ),
     ]);
+    const archive = await createPackage(
+      archiveSource,
+      join(application, "Contents/Resources/app.asar"),
+    );
+    await finished(archive);
   }
   const metadata = new Map<string, SignedApplicationMetadata>([
     [baseline, signedApplicationMetadata("2026.7.1", "a".repeat(40))],
     [candidate, signedApplicationMetadata("2026.7.2", "b".repeat(40))],
   ]);
   const applicationForPath = (path: string) =>
-    path.startsWith(baseline) ? baseline : path.startsWith(candidate) ? candidate : undefined;
+    [...metadata.keys()].find(
+      (application) => path === application || path.startsWith(`${application}/`),
+    );
   const temporaryEntitlements = new Map<string, Record<string, unknown>>();
   const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
     const finalArgument = arguments_.at(-1);
     if (typeof finalArgument !== "string") throw new Error("synthetic command shape rejected");
+    if (executable === "/usr/bin/ditto") {
+      const source = arguments_.at(-2);
+      if (
+        typeof source !== "string" ||
+        arguments_.slice(0, -2).join(" ") !== "--rsrc --extattr --qtn --acl" ||
+        metadata.has(source) === false ||
+        metadata.has(finalArgument)
+      ) {
+        throw new Error("synthetic application snapshot shape rejected");
+      }
+      await cp(source, finalArgument, { recursive: true });
+      metadata.set(finalArgument, structuredClone(metadata.get(source)!));
+      return { stdout: "", stderr: "" };
+    }
     if (executable === "/usr/bin/xcrun" || executable === "/usr/sbin/spctl") {
       return { stdout: "", stderr: "" };
     }
@@ -197,6 +241,7 @@ async function signedIdentityFixture() {
             `Executable=${application}/Contents/MacOS/Enduragent`,
             `Identifier=${selected.identifier}`,
             `CodeDirectory ${selected.codeDirectory.replace(`(${selected.codeDirectory.includes("runtime") ? "runtime" : "none"})`, `(${selected.flags})`)}`,
+            ...selected.candidateCDHashFullLines,
             `CDHash=${selected.cdHash}`,
             `Authority=Developer ID Application: Enduragent Test (${selected.teamIdentifier})`,
             "Authority=Developer ID Certification Authority",
@@ -260,12 +305,331 @@ async function signedIdentityFixture() {
   const extractAsarFile = vi.fn(async (archivePath: string) => {
     const application = applicationForPath(archivePath);
     if (application === undefined) throw new Error("synthetic ASAR path rejected");
-    return Buffer.from(JSON.stringify(metadata.get(application)!.manifest));
+    const serialized = Buffer.from(JSON.stringify(metadata.get(application)!.manifest));
+    if (serialized.length > syntheticPackageManifestBytes) {
+      throw new Error("synthetic manifest exceeds fixed ASAR entry");
+    }
+    return Buffer.concat([
+      serialized,
+      Buffer.alloc(syntheticPackageManifestBytes - serialized.length, 0x20),
+    ]);
   });
   return { baseline, candidate, executeFile, extractAsarFile, metadata };
 }
 
 describe("macOS signed identity continuity", () => {
+  it("inspects one marked release application through the canonical native identity pipeline", async () => {
+    const fixture = await signedIdentityFixture();
+    const uncacheAsar = vi.fn(uncache);
+
+    const inspected = await inspectMacosReleaseApplication(fixture.candidate, {
+      executeFile: fixture.executeFile,
+      extractAsarFile: fixture.extractAsarFile,
+      uncacheAsar,
+    });
+
+    expect(inspected).toEqual({
+      version,
+      enduragentDesktopRelease: true,
+      feedUrl: "https://github.com/yerzhansa/enduragent/releases/latest/download/",
+      bundleIdentifier: "icu.enduragent.desktop",
+      teamIdentifier: "FA494ACVTF",
+      designatedRequirementSha256: createHash("sha256")
+        .update(canonicalDesignatedRequirement)
+        .digest("hex"),
+      codeDirectorySha256: "b".repeat(64),
+      cdHash: "b".repeat(40),
+    });
+    expect(Object.isFrozen(inspected)).toBe(true);
+    expect(uncacheAsar.mock.results.map(({ value }) => value)).toEqual([false, true]);
+  });
+
+  it.each(["missing", "false", "nested"])("rejects a %s packaged release marker", async (shape) => {
+    const fixture = await signedIdentityFixture();
+    const manifest = fixture.metadata.get(fixture.candidate)!.manifest;
+    if (shape === "missing") delete manifest.enduragentDesktopRelease;
+    else if (shape === "false") manifest.enduragentDesktopRelease = false;
+    else {
+      delete manifest.enduragentDesktopRelease;
+      manifest.build = { enduragentDesktopRelease: true };
+    }
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+      }),
+    ).rejects.toThrow("macOS release marker is invalid");
+  });
+
+  it("rejects a noncanonical signer before inspecting the packaged manifest", async () => {
+    const fixture = await signedIdentityFixture();
+    fixture.metadata.get(fixture.candidate)!.teamIdentifier = "ZZZZZ99999";
+    const statAsarFile = vi.fn((_archivePath: string, _filename: string, _followLinks: false) => ({
+      size: syntheticPackageManifestBytes,
+    }));
+    const uncacheAsar = vi.fn(() => false);
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+        statAsarFile,
+        uncacheAsar,
+      }),
+    ).rejects.toThrow("macOS signed identity is invalid");
+    expect(statAsarFile).not.toHaveBeenCalled();
+    expect(fixture.extractAsarFile).not.toHaveBeenCalled();
+    expect(uncacheAsar).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized packaged manifest metadata before extracting bytes", async () => {
+    const fixture = await signedIdentityFixture();
+    const statAsarFile = vi.fn((_archivePath: string, _filename: string, _followLinks: false) => ({
+      size: 16_385,
+    }));
+    const uncacheAsar = vi.fn().mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+        statAsarFile,
+        uncacheAsar,
+      }),
+    ).rejects.toThrow("macOS package identity is invalid");
+    expect(statAsarFile).toHaveBeenCalledOnce();
+    expect(fixture.extractAsarFile).not.toHaveBeenCalled();
+    expect(uncacheAsar).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects inspection when packaged manifest cache eviction cannot be confirmed", async () => {
+    const fixture = await signedIdentityFixture();
+    const statAsarFile = vi.fn((_archivePath: string, _filename: string, _followLinks: false) => ({
+      size: syntheticPackageManifestBytes,
+    }));
+    const uncacheAsar = vi.fn(() => false);
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+        statAsarFile,
+        uncacheAsar,
+      }),
+    ).rejects.toThrow("macOS package identity cache cleanup failed");
+    expect(fixture.extractAsarFile).toHaveBeenCalledOnce();
+    expect(uncacheAsar).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [
+      "provider",
+      "provider: github\nurl: https://github.com/yerzhansa/enduragent/releases/latest/download/\nchannel: latest\nupdaterCacheDirName: '@enduragentdesktop-updater'\n",
+    ],
+    [
+      "channel",
+      "provider: generic\nurl: https://github.com/yerzhansa/enduragent/releases/latest/download/\nchannel: beta\nupdaterCacheDirName: '@enduragentdesktop-updater'\n",
+    ],
+    [
+      "cache directory",
+      "provider: generic\nurl: https://github.com/yerzhansa/enduragent/releases/latest/download/\nchannel: latest\nupdaterCacheDirName: alternate\n",
+    ],
+    [
+      "HTTPS feed",
+      "provider: generic\nurl: http://github.com/yerzhansa/enduragent/releases/latest/download/\nchannel: latest\nupdaterCacheDirName: '@enduragentdesktop-updater'\n",
+    ],
+    [
+      "exact keys",
+      "provider: generic\nurl: https://github.com/yerzhansa/enduragent/releases/latest/download/\nchannel: latest\nupdaterCacheDirName: '@enduragentdesktop-updater'\nextra: forbidden\n",
+    ],
+  ])("rejects updater metadata with invalid %s", async (_label, contents) => {
+    const fixture = await signedIdentityFixture();
+    await writeFile(join(fixture.candidate, "Contents/Resources/app-update.yml"), contents);
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+      }),
+    ).rejects.toThrow("macOS release updater metadata is invalid");
+  });
+
+  it.each(["missing", "directory", "symlink", "malformed"])(
+    "rejects %s updater metadata",
+    async (shape) => {
+      const fixture = await signedIdentityFixture();
+      const updaterPath = join(fixture.candidate, "Contents/Resources/app-update.yml");
+      await rm(updaterPath);
+      if (shape === "directory") await mkdir(updaterPath);
+      if (shape === "symlink") await symlink("app.asar", updaterPath);
+      if (shape === "malformed") await writeFile(updaterPath, "[unterminated\n");
+
+      await expect(
+        inspectMacosReleaseApplication(fixture.candidate, {
+          executeFile: fixture.executeFile,
+          extractAsarFile: fixture.extractAsarFile,
+        }),
+      ).rejects.toThrow("macOS release updater metadata is invalid");
+    },
+  );
+
+  it("rejects updater metadata that changes while it is read", async () => {
+    const fixture = await signedIdentityFixture();
+    let updaterInspectionCount = 0;
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+        lstat: async (path) => {
+          const stat = await lstat(path);
+          if (
+            !path.endsWith("/Contents/Resources/app-update.yml") ||
+            ++updaterInspectionCount === 1
+          ) {
+            return stat;
+          }
+          return new Proxy(stat, {
+            get(target, property) {
+              if (property === "mtimeMs") return target.mtimeMs + 1;
+              const value = Reflect.get(target, property, target);
+              return typeof value === "function" ? value.bind(target) : value;
+            },
+          });
+        },
+      }),
+    ).rejects.toThrow("macOS release updater metadata is invalid");
+  });
+
+  it("rejects oversized updater metadata without reading it", async () => {
+    const fixture = await signedIdentityFixture();
+    await writeFile(
+      join(fixture.candidate, "Contents/Resources/app-update.yml"),
+      "x".repeat(16_385),
+    );
+    const readUpdater = vi.fn((path: string) => readFile(path));
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+        readFile: readUpdater,
+      }),
+    ).rejects.toThrow("macOS release updater metadata is invalid");
+    expect(readUpdater).not.toHaveBeenCalled();
+  });
+
+  it("derives marker and updater evidence only from the verified snapshot", async () => {
+    const fixture = await signedIdentityFixture();
+    const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+      const result = await fixture.executeFile(executable, arguments_);
+      if (executable === "/usr/bin/ditto") {
+        fixture.metadata.get(fixture.candidate)!.manifest.enduragentDesktopRelease = false;
+        await writeFile(
+          join(fixture.candidate, "Contents/Resources/app-update.yml"),
+          "provider: github\nurl: http://invalid.example/\n",
+        );
+      }
+      return result;
+    });
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+      }),
+    ).resolves.toMatchObject({
+      enduragentDesktopRelease: true,
+      feedUrl: "https://github.com/yerzhansa/enduragent/releases/latest/download/",
+    });
+    expect(executeFile).toHaveBeenCalledWith(
+      "/usr/bin/ditto",
+      expect.arrayContaining([fixture.candidate]),
+    );
+  });
+
+  it("does not read updater metadata before the snapshot signature verifies", async () => {
+    const fixture = await signedIdentityFixture();
+    const readUpdater = vi.fn((path: string) => readFile(path));
+    const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+      const application = arguments_.at(-1);
+      if (
+        executable === "/usr/bin/codesign" &&
+        arguments_.includes("--verify") &&
+        typeof application === "string" &&
+        application.includes("/enduragent-release-inspector-")
+      ) {
+        throw new Error("synthetic snapshot signature failure");
+      }
+      return fixture.executeFile(executable, arguments_);
+    });
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+        readFile: readUpdater,
+      }),
+    ).rejects.toThrow("macOS application signature verification failed");
+    expect(readUpdater).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["absent", []],
+    [
+      "duplicate",
+      [
+        `CandidateCDHashFull sha256=${"b".repeat(64)}`,
+        `CandidateCDHashFull sha256=${"b".repeat(64)}`,
+      ],
+    ],
+    ["malformed", ["CandidateCDHashFull sha256=not-a-digest"]],
+    ["CDHash prefix mismatch", [`CandidateCDHashFull sha256=${"c".repeat(64)}`]],
+  ])("rejects an %s full CodeDirectory digest", async (_label, lines) => {
+    const fixture = await signedIdentityFixture();
+    fixture.metadata.get(fixture.candidate)!.candidateCDHashFullLines = lines;
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+      }),
+    ).rejects.toThrow("macOS signed identity is invalid");
+  });
+
+  it("normalizes the full CodeDirectory digest and CDHash to lowercase", async () => {
+    const fixture = await signedIdentityFixture();
+    const metadata = fixture.metadata.get(fixture.candidate)!;
+    metadata.candidateCDHashFullLines = [`CandidateCDHashFull sha256=${"B".repeat(64)}`];
+    metadata.cdHash = "B".repeat(40);
+
+    await expect(
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+      }),
+    ).resolves.toMatchObject({
+      codeDirectorySha256: "b".repeat(64),
+      cdHash: "b".repeat(40),
+    });
+  });
+
+  it.each([undefined, "Enduragent.app", "/tmp/Enduragent"])(
+    "rejects a non-absolute or non-app inspector input before native inspection: %s",
+    async (application) => {
+      const fixture = await signedIdentityFixture();
+
+      await expect(
+        inspectMacosReleaseApplication(application as never, {
+          executeFile: fixture.executeFile,
+          extractAsarFile: fixture.extractAsarFile,
+        }),
+      ).rejects.toThrow("release application path must be one absolute .app path");
+      expect(fixture.executeFile).not.toHaveBeenCalled();
+    },
+  );
+
   it("proves a canonical candidate without requiring an older baseline", async () => {
     const fixture = await signedIdentityFixture();
 
@@ -294,6 +658,7 @@ describe("macOS signed identity continuity", () => {
       entitlements: JSON.stringify({ "com.apple.security.cs.allow-jit": true }),
       candidateCodeIdentity: {
         codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+        codeDirectorySha256: "b".repeat(64),
         cdHash: "b".repeat(40),
       },
     });
@@ -383,6 +748,7 @@ describe("macOS signed identity continuity", () => {
       teamIdentifier: "FA494ACVTF",
       candidateCodeIdentity: {
         codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+        codeDirectorySha256: "b".repeat(64),
         cdHash: "b".repeat(40),
       },
     });
@@ -464,6 +830,21 @@ describe("macOS signed identity continuity", () => {
         { executeFile: fixture.executeFile, extractAsarFile: fixture.extractAsarFile },
       ),
     ).resolves.toMatchObject({ teamIdentifier: "FA494ACVTF" });
+
+    const [commented, canonical] = await Promise.all([
+      inspectMacosReleaseApplication(fixture.baseline, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+      }),
+      inspectMacosReleaseApplication(fixture.candidate, {
+        executeFile: fixture.executeFile,
+        extractAsarFile: fixture.extractAsarFile,
+      }),
+    ]);
+    expect(commented.designatedRequirementSha256).toBe(canonical.designatedRequirementSha256);
+    expect(canonical.designatedRequirementSha256).toBe(
+      createHash("sha256").update(canonicalDesignatedRequirement).digest("hex"),
+    );
   });
 
   it.each([
@@ -707,11 +1088,13 @@ type PackagedRootShape =
   | "valid";
 interface PackagedCodeIdentity {
   readonly codeDirectory: string;
+  readonly codeDirectorySha256: string;
   readonly cdHash: string;
 }
 
 const looseCandidateCodeIdentity: PackagedCodeIdentity = Object.freeze({
   codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+  codeDirectorySha256: "b".repeat(64),
   cdHash: "b".repeat(40),
 });
 
@@ -1107,6 +1490,7 @@ describe("macOS packaged application identity binding", () => {
     async (source) => {
       const mismatchedCodeIdentity = {
         ...looseCandidateCodeIdentity,
+        codeDirectorySha256: "c".repeat(64),
         cdHash: "c".repeat(40),
       };
       const fixture = await packagedApplicationFixture(
@@ -1399,7 +1783,31 @@ describe("macOS packaged application identity binding", () => {
     ["DMG", { dmgCodeIdentity: { ...looseCandidateCodeIdentity, codeDirectory: "different" } }],
     [
       "same signed identity but different CDHash",
-      { dmgCodeIdentity: { ...looseCandidateCodeIdentity, cdHash: "c".repeat(40) } },
+      {
+        dmgCodeIdentity: {
+          ...looseCandidateCodeIdentity,
+          codeDirectorySha256: "c".repeat(64),
+          cdHash: "c".repeat(40),
+        },
+      },
+    ],
+    [
+      "ZIP with the same signed identity and CDHash prefix but different full digest content",
+      {
+        zipCodeIdentity: {
+          ...looseCandidateCodeIdentity,
+          codeDirectorySha256: `${"b".repeat(40)}${"c".repeat(24)}`,
+        },
+      },
+    ],
+    [
+      "DMG with the same signed identity and CDHash prefix but different full digest content",
+      {
+        dmgCodeIdentity: {
+          ...looseCandidateCodeIdentity,
+          codeDirectorySha256: `${"b".repeat(40)}${"c".repeat(24)}`,
+        },
+      },
     ],
   ])("rejects %s application drift", async (_label, options) => {
     const fixture = await packagedApplicationFixture(options);
@@ -1608,6 +2016,7 @@ describe("macOS release artifact envelope", () => {
       entitlements: JSON.stringify({ "com.apple.security.cs.allow-jit": true }),
       candidateCodeIdentity: Object.freeze({
         codeDirectory: looseCandidateCodeIdentity.codeDirectory,
+        codeDirectorySha256: looseCandidateCodeIdentity.codeDirectorySha256,
         cdHash: looseCandidateCodeIdentity.cdHash,
       }),
     });
@@ -1669,6 +2078,7 @@ describe("macOS release artifact envelope", () => {
       teamIdentifier: "FA494ACVTF",
       candidateCodeIdentity: Object.freeze({
         codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+        codeDirectorySha256: "b".repeat(64),
         cdHash: "b".repeat(40),
       }),
     });

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -52,6 +52,7 @@ const verifiedLooseIdentity = Object.freeze({
   teamIdentifier: "FA494ACVTF",
   candidateCodeIdentity: Object.freeze({
     codeDirectory: "v=20500 size=100 flags=0x10000(runtime) hashes=1+7 location=embedded",
+    codeDirectorySha256: "b".repeat(64),
     cdHash: "b".repeat(40),
   }),
 });


### PR DESCRIPTION
Summary
- add a reusable signed application inspector for updater acceptance
- verify full CodeDirectory evidence, bundle identity, Team identity, and notarization
- reject unsafe extraction paths and untrusted nested application layouts

Dependency
- stacked on #510

Verification
- pnpm check