### PR TITLE
ci(desktop): activate signed update transaction

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -47,11 +47,15 @@ jobs:
       contents: read
     outputs:
       baseline_tag: ${{ steps.baseline.outputs.baseline_tag }}
+      baseline_version: ${{ steps.baseline.outputs.baseline_version }}
       baseline_release_id: ${{ steps.baseline.outputs.baseline_release_id }}
       baseline_commit: ${{ steps.baseline.outputs.baseline_commit }}
       baseline_zip_sha256: ${{ steps.baseline.outputs.baseline_zip_sha256 }}
       baseline_signing_identity: ${{ steps.baseline.outputs.baseline_signing_identity }}
       baseline_cdhash: ${{ steps.baseline.outputs.baseline_cdhash }}
+      baseline_artifact_name: desktop-baseline-${{ github.run_id }}-${{ github.run_attempt }}
+      baseline_artifact_id: ${{ steps.baseline-artifact.outputs.artifact-id }}
+      baseline_artifact_digest: ${{ steps.baseline-artifact.outputs.artifact-digest }}
       cdhash: ${{ steps.signing-evidence.outputs.cdhash }}
       code_directory_sha256: ${{ steps.signing-evidence.outputs.code_directory_sha256 }}
       signing_identity: ${{ steps.signing-evidence.outputs.signing_identity }}
@@ -93,8 +97,8 @@ jobs:
           if [ "$RELEASE_MODE" = 'steady' ]; then
             BASELINE_ZIP=$(find "$RUNNER_TEMP/desktop-baseline" -maxdepth 1 -type f -name '*-arm64.zip' -print -quit)
             test -n "$BASELINE_ZIP"
-            ditto -x -k "$BASELINE_ZIP" "$RUNNER_TEMP/desktop-baseline/unpacked"
-            BASELINE_APP=$(find "$RUNNER_TEMP/desktop-baseline/unpacked" -maxdepth 2 -type d -name Enduragent.app -print -quit)
+            ditto -x -k "$BASELINE_ZIP" "$RUNNER_TEMP/desktop-baseline-unpacked"
+            BASELINE_APP=$(find "$RUNNER_TEMP/desktop-baseline-unpacked" -maxdepth 2 -type d -name Enduragent.app -print -quit)
             if [ -z "$BASELINE_APP" ]; then
               echo '::error::Signed baseline application is missing from the prior release ZIP'
               exit 1
@@ -206,6 +210,16 @@ jobs:
         with:
           name: desktop-release-${{ github.run_id }}-${{ github.run_attempt }}
           path: apps/desktop/dist/release-envelope-${{ inputs.version }}-mac-arm64/
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
+      - name: Upload sealed baseline updater envelope
+        if: ${{ inputs.mode == 'steady' }}
+        id: baseline-artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-baseline-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/desktop-baseline/
           if-no-files-found: error
           compression-level: 0
           retention-days: 90
@@ -426,30 +440,17 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm desktop-release:transaction -- stage --directory "$RUNNER_TEMP/desktop-release"
 
-  desktop-activation-not-implemented:
-    runs-on: ubuntu-latest
-    needs: stage-private-draft
-    if: ${{ inputs.mode == 'steady' }}
-    permissions:
-      contents: read
-    steps:
-      - name: Refuse incomplete public activation transaction
-        run: |
-          echo '::error::Public activation, compensation, production-feed roundtrip, and GA body activation have not landed; stable publication fails closed.'
-          exit 1
-
   publish-assets:
     runs-on: ubuntu-latest
     needs: [sign-macos, stage-private-draft]
-    if: ${{ false && inputs.mode == 'steady' }}
     environment: desktop-macos-publication
     permissions:
       actions: read
       contents: write
     outputs:
-      latest_id: ${{ steps.publish.outputs.latest_id }}
-      latest_tag: ${{ steps.publish.outputs.latest_tag }}
-      latest_metadata_sha256: ${{ steps.publish.outputs.latest_metadata_sha256 }}
+      latest_id: ${{ steps.observe.outputs.latest_id }}
+      latest_tag: ${{ steps.observe.outputs.latest_tag }}
+      latest_metadata_sha256: ${{ steps.observe.outputs.latest_metadata_sha256 }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -477,19 +478,30 @@ jobs:
           printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
           test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
-      - name: Publish verified release without changing latest
-        id: publish
+      - name: Bind latest before public mutation
+        id: observe
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          pnpm desktop-release:transaction -- publish \
+          pnpm desktop-release:transaction -- observe \
             --directory "$RUNNER_TEMP/desktop-release" \
             --github-output "$GITHUB_OUTPUT"
+      - name: Publish verified release without changing latest
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          EXPECTED_LATEST_ID: ${{ steps.observe.outputs.latest_id }}
+          EXPECTED_LATEST_TAG: ${{ steps.observe.outputs.latest_tag }}
+          EXPECTED_LATEST_METADATA_SHA256: ${{ steps.observe.outputs.latest_metadata_sha256 }}
+        run: |
+          pnpm desktop-release:transaction -- publish \
+            --directory "$RUNNER_TEMP/desktop-release" \
+            --expected-latest-id "$EXPECTED_LATEST_ID" \
+            --expected-latest-tag "$EXPECTED_LATEST_TAG" \
+            --expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"
 
   promote-latest:
     runs-on: ubuntu-latest
     needs: [sign-macos, publish-assets]
-    if: ${{ inputs.mode == 'steady' }}
     environment: desktop-macos-latest
     permissions:
       actions: read
@@ -530,6 +542,182 @@ jobs:
         run: |
           pnpm desktop-release:transaction -- promote \
             --directory "$RUNNER_TEMP/desktop-release" \
+            --expected-latest-id "$EXPECTED_LATEST_ID" \
+            --expected-latest-tag "$EXPECTED_LATEST_TAG" \
+            --expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"
+
+  verify-production-update:
+    runs-on: macos-15
+    needs: [sign-macos, promote-latest]
+    if: ${{ inputs.mode == 'steady' }}
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.commit }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
+          path: ${{ runner.temp }}/desktop-release
+          digest-mismatch: error
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.sign-macos.outputs.baseline_artifact_id }}
+          path: ${{ runner.temp }}/desktop-baseline
+          digest-mismatch: error
+      - name: Bind immutable candidate and baseline artifacts
+        env:
+          CANDIDATE_ID: ${{ needs.sign-macos.outputs.artifact_id }}
+          CANDIDATE_DIGEST: ${{ needs.sign-macos.outputs.artifact_digest }}
+          CANDIDATE_NAME: ${{ needs.sign-macos.outputs.artifact_name }}
+          BASELINE_ID: ${{ needs.sign-macos.outputs.baseline_artifact_id }}
+          BASELINE_DIGEST: ${{ needs.sign-macos.outputs.baseline_artifact_digest }}
+          BASELINE_NAME: ${{ needs.sign-macos.outputs.baseline_artifact_name }}
+          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$CANDIDATE_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$CANDIDATE_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
+          printf '%s' "$BASELINE_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$BASELINE_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
+          test "$CANDIDATE_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+          test "$BASELINE_NAME" = "desktop-baseline-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+      - name: Exercise native production-feed update
+        env:
+          ENDURAGENT_MACOS_UPDATE_ROUNDTRIP_MODE: steady
+          BASELINE_VERSION: ${{ needs.sign-macos.outputs.baseline_version }}
+          CANDIDATE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          CANDIDATE_ENVELOPE="$RUNNER_TEMP/desktop-public-envelope"
+          EVIDENCE="$RUNNER_TEMP/macos-update-roundtrip.json"
+          pnpm desktop-release:transaction -- public-envelope \
+            --directory "$RUNNER_TEMP/desktop-release" \
+            --output "$CANDIDATE_ENVELOPE"
+          pnpm --filter @enduragent/desktop test:macos-update-roundtrip -- \
+            "$BASELINE_VERSION" \
+            "$CANDIDATE_VERSION" \
+            "$RUNNER_TEMP/desktop-baseline" \
+            "$CANDIDATE_ENVELOPE" \
+            "$EVIDENCE"
+      - name: Upload updater round-trip evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-update-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/macos-update-roundtrip.json
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
+
+  activate-release:
+    runs-on: ubuntu-latest
+    needs: [sign-macos, publish-assets, promote-latest, verify-production-update]
+    if: >-
+      ${{ always() && needs.publish-assets.result == 'success' &&
+          needs.promote-latest.result == 'success' &&
+          ((inputs.mode == 'genesis' && needs.verify-production-update.result == 'skipped') ||
+           (inputs.mode == 'steady' && needs.verify-production-update.result == 'success')) }}
+    environment: desktop-macos-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.commit }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
+          path: ${{ runner.temp }}/desktop-release
+          digest-mismatch: error
+      - name: Bind immutable Actions artifact evidence
+        env:
+          ARTIFACT_ID: ${{ needs.sign-macos.outputs.artifact_id }}
+          ARTIFACT_DIGEST: ${{ needs.sign-macos.outputs.artifact_digest }}
+          ARTIFACT_NAME: ${{ needs.sign-macos.outputs.artifact_name }}
+          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
+          test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+      - name: Activate bound general-availability body
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' packages/cycling-coach/CHANGELOG.md | tail -n +2)
+          printf '%s' "$BODY" > "$RUNNER_TEMP/desktop-release-body.md"
+          pnpm desktop-release:transaction -- activate \
+            --directory "$RUNNER_TEMP/desktop-release" \
+            --body-file "$RUNNER_TEMP/desktop-release-body.md"
+
+  compensate-publication:
+    runs-on: ubuntu-latest
+    needs: [sign-macos, publish-assets, promote-latest, verify-production-update, activate-release]
+    if: >-
+      ${{ always() && needs.publish-assets.outputs.latest_id != '' &&
+          needs.activate-release.result != 'success' }}
+    environment: desktop-macos-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.commit }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
+          path: ${{ runner.temp }}/desktop-release
+          digest-mismatch: error
+      - name: Bind immutable Actions artifact evidence
+        env:
+          ARTIFACT_ID: ${{ needs.sign-macos.outputs.artifact_id }}
+          ARTIFACT_DIGEST: ${{ needs.sign-macos.outputs.artifact_digest }}
+          ARTIFACT_NAME: ${{ needs.sign-macos.outputs.artifact_name }}
+          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
+          test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+      - name: Restore prior latest and withdraw candidate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          EXPECTED_LATEST_ID: ${{ needs.publish-assets.outputs.latest_id }}
+          EXPECTED_LATEST_TAG: ${{ needs.publish-assets.outputs.latest_tag }}
+          EXPECTED_LATEST_METADATA_SHA256: ${{ needs.publish-assets.outputs.latest_metadata_sha256 }}
+        run: |
+          set -euo pipefail
+          BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' packages/cycling-coach/CHANGELOG.md | tail -n +2)
+          printf '%s' "$BODY" > "$RUNNER_TEMP/desktop-release-body.md"
+          pnpm desktop-release:transaction -- compensate \
+            --directory "$RUNNER_TEMP/desktop-release" \
+            --body-file "$RUNNER_TEMP/desktop-release-body.md" \
             --expected-latest-id "$EXPECTED_LATEST_ID" \
             --expected-latest-tag "$EXPECTED_LATEST_TAG" \
             --expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -51,17 +51,46 @@ describe("desktop release workflow policy", () => {
     expect(issues.some((issue) => issue.includes("create-normal-or-leave-existing"))).toBe(true);
   });
 
-  it("rejects direct triggers and a non-failing activation stop", () => {
+  it("rejects direct triggers and activation that bypasses native acceptance", () => {
     const source = sources();
     const desktop = source.desktop
       .replace("workflow_call:", "workflow_call:\n  workflow_dispatch:")
       .replace(
-        "echo '::error::Public activation, compensation, production-feed roundtrip, and GA body activation have not landed; stable publication fails closed.'\n          exit 1",
-        "echo 'unsafe continuation'\n          exit 0",
+        "needs.verify-production-update.result == 'success'",
+        "needs.verify-production-update.result != 'failure'",
       );
     const issues = inspect(source.release, desktop);
     expect(issues.some((issue) => issue.includes("workflow_call-only"))).toBe(true);
-    expect(issues.some((issue) => issue.includes("stop explicitly and nonzero"))).toBe(true);
+    expect(issues.some((issue) => issue.includes("mode-specific acceptance gate"))).toBe(true);
+  });
+
+  it("requires observation, production-feed round trip, and compensation", () => {
+    const source = sources();
+    const mutations = [
+      {
+        desktop: source.desktop.replace(
+          "desktop-release:transaction -- observe",
+          "desktop-release:transaction -- verify",
+        ),
+        issue: "bind latest before provisional publication",
+      },
+      {
+        desktop: source.desktop.replace("test:macos-update-roundtrip", "test:disabled-roundtrip"),
+        issue: "native production-feed N-to-N+1 round trip",
+      },
+      {
+        desktop: source.desktop.replace(
+          "needs.activate-release.result != 'success'",
+          "needs.activate-release.result == 'failure'",
+        ),
+        issue: "restore the observed latest",
+      },
+    ];
+    for (const mutation of mutations) {
+      expect(
+        inspect(source.release, mutation.desktop).some((issue) => issue.includes(mutation.issue)),
+      ).toBe(true);
+    }
   });
 
   it("rejects a reusable call without a write permission ceiling", () => {

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -370,13 +370,23 @@ export function inspectDesktopReleaseWorkflows(
     "desktop.jobs.stage-private-draft",
     issues,
   );
-  const activation = mapping(
-    desktopJobs["desktop-activation-not-implemented"],
-    "desktop.jobs.desktop-activation-not-implemented",
-    issues,
-  );
   const publish = mapping(desktopJobs["publish-assets"], "desktop.jobs.publish-assets", issues);
   const promote = mapping(desktopJobs["promote-latest"], "desktop.jobs.promote-latest", issues);
+  const roundTrip = mapping(
+    desktopJobs["verify-production-update"],
+    "desktop.jobs.verify-production-update",
+    issues,
+  );
+  const activate = mapping(
+    desktopJobs["activate-release"],
+    "desktop.jobs.activate-release",
+    issues,
+  );
+  const compensate = mapping(
+    desktopJobs["compensate-publication"],
+    "desktop.jobs.compensate-publication",
+    issues,
+  );
   exactPermissions(sign.permissions, { contents: "read" }, "macOS signing", issues);
   exactPermissions(
     verify.permissions,
@@ -400,6 +410,24 @@ export function inspectDesktopReleaseWorkflows(
     promote.permissions,
     { actions: "read", contents: "write" },
     "latest promotion",
+    issues,
+  );
+  exactPermissions(
+    roundTrip.permissions,
+    { actions: "read", contents: "read" },
+    "production update verification",
+    issues,
+  );
+  exactPermissions(
+    activate.permissions,
+    { actions: "read", contents: "write" },
+    "release activation",
+    issues,
+  );
+  exactPermissions(
+    compensate.permissions,
+    { actions: "read", contents: "write" },
+    "release compensation",
     issues,
   );
   const signingSecrets = [
@@ -432,27 +460,88 @@ export function inspectDesktopReleaseWorkflows(
   }
   if (
     stage.environment !== "desktop-macos-publication" ||
-    promote.environment !== "desktop-macos-latest"
+    publish.environment !== "desktop-macos-publication" ||
+    promote.environment !== "desktop-macos-latest" ||
+    activate.environment !== "desktop-macos-latest" ||
+    compensate.environment !== "desktop-macos-latest"
   )
     issues.push("write-authority desktop jobs must use protected environments");
   if (!scalar(stage.needs).includes("verify-macos-envelope") || verify.needs !== "sign-macos")
     issues.push("independent macOS verification must follow signing before private staging");
-  const activationRun = runs(activation).join("\n");
+  const publishRun = runs(publish).join("\n");
+  const promoteRun = runs(promote).join("\n");
+  const roundTripRun = runs(roundTrip).join("\n");
+  const activateRun = runs(activate).join("\n");
+  const compensateRun = runs(compensate).join("\n");
+  const observeIndex = publishRun.indexOf("desktop-release:transaction -- observe");
+  const publicationIndex = publishRun.indexOf("desktop-release:transaction -- publish");
   if (
-    activation.needs !== "stage-private-draft" ||
-    !activationRun.includes("stable publication fails closed") ||
-    !/(?:^|\n)\s*exit 1\s*$/u.test(activationRun)
+    !scalar(publish.needs).includes("stage-private-draft") ||
+    observeIndex === -1 ||
+    publicationIndex <= observeIndex ||
+    !publishRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"') ||
+    !publishRun.includes('--expected-latest-tag "$EXPECTED_LATEST_TAG"') ||
+    !publishRun.includes('--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"') ||
+    scalar(mapping(publish.outputs, "desktop publish outputs", issues).latest_id) !==
+      "${{ steps.observe.outputs.latest_id }}"
   ) {
-    issues.push(
-      "incomplete desktop activation must stop explicitly and nonzero after private staging",
-    );
+    issues.push("public desktop publication must bind latest before provisional publication");
   }
   if (
-    publish.if !== "${{ false && inputs.mode == 'steady' }}" ||
-    !scalar(publish.needs).includes("stage-private-draft") ||
-    !scalar(promote.needs).includes("publish-assets")
+    !scalar(promote.needs).includes("publish-assets") ||
+    !promoteRun.includes("desktop-release:transaction -- promote") ||
+    !promoteRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"')
   ) {
-    issues.push("public desktop publication must remain unreachable until activation lands");
+    issues.push("desktop latest promotion must compare-and-swap the observed release");
+  }
+  const roundTripNeeds = scalar(roundTrip.needs);
+  if (
+    roundTrip.if !== "${{ inputs.mode == 'steady' }}" ||
+    !roundTripNeeds.includes("sign-macos") ||
+    !roundTripNeeds.includes("promote-latest") ||
+    !roundTripRun.includes("desktop-release:transaction -- public-envelope") ||
+    !roundTripRun.includes("test:macos-update-roundtrip") ||
+    !roundTripRun.includes('"$RUNNER_TEMP/desktop-baseline"') ||
+    !roundTripRun.includes('"$CANDIDATE_ENVELOPE"') ||
+    !roundTripRun.includes('"$EVIDENCE"') ||
+    !scalar(roundTrip).includes("desktop-update-evidence-") ||
+    !scalar(roundTrip).includes("needs.sign-macos.outputs.baseline_version")
+  ) {
+    issues.push("steady publication must pass a native production-feed N-to-N+1 round trip");
+  }
+  const activateCondition = scalar(activate.if).replace(/\s+/gu, " ");
+  const activateNeeds = scalar(activate.needs);
+  if (
+    !activateNeeds.includes("publish-assets") ||
+    !activateNeeds.includes("promote-latest") ||
+    !activateNeeds.includes("verify-production-update") ||
+    !activateCondition.includes("always()") ||
+    !activateCondition.includes("needs.publish-assets.result == 'success'") ||
+    !activateCondition.includes("needs.promote-latest.result == 'success'") ||
+    !activateCondition.includes("inputs.mode == 'genesis'") ||
+    !activateCondition.includes("needs.verify-production-update.result == 'skipped'") ||
+    !activateCondition.includes("inputs.mode == 'steady'") ||
+    !activateCondition.includes("needs.verify-production-update.result == 'success'") ||
+    !activateRun.includes("desktop-release:transaction -- activate") ||
+    !activateRun.includes("packages/cycling-coach/CHANGELOG.md")
+  ) {
+    issues.push("general-availability activation must follow the mode-specific acceptance gate");
+  }
+  const compensateCondition = scalar(compensate.if).replace(/\s+/gu, " ");
+  const compensateNeeds = scalar(compensate.needs);
+  if (
+    !compensateNeeds.includes("activate-release") ||
+    !compensateCondition.includes("always()") ||
+    !compensateCondition.includes("needs.publish-assets.outputs.latest_id != ''") ||
+    !compensateCondition.includes("needs.activate-release.result != 'success'") ||
+    !compensateRun.includes("desktop-release:transaction -- compensate") ||
+    !compensateRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"') ||
+    !compensateRun.includes('--expected-latest-tag "$EXPECTED_LATEST_TAG"') ||
+    !compensateRun.includes('--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"')
+  ) {
+    issues.push(
+      "failed desktop activation must restore the observed latest and withdraw the candidate",
+    );
   }
   const signingSteps = steps(sign);
   const signingStep = namedStep(sign, "Build signed and notarized macOS envelope");
@@ -545,17 +634,25 @@ export function inspectDesktopReleaseWorkflows(
       desktopSource.match(
         /SIGNING_RUN_ATTEMPT: \$\{\{ needs\.sign-macos\.outputs\.workflow_run_attempt \}\}/gu,
       ) ?? []
-    ).length !== 5 ||
+    ).length !== 8 ||
     desktopSource.includes("SIGNING_RUN_ATTEMPT: ${{ github.run_attempt }}") ||
     !independentRun.includes('--workflow-run-attempt "$SIGNING_RUN_ATTEMPT"')
   ) {
     issues.push("desktop verification must bind the successful signing attempt on reruns");
   }
   if (
-    (desktopSource.match(/actions\/download-artifact@[^\n]+# v8/gu) ?? []).length !== 4 ||
-    (desktopSource.match(/digest-mismatch: error/gu) ?? []).length !== 4 ||
+    (desktopSource.match(/actions\/download-artifact@[^\n]+# v8/gu) ?? []).length !== 8 ||
+    (desktopSource.match(/digest-mismatch: error/gu) ?? []).length !== 8 ||
     !desktopSource.includes("artifact_id: ${{ steps.sealed-artifact.outputs.artifact-id }}") ||
-    !desktopSource.includes("artifact_digest: ${{ steps.sealed-artifact.outputs.artifact-digest }}")
+    !desktopSource.includes(
+      "artifact_digest: ${{ steps.sealed-artifact.outputs.artifact-digest }}",
+    ) ||
+    !desktopSource.includes(
+      "baseline_artifact_id: ${{ steps.baseline-artifact.outputs.artifact-id }}",
+    ) ||
+    !desktopSource.includes(
+      "baseline_artifact_digest: ${{ steps.baseline-artifact.outputs.artifact-digest }}",
+    )
   ) {
     issues.push("desktop consumers must bind the exact digest-checked signing artifact");
   }

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -1,13 +1,17 @@
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { stringify } from "yaml";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   DESKTOP_FEED_URL,
+  DESKTOP_PROVISIONAL_RELEASE_BODY,
   GithubClient,
+  activateDesktopRelease,
+  compensateDesktopRelease,
+  observeDesktopLatest,
   prepareDesktopBaseline,
   promoteDesktopLatest,
   publishDesktopRelease,
@@ -20,6 +24,7 @@ import {
 
 const candidateVersion = "2026.8.7";
 const candidateCommit = "a".repeat(40);
+const realSetImmediate = setImmediate;
 
 interface FakeAsset {
   id: number;
@@ -115,6 +120,11 @@ class FakeGithub {
   latest: FakeRelease | null = null;
   nextAssetId = 1000;
   failNextUploadWithStarter = false;
+  anonymousDownloadFailures = 0;
+  private resolveAnonymousDownloadFailure!: () => void;
+  readonly anonymousDownloadFailureObserved = new Promise<void>((resolveFailure) => {
+    this.resolveAnonymousDownloadFailure = resolveFailure;
+  });
 
   constructor(tag = `cycling-coach@${candidateVersion}`, commit = candidateCommit) {
     this.candidate = this.release(123, tag, true);
@@ -159,6 +169,10 @@ class FakeGithub {
     return asset;
   }
 
+  findRelease(id: number): FakeRelease | undefined {
+    return [this.candidate, ...this.pages.flat()].find((release) => release.id === id);
+  }
+
   client(): GithubClient {
     return new GithubClient("yerzhansa/enduragent", "token", this.fetch);
   }
@@ -179,7 +193,11 @@ class FakeGithub {
           : null,
         { status },
       );
-    if (url.endsWith("/releases/123") && method === "GET") return json(this.candidate);
+    const releaseMatch = /\/releases\/([1-9]\d*)$/u.exec(new URL(url).pathname);
+    if (releaseMatch && method === "GET") {
+      const release = this.findRelease(Number(releaseMatch[1]));
+      return release ? json(release) : json({}, 404);
+    }
     if (url.includes("/git/ref/tags/")) {
       const tag = decodeURIComponent(url.split("/git/ref/tags/")[1]);
       const commit = this.commits.get(tag);
@@ -209,15 +227,28 @@ class FakeGithub {
       this.bytes.delete(asset.browser_download_url);
       return new Response(null, { status: 204 });
     }
-    if (url.endsWith("/releases/123") && method === "PATCH") {
-      const update = JSON.parse(String(init.body)) as { draft?: boolean; make_latest?: string };
-      if (update.draft === false) this.candidate.draft = false;
-      if (update.make_latest === "true") this.latest = this.candidate;
-      return json(this.candidate);
+    if (releaseMatch && method === "PATCH") {
+      const release = this.findRelease(Number(releaseMatch[1]));
+      if (!release) return json({}, 404);
+      const update = JSON.parse(String(init.body)) as {
+        body?: string;
+        draft?: boolean;
+        make_latest?: string;
+      };
+      if (update.body !== undefined) release.body = update.body;
+      if (update.draft !== undefined) release.draft = update.draft;
+      if (update.make_latest === "true") this.latest = release;
+      if (release.draft && this.latest?.id === release.id) this.latest = null;
+      return json(release);
     }
     if (url === `${DESKTOP_FEED_URL}latest-mac.yml`) {
       const asset = this.latest?.assets.find((candidate) => candidate.name === "latest-mac.yml");
       return asset ? binary(this.bytes.get(asset.url)) : binary(undefined, 404);
+    }
+    if (url.includes("/releases/download/") && this.anonymousDownloadFailures > 0) {
+      this.anonymousDownloadFailures -= 1;
+      this.resolveAnonymousDownloadFailure();
+      return binary(undefined, 404);
     }
     const bytes = this.bytes.get(url);
     if (bytes) return binary(bytes);
@@ -382,12 +413,15 @@ describe("GitHub desktop release transaction", () => {
     ).rejects.toThrow("outside the bound repository");
   });
 
-  it("publishes steady assets non-latest and verifies tag downloads anonymously", async () => {
+  it("publishes steady assets provisionally and verifies tag downloads anonymously", async () => {
     const fake = new FakeGithub();
     const { directory } = await steadyCandidate(fake);
-    await publishDesktopRelease(directory, fake.client());
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
     expect(fake.candidate.draft).toBe(false);
     expect(fake.latest).toBeNull();
+    expect(fake.candidate.body).toBe(DESKTOP_PROVISIONAL_RELEASE_BODY);
     const anonymousDownloads = fake.calls.filter((call) =>
       call.url.includes("/releases/download/"),
     );
@@ -397,6 +431,58 @@ describe("GitHub desktop release transaction", () => {
       .filter((call) => call.method === "POST")
       .map((call) => new URL(call.url).searchParams.get("name"));
     expect(uploads.at(-1)).toBe("latest-mac.yml");
+  });
+
+  it("waits for transient tag-specific asset propagation", async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = new FakeGithub();
+      const { directory } = await steadyCandidate(fake);
+      await stageDesktopRelease(directory, fake.client());
+      const observed = await observeDesktopLatest(directory, fake.client());
+      fake.anonymousDownloadFailures = 1;
+      const publication = publishDesktopRelease(directory, fake.client(), observed);
+      await fake.anonymousDownloadFailureObserved;
+      await new Promise<void>((resolveTurn) => realSetImmediate(resolveTurn));
+      expect(vi.getTimerCount()).toBe(1);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await publication;
+      expect(fake.candidate.body).toBe(DESKTOP_PROVISIONAL_RELEASE_BODY);
+      expect(fake.anonymousDownloadFailures).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("activates only after promotion and restores the observed latest on compensation", async () => {
+    const successful = new FakeGithub();
+    const accepted = await steadyCandidate(successful);
+    accepted.baseline.draft = false;
+    successful.latest = accepted.baseline;
+    await stageDesktopRelease(accepted.directory, successful.client());
+    const observed = await observeDesktopLatest(accepted.directory, successful.client());
+    await publishDesktopRelease(accepted.directory, successful.client(), observed);
+    await promoteDesktopLatest(accepted.directory, successful.client(), observed);
+    const bodyDirectory = mkdtempSync(join(tmpdir(), "desktop-release-body-"));
+    directories.push(bodyDirectory);
+    const bodyPath = join(bodyDirectory, "body.md");
+    writeFileSync(bodyPath, "release body");
+    await activateDesktopRelease(accepted.directory, bodyPath, successful.client());
+    expect(successful.latest?.id).toBe(successful.candidate.id);
+    expect(successful.candidate.body).toBe("release body");
+
+    const failed = new FakeGithub();
+    const compensating = await steadyCandidate(failed);
+    compensating.baseline.draft = false;
+    failed.latest = compensating.baseline;
+    await stageDesktopRelease(compensating.directory, failed.client());
+    const prior = await observeDesktopLatest(compensating.directory, failed.client());
+    await publishDesktopRelease(compensating.directory, failed.client(), prior);
+    await promoteDesktopLatest(compensating.directory, failed.client(), prior);
+    await compensateDesktopRelease(compensating.directory, bodyPath, failed.client(), prior);
+    expect(failed.latest?.id).toBe(compensating.baseline.id);
+    expect(failed.candidate.draft).toBe(true);
+    expect(failed.candidate.body).toBe("release body");
   });
 
   it("discovers a complete retained draft baseline on a later page", async () => {
@@ -422,6 +508,8 @@ describe("GitHub desktop release transaction", () => {
       output,
     );
     expect(readFileSync(output, "utf8")).toContain("baseline_release_id=122");
+    expect(readFileSync(output, "utf8")).toContain("baseline_version=2026.8.6");
+    expect(readdirSync(target).sort()).toEqual([...releaseFileNames("2026.8.6")].sort());
     expect(fake.calls.some((call) => call.url.includes("page=2"))).toBe(true);
   });
 

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -9,6 +9,8 @@ import { z } from "zod";
 export const DESKTOP_FEED_URL = "https://github.com/yerzhansa/enduragent/releases/latest/download/";
 export const DESKTOP_MANIFEST = "desktop-release-manifest.json";
 export const DESKTOP_RELEASE_SCHEMA_VERSION = 1 as const;
+export const DESKTOP_PROVISIONAL_RELEASE_BODY =
+  "Desktop update validation is in progress. This release is not yet generally available.";
 
 export type DesktopReleaseMode = "steady" | "genesis";
 
@@ -117,6 +119,8 @@ export type NpmProvenanceBundleVerifier = (
 const versionPattern = /^([1-9]\d{3})\.([1-9]|1[0-2])\.(0|[1-9]\d*)$/u;
 const commitPattern = /^[0-9a-f]{40}$/u;
 const signingIdentityPattern = /^Developer ID Application: .+ \(FA494ACVTF\)$/u;
+const releasePropagationAttempts = 30;
+const releasePropagationDelayMs = 2_000;
 
 function exactObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -1155,23 +1159,36 @@ async function stageExactAssets(
 export async function publishDesktopRelease(
   directory: string,
   client: GithubClient,
-): Promise<LatestObservation> {
+  observedLatest?: LatestObservation,
+): Promise<void> {
   const manifest = await verifyDesktopRelease(directory);
-  if (manifest.mode !== "steady")
-    throw new TypeError("genesis desktop release must remain a private draft");
   const release = await verifyReleaseBinding(client, manifest);
   assertPublishableAssets(release.assets, manifest);
   const baseline = await resolvedBaselineForManifest(manifest, client);
   await assertResolvedBaseline(manifest, baseline, client);
-  const observedLatest = await client.latest();
+  if (observedLatest === undefined) {
+    throw new TypeError("desktop publication requires a bound latest observation");
+  }
+  assertLatestCas(
+    manifest.version,
+    observedLatest,
+    await client.latest(),
+    baseline?.version ?? null,
+  );
   await stageExactAssets(client, release, directory, manifest);
   await client.request(`/repos/${client.repository()}/releases/${release.id}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ draft: false, make_latest: "false" }),
+    body: JSON.stringify({
+      draft: false,
+      make_latest: "false",
+      body: DESKTOP_PROVISIONAL_RELEASE_BODY,
+    }),
   });
   const published = await client.release(release.id);
-  if (published.draft) throw new TypeError("desktop release remained a draft");
+  if (published.draft || published.body !== DESKTOP_PROVISIONAL_RELEASE_BODY) {
+    throw new TypeError("desktop release did not enter provisional publication");
+  }
   for (const file of manifest.files) {
     const asset = published.assets.find((candidate) => candidate.name === file.name);
     if (!asset) throw new TypeError(`published release asset is missing: ${file.name}`);
@@ -1180,12 +1197,36 @@ export async function publishDesktopRelease(
     if (!parts.includes(manifest.tag) || parts.at(-1) !== file.name) {
       throw new TypeError(`release asset is not tag-specific: ${file.name}`);
     }
-    const remote = await client.anonymousBytes(asset.browser_download_url);
-    if (remote.length !== file.size || sha256(remote) !== file.sha256) {
-      throw new TypeError(`tag-specific release download mismatch: ${file.name}`);
-    }
+    await waitForAnonymousAsset(client, asset.browser_download_url, file);
   }
-  return observedLatest;
+  assertLatestCas(
+    manifest.version,
+    observedLatest,
+    await client.latest(),
+    baseline?.version ?? null,
+  );
+}
+
+export async function observeDesktopLatest(
+  directory: string,
+  client: GithubClient,
+): Promise<LatestObservation> {
+  const manifest = await verifyDesktopRelease(directory);
+  const release = await verifyReleaseBinding(client, manifest);
+  assertPublishableAssets(release.assets, manifest);
+  const baseline = await resolvedBaselineForManifest(manifest, client);
+  await assertResolvedBaseline(manifest, baseline, client);
+  if (release.assets.length !== manifest.files.length) {
+    throw new TypeError("observed desktop draft asset set is incomplete");
+  }
+  for (const file of manifest.files) {
+    const asset = release.assets.find((candidate) => candidate.name === file.name);
+    if (!asset || asset.state !== "uploaded") {
+      throw new TypeError(`observed desktop draft asset is incomplete: ${file.name}`);
+    }
+    assertRemoteAsset(file, await client.bytes(asset.url));
+  }
+  return client.latest();
 }
 
 export async function stageDesktopRelease(directory: string, client: GithubClient): Promise<void> {
@@ -1206,8 +1247,8 @@ export async function promoteDesktopLatest(
   const candidate = await client.release(manifest.draftId);
   if (candidate.draft || candidate.prerelease || candidate.tag_name !== manifest.tag)
     throw new TypeError("published candidate binding mismatch");
-  if (sha256(Buffer.from(candidate.body, "utf8")) !== manifest.draftBodySha256)
-    throw new TypeError("published release body binding mismatch");
+  if (candidate.body !== DESKTOP_PROVISIONAL_RELEASE_BODY)
+    throw new TypeError("published release is not provisional");
   if ((await client.tagCommit(manifest.tag)) !== manifest.commit)
     throw new TypeError("published tag commit binding mismatch");
   const current = await client.latest();
@@ -1217,8 +1258,7 @@ export async function promoteDesktopLatest(
     const asset = candidate.assets.find((candidateAsset) => candidateAsset.name === file.name);
     if (!asset || asset.state !== "uploaded")
       throw new TypeError(`promotion candidate asset is missing: ${file.name}`);
-    const remote = await client.anonymousBytes(asset.browser_download_url);
-    assertRemoteAsset(file, remote);
+    await waitForAnonymousAsset(client, asset.browser_download_url, file);
   }
   assertLatestCas(manifest.version, observed, await client.latest(), previous?.version ?? null);
   await client.request(`/repos/${client.repository()}/releases/${candidate.id}`, {
@@ -1226,9 +1266,231 @@ export async function promoteDesktopLatest(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ make_latest: "true" }),
   });
-  const promoted = await client.latest();
-  if (promoted.id !== candidate.id || promoted.tag !== manifest.tag) {
-    throw new TypeError("desktop latest promotion did not round-trip");
+  const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
+  if (!metadata) throw new TypeError("desktop latest metadata is missing");
+  await waitForLatest(
+    client,
+    { id: candidate.id, tag: manifest.tag, metadataSha256: metadata.sha256 },
+    "desktop latest promotion did not converge",
+  );
+}
+
+async function readFinalReleaseBody(
+  path: string,
+  manifest: DesktopReleaseManifest,
+): Promise<string> {
+  const snapshot = await stableFile(path);
+  const body = snapshot.bytes.toString("utf8");
+  if (
+    !Buffer.from(body, "utf8").equals(snapshot.bytes) ||
+    sha256(snapshot.bytes) !== manifest.draftBodySha256
+  ) {
+    throw new TypeError("final release body binding mismatch");
+  }
+  return body;
+}
+
+function sameLatest(left: LatestObservation, right: LatestObservation): boolean {
+  return (
+    left.id === right.id && left.tag === right.tag && left.metadataSha256 === right.metadataSha256
+  );
+}
+
+function pauseForReleasePropagation(): Promise<void> {
+  return new Promise((resolvePause) => setTimeout(resolvePause, releasePropagationDelayMs));
+}
+
+async function waitForAnonymousAsset(
+  client: GithubClient,
+  url: string,
+  file: DesktopReleaseFile,
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= releasePropagationAttempts; attempt += 1) {
+    try {
+      assertRemoteAsset(file, await client.anonymousBytes(url));
+      return;
+    } catch (error) {
+      lastError = error;
+      if (error instanceof TypeError && error.message.startsWith("conflicting release asset:")) {
+        throw error;
+      }
+      if (attempt < releasePropagationAttempts) await pauseForReleasePropagation();
+    }
+  }
+  throw new TypeError(`tag-specific release download did not converge: ${file.name}`, {
+    cause: lastError,
+  });
+}
+
+async function waitForLatest(
+  client: GithubClient,
+  expected: LatestObservation | readonly LatestObservation[],
+  message: string,
+): Promise<LatestObservation> {
+  const accepted = Array.isArray(expected) ? expected : [expected];
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= releasePropagationAttempts; attempt += 1) {
+    try {
+      const current = await client.latest();
+      if (accepted.some((candidate) => sameLatest(candidate, current))) return current;
+      lastError = new TypeError("repository latest does not match the expected release");
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt < releasePropagationAttempts) await pauseForReleasePropagation();
+  }
+  throw new TypeError(message, { cause: lastError });
+}
+
+function requireObservedLatest(value: LatestObservation): LatestObservation {
+  if (
+    (value.id === null) !== (value.tag === null) ||
+    (value.id !== null && (!Number.isSafeInteger(value.id) || value.id <= 0)) ||
+    (value.tag !== null && !/^[-A-Za-z0-9@._]+$/u.test(value.tag)) ||
+    (value.id === null && value.metadataSha256 !== null) ||
+    (value.metadataSha256 !== null && !/^[0-9a-f]{64}$/u.test(value.metadataSha256))
+  ) {
+    throw new TypeError("observed latest release is invalid");
+  }
+  return value;
+}
+
+export async function activateDesktopRelease(
+  directory: string,
+  bodyPath: string,
+  client: GithubClient,
+): Promise<void> {
+  const manifest = await verifyDesktopRelease(directory);
+  const finalBody = await readFinalReleaseBody(bodyPath, manifest);
+  const candidate = await client.release(manifest.draftId);
+  if (
+    candidate.draft ||
+    candidate.prerelease ||
+    candidate.tag_name !== manifest.tag ||
+    candidate.body !== DESKTOP_PROVISIONAL_RELEASE_BODY ||
+    (await client.tagCommit(manifest.tag)) !== manifest.commit
+  ) {
+    throw new TypeError("desktop activation candidate binding mismatch");
+  }
+  assertPublishableAssets(candidate.assets, manifest);
+  if (candidate.assets.length !== manifest.files.length) {
+    throw new TypeError("desktop activation asset set is incomplete");
+  }
+  for (const file of manifest.files) {
+    const asset = candidate.assets.find((entry) => entry.name === file.name);
+    if (!asset || asset.state !== "uploaded") {
+      throw new TypeError(`desktop activation asset is incomplete: ${file.name}`);
+    }
+    assertRemoteAsset(file, await client.anonymousBytes(asset.browser_download_url));
+  }
+  const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
+  if (!metadata) throw new TypeError("desktop activation latest metadata is missing");
+  const expectedLatest = {
+    id: candidate.id,
+    tag: manifest.tag,
+    metadataSha256: metadata.sha256,
+  };
+  const latest = await waitForLatest(
+    client,
+    expectedLatest,
+    "desktop activation latest state did not converge",
+  );
+  if (
+    latest.id !== candidate.id ||
+    latest.tag !== manifest.tag ||
+    latest.metadataSha256 !== metadata.sha256
+  ) {
+    throw new TypeError("desktop activation latest binding mismatch");
+  }
+  await client.request(`/repos/${client.repository()}/releases/${candidate.id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ body: finalBody }),
+  });
+  const activated = await client.release(candidate.id);
+  if (
+    activated.draft ||
+    activated.prerelease ||
+    activated.tag_name !== manifest.tag ||
+    activated.body !== finalBody ||
+    sha256(Buffer.from(activated.body, "utf8")) !== manifest.draftBodySha256 ||
+    !sameLatest(
+      latest,
+      await waitForLatest(
+        client,
+        expectedLatest,
+        "desktop activation latest state changed during body activation",
+      ),
+    )
+  ) {
+    throw new TypeError("desktop release body activation did not round-trip");
+  }
+}
+
+export async function compensateDesktopRelease(
+  directory: string,
+  bodyPath: string,
+  client: GithubClient,
+  rawObserved: LatestObservation,
+): Promise<void> {
+  const manifest = await verifyDesktopRelease(directory);
+  const finalBody = await readFinalReleaseBody(bodyPath, manifest);
+  const observed = requireObservedLatest(rawObserved);
+  let candidate = await client.release(manifest.draftId);
+  if (candidate.prerelease || candidate.tag_name !== manifest.tag) {
+    throw new TypeError("desktop compensation candidate binding mismatch");
+  }
+  if (candidate.draft) {
+    const current = await waitForLatest(
+      client,
+      observed,
+      "desktop compensation draft latest state did not converge",
+    );
+    if (candidate.body !== finalBody || !sameLatest(observed, current)) {
+      throw new TypeError("desktop compensation draft state is invalid");
+    }
+    return;
+  }
+  if ((await client.tagCommit(manifest.tag)) !== manifest.commit) {
+    throw new TypeError("desktop compensation tag binding mismatch");
+  }
+  const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
+  if (!metadata) throw new TypeError("desktop compensation latest metadata is missing");
+  const current = await waitForLatest(
+    client,
+    [observed, { id: candidate.id, tag: manifest.tag, metadataSha256: metadata.sha256 }],
+    "desktop compensation could not resolve the public latest state",
+  );
+  if (current.id === candidate.id && current.tag === manifest.tag) {
+    if (observed.id !== null) {
+      const previous = await client.release(observed.id);
+      if (previous.draft || previous.prerelease || previous.tag_name !== observed.tag) {
+        throw new TypeError("desktop compensation previous latest binding mismatch");
+      }
+      await client.request(`/repos/${client.repository()}/releases/${previous.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ make_latest: "true" }),
+      });
+      await waitForLatest(client, observed, "desktop compensation latest restoration failed");
+    }
+  } else if (!sameLatest(observed, current)) {
+    throw new TypeError("desktop compensation refused unexpected latest state");
+  }
+  await client.request(`/repos/${client.repository()}/releases/${candidate.id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ draft: true, make_latest: "false", body: finalBody }),
+  });
+  candidate = await client.release(candidate.id);
+  const restored = await waitForLatest(
+    client,
+    observed,
+    "desktop compensation latest state did not converge",
+  );
+  if (!candidate.draft || candidate.body !== finalBody || !sameLatest(observed, restored)) {
+    throw new TypeError("desktop compensation did not round-trip");
   }
 }
 
@@ -1248,7 +1510,7 @@ export async function prepareDesktopBaseline(
       throw new TypeError("genesis release refused after a desktop baseline exists");
     await writeFile(
       output,
-      "baseline_tag=none\nbaseline_release_id=none\nbaseline_commit=none\nbaseline_zip_sha256=none\nbaseline_signing_identity=none\nbaseline_cdhash=none\nbaseline_zip=none\n",
+      "baseline_tag=none\nbaseline_version=none\nbaseline_release_id=none\nbaseline_commit=none\nbaseline_zip_sha256=none\nbaseline_signing_identity=none\nbaseline_cdhash=none\nbaseline_zip=none\n",
       { flag: "a" },
     );
     return;
@@ -1257,18 +1519,27 @@ export async function prepareDesktopBaseline(
   if (baseline === null) throw new TypeError("steady release requires a desktop baseline");
   if (compareVersions(baseline.version, version) >= 0)
     throw new TypeError("steady desktop baseline must precede the candidate version");
-  const zipName = releaseFileNames(baseline.version)[1];
-  const asset = baseline.release.assets.find((candidate) => candidate.name === zipName);
-  if (!asset) throw new TypeError("desktop baseline ZIP is missing");
-  const bytes = await client.bytes(asset.url);
-  if (bytes.length !== asset.size || bytes.length === 0)
-    throw new TypeError("desktop baseline ZIP is invalid");
   await mkdir(directory, { recursive: true });
-  const path = resolve(directory, zipName);
-  await writeFile(path, bytes, { flag: "wx", mode: 0o600 });
+  const names = releaseFileNames(baseline.version);
+  let zipSha256 = "";
+  let zipPath = "";
+  for (const name of names) {
+    const asset = baseline.release.assets.find((candidate) => candidate.name === name);
+    if (!asset) throw new TypeError(`desktop baseline asset is missing: ${name}`);
+    const bytes = await client.bytes(asset.url);
+    if (bytes.length !== asset.size || bytes.length === 0) {
+      throw new TypeError(`desktop baseline asset is invalid: ${name}`);
+    }
+    const path = resolve(directory, name);
+    await writeFile(path, bytes, { flag: "wx", mode: 0o600 });
+    if (name === names[1]) {
+      zipSha256 = sha256(bytes);
+      zipPath = path;
+    }
+  }
   await writeFile(
     output,
-    `baseline_tag=${baseline.release.tag_name}\nbaseline_release_id=${baseline.release.id}\nbaseline_commit=${baseline.commit}\nbaseline_zip_sha256=${sha256(bytes)}\nbaseline_zip=${path}\n`,
+    `baseline_tag=${baseline.release.tag_name}\nbaseline_version=${baseline.version}\nbaseline_release_id=${baseline.release.id}\nbaseline_commit=${baseline.commit}\nbaseline_zip_sha256=${zipSha256}\nbaseline_zip=${zipPath}\n`,
     { flag: "a" },
   );
 }
@@ -1302,6 +1573,40 @@ function bindingArguments(): Parameters<typeof requireBinding>[0] {
     baselineSigningIdentity: argument("baseline-signing-identity"),
     baselineCdHash: argument("baseline-cdhash"),
   };
+}
+
+function latestArguments(): LatestObservation {
+  const id = argument("expected-latest-id");
+  const tag = argument("expected-latest-tag");
+  const metadataSha256 = argument("expected-latest-metadata-sha256");
+  if (id !== "none" && !/^[1-9]\d*$/u.test(id)) {
+    throw new TypeError("expected latest id is invalid");
+  }
+  if (tag !== "none" && !/^[-A-Za-z0-9@._]+$/u.test(tag)) {
+    throw new TypeError("expected latest tag is invalid");
+  }
+  if ((id === "none") !== (tag === "none")) {
+    throw new TypeError("expected latest release is incomplete");
+  }
+  if (id === "none" && metadataSha256 !== "none") {
+    throw new TypeError("expected latest metadata has no release");
+  }
+  if (metadataSha256 !== "none" && !/^[0-9a-f]{64}$/u.test(metadataSha256)) {
+    throw new TypeError("expected latest metadata hash is invalid");
+  }
+  return {
+    id: id === "none" ? null : Number(id),
+    tag: tag === "none" ? null : tag,
+    metadataSha256: metadataSha256 === "none" ? null : metadataSha256,
+  };
+}
+
+async function writeLatestOutput(output: string, observed: LatestObservation): Promise<void> {
+  await writeFile(
+    output,
+    `latest_id=${observed.id ?? "none"}\nlatest_tag=${observed.tag ?? "none"}\nlatest_metadata_sha256=${observed.metadataSha256 ?? "none"}\n`,
+    { flag: "a" },
+  );
 }
 
 async function main(): Promise<void> {
@@ -1363,14 +1668,15 @@ async function main(): Promise<void> {
     );
     return;
   }
-  if (command === "publish") {
-    const observed = await publishDesktopRelease(directory, client);
-    const output = argument("github-output");
-    await writeFile(
-      output,
-      `latest_id=${observed.id ?? "none"}\nlatest_tag=${observed.tag ?? "none"}\nlatest_metadata_sha256=${observed.metadataSha256 ?? "none"}\n`,
-      { flag: "a" },
+  if (command === "observe") {
+    await writeLatestOutput(
+      argument("github-output"),
+      await observeDesktopLatest(directory, client),
     );
+    return;
+  }
+  if (command === "publish") {
+    await publishDesktopRelease(directory, client, latestArguments());
     return;
   }
   if (command === "stage") {
@@ -1378,22 +1684,24 @@ async function main(): Promise<void> {
     return;
   }
   if (command === "promote") {
-    const id = argument("expected-latest-id");
-    const tag = argument("expected-latest-tag");
-    const expectedMetadataSha256 = argument("expected-latest-metadata-sha256");
-    if (id !== "none" && !/^[1-9]\d*$/u.test(id))
-      throw new TypeError("expected latest id is invalid");
-    if (expectedMetadataSha256 !== "none" && !/^[0-9a-f]{64}$/u.test(expectedMetadataSha256))
-      throw new TypeError("expected latest metadata hash is invalid");
-    await promoteDesktopLatest(directory, client, {
-      id: id === "none" ? null : Number(id),
-      tag: tag === "none" ? null : tag,
-      metadataSha256: expectedMetadataSha256 === "none" ? null : expectedMetadataSha256,
-    });
+    await promoteDesktopLatest(directory, client, latestArguments());
+    return;
+  }
+  if (command === "activate") {
+    await activateDesktopRelease(directory, resolve(argument("body-file")), client);
+    return;
+  }
+  if (command === "compensate") {
+    await compensateDesktopRelease(
+      directory,
+      resolve(argument("body-file")),
+      client,
+      latestArguments(),
+    );
     return;
   }
   throw new TypeError(
-    "desktop release command must be verify-npm-provenance, seal, verify, public-envelope, baseline, stage, publish, or promote",
+    "desktop release command must be verify-npm-provenance, seal, verify, public-envelope, baseline, stage, observe, publish, promote, activate, or compensate",
   );
 }
 


### PR DESCRIPTION
Summary
- publish a verified candidate provisionally without changing latest
- promote by compare-and-swap, run the signed production-feed N to N plus 1 acceptance gate, then activate final release notes
- restore the observed latest and withdraw the candidate on any activation failure
- tolerate transient GitHub propagation while retaining exact byte checks

Dependency
- stacked on #514

Verification
- pnpm check
- 53 focused release transaction and workflow policy tests