### PR TITLE
feat(store): persist complete curve generations

### DIFF
--- a/.changeset/quiet-curve-evidence.md
+++ b/.changeset/quiet-curve-evidence.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Add immutable local storage for complete Power Progress curve generations and last-good refresh state.

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -878,7 +878,8 @@ describe("incremental backfill pages", () => {
         sourceChanges: 0,
       });
     });
-    const before = await dumpStore(legacy);
+    const beforeWorkouts = await legacy.all("SELECT * FROM workout ORDER BY workout_key");
+    const beforeSessions = await legacy.all("SELECT * FROM session ORDER BY session_key");
     await legacy.close();
     const baseFetch = profileFetch("synthetic-athlete-upgrade");
 
@@ -895,9 +896,12 @@ describe("incremental backfill pages", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 9 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 10 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
-      expect(await dumpStore(upgraded)).toBe(before);
+      expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(beforeWorkouts);
+      expect(await upgraded.all("SELECT * FROM session ORDER BY session_key")).toEqual(beforeSessions);
+      expect(await upgraded.get("SELECT count(*) AS count FROM analytics_curve_generation"))
+        .toEqual({ count: 0 });
     } finally {
       await upgraded.close();
     }

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -582,7 +582,7 @@ describe("coach sync composition", () => {
           return store.get("PRAGMA user_version");
         },
       );
-      expect(value).toEqual({ user_version: 9 });
+      expect(value).toEqual({ user_version: 10 });
       expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
       expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
       expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -590,7 +590,7 @@ describe("coach sync composition", () => {
       const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
       try {
         await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-          user_version: 9,
+          user_version: 10,
         });
       } finally {
         await reopened.close();

--- a/packages/kernel-node/tests/analytics-curve-repository.test.ts
+++ b/packages/kernel-node/tests/analytics-curve-repository.test.ts
@@ -1,0 +1,273 @@
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ANALYTICS_CURVE_PARTS,
+  analyticsCurveWindows,
+  createAnalyticsCurveRepository,
+  runMigrations,
+  type AnalyticsCurveRepository,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const FROZEN_ON = "2026-08-07";
+const FROZEN_EPOCH_SECONDS = Date.parse(`${FROZEN_ON}T12:00:00.000Z`) / 1_000;
+
+async function hashKey(fields: readonly (string | number)[]): Promise<string> {
+  return createHash("sha256").update(JSON.stringify(fields)).digest("hex");
+}
+
+describe("analytics curve repository", () => {
+  let store: SqlStore & MigratorStore;
+  let repository: AnalyticsCurveRepository;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    repository = createAnalyticsCurveRepository(store, hashKey);
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  async function begin(day = FROZEN_ON, hour = 12) {
+    return repository.beginGeneration({
+      frozenOn: day,
+      frozenEpochSeconds: Date.parse(`${day}T${String(hour).padStart(2, "0")}:00:00.000Z`) / 1_000,
+    });
+  }
+
+  async function recordAll(
+    generationId: string,
+    offset = 0,
+    archiveEpochSeconds = FROZEN_EPOCH_SECONDS,
+  ): Promise<void> {
+    for (const [index, part] of ANALYTICS_CURVE_PARTS.entries()) {
+      const archiveAddress = (index + offset + 1).toString(16).padStart(64, "0");
+      await repository.recordEvidence({
+        generationId,
+        ...part,
+        archiveAddress,
+        archiveRelPath: `2026/08/${archiveAddress}.json.gz`,
+        archiveEpochSeconds,
+        decodedBytes: 100 + index,
+      });
+    }
+  }
+
+  it("derives exact adjacent windows and idempotently begins one immutable generation", async () => {
+    expect(analyticsCurveWindows(FROZEN_ON)).toEqual({
+      current: { start: "2026-07-11", end: "2026-08-07" },
+      previous: { start: "2026-06-13", end: "2026-07-10" },
+      sustainability: { start: "2026-06-27", end: "2026-08-07" },
+    });
+    const first = await begin();
+    const second = await begin();
+    expect(first.inserted).toBe(true);
+    expect(second).toEqual({ ...first, inserted: false });
+    expect(first.generation.generationId).toMatch(/^[0-9a-f]{64}$/);
+    expect(Object.isFrozen(first.generation)).toBe(true);
+    expect(Object.isFrozen(first.generation.windows.current)).toBe(true);
+  });
+
+  it("records exactly four immutable parts and promotes only the complete generation", async () => {
+    const { generation } = await begin();
+    const firstPart = ANALYTICS_CURVE_PARTS[0]!;
+    const archiveAddress = "1".padStart(64, "0");
+    const first = await repository.recordEvidence({
+      generationId: generation.generationId,
+      ...firstPart,
+      archiveAddress,
+      archiveRelPath: `2026/08/${archiveAddress}.json.gz`,
+      archiveEpochSeconds: FROZEN_EPOCH_SECONDS,
+      decodedBytes: 100,
+    });
+    await expect(repository.recordEvidence({
+      generationId: generation.generationId,
+      ...firstPart,
+      archiveAddress,
+      archiveRelPath: `2026/08/${archiveAddress}.json.gz`,
+      archiveEpochSeconds: FROZEN_EPOCH_SECONDS,
+      decodedBytes: 100,
+    })).resolves.toEqual({ ...first, inserted: false });
+    await expect(repository.promoteGeneration({
+      generationId: generation.generationId,
+      promotedEpochSeconds: FROZEN_EPOCH_SECONDS + 1,
+    })).rejects.toThrow("analytics curve generation is incomplete");
+
+    for (const [index, part] of ANALYTICS_CURVE_PARTS.slice(1).entries()) {
+      const address = (index + 2).toString(16).padStart(64, "0");
+      await repository.recordEvidence({
+        generationId: generation.generationId,
+        ...part,
+        archiveAddress: address,
+        archiveRelPath: `2026/08/${address}.json.gz`,
+        archiveEpochSeconds: FROZEN_EPOCH_SECONDS,
+        decodedBytes: 101 + index,
+      });
+    }
+    await expect(repository.promoteGeneration({
+      generationId: generation.generationId,
+      promotedEpochSeconds: FROZEN_EPOCH_SECONDS + 1,
+    })).resolves.toBe("promoted");
+    await expect(repository.promoteGeneration({
+      generationId: generation.generationId,
+      promotedEpochSeconds: FROZEN_EPOCH_SECONDS + 1,
+    })).resolves.toBe("already-current");
+
+    const state = await repository.readState();
+    expect(state.current?.generation).toEqual(generation);
+    expect(state.current?.evidence).toHaveLength(4);
+    expect(new Set(state.current?.evidence.map((row) => row.requestIdentity)).size).toBe(4);
+    expect(state.refreshFailure).toBeNull();
+    expect(Object.isFrozen(state.current?.evidence)).toBe(true);
+  });
+
+  it("preserves last-good state across a failed partial refresh and clears failure on promotion", async () => {
+    const first = (await begin(FROZEN_ON, 11)).generation;
+    await recordAll(first.generationId, 0, first.frozenEpochSeconds);
+    await repository.promoteGeneration({
+      generationId: first.generationId,
+      promotedEpochSeconds: FROZEN_EPOCH_SECONDS,
+    });
+
+    const second = (await begin(FROZEN_ON, 13)).generation;
+    const part = ANALYTICS_CURVE_PARTS[0]!;
+    const archiveAddress = "f".repeat(64);
+    await repository.recordEvidence({
+      generationId: second.generationId,
+      ...part,
+      archiveAddress,
+      archiveRelPath: `2026/08/${archiveAddress}.json.gz`,
+      archiveEpochSeconds: second.frozenEpochSeconds,
+      decodedBytes: 200,
+    });
+    await repository.recordRefreshFailure({
+      generationId: second.generationId,
+      code: "timeout",
+      failedEpochSeconds: second.frozenEpochSeconds + 10,
+    });
+    const stale = await repository.readState();
+    expect(stale.current?.generation.generationId).toBe(first.generationId);
+    expect(stale.refreshFailure).toEqual({
+      generationId: second.generationId,
+      code: "timeout",
+      failedEpochSeconds: second.frozenEpochSeconds + 10,
+    });
+
+    for (const [index, nextPart] of ANALYTICS_CURVE_PARTS.slice(1).entries()) {
+      const address = (index + 32).toString(16).padStart(64, "0");
+      await repository.recordEvidence({
+        generationId: second.generationId,
+        ...nextPart,
+        archiveAddress: address,
+        archiveRelPath: `2026/08/${address}.json.gz`,
+        archiveEpochSeconds: second.frozenEpochSeconds,
+        decodedBytes: 201 + index,
+      });
+    }
+    await repository.promoteGeneration({
+      generationId: second.generationId,
+      promotedEpochSeconds: second.frozenEpochSeconds + 20,
+    });
+    const refreshed = await repository.readState();
+    expect(refreshed.current?.generation.generationId).toBe(second.generationId);
+    expect(refreshed.refreshFailure).toBeNull();
+  });
+
+  it("rejects changed duplicate parts, unsafe paths, oversize payloads, and malformed dates", async () => {
+    const { generation } = await begin();
+    const part = ANALYTICS_CURVE_PARTS[0]!;
+    const archiveAddress = "a".repeat(64);
+    const valid = {
+      generationId: generation.generationId,
+      ...part,
+      archiveAddress,
+      archiveRelPath: `2026/08/${archiveAddress}.json.gz`,
+      archiveEpochSeconds: FROZEN_EPOCH_SECONDS,
+      decodedBytes: 100,
+    } as const;
+    await repository.recordEvidence(valid);
+    await expect(repository.recordEvidence({ ...valid, decodedBytes: 101 }))
+      .rejects.toThrow("analytics curve invariant mismatch");
+    await expect(repository.recordEvidence({ ...valid, archiveRelPath: "/private/curve.json.gz" }))
+      .rejects.toThrow(new TypeError("invalid analytics curve input"));
+    await expect(repository.recordEvidence({ ...valid, decodedBytes: 2_097_153 }))
+      .rejects.toThrow(new TypeError("invalid analytics curve input"));
+    await expect(repository.recordEvidence({
+      ...valid,
+      archiveEpochSeconds: FROZEN_EPOCH_SECONDS + 1,
+    })).rejects.toThrow(new TypeError("invalid analytics curve input"));
+    await expect(repository.recordRefreshFailure({
+      generationId: generation.generationId,
+      code: "timeout",
+      failedEpochSeconds: FROZEN_EPOCH_SECONDS - 1,
+    })).rejects.toThrow(new TypeError("invalid analytics curve input"));
+    await expect(repository.beginGeneration({
+      frozenEpochSeconds: FROZEN_EPOCH_SECONDS,
+      frozenOn: "2026-02-30",
+    })).rejects.toThrow(new TypeError("invalid analytics curve input"));
+    const read = vi.fn(() => FROZEN_EPOCH_SECONDS);
+    const accessorInput = { frozenOn: FROZEN_ON } as Record<string, unknown>;
+    Object.defineProperty(accessorInput, "frozenEpochSeconds", { enumerable: true, get: read });
+    await expect(repository.beginGeneration(accessorInput as never))
+      .rejects.toThrow(new TypeError("invalid analytics curve input"));
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("enforces completeness and append-only evidence in SQLite itself", async () => {
+    const { generation } = await begin();
+    await expect(store.run(
+      "INSERT INTO analytics_curve_generation_promotion(generation_id,promoted_epoch_s) VALUES(?,?)",
+      [generation.generationId, FROZEN_EPOCH_SECONDS],
+    )).rejects.toThrow();
+    await recordAll(generation.generationId);
+    await expect(store.run(
+      "INSERT INTO analytics_curve_generation_promotion(generation_id,promoted_epoch_s) VALUES(?,?)",
+      [generation.generationId, FROZEN_EPOCH_SECONDS - 1],
+    )).rejects.toThrow();
+    await repository.promoteGeneration({
+      generationId: generation.generationId,
+      promotedEpochSeconds: FROZEN_EPOCH_SECONDS,
+    });
+    await expect(store.run("DELETE FROM analytics_curve_evidence")).rejects.toThrow();
+    await expect(store.run(
+      "UPDATE analytics_curve_generation SET frozen_on='2026-08-08'",
+    )).rejects.toThrow();
+    await expect(store.run("DELETE FROM analytics_curve_current")).rejects.toThrow();
+    expect(await store.all("PRAGMA foreign_key_check")).toEqual([]);
+  });
+
+  it("rejects structurally valid rows whose content-derived identity was forged", async () => {
+    const windows = analyticsCurveWindows(FROZEN_ON);
+    const forgedGenerationId = "d".repeat(64);
+    await store.run(`INSERT INTO analytics_curve_generation (
+  generation_id,source,lane,frozen_epoch_s,frozen_on,current_start,current_end,
+  previous_start,previous_end,sustainability_start,sustainability_end
+) VALUES(?,?,?,?,?,?,?,?,?,?,?)`, [
+      forgedGenerationId,
+      "intervals-icu",
+      "analytics-curves",
+      FROZEN_EPOCH_SECONDS,
+      FROZEN_ON,
+      windows.current.start,
+      windows.current.end,
+      windows.previous.start,
+      windows.previous.end,
+      windows.sustainability.start,
+      windows.sustainability.end,
+    ]);
+    await expect(repository.recordRefreshFailure({
+      generationId: forgedGenerationId,
+      code: "timeout",
+      failedEpochSeconds: FROZEN_EPOCH_SECONDS,
+    })).rejects.toThrow("analytics curve invariant mismatch");
+    await store.run(`INSERT INTO analytics_curve_refresh_failure (
+  singleton,generation_id,code,failed_epoch_s
+) VALUES(1,?,?,?)`, [forgedGenerationId, "timeout", FROZEN_EPOCH_SECONDS]);
+    await expect(repository.readState()).rejects.toThrow("analytics curve invariant mismatch");
+  });
+});

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -583,7 +583,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -31,9 +31,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 9", async () => {
+  it("applies the full migration list and advances user_version to 10", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -53,7 +53,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -82,11 +82,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 9", async () => {
+  it("upgrades a version-1-on-disk store to version 10", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -106,8 +106,8 @@ describe("migrator end-to-end over node:sqlite", () => {
     );
 
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 4, toVersion: 9, applied: [5, 6, 7, 8, 9] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
+    expect(result).toEqual({ fromVersion: 4, toVersion: 10, applied: [5, 6, 7, 8, 9, 10] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -158,14 +158,14 @@ describe("migrator end-to-end over node:sqlite", () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 6, toVersion: 9, applied: [7, 8, 9] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
+    expect(result).toEqual({ fromVersion: 6, toVersion: 10, applied: [7, 8, 9, 10] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 9,
-      toVersion: 9,
+      fromVersion: 10,
+      toVersion: 10,
       applied: [],
     });
   });

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -231,14 +231,13 @@ describe("sync failure repository", () => {
     }
   });
 
-  it("upgrades a migration-six store without changing canonical dump ownership", async () => {
+  it("upgrades a migration-six store while keeping operational failures outside the dump", async () => {
     store = openSqliteStorage(":memory:");
     await runMigrations(store, MIGRATIONS.slice(0, 6));
-    const before = await dumpStore(store);
     await runMigrations(store, MIGRATIONS);
-    expect(await dumpStore(store)).toBe(before);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 9 });
-    expect(DUMP_TABLES).toHaveLength(32);
+    expect(await dumpStore(store)).not.toContain("# sync_failure");
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
+    expect(DUMP_TABLES).toHaveLength(36);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");
     expect(DERIVED_TABLES).not.toContain("sync_failure");

--- a/packages/kernel/src/store/analytics-curve-repository.ts
+++ b/packages/kernel/src/store/analytics-curve-repository.ts
@@ -1,0 +1,506 @@
+import type { Row, SqlStore } from "./ports.js";
+
+export const ANALYTICS_CURVE_PARTS = Object.freeze([
+  Object.freeze({ curveFamily: "power" as const, activityType: "Ride" as const }),
+  Object.freeze({ curveFamily: "power" as const, activityType: "VirtualRide" as const }),
+  Object.freeze({ curveFamily: "heart-rate" as const, activityType: "Ride" as const }),
+  Object.freeze({ curveFamily: "heart-rate" as const, activityType: "VirtualRide" as const }),
+]);
+
+export const ANALYTICS_CURVE_REFRESH_FAILURE_CODES = Object.freeze([
+  "request-budget-exhausted",
+  "rate-limited",
+  "timeout",
+  "network",
+  "provider-unavailable",
+  "malformed-response",
+  "response-too-large",
+  "cancelled",
+  "temporary-failure",
+] as const);
+
+export type AnalyticsCurveFamily = (typeof ANALYTICS_CURVE_PARTS)[number]["curveFamily"];
+export type AnalyticsCurveActivityType = (typeof ANALYTICS_CURVE_PARTS)[number]["activityType"];
+export type AnalyticsCurveRefreshFailureCode =
+  (typeof ANALYTICS_CURVE_REFRESH_FAILURE_CODES)[number];
+
+export interface AnalyticsCurveWindows {
+  readonly current: { readonly start: string; readonly end: string };
+  readonly previous: { readonly start: string; readonly end: string };
+  readonly sustainability: { readonly start: string; readonly end: string };
+}
+
+export interface AnalyticsCurveGeneration {
+  readonly generationId: string;
+  readonly frozenEpochSeconds: number;
+  readonly frozenOn: string;
+  readonly windows: AnalyticsCurveWindows;
+}
+
+export interface AnalyticsCurveEvidence {
+  readonly evidenceId: string;
+  readonly generationId: string;
+  readonly curveFamily: AnalyticsCurveFamily;
+  readonly activityType: AnalyticsCurveActivityType;
+  readonly requestIdentity: string;
+  readonly archiveAddress: string;
+  readonly archiveRelPath: string;
+  readonly archiveEpochSeconds: number;
+  readonly decodedBytes: number;
+}
+
+export interface AnalyticsCurveRefreshFailure {
+  readonly generationId: string;
+  readonly code: AnalyticsCurveRefreshFailureCode;
+  readonly failedEpochSeconds: number;
+}
+
+export interface AnalyticsCurveState {
+  readonly current: null | {
+    readonly generation: AnalyticsCurveGeneration;
+    readonly evidence: readonly AnalyticsCurveEvidence[];
+    readonly promotedEpochSeconds: number;
+  };
+  readonly refreshFailure: AnalyticsCurveRefreshFailure | null;
+}
+
+export interface AnalyticsCurveRepository {
+  beginGeneration(input: {
+    readonly frozenEpochSeconds: number;
+    readonly frozenOn: string;
+  }): Promise<{ readonly generation: AnalyticsCurveGeneration; readonly inserted: boolean }>;
+  recordEvidence(input: {
+    readonly generationId: string;
+    readonly curveFamily: AnalyticsCurveFamily;
+    readonly activityType: AnalyticsCurveActivityType;
+    readonly archiveAddress: string;
+    readonly archiveRelPath: string;
+    readonly archiveEpochSeconds: number;
+    readonly decodedBytes: number;
+  }): Promise<{ readonly evidence: AnalyticsCurveEvidence; readonly inserted: boolean }>;
+  promoteGeneration(input: {
+    readonly generationId: string;
+    readonly promotedEpochSeconds: number;
+  }): Promise<"promoted" | "already-current" | "reselected-current">;
+  recordRefreshFailure(input: AnalyticsCurveRefreshFailure): Promise<void>;
+  readState(): Promise<AnalyticsCurveState>;
+}
+
+type HashKey = (fields: readonly (string | number)[]) => Promise<string>;
+
+const HEX = /^[0-9a-f]{64}$/;
+const CIVIL_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_EPOCH_SECONDS = 8_640_000_000_000;
+const MAX_DECODED_BYTES = 2_097_152;
+
+function invalidInput(): never {
+  throw new TypeError("invalid analytics curve input");
+}
+
+function invariantMismatch(): never {
+  throw new Error("analytics curve invariant mismatch");
+}
+
+function isPlainExact(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return false;
+  const actual = Reflect.ownKeys(value);
+  return actual.length === keys.length
+    && actual.every((key) => typeof key === "string" && keys.includes(key))
+    && keys.every((key) => {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      return descriptor !== undefined && "value" in descriptor && descriptor.enumerable;
+    });
+}
+
+function isAddress(value: unknown): value is string {
+  return typeof value === "string" && HEX.test(value);
+}
+
+function isEpoch(value: unknown): value is number {
+  return Number.isSafeInteger(value)
+    && (value as number) >= 0
+    && (value as number) <= MAX_EPOCH_SECONDS;
+}
+
+function civilDate(value: unknown): string {
+  if (typeof value !== "string" || !CIVIL_DATE.test(value)) invalidInput();
+  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
+  const parsed = new Date(0);
+  parsed.setUTCHours(0, 0, 0, 0);
+  parsed.setUTCFullYear(year, month - 1, day);
+  if (parsed.getUTCFullYear() !== year || parsed.getUTCMonth() !== month - 1
+    || parsed.getUTCDate() !== day || parsed.toISOString().slice(0, 10) !== value) invalidInput();
+  return value;
+}
+
+function shiftCivilDate(value: string, days: number): string {
+  civilDate(value);
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return parsed.toISOString().slice(0, 10);
+}
+
+export function analyticsCurveWindows(frozenOn: string): AnalyticsCurveWindows {
+  const date = civilDate(frozenOn);
+  return Object.freeze({
+    current: Object.freeze({ start: shiftCivilDate(date, -27), end: date }),
+    previous: Object.freeze({ start: shiftCivilDate(date, -55), end: shiftCivilDate(date, -28) }),
+    sustainability: Object.freeze({ start: shiftCivilDate(date, -41), end: date }),
+  });
+}
+
+function generationFields(generation: AnalyticsCurveGeneration): readonly (string | number)[] {
+  return [
+    "analytics_curve_generation",
+    "intervals-icu",
+    "analytics-curves",
+    generation.frozenEpochSeconds,
+    generation.frozenOn,
+    generation.windows.current.start,
+    generation.windows.current.end,
+    generation.windows.previous.start,
+    generation.windows.previous.end,
+    generation.windows.sustainability.start,
+    generation.windows.sustainability.end,
+  ];
+}
+
+function requestFields(
+  generation: AnalyticsCurveGeneration,
+  curveFamily: AnalyticsCurveFamily,
+  activityType: AnalyticsCurveActivityType,
+): readonly (string | number)[] {
+  return [
+    "analytics_curve_request",
+    curveFamily,
+    activityType,
+    `r.${generation.windows.current.start}.${generation.windows.current.end}`,
+    `r.${generation.windows.previous.start}.${generation.windows.previous.end}`,
+    `r.${generation.windows.sustainability.start}.${generation.windows.sustainability.end}`,
+  ];
+}
+
+function isCurveFamily(value: unknown): value is AnalyticsCurveFamily {
+  return value === "power" || value === "heart-rate";
+}
+
+function isCurveActivityType(value: unknown): value is AnalyticsCurveActivityType {
+  return value === "Ride" || value === "VirtualRide";
+}
+
+function isCurvePart(curveFamily: unknown, activityType: unknown): boolean {
+  return isCurveFamily(curveFamily) && isCurveActivityType(activityType);
+}
+
+function isRefreshFailureCode(value: unknown): value is AnalyticsCurveRefreshFailureCode {
+  return (ANALYTICS_CURVE_REFRESH_FAILURE_CODES as readonly unknown[]).includes(value);
+}
+
+function archivePath(value: unknown, address: string, epochSeconds: number): value is string {
+  if (typeof value !== "string") return false;
+  const prefix = new Date(epochSeconds * 1_000).toISOString().slice(0, 7).replace("-", "/");
+  return value === `${prefix}/${address}.json.gz`;
+}
+
+function generationFromRow(row: Row | undefined): AnalyticsCurveGeneration {
+  if (row === undefined || !isAddress(row.generation_id) || row.source !== "intervals-icu"
+    || row.lane !== "analytics-curves" || !isEpoch(row.frozen_epoch_s)
+    || typeof row.frozen_on !== "string" || typeof row.current_start !== "string"
+    || typeof row.current_end !== "string" || typeof row.previous_start !== "string"
+    || typeof row.previous_end !== "string" || typeof row.sustainability_start !== "string"
+    || typeof row.sustainability_end !== "string") invariantMismatch();
+  let windows: AnalyticsCurveWindows;
+  try {
+    windows = analyticsCurveWindows(row.frozen_on);
+  } catch {
+    invariantMismatch();
+  }
+  if (row.current_start !== windows.current.start || row.current_end !== windows.current.end
+    || row.previous_start !== windows.previous.start || row.previous_end !== windows.previous.end
+    || row.sustainability_start !== windows.sustainability.start
+    || row.sustainability_end !== windows.sustainability.end
+    || new Date(row.frozen_epoch_s * 1_000).toISOString().slice(0, 10) !== row.frozen_on) {
+    invariantMismatch();
+  }
+  return Object.freeze({
+    generationId: row.generation_id,
+    frozenEpochSeconds: row.frozen_epoch_s,
+    frozenOn: row.frozen_on,
+    windows,
+  });
+}
+
+function evidenceFromRow(row: Row): AnalyticsCurveEvidence {
+  if (!isAddress(row.evidence_id) || !isAddress(row.generation_id)
+    || !isCurvePart(row.curve_family, row.activity_type) || !isAddress(row.request_identity)
+    || !isAddress(row.archive_address) || !isEpoch(row.archive_epoch_s)
+    || !archivePath(row.archive_rel_path, row.archive_address, row.archive_epoch_s)
+    || typeof row.decoded_bytes !== "number" || !Number.isSafeInteger(row.decoded_bytes)
+    || row.decoded_bytes < 1 || row.decoded_bytes > MAX_DECODED_BYTES) invariantMismatch();
+  return Object.freeze({
+    evidenceId: row.evidence_id,
+    generationId: row.generation_id,
+    curveFamily: row.curve_family as AnalyticsCurveFamily,
+    activityType: row.activity_type as AnalyticsCurveActivityType,
+    requestIdentity: row.request_identity,
+    archiveAddress: row.archive_address,
+    archiveRelPath: row.archive_rel_path,
+    archiveEpochSeconds: row.archive_epoch_s,
+    decodedBytes: row.decoded_bytes,
+  });
+}
+
+function sameGeneration(left: AnalyticsCurveGeneration, right: AnalyticsCurveGeneration): boolean {
+  return left.generationId === right.generationId
+    && left.frozenEpochSeconds === right.frozenEpochSeconds
+    && left.frozenOn === right.frozenOn
+    && left.windows.current.start === right.windows.current.start
+    && left.windows.current.end === right.windows.current.end
+    && left.windows.previous.start === right.windows.previous.start
+    && left.windows.previous.end === right.windows.previous.end
+    && left.windows.sustainability.start === right.windows.sustainability.start
+    && left.windows.sustainability.end === right.windows.sustainability.end;
+}
+
+function sameEvidence(left: AnalyticsCurveEvidence, right: AnalyticsCurveEvidence): boolean {
+  return left.evidenceId === right.evidenceId
+    && left.generationId === right.generationId
+    && left.curveFamily === right.curveFamily
+    && left.activityType === right.activityType
+    && left.requestIdentity === right.requestIdentity
+    && left.archiveAddress === right.archiveAddress
+    && left.archiveRelPath === right.archiveRelPath
+    && left.archiveEpochSeconds === right.archiveEpochSeconds
+    && left.decodedBytes === right.decodedBytes;
+}
+
+function isCompleteEvidence(evidence: readonly AnalyticsCurveEvidence[]): boolean {
+  return evidence.length === ANALYTICS_CURVE_PARTS.length
+    && ANALYTICS_CURVE_PARTS.every((part) => evidence.some((row) =>
+      row.curveFamily === part.curveFamily && row.activityType === part.activityType));
+}
+
+const GENERATION_COLUMNS = `generation_id,source,lane,frozen_epoch_s,frozen_on,
+  current_start,current_end,previous_start,previous_end,sustainability_start,sustainability_end`;
+const EVIDENCE_COLUMNS = `evidence_id,generation_id,curve_family,activity_type,request_identity,
+  archive_address,archive_rel_path,archive_epoch_s,decoded_bytes`;
+
+export function createAnalyticsCurveRepository(
+  store: SqlStore,
+  hashKey: HashKey,
+): AnalyticsCurveRepository {
+  if (store === null || typeof store !== "object" || typeof hashKey !== "function") invalidInput();
+
+  const readGeneration = async (generationId: string): Promise<AnalyticsCurveGeneration> => {
+    const generation = generationFromRow(await store.get(
+      `SELECT ${GENERATION_COLUMNS} FROM analytics_curve_generation WHERE generation_id=?`,
+      [generationId],
+    ));
+    if (generation.generationId !== generationId
+      || await hashKey(generationFields(generation)) !== generationId) invariantMismatch();
+    return generation;
+  };
+
+  const readEvidence = async (
+    generation: AnalyticsCurveGeneration,
+  ): Promise<readonly AnalyticsCurveEvidence[]> => {
+    const evidence = (await store.all(`SELECT ${EVIDENCE_COLUMNS}
+FROM analytics_curve_evidence
+WHERE generation_id=?
+ORDER BY curve_family COLLATE BINARY ASC, activity_type COLLATE BINARY ASC`, [generation.generationId]))
+      .map(evidenceFromRow);
+    for (const row of evidence) {
+      const requestIdentity = await hashKey(requestFields(
+        generation,
+        row.curveFamily,
+        row.activityType,
+      ));
+      const evidenceId = await hashKey(["analytics_curve_evidence", requestIdentity,
+        row.archiveAddress, row.archiveRelPath, row.archiveEpochSeconds, row.decodedBytes]);
+      if (row.generationId !== generation.generationId
+        || row.archiveEpochSeconds !== generation.frozenEpochSeconds
+        || row.requestIdentity !== requestIdentity || row.evidenceId !== evidenceId) invariantMismatch();
+    }
+    return evidence;
+  };
+
+  const repository: AnalyticsCurveRepository = {
+    async beginGeneration(input) {
+      if (!isPlainExact(input, ["frozenEpochSeconds", "frozenOn"])
+        || !isEpoch(input.frozenEpochSeconds)) invalidInput();
+      const frozenOn = civilDate(input.frozenOn);
+      if (new Date(input.frozenEpochSeconds * 1_000).toISOString().slice(0, 10) !== frozenOn) {
+        invalidInput();
+      }
+      const seed: AnalyticsCurveGeneration = {
+        generationId: "0".repeat(64),
+        frozenEpochSeconds: input.frozenEpochSeconds,
+        frozenOn,
+        windows: analyticsCurveWindows(frozenOn),
+      };
+      const generationId = await hashKey(generationFields(seed));
+      if (!isAddress(generationId)) invalidInput();
+      const generation = Object.freeze({ ...seed, generationId });
+      const values = [generationId, "intervals-icu", "analytics-curves", input.frozenEpochSeconds,
+        frozenOn, generation.windows.current.start, generation.windows.current.end,
+        generation.windows.previous.start, generation.windows.previous.end,
+        generation.windows.sustainability.start, generation.windows.sustainability.end] as const;
+      const inserted = await store.get(`INSERT INTO analytics_curve_generation (
+  generation_id,source,lane,frozen_epoch_s,frozen_on,current_start,current_end,
+  previous_start,previous_end,sustainability_start,sustainability_end
+) VALUES (?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT DO NOTHING RETURNING generation_id`, values);
+      const byId = generationFromRow(await store.get(
+        `SELECT ${GENERATION_COLUMNS} FROM analytics_curve_generation WHERE generation_id=?`,
+        [generationId],
+      ));
+      const byTuple = generationFromRow(await store.get(`SELECT ${GENERATION_COLUMNS}
+FROM analytics_curve_generation
+WHERE frozen_epoch_s=? AND current_start=? AND current_end=? AND previous_start=?
+  AND previous_end=? AND sustainability_start=? AND sustainability_end=?`, [
+        input.frozenEpochSeconds, generation.windows.current.start, generation.windows.current.end,
+        generation.windows.previous.start, generation.windows.previous.end,
+        generation.windows.sustainability.start, generation.windows.sustainability.end,
+      ]));
+      if (!sameGeneration(byId, generation) || !sameGeneration(byTuple, generation)) {
+        invariantMismatch();
+      }
+      return Object.freeze({ generation, inserted: inserted !== undefined });
+    },
+
+    async recordEvidence(input) {
+      if (!isPlainExact(input, ["generationId", "curveFamily", "activityType", "archiveAddress",
+        "archiveRelPath", "archiveEpochSeconds", "decodedBytes"])
+        || !isAddress(input.generationId) || !isCurvePart(input.curveFamily, input.activityType)
+        || !isAddress(input.archiveAddress) || !isEpoch(input.archiveEpochSeconds)
+        || !archivePath(input.archiveRelPath, input.archiveAddress, input.archiveEpochSeconds)
+        || !Number.isSafeInteger(input.decodedBytes) || input.decodedBytes < 1
+        || input.decodedBytes > MAX_DECODED_BYTES) invalidInput();
+      const generation = await readGeneration(input.generationId);
+      if (input.archiveEpochSeconds !== generation.frozenEpochSeconds) invalidInput();
+      const requestIdentity = await hashKey(requestFields(
+        generation,
+        input.curveFamily,
+        input.activityType,
+      ));
+      if (!isAddress(requestIdentity)) invalidInput();
+      const evidenceId = await hashKey(["analytics_curve_evidence", requestIdentity,
+        input.archiveAddress, input.archiveRelPath, input.archiveEpochSeconds, input.decodedBytes]);
+      if (!isAddress(evidenceId)) invalidInput();
+      const values = [evidenceId, input.generationId, input.curveFamily, input.activityType,
+        requestIdentity, input.archiveAddress, input.archiveRelPath, input.archiveEpochSeconds,
+        input.decodedBytes] as const;
+      const inserted = await store.get(`INSERT INTO analytics_curve_evidence (
+  evidence_id,generation_id,curve_family,activity_type,request_identity,
+  archive_address,archive_rel_path,archive_epoch_s,decoded_bytes
+) VALUES (?,?,?,?,?,?,?,?,?) ON CONFLICT DO NOTHING RETURNING evidence_id`, values);
+      const expected: AnalyticsCurveEvidence = {
+        evidenceId,
+        generationId: input.generationId,
+        curveFamily: input.curveFamily,
+        activityType: input.activityType,
+        requestIdentity,
+        archiveAddress: input.archiveAddress,
+        archiveRelPath: input.archiveRelPath,
+        archiveEpochSeconds: input.archiveEpochSeconds,
+        decodedBytes: input.decodedBytes,
+      };
+      const byId = evidenceFromRow((await store.get(
+        `SELECT ${EVIDENCE_COLUMNS} FROM analytics_curve_evidence WHERE evidence_id=?`,
+        [evidenceId],
+      )) ?? invariantMismatch());
+      const byPart = evidenceFromRow((await store.get(`SELECT ${EVIDENCE_COLUMNS}
+FROM analytics_curve_evidence
+WHERE generation_id=? AND curve_family=? AND activity_type=?`, [
+        input.generationId, input.curveFamily, input.activityType,
+      ])) ?? invariantMismatch());
+      if (!sameEvidence(byId, expected) || !sameEvidence(byPart, expected)) invariantMismatch();
+      return Object.freeze({ evidence: byId, inserted: inserted !== undefined });
+    },
+
+    async promoteGeneration(input) {
+      if (!isPlainExact(input, ["generationId", "promotedEpochSeconds"])
+        || !isAddress(input.generationId) || !isEpoch(input.promotedEpochSeconds)) invalidInput();
+      const generation = await readGeneration(input.generationId);
+      if (input.promotedEpochSeconds < generation.frozenEpochSeconds) invalidInput();
+      const evidence = await readEvidence(generation);
+      if (!isCompleteEvidence(evidence)) {
+        throw new Error("analytics curve generation is incomplete");
+      }
+      const inserted = await store.get(`INSERT INTO analytics_curve_generation_promotion (
+  generation_id,promoted_epoch_s
+) VALUES (?,?) ON CONFLICT DO NOTHING RETURNING generation_id`, [
+        input.generationId, input.promotedEpochSeconds,
+      ]);
+      const promotion = await store.get(
+        "SELECT generation_id,promoted_epoch_s FROM analytics_curve_generation_promotion WHERE generation_id=?",
+        [input.generationId],
+      );
+      if (promotion?.generation_id !== input.generationId
+        || promotion.promoted_epoch_s !== input.promotedEpochSeconds) invariantMismatch();
+      const before = await store.get("SELECT generation_id FROM analytics_curve_current WHERE singleton=1");
+      await store.run(`INSERT INTO analytics_curve_current(singleton,generation_id) VALUES(1,?)
+ON CONFLICT(singleton) DO UPDATE SET generation_id=excluded.generation_id
+WHERE analytics_curve_current.generation_id != excluded.generation_id`, [input.generationId]);
+      const current = await store.get("SELECT generation_id FROM analytics_curve_current WHERE singleton=1");
+      if (current?.generation_id !== input.generationId) invariantMismatch();
+      if (before?.generation_id === input.generationId) return "already-current";
+      return inserted === undefined ? "reselected-current" : "promoted";
+    },
+
+    async recordRefreshFailure(input) {
+      if (!isPlainExact(input, ["generationId", "code", "failedEpochSeconds"])
+        || !isAddress(input.generationId) || !isRefreshFailureCode(input.code)
+        || !isEpoch(input.failedEpochSeconds)) invalidInput();
+      const generation = await readGeneration(input.generationId);
+      if (input.failedEpochSeconds < generation.frozenEpochSeconds) invalidInput();
+      await store.run(`INSERT INTO analytics_curve_refresh_failure (
+  singleton,generation_id,code,failed_epoch_s
+) VALUES(1,?,?,?)
+ON CONFLICT(singleton) DO UPDATE SET generation_id=excluded.generation_id,
+  code=excluded.code,failed_epoch_s=excluded.failed_epoch_s`, [
+        input.generationId, input.code, input.failedEpochSeconds,
+      ]);
+    },
+
+    async readState() {
+      const failureRow = await store.get(
+        "SELECT generation_id,code,failed_epoch_s FROM analytics_curve_refresh_failure WHERE singleton=1",
+      );
+      let refreshFailure: AnalyticsCurveRefreshFailure | null = null;
+      if (failureRow !== undefined) {
+        if (!isAddress(failureRow.generation_id) || !isRefreshFailureCode(failureRow.code)
+          || !isEpoch(failureRow.failed_epoch_s)) invariantMismatch();
+        const failureGeneration = await readGeneration(failureRow.generation_id);
+        if (failureRow.failed_epoch_s < failureGeneration.frozenEpochSeconds) invariantMismatch();
+        refreshFailure = Object.freeze({
+          generationId: failureRow.generation_id,
+          code: failureRow.code,
+          failedEpochSeconds: failureRow.failed_epoch_s,
+        });
+      }
+      const currentRow = await store.get(`SELECT c.generation_id,p.promoted_epoch_s
+FROM analytics_curve_current AS c
+JOIN analytics_curve_generation_promotion AS p ON p.generation_id=c.generation_id
+WHERE c.singleton=1`);
+      if (currentRow === undefined) return Object.freeze({ current: null, refreshFailure });
+      if (!isAddress(currentRow.generation_id) || !isEpoch(currentRow.promoted_epoch_s)) {
+        invariantMismatch();
+      }
+      const generation = await readGeneration(currentRow.generation_id);
+      if (currentRow.promoted_epoch_s < generation.frozenEpochSeconds) invariantMismatch();
+      const evidence = await readEvidence(generation);
+      if (!isCompleteEvidence(evidence)) invariantMismatch();
+      return Object.freeze({
+        current: Object.freeze({
+          generation,
+          evidence: Object.freeze(evidence),
+          promotedEpochSeconds: currentRow.promoted_epoch_s,
+        }),
+        refreshFailure,
+      });
+    },
+  };
+  return Object.freeze(repository);
+}

--- a/packages/kernel/src/store/dump.ts
+++ b/packages/kernel/src/store/dump.ts
@@ -18,6 +18,10 @@ export const DERIVED_TABLES = [
 
 /** Every current store table, alphabetical, with its content-derived order key. */
 export const DUMP_TABLES = [
+  { table: "analytics_curve_current", orderBy: "singleton" },
+  { table: "analytics_curve_evidence", orderBy: "evidence_id" },
+  { table: "analytics_curve_generation", orderBy: "generation_id" },
+  { table: "analytics_curve_generation_promotion", orderBy: "generation_id" },
   { table: "anchor_history", orderBy: "id" },
   { table: "athlete", orderBy: "id" },
   { table: "dedup_confirmation", orderBy: "id" },

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -10,6 +10,7 @@ export * from "./intake-repository.js";
 export * from "./activity-repository.js";
 export * from "./canonical-activity-reader.js";
 export * from "./trusted-activity-source-resolver.js";
+export * from "./analytics-curve-repository.js";
 export * from "./derived-key.js";
 export * from "./sync-source.js";
 export * from "./sync-state-repository.js";

--- a/packages/kernel/src/store/migrations/010_analytics_curves.sql
+++ b/packages/kernel/src/store/migrations/010_analytics_curves.sql
@@ -1,0 +1,222 @@
+CREATE TABLE analytics_curve_generation (
+  generation_id TEXT PRIMARY KEY
+    CHECK (
+      length(generation_id) = 64
+      AND generation_id = lower(generation_id)
+      AND generation_id NOT GLOB '*[^0-9a-f]*'
+    ),
+  source TEXT NOT NULL CHECK (source = 'intervals-icu'),
+  lane TEXT NOT NULL CHECK (lane = 'analytics-curves'),
+  frozen_epoch_s INTEGER NOT NULL CHECK (frozen_epoch_s >= 0),
+  frozen_on TEXT NOT NULL
+    CHECK (length(frozen_on) = 10 AND frozen_on GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  current_start TEXT NOT NULL
+    CHECK (length(current_start) = 10 AND current_start GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  current_end TEXT NOT NULL
+    CHECK (length(current_end) = 10 AND current_end GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  previous_start TEXT NOT NULL
+    CHECK (length(previous_start) = 10 AND previous_start GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  previous_end TEXT NOT NULL
+    CHECK (length(previous_end) = 10 AND previous_end GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  sustainability_start TEXT NOT NULL
+    CHECK (length(sustainability_start) = 10 AND sustainability_start GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  sustainability_end TEXT NOT NULL
+    CHECK (length(sustainability_end) = 10 AND sustainability_end GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'),
+  CHECK (current_end = frozen_on),
+  CHECK (sustainability_end = frozen_on),
+  CHECK (previous_start < previous_end),
+  CHECK (previous_end < current_start),
+  CHECK (current_start < current_end),
+  CHECK (sustainability_start < sustainability_end),
+  UNIQUE (
+    frozen_epoch_s,
+    current_start,
+    current_end,
+    previous_start,
+    previous_end,
+    sustainability_start,
+    sustainability_end
+  )
+) STRICT;
+
+CREATE TABLE analytics_curve_evidence (
+  evidence_id TEXT PRIMARY KEY
+    CHECK (
+      length(evidence_id) = 64
+      AND evidence_id = lower(evidence_id)
+      AND evidence_id NOT GLOB '*[^0-9a-f]*'
+    ),
+  generation_id TEXT NOT NULL
+    REFERENCES analytics_curve_generation(generation_id) ON DELETE RESTRICT,
+  curve_family TEXT NOT NULL CHECK (curve_family IN ('power','heart-rate')),
+  activity_type TEXT NOT NULL CHECK (activity_type IN ('Ride','VirtualRide')),
+  request_identity TEXT NOT NULL
+    CHECK (
+      length(request_identity) = 64
+      AND request_identity = lower(request_identity)
+      AND request_identity NOT GLOB '*[^0-9a-f]*'
+    ),
+  archive_address TEXT NOT NULL
+    CHECK (
+      length(archive_address) = 64
+      AND archive_address = lower(archive_address)
+      AND archive_address NOT GLOB '*[^0-9a-f]*'
+    ),
+  archive_rel_path TEXT NOT NULL
+    CHECK (
+      length(archive_rel_path) = 80
+      AND archive_rel_path GLOB '[0-9][0-9][0-9][0-9]/[0-9][0-9]/*.json.gz'
+      AND substr(archive_rel_path, 9) = archive_address || '.json.gz'
+    ),
+  archive_epoch_s INTEGER NOT NULL CHECK (archive_epoch_s >= 0),
+  decoded_bytes INTEGER NOT NULL CHECK (decoded_bytes BETWEEN 1 AND 2097152),
+  UNIQUE (generation_id, curve_family, activity_type)
+) STRICT;
+
+CREATE INDEX idx_analytics_curve_evidence_request
+  ON analytics_curve_evidence (request_identity, archive_epoch_s, evidence_id);
+
+CREATE TRIGGER analytics_curve_evidence_uses_generation_instant
+BEFORE INSERT ON analytics_curve_evidence
+WHEN NEW.archive_epoch_s != (
+  SELECT frozen_epoch_s
+  FROM analytics_curve_generation
+  WHERE generation_id = NEW.generation_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve evidence instant mismatch');
+END;
+
+CREATE TABLE analytics_curve_generation_promotion (
+  generation_id TEXT PRIMARY KEY
+    REFERENCES analytics_curve_generation(generation_id) ON DELETE RESTRICT,
+  promoted_epoch_s INTEGER NOT NULL CHECK (promoted_epoch_s >= 0)
+) STRICT;
+
+CREATE TRIGGER analytics_curve_generation_promotion_requires_complete_evidence
+BEFORE INSERT ON analytics_curve_generation_promotion
+WHEN (
+  SELECT count(*)
+  FROM analytics_curve_evidence
+  WHERE generation_id = NEW.generation_id
+) != 4
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve generation is incomplete');
+END;
+
+CREATE TRIGGER analytics_curve_generation_promotion_uses_later_instant
+BEFORE INSERT ON analytics_curve_generation_promotion
+WHEN NEW.promoted_epoch_s < (
+  SELECT frozen_epoch_s
+  FROM analytics_curve_generation
+  WHERE generation_id = NEW.generation_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve promotion instant mismatch');
+END;
+
+CREATE TABLE analytics_curve_current (
+  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+  generation_id TEXT NOT NULL UNIQUE
+    REFERENCES analytics_curve_generation_promotion(generation_id) ON DELETE RESTRICT
+) STRICT;
+
+CREATE TABLE analytics_curve_refresh_failure (
+  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+  generation_id TEXT NOT NULL
+    CHECK (
+      length(generation_id) = 64
+      AND generation_id = lower(generation_id)
+      AND generation_id NOT GLOB '*[^0-9a-f]*'
+    )
+    REFERENCES analytics_curve_generation(generation_id) ON DELETE RESTRICT,
+  code TEXT NOT NULL
+    CHECK (code IN (
+      'request-budget-exhausted',
+      'rate-limited',
+      'timeout',
+      'network',
+      'provider-unavailable',
+      'malformed-response',
+      'response-too-large',
+      'cancelled',
+      'temporary-failure'
+    )),
+  failed_epoch_s INTEGER NOT NULL CHECK (failed_epoch_s >= 0)
+) STRICT;
+
+CREATE TRIGGER analytics_curve_refresh_failure_insert_uses_later_instant
+BEFORE INSERT ON analytics_curve_refresh_failure
+WHEN NEW.failed_epoch_s < (
+  SELECT frozen_epoch_s
+  FROM analytics_curve_generation
+  WHERE generation_id = NEW.generation_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve failure instant mismatch');
+END;
+
+CREATE TRIGGER analytics_curve_refresh_failure_update_uses_later_instant
+BEFORE UPDATE ON analytics_curve_refresh_failure
+WHEN NEW.failed_epoch_s < (
+  SELECT frozen_epoch_s
+  FROM analytics_curve_generation
+  WHERE generation_id = NEW.generation_id
+)
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve failure instant mismatch');
+END;
+
+CREATE TRIGGER analytics_curve_generation_no_update
+BEFORE UPDATE ON analytics_curve_generation
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve generation is append-only');
+END;
+
+CREATE TRIGGER analytics_curve_generation_no_delete
+BEFORE DELETE ON analytics_curve_generation
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve generation is append-only');
+END;
+
+CREATE TRIGGER analytics_curve_evidence_no_update
+BEFORE UPDATE ON analytics_curve_evidence
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve evidence is append-only');
+END;
+
+CREATE TRIGGER analytics_curve_evidence_no_delete
+BEFORE DELETE ON analytics_curve_evidence
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve evidence is append-only');
+END;
+
+CREATE TRIGGER analytics_curve_generation_promotion_no_update
+BEFORE UPDATE ON analytics_curve_generation_promotion
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve promotion is append-only');
+END;
+
+CREATE TRIGGER analytics_curve_generation_promotion_no_delete
+BEFORE DELETE ON analytics_curve_generation_promotion
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve promotion is append-only');
+END;
+
+CREATE TRIGGER analytics_curve_current_no_delete
+BEFORE DELETE ON analytics_curve_current
+BEGIN
+  SELECT RAISE(ABORT, 'analytics curve current selection cannot be deleted');
+END;
+
+CREATE TRIGGER analytics_curve_current_insert_clears_failure
+AFTER INSERT ON analytics_curve_current
+BEGIN
+  DELETE FROM analytics_curve_refresh_failure;
+END;
+
+CREATE TRIGGER analytics_curve_current_update_clears_failure
+AFTER UPDATE OF generation_id ON analytics_curve_current
+BEGIN
+  DELETE FROM analytics_curve_refresh_failure;
+END;

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -7,6 +7,7 @@ import incremental006 from "./006_incremental_ingest.sql";
 import syncFailure007 from "./007_sync_failure.sql";
 import storeOwner008 from "./008_store_owner.sql";
 import activitySourceResolver009 from "./009_activity_source_resolver.sql";
+import analyticsCurves010 from "./010_analytics_curves.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -31,4 +32,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 7, name: "007_sync_failure", sql: syncFailure007 },
   { version: 8, name: "008_store_owner", sql: storeOwner008 },
   { version: 9, name: "009_activity_source_resolver", sql: activitySourceResolver009 },
+  { version: 10, name: "010_analytics_curves", sql: analyticsCurves010 },
 ];

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -45,6 +45,11 @@ const EXPECTED_FULL_TABLES = [
   "ingest_cluster_state",
   "sync_failure",
   "store_owner",
+  "analytics_curve_generation",
+  "analytics_curve_evidence",
+  "analytics_curve_generation_promotion",
+  "analytics_curve_current",
+  "analytics_curve_refresh_failure",
 ];
 const MIGRATION_002 = `ALTER TABLE swim_length ADD COLUMN distance_m REAL;
 
@@ -163,6 +168,7 @@ describe("001_init migration", () => {
       { version: 7, name: "007_sync_failure" },
       { version: 8, name: "008_store_owner" },
       { version: 9, name: "009_activity_source_resolver" },
+      { version: 10, name: "010_analytics_curves" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -254,7 +260,7 @@ describe("001_init migration", () => {
     expect(MIGRATIONS[2]!.sql).toBe(MIGRATION_003);
   });
 
-  it("applies 001 through 008 with exactly thirty-six tables and no foreign-key violations", () => {
+  it("applies 001 through 010 with exactly forty-one tables and no foreign-key violations", () => {
     db = openFull();
     const names = (
       db
@@ -264,7 +270,7 @@ describe("001_init migration", () => {
       .map((row) => row.name)
       .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
-    expect(names).toHaveLength(36);
+    expect(names).toHaveLength(41);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
@@ -497,6 +503,20 @@ describe("001_init migration", () => {
         "sync_operation_no_delete",
         "store_owner_no_update",
         "store_owner_no_delete",
+        "analytics_curve_generation_promotion_requires_complete_evidence",
+        "analytics_curve_evidence_uses_generation_instant",
+        "analytics_curve_generation_promotion_uses_later_instant",
+        "analytics_curve_refresh_failure_insert_uses_later_instant",
+        "analytics_curve_refresh_failure_update_uses_later_instant",
+        "analytics_curve_generation_no_update",
+        "analytics_curve_generation_no_delete",
+        "analytics_curve_evidence_no_update",
+        "analytics_curve_evidence_no_delete",
+        "analytics_curve_generation_promotion_no_update",
+        "analytics_curve_generation_promotion_no_delete",
+        "analytics_curve_current_no_delete",
+        "analytics_curve_current_insert_clears_failure",
+        "analytics_curve_current_update_clears_failure",
       ]),
     );
 
@@ -714,6 +734,10 @@ describe("001_init migration", () => {
 
   it("enumerates sync state ownership", () => {
     expect(DUMP_TABLES).toEqual([
+      { table: "analytics_curve_current", orderBy: "singleton" },
+      { table: "analytics_curve_evidence", orderBy: "evidence_id" },
+      { table: "analytics_curve_generation", orderBy: "generation_id" },
+      { table: "analytics_curve_generation_promotion", orderBy: "generation_id" },
       { table: "anchor_history", orderBy: "id" },
       { table: "athlete", orderBy: "id" },
       { table: "dedup_confirmation", orderBy: "id" },
@@ -747,12 +771,19 @@ describe("001_init migration", () => {
       { table: "workout", orderBy: "workout_key" },
       { table: "zone_set_history", orderBy: "id" },
     ]);
-    expect(DUMP_TABLES).toHaveLength(32);
+    expect(DUMP_TABLES).toHaveLength(36);
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("source_watermark");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_failure");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("store_owner");
+    expect(DUMP_TABLES.map(({ table }) => String(table)))
+      .not.toContain("analytics_curve_refresh_failure");
     for (const table of [
+      "analytics_curve_current",
+      "analytics_curve_evidence",
+      "analytics_curve_generation",
+      "analytics_curve_generation_promotion",
+      "analytics_curve_refresh_failure",
       "source_artifact",
       "source_record_revision",
       "source_record_current",
@@ -796,7 +827,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     }>;
     expect(tables.find((row) => row.name === "sync_failure")?.strict).toBe(1);
     expect(db.prepare("PRAGMA foreign_key_list(sync_failure)").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(32);
+    expect(DUMP_TABLES).toHaveLength(36);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(PURE_AUTHORED_TABLES).not.toContain("sync_failure");
     expect(MIXED_AUTHORED_TABLES).not.toContain("sync_failure");
@@ -832,6 +863,30 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       expect.objectContaining({ seqno: 1, name: "source" }),
       expect.objectContaining({ seqno: 2, name: "id" }),
     ]);
+  });
+
+  it("adds strict immutable four-part analytics curve generations", () => {
+    db = openFull();
+    expect(createHash("sha256").update(MIGRATIONS[9]!.sql).digest("hex")).toBe(
+      "adff3df143002dae23e39a4633d6cc0e39b80fb3689dca843262549b883fbe77",
+    );
+    const tables = db.prepare("PRAGMA table_list").all() as Array<{
+      name: string;
+      strict: number;
+    }>;
+    for (const name of [
+      "analytics_curve_generation",
+      "analytics_curve_evidence",
+      "analytics_curve_generation_promotion",
+      "analytics_curve_current",
+      "analytics_curve_refresh_failure",
+    ]) {
+      expect(tables.find((row) => row.name === name)?.strict).toBe(1);
+    }
+    expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    expect(DUMP_TABLES).toHaveLength(36);
+    expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("analytics_curve_refresh_failure");
+    expect(DERIVED_TABLES).not.toContain("analytics_curve_generation");
   });
 
   it("omits the unreleased prior bone-stress column from the baseline schema", () => {

--- a/packages/kernel/tests/store-dump.test.ts
+++ b/packages/kernel/tests/store-dump.test.ts
@@ -71,11 +71,14 @@ describe("INV-2 canonical dump (armed with real ingest at W2)", () => {
   it("includes every incremental cache while excluding checkpoint operations", () => {
     const dumped = DUMP_TABLES.map(({ table }) => table);
     expect(dumped).toEqual(expect.arrayContaining([
+      "analytics_curve_current", "analytics_curve_evidence", "analytics_curve_generation",
+      "analytics_curve_generation_promotion",
       "ingest_candidate_index", "ingest_cluster_state", "ingest_dedup_pair_state",
       "ingest_dedup_session_state", "ingest_incremental_state",
     ]));
     expect(dumped).not.toContain("source_watermark");
     expect(dumped).not.toContain("sync_operation");
+    expect(dumped).not.toContain("analytics_curve_refresh_failure");
     expect(DERIVED_TABLES).toEqual(expect.arrayContaining([
       "ingest_candidate_index", "ingest_cluster_state", "ingest_dedup_pair_state", "ingest_dedup_session_state",
     ]));


### PR DESCRIPTION
## Summary

- add migration 10 for immutable four-part analytics curve generations and archived evidence
- derive content-addressed generation, request, and evidence identities from exact date selectors and archive revisions
- promote only complete Power and heart-rate evidence for Ride and VirtualRide, preserving the last-good generation across partial or failed refreshes
- persist safe operational failure codes separately and clear them atomically when a new generation becomes current
- include durable curve state in canonical store dumps while excluding transient refresh failures
- reject malformed inputs and re-verify identities, timestamps, completeness, and archive paths when reading

## Verification

- pnpm check
- 128 focused migration, repository, dump, and affected integration tests
- full suite: 8,165 passed and 15 skipped; one unrelated spend-meter fixed-timeout test failed only under full parallel load and passed 3/3 immediately in isolation
- local privacy and security review: no actionable findings

The optional external review helper was not run because it would upload the private uncommitted diff.