### PR TITLE
feat(sync): acquire bounded curve evidence

### DIFF
--- a/.changeset/tidy-curve-acquisition.md
+++ b/.changeset/tidy-curve-acquisition.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Prepare bounded, archive-first Power Progress curve refreshes with strict response validation.

--- a/packages/sync-intervals-icu/package.json
+++ b/packages/sync-intervals-icu/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@enduragent/kernel": "workspace:*",
-    "fflate": "0.8.3"
+    "fflate": "0.8.3",
+    "intervals-icu-api": "^0.3.1"
   },
   "devDependencies": {
     "tsup": "^8.4.0",

--- a/packages/sync-intervals-icu/src/analytics-curves.ts
+++ b/packages/sync-intervals-icu/src/analytics-curves.ts
@@ -1,0 +1,319 @@
+import {
+  AthleteHeartRateCurveSetSchema,
+  AthletePowerCurveSetSchema,
+  decode,
+} from "intervals-icu-api";
+import type { ArchiveManager } from "@enduragent/kernel/archive";
+import type { ClockPort, HttpResponse } from "@enduragent/kernel/ports";
+import {
+  ANALYTICS_CURVE_PARTS,
+  analyticsCurveWindows,
+  type AnalyticsCurveRefreshFailureCode,
+  type AnalyticsCurveRepository,
+  type PhysicalRequestLedger,
+  type PhysicalRequestReservation,
+  type SyncBudget,
+} from "@enduragent/kernel/store";
+import { MIN_CONFIGURED_INTERVAL_MS, validateBudget } from "./http.js";
+import type { IntervalsHttpFactory } from "./types.js";
+
+export const ANALYTICS_CURVE_REQUESTS = 4;
+export const ANALYTICS_CURVE_REQUEST_TIMEOUT_MS = 30_000;
+export const ANALYTICS_CURVE_LANE_TIMEOUT_MS = 120_000;
+export const ANALYTICS_CURVE_MAX_RESPONSE_BYTES = 2_097_152;
+export const ANALYTICS_CURVE_MAX_TOTAL_BYTES = 8_388_608;
+
+export type AnalyticsCurveRefreshOutcome =
+  | {
+      readonly kind: "promoted";
+      readonly generationId: string;
+      readonly frozenAt: string;
+      readonly physicalRequests: 4;
+      readonly decodedBytes: number;
+    }
+  | {
+      readonly kind: "failed" | "skipped";
+      readonly generationId: string;
+      readonly frozenAt: string;
+      readonly physicalRequests: number;
+      readonly decodedBytes: number;
+      readonly failure: AnalyticsCurveRefreshFailureCode;
+    };
+
+export interface RefreshAnalyticsCurvesOptions {
+  readonly athleteId: string;
+  readonly minRequestIntervalMs: number;
+  readonly httpFactory: IntervalsHttpFactory;
+  readonly archive: ArchiveManager;
+  readonly repository: AnalyticsCurveRepository;
+  readonly attemptLedger: PhysicalRequestLedger;
+  readonly wallClock: Pick<ClockPort, "now">;
+  readonly sleep: (ms: number, signal: AbortSignal) => Promise<void>;
+  readonly budget: SyncBudget;
+}
+
+class AnalyticsCurveRequestError extends Error {
+  constructor(readonly code: AnalyticsCurveRefreshFailureCode) {
+    super("analytics curve refresh failed");
+    this.name = "AnalyticsCurveRequestError";
+  }
+}
+
+function nonempty(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) throw new TypeError("athlete id is invalid");
+  return value;
+}
+
+function monotonicNow(budget: SyncBudget): number {
+  const value = budget.clock.monotonicNow();
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new TypeError("sync clock is invalid");
+  }
+  return value;
+}
+
+function wallEpochSeconds(clock: Pick<ClockPort, "now">): number {
+  const value = clock.now();
+  if (!Number.isSafeInteger(value) || value < 0 || value > 8_640_000_000_000_000) {
+    throw new TypeError("wall clock is invalid");
+  }
+  return Math.floor(value / 1_000);
+}
+
+function baseContentType(response: HttpResponse): string {
+  return (response.headers["content-type"] ?? "").split(";", 1)[0]!.trim().toLowerCase();
+}
+
+function responseFailure(status: number): AnalyticsCurveRefreshFailureCode {
+  if (status === 429) return "rate-limited";
+  if (status === 408 || status === 504) return "timeout";
+  if (status === 404 || status >= 500) return "provider-unavailable";
+  return "temporary-failure";
+}
+
+function parseResponse(response: HttpResponse): unknown {
+  if (response.status !== 200) throw new AnalyticsCurveRequestError(responseFailure(response.status));
+  if (baseContentType(response) !== "application/json") {
+    throw new AnalyticsCurveRequestError("malformed-response");
+  }
+  if (response.body.byteLength > ANALYTICS_CURVE_MAX_RESPONSE_BYTES) {
+    throw new AnalyticsCurveRequestError("response-too-large");
+  }
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(response.body);
+  } catch {
+    throw new AnalyticsCurveRequestError("malformed-response");
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new AnalyticsCurveRequestError("malformed-response");
+  }
+}
+
+function isValidCurvePayload(curveFamily: "power" | "heart-rate", value: unknown): boolean {
+  return curveFamily === "power"
+    ? decode(AthletePowerCurveSetSchema, value).ok
+    : decode(AthleteHeartRateCurveSetSchema, value).ok;
+}
+
+function requestUrl(
+  athleteId: string,
+  curveFamily: "power" | "heart-rate",
+  activityType: "Ride" | "VirtualRide",
+  selectors: readonly string[],
+): string {
+  const url = new URL(
+    `/api/v1/athlete/${encodeURIComponent(athleteId)}/${curveFamily === "power" ? "power" : "hr"}-curves`,
+    "https://intervals.icu",
+  );
+  url.searchParams.set("curves", selectors.join(","));
+  url.searchParams.set("type", "Ride");
+  url.searchParams.set("filters", JSON.stringify([{ field_id: "type", value: [activityType] }]));
+  return url.toString();
+}
+
+function safeFailure(
+  error: unknown,
+  budgetSignal: AbortSignal,
+  laneSignal: AbortSignal,
+): AnalyticsCurveRefreshFailureCode {
+  if (error instanceof AnalyticsCurveRequestError) return error.code;
+  if (budgetSignal.aborted) return "cancelled";
+  if (laneSignal.aborted) return "timeout";
+  return "temporary-failure";
+}
+
+async function recordFailure(
+  repository: AnalyticsCurveRepository,
+  generationId: string,
+  frozenEpochSeconds: number,
+  wallClock: Pick<ClockPort, "now">,
+  code: AnalyticsCurveRefreshFailureCode,
+): Promise<void> {
+  await repository.recordRefreshFailure({
+    generationId,
+    code,
+    failedEpochSeconds: Math.max(frozenEpochSeconds, wallEpochSeconds(wallClock)),
+  });
+}
+
+function release(reservation: PhysicalRequestReservation | null): void {
+  reservation?.release();
+}
+
+export async function refreshAnalyticsCurves(
+  options: RefreshAnalyticsCurvesOptions,
+): Promise<AnalyticsCurveRefreshOutcome> {
+  const athleteId = nonempty(options.athleteId);
+  validateBudget(options.budget);
+  if (!Number.isSafeInteger(options.minRequestIntervalMs)
+    || options.minRequestIntervalMs < MIN_CONFIGURED_INTERVAL_MS) {
+    throw new TypeError("minimum request interval is invalid");
+  }
+  if (typeof options.httpFactory !== "function" || typeof options.sleep !== "function"
+    || typeof options.archive?.writeSnapshot !== "function"
+    || typeof options.repository?.beginGeneration !== "function"
+    || typeof options.attemptLedger?.tryReserve !== "function") {
+    throw new TypeError("analytics curve dependencies are invalid");
+  }
+
+  const frozenEpochSeconds = wallEpochSeconds(options.wallClock);
+  const frozenAt = new Date(frozenEpochSeconds * 1_000).toISOString();
+  const frozenOn = frozenAt.slice(0, 10);
+  const { generation } = await options.repository.beginGeneration({ frozenEpochSeconds, frozenOn });
+  let physicalRequests = 0;
+  let decodedBytes = 0;
+  let reservation: PhysicalRequestReservation | null = null;
+
+  if (options.budget.maxRequests < ANALYTICS_CURVE_REQUESTS
+    || options.budget.maxArtifacts < ANALYTICS_CURVE_REQUESTS) {
+    await recordFailure(options.repository, generation.generationId, frozenEpochSeconds,
+      options.wallClock, "request-budget-exhausted");
+    return Object.freeze({ kind: "skipped", generationId: generation.generationId, frozenAt,
+      physicalRequests, decodedBytes, failure: "request-budget-exhausted" });
+  }
+  reservation = options.attemptLedger.tryReserve(
+    "store",
+    "store:analytics-curves",
+    ANALYTICS_CURVE_REQUESTS,
+  );
+  if (reservation === null) {
+    await recordFailure(options.repository, generation.generationId, frozenEpochSeconds,
+      options.wallClock, "request-budget-exhausted");
+    return Object.freeze({ kind: "skipped", generationId: generation.generationId, frozenAt,
+      physicalRequests, decodedBytes, failure: "request-budget-exhausted" });
+  }
+
+  const laneController = new AbortController();
+  const laneStart = monotonicNow(options.budget);
+  const laneDeadline = Math.min(
+    options.budget.deadlineMonotonicMs,
+    laneStart + ANALYTICS_CURVE_LANE_TIMEOUT_MS,
+  );
+  const timer = setTimeout(
+    () => laneController.abort(new Error("analytics curve lane timed out")),
+    Math.max(1, Math.min(ANALYTICS_CURVE_LANE_TIMEOUT_MS, laneDeadline - laneStart)),
+  );
+  const signal = AbortSignal.any([options.budget.signal, laneController.signal]);
+  const http = options.httpFactory({
+    outer: signal,
+    perRequestTimeoutMs: Math.min(
+      ANALYTICS_CURVE_REQUEST_TIMEOUT_MS,
+      options.budget.perRequestTimeoutMs,
+    ),
+  });
+  const windows = analyticsCurveWindows(frozenOn);
+  const selectors = Object.freeze([
+    `r.${windows.current.start}.${windows.current.end}`,
+    `r.${windows.previous.start}.${windows.previous.end}`,
+    `r.${windows.sustainability.start}.${windows.sustainability.end}`,
+  ]);
+  let lastRequestStart: number | null = null;
+
+  const assertActive = (): void => {
+    if (options.budget.signal.aborted) throw new AnalyticsCurveRequestError("cancelled");
+    if (laneController.signal.aborted || monotonicNow(options.budget) >= laneDeadline) {
+      throw new AnalyticsCurveRequestError("timeout");
+    }
+  };
+
+  try {
+    for (const part of ANALYTICS_CURVE_PARTS) {
+      assertActive();
+      if (lastRequestStart !== null) {
+        const delay = Math.max(
+          0,
+          lastRequestStart + options.minRequestIntervalMs - monotonicNow(options.budget),
+        );
+        if (delay > 0) {
+          if (monotonicNow(options.budget) + delay >= laneDeadline) {
+            throw new AnalyticsCurveRequestError("timeout");
+          }
+          await options.sleep(delay, signal);
+          assertActive();
+        }
+      }
+      reservation.charge();
+      physicalRequests += 1;
+      lastRequestStart = monotonicNow(options.budget);
+      let response: HttpResponse;
+      try {
+        response = await http.fetch({
+          method: "GET",
+          url: requestUrl(athleteId, part.curveFamily, part.activityType, selectors),
+        });
+      } catch {
+        if (options.budget.signal.aborted) throw new AnalyticsCurveRequestError("cancelled");
+        if (laneController.signal.aborted || monotonicNow(options.budget) >= laneDeadline) {
+          throw new AnalyticsCurveRequestError("timeout");
+        }
+        throw new AnalyticsCurveRequestError("network");
+      }
+      assertActive();
+      if (response.status === 200) decodedBytes += response.body.byteLength;
+      const payload = parseResponse(response);
+      if (decodedBytes > ANALYTICS_CURVE_MAX_TOTAL_BYTES) {
+        throw new AnalyticsCurveRequestError("response-too-large");
+      }
+      const archived = await options.archive.writeSnapshot(payload, { epochSeconds: frozenEpochSeconds });
+      assertActive();
+      if (!isValidCurvePayload(part.curveFamily, payload)) {
+        throw new AnalyticsCurveRequestError("malformed-response");
+      }
+      await options.repository.recordEvidence({
+        generationId: generation.generationId,
+        curveFamily: part.curveFamily,
+        activityType: part.activityType,
+        archiveAddress: archived.address,
+        archiveRelPath: archived.relPath,
+        archiveEpochSeconds: frozenEpochSeconds,
+        decodedBytes: response.body.byteLength,
+      });
+      assertActive();
+    }
+    assertActive();
+    const promotedEpochSeconds = Math.max(frozenEpochSeconds, wallEpochSeconds(options.wallClock));
+    await options.repository.promoteGeneration({
+      generationId: generation.generationId,
+      promotedEpochSeconds,
+    });
+    return Object.freeze({
+      kind: "promoted",
+      generationId: generation.generationId,
+      frozenAt,
+      physicalRequests: ANALYTICS_CURVE_REQUESTS,
+      decodedBytes,
+    });
+  } catch (error) {
+    const failure = safeFailure(error, options.budget.signal, laneController.signal);
+    await recordFailure(options.repository, generation.generationId, frozenEpochSeconds,
+      options.wallClock, failure);
+    return Object.freeze({ kind: "failed", generationId: generation.generationId, frozenAt,
+      physicalRequests, decodedBytes, failure });
+  } finally {
+    clearTimeout(timer);
+    release(reservation);
+  }
+}

--- a/packages/sync-intervals-icu/src/index.ts
+++ b/packages/sync-intervals-icu/src/index.ts
@@ -5,4 +5,5 @@ export * from "./landing.js";
 export * from "./source.js";
 export * from "./zip.js";
 export * from "./projection.js";
+export * from "./analytics-curves.js";
 export type { PhysicalRequestLedger } from "@enduragent/kernel/store";

--- a/packages/sync-intervals-icu/src/types.ts
+++ b/packages/sync-intervals-icu/src/types.ts
@@ -33,6 +33,11 @@ export const INTERVALS_ICU_CAPABILITIES = Object.freeze({
 
 export const MAX_JSON_BYTES = 67_108_864;
 
+export type IntervalsHttpFactory = (args: {
+  readonly outer: AbortSignal;
+  readonly perRequestTimeoutMs: number;
+}) => HttpPort;
+
 export interface IntervalsLandingAcl {
   activity(row: Record<string, unknown>): Readonly<Record<string, unknown>>;
   wellness(row: Record<string, unknown>): Readonly<Record<string, unknown>>;
@@ -45,10 +50,7 @@ export interface IntervalsIcuSourceOptions {
   readonly historyNewestDate: string;
   readonly historyOldestDate?: string;
   readonly minRequestIntervalMs: number;
-  readonly httpFactory: (args: {
-    readonly outer: AbortSignal;
-    readonly perRequestTimeoutMs: number;
-  }) => HttpPort;
+  readonly httpFactory: IntervalsHttpFactory;
   readonly archive: ArchiveManager;
   readonly acl: IntervalsLandingAcl;
   readonly wallClock: Pick<ClockPort, "now">;

--- a/packages/sync-intervals-icu/tests/analytics-curves.test.ts
+++ b/packages/sync-intervals-icu/tests/analytics-curves.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "vitest";
+import type { ArchiveManager } from "@enduragent/kernel/archive";
+import type { HttpResponse } from "@enduragent/kernel/ports";
+import {
+  analyticsCurveWindows,
+  createPhysicalRequestLedger,
+  type AnalyticsCurveGeneration,
+  type AnalyticsCurveRepository,
+  type SyncBudget,
+} from "@enduragent/kernel/store";
+import {
+  ANALYTICS_CURVE_MAX_RESPONSE_BYTES,
+  refreshAnalyticsCurves,
+  type RefreshAnalyticsCurvesOptions,
+} from "../src/index.js";
+
+const FROZEN_MS = Date.parse("2012-06-15T12:00:00.000Z");
+const FROZEN_EPOCH_SECONDS = FROZEN_MS / 1_000;
+const GENERATION_ID = "a".repeat(64);
+
+function jsonResponse(value: unknown, status = 200): HttpResponse {
+  return {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+    body: new TextEncoder().encode(JSON.stringify(value)),
+  };
+}
+
+function generation(): AnalyticsCurveGeneration {
+  return Object.freeze({
+    generationId: GENERATION_ID,
+    frozenEpochSeconds: FROZEN_EPOCH_SECONDS,
+    frozenOn: "2012-06-15",
+    windows: analyticsCurveWindows("2012-06-15"),
+  });
+}
+
+function harness(responses: readonly (HttpResponse | Error)[] = [
+  jsonResponse({ activities: {}, list: [] }),
+  jsonResponse({ activities: {}, list: [] }),
+  jsonResponse({ activities: {}, list: [] }),
+  jsonResponse({ activities: {}, list: [] }),
+]) {
+  let monotonicMs = 1_000;
+  let responseIndex = 0;
+  let active = 0;
+  let maxActive = 0;
+  let archiveIndex = 0;
+  const events: string[] = [];
+  const requests: string[] = [];
+  const evidence: Parameters<AnalyticsCurveRepository["recordEvidence"]>[0][] = [];
+  const failures: Parameters<AnalyticsCurveRepository["recordRefreshFailure"]>[0][] = [];
+  const promotions: Parameters<AnalyticsCurveRepository["promoteGeneration"]>[0][] = [];
+  const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
+  const repository: AnalyticsCurveRepository = Object.freeze({
+    async beginGeneration() {
+      events.push("begin");
+      return { generation: generation(), inserted: true };
+    },
+    async recordEvidence(input: Parameters<AnalyticsCurveRepository["recordEvidence"]>[0]) {
+      evidence.push(input);
+      events.push(`evidence:${input.curveFamily}:${input.activityType}`);
+      return {
+        inserted: true,
+        evidence: {
+          evidenceId: "b".repeat(64),
+          requestIdentity: "c".repeat(64),
+          ...input,
+        },
+      };
+    },
+    async promoteGeneration(input: Parameters<AnalyticsCurveRepository["promoteGeneration"]>[0]) {
+      promotions.push(input);
+      events.push("promote");
+      return "promoted" as const;
+    },
+    async recordRefreshFailure(
+      input: Parameters<AnalyticsCurveRepository["recordRefreshFailure"]>[0],
+    ) {
+      failures.push(input);
+      events.push(`failure:${input.code}`);
+    },
+    async readState() {
+      return { current: null, refreshFailure: null };
+    },
+  });
+  const archive = Object.freeze({
+    async writeSnapshot() {
+      const current = archiveIndex++;
+      const address = (current + 1).toString(16).padStart(64, "0");
+      events.push(`archive:${current}`);
+      return { address, relPath: `2012/06/${address}.json.gz`, deduped: false };
+    },
+  }) as unknown as ArchiveManager;
+  const controller = new AbortController();
+  const budget: SyncBudget = {
+    signal: controller.signal,
+    clock: { monotonicNow: () => monotonicMs },
+    deadlineMonotonicMs: 601_000,
+    perRequestTimeoutMs: 30_000,
+    maxRequests: 64,
+    maxArtifacts: 1_000,
+  };
+  const options: RefreshAnalyticsCurvesOptions = {
+    athleteId: "i0",
+    minRequestIntervalMs: 250,
+    archive,
+    repository,
+    attemptLedger: ledger,
+    wallClock: { now: () => FROZEN_MS },
+    sleep: async (ms, signal) => {
+      signal.throwIfAborted();
+      monotonicMs += ms;
+    },
+    budget,
+    httpFactory: ({ outer, perRequestTimeoutMs }) => {
+      expect(outer).toBeInstanceOf(AbortSignal);
+      expect(perRequestTimeoutMs).toBe(30_000);
+      return {
+        async fetch(request) {
+          requests.push(request.url);
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await Promise.resolve();
+          active -= 1;
+          const selected = responses[responseIndex++];
+          if (selected instanceof Error) throw selected;
+          if (selected === undefined) throw new Error("unexpected request");
+          return selected;
+        },
+      };
+    },
+  };
+  return { options, budget, controller, ledger, repository, requests, events, evidence, failures,
+    promotions, maxActive: () => maxActive };
+}
+
+describe("analytics curve acquisition", () => {
+  it("reserves four calls, serializes exact selectors, archives first, and promotes once", async () => {
+    const test = harness();
+    const result = await refreshAnalyticsCurves(test.options);
+
+    expect(result).toMatchObject({
+      kind: "promoted",
+      generationId: GENERATION_ID,
+      frozenAt: "2012-06-15T12:00:00.000Z",
+      physicalRequests: 4,
+    });
+    expect(test.maxActive()).toBe(1);
+    expect(test.ledger.snapshot()).toMatchObject({
+      storeRequests: 4,
+      totalRequests: 4,
+      byTag: { "store:analytics-curves": 4 },
+    });
+    expect(test.requests.map((value) => new URL(value).pathname)).toEqual([
+      "/api/v1/athlete/i0/power-curves",
+      "/api/v1/athlete/i0/power-curves",
+      "/api/v1/athlete/i0/hr-curves",
+      "/api/v1/athlete/i0/hr-curves",
+    ]);
+    const parsed = test.requests.map((value) => new URL(value));
+    expect(parsed.map((url) => url.searchParams.get("curves"))).toEqual(Array(4).fill(
+      "r.2012-05-19.2012-06-15,r.2012-04-21.2012-05-18,r.2012-05-05.2012-06-15",
+    ));
+    expect(parsed.map((url) => url.searchParams.get("type"))).toEqual(Array(4).fill("Ride"));
+    expect(parsed.map((url) => JSON.parse(url.searchParams.get("filters")!))).toEqual([
+      [{ field_id: "type", value: ["Ride"] }],
+      [{ field_id: "type", value: ["VirtualRide"] }],
+      [{ field_id: "type", value: ["Ride"] }],
+      [{ field_id: "type", value: ["VirtualRide"] }],
+    ]);
+    expect(test.events).toEqual([
+      "begin",
+      "archive:0", "evidence:power:Ride",
+      "archive:1", "evidence:power:VirtualRide",
+      "archive:2", "evidence:heart-rate:Ride",
+      "archive:3", "evidence:heart-rate:VirtualRide",
+      "promote",
+    ]);
+    expect(test.evidence).toHaveLength(4);
+    expect(test.promotions).toEqual([{
+      generationId: GENERATION_ID,
+      promotedEpochSeconds: FROZEN_EPOCH_SECONDS,
+    }]);
+    expect(test.failures).toEqual([]);
+  });
+
+  it("makes zero calls when all four physical slots cannot be reserved", async () => {
+    const test = harness();
+    for (let index = 0; index < 61; index += 1) {
+      test.ledger.charge("store", "store:activities");
+    }
+    const result = await refreshAnalyticsCurves(test.options);
+
+    expect(result).toMatchObject({
+      kind: "skipped",
+      physicalRequests: 0,
+      failure: "request-budget-exhausted",
+    });
+    expect(test.requests).toEqual([]);
+    expect(test.evidence).toEqual([]);
+    expect(test.promotions).toEqual([]);
+    expect(test.failures).toEqual([{
+      generationId: GENERATION_ID,
+      code: "request-budget-exhausted",
+      failedEpochSeconds: FROZEN_EPOCH_SECONDS,
+    }]);
+  });
+
+  it("does not retry a failed part and releases every unused reserved slot", async () => {
+    const test = harness([
+      jsonResponse({ activities: {}, list: [] }),
+      jsonResponse({ message: "limited" }, 429),
+    ]);
+    const result = await refreshAnalyticsCurves(test.options);
+
+    expect(result).toMatchObject({ kind: "failed", physicalRequests: 2, failure: "rate-limited" });
+    expect(test.requests).toHaveLength(2);
+    expect(test.evidence).toHaveLength(1);
+    expect(test.promotions).toEqual([]);
+    expect(test.failures[0]?.code).toBe("rate-limited");
+    const remaining = test.ledger.tryReserve("store", "store:analytics-curves", 62);
+    expect(remaining).not.toBeNull();
+    remaining?.release();
+  });
+
+  it("archives valid JSON before rejecting a malformed curve envelope", async () => {
+    const test = harness([jsonResponse({ activities: {} })]);
+    const result = await refreshAnalyticsCurves(test.options);
+
+    expect(result).toMatchObject({
+      kind: "failed",
+      physicalRequests: 1,
+      failure: "malformed-response",
+    });
+    expect(test.events).toEqual(["begin", "archive:0", "failure:malformed-response"]);
+    expect(test.evidence).toEqual([]);
+    expect(test.promotions).toEqual([]);
+  });
+
+  it("rejects an oversized decoded response before archive or persistence", async () => {
+    const test = harness([{
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: new Uint8Array(ANALYTICS_CURVE_MAX_RESPONSE_BYTES + 1),
+    }]);
+    const result = await refreshAnalyticsCurves(test.options);
+
+    expect(result).toMatchObject({
+      kind: "failed",
+      physicalRequests: 1,
+      failure: "response-too-large",
+    });
+    expect(test.events).toEqual(["begin", "failure:response-too-large"]);
+  });
+
+  it("aborts before the first call without publishing a partial generation", async () => {
+    const test = harness();
+    test.controller.abort(new Error("shutdown"));
+    const result = await refreshAnalyticsCurves(test.options);
+
+    expect(result).toMatchObject({ kind: "failed", physicalRequests: 0, failure: "cancelled" });
+    expect(test.requests).toEqual([]);
+    expect(test.evidence).toEqual([]);
+    expect(test.promotions).toEqual([]);
+  });
+
+  it("classifies a transport error without replaying the request", async () => {
+    const test = harness([new Error("offline")]);
+    const result = await refreshAnalyticsCurves(test.options);
+
+    expect(result).toMatchObject({ kind: "failed", physicalRequests: 1, failure: "network" });
+    expect(test.requests).toHaveLength(1);
+    expect(test.promotions).toEqual([]);
+  });
+
+  it("stops before the next request when the lane deadline has no pacing headroom", async () => {
+    const test = harness();
+    const options = {
+      ...test.options,
+      budget: { ...test.budget, deadlineMonotonicMs: 1_100 },
+    };
+    const result = await refreshAnalyticsCurves(options);
+
+    expect(result).toMatchObject({ kind: "failed", physicalRequests: 1, failure: "timeout" });
+    expect(test.requests).toHaveLength(1);
+    expect(test.promotions).toEqual([]);
+  });
+
+  it("does not misclassify a local archive failure as a network failure", async () => {
+    const test = harness();
+    const options = {
+      ...test.options,
+      archive: Object.freeze({
+        async writeSnapshot() {
+          throw new Error("disk unavailable");
+        },
+      }) as unknown as ArchiveManager,
+    };
+    const result = await refreshAnalyticsCurves(options);
+
+    expect(result).toMatchObject({
+      kind: "failed",
+      physicalRequests: 1,
+      failure: "temporary-failure",
+    });
+    expect(test.requests).toHaveLength(1);
+    expect(test.evidence).toEqual([]);
+    expect(test.promotions).toEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -709,6 +709,9 @@ importers:
       fflate:
         specifier: 0.8.3
         version: 0.8.3
+      intervals-icu-api:
+        specifier: ^0.3.1
+        version: 0.3.1(typescript@6.0.3)
     devDependencies:
       tsup:
         specifier: ^8.4.0


### PR DESCRIPTION
## Summary

- add a store-native Power Progress curve refresher backed by intervals-icu-api 0.3.1 response schemas
- atomically reserve all four analytics request slots before sending any provider call
- fetch power and heart-rate curves sequentially for explicit Ride and VirtualRide filters with exact adjacent 28-day and 42-day selectors
- disable replay by issuing one physical request per part and release every unused reservation on failure
- enforce 30-second request, 120-second lane, 2 MiB response, and 8 MiB total bounds
- archive each valid JSON response before schema validation and evidence persistence; promote only after all four parts succeed
- preserve last-good state and record only closed safe failure categories for budget, provider, timeout, cancellation, transport, validation, size, or local failures

## Verification

- pnpm check
- complete sync package: 373 tests passed
- focused acquisition, ledger, HTTP, and repository tests: 29 passed
- complete monorepo: 539 test files passed, 5 skipped; 8,175 tests passed, 15 skipped
- new acquisition files: 0 lint warnings and 0 errors
- frozen offline lockfile validation
- local privacy and security review: no actionable findings

The optional external review helper was not run because it would upload the private uncommitted diff.