### PR TITLE
feat(sync): join curve refresh to store window

### DIFF
--- a/.changeset/curves-join-store-window.md
+++ b/.changeset/curves-join-store-window.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Refresh Power Progress curve evidence in the normal desktop sync window without blocking base training-data updates.

--- a/packages/coach/src/analytics-curves.ts
+++ b/packages/coach/src/analytics-curves.ts
@@ -1,0 +1,81 @@
+import { setTimeout as setTimeoutPromise } from "node:timers/promises";
+import { makeIntervalsHttpFactory } from "@enduragent/core";
+import {
+  H,
+  createAnalyticsCurveRepository,
+  type PhysicalRequestLedger,
+  type SyncBudget,
+} from "@enduragent/kernel/store";
+import { createArchiveManager } from "@enduragent/kernel-node/archive";
+import { nodeFileSystem } from "@enduragent/kernel-node/filesystem";
+import { createNodeCrypto } from "@enduragent/kernel-node/ingest";
+import {
+  refreshAnalyticsCurves,
+  type AnalyticsCurveRefreshOutcome,
+} from "@enduragent/sync-intervals-icu";
+import { DEFAULT_REQUEST_INTERVAL_MS } from "./backfill.js";
+import { withCoachStoreWriter, type CoachStoreWriterContext } from "./runtime.js";
+
+export interface RunAnalyticsCurveRefreshOptions {
+  readonly env: Record<string, string | undefined>;
+  readonly writerContext?: CoachStoreWriterContext;
+  readonly apiKey: string;
+  readonly athleteId: string;
+  readonly frozenAt: Date;
+  readonly budget: SyncBudget;
+  readonly attemptLedger: PhysicalRequestLedger;
+  readonly baseFetch?: typeof globalThis.fetch;
+}
+
+export interface RunAnalyticsCurveRefreshDependencies {
+  readonly sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+}
+
+export async function runAnalyticsCurveRefresh(
+  options: RunAnalyticsCurveRefreshOptions,
+  dependencies: RunAnalyticsCurveRefreshDependencies = {},
+): Promise<AnalyticsCurveRefreshOutcome> {
+  const frozenEpochMs = options.frozenAt.getTime();
+  if (
+    !Number.isSafeInteger(frozenEpochMs) ||
+    frozenEpochMs < 0 ||
+    frozenEpochMs > 8_640_000_000_000_000
+  ) {
+    throw new TypeError("analytics curve frozen instant is invalid");
+  }
+  const sleep =
+    dependencies.sleep ??
+    ((ms: number, signal: AbortSignal) =>
+      setTimeoutPromise(ms, undefined, { signal }).then(() => undefined));
+
+  const refresh = async ({ home, store }: CoachStoreWriterContext) => {
+    const crypto = createNodeCrypto();
+    const archive = createArchiveManager({
+      archiveRoot: home.archiveDir,
+      crypto,
+      fs: nodeFileSystem(),
+    });
+    const repository = createAnalyticsCurveRepository(store, (fields) => {
+      if (fields.length === 0) throw new TypeError("empty key tuple");
+      return H(crypto, ...(fields as [string | number, ...(string | number)[]]));
+    });
+    return refreshAnalyticsCurves({
+      athleteId: options.athleteId,
+      minRequestIntervalMs: DEFAULT_REQUEST_INTERVAL_MS,
+      httpFactory: makeIntervalsHttpFactory({
+        apiKey: options.apiKey,
+        ...(options.baseFetch === undefined ? {} : { baseFetch: options.baseFetch }),
+      }),
+      archive,
+      repository,
+      attemptLedger: options.attemptLedger,
+      wallClock: { now: () => frozenEpochMs },
+      sleep,
+      budget: options.budget,
+    });
+  };
+
+  return options.writerContext === undefined
+    ? withCoachStoreWriter(options.env, refresh)
+    : refresh(options.writerContext);
+}

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -1,5 +1,10 @@
 import { performance } from "node:perf_hooks";
-import type { Config, AthleteDataReader, ReferenceRuntime } from "@enduragent/core";
+import type {
+  Config,
+  AthleteDataReader,
+  ReferenceRuntime,
+  SubsystemLogger,
+} from "@enduragent/core";
 import { createStoreAthleteDataReader, createSubsystemLogger } from "@enduragent/core";
 import {
   createCanonicalActivityReader,
@@ -15,6 +20,7 @@ import type { ProducedLocalBundle } from "@enduragent/kernel/reference/local-bun
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { openReadonlySqliteStorage } from "@enduragent/kernel-node/sqlite";
 import { join } from "node:path";
+import { runAnalyticsCurveRefresh } from "./analytics-curves.js";
 import { runReferenceCapture } from "./capture.js";
 import { createLocalBundleProducer } from "./local-bundle-producer.js";
 import type { CoachStoreWriterContext } from "./runtime.js";
@@ -48,6 +54,7 @@ export interface StoreWriteResult<T> {
 
 export interface StoreRuntimeDependencies {
   readonly capture?: typeof runReferenceCapture;
+  readonly refreshCurves?: typeof runAnalyticsCurveRefresh;
   readonly produce?: (manifest: ReferenceCaptureManifest) => Promise<ProducedLocalBundle>;
   readonly now?: () => Date;
   readonly monotonicNow?: () => number;
@@ -81,8 +88,9 @@ export class StoreRuntime {
   private readonlyStore: SqlReadStore | undefined;
   private readonly canonicalActivities: CanonicalActivityReader;
   private readonly dependencies: Required<
-    Pick<StoreRuntimeDependencies, "capture" | "produce" | "now" | "monotonicNow">
+    Pick<StoreRuntimeDependencies, "capture" | "refreshCurves" | "produce" | "now" | "monotonicNow">
   >;
+  private readonly logger: SubsystemLogger;
   private readonly scheduler: WallClockScheduler;
   private snapshotValue: ProducedLocalBundle | undefined;
   private activeLedger: PhysicalRequestLedger | undefined;
@@ -106,9 +114,10 @@ export class StoreRuntime {
     const dependencies = options.dependencies ?? {};
     const now = dependencies.now ?? (() => new Date());
     const schedulerDependencies = dependencies.schedulerDependencies ?? {};
-    const logger = createSubsystemLogger("sync", options.home.root);
+    this.logger = createSubsystemLogger("sync", options.home.root);
     this.dependencies = {
       capture: dependencies.capture ?? runReferenceCapture,
+      refreshCurves: dependencies.refreshCurves ?? runAnalyticsCurveRefresh,
       produce:
         dependencies.produce ??
         ((manifest) =>
@@ -135,7 +144,7 @@ export class StoreRuntime {
         await this.runWindow();
       },
       onError: (error) => {
-        logger.error("scheduled_store_refresh_failed", error);
+        this.logger.error("scheduled_store_refresh_failed", error);
       },
       dependencies: {
         nowEpochMs: schedulerDependencies.nowEpochMs ?? (() => now().getTime()),
@@ -401,6 +410,22 @@ LIMIT 1`,
       ]);
       let published = false;
       if (captureResult.status === "fulfilled" && captureResult.value !== undefined) {
+        try {
+          await this.dependencies.refreshCurves({
+            env: this.options.env,
+            ...(this.options.writerContext === undefined
+              ? {}
+              : { writerContext: this.options.writerContext }),
+            apiKey: config.intervals.apiKey,
+            athleteId: config.intervals.athleteId,
+            frozenAt: now,
+            budget,
+            attemptLedger: ledger,
+          });
+        } catch (error) {
+          this.logger.warn("analytics_curve_refresh_failed", error);
+        }
+        controller.signal.throwIfAborted();
         const produced = await this.dependencies.produce(captureResult.value);
         this.snapshotValue = produced;
         published = true;

--- a/packages/coach/tests/analytics-curves.test.ts
+++ b/packages/coach/tests/analytics-curves.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createPhysicalRequestLedger,
+  runMigrations,
+  type SyncBudget,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runAnalyticsCurveRefresh } from "../src/analytics-curves.js";
+import type { CoachStoreWriterContext } from "../src/runtime.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("desktop analytics curve composition", () => {
+  it("uses the active writer, authenticated transport, private archive, and shared ledger", async () => {
+    const root = await mkdtemp(join(tmpdir(), "analytics-curve-composition-"));
+    roots.push(root);
+    const home = {
+      root,
+      storeDir: join(root, "store"),
+      archiveDir: join(root, "archive"),
+      configDir: join(root, "config"),
+    };
+    await mkdir(home.archiveDir, { recursive: true });
+    const store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    const writerContext: CoachStoreWriterContext = {
+      home,
+      store,
+      listener: {} as CoachStoreWriterContext["listener"],
+    };
+    const ledger = createPhysicalRequestLedger({
+      storeLimit: 64,
+      legacyLimit: 15,
+      totalLimit: 79,
+    });
+    const controller = new AbortController();
+    let monotonicMs = 1_000;
+    const budget: SyncBudget = {
+      signal: controller.signal,
+      clock: { monotonicNow: () => monotonicMs },
+      deadlineMonotonicMs: 601_000,
+      perRequestTimeoutMs: 30_000,
+      maxRequests: 64,
+      maxArtifacts: 1_000,
+    };
+    const requests: string[] = [];
+    const baseFetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+      requests.push(String(input));
+      const authorization = new Headers(init?.headers).get("authorization");
+      expect(authorization).toMatch(/^Basic /);
+      expect(authorization).not.toContain("synthetic-secret");
+      return new Response(JSON.stringify({ activities: {}, list: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      });
+    });
+
+    try {
+      const outcome = await runAnalyticsCurveRefresh(
+        {
+          env: {},
+          writerContext,
+          apiKey: "synthetic-secret",
+          athleteId: "i0",
+          frozenAt: new Date("2012-06-15T12:00:00.000Z"),
+          budget,
+          attemptLedger: ledger,
+          baseFetch,
+        },
+        {
+          sleep: async (ms, signal) => {
+            signal.throwIfAborted();
+            monotonicMs += ms;
+          },
+        },
+      );
+
+      expect(outcome).toMatchObject({
+        kind: "promoted",
+        frozenAt: "2012-06-15T12:00:00.000Z",
+        physicalRequests: 4,
+      });
+      expect(requests).toHaveLength(4);
+      expect(ledger.snapshot()).toMatchObject({
+        storeRequests: 4,
+        totalRequests: 4,
+        byTag: { "store:analytics-curves": 4 },
+      });
+      await expect(
+        store.get("SELECT generation_id FROM analytics_curve_current WHERE singleton = 1"),
+      ).resolves.toEqual({ generation_id: outcome.generationId });
+      await expect(
+        store.get("SELECT count(*) AS count FROM analytics_curve_evidence"),
+      ).resolves.toEqual({ count: 4 });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("rejects an invalid frozen instant before opening a writer", async () => {
+    await expect(
+      runAnalyticsCurveRefresh({
+        env: {},
+        apiKey: "synthetic-secret",
+        athleteId: "i0",
+        frozenAt: new Date(Number.NaN),
+        budget: {} as SyncBudget,
+        attemptLedger: {} as never,
+      }),
+    ).rejects.toThrow("analytics curve frozen instant is invalid");
+  });
+});

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -42,6 +42,19 @@ const produced: ProducedLocalBundle = {
   bundle: { activities: [], wellness: [], ftpHistory: [], athlete: { sportSettings: [] } },
 };
 
+async function skipCurveRefresh(
+  options: Parameters<typeof import("../src/analytics-curves.js").runAnalyticsCurveRefresh>[0],
+) {
+  return {
+    kind: "skipped" as const,
+    generationId: "a".repeat(64),
+    frozenAt: options.frozenAt.toISOString(),
+    physicalRequests: 0,
+    decodedBytes: 0,
+    failure: "request-budget-exhausted" as const,
+  };
+}
+
 function emptyReadonlyStore(): SqlReadStore {
   return {
     get: vi.fn(async () => undefined),
@@ -72,6 +85,23 @@ async function makeRuntime(
       return manifest;
     },
   );
+  const refreshCurves = vi.fn(
+    async (
+      options: Parameters<typeof import("../src/analytics-curves.js").runAnalyticsCurveRefresh>[0],
+    ) => {
+      const reservation = options.attemptLedger.tryReserve("store", "store:analytics-curves", 4);
+      if (reservation === null) throw new Error("synthetic curve reservation failed");
+      for (let index = 0; index < 4; index += 1) reservation.charge();
+      reservation.release();
+      return {
+        kind: "promoted" as const,
+        generationId: "a".repeat(64),
+        frozenAt: options.frozenAt.toISOString(),
+        physicalRequests: 4 as const,
+        decodedBytes: 0,
+      };
+    },
+  );
   const produce = vi.fn(async () => produced);
   runtime = createStoreRuntime({
     env: {},
@@ -86,27 +116,72 @@ async function makeRuntime(
     reference,
     dependencies: {
       capture,
+      refreshCurves,
       produce,
       now: () => new Date("1998-07-18T12:00:00.000Z"),
       monotonicNow: () => 1,
       openReadonlyStore: () => readonlyStore,
     },
   });
-  return { runtime, capture, produce, reference, readonlyStore };
+  return { root, runtime, capture, refreshCurves, produce, reference, readonlyStore };
 }
 
 describe("StoreRuntime", () => {
-  it("starts both request stacks in one ledger window and publishes only after production", async () => {
-    const { runtime, reference } = await makeRuntime();
+  it("runs base capture, curve acquisition, and legacy refresh in one ledger window", async () => {
+    const { runtime, capture, refreshCurves, produce, reference } = await makeRuntime();
     const result = await runtime.runWindow();
-    expect(result.counts).toMatchObject({ storeRequests: 1, legacyRequests: 1, totalRequests: 2 });
+    expect(result.counts).toMatchObject({
+      storeRequests: 5,
+      legacyRequests: 1,
+      totalRequests: 6,
+      byTag: { "store:settings": 1, "store:analytics-curves": 4 },
+    });
+    expect(refreshCurves).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "synthetic",
+        athleteId: "synthetic-athlete",
+        frozenAt: new Date("1998-07-18T12:00:00.000Z"),
+      }),
+    );
+    expect(capture.mock.invocationCallOrder[0]).toBeLessThan(
+      refreshCurves.mock.invocationCallOrder[0]!,
+    );
+    expect(refreshCurves.mock.invocationCallOrder[0]).toBeLessThan(
+      produce.mock.invocationCallOrder[0]!,
+    );
     expect(reference.runScheduledOnce).toHaveBeenCalledTimes(1);
     expect(runtime.currentSnapshot()).toBe(produced);
     await runtime.close();
   });
 
+  it("waits for both base lanes before reserving optional curve capacity", async () => {
+    const { runtime, refreshCurves, reference } = await makeRuntime();
+    let releaseLegacy!: () => void;
+    let markLegacyStarted!: () => void;
+    const legacyStarted = new Promise<void>((resolve) => {
+      markLegacyStarted = resolve;
+    });
+    vi.mocked(reference.runScheduledOnce).mockImplementationOnce(async () => {
+      runtime.attemptLedgerForRun().charge("legacy", "legacy:reference");
+      markLegacyStarted();
+      await new Promise<void>((resolve) => {
+        releaseLegacy = resolve;
+      });
+      return { kind: "ran", lastSyncAt: "1998-07-18T12:00:00.000Z", refreshed: [] };
+    });
+
+    const window = runtime.runWindow();
+    await legacyStarted;
+    await Promise.resolve();
+    expect(refreshCurves).not.toHaveBeenCalled();
+    releaseLegacy();
+    await expect(window).resolves.toMatchObject({ published: true, legacySucceeded: true });
+    expect(refreshCurves).toHaveBeenCalledTimes(1);
+    await runtime.close();
+  });
+
   it("runs the legacy lane without capture when the intervals.icu API key is empty", async () => {
-    const { runtime, capture, produce, reference } = await makeRuntime({
+    const { runtime, capture, refreshCurves, produce, reference } = await makeRuntime({
       ...config,
       intervals: { ...config.intervals, apiKey: "" },
     });
@@ -117,6 +192,7 @@ describe("StoreRuntime", () => {
       legacySucceeded: true,
     });
     expect(capture).not.toHaveBeenCalled();
+    expect(refreshCurves).not.toHaveBeenCalled();
     expect(produce).not.toHaveBeenCalled();
     expect(reference.runScheduledOnce).toHaveBeenCalledTimes(1);
     expect(runtime.currentSnapshot()).toBeUndefined();
@@ -144,11 +220,42 @@ describe("StoreRuntime", () => {
   });
 
   it("retains the prior complete snapshot after a later capture failure", async () => {
-    const { runtime, capture } = await makeRuntime();
+    const { runtime, capture, refreshCurves } = await makeRuntime();
     await runtime.runWindow();
+    refreshCurves.mockClear();
     capture.mockRejectedValueOnce(new Error("capture failed"));
     await expect(runtime.runWindow()).rejects.toThrow("capture failed");
+    expect(refreshCurves).not.toHaveBeenCalled();
     expect(runtime.currentSnapshot()).toBe(produced);
+    await runtime.close();
+  });
+
+  it("isolates an unexpected curve refresh failure and publishes the base snapshot", async () => {
+    const { root, runtime, refreshCurves, produce } = await makeRuntime();
+    refreshCurves.mockRejectedValueOnce(
+      Object.assign(new Error("curve adapter failed"), {
+        apiKey: "SECRET-CURVE-KEY",
+        authorization: "Basic SECRET",
+      }),
+    );
+
+    await expect(runtime.runWindow()).resolves.toMatchObject({
+      published: true,
+      legacySucceeded: true,
+      counts: { storeRequests: 1, legacyRequests: 1, totalRequests: 2 },
+    });
+    expect(produce).toHaveBeenCalledTimes(1);
+    expect(runtime.currentSnapshot()).toBe(produced);
+
+    const raw = await readFile(join(root, "logs", "log.jsonl"), "utf8");
+    expect(JSON.parse(raw.trim())).toMatchObject({
+      level: "warn",
+      component: "sync",
+      event: "analytics_curve_refresh_failed",
+      err: { name: "Error", message: "curve adapter failed", authorization: "[redacted]" },
+    });
+    expect(raw).not.toContain("SECRET-CURVE-KEY");
+    expect(raw).not.toContain("Basic SECRET");
     await runtime.close();
   });
 
@@ -187,6 +294,7 @@ describe("StoreRuntime", () => {
       reference,
       dependencies: {
         capture,
+        refreshCurves: skipCurveRefresh,
         produce: vi.fn(async () => produced),
         now: () => new Date("1998-07-18T12:00:00.000Z"),
         monotonicNow: () => 1,
@@ -257,6 +365,7 @@ describe("StoreRuntime", () => {
               release = () => resolve(manifest);
             }),
         ),
+        refreshCurves: skipCurveRefresh,
         produce: vi.fn(async () => produced),
         now: () => new Date("1998-07-18T12:00:00.000Z"),
         monotonicNow: () => 1,
@@ -493,6 +602,7 @@ describe("StoreRuntime", () => {
             });
           },
         ),
+        refreshCurves: skipCurveRefresh,
         produce: vi.fn(async () => produced),
         now: () => new Date("1998-07-18T12:00:00.000Z"),
         monotonicNow: () => 1,


### PR DESCRIPTION
## Summary

- compose bounded curve acquisition with the active desktop writer, authenticated transport, private archive, and analytics repository
- run curve refresh only after base capture and legacy refresh settle, using their shared physical-request ledger
- isolate expected and unexpected curve failures so base snapshot publication continues, with redacted diagnostics

## Acceptance criteria

- curve calls use the normal store window, frozen instant, cancellation signal, request deadline, and shared 64/15/79 ledger
- optional curve reservation cannot consume capacity still needed by either base lane
- missing credentials or failed base capture send no curve requests
- curve failure cannot roll back a valid base snapshot or expose credentials in logs
- active desktop writer and archive paths are reused without a nested writer lock

## Test plan

- pnpm check
- pnpm exec vitest run packages/coach/tests: 49 files, 610 tests passed
- focused curve and store runtime tests: 17 tests passed
- full pnpm test: 539 files and 8,178 tests passed; one unrelated memory-query corpus test exceeded its 5 second timeout under parallel load, then passed all 13 tests on focused rerun
- oxfmt check, oxlint, changeset policy, and git diff check passed

External autoreview was not run because it would upload the private uncommitted diff; local pre-commit review found and fixed optional-lane reservation ordering.