### PR TITLE
feat(sync): project archived analytics curves

### DIFF
--- a/.changeset/curve-evidence-metrics.md
+++ b/.changeset/curve-evidence-metrics.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Feed verified current Power Progress snapshots into existing local metrics without making duplicate provider requests.

--- a/packages/coach/src/analytics-curves.ts
+++ b/packages/coach/src/analytics-curves.ts
@@ -2,6 +2,7 @@ import { setTimeout as setTimeoutPromise } from "node:timers/promises";
 import { makeIntervalsHttpFactory } from "@enduragent/core";
 import {
   H,
+  analyticsCurveWindows,
   createAnalyticsCurveRepository,
   type PhysicalRequestLedger,
   type SyncBudget,
@@ -22,6 +23,7 @@ export interface RunAnalyticsCurveRefreshOptions {
   readonly apiKey: string;
   readonly athleteId: string;
   readonly frozenAt: Date;
+  readonly frozenOn: string;
   readonly budget: SyncBudget;
   readonly attemptLedger: PhysicalRequestLedger;
   readonly baseFetch?: typeof globalThis.fetch;
@@ -43,6 +45,7 @@ export async function runAnalyticsCurveRefresh(
   ) {
     throw new TypeError("analytics curve frozen instant is invalid");
   }
+  analyticsCurveWindows(options.frozenOn);
   const sleep =
     dependencies.sleep ??
     ((ms: number, signal: AbortSignal) =>
@@ -61,6 +64,7 @@ export async function runAnalyticsCurveRefresh(
     });
     return refreshAnalyticsCurves({
       athleteId: options.athleteId,
+      frozenOn: options.frozenOn,
       minRequestIntervalMs: DEFAULT_REQUEST_INTERVAL_MS,
       httpFactory: makeIntervalsHttpFactory({
         apiKey: options.apiKey,

--- a/packages/coach/src/local-bundle-producer.ts
+++ b/packages/coach/src/local-bundle-producer.ts
@@ -14,12 +14,16 @@ import {
   type ReferenceBundleProjection,
   type VerifiedSnapshotReader,
 } from "@enduragent/kernel/reference/local-bundle";
-import type { SqlReadStore } from "@enduragent/kernel/store";
+import { H, createAnalyticsCurveStateReader, type SqlReadStore } from "@enduragent/kernel/store";
 import { createVerifiedSnapshotReader } from "@enduragent/kernel-node/archive";
 import { nodeFileSystem } from "@enduragent/kernel-node/filesystem";
 import { createNodeCrypto } from "@enduragent/kernel-node/ingest";
 import { openReadonlySqliteStorage } from "@enduragent/kernel-node/sqlite";
-import { decodeLocalBundleProjection, type LocalBundleSelectedEvidence } from "@enduragent/sync-intervals-icu";
+import {
+  decodeLocalBundleProjection,
+  projectAnalyticsCurveEvidence,
+  type LocalBundleSelectedEvidence,
+} from "@enduragent/sync-intervals-icu";
 
 const SOURCE = "intervals-icu" as const;
 
@@ -60,6 +64,30 @@ export interface LocalBundleProducerDependencies {
     snapshots: VerifiedSnapshotReader,
     activityFilter: ActivityProjectionFilter,
   ) => Promise<ProducedLocalBundle["bundle"]>;
+  readonly projectCurves?: (input: {
+    readonly store: SqlReadStore;
+    readonly snapshots: VerifiedSnapshotReader;
+    readonly crypto: CryptoPort;
+    readonly frozenOn: string;
+  }) => Promise<Partial<
+    Pick<ProducedLocalBundle["bundle"], "powerCurves" | "hrCurves" | "sustainabilityCurves">
+  >>;
+}
+
+async function projectCurrentCurves(input: {
+  readonly store: SqlReadStore;
+  readonly snapshots: VerifiedSnapshotReader;
+  readonly crypto: CryptoPort;
+  readonly frozenOn: string;
+}): Promise<Partial<
+  Pick<ProducedLocalBundle["bundle"], "powerCurves" | "hrCurves" | "sustainabilityCurves">
+>> {
+  const state = await createAnalyticsCurveStateReader(input.store, (fields: readonly (string | number)[]) => {
+    if (fields.length === 0) throw new TypeError("empty key tuple");
+    return H(input.crypto, ...(fields as [string | number, ...(string | number)[]]));
+  }).readState();
+  if (state.current === null || state.current.generation.frozenOn !== input.frozenOn) return {};
+  return projectAnalyticsCurveEvidence(state.current, input.snapshots);
 }
 
 export function createLocalBundleProducer(
@@ -71,6 +99,7 @@ export function createLocalBundleProducer(
   const makeFileSystem = dependencies.fileSystem ?? nodeFileSystem;
   const makeCrypto = dependencies.crypto ?? createNodeCrypto;
   const decode = dependencies.decode ?? decodeLocalBundleProjection;
+  const projectCurves = dependencies.projectCurves ?? projectCurrentCurves;
   const activityFilter = options.activityFilter ?? KEEP_ALL_ACTIVITIES;
   const bundleProjection = options.bundleProjection ?? IDENTITY_REFERENCE_BUNDLE_PROJECTION;
 
@@ -81,7 +110,8 @@ export function createLocalBundleProducer(
       let projectionFailed = false;
       try {
         store = openStore(options.storePath);
-        const snapshots = makeSnapshots({ archiveRoot: options.archiveRoot, fs: makeFileSystem(), crypto: makeCrypto() });
+        const crypto = makeCrypto();
+        const snapshots = makeSnapshots({ archiveRoot: options.archiveRoot, fs: makeFileSystem(), crypto });
         const selected: LocalBundleSelectedEvidence = {
           activities: await readSelectedSourceRows(store, { source: SOURCE, lane: "activities" }),
           settings: await readSelectedGenericRows(store, { source: SOURCE, lane: "settings" }),
@@ -89,8 +119,21 @@ export function createLocalBundleProducer(
           streams: await readSelectedGenericRows(store, { source: SOURCE, lane: "streams" }),
         };
         const bundle = await decode(manifest, selected, snapshots, activityFilter);
+        let curveProjection: Partial<
+          Pick<typeof bundle, "powerCurves" | "hrCurves" | "sustainabilityCurves">
+        > = {};
+        try {
+          curveProjection = await projectCurves({
+            store,
+            snapshots,
+            crypto,
+            frozenOn: manifest.plan.frozenNow.slice(0, 10),
+          });
+        } catch {
+          curveProjection = {};
+        }
         produced = { captureId: manifest.capture_id, frozenNow: manifest.plan.frozenNow,
-          bundle: bundleProjection(bundle) };
+          bundle: bundleProjection({ ...bundle, ...curveProjection }) };
       } catch {
         projectionFailed = true;
       }

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -419,6 +419,7 @@ LIMIT 1`,
             apiKey: config.intervals.apiKey,
             athleteId: config.intervals.athleteId,
             frozenAt: now,
+            frozenOn: captureResult.value.plan.frozenNow.slice(0, 10),
             budget,
             attemptLedger: ledger,
           });

--- a/packages/coach/tests/analytics-curves.test.ts
+++ b/packages/coach/tests/analytics-curves.test.ts
@@ -71,6 +71,7 @@ describe("desktop analytics curve composition", () => {
           apiKey: "synthetic-secret",
           athleteId: "i0",
           frozenAt: new Date("2012-06-15T12:00:00.000Z"),
+          frozenOn: "2012-06-15",
           budget,
           attemptLedger: ledger,
           baseFetch,
@@ -112,9 +113,20 @@ describe("desktop analytics curve composition", () => {
         apiKey: "synthetic-secret",
         athleteId: "i0",
         frozenAt: new Date(Number.NaN),
+        frozenOn: "2012-06-15",
         budget: {} as SyncBudget,
         attemptLedger: {} as never,
       }),
     ).rejects.toThrow("analytics curve frozen instant is invalid");
+  });
+
+  it("rejects an invalid capture civil date before opening a writer", async () => {
+    await expect(
+      runAnalyticsCurveRefresh({
+        env: {}, apiKey: "synthetic-secret", athleteId: "i0",
+        frozenAt: new Date("2012-06-15T12:00:00.000Z"), frozenOn: "2012-02-30",
+        budget: {} as SyncBudget, attemptLedger: {} as never,
+      }),
+    ).rejects.toThrow("invalid analytics curve input");
   });
 });

--- a/packages/coach/tests/local-bundle-producer.test.ts
+++ b/packages/coach/tests/local-bundle-producer.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CryptoPort, FileSystemPort } from "@enduragent/kernel/ports";
 import { validateReferenceCaptureManifest } from "@enduragent/kernel/reference/capture";
-import type { ReferenceBundle, VerifiedSnapshotReader } from "@enduragent/kernel/reference/local-bundle";
+import type { ReferenceBundle } from "@enduragent/kernel/reference/local-bundle";
 import type { Row, SqlReadStore } from "@enduragent/kernel/store";
 import {
   createLocalBundleProducer,
@@ -95,6 +95,40 @@ describe("local bundle producer composition", () => {
     ]);
     expect(readerKeys).toEqual(["readVerifiedSnapshot"]);
     expect(selectedKeys.sort()).toEqual(["activities", "settings", "streams", "wellness"]);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("merges current curve evidence before the configured bundle projection", async () => {
+    const store = readStore();
+    const curveProjection = { powerCurves: { list: [] }, hrCurves: { list: [] },
+      sustainabilityCurves: { cycling: { power: {}, hr: {} } } };
+    const bundleProjection = vi.fn((bundle: ReferenceBundle) => bundle);
+    const projectCurves = vi.fn(async () => curveProjection);
+    const producer = createLocalBundleProducer({ storePath: "synthetic.sqlite",
+      archiveRoot: "synthetic-archive", bundleProjection },
+    dependencies(store, { projectCurves }));
+
+    const value = await producer.produce(manifest());
+
+    expect(projectCurves).toHaveBeenCalledWith(expect.objectContaining({
+      store, frozenOn: "1998-06-10",
+    }));
+    expect(bundleProjection).toHaveBeenCalledWith({ ...emptyBundle, ...curveProjection });
+    expect(value.bundle).toEqual({ ...emptyBundle, ...curveProjection });
+  });
+
+  it("keeps the base bundle publishable when optional curve projection fails", async () => {
+    const close = vi.fn(async () => {});
+    const store = readStore(close);
+    const producer = createLocalBundleProducer({ storePath: "synthetic.sqlite",
+      archiveRoot: "synthetic-archive" }, dependencies(store, {
+      projectCurves: async () => { throw new Error("curve-private-sentinel"); },
+    }));
+
+    await expect(producer.produce(manifest())).resolves.toEqual({
+      captureId: "123e4567-e89b-42d3-a456-426614174000",
+      frozenNow: "1998-06-10T12:00:00", bundle: emptyBundle,
+    });
     expect(close).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -141,6 +141,7 @@ describe("StoreRuntime", () => {
         apiKey: "synthetic",
         athleteId: "synthetic-athlete",
         frozenAt: new Date("1998-07-18T12:00:00.000Z"),
+        frozenOn: "1998-07-18",
       }),
     );
     expect(capture.mock.invocationCallOrder[0]).toBeLessThan(

--- a/packages/kernel-node/tests/analytics-curve-repository.test.ts
+++ b/packages/kernel-node/tests/analytics-curve-repository.test.ts
@@ -4,6 +4,7 @@ import {
   ANALYTICS_CURVE_PARTS,
   analyticsCurveWindows,
   createAnalyticsCurveRepository,
+  createAnalyticsCurveStateReader,
   runMigrations,
   type AnalyticsCurveRepository,
   type MigratorStore,
@@ -73,6 +74,19 @@ describe("analytics curve repository", () => {
     expect(Object.isFrozen(first.generation.windows.current)).toBe(true);
   });
 
+  it("allows the capture civil date to be one day either side of the UTC instant", async () => {
+    const lateUtc = Date.parse("2026-08-07T23:30:00.000Z") / 1_000;
+    const adjacent = await repository.beginGeneration({
+      frozenEpochSeconds: lateUtc,
+      frozenOn: "2026-08-08",
+    });
+    expect(adjacent.generation.windows.current.end).toBe("2026-08-08");
+    await expect(repository.beginGeneration({
+      frozenEpochSeconds: lateUtc,
+      frozenOn: "2026-08-09",
+    })).rejects.toThrow(new TypeError("invalid analytics curve input"));
+  });
+
   it("records exactly four immutable parts and promotes only the complete generation", async () => {
     const { generation } = await begin();
     const firstPart = ANALYTICS_CURVE_PARTS[0]!;
@@ -124,6 +138,7 @@ describe("analytics curve repository", () => {
     expect(new Set(state.current?.evidence.map((row) => row.requestIdentity)).size).toBe(4);
     expect(state.refreshFailure).toBeNull();
     expect(Object.isFrozen(state.current?.evidence)).toBe(true);
+    await expect(createAnalyticsCurveStateReader(store, hashKey).readState()).resolves.toEqual(state);
   });
 
   it("preserves last-good state across a failed partial refresh and clears failure on promotion", async () => {

--- a/packages/kernel/src/store/analytics-curve-repository.ts
+++ b/packages/kernel/src/store/analytics-curve-repository.ts
@@ -1,4 +1,4 @@
-import type { Row, SqlStore } from "./ports.js";
+import type { Row, SqlReadStore, SqlStore } from "./ports.js";
 
 export const ANALYTICS_CURVE_PARTS = Object.freeze([
   Object.freeze({ curveFamily: "power" as const, activityType: "Ride" as const }),
@@ -86,12 +86,17 @@ export interface AnalyticsCurveRepository {
   readState(): Promise<AnalyticsCurveState>;
 }
 
+export interface AnalyticsCurveStateReader {
+  readState(): Promise<AnalyticsCurveState>;
+}
+
 type HashKey = (fields: readonly (string | number)[]) => Promise<string>;
 
 const HEX = /^[0-9a-f]{64}$/;
 const CIVIL_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const MAX_EPOCH_SECONDS = 8_640_000_000_000;
 const MAX_DECODED_BYTES = 2_097_152;
+const DAY_MS = 86_400_000;
 
 function invalidInput(): never {
   throw new TypeError("invalid analytics curve input");
@@ -140,6 +145,11 @@ function shiftCivilDate(value: string, days: number): string {
   const parsed = new Date(`${value}T00:00:00.000Z`);
   parsed.setUTCDate(parsed.getUTCDate() + days);
   return parsed.toISOString().slice(0, 10);
+}
+
+function civilDateMatchesInstant(value: string, epochSeconds: number): boolean {
+  const utcDate = new Date(epochSeconds * 1_000).toISOString().slice(0, 10);
+  return Math.abs(Date.parse(`${value}T00:00:00.000Z`) - Date.parse(`${utcDate}T00:00:00.000Z`)) <= DAY_MS;
 }
 
 export function analyticsCurveWindows(frozenOn: string): AnalyticsCurveWindows {
@@ -221,7 +231,7 @@ function generationFromRow(row: Row | undefined): AnalyticsCurveGeneration {
     || row.previous_start !== windows.previous.start || row.previous_end !== windows.previous.end
     || row.sustainability_start !== windows.sustainability.start
     || row.sustainability_end !== windows.sustainability.end
-    || new Date(row.frozen_epoch_s * 1_000).toISOString().slice(0, 10) !== row.frozen_on) {
+    || !civilDateMatchesInstant(row.frozen_on, row.frozen_epoch_s)) {
     invariantMismatch();
   }
   return Object.freeze({
@@ -287,12 +297,16 @@ const GENERATION_COLUMNS = `generation_id,source,lane,frozen_epoch_s,frozen_on,
 const EVIDENCE_COLUMNS = `evidence_id,generation_id,curve_family,activity_type,request_identity,
   archive_address,archive_rel_path,archive_epoch_s,decoded_bytes`;
 
-export function createAnalyticsCurveRepository(
-  store: SqlStore,
+function createAnalyticsCurveReadAccess(
+  store: SqlReadStore,
   hashKey: HashKey,
-): AnalyticsCurveRepository {
-  if (store === null || typeof store !== "object" || typeof hashKey !== "function") invalidInput();
-
+): {
+  readonly readGeneration: (generationId: string) => Promise<AnalyticsCurveGeneration>;
+  readonly readEvidence: (
+    generation: AnalyticsCurveGeneration,
+  ) => Promise<readonly AnalyticsCurveEvidence[]>;
+  readonly readState: () => Promise<AnalyticsCurveState>;
+} {
   const readGeneration = async (generationId: string): Promise<AnalyticsCurveGeneration> => {
     const generation = generationFromRow(await store.get(
       `SELECT ${GENERATION_COLUMNS} FROM analytics_curve_generation WHERE generation_id=?`,
@@ -326,12 +340,69 @@ ORDER BY curve_family COLLATE BINARY ASC, activity_type COLLATE BINARY ASC`, [ge
     return evidence;
   };
 
+  const readState = async (): Promise<AnalyticsCurveState> => {
+    const failureRow = await store.get(
+      "SELECT generation_id,code,failed_epoch_s FROM analytics_curve_refresh_failure WHERE singleton=1",
+    );
+    let refreshFailure: AnalyticsCurveRefreshFailure | null = null;
+    if (failureRow !== undefined) {
+      if (!isAddress(failureRow.generation_id) || !isRefreshFailureCode(failureRow.code)
+        || !isEpoch(failureRow.failed_epoch_s)) invariantMismatch();
+      const failureGeneration = await readGeneration(failureRow.generation_id);
+      if (failureRow.failed_epoch_s < failureGeneration.frozenEpochSeconds) invariantMismatch();
+      refreshFailure = Object.freeze({
+        generationId: failureRow.generation_id,
+        code: failureRow.code,
+        failedEpochSeconds: failureRow.failed_epoch_s,
+      });
+    }
+    const currentRow = await store.get(`SELECT c.generation_id,p.promoted_epoch_s
+FROM analytics_curve_current AS c
+JOIN analytics_curve_generation_promotion AS p ON p.generation_id=c.generation_id
+WHERE c.singleton=1`);
+    if (currentRow === undefined) return Object.freeze({ current: null, refreshFailure });
+    if (!isAddress(currentRow.generation_id) || !isEpoch(currentRow.promoted_epoch_s)) {
+      invariantMismatch();
+    }
+    const generation = await readGeneration(currentRow.generation_id);
+    if (currentRow.promoted_epoch_s < generation.frozenEpochSeconds) invariantMismatch();
+    const evidence = await readEvidence(generation);
+    if (!isCompleteEvidence(evidence)) invariantMismatch();
+    return Object.freeze({
+      current: Object.freeze({
+        generation,
+        evidence: Object.freeze(evidence),
+        promotedEpochSeconds: currentRow.promoted_epoch_s,
+      }),
+      refreshFailure,
+    });
+  };
+
+  return Object.freeze({ readGeneration, readEvidence, readState });
+}
+
+export function createAnalyticsCurveStateReader(
+  store: SqlReadStore,
+  hashKey: HashKey,
+): AnalyticsCurveStateReader {
+  if (store === null || typeof store !== "object" || typeof hashKey !== "function") invalidInput();
+  const access = createAnalyticsCurveReadAccess(store, hashKey);
+  return Object.freeze({ readState: access.readState });
+}
+
+export function createAnalyticsCurveRepository(
+  store: SqlStore,
+  hashKey: HashKey,
+): AnalyticsCurveRepository {
+  if (store === null || typeof store !== "object" || typeof hashKey !== "function") invalidInput();
+  const { readGeneration, readEvidence, readState } = createAnalyticsCurveReadAccess(store, hashKey);
+
   const repository: AnalyticsCurveRepository = {
     async beginGeneration(input) {
       if (!isPlainExact(input, ["frozenEpochSeconds", "frozenOn"])
         || !isEpoch(input.frozenEpochSeconds)) invalidInput();
       const frozenOn = civilDate(input.frozenOn);
-      if (new Date(input.frozenEpochSeconds * 1_000).toISOString().slice(0, 10) !== frozenOn) {
+      if (!civilDateMatchesInstant(frozenOn, input.frozenEpochSeconds)) {
         invalidInput();
       }
       const seed: AnalyticsCurveGeneration = {
@@ -464,43 +535,7 @@ ON CONFLICT(singleton) DO UPDATE SET generation_id=excluded.generation_id,
       ]);
     },
 
-    async readState() {
-      const failureRow = await store.get(
-        "SELECT generation_id,code,failed_epoch_s FROM analytics_curve_refresh_failure WHERE singleton=1",
-      );
-      let refreshFailure: AnalyticsCurveRefreshFailure | null = null;
-      if (failureRow !== undefined) {
-        if (!isAddress(failureRow.generation_id) || !isRefreshFailureCode(failureRow.code)
-          || !isEpoch(failureRow.failed_epoch_s)) invariantMismatch();
-        const failureGeneration = await readGeneration(failureRow.generation_id);
-        if (failureRow.failed_epoch_s < failureGeneration.frozenEpochSeconds) invariantMismatch();
-        refreshFailure = Object.freeze({
-          generationId: failureRow.generation_id,
-          code: failureRow.code,
-          failedEpochSeconds: failureRow.failed_epoch_s,
-        });
-      }
-      const currentRow = await store.get(`SELECT c.generation_id,p.promoted_epoch_s
-FROM analytics_curve_current AS c
-JOIN analytics_curve_generation_promotion AS p ON p.generation_id=c.generation_id
-WHERE c.singleton=1`);
-      if (currentRow === undefined) return Object.freeze({ current: null, refreshFailure });
-      if (!isAddress(currentRow.generation_id) || !isEpoch(currentRow.promoted_epoch_s)) {
-        invariantMismatch();
-      }
-      const generation = await readGeneration(currentRow.generation_id);
-      if (currentRow.promoted_epoch_s < generation.frozenEpochSeconds) invariantMismatch();
-      const evidence = await readEvidence(generation);
-      if (!isCompleteEvidence(evidence)) invariantMismatch();
-      return Object.freeze({
-        current: Object.freeze({
-          generation,
-          evidence: Object.freeze(evidence),
-          promotedEpochSeconds: currentRow.promoted_epoch_s,
-        }),
-        refreshFailure,
-      });
-    },
+    readState,
   };
   return Object.freeze(repository);
 }

--- a/packages/sync-intervals-icu/src/analytics-curve-projection.ts
+++ b/packages/sync-intervals-icu/src/analytics-curve-projection.ts
@@ -1,0 +1,274 @@
+import {
+  AthleteHeartRateCurveSetSchema,
+  AthletePowerCurveSetSchema,
+  decode,
+} from "intervals-icu-api";
+import type {
+  ReferenceBundle,
+  VerifiedSnapshotReader,
+} from "@enduragent/kernel/reference/local-bundle";
+import { ANALYTICS_CURVE_PARTS, type AnalyticsCurveState } from "@enduragent/kernel/store";
+
+const MAX_PROJECTED_AXIS_LENGTH = 65_536;
+const ACTIVITY_TYPES = Object.freeze(["Ride", "VirtualRide"] as const);
+
+type CurrentAnalyticsCurves = NonNullable<AnalyticsCurveState["current"]>;
+type ActivityType = (typeof ACTIVITY_TYPES)[number];
+type CurveFamily = "power" | "heart-rate";
+type CurveProjection = Required<
+  Pick<ReferenceBundle, "powerCurves" | "hrCurves" | "sustainabilityCurves">
+>;
+
+interface NormalizedCurve {
+  readonly id: string;
+  readonly secs: readonly number[];
+  readonly values: readonly (number | null)[];
+}
+
+export class AnalyticsCurveProjectionError extends Error {
+  readonly code = "ANALYTICS_CURVE_PROJECTION_FAILED";
+
+  constructor() {
+    super("analytics curve evidence could not be projected");
+    this.name = "AnalyticsCurveProjectionError";
+    this.stack = `${this.name}: ${this.message}`;
+    Object.freeze(this);
+  }
+}
+
+function fail(): never {
+  throw new AnalyticsCurveProjectionError();
+}
+
+function partKey(family: CurveFamily, activityType: ActivityType): string {
+  return `${family}:${activityType}`;
+}
+
+function normalizeCurve(
+  id: string,
+  secs: readonly number[],
+  values: readonly (number | null)[],
+): NormalizedCurve {
+  if (secs.length !== values.length || secs.length > MAX_PROJECTED_AXIS_LENGTH) fail();
+  const projectedSecs: number[] = [];
+  const projectedValues: (number | null)[] = [];
+  let previous = 0;
+  for (let index = 0; index < secs.length; index += 1) {
+    const seconds = secs[index];
+    const value = values[index];
+    if (
+      !Number.isSafeInteger(seconds) ||
+      seconds <= previous ||
+      (value !== null && (!Number.isFinite(value) || value < 0))
+    )
+      fail();
+    projectedSecs.push(seconds);
+    projectedValues.push(value);
+    previous = seconds;
+  }
+  return Object.freeze({
+    id,
+    secs: Object.freeze(projectedSecs),
+    values: Object.freeze(projectedValues),
+  });
+}
+
+function selectPowerCurves(
+  payload: unknown,
+  selectors: ReadonlySet<string>,
+): readonly NormalizedCurve[] {
+  const decoded = decode(AthletePowerCurveSetSchema, payload);
+  if (!decoded.ok) fail();
+  const seen = new Set<string>();
+  const selected: NormalizedCurve[] = [];
+  for (const curve of decoded.value.list) {
+    if (typeof curve.id !== "string" || !selectors.has(curve.id)) continue;
+    if (seen.has(curve.id)) fail();
+    seen.add(curve.id);
+    selected.push(normalizeCurve(curve.id, curve.secs, curve.values));
+  }
+  return Object.freeze(selected);
+}
+
+function selectHeartRateCurves(
+  payload: unknown,
+  selectors: ReadonlySet<string>,
+): readonly NormalizedCurve[] {
+  const decoded = decode(AthleteHeartRateCurveSetSchema, payload);
+  if (!decoded.ok) fail();
+  const seen = new Set<string>();
+  const selected: NormalizedCurve[] = [];
+  for (const curve of decoded.value.list) {
+    if (typeof curve.id !== "string" || !selectors.has(curve.id)) continue;
+    if (seen.has(curve.id)) fail();
+    seen.add(curve.id);
+    selected.push(normalizeCurve(curve.id, curve.secs, curve.values));
+  }
+  return Object.freeze(selected);
+}
+
+function curveById(curves: readonly NormalizedCurve[], id: string): NormalizedCurve | undefined {
+  return curves.find((curve) => curve.id === id);
+}
+
+function aggregateCurves(
+  curvesByType: Readonly<Record<ActivityType, readonly NormalizedCurve[]>>,
+  selectors: readonly string[],
+): readonly NormalizedCurve[] {
+  // The headline delta is family-wide. Reconstruct the provider's cycling-family best curve
+  // from the explicitly separated outdoor/indoor evidence by taking the best value per duration.
+  const aggregated: NormalizedCurve[] = [];
+  for (const id of selectors) {
+    const bySecond = new Map<number, number | null>();
+    for (const activityType of ACTIVITY_TYPES) {
+      const curve = curveById(curvesByType[activityType], id);
+      if (curve === undefined) continue;
+      for (let index = 0; index < curve.secs.length; index += 1) {
+        const seconds = curve.secs[index]!;
+        const value = curve.values[index] ?? null;
+        const previous = bySecond.get(seconds);
+        if (previous === undefined || previous === null || (value !== null && value > previous)) {
+          bySecond.set(seconds, value);
+        }
+      }
+    }
+    if (bySecond.size === 0) continue;
+    const secs = [...bySecond.keys()].sort((left, right) => left - right);
+    aggregated.push(
+      Object.freeze({
+        id,
+        secs: Object.freeze(secs),
+        values: Object.freeze(secs.map((seconds) => bySecond.get(seconds) ?? null)),
+      }),
+    );
+  }
+  return Object.freeze(aggregated);
+}
+
+function powerEnvelope(
+  curves: readonly NormalizedCurve[],
+): NonNullable<ReferenceBundle["powerCurves"]> {
+  const list = curves.map((curve) => {
+    const secs = [...curve.secs];
+    const watts = [...curve.values];
+    const entry = { id: curve.id, secs, watts };
+    Object.freeze(secs);
+    Object.freeze(watts);
+    return Object.freeze(entry);
+  });
+  Object.freeze(list);
+  return Object.freeze({ list });
+}
+
+function heartRateEnvelope(
+  curves: readonly NormalizedCurve[],
+): NonNullable<ReferenceBundle["hrCurves"]> {
+  const list = curves.map((curve) => {
+    const secs = [...curve.secs];
+    const values = [...curve.values];
+    const entry = { id: curve.id, secs, values };
+    Object.freeze(secs);
+    Object.freeze(values);
+    return Object.freeze(entry);
+  });
+  Object.freeze(list);
+  return Object.freeze({ list });
+}
+
+async function projectCurrentAnalyticsCurves(
+  current: CurrentAnalyticsCurves,
+  snapshots: VerifiedSnapshotReader,
+): Promise<CurveProjection> {
+  if (typeof snapshots?.readVerifiedSnapshot !== "function") fail();
+  const evidenceByPart = new Map<string, CurrentAnalyticsCurves["evidence"][number]>();
+  for (const evidence of current.evidence) {
+    const key = partKey(evidence.curveFamily, evidence.activityType);
+    if (evidenceByPart.has(key)) fail();
+    evidenceByPart.set(key, evidence);
+  }
+  if (evidenceByPart.size !== ANALYTICS_CURVE_PARTS.length) fail();
+
+  const windows = current.generation.windows;
+  const selectors = Object.freeze([
+    `r.${windows.current.start}.${windows.current.end}`,
+    `r.${windows.previous.start}.${windows.previous.end}`,
+    `r.${windows.sustainability.start}.${windows.sustainability.end}`,
+  ]);
+  const selectorSet = new Set(selectors);
+  const projected = new Map<string, readonly NormalizedCurve[]>();
+
+  for (const part of ANALYTICS_CURVE_PARTS) {
+    const evidence = evidenceByPart.get(partKey(part.curveFamily, part.activityType));
+    if (evidence === undefined) fail();
+    const payload = await snapshots.readVerifiedSnapshot({
+      address: evidence.archiveAddress,
+      rel_path: evidence.archiveRelPath,
+    });
+    projected.set(
+      partKey(part.curveFamily, part.activityType),
+      part.curveFamily === "power"
+        ? selectPowerCurves(payload, selectorSet)
+        : selectHeartRateCurves(payload, selectorSet),
+    );
+  }
+
+  const curves = (family: CurveFamily, activityType: ActivityType): readonly NormalizedCurve[] =>
+    projected.get(partKey(family, activityType)) ?? fail();
+  const powerByType = Object.freeze({
+    Ride: curves("power", "Ride"),
+    VirtualRide: curves("power", "VirtualRide"),
+  });
+  const heartRateByType = Object.freeze({
+    Ride: curves("heart-rate", "Ride"),
+    VirtualRide: curves("heart-rate", "VirtualRide"),
+  });
+  const sustainabilityId = selectors[2]!;
+
+  return Object.freeze({
+    powerCurves: powerEnvelope(aggregateCurves(powerByType, selectors)),
+    hrCurves: heartRateEnvelope(aggregateCurves(heartRateByType, selectors)),
+    sustainabilityCurves: Object.freeze({
+      cycling: Object.freeze({
+        power: Object.freeze({
+          Ride: powerEnvelope(
+            curveById(powerByType.Ride, sustainabilityId)
+              ? [curveById(powerByType.Ride, sustainabilityId)!]
+              : [],
+          ),
+          VirtualRide: powerEnvelope(
+            curveById(powerByType.VirtualRide, sustainabilityId)
+              ? [curveById(powerByType.VirtualRide, sustainabilityId)!]
+              : [],
+          ),
+        }),
+        hr: Object.freeze({
+          Ride: heartRateEnvelope(
+            curveById(heartRateByType.Ride, sustainabilityId)
+              ? [curveById(heartRateByType.Ride, sustainabilityId)!]
+              : [],
+          ),
+          VirtualRide: heartRateEnvelope(
+            curveById(heartRateByType.VirtualRide, sustainabilityId)
+              ? [curveById(heartRateByType.VirtualRide, sustainabilityId)!]
+              : [],
+          ),
+        }),
+      }),
+    }),
+  });
+}
+
+/**
+ * Rebuild the existing metric-input curve envelopes exclusively from the last promoted,
+ * archive-verified four-part generation. No provider client or request surface is accepted here.
+ */
+export async function projectAnalyticsCurveEvidence(
+  current: CurrentAnalyticsCurves,
+  snapshots: VerifiedSnapshotReader,
+): Promise<CurveProjection> {
+  try {
+    return await projectCurrentAnalyticsCurves(current, snapshots);
+  } catch {
+    throw new AnalyticsCurveProjectionError();
+  }
+}

--- a/packages/sync-intervals-icu/src/analytics-curves.ts
+++ b/packages/sync-intervals-icu/src/analytics-curves.ts
@@ -42,6 +42,7 @@ export type AnalyticsCurveRefreshOutcome =
 
 export interface RefreshAnalyticsCurvesOptions {
   readonly athleteId: string;
+  readonly frozenOn: string;
   readonly minRequestIntervalMs: number;
   readonly httpFactory: IntervalsHttpFactory;
   readonly archive: ArchiveManager;
@@ -181,7 +182,8 @@ export async function refreshAnalyticsCurves(
 
   const frozenEpochSeconds = wallEpochSeconds(options.wallClock);
   const frozenAt = new Date(frozenEpochSeconds * 1_000).toISOString();
-  const frozenOn = frozenAt.slice(0, 10);
+  const frozenOn = options.frozenOn;
+  const windows = analyticsCurveWindows(frozenOn);
   const { generation } = await options.repository.beginGeneration({ frozenEpochSeconds, frozenOn });
   let physicalRequests = 0;
   let decodedBytes = 0;
@@ -224,7 +226,6 @@ export async function refreshAnalyticsCurves(
       options.budget.perRequestTimeoutMs,
     ),
   });
-  const windows = analyticsCurveWindows(frozenOn);
   const selectors = Object.freeze([
     `r.${windows.current.start}.${windows.current.end}`,
     `r.${windows.previous.start}.${windows.previous.end}`,

--- a/packages/sync-intervals-icu/src/index.ts
+++ b/packages/sync-intervals-icu/src/index.ts
@@ -6,4 +6,5 @@ export * from "./source.js";
 export * from "./zip.js";
 export * from "./projection.js";
 export * from "./analytics-curves.js";
+export * from "./analytics-curve-projection.js";
 export type { PhysicalRequestLedger } from "@enduragent/kernel/store";

--- a/packages/sync-intervals-icu/tests/analytics-curve-projection.test.ts
+++ b/packages/sync-intervals-icu/tests/analytics-curve-projection.test.ts
@@ -57,7 +57,7 @@ function heartRateCurve(id: string, secs: readonly number[], values: readonly (n
   return { id, secs: [...secs], values: [...values], provider_private_field: "not-projected" };
 }
 
-function payloads() {
+function payloads(): readonly unknown[] {
   return [
     {
       activities: { private_activity: { id: "private_activity", start_date_local: FROZEN_ON } },
@@ -90,7 +90,7 @@ function payloads() {
         heartRateCurve(SUSTAINABILITY, [300, 600, 1_200, 3_600], [176, 169, 164, 149]),
       ],
     },
-  ] as const;
+  ];
 }
 
 function reader(

--- a/packages/sync-intervals-icu/tests/analytics-curve-projection.test.ts
+++ b/packages/sync-intervals-icu/tests/analytics-curve-projection.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ReferenceBundle,
+  VerifiedSnapshotReader,
+} from "@enduragent/kernel/reference/local-bundle";
+import { buildMetricInput } from "@enduragent/kernel/reference/local-bundle";
+import {
+  computeHrCurveDelta,
+  computePowerCurveDelta,
+  computeSustainabilityProfile,
+  type SustainabilitySportBlock,
+} from "@enduragent/kernel/reference/metrics";
+import {
+  ANALYTICS_CURVE_PARTS,
+  analyticsCurveWindows,
+  type AnalyticsCurveState,
+} from "@enduragent/kernel/store";
+import { AnalyticsCurveProjectionError, projectAnalyticsCurveEvidence } from "../src/index.js";
+
+const FROZEN_ON = "2026-08-07";
+const FROZEN_EPOCH_SECONDS = Date.parse(`${FROZEN_ON}T12:00:00.000Z`) / 1_000;
+const WINDOWS = analyticsCurveWindows(FROZEN_ON);
+const CURRENT = `r.${WINDOWS.current.start}.${WINDOWS.current.end}`;
+const PREVIOUS = `r.${WINDOWS.previous.start}.${WINDOWS.previous.end}`;
+const SUSTAINABILITY = `r.${WINDOWS.sustainability.start}.${WINDOWS.sustainability.end}`;
+
+function currentState(): NonNullable<AnalyticsCurveState["current"]> {
+  return {
+    generation: {
+      generationId: "a".repeat(64),
+      frozenEpochSeconds: FROZEN_EPOCH_SECONDS,
+      frozenOn: FROZEN_ON,
+      windows: WINDOWS,
+    },
+    evidence: ANALYTICS_CURVE_PARTS.map((part, index) => {
+      const address = (index + 1).toString(16).padStart(64, "0");
+      return {
+        evidenceId: (index + 10).toString(16).padStart(64, "0"),
+        generationId: "a".repeat(64),
+        ...part,
+        requestIdentity: (index + 20).toString(16).padStart(64, "0"),
+        archiveAddress: address,
+        archiveRelPath: `2026/08/${address}.json.gz`,
+        archiveEpochSeconds: FROZEN_EPOCH_SECONDS,
+        decodedBytes: 100,
+      };
+    }),
+    promotedEpochSeconds: FROZEN_EPOCH_SECONDS,
+  };
+}
+
+function powerCurve(id: string, secs: readonly number[], values: readonly (number | null)[]) {
+  return { id, secs: [...secs], values: [...values], provider_private_field: "not-projected" };
+}
+
+function heartRateCurve(id: string, secs: readonly number[], values: readonly (number | null)[]) {
+  return { id, secs: [...secs], values: [...values], provider_private_field: "not-projected" };
+}
+
+function payloads() {
+  return [
+    {
+      activities: { private_activity: { id: "private_activity", start_date_local: FROZEN_ON } },
+      list: [
+        powerCurve(CURRENT, [5, 60, 300, 1_200, 3_600], [1_000, 500, 350, 280, 240]),
+        powerCurve(PREVIOUS, [5, 60, 300, 1_200, 3_600], [900, 480, 330, 260, 230]),
+        powerCurve(SUSTAINABILITY, [300, 600, 1_200, 3_600], [360, 330, 285, 245]),
+        powerCurve("r.1900-01-01.1900-01-02", [5], [9_999]),
+      ],
+    },
+    {
+      activities: {},
+      list: [
+        powerCurve(CURRENT, [5, 300], [1_100, 340]),
+        powerCurve(SUSTAINABILITY, [300, 600, 1_200, 3_600], [370, 320, 275, 235]),
+      ],
+    },
+    {
+      activities: {},
+      list: [
+        heartRateCurve(CURRENT, [60, 300, 1_200, 3_600], [180, 175, 165, 150]),
+        heartRateCurve(PREVIOUS, [60, 300, 1_200, 3_600], [175, 170, 160, 148]),
+        heartRateCurve(SUSTAINABILITY, [300, 600, 1_200, 3_600], [175, 170, 165, 150]),
+      ],
+    },
+    {
+      activities: {},
+      list: [
+        heartRateCurve(CURRENT, [60, 300], [178, 176]),
+        heartRateCurve(SUSTAINABILITY, [300, 600, 1_200, 3_600], [176, 169, 164, 149]),
+      ],
+    },
+  ] as const;
+}
+
+function reader(
+  values: readonly unknown[],
+): VerifiedSnapshotReader & { read: ReturnType<typeof vi.fn> } {
+  const byAddress = new Map(
+    currentState().evidence.map((evidence, index) => [evidence.archiveAddress, values[index]]),
+  );
+  const read = vi.fn(async (reference: { address: string }) => byAddress.get(reference.address));
+  return { readVerifiedSnapshot: read, read };
+}
+
+describe("analytics curve evidence projection", () => {
+  it("allowlists archived curves, aggregates Ride/VirtualRide maxima, and feeds existing metrics", async () => {
+    const snapshots = reader(payloads());
+    const projected = await projectAnalyticsCurveEvidence(currentState(), snapshots);
+
+    expect(snapshots.read).toHaveBeenCalledTimes(4);
+    expect(projected.powerCurves.list.map((curve) => curve.id)).toEqual([
+      CURRENT,
+      PREVIOUS,
+      SUSTAINABILITY,
+    ]);
+    expect(projected.powerCurves.list[0]).toEqual({
+      id: CURRENT,
+      secs: [5, 60, 300, 1_200, 3_600],
+      watts: [1_100, 500, 350, 280, 240],
+    });
+    expect(projected.hrCurves.list[0]).toEqual({
+      id: CURRENT,
+      secs: [60, 300, 1_200, 3_600],
+      values: [180, 176, 165, 150],
+    });
+    expect(JSON.stringify(projected)).not.toMatch(/private_activity|provider_private_field|9999/);
+    expect(projected.sustainabilityCurves.cycling?.power.VirtualRide?.list[0]?.watts[0]).toBe(370);
+
+    const bundle: ReferenceBundle = {
+      activities: [],
+      wellness: [],
+      ftpHistory: [],
+      athlete: { sportSettings: [{ types: ["Ride", "VirtualRide"], ftp: 250, lthr: 170 }] },
+      ...projected,
+    };
+    const input = buildMetricInput(bundle, `${FROZEN_ON}T12:00:00`);
+    expect(computePowerCurveDelta(input).anchors?.["5s"]).toEqual({
+      current_watts: 1_100,
+      previous_watts: 900,
+      pct_change: 22.2,
+    });
+    expect(computeHrCurveDelta(input).anchors?.["300s"]).toEqual({
+      current_bpm: 176,
+      previous_bpm: 170,
+      pct_change: 3.5,
+    });
+    const cycling = computeSustainabilityProfile(input).cycling as SustainabilitySportBlock;
+    expect(cycling.anchors?.["300s"]).toMatchObject({
+      actual_watts: 370,
+      actual_hr: 176,
+      source: "observed_indoor",
+    });
+    expect(cycling.anchors?.["600s"]).toMatchObject({
+      actual_watts: 330,
+      actual_hr: 170,
+      source: "observed_outdoor",
+    });
+  });
+
+  it("keeps a valid empty VirtualRide response as explicit empty per-type evidence", async () => {
+    const values = payloads().map((value, index) =>
+      index === 1 || index === 3 ? { activities: {}, list: [] } : value,
+    );
+    const projected = await projectAnalyticsCurveEvidence(currentState(), reader(values));
+
+    expect(projected.powerCurves.list).toHaveLength(3);
+    expect(projected.sustainabilityCurves.cycling?.power.VirtualRide).toEqual({ list: [] });
+    expect(projected.sustainabilityCurves.cycling?.hr.VirtualRide).toEqual({ list: [] });
+  });
+
+  it("fails closed with a path-neutral error on malformed axes or unreadable evidence", async () => {
+    const malformed = [...payloads()];
+    malformed[0] = {
+      activities: {},
+      list: [powerCurve(CURRENT, [60, 5], [500, 1_000])],
+    };
+    const first = await projectAnalyticsCurveEvidence(currentState(), reader(malformed)).catch(
+      (error: unknown) => error,
+    );
+    expect(first).toEqual(new AnalyticsCurveProjectionError());
+    expect(first).toMatchObject({
+      code: "ANALYTICS_CURVE_PROJECTION_FAILED",
+      stack: "AnalyticsCurveProjectionError: analytics curve evidence could not be projected",
+    });
+
+    const snapshots: VerifiedSnapshotReader = {
+      async readVerifiedSnapshot() {
+        throw new Error("/private/archive/athlete-secret.json.gz");
+      },
+    };
+    const second = await projectAnalyticsCurveEvidence(currentState(), snapshots).catch(
+      (error: unknown) => error,
+    );
+    expect(JSON.stringify(second)).not.toContain("athlete-secret");
+    expect(second).not.toHaveProperty("cause");
+  });
+
+  it("rejects duplicate promoted parts before reading any archive payload", async () => {
+    const current = currentState();
+    const duplicate = {
+      ...current,
+      evidence: [current.evidence[0]!, current.evidence[0]!, ...current.evidence.slice(2)],
+    };
+    const snapshots = reader(payloads());
+    await expect(projectAnalyticsCurveEvidence(duplicate, snapshots)).rejects.toBeInstanceOf(
+      AnalyticsCurveProjectionError,
+    );
+    expect(snapshots.read).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sync-intervals-icu/tests/analytics-curves.test.ts
+++ b/packages/sync-intervals-icu/tests/analytics-curves.test.ts
@@ -103,6 +103,7 @@ function harness(responses: readonly (HttpResponse | Error)[] = [
   };
   const options: RefreshAnalyticsCurvesOptions = {
     athleteId: "i0",
+    frozenOn: "2012-06-15",
     minRequestIntervalMs: 250,
     archive,
     repository,
@@ -183,6 +184,18 @@ describe("analytics curve acquisition", () => {
       promotedEpochSeconds: FROZEN_EPOCH_SECONDS,
     }]);
     expect(test.failures).toEqual([]);
+  });
+
+  it("uses the capture civil date for selectors when it is adjacent to the UTC date", async () => {
+    const test = harness();
+    const result = await refreshAnalyticsCurves({ ...test.options, frozenOn: "2012-06-16" });
+
+    expect(result).toMatchObject({ kind: "promoted", frozenAt: "2012-06-15T12:00:00.000Z" });
+    expect(test.requests.map((value) => new URL(value).searchParams.get("curves"))).toEqual(
+      Array(4).fill(
+        "r.2012-05-20.2012-06-16,r.2012-04-22.2012-05-19,r.2012-05-06.2012-06-16",
+      ),
+    );
   });
 
   it("makes zero calls when all four physical slots cannot be reserved", async () => {


### PR DESCRIPTION
## Summary

- add a read-only, identity-verifying view of the promoted analytics-curve generation and rebuild metric inputs only from archive-verified snapshots
- strictly allowlist exact current/prior/42-day curves, combine Ride and VirtualRide pointwise for family-wide power/HR deltas, and preserve per-type sustainability evidence
- join projection to the local bundle without any provider calls; malformed, stale-date, or unreadable optional curve evidence cannot block the base snapshot
- align curve selectors with the capture civil date, including the safe UTC-boundary case, while rejecting dates more than one day from the frozen instant

## Bounds and failure behavior

- only the four promoted parts are accepted
- only exact generation selectors are projected
- curve axes must be aligned, strictly increasing positive integer seconds, finite non-negative values, and at most 65,536 points
- provider activity metadata and unknown response fields never cross the projection boundary
- valid empty VirtualRide evidence remains explicit empty per-type data
- projection errors are path-neutral and fall back to the base local bundle
- this path accepts no HTTP client and performs zero curve network calls

## Verification

- focused projection/acquisition/repository/runtime tests: 45 passed
- `pnpm check-parity --all`: all registered metric/fixture pairs passed
- `pnpm check`: passed all build, type, lint, privacy, changeset, dependency, kernel-discipline, and schema gates
- `pnpm test`: passed
- `pnpm s8a`: passed with only documented S8A-SUP-004 prompt-supersession warnings
- touched-file lint: 0 warnings, 0 errors
- new-file formatting check: passed
- local pre-commit review: no actionable findings; external review helper not run because it would upload the private staged diff

## Changeset

User-facing: verified current Power Progress snapshots can now feed the existing local power, HR, and sustainability metrics without duplicate provider requests.