### PR TITLE
feat: project Power Progress into desktop state

### DIFF
--- a/.changeset/power-progress-contract.md
+++ b/.changeset/power-progress-contract.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/coach-contract": patch
+"@enduragent/coach": patch
+"cycling-coach": patch
+---
+
+Project verified curve evidence into a bounded Power Progress training contract with independent freshness, stale-last-good failure context, and no raw provider data.

--- a/apps/desktop-renderer/tests/training-context.test.ts
+++ b/apps/desktop-renderer/tests/training-context.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/training-context/format.js";
 
 const context: CyclingTrainingContext = {
+  performanceProgress: { kind: "unavailable", reason: "not-synced" },
   anchorZones: { kind: "unknown", reason: "missing-anchor" },
   cyclingLoad: {
     kind: "computed",

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -27,6 +27,7 @@ function planItem(index: number) {
 }
 
 const context: CyclingTrainingContext = {
+  performanceProgress: { kind: "unavailable", reason: "not-synced" },
   anchorZones: {
     kind: "computed",
     asOf: "1998-07-19T08:00:00.000Z",
@@ -86,6 +87,7 @@ const context: CyclingTrainingContext = {
 };
 
 const unknownContext: CyclingTrainingContext = {
+  performanceProgress: { kind: "unavailable", reason: "not-synced" },
   anchorZones: { kind: "unknown", reason: "missing-anchor" },
   cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
   plan: { kind: "unknown", reason: "no-plan" },

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -25,6 +25,7 @@ const fixtures: RunningDesktopFixture[] = [];
 const scratchPaths: string[] = [];
 
 const trainingContext = {
+  performanceProgress: { kind: "unavailable", reason: "not-synced" },
   anchorZones: {
     kind: "computed",
     asOf: "2026-07-19T08:00:00.000Z",

--- a/packages/coach-contract/DERIVATION.md
+++ b/packages/coach-contract/DERIVATION.md
@@ -52,8 +52,10 @@ error object.
 
 ## Table B — AthleteState fields
 
-Derivation rule: `AthleteState` is derived from the persisted latest-data
-model, never from the `/status` chat turn —
+Derivation rule: `AthleteState` is derived from validated persisted application
+state, never from the `/status` chat turn. Most fields come from the latest-data
+model; `trainingContext.performanceProgress` additionally reads the verified
+store-native analytics-curve generation —
 `packages/core/src/channels/telegram.ts:385-398` shows `/status` is a model
 turn, not a deterministic render.
 
@@ -71,7 +73,7 @@ turn, not a deterministic render.
 | `recentActivities`   | `packages/core/src/reference/schemas/latest.ts:76` (`recent_activities`)                                                                                                                                                                                                                                                                                                                                    |
 | `plannedWorkouts`    | `packages/core/src/reference/schemas/latest.ts:77` (`planned_workouts`)                                                                                                                                                                                                                                                                                                                                     |
 | `wellness`           | `packages/core/src/reference/schemas/latest.ts:78` (`wellness_data` — explicitly NOT an array; typed `z.unknown()`)                                                                                                                                                                                                                                                                                         |
-| `trainingContext`    | Deterministic projection in `packages/coach/src/training-context.ts`, assembled by `packages/coach/src/athlete-state-reader.ts` from the same parsed latest snapshot, the persisted-anchor resolver in `packages/kernel/src/anchors/resolve-anchor.ts`, the zone calculator in `packages/sport-cycling/src/zones.ts`, and the Reference input schemas in `packages/kernel/src/reference/schemas/inputs.ts`. |
+| `trainingContext`    | Deterministic projection in `packages/coach/src/training-context.ts`, assembled by `packages/coach/src/athlete-state-reader.ts` from the parsed latest snapshot, the persisted-anchor resolver, and the sanitized Power Progress source.                                                                                                                                                |
 
 Renames (source snake_case → contract camelCase): `metadata.schema_version` →
 `schemaVersion`, `metadata.last_updated` → `lastUpdated`,
@@ -90,6 +92,7 @@ not infer it from raw state fields.
 
 | Envelope or field group    | Persisted source and recipe                                                                                                                                                                                                                                                         |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `performanceProgress`      | `packages/coach/src/power-progress.ts` reads the current analytics-curve generation and its separate refresh-failure marker, verifies all four archived payloads, runs the unchanged power/HR/sustainability metrics, and emits only bounded display DTOs. Raw curves, provider IDs, generation IDs, archive paths, and metric maps never cross this contract. |
 | `anchorZones.kind`, `asOf` | Resolver result evaluated at whole epoch seconds parsed from `metadata.last_updated`; invalid time or resolver failure yields `unknown/not-synced`, and a missing resolver result yields `unknown/missing-anchor`.                                                                  |
 | `anchorZones.anchor`       | `watts`, `validFrom`, `source`, `confidence`, `ageDays`, `stalenessBand`, and `stale` are copied from `CyclingFtpAnchorResult` without reinterpretation.                                                                                                                            |
 | `anchorZones.zones`        | Six ordered rows from one `calculateCyclingZones(anchor.watts)` call; `label` becomes `name`, formatted `value` becomes `range`, and an absent overlap marker becomes `false`.                                                                                                      |

--- a/packages/coach-contract/src/athlete-state.ts
+++ b/packages/coach-contract/src/athlete-state.ts
@@ -3,6 +3,252 @@ import { z } from "zod";
 export const FreshnessSchema = z.enum(["fresh", "flag", "stale", "critical"]);
 export type Freshness = z.infer<typeof FreshnessSchema>;
 
+const POWER_PROGRESS_DURATIONS = [5, 60, 300, 1_200, 3_600] as const;
+const POWER_PROGRESS_HR_DURATIONS = [60, 300, 1_200, 3_600] as const;
+
+function isCivilDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return (
+    parsed.getUTCFullYear() === year &&
+    parsed.getUTCMonth() === month - 1 &&
+    parsed.getUTCDate() === day
+  );
+}
+
+function civilEpochDay(value: string): number {
+  return Date.parse(`${value}T00:00:00.000Z`) / 86_400_000;
+}
+
+const PowerProgressDateSchema = z.string().length(10).refine(isCivilDate, "invalid civil date");
+
+const CivilDateWindowSchema = z
+  .object({
+    start: PowerProgressDateSchema,
+    end: PowerProgressDateSchema,
+  })
+  .strict()
+  .refine((value) => value.start <= value.end, "date window start must not follow its end");
+
+export const PowerProgressDateWindowSchema = CivilDateWindowSchema.refine(
+  (value) => civilEpochDay(value.end) - civilEpochDay(value.start) === 27,
+  {
+    message: "power progress window must contain 28 days",
+  },
+);
+
+const PowerProgressSustainabilityWindowSchema = CivilDateWindowSchema.refine(
+  (value) => civilEpochDay(value.end) - civilEpochDay(value.start) === 41,
+  { message: "sustainability window must contain 42 days" },
+);
+
+const ProgressUnavailableValueSchema = z.object({ kind: z.literal("unavailable") }).strict();
+
+export const PowerProgressWattsSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      watts: z.number().finite().positive().max(20_000),
+    })
+    .strict(),
+  ProgressUnavailableValueSchema,
+]);
+
+export const PowerProgressBpmSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      bpm: z.number().finite().positive().max(500),
+    })
+    .strict(),
+  ProgressUnavailableValueSchema,
+]);
+
+export const PowerProgressChangeSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      percent: z.number().finite().min(-1_000_000).max(1_000_000),
+    })
+    .strict(),
+  ProgressUnavailableValueSchema,
+]);
+
+function changeMatchesValues(value: {
+  readonly current: { readonly kind: "computed" | "unavailable" };
+  readonly previous: { readonly kind: "computed" | "unavailable" };
+  readonly change: { readonly kind: "computed" | "unavailable" };
+}): boolean {
+  const comparable = value.current.kind === "computed" && value.previous.kind === "computed";
+  return comparable === (value.change.kind === "computed");
+}
+
+export const PowerProgressAnchorSchema = z
+  .object({
+    durationSeconds: z.union(POWER_PROGRESS_DURATIONS.map((value) => z.literal(value))),
+    current: PowerProgressWattsSchema,
+    previous: PowerProgressWattsSchema,
+    change: PowerProgressChangeSchema,
+  })
+  .strict()
+  .refine(changeMatchesValues, "power progress change requires both window values");
+
+export const PowerProgressHeartRateAnchorSchema = z
+  .object({
+    durationSeconds: z.union(POWER_PROGRESS_HR_DURATIONS.map((value) => z.literal(value))),
+    current: PowerProgressBpmSchema,
+    previous: PowerProgressBpmSchema,
+    change: PowerProgressChangeSchema,
+  })
+  .strict()
+  .refine(changeMatchesValues, "heart-rate change requires both window values");
+
+function exactDurations(
+  values: readonly { readonly durationSeconds: number }[],
+  expected: readonly number[],
+): boolean {
+  return (
+    values.length === expected.length &&
+    values.every((value, index) => value.durationSeconds === expected[index])
+  );
+}
+
+const PowerProgressAnchorsSchema = z
+  .array(PowerProgressAnchorSchema)
+  .length(POWER_PROGRESS_DURATIONS.length)
+  .refine((value) => exactDurations(value, POWER_PROGRESS_DURATIONS), "unexpected power anchors");
+
+const PowerProgressHeartRateContextSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      anchors: z
+        .array(PowerProgressHeartRateAnchorSchema)
+        .length(POWER_PROGRESS_HR_DURATIONS.length)
+        .refine(
+          (value) => exactDurations(value, POWER_PROGRESS_HR_DURATIONS),
+          "unexpected heart-rate anchors",
+        ),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("unavailable"),
+      reason: z.literal("insufficient-data"),
+    })
+    .strict(),
+]);
+
+const PowerProgressSustainabilityContextSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      window: PowerProgressSustainabilityWindowSchema,
+      coverageRatio: z.number().finite().min(0).max(1),
+      sourceContext: z.enum(["indoor", "outdoor", "mixed", "unknown"]),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("unavailable"),
+      reason: z.literal("insufficient-data"),
+    })
+    .strict(),
+]);
+
+export const PowerProgressRefreshFailureCodeSchema = z.enum([
+  "request-budget-exhausted",
+  "rate-limited",
+  "timeout",
+  "network",
+  "provider-unavailable",
+  "malformed-response",
+  "response-too-large",
+  "cancelled",
+  "temporary-failure",
+]);
+
+export const PowerProgressRefreshFailureSchema = z
+  .object({
+    code: PowerProgressRefreshFailureCodeSchema,
+    failedAt: z.string().max(64).datetime({ offset: true }),
+  })
+  .strict();
+
+export const PowerProgressUnavailableReasonSchema = z.enum([
+  "not-synced",
+  "insufficient-data",
+  "invalid-data",
+  "refresh-failed",
+  "temporary-failure",
+]);
+
+export const PowerProgressComputedSchema = z
+  .object({
+    kind: z.literal("computed"),
+    currentWindow: PowerProgressDateWindowSchema,
+    previousWindow: PowerProgressDateWindowSchema,
+    anchors: PowerProgressAnchorsSchema,
+    rotation: z.enum(["sprint", "endurance", "balanced", "unknown"]),
+    heartRateContext: PowerProgressHeartRateContextSchema,
+    sustainabilityContext: PowerProgressSustainabilityContextSchema,
+    freshness: FreshnessSchema,
+    asOf: z.string().max(64).datetime({ offset: true }),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (civilEpochDay(value.currentWindow.start) - civilEpochDay(value.previousWindow.end) !== 1) {
+      context.addIssue({
+        code: "custom",
+        path: ["previousWindow"],
+        message: "power progress windows must be adjacent",
+      });
+    }
+    if (
+      value.sustainabilityContext.kind === "computed" &&
+      (value.sustainabilityContext.window.end !== value.currentWindow.end ||
+        civilEpochDay(value.sustainabilityContext.window.end) -
+          civilEpochDay(value.sustainabilityContext.window.start) !==
+          41)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["sustainabilityContext", "window"],
+        message: "sustainability window must be the matching 42-day window",
+      });
+    }
+  });
+
+export const PowerProgressPanelSchema = z.discriminatedUnion("kind", [
+  PowerProgressComputedSchema,
+  z
+    .object({
+      kind: z.literal("unavailable"),
+      reason: PowerProgressUnavailableReasonSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("stale"),
+      lastGood: PowerProgressComputedSchema,
+      refreshFailure: PowerProgressRefreshFailureSchema,
+    })
+    .strict(),
+]);
+
+export type PowerProgressDateWindow = z.infer<typeof PowerProgressDateWindowSchema>;
+export type PowerProgressWatts = z.infer<typeof PowerProgressWattsSchema>;
+export type PowerProgressBpm = z.infer<typeof PowerProgressBpmSchema>;
+export type PowerProgressChange = z.infer<typeof PowerProgressChangeSchema>;
+export type PowerProgressAnchor = z.infer<typeof PowerProgressAnchorSchema>;
+export type PowerProgressHeartRateAnchor = z.infer<typeof PowerProgressHeartRateAnchorSchema>;
+export type PowerProgressRefreshFailureCode = z.infer<typeof PowerProgressRefreshFailureCodeSchema>;
+export type PowerProgressRefreshFailure = z.infer<typeof PowerProgressRefreshFailureSchema>;
+export type PowerProgressUnavailableReason = z.infer<typeof PowerProgressUnavailableReasonSchema>;
+export type PowerProgressComputed = z.infer<typeof PowerProgressComputedSchema>;
+export type PowerProgressPanel = z.infer<typeof PowerProgressPanelSchema>;
+
 export const TrainingContextUnknownReasonSchema = z.enum([
   "not-synced",
   "missing-anchor",
@@ -140,6 +386,7 @@ export const WellnessTrendPanelSchema = z.discriminatedUnion("kind", [
 
 export const CyclingTrainingContextSchema = z
   .object({
+    performanceProgress: PowerProgressPanelSchema,
     anchorZones: AnchorZonesPanelSchema,
     cyclingLoad: CyclingLoadPanelSchema,
     plan: PlanPanelSchema,
@@ -162,6 +409,7 @@ export type WellnessTrendPanel = z.infer<typeof WellnessTrendPanelSchema>;
 export type CyclingTrainingContext = z.infer<typeof CyclingTrainingContextSchema>;
 
 export const UNKNOWN_CYCLING_TRAINING_CONTEXT: CyclingTrainingContext = {
+  performanceProgress: { kind: "unavailable", reason: "not-synced" },
   anchorZones: { kind: "unknown", reason: "not-synced" },
   cyclingLoad: { kind: "unknown", reason: "not-synced" },
   plan: { kind: "unknown", reason: "not-synced" },

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 12;
+export const PROTOCOL_VERSION = 13;

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -12,6 +12,7 @@ import {
   TurnEventSchema,
   AthleteStateSchema,
   CyclingTrainingContextSchema,
+  PowerProgressPanelSchema,
   UNKNOWN_CYCLING_TRAINING_CONTEXT,
   ChatRequestSchema,
   ChatResponseSchema,
@@ -70,6 +71,28 @@ const validState = {
   wellness: { restingHr: 45 },
 } as const;
 
+const computedPowerProgress = {
+  kind: "computed",
+  currentWindow: { start: "1998-06-09", end: "1998-07-06" },
+  previousWindow: { start: "1998-05-12", end: "1998-06-08" },
+  anchors: [5, 60, 300, 1_200, 3_600].map((durationSeconds) => ({
+    durationSeconds,
+    current: { kind: "computed", watts: 300 },
+    previous: { kind: "computed", watts: 280 },
+    change: { kind: "computed", percent: 7.1 },
+  })),
+  rotation: "balanced",
+  heartRateContext: { kind: "unavailable", reason: "insufficient-data" },
+  sustainabilityContext: {
+    kind: "computed",
+    window: { start: "1998-05-26", end: "1998-07-06" },
+    coverageRatio: 0.8,
+    sourceContext: "mixed",
+  },
+  freshness: "fresh",
+  asOf: "1998-07-06T09:00:00.000Z",
+} as const;
+
 function cloneState(): Record<string, unknown> {
   return structuredClone(validState) as unknown as Record<string, unknown>;
 }
@@ -87,8 +110,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 12", () => {
-    expect(PROTOCOL_VERSION).toBe(12);
+  it("is 13", () => {
+    expect(PROTOCOL_VERSION).toBe(13);
   });
 });
 
@@ -267,6 +290,7 @@ describe("AthleteState", () => {
 
   it("parses computed and unknown training-context envelopes strictly", () => {
     const computed = {
+      performanceProgress: { kind: "unavailable", reason: "not-synced" },
       anchorZones: {
         kind: "computed",
         asOf: "1998-07-06T09:00:00.000Z",
@@ -331,6 +355,45 @@ describe("AthleteState", () => {
       CyclingTrainingContextSchema.safeParse({
         ...computed,
         adherence: { ...computed.adherence, ratio: 1.1 },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("bounds Power Progress and preserves explicit unavailable and stale states", () => {
+    expect(PowerProgressPanelSchema.parse(computedPowerProgress)).toEqual(computedPowerProgress);
+    expect(
+      PowerProgressPanelSchema.parse({
+        kind: "stale",
+        lastGood: computedPowerProgress,
+        refreshFailure: { code: "timeout", failedAt: "1998-07-07T09:00:00.000Z" },
+      }),
+    ).toMatchObject({ kind: "stale", lastGood: computedPowerProgress });
+    expect(PowerProgressPanelSchema.parse({ kind: "unavailable", reason: "not-synced" })).toEqual({
+      kind: "unavailable",
+      reason: "not-synced",
+    });
+    expect(
+      PowerProgressPanelSchema.safeParse({
+        ...computedPowerProgress,
+        anchors: [...computedPowerProgress.anchors].reverse(),
+      }).success,
+    ).toBe(false);
+    expect(
+      PowerProgressPanelSchema.safeParse({
+        ...computedPowerProgress,
+        anchors: computedPowerProgress.anchors.map((anchor, index) =>
+          index === 0
+            ? { ...anchor, current: { kind: "computed", watts: Number.POSITIVE_INFINITY } }
+            : anchor,
+        ),
+      }).success,
+    ).toBe(false);
+    expect(
+      PowerProgressPanelSchema.safeParse({
+        ...computedPowerProgress,
+        anchors: computedPowerProgress.anchors.map((anchor, index) =>
+          index === 0 ? { ...anchor, current: { kind: "unavailable" } } : anchor,
+        ),
       }).success,
     ).toBe(false);
   });

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1502,7 +1502,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-12 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-13 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1510,8 +1510,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 12,
-      serverProtocolVersion: 12,
+      clientProtocolVersion: 13,
+      serverProtocolVersion: 13,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1566,9 +1566,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 12 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 13 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(12);
+    expect(client.clientProtocolVersion).toBe(13);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -1578,17 +1578,17 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual(
       accepted,
     );
-    const oldClient = createVersionMismatchServerHandshakeFrame("ephemeral-client-started", 11, 12);
-    const oldServer = createVersionMismatchServerHandshakeFrame("unmanaged-foreground", 13, 12);
+    const oldClient = createVersionMismatchServerHandshakeFrame("ephemeral-client-started", 12, 13);
+    const oldServer = createVersionMismatchServerHandshakeFrame("unmanaged-foreground", 14, 13);
     expect(ServerHandshakeFrameSchema.parse(oldClient)).toEqual(oldClient);
     expect(oldClient.direction).toBe("client-older");
     expect(ServerHandshakeFrameSchema.parse(oldServer)).toEqual(oldServer);
     expect(oldServer.direction).toBe("client-newer");
     expect(() =>
-      createAcceptedServerHandshakeFrame("service-managed", 11, acceptedHandshakeBinding, 12),
+      createAcceptedServerHandshakeFrame("service-managed", 12, acceptedHandshakeBinding, 13),
     ).toThrow();
     expect(() =>
-      createAcceptedServerHandshakeFrame("service-managed", 13, acceptedHandshakeBinding, 12),
+      createAcceptedServerHandshakeFrame("service-managed", 14, acceptedHandshakeBinding, 13),
     ).toThrow();
   });
 
@@ -1694,7 +1694,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version twelve", () => {
-    expect(PROTOCOL_VERSION).toBe(12);
+  it("uses protocol version thirteen", () => {
+    expect(PROTOCOL_VERSION).toBe(13);
   });
 });

--- a/packages/coach/src/athlete-state-reader.ts
+++ b/packages/coach/src/athlete-state-reader.ts
@@ -1,6 +1,11 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { AthleteStateSchema, type AthleteState } from "@enduragent/coach-contract";
+import {
+  AthleteStateSchema,
+  PowerProgressPanelSchema,
+  type AthleteState,
+  type PowerProgressPanel,
+} from "@enduragent/coach-contract";
 import type { AthleteStateReaderPort } from "@enduragent/engine";
 import type { CyclingFtpAnchorResolver } from "@enduragent/kernel/anchors";
 import {
@@ -47,6 +52,9 @@ function isFiniteInstant(value: string): boolean {
 export interface CreatePersistedAthleteStateSourceOptions {
   readonly dataDir: string;
   readonly cyclingFtpAnchorResolver: CyclingFtpAnchorResolver;
+  readonly powerProgressSource?: {
+    readPowerProgress(): Promise<PowerProgressPanel>;
+  };
 }
 
 export function createPersistedAthleteStateSource(
@@ -98,12 +106,29 @@ export function createPersistedAthleteStateSource(
       const parsedAsOf = Date.parse(latest.metadata.last_updated);
       const asOfEpochS =
         Number.isFinite(parsedAsOf) && parsedAsOf >= 0 ? Math.floor(parsedAsOf / 1_000) : null;
-      const anchor =
+      const [anchor, performanceProgress] = await Promise.all([
         asOfEpochS === null
-          ? null
-          : await input.cyclingFtpAnchorResolver
+          ? Promise.resolve(null)
+          : input.cyclingFtpAnchorResolver
               .resolve({ effectiveAtEpochS: asOfEpochS, evaluatedAtEpochS: asOfEpochS })
-              .catch(() => null);
+              .catch(() => null),
+        input.powerProgressSource === undefined
+          ? Promise.resolve({ kind: "unavailable", reason: "not-synced" } as const)
+          : input.powerProgressSource
+              .readPowerProgress()
+              .then((value): PowerProgressPanel => {
+                const parsed = PowerProgressPanelSchema.safeParse(value);
+                return parsed.success
+                  ? parsed.data
+                  : { kind: "unavailable", reason: "invalid-data" };
+              })
+              .catch(
+                (): PowerProgressPanel => ({
+                  kind: "unavailable",
+                  reason: "temporary-failure",
+                }),
+              ),
+      ]);
       const trainingContext = projectCyclingTrainingContext({
         asOf: latest.metadata.last_updated,
         anchor,
@@ -111,6 +136,7 @@ export function createPersistedAthleteStateSource(
         recentActivities: latest.recent_activities,
         plannedWorkouts: latest.planned_workouts,
         wellness: latest.wellness_data,
+        performanceProgress,
       });
       const mapped = {
         schemaVersion: latest.metadata.schema_version,

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -75,6 +75,7 @@ import {
 } from "@enduragent/coach-contract";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import { createPersistedAthleteStateSource } from "./athlete-state-reader.js";
+import { createPowerProgressStateSource } from "./power-progress.js";
 import {
   assertRuntimeAthleteOwner,
   RuntimeAthleteOwnerRefusal,
@@ -769,9 +770,15 @@ export async function createLocalCoachComposition(
     const cyclingFtpAnchorResolver = (
       dependencies.createResolver ?? createCyclingFtpAnchorResolver
     )(repository);
+    const powerProgress = createPowerProgressStateSource({
+      store: input.context.store,
+      archiveRoot: input.home.archiveDir,
+      now,
+    });
     const stateReader = createPersistedAthleteStateSource({
       dataDir: input.home.root,
       cyclingFtpAnchorResolver,
+      powerProgressSource: powerProgress,
     });
     const buildBundle = (config: Config): RuntimeBundle => {
       const timezone = resolveUserTimezone(config.session.timezone);

--- a/packages/coach/src/power-progress.ts
+++ b/packages/coach/src/power-progress.ts
@@ -1,0 +1,347 @@
+import {
+  PowerProgressPanelSchema,
+  type PowerProgressComputed,
+  type PowerProgressPanel,
+} from "@enduragent/coach-contract";
+import type { CryptoPort, FileSystemPort } from "@enduragent/kernel/ports";
+import {
+  CRITICAL_MS,
+  FRESH_MS,
+  FUTURE_TOLERANCE_MS,
+  STALE_MS,
+} from "@enduragent/kernel/reference/freshness";
+import {
+  buildMetricInput,
+  type ReferenceBundle,
+  type VerifiedSnapshotReader,
+} from "@enduragent/kernel/reference/local-bundle";
+import {
+  computeHrCurveDelta,
+  computePowerCurveDelta,
+  computeSustainabilityProfile,
+  type HrCurveAnchor,
+  type PowerCurveAnchor,
+  type SustainabilitySportBlock,
+} from "@enduragent/kernel/reference/metrics";
+import {
+  H,
+  createAnalyticsCurveStateReader,
+  type AnalyticsCurveState,
+  type SqlReadStore,
+} from "@enduragent/kernel/store";
+import { createVerifiedSnapshotReader } from "@enduragent/kernel-node/archive";
+import { nodeFileSystem } from "@enduragent/kernel-node/filesystem";
+import { createNodeCrypto } from "@enduragent/kernel-node/ingest";
+import {
+  AnalyticsCurveProjectionError,
+  projectAnalyticsCurveEvidence,
+} from "@enduragent/sync-intervals-icu";
+
+const POWER_ANCHORS = [
+  [5, "5s"],
+  [60, "60s"],
+  [300, "300s"],
+  [1_200, "1200s"],
+  [3_600, "3600s"],
+] as const;
+
+const HEART_RATE_ANCHORS = [
+  [60, "60s"],
+  [300, "300s"],
+  [1_200, "1200s"],
+  [3_600, "3600s"],
+] as const;
+
+export class PowerProgressProjectionError extends Error {
+  readonly code = "POWER_PROGRESS_PROJECTION_FAILED";
+
+  constructor() {
+    super("power progress could not be projected");
+    this.name = "PowerProgressProjectionError";
+    this.stack = `${this.name}: ${this.message}`;
+  }
+}
+
+export interface PowerProgressStateSource {
+  readPowerProgress(): Promise<PowerProgressPanel>;
+}
+
+export interface PowerProgressStateSourceOptions {
+  readonly store: SqlReadStore;
+  readonly archiveRoot: string;
+  readonly now?: () => number;
+}
+
+export interface PowerProgressStateSourceDependencies {
+  readonly crypto?: () => CryptoPort;
+  readonly fileSystem?: () => FileSystemPort;
+  readonly createSnapshotReader?: (dependencies: {
+    readonly archiveRoot: string;
+    readonly crypto: CryptoPort;
+    readonly fs: FileSystemPort;
+  }) => VerifiedSnapshotReader;
+}
+
+type ProjectedCurves = Pick<ReferenceBundle, "powerCurves" | "hrCurves" | "sustainabilityCurves">;
+
+function invalidProjection(): never {
+  throw new PowerProgressProjectionError();
+}
+
+function exactWindow(
+  actual: { readonly start: string; readonly end: string } | undefined,
+  expected: { readonly start: string; readonly end: string },
+): boolean {
+  return actual?.start === expected.start && actual.end === expected.end;
+}
+
+function freshnessAt(frozenEpochSeconds: number, nowEpochMilliseconds: number) {
+  const frozenMs = frozenEpochSeconds * 1_000;
+  if (
+    !Number.isSafeInteger(frozenEpochSeconds) ||
+    frozenEpochSeconds < 0 ||
+    !Number.isSafeInteger(nowEpochMilliseconds) ||
+    nowEpochMilliseconds < 0
+  ) {
+    invalidProjection();
+  }
+  const elapsed = nowEpochMilliseconds - frozenMs;
+  if (elapsed < -FUTURE_TOLERANCE_MS) return "stale" as const;
+  if (elapsed >= CRITICAL_MS) return "critical" as const;
+  if (elapsed >= STALE_MS) return "stale" as const;
+  if (elapsed >= FRESH_MS) return "flag" as const;
+  return "fresh" as const;
+}
+
+function watts(value: number | null) {
+  return value === null
+    ? ({ kind: "unavailable" } as const)
+    : ({ kind: "computed", watts: value } as const);
+}
+
+function bpm(value: number | null) {
+  return value === null
+    ? ({ kind: "unavailable" } as const)
+    : ({ kind: "computed", bpm: value } as const);
+}
+
+function change(value: number | null) {
+  return value === null
+    ? ({ kind: "unavailable" } as const)
+    : ({ kind: "computed", percent: value } as const);
+}
+
+function powerAnchor(durationSeconds: number, value: PowerCurveAnchor | undefined) {
+  if (value === undefined) invalidProjection();
+  return {
+    durationSeconds,
+    current: watts(value.current_watts),
+    previous: watts(value.previous_watts),
+    change: change(value.pct_change),
+  };
+}
+
+function heartRateAnchor(durationSeconds: number, value: HrCurveAnchor | undefined) {
+  if (value === undefined) invalidProjection();
+  return {
+    durationSeconds,
+    current: bpm(value.current_bpm),
+    previous: bpm(value.previous_bpm),
+    change: change(value.pct_change),
+  };
+}
+
+function rotation(value: number | null): PowerProgressComputed["rotation"] {
+  if (value === null) return "unknown";
+  if (!Number.isFinite(value)) invalidProjection();
+  if (value > 0) return "sprint";
+  if (value < 0) return "endurance";
+  return "balanced";
+}
+
+function sourceContext(
+  block: SustainabilitySportBlock,
+): "indoor" | "outdoor" | "mixed" | "unknown" {
+  if (block.anchors === null) return "unknown";
+  let indoor = false;
+  let outdoor = false;
+  for (const anchor of Object.values(block.anchors)) {
+    if (anchor.source === null) continue;
+    if (anchor.source === "observed_indoor") indoor = true;
+    else if (anchor.source === "observed_outdoor") outdoor = true;
+    else invalidProjection();
+  }
+  if (indoor && outdoor) return "mixed";
+  if (indoor) return "indoor";
+  if (outdoor) return "outdoor";
+  return "unknown";
+}
+
+function projectPowerProgressPanelUnchecked(input: {
+  readonly current: NonNullable<AnalyticsCurveState["current"]>;
+  readonly curves: ProjectedCurves;
+  readonly nowEpochMilliseconds: number;
+}): PowerProgressComputed {
+  const generation = input.current.generation;
+  const metricInput = buildMetricInput(
+    {
+      activities: [],
+      wellness: [],
+      ftpHistory: [],
+      ...input.curves,
+    },
+    `${generation.frozenOn}T12:00:00.000Z`,
+  );
+  const power = computePowerCurveDelta(metricInput);
+  if (
+    power.window_days !== 28 ||
+    power.anchors === null ||
+    !exactWindow(power.current_window, generation.windows.current) ||
+    !exactWindow(power.previous_window, generation.windows.previous)
+  ) {
+    invalidProjection();
+  }
+
+  const heartRate = computeHrCurveDelta(metricInput);
+  const heartRateContext =
+    heartRate.window_days === 28 &&
+    heartRate.anchors !== null &&
+    exactWindow(heartRate.current_window, generation.windows.current) &&
+    exactWindow(heartRate.previous_window, generation.windows.previous)
+      ? {
+          kind: "computed" as const,
+          anchors: HEART_RATE_ANCHORS.map(([durationSeconds, key]) =>
+            heartRateAnchor(durationSeconds, heartRate.anchors?.[key]),
+          ),
+        }
+      : ({ kind: "unavailable", reason: "insufficient-data" } as const);
+
+  const sustainability = computeSustainabilityProfile(metricInput);
+  const cycling = sustainability.cycling;
+  const sustainabilityContext =
+    sustainability.window !== undefined &&
+    exactWindow(sustainability.window, generation.windows.sustainability) &&
+    cycling !== undefined &&
+    cycling !== null &&
+    typeof cycling === "object" &&
+    "coverage_ratio" in cycling
+      ? {
+          kind: "computed" as const,
+          window: generation.windows.sustainability,
+          coverageRatio: (cycling as SustainabilitySportBlock).coverage_ratio,
+          sourceContext: sourceContext(cycling as SustainabilitySportBlock),
+        }
+      : ({ kind: "unavailable", reason: "insufficient-data" } as const);
+
+  const asOf = new Date(generation.frozenEpochSeconds * 1_000).toISOString();
+  const parsed = PowerProgressPanelSchema.safeParse({
+    kind: "computed",
+    currentWindow: generation.windows.current,
+    previousWindow: generation.windows.previous,
+    anchors: POWER_ANCHORS.map(([durationSeconds, key]) =>
+      powerAnchor(durationSeconds, power.anchors?.[key]),
+    ),
+    rotation: rotation(power.rotation_index),
+    heartRateContext,
+    sustainabilityContext,
+    freshness: freshnessAt(generation.frozenEpochSeconds, input.nowEpochMilliseconds),
+    asOf,
+  });
+  if (!parsed.success || parsed.data.kind !== "computed") invalidProjection();
+  return parsed.data;
+}
+
+export function projectPowerProgressPanel(
+  input: Parameters<typeof projectPowerProgressPanelUnchecked>[0],
+): PowerProgressComputed {
+  try {
+    return projectPowerProgressPanelUnchecked(input);
+  } catch (error) {
+    if (error instanceof PowerProgressProjectionError) throw error;
+    throw new PowerProgressProjectionError();
+  }
+}
+
+function unavailable(
+  reason: "not-synced" | "invalid-data" | "refresh-failed" | "temporary-failure",
+) {
+  return PowerProgressPanelSchema.parse({ kind: "unavailable", reason });
+}
+
+export function projectPowerProgressState(input: {
+  readonly state: AnalyticsCurveState;
+  readonly curves?: ProjectedCurves;
+  readonly nowEpochMilliseconds: number;
+}): PowerProgressPanel {
+  if (input.state.current === null) {
+    return unavailable(input.state.refreshFailure === null ? "not-synced" : "refresh-failed");
+  }
+  if (input.curves === undefined) invalidProjection();
+  const computed = projectPowerProgressPanel({
+    current: input.state.current,
+    curves: input.curves,
+    nowEpochMilliseconds: input.nowEpochMilliseconds,
+  });
+  if (input.state.refreshFailure === null) return computed;
+  return PowerProgressPanelSchema.parse({
+    kind: "stale",
+    lastGood: computed,
+    refreshFailure: {
+      code: input.state.refreshFailure.code,
+      failedAt: new Date(input.state.refreshFailure.failedEpochSeconds * 1_000).toISOString(),
+    },
+  });
+}
+
+export function createPowerProgressStateSource(
+  options: PowerProgressStateSourceOptions,
+  dependencies: PowerProgressStateSourceDependencies = {},
+): PowerProgressStateSource {
+  if (
+    options === null ||
+    typeof options !== "object" ||
+    options.store === null ||
+    typeof options.store !== "object" ||
+    typeof options.archiveRoot !== "string" ||
+    options.archiveRoot.length === 0
+  ) {
+    throw new TypeError("power progress source options are invalid");
+  }
+  const crypto = (dependencies.crypto ?? createNodeCrypto)();
+  const snapshots = (dependencies.createSnapshotReader ?? createVerifiedSnapshotReader)({
+    archiveRoot: options.archiveRoot,
+    crypto,
+    fs: (dependencies.fileSystem ?? nodeFileSystem)(),
+  });
+  const state = createAnalyticsCurveStateReader(options.store, (fields) => {
+    if (fields.length === 0) throw new TypeError("empty key tuple");
+    return H(crypto, ...(fields as [string | number, ...(string | number)[]]));
+  });
+  const now = options.now ?? Date.now;
+
+  return Object.freeze({
+    async readPowerProgress(): Promise<PowerProgressPanel> {
+      try {
+        const selected = await state.readState();
+        if (selected.current === null)
+          return projectPowerProgressState({
+            state: selected,
+            nowEpochMilliseconds: now(),
+          });
+        const curves = await projectAnalyticsCurveEvidence(selected.current, snapshots);
+        return projectPowerProgressState({
+          state: selected,
+          curves,
+          nowEpochMilliseconds: now(),
+        });
+      } catch (error) {
+        return unavailable(
+          error instanceof AnalyticsCurveProjectionError ||
+            error instanceof PowerProgressProjectionError
+            ? "invalid-data"
+            : "temporary-failure",
+        );
+      }
+    },
+  });
+}

--- a/packages/coach/src/training-context.ts
+++ b/packages/coach/src/training-context.ts
@@ -1,6 +1,7 @@
 import type {
   CyclingTrainingContext,
   CyclingZoneRow,
+  PowerProgressPanel,
   WellnessSeries,
 } from "@enduragent/coach-contract";
 import type { CyclingFtpAnchorResult } from "@enduragent/kernel/anchors";
@@ -18,6 +19,7 @@ export interface ProjectCyclingTrainingContextInput {
   readonly recentActivities: readonly unknown[];
   readonly plannedWorkouts: readonly unknown[];
   readonly wellness: unknown;
+  readonly performanceProgress?: PowerProgressPanel;
 }
 
 const cyclingTypes = new Set<string>(cyclingSport.intervalsActivityTypes);
@@ -187,6 +189,10 @@ export function projectCyclingTrainingContext(
   input: ProjectCyclingTrainingContextInput,
 ): CyclingTrainingContext {
   return {
+    performanceProgress: input.performanceProgress ?? {
+      kind: "unavailable",
+      reason: "not-synced",
+    },
     anchorZones: projectAnchorZones(input),
     cyclingLoad: projectCyclingLoad(input),
     plan: projectPlan(input),

--- a/packages/coach/tests/athlete-state-reader.test.ts
+++ b/packages/coach/tests/athlete-state-reader.test.ts
@@ -420,9 +420,14 @@ describe("persisted athlete state source", () => {
       stalenessBand: "aging" as const,
       stale: true,
     }));
+    const readPowerProgress = vi.fn(async () => ({
+      kind: "unavailable" as const,
+      reason: "insufficient-data" as const,
+    }));
     const state = await createPersistedAthleteStateSource({
       dataDir: root,
       cyclingFtpAnchorResolver: { resolve },
+      powerProgressSource: { readPowerProgress },
     }).getAthleteState();
     const expectedEpoch = Date.parse(snapshot.metadata.last_updated) / 1_000;
     expect(resolve).toHaveBeenCalledOnce();
@@ -430,12 +435,42 @@ describe("persisted athlete state source", () => {
       effectiveAtEpochS: expectedEpoch,
       evaluatedAtEpochS: expectedEpoch,
     });
+    expect(readPowerProgress).toHaveBeenCalledOnce();
     expect(state.trainingContext).toMatchObject({
+      performanceProgress: { kind: "unavailable", reason: "insufficient-data" },
       anchorZones: { kind: "computed" },
       cyclingLoad: { kind: "computed", value: 80 },
       plan: { kind: "computed" },
       adherence: { kind: "computed", ratio: 1 },
       wellnessTrend: { kind: "computed" },
+    });
+  });
+
+  it("isolates a Power Progress read failure from the rest of athlete state", async () => {
+    const root = await home();
+    await writeJson(root, "latest.json", latest());
+    const state = await createPersistedAthleteStateSource({
+      dataDir: root,
+      cyclingFtpAnchorResolver: resolver,
+      powerProgressSource: {
+        readPowerProgress: async () => Promise.reject(new Error("private archive path")),
+      },
+    }).getAthleteState();
+    expect(state.trainingContext?.performanceProgress).toEqual({
+      kind: "unavailable",
+      reason: "temporary-failure",
+    });
+    expect(JSON.stringify(state)).not.toContain("private archive path");
+    const malformed = await createPersistedAthleteStateSource({
+      dataDir: root,
+      cyclingFtpAnchorResolver: resolver,
+      powerProgressSource: {
+        readPowerProgress: async () => ({ kind: "computed" }) as never,
+      },
+    }).getAthleteState();
+    expect(malformed.trainingContext?.performanceProgress).toEqual({
+      kind: "unavailable",
+      reason: "invalid-data",
     });
   });
 

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -61,6 +61,7 @@ const state: AthleteState = {
   plannedWorkouts: [{ id: "workout-1" }],
   wellness: { restingHr: 45 },
   trainingContext: {
+    performanceProgress: { kind: "unavailable", reason: "not-synced" },
     anchorZones: { kind: "unknown", reason: "missing-anchor" },
     cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
     plan: { kind: "unknown", reason: "no-plan" },

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -105,8 +105,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 12 as const,
-      serverProtocolVersion: 12 as const,
+      clientProtocolVersion: 13 as const,
+      serverProtocolVersion: 13 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/power-progress.test.ts
+++ b/packages/coach/tests/power-progress.test.ts
@@ -1,0 +1,308 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ReferenceBundle } from "@enduragent/kernel/reference/local-bundle";
+import {
+  ANALYTICS_CURVE_PARTS,
+  H,
+  analyticsCurveWindows,
+  createAnalyticsCurveRepository,
+  runMigrations,
+  type AnalyticsCurveState,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createArchiveManager } from "@enduragent/kernel-node/archive";
+import { nodeFileSystem } from "@enduragent/kernel-node/filesystem";
+import { createNodeCrypto } from "@enduragent/kernel-node/ingest";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import {
+  PowerProgressProjectionError,
+  createPowerProgressStateSource,
+  projectPowerProgressPanel,
+  projectPowerProgressState,
+} from "../src/power-progress.js";
+
+const FROZEN_ON = "2026-08-07";
+const FROZEN_AT = `${FROZEN_ON}T12:00:00.000Z`;
+const FROZEN_EPOCH_SECONDS = Date.parse(FROZEN_AT) / 1_000;
+const WINDOWS = analyticsCurveWindows(FROZEN_ON);
+const CURRENT = `r.${WINDOWS.current.start}.${WINDOWS.current.end}`;
+const PREVIOUS = `r.${WINDOWS.previous.start}.${WINDOWS.previous.end}`;
+const SUSTAINABILITY = `r.${WINDOWS.sustainability.start}.${WINDOWS.sustainability.end}`;
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function current(): NonNullable<AnalyticsCurveState["current"]> {
+  return {
+    generation: {
+      generationId: "a".repeat(64),
+      frozenEpochSeconds: FROZEN_EPOCH_SECONDS,
+      frozenOn: FROZEN_ON,
+      windows: WINDOWS,
+    },
+    evidence: [],
+    promotedEpochSeconds: FROZEN_EPOCH_SECONDS,
+  };
+}
+
+function power(id: string, secs: number[], watts: number[]) {
+  return { id, secs, watts };
+}
+
+function heartRate(id: string, secs: number[], values: number[]) {
+  return { id, secs, values };
+}
+
+function curves(): Pick<ReferenceBundle, "powerCurves" | "hrCurves" | "sustainabilityCurves"> {
+  const powerSecs = [5, 60, 300, 1_200, 3_600];
+  const heartRateSecs = [60, 300, 1_200, 3_600];
+  const sustainabilitySecs = [300, 600, 1_200, 3_600];
+  return {
+    powerCurves: {
+      list: [
+        power(CURRENT, powerSecs, [1_100, 500, 350, 280, 240]),
+        power(PREVIOUS, powerSecs, [900, 480, 330, 260, 230]),
+      ],
+    },
+    hrCurves: {
+      list: [
+        heartRate(CURRENT, heartRateSecs, [180, 176, 165, 150]),
+        heartRate(PREVIOUS, heartRateSecs, [175, 170, 160, 148]),
+      ],
+    },
+    sustainabilityCurves: {
+      cycling: {
+        power: {
+          Ride: {
+            list: [power(SUSTAINABILITY, sustainabilitySecs, [360, 330, 285, 245])],
+          },
+          VirtualRide: {
+            list: [power(SUSTAINABILITY, sustainabilitySecs, [370, 320, 275, 235])],
+          },
+        },
+        hr: {
+          Ride: {
+            list: [heartRate(SUSTAINABILITY, sustainabilitySecs, [175, 170, 165, 150])],
+          },
+          VirtualRide: {
+            list: [heartRate(SUSTAINABILITY, sustainabilitySecs, [176, 169, 164, 149])],
+          },
+        },
+      },
+    },
+  };
+}
+
+function providerPayloads() {
+  const powerSecs = [5, 60, 300, 600, 1_200, 3_600];
+  const heartRateSecs = [60, 300, 600, 1_200, 3_600];
+  return [
+    {
+      activities: {},
+      list: [
+        { id: CURRENT, secs: powerSecs, values: [1_000, 500, 350, 330, 280, 240] },
+        { id: PREVIOUS, secs: powerSecs, values: [900, 480, 330, 310, 260, 230] },
+        { id: SUSTAINABILITY, secs: powerSecs, values: [1_000, 500, 360, 330, 285, 245] },
+      ],
+    },
+    {
+      activities: {},
+      list: [
+        { id: CURRENT, secs: powerSecs, values: [1_100, 490, 340, 320, 275, 235] },
+        { id: PREVIOUS, secs: powerSecs, values: [880, 470, 320, 300, 250, 220] },
+        { id: SUSTAINABILITY, secs: powerSecs, values: [1_100, 490, 370, 320, 275, 235] },
+      ],
+    },
+    {
+      activities: {},
+      list: [
+        { id: CURRENT, secs: heartRateSecs, values: [180, 175, 170, 165, 150] },
+        { id: PREVIOUS, secs: heartRateSecs, values: [175, 170, 165, 160, 148] },
+        { id: SUSTAINABILITY, secs: heartRateSecs, values: [180, 175, 170, 165, 150] },
+      ],
+    },
+    {
+      activities: {},
+      list: [
+        { id: CURRENT, secs: heartRateSecs, values: [178, 176, 169, 164, 149] },
+        { id: PREVIOUS, secs: heartRateSecs, values: [173, 169, 164, 159, 147] },
+        { id: SUSTAINABILITY, secs: heartRateSecs, values: [178, 176, 169, 164, 149] },
+      ],
+    },
+  ] as const;
+}
+
+describe("Power Progress state projection", () => {
+  it("projects exact bounded power anchors with secondary HR and sustainability context", () => {
+    const result = projectPowerProgressPanel({
+      current: current(),
+      curves: curves(),
+      nowEpochMilliseconds: Date.parse(FROZEN_AT),
+    });
+
+    expect(result).toMatchObject({
+      kind: "computed",
+      currentWindow: WINDOWS.current,
+      previousWindow: WINDOWS.previous,
+      rotation: "sprint",
+      freshness: "fresh",
+      asOf: FROZEN_AT,
+      heartRateContext: { kind: "computed" },
+      sustainabilityContext: {
+        kind: "computed",
+        window: WINDOWS.sustainability,
+        sourceContext: "mixed",
+      },
+    });
+    expect(result.anchors.map((anchor) => anchor.durationSeconds)).toEqual([
+      5, 60, 300, 1_200, 3_600,
+    ]);
+    expect(result.anchors[0]).toEqual({
+      durationSeconds: 5,
+      current: { kind: "computed", watts: 1_100 },
+      previous: { kind: "computed", watts: 900 },
+      change: { kind: "computed", percent: 22.2 },
+    });
+    expect(
+      result.heartRateContext.kind === "computed" && result.heartRateContext.anchors[1]?.current,
+    ).toEqual({ kind: "computed", bpm: 176 });
+  });
+
+  it("keeps curve freshness independent from base state and wraps a failed refresh as stale", () => {
+    const selected: AnalyticsCurveState = {
+      current: current(),
+      refreshFailure: {
+        generationId: "b".repeat(64),
+        code: "timeout",
+        failedEpochSeconds: FROZEN_EPOCH_SECONDS + 3_600,
+      },
+    };
+    const result = projectPowerProgressState({
+      state: selected,
+      curves: curves(),
+      nowEpochMilliseconds: Date.parse(FROZEN_AT) + 8 * 86_400_000,
+    });
+
+    expect(result).toMatchObject({
+      kind: "stale",
+      lastGood: { kind: "computed", freshness: "critical" },
+      refreshFailure: { code: "timeout", failedAt: "2026-08-07T13:00:00.000Z" },
+    });
+  });
+
+  it("returns stable unavailable reasons when no promoted generation exists", () => {
+    expect(
+      projectPowerProgressState({
+        state: { current: null, refreshFailure: null },
+        nowEpochMilliseconds: Date.parse(FROZEN_AT),
+      }),
+    ).toEqual({ kind: "unavailable", reason: "not-synced" });
+    expect(
+      projectPowerProgressState({
+        state: {
+          current: null,
+          refreshFailure: {
+            generationId: "b".repeat(64),
+            code: "network",
+            failedEpochSeconds: FROZEN_EPOCH_SECONDS,
+          },
+        },
+        nowEpochMilliseconds: Date.parse(FROZEN_AT),
+      }),
+    ).toEqual({ kind: "unavailable", reason: "refresh-failed" });
+  });
+
+  it("fails closed when the exact prior power window is absent", () => {
+    const selected = curves();
+    const malformed = {
+      ...selected,
+      powerCurves: { list: selected.powerCurves!.list.slice(0, 1) },
+    };
+    expect(() =>
+      projectPowerProgressPanel({
+        current: current(),
+        curves: malformed,
+        nowEpochMilliseconds: Date.parse(FROZEN_AT),
+      }),
+    ).toThrow(new PowerProgressProjectionError());
+  });
+
+  it("reads verified persisted evidence and retains it after a later failed generation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "power-progress-state-"));
+    roots.push(root);
+    const archiveRoot = join(root, "archive");
+    await mkdir(archiveRoot, { mode: 0o700 });
+    const store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    const crypto = createNodeCrypto();
+    const archive = createArchiveManager({ archiveRoot, crypto, fs: nodeFileSystem() });
+    const repository = createAnalyticsCurveRepository(store, (fields) => {
+      if (fields.length === 0) throw new TypeError("empty key tuple");
+      return H(crypto, ...(fields as [string | number, ...(string | number)[]]));
+    });
+
+    try {
+      const { generation } = await repository.beginGeneration({
+        frozenEpochSeconds: FROZEN_EPOCH_SECONDS,
+        frozenOn: FROZEN_ON,
+      });
+      let firstArchivePath = "";
+      for (const [index, part] of ANALYTICS_CURVE_PARTS.entries()) {
+        const payload = providerPayloads()[index]!;
+        const persisted = await archive.writeSnapshot(payload, {
+          epochSeconds: FROZEN_EPOCH_SECONDS,
+        });
+        if (firstArchivePath.length === 0) {
+          firstArchivePath = join(archiveRoot, persisted.relPath);
+        }
+        await repository.recordEvidence({
+          generationId: generation.generationId,
+          ...part,
+          archiveAddress: persisted.address,
+          archiveRelPath: persisted.relPath,
+          archiveEpochSeconds: FROZEN_EPOCH_SECONDS,
+          decodedBytes: new TextEncoder().encode(JSON.stringify(payload)).byteLength,
+        });
+      }
+      await repository.promoteGeneration({
+        generationId: generation.generationId,
+        promotedEpochSeconds: FROZEN_EPOCH_SECONDS,
+      });
+      let now = Date.parse(FROZEN_AT);
+      const source = createPowerProgressStateSource({ store, archiveRoot, now: () => now });
+      await expect(source.readPowerProgress()).resolves.toMatchObject({
+        kind: "computed",
+        freshness: "fresh",
+      });
+
+      now += 86_400_000;
+      const failed = await repository.beginGeneration({
+        frozenEpochSeconds: FROZEN_EPOCH_SECONDS + 86_400,
+        frozenOn: "2026-08-08",
+      });
+      await repository.recordRefreshFailure({
+        generationId: failed.generation.generationId,
+        code: "network",
+        failedEpochSeconds: FROZEN_EPOCH_SECONDS + 86_400,
+      });
+      const stale = await source.readPowerProgress();
+      expect(stale).toMatchObject({
+        kind: "stale",
+        lastGood: { kind: "computed", asOf: FROZEN_AT },
+        refreshFailure: { code: "network", failedAt: "2026-08-08T12:00:00.000Z" },
+      });
+      expect(JSON.stringify(stale)).not.toMatch(/generationId|archive|\.json\.gz/);
+      await rm(firstArchivePath);
+      await expect(source.readPowerProgress()).resolves.toEqual({
+        kind: "unavailable",
+        reason: "invalid-data",
+      });
+    } finally {
+      await store.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- project verified analytics-curve archives into a strict, bounded Power Progress DTO
- preserve the last good result with independent freshness and safe refresh-failure context
- add the required desktop training-context field and bump the wire protocol to 13
- cover real archive verification, malformed evidence, privacy boundaries, and consumer fixtures

## Verification

- pnpm check
- pnpm check-parity --all
- pnpm s8a
- pnpm test: 8,192 passed; three unrelated timing-sensitive core tests failed under full parallel load and all 24 passed when rerun in isolation

## Scope

This is the backend/contract half of Power Progress. The renderer surface follows in a separate small PR.