### PR TITLE
feat: add Power Progress desktop panel

### DIFF
--- a/.changeset/power-progress-ui.md
+++ b/.changeset/power-progress-ui.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop now compares five key power durations across your latest two 28-day periods, with optional heart-rate and durability context and clear stale-data warnings.

--- a/apps/desktop-renderer/src/ui/training/PowerProgressPanel.tsx
+++ b/apps/desktop-renderer/src/ui/training/PowerProgressPanel.tsx
@@ -1,0 +1,210 @@
+import type { PowerProgressComputed, PowerProgressPanel } from "@enduragent/coach-contract";
+import type { ReactElement } from "react";
+import {
+  formatDateLabel,
+  formatUtcTimestamp,
+  formatWholeNumber,
+} from "../../training-context/format.js";
+import {
+  POWER_PROGRESS_FRESHNESS_COPY,
+  POWER_PROGRESS_REFRESH_FAILURE_COPY,
+  POWER_PROGRESS_ROTATION_COPY,
+  POWER_PROGRESS_UNAVAILABLE_COPY,
+} from "./copy.js";
+import styles from "./TrainingView.module.css";
+
+const POWER_DURATION_LABELS = new Map<number, string>([
+  [5, "5 sec"],
+  [60, "1 min"],
+  [300, "5 min"],
+  [1_200, "20 min"],
+  [3_600, "60 min"],
+]);
+
+function formatPowerDuration(durationSeconds: number): string {
+  return POWER_DURATION_LABELS.get(durationSeconds) ?? `${durationSeconds} sec`;
+}
+
+function formatProgressChange(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  const normalized = Object.is(rounded, -0) ? 0 : rounded;
+  return `${normalized > 0 ? "+" : ""}${normalized}%`;
+}
+
+function formatProgressMagnitude(value: number): string {
+  return `${Math.round(Math.abs(value) * 10) / 10}%`;
+}
+
+function ProgressWatts(props: {
+  readonly value:
+    | { readonly kind: "computed"; readonly watts: number }
+    | { readonly kind: "unavailable" };
+}): ReactElement {
+  return props.value.kind === "computed" ? (
+    <span>{formatWholeNumber(props.value.watts)} W</span>
+  ) : (
+    <span aria-label="Unavailable">—</span>
+  );
+}
+
+function ProgressBpm(props: {
+  readonly value:
+    | { readonly kind: "computed"; readonly bpm: number }
+    | { readonly kind: "unavailable" };
+}): ReactElement {
+  return props.value.kind === "computed" ? (
+    <span>{formatWholeNumber(props.value.bpm)} bpm</span>
+  ) : (
+    <span aria-label="Unavailable">—</span>
+  );
+}
+
+function ProgressChange(props: {
+  readonly value:
+    | { readonly kind: "computed"; readonly percent: number }
+    | { readonly kind: "unavailable" };
+}): ReactElement {
+  if (props.value.kind === "unavailable") return <span aria-label="Unavailable">—</span>;
+  const { percent } = props.value;
+  const direction = percent > 0 ? "Increased" : percent < 0 ? "Decreased" : "No change";
+  const arrow = percent > 0 ? "↑" : percent < 0 ? "↓" : "→";
+  const tone = percent > 0 ? "positive" : percent < 0 ? "negative" : "neutral";
+  return (
+    <span
+      className={styles.progressChange}
+      data-tone={tone}
+      aria-label={`${direction}, ${formatProgressMagnitude(percent)}`}
+    >
+      <span aria-hidden="true">{arrow}</span> {formatProgressChange(percent)}
+    </span>
+  );
+}
+
+function PowerProgressTable(props: { readonly progress: PowerProgressComputed }): ReactElement {
+  return (
+    <div className={styles.progressTableWrap}>
+      <table className={styles.progressTable}>
+        <caption className={styles.srOnly}>
+          Power curve for the current 28 days compared with the previous 28 days
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">Effort</th>
+            <th scope="col">Now</th>
+            <th scope="col">Prior</th>
+            <th scope="col">Change</th>
+          </tr>
+        </thead>
+        <tbody>
+          {props.progress.anchors.map((anchor) => (
+            <tr key={anchor.durationSeconds}>
+              <th scope="row">{formatPowerDuration(anchor.durationSeconds)}</th>
+              <td>
+                <ProgressWatts value={anchor.current} />
+              </td>
+              <td>
+                <ProgressWatts value={anchor.previous} />
+              </td>
+              <td>
+                <ProgressChange value={anchor.change} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function HeartRateProgress(props: { readonly progress: PowerProgressComputed }): ReactElement {
+  if (props.progress.heartRateContext.kind === "unavailable") {
+    return <p className={styles.support}>Heart-rate comparison needs more data.</p>;
+  }
+  return (
+    <details className={styles.progressDetails}>
+      <summary>
+        Heart-rate response · {props.progress.heartRateContext.anchors.length} efforts
+      </summary>
+      <div className={styles.progressTableWrap}>
+        <table className={`${styles.progressTable} ${styles.heartRateTable}`}>
+          <caption className={styles.srOnly}>
+            Heart-rate curve for the current 28 days compared with the previous 28 days
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">Effort</th>
+              <th scope="col">Now</th>
+              <th scope="col">Prior</th>
+              <th scope="col">Change</th>
+            </tr>
+          </thead>
+          <tbody>
+            {props.progress.heartRateContext.anchors.map((anchor) => (
+              <tr key={anchor.durationSeconds}>
+                <th scope="row">{formatPowerDuration(anchor.durationSeconds)}</th>
+                <td>
+                  <ProgressBpm value={anchor.current} />
+                </td>
+                <td>
+                  <ProgressBpm value={anchor.previous} />
+                </td>
+                <td>
+                  <ProgressChange value={anchor.change} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}
+
+function sustainabilityCopy(progress: PowerProgressComputed): string {
+  if (progress.sustainabilityContext.kind === "unavailable") {
+    return "Durability context needs more data.";
+  }
+  const source = {
+    indoor: "indoor rides",
+    outdoor: "outdoor rides",
+    mixed: "indoor and outdoor rides",
+    unknown: "available rides",
+  }[progress.sustainabilityContext.sourceContext];
+  return `42-day durability context · ${Math.round(progress.sustainabilityContext.coverageRatio * 100)}% curve coverage · ${source}`;
+}
+
+export function PowerProgressContent(props: { readonly panel: PowerProgressPanel }): ReactElement {
+  if (props.panel.kind === "unavailable") {
+    return <p className={styles.empty}>{POWER_PROGRESS_UNAVAILABLE_COPY[props.panel.reason]}</p>;
+  }
+  const progress = props.panel.kind === "stale" ? props.panel.lastGood : props.panel;
+  return (
+    <>
+      {props.panel.kind === "stale" ? (
+        <p className={styles.progressNotice}>
+          {POWER_PROGRESS_REFRESH_FAILURE_COPY[props.panel.refreshFailure.code]} Showing the last
+          complete comparison. Failed{" "}
+          <time dateTime={props.panel.refreshFailure.failedAt}>
+            {formatUtcTimestamp(props.panel.refreshFailure.failedAt)}
+          </time>
+          .
+        </p>
+      ) : null}
+      <div className={styles.progressHeader}>
+        <div>
+          <p className={styles.progressLead}>{POWER_PROGRESS_ROTATION_COPY[progress.rotation]}</p>
+          <p className={styles.meta}>
+            {formatDateLabel(progress.currentWindow.start)}–
+            {formatDateLabel(progress.currentWindow.end)} · compared with the prior 28 days
+          </p>
+        </div>
+        <p className={styles.badge} data-freshness={progress.freshness}>
+          {POWER_PROGRESS_FRESHNESS_COPY[progress.freshness]}
+        </p>
+      </div>
+      <PowerProgressTable progress={progress} />
+      <HeartRateProgress progress={progress} />
+      <p className={styles.progressFoot}>{sustainabilityCopy(progress)}</p>
+    </>
+  );
+}

--- a/apps/desktop-renderer/src/ui/training/TrainingView.module.css
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.module.css
@@ -64,6 +64,182 @@
   line-height: 1.45;
 }
 
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.progressNotice {
+  margin: 0 0 14px;
+  padding: 9px 11px;
+  border-left: 3px solid var(--warn);
+  color: var(--ink-2);
+  background: color-mix(in srgb, var(--warn) var(--tint), transparent);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.progressHeader {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.progressHeader > div {
+  min-width: 0;
+}
+
+.progressHeader .badge {
+  flex: none;
+  margin: 0;
+}
+
+.progressHeader .badge[data-freshness="flag"],
+.progressHeader .badge[data-freshness="stale"],
+.progressHeader .badge[data-freshness="critical"] {
+  color: var(--warn);
+  background-color: color-mix(in srgb, var(--warn) var(--tint), transparent);
+}
+
+.progressLead {
+  margin: 0 0 5px;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 560;
+  line-height: 1.35;
+}
+
+.progressTableWrap {
+  min-width: 0;
+  margin-top: 14px;
+  overflow-x: auto;
+}
+
+.progressTable {
+  width: 100%;
+  min-width: 390px;
+  border-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.progressTable th,
+.progressTable td {
+  padding: 9px 8px;
+  border-bottom: 1px solid var(--line);
+  text-align: right;
+}
+
+.progressTable thead th {
+  padding-top: 0;
+  color: var(--ink-3);
+  font: 10px/1.3 var(--f-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.progressTable th:first-child,
+.progressTable td:first-child {
+  padding-left: 0;
+  text-align: left;
+}
+
+.progressTable th:last-child,
+.progressTable td:last-child {
+  padding-right: 0;
+}
+
+.progressTable tbody th {
+  position: relative;
+  color: var(--ink);
+  font: 560 12px/1.35 var(--f-ui);
+}
+
+.progressTable tbody th::before {
+  display: inline-block;
+  width: 3px;
+  height: 18px;
+  margin-right: 9px;
+  vertical-align: middle;
+  background: var(--ink);
+  border-radius: 2px;
+  content: "";
+  opacity: 0.26;
+}
+
+.progressTable tbody tr:nth-child(1) th::before {
+  opacity: 1;
+}
+
+.progressTable tbody tr:nth-child(2) th::before {
+  opacity: 0.8;
+}
+
+.progressTable tbody tr:nth-child(3) th::before {
+  opacity: 0.62;
+}
+
+.progressTable tbody tr:nth-child(4) th::before {
+  opacity: 0.44;
+}
+
+.progressTable tbody td {
+  color: var(--ink-2);
+  font: 11px/1.35 var(--f-mono);
+}
+
+.progressTable tbody td:nth-child(2) {
+  color: var(--ink);
+  font-weight: 650;
+}
+
+.progressChange[data-tone="positive"] {
+  color: var(--ok);
+}
+
+.progressChange[data-tone="negative"] {
+  color: var(--warn);
+}
+
+.progressDetails {
+  margin-top: 14px;
+  color: var(--ink-2);
+  font-size: 12px;
+}
+
+.progressDetails summary {
+  width: fit-content;
+  cursor: pointer;
+  font-weight: 560;
+}
+
+.progressDetails summary:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
+}
+
+.progressDetails .progressTableWrap {
+  margin-top: 10px;
+}
+
+.heartRateTable tbody th::before {
+  opacity: 0.45;
+}
+
+.progressFoot {
+  margin: 14px 0 0;
+  color: var(--ink-3);
+  font: 10.5px/1.5 var(--f-mono);
+}
+
 .badge {
   composes: chip from "../../theme/surface.module.css";
   margin: 4px 0 8px;
@@ -227,6 +403,14 @@
 }
 
 @media (max-width: 760px) {
+  .progressHeader {
+    display: grid;
+  }
+
+  .progressHeader .badge {
+    justify-self: start;
+  }
+
   .wellnessRow {
     grid-template-columns: 62px 70px minmax(50px, 1fr);
   }

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -3,6 +3,7 @@ import type {
   AnchorZonesPanel,
   CyclingLoadPanel,
   PlanPanel,
+  PowerProgressPanel,
   WellnessTrendPanel,
 } from "@enduragent/coach-contract";
 import { useEffect, useRef, type ReactElement, type ReactNode } from "react";
@@ -29,6 +30,7 @@ import {
   trainingStatusCopy,
 } from "./copy.js";
 import styles from "./TrainingView.module.css";
+import { PowerProgressContent } from "./PowerProgressPanel.js";
 import { WellnessSparkline } from "./WellnessSparkline.js";
 
 function Panel(props: {
@@ -46,6 +48,14 @@ function Panel(props: {
 
 function Unknown(props: { readonly reason: keyof typeof TRAINING_UNKNOWN_COPY }): ReactElement {
   return <p className={styles.empty}>{TRAINING_UNKNOWN_COPY[props.reason]}</p>;
+}
+
+function PowerProgressStatePanel(props: { readonly panel: PowerProgressPanel }): ReactElement {
+  return (
+    <Panel name="power-progress" title="Power progress">
+      <PowerProgressContent panel={props.panel} />
+    </Panel>
+  );
 }
 
 function SyncPanel(): ReactElement {
@@ -305,6 +315,7 @@ export function TrainingView(): ReactElement {
         {status}
       </p>
       <SyncPanel />
+      <PowerProgressStatePanel panel={training.trainingContext.performanceProgress} />
       <AnchorPanel panel={training.trainingContext.anchorZones} />
       <LoadPanel panel={training.trainingContext.cyclingLoad} />
       <UpcomingPlanPanel panel={training.trainingContext.plan} />

--- a/apps/desktop-renderer/src/ui/training/copy.ts
+++ b/apps/desktop-renderer/src/ui/training/copy.ts
@@ -1,4 +1,10 @@
-import type { CyclingAnchor, TrainingContextUnknownReason } from "@enduragent/coach-contract";
+import type {
+  CyclingAnchor,
+  PowerProgressComputed,
+  PowerProgressRefreshFailureCode,
+  PowerProgressUnavailableReason,
+  TrainingContextUnknownReason,
+} from "@enduragent/coach-contract";
 import type { TrainingContextStatus } from "../../training-context/controller.js";
 
 export const MAX_VISIBLE_PLAN_ITEMS = 7;
@@ -13,6 +19,48 @@ export const TRAINING_UNKNOWN_COPY: Readonly<Record<TrainingContextUnknownReason
 };
 
 export const WELLNESS_LABELS: readonly string[] = ["HRV", "Sleep", "Resting HR"];
+
+export const POWER_PROGRESS_UNAVAILABLE_COPY: Readonly<
+  Record<PowerProgressUnavailableReason, string>
+> = {
+  "not-synced": "Sync training data to compare your recent power.",
+  "insufficient-data": "Not enough power-curve data to compare two 28-day periods.",
+  "invalid-data": "Power progress data could not be verified. Sync again.",
+  "refresh-failed": "Power progress has not refreshed yet. Try syncing again.",
+  "temporary-failure": "Power progress is temporarily unavailable. Try again.",
+};
+
+export const POWER_PROGRESS_REFRESH_FAILURE_COPY: Readonly<
+  Record<PowerProgressRefreshFailureCode, string>
+> = {
+  "request-budget-exhausted": "The latest refresh exceeded its request budget.",
+  "rate-limited": "intervals.icu delayed the latest refresh.",
+  timeout: "The latest refresh timed out.",
+  network: "The latest refresh lost its network connection.",
+  "provider-unavailable": "intervals.icu was unavailable during the latest refresh.",
+  "malformed-response": "The latest refresh returned data that could not be used.",
+  "response-too-large": "The latest refresh returned more data than the app could accept.",
+  cancelled: "The latest refresh was cancelled.",
+  "temporary-failure": "The latest refresh did not finish.",
+};
+
+export const POWER_PROGRESS_ROTATION_COPY: Readonly<
+  Record<PowerProgressComputed["rotation"], string>
+> = {
+  sprint: "Short efforts changed more favorably than long efforts.",
+  endurance: "Long efforts changed more favorably than short efforts.",
+  balanced: "Short and long efforts changed at a similar rate.",
+  unknown: "Not enough comparable efforts to identify a power shift.",
+};
+
+export const POWER_PROGRESS_FRESHNESS_COPY: Readonly<
+  Record<PowerProgressComputed["freshness"], string>
+> = {
+  fresh: "Fresh",
+  flag: "Refresh due",
+  stale: "Stale",
+  critical: "Very stale",
+};
 
 export const RIDE_IMPORT_DESCRIPTION =
   "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.";

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -2,6 +2,7 @@ import type {
   CoachOperationProgressNotificationEnvelope,
   CyclingTrainingContext,
   ImportFilesRpcResult,
+  PowerProgressComputed,
 } from "@enduragent/coach-contract";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -26,8 +27,84 @@ function planItem(index: number) {
   };
 }
 
+const computedPowerProgress = {
+  kind: "computed",
+  currentWindow: { start: "1998-06-22", end: "1998-07-19" },
+  previousWindow: { start: "1998-05-25", end: "1998-06-21" },
+  anchors: [
+    {
+      durationSeconds: 5,
+      current: { kind: "computed", watts: 1_120 },
+      previous: { kind: "computed", watts: 1_050 },
+      change: { kind: "computed", percent: 6.7 },
+    },
+    {
+      durationSeconds: 60,
+      current: { kind: "computed", watts: 620 },
+      previous: { kind: "computed", watts: 600 },
+      change: { kind: "computed", percent: 3.3 },
+    },
+    {
+      durationSeconds: 300,
+      current: { kind: "computed", watts: 390 },
+      previous: { kind: "computed", watts: 400 },
+      change: { kind: "computed", percent: -2.5 },
+    },
+    {
+      durationSeconds: 1_200,
+      current: { kind: "computed", watts: 310 },
+      previous: { kind: "computed", watts: 310 },
+      change: { kind: "computed", percent: 0 },
+    },
+    {
+      durationSeconds: 3_600,
+      current: { kind: "unavailable" },
+      previous: { kind: "unavailable" },
+      change: { kind: "unavailable" },
+    },
+  ],
+  rotation: "sprint",
+  heartRateContext: {
+    kind: "computed",
+    anchors: [
+      {
+        durationSeconds: 60,
+        current: { kind: "computed", bpm: 181 },
+        previous: { kind: "computed", bpm: 178 },
+        change: { kind: "computed", percent: 1.7 },
+      },
+      {
+        durationSeconds: 300,
+        current: { kind: "computed", bpm: 176 },
+        previous: { kind: "computed", bpm: 175 },
+        change: { kind: "computed", percent: 0.6 },
+      },
+      {
+        durationSeconds: 1_200,
+        current: { kind: "computed", bpm: 165 },
+        previous: { kind: "computed", bpm: 166 },
+        change: { kind: "computed", percent: -0.6 },
+      },
+      {
+        durationSeconds: 3_600,
+        current: { kind: "computed", bpm: 151 },
+        previous: { kind: "computed", bpm: 150 },
+        change: { kind: "computed", percent: 0.7 },
+      },
+    ],
+  },
+  sustainabilityContext: {
+    kind: "computed",
+    window: { start: "1998-06-08", end: "1998-07-19" },
+    coverageRatio: 0.83,
+    sourceContext: "mixed",
+  },
+  freshness: "fresh",
+  asOf: "1998-07-19T08:00:00.000Z",
+} as const satisfies PowerProgressComputed;
+
 const context: CyclingTrainingContext = {
-  performanceProgress: { kind: "unavailable", reason: "not-synced" },
+  performanceProgress: computedPowerProgress,
   anchorZones: {
     kind: "computed",
     asOf: "1998-07-19T08:00:00.000Z",
@@ -178,6 +255,7 @@ describe("training page", () => {
     const headings = [...document.querySelectorAll("[data-panel] h2")];
     expect(headings.map((node) => node.textContent)).toEqual([
       "Sync",
+      "Power progress",
       "Current cycling anchor",
       "Cycling Load",
       "Plan",
@@ -194,6 +272,74 @@ describe("training page", () => {
     expect(screen.getByText("80%")).toBeInTheDocument();
     expect(screen.getByText("4/5 planned days matched")).toBeInTheDocument();
     expect(document.querySelector(".training-status")).toHaveProperty("hidden", true);
+  });
+
+  it("renders an accessible five-effort Power Progress comparison with secondary context", async () => {
+    const user = userEvent.setup();
+    render(<TrainingView />);
+
+    const progress = screen.getByRole("region", { name: "Power progress" });
+    expect(
+      within(progress).getByText("Short efforts changed more favorably than long efforts."),
+    ).toBeInTheDocument();
+    expect(
+      within(progress).getByText("1998-06-22–1998-07-19 · compared with the prior 28 days"),
+    ).toBeInTheDocument();
+    expect(within(progress).getByText("Fresh")).toBeInTheDocument();
+    const powerTable = within(progress).getByRole("table", {
+      name: "Power curve for the current 28 days compared with the previous 28 days",
+    });
+    expect(within(powerTable).getAllByRole("row")).toHaveLength(6);
+    expect(within(powerTable).getByText("1120 W")).toBeInTheDocument();
+    expect(within(powerTable).getByLabelText("Increased, 6.7%")).toHaveTextContent("↑ +6.7%");
+    expect(within(powerTable).getByLabelText("Decreased, 2.5%")).toHaveTextContent("↓ -2.5%");
+    expect(within(powerTable).getAllByLabelText("Unavailable")).toHaveLength(3);
+    await user.click(within(progress).getByText("Heart-rate response · 4 efforts"));
+    expect(
+      within(progress).getByRole("table", {
+        name: "Heart-rate curve for the current 28 days compared with the previous 28 days",
+      }),
+    ).toBeVisible();
+    expect(within(progress).getByText("181 bpm")).toBeInTheDocument();
+    expect(
+      within(progress).getByText(
+        "42-day durability context · 83% curve coverage · indoor and outdoor rides",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("explains unavailable data and clearly labels a stale last-good comparison", () => {
+    useEnduragentStore.setState({
+      training: ready({
+        trainingContext: {
+          ...context,
+          performanceProgress: { kind: "unavailable", reason: "invalid-data" },
+        },
+      }),
+    });
+    render(<TrainingView />);
+    expect(
+      screen.getByText("Power progress data could not be verified. Sync again."),
+    ).toBeInTheDocument();
+
+    update({
+      training: ready({
+        trainingContext: {
+          ...context,
+          performanceProgress: {
+            kind: "stale",
+            lastGood: { ...computedPowerProgress, freshness: "stale" },
+            refreshFailure: { code: "timeout", failedAt: "1998-07-20T08:00:00.000Z" },
+          },
+        },
+      }),
+    });
+    const progress = screen.getByRole("region", { name: "Power progress" });
+    expect(within(progress).getByText(/latest refresh timed out/i)).toHaveTextContent(
+      "The latest refresh timed out. Showing the last complete comparison. Failed 1998-07-20 08:00:00 UTC.",
+    );
+    expect(within(progress).getByText("Stale")).toBeInTheDocument();
+    expect(within(progress).getByText("1120 W")).toBeInTheDocument();
   });
 
   it("renders the power zones and caps the plan at seven upcoming workouts", () => {
@@ -232,6 +378,7 @@ describe("training page", () => {
     expect(screen.getByText("Loading training data…")).toBeVisible();
     expect(screen.getByRole("region", { name: "Training" })).toHaveAttribute("aria-busy", "true");
     for (const copy of [
+      "Sync training data to compare your recent power.",
       "No cycling FTP anchor is available",
       "No platform Load is available for the last 7 days",
       "No planned cycling workouts are available",
@@ -254,10 +401,7 @@ describe("training page sync", () => {
       "fresh",
       "Last synced 1998-07-19 07:55:00 UTC",
     ]);
-    expect(metadata?.querySelector("time")).toHaveAttribute(
-      "datetime",
-      "1998-07-19T07:55:00.000Z",
-    );
+    expect(metadata?.querySelector("time")).toHaveAttribute("datetime", "1998-07-19T07:55:00.000Z");
   });
 
   it("keeps an unparsable sync instant out of the markup", () => {


### PR DESCRIPTION
## Summary

- add a five-duration Power Progress effort ladder to the Training page
- compare current and prior 28-day power with signed, non-color-only direction labels
- expose optional heart-rate details and 42-day durability coverage
- render explicit unavailable states and stale-last-good refresh warnings
- keep the panel responsive and keyboard/screen-reader friendly

## Verification

- pnpm --filter @enduragent/desktop-renderer test (725 passed)
- pnpm check
- pnpm s8a
- visual QA at 900px and 520px widths, including expanded heart-rate details

## Design

The frontend-design review kept the existing desktop card and theme system while introducing a cycling-specific five-effort ladder. A semantic table provides exact values, arrows reinforce direction without relying on color, and secondary context stays compact in native details.