### PR TITLE
feat(desktop): add bounded activity analysis service

### DIFF
--- a/.changeset/bounded-activity-analysis.md
+++ b/.changeset/bounded-activity-analysis.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop activity analysis now uses a bounded local cache, preserves last-good results when refreshes fail, and keeps provider activity IDs out of the interface.

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1247,6 +1247,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       current: "page",
       order: [
         "Sync",
+        "Power progress",
         "Current cycling anchor",
         "Cycling Load",
         "Plan",

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -117,6 +117,7 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   listArchivedConversations: 30_000,
   getArchivedTranscriptPage: 30_000,
   getAthleteState: 30_000,
+  getActivityAnalysis: 90_000,
   importFiles: 60 * 60_000,
   sync: 24 * 60 * 60_000,
   saveIntake: 30_000,

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -50,6 +50,11 @@ const rpcDeadlineCases = [
   ["listArchivedConversations", {}, 30_000],
   ["getArchivedTranscriptPage", { boundaryRef: "a".repeat(64), cursor: null, limit: 25 }, 30_000],
   ["getAthleteState", {}, 30_000],
+  [
+    "getActivityAnalysis",
+    { canonicalActivityId: "a".repeat(64), sections: ["aerobic-drift"] },
+    90_000,
+  ],
   ["importFiles", { paths: ["/synthetic/ride.fit"] }, 3_600_000],
   ["sync", {}, 86_400_000],
   [
@@ -683,6 +688,51 @@ describe("RPC receive and observers", () => {
     );
   });
 
+  it("parses a bounded activity-analysis result before typed delivery", async () => {
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    socket.sendHook = (text) => {
+      const request = JSON.parse(text) as { readonly id: number };
+      socket.emitMessage(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            schemaVersion: 1,
+            activity: {
+              id: "a".repeat(64),
+              workoutId: "b".repeat(64),
+              sessionSequence: 0,
+              isMultisport: false,
+              sport: "cycling",
+              subSport: null,
+              isTransition: false,
+              startEpochSeconds: 899_985_600,
+              timezoneOffsetSeconds: 0,
+              localDate: "1998-07-06",
+              elapsedSeconds: 3_600,
+              timerSeconds: 3_500,
+              movingSeconds: 3_400,
+              distanceMeters: 40_000,
+            },
+            revision: "c".repeat(64),
+            sections: {
+              intervals: { kind: "unavailable", reason: "not-provider-backed" },
+            },
+          },
+        }),
+      );
+    };
+
+    await expect(client.call("getActivityAnalysis", {
+      canonicalActivityId: "a".repeat(64),
+      sections: ["intervals"],
+    })).resolves.toMatchObject({
+      schemaVersion: 1,
+      sections: { intervals: { kind: "unavailable", reason: "not-provider-backed" } },
+    });
+  });
+
   it("exercises all methods with monotonic strict requests and parsed results", async () => {
     const received: unknown[] = [];
     const { socket, connecting } = acceptedSocket();
@@ -724,6 +774,27 @@ describe("RPC receive and observers", () => {
           recentActivities: [],
           plannedWorkouts: [],
           wellness: {},
+        },
+        getActivityAnalysis: {
+          schemaVersion: 1,
+          activity: {
+            id: "a".repeat(64),
+            workoutId: "b".repeat(64),
+            sessionSequence: 0,
+            isMultisport: false,
+            sport: "cycling",
+            subSport: null,
+            isTransition: false,
+            startEpochSeconds: 899_985_600,
+            timezoneOffsetSeconds: 0,
+            localDate: "1998-07-06",
+            elapsedSeconds: 3_600,
+            timerSeconds: 3_500,
+            movingSeconds: 3_400,
+            distanceMeters: 40_000,
+          },
+          revision: "c".repeat(64),
+          sections: { intervals: { kind: "unavailable", reason: "unsupported" } },
         },
         importFiles: {
           schemaVersion: 2,

--- a/packages/coach-contract/src/activity-analysis.ts
+++ b/packages/coach-contract/src/activity-analysis.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 
 export const ACTIVITY_ANALYSIS_SCHEMA_VERSION = 1 as const;
+export const MAX_ACTIVITY_ANALYSIS_RESPONSE_BYTES = 512 * 1_024;
+export const MAX_ACTIVITY_ANALYSIS_INTERVALS = 200;
+export const MAX_ACTIVITY_ANALYSIS_INTERVAL_GROUPS = 50;
+export const MAX_ACTIVITY_ANALYSIS_EFFORTS = 10;
+export const MAX_ACTIVITY_ANALYSIS_BUCKETS = 256;
+export const MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_ROWS = 256;
+export const MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_CURVES = 8;
 
 export const ACTIVITY_ANALYSIS_SECTIONS = [
   "aerobic-drift",
@@ -64,6 +71,9 @@ const boundedDisplayText = (maximum: number) => z.string().min(1).max(maximum)
 const SafeIntegerSchema = z.number().int().min(Number.MIN_SAFE_INTEGER).max(Number.MAX_SAFE_INTEGER);
 const NonnegativeIntegerSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
 const NullableDurationSchema = NonnegativeIntegerSchema.nullable();
+const NonnegativeFiniteSchema = z.number().finite().nonnegative().max(Number.MAX_SAFE_INTEGER);
+const NullableNonnegativeFiniteSchema = NonnegativeFiniteSchema.nullable();
+const NullableNonnegativeIntegerSchema = NonnegativeIntegerSchema.nullable();
 
 export const CanonicalActivitySummarySchema = z
   .object({
@@ -164,8 +174,263 @@ export function createAnalysisSectionSchema<T extends z.ZodType>(data: T) {
         refreshFailure: AnalysisRefreshFailureSchema,
       })
       .strict(),
-  ]);
+  ]).superRefine((value, context) => {
+    if (
+      value.kind === "stale"
+      && "lastGood" in value
+      && value.lastGood.provenance.delivery !== "persisted-cache"
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["lastGood", "provenance", "delivery"],
+        message: "stale last-good analysis must come from persisted cache",
+      });
+    }
+  });
 }
+
+const AerobicDriftHalfSchema = z
+  .object({
+    durationSeconds: NonnegativeFiniteSchema.max(7 * 86_400),
+    sampleCount: NonnegativeIntegerSchema.max(1_000_000),
+    averagePowerWatts: NonnegativeFiniteSchema.max(100_000),
+    averageHeartRateBpm: NonnegativeFiniteSchema.max(400),
+    efficiencyFactor: NonnegativeFiniteSchema.max(100_000),
+  })
+  .strict();
+
+const AerobicDriftCoverageSchema = z
+  .object({
+    totalSamples: NonnegativeIntegerSchema.max(1_000_000),
+    validSamples: NonnegativeIntegerSchema.max(1_000_000),
+    includedDurationSeconds: NonnegativeFiniteSchema.max(7 * 86_400),
+    windowDurationSeconds: NonnegativeFiniteSchema.max(7 * 86_400),
+    fraction: z.number().finite().min(0).max(1),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.validSamples > value.totalSamples) {
+      context.addIssue({ code: "custom", path: ["validSamples"], message: "valid samples exceed total" });
+    }
+    if (value.includedDurationSeconds > value.windowDurationSeconds) {
+      context.addIssue({
+        code: "custom",
+        path: ["includedDurationSeconds"],
+        message: "included duration exceeds window",
+      });
+    }
+  });
+
+export const AerobicDriftDataSchema = z
+  .object({
+    method: z.literal("local-time-weighted-efficiency-factor"),
+    firstHalf: AerobicDriftHalfSchema,
+    secondHalf: AerobicDriftHalfSchema,
+    decouplingPercent: z.number().finite().min(-1_000).max(1_000),
+    coverage: AerobicDriftCoverageSchema,
+    evidence: z.enum(["standard", "limited"]),
+    limitations: z
+      .array(z.enum(["duration-under-60-minutes", "variable-output", "moving-status-unavailable"]))
+      .max(3)
+      .refine((value) => new Set(value).size === value.length, "limitations must be unique"),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if ((value.evidence === "standard") !== (value.limitations.length === 0)) {
+      context.addIssue({
+        code: "custom",
+        path: ["limitations"],
+        message: "limited evidence requires at least one limitation",
+      });
+    }
+  });
+
+const IntervalKindSchema = z.enum(["work", "recovery", "unknown"]);
+const NullableDisplayTextSchema = boundedDisplayText(128).nullable();
+
+export const ActivityIntervalSchema = z
+  .object({
+    ordinal: z.number().int().min(1).max(MAX_ACTIVITY_ANALYSIS_INTERVALS),
+    groupOrdinal: z.number().int().min(1).max(MAX_ACTIVITY_ANALYSIS_INTERVAL_GROUPS).nullable(),
+    kind: IntervalKindSchema,
+    label: NullableDisplayTextSchema,
+    startIndex: NullableNonnegativeIntegerSchema,
+    endIndex: NullableNonnegativeIntegerSchema,
+    startSeconds: NullableNonnegativeFiniteSchema,
+    endSeconds: NullableNonnegativeFiniteSchema,
+    movingSeconds: NullableNonnegativeFiniteSchema,
+    elapsedSeconds: NullableNonnegativeFiniteSchema,
+    distanceMeters: NullableNonnegativeFiniteSchema,
+    averagePowerWatts: NullableNonnegativeFiniteSchema,
+    maximumPowerWatts: NullableNonnegativeFiniteSchema,
+    averageHeartRateBpm: NullableNonnegativeFiniteSchema,
+    maximumHeartRateBpm: NullableNonnegativeFiniteSchema,
+    averageCadenceRpm: NullableNonnegativeFiniteSchema,
+    maximumCadenceRpm: NullableNonnegativeFiniteSchema,
+    zone: z.number().int().min(0).max(100).nullable(),
+    intensityPercent: z.number().finite().min(0).max(10_000).nullable(),
+    trainingLoad: NullableNonnegativeFiniteSchema,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.startIndex !== null && value.endIndex !== null && value.startIndex > value.endIndex) {
+      context.addIssue({ code: "custom", path: ["endIndex"], message: "interval indexes are reversed" });
+    }
+    if (value.startSeconds !== null && value.endSeconds !== null && value.startSeconds > value.endSeconds) {
+      context.addIssue({ code: "custom", path: ["endSeconds"], message: "interval times are reversed" });
+    }
+  });
+
+export const ActivityIntervalGroupSchema = z
+  .object({
+    ordinal: z.number().int().min(1).max(MAX_ACTIVITY_ANALYSIS_INTERVAL_GROUPS),
+    intervalOrdinals: z
+      .array(z.number().int().min(1).max(MAX_ACTIVITY_ANALYSIS_INTERVALS))
+      .min(1)
+      .max(MAX_ACTIVITY_ANALYSIS_INTERVALS)
+      .refine((value) => new Set(value).size === value.length, "interval ordinals must be unique"),
+    kind: IntervalKindSchema,
+    movingSeconds: NullableNonnegativeFiniteSchema,
+    elapsedSeconds: NullableNonnegativeFiniteSchema,
+    averagePowerWatts: NullableNonnegativeFiniteSchema,
+    maximumPowerWatts: NullableNonnegativeFiniteSchema,
+    averageHeartRateBpm: NullableNonnegativeFiniteSchema,
+    maximumHeartRateBpm: NullableNonnegativeFiniteSchema,
+    averageCadenceRpm: NullableNonnegativeFiniteSchema,
+    maximumCadenceRpm: NullableNonnegativeFiniteSchema,
+    zone: z.number().int().min(0).max(100).nullable(),
+    intensityPercent: z.number().finite().min(0).max(10_000).nullable(),
+    trainingLoad: NullableNonnegativeFiniteSchema,
+  })
+  .strict();
+
+export const IntervalReviewDataSchema = z
+  .object({
+    source: z.enum(["local-canonical", "provider"]),
+    intervals: z.array(ActivityIntervalSchema).max(MAX_ACTIVITY_ANALYSIS_INTERVALS),
+    groups: z.array(ActivityIntervalGroupSchema).max(MAX_ACTIVITY_ANALYSIS_INTERVAL_GROUPS),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.intervals.some((interval, index) => interval.ordinal !== index + 1)) {
+      context.addIssue({ code: "custom", path: ["intervals"], message: "interval ordinals are not contiguous" });
+    }
+    if (value.groups.some((group, index) => group.ordinal !== index + 1)) {
+      context.addIssue({ code: "custom", path: ["groups"], message: "group ordinals are not contiguous" });
+    }
+    const ordinals = new Set(value.intervals.map((interval) => interval.ordinal));
+    if (value.groups.some((group) => group.intervalOrdinals.some((ordinal) => !ordinals.has(ordinal)))) {
+      context.addIssue({ code: "custom", path: ["groups"], message: "group references a missing interval" });
+    }
+  });
+
+export const BestEffortSchema = z
+  .object({
+    rank: z.number().int().min(1).max(MAX_ACTIVITY_ANALYSIS_EFFORTS),
+    startIndex: NonnegativeIntegerSchema,
+    endIndex: NonnegativeIntegerSchema,
+    durationSeconds: NonnegativeFiniteSchema.max(7 * 86_400),
+    distanceMeters: NullableNonnegativeFiniteSchema,
+    averageWatts: NonnegativeFiniteSchema.max(100_000),
+  })
+  .strict()
+  .refine((value) => value.startIndex <= value.endIndex, { path: ["endIndex"], message: "effort indexes are reversed" });
+
+export const BestEffortDataSchema = z
+  .object({
+    scope: z
+      .object({
+        kind: z.literal("selected-activity"),
+        stream: z.literal("power"),
+        durationSeconds: z.number().int().min(1).max(7 * 86_400),
+        tieRule: z.literal("earliest-start"),
+      })
+      .strict(),
+    efforts: z.array(BestEffortSchema).max(MAX_ACTIVITY_ANALYSIS_EFFORTS),
+  })
+  .strict()
+  .refine((value) => value.efforts.every((effort, index) => effort.rank === index + 1), {
+    path: ["efforts"],
+    message: "effort ranks are not contiguous",
+  });
+
+export const DistributionBucketSchema = z
+  .object({
+    lower: NonnegativeFiniteSchema,
+    upper: NonnegativeFiniteSchema,
+    seconds: NonnegativeFiniteSchema.max(7 * 86_400),
+  })
+  .strict()
+  .refine((value) => value.lower < value.upper, { path: ["upper"], message: "bucket is empty" });
+
+export const DistributionDataSchema = z
+  .object({
+    unit: z.enum(["watts", "bpm"]),
+    buckets: z.array(DistributionBucketSchema).max(MAX_ACTIVITY_ANALYSIS_BUCKETS),
+    totalSeconds: NonnegativeFiniteSchema.max(7 * 86_400),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    for (let index = 1; index < value.buckets.length; index += 1) {
+      if (value.buckets[index - 1]!.upper > value.buckets[index]!.lower) {
+        context.addIssue({ code: "custom", path: ["buckets", index], message: "buckets overlap" });
+      }
+    }
+    const total = value.buckets.reduce((sum, bucket) => sum + bucket.seconds, 0);
+    if (Math.abs(total - value.totalSeconds) > 0.001) {
+      context.addIssue({ code: "custom", path: ["totalSeconds"], message: "bucket total mismatch" });
+    }
+  });
+
+export const PowerHeartRateRowSchema = z
+  .object({
+    startSeconds: NonnegativeFiniteSchema.max(7 * 86_400),
+    watts: NonnegativeFiniteSchema.max(100_000),
+    heartRateBpm: NonnegativeFiniteSchema.max(400),
+    cadenceRpm: NullableNonnegativeFiniteSchema,
+    movingSeconds: NullableNonnegativeFiniteSchema,
+    seconds: NonnegativeFiniteSchema.max(7 * 86_400),
+  })
+  .strict();
+
+export const PowerHeartRateCurveSchema = z
+  .object({
+    kind: z.enum(["all", "zone-2", "other"]),
+    coefficients: z.array(z.number().finite()).min(1).max(16),
+    rSquared: z.number().finite().min(0).max(1).nullable(),
+  })
+  .strict();
+
+export const PowerHeartRateDataSchema = z
+  .object({
+    source: z.literal("provider"),
+    rows: z.array(PowerHeartRateRowSchema).max(MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_ROWS),
+    curves: z.array(PowerHeartRateCurveSchema).max(MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_CURVES),
+    coverageFraction: z.number().finite().min(0).max(1),
+    heartRateLagSeconds: NullableNonnegativeFiniteSchema,
+    warmupSeconds: NullableNonnegativeFiniteSchema,
+    cooldownSeconds: NullableNonnegativeFiniteSchema,
+  })
+  .strict()
+  .refine((value) => value.rows.every((row, index) => index === 0 || value.rows[index - 1]!.startSeconds <= row.startSeconds), {
+    path: ["rows"],
+    message: "power/heart-rate rows are not ordered",
+  });
+
+export const ActivityAnalysisDataSchemaMap = {
+  aerobicDrift: AerobicDriftDataSchema,
+  intervals: IntervalReviewDataSchema,
+  bestEfforts: BestEffortDataSchema,
+  powerDistribution: DistributionDataSchema.refine((value) => value.unit === "watts", {
+    path: ["unit"],
+    message: "power distribution must use watts",
+  }),
+  heartRateDistribution: DistributionDataSchema.refine((value) => value.unit === "bpm", {
+    path: ["unit"],
+    message: "heart-rate distribution must use bpm",
+  }),
+  powerHeartRate: PowerHeartRateDataSchema,
+} as const;
 
 export interface ActivityAnalysisDataSchemas {
   readonly aerobicDrift: z.ZodType;
@@ -198,6 +463,45 @@ export function createActivityAnalysisResultSchema<T extends ActivityAnalysisDat
     .strict();
 }
 
+const ConcreteActivityAnalysisResultSchema = createActivityAnalysisResultSchema(
+  ActivityAnalysisDataSchemaMap,
+).superRefine((value, context) => {
+  const intervals = value.sections.intervals;
+  const intervalEvidence = intervals?.kind === "stale"
+    ? intervals.lastGood
+    : intervals?.kind === "computed" ? intervals : undefined;
+  if (
+    intervalEvidence !== undefined
+    && (intervalEvidence.data as { readonly source?: unknown }).source
+      !== intervalEvidence.provenance.source
+  ) {
+    context.addIssue({
+      code: "custom",
+      path: ["sections", "intervals", "provenance", "source"],
+      message: "interval source and provenance disagree",
+    });
+  }
+  const powerHeartRate = value.sections.powerHeartRate;
+  const powerHeartRateEvidence = powerHeartRate?.kind === "stale"
+    ? powerHeartRate.lastGood
+    : powerHeartRate?.kind === "computed" ? powerHeartRate : undefined;
+  if (
+    powerHeartRateEvidence !== undefined
+    && powerHeartRateEvidence.provenance.source !== "provider"
+  ) {
+    context.addIssue({
+      code: "custom",
+      path: ["sections", "powerHeartRate", "provenance", "source"],
+      message: "power/heart-rate provenance must be provider data",
+    });
+  }
+});
+
+export const ActivityAnalysisResultSchema = ConcreteActivityAnalysisResultSchema.refine(
+  (value) => new TextEncoder().encode(JSON.stringify(value)).byteLength <= MAX_ACTIVITY_ANALYSIS_RESPONSE_BYTES,
+  "activity analysis response is too large",
+);
+
 export type ActivityAnalysisSection = z.infer<typeof ActivityAnalysisSectionSchema>;
 export type ActivityAnalysisRequest = z.infer<typeof ActivityAnalysisRequestSchema>;
 export type CanonicalActivitySummary = z.infer<typeof CanonicalActivitySummarySchema>;
@@ -222,15 +526,15 @@ export type AnalysisSection<T> =
     };
 
 export interface ActivityAnalysisData {
-  readonly aerobicDrift: unknown;
-  readonly intervals: unknown;
-  readonly bestEfforts: unknown;
-  readonly powerDistribution: unknown;
-  readonly heartRateDistribution: unknown;
-  readonly powerHeartRate: unknown;
+  readonly aerobicDrift: z.infer<typeof AerobicDriftDataSchema>;
+  readonly intervals: z.infer<typeof IntervalReviewDataSchema>;
+  readonly bestEfforts: z.infer<typeof BestEffortDataSchema>;
+  readonly powerDistribution: z.infer<(typeof ActivityAnalysisDataSchemaMap)["powerDistribution"]>;
+  readonly heartRateDistribution: z.infer<(typeof ActivityAnalysisDataSchemaMap)["heartRateDistribution"]>;
+  readonly powerHeartRate: z.infer<typeof PowerHeartRateDataSchema>;
 }
 
-export type ActivityAnalysisResult<T extends ActivityAnalysisData> = {
+export type ActivityAnalysisResult<T extends ActivityAnalysisData = ActivityAnalysisData> = {
   readonly schemaVersion: typeof ACTIVITY_ANALYSIS_SCHEMA_VERSION;
   readonly activity: CanonicalActivitySummary;
   readonly revision: string;

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -22,6 +22,12 @@ import {
   type SelfTestRpcResult,
 } from "./self-test.js";
 import {
+  ActivityAnalysisRequestSchema,
+  ActivityAnalysisResultSchema,
+  type ActivityAnalysisRequest,
+  type ActivityAnalysisResult,
+} from "./activity-analysis.js";
+import {
   ConfigureTelegramRpcParamsSchema,
   DeleteTelegramWebhookRpcParamsSchema,
   InspectTelegramCredentialRpcParamsSchema,
@@ -142,6 +148,7 @@ export const COACH_RPC_METHOD_NAMES = [
   "listArchivedConversations",
   "getArchivedTranscriptPage",
   "getAthleteState",
+  "getActivityAnalysis",
   "importFiles",
   "sync",
   "saveIntake",
@@ -810,6 +817,10 @@ export const OperationProgressEventSchema = z
 export type OperationProgressEvent = z.infer<typeof OperationProgressEventSchema>;
 
 export interface CoachOperations {
+  getActivityAnalysis?(
+    request: ActivityAnalysisRequest,
+    signal?: AbortSignal,
+  ): Promise<ActivityAnalysisResult>;
   importFiles(
     request: ImportFilesRpcParams,
     onEvent?: (event: OperationProgressEvent) => void,
@@ -929,6 +940,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("getAthleteState"),
       params: EmptyRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("getActivityAnalysis"),
+      params: ActivityAnalysisRequestSchema,
     })
     .strict(),
   z
@@ -1280,6 +1299,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "getAthleteState",
     requestSchema: EmptyRpcParamsSchema,
     responseSchema: AthleteStateSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  getActivityAnalysis: {
+    wireName: "getActivityAnalysis",
+    requestSchema: ActivityAnalysisRequestSchema,
+    responseSchema: ActivityAnalysisResultSchema,
     eventSchema: NoRpcEventSchema,
   },
   importFiles: {

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 13;
+export const PROTOCOL_VERSION = 14;

--- a/packages/coach-contract/tests/activity-analysis.test.ts
+++ b/packages/coach-contract/tests/activity-analysis.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import { z } from "zod";
 import {
   ACTIVITY_ANALYSIS_SECTIONS,
+  ActivityAnalysisResultSchema,
   ActivityAnalysisRequestSchema,
   CanonicalActivitySummarySchema,
   createActivityAnalysisResultSchema,
@@ -135,5 +136,117 @@ describe("activity analysis contract", () => {
     ]) {
       expect(ResultSchema.safeParse(invalid).success).toBe(false);
     }
+  });
+
+  it("freezes concrete units and bounds for every renderer section", () => {
+    const concrete = {
+      schemaVersion: 1,
+      activity,
+      revision: REVISION,
+      sections: {
+        aerobicDrift: {
+          kind: "computed",
+          data: {
+            method: "local-time-weighted-efficiency-factor",
+            firstHalf: {
+              durationSeconds: 1_800,
+              sampleCount: 1_800,
+              averagePowerWatts: 200,
+              averageHeartRateBpm: 140,
+              efficiencyFactor: 1.43,
+            },
+            secondHalf: {
+              durationSeconds: 1_800,
+              sampleCount: 1_800,
+              averagePowerWatts: 198,
+              averageHeartRateBpm: 145,
+              efficiencyFactor: 1.37,
+            },
+            decouplingPercent: 4.2,
+            coverage: {
+              totalSamples: 3_600,
+              validSamples: 3_600,
+              includedDurationSeconds: 3_600,
+              windowDurationSeconds: 3_600,
+              fraction: 1,
+            },
+            evidence: "standard",
+            limitations: [],
+          },
+          provenance,
+        },
+        powerDistribution: {
+          kind: "computed",
+          data: {
+            unit: "watts",
+            buckets: [{ lower: 100, upper: 125, seconds: 600 }],
+            totalSeconds: 600,
+          },
+          provenance: { ...provenance, source: "provider" },
+        },
+        heartRateDistribution: {
+          kind: "computed",
+          data: {
+            unit: "bpm",
+            buckets: [{ lower: 130, upper: 135, seconds: 600 }],
+            totalSeconds: 600,
+          },
+          provenance: { ...provenance, source: "provider" },
+        },
+      },
+    } as const;
+    expect(ActivityAnalysisResultSchema.parse(concrete)).toEqual(concrete);
+    expect(ActivityAnalysisResultSchema.safeParse({
+      ...concrete,
+      sections: {
+        ...concrete.sections,
+        powerDistribution: {
+          ...concrete.sections.powerDistribution,
+          data: { ...concrete.sections.powerDistribution.data, unit: "bpm" },
+        },
+      },
+    }).success).toBe(false);
+    expect(ActivityAnalysisResultSchema.safeParse({
+      ...concrete,
+      sections: {
+        ...concrete.sections,
+        aerobicDrift: {
+          ...concrete.sections.aerobicDrift,
+          data: {
+            ...concrete.sections.aerobicDrift.data,
+            evidence: "limited",
+            limitations: [],
+          },
+        },
+      },
+    }).success).toBe(false);
+    expect(ActivityAnalysisResultSchema.safeParse({
+      ...concrete,
+      sections: {
+        intervals: {
+          kind: "computed",
+          data: { source: "provider", intervals: [], groups: [] },
+          provenance,
+        },
+      },
+    }).success).toBe(false);
+    expect(ActivityAnalysisResultSchema.safeParse({
+      ...concrete,
+      sections: {
+        powerHeartRate: {
+          kind: "computed",
+          data: {
+            source: "provider",
+            rows: [],
+            curves: [],
+            coverageFraction: 0,
+            heartRateLagSeconds: null,
+            warmupSeconds: null,
+            cooldownSeconds: null,
+          },
+          provenance,
+        },
+      },
+    }).success).toBe(false);
   });
 });

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -111,7 +111,7 @@ describe("exit codes", () => {
 
 describe("protocol version", () => {
   it("is 13", () => {
-    expect(PROTOCOL_VERSION).toBe(13);
+    expect(PROTOCOL_VERSION).toBe(14);
   });
 });
 

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -944,6 +944,9 @@ describe("coach request and event projection", () => {
           plannedWorkouts: [],
           wellness: {},
         }),
+      getActivityAnalysis: async () => {
+        throw new Error("not exercised by registry exhaustiveness");
+      },
       importFiles: async ({ paths }) => ({
         schemaVersion: 2,
         files: { total: paths.length, imported: paths.length, quarantined: 0 },
@@ -1502,7 +1505,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-13 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-14 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1510,8 +1513,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 13,
-      serverProtocolVersion: 13,
+      clientProtocolVersion: 14,
+      serverProtocolVersion: 14,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1566,9 +1569,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 13 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 14 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(13);
+    expect(client.clientProtocolVersion).toBe(14);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -1578,8 +1581,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual(
       accepted,
     );
-    const oldClient = createVersionMismatchServerHandshakeFrame("ephemeral-client-started", 12, 13);
-    const oldServer = createVersionMismatchServerHandshakeFrame("unmanaged-foreground", 14, 13);
+    const oldClient = createVersionMismatchServerHandshakeFrame("ephemeral-client-started", 13, 14);
+    const oldServer = createVersionMismatchServerHandshakeFrame("unmanaged-foreground", 15, 14);
     expect(ServerHandshakeFrameSchema.parse(oldClient)).toEqual(oldClient);
     expect(oldClient.direction).toBe("client-older");
     expect(ServerHandshakeFrameSchema.parse(oldServer)).toEqual(oldServer);
@@ -1695,6 +1698,6 @@ describe("additive protocol signals", () => {
   });
 
   it("uses protocol version thirteen", () => {
-    expect(PROTOCOL_VERSION).toBe(13);
+    expect(PROTOCOL_VERSION).toBe(14);
   });
 });

--- a/packages/coach/src/activity-analysis-service.ts
+++ b/packages/coach/src/activity-analysis-service.ts
@@ -1,0 +1,599 @@
+import {
+  ACTIVITY_ANALYSIS_SCHEMA_VERSION,
+  ActivityAnalysisDataSchemaMap,
+  ActivityAnalysisRequestSchema,
+  ActivityAnalysisResultSchema,
+  AnalysisUnavailableReasonSchema,
+  MAX_ACTIVITY_ANALYSIS_RESPONSE_BYTES,
+  type ActivityAnalysisData,
+  type ActivityAnalysisRequest,
+  type ActivityAnalysisResult,
+  type ActivityAnalysisSection,
+  type AnalysisComputed,
+  type AnalysisRefreshFailureCode,
+  type AnalysisSection,
+  type AnalysisUnavailableReason,
+  type CanonicalActivitySummary,
+} from "@enduragent/coach-contract";
+import {
+  ACTIVITY_ANALYSIS_PROJECTION_CONTRACT_VERSION,
+  createActivityAnalysisProjectionRepository,
+  type ActivityAnalysisProjectionRepository,
+  type CanonicalActivityDetail,
+  type CanonicalActivityReader,
+  type SqlStore,
+  type TrustedActivitySourceResolution,
+  type TrustedActivitySourceResolver,
+  type TrustedProviderActivityId,
+} from "@enduragent/kernel/store";
+
+export const ACTIVITY_ANALYSIS_AGGREGATE_DEADLINE_MS = 90_000;
+export const ACTIVITY_ANALYSIS_SECTION_CONCURRENCY = 2;
+const MAX_MEMORY_CACHE_ENTRIES = 128 * 6;
+
+const SECTION_RESULT_KEYS = {
+  "aerobic-drift": "aerobicDrift",
+  intervals: "intervals",
+  "best-efforts": "bestEfforts",
+  "power-distribution": "powerDistribution",
+  "heart-rate-distribution": "heartRateDistribution",
+  "power-heart-rate": "powerHeartRate",
+} as const satisfies Record<ActivityAnalysisSection, keyof ActivityAnalysisData>;
+
+export type ActivityAnalysisSourceStatus =
+  | { readonly kind: "resolved"; readonly providerActivityId: TrustedProviderActivityId }
+  | { readonly kind: "unavailable"; readonly reason: "source-not-found" | "ambiguous-source" };
+
+export type ActivityAnalysisSectionOutput<K extends keyof ActivityAnalysisData> =
+  | {
+      readonly kind: "computed";
+      readonly data: ActivityAnalysisData[K];
+      readonly source: "local-canonical" | "provider";
+    }
+  | { readonly kind: "unavailable"; readonly reason: AnalysisUnavailableReason };
+
+export interface ActivityAnalysisSectionInput {
+  readonly activity: CanonicalActivityDetail;
+  readonly sourceRevision: string;
+  readonly source: ActivityAnalysisSourceStatus;
+  readonly signal: AbortSignal;
+}
+
+export interface ActivityAnalysisSectionAnalyzer<K extends keyof ActivityAnalysisData> {
+  analyze(input: ActivityAnalysisSectionInput): Promise<ActivityAnalysisSectionOutput<K>>;
+}
+
+export type ActivityAnalysisSectionAnalyzers = {
+  readonly [K in keyof ActivityAnalysisData]?: ActivityAnalysisSectionAnalyzer<K>;
+};
+
+export interface ActivityAnalysisService {
+  getActivityAnalysis(
+    request: ActivityAnalysisRequest,
+    signal?: AbortSignal,
+  ): Promise<ActivityAnalysisResult>;
+}
+
+export interface ActivityAnalysisServiceOptions {
+  readonly activities: Pick<CanonicalActivityReader, "getActivity">;
+  readonly sources: TrustedActivitySourceResolver;
+  readonly cache: ActivityAnalysisProjectionRepository;
+  readonly analyzers?: ActivityAnalysisSectionAnalyzers;
+  readonly runCacheWrite?: <T>(work: (signal: AbortSignal) => Promise<T>) => Promise<T>;
+  readonly now?: () => number;
+  readonly aggregateDeadlineMs?: number;
+}
+
+export class ActivityAnalysisServiceError extends Error {
+  readonly code: "activity-not-found" | "invalid-clock";
+
+  constructor(code: "activity-not-found" | "invalid-clock") {
+    super(`activity analysis failed: ${code}`);
+    this.name = "ActivityAnalysisServiceError";
+    this.code = code;
+  }
+}
+
+export class ActivityAnalysisComputationError extends Error {
+  readonly code: AnalysisRefreshFailureCode;
+
+  constructor(code: AnalysisRefreshFailureCode, options?: ErrorOptions) {
+    super(`activity analysis section failed: ${code}`, options);
+    this.name = "ActivityAnalysisComputationError";
+    this.code = code;
+  }
+}
+
+interface CacheIdentity {
+  readonly canonicalActivityId: string;
+  readonly sourceRevision: string;
+  readonly section: ActivityAnalysisSection;
+}
+
+interface SharedSectionTask {
+  readonly controller: AbortController;
+  readonly promise: Promise<AnalysisSection<unknown>>;
+  consumers: number;
+  settled: boolean;
+}
+
+interface ActivityWaiter {
+  readonly activityId: string;
+  readonly resolve: () => void;
+  readonly reject: (error: unknown) => void;
+  readonly signal: AbortSignal;
+  readonly onAbort: () => void;
+}
+
+function cacheKey(identity: CacheIdentity): string {
+  return `${identity.canonicalActivityId}\u0000${identity.sourceRevision}\u0000${identity.section}`;
+}
+
+function summary(activity: CanonicalActivityDetail): CanonicalActivitySummary {
+  return {
+    id: activity.id,
+    workoutId: activity.workoutId,
+    sessionSequence: activity.sessionSequence,
+    isMultisport: activity.isMultisport,
+    sport: activity.sport,
+    subSport: activity.subSport,
+    isTransition: activity.isTransition,
+    startEpochSeconds: activity.startEpochSeconds,
+    timezoneOffsetSeconds: activity.timezoneOffsetSeconds,
+    localDate: activity.localDate,
+    elapsedSeconds: activity.elapsedSeconds,
+    timerSeconds: activity.timerSeconds,
+    movingSeconds: activity.movingSeconds,
+    distanceMeters: activity.distanceMeters,
+  };
+}
+
+function nowInstant(now: () => number): { readonly epochSeconds: number; readonly instant: string } {
+  const epochMilliseconds = now();
+  if (!Number.isSafeInteger(epochMilliseconds) || epochMilliseconds < 0) {
+    throw new ActivityAnalysisServiceError("invalid-clock");
+  }
+  return {
+    epochSeconds: Math.floor(epochMilliseconds / 1_000),
+    instant: new Date(epochMilliseconds).toISOString(),
+  };
+}
+
+function sourceStatus(resolution: TrustedActivitySourceResolution): ActivityAnalysisSourceStatus {
+  if (resolution.kind === "resolved") {
+    return { kind: "resolved", providerActivityId: resolution.providerActivityId };
+  }
+  return {
+    kind: "unavailable",
+    reason: resolution.reason === "ambiguous" ? "ambiguous-source" : "source-not-found",
+  };
+}
+
+function refreshFailureReason(code: AnalysisRefreshFailureCode): AnalysisUnavailableReason {
+  if (code === "source-changed") return "temporary-failure";
+  return AnalysisUnavailableReasonSchema.safeParse(code).success ? code : "temporary-failure";
+}
+
+function failureCode(
+  error: unknown,
+  deadline: AbortSignal,
+  operation: AbortSignal,
+): AnalysisRefreshFailureCode {
+  if (error instanceof ActivityAnalysisComputationError) return error.code;
+  if (deadline.aborted) return "timeout";
+  if (operation.aborted) return "cancelled";
+  if (error instanceof Error && error.name === "AbortError") return "cancelled";
+  if (error instanceof Error && error.name === "ZodError") return "malformed-response";
+  return "temporary-failure";
+}
+
+function persisted<T>(value: AnalysisComputed<T>): AnalysisComputed<T> {
+  return {
+    ...value,
+    provenance: { ...value.provenance, delivery: "persisted-cache" },
+  };
+}
+
+function byteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function assertComputedSource(
+  resultKey: keyof ActivityAnalysisData,
+  data: ActivityAnalysisData[keyof ActivityAnalysisData],
+  source: "local-canonical" | "provider",
+  sourceStatusValue: ActivityAnalysisSourceStatus,
+): void {
+  if (source === "provider" && sourceStatusValue.kind !== "resolved") {
+    throw new ActivityAnalysisComputationError("malformed-response");
+  }
+  if (
+    resultKey === "intervals"
+    && (data as ActivityAnalysisData["intervals"]).source !== source
+  ) {
+    throw new ActivityAnalysisComputationError("malformed-response");
+  }
+  if (resultKey === "powerHeartRate" && source !== "provider") {
+    throw new ActivityAnalysisComputationError("malformed-response");
+  }
+}
+
+class SectionSemaphore {
+  private active = 0;
+  private readonly waiters: Array<() => void> = [];
+
+  async run<T>(signal: AbortSignal, work: () => Promise<T>): Promise<T> {
+    await this.acquire(signal);
+    try {
+      return await work();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(signal: AbortSignal): Promise<void> {
+    signal.throwIfAborted();
+    if (this.active < ACTIVITY_ANALYSIS_SECTION_CONCURRENCY) {
+      this.active += 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+      const resume = (): void => {
+        signal.removeEventListener("abort", abort);
+        this.active += 1;
+        resolve();
+      };
+      const abort = (): void => {
+        const index = this.waiters.indexOf(resume);
+        if (index >= 0) this.waiters.splice(index, 1);
+        reject(signal.reason);
+      };
+      this.waiters.push(resume);
+      signal.addEventListener("abort", abort, { once: true });
+      if (signal.aborted) abort();
+    });
+  }
+
+  private release(): void {
+    this.active -= 1;
+    this.waiters.shift()?.();
+  }
+}
+
+class ActivityGate {
+  private activeActivityId: string | undefined;
+  private activeCount = 0;
+  private readonly waiters: ActivityWaiter[] = [];
+
+  async run<T>(activityId: string, signal: AbortSignal, work: () => Promise<T>): Promise<T> {
+    await this.acquire(activityId, signal);
+    try {
+      return await work();
+    } finally {
+      this.release();
+    }
+  }
+
+  private async acquire(activityId: string, signal: AbortSignal): Promise<void> {
+    signal.throwIfAborted();
+    if (this.activeActivityId === undefined || this.activeActivityId === activityId) {
+      this.activeActivityId = activityId;
+      this.activeCount += 1;
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      const waiter: ActivityWaiter = {
+        activityId,
+        resolve,
+        reject,
+        signal,
+        onAbort: () => {
+          const index = this.waiters.indexOf(waiter);
+          if (index >= 0) this.waiters.splice(index, 1);
+          reject(signal.reason);
+        },
+      };
+      this.waiters.push(waiter);
+      signal.addEventListener("abort", waiter.onAbort, { once: true });
+      if (signal.aborted) waiter.onAbort();
+    });
+    return this.acquire(activityId, signal);
+  }
+
+  private release(): void {
+    this.activeCount -= 1;
+    if (this.activeCount !== 0) return;
+    this.activeActivityId = undefined;
+    const nextActivity = this.waiters[0]?.activityId;
+    if (nextActivity === undefined) return;
+    const ready = this.waiters.filter((waiter) => waiter.activityId === nextActivity);
+    for (const waiter of ready) {
+      const index = this.waiters.indexOf(waiter);
+      if (index >= 0) this.waiters.splice(index, 1);
+      waiter.signal.removeEventListener("abort", waiter.onAbort);
+      waiter.resolve();
+    }
+  }
+}
+
+class ActivityAnalysisServiceImplementation implements ActivityAnalysisService {
+  private readonly analyzers: ActivityAnalysisSectionAnalyzers;
+  private readonly now: () => number;
+  private readonly aggregateDeadlineMs: number;
+  private readonly memory = new Map<string, AnalysisComputed<unknown>>();
+  private readonly inFlight = new Map<string, SharedSectionTask>();
+  private readonly sections = new SectionSemaphore();
+  private readonly activities = new ActivityGate();
+
+  constructor(private readonly options: ActivityAnalysisServiceOptions) {
+    this.analyzers = options.analyzers ?? {};
+    this.now = options.now ?? Date.now;
+    this.aggregateDeadlineMs = options.aggregateDeadlineMs ?? ACTIVITY_ANALYSIS_AGGREGATE_DEADLINE_MS;
+    if (!Number.isSafeInteger(this.aggregateDeadlineMs) || this.aggregateDeadlineMs < 1) {
+      throw new TypeError("activity analysis deadline is invalid");
+    }
+  }
+
+  async getActivityAnalysis(
+    request: ActivityAnalysisRequest,
+    signal?: AbortSignal,
+  ): Promise<ActivityAnalysisResult> {
+    const parsed = ActivityAnalysisRequestSchema.parse(request);
+    const deadline = AbortSignal.timeout(this.aggregateDeadlineMs);
+    const operationSignal = signal === undefined ? deadline : AbortSignal.any([signal, deadline]);
+    return this.activities.run(parsed.canonicalActivityId, operationSignal, async () => {
+      const activity = await this.options.activities.getActivity({ id: parsed.canonicalActivityId });
+      if (activity === undefined) throw new ActivityAnalysisServiceError("activity-not-found");
+      operationSignal.throwIfAborted();
+      const resolution = await this.options.sources.resolve({
+        canonicalActivityId: parsed.canonicalActivityId,
+      });
+      const revision = resolution.kind === "resolved" ? resolution.sourceRevision : activity.id;
+      const context = { activity, sourceRevision: revision, source: sourceStatus(resolution) };
+      const computed = await Promise.all(parsed.sections.map(async (section) => {
+        const state = await this.section(
+          { canonicalActivityId: activity.id, sourceRevision: revision, section },
+          context,
+          parsed.refresh === true,
+          operationSignal,
+          deadline,
+        );
+        return [SECTION_RESULT_KEYS[section], state] as const;
+      }));
+      const sectionStates: Record<string, AnalysisSection<unknown>> = {};
+      const activitySummary = summary(activity);
+      for (const [key, state] of computed) {
+        const candidate = { ...sectionStates, [key]: state };
+        const envelope = {
+          schemaVersion: ACTIVITY_ANALYSIS_SCHEMA_VERSION,
+          activity: activitySummary,
+          revision,
+          sections: candidate,
+        };
+        sectionStates[key] = byteLength(envelope) <= MAX_ACTIVITY_ANALYSIS_RESPONSE_BYTES
+          ? state
+          : { kind: "unavailable", reason: "response-too-large" };
+      }
+      return ActivityAnalysisResultSchema.parse({
+        schemaVersion: ACTIVITY_ANALYSIS_SCHEMA_VERSION,
+        activity: activitySummary,
+        revision,
+        sections: sectionStates,
+      }) as ActivityAnalysisResult;
+    });
+  }
+
+  private async section(
+    identity: CacheIdentity,
+    context: Omit<ActivityAnalysisSectionInput, "signal">,
+    refresh: boolean,
+    signal: AbortSignal,
+    deadline: AbortSignal,
+  ): Promise<AnalysisSection<unknown>> {
+    const cached = await this.readCache(identity);
+    if (!refresh && cached !== undefined) return persisted(cached);
+    try {
+      return await this.consumeShared(identity, context, signal);
+    } catch (error) {
+      const code = failureCode(error, deadline, signal);
+      if (cached !== undefined) {
+        return {
+          kind: "stale",
+          lastGood: persisted(cached),
+          refreshFailure: { code, failedAt: nowInstant(this.now).instant },
+        };
+      }
+      return { kind: "unavailable", reason: refreshFailureReason(code) };
+    }
+  }
+
+  private consumeShared(
+    identity: CacheIdentity,
+    context: Omit<ActivityAnalysisSectionInput, "signal">,
+    signal: AbortSignal,
+  ): Promise<AnalysisSection<unknown>> {
+    signal.throwIfAborted();
+    const key = cacheKey(identity);
+    let shared = this.inFlight.get(key);
+    if (shared === undefined) {
+      const controller = new AbortController();
+      shared = {
+        controller,
+        consumers: 0,
+        settled: false,
+        promise: this.sections.run(controller.signal, () =>
+          this.computeSection(identity, context, controller.signal)),
+      };
+      this.inFlight.set(key, shared);
+      const selected = shared;
+      void shared.promise.finally(() => {
+        selected.settled = true;
+        if (this.inFlight.get(key) === selected) this.inFlight.delete(key);
+      }).catch(() => {});
+    }
+    shared.consumers += 1;
+    return new Promise((resolve, reject) => {
+      let claimed = false;
+      const claim = (): void => {
+        if (claimed) return;
+        claimed = true;
+        signal.removeEventListener("abort", abort);
+        shared!.consumers -= 1;
+        if (shared!.consumers === 0 && !shared!.settled) shared!.controller.abort();
+      };
+      const abort = (): void => {
+        claim();
+        reject(signal.reason);
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      if (signal.aborted) {
+        abort();
+        return;
+      }
+      void shared.promise.then(
+        (value) => {
+          claim();
+          resolve(value);
+        },
+        (error) => {
+          claim();
+          reject(error);
+        },
+      );
+    });
+  }
+
+  private async computeSection(
+    identity: CacheIdentity,
+    context: Omit<ActivityAnalysisSectionInput, "signal">,
+    signal: AbortSignal,
+  ): Promise<AnalysisSection<unknown>> {
+    const resultKey = SECTION_RESULT_KEYS[identity.section];
+    const analyzer = this.analyzers[resultKey] as
+      | ActivityAnalysisSectionAnalyzer<keyof ActivityAnalysisData>
+      | undefined;
+    if (analyzer === undefined) return { kind: "unavailable", reason: "unsupported" };
+    const output = await analyzer.analyze({ ...context, signal });
+    signal.throwIfAborted();
+    if (output.kind === "unavailable") {
+      return {
+        kind: "unavailable",
+        reason: AnalysisUnavailableReasonSchema.parse(output.reason),
+      };
+    }
+    const data = ActivityAnalysisDataSchemaMap[resultKey].parse(output.data);
+    assertComputedSource(resultKey, data, output.source, context.source);
+    const observed = nowInstant(this.now);
+    const computed: AnalysisComputed<unknown> = {
+      kind: "computed",
+      data,
+      provenance: {
+        source: output.source,
+        delivery: "live",
+        observedAt: observed.instant,
+      },
+    };
+    const current = await this.options.sources.resolve({
+      canonicalActivityId: identity.canonicalActivityId,
+    });
+    const currentRevision = current.kind === "resolved" ? current.sourceRevision : identity.canonicalActivityId;
+    if (currentRevision !== identity.sourceRevision) {
+      throw new ActivityAnalysisComputationError("source-changed");
+    }
+    await this.writeCache(identity, computed, observed.epochSeconds);
+    return computed;
+  }
+
+  private async readCache(identity: CacheIdentity): Promise<AnalysisComputed<unknown> | undefined> {
+    const key = cacheKey(identity);
+    const memory = this.memory.get(key);
+    if (memory !== undefined) {
+      this.memory.delete(key);
+      this.memory.set(key, memory);
+      return memory;
+    }
+    let stored;
+    try {
+      const accessed = nowInstant(this.now).epochSeconds;
+      stored = await this.cacheAccess((cache) => cache.read({
+        canonicalActivityId: identity.canonicalActivityId,
+        sourceRevision: identity.sourceRevision,
+        contractVersion: ACTIVITY_ANALYSIS_PROJECTION_CONTRACT_VERSION,
+        section: identity.section,
+      }, accessed));
+    } catch {
+      return undefined;
+    }
+    if (stored === undefined) return undefined;
+    try {
+      const resultKey = SECTION_RESULT_KEYS[identity.section];
+      const computed: AnalysisComputed<unknown> = {
+        kind: "computed",
+        data: ActivityAnalysisDataSchemaMap[resultKey].parse(JSON.parse(stored.dataJson)),
+        provenance: {
+          source: stored.source,
+          delivery: "persisted-cache",
+          observedAt: stored.observedAt,
+        },
+      };
+      this.remember(key, computed);
+      return computed;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async writeCache(
+    identity: CacheIdentity,
+    computed: AnalysisComputed<unknown>,
+    cachedEpochSeconds: number,
+  ): Promise<void> {
+    try {
+      await this.cacheAccess((cache) => cache.write({
+        canonicalActivityId: identity.canonicalActivityId,
+        sourceRevision: identity.sourceRevision,
+        contractVersion: ACTIVITY_ANALYSIS_PROJECTION_CONTRACT_VERSION,
+        section: identity.section,
+        source: computed.provenance.source,
+        observedAt: computed.provenance.observedAt,
+        dataJson: JSON.stringify(computed.data),
+      }, cachedEpochSeconds));
+      this.remember(cacheKey(identity), computed);
+    } catch {
+      // A cache failure must not hide a freshly validated computation.
+    }
+  }
+
+  private cacheAccess<T>(
+    operation: (cache: ActivityAnalysisProjectionRepository) => Promise<T>,
+  ): Promise<T> {
+    if (this.options.runCacheWrite === undefined) return operation(this.options.cache);
+    return this.options.runCacheWrite(() => operation(this.options.cache));
+  }
+
+  private remember(key: string, value: AnalysisComputed<unknown>): void {
+    this.memory.delete(key);
+    this.memory.set(key, value);
+    while (this.memory.size > MAX_MEMORY_CACHE_ENTRIES) {
+      const oldest = this.memory.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.memory.delete(oldest);
+    }
+  }
+}
+
+export function createActivityAnalysisService(
+  options: ActivityAnalysisServiceOptions,
+): ActivityAnalysisService {
+  return new ActivityAnalysisServiceImplementation(options);
+}
+
+export function createStoredActivityAnalysisService(input: Omit<
+  ActivityAnalysisServiceOptions,
+  "cache"
+> & { readonly store: SqlStore }): ActivityAnalysisService {
+  return createActivityAnalysisService({
+    ...input,
+    cache: createActivityAnalysisProjectionRepository(input.store),
+  });
+}

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -56,7 +56,12 @@ import {
   createCyclingFtpAnchorResolver,
   type CyclingFtpAnchorResolver,
 } from "@enduragent/kernel/anchors";
-import { createAnchorRepository, type AnchorRepository } from "@enduragent/kernel/store";
+import {
+  createAnchorRepository,
+  createCanonicalActivityReader,
+  createTrustedActivitySourceResolver,
+  type AnchorRepository,
+} from "@enduragent/kernel/store";
 import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import type { CoachStoreWriterContext } from "./runtime.js";
@@ -91,6 +96,7 @@ import {
 import { createCoachOperations } from "./operations.js";
 import type { CoachOperationsDependencies } from "./operations.js";
 import { createSpendMeterService, type SpendMeterService } from "./spend-meter.js";
+import { createStoredActivityAnalysisService } from "./activity-analysis-service.js";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -992,23 +998,34 @@ export async function createLocalCoachComposition(
       },
     });
     const options = Object.freeze({ liveIntervals });
-    const operations = createCoachOperations(
-      {
-        home: input.home,
-        context: input.context,
-        runtime,
-        intervalsCredentials: options.liveIntervals,
-        historyNewestDate: () => new Date(now()).toISOString().slice(0, 10),
-        readTranscriptPage: (request) => reconfigurable.getTranscriptPage(request),
-        readArchivedConversations: (request) => reconfigurable.listArchivedConversations(request),
-        readArchivedTranscriptPage: (request) =>
-          reconfigurable.getArchivedTranscriptPage(request),
-        applyRuntimeConfig,
-        readRuntimeConfig: () =>
-          runtimeConfigSnapshot(input.home.configDir, activeConfig, input.env, activeTimezone),
-      },
-      dependencies.operationsDependencies,
-    );
+    const activityAnalysis = createStoredActivityAnalysisService({
+      store: input.context.store,
+      activities: createCanonicalActivityReader(input.context.store),
+      sources: createTrustedActivitySourceResolver(input.context.store),
+      runCacheWrite: (work) => runtime!.runExclusive(work),
+      now,
+    });
+    const operations = {
+      ...createCoachOperations(
+        {
+          home: input.home,
+          context: input.context,
+          runtime,
+          intervalsCredentials: options.liveIntervals,
+          historyNewestDate: () => new Date(now()).toISOString().slice(0, 10),
+          readTranscriptPage: (request) => reconfigurable.getTranscriptPage(request),
+          readArchivedConversations: (request) => reconfigurable.listArchivedConversations(request),
+          readArchivedTranscriptPage: (request) =>
+            reconfigurable.getArchivedTranscriptPage(request),
+          applyRuntimeConfig,
+          readRuntimeConfig: () =>
+            runtimeConfigSnapshot(input.home.configDir, activeConfig, input.env, activeTimezone),
+        },
+        dependencies.operationsDependencies,
+      ),
+      getActivityAnalysis: (request, signal) =>
+        activityAnalysis.getActivityAnalysis(request, signal),
+    } satisfies CoachOperations;
     return {
       engine: reconfigurable.engine,
       operations,

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -354,6 +354,7 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "listArchivedConversations",
   "getArchivedTranscriptPage",
   "getAthleteState",
+  "getActivityAnalysis",
   "importFiles",
   "sync",
   "saveIntake",
@@ -794,6 +795,23 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
             try {
               COACH_RPC_METHOD_REGISTRY.getAthleteState.requestSchema.parse(generic.data.params);
               result = await input.engine.getAthleteState();
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "getActivityAnalysis":
+            try {
+              const request =
+                COACH_RPC_METHOD_REGISTRY.getActivityAnalysis.requestSchema.parse(
+                  generic.data.params,
+                );
+              if (input.operations.getActivityAnalysis === undefined) {
+                throw new TypeError("Activity analysis operation is unavailable.");
+              }
+              result = await input.operations.getActivityAnalysis(
+                request,
+                state.detachController.signal,
+              );
             } catch (error) {
               invocationFailure = { error };
             }

--- a/packages/coach/tests/activity-analysis-service.test.ts
+++ b/packages/coach/tests/activity-analysis-service.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ActivityAnalysisData, ActivityAnalysisRequest } from "@enduragent/coach-contract";
+import type {
+  ActivityAnalysisProjection,
+  ActivityAnalysisProjectionKey,
+  ActivityAnalysisProjectionRepository,
+  CanonicalActivityDetail,
+  TrustedActivitySourceResolver,
+} from "@enduragent/kernel/store";
+import {
+  ActivityAnalysisComputationError,
+  ActivityAnalysisServiceError,
+  createActivityAnalysisService,
+  type ActivityAnalysisSectionAnalyzer,
+  type ActivityAnalysisSectionAnalyzers,
+} from "../src/activity-analysis-service.js";
+
+const ACTIVITY_ID = "a".repeat(64);
+const WORKOUT_ID = "b".repeat(64);
+const REVISION = "c".repeat(64);
+
+const activity: CanonicalActivityDetail = {
+  id: ACTIVITY_ID,
+  workoutId: WORKOUT_ID,
+  sessionSequence: 0,
+  isMultisport: false,
+  sport: "cycling",
+  subSport: null,
+  isTransition: false,
+  startEpochSeconds: 899_985_600,
+  timezoneOffsetSeconds: 0,
+  localDate: "1998-07-06",
+  elapsedSeconds: 3_600,
+  timerSeconds: 3_500,
+  movingSeconds: 3_400,
+  distanceMeters: 40_000,
+  laps: [],
+};
+
+const drift: ActivityAnalysisData["aerobicDrift"] = {
+  method: "local-time-weighted-efficiency-factor",
+  firstHalf: {
+    durationSeconds: 1_700,
+    sampleCount: 1_700,
+    averagePowerWatts: 200,
+    averageHeartRateBpm: 140,
+    efficiencyFactor: 1.43,
+  },
+  secondHalf: {
+    durationSeconds: 1_700,
+    sampleCount: 1_700,
+    averagePowerWatts: 200,
+    averageHeartRateBpm: 145,
+    efficiencyFactor: 1.38,
+  },
+  decouplingPercent: 3.5,
+  coverage: {
+    totalSamples: 3_400,
+    validSamples: 3_400,
+    includedDurationSeconds: 3_400,
+    windowDurationSeconds: 3_400,
+    fraction: 1,
+  },
+  evidence: "standard",
+  limitations: [],
+};
+
+function cache(): ActivityAnalysisProjectionRepository & {
+  readonly values: Map<string, ActivityAnalysisProjection>;
+} {
+  const values = new Map<string, ActivityAnalysisProjection>();
+  const key = (value: ActivityAnalysisProjectionKey): string =>
+    `${value.canonicalActivityId}:${value.sourceRevision}:${value.section}`;
+  return {
+    values,
+    async read(value) {
+      return values.get(key(value));
+    },
+    async write(value) {
+      values.set(key(value), value);
+    },
+  };
+}
+
+function source(
+  resolve: TrustedActivitySourceResolver["resolve"] = async () => ({
+    kind: "resolved",
+    providerActivityId: "provider-42" as never,
+    sourceRevision: REVISION,
+  }),
+): TrustedActivitySourceResolver {
+  return { resolve };
+}
+
+function setup(input: {
+  readonly analyzer?: ActivityAnalysisSectionAnalyzer<"aerobicDrift">;
+  readonly resolver?: TrustedActivitySourceResolver;
+  readonly projectionCache?: ActivityAnalysisProjectionRepository;
+  readonly activityValue?: CanonicalActivityDetail;
+}) {
+  const analyzer = input.analyzer ?? { analyze: async () => ({
+    kind: "computed" as const,
+    data: drift,
+    source: "local-canonical" as const,
+  }) };
+  const getActivity = vi.fn(async () => input.activityValue ?? activity);
+  const service = createActivityAnalysisService({
+    activities: { getActivity },
+    sources: input.resolver ?? source(),
+    cache: input.projectionCache ?? cache(),
+    analyzers: { aerobicDrift: analyzer },
+    now: () => Date.parse("1998-07-06T12:00:00.000Z"),
+  });
+  return { service, getActivity, analyzer };
+}
+
+describe("activity analysis service", () => {
+  it("returns a validated live section, then serves persisted last-good evidence", async () => {
+    const projectionCache = cache();
+    const analyze = vi.fn(async () => ({
+      kind: "computed" as const,
+      data: drift,
+      source: "local-canonical" as const,
+    }));
+    const { service } = setup({ analyzer: { analyze }, projectionCache });
+    const request: ActivityAnalysisRequest = {
+      canonicalActivityId: ACTIVITY_ID,
+      sections: ["aerobic-drift"],
+    };
+
+    await expect(service.getActivityAnalysis(request)).resolves.toMatchObject({
+      schemaVersion: 1,
+      revision: REVISION,
+      sections: {
+        aerobicDrift: {
+          kind: "computed",
+          data: drift,
+          provenance: { source: "local-canonical", delivery: "live" },
+        },
+      },
+    });
+    expect(projectionCache.values.size).toBe(1);
+    await expect(service.getActivityAnalysis(request)).resolves.toMatchObject({
+      sections: {
+        aerobicDrift: {
+          kind: "computed",
+          provenance: { delivery: "persisted-cache" },
+        },
+      },
+    });
+    expect(analyze).toHaveBeenCalledOnce();
+  });
+
+  it("preserves cached evidence as stale when an explicit refresh fails", async () => {
+    let fail = false;
+    const analyzer: ActivityAnalysisSectionAnalyzer<"aerobicDrift"> = {
+      async analyze() {
+        if (fail) throw new ActivityAnalysisComputationError("timeout");
+        return { kind: "computed", data: drift, source: "local-canonical" };
+      },
+    };
+    const { service } = setup({ analyzer });
+    const request: ActivityAnalysisRequest = {
+      canonicalActivityId: ACTIVITY_ID,
+      sections: ["aerobic-drift"],
+    };
+    await service.getActivityAnalysis(request);
+    fail = true;
+    await expect(service.getActivityAnalysis({ ...request, refresh: true })).resolves.toMatchObject({
+      sections: {
+        aerobicDrift: {
+          kind: "stale",
+          lastGood: { provenance: { delivery: "persisted-cache" } },
+          refreshFailure: { code: "timeout", failedAt: "1998-07-06T12:00:00.000Z" },
+        },
+      },
+    });
+  });
+
+  it("isolates unsupported sections and does not expose provider identity", async () => {
+    const { service } = setup({});
+    const result = await service.getActivityAnalysis({
+      canonicalActivityId: ACTIVITY_ID,
+      sections: ["aerobic-drift", "intervals", "power-heart-rate"],
+    });
+    expect(result.sections.intervals).toEqual({ kind: "unavailable", reason: "unsupported" });
+    expect(result.sections.powerHeartRate).toEqual({ kind: "unavailable", reason: "unsupported" });
+    expect(JSON.stringify(result)).not.toContain("provider-42");
+  });
+
+  it("rejects provider provenance without a trusted provider source", async () => {
+    const analyzer: ActivityAnalysisSectionAnalyzer<"aerobicDrift"> = {
+      async analyze() {
+        return { kind: "computed", data: drift, source: "provider" };
+      },
+    };
+    const { service } = setup({
+      analyzer,
+      resolver: source(async () => ({ kind: "unavailable", reason: "not_found" })),
+    });
+    await expect(service.getActivityAnalysis({
+      canonicalActivityId: ACTIVITY_ID,
+      sections: ["aerobic-drift"],
+    })).resolves.toMatchObject({
+      sections: { aerobicDrift: { kind: "unavailable", reason: "malformed-response" } },
+    });
+  });
+
+  it("classifies invalid analyzer data as a malformed response", async () => {
+    const analyzer: ActivityAnalysisSectionAnalyzer<"aerobicDrift"> = {
+      async analyze() {
+        return {
+          kind: "computed",
+          data: { method: "wrong-method" },
+          source: "local-canonical",
+        } as never;
+      },
+    };
+    const { service } = setup({ analyzer });
+    await expect(service.getActivityAnalysis({
+      canonicalActivityId: ACTIVITY_ID,
+      sections: ["aerobic-drift"],
+    })).resolves.toMatchObject({
+      sections: { aerobicDrift: { kind: "unavailable", reason: "malformed-response" } },
+    });
+  });
+
+  it("deduplicates identical work and keeps it alive for a remaining consumer", async () => {
+    let release!: () => void;
+    const wait = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let observedSignal: AbortSignal | undefined;
+    const analyze = vi.fn(async ({ signal }: { readonly signal: AbortSignal }) => {
+      observedSignal = signal;
+      await wait;
+      signal.throwIfAborted();
+      return { kind: "computed" as const, data: drift, source: "local-canonical" as const };
+    });
+    const { service } = setup({ analyzer: { analyze } });
+    const request: ActivityAnalysisRequest = {
+      canonicalActivityId: ACTIVITY_ID,
+      sections: ["aerobic-drift"],
+    };
+    const firstController = new AbortController();
+    const first = service.getActivityAnalysis(request, firstController.signal);
+    const second = service.getActivityAnalysis(request);
+    await vi.waitFor(() => expect(analyze).toHaveBeenCalledOnce());
+    firstController.abort(new Error("private abort detail"));
+    await expect(first).resolves.toMatchObject({
+      sections: { aerobicDrift: { kind: "unavailable", reason: "cancelled" } },
+    });
+    expect(observedSignal?.aborted).toBe(false);
+    release();
+    await expect(second).resolves.toMatchObject({
+      sections: { aerobicDrift: { kind: "computed" } },
+    });
+    expect(analyze).toHaveBeenCalledOnce();
+  });
+
+  it("runs at most two section analyzers concurrently", async () => {
+    let release!: () => void;
+    const wait = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let active = 0;
+    let maximumActive = 0;
+    let started = 0;
+    const analyze = async <T>(data: T) => {
+      started += 1;
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await wait;
+      active -= 1;
+      return { kind: "computed" as const, data, source: "local-canonical" as const };
+    };
+    const analyzers: ActivityAnalysisSectionAnalyzers = {
+      aerobicDrift: { analyze: async () => analyze(drift) },
+      intervals: {
+        analyze: async () => analyze({ source: "local-canonical" as const, intervals: [], groups: [] }),
+      },
+      bestEfforts: {
+        analyze: async () => analyze({
+          scope: {
+            kind: "selected-activity" as const,
+            stream: "power" as const,
+            durationSeconds: 60,
+            tieRule: "earliest-start" as const,
+          },
+          efforts: [],
+        }),
+      },
+    };
+    const service = createActivityAnalysisService({
+      activities: { getActivity: async () => activity },
+      sources: source(),
+      cache: cache(),
+      analyzers,
+      now: () => Date.parse("1998-07-06T12:00:00.000Z"),
+    });
+    const result = service.getActivityAnalysis({
+      canonicalActivityId: ACTIVITY_ID,
+      sections: ["aerobic-drift", "intervals", "best-efforts"],
+    });
+
+    await vi.waitFor(() => expect(started).toBe(2));
+    expect(maximumActive).toBe(2);
+    release();
+    await expect(result).resolves.toMatchObject({
+      sections: {
+        aerobicDrift: { kind: "computed" },
+        intervals: { kind: "computed" },
+        bestEfforts: { kind: "computed" },
+      },
+    });
+    expect(started).toBe(3);
+    expect(maximumActive).toBe(2);
+  });
+
+  it("serializes analysis for different activities", async () => {
+    const otherActivityId = "d".repeat(64);
+    let releaseFirst!: () => void;
+    const firstWait = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const getActivity = vi.fn(async ({ id }: { readonly id: string }) => ({
+      ...activity,
+      id,
+    }));
+    const analyzed: string[] = [];
+    const service = createActivityAnalysisService({
+      activities: { getActivity },
+      sources: source(async ({ canonicalActivityId }) => ({
+        kind: "resolved",
+        providerActivityId: `provider-${canonicalActivityId.slice(0, 1)}` as never,
+        sourceRevision: canonicalActivityId,
+      })),
+      cache: cache(),
+      analyzers: {
+        aerobicDrift: {
+          async analyze({ activity: selected }) {
+            analyzed.push(selected.id);
+            if (selected.id === ACTIVITY_ID) await firstWait;
+            return { kind: "computed", data: drift, source: "local-canonical" };
+          },
+        },
+      },
+      now: () => Date.parse("1998-07-06T12:00:00.000Z"),
+    });
+    const first = service.getActivityAnalysis({
+      canonicalActivityId: ACTIVITY_ID,
+      sections: ["aerobic-drift"],
+    });
+    await vi.waitFor(() => expect(analyzed).toEqual([ACTIVITY_ID]));
+    const second = service.getActivityAnalysis({
+      canonicalActivityId: otherActivityId,
+      sections: ["aerobic-drift"],
+    });
+    await Promise.resolve();
+    expect(getActivity).toHaveBeenCalledOnce();
+
+    releaseFirst();
+    await expect(first).resolves.toMatchObject({ activity: { id: ACTIVITY_ID } });
+    await expect(second).resolves.toMatchObject({ activity: { id: otherActivityId } });
+    expect(analyzed).toEqual([ACTIVITY_ID, otherActivityId]);
+  });
+
+  it("discards a computation if the trusted source revision changes", async () => {
+    let revision = REVISION;
+    const resolver = source(async () => ({
+      kind: "resolved",
+      providerActivityId: "provider-42" as never,
+      sourceRevision: revision,
+    }));
+    const analyzer: ActivityAnalysisSectionAnalyzer<"aerobicDrift"> = {
+      async analyze() {
+        revision = "d".repeat(64);
+        return { kind: "computed", data: drift, source: "local-canonical" };
+      },
+    };
+    const { service } = setup({ analyzer, resolver });
+    await expect(service.getActivityAnalysis({
+      canonicalActivityId: ACTIVITY_ID,
+      sections: ["aerobic-drift"],
+    })).resolves.toMatchObject({
+      revision: REVISION,
+      sections: { aerobicDrift: { kind: "unavailable", reason: "temporary-failure" } },
+    });
+  });
+
+  it("fails closed when the canonical activity no longer exists", async () => {
+    const { service } = setup({ activityValue: undefined });
+    const missing = createActivityAnalysisService({
+      activities: { getActivity: async () => undefined },
+      sources: source(),
+      cache: cache(),
+      now: () => 0,
+    });
+    await expect(missing.getActivityAnalysis({
+      canonicalActivityId: ACTIVITY_ID,
+      sections: ["intervals"],
+    })).rejects.toEqual(new ActivityAnalysisServiceError("activity-not-found"));
+    expect(service).toBeDefined();
+  });
+});

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -896,7 +896,7 @@ describe("incremental backfill pages", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 10 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 11 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(beforeWorkouts);
       expect(await upgraded.all("SELECT * FROM session ORDER BY session_key")).toEqual(beforeSessions);

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -582,7 +582,7 @@ describe("coach sync composition", () => {
           return store.get("PRAGMA user_version");
         },
       );
-      expect(value).toEqual({ user_version: 10 });
+      expect(value).toEqual({ user_version: 11 });
       expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
       expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
       expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -590,7 +590,7 @@ describe("coach sync composition", () => {
       const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
       try {
         await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-          user_version: 10,
+          user_version: 11,
         });
       } finally {
         await reopened.close();

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -64,6 +64,27 @@ const state: AthleteState = {
 };
 
 const operations: CoachOperations = {
+  getActivityAnalysis: async ({ canonicalActivityId }) => ({
+    schemaVersion: 1,
+    activity: {
+      id: canonicalActivityId,
+      workoutId: "b".repeat(64),
+      sessionSequence: 0,
+      isMultisport: false,
+      sport: "cycling",
+      subSport: null,
+      isTransition: false,
+      startEpochSeconds: 899_985_600,
+      timezoneOffsetSeconds: 0,
+      localDate: "1998-07-06",
+      elapsedSeconds: 3_600,
+      timerSeconds: 3_500,
+      movingSeconds: 3_400,
+      distanceMeters: 40_000,
+    },
+    revision: "c".repeat(64),
+    sections: { aerobicDrift: { kind: "unavailable", reason: "unsupported" } },
+  }),
   importFiles: async ({ paths }) => ({
     schemaVersion: 2,
     files: { total: paths.length, imported: paths.length, quarantined: 0 },
@@ -462,7 +483,7 @@ async function openSocket(
 }
 
 describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
-  it("accepts the first-frame token and projects all four registry methods", async () => {
+  it("accepts the first-frame token and projects engine plus activity-analysis methods", async () => {
     const token = "x".repeat(43);
     const calls: string[] = [];
     const rpc = createCoachRpcServer({
@@ -488,6 +509,13 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
           return state;
         },
       }),
+      operations: {
+        ...operations,
+        getActivityAnalysis: async (request) => {
+          calls.push("getActivityAnalysis");
+          return operations.getActivityAnalysis!(request);
+        },
+      },
     });
     const client = await openSocket(rpc);
     client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
@@ -526,13 +554,24 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       { id: 2, method: "resetSession", params: { chatId: "chat" } },
       { id: 3, method: "hasSession", params: { chatId: "chat" } },
       { id: 4, method: "getAthleteState", params: {} },
+      {
+        id: 5,
+        method: "getActivityAnalysis",
+        params: { canonicalActivityId: "a".repeat(64), sections: ["aerobic-drift"] },
+      },
     ];
     for (const value of requests) {
       client.ws.send(JSON.stringify({ jsonrpc: "2.0", ...value }));
       const response = parseCoachRpcEnvelope(await client.frames.next());
       expect(response).toMatchObject({ jsonrpc: "2.0", id: value.id });
     }
-    expect(calls).toEqual(["chat:chat", "resetSession:chat", "hasSession:chat", "getAthleteState"]);
+    expect(calls).toEqual([
+      "chat:chat",
+      "resetSession:chat",
+      "hasSession:chat",
+      "getAthleteState",
+      "getActivityAnalysis",
+    ]);
     await client.close();
   });
 
@@ -722,6 +761,44 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         id: "runtime-detach",
         method: "configureRuntime",
         params: { llm: { provider: "openai-codex", model: "gpt-5.5" } },
+      }),
+    );
+    await started.promise;
+
+    const closed = new Promise<void>((resolve) => client.ws.once("close", () => resolve()));
+    client.ws.close();
+    await closed;
+    await vi.waitFor(() => expect(operationSignal?.aborted).toBe(true));
+
+    await client.close();
+  });
+
+  it("aborts activity analysis when its requesting connection detaches", async () => {
+    const token = "x".repeat(43);
+    const started = deferred<void>();
+    let operationSignal: AbortSignal | undefined;
+    const getActivityAnalysis = vi.fn(async (_request, signal?: AbortSignal): Promise<never> => {
+      operationSignal = signal;
+      started.resolve(undefined);
+      return await new Promise<never>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    });
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: { ...operations, getActivityAnalysis },
+      token,
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "activity-analysis-detach",
+        method: "getActivityAnalysis",
+        params: { canonicalActivityId: "a".repeat(64), sections: ["aerobic-drift"] },
       }),
     );
     await started.promise;
@@ -1274,8 +1351,10 @@ describe.skipIf(!hasLoopback)("RPC authority boundaries", () => {
     const chat = vi.fn(async () => ({ text: "ok" }));
     const resetSession = vi.fn(async () => ({ memoryFlushed: true }));
     const hasSession = vi.fn(async () => ({ hasSession: true }));
+    const getActivityAnalysis = vi.fn(operations.getActivityAnalysis!);
     const rpc = createCoachRpcServer({
       engine: engine({ chat, resetSession, hasSession }),
+      operations: { ...operations, getActivityAnalysis },
       token,
       owner: "app-supervised",
     });
@@ -1335,6 +1414,21 @@ describe.skipIf(!hasLoopback)("RPC authority boundaries", () => {
     expect(chat).toHaveBeenCalledOnce();
     expect(resetSession).toHaveBeenCalledOnce();
     expect(hasSession).toHaveBeenCalledOnce();
+
+    id += 1;
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method: "getActivityAnalysis",
+        params: { canonicalActivityId: "a".repeat(64), sections: ["aerobic-drift"] },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+      id,
+      result: { schemaVersion: 1, sections: { aerobicDrift: { kind: "unavailable" } } },
+    });
+    expect(getActivityAnalysis).toHaveBeenCalledOnce();
     await client.close();
   });
 

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -105,8 +105,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 13 as const,
-      serverProtocolVersion: 13 as const,
+      clientProtocolVersion: 14 as const,
+      serverProtocolVersion: 14 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/core/tests/memory-query.test.ts
+++ b/packages/core/tests/memory-query.test.ts
@@ -153,7 +153,7 @@ describe("memory_query tool", () => {
     expect(result.endsWith("[truncated — narrow the date range or add a query term]")).toBe(true);
   });
 
-  it("365-file corpus scans under the budget", async () => {
+  it("365-file corpus scans under the budget", { timeout: 15_000 }, async () => {
     const start = Date.parse("2025-06-01T00:00:00Z");
     for (let i = 0; i < 365; i++) {
       const date = new Date(start + i * 86_400_000).toISOString().slice(0, 10);

--- a/packages/kernel-node/tests/activity-analysis-projection-repository.test.ts
+++ b/packages/kernel-node/tests/activity-analysis-projection-repository.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ACTIVITY_ANALYSIS_PROJECTION_MAX_REVISIONS,
+  ActivityAnalysisProjectionError,
+  createActivityAnalysisProjectionRepository,
+  runMigrations,
+  type ActivityAnalysisProjectionRepository,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const SESSION = "a".repeat(64);
+const WORKOUT = "b".repeat(64);
+const REVISION = "c".repeat(64);
+
+describe("activity analysis projection repository", () => {
+  let store: SqlStore & MigratorStore;
+  let repository: ActivityAnalysisProjectionRepository;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    await store.run(
+      "INSERT INTO workout(workout_key,start_utc,tz_offset_s,name,notes,is_multisport,dedup_cluster_id) VALUES(?,?,?,?,?,?,?)",
+      [WORKOUT, 900, 0, null, null, 0, "cluster"],
+    );
+    await store.run(
+      "INSERT INTO session(session_key,workout_key,session_seq,sport,sub_sport,start_utc,tz_offset_s,local_date_key,elapsed_s,timer_s,moving_s,distance_m,is_transition,summary_json) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+      [SESSION, WORKOUT, 0, "cycling", null, 900, 0, 19980704, 100, 90, 80, 1_000, 0, null],
+    );
+    repository = createActivityAnalysisProjectionRepository(store);
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("upserts and reads a bounded projection while advancing LRU access", async () => {
+    const projection = {
+      canonicalActivityId: SESSION,
+      sourceRevision: REVISION,
+      contractVersion: 1,
+      section: "aerobic-drift",
+      source: "local-canonical",
+      observedAt: "1998-07-06T12:00:00.000Z",
+      dataJson: '{"value":1}',
+    } as const;
+    await repository.write(projection, 100);
+    await expect(repository.read(projection, 120)).resolves.toEqual(projection);
+    expect(await store.get(
+      "SELECT cached_epoch_s,accessed_epoch_s FROM activity_analysis_projection",
+    )).toEqual({ cached_epoch_s: 100, accessed_epoch_s: 120 });
+
+    const replacement = { ...projection, source: "provider", dataJson: '{"value":2}' } as const;
+    await repository.write(replacement, 130);
+    await expect(repository.read(projection, 125)).resolves.toEqual(replacement);
+    expect(await store.get(
+      "SELECT cached_epoch_s,accessed_epoch_s FROM activity_analysis_projection",
+    )).toEqual({ cached_epoch_s: 130, accessed_epoch_s: 130 });
+  });
+
+  it("rejects invalid identities and payloads before SQL and enforces the database boundary", async () => {
+    const base = {
+      canonicalActivityId: SESSION,
+      sourceRevision: REVISION,
+      contractVersion: 1,
+      section: "intervals",
+      source: "provider",
+      observedAt: "1998-07-06T12:00:00.000Z",
+      dataJson: "{}",
+    } as const;
+    await expect(repository.write({ ...base, canonicalActivityId: "provider-id" }, 1))
+      .rejects.toEqual(new ActivityAnalysisProjectionError("invalid-input"));
+    await expect(repository.write({ ...base, dataJson: "not-json" }, 1))
+      .rejects.toEqual(new ActivityAnalysisProjectionError("invalid-input"));
+    await repository.write(base, 1);
+    await expect(store.run(
+      "UPDATE activity_analysis_projection SET data_json = ?",
+      ["not-json"],
+    )).rejects.toThrow();
+  });
+
+  it("keeps at most 128 recently accessed activity revisions and cascades deleted sessions", async () => {
+    for (let index = 0; index <= ACTIVITY_ANALYSIS_PROJECTION_MAX_REVISIONS; index += 1) {
+      await repository.write({
+        canonicalActivityId: SESSION,
+        sourceRevision: index.toString(16).padStart(64, "0"),
+        contractVersion: 1,
+        section: "best-efforts",
+        source: "provider",
+        observedAt: "1998-07-06T12:00:00.000Z",
+        dataJson: `{"index":${index}}`,
+      }, index + 1);
+    }
+    expect(await store.get(
+      "SELECT count(DISTINCT source_revision) AS count FROM activity_analysis_projection",
+    )).toEqual({ count: ACTIVITY_ANALYSIS_PROJECTION_MAX_REVISIONS });
+    expect(await store.get(
+      "SELECT 1 AS present FROM activity_analysis_projection WHERE source_revision = ?",
+      ["0".repeat(64)],
+    )).toBeUndefined();
+
+    await store.run("DELETE FROM workout WHERE workout_key = ?", [WORKOUT]);
+    expect(await store.get("SELECT count(*) AS count FROM activity_analysis_projection"))
+      .toEqual({ count: 0 });
+  });
+});

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -583,7 +583,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -31,9 +31,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 10", async () => {
+  it("applies the full migration list and advances user_version to 11", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -53,7 +53,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -82,11 +82,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 10", async () => {
+  it("upgrades a version-1-on-disk store to version 11", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -106,8 +106,8 @@ describe("migrator end-to-end over node:sqlite", () => {
     );
 
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 4, toVersion: 10, applied: [5, 6, 7, 8, 9, 10] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
+    expect(result).toEqual({ fromVersion: 4, toVersion: 11, applied: [5, 6, 7, 8, 9, 10, 11] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -158,14 +158,14 @@ describe("migrator end-to-end over node:sqlite", () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 6, toVersion: 10, applied: [7, 8, 9, 10] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
+    expect(result).toEqual({ fromVersion: 6, toVersion: 11, applied: [7, 8, 9, 10, 11] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 10,
-      toVersion: 10,
+      fromVersion: 11,
+      toVersion: 11,
       applied: [],
     });
   });

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -236,8 +236,8 @@ describe("sync failure repository", () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     await runMigrations(store, MIGRATIONS);
     expect(await dumpStore(store)).not.toContain("# sync_failure");
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 10 });
-    expect(DUMP_TABLES).toHaveLength(36);
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(DUMP_TABLES).toHaveLength(37);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");
     expect(DERIVED_TABLES).not.toContain("sync_failure");

--- a/packages/kernel/src/store/activity-analysis-projection-repository.ts
+++ b/packages/kernel/src/store/activity-analysis-projection-repository.ts
@@ -1,0 +1,249 @@
+import type { Row, SqlStore } from "./ports.js";
+
+export const ACTIVITY_ANALYSIS_PROJECTION_CONTRACT_VERSION = 1 as const;
+export const ACTIVITY_ANALYSIS_PROJECTION_MAX_BYTES = 256 * 1_024;
+export const ACTIVITY_ANALYSIS_PROJECTION_MAX_REVISIONS = 128;
+export const ACTIVITY_ANALYSIS_PROJECTION_MAX_TOTAL_BYTES = 64 * 1_024 * 1_024;
+
+export const ACTIVITY_ANALYSIS_PROJECTION_SECTIONS = [
+  "aerobic-drift",
+  "intervals",
+  "best-efforts",
+  "power-distribution",
+  "heart-rate-distribution",
+  "power-heart-rate",
+] as const;
+
+export type ActivityAnalysisProjectionSection =
+  (typeof ACTIVITY_ANALYSIS_PROJECTION_SECTIONS)[number];
+export type ActivityAnalysisProjectionSource = "local-canonical" | "provider";
+
+export interface ActivityAnalysisProjectionKey {
+  readonly canonicalActivityId: string;
+  readonly sourceRevision: string;
+  readonly contractVersion: typeof ACTIVITY_ANALYSIS_PROJECTION_CONTRACT_VERSION;
+  readonly section: ActivityAnalysisProjectionSection;
+}
+
+export interface ActivityAnalysisProjection extends ActivityAnalysisProjectionKey {
+  readonly source: ActivityAnalysisProjectionSource;
+  readonly observedAt: string;
+  readonly dataJson: string;
+}
+
+export interface ActivityAnalysisProjectionRepository {
+  read(
+    key: ActivityAnalysisProjectionKey,
+    accessedEpochSeconds: number,
+  ): Promise<ActivityAnalysisProjection | undefined>;
+  write(
+    value: ActivityAnalysisProjection,
+    cachedEpochSeconds: number,
+  ): Promise<void>;
+}
+
+export class ActivityAnalysisProjectionError extends Error {
+  readonly code: "invalid-input" | "invalid-row";
+
+  constructor(code: "invalid-input" | "invalid-row") {
+    super(`activity analysis projection rejected: ${code}`);
+    this.name = "ActivityAnalysisProjectionError";
+    this.code = code;
+  }
+}
+
+const HASH = /^[0-9a-f]{64}$/;
+const INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const SECTION_SET = new Set<string>(ACTIVITY_ANALYSIS_PROJECTION_SECTIONS);
+
+function invalidInput(): never {
+  throw new ActivityAnalysisProjectionError("invalid-input");
+}
+
+function invalidRow(): never {
+  throw new ActivityAnalysisProjectionError("invalid-row");
+}
+
+function validEpochSeconds(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function validInstant(value: unknown): value is string {
+  if (typeof value !== "string" || !INSTANT.test(value)) return false;
+  const epoch = Date.parse(value);
+  return Number.isFinite(epoch) && new Date(epoch).toISOString() === value;
+}
+
+function validJson(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const bytes = new TextEncoder().encode(value).byteLength;
+  if (bytes < 2 || bytes > ACTIVITY_ANALYSIS_PROJECTION_MAX_BYTES) return false;
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function validateKey(value: ActivityAnalysisProjectionKey): void {
+  if (
+    value === null
+    || typeof value !== "object"
+    || !HASH.test(value.canonicalActivityId)
+    || !HASH.test(value.sourceRevision)
+    || value.contractVersion !== ACTIVITY_ANALYSIS_PROJECTION_CONTRACT_VERSION
+    || !SECTION_SET.has(value.section)
+  ) {
+    invalidInput();
+  }
+}
+
+function projectionFromRow(row: Row, key: ActivityAnalysisProjectionKey): ActivityAnalysisProjection {
+  const source = row.source;
+  const observedAt = row.observed_at;
+  const dataJson = row.data_json;
+  if (
+    (source !== "local-canonical" && source !== "provider")
+    || !validInstant(observedAt)
+    || !validJson(dataJson)
+  ) {
+    invalidRow();
+  }
+  return Object.freeze({ ...key, source, observedAt, dataJson });
+}
+
+interface RevisionUsage {
+  readonly canonicalActivityId: string;
+  readonly sourceRevision: string;
+  readonly bytes: number;
+  readonly accessedEpochSeconds: number;
+}
+
+function revisionUsage(row: Row): RevisionUsage {
+  if (
+    typeof row.canonical_activity_id !== "string"
+    || !HASH.test(row.canonical_activity_id)
+    || typeof row.source_revision !== "string"
+    || !HASH.test(row.source_revision)
+    || typeof row.bytes !== "number"
+    || !Number.isSafeInteger(row.bytes)
+    || row.bytes < 0
+    || !validEpochSeconds(row.accessed_epoch_s)
+  ) {
+    invalidRow();
+  }
+  return {
+    canonicalActivityId: row.canonical_activity_id,
+    sourceRevision: row.source_revision,
+    bytes: row.bytes,
+    accessedEpochSeconds: row.accessed_epoch_s,
+  };
+}
+
+async function prune(store: SqlStore): Promise<void> {
+  const revisions = (await store.all(`SELECT
+  canonical_activity_id,
+  source_revision,
+  sum(length(CAST(data_json AS BLOB))) AS bytes,
+  max(accessed_epoch_s) AS accessed_epoch_s
+FROM activity_analysis_projection
+GROUP BY canonical_activity_id, source_revision
+ORDER BY accessed_epoch_s DESC, canonical_activity_id DESC, source_revision DESC`)).map(
+    revisionUsage,
+  );
+  let retainedBytes = 0;
+  for (let index = 0; index < revisions.length; index += 1) {
+    const revision = revisions[index]!;
+    retainedBytes += revision.bytes;
+    if (
+      index < ACTIVITY_ANALYSIS_PROJECTION_MAX_REVISIONS
+      && retainedBytes <= ACTIVITY_ANALYSIS_PROJECTION_MAX_TOTAL_BYTES
+    ) {
+      continue;
+    }
+    await store.run(
+      `DELETE FROM activity_analysis_projection
+WHERE canonical_activity_id = ? AND source_revision = ?`,
+      [revision.canonicalActivityId, revision.sourceRevision],
+    );
+  }
+}
+
+export function createActivityAnalysisProjectionRepository(
+  store: SqlStore,
+): ActivityAnalysisProjectionRepository {
+  return Object.freeze({
+    async read(key: ActivityAnalysisProjectionKey, accessedEpochSeconds: number) {
+      validateKey(key);
+      if (!validEpochSeconds(accessedEpochSeconds)) invalidInput();
+      const row = await store.get(`SELECT source, observed_at, data_json
+FROM activity_analysis_projection
+WHERE canonical_activity_id = ?
+  AND source_revision = ?
+  AND contract_version = ?
+  AND section = ?`, [
+        key.canonicalActivityId,
+        key.sourceRevision,
+        key.contractVersion,
+        key.section,
+      ]);
+      if (row === undefined) return undefined;
+      const projection = projectionFromRow(row, key);
+      await store.run(`UPDATE activity_analysis_projection
+SET accessed_epoch_s = max(accessed_epoch_s, ?)
+WHERE canonical_activity_id = ?
+  AND source_revision = ?
+  AND contract_version = ?
+  AND section = ?`, [
+        accessedEpochSeconds,
+        key.canonicalActivityId,
+        key.sourceRevision,
+        key.contractVersion,
+        key.section,
+      ]);
+      return projection;
+    },
+
+    async write(value: ActivityAnalysisProjection, cachedEpochSeconds: number) {
+      validateKey(value);
+      if (
+        (value.source !== "local-canonical" && value.source !== "provider")
+        || !validInstant(value.observedAt)
+        || !validJson(value.dataJson)
+        || !validEpochSeconds(cachedEpochSeconds)
+      ) {
+        invalidInput();
+      }
+      await store.run(`INSERT INTO activity_analysis_projection (
+  canonical_activity_id,
+  source_revision,
+  contract_version,
+  section,
+  source,
+  observed_at,
+  data_json,
+  cached_epoch_s,
+  accessed_epoch_s
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (canonical_activity_id, source_revision, contract_version, section)
+DO UPDATE SET
+  source = excluded.source,
+  observed_at = excluded.observed_at,
+  data_json = excluded.data_json,
+  cached_epoch_s = excluded.cached_epoch_s,
+  accessed_epoch_s = excluded.accessed_epoch_s`, [
+        value.canonicalActivityId,
+        value.sourceRevision,
+        value.contractVersion,
+        value.section,
+        value.source,
+        value.observedAt,
+        value.dataJson,
+        cachedEpochSeconds,
+        cachedEpochSeconds,
+      ]);
+      await prune(store);
+    },
+  });
+}

--- a/packages/kernel/src/store/dump.ts
+++ b/packages/kernel/src/store/dump.ts
@@ -18,6 +18,10 @@ export const DERIVED_TABLES = [
 
 /** Every current store table, alphabetical, with its content-derived order key. */
 export const DUMP_TABLES = [
+  {
+    table: "activity_analysis_projection",
+    orderBy: "canonical_activity_id, source_revision, contract_version, section",
+  },
   { table: "analytics_curve_current", orderBy: "singleton" },
   { table: "analytics_curve_evidence", orderBy: "evidence_id" },
   { table: "analytics_curve_generation", orderBy: "generation_id" },

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -9,6 +9,7 @@ export * from "./dedup-confirmation-repository.js";
 export * from "./intake-repository.js";
 export * from "./activity-repository.js";
 export * from "./canonical-activity-reader.js";
+export * from "./activity-analysis-projection-repository.js";
 export * from "./trusted-activity-source-resolver.js";
 export * from "./analytics-curve-repository.js";
 export * from "./derived-key.js";

--- a/packages/kernel/src/store/migrations/011_activity_analysis_projection.sql
+++ b/packages/kernel/src/store/migrations/011_activity_analysis_projection.sql
@@ -1,0 +1,45 @@
+CREATE TABLE activity_analysis_projection (
+  canonical_activity_id TEXT NOT NULL
+    REFERENCES session(session_key) ON DELETE CASCADE
+    CHECK (
+      length(canonical_activity_id) = 64
+      AND canonical_activity_id = lower(canonical_activity_id)
+      AND canonical_activity_id NOT GLOB '*[^0-9a-f]*'
+    ),
+  source_revision TEXT NOT NULL
+    CHECK (
+      length(source_revision) = 64
+      AND source_revision = lower(source_revision)
+      AND source_revision NOT GLOB '*[^0-9a-f]*'
+    ),
+  contract_version INTEGER NOT NULL CHECK (contract_version = 1),
+  section TEXT NOT NULL CHECK (section IN (
+    'aerobic-drift',
+    'intervals',
+    'best-efforts',
+    'power-distribution',
+    'heart-rate-distribution',
+    'power-heart-rate'
+  )),
+  source TEXT NOT NULL CHECK (source IN ('local-canonical','provider')),
+  observed_at TEXT NOT NULL CHECK (
+    length(observed_at) BETWEEN 20 AND 32
+    AND observed_at GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T*Z'
+  ),
+  data_json TEXT NOT NULL CHECK (
+    json_valid(data_json)
+    AND length(CAST(data_json AS BLOB)) BETWEEN 2 AND 262144
+  ),
+  cached_epoch_s INTEGER NOT NULL CHECK (cached_epoch_s >= 0),
+  accessed_epoch_s INTEGER NOT NULL CHECK (accessed_epoch_s >= cached_epoch_s),
+  PRIMARY KEY (canonical_activity_id, source_revision, contract_version, section)
+) STRICT, WITHOUT ROWID;
+
+CREATE INDEX idx_activity_analysis_projection_lru
+  ON activity_analysis_projection (
+    accessed_epoch_s,
+    canonical_activity_id,
+    source_revision,
+    contract_version,
+    section
+  );

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -8,6 +8,7 @@ import syncFailure007 from "./007_sync_failure.sql";
 import storeOwner008 from "./008_store_owner.sql";
 import activitySourceResolver009 from "./009_activity_source_resolver.sql";
 import analyticsCurves010 from "./010_analytics_curves.sql";
+import activityAnalysisProjection011 from "./011_activity_analysis_projection.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -33,4 +34,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 8, name: "008_store_owner", sql: storeOwner008 },
   { version: 9, name: "009_activity_source_resolver", sql: activitySourceResolver009 },
   { version: 10, name: "010_analytics_curves", sql: analyticsCurves010 },
+  { version: 11, name: "011_activity_analysis_projection", sql: activityAnalysisProjection011 },
 ];

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -50,6 +50,7 @@ const EXPECTED_FULL_TABLES = [
   "analytics_curve_generation_promotion",
   "analytics_curve_current",
   "analytics_curve_refresh_failure",
+  "activity_analysis_projection",
 ];
 const MIGRATION_002 = `ALTER TABLE swim_length ADD COLUMN distance_m REAL;
 
@@ -169,6 +170,7 @@ describe("001_init migration", () => {
       { version: 8, name: "008_store_owner" },
       { version: 9, name: "009_activity_source_resolver" },
       { version: 10, name: "010_analytics_curves" },
+      { version: 11, name: "011_activity_analysis_projection" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -270,7 +272,7 @@ describe("001_init migration", () => {
       .map((row) => row.name)
       .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
-    expect(names).toHaveLength(41);
+    expect(names).toHaveLength(42);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
@@ -734,6 +736,10 @@ describe("001_init migration", () => {
 
   it("enumerates sync state ownership", () => {
     expect(DUMP_TABLES).toEqual([
+      {
+        table: "activity_analysis_projection",
+        orderBy: "canonical_activity_id, source_revision, contract_version, section",
+      },
       { table: "analytics_curve_current", orderBy: "singleton" },
       { table: "analytics_curve_evidence", orderBy: "evidence_id" },
       { table: "analytics_curve_generation", orderBy: "generation_id" },
@@ -771,7 +777,7 @@ describe("001_init migration", () => {
       { table: "workout", orderBy: "workout_key" },
       { table: "zone_set_history", orderBy: "id" },
     ]);
-    expect(DUMP_TABLES).toHaveLength(36);
+    expect(DUMP_TABLES).toHaveLength(37);
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("source_watermark");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_failure");
@@ -827,7 +833,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     }>;
     expect(tables.find((row) => row.name === "sync_failure")?.strict).toBe(1);
     expect(db.prepare("PRAGMA foreign_key_list(sync_failure)").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(36);
+    expect(DUMP_TABLES).toHaveLength(37);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(PURE_AUTHORED_TABLES).not.toContain("sync_failure");
     expect(MIXED_AUTHORED_TABLES).not.toContain("sync_failure");
@@ -884,9 +890,34 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       expect(tables.find((row) => row.name === name)?.strict).toBe(1);
     }
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(36);
+    expect(DUMP_TABLES).toHaveLength(37);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("analytics_curve_refresh_failure");
     expect(DERIVED_TABLES).not.toContain("analytics_curve_generation");
+  });
+
+  it("adds the bounded activity-analysis projection cache", () => {
+    db = openFull();
+    expect(createHash("sha256").update(MIGRATIONS[10]!.sql).digest("hex")).toBe(
+      "b9c22b99343093655536059e68c1846b5deb8b77355a08e38013d807906e300e",
+    );
+    const table = db.prepare("PRAGMA table_list").all().find(
+      (row) => (row as { name?: unknown }).name === "activity_analysis_projection",
+    ) as { strict: number; wr: number } | undefined;
+    expect(table).toMatchObject({ strict: 1, wr: 1 });
+    expect(db.prepare("PRAGMA foreign_key_list(activity_analysis_projection)").all())
+      .toContainEqual(expect.objectContaining({ table: "session", on_delete: "CASCADE" }));
+    expect(db.prepare("PRAGMA index_info(idx_activity_analysis_projection_lru)").all())
+      .toEqual([
+        expect.objectContaining({ seqno: 0, name: "accessed_epoch_s" }),
+        expect.objectContaining({ seqno: 1, name: "canonical_activity_id" }),
+        expect.objectContaining({ seqno: 2, name: "source_revision" }),
+        expect.objectContaining({ seqno: 3, name: "contract_version" }),
+        expect.objectContaining({ seqno: 4, name: "section" }),
+      ]);
+    expect(DUMP_TABLES.map(({ table: name }) => name)).toContain(
+      "activity_analysis_projection",
+    );
+    expect(DERIVED_TABLES).not.toContain("activity_analysis_projection");
   });
 
   it("omits the unreleased prior bone-stress column from the baseline schema", () => {

--- a/packages/kernel/tests/store-dump.test.ts
+++ b/packages/kernel/tests/store-dump.test.ts
@@ -71,6 +71,7 @@ describe("INV-2 canonical dump (armed with real ingest at W2)", () => {
   it("includes every incremental cache while excluding checkpoint operations", () => {
     const dumped = DUMP_TABLES.map(({ table }) => table);
     expect(dumped).toEqual(expect.arrayContaining([
+      "activity_analysis_projection",
       "analytics_curve_current", "analytics_curve_evidence", "analytics_curve_generation",
       "analytics_curve_generation_promotion",
       "ingest_candidate_index", "ingest_cluster_state", "ingest_dedup_pair_state",
@@ -83,5 +84,6 @@ describe("INV-2 canonical dump (armed with real ingest at W2)", () => {
       "ingest_candidate_index", "ingest_cluster_state", "ingest_dedup_pair_state", "ingest_dedup_session_state",
     ]));
     expect(DERIVED_TABLES).not.toContain("ingest_incremental_state");
+    expect(DERIVED_TABLES).not.toContain("activity_analysis_projection");
   });
 });


### PR DESCRIPTION
## Summary
- freeze strict, renderer-safe DTOs for the six on-demand activity-analysis sections and expose one protocol-v14 RPC
- add a bounded SQLite projection cache keyed by canonical activity, source revision, contract version, and section
- deduplicate identical work, cap section and activity concurrency, propagate cancellation, preserve last-good evidence, and reject source/provenance contradictions
- cover renderer authority, connection detach, revision changes, cache pruning, migration upgrades, and full-suite stability

## Verification
- pnpm check
- pnpm test (544 files; 8,215 passed; 15 skipped)
- pnpm s8a
- focused activity-analysis/RPC/migration regression suite (276 tests)
- oxlint on all touched TypeScript files (0 warnings, 0 errors)

## Scope
This is the hidden on-demand analysis foundation for Aerobic Drift, Intervals, Best Efforts, Distributions, and Power/HR. Feature analyzers and ride-detail UI follow in separate PRs.