### PR TITLE
feat(desktop): add local aerobic drift review

### DIFF
--- a/.changeset/local-aerobic-drift.md
+++ b/.changeset/local-aerobic-drift.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Ride review now shows a whole-ride local aerobic drift estimate when power, heart-rate, timing, duration, and coverage checks pass, with clear limitations instead of a good-or-bad judgment.

--- a/apps/desktop-renderer/src/activity-analysis/controller.ts
+++ b/apps/desktop-renderer/src/activity-analysis/controller.ts
@@ -1,0 +1,176 @@
+import {
+  CoachClientDisconnectedError,
+  CoachClientProtocolError,
+  type CoachClient,
+} from "@enduragent/coach-client";
+import {
+  ActivityAnalysisResultSchema,
+  CanonicalActivityIdSchema,
+  type ActivityAnalysisResult,
+  type ActivityAnalysisSection,
+} from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../coach-client.js";
+
+export type RideAnalysisStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "unavailable"
+  | "refresh-unavailable";
+
+export interface RideAnalysisViewState {
+  readonly activityId: string | null;
+  readonly status: RideAnalysisStatus;
+  readonly revision: string | null;
+  readonly sections: ActivityAnalysisResult["sections"];
+  readonly loadingSections: readonly ActivityAnalysisSection[];
+}
+
+export const EMPTY_RIDE_ANALYSIS: RideAnalysisViewState = Object.freeze({
+  activityId: null,
+  status: "idle" as const,
+  revision: null,
+  sections: Object.freeze({}),
+  loadingSections: Object.freeze([]),
+});
+
+export interface RideAnalysisView {
+  render(state: RideAnalysisViewState): void;
+}
+
+export interface RideAnalysisController {
+  select(activityId: string | null): Promise<void>;
+  load(sections: readonly ActivityAnalysisSection[], refresh?: boolean): Promise<void>;
+  dispose(): void;
+}
+
+export function createRideAnalysisController(input: {
+  readonly clients: DesktopCoachClientProvider;
+  readonly view: RideAnalysisView;
+}): RideAnalysisController {
+  let disposed = false;
+  let generation = 0;
+  let operation: AbortController | undefined;
+  let failedClient: CoachClient | undefined;
+  let reconnectRequired = false;
+  let state: RideAnalysisViewState = EMPTY_RIDE_ANALYSIS;
+
+  const render = (next: RideAnalysisViewState): void => {
+    state = next;
+    if (!disposed) input.view.render(state);
+  };
+  const clientAfterFailure = async (): Promise<CoachClient> => {
+    if (!reconnectRequired) return input.clients.getClient();
+    const current = await input.clients.getClient();
+    const client =
+      failedClient === undefined || current === failedClient
+        ? await input.clients.reconnect()
+        : current;
+    reconnectRequired = false;
+    failedClient = undefined;
+    return client;
+  };
+
+  const load = async (
+    sections: readonly ActivityAnalysisSection[],
+    refresh = false,
+  ): Promise<void> => {
+    if (disposed || state.activityId === null) return;
+    const selectedActivityId = state.activityId;
+    const requested = [...new Set(sections)];
+    if (requested.length === 0) return;
+    const selectedGeneration = ++generation;
+    operation?.abort();
+    const controller = new AbortController();
+    operation = controller;
+    render({
+      ...state,
+      status: "loading",
+      loadingSections: requested,
+    });
+    let client: CoachClient | undefined;
+    try {
+      client = await clientAfterFailure();
+      controller.signal.throwIfAborted();
+      const result = ActivityAnalysisResultSchema.parse(
+        await client.call(
+          "getActivityAnalysis",
+          {
+            canonicalActivityId: selectedActivityId,
+            sections: requested,
+            ...(refresh ? { refresh: true } : {}),
+          },
+          { signal: controller.signal },
+        ),
+      ) as ActivityAnalysisResult;
+      if (
+        disposed ||
+        selectedGeneration !== generation ||
+        state.activityId !== selectedActivityId
+      ) {
+        return;
+      }
+      const retain = state.revision === null || state.revision === result.revision;
+      render({
+        activityId: selectedActivityId,
+        status: "ready",
+        revision: result.revision,
+        sections: retain ? { ...state.sections, ...result.sections } : result.sections,
+        loadingSections: [],
+      });
+    } catch (error) {
+      if (
+        disposed ||
+        selectedGeneration !== generation ||
+        state.activityId !== selectedActivityId
+      ) {
+        return;
+      }
+      if (
+        error instanceof CoachClientDisconnectedError ||
+        error instanceof CoachClientProtocolError
+      ) {
+        reconnectRequired = true;
+        failedClient = client;
+      }
+      render({
+        ...state,
+        status: Object.keys(state.sections).length === 0 ? "unavailable" : "refresh-unavailable",
+        loadingSections: [],
+      });
+    } finally {
+      if (operation === controller) operation = undefined;
+    }
+  };
+
+  input.view.render(state);
+  return {
+    async select(activityId) {
+      const selected = activityId === null ? null : CanonicalActivityIdSchema.parse(activityId);
+      if (disposed || selected === state.activityId) return;
+      generation += 1;
+      operation?.abort();
+      operation = undefined;
+      if (selected === null) {
+        render(EMPTY_RIDE_ANALYSIS);
+        return;
+      }
+      render({
+        activityId: selected,
+        status: "loading",
+        revision: null,
+        sections: {},
+        loadingSections: ["aerobic-drift"],
+      });
+      await load(["aerobic-drift"]);
+    },
+    load,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      generation += 1;
+      operation?.abort();
+      operation = undefined;
+    },
+  };
+}

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -6,6 +6,7 @@ import {
 import { SaveIntakeRpcParamsSchema } from "@enduragent/coach-contract";
 import { flushSync } from "react-dom";
 import { createArchiveController } from "./archive/controller.js";
+import { createRideAnalysisController } from "./activity-analysis/controller.js";
 import { createChatController } from "./chat/controller.js";
 import { createDesktopCoachClientProvider } from "./coach-client.js";
 import { createFirstSyncController } from "./first-sync.js";
@@ -77,6 +78,24 @@ export function bootRenderer(): Disposer {
   void desktopUpdateController.start();
 
   const clients = createDesktopCoachClientProvider();
+  const rideAnalysisController = createRideAnalysisController({
+    clients,
+    view: {
+      render: (next) => store.getState().setRideAnalysis(next),
+    },
+  });
+  store.getState().bindRideAnalysisActions({
+    refresh: () => {
+      void rideAnalysisController.load(["aerobic-drift"], true);
+    },
+  });
+  let selectedAnalysisRide = store.getState().selectedRide?.id ?? null;
+  const disposeRideAnalysisSelection = store.subscribe((next) => {
+    const selected = next.selectedRide?.id ?? null;
+    if (selected === selectedAnalysisRide) return;
+    selectedAnalysisRide = selected;
+    void rideAnalysisController.select(selected);
+  });
   const clientAfterFailure = async (failedClient: CoachClient | undefined) => {
     if (failedClient === undefined) return clients.reconnect();
     const current = await clients.getClient();
@@ -381,8 +400,10 @@ export function bootRenderer(): Disposer {
     store.getState().bindSettingsPorts(null);
     store.getState().bindSyncActions(null);
     store.getState().bindRideImportActions(null);
+    store.getState().bindRideAnalysisActions(null);
     store.getState().bindOnboardingActions(null);
     disposeLifecycle();
+    disposeRideAnalysisSelection();
     window.removeEventListener("pagehide", dispose);
     releaseNotesController.dispose();
     desktopUpdateController.dispose();
@@ -402,6 +423,7 @@ export function bootRenderer(): Disposer {
     archiveController.dispose();
     spendController.dispose();
     trainingContextController.dispose();
+    rideAnalysisController.dispose();
     void clients.close();
   };
   window.addEventListener("pagehide", dispose, { once: true });

--- a/apps/desktop-renderer/src/state/activity-analysis-slice.ts
+++ b/apps/desktop-renderer/src/state/activity-analysis-slice.ts
@@ -1,0 +1,33 @@
+import type { StateCreator } from "zustand";
+import {
+  EMPTY_RIDE_ANALYSIS,
+  type RideAnalysisViewState,
+} from "../activity-analysis/controller.js";
+import type { EnduragentState } from "./store.js";
+
+export interface RideAnalysisActions {
+  refresh(): void;
+}
+
+export interface ActivityAnalysisSlice {
+  readonly rideAnalysis: RideAnalysisViewState;
+  readonly rideAnalysisActions: RideAnalysisActions | null;
+  setRideAnalysis: (next: RideAnalysisViewState) => void;
+  bindRideAnalysisActions: (actions: RideAnalysisActions | null) => void;
+}
+
+export const createActivityAnalysisSlice: StateCreator<
+  EnduragentState,
+  [],
+  [],
+  ActivityAnalysisSlice
+> = (set) => ({
+  rideAnalysis: EMPTY_RIDE_ANALYSIS,
+  rideAnalysisActions: null,
+  setRideAnalysis(next) {
+    set({ rideAnalysis: next });
+  },
+  bindRideAnalysisActions(actions) {
+    set({ rideAnalysisActions: actions });
+  },
+});

--- a/apps/desktop-renderer/src/state/store.ts
+++ b/apps/desktop-renderer/src/state/store.ts
@@ -14,6 +14,10 @@ import {
   writeStoredPaletteId,
 } from "../theme/preferences.js";
 import { createArchiveSlice, type ArchiveSlice } from "./archive-slice.js";
+import {
+  createActivityAnalysisSlice,
+  type ActivityAnalysisSlice,
+} from "./activity-analysis-slice.js";
 import { createChatSlice, type ChatSlice } from "./chat-slice.js";
 import { createConnectionSlice, type ConnectionSlice } from "./connection-slice.js";
 import { createOnboardingSlice, type OnboardingSlice } from "./onboarding-slice.js";
@@ -27,10 +31,12 @@ import { createSyncSlice, type SyncSlice } from "./sync-slice.js";
 import { createTrainingSlice, type TrainingSlice } from "./training-slice.js";
 
 export interface EnduragentState
-  extends ChatSlice,
+  extends
+    ChatSlice,
     ArchiveSlice,
     SettingsSlice,
     TrainingSlice,
+    ActivityAnalysisSlice,
     SyncSlice,
     ConnectionSlice,
     RideImportSlice,
@@ -61,6 +67,7 @@ export const useEnduragentStore = create<EnduragentState>((set, get, api) => ({
   ...createArchiveSlice(set, get, api),
   ...createSettingsSlice(set, get, api),
   ...createTrainingSlice(set, get, api),
+  ...createActivityAnalysisSlice(set, get, api),
   ...createSyncSlice(set, get, api),
   ...createConnectionSlice(set, get, api),
   ...createRideImportSlice(set, get, api),

--- a/apps/desktop-renderer/src/ui/training/RideReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideReview.tsx
@@ -1,7 +1,15 @@
-import type { RecentRide, RecentRidesPanel, UnitsPreference } from "@enduragent/coach-contract";
+import type {
+  ActivityAnalysisData,
+  AnalysisSection,
+  RecentRide,
+  RecentRidesPanel,
+  UnitsPreference,
+} from "@enduragent/coach-contract";
 import type { ReactElement, Ref } from "react";
+import type { RideAnalysisViewState } from "../../activity-analysis/controller.js";
 import { formatDateLabel } from "../../training-context/format.js";
 import { Page } from "../shared/Page.js";
+import { analysisRefreshFailureCopy, analysisUnavailableCopy } from "./copy.js";
 import styles from "./TrainingView.module.css";
 
 const RIDE_KIND: Readonly<Record<string, string>> = {
@@ -82,6 +90,199 @@ function RideSummary(props: {
   );
 }
 
+function formatAnalysisDuration(seconds: number): string {
+  const minutes = Math.round(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return hours === 0 ? `${minutes} min` : `${hours} hr ${remainder} min`;
+}
+
+function formatDrift(value: number): string {
+  const rounded = Math.abs(value) < 0.05 ? 0 : value;
+  return `${rounded > 0 ? "+" : ""}${rounded.toFixed(1)}%`;
+}
+
+const LIMITATION_COPY: Readonly<
+  Record<ActivityAnalysisData["aerobicDrift"]["limitations"][number], string>
+> = {
+  "duration-under-60-minutes": "Usable duration is below the 60-minute reference context.",
+  "variable-output": "Power varied substantially across the ride.",
+  "moving-status-unavailable":
+    "No moving-status stream was available, so stopped time may be included.",
+};
+
+function shouldOfferRetry(reason: Parameters<typeof analysisUnavailableCopy>[0]): boolean {
+  return (
+    reason === "empty-response" ||
+    reason === "malformed-response" ||
+    reason === "response-too-large" ||
+    reason === "request-budget-exhausted" ||
+    reason === "rate-limited" ||
+    reason === "timeout" ||
+    reason === "network" ||
+    reason === "provider-unavailable" ||
+    reason === "cancelled" ||
+    reason === "temporary-failure"
+  );
+}
+
+function DriftHalf(props: {
+  readonly label: string;
+  readonly half: ActivityAnalysisData["aerobicDrift"]["firstHalf"];
+}): ReactElement {
+  return (
+    <div className={styles.driftHalf}>
+      <h3>{props.label}</h3>
+      <p className={styles.driftEf}>{props.half.efficiencyFactor.toFixed(2)} EF</p>
+      <p className={styles.driftHalfStats}>
+        {Math.round(props.half.averagePowerWatts)} W · {Math.round(props.half.averageHeartRateBpm)}{" "}
+        bpm
+      </p>
+      <p className={styles.driftHalfMeta}>
+        {formatAnalysisDuration(props.half.durationSeconds)} ·{" "}
+        {props.half.sampleCount.toLocaleString()} samples
+      </p>
+    </div>
+  );
+}
+
+function DriftEvidence(props: {
+  readonly data: ActivityAnalysisData["aerobicDrift"];
+  readonly saved: boolean;
+  readonly refreshing?: boolean;
+  readonly clientRefreshUnavailable?: boolean;
+  readonly refreshFailure?: Extract<
+    AnalysisSection<ActivityAnalysisData["aerobicDrift"]>,
+    { readonly kind: "stale" }
+  >["refreshFailure"];
+}): ReactElement {
+  const provenance = props.saved ? "Saved analysis" : "Current analysis";
+  const notice =
+    props.refreshFailure !== undefined
+      ? `Showing the saved result. ${analysisRefreshFailureCopy(props.refreshFailure.code)}`
+      : props.clientRefreshUnavailable === true
+        ? "Showing the previous result. The latest refresh did not finish."
+        : props.refreshing === true
+          ? "Refreshing the ride analysis…"
+          : null;
+  return (
+    <>
+      {notice === null ? null : (
+        <p
+          className={props.refreshing === true ? styles.analysisRefresh : styles.analysisNotice}
+          role="status"
+        >
+          {notice}
+        </p>
+      )}
+      <div className={styles.driftReading}>
+        <div>
+          <p className={styles.rideEyebrow}>Observed EF change</p>
+          <p
+            className={styles.driftValue}
+            aria-label={`Observed efficiency-factor change ${formatDrift(props.data.decouplingPercent)}`}
+          >
+            {formatDrift(props.data.decouplingPercent)}
+          </p>
+        </div>
+        <div className={styles.driftContext}>
+          <span className={styles.driftEvidenceBadge} data-evidence={props.data.evidence}>
+            {props.data.evidence === "standard" ? "Data checks passed" : "Limited context"}
+          </span>
+          <p>{provenance} · whole ride</p>
+        </div>
+      </div>
+      <div className={styles.driftTrace}>
+        <DriftHalf label="First half" half={props.data.firstHalf} />
+        <span className={styles.driftConnector} aria-hidden="true">
+          →
+        </span>
+        <DriftHalf label="Second half" half={props.data.secondHalf} />
+      </div>
+      <p className={styles.driftCoverage}>
+        {Math.round(props.data.coverage.fraction * 100)}% usable time ·{" "}
+        {formatAnalysisDuration(props.data.coverage.includedDurationSeconds)} included ·{" "}
+        {props.data.coverage.validSamples.toLocaleString()} of{" "}
+        {props.data.coverage.totalSamples.toLocaleString()} samples
+      </p>
+      {props.data.limitations.length === 0 ? null : (
+        <ul className={styles.driftLimitations} aria-label="Analysis limitations">
+          {props.data.limitations.map((limitation) => (
+            <li key={limitation}>{LIMITATION_COPY[limitation]}</li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}
+
+function AerobicDriftPanel(props: {
+  readonly rideId: string;
+  readonly analysis: RideAnalysisViewState;
+  readonly onRefresh: (() => void) | null;
+}): ReactElement {
+  const matches = props.analysis.activityId === props.rideId;
+  const section = matches ? props.analysis.sections.aerobicDrift : undefined;
+  let content: ReactElement;
+  if (section?.kind === "computed") {
+    content = (
+      <DriftEvidence
+        data={section.data}
+        saved={section.provenance.delivery === "persisted-cache"}
+        refreshing={props.analysis.status === "loading"}
+        clientRefreshUnavailable={props.analysis.status === "refresh-unavailable"}
+      />
+    );
+  } else if (section?.kind === "stale") {
+    content = (
+      <DriftEvidence data={section.lastGood.data} saved refreshFailure={section.refreshFailure} />
+    );
+  } else if (section?.kind === "unavailable") {
+    content = (
+      <div className={styles.analysisUnavailable}>
+        <p>{analysisUnavailableCopy(section.reason)}</p>
+        {props.onRefresh !== null && shouldOfferRetry(section.reason) ? (
+          <button type="button" className={styles.action} onClick={props.onRefresh}>
+            Try again
+          </button>
+        ) : null}
+      </div>
+    );
+  } else if (matches && props.analysis.status === "unavailable") {
+    content = (
+      <div className={styles.analysisUnavailable}>
+        <p>The ride could not be analyzed right now.</p>
+        {props.onRefresh === null ? null : (
+          <button type="button" className={styles.action} onClick={props.onRefresh}>
+            Try again
+          </button>
+        )}
+      </div>
+    );
+  } else {
+    content = (
+      <p className={styles.analysisLoading} role="status">
+        Checking ride streams…
+      </p>
+    );
+  }
+  return (
+    <section className={styles.analysisPanel} aria-labelledby="aerobic-drift-title">
+      <div className={styles.analysisHeading}>
+        <div>
+          <p className={styles.rideEyebrow}>Whole-ride analysis</p>
+          <h2 id="aerobic-drift-title">Local aerobic drift estimate</h2>
+        </div>
+      </div>
+      <p className={styles.analysisIntro}>
+        Compares power per heartbeat in the first and second time-weighted halves. This local
+        estimate is distinct from intervals.icu's cleaned power/HR metric.
+      </p>
+      {content}
+    </section>
+  );
+}
+
 export function RecentRidesStatePanel(props: {
   readonly panel: RecentRidesPanel;
   readonly units: UnitsPreference;
@@ -142,6 +343,8 @@ export function RecentRidesStatePanel(props: {
 export function RideDetailView(props: {
   readonly ride: RecentRide;
   readonly units: UnitsPreference;
+  readonly analysis: RideAnalysisViewState;
+  readonly onRefreshAnalysis: (() => void) | null;
   readonly onBack: () => void;
   readonly titleRef: Ref<HTMLHeadingElement>;
 }): ReactElement {
@@ -161,6 +364,11 @@ export function RideDetailView(props: {
         <h2 id="ride-overview-title">{rideKind(props.ride)}</h2>
         <RideSummary ride={props.ride} units={props.units} />
       </section>
+      <AerobicDriftPanel
+        rideId={props.ride.id}
+        analysis={props.analysis}
+        onRefresh={props.onRefreshAnalysis}
+      />
     </Page>
   );
 }

--- a/apps/desktop-renderer/src/ui/training/TrainingView.module.css
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.module.css
@@ -518,6 +518,183 @@
   padding: 20px;
 }
 
+.analysisPanel {
+  composes: raised from "../../theme/surface.module.css";
+  margin-top: 14px;
+  padding: 20px;
+}
+
+.analysisHeading {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.analysisHeading h2 {
+  margin: 0;
+  font: 600 21px/1.2 var(--f-dis);
+  letter-spacing: -0.015em;
+}
+
+.analysisIntro {
+  max-width: 650px;
+  margin: 9px 0 0;
+  color: var(--ink-2);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.analysisLoading,
+.analysisUnavailable p {
+  margin: 20px 0 0;
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.analysisUnavailable .action {
+  margin-top: 12px;
+}
+
+.analysisNotice {
+  margin: 18px 0 0;
+  padding: 9px 11px;
+  border-left: 3px solid var(--warn);
+  color: var(--ink-2);
+  background: color-mix(in srgb, var(--warn) var(--tint), transparent);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.analysisRefresh {
+  margin: 16px 0 0;
+  color: var(--ink-2);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.driftReading {
+  display: flex;
+  gap: 22px;
+  align-items: flex-end;
+  justify-content: space-between;
+  min-width: 0;
+  margin-top: 22px;
+  padding-left: 13px;
+  border-left: 2px solid var(--ink);
+}
+
+.driftValue {
+  margin: 0;
+  font: 600 33px/1 var(--f-dis);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.025em;
+}
+
+.driftContext {
+  display: grid;
+  gap: 6px;
+  justify-items: end;
+  min-width: 0;
+  text-align: right;
+}
+
+.driftEvidenceBadge {
+  composes: chip from "../../theme/surface.module.css";
+  font-size: 10.5px;
+}
+
+.driftEvidenceBadge[data-evidence="limited"] {
+  color: var(--warn);
+  background-color: color-mix(in srgb, var(--warn) var(--tint), transparent);
+}
+
+.driftContext p {
+  margin: 0;
+  color: var(--ink-3);
+  font: 10px/1.4 var(--f-mono);
+  text-transform: uppercase;
+}
+
+.driftTrace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 28px minmax(0, 1fr);
+  gap: 8px;
+  align-items: stretch;
+  margin-top: 18px;
+}
+
+.driftHalf {
+  composes: sunken from "../../theme/surface.module.css";
+  min-width: 0;
+  padding: 13px 14px;
+}
+
+.driftHalf h3 {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 10px;
+  font-weight: 560;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.driftEf {
+  margin: 10px 0 0;
+  font: 600 18px/1.1 var(--f-dis);
+  font-variant-numeric: tabular-nums;
+}
+
+.driftHalfStats {
+  margin: 7px 0 0;
+  color: var(--ink-2);
+  font: 11px/1.4 var(--f-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.driftHalfMeta {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-3);
+  font: 9.5px/1.4 var(--f-mono);
+}
+
+.driftConnector {
+  position: relative;
+  display: grid;
+  place-items: center;
+  color: var(--ink-3);
+  font: 13px/1 var(--f-mono);
+}
+
+.driftConnector::before {
+  position: absolute;
+  right: 0;
+  left: 0;
+  z-index: -1;
+  height: 1px;
+  background: var(--line);
+  content: "";
+}
+
+.driftCoverage {
+  margin: 13px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-3);
+  font: 10px/1.5 var(--f-mono);
+}
+
+.driftLimitations {
+  display: grid;
+  gap: 5px;
+  margin: 13px 0 0;
+  padding-left: 18px;
+  color: var(--ink-2);
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+
 .rideEyebrow {
   margin: 0 0 8px;
   color: var(--ink-3);
@@ -594,6 +771,25 @@
 @media (max-width: 520px) {
   .rideSummary {
     grid-template-columns: 1fr;
+  }
+
+  .driftReading {
+    display: grid;
+    align-items: start;
+  }
+
+  .driftContext {
+    justify-items: start;
+    text-align: left;
+  }
+
+  .driftTrace {
+    grid-template-columns: 1fr;
+  }
+
+  .driftConnector {
+    height: 18px;
+    transform: rotate(90deg);
   }
 }
 

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -312,6 +312,8 @@ export function TrainingView(): ReactElement {
   const selectedRide = useEnduragentStore((store) => store.selectedRide);
   const openRide = useEnduragentStore((store) => store.openRide);
   const closeRide = useEnduragentStore((store) => store.closeRide);
+  const rideAnalysis = useEnduragentStore((store) => store.rideAnalysis);
+  const rideAnalysisActions = useEnduragentStore((store) => store.rideAnalysisActions);
   const rideButtons = useRef(new Map<string, HTMLButtonElement>());
   const previousRideId = useRef<string | null>(null);
   const title = useRef<HTMLHeadingElement>(null);
@@ -332,6 +334,8 @@ export function TrainingView(): ReactElement {
       <RideDetailView
         ride={selectedRide}
         units={training.unitsPreference.value}
+        analysis={rideAnalysis}
+        onRefreshAnalysis={rideAnalysisActions?.refresh ?? null}
         titleRef={title}
         onBack={closeRide}
       />

--- a/apps/desktop-renderer/src/ui/training/copy.ts
+++ b/apps/desktop-renderer/src/ui/training/copy.ts
@@ -1,4 +1,6 @@
 import type {
+  AnalysisRefreshFailureCode,
+  AnalysisUnavailableReason,
   CyclingAnchor,
   PowerProgressComputed,
   PowerProgressRefreshFailureCode,
@@ -64,6 +66,81 @@ export const POWER_PROGRESS_FRESHNESS_COPY: Readonly<
 
 export const RIDE_IMPORT_DESCRIPTION =
   "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.";
+
+export function analysisUnavailableCopy(reason: AnalysisUnavailableReason): string {
+  switch (reason) {
+    case "activity-not-found":
+      return "This ride is no longer available in local training history.";
+    case "source-not-found":
+    case "ambiguous-source":
+    case "not-provider-backed":
+      return "No trusted stream source is available for this ride.";
+    case "missing-sensor-data":
+      return "This ride does not have both power and heart-rate data.";
+    case "duplicate-stream":
+      return "Duplicate sensor streams prevent a reliable comparison.";
+    case "misaligned-stream":
+      return "The power, heart-rate, and time streams do not line up.";
+    case "invalid-timestamps":
+      return "The ride timeline contains invalid timestamps or a long recording gap.";
+    case "activity-too-short":
+      return "At least 30 usable minutes, with 15 minutes in each half, are required.";
+    case "insufficient-coverage":
+      return "Less than 80% of the ride has usable power and heart-rate coverage.";
+    case "unstable-output":
+      return "The ride output could not support an efficiency-factor comparison.";
+    case "moving-status-unavailable":
+      return "The moving-status stream is present but cannot be verified.";
+    case "unsuitable-activity":
+      return "This ride does not meet the whole-ride analysis checks.";
+    case "empty-response":
+    case "malformed-response":
+      return "The latest stream response could not be verified.";
+    case "response-too-large":
+      return "The ride streams exceed the app's private processing limit.";
+    case "request-budget-exhausted":
+      return "The analysis request budget has been reached for this ride.";
+    case "rate-limited":
+      return "intervals.icu delayed this analysis request.";
+    case "timeout":
+      return "The analysis request timed out.";
+    case "network":
+      return "The analysis request lost its network connection.";
+    case "provider-unavailable":
+      return "intervals.icu is unavailable for this analysis.";
+    case "cancelled":
+      return "The analysis request was cancelled.";
+    case "unsupported":
+      return "This analysis is not available in the current app version.";
+    case "temporary-failure":
+      return "The ride could not be analyzed right now.";
+  }
+}
+
+export function analysisRefreshFailureCopy(reason: AnalysisRefreshFailureCode): string {
+  switch (reason) {
+    case "request-budget-exhausted":
+      return "The latest refresh reached its request budget.";
+    case "rate-limited":
+      return "intervals.icu delayed the latest refresh.";
+    case "timeout":
+      return "The latest refresh timed out.";
+    case "network":
+      return "The latest refresh lost its network connection.";
+    case "provider-unavailable":
+      return "intervals.icu was unavailable during the latest refresh.";
+    case "malformed-response":
+      return "The latest refresh returned data that could not be verified.";
+    case "response-too-large":
+      return "The latest refresh exceeded the private processing limit.";
+    case "cancelled":
+      return "The latest refresh was cancelled.";
+    case "source-changed":
+      return "The ride changed while the latest refresh was running.";
+    case "temporary-failure":
+      return "The latest refresh did not finish.";
+  }
+}
 
 export function trainingStatusCopy(status: TrainingContextStatus): string {
   if (status === "loading") return "Loading training data…";

--- a/apps/desktop-renderer/tests/activity-analysis-controller.test.ts
+++ b/apps/desktop-renderer/tests/activity-analysis-controller.test.ts
@@ -1,0 +1,166 @@
+import type { CoachClient } from "@enduragent/coach-client";
+import type { ActivityAnalysisResult } from "@enduragent/coach-contract";
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
+import {
+  createRideAnalysisController,
+  type RideAnalysisViewState,
+} from "../src/activity-analysis/controller.js";
+
+const FIRST = "a".repeat(64);
+const SECOND = "b".repeat(64);
+const REVISION = "c".repeat(64);
+
+function result(id = FIRST): ActivityAnalysisResult {
+  return {
+    schemaVersion: 1,
+    activity: {
+      id,
+      workoutId: "d".repeat(64),
+      sessionSequence: 0,
+      isMultisport: false,
+      sport: "cycling",
+      subSport: "road",
+      isTransition: false,
+      startEpochSeconds: 899_985_600,
+      timezoneOffsetSeconds: 0,
+      localDate: "1998-07-06",
+      elapsedSeconds: 3_600,
+      timerSeconds: 3_600,
+      movingSeconds: 3_600,
+      distanceMeters: 36_000,
+    },
+    revision: REVISION,
+    sections: {
+      aerobicDrift: {
+        kind: "computed",
+        data: {
+          method: "local-time-weighted-efficiency-factor",
+          firstHalf: {
+            durationSeconds: 1_800,
+            sampleCount: 1_800,
+            averagePowerWatts: 200,
+            averageHeartRateBpm: 140,
+            efficiencyFactor: 1.43,
+          },
+          secondHalf: {
+            durationSeconds: 1_800,
+            sampleCount: 1_800,
+            averagePowerWatts: 200,
+            averageHeartRateBpm: 145,
+            efficiencyFactor: 1.38,
+          },
+          decouplingPercent: 3.5,
+          coverage: {
+            totalSamples: 3_600,
+            validSamples: 3_600,
+            includedDurationSeconds: 3_600,
+            windowDurationSeconds: 3_600,
+            fraction: 1,
+          },
+          evidence: "standard",
+          limitations: [],
+        },
+        provenance: {
+          source: "local-canonical",
+          delivery: "live",
+          observedAt: "1998-07-06T12:00:00.000Z",
+        },
+      },
+    },
+  };
+}
+
+function setup(call: CoachClient["call"]) {
+  const states: RideAnalysisViewState[] = [];
+  const client = { call } as CoachClient;
+  const clients: DesktopCoachClientProvider = {
+    getClient: vi.fn(async () => client),
+    reconnect: vi.fn(async () => client),
+    close: vi.fn(async () => {}),
+  };
+  const controller = createRideAnalysisController({
+    clients,
+    view: { render: (state) => states.push(state) },
+  });
+  return { controller, states, clients };
+}
+
+describe("ride analysis controller", () => {
+  it("loads the drift section for a selected canonical ride", async () => {
+    const call = vi.fn(async () => result()) as unknown as CoachClient["call"];
+    const { controller, states } = setup(call);
+
+    await controller.select(FIRST);
+
+    expect(call).toHaveBeenCalledWith(
+      "getActivityAnalysis",
+      { canonicalActivityId: FIRST, sections: ["aerobic-drift"] },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(states.at(-1)).toMatchObject({
+      activityId: FIRST,
+      status: "ready",
+      revision: REVISION,
+      sections: { aerobicDrift: { kind: "computed" } },
+    });
+    expect(JSON.stringify(states.at(-1))).not.toContain("provider-");
+  });
+
+  it("aborts obsolete work and ignores its late failure when the selection changes", async () => {
+    const calls: string[] = [];
+    const call = vi.fn(
+      (
+        _method: string,
+        request: { canonicalActivityId: string },
+        options?: { signal?: AbortSignal },
+      ) => {
+        calls.push(request.canonicalActivityId);
+        if (request.canonicalActivityId === SECOND) return Promise.resolve(result(SECOND));
+        return new Promise((_, reject) => {
+          options?.signal?.addEventListener("abort", () => reject(new Error("private abort")), {
+            once: true,
+          });
+        });
+      },
+    ) as unknown as CoachClient["call"];
+    const { controller, states } = setup(call);
+
+    const first = controller.select(FIRST);
+    await vi.waitFor(() => expect(calls).toEqual([FIRST]));
+    await controller.select(SECOND);
+    await first;
+
+    expect(states.at(-1)).toMatchObject({ activityId: SECOND, status: "ready" });
+  });
+
+  it("preserves completed evidence when a refresh transport fails", async () => {
+    let fail = false;
+    const call = vi.fn(async () => {
+      if (fail) throw new Error("private transport detail");
+      return result();
+    }) as unknown as CoachClient["call"];
+    const { controller, states } = setup(call);
+
+    await controller.select(FIRST);
+    fail = true;
+    await controller.load(["aerobic-drift"], true);
+
+    expect(states.at(-1)).toMatchObject({
+      activityId: FIRST,
+      status: "refresh-unavailable",
+      sections: { aerobicDrift: { kind: "computed" } },
+    });
+    expect(JSON.stringify(states.at(-1))).not.toContain("private transport detail");
+  });
+
+  it("clears analysis state and cancels work when the ride closes", async () => {
+    const call = vi.fn(async () => result()) as unknown as CoachClient["call"];
+    const { controller, states } = setup(call);
+    await controller.select(FIRST);
+
+    await controller.select(null);
+
+    expect(states.at(-1)).toMatchObject({ activityId: null, status: "idle", sections: {} });
+  });
+});

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -8,6 +8,7 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RideImportState } from "../src/ride-import.js";
+import { EMPTY_RIDE_ANALYSIS } from "../src/activity-analysis/controller.js";
 import { restoreManualSyncFocus } from "../src/state/manual-sync-focus.js";
 import { IDLE_RIDE_IMPORT } from "../src/state/ride-import-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
@@ -256,6 +257,8 @@ beforeEach(() => {
     activeView: "training",
     training: ready(),
     selectedRide: null,
+    rideAnalysis: EMPTY_RIDE_ANALYSIS,
+    rideAnalysisActions: null,
     sync: IDLE_MANUAL_SYNC,
     syncActions: null,
     rideImport: IDLE_RIDE_IMPORT,
@@ -269,6 +272,8 @@ afterEach(() => {
     activeView: "chat",
     training: EMPTY_TRAINING_SURFACE,
     selectedRide: null,
+    rideAnalysis: EMPTY_RIDE_ANALYSIS,
+    rideAnalysisActions: null,
     sync: IDLE_MANUAL_SYNC,
     syncActions: null,
     rideImport: IDLE_RIDE_IMPORT,
@@ -343,6 +348,114 @@ describe("training page", () => {
     expect(within(recent).getByText("26.2 mi")).toBeInTheDocument();
     expect(within(recent).getByText("Distance unavailable")).toBeInTheDocument();
     expect(within(recent).getByText("1h 0m")).toBeInTheDocument();
+  });
+
+  it("shows a neutral, time-weighted local aerobic drift estimate with its limitations", async () => {
+    const user = userEvent.setup();
+    if (context.recentRides.kind !== "computed") throw new Error("expected fixture rides");
+    const ride = context.recentRides.items[0]!;
+    useEnduragentStore.setState({
+      rideAnalysis: {
+        activityId: ride.id,
+        status: "refresh-unavailable",
+        revision: "c".repeat(64),
+        loadingSections: [],
+        sections: {
+          aerobicDrift: {
+            kind: "computed",
+            data: {
+              method: "local-time-weighted-efficiency-factor",
+              firstHalf: {
+                durationSeconds: 1_650,
+                sampleCount: 1_650,
+                averagePowerWatts: 205,
+                averageHeartRateBpm: 140,
+                efficiencyFactor: 1.46,
+              },
+              secondHalf: {
+                durationSeconds: 1_650,
+                sampleCount: 1_650,
+                averagePowerWatts: 202,
+                averageHeartRateBpm: 145,
+                efficiencyFactor: 1.39,
+              },
+              decouplingPercent: 4.8,
+              coverage: {
+                totalSamples: 3_600,
+                validSamples: 3_300,
+                includedDurationSeconds: 3_300,
+                windowDurationSeconds: 3_600,
+                fraction: 3_300 / 3_600,
+              },
+              evidence: "limited",
+              limitations: ["duration-under-60-minutes", "moving-status-unavailable"],
+            },
+            provenance: {
+              source: "local-canonical",
+              delivery: "live",
+              observedAt: "1998-07-19T08:00:00.000Z",
+            },
+          },
+        },
+      },
+    });
+    render(<TrainingView />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Review road ride from 1998-07-09 · 22:00, 1h 31m, 42.1 km",
+      }),
+    );
+
+    const panel = screen.getByRole("region", { name: "Local aerobic drift estimate" });
+    expect(within(panel).getByText("+4.8%")).toHaveAccessibleName(
+      "Observed efficiency-factor change +4.8%",
+    );
+    expect(within(panel).getByText("1.46 EF")).toBeInTheDocument();
+    expect(within(panel).getByText("1.39 EF")).toBeInTheDocument();
+    expect(within(panel).getByText(/92% usable time/)).toBeInTheDocument();
+    expect(within(panel).getByText("Limited context")).toBeInTheDocument();
+    expect(
+      within(panel).getByText(
+        "No moving-status stream was available, so stopped time may be included.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(panel).getByText("Showing the previous result. The latest refresh did not finish."),
+    ).toBeInTheDocument();
+    expect(panel).not.toHaveTextContent("good");
+    expect(panel).not.toHaveTextContent("bad");
+    expect(document.body).not.toHaveTextContent(ride.id);
+  });
+
+  it("explains deterministic unavailable states without offering a pointless retry", async () => {
+    const user = userEvent.setup();
+    if (context.recentRides.kind !== "computed") throw new Error("expected fixture rides");
+    const ride = context.recentRides.items[0]!;
+    useEnduragentStore.setState({
+      rideAnalysis: {
+        activityId: ride.id,
+        status: "ready",
+        revision: "c".repeat(64),
+        loadingSections: [],
+        sections: { aerobicDrift: { kind: "unavailable", reason: "activity-too-short" } },
+      },
+      rideAnalysisActions: { refresh: vi.fn() },
+    });
+    render(<TrainingView />);
+    await user.click(
+      screen.getByRole("button", {
+        name: "Review road ride from 1998-07-09 · 22:00, 1h 31m, 42.1 km",
+      }),
+    );
+
+    const panel = screen.getByRole("region", { name: "Local aerobic drift estimate" });
+    expect(
+      within(panel).getByText(
+        "At least 30 usable minutes, with 15 minutes in each half, are required.",
+      ),
+    ).toBeInTheDocument();
+    expect(within(panel).queryByRole("button", { name: "Try again" })).not.toBeInTheDocument();
   });
 
   it("preserves a selected ride across temporary refresh failure and reconciles authoritative lists", () => {

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -155,6 +155,67 @@ function makeScript(
       if (request.method === "getAthleteState") {
         return response({ ...athleteState, lastSynced });
       }
+      if (request.method === "getActivityAnalysis") {
+        const canonicalActivityId = (request.params as { readonly canonicalActivityId: string })
+          .canonicalActivityId;
+        return response({
+          schemaVersion: 1,
+          activity: {
+            id: canonicalActivityId,
+            workoutId: "e".repeat(64),
+            sessionSequence: 0,
+            isMultisport: false,
+            sport: "cycling",
+            subSport: "road",
+            isTransition: false,
+            startEpochSeconds: 1_784_358_000,
+            timezoneOffsetSeconds: 18_000,
+            localDate: "2026-07-18",
+            elapsedSeconds: 5_460,
+            timerSeconds: 5_200,
+            movingSeconds: 5_100,
+            distanceMeters: 42_120,
+          },
+          revision: "f".repeat(64),
+          sections: {
+            aerobicDrift: {
+              kind: "computed",
+              data: {
+                method: "local-time-weighted-efficiency-factor",
+                firstHalf: {
+                  durationSeconds: 2_550,
+                  sampleCount: 2_550,
+                  averagePowerWatts: 205,
+                  averageHeartRateBpm: 140,
+                  efficiencyFactor: 1.46,
+                },
+                secondHalf: {
+                  durationSeconds: 2_550,
+                  sampleCount: 2_550,
+                  averagePowerWatts: 202,
+                  averageHeartRateBpm: 145,
+                  efficiencyFactor: 1.39,
+                },
+                decouplingPercent: 4.8,
+                coverage: {
+                  totalSamples: 5_460,
+                  validSamples: 5_100,
+                  includedDurationSeconds: 5_100,
+                  windowDurationSeconds: 5_460,
+                  fraction: 5_100 / 5_460,
+                },
+                evidence: "limited",
+                limitations: ["moving-status-unavailable"],
+              },
+              provenance: {
+                source: "local-canonical",
+                delivery: "live",
+                observedAt: "2026-07-19T08:00:00.000Z",
+              },
+            },
+          },
+        });
+      }
       if (request.method === "getUnitsPreference") {
         return response({ value: units, source: units === "metric" ? "default" : "cycling" });
       }
@@ -1320,6 +1381,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly canonicalIdVisible: boolean;
       readonly pageOverflow: boolean;
       readonly documentOverflow: boolean;
+      readonly drift: string;
+      readonly limitation: string;
     }>(`
       const recent = document.querySelector('[data-panel="recent-rides"]');
       const opener = recent.querySelector("button");
@@ -1330,6 +1393,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
       const page = document.querySelector('section[aria-label="Ride review"]');
+      const analysisDeadline = Date.now() + 5000;
+      while (!page.textContent.includes("+4.8%") && Date.now() < analysisDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
       const title = page.querySelector("h1");
       return {
         page: page.getAttribute("aria-label"),
@@ -1340,6 +1407,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
           (node) => node.scrollWidth > node.clientWidth,
         ),
         documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+        drift: page.querySelector('[aria-label^="Observed efficiency-factor change"]')?.textContent ?? "",
+        limitation: page.querySelector('[aria-label="Analysis limitations"]')?.textContent ?? "",
       };
     `);
     expect(rideReview).toEqual({
@@ -1349,6 +1418,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       canonicalIdVisible: false,
       pageOverflow: false,
       documentOverflow: false,
+      drift: "+4.8%",
+      limitation: "No moving-status stream was available, so stopped time may be included.",
     });
     const rideReturn = await fixture.evaluate<{
       readonly page: string | null;
@@ -1434,6 +1505,13 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     ]);
     expect(calls.filter((call) => call.method === "setUnitsPreference")).toEqual([
       { jsonrpc: "2.0", method: "setUnitsPreference", params: { value: "imperial" } },
+    ]);
+    expect(calls.filter((call) => call.method === "getActivityAnalysis")).toEqual([
+      {
+        jsonrpc: "2.0",
+        method: "getActivityAnalysis",
+        params: { canonicalActivityId: "c".repeat(64), sections: ["aerobic-drift"] },
+      },
     ]);
     await fixture.setViewport(720, 800);
     const compactTrainingGeometry = await fixture.evaluate<{

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -383,6 +383,11 @@ export async function launchDesktopFixture(input: {
         ReturnType<CoachOperations["getArchivedTranscriptPage"]>
       >;
     },
+    async getActivityAnalysis(request) {
+      return finalFrame(await invoke("getActivityAnalysis", request)) as Awaited<
+        ReturnType<NonNullable<CoachOperations["getActivityAnalysis"]>>
+      >;
+    },
     async configureRuntime(request) {
       return finalFrame(await invoke("configureRuntime", request)) as Awaited<
         ReturnType<CoachOperations["configureRuntime"]>

--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -43,6 +43,7 @@
     "@enduragent/kernel-node": "workspace:*",
     "@enduragent/sync-intervals-icu": "workspace:*",
     "@enduragent/sport-cycling": "workspace:*",
+    "intervals-icu-api": "0.3.1",
     "ws": "^8.20.0",
     "yaml": "^2.8.3"
   },

--- a/packages/coach/src/activity-analysis-archive.ts
+++ b/packages/coach/src/activity-analysis-archive.ts
@@ -1,0 +1,74 @@
+import { canonicalJson, type ArchiveManager } from "@enduragent/kernel/archive";
+import type { IntervalsSourceRepository, SqlStore } from "@enduragent/kernel/store";
+import type {
+  ProviderActivityStreamArchive,
+  ProviderActivityStreamArchiveRequest,
+} from "./activity-analysis-provider.js";
+
+interface TransactionalStore extends SqlStore {
+  transaction<T>(work: () => Promise<T>): Promise<T>;
+}
+
+export function createProviderActivityStreamArchive(input: {
+  readonly archive: Pick<ArchiveManager, "writeSnapshot">;
+  readonly store: TransactionalStore;
+  readonly sources: Pick<IntervalsSourceRepository, "recordArtifact" | "recordGenericLanding">;
+  readonly runExclusive: <T>(work: () => Promise<T>) => Promise<T>;
+  readonly now: () => number;
+}): ProviderActivityStreamArchive {
+  return Object.freeze({
+    async write(request: ProviderActivityStreamArchiveRequest) {
+      request.signal.throwIfAborted();
+      const snapshot = JSON.parse(
+        JSON.stringify({
+          schema_version: 1,
+          source_revision: request.sourceRevision,
+          descriptors: request.descriptors,
+        }),
+      ) as {
+        readonly schema_version: 1;
+        readonly source_revision: string;
+        readonly descriptors: readonly {
+          readonly type: string;
+          readonly data: readonly unknown[];
+        }[];
+      };
+      const epochMilliseconds = input.now();
+      if (!Number.isSafeInteger(epochMilliseconds) || epochMilliseconds < 0) {
+        throw new TypeError("activity analysis archive clock is invalid");
+      }
+      const epochSeconds = Math.floor(epochMilliseconds / 1_000);
+      const archived = await input.archive.writeSnapshot(snapshot, { epochSeconds });
+      request.signal.throwIfAborted();
+      const externalId = `streams:analysis:${request.sourceRevision}:${archived.address}`;
+      const landing = canonicalJson({
+        descriptor_count: snapshot.descriptors.length,
+        sample_counts: snapshot.descriptors.map((descriptor) => descriptor.data.length),
+        schema_version: 1,
+        source_revision: request.sourceRevision,
+        types: snapshot.descriptors.map((descriptor) => descriptor.type),
+      });
+      await input.runExclusive(() =>
+        input.store.transaction(async () => {
+          const artifact = await input.sources.recordArtifact({
+            source: "intervals-icu",
+            lane: "streams",
+            externalId,
+            artifactKind: "snapshot",
+            archiveAddress: archived.address,
+            archiveRelPath: archived.relPath,
+            archiveEpochSeconds: epochSeconds,
+          });
+          await input.sources.recordGenericLanding({
+            externalId,
+            artifactKey: artifact.artifactKey,
+            archiveAddress: archived.address,
+            endpoint: "streams",
+            normalizedPayloadJson: landing,
+          });
+        }),
+      );
+      request.signal.throwIfAborted();
+    },
+  });
+}

--- a/packages/coach/src/activity-analysis-provider.ts
+++ b/packages/coach/src/activity-analysis-provider.ts
@@ -1,0 +1,189 @@
+import { makeAbortableClient } from "@enduragent/core";
+import type { AnalysisUnavailableReason } from "@enduragent/coach-contract";
+import type {
+  ActivityStream,
+  ApiError,
+  IntervalsClient,
+  NormalizedActivityStreams,
+} from "intervals-icu-api";
+import { ActivityAnalysisComputationError } from "./activity-analysis-service.js";
+
+export const ACTIVITY_STREAM_RESPONSE_LIMIT_BYTES = 16 * 1_024 * 1_024;
+const MAX_STREAM_DESCRIPTORS = 16;
+const MAX_STREAM_SAMPLES = 1_000_000;
+const MAX_TOTAL_STREAM_SAMPLES = 4_000_000;
+const PROVIDER_REQUEST_TIMEOUT_MS = 30_000;
+const REQUESTED_STREAMS = ["time", "watts", "heartrate", "moving"] as const;
+
+export interface ProviderActivityStreamArchive {
+  write(input: ProviderActivityStreamArchiveRequest): Promise<void>;
+}
+
+export interface ProviderActivityStreamArchiveRequest {
+  readonly sourceRevision: string;
+  readonly descriptors: readonly ActivityStream[];
+  readonly signal: AbortSignal;
+}
+
+export type ProviderActivityStreamResult =
+  | { readonly kind: "available"; readonly streams: NormalizedActivityStreams }
+  | { readonly kind: "unavailable"; readonly reason: AnalysisUnavailableReason };
+
+export interface ProviderActivityStreamReader {
+  read(input: ProviderActivityStreamRequest): Promise<ProviderActivityStreamResult>;
+}
+
+export interface ProviderActivityStreamRequest {
+  readonly providerActivityId: string;
+  readonly sourceRevision: string;
+  readonly signal: AbortSignal;
+}
+
+interface ProviderStreamClient {
+  readonly activities: Pick<IntervalsClient["activities"], "getStreamMap">;
+}
+
+type ProviderStreamClientFactory = (input: {
+  readonly apiKey: string;
+  readonly athleteId: string;
+  readonly signal: AbortSignal;
+  readonly baseFetch: typeof globalThis.fetch;
+}) => ProviderStreamClient;
+
+function failure(error: ApiError, responseLimitExceeded: boolean, signal: AbortSignal): never {
+  signal.throwIfAborted();
+  if (responseLimitExceeded) throw new ActivityAnalysisComputationError("response-too-large");
+  if (error.kind === "RateLimit") throw new ActivityAnalysisComputationError("rate-limited");
+  if (error.kind === "Timeout") throw new ActivityAnalysisComputationError("timeout");
+  if (error.kind === "Network") throw new ActivityAnalysisComputationError("network");
+  if (error.kind === "Validation") throw new ActivityAnalysisComputationError("malformed-response");
+  if (error.kind === "NotFound") throw new ActivityAnalysisComputationError("provider-unavailable");
+  throw new ActivityAnalysisComputationError("provider-unavailable");
+}
+
+function boundedDescriptors(streams: NormalizedActivityStreams): boolean {
+  if (streams.descriptors.length > MAX_STREAM_DESCRIPTORS) return false;
+  let total = 0;
+  for (const descriptor of streams.descriptors) {
+    if (!Array.isArray(descriptor.data) || descriptor.data.length > MAX_STREAM_SAMPLES)
+      return false;
+    total += descriptor.data.length;
+    if (total > MAX_TOTAL_STREAM_SAMPLES) return false;
+  }
+  try {
+    return (
+      new TextEncoder().encode(JSON.stringify(streams.descriptors)).byteLength <=
+      ACTIVITY_STREAM_RESPONSE_LIMIT_BYTES
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function createBoundedActivityStreamFetch(input: {
+  readonly baseFetch: typeof globalThis.fetch;
+  readonly noteLimitExceeded: () => void;
+  readonly maximumBytes?: number;
+}): typeof globalThis.fetch {
+  const maximumBytes = input.maximumBytes ?? ACTIVITY_STREAM_RESPONSE_LIMIT_BYTES;
+  if (!Number.isSafeInteger(maximumBytes) || maximumBytes < 1) {
+    throw new TypeError("activity stream response limit is invalid");
+  }
+  return async (request, init) => {
+    const response = await input.baseFetch(request, init);
+    const declared = response.headers.get("content-length");
+    if (declared !== null) {
+      const bytes = Number(declared);
+      if (Number.isFinite(bytes) && bytes > maximumBytes) {
+        input.noteLimitExceeded();
+        await response.body?.cancel();
+        throw new Error("activity stream response exceeded its private byte limit");
+      }
+    }
+    if (response.body === null) return response;
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value.byteLength;
+      if (total > maximumBytes) {
+        input.noteLimitExceeded();
+        await reader.cancel();
+        throw new Error("activity stream response exceeded its private byte limit");
+      }
+      chunks.push(next.value);
+    }
+    const body = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+}
+
+export function createProviderActivityStreamReader(input: {
+  readonly credentials: {
+    read(): Promise<{ readonly apiKey: string; readonly athleteId: string }>;
+  };
+  readonly archive: ProviderActivityStreamArchive;
+  readonly createClient?: ProviderStreamClientFactory;
+  readonly baseFetch?: typeof globalThis.fetch;
+}): ProviderActivityStreamReader {
+  const createClient =
+    input.createClient ??
+    ((options) =>
+      makeAbortableClient({
+        apiKey: options.apiKey,
+        ...(options.athleteId.length === 0 ? {} : { athleteId: options.athleteId }),
+        signal: options.signal,
+        perRequestMs: PROVIDER_REQUEST_TIMEOUT_MS,
+        baseFetch: options.baseFetch,
+      }));
+  const reader: ProviderActivityStreamReader = {
+    async read(request: ProviderActivityStreamRequest) {
+      request.signal.throwIfAborted();
+      const credentials = await input.credentials.read();
+      request.signal.throwIfAborted();
+      if (credentials.apiKey.length === 0) {
+        throw new ActivityAnalysisComputationError("provider-unavailable");
+      }
+      let responseLimitExceeded = false;
+      const client = createClient({
+        apiKey: credentials.apiKey,
+        athleteId: credentials.athleteId,
+        signal: request.signal,
+        baseFetch: createBoundedActivityStreamFetch({
+          baseFetch: input.baseFetch ?? globalThis.fetch,
+          noteLimitExceeded: () => {
+            responseLimitExceeded = true;
+          },
+        }),
+      });
+      const result = await client.activities.getStreamMap(request.providerActivityId, {
+        types: REQUESTED_STREAMS,
+        includeDefaults: false,
+      });
+      request.signal.throwIfAborted();
+      if (!result.ok) failure(result.error, responseLimitExceeded, request.signal);
+      if (!boundedDescriptors(result.value)) {
+        throw new ActivityAnalysisComputationError("response-too-large");
+      }
+      await input.archive.write({
+        sourceRevision: request.sourceRevision,
+        descriptors: result.value.descriptors,
+        signal: request.signal,
+      });
+      request.signal.throwIfAborted();
+      return { kind: "available" as const, streams: result.value };
+    },
+  };
+  return Object.freeze(reader);
+}

--- a/packages/coach/src/aerobic-drift.ts
+++ b/packages/coach/src/aerobic-drift.ts
@@ -1,0 +1,254 @@
+import type { ActivityAnalysisData, AnalysisUnavailableReason } from "@enduragent/coach-contract";
+import type { CanonicalActivityReader } from "@enduragent/kernel/store";
+import {
+  calculateEfficiencyFactorDecoupling,
+  normalizeActivityStreams,
+  type ActivityStream,
+  type NormalizedActivityStreams,
+  type StreamAnalysisIssue,
+} from "intervals-icu-api";
+import type {
+  ActivityAnalysisSectionInput,
+  ActivityAnalysisSectionAnalyzer,
+  ActivityAnalysisSectionOutput,
+} from "./activity-analysis-service.js";
+import type { ProviderActivityStreamReader } from "./activity-analysis-provider.js";
+
+const MINIMUM_INCLUDED_SECONDS = 30 * 60;
+const MINIMUM_HALF_SECONDS = 15 * 60;
+const REFERENCE_DURATION_SECONDS = 60 * 60;
+const MINIMUM_COVERAGE = 0.8;
+const VARIABLE_OUTPUT_CV = 0.2;
+
+type AerobicDriftEvaluation =
+  | { readonly kind: "computed"; readonly data: ActivityAnalysisData["aerobicDrift"] }
+  | { readonly kind: "unavailable"; readonly reason: AnalysisUnavailableReason };
+
+function issueReason(issues: readonly StreamAnalysisIssue[]): AnalysisUnavailableReason {
+  if (issues.some((issue) => issue.kind === "DuplicateStream")) return "duplicate-stream";
+  if (issues.some((issue) => issue.kind === "LengthMismatch")) return "misaligned-stream";
+  if (issues.some((issue) => issue.kind === "InvalidTimeStream")) return "invalid-timestamps";
+  if (issues.some((issue) => issue.kind === "InvalidMovingStream")) {
+    return "moving-status-unavailable";
+  }
+  if (issues.some((issue) => issue.kind === "MissingStream")) return "missing-sensor-data";
+  if (issues.some((issue) => issue.kind === "ZeroEfficiencyFactor")) return "unstable-output";
+  return "unsuitable-activity";
+}
+
+function median(values: readonly number[]): number | undefined {
+  if (values.length === 0) return undefined;
+  const ordered = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(ordered.length / 2);
+  return ordered.length % 2 === 0 ? (ordered[middle - 1]! + ordered[middle]!) / 2 : ordered[middle];
+}
+
+function outputCoefficientOfVariation(streams: NormalizedActivityStreams): number | undefined {
+  const time = streams.getUnique("time");
+  const power = streams.getUnique("watts");
+  const heartRate = streams.getUnique("heartrate");
+  const moving = streams.getUnique("moving");
+  if (!time.ok || !power.ok || !heartRate.ok) return undefined;
+  if (!moving.ok && moving.error.kind !== "MissingStream") return undefined;
+  const timestamps = time.value.data as readonly number[];
+  const deltas = timestamps.slice(1).map((value, index) => value - timestamps[index]!);
+  const fallback = median(deltas) ?? 1;
+  let duration = 0;
+  let weightedOutput = 0;
+  let weightedOutputSquared = 0;
+  for (let index = 0; index < timestamps.length; index += 1) {
+    const watts = power.value.data[index];
+    const bpm = heartRate.value.data[index];
+    const isMoving = moving.ok ? moving.value.data[index] === true : true;
+    if (
+      typeof watts !== "number" ||
+      !Number.isFinite(watts) ||
+      typeof bpm !== "number" ||
+      !Number.isFinite(bpm) ||
+      bpm <= 0 ||
+      !isMoving
+    ) {
+      continue;
+    }
+    const weight = deltas[index] ?? fallback;
+    duration += weight;
+    weightedOutput += watts * weight;
+    weightedOutputSquared += watts * watts * weight;
+  }
+  if (!(duration > 0)) return undefined;
+  const mean = weightedOutput / duration;
+  if (!(mean > 0)) return undefined;
+  const variance = Math.max(0, weightedOutputSquared / duration - mean * mean);
+  return Math.sqrt(variance) / mean;
+}
+
+function hasLongTimestampGap(streams: NormalizedActivityStreams): boolean {
+  const time = streams.getUnique("time");
+  if (!time.ok) return false;
+  const values = time.value.data as readonly number[];
+  const deltas = values.slice(1).map((value, index) => value - values[index]!);
+  const sampleInterval = median(deltas);
+  if (sampleInterval === undefined) return false;
+  const maximumGap = Math.max(30, 5 * sampleInterval);
+  return deltas.some((gap) => gap > maximumGap);
+}
+
+function boundedResult(data: ActivityAnalysisData["aerobicDrift"]): boolean {
+  const halves = [data.firstHalf, data.secondHalf];
+  return (
+    Number.isFinite(data.decouplingPercent) &&
+    Math.abs(data.decouplingPercent) <= 1_000 &&
+    halves.every(
+      (half) =>
+        half.durationSeconds >= 0 &&
+        half.durationSeconds <= 7 * 86_400 &&
+        half.sampleCount >= 0 &&
+        half.sampleCount <= 1_000_000 &&
+        half.averagePowerWatts >= 0 &&
+        half.averagePowerWatts <= 100_000 &&
+        half.averageHeartRateBpm >= 0 &&
+        half.averageHeartRateBpm <= 400 &&
+        half.efficiencyFactor >= 0 &&
+        half.efficiencyFactor <= 100_000,
+    )
+  );
+}
+
+export function evaluateAerobicDrift(
+  source: NormalizedActivityStreams | readonly ActivityStream[],
+): AerobicDriftEvaluation {
+  const streams: NormalizedActivityStreams = Array.isArray(source)
+    ? normalizeActivityStreams(source)
+    : (source as NormalizedActivityStreams);
+  const result = calculateEfficiencyFactorDecoupling(streams, { outputStream: "watts" });
+  if (!result.ok) return { kind: "unavailable", reason: issueReason(result.error) };
+  if (hasLongTimestampGap(streams)) {
+    return { kind: "unavailable", reason: "invalid-timestamps" };
+  }
+  if (
+    result.value.coverage.includedDurationSeconds < MINIMUM_INCLUDED_SECONDS ||
+    result.value.firstHalf.durationSeconds < MINIMUM_HALF_SECONDS ||
+    result.value.secondHalf.durationSeconds < MINIMUM_HALF_SECONDS
+  ) {
+    return { kind: "unavailable", reason: "activity-too-short" };
+  }
+  if (result.value.coverage.fraction < MINIMUM_COVERAGE) {
+    return { kind: "unavailable", reason: "insufficient-coverage" };
+  }
+  const moving = streams.getUnique("moving");
+  const variability = outputCoefficientOfVariation(streams);
+  const limitations: ActivityAnalysisData["aerobicDrift"]["limitations"][number][] = [];
+  if (result.value.coverage.includedDurationSeconds < REFERENCE_DURATION_SECONDS) {
+    limitations.push("duration-under-60-minutes");
+  }
+  if (variability !== undefined && variability > VARIABLE_OUTPUT_CV) {
+    limitations.push("variable-output");
+  }
+  if (!moving.ok && moving.error.kind === "MissingStream") {
+    limitations.push("moving-status-unavailable");
+  }
+  const data: ActivityAnalysisData["aerobicDrift"] = {
+    method: "local-time-weighted-efficiency-factor",
+    firstHalf: {
+      durationSeconds: result.value.firstHalf.durationSeconds,
+      sampleCount: result.value.firstHalf.sampleCount,
+      averagePowerWatts: result.value.firstHalf.outputMean,
+      averageHeartRateBpm: result.value.firstHalf.heartRateMean,
+      efficiencyFactor: result.value.firstHalf.efficiencyFactor,
+    },
+    secondHalf: {
+      durationSeconds: result.value.secondHalf.durationSeconds,
+      sampleCount: result.value.secondHalf.sampleCount,
+      averagePowerWatts: result.value.secondHalf.outputMean,
+      averageHeartRateBpm: result.value.secondHalf.heartRateMean,
+      efficiencyFactor: result.value.secondHalf.efficiencyFactor,
+    },
+    decouplingPercent: result.value.decouplingPercent,
+    coverage: result.value.coverage,
+    evidence: limitations.length === 0 ? "standard" : "limited",
+    limitations,
+  };
+  return boundedResult(data)
+    ? { kind: "computed", data }
+    : { kind: "unavailable", reason: "unsuitable-activity" };
+}
+
+function localDescriptors(
+  channels: Readonly<Record<string, readonly (number | null)[]>>,
+): readonly ActivityStream[] {
+  const descriptors: ActivityStream[] = [];
+  if (channels.time !== undefined) descriptors.push({ type: "time", data: [...channels.time] });
+  if (channels.power !== undefined) descriptors.push({ type: "watts", data: [...channels.power] });
+  if (channels.heart_rate !== undefined) {
+    descriptors.push({ type: "heartrate", data: [...channels.heart_rate] });
+  }
+  return descriptors;
+}
+
+function canRetryFromProvider(reason: AnalysisUnavailableReason): boolean {
+  return (
+    reason === "missing-sensor-data" ||
+    reason === "duplicate-stream" ||
+    reason === "misaligned-stream" ||
+    reason === "invalid-timestamps" ||
+    reason === "malformed-response" ||
+    reason === "response-too-large"
+  );
+}
+
+function canonicalReadReason(error: unknown): AnalysisUnavailableReason {
+  if (error !== null && typeof error === "object" && "code" in error) {
+    const code = (error as { readonly code?: unknown }).code;
+    if (code === "stream_limit_exceeded") return "response-too-large";
+    if (code === "stream_decode_failed" || code === "invalid_row") return "malformed-response";
+  }
+  return "temporary-failure";
+}
+
+export function createAerobicDriftAnalyzer(input: {
+  readonly activities: Pick<CanonicalActivityReader, "getStreams">;
+  readonly provider?: ProviderActivityStreamReader;
+}): ActivityAnalysisSectionAnalyzer<"aerobicDrift"> {
+  return Object.freeze({
+    async analyze(
+      request: ActivityAnalysisSectionInput,
+    ): Promise<ActivityAnalysisSectionOutput<"aerobicDrift">> {
+      request.signal.throwIfAborted();
+      let local: AerobicDriftEvaluation;
+      try {
+        const streams = await input.activities.getStreams({
+          id: request.activity.id,
+          channels: ["time", "power", "heart_rate"],
+        });
+        request.signal.throwIfAborted();
+        local =
+          streams === undefined
+            ? { kind: "unavailable", reason: "activity-not-found" }
+            : evaluateAerobicDrift(localDescriptors(streams.channels));
+      } catch (error) {
+        request.signal.throwIfAborted();
+        local = { kind: "unavailable", reason: canonicalReadReason(error) };
+      }
+      if (local.kind === "computed") {
+        return { kind: "computed", data: local.data, source: "local-canonical" };
+      }
+      if (
+        !canRetryFromProvider(local.reason) ||
+        input.provider === undefined ||
+        request.source.kind !== "resolved"
+      ) {
+        return local;
+      }
+      const provider = await input.provider.read({
+        providerActivityId: request.source.providerActivityId,
+        sourceRevision: request.sourceRevision,
+        signal: request.signal,
+      });
+      if (provider.kind === "unavailable") return provider;
+      const evaluated = evaluateAerobicDrift(provider.streams);
+      return evaluated.kind === "computed"
+        ? { kind: "computed", data: evaluated.data, source: "provider" }
+        : evaluated;
+    },
+  });
+}

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -59,11 +59,14 @@ import {
 import {
   createAnchorRepository,
   createCanonicalActivityReader,
+  createIntervalsSourceRepository,
   createTrustedActivitySourceResolver,
+  H,
   type AnchorRepository,
 } from "@enduragent/kernel/store";
 import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import type { CoachStoreWriterContext } from "./runtime.js";
 import {
   type CoachEngine,
@@ -98,6 +101,9 @@ import { createCoachOperations } from "./operations.js";
 import type { CoachOperationsDependencies } from "./operations.js";
 import { createSpendMeterService, type SpendMeterService } from "./spend-meter.js";
 import { createStoredActivityAnalysisService } from "./activity-analysis-service.js";
+import { createAerobicDriftAnalyzer } from "./aerobic-drift.js";
+import { createProviderActivityStreamReader } from "./activity-analysis-provider.js";
+import { createProviderActivityStreamArchive } from "./activity-analysis-archive.js";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -1001,10 +1007,35 @@ export async function createLocalCoachComposition(
       },
     });
     const options = Object.freeze({ liveIntervals });
+    const analysisImport = createNodeImportRuntime({
+      archiveDir: input.home.archiveDir,
+      store: input.context.store,
+    });
+    const analysisCrypto = createNodeCrypto();
+    const analysisSources = createIntervalsSourceRepository(input.context.store, (fields) => {
+      if (fields.length === 0) throw new TypeError("empty key tuple");
+      return H(analysisCrypto, ...(fields as [string | number, ...(string | number)[]]));
+    });
+    const providerStreams = createProviderActivityStreamReader({
+      credentials: options.liveIntervals,
+      archive: createProviderActivityStreamArchive({
+        archive: analysisImport.archive,
+        store: input.context.store,
+        sources: analysisSources,
+        runExclusive: (work) => runtime!.runExclusive(work),
+        now,
+      }),
+    });
     const activityAnalysis = createStoredActivityAnalysisService({
       store: input.context.store,
       activities: canonicalActivities,
       sources: createTrustedActivitySourceResolver(input.context.store),
+      analyzers: {
+        aerobicDrift: createAerobicDriftAnalyzer({
+          activities: canonicalActivities,
+          provider: providerStreams,
+        }),
+      },
       runCacheWrite: (work) => runtime!.runExclusive(work),
       now,
     });

--- a/packages/coach/tests/activity-analysis-archive.test.ts
+++ b/packages/coach/tests/activity-analysis-archive.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+import { createProviderActivityStreamArchive } from "../src/activity-analysis-archive.js";
+
+const REVISION = "a".repeat(64);
+const ADDRESS = "b".repeat(64);
+const ARTIFACT = "c".repeat(64);
+
+function setup(input: { readonly abortAfterArchive?: AbortController } = {}) {
+  const events: string[] = [];
+  const snapshots: unknown[] = [];
+  const artifactDrafts: unknown[] = [];
+  const landingDrafts: unknown[] = [];
+  const store = {
+    exec: vi.fn(async () => {}),
+    run: vi.fn(async () => {}),
+    get: vi.fn(async () => undefined),
+    all: vi.fn(async () => []),
+    close: vi.fn(async () => {}),
+    async transaction<T>(work: () => Promise<T>): Promise<T> {
+      events.push("transaction:start");
+      const value = await work();
+      events.push("transaction:end");
+      return value;
+    },
+  };
+  const archive = createProviderActivityStreamArchive({
+    archive: {
+      async writeSnapshot(snapshot) {
+        events.push("archive");
+        snapshots.push(snapshot);
+        input.abortAfterArchive?.abort();
+        return { address: ADDRESS, relPath: `1998/07/${ADDRESS}.json.gz`, deduped: false };
+      },
+    },
+    store,
+    sources: {
+      async recordArtifact(draft) {
+        events.push("artifact");
+        artifactDrafts.push(draft);
+        return { artifactKey: ARTIFACT, inserted: true };
+      },
+      async recordGenericLanding(draft) {
+        events.push("landing");
+        landingDrafts.push(draft);
+        return true;
+      },
+    },
+    runExclusive: async (work) => {
+      events.push("exclusive");
+      return work();
+    },
+    now: () => Date.parse("1998-07-06T12:00:00.000Z"),
+  });
+  return { archive, events, snapshots, artifactDrafts, landingDrafts };
+}
+
+describe("provider activity stream archive", () => {
+  it("writes private evidence before publishing its bounded landing record", async () => {
+    const state = setup();
+    await state.archive.write({
+      sourceRevision: REVISION,
+      descriptors: [
+        { type: "time", data: [0, 1] },
+        { type: "watts", data: [200, 201] },
+      ],
+      signal: new AbortController().signal,
+    });
+
+    expect(state.events).toEqual([
+      "archive",
+      "exclusive",
+      "transaction:start",
+      "artifact",
+      "landing",
+      "transaction:end",
+    ]);
+    expect(state.snapshots[0]).toMatchObject({
+      schema_version: 1,
+      source_revision: REVISION,
+      descriptors: [
+        { type: "time", data: [0, 1] },
+        { type: "watts", data: [200, 201] },
+      ],
+    });
+    expect(state.artifactDrafts[0]).toMatchObject({
+      lane: "streams",
+      archiveAddress: ADDRESS,
+      externalId: `streams:analysis:${REVISION}:${ADDRESS}`,
+    });
+    expect(state.landingDrafts[0]).toMatchObject({
+      externalId: `streams:analysis:${REVISION}:${ADDRESS}`,
+      artifactKey: ARTIFACT,
+    });
+    expect(JSON.stringify(state.landingDrafts[0])).not.toContain("200");
+  });
+
+  it("does not publish store evidence after cancellation", async () => {
+    const controller = new AbortController();
+    const state = setup({ abortAfterArchive: controller });
+
+    await expect(
+      state.archive.write({
+        sourceRevision: REVISION,
+        descriptors: [{ type: "time", data: [0, 1] }],
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+
+    expect(state.events).toEqual(["archive"]);
+    expect(state.artifactDrafts).toEqual([]);
+    expect(state.landingDrafts).toEqual([]);
+  });
+
+  it("rejects an invalid archive clock before any store publication", async () => {
+    const state = setup();
+    const archive = createProviderActivityStreamArchive({
+      archive: { writeSnapshot: vi.fn() },
+      store: {} as never,
+      sources: {} as never,
+      runExclusive: vi.fn(),
+      now: () => Number.NaN,
+    });
+
+    await expect(
+      archive.write({
+        sourceRevision: REVISION,
+        descriptors: [{ type: "time", data: [0, 1] }],
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow("archive clock is invalid");
+    expect(state.events).toEqual([]);
+  });
+});

--- a/packages/coach/tests/activity-analysis-provider.test.ts
+++ b/packages/coach/tests/activity-analysis-provider.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { normalizeActivityStreams, type ActivityStream } from "intervals-icu-api";
+import {
+  createBoundedActivityStreamFetch,
+  createProviderActivityStreamReader,
+} from "../src/activity-analysis-provider.js";
+
+const REVISION = "a".repeat(64);
+const streams: ActivityStream[] = [
+  { type: "time", data: [0, 1] },
+  { type: "watts", data: [200, 200] },
+  { type: "heartrate", data: [140, 140] },
+];
+
+describe("provider activity stream reader", () => {
+  it("does not create a client without credentials", async () => {
+    const createClient = vi.fn();
+    const archive = { write: vi.fn() };
+    const reader = createProviderActivityStreamReader({
+      credentials: { read: async () => ({ apiKey: "", athleteId: "0" }) },
+      archive,
+      createClient,
+    });
+
+    await expect(
+      reader.read({
+        providerActivityId: "provider-1",
+        sourceRevision: REVISION,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toMatchObject({ code: "provider-unavailable" });
+    expect(createClient).not.toHaveBeenCalled();
+    expect(archive.write).not.toHaveBeenCalled();
+  });
+
+  it("archives bounded duplicate-safe evidence before returning it", async () => {
+    const order: string[] = [];
+    const normalized = normalizeActivityStreams(streams);
+    const reader = createProviderActivityStreamReader({
+      credentials: { read: async () => ({ apiKey: "secret", athleteId: "0" }) },
+      archive: {
+        write: async () => {
+          order.push("archive");
+        },
+      },
+      createClient: () => ({
+        activities: {
+          getStreamMap: async () => {
+            order.push("fetch");
+            return { ok: true as const, value: normalized };
+          },
+        },
+      }),
+    });
+
+    await expect(
+      reader.read({
+        providerActivityId: "provider-1",
+        sourceRevision: REVISION,
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ kind: "available", streams: normalized });
+    expect(order).toEqual(["fetch", "archive"]);
+  });
+
+  it("maps provider rate limits to a refresh failure without exposing response details", async () => {
+    const reader = createProviderActivityStreamReader({
+      credentials: { read: async () => ({ apiKey: "secret", athleteId: "0" }) },
+      archive: { write: vi.fn() },
+      createClient: () => ({
+        activities: {
+          getStreamMap: async () => ({
+            ok: false as const,
+            error: {
+              kind: "RateLimit" as const,
+              status: 429 as const,
+              retryAfterMs: 1,
+              body: "private",
+            },
+          }),
+        },
+      }),
+    });
+
+    await expect(
+      reader.read({
+        providerActivityId: "provider-1",
+        sourceRevision: REVISION,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toMatchObject({ code: "rate-limited" });
+  });
+});
+
+describe("bounded activity stream fetch", () => {
+  it("rejects declared and streamed bodies above the private byte limit", async () => {
+    const declared = vi.fn();
+    const declaredFetch = createBoundedActivityStreamFetch({
+      maximumBytes: 3,
+      noteLimitExceeded: declared,
+      baseFetch: async () => new Response("data", { headers: { "content-length": "4" } }),
+    });
+    await expect(declaredFetch("https://example.test")).rejects.toThrow("private byte limit");
+    expect(declared).toHaveBeenCalledOnce();
+
+    const streamed = vi.fn();
+    const streamedFetch = createBoundedActivityStreamFetch({
+      maximumBytes: 3,
+      noteLimitExceeded: streamed,
+      baseFetch: async () => new Response("data"),
+    });
+    await expect(streamedFetch("https://example.test")).rejects.toThrow("private byte limit");
+    expect(streamed).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/coach/tests/aerobic-drift.test.ts
+++ b/packages/coach/tests/aerobic-drift.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CanonicalActivityDetail } from "@enduragent/kernel/store";
+import { normalizeActivityStreams, type ActivityStream } from "intervals-icu-api";
+import { createAerobicDriftAnalyzer, evaluateAerobicDrift } from "../src/aerobic-drift.js";
+
+const ACTIVITY_ID = "a".repeat(64);
+const REVISION = "b".repeat(64);
+
+const activity: CanonicalActivityDetail = {
+  id: ACTIVITY_ID,
+  workoutId: "c".repeat(64),
+  sessionSequence: 0,
+  isMultisport: false,
+  sport: "cycling",
+  subSport: "road",
+  isTransition: false,
+  startEpochSeconds: 899_985_600,
+  timezoneOffsetSeconds: 0,
+  localDate: "1998-07-06",
+  elapsedSeconds: 3_600,
+  timerSeconds: 3_600,
+  movingSeconds: 3_600,
+  distanceMeters: 36_000,
+  laps: [],
+};
+
+function fixture(
+  input: {
+    readonly count?: number;
+    readonly times?: number[];
+    readonly power?: (index: number) => number | null;
+    readonly heartRate?: (index: number) => number | null;
+    readonly moving?: (index: number) => boolean;
+    readonly includeMoving?: boolean;
+  } = {},
+): ActivityStream[] {
+  const count = input.times?.length ?? input.count ?? 3_600;
+  const streams: ActivityStream[] = [
+    { type: "time", data: input.times ?? Array.from({ length: count }, (_, index) => index) },
+    {
+      type: "watts",
+      data: Array.from({ length: count }, (_, index) =>
+        input.power === undefined ? 200 : input.power(index),
+      ),
+    },
+    {
+      type: "heartrate",
+      data: Array.from({ length: count }, (_, index) =>
+        input.heartRate === undefined ? 140 : input.heartRate(index),
+      ),
+    },
+  ];
+  if (input.includeMoving !== false) {
+    streams.push({
+      type: "moving",
+      data: Array.from({ length: count }, (_, index) => input.moving?.(index) ?? true),
+    });
+  }
+  return streams;
+}
+
+describe("aerobic drift suitability", () => {
+  it("time-weights irregular constant streams to approximately zero drift", () => {
+    const result = evaluateAerobicDrift(
+      fixture({
+        times: [0, 300, 900, 1_500, 2_400, 3_300],
+      }),
+    );
+
+    expect(result.kind).toBe("computed");
+    if (result.kind !== "computed") return;
+    expect(result.data.decouplingPercent).toBeCloseTo(0, 10);
+    expect(result.data.coverage.fraction).toBe(1);
+    expect(result.data.evidence).toBe("standard");
+  });
+
+  it("reports a positive whole-ride estimate when heart rate rises at constant power", () => {
+    const result = evaluateAerobicDrift(
+      fixture({
+        heartRate: (index) => (index < 1_800 ? 140 : 150),
+      }),
+    );
+
+    expect(result.kind).toBe("computed");
+    if (result.kind !== "computed") return;
+    expect(result.data.decouplingPercent).toBeCloseTo(6.67, 1);
+    expect(result.data.firstHalf.averagePowerWatts).toBe(200);
+    expect(result.data.secondHalf.averageHeartRateBpm).toBe(150);
+  });
+
+  it("splits a sample that crosses the time midpoint without discarding time", () => {
+    const result = evaluateAerobicDrift(
+      fixture({
+        times: [0, 1_000, 1_700, 2_300, 3_000],
+      }),
+    );
+
+    expect(result.kind).toBe("computed");
+    if (result.kind !== "computed") return;
+    expect(result.data.firstHalf.durationSeconds).toBeCloseTo(1_850);
+    expect(result.data.secondHalf.durationSeconds).toBeCloseTo(1_850);
+    expect(result.data.coverage.includedDurationSeconds).toBeCloseTo(3_700);
+  });
+
+  it("uses the whole ride, including warm-up and cool-down", () => {
+    const result = evaluateAerobicDrift(
+      fixture({
+        power: (index) => (index < 600 ? 120 + index / 10 : index >= 3_000 ? 120 : 200),
+      }),
+    );
+
+    expect(result.kind).toBe("computed");
+    if (result.kind !== "computed") return;
+    expect(result.data.firstHalf.averagePowerWatts).not.toBe(200);
+    expect(result.data.secondHalf.averagePowerWatts).not.toBe(200);
+    expect(result.data.coverage.windowDurationSeconds).toBe(3_600);
+  });
+
+  it("excludes stopped time only when a valid moving stream is present", () => {
+    const result = evaluateAerobicDrift(fixture({ moving: (index) => index % 10 !== 0 }));
+
+    expect(result.kind).toBe("computed");
+    if (result.kind !== "computed") return;
+    expect(result.data.coverage.fraction).toBeCloseTo(0.9);
+    expect(result.data.limitations).toEqual(["duration-under-60-minutes"]);
+  });
+
+  it("fails closed for invalid moving samples", () => {
+    const streams = fixture();
+    streams.at(-1)!.data[3] = 1;
+    expect(evaluateAerobicDrift(streams)).toEqual({
+      kind: "unavailable",
+      reason: "moving-status-unavailable",
+    });
+  });
+
+  it("rejects long gaps, short rides, sparse coverage, and duplicate sensors", () => {
+    const gapTimes = Array.from({ length: 3_600 }, (_, index) =>
+      index < 1_800 ? index : index + 60,
+    );
+    expect(evaluateAerobicDrift(fixture({ times: gapTimes }))).toEqual({
+      kind: "unavailable",
+      reason: "invalid-timestamps",
+    });
+    expect(evaluateAerobicDrift(fixture({ count: 1_799 }))).toEqual({
+      kind: "unavailable",
+      reason: "activity-too-short",
+    });
+    expect(
+      evaluateAerobicDrift(
+        fixture({
+          heartRate: (index) => (index % 10 < 7 ? 140 : null),
+        }),
+      ),
+    ).toEqual({ kind: "unavailable", reason: "insufficient-coverage" });
+    expect(
+      evaluateAerobicDrift([
+        ...fixture(),
+        { type: "heartrate", data: Array.from({ length: 3_600 }, () => 140) },
+      ]),
+    ).toEqual({ kind: "unavailable", reason: "duplicate-stream" });
+  });
+
+  it("keeps usable but limited estimates visible with explicit limitations", () => {
+    const short = evaluateAerobicDrift(fixture({ count: 2_700, includeMoving: false }));
+    expect(short.kind).toBe("computed");
+    if (short.kind !== "computed") return;
+    expect(short.data.evidence).toBe("limited");
+    expect(short.data.limitations).toEqual([
+      "duration-under-60-minutes",
+      "moving-status-unavailable",
+    ]);
+
+    const variable = evaluateAerobicDrift(
+      fixture({
+        power: (index) => (index % 2 === 0 ? 100 : 300),
+      }),
+    );
+    expect(variable.kind).toBe("computed");
+    if (variable.kind !== "computed") return;
+    expect(variable.data.limitations).toEqual(["variable-output"]);
+  });
+});
+
+describe("aerobic drift analyzer acquisition", () => {
+  it("uses canonical streams without contacting the provider", async () => {
+    const providerRead = vi.fn();
+    const analyzer = createAerobicDriftAnalyzer({
+      activities: {
+        getStreams: async () => ({
+          activityId: ACTIVITY_ID,
+          channels: {
+            time: fixture()[0]!.data as number[],
+            power: fixture()[1]!.data as number[],
+            heart_rate: fixture()[2]!.data as number[],
+          },
+        }),
+      },
+      provider: { read: providerRead },
+    });
+
+    await expect(
+      analyzer.analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "resolved", providerActivityId: "provider-1" as never },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({
+      kind: "computed",
+      source: "local-canonical",
+      data: { limitations: ["moving-status-unavailable"] },
+    });
+    expect(providerRead).not.toHaveBeenCalled();
+  });
+
+  it("falls back to duplicate-safe provider streams when canonical sensors are absent", async () => {
+    const providerRead = vi.fn(async () => ({
+      kind: "available" as const,
+      streams: normalizeActivityStreams(fixture()),
+    }));
+    const analyzer = createAerobicDriftAnalyzer({
+      activities: {
+        getStreams: async () => ({
+          activityId: ACTIVITY_ID,
+          channels: { time: Array.from({ length: 3_600 }, (_, index) => index) },
+        }),
+      },
+      provider: { read: providerRead },
+    });
+
+    await expect(
+      analyzer.analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "resolved", providerActivityId: "provider-1" as never },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({ kind: "computed", source: "provider" });
+    expect(providerRead).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerActivityId: "provider-1",
+        sourceRevision: REVISION,
+      }),
+    );
+  });
+
+  it("does not send file-only activity identity to a provider", async () => {
+    const providerRead = vi.fn();
+    const analyzer = createAerobicDriftAnalyzer({
+      activities: {
+        getStreams: async () => ({ activityId: ACTIVITY_ID, channels: {} }),
+      },
+      provider: { read: providerRead },
+    });
+
+    await expect(
+      analyzer.analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "unavailable", reason: "source-not-found" },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ kind: "unavailable", reason: "missing-sensor-data" });
+    expect(providerRead).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,7 +44,7 @@ export * from "./reference/index.js";
 export { bootstrapReference } from "./reference/runtime.js";
 export type { BootstrapReferenceDeps, ReferenceRuntime } from "./reference/runtime.js";
 export { wrapFetchWithSignal } from "./reference/sync/intervals-client-factory.js";
-export { makeChatClient } from "./reference/sync/intervals-client-factory.js";
+export { makeAbortableClient, makeChatClient } from "./reference/sync/intervals-client-factory.js";
 
 export {
   appendUsageLine,

--- a/packages/core/src/reference/sync/intervals-client-factory.ts
+++ b/packages/core/src/reference/sync/intervals-client-factory.ts
@@ -170,12 +170,13 @@ export function makeAbortableClient(opts: {
   signal: AbortSignal;
   perRequestMs: number;
   attemptLedger?: PhysicalRequestLedger;
+  baseFetch?: typeof globalThis.fetch;
 }): IntervalsClient {
   return new IntervalsClient({
     apiKey: opts.apiKey,
     athleteId: opts.athleteId,
     fetch: wrapFetchWithSignal({
-      baseFetch: wrapFetchWithSharedBucket(globalThis.fetch),
+      baseFetch: wrapFetchWithSharedBucket(opts.baseFetch ?? globalThis.fetch),
       outer: opts.signal,
       perRequestMs: opts.perRequestMs,
       attemptLedger: opts.attemptLedger,

--- a/packages/core/tests/reference-intervals-client-factory.test.ts
+++ b/packages/core/tests/reference-intervals-client-factory.test.ts
@@ -29,7 +29,10 @@ function mockAbortSignalTimeout(): ReturnType<typeof vi.spyOn> {
   return vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
     const controller = new AbortController();
     setTimeout(
-      () => controller.abort(new DOMException("The operation was aborted due to timeout", "TimeoutError")),
+      () =>
+        controller.abort(
+          new DOMException("The operation was aborted due to timeout", "TimeoutError"),
+        ),
       ms,
     );
     return controller.signal;
@@ -120,10 +123,16 @@ describe("wrapFetchWithSignal", () => {
   it("charges the shared legacy ceiling immediately before the physical fetch", async () => {
     const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
     const baseFetch = vi.fn(async () => new Response("ok"));
-    const wrapped = wrapFetchWithSignal({ baseFetch, outer: new AbortController().signal,
-      perRequestMs: 30_000, attemptLedger: ledger });
+    const wrapped = wrapFetchWithSignal({
+      baseFetch,
+      outer: new AbortController().signal,
+      perRequestMs: 30_000,
+      attemptLedger: ledger,
+    });
     for (let index = 0; index < 15; index += 1) await wrapped(`https://example.test/${index}`);
-    await expect(wrapped("https://example.test/rejected")).rejects.toBeInstanceOf(PhysicalRequestLimitError);
+    await expect(wrapped("https://example.test/rejected")).rejects.toBeInstanceOf(
+      PhysicalRequestLimitError,
+    );
     expect(baseFetch).toHaveBeenCalledTimes(15);
     expect(ledger.snapshot()).toMatchObject({ legacyRequests: 15, totalRequests: 15 });
   });
@@ -233,6 +242,31 @@ describe("makeAbortableClient", () => {
       perRequestMs: 30_000,
     });
     expect(client).toBeInstanceOf(IntervalsClient);
+  });
+
+  it("uses an injected transport while preserving the operation-scoped signal", async () => {
+    const outer = new AbortController();
+    let captured: AbortSignal | undefined;
+    const baseFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      captured = init?.signal ?? undefined;
+      return new Response("[]", { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const client = makeAbortableClient({
+      apiKey: "test-key",
+      signal: outer.signal,
+      perRequestMs: 30_000,
+      baseFetch: baseFetch as unknown as typeof globalThis.fetch,
+    });
+
+    await expect(
+      client.activities.getStreamMap("activity-1", {
+        types: ["time"],
+        includeDefaults: false,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(baseFetch).toHaveBeenCalledOnce();
+    expect(captured).toBeInstanceOf(AbortSignal);
+    expect(captured!.aborted).toBe(false);
   });
 });
 
@@ -347,17 +381,27 @@ describe("makeIntervalsHttpFactory raw adapter", () => {
 
   it("injects Basic credentials while preserving raw response bytes and headers", async () => {
     const baseFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      expect(new Headers(init?.headers).get("authorization")).toBe(`Basic ${btoa(`${basicUser}:dummy`)}`);
+      expect(new Headers(init?.headers).get("authorization")).toBe(
+        `Basic ${btoa(`${basicUser}:dummy`)}`,
+      );
       expect(init?.method).toBe("POST");
       expect(init?.body).toEqual(new Uint8Array([1, 2]));
-      return new Response(new Uint8Array([9, 8]), { status: 201, headers: { "Retry-After": "120", "X-Test": "yes" } });
+      return new Response(new Uint8Array([9, 8]), {
+        status: 201,
+        headers: { "Retry-After": "120", "X-Test": "yes" },
+      });
     });
     const outer = new AbortController();
-    const port = makeIntervalsHttpFactory({ apiKey: "dummy", baseFetch: baseFetch as typeof globalThis.fetch })({
+    const port = makeIntervalsHttpFactory({
+      apiKey: "dummy",
+      baseFetch: baseFetch as typeof globalThis.fetch,
+    })({
       outer: outer.signal,
       perRequestTimeoutMs: 30_000,
     });
-    await expect(port.fetch({ method: "POST", url: "https://example.test/raw", body: new Uint8Array([1, 2]) })).resolves.toEqual({
+    await expect(
+      port.fetch({ method: "POST", url: "https://example.test/raw", body: new Uint8Array([1, 2]) }),
+    ).resolves.toEqual({
       status: 201,
       headers: { "retry-after": "120", "x-test": "yes" },
       body: new Uint8Array([9, 8]),
@@ -371,8 +415,13 @@ describe("makeIntervalsHttpFactory raw adapter", () => {
       outer: new AbortController().signal,
       perRequestTimeoutMs: 1_000,
     });
-    await expect(port.fetch({ method: "GET", url: "https://example.test/", headers: { Authorization: "dummy" } }))
-      .rejects.toThrow("authorization header is managed");
+    await expect(
+      port.fetch({
+        method: "GET",
+        url: "https://example.test/",
+        headers: { Authorization: "dummy" },
+      }),
+    ).rejects.toThrow("authorization header is managed");
   });
 
   it("creates a fresh run-scoped abort closure", async () => {
@@ -382,9 +431,16 @@ describe("makeIntervalsHttpFactory raw adapter", () => {
       return new Response();
     };
     const factory = makeIntervalsHttpFactory({ apiKey: "dummy", baseFetch });
-    const first = new AbortController(), second = new AbortController();
-    await factory({ outer: first.signal, perRequestTimeoutMs: 30_000 }).fetch({ method: "GET", url: "https://example.test/1" });
-    await factory({ outer: second.signal, perRequestTimeoutMs: 30_000 }).fetch({ method: "GET", url: "https://example.test/2" });
+    const first = new AbortController(),
+      second = new AbortController();
+    await factory({ outer: first.signal, perRequestTimeoutMs: 30_000 }).fetch({
+      method: "GET",
+      url: "https://example.test/1",
+    });
+    await factory({ outer: second.signal, perRequestTimeoutMs: 30_000 }).fetch({
+      method: "GET",
+      url: "https://example.test/2",
+    });
     first.abort();
     expect(signals[0]?.aborted).toBe(true);
     expect(signals[1]?.aborted).toBe(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       '@enduragent/sync-intervals-icu':
         specifier: workspace:*
         version: link:../sync-intervals-icu
+      intervals-icu-api:
+        specifier: 0.3.1
+        version: 0.3.1(typescript@6.0.3)
       ws:
         specifier: ^8.20.0
         version: 8.20.0


### PR DESCRIPTION
## Summary

- add a whole-ride, time-weighted local aerobic-drift estimate to Ride review
- prefer canonical local power, heart-rate, and time streams, with a one-request trusted provider fallback only when local stream structure is missing or invalid
- archive bounded provider evidence privately before publishing metadata, and keep raw streams, credentials, provider identity, and transport errors outside the renderer
- preserve last-good results across refresh failures and suppress cancelled or late responses
- present neutral evidence and explicit limitations without physiological grading or a good/bad threshold

## Binding acceptance criteria

- Canonical streams are used first; provider fallback requires a trusted resolved source and never receives file-only identity.
- Provider acquisition is cancellable, shares the provider request bucket, performs one library request, caps the transport at 16 MiB, and bounds descriptor/sample counts.
- Provider evidence is archived before store publication; the generic landing contains metadata only.
- The calculation uses the full ride, time-weighted halves, duplicate-safe stream normalization, and no warm-up/cool-down trimming.
- Analysis is unavailable for gaps above max(30 s, 5x median sample interval), under 30 included minutes, either half under 15 minutes, or under 80% coverage.
- Under 60 minutes, variable power above 0.20 CV, and missing moving status remain visible as limited evidence.
- Raw streams, provider identifiers, credentials, and private errors never cross the renderer boundary.
- Selection changes cancel obsolete work, late responses are ignored, revision changes do not merge incompatible sections, and refresh failure preserves last-good evidence.
- Desktop copy is neutral, accessible, responsive, and explicitly distinguishes this local estimate from intervals.icu's cleaned power/HR metric.
- A plain-English user-facing changeset is included.

## Verification

- `pnpm check`
- `pnpm test` (549 files passed; 8,248 tests passed)
- `pnpm s8a`
- focused coach, core, renderer, and controller tests
- real Electron ride-review integration scenario
- production desktop build (included in `pnpm check`)
- local privacy, cancellation, numerical-bound, and UI review

The optional external autoreview helper was not run because it would upload this private diff without explicit approval; local review and all repository gates above passed.
