### PR TITLE
feat(desktop): add interval and effort review

### DIFF
--- a/.changeset/interval-review-best-efforts.md
+++ b/.changeset/interval-review-best-efforts.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Ride review now shows ordered intervals or laps with available timing, distance, power, and heart-rate metrics, plus five-minute power efforts scoped explicitly to the selected ride.

--- a/apps/desktop-renderer/src/activity-analysis/controller.ts
+++ b/apps/desktop-renderer/src/activity-analysis/controller.ts
@@ -24,7 +24,14 @@ export interface RideAnalysisViewState {
   readonly revision: string | null;
   readonly sections: ActivityAnalysisResult["sections"];
   readonly loadingSections: readonly ActivityAnalysisSection[];
+  readonly failedSections: readonly ActivityAnalysisSection[];
 }
+
+export const DEFAULT_RIDE_ANALYSIS_SECTIONS = [
+  "aerobic-drift",
+  "intervals",
+  "best-efforts",
+] as const satisfies readonly ActivityAnalysisSection[];
 
 export const EMPTY_RIDE_ANALYSIS: RideAnalysisViewState = Object.freeze({
   activityId: null,
@@ -32,6 +39,7 @@ export const EMPTY_RIDE_ANALYSIS: RideAnalysisViewState = Object.freeze({
   revision: null,
   sections: Object.freeze({}),
   loadingSections: Object.freeze([]),
+  failedSections: Object.freeze([]),
 });
 
 export interface RideAnalysisView {
@@ -87,6 +95,7 @@ export function createRideAnalysisController(input: {
       ...state,
       status: "loading",
       loadingSections: requested,
+      failedSections: state.failedSections.filter((section) => !requested.includes(section)),
     });
     let client: CoachClient | undefined;
     try {
@@ -117,6 +126,7 @@ export function createRideAnalysisController(input: {
         revision: result.revision,
         sections: retain ? { ...state.sections, ...result.sections } : result.sections,
         loadingSections: [],
+        failedSections: state.failedSections.filter((section) => !requested.includes(section)),
       });
     } catch (error) {
       if (
@@ -137,6 +147,7 @@ export function createRideAnalysisController(input: {
         ...state,
         status: Object.keys(state.sections).length === 0 ? "unavailable" : "refresh-unavailable",
         loadingSections: [],
+        failedSections: [...new Set([...state.failedSections, ...requested])],
       });
     } finally {
       if (operation === controller) operation = undefined;
@@ -160,9 +171,10 @@ export function createRideAnalysisController(input: {
         status: "loading",
         revision: null,
         sections: {},
-        loadingSections: ["aerobic-drift"],
+        loadingSections: DEFAULT_RIDE_ANALYSIS_SECTIONS,
+        failedSections: [],
       });
-      await load(["aerobic-drift"]);
+      await load(DEFAULT_RIDE_ANALYSIS_SECTIONS);
     },
     load,
     dispose() {

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -85,8 +85,8 @@ export function bootRenderer(): Disposer {
     },
   });
   store.getState().bindRideAnalysisActions({
-    refresh: () => {
-      void rideAnalysisController.load(["aerobic-drift"], true);
+    refresh: (sections) => {
+      void rideAnalysisController.load(sections, true);
     },
   });
   let selectedAnalysisRide = store.getState().selectedRide?.id ?? null;

--- a/apps/desktop-renderer/src/state/activity-analysis-slice.ts
+++ b/apps/desktop-renderer/src/state/activity-analysis-slice.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from "zustand";
+import type { ActivityAnalysisSection } from "@enduragent/coach-contract";
 import {
   EMPTY_RIDE_ANALYSIS,
   type RideAnalysisViewState,
@@ -6,7 +7,7 @@ import {
 import type { EnduragentState } from "./store.js";
 
 export interface RideAnalysisActions {
-  refresh(): void;
+  refresh(sections: readonly ActivityAnalysisSection[]): void;
 }
 
 export interface ActivityAnalysisSlice {

--- a/apps/desktop-renderer/src/ui/training/RideReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideReview.tsx
@@ -1,11 +1,12 @@
 import type {
   ActivityAnalysisData,
+  ActivityAnalysisSection,
   AnalysisSection,
   RecentRide,
   RecentRidesPanel,
   UnitsPreference,
 } from "@enduragent/coach-contract";
-import type { ReactElement, Ref } from "react";
+import type { ReactElement, ReactNode, Ref } from "react";
 import type { RideAnalysisViewState } from "../../activity-analysis/controller.js";
 import { formatDateLabel } from "../../training-context/format.js";
 import { Page } from "../shared/Page.js";
@@ -223,14 +224,17 @@ function AerobicDriftPanel(props: {
 }): ReactElement {
   const matches = props.analysis.activityId === props.rideId;
   const section = matches ? props.analysis.sections.aerobicDrift : undefined;
+  const refreshing = matches && props.analysis.loadingSections.includes("aerobic-drift");
+  const clientRefreshUnavailable =
+    matches && props.analysis.failedSections.includes("aerobic-drift");
   let content: ReactElement;
   if (section?.kind === "computed") {
     content = (
       <DriftEvidence
         data={section.data}
         saved={section.provenance.delivery === "persisted-cache"}
-        refreshing={props.analysis.status === "loading"}
-        clientRefreshUnavailable={props.analysis.status === "refresh-unavailable"}
+        refreshing={refreshing}
+        clientRefreshUnavailable={clientRefreshUnavailable}
       />
     );
   } else if (section?.kind === "stale") {
@@ -248,7 +252,7 @@ function AerobicDriftPanel(props: {
         ) : null}
       </div>
     );
-  } else if (matches && props.analysis.status === "unavailable") {
+  } else if (clientRefreshUnavailable) {
     content = (
       <div className={styles.analysisUnavailable}>
         <p>The ride could not be analyzed right now.</p>
@@ -277,6 +281,328 @@ function AerobicDriftPanel(props: {
       <p className={styles.analysisIntro}>
         Compares power per heartbeat in the first and second time-weighted halves. This local
         estimate is distinct from intervals.icu's cleaned power/HR metric.
+      </p>
+      {content}
+    </section>
+  );
+}
+
+const INTERVAL_KIND_COPY: Readonly<
+  Record<ActivityAnalysisData["intervals"]["intervals"][number]["kind"], string>
+> = {
+  work: "Work",
+  recovery: "Recovery",
+  lap: "Lap",
+  unknown: "Segment",
+};
+
+function unavailableMetric(): ReactElement {
+  return <span aria-label="Unavailable">—</span>;
+}
+
+function durationMetric(seconds: number | null): ReactNode {
+  return seconds === null ? unavailableMetric() : formatAnalysisDuration(seconds);
+}
+
+function distanceMetric(meters: number | null, units: UnitsPreference): ReactNode {
+  if (meters === null) return unavailableMetric();
+  return units === "imperial"
+    ? `${(meters / 1_609.344).toFixed(1)} mi`
+    : `${(meters / 1_000).toFixed(1)} km`;
+}
+
+function sensorMetric(average: number | null, maximum: number | null, unit: string): ReactNode {
+  if (average === null && maximum === null) return unavailableMetric();
+  if (average === null) return `${Math.round(maximum!)} max ${unit}`;
+  if (maximum === null) return `${Math.round(average)} avg ${unit}`;
+  return `${Math.round(average)} avg · ${Math.round(maximum)} max ${unit}`;
+}
+
+function AnalysisRetry(props: {
+  readonly reason: Parameters<typeof analysisUnavailableCopy>[0] | null;
+  readonly onRefresh: (() => void) | null;
+  readonly fallback?: string;
+}): ReactElement {
+  const retry = props.reason === null || shouldOfferRetry(props.reason);
+  return (
+    <div className={styles.analysisUnavailable}>
+      <p>
+        {props.reason === null
+          ? (props.fallback ?? "This analysis could not be loaded right now.")
+          : analysisUnavailableCopy(props.reason)}
+      </p>
+      {props.onRefresh !== null && retry ? (
+        <button type="button" className={styles.action} onClick={props.onRefresh}>
+          Try again
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function AnalysisEvidenceStatus(props: {
+  readonly saved: boolean;
+  readonly refreshing: boolean;
+  readonly clientRefreshUnavailable: boolean;
+  readonly refreshFailure?: Extract<
+    AnalysisSection<unknown>,
+    { readonly kind: "stale" }
+  >["refreshFailure"];
+}): ReactElement | null {
+  const notice =
+    props.refreshFailure !== undefined
+      ? `Showing the saved result. ${analysisRefreshFailureCopy(props.refreshFailure.code)}`
+      : props.clientRefreshUnavailable
+        ? "Showing the previous result. The latest refresh did not finish."
+        : props.refreshing
+          ? "Refreshing this analysis…"
+          : props.saved
+            ? "Showing saved analysis."
+            : null;
+  return notice === null ? null : (
+    <p className={props.refreshing ? styles.analysisRefresh : styles.analysisNotice} role="status">
+      {notice}
+    </p>
+  );
+}
+
+function IntervalEvidence(props: {
+  readonly data: ActivityAnalysisData["intervals"];
+  readonly units: UnitsPreference;
+  readonly saved: boolean;
+  readonly refreshing: boolean;
+  readonly clientRefreshUnavailable: boolean;
+  readonly refreshFailure?: Extract<
+    AnalysisSection<ActivityAnalysisData["intervals"]>,
+    { readonly kind: "stale" }
+  >["refreshFailure"];
+}): ReactElement {
+  return (
+    <>
+      <AnalysisEvidenceStatus
+        saved={props.saved}
+        refreshing={props.refreshing}
+        clientRefreshUnavailable={props.clientRefreshUnavailable}
+        refreshFailure={props.refreshFailure}
+      />
+      <p className={styles.analysisSource}>
+        {props.data.source === "provider"
+          ? "Ordered analysis from intervals.icu"
+          : "Ordered laps from the local ride file"}
+        {props.data.groups.length === 0 ? "" : ` · ${props.data.groups.length} groups`}
+      </p>
+      {props.data.intervals.length === 0 ? (
+        <p className={styles.analysisEmpty}>No intervals or laps were found for this ride.</p>
+      ) : (
+        <ol className={styles.intervalList} aria-label="Ordered ride intervals and laps">
+          {props.data.intervals.map((interval) => (
+            <li key={interval.ordinal} className={styles.intervalItem} data-kind={interval.kind}>
+              <div className={styles.intervalIdentity}>
+                <span className={styles.intervalOrdinal} aria-hidden="true">
+                  {interval.ordinal}
+                </span>
+                <div>
+                  <span className={styles.intervalKind}>{INTERVAL_KIND_COPY[interval.kind]}</span>
+                  <h3>{interval.label ?? `Interval ${interval.ordinal}`}</h3>
+                  {interval.groupOrdinal === null ? null : <p>Group {interval.groupOrdinal}</p>}
+                </div>
+              </div>
+              <dl className={styles.intervalMetrics}>
+                <div>
+                  <dt>Duration</dt>
+                  <dd>{durationMetric(interval.movingSeconds ?? interval.elapsedSeconds)}</dd>
+                </div>
+                <div>
+                  <dt>Distance</dt>
+                  <dd>{distanceMetric(interval.distanceMeters, props.units)}</dd>
+                </div>
+                <div>
+                  <dt>Power</dt>
+                  <dd>
+                    {sensorMetric(interval.averagePowerWatts, interval.maximumPowerWatts, "W")}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Heart rate</dt>
+                  <dd>
+                    {sensorMetric(
+                      interval.averageHeartRateBpm,
+                      interval.maximumHeartRateBpm,
+                      "bpm",
+                    )}
+                  </dd>
+                </div>
+              </dl>
+            </li>
+          ))}
+        </ol>
+      )}
+    </>
+  );
+}
+
+function IntervalReviewPanel(props: {
+  readonly rideId: string;
+  readonly analysis: RideAnalysisViewState;
+  readonly units: UnitsPreference;
+  readonly onRefresh: (() => void) | null;
+}): ReactElement {
+  const matches = props.analysis.activityId === props.rideId;
+  const section = matches ? props.analysis.sections.intervals : undefined;
+  const refreshing = matches && props.analysis.loadingSections.includes("intervals");
+  const failed = matches && props.analysis.failedSections.includes("intervals");
+  let content: ReactElement;
+  if (section?.kind === "computed") {
+    content = (
+      <IntervalEvidence
+        data={section.data}
+        units={props.units}
+        saved={section.provenance.delivery === "persisted-cache"}
+        refreshing={refreshing}
+        clientRefreshUnavailable={failed}
+      />
+    );
+  } else if (section?.kind === "stale") {
+    content = (
+      <IntervalEvidence
+        data={section.lastGood.data}
+        units={props.units}
+        saved
+        refreshing={false}
+        clientRefreshUnavailable={false}
+        refreshFailure={section.refreshFailure}
+      />
+    );
+  } else if (section?.kind === "unavailable") {
+    content = <AnalysisRetry reason={section.reason} onRefresh={props.onRefresh} />;
+  } else if (failed) {
+    content = (
+      <AnalysisRetry
+        reason={null}
+        fallback="Intervals and laps could not be loaded right now."
+        onRefresh={props.onRefresh}
+      />
+    );
+  } else {
+    content = (
+      <p className={styles.analysisLoading} role="status">
+        Checking ride intervals…
+      </p>
+    );
+  }
+  return (
+    <section className={styles.analysisPanel} aria-labelledby="interval-review-title">
+      <p className={styles.rideEyebrow}>Ordered ride segments</p>
+      <h2 id="interval-review-title" className={styles.analysisTitle}>
+        Intervals and laps
+      </h2>
+      <p className={styles.analysisIntro}>
+        Shows recorded segments in order. Missing metrics stay unavailable, and no planned workout
+        targets are inferred.
+      </p>
+      {content}
+    </section>
+  );
+}
+
+function BestEffortEvidence(props: {
+  readonly data: ActivityAnalysisData["bestEfforts"];
+  readonly units: UnitsPreference;
+  readonly saved: boolean;
+  readonly refreshing: boolean;
+  readonly clientRefreshUnavailable: boolean;
+  readonly refreshFailure?: Extract<
+    AnalysisSection<ActivityAnalysisData["bestEfforts"]>,
+    { readonly kind: "stale" }
+  >["refreshFailure"];
+}): ReactElement {
+  return (
+    <>
+      <AnalysisEvidenceStatus
+        saved={props.saved}
+        refreshing={props.refreshing}
+        clientRefreshUnavailable={props.clientRefreshUnavailable}
+        refreshFailure={props.refreshFailure}
+      />
+      <p className={styles.analysisSource}>
+        This ride · power · {formatAnalysisDuration(props.data.scope.durationSeconds)} · equal
+        efforts rank the earlier start first
+      </p>
+      {props.data.efforts.length === 0 ? (
+        <p className={styles.analysisEmpty}>No five-minute power efforts were found.</p>
+      ) : (
+        <ol className={styles.effortList} aria-label="Five-minute power efforts in this ride">
+          {props.data.efforts.map((effort) => (
+            <li key={effort.rank} className={styles.effortItem}>
+              <span className={styles.effortRank}>#{effort.rank}</span>
+              <strong>{Math.round(effort.averageWatts)} W</strong>
+              <span>{distanceMetric(effort.distanceMeters, props.units)}</span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </>
+  );
+}
+
+function BestEffortPanel(props: {
+  readonly rideId: string;
+  readonly analysis: RideAnalysisViewState;
+  readonly units: UnitsPreference;
+  readonly onRefresh: (() => void) | null;
+}): ReactElement {
+  const matches = props.analysis.activityId === props.rideId;
+  const section = matches ? props.analysis.sections.bestEfforts : undefined;
+  const refreshing = matches && props.analysis.loadingSections.includes("best-efforts");
+  const failed = matches && props.analysis.failedSections.includes("best-efforts");
+  let content: ReactElement;
+  if (section?.kind === "computed") {
+    content = (
+      <BestEffortEvidence
+        data={section.data}
+        units={props.units}
+        saved={section.provenance.delivery === "persisted-cache"}
+        refreshing={refreshing}
+        clientRefreshUnavailable={failed}
+      />
+    );
+  } else if (section?.kind === "stale") {
+    content = (
+      <BestEffortEvidence
+        data={section.lastGood.data}
+        units={props.units}
+        saved
+        refreshing={false}
+        clientRefreshUnavailable={false}
+        refreshFailure={section.refreshFailure}
+      />
+    );
+  } else if (section?.kind === "unavailable") {
+    content = <AnalysisRetry reason={section.reason} onRefresh={props.onRefresh} />;
+  } else if (failed) {
+    content = (
+      <AnalysisRetry
+        reason={null}
+        fallback="Five-minute efforts could not be loaded right now."
+        onRefresh={props.onRefresh}
+      />
+    );
+  } else {
+    content = (
+      <p className={styles.analysisLoading} role="status">
+        Checking five-minute efforts…
+      </p>
+    );
+  }
+  return (
+    <section className={styles.analysisPanel} aria-labelledby="best-efforts-title">
+      <p className={styles.rideEyebrow}>Selected-ride scope</p>
+      <h2 id="best-efforts-title" className={styles.analysisTitle}>
+        Five-minute best efforts
+      </h2>
+      <p className={styles.analysisIntro}>
+        Ranks measured five-minute power efforts from this ride only. It does not compare against
+        other rides or all-history results.
       </p>
       {content}
     </section>
@@ -344,7 +670,7 @@ export function RideDetailView(props: {
   readonly ride: RecentRide;
   readonly units: UnitsPreference;
   readonly analysis: RideAnalysisViewState;
-  readonly onRefreshAnalysis: (() => void) | null;
+  readonly onRefreshAnalysis: ((sections: readonly ActivityAnalysisSection[]) => void) | null;
   readonly onBack: () => void;
   readonly titleRef: Ref<HTMLHeadingElement>;
 }): ReactElement {
@@ -367,7 +693,29 @@ export function RideDetailView(props: {
       <AerobicDriftPanel
         rideId={props.ride.id}
         analysis={props.analysis}
-        onRefresh={props.onRefreshAnalysis}
+        onRefresh={
+          props.onRefreshAnalysis === null
+            ? null
+            : () => props.onRefreshAnalysis?.(["aerobic-drift"])
+        }
+      />
+      <IntervalReviewPanel
+        rideId={props.ride.id}
+        analysis={props.analysis}
+        units={props.units}
+        onRefresh={
+          props.onRefreshAnalysis === null ? null : () => props.onRefreshAnalysis?.(["intervals"])
+        }
+      />
+      <BestEffortPanel
+        rideId={props.ride.id}
+        analysis={props.analysis}
+        units={props.units}
+        onRefresh={
+          props.onRefreshAnalysis === null
+            ? null
+            : () => props.onRefreshAnalysis?.(["best-efforts"])
+        }
       />
     </Page>
   );

--- a/apps/desktop-renderer/src/ui/training/TrainingView.module.css
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.module.css
@@ -537,6 +537,12 @@
   letter-spacing: -0.015em;
 }
 
+.analysisTitle {
+  margin: 0;
+  font: 600 21px/1.2 var(--f-dis);
+  letter-spacing: -0.015em;
+}
+
 .analysisIntro {
   max-width: 650px;
   margin: 9px 0 0;
@@ -695,6 +701,149 @@
   line-height: 1.45;
 }
 
+.analysisSource {
+  margin: 17px 0 0;
+  color: var(--ink-3);
+  font: 10px/1.5 var(--f-mono);
+  text-transform: uppercase;
+}
+
+.analysisEmpty {
+  margin: 16px 0 0;
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.intervalList {
+  display: grid;
+  gap: 9px;
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.intervalItem {
+  composes: sunken from "../../theme/surface.module.css";
+  display: grid;
+  grid-template-columns: minmax(155px, 0.72fr) minmax(0, 1.6fr);
+  gap: 16px;
+  align-items: center;
+  min-width: 0;
+  padding: 13px 14px;
+  border-left: 3px solid var(--line-2);
+}
+
+.intervalItem[data-kind="work"] {
+  border-left-color: var(--brand);
+}
+
+.intervalItem[data-kind="recovery"] {
+  border-left-color: var(--ink-3);
+}
+
+.intervalIdentity {
+  display: grid;
+  grid-template-columns: 27px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  min-width: 0;
+}
+
+.intervalOrdinal {
+  display: grid;
+  place-items: center;
+  width: 25px;
+  height: 25px;
+  border: 1px solid var(--line-2);
+  border-radius: 50%;
+  color: var(--ink-2);
+  font: 10px/1 var(--f-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.intervalKind {
+  color: var(--ink-3);
+  font: 9px/1 var(--f-mono);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.intervalIdentity h3 {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+  font: 600 13px/1.25 var(--f-dis);
+}
+
+.intervalIdentity p {
+  margin: 4px 0 0;
+  color: var(--ink-3);
+  font: 9.5px/1.3 var(--f-mono);
+}
+
+.intervalMetrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  min-width: 0;
+  margin: 0;
+}
+
+.intervalMetrics > div {
+  min-width: 0;
+}
+
+.intervalMetrics dt {
+  color: var(--ink-3);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.intervalMetrics dd {
+  margin: 5px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-2);
+  font: 10px/1.4 var(--f-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.effortList {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 9px;
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.effortItem {
+  composes: sunken from "../../theme/surface.module.css";
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 5px 10px;
+  align-items: baseline;
+  min-width: 0;
+  padding: 13px 14px;
+}
+
+.effortRank {
+  grid-row: 1 / span 2;
+  color: var(--ink-3);
+  font: 10px/1 var(--f-mono);
+}
+
+.effortList strong {
+  font: 600 20px/1.1 var(--f-dis);
+  font-variant-numeric: tabular-nums;
+}
+
+.effortItem > span:last-child {
+  overflow-wrap: anywhere;
+  color: var(--ink-3);
+  font: 9.5px/1.4 var(--f-mono);
+}
+
 .rideEyebrow {
   margin: 0 0 8px;
   color: var(--ink-3);
@@ -766,6 +915,18 @@
     grid-row: 1 / span 2;
     grid-column: 3;
   }
+
+  .intervalItem {
+    grid-template-columns: 1fr;
+  }
+
+  .intervalMetrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .effortList {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 520px) {
@@ -790,6 +951,11 @@
   .driftConnector {
     height: 18px;
     transform: rotate(90deg);
+  }
+
+  .intervalMetrics,
+  .effortList {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -335,7 +335,9 @@ export function TrainingView(): ReactElement {
         ride={selectedRide}
         units={training.unitsPreference.value}
         analysis={rideAnalysis}
-        onRefreshAnalysis={rideAnalysisActions?.refresh ?? null}
+        onRefreshAnalysis={
+          rideAnalysisActions === null ? null : (sections) => rideAnalysisActions.refresh(sections)
+        }
         titleRef={title}
         onBack={closeRide}
       />

--- a/apps/desktop-renderer/src/ui/training/copy.ts
+++ b/apps/desktop-renderer/src/ui/training/copy.ts
@@ -72,9 +72,10 @@ export function analysisUnavailableCopy(reason: AnalysisUnavailableReason): stri
     case "activity-not-found":
       return "This ride is no longer available in local training history.";
     case "source-not-found":
-    case "ambiguous-source":
     case "not-provider-backed":
-      return "No trusted stream source is available for this ride.";
+      return "This analysis requires a ride synced from intervals.icu.";
+    case "ambiguous-source":
+      return "More than one intervals.icu source matches this ride, so analysis is paused.";
     case "missing-sensor-data":
       return "This ride does not have both power and heart-rate data.";
     case "duplicate-stream":

--- a/apps/desktop-renderer/tests/activity-analysis-controller.test.ts
+++ b/apps/desktop-renderer/tests/activity-analysis-controller.test.ts
@@ -87,7 +87,7 @@ function setup(call: CoachClient["call"]) {
 }
 
 describe("ride analysis controller", () => {
-  it("loads the drift section for a selected canonical ride", async () => {
+  it("loads the visible ride-analysis sections for a selected canonical ride", async () => {
     const call = vi.fn(async () => result()) as unknown as CoachClient["call"];
     const { controller, states } = setup(call);
 
@@ -95,7 +95,10 @@ describe("ride analysis controller", () => {
 
     expect(call).toHaveBeenCalledWith(
       "getActivityAnalysis",
-      { canonicalActivityId: FIRST, sections: ["aerobic-drift"] },
+      {
+        canonicalActivityId: FIRST,
+        sections: ["aerobic-drift", "intervals", "best-efforts"],
+      },
       { signal: expect.any(AbortSignal) },
     );
     expect(states.at(-1)).toMatchObject({
@@ -150,8 +153,28 @@ describe("ride analysis controller", () => {
       activityId: FIRST,
       status: "refresh-unavailable",
       sections: { aerobicDrift: { kind: "computed" } },
+      failedSections: ["aerobic-drift"],
     });
     expect(JSON.stringify(states.at(-1))).not.toContain("private transport detail");
+  });
+
+  it("tracks a failed section without marking completed sibling evidence as failed", async () => {
+    let fail = false;
+    const call = vi.fn(async () => {
+      if (fail) throw new Error("private interval failure");
+      return result();
+    }) as unknown as CoachClient["call"];
+    const { controller, states } = setup(call);
+    await controller.select(FIRST);
+
+    fail = true;
+    await controller.load(["intervals"], true);
+
+    expect(states.at(-1)).toMatchObject({
+      status: "refresh-unavailable",
+      failedSections: ["intervals"],
+      sections: { aerobicDrift: { kind: "computed" } },
+    });
   });
 
   it("clears analysis state and cancels work when the ride closes", async () => {

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -360,6 +360,7 @@ describe("training page", () => {
         status: "refresh-unavailable",
         revision: "c".repeat(64),
         loadingSections: [],
+        failedSections: ["aerobic-drift"],
         sections: {
           aerobicDrift: {
             kind: "computed",
@@ -428,6 +429,135 @@ describe("training page", () => {
     expect(document.body).not.toHaveTextContent(ride.id);
   });
 
+  it("shows ordered intervals and explicitly scoped five-minute best efforts", async () => {
+    const user = userEvent.setup();
+    if (context.recentRides.kind !== "computed") throw new Error("expected fixture rides");
+    const ride = context.recentRides.items[0]!;
+    const emptyMetrics = {
+      movingSeconds: null,
+      elapsedSeconds: null,
+      distanceMeters: null,
+      averagePowerWatts: null,
+      maximumPowerWatts: null,
+      averageHeartRateBpm: null,
+      maximumHeartRateBpm: null,
+      averageCadenceRpm: null,
+      maximumCadenceRpm: null,
+      zone: null,
+      intensityPercent: null,
+      trainingLoad: null,
+    } as const;
+    const provenance = {
+      source: "provider" as const,
+      delivery: "live" as const,
+      observedAt: "1998-07-19T08:00:00.000Z",
+    };
+    useEnduragentStore.setState({
+      rideAnalysis: {
+        activityId: ride.id,
+        status: "ready",
+        revision: "c".repeat(64),
+        loadingSections: [],
+        failedSections: [],
+        sections: {
+          intervals: {
+            kind: "computed",
+            data: {
+              source: "provider",
+              intervals: [
+                {
+                  ...emptyMetrics,
+                  ordinal: 1,
+                  groupOrdinal: null,
+                  kind: "work",
+                  label: "Threshold",
+                  startIndex: 0,
+                  endIndex: 299,
+                  startSeconds: 0,
+                  endSeconds: 300,
+                  movingSeconds: 300,
+                  elapsedSeconds: 300,
+                  distanceMeters: 2_500,
+                  averagePowerWatts: 250,
+                  maximumPowerWatts: 310,
+                  averageHeartRateBpm: 155,
+                  maximumHeartRateBpm: 170,
+                },
+                {
+                  ...emptyMetrics,
+                  ordinal: 2,
+                  groupOrdinal: null,
+                  kind: "recovery",
+                  label: null,
+                  startIndex: 300,
+                  endIndex: 419,
+                  startSeconds: 300,
+                  endSeconds: 420,
+                  movingSeconds: 120,
+                  elapsedSeconds: 120,
+                },
+              ],
+              groups: [],
+            },
+            provenance,
+          },
+          bestEfforts: {
+            kind: "computed",
+            data: {
+              scope: {
+                kind: "selected-activity",
+                stream: "power",
+                durationSeconds: 300,
+                tieRule: "earliest-start",
+              },
+              efforts: [
+                {
+                  rank: 1,
+                  startIndex: 900,
+                  endIndex: 1_199,
+                  durationSeconds: 300,
+                  distanceMeters: 2_600,
+                  averageWatts: 310,
+                },
+                {
+                  rank: 2,
+                  startIndex: 300,
+                  endIndex: 599,
+                  durationSeconds: 300,
+                  distanceMeters: null,
+                  averageWatts: 300,
+                },
+              ],
+            },
+            provenance,
+          },
+        },
+      },
+    });
+    render(<TrainingView />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Review road ride from 1998-07-09 · 22:00, 1h 31m, 42.1 km",
+      }),
+    );
+
+    const intervals = screen.getByRole("region", { name: "Intervals and laps" });
+    expect(within(intervals).getByText("Threshold")).toBeInTheDocument();
+    expect(within(intervals).getByText("Recovery")).toBeInTheDocument();
+    expect(within(intervals).getByText("250 avg · 310 max W")).toBeInTheDocument();
+    expect(within(intervals).getAllByLabelText("Unavailable").length).toBeGreaterThan(0);
+    expect(intervals).toHaveTextContent("no planned workout targets are inferred");
+
+    const efforts = screen.getByRole("region", { name: "Five-minute best efforts" });
+    expect(within(efforts).getByText("#1")).toBeInTheDocument();
+    expect(within(efforts).getByText("310 W")).toBeInTheDocument();
+    expect(within(efforts).getByText(/This ride · power · 5 min/)).toBeInTheDocument();
+    expect(efforts).toHaveTextContent("does not compare against other rides");
+    expect(efforts).not.toHaveTextContent(/\bPR\b/);
+    expect(document.body).not.toHaveTextContent(ride.id);
+  });
+
   it("explains deterministic unavailable states without offering a pointless retry", async () => {
     const user = userEvent.setup();
     if (context.recentRides.kind !== "computed") throw new Error("expected fixture rides");
@@ -438,6 +568,7 @@ describe("training page", () => {
         status: "ready",
         revision: "c".repeat(64),
         loadingSections: [],
+        failedSections: [],
         sections: { aerobicDrift: { kind: "unavailable", reason: "activity-too-short" } },
       },
       rideAnalysisActions: { refresh: vi.fn() },

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -213,6 +213,68 @@ function makeScript(
                 observedAt: "2026-07-19T08:00:00.000Z",
               },
             },
+            intervals: {
+              kind: "computed",
+              data: {
+                source: "provider",
+                intervals: [
+                  {
+                    ordinal: 1,
+                    groupOrdinal: null,
+                    kind: "work",
+                    label: "Threshold",
+                    startIndex: 0,
+                    endIndex: 299,
+                    startSeconds: 0,
+                    endSeconds: 300,
+                    movingSeconds: 300,
+                    elapsedSeconds: 300,
+                    distanceMeters: 2_500,
+                    averagePowerWatts: 250,
+                    maximumPowerWatts: 310,
+                    averageHeartRateBpm: 155,
+                    maximumHeartRateBpm: 170,
+                    averageCadenceRpm: 91,
+                    maximumCadenceRpm: 104,
+                    zone: 4,
+                    intensityPercent: 96,
+                    trainingLoad: 12,
+                  },
+                ],
+                groups: [],
+              },
+              provenance: {
+                source: "provider",
+                delivery: "live",
+                observedAt: "2026-07-19T08:00:00.000Z",
+              },
+            },
+            bestEfforts: {
+              kind: "computed",
+              data: {
+                scope: {
+                  kind: "selected-activity",
+                  stream: "power",
+                  durationSeconds: 300,
+                  tieRule: "earliest-start",
+                },
+                efforts: [
+                  {
+                    rank: 1,
+                    startIndex: 900,
+                    endIndex: 1_199,
+                    durationSeconds: 300,
+                    distanceMeters: 2_600,
+                    averageWatts: 310,
+                  },
+                ],
+              },
+              provenance: {
+                source: "provider",
+                delivery: "live",
+                observedAt: "2026-07-19T08:00:00.000Z",
+              },
+            },
           },
         });
       }
@@ -1394,7 +1456,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       }
       const page = document.querySelector('section[aria-label="Ride review"]');
       const analysisDeadline = Date.now() + 5000;
-      while (!page.textContent.includes("+4.8%") && Date.now() < analysisDeadline) {
+      while (
+        (!page.textContent.includes("+4.8%") || !page.textContent.includes("Threshold")) &&
+        Date.now() < analysisDeadline
+      ) {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
       const title = page.querySelector("h1");
@@ -1409,6 +1474,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
         drift: page.querySelector('[aria-label^="Observed efficiency-factor change"]')?.textContent ?? "",
         limitation: page.querySelector('[aria-label="Analysis limitations"]')?.textContent ?? "",
+        interval: page.querySelector('[aria-labelledby="interval-review-title"]')?.textContent ?? "",
+        efforts: page.querySelector('[aria-labelledby="best-efforts-title"]')?.textContent ?? "",
       };
     `);
     expect(rideReview).toEqual({
@@ -1420,6 +1487,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       documentOverflow: false,
       drift: "+4.8%",
       limitation: "No moving-status stream was available, so stopped time may be included.",
+      interval:
+        "Ordered ride segmentsIntervals and lapsShows recorded segments in order. Missing metrics stay unavailable, and no planned workout targets are inferred.Ordered analysis from intervals.icu1WorkThresholdDuration5 minDistance2.5 kmPower250 avg · 310 max WHeart rate155 avg · 170 max bpm",
+      efforts:
+        "Selected-ride scopeFive-minute best effortsRanks measured five-minute power efforts from this ride only. It does not compare against other rides or all-history results.This ride · power · 5 min · equal efforts rank the earlier start first#1310 W2.6 km",
     });
     const rideReturn = await fixture.evaluate<{
       readonly page: string | null;
@@ -1510,7 +1581,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       {
         jsonrpc: "2.0",
         method: "getActivityAnalysis",
-        params: { canonicalActivityId: "c".repeat(64), sections: ["aerobic-drift"] },
+        params: {
+          canonicalActivityId: "c".repeat(64),
+          sections: ["aerobic-drift", "intervals", "best-efforts"],
+        },
       },
     ]);
     await fixture.setViewport(720, 800);

--- a/packages/coach-contract/src/activity-analysis.ts
+++ b/packages/coach-contract/src/activity-analysis.ts
@@ -245,7 +245,7 @@ export const AerobicDriftDataSchema = z
     }
   });
 
-const IntervalKindSchema = z.enum(["work", "recovery", "unknown"]);
+const IntervalKindSchema = z.enum(["work", "recovery", "lap", "unknown"]);
 const NullableDisplayTextSchema = boundedDisplayText(128).nullable();
 
 export const ActivityIntervalSchema = z

--- a/packages/coach/src/activity-analysis-archive.ts
+++ b/packages/coach/src/activity-analysis-archive.ts
@@ -1,5 +1,6 @@
 import { canonicalJson, type ArchiveManager } from "@enduragent/kernel/archive";
 import type { IntervalsSourceRepository, SqlStore } from "@enduragent/kernel/store";
+import type { ActivityIntervals, BestEfforts } from "intervals-icu-api";
 import type {
   ProviderActivityStreamArchive,
   ProviderActivityStreamArchiveRequest,
@@ -9,23 +10,90 @@ interface TransactionalStore extends SqlStore {
   transaction<T>(work: () => Promise<T>): Promise<T>;
 }
 
-export function createProviderActivityStreamArchive(input: {
+interface ProviderActivityAnalysisArchiveDependencies {
   readonly archive: Pick<ArchiveManager, "writeSnapshot">;
   readonly store: TransactionalStore;
   readonly sources: Pick<IntervalsSourceRepository, "recordArtifact" | "recordGenericLanding">;
   readonly runExclusive: <T>(work: () => Promise<T>) => Promise<T>;
   readonly now: () => number;
-}): ProviderActivityStreamArchive {
+}
+
+export interface ProviderActivityIntervalsArchiveRequest {
+  readonly sourceRevision: string;
+  readonly response: ActivityIntervals;
+  readonly signal: AbortSignal;
+}
+
+export interface ProviderActivityIntervalsArchive {
+  write(input: ProviderActivityIntervalsArchiveRequest): Promise<void>;
+}
+
+export interface ProviderActivityBestEffortsArchiveRequest {
+  readonly sourceRevision: string;
+  readonly durationSeconds: number;
+  readonly response: BestEfforts;
+  readonly signal: AbortSignal;
+}
+
+export interface ProviderActivityBestEffortsArchive {
+  write(input: ProviderActivityBestEffortsArchiveRequest): Promise<void>;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+async function publishEvidence(input: {
+  readonly dependencies: ProviderActivityAnalysisArchiveDependencies;
+  readonly sourceRevision: string;
+  readonly externalPrefix: string;
+  readonly snapshot: unknown;
+  readonly landing: unknown;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  input.signal.throwIfAborted();
+  const epochMilliseconds = input.dependencies.now();
+  if (!Number.isSafeInteger(epochMilliseconds) || epochMilliseconds < 0) {
+    throw new TypeError("activity analysis archive clock is invalid");
+  }
+  const epochSeconds = Math.floor(epochMilliseconds / 1_000);
+  const archived = await input.dependencies.archive.writeSnapshot(input.snapshot, { epochSeconds });
+  input.signal.throwIfAborted();
+  const externalId = `${input.externalPrefix}:analysis:${input.sourceRevision}:${archived.address}`;
+  const landing = canonicalJson(input.landing);
+  await input.dependencies.runExclusive(() =>
+    input.dependencies.store.transaction(async () => {
+      const artifact = await input.dependencies.sources.recordArtifact({
+        source: "intervals-icu",
+        lane: "streams",
+        externalId,
+        artifactKind: "snapshot",
+        archiveAddress: archived.address,
+        archiveRelPath: archived.relPath,
+        archiveEpochSeconds: epochSeconds,
+      });
+      await input.dependencies.sources.recordGenericLanding({
+        externalId,
+        artifactKey: artifact.artifactKey,
+        archiveAddress: archived.address,
+        endpoint: "streams",
+        normalizedPayloadJson: landing,
+      });
+    }),
+  );
+  input.signal.throwIfAborted();
+}
+
+export function createProviderActivityStreamArchive(
+  input: ProviderActivityAnalysisArchiveDependencies,
+): ProviderActivityStreamArchive {
   return Object.freeze({
     async write(request: ProviderActivityStreamArchiveRequest) {
-      request.signal.throwIfAborted();
-      const snapshot = JSON.parse(
-        JSON.stringify({
-          schema_version: 1,
-          source_revision: request.sourceRevision,
-          descriptors: request.descriptors,
-        }),
-      ) as {
+      const snapshot = cloneJson({
+        schema_version: 1,
+        source_revision: request.sourceRevision,
+        descriptors: request.descriptors,
+      }) as {
         readonly schema_version: 1;
         readonly source_revision: string;
         readonly descriptors: readonly {
@@ -33,42 +101,75 @@ export function createProviderActivityStreamArchive(input: {
           readonly data: readonly unknown[];
         }[];
       };
-      const epochMilliseconds = input.now();
-      if (!Number.isSafeInteger(epochMilliseconds) || epochMilliseconds < 0) {
-        throw new TypeError("activity analysis archive clock is invalid");
-      }
-      const epochSeconds = Math.floor(epochMilliseconds / 1_000);
-      const archived = await input.archive.writeSnapshot(snapshot, { epochSeconds });
-      request.signal.throwIfAborted();
-      const externalId = `streams:analysis:${request.sourceRevision}:${archived.address}`;
-      const landing = canonicalJson({
-        descriptor_count: snapshot.descriptors.length,
-        sample_counts: snapshot.descriptors.map((descriptor) => descriptor.data.length),
-        schema_version: 1,
-        source_revision: request.sourceRevision,
-        types: snapshot.descriptors.map((descriptor) => descriptor.type),
+      await publishEvidence({
+        dependencies: input,
+        sourceRevision: request.sourceRevision,
+        externalPrefix: "streams",
+        snapshot,
+        landing: {
+          descriptor_count: snapshot.descriptors.length,
+          sample_counts: snapshot.descriptors.map((descriptor) => descriptor.data.length),
+          schema_version: 1,
+          source_revision: request.sourceRevision,
+          types: snapshot.descriptors.map((descriptor) => descriptor.type),
+        },
+        signal: request.signal,
       });
-      await input.runExclusive(() =>
-        input.store.transaction(async () => {
-          const artifact = await input.sources.recordArtifact({
-            source: "intervals-icu",
-            lane: "streams",
-            externalId,
-            artifactKind: "snapshot",
-            archiveAddress: archived.address,
-            archiveRelPath: archived.relPath,
-            archiveEpochSeconds: epochSeconds,
-          });
-          await input.sources.recordGenericLanding({
-            externalId,
-            artifactKey: artifact.artifactKey,
-            archiveAddress: archived.address,
-            endpoint: "streams",
-            normalizedPayloadJson: landing,
-          });
-        }),
-      );
-      request.signal.throwIfAborted();
+    },
+  });
+}
+
+export function createProviderActivityIntervalsArchive(
+  input: ProviderActivityAnalysisArchiveDependencies,
+): ProviderActivityIntervalsArchive {
+  return Object.freeze({
+    async write(request: ProviderActivityIntervalsArchiveRequest) {
+      const response = cloneJson(request.response);
+      await publishEvidence({
+        dependencies: input,
+        sourceRevision: request.sourceRevision,
+        externalPrefix: "intervals",
+        snapshot: {
+          schema_version: 1,
+          source_revision: request.sourceRevision,
+          response,
+        },
+        landing: {
+          group_count: response.icuGroups?.length ?? 0,
+          interval_count: response.icuIntervals?.length ?? 0,
+          schema_version: 1,
+          source_revision: request.sourceRevision,
+        },
+        signal: request.signal,
+      });
+    },
+  });
+}
+
+export function createProviderActivityBestEffortsArchive(
+  input: ProviderActivityAnalysisArchiveDependencies,
+): ProviderActivityBestEffortsArchive {
+  return Object.freeze({
+    async write(request: ProviderActivityBestEffortsArchiveRequest) {
+      const response = cloneJson(request.response);
+      await publishEvidence({
+        dependencies: input,
+        sourceRevision: request.sourceRevision,
+        externalPrefix: `best-efforts-${request.durationSeconds}`,
+        snapshot: {
+          schema_version: 1,
+          source_revision: request.sourceRevision,
+          duration_seconds: request.durationSeconds,
+          response,
+        },
+        landing: {
+          duration_seconds: request.durationSeconds,
+          effort_count: response.efforts.length,
+          schema_version: 1,
+          source_revision: request.sourceRevision,
+        },
+        signal: request.signal,
+      });
     },
   });
 }

--- a/packages/coach/src/activity-analysis-provider.ts
+++ b/packages/coach/src/activity-analysis-provider.ts
@@ -9,9 +9,11 @@ import type {
 import { ActivityAnalysisComputationError } from "./activity-analysis-service.js";
 
 export const ACTIVITY_STREAM_RESPONSE_LIMIT_BYTES = 16 * 1_024 * 1_024;
+export const MAX_PROVIDER_ACTIVITY_REQUESTS_PER_REVISION = 8;
 const MAX_STREAM_DESCRIPTORS = 16;
 const MAX_STREAM_SAMPLES = 1_000_000;
 const MAX_TOTAL_STREAM_SAMPLES = 4_000_000;
+const MAX_TRACKED_PROVIDER_REVISIONS = 128;
 const PROVIDER_REQUEST_TIMEOUT_MS = 30_000;
 const REQUESTED_STREAMS = ["time", "watts", "heartrate", "moving"] as const;
 
@@ -39,18 +41,35 @@ export interface ProviderActivityStreamRequest {
   readonly signal: AbortSignal;
 }
 
-interface ProviderStreamClient {
-  readonly activities: Pick<IntervalsClient["activities"], "getStreamMap">;
+export interface ProviderActivityAnalysisClient {
+  readonly activities: IntervalsClient["activities"];
 }
 
-type ProviderStreamClientFactory = (input: {
+export type ProviderActivityAnalysisClientFactory = (input: {
   readonly apiKey: string;
   readonly athleteId: string;
   readonly signal: AbortSignal;
   readonly baseFetch: typeof globalThis.fetch;
-}) => ProviderStreamClient;
+}) => ProviderActivityAnalysisClient;
 
-function failure(error: ApiError, responseLimitExceeded: boolean, signal: AbortSignal): never {
+export interface ProviderActivityAnalysisClientLease {
+  readonly client: ProviderActivityAnalysisClient;
+  responseLimitExceeded(): boolean;
+}
+
+export interface ProviderActivityAnalysisClientAccess {
+  open(input: {
+    readonly sourceRevision: string;
+    readonly signal: AbortSignal;
+    readonly maximumBytes: number;
+  }): Promise<ProviderActivityAnalysisClientLease>;
+}
+
+export function providerActivityFailure(
+  error: ApiError,
+  responseLimitExceeded: boolean,
+  signal: AbortSignal,
+): never {
   signal.throwIfAborted();
   if (responseLimitExceeded) throw new ActivityAnalysisComputationError("response-too-large");
   if (error.kind === "RateLimit") throw new ActivityAnalysisComputationError("rate-limited");
@@ -129,14 +148,20 @@ export function createBoundedActivityStreamFetch(input: {
   };
 }
 
-export function createProviderActivityStreamReader(input: {
+export function createProviderActivityAnalysisClientAccess(input: {
   readonly credentials: {
     read(): Promise<{ readonly apiKey: string; readonly athleteId: string }>;
   };
-  readonly archive: ProviderActivityStreamArchive;
-  readonly createClient?: ProviderStreamClientFactory;
+  readonly createClient?: ProviderActivityAnalysisClientFactory;
   readonly baseFetch?: typeof globalThis.fetch;
-}): ProviderActivityStreamReader {
+  readonly maximumRequestsPerRevision?: number;
+}): ProviderActivityAnalysisClientAccess {
+  const maximumRequests =
+    input.maximumRequestsPerRevision ?? MAX_PROVIDER_ACTIVITY_REQUESTS_PER_REVISION;
+  if (!Number.isSafeInteger(maximumRequests) || maximumRequests < 1) {
+    throw new TypeError("provider activity request budget is invalid");
+  }
+  const requests = new Map<string, number>();
   const createClient =
     input.createClient ??
     ((options) =>
@@ -147,32 +172,73 @@ export function createProviderActivityStreamReader(input: {
         perRequestMs: PROVIDER_REQUEST_TIMEOUT_MS,
         baseFetch: options.baseFetch,
       }));
-  const reader: ProviderActivityStreamReader = {
-    async read(request: ProviderActivityStreamRequest) {
-      request.signal.throwIfAborted();
+  return Object.freeze({
+    async open(options: {
+      readonly sourceRevision: string;
+      readonly signal: AbortSignal;
+      readonly maximumBytes: number;
+    }) {
+      options.signal.throwIfAborted();
+      if (!/^[0-9a-f]{64}$/.test(options.sourceRevision)) {
+        throw new TypeError("provider activity source revision is invalid");
+      }
       const credentials = await input.credentials.read();
-      request.signal.throwIfAborted();
+      options.signal.throwIfAborted();
       if (credentials.apiKey.length === 0) {
         throw new ActivityAnalysisComputationError("provider-unavailable");
       }
-      let responseLimitExceeded = false;
+      const used = requests.get(options.sourceRevision) ?? 0;
+      if (used >= maximumRequests) {
+        throw new ActivityAnalysisComputationError("request-budget-exhausted");
+      }
+      requests.delete(options.sourceRevision);
+      requests.set(options.sourceRevision, used + 1);
+      while (requests.size > MAX_TRACKED_PROVIDER_REVISIONS) {
+        const oldest = requests.keys().next().value as string | undefined;
+        if (oldest === undefined) break;
+        requests.delete(oldest);
+      }
+      let exceeded = false;
       const client = createClient({
         apiKey: credentials.apiKey,
         athleteId: credentials.athleteId,
-        signal: request.signal,
+        signal: options.signal,
         baseFetch: createBoundedActivityStreamFetch({
           baseFetch: input.baseFetch ?? globalThis.fetch,
+          maximumBytes: options.maximumBytes,
           noteLimitExceeded: () => {
-            responseLimitExceeded = true;
+            exceeded = true;
           },
         }),
       });
-      const result = await client.activities.getStreamMap(request.providerActivityId, {
+      return Object.freeze({
+        client,
+        responseLimitExceeded: () => exceeded,
+      });
+    },
+  });
+}
+
+export function createProviderActivityStreamReader(input: {
+  readonly access: ProviderActivityAnalysisClientAccess;
+  readonly archive: ProviderActivityStreamArchive;
+}): ProviderActivityStreamReader {
+  const reader: ProviderActivityStreamReader = {
+    async read(request: ProviderActivityStreamRequest) {
+      request.signal.throwIfAborted();
+      const lease = await input.access.open({
+        sourceRevision: request.sourceRevision,
+        signal: request.signal,
+        maximumBytes: ACTIVITY_STREAM_RESPONSE_LIMIT_BYTES,
+      });
+      const result = await lease.client.activities.getStreamMap(request.providerActivityId, {
         types: REQUESTED_STREAMS,
         includeDefaults: false,
       });
       request.signal.throwIfAborted();
-      if (!result.ok) failure(result.error, responseLimitExceeded, request.signal);
+      if (!result.ok) {
+        providerActivityFailure(result.error, lease.responseLimitExceeded(), request.signal);
+      }
       if (!boundedDescriptors(result.value)) {
         throw new ActivityAnalysisComputationError("response-too-large");
       }

--- a/packages/coach/src/activity-best-efforts.ts
+++ b/packages/coach/src/activity-best-efforts.ts
@@ -1,0 +1,178 @@
+import {
+  BestEffortDataSchema,
+  MAX_ACTIVITY_ANALYSIS_EFFORTS,
+  type ActivityAnalysisData,
+} from "@enduragent/coach-contract";
+import { z } from "zod";
+import type { BestEfforts } from "intervals-icu-api";
+import type { ProviderActivityBestEffortsArchive } from "./activity-analysis-archive.js";
+import {
+  ActivityAnalysisComputationError,
+  type ActivityAnalysisSectionInput,
+  type ActivityAnalysisSectionAnalyzer,
+  type ActivityAnalysisSectionOutput,
+} from "./activity-analysis-service.js";
+import {
+  providerActivityFailure,
+  type ProviderActivityAnalysisClientAccess,
+} from "./activity-analysis-provider.js";
+
+export const DEFAULT_BEST_EFFORT_DURATION_SECONDS = 5 * 60;
+export const ACTIVITY_BEST_EFFORT_RESPONSE_LIMIT_BYTES = 256 * 1_024;
+
+const ProviderEffortSchema = z
+  .object({
+    average: z.number().finite().nonnegative().max(100_000),
+    distance: z.number().finite().nonnegative().max(Number.MAX_SAFE_INTEGER).nullish(),
+    duration: z
+      .number()
+      .int()
+      .min(1)
+      .max(7 * 86_400),
+    startIndex: z.number().int().nonnegative().max(1_000_000),
+    endIndex: z.number().int().nonnegative().max(1_000_000),
+  })
+  .passthrough()
+  .refine((value) => value.startIndex <= value.endIndex, {
+    path: ["endIndex"],
+    message: "effort indexes are reversed",
+  });
+
+const ProviderBestEffortsSchema = z
+  .object({
+    efforts: z.array(ProviderEffortSchema).max(MAX_ACTIVITY_ANALYSIS_EFFORTS),
+  })
+  .passthrough();
+
+export interface ProviderActivityBestEffortReader {
+  read(input: {
+    readonly providerActivityId: string;
+    readonly sourceRevision: string;
+    readonly durationSeconds: number;
+    readonly signal: AbortSignal;
+  }): Promise<BestEfforts>;
+}
+
+export function projectProviderBestEfforts(
+  response: BestEfforts,
+  durationSeconds: number,
+): ActivityAnalysisData["bestEfforts"] {
+  if (Array.isArray(response.efforts) && response.efforts.length > MAX_ACTIVITY_ANALYSIS_EFFORTS) {
+    throw new ActivityAnalysisComputationError("response-too-large");
+  }
+  let parsed: z.infer<typeof ProviderBestEffortsSchema>;
+  try {
+    parsed = ProviderBestEffortsSchema.parse(response);
+  } catch (error) {
+    throw new ActivityAnalysisComputationError("malformed-response", { cause: error });
+  }
+  if (parsed.efforts.some((effort) => effort.duration !== durationSeconds)) {
+    throw new ActivityAnalysisComputationError("malformed-response");
+  }
+  const identities = new Set<string>();
+  for (const effort of parsed.efforts) {
+    const identity = `${effort.startIndex}:${effort.endIndex}`;
+    if (identities.has(identity)) {
+      throw new ActivityAnalysisComputationError("malformed-response");
+    }
+    identities.add(identity);
+  }
+  const ordered = [...parsed.efforts].sort(
+    (left, right) =>
+      right.average - left.average ||
+      left.startIndex - right.startIndex ||
+      left.endIndex - right.endIndex,
+  );
+  try {
+    return BestEffortDataSchema.parse({
+      scope: {
+        kind: "selected-activity",
+        stream: "power",
+        durationSeconds,
+        tieRule: "earliest-start",
+      },
+      efforts: ordered.map((effort, index) => ({
+        rank: index + 1,
+        startIndex: effort.startIndex,
+        endIndex: effort.endIndex,
+        durationSeconds: effort.duration,
+        distanceMeters: effort.distance ?? null,
+        averageWatts: effort.average,
+      })),
+    });
+  } catch (error) {
+    throw new ActivityAnalysisComputationError("malformed-response", { cause: error });
+  }
+}
+
+export function createProviderActivityBestEffortReader(input: {
+  readonly access: ProviderActivityAnalysisClientAccess;
+  readonly archive: ProviderActivityBestEffortsArchive;
+}): ProviderActivityBestEffortReader {
+  return Object.freeze({
+    async read(request: {
+      readonly providerActivityId: string;
+      readonly sourceRevision: string;
+      readonly durationSeconds: number;
+      readonly signal: AbortSignal;
+    }) {
+      const lease = await input.access.open({
+        sourceRevision: request.sourceRevision,
+        signal: request.signal,
+        maximumBytes: ACTIVITY_BEST_EFFORT_RESPONSE_LIMIT_BYTES,
+      });
+      const result = await lease.client.activities.findBestEfforts(request.providerActivityId, {
+        stream: "watts",
+        duration: request.durationSeconds,
+        count: MAX_ACTIVITY_ANALYSIS_EFFORTS,
+      });
+      request.signal.throwIfAborted();
+      if (!result.ok) {
+        providerActivityFailure(result.error, lease.responseLimitExceeded(), request.signal);
+      }
+      await input.archive.write({
+        sourceRevision: request.sourceRevision,
+        durationSeconds: request.durationSeconds,
+        response: result.value,
+        signal: request.signal,
+      });
+      request.signal.throwIfAborted();
+      return result.value;
+    },
+  });
+}
+
+export function createBestEffortAnalyzer(input: {
+  readonly provider: ProviderActivityBestEffortReader;
+  readonly durationSeconds?: number;
+}): ActivityAnalysisSectionAnalyzer<"bestEfforts"> {
+  const durationSeconds = input.durationSeconds ?? DEFAULT_BEST_EFFORT_DURATION_SECONDS;
+  if (
+    !Number.isSafeInteger(durationSeconds) ||
+    durationSeconds < 1 ||
+    durationSeconds > 7 * 86_400
+  ) {
+    throw new TypeError("best-effort duration is invalid");
+  }
+  return Object.freeze({
+    async analyze(
+      request: ActivityAnalysisSectionInput,
+    ): Promise<ActivityAnalysisSectionOutput<"bestEfforts">> {
+      request.signal.throwIfAborted();
+      if (request.source.kind !== "resolved") {
+        return { kind: "unavailable", reason: request.source.reason };
+      }
+      const response = await input.provider.read({
+        providerActivityId: request.source.providerActivityId,
+        sourceRevision: request.sourceRevision,
+        durationSeconds,
+        signal: request.signal,
+      });
+      return {
+        kind: "computed",
+        source: "provider",
+        data: projectProviderBestEfforts(response, durationSeconds),
+      };
+    },
+  });
+}

--- a/packages/coach/src/activity-interval-review.ts
+++ b/packages/coach/src/activity-interval-review.ts
@@ -1,0 +1,308 @@
+import {
+  IntervalReviewDataSchema,
+  MAX_ACTIVITY_ANALYSIS_INTERVAL_GROUPS,
+  MAX_ACTIVITY_ANALYSIS_INTERVALS,
+  type ActivityAnalysisData,
+  type AnalysisUnavailableReason,
+} from "@enduragent/coach-contract";
+import { z } from "zod";
+import type { ActivityIntervals } from "intervals-icu-api";
+import type { ProviderActivityIntervalsArchive } from "./activity-analysis-archive.js";
+import {
+  ActivityAnalysisComputationError,
+  type ActivityAnalysisSectionInput,
+  type ActivityAnalysisSectionAnalyzer,
+  type ActivityAnalysisSectionOutput,
+} from "./activity-analysis-service.js";
+import {
+  providerActivityFailure,
+  type ProviderActivityAnalysisClientAccess,
+} from "./activity-analysis-provider.js";
+
+export const ACTIVITY_INTERVAL_RESPONSE_LIMIT_BYTES = 2 * 1_024 * 1_024;
+
+const MAX_ACTIVITY_SECONDS = 7 * 86_400;
+const MAX_ACTIVITY_SAMPLES = 1_000_000;
+const MAX_DISPLAY_METRIC = 100_000;
+
+const NullableDuration = z.number().finite().nonnegative().max(MAX_ACTIVITY_SECONDS).nullish();
+const NullableIndex = z.number().int().nonnegative().max(MAX_ACTIVITY_SAMPLES).nullish();
+const NullableMetric = z.number().finite().nonnegative().max(MAX_DISPLAY_METRIC).nullish();
+const NullableDistance = z.number().finite().nonnegative().max(Number.MAX_SAFE_INTEGER).nullish();
+const NullableZone = z.number().int().min(0).max(100).nullish();
+const NullableIntensity = z.number().finite().min(0).max(10_000).nullish();
+const NullableLabel = z.string().min(1).max(128).nullish();
+const NullableGroupId = z.string().min(1).max(128).nullish();
+
+const IntervalMetricsShape = {
+  movingTime: NullableDuration,
+  elapsedTime: NullableDuration,
+  distance: NullableDistance,
+  averageWatts: NullableMetric,
+  maxWatts: NullableMetric,
+  averageHeartrate: z.number().finite().nonnegative().max(400).nullish(),
+  maxHeartrate: z.number().finite().nonnegative().max(400).nullish(),
+  averageCadence: NullableMetric,
+  maxCadence: NullableMetric,
+  zone: NullableZone,
+  intensity: NullableIntensity,
+  trainingLoad: NullableMetric,
+} as const;
+
+const ProviderIntervalSchema = z
+  .object({
+    ...IntervalMetricsShape,
+    groupId: NullableGroupId,
+    label: NullableLabel,
+    type: z.enum(["WORK", "RECOVERY"]).nullish(),
+    startIndex: NullableIndex,
+    endIndex: NullableIndex,
+    startTime: NullableDuration,
+    endTime: NullableDuration,
+  })
+  .passthrough();
+
+const ProviderIntervalGroupSchema = z
+  .object({
+    ...IntervalMetricsShape,
+    id: NullableGroupId,
+  })
+  .passthrough();
+
+const ProviderIntervalsSchema = z
+  .object({
+    icuIntervals: z.array(ProviderIntervalSchema).max(MAX_ACTIVITY_ANALYSIS_INTERVALS).nullish(),
+    icuGroups: z
+      .array(ProviderIntervalGroupSchema)
+      .max(MAX_ACTIVITY_ANALYSIS_INTERVAL_GROUPS)
+      .nullish(),
+  })
+  .passthrough();
+
+type ProviderInterval = z.infer<typeof ProviderIntervalSchema>;
+type ProviderIntervalGroup = z.infer<typeof ProviderIntervalGroupSchema>;
+type IntervalKind = ActivityAnalysisData["intervals"]["intervals"][number]["kind"];
+
+export interface ProviderActivityIntervalReader {
+  read(input: {
+    readonly providerActivityId: string;
+    readonly sourceRevision: string;
+    readonly signal: AbortSignal;
+  }): Promise<ActivityIntervals>;
+}
+
+function providerKind(value: ProviderInterval["type"]): IntervalKind {
+  if (value === "WORK") return "work";
+  if (value === "RECOVERY") return "recovery";
+  return "unknown";
+}
+
+function projectedMetrics(value: ProviderInterval | ProviderIntervalGroup) {
+  return {
+    movingSeconds: value.movingTime ?? null,
+    elapsedSeconds: value.elapsedTime ?? null,
+    averagePowerWatts: value.averageWatts ?? null,
+    maximumPowerWatts: value.maxWatts ?? null,
+    averageHeartRateBpm: value.averageHeartrate ?? null,
+    maximumHeartRateBpm: value.maxHeartrate ?? null,
+    averageCadenceRpm: value.averageCadence ?? null,
+    maximumCadenceRpm: value.maxCadence ?? null,
+    zone: value.zone ?? null,
+    intensityPercent: value.intensity ?? null,
+    trainingLoad: value.trainingLoad ?? null,
+  };
+}
+
+function oversized(response: ActivityIntervals): boolean {
+  return (
+    (Array.isArray(response.icuIntervals) &&
+      response.icuIntervals.length > MAX_ACTIVITY_ANALYSIS_INTERVALS) ||
+    (Array.isArray(response.icuGroups) &&
+      response.icuGroups.length > MAX_ACTIVITY_ANALYSIS_INTERVAL_GROUPS)
+  );
+}
+
+export function projectProviderActivityIntervals(
+  response: ActivityIntervals,
+): ActivityAnalysisData["intervals"] {
+  if (oversized(response)) {
+    throw new ActivityAnalysisComputationError("response-too-large");
+  }
+  let parsed: z.infer<typeof ProviderIntervalsSchema>;
+  try {
+    parsed = ProviderIntervalsSchema.parse(response);
+  } catch (error) {
+    throw new ActivityAnalysisComputationError("malformed-response", { cause: error });
+  }
+  const rawIntervals = parsed.icuIntervals ?? [];
+  const rawGroups = parsed.icuGroups ?? [];
+  const groupsById = new Map<string, ProviderIntervalGroup>();
+  for (const group of rawGroups) {
+    if (group.id === null || group.id === undefined || groupsById.has(group.id)) {
+      throw new ActivityAnalysisComputationError("malformed-response");
+    }
+    groupsById.set(group.id, group);
+  }
+  const referencedGroupIds = new Set<string>();
+  for (const interval of rawIntervals) {
+    if (interval.groupId === null || interval.groupId === undefined) continue;
+    if (!groupsById.has(interval.groupId)) {
+      throw new ActivityAnalysisComputationError("malformed-response");
+    }
+    referencedGroupIds.add(interval.groupId);
+  }
+  const projectedGroups = rawGroups.filter(
+    (group): group is ProviderIntervalGroup & { readonly id: string } =>
+      group.id !== null && group.id !== undefined && referencedGroupIds.has(group.id),
+  );
+  const groupOrdinals = new Map(
+    projectedGroups.map((group, index) => [group.id, index + 1] as const),
+  );
+  const intervals = rawIntervals.map((interval, index) => ({
+    ordinal: index + 1,
+    groupOrdinal:
+      interval.groupId === null || interval.groupId === undefined
+        ? null
+        : (groupOrdinals.get(interval.groupId) ?? null),
+    kind: providerKind(interval.type),
+    label: interval.label ?? null,
+    startIndex: interval.startIndex ?? null,
+    endIndex: interval.endIndex ?? null,
+    startSeconds: interval.startTime ?? null,
+    endSeconds: interval.endTime ?? null,
+    distanceMeters: interval.distance ?? null,
+    ...projectedMetrics(interval),
+  }));
+  const groups = projectedGroups.map((group, index) => {
+    const intervalOrdinals = intervals
+      .filter((interval) => interval.groupOrdinal === index + 1)
+      .map((interval) => interval.ordinal);
+    const kinds = new Set(intervalOrdinals.map((ordinal) => intervals[ordinal - 1]!.kind));
+    const kind: IntervalKind =
+      kinds.size === 1 ? intervals[intervalOrdinals[0]! - 1]!.kind : "unknown";
+    return {
+      ordinal: index + 1,
+      intervalOrdinals,
+      kind,
+      ...projectedMetrics(group),
+    };
+  });
+  try {
+    return IntervalReviewDataSchema.parse({ source: "provider", intervals, groups });
+  } catch (error) {
+    throw new ActivityAnalysisComputationError("malformed-response", { cause: error });
+  }
+}
+
+function localIntervalReview(
+  activity: Parameters<ActivityAnalysisSectionAnalyzer<"intervals">["analyze"]>[0]["activity"],
+):
+  | { readonly kind: "computed"; readonly data: ActivityAnalysisData["intervals"] }
+  | { readonly kind: "unavailable"; readonly reason: AnalysisUnavailableReason } {
+  if (activity.laps.length > MAX_ACTIVITY_ANALYSIS_INTERVALS) {
+    return { kind: "unavailable", reason: "response-too-large" };
+  }
+  const intervals = activity.laps.map((lap, index) => {
+    const startSeconds =
+      lap.startEpochSeconds === null ? null : lap.startEpochSeconds - activity.startEpochSeconds;
+    const safeStart =
+      startSeconds !== null && startSeconds >= 0 && startSeconds <= MAX_ACTIVITY_SECONDS
+        ? startSeconds
+        : null;
+    const elapsed =
+      lap.elapsedSeconds !== null && lap.elapsedSeconds <= MAX_ACTIVITY_SECONDS
+        ? lap.elapsedSeconds
+        : null;
+    return {
+      ordinal: index + 1,
+      groupOrdinal: null,
+      kind: "lap" as const,
+      label: null,
+      startIndex: null,
+      endIndex: null,
+      startSeconds: safeStart,
+      endSeconds: safeStart === null || elapsed === null ? null : safeStart + elapsed,
+      movingSeconds: null,
+      elapsedSeconds: elapsed,
+      distanceMeters: lap.distanceMeters,
+      averagePowerWatts: null,
+      maximumPowerWatts: null,
+      averageHeartRateBpm: null,
+      maximumHeartRateBpm: null,
+      averageCadenceRpm: null,
+      maximumCadenceRpm: null,
+      zone: null,
+      intensityPercent: null,
+      trainingLoad: null,
+    };
+  });
+  try {
+    return {
+      kind: "computed",
+      data: IntervalReviewDataSchema.parse({
+        source: "local-canonical",
+        intervals,
+        groups: [],
+      }),
+    };
+  } catch {
+    return { kind: "unavailable", reason: "unsuitable-activity" };
+  }
+}
+
+export function createProviderActivityIntervalReader(input: {
+  readonly access: ProviderActivityAnalysisClientAccess;
+  readonly archive: ProviderActivityIntervalsArchive;
+}): ProviderActivityIntervalReader {
+  return Object.freeze({
+    async read(request: {
+      readonly providerActivityId: string;
+      readonly sourceRevision: string;
+      readonly signal: AbortSignal;
+    }) {
+      const lease = await input.access.open({
+        sourceRevision: request.sourceRevision,
+        signal: request.signal,
+        maximumBytes: ACTIVITY_INTERVAL_RESPONSE_LIMIT_BYTES,
+      });
+      const result = await lease.client.activities.getIntervals(request.providerActivityId);
+      request.signal.throwIfAborted();
+      if (!result.ok) {
+        providerActivityFailure(result.error, lease.responseLimitExceeded(), request.signal);
+      }
+      await input.archive.write({
+        sourceRevision: request.sourceRevision,
+        response: result.value,
+        signal: request.signal,
+      });
+      request.signal.throwIfAborted();
+      return result.value;
+    },
+  });
+}
+
+export function createIntervalReviewAnalyzer(input: {
+  readonly provider: ProviderActivityIntervalReader;
+}): ActivityAnalysisSectionAnalyzer<"intervals"> {
+  return Object.freeze({
+    async analyze(
+      request: ActivityAnalysisSectionInput,
+    ): Promise<ActivityAnalysisSectionOutput<"intervals">> {
+      request.signal.throwIfAborted();
+      if (request.source.kind !== "resolved") {
+        const local = localIntervalReview(request.activity);
+        return local.kind === "computed" ? { ...local, source: "local-canonical" } : local;
+      }
+      const response = await input.provider.read({
+        providerActivityId: request.source.providerActivityId,
+        sourceRevision: request.sourceRevision,
+        signal: request.signal,
+      });
+      return {
+        kind: "computed",
+        source: "provider",
+        data: projectProviderActivityIntervals(response),
+      };
+    },
+  });
+}

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -102,8 +102,23 @@ import type { CoachOperationsDependencies } from "./operations.js";
 import { createSpendMeterService, type SpendMeterService } from "./spend-meter.js";
 import { createStoredActivityAnalysisService } from "./activity-analysis-service.js";
 import { createAerobicDriftAnalyzer } from "./aerobic-drift.js";
-import { createProviderActivityStreamReader } from "./activity-analysis-provider.js";
-import { createProviderActivityStreamArchive } from "./activity-analysis-archive.js";
+import {
+  createProviderActivityAnalysisClientAccess,
+  createProviderActivityStreamReader,
+} from "./activity-analysis-provider.js";
+import {
+  createProviderActivityBestEffortsArchive,
+  createProviderActivityIntervalsArchive,
+  createProviderActivityStreamArchive,
+} from "./activity-analysis-archive.js";
+import {
+  createIntervalReviewAnalyzer,
+  createProviderActivityIntervalReader,
+} from "./activity-interval-review.js";
+import {
+  createBestEffortAnalyzer,
+  createProviderActivityBestEffortReader,
+} from "./activity-best-efforts.js";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -1016,15 +1031,29 @@ export async function createLocalCoachComposition(
       if (fields.length === 0) throw new TypeError("empty key tuple");
       return H(analysisCrypto, ...(fields as [string | number, ...(string | number)[]]));
     });
-    const providerStreams = createProviderActivityStreamReader({
+    const providerAccess = createProviderActivityAnalysisClientAccess({
       credentials: options.liveIntervals,
+    });
+    const archiveDependencies = {
+      archive: analysisImport.archive,
+      store: input.context.store,
+      sources: analysisSources,
+      runExclusive: <T>(work: () => Promise<T>) => runtime!.runExclusive(work),
+      now,
+    };
+    const providerStreams = createProviderActivityStreamReader({
+      access: providerAccess,
       archive: createProviderActivityStreamArchive({
-        archive: analysisImport.archive,
-        store: input.context.store,
-        sources: analysisSources,
-        runExclusive: (work) => runtime!.runExclusive(work),
-        now,
+        ...archiveDependencies,
       }),
+    });
+    const providerIntervals = createProviderActivityIntervalReader({
+      access: providerAccess,
+      archive: createProviderActivityIntervalsArchive({ ...archiveDependencies }),
+    });
+    const providerBestEfforts = createProviderActivityBestEffortReader({
+      access: providerAccess,
+      archive: createProviderActivityBestEffortsArchive({ ...archiveDependencies }),
     });
     const activityAnalysis = createStoredActivityAnalysisService({
       store: input.context.store,
@@ -1035,6 +1064,8 @@ export async function createLocalCoachComposition(
           activities: canonicalActivities,
           provider: providerStreams,
         }),
+        intervals: createIntervalReviewAnalyzer({ provider: providerIntervals }),
+        bestEfforts: createBestEffortAnalyzer({ provider: providerBestEfforts }),
       },
       runCacheWrite: (work) => runtime!.runExclusive(work),
       now,

--- a/packages/coach/tests/activity-analysis-archive.test.ts
+++ b/packages/coach/tests/activity-analysis-archive.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { createProviderActivityStreamArchive } from "../src/activity-analysis-archive.js";
+import {
+  createProviderActivityBestEffortsArchive,
+  createProviderActivityIntervalsArchive,
+  createProviderActivityStreamArchive,
+} from "../src/activity-analysis-archive.js";
 
 const REVISION = "a".repeat(64);
 const ADDRESS = "b".repeat(64);
@@ -23,9 +27,9 @@ function setup(input: { readonly abortAfterArchive?: AbortController } = {}) {
       return value;
     },
   };
-  const archive = createProviderActivityStreamArchive({
+  const dependencies = {
     archive: {
-      async writeSnapshot(snapshot) {
+      async writeSnapshot(snapshot: unknown) {
         events.push("archive");
         snapshots.push(snapshot);
         input.abortAfterArchive?.abort();
@@ -34,24 +38,25 @@ function setup(input: { readonly abortAfterArchive?: AbortController } = {}) {
     },
     store,
     sources: {
-      async recordArtifact(draft) {
+      async recordArtifact(draft: unknown) {
         events.push("artifact");
         artifactDrafts.push(draft);
         return { artifactKey: ARTIFACT, inserted: true };
       },
-      async recordGenericLanding(draft) {
+      async recordGenericLanding(draft: unknown) {
         events.push("landing");
         landingDrafts.push(draft);
         return true;
       },
     },
-    runExclusive: async (work) => {
+    runExclusive: async <T>(work: () => Promise<T>): Promise<T> => {
       events.push("exclusive");
       return work();
     },
     now: () => Date.parse("1998-07-06T12:00:00.000Z"),
-  });
-  return { archive, events, snapshots, artifactDrafts, landingDrafts };
+  };
+  const archive = createProviderActivityStreamArchive(dependencies);
+  return { archive, dependencies, events, snapshots, artifactDrafts, landingDrafts };
 }
 
 describe("provider activity stream archive", () => {
@@ -92,6 +97,44 @@ describe("provider activity stream archive", () => {
       artifactKey: ARTIFACT,
     });
     expect(JSON.stringify(state.landingDrafts[0])).not.toContain("200");
+  });
+
+  it("keeps interval and effort values private while publishing only bounded counts", async () => {
+    const intervals = setup();
+    await createProviderActivityIntervalsArchive(intervals.dependencies).write({
+      sourceRevision: REVISION,
+      response: {
+        id: "private-provider-id",
+        icuIntervals: [{ averageWatts: 271, label: "Private label" }],
+        icuGroups: [{ id: "private-group" }],
+      },
+      signal: new AbortController().signal,
+    });
+    expect(JSON.stringify(intervals.snapshots[0])).toContain("271");
+    expect(intervals.artifactDrafts[0]).toMatchObject({
+      lane: "streams",
+      externalId: `intervals:analysis:${REVISION}:${ADDRESS}`,
+    });
+    expect(JSON.stringify(intervals.landingDrafts[0])).not.toContain("271");
+    expect(JSON.stringify(intervals.landingDrafts[0])).not.toContain("Private label");
+    expect(JSON.stringify(intervals.landingDrafts[0])).not.toContain("private-provider-id");
+
+    const efforts = setup();
+    await createProviderActivityBestEffortsArchive(efforts.dependencies).write({
+      sourceRevision: REVISION,
+      durationSeconds: 300,
+      response: {
+        efforts: [{ average: 333, duration: 300, startIndex: 1, endIndex: 300, distance: 2_500 }],
+      },
+      signal: new AbortController().signal,
+    });
+    expect(JSON.stringify(efforts.snapshots[0])).toContain("333");
+    expect(efforts.artifactDrafts[0]).toMatchObject({
+      lane: "streams",
+      externalId: `best-efforts-300:analysis:${REVISION}:${ADDRESS}`,
+    });
+    expect(JSON.stringify(efforts.landingDrafts[0])).not.toContain("333");
+    expect(JSON.stringify(efforts.landingDrafts[0])).not.toContain("2500");
   });
 
   it("does not publish store evidence after cancellation", async () => {

--- a/packages/coach/tests/activity-analysis-provider.test.ts
+++ b/packages/coach/tests/activity-analysis-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { normalizeActivityStreams, type ActivityStream } from "intervals-icu-api";
 import {
   createBoundedActivityStreamFetch,
+  createProviderActivityAnalysisClientAccess,
   createProviderActivityStreamReader,
 } from "../src/activity-analysis-provider.js";
 
@@ -16,10 +17,13 @@ describe("provider activity stream reader", () => {
   it("does not create a client without credentials", async () => {
     const createClient = vi.fn();
     const archive = { write: vi.fn() };
-    const reader = createProviderActivityStreamReader({
+    const access = createProviderActivityAnalysisClientAccess({
       credentials: { read: async () => ({ apiKey: "", athleteId: "0" }) },
-      archive,
       createClient,
+    });
+    const reader = createProviderActivityStreamReader({
+      access,
+      archive,
     });
 
     await expect(
@@ -36,21 +40,25 @@ describe("provider activity stream reader", () => {
   it("archives bounded duplicate-safe evidence before returning it", async () => {
     const order: string[] = [];
     const normalized = normalizeActivityStreams(streams);
-    const reader = createProviderActivityStreamReader({
+    const access = createProviderActivityAnalysisClientAccess({
       credentials: { read: async () => ({ apiKey: "secret", athleteId: "0" }) },
+      createClient: () =>
+        ({
+          activities: {
+            getStreamMap: async () => {
+              order.push("fetch");
+              return { ok: true as const, value: normalized };
+            },
+          },
+        }) as never,
+    });
+    const reader = createProviderActivityStreamReader({
+      access,
       archive: {
         write: async () => {
           order.push("archive");
         },
       },
-      createClient: () => ({
-        activities: {
-          getStreamMap: async () => {
-            order.push("fetch");
-            return { ok: true as const, value: normalized };
-          },
-        },
-      }),
     });
 
     await expect(
@@ -64,22 +72,26 @@ describe("provider activity stream reader", () => {
   });
 
   it("maps provider rate limits to a refresh failure without exposing response details", async () => {
-    const reader = createProviderActivityStreamReader({
+    const access = createProviderActivityAnalysisClientAccess({
       credentials: { read: async () => ({ apiKey: "secret", athleteId: "0" }) },
+      createClient: () =>
+        ({
+          activities: {
+            getStreamMap: async () => ({
+              ok: false as const,
+              error: {
+                kind: "RateLimit" as const,
+                status: 429 as const,
+                retryAfterMs: 1,
+                body: "private",
+              },
+            }),
+          },
+        }) as never,
+    });
+    const reader = createProviderActivityStreamReader({
+      access,
       archive: { write: vi.fn() },
-      createClient: () => ({
-        activities: {
-          getStreamMap: async () => ({
-            ok: false as const,
-            error: {
-              kind: "RateLimit" as const,
-              status: 429 as const,
-              retryAfterMs: 1,
-              body: "private",
-            },
-          }),
-        },
-      }),
     });
 
     await expect(
@@ -89,6 +101,27 @@ describe("provider activity stream reader", () => {
         signal: new AbortController().signal,
       }),
     ).rejects.toMatchObject({ code: "rate-limited" });
+  });
+
+  it("shares a bounded physical request budget across readers for one source revision", async () => {
+    const createClient = vi.fn(() => ({ activities: {} }) as never);
+    const access = createProviderActivityAnalysisClientAccess({
+      credentials: { read: async () => ({ apiKey: "secret", athleteId: "0" }) },
+      createClient,
+      maximumRequestsPerRevision: 2,
+    });
+    const request = {
+      sourceRevision: REVISION,
+      signal: new AbortController().signal,
+      maximumBytes: 10,
+    };
+
+    await access.open(request);
+    await access.open(request);
+    await expect(access.open(request)).rejects.toMatchObject({
+      code: "request-budget-exhausted",
+    });
+    expect(createClient).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/coach/tests/activity-best-efforts.test.ts
+++ b/packages/coach/tests/activity-best-efforts.test.ts
@@ -1,0 +1,179 @@
+import type { CanonicalActivityDetail } from "@enduragent/kernel/store";
+import type { BestEfforts } from "intervals-icu-api";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_BEST_EFFORT_DURATION_SECONDS,
+  createBestEffortAnalyzer,
+  createProviderActivityBestEffortReader,
+  projectProviderBestEfforts,
+} from "../src/activity-best-efforts.js";
+
+const ACTIVITY_ID = "a".repeat(64);
+const REVISION = "b".repeat(64);
+
+const activity: CanonicalActivityDetail = {
+  id: ACTIVITY_ID,
+  workoutId: "c".repeat(64),
+  sessionSequence: 0,
+  isMultisport: false,
+  sport: "cycling",
+  subSport: "road",
+  isTransition: false,
+  startEpochSeconds: 1_000,
+  timezoneOffsetSeconds: 0,
+  localDate: "1998-07-06",
+  elapsedSeconds: 3_600,
+  timerSeconds: 3_500,
+  movingSeconds: 3_400,
+  distanceMeters: 36_000,
+  laps: [],
+};
+
+function response(): BestEfforts {
+  return {
+    efforts: [
+      { average: 300, distance: 2_500, duration: 300, startIndex: 800, endIndex: 1_099 },
+      { average: 310, distance: 2_600, duration: 300, startIndex: 1_200, endIndex: 1_499 },
+      { average: 300, distance: null, duration: 300, startIndex: 200, endIndex: 499 },
+    ],
+    privateField: "must-not-render",
+  } as BestEfforts;
+}
+
+describe("best-effort projection", () => {
+  it("ranks by average power and resolves ties by earliest start", () => {
+    const projected = projectProviderBestEfforts(response(), DEFAULT_BEST_EFFORT_DURATION_SECONDS);
+
+    expect(projected).toEqual({
+      scope: {
+        kind: "selected-activity",
+        stream: "power",
+        durationSeconds: 300,
+        tieRule: "earliest-start",
+      },
+      efforts: [
+        {
+          rank: 1,
+          startIndex: 1_200,
+          endIndex: 1_499,
+          durationSeconds: 300,
+          distanceMeters: 2_600,
+          averageWatts: 310,
+        },
+        {
+          rank: 2,
+          startIndex: 200,
+          endIndex: 499,
+          durationSeconds: 300,
+          distanceMeters: null,
+          averageWatts: 300,
+        },
+        {
+          rank: 3,
+          startIndex: 800,
+          endIndex: 1_099,
+          durationSeconds: 300,
+          distanceMeters: 2_500,
+          averageWatts: 300,
+        },
+      ],
+    });
+    expect(JSON.stringify(projected)).not.toContain("must-not-render");
+  });
+
+  it("fails closed for excess, mismatched, duplicate, and non-finite efforts", () => {
+    expect(() =>
+      projectProviderBestEfforts(
+        {
+          efforts: Array.from({ length: 11 }, (_, index) => ({
+            average: 200,
+            duration: 300,
+            startIndex: index * 300,
+            endIndex: index * 300 + 299,
+          })),
+        } as BestEfforts,
+        300,
+      ),
+    ).toThrow(expect.objectContaining({ code: "response-too-large" }));
+
+    const mismatched = response();
+    mismatched.efforts[0]!.duration = 60;
+    expect(() => projectProviderBestEfforts(mismatched, 300)).toThrow(
+      expect.objectContaining({ code: "malformed-response" }),
+    );
+
+    const duplicate = response();
+    duplicate.efforts[1]!.startIndex = duplicate.efforts[0]!.startIndex;
+    duplicate.efforts[1]!.endIndex = duplicate.efforts[0]!.endIndex;
+    expect(() => projectProviderBestEfforts(duplicate, 300)).toThrow(
+      expect.objectContaining({ code: "malformed-response" }),
+    );
+
+    const nonfinite = response();
+    nonfinite.efforts[0]!.average = Number.NaN;
+    expect(() => projectProviderBestEfforts(nonfinite, 300)).toThrow(
+      expect.objectContaining({ code: "malformed-response" }),
+    );
+  });
+});
+
+describe("best-effort acquisition", () => {
+  it("does not send unresolved canonical identity to the provider", async () => {
+    const read = vi.fn();
+    const analyzer = createBestEffortAnalyzer({ provider: { read } });
+
+    await expect(
+      analyzer.analyze({
+        activity,
+        sourceRevision: ACTIVITY_ID,
+        source: { kind: "unavailable", reason: "source-not-found" },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ kind: "unavailable", reason: "source-not-found" });
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("requests one fixed five-minute power search and archives before returning", async () => {
+    const events: string[] = [];
+    const findBestEfforts = vi.fn(async () => {
+      events.push("fetch");
+      return { ok: true as const, value: response() };
+    });
+    const reader = createProviderActivityBestEffortReader({
+      access: {
+        open: async () => ({
+          client: { activities: { findBestEfforts } as never },
+          responseLimitExceeded: () => false,
+        }),
+      },
+      archive: {
+        write: async () => {
+          events.push("archive");
+        },
+      },
+    });
+    const analyzer = createBestEffortAnalyzer({ provider: reader });
+
+    const analyzed = await analyzer.analyze({
+      activity,
+      sourceRevision: REVISION,
+      source: { kind: "resolved", providerActivityId: "provider-1" as never },
+      signal: new AbortController().signal,
+    });
+    expect(analyzed).toMatchObject({
+      kind: "computed",
+      source: "provider",
+      data: { scope: { durationSeconds: 300 } },
+    });
+    expect(analyzed.kind === "computed" ? analyzed.data.efforts[0] : undefined).toMatchObject({
+      rank: 1,
+      averageWatts: 310,
+    });
+    expect(findBestEfforts).toHaveBeenCalledWith("provider-1", {
+      stream: "watts",
+      duration: 300,
+      count: 10,
+    });
+    expect(events).toEqual(["fetch", "archive"]);
+  });
+});

--- a/packages/coach/tests/activity-interval-review.test.ts
+++ b/packages/coach/tests/activity-interval-review.test.ts
@@ -1,0 +1,215 @@
+import type { CanonicalActivityDetail } from "@enduragent/kernel/store";
+import type { ActivityIntervals } from "intervals-icu-api";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createIntervalReviewAnalyzer,
+  createProviderActivityIntervalReader,
+  projectProviderActivityIntervals,
+} from "../src/activity-interval-review.js";
+
+const ACTIVITY_ID = "a".repeat(64);
+const REVISION = "b".repeat(64);
+
+const activity: CanonicalActivityDetail = {
+  id: ACTIVITY_ID,
+  workoutId: "c".repeat(64),
+  sessionSequence: 0,
+  isMultisport: false,
+  sport: "cycling",
+  subSport: "road",
+  isTransition: false,
+  startEpochSeconds: 1_000,
+  timezoneOffsetSeconds: 0,
+  localDate: "1998-07-06",
+  elapsedSeconds: 600,
+  timerSeconds: 590,
+  movingSeconds: 580,
+  distanceMeters: 5_000,
+  laps: [
+    {
+      lapSequence: 0,
+      startEpochSeconds: 1_000,
+      elapsedSeconds: 300,
+      timerSeconds: 290,
+      distanceMeters: 2_500,
+    },
+    {
+      lapSequence: 1,
+      startEpochSeconds: 1_300,
+      elapsedSeconds: 300,
+      timerSeconds: 290,
+      distanceMeters: 2_500,
+    },
+  ],
+};
+
+function providerResponse(): ActivityIntervals {
+  return {
+    id: "private-provider-id",
+    icuIntervals: [
+      {
+        type: "WORK",
+        groupId: "group-1",
+        label: "Threshold",
+        startIndex: 10,
+        endIndex: 310,
+        startTime: 10,
+        endTime: 310,
+        movingTime: 300,
+        elapsedTime: 300,
+        distance: 2_500,
+        averageWatts: 250,
+        maxWatts: 310,
+        averageHeartrate: 155,
+        maxHeartrate: 170,
+        averageCadence: 91,
+        maxCadence: 104,
+        zone: 4,
+        intensity: 96,
+        trainingLoad: 12,
+        privateField: "must-not-render",
+      },
+      {
+        type: "RECOVERY",
+        groupId: "group-1",
+        label: null,
+        startIndex: 311,
+        endIndex: 430,
+        startTime: 311,
+        endTime: 430,
+        movingTime: 119,
+        elapsedTime: 120,
+        averageWatts: 110,
+      },
+    ],
+    icuGroups: [
+      {
+        id: "group-1",
+        movingTime: 419,
+        elapsedTime: 420,
+        averageWatts: 210,
+        averageHeartrate: 148,
+      },
+    ],
+  } as unknown as ActivityIntervals;
+}
+
+describe("provider interval projection", () => {
+  it("preserves provider order, semantic kinds, groups, and allowlisted metrics", () => {
+    const projected = projectProviderActivityIntervals(providerResponse());
+
+    expect(projected).toMatchObject({
+      source: "provider",
+      intervals: [
+        {
+          ordinal: 1,
+          groupOrdinal: 1,
+          kind: "work",
+          label: "Threshold",
+          averagePowerWatts: 250,
+          averageHeartRateBpm: 155,
+        },
+        {
+          ordinal: 2,
+          groupOrdinal: 1,
+          kind: "recovery",
+          label: null,
+          averagePowerWatts: 110,
+        },
+      ],
+      groups: [{ ordinal: 1, intervalOrdinals: [1, 2], kind: "unknown" }],
+    });
+    expect(JSON.stringify(projected)).not.toContain("private-provider-id");
+    expect(JSON.stringify(projected)).not.toContain("must-not-render");
+    expect(JSON.stringify(projected)).not.toContain("group-1");
+  });
+
+  it("fails closed for oversized, inconsistent, reversed, and unsafe provider data", () => {
+    expect(() =>
+      projectProviderActivityIntervals({
+        icuIntervals: Array.from({ length: 201 }, () => ({})),
+      } as ActivityIntervals),
+    ).toThrow(expect.objectContaining({ code: "response-too-large" }));
+
+    const missingGroup = providerResponse();
+    missingGroup.icuGroups = [];
+    expect(() => projectProviderActivityIntervals(missingGroup)).toThrow(
+      expect.objectContaining({ code: "malformed-response" }),
+    );
+
+    const reversed = providerResponse();
+    reversed.icuIntervals![0]!.endTime = 1;
+    expect(() => projectProviderActivityIntervals(reversed)).toThrow(
+      expect.objectContaining({ code: "malformed-response" }),
+    );
+
+    const unsafe = providerResponse();
+    unsafe.icuIntervals![0]!.label = "unsafe\u0000label";
+    expect(() => projectProviderActivityIntervals(unsafe)).toThrow(
+      expect.objectContaining({ code: "malformed-response" }),
+    );
+  });
+});
+
+describe("interval review acquisition", () => {
+  it("uses canonical laps for file-only activities and labels them as laps", async () => {
+    const read = vi.fn();
+    const analyzer = createIntervalReviewAnalyzer({ provider: { read } });
+
+    await expect(
+      analyzer.analyze({
+        activity,
+        sourceRevision: ACTIVITY_ID,
+        source: { kind: "unavailable", reason: "source-not-found" },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({
+      kind: "computed",
+      source: "local-canonical",
+      data: {
+        source: "local-canonical",
+        intervals: [
+          { ordinal: 1, kind: "lap", startSeconds: 0, endSeconds: 300 },
+          { ordinal: 2, kind: "lap", startSeconds: 300, endSeconds: 600 },
+        ],
+      },
+    });
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("archives a provider response before returning it to the analyzer", async () => {
+    const events: string[] = [];
+    const response = providerResponse();
+    const reader = createProviderActivityIntervalReader({
+      access: {
+        open: async () => ({
+          client: {
+            activities: {
+              getIntervals: async () => {
+                events.push("fetch");
+                return { ok: true as const, value: response };
+              },
+            } as never,
+          },
+          responseLimitExceeded: () => false,
+        }),
+      },
+      archive: {
+        write: async () => {
+          events.push("archive");
+        },
+      },
+    });
+    const analyzer = createIntervalReviewAnalyzer({ provider: reader });
+
+    await expect(
+      analyzer.analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "resolved", providerActivityId: "provider-1" as never },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({ kind: "computed", source: "provider" });
+    expect(events).toEqual(["fetch", "archive"]);
+  });
+});


### PR DESCRIPTION
## Summary

- add ordered intervals from intervals.icu with a conservative local-lap fallback
- add five-minute power efforts scoped explicitly to the selected ride
- share a bounded provider request budget and archive raw provider evidence privately before allowlisted projection
- isolate section refresh failures while preserving last-good analysis
- render responsive, keyboard- and screen-reader-friendly ride-review panels

## Acceptance criteria

- one default activity-analysis RPC requests aerobic drift, intervals, and best efforts
- provider calls share an 8-request budget per source revision; intervals are capped at 2 MiB and efforts at 256 KiB
- raw responses and provider identifiers never enter renderer DTOs or store landings
- provider interval order is preserved; groups are validated and remapped to local ordinals
- unresolved provider identity falls back only to recorded local laps and never fabricates sensor metrics
- efforts use measured power, a fixed 5-minute window, selected-ride scope, and earliest-start tie handling; the UI makes no personal-record claim
- missing values remain explicitly unavailable and each section has isolated retry/stale/loading behavior

## Verification

- pnpm check
- pnpm test: 551 files passed, 5 skipped; 8,260 tests passed, 15 skipped
- pnpm s8a: passed with only documented S8A-SUP-004 recording warnings
- production Electron build and real desktop integration scenario
- focused provider, archive, analyzer, controller, renderer, accessibility, cancellation, and privacy tests
- responsive visual QA at 720 x 800

## Release

Includes a patch changeset for cycling-coach.