### PR TITLE
feat(desktop): add ride distributions and power/HR response

### DIFF
--- a/.changeset/distributions-power-heart-rate.md
+++ b/.changeset/distributions-power-heart-rate.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Ride review now includes accessible power and heart-rate distribution charts with exact tables, plus a coverage-qualified server power and heart-rate response view.

--- a/apps/desktop-renderer/src/activity-analysis/controller.ts
+++ b/apps/desktop-renderer/src/activity-analysis/controller.ts
@@ -31,6 +31,9 @@ export const DEFAULT_RIDE_ANALYSIS_SECTIONS = [
   "aerobic-drift",
   "intervals",
   "best-efforts",
+  "power-distribution",
+  "heart-rate-distribution",
+  "power-heart-rate",
 ] as const satisfies readonly ActivityAnalysisSection[];
 
 export const EMPTY_RIDE_ANALYSIS: RideAnalysisViewState = Object.freeze({

--- a/apps/desktop-renderer/src/ui/training/RideResponseReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideResponseReview.tsx
@@ -1,0 +1,567 @@
+import type {
+  ActivityAnalysisData,
+  ActivityAnalysisSection,
+  AnalysisSection,
+} from "@enduragent/coach-contract";
+import type { ReactElement } from "react";
+import type { RideAnalysisViewState } from "../../activity-analysis/controller.js";
+import { analysisRefreshFailureCopy, analysisUnavailableCopy } from "./copy.js";
+import styles from "./TrainingView.module.css";
+
+const CHART_WIDTH = 640;
+const CHART_HEIGHT = 190;
+const CHART_LEFT = 52;
+const CHART_RIGHT = 18;
+const CHART_TOP = 14;
+const CHART_BOTTOM = 34;
+
+function offerRetry(reason: Parameters<typeof analysisUnavailableCopy>[0]): boolean {
+  return (
+    reason === "empty-response" ||
+    reason === "malformed-response" ||
+    reason === "response-too-large" ||
+    reason === "request-budget-exhausted" ||
+    reason === "rate-limited" ||
+    reason === "timeout" ||
+    reason === "network" ||
+    reason === "provider-unavailable" ||
+    reason === "cancelled" ||
+    reason === "temporary-failure"
+  );
+}
+
+function AnalysisRetry(props: {
+  readonly reason: Parameters<typeof analysisUnavailableCopy>[0] | null;
+  readonly onRefresh: (() => void) | null;
+  readonly fallback: string;
+}): ReactElement {
+  return (
+    <div className={styles.analysisUnavailable}>
+      <p>{props.reason === null ? props.fallback : analysisUnavailableCopy(props.reason)}</p>
+      {props.onRefresh !== null && (props.reason === null || offerRetry(props.reason)) ? (
+        <button type="button" className={styles.action} onClick={props.onRefresh}>
+          Try again
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function EvidenceStatus(props: {
+  readonly saved: boolean;
+  readonly refreshing: boolean;
+  readonly failed: boolean;
+  readonly refreshFailure?: Extract<
+    AnalysisSection<unknown>,
+    { readonly kind: "stale" }
+  >["refreshFailure"];
+}): ReactElement | null {
+  const notice =
+    props.refreshFailure !== undefined
+      ? `Showing the saved result. ${analysisRefreshFailureCopy(props.refreshFailure.code)}`
+      : props.failed
+        ? "Showing the previous result. The latest refresh did not finish."
+        : props.refreshing
+          ? "Refreshing this analysis…"
+          : props.saved
+            ? "Showing saved analysis."
+            : null;
+  return notice === null ? null : (
+    <p className={props.refreshing ? styles.analysisRefresh : styles.analysisNotice} role="status">
+      {notice}
+    </p>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  const roundedMinutes = Math.round(seconds / 60);
+  if (roundedMinutes < 1) return `${Math.round(seconds)} sec`;
+  const hours = Math.floor(roundedMinutes / 60);
+  const minutes = roundedMinutes % 60;
+  if (hours === 0) return `${minutes} min`;
+  return minutes === 0 ? `${hours} hr` : `${hours} hr ${minutes} min`;
+}
+
+function axisValue(value: number, unit: ActivityAnalysisData["powerDistribution"]["unit"]): string {
+  return `${Math.round(value)} ${unit === "watts" ? "W" : "bpm"}`;
+}
+
+function DistributionChart(props: {
+  readonly data: ActivityAnalysisData["powerDistribution"];
+  readonly label: string;
+}): ReactElement {
+  const first = props.data.buckets[0]!;
+  const last = props.data.buckets.at(-1)!;
+  const axisMinimum = first.lower;
+  const axisMaximum = last.upper;
+  const axisSpan = Math.max(axisMaximum - axisMinimum, 1);
+  const maximumSeconds = Math.max(...props.data.buckets.map((bucket) => bucket.seconds), 1);
+  const width = CHART_WIDTH - CHART_LEFT - CHART_RIGHT;
+  const height = CHART_HEIGHT - CHART_TOP - CHART_BOTTOM;
+  return (
+    <figure className={styles.distributionFigure}>
+      <svg
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        className={styles.distributionChart}
+        data-unit={props.data.unit}
+        aria-hidden="true"
+        focusable="false"
+      >
+        <line
+          className={styles.chartAxis}
+          x1={CHART_LEFT}
+          x2={CHART_LEFT}
+          y1={CHART_TOP}
+          y2={CHART_TOP + height}
+        />
+        <line
+          className={styles.chartAxis}
+          x1={CHART_LEFT}
+          x2={CHART_LEFT + width}
+          y1={CHART_TOP + height}
+          y2={CHART_TOP + height}
+        />
+        {props.data.buckets.map((bucket, index) => {
+          const x = CHART_LEFT + ((bucket.lower - axisMinimum) / axisSpan) * width;
+          const barWidth = Math.max(1, ((bucket.upper - bucket.lower) / axisSpan) * width - 1);
+          const barHeight = (bucket.seconds / maximumSeconds) * height;
+          return (
+            <rect
+              key={`${bucket.lower}-${bucket.upper}-${index}`}
+              className={styles.distributionBar}
+              x={x}
+              y={CHART_TOP + height - barHeight}
+              width={barWidth}
+              height={barHeight}
+              rx="2"
+            />
+          );
+        })}
+        <text className={styles.chartTick} x={CHART_LEFT} y={CHART_HEIGHT - 10}>
+          {Math.round(axisMinimum)}
+        </text>
+        <text
+          className={styles.chartTick}
+          x={CHART_LEFT + width}
+          y={CHART_HEIGHT - 10}
+          textAnchor="end"
+        >
+          {Math.round(axisMaximum)} {props.data.unit === "watts" ? "W" : "bpm"}
+        </text>
+        <text className={styles.chartTick} x={CHART_LEFT - 8} y={CHART_TOP + 5} textAnchor="end">
+          {formatDuration(maximumSeconds)}
+        </text>
+        <text
+          className={styles.chartTick}
+          x={CHART_LEFT - 8}
+          y={CHART_TOP + height}
+          textAnchor="end"
+        >
+          0
+        </text>
+      </svg>
+      <figcaption>
+        Horizontal position is {props.data.unit === "watts" ? "power" : "heart rate"}; bar height is
+        accumulated ride time. Gaps are left as recorded.
+      </figcaption>
+      <details className={styles.analysisTableDisclosure}>
+        <summary>Read {props.label.toLowerCase()} as a table</summary>
+        <div className={styles.analysisTableScroller}>
+          <table className={styles.analysisDataTable}>
+            <thead>
+              <tr>
+                <th scope="col">Range</th>
+                <th scope="col">Ride time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {props.data.buckets.map((bucket, index) => (
+                <tr key={`${bucket.lower}-${bucket.upper}-${index}`}>
+                  <th scope="row">
+                    {axisValue(bucket.lower, props.data.unit)}–
+                    {axisValue(bucket.upper, props.data.unit)}
+                  </th>
+                  <td>{formatDuration(bucket.seconds)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </figure>
+  );
+}
+
+function DistributionEvidence(props: {
+  readonly data: ActivityAnalysisData["powerDistribution"];
+  readonly label: string;
+  readonly saved: boolean;
+  readonly refreshing: boolean;
+  readonly failed: boolean;
+  readonly refreshFailure?: Extract<
+    AnalysisSection<ActivityAnalysisData["powerDistribution"]>,
+    { readonly kind: "stale" }
+  >["refreshFailure"];
+}): ReactElement {
+  return (
+    <>
+      <EvidenceStatus
+        saved={props.saved}
+        refreshing={props.refreshing}
+        failed={props.failed}
+        refreshFailure={props.refreshFailure}
+      />
+      <p className={styles.analysisSource}>
+        {formatDuration(props.data.totalSeconds)} of measured ride time ·{" "}
+        {props.data.buckets.length} recorded buckets
+      </p>
+      <DistributionChart data={props.data} label={props.label} />
+    </>
+  );
+}
+
+function DistributionPanel(props: {
+  readonly rideId: string;
+  readonly analysis: RideAnalysisViewState;
+  readonly sectionName: "power-distribution" | "heart-rate-distribution";
+  readonly resultKey: "powerDistribution" | "heartRateDistribution";
+  readonly title: string;
+  readonly intro: string;
+  readonly onRefresh: (() => void) | null;
+}): ReactElement {
+  const matches = props.analysis.activityId === props.rideId;
+  const section = matches ? props.analysis.sections[props.resultKey] : undefined;
+  const refreshing = matches && props.analysis.loadingSections.includes(props.sectionName);
+  const failed = matches && props.analysis.failedSections.includes(props.sectionName);
+  let content: ReactElement;
+  if (section?.kind === "computed") {
+    content = (
+      <DistributionEvidence
+        data={section.data}
+        label={props.title}
+        saved={section.provenance.delivery === "persisted-cache"}
+        refreshing={refreshing}
+        failed={failed}
+      />
+    );
+  } else if (section?.kind === "stale") {
+    content = (
+      <DistributionEvidence
+        data={section.lastGood.data}
+        label={props.title}
+        saved
+        refreshing={false}
+        failed={false}
+        refreshFailure={section.refreshFailure}
+      />
+    );
+  } else if (section?.kind === "unavailable") {
+    content = (
+      <AnalysisRetry
+        reason={section.reason}
+        fallback={`${props.title} could not be loaded right now.`}
+        onRefresh={props.onRefresh}
+      />
+    );
+  } else if (failed) {
+    content = (
+      <AnalysisRetry
+        reason={null}
+        fallback={`${props.title} could not be loaded right now.`}
+        onRefresh={props.onRefresh}
+      />
+    );
+  } else {
+    content = (
+      <p className={styles.analysisLoading} role="status">
+        Checking {props.title.toLowerCase()}…
+      </p>
+    );
+  }
+  const titleId = `${props.resultKey}-title`;
+  return (
+    <section className={styles.analysisPanel} aria-labelledby={titleId}>
+      <p className={styles.rideEyebrow}>Measured ride time</p>
+      <h2 id={titleId} className={styles.analysisTitle}>
+        {props.title}
+      </h2>
+      <p className={styles.analysisIntro}>{props.intro}</p>
+      {content}
+    </section>
+  );
+}
+
+function ScatterChart(props: {
+  readonly data: ActivityAnalysisData["powerHeartRate"];
+}): ReactElement {
+  const watts = props.data.rows.map((row) => row.watts);
+  const heartRates = props.data.rows.map((row) => row.heartRateBpm);
+  const minimumWatts = Math.min(...watts);
+  const maximumWatts = Math.max(...watts);
+  const minimumHeartRate = Math.min(...heartRates);
+  const maximumHeartRate = Math.max(...heartRates);
+  const wattsSpan = Math.max(maximumWatts - minimumWatts, 1);
+  const heartRateSpan = Math.max(maximumHeartRate - minimumHeartRate, 1);
+  const width = CHART_WIDTH - CHART_LEFT - CHART_RIGHT;
+  const height = CHART_HEIGHT - CHART_TOP - CHART_BOTTOM;
+  return (
+    <figure className={styles.responseFigure}>
+      <svg
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        className={styles.responseChart}
+        aria-hidden="true"
+        focusable="false"
+      >
+        <line
+          className={styles.chartAxis}
+          x1={CHART_LEFT}
+          x2={CHART_LEFT}
+          y1={CHART_TOP}
+          y2={CHART_TOP + height}
+        />
+        <line
+          className={styles.chartAxis}
+          x1={CHART_LEFT}
+          x2={CHART_LEFT + width}
+          y1={CHART_TOP + height}
+          y2={CHART_TOP + height}
+        />
+        {props.data.rows.map((row, index) => {
+          const x = CHART_LEFT + ((row.watts - minimumWatts) / wattsSpan) * width;
+          const y =
+            CHART_TOP + height - ((row.heartRateBpm - minimumHeartRate) / heartRateSpan) * height;
+          return (
+            <circle
+              key={`${row.startSeconds}-${index}`}
+              className={styles.responsePoint}
+              cx={x}
+              cy={y}
+              r="4"
+            />
+          );
+        })}
+        <text className={styles.chartTick} x={CHART_LEFT} y={CHART_HEIGHT - 10}>
+          {Math.round(minimumWatts)} W
+        </text>
+        <text
+          className={styles.chartTick}
+          x={CHART_LEFT + width}
+          y={CHART_HEIGHT - 10}
+          textAnchor="end"
+        >
+          {Math.round(maximumWatts)} W
+        </text>
+        <text className={styles.chartTick} x={CHART_LEFT - 8} y={CHART_TOP + 5} textAnchor="end">
+          {Math.round(maximumHeartRate)}
+        </text>
+        <text
+          className={styles.chartTick}
+          x={CHART_LEFT - 8}
+          y={CHART_TOP + height}
+          textAnchor="end"
+        >
+          {Math.round(minimumHeartRate)} bpm
+        </text>
+      </svg>
+      <figcaption>
+        Each dot is one retained server-cleaned ride segment: power is horizontal and lag-adjusted
+        heart rate is vertical. No missing points or lines are interpolated.
+      </figcaption>
+      <details className={styles.analysisTableDisclosure}>
+        <summary>Read all power and heart-rate points as a table</summary>
+        <div className={styles.analysisTableScroller}>
+          <table className={styles.analysisDataTable}>
+            <thead>
+              <tr>
+                <th scope="col">Ride time</th>
+                <th scope="col">Power</th>
+                <th scope="col">Heart rate</th>
+                <th scope="col">Cadence</th>
+                <th scope="col">Segment</th>
+              </tr>
+            </thead>
+            <tbody>
+              {props.data.rows.map((row, index) => (
+                <tr key={`${row.startSeconds}-${index}`}>
+                  <th scope="row">{formatDuration(row.startSeconds)}</th>
+                  <td>{Math.round(row.watts)} W</td>
+                  <td>{Math.round(row.heartRateBpm)} bpm</td>
+                  <td>
+                    {row.cadenceRpm === null ? "Unavailable" : `${Math.round(row.cadenceRpm)} rpm`}
+                  </td>
+                  <td>{formatDuration(row.movingSeconds ?? row.seconds)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </figure>
+  );
+}
+
+function PowerHeartRateEvidence(props: {
+  readonly data: ActivityAnalysisData["powerHeartRate"];
+  readonly saved: boolean;
+  readonly refreshing: boolean;
+  readonly failed: boolean;
+  readonly refreshFailure?: Extract<
+    AnalysisSection<ActivityAnalysisData["powerHeartRate"]>,
+    { readonly kind: "stale" }
+  >["refreshFailure"];
+}): ReactElement {
+  const coverage = Math.round(props.data.coverageFraction * 100);
+  return (
+    <>
+      <EvidenceStatus
+        saved={props.saved}
+        refreshing={props.refreshing}
+        failed={props.failed}
+        refreshFailure={props.refreshFailure}
+      />
+      <div className={styles.responseSummary}>
+        <div>
+          <p className={styles.responseValue}>{props.data.rows.length}</p>
+          <p>retained segments</p>
+        </div>
+        <div>
+          <p className={styles.responseValue}>{coverage}%</p>
+          <p>ride coverage</p>
+        </div>
+        <span className={styles.responseCoverage} data-limited={coverage < 80}>
+          {coverage < 80 ? "Limited coverage" : "Strong coverage"}
+        </span>
+      </div>
+      <dl className={styles.responseMeta}>
+        <div>
+          <dt>HR lag adjustment</dt>
+          <dd>
+            {props.data.heartRateLagSeconds === null
+              ? "Applied by server; duration unavailable"
+              : formatDuration(props.data.heartRateLagSeconds)}
+          </dd>
+        </div>
+        <div>
+          <dt>Warm-up excluded</dt>
+          <dd>
+            {props.data.warmupSeconds === null
+              ? "Unavailable"
+              : formatDuration(props.data.warmupSeconds)}
+          </dd>
+        </div>
+        <div>
+          <dt>Cool-down excluded</dt>
+          <dd>
+            {props.data.cooldownSeconds === null
+              ? "Unavailable"
+              : formatDuration(props.data.cooldownSeconds)}
+          </dd>
+        </div>
+      </dl>
+      <ScatterChart data={props.data} />
+    </>
+  );
+}
+
+function PowerHeartRatePanel(props: {
+  readonly rideId: string;
+  readonly analysis: RideAnalysisViewState;
+  readonly onRefresh: (() => void) | null;
+}): ReactElement {
+  const matches = props.analysis.activityId === props.rideId;
+  const section = matches ? props.analysis.sections.powerHeartRate : undefined;
+  const refreshing = matches && props.analysis.loadingSections.includes("power-heart-rate");
+  const failed = matches && props.analysis.failedSections.includes("power-heart-rate");
+  let content: ReactElement;
+  if (section?.kind === "computed") {
+    content = (
+      <PowerHeartRateEvidence
+        data={section.data}
+        saved={section.provenance.delivery === "persisted-cache"}
+        refreshing={refreshing}
+        failed={failed}
+      />
+    );
+  } else if (section?.kind === "stale") {
+    content = (
+      <PowerHeartRateEvidence
+        data={section.lastGood.data}
+        saved
+        refreshing={false}
+        failed={false}
+        refreshFailure={section.refreshFailure}
+      />
+    );
+  } else if (section?.kind === "unavailable") {
+    content = (
+      <AnalysisRetry
+        reason={section.reason}
+        fallback="Power and heart-rate response could not be loaded right now."
+        onRefresh={props.onRefresh}
+      />
+    );
+  } else if (failed) {
+    content = (
+      <AnalysisRetry
+        reason={null}
+        fallback="Power and heart-rate response could not be loaded right now."
+        onRefresh={props.onRefresh}
+      />
+    );
+  } else {
+    content = (
+      <p className={styles.analysisLoading} role="status">
+        Checking the power and heart-rate response…
+      </p>
+    );
+  }
+  return (
+    <section className={styles.analysisPanel} aria-labelledby="power-heart-rate-title">
+      <p className={styles.rideEyebrow}>Server-produced relationship</p>
+      <h2 id="power-heart-rate-title" className={styles.analysisTitle}>
+        Power and heart-rate response
+      </h2>
+      <p className={styles.analysisIntro}>
+        Shows intervals.icu's cleaned, lag-adjusted relationship for this ride. It is separate from
+        the local aerobic drift estimate and does not prescribe training on its own.
+      </p>
+      {content}
+    </section>
+  );
+}
+
+export function RideResponseReview(props: {
+  readonly rideId: string;
+  readonly analysis: RideAnalysisViewState;
+  readonly onRefresh: ((sections: readonly ActivityAnalysisSection[]) => void) | null;
+}): ReactElement {
+  const refresh = (section: ActivityAnalysisSection): (() => void) | null =>
+    props.onRefresh === null ? null : () => props.onRefresh?.([section]);
+  return (
+    <>
+      <DistributionPanel
+        rideId={props.rideId}
+        analysis={props.analysis}
+        sectionName="power-distribution"
+        resultKey="powerDistribution"
+        title="Power distribution"
+        intro="Shows how much measured ride time fell inside each recorded power range. Missing ranges are not filled with zeros."
+        onRefresh={refresh("power-distribution")}
+      />
+      <DistributionPanel
+        rideId={props.rideId}
+        analysis={props.analysis}
+        sectionName="heart-rate-distribution"
+        resultKey="heartRateDistribution"
+        title="Heart-rate distribution"
+        intro="Shows how much measured ride time fell inside each recorded heart-rate range. It can load even when power data is unavailable."
+        onRefresh={refresh("heart-rate-distribution")}
+      />
+      <PowerHeartRatePanel
+        rideId={props.rideId}
+        analysis={props.analysis}
+        onRefresh={refresh("power-heart-rate")}
+      />
+    </>
+  );
+}

--- a/apps/desktop-renderer/src/ui/training/RideReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideReview.tsx
@@ -11,6 +11,7 @@ import type { RideAnalysisViewState } from "../../activity-analysis/controller.j
 import { formatDateLabel } from "../../training-context/format.js";
 import { Page } from "../shared/Page.js";
 import { analysisRefreshFailureCopy, analysisUnavailableCopy } from "./copy.js";
+import { RideResponseReview } from "./RideResponseReview.js";
 import styles from "./TrainingView.module.css";
 
 const RIDE_KIND: Readonly<Record<string, string>> = {
@@ -716,6 +717,11 @@ export function RideDetailView(props: {
             ? null
             : () => props.onRefreshAnalysis?.(["best-efforts"])
         }
+      />
+      <RideResponseReview
+        rideId={props.ride.id}
+        analysis={props.analysis}
+        onRefresh={props.onRefreshAnalysis}
       />
     </Page>
   );

--- a/apps/desktop-renderer/src/ui/training/TrainingView.module.css
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.module.css
@@ -844,6 +844,190 @@
   font: 9.5px/1.4 var(--f-mono);
 }
 
+.distributionFigure,
+.responseFigure {
+  margin: 16px 0 0;
+}
+
+.distributionChart,
+.responseChart {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.chartAxis {
+  stroke: var(--line-2);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.chartTick {
+  fill: var(--ink-3);
+  font: 9px var(--f-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.distributionBar {
+  fill: var(--brand);
+  opacity: 0.78;
+}
+
+.distributionChart[data-unit="bpm"] .distributionBar {
+  fill: var(--ink-2);
+}
+
+.distributionFigure figcaption,
+.responseFigure figcaption {
+  max-width: 660px;
+  margin: 8px 0 0;
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.analysisTableDisclosure {
+  margin: 13px 0 0;
+  border-top: 1px solid var(--line);
+}
+
+.analysisTableDisclosure summary {
+  width: fit-content;
+  padding: 11px 2px 2px;
+  color: var(--ink-2);
+  cursor: pointer;
+  font: 10px/1.4 var(--f-mono);
+}
+
+.analysisTableDisclosure summary:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 3px;
+}
+
+.analysisTableScroller {
+  max-height: 320px;
+  margin-top: 10px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+.analysisDataTable {
+  width: 100%;
+  border-collapse: collapse;
+  color: var(--ink-2);
+  font: 10px/1.4 var(--f-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.analysisDataTable th,
+.analysisDataTable td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.analysisDataTable thead th {
+  position: sticky;
+  z-index: 1;
+  top: 0;
+  background: var(--surface);
+  color: var(--ink-3);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.analysisDataTable tbody tr:last-child > * {
+  border-bottom: 0;
+}
+
+.analysisDataTable tbody th {
+  font-weight: 500;
+}
+
+.responsePoint {
+  fill: var(--brand);
+  stroke: var(--surface);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.responseSummary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
+  gap: 12px;
+  align-items: center;
+  margin: 16px 0 0;
+}
+
+.responseSummary > div {
+  min-width: 0;
+  padding-right: 12px;
+  border-right: 1px solid var(--line);
+}
+
+.responseSummary p {
+  margin: 0;
+}
+
+.responseSummary > div > p:last-child {
+  margin-top: 4px;
+  color: var(--ink-3);
+  font-size: 10px;
+}
+
+.responseValue {
+  font: 600 22px/1 var(--f-dis);
+  font-variant-numeric: tabular-nums;
+}
+
+.responseCoverage {
+  justify-self: end;
+  padding: 5px 8px;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  color: var(--ink-2);
+  font: 9px/1 var(--f-mono);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.responseCoverage[data-limited="true"] {
+  border-color: var(--brand);
+}
+
+.responseMeta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 14px 0 0;
+}
+
+.responseMeta > div {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+.responseMeta dt {
+  color: var(--ink-3);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.responseMeta dd {
+  margin: 5px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-2);
+  font: 10px/1.4 var(--f-mono);
+  font-variant-numeric: tabular-nums;
+}
+
 .rideEyebrow {
   margin: 0 0 8px;
   color: var(--ink-3);
@@ -926,6 +1110,19 @@
 
   .effortList {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .responseSummary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .responseCoverage {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .responseMeta {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/apps/desktop-renderer/tests/activity-analysis-controller.test.ts
+++ b/apps/desktop-renderer/tests/activity-analysis-controller.test.ts
@@ -97,7 +97,14 @@ describe("ride analysis controller", () => {
       "getActivityAnalysis",
       {
         canonicalActivityId: FIRST,
-        sections: ["aerobic-drift", "intervals", "best-efforts"],
+        sections: [
+          "aerobic-drift",
+          "intervals",
+          "best-efforts",
+          "power-distribution",
+          "heart-rate-distribution",
+          "power-heart-rate",
+        ],
       },
       { signal: expect.any(AbortSignal) },
     );

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -558,6 +558,104 @@ describe("training page", () => {
     expect(document.body).not.toHaveTextContent(ride.id);
   });
 
+  it("shows independent accessible distributions and a distinct server power/HR response", async () => {
+    const user = userEvent.setup();
+    if (context.recentRides.kind !== "computed") throw new Error("expected fixture rides");
+    const ride = context.recentRides.items[0]!;
+    const provenance = {
+      source: "provider" as const,
+      delivery: "live" as const,
+      observedAt: "1998-07-19T08:00:00.000Z",
+    };
+    useEnduragentStore.setState({
+      rideAnalysis: {
+        activityId: ride.id,
+        status: "ready",
+        revision: "c".repeat(64),
+        loadingSections: [],
+        failedSections: [],
+        sections: {
+          powerDistribution: {
+            kind: "computed",
+            data: {
+              unit: "watts",
+              buckets: [
+                { lower: 0, upper: 100, seconds: 300 },
+                { lower: 100, upper: 200, seconds: 600 },
+                { lower: 225, upper: 300, seconds: 120 },
+              ],
+              totalSeconds: 1_020,
+            },
+            provenance,
+          },
+          heartRateDistribution: {
+            kind: "computed",
+            data: {
+              unit: "bpm",
+              buckets: [
+                { lower: 110, upper: 130, seconds: 420 },
+                { lower: 130, upper: 150, seconds: 600 },
+              ],
+              totalSeconds: 1_020,
+            },
+            provenance,
+          },
+          powerHeartRate: {
+            kind: "computed",
+            data: {
+              source: "provider",
+              rows: Array.from({ length: 6 }, (_, index) => ({
+                startSeconds: index * 60,
+                watts: 150 + index * 10,
+                heartRateBpm: 120 + index * 2,
+                cadenceRpm: index === 0 ? null : 85 + index,
+                movingSeconds: 60,
+                seconds: 60,
+              })),
+              curves: [{ kind: "all", coefficients: [100, 0.1], rSquared: 0.9 }],
+              coverageFraction: 0.6,
+              heartRateLagSeconds: 15,
+              warmupSeconds: 60,
+              cooldownSeconds: 30,
+            },
+            provenance,
+          },
+        },
+      },
+    });
+    render(<TrainingView />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Review road ride from 1998-07-09 · 22:00, 1h 31m, 42.1 km",
+      }),
+    );
+
+    const power = screen.getByRole("region", { name: "Power distribution" });
+    expect(power).toHaveTextContent("17 min of measured ride time · 3 recorded buckets");
+    expect(power).toHaveTextContent("Gaps are left as recorded");
+    await user.click(within(power).getByText("Read power distribution as a table"));
+    const powerTable = within(power).getByRole("table");
+    expect(within(powerTable).getByText("0 W–100 W")).toBeInTheDocument();
+    expect(within(powerTable).getAllByRole("row")).toHaveLength(4);
+
+    const heartRate = screen.getByRole("region", { name: "Heart-rate distribution" });
+    expect(heartRate).toHaveTextContent("can load even when power data is unavailable");
+    await user.click(within(heartRate).getByText("Read heart-rate distribution as a table"));
+    expect(within(heartRate).getByText("110 bpm–130 bpm")).toBeInTheDocument();
+
+    const response = screen.getByRole("region", { name: "Power and heart-rate response" });
+    expect(response).toHaveTextContent("server-cleaned ride segment");
+    expect(response).toHaveTextContent("No missing points or lines are interpolated");
+    expect(response).toHaveTextContent("60%");
+    expect(response).toHaveTextContent("Limited coverage");
+    expect(response).toHaveTextContent("separate from the local aerobic drift estimate");
+    await user.click(within(response).getByText("Read all power and heart-rate points as a table"));
+    expect(within(response).getByRole("table")).toHaveTextContent("150 W");
+    expect(document.body).not.toHaveTextContent("provider-");
+    expect(document.body).not.toHaveTextContent(ride.id);
+  });
+
   it("explains deterministic unavailable states without offering a pointless retry", async () => {
     const user = userEvent.setup();
     if (context.recentRides.kind !== "computed") throw new Error("expected fixture rides");

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -275,6 +275,63 @@ function makeScript(
                 observedAt: "2026-07-19T08:00:00.000Z",
               },
             },
+            powerDistribution: {
+              kind: "computed",
+              data: {
+                unit: "watts",
+                buckets: [
+                  { lower: 0, upper: 100, seconds: 300 },
+                  { lower: 100, upper: 200, seconds: 600 },
+                  { lower: 225, upper: 300, seconds: 120 },
+                ],
+                totalSeconds: 1_020,
+              },
+              provenance: {
+                source: "provider",
+                delivery: "live",
+                observedAt: "2026-07-19T08:00:00.000Z",
+              },
+            },
+            heartRateDistribution: {
+              kind: "computed",
+              data: {
+                unit: "bpm",
+                buckets: [
+                  { lower: 110, upper: 130, seconds: 420 },
+                  { lower: 130, upper: 150, seconds: 600 },
+                ],
+                totalSeconds: 1_020,
+              },
+              provenance: {
+                source: "provider",
+                delivery: "live",
+                observedAt: "2026-07-19T08:00:00.000Z",
+              },
+            },
+            powerHeartRate: {
+              kind: "computed",
+              data: {
+                source: "provider",
+                rows: Array.from({ length: 6 }, (_, index) => ({
+                  startSeconds: index * 60,
+                  watts: 150 + index * 10,
+                  heartRateBpm: 120 + index * 2,
+                  cadenceRpm: index === 0 ? null : 85 + index,
+                  movingSeconds: 60,
+                  seconds: 60,
+                })),
+                curves: [{ kind: "all", coefficients: [100, 0.1], rSquared: 0.9 }],
+                coverageFraction: 0.6,
+                heartRateLagSeconds: 15,
+                warmupSeconds: 60,
+                cooldownSeconds: 30,
+              },
+              provenance: {
+                source: "provider",
+                delivery: "live",
+                observedAt: "2026-07-19T08:00:00.000Z",
+              },
+            },
           },
         });
       }
@@ -1445,6 +1502,11 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly documentOverflow: boolean;
       readonly drift: string;
       readonly limitation: string;
+      readonly interval: string;
+      readonly efforts: string;
+      readonly powerDistribution: boolean;
+      readonly heartRateDistribution: boolean;
+      readonly powerHeartRate: boolean;
     }>(`
       const recent = document.querySelector('[data-panel="recent-rides"]');
       const opener = recent.querySelector("button");
@@ -1457,12 +1519,17 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       const page = document.querySelector('section[aria-label="Ride review"]');
       const analysisDeadline = Date.now() + 5000;
       while (
-        (!page.textContent.includes("+4.8%") || !page.textContent.includes("Threshold")) &&
+        (!page.textContent.includes("+4.8%") ||
+          !page.textContent.includes("Threshold") ||
+          !page.textContent.includes("17 min of measured ride time · 3 recorded buckets") ||
+          !page.textContent.includes("17 min of measured ride time · 2 recorded buckets") ||
+          !page.textContent.includes("60%ride coverage")) &&
         Date.now() < analysisDeadline
       ) {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
       const title = page.querySelector("h1");
+      const powerHeartRatePanel = page.querySelector('[aria-labelledby="power-heart-rate-title"]');
       return {
         page: page.getAttribute("aria-label"),
         titleFocused: document.activeElement === title,
@@ -1476,6 +1543,15 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         limitation: page.querySelector('[aria-label="Analysis limitations"]')?.textContent ?? "",
         interval: page.querySelector('[aria-labelledby="interval-review-title"]')?.textContent ?? "",
         efforts: page.querySelector('[aria-labelledby="best-efforts-title"]')?.textContent ?? "",
+        powerDistribution: page
+          .querySelector('[aria-labelledby="powerDistribution-title"]')
+          ?.textContent.includes("17 min of measured ride time · 3 recorded buckets") ?? false,
+        heartRateDistribution: page
+          .querySelector('[aria-labelledby="heartRateDistribution-title"]')
+          ?.textContent.includes("17 min of measured ride time · 2 recorded buckets") ?? false,
+        powerHeartRate:
+          powerHeartRatePanel?.textContent.includes("60%ride coverage") === true &&
+          powerHeartRatePanel.textContent.includes("No missing points or lines are interpolated."),
       };
     `);
     expect(rideReview).toEqual({
@@ -1491,6 +1567,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "Ordered ride segmentsIntervals and lapsShows recorded segments in order. Missing metrics stay unavailable, and no planned workout targets are inferred.Ordered analysis from intervals.icu1WorkThresholdDuration5 minDistance2.5 kmPower250 avg · 310 max WHeart rate155 avg · 170 max bpm",
       efforts:
         "Selected-ride scopeFive-minute best effortsRanks measured five-minute power efforts from this ride only. It does not compare against other rides or all-history results.This ride · power · 5 min · equal efforts rank the earlier start first#1310 W2.6 km",
+      powerDistribution: true,
+      heartRateDistribution: true,
+      powerHeartRate: true,
     });
     const rideReturn = await fixture.evaluate<{
       readonly page: string | null;
@@ -1583,7 +1662,14 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         method: "getActivityAnalysis",
         params: {
           canonicalActivityId: "c".repeat(64),
-          sections: ["aerobic-drift", "intervals", "best-efforts"],
+          sections: [
+            "aerobic-drift",
+            "intervals",
+            "best-efforts",
+            "power-distribution",
+            "heart-rate-distribution",
+            "power-heart-rate",
+          ],
         },
       },
     ]);

--- a/packages/coach-contract/src/activity-analysis.ts
+++ b/packages/coach-contract/src/activity-analysis.ts
@@ -366,7 +366,7 @@ export const DistributionBucketSchema = z
 export const DistributionDataSchema = z
   .object({
     unit: z.enum(["watts", "bpm"]),
-    buckets: z.array(DistributionBucketSchema).max(MAX_ACTIVITY_ANALYSIS_BUCKETS),
+    buckets: z.array(DistributionBucketSchema).min(1).max(MAX_ACTIVITY_ANALYSIS_BUCKETS),
     totalSeconds: NonnegativeFiniteSchema.max(7 * 86_400),
   })
   .strict()
@@ -404,7 +404,7 @@ export const PowerHeartRateCurveSchema = z
 export const PowerHeartRateDataSchema = z
   .object({
     source: z.literal("provider"),
-    rows: z.array(PowerHeartRateRowSchema).max(MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_ROWS),
+    rows: z.array(PowerHeartRateRowSchema).min(1).max(MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_ROWS),
     curves: z.array(PowerHeartRateCurveSchema).max(MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_CURVES),
     coverageFraction: z.number().finite().min(0).max(1),
     heartRateLagSeconds: NullableNonnegativeFiniteSchema,

--- a/packages/coach-contract/tests/activity-analysis.test.ts
+++ b/packages/coach-contract/tests/activity-analysis.test.ts
@@ -233,6 +233,16 @@ describe("activity analysis contract", () => {
     expect(ActivityAnalysisResultSchema.safeParse({
       ...concrete,
       sections: {
+        powerDistribution: {
+          kind: "computed",
+          data: { unit: "watts", buckets: [], totalSeconds: 0 },
+          provenance: { ...provenance, source: "provider" },
+        },
+      },
+    }).success).toBe(false);
+    expect(ActivityAnalysisResultSchema.safeParse({
+      ...concrete,
+      sections: {
         powerHeartRate: {
           kind: "computed",
           data: {
@@ -244,7 +254,7 @@ describe("activity analysis contract", () => {
             warmupSeconds: null,
             cooldownSeconds: null,
           },
-          provenance,
+          provenance: { ...provenance, source: "provider" },
         },
       },
     }).success).toBe(false);

--- a/packages/coach/src/activity-analysis-archive.ts
+++ b/packages/coach/src/activity-analysis-archive.ts
@@ -1,6 +1,11 @@
 import { canonicalJson, type ArchiveManager } from "@enduragent/kernel/archive";
 import type { IntervalsSourceRepository, SqlStore } from "@enduragent/kernel/store";
-import type { ActivityIntervals, BestEfforts } from "intervals-icu-api";
+import type {
+  ActivityIntervals,
+  BestEfforts,
+  HistogramBucket,
+  PowerVsHeartRatePlot,
+} from "intervals-icu-api";
 import type {
   ProviderActivityStreamArchive,
   ProviderActivityStreamArchiveRequest,
@@ -37,6 +42,27 @@ export interface ProviderActivityBestEffortsArchiveRequest {
 
 export interface ProviderActivityBestEffortsArchive {
   write(input: ProviderActivityBestEffortsArchiveRequest): Promise<void>;
+}
+
+export interface ProviderActivityHistogramArchiveRequest {
+  readonly sourceRevision: string;
+  readonly metric: "power" | "heart-rate";
+  readonly response: readonly HistogramBucket[];
+  readonly signal: AbortSignal;
+}
+
+export interface ProviderActivityHistogramArchive {
+  write(input: ProviderActivityHistogramArchiveRequest): Promise<void>;
+}
+
+export interface ProviderActivityPowerHeartRateArchiveRequest {
+  readonly sourceRevision: string;
+  readonly response: PowerVsHeartRatePlot;
+  readonly signal: AbortSignal;
+}
+
+export interface ProviderActivityPowerHeartRateArchive {
+  write(input: ProviderActivityPowerHeartRateArchiveRequest): Promise<void>;
 }
 
 function cloneJson<T>(value: T): T {
@@ -165,6 +191,61 @@ export function createProviderActivityBestEffortsArchive(
         landing: {
           duration_seconds: request.durationSeconds,
           effort_count: response.efforts.length,
+          schema_version: 1,
+          source_revision: request.sourceRevision,
+        },
+        signal: request.signal,
+      });
+    },
+  });
+}
+
+export function createProviderActivityHistogramArchive(
+  input: ProviderActivityAnalysisArchiveDependencies,
+): ProviderActivityHistogramArchive {
+  return Object.freeze({
+    async write(request: ProviderActivityHistogramArchiveRequest) {
+      const response = cloneJson(request.response);
+      await publishEvidence({
+        dependencies: input,
+        sourceRevision: request.sourceRevision,
+        externalPrefix: `${request.metric}-histogram`,
+        snapshot: {
+          schema_version: 1,
+          source_revision: request.sourceRevision,
+          metric: request.metric,
+          response,
+        },
+        landing: {
+          bucket_count: response.length,
+          metric: request.metric,
+          schema_version: 1,
+          source_revision: request.sourceRevision,
+        },
+        signal: request.signal,
+      });
+    },
+  });
+}
+
+export function createProviderActivityPowerHeartRateArchive(
+  input: ProviderActivityAnalysisArchiveDependencies,
+): ProviderActivityPowerHeartRateArchive {
+  return Object.freeze({
+    async write(request: ProviderActivityPowerHeartRateArchiveRequest) {
+      const response = cloneJson(request.response);
+      await publishEvidence({
+        dependencies: input,
+        sourceRevision: request.sourceRevision,
+        externalPrefix: "power-heart-rate",
+        snapshot: {
+          schema_version: 1,
+          source_revision: request.sourceRevision,
+          response,
+        },
+        landing: {
+          curve_count: Array.isArray(response.curves) ? response.curves.length : 0,
+          row_count: Array.isArray(response.series) ? response.series.length : 0,
           schema_version: 1,
           source_revision: request.sourceRevision,
         },

--- a/packages/coach/src/activity-distribution.ts
+++ b/packages/coach/src/activity-distribution.ts
@@ -1,0 +1,175 @@
+import {
+  DistributionDataSchema,
+  MAX_ACTIVITY_ANALYSIS_BUCKETS,
+  type ActivityAnalysisData,
+} from "@enduragent/coach-contract";
+import { z } from "zod";
+import type { HistogramBucket } from "intervals-icu-api";
+import type { ProviderActivityHistogramArchive } from "./activity-analysis-archive.js";
+import {
+  ActivityAnalysisComputationError,
+  type ActivityAnalysisSectionAnalyzer,
+  type ActivityAnalysisSectionInput,
+  type ActivityAnalysisSectionOutput,
+} from "./activity-analysis-service.js";
+import {
+  providerActivityFailure,
+  type ProviderActivityAnalysisClientAccess,
+} from "./activity-analysis-provider.js";
+
+export const ACTIVITY_HISTOGRAM_RESPONSE_LIMIT_BYTES = 256 * 1_024;
+
+export type ActivityDistributionMetric = "power" | "heart-rate";
+
+interface ProviderActivityHistogramReadRequest {
+  readonly providerActivityId: string;
+  readonly sourceRevision: string;
+  readonly metric: ActivityDistributionMetric;
+  readonly signal: AbortSignal;
+}
+
+const ProviderHistogramBucketSchema = z
+  .object({
+    min: z.number().finite().nonnegative(),
+    max: z.number().finite().positive(),
+    secs: z
+      .number()
+      .finite()
+      .nonnegative()
+      .max(7 * 86_400),
+  })
+  .passthrough()
+  .refine((value) => value.min < value.max, {
+    path: ["max"],
+    message: "histogram bucket is empty",
+  });
+
+export interface ProviderActivityHistogramReader {
+  read(input: ProviderActivityHistogramReadRequest): Promise<readonly HistogramBucket[]>;
+}
+
+function maximumAxis(metric: ActivityDistributionMetric): number {
+  return metric === "power" ? 100_000 : 400;
+}
+
+function unit(metric: ActivityDistributionMetric): "watts" | "bpm" {
+  return metric === "power" ? "watts" : "bpm";
+}
+
+export function projectProviderActivityHistogram(
+  response: readonly HistogramBucket[],
+  metric: ActivityDistributionMetric,
+): ActivityAnalysisData["powerDistribution"] {
+  if (response.length > MAX_ACTIVITY_ANALYSIS_BUCKETS) {
+    throw new ActivityAnalysisComputationError("response-too-large");
+  }
+  let parsed: readonly z.infer<typeof ProviderHistogramBucketSchema>[];
+  try {
+    parsed = z
+      .array(ProviderHistogramBucketSchema)
+      .max(MAX_ACTIVITY_ANALYSIS_BUCKETS)
+      .parse(response);
+  } catch (error) {
+    throw new ActivityAnalysisComputationError("malformed-response", { cause: error });
+  }
+  const axisLimit = maximumAxis(metric);
+  if (parsed.some((bucket) => bucket.min > axisLimit || bucket.max > axisLimit)) {
+    throw new ActivityAnalysisComputationError("malformed-response");
+  }
+  const buckets = parsed.map((bucket) => ({
+    lower: bucket.min,
+    upper: bucket.max,
+    seconds: bucket.secs,
+  }));
+  const totalSeconds = buckets.reduce((sum, bucket) => sum + bucket.seconds, 0);
+  if (!Number.isFinite(totalSeconds) || totalSeconds > 7 * 86_400) {
+    throw new ActivityAnalysisComputationError("malformed-response");
+  }
+  try {
+    return DistributionDataSchema.parse({ unit: unit(metric), buckets, totalSeconds });
+  } catch (error) {
+    throw new ActivityAnalysisComputationError("malformed-response", { cause: error });
+  }
+}
+
+export function createProviderActivityHistogramReader(input: {
+  readonly access: ProviderActivityAnalysisClientAccess;
+  readonly archive: ProviderActivityHistogramArchive;
+}): ProviderActivityHistogramReader {
+  return Object.freeze({
+    async read(request: ProviderActivityHistogramReadRequest) {
+      const lease = await input.access.open({
+        sourceRevision: request.sourceRevision,
+        signal: request.signal,
+        maximumBytes: ACTIVITY_HISTOGRAM_RESPONSE_LIMIT_BYTES,
+      });
+      const result =
+        request.metric === "power"
+          ? await lease.client.activities.getPowerHistogram(request.providerActivityId)
+          : await lease.client.activities.getHeartRateHistogram(request.providerActivityId);
+      request.signal.throwIfAborted();
+      if (!result.ok) {
+        providerActivityFailure(result.error, lease.responseLimitExceeded(), request.signal);
+      }
+      await input.archive.write({
+        sourceRevision: request.sourceRevision,
+        metric: request.metric,
+        response: result.value,
+        signal: request.signal,
+      });
+      request.signal.throwIfAborted();
+      return result.value;
+    },
+  });
+}
+
+function analyzeDistribution(
+  metric: ActivityDistributionMetric,
+  provider: ProviderActivityHistogramReader,
+  request: ActivityAnalysisSectionInput,
+): Promise<ActivityAnalysisSectionOutput<"powerDistribution" | "heartRateDistribution">> {
+  return (async () => {
+    request.signal.throwIfAborted();
+    if (request.source.kind !== "resolved") {
+      return { kind: "unavailable", reason: request.source.reason };
+    }
+    const response = await provider.read({
+      providerActivityId: request.source.providerActivityId,
+      sourceRevision: request.sourceRevision,
+      metric,
+      signal: request.signal,
+    });
+    if (response.length === 0) {
+      return { kind: "unavailable", reason: "missing-sensor-data" };
+    }
+    return {
+      kind: "computed",
+      source: "provider",
+      data: projectProviderActivityHistogram(response, metric),
+    };
+  })();
+}
+
+export function createPowerDistributionAnalyzer(input: {
+  readonly provider: ProviderActivityHistogramReader;
+}): ActivityAnalysisSectionAnalyzer<"powerDistribution"> {
+  return Object.freeze({
+    analyze(request: ActivityAnalysisSectionInput) {
+      return analyzeDistribution("power", input.provider, request) as Promise<
+        ActivityAnalysisSectionOutput<"powerDistribution">
+      >;
+    },
+  });
+}
+
+export function createHeartRateDistributionAnalyzer(input: {
+  readonly provider: ProviderActivityHistogramReader;
+}): ActivityAnalysisSectionAnalyzer<"heartRateDistribution"> {
+  return Object.freeze({
+    analyze(request: ActivityAnalysisSectionInput) {
+      return analyzeDistribution("heart-rate", input.provider, request) as Promise<
+        ActivityAnalysisSectionOutput<"heartRateDistribution">
+      >;
+    },
+  });
+}

--- a/packages/coach/src/activity-power-heart-rate.ts
+++ b/packages/coach/src/activity-power-heart-rate.ts
@@ -1,0 +1,259 @@
+import {
+  MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_CURVES,
+  MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_ROWS,
+  PowerHeartRateDataSchema,
+  type ActivityAnalysisData,
+} from "@enduragent/coach-contract";
+import { z } from "zod";
+import type { PowerVsHeartRatePlot } from "intervals-icu-api";
+import type { ProviderActivityPowerHeartRateArchive } from "./activity-analysis-archive.js";
+import {
+  ActivityAnalysisComputationError,
+  type ActivityAnalysisSectionAnalyzer,
+  type ActivityAnalysisSectionInput,
+  type ActivityAnalysisSectionOutput,
+} from "./activity-analysis-service.js";
+import {
+  providerActivityFailure,
+  type ProviderActivityAnalysisClientAccess,
+} from "./activity-analysis-provider.js";
+
+export const ACTIVITY_POWER_HEART_RATE_RESPONSE_LIMIT_BYTES = 2 * 1_024 * 1_024;
+export const MINIMUM_POWER_HEART_RATE_ROWS = 5;
+export const MINIMUM_POWER_HEART_RATE_SECONDS = 5 * 60;
+export const MINIMUM_POWER_HEART_RATE_COVERAGE = 0.5;
+
+const MAX_ACTIVITY_SECONDS = 7 * 86_400;
+const NullableActivitySeconds = z
+  .number()
+  .finite()
+  .nonnegative()
+  .max(MAX_ACTIVITY_SECONDS)
+  .nullish();
+
+const ProviderPowerHeartRateRowSchema = z
+  .object({
+    start: z.number().finite().nonnegative().max(MAX_ACTIVITY_SECONDS),
+    watts: z.number().finite().nonnegative().max(100_000),
+    hr: z.number().finite().positive().max(400),
+    cadence: z.number().finite().nonnegative().max(1_000).nullish(),
+    movingSecs: NullableActivitySeconds,
+    secs: z.number().finite().positive().max(MAX_ACTIVITY_SECONDS),
+  })
+  .passthrough()
+  .refine(
+    (value) =>
+      value.movingSecs === null || value.movingSecs === undefined || value.movingSecs <= value.secs,
+    { path: ["movingSecs"], message: "moving time exceeds segment duration" },
+  );
+
+const ProviderPowerHeartRateCurveSchema = z
+  .object({
+    id: z.string().max(128).nullish(),
+    coefficients: z.array(z.number().finite().nullable()).max(16).nullish(),
+    r2: z.number().finite().min(0).max(1).nullish(),
+  })
+  .passthrough();
+
+const ProviderPowerHeartRateSchema = z
+  .object({
+    elapsedTime: NullableActivitySeconds,
+    hrLag: NullableActivitySeconds,
+    warmup: NullableActivitySeconds,
+    cooldown: NullableActivitySeconds,
+    series: z
+      .array(ProviderPowerHeartRateRowSchema)
+      .max(MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_ROWS),
+    curves: z
+      .array(ProviderPowerHeartRateCurveSchema)
+      .max(MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_CURVES)
+      .nullish(),
+  })
+  .passthrough();
+
+type ProviderPowerHeartRateCurve = z.infer<typeof ProviderPowerHeartRateCurveSchema>;
+
+export interface ProviderActivityPowerHeartRateReader {
+  read(input: ProviderActivityPowerHeartRateReadRequest): Promise<PowerVsHeartRatePlot>;
+}
+
+interface ProviderActivityPowerHeartRateReadRequest {
+  readonly providerActivityId: string;
+  readonly sourceRevision: string;
+  readonly signal: AbortSignal;
+}
+
+function curveKind(
+  id: ProviderPowerHeartRateCurve["id"],
+): ActivityAnalysisData["powerHeartRate"]["curves"][number]["kind"] {
+  const normalized = id
+    ?.trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, "-");
+  if (normalized === "z2" || normalized === "zone-2" || normalized === "zone2") return "zone-2";
+  if (normalized === "all" || normalized === "overall") return "all";
+  return "other";
+}
+
+function projectedCurves(curves: readonly ProviderPowerHeartRateCurve[]) {
+  return curves.flatMap((curve) => {
+    if (
+      curve.coefficients === null ||
+      curve.coefficients === undefined ||
+      curve.coefficients.length === 0
+    ) {
+      return [];
+    }
+    if (curve.coefficients.some((coefficient) => coefficient === null)) {
+      throw new ActivityAnalysisComputationError("malformed-response");
+    }
+    return [
+      {
+        kind: curveKind(curve.id),
+        coefficients: curve.coefficients as number[],
+        rSquared: curve.r2 ?? null,
+      },
+    ];
+  });
+}
+
+export function projectProviderPowerHeartRate(
+  response: PowerVsHeartRatePlot,
+  activityElapsedSeconds: number | null,
+): ActivityAnalysisData["powerHeartRate"] {
+  if (
+    (Array.isArray(response.series) &&
+      response.series.length > MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_ROWS) ||
+    (Array.isArray(response.curves) &&
+      response.curves.length > MAX_ACTIVITY_ANALYSIS_POWER_HEART_RATE_CURVES)
+  ) {
+    throw new ActivityAnalysisComputationError("response-too-large");
+  }
+  let parsed: z.infer<typeof ProviderPowerHeartRateSchema>;
+  try {
+    parsed = ProviderPowerHeartRateSchema.parse(response);
+  } catch (error) {
+    throw new ActivityAnalysisComputationError("malformed-response", { cause: error });
+  }
+  const rows = parsed.series.map((row) => ({
+    startSeconds: row.start,
+    watts: row.watts,
+    heartRateBpm: row.hr,
+    cadenceRpm: row.cadence ?? null,
+    movingSeconds: row.movingSecs ?? null,
+    seconds: row.secs,
+  }));
+  for (let index = 1; index < rows.length; index += 1) {
+    const previous = rows[index - 1]!;
+    const current = rows[index]!;
+    if (previous.startSeconds + previous.seconds > current.startSeconds) {
+      throw new ActivityAnalysisComputationError("malformed-response");
+    }
+  }
+  const lastEnd = rows.reduce(
+    (maximum, row) => Math.max(maximum, row.startSeconds + row.seconds),
+    0,
+  );
+  const providerElapsed = parsed.elapsedTime ?? null;
+  const denominator =
+    providerElapsed !== null && providerElapsed > 0
+      ? providerElapsed
+      : activityElapsedSeconds !== null && activityElapsedSeconds > 0
+        ? activityElapsedSeconds
+        : lastEnd;
+  if (denominator < lastEnd || denominator > MAX_ACTIVITY_SECONDS) {
+    throw new ActivityAnalysisComputationError("malformed-response");
+  }
+  const includedSeconds = rows.reduce((sum, row) => sum + (row.movingSeconds ?? row.seconds), 0);
+  if (includedSeconds > denominator) {
+    throw new ActivityAnalysisComputationError("malformed-response");
+  }
+  const coverageFraction = denominator === 0 ? 0 : includedSeconds / denominator;
+  try {
+    return PowerHeartRateDataSchema.parse({
+      source: "provider",
+      rows,
+      curves: projectedCurves(parsed.curves ?? []),
+      coverageFraction,
+      heartRateLagSeconds: parsed.hrLag ?? null,
+      warmupSeconds: parsed.warmup ?? null,
+      cooldownSeconds: parsed.cooldown ?? null,
+    });
+  } catch (error) {
+    if (error instanceof ActivityAnalysisComputationError) throw error;
+    throw new ActivityAnalysisComputationError("malformed-response", { cause: error });
+  }
+}
+
+export function createProviderActivityPowerHeartRateReader(input: {
+  readonly access: ProviderActivityAnalysisClientAccess;
+  readonly archive: ProviderActivityPowerHeartRateArchive;
+}): ProviderActivityPowerHeartRateReader {
+  return Object.freeze({
+    async read(request: ProviderActivityPowerHeartRateReadRequest) {
+      const lease = await input.access.open({
+        sourceRevision: request.sourceRevision,
+        signal: request.signal,
+        maximumBytes: ACTIVITY_POWER_HEART_RATE_RESPONSE_LIMIT_BYTES,
+      });
+      const result = await lease.client.activities.getPowerVsHeartRate(request.providerActivityId);
+      request.signal.throwIfAborted();
+      if (!result.ok) {
+        providerActivityFailure(result.error, lease.responseLimitExceeded(), request.signal);
+      }
+      await input.archive.write({
+        sourceRevision: request.sourceRevision,
+        response: result.value,
+        signal: request.signal,
+      });
+      request.signal.throwIfAborted();
+      return result.value;
+    },
+  });
+}
+
+export function createPowerHeartRateAnalyzer(input: {
+  readonly provider: ProviderActivityPowerHeartRateReader;
+}): ActivityAnalysisSectionAnalyzer<"powerHeartRate"> {
+  return Object.freeze({
+    async analyze(
+      request: ActivityAnalysisSectionInput,
+    ): Promise<ActivityAnalysisSectionOutput<"powerHeartRate">> {
+      request.signal.throwIfAborted();
+      if (request.source.kind !== "resolved") {
+        return { kind: "unavailable", reason: request.source.reason };
+      }
+      const response = await input.provider.read({
+        providerActivityId: request.source.providerActivityId,
+        sourceRevision: request.sourceRevision,
+        signal: request.signal,
+      });
+      if (Array.isArray(response.series) && response.series.length === 0) {
+        return { kind: "unavailable", reason: "missing-sensor-data" };
+      }
+      const data = projectProviderPowerHeartRate(response, request.activity.elapsedSeconds);
+      const includedSeconds = data.rows.reduce(
+        (sum, row) => sum + (row.movingSeconds ?? row.seconds),
+        0,
+      );
+      if (
+        data.rows.length < MINIMUM_POWER_HEART_RATE_ROWS ||
+        includedSeconds < MINIMUM_POWER_HEART_RATE_SECONDS
+      ) {
+        return { kind: "unavailable", reason: "activity-too-short" };
+      }
+      if (data.coverageFraction < MINIMUM_POWER_HEART_RATE_COVERAGE) {
+        return { kind: "unavailable", reason: "insufficient-coverage" };
+      }
+      const watts = data.rows.map((row) => row.watts);
+      const heartRates = data.rows.map((row) => row.heartRateBpm);
+      if (
+        Math.max(...watts) - Math.min(...watts) < 10 ||
+        Math.max(...heartRates) - Math.min(...heartRates) < 5
+      ) {
+        return { kind: "unavailable", reason: "unsuitable-activity" };
+      }
+      return { kind: "computed", source: "provider", data };
+    },
+  });
+}

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -108,7 +108,9 @@ import {
 } from "./activity-analysis-provider.js";
 import {
   createProviderActivityBestEffortsArchive,
+  createProviderActivityHistogramArchive,
   createProviderActivityIntervalsArchive,
+  createProviderActivityPowerHeartRateArchive,
   createProviderActivityStreamArchive,
 } from "./activity-analysis-archive.js";
 import {
@@ -119,6 +121,15 @@ import {
   createBestEffortAnalyzer,
   createProviderActivityBestEffortReader,
 } from "./activity-best-efforts.js";
+import {
+  createHeartRateDistributionAnalyzer,
+  createPowerDistributionAnalyzer,
+  createProviderActivityHistogramReader,
+} from "./activity-distribution.js";
+import {
+  createPowerHeartRateAnalyzer,
+  createProviderActivityPowerHeartRateReader,
+} from "./activity-power-heart-rate.js";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -1055,6 +1066,14 @@ export async function createLocalCoachComposition(
       access: providerAccess,
       archive: createProviderActivityBestEffortsArchive({ ...archiveDependencies }),
     });
+    const providerHistograms = createProviderActivityHistogramReader({
+      access: providerAccess,
+      archive: createProviderActivityHistogramArchive({ ...archiveDependencies }),
+    });
+    const providerPowerHeartRate = createProviderActivityPowerHeartRateReader({
+      access: providerAccess,
+      archive: createProviderActivityPowerHeartRateArchive({ ...archiveDependencies }),
+    });
     const activityAnalysis = createStoredActivityAnalysisService({
       store: input.context.store,
       activities: canonicalActivities,
@@ -1066,6 +1085,11 @@ export async function createLocalCoachComposition(
         }),
         intervals: createIntervalReviewAnalyzer({ provider: providerIntervals }),
         bestEfforts: createBestEffortAnalyzer({ provider: providerBestEfforts }),
+        powerDistribution: createPowerDistributionAnalyzer({ provider: providerHistograms }),
+        heartRateDistribution: createHeartRateDistributionAnalyzer({
+          provider: providerHistograms,
+        }),
+        powerHeartRate: createPowerHeartRateAnalyzer({ provider: providerPowerHeartRate }),
       },
       runCacheWrite: (work) => runtime!.runExclusive(work),
       now,

--- a/packages/coach/tests/activity-analysis-archive.test.ts
+++ b/packages/coach/tests/activity-analysis-archive.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createProviderActivityBestEffortsArchive,
+  createProviderActivityHistogramArchive,
   createProviderActivityIntervalsArchive,
+  createProviderActivityPowerHeartRateArchive,
   createProviderActivityStreamArchive,
 } from "../src/activity-analysis-archive.js";
 
@@ -135,6 +137,39 @@ describe("provider activity stream archive", () => {
     });
     expect(JSON.stringify(efforts.landingDrafts[0])).not.toContain("333");
     expect(JSON.stringify(efforts.landingDrafts[0])).not.toContain("2500");
+
+    const histogram = setup();
+    await createProviderActivityHistogramArchive(histogram.dependencies).write({
+      sourceRevision: REVISION,
+      metric: "power",
+      response: [{ min: 200, max: 225, secs: 601 }],
+      signal: new AbortController().signal,
+    });
+    expect(JSON.stringify(histogram.snapshots[0])).toContain("601");
+    expect(histogram.artifactDrafts[0]).toMatchObject({
+      lane: "streams",
+      externalId: `power-histogram:analysis:${REVISION}:${ADDRESS}`,
+    });
+    expect(JSON.stringify(histogram.landingDrafts[0])).not.toContain("200");
+    expect(JSON.stringify(histogram.landingDrafts[0])).not.toContain("601");
+
+    const powerHeartRate = setup();
+    await createProviderActivityPowerHeartRateArchive(powerHeartRate.dependencies).write({
+      sourceRevision: REVISION,
+      response: {
+        series: [{ start: 0, watts: 244, hr: 151, secs: 60 }],
+        curves: [{ id: "private-curve", coefficients: [120, 0.1] }],
+      },
+      signal: new AbortController().signal,
+    });
+    expect(JSON.stringify(powerHeartRate.snapshots[0])).toContain("244");
+    expect(powerHeartRate.artifactDrafts[0]).toMatchObject({
+      lane: "streams",
+      externalId: `power-heart-rate:analysis:${REVISION}:${ADDRESS}`,
+    });
+    expect(JSON.stringify(powerHeartRate.landingDrafts[0])).not.toContain("244");
+    expect(JSON.stringify(powerHeartRate.landingDrafts[0])).not.toContain("151");
+    expect(JSON.stringify(powerHeartRate.landingDrafts[0])).not.toContain("private-curve");
   });
 
   it("does not publish store evidence after cancellation", async () => {

--- a/packages/coach/tests/activity-distribution.test.ts
+++ b/packages/coach/tests/activity-distribution.test.ts
@@ -1,0 +1,168 @@
+import type { CanonicalActivityDetail } from "@enduragent/kernel/store";
+import type { HistogramBucket } from "intervals-icu-api";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createHeartRateDistributionAnalyzer,
+  createPowerDistributionAnalyzer,
+  createProviderActivityHistogramReader,
+  projectProviderActivityHistogram,
+} from "../src/activity-distribution.js";
+
+const ACTIVITY_ID = "a".repeat(64);
+const REVISION = "b".repeat(64);
+
+const activity: CanonicalActivityDetail = {
+  id: ACTIVITY_ID,
+  workoutId: "c".repeat(64),
+  sessionSequence: 0,
+  isMultisport: false,
+  sport: "cycling",
+  subSport: "road",
+  isTransition: false,
+  startEpochSeconds: 1_000,
+  timezoneOffsetSeconds: 0,
+  localDate: "1998-07-06",
+  elapsedSeconds: 3_600,
+  timerSeconds: 3_500,
+  movingSeconds: 3_400,
+  distanceMeters: 36_000,
+  laps: [],
+};
+
+const powerBuckets: HistogramBucket[] = [
+  { min: 0, max: 100, secs: 300, privateField: "must-not-render" },
+  { min: 100, max: 200, secs: 600 },
+  { min: 225, max: 300, secs: 120 },
+];
+
+describe("activity histogram projection", () => {
+  it("preserves ordered provider buckets, accumulated seconds, gaps, and endpoint units", () => {
+    expect(projectProviderActivityHistogram(powerBuckets, "power")).toEqual({
+      unit: "watts",
+      buckets: [
+        { lower: 0, upper: 100, seconds: 300 },
+        { lower: 100, upper: 200, seconds: 600 },
+        { lower: 225, upper: 300, seconds: 120 },
+      ],
+      totalSeconds: 1_020,
+    });
+    expect(
+      projectProviderActivityHistogram(
+        [
+          { min: 100, max: 120, secs: 60 },
+          { min: 120, max: 140, secs: 90 },
+        ],
+        "heart-rate",
+      ),
+    ).toMatchObject({ unit: "bpm", totalSeconds: 150 });
+    expect(JSON.stringify(projectProviderActivityHistogram(powerBuckets, "power"))).not.toContain(
+      "must-not-render",
+    );
+  });
+
+  it("fails closed for oversized, overlapping, endpoint-invalid, and malformed buckets", () => {
+    expect(() =>
+      projectProviderActivityHistogram(
+        Array.from({ length: 257 }, (_, index) => ({
+          min: index,
+          max: index + 1,
+          secs: 1,
+        })),
+        "power",
+      ),
+    ).toThrow(expect.objectContaining({ code: "response-too-large" }));
+    expect(() =>
+      projectProviderActivityHistogram(
+        [
+          { min: 100, max: 200, secs: 60 },
+          { min: 150, max: 250, secs: 60 },
+        ],
+        "power",
+      ),
+    ).toThrow(expect.objectContaining({ code: "malformed-response" }));
+    expect(() =>
+      projectProviderActivityHistogram([{ min: 390, max: 410, secs: 60 }], "heart-rate"),
+    ).toThrow(expect.objectContaining({ code: "malformed-response" }));
+    expect(() => projectProviderActivityHistogram([{ min: 100, secs: 60 }], "power")).toThrow(
+      expect.objectContaining({ code: "malformed-response" }),
+    );
+  });
+});
+
+describe("activity histogram acquisition", () => {
+  it("keeps power and heart-rate requests independent and archives before projection", async () => {
+    const events: string[] = [];
+    const getPowerHistogram = vi.fn(async () => {
+      events.push("power:fetch");
+      return { ok: true as const, value: powerBuckets };
+    });
+    const getHeartRateHistogram = vi.fn(async () => {
+      events.push("heart-rate:fetch");
+      return { ok: true as const, value: [{ min: 120, max: 140, secs: 600 }] };
+    });
+    const reader = createProviderActivityHistogramReader({
+      access: {
+        open: async () => ({
+          client: { activities: { getPowerHistogram, getHeartRateHistogram } as never },
+          responseLimitExceeded: () => false,
+        }),
+      },
+      archive: {
+        write: async ({ metric }) => {
+          events.push(`${metric}:archive`);
+        },
+      },
+    });
+    const power = createPowerDistributionAnalyzer({ provider: reader });
+    const heartRate = createHeartRateDistributionAnalyzer({ provider: reader });
+    const request = {
+      activity,
+      sourceRevision: REVISION,
+      source: { kind: "resolved" as const, providerActivityId: "provider-1" as never },
+      signal: new AbortController().signal,
+    };
+
+    await expect(power.analyze(request)).resolves.toMatchObject({
+      kind: "computed",
+      source: "provider",
+      data: { unit: "watts" },
+    });
+    await expect(heartRate.analyze(request)).resolves.toMatchObject({
+      kind: "computed",
+      source: "provider",
+      data: { unit: "bpm" },
+    });
+    expect(events).toEqual([
+      "power:fetch",
+      "power:archive",
+      "heart-rate:fetch",
+      "heart-rate:archive",
+    ]);
+  });
+
+  it("does not call the provider for unresolved rides and treats a valid empty histogram as missing sensor data", async () => {
+    const read = vi.fn();
+    const analyzer = createPowerDistributionAnalyzer({ provider: { read } });
+    await expect(
+      analyzer.analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "unavailable", reason: "source-not-found" },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ kind: "unavailable", reason: "source-not-found" });
+    expect(read).not.toHaveBeenCalled();
+
+    const empty = createPowerDistributionAnalyzer({
+      provider: { read: async () => [] },
+    });
+    await expect(
+      empty.analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "resolved", providerActivityId: "provider-1" as never },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ kind: "unavailable", reason: "missing-sensor-data" });
+  });
+});

--- a/packages/coach/tests/activity-power-heart-rate.test.ts
+++ b/packages/coach/tests/activity-power-heart-rate.test.ts
@@ -1,0 +1,209 @@
+import type { CanonicalActivityDetail } from "@enduragent/kernel/store";
+import type { PowerVsHeartRatePlot } from "intervals-icu-api";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPowerHeartRateAnalyzer,
+  createProviderActivityPowerHeartRateReader,
+  projectProviderPowerHeartRate,
+} from "../src/activity-power-heart-rate.js";
+
+const ACTIVITY_ID = "a".repeat(64);
+const REVISION = "b".repeat(64);
+
+const activity: CanonicalActivityDetail = {
+  id: ACTIVITY_ID,
+  workoutId: "c".repeat(64),
+  sessionSequence: 0,
+  isMultisport: false,
+  sport: "cycling",
+  subSport: "road",
+  isTransition: false,
+  startEpochSeconds: 1_000,
+  timezoneOffsetSeconds: 0,
+  localDate: "1998-07-06",
+  elapsedSeconds: 600,
+  timerSeconds: 590,
+  movingSeconds: 580,
+  distanceMeters: 5_000,
+  laps: [],
+};
+
+function response(): PowerVsHeartRatePlot {
+  return {
+    elapsedTime: 600,
+    hrLag: 15,
+    warmup: 60,
+    cooldown: 30,
+    decoupling: 4.2,
+    series: Array.from({ length: 6 }, (_, index) => ({
+      start: index * 60,
+      secs: 60,
+      movingSecs: 60,
+      watts: 150 + index * 10,
+      hr: 120 + index * 2,
+      cadence: index === 0 ? null : 85 + index,
+      privateField: "must-not-render",
+    })),
+    curves: [
+      { id: "overall", coefficients: [100, 0.1], r2: 0.9 },
+      { id: "z2", coefficients: [105, 0.08], r2: 0.8 },
+      { id: "private-provider-fit", coefficients: null, r2: null },
+    ],
+  } as PowerVsHeartRatePlot;
+}
+
+describe("provider power/heart-rate projection", () => {
+  it("projects only aligned segment evidence, bounded fits, and coverage summaries", () => {
+    const projected = projectProviderPowerHeartRate(response(), activity.elapsedSeconds);
+    expect(projected).toMatchObject({
+      source: "provider",
+      coverageFraction: 0.6,
+      heartRateLagSeconds: 15,
+      warmupSeconds: 60,
+      cooldownSeconds: 30,
+      curves: [
+        { kind: "all", coefficients: [100, 0.1], rSquared: 0.9 },
+        { kind: "zone-2", coefficients: [105, 0.08], rSquared: 0.8 },
+      ],
+    });
+    expect(projected.rows[0]).toEqual({
+      startSeconds: 0,
+      seconds: 60,
+      movingSeconds: 60,
+      watts: 150,
+      heartRateBpm: 120,
+      cadenceRpm: null,
+    });
+    expect(JSON.stringify(projected)).not.toContain("decoupling");
+    expect(JSON.stringify(projected)).not.toContain("must-not-render");
+    expect(JSON.stringify(projected)).not.toContain("private-provider-fit");
+  });
+
+  it("fails closed for oversized, overlapping, impossible-motion, and malformed curve data", () => {
+    const oversized = response();
+    oversized.series = Array.from({ length: 257 }, (_, index) => ({
+      start: index,
+      secs: 1,
+      watts: 150,
+      hr: 120,
+    }));
+    expect(() => projectProviderPowerHeartRate(oversized, 600)).toThrow(
+      expect.objectContaining({ code: "response-too-large" }),
+    );
+
+    const overlapping = response();
+    overlapping.series[1]!.start = 30;
+    expect(() => projectProviderPowerHeartRate(overlapping, 600)).toThrow(
+      expect.objectContaining({ code: "malformed-response" }),
+    );
+
+    const impossibleMotion = response();
+    impossibleMotion.series[0]!.movingSecs = 61;
+    expect(() => projectProviderPowerHeartRate(impossibleMotion, 600)).toThrow(
+      expect.objectContaining({ code: "malformed-response" }),
+    );
+
+    const nullCoefficient = response();
+    nullCoefficient.curves![0]!.coefficients = [100, null];
+    expect(() => projectProviderPowerHeartRate(nullCoefficient, 600)).toThrow(
+      expect.objectContaining({ code: "malformed-response" }),
+    );
+  });
+});
+
+describe("provider power/heart-rate acquisition", () => {
+  it("archives the server response before projection and returns adequate evidence", async () => {
+    const events: string[] = [];
+    const getPowerVsHeartRate = vi.fn(async () => {
+      events.push("fetch");
+      return { ok: true as const, value: response() };
+    });
+    const reader = createProviderActivityPowerHeartRateReader({
+      access: {
+        open: async () => ({
+          client: { activities: { getPowerVsHeartRate } as never },
+          responseLimitExceeded: () => false,
+        }),
+      },
+      archive: {
+        write: async () => {
+          events.push("archive");
+        },
+      },
+    });
+    const analyzer = createPowerHeartRateAnalyzer({ provider: reader });
+
+    await expect(
+      analyzer.analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "resolved", providerActivityId: "provider-1" as never },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({
+      kind: "computed",
+      source: "provider",
+      data: { coverageFraction: 0.6 },
+    });
+    expect(getPowerVsHeartRate).toHaveBeenCalledWith("provider-1");
+    expect(events).toEqual(["fetch", "archive"]);
+  });
+
+  it("fails closed for unresolved, empty, short, low-coverage, and no-spread evidence", async () => {
+    const read = vi.fn(async () => response());
+    const analyzer = createPowerHeartRateAnalyzer({ provider: { read } });
+    await expect(
+      analyzer.analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "unavailable", reason: "source-not-found" },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ kind: "unavailable", reason: "source-not-found" });
+    expect(read).not.toHaveBeenCalled();
+
+    const empty = response();
+    empty.series = [];
+    await expect(
+      createPowerHeartRateAnalyzer({ provider: { read: async () => empty } }).analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "resolved", providerActivityId: "provider-1" as never },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ kind: "unavailable", reason: "missing-sensor-data" });
+
+    const short = response();
+    short.series = short.series.slice(0, 4);
+    await expect(
+      createPowerHeartRateAnalyzer({ provider: { read: async () => short } }).analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "resolved", providerActivityId: "provider-1" as never },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ kind: "unavailable", reason: "activity-too-short" });
+
+    const lowCoverage = response();
+    lowCoverage.elapsedTime = 3_600;
+    await expect(
+      createPowerHeartRateAnalyzer({ provider: { read: async () => lowCoverage } }).analyze({
+        activity: { ...activity, elapsedSeconds: 3_600 },
+        sourceRevision: REVISION,
+        source: { kind: "resolved", providerActivityId: "provider-1" as never },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ kind: "unavailable", reason: "insufficient-coverage" });
+
+    const noSpread = response();
+    noSpread.series = noSpread.series.map((row) => ({ ...row, watts: 180, hr: 130 }));
+    await expect(
+      createPowerHeartRateAnalyzer({ provider: { read: async () => noSpread } }).analyze({
+        activity,
+        sourceRevision: REVISION,
+        source: { kind: "resolved", providerActivityId: "provider-1" as never },
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ kind: "unavailable", reason: "unsuitable-activity" });
+  });
+});

--- a/packages/coach/tests/daemon-contention.integration.test.ts
+++ b/packages/coach/tests/daemon-contention.integration.test.ts
@@ -107,7 +107,7 @@ async function loopbackAvailable(): Promise<boolean> {
 const hasLoopback = await loopbackAvailable();
 
 describe.skipIf(!hasLoopback)("real daemon contention matrix", () => {
-  it("covers healthy, SIGKILL-stale, bound-unresponsive, and foreign-port processes", async () => {
+  it("covers healthy, SIGKILL-stale, bound-unresponsive, and foreign-port processes", { timeout: 20_000 }, async () => {
     const healthyHome = await syntheticHome("contention-healthy");
     const healthy = spawn("writer", healthyHome);
     const healthyReadyPromise = message<{

--- a/packages/core/tests/telegram-nonblocking.test.ts
+++ b/packages/core/tests/telegram-nonblocking.test.ts
@@ -261,7 +261,7 @@ describe("setMyCommands menu list", () => {
   it("includes the full command set (with start) and excludes snapshot when reference is present", async () => {
     const reference: StubReference = { runSync: vi.fn(), loadLatest: vi.fn() };
     const { bot } = await buildBot({ reference });
-    expect(bot.api.setMyCommands).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(bot.api.setMyCommands).toHaveBeenCalledTimes(1));
     const menu = bot.api.setMyCommands.mock.calls[0][0] as {
       command: string;
       description: string;
@@ -289,6 +289,7 @@ describe("setMyCommands menu list", () => {
 
   it("excludes sync when reference is undefined", async () => {
     const { bot } = await buildBot();
+    await vi.waitFor(() => expect(bot.api.setMyCommands).toHaveBeenCalledTimes(1));
     const menu = bot.api.setMyCommands.mock.calls[0][0] as {
       command: string;
       description: string;


### PR DESCRIPTION
## Summary

- add independent power and heart-rate ride distributions with exact accessible tables and preserved provider gaps
- add a distinct intervals.icu server-cleaned, lag-adjusted power/heart-rate response view with retained segments, coverage, and preprocessing context
- archive raw provider evidence privately while exposing only bounded, allowlisted renderer DTOs
- fail closed on malformed, oversized, empty, short, low-coverage, or low-spread evidence without breaking sibling sections

## Binding behavior

- distribution buckets retain provider order, endpoint units, and accumulated seconds; missing ranges are never synthesized as zero
- power/heart-rate response requires at least 5 rows, 5 minutes of included evidence, 50% ride coverage, 10 W power spread, and 5 bpm heart-rate spread
- coverage below 80% is shown as limited; this is separate from the local aerobic-drift estimate and is not training prescription
- provider activity IDs, curve IDs, raw payload fields, and server decoupling values do not cross the renderer boundary
- computed distribution and power/heart-rate DTOs must contain evidence; empty responses become missing-sensor unavailable states

## Verification

- pnpm check
- pnpm test: 553 files passed, 8,269 tests passed
- pnpm s8a
- focused coach/contract/renderer tests
- real Electron integration: 5 tests passed
- visual QA at 1440x900 and 720x800
- local privacy/security/architecture review: no remaining actionable findings