### PR TITLE
feat(desktop): add secure training export

### DIFF
--- a/.changeset/secure-training-export.md
+++ b/.changeset/secure-training-export.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/coach-contract": patch
+"@enduragent/coach-client": patch
+"@enduragent/coach": patch
+"cycling-coach": patch
+---
+
+User-facing: Desktop ride reviews can now save FIT or GPX files, and the visible training plan can be saved as a ZIP of ZWO, MRC, ERG, or FIT workouts.
+
+Keep export credentials, provider identifiers, file paths, and downloaded bytes in trusted processes; enforce bounded downloads and atomically publish private mode-0600 files selected through the native save dialog.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -46,6 +46,7 @@ import { createSessionSettingsController } from "./settings/session-controller.j
 import { createTelegramSettingsController } from "./settings/telegram-controller.js";
 import { createCredentialSettingsController } from "./settings/credential-controller.js";
 import { createRideImportController, subscribeToDroppedRideImports } from "./ride-import.js";
+import { createTrainingExportController } from "./training-export/controller.js";
 
 export type Disposer = () => void;
 
@@ -89,6 +90,11 @@ export function bootRenderer(): Disposer {
       void rideAnalysisController.load(sections, true);
     },
   });
+  const trainingExportController = createTrainingExportController({
+    transport: window.enduragentAuth,
+    view: { render: (next) => store.getState().setTrainingExport(next) },
+  });
+  store.getState().bindTrainingExportActions(trainingExportController);
   let selectedAnalysisRide = store.getState().selectedRide?.id ?? null;
   const disposeRideAnalysisSelection = store.subscribe((next) => {
     const selected = next.selectedRide?.id ?? null;
@@ -401,6 +407,7 @@ export function bootRenderer(): Disposer {
     store.getState().bindSyncActions(null);
     store.getState().bindRideImportActions(null);
     store.getState().bindRideAnalysisActions(null);
+    store.getState().bindTrainingExportActions(null);
     store.getState().bindOnboardingActions(null);
     disposeLifecycle();
     disposeRideAnalysisSelection();

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -50,6 +50,7 @@ interface EnduragentAuth {
   }): Promise<DesktopTelegramAllowedSendersMutationResult>;
   acknowledgeTelegramGapWarning(): Promise<DesktopTelegramMutationResult>;
   chooseImportFiles(): Promise<readonly string[]>;
+  exportTrainingFile(input: DesktopTrainingExportRequest): Promise<DesktopTrainingExportResult>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
   releaseNotes(): Promise<ReleaseNotesResult>;
   getUpdateState(): Promise<DesktopUpdateState>;
@@ -57,6 +58,39 @@ interface EnduragentAuth {
   restartToUpdate(): Promise<DesktopUpdateState>;
   onUpdateState(listener: (state: DesktopUpdateState) => void): () => void;
 }
+
+type DesktopTrainingExportRequest =
+  | {
+      readonly kind: "activity";
+      readonly canonicalActivityId: string;
+      readonly localDate: string;
+      readonly format: "fit" | "gpx";
+    }
+  | {
+      readonly kind: "workout-archive";
+      readonly oldest: string;
+      readonly newest: string;
+      readonly format: "zwo" | "mrc" | "erg" | "fit";
+    };
+
+type DesktopTrainingExportRefusalReason =
+  | "not-configured"
+  | "source-not-found"
+  | "ambiguous-source"
+  | "provider-unavailable"
+  | "not-supported"
+  | "rate-limited"
+  | "network"
+  | "timeout"
+  | "response-too-large"
+  | "invalid-response"
+  | "write-failed"
+  | "commit-uncertain";
+
+type DesktopTrainingExportResult =
+  | { readonly status: "cancelled" }
+  | { readonly status: "saved"; readonly byteLength: number }
+  | { readonly status: "refused"; readonly reason: DesktopTrainingExportRefusalReason };
 
 interface EnduragentTrayStatus {
   readonly channelState:

--- a/apps/desktop-renderer/src/state/store.ts
+++ b/apps/desktop-renderer/src/state/store.ts
@@ -29,6 +29,7 @@ import {
 } from "./settings-slice.js";
 import { createSyncSlice, type SyncSlice } from "./sync-slice.js";
 import { createTrainingSlice, type TrainingSlice } from "./training-slice.js";
+import { createTrainingExportSlice, type TrainingExportSlice } from "./training-export-slice.js";
 
 export interface EnduragentState
   extends
@@ -36,6 +37,7 @@ export interface EnduragentState
     ArchiveSlice,
     SettingsSlice,
     TrainingSlice,
+    TrainingExportSlice,
     ActivityAnalysisSlice,
     SyncSlice,
     ConnectionSlice,
@@ -67,6 +69,7 @@ export const useEnduragentStore = create<EnduragentState>((set, get, api) => ({
   ...createArchiveSlice(set, get, api),
   ...createSettingsSlice(set, get, api),
   ...createTrainingSlice(set, get, api),
+  ...createTrainingExportSlice(set, get, api),
   ...createActivityAnalysisSlice(set, get, api),
   ...createSyncSlice(set, get, api),
   ...createConnectionSlice(set, get, api),

--- a/apps/desktop-renderer/src/state/training-export-slice.ts
+++ b/apps/desktop-renderer/src/state/training-export-slice.ts
@@ -1,0 +1,30 @@
+import type { StateCreator } from "zustand";
+import {
+  IDLE_TRAINING_EXPORT,
+  type TrainingExportController,
+  type TrainingExportState,
+} from "../training-export/controller.js";
+import type { EnduragentState } from "./store.js";
+
+export interface TrainingExportSlice {
+  readonly trainingExport: TrainingExportState;
+  readonly trainingExportActions: TrainingExportController | null;
+  setTrainingExport: (next: TrainingExportState) => void;
+  bindTrainingExportActions: (actions: TrainingExportController | null) => void;
+}
+
+export const createTrainingExportSlice: StateCreator<
+  EnduragentState,
+  [],
+  [],
+  TrainingExportSlice
+> = (set) => ({
+  trainingExport: IDLE_TRAINING_EXPORT,
+  trainingExportActions: null,
+  setTrainingExport(next) {
+    set({ trainingExport: next });
+  },
+  bindTrainingExportActions(actions) {
+    set({ trainingExportActions: actions });
+  },
+});

--- a/apps/desktop-renderer/src/training-export/controller.ts
+++ b/apps/desktop-renderer/src/training-export/controller.ts
@@ -1,0 +1,102 @@
+import type {
+  ActivityExportFormat,
+  DesktopTrainingExportRequest,
+  DesktopTrainingExportResult,
+  TrainingExportRefusalReason,
+  WorkoutArchiveFormat,
+} from "@enduragent/coach-contract";
+
+export type TrainingExportTarget = "activity" | "workout-archive";
+
+export type TrainingExportState =
+  | { readonly status: "idle" }
+  | { readonly status: "running"; readonly target: TrainingExportTarget }
+  | {
+      readonly status: "saved";
+      readonly target: TrainingExportTarget;
+      readonly byteLength: number;
+    }
+  | { readonly status: "cancelled"; readonly target: TrainingExportTarget }
+  | {
+      readonly status: "refused";
+      readonly target: TrainingExportTarget;
+      readonly reason: TrainingExportRefusalReason;
+    };
+
+export const IDLE_TRAINING_EXPORT: TrainingExportState = Object.freeze({ status: "idle" });
+
+export interface TrainingExportTransport {
+  exportTrainingFile(request: DesktopTrainingExportRequest): Promise<DesktopTrainingExportResult>;
+}
+
+export interface TrainingExportView {
+  render(state: TrainingExportState): void;
+}
+
+export interface TrainingExportController {
+  exportActivity(input: {
+    readonly canonicalActivityId: string;
+    readonly localDate: string;
+    readonly format: ActivityExportFormat;
+  }): Promise<void>;
+  exportWorkoutArchive(input: {
+    readonly oldest: string;
+    readonly newest: string;
+    readonly format: WorkoutArchiveFormat;
+  }): Promise<void>;
+}
+
+export function createTrainingExportController(input: {
+  readonly transport: TrainingExportTransport;
+  readonly view: TrainingExportView;
+}): TrainingExportController {
+  let running = false;
+
+  const run = async (
+    target: TrainingExportTarget,
+    request: DesktopTrainingExportRequest,
+  ): Promise<void> => {
+    if (running) return;
+    running = true;
+    input.view.render({ status: "running", target });
+    try {
+      const result = await input.transport.exportTrainingFile(request);
+      input.view.render({ ...result, target });
+    } catch {
+      input.view.render({ status: "refused", target, reason: "write-failed" });
+    } finally {
+      running = false;
+    }
+  };
+
+  return Object.freeze({
+    exportActivity(request: Parameters<TrainingExportController["exportActivity"]>[0]) {
+      return run("activity", { kind: "activity", ...request });
+    },
+    exportWorkoutArchive(request: Parameters<TrainingExportController["exportWorkoutArchive"]>[0]) {
+      return run("workout-archive", { kind: "workout-archive", ...request });
+    },
+  });
+}
+
+export function trainingExportStatusCopy(state: TrainingExportState): string {
+  if (state.status === "idle") return "";
+  if (state.status === "running") return "Choose where to save the file.";
+  if (state.status === "saved") return "Export saved locally.";
+  if (state.status === "cancelled") return "Export cancelled. No file was changed.";
+  const copy: Record<TrainingExportRefusalReason, string> = {
+    "not-configured": "Connect your training account before exporting.",
+    "source-not-found": "This ride is no longer available to export.",
+    "ambiguous-source": "This ride could not be matched safely. Sync and try again.",
+    "provider-unavailable": "The training service is temporarily unavailable.",
+    "not-supported": "That export format is not available for this item.",
+    "rate-limited": "The training service is busy. Try again shortly.",
+    network: "The export could not be downloaded. Check your connection and try again.",
+    timeout: "The export took too long. Try again.",
+    "response-too-large": "The export was too large to save safely.",
+    "invalid-response": "The downloaded export could not be verified.",
+    "write-failed": "The export could not be saved to that location.",
+    "commit-uncertain": "The save result is uncertain. Check the chosen location before retrying.",
+  };
+  return copy[state.reason];
+}

--- a/apps/desktop-renderer/src/ui/training/RideReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideReview.tsx
@@ -13,6 +13,7 @@ import { Page } from "../shared/Page.js";
 import { analysisRefreshFailureCopy, analysisUnavailableCopy } from "./copy.js";
 import { RideResponseReview } from "./RideResponseReview.js";
 import styles from "./TrainingView.module.css";
+import { ActivityExportControl } from "./TrainingExportControls.js";
 
 const RIDE_KIND: Readonly<Record<string, string>> = {
   road: "Road ride",
@@ -691,6 +692,7 @@ export function RideDetailView(props: {
         <h2 id="ride-overview-title">{rideKind(props.ride)}</h2>
         <RideSummary ride={props.ride} units={props.units} />
       </section>
+      <ActivityExportControl canonicalActivityId={props.ride.id} localDate={props.ride.localDate} />
       <AerobicDriftPanel
         rideId={props.ride.id}
         analysis={props.analysis}

--- a/apps/desktop-renderer/src/ui/training/TrainingExportControls.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingExportControls.tsx
@@ -1,0 +1,116 @@
+import type { ActivityExportFormat, WorkoutArchiveFormat } from "@enduragent/coach-contract";
+import { useId, useState, type ReactElement } from "react";
+import { useEnduragentStore } from "../../state/store.js";
+import {
+  trainingExportStatusCopy,
+  type TrainingExportTarget,
+} from "../../training-export/controller.js";
+import styles from "./TrainingView.module.css";
+
+function Status(props: { readonly target: TrainingExportTarget }): ReactElement {
+  const state = useEnduragentStore((store) => store.trainingExport);
+  const copy =
+    state.status === "idle" || state.target !== props.target ? "" : trainingExportStatusCopy(state);
+  return (
+    <p
+      className={styles.exportStatus}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      hidden={copy.length === 0}
+    >
+      {copy}
+    </p>
+  );
+}
+
+export function ActivityExportControl(props: {
+  readonly canonicalActivityId: string;
+  readonly localDate: string;
+}): ReactElement {
+  const id = useId();
+  const [format, setFormat] = useState<ActivityExportFormat>("fit");
+  const state = useEnduragentStore((store) => store.trainingExport);
+  const actions = useEnduragentStore((store) => store.trainingExportActions);
+  const busy = state.status === "running";
+  return (
+    <section className={styles.analysisPanel} aria-labelledby={`${id}-title`}>
+      <h2 id={`${id}-title`} className={styles.analysisTitle}>
+        Export ride
+      </h2>
+      <p className={styles.analysisIntro}>
+        Save a copy to your computer. Exporting does not change this ride or your training account.
+      </p>
+      <div className={styles.exportControls}>
+        <label htmlFor={`${id}-format`}>File format</label>
+        <select
+          id={`${id}-format`}
+          className={styles.exportSelect}
+          value={format}
+          disabled={busy}
+          onChange={(event) => setFormat(event.currentTarget.value as ActivityExportFormat)}
+        >
+          <option value="fit">FIT</option>
+          <option value="gpx">GPX</option>
+        </select>
+        <button
+          type="button"
+          className={styles.action}
+          disabled={actions === null || busy}
+          aria-busy={busy ? "true" : undefined}
+          onClick={() => {
+            void actions?.exportActivity({ ...props, format });
+          }}
+        >
+          Export ride
+        </button>
+      </div>
+      <Status target="activity" />
+    </section>
+  );
+}
+
+export function WorkoutArchiveExportControl(props: {
+  readonly oldest: string;
+  readonly newest: string;
+}): ReactElement {
+  const id = useId();
+  const [format, setFormat] = useState<WorkoutArchiveFormat>("zwo");
+  const state = useEnduragentStore((store) => store.trainingExport);
+  const actions = useEnduragentStore((store) => store.trainingExportActions);
+  const busy = state.status === "running";
+  return (
+    <div className={styles.planExport}>
+      <p className={styles.support}>
+        Save the visible planned workouts as a ZIP. Exporting does not change your plan.
+      </p>
+      <div className={styles.exportControls}>
+        <label htmlFor={`${id}-format`}>Workout format</label>
+        <select
+          id={`${id}-format`}
+          className={styles.exportSelect}
+          value={format}
+          disabled={busy}
+          onChange={(event) => setFormat(event.currentTarget.value as WorkoutArchiveFormat)}
+        >
+          <option value="zwo">ZWO</option>
+          <option value="mrc">MRC</option>
+          <option value="erg">ERG</option>
+          <option value="fit">FIT</option>
+        </select>
+        <button
+          type="button"
+          className={styles.action}
+          disabled={actions === null || busy}
+          aria-busy={busy ? "true" : undefined}
+          onClick={() => {
+            void actions?.exportWorkoutArchive({ ...props, format });
+          }}
+        >
+          Export workouts
+        </button>
+      </div>
+      <Status target="workout-archive" />
+    </div>
+  );
+}

--- a/apps/desktop-renderer/src/ui/training/TrainingView.module.css
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.module.css
@@ -364,6 +364,38 @@
   font: 11px/1.4 var(--f-mono);
 }
 
+.planExport {
+  padding-top: 14px;
+  margin-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+.exportControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.exportControls label {
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 560;
+}
+
+.exportSelect {
+  composes: control from "../../theme/surface.module.css";
+  min-width: 86px;
+}
+
+.exportStatus {
+  margin: 10px 0 0;
+  color: var(--ink-2);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 .wellness {
   display: grid;
   gap: 10px;

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -34,6 +34,7 @@ import styles from "./TrainingView.module.css";
 import { PowerProgressContent } from "./PowerProgressPanel.js";
 import { RecentRidesStatePanel, RideDetailView } from "./RideReview.js";
 import { WellnessSparkline } from "./WellnessSparkline.js";
+import { WorkoutArchiveExportControl } from "./TrainingExportControls.js";
 
 function Panel(props: {
   readonly name: string;
@@ -196,6 +197,12 @@ function UpcomingPlanPanel(props: { readonly panel: PlanPanel }): ReactElement {
       </Panel>
     );
   }
+  const dates = props.panel.items
+    .slice(0, MAX_VISIBLE_PLAN_ITEMS)
+    .map((item) => item.date)
+    .sort();
+  const oldest = dates[0];
+  const newest = dates.at(-1);
   return (
     <Panel name="plan" title="Plan">
       <ol className={styles.plan}>
@@ -208,6 +215,9 @@ function UpcomingPlanPanel(props: { readonly panel: PlanPanel }): ReactElement {
           </li>
         ))}
       </ol>
+      {oldest === undefined || newest === undefined ? null : (
+        <WorkoutArchiveExportControl oldest={oldest} newest={newest} />
+      )}
     </Panel>
   );
 }

--- a/apps/desktop-renderer/tests/training-export.test.ts
+++ b/apps/desktop-renderer/tests/training-export.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTrainingExportController,
+  trainingExportStatusCopy,
+  type TrainingExportTransport,
+  type TrainingExportState,
+} from "../src/training-export/controller.js";
+
+function subject(
+  exportTrainingFile: TrainingExportTransport["exportTrainingFile"] = vi.fn(async () => ({
+    status: "saved" as const,
+    byteLength: 64,
+  })),
+) {
+  const states: TrainingExportState[] = [];
+  const controller = createTrainingExportController({
+    transport: { exportTrainingFile },
+    view: { render: (state) => states.push(state) },
+  });
+  return { controller, exportTrainingFile, states };
+}
+
+describe("training export controller", () => {
+  it("sends a closed ride request and publishes a saved result", async () => {
+    const test = subject();
+    await test.controller.exportActivity({
+      canonicalActivityId: "a".repeat(64),
+      localDate: "1998-07-19",
+      format: "fit",
+    });
+    expect(test.exportTrainingFile).toHaveBeenCalledWith({
+      kind: "activity",
+      canonicalActivityId: "a".repeat(64),
+      localDate: "1998-07-19",
+      format: "fit",
+    });
+    expect(test.states).toEqual([
+      { status: "running", target: "activity" },
+      { status: "saved", target: "activity", byteLength: 64 },
+    ]);
+  });
+
+  it("routes workout archives and preserves cancellations and refusal reasons", async () => {
+    const cancelled = subject(vi.fn(async () => ({ status: "cancelled" as const })));
+    await cancelled.controller.exportWorkoutArchive({
+      oldest: "1998-07-20",
+      newest: "1998-07-26",
+      format: "erg",
+    });
+    expect(cancelled.exportTrainingFile).toHaveBeenCalledWith({
+      kind: "workout-archive",
+      oldest: "1998-07-20",
+      newest: "1998-07-26",
+      format: "erg",
+    });
+    expect(cancelled.states.at(-1)).toEqual({
+      status: "cancelled",
+      target: "workout-archive",
+    });
+
+    const refused = subject(
+      vi.fn(async () => ({ status: "refused" as const, reason: "rate-limited" as const })),
+    );
+    await refused.controller.exportWorkoutArchive({
+      oldest: "1998-07-20",
+      newest: "1998-07-26",
+      format: "zwo",
+    });
+    expect(refused.states.at(-1)).toEqual({
+      status: "refused",
+      target: "workout-archive",
+      reason: "rate-limited",
+    });
+    expect(trainingExportStatusCopy(refused.states.at(-1)!)).toMatch(/busy/i);
+  });
+
+  it("is single-flight and turns transport failures into a generic local refusal", async () => {
+    let release!: () => void;
+    const pending = new Promise<{ status: "saved"; byteLength: number }>((resolve) => {
+      release = () => resolve({ status: "saved", byteLength: 1 });
+    });
+    const test = subject(vi.fn(() => pending));
+    const first = test.controller.exportActivity({
+      canonicalActivityId: "a".repeat(64),
+      localDate: "1998-07-19",
+      format: "fit",
+    });
+    await test.controller.exportWorkoutArchive({
+      oldest: "1998-07-20",
+      newest: "1998-07-26",
+      format: "zwo",
+    });
+    expect(test.exportTrainingFile).toHaveBeenCalledOnce();
+    release();
+    await first;
+
+    const failed = subject(
+      vi.fn(async () => {
+        throw new Error("private failure");
+      }),
+    );
+    await failed.controller.exportActivity({
+      canonicalActivityId: "a".repeat(64),
+      localDate: "1998-07-19",
+      format: "gpx",
+    });
+    expect(failed.states.at(-1)).toEqual({
+      status: "refused",
+      target: "activity",
+      reason: "write-failed",
+    });
+  });
+});

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -14,6 +14,7 @@ import { IDLE_RIDE_IMPORT } from "../src/state/ride-import-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
 import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
+import { IDLE_TRAINING_EXPORT } from "../src/training-export/controller.js";
 import type { TrainingContextViewState } from "../src/training-context/controller.js";
 import { toManualSyncViewState } from "../src/training-context/manual-sync.js";
 import { TrainingView } from "../src/ui/training/TrainingView.js";
@@ -264,6 +265,8 @@ beforeEach(() => {
     rideImport: IDLE_RIDE_IMPORT,
     rideImportSuppressed: false,
     rideImportActions: null,
+    trainingExport: IDLE_TRAINING_EXPORT,
+    trainingExportActions: null,
   });
 });
 
@@ -279,6 +282,8 @@ afterEach(() => {
     rideImport: IDLE_RIDE_IMPORT,
     rideImportSuppressed: false,
     rideImportActions: null,
+    trainingExport: IDLE_TRAINING_EXPORT,
+    trainingExportActions: null,
   });
 });
 
@@ -334,6 +339,38 @@ describe("training page", () => {
         name: "Review road ride from 1998-07-09 · 22:00, 1h 31m, 42.1 km",
       }),
     ).toHaveFocus();
+  });
+
+  it("exports a ride through the bound desktop action without rendering its canonical ID", async () => {
+    const user = userEvent.setup();
+    const exportActivity = vi.fn(async () => {});
+    const exportWorkoutArchive = vi.fn(async () => {});
+    useEnduragentStore.setState({
+      trainingExportActions: { exportActivity, exportWorkoutArchive },
+    });
+    render(<TrainingView />);
+    await user.click(
+      screen.getByRole("button", {
+        name: "Review road ride from 1998-07-09 · 22:00, 1h 31m, 42.1 km",
+      }),
+    );
+
+    const panel = screen.getByRole("region", { name: "Export ride" });
+    await user.selectOptions(within(panel).getByRole("combobox", { name: "File format" }), "gpx");
+    await user.click(within(panel).getByRole("button", { name: "Export ride" }));
+    expect(exportActivity).toHaveBeenCalledWith({
+      canonicalActivityId: "a".repeat(64),
+      localDate: "1998-07-09",
+      format: "gpx",
+    });
+    expect(document.body).not.toHaveTextContent("a".repeat(64));
+
+    act(() => {
+      useEnduragentStore.setState({
+        trainingExport: { status: "saved", target: "activity", byteLength: 4_096 },
+      });
+    });
+    expect(within(panel).getByRole("status")).toHaveTextContent("Export saved locally.");
   });
 
   it("uses the cycling unit preference and explicit unavailable ride metadata", () => {
@@ -817,6 +854,24 @@ describe("training page", () => {
     expect(plan.getAllByRole("listitem")).toHaveLength(7);
     expect(plan.getByText("Endurance ride 1")).toBeInTheDocument();
     expect(plan.queryByText("Endurance ride 8")).toBeNull();
+  });
+
+  it("exports exactly the visible planned-workout date range", async () => {
+    const user = userEvent.setup();
+    const exportWorkoutArchive = vi.fn(async () => {});
+    useEnduragentStore.setState({
+      trainingExportActions: { exportActivity: vi.fn(async () => {}), exportWorkoutArchive },
+    });
+    render(<TrainingView />);
+
+    const plan = screen.getByRole("region", { name: "Plan" });
+    await user.selectOptions(within(plan).getByRole("combobox", { name: "Workout format" }), "fit");
+    await user.click(within(plan).getByRole("button", { name: "Export workouts" }));
+    expect(exportWorkoutArchive).toHaveBeenCalledWith({
+      oldest: "1998-07-11",
+      newest: "1998-07-17",
+      format: "fit",
+    });
   });
 
   it("draws a sparkline per wellness series from the athlete-state readings", () => {

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { connect } from "node:net";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -89,8 +89,8 @@ async function startElectron(flag, env, extraArgs = []) {
   };
 }
 
-async function launch(flag, env) {
-  const running = await startElectron(flag, env);
+async function launch(flag, env, extraArgs = []) {
+  const running = await startElectron(flag, env, extraArgs);
   const result = await running.exited;
   const { stdout, stderr } = running.output();
   if (result.code !== 0 || result.signal !== null)
@@ -106,21 +106,31 @@ function summaryLine(stdout, prefix) {
 }
 
 async function runtime() {
-  const result = await launch("--desktop-runtime-smoke", {
-    ...process.env,
-    FORCE_COLOR: undefined,
-    CLICOLOR_FORCE: undefined,
-  });
-  const summary = summaryLine(result.stdout, "DESKTOP_RUNTIME_SMOKE");
-  if (
-    summary.electron !== "43.1.1" ||
-    summary.node !== "24.18.0" ||
-    summary.result !== "tempo threshold" ||
-    existsSync(summary.directory)
-  ) {
-    throw new Error("desktop runtime assertions failed");
+  const base = await realpath(process.platform === "darwin" ? "/tmp" : tmpdir());
+  const userDataDirectory = await mkdtemp(join(base, "ear-"));
+  try {
+    const result = await launch(
+      "--desktop-runtime-smoke",
+      {
+        ...process.env,
+        FORCE_COLOR: undefined,
+        CLICOLOR_FORCE: undefined,
+      },
+      [`--user-data-dir=${userDataDirectory}`],
+    );
+    const summary = summaryLine(result.stdout, "DESKTOP_RUNTIME_SMOKE");
+    if (
+      summary.electron !== "43.1.1" ||
+      summary.node !== "24.18.0" ||
+      summary.result !== "tempo threshold" ||
+      existsSync(summary.directory)
+    ) {
+      throw new Error("desktop runtime assertions failed");
+    }
+    process.stdout.write(`DESKTOP_RUNTIME_SMOKE ${JSON.stringify(summary)}\n`);
+  } finally {
+    await rm(userDataDirectory, { recursive: true, force: true });
   }
-  process.stdout.write(`DESKTOP_RUNTIME_SMOKE ${JSON.stringify(summary)}\n`);
 }
 
 async function spoofOriginResponse(url) {
@@ -285,6 +295,7 @@ async function security() {
             "deleteCredential",
             "disableTelegram",
             "enableTelegram",
+            "exportTrainingFile",
             "getArchivedTranscriptPage",
             "getDaemonConnection",
             "getTranscriptPage",

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -9,6 +9,7 @@ export const DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL =
 export const DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL =
   "desktop:get-archived-transcript-page" as const;
 export const DESKTOP_RELEASE_NOTES_CHANNEL = "desktop:get-release-notes" as const;
+export const DESKTOP_TRAINING_EXPORT_CHANNEL = "desktop:training:export" as const;
 export const DESKTOP_UPDATE_GET_CHANNEL = "desktop:update:get" as const;
 export const DESKTOP_UPDATE_CHECK_CHANNEL = "desktop:update:check" as const;
 export const DESKTOP_UPDATE_RESTART_CHANNEL = "desktop:update:restart" as const;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -99,6 +99,11 @@ import {
   installDesktopTranscriptIpc,
   type DesktopTranscriptReader,
 } from "./transcript-ipc.js";
+import {
+  createConnectionTrainingExporter,
+  installDesktopTrainingExportIpc,
+  type DesktopTrainingExporter,
+} from "./training-export-ipc.js";
 
 registerDesktopScheme();
 
@@ -179,6 +184,7 @@ async function runDesktop(): Promise<void> {
   let protocolInstalled = false;
   let disposeConnectionIpc: (() => void) | undefined;
   let disposeTranscriptIpc: (() => void) | undefined;
+  let disposeTrainingExportIpc: (() => void) | undefined;
   let disposeExternalLinkIpc: (() => void) | undefined;
   let disposeReleaseNotesIpc: (() => void) | undefined;
   let disposeUpdateIpc: (() => void) | undefined;
@@ -216,6 +222,8 @@ async function runDesktop(): Promise<void> {
       disposeConnectionIpc = undefined;
       disposeTranscriptIpc?.();
       disposeTranscriptIpc = undefined;
+      disposeTrainingExportIpc?.();
+      disposeTrainingExportIpc = undefined;
       disposeExternalLinkIpc?.();
       disposeExternalLinkIpc = undefined;
       disposeReleaseNotesIpc?.();
@@ -307,6 +315,7 @@ async function runDesktop(): Promise<void> {
       readonly authority: RuntimeConfigurationAuthority;
       readonly credentials: CredentialRuntimeApplication;
       readonly transcript: DesktopTranscriptReader;
+      readonly trainingExporter: DesktopTrainingExporter;
     };
     let activeRuntimeBinding: RuntimeBinding | undefined;
     const preparedRuntimeBindings = new Map<
@@ -419,6 +428,7 @@ async function runDesktop(): Promise<void> {
       return {
         authority,
         transcript: createConnectionTranscriptReader(boundConnection),
+        trainingExporter: createConnectionTrainingExporter(boundConnection),
         credentials: createCredentialRuntimeApplication({
           configureRuntime: authority.configureRuntime,
           clearRuntimeCredential: authority.clearCredential,
@@ -795,6 +805,18 @@ async function runDesktop(): Promise<void> {
         readActiveTranscript((reader) => reader.listArchivedConversations(request)),
       readArchivedPage: (request) =>
         readActiveTranscript((reader) => reader.getArchivedTranscriptPage(request)),
+    });
+    disposeTrainingExportIpc = installDesktopTrainingExportIpc({
+      ipcMain,
+      currentWindow: () => mainWindow.current() ?? undefined,
+      dialog,
+      exporter: () => {
+        const binding = activeRuntimeBinding;
+        const lifecycleState = daemonLifecycle?.snapshot();
+        return binding !== undefined && lifecycleState?.status === "ready"
+          ? binding.trainingExporter
+          : undefined;
+      },
     });
     disposeExternalLinkIpc = installDesktopExternalLinkIpc({
       ipcMain,

--- a/apps/desktop/src/main/training-export-ipc.ts
+++ b/apps/desktop/src/main/training-export-ipc.ts
@@ -1,0 +1,146 @@
+import { connectCoachClient, type CoachClient } from "@enduragent/coach-client";
+import {
+  DesktopTrainingExportRequestSchema,
+  DesktopTrainingExportResultSchema,
+  ExportTrainingFileRpcParamsSchema,
+  ExportTrainingFileRpcResultSchema,
+  type DesktopTrainingExportRequest,
+  type DesktopTrainingExportResult,
+  type ExportTrainingFileRpcParams,
+  type ExportTrainingFileRpcResult,
+} from "@enduragent/coach-contract";
+import type { BrowserWindow, IpcMain, IpcMainInvokeEvent, SaveDialogOptions } from "electron";
+import { DESKTOP_TRAINING_EXPORT_CHANNEL } from "./constants.js";
+import { isTrustedConnectionRequest } from "./security.js";
+
+export interface DesktopTrainingExporter {
+  export(request: ExportTrainingFileRpcParams): Promise<ExportTrainingFileRpcResult>;
+}
+
+export interface TrainingExportDialogPort {
+  showSaveDialog(
+    window: BrowserWindow,
+    options: SaveDialogOptions,
+  ): Promise<{ readonly canceled: boolean; readonly filePath?: string }>;
+}
+
+export function createConnectionTrainingExporter(
+  connection: Readonly<{
+    url: `ws://127.0.0.1:${number}/rpc`;
+    token: string;
+    athleteHome: string;
+  }>,
+  connect: typeof connectCoachClient = connectCoachClient,
+): DesktopTrainingExporter {
+  const call = async <T>(operation: (client: CoachClient) => Promise<T>): Promise<T> => {
+    const client = await connect({
+      url: connection.url,
+      token: connection.token,
+      expectedAthleteHome: connection.athleteHome,
+    });
+    try {
+      return await operation(client);
+    } finally {
+      await client.close();
+    }
+  };
+  return Object.freeze({
+    export(request: ExportTrainingFileRpcParams) {
+      return call((client) => client.call("exportTrainingFile", request));
+    },
+  });
+}
+
+function saveDialogOptions(request: DesktopTrainingExportRequest): SaveDialogOptions {
+  if (request.kind === "activity") {
+    const extension = request.format;
+    return {
+      title: `Export ride as ${extension.toUpperCase()}`,
+      defaultPath: `ride-${request.localDate}.${extension}`,
+      filters: [
+        {
+          name: extension === "fit" ? "FIT activity" : "GPX activity",
+          extensions: [extension],
+        },
+      ],
+      properties: ["createDirectory", "showOverwriteConfirmation"],
+    };
+  }
+  return {
+    title: `Export planned workouts as ${request.format.toUpperCase()}`,
+    defaultPath: `cycling-workouts-${request.oldest}-to-${request.newest}-${request.format}.zip`,
+    filters: [{ name: "Workout archive", extensions: ["zip"] }],
+    properties: ["createDirectory", "showOverwriteConfirmation"],
+  };
+}
+
+function rpcRequest(
+  request: DesktopTrainingExportRequest,
+  destinationPath: string,
+): ExportTrainingFileRpcParams {
+  return request.kind === "activity"
+    ? {
+        kind: "activity",
+        canonicalActivityId: request.canonicalActivityId,
+        format: request.format,
+        destinationPath,
+      }
+    : {
+        kind: "workout-archive",
+        oldest: request.oldest,
+        newest: request.newest,
+        format: request.format,
+        destinationPath,
+      };
+}
+
+function refusedWrite(): DesktopTrainingExportResult {
+  return { status: "refused", reason: "write-failed" };
+}
+
+export function installDesktopTrainingExportIpc(input: {
+  readonly ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
+  readonly currentWindow: () => BrowserWindow | undefined;
+  readonly dialog: TrainingExportDialogPort;
+  readonly exporter: () => DesktopTrainingExporter | undefined;
+}): () => void {
+  input.ipcMain.handle(
+    DESKTOP_TRAINING_EXPORT_CHANNEL,
+    async (event: IpcMainInvokeEvent, ...args: unknown[]): Promise<DesktopTrainingExportResult> => {
+      if (!isTrustedConnectionRequest(event, input.currentWindow())) {
+        throw new Error("untrusted desktop training export request");
+      }
+      const parsed =
+        args.length === 1 ? DesktopTrainingExportRequestSchema.safeParse(args[0]) : null;
+      if (parsed === null || !parsed.success)
+        throw new TypeError("invalid training export request");
+      const window = input.currentWindow();
+      if (window === undefined || input.exporter() === undefined) return refusedWrite();
+      let selection: Awaited<ReturnType<TrainingExportDialogPort["showSaveDialog"]>>;
+      try {
+        selection = await input.dialog.showSaveDialog(window, saveDialogOptions(parsed.data));
+      } catch {
+        return refusedWrite();
+      }
+      if (selection.canceled || selection.filePath === undefined) return { status: "cancelled" };
+      try {
+        const exporter = input.exporter();
+        if (exporter === undefined) return refusedWrite();
+        const request = ExportTrainingFileRpcParamsSchema.parse(
+          rpcRequest(parsed.data, selection.filePath),
+        );
+        const result = ExportTrainingFileRpcResultSchema.parse(await exporter.export(request));
+        return DesktopTrainingExportResultSchema.parse(
+          result.status === "exported"
+            ? { status: "saved", byteLength: result.byteLength }
+            : result,
+        );
+      } catch {
+        return refusedWrite();
+      }
+    },
+  );
+  return () => {
+    input.ipcMain.removeHandler(DESKTOP_TRAINING_EXPORT_CHANNEL);
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -20,6 +20,7 @@ import {
   DESKTOP_TELEGRAM_REMOVE_CHANNEL,
   DESKTOP_TELEGRAM_REMOVE_WEBHOOK_CHANNEL,
   DESKTOP_TELEGRAM_STATUS_CHANNEL,
+  DESKTOP_TRAINING_EXPORT_CHANNEL,
   DESKTOP_UPDATE_CHECK_CHANNEL,
   DESKTOP_UPDATE_GET_CHANNEL,
   DESKTOP_UPDATE_RESTART_CHANNEL,
@@ -115,6 +116,22 @@ const CLAUDE_CLI_STATES = new Set([
   "disabled",
 ]);
 const IMPORT_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
+const ACTIVITY_EXPORT_FORMATS = new Set(["fit", "gpx"]);
+const WORKOUT_ARCHIVE_FORMATS = new Set(["zwo", "mrc", "erg", "fit"]);
+const TRAINING_EXPORT_REFUSAL_REASONS = new Set([
+  "not-configured",
+  "source-not-found",
+  "ambiguous-source",
+  "provider-unavailable",
+  "not-supported",
+  "rate-limited",
+  "network",
+  "timeout",
+  "response-too-large",
+  "invalid-response",
+  "write-failed",
+  "commit-uncertain",
+]);
 const TELEGRAM_DESKTOP_ERROR_CODES = new Set([
   "telegram-credential-storage-failed",
   "telegram-credential-encryption-unavailable",
@@ -171,6 +188,79 @@ function record(value: unknown): value is Record<string, unknown> {
 
 function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
   return JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+}
+
+function isCivilDate(value: unknown): value is string {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return (
+    parsed.getUTCFullYear() === year &&
+    parsed.getUTCMonth() === month - 1 &&
+    parsed.getUTCDate() === day
+  );
+}
+
+function parseTrainingExportRequest(value: unknown): unknown {
+  if (!record(value) || typeof value.kind !== "string") throw new TypeError();
+  if (value.kind === "activity") {
+    if (
+      !exactKeys(value, ["kind", "canonicalActivityId", "localDate", "format"]) ||
+      typeof value.canonicalActivityId !== "string" ||
+      !BOUNDARY_REF_PATTERN.test(value.canonicalActivityId) ||
+      !isCivilDate(value.localDate) ||
+      typeof value.format !== "string" ||
+      !ACTIVITY_EXPORT_FORMATS.has(value.format)
+    ) {
+      throw new TypeError();
+    }
+    return {
+      kind: value.kind,
+      canonicalActivityId: value.canonicalActivityId,
+      localDate: value.localDate,
+      format: value.format,
+    };
+  }
+  if (
+    value.kind !== "workout-archive" ||
+    !exactKeys(value, ["kind", "oldest", "newest", "format"]) ||
+    !isCivilDate(value.oldest) ||
+    !isCivilDate(value.newest) ||
+    value.oldest > value.newest ||
+    typeof value.format !== "string" ||
+    !WORKOUT_ARCHIVE_FORMATS.has(value.format)
+  ) {
+    throw new TypeError();
+  }
+  return {
+    kind: value.kind,
+    oldest: value.oldest,
+    newest: value.newest,
+    format: value.format,
+  };
+}
+
+function parseTrainingExportResult(value: unknown): unknown {
+  if (!record(value) || typeof value.status !== "string") throw new TypeError();
+  if (value.status === "cancelled" && exactKeys(value, ["status"])) return { status: value.status };
+  if (
+    value.status === "saved" &&
+    exactKeys(value, ["status", "byteLength"]) &&
+    typeof value.byteLength === "number" &&
+    Number.isSafeInteger(value.byteLength) &&
+    value.byteLength > 0
+  ) {
+    return { status: value.status, byteLength: value.byteLength };
+  }
+  if (
+    value.status === "refused" &&
+    exactKeys(value, ["status", "reason"]) &&
+    typeof value.reason === "string" &&
+    TRAINING_EXPORT_REFUSAL_REASONS.has(value.reason)
+  ) {
+    return { status: value.status, reason: value.reason };
+  }
+  throw new TypeError();
 }
 
 function decodedBase64Url(value: string): Uint8Array | null {
@@ -1398,6 +1488,12 @@ contextBridge.exposeInMainWorld(
     },
     chooseImportFiles: async () =>
       parsePaths(await ipcRenderer.invoke(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL)),
+    exportTrainingFile: async (input: unknown) => {
+      const request = parseTrainingExportRequest(input);
+      return parseTrainingExportResult(
+        await ipcRenderer.invoke(DESKTOP_TRAINING_EXPORT_CHANNEL, request),
+      );
+    },
     releaseNotes: async () =>
       parseReleaseNotes(await ipcRenderer.invoke(DESKTOP_RELEASE_NOTES_CHANNEL)),
     getUpdateState: async () =>

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1053,6 +1053,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "deleteCredential",
         "disableTelegram",
         "enableTelegram",
+        "exportTrainingFile",
         "getArchivedTranscriptPage",
         "getDaemonConnection",
         "getTranscriptPage",

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -71,6 +71,7 @@ interface AuthBridge {
   addTelegramAllowedSender(input: unknown): Promise<unknown>;
   removeTelegramAllowedSender(input: unknown): Promise<unknown>;
   acknowledgeTelegramGapWarning(): Promise<unknown>;
+  exportTrainingFile(input: unknown): Promise<unknown>;
   getUpdateState(): Promise<unknown>;
   checkForUpdates(): Promise<unknown>;
   restartToUpdate(): Promise<unknown>;
@@ -241,6 +242,7 @@ describe("desktop preload ChatGPT auth", () => {
         "deleteCredential",
         "disableTelegram",
         "enableTelegram",
+        "exportTrainingFile",
         "getUpdateState",
         "getDaemonConnection",
         "getTranscriptPage",
@@ -269,6 +271,51 @@ describe("desktop preload ChatGPT auth", () => {
 
   it("keeps the release-gate smoke bridge list byte-equal to the sorted public bridge", () => {
     expect(pinnedSmokeBridgeKeys()).toEqual(Object.keys(bridge).sort());
+  });
+
+  it("exports only a closed training request and validates the minimized result", async () => {
+    const request = {
+      kind: "activity",
+      canonicalActivityId: "a".repeat(64),
+      localDate: "1998-07-19",
+      format: "fit",
+    };
+    mocks.invoke.mockResolvedValue({ status: "saved", byteLength: 4096 });
+
+    await expect(bridge.exportTrainingFile(request)).resolves.toEqual({
+      status: "saved",
+      byteLength: 4096,
+    });
+    expect(mocks.invoke).toHaveBeenCalledWith("desktop:training:export", request);
+
+    await expect(
+      bridge.exportTrainingFile({ ...request, canonicalActivityId: "provider-activity-42" }),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      bridge.exportTrainingFile({ ...request, localDate: "1998-02-30" }),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      bridge.exportTrainingFile({ ...request, destinationPath: "/tmp/private.fit" }),
+    ).rejects.toBeInstanceOf(TypeError);
+
+    mocks.invoke.mockResolvedValue({ status: "saved", byteLength: 0 });
+    await expect(bridge.exportTrainingFile(request)).rejects.toBeInstanceOf(TypeError);
+    mocks.invoke.mockResolvedValue({ status: "refused", reason: "private-provider-detail" });
+    await expect(bridge.exportTrainingFile(request)).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("accepts closed workout archive ranges and rejects inverted ranges", async () => {
+    const request = {
+      kind: "workout-archive",
+      oldest: "1998-07-20",
+      newest: "1998-07-26",
+      format: "zwo",
+    };
+    mocks.invoke.mockResolvedValue({ status: "cancelled" });
+    await expect(bridge.exportTrainingFile(request)).resolves.toEqual({ status: "cancelled" });
+    await expect(
+      bridge.exportTrainingFile({ ...request, oldest: "1998-07-27" }),
+    ).rejects.toBeInstanceOf(TypeError);
   });
 
   it("exposes semantic Telegram controls and validates redacted snapshots", async () => {

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -378,6 +378,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "deleteCredential",
       "disableTelegram",
       "enableTelegram",
+      "exportTrainingFile",
       "getArchivedTranscriptPage",
       "getDaemonConnection",
       "getTranscriptPage",

--- a/apps/desktop/tests/training-export-ipc.test.ts
+++ b/apps/desktop/tests/training-export-ipc.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  BrowserWindow: class {},
+  net: { fetch: vi.fn() },
+  protocol: { registerSchemesAsPrivileged: vi.fn() },
+}));
+
+import {
+  createConnectionTrainingExporter,
+  installDesktopTrainingExportIpc,
+} from "../src/main/training-export-ipc.js";
+import { DESKTOP_RENDERER_URL, DESKTOP_TRAINING_EXPORT_CHANNEL } from "../src/main/constants.js";
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const EXPORTED = {
+  status: "exported" as const,
+  byteLength: 4_096,
+  suggestedFilename: "provider-name.fit",
+  contentType: "application/octet-stream",
+};
+
+function setup(result: unknown = EXPORTED) {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: vi.fn((channel: string, handler: Handler) => handlers.set(channel, handler)),
+    removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+  };
+  const mainFrame = { url: DESKTOP_RENDERER_URL };
+  const webContents = { isDestroyed: () => false, mainFrame };
+  const window = { isDestroyed: () => false, webContents };
+  const dialog = {
+    showSaveDialog: vi.fn(
+      async (): Promise<{ canceled: boolean; filePath?: string }> => ({
+        canceled: false,
+        filePath: "/tmp/synthetic-training-export.fit",
+      }),
+    ),
+  };
+  const exporter = { export: vi.fn(async () => result) };
+  const dispose = installDesktopTrainingExportIpc({
+    ipcMain: ipcMain as never,
+    currentWindow: () => window as never,
+    dialog,
+    exporter: () => exporter as never,
+  });
+  return {
+    handlers,
+    ipcMain,
+    dialog,
+    exporter,
+    dispose,
+    trusted: { sender: webContents, senderFrame: mainFrame },
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("desktop training export IPC", () => {
+  it("uses the native save dialog and adds the destination only in the trusted main process", async () => {
+    const subject = setup();
+    const request = {
+      kind: "activity",
+      canonicalActivityId: "a".repeat(64),
+      localDate: "1998-07-19",
+      format: "fit",
+    } as const;
+    const result = await subject.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(
+      subject.trusted,
+      request,
+    );
+
+    expect(result).toEqual({ status: "saved", byteLength: 4_096 });
+    expect(subject.dialog.showSaveDialog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        title: "Export ride as FIT",
+        defaultPath: "ride-1998-07-19.fit",
+        filters: [{ name: "FIT activity", extensions: ["fit"] }],
+      }),
+    );
+    expect(subject.exporter.export).toHaveBeenCalledWith({
+      kind: "activity",
+      canonicalActivityId: "a".repeat(64),
+      format: "fit",
+      destinationPath: "/tmp/synthetic-training-export.fit",
+    });
+    expect(result).not.toHaveProperty("suggestedFilename");
+    expect(result).not.toHaveProperty("contentType");
+  });
+
+  it("routes a closed workout archive request and handles cancellation without daemon work", async () => {
+    const subject = setup();
+    const request = {
+      kind: "workout-archive",
+      oldest: "1998-07-20",
+      newest: "1998-07-26",
+      format: "zwo",
+    } as const;
+    await expect(
+      subject.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(subject.trusted, request),
+    ).resolves.toEqual({ status: "saved", byteLength: 4_096 });
+    expect(subject.exporter.export).toHaveBeenCalledWith({
+      ...request,
+      destinationPath: "/tmp/synthetic-training-export.fit",
+    });
+    expect(subject.dialog.showSaveDialog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        defaultPath: "cycling-workouts-1998-07-20-to-1998-07-26-zwo.zip",
+      }),
+    );
+
+    subject.dialog.showSaveDialog.mockResolvedValueOnce({ canceled: true });
+    await expect(
+      subject.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(subject.trusted, request),
+    ).resolves.toEqual({ status: "cancelled" });
+    expect(subject.exporter.export).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects untrusted or malformed input before showing a dialog", async () => {
+    const subject = setup();
+    const handler = subject.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!;
+    await expect(
+      handler(
+        { sender: {}, senderFrame: { url: DESKTOP_RENDERER_URL } },
+        {
+          kind: "activity",
+          canonicalActivityId: "a".repeat(64),
+          localDate: "1998-07-19",
+          format: "fit",
+        },
+      ),
+    ).rejects.toThrow("untrusted desktop training export request");
+    for (const args of [
+      [],
+      [
+        {
+          kind: "activity",
+          canonicalActivityId: "provider-42",
+          localDate: "1998-07-19",
+          format: "fit",
+        },
+      ],
+      [
+        {
+          kind: "activity",
+          canonicalActivityId: "a".repeat(64),
+          localDate: "1998-02-30",
+          format: "fit",
+        },
+      ],
+      [{ kind: "workout-archive", oldest: "1998-07-27", newest: "1998-07-20", format: "zwo" }],
+      [{ kind: "workout-archive", oldest: "1998-07-20", newest: "1998-07-27", format: "zip" }],
+      [
+        {
+          kind: "activity",
+          canonicalActivityId: "a".repeat(64),
+          localDate: "1998-07-19",
+          format: "fit",
+          destinationPath: "/tmp/hostile",
+        },
+      ],
+    ]) {
+      await expect(handler(subject.trusted, ...args)).rejects.toThrow(
+        "invalid training export request",
+      );
+    }
+    expect(subject.dialog.showSaveDialog).not.toHaveBeenCalled();
+    expect(subject.exporter.export).not.toHaveBeenCalled();
+  });
+
+  it("redacts dialog, daemon, and malformed-result failures", async () => {
+    const request = {
+      kind: "activity",
+      canonicalActivityId: "a".repeat(64),
+      localDate: "1998-07-19",
+      format: "gpx",
+    } as const;
+    const malformed = setup({ ...EXPORTED, destinationPath: "/private/provider/path" });
+    await expect(
+      malformed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(malformed.trusted, request),
+    ).resolves.toEqual({ status: "refused", reason: "write-failed" });
+
+    const failed = setup();
+    failed.exporter.export.mockRejectedValueOnce(new Error("private provider response"));
+    await expect(
+      failed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(failed.trusted, request),
+    ).resolves.toEqual({ status: "refused", reason: "write-failed" });
+
+    failed.dialog.showSaveDialog.mockRejectedValueOnce(new Error("private filesystem path"));
+    await expect(
+      failed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(failed.trusted, request),
+    ).resolves.toEqual({ status: "refused", reason: "write-failed" });
+
+    failed.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePath: "relative/private.fit",
+    });
+    await expect(
+      failed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(failed.trusted, request),
+    ).resolves.toEqual({ status: "refused", reason: "write-failed" });
+  });
+
+  it("uses one privileged client and closes it after the export", async () => {
+    const client = { call: vi.fn(async () => EXPORTED), close: vi.fn(async () => {}) };
+    const connect = vi.fn(async () => client);
+    const exporter = createConnectionTrainingExporter(
+      {
+        url: "ws://127.0.0.1:45001/rpc",
+        token: "s".repeat(43),
+        athleteHome: "/synthetic/athlete",
+      },
+      connect as never,
+    );
+    const request = {
+      kind: "activity" as const,
+      canonicalActivityId: "a".repeat(64),
+      format: "fit" as const,
+      destinationPath: "/tmp/synthetic.fit",
+    };
+    await expect(exporter.export(request)).resolves.toEqual(EXPORTED);
+    expect(client.call).toHaveBeenCalledWith("exportTrainingFile", request);
+    expect(client.close).toHaveBeenCalledOnce();
+    expect(connect).toHaveBeenCalledWith({
+      url: "ws://127.0.0.1:45001/rpc",
+      token: "s".repeat(43),
+      expectedAthleteHome: "/synthetic/athlete",
+    });
+  });
+
+  it("removes the handler during shutdown", () => {
+    const subject = setup();
+    subject.dispose();
+    expect(subject.handlers.has(DESKTOP_TRAINING_EXPORT_CHANNEL)).toBe(false);
+    expect(subject.ipcMain.removeHandler).toHaveBeenCalledWith(DESKTOP_TRAINING_EXPORT_CHANNEL);
+  });
+});

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -118,6 +118,7 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   getArchivedTranscriptPage: 30_000,
   getAthleteState: 30_000,
   getActivityAnalysis: 90_000,
+  exportTrainingFile: 120_000,
   importFiles: 60 * 60_000,
   sync: 24 * 60 * 60_000,
   saveIntake: 30_000,

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -55,6 +55,16 @@ const rpcDeadlineCases = [
     { canonicalActivityId: "a".repeat(64), sections: ["aerobic-drift"] },
     90_000,
   ],
+  [
+    "exportTrainingFile",
+    {
+      kind: "activity",
+      canonicalActivityId: "a".repeat(64),
+      format: "fit",
+      destinationPath: "/synthetic/ride.fit",
+    },
+    120_000,
+  ],
   ["importFiles", { paths: ["/synthetic/ride.fit"] }, 3_600_000],
   ["sync", {}, 86_400_000],
   [
@@ -795,6 +805,12 @@ describe("RPC receive and observers", () => {
           },
           revision: "c".repeat(64),
           sections: { intervals: { kind: "unavailable", reason: "unsupported" } },
+        },
+        exportTrainingFile: {
+          status: "exported",
+          byteLength: 4_096,
+          suggestedFilename: "synthetic.fit",
+          contentType: "application/octet-stream",
         },
         importFiles: {
           schemaVersion: 2,

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -9,3 +9,4 @@ export * from "./self-test.js";
 export * from "./handshake.js";
 export * from "./telegram-control.js";
 export * from "./activity-analysis.js";
+export * from "./training-export.js";

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -28,6 +28,12 @@ import {
   type ActivityAnalysisResult,
 } from "./activity-analysis.js";
 import {
+  ExportTrainingFileRpcParamsSchema,
+  ExportTrainingFileRpcResultSchema,
+  type ExportTrainingFileRpcParams,
+  type ExportTrainingFileRpcResult,
+} from "./training-export.js";
+import {
   ConfigureTelegramRpcParamsSchema,
   DeleteTelegramWebhookRpcParamsSchema,
   InspectTelegramCredentialRpcParamsSchema,
@@ -149,6 +155,7 @@ export const COACH_RPC_METHOD_NAMES = [
   "getArchivedTranscriptPage",
   "getAthleteState",
   "getActivityAnalysis",
+  "exportTrainingFile",
   "importFiles",
   "sync",
   "saveIntake",
@@ -821,6 +828,10 @@ export interface CoachOperations {
     request: ActivityAnalysisRequest,
     signal?: AbortSignal,
   ): Promise<ActivityAnalysisResult>;
+  exportTrainingFile?(
+    request: ExportTrainingFileRpcParams,
+    signal?: AbortSignal,
+  ): Promise<ExportTrainingFileRpcResult>;
   importFiles(
     request: ImportFilesRpcParams,
     onEvent?: (event: OperationProgressEvent) => void,
@@ -948,6 +959,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("getActivityAnalysis"),
       params: ActivityAnalysisRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("exportTrainingFile"),
+      params: ExportTrainingFileRpcParamsSchema,
     })
     .strict(),
   z
@@ -1305,6 +1324,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "getActivityAnalysis",
     requestSchema: ActivityAnalysisRequestSchema,
     responseSchema: ActivityAnalysisResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  exportTrainingFile: {
+    wireName: "exportTrainingFile",
+    requestSchema: ExportTrainingFileRpcParamsSchema,
+    responseSchema: ExportTrainingFileRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
   importFiles: {

--- a/packages/coach-contract/src/training-export.ts
+++ b/packages/coach-contract/src/training-export.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+import { CanonicalActivityIdSchema } from "./activity-analysis.js";
+
+export const ACTIVITY_EXPORT_FORMATS = ["fit", "gpx"] as const;
+export const WORKOUT_ARCHIVE_FORMATS = ["zwo", "mrc", "erg", "fit"] as const;
+
+export const ActivityExportFormatSchema = z.enum(ACTIVITY_EXPORT_FORMATS);
+export const WorkoutArchiveFormatSchema = z.enum(WORKOUT_ARCHIVE_FORMATS);
+
+function isCivilDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return (
+    parsed.getUTCFullYear() === year &&
+    parsed.getUTCMonth() === month - 1 &&
+    parsed.getUTCDate() === day
+  );
+}
+
+export const TrainingExportCivilDateSchema = z
+  .string()
+  .refine(isCivilDate, "invalid training export civil date");
+
+export const DesktopTrainingExportRequestSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("activity"),
+      canonicalActivityId: CanonicalActivityIdSchema,
+      localDate: TrainingExportCivilDateSchema,
+      format: ActivityExportFormatSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("workout-archive"),
+      oldest: TrainingExportCivilDateSchema,
+      newest: TrainingExportCivilDateSchema,
+      format: WorkoutArchiveFormatSchema,
+    })
+    .strict()
+    .refine((value) => value.oldest <= value.newest, {
+      message: "workout export date range is invalid",
+      path: ["newest"],
+    }),
+]);
+
+export const TrainingExportDestinationPathSchema = z
+  .string()
+  .min(1)
+  .max(4_096)
+  .refine((value) => value.startsWith("/") && !value.includes("\0"), {
+    message: "training export destination must be absolute",
+  });
+
+export const ExportTrainingFileRpcParamsSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("activity"),
+      canonicalActivityId: CanonicalActivityIdSchema,
+      format: ActivityExportFormatSchema,
+      destinationPath: TrainingExportDestinationPathSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("workout-archive"),
+      oldest: TrainingExportCivilDateSchema,
+      newest: TrainingExportCivilDateSchema,
+      format: WorkoutArchiveFormatSchema,
+      destinationPath: TrainingExportDestinationPathSchema,
+    })
+    .strict()
+    .refine((value) => value.oldest <= value.newest, {
+      message: "workout export date range is invalid",
+      path: ["newest"],
+    }),
+]);
+
+export const TrainingExportRefusalReasonSchema = z.enum([
+  "not-configured",
+  "source-not-found",
+  "ambiguous-source",
+  "provider-unavailable",
+  "not-supported",
+  "rate-limited",
+  "network",
+  "timeout",
+  "response-too-large",
+  "invalid-response",
+  "write-failed",
+  "commit-uncertain",
+]);
+
+export const TrainingExportFilenameSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .refine(
+    (value) =>
+      value !== "." &&
+      value !== ".." &&
+      !value.includes("/") &&
+      !value.includes("\\") &&
+      [...value].every((character) => {
+        const codePoint = character.codePointAt(0)!;
+        return codePoint > 31 && !(codePoint >= 127 && codePoint <= 159);
+      }),
+    "invalid training export filename",
+  );
+
+export const ExportTrainingFileRpcResultSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("exported"),
+      byteLength: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+      suggestedFilename: TrainingExportFilenameSchema.nullable(),
+      contentType: z.string().min(1).max(255).nullable(),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("refused"),
+      reason: TrainingExportRefusalReasonSchema,
+    })
+    .strict(),
+]);
+
+export const DesktopTrainingExportResultSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("cancelled") }).strict(),
+  z
+    .object({
+      status: z.literal("saved"),
+      byteLength: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("refused"),
+      reason: TrainingExportRefusalReasonSchema,
+    })
+    .strict(),
+]);
+
+export type ActivityExportFormat = z.infer<typeof ActivityExportFormatSchema>;
+export type WorkoutArchiveFormat = z.infer<typeof WorkoutArchiveFormatSchema>;
+export type DesktopTrainingExportRequest = z.infer<typeof DesktopTrainingExportRequestSchema>;
+export type ExportTrainingFileRpcParams = z.infer<typeof ExportTrainingFileRpcParamsSchema>;
+export type TrainingExportRefusalReason = z.infer<typeof TrainingExportRefusalReasonSchema>;
+export type ExportTrainingFileRpcResult = z.infer<typeof ExportTrainingFileRpcResultSchema>;
+export type DesktopTrainingExportResult = z.infer<typeof DesktopTrainingExportResultSchema>;

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 15;
+export const PROTOCOL_VERSION = 16;

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -111,8 +111,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 13", () => {
-    expect(PROTOCOL_VERSION).toBe(15);
+  it("is 16", () => {
+    expect(PROTOCOL_VERSION).toBe(16);
   });
 });
 

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -947,6 +947,10 @@ describe("coach request and event projection", () => {
       getActivityAnalysis: async () => {
         throw new Error("not exercised by registry exhaustiveness");
       },
+      exportTrainingFile: async () => ({
+        status: "refused",
+        reason: "not-configured",
+      }),
       importFiles: async ({ paths }) => ({
         schemaVersion: 2,
         files: { total: paths.length, imported: paths.length, quarantined: 0 },
@@ -1505,7 +1509,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-15 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-16 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1513,8 +1517,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 15,
-      serverProtocolVersion: 15,
+      clientProtocolVersion: 16,
+      serverProtocolVersion: 16,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1569,9 +1573,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 15 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 16 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(15);
+    expect(client.clientProtocolVersion).toBe(16);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -1701,7 +1705,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version fifteen", () => {
-    expect(PROTOCOL_VERSION).toBe(15);
+  it("uses protocol version sixteen", () => {
+    expect(PROTOCOL_VERSION).toBe(16);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -130,6 +130,7 @@ import {
   createPowerHeartRateAnalyzer,
   createProviderActivityPowerHeartRateReader,
 } from "./activity-power-heart-rate.js";
+import { createTrainingExportService } from "./training-export.js";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -1074,10 +1075,11 @@ export async function createLocalCoachComposition(
       access: providerAccess,
       archive: createProviderActivityPowerHeartRateArchive({ ...archiveDependencies }),
     });
+    const trustedActivitySources = createTrustedActivitySourceResolver(input.context.store);
     const activityAnalysis = createStoredActivityAnalysisService({
       store: input.context.store,
       activities: canonicalActivities,
-      sources: createTrustedActivitySourceResolver(input.context.store),
+      sources: trustedActivitySources,
       analyzers: {
         aerobicDrift: createAerobicDriftAnalyzer({
           activities: canonicalActivities,
@@ -1093,6 +1095,10 @@ export async function createLocalCoachComposition(
       },
       runCacheWrite: (work) => runtime!.runExclusive(work),
       now,
+    });
+    const trainingExport = createTrainingExportService({
+      credentials: options.liveIntervals,
+      sources: trustedActivitySources,
     });
     const operations = {
       ...createCoachOperations(
@@ -1114,6 +1120,7 @@ export async function createLocalCoachComposition(
       ),
       getActivityAnalysis: (request, signal) =>
         activityAnalysis.getActivityAnalysis(request, signal),
+      exportTrainingFile: (request, signal) => trainingExport.export(request, signal),
     } satisfies CoachOperations;
     return {
       engine: reconfigurable.engine,

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -816,6 +816,22 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               invocationFailure = { error };
             }
             break;
+          case "exportTrainingFile":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.exportTrainingFile.requestSchema.parse(
+                generic.data.params,
+              );
+              if (input.operations.exportTrainingFile === undefined) {
+                throw new TypeError("Training export operation is unavailable.");
+              }
+              result = await input.operations.exportTrainingFile(
+                request,
+                state.detachController.signal,
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
           case "importFiles":
             try {
               const request = COACH_RPC_METHOD_REGISTRY.importFiles.requestSchema.parse(

--- a/packages/coach/src/training-export.ts
+++ b/packages/coach/src/training-export.ts
@@ -1,0 +1,382 @@
+import { randomBytes } from "node:crypto";
+import { open, rename, rm } from "node:fs/promises";
+import { basename, dirname, isAbsolute, normalize } from "node:path";
+import { makeAbortableClient } from "@enduragent/core";
+import {
+  ExportTrainingFileRpcResultSchema,
+  TrainingExportFilenameSchema,
+  type ExportTrainingFileRpcParams,
+  type ExportTrainingFileRpcResult,
+  type TrainingExportRefusalReason,
+} from "@enduragent/coach-contract";
+import type { TrustedActivitySourceResolver } from "@enduragent/kernel/store";
+import type { ApiError, BinaryDownload, IntervalsClient, Result } from "intervals-icu-api";
+
+export const MAX_ACTIVITY_EXPORT_BYTES = 128 * 1_024 * 1_024;
+export const MAX_WORKOUT_ARCHIVE_EXPORT_BYTES = 256 * 1_024 * 1_024;
+export const TRAINING_EXPORT_REQUEST_TIMEOUT_MS = 60_000;
+
+export type TrainingExportWriteOutcome = "committed" | "failed" | "uncertain";
+
+export interface TrainingExportWriter {
+  write(input: {
+    readonly destinationPath: string;
+    readonly bytes: Uint8Array;
+  }): Promise<TrainingExportWriteOutcome>;
+}
+
+export interface TrainingExportService {
+  export(
+    request: ExportTrainingFileRpcParams,
+    signal?: AbortSignal,
+  ): Promise<ExportTrainingFileRpcResult>;
+}
+
+export type TrainingExportClientFactory = (input: {
+  readonly apiKey: string;
+  readonly athleteId: string;
+  readonly signal: AbortSignal;
+  readonly baseFetch: typeof globalThis.fetch;
+}) => Pick<IntervalsClient, "activities" | "workouts">;
+
+function refused(reason: TrainingExportRefusalReason): ExportTrainingFileRpcResult {
+  return { status: "refused", reason };
+}
+
+function safeContentType(value: string | null): string | null {
+  if (value === null || value.length === 0 || value.length > 255) return null;
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if (codePoint <= 31 || (codePoint >= 127 && codePoint <= 159)) return null;
+  }
+  return value;
+}
+
+function resultMetadata(value: BinaryDownload): {
+  readonly suggestedFilename: string | null;
+  readonly contentType: string | null;
+} {
+  const filename = TrainingExportFilenameSchema.safeParse(value.filename);
+  return {
+    suggestedFilename: filename.success ? filename.data : null,
+    contentType: safeContentType(value.contentType),
+  };
+}
+
+function contentTypeMatches(request: ExportTrainingFileRpcParams, value: string | null): boolean {
+  if (value === null) return true;
+  const mediaType = value.split(";", 1)[0]!.trim().toLowerCase();
+  if (mediaType === "application/octet-stream") return true;
+  if (request.kind === "workout-archive") {
+    return mediaType === "application/zip" || mediaType === "application/x-zip-compressed";
+  }
+  if (request.format === "fit") {
+    return ["application/vnd.ant.fit", "application/fit", "application/x-fit"].includes(mediaType);
+  }
+  return ["application/gpx+xml", "application/xml", "text/xml"].includes(mediaType);
+}
+
+function hasPrefix(bytes: Uint8Array, prefix: readonly number[]): boolean {
+  return prefix.every((value, index) => bytes[index] === value);
+}
+
+function contentBytesMatch(request: ExportTrainingFileRpcParams, bytes: Uint8Array): boolean {
+  if (request.kind === "workout-archive") {
+    return (
+      bytes.byteLength >= 4 &&
+      (hasPrefix(bytes, [0x50, 0x4b, 0x03, 0x04]) ||
+        hasPrefix(bytes, [0x50, 0x4b, 0x05, 0x06]) ||
+        hasPrefix(bytes, [0x50, 0x4b, 0x07, 0x08]))
+    );
+  }
+  if (request.format === "fit") {
+    const headerSize = bytes[0] ?? 0;
+    return (
+      bytes.byteLength >= 12 &&
+      headerSize >= 12 &&
+      headerSize <= bytes.byteLength &&
+      hasPrefix(bytes.subarray(8), [0x2e, 0x46, 0x49, 0x54])
+    );
+  }
+  const prefix = new TextDecoder().decode(bytes.subarray(0, Math.min(bytes.byteLength, 65_536)));
+  return /<gpx(?:\s|>)/iu.test(prefix);
+}
+
+function providerRefusal(
+  error: ApiError,
+  responseLimitExceeded: boolean,
+): TrainingExportRefusalReason {
+  if (responseLimitExceeded) return "response-too-large";
+  if (error.kind === "RateLimit") return "rate-limited";
+  if (error.kind === "Timeout") return "timeout";
+  if (error.kind === "Network") return "network";
+  if (error.kind === "Validation") return "invalid-response";
+  if (error.kind === "NotFound") return "not-supported";
+  return "provider-unavailable";
+}
+
+export function createBoundedTrainingExportFetch(input: {
+  readonly baseFetch: typeof globalThis.fetch;
+  readonly maximumBytes: number;
+  readonly noteLimitExceeded: () => void;
+}): typeof globalThis.fetch {
+  if (!Number.isSafeInteger(input.maximumBytes) || input.maximumBytes < 1) {
+    throw new TypeError("training export response limit is invalid");
+  }
+  return async (request, init) => {
+    const response = await input.baseFetch(request, init);
+    const declared = response.headers.get("content-length");
+    if (declared !== null) {
+      const bytes = Number(declared);
+      if (Number.isFinite(bytes) && bytes > input.maximumBytes) {
+        input.noteLimitExceeded();
+        await response.body?.cancel();
+        throw new Error("training export response exceeded its private byte limit");
+      }
+    }
+    if (response.body === null) return response;
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value.byteLength;
+      if (total > input.maximumBytes) {
+        input.noteLimitExceeded();
+        await reader.cancel();
+        throw new Error("training export response exceeded its private byte limit");
+      }
+      chunks.push(next.value);
+    }
+    const body = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const directory = await open(path, "r");
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close().catch(() => undefined);
+  }
+}
+
+export function createDurableTrainingExportWriter(input?: {
+  readonly createTemporaryId?: () => string;
+  readonly openFile?: typeof open;
+  readonly renameFile?: typeof rename;
+  readonly removeFile?: typeof rm;
+  readonly syncDirectory?: (path: string) => Promise<void>;
+}): TrainingExportWriter {
+  const createTemporaryId = input?.createTemporaryId ?? (() => randomBytes(12).toString("hex"));
+  const openFile = input?.openFile ?? open;
+  const renameFile = input?.renameFile ?? rename;
+  const removeFile = input?.removeFile ?? rm;
+  const sync = input?.syncDirectory ?? syncDirectory;
+  return Object.freeze({
+    async write(request: {
+      readonly destinationPath: string;
+      readonly bytes: Uint8Array;
+    }): Promise<TrainingExportWriteOutcome> {
+      const destination = request.destinationPath;
+      const fileName = basename(destination);
+      if (
+        !isAbsolute(destination) ||
+        normalize(destination) !== destination ||
+        fileName.length === 0 ||
+        fileName === "/" ||
+        fileName === "." ||
+        fileName === ".."
+      ) {
+        return "failed";
+      }
+      const root = dirname(destination);
+      const id = createTemporaryId();
+      if (!/^[A-Za-z0-9-]{1,128}$/.test(id)) return "failed";
+      const temporary = `${root}/.enduragent-export-${id}.tmp`;
+      let handle: Awaited<ReturnType<typeof open>> | undefined;
+      let renamed = false;
+      try {
+        handle = await openFile(temporary, "wx", 0o600);
+        await handle.writeFile(request.bytes);
+        await handle.chmod(0o600);
+        await handle.sync();
+        await handle.close();
+        handle = undefined;
+        await renameFile(temporary, destination);
+        renamed = true;
+        await sync(root);
+        return "committed";
+      } catch {
+        return renamed ? "uncertain" : "failed";
+      } finally {
+        await handle?.close().catch(() => undefined);
+        await removeFile(temporary, { force: true }).catch(() => undefined);
+      }
+    },
+  });
+}
+
+function downloadActivity(
+  client: Pick<IntervalsClient, "activities">,
+  providerActivityId: string,
+  format: "fit" | "gpx",
+): Promise<Result<BinaryDownload>> {
+  return format === "fit"
+    ? client.activities.downloadFitFile(providerActivityId, {
+        includeMetadata: true,
+        power: true,
+        hr: true,
+      })
+    : client.activities.downloadGpxFile(providerActivityId, {
+        includeMetadata: true,
+        power: true,
+        hr: true,
+      });
+}
+
+export function createTrainingExportService(input: {
+  readonly credentials: {
+    read(): Promise<{ readonly apiKey: string; readonly athleteId: string }>;
+  };
+  readonly sources: TrustedActivitySourceResolver;
+  readonly writer?: TrainingExportWriter;
+  readonly createClient?: TrainingExportClientFactory;
+  readonly baseFetch?: typeof globalThis.fetch;
+  readonly maximumActivityBytes?: number;
+  readonly maximumWorkoutArchiveBytes?: number;
+  readonly requestTimeoutMs?: number;
+}): TrainingExportService {
+  const writer = input.writer ?? createDurableTrainingExportWriter();
+  const maximumActivityBytes = input.maximumActivityBytes ?? MAX_ACTIVITY_EXPORT_BYTES;
+  const maximumWorkoutArchiveBytes =
+    input.maximumWorkoutArchiveBytes ?? MAX_WORKOUT_ARCHIVE_EXPORT_BYTES;
+  const requestTimeoutMs = input.requestTimeoutMs ?? TRAINING_EXPORT_REQUEST_TIMEOUT_MS;
+  for (const value of [maximumActivityBytes, maximumWorkoutArchiveBytes, requestTimeoutMs]) {
+    if (!Number.isSafeInteger(value) || value < 1) {
+      throw new TypeError("training export limit is invalid");
+    }
+  }
+  const createClient =
+    input.createClient ??
+    ((options) =>
+      makeAbortableClient({
+        apiKey: options.apiKey,
+        ...(options.athleteId.length === 0 ? {} : { athleteId: options.athleteId }),
+        signal: options.signal,
+        perRequestMs: requestTimeoutMs,
+        baseFetch: options.baseFetch,
+      }));
+
+  return Object.freeze({
+    async export(
+      request: ExportTrainingFileRpcParams,
+      signal: AbortSignal = new AbortController().signal,
+    ): Promise<ExportTrainingFileRpcResult> {
+      signal.throwIfAborted();
+      let providerActivityId: string | undefined;
+      if (request.kind === "activity") {
+        const resolution = await input.sources.resolve({
+          canonicalActivityId: request.canonicalActivityId,
+        });
+        signal.throwIfAborted();
+        if (resolution.kind === "unavailable") {
+          return refused(
+            resolution.reason === "ambiguous" ? "ambiguous-source" : "source-not-found",
+          );
+        }
+        providerActivityId = resolution.providerActivityId;
+      }
+      const credentials = await input.credentials.read();
+      signal.throwIfAborted();
+      if (
+        credentials.apiKey.length === 0 ||
+        (request.kind === "workout-archive" && credentials.athleteId.length === 0)
+      ) {
+        return refused("not-configured");
+      }
+      const maximumBytes =
+        request.kind === "activity" ? maximumActivityBytes : maximumWorkoutArchiveBytes;
+      let responseLimitExceeded = false;
+      const client = createClient({
+        apiKey: credentials.apiKey,
+        athleteId: credentials.athleteId,
+        signal,
+        baseFetch: createBoundedTrainingExportFetch({
+          baseFetch: input.baseFetch ?? globalThis.fetch,
+          maximumBytes,
+          noteLimitExceeded: () => {
+            responseLimitExceeded = true;
+          },
+        }),
+      });
+      let result: Result<BinaryDownload>;
+      try {
+        result =
+          request.kind === "activity"
+            ? await downloadActivity(client, providerActivityId!, request.format)
+            : await client.workouts.downloadZip({
+                format: request.format,
+                oldest: request.oldest,
+                newest: request.newest,
+                includeMetadata: true,
+              });
+      } catch (error) {
+        if (signal.aborted) throw signal.reason ?? error;
+        return refused(responseLimitExceeded ? "response-too-large" : "provider-unavailable");
+      }
+      signal.throwIfAborted();
+      if (!result.ok) return refused(providerRefusal(result.error, responseLimitExceeded));
+      if (
+        !(result.value.bytes instanceof ArrayBuffer) ||
+        result.value.bytes.byteLength < 1 ||
+        result.value.bytes.byteLength > maximumBytes
+      ) {
+        return refused(
+          result.value.bytes.byteLength > maximumBytes ? "response-too-large" : "invalid-response",
+        );
+      }
+      if (!contentTypeMatches(request, result.value.contentType)) {
+        return refused("invalid-response");
+      }
+      const metadata = resultMetadata(result.value);
+      const bytes = new Uint8Array(result.value.bytes);
+      try {
+        if (!contentBytesMatch(request, bytes)) return refused("invalid-response");
+        let outcome: TrainingExportWriteOutcome;
+        try {
+          outcome = await writer.write({
+            destinationPath: request.destinationPath,
+            bytes,
+          });
+        } catch {
+          return refused("write-failed");
+        }
+        // A successful rename is the commit point. If the caller disconnects while the
+        // file is being published, report the committed result rather than encouraging
+        // an unsafe retry that could overwrite the file.
+        if (outcome !== "committed") {
+          return refused(outcome === "uncertain" ? "commit-uncertain" : "write-failed");
+        }
+        return ExportTrainingFileRpcResultSchema.parse({
+          status: "exported",
+          byteLength: bytes.byteLength,
+          ...metadata,
+        });
+      } finally {
+        bytes.fill(0);
+      }
+    },
+  });
+}

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -64,6 +64,12 @@ const state: AthleteState = {
 };
 
 const operations: CoachOperations = {
+  exportTrainingFile: async () => ({
+    status: "exported",
+    byteLength: 4_096,
+    suggestedFilename: "synthetic.fit",
+    contentType: "application/octet-stream",
+  }),
   getActivityAnalysis: async ({ canonicalActivityId }) => ({
     schemaVersion: 1,
     activity: {
@@ -511,6 +517,10 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       }),
       operations: {
         ...operations,
+        exportTrainingFile: async (request, signal) => {
+          calls.push("exportTrainingFile");
+          return operations.exportTrainingFile!(request, signal);
+        },
         getActivityAnalysis: async (request) => {
           calls.push("getActivityAnalysis");
           return operations.getActivityAnalysis!(request);
@@ -559,6 +569,16 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         method: "getActivityAnalysis",
         params: { canonicalActivityId: "a".repeat(64), sections: ["aerobic-drift"] },
       },
+      {
+        id: 6,
+        method: "exportTrainingFile",
+        params: {
+          kind: "activity",
+          canonicalActivityId: "a".repeat(64),
+          format: "fit",
+          destinationPath: "/tmp/synthetic-export.fit",
+        },
+      },
     ];
     for (const value of requests) {
       client.ws.send(JSON.stringify({ jsonrpc: "2.0", ...value }));
@@ -571,6 +591,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       "hasSession:chat",
       "getAthleteState",
       "getActivityAnalysis",
+      "exportTrainingFile",
     ]);
     await client.close();
   });
@@ -2094,6 +2115,43 @@ describe.skipIf(!hasLoopback)("RPC authority boundaries", () => {
       if (client === undefined) await rpc.close();
       else await client.close();
     }
+  });
+
+  it("keeps file export outside renderer authority", async () => {
+    const exportTrainingFile = vi.fn(operations.exportTrainingFile!);
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: { ...operations, exportTrainingFile },
+      token: "x".repeat(43),
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(
+      JSON.stringify(
+        createClientHandshakeFrame(TEST_RENDERER_CAPABILITY_BYTES.toString("base64url")),
+      ),
+    );
+    await client.frames.next();
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "export",
+        method: "exportTrainingFile",
+        params: {
+          kind: "activity",
+          canonicalActivityId: "a".repeat(64),
+          format: "fit",
+          destinationPath: "/tmp/renderer-must-not-write.fit",
+        },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "export",
+      error: { code: -32601, message: "Method not found" },
+    });
+    expect(exportTrainingFile).not.toHaveBeenCalled();
+    await client.close();
   });
 });
 

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -105,8 +105,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 15 as const,
-      serverProtocolVersion: 15 as const,
+      clientProtocolVersion: 16 as const,
+      serverProtocolVersion: 16 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/training-export.test.ts
+++ b/packages/coach/tests/training-export.test.ts
@@ -1,0 +1,459 @@
+import { mkdtemp, readFile, readdir, rename, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TrustedActivitySourceResolver } from "@enduragent/kernel/store";
+import {
+  createBoundedTrainingExportFetch,
+  createDurableTrainingExportWriter,
+  createTrainingExportService,
+  type TrainingExportClientFactory,
+  type TrainingExportWriter,
+} from "../src/training-export.js";
+
+const roots: string[] = [];
+const canonicalActivityId = "a".repeat(64);
+const validFitBytes = [14, 16, 0, 0, 0, 0, 0, 0, 0x2e, 0x46, 0x49, 0x54, 0, 0];
+const validGpxBytes = [...new TextEncoder().encode('<?xml version="1.0"?><gpx version="1.1"/>')];
+const validZipBytes = [0x50, 0x4b, 0x05, 0x06];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function availableSource(providerActivityId = "i123"): TrustedActivitySourceResolver {
+  return {
+    resolve: vi.fn(async () => ({
+      kind: "resolved" as const,
+      providerActivityId: providerActivityId as never,
+      sourceRevision: "b".repeat(64),
+    })),
+  };
+}
+
+function credentials(
+  apiKey = "secret",
+  athleteId = "athlete",
+): {
+  read(): Promise<{ readonly apiKey: string; readonly athleteId: string }>;
+} {
+  return { read: vi.fn(async () => ({ apiKey, athleteId })) };
+}
+
+function binary(
+  bytes: readonly number[],
+  metadata?: { readonly filename?: string | null; readonly contentType?: string | null },
+) {
+  return {
+    ok: true as const,
+    value: {
+      bytes: Uint8Array.from(bytes).buffer as ArrayBuffer,
+      filename: metadata?.filename ?? "ride.fit",
+      contentType: metadata?.contentType ?? "application/octet-stream",
+      contentLength: bytes.length,
+      contentEncoding: null,
+    },
+  };
+}
+
+function clientFactory(input: {
+  readonly downloadFitFile?: ReturnType<typeof vi.fn>;
+  readonly downloadGpxFile?: ReturnType<typeof vi.fn>;
+  readonly downloadZip?: ReturnType<typeof vi.fn>;
+}): TrainingExportClientFactory {
+  return vi.fn(
+    () =>
+      ({
+        activities: {
+          downloadFitFile: input.downloadFitFile ?? vi.fn(),
+          downloadGpxFile: input.downloadGpxFile ?? vi.fn(),
+        },
+        workouts: { downloadZip: input.downloadZip ?? vi.fn() },
+      }) as never,
+  );
+}
+
+describe("training export service", () => {
+  it("resolves a canonical ride privately and writes a bounded FIT export with metadata", async () => {
+    const downloadFitFile = vi.fn(async () =>
+      binary(validFitBytes, {
+        filename: "Morning Ride.fit",
+        contentType: "application/vnd.ant.fit",
+      }),
+    );
+    const retained: Uint8Array[] = [];
+    const copies: Uint8Array[] = [];
+    const writer: TrainingExportWriter = {
+      write: vi.fn(async ({ bytes }) => {
+        retained.push(bytes);
+        copies.push(Uint8Array.from(bytes));
+        return "committed" as const;
+      }),
+    };
+    const sources = availableSource("provider-42");
+    const service = createTrainingExportService({
+      credentials: credentials(),
+      sources,
+      writer,
+      createClient: clientFactory({ downloadFitFile }),
+    });
+
+    await expect(
+      service.export({
+        kind: "activity",
+        canonicalActivityId,
+        format: "fit",
+        destinationPath: "/tmp/ride.fit",
+      }),
+    ).resolves.toEqual({
+      status: "exported",
+      byteLength: validFitBytes.length,
+      suggestedFilename: "Morning Ride.fit",
+      contentType: "application/vnd.ant.fit",
+    });
+    expect(sources.resolve).toHaveBeenCalledWith({ canonicalActivityId });
+    expect(downloadFitFile).toHaveBeenCalledWith("provider-42", {
+      includeMetadata: true,
+      power: true,
+      hr: true,
+    });
+    expect(copies[0]).toEqual(Uint8Array.from(validFitBytes));
+    expect(retained[0]).toEqual(Uint8Array.from(validFitBytes, () => 0));
+  });
+
+  it("routes GPX and workout ZIP formats through their typed metadata methods", async () => {
+    const downloadGpxFile = vi.fn(async () =>
+      binary(validGpxBytes, { filename: "ride.gpx", contentType: "application/gpx+xml" }),
+    );
+    const downloadZip = vi.fn(async () =>
+      binary(validZipBytes, { filename: "workouts.zip", contentType: "application/zip" }),
+    );
+    const writer: TrainingExportWriter = { write: vi.fn(async () => "committed" as const) };
+    const sources = availableSource();
+    const createClient = clientFactory({ downloadGpxFile, downloadZip });
+    const service = createTrainingExportService({
+      credentials: credentials(),
+      sources,
+      writer,
+      createClient,
+    });
+
+    await service.export({
+      kind: "activity",
+      canonicalActivityId,
+      format: "gpx",
+      destinationPath: "/tmp/ride.gpx",
+    });
+    await expect(
+      service.export({
+        kind: "workout-archive",
+        oldest: "1998-07-20",
+        newest: "1998-07-26",
+        format: "zwo",
+        destinationPath: "/tmp/workouts.zip",
+      }),
+    ).resolves.toMatchObject({ status: "exported", byteLength: validZipBytes.length });
+    expect(downloadGpxFile).toHaveBeenCalledWith("i123", {
+      includeMetadata: true,
+      power: true,
+      hr: true,
+    });
+    expect(downloadZip).toHaveBeenCalledWith({
+      format: "zwo",
+      oldest: "1998-07-20",
+      newest: "1998-07-26",
+      includeMetadata: true,
+    });
+    expect(sources.resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses missing or ambiguous ride authority before reading credentials", async () => {
+    const read = vi.fn(async () => ({ apiKey: "secret", athleteId: "athlete" }));
+    for (const reason of ["not_found", "ambiguous"] as const) {
+      const service = createTrainingExportService({
+        credentials: { read },
+        sources: { resolve: vi.fn(async () => ({ kind: "unavailable" as const, reason })) },
+        writer: { write: vi.fn(async () => "committed" as const) },
+        createClient: clientFactory({}),
+      });
+      await expect(
+        service.export({
+          kind: "activity",
+          canonicalActivityId,
+          format: "fit",
+          destinationPath: "/tmp/ride.fit",
+        }),
+      ).resolves.toEqual({
+        status: "refused",
+        reason: reason === "ambiguous" ? "ambiguous-source" : "source-not-found",
+      });
+    }
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("requires configured credentials and maps provider and writer failures", async () => {
+    const request = {
+      kind: "workout-archive" as const,
+      oldest: "1998-07-20",
+      newest: "1998-07-26",
+      format: "fit" as const,
+      destinationPath: "/tmp/workouts.zip",
+    };
+    const missing = createTrainingExportService({
+      credentials: credentials("", ""),
+      sources: availableSource(),
+      writer: { write: vi.fn(async () => "committed" as const) },
+      createClient: clientFactory({}),
+    });
+    await expect(missing.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "not-configured",
+    });
+
+    const rateLimited = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      writer: { write: vi.fn(async () => "committed" as const) },
+      createClient: clientFactory({
+        downloadZip: vi.fn(async () => ({
+          ok: false,
+          error: { kind: "RateLimit", status: 429, retryAfterMs: 1_000, body: null },
+        })),
+      }),
+    });
+    await expect(rateLimited.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "rate-limited",
+    });
+
+    for (const [outcome, reason] of [
+      ["failed", "write-failed"],
+      ["uncertain", "commit-uncertain"],
+    ] as const) {
+      const service = createTrainingExportService({
+        credentials: credentials(),
+        sources: availableSource(),
+        writer: { write: vi.fn(async () => outcome) },
+        createClient: clientFactory({ downloadZip: vi.fn(async () => binary(validZipBytes)) }),
+      });
+      await expect(service.export(request)).resolves.toEqual({ status: "refused", reason });
+    }
+
+    const thrownProvider = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      writer: { write: vi.fn(async () => "committed" as const) },
+      createClient: clientFactory({
+        downloadZip: vi.fn(async () => {
+          throw new Error("private provider failure");
+        }),
+      }),
+    });
+    await expect(thrownProvider.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "provider-unavailable",
+    });
+
+    const thrownWriter = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      writer: {
+        write: vi.fn(async () => {
+          throw new Error("private filesystem failure");
+        }),
+      },
+      createClient: clientFactory({ downloadZip: vi.fn(async () => binary(validZipBytes)) }),
+    });
+    await expect(thrownWriter.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "write-failed",
+    });
+  });
+
+  it("reports a file committed while the caller disconnects instead of inviting a retry", async () => {
+    const controller = new AbortController();
+    const service = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      writer: {
+        write: vi.fn(async () => {
+          controller.abort(new Error("caller detached"));
+          return "committed" as const;
+        }),
+      },
+      createClient: clientFactory({ downloadZip: vi.fn(async () => binary(validZipBytes)) }),
+    });
+    await expect(
+      service.export(
+        {
+          kind: "workout-archive",
+          oldest: "1998-07-20",
+          newest: "1998-07-26",
+          format: "zwo",
+          destinationPath: "/tmp/workouts.zip",
+        },
+        controller.signal,
+      ),
+    ).resolves.toMatchObject({ status: "exported", byteLength: validZipBytes.length });
+  });
+
+  it("rejects empty, oversized, or unexpected content without exposing metadata", async () => {
+    const request = {
+      kind: "workout-archive" as const,
+      oldest: "1998-07-20",
+      newest: "1998-07-26",
+      format: "erg" as const,
+      destinationPath: "/tmp/workouts.zip",
+    };
+    const empty = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      writer: { write: vi.fn(async () => "committed" as const) },
+      createClient: clientFactory({ downloadZip: vi.fn(async () => binary([])) }),
+    });
+    await expect(empty.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "invalid-response",
+    });
+
+    const oversized = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      maximumWorkoutArchiveBytes: 1,
+      writer: { write: vi.fn(async () => "committed" as const) },
+      createClient: clientFactory({ downloadZip: vi.fn(async () => binary(validZipBytes)) }),
+    });
+    await expect(oversized.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "response-too-large",
+    });
+
+    const sanitized = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      writer: { write: vi.fn(async () => "committed" as const) },
+      createClient: clientFactory({
+        downloadZip: vi.fn(async () =>
+          binary(validZipBytes, { filename: "../secret.zip", contentType: "application/zip" }),
+        ),
+      }),
+    });
+    await expect(sanitized.export(request)).resolves.toMatchObject({
+      status: "exported",
+      suggestedFilename: null,
+      contentType: "application/zip",
+    });
+
+    const unexpectedWriter = { write: vi.fn(async () => "committed" as const) };
+    const unexpectedContent = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      writer: unexpectedWriter,
+      createClient: clientFactory({
+        downloadZip: vi.fn(async () =>
+          binary([1], { filename: "private.html", contentType: "text/html; charset=utf-8" }),
+        ),
+      }),
+    });
+    await expect(unexpectedContent.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "invalid-response",
+    });
+    expect(unexpectedWriter.write).not.toHaveBeenCalled();
+
+    const invalidSignatureWriter = { write: vi.fn(async () => "committed" as const) };
+    const invalidSignature = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      writer: invalidSignatureWriter,
+      createClient: clientFactory({ downloadZip: vi.fn(async () => binary([1, 2, 3, 4])) }),
+    });
+    await expect(invalidSignature.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "invalid-response",
+    });
+    expect(invalidSignatureWriter.write).not.toHaveBeenCalled();
+  });
+});
+
+describe("bounded training export fetch", () => {
+  it("stops declared and streamed responses above the private byte limit", async () => {
+    const declared = vi.fn(
+      async () => new Response(Uint8Array.from([1]), { headers: { "content-length": "3" } }),
+    );
+    const noteDeclared = vi.fn();
+    await expect(
+      createBoundedTrainingExportFetch({
+        baseFetch: declared,
+        maximumBytes: 2,
+        noteLimitExceeded: noteDeclared,
+      })("https://example.test"),
+    ).rejects.toThrow("private byte limit");
+    expect(noteDeclared).toHaveBeenCalledOnce();
+
+    const streamed = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(Uint8Array.from([1, 2]));
+              controller.enqueue(Uint8Array.from([3]));
+              controller.close();
+            },
+          }),
+        ),
+    );
+    const noteStreamed = vi.fn();
+    await expect(
+      createBoundedTrainingExportFetch({
+        baseFetch: streamed,
+        maximumBytes: 2,
+        noteLimitExceeded: noteStreamed,
+      })("https://example.test"),
+    ).rejects.toThrow("private byte limit");
+    expect(noteStreamed).toHaveBeenCalledOnce();
+  });
+});
+
+describe("durable training export writer", () => {
+  it("writes mode-0600 bytes atomically in the selected directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "enduragent-export-"));
+    roots.push(root);
+    const destinationPath = join(root, "ride.fit");
+    const writer = createDurableTrainingExportWriter({ createTemporaryId: () => "fixed" });
+
+    await expect(
+      writer.write({ destinationPath, bytes: Uint8Array.from([1, 2, 3]) }),
+    ).resolves.toBe("committed");
+    expect(await readFile(destinationPath)).toEqual(Buffer.from([1, 2, 3]));
+    expect((await stat(destinationPath)).mode & 0o777).toBe(0o600);
+    expect(await readdir(root)).toEqual(["ride.fit"]);
+  });
+
+  it("distinguishes pre-commit failure from post-rename commit uncertainty", async () => {
+    const root = await mkdtemp(join(tmpdir(), "enduragent-export-state-"));
+    roots.push(root);
+    const destinationPath = join(root, "workouts.zip");
+    const failed = createDurableTrainingExportWriter({
+      createTemporaryId: () => "failed",
+      openFile: vi.fn(async () => {
+        throw new Error("open failed");
+      }) as never,
+    });
+    await expect(failed.write({ destinationPath, bytes: Uint8Array.from([1]) })).resolves.toBe(
+      "failed",
+    );
+
+    const uncertain = createDurableTrainingExportWriter({
+      createTemporaryId: () => "uncertain",
+      renameFile: rename,
+      syncDirectory: vi.fn(async () => {
+        throw new Error("directory sync failed");
+      }),
+    });
+    await expect(uncertain.write({ destinationPath, bytes: Uint8Array.from([2]) })).resolves.toBe(
+      "uncertain",
+    );
+    expect(await readFile(destinationPath)).toEqual(Buffer.from([2]));
+  });
+});


### PR DESCRIPTION
## Summary

- add FIT/GPX ride export and visible-plan ZIP export for ZWO, MRC, ERG, or FIT workouts
- keep provider IDs, credentials, destination paths, and downloaded bytes in trusted main/daemon processes
- enforce strict contracts, privileged-only RPC, bounded downloads, FIT/GPX/ZIP signature checks, mode-0600 atomic writes, and native save-dialog selection
- add accessible single-flight desktop controls and minimized renderer results
- isolate Electron runtime smokes from installed app sessions

## Verification

- pnpm check
- pnpm test (8,293 passed; 15 skipped)
- pnpm check-parity --all
- pnpm s8a
- 302 focused contract/RPC/preload/renderer/export tests
- development runtime and security Electron smokes
- packaged runtime and security Electron smokes
- unsigned development package build

## Release

Includes patch changesets for coach-contract, coach-client, coach, and cycling-coach.