### PR TITLE
fix(desktop): complete training analysis safeguards

### DIFF
--- a/.changeset/complete-desktop-analysis-evidence.md
+++ b/.changeset/complete-desktop-analysis-evidence.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop ride analysis now shows complete interval details and provider power-versus-heart-rate curve evidence with accessible chart tables.
+
+Bound activity analysis and training exports across their full operation, and tighten activity-analysis result validation.

--- a/apps/desktop-renderer/src/ui/training/RideResponseReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideResponseReview.tsx
@@ -86,6 +86,18 @@ function axisValue(value: number, unit: ActivityAnalysisData["powerDistribution"
   return `${Math.round(value)} ${unit === "watts" ? "W" : "bpm"}`;
 }
 
+function curveLabel(
+  kind: ActivityAnalysisData["powerHeartRate"]["curves"][number]["kind"],
+): string {
+  if (kind === "all") return "All retained segments";
+  if (kind === "zone-2") return "Zone 2 segments";
+  return "Other provider fit";
+}
+
+function formatCoefficient(value: number): string {
+  return value.toLocaleString("en-US", { maximumSignificantDigits: 8 });
+}
+
 function DistributionChart(props: {
   readonly data: ActivityAnalysisData["powerDistribution"];
   readonly label: string;
@@ -168,6 +180,9 @@ function DistributionChart(props: {
         <summary>Read {props.label.toLowerCase()} as a table</summary>
         <div className={styles.analysisTableScroller}>
           <table className={styles.analysisDataTable}>
+            <caption className={styles.srOnly}>
+              {props.label} measured ride time by recorded range
+            </caption>
             <thead>
               <tr>
                 <th scope="col">Range</th>
@@ -371,6 +386,7 @@ function ScatterChart(props: {
         <summary>Read all power and heart-rate points as a table</summary>
         <div className={styles.analysisTableScroller}>
           <table className={styles.analysisDataTable}>
+            <caption className={styles.srOnly}>Retained power and heart-rate ride segments</caption>
             <thead>
               <tr>
                 <th scope="col">Ride time</th>
@@ -397,6 +413,68 @@ function ScatterChart(props: {
         </div>
       </details>
     </figure>
+  );
+}
+
+function ProviderCurveFits(props: {
+  readonly curves: ActivityAnalysisData["powerHeartRate"]["curves"];
+}): ReactElement | null {
+  if (props.curves.length === 0) return null;
+  return (
+    <section className={styles.responseFits} aria-labelledby="provider-fits-title">
+      <h3 id="provider-fits-title" className={styles.responseFitsTitle}>
+        Provider fitted curves
+      </h3>
+      <ul className={styles.responseFitList} aria-label="Provider fitted curves">
+        {props.curves.map((curve, index) => (
+          <li
+            key={`${curve.kind}-${index}`}
+            className={styles.responseFitItem}
+            data-curve-kind={curve.kind}
+          >
+            <span className={styles.responseFitLine} aria-hidden="true" />
+            <span>
+              <strong>{curveLabel(curve.kind)}</strong>
+              <span>
+                {curve.rSquared === null ? "R² unavailable" : `R² ${curve.rSquared.toFixed(2)}`}
+              </span>
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p className={styles.responseFitNote}>
+        Fit quality and model terms are supplied by the provider. The desktop does not infer a model
+        equation.
+      </p>
+      <details className={styles.analysisTableDisclosure}>
+        <summary>Read provider fit details</summary>
+        <div className={styles.analysisTableScroller}>
+          <table className={styles.analysisDataTable}>
+            <caption className={styles.srOnly}>
+              Provider-fitted power and heart-rate curve details
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Fit scope</th>
+                <th scope="col">Fit quality</th>
+                <th scope="col">Model terms in provider order</th>
+              </tr>
+            </thead>
+            <tbody>
+              {props.curves.map((curve, index) => (
+                <tr key={`${curve.kind}-${index}`}>
+                  <th scope="row">{curveLabel(curve.kind)}</th>
+                  <td>
+                    {curve.rSquared === null ? "Unavailable" : `R² ${curve.rSquared.toFixed(2)}`}
+                  </td>
+                  <td>{curve.coefficients.map(formatCoefficient).join(", ")}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </section>
   );
 }
 
@@ -458,6 +536,7 @@ function PowerHeartRateEvidence(props: {
           </dd>
         </div>
       </dl>
+      <ProviderCurveFits curves={props.data.curves} />
       <ScatterChart data={props.data} />
     </>
   );

--- a/apps/desktop-renderer/src/ui/training/RideReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideReview.tsx
@@ -320,6 +320,116 @@ function sensorMetric(average: number | null, maximum: number | null, unit: stri
   return `${Math.round(average)} avg · ${Math.round(maximum)} max ${unit}`;
 }
 
+function decimalMetric(value: number | null, unit = ""): ReactNode {
+  if (value === null) return unavailableMetric();
+  const formatted = value.toFixed(1).replace(/\.0$/, "");
+  return unit.length === 0 ? formatted : `${formatted}${unit}`;
+}
+
+function zoneMetric(zone: number | null): ReactNode {
+  return zone === null ? unavailableMetric() : `Zone ${zone}`;
+}
+
+type IntervalMetricsData = Pick<
+  ActivityAnalysisData["intervals"]["intervals"][number],
+  | "movingSeconds"
+  | "elapsedSeconds"
+  | "averagePowerWatts"
+  | "maximumPowerWatts"
+  | "averageHeartRateBpm"
+  | "maximumHeartRateBpm"
+  | "averageCadenceRpm"
+  | "maximumCadenceRpm"
+  | "zone"
+  | "intensityPercent"
+  | "trainingLoad"
+>;
+
+function IntervalMetricGrid(props: {
+  readonly metrics: IntervalMetricsData;
+  readonly units: UnitsPreference;
+  readonly distanceMeters?: number | null;
+}): ReactElement {
+  return (
+    <dl className={styles.intervalMetrics}>
+      <div>
+        <dt>Duration</dt>
+        <dd>{durationMetric(props.metrics.movingSeconds ?? props.metrics.elapsedSeconds)}</dd>
+      </div>
+      {props.distanceMeters === undefined ? null : (
+        <div>
+          <dt>Distance</dt>
+          <dd>{distanceMetric(props.distanceMeters, props.units)}</dd>
+        </div>
+      )}
+      <div>
+        <dt>Power</dt>
+        <dd>
+          {sensorMetric(props.metrics.averagePowerWatts, props.metrics.maximumPowerWatts, "W")}
+        </dd>
+      </div>
+      <div>
+        <dt>Heart rate</dt>
+        <dd>
+          {sensorMetric(
+            props.metrics.averageHeartRateBpm,
+            props.metrics.maximumHeartRateBpm,
+            "bpm",
+          )}
+        </dd>
+      </div>
+      <div>
+        <dt>Cadence</dt>
+        <dd>
+          {sensorMetric(props.metrics.averageCadenceRpm, props.metrics.maximumCadenceRpm, "rpm")}
+        </dd>
+      </div>
+      <div>
+        <dt>Zone</dt>
+        <dd>{zoneMetric(props.metrics.zone)}</dd>
+      </div>
+      <div>
+        <dt>Intensity</dt>
+        <dd>{decimalMetric(props.metrics.intensityPercent, "%")}</dd>
+      </div>
+      <div>
+        <dt>Training load</dt>
+        <dd>{decimalMetric(props.metrics.trainingLoad)}</dd>
+      </div>
+    </dl>
+  );
+}
+
+function IntervalGroupEvidence(props: {
+  readonly groups: ActivityAnalysisData["intervals"]["groups"];
+  readonly units: UnitsPreference;
+}): ReactElement | null {
+  if (props.groups.length === 0) return null;
+  return (
+    <section className={styles.intervalGroups} aria-label="Interval group summaries">
+      <h3>Group summaries</h3>
+      <p>Provider summary metrics for related ordered segments.</p>
+      <ol className={styles.intervalGroupList}>
+        {props.groups.map((group) => (
+          <li key={group.ordinal} className={styles.intervalGroupItem}>
+            <div className={styles.intervalGroupIdentity}>
+              <div>
+                <span>Group {group.ordinal}</span>
+                <strong>{INTERVAL_KIND_COPY[group.kind]} group</strong>
+              </div>
+              <p>
+                {group.intervalOrdinals.length === 1 ? "Segment" : "Segments"}{" "}
+                {group.intervalOrdinals.join(", ")}
+              </p>
+            </div>
+            <IntervalMetricGrid metrics={group} units={props.units} />
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
 function AnalysisRetry(props: {
   readonly reason: Parameters<typeof analysisUnavailableCopy>[0] | null;
   readonly onRefresh: (() => void) | null;
@@ -393,6 +503,7 @@ function IntervalEvidence(props: {
           : "Ordered laps from the local ride file"}
         {props.data.groups.length === 0 ? "" : ` · ${props.data.groups.length} groups`}
       </p>
+      <IntervalGroupEvidence groups={props.data.groups} units={props.units} />
       {props.data.intervals.length === 0 ? (
         <p className={styles.analysisEmpty}>No intervals or laps were found for this ride.</p>
       ) : (
@@ -409,32 +520,11 @@ function IntervalEvidence(props: {
                   {interval.groupOrdinal === null ? null : <p>Group {interval.groupOrdinal}</p>}
                 </div>
               </div>
-              <dl className={styles.intervalMetrics}>
-                <div>
-                  <dt>Duration</dt>
-                  <dd>{durationMetric(interval.movingSeconds ?? interval.elapsedSeconds)}</dd>
-                </div>
-                <div>
-                  <dt>Distance</dt>
-                  <dd>{distanceMetric(interval.distanceMeters, props.units)}</dd>
-                </div>
-                <div>
-                  <dt>Power</dt>
-                  <dd>
-                    {sensorMetric(interval.averagePowerWatts, interval.maximumPowerWatts, "W")}
-                  </dd>
-                </div>
-                <div>
-                  <dt>Heart rate</dt>
-                  <dd>
-                    {sensorMetric(
-                      interval.averageHeartRateBpm,
-                      interval.maximumHeartRateBpm,
-                      "bpm",
-                    )}
-                  </dd>
-                </div>
-              </dl>
+              <IntervalMetricGrid
+                metrics={interval}
+                units={props.units}
+                distanceMeters={interval.distanceMeters}
+              />
             </li>
           ))}
         </ol>

--- a/apps/desktop-renderer/src/ui/training/TrainingView.module.css
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.module.css
@@ -1059,7 +1059,7 @@
 .responseFitsTitle {
   margin: 0;
   color: var(--ink-2);
-  font: 600 13px/1.4 var(--f-sans);
+  font: 600 13px/1.4 var(--f-dis);
 }
 
 .responseFitList {

--- a/apps/desktop-renderer/src/ui/training/TrainingView.module.css
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.module.css
@@ -755,6 +755,71 @@
   list-style: none;
 }
 
+.intervalGroups {
+  margin: 16px 0 0;
+}
+
+.intervalGroups > h3 {
+  margin: 0;
+  font: 600 13px/1.25 var(--f-dis);
+}
+
+.intervalGroups > p {
+  margin: 4px 0 0;
+  color: var(--ink-3);
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+
+.intervalGroupList {
+  display: grid;
+  gap: 9px;
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.intervalGroupItem {
+  composes: sunken from "../../theme/surface.module.css";
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 12px 14px;
+}
+
+.intervalGroupIdentity {
+  display: flex;
+  gap: 12px;
+  align-items: end;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.intervalGroupIdentity > div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.intervalGroupIdentity span {
+  color: var(--ink-3);
+  font: 9px/1 var(--f-mono);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.intervalGroupIdentity strong {
+  font: 600 13px/1.25 var(--f-dis);
+}
+
+.intervalGroupIdentity p {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-3);
+  font: 9.5px/1.3 var(--f-mono);
+  text-align: right;
+}
+
 .intervalItem {
   composes: sunken from "../../theme/surface.module.css";
   display: grid;
@@ -987,6 +1052,74 @@
   vector-effect: non-scaling-stroke;
 }
 
+.responseFits {
+  margin: 18px 0 0;
+}
+
+.responseFitsTitle {
+  margin: 0;
+  color: var(--ink-2);
+  font: 600 13px/1.4 var(--f-sans);
+}
+
+.responseFitList {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+  margin: 9px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.responseFitItem {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 11px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--ink-2);
+}
+
+.responseFitLine {
+  flex: 0 0 34px;
+  border-top: 3px solid var(--brand);
+}
+
+.responseFitItem[data-curve-kind="zone-2"] .responseFitLine {
+  border-color: var(--ink-2);
+}
+
+.responseFitItem[data-curve-kind="other"] .responseFitLine {
+  border-top-style: dashed;
+  border-color: var(--ink-3);
+}
+
+.responseFitItem > span:last-child {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.responseFitItem strong {
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.responseFitItem > span:last-child > span {
+  color: var(--ink-3);
+  font: 10px/1.3 var(--f-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.responseFitNote {
+  max-width: 660px;
+  margin: 8px 0 0;
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
 .responseSummary {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
@@ -1185,6 +1318,15 @@
   .intervalMetrics,
   .effortList {
     grid-template-columns: 1fr;
+  }
+
+  .intervalGroupIdentity {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .intervalGroupIdentity p {
+    text-align: left;
   }
 }
 

--- a/apps/desktop-renderer/tests/ride-interval-evidence.test.tsx
+++ b/apps/desktop-renderer/tests/ride-interval-evidence.test.tsx
@@ -1,0 +1,144 @@
+import type { ActivityAnalysisData, RecentRide } from "@enduragent/coach-contract";
+import { render, screen, within } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import type { RideAnalysisViewState } from "../src/activity-analysis/controller.js";
+import { RideDetailView } from "../src/ui/training/RideReview.js";
+
+const ride: RecentRide = {
+  id: "a".repeat(64),
+  subSport: "road",
+  startEpochSeconds: 900_000_000,
+  timezoneOffsetSeconds: 0,
+  localDate: "1998-07-09",
+  elapsedSeconds: 3_600,
+  movingSeconds: 3_500,
+  distanceMeters: 32_000,
+};
+
+const fullMetrics = {
+  movingSeconds: 300,
+  elapsedSeconds: 305,
+  averagePowerWatts: 250,
+  maximumPowerWatts: 310,
+  averageHeartRateBpm: 155,
+  maximumHeartRateBpm: 170,
+  averageCadenceRpm: 91,
+  maximumCadenceRpm: 108,
+  zone: 4,
+  intensityPercent: 96.5,
+  trainingLoad: 73.2,
+} as const;
+
+const emptyMetrics = {
+  movingSeconds: 120,
+  elapsedSeconds: 120,
+  averagePowerWatts: null,
+  maximumPowerWatts: null,
+  averageHeartRateBpm: null,
+  maximumHeartRateBpm: null,
+  averageCadenceRpm: null,
+  maximumCadenceRpm: null,
+  zone: null,
+  intensityPercent: null,
+  trainingLoad: null,
+} as const;
+
+const intervalData = {
+  source: "provider",
+  intervals: [
+    {
+      ...fullMetrics,
+      ordinal: 1,
+      groupOrdinal: 1,
+      kind: "work",
+      label: "Threshold",
+      startIndex: 0,
+      endIndex: 299,
+      startSeconds: 0,
+      endSeconds: 300,
+      distanceMeters: 2_500,
+    },
+    {
+      ...emptyMetrics,
+      ordinal: 2,
+      groupOrdinal: 1,
+      kind: "recovery",
+      label: null,
+      startIndex: 300,
+      endIndex: 419,
+      startSeconds: 300,
+      endSeconds: 420,
+      distanceMeters: null,
+    },
+  ],
+  groups: [
+    {
+      ...fullMetrics,
+      ordinal: 1,
+      intervalOrdinals: [1, 2],
+      kind: "unknown",
+      averageCadenceRpm: 92,
+      maximumCadenceRpm: 109,
+      intensityPercent: 93,
+      trainingLoad: 81,
+    },
+  ],
+} as const satisfies ActivityAnalysisData["intervals"];
+
+const analysis: RideAnalysisViewState = {
+  activityId: ride.id,
+  status: "ready",
+  revision: "b".repeat(64),
+  loadingSections: [],
+  failedSections: [],
+  sections: {
+    intervals: {
+      kind: "computed",
+      data: intervalData,
+      provenance: {
+        source: "provider",
+        delivery: "live",
+        observedAt: "1998-07-19T08:00:00.000Z",
+      },
+    },
+  },
+};
+
+describe("ride interval evidence", () => {
+  it("shows complete interval and group metrics while keeping missing values unavailable", () => {
+    render(
+      <RideDetailView
+        ride={ride}
+        units="metric"
+        analysis={analysis}
+        onRefreshAnalysis={null}
+        onBack={() => undefined}
+        titleRef={createRef<HTMLHeadingElement>()}
+      />,
+    );
+
+    const ordered = screen.getByRole("list", { name: "Ordered ride intervals and laps" });
+    const [work, recovery] = within(ordered).getAllByRole("listitem");
+    expect(work).toHaveTextContent("91 avg · 108 max rpm");
+    expect(work).toHaveTextContent("Zone 4");
+    expect(work).toHaveTextContent("96.5%");
+    expect(work).toHaveTextContent("73.2");
+
+    const cadence = within(recovery!).getByText("Cadence").closest("div");
+    const zone = within(recovery!).getByText("Zone").closest("div");
+    const intensity = within(recovery!).getByText("Intensity").closest("div");
+    const trainingLoad = within(recovery!).getByText("Training load").closest("div");
+    for (const metric of [cadence, zone, intensity, trainingLoad]) {
+      expect(metric).not.toBeNull();
+      expect(within(metric!).getByLabelText("Unavailable")).toBeInTheDocument();
+    }
+
+    const groups = screen.getByRole("region", { name: "Interval group summaries" });
+    expect(within(groups).getByText("Segment group")).toBeInTheDocument();
+    expect(within(groups).getByText("Segments 1, 2")).toBeInTheDocument();
+    expect(groups).toHaveTextContent("92 avg · 109 max rpm");
+    expect(groups).toHaveTextContent("93%");
+    expect(groups).toHaveTextContent("81");
+  });
+});

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -672,14 +672,19 @@ describe("training page", () => {
     expect(power).toHaveTextContent("17 min of measured ride time · 3 recorded buckets");
     expect(power).toHaveTextContent("Gaps are left as recorded");
     await user.click(within(power).getByText("Read power distribution as a table"));
-    const powerTable = within(power).getByRole("table");
+    const powerTable = within(power).getByRole("table", {
+      name: "Power distribution measured ride time by recorded range",
+    });
     expect(within(powerTable).getByText("0 W–100 W")).toBeInTheDocument();
     expect(within(powerTable).getAllByRole("row")).toHaveLength(4);
 
     const heartRate = screen.getByRole("region", { name: "Heart-rate distribution" });
     expect(heartRate).toHaveTextContent("can load even when power data is unavailable");
     await user.click(within(heartRate).getByText("Read heart-rate distribution as a table"));
-    expect(within(heartRate).getByText("110 bpm–130 bpm")).toBeInTheDocument();
+    const heartRateTable = within(heartRate).getByRole("table", {
+      name: "Heart-rate distribution measured ride time by recorded range",
+    });
+    expect(within(heartRateTable).getByText("110 bpm–130 bpm")).toBeInTheDocument();
 
     const response = screen.getByRole("region", { name: "Power and heart-rate response" });
     expect(response).toHaveTextContent("server-cleaned ride segment");
@@ -687,8 +692,20 @@ describe("training page", () => {
     expect(response).toHaveTextContent("60%");
     expect(response).toHaveTextContent("Limited coverage");
     expect(response).toHaveTextContent("separate from the local aerobic drift estimate");
+    const fittedCurves = within(response).getByRole("list", { name: "Provider fitted curves" });
+    expect(fittedCurves).toHaveTextContent("All retained segments");
+    expect(fittedCurves).toHaveTextContent("R² 0.90");
+    expect(fittedCurves.querySelector('[data-curve-kind="all"]')).not.toBeNull();
+    await user.click(within(response).getByText("Read provider fit details"));
+    const fitTable = within(response).getByRole("table", {
+      name: "Provider-fitted power and heart-rate curve details",
+    });
+    expect(fitTable).toHaveTextContent("Model terms in provider order");
+    expect(fitTable).toHaveTextContent("100, 0.1");
     await user.click(within(response).getByText("Read all power and heart-rate points as a table"));
-    expect(within(response).getByRole("table")).toHaveTextContent("150 W");
+    expect(
+      within(response).getByRole("table", { name: "Retained power and heart-rate ride segments" }),
+    ).toHaveTextContent("150 W");
     expect(document.body).not.toHaveTextContent("provider-");
     expect(document.body).not.toHaveTextContent(ride.id);
   });

--- a/packages/coach-contract/src/activity-analysis.ts
+++ b/packages/coach-contract/src/activity-analysis.ts
@@ -452,7 +452,10 @@ export function createActivityAnalysisResultSchema<T extends ActivityAnalysisDat
       powerHeartRate: createAnalysisSectionSchema(data.powerHeartRate).optional(),
     })
     .strict()
-    .refine((value) => Object.keys(value).length > 0, "analysis result needs one section");
+    .refine(
+      (value) => Object.values(value).some((section) => section !== undefined),
+      "analysis result needs one section",
+    );
   return z
     .object({
       schemaVersion: z.literal(ACTIVITY_ANALYSIS_SCHEMA_VERSION),

--- a/packages/coach-contract/tests/activity-analysis.test.ts
+++ b/packages/coach-contract/tests/activity-analysis.test.ts
@@ -124,6 +124,7 @@ describe("activity analysis contract", () => {
       { ...base, revision: "provider-revision" },
       { ...base, providerActivityId: "i42" },
       { ...base, sections: {} },
+      { ...base, sections: { aerobicDrift: undefined } },
       { ...base, sections: { rawPayload: { kind: "unavailable", reason: "unsupported" } } },
       { ...base, sections: { aerobicDrift: { ...base.sections.aerobicDrift, data: { value: 2.5, raw: {} } } } },
       { ...base, sections: { aerobicDrift: { kind: "unavailable", reason: "network", message: "/private/path" } } },

--- a/packages/coach/src/abortable-operation.ts
+++ b/packages/coach/src/abortable-operation.ts
@@ -1,0 +1,25 @@
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
+}
+
+/**
+ * Stop waiting for an untrusted dependency when the operation is aborted.
+ *
+ * The dependency promise remains observed after an abort, so a late rejection
+ * cannot become unhandled. Listing the work promise first also lets a result
+ * that reached its commit point synchronously win over an abort raised by that
+ * same work.
+ */
+export async function awaitWithSignal<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(abortReason(signal));
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
+  try {
+    return await Promise.race([work, aborted]);
+  } finally {
+    if (onAbort !== undefined) signal.removeEventListener("abort", onAbort);
+  }
+}

--- a/packages/coach/src/activity-analysis-service.ts
+++ b/packages/coach/src/activity-analysis-service.ts
@@ -26,6 +26,7 @@ import {
   type TrustedActivitySourceResolver,
   type TrustedProviderActivityId,
 } from "@enduragent/kernel/store";
+import { awaitWithSignal } from "./abortable-operation.js";
 
 export const ACTIVITY_ANALYSIS_AGGREGATE_DEADLINE_MS = 90_000;
 export const ACTIVITY_ANALYSIS_SECTION_CONCURRENCY = 2;
@@ -342,12 +343,16 @@ class ActivityAnalysisServiceImplementation implements ActivityAnalysisService {
     const deadline = AbortSignal.timeout(this.aggregateDeadlineMs);
     const operationSignal = signal === undefined ? deadline : AbortSignal.any([signal, deadline]);
     return this.activities.run(parsed.canonicalActivityId, operationSignal, async () => {
-      const activity = await this.options.activities.getActivity({ id: parsed.canonicalActivityId });
+      const activity = await awaitWithSignal(
+        this.options.activities.getActivity({ id: parsed.canonicalActivityId }),
+        operationSignal,
+      );
       if (activity === undefined) throw new ActivityAnalysisServiceError("activity-not-found");
       operationSignal.throwIfAborted();
-      const resolution = await this.options.sources.resolve({
-        canonicalActivityId: parsed.canonicalActivityId,
-      });
+      const resolution = await awaitWithSignal(
+        this.options.sources.resolve({ canonicalActivityId: parsed.canonicalActivityId }),
+        operationSignal,
+      );
       const revision = resolution.kind === "resolved" ? resolution.sourceRevision : activity.id;
       const context = { activity, sourceRevision: revision, source: sourceStatus(resolution) };
       const computed = await Promise.all(parsed.sections.map(async (section) => {
@@ -390,9 +395,10 @@ class ActivityAnalysisServiceImplementation implements ActivityAnalysisService {
     signal: AbortSignal,
     deadline: AbortSignal,
   ): Promise<AnalysisSection<unknown>> {
-    const cached = await this.readCache(identity);
-    if (!refresh && cached !== undefined) return persisted(cached);
+    let cached: AnalysisComputed<unknown> | undefined;
     try {
+      cached = await this.readCache(identity, signal);
+      if (!refresh && cached !== undefined) return persisted(cached);
       return await this.consumeShared(identity, context, signal);
     } catch (error) {
       const code = failureCode(error, deadline, signal);
@@ -496,15 +502,20 @@ class ActivityAnalysisServiceImplementation implements ActivityAnalysisService {
     const current = await this.options.sources.resolve({
       canonicalActivityId: identity.canonicalActivityId,
     });
+    signal.throwIfAborted();
     const currentRevision = current.kind === "resolved" ? current.sourceRevision : identity.canonicalActivityId;
     if (currentRevision !== identity.sourceRevision) {
       throw new ActivityAnalysisComputationError("source-changed");
     }
-    await this.writeCache(identity, computed, observed.epochSeconds);
+    await this.writeCache(identity, computed, observed.epochSeconds, signal);
     return computed;
   }
 
-  private async readCache(identity: CacheIdentity): Promise<AnalysisComputed<unknown> | undefined> {
+  private async readCache(
+    identity: CacheIdentity,
+    signal: AbortSignal,
+  ): Promise<AnalysisComputed<unknown> | undefined> {
+    signal.throwIfAborted();
     const key = cacheKey(identity);
     const memory = this.memory.get(key);
     if (memory !== undefined) {
@@ -515,13 +526,17 @@ class ActivityAnalysisServiceImplementation implements ActivityAnalysisService {
     let stored;
     try {
       const accessed = nowInstant(this.now).epochSeconds;
-      stored = await this.cacheAccess((cache) => cache.read({
-        canonicalActivityId: identity.canonicalActivityId,
-        sourceRevision: identity.sourceRevision,
-        contractVersion: ACTIVITY_ANALYSIS_PROJECTION_CONTRACT_VERSION,
-        section: identity.section,
-      }, accessed));
+      stored = await awaitWithSignal(
+        this.cacheAccess((cache) => cache.read({
+          canonicalActivityId: identity.canonicalActivityId,
+          sourceRevision: identity.sourceRevision,
+          contractVersion: ACTIVITY_ANALYSIS_PROJECTION_CONTRACT_VERSION,
+          section: identity.section,
+        }, accessed)),
+        signal,
+      );
     } catch {
+      signal.throwIfAborted();
       return undefined;
     }
     if (stored === undefined) return undefined;
@@ -547,6 +562,7 @@ class ActivityAnalysisServiceImplementation implements ActivityAnalysisService {
     identity: CacheIdentity,
     computed: AnalysisComputed<unknown>,
     cachedEpochSeconds: number,
+    signal: AbortSignal,
   ): Promise<void> {
     try {
       await this.cacheAccess((cache) => cache.write({
@@ -558,8 +574,10 @@ class ActivityAnalysisServiceImplementation implements ActivityAnalysisService {
         observedAt: computed.provenance.observedAt,
         dataJson: JSON.stringify(computed.data),
       }, cachedEpochSeconds));
+      signal.throwIfAborted();
       this.remember(cacheKey(identity), computed);
     } catch {
+      signal.throwIfAborted();
       // A cache failure must not hide a freshly validated computation.
     }
   }

--- a/packages/coach/src/training-export.ts
+++ b/packages/coach/src/training-export.ts
@@ -11,6 +11,7 @@ import {
 } from "@enduragent/coach-contract";
 import type { TrustedActivitySourceResolver } from "@enduragent/kernel/store";
 import type { ApiError, BinaryDownload, IntervalsClient, Result } from "intervals-icu-api";
+import { awaitWithSignal } from "./abortable-operation.js";
 
 export const MAX_ACTIVITY_EXPORT_BYTES = 128 * 1_024 * 1_024;
 export const MAX_WORKOUT_ARCHIVE_EXPORT_BYTES = 256 * 1_024 * 1_024;
@@ -22,6 +23,7 @@ export interface TrainingExportWriter {
   write(input: {
     readonly destinationPath: string;
     readonly bytes: Uint8Array;
+    readonly signal?: AbortSignal;
   }): Promise<TrainingExportWriteOutcome>;
 }
 
@@ -188,6 +190,7 @@ export function createDurableTrainingExportWriter(input?: {
     async write(request: {
       readonly destinationPath: string;
       readonly bytes: Uint8Array;
+      readonly signal?: AbortSignal;
     }): Promise<TrainingExportWriteOutcome> {
       const destination = request.destinationPath;
       const fileName = basename(destination);
@@ -208,12 +211,20 @@ export function createDurableTrainingExportWriter(input?: {
       let handle: Awaited<ReturnType<typeof open>> | undefined;
       let renamed = false;
       try {
+        request.signal?.throwIfAborted();
         handle = await openFile(temporary, "wx", 0o600);
-        await handle.writeFile(request.bytes);
+        request.signal?.throwIfAborted();
+        await handle.writeFile(request.bytes, { signal: request.signal });
+        request.signal?.throwIfAborted();
         await handle.chmod(0o600);
+        request.signal?.throwIfAborted();
         await handle.sync();
+        request.signal?.throwIfAborted();
         await handle.close();
         handle = undefined;
+        // No abort may advance past this boundary. Once rename starts, an abort
+        // has an uncertain commit outcome and the service must not invite a retry.
+        request.signal?.throwIfAborted();
         await renameFile(temporary, destination);
         renamed = true;
         await sync(root);
@@ -284,13 +295,25 @@ export function createTrainingExportService(input: {
       request: ExportTrainingFileRpcParams,
       signal: AbortSignal = new AbortController().signal,
     ): Promise<ExportTrainingFileRpcResult> {
-      signal.throwIfAborted();
+      const deadline = AbortSignal.timeout(requestTimeoutMs);
+      const operationSignal = AbortSignal.any([signal, deadline]);
+      const preCommitAbort = (error: unknown): ExportTrainingFileRpcResult => {
+        if (signal.aborted) throw signal.reason ?? error;
+        return refused("timeout");
+      };
+      operationSignal.throwIfAborted();
       let providerActivityId: string | undefined;
       if (request.kind === "activity") {
-        const resolution = await input.sources.resolve({
-          canonicalActivityId: request.canonicalActivityId,
-        });
-        signal.throwIfAborted();
+        let resolution;
+        try {
+          resolution = await awaitWithSignal(
+            input.sources.resolve({ canonicalActivityId: request.canonicalActivityId }),
+            operationSignal,
+          );
+        } catch (error) {
+          if (operationSignal.aborted) return preCommitAbort(error);
+          throw error;
+        }
         if (resolution.kind === "unavailable") {
           return refused(
             resolution.reason === "ambiguous" ? "ambiguous-source" : "source-not-found",
@@ -298,8 +321,13 @@ export function createTrainingExportService(input: {
         }
         providerActivityId = resolution.providerActivityId;
       }
-      const credentials = await input.credentials.read();
-      signal.throwIfAborted();
+      let credentials;
+      try {
+        credentials = await awaitWithSignal(input.credentials.read(), operationSignal);
+      } catch (error) {
+        if (operationSignal.aborted) return preCommitAbort(error);
+        throw error;
+      }
       if (
         credentials.apiKey.length === 0 ||
         (request.kind === "workout-archive" && credentials.athleteId.length === 0)
@@ -312,7 +340,7 @@ export function createTrainingExportService(input: {
       const client = createClient({
         apiKey: credentials.apiKey,
         athleteId: credentials.athleteId,
-        signal,
+        signal: operationSignal,
         baseFetch: createBoundedTrainingExportFetch({
           baseFetch: input.baseFetch ?? globalThis.fetch,
           maximumBytes,
@@ -325,18 +353,28 @@ export function createTrainingExportService(input: {
       try {
         result =
           request.kind === "activity"
-            ? await downloadActivity(client, providerActivityId!, request.format)
-            : await client.workouts.downloadZip({
-                format: request.format,
-                oldest: request.oldest,
-                newest: request.newest,
-                includeMetadata: true,
-              });
+            ? await awaitWithSignal(
+                downloadActivity(client, providerActivityId!, request.format),
+                operationSignal,
+              )
+            : await awaitWithSignal(
+                client.workouts.downloadZip({
+                  format: request.format,
+                  oldest: request.oldest,
+                  newest: request.newest,
+                  includeMetadata: true,
+                }),
+                operationSignal,
+              );
       } catch (error) {
-        if (signal.aborted) throw signal.reason ?? error;
+        if (operationSignal.aborted) return preCommitAbort(error);
         return refused(responseLimitExceeded ? "response-too-large" : "provider-unavailable");
       }
-      signal.throwIfAborted();
+      try {
+        operationSignal.throwIfAborted();
+      } catch (error) {
+        return preCommitAbort(error);
+      }
       if (!result.ok) return refused(providerRefusal(result.error, responseLimitExceeded));
       if (
         !(result.value.bytes instanceof ArrayBuffer) ||
@@ -352,21 +390,35 @@ export function createTrainingExportService(input: {
       }
       const metadata = resultMetadata(result.value);
       const bytes = new Uint8Array(result.value.bytes);
+      let writerOwnsBytes = false;
       try {
         if (!contentBytesMatch(request, bytes)) return refused("invalid-response");
         let outcome: TrainingExportWriteOutcome;
         try {
-          outcome = await writer.write({
+          operationSignal.throwIfAborted();
+        } catch (error) {
+          return preCommitAbort(error);
+        }
+        try {
+          const write = writer.write({
             destinationPath: request.destinationPath,
             bytes,
+            signal: operationSignal,
           });
+          writerOwnsBytes = true;
+          void write.finally(() => bytes.fill(0)).catch(() => {});
+          outcome = await awaitWithSignal(write, operationSignal);
         } catch {
+          if (operationSignal.aborted) return refused("commit-uncertain");
           return refused("write-failed");
         }
         // A successful rename is the commit point. If the caller disconnects while the
         // file is being published, report the committed result rather than encouraging
         // an unsafe retry that could overwrite the file.
         if (outcome !== "committed") {
+          if (outcome === "failed" && operationSignal.aborted) {
+            return preCommitAbort(operationSignal.reason);
+          }
           return refused(outcome === "uncertain" ? "commit-uncertain" : "write-failed");
         }
         return ExportTrainingFileRpcResultSchema.parse({
@@ -375,7 +427,10 @@ export function createTrainingExportService(input: {
           ...metadata,
         });
       } finally {
-        bytes.fill(0);
+        // Once handed off, the writer may still be using the buffer after the
+        // service has conservatively reported commit uncertainty. Its settlement
+        // handler owns zeroization so the bytes cannot change underneath it.
+        if (!writerOwnsBytes) bytes.fill(0);
       }
     },
   });

--- a/packages/coach/tests/activity-analysis-service.test.ts
+++ b/packages/coach/tests/activity-analysis-service.test.ts
@@ -97,6 +97,7 @@ function setup(input: {
   readonly resolver?: TrustedActivitySourceResolver;
   readonly projectionCache?: ActivityAnalysisProjectionRepository;
   readonly activityValue?: CanonicalActivityDetail;
+  readonly aggregateDeadlineMs?: number;
 }) {
   const analyzer = input.analyzer ?? { analyze: async () => ({
     kind: "computed" as const,
@@ -110,6 +111,7 @@ function setup(input: {
     cache: input.projectionCache ?? cache(),
     analyzers: { aerobicDrift: analyzer },
     now: () => Date.parse("1998-07-06T12:00:00.000Z"),
+    aggregateDeadlineMs: input.aggregateDeadlineMs,
   });
   return { service, getActivity, analyzer };
 }
@@ -401,5 +403,215 @@ describe("activity analysis service", () => {
       sections: ["intervals"],
     })).rejects.toEqual(new ActivityAnalysisServiceError("activity-not-found"));
     expect(service).toBeDefined();
+  });
+
+  it("bounds a stalled activity lookup and releases the activity gate", async () => {
+    const otherActivityId = "d".repeat(64);
+    const getActivity = vi.fn(({ id }: { readonly id: string }) =>
+      id === ACTIVITY_ID
+        ? new Promise<CanonicalActivityDetail | undefined>(() => {})
+        : Promise.resolve({ ...activity, id }),
+    );
+    const service = createActivityAnalysisService({
+      activities: { getActivity },
+      sources: source(async ({ canonicalActivityId }) => ({
+        kind: "resolved",
+        providerActivityId: "provider-42" as never,
+        sourceRevision: canonicalActivityId,
+      })),
+      cache: cache(),
+      analyzers: {
+        aerobicDrift: {
+          analyze: async () => ({
+            kind: "computed",
+            data: drift,
+            source: "local-canonical",
+          }),
+        },
+      },
+      aggregateDeadlineMs: 20,
+      now: () => Date.parse("1998-07-06T12:00:00.000Z"),
+    });
+
+    await expect(
+      service.getActivityAnalysis({
+        canonicalActivityId: ACTIVITY_ID,
+        sections: ["aerobic-drift"],
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    await expect(
+      service.getActivityAnalysis({
+        canonicalActivityId: otherActivityId,
+        sections: ["aerobic-drift"],
+      }),
+    ).resolves.toMatchObject({ activity: { id: otherActivityId } });
+    expect(getActivity).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds stalled source resolution before section work starts", async () => {
+    const analyze = vi.fn(async () => ({
+      kind: "computed" as const,
+      data: drift,
+      source: "local-canonical" as const,
+    }));
+    const { service } = setup({
+      aggregateDeadlineMs: 20,
+      resolver: source(() => new Promise(() => {})),
+      analyzer: { analyze },
+    });
+
+    await expect(
+      service.getActivityAnalysis({
+        canonicalActivityId: ACTIVITY_ID,
+        sections: ["aerobic-drift"],
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(analyze).not.toHaveBeenCalled();
+  });
+
+  it("turns a stalled persistent-cache read into a bounded timeout section", async () => {
+    const projectionCache: ActivityAnalysisProjectionRepository = {
+      read: () => new Promise(() => {}),
+      write: async () => {},
+    };
+    const analyze = vi.fn(async () => ({
+      kind: "computed" as const,
+      data: drift,
+      source: "local-canonical" as const,
+    }));
+    const { service } = setup({
+      projectionCache,
+      aggregateDeadlineMs: 20,
+      analyzer: { analyze },
+    });
+
+    await expect(
+      service.getActivityAnalysis({
+        canonicalActivityId: ACTIVITY_ID,
+        sections: ["aerobic-drift"],
+      }),
+    ).resolves.toMatchObject({
+      sections: { aerobicDrift: { kind: "unavailable", reason: "timeout" } },
+    });
+    expect(analyze).not.toHaveBeenCalled();
+  });
+
+  it("keeps section permits until aborted physical analyzers actually settle", async () => {
+    const otherActivityId = "d".repeat(64);
+    let releaseDrift!: () => void;
+    let releaseIntervals!: () => void;
+    const driftWait = new Promise<void>((resolve) => {
+      releaseDrift = resolve;
+    });
+    const intervalsWait = new Promise<void>((resolve) => {
+      releaseIntervals = resolve;
+    });
+    const started: string[] = [];
+    const service = createActivityAnalysisService({
+      activities: { getActivity: async ({ id }) => ({ ...activity, id }) },
+      sources: source(async ({ canonicalActivityId }) => ({
+        kind: "resolved",
+        providerActivityId: "provider-42" as never,
+        sourceRevision: canonicalActivityId,
+      })),
+      cache: cache(),
+      analyzers: {
+        aerobicDrift: {
+          async analyze({ activity: selected }) {
+            started.push(`drift:${selected.id}`);
+            if (selected.id === ACTIVITY_ID) await driftWait;
+            return { kind: "computed", data: drift, source: "local-canonical" };
+          },
+        },
+        intervals: {
+          async analyze({ activity: selected }) {
+            started.push(`intervals:${selected.id}`);
+            await intervalsWait;
+            return {
+              kind: "computed",
+              data: { source: "local-canonical", intervals: [], groups: [] },
+              source: "local-canonical",
+            };
+          },
+        },
+      },
+      aggregateDeadlineMs: 1_000,
+      now: () => Date.parse("1998-07-06T12:00:00.000Z"),
+    });
+    const controller = new AbortController();
+    const first = service.getActivityAnalysis(
+      {
+        canonicalActivityId: ACTIVITY_ID,
+        sections: ["aerobic-drift", "intervals"],
+      },
+      controller.signal,
+    );
+    await vi.waitFor(() => expect(started).toHaveLength(2));
+    controller.abort();
+    await expect(first).resolves.toMatchObject({
+      sections: {
+        aerobicDrift: { kind: "unavailable", reason: "cancelled" },
+        intervals: { kind: "unavailable", reason: "cancelled" },
+      },
+    });
+
+    const second = service.getActivityAnalysis({
+      canonicalActivityId: otherActivityId,
+      sections: ["aerobic-drift"],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(started).not.toContain(`drift:${otherActivityId}`);
+
+    releaseDrift();
+    releaseIntervals();
+    await expect(second).resolves.toMatchObject({
+      sections: { aerobicDrift: { kind: "computed" } },
+    });
+    expect(started).toContain(`drift:${otherActivityId}`);
+  });
+
+  it("bounds the post-analysis source revision check", async () => {
+    let resolutions = 0;
+    const { service } = setup({
+      aggregateDeadlineMs: 20,
+      resolver: source(async () => {
+        resolutions += 1;
+        if (resolutions > 1) return new Promise(() => {});
+        return {
+          kind: "resolved",
+          providerActivityId: "provider-42" as never,
+          sourceRevision: REVISION,
+        };
+      }),
+    });
+
+    await expect(
+      service.getActivityAnalysis({
+        canonicalActivityId: ACTIVITY_ID,
+        sections: ["aerobic-drift"],
+      }),
+    ).resolves.toMatchObject({
+      sections: { aerobicDrift: { kind: "unavailable", reason: "timeout" } },
+    });
+    expect(resolutions).toBe(2);
+  });
+
+  it("bounds a stalled persistent-cache write", async () => {
+    const write = vi.fn(() => new Promise<void>(() => {}));
+    const projectionCache: ActivityAnalysisProjectionRepository = {
+      read: async () => undefined,
+      write,
+    };
+    const { service } = setup({ projectionCache, aggregateDeadlineMs: 20 });
+
+    await expect(
+      service.getActivityAnalysis({
+        canonicalActivityId: ACTIVITY_ID,
+        sections: ["aerobic-drift"],
+      }),
+    ).resolves.toMatchObject({
+      sections: { aerobicDrift: { kind: "unavailable", reason: "timeout" } },
+    });
+    expect(write).toHaveBeenCalledOnce();
   });
 });

--- a/packages/coach/tests/training-export.test.ts
+++ b/packages/coach/tests/training-export.test.ts
@@ -297,6 +297,141 @@ describe("training export service", () => {
     ).resolves.toMatchObject({ status: "exported", byteLength: validZipBytes.length });
   });
 
+  it("bounds stalled source, credential, and provider dependencies", async () => {
+    const request = {
+      kind: "activity" as const,
+      canonicalActivityId,
+      format: "fit" as const,
+      destinationPath: "/tmp/ride.fit",
+    };
+    const never = <T>(): Promise<T> => new Promise(() => {});
+    const stalledSource = createTrainingExportService({
+      credentials: credentials(),
+      sources: { resolve: () => never() },
+      requestTimeoutMs: 20,
+      createClient: clientFactory({}),
+    });
+    await expect(stalledSource.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "timeout",
+    });
+
+    const stalledCredentials = createTrainingExportService({
+      credentials: { read: () => never() },
+      sources: availableSource(),
+      requestTimeoutMs: 20,
+      createClient: clientFactory({}),
+    });
+    await expect(stalledCredentials.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "timeout",
+    });
+
+    const stalledProvider = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      requestTimeoutMs: 20,
+      createClient: clientFactory({ downloadFitFile: vi.fn(() => never()) }),
+    });
+    await expect(stalledProvider.export(request)).resolves.toEqual({
+      status: "refused",
+      reason: "timeout",
+    });
+  });
+
+  it.each(["resolves", "rejects"] as const)(
+    "keeps writer-owned bytes intact after timeout, then zeroes them when it %s",
+    async (settlement) => {
+      let writerSignal: AbortSignal | undefined;
+      let retained: Uint8Array | undefined;
+      let settle!: () => void;
+      const pending = new Promise<"failed">((resolve, reject) => {
+        settle = () => {
+          if (settlement === "resolves") resolve("failed");
+          else reject(new Error("private late writer failure"));
+        };
+      });
+      const service = createTrainingExportService({
+        credentials: credentials(),
+        sources: availableSource(),
+        requestTimeoutMs: 20,
+        writer: {
+          write: vi.fn(({ bytes, signal }) => {
+            writerSignal = signal;
+            retained = bytes;
+            return pending;
+          }),
+        },
+        createClient: clientFactory({ downloadFitFile: vi.fn(async () => binary(validFitBytes)) }),
+      });
+
+      await expect(
+        service.export({
+          kind: "activity",
+          canonicalActivityId,
+          format: "fit",
+          destinationPath: "/tmp/ride.fit",
+        }),
+      ).resolves.toEqual({ status: "refused", reason: "commit-uncertain" });
+      expect(writerSignal?.aborted).toBe(true);
+      expect(Array.from(retained!)).toEqual(validFitBytes);
+
+      settle();
+      await vi.waitFor(() => {
+        expect(Array.from(retained!)).toEqual(validFitBytes.map(() => 0));
+      });
+    },
+  );
+
+  it("reports timeout when a signal-aware writer confirms it stopped before commit", async () => {
+    const service = createTrainingExportService({
+      credentials: credentials(),
+      sources: availableSource(),
+      requestTimeoutMs: 20,
+      writer: {
+        write: vi.fn(
+          ({ signal }) =>
+            new Promise<"failed">((resolve) => {
+              signal!.addEventListener("abort", () => resolve("failed"), { once: true });
+            }),
+        ),
+      },
+      createClient: clientFactory({ downloadFitFile: vi.fn(async () => binary(validFitBytes)) }),
+    });
+
+    await expect(
+      service.export({
+        kind: "activity",
+        canonicalActivityId,
+        format: "fit",
+        destinationPath: "/tmp/ride.fit",
+      }),
+    ).resolves.toEqual({ status: "refused", reason: "timeout" });
+  });
+
+  it("propagates caller cancellation before writing starts", async () => {
+    const controller = new AbortController();
+    const cancellation = new Error("caller detached");
+    const service = createTrainingExportService({
+      credentials: credentials(),
+      sources: { resolve: () => new Promise(() => {}) },
+      requestTimeoutMs: 1_000,
+      createClient: clientFactory({}),
+    });
+    const result = service.export(
+      {
+        kind: "activity",
+        canonicalActivityId,
+        format: "fit",
+        destinationPath: "/tmp/ride.fit",
+      },
+      controller.signal,
+    );
+
+    controller.abort(cancellation);
+    await expect(result).rejects.toBe(cancellation);
+  });
+
   it("rejects empty, oversized, or unexpected content without exposing metadata", async () => {
     const request = {
       kind: "workout-archive" as const,
@@ -455,5 +590,34 @@ describe("durable training export writer", () => {
       "uncertain",
     );
     expect(await readFile(destinationPath)).toEqual(Buffer.from([2]));
+  });
+
+  it("does not rename when cancellation is observed before the commit point", async () => {
+    const controller = new AbortController();
+    const renameFile = vi.fn(async () => {});
+    const handle = {
+      writeFile: vi.fn(async () => {
+        controller.abort(new Error("caller detached"));
+      }),
+      chmod: vi.fn(async () => {}),
+      sync: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+    };
+    const writer = createDurableTrainingExportWriter({
+      createTemporaryId: () => "cancelled",
+      openFile: vi.fn(async () => handle) as never,
+      renameFile,
+      removeFile: vi.fn(async () => {}) as never,
+    });
+
+    await expect(
+      writer.write({
+        destinationPath: "/tmp/ride.fit",
+        bytes: Uint8Array.from(validFitBytes),
+        signal: controller.signal,
+      }),
+    ).resolves.toBe("failed");
+    expect(renameFile).not.toHaveBeenCalled();
+    expect(handle.chmod).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- bound activity analysis and training exports across their complete operation lifecycles while preserving physical concurrency and safe export commit semantics
- display complete interval and group evidence plus provider curve coefficients and R², with accessible table captions
- reject logically empty activity-analysis result sections

## Findings resolved
- enforce the 90-second analysis deadline across lookup, source resolution, cache reads, and analyzer work
- enforce export timeout across resolution, credentials, provider access, and durable writes
- render cadence, zone, intensity, training load, and group metrics
- render provider-fitted power/HR curves, coefficients, and R²
- add screen-reader captions to both chart data tables
- reject section objects whose values are all undefined

## Verification
- focused Vitest suites: 64/64 passed
- coach-contract, coach, and desktop-renderer package checks passed
- root type checking passed
- changed-file Oxlint passed with 0 warnings and 0 errors
- privacy, policy, changeset, dependency, and schema gates passed
- independent verification review found no remaining actionable findings