### PR TITLE
fix(ci): pass desktop release commands correctly

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/desktop-baseline"
-          pnpm desktop-release:transaction -- baseline \
+          pnpm desktop-release:transaction baseline \
             --directory "$RUNNER_TEMP/desktop-baseline" \
             --mode "$RELEASE_MODE" \
             --candidate-version "$RELEASE_VERSION" \
@@ -183,7 +183,7 @@ jobs:
           BASELINE_SIGNING_IDENTITY: ${{ steps.baseline.outputs.baseline_signing_identity }}
           BASELINE_CDHASH: ${{ steps.baseline.outputs.baseline_cdhash }}
         run: |
-          pnpm desktop-release:transaction -- seal \
+          pnpm desktop-release:transaction seal \
             --directory "apps/desktop/dist/release-envelope-$RELEASE_VERSION-mac-arm64" \
             --tag "$RELEASE_TAG" \
             --version "$RELEASE_VERSION" \
@@ -265,7 +265,7 @@ jobs:
           RELEASE_VERSION: ${{ inputs.version }}
           RELEASE_BASELINE_TAG: ${{ inputs.baseline_tag }}
         run: |
-          pnpm desktop-release:transaction -- baseline \
+          pnpm desktop-release:transaction baseline \
             --directory "$RUNNER_TEMP/independent-baseline" \
             --mode "$RELEASE_MODE" \
             --candidate-version "$RELEASE_VERSION" \
@@ -331,7 +331,7 @@ jobs:
           INDEPENDENT_BASELINE_APP: ${{ steps.independent-baseline.outputs.baseline_app }}
         run: |
           set -euo pipefail
-          pnpm desktop-release:transaction -- verify \
+          pnpm desktop-release:transaction verify \
             --directory "$RUNNER_TEMP/desktop-release" \
             --tag "$RELEASE_TAG" \
             --version "$RELEASE_VERSION" \
@@ -372,7 +372,7 @@ jobs:
             "$RUNNER_TEMP/desktop-release-unpacked/Enduragent.app"
           PUBLIC_ENVELOPE="$RUNNER_TEMP/desktop-public-envelope"
           CANDIDATE_APP="$RUNNER_TEMP/desktop-release-unpacked/Enduragent.app"
-          pnpm desktop-release:transaction -- public-envelope \
+          pnpm desktop-release:transaction public-envelope \
             --directory "$RUNNER_TEMP/desktop-release" \
             --output "$PUBLIC_ENVELOPE"
           case "$RELEASE_MODE" in
@@ -438,7 +438,7 @@ jobs:
       - name: Upload updater envelope to the private draft
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: pnpm desktop-release:transaction -- stage --directory "$RUNNER_TEMP/desktop-release"
+        run: pnpm desktop-release:transaction stage --directory "$RUNNER_TEMP/desktop-release"
 
   publish-assets:
     runs-on: ubuntu-latest
@@ -483,7 +483,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          pnpm desktop-release:transaction -- observe \
+          pnpm desktop-release:transaction observe \
             --directory "$RUNNER_TEMP/desktop-release" \
             --github-output "$GITHUB_OUTPUT"
       - name: Publish verified release without changing latest
@@ -493,7 +493,7 @@ jobs:
           EXPECTED_LATEST_TAG: ${{ steps.observe.outputs.latest_tag }}
           EXPECTED_LATEST_METADATA_SHA256: ${{ steps.observe.outputs.latest_metadata_sha256 }}
         run: |
-          pnpm desktop-release:transaction -- publish \
+          pnpm desktop-release:transaction publish \
             --directory "$RUNNER_TEMP/desktop-release" \
             --expected-latest-id "$EXPECTED_LATEST_ID" \
             --expected-latest-tag "$EXPECTED_LATEST_TAG" \
@@ -540,7 +540,7 @@ jobs:
           EXPECTED_LATEST_TAG: ${{ needs.publish-assets.outputs.latest_tag }}
           EXPECTED_LATEST_METADATA_SHA256: ${{ needs.publish-assets.outputs.latest_metadata_sha256 }}
         run: |
-          pnpm desktop-release:transaction -- promote \
+          pnpm desktop-release:transaction promote \
             --directory "$RUNNER_TEMP/desktop-release" \
             --expected-latest-id "$EXPECTED_LATEST_ID" \
             --expected-latest-tag "$EXPECTED_LATEST_TAG" \
@@ -600,7 +600,7 @@ jobs:
           set -euo pipefail
           CANDIDATE_ENVELOPE="$RUNNER_TEMP/desktop-public-envelope"
           EVIDENCE="$RUNNER_TEMP/macos-update-roundtrip.json"
-          pnpm desktop-release:transaction -- public-envelope \
+          pnpm desktop-release:transaction public-envelope \
             --directory "$RUNNER_TEMP/desktop-release" \
             --output "$CANDIDATE_ENVELOPE"
           pnpm --filter @enduragent/desktop test:macos-update-roundtrip -- \
@@ -664,7 +664,7 @@ jobs:
           set -euo pipefail
           BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' packages/cycling-coach/CHANGELOG.md | tail -n +2)
           printf '%s' "$BODY" > "$RUNNER_TEMP/desktop-release-body.md"
-          pnpm desktop-release:transaction -- activate \
+          pnpm desktop-release:transaction activate \
             --directory "$RUNNER_TEMP/desktop-release" \
             --body-file "$RUNNER_TEMP/desktop-release-body.md"
 
@@ -715,7 +715,7 @@ jobs:
           set -euo pipefail
           BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' packages/cycling-coach/CHANGELOG.md | tail -n +2)
           printf '%s' "$BODY" > "$RUNNER_TEMP/desktop-release-body.md"
-          pnpm desktop-release:transaction -- compensate \
+          pnpm desktop-release:transaction compensate \
             --directory "$RUNNER_TEMP/desktop-release" \
             --body-file "$RUNNER_TEMP/desktop-release-body.md" \
             --expected-latest-id "$EXPECTED_LATEST_ID" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -592,7 +592,7 @@ jobs:
           if [ "$PUBLISHED_NEW" = "false" ]; then
             ALLOW_PRIOR_INVOCATION=true
           fi
-          pnpm desktop-release:transaction -- verify-npm-provenance \
+          pnpm desktop-release:transaction verify-npm-provenance \
             --metadata "$ATTESTATION_FILE" \
             --name "$RELEASE_PACKAGE" \
             --version "$RELEASE_VERSION" \

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -29,6 +29,21 @@ describe("desktop release workflow policy", () => {
     expect(inspect(source.release, source.desktop, source.version)).toEqual([]);
   });
 
+  it("rejects pnpm separators that become the transaction command", () => {
+    const source = sources();
+    const release = source.release.replace(
+      "desktop-release:transaction verify-npm-provenance",
+      "desktop-release:transaction -- verify-npm-provenance",
+    );
+    const desktop = source.desktop.replace(
+      "desktop-release:transaction baseline",
+      "desktop-release:transaction -- baseline",
+    );
+    for (const mutated of [inspect(release, source.desktop), inspect(source.release, desktop)]) {
+      expect(mutated.some((issue) => issue.includes("pnpm argument separator"))).toBe(true);
+    }
+  });
+
   it("rejects signing write permission and publication signing secrets", () => {
     const source = sources();
     const mutated = source.desktop
@@ -69,8 +84,8 @@ describe("desktop release workflow policy", () => {
     const mutations = [
       {
         desktop: source.desktop.replace(
-          "desktop-release:transaction -- observe",
-          "desktop-release:transaction -- verify",
+          "desktop-release:transaction observe",
+          "desktop-release:transaction verify",
         ),
         issue: "bind latest before provisional publication",
       },
@@ -177,8 +192,8 @@ describe("desktop release workflow policy", () => {
       '                "$RUNNER_TEMP/desktop-release" \\\n',
     );
     const escapedPackaging = source.desktop.replace(
-      "pnpm desktop-release:transaction -- verify \\\n",
-      "pnpm --filter @enduragent/desktop package:mac:genesis\n          pnpm desktop-release:transaction -- verify \\\n",
+      "pnpm desktop-release:transaction verify \\\n",
+      "pnpm --filter @enduragent/desktop package:mac:genesis\n          pnpm desktop-release:transaction verify \\\n",
     );
     const constantSigningMode = source.desktop.replace(
       "RELEASE_MODE: ${{ inputs.mode }}\n          ENDURAGENT_DEVELOPER_ID_IDENTITY:",

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -110,6 +110,13 @@ export function inspectDesktopReleaseWorkflows(
     return ["release workflows must be valid YAML"];
   }
 
+  if (
+    releaseSource.includes("desktop-release:transaction --") ||
+    desktopSource.includes("desktop-release:transaction --")
+  ) {
+    issues.push("release transaction commands must not pass a pnpm argument separator");
+  }
+
   const releaseOn = mapping(release.on, "release.on", issues);
   if (!("push" in releaseOn) || !("workflow_dispatch" in releaseOn))
     issues.push("release.yml must remain the tag/manual coordinator");
@@ -473,8 +480,8 @@ export function inspectDesktopReleaseWorkflows(
   const roundTripRun = runs(roundTrip).join("\n");
   const activateRun = runs(activate).join("\n");
   const compensateRun = runs(compensate).join("\n");
-  const observeIndex = publishRun.indexOf("desktop-release:transaction -- observe");
-  const publicationIndex = publishRun.indexOf("desktop-release:transaction -- publish");
+  const observeIndex = publishRun.indexOf("desktop-release:transaction observe");
+  const publicationIndex = publishRun.indexOf("desktop-release:transaction publish");
   if (
     !scalar(publish.needs).includes("stage-private-draft") ||
     observeIndex === -1 ||
@@ -489,7 +496,7 @@ export function inspectDesktopReleaseWorkflows(
   }
   if (
     !scalar(promote.needs).includes("publish-assets") ||
-    !promoteRun.includes("desktop-release:transaction -- promote") ||
+    !promoteRun.includes("desktop-release:transaction promote") ||
     !promoteRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"')
   ) {
     issues.push("desktop latest promotion must compare-and-swap the observed release");
@@ -499,7 +506,7 @@ export function inspectDesktopReleaseWorkflows(
     roundTrip.if !== "${{ inputs.mode == 'steady' }}" ||
     !roundTripNeeds.includes("sign-macos") ||
     !roundTripNeeds.includes("promote-latest") ||
-    !roundTripRun.includes("desktop-release:transaction -- public-envelope") ||
+    !roundTripRun.includes("desktop-release:transaction public-envelope") ||
     !roundTripRun.includes("test:macos-update-roundtrip") ||
     !roundTripRun.includes('"$RUNNER_TEMP/desktop-baseline"') ||
     !roundTripRun.includes('"$CANDIDATE_ENVELOPE"') ||
@@ -522,7 +529,7 @@ export function inspectDesktopReleaseWorkflows(
     !activateCondition.includes("needs.verify-production-update.result == 'skipped'") ||
     !activateCondition.includes("inputs.mode == 'steady'") ||
     !activateCondition.includes("needs.verify-production-update.result == 'success'") ||
-    !activateRun.includes("desktop-release:transaction -- activate") ||
+    !activateRun.includes("desktop-release:transaction activate") ||
     !activateRun.includes("packages/cycling-coach/CHANGELOG.md")
   ) {
     issues.push("general-availability activation must follow the mode-specific acceptance gate");
@@ -534,7 +541,7 @@ export function inspectDesktopReleaseWorkflows(
     !compensateCondition.includes("always()") ||
     !compensateCondition.includes("needs.publish-assets.outputs.latest_id != ''") ||
     !compensateCondition.includes("needs.activate-release.result != 'success'") ||
-    !compensateRun.includes("desktop-release:transaction -- compensate") ||
+    !compensateRun.includes("desktop-release:transaction compensate") ||
     !compensateRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"') ||
     !compensateRun.includes('--expected-latest-tag "$EXPECTED_LATEST_TAG"') ||
     !compensateRun.includes('--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"')
@@ -585,8 +592,8 @@ export function inspectDesktopReleaseWorkflows(
     issues,
   );
   const independentRun = typeof independentStep?.run === "string" ? independentStep.run : "";
-  const transactionVerification = independentRun.indexOf("desktop-release:transaction -- verify");
-  const publicEnvelope = independentRun.indexOf("desktop-release:transaction -- public-envelope");
+  const transactionVerification = independentRun.indexOf("desktop-release:transaction verify");
+  const publicEnvelope = independentRun.indexOf("desktop-release:transaction public-envelope");
   const genesisVerification = independentRun.indexOf(
     "verify:mac-genesis-release --",
     publicEnvelope,


### PR DESCRIPTION
Remove the pnpm argument separator that was reaching the transaction CLI as its command, update all desktop release transaction calls, and add a workflow-policy regression guard. Validated with the full workspace build, typecheck, workflow checker, and 37 focused tests. No changeset: release-infrastructure-only correction.