### PR TITLE
fix(desktop): decouple app version from npm release

### DIFF
--- a/.changeset/decouple-desktop-semver.md
+++ b/.changeset/decouple-desktop-semver.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop releases now use an independent, easy-to-read version sequence starting at 0.1.0.
+
+Keep the npm package on its existing calendar-version sequence while binding signed desktop builds, updater metadata, artifacts, and native update acceptance to `apps/desktop/package.json` SemVer.

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -6,7 +6,10 @@ on:
       tag:
         required: true
         type: string
-      version:
+      npm_version:
+        required: true
+        type: string
+      desktop_version:
         required: true
         type: string
       commit:
@@ -83,7 +86,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_MODE: ${{ inputs.mode }}
-          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          DESKTOP_VERSION: ${{ inputs.desktop_version }}
           RELEASE_BASELINE_TAG: ${{ inputs.baseline_tag }}
         run: |
           set -euo pipefail
@@ -91,7 +95,8 @@ jobs:
           pnpm desktop-release:transaction baseline \
             --directory "$RUNNER_TEMP/desktop-baseline" \
             --mode "$RELEASE_MODE" \
-            --candidate-version "$RELEASE_VERSION" \
+            --candidate-tag "$RELEASE_TAG" \
+            --candidate-version "$DESKTOP_VERSION" \
             --baseline-tag "$RELEASE_BASELINE_TAG" \
             --github-output "$GITHUB_OUTPUT"
           if [ "$RELEASE_MODE" = 'steady' ]; then
@@ -120,7 +125,7 @@ jobs:
           ENDURAGENT_DEVELOPER_ID_IDENTITY: ${{ vars.ENDURAGENT_DEVELOPER_ID_IDENTITY }}
           ENDURAGENT_DESKTOP_UPDATE_URL: https://github.com/yerzhansa/enduragent/releases/latest/download/
           ENDURAGENT_MACOS_BASELINE_APP: ${{ steps.baseline.outputs.baseline_app }}
-          ENDURAGENT_MACOS_GENESIS_VERSION: ${{ inputs.version }}
+          ENDURAGENT_MACOS_GENESIS_VERSION: ${{ inputs.desktop_version }}
           APPLE_API_KEY: ${{ runner.temp }}/AuthKey.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
@@ -164,7 +169,8 @@ jobs:
       - name: Seal digest-bound release manifest
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-          RELEASE_VERSION: ${{ inputs.version }}
+          NPM_VERSION: ${{ inputs.npm_version }}
+          DESKTOP_VERSION: ${{ inputs.desktop_version }}
           RELEASE_COMMIT: ${{ inputs.commit }}
           RELEASE_DRAFT_ID: ${{ inputs.draft_id }}
           RELEASE_MODE: ${{ inputs.mode }}
@@ -184,9 +190,10 @@ jobs:
           BASELINE_CDHASH: ${{ steps.baseline.outputs.baseline_cdhash }}
         run: |
           pnpm desktop-release:transaction seal \
-            --directory "apps/desktop/dist/release-envelope-$RELEASE_VERSION-mac-arm64" \
+            --directory "apps/desktop/dist/release-envelope-$DESKTOP_VERSION-mac-arm64" \
             --tag "$RELEASE_TAG" \
-            --version "$RELEASE_VERSION" \
+            --npm-version "$NPM_VERSION" \
+            --desktop-version "$DESKTOP_VERSION" \
             --commit "$RELEASE_COMMIT" \
             --draft-id "$RELEASE_DRAFT_ID" \
             --mode "$RELEASE_MODE" \
@@ -209,7 +216,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: desktop-release-${{ github.run_id }}-${{ github.run_attempt }}
-          path: apps/desktop/dist/release-envelope-${{ inputs.version }}-mac-arm64/
+          path: apps/desktop/dist/release-envelope-${{ inputs.desktop_version }}-mac-arm64/
           if-no-files-found: error
           compression-level: 0
           retention-days: 90
@@ -262,13 +269,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_MODE: ${{ inputs.mode }}
-          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          DESKTOP_VERSION: ${{ inputs.desktop_version }}
           RELEASE_BASELINE_TAG: ${{ inputs.baseline_tag }}
         run: |
           pnpm desktop-release:transaction baseline \
             --directory "$RUNNER_TEMP/independent-baseline" \
             --mode "$RELEASE_MODE" \
-            --candidate-version "$RELEASE_VERSION" \
+            --candidate-tag "$RELEASE_TAG" \
+            --candidate-version "$DESKTOP_VERSION" \
             --baseline-tag "$RELEASE_BASELINE_TAG" \
             --github-output "$GITHUB_OUTPUT"
           if [ "$RELEASE_MODE" = 'steady' ]; then
@@ -310,7 +319,8 @@ jobs:
       - name: Independently verify signed updater envelope
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-          RELEASE_VERSION: ${{ inputs.version }}
+          NPM_VERSION: ${{ inputs.npm_version }}
+          DESKTOP_VERSION: ${{ inputs.desktop_version }}
           RELEASE_COMMIT: ${{ inputs.commit }}
           RELEASE_DRAFT_ID: ${{ inputs.draft_id }}
           RELEASE_MODE: ${{ inputs.mode }}
@@ -334,7 +344,8 @@ jobs:
           pnpm desktop-release:transaction verify \
             --directory "$RUNNER_TEMP/desktop-release" \
             --tag "$RELEASE_TAG" \
-            --version "$RELEASE_VERSION" \
+            --npm-version "$NPM_VERSION" \
+            --desktop-version "$DESKTOP_VERSION" \
             --commit "$RELEASE_COMMIT" \
             --draft-id "$RELEASE_DRAFT_ID" \
             --mode "$RELEASE_MODE" \
@@ -352,11 +363,11 @@ jobs:
             --baseline-zip-sha256 "$BASELINE_ZIP_SHA256" \
             --baseline-signing-identity "$BASELINE_SIGNING_IDENTITY" \
             --baseline-cdhash "$BASELINE_CDHASH"
-          hdiutil verify "$RUNNER_TEMP/desktop-release/Enduragent-$RELEASE_VERSION-arm64.dmg"
+          hdiutil verify "$RUNNER_TEMP/desktop-release/Enduragent-$DESKTOP_VERSION-arm64.dmg"
           spctl --assess --type open --context context:primary-signature --verbose \
-            "$RUNNER_TEMP/desktop-release/Enduragent-$RELEASE_VERSION-arm64.dmg"
+            "$RUNNER_TEMP/desktop-release/Enduragent-$DESKTOP_VERSION-arm64.dmg"
           mkdir "$RUNNER_TEMP/desktop-release-unpacked"
-          ditto -x -k "$RUNNER_TEMP/desktop-release/Enduragent-$RELEASE_VERSION-arm64.zip" \
+          ditto -x -k "$RUNNER_TEMP/desktop-release/Enduragent-$DESKTOP_VERSION-arm64.zip" \
             "$RUNNER_TEMP/desktop-release-unpacked"
           INDEPENDENT_EVIDENCE=$(codesign --display --verbose=4 \
             "$RUNNER_TEMP/desktop-release-unpacked/Enduragent.app" 2>&1)
@@ -394,7 +405,7 @@ jobs:
           mkdir "$RUNNER_TEMP/desktop-release-dmg"
           hdiutil attach -readonly -nobrowse \
             -mountpoint "$RUNNER_TEMP/desktop-release-dmg" \
-            "$RUNNER_TEMP/desktop-release/Enduragent-$RELEASE_VERSION-arm64.dmg"
+            "$RUNNER_TEMP/desktop-release/Enduragent-$DESKTOP_VERSION-arm64.dmg"
           trap 'hdiutil detach "$RUNNER_TEMP/desktop-release-dmg"' EXIT
           codesign --verify --deep --strict --verbose=2 \
             "$RUNNER_TEMP/desktop-release-dmg/Enduragent.app"
@@ -595,7 +606,7 @@ jobs:
         env:
           ENDURAGENT_MACOS_UPDATE_ROUNDTRIP_MODE: steady
           BASELINE_VERSION: ${{ needs.sign-macos.outputs.baseline_version }}
-          CANDIDATE_VERSION: ${{ inputs.version }}
+          CANDIDATE_VERSION: ${{ inputs.desktop_version }}
         run: |
           set -euo pipefail
           CANDIDATE_ENVELOPE="$RUNNER_TEMP/desktop-public-envelope"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
     outputs:
       package: ${{ steps.parse.outputs.package }}
       version: ${{ steps.parse.outputs.version }}
+      desktop_version: ${{ steps.parse.outputs.desktop_version }}
       ref: ${{ steps.parse.outputs.ref }}
       commit: ${{ steps.parse.outputs.commit }}
       desktop_mode: ${{ steps.parse.outputs.desktop_mode }}
@@ -118,6 +119,11 @@ jobs:
             exit 1
           fi
           COMMIT=$(git rev-parse "refs/tags/$TAG^{commit}")
+          DESKTOP_VERSION=$(git show "$COMMIT:apps/desktop/package.json" | jq -er '.version')
+          if ! printf '%s' "$DESKTOP_VERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo "::error::Desktop version '$DESKTOP_VERSION' is not stable SemVer"
+            exit 1
+          fi
           MODE="steady"
           BASELINE_TAG="none"
           DESKTOP_ENABLED=false
@@ -165,6 +171,7 @@ jobs:
           fi
           echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "desktop_version=$DESKTOP_VERSION" >> "$GITHUB_OUTPUT"
           echo "ref=$TAG" >> "$GITHUB_OUTPUT"
           echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
           echo "desktop_mode=$MODE" >> "$GITHUB_OUTPUT"
@@ -683,7 +690,8 @@ jobs:
     uses: ./.github/workflows/desktop-release.yml
     with:
       tag: ${{ needs.parse-tag.outputs.ref }}
-      version: ${{ needs.parse-tag.outputs.version }}
+      npm_version: ${{ needs.parse-tag.outputs.version }}
+      desktop_version: ${{ needs.parse-tag.outputs.desktop_version }}
       commit: ${{ needs.parse-tag.outputs.commit }}
       draft_id: ${{ needs.prepare-release-draft.outputs.draft_id }}
       mode: ${{ needs.parse-tag.outputs.desktop_mode }}

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @enduragent/desktop
 
+## 0.1.0
+
+### Minor Changes
+
+- Start the independent desktop SemVer sequence and bind packaged application identity, update metadata, signed artifacts, and native update acceptance to that version.
+
 ## 0.0.3
 
 ### Patch Changes

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enduragent/desktop",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "out/main/index.js",

--- a/apps/desktop/scripts/macos-release-plan.d.mts
+++ b/apps/desktop/scripts/macos-release-plan.d.mts
@@ -173,7 +173,7 @@ export const DESKTOP_UPDATER_CACHE_DIRECTORY: "@enduragentdesktop-updater";
 export function requireNotarizationCredentials(
   environment?: Readonly<Record<string, string | undefined>>,
 ): NotarizationCredentialSelection;
-export function requireStableCalVer(value: unknown): string;
+export function requireStableSemVer(value: unknown): string;
 export function requireGenericFeedUrl(value: unknown): string;
 export function parseMacosReleaseUpdaterMetadata(
   value: string | Uint8Array,
@@ -181,8 +181,9 @@ export function parseMacosReleaseUpdaterMetadata(
 export function requireDeveloperIdIdentity(value: unknown): string;
 export function requireMacosBaselineApplication(value: unknown): string;
 export function releaseArtifactNames(version: string): ReleaseArtifactNames;
-export function readCyclingCoachVersion(options?: {
+export function readDesktopVersion(options?: {
   readonly repositoryRoot?: string;
+  readonly desktopRoot?: string;
   readonly readFile?: (path: string, encoding: "utf8") => Promise<string>;
 }): Promise<string>;
 export function createMacosReleasePlan(

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -7,7 +7,7 @@ import { parse, stringify } from "yaml";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const canonicalRepositoryRoot = resolve(scriptDirectory, "../../..");
-const stableCalVerPattern = /^([1-9]\d{3})\.([1-9]|1[0-2])\.(0|[1-9]\d*)$/u;
+const stableSemVerPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/u;
 const builderCertificateClassPrefixes = [
   "Developer ID Application:",
   "Developer ID Installer:",
@@ -212,13 +212,13 @@ async function replaceMetadataAtomically(metadataPath, metadata) {
   }
 }
 
-export function requireStableCalVer(value) {
-  if (typeof value !== "string" || value.length > 32 || !stableCalVerPattern.test(value)) {
-    throw new TypeError("release version must be a stable CalVer");
+export function requireStableSemVer(value) {
+  if (typeof value !== "string" || value.length > 32 || !stableSemVerPattern.test(value)) {
+    throw new TypeError("desktop release version must be stable SemVer");
   }
-  const patch = Number(value.split(".")[2]);
-  if (!Number.isSafeInteger(patch)) {
-    throw new TypeError("release version must be a stable CalVer");
+  const parts = value.split(".").map(Number);
+  if (parts.some((part) => !Number.isSafeInteger(part))) {
+    throw new TypeError("desktop release version must be stable SemVer");
   }
   return value;
 }
@@ -330,27 +330,31 @@ export function requireMacosBaselineApplication(value) {
   return value;
 }
 
-export async function readCyclingCoachVersion(options = {}) {
+export async function readDesktopVersion(options = {}) {
   const repositoryRoot = options.repositoryRoot ?? canonicalRepositoryRoot;
   if (!isAbsolute(repositoryRoot)) {
     throw new TypeError("repository root must be absolute");
   }
+  const desktopRoot = options.desktopRoot ?? join(repositoryRoot, "apps/desktop");
+  if (!isAbsolute(desktopRoot)) {
+    throw new TypeError("desktop root must be absolute");
+  }
   const read = options.readFile ?? readFile;
-  const manifestPath = join(repositoryRoot, "packages/cycling-coach/package.json");
+  const manifestPath = join(desktopRoot, "package.json");
   let manifest;
   try {
     manifest = JSON.parse(await read(manifestPath, "utf8"));
   } catch {
-    throw new TypeError("cycling-coach release manifest is invalid");
+    throw new TypeError("desktop release manifest is invalid");
   }
   if (!exactObject(manifest) || !Object.hasOwn(manifest, "version")) {
-    throw new TypeError("cycling-coach release manifest is invalid");
+    throw new TypeError("desktop release manifest is invalid");
   }
-  return requireStableCalVer(manifest.version);
+  return requireStableSemVer(manifest.version);
 }
 
 export function releaseArtifactNames(version) {
-  const stableVersion = requireStableCalVer(version);
+  const stableVersion = requireStableSemVer(version);
   const base = `Enduragent-${stableVersion}-arm64`;
   return Object.freeze({
     dmg: `${base}.dmg`,
@@ -366,8 +370,9 @@ async function createMacosReleasePlanCore(input, dependencies = {}) {
   if (!isAbsolute(desktopRoot)) {
     throw new TypeError("desktop root must be absolute");
   }
-  const version = await readCyclingCoachVersion({
+  const version = await readDesktopVersion({
     repositoryRoot,
+    desktopRoot,
     readFile: dependencies.readFile,
   });
   const feedUrl = requireGenericFeedUrl(input.feedUrl);

--- a/apps/desktop/scripts/verify-macos-release.mjs
+++ b/apps/desktop/scripts/verify-macos-release.mjs
@@ -21,9 +21,9 @@ import { extractFile, statFile, uncache as uncacheAsarFile } from "@electron/asa
 import { parse } from "yaml";
 import {
   parseMacosReleaseUpdaterMetadata,
-  readCyclingCoachVersion,
+  readDesktopVersion,
   releaseArtifactNames,
-  requireStableCalVer,
+  requireStableSemVer,
 } from "./macos-release-plan.mjs";
 
 const localRequire = createRequire(import.meta.url);
@@ -274,7 +274,7 @@ function parseBundleMetadata(result) {
     fail("macOS product identity is invalid");
   }
   try {
-    return requireStableCalVer(info.CFBundleShortVersionString);
+    return requireStableSemVer(info.CFBundleShortVersionString);
   } catch {
     fail("macOS product identity is invalid");
   }
@@ -389,7 +389,7 @@ async function inspectMacosApplicationIdentity(application, bundle, dependencies
   });
 }
 
-function olderStableCalVer(left, right) {
+function olderStableSemVer(left, right) {
   const leftParts = left.split(".").map(Number);
   const rightParts = right.split(".").map(Number);
   for (const [index, part] of leftParts.entries()) {
@@ -402,7 +402,7 @@ function olderStableCalVer(left, right) {
 export async function verifyMacosBaselineApplication(baselineApplication, options, overrides = {}) {
   let candidateVersion;
   try {
-    candidateVersion = requireStableCalVer(options?.candidateVersion);
+    candidateVersion = requireStableSemVer(options?.candidateVersion);
   } catch {
     fail("candidate release version is invalid");
   }
@@ -422,7 +422,7 @@ export async function verifyMacosBaselineApplication(baselineApplication, option
   };
   const bundle = await requireApplicationBundle(baselineApplication, "baseline", dependencies);
   const baseline = await inspectMacosApplicationIdentity(baselineApplication, bundle, dependencies);
-  if (!olderStableCalVer(baseline.version, candidateVersion)) {
+  if (!olderStableSemVer(baseline.version, candidateVersion)) {
     fail("baseline application is not older than candidate");
   }
   return Object.freeze({
@@ -468,7 +468,7 @@ export async function verifyMacosReleaseCandidateApplication(
 ) {
   let candidateVersion;
   try {
-    candidateVersion = requireStableCalVer(options?.candidateVersion);
+    candidateVersion = requireStableSemVer(options?.candidateVersion);
   } catch {
     fail("candidate release version is invalid");
   }
@@ -664,7 +664,7 @@ export async function verifyMacosIdentityContinuity(
 ) {
   let candidateVersion;
   try {
-    candidateVersion = requireStableCalVer(options?.candidateVersion);
+    candidateVersion = requireStableSemVer(options?.candidateVersion);
   } catch {
     fail("candidate release version is invalid");
   }
@@ -710,7 +710,7 @@ export async function verifyMacosIdentityContinuity(
     codeDirectorySha256: candidateIdentity.candidateCodeIdentity.codeDirectorySha256,
     cdHash: candidateIdentity.candidateCodeIdentity.cdHash,
   };
-  if (!olderStableCalVer(baseline.version, candidate.version)) {
+  if (!olderStableSemVer(baseline.version, candidate.version)) {
     fail("baseline application is not older than candidate");
   }
   if (
@@ -1158,7 +1158,7 @@ async function verifyMacosReleaseApplicationContentsWithCandidate(
   if (!isAbsolute(artifactDirectory)) fail("artifact directory must be absolute");
   let candidateVersion;
   try {
-    candidateVersion = requireStableCalVer(options?.candidateVersion);
+    candidateVersion = requireStableSemVer(options?.candidateVersion);
   } catch {
     fail("candidate release version is invalid");
   }
@@ -1695,8 +1695,9 @@ export async function verifyMacosReleaseArtifacts(artifactDirectory, options = {
     verifySignature: overrides.verifySignature,
     verifyNotarization: overrides.verifyNotarization,
   };
-  const version = await readCyclingCoachVersion({
+  const version = await readDesktopVersion({
     repositoryRoot: options.repositoryRoot,
+    desktopRoot: options.desktopRoot,
     readFile: options.readVersionFile,
   });
   const names = releaseArtifactNames(version);
@@ -1791,7 +1792,7 @@ export async function verifyMacosReleaseEnvelope(
   const artifacts = await verifyReleaseArtifacts(artifactDirectory, options, overrides);
   let candidateVersion;
   try {
-    candidateVersion = requireStableCalVer(artifacts?.version);
+    candidateVersion = requireStableSemVer(artifacts?.version);
   } catch {
     fail("verified release version is invalid");
   }
@@ -1830,7 +1831,7 @@ export async function verifyMacosGenesisReleaseEnvelope(
   const artifacts = await verifyReleaseArtifacts(artifactDirectory, options, overrides);
   let candidateVersion;
   try {
-    candidateVersion = requireStableCalVer(artifacts?.version);
+    candidateVersion = requireStableSemVer(artifacts?.version);
   } catch {
     fail("verified release version is invalid");
   }

--- a/apps/desktop/scripts/verify-package-layout.mjs
+++ b/apps/desktop/scripts/verify-package-layout.mjs
@@ -8,7 +8,7 @@ import { parse } from "yaml";
 import {
   parseMacosReleaseUpdaterMetadata,
   requireGenericFeedUrl,
-  requireStableCalVer,
+  requireStableSemVer,
 } from "./macos-release-plan.mjs";
 import {
   DEVELOPMENT_PACKAGE_NAME,
@@ -730,7 +730,7 @@ export async function verifyPackageLayout(application, options = {}) {
       fail("invalid release package-layout options");
     }
     release = {
-      version: requireStableCalVer(options.release.version),
+      version: requireStableSemVer(options.release.version),
       feedUrl: requireGenericFeedUrl(options.release.feedUrl),
     };
   }

--- a/apps/desktop/scripts/verify-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-updater-round-trip.mjs
@@ -17,7 +17,7 @@ import { PROTOCOL_VERSION } from "@enduragent/coach-contract";
 import {
   DESKTOP_UPDATER_CACHE_DIRECTORY,
   requireGenericFeedUrl,
-  requireStableCalVer,
+  requireStableSemVer,
 } from "./macos-release-plan.mjs";
 import {
   inspectMacosReleaseApplication,
@@ -73,7 +73,7 @@ function exactKeys(value, expected) {
   );
 }
 
-function olderStableCalVer(left, right) {
+function olderStableSemVer(left, right) {
   const leftParts = left.split(".").map(Number);
   const rightParts = right.split(".").map(Number);
   for (const [index, part] of leftParts.entries()) {
@@ -119,12 +119,12 @@ export function requireMacosUpdaterRoundTripInput(input, context = {}) {
   let baselineVersion;
   let candidateVersion;
   try {
-    baselineVersion = requireStableCalVer(input.baselineVersion);
-    candidateVersion = requireStableCalVer(input.candidateVersion);
+    baselineVersion = requireStableSemVer(input.baselineVersion);
+    candidateVersion = requireStableSemVer(input.candidateVersion);
   } catch {
     fail("round-trip versions are invalid");
   }
-  if (!olderStableCalVer(baselineVersion, candidateVersion)) {
+  if (!olderStableSemVer(baselineVersion, candidateVersion)) {
     fail("round-trip candidate must be newer than baseline");
   }
   const paths = {
@@ -1013,14 +1013,14 @@ export function createMacosUpdaterRoundTripEvidence(input) {
   let baselineVersion;
   let candidateVersion;
   try {
-    baselineVersion = requireStableCalVer(input?.baselineVersion);
-    candidateVersion = requireStableCalVer(input?.candidateVersion);
+    baselineVersion = requireStableSemVer(input?.baselineVersion);
+    candidateVersion = requireStableSemVer(input?.candidateVersion);
   } catch {
     fail("round-trip evidence is invalid");
   }
   if (
     !exactObject(input) ||
-    !olderStableCalVer(baselineVersion, candidateVersion) ||
+    !olderStableSemVer(baselineVersion, candidateVersion) ||
     !Number.isSafeInteger(input.initialPid) ||
     input.initialPid < 1 ||
     !Number.isSafeInteger(input.relaunchedPid) ||

--- a/apps/desktop/src/main/desktop-version.ts
+++ b/apps/desktop/src/main/desktop-version.ts
@@ -1,0 +1,26 @@
+const MAX_DESKTOP_VERSION_LENGTH = 32;
+const STABLE_SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/u;
+
+function stableSemVerParts(value: unknown): readonly [number, number, number] | null {
+  if (typeof value !== "string" || value.length > MAX_DESKTOP_VERSION_LENGTH) return null;
+  const match = STABLE_SEMVER_PATTERN.exec(value);
+  if (match === null) return null;
+  const parts = [Number(match[1]), Number(match[2]), Number(match[3])] as const;
+  return parts.every(Number.isSafeInteger) ? parts : null;
+}
+
+export function isStableDesktopVersion(value: unknown): value is string {
+  return stableSemVerParts(value) !== null;
+}
+
+export function isDesktopUpdateAvailable(candidate: string, current: string): boolean {
+  const candidateParts = stableSemVerParts(candidate);
+  const currentParts = stableSemVerParts(current);
+  if (candidateParts === null || currentParts === null) return false;
+  for (let index = 0; index < candidateParts.length; index += 1) {
+    if (candidateParts[index] !== currentParts[index]) {
+      return candidateParts[index] > currentParts[index];
+    }
+  }
+  return false;
+}

--- a/apps/desktop/src/main/update-controller.ts
+++ b/apps/desktop/src/main/update-controller.ts
@@ -1,5 +1,5 @@
-import { isStableCalVer, isUpdateAvailable } from "@enduragent/core";
 import type { AppUpdater, UpdateDownloadedEvent } from "electron-updater";
+import { isDesktopUpdateAvailable, isStableDesktopVersion } from "./desktop-version.js";
 
 export type DesktopUpdateState =
   | { readonly status: "disabled" }
@@ -144,8 +144,8 @@ export function createDesktopUpdateController(input: {
         const version = result?.updateInfo.version;
         if (
           result?.isUpdateAvailable !== true ||
-          !isStableCalVer(version) ||
-          !isUpdateAvailable(version, input.currentVersion)
+          !isStableDesktopVersion(version) ||
+          !isDesktopUpdateAvailable(version, input.currentVersion)
         ) {
           targetVersion = undefined;
           publish({ status: "current" });

--- a/apps/desktop/src/main/update-eligibility.ts
+++ b/apps/desktop/src/main/update-eligibility.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { isStableCalVer } from "@enduragent/core";
+import { isStableDesktopVersion } from "./desktop-version.js";
 
 const PACKAGE_JSON_LIMIT = 64 * 1024;
 
@@ -16,7 +16,7 @@ export function isDesktopUpdateReleaseEligible(input: {
     !input.isPackaged ||
     input.platform !== "darwin" ||
     input.securitySmokeMode ||
-    !isStableCalVer(input.currentVersion)
+    !isStableDesktopVersion(input.currentVersion)
   ) {
     return false;
   }
@@ -33,7 +33,7 @@ export function isDesktopUpdateReleaseEligible(input: {
       metadata.enduragentDesktopRelease === true &&
       Object.hasOwn(metadata, "version") &&
       metadata.version === input.currentVersion &&
-      isStableCalVer(metadata.version)
+      isStableDesktopVersion(metadata.version)
     );
   } catch {
     return false;

--- a/apps/desktop/tests/desktop-version.test.ts
+++ b/apps/desktop/tests/desktop-version.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { isDesktopUpdateAvailable, isStableDesktopVersion } from "../src/main/desktop-version.js";
+
+describe("desktop versions", () => {
+  it.each(["0.1.0", "0.1.1", "1.0.0", "12.34.56"])("accepts stable SemVer %s", (version) => {
+    expect(isStableDesktopVersion(version)).toBe(true);
+  });
+
+  it.each(["v0.1.0", "0.01.0", "0.1", "0.1.0-beta.1", "0.1.9007199254740992", ""])(
+    "rejects non-stable SemVer %s",
+    (version) => {
+      expect(isStableDesktopVersion(version)).toBe(false);
+    },
+  );
+
+  it("compares major, minor, and patch numerically", () => {
+    expect(isDesktopUpdateAvailable("0.1.1", "0.1.0")).toBe(true);
+    expect(isDesktopUpdateAvailable("0.2.0", "0.1.99")).toBe(true);
+    expect(isDesktopUpdateAvailable("1.0.0", "0.99.99")).toBe(true);
+    expect(isDesktopUpdateAvailable("0.1.0", "0.1.0")).toBe(false);
+    expect(isDesktopUpdateAvailable("0.1.0", "0.1.1")).toBe(false);
+    expect(isDesktopUpdateAvailable("0.1.0-beta.1", "0.1.0")).toBe(false);
+  });
+});

--- a/apps/desktop/tests/macos-genesis-verifier.test.ts
+++ b/apps/desktop/tests/macos-genesis-verifier.test.ts
@@ -17,7 +17,7 @@ function output() {
 
 describe("macOS genesis verifier boundary", () => {
   it("delegates exact absolute paths to the canonical verifier", async () => {
-    const verified = Object.freeze({ version: "2026.8.1" });
+    const verified = Object.freeze({ version: "0.1.0" });
     const verifyEnvelope = vi.fn(async () => verified);
 
     await expect(
@@ -58,7 +58,7 @@ describe("macOS genesis verifier boundary", () => {
 
     await expect(
       runMacosGenesisVerifierCli([artifactDirectory, candidateApplication], {
-        verifyEnvelope: vi.fn(async () => Object.freeze({ version: "2026.8.1" })) as never,
+        verifyEnvelope: vi.fn(async () => Object.freeze({ version: "0.1.0" })) as never,
         stdout: stdout.writer,
         stderr: stderr.writer,
       }),

--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -43,7 +43,7 @@ const { buildBlockMap: installedBuildBlockMap } = builderRequire(
 };
 const roots: string[] = [];
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const version = "2026.7.2";
+const version = "0.1.2";
 const names = {
   dmg: `Enduragent-${version}-arm64.dmg`,
   zip: `Enduragent-${version}-arm64.zip`,
@@ -61,11 +61,11 @@ async function releaseFixture() {
   const repositoryRoot = join(root, "repository");
   const artifactDirectory = join(root, "artifacts");
   await Promise.all([
-    mkdir(join(repositoryRoot, "packages/cycling-coach"), { recursive: true }),
+    mkdir(join(repositoryRoot, "apps/desktop"), { recursive: true }),
     mkdir(artifactDirectory, { recursive: true }),
   ]);
   await writeFile(
-    join(repositoryRoot, "packages/cycling-coach/package.json"),
+    join(repositoryRoot, "apps/desktop/package.json"),
     `${JSON.stringify({ version })}\n`,
   );
   const zip = Buffer.from("synthetic signed ZIP bytes\n");
@@ -200,8 +200,8 @@ async function signedIdentityFixture() {
     await finished(archive);
   }
   const metadata = new Map<string, SignedApplicationMetadata>([
-    [baseline, signedApplicationMetadata("2026.7.1", "a".repeat(40))],
-    [candidate, signedApplicationMetadata("2026.7.2", "b".repeat(40))],
+    [baseline, signedApplicationMetadata("0.1.1", "a".repeat(40))],
+    [candidate, signedApplicationMetadata("0.1.2", "b".repeat(40))],
   ]);
   const applicationForPath = (path: string) =>
     [...metadata.keys()].find(
@@ -675,7 +675,7 @@ describe("macOS signed identity continuity", () => {
     {
       label: "package version",
       mutate(metadata: SignedApplicationMetadata) {
-        metadata.manifest.version = "2026.7.1";
+        metadata.manifest.version = "0.1.1";
       },
       error: "macOS package identity is invalid",
     },
@@ -712,7 +712,7 @@ describe("macOS signed identity continuity", () => {
         },
       ),
     ).resolves.toEqual({
-      baselineVersion: "2026.7.1",
+      baselineVersion: "0.1.1",
       teamIdentifier: "FA494ACVTF",
     });
     expect(fixture.executeFile).toHaveBeenCalledWith("/usr/bin/codesign", [
@@ -743,7 +743,7 @@ describe("macOS signed identity continuity", () => {
         },
       ),
     ).resolves.toEqual({
-      baselineVersion: "2026.7.1",
+      baselineVersion: "0.1.1",
       candidateVersion: version,
       teamIdentifier: "FA494ACVTF",
       candidateCodeIdentity: {
@@ -946,7 +946,7 @@ describe("macOS signed identity continuity", () => {
     expect(fixture.executeFile).not.toHaveBeenCalled();
   });
 
-  it.each(["2026.7.2", "2026.7.3"])(
+  it.each(["0.1.2", "0.1.3"])(
     "rejects a baseline that is not older than the candidate: %s",
     async (baselineVersion) => {
       const fixture = await signedIdentityFixture();
@@ -1339,7 +1339,7 @@ async function packagedApplicationFixture(
         throw new Error(`${application}: private signing output`);
       }
       return {
-        baselineVersion: "2026.7.1",
+        baselineVersion: "0.1.1",
         candidateVersion: verificationOptions.candidateVersion,
         teamIdentifier: "FA494ACVTF",
         candidateCodeIdentity:
@@ -2073,7 +2073,7 @@ describe("macOS release artifact envelope", () => {
       zipSha512: fixture.zipSha512,
     });
     const identityContinuity = Object.freeze({
-      baselineVersion: "2026.7.1",
+      baselineVersion: "0.1.1",
       candidateVersion: version,
       teamIdentifier: "FA494ACVTF",
       candidateCodeIdentity: Object.freeze({
@@ -2364,7 +2364,7 @@ describe("macOS release artifact envelope", () => {
   });
 
   it.each([
-    ["version", (source: string) => source.replace(version, "2026.7.1")],
+    ["version", (source: string) => source.replace(version, "0.1.1")],
     ["ZIP filename", (source: string) => source.replace(names.zip, "stale.zip")],
     [
       "ZIP SHA-512",

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -166,7 +166,7 @@ async function metadataSealFixture() {
 }
 
 describe("macOS release plan", () => {
-  it("uses only the cycling package version and creates the exact sealed overlay", async () => {
+  it("uses only the desktop package version and creates the exact sealed overlay", async () => {
     const readVersion = versionReader();
     const plan = await createMacosReleasePlan(
       {
@@ -180,7 +180,7 @@ describe("macOS release plan", () => {
     );
     expect(readVersion).toHaveBeenCalledOnce();
     expect(readVersion).toHaveBeenCalledWith(
-      "/synthetic/repository/packages/cycling-coach/package.json",
+      "/synthetic/repository/apps/desktop/package.json",
       "utf8",
     );
     expect(plan.version).toBe("2026.7.2");
@@ -1388,7 +1388,7 @@ describe("macOS release plan", () => {
     ).toEqual([]);
   });
 
-  it.each(["2026.07.2", "2026.7.02", "2026.13.0", "2026.0.1", "2026.7.2-1", "0.0.1", "", "latest"])(
+  it.each(["01.2.3", "1.02.3", "1.2.03", "1.2", "1.2.3-1", "", "latest"])(
     "rejects a non-stable release version: %s",
     async (version) => {
       await expect(
@@ -1401,7 +1401,7 @@ describe("macOS release plan", () => {
           },
           { readFile: versionReader(version) },
         ),
-      ).rejects.toThrow("stable CalVer");
+      ).rejects.toThrow("stable SemVer");
     },
   );
 
@@ -1462,7 +1462,7 @@ describe("macOS release plan", () => {
     expect(dependencyManifest.version).toBe("2.5.0");
   });
 
-  it("reads the live version authority without consulting the desktop manifest", async () => {
+  it("reads the live desktop version authority without consulting the npm manifest", async () => {
     const plan = await createMacosReleasePlan({
       repositoryRoot,
       desktopRoot,
@@ -1470,9 +1470,9 @@ describe("macOS release plan", () => {
       identity,
       baselineApplication,
     });
-    const manifest = JSON.parse(
-      await readFile(join(repositoryRoot, "packages/cycling-coach/package.json"), "utf8"),
-    ) as { version: string };
+    const manifest = JSON.parse(await readFile(join(desktopRoot, "package.json"), "utf8")) as {
+      version: string;
+    };
     expect(plan.version).toBe(manifest.version);
     expect(plan.version).not.toBe("0.0.1");
   });

--- a/apps/desktop/tests/macos-update-roundtrip.test.ts
+++ b/apps/desktop/tests/macos-update-roundtrip.test.ts
@@ -11,8 +11,8 @@ import {
 } from "../scripts/verify-updater-round-trip.mjs";
 import type { VerifiedMacosReleaseApplication } from "../scripts/verify-macos-release.mjs";
 
-const baselineVersion = "2026.8.7";
-const candidateVersion = "2026.8.8";
+const baselineVersion = "0.1.0";
+const candidateVersion = "0.1.1";
 
 const input: MacosUpdaterRoundTripInput = {
   baselineVersion,
@@ -106,9 +106,9 @@ describe("macOS updater round-trip input", () => {
 
   it.each([
     { baselineVersion: candidateVersion },
-    { baselineVersion: "2026.9.1" },
-    { candidateVersion: "v2026.8.8" },
-    { candidateVersion: "2026.08.8" },
+    { baselineVersion: "0.2.0" },
+    { candidateVersion: "v0.1.1" },
+    { candidateVersion: "0.01.1" },
   ])("rejects a non-increasing or non-canonical version pair", (patch) => {
     expect(() =>
       requireMacosUpdaterRoundTripInput(
@@ -157,7 +157,7 @@ describe("macOS updater identity continuity", () => {
     () => ({ candidate: identity(candidateVersion, "a".repeat(64)) }),
     () => ({ installedBaseline: identity(baselineVersion, "d".repeat(64)) }),
     () => ({ relaunched: identity(candidateVersion, "d".repeat(64)) }),
-    () => ({ candidate: identity("2026.8.9", "b".repeat(64)) }),
+    () => ({ candidate: identity("0.1.2", "b".repeat(64)) }),
     () => ({
       candidate: {
         ...identity(candidateVersion, "b".repeat(64)),

--- a/apps/desktop/tests/update-controller.test.ts
+++ b/apps/desktop/tests/update-controller.test.ts
@@ -67,7 +67,7 @@ function activeController(
   const clearInterval = vi.fn();
   const controller = createDesktopUpdateController({
     releaseEligible: true,
-    currentVersion: "2026.7.22",
+    currentVersion: "0.1.0",
     loadUpdater: vi.fn(async () => updater),
     requestQuit: quit,
     setInterval: vi.fn((callback, interval) => {
@@ -87,7 +87,7 @@ describe("desktop update controller", () => {
     const setInterval = vi.fn();
     const controller = createDesktopUpdateController({
       releaseEligible: false,
-      currentVersion: "2026.7.22",
+      currentVersion: "0.1.0",
       loadUpdater,
       requestQuit: vi.fn(),
       setInterval,
@@ -103,7 +103,7 @@ describe("desktop update controller", () => {
 
   it("configures a quiet updater, performs startup and unref'd daily checks, and cleans up", async () => {
     const fake = fakeUpdater();
-    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("2026.7.22"));
+    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("0.1.0"));
     const subject = activeController(fake.updater);
 
     await subject.controller.start();
@@ -132,13 +132,13 @@ describe("desktop update controller", () => {
     const first = deferred<never>();
     vi.mocked(fake.updater.checkForUpdates)
       .mockReturnValueOnce(first.promise)
-      .mockResolvedValueOnce(updateResult("2026.7.22"));
+      .mockResolvedValueOnce(updateResult("0.1.0"));
     const subject = activeController(fake.updater);
     const startup = subject.controller.start();
     await vi.waitFor(() => expect(fake.updater.checkForUpdates).toHaveBeenCalledOnce());
 
     const concurrent = subject.controller.check();
-    first.resolve(updateResult("2026.7.22"));
+    first.resolve(updateResult("0.1.0"));
     await expect(concurrent).resolves.toEqual({ status: "current" });
     await startup;
     await subject.controller.check();
@@ -147,48 +147,41 @@ describe("desktop update controller", () => {
 
   it("downloads only a strictly newer stable target and accepts only its exact event", async () => {
     const fake = fakeUpdater();
-    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("2026.7.23"));
+    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("0.1.1"));
     const subject = activeController(fake.updater);
     await subject.controller.start();
 
     expect(fake.updater.downloadUpdate).toHaveBeenCalledOnce();
     expect(subject.controller.state()).toEqual({
       status: "downloading",
-      version: "2026.7.23",
+      version: "0.1.1",
     });
     expect(subject.quit).not.toHaveBeenCalled();
-    fake.emit("update-downloaded", { version: "2026.7.23", downloadedFile: "/private/raw.zip" });
+    fake.emit("update-downloaded", { version: "0.1.1", downloadedFile: "/private/raw.zip" });
     expect(subject.controller.state()).toEqual({
       status: "downloaded",
-      version: "2026.7.23",
+      version: "0.1.1",
     });
     expect(JSON.stringify(subject.controller.state())).not.toContain("raw.zip");
   });
 
-  it.each([
-    "2026.7.22",
-    "2026.7.21",
-    "2026.7.23-beta.1",
-    "2026.0.23",
-    "2026.13.23",
-    "2026.7.9007199254740992",
-    "999.7.23",
-    "10000.7.23",
-    "not-a-version",
-  ])("refuses non-newer or non-stable target %s", async (version) => {
-    const fake = fakeUpdater();
-    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult(version));
-    const subject = activeController(fake.updater);
-    await subject.controller.start();
-    expect(subject.controller.state()).toEqual({ status: "current" });
-    expect(fake.updater.downloadUpdate).not.toHaveBeenCalled();
-  });
+  it.each(["0.1.0", "0.0.9", "0.1.1-beta.1", "0.01.1", "0.1.9007199254740992", "not-a-version"])(
+    "refuses non-newer or non-stable target %s",
+    async (version) => {
+      const fake = fakeUpdater();
+      vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult(version));
+      const subject = activeController(fake.updater);
+      await subject.controller.start();
+      expect(subject.controller.state()).toEqual({ status: "current" });
+      expect(fake.updater.downloadUpdate).not.toHaveBeenCalled();
+    },
+  );
 
   it("clears a failed candidate when the updater reports a newer version unavailable", async () => {
     const fake = fakeUpdater();
     vi.mocked(fake.updater.checkForUpdates)
-      .mockResolvedValueOnce(updateResult("2026.7.23"))
-      .mockResolvedValueOnce(updateResult("2026.7.24", false));
+      .mockResolvedValueOnce(updateResult("0.1.1"))
+      .mockResolvedValueOnce(updateResult("0.1.2", false));
     vi.mocked(fake.updater.downloadUpdate).mockRejectedValueOnce(
       new Error("synthetic download failure"),
     );
@@ -200,19 +193,19 @@ describe("desktop update controller", () => {
 
     expect(subject.controller.state()).toEqual({ status: "current" });
     expect(fake.updater.downloadUpdate).toHaveBeenCalledOnce();
-    fake.emit("update-downloaded", { version: "2026.7.23" });
+    fake.emit("update-downloaded", { version: "0.1.1" });
     expect(subject.controller.state()).toEqual({ status: "current" });
   });
 
   it("fails closed on a mismatched downloaded event and contains updater diagnostics", async () => {
     const fake = fakeUpdater();
-    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("2026.7.23"));
+    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("0.1.1"));
     const states: unknown[] = [];
     const subject = activeController(fake.updater);
     subject.controller.subscribe((state) => states.push(state));
     await subject.controller.start();
     fake.emit("update-downloaded", {
-      version: "2026.7.24",
+      version: "0.1.2",
       downloadedFile: "/Users/athlete/private/update.zip",
     });
     fake.emit("error", new Error("Authorization: secret"));
@@ -224,18 +217,18 @@ describe("desktop update controller", () => {
 
   it("requests an explicit quit only after download and installs once after a successful drain", async () => {
     const fake = fakeUpdater();
-    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("2026.7.23"));
+    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("0.1.1"));
     const subject = activeController(fake.updater);
     await subject.controller.start();
 
     expect(subject.controller.restart()).toEqual({
       status: "downloading",
-      version: "2026.7.23",
+      version: "0.1.1",
     });
-    fake.emit("update-downloaded", { version: "2026.7.23" });
+    fake.emit("update-downloaded", { version: "0.1.1" });
     expect(subject.controller.restart()).toEqual({
       status: "installing",
-      version: "2026.7.23",
+      version: "0.1.1",
     });
     subject.controller.restart();
     expect(subject.quit).toHaveBeenCalledOnce();

--- a/apps/desktop/tests/update-eligibility.test.ts
+++ b/apps/desktop/tests/update-eligibility.test.ts
@@ -11,15 +11,15 @@ function eligibility(
     platform: "darwin",
     securitySmokeMode: false,
     appPath,
-    currentVersion: "2026.7.23",
-    readPackageJson: () => JSON.stringify({ version: "2026.7.23", enduragentDesktopRelease: true }),
+    currentVersion: "0.1.0",
+    readPackageJson: () => JSON.stringify({ version: "0.1.0", enduragentDesktopRelease: true }),
     ...overrides,
   });
 }
 
 describe("desktop update release eligibility", () => {
   it("accepts only the marked packaged mac release with its exact stable version", () => {
-    const readPackageJson = vi.fn(() => '{"version":"2026.7.23","enduragentDesktopRelease":true}');
+    const readPackageJson = vi.fn(() => '{"version":"0.1.0","enduragentDesktopRelease":true}');
     expect(eligibility({ readPackageJson })).toBe(true);
     expect(readPackageJson).toHaveBeenCalledWith(`${appPath}/package.json`);
   });
@@ -38,42 +38,42 @@ describe("desktop update release eligibility", () => {
 
   it.each([
     ["ordinary package", JSON.stringify({ version: "0.0.1" }), "0.0.1"],
-    ["unmarked stable package", JSON.stringify({ version: "2026.7.23" }), "2026.7.23"],
+    ["unmarked stable package", JSON.stringify({ version: "0.1.0" }), "0.1.0"],
     [
       "ordinary package with false marker",
-      JSON.stringify({ version: "2026.7.23", enduragentDesktopRelease: false }),
-      "2026.7.23",
+      JSON.stringify({ version: "0.1.0", enduragentDesktopRelease: false }),
+      "0.1.0",
     ],
     [
       "nested marker",
       JSON.stringify({
-        version: "2026.7.23",
+        version: "0.1.0",
         build: { enduragentDesktopRelease: true },
       }),
-      "2026.7.23",
+      "0.1.0",
     ],
     [
       "mismatched version",
-      JSON.stringify({ version: "2026.7.24", enduragentDesktopRelease: true }),
-      "2026.7.23",
+      JSON.stringify({ version: "0.1.1", enduragentDesktopRelease: true }),
+      "0.1.0",
     ],
     [
-      "impossible month",
-      JSON.stringify({ version: "2026.13.1", enduragentDesktopRelease: true }),
-      "2026.13.1",
+      "leading-zero minor",
+      JSON.stringify({ version: "0.01.0", enduragentDesktopRelease: true }),
+      "0.01.0",
     ],
     [
       "unsafe patch",
       JSON.stringify({
-        version: "2026.7.9007199254740992",
+        version: "0.1.9007199254740992",
         enduragentDesktopRelease: true,
       }),
-      "2026.7.9007199254740992",
+      "0.1.9007199254740992",
     ],
     [
-      "invalid year",
-      JSON.stringify({ version: "26.7.23", enduragentDesktopRelease: true }),
-      "26.7.23",
+      "prerelease",
+      JSON.stringify({ version: "0.1.0-beta.1", enduragentDesktopRelease: true }),
+      "0.1.0-beta.1",
     ],
   ])("rejects %s", (_case, raw, currentVersion) => {
     expect(eligibility({ currentVersion, readPackageJson: () => raw })).toBe(false);

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -27,6 +27,26 @@ describe("desktop release workflow policy", () => {
   it("accepts the canonical coordinator and reusable workflow", () => {
     const source = sources();
     expect(inspect(source.release, source.desktop, source.version)).toEqual([]);
+    expect(source.release).toContain("desktop_version: ${{ steps.parse.outputs.desktop_version }}");
+    expect(source.release).toContain("npm_version: ${{ needs.parse-tag.outputs.version }}");
+    expect(source.release).toContain(
+      "desktop_version: ${{ needs.parse-tag.outputs.desktop_version }}",
+    );
+    expect(source.desktop).toContain('--npm-version "$NPM_VERSION"');
+    expect(source.desktop).toContain('--desktop-version "$DESKTOP_VERSION"');
+  });
+
+  it("rejects coupling the desktop version back to the npm version", () => {
+    const source = sources();
+    const release = source.release.replace(
+      "desktop_version: ${{ needs.parse-tag.outputs.desktop_version }}",
+      "desktop_version: ${{ needs.parse-tag.outputs.version }}",
+    );
+    expect(
+      inspect(release, source.desktop).some((issue) =>
+        issue.includes("frozen version authorities"),
+      ),
+    ).toBe(true);
   });
 
   it("rejects pnpm separators that become the transaction command", () => {
@@ -180,8 +200,8 @@ describe("desktop release workflow policy", () => {
     const source = sources();
     const wrongPackage = source.desktop.replace("package:mac:genesis", "package:mac");
     const wrongAcknowledgement = source.desktop.replace(
-      "ENDURAGENT_MACOS_GENESIS_VERSION: ${{ inputs.version }}",
-      "ENDURAGENT_MACOS_GENESIS_VERSION: 2026.1.1",
+      "ENDURAGENT_MACOS_GENESIS_VERSION: ${{ inputs.desktop_version }}",
+      "ENDURAGENT_MACOS_GENESIS_VERSION: 0.0.1",
     );
     const missingGenesisVerifier = source.desktop.replace(
       "verify:mac-genesis-release --",
@@ -360,7 +380,7 @@ describe("desktop release workflow policy", () => {
         "/actions/runs/$PUBLICATION_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT",
       );
     const issues = inspect(release, source.desktop);
-    expect(issues.some((issue) => issue.includes("verified npm job outputs"))).toBe(true);
+    expect(issues.some((issue) => issue.includes("verified npm outputs"))).toBe(true);
     expect(issues.some((issue) => issue.includes("exact signed provenance"))).toBe(true);
     expect(issues.some((issue) => issue.includes("publication attempt tuple"))).toBe(true);
   });

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -130,7 +130,8 @@ export function inspectDesktopReleaseWorkflows(
   );
   for (const input of [
     "tag",
-    "version",
+    "npm_version",
+    "desktop_version",
     "commit",
     "draft_id",
     "mode",
@@ -335,11 +336,13 @@ export function inspectDesktopReleaseWorkflows(
   );
   const callWith = mapping(desktopCall.with, "desktop call inputs", issues);
   if (
+    callWith.npm_version !== "${{ needs.parse-tag.outputs.version }}" ||
+    callWith.desktop_version !== "${{ needs.parse-tag.outputs.desktop_version }}" ||
     callWith.npm_integrity !== "${{ needs.verify-npm-publication.outputs.npm_integrity }}" ||
     callWith.npm_attestation_url !==
       "${{ needs.verify-npm-publication.outputs.npm_attestation_url }}"
   ) {
-    issues.push("desktop call must consume non-empty verified npm job outputs");
+    issues.push("desktop call must consume frozen version authorities and verified npm outputs");
   }
 
   const packageOnlyText = scalar(packageOnly);
@@ -360,9 +363,12 @@ export function inspectDesktopReleaseWorkflows(
   const parseOutputs = mapping(parseTag.outputs, "parse-tag outputs", issues);
   if (
     parseOutputs.desktop_enabled !== "${{ steps.parse.outputs.desktop_enabled }}" ||
+    parseOutputs.desktop_version !== "${{ steps.parse.outputs.desktop_version }}" ||
+    !releaseSource.includes('git show "$COMMIT:apps/desktop/package.json"') ||
+    !releaseSource.includes('echo "desktop_version=$DESKTOP_VERSION" >> "$GITHUB_OUTPUT"') ||
     (releaseSource.match(/vars\.ENABLE_DESKTOP_MACOS_RELEASE/gu) ?? []).length !== 1
   ) {
-    issues.push("desktop opt-in must be read once and frozen by parse-tag");
+    issues.push("desktop opt-in and version authority must be read once and frozen by parse-tag");
   }
 
   const desktopJobs = mapping(desktop.jobs, "desktop.jobs", issues);
@@ -569,7 +575,10 @@ export function inspectDesktopReleaseWorkflows(
     !signingRun.includes("genesis)") ||
     !signingRun.includes("steady)") ||
     signingEnvironment.RELEASE_MODE !== "${{ inputs.mode }}" ||
-    signingEnvironment.ENDURAGENT_MACOS_GENESIS_VERSION !== "${{ inputs.version }}" ||
+    signingEnvironment.ENDURAGENT_MACOS_GENESIS_VERSION !== "${{ inputs.desktop_version }}" ||
+    !desktopSource.includes('--npm-version "$NPM_VERSION"') ||
+    !desktopSource.includes('--desktop-version "$DESKTOP_VERSION"') ||
+    !desktopSource.includes('--candidate-tag "$RELEASE_TAG"') ||
     nonSigningDesktopText.includes("package:mac")
   ) {
     issues.push("signing must dispatch explicit genesis and steady packaging modes");

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -22,7 +22,8 @@ import {
   type DesktopReleaseMode,
 } from "./desktop-release-transaction.js";
 
-const candidateVersion = "2026.8.7";
+const candidateVersion = "0.1.7";
+const candidateNpmVersion = "2026.8.7";
 const candidateCommit = "a".repeat(40);
 const realSetImmediate = setImmediate;
 
@@ -81,9 +82,11 @@ async function sealed(
   directories.push(directory);
   writeEnvelope(directory, version);
   const baselineZip = baseline?.manifest.files.find((file) => file.name.endsWith("-arm64.zip"));
+  const npmVersion = `2026.8.${version.split(".")[2]}`;
   const manifest = await sealDesktopRelease(directory, {
-    tag: `cycling-coach@${version}`,
-    version,
+    tag: `cycling-coach@${npmVersion}`,
+    npmVersion,
+    desktopVersion: version,
     commit: version === candidateVersion ? candidateCommit : "b".repeat(40),
     draftId,
     mode,
@@ -91,7 +94,7 @@ async function sealed(
     workflowRunAttempt: "1",
     draftBodySha256: digest(Buffer.from("release body"), "sha256", "hex"),
     npmIntegrity: `sha512-${Buffer.alloc(64, 1).toString("base64")}`,
-    npmAttestationUrl: `https://registry.npmjs.org/-/npm/v1/attestations/cycling-coach@${version}`,
+    npmAttestationUrl: `https://registry.npmjs.org/-/npm/v1/attestations/cycling-coach@${npmVersion}`,
     signingIdentity: "Developer ID Application: Example (FA494ACVTF)",
     candidateCdHash: "d".repeat(40),
     candidateCodeDirectorySha256: "e".repeat(64),
@@ -126,7 +129,7 @@ class FakeGithub {
     this.resolveAnonymousDownloadFailure = resolveFailure;
   });
 
-  constructor(tag = `cycling-coach@${candidateVersion}`, commit = candidateCommit) {
+  constructor(tag = `cycling-coach@${candidateNpmVersion}`, commit = candidateCommit) {
     this.candidate = this.release(123, tag, true);
     this.commits.set(tag, commit);
   }
@@ -143,8 +146,8 @@ class FakeGithub {
     };
   }
 
-  addEnvelope(release: FakeRelease, directory: string): void {
-    for (const name of releaseFileNames(release.tag_name.split("@")[1])) {
+  addEnvelope(release: FakeRelease, directory: string, version: string): void {
+    for (const name of releaseFileNames(version)) {
       this.addAsset(release, name, readFileSync(join(directory, name)));
     }
   }
@@ -267,10 +270,11 @@ async function genesisCandidate(fake: FakeGithub) {
 }
 
 async function steadyCandidate(fake: FakeGithub) {
-  const genesis = await sealed("2026.8.6", "122", "genesis");
-  const baseline = fake.release(122, "cycling-coach@2026.8.6", true);
+  const genesis = await sealed("0.1.6", "122", "genesis");
+  const baseline = fake.release(122, "cycling-coach@2026.8.6", false);
   fake.commits.set(baseline.tag_name, genesis.manifest.commit);
-  fake.addEnvelope(baseline, genesis.directory);
+  fake.addEnvelope(baseline, genesis.directory, "0.1.6");
+  fake.latest = baseline;
   fake.pages = [[baseline]];
   const candidate = await sealed(candidateVersion, "123", "steady", {
     release: baseline,
@@ -420,7 +424,7 @@ describe("GitHub desktop release transaction", () => {
     const observed = await observeDesktopLatest(directory, fake.client());
     await publishDesktopRelease(directory, fake.client(), observed);
     expect(fake.candidate.draft).toBe(false);
-    expect(fake.latest).toBeNull();
+    expect(fake.latest?.id).toBe(122);
     expect(fake.candidate.body).toBe(DESKTOP_PROVISIONAL_RELEASE_BODY);
     const anonymousDownloads = fake.calls.filter((call) =>
       call.url.includes("/releases/download/"),
@@ -485,7 +489,7 @@ describe("GitHub desktop release transaction", () => {
     expect(failed.candidate.body).toBe("release body");
   });
 
-  it("discovers a complete retained draft baseline on a later page", async () => {
+  it("discovers a complete retained baseline on a later page", async () => {
     const fake = new FakeGithub();
     const { baseline } = await steadyCandidate(fake);
     fake.pages = [
@@ -503,23 +507,24 @@ describe("GitHub desktop release transaction", () => {
       target,
       fake.client(),
       "steady",
+      `cycling-coach@${candidateNpmVersion}`,
       candidateVersion,
       baseline.tag_name,
       output,
     );
     expect(readFileSync(output, "utf8")).toContain("baseline_release_id=122");
-    expect(readFileSync(output, "utf8")).toContain("baseline_version=2026.8.6");
-    expect(readdirSync(target).sort()).toEqual([...releaseFileNames("2026.8.6")].sort());
+    expect(readFileSync(output, "utf8")).toContain("baseline_version=0.1.6");
+    expect(readdirSync(target).sort()).toEqual([...releaseFileNames("0.1.6")].sort());
     expect(fake.calls.some((call) => call.url.includes("page=2"))).toBe(true);
   });
 
   it("uses the requested retained baseline instead of a newer failed draft", async () => {
     const fake = new FakeGithub();
     const { baseline } = await steadyCandidate(fake);
-    const failed = await sealed("2026.8.8", "124", "genesis");
+    const failed = await sealed("0.1.8", "124", "genesis");
     const failedRelease = fake.release(124, "cycling-coach@2026.8.8", true);
     fake.commits.set(failedRelease.tag_name, failed.manifest.commit);
-    fake.addEnvelope(failedRelease, failed.directory);
+    fake.addEnvelope(failedRelease, failed.directory, "0.1.8");
     fake.pages = [[failedRelease, baseline]];
     const outputDirectory = mkdtempSync(join(tmpdir(), "desktop-baseline-output-"));
     const target = mkdtempSync(join(tmpdir(), "desktop-baseline-target-"));
@@ -531,7 +536,8 @@ describe("GitHub desktop release transaction", () => {
       target,
       fake.client(),
       "steady",
-      "2026.8.9",
+      "cycling-coach@2026.8.9",
+      "0.1.9",
       baseline.tag_name,
       output,
     );
@@ -543,10 +549,10 @@ describe("GitHub desktop release transaction", () => {
   it("requires N+1 latest instead of reusing N as the N+2 baseline", async () => {
     const fake = new FakeGithub();
     const { baseline } = await steadyCandidate(fake);
-    const accepted = await sealed("2026.8.7", "124", "genesis");
+    const accepted = await sealed("0.1.7", "124", "genesis");
     const latest = fake.release(124, "cycling-coach@2026.8.7", false);
     fake.commits.set(latest.tag_name, accepted.manifest.commit);
-    fake.addEnvelope(latest, accepted.directory);
+    fake.addEnvelope(latest, accepted.directory, "0.1.7");
     fake.latest = latest;
     fake.pages = [[latest, baseline]];
     const outputDirectory = mkdtempSync(join(tmpdir(), "desktop-baseline-output-"));
@@ -559,7 +565,8 @@ describe("GitHub desktop release transaction", () => {
         target,
         fake.client(),
         "steady",
-        "2026.8.8",
+        "cycling-coach@2026.8.8",
+        "0.1.8",
         baseline.tag_name,
         output,
       ),
@@ -570,7 +577,7 @@ describe("GitHub desktop release transaction", () => {
     const fake = new FakeGithub();
     const { directory, baseline } = await steadyCandidate(fake);
     fake.candidate.draft = false;
-    fake.addEnvelope(fake.candidate, directory);
+    fake.addEnvelope(fake.candidate, directory, candidateVersion);
     baseline.draft = false;
     fake.latest = baseline;
     const metadata = baseline.assets.find((asset) => asset.name === "latest-mac.yml")!;

--- a/tools/desktop-release-transaction.test.ts
+++ b/tools/desktop-release-transaction.test.ts
@@ -29,10 +29,12 @@ import {
   verifyDesktopRelease,
 } from "./desktop-release-transaction.js";
 
-const version = "2026.8.7";
+const npmVersion = "2026.8.7";
+const desktopVersion = "0.1.7";
 const binding = {
-  tag: `cycling-coach@${version}`,
-  version,
+  tag: `cycling-coach@${npmVersion}`,
+  npmVersion,
+  desktopVersion,
   commit: "a".repeat(40),
   draftId: "123",
   mode: "steady" as const,
@@ -40,7 +42,7 @@ const binding = {
   workflowRunAttempt: "1",
   draftBodySha256: "b".repeat(64),
   npmIntegrity: `sha512-${Buffer.alloc(64, 1).toString("base64")}`,
-  npmAttestationUrl: `https://registry.npmjs.org/-/npm/v1/attestations/cycling-coach@${version}`,
+  npmAttestationUrl: `https://registry.npmjs.org/-/npm/v1/attestations/cycling-coach@${npmVersion}`,
   signingIdentity: "Developer ID Application: Example (FA494ACVTF)",
   candidateCdHash: "c".repeat(40),
   candidateCodeDirectorySha256: "d".repeat(64),
@@ -59,7 +61,7 @@ function sha512(bytes: Uint8Array): string {
 }
 
 function writeEnvelope(extra?: string): void {
-  const [dmgName, zipName, blockmapName] = releaseFileNames(version);
+  const [dmgName, zipName, blockmapName] = releaseFileNames(desktopVersion);
   const dmg = Buffer.from("signed-dmg");
   const zip = Buffer.from("signed-zip");
   writeFileSync(join(directory, dmgName), dmg);
@@ -68,7 +70,7 @@ function writeEnvelope(extra?: string): void {
   writeFileSync(
     join(directory, "latest-mac.yml"),
     stringify({
-      version,
+      version: desktopVersion,
       files: [
         { url: zipName, sha512: sha512(zip), size: zip.length },
         { url: dmgName, sha512: sha512(dmg), size: dmg.length },
@@ -91,12 +93,12 @@ describe("advertised npm attestation claims", () => {
   const integrity = `sha512-${integrityBytes.toString("base64")}`;
   const expectation = {
     name: "cycling-coach",
-    version,
+    version: npmVersion,
     integrity,
     repository: "https://github.com/yerzhansa/enduragent",
     workflow: ".github/workflows/release.yml",
-    ref: `refs/tags/cycling-coach@${version}`,
-    releaseTag: `cycling-coach@${version}`,
+    ref: `refs/tags/cycling-coach@${npmVersion}`,
+    releaseTag: `cycling-coach@${npmVersion}`,
     commit: "a".repeat(40),
     invocationId: "https://github.com/yerzhansa/enduragent/actions/runs/456/attempts/1",
     eventName: "push",
@@ -112,7 +114,7 @@ describe("advertised npm attestation claims", () => {
           : "https://in-toto.io/Statement/v0.1",
       subject: [
         {
-          name: `pkg:npm/cycling-coach@${version}`,
+          name: `pkg:npm/cycling-coach@${npmVersion}`,
           digest: { sha512: integrityBytes.toString("hex") },
         },
       ],
@@ -297,7 +299,12 @@ describe("desktop release envelope", () => {
       ).schemaVersion,
     ).toBe(DESKTOP_RELEASE_SCHEMA_VERSION);
     expect(manifest.feedUrl).toBe(DESKTOP_FEED_URL);
-    expect(manifest.files.map((file) => file.name)).toEqual(releaseFileNames(version));
+    expect(manifest).toMatchObject({
+      tag: `cycling-coach@${npmVersion}`,
+      npmVersion,
+      desktopVersion,
+    });
+    expect(manifest.files.map((file) => file.name)).toEqual(releaseFileNames(desktopVersion));
     expect(manifest.files.at(-1)?.name).toBe("latest-mac.yml");
     await expect(verifyDesktopRelease(directory, binding)).resolves.toEqual(manifest);
   });
@@ -309,7 +316,7 @@ describe("desktop release envelope", () => {
     const output = join(parent, "public");
     try {
       await expect(materializeDesktopPublicEnvelope(directory, output)).resolves.toEqual(manifest);
-      expect(readdirSync(output).sort()).toEqual([...releaseFileNames(version)].sort());
+      expect(readdirSync(output).sort()).toEqual([...releaseFileNames(desktopVersion)].sort());
       expect(readdirSync(output)).not.toContain(DESKTOP_MANIFEST);
       for (const file of manifest.files) {
         expect(lstatSync(join(output, file.name)).ino).toBe(
@@ -359,7 +366,7 @@ describe("desktop release envelope", () => {
 
     rmSync(join(directory, "old-latest.yml"));
     await sealDesktopRelease(directory, binding);
-    writeFileSync(join(directory, releaseFileNames(version)[1]), "conflict");
+    writeFileSync(join(directory, releaseFileNames(desktopVersion)[1]), "conflict");
     await expect(verifyDesktopRelease(directory, binding)).rejects.toThrow("digest mismatch");
   });
 
@@ -420,31 +427,31 @@ describe("desktop release publication guards", () => {
   });
 
   it("refuses genesis after a baseline and steady mode without one", () => {
-    expect(() => assertReleaseMode("genesis", "2026.8.6")).toThrow("genesis");
+    expect(() => assertReleaseMode("genesis", "0.1.6")).toThrow("genesis");
     expect(() => assertReleaseMode("steady", null)).toThrow("baseline");
     expect(() => assertReleaseMode("genesis", null)).not.toThrow();
-    expect(() => assertReleaseMode("steady", "2026.8.6")).not.toThrow();
+    expect(() => assertReleaseMode("steady", "0.1.6")).not.toThrow();
   });
 
   it("requires an unchanged latest observation and monotonic desktop version", () => {
     const observed = { id: 12, tag: "cycling-coach@2026.8.6", metadataSha256: "e".repeat(64) };
-    expect(() => assertLatestCas(version, observed, observed, "2026.8.6")).not.toThrow();
+    expect(() => assertLatestCas(desktopVersion, observed, observed, "0.1.6")).not.toThrow();
     expect(() =>
       assertLatestCas(
-        version,
+        desktopVersion,
         observed,
         { id: 13, tag: "running-coach@2026.8.7", metadataSha256: null },
-        "2026.8.6",
+        "0.1.6",
       ),
     ).toThrow("changed");
     expect(() =>
       assertLatestCas(
-        version,
+        desktopVersion,
         observed,
         { ...observed, metadataSha256: "f".repeat(64) },
-        "2026.8.6",
+        "0.1.6",
       ),
     ).toThrow("changed");
-    expect(() => assertLatestCas(version, observed, observed, "2026.8.8")).toThrow("monotonic");
+    expect(() => assertLatestCas(desktopVersion, observed, observed, "0.1.8")).toThrow("monotonic");
   });
 });

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 
 export const DESKTOP_FEED_URL = "https://github.com/yerzhansa/enduragent/releases/latest/download/";
 export const DESKTOP_MANIFEST = "desktop-release-manifest.json";
-export const DESKTOP_RELEASE_SCHEMA_VERSION = 1 as const;
+export const DESKTOP_RELEASE_SCHEMA_VERSION = 2 as const;
 export const DESKTOP_PROVISIONAL_RELEASE_BODY =
   "Desktop update validation is in progress. This release is not yet generally available.";
 
@@ -30,7 +30,8 @@ const DesktopReleaseManifestSchema = z
   .object({
     schemaVersion: z.literal(DESKTOP_RELEASE_SCHEMA_VERSION),
     tag: z.string(),
-    version: z.string(),
+    npmVersion: z.string(),
+    desktopVersion: z.string(),
     commit: z.string(),
     draftId: z.string(),
     mode: z.enum(["steady", "genesis"]),
@@ -116,7 +117,8 @@ export type NpmProvenanceBundleVerifier = (
   identity: NpmProvenanceIdentity,
 ) => Promise<void>;
 
-const versionPattern = /^([1-9]\d{3})\.([1-9]|1[0-2])\.(0|[1-9]\d*)$/u;
+const desktopVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/u;
+const npmVersionPattern = /^([1-9]\d{3})\.([1-9]|1[0-2])\.(0|[1-9]\d*)$/u;
 const commitPattern = /^[0-9a-f]{40}$/u;
 const signingIdentityPattern = /^Developer ID Application: .+ \(FA494ACVTF\)$/u;
 const releasePropagationAttempts = 30;
@@ -132,9 +134,19 @@ function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boo
   return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
 }
 
-export function requireVersion(value: unknown): string {
-  if (typeof value !== "string" || !versionPattern.test(value)) {
+export function requireDesktopVersion(value: unknown): string {
+  if (typeof value !== "string" || !desktopVersionPattern.test(value)) {
     throw new TypeError("desktop release version is invalid");
+  }
+  if (value.split(".").some((part) => !Number.isSafeInteger(Number(part)))) {
+    throw new TypeError("desktop release version is invalid");
+  }
+  return value;
+}
+
+export function requireNpmVersion(value: unknown): string {
+  if (typeof value !== "string" || !npmVersionPattern.test(value)) {
+    throw new TypeError("npm release version is invalid");
   }
   return value;
 }
@@ -147,14 +159,15 @@ export function requireMode(value: unknown): DesktopReleaseMode {
 }
 
 export function releaseFileNames(version: string): readonly [string, string, string, string] {
-  const stableVersion = requireVersion(version);
+  const stableVersion = requireDesktopVersion(version);
   const base = `Enduragent-${stableVersion}-arm64`;
   return [`${base}.dmg`, `${base}.zip`, `${base}.zip.blockmap`, "latest-mac.yml"];
 }
 
 function requireBinding(input: {
   tag: unknown;
-  version: unknown;
+  npmVersion: unknown;
+  desktopVersion: unknown;
   commit: unknown;
   draftId: unknown;
   mode: unknown;
@@ -173,9 +186,10 @@ function requireBinding(input: {
   baselineSigningIdentity?: unknown;
   baselineCdHash?: unknown;
 }): Omit<DesktopReleaseManifest, "schemaVersion" | "feedUrl" | "files" | "transactionSha256"> {
-  const version = requireVersion(input.version);
-  const tag = `cycling-coach@${version}`;
-  if (input.tag !== tag) throw new TypeError("desktop release tag and version do not match");
+  const npmVersion = requireNpmVersion(input.npmVersion);
+  const desktopVersion = requireDesktopVersion(input.desktopVersion);
+  const tag = `cycling-coach@${npmVersion}`;
+  if (input.tag !== tag) throw new TypeError("npm release tag and version do not match");
   if (typeof input.commit !== "string" || !commitPattern.test(input.commit)) {
     throw new TypeError("desktop release commit is invalid");
   }
@@ -204,7 +218,7 @@ function requireBinding(input: {
   if (
     typeof input.npmAttestationUrl !== "string" ||
     input.npmAttestationUrl !==
-      `https://registry.npmjs.org/-/npm/v1/attestations/cycling-coach@${version}`
+      `https://registry.npmjs.org/-/npm/v1/attestations/cycling-coach@${npmVersion}`
   )
     throw new TypeError("npm attestation URL is invalid");
   if (
@@ -243,7 +257,8 @@ function requireBinding(input: {
     throw new TypeError("steady baseline evidence is invalid");
   return {
     tag,
-    version,
+    npmVersion,
+    desktopVersion,
     commit: input.commit,
     draftId: input.draftId,
     mode,
@@ -489,14 +504,14 @@ export async function sealDesktopRelease(
   bindingInput: Parameters<typeof requireBinding>[0],
 ): Promise<DesktopReleaseManifest> {
   const binding = requireBinding(bindingInput);
-  const expected = releaseFileNames(binding.version);
+  const expected = releaseFileNames(binding.desktopVersion);
   const entries = (await readdir(directory)).sort();
   if (entries.length !== expected.length || expected.some((name) => !entries.includes(name))) {
     throw new TypeError("release envelope must contain exactly four updater files before sealing");
   }
   const snapshots = new Map<string, { bytes: Buffer; size: number }>();
   for (const name of expected) snapshots.set(name, await stableFile(resolve(directory, name)));
-  requireMetadata(snapshots.get(expected[3])!.bytes, binding.version, snapshots);
+  requireMetadata(snapshots.get(expected[3])!.bytes, binding.desktopVersion, snapshots);
   const files = expected.map((name) => {
     const snapshot = snapshots.get(name)!;
     return {
@@ -532,7 +547,8 @@ function parseManifest(value: unknown): DesktopReleaseManifest {
   }
   const binding = requireBinding({
     tag: manifest.tag,
-    version: manifest.version,
+    npmVersion: manifest.npmVersion,
+    desktopVersion: manifest.desktopVersion,
     commit: manifest.commit,
     draftId: manifest.draftId,
     mode: manifest.mode,
@@ -551,7 +567,7 @@ function parseManifest(value: unknown): DesktopReleaseManifest {
     baselineSigningIdentity: manifest.baselineSigningIdentity,
     baselineCdHash: manifest.baselineCdHash,
   });
-  const expected = releaseFileNames(binding.version);
+  const expected = releaseFileNames(binding.desktopVersion);
   if (manifest.files.length !== expected.length)
     throw new TypeError("desktop release manifest file set is invalid");
   for (const [index, file] of manifest.files.entries()) {
@@ -580,7 +596,7 @@ export async function verifyDesktopRelease(
     throw new TypeError("desktop release manifest is invalid JSON");
   }
   const manifest = parseManifest(decoded);
-  const expectedNames = [...releaseFileNames(manifest.version), DESKTOP_MANIFEST].sort();
+  const expectedNames = [...releaseFileNames(manifest.desktopVersion), DESKTOP_MANIFEST].sort();
   if (
     names.length !== expectedNames.length ||
     names.some((name, index) => name !== expectedNames[index])
@@ -591,7 +607,8 @@ export async function verifyDesktopRelease(
     const expected = requireBinding(expectedBinding);
     for (const key of [
       "tag",
-      "version",
+      "npmVersion",
+      "desktopVersion",
       "commit",
       "draftId",
       "mode",
@@ -626,7 +643,7 @@ export async function verifyDesktopRelease(
     }
     snapshots.set(file.name, snapshot);
   }
-  requireMetadata(snapshots.get("latest-mac.yml")!.bytes, manifest.version, snapshots);
+  requireMetadata(snapshots.get("latest-mac.yml")!.bytes, manifest.desktopVersion, snapshots);
   return manifest;
 }
 
@@ -658,7 +675,7 @@ export async function materializeDesktopPublicEnvelope(
     }
   }
   const names = (await readdir(target)).sort();
-  const expected = [...releaseFileNames(manifest.version)].sort();
+  const expected = [...releaseFileNames(manifest.desktopVersion)].sort();
   if (names.length !== expected.length || names.some((name, index) => name !== expected[index])) {
     throw new TypeError("public envelope must contain exactly four updater files");
   }
@@ -699,7 +716,7 @@ async function assertResolvedBaseline(
   const baselineZipBytes = baselineZipAsset ? await client.bytes(baselineZipAsset.url) : null;
   if (
     !baseline ||
-    compareVersions(baseline.version, manifest.version) >= 0 ||
+    compareVersions(baseline.version, manifest.desktopVersion) >= 0 ||
     manifest.baselineTag !== baseline.release.tag_name ||
     manifest.baselineReleaseId !== String(baseline.release.id) ||
     manifest.baselineCommit !== baseline.commit ||
@@ -719,8 +736,8 @@ export function assertRemoteAsset(file: DesktopReleaseFile, bytes: Uint8Array): 
 }
 
 export function compareVersions(left: string, right: string): number {
-  const a = requireVersion(left).split(".").map(Number);
-  const b = requireVersion(right).split(".").map(Number);
+  const a = requireDesktopVersion(left).split(".").map(Number);
+  const b = requireDesktopVersion(right).split(".").map(Number);
   for (let index = 0; index < 3; index += 1) {
     if (a[index] !== b[index]) return a[index] < b[index] ? -1 : 1;
   }
@@ -987,14 +1004,20 @@ export class GithubClient {
 }
 
 function desktopReleaseVersion(release: GithubRelease, excludingTag?: string): string | null {
-  if (release.prerelease || release.tag_name === excludingTag) return null;
-  const match = /^cycling-coach@(.+)$/u.exec(release.tag_name);
-  if (!match || !versionPattern.test(match[1])) return null;
-  const expected = [...releaseFileNames(match[1])].sort();
+  if (release.draft || release.prerelease || release.tag_name === excludingTag) return null;
+  const tag = /^cycling-coach@(.+)$/u.exec(release.tag_name);
+  if (!tag || !npmVersionPattern.test(tag[1])) return null;
+  const versions = release.assets.flatMap((asset) => {
+    const match = /^Enduragent-(\d+\.\d+\.\d+)-arm64\.dmg$/u.exec(asset.name);
+    return match ? [match[1]] : [];
+  });
+  if (versions.length !== 1 || !desktopVersionPattern.test(versions[0])) return null;
+  const version = versions[0];
+  const expected = [...releaseFileNames(version)].sort();
   const actual = release.assets.map((asset) => asset.name).sort();
   return actual.length === expected.length &&
     actual.every((name, index) => name === expected[index])
-    ? match[1]
+    ? version
     : null;
 }
 
@@ -1170,7 +1193,7 @@ export async function publishDesktopRelease(
     throw new TypeError("desktop publication requires a bound latest observation");
   }
   assertLatestCas(
-    manifest.version,
+    manifest.desktopVersion,
     observedLatest,
     await client.latest(),
     baseline?.version ?? null,
@@ -1200,7 +1223,7 @@ export async function publishDesktopRelease(
     await waitForAnonymousAsset(client, asset.browser_download_url, file);
   }
   assertLatestCas(
-    manifest.version,
+    manifest.desktopVersion,
     observedLatest,
     await client.latest(),
     baseline?.version ?? null,
@@ -1253,14 +1276,19 @@ export async function promoteDesktopLatest(
     throw new TypeError("published tag commit binding mismatch");
   const current = await client.latest();
   const previous = await newestDesktopRelease(await client.releases(), client, manifest.tag);
-  assertLatestCas(manifest.version, observed, current, previous?.version ?? null);
+  assertLatestCas(manifest.desktopVersion, observed, current, previous?.version ?? null);
   for (const file of manifest.files) {
     const asset = candidate.assets.find((candidateAsset) => candidateAsset.name === file.name);
     if (!asset || asset.state !== "uploaded")
       throw new TypeError(`promotion candidate asset is missing: ${file.name}`);
     await waitForAnonymousAsset(client, asset.browser_download_url, file);
   }
-  assertLatestCas(manifest.version, observed, await client.latest(), previous?.version ?? null);
+  assertLatestCas(
+    manifest.desktopVersion,
+    observed,
+    await client.latest(),
+    previous?.version ?? null,
+  );
   await client.request(`/repos/${client.repository()}/releases/${candidate.id}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
@@ -1498,14 +1526,18 @@ export async function prepareDesktopBaseline(
   directory: string,
   client: GithubClient,
   mode: DesktopReleaseMode,
+  candidateTag: string,
   candidateVersion: string,
   requestedBaselineTag: string,
   output: string,
 ): Promise<void> {
-  const version = requireVersion(candidateVersion);
+  if (!/^cycling-coach@([1-9]\d{3})\.([1-9]|1[0-2])\.(0|[1-9]\d*)$/u.test(candidateTag)) {
+    throw new TypeError("candidate npm release tag is invalid");
+  }
+  const version = requireDesktopVersion(candidateVersion);
   const releases = await client.releases();
   if (mode === "genesis") {
-    const baseline = await newestDesktopRelease(releases, client, `cycling-coach@${version}`);
+    const baseline = await newestDesktopRelease(releases, client, candidateTag);
     if (baseline !== null)
       throw new TypeError("genesis release refused after a desktop baseline exists");
     await writeFile(
@@ -1554,7 +1586,8 @@ function argument(name: string): string {
 function bindingArguments(): Parameters<typeof requireBinding>[0] {
   return {
     tag: argument("tag"),
-    version: argument("version"),
+    npmVersion: argument("npm-version"),
+    desktopVersion: argument("desktop-version"),
     commit: argument("commit"),
     draftId: argument("draft-id"),
     mode: argument("mode"),
@@ -1618,7 +1651,7 @@ async function main(): Promise<void> {
       metadata,
       {
         name: argument("name"),
-        version: requireVersion(argument("version")),
+        version: requireNpmVersion(argument("version")),
         integrity: argument("integrity"),
         repository: argument("repository"),
         workflow: argument("workflow"),
@@ -1662,7 +1695,8 @@ async function main(): Promise<void> {
       directory,
       client,
       requireMode(argument("mode")),
-      requireVersion(argument("candidate-version")),
+      argument("candidate-tag"),
+      requireDesktopVersion(argument("candidate-version")),
       argument("baseline-tag"),
       argument("github-output"),
     );


### PR DESCRIPTION
## Summary

- keep the published npm package on its existing calendar-version sequence
- make `apps/desktop/package.json` the independent desktop SemVer authority, starting at `0.1.0`
- bind signed artifacts, updater metadata, baselines, and runtime comparisons to desktop SemVer while preserving npm tag and provenance bindings

## Validation

- `pnpm check` with Node 24
- 351 focused desktop release and updater tests
- TypeScript project check
- desktop release workflow policy check
- targeted formatting and `git diff --check`