### PR TITLE
fix(ci): prepare workspace for desktop signing

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -33,6 +33,17 @@ on:
       baseline_tag:
         required: true
         type: string
+    secrets:
+      CSC_LINK:
+        required: false
+      CSC_KEY_PASSWORD:
+        required: false
+      APPLE_API_KEY_ID:
+        required: false
+      APPLE_API_ISSUER:
+        required: false
+      APPLE_API_KEY_P8_BASE64:
+        required: false
 permissions:
   actions: read
   contents: read
@@ -78,6 +89,7 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm -r build
       - name: Refuse invalid release mode
         if: ${{ inputs.mode != 'steady' && inputs.mode != 'genesis' }}
         run: exit 1
@@ -133,6 +145,12 @@ jobs:
         run: |
           set -euo pipefail
           umask 077
+          for secret_name in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_API_KEY_P8_BASE64; do
+            if [ -z "${!secret_name:-}" ]; then
+              echo "::error::Required desktop signing secret $secret_name is unavailable"
+              exit 1
+            fi
+          done
           printf '%s' "$APPLE_API_KEY_P8_BASE64" | base64 -D > "$APPLE_API_KEY"
           chmod 600 "$APPLE_API_KEY"
           case "$RELEASE_MODE" in

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -74,6 +74,35 @@ describe("desktop release workflow policy", () => {
     expect(issues.some((issue) => issue.includes("escaped the signing job"))).toBe(true);
   });
 
+  it("requires workspace dependencies before macOS packaging", () => {
+    const source = sources();
+    const desktop = source.desktop.replace("      - run: pnpm -r build\n", "");
+    expect(
+      inspect(source.release, desktop).some((issue) =>
+        issue.includes("build workspace dependencies before packaging"),
+      ),
+    ).toBe(true);
+  });
+
+  it("requires declared and available signing environment secrets", () => {
+    const source = sources();
+    const undeclared = source.desktop.replace("      CSC_LINK:\n", "      UNUSED_LINK:\n");
+    const unchecked = source.desktop.replace(
+      "for secret_name in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_API_KEY_P8_BASE64; do",
+      "for secret_name in CSC_LINK; do",
+    );
+    expect(
+      inspect(source.release, undeclared).some((issue) =>
+        issue.includes("declare environment secret CSC_LINK"),
+      ),
+    ).toBe(true);
+    expect(
+      inspect(source.release, unchecked).some((issue) =>
+        issue.includes("fail closed when an environment secret is unavailable"),
+      ),
+    ).toBe(true);
+  });
+
   it("rejects reordered jobs and draft semantics on the default package-only path", () => {
     const source = sources();
     const desktop = source.desktop.replace("needs: sign-macos", "needs: promote-latest");

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -123,11 +123,8 @@ export function inspectDesktopReleaseWorkflows(
   const desktopOn = mapping(desktop.on, "desktop.on", issues);
   if (Object.keys(desktopOn).length !== 1 || !("workflow_call" in desktopOn))
     issues.push("desktop-release.yml must be workflow_call-only");
-  const inputs = mapping(
-    mapping(desktopOn.workflow_call, "desktop.workflow_call", issues).inputs,
-    "desktop.workflow_call.inputs",
-    issues,
-  );
+  const workflowCall = mapping(desktopOn.workflow_call, "desktop.workflow_call", issues);
+  const inputs = mapping(workflowCall.inputs, "desktop.workflow_call.inputs", issues);
   for (const input of [
     "tag",
     "npm_version",
@@ -141,6 +138,27 @@ export function inspectDesktopReleaseWorkflows(
     "baseline_tag",
   ]) {
     if (!(input in inputs)) issues.push(`desktop workflow_call is missing ${input}`);
+  }
+  const workflowCallSecrets = mapping(
+    workflowCall.secrets,
+    "desktop.workflow_call.secrets",
+    issues,
+  );
+  const requiredSigningSecrets = [
+    "CSC_LINK",
+    "CSC_KEY_PASSWORD",
+    "APPLE_API_KEY_ID",
+    "APPLE_API_ISSUER",
+    "APPLE_API_KEY_P8_BASE64",
+  ];
+  for (const secret of requiredSigningSecrets) {
+    const declaration = mapping(
+      workflowCallSecrets[secret],
+      `desktop.workflow_call.secrets.${secret}`,
+      issues,
+    );
+    if (declaration.required !== false)
+      issues.push(`desktop workflow_call must declare environment secret ${secret}`);
   }
 
   requireQueue(release.concurrency, "stable-desktop-coordinator", "release coordinator", issues);
@@ -558,6 +576,11 @@ export function inspectDesktopReleaseWorkflows(
   }
   const signingSteps = steps(sign);
   const signingStep = namedStep(sign, "Build signed and notarized macOS envelope");
+  const signingInstallIndex = signingSteps.findIndex(
+    (step) => step.run === "pnpm install --frozen-lockfile",
+  );
+  const signingWorkspaceBuildIndex = signingSteps.findIndex((step) => step.run === "pnpm -r build");
+  const signingPackageIndex = signingSteps.indexOf(signingStep ?? {});
   const signingEnvironment = mapping(signingStep?.env, "macOS signing step environment", issues);
   const signingRun = typeof signingStep?.run === "string" ? signingStep.run : "";
   const keyCleanupStep = namedStep(sign, "Remove temporary notarization key");
@@ -566,6 +589,20 @@ export function inspectDesktopReleaseWorkflows(
     'printf \'%s\' "$APPLE_API_KEY_P8_BASE64" | base64 -D > "$APPLE_API_KEY"',
   );
   const privateUmask = signingRun.indexOf("umask 077");
+  if (
+    signingInstallIndex === -1 ||
+    signingWorkspaceBuildIndex <= signingInstallIndex ||
+    signingWorkspaceBuildIndex >= signingPackageIndex
+  ) {
+    issues.push("macOS signing must build workspace dependencies before packaging");
+  }
+  if (
+    countShellLine(signingRun, `for secret_name in ${requiredSigningSecrets.join(" ")}; do`) !==
+      1 ||
+    !signingRun.includes("Required desktop signing secret $secret_name is unavailable")
+  ) {
+    issues.push("macOS signing must fail closed when an environment secret is unavailable");
+  }
   if (
     (signingRun.match(/pnpm --filter @enduragent\/desktop package:mac:genesis(?:\s|$)/gu) ?? [])
       .length !== 1 ||


### PR DESCRIPTION
Summary:
- build workspace dependencies on the fresh macOS runner before desktop packaging
- declare signing environment secrets for the reusable workflow and fail closed when unavailable
- enforce both invariants with release-policy regression tests

Validation:
- pnpm exec vitest run tools/check-desktop-release-workflow.test.ts
- pnpm check
- git diff --check