### PR TITLE
fix(ci): bind desktop signing to direct workflow

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,49 +1,57 @@
 name: Desktop release
+run-name: Desktop release ${{ inputs.tag }} via ${{ inputs.coordinator_run_id }}.${{ inputs.coordinator_run_attempt }}
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       tag:
+        description: Exact cycling-coach release tag
         required: true
         type: string
       npm_version:
+        description: Frozen npm package version
         required: true
         type: string
       desktop_version:
+        description: Frozen desktop SemVer
         required: true
         type: string
       commit:
+        description: Exact tagged source commit
         required: true
         type: string
       draft_id:
+        description: Bound unpublished GitHub Release id
         required: true
         type: string
       mode:
+        description: Desktop continuity mode
         required: true
         type: string
       draft_body_sha256:
+        description: Bound draft release-notes digest
         required: true
         type: string
       npm_integrity:
+        description: Verified public npm integrity
         required: true
         type: string
       npm_attestation_url:
+        description: Verified public npm provenance URL
         required: true
         type: string
       baseline_tag:
+        description: Prior signed desktop release tag or none
         required: true
         type: string
-    secrets:
-      CSC_LINK:
-        required: false
-      CSC_KEY_PASSWORD:
-        required: false
-      APPLE_API_KEY_ID:
-        required: false
-      APPLE_API_ISSUER:
-        required: false
-      APPLE_API_KEY_P8_BASE64:
-        required: false
+      coordinator_run_id:
+        description: Parent release workflow run id
+        required: true
+        type: string
+      coordinator_run_attempt:
+        description: Parent release workflow attempt
+        required: true
+        type: string
 permissions:
   actions: read
   contents: read
@@ -54,8 +62,30 @@ concurrency:
   queue: max
 
 jobs:
+  authorize-coordinator:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Bind dispatch to the active release coordinator
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id }}
+          COORDINATOR_RUN_ATTEMPT: ${{ inputs.coordinator_run_attempt }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$COORDINATOR_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$COORDINATOR_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          COORDINATOR=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID")
+          test "$(printf '%s' "$COORDINATOR" | jq -r '.path')" = '.github/workflows/release.yml'
+          test "$(printf '%s' "$COORDINATOR" | jq -r '.run_attempt')" = "$COORDINATOR_RUN_ATTEMPT"
+          test "$(printf '%s' "$COORDINATOR" | jq -r '.status')" = 'in_progress'
+          printf '%s' "$COORDINATOR" | jq -er '.event == "push" or .event == "workflow_dispatch"' >/dev/null
+
   sign-macos:
     runs-on: macos-15
+    needs: authorize-coordinator
     environment: desktop-macos-signing
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -682,23 +682,70 @@ jobs:
           echo "body_sha256=$BODY_SHA256" >> "$GITHUB_OUTPUT"
 
   desktop-release:
+    runs-on: ubuntu-latest
     needs: [parse-tag, verify-npm-publication, prepare-release-draft]
     if: ${{ needs.parse-tag.outputs.package == 'cycling-coach' && needs.parse-tag.outputs.desktop_enabled == 'true' }}
     permissions:
-      actions: read
-      contents: write
-    uses: ./.github/workflows/desktop-release.yml
-    with:
-      tag: ${{ needs.parse-tag.outputs.ref }}
-      npm_version: ${{ needs.parse-tag.outputs.version }}
-      desktop_version: ${{ needs.parse-tag.outputs.desktop_version }}
-      commit: ${{ needs.parse-tag.outputs.commit }}
-      draft_id: ${{ needs.prepare-release-draft.outputs.draft_id }}
-      mode: ${{ needs.parse-tag.outputs.desktop_mode }}
-      draft_body_sha256: ${{ needs.prepare-release-draft.outputs.draft_body_sha256 }}
-      npm_integrity: ${{ needs.verify-npm-publication.outputs.npm_integrity }}
-      npm_attestation_url: ${{ needs.verify-npm-publication.outputs.npm_attestation_url }}
-      baseline_tag: ${{ needs.parse-tag.outputs.desktop_baseline_tag }}
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch and await environment-bound desktop transaction
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.parse-tag.outputs.ref }}
+          NPM_VERSION: ${{ needs.parse-tag.outputs.version }}
+          DESKTOP_VERSION: ${{ needs.parse-tag.outputs.desktop_version }}
+          RELEASE_COMMIT: ${{ needs.parse-tag.outputs.commit }}
+          RELEASE_DRAFT_ID: ${{ needs.prepare-release-draft.outputs.draft_id }}
+          RELEASE_MODE: ${{ needs.parse-tag.outputs.desktop_mode }}
+          RELEASE_BODY_SHA256: ${{ needs.prepare-release-draft.outputs.draft_body_sha256 }}
+          NPM_INTEGRITY: ${{ needs.verify-npm-publication.outputs.npm_integrity }}
+          NPM_ATTESTATION_URL: ${{ needs.verify-npm-publication.outputs.npm_attestation_url }}
+          RELEASE_BASELINE_TAG: ${{ needs.parse-tag.outputs.desktop_baseline_tag }}
+          COORDINATOR_RUN_ID: ${{ github.run_id }}
+          COORDINATOR_RUN_ATTEMPT: ${{ github.run_attempt }}
+          COORDINATOR_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          DESKTOP_WORKFLOW_REF=main
+          if [ "$COORDINATOR_REF" = "refs/tags/$RELEASE_TAG" ]; then
+            DESKTOP_WORKFLOW_REF="$RELEASE_TAG"
+          fi
+          EXPECTED_TITLE="Desktop release $RELEASE_TAG via $COORDINATOR_RUN_ID.$COORDINATOR_RUN_ATTEMPT"
+          gh workflow run desktop-release.yml \
+            --ref "$DESKTOP_WORKFLOW_REF" \
+            -f tag="$RELEASE_TAG" \
+            -f npm_version="$NPM_VERSION" \
+            -f desktop_version="$DESKTOP_VERSION" \
+            -f commit="$RELEASE_COMMIT" \
+            -f draft_id="$RELEASE_DRAFT_ID" \
+            -f mode="$RELEASE_MODE" \
+            -f draft_body_sha256="$RELEASE_BODY_SHA256" \
+            -f npm_integrity="$NPM_INTEGRITY" \
+            -f npm_attestation_url="$NPM_ATTESTATION_URL" \
+            -f baseline_tag="$RELEASE_BASELINE_TAG" \
+            -f coordinator_run_id="$COORDINATOR_RUN_ID" \
+            -f coordinator_run_attempt="$COORDINATOR_RUN_ATTEMPT"
+          DESKTOP_RUN_ID=''
+          for attempt in $(seq 1 12); do
+            DESKTOP_RUNS=$(gh run list \
+              --workflow desktop-release.yml \
+              --event workflow_dispatch \
+              --limit 20 \
+              --json databaseId,displayTitle)
+            DESKTOP_RUN_ID=$(printf '%s' "$DESKTOP_RUNS" | jq -r --arg title "$EXPECTED_TITLE" \
+              '[.[] | select(.displayTitle == $title)] | first | .databaseId // empty')
+            if [ -n "$DESKTOP_RUN_ID" ]; then
+              break
+            fi
+            sleep 5
+          done
+          if [ -z "$DESKTOP_RUN_ID" ]; then
+            echo '::error::Dispatched desktop workflow run could not be identified'
+            exit 1
+          fi
+          echo "::notice::Awaiting desktop workflow run $DESKTOP_RUN_ID"
+          gh run watch "$DESKTOP_RUN_ID" --interval 15 --exit-status
   publish-package-only-release:
     runs-on: ubuntu-latest
     needs: [parse-tag, verify-npm-publication]

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -24,14 +24,16 @@ function inspect(release: string, desktop: string, version = sources().version):
 }
 
 describe("desktop release workflow policy", () => {
-  it("accepts the canonical coordinator and reusable workflow", () => {
+  it("accepts the canonical coordinator and environment-bound workflow", () => {
     const source = sources();
     expect(inspect(source.release, source.desktop, source.version)).toEqual([]);
     expect(source.release).toContain("desktop_version: ${{ steps.parse.outputs.desktop_version }}");
-    expect(source.release).toContain("npm_version: ${{ needs.parse-tag.outputs.version }}");
+    expect(source.release).toContain("NPM_VERSION: ${{ needs.parse-tag.outputs.version }}");
     expect(source.release).toContain(
-      "desktop_version: ${{ needs.parse-tag.outputs.desktop_version }}",
+      "DESKTOP_VERSION: ${{ needs.parse-tag.outputs.desktop_version }}",
     );
+    expect(source.release).toContain("gh workflow run desktop-release.yml");
+    expect(source.release).toContain('gh run watch "$DESKTOP_RUN_ID" --interval 15 --exit-status');
     expect(source.desktop).toContain('--npm-version "$NPM_VERSION"');
     expect(source.desktop).toContain('--desktop-version "$DESKTOP_VERSION"');
   });
@@ -39,8 +41,8 @@ describe("desktop release workflow policy", () => {
   it("rejects coupling the desktop version back to the npm version", () => {
     const source = sources();
     const release = source.release.replace(
-      "desktop_version: ${{ needs.parse-tag.outputs.desktop_version }}",
-      "desktop_version: ${{ needs.parse-tag.outputs.version }}",
+      "DESKTOP_VERSION: ${{ needs.parse-tag.outputs.desktop_version }}",
+      "DESKTOP_VERSION: ${{ needs.parse-tag.outputs.version }}",
     );
     expect(
       inspect(release, source.desktop).some((issue) =>
@@ -84,16 +86,16 @@ describe("desktop release workflow policy", () => {
     ).toBe(true);
   });
 
-  it("requires declared and available signing environment secrets", () => {
+  it("requires a direct dispatch and available signing environment secrets", () => {
     const source = sources();
-    const undeclared = source.desktop.replace("      CSC_LINK:\n", "      UNUSED_LINK:\n");
+    const reusable = source.desktop.replace("workflow_dispatch:", "workflow_call:");
     const unchecked = source.desktop.replace(
       "for secret_name in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_API_KEY_P8_BASE64; do",
       "for secret_name in CSC_LINK; do",
     );
     expect(
-      inspect(source.release, undeclared).some((issue) =>
-        issue.includes("declare environment secret CSC_LINK"),
+      inspect(source.release, reusable).some((issue) =>
+        issue.includes("workflow_dispatch-only"),
       ),
     ).toBe(true);
     expect(
@@ -115,16 +117,16 @@ describe("desktop release workflow policy", () => {
     expect(issues.some((issue) => issue.includes("create-normal-or-leave-existing"))).toBe(true);
   });
 
-  it("rejects direct triggers and activation that bypasses native acceptance", () => {
+  it("rejects reusable triggers and activation that bypasses native acceptance", () => {
     const source = sources();
     const desktop = source.desktop
-      .replace("workflow_call:", "workflow_call:\n  workflow_dispatch:")
+      .replace("workflow_dispatch:", "workflow_call:")
       .replace(
         "needs.verify-production-update.result == 'success'",
         "needs.verify-production-update.result != 'failure'",
       );
     const issues = inspect(source.release, desktop);
-    expect(issues.some((issue) => issue.includes("workflow_call-only"))).toBe(true);
+    expect(issues.some((issue) => issue.includes("workflow_dispatch-only"))).toBe(true);
     expect(issues.some((issue) => issue.includes("mode-specific acceptance gate"))).toBe(true);
   });
 
@@ -157,15 +159,42 @@ describe("desktop release workflow policy", () => {
     }
   });
 
-  it("rejects a reusable call without a write permission ceiling", () => {
+  it("rejects a desktop dispatcher without actions write permission", () => {
     const source = sources();
     const release = source.release.replace(
-      "    permissions:\n      actions: read\n      contents: write\n    uses: ./.github/workflows/desktop-release.yml",
-      "    uses: ./.github/workflows/desktop-release.yml",
+      "    permissions:\n      actions: write\n      contents: read\n    steps:",
+      "    steps:",
     );
     expect(
       inspect(release, source.desktop).some((issue) =>
-        issue.includes("desktop reusable call permissions"),
+        issue.includes("desktop dispatcher permissions"),
+      ),
+    ).toBe(true);
+  });
+
+  it("requires the coordinator to correlate and await the dispatched desktop run", () => {
+    const source = sources();
+    const release = source.release
+      .replace('--arg title "$EXPECTED_TITLE"', '--arg title "$RELEASE_TAG"')
+      .replace(
+        'gh run watch "$DESKTOP_RUN_ID" --interval 15 --exit-status',
+        'gh run view "$DESKTOP_RUN_ID"',
+      );
+    expect(
+      inspect(release, source.desktop).some((issue) =>
+        issue.includes("dispatch, correlate, and await the exact child run"),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects desktop signing that is not bound to an active release coordinator", () => {
+    const source = sources();
+    const desktop = source.desktop
+      .replace("    needs: authorize-coordinator\n", "")
+      .replace("test \"$(printf '%s' \"$COORDINATOR\" | jq -r '.status')\" = 'in_progress'", "true");
+    expect(
+      inspect(source.release, desktop).some((issue) =>
+        issue.includes("bind to its active release coordinator"),
       ),
     ).toBe(true);
   });
@@ -400,8 +429,8 @@ describe("desktop release workflow policy", () => {
     const source = sources();
     const release = source.release
       .replace(
-        "npm_integrity: ${{ needs.verify-npm-publication.outputs.npm_integrity }}",
-        "npm_integrity: ${{ needs.publish-npm.outputs.npm_integrity }}",
+        "NPM_INTEGRITY: ${{ needs.verify-npm-publication.outputs.npm_integrity }}",
+        "NPM_INTEGRITY: ${{ needs.publish-npm.outputs.npm_integrity }}",
       )
       .replace("--workflow .github/workflows/release.yml", "--workflow release.yml")
       .replace(

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -121,10 +121,18 @@ export function inspectDesktopReleaseWorkflows(
   if (!("push" in releaseOn) || !("workflow_dispatch" in releaseOn))
     issues.push("release.yml must remain the tag/manual coordinator");
   const desktopOn = mapping(desktop.on, "desktop.on", issues);
-  if (Object.keys(desktopOn).length !== 1 || !("workflow_call" in desktopOn))
-    issues.push("desktop-release.yml must be workflow_call-only");
-  const workflowCall = mapping(desktopOn.workflow_call, "desktop.workflow_call", issues);
-  const inputs = mapping(workflowCall.inputs, "desktop.workflow_call.inputs", issues);
+  if (Object.keys(desktopOn).length !== 1 || !("workflow_dispatch" in desktopOn))
+    issues.push("desktop-release.yml must be workflow_dispatch-only");
+  const workflowDispatch = mapping(
+    desktopOn.workflow_dispatch,
+    "desktop.workflow_dispatch",
+    issues,
+  );
+  const inputs = mapping(
+    workflowDispatch.inputs,
+    "desktop.workflow_dispatch.inputs",
+    issues,
+  );
   for (const input of [
     "tag",
     "npm_version",
@@ -136,14 +144,17 @@ export function inspectDesktopReleaseWorkflows(
     "npm_integrity",
     "npm_attestation_url",
     "baseline_tag",
+    "coordinator_run_id",
+    "coordinator_run_attempt",
   ]) {
-    if (!(input in inputs)) issues.push(`desktop workflow_call is missing ${input}`);
+    const declaration = mapping(
+      inputs[input],
+      `desktop.workflow_dispatch.inputs.${input}`,
+      issues,
+    );
+    if (declaration.required !== true || declaration.type !== "string")
+      issues.push(`desktop workflow_dispatch must require string input ${input}`);
   }
-  const workflowCallSecrets = mapping(
-    workflowCall.secrets,
-    "desktop.workflow_call.secrets",
-    issues,
-  );
   const requiredSigningSecrets = [
     "CSC_LINK",
     "CSC_KEY_PASSWORD",
@@ -151,15 +162,11 @@ export function inspectDesktopReleaseWorkflows(
     "APPLE_API_ISSUER",
     "APPLE_API_KEY_P8_BASE64",
   ];
-  for (const secret of requiredSigningSecrets) {
-    const declaration = mapping(
-      workflowCallSecrets[secret],
-      `desktop.workflow_call.secrets.${secret}`,
-      issues,
-    );
-    if (declaration.required !== false)
-      issues.push(`desktop workflow_call must declare environment secret ${secret}`);
-  }
+  if (
+    desktop["run-name"] !==
+    "Desktop release ${{ inputs.tag }} via ${{ inputs.coordinator_run_id }}.${{ inputs.coordinator_run_attempt }}"
+  )
+    issues.push("desktop workflow run name must bind its coordinator invocation");
 
   requireQueue(release.concurrency, "stable-desktop-coordinator", "release coordinator", issues);
   requireQueue(desktop.concurrency, "stable-desktop", "desktop release", issues);
@@ -344,23 +351,49 @@ export function inspectDesktopReleaseWorkflows(
     "${{ needs.parse-tag.outputs.package == 'cycling-coach' && needs.parse-tag.outputs.desktop_enabled == 'true' }}";
   if (draft.if !== desktopGate || desktopCall.if !== desktopGate)
     issues.push("desktop transaction must use the frozen coordinator opt-in decision");
-  if (desktopCall.uses !== "./.github/workflows/desktop-release.yml")
-    issues.push("release.yml must coordinate the reusable desktop workflow");
+  if ("uses" in desktopCall || desktopCall["runs-on"] !== "ubuntu-latest")
+    issues.push("release.yml must directly dispatch the environment-bound desktop workflow");
   exactPermissions(
     desktopCall.permissions,
-    { actions: "read", contents: "write" },
-    "desktop reusable call",
+    { actions: "write", contents: "read" },
+    "desktop dispatcher",
     issues,
   );
-  const callWith = mapping(desktopCall.with, "desktop call inputs", issues);
+  const dispatchStep = namedStep(
+    desktopCall,
+    "Dispatch and await environment-bound desktop transaction",
+  );
+  const dispatchEnvironment = mapping(
+    dispatchStep?.env,
+    "desktop dispatcher environment",
+    issues,
+  );
+  const dispatchRun = typeof dispatchStep?.run === "string" ? dispatchStep.run : "";
   if (
-    callWith.npm_version !== "${{ needs.parse-tag.outputs.version }}" ||
-    callWith.desktop_version !== "${{ needs.parse-tag.outputs.desktop_version }}" ||
-    callWith.npm_integrity !== "${{ needs.verify-npm-publication.outputs.npm_integrity }}" ||
-    callWith.npm_attestation_url !==
-      "${{ needs.verify-npm-publication.outputs.npm_attestation_url }}"
+    dispatchEnvironment.NPM_VERSION !== "${{ needs.parse-tag.outputs.version }}" ||
+    dispatchEnvironment.DESKTOP_VERSION !==
+      "${{ needs.parse-tag.outputs.desktop_version }}" ||
+    dispatchEnvironment.NPM_INTEGRITY !==
+      "${{ needs.verify-npm-publication.outputs.npm_integrity }}" ||
+    dispatchEnvironment.NPM_ATTESTATION_URL !==
+      "${{ needs.verify-npm-publication.outputs.npm_attestation_url }}" ||
+    dispatchEnvironment.COORDINATOR_RUN_ID !== "${{ github.run_id }}" ||
+    dispatchEnvironment.COORDINATOR_RUN_ATTEMPT !== "${{ github.run_attempt }}"
   ) {
-    issues.push("desktop call must consume frozen version authorities and verified npm outputs");
+    issues.push(
+      "desktop dispatch must consume frozen version authorities and verified npm outputs",
+    );
+  }
+  if (
+    !dispatchRun.includes("gh workflow run desktop-release.yml \\") ||
+    !dispatchRun.includes('--ref "$DESKTOP_WORKFLOW_REF"') ||
+    !dispatchRun.includes('-f coordinator_run_id="$COORDINATOR_RUN_ID"') ||
+    !dispatchRun.includes('-f coordinator_run_attempt="$COORDINATOR_RUN_ATTEMPT"') ||
+    !dispatchRun.includes('--arg title "$EXPECTED_TITLE"') ||
+    !dispatchRun.includes('gh run watch "$DESKTOP_RUN_ID" --interval 15 --exit-status') ||
+    !dispatchRun.includes('if [ "$COORDINATOR_REF" = "refs/tags/$RELEASE_TAG" ]')
+  ) {
+    issues.push("desktop coordinator must dispatch, correlate, and await the exact child run");
   }
 
   const packageOnlyText = scalar(packageOnly);
@@ -390,6 +423,11 @@ export function inspectDesktopReleaseWorkflows(
   }
 
   const desktopJobs = mapping(desktop.jobs, "desktop.jobs", issues);
+  const authorize = mapping(
+    desktopJobs["authorize-coordinator"],
+    "desktop.jobs.authorize-coordinator",
+    issues,
+  );
   const sign = mapping(desktopJobs["sign-macos"], "desktop.jobs.sign-macos", issues);
   const verify = mapping(
     desktopJobs["verify-macos-envelope"],
@@ -418,6 +456,24 @@ export function inspectDesktopReleaseWorkflows(
     "desktop.jobs.compensate-publication",
     issues,
   );
+  exactPermissions(
+    authorize.permissions,
+    { actions: "read", contents: "read" },
+    "desktop coordinator authorization",
+    issues,
+  );
+  const authorizeStep = namedStep(authorize, "Bind dispatch to the active release coordinator");
+  const authorizeRun = typeof authorizeStep?.run === "string" ? authorizeStep.run : "";
+  if (
+    sign.needs !== "authorize-coordinator" ||
+    !authorizeRun.includes('gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID"') ||
+    !authorizeRun.includes(".github/workflows/release.yml") ||
+    !authorizeRun.includes(".run_attempt") ||
+    !authorizeRun.includes(".status") ||
+    !authorizeRun.includes("in_progress")
+  ) {
+    issues.push("desktop signing must bind to its active release coordinator");
+  }
   exactPermissions(sign.permissions, { contents: "read" }, "macOS signing", issues);
   exactPermissions(
     verify.permissions,


### PR DESCRIPTION
## Summary

- dispatch the macOS signing transaction as an environment-bound workflow
- bind each child run to its active release coordinator
- make the coordinator identify and await the exact desktop run
- extend workflow-policy regression coverage

## Validation

- pnpm check
- targeted desktop release workflow policy tests (23 passed)

## Changeset

Not included: CI/release infrastructure only; no shipped package behavior or version change.