### PR TITLE
fix(ci): set desktop dispatch repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -713,6 +713,7 @@ jobs:
           fi
           EXPECTED_TITLE="Desktop release $RELEASE_TAG via $COORDINATOR_RUN_ID.$COORDINATOR_RUN_ATTEMPT"
           gh workflow run desktop-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
             --ref "$DESKTOP_WORKFLOW_REF" \
             -f tag="$RELEASE_TAG" \
             -f npm_version="$NPM_VERSION" \
@@ -729,6 +730,7 @@ jobs:
           DESKTOP_RUN_ID=''
           for attempt in $(seq 1 12); do
             DESKTOP_RUNS=$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
               --workflow desktop-release.yml \
               --event workflow_dispatch \
               --limit 20 \
@@ -745,7 +747,7 @@ jobs:
             exit 1
           fi
           echo "::notice::Awaiting desktop workflow run $DESKTOP_RUN_ID"
-          gh run watch "$DESKTOP_RUN_ID" --interval 15 --exit-status
+          gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status
   publish-package-only-release:
     runs-on: ubuntu-latest
     needs: [parse-tag, verify-npm-publication]

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -33,7 +33,9 @@ describe("desktop release workflow policy", () => {
       "DESKTOP_VERSION: ${{ needs.parse-tag.outputs.desktop_version }}",
     );
     expect(source.release).toContain("gh workflow run desktop-release.yml");
-    expect(source.release).toContain('gh run watch "$DESKTOP_RUN_ID" --interval 15 --exit-status');
+    expect(source.release).toContain(
+      'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
+    );
     expect(source.desktop).toContain('--npm-version "$NPM_VERSION"');
     expect(source.desktop).toContain('--desktop-version "$DESKTOP_VERSION"');
   });
@@ -177,9 +179,22 @@ describe("desktop release workflow policy", () => {
     const release = source.release
       .replace('--arg title "$EXPECTED_TITLE"', '--arg title "$RELEASE_TAG"')
       .replace(
-        'gh run watch "$DESKTOP_RUN_ID" --interval 15 --exit-status',
+        'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
         'gh run view "$DESKTOP_RUN_ID"',
       );
+    expect(
+      inspect(release, source.desktop).some((issue) =>
+        issue.includes("dispatch, correlate, and await the exact child run"),
+      ),
+    ).toBe(true);
+  });
+
+  it("requires explicit repository context without a checkout", () => {
+    const source = sources();
+    const release = source.release.replace(
+      '--repo "$GITHUB_REPOSITORY"',
+      '--repo "missing/repository"',
+    );
     expect(
       inspect(release, source.desktop).some((issue) =>
         issue.includes("dispatch, correlate, and await the exact child run"),

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -386,11 +386,14 @@ export function inspectDesktopReleaseWorkflows(
   }
   if (
     !dispatchRun.includes("gh workflow run desktop-release.yml \\") ||
+    (dispatchRun.match(/--repo "\$GITHUB_REPOSITORY"/gu) ?? []).length !== 3 ||
     !dispatchRun.includes('--ref "$DESKTOP_WORKFLOW_REF"') ||
     !dispatchRun.includes('-f coordinator_run_id="$COORDINATOR_RUN_ID"') ||
     !dispatchRun.includes('-f coordinator_run_attempt="$COORDINATOR_RUN_ATTEMPT"') ||
     !dispatchRun.includes('--arg title "$EXPECTED_TITLE"') ||
-    !dispatchRun.includes('gh run watch "$DESKTOP_RUN_ID" --interval 15 --exit-status') ||
+    !dispatchRun.includes(
+      'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
+    ) ||
     !dispatchRun.includes('if [ "$COORDINATOR_REF" = "refs/tags/$RELEASE_TAG" ]')
   ) {
     issues.push("desktop coordinator must dispatch, correlate, and await the exact child run");


### PR DESCRIPTION
## Summary

- give every GitHub CLI dispatcher command an explicit repository
- preserve the checkout-free coordinator job
- add regression coverage for missing repository context

## Validation

- desktop release workflow policy tests (24 passed)
- desktop release workflow structural check
- git diff --check

## Changeset

Not included: CI/release infrastructure only; no shipped package behavior or version change.