### PR TITLE
fix(desktop): surface macos release failure stage

### DIFF
--- a/apps/desktop/scripts/macos-genesis-release.mjs
+++ b/apps/desktop/scripts/macos-genesis-release.mjs
@@ -9,20 +9,24 @@ import {
 } from "./macos-release-plan.mjs";
 
 export async function runMacosGenesisRelease(input, dependencies = {}) {
+  dependencies.reportStage?.("release-plan");
   const plan = await createMacosGenesisReleasePlan(input, dependencies);
   if (input.genesisVersion !== plan.version) {
     throw new TypeError("macOS genesis release version acknowledgement is invalid");
   }
+  dependencies.reportStage?.("notarization-credentials");
   const notarizationCredentials = requireNotarizationCredentials(
     dependencies.environment ?? process.env,
   );
   const verification = await import("./verify-macos-release.mjs");
   const build = dependencies.build ?? (await import("electron-builder")).build;
+  dependencies.reportStage?.("electron-builder");
   const artifacts = await build(plan.builderOptions);
   const application = join(plan.builderOptions.projectDir, "dist/mac-arm64/Enduragent.app");
   const verifyPackageLayout =
     dependencies.verifyPackageLayout ??
     (await import("./verify-package-layout.mjs")).verifyPackageLayout;
+  dependencies.reportStage?.("package-layout");
   await verifyPackageLayout(application, {
     desktopRoot: plan.builderOptions.projectDir,
     release: {
@@ -36,8 +40,10 @@ export async function runMacosGenesisRelease(input, dependencies = {}) {
       verification.verifyMacosReleaseCandidateApplication(candidate, options, {
         executeFile: dependencies.executeFile,
       }));
+  dependencies.reportStage?.("candidate-verification");
   await verifyCandidateApplication(application, { candidateVersion: plan.version });
   const dmgPath = join(plan.builderOptions.projectDir, "dist", plan.artifactNames.dmg);
+  dependencies.reportStage?.("dmg-notarization");
   await notarizeMacosDmg(dmgPath, notarizationCredentials, {
     notarize: dependencies.notarize,
   });
@@ -47,8 +53,10 @@ export async function runMacosGenesisRelease(input, dependencies = {}) {
       verification.verifyMacosDmg(path, {
         executeFile: dependencies.executeFile,
       }));
+  dependencies.reportStage?.("dmg-verification");
   await verifyDmg(dmgPath);
   const sealReleaseMetadata = dependencies.sealReleaseMetadata ?? sealMacosReleaseMetadata;
+  dependencies.reportStage?.("metadata-sealing");
   await sealReleaseMetadata(plan);
   const verifyEnvelope = (artifactDirectory) =>
     verification.verifyMacosGenesisReleaseEnvelope(
@@ -66,17 +74,27 @@ export async function runMacosGenesisRelease(input, dependencies = {}) {
       },
     );
   const promoteReleaseEnvelope = dependencies.promoteReleaseEnvelope ?? promoteMacosReleaseEnvelope;
+  dependencies.reportStage?.("envelope-promotion");
   const envelopePath = await promoteReleaseEnvelope(plan, verifyEnvelope);
   return { plan, artifacts, envelopePath };
 }
 
+let activeStage = "initialization";
+
 async function main() {
   if (process.argv.length !== 2) throw new TypeError("arguments are not supported");
-  const result = await runMacosGenesisRelease({
-    feedUrl: process.env.ENDURAGENT_DESKTOP_UPDATE_URL,
-    identity: process.env.ENDURAGENT_DEVELOPER_ID_IDENTITY,
-    genesisVersion: process.env.ENDURAGENT_MACOS_GENESIS_VERSION,
-  });
+  const result = await runMacosGenesisRelease(
+    {
+      feedUrl: process.env.ENDURAGENT_DESKTOP_UPDATE_URL,
+      identity: process.env.ENDURAGENT_DEVELOPER_ID_IDENTITY,
+      genesisVersion: process.env.ENDURAGENT_MACOS_GENESIS_VERSION,
+    },
+    {
+      reportStage(stage) {
+        activeStage = stage;
+      },
+    },
+  );
   process.stdout.write(`macOS genesis release envelope: ${result.envelopePath}\n`);
 }
 
@@ -84,7 +102,6 @@ if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(
   try {
     await main();
   } catch {
-    process.stderr.write("macOS genesis release build failed\n");
-    process.exitCode = 1;
+    throw new TypeError(`macOS genesis release build failed at ${activeStage}`);
   }
 }

--- a/apps/desktop/scripts/macos-release-plan.d.mts
+++ b/apps/desktop/scripts/macos-release-plan.d.mts
@@ -108,7 +108,21 @@ export type NotarizationCredentialSelection =
       };
     };
 
+export type MacosReleaseStage =
+  | "release-plan"
+  | "notarization-credentials"
+  | "baseline-verification"
+  | "electron-builder"
+  | "package-layout"
+  | "candidate-verification"
+  | "identity-continuity"
+  | "dmg-notarization"
+  | "dmg-verification"
+  | "metadata-sealing"
+  | "envelope-promotion";
+
 export interface MacosReleaseDependencies {
+  readonly reportStage?: (stage: MacosReleaseStage) => void;
   readonly readFile?: (path: string, encoding: "utf8") => Promise<string>;
   readonly environment?: Readonly<Record<string, string | undefined>>;
   readonly build?: (options: MacosReleaseBuilderOptions) => Promise<readonly string[]>;

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -696,7 +696,9 @@ export async function notarizeMacosDmg(dmgPath, credentials, dependencies = {}) 
 }
 
 export async function runMacosRelease(input, dependencies = {}) {
+  dependencies.reportStage?.("release-plan");
   const plan = await createMacosReleasePlan(input, dependencies);
+  dependencies.reportStage?.("notarization-credentials");
   const notarizationCredentials = requireNotarizationCredentials(
     dependencies.environment ?? process.env,
   );
@@ -707,15 +709,18 @@ export async function runMacosRelease(input, dependencies = {}) {
       verification.verifyMacosBaselineApplication(baseline, options, {
         executeFile: dependencies.executeFile,
       }));
+  dependencies.reportStage?.("baseline-verification");
   await verifyBaselineApplication(plan.baselineApplication, {
     candidateVersion: plan.version,
   });
   const build = dependencies.build ?? (await import("electron-builder")).build;
+  dependencies.reportStage?.("electron-builder");
   const artifacts = await build(plan.builderOptions);
   const application = join(plan.builderOptions.projectDir, "dist/mac-arm64/Enduragent.app");
   const verifyPackageLayout =
     dependencies.verifyPackageLayout ??
     (await import("./verify-package-layout.mjs")).verifyPackageLayout;
+  dependencies.reportStage?.("package-layout");
   await verifyPackageLayout(application, {
     desktopRoot: plan.builderOptions.projectDir,
     release: {
@@ -735,15 +740,19 @@ export async function runMacosRelease(input, dependencies = {}) {
       verification.verifyMacosDmg(path, {
         executeFile: dependencies.executeFile,
       }));
+  dependencies.reportStage?.("identity-continuity");
   await verifyIdentityContinuity(plan.baselineApplication, application, {
     candidateVersion: plan.version,
   });
   const dmgPath = join(plan.builderOptions.projectDir, "dist", plan.artifactNames.dmg);
+  dependencies.reportStage?.("dmg-notarization");
   await notarizeMacosDmg(dmgPath, notarizationCredentials, {
     notarize: dependencies.notarize,
   });
+  dependencies.reportStage?.("dmg-verification");
   await verifyDmg(dmgPath);
   const sealReleaseMetadata = dependencies.sealReleaseMetadata ?? sealMacosReleaseMetadata;
+  dependencies.reportStage?.("metadata-sealing");
   await sealReleaseMetadata(plan);
   const verifyEnvelope = (artifactDirectory) =>
     verification.verifyMacosReleaseEnvelope(
@@ -762,17 +771,27 @@ export async function runMacosRelease(input, dependencies = {}) {
       },
     );
   const promoteReleaseEnvelope = dependencies.promoteReleaseEnvelope ?? promoteMacosReleaseEnvelope;
+  dependencies.reportStage?.("envelope-promotion");
   const envelopePath = await promoteReleaseEnvelope(plan, verifyEnvelope);
   return { plan, artifacts, envelopePath };
 }
 
+let activeStage = "initialization";
+
 async function main() {
   if (process.argv.length !== 2) throw new TypeError("arguments are not supported");
-  const result = await runMacosRelease({
-    feedUrl: process.env.ENDURAGENT_DESKTOP_UPDATE_URL,
-    identity: process.env.ENDURAGENT_DEVELOPER_ID_IDENTITY,
-    baselineApplication: process.env.ENDURAGENT_MACOS_BASELINE_APP,
-  });
+  const result = await runMacosRelease(
+    {
+      feedUrl: process.env.ENDURAGENT_DESKTOP_UPDATE_URL,
+      identity: process.env.ENDURAGENT_DEVELOPER_ID_IDENTITY,
+      baselineApplication: process.env.ENDURAGENT_MACOS_BASELINE_APP,
+    },
+    {
+      reportStage(stage) {
+        activeStage = stage;
+      },
+    },
+  );
   process.stdout.write(`macOS release envelope: ${result.envelopePath}\n`);
 }
 
@@ -780,7 +799,6 @@ if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(
   try {
     await main();
   } catch {
-    process.stderr.write("macOS release build failed\n");
-    process.exitCode = 1;
+    throw new TypeError(`macOS release build failed at ${activeStage}`);
   }
 }

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import {
   lstat,
   mkdir,
@@ -376,6 +377,7 @@ describe("macOS release plan", () => {
         return envelopePath;
       },
     );
+    const reportStage = vi.fn();
 
     const result = await runMacosGenesisRelease(
       {
@@ -397,6 +399,7 @@ describe("macOS release plan", () => {
         verifyReleaseArtifacts,
         verifyReleaseApplicationContents,
         promoteReleaseEnvelope,
+        reportStage,
       },
     );
 
@@ -429,6 +432,38 @@ describe("macOS release plan", () => {
     expect(sealReleaseMetadata.mock.invocationCallOrder[0]).toBeLessThan(
       promoteReleaseEnvelope.mock.invocationCallOrder[0]!,
     );
+    expect(reportStage.mock.calls.map(([stage]) => stage)).toEqual([
+      "release-plan",
+      "notarization-credentials",
+      "electron-builder",
+      "package-layout",
+      "candidate-verification",
+      "dmg-notarization",
+      "dmg-verification",
+      "metadata-sealing",
+      "envelope-promotion",
+    ]);
+  });
+
+  it("fails the genesis CLI with a safe actionable stage", () => {
+    const secretSentinel = "must-not-reach-stderr";
+    const result = spawnSync(
+      process.execPath,
+      [join(desktopRoot, "scripts/macos-genesis-release.mjs")],
+      {
+        cwd: repositoryRoot,
+        encoding: "utf8",
+        env: {
+          ENDURAGENT_DESKTOP_UPDATE_URL: "not-a-url",
+          ENDURAGENT_DEVELOPER_ID_IDENTITY: secretSentinel,
+          ENDURAGENT_MACOS_GENESIS_VERSION: "0.1.0",
+        },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("macOS genesis release build failed at release-plan");
+    expect(result.stderr).not.toContain(secretSentinel);
   });
 
   it("rejects a missing absolute baseline before invoking electron-builder", async () => {
@@ -560,6 +595,7 @@ describe("macOS release plan", () => {
     const verifyReleaseArtifacts = vi.fn(async (artifactDirectory: string) =>
       verifiedReleaseArtifactsAt(artifactDirectory),
     );
+    const reportStage = vi.fn();
     const result = await runMacosRelease(
       {
         repositoryRoot: "/synthetic/repository",
@@ -581,6 +617,7 @@ describe("macOS release plan", () => {
         verifyReleaseApplicationContents,
         promoteReleaseEnvelope,
         verifyReleaseArtifacts,
+        reportStage,
       },
     );
     expect(build).toHaveBeenCalledOnce();
@@ -683,6 +720,18 @@ describe("macOS release plan", () => {
     expect(verifyReleaseApplicationContents.mock.invocationCallOrder[0]).toBeLessThan(
       promotionCommitted.mock.invocationCallOrder[0]!,
     );
+    expect(reportStage.mock.calls.map(([stage]) => stage)).toEqual([
+      "release-plan",
+      "notarization-credentials",
+      "baseline-verification",
+      "electron-builder",
+      "package-layout",
+      "identity-continuity",
+      "dmg-notarization",
+      "dmg-verification",
+      "metadata-sealing",
+      "envelope-promotion",
+    ]);
   });
 
   it("propagates release package-layout verification failures", async () => {


### PR DESCRIPTION
## Summary

- report the exact macOS release stage before each signed-build operation
- make command failures reliably non-zero while keeping underlying credential-bearing errors redacted
- cover genesis and steady stage order plus CLI exit and redaction behavior

## Verification

- pnpm check
- pnpm exec vitest run apps/desktop/tests/macos-release-plan.test.ts

No changeset: release infrastructure only.