### PR TITLE
fix(ci): bind recovery release tooling

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -20,6 +20,10 @@ on:
         description: Exact tagged source commit
         required: true
         type: string
+      tooling_commit:
+        description: Exact coordinator commit supplying audited release-only tooling
+        required: true
+        type: string
       draft_id:
         description: Bound unpublished GitHub Release id
         required: true
@@ -73,15 +77,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id }}
           COORDINATOR_RUN_ATTEMPT: ${{ inputs.coordinator_run_attempt }}
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+          WORKFLOW_COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
           printf '%s' "$COORDINATOR_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$COORDINATOR_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$RELEASE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
+          printf '%s' "$RELEASE_TOOLING_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
+          test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"
           COORDINATOR=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID")
           test "$(printf '%s' "$COORDINATOR" | jq -r '.path')" = '.github/workflows/release.yml'
           test "$(printf '%s' "$COORDINATOR" | jq -r '.run_attempt')" = "$COORDINATOR_RUN_ATTEMPT"
           test "$(printf '%s' "$COORDINATOR" | jq -r '.status')" = 'in_progress'
+          test "$(printf '%s' "$COORDINATOR" | jq -r '.head_sha')" = "$RELEASE_TOOLING_COMMIT"
           printf '%s' "$COORDINATOR" | jq -er '.event == "push" or .event == "workflow_dispatch"' >/dev/null
+          if [ "$RELEASE_TOOLING_COMMIT" != "$RELEASE_COMMIT" ]; then
+            test "$(printf '%s' "$COORDINATOR" | jq -r '.event')" = 'workflow_dispatch'
+            test "$(printf '%s' "$COORDINATOR" | jq -r '.head_branch')" = 'main'
+          fi
 
   sign-macos:
     runs-on: macos-15
@@ -113,6 +128,40 @@ jobs:
           ref: ${{ inputs.commit }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Bind recovery release tooling
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
+            exit 0
+          fi
+          git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
+          git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"
+          while IFS= read -r changed_path; do
+            case "$changed_path" in
+              .github/workflows/desktop-release.yml | \
+              .github/workflows/release.yml | \
+              apps/desktop/scripts/macos-genesis-release.mjs | \
+              apps/desktop/scripts/macos-release-plan.d.mts | \
+              apps/desktop/scripts/macos-release-plan.mjs | \
+              apps/desktop/tests/macos-release-plan.test.ts | \
+              tools/check-desktop-release-workflow.test.ts | \
+              tools/check-desktop-release-workflow.ts)
+                ;;
+              *)
+                echo "::error::Recovery tooling commit changes non-release path $changed_path"
+                exit 1
+                ;;
+            esac
+          done < <(git diff --name-only "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT")
+          git restore --source="$RELEASE_TOOLING_COMMIT" --worktree -- \
+            apps/desktop/scripts/macos-genesis-release.mjs \
+            apps/desktop/scripts/macos-release-plan.d.mts \
+            apps/desktop/scripts/macos-release-plan.mjs
+          test "$(git diff --name-only | wc -l | tr -d ' ')" = '3'
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -696,6 +696,7 @@ jobs:
           NPM_VERSION: ${{ needs.parse-tag.outputs.version }}
           DESKTOP_VERSION: ${{ needs.parse-tag.outputs.desktop_version }}
           RELEASE_COMMIT: ${{ needs.parse-tag.outputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ github.sha }}
           RELEASE_DRAFT_ID: ${{ needs.prepare-release-draft.outputs.draft_id }}
           RELEASE_MODE: ${{ needs.parse-tag.outputs.desktop_mode }}
           RELEASE_BODY_SHA256: ${{ needs.prepare-release-draft.outputs.draft_body_sha256 }}
@@ -719,6 +720,7 @@ jobs:
             -f npm_version="$NPM_VERSION" \
             -f desktop_version="$DESKTOP_VERSION" \
             -f commit="$RELEASE_COMMIT" \
+            -f tooling_commit="$RELEASE_TOOLING_COMMIT" \
             -f draft_id="$RELEASE_DRAFT_ID" \
             -f mode="$RELEASE_MODE" \
             -f draft_body_sha256="$RELEASE_BODY_SHA256" \

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -214,6 +214,38 @@ describe("desktop release workflow policy", () => {
     ).toBe(true);
   });
 
+  it("binds manual recovery tooling to the coordinator and release-only paths", () => {
+    const source = sources();
+    const unboundDispatch = source.release.replace(
+      '-f tooling_commit="$RELEASE_TOOLING_COMMIT" \\\n',
+      "",
+    );
+    const unboundCoordinator = source.desktop.replace(
+      'test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"',
+      "true",
+    );
+    const productOverlay = source.desktop.replace(
+      "              apps/desktop/tests/macos-release-plan.test.ts | \\\n",
+      "              apps/desktop/src/main/index.ts | \\\n",
+    );
+
+    expect(
+      inspect(unboundDispatch, source.desktop).some((issue) =>
+        issue.includes("dispatch, correlate, and await"),
+      ),
+    ).toBe(true);
+    expect(
+      inspect(source.release, unboundCoordinator).some((issue) =>
+        issue.includes("active release coordinator"),
+      ),
+    ).toBe(true);
+    expect(
+      inspect(source.release, productOverlay).some((issue) =>
+        issue.includes("overlay only audited release tooling"),
+      ),
+    ).toBe(true);
+  });
+
   it("uses a byte-deterministic npm alias packer", () => {
     const source = sources();
     expect(source.release).toContain('npm pack "$ALIAS_DIR/extract/package"');

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -138,6 +138,7 @@ export function inspectDesktopReleaseWorkflows(
     "npm_version",
     "desktop_version",
     "commit",
+    "tooling_commit",
     "draft_id",
     "mode",
     "draft_body_sha256",
@@ -377,6 +378,7 @@ export function inspectDesktopReleaseWorkflows(
       "${{ needs.verify-npm-publication.outputs.npm_integrity }}" ||
     dispatchEnvironment.NPM_ATTESTATION_URL !==
       "${{ needs.verify-npm-publication.outputs.npm_attestation_url }}" ||
+    dispatchEnvironment.RELEASE_TOOLING_COMMIT !== "${{ github.sha }}" ||
     dispatchEnvironment.COORDINATOR_RUN_ID !== "${{ github.run_id }}" ||
     dispatchEnvironment.COORDINATOR_RUN_ATTEMPT !== "${{ github.run_attempt }}"
   ) {
@@ -388,6 +390,7 @@ export function inspectDesktopReleaseWorkflows(
     !dispatchRun.includes("gh workflow run desktop-release.yml \\") ||
     (dispatchRun.match(/--repo "\$GITHUB_REPOSITORY"/gu) ?? []).length !== 3 ||
     !dispatchRun.includes('--ref "$DESKTOP_WORKFLOW_REF"') ||
+    !dispatchRun.includes('-f tooling_commit="$RELEASE_TOOLING_COMMIT"') ||
     !dispatchRun.includes('-f coordinator_run_id="$COORDINATOR_RUN_ID"') ||
     !dispatchRun.includes('-f coordinator_run_attempt="$COORDINATOR_RUN_ATTEMPT"') ||
     !dispatchRun.includes('--arg title "$EXPECTED_TITLE"') ||
@@ -473,7 +476,12 @@ export function inspectDesktopReleaseWorkflows(
     !authorizeRun.includes(".github/workflows/release.yml") ||
     !authorizeRun.includes(".run_attempt") ||
     !authorizeRun.includes(".status") ||
-    !authorizeRun.includes("in_progress")
+    !authorizeRun.includes("in_progress") ||
+    !authorizeRun.includes(".head_sha") ||
+    !authorizeRun.includes('test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"') ||
+    !authorizeRun.includes('if [ "$RELEASE_TOOLING_COMMIT" != "$RELEASE_COMMIT" ]') ||
+    !authorizeRun.includes(".head_branch") ||
+    !authorizeRun.includes("workflow_dispatch")
   ) {
     issues.push("desktop signing must bind to its active release coordinator");
   }
@@ -634,7 +642,14 @@ export function inspectDesktopReleaseWorkflows(
     );
   }
   const signingSteps = steps(sign);
+  const recoveryToolingStep = namedStep(sign, "Bind recovery release tooling");
+  const recoveryToolingRun =
+    typeof recoveryToolingStep?.run === "string" ? recoveryToolingStep.run : "";
   const signingStep = namedStep(sign, "Build signed and notarized macOS envelope");
+  const signingCheckoutIndex = signingSteps.findIndex(
+    (step) => typeof step.uses === "string" && step.uses.startsWith("actions/checkout@"),
+  );
+  const recoveryToolingIndex = signingSteps.indexOf(recoveryToolingStep ?? {});
   const signingInstallIndex = signingSteps.findIndex(
     (step) => step.run === "pnpm install --frozen-lockfile",
   );
@@ -648,6 +663,54 @@ export function inspectDesktopReleaseWorkflows(
     'printf \'%s\' "$APPLE_API_KEY_P8_BASE64" | base64 -D > "$APPLE_API_KEY"',
   );
   const privateUmask = signingRun.indexOf("umask 077");
+  const expectedRecoveryPaths = [
+    ".github/workflows/desktop-release.yml",
+    ".github/workflows/release.yml",
+    "apps/desktop/scripts/macos-genesis-release.mjs",
+    "apps/desktop/scripts/macos-release-plan.d.mts",
+    "apps/desktop/scripts/macos-release-plan.mjs",
+    "apps/desktop/tests/macos-release-plan.test.ts",
+    "tools/check-desktop-release-workflow.test.ts",
+    "tools/check-desktop-release-workflow.ts",
+  ];
+  const recoveryToolingFiles = [
+    "apps/desktop/scripts/macos-genesis-release.mjs",
+    "apps/desktop/scripts/macos-release-plan.d.mts",
+    "apps/desktop/scripts/macos-release-plan.mjs",
+  ];
+  const recoveryAllowlistMatch = recoveryToolingRun.match(
+    /case "\$changed_path" in\n([\s\S]*?)\n\s+\*\)/u,
+  );
+  const recoveryAllowedPaths = (recoveryAllowlistMatch?.[1] ?? "")
+    .split("|")
+    .map((path) => path.replaceAll("\\", "").replace(/\)\s*;;$/u, "").trim())
+    .filter(Boolean)
+    .sort();
+  if (
+    recoveryToolingIndex <= signingCheckoutIndex ||
+    recoveryToolingIndex >= signingInstallIndex ||
+    !recoveryToolingRun.includes('test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"') ||
+    !recoveryToolingRun.includes(
+      'git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"',
+    ) ||
+    !recoveryToolingRun.includes(
+      'done < <(git diff --name-only "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT")',
+    ) ||
+    !recoveryToolingRun.includes('git restore --source="$RELEASE_TOOLING_COMMIT" --worktree --') ||
+    recoveryAllowedPaths.length !== expectedRecoveryPaths.length ||
+    [...expectedRecoveryPaths]
+      .sort()
+      .some((path, index) => recoveryAllowedPaths[index] !== path) ||
+    recoveryToolingFiles.some(
+      (path) =>
+        (recoveryToolingRun.match(new RegExp(path.replaceAll(".", "\\."), "gu")) ?? []).length !==
+        2,
+    )
+  ) {
+    issues.push(
+      "manual recovery must bind the coordinator commit and overlay only audited release tooling",
+    );
+  }
   if (
     signingInstallIndex === -1 ||
     signingWorkspaceBuildIndex <= signingInstallIndex ||


### PR DESCRIPTION
## Summary

- bind manual desktop recovery tooling to the active coordinator and workflow commit
- keep packaged application source pinned to the immutable release tag while overlaying only three non-packaged release scripts
- reject unrelated main-branch drift before dependency installation, secrets, or signing

## Verification

- pnpm check
- pnpm check:desktop-release-workflow
- pnpm exec vitest run tools/check-desktop-release-workflow.test.ts
- Bash syntax validation for the recovery step
- confirmed packaged app source is unchanged from cycling-coach@2026.8.8

No changeset: release infrastructure only.