### PR TITLE
fix(desktop): expose safe macOS verifier failures

### DIFF
--- a/apps/desktop/scripts/macos-genesis-release.mjs
+++ b/apps/desktop/scripts/macos-genesis-release.mjs
@@ -101,7 +101,10 @@ async function main() {
 if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   try {
     await main();
-  } catch {
-    throw new TypeError(`macOS genesis release build failed at ${activeStage}`);
+  } catch (error) {
+    const verification = await import("./verify-macos-release.mjs");
+    const detail = verification.safeMacosReleaseVerificationMessage(error);
+    const suffix = detail === undefined ? "" : `: ${detail}`;
+    throw new TypeError(`macOS genesis release build failed at ${activeStage}${suffix}`);
   }
 }

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -798,7 +798,10 @@ async function main() {
 if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   try {
     await main();
-  } catch {
-    throw new TypeError(`macOS release build failed at ${activeStage}`);
+  } catch (error) {
+    const verification = await import("./verify-macos-release.mjs");
+    const detail = verification.safeMacosReleaseVerificationMessage(error);
+    const suffix = detail === undefined ? "" : `: ${detail}`;
+    throw new TypeError(`macOS release build failed at ${activeStage}${suffix}`);
   }
 }

--- a/apps/desktop/scripts/verify-macos-release.d.mts
+++ b/apps/desktop/scripts/verify-macos-release.d.mts
@@ -156,6 +156,8 @@ export interface VerifiedMacosGenesisReleaseEnvelope {
   readonly candidateIdentity: VerifiedMacosReleaseCandidateApplication;
 }
 
+export function safeMacosReleaseVerificationMessage(error: unknown): string | undefined;
+
 export function verifyMacosApplication(
   application: string,
   dependencies?: Pick<VerifyMacosReleaseDependencies, "executeFile">,

--- a/apps/desktop/scripts/verify-macos-release.mjs
+++ b/apps/desktop/scripts/verify-macos-release.mjs
@@ -54,6 +54,10 @@ function fail(message) {
   throw new MacosReleaseVerificationError(message);
 }
 
+export function safeMacosReleaseVerificationMessage(error) {
+  return error instanceof MacosReleaseVerificationError ? error.message : undefined;
+}
+
 async function executeSystemFile(executable, arguments_) {
   return execFileAsync(executable, [...arguments_], {
     encoding: "utf8",

--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -23,6 +23,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse, stringify } from "yaml";
 import {
   inspectMacosReleaseApplication,
+  safeMacosReleaseVerificationMessage,
   verifyMacosApplication,
   verifyMacosBaselineApplication,
   verifyMacosGenesisReleaseApplicationContents,
@@ -53,6 +54,24 @@ const names = {
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("safe macOS release verification diagnostics", () => {
+  it("reports only failures created by the release verifier", async () => {
+    let verificationFailure: unknown;
+    try {
+      await verifyMacosReleaseArtifacts("relative-artifacts");
+    } catch (error) {
+      verificationFailure = error;
+    }
+
+    expect(safeMacosReleaseVerificationMessage(verificationFailure)).toBe(
+      "artifact directory must be absolute",
+    );
+    expect(
+      safeMacosReleaseVerificationMessage(new Error("must-not-reach-release-logs")),
+    ).toBeUndefined();
+  });
 });
 
 async function releaseFixture() {


### PR DESCRIPTION
## Summary
- preserve the existing release-stage diagnostic
- append details only for failures created by the macOS release verifier
- suppress arbitrary exception text so credentials and other secrets cannot reach logs

## Verification
- pnpm exec vitest run apps/desktop/tests/macos-release-artifacts.test.ts apps/desktop/tests/macos-release-plan.test.ts (191 tests)
- pnpm check

No changeset: release diagnostics only; no shipped application behavior changes.