### PR TITLE
fix(desktop): bind recovery verifier tooling

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -147,6 +147,9 @@ jobs:
               apps/desktop/scripts/macos-genesis-release.mjs | \
               apps/desktop/scripts/macos-release-plan.d.mts | \
               apps/desktop/scripts/macos-release-plan.mjs | \
+              apps/desktop/scripts/verify-macos-release.d.mts | \
+              apps/desktop/scripts/verify-macos-release.mjs | \
+              apps/desktop/tests/macos-release-artifacts.test.ts | \
               apps/desktop/tests/macos-release-plan.test.ts | \
               tools/check-desktop-release-workflow.test.ts | \
               tools/check-desktop-release-workflow.ts)
@@ -160,8 +163,9 @@ jobs:
           git restore --source="$RELEASE_TOOLING_COMMIT" --worktree -- \
             apps/desktop/scripts/macos-genesis-release.mjs \
             apps/desktop/scripts/macos-release-plan.d.mts \
-            apps/desktop/scripts/macos-release-plan.mjs
-          test "$(git diff --name-only | wc -l | tr -d ' ')" = '3'
+            apps/desktop/scripts/macos-release-plan.mjs \
+            apps/desktop/scripts/verify-macos-release.mjs
+          test "$(git diff --name-only | wc -l | tr -d ' ')" = '4'
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -669,6 +669,9 @@ export function inspectDesktopReleaseWorkflows(
     "apps/desktop/scripts/macos-genesis-release.mjs",
     "apps/desktop/scripts/macos-release-plan.d.mts",
     "apps/desktop/scripts/macos-release-plan.mjs",
+    "apps/desktop/scripts/verify-macos-release.d.mts",
+    "apps/desktop/scripts/verify-macos-release.mjs",
+    "apps/desktop/tests/macos-release-artifacts.test.ts",
     "apps/desktop/tests/macos-release-plan.test.ts",
     "tools/check-desktop-release-workflow.test.ts",
     "tools/check-desktop-release-workflow.ts",
@@ -677,6 +680,7 @@ export function inspectDesktopReleaseWorkflows(
     "apps/desktop/scripts/macos-genesis-release.mjs",
     "apps/desktop/scripts/macos-release-plan.d.mts",
     "apps/desktop/scripts/macos-release-plan.mjs",
+    "apps/desktop/scripts/verify-macos-release.mjs",
   ];
   const recoveryAllowlistMatch = recoveryToolingRun.match(
     /case "\$changed_path" in\n([\s\S]*?)\n\s+\*\)/u,


### PR DESCRIPTION
## Summary
- allow the audited verifier diagnostic files in the immutable-tag recovery diff
- overlay the verifier runtime alongside the existing release scripts
- keep the recovery worktree assertion exact at four runtime files

## Verification
- pnpm exec vitest run tools/check-desktop-release-workflow.test.ts (25 tests)
- pnpm check:desktop-release-workflow

No changeset: release recovery infrastructure only.