### PR TITLE
fix(desktop): expose safe promotion failures

### DIFF
--- a/apps/desktop/scripts/macos-genesis-release.mjs
+++ b/apps/desktop/scripts/macos-genesis-release.mjs
@@ -5,6 +5,7 @@ import {
   notarizeMacosDmg,
   promoteMacosReleaseEnvelope,
   requireNotarizationCredentials,
+  safeMacosReleasePlanMessage,
   sealMacosReleaseMetadata,
 } from "./macos-release-plan.mjs";
 
@@ -103,7 +104,8 @@ if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(
     await main();
   } catch (error) {
     const verification = await import("./verify-macos-release.mjs");
-    const detail = verification.safeMacosReleaseVerificationMessage(error);
+    const detail =
+      verification.safeMacosReleaseVerificationMessage(error) ?? safeMacosReleasePlanMessage(error);
     const suffix = detail === undefined ? "" : `: ${detail}`;
     throw new TypeError(`macOS genesis release build failed at ${activeStage}${suffix}`);
   }

--- a/apps/desktop/scripts/macos-release-plan.d.mts
+++ b/apps/desktop/scripts/macos-release-plan.d.mts
@@ -184,6 +184,7 @@ export interface PromoteMacosReleaseEnvelopeDependencies {
 }
 
 export const DESKTOP_UPDATER_CACHE_DIRECTORY: "@enduragentdesktop-updater";
+export function safeMacosReleasePlanMessage(error: unknown): string | undefined;
 export function requireNotarizationCredentials(
   environment?: Readonly<Record<string, string | undefined>>,
 ): NotarizationCredentialSelection;

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -31,7 +31,28 @@ const notarizationCredentialSets = [
     required: ["APPLE_KEYCHAIN_PROFILE"],
   },
 ];
+const safeReleaseArtifactMessagePattern =
+  /^(?:missing|invalid|unreadable|unstable) (?:(?:promoted|verified) )?(?:DMG artifact|ZIP artifact|ZIP blockmap|latest-mac\.yml)$/u;
+const safeReleasePlanMessages = new Set([
+  "release envelope verifier is required",
+  "release envelope cleanup failed",
+  "release envelope cleanup target changed",
+  "release envelope destination is inaccessible",
+  "release envelope destination already exists",
+  "promoted release artifact differs from builder output",
+  "promoted release artifact envelope differs",
+  "release artifact changed during promotion",
+  "release envelope changed during verification",
+]);
 export const DESKTOP_UPDATER_CACHE_DIRECTORY = "@enduragentdesktop-updater";
+
+export function safeMacosReleasePlanMessage(error) {
+  return error instanceof TypeError &&
+    (safeReleasePlanMessages.has(error.message) ||
+      safeReleaseArtifactMessagePattern.test(error.message))
+    ? error.message
+    : undefined;
+}
 
 function exactObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -800,7 +821,8 @@ if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(
     await main();
   } catch (error) {
     const verification = await import("./verify-macos-release.mjs");
-    const detail = verification.safeMacosReleaseVerificationMessage(error);
+    const detail =
+      verification.safeMacosReleaseVerificationMessage(error) ?? safeMacosReleasePlanMessage(error);
     const suffix = detail === undefined ? "" : `: ${detail}`;
     throw new TypeError(`macOS release build failed at ${activeStage}${suffix}`);
   }

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -28,6 +28,7 @@ import {
   requireMacosBaselineApplication,
   requireNotarizationCredentials,
   runMacosRelease,
+  safeMacosReleasePlanMessage,
   sealMacosReleaseMetadata,
 } from "../scripts/macos-release-plan.mjs";
 import { runMacosGenesisRelease } from "../scripts/macos-genesis-release.mjs";
@@ -167,6 +168,18 @@ async function metadataSealFixture() {
 }
 
 describe("macOS release plan", () => {
+  it("exposes only controlled release-plan failures to the release log", () => {
+    expect(
+      safeMacosReleasePlanMessage(new TypeError("release envelope changed during verification")),
+    ).toBe("release envelope changed during verification");
+    expect(safeMacosReleasePlanMessage(new TypeError("unstable verified DMG artifact"))).toBe(
+      "unstable verified DMG artifact",
+    );
+    expect(
+      safeMacosReleasePlanMessage(new TypeError("must-not-reach-release-logs")),
+    ).toBeUndefined();
+  });
+
   it("uses only the desktop package version and creates the exact sealed overlay", async () => {
     const readVersion = versionReader();
     const plan = await createMacosReleasePlan(


### PR DESCRIPTION
## Summary

- expose only controlled macOS envelope-promotion failures in signed release logs
- keep arbitrary exception text hidden from release output
- cover fixed promotion failures, artifact-state failures, and the safe fallback boundary

## Verification

- `pnpm check`
- `pnpm exec vitest run apps/desktop/tests/macos-release-plan.test.ts apps/desktop/tests/macos-release-artifacts.test.ts` (192 tests)

No changeset: release infrastructure only.