### PR TITLE
fix(desktop): allow verified artifact timestamps

### DIFF
--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -86,6 +86,15 @@ function sameReleaseFileIdentity(left, right) {
   );
 }
 
+function sameVerifiedReleaseFileIdentity(left, right) {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.size === right.size
+  );
+}
+
 function releaseDirectoryIdentity(stat) {
   return Object.freeze({ dev: stat.dev, ino: stat.ino, mode: stat.mode });
 }
@@ -661,7 +670,7 @@ export async function promoteMacosReleaseEnvelope(plan, verifyEnvelope, override
     if (
       verifiedSnapshots.some(
         (verified, index) =>
-          !sameReleaseFileIdentity(verified.identity, promotedSnapshots[index].identity) ||
+          !sameVerifiedReleaseFileIdentity(verified.identity, promotedSnapshots[index].identity) ||
           !verified.bytes.equals(promotedSnapshots[index].bytes),
       )
     ) {

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -9,6 +9,7 @@ import {
   rename,
   rm,
   symlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -1271,6 +1272,32 @@ describe("macOS release plan", () => {
     }
     expect((await lstat(builderApplication)).isDirectory()).toBe(true);
     expect((await lstat(builderScratch)).isDirectory()).toBe(true);
+  });
+
+  it("accepts verification-only timestamp changes when file identity and bytes are stable", async () => {
+    const fixture = await metadataSealFixture();
+    await sealMacosReleaseMetadata(fixture.plan);
+    const sourceBytes = new Map(
+      await Promise.all(
+        Object.values(fixture.plan.artifactNames).map(
+          async (name) => [name, await readFile(join(fixture.artifactDirectory, name))] as const,
+        ),
+      ),
+    );
+    const verificationTimestamp = new Date("2000-01-01T00:00:00.000Z");
+
+    const envelopePath = await promoteMacosReleaseEnvelope(fixture.plan, async (candidatePath) => {
+      await Promise.all(
+        Object.values(fixture.plan.artifactNames).map((name) =>
+          utimes(join(candidatePath, name), verificationTimestamp, verificationTimestamp),
+        ),
+      );
+    });
+
+    for (const [name, bytes] of sourceBytes) {
+      expect(await readFile(join(envelopePath, name))).toEqual(bytes);
+      expect(await readFile(join(fixture.artifactDirectory, name))).toEqual(bytes);
+    }
   });
 
   it("never overwrites a stale release envelope", async () => {


### PR DESCRIPTION
## Summary

- stop treating verification-only timestamp updates as release artifact replacement
- continue requiring stable device, inode, mode, size, exact bytes, file set, and directory identity
- reproduce the production promotion failure with a focused timestamp regression

## Verification

- `pnpm check`
- `pnpm exec vitest run apps/desktop/tests/macos-release-plan.test.ts apps/desktop/tests/macos-release-artifacts.test.ts` (193 tests)
- existing byte mutation, entry swap, directory swap, and source mutation tests remain green

No changeset: release infrastructure only.