### PR TITLE
fix(ci): allow unrelated recovery history

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -140,32 +140,13 @@ jobs:
           fi
           git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
           git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"
-          while IFS= read -r changed_path; do
-            case "$changed_path" in
-              .github/workflows/desktop-release.yml | \
-              .github/workflows/release.yml | \
-              apps/desktop/scripts/macos-genesis-release.mjs | \
-              apps/desktop/scripts/macos-release-plan.d.mts | \
-              apps/desktop/scripts/macos-release-plan.mjs | \
-              apps/desktop/scripts/verify-macos-release.d.mts | \
-              apps/desktop/scripts/verify-macos-release.mjs | \
-              apps/desktop/tests/macos-release-artifacts.test.ts | \
-              apps/desktop/tests/macos-release-plan.test.ts | \
-              tools/check-desktop-release-workflow.test.ts | \
-              tools/check-desktop-release-workflow.ts)
-                ;;
-              *)
-                echo "::error::Recovery tooling commit changes non-release path $changed_path"
-                exit 1
-                ;;
-            esac
-          done < <(git diff --name-only "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT")
           git restore --source="$RELEASE_TOOLING_COMMIT" --worktree -- \
             apps/desktop/scripts/macos-genesis-release.mjs \
             apps/desktop/scripts/macos-release-plan.d.mts \
             apps/desktop/scripts/macos-release-plan.mjs \
             apps/desktop/scripts/verify-macos-release.mjs
-          test "$(git diff --name-only | wc -l | tr -d ' ')" = '4'
+          EXPECTED_RECOVERY_DIFF=$'apps/desktop/scripts/macos-genesis-release.mjs\napps/desktop/scripts/macos-release-plan.d.mts\napps/desktop/scripts/macos-release-plan.mjs\napps/desktop/scripts/verify-macos-release.mjs'
+          test "$(git diff --name-only)" = "$EXPECTED_RECOVERY_DIFF"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -214,7 +214,7 @@ describe("desktop release workflow policy", () => {
     ).toBe(true);
   });
 
-  it("binds manual recovery tooling to the coordinator and release-only paths", () => {
+  it("binds manual recovery tooling to the coordinator and exact release overlay", () => {
     const source = sources();
     const unboundDispatch = source.release.replace(
       '-f tooling_commit="$RELEASE_TOOLING_COMMIT" \\\n',
@@ -225,8 +225,12 @@ describe("desktop release workflow policy", () => {
       "true",
     );
     const productOverlay = source.desktop.replace(
-      "              apps/desktop/tests/macos-release-plan.test.ts | \\\n",
-      "              apps/desktop/src/main/index.ts | \\\n",
+      "apps/desktop/scripts/macos-release-plan.d.mts\\n",
+      "apps/desktop/src/main/index.ts\\n",
+    );
+
+    expect(source.desktop).not.toContain(
+      'git diff --name-only "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"',
     );
 
     expect(

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -663,33 +663,13 @@ export function inspectDesktopReleaseWorkflows(
     'printf \'%s\' "$APPLE_API_KEY_P8_BASE64" | base64 -D > "$APPLE_API_KEY"',
   );
   const privateUmask = signingRun.indexOf("umask 077");
-  const expectedRecoveryPaths = [
-    ".github/workflows/desktop-release.yml",
-    ".github/workflows/release.yml",
-    "apps/desktop/scripts/macos-genesis-release.mjs",
-    "apps/desktop/scripts/macos-release-plan.d.mts",
-    "apps/desktop/scripts/macos-release-plan.mjs",
-    "apps/desktop/scripts/verify-macos-release.d.mts",
-    "apps/desktop/scripts/verify-macos-release.mjs",
-    "apps/desktop/tests/macos-release-artifacts.test.ts",
-    "apps/desktop/tests/macos-release-plan.test.ts",
-    "tools/check-desktop-release-workflow.test.ts",
-    "tools/check-desktop-release-workflow.ts",
-  ];
   const recoveryToolingFiles = [
     "apps/desktop/scripts/macos-genesis-release.mjs",
     "apps/desktop/scripts/macos-release-plan.d.mts",
     "apps/desktop/scripts/macos-release-plan.mjs",
     "apps/desktop/scripts/verify-macos-release.mjs",
   ];
-  const recoveryAllowlistMatch = recoveryToolingRun.match(
-    /case "\$changed_path" in\n([\s\S]*?)\n\s+\*\)/u,
-  );
-  const recoveryAllowedPaths = (recoveryAllowlistMatch?.[1] ?? "")
-    .split("|")
-    .map((path) => path.replaceAll("\\", "").replace(/\)\s*;;$/u, "").trim())
-    .filter(Boolean)
-    .sort();
+  const expectedRecoveryDiff = recoveryToolingFiles.join("\\n");
   if (
     recoveryToolingIndex <= signingCheckoutIndex ||
     recoveryToolingIndex >= signingInstallIndex ||
@@ -697,14 +677,9 @@ export function inspectDesktopReleaseWorkflows(
     !recoveryToolingRun.includes(
       'git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"',
     ) ||
-    !recoveryToolingRun.includes(
-      'done < <(git diff --name-only "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT")',
-    ) ||
     !recoveryToolingRun.includes('git restore --source="$RELEASE_TOOLING_COMMIT" --worktree --') ||
-    recoveryAllowedPaths.length !== expectedRecoveryPaths.length ||
-    [...expectedRecoveryPaths]
-      .sort()
-      .some((path, index) => recoveryAllowedPaths[index] !== path) ||
+    !recoveryToolingRun.includes(`EXPECTED_RECOVERY_DIFF=$'${expectedRecoveryDiff}'`) ||
+    !recoveryToolingRun.includes('test "$(git diff --name-only)" = "$EXPECTED_RECOVERY_DIFF"') ||
     recoveryToolingFiles.some(
       (path) =>
         (recoveryToolingRun.match(new RegExp(path.replaceAll(".", "\\."), "gu")) ?? []).length !==


### PR DESCRIPTION
## Summary
- permit unrelated commits between the published release and recovery tooling commit
- restore only the four audited release scripts into the original release checkout
- verify the resulting worktree diff exactly matches those four scripts

## Verification
- pnpm exec vitest run tools/check-desktop-release-workflow.test.ts
- pnpm check:desktop-release-workflow
- pnpm check
- exact original-release-to-current-tooling overlay contains only the four expected scripts

No changeset: release infrastructure only.