### PR TITLE
fix(ci): pass macos verifier arguments

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -470,12 +470,12 @@ jobs:
             --output "$PUBLIC_ENVELOPE"
           case "$RELEASE_MODE" in
             genesis)
-              pnpm --filter @enduragent/desktop verify:mac-genesis-release -- \
+              pnpm --filter @enduragent/desktop verify:mac-genesis-release \
                 "$PUBLIC_ENVELOPE" \
                 "$CANDIDATE_APP"
               ;;
             steady)
-              pnpm --filter @enduragent/desktop verify:mac-release -- \
+              pnpm --filter @enduragent/desktop verify:mac-release \
                 "$PUBLIC_ENVELOPE" \
                 "$INDEPENDENT_BASELINE_APP" \
                 "$CANDIDATE_APP"

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -313,8 +313,8 @@ describe("desktop release workflow policy", () => {
       "ENDURAGENT_MACOS_GENESIS_VERSION: 0.0.1",
     );
     const missingGenesisVerifier = source.desktop.replace(
-      "verify:mac-genesis-release --",
-      "verify:mac-release --",
+      "verify:mac-genesis-release \\",
+      "verify:mac-release \\",
     );
     const sealedGenesisVerifier = source.desktop.replace(
       '                "$PUBLIC_ENVELOPE" \\\n',
@@ -328,6 +328,9 @@ describe("desktop release workflow policy", () => {
       "RELEASE_MODE: ${{ inputs.mode }}\n          ENDURAGENT_DEVELOPER_ID_IDENTITY:",
       "RELEASE_MODE: steady\n          ENDURAGENT_DEVELOPER_ID_IDENTITY:",
     );
+
+    expect(source.desktop).not.toContain("verify:mac-genesis-release --");
+    expect(source.desktop).not.toContain("verify:mac-release --");
     const constantVerificationMode = source.desktop.replace(
       '--output "$PUBLIC_ENVELOPE"\n          case "$RELEASE_MODE" in',
       '--output "$PUBLIC_ENVELOPE"\n          case "genesis" in',

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -742,10 +742,10 @@ export function inspectDesktopReleaseWorkflows(
   const transactionVerification = independentRun.indexOf("desktop-release:transaction verify");
   const publicEnvelope = independentRun.indexOf("desktop-release:transaction public-envelope");
   const genesisVerification = independentRun.indexOf(
-    "verify:mac-genesis-release --",
+    "verify:mac-genesis-release \\",
     publicEnvelope,
   );
-  const steadyVerification = independentRun.indexOf("verify:mac-release --", publicEnvelope);
+  const steadyVerification = independentRun.indexOf("verify:mac-release \\", publicEnvelope);
   const genesisCase = independentRun.slice(
     independentRun.indexOf("genesis)", publicEnvelope),
     independentRun.indexOf(";;", independentRun.indexOf("genesis)", publicEnvelope)),
@@ -761,8 +761,12 @@ export function inspectDesktopReleaseWorkflows(
     steadyVerification <= publicEnvelope ||
     independentEnvironment.RELEASE_MODE !== "${{ inputs.mode }}" ||
     countShellLine(independentRun, 'case "$RELEASE_MODE" in') !== 1 ||
-    (independentRun.match(/verify:mac-genesis-release --/gu) ?? []).length !== 1 ||
-    (independentRun.match(/verify:mac-release --/gu) ?? []).length !== 1 ||
+    countShellLine(
+      independentRun,
+      "pnpm --filter @enduragent/desktop verify:mac-genesis-release \\",
+    ) !== 1 ||
+    countShellLine(independentRun, "pnpm --filter @enduragent/desktop verify:mac-release \\") !==
+      1 ||
     (independentRun.slice(publicEnvelope).match(/"\$PUBLIC_ENVELOPE"/gu) ?? []).length !== 3 ||
     !genesisCase.includes('"$PUBLIC_ENVELOPE"') ||
     !genesisCase.includes('"$CANDIDATE_APP"') ||


### PR DESCRIPTION
## Summary
- stop forwarding a literal argument separator to the genesis verifier
- apply the same correction to steady-update verification
- enforce the exact package-script invocation in workflow policy tests

## Verification
- pnpm exec vitest run tools/check-desktop-release-workflow.test.ts
- pnpm check:desktop-release-workflow
- pnpm check

No changeset: release infrastructure only.