### PR TITLE
fix(ci): pass updater roundtrip arguments

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -696,7 +696,7 @@ jobs:
           pnpm desktop-release:transaction public-envelope \
             --directory "$RUNNER_TEMP/desktop-release" \
             --output "$CANDIDATE_ENVELOPE"
-          pnpm --filter @enduragent/desktop test:macos-update-roundtrip -- \
+          pnpm --filter @enduragent/desktop test:macos-update-roundtrip \
             "$BASELINE_VERSION" \
             "$CANDIDATE_VERSION" \
             "$RUNNER_TEMP/desktop-baseline" \

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -148,6 +148,13 @@ describe("desktop release workflow policy", () => {
       },
       {
         desktop: source.desktop.replace(
+          "test:macos-update-roundtrip \\",
+          "test:macos-update-roundtrip -- \\",
+        ),
+        issue: "native production-feed N-to-N+1 round trip",
+      },
+      {
+        desktop: source.desktop.replace(
           "needs.activate-release.result != 'success'",
           "needs.activate-release.result == 'failure'",
         ),

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -598,7 +598,10 @@ export function inspectDesktopReleaseWorkflows(
     !roundTripNeeds.includes("sign-macos") ||
     !roundTripNeeds.includes("promote-latest") ||
     !roundTripRun.includes("desktop-release:transaction public-envelope") ||
-    !roundTripRun.includes("test:macos-update-roundtrip") ||
+    countShellLine(
+      roundTripRun,
+      "pnpm --filter @enduragent/desktop test:macos-update-roundtrip \\",
+    ) !== 1 ||
     !roundTripRun.includes('"$RUNNER_TEMP/desktop-baseline"') ||
     !roundTripRun.includes('"$CANDIDATE_ENVELOPE"') ||
     !roundTripRun.includes('"$EVIDENCE"') ||


### PR DESCRIPTION
## Summary
- stop forwarding a literal argument separator to the native macOS updater round-trip
- require the exact five-argument package-script invocation in workflow policy checks
- add a regression mutation for the broken separator form

## Verification
- 83 focused updater round-trip and workflow-policy tests
- pnpm check:desktop-release-workflow
- pnpm check

No changeset: release infrastructure only.