### PR TITLE
fix(desktop): separate app releases from npm

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -12,7 +12,9 @@ pnpm exec changeset
 
 The CLI will ask which packages changed and how (patch/minor/major), and write a markdown file to `.changeset/`. Commit that file with your PR.
 
-When the PR merges to main, a "Version PR" will be opened (or updated) by the changesets GitHub Action, aggregating pending changesets into version bumps + CHANGELOG entries. Merging the Version PR triggers the publish workflow.
+When the PR merges to main, a "Version PR" will be opened (or updated) by the changesets GitHub Action, aggregating pending changesets into version bumps + CHANGELOG entries. Merging it dispatches only the release paths whose package versions changed.
+
+Desktop changes select `@enduragent/desktop` (and the renderer when applicable), not `cycling-coach`. The desktop app uses independent SemVer and an `enduragent-desktop@<version>` release; it never requires an npm publication.
 
 ## Why `commit: false`?
 
@@ -34,11 +36,11 @@ Engineering details (anything you want — code refs, hash, rationale). Ignored 
 
 Rules:
 
-- One sentence per `User-facing:` line, written in plain English in the bot's voice.
+- One sentence per `User-facing:` line, written in plain product language.
 - Multiple user-visible changes in one changeset → multiple `User-facing:` lines, each becomes a bullet.
 - Pure-infra changes (CI, publishing, build tooling, internal refactors) omit the line — they stay in `CHANGELOG.md` for git history but don't reach athletes.
 - The token must start the line after optional indentation. Generated changelog lines may prefix it with a Markdown bullet and an optional commit hash of 7 or more hexadecimal characters followed by a colon (for example, `- abc1234: User-facing: ...`). Mid-line prose that merely mentions `User-facing:` is ignored.
-- The convention propagates from `.changeset/*.md` → `CHANGELOG.md` → GitHub Release body automatically; `/whatsnew` reads the GitHub Release body.
+- The convention propagates from `.changeset/*.md` → `CHANGELOG.md` → the matching GitHub Release body. `/whatsnew` reads npm-binary release notes; desktop notes stay with the desktop release.
 
 ## Binary packages and CalVer
 

--- a/.changeset/clean-desktop-sidebar.md
+++ b/.changeset/clean-desktop-sidebar.md
@@ -1,5 +1,4 @@
 ---
-"cycling-coach": patch
 "@enduragent/desktop": patch
 "@enduragent/desktop-renderer": patch
 ---

--- a/.github/workflows/desktop-release-coordinator.yml
+++ b/.github/workflows/desktop-release-coordinator.yml
@@ -1,0 +1,196 @@
+name: Desktop release coordinator
+run-name: Desktop release coordinator ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Exact enduragent-desktop@<version> tag'
+        required: true
+        type: string
+      desktop_mode:
+        description: 'macOS release continuity mode'
+        type: choice
+        default: steady
+        options:
+          - steady
+          - genesis
+      desktop_baseline_tag:
+        description: 'Explicit prior signed desktop release tag; leave empty to require repository latest'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stable-desktop-coordinator
+  cancel-in-progress: false
+  queue: max
+
+jobs:
+  bind-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.bind.outputs.tag }}
+      desktop_version: ${{ steps.bind.outputs.desktop_version }}
+      commit: ${{ steps.bind.outputs.commit }}
+      mode: ${{ steps.bind.outputs.mode }}
+      baseline_tag: ${{ steps.bind.outputs.baseline_tag }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Bind desktop tag, version, and source commit
+        id: bind
+        env:
+          RELEASE_TAG_INPUT: ${{ inputs.tag }}
+          RELEASE_MODE_INPUT: ${{ inputs.desktop_mode }}
+          RELEASE_BASELINE_TAG_INPUT: ${{ inputs.desktop_baseline_tag }}
+          DESKTOP_ENABLED: ${{ vars.ENABLE_DESKTOP_MACOS_RELEASE }}
+          WORKFLOW_REF: ${{ github.ref }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$DESKTOP_ENABLED" = 'true'
+          TAG="$RELEASE_TAG_INPUT"
+          if ! printf '%s' "$TAG" | grep -Eq '^enduragent-desktop@(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo "::error::Desktop tag '$TAG' is invalid"
+            exit 1
+          fi
+          VERSION="${TAG#enduragent-desktop@}"
+          git fetch --force --no-tags origin "refs/tags/$TAG:refs/tags/$TAG"
+          COMMIT=$(git rev-parse "refs/tags/$TAG^{commit}")
+          test "$WORKFLOW_REF" = "refs/tags/$TAG"
+          test "$WORKFLOW_SHA" = "$COMMIT"
+          MANIFEST_VERSION=$(git show "$COMMIT:apps/desktop/package.json" | jq -er '.version')
+          if [ "$MANIFEST_VERSION" != "$VERSION" ]; then
+            echo "::error::Desktop tag version $VERSION does not match apps/desktop/package.json $MANIFEST_VERSION"
+            exit 1
+          fi
+          git fetch --force --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$COMMIT" refs/remotes/origin/main; then
+            echo '::error::Desktop release commit must be merged into main'
+            exit 1
+          fi
+          MODE="$RELEASE_MODE_INPUT"
+          BASELINE_TAG=none
+          if [ -n "$RELEASE_BASELINE_TAG_INPUT" ]; then
+            BASELINE_TAG="$RELEASE_BASELINE_TAG_INPUT"
+          fi
+          if [ "$MODE" != 'steady' ] && [ "$MODE" != 'genesis' ]; then
+            echo "::error::Unsupported desktop release mode '$MODE'"
+            exit 1
+          fi
+          if [ "$MODE" = 'genesis' ] && [ "$BASELINE_TAG" != 'none' ]; then
+            echo '::error::Genesis cannot consume a prior desktop baseline'
+            exit 1
+          fi
+          if [ "$BASELINE_TAG" != 'none' ] && \
+             [ "$BASELINE_TAG" != 'cycling-coach@2026.8.8' ] && \
+             ! printf '%s' "$BASELINE_TAG" | grep -Eq '^enduragent-desktop@(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo '::error::Explicit desktop baseline tag is invalid'
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "desktop_version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "baseline_tag=$BASELINE_TAG" >> "$GITHUB_OUTPUT"
+
+  prepare-release-draft:
+    runs-on: ubuntu-latest
+    needs: bind-release
+    permissions:
+      contents: write
+    outputs:
+      draft_id: ${{ steps.release-draft.outputs.draft_id }}
+      body_sha256: ${{ steps.release-draft.outputs.body_sha256 }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.bind-release.outputs.commit }}
+          persist-credentials: false
+      - name: Create or validate bound desktop release draft
+        id: release-draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.bind-release.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.bind-release.outputs.desktop_version }}
+          RELEASE_COMMIT: ${{ needs.bind-release.outputs.commit }}
+        run: |
+          set -euo pipefail
+          FIRST_HEADING=$(grep -m1 '^## ' apps/desktop/CHANGELOG.md)
+          test "$FIRST_HEADING" = "## $RELEASE_VERSION"
+          BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' apps/desktop/CHANGELOG.md | tail -n +2)
+          test -n "$BODY"
+          BODY_SHA256=$(printf '%s' "$BODY" | shasum -a 256 | awk '{print $1}')
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            RELEASE_JSON=$(gh release view "$RELEASE_TAG" --json body,databaseId,isDraft,isPrerelease,tagName)
+            test "$(printf '%s' "$RELEASE_JSON" | jq -r '.tagName')" = "$RELEASE_TAG"
+            test "$(printf '%s' "$RELEASE_JSON" | jq -r '.isDraft')" = 'true'
+            test "$(printf '%s' "$RELEASE_JSON" | jq -r '.isPrerelease')" = 'false'
+            EXISTING_BODY_SHA256=$(printf '%s' "$RELEASE_JSON" | jq -j '.body' | shasum -a 256 | awk '{print $1}')
+            test "$EXISTING_BODY_SHA256" = "$BODY_SHA256"
+          else
+            gh release create "$RELEASE_TAG" --draft --latest=false --target "$RELEASE_COMMIT" \
+              --title "Enduragent Desktop $RELEASE_VERSION" --notes "$BODY"
+            RELEASE_JSON=$(gh release view "$RELEASE_TAG" --json databaseId,isDraft,isPrerelease,tagName)
+          fi
+          DRAFT_ID=$(printf '%s' "$RELEASE_JSON" | jq -r '.databaseId')
+          printf '%s' "$DRAFT_ID" | grep -Eq '^[1-9][0-9]*$'
+          echo "draft_id=$DRAFT_ID" >> "$GITHUB_OUTPUT"
+          echo "body_sha256=$BODY_SHA256" >> "$GITHUB_OUTPUT"
+
+  dispatch-desktop-release:
+    runs-on: ubuntu-latest
+    needs: [bind-release, prepare-release-draft]
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch and await environment-bound desktop transaction
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.bind-release.outputs.tag }}
+          DESKTOP_VERSION: ${{ needs.bind-release.outputs.desktop_version }}
+          RELEASE_COMMIT: ${{ needs.bind-release.outputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ github.sha }}
+          RELEASE_DRAFT_ID: ${{ needs.prepare-release-draft.outputs.draft_id }}
+          RELEASE_MODE: ${{ needs.bind-release.outputs.mode }}
+          RELEASE_BODY_SHA256: ${{ needs.prepare-release-draft.outputs.body_sha256 }}
+          RELEASE_BASELINE_TAG: ${{ needs.bind-release.outputs.baseline_tag }}
+          COORDINATOR_RUN_ID: ${{ github.run_id }}
+          COORDINATOR_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          EXPECTED_TITLE="Desktop release $RELEASE_TAG via $COORDINATOR_RUN_ID.$COORDINATOR_RUN_ATTEMPT"
+          gh workflow run desktop-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_TAG" \
+            -f tag="$RELEASE_TAG" \
+            -f desktop_version="$DESKTOP_VERSION" \
+            -f commit="$RELEASE_COMMIT" \
+            -f tooling_commit="$RELEASE_TOOLING_COMMIT" \
+            -f draft_id="$RELEASE_DRAFT_ID" \
+            -f mode="$RELEASE_MODE" \
+            -f draft_body_sha256="$RELEASE_BODY_SHA256" \
+            -f baseline_tag="$RELEASE_BASELINE_TAG" \
+            -f coordinator_run_id="$COORDINATOR_RUN_ID" \
+            -f coordinator_run_attempt="$COORDINATOR_RUN_ATTEMPT"
+          DESKTOP_RUN_ID=''
+          for attempt in $(seq 1 12); do
+            DESKTOP_RUNS=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow desktop-release.yml \
+              --event workflow_dispatch --limit 20 --json databaseId,displayTitle)
+            DESKTOP_RUN_ID=$(printf '%s' "$DESKTOP_RUNS" | jq -r --arg title "$EXPECTED_TITLE" \
+              '[.[] | select(.displayTitle == $title)] | first | .databaseId // empty')
+            if [ -n "$DESKTOP_RUN_ID" ]; then
+              break
+            fi
+            sleep 5
+          done
+          test -n "$DESKTOP_RUN_ID"
+          gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -5,11 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Exact cycling-coach release tag
-        required: true
-        type: string
-      npm_version:
-        description: Frozen npm package version
+        description: Exact enduragent-desktop release tag
         required: true
         type: string
       desktop_version:
@@ -34,14 +30,6 @@ on:
         type: string
       draft_body_sha256:
         description: Bound draft release-notes digest
-        required: true
-        type: string
-      npm_integrity:
-        description: Verified public npm integrity
-        required: true
-        type: string
-      npm_attestation_url:
-        description: Verified public npm provenance URL
         required: true
         type: string
       baseline_tag:
@@ -88,15 +76,11 @@ jobs:
           printf '%s' "$RELEASE_TOOLING_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
           test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"
           COORDINATOR=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID")
-          test "$(printf '%s' "$COORDINATOR" | jq -r '.path')" = '.github/workflows/release.yml'
+          test "$(printf '%s' "$COORDINATOR" | jq -r '.path')" = '.github/workflows/desktop-release-coordinator.yml'
           test "$(printf '%s' "$COORDINATOR" | jq -r '.run_attempt')" = "$COORDINATOR_RUN_ATTEMPT"
           test "$(printf '%s' "$COORDINATOR" | jq -r '.status')" = 'in_progress'
           test "$(printf '%s' "$COORDINATOR" | jq -r '.head_sha')" = "$RELEASE_TOOLING_COMMIT"
-          printf '%s' "$COORDINATOR" | jq -er '.event == "push" or .event == "workflow_dispatch"' >/dev/null
-          if [ "$RELEASE_TOOLING_COMMIT" != "$RELEASE_COMMIT" ]; then
-            test "$(printf '%s' "$COORDINATOR" | jq -r '.event')" = 'workflow_dispatch'
-            test "$(printf '%s' "$COORDINATOR" | jq -r '.head_branch')" = 'main'
-          fi
+          test "$(printf '%s' "$COORDINATOR" | jq -r '.event')" = 'workflow_dispatch'
 
   sign-macos:
     runs-on: macos-15
@@ -251,7 +235,6 @@ jobs:
       - name: Seal digest-bound release manifest
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-          NPM_VERSION: ${{ inputs.npm_version }}
           DESKTOP_VERSION: ${{ inputs.desktop_version }}
           RELEASE_COMMIT: ${{ inputs.commit }}
           RELEASE_DRAFT_ID: ${{ inputs.draft_id }}
@@ -259,8 +242,6 @@ jobs:
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
           RELEASE_BODY_SHA256: ${{ inputs.draft_body_sha256 }}
-          NPM_INTEGRITY: ${{ inputs.npm_integrity }}
-          NPM_ATTESTATION_URL: ${{ inputs.npm_attestation_url }}
           SIGNING_IDENTITY: ${{ steps.signing-evidence.outputs.signing_identity }}
           CANDIDATE_CDHASH: ${{ steps.signing-evidence.outputs.cdhash }}
           CANDIDATE_CODE_DIRECTORY_SHA256: ${{ steps.signing-evidence.outputs.code_directory_sha256 }}
@@ -274,7 +255,6 @@ jobs:
           pnpm desktop-release:transaction seal \
             --directory "apps/desktop/dist/release-envelope-$DESKTOP_VERSION-mac-arm64" \
             --tag "$RELEASE_TAG" \
-            --npm-version "$NPM_VERSION" \
             --desktop-version "$DESKTOP_VERSION" \
             --commit "$RELEASE_COMMIT" \
             --draft-id "$RELEASE_DRAFT_ID" \
@@ -282,8 +262,6 @@ jobs:
             --workflow-run-id "$WORKFLOW_RUN_ID" \
             --workflow-run-attempt "$WORKFLOW_RUN_ATTEMPT" \
             --draft-body-sha256 "$RELEASE_BODY_SHA256" \
-            --npm-integrity "$NPM_INTEGRITY" \
-            --npm-attestation-url "$NPM_ATTESTATION_URL" \
             --signing-identity "$SIGNING_IDENTITY" \
             --candidate-cdhash "$CANDIDATE_CDHASH" \
             --candidate-code-directory-sha256 "$CANDIDATE_CODE_DIRECTORY_SHA256" \
@@ -401,7 +379,6 @@ jobs:
       - name: Independently verify signed updater envelope
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-          NPM_VERSION: ${{ inputs.npm_version }}
           DESKTOP_VERSION: ${{ inputs.desktop_version }}
           RELEASE_COMMIT: ${{ inputs.commit }}
           RELEASE_DRAFT_ID: ${{ inputs.draft_id }}
@@ -409,8 +386,6 @@ jobs:
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
           RELEASE_BODY_SHA256: ${{ inputs.draft_body_sha256 }}
-          NPM_INTEGRITY: ${{ inputs.npm_integrity }}
-          NPM_ATTESTATION_URL: ${{ inputs.npm_attestation_url }}
           SIGNING_IDENTITY: ${{ needs.sign-macos.outputs.signing_identity }}
           CANDIDATE_CDHASH: ${{ needs.sign-macos.outputs.cdhash }}
           CANDIDATE_CODE_DIRECTORY_SHA256: ${{ needs.sign-macos.outputs.code_directory_sha256 }}
@@ -426,7 +401,6 @@ jobs:
           pnpm desktop-release:transaction verify \
             --directory "$RUNNER_TEMP/desktop-release" \
             --tag "$RELEASE_TAG" \
-            --npm-version "$NPM_VERSION" \
             --desktop-version "$DESKTOP_VERSION" \
             --commit "$RELEASE_COMMIT" \
             --draft-id "$RELEASE_DRAFT_ID" \
@@ -434,8 +408,6 @@ jobs:
             --workflow-run-id "$WORKFLOW_RUN_ID" \
             --workflow-run-attempt "$SIGNING_RUN_ATTEMPT" \
             --draft-body-sha256 "$RELEASE_BODY_SHA256" \
-            --npm-integrity "$NPM_INTEGRITY" \
-            --npm-attestation-url "$NPM_ATTESTATION_URL" \
             --signing-identity "$SIGNING_IDENTITY" \
             --candidate-cdhash "$CANDIDATE_CDHASH" \
             --candidate-code-directory-sha256 "$CANDIDATE_CODE_DIRECTORY_SHA256" \
@@ -755,7 +727,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' packages/cycling-coach/CHANGELOG.md | tail -n +2)
+          BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' apps/desktop/CHANGELOG.md | tail -n +2)
           printf '%s' "$BODY" > "$RUNNER_TEMP/desktop-release-body.md"
           pnpm desktop-release:transaction activate \
             --directory "$RUNNER_TEMP/desktop-release" \
@@ -806,7 +778,7 @@ jobs:
           EXPECTED_LATEST_METADATA_SHA256: ${{ needs.publish-assets.outputs.latest_metadata_sha256 }}
         run: |
           set -euo pipefail
-          BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' packages/cycling-coach/CHANGELOG.md | tail -n +2)
+          BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' apps/desktop/CHANGELOG.md | tail -n +2)
           printf '%s' "$BODY" > "$RUNNER_TEMP/desktop-release-body.md"
           pnpm desktop-release:transaction compensate \
             --directory "$RUNNER_TEMP/desktop-release" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,24 +32,13 @@ on:
         description: 'Exact release tag; a main-ref dispatch can only resume versions already present on npm'
         required: false
         default: ''
-      desktop_mode:
-        description: 'macOS release continuity mode (genesis is manual-dispatch only)'
-        type: choice
-        default: steady
-        options:
-          - steady
-          - genesis
-      desktop_baseline_tag:
-        description: 'Explicit retained genesis baseline tag; leave empty to require repository latest'
-        required: false
-        default: ''
 
 # PG-16: per-job least-privilege; id-token only on publish.
 permissions:
   contents: read
 
 concurrency:
-  group: stable-desktop-coordinator
+  group: npm-release-coordinator
   cancel-in-progress: false
   queue: max
 
@@ -59,12 +48,8 @@ jobs:
     outputs:
       package: ${{ steps.parse.outputs.package }}
       version: ${{ steps.parse.outputs.version }}
-      desktop_version: ${{ steps.parse.outputs.desktop_version }}
       ref: ${{ steps.parse.outputs.ref }}
       commit: ${{ steps.parse.outputs.commit }}
-      desktop_mode: ${{ steps.parse.outputs.desktop_mode }}
-      desktop_baseline_tag: ${{ steps.parse.outputs.desktop_baseline_tag }}
-      desktop_enabled: ${{ steps.parse.outputs.desktop_enabled }}
     steps:
       # Needed only when workflow_dispatch is invoked with an empty tag input —
       # we resolve the version from packages/<package>/package.json on the
@@ -74,11 +59,8 @@ jobs:
           persist-credentials: false
       - id: parse
         env:
-          DESKTOP_ENABLED_INPUT: ${{ vars.ENABLE_DESKTOP_MACOS_RELEASE }}
           DISPATCH_TAG_INPUT: ${{ github.event.inputs.tag }}
           DISPATCH_PACKAGE_INPUT: ${{ github.event.inputs.package }}
-          DISPATCH_MODE_INPUT: ${{ github.event.inputs.desktop_mode }}
-          DISPATCH_BASELINE_TAG_INPUT: ${{ github.event.inputs.desktop_baseline_tag }}
           WORKFLOW_EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_REF_NAME: ${{ github.ref_name }}
@@ -119,47 +101,6 @@ jobs:
             exit 1
           fi
           COMMIT=$(git rev-parse "refs/tags/$TAG^{commit}")
-          DESKTOP_VERSION=$(git show "$COMMIT:apps/desktop/package.json" | jq -er '.version')
-          if ! printf '%s' "$DESKTOP_VERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
-            echo "::error::Desktop version '$DESKTOP_VERSION' is not stable SemVer"
-            exit 1
-          fi
-          MODE="steady"
-          BASELINE_TAG="none"
-          DESKTOP_ENABLED=false
-          if [ "$DESKTOP_ENABLED_INPUT" = "true" ]; then
-            DESKTOP_ENABLED=true
-          fi
-          if [ "$WORKFLOW_EVENT_NAME" = "workflow_dispatch" ]; then
-            MODE="$DISPATCH_MODE_INPUT"
-            if [ -n "$DISPATCH_BASELINE_TAG_INPUT" ]; then
-              BASELINE_TAG="$DISPATCH_BASELINE_TAG_INPUT"
-            fi
-          fi
-          if [ "$MODE" = "genesis" ] && [ "$WORKFLOW_EVENT_NAME" != "workflow_dispatch" ]; then
-            echo "::error::Genesis mode is allowed only by an explicit manual dispatch"
-            exit 1
-          fi
-          if [ "$MODE" = "genesis" ] && { [ -z "$INPUT_TAG" ] || [ "$PACKAGE" != "cycling-coach" ]; }; then
-            echo "::error::Genesis requires an explicitly supplied cycling-coach tag"
-            exit 1
-          fi
-          if [ "$MODE" = "genesis" ] && [ "$DESKTOP_ENABLED" != "true" ]; then
-            echo "::error::Genesis requires ENABLE_DESKTOP_MACOS_RELEASE=true"
-            exit 1
-          fi
-          if [ "$MODE" = "genesis" ] && [ "$BASELINE_TAG" != "none" ]; then
-            echo "::error::Genesis cannot consume a prior desktop baseline"
-            exit 1
-          fi
-          if [ "$BASELINE_TAG" != "none" ] && ! printf '%s' "$BASELINE_TAG" | grep -Eq '^cycling-coach@[1-9][0-9]{3}\.([1-9]|1[0-2])\.(0|[1-9][0-9]*)$'; then
-            echo "::error::Explicit desktop baseline tag is invalid"
-            exit 1
-          fi
-          if [ "$MODE" != "steady" ] && [ "$MODE" != "genesis" ]; then
-            echo "::error::Unsupported desktop release mode '$MODE'"
-            exit 1
-          fi
           if [ "$WORKFLOW_EVENT_NAME" = "workflow_dispatch" ] && \
              [ "$WORKFLOW_REF" != "refs/heads/main" ] && [ "$WORKFLOW_REF" != "refs/tags/$TAG" ]; then
             echo "::error::Manual release dispatch must run from main or the exact release tag"
@@ -171,12 +112,8 @@ jobs:
           fi
           echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "desktop_version=$DESKTOP_VERSION" >> "$GITHUB_OUTPUT"
           echo "ref=$TAG" >> "$GITHUB_OUTPUT"
           echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
-          echo "desktop_mode=$MODE" >> "$GITHUB_OUTPUT"
-          echo "desktop_baseline_tag=$BASELINE_TAG" >> "$GITHUB_OUTPUT"
-          echo "desktop_enabled=$DESKTOP_ENABLED" >> "$GITHUB_OUTPUT"
           echo "::notice::Releasing $PACKAGE @ $VERSION (ref: $TAG)"
 
   build:
@@ -320,7 +257,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: [parse-tag, smoke]
-    environment: ${{ needs.parse-tag.outputs.package == 'cycling-coach' && needs.parse-tag.outputs.desktop_enabled == 'true' && 'npm-production' || '' }}
+    environment: npm-production
     # Per-package serialization. Two cycling-coach releases on the same day
     # never run in parallel (avoids any same-tag publish race), but cycling
     # and running can publish at the same time once both are real binaries.
@@ -380,9 +317,8 @@ jobs:
         # is granted (no NPM_TOKEN secret needed). The trusted publisher
         # must be configured per-package on npmjs.com (one-time operator
         # action; matches repo `yerzhansa/enduragent` + workflow
-        # `release.yml`). Keep the npm publisher environment-unbound while
-        # package-only releases remain environment-free; the conditional
-        # `npm-production` environment above is a GitHub approval boundary.
+        # `release.yml`). The `npm-production` environment is the package
+        # publication boundary; desktop tags cannot enter it.
         run: |
           set -euo pipefail
           PACKAGE="$RELEASE_PACKAGE"
@@ -620,7 +556,7 @@ jobs:
   prepare-release-draft:
     runs-on: ubuntu-latest
     needs: [parse-tag, verify-npm-publication]
-    if: ${{ needs.parse-tag.outputs.package == 'cycling-coach' && needs.parse-tag.outputs.desktop_enabled == 'true' }}
+    if: ${{ false }}
     permissions:
       contents: write
     outputs:
@@ -684,7 +620,7 @@ jobs:
   desktop-release:
     runs-on: ubuntu-latest
     needs: [parse-tag, verify-npm-publication, prepare-release-draft]
-    if: ${{ needs.parse-tag.outputs.package == 'cycling-coach' && needs.parse-tag.outputs.desktop_enabled == 'true' }}
+    if: ${{ false }}
     permissions:
       actions: write
       contents: read
@@ -753,7 +689,6 @@ jobs:
   publish-package-only-release:
     runs-on: ubuntu-latest
     needs: [parse-tag, verify-npm-publication]
-    if: ${{ needs.parse-tag.outputs.package != 'cycling-coach' || needs.parse-tag.outputs.desktop_enabled != 'true' }}
     permissions:
       contents: write
     steps:
@@ -761,7 +696,7 @@ jobs:
         with:
           ref: ${{ needs.parse-tag.outputs.commit }}
           persist-credentials: false
-      - name: Preserve package-only GitHub Release behavior
+      - name: Publish non-latest package GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_PACKAGE: ${{ needs.parse-tag.outputs.package }}
@@ -774,6 +709,6 @@ jobs:
             echo "::notice::Release $TAG already exists (likely created via UI). Leaving it untouched."
           else
             BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' "packages/$PACKAGE/CHANGELOG.md" | tail -n +2)
-            gh release create "$TAG" --title "$TAG" --notes "$BODY"
+            gh release create "$TAG" --latest=false --title "$TAG" --notes "$BODY"
             echo "::notice::Created GitHub Release $TAG"
           fi

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write   # for `gh workflow run release.yml` after a Version-PR merge
+      actions: write   # dispatch package or desktop release coordinators after a Version-PR merge
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -54,12 +54,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push tags and dispatch release for publishable packages on Version-PR merge
+      - name: Dispatch changed package and desktop releases on Version-PR merge
         # Closes the manual gap between "Version PR merged" and "release fires".
         # When the operator merges the changesets-bot PR, package.json versions
-        # bump on main but no tag is created — release.yml never sees it. This
-        # step ensures <name>@<version> for every non-private packages/*/package.json
-        # resolves to this commit, then dispatches release.yml for it.
+        # bump on main but no tag is created. This step tags and dispatches only
+        # public packages whose versions changed, then independently tags and
+        # dispatches the desktop app when its private SemVer changed.
         #
         # Why dispatch instead of relying on the `push: tags:` trigger in
         # release.yml: GitHub blocks workflow runs from events triggered by
@@ -78,6 +78,7 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_COMMIT=$(git rev-parse HEAD)
+          PREVIOUS_COMMIT=$(git rev-parse HEAD^)
           for pkg_json in packages/*/package.json; do
             PRIVATE=$(node -p "require('./$pkg_json').private === true")
             if [ "$PRIVATE" = "true" ]; then
@@ -85,6 +86,11 @@ jobs:
             fi
             NAME=$(node -p "require('./$pkg_json').name")
             VERSION=$(node -p "require('./$pkg_json').version")
+            PREVIOUS_VERSION=$(git show "$PREVIOUS_COMMIT:$pkg_json" | jq -er '.version')
+            if [ "$VERSION" = "$PREVIOUS_VERSION" ]; then
+              echo "::notice::$NAME remains at $VERSION — skipping npm release"
+              continue
+            fi
             TAG="$NAME@$VERSION"
             if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
               git fetch --force --no-tags origin "refs/tags/$TAG:refs/tags/$TAG"
@@ -115,3 +121,40 @@ jobs:
             fi
             echo "::notice::Dispatched release.yml on exact tag $TAG"
           done
+
+          DESKTOP_PACKAGE_JSON=apps/desktop/package.json
+          DESKTOP_VERSION=$(jq -er '.version' "$DESKTOP_PACKAGE_JSON")
+          PREVIOUS_DESKTOP_VERSION=$(git show "$PREVIOUS_COMMIT:$DESKTOP_PACKAGE_JSON" | jq -er '.version')
+          if [ "$DESKTOP_VERSION" = "$PREVIOUS_DESKTOP_VERSION" ]; then
+            echo "::notice::Desktop remains at $DESKTOP_VERSION — skipping desktop release"
+            exit 0
+          fi
+          DESKTOP_TAG="enduragent-desktop@$DESKTOP_VERSION"
+          if git ls-remote --exit-code --tags origin "refs/tags/$DESKTOP_TAG" >/dev/null 2>&1; then
+            git fetch --force --no-tags origin "refs/tags/$DESKTOP_TAG:refs/tags/$DESKTOP_TAG"
+            DESKTOP_TAG_COMMIT=$(git rev-parse "refs/tags/$DESKTOP_TAG^{commit}")
+            if [ "$DESKTOP_TAG_COMMIT" != "$RELEASE_COMMIT" ]; then
+              echo "::error::Existing tag $DESKTOP_TAG resolves to $DESKTOP_TAG_COMMIT, expected $RELEASE_COMMIT"
+              exit 1
+            fi
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$DESKTOP_TAG" -f sha="$RELEASE_COMMIT" >/dev/null
+            echo "::notice::Created tag $DESKTOP_TAG at $RELEASE_COMMIT"
+          fi
+          DISPATCHED=false
+          for attempt in $(seq 1 6); do
+            if gh workflow run desktop-release-coordinator.yml --ref "$DESKTOP_TAG" \
+              -f tag="$DESKTOP_TAG" -f desktop_mode=steady; then
+              DISPATCHED=true
+              break
+            fi
+            if [ "$attempt" -lt 6 ]; then
+              sleep $((attempt * 2))
+            fi
+          done
+          if [ "$DISPATCHED" != "true" ]; then
+            echo "::error::Unable to dispatch desktop release for $DESKTOP_TAG after bounded retries"
+            exit 1
+          fi
+          echo "::notice::Dispatched desktop release for $DESKTOP_TAG"

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -36,9 +36,11 @@ Current state of the Core/Sport seam:
 
 ## Release flow
 
-Changesets-driven, tag-triggered, two-workflow split:
+Changesets-driven, tag-triggered release split:
 
-1. **`version-pr.yml`** runs on every push to `main`. It (a) opens or updates the bot-managed "Version Packages" PR whenever unconsumed `.changeset/*.md` files exist, and (b) when that PR is merged, auto-pushes `<package>@<version>` tags for every non-private bumped package. The tag push is what fires the next workflow.
-2. **`release.yml`** runs on tag push (`cycling-coach@*`, `running-coach@*`, `duathlon-coach@*`). It gates on build + test + smoke-install of the packed tarball, then publishes to npm via OIDC trusted publisher (no `NPM_TOKEN`), and auto-creates the GitHub Release with notes pulled from `CHANGELOG.md`.
+1. **`version-pr.yml`** opens or updates the bot-managed "Version Packages" PR. When that PR is merged, it tags and dispatches only public packages whose versions changed; a changed desktop app is independently tagged as `enduragent-desktop@<SemVer>`.
+2. **`release.yml`** handles npm packages only. It gates on build + test + smoke-install, publishes via OIDC trusted publisher, and creates a non-latest GitHub Release so package releases cannot replace the desktop updater feed.
+3. **`desktop-release-coordinator.yml`** validates the desktop tag against `apps/desktop/package.json`, binds a draft to the exact commit and desktop changelog, then dispatches the protected macOS transaction without publishing npm.
+4. **`desktop-release.yml`** signs and notarizes on macOS, verifies the exact four updater assets, exercises the production `N → N+1` updater round trip, promotes metadata last, and activates the tested release as repository latest.
 
-Currently only `cycling-coach` is publishable (per ADR-0009); the other six packages are `private: true` and skipped by both the changesets bump path and the tag-push step. `tools/bump-binaries-to-calver.ts` overrides changesets' SemVer bumps with today's UTC `YYYY.M.D` for the publishable binaries and queries npm to refuse occupied or non-monotonic dates. See `CONTRIBUTING.md` for the contributor-side steps.
+Currently only `cycling-coach` is npm-publishable (per ADR-0009). The private desktop app follows its own SemVer and release transaction; changing it never changes or publishes `cycling-coach`. See `CONTRIBUTING.md` for the contributor-side steps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,18 +146,18 @@ Calendar-based for npm-published binaries: stable, SemVer-compatible UTC calenda
 
 ## Releasing
 
-Changesets-driven and CI-automated. Contributors do **not** create tags or GitHub Releases by hand — those steps are wrong, and the tag namespace is `<package>@<version>` (e.g., `cycling-coach@2026.5.4`), not a `v`-prefixed CalVer tag.
+Changesets-driven and CI-automated. Contributors do **not** create tags or GitHub Releases by hand. npm packages use `<package>@<version>` tags; the independent desktop app uses `enduragent-desktop@<SemVer>`.
 
 1. **Add a changeset to your PR.** Run `pnpm exec changeset`, pick the affected publishable package(s), describe the change in athlete-readable language. Commit the resulting `.changeset/<slug>.md`. A PR with a user-visible change but no changeset will skip release — this is intentional, not a bug. The required patch/minor/major choice is overridden by the CalVer policy for binary packages.
 
    For user-visible changes, add a `User-facing: <one-sentence description>` line at the top of the changeset body — see `.changeset/README.md` for the convention. The bot's `/whatsnew` command surfaces only those lines to athletes; engineering details, hashes, and infra-only changesets stay in `CHANGELOG.md` for git history but never reach users.
 
 2. **Merge your PR to `main`.** `version-pr.yml` opens (or updates) a bot-managed "Version Packages" PR aggregating all pending changesets.
-3. **Merge the "Version Packages" PR when ready to ship.** It bumps `package.json` + CHANGELOG.md for the listed packages plus their internal dependents (per `updateInternalDependencies: "patch"` in `.changeset/config.json`). On merge, `version-pr.yml` then auto-pushes `<package>@<version>` tags for every **non-private** bumped package.
-4. **`release.yml` fires on the tag.** It builds, runs tests, packs the binary and smoke-installs the tarball, publishes to npm via OIDC trusted publisher (no `NPM_TOKEN`), and auto-creates the GitHub Release with notes extracted from `CHANGELOG.md`.
+3. **Merge the "Version Packages" PR when ready to ship.** It bumps only the packages listed by pending changesets. On merge, `version-pr.yml` tags and dispatches only public package versions that changed; if `apps/desktop/package.json` changed, it separately creates `enduragent-desktop@<SemVer>` and dispatches the desktop coordinator.
+4. **The matching release path runs.** `release.yml` publishes changed npm packages via OIDC and keeps their GitHub Releases non-latest. `desktop-release-coordinator.yml` publishes no npm package; it dispatches the protected macOS signing, notarization, exact-asset, updater-roundtrip, and metadata-last transaction.
 
 Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is tagged. When a stub binary (`running-coach`, `duathlon-coach`) graduates by flipping `private: false`, it auto-tags on the next Version-PR merge.
 
-**If a release fails partway** (e.g., a flaky smoke test), re-run `release.yml` via Actions → "Run workflow" with the existing tag as input. `workflow_dispatch` is a fallback for re-running on a tag that already exists — it does **not** create the tag, so don't use it before the version-PR-merge has pushed one.
+**If a release fails partway**, re-run the matching coordinator with its existing tag: `release.yml` for npm or `desktop-release-coordinator.yml` for desktop. A rerun never creates or moves a tag.
 
 `tools/bump-binaries-to-calver.ts` runs after `changeset version`. It reads the committed pre-Changesets version and all occupied npm versions, then overrides binary versions with the next stable release number for the current UTC month. It rewrites only the new matching changelog header; historical entries are immutable.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,5 +1,9 @@
 # Enduragent desktop
 
+## Releases and updates
+
+The desktop app uses its own SemVer from `apps/desktop/package.json` and releases under `enduragent-desktop@<version>`; desktop releases never publish or bump the npm package. The protected macOS workflow signs with Developer ID, notarizes with Apple, verifies the DMG, ZIP, blockmap, and `latest-mac.yml`, runs the signed update round trip, and makes the tested release the updater feed only after those checks pass.
+
 ## Open at Login and uninstalling
 
 Turn off **Open at Login** from Enduragent's menu-bar menu before removing the app. macOS can retain an inactive background-items record after unregistering it; Electron may report that record as `not-registered`. This is expected when both login-launch flags are off and does not mean Enduragent will start at login.

--- a/tools/check-changeset-user-facing.test.ts
+++ b/tools/check-changeset-user-facing.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import {
   findChangesetHits,
   discoverPublishedBinaries,
+  discoverUserFacingReleaseTargets,
   main,
   type ChangesetHit,
 } from "./check-changeset-user-facing.js";
@@ -41,13 +42,14 @@ function writeRealisticPackages(): string {
     "packages/cycling-coach/package.json",
     JSON.stringify({ name: "cycling-coach", bin: { "cycling-coach": "dist/index.js" } }),
   );
-  write(
-    "packages/core/package.json",
-    JSON.stringify({ name: "@enduragent/core", private: true }),
-  );
+  write("packages/core/package.json", JSON.stringify({ name: "@enduragent/core", private: true }));
   write(
     "packages/running-coach/package.json",
-    JSON.stringify({ name: "running-coach", bin: { "running-coach": "dist/index.js" }, private: true }),
+    JSON.stringify({
+      name: "running-coach",
+      bin: { "running-coach": "dist/index.js" },
+      private: true,
+    }),
   );
   write(
     "packages/sport-cycling/package.json",
@@ -78,7 +80,11 @@ describe("discoverPublishedBinaries", () => {
     const pkgsDir = writeRealisticPackages();
     write(
       "packages/cycling-coach/package.json",
-      JSON.stringify({ name: "cycling-coach", bin: { "cycling-coach": "dist/index.js" }, private: true }),
+      JSON.stringify({
+        name: "cycling-coach",
+        bin: { "cycling-coach": "dist/index.js" },
+        private: true,
+      }),
     );
     const set = discoverPublishedBinaries(pkgsDir);
     expect([...set]).toEqual([]);
@@ -86,10 +92,7 @@ describe("discoverPublishedBinaries", () => {
 
   it("treats a missing private field as public and an empty bin object as no bin", () => {
     const pkgsDir = writeRealisticPackages();
-    write(
-      "packages/empty-bin/package.json",
-      JSON.stringify({ name: "empty-bin", bin: {} }),
-    );
+    write("packages/empty-bin/package.json", JSON.stringify({ name: "empty-bin", bin: {} }));
     write(
       "packages/string-bin/package.json",
       JSON.stringify({ name: "string-bin", bin: "dist/cli.js" }),
@@ -113,12 +116,31 @@ describe("discoverPublishedBinaries", () => {
   });
 });
 
+describe("discoverUserFacingReleaseTargets", () => {
+  it("includes the independently released private desktop app", () => {
+    const pkgsDir = writeRealisticPackages();
+    expect([...discoverUserFacingReleaseTargets(pkgsDir)].sort()).toEqual([
+      "@enduragent/desktop",
+      "cycling-coach",
+    ]);
+  });
+});
+
 describe("findChangesetHits — User-facing routing", () => {
   it("PASS: a User-facing changeset that names the published binary", () => {
     const pkgsDir = writeRealisticPackages();
     const file = write(
       ".changeset/good.md",
       `---\n"cycling-coach": patch\n---\n\nUser-facing: Added /review command.\n`,
+    );
+    expect(findChangesetHits([file], pkgsDir)).toEqual([]);
+  });
+
+  it("PASS: a User-facing changeset that names only the desktop release", () => {
+    const pkgsDir = writeRealisticPackages();
+    const file = write(
+      ".changeset/desktop.md",
+      `---\n"@enduragent/desktop": patch\n---\n\nUser-facing: Desktop updates are clearer.\n`,
     );
     expect(findChangesetHits([file], pkgsDir)).toEqual([]);
   });

--- a/tools/check-changeset-user-facing.ts
+++ b/tools/check-changeset-user-facing.ts
@@ -6,13 +6,11 @@
 /**
  * Changeset user-facing routing lint — `pnpm check:changeset-userfacing`.
  *
- * The Telegram bot's `/whatsnew` parses `User-facing:` lines out of the
- * published release body. A release body is built by changesets ONLY for
- * packages that actually publish — the private `@enduragent/core` package has
- * no npm release, so a `User-facing:` line filed against `@enduragent/core`
- * alone never reaches an athlete. This gate blocks that misfiling on PR: every
- * changeset whose body carries a `User-facing:` line MUST name at least one
- * PUBLISHED BINARY package in its frontmatter package list.
+ * `User-facing:` lines flow into the release notes for the named product. npm
+ * binary notes feed Telegram's `/whatsnew`; desktop notes feed the independent
+ * signed desktop GitHub Release. A line filed only against an internal package
+ * has no user-facing release destination. This gate blocks that misfiling on
+ * PR: every marked changeset MUST name at least one user-facing release target.
  *
  * "Published binary" is computed DYNAMICALLY from the on-disk package manifests
  * (`packages/<dir>/package.json`), never hardcoded:
@@ -23,6 +21,9 @@
  * and the scoped npm name can diverge. This auto-extends: the moment a sibling
  * binary drops `private` (or sets it false) it joins the set with zero code
  * change; marking the one published binary private auto-removes it.
+ *
+ * The private `@enduragent/desktop` package is an explicit release target: it
+ * ships through the independent signed desktop workflow rather than npm.
  *
  * A changeset with NO `User-facing:` line is unaffected (pure-infra changesets
  * legitimately target only the private packages). `.changeset/README.md` and
@@ -52,6 +53,7 @@ const MD_EXTS = new Set([".md", ".mdx"]);
 const NON_CHANGESET_BASENAMES: ReadonlySet<string> = new Set(["README.md", "config.json"]);
 
 const SKIP_DIRECTIVE = "changeset-userfacing-lint:skip-file";
+const INDEPENDENT_RELEASE_TARGETS: ReadonlySet<string> = new Set(["@enduragent/desktop"]);
 
 const isSkippedFile = makeSkipCheck(SKIP_DIRECTIVE);
 
@@ -158,9 +160,13 @@ export function discoverPublishedBinaries(packagesDir: string): Set<string> {
   return published;
 }
 
+export function discoverUserFacingReleaseTargets(packagesDir: string): Set<string> {
+  return new Set([...discoverPublishedBinaries(packagesDir), ...INDEPENDENT_RELEASE_TARGETS]);
+}
+
 /**
  * Lint a single changeset file. Returns a hit when the body carries a
- * `User-facing:` line but no named frontmatter package is a published binary.
+ * `User-facing:` line but no named frontmatter package is a user-facing release target.
  * Returns `[]` when there is no `User-facing:` line, when the file is skipped,
  * when it is a non-changeset (README/config), or when the routing is correct.
  *
@@ -210,11 +216,11 @@ export function findChangesetHits(
   files: readonly string[],
   packagesDir = "packages",
 ): ChangesetHit[] {
-  const published = discoverPublishedBinaries(packagesDir);
+  const releaseTargets = discoverUserFacingReleaseTargets(packagesDir);
   const out: ChangesetHit[] = [];
   for (const file of files) {
     if (MD_EXTS.has(ext(file))) {
-      out.push(...findHitsInChangesetFile(file, published));
+      out.push(...findHitsInChangesetFile(file, releaseTargets));
     }
   }
   return out;
@@ -229,8 +235,8 @@ function formatHit(hit: ChangesetHit): string {
       ? hit.namedPackages.map((n) => `"${n}"`).join(", ")
       : "(no packages named)";
   return (
-    `${hit.file}:${hit.line}:${hit.column}  has a User-facing line but names no published binary ` +
-    `— named ${named}; add a published binary (e.g. "cycling-coach") to the frontmatter package list`
+    `${hit.file}:${hit.line}:${hit.column}  has a User-facing line but names no release target ` +
+    `— named ${named}; add the affected npm binary or @enduragent/desktop to the frontmatter package list`
   );
 }
 
@@ -247,21 +253,23 @@ export function main(argv: readonly string[]): number {
     return 0;
   }
 
-  const published = discoverPublishedBinaries(DEFAULT_PACKAGES_DIR);
+  const releaseTargets = discoverUserFacingReleaseTargets(DEFAULT_PACKAGES_DIR);
   const hits = findChangesetHits(changesetFiles, DEFAULT_PACKAGES_DIR);
   if (hits.length === 0) {
     console.log(
       `check-changeset-userfacing: ${changesetFiles.length} changeset(s) clean ` +
-        `(published binaries: ${[...published].sort().join(", ") || "none"}).`,
+        `(release targets: ${[...releaseTargets].sort().join(", ") || "none"}).`,
     );
     return 0;
   }
-  console.error(`check-changeset-userfacing: ${hits.length} misfiled User-facing changeset(s) found:`);
+  console.error(
+    `check-changeset-userfacing: ${hits.length} misfiled User-facing changeset(s) found:`,
+  );
   for (const hit of hits) console.error("  " + formatHit(hit));
   console.error(
-    "\nA `User-facing:` line only reaches athletes via /whatsnew if the changeset " +
-      "names a PUBLISHED BINARY package (one with a `bin` field and not `private`). " +
-      `Currently: ${[...published].sort().join(", ") || "none"}. ` +
+    "\nA `User-facing:` line must name a user-facing release target: an npm binary " +
+      "or the independently released @enduragent/desktop app. " +
+      `Currently: ${[...releaseTargets].sort().join(", ") || "none"}. ` +
       "Add it to the changeset frontmatter, or drop the User-facing line if the change " +
       "is pure infra. See .changeset/README.md / CLAUDE.local.md (Changesets).",
   );

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -7,254 +7,315 @@ import { describe, expect, it } from "vitest";
 import { inspectDesktopReleaseWorkflows } from "./check-desktop-release-workflow.js";
 
 const releasePath = resolve(".github/workflows/release.yml");
+const coordinatorPath = resolve(".github/workflows/desktop-release-coordinator.yml");
 const desktopPath = resolve(".github/workflows/desktop-release.yml");
 const versionPath = resolve(".github/workflows/version-pr.yml");
 const npmViewFixturePath = resolve("tools/fixtures/npm-view-cycling-coach-2026.7.28.json");
 
-function sources(): { release: string; desktop: string; version: string } {
+interface WorkflowSources {
+  release: string;
+  coordinator: string;
+  desktop: string;
+  version: string;
+}
+
+function sources(): WorkflowSources {
   return {
     release: readFileSync(releasePath, "utf8"),
+    coordinator: readFileSync(coordinatorPath, "utf8"),
     desktop: readFileSync(desktopPath, "utf8"),
     version: readFileSync(versionPath, "utf8"),
   };
 }
 
-function inspect(release: string, desktop: string, version = sources().version): string[] {
-  return inspectDesktopReleaseWorkflows(release, desktop, version);
+function inspect(source: WorkflowSources): string[] {
+  return inspectDesktopReleaseWorkflows(
+    source.release,
+    source.coordinator,
+    source.desktop,
+    source.version,
+  );
+}
+
+function replaceRequired(source: string, search: string, replacement: string): string {
+  if (!source.includes(search)) throw new TypeError(`Mutation target not found: ${search}`);
+  return source.replace(search, replacement);
+}
+
+function expectIssue(source: WorkflowSources, fragment: string): void {
+  expect(inspect(source).some((issue) => issue.includes(fragment))).toBe(true);
 }
 
 describe("desktop release workflow policy", () => {
-  it("accepts the canonical coordinator and environment-bound workflow", () => {
+  it("accepts the npm-independent desktop coordinator chain", () => {
     const source = sources();
-    expect(inspect(source.release, source.desktop, source.version)).toEqual([]);
-    expect(source.release).toContain("desktop_version: ${{ steps.parse.outputs.desktop_version }}");
-    expect(source.release).toContain("NPM_VERSION: ${{ needs.parse-tag.outputs.version }}");
-    expect(source.release).toContain(
-      "DESKTOP_VERSION: ${{ needs.parse-tag.outputs.desktop_version }}",
-    );
-    expect(source.release).toContain("gh workflow run desktop-release.yml");
-    expect(source.release).toContain(
-      'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
-    );
-    expect(source.desktop).toContain('--npm-version "$NPM_VERSION"');
-    expect(source.desktop).toContain('--desktop-version "$DESKTOP_VERSION"');
+    expect(inspect(source)).toEqual([]);
+    expect(source.coordinator).toContain("^enduragent-desktop@");
+    expect(source.coordinator).toContain('git show "$COMMIT:apps/desktop/package.json"');
+    expect(source.coordinator).toContain('--ref "$RELEASE_TAG"');
+    expect(source.desktop).toContain(".github/workflows/desktop-release-coordinator.yml");
+    expect(source.desktop).not.toMatch(/\bnpm_(?:version|integrity|attestation_url)\b/u);
+    expect(source.version).toContain('DESKTOP_TAG="enduragent-desktop@$DESKTOP_VERSION"');
   });
 
-  it("rejects coupling the desktop version back to the npm version", () => {
+  it("requires the stable desktop tag namespace, manifest version, and exact tag ref", () => {
     const source = sources();
-    const release = source.release.replace(
-      "DESKTOP_VERSION: ${{ needs.parse-tag.outputs.desktop_version }}",
-      "DESKTOP_VERSION: ${{ needs.parse-tag.outputs.version }}",
-    );
-    expect(
-      inspect(release, source.desktop).some((issue) =>
-        issue.includes("frozen version authorities"),
+    const mutations = [
+      replaceRequired(
+        source.coordinator,
+        "^enduragent-desktop@(0|[1-9][0-9]*)",
+        "^cycling-coach@(0|[1-9][0-9]*)",
       ),
-    ).toBe(true);
+      replaceRequired(
+        source.coordinator,
+        'if [ "$MANIFEST_VERSION" != "$VERSION" ]; then',
+        "if false; then",
+      ),
+      replaceRequired(
+        source.coordinator,
+        'test "$WORKFLOW_REF" = "refs/tags/$TAG"',
+        'test "$WORKFLOW_REF" = "refs/heads/main"',
+      ),
+      replaceRequired(
+        source.coordinator,
+        'test "$WORKFLOW_SHA" = "$COMMIT"',
+        'test "$WORKFLOW_SHA" != "$COMMIT"',
+      ),
+    ];
+    for (const coordinator of mutations) {
+      expectIssue({ ...source, coordinator }, "stable enduragent-desktop SemVer");
+    }
   });
 
-  it("rejects pnpm separators that become the transaction command", () => {
+  it("requires a desktop changelog draft with stable non-latest semantics", () => {
     const source = sources();
-    const release = source.release.replace(
-      "desktop-release:transaction verify-npm-provenance",
-      "desktop-release:transaction -- verify-npm-provenance",
+    const wrongChangelog = replaceRequired(
+      source.coordinator,
+      "apps/desktop/CHANGELOG.md",
+      "packages/cycling-coach/CHANGELOG.md",
     );
-    const desktop = source.desktop.replace(
+    const latestDraft = replaceRequired(
+      source.coordinator,
+      "--draft --latest=false --target",
+      "--draft --target",
+    );
+    for (const coordinator of [wrongChangelog, latestDraft]) {
+      expectIssue({ ...source, coordinator }, "non-latest draft from the desktop changelog");
+    }
+  });
+
+  it("requires one exact-tag, npm-independent child dispatch and awaits it", () => {
+    const source = sources();
+    const wrongRef = replaceRequired(source.coordinator, '--ref "$RELEASE_TAG"', "--ref main");
+    const npmCoupled = replaceRequired(
+      source.coordinator,
+      '            -f desktop_version="$DESKTOP_VERSION" \\\n',
+      '            -f npm_version="$DESKTOP_VERSION" \\\n            -f desktop_version="$DESKTOP_VERSION" \\\n',
+    );
+    const notAwaited = replaceRequired(
+      source.coordinator,
+      'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
+      'gh run view "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY"',
+    );
+    for (const coordinator of [wrongRef, npmCoupled, notAwaited]) {
+      expectIssue({ ...source, coordinator }, "npm-independent child tuple");
+    }
+  });
+
+  it("requires the child to accept only desktop release inputs", () => {
+    const source = sources();
+    const desktop = replaceRequired(
+      source.desktop,
+      "      desktop_version:\n",
+      "      npm_version:\n        description: Forbidden npm identity\n        required: true\n        type: string\n      desktop_version:\n",
+    );
+    expectIssue({ ...source, desktop }, "only the frozen desktop release tuple");
+    expectIssue({ ...source, desktop }, "must not consume npm release identity");
+  });
+
+  it("authorizes only the active desktop coordinator", () => {
+    const source = sources();
+    const wrongPath = replaceRequired(
+      source.desktop,
+      ".github/workflows/desktop-release-coordinator.yml",
+      ".github/workflows/release.yml",
+    );
+    const noAttempt = replaceRequired(
+      source.desktop,
+      'test "$(printf \'%s\' "$COORDINATOR" | jq -r \'.run_attempt\')" = "$COORDINATOR_RUN_ATTEMPT"',
+      "true",
+    );
+    for (const desktop of [wrongPath, noAttempt]) {
+      expectIssue({ ...source, desktop }, "authorize only its active desktop coordinator");
+    }
+  });
+
+  it("keeps the npm workflow unable to trigger or parse desktop releases", () => {
+    const source = sources();
+    const desktopTrigger = replaceRequired(
+      source.release,
+      "      - 'duathlon-coach@*'",
+      "      - 'duathlon-coach@*'\n      - 'enduragent-desktop@*'",
+    );
+    expectIssue({ ...source, release: desktopTrigger }, "must not authorize desktop candidates");
+
+    const enabledLegacy = replaceRequired(source.release, "if: ${{ false }}", "if: ${{ true }}");
+    expectIssue({ ...source, release: enabledLegacy }, "must remain literally disabled");
+  });
+
+  it("keeps npm GitHub releases non-latest and non-destructive", () => {
+    const source = sources();
+    const release = replaceRequired(
+      source.release,
+      'gh release create "$TAG" --latest=false --title',
+      'gh release create "$TAG" --title',
+    );
+    expectIssue({ ...source, release }, "npm GitHub releases must be verified, non-latest");
+  });
+
+  it("skips unchanged public package versions before tagging", () => {
+    const source = sources();
+    const version = replaceRequired(
+      source.version,
+      'if [ "$VERSION" = "$PREVIOUS_VERSION" ]; then',
+      'if [ "$VERSION" != "$PREVIOUS_VERSION" ]; then',
+    );
+    expectIssue({ ...source, version }, "skip unchanged npm versions");
+  });
+
+  it("independently tags and dispatches changed desktop versions on the exact tag", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.version,
+        'DESKTOP_TAG="enduragent-desktop@$DESKTOP_VERSION"',
+        'DESKTOP_TAG="cycling-coach@$DESKTOP_VERSION"',
+      ),
+      replaceRequired(
+        source.version,
+        'gh workflow run desktop-release-coordinator.yml --ref "$DESKTOP_TAG"',
+        "gh workflow run desktop-release-coordinator.yml --ref main",
+      ),
+      replaceRequired(
+        source.version,
+        "gh workflow run desktop-release-coordinator.yml",
+        "gh workflow run desktop-release.yml",
+      ),
+    ];
+    for (const version of mutations) {
+      expectIssue({ ...source, version }, "independently tag and dispatch changed desktop SemVer");
+    }
+  });
+
+  it("rejects pnpm separators that become transaction arguments", () => {
+    const source = sources();
+    const desktop = replaceRequired(
+      source.desktop,
       "desktop-release:transaction baseline",
       "desktop-release:transaction -- baseline",
     );
-    for (const mutated of [inspect(release, source.desktop), inspect(source.release, desktop)]) {
-      expect(mutated.some((issue) => issue.includes("pnpm argument separator"))).toBe(true);
-    }
+    expectIssue({ ...source, desktop }, "pnpm argument separator");
   });
 
-  it("rejects signing write permission and publication signing secrets", () => {
+  it("keeps signing permission and secrets exclusive", () => {
     const source = sources();
-    const mutated = source.desktop
-      .replace("contents: read\n    outputs:", "contents: write\n    outputs:")
-      .replaceAll("GITHUB_TOKEN: ${{ github.token }}", "CSC_LINK: ${{ secrets.CSC_LINK }}");
-    const issues = inspect(source.release, mutated);
-    expect(issues.some((issue) => issue.includes("macOS signing permissions"))).toBe(true);
-    expect(issues.some((issue) => issue.includes("escaped the signing job"))).toBe(true);
+    const githubTokenBinding = ["GITHUB_TOKEN", "${{ github.token }}"].join(": ");
+    const desktop = replaceRequired(
+      source.desktop,
+      "contents: read\n    outputs:",
+      "contents: write\n    outputs:",
+    ).replaceAll(githubTokenBinding, "CSC_LINK: ${{ secrets.CSC_LINK }}");
+    expectIssue({ ...source, desktop }, "macOS signing permissions");
+    expectIssue({ ...source, desktop }, "escaped the signing job");
   });
 
-  it("requires workspace dependencies before macOS packaging", () => {
+  it("requires workspace dependencies and signing environment secrets before packaging", () => {
     const source = sources();
-    const desktop = source.desktop.replace("      - run: pnpm -r build\n", "");
-    expect(
-      inspect(source.release, desktop).some((issue) =>
-        issue.includes("build workspace dependencies before packaging"),
-      ),
-    ).toBe(true);
-  });
-
-  it("requires a direct dispatch and available signing environment secrets", () => {
-    const source = sources();
-    const reusable = source.desktop.replace("workflow_dispatch:", "workflow_call:");
-    const unchecked = source.desktop.replace(
+    const noBuild = replaceRequired(source.desktop, "      - run: pnpm -r build\n", "");
+    expectIssue({ ...source, desktop: noBuild }, "build workspace dependencies before packaging");
+    const unchecked = replaceRequired(
+      source.desktop,
       "for secret_name in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_API_KEY_P8_BASE64; do",
       "for secret_name in CSC_LINK; do",
     );
-    expect(
-      inspect(source.release, reusable).some((issue) =>
-        issue.includes("workflow_dispatch-only"),
-      ),
-    ).toBe(true);
-    expect(
-      inspect(source.release, unchecked).some((issue) =>
-        issue.includes("fail closed when an environment secret is unavailable"),
-      ),
-    ).toBe(true);
+    expectIssue({ ...source, desktop: unchecked }, "fail closed when an environment secret");
   });
 
-  it("rejects reordered jobs and draft semantics on the default package-only path", () => {
+  it("requires protected publication, latest, and compensation environments", () => {
     const source = sources();
-    const desktop = source.desktop.replace("needs: sign-macos", "needs: promote-latest");
-    const release = source.release.replace(
-      'gh release create "$TAG" --title "$TAG" --notes "$BODY"',
-      'gh release create "$TAG" --draft --latest=false --title "$TAG" --notes "$BODY"',
+    const desktop = replaceRequired(
+      source.desktop,
+      "environment: desktop-macos-latest",
+      "environment: desktop-macos-publication",
     );
-    const issues = inspect(release, desktop);
-    expect(issues.some((issue) => issue.includes("verification must follow signing"))).toBe(true);
-    expect(issues.some((issue) => issue.includes("create-normal-or-leave-existing"))).toBe(true);
-  });
-
-  it("rejects reusable triggers and activation that bypasses native acceptance", () => {
-    const source = sources();
-    const desktop = source.desktop
-      .replace("workflow_dispatch:", "workflow_call:")
-      .replace(
-        "needs.verify-production-update.result == 'success'",
-        "needs.verify-production-update.result != 'failure'",
-      );
-    const issues = inspect(source.release, desktop);
-    expect(issues.some((issue) => issue.includes("workflow_dispatch-only"))).toBe(true);
-    expect(issues.some((issue) => issue.includes("mode-specific acceptance gate"))).toBe(true);
-  });
-
-  it("requires observation, production-feed round trip, and compensation", () => {
-    const source = sources();
-    const mutations = [
-      {
-        desktop: source.desktop.replace(
-          "desktop-release:transaction observe",
-          "desktop-release:transaction verify",
-        ),
-        issue: "bind latest before provisional publication",
-      },
-      {
-        desktop: source.desktop.replace("test:macos-update-roundtrip", "test:disabled-roundtrip"),
-        issue: "native production-feed N-to-N+1 round trip",
-      },
-      {
-        desktop: source.desktop.replace(
-          "test:macos-update-roundtrip \\",
-          "test:macos-update-roundtrip -- \\",
-        ),
-        issue: "native production-feed N-to-N+1 round trip",
-      },
-      {
-        desktop: source.desktop.replace(
-          "needs.activate-release.result != 'success'",
-          "needs.activate-release.result == 'failure'",
-        ),
-        issue: "restore the observed latest",
-      },
-    ];
-    for (const mutation of mutations) {
-      expect(
-        inspect(source.release, mutation.desktop).some((issue) => issue.includes(mutation.issue)),
-      ).toBe(true);
-    }
-  });
-
-  it("rejects a desktop dispatcher without actions write permission", () => {
-    const source = sources();
-    const release = source.release.replace(
-      "    permissions:\n      actions: write\n      contents: read\n    steps:",
-      "    steps:",
+    expectIssue(
+      { ...source, desktop },
+      "write-authority desktop jobs must use protected environments",
     );
-    expect(
-      inspect(release, source.desktop).some((issue) =>
-        issue.includes("desktop dispatcher permissions"),
-      ),
-    ).toBe(true);
   });
 
-  it("requires the coordinator to correlate and await the dispatched desktop run", () => {
+  it("requires exact asset staging, metadata-last publication, and latest CAS", () => {
     const source = sources();
-    const release = source.release
-      .replace('--arg title "$EXPECTED_TITLE"', '--arg title "$RELEASE_TAG"')
-      .replace(
-        'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
-        'gh run view "$DESKTOP_RUN_ID"',
-      );
-    expect(
-      inspect(release, source.desktop).some((issue) =>
-        issue.includes("dispatch, correlate, and await the exact child run"),
-      ),
-    ).toBe(true);
-  });
-
-  it("requires explicit repository context without a checkout", () => {
-    const source = sources();
-    const release = source.release.replace(
-      '--repo "$GITHUB_REPOSITORY"',
-      '--repo "missing/repository"',
+    const noStage = replaceRequired(
+      source.desktop,
+      "desktop-release:transaction stage",
+      "desktop-release:transaction verify",
     );
-    expect(
-      inspect(release, source.desktop).some((issue) =>
-        issue.includes("dispatch, correlate, and await the exact child run"),
-      ),
-    ).toBe(true);
-  });
-
-  it("rejects desktop signing that is not bound to an active release coordinator", () => {
-    const source = sources();
-    const desktop = source.desktop
-      .replace("    needs: authorize-coordinator\n", "")
-      .replace("test \"$(printf '%s' \"$COORDINATOR\" | jq -r '.status')\" = 'in_progress'", "true");
-    expect(
-      inspect(source.release, desktop).some((issue) =>
-        issue.includes("bind to its active release coordinator"),
-      ),
-    ).toBe(true);
-  });
-
-  it("binds manual recovery tooling to the coordinator and exact release overlay", () => {
-    const source = sources();
-    const unboundDispatch = source.release.replace(
-      '-f tooling_commit="$RELEASE_TOOLING_COMMIT" \\\n',
-      "",
+    expectIssue({ ...source, desktop: noStage }, "stage exact assets");
+    const noObservation = replaceRequired(
+      source.desktop,
+      "desktop-release:transaction observe",
+      "desktop-release:transaction verify",
     );
-    const unboundCoordinator = source.desktop.replace(
+    expectIssue({ ...source, desktop: noObservation }, "bind latest before metadata-last");
+    const noCas = replaceRequired(
+      source.desktop,
+      "desktop-release:transaction promote",
+      "desktop-release:transaction publish",
+    );
+    expectIssue({ ...source, desktop: noCas }, "compare-and-swap");
+  });
+
+  it("requires the native production-feed round trip and gated activation", () => {
+    const source = sources();
+    const noRoundTrip = replaceRequired(
+      source.desktop,
+      "test:macos-update-roundtrip",
+      "test:disabled-roundtrip",
+    );
+    expectIssue({ ...source, desktop: noRoundTrip }, "production-feed N-to-N+1 round trip");
+    const bypass = replaceRequired(
+      source.desktop,
+      "needs.verify-production-update.result == 'success'",
+      "needs.verify-production-update.result != 'failure'",
+    );
+    expectIssue({ ...source, desktop: bypass }, "mode-specific acceptance");
+  });
+
+  it("requires compensation to restore prior latest and withdraw the candidate", () => {
+    const source = sources();
+    const desktop = replaceRequired(
+      source.desktop,
+      "needs.activate-release.result != 'success'",
+      "needs.activate-release.result == 'failure'",
+    );
+    expectIssue({ ...source, desktop }, "restore prior latest");
+  });
+
+  it("binds recovery tooling to the coordinator and audited overlay", () => {
+    const source = sources();
+    const unbound = replaceRequired(
+      source.desktop,
       'test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"',
       "true",
     );
-    const productOverlay = source.desktop.replace(
+    expectIssue({ ...source, desktop: unbound }, "active desktop coordinator");
+    const productOverlay = replaceRequired(
+      source.desktop,
       "apps/desktop/scripts/macos-release-plan.d.mts\\n",
       "apps/desktop/src/main/index.ts\\n",
     );
-
-    expect(source.desktop).not.toContain(
-      'git diff --name-only "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"',
-    );
-
-    expect(
-      inspect(unboundDispatch, source.desktop).some((issue) =>
-        issue.includes("dispatch, correlate, and await"),
-      ),
-    ).toBe(true);
-    expect(
-      inspect(source.release, unboundCoordinator).some((issue) =>
-        issue.includes("active release coordinator"),
-      ),
-    ).toBe(true);
-    expect(
-      inspect(source.release, productOverlay).some((issue) =>
-        issue.includes("overlay only audited release tooling"),
-      ),
-    ).toBe(true);
+    expectIssue({ ...source, desktop: productOverlay }, "overlay only audited release tooling");
   });
 
   it("uses a byte-deterministic npm alias packer", () => {
@@ -286,222 +347,81 @@ describe("desktop release workflow policy", () => {
     }
   });
 
-  it("binds downstream verification to the successful signing attempt", () => {
+  it("binds every consumer to the successful signing attempt", () => {
     const source = sources();
-    const desktop = source.desktop.replace(
+    const desktop = replaceRequired(
+      source.desktop,
       "SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}",
       "SIGNING_RUN_ATTEMPT: ${{ github.run_attempt }}",
     );
-    expect(
-      inspect(source.release, desktop).some((issue) =>
-        issue.includes("successful signing attempt"),
-      ),
-    ).toBe(true);
+    expectIssue({ ...source, desktop }, "successful signing attempt");
   });
 
-  it("keeps the audit manifest outside the native exact-four verifier boundary", () => {
+  it("keeps native verification on the exact-four public envelope", () => {
     const source = sources();
     const desktop = source.desktop.replaceAll(
       '"$PUBLIC_ENVELOPE"',
       '"$RUNNER_TEMP/desktop-release"',
     );
-    expect(
-      inspect(source.release, desktop).some((issue) =>
-        issue.includes("exact-four public envelope"),
-      ),
-    ).toBe(true);
+    expectIssue({ ...source, desktop }, "exact-four public envelope");
   });
 
-  it("requires explicit genesis packaging, acknowledgement, and native verification", () => {
+  it("requires explicit genesis and steady packaging plus native verification", () => {
     const source = sources();
-    const wrongPackage = source.desktop.replace("package:mac:genesis", "package:mac");
-    const wrongAcknowledgement = source.desktop.replace(
-      "ENDURAGENT_MACOS_GENESIS_VERSION: ${{ inputs.desktop_version }}",
-      "ENDURAGENT_MACOS_GENESIS_VERSION: 0.0.1",
-    );
-    const missingGenesisVerifier = source.desktop.replace(
+    const wrongPackage = replaceRequired(source.desktop, "package:mac:genesis", "package:mac");
+    expectIssue({ ...source, desktop: wrongPackage }, "desktop packaging modes");
+    const wrongVerifier = replaceRequired(
+      source.desktop,
       "verify:mac-genesis-release \\",
       "verify:mac-release \\",
     );
-    const sealedGenesisVerifier = source.desktop.replace(
-      '                "$PUBLIC_ENVELOPE" \\\n',
-      '                "$RUNNER_TEMP/desktop-release" \\\n',
-    );
-    const escapedPackaging = source.desktop.replace(
-      "pnpm desktop-release:transaction verify \\\n",
-      "pnpm --filter @enduragent/desktop package:mac:genesis\n          pnpm desktop-release:transaction verify \\\n",
-    );
-    const constantSigningMode = source.desktop.replace(
-      "RELEASE_MODE: ${{ inputs.mode }}\n          ENDURAGENT_DEVELOPER_ID_IDENTITY:",
-      "RELEASE_MODE: steady\n          ENDURAGENT_DEVELOPER_ID_IDENTITY:",
-    );
-
-    expect(source.desktop).not.toContain("verify:mac-genesis-release --");
-    expect(source.desktop).not.toContain("verify:mac-release --");
-    const constantVerificationMode = source.desktop.replace(
-      '--output "$PUBLIC_ENVELOPE"\n          case "$RELEASE_MODE" in',
-      '--output "$PUBLIC_ENVELOPE"\n          case "genesis" in',
-    );
-    const commentedSigningSelector = source.desktop.replace(
-      '          case "$RELEASE_MODE" in',
-      '          case "genesis" in # case "$RELEASE_MODE" in',
-    );
-    const commentedVerificationSelector = source.desktop.replace(
-      '--output "$PUBLIC_ENVELOPE"\n          case "$RELEASE_MODE" in',
-      '--output "$PUBLIC_ENVELOPE"\n          case "genesis" in # case "$RELEASE_MODE" in',
-    );
-
-    for (const mutated of [
-      wrongPackage,
-      wrongAcknowledgement,
-      missingGenesisVerifier,
-      sealedGenesisVerifier,
-      escapedPackaging,
-      constantSigningMode,
-      constantVerificationMode,
-      commentedSigningSelector,
-      commentedVerificationSelector,
-    ]) {
-      expect(
-        inspect(source.release, mutated).some(
-          (issue) =>
-            issue.includes("packaging modes") || issue.includes("exact-four public envelope"),
-        ),
-      ).toBe(true);
-    }
+    expectIssue({ ...source, desktop: wrongVerifier }, "exact-four public envelope");
   });
 
-  it("requires independent candidate identity binding", () => {
+  it("requires independent candidate identity continuity", () => {
     const source = sources();
-    const mutations = [
-      source.desktop.replace('test "$INDEPENDENT_CDHASH" = "$CANDIDATE_CDHASH"', "true"),
-      source.desktop.replace(
-        'test "$INDEPENDENT_CODE_DIRECTORY_SHA256" = "$CANDIDATE_CODE_DIRECTORY_SHA256"',
-        "true",
-      ),
-      source.desktop.replace(
-        'test "$INDEPENDENT_SIGNING_IDENTITY" = "$SIGNING_IDENTITY"',
-        '# test "$INDEPENDENT_SIGNING_IDENTITY" = "$SIGNING_IDENTITY"',
-      ),
-    ];
-
-    for (const mutated of mutations) {
-      expect(
-        inspect(source.release, mutated).some((issue) =>
-          issue.includes("mode-specific native verification"),
-        ),
-      ).toBe(true);
-    }
+    const desktop = replaceRequired(
+      source.desktop,
+      'test "$INDEPENDENT_CODE_DIRECTORY_SHA256" = "$CANDIDATE_CODE_DIRECTORY_SHA256"',
+      "true",
+    );
+    expectIssue({ ...source, desktop }, "exact-four public envelope");
   });
 
-  it("keeps signing credentials exclusive and always removes the notarization key", () => {
+  it("always removes the privately-created notarization key", () => {
     const source = sources();
-    const cleanupStep =
-      '      - name: Remove temporary notarization key\n        if: ${{ always() }}\n        run: rm -f "$RUNNER_TEMP/AuthKey.p8"\n';
-    const missingCleanup = source.desktop.replace(cleanupStep, "");
-    const permissiveCreation = source.desktop.replace("          umask 077\n", "");
-    const divergentKeyPath = source.desktop.replace(
-      "APPLE_API_KEY: ${{ runner.temp }}/AuthKey.p8",
-      "APPLE_API_KEY: ${{ runner.temp }}/OtherKey.p8",
+    const noUmask = replaceRequired(source.desktop, "          umask 077\n", "");
+    expectIssue({ ...source, desktop: noUmask }, "created privately and always removed");
+    const noCleanup = replaceRequired(
+      source.desktop,
+      '      - name: Remove temporary notarization key\n        if: ${{ always() }}\n        run: rm -f "$RUNNER_TEMP/AuthKey.p8"\n',
+      "",
     );
-    const earlyCleanup = source.desktop
-      .replace(cleanupStep, "")
-      .replace(
-        "      - name: Build signed and notarized macOS envelope\n",
-        `${cleanupStep}      - name: Build signed and notarized macOS envelope\n`,
-      );
-    const leakedVerifierSecret = source.desktop.replace(
-      "  verify-macos-envelope:\n    runs-on: macos-15",
-      "  verify-macos-envelope:\n    environment: desktop-macos-signing\n    env:\n      CSC_LINK: ${{ secrets.CSC_LINK }}\n    runs-on: macos-15",
-    );
-
-    expect(
-      inspect(source.release, missingCleanup).some((issue) => issue.includes("always removed")),
-    ).toBe(true);
-    expect(
-      inspect(source.release, permissiveCreation).some((issue) =>
-        issue.includes("created privately"),
-      ),
-    ).toBe(true);
-    for (const mutated of [divergentKeyPath, earlyCleanup]) {
-      expect(
-        inspect(source.release, mutated).some((issue) => issue.includes("always removed")),
-      ).toBe(true);
-    }
-    const leakedIssues = inspect(source.release, leakedVerifierSecret);
-    expect(leakedIssues.some((issue) => issue.includes("escaped the signing job"))).toBe(true);
-    expect(leakedIssues.some((issue) => issue.includes("exclusive to the signing job"))).toBe(true);
+    expectIssue({ ...source, desktop: noCleanup }, "created privately and always removed");
   });
 
-  it("keeps desktop opt-in and defaults cycling releases to package-only", () => {
+  it("rejects direct GitHub expression interpolation in shell", () => {
     const source = sources();
-    expect(source.release.match(/vars\.ENABLE_DESKTOP_MACOS_RELEASE/gu)).toHaveLength(1);
-    expect(source.release).toContain("needs.parse-tag.outputs.desktop_enabled == 'true'");
-    expect(source.release).toContain("needs.parse-tag.outputs.desktop_enabled != 'true'");
-    const alwaysEnabled = source.release.replaceAll(
-      "needs.parse-tag.outputs.package == 'cycling-coach' && needs.parse-tag.outputs.desktop_enabled == 'true'",
-      "needs.parse-tag.outputs.package == 'cycling-coach'",
-    );
-    expect(
-      inspect(alwaysEnabled, source.desktop).some((issue) =>
-        issue.includes("frozen coordinator opt-in"),
-      ),
-    ).toBe(true);
-    const strandsCycling = source.release.replace(
-      "needs.parse-tag.outputs.package != 'cycling-coach' || needs.parse-tag.outputs.desktop_enabled != 'true'",
-      "needs.parse-tag.outputs.package != 'cycling-coach'",
-    );
-    expect(
-      inspect(strandsCycling, source.desktop).some((issue) => issue.includes("package-only")),
-    ).toBe(true);
-    const splitBrain = source.release.replace(
-      "DESKTOP_ENABLED: ${{ needs.parse-tag.outputs.desktop_enabled }}",
-      "DESKTOP_ENABLED: ${{ vars.ENABLE_DESKTOP_MACOS_RELEASE }}",
-    );
-    expect(
-      inspect(splitBrain, source.desktop).some((issue) => issue.includes("read once and frozen")),
-    ).toBe(true);
-  });
-
-  it("rejects GitHub expressions interpolated directly into shell scripts", () => {
-    const source = sources();
-    const desktop = source.desktop.replace(
+    const desktop = replaceRequired(
+      source.desktop,
       'test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"',
       'test "$ARTIFACT_NAME" = "desktop-release-${{ github.run_id }}-$SIGNING_RUN_ATTEMPT"',
     );
-    expect(
-      inspect(source.release, desktop).some((issue) =>
-        issue.includes("run scripts must receive contexts through env"),
-      ),
-    ).toBe(true);
+    expectIssue({ ...source, desktop }, "run scripts must receive contexts through env");
   });
 
-  it("requires queued exact-tag dispatch recovery", () => {
+  it("retains npm provenance and successful publication-attempt checks", () => {
     const source = sources();
-    const version = source.version
-      .replace("  queue: max\n", "")
-      .replace('--ref "$TAG" -f tag="$TAG"', '--ref main -f tag="$TAG"');
-    const issues = inspect(source.release, source.desktop, version);
-    expect(issues.some((issue) => issue.includes("queue:max"))).toBe(true);
-    expect(issues.some((issue) => issue.includes("exact-tag release dispatch"))).toBe(true);
-  });
-
-  it("requires verified npm outputs and the successful publication tuple", () => {
-    const source = sources();
-    const release = source.release
-      .replace(
-        "NPM_INTEGRITY: ${{ needs.verify-npm-publication.outputs.npm_integrity }}",
-        "NPM_INTEGRITY: ${{ needs.publish-npm.outputs.npm_integrity }}",
-      )
-      .replace("--workflow .github/workflows/release.yml", "--workflow release.yml")
-      .replace(
-        "/actions/runs/$PUBLICATION_RUN_ID/attempts/$PUBLICATION_RUN_ATTEMPT",
-        "/actions/runs/$PUBLICATION_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT",
-      );
-    const issues = inspect(release, source.desktop);
-    expect(issues.some((issue) => issue.includes("verified npm outputs"))).toBe(true);
-    expect(issues.some((issue) => issue.includes("exact signed provenance"))).toBe(true);
-    expect(issues.some((issue) => issue.includes("publication attempt tuple"))).toBe(true);
+    const release = replaceRequired(
+      source.release,
+      "--workflow .github/workflows/release.yml",
+      "--workflow release.yml",
+    ).replace(
+      "/actions/runs/$PUBLICATION_RUN_ID/attempts/$PUBLICATION_RUN_ATTEMPT",
+      "/actions/runs/$PUBLICATION_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT",
+    );
+    expectIssue({ ...source, release }, "exact provenance");
+    expectIssue({ ...source, release }, "publication attempt tuple");
   });
 
   it("uses the public npm view dist evidence shape", () => {

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -16,7 +16,7 @@ function mapping(value: unknown, label: string, issues: string[]): Mapping {
 }
 
 function scalar(value: unknown): string {
-  return typeof value === "string" ? value : JSON.stringify(value);
+  return typeof value === "string" ? value : (JSON.stringify(value) ?? "");
 }
 
 function steps(job: Mapping): Mapping[] {
@@ -40,6 +40,12 @@ function countShellLine(script: string, expected: string): number {
   return script.split(/\r?\n/u).filter((line) => line.trim() === expected).length;
 }
 
+function exactKeys(value: Mapping, expected: string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
+}
+
 function exactPermissions(
   value: unknown,
   expected: Mapping,
@@ -47,12 +53,9 @@ function exactPermissions(
   issues: string[],
 ): void {
   const permissions = mapping(value, `${label} permissions`, issues);
-  const keys = Object.keys(permissions).sort();
-  const expectedKeys = Object.keys(expected).sort();
   if (
-    keys.length !== expectedKeys.length ||
-    keys.some((key, index) => key !== expectedKeys[index]) ||
-    expectedKeys.some((key) => permissions[key] !== expected[key])
+    !exactKeys(permissions, Object.keys(expected)) ||
+    Object.entries(expected).some(([key, permission]) => permissions[key] !== permission)
   ) {
     issues.push(`${label} permissions are not least-privilege`);
   }
@@ -74,132 +77,271 @@ function requireQueue(
   }
 }
 
-function checkCheckouts(source: string, workflow: Mapping, label: string, issues: string[]): void {
+function checkCheckouts(workflow: Mapping, label: string, issues: string[]): void {
   const jobs = mapping(workflow.jobs, `${label}.jobs`, issues);
   for (const [jobName, rawJob] of Object.entries(jobs)) {
     const job = mapping(rawJob, `${label}.jobs.${jobName}`, issues);
     for (const step of steps(job)) {
       if (typeof step.uses === "string" && step.uses.startsWith("actions/checkout@")) {
         const withInputs = mapping(step.with, `${label}.${jobName}.checkout.with`, issues);
-        if (withInputs["persist-credentials"] !== false)
+        if (withInputs["persist-credentials"] !== false) {
           issues.push(`${label} checkout credentials must never persist`);
+        }
+      }
+      if (typeof step.run === "string" && step.run.includes("${{")) {
+        issues.push(`${label} run scripts must receive contexts through env`);
       }
     }
   }
-  for (const run of Object.values(jobs).flatMap((raw) => runs(mapping(raw, label, issues)))) {
-    if (run.includes("${{")) issues.push(`${label} run scripts must receive contexts through env`);
-  }
-  if (source.includes("github.event.inputs") && !source.includes("DISPATCH_TAG_INPUT:"))
-    issues.push("manual release inputs must be routed through step environment variables");
 }
 
-export function inspectDesktopReleaseWorkflows(
-  releaseSource: string,
-  desktopSource: string,
-  versionSource: string,
-): string[] {
-  const issues: string[] = [];
-  let release: Mapping;
-  let desktop: Mapping;
-  let version: Mapping;
-  try {
-    release = mapping(parse(releaseSource), "release workflow", issues);
-    desktop = mapping(parse(desktopSource), "desktop workflow", issues);
-    version = mapping(parse(versionSource), "version workflow", issues);
-  } catch {
-    return ["release workflows must be valid YAML"];
+function checkCoordinator(source: string, coordinator: Mapping, issues: string[]): void {
+  const workflowOn = mapping(coordinator.on, "desktop coordinator.on", issues);
+  if (Object.keys(workflowOn).length !== 1 || !("workflow_dispatch" in workflowOn)) {
+    issues.push("desktop release coordinator must be workflow_dispatch-only");
   }
-
-  if (
-    releaseSource.includes("desktop-release:transaction --") ||
-    desktopSource.includes("desktop-release:transaction --")
-  ) {
-    issues.push("release transaction commands must not pass a pnpm argument separator");
-  }
-
-  const releaseOn = mapping(release.on, "release.on", issues);
-  if (!("push" in releaseOn) || !("workflow_dispatch" in releaseOn))
-    issues.push("release.yml must remain the tag/manual coordinator");
-  const desktopOn = mapping(desktop.on, "desktop.on", issues);
-  if (Object.keys(desktopOn).length !== 1 || !("workflow_dispatch" in desktopOn))
-    issues.push("desktop-release.yml must be workflow_dispatch-only");
   const workflowDispatch = mapping(
-    desktopOn.workflow_dispatch,
-    "desktop.workflow_dispatch",
+    workflowOn.workflow_dispatch,
+    "desktop coordinator.workflow_dispatch",
     issues,
   );
   const inputs = mapping(
     workflowDispatch.inputs,
-    "desktop.workflow_dispatch.inputs",
+    "desktop coordinator.workflow_dispatch.inputs",
     issues,
   );
-  for (const input of [
+  if (!exactKeys(inputs, ["tag", "desktop_mode", "desktop_baseline_tag"])) {
+    issues.push("desktop coordinator inputs must remain desktop-only");
+  }
+  const tagInput = mapping(inputs.tag, "desktop coordinator tag input", issues);
+  const modeInput = mapping(inputs.desktop_mode, "desktop coordinator mode input", issues);
+  if (tagInput.required !== true || tagInput.type !== "string") {
+    issues.push("desktop coordinator must require a string candidate tag");
+  }
+  if (
+    modeInput.type !== "choice" ||
+    modeInput.default !== "steady" ||
+    scalar(modeInput.options) !== '["steady","genesis"]'
+  ) {
+    issues.push("desktop coordinator must expose only steady and genesis modes");
+  }
+  if (coordinator["run-name"] !== "Desktop release coordinator ${{ inputs.tag }}") {
+    issues.push("desktop coordinator run name must bind the candidate tag");
+  }
+  exactPermissions(coordinator.permissions, { contents: "read" }, "desktop coordinator", issues);
+  requireQueue(
+    coordinator.concurrency,
+    "stable-desktop-coordinator",
+    "desktop release coordinator",
+    issues,
+  );
+
+  const jobs = mapping(coordinator.jobs, "desktop coordinator.jobs", issues);
+  const bind = mapping(jobs["bind-release"], "desktop coordinator.jobs.bind-release", issues);
+  const draft = mapping(
+    jobs["prepare-release-draft"],
+    "desktop coordinator.jobs.prepare-release-draft",
+    issues,
+  );
+  const dispatch = mapping(
+    jobs["dispatch-desktop-release"],
+    "desktop coordinator.jobs.dispatch-desktop-release",
+    issues,
+  );
+  exactPermissions(bind.permissions, { contents: "read" }, "desktop candidate binding", issues);
+  exactPermissions(draft.permissions, { contents: "write" }, "desktop draft preparation", issues);
+  exactPermissions(
+    dispatch.permissions,
+    { actions: "write", contents: "read" },
+    "desktop child dispatcher",
+    issues,
+  );
+
+  const bindOutputs = mapping(bind.outputs, "desktop coordinator bind outputs", issues);
+  const expectedBindOutputs: Mapping = {
+    tag: "${{ steps.bind.outputs.tag }}",
+    desktop_version: "${{ steps.bind.outputs.desktop_version }}",
+    commit: "${{ steps.bind.outputs.commit }}",
+    mode: "${{ steps.bind.outputs.mode }}",
+    baseline_tag: "${{ steps.bind.outputs.baseline_tag }}",
+  };
+  if (
+    !exactKeys(bindOutputs, Object.keys(expectedBindOutputs)) ||
+    Object.entries(expectedBindOutputs).some(([key, value]) => bindOutputs[key] !== value)
+  ) {
+    issues.push("desktop coordinator must freeze the candidate release tuple once");
+  }
+  const bindStep = namedStep(bind, "Bind desktop tag, version, and source commit");
+  const bindEnvironment = mapping(bindStep?.env, "desktop candidate binding environment", issues);
+  const bindRun = typeof bindStep?.run === "string" ? bindStep.run : "";
+  if (
+    bindEnvironment.RELEASE_TAG_INPUT !== "${{ inputs.tag }}" ||
+    bindEnvironment.DESKTOP_ENABLED !== "${{ vars.ENABLE_DESKTOP_MACOS_RELEASE }}" ||
+    bindEnvironment.WORKFLOW_REF !== "${{ github.ref }}" ||
+    bindEnvironment.WORKFLOW_SHA !== "${{ github.sha }}" ||
+    (source.match(/vars\.ENABLE_DESKTOP_MACOS_RELEASE/gu) ?? []).length !== 1 ||
+    !bindRun.includes("test \"$DESKTOP_ENABLED\" = 'true'") ||
+    !bindRun.includes(
+      "printf '%s' \"$TAG\" | grep -Eq '^enduragent-desktop@(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$'",
+    ) ||
+    !bindRun.includes('VERSION="${TAG#enduragent-desktop@}"') ||
+    !bindRun.includes('git fetch --force --no-tags origin "refs/tags/$TAG:refs/tags/$TAG"') ||
+    !bindRun.includes('COMMIT=$(git rev-parse "refs/tags/$TAG^{commit}")') ||
+    !bindRun.includes('test "$WORKFLOW_REF" = "refs/tags/$TAG"') ||
+    !bindRun.includes('test "$WORKFLOW_SHA" = "$COMMIT"') ||
+    !bindRun.includes('git show "$COMMIT:apps/desktop/package.json"') ||
+    !bindRun.includes('if [ "$MANIFEST_VERSION" != "$VERSION" ]') ||
+    !bindRun.includes('git merge-base --is-ancestor "$COMMIT" refs/remotes/origin/main') ||
+    !bindRun.includes('echo "desktop_version=$VERSION" >> "$GITHUB_OUTPUT"')
+  ) {
+    issues.push(
+      "desktop candidate tag must be stable enduragent-desktop SemVer bound to apps/desktop/package.json",
+    );
+  }
+
+  const draftNeeds = scalar(draft.needs);
+  const draftOutputs = mapping(draft.outputs, "desktop coordinator draft outputs", issues);
+  const draftStep = namedStep(draft, "Create or validate bound desktop release draft");
+  const draftRun = typeof draftStep?.run === "string" ? draftStep.run : "";
+  if (
+    !draftNeeds.includes("bind-release") ||
+    draftOutputs.draft_id !== "${{ steps.release-draft.outputs.draft_id }}" ||
+    draftOutputs.body_sha256 !== "${{ steps.release-draft.outputs.body_sha256 }}" ||
+    !draftRun.includes("apps/desktop/CHANGELOG.md") ||
+    draftRun.includes("packages/cycling-coach/CHANGELOG.md") ||
+    !draftRun.includes('test "$FIRST_HEADING" = "## $RELEASE_VERSION"') ||
+    !draftRun.includes("--json body,databaseId,isDraft,isPrerelease,tagName") ||
+    !draftRun.includes(".isDraft')\" = 'true'") ||
+    !draftRun.includes(".isPrerelease')\" = 'false'") ||
+    !draftRun.includes('test "$EXISTING_BODY_SHA256" = "$BODY_SHA256"') ||
+    !draftRun.includes(
+      'gh release create "$RELEASE_TAG" --draft --latest=false --target "$RELEASE_COMMIT"',
+    )
+  ) {
+    issues.push(
+      "desktop coordinator must create a bound non-latest draft from the desktop changelog",
+    );
+  }
+
+  const dispatchNeeds = scalar(dispatch.needs);
+  const dispatchStep = namedStep(
+    dispatch,
+    "Dispatch and await environment-bound desktop transaction",
+  );
+  const dispatchEnvironment = mapping(
+    dispatchStep?.env,
+    "desktop coordinator dispatch environment",
+    issues,
+  );
+  const dispatchRun = typeof dispatchStep?.run === "string" ? dispatchStep.run : "";
+  const expectedDispatchEnvironment: Mapping = {
+    RELEASE_TAG: "${{ needs.bind-release.outputs.tag }}",
+    DESKTOP_VERSION: "${{ needs.bind-release.outputs.desktop_version }}",
+    RELEASE_COMMIT: "${{ needs.bind-release.outputs.commit }}",
+    RELEASE_TOOLING_COMMIT: "${{ github.sha }}",
+    RELEASE_DRAFT_ID: "${{ needs.prepare-release-draft.outputs.draft_id }}",
+    RELEASE_MODE: "${{ needs.bind-release.outputs.mode }}",
+    RELEASE_BODY_SHA256: "${{ needs.prepare-release-draft.outputs.body_sha256 }}",
+    RELEASE_BASELINE_TAG: "${{ needs.bind-release.outputs.baseline_tag }}",
+    COORDINATOR_RUN_ID: "${{ github.run_id }}",
+    COORDINATOR_RUN_ATTEMPT: "${{ github.run_attempt }}",
+  };
+  const dispatchedInputs = Array.from(
+    dispatchRun.matchAll(/(?:^|\s)-f ([a-z0-9_]+)=/gu),
+    (match) => match[1],
+  );
+  const expectedDispatchedInputs = [
     "tag",
-    "npm_version",
     "desktop_version",
     "commit",
     "tooling_commit",
     "draft_id",
     "mode",
     "draft_body_sha256",
-    "npm_integrity",
-    "npm_attestation_url",
     "baseline_tag",
     "coordinator_run_id",
     "coordinator_run_attempt",
-  ]) {
-    const declaration = mapping(
-      inputs[input],
-      `desktop.workflow_dispatch.inputs.${input}`,
-      issues,
-    );
-    if (declaration.required !== true || declaration.type !== "string")
-      issues.push(`desktop workflow_dispatch must require string input ${input}`);
-  }
-  const requiredSigningSecrets = [
-    "CSC_LINK",
-    "CSC_KEY_PASSWORD",
-    "APPLE_API_KEY_ID",
-    "APPLE_API_ISSUER",
-    "APPLE_API_KEY_P8_BASE64",
   ];
   if (
-    desktop["run-name"] !==
-    "Desktop release ${{ inputs.tag }} via ${{ inputs.coordinator_run_id }}.${{ inputs.coordinator_run_attempt }}"
-  )
-    issues.push("desktop workflow run name must bind its coordinator invocation");
+    !dispatchNeeds.includes("bind-release") ||
+    !dispatchNeeds.includes("prepare-release-draft") ||
+    Object.entries(expectedDispatchEnvironment).some(
+      ([key, value]) => dispatchEnvironment[key] !== value,
+    ) ||
+    !exactKeys(
+      Object.fromEntries(dispatchedInputs.map((input) => [input, true])),
+      expectedDispatchedInputs,
+    ) ||
+    dispatchedInputs.length !== expectedDispatchedInputs.length ||
+    !dispatchRun.includes("gh workflow run desktop-release.yml \\") ||
+    !dispatchRun.includes('--ref "$RELEASE_TAG"') ||
+    (dispatchRun.match(/--repo "\$GITHUB_REPOSITORY"/gu) ?? []).length !== 3 ||
+    !dispatchRun.includes('--arg title "$EXPECTED_TITLE"') ||
+    !dispatchRun.includes(
+      'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
+    ) ||
+    /npm_version|npm_integrity|npm_attestation_url/u.test(dispatchRun)
+  ) {
+    issues.push("desktop coordinator must dispatch and await one npm-independent child tuple");
+  }
+}
 
-  requireQueue(release.concurrency, "stable-desktop-coordinator", "release coordinator", issues);
-  requireQueue(desktop.concurrency, "stable-desktop", "desktop release", issues);
-  requireQueue(version.concurrency, "version-pr", "version dispatcher", issues);
-  checkCheckouts(releaseSource, release, "release", issues);
-  checkCheckouts(desktopSource, desktop, "desktop", issues);
-  checkCheckouts(versionSource, version, "version", issues);
+function checkNpmRelease(source: string, release: Mapping, issues: string[]): void {
+  const workflowOn = mapping(release.on, "npm release.on", issues);
+  if (!("push" in workflowOn) || !("workflow_dispatch" in workflowOn)) {
+    issues.push("release.yml must remain the npm tag/manual coordinator");
+  }
+  const push = mapping(workflowOn.push, "npm release push trigger", issues);
+  const tags = Array.isArray(push.tags) ? push.tags.map(String) : [];
+  const dispatch = mapping(workflowOn.workflow_dispatch, "npm release workflow_dispatch", issues);
+  const dispatchInputs = mapping(dispatch.inputs, "npm release workflow_dispatch inputs", issues);
+  if (
+    tags.length === 0 ||
+    tags.some((tag) => tag.startsWith("enduragent-desktop@")) ||
+    !exactKeys(dispatchInputs, ["package", "tag"])
+  ) {
+    issues.push("npm release triggers must not authorize desktop candidates");
+  }
+  exactPermissions(release.permissions, { contents: "read" }, "npm release", issues);
+  requireQueue(release.concurrency, "npm-release-coordinator", "npm release", issues);
 
-  const releaseJobs = mapping(release.jobs, "release.jobs", issues);
-  const smoke = mapping(releaseJobs.smoke, "release.jobs.smoke", issues);
-  const npmPublish = mapping(releaseJobs["publish-npm"], "release.jobs.publish-npm", issues);
+  const jobs = mapping(release.jobs, "npm release.jobs", issues);
+  for (const legacyJobName of ["prepare-release-draft", "desktop-release"]) {
+    if (
+      legacyJobName in jobs &&
+      mapping(jobs[legacyJobName], `npm release.jobs.${legacyJobName}`, issues).if !==
+        "${{ false }}"
+    ) {
+      issues.push("legacy npm-side desktop jobs must remain literally disabled");
+    }
+  }
+  const liveJobsText = Object.entries(jobs)
+    .filter(([, rawJob]) => mapping(rawJob, "npm release live job", issues).if !== "${{ false }}")
+    .map(([, rawJob]) => scalar(rawJob))
+    .join("\n");
+  const parseTag = mapping(jobs["parse-tag"], "npm release.jobs.parse-tag", issues);
+  const parseOutputs = mapping(parseTag.outputs, "npm parse-tag outputs", issues);
+  if (
+    Object.keys(parseOutputs).some((key) => key.startsWith("desktop")) ||
+    /apps\/desktop|ENABLE_DESKTOP_MACOS_RELEASE|enduragent-desktop@|desktop-release\.yml/u.test(
+      liveJobsText,
+    )
+  ) {
+    issues.push("npm release workflow must have no live desktop parse or dispatch authority");
+  }
+
+  const smoke = mapping(jobs.smoke, "npm release.jobs.smoke", issues);
+  const npmPublish = mapping(jobs["publish-npm"], "npm release.jobs.publish-npm", issues);
   const npmVerify = mapping(
-    releaseJobs["verify-npm-publication"],
-    "release.jobs.verify-npm-publication",
+    jobs["verify-npm-publication"],
+    "npm release.jobs.verify-npm-publication",
     issues,
   );
-  const draft = mapping(
-    releaseJobs["prepare-release-draft"],
-    "release.jobs.prepare-release-draft",
+  const packageRelease = mapping(
+    jobs["publish-package-only-release"],
+    "npm release.jobs.publish-package-only-release",
     issues,
   );
-  const desktopCall = mapping(
-    releaseJobs["desktop-release"],
-    "release.jobs.desktop-release",
-    issues,
-  );
-  const packageOnly = mapping(
-    releaseJobs["publish-package-only-release"],
-    "release.jobs.publish-package-only-release",
-    issues,
-  );
-
   exactPermissions(
     npmPublish.permissions,
     { actions: "read", contents: "read", "id-token": "write" },
@@ -212,14 +354,15 @@ export function inspectDesktopReleaseWorkflows(
     "npm verification",
     issues,
   );
-  const expectedNpmEnvironment =
-    "${{ needs.parse-tag.outputs.package == 'cycling-coach' && needs.parse-tag.outputs.desktop_enabled == 'true' && 'npm-production' || '' }}";
-  if (npmPublish.environment !== expectedNpmEnvironment)
-    issues.push("desktop npm publication must use the conditional protected environment");
-  if (!scalar(npmVerify.needs).includes("publish-npm") || "environment" in npmVerify)
+  exactPermissions(packageRelease.permissions, { contents: "write" }, "npm GitHub release", issues);
+  if (npmPublish.environment !== "npm-production") {
+    issues.push("npm publication must use the protected npm-production environment");
+  }
+  if (!scalar(npmVerify.needs).includes("publish-npm") || "environment" in npmVerify) {
     issues.push("no-OIDC npm verification must follow publication outside a protected environment");
+  }
 
-  const smokeOutputs = mapping(smoke.outputs, "smoke outputs", issues);
+  const smokeOutputs = mapping(smoke.outputs, "npm smoke outputs", issues);
   for (const output of [
     "artifact_id",
     "artifact_digest",
@@ -230,7 +373,9 @@ export function inspectDesktopReleaseWorkflows(
     "alias_filename",
     "alias_sha512",
   ]) {
-    if (!(output in smokeOutputs)) issues.push(`immutable npm preparation is missing ${output}`);
+    if (!(output in smokeOutputs)) {
+      issues.push(`immutable npm preparation is missing ${output}`);
+    }
   }
   const npmPublishOutputs = mapping(npmPublish.outputs, "npm publish outputs", issues);
   for (const output of [
@@ -241,22 +386,23 @@ export function inspectDesktopReleaseWorkflows(
     "publication_event_name",
     "publication_commit",
   ]) {
-    if (!(output in npmPublishOutputs)) issues.push(`npm publication tuple is missing ${output}`);
+    if (!(output in npmPublishOutputs)) {
+      issues.push(`npm publication tuple is missing ${output}`);
+    }
   }
   const npmVerifyOutputs = mapping(npmVerify.outputs, "npm verification outputs", issues);
   if (
     npmVerifyOutputs.npm_integrity !== "${{ steps.verify.outputs.npm_integrity }}" ||
     npmVerifyOutputs.npm_attestation_url !== "${{ steps.verify.outputs.npm_attestation_url }}"
   ) {
-    issues.push("verified npm integrity and attestation URL must be exposed as job outputs");
+    issues.push("verified npm integrity and attestation URL must remain exposed as job outputs");
   }
 
   const publishText = runs(npmPublish).join("\n");
   const verifyText = runs(npmVerify).join("\n");
   const smokeText = runs(smoke).join("\n");
-  const publishSteps = steps(npmPublish);
   if (
-    publishSteps.some(
+    steps(npmPublish).some(
       (step) =>
         typeof step.uses === "string" &&
         (step.uses.startsWith("actions/checkout@") || step.uses.startsWith("pnpm/action-setup@")),
@@ -268,10 +414,10 @@ export function inspectDesktopReleaseWorkflows(
     );
   }
   if (
-    !releaseSource.includes("actions/upload-artifact@") ||
-    (releaseSource.match(/actions\/download-artifact@[^\n]+# v8/gu) ?? []).length < 2 ||
-    (releaseSource.match(/artifact-ids:/gu) ?? []).length < 2 ||
-    (releaseSource.match(/digest-mismatch: error/gu) ?? []).length < 2
+    !source.includes("actions/upload-artifact@") ||
+    (source.match(/actions\/download-artifact@[^\n]+# v8/gu) ?? []).length < 2 ||
+    (source.match(/artifact-ids:/gu) ?? []).length < 2 ||
+    (source.match(/digest-mismatch: error/gu) ?? []).length < 2
   ) {
     issues.push("npm prepare, publish, and verify must reuse one digest-checked Actions artifact");
   }
@@ -281,9 +427,7 @@ export function inspectDesktopReleaseWorkflows(
     (publishText.match(/--provenance/gu) ?? []).length !== 2 ||
     (publishText.match(/--ignore-scripts/gu) ?? []).length !== 2
   ) {
-    issues.push(
-      "both npm identities must publish exact tarballs through the explicit public registry",
-    );
+    issues.push("both npm identities must publish exact tarballs through the public registry");
   }
   if (
     !smokeText.includes('npm pack "$ALIAS_DIR/extract/package"') ||
@@ -309,11 +453,9 @@ export function inspectDesktopReleaseWorkflows(
     !verifyText.includes(".dist.integrity") ||
     !verifyText.includes(".dist.attestations.url") ||
     verifyText.includes("._attestations") ||
-    releaseSource.includes(".gitHead")
+    source.includes(".gitHead")
   ) {
-    issues.push(
-      "no-OIDC verification must bind public bytes, signatures, and exact signed provenance",
-    );
+    issues.push("no-OIDC verification must bind public bytes, signatures, and exact provenance");
   }
   if (
     !verifyText.includes("PUBLICATION_RUN_ATTEMPT") ||
@@ -331,137 +473,107 @@ export function inspectDesktopReleaseWorkflows(
     canonicalUrl === -1 ||
     fetchUrl <= canonicalUrl ||
     !verifyText.includes('test "$OBSERVED_ATTESTATION_URL" = "$EXPECTED_ATTESTATION_URL"')
-  )
+  ) {
     issues.push("npm attestation URL must be canonicalized before network fetch");
+  }
 
-  exactPermissions(draft.permissions, { contents: "write" }, "draft preparation", issues);
+  const packageReleaseText = runs(packageRelease).join("\n");
   if (
-    !scalar(draft.needs).includes("verify-npm-publication") ||
-    !scalar(packageOnly.needs).includes("verify-npm-publication") ||
-    !scalar(desktopCall.needs).includes("verify-npm-publication")
+    !scalar(packageRelease.needs).includes("verify-npm-publication") ||
+    !packageReleaseText.includes('gh release view "$TAG"') ||
+    !packageReleaseText.includes("Leaving it untouched") ||
+    !packageReleaseText.includes('gh release create "$TAG" --latest=false') ||
+    packageReleaseText.includes("--draft")
   ) {
-    issues.push("GitHub release paths must wait for verified npm publication");
+    issues.push(
+      "npm GitHub releases must be verified, non-latest, and never replace existing releases",
+    );
+  }
+}
+
+function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): void {
+  const workflowOn = mapping(desktop.on, "desktop child.on", issues);
+  if (Object.keys(workflowOn).length !== 1 || !("workflow_dispatch" in workflowOn)) {
+    issues.push("desktop-release.yml must be workflow_dispatch-only");
+  }
+  const workflowDispatch = mapping(workflowOn.workflow_dispatch, "desktop child dispatch", issues);
+  const inputs = mapping(workflowDispatch.inputs, "desktop child inputs", issues);
+  const expectedInputs = [
+    "tag",
+    "desktop_version",
+    "commit",
+    "tooling_commit",
+    "draft_id",
+    "mode",
+    "draft_body_sha256",
+    "baseline_tag",
+    "coordinator_run_id",
+    "coordinator_run_attempt",
+  ];
+  if (!exactKeys(inputs, expectedInputs)) {
+    issues.push("desktop child must accept only the frozen desktop release tuple");
+  }
+  for (const input of expectedInputs) {
+    const declaration = mapping(inputs[input], `desktop child input ${input}`, issues);
+    if (declaration.required !== true || declaration.type !== "string") {
+      issues.push(`desktop workflow_dispatch must require string input ${input}`);
+    }
   }
   if (
-    !releaseSource.includes("--json body,databaseId,isDraft,isPrerelease,tagName") ||
-    !releaseSource.includes('"$IS_PRERELEASE" != "false"')
+    /\bnpm_(?:version|integrity|attestation_url)\b|--npm-(?:version|integrity|attestation-url)\b/u.test(
+      source,
+    )
   ) {
-    issues.push("stable desktop draft preparation must reject prereleases");
+    issues.push("desktop child must not consume npm release identity or provenance");
   }
-  const desktopGate =
-    "${{ needs.parse-tag.outputs.package == 'cycling-coach' && needs.parse-tag.outputs.desktop_enabled == 'true' }}";
-  if (draft.if !== desktopGate || desktopCall.if !== desktopGate)
-    issues.push("desktop transaction must use the frozen coordinator opt-in decision");
-  if ("uses" in desktopCall || desktopCall["runs-on"] !== "ubuntu-latest")
-    issues.push("release.yml must directly dispatch the environment-bound desktop workflow");
+  if (
+    desktop["run-name"] !==
+    "Desktop release ${{ inputs.tag }} via ${{ inputs.coordinator_run_id }}.${{ inputs.coordinator_run_attempt }}"
+  ) {
+    issues.push("desktop child run name must bind its coordinator invocation");
+  }
   exactPermissions(
-    desktopCall.permissions,
-    { actions: "write", contents: "read" },
-    "desktop dispatcher",
+    desktop.permissions,
+    { actions: "read", contents: "read" },
+    "desktop child",
     issues,
   );
-  const dispatchStep = namedStep(
-    desktopCall,
-    "Dispatch and await environment-bound desktop transaction",
-  );
-  const dispatchEnvironment = mapping(
-    dispatchStep?.env,
-    "desktop dispatcher environment",
-    issues,
-  );
-  const dispatchRun = typeof dispatchStep?.run === "string" ? dispatchStep.run : "";
-  if (
-    dispatchEnvironment.NPM_VERSION !== "${{ needs.parse-tag.outputs.version }}" ||
-    dispatchEnvironment.DESKTOP_VERSION !==
-      "${{ needs.parse-tag.outputs.desktop_version }}" ||
-    dispatchEnvironment.NPM_INTEGRITY !==
-      "${{ needs.verify-npm-publication.outputs.npm_integrity }}" ||
-    dispatchEnvironment.NPM_ATTESTATION_URL !==
-      "${{ needs.verify-npm-publication.outputs.npm_attestation_url }}" ||
-    dispatchEnvironment.RELEASE_TOOLING_COMMIT !== "${{ github.sha }}" ||
-    dispatchEnvironment.COORDINATOR_RUN_ID !== "${{ github.run_id }}" ||
-    dispatchEnvironment.COORDINATOR_RUN_ATTEMPT !== "${{ github.run_attempt }}"
-  ) {
-    issues.push(
-      "desktop dispatch must consume frozen version authorities and verified npm outputs",
-    );
-  }
-  if (
-    !dispatchRun.includes("gh workflow run desktop-release.yml \\") ||
-    (dispatchRun.match(/--repo "\$GITHUB_REPOSITORY"/gu) ?? []).length !== 3 ||
-    !dispatchRun.includes('--ref "$DESKTOP_WORKFLOW_REF"') ||
-    !dispatchRun.includes('-f tooling_commit="$RELEASE_TOOLING_COMMIT"') ||
-    !dispatchRun.includes('-f coordinator_run_id="$COORDINATOR_RUN_ID"') ||
-    !dispatchRun.includes('-f coordinator_run_attempt="$COORDINATOR_RUN_ATTEMPT"') ||
-    !dispatchRun.includes('--arg title "$EXPECTED_TITLE"') ||
-    !dispatchRun.includes(
-      'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
-    ) ||
-    !dispatchRun.includes('if [ "$COORDINATOR_REF" = "refs/tags/$RELEASE_TAG" ]')
-  ) {
-    issues.push("desktop coordinator must dispatch, correlate, and await the exact child run");
-  }
+  requireQueue(desktop.concurrency, "stable-desktop", "desktop release", issues);
 
-  const packageOnlyText = scalar(packageOnly);
-  if (
-    packageOnly.if !==
-      "${{ needs.parse-tag.outputs.package != 'cycling-coach' || needs.parse-tag.outputs.desktop_enabled != 'true' }}" ||
-    !packageOnlyText.includes("gh release view") ||
-    !packageOnlyText.includes("Leaving it untouched") ||
-    !packageOnlyText.includes("gh release create") ||
-    packageOnlyText.includes("--draft") ||
-    packageOnlyText.includes("--latest=false")
-  ) {
-    issues.push(
-      "disabled desktop releases must retain the package-only create-normal-or-leave-existing behavior",
-    );
-  }
-  const parseTag = mapping(releaseJobs["parse-tag"], "release.jobs.parse-tag", issues);
-  const parseOutputs = mapping(parseTag.outputs, "parse-tag outputs", issues);
-  if (
-    parseOutputs.desktop_enabled !== "${{ steps.parse.outputs.desktop_enabled }}" ||
-    parseOutputs.desktop_version !== "${{ steps.parse.outputs.desktop_version }}" ||
-    !releaseSource.includes('git show "$COMMIT:apps/desktop/package.json"') ||
-    !releaseSource.includes('echo "desktop_version=$DESKTOP_VERSION" >> "$GITHUB_OUTPUT"') ||
-    (releaseSource.match(/vars\.ENABLE_DESKTOP_MACOS_RELEASE/gu) ?? []).length !== 1
-  ) {
-    issues.push("desktop opt-in and version authority must be read once and frozen by parse-tag");
-  }
-
-  const desktopJobs = mapping(desktop.jobs, "desktop.jobs", issues);
+  const requiredSigningSecrets = [
+    "CSC_LINK",
+    "CSC_KEY_PASSWORD",
+    "APPLE_API_KEY_ID",
+    "APPLE_API_ISSUER",
+    "APPLE_API_KEY_P8_BASE64",
+  ];
+  const jobs = mapping(desktop.jobs, "desktop.jobs", issues);
   const authorize = mapping(
-    desktopJobs["authorize-coordinator"],
+    jobs["authorize-coordinator"],
     "desktop.jobs.authorize-coordinator",
     issues,
   );
-  const sign = mapping(desktopJobs["sign-macos"], "desktop.jobs.sign-macos", issues);
+  const sign = mapping(jobs["sign-macos"], "desktop.jobs.sign-macos", issues);
   const verify = mapping(
-    desktopJobs["verify-macos-envelope"],
+    jobs["verify-macos-envelope"],
     "desktop.jobs.verify-macos-envelope",
     issues,
   );
-  const stage = mapping(
-    desktopJobs["stage-private-draft"],
-    "desktop.jobs.stage-private-draft",
-    issues,
-  );
-  const publish = mapping(desktopJobs["publish-assets"], "desktop.jobs.publish-assets", issues);
-  const promote = mapping(desktopJobs["promote-latest"], "desktop.jobs.promote-latest", issues);
+  const stage = mapping(jobs["stage-private-draft"], "desktop.jobs.stage-private-draft", issues);
+  const publish = mapping(jobs["publish-assets"], "desktop.jobs.publish-assets", issues);
+  const promote = mapping(jobs["promote-latest"], "desktop.jobs.promote-latest", issues);
   const roundTrip = mapping(
-    desktopJobs["verify-production-update"],
+    jobs["verify-production-update"],
     "desktop.jobs.verify-production-update",
     issues,
   );
-  const activate = mapping(
-    desktopJobs["activate-release"],
-    "desktop.jobs.activate-release",
-    issues,
-  );
+  const activate = mapping(jobs["activate-release"], "desktop.jobs.activate-release", issues);
   const compensate = mapping(
-    desktopJobs["compensate-publication"],
+    jobs["compensate-publication"],
     "desktop.jobs.compensate-publication",
     issues,
   );
+
   exactPermissions(
     authorize.permissions,
     { actions: "read", contents: "read" },
@@ -473,18 +585,19 @@ export function inspectDesktopReleaseWorkflows(
   if (
     sign.needs !== "authorize-coordinator" ||
     !authorizeRun.includes('gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID"') ||
-    !authorizeRun.includes(".github/workflows/release.yml") ||
+    !authorizeRun.includes(".github/workflows/desktop-release-coordinator.yml") ||
+    authorizeRun.includes(".github/workflows/release.yml") ||
     !authorizeRun.includes(".run_attempt") ||
     !authorizeRun.includes(".status") ||
     !authorizeRun.includes("in_progress") ||
     !authorizeRun.includes(".head_sha") ||
     !authorizeRun.includes('test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"') ||
-    !authorizeRun.includes('if [ "$RELEASE_TOOLING_COMMIT" != "$RELEASE_COMMIT" ]') ||
-    !authorizeRun.includes(".head_branch") ||
-    !authorizeRun.includes("workflow_dispatch")
+    !authorizeRun.includes("workflow_dispatch") ||
+    authorizeRun.includes('.event == "push"')
   ) {
-    issues.push("desktop signing must bind to its active release coordinator");
+    issues.push("desktop signing must authorize only its active desktop coordinator");
   }
+
   exactPermissions(sign.permissions, { contents: "read" }, "macOS signing", issues);
   exactPermissions(
     verify.permissions,
@@ -528,6 +641,7 @@ export function inspectDesktopReleaseWorkflows(
     "release compensation",
     issues,
   );
+
   const signingSecrets = [
     "CSC_LINK",
     "CSC_KEY_PASSWORD",
@@ -537,18 +651,20 @@ export function inspectDesktopReleaseWorkflows(
     "APPLE_API_KEY_P8_BASE64",
     "ENDURAGENT_DEVELOPER_ID_IDENTITY",
   ];
-  const nonSigningDesktopText = Object.entries(desktopJobs)
+  const nonSigningText = Object.entries(jobs)
     .filter(([jobName]) => jobName !== "sign-macos")
     .map(([jobName, rawJob]) => scalar(mapping(rawJob, `desktop.jobs.${jobName}`, issues)))
     .join("\n");
   for (const secret of signingSecrets) {
-    if (new RegExp(`\\b${secret}\\b`, "u").test(nonSigningDesktopText))
+    if (new RegExp(`\\b${secret}\\b`, "u").test(nonSigningText)) {
       issues.push(`signing secret ${secret} escaped the signing job`);
+    }
   }
-  if (sign.environment !== "desktop-macos-signing")
+  if (sign.environment !== "desktop-macos-signing") {
     issues.push("signing secrets must come from desktop-macos-signing environment");
+  }
   if (
-    Object.entries(desktopJobs).some(
+    Object.entries(jobs).some(
       ([jobName, rawJob]) =>
         jobName !== "sign-macos" &&
         mapping(rawJob, `desktop.jobs.${jobName}`, issues).environment === "desktop-macos-signing",
@@ -562,10 +678,14 @@ export function inspectDesktopReleaseWorkflows(
     promote.environment !== "desktop-macos-latest" ||
     activate.environment !== "desktop-macos-latest" ||
     compensate.environment !== "desktop-macos-latest"
-  )
+  ) {
     issues.push("write-authority desktop jobs must use protected environments");
-  if (!scalar(stage.needs).includes("verify-macos-envelope") || verify.needs !== "sign-macos")
+  }
+  if (!scalar(stage.needs).includes("verify-macos-envelope") || verify.needs !== "sign-macos") {
     issues.push("independent macOS verification must follow signing before private staging");
+  }
+
+  const stageRun = runs(stage).join("\n");
   const publishRun = runs(publish).join("\n");
   const promoteRun = runs(promote).join("\n");
   const roundTripRun = runs(roundTrip).join("\n");
@@ -574,6 +694,7 @@ export function inspectDesktopReleaseWorkflows(
   const observeIndex = publishRun.indexOf("desktop-release:transaction observe");
   const publicationIndex = publishRun.indexOf("desktop-release:transaction publish");
   if (
+    !stageRun.includes("desktop-release:transaction stage") ||
     !scalar(publish.needs).includes("stage-private-draft") ||
     observeIndex === -1 ||
     publicationIndex <= observeIndex ||
@@ -583,15 +704,18 @@ export function inspectDesktopReleaseWorkflows(
     scalar(mapping(publish.outputs, "desktop publish outputs", issues).latest_id) !==
       "${{ steps.observe.outputs.latest_id }}"
   ) {
-    issues.push("public desktop publication must bind latest before provisional publication");
+    issues.push("desktop publication must stage exact assets and bind latest before metadata-last");
   }
   if (
     !scalar(promote.needs).includes("publish-assets") ||
     !promoteRun.includes("desktop-release:transaction promote") ||
-    !promoteRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"')
+    !promoteRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"') ||
+    !promoteRun.includes('--expected-latest-tag "$EXPECTED_LATEST_TAG"') ||
+    !promoteRun.includes('--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"')
   ) {
     issues.push("desktop latest promotion must compare-and-swap the observed release");
   }
+
   const roundTripNeeds = scalar(roundTrip.needs);
   if (
     roundTrip.if !== "${{ inputs.mode == 'steady' }}" ||
@@ -610,6 +734,7 @@ export function inspectDesktopReleaseWorkflows(
   ) {
     issues.push("steady publication must pass a native production-feed N-to-N+1 round trip");
   }
+
   const activateCondition = scalar(activate.if).replace(/\s+/gu, " ");
   const activateNeeds = scalar(activate.needs);
   if (
@@ -624,9 +749,12 @@ export function inspectDesktopReleaseWorkflows(
     !activateCondition.includes("inputs.mode == 'steady'") ||
     !activateCondition.includes("needs.verify-production-update.result == 'success'") ||
     !activateRun.includes("desktop-release:transaction activate") ||
-    !activateRun.includes("packages/cycling-coach/CHANGELOG.md")
+    !activateRun.includes("apps/desktop/CHANGELOG.md") ||
+    activateRun.includes("packages/cycling-coach/CHANGELOG.md")
   ) {
-    issues.push("general-availability activation must follow the mode-specific acceptance gate");
+    issues.push(
+      "desktop activation must follow mode-specific acceptance and desktop release notes",
+    );
   }
   const compensateCondition = scalar(compensate.if).replace(/\s+/gu, " ");
   const compensateNeeds = scalar(compensate.needs);
@@ -636,67 +764,65 @@ export function inspectDesktopReleaseWorkflows(
     !compensateCondition.includes("needs.publish-assets.outputs.latest_id != ''") ||
     !compensateCondition.includes("needs.activate-release.result != 'success'") ||
     !compensateRun.includes("desktop-release:transaction compensate") ||
+    !compensateRun.includes("apps/desktop/CHANGELOG.md") ||
     !compensateRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"') ||
     !compensateRun.includes('--expected-latest-tag "$EXPECTED_LATEST_TAG"') ||
     !compensateRun.includes('--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"')
   ) {
-    issues.push(
-      "failed desktop activation must restore the observed latest and withdraw the candidate",
-    );
+    issues.push("failed desktop activation must restore prior latest and withdraw the candidate");
   }
+
   const signingSteps = steps(sign);
-  const recoveryToolingStep = namedStep(sign, "Bind recovery release tooling");
-  const recoveryToolingRun =
-    typeof recoveryToolingStep?.run === "string" ? recoveryToolingStep.run : "";
+  const recoveryStep = namedStep(sign, "Bind recovery release tooling");
+  const recoveryRun = typeof recoveryStep?.run === "string" ? recoveryStep.run : "";
   const signingStep = namedStep(sign, "Build signed and notarized macOS envelope");
   const signingCheckoutIndex = signingSteps.findIndex(
     (step) => typeof step.uses === "string" && step.uses.startsWith("actions/checkout@"),
   );
-  const recoveryToolingIndex = signingSteps.indexOf(recoveryToolingStep ?? {});
-  const signingInstallIndex = signingSteps.findIndex(
+  const recoveryIndex = signingSteps.indexOf(recoveryStep ?? {});
+  const installIndex = signingSteps.findIndex(
     (step) => step.run === "pnpm install --frozen-lockfile",
   );
-  const signingWorkspaceBuildIndex = signingSteps.findIndex((step) => step.run === "pnpm -r build");
-  const signingPackageIndex = signingSteps.indexOf(signingStep ?? {});
-  const signingEnvironment = mapping(signingStep?.env, "macOS signing step environment", issues);
+  const workspaceBuildIndex = signingSteps.findIndex((step) => step.run === "pnpm -r build");
+  const packageIndex = signingSteps.indexOf(signingStep ?? {});
+  const signingEnvironment = mapping(signingStep?.env, "macOS signing environment", issues);
   const signingRun = typeof signingStep?.run === "string" ? signingStep.run : "";
-  const keyCleanupStep = namedStep(sign, "Remove temporary notarization key");
-  const keyCleanupRun = typeof keyCleanupStep?.run === "string" ? keyCleanupStep.run : "";
+  const cleanupStep = namedStep(sign, "Remove temporary notarization key");
+  const cleanupRun = typeof cleanupStep?.run === "string" ? cleanupStep.run : "";
   const keyCreation = signingRun.indexOf(
     'printf \'%s\' "$APPLE_API_KEY_P8_BASE64" | base64 -D > "$APPLE_API_KEY"',
   );
   const privateUmask = signingRun.indexOf("umask 077");
-  const recoveryToolingFiles = [
+  const recoveryFiles = [
     "apps/desktop/scripts/macos-genesis-release.mjs",
     "apps/desktop/scripts/macos-release-plan.d.mts",
     "apps/desktop/scripts/macos-release-plan.mjs",
     "apps/desktop/scripts/verify-macos-release.mjs",
   ];
-  const expectedRecoveryDiff = recoveryToolingFiles.join("\\n");
+  const expectedRecoveryDiff = recoveryFiles.join("\\n");
   if (
-    recoveryToolingIndex <= signingCheckoutIndex ||
-    recoveryToolingIndex >= signingInstallIndex ||
-    !recoveryToolingRun.includes('test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"') ||
-    !recoveryToolingRun.includes(
+    recoveryIndex <= signingCheckoutIndex ||
+    recoveryIndex >= installIndex ||
+    !recoveryRun.includes('test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"') ||
+    !recoveryRun.includes(
       'git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"',
     ) ||
-    !recoveryToolingRun.includes('git restore --source="$RELEASE_TOOLING_COMMIT" --worktree --') ||
-    !recoveryToolingRun.includes(`EXPECTED_RECOVERY_DIFF=$'${expectedRecoveryDiff}'`) ||
-    !recoveryToolingRun.includes('test "$(git diff --name-only)" = "$EXPECTED_RECOVERY_DIFF"') ||
-    recoveryToolingFiles.some(
+    !recoveryRun.includes('git restore --source="$RELEASE_TOOLING_COMMIT" --worktree --') ||
+    !recoveryRun.includes(`EXPECTED_RECOVERY_DIFF=$'${expectedRecoveryDiff}'`) ||
+    !recoveryRun.includes('test "$(git diff --name-only)" = "$EXPECTED_RECOVERY_DIFF"') ||
+    recoveryFiles.some(
       (path) =>
-        (recoveryToolingRun.match(new RegExp(path.replaceAll(".", "\\."), "gu")) ?? []).length !==
-        2,
+        (recoveryRun.match(new RegExp(path.replaceAll(".", "\\."), "gu")) ?? []).length !== 2,
     )
   ) {
     issues.push(
-      "manual recovery must bind the coordinator commit and overlay only audited release tooling",
+      "manual recovery must bind the coordinator and overlay only audited release tooling",
     );
   }
   if (
-    signingInstallIndex === -1 ||
-    signingWorkspaceBuildIndex <= signingInstallIndex ||
-    signingWorkspaceBuildIndex >= signingPackageIndex
+    installIndex === -1 ||
+    workspaceBuildIndex <= installIndex ||
+    workspaceBuildIndex >= packageIndex
   ) {
     issues.push("macOS signing must build workspace dependencies before packaging");
   }
@@ -717,28 +843,28 @@ export function inspectDesktopReleaseWorkflows(
     !signingRun.includes("steady)") ||
     signingEnvironment.RELEASE_MODE !== "${{ inputs.mode }}" ||
     signingEnvironment.ENDURAGENT_MACOS_GENESIS_VERSION !== "${{ inputs.desktop_version }}" ||
-    !desktopSource.includes('--npm-version "$NPM_VERSION"') ||
-    !desktopSource.includes('--desktop-version "$DESKTOP_VERSION"') ||
-    !desktopSource.includes('--candidate-tag "$RELEASE_TAG"') ||
-    nonSigningDesktopText.includes("package:mac")
+    !source.includes('--desktop-version "$DESKTOP_VERSION"') ||
+    !source.includes('--candidate-tag "$RELEASE_TAG"') ||
+    nonSigningText.includes("package:mac")
   ) {
-    issues.push("signing must dispatch explicit genesis and steady packaging modes");
+    issues.push("signing must dispatch explicit genesis and steady desktop packaging modes");
   }
   if (
     keyCreation === -1 ||
     privateUmask === -1 ||
     privateUmask > keyCreation ||
     signingEnvironment.APPLE_API_KEY !== "${{ runner.temp }}/AuthKey.p8" ||
-    keyCleanupStep?.if !== "${{ always() }}" ||
-    signingSteps.indexOf(keyCleanupStep ?? {}) <= signingSteps.indexOf(signingStep ?? {}) ||
-    countShellLine(keyCleanupRun, 'rm -f "$RUNNER_TEMP/AuthKey.p8"') !== 1
+    cleanupStep?.if !== "${{ always() }}" ||
+    signingSteps.indexOf(cleanupStep ?? {}) <= signingSteps.indexOf(signingStep ?? {}) ||
+    countShellLine(cleanupRun, 'rm -f "$RUNNER_TEMP/AuthKey.p8"') !== 1
   ) {
     issues.push("temporary notarization key must be created privately and always removed");
   }
+
   const independentStep = namedStep(verify, "Independently verify signed updater envelope");
   const independentEnvironment = mapping(
     independentStep?.env,
-    "independent macOS verification step environment",
+    "independent macOS verification environment",
     issues,
   );
   const independentRun = typeof independentStep?.run === "string" ? independentStep.run : "";
@@ -777,7 +903,7 @@ export function inspectDesktopReleaseWorkflows(
     !steadyCase.includes('"$PUBLIC_ENVELOPE"') ||
     !steadyCase.includes('"$INDEPENDENT_BASELINE_APP"') ||
     !steadyCase.includes('"$CANDIDATE_APP"') ||
-    desktopSource.split("\\(FA494ACVTF\\)$").length - 1 !== 3 ||
+    source.split("\\(FA494ACVTF\\)$").length - 1 !== 3 ||
     countShellLine(independentRun, 'test "$INDEPENDENT_CDHASH" = "$CANDIDATE_CDHASH"') !== 1 ||
     countShellLine(
       independentRun,
@@ -786,52 +912,115 @@ export function inspectDesktopReleaseWorkflows(
     countShellLine(independentRun, 'test "$INDEPENDENT_SIGNING_IDENTITY" = "$SIGNING_IDENTITY"') !==
       1
   ) {
-    issues.push(
-      "mode-specific native verification must consume a signed exact-four public envelope",
-    );
+    issues.push("native verification must consume the signed exact-four public envelope");
   }
   if (
     (
-      desktopSource.match(
+      source.match(
         /SIGNING_RUN_ATTEMPT: \$\{\{ needs\.sign-macos\.outputs\.workflow_run_attempt \}\}/gu,
       ) ?? []
     ).length !== 8 ||
-    desktopSource.includes("SIGNING_RUN_ATTEMPT: ${{ github.run_attempt }}") ||
+    source.includes("SIGNING_RUN_ATTEMPT: ${{ github.run_attempt }}") ||
     !independentRun.includes('--workflow-run-attempt "$SIGNING_RUN_ATTEMPT"')
   ) {
     issues.push("desktop verification must bind the successful signing attempt on reruns");
   }
   if (
-    (desktopSource.match(/actions\/download-artifact@[^\n]+# v8/gu) ?? []).length !== 8 ||
-    (desktopSource.match(/digest-mismatch: error/gu) ?? []).length !== 8 ||
-    !desktopSource.includes("artifact_id: ${{ steps.sealed-artifact.outputs.artifact-id }}") ||
-    !desktopSource.includes(
-      "artifact_digest: ${{ steps.sealed-artifact.outputs.artifact-digest }}",
-    ) ||
-    !desktopSource.includes(
-      "baseline_artifact_id: ${{ steps.baseline-artifact.outputs.artifact-id }}",
-    ) ||
-    !desktopSource.includes(
+    (source.match(/actions\/download-artifact@[^\n]+# v8/gu) ?? []).length !== 8 ||
+    (source.match(/digest-mismatch: error/gu) ?? []).length !== 8 ||
+    !source.includes("artifact_id: ${{ steps.sealed-artifact.outputs.artifact-id }}") ||
+    !source.includes("artifact_digest: ${{ steps.sealed-artifact.outputs.artifact-digest }}") ||
+    !source.includes("baseline_artifact_id: ${{ steps.baseline-artifact.outputs.artifact-id }}") ||
+    !source.includes(
       "baseline_artifact_digest: ${{ steps.baseline-artifact.outputs.artifact-digest }}",
     )
   ) {
     issues.push("desktop consumers must bind the exact digest-checked signing artifact");
   }
+}
 
-  const versionJobs = mapping(version.jobs, "version.jobs", issues);
-  const versionJob = mapping(versionJobs["version-pr"], "version.jobs.version-pr", issues);
+function checkVersionDispatch(version: Mapping, issues: string[]): void {
+  requireQueue(version.concurrency, "version-pr", "version dispatcher", issues);
+  const jobs = mapping(version.jobs, "version.jobs", issues);
+  const versionJob = mapping(jobs["version-pr"], "version.jobs.version-pr", issues);
   const versionText = runs(versionJob).join("\n");
+  const previousPackageVersion = versionText.indexOf(
+    "PREVIOUS_VERSION=$(git show \"$PREVIOUS_COMMIT:$pkg_json\" | jq -er '.version')",
+  );
+  const packageSkip = versionText.indexOf('if [ "$VERSION" = "$PREVIOUS_VERSION" ]; then');
+  const packageTag = versionText.indexOf('TAG="$NAME@$VERSION"');
   if (
+    !versionText.includes("PREVIOUS_COMMIT=$(git rev-parse HEAD^)") ||
+    previousPackageVersion === -1 ||
+    packageSkip <= previousPackageVersion ||
+    packageTag <= packageSkip ||
+    !versionText.slice(packageSkip, packageTag).includes("continue") ||
     !versionText.includes('git rev-parse "refs/tags/$TAG^{commit}"') ||
     !versionText.includes('"$TAG_COMMIT" != "$RELEASE_COMMIT"') ||
     !versionText.includes('gh workflow run release.yml --ref "$TAG" -f tag="$TAG"') ||
-    !versionText.includes("for attempt in $(seq 1 6)") ||
     versionText.includes("Tag $TAG already on origin — skipping")
   ) {
     issues.push(
-      "version dispatcher must verify existing tags and retry exact-tag release dispatch",
+      "version dispatcher must skip unchanged npm versions and verify exact changed tags",
     );
   }
+  if (
+    !versionText.includes("DESKTOP_PACKAGE_JSON=apps/desktop/package.json") ||
+    !versionText.includes("DESKTOP_VERSION=$(jq -er '.version' \"$DESKTOP_PACKAGE_JSON\")") ||
+    !versionText.includes(
+      "PREVIOUS_DESKTOP_VERSION=$(git show \"$PREVIOUS_COMMIT:$DESKTOP_PACKAGE_JSON\" | jq -er '.version')",
+    ) ||
+    !versionText.includes('if [ "$DESKTOP_VERSION" = "$PREVIOUS_DESKTOP_VERSION" ]; then') ||
+    !versionText.includes("skipping desktop release") ||
+    !versionText.includes('DESKTOP_TAG="enduragent-desktop@$DESKTOP_VERSION"') ||
+    !versionText.includes('git rev-parse "refs/tags/$DESKTOP_TAG^{commit}"') ||
+    !versionText.includes('"$DESKTOP_TAG_COMMIT" != "$RELEASE_COMMIT"') ||
+    !versionText.includes(
+      'gh workflow run desktop-release-coordinator.yml --ref "$DESKTOP_TAG" \\',
+    ) ||
+    !versionText.includes('-f tag="$DESKTOP_TAG" -f desktop_mode=steady') ||
+    versionText.includes("gh workflow run desktop-release.yml") ||
+    (versionText.match(/for attempt in \$\(seq 1 6\)/gu) ?? []).length < 2
+  ) {
+    issues.push("version dispatcher must independently tag and dispatch changed desktop SemVer");
+  }
+}
+
+export function inspectDesktopReleaseWorkflows(
+  releaseSource: string,
+  coordinatorSource: string,
+  desktopSource: string,
+  versionSource: string,
+): string[] {
+  const issues: string[] = [];
+  let release: Mapping;
+  let coordinator: Mapping;
+  let desktop: Mapping;
+  let version: Mapping;
+  try {
+    release = mapping(parse(releaseSource), "npm release workflow", issues);
+    coordinator = mapping(parse(coordinatorSource), "desktop coordinator workflow", issues);
+    desktop = mapping(parse(desktopSource), "desktop child workflow", issues);
+    version = mapping(parse(versionSource), "version workflow", issues);
+  } catch {
+    return ["release workflows must be valid YAML"];
+  }
+
+  if (
+    coordinatorSource.includes("desktop-release:transaction --") ||
+    desktopSource.includes("desktop-release:transaction --") ||
+    releaseSource.includes("desktop-release:transaction --")
+  ) {
+    issues.push("release transaction commands must not pass a pnpm argument separator");
+  }
+  checkCheckouts(release, "npm release", issues);
+  checkCheckouts(coordinator, "desktop coordinator", issues);
+  checkCheckouts(desktop, "desktop child", issues);
+  checkCheckouts(version, "version", issues);
+  checkNpmRelease(releaseSource, release, issues);
+  checkCoordinator(coordinatorSource, coordinator, issues);
+  checkDesktopChild(desktopSource, desktop, issues);
+  checkVersionDispatch(version, issues);
   return issues;
 }
 
@@ -839,11 +1028,16 @@ export function main(): void {
   const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
   const issues = inspectDesktopReleaseWorkflows(
     readFileSync(resolve(root, ".github/workflows/release.yml"), "utf8"),
+    readFileSync(resolve(root, ".github/workflows/desktop-release-coordinator.yml"), "utf8"),
     readFileSync(resolve(root, ".github/workflows/desktop-release.yml"), "utf8"),
     readFileSync(resolve(root, ".github/workflows/version-pr.yml"), "utf8"),
   );
-  if (issues.length > 0) throw new TypeError(issues.map((issue) => `- ${issue}`).join("\n"));
+  if (issues.length > 0) {
+    throw new TypeError(issues.map((issue) => `- ${issue}`).join("\n"));
+  }
   process.stdout.write("Desktop release workflow structure verified\n");
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -23,7 +23,7 @@ import {
 } from "./desktop-release-transaction.js";
 
 const candidateVersion = "0.1.7";
-const candidateNpmVersion = "2026.8.7";
+const candidateTag = `enduragent-desktop@${candidateVersion}`;
 const candidateCommit = "a".repeat(40);
 const realSetImmediate = setImmediate;
 
@@ -82,10 +82,8 @@ async function sealed(
   directories.push(directory);
   writeEnvelope(directory, version);
   const baselineZip = baseline?.manifest.files.find((file) => file.name.endsWith("-arm64.zip"));
-  const npmVersion = `2026.8.${version.split(".")[2]}`;
   const manifest = await sealDesktopRelease(directory, {
-    tag: `cycling-coach@${npmVersion}`,
-    npmVersion,
+    tag: `enduragent-desktop@${version}`,
     desktopVersion: version,
     commit: version === candidateVersion ? candidateCommit : "b".repeat(40),
     draftId,
@@ -93,8 +91,6 @@ async function sealed(
     workflowRunId: "456",
     workflowRunAttempt: "1",
     draftBodySha256: digest(Buffer.from("release body"), "sha256", "hex"),
-    npmIntegrity: `sha512-${Buffer.alloc(64, 1).toString("base64")}`,
-    npmAttestationUrl: `https://registry.npmjs.org/-/npm/v1/attestations/cycling-coach@${npmVersion}`,
     signingIdentity: "Developer ID Application: Example (FA494ACVTF)",
     candidateCdHash: "d".repeat(40),
     candidateCodeDirectorySha256: "e".repeat(64),
@@ -129,7 +125,7 @@ class FakeGithub {
     this.resolveAnonymousDownloadFailure = resolveFailure;
   });
 
-  constructor(tag = `cycling-coach@${candidateNpmVersion}`, commit = candidateCommit) {
+  constructor(tag = candidateTag, commit = candidateCommit) {
     this.candidate = this.release(123, tag, true);
     this.commits.set(tag, commit);
   }
@@ -271,7 +267,7 @@ async function genesisCandidate(fake: FakeGithub) {
 
 async function steadyCandidate(fake: FakeGithub) {
   const genesis = await sealed("0.1.6", "122", "genesis");
-  const baseline = fake.release(122, "cycling-coach@2026.8.6", false);
+  const baseline = fake.release(122, "enduragent-desktop@0.1.6", false);
   fake.commits.set(baseline.tag_name, genesis.manifest.commit);
   fake.addEnvelope(baseline, genesis.directory, "0.1.6");
   fake.latest = baseline;
@@ -507,7 +503,7 @@ describe("GitHub desktop release transaction", () => {
       target,
       fake.client(),
       "steady",
-      `cycling-coach@${candidateNpmVersion}`,
+      candidateTag,
       candidateVersion,
       baseline.tag_name,
       output,
@@ -518,11 +514,94 @@ describe("GitHub desktop release transaction", () => {
     expect(fake.calls.some((call) => call.url.includes("page=2"))).toBe(true);
   });
 
+  it("accepts only the exact legacy first-signed desktop baseline", async () => {
+    const fake = new FakeGithub();
+    const legacyEnvelope = await sealed("0.1.0", "121", "genesis");
+    const legacy = fake.release(121, "cycling-coach@2026.8.8", false);
+    fake.commits.set(legacy.tag_name, legacyEnvelope.manifest.commit);
+    fake.addEnvelope(legacy, legacyEnvelope.directory, "0.1.0");
+    fake.latest = legacy;
+    fake.pages = [[legacy]];
+    const outputDirectory = mkdtempSync(join(tmpdir(), "desktop-baseline-output-"));
+    const target = mkdtempSync(join(tmpdir(), "desktop-baseline-target-"));
+    directories.push(outputDirectory, target);
+    const output = join(outputDirectory, "output");
+    writeFileSync(output, "");
+
+    await prepareDesktopBaseline(
+      target,
+      fake.client(),
+      "steady",
+      "enduragent-desktop@0.1.1",
+      "0.1.1",
+      legacy.tag_name,
+      output,
+    );
+
+    expect(readFileSync(output, "utf8")).toContain("baseline_tag=cycling-coach@2026.8.8");
+    expect(readFileSync(output, "utf8")).toContain("baseline_version=0.1.0");
+    expect(readdirSync(target).sort()).toEqual([...releaseFileNames("0.1.0")].sort());
+  });
+
+  it.each([
+    ["cycling-coach@2026.8.9", "0.1.0"],
+    ["cycling-coach@2026.8.8", "0.1.1"],
+    ["enduragent-desktop@0.1.1", "0.1.0"],
+  ])("rejects a noncanonical desktop baseline %s carrying %s assets", async (tag, version) => {
+    const fake = new FakeGithub();
+    const envelope = await sealed(version, "121", "genesis");
+    const release = fake.release(121, tag, false);
+    fake.commits.set(release.tag_name, envelope.manifest.commit);
+    fake.addEnvelope(release, envelope.directory, version);
+    fake.latest = release;
+    fake.pages = [[release]];
+    const outputDirectory = mkdtempSync(join(tmpdir(), "desktop-baseline-output-"));
+    const target = mkdtempSync(join(tmpdir(), "desktop-baseline-target-"));
+    directories.push(outputDirectory, target);
+    const output = join(outputDirectory, "output");
+    writeFileSync(output, "");
+
+    await expect(
+      prepareDesktopBaseline(
+        target,
+        fake.client(),
+        "steady",
+        candidateTag,
+        candidateVersion,
+        tag,
+        output,
+      ),
+    ).rejects.toThrow("desktop baseline");
+    expect(readdirSync(target)).toEqual([]);
+  });
+
+  it("requires the candidate desktop tag to equal the candidate app version", async () => {
+    const fake = new FakeGithub();
+    const outputDirectory = mkdtempSync(join(tmpdir(), "desktop-baseline-output-"));
+    const target = mkdtempSync(join(tmpdir(), "desktop-baseline-target-"));
+    directories.push(outputDirectory, target);
+    const output = join(outputDirectory, "output");
+    writeFileSync(output, "");
+
+    await expect(
+      prepareDesktopBaseline(
+        target,
+        fake.client(),
+        "genesis",
+        "enduragent-desktop@0.1.8",
+        candidateVersion,
+        "none",
+        output,
+      ),
+    ).rejects.toThrow("tag and version do not match");
+    expect(fake.calls).toEqual([]);
+  });
+
   it("uses the requested retained baseline instead of a newer failed draft", async () => {
     const fake = new FakeGithub();
     const { baseline } = await steadyCandidate(fake);
     const failed = await sealed("0.1.8", "124", "genesis");
-    const failedRelease = fake.release(124, "cycling-coach@2026.8.8", true);
+    const failedRelease = fake.release(124, "enduragent-desktop@0.1.8", true);
     fake.commits.set(failedRelease.tag_name, failed.manifest.commit);
     fake.addEnvelope(failedRelease, failed.directory, "0.1.8");
     fake.pages = [[failedRelease, baseline]];
@@ -536,7 +615,7 @@ describe("GitHub desktop release transaction", () => {
       target,
       fake.client(),
       "steady",
-      "cycling-coach@2026.8.9",
+      "enduragent-desktop@0.1.9",
       "0.1.9",
       baseline.tag_name,
       output,
@@ -550,7 +629,7 @@ describe("GitHub desktop release transaction", () => {
     const fake = new FakeGithub();
     const { baseline } = await steadyCandidate(fake);
     const accepted = await sealed("0.1.7", "124", "genesis");
-    const latest = fake.release(124, "cycling-coach@2026.8.7", false);
+    const latest = fake.release(124, "enduragent-desktop@0.1.7", false);
     fake.commits.set(latest.tag_name, accepted.manifest.commit);
     fake.addEnvelope(latest, accepted.directory, "0.1.7");
     fake.latest = latest;
@@ -565,7 +644,7 @@ describe("GitHub desktop release transaction", () => {
         target,
         fake.client(),
         "steady",
-        "cycling-coach@2026.8.8",
+        "enduragent-desktop@0.1.8",
         "0.1.8",
         baseline.tag_name,
         output,

--- a/tools/desktop-release-transaction.test.ts
+++ b/tools/desktop-release-transaction.test.ts
@@ -32,8 +32,7 @@ import {
 const npmVersion = "2026.8.7";
 const desktopVersion = "0.1.7";
 const binding = {
-  tag: `cycling-coach@${npmVersion}`,
-  npmVersion,
+  tag: `enduragent-desktop@${desktopVersion}`,
   desktopVersion,
   commit: "a".repeat(40),
   draftId: "123",
@@ -41,12 +40,10 @@ const binding = {
   workflowRunId: "456",
   workflowRunAttempt: "1",
   draftBodySha256: "b".repeat(64),
-  npmIntegrity: `sha512-${Buffer.alloc(64, 1).toString("base64")}`,
-  npmAttestationUrl: `https://registry.npmjs.org/-/npm/v1/attestations/cycling-coach@${npmVersion}`,
   signingIdentity: "Developer ID Application: Example (FA494ACVTF)",
   candidateCdHash: "c".repeat(40),
   candidateCodeDirectorySha256: "d".repeat(64),
-  baselineTag: "cycling-coach@2026.8.6",
+  baselineTag: "enduragent-desktop@0.1.6",
   baselineReleaseId: "122",
   baselineCommit: "e".repeat(40),
   baselineZipSha256: "f".repeat(64),
@@ -300,10 +297,12 @@ describe("desktop release envelope", () => {
     ).toBe(DESKTOP_RELEASE_SCHEMA_VERSION);
     expect(manifest.feedUrl).toBe(DESKTOP_FEED_URL);
     expect(manifest).toMatchObject({
-      tag: `cycling-coach@${npmVersion}`,
-      npmVersion,
+      tag: `enduragent-desktop@${desktopVersion}`,
       desktopVersion,
     });
+    expect(manifest).not.toHaveProperty("npmVersion");
+    expect(manifest).not.toHaveProperty("npmIntegrity");
+    expect(manifest).not.toHaveProperty("npmAttestationUrl");
     expect(manifest.files.map((file) => file.name)).toEqual(releaseFileNames(desktopVersion));
     expect(manifest.files.at(-1)?.name).toBe("latest-mac.yml");
     await expect(verifyDesktopRelease(directory, binding)).resolves.toEqual(manifest);
@@ -344,20 +343,36 @@ describe("desktop release envelope", () => {
     await expect(sealDesktopRelease(directory, binding)).rejects.toThrow("latest-mac.yml");
   });
 
-  it("pins the npm attestation endpoint and Developer ID team", async () => {
+  it("requires the desktop tag to match the app version and pins the Developer ID team", async () => {
     writeEnvelope();
     await expect(
       sealDesktopRelease(directory, {
         ...binding,
-        npmAttestationUrl: "https://example.invalid/attestations/cycling-coach",
+        tag: "enduragent-desktop@0.1.8",
       }),
-    ).rejects.toThrow("npm attestation URL");
+    ).rejects.toThrow("tag and version do not match");
     await expect(
       sealDesktopRelease(directory, {
         ...binding,
         signingIdentity: "Developer ID Application: Example (ABCDE12345)",
       }),
     ).rejects.toThrow("signing identity");
+  });
+
+  it("allows only desktop tags and the exact legacy first-signed tag as baseline evidence", async () => {
+    writeEnvelope();
+    await expect(
+      sealDesktopRelease(directory, {
+        ...binding,
+        baselineTag: "cycling-coach@2026.8.9",
+      }),
+    ).rejects.toThrow("baseline evidence");
+    await expect(
+      sealDesktopRelease(directory, {
+        ...binding,
+        baselineTag: "cycling-coach@2026.8.8",
+      }),
+    ).resolves.toMatchObject({ baselineTag: "cycling-coach@2026.8.8" });
   });
 
   it("rejects an extra pre-seal file and post-seal byte changes", async () => {
@@ -388,6 +403,16 @@ describe("desktop release envelope", () => {
     manifest.unexpected = true;
     writeFileSync(path, `${JSON.stringify(manifest)}\n`);
     await expect(verifyDesktopRelease(directory, binding)).rejects.toThrow("manifest is invalid");
+  });
+
+  it("rejects legacy npm release fields in the desktop manifest", async () => {
+    writeEnvelope();
+    await sealDesktopRelease(directory, binding);
+    const path = join(directory, DESKTOP_MANIFEST);
+    const manifest = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    manifest.npmVersion = npmVersion;
+    writeFileSync(path, `${JSON.stringify(manifest)}\n`);
+    await expect(verifyDesktopRelease(directory)).rejects.toThrow("manifest is invalid");
   });
 
   it("rejects unknown nested-file manifest keys", async () => {
@@ -434,7 +459,11 @@ describe("desktop release publication guards", () => {
   });
 
   it("requires an unchanged latest observation and monotonic desktop version", () => {
-    const observed = { id: 12, tag: "cycling-coach@2026.8.6", metadataSha256: "e".repeat(64) };
+    const observed = {
+      id: 12,
+      tag: "enduragent-desktop@0.1.6",
+      metadataSha256: "e".repeat(64),
+    };
     expect(() => assertLatestCas(desktopVersion, observed, observed, "0.1.6")).not.toThrow();
     expect(() =>
       assertLatestCas(

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 
 export const DESKTOP_FEED_URL = "https://github.com/yerzhansa/enduragent/releases/latest/download/";
 export const DESKTOP_MANIFEST = "desktop-release-manifest.json";
-export const DESKTOP_RELEASE_SCHEMA_VERSION = 2 as const;
+export const DESKTOP_RELEASE_SCHEMA_VERSION = 3 as const;
 export const DESKTOP_PROVISIONAL_RELEASE_BODY =
   "Desktop update validation is in progress. This release is not yet generally available.";
 
@@ -30,7 +30,6 @@ const DesktopReleaseManifestSchema = z
   .object({
     schemaVersion: z.literal(DESKTOP_RELEASE_SCHEMA_VERSION),
     tag: z.string(),
-    npmVersion: z.string(),
     desktopVersion: z.string(),
     commit: z.string(),
     draftId: z.string(),
@@ -39,8 +38,6 @@ const DesktopReleaseManifestSchema = z
     workflowRunId: z.string(),
     workflowRunAttempt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
     draftBodySha256: sha256HexSchema,
-    npmIntegrity: z.string(),
-    npmAttestationUrl: z.string(),
     signingIdentity: z.string(),
     candidateCdHash: z.string(),
     candidateCodeDirectorySha256: sha256HexSchema,
@@ -119,6 +116,9 @@ export type NpmProvenanceBundleVerifier = (
 
 const desktopVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/u;
 const npmVersionPattern = /^([1-9]\d{3})\.([1-9]|1[0-2])\.(0|[1-9]\d*)$/u;
+const desktopTagPrefix = "enduragent-desktop@";
+const legacyDesktopBaselineTag = "cycling-coach@2026.8.8";
+const legacyDesktopBaselineVersion = "0.1.0";
 const commitPattern = /^[0-9a-f]{40}$/u;
 const signingIdentityPattern = /^Developer ID Application: .+ \(FA494ACVTF\)$/u;
 const releasePropagationAttempts = 30;
@@ -158,6 +158,24 @@ export function requireMode(value: unknown): DesktopReleaseMode {
   return value;
 }
 
+function desktopTag(version: string): string {
+  return `${desktopTagPrefix}${requireDesktopVersion(version)}`;
+}
+
+function versionFromDesktopTag(tag: string): string | null {
+  if (!tag.startsWith(desktopTagPrefix)) return null;
+  const version = tag.slice(desktopTagPrefix.length);
+  try {
+    return desktopTag(version) === tag ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+function validDesktopBaselineTag(tag: string): boolean {
+  return tag === legacyDesktopBaselineTag || versionFromDesktopTag(tag) !== null;
+}
+
 export function releaseFileNames(version: string): readonly [string, string, string, string] {
   const stableVersion = requireDesktopVersion(version);
   const base = `Enduragent-${stableVersion}-arm64`;
@@ -166,7 +184,6 @@ export function releaseFileNames(version: string): readonly [string, string, str
 
 function requireBinding(input: {
   tag: unknown;
-  npmVersion: unknown;
   desktopVersion: unknown;
   commit: unknown;
   draftId: unknown;
@@ -174,8 +191,6 @@ function requireBinding(input: {
   workflowRunId?: unknown;
   workflowRunAttempt?: unknown;
   draftBodySha256?: unknown;
-  npmIntegrity?: unknown;
-  npmAttestationUrl?: unknown;
   signingIdentity?: unknown;
   candidateCdHash?: unknown;
   candidateCodeDirectorySha256?: unknown;
@@ -186,10 +201,9 @@ function requireBinding(input: {
   baselineSigningIdentity?: unknown;
   baselineCdHash?: unknown;
 }): Omit<DesktopReleaseManifest, "schemaVersion" | "feedUrl" | "files" | "transactionSha256"> {
-  const npmVersion = requireNpmVersion(input.npmVersion);
   const desktopVersion = requireDesktopVersion(input.desktopVersion);
-  const tag = `cycling-coach@${npmVersion}`;
-  if (input.tag !== tag) throw new TypeError("npm release tag and version do not match");
+  const tag = desktopTag(desktopVersion);
+  if (input.tag !== tag) throw new TypeError("desktop release tag and version do not match");
   if (typeof input.commit !== "string" || !commitPattern.test(input.commit)) {
     throw new TypeError("desktop release commit is invalid");
   }
@@ -211,17 +225,6 @@ function requireBinding(input: {
   )
     throw new TypeError("candidate CodeDirectory hash is invalid");
   if (
-    typeof input.npmIntegrity !== "string" ||
-    !/^sha512-[A-Za-z0-9+/]+={0,2}$/u.test(input.npmIntegrity)
-  )
-    throw new TypeError("npm integrity is invalid");
-  if (
-    typeof input.npmAttestationUrl !== "string" ||
-    input.npmAttestationUrl !==
-      `https://registry.npmjs.org/-/npm/v1/attestations/cycling-coach@${npmVersion}`
-  )
-    throw new TypeError("npm attestation URL is invalid");
-  if (
     typeof input.signingIdentity !== "string" ||
     !signingIdentityPattern.test(input.signingIdentity)
   )
@@ -238,7 +241,7 @@ function requireBinding(input: {
   if (
     mode === "genesis"
       ? baselineTag !== "none" || baselineEvidence.some((value) => value !== "none")
-      : !baselineTag.startsWith("cycling-coach@")
+      : !validDesktopBaselineTag(baselineTag)
   )
     throw new TypeError("baseline evidence is invalid");
   if (
@@ -257,7 +260,6 @@ function requireBinding(input: {
     throw new TypeError("steady baseline evidence is invalid");
   return {
     tag,
-    npmVersion,
     desktopVersion,
     commit: input.commit,
     draftId: input.draftId,
@@ -265,8 +267,6 @@ function requireBinding(input: {
     workflowRunId: input.workflowRunId,
     workflowRunAttempt,
     draftBodySha256: input.draftBodySha256 as string,
-    npmIntegrity: input.npmIntegrity,
-    npmAttestationUrl: input.npmAttestationUrl,
     signingIdentity: input.signingIdentity,
     candidateCdHash: input.candidateCdHash as string,
     candidateCodeDirectorySha256: input.candidateCodeDirectorySha256 as string,
@@ -547,7 +547,6 @@ function parseManifest(value: unknown): DesktopReleaseManifest {
   }
   const binding = requireBinding({
     tag: manifest.tag,
-    npmVersion: manifest.npmVersion,
     desktopVersion: manifest.desktopVersion,
     commit: manifest.commit,
     draftId: manifest.draftId,
@@ -555,8 +554,6 @@ function parseManifest(value: unknown): DesktopReleaseManifest {
     workflowRunId: manifest.workflowRunId,
     workflowRunAttempt: manifest.workflowRunAttempt,
     draftBodySha256: manifest.draftBodySha256,
-    npmIntegrity: manifest.npmIntegrity,
-    npmAttestationUrl: manifest.npmAttestationUrl,
     signingIdentity: manifest.signingIdentity,
     candidateCdHash: manifest.candidateCdHash,
     candidateCodeDirectorySha256: manifest.candidateCodeDirectorySha256,
@@ -607,7 +604,6 @@ export async function verifyDesktopRelease(
     const expected = requireBinding(expectedBinding);
     for (const key of [
       "tag",
-      "npmVersion",
       "desktopVersion",
       "commit",
       "draftId",
@@ -615,8 +611,6 @@ export async function verifyDesktopRelease(
       "workflowRunId",
       "workflowRunAttempt",
       "draftBodySha256",
-      "npmIntegrity",
-      "npmAttestationUrl",
       "signingIdentity",
       "candidateCdHash",
       "candidateCodeDirectorySha256",
@@ -1005,13 +999,16 @@ export class GithubClient {
 
 function desktopReleaseVersion(release: GithubRelease, excludingTag?: string): string | null {
   if (release.draft || release.prerelease || release.tag_name === excludingTag) return null;
-  const tag = /^cycling-coach@(.+)$/u.exec(release.tag_name);
-  if (!tag || !npmVersionPattern.test(tag[1])) return null;
+  const tagVersion =
+    release.tag_name === legacyDesktopBaselineTag
+      ? legacyDesktopBaselineVersion
+      : versionFromDesktopTag(release.tag_name);
+  if (tagVersion === null) return null;
   const versions = release.assets.flatMap((asset) => {
     const match = /^Enduragent-(\d+\.\d+\.\d+)-arm64\.dmg$/u.exec(asset.name);
     return match ? [match[1]] : [];
   });
-  if (versions.length !== 1 || !desktopVersionPattern.test(versions[0])) return null;
+  if (versions.length !== 1 || versions[0] !== tagVersion) return null;
   const version = versions[0];
   const expected = [...releaseFileNames(version)].sort();
   const actual = release.assets.map((asset) => asset.name).sort();
@@ -1531,10 +1528,10 @@ export async function prepareDesktopBaseline(
   requestedBaselineTag: string,
   output: string,
 ): Promise<void> {
-  if (!/^cycling-coach@([1-9]\d{3})\.([1-9]|1[0-2])\.(0|[1-9]\d*)$/u.test(candidateTag)) {
-    throw new TypeError("candidate npm release tag is invalid");
-  }
   const version = requireDesktopVersion(candidateVersion);
+  if (candidateTag !== desktopTag(version)) {
+    throw new TypeError("candidate desktop release tag and version do not match");
+  }
   const releases = await client.releases();
   if (mode === "genesis") {
     const baseline = await newestDesktopRelease(releases, client, candidateTag);
@@ -1586,7 +1583,6 @@ function argument(name: string): string {
 function bindingArguments(): Parameters<typeof requireBinding>[0] {
   return {
     tag: argument("tag"),
-    npmVersion: argument("npm-version"),
     desktopVersion: argument("desktop-version"),
     commit: argument("commit"),
     draftId: argument("draft-id"),
@@ -1594,8 +1590,6 @@ function bindingArguments(): Parameters<typeof requireBinding>[0] {
     workflowRunId: argument("workflow-run-id"),
     workflowRunAttempt: argument("workflow-run-attempt"),
     draftBodySha256: argument("draft-body-sha256"),
-    npmIntegrity: argument("npm-integrity"),
-    npmAttestationUrl: argument("npm-attestation-url"),
     signingIdentity: argument("signing-identity"),
     candidateCdHash: argument("candidate-cdhash"),
     candidateCodeDirectorySha256: argument("candidate-code-directory-sha256"),


### PR DESCRIPTION
## Summary

- add an exact-tag desktop release coordinator using independent desktop SemVer
- remove npm provenance and version coupling from the signed desktop transaction
- keep npm package releases non-latest so they cannot replace the desktop updater feed
- dispatch desktop releases only when apps/desktop/package.json changes
- preserve signing, Apple notarization, exact-four-asset promotion, production update roundtrip, activation, and compensation

## Release behavior

- desktop: 0.1.0 to 0.1.1 through enduragent-desktop@0.1.1
- npm: remains 2026.8.8 and is not published by this release

The desktop signing, publication, and latest environments already allow enduragent-desktop@*; npm-production does not.

## Validation

- pnpm check
- 100 focused release/checker tests
- changeset status lists only @enduragent/desktop and @enduragent/desktop-renderer
- git diff --check
