### PR TITLE
fix(ci): recover macOS release launcher

### DIFF
--- a/.github/workflows/desktop-release-coordinator.yml
+++ b/.github/workflows/desktop-release-coordinator.yml
@@ -5,20 +5,25 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Exact enduragent-desktop@<version> tag'
+        description: "Exact enduragent-desktop@<version> tag"
         required: true
         type: string
       desktop_mode:
-        description: 'macOS release continuity mode'
+        description: "macOS release continuity mode"
         type: choice
         default: steady
         options:
           - steady
           - genesis
       desktop_baseline_tag:
-        description: 'Explicit prior signed desktop release tag; leave empty to require repository latest'
+        description: "Explicit prior signed desktop release tag; leave empty to require repository latest"
         required: false
-        default: ''
+        default: ""
+      recovery_tooling_tag:
+        description: "Optional immutable enduragent-desktop@<version>-recovery.<revision> tooling tag"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -37,6 +42,8 @@ jobs:
       tag: ${{ steps.bind.outputs.tag }}
       desktop_version: ${{ steps.bind.outputs.desktop_version }}
       commit: ${{ steps.bind.outputs.commit }}
+      workflow_ref: ${{ steps.bind.outputs.workflow_ref }}
+      tooling_commit: ${{ steps.bind.outputs.tooling_commit }}
       mode: ${{ steps.bind.outputs.mode }}
       baseline_tag: ${{ steps.bind.outputs.baseline_tag }}
     steps:
@@ -50,6 +57,7 @@ jobs:
           RELEASE_TAG_INPUT: ${{ inputs.tag }}
           RELEASE_MODE_INPUT: ${{ inputs.desktop_mode }}
           RELEASE_BASELINE_TAG_INPUT: ${{ inputs.desktop_baseline_tag }}
+          RECOVERY_TOOLING_TAG_INPUT: ${{ inputs.recovery_tooling_tag }}
           DESKTOP_ENABLED: ${{ vars.ENABLE_DESKTOP_MACOS_RELEASE }}
           WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_SHA: ${{ github.sha }}
@@ -64,8 +72,6 @@ jobs:
           VERSION="${TAG#enduragent-desktop@}"
           git fetch --force --no-tags origin "refs/tags/$TAG:refs/tags/$TAG"
           COMMIT=$(git rev-parse "refs/tags/$TAG^{commit}")
-          test "$WORKFLOW_REF" = "refs/tags/$TAG"
-          test "$WORKFLOW_SHA" = "$COMMIT"
           MANIFEST_VERSION=$(git show "$COMMIT:apps/desktop/package.json" | jq -er '.version')
           if [ "$MANIFEST_VERSION" != "$VERSION" ]; then
             echo "::error::Desktop tag version $VERSION does not match apps/desktop/package.json $MANIFEST_VERSION"
@@ -77,13 +83,46 @@ jobs:
             exit 1
           fi
           MODE="$RELEASE_MODE_INPUT"
-          BASELINE_TAG=none
-          if [ -n "$RELEASE_BASELINE_TAG_INPUT" ]; then
-            BASELINE_TAG="$RELEASE_BASELINE_TAG_INPUT"
-          fi
           if [ "$MODE" != 'steady' ] && [ "$MODE" != 'genesis' ]; then
             echo "::error::Unsupported desktop release mode '$MODE'"
             exit 1
+          fi
+          CHILD_WORKFLOW_REF="$TAG"
+          TOOLING_COMMIT="$COMMIT"
+          if [ -n "$RECOVERY_TOOLING_TAG_INPUT" ]; then
+            if [ "$MODE" != 'steady' ]; then
+              echo '::error::Recovery tooling is allowed only for steady desktop releases'
+              exit 1
+            fi
+            RECOVERY_TAG="$RECOVERY_TOOLING_TAG_INPUT"
+            RECOVERY_REVISION="${RECOVERY_TAG#"${TAG}-recovery."}"
+            if ! printf '%s' "$RECOVERY_REVISION" | grep -Eq '^[1-9][0-9]*$' || \
+               [ "$RECOVERY_TAG" != "${TAG}-recovery.${RECOVERY_REVISION}" ]; then
+              echo "::error::Recovery tooling tag must be exactly ${TAG}-recovery.<positive integer>"
+              exit 1
+            fi
+            git fetch --force --no-tags origin \
+              "refs/tags/$RECOVERY_TAG:refs/tags/$RECOVERY_TAG"
+            TOOLING_COMMIT=$(git rev-parse "refs/tags/$RECOVERY_TAG^{commit}")
+            test "$TOOLING_COMMIT" != "$COMMIT"
+            test "$WORKFLOW_REF" = "refs/tags/$RECOVERY_TAG"
+            test "$WORKFLOW_SHA" = "$TOOLING_COMMIT"
+            if ! git merge-base --is-ancestor "$COMMIT" "$TOOLING_COMMIT"; then
+              echo '::error::Candidate commit must be an ancestor of recovery tooling'
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "$TOOLING_COMMIT" refs/remotes/origin/main; then
+              echo '::error::Recovery tooling commit must be merged into main'
+              exit 1
+            fi
+            CHILD_WORKFLOW_REF="$RECOVERY_TAG"
+          else
+            test "$WORKFLOW_REF" = "refs/tags/$TAG"
+            test "$WORKFLOW_SHA" = "$COMMIT"
+          fi
+          BASELINE_TAG=none
+          if [ -n "$RELEASE_BASELINE_TAG_INPUT" ]; then
+            BASELINE_TAG="$RELEASE_BASELINE_TAG_INPUT"
           fi
           if [ "$MODE" = 'genesis' ] && [ "$BASELINE_TAG" != 'none' ]; then
             echo '::error::Genesis cannot consume a prior desktop baseline'
@@ -98,6 +137,8 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "desktop_version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
+          echo "workflow_ref=$CHILD_WORKFLOW_REF" >> "$GITHUB_OUTPUT"
+          echo "tooling_commit=$TOOLING_COMMIT" >> "$GITHUB_OUTPUT"
           echo "mode=$MODE" >> "$GITHUB_OUTPUT"
           echo "baseline_tag=$BASELINE_TAG" >> "$GITHUB_OUTPUT"
 
@@ -158,7 +199,8 @@ jobs:
           RELEASE_TAG: ${{ needs.bind-release.outputs.tag }}
           DESKTOP_VERSION: ${{ needs.bind-release.outputs.desktop_version }}
           RELEASE_COMMIT: ${{ needs.bind-release.outputs.commit }}
-          RELEASE_TOOLING_COMMIT: ${{ github.sha }}
+          RELEASE_WORKFLOW_REF: ${{ needs.bind-release.outputs.workflow_ref }}
+          RELEASE_TOOLING_COMMIT: ${{ needs.bind-release.outputs.tooling_commit }}
           RELEASE_DRAFT_ID: ${{ needs.prepare-release-draft.outputs.draft_id }}
           RELEASE_MODE: ${{ needs.bind-release.outputs.mode }}
           RELEASE_BODY_SHA256: ${{ needs.prepare-release-draft.outputs.body_sha256 }}
@@ -170,7 +212,7 @@ jobs:
           EXPECTED_TITLE="Desktop release $RELEASE_TAG via $COORDINATOR_RUN_ID.$COORDINATOR_RUN_ATTEMPT"
           gh workflow run desktop-release.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref "$RELEASE_TAG" \
+            --ref "$RELEASE_WORKFLOW_REF" \
             -f tag="$RELEASE_TAG" \
             -f desktop_version="$DESKTOP_VERSION" \
             -f commit="$RELEASE_COMMIT" \

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -65,8 +65,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id }}
           COORDINATOR_RUN_ATTEMPT: ${{ inputs.coordinator_run_attempt }}
+          RELEASE_TAG: ${{ inputs.tag }}
           RELEASE_COMMIT: ${{ inputs.commit }}
           RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+          RELEASE_MODE: ${{ inputs.mode }}
+          WORKFLOW_REF: ${{ github.ref }}
+          WORKFLOW_REF_NAME: ${{ github.ref_name }}
           WORKFLOW_COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -75,11 +79,22 @@ jobs:
           printf '%s' "$RELEASE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
           printf '%s' "$RELEASE_TOOLING_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
           test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"
+          if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
+            test "$WORKFLOW_REF" = "refs/tags/$RELEASE_TAG"
+            test "$WORKFLOW_REF_NAME" = "$RELEASE_TAG"
+          else
+            test "$RELEASE_MODE" = 'steady'
+            RECOVERY_REVISION="${WORKFLOW_REF_NAME#"${RELEASE_TAG}-recovery."}"
+            printf '%s' "$RECOVERY_REVISION" | grep -Eq '^[1-9][0-9]*$'
+            test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${RECOVERY_REVISION}"
+            test "$WORKFLOW_REF" = "refs/tags/$WORKFLOW_REF_NAME"
+          fi
           COORDINATOR=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID")
           test "$(printf '%s' "$COORDINATOR" | jq -r '.path')" = '.github/workflows/desktop-release-coordinator.yml'
           test "$(printf '%s' "$COORDINATOR" | jq -r '.run_attempt')" = "$COORDINATOR_RUN_ATTEMPT"
           test "$(printf '%s' "$COORDINATOR" | jq -r '.status')" = 'in_progress'
           test "$(printf '%s' "$COORDINATOR" | jq -r '.head_sha')" = "$RELEASE_TOOLING_COMMIT"
+          test "$(printf '%s' "$COORDINATOR" | jq -r '.head_branch')" = "$WORKFLOW_REF_NAME"
           test "$(printf '%s' "$COORDINATOR" | jq -r '.event')" = 'workflow_dispatch'
 
   sign-macos:
@@ -124,13 +139,14 @@ jobs:
           fi
           git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
           git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"
-          git restore --source="$RELEASE_TOOLING_COMMIT" --worktree -- \
-            apps/desktop/scripts/macos-genesis-release.mjs \
-            apps/desktop/scripts/macos-release-plan.d.mts \
-            apps/desktop/scripts/macos-release-plan.mjs \
-            apps/desktop/scripts/verify-macos-release.mjs
-          EXPECTED_RECOVERY_DIFF=$'apps/desktop/scripts/macos-genesis-release.mjs\napps/desktop/scripts/macos-release-plan.d.mts\napps/desktop/scripts/macos-release-plan.mjs\napps/desktop/scripts/verify-macos-release.mjs'
-          test "$(git diff --name-only)" = "$EXPECTED_RECOVERY_DIFF"
+          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
+            apps/desktop/scripts/macos-release-cli.mjs \
+            apps/desktop/scripts/macos-release-plan.mjs
+          EXPECTED_RECOVERY_DIFF=$'apps/desktop/scripts/macos-release-cli.mjs\napps/desktop/scripts/macos-release-plan.mjs'
+          test "$(git diff --cached --name-only)" = "$EXPECTED_RECOVERY_DIFF"
+          test -z "$(git diff --name-only)"
+          test -z "$(git ls-files --others --exclude-standard)"
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/apps/desktop/scripts/macos-release-cli.mjs
+++ b/apps/desktop/scripts/macos-release-cli.mjs
@@ -1,0 +1,34 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runMacosRelease, safeMacosReleasePlanMessage } from "./macos-release-plan.mjs";
+import { safeMacosReleaseVerificationMessage } from "./verify-macos-release.mjs";
+
+let activeStage = "initialization";
+
+async function main() {
+  if (process.argv.length !== 2) throw new TypeError("arguments are not supported");
+  const result = await runMacosRelease(
+    {
+      feedUrl: process.env.ENDURAGENT_DESKTOP_UPDATE_URL,
+      identity: process.env.ENDURAGENT_DEVELOPER_ID_IDENTITY,
+      baselineApplication: process.env.ENDURAGENT_MACOS_BASELINE_APP,
+    },
+    {
+      reportStage(stage) {
+        activeStage = stage;
+      },
+    },
+  );
+  process.stdout.write(`macOS release envelope: ${result.envelopePath}\n`);
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    process.exitCode = 1;
+    const detail = safeMacosReleaseVerificationMessage(error) ?? safeMacosReleasePlanMessage(error);
+    const suffix = detail === undefined ? "" : `: ${detail}`;
+    process.stderr.write(`macOS release build failed at ${activeStage}${suffix}\n`);
+  }
+}

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { lstat, mkdtemp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
@@ -806,33 +807,19 @@ export async function runMacosRelease(input, dependencies = {}) {
   return { plan, artifacts, envelopePath };
 }
 
-let activeStage = "initialization";
-
-async function main() {
-  if (process.argv.length !== 2) throw new TypeError("arguments are not supported");
-  const result = await runMacosRelease(
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const result = spawnSync(
+    process.execPath,
+    [join(scriptDirectory, "macos-release-cli.mjs"), ...process.argv.slice(2)],
     {
-      feedUrl: process.env.ENDURAGENT_DESKTOP_UPDATE_URL,
-      identity: process.env.ENDURAGENT_DEVELOPER_ID_IDENTITY,
-      baselineApplication: process.env.ENDURAGENT_MACOS_BASELINE_APP,
-    },
-    {
-      reportStage(stage) {
-        activeStage = stage;
-      },
+      env: process.env,
+      stdio: "inherit",
     },
   );
-  process.stdout.write(`macOS release envelope: ${result.envelopePath}\n`);
-}
-
-if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  try {
-    await main();
-  } catch (error) {
-    const verification = await import("./verify-macos-release.mjs");
-    const detail =
-      verification.safeMacosReleaseVerificationMessage(error) ?? safeMacosReleasePlanMessage(error);
-    const suffix = detail === undefined ? "" : `: ${detail}`;
-    throw new TypeError(`macOS release build failed at ${activeStage}${suffix}`);
+  if (result.error !== undefined || result.signal !== null || result.status === null) {
+    process.stderr.write("macOS release build failed at initialization\n");
+    process.exitCode = 1;
+  } else {
+    process.exitCode = result.status;
   }
 }

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -5,6 +5,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   readdir,
   rename,
   rm,
@@ -478,6 +479,64 @@ describe("macOS release plan", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("macOS genesis release build failed at release-plan");
     expect(result.stderr).not.toContain(secretSentinel);
+  });
+
+  it("fails the steady CLI with a safe actionable stage", () => {
+    const secretSentinel = "must-not-reach-stderr";
+    const result = spawnSync(
+      process.execPath,
+      [join(desktopRoot, "scripts/macos-release-plan.mjs")],
+      {
+        cwd: repositoryRoot,
+        encoding: "utf8",
+        env: {
+          ENDURAGENT_DESKTOP_UPDATE_URL: feedUrl,
+          ENDURAGENT_DEVELOPER_ID_IDENTITY: identity,
+          ENDURAGENT_MACOS_BASELINE_APP: "/synthetic/missing/Enduragent.app",
+          APPLE_API_KEY: `/synthetic/${secretSentinel}.p8`,
+          APPLE_API_KEY_ID: "SYNTHETICKEY",
+          APPLE_API_ISSUER: "00000000-0000-0000-0000-000000000000",
+          NODE_OPTIONS: "--unhandled-rejections=none",
+        },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "macOS release build failed at baseline-verification: baseline application bundle is invalid",
+    );
+    expect(result.stderr).not.toContain("unsettled top-level await");
+    expect(result.stderr).not.toContain(secretSentinel);
+  });
+
+  it("fails closed when the steady release command never settles", async () => {
+    const root = await mkdtemp(join(tmpdir(), "desktop-release-cli-unsettled-"));
+    temporaryRoots.push(root);
+    const scripts = join(await realpath(root), "scripts");
+    await mkdir(scripts);
+    const releaseCli = await readFile(join(desktopRoot, "scripts/macos-release-cli.mjs"), "utf8");
+    await Promise.all([
+      writeFile(join(scripts, "macos-release-cli.mjs"), releaseCli),
+      writeFile(
+        join(scripts, "macos-release-plan.mjs"),
+        [
+          "export function safeMacosReleasePlanMessage() { return undefined; }",
+          "export async function runMacosRelease() { await new Promise(() => {}); }",
+          "",
+        ].join("\n"),
+      ),
+      writeFile(
+        join(scripts, "verify-macos-release.mjs"),
+        "export function safeMacosReleaseVerificationMessage() { return undefined; }\n",
+      ),
+    ]);
+
+    const result = spawnSync(process.execPath, [join(scripts, "macos-release-cli.mjs")], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(13);
+    expect(result.signal).toBeNull();
   });
 
   it("rejects a missing absolute baseline before invoking electron-builder", async () => {

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -39,7 +39,7 @@ function inspect(source: WorkflowSources): string[] {
 
 function replaceRequired(source: string, search: string, replacement: string): string {
   if (!source.includes(search)) throw new TypeError(`Mutation target not found: ${search}`);
-  return source.replace(search, replacement);
+  return source.replace(search, () => replacement);
 }
 
 function expectIssue(source: WorkflowSources, fragment: string): void {
@@ -52,7 +52,7 @@ describe("desktop release workflow policy", () => {
     expect(inspect(source)).toEqual([]);
     expect(source.coordinator).toContain("^enduragent-desktop@");
     expect(source.coordinator).toContain('git show "$COMMIT:apps/desktop/package.json"');
-    expect(source.coordinator).toContain('--ref "$RELEASE_TAG"');
+    expect(source.coordinator).toContain('--ref "$RELEASE_WORKFLOW_REF"');
     expect(source.desktop).toContain(".github/workflows/desktop-release-coordinator.yml");
     expect(source.desktop).not.toMatch(/\bnpm_(?:version|integrity|attestation_url)\b/u);
     expect(source.version).toContain('DESKTOP_TAG="enduragent-desktop@$DESKTOP_VERSION"');
@@ -87,6 +87,62 @@ describe("desktop release workflow policy", () => {
     }
   });
 
+  it("requires an optional immutable recovery tooling tag", () => {
+    const source = sources();
+    const recoveryInput = [
+      "      recovery_tooling_tag:",
+      '        description: "Optional immutable enduragent-desktop@<version>-recovery.<revision> tooling tag"',
+      "        required: false",
+      '        default: ""',
+      "        type: string",
+    ].join("\n");
+    const coordinator = replaceRequired(
+      source.coordinator,
+      recoveryInput,
+      recoveryInput.replace("required: false", "required: true"),
+    );
+    expectIssue({ ...source, coordinator }, "recovery tooling tag must be an optional string");
+  });
+
+  it("binds recovery tooling to an exact steady-only tag on main", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.coordinator,
+        "printf '%s' \"$RECOVERY_REVISION\" | grep -Eq '^[1-9][0-9]*$'",
+        "printf '%s' \"$RECOVERY_REVISION\" | grep -Eq '^[0-9]+$'",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "if [ \"$MODE\" != 'steady' ]; then",
+        "if [ \"$MODE\" != 'genesis' ]; then",
+      ),
+      replaceRequired(
+        source.coordinator,
+        'git merge-base --is-ancestor "$COMMIT" "$TOOLING_COMMIT"',
+        'git merge-base --is-ancestor "$TOOLING_COMMIT" "$COMMIT"',
+      ),
+      replaceRequired(
+        source.coordinator,
+        'git merge-base --is-ancestor "$TOOLING_COMMIT" refs/remotes/origin/main',
+        'git merge-base --is-ancestor "$COMMIT" refs/remotes/origin/main',
+      ),
+      replaceRequired(
+        source.coordinator,
+        'test "$WORKFLOW_SHA" = "$TOOLING_COMMIT"',
+        'test "$WORKFLOW_SHA" = "$COMMIT"',
+      ),
+    ];
+    for (const [index, coordinator] of mutations.entries()) {
+      expect(
+        inspect({ ...source, coordinator }).some((issue) =>
+          issue.includes("distinct immutable steady-only tag"),
+        ),
+        `recovery mutation ${index}`,
+      ).toBe(true);
+    }
+  });
+
   it("requires a desktop changelog draft with stable non-latest semantics", () => {
     const source = sources();
     const wrongChangelog = replaceRequired(
@@ -104,9 +160,18 @@ describe("desktop release workflow policy", () => {
     }
   });
 
-  it("requires one exact-tag, npm-independent child dispatch and awaits it", () => {
+  it("requires one bound-ref, npm-independent child dispatch and awaits it", () => {
     const source = sources();
-    const wrongRef = replaceRequired(source.coordinator, '--ref "$RELEASE_TAG"', "--ref main");
+    const wrongRef = replaceRequired(
+      source.coordinator,
+      '--ref "$RELEASE_WORKFLOW_REF"',
+      '--ref "$RELEASE_TAG"',
+    );
+    const wrongCandidateCommit = replaceRequired(
+      source.coordinator,
+      '-f commit="$RELEASE_COMMIT"',
+      '-f commit="$RELEASE_TOOLING_COMMIT"',
+    );
     const npmCoupled = replaceRequired(
       source.coordinator,
       '            -f desktop_version="$DESKTOP_VERSION" \\\n',
@@ -117,7 +182,7 @@ describe("desktop release workflow policy", () => {
       'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
       'gh run view "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY"',
     );
-    for (const coordinator of [wrongRef, npmCoupled, notAwaited]) {
+    for (const coordinator of [wrongRef, wrongCandidateCommit, npmCoupled, notAwaited]) {
       expectIssue({ ...source, coordinator }, "npm-independent child tuple");
     }
   });
@@ -146,6 +211,31 @@ describe("desktop release workflow policy", () => {
       "true",
     );
     for (const desktop of [wrongPath, noAttempt]) {
+      expectIssue({ ...source, desktop }, "authorize only its active desktop coordinator");
+    }
+  });
+
+  it("binds child authorization to the normal or recovery workflow ref", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.desktop,
+        "          RELEASE_TAG: ${{ inputs.tag }}",
+        "          RELEASE_TAG: ${{ inputs.tooling_commit }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$WORKFLOW_REF_NAME" = "$RELEASE_TAG"',
+        'test "$WORKFLOW_REF_NAME" = "$RELEASE_TAG-recovery.1"',
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${RECOVERY_REVISION}"',
+        'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.1"',
+      ),
+      replaceRequired(source.desktop, "jq -r '.head_branch'", "jq -r '.head_sha'"),
+    ];
+    for (const desktop of mutations) {
       expectIssue({ ...source, desktop }, "authorize only its active desktop coordinator");
     }
   });
@@ -312,10 +402,45 @@ describe("desktop release workflow policy", () => {
     expectIssue({ ...source, desktop: unbound }, "active desktop coordinator");
     const productOverlay = replaceRequired(
       source.desktop,
-      "apps/desktop/scripts/macos-release-plan.d.mts\\n",
-      "apps/desktop/src/main/index.ts\\n",
+      "            apps/desktop/scripts/macos-release-cli.mjs \\\n",
+      "            apps/desktop/src/main/index.ts\n",
     );
     expectIssue({ ...source, desktop: productOverlay }, "overlay only audited release tooling");
+    const reversedAncestry = replaceRequired(
+      source.desktop,
+      'git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"',
+      'git merge-base --is-ancestor "$RELEASE_TOOLING_COMMIT" "$RELEASE_COMMIT"',
+    );
+    expectIssue({ ...source, desktop: reversedAncestry }, "overlay only audited release tooling");
+    const unstagedRestore = replaceRequired(source.desktop, "--staged --worktree", "--worktree");
+    expectIssue({ ...source, desktop: unstagedRestore }, "overlay only audited release tooling");
+    const unstagedOverlay = replaceRequired(
+      source.desktop,
+      "git diff --cached --name-only",
+      "git diff --name-only",
+    );
+    expectIssue({ ...source, desktop: unstagedOverlay }, "overlay only audited release tooling");
+    const allowsTrackedDrift = replaceRequired(
+      source.desktop,
+      'test -z "$(git diff --name-only)"',
+      "true",
+    );
+    expectIssue({ ...source, desktop: allowsTrackedDrift }, "overlay only audited release tooling");
+    const allowsUntrackedDrift = replaceRequired(
+      source.desktop,
+      'test -z "$(git ls-files --others --exclude-standard)"',
+      "true",
+    );
+    expectIssue(
+      { ...source, desktop: allowsUntrackedDrift },
+      "overlay only audited release tooling",
+    );
+    const movesCandidateHead = replaceRequired(
+      source.desktop,
+      '          test -z "$(git ls-files --others --exclude-standard)"\n          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"',
+      '          test -z "$(git ls-files --others --exclude-standard)"',
+    );
+    expectIssue({ ...source, desktop: movesCandidateHead }, "overlay only audited release tooling");
   });
 
   it("uses a byte-deterministic npm alias packer", () => {

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -110,11 +110,16 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     "desktop coordinator.workflow_dispatch.inputs",
     issues,
   );
-  if (!exactKeys(inputs, ["tag", "desktop_mode", "desktop_baseline_tag"])) {
+  if (!exactKeys(inputs, ["tag", "desktop_mode", "desktop_baseline_tag", "recovery_tooling_tag"])) {
     issues.push("desktop coordinator inputs must remain desktop-only");
   }
   const tagInput = mapping(inputs.tag, "desktop coordinator tag input", issues);
   const modeInput = mapping(inputs.desktop_mode, "desktop coordinator mode input", issues);
+  const recoveryToolingTagInput = mapping(
+    inputs.recovery_tooling_tag,
+    "desktop coordinator recovery tooling tag input",
+    issues,
+  );
   if (tagInput.required !== true || tagInput.type !== "string") {
     issues.push("desktop coordinator must require a string candidate tag");
   }
@@ -124,6 +129,13 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     scalar(modeInput.options) !== '["steady","genesis"]'
   ) {
     issues.push("desktop coordinator must expose only steady and genesis modes");
+  }
+  if (
+    recoveryToolingTagInput.type !== "string" ||
+    recoveryToolingTagInput.required !== false ||
+    recoveryToolingTagInput.default !== ""
+  ) {
+    issues.push("desktop coordinator recovery tooling tag must be an optional string");
   }
   if (coordinator["run-name"] !== "Desktop release coordinator ${{ inputs.tag }}") {
     issues.push("desktop coordinator run name must bind the candidate tag");
@@ -162,6 +174,8 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     tag: "${{ steps.bind.outputs.tag }}",
     desktop_version: "${{ steps.bind.outputs.desktop_version }}",
     commit: "${{ steps.bind.outputs.commit }}",
+    workflow_ref: "${{ steps.bind.outputs.workflow_ref }}",
+    tooling_commit: "${{ steps.bind.outputs.tooling_commit }}",
     mode: "${{ steps.bind.outputs.mode }}",
     baseline_tag: "${{ steps.bind.outputs.baseline_tag }}",
   };
@@ -176,6 +190,7 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
   const bindRun = typeof bindStep?.run === "string" ? bindStep.run : "";
   if (
     bindEnvironment.RELEASE_TAG_INPUT !== "${{ inputs.tag }}" ||
+    bindEnvironment.RECOVERY_TOOLING_TAG_INPUT !== "${{ inputs.recovery_tooling_tag }}" ||
     bindEnvironment.DESKTOP_ENABLED !== "${{ vars.ENABLE_DESKTOP_MACOS_RELEASE }}" ||
     bindEnvironment.WORKFLOW_REF !== "${{ github.ref }}" ||
     bindEnvironment.WORKFLOW_SHA !== "${{ github.sha }}" ||
@@ -196,6 +211,29 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
   ) {
     issues.push(
       "desktop candidate tag must be stable enduragent-desktop SemVer bound to apps/desktop/package.json",
+    );
+  }
+  if (
+    !bindRun.includes('CHILD_WORKFLOW_REF="$TAG"') ||
+    !bindRun.includes('TOOLING_COMMIT="$COMMIT"') ||
+    !bindRun.includes('if [ -n "$RECOVERY_TOOLING_TAG_INPUT" ]; then') ||
+    !bindRun.includes("if [ \"$MODE\" != 'steady' ]; then") ||
+    !bindRun.includes('RECOVERY_REVISION="${RECOVERY_TAG#"${TAG}-recovery."}"') ||
+    !bindRun.includes("printf '%s' \"$RECOVERY_REVISION\" | grep -Eq '^[1-9][0-9]*$'") ||
+    !bindRun.includes('[ "$RECOVERY_TAG" != "${TAG}-recovery.${RECOVERY_REVISION}" ]') ||
+    !bindRun.includes('"refs/tags/$RECOVERY_TAG:refs/tags/$RECOVERY_TAG"') ||
+    !bindRun.includes('TOOLING_COMMIT=$(git rev-parse "refs/tags/$RECOVERY_TAG^{commit}")') ||
+    !bindRun.includes('test "$TOOLING_COMMIT" != "$COMMIT"') ||
+    !bindRun.includes('test "$WORKFLOW_REF" = "refs/tags/$RECOVERY_TAG"') ||
+    !bindRun.includes('test "$WORKFLOW_SHA" = "$TOOLING_COMMIT"') ||
+    !bindRun.includes('git merge-base --is-ancestor "$COMMIT" "$TOOLING_COMMIT"') ||
+    !bindRun.includes('git merge-base --is-ancestor "$TOOLING_COMMIT" refs/remotes/origin/main') ||
+    !bindRun.includes('CHILD_WORKFLOW_REF="$RECOVERY_TAG"') ||
+    !bindRun.includes('echo "workflow_ref=$CHILD_WORKFLOW_REF" >> "$GITHUB_OUTPUT"') ||
+    !bindRun.includes('echo "tooling_commit=$TOOLING_COMMIT" >> "$GITHUB_OUTPUT"')
+  ) {
+    issues.push(
+      "desktop recovery tooling must use a distinct immutable steady-only tag merged into main",
     );
   }
 
@@ -238,7 +276,8 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     RELEASE_TAG: "${{ needs.bind-release.outputs.tag }}",
     DESKTOP_VERSION: "${{ needs.bind-release.outputs.desktop_version }}",
     RELEASE_COMMIT: "${{ needs.bind-release.outputs.commit }}",
-    RELEASE_TOOLING_COMMIT: "${{ github.sha }}",
+    RELEASE_WORKFLOW_REF: "${{ needs.bind-release.outputs.workflow_ref }}",
+    RELEASE_TOOLING_COMMIT: "${{ needs.bind-release.outputs.tooling_commit }}",
     RELEASE_DRAFT_ID: "${{ needs.prepare-release-draft.outputs.draft_id }}",
     RELEASE_MODE: "${{ needs.bind-release.outputs.mode }}",
     RELEASE_BODY_SHA256: "${{ needs.prepare-release-draft.outputs.body_sha256 }}",
@@ -262,6 +301,18 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     "coordinator_run_id",
     "coordinator_run_attempt",
   ];
+  const expectedDispatchedAssignments: Mapping = {
+    tag: "RELEASE_TAG",
+    desktop_version: "DESKTOP_VERSION",
+    commit: "RELEASE_COMMIT",
+    tooling_commit: "RELEASE_TOOLING_COMMIT",
+    draft_id: "RELEASE_DRAFT_ID",
+    mode: "RELEASE_MODE",
+    draft_body_sha256: "RELEASE_BODY_SHA256",
+    baseline_tag: "RELEASE_BASELINE_TAG",
+    coordinator_run_id: "COORDINATOR_RUN_ID",
+    coordinator_run_attempt: "COORDINATOR_RUN_ATTEMPT",
+  };
   if (
     !dispatchNeeds.includes("bind-release") ||
     !dispatchNeeds.includes("prepare-release-draft") ||
@@ -273,8 +324,11 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
       expectedDispatchedInputs,
     ) ||
     dispatchedInputs.length !== expectedDispatchedInputs.length ||
+    Object.entries(expectedDispatchedAssignments).some(
+      ([input, variable]) => !dispatchRun.includes(`-f ${input}="$${variable}"`),
+    ) ||
     !dispatchRun.includes("gh workflow run desktop-release.yml \\") ||
-    !dispatchRun.includes('--ref "$RELEASE_TAG"') ||
+    !dispatchRun.includes('--ref "$RELEASE_WORKFLOW_REF"') ||
     (dispatchRun.match(/--repo "\$GITHUB_REPOSITORY"/gu) ?? []).length !== 3 ||
     !dispatchRun.includes('--arg title "$EXPECTED_TITLE"') ||
     !dispatchRun.includes(
@@ -581,9 +635,18 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     issues,
   );
   const authorizeStep = namedStep(authorize, "Bind dispatch to the active release coordinator");
+  const authorizeEnvironment = mapping(
+    authorizeStep?.env,
+    "desktop coordinator authorization environment",
+    issues,
+  );
   const authorizeRun = typeof authorizeStep?.run === "string" ? authorizeStep.run : "";
   if (
     sign.needs !== "authorize-coordinator" ||
+    authorizeEnvironment.RELEASE_TAG !== "${{ inputs.tag }}" ||
+    authorizeEnvironment.RELEASE_MODE !== "${{ inputs.mode }}" ||
+    authorizeEnvironment.WORKFLOW_REF !== "${{ github.ref }}" ||
+    authorizeEnvironment.WORKFLOW_REF_NAME !== "${{ github.ref_name }}" ||
     !authorizeRun.includes('gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID"') ||
     !authorizeRun.includes(".github/workflows/desktop-release-coordinator.yml") ||
     authorizeRun.includes(".github/workflows/release.yml") ||
@@ -592,6 +655,20 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     !authorizeRun.includes("in_progress") ||
     !authorizeRun.includes(".head_sha") ||
     !authorizeRun.includes('test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"') ||
+    !authorizeRun.includes(".head_branch") ||
+    !authorizeRun.includes(
+      'test "$(printf \'%s\' "$COORDINATOR" | jq -r \'.head_branch\')" = "$WORKFLOW_REF_NAME"',
+    ) ||
+    !authorizeRun.includes('if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then') ||
+    !authorizeRun.includes('test "$WORKFLOW_REF" = "refs/tags/$RELEASE_TAG"') ||
+    !authorizeRun.includes('test "$WORKFLOW_REF_NAME" = "$RELEASE_TAG"') ||
+    !authorizeRun.includes("test \"$RELEASE_MODE\" = 'steady'") ||
+    !authorizeRun.includes('RECOVERY_REVISION="${WORKFLOW_REF_NAME#"${RELEASE_TAG}-recovery."}"') ||
+    !authorizeRun.includes("grep -Eq '^[1-9][0-9]*$'") ||
+    !authorizeRun.includes(
+      'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${RECOVERY_REVISION}"',
+    ) ||
+    !authorizeRun.includes('test "$WORKFLOW_REF" = "refs/tags/$WORKFLOW_REF_NAME"') ||
     !authorizeRun.includes("workflow_dispatch") ||
     authorizeRun.includes('.event == "push"')
   ) {
@@ -794,22 +871,28 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
   );
   const privateUmask = signingRun.indexOf("umask 077");
   const recoveryFiles = [
-    "apps/desktop/scripts/macos-genesis-release.mjs",
-    "apps/desktop/scripts/macos-release-plan.d.mts",
+    "apps/desktop/scripts/macos-release-cli.mjs",
     "apps/desktop/scripts/macos-release-plan.mjs",
-    "apps/desktop/scripts/verify-macos-release.mjs",
   ];
   const expectedRecoveryDiff = recoveryFiles.join("\\n");
+  const observedRecoveryPaths =
+    recoveryRun.match(/apps\/desktop\/scripts\/[A-Za-z0-9_.-]+/gu) ?? [];
   if (
     recoveryIndex <= signingCheckoutIndex ||
     recoveryIndex >= installIndex ||
-    !recoveryRun.includes('test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"') ||
+    countShellLine(recoveryRun, 'test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"') !== 2 ||
     !recoveryRun.includes(
       'git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"',
     ) ||
-    !recoveryRun.includes('git restore --source="$RELEASE_TOOLING_COMMIT" --worktree --') ||
+    !recoveryRun.includes(
+      'git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree --',
+    ) ||
     !recoveryRun.includes(`EXPECTED_RECOVERY_DIFF=$'${expectedRecoveryDiff}'`) ||
-    !recoveryRun.includes('test "$(git diff --name-only)" = "$EXPECTED_RECOVERY_DIFF"') ||
+    !recoveryRun.includes('test "$(git diff --cached --name-only)" = "$EXPECTED_RECOVERY_DIFF"') ||
+    !recoveryRun.includes('test -z "$(git diff --name-only)"') ||
+    !recoveryRun.includes('test -z "$(git ls-files --others --exclude-standard)"') ||
+    observedRecoveryPaths.length !== recoveryFiles.length * 2 ||
+    observedRecoveryPaths.some((path) => !recoveryFiles.includes(path)) ||
     recoveryFiles.some(
       (path) =>
         (recoveryRun.match(new RegExp(path.replaceAll(".", "\\."), "gu")) ?? []).length !== 2,


### PR DESCRIPTION
## Summary

- break the steady macOS release module-evaluation cycle with an observed CLI child process
- keep immediate and non-settling release failures fail-closed
- add an exact two-script recovery path bound to an immutable recovery tooling tag
- preserve the original desktop 0.1.1 candidate commit, tag, and draft

## Verification

- `pnpm check`
- 371 focused updater and desktop-release tests
- desktop release structural policy checker
- architecture, security, and adversarial QA review

## Release scope

This recovers only the desktop 0.1.1 release. No npm version, package, lockfile, changeset, or npm publication workflow is changed; npm remains 2026.8.8.