### PR TITLE
ci(desktop): resume notarized release transaction

### DIFF
--- a/.github/workflows/desktop-release-coordinator.yml
+++ b/.github/workflows/desktop-release-coordinator.yml
@@ -24,6 +24,11 @@ on:
         required: false
         default: ""
         type: string
+      recovery_source_run_id:
+        description: "Optional failed desktop release run whose immutable signed artifacts should be resumed"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -37,6 +42,7 @@ jobs:
   bind-release:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     outputs:
       tag: ${{ steps.bind.outputs.tag }}
@@ -46,6 +52,7 @@ jobs:
       tooling_commit: ${{ steps.bind.outputs.tooling_commit }}
       mode: ${{ steps.bind.outputs.mode }}
       baseline_tag: ${{ steps.bind.outputs.baseline_tag }}
+      source_run_id: ${{ steps.bind.outputs.source_run_id }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -58,7 +65,9 @@ jobs:
           RELEASE_MODE_INPUT: ${{ inputs.desktop_mode }}
           RELEASE_BASELINE_TAG_INPUT: ${{ inputs.desktop_baseline_tag }}
           RECOVERY_TOOLING_TAG_INPUT: ${{ inputs.recovery_tooling_tag }}
+          RECOVERY_SOURCE_RUN_ID_INPUT: ${{ inputs.recovery_source_run_id }}
           DESKTOP_ENABLED: ${{ vars.ENABLE_DESKTOP_MACOS_RELEASE }}
+          GH_TOKEN: ${{ github.token }}
           WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_SHA: ${{ github.sha }}
         run: |
@@ -120,6 +129,52 @@ jobs:
             test "$WORKFLOW_REF" = "refs/tags/$TAG"
             test "$WORKFLOW_SHA" = "$COMMIT"
           fi
+          SOURCE_RUN_ID=none
+          if [ -n "$RECOVERY_SOURCE_RUN_ID_INPUT" ]; then
+            if [ -z "$RECOVERY_TOOLING_TAG_INPUT" ] || [ "$MODE" != 'steady' ]; then
+              echo '::error::A recovery source run requires steady mode and an immutable recovery tooling tag'
+              exit 1
+            fi
+            printf '%s' "$RECOVERY_SOURCE_RUN_ID_INPUT" | grep -Eq '^[1-9][0-9]*$'
+            SOURCE_RUN_ID="$RECOVERY_SOURCE_RUN_ID_INPUT"
+            SOURCE_RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")
+            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.path')" = '.github/workflows/desktop-release.yml'
+            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.event')" = 'workflow_dispatch'
+            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.actor.login')" = 'github-actions[bot]'
+            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.triggering_actor.login')" = 'github-actions[bot]'
+            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.status')" = 'completed'
+            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.conclusion')" = 'failure'
+            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.repository.full_name')" = "$GITHUB_REPOSITORY"
+            SOURCE_ATTEMPT=$(printf '%s' "$SOURCE_RUN" | jq -er '.run_attempt')
+            printf '%s' "$SOURCE_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+            SOURCE_HEAD=$(printf '%s' "$SOURCE_RUN" | jq -er '.head_branch')
+            SOURCE_SHA=$(printf '%s' "$SOURCE_RUN" | jq -er '.head_sha')
+            SOURCE_REVISION="${SOURCE_HEAD#"${TAG}-recovery."}"
+            printf '%s' "$SOURCE_REVISION" | grep -Eq '^[1-9][0-9]*$'
+            test "$SOURCE_HEAD" = "${TAG}-recovery.${SOURCE_REVISION}"
+            test "$SOURCE_HEAD" != "$RECOVERY_TOOLING_TAG_INPUT"
+            printf '%s' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'
+            git fetch --force --no-tags origin "refs/tags/$SOURCE_HEAD:refs/tags/$SOURCE_HEAD"
+            test "$(git rev-parse "refs/tags/$SOURCE_HEAD^{commit}")" = "$SOURCE_SHA"
+            git merge-base --is-ancestor "$COMMIT" "$SOURCE_SHA"
+            git merge-base --is-ancestor "$SOURCE_SHA" "$TOOLING_COMMIT"
+            git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
+            SOURCE_JOBS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/jobs?per_page=100")
+            for required_job in sign-macos verify-macos-envelope stage-private-draft publish-assets; do
+              test "$(printf '%s' "$SOURCE_JOBS" | jq --arg name "$required_job" '[.jobs[] | select(.name == $name and .conclusion == "success")] | length')" = '1'
+            done
+            test "$(printf '%s' "$SOURCE_JOBS" | jq '[.jobs[] | select(.name == "activate-release" and .conclusion == "success")] | length')" = '0'
+            SOURCE_ARTIFACTS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100")
+            for artifact_name in "desktop-release-$SOURCE_RUN_ID-$SOURCE_ATTEMPT" "desktop-baseline-$SOURCE_RUN_ID-$SOURCE_ATTEMPT"; do
+              ARTIFACT=$(printf '%s' "$SOURCE_ARTIFACTS" | jq -ec --arg name "$artifact_name" '[.artifacts[] | select(.name == $name)] | if length == 1 then .[0] else error("artifact cardinality") end')
+              test "$(printf '%s' "$ARTIFACT" | jq -r '.expired')" = 'false'
+              printf '%s' "$(printf '%s' "$ARTIFACT" | jq -er '.id')" | grep -Eq '^[1-9][0-9]*$'
+              printf '%s' "$(printf '%s' "$ARTIFACT" | jq -er '.digest')" | grep -Eq '^sha256:[0-9a-f]{64}$'
+              test "$(printf '%s' "$ARTIFACT" | jq -r '.workflow_run.id')" = "$SOURCE_RUN_ID"
+              test "$(printf '%s' "$ARTIFACT" | jq -r '.workflow_run.head_branch')" = "$SOURCE_HEAD"
+              test "$(printf '%s' "$ARTIFACT" | jq -r '.workflow_run.head_sha')" = "$SOURCE_SHA"
+            done
+          fi
           BASELINE_TAG=none
           if [ -n "$RELEASE_BASELINE_TAG_INPUT" ]; then
             BASELINE_TAG="$RELEASE_BASELINE_TAG_INPUT"
@@ -141,6 +196,7 @@ jobs:
           echo "tooling_commit=$TOOLING_COMMIT" >> "$GITHUB_OUTPUT"
           echo "mode=$MODE" >> "$GITHUB_OUTPUT"
           echo "baseline_tag=$BASELINE_TAG" >> "$GITHUB_OUTPUT"
+          echo "source_run_id=$SOURCE_RUN_ID" >> "$GITHUB_OUTPUT"
 
   prepare-release-draft:
     runs-on: ubuntu-latest
@@ -162,6 +218,7 @@ jobs:
           RELEASE_TAG: ${{ needs.bind-release.outputs.tag }}
           RELEASE_VERSION: ${{ needs.bind-release.outputs.desktop_version }}
           RELEASE_COMMIT: ${{ needs.bind-release.outputs.commit }}
+          RELEASE_SOURCE_RUN_ID: ${{ needs.bind-release.outputs.source_run_id }}
         run: |
           set -euo pipefail
           FIRST_HEADING=$(grep -m1 '^## ' apps/desktop/CHANGELOG.md)
@@ -172,11 +229,22 @@ jobs:
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             RELEASE_JSON=$(gh release view "$RELEASE_TAG" --json body,databaseId,isDraft,isPrerelease,tagName)
             test "$(printf '%s' "$RELEASE_JSON" | jq -r '.tagName')" = "$RELEASE_TAG"
-            test "$(printf '%s' "$RELEASE_JSON" | jq -r '.isDraft')" = 'true'
             test "$(printf '%s' "$RELEASE_JSON" | jq -r '.isPrerelease')" = 'false'
-            EXISTING_BODY_SHA256=$(printf '%s' "$RELEASE_JSON" | jq -j '.body' | shasum -a 256 | awk '{print $1}')
-            test "$EXISTING_BODY_SHA256" = "$BODY_SHA256"
+            if [ "$(printf '%s' "$RELEASE_JSON" | jq -r '.isDraft')" = 'true' ]; then
+              EXISTING_BODY_SHA256=$(printf '%s' "$RELEASE_JSON" | jq -j '.body' | shasum -a 256 | awk '{print $1}')
+              test "$EXISTING_BODY_SHA256" = "$BODY_SHA256"
+            else
+              test "$RELEASE_SOURCE_RUN_ID" != 'none'
+              if [ "$(printf '%s' "$RELEASE_JSON" | jq -r '.body')" != 'Desktop update validation is in progress. This release is not yet generally available.' ]; then
+                EXISTING_BODY_SHA256=$(printf '%s' "$RELEASE_JSON" | jq -j '.body' | shasum -a 256 | awk '{print $1}')
+                test "$EXISTING_BODY_SHA256" = "$BODY_SHA256"
+                LATEST_JSON=$(gh api -H 'Cache-Control: no-cache' "repos/$GITHUB_REPOSITORY/releases/latest")
+                test "$(printf '%s' "$LATEST_JSON" | jq -r '.id | tostring')" = "$(printf '%s' "$RELEASE_JSON" | jq -r '.databaseId | tostring')"
+                test "$(printf '%s' "$LATEST_JSON" | jq -r '.tag_name')" = "$RELEASE_TAG"
+              fi
+            fi
           else
+            test "$RELEASE_SOURCE_RUN_ID" = 'none'
             gh release create "$RELEASE_TAG" --draft --latest=false --target "$RELEASE_COMMIT" \
               --title "Enduragent Desktop $RELEASE_VERSION" --notes "$BODY"
             RELEASE_JSON=$(gh release view "$RELEASE_TAG" --json databaseId,isDraft,isPrerelease,tagName)
@@ -193,6 +261,63 @@ jobs:
       actions: write
       contents: read
     steps:
+      - name: Seal exact child dispatch binding
+        id: dispatch-binding
+        env:
+          RELEASE_TAG: ${{ needs.bind-release.outputs.tag }}
+          DESKTOP_VERSION: ${{ needs.bind-release.outputs.desktop_version }}
+          RELEASE_COMMIT: ${{ needs.bind-release.outputs.commit }}
+          RELEASE_WORKFLOW_REF: ${{ needs.bind-release.outputs.workflow_ref }}
+          RELEASE_TOOLING_COMMIT: ${{ needs.bind-release.outputs.tooling_commit }}
+          RELEASE_DRAFT_ID: ${{ needs.prepare-release-draft.outputs.draft_id }}
+          RELEASE_MODE: ${{ needs.bind-release.outputs.mode }}
+          RELEASE_BODY_SHA256: ${{ needs.prepare-release-draft.outputs.body_sha256 }}
+          RELEASE_BASELINE_TAG: ${{ needs.bind-release.outputs.baseline_tag }}
+          RELEASE_SOURCE_RUN_ID: ${{ needs.bind-release.outputs.source_run_id }}
+          COORDINATOR_RUN_ID: ${{ github.run_id }}
+          COORDINATOR_RUN_ATTEMPT: ${{ github.run_attempt }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_ID: ${{ github.repository_id }}
+          WORKFLOW_REF: ${{ github.ref }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          DISPATCH_NONCE=$(openssl rand -hex 32)
+          printf '%s' "$DISPATCH_NONCE" | grep -Eq '^[0-9a-f]{64}$'
+          BINDING=$(jq -cnS \
+            --arg repository "$REPOSITORY" \
+            --arg repositoryId "$REPOSITORY_ID" \
+            --arg coordinatorRunId "$COORDINATOR_RUN_ID" \
+            --arg coordinatorRunAttempt "$COORDINATOR_RUN_ATTEMPT" \
+            --arg workflowRef "$WORKFLOW_REF" \
+            --arg workflowSha "$WORKFLOW_SHA" \
+            --arg childWorkflowRef "$RELEASE_WORKFLOW_REF" \
+            --arg tag "$RELEASE_TAG" \
+            --arg desktopVersion "$DESKTOP_VERSION" \
+            --arg commit "$RELEASE_COMMIT" \
+            --arg toolingCommit "$RELEASE_TOOLING_COMMIT" \
+            --arg draftId "$RELEASE_DRAFT_ID" \
+            --arg mode "$RELEASE_MODE" \
+            --arg draftBodySha256 "$RELEASE_BODY_SHA256" \
+            --arg baselineTag "$RELEASE_BASELINE_TAG" \
+            --arg sourceRunId "$RELEASE_SOURCE_RUN_ID" \
+            --arg nonce "$DISPATCH_NONCE" \
+            '{schemaVersion: 1, repository: $repository, repositoryId: $repositoryId, coordinatorRunId: $coordinatorRunId, coordinatorRunAttempt: $coordinatorRunAttempt, workflowRef: $workflowRef, workflowSha: $workflowSha, childWorkflowRef: $childWorkflowRef, tag: $tag, desktopVersion: $desktopVersion, commit: $commit, toolingCommit: $toolingCommit, draftId: $draftId, mode: $mode, draftBodySha256: $draftBodySha256, baselineTag: $baselineTag, sourceRunId: $sourceRunId, nonce: $nonce}')
+          BINDING_SHA256=$(printf '%s' "$BINDING" | sha256sum | awk '{print $1}')
+          printf '%s' "$BINDING_SHA256" | grep -Eq '^[0-9a-f]{64}$'
+          ARTIFACT_NAME="desktop-dispatch-binding-$COORDINATOR_RUN_ID-$COORDINATOR_RUN_ATTEMPT-$BINDING_SHA256"
+          printf '%s' "$BINDING" > "$RUNNER_TEMP/desktop-dispatch-binding.json"
+          echo "nonce=$DISPATCH_NONCE" >> "$GITHUB_OUTPUT"
+          echo "sha256=$BINDING_SHA256" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+      - name: Upload exact child dispatch binding
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.dispatch-binding.outputs.artifact_name }}
+          path: ${{ runner.temp }}/desktop-dispatch-binding.json
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
       - name: Dispatch and await environment-bound desktop transaction
         env:
           GH_TOKEN: ${{ github.token }}
@@ -205,11 +330,14 @@ jobs:
           RELEASE_MODE: ${{ needs.bind-release.outputs.mode }}
           RELEASE_BODY_SHA256: ${{ needs.prepare-release-draft.outputs.body_sha256 }}
           RELEASE_BASELINE_TAG: ${{ needs.bind-release.outputs.baseline_tag }}
+          RELEASE_SOURCE_RUN_ID: ${{ needs.bind-release.outputs.source_run_id }}
           COORDINATOR_RUN_ID: ${{ github.run_id }}
           COORDINATOR_RUN_ATTEMPT: ${{ github.run_attempt }}
+          DISPATCH_NONCE: ${{ steps.dispatch-binding.outputs.nonce }}
+          DISPATCH_BINDING_SHA256: ${{ steps.dispatch-binding.outputs.sha256 }}
         run: |
           set -euo pipefail
-          EXPECTED_TITLE="Desktop release $RELEASE_TAG via $COORDINATOR_RUN_ID.$COORDINATOR_RUN_ATTEMPT"
+          EXPECTED_TITLE="Desktop release $RELEASE_TAG via $COORDINATOR_RUN_ID.$COORDINATOR_RUN_ATTEMPT binding $DISPATCH_BINDING_SHA256"
           gh workflow run desktop-release.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref "$RELEASE_WORKFLOW_REF" \
@@ -221,8 +349,11 @@ jobs:
             -f mode="$RELEASE_MODE" \
             -f draft_body_sha256="$RELEASE_BODY_SHA256" \
             -f baseline_tag="$RELEASE_BASELINE_TAG" \
+            -f source_run_id="$RELEASE_SOURCE_RUN_ID" \
             -f coordinator_run_id="$COORDINATOR_RUN_ID" \
-            -f coordinator_run_attempt="$COORDINATOR_RUN_ATTEMPT"
+            -f coordinator_run_attempt="$COORDINATOR_RUN_ATTEMPT" \
+            -f dispatch_nonce="$DISPATCH_NONCE" \
+            -f dispatch_binding_sha256="$DISPATCH_BINDING_SHA256"
           DESKTOP_RUN_ID=''
           for attempt in $(seq 1 12); do
             DESKTOP_RUNS=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow desktop-release.yml \

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,5 +1,5 @@
 name: Desktop release
-run-name: Desktop release ${{ inputs.tag }} via ${{ inputs.coordinator_run_id }}.${{ inputs.coordinator_run_attempt }}
+run-name: Desktop release ${{ inputs.tag }} via ${{ inputs.coordinator_run_id }}.${{ inputs.coordinator_run_attempt }} binding ${{ inputs.dispatch_binding_sha256 }}
 
 on:
   workflow_dispatch:
@@ -36,12 +36,24 @@ on:
         description: Prior signed desktop release tag or none
         required: true
         type: string
+      source_run_id:
+        description: Failed source run id or none
+        required: true
+        type: string
       coordinator_run_id:
         description: Parent release workflow run id
         required: true
         type: string
       coordinator_run_attempt:
         description: Parent release workflow attempt
+        required: true
+        type: string
+      dispatch_nonce:
+        description: Coordinator-generated one-time dispatch nonce
+        required: true
+        type: string
+      dispatch_binding_sha256:
+        description: SHA-256 of the coordinator-sealed child dispatch tuple
         required: true
         type: string
 permissions:
@@ -59,34 +71,66 @@ jobs:
     permissions:
       actions: read
       contents: read
+    outputs:
+      source_run_id: ${{ steps.authorize.outputs.source_run_id }}
+      source_run_attempt: ${{ steps.authorize.outputs.source_run_attempt }}
+      artifact_name: ${{ steps.authorize.outputs.artifact_name }}
+      artifact_id: ${{ steps.authorize.outputs.artifact_id }}
+      artifact_digest: ${{ steps.authorize.outputs.artifact_digest }}
+      baseline_artifact_name: ${{ steps.authorize.outputs.baseline_artifact_name }}
+      baseline_artifact_id: ${{ steps.authorize.outputs.baseline_artifact_id }}
+      baseline_artifact_digest: ${{ steps.authorize.outputs.baseline_artifact_digest }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Bind dispatch to the active release coordinator
+        id: authorize
         env:
           GH_TOKEN: ${{ github.token }}
           COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id }}
           COORDINATOR_RUN_ATTEMPT: ${{ inputs.coordinator_run_attempt }}
           RELEASE_TAG: ${{ inputs.tag }}
+          DESKTOP_VERSION: ${{ inputs.desktop_version }}
           RELEASE_COMMIT: ${{ inputs.commit }}
           RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+          RELEASE_DRAFT_ID: ${{ inputs.draft_id }}
           RELEASE_MODE: ${{ inputs.mode }}
+          RELEASE_BODY_SHA256: ${{ inputs.draft_body_sha256 }}
+          RELEASE_BASELINE_TAG: ${{ inputs.baseline_tag }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          DISPATCH_NONCE: ${{ inputs.dispatch_nonce }}
+          DISPATCH_BINDING_SHA256: ${{ inputs.dispatch_binding_sha256 }}
           WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_REF_NAME: ${{ github.ref_name }}
           WORKFLOW_COMMIT: ${{ github.sha }}
+          RUN_ACTOR: ${{ github.actor }}
+          RUN_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_ID: ${{ github.repository_id }}
         run: |
           set -euo pipefail
+          test "$RUN_ACTOR" = 'github-actions[bot]'
+          test "$RUN_TRIGGERING_ACTOR" = 'github-actions[bot]'
           printf '%s' "$COORDINATOR_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$COORDINATOR_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$DESKTOP_VERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          printf '%s' "$RELEASE_DRAFT_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$RELEASE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
           printf '%s' "$RELEASE_TOOLING_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
+          printf '%s' "$RELEASE_BODY_SHA256" | grep -Eq '^[0-9a-f]{64}$'
+          printf '%s' "$DISPATCH_NONCE" | grep -Eq '^[0-9a-f]{64}$'
+          printf '%s' "$DISPATCH_BINDING_SHA256" | grep -Eq '^[0-9a-f]{64}$'
           test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"
+          CURRENT_RECOVERY_REVISION=none
           if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
             test "$WORKFLOW_REF" = "refs/tags/$RELEASE_TAG"
             test "$WORKFLOW_REF_NAME" = "$RELEASE_TAG"
           else
             test "$RELEASE_MODE" = 'steady'
-            RECOVERY_REVISION="${WORKFLOW_REF_NAME#"${RELEASE_TAG}-recovery."}"
-            printf '%s' "$RECOVERY_REVISION" | grep -Eq '^[1-9][0-9]*$'
-            test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${RECOVERY_REVISION}"
+            CURRENT_RECOVERY_REVISION="${WORKFLOW_REF_NAME#"${RELEASE_TAG}-recovery."}"
+            printf '%s' "$CURRENT_RECOVERY_REVISION" | grep -Eq '^[1-9][0-9]*$'
+            test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${CURRENT_RECOVERY_REVISION}"
             test "$WORKFLOW_REF" = "refs/tags/$WORKFLOW_REF_NAME"
           fi
           COORDINATOR=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID")
@@ -96,31 +140,185 @@ jobs:
           test "$(printf '%s' "$COORDINATOR" | jq -r '.head_sha')" = "$RELEASE_TOOLING_COMMIT"
           test "$(printf '%s' "$COORDINATOR" | jq -r '.head_branch')" = "$WORKFLOW_REF_NAME"
           test "$(printf '%s' "$COORDINATOR" | jq -r '.event')" = 'workflow_dispatch'
+          BINDING=$(jq -cnS \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg repositoryId "$REPOSITORY_ID" \
+            --arg coordinatorRunId "$COORDINATOR_RUN_ID" \
+            --arg coordinatorRunAttempt "$COORDINATOR_RUN_ATTEMPT" \
+            --arg workflowRef "$WORKFLOW_REF" \
+            --arg workflowSha "$WORKFLOW_COMMIT" \
+            --arg childWorkflowRef "$WORKFLOW_REF_NAME" \
+            --arg tag "$RELEASE_TAG" \
+            --arg desktopVersion "$DESKTOP_VERSION" \
+            --arg commit "$RELEASE_COMMIT" \
+            --arg toolingCommit "$RELEASE_TOOLING_COMMIT" \
+            --arg draftId "$RELEASE_DRAFT_ID" \
+            --arg mode "$RELEASE_MODE" \
+            --arg draftBodySha256 "$RELEASE_BODY_SHA256" \
+            --arg baselineTag "$RELEASE_BASELINE_TAG" \
+            --arg sourceRunId "$SOURCE_RUN_ID" \
+            --arg nonce "$DISPATCH_NONCE" \
+            '{schemaVersion: 1, repository: $repository, repositoryId: $repositoryId, coordinatorRunId: $coordinatorRunId, coordinatorRunAttempt: $coordinatorRunAttempt, workflowRef: $workflowRef, workflowSha: $workflowSha, childWorkflowRef: $childWorkflowRef, tag: $tag, desktopVersion: $desktopVersion, commit: $commit, toolingCommit: $toolingCommit, draftId: $draftId, mode: $mode, draftBodySha256: $draftBodySha256, baselineTag: $baselineTag, sourceRunId: $sourceRunId, nonce: $nonce}')
+          test "$(printf '%s' "$BINDING" | sha256sum | awk '{print $1}')" = "$DISPATCH_BINDING_SHA256"
+          BINDING_ARTIFACT_NAME="desktop-dispatch-binding-$COORDINATOR_RUN_ID-$COORDINATOR_RUN_ATTEMPT-$DISPATCH_BINDING_SHA256"
+          COORDINATOR_ARTIFACTS=$(gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID/artifacts?per_page=100")
+          printf '%s' "$COORDINATOR_ARTIFACTS" | jq -e \
+            'type == "array" and length > 0 and ([.[].artifacts[]] | length) == .[0].total_count' >/dev/null
+          BINDING_ARTIFACT=$(printf '%s' "$COORDINATOR_ARTIFACTS" | jq -cer --arg name "$BINDING_ARTIFACT_NAME" \
+            '[.[].artifacts[] | select(.name == $name)] | select(length == 1) | .[0]')
+          printf '%s' "$BINDING_ARTIFACT" | jq -e \
+            --arg run "$COORDINATOR_RUN_ID" \
+            --arg repo "$REPOSITORY_ID" \
+            --arg branch "$WORKFLOW_REF_NAME" \
+            --arg sha "$WORKFLOW_COMMIT" '
+            (.id | type) == "number" and .id > 0 and
+            .expired == false and
+            (.size_in_bytes | type) == "number" and .size_in_bytes > 0 and
+            (.digest | type) == "string" and (.digest | test("^sha256:[0-9a-f]{64}$")) and
+            (.workflow_run.id | tostring) == $run and
+            (.workflow_run.repository_id | tostring) == $repo and
+            (.workflow_run.head_repository_id | tostring) == $repo and
+            .workflow_run.head_branch == $branch and
+            .workflow_run.head_sha == $sha
+          ' >/dev/null
+          CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")
+          test "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.id | tostring')" = "$RELEASE_DRAFT_ID"
+          test "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.tag_name')" = "$RELEASE_TAG"
+          test "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.prerelease')" = 'false'
+          if [ "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.draft')" = 'false' ]; then
+            test "$SOURCE_RUN_ID" != 'none'
+            if [ "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.body')" != 'Desktop update validation is in progress. This release is not yet generally available.' ]; then
+              CANDIDATE_BODY_SHA256=$(printf '%s' "$CANDIDATE_RELEASE" | jq -j '.body' | shasum -a 256 | awk '{print $1}')
+              test "$CANDIDATE_BODY_SHA256" = "$RELEASE_BODY_SHA256"
+              LATEST_RELEASE=$(gh api -H 'Cache-Control: no-cache' "repos/$GITHUB_REPOSITORY/releases/latest")
+              test "$(printf '%s' "$LATEST_RELEASE" | jq -r '.id | tostring')" = "$RELEASE_DRAFT_ID"
+              test "$(printf '%s' "$LATEST_RELEASE" | jq -r '.tag_name')" = "$RELEASE_TAG"
+            fi
+          fi
+          if [ "$SOURCE_RUN_ID" = 'none' ]; then
+            for output in source_run_id source_run_attempt artifact_name artifact_id artifact_digest baseline_artifact_name baseline_artifact_id baseline_artifact_digest; do
+              echo "$output=none" >> "$GITHUB_OUTPUT"
+            done
+            exit 0
+          fi
+          printf '%s' "$SOURCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          test "$SOURCE_RUN_ID" != "$GITHUB_RUN_ID"
+          test "$SOURCE_RUN_ID" != "$COORDINATOR_RUN_ID"
+          test "$RELEASE_MODE" = 'steady'
+          test "$RELEASE_TOOLING_COMMIT" != "$RELEASE_COMMIT"
+          test "$CURRENT_RECOVERY_REVISION" != 'none'
+          SOURCE=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")
+          test "$(printf '%s' "$SOURCE" | jq -r '.repository.full_name')" = "$GITHUB_REPOSITORY"
+          test "$(printf '%s' "$SOURCE" | jq -r '.head_repository.full_name')" = "$GITHUB_REPOSITORY"
+          test "$(printf '%s' "$SOURCE" | jq -r '.path')" = '.github/workflows/desktop-release.yml'
+          test "$(printf '%s' "$SOURCE" | jq -r '.event')" = 'workflow_dispatch'
+          test "$(printf '%s' "$SOURCE" | jq -r '.actor.login')" = 'github-actions[bot]'
+          test "$(printf '%s' "$SOURCE" | jq -r '.triggering_actor.login')" = 'github-actions[bot]'
+          test "$(printf '%s' "$SOURCE" | jq -r '.status')" = 'completed'
+          test "$(printf '%s' "$SOURCE" | jq -r '.conclusion')" = 'failure'
+          SOURCE_RUN_ATTEMPT=$(printf '%s' "$SOURCE" | jq -er '.run_attempt | tostring')
+          printf '%s' "$SOURCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          SOURCE_HEAD_BRANCH=$(printf '%s' "$SOURCE" | jq -er '.head_branch')
+          SOURCE_HEAD_SHA=$(printf '%s' "$SOURCE" | jq -er '.head_sha')
+          printf '%s' "$SOURCE_HEAD_SHA" | grep -Eq '^[0-9a-f]{40}$'
+          SOURCE_RECOVERY_REVISION="${SOURCE_HEAD_BRANCH#"${RELEASE_TAG}-recovery."}"
+          printf '%s' "$SOURCE_RECOVERY_REVISION" | grep -Eq '^[1-9][0-9]*$'
+          test "$SOURCE_HEAD_BRANCH" = "${RELEASE_TAG}-recovery.${SOURCE_RECOVERY_REVISION}"
+          test "$SOURCE_RECOVERY_REVISION" != "$CURRENT_RECOVERY_REVISION"
+          test "$(printf '%s\n%s\n' "$SOURCE_RECOVERY_REVISION" "$CURRENT_RECOVERY_REVISION" | sort -n | head -1)" = "$SOURCE_RECOVERY_REVISION"
+          git fetch --force --no-tags origin \
+            "refs/tags/$SOURCE_HEAD_BRANCH:refs/tags/$SOURCE_HEAD_BRANCH" \
+            main:refs/remotes/origin/main
+          test "$(git rev-parse "refs/tags/$SOURCE_HEAD_BRANCH^{commit}")" = "$SOURCE_HEAD_SHA"
+          git merge-base --is-ancestor "$RELEASE_COMMIT" "$SOURCE_HEAD_SHA"
+          git merge-base --is-ancestor "$SOURCE_HEAD_SHA" "$RELEASE_TOOLING_COMMIT"
+          git merge-base --is-ancestor "$SOURCE_HEAD_SHA" refs/remotes/origin/main
+          SOURCE_JOBS=$(gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_RUN_ATTEMPT/jobs?per_page=100")
+          printf '%s' "$SOURCE_JOBS" | jq -e \
+            'type == "array" and length > 0 and ([.[].jobs[]] | length) == .[0].total_count' >/dev/null
+          for job_name in sign-macos verify-macos-envelope stage-private-draft publish-assets; do
+            printf '%s' "$SOURCE_JOBS" | jq -e --arg job "$job_name" '
+              [.[].jobs[] | select(.name == $job)] as $matches |
+              ($matches | length) == 1 and
+              $matches[0].status == "completed" and
+              $matches[0].conclusion == "success"
+            ' >/dev/null
+          done
+          printf '%s' "$SOURCE_JOBS" | jq -e '
+            [.[].jobs[] | select(.name == "activate-release")] as $matches |
+            ($matches | length) == 1 and
+            $matches[0].status == "completed" and
+            $matches[0].conclusion != "success"
+          ' >/dev/null
+          SOURCE_ARTIFACTS=$(gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100")
+          printf '%s' "$SOURCE_ARTIFACTS" | jq -e \
+            'type == "array" and length > 0 and ([.[].artifacts[]] | length) == .[0].total_count' >/dev/null
+          ARTIFACT_NAME="desktop-release-$SOURCE_RUN_ID-$SOURCE_RUN_ATTEMPT"
+          BASELINE_ARTIFACT_NAME="desktop-baseline-$SOURCE_RUN_ID-$SOURCE_RUN_ATTEMPT"
+          ARTIFACT=$(printf '%s' "$SOURCE_ARTIFACTS" | jq -cer --arg name "$ARTIFACT_NAME" \
+            '[.[].artifacts[] | select(.name == $name)] | select(length == 1) | .[0]')
+          BASELINE_ARTIFACT=$(printf '%s' "$SOURCE_ARTIFACTS" | jq -cer --arg name "$BASELINE_ARTIFACT_NAME" \
+            '[.[].artifacts[] | select(.name == $name)] | select(length == 1) | .[0]')
+          for artifact in "$ARTIFACT" "$BASELINE_ARTIFACT"; do
+            printf '%s' "$artifact" | jq -e \
+              --arg run "$SOURCE_RUN_ID" \
+              --arg repo "$REPOSITORY_ID" \
+              --arg branch "$SOURCE_HEAD_BRANCH" \
+              --arg sha "$SOURCE_HEAD_SHA" '
+              (.id | type) == "number" and .id > 0 and
+              .expired == false and
+              (.size_in_bytes | type) == "number" and .size_in_bytes > 0 and
+              (.digest | type) == "string" and (.digest | test("^sha256:[0-9a-f]{64}$")) and
+              (.workflow_run.id | tostring) == $run and
+              (.workflow_run.repository_id | tostring) == $repo and
+              (.workflow_run.head_repository_id | tostring) == $repo and
+              .workflow_run.head_branch == $branch and
+              .workflow_run.head_sha == $sha
+            ' >/dev/null
+          done
+          ARTIFACT_ID=$(printf '%s' "$ARTIFACT" | jq -er '.id | tostring')
+          ARTIFACT_DIGEST=$(printf '%s' "$ARTIFACT" | jq -er '.digest | sub("^sha256:"; "")')
+          BASELINE_ARTIFACT_ID=$(printf '%s' "$BASELINE_ARTIFACT" | jq -er '.id | tostring')
+          BASELINE_ARTIFACT_DIGEST=$(printf '%s' "$BASELINE_ARTIFACT" | jq -er '.digest | sub("^sha256:"; "")')
+          echo "source_run_id=$SOURCE_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "source_run_attempt=$SOURCE_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "artifact_id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
+          echo "artifact_digest=$ARTIFACT_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "baseline_artifact_name=$BASELINE_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "baseline_artifact_id=$BASELINE_ARTIFACT_ID" >> "$GITHUB_OUTPUT"
+          echo "baseline_artifact_digest=$BASELINE_ARTIFACT_DIGEST" >> "$GITHUB_OUTPUT"
 
   sign-macos:
     runs-on: macos-15
     needs: authorize-coordinator
     environment: desktop-macos-signing
     permissions:
+      actions: read
       contents: read
     outputs:
-      baseline_tag: ${{ steps.baseline.outputs.baseline_tag }}
-      baseline_version: ${{ steps.baseline.outputs.baseline_version }}
-      baseline_release_id: ${{ steps.baseline.outputs.baseline_release_id }}
-      baseline_commit: ${{ steps.baseline.outputs.baseline_commit }}
-      baseline_zip_sha256: ${{ steps.baseline.outputs.baseline_zip_sha256 }}
-      baseline_signing_identity: ${{ steps.baseline.outputs.baseline_signing_identity }}
-      baseline_cdhash: ${{ steps.baseline.outputs.baseline_cdhash }}
-      baseline_artifact_name: desktop-baseline-${{ github.run_id }}-${{ github.run_attempt }}
-      baseline_artifact_id: ${{ steps.baseline-artifact.outputs.artifact-id }}
-      baseline_artifact_digest: ${{ steps.baseline-artifact.outputs.artifact-digest }}
-      cdhash: ${{ steps.signing-evidence.outputs.cdhash }}
-      code_directory_sha256: ${{ steps.signing-evidence.outputs.code_directory_sha256 }}
-      signing_identity: ${{ steps.signing-evidence.outputs.signing_identity }}
-      workflow_run_attempt: ${{ github.run_attempt }}
-      artifact_name: desktop-release-${{ github.run_id }}-${{ github.run_attempt }}
-      artifact_id: ${{ steps.sealed-artifact.outputs.artifact-id }}
-      artifact_digest: ${{ steps.sealed-artifact.outputs.artifact-digest }}
+      baseline_tag: ${{ steps.normalized-evidence.outputs.baseline_tag }}
+      baseline_version: ${{ steps.normalized-evidence.outputs.baseline_version }}
+      baseline_release_id: ${{ steps.normalized-evidence.outputs.baseline_release_id }}
+      baseline_commit: ${{ steps.normalized-evidence.outputs.baseline_commit }}
+      baseline_zip_sha256: ${{ steps.normalized-evidence.outputs.baseline_zip_sha256 }}
+      baseline_metadata_sha256: ${{ steps.normalized-evidence.outputs.baseline_metadata_sha256 }}
+      baseline_signing_identity: ${{ steps.normalized-evidence.outputs.baseline_signing_identity }}
+      baseline_cdhash: ${{ steps.normalized-evidence.outputs.baseline_cdhash }}
+      baseline_artifact_name: ${{ steps.normalized-evidence.outputs.baseline_artifact_name }}
+      baseline_artifact_id: ${{ steps.normalized-evidence.outputs.baseline_artifact_id }}
+      baseline_artifact_digest: ${{ steps.normalized-evidence.outputs.baseline_artifact_digest }}
+      cdhash: ${{ steps.normalized-evidence.outputs.cdhash }}
+      code_directory_sha256: ${{ steps.normalized-evidence.outputs.code_directory_sha256 }}
+      signing_identity: ${{ steps.normalized-evidence.outputs.signing_identity }}
+      evidence_run_id: ${{ steps.normalized-evidence.outputs.evidence_run_id }}
+      evidence_run_attempt: ${{ steps.normalized-evidence.outputs.evidence_run_attempt }}
+      artifact_name: ${{ steps.normalized-evidence.outputs.artifact_name }}
+      artifact_id: ${{ steps.normalized-evidence.outputs.artifact_id }}
+      artifact_digest: ${{ steps.normalized-evidence.outputs.artifact_digest }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -141,8 +339,9 @@ jobs:
           git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"
           git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
             apps/desktop/scripts/macos-release-cli.mjs \
-            apps/desktop/scripts/macos-release-plan.mjs
-          EXPECTED_RECOVERY_DIFF=$'apps/desktop/scripts/macos-release-cli.mjs\napps/desktop/scripts/macos-release-plan.mjs'
+            apps/desktop/scripts/macos-release-plan.mjs \
+            tools/desktop-release-transaction.ts
+          EXPECTED_RECOVERY_DIFF=$'apps/desktop/scripts/macos-release-cli.mjs\napps/desktop/scripts/macos-release-plan.mjs\ntools/desktop-release-transaction.ts'
           test "$(git diff --cached --name-only)" = "$EXPECTED_RECOVERY_DIFF"
           test -z "$(git diff --name-only)"
           test -z "$(git ls-files --others --exclude-standard)"
@@ -153,11 +352,13 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm -r build
+      - if: ${{ inputs.source_run_id == 'none' }}
+        run: pnpm -r build
       - name: Refuse invalid release mode
         if: ${{ inputs.mode != 'steady' && inputs.mode != 'genesis' }}
         run: exit 1
       - name: Resolve signed baseline
+        if: ${{ inputs.source_run_id == 'none' }}
         id: baseline
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -194,6 +395,7 @@ jobs:
             echo "baseline_cdhash=$BASELINE_CDHASH" >> "$GITHUB_OUTPUT"
           fi
       - name: Build signed and notarized macOS envelope
+        if: ${{ inputs.source_run_id == 'none' }}
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -229,6 +431,7 @@ jobs:
               ;;
           esac
       - name: Bind candidate signing evidence
+        if: ${{ inputs.source_run_id == 'none' }}
         id: signing-evidence
         run: |
           set -euo pipefail
@@ -246,9 +449,10 @@ jobs:
           echo "code_directory_sha256=$CODE_DIRECTORY_SHA256" >> "$GITHUB_OUTPUT"
           echo "signing_identity=$SIGNING_IDENTITY" >> "$GITHUB_OUTPUT"
       - name: Remove temporary notarization key
-        if: ${{ always() }}
+        if: ${{ always() && inputs.source_run_id == 'none' }}
         run: rm -f "$RUNNER_TEMP/AuthKey.p8"
       - name: Seal digest-bound release manifest
+        if: ${{ inputs.source_run_id == 'none' }}
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           DESKTOP_VERSION: ${{ inputs.desktop_version }}
@@ -288,6 +492,7 @@ jobs:
             --baseline-signing-identity "$BASELINE_SIGNING_IDENTITY" \
             --baseline-cdhash "$BASELINE_CDHASH"
       - name: Upload sealed macOS transaction artifact
+        if: ${{ inputs.source_run_id == 'none' }}
         id: sealed-artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -297,7 +502,7 @@ jobs:
           compression-level: 0
           retention-days: 90
       - name: Upload sealed baseline updater envelope
-        if: ${{ inputs.mode == 'steady' }}
+        if: ${{ inputs.source_run_id == 'none' && inputs.mode == 'steady' }}
         id: baseline-artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -306,6 +511,267 @@ jobs:
           if-no-files-found: error
           compression-level: 0
           retention-days: 90
+      - name: Download resumed sealed macOS transaction artifact
+        if: ${{ inputs.source_run_id != 'none' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.authorize-coordinator.outputs.artifact_id }}
+          path: ${{ runner.temp }}/desktop-release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.authorize-coordinator.outputs.source_run_id }}
+          digest-mismatch: error
+      - name: Download resumed sealed baseline updater envelope
+        if: ${{ inputs.source_run_id != 'none' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.authorize-coordinator.outputs.baseline_artifact_id }}
+          path: ${{ runner.temp }}/desktop-baseline
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.authorize-coordinator.outputs.source_run_id }}
+          digest-mismatch: error
+      - name: Verify resumed artifact and manifest bindings
+        if: ${{ inputs.source_run_id != 'none' }}
+        id: resumed-evidence
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          DESKTOP_VERSION: ${{ inputs.desktop_version }}
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_DRAFT_ID: ${{ inputs.draft_id }}
+          RELEASE_MODE: ${{ inputs.mode }}
+          RELEASE_BODY_SHA256: ${{ inputs.draft_body_sha256 }}
+          RELEASE_BASELINE_TAG: ${{ inputs.baseline_tag }}
+          SOURCE_RUN_ID: ${{ needs.authorize-coordinator.outputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ needs.authorize-coordinator.outputs.source_run_attempt }}
+          ARTIFACT_NAME: ${{ needs.authorize-coordinator.outputs.artifact_name }}
+          ARTIFACT_ID: ${{ needs.authorize-coordinator.outputs.artifact_id }}
+          ARTIFACT_DIGEST: ${{ needs.authorize-coordinator.outputs.artifact_digest }}
+          BASELINE_ARTIFACT_NAME: ${{ needs.authorize-coordinator.outputs.baseline_artifact_name }}
+          BASELINE_ARTIFACT_ID: ${{ needs.authorize-coordinator.outputs.baseline_artifact_id }}
+          BASELINE_ARTIFACT_DIGEST: ${{ needs.authorize-coordinator.outputs.baseline_artifact_digest }}
+        run: |
+          set -euo pipefail
+          test "$RELEASE_MODE" = 'steady'
+          printf '%s' "$SOURCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$SOURCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
+          printf '%s' "$BASELINE_ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$BASELINE_ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
+          test "$ARTIFACT_NAME" = "desktop-release-$SOURCE_RUN_ID-$SOURCE_RUN_ATTEMPT"
+          test "$BASELINE_ARTIFACT_NAME" = "desktop-baseline-$SOURCE_RUN_ID-$SOURCE_RUN_ATTEMPT"
+          MANIFEST="$RUNNER_TEMP/desktop-release/desktop-release-manifest.json"
+          test -f "$MANIFEST"
+          test ! -L "$MANIFEST"
+          test "$(jq -er '.schemaVersion' "$MANIFEST")" = '3'
+          test "$(jq -er '.tag' "$MANIFEST")" = "$RELEASE_TAG"
+          test "$(jq -er '.desktopVersion' "$MANIFEST")" = "$DESKTOP_VERSION"
+          test "$(jq -er '.commit' "$MANIFEST")" = "$RELEASE_COMMIT"
+          test "$(jq -er '.draftId' "$MANIFEST")" = "$RELEASE_DRAFT_ID"
+          test "$(jq -er '.mode' "$MANIFEST")" = 'steady'
+          test "$(jq -er '.workflowRunId' "$MANIFEST")" = "$SOURCE_RUN_ID"
+          test "$(jq -er '.workflowRunAttempt' "$MANIFEST")" = "$SOURCE_RUN_ATTEMPT"
+          test "$(jq -er '.draftBodySha256' "$MANIFEST")" = "$RELEASE_BODY_SHA256"
+          SIGNING_IDENTITY=$(jq -er '.signingIdentity' "$MANIFEST")
+          CANDIDATE_CDHASH=$(jq -er '.candidateCdHash' "$MANIFEST")
+          CANDIDATE_CODE_DIRECTORY_SHA256=$(jq -er '.candidateCodeDirectorySha256' "$MANIFEST")
+          BASELINE_TAG=$(jq -er '.baselineTag' "$MANIFEST")
+          BASELINE_RELEASE_ID=$(jq -er '.baselineReleaseId' "$MANIFEST")
+          BASELINE_COMMIT=$(jq -er '.baselineCommit' "$MANIFEST")
+          BASELINE_ZIP_SHA256=$(jq -er '.baselineZipSha256' "$MANIFEST")
+          BASELINE_SIGNING_IDENTITY=$(jq -er '.baselineSigningIdentity' "$MANIFEST")
+          BASELINE_CDHASH=$(jq -er '.baselineCdHash' "$MANIFEST")
+          printf '%s' "$SIGNING_IDENTITY" | grep -Eq '^Developer ID Application: .+ \(FA494ACVTF\)$'
+          printf '%s' "$CANDIDATE_CDHASH" | grep -Eq '^[0-9a-f]{40}$'
+          printf '%s' "$CANDIDATE_CODE_DIRECTORY_SHA256" | grep -Eq '^[0-9a-f]{64}$'
+          printf '%s' "$BASELINE_RELEASE_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$BASELINE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
+          printf '%s' "$BASELINE_ZIP_SHA256" | grep -Eq '^[0-9a-f]{64}$'
+          printf '%s' "$BASELINE_SIGNING_IDENTITY" | grep -Eq '^Developer ID Application: .+ \(FA494ACVTF\)$'
+          printf '%s' "$BASELINE_CDHASH" | grep -Eq '^[0-9a-f]{40}$'
+          if [ "$RELEASE_BASELINE_TAG" != 'none' ]; then
+            test "$BASELINE_TAG" = "$RELEASE_BASELINE_TAG"
+          fi
+          if [ "$BASELINE_TAG" = 'cycling-coach@2026.8.8' ]; then
+            BASELINE_VERSION=0.1.0
+          else
+            BASELINE_VERSION="${BASELINE_TAG#enduragent-desktop@}"
+            printf '%s' "$BASELINE_VERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+            test "$BASELINE_TAG" = "enduragent-desktop@$BASELINE_VERSION"
+          fi
+          pnpm desktop-release:transaction verify \
+            --directory "$RUNNER_TEMP/desktop-release" \
+            --tag "$RELEASE_TAG" \
+            --desktop-version "$DESKTOP_VERSION" \
+            --commit "$RELEASE_COMMIT" \
+            --draft-id "$RELEASE_DRAFT_ID" \
+            --mode steady \
+            --workflow-run-id "$SOURCE_RUN_ID" \
+            --workflow-run-attempt "$SOURCE_RUN_ATTEMPT" \
+            --draft-body-sha256 "$RELEASE_BODY_SHA256" \
+            --signing-identity "$SIGNING_IDENTITY" \
+            --candidate-cdhash "$CANDIDATE_CDHASH" \
+            --candidate-code-directory-sha256 "$CANDIDATE_CODE_DIRECTORY_SHA256" \
+            --baseline-tag "$BASELINE_TAG" \
+            --baseline-release-id "$BASELINE_RELEASE_ID" \
+            --baseline-commit "$BASELINE_COMMIT" \
+            --baseline-zip-sha256 "$BASELINE_ZIP_SHA256" \
+            --baseline-signing-identity "$BASELINE_SIGNING_IDENTITY" \
+            --baseline-cdhash "$BASELINE_CDHASH"
+          EXPECTED_BASELINE_FILES=$(printf '%s\n' \
+            "Enduragent-$BASELINE_VERSION-arm64.dmg" \
+            "Enduragent-$BASELINE_VERSION-arm64.zip" \
+            "Enduragent-$BASELINE_VERSION-arm64.zip.blockmap" \
+            latest-mac.yml | LC_ALL=C sort)
+          ACTUAL_BASELINE_FILES=$(find "$RUNNER_TEMP/desktop-baseline" -mindepth 1 -maxdepth 1 -type f \
+            -exec basename {} \; | LC_ALL=C sort)
+          BASELINE_ENTRY_COUNT=$(find "$RUNNER_TEMP/desktop-baseline" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d '[:space:]')
+          test "$BASELINE_ENTRY_COUNT" = '4'
+          test "$ACTUAL_BASELINE_FILES" = "$EXPECTED_BASELINE_FILES"
+          test "$(shasum -a 256 "$RUNNER_TEMP/desktop-baseline/Enduragent-$BASELINE_VERSION-arm64.zip" | awk '{print $1}')" = "$BASELINE_ZIP_SHA256"
+          BASELINE_METADATA_SHA256=$(shasum -a 256 "$RUNNER_TEMP/desktop-baseline/latest-mac.yml" | awk '{print $1}')
+          printf '%s' "$BASELINE_METADATA_SHA256" | grep -Eq '^[0-9a-f]{64}$'
+          echo "baseline_tag=$BASELINE_TAG" >> "$GITHUB_OUTPUT"
+          echo "baseline_version=$BASELINE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "baseline_release_id=$BASELINE_RELEASE_ID" >> "$GITHUB_OUTPUT"
+          echo "baseline_commit=$BASELINE_COMMIT" >> "$GITHUB_OUTPUT"
+          echo "baseline_zip_sha256=$BASELINE_ZIP_SHA256" >> "$GITHUB_OUTPUT"
+          echo "baseline_metadata_sha256=$BASELINE_METADATA_SHA256" >> "$GITHUB_OUTPUT"
+          echo "baseline_signing_identity=$BASELINE_SIGNING_IDENTITY" >> "$GITHUB_OUTPUT"
+          echo "baseline_cdhash=$BASELINE_CDHASH" >> "$GITHUB_OUTPUT"
+          echo "cdhash=$CANDIDATE_CDHASH" >> "$GITHUB_OUTPUT"
+          echo "code_directory_sha256=$CANDIDATE_CODE_DIRECTORY_SHA256" >> "$GITHUB_OUTPUT"
+          echo "signing_identity=$SIGNING_IDENTITY" >> "$GITHUB_OUTPUT"
+      - name: Normalize immutable signing and artifact evidence
+        id: normalized-evidence
+        env:
+          RELEASE_MODE: ${{ inputs.mode }}
+          SOURCE_RUN_ID: ${{ needs.authorize-coordinator.outputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ needs.authorize-coordinator.outputs.source_run_attempt }}
+          SOURCE_ARTIFACT_NAME: ${{ needs.authorize-coordinator.outputs.artifact_name }}
+          SOURCE_ARTIFACT_ID: ${{ needs.authorize-coordinator.outputs.artifact_id }}
+          SOURCE_ARTIFACT_DIGEST: ${{ needs.authorize-coordinator.outputs.artifact_digest }}
+          SOURCE_BASELINE_ARTIFACT_NAME: ${{ needs.authorize-coordinator.outputs.baseline_artifact_name }}
+          SOURCE_BASELINE_ARTIFACT_ID: ${{ needs.authorize-coordinator.outputs.baseline_artifact_id }}
+          SOURCE_BASELINE_ARTIFACT_DIGEST: ${{ needs.authorize-coordinator.outputs.baseline_artifact_digest }}
+          FRESH_ARTIFACT_ID: ${{ steps.sealed-artifact.outputs.artifact-id }}
+          FRESH_ARTIFACT_DIGEST: ${{ steps.sealed-artifact.outputs.artifact-digest }}
+          FRESH_BASELINE_ARTIFACT_ID: ${{ steps.baseline-artifact.outputs.artifact-id }}
+          FRESH_BASELINE_ARTIFACT_DIGEST: ${{ steps.baseline-artifact.outputs.artifact-digest }}
+          FRESH_BASELINE_TAG: ${{ steps.baseline.outputs.baseline_tag }}
+          FRESH_BASELINE_VERSION: ${{ steps.baseline.outputs.baseline_version }}
+          FRESH_BASELINE_RELEASE_ID: ${{ steps.baseline.outputs.baseline_release_id }}
+          FRESH_BASELINE_COMMIT: ${{ steps.baseline.outputs.baseline_commit }}
+          FRESH_BASELINE_ZIP_SHA256: ${{ steps.baseline.outputs.baseline_zip_sha256 }}
+          FRESH_BASELINE_METADATA_SHA256: ${{ steps.baseline.outputs.baseline_metadata_sha256 }}
+          FRESH_BASELINE_SIGNING_IDENTITY: ${{ steps.baseline.outputs.baseline_signing_identity }}
+          FRESH_BASELINE_CDHASH: ${{ steps.baseline.outputs.baseline_cdhash }}
+          FRESH_CDHASH: ${{ steps.signing-evidence.outputs.cdhash }}
+          FRESH_CODE_DIRECTORY_SHA256: ${{ steps.signing-evidence.outputs.code_directory_sha256 }}
+          FRESH_SIGNING_IDENTITY: ${{ steps.signing-evidence.outputs.signing_identity }}
+          RESUMED_BASELINE_TAG: ${{ steps.resumed-evidence.outputs.baseline_tag }}
+          RESUMED_BASELINE_VERSION: ${{ steps.resumed-evidence.outputs.baseline_version }}
+          RESUMED_BASELINE_RELEASE_ID: ${{ steps.resumed-evidence.outputs.baseline_release_id }}
+          RESUMED_BASELINE_COMMIT: ${{ steps.resumed-evidence.outputs.baseline_commit }}
+          RESUMED_BASELINE_ZIP_SHA256: ${{ steps.resumed-evidence.outputs.baseline_zip_sha256 }}
+          RESUMED_BASELINE_METADATA_SHA256: ${{ steps.resumed-evidence.outputs.baseline_metadata_sha256 }}
+          RESUMED_BASELINE_SIGNING_IDENTITY: ${{ steps.resumed-evidence.outputs.baseline_signing_identity }}
+          RESUMED_BASELINE_CDHASH: ${{ steps.resumed-evidence.outputs.baseline_cdhash }}
+          RESUMED_CDHASH: ${{ steps.resumed-evidence.outputs.cdhash }}
+          RESUMED_CODE_DIRECTORY_SHA256: ${{ steps.resumed-evidence.outputs.code_directory_sha256 }}
+          RESUMED_SIGNING_IDENTITY: ${{ steps.resumed-evidence.outputs.signing_identity }}
+        run: |
+          set -euo pipefail
+          if [ "$SOURCE_RUN_ID" = 'none' ]; then
+            EVIDENCE_RUN_ID="$GITHUB_RUN_ID"
+            EVIDENCE_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT"
+            ARTIFACT_NAME="desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
+            ARTIFACT_ID="$FRESH_ARTIFACT_ID"
+            ARTIFACT_DIGEST="${FRESH_ARTIFACT_DIGEST#sha256:}"
+            BASELINE_TAG="$FRESH_BASELINE_TAG"
+            BASELINE_VERSION="$FRESH_BASELINE_VERSION"
+            BASELINE_RELEASE_ID="$FRESH_BASELINE_RELEASE_ID"
+            BASELINE_COMMIT="$FRESH_BASELINE_COMMIT"
+            BASELINE_ZIP_SHA256="$FRESH_BASELINE_ZIP_SHA256"
+            BASELINE_METADATA_SHA256="$FRESH_BASELINE_METADATA_SHA256"
+            BASELINE_SIGNING_IDENTITY="$FRESH_BASELINE_SIGNING_IDENTITY"
+            BASELINE_CDHASH="$FRESH_BASELINE_CDHASH"
+            CDHASH="$FRESH_CDHASH"
+            CODE_DIRECTORY_SHA256="$FRESH_CODE_DIRECTORY_SHA256"
+            SIGNING_IDENTITY="$FRESH_SIGNING_IDENTITY"
+            if [ "$RELEASE_MODE" = 'steady' ]; then
+              BASELINE_ARTIFACT_NAME="desktop-baseline-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
+              BASELINE_ARTIFACT_ID="$FRESH_BASELINE_ARTIFACT_ID"
+              BASELINE_ARTIFACT_DIGEST="${FRESH_BASELINE_ARTIFACT_DIGEST#sha256:}"
+            else
+              BASELINE_ARTIFACT_NAME=none
+              BASELINE_ARTIFACT_ID=none
+              BASELINE_ARTIFACT_DIGEST=none
+            fi
+          else
+            EVIDENCE_RUN_ID="$SOURCE_RUN_ID"
+            EVIDENCE_RUN_ATTEMPT="$SOURCE_RUN_ATTEMPT"
+            ARTIFACT_NAME="$SOURCE_ARTIFACT_NAME"
+            ARTIFACT_ID="$SOURCE_ARTIFACT_ID"
+            ARTIFACT_DIGEST="$SOURCE_ARTIFACT_DIGEST"
+            BASELINE_ARTIFACT_NAME="$SOURCE_BASELINE_ARTIFACT_NAME"
+            BASELINE_ARTIFACT_ID="$SOURCE_BASELINE_ARTIFACT_ID"
+            BASELINE_ARTIFACT_DIGEST="$SOURCE_BASELINE_ARTIFACT_DIGEST"
+            BASELINE_TAG="$RESUMED_BASELINE_TAG"
+            BASELINE_VERSION="$RESUMED_BASELINE_VERSION"
+            BASELINE_RELEASE_ID="$RESUMED_BASELINE_RELEASE_ID"
+            BASELINE_COMMIT="$RESUMED_BASELINE_COMMIT"
+            BASELINE_ZIP_SHA256="$RESUMED_BASELINE_ZIP_SHA256"
+            BASELINE_METADATA_SHA256="$RESUMED_BASELINE_METADATA_SHA256"
+            BASELINE_SIGNING_IDENTITY="$RESUMED_BASELINE_SIGNING_IDENTITY"
+            BASELINE_CDHASH="$RESUMED_BASELINE_CDHASH"
+            CDHASH="$RESUMED_CDHASH"
+            CODE_DIRECTORY_SHA256="$RESUMED_CODE_DIRECTORY_SHA256"
+            SIGNING_IDENTITY="$RESUMED_SIGNING_IDENTITY"
+          fi
+          printf '%s' "$EVIDENCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
+          test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
+          printf '%s' "$CDHASH" | grep -Eq '^[0-9a-f]{40}$'
+          printf '%s' "$CODE_DIRECTORY_SHA256" | grep -Eq '^[0-9a-f]{64}$'
+          printf '%s' "$SIGNING_IDENTITY" | grep -Eq '^Developer ID Application: .+ \(FA494ACVTF\)$'
+          if [ "$RELEASE_MODE" = 'steady' ]; then
+            printf '%s' "$BASELINE_ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
+            printf '%s' "$BASELINE_ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
+            test "$BASELINE_ARTIFACT_NAME" = "desktop-baseline-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
+            printf '%s' "$BASELINE_METADATA_SHA256" | grep -Eq '^[0-9a-f]{64}$'
+          else
+            test "$BASELINE_TAG" = 'none'
+            test "$BASELINE_VERSION" = 'none'
+            test "$BASELINE_RELEASE_ID" = 'none'
+            test "$BASELINE_COMMIT" = 'none'
+            test "$BASELINE_ZIP_SHA256" = 'none'
+            test "$BASELINE_METADATA_SHA256" = 'none'
+            test "$BASELINE_SIGNING_IDENTITY" = 'none'
+            test "$BASELINE_CDHASH" = 'none'
+          fi
+          echo "baseline_tag=$BASELINE_TAG" >> "$GITHUB_OUTPUT"
+          echo "baseline_version=$BASELINE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "baseline_release_id=$BASELINE_RELEASE_ID" >> "$GITHUB_OUTPUT"
+          echo "baseline_commit=$BASELINE_COMMIT" >> "$GITHUB_OUTPUT"
+          echo "baseline_zip_sha256=$BASELINE_ZIP_SHA256" >> "$GITHUB_OUTPUT"
+          echo "baseline_metadata_sha256=$BASELINE_METADATA_SHA256" >> "$GITHUB_OUTPUT"
+          echo "baseline_signing_identity=$BASELINE_SIGNING_IDENTITY" >> "$GITHUB_OUTPUT"
+          echo "baseline_cdhash=$BASELINE_CDHASH" >> "$GITHUB_OUTPUT"
+          echo "baseline_artifact_name=$BASELINE_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "baseline_artifact_id=$BASELINE_ARTIFACT_ID" >> "$GITHUB_OUTPUT"
+          echo "baseline_artifact_digest=$BASELINE_ARTIFACT_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "cdhash=$CDHASH" >> "$GITHUB_OUTPUT"
+          echo "code_directory_sha256=$CODE_DIRECTORY_SHA256" >> "$GITHUB_OUTPUT"
+          echo "signing_identity=$SIGNING_IDENTITY" >> "$GITHUB_OUTPUT"
+          echo "evidence_run_id=$EVIDENCE_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "evidence_run_attempt=$EVIDENCE_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "artifact_id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
+          echo "artifact_digest=$ARTIFACT_DIGEST" >> "$GITHUB_OUTPUT"
 
   verify-macos-envelope:
     runs-on: macos-15
@@ -318,6 +784,23 @@ jobs:
         with:
           ref: ${{ inputs.commit }}
           persist-credentials: false
+      - name: Bind recovery transaction tooling
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
+            exit 0
+          fi
+          git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
+          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
+            tools/desktop-release-transaction.ts
+          test "$(git diff --cached --name-only)" = 'tools/desktop-release-transaction.ts'
+          test -z "$(git diff --name-only)"
+          test -z "$(git ls-files --others --exclude-standard)"
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -328,18 +811,24 @@ jobs:
         with:
           artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
           path: ${{ runner.temp }}/desktop-release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}
           digest-mismatch: error
       - name: Bind immutable Actions artifact evidence
         env:
           ARTIFACT_ID: ${{ needs.sign-macos.outputs.artifact_id }}
           ARTIFACT_DIGEST: ${{ needs.sign-macos.outputs.artifact_digest }}
           ARTIFACT_NAME: ${{ needs.sign-macos.outputs.artifact_name }}
-          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+          EVIDENCE_RUN_ID: ${{ needs.sign-macos.outputs.evidence_run_id }}
+          EVIDENCE_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.evidence_run_attempt }}
         run: |
           set -euo pipefail
           printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
-          test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+          printf '%s' "$EVIDENCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
       - name: Resolve independent baseline
         id: independent-baseline
         env:
@@ -347,7 +836,7 @@ jobs:
           RELEASE_MODE: ${{ inputs.mode }}
           RELEASE_TAG: ${{ inputs.tag }}
           DESKTOP_VERSION: ${{ inputs.desktop_version }}
-          RELEASE_BASELINE_TAG: ${{ inputs.baseline_tag }}
+          RELEASE_BASELINE_TAG: ${{ needs.sign-macos.outputs.baseline_tag }}
         run: |
           pnpm desktop-release:transaction baseline \
             --directory "$RUNNER_TEMP/independent-baseline" \
@@ -377,12 +866,14 @@ jobs:
           INDEPENDENT_RELEASE_ID: ${{ steps.independent-baseline.outputs.baseline_release_id }}
           INDEPENDENT_COMMIT: ${{ steps.independent-baseline.outputs.baseline_commit }}
           INDEPENDENT_ZIP_SHA256: ${{ steps.independent-baseline.outputs.baseline_zip_sha256 }}
+          INDEPENDENT_METADATA_SHA256: ${{ steps.independent-baseline.outputs.baseline_metadata_sha256 }}
           INDEPENDENT_SIGNING_IDENTITY: ${{ steps.independent-baseline.outputs.baseline_signing_identity }}
           INDEPENDENT_CDHASH: ${{ steps.independent-baseline.outputs.baseline_cdhash }}
           SIGNED_TAG: ${{ needs.sign-macos.outputs.baseline_tag }}
           SIGNED_RELEASE_ID: ${{ needs.sign-macos.outputs.baseline_release_id }}
           SIGNED_COMMIT: ${{ needs.sign-macos.outputs.baseline_commit }}
           SIGNED_ZIP_SHA256: ${{ needs.sign-macos.outputs.baseline_zip_sha256 }}
+          SIGNED_METADATA_SHA256: ${{ needs.sign-macos.outputs.baseline_metadata_sha256 }}
           SIGNED_SIGNING_IDENTITY: ${{ needs.sign-macos.outputs.baseline_signing_identity }}
           SIGNED_CDHASH: ${{ needs.sign-macos.outputs.baseline_cdhash }}
         run: |
@@ -390,6 +881,7 @@ jobs:
           test "$INDEPENDENT_RELEASE_ID" = "$SIGNED_RELEASE_ID"
           test "$INDEPENDENT_COMMIT" = "$SIGNED_COMMIT"
           test "$INDEPENDENT_ZIP_SHA256" = "$SIGNED_ZIP_SHA256"
+          test "$INDEPENDENT_METADATA_SHA256" = "$SIGNED_METADATA_SHA256"
           test "$INDEPENDENT_SIGNING_IDENTITY" = "$SIGNED_SIGNING_IDENTITY"
           test "$INDEPENDENT_CDHASH" = "$SIGNED_CDHASH"
       - name: Independently verify signed updater envelope
@@ -399,8 +891,8 @@ jobs:
           RELEASE_COMMIT: ${{ inputs.commit }}
           RELEASE_DRAFT_ID: ${{ inputs.draft_id }}
           RELEASE_MODE: ${{ inputs.mode }}
-          WORKFLOW_RUN_ID: ${{ github.run_id }}
-          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+          WORKFLOW_RUN_ID: ${{ needs.sign-macos.outputs.evidence_run_id }}
+          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.evidence_run_attempt }}
           RELEASE_BODY_SHA256: ${{ inputs.draft_body_sha256 }}
           SIGNING_IDENTITY: ${{ needs.sign-macos.outputs.signing_identity }}
           CANDIDATE_CDHASH: ${{ needs.sign-macos.outputs.cdhash }}
@@ -494,6 +986,23 @@ jobs:
         with:
           ref: ${{ inputs.commit }}
           persist-credentials: false
+      - name: Bind recovery transaction tooling
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
+            exit 0
+          fi
+          git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
+          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
+            tools/desktop-release-transaction.ts
+          test "$(git diff --cached --name-only)" = 'tools/desktop-release-transaction.ts'
+          test -z "$(git diff --name-only)"
+          test -z "$(git ls-files --others --exclude-standard)"
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -504,18 +1013,24 @@ jobs:
         with:
           artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
           path: ${{ runner.temp }}/desktop-release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}
           digest-mismatch: error
       - name: Bind immutable Actions artifact evidence
         env:
           ARTIFACT_ID: ${{ needs.sign-macos.outputs.artifact_id }}
           ARTIFACT_DIGEST: ${{ needs.sign-macos.outputs.artifact_digest }}
           ARTIFACT_NAME: ${{ needs.sign-macos.outputs.artifact_name }}
-          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+          EVIDENCE_RUN_ID: ${{ needs.sign-macos.outputs.evidence_run_id }}
+          EVIDENCE_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.evidence_run_attempt }}
         run: |
           set -euo pipefail
           printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
-          test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+          printf '%s' "$EVIDENCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
       - name: Upload updater envelope to the private draft
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -532,11 +1047,31 @@ jobs:
       latest_id: ${{ steps.observe.outputs.latest_id }}
       latest_tag: ${{ steps.observe.outputs.latest_tag }}
       latest_metadata_sha256: ${{ steps.observe.outputs.latest_metadata_sha256 }}
+      rollback_latest_id: ${{ steps.observe.outputs.rollback_latest_id }}
+      rollback_latest_tag: ${{ steps.observe.outputs.rollback_latest_tag }}
+      rollback_latest_metadata_sha256: ${{ steps.observe.outputs.rollback_latest_metadata_sha256 }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.commit }}
           persist-credentials: false
+      - name: Bind recovery transaction tooling
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
+            exit 0
+          fi
+          git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
+          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
+            tools/desktop-release-transaction.ts
+          test "$(git diff --cached --name-only)" = 'tools/desktop-release-transaction.ts'
+          test -z "$(git diff --name-only)"
+          test -z "$(git ls-files --others --exclude-standard)"
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -547,25 +1082,33 @@ jobs:
         with:
           artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
           path: ${{ runner.temp }}/desktop-release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}
           digest-mismatch: error
       - name: Bind immutable Actions artifact evidence
         env:
           ARTIFACT_ID: ${{ needs.sign-macos.outputs.artifact_id }}
           ARTIFACT_DIGEST: ${{ needs.sign-macos.outputs.artifact_digest }}
           ARTIFACT_NAME: ${{ needs.sign-macos.outputs.artifact_name }}
-          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+          EVIDENCE_RUN_ID: ${{ needs.sign-macos.outputs.evidence_run_id }}
+          EVIDENCE_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.evidence_run_attempt }}
         run: |
           set -euo pipefail
           printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
-          test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+          printf '%s' "$EVIDENCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
       - name: Bind latest before public mutation
         id: observe
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          BASELINE_METADATA_SHA256: ${{ needs.sign-macos.outputs.baseline_metadata_sha256 }}
         run: |
           pnpm desktop-release:transaction observe \
             --directory "$RUNNER_TEMP/desktop-release" \
+            --baseline-metadata-sha256 "$BASELINE_METADATA_SHA256" \
             --github-output "$GITHUB_OUTPUT"
       - name: Publish verified release without changing latest
         env:
@@ -580,7 +1123,7 @@ jobs:
             --expected-latest-tag "$EXPECTED_LATEST_TAG" \
             --expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"
 
-  promote-latest:
+  request-latest:
     runs-on: ubuntu-latest
     needs: [sign-macos, publish-assets]
     environment: desktop-macos-latest
@@ -592,6 +1135,23 @@ jobs:
         with:
           ref: ${{ inputs.commit }}
           persist-credentials: false
+      - name: Bind recovery transaction tooling
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
+            exit 0
+          fi
+          git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
+          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
+            tools/desktop-release-transaction.ts
+          test "$(git diff --cached --name-only)" = 'tools/desktop-release-transaction.ts'
+          test -z "$(git diff --name-only)"
+          test -z "$(git ls-files --others --exclude-standard)"
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -602,18 +1162,24 @@ jobs:
         with:
           artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
           path: ${{ runner.temp }}/desktop-release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}
           digest-mismatch: error
       - name: Bind immutable Actions artifact evidence
         env:
           ARTIFACT_ID: ${{ needs.sign-macos.outputs.artifact_id }}
           ARTIFACT_DIGEST: ${{ needs.sign-macos.outputs.artifact_digest }}
           ARTIFACT_NAME: ${{ needs.sign-macos.outputs.artifact_name }}
-          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+          EVIDENCE_RUN_ID: ${{ needs.sign-macos.outputs.evidence_run_id }}
+          EVIDENCE_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.evidence_run_attempt }}
         run: |
           set -euo pipefail
           printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
-          test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+          printf '%s' "$EVIDENCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
       - name: Compare-and-swap repository latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -627,10 +1193,10 @@ jobs:
             --expected-latest-tag "$EXPECTED_LATEST_TAG" \
             --expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"
 
-  verify-production-update:
-    runs-on: macos-15
-    needs: [sign-macos, promote-latest]
-    if: ${{ inputs.mode == 'steady' }}
+  reconcile-latest:
+    runs-on: ubuntu-latest
+    needs: [sign-macos, publish-assets, request-latest]
+    environment: desktop-macos-latest
     permissions:
       actions: read
       contents: read
@@ -639,6 +1205,23 @@ jobs:
         with:
           ref: ${{ inputs.commit }}
           persist-credentials: false
+      - name: Bind recovery transaction tooling
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
+            exit 0
+          fi
+          git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
+          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
+            tools/desktop-release-transaction.ts
+          test "$(git diff --cached --name-only)" = 'tools/desktop-release-transaction.ts'
+          test -z "$(git diff --name-only)"
+          test -z "$(git ls-files --others --exclude-standard)"
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -649,11 +1232,79 @@ jobs:
         with:
           artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
           path: ${{ runner.temp }}/desktop-release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}
+          digest-mismatch: error
+      - name: Bind immutable Actions artifact evidence
+        env:
+          ARTIFACT_ID: ${{ needs.sign-macos.outputs.artifact_id }}
+          ARTIFACT_DIGEST: ${{ needs.sign-macos.outputs.artifact_digest }}
+          ARTIFACT_NAME: ${{ needs.sign-macos.outputs.artifact_name }}
+          EVIDENCE_RUN_ID: ${{ needs.sign-macos.outputs.evidence_run_id }}
+          EVIDENCE_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.evidence_run_attempt }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
+          printf '%s' "$EVIDENCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
+      - name: Reconcile repository latest read-only
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm desktop-release:transaction reconcile --directory "$RUNNER_TEMP/desktop-release"
+
+  verify-production-update:
+    runs-on: macos-15
+    needs: [sign-macos, reconcile-latest]
+    if: ${{ inputs.mode == 'steady' }}
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.commit }}
+          persist-credentials: false
+      - name: Bind recovery transaction tooling
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
+            exit 0
+          fi
+          git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
+          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
+            tools/desktop-release-transaction.ts
+          test "$(git diff --cached --name-only)" = 'tools/desktop-release-transaction.ts'
+          test -z "$(git diff --name-only)"
+          test -z "$(git ls-files --others --exclude-standard)"
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
+          path: ${{ runner.temp }}/desktop-release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}
           digest-mismatch: error
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           artifact-ids: ${{ needs.sign-macos.outputs.baseline_artifact_id }}
           path: ${{ runner.temp }}/desktop-baseline
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}
           digest-mismatch: error
       - name: Bind immutable candidate and baseline artifacts
         env:
@@ -663,15 +1314,18 @@ jobs:
           BASELINE_ID: ${{ needs.sign-macos.outputs.baseline_artifact_id }}
           BASELINE_DIGEST: ${{ needs.sign-macos.outputs.baseline_artifact_digest }}
           BASELINE_NAME: ${{ needs.sign-macos.outputs.baseline_artifact_name }}
-          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+          EVIDENCE_RUN_ID: ${{ needs.sign-macos.outputs.evidence_run_id }}
+          EVIDENCE_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.evidence_run_attempt }}
         run: |
           set -euo pipefail
           printf '%s' "$CANDIDATE_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$CANDIDATE_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
           printf '%s' "$BASELINE_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$BASELINE_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
-          test "$CANDIDATE_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
-          test "$BASELINE_NAME" = "desktop-baseline-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+          printf '%s' "$EVIDENCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          test "$CANDIDATE_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
+          test "$BASELINE_NAME" = "desktop-baseline-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
       - name: Exercise native production-feed update
         env:
           ENDURAGENT_MACOS_UPDATE_ROUNDTRIP_MODE: steady
@@ -701,10 +1355,10 @@ jobs:
 
   activate-release:
     runs-on: ubuntu-latest
-    needs: [sign-macos, publish-assets, promote-latest, verify-production-update]
+    needs: [sign-macos, publish-assets, request-latest, reconcile-latest, verify-production-update]
     if: >-
       ${{ always() && needs.publish-assets.result == 'success' &&
-          needs.promote-latest.result == 'success' &&
+          needs.reconcile-latest.result == 'success' &&
           ((inputs.mode == 'genesis' && needs.verify-production-update.result == 'skipped') ||
            (inputs.mode == 'steady' && needs.verify-production-update.result == 'success')) }}
     environment: desktop-macos-latest
@@ -716,6 +1370,23 @@ jobs:
         with:
           ref: ${{ inputs.commit }}
           persist-credentials: false
+      - name: Bind recovery transaction tooling
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
+            exit 0
+          fi
+          git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
+          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
+            tools/desktop-release-transaction.ts
+          test "$(git diff --cached --name-only)" = 'tools/desktop-release-transaction.ts'
+          test -z "$(git diff --name-only)"
+          test -z "$(git ls-files --others --exclude-standard)"
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -726,18 +1397,24 @@ jobs:
         with:
           artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
           path: ${{ runner.temp }}/desktop-release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}
           digest-mismatch: error
       - name: Bind immutable Actions artifact evidence
         env:
           ARTIFACT_ID: ${{ needs.sign-macos.outputs.artifact_id }}
           ARTIFACT_DIGEST: ${{ needs.sign-macos.outputs.artifact_digest }}
           ARTIFACT_NAME: ${{ needs.sign-macos.outputs.artifact_name }}
-          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+          EVIDENCE_RUN_ID: ${{ needs.sign-macos.outputs.evidence_run_id }}
+          EVIDENCE_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.evidence_run_attempt }}
         run: |
           set -euo pipefail
           printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
-          test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+          printf '%s' "$EVIDENCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
       - name: Activate bound general-availability body
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -751,9 +1428,18 @@ jobs:
 
   compensate-publication:
     runs-on: ubuntu-latest
-    needs: [sign-macos, publish-assets, promote-latest, verify-production-update, activate-release]
+    needs:
+      [
+        sign-macos,
+        publish-assets,
+        request-latest,
+        reconcile-latest,
+        verify-production-update,
+        activate-release,
+      ]
     if: >-
       ${{ always() && needs.publish-assets.outputs.latest_id != '' &&
+          needs.reconcile-latest.result == 'success' &&
           needs.activate-release.result != 'success' }}
     environment: desktop-macos-latest
     permissions:
@@ -764,6 +1450,23 @@ jobs:
         with:
           ref: ${{ inputs.commit }}
           persist-credentials: false
+      - name: Bind recovery transaction tooling
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
+            exit 0
+          fi
+          git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
+          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
+            tools/desktop-release-transaction.ts
+          test "$(git diff --cached --name-only)" = 'tools/desktop-release-transaction.ts'
+          test -z "$(git diff --name-only)"
+          test -z "$(git ls-files --others --exclude-standard)"
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -774,24 +1477,30 @@ jobs:
         with:
           artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}
           path: ${{ runner.temp }}/desktop-release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}
           digest-mismatch: error
       - name: Bind immutable Actions artifact evidence
         env:
           ARTIFACT_ID: ${{ needs.sign-macos.outputs.artifact_id }}
           ARTIFACT_DIGEST: ${{ needs.sign-macos.outputs.artifact_digest }}
           ARTIFACT_NAME: ${{ needs.sign-macos.outputs.artifact_name }}
-          SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}
+          EVIDENCE_RUN_ID: ${{ needs.sign-macos.outputs.evidence_run_id }}
+          EVIDENCE_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.evidence_run_attempt }}
         run: |
           set -euo pipefail
           printf '%s' "$ARTIFACT_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$ARTIFACT_DIGEST" | grep -Eq '^[0-9a-f]{64}$'
-          test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"
+          printf '%s' "$EVIDENCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
       - name: Restore prior latest and withdraw candidate
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          EXPECTED_LATEST_ID: ${{ needs.publish-assets.outputs.latest_id }}
-          EXPECTED_LATEST_TAG: ${{ needs.publish-assets.outputs.latest_tag }}
-          EXPECTED_LATEST_METADATA_SHA256: ${{ needs.publish-assets.outputs.latest_metadata_sha256 }}
+          EXPECTED_LATEST_ID: ${{ needs.publish-assets.outputs.rollback_latest_id }}
+          EXPECTED_LATEST_TAG: ${{ needs.publish-assets.outputs.rollback_latest_tag }}
+          EXPECTED_LATEST_METADATA_SHA256: ${{ needs.publish-assets.outputs.rollback_latest_metadata_sha256 }}
         run: |
           set -euo pipefail
           BODY=$(awk '/^## /{i++} i==1{print} i==2{exit}' apps/desktop/CHANGELOG.md | tail -n +2)

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -104,6 +104,75 @@ describe("desktop release workflow policy", () => {
     expectIssue({ ...source, coordinator }, "recovery tooling tag must be an optional string");
   });
 
+  it("requires an optional recovery source run guarded by steady recovery tooling", () => {
+    const source = sources();
+    const requiredSource = replaceRequired(
+      source.coordinator,
+      [
+        "      recovery_source_run_id:",
+        '        description: "Optional failed desktop release run whose immutable signed artifacts should be resumed"',
+        "        required: false",
+        '        default: ""',
+        "        type: string",
+      ].join("\n"),
+      [
+        "      recovery_source_run_id:",
+        '        description: "Optional failed desktop release run whose immutable signed artifacts should be resumed"',
+        "        required: true",
+        '        default: ""',
+        "        type: string",
+      ].join("\n"),
+    );
+    expectIssue({ ...source, coordinator: requiredSource }, "source run id must be an optional");
+
+    const unguardedSource = replaceRequired(
+      source.coordinator,
+      'if [ -z "$RECOVERY_TOOLING_TAG_INPUT" ] || [ "$MODE" != \'steady\' ]; then',
+      "if false; then",
+    );
+    expectIssue(
+      { ...source, coordinator: unguardedSource },
+      "source run must require a steady immutable recovery tag",
+    );
+  });
+
+  it("requires independent coordinator source run, job, and artifact provenance", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.coordinator,
+        "actions/runs/$SOURCE_RUN_ID/jobs?per_page=100",
+        "actions/runs/$SOURCE_RUN_ID/jobs?per_page=1",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "for required_job in sign-macos verify-macos-envelope stage-private-draft publish-assets; do",
+        "for required_job in sign-macos verify-macos-envelope stage-private-draft; do",
+      ),
+      replaceRequired(
+        source.coordinator,
+        'test "$(printf \'%s\' "$ARTIFACT" | jq -r \'.workflow_run.head_sha\')" = "$SOURCE_SHA"',
+        "true",
+      ),
+    ];
+    for (const coordinator of mutations) {
+      expectIssue(
+        { ...source, coordinator },
+        "independently validate source run, job, and artifact provenance",
+      );
+    }
+  });
+
+  it("keeps source final-state authorization out of the frozen coordinator tuple", () => {
+    const source = sources();
+    const coordinator = replaceRequired(
+      source.coordinator,
+      "      source_run_id: ${{ steps.bind.outputs.source_run_id }}\n",
+      "      source_run_id: ${{ steps.bind.outputs.source_run_id }}\n      source_final_body_allowed: ${{ steps.bind.outputs.source_final_body_allowed }}\n",
+    );
+    expectIssue({ ...source, coordinator }, "freeze the candidate release tuple once");
+  });
+
   it("binds recovery tooling to an exact steady-only tag on main", () => {
     const source = sources();
     const mutations = [
@@ -143,21 +212,60 @@ describe("desktop release workflow policy", () => {
     }
   });
 
-  it("requires a desktop changelog draft with stable non-latest semantics", () => {
+  it("admits only an exact draft, recovery-provisional public, or live-latest final release", () => {
     const source = sources();
-    const wrongChangelog = replaceRequired(
-      source.coordinator,
-      "apps/desktop/CHANGELOG.md",
-      "packages/cycling-coach/CHANGELOG.md",
-    );
-    const latestDraft = replaceRequired(
-      source.coordinator,
-      "--draft --latest=false --target",
-      "--draft --target",
-    );
-    for (const coordinator of [wrongChangelog, latestDraft]) {
-      expectIssue({ ...source, coordinator }, "non-latest draft from the desktop changelog");
+    const mutations = [
+      replaceRequired(
+        source.coordinator,
+        "apps/desktop/CHANGELOG.md",
+        "packages/cycling-coach/CHANGELOG.md",
+      ),
+      replaceRequired(source.coordinator, "--draft --latest=false --target", "--draft --target"),
+      replaceRequired(
+        source.coordinator,
+        "Desktop update validation is in progress. This release is not yet generally available.",
+        "A public body that is not the exact provisional sentinel.",
+      ),
+      replaceRequired(source.coordinator, "test \"$RELEASE_SOURCE_RUN_ID\" != 'none'", "true"),
+      replaceRequired(
+        source.coordinator,
+        '                test "$EXISTING_BODY_SHA256" = "$BODY_SHA256"\n                LATEST_JSON=',
+        "                true\n                LATEST_JSON=",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
+        '          GH_TOKEN: ""',
+      ),
+      replaceRequired(
+        source.coordinator,
+        "gh api -H 'Cache-Control: no-cache' \"repos/$GITHUB_REPOSITORY/releases/latest\"",
+        'gh api "repos/$GITHUB_REPOSITORY/releases/latest"',
+      ),
+      replaceRequired(
+        source.coordinator,
+        "test \"$(printf '%s' \"$LATEST_JSON\" | jq -r '.id | tostring')\" = \"$(printf '%s' \"$RELEASE_JSON\" | jq -r '.databaseId | tostring')\"",
+        "true",
+      ),
+      replaceRequired(
+        source.coordinator,
+        'test "$(printf \'%s\' "$LATEST_JSON" | jq -r \'.tag_name\')" = "$RELEASE_TAG"',
+        "true",
+      ),
+    ];
+    for (const coordinator of mutations) {
+      expectIssue({ ...source, coordinator }, "live-latest exact-final release");
     }
+  });
+
+  it("never creates a missing candidate while recovering source artifacts", () => {
+    const source = sources();
+    const coordinator = replaceRequired(
+      source.coordinator,
+      "          else\n            test \"$RELEASE_SOURCE_RUN_ID\" = 'none'\n            gh release create",
+      "          else\n            true\n            gh release create",
+    );
+    expectIssue({ ...source, coordinator }, "never create a missing candidate release");
   });
 
   it("requires one bound-ref, npm-independent child dispatch and awaits it", () => {
@@ -187,6 +295,37 @@ describe("desktop release workflow policy", () => {
     }
   });
 
+  it("seals exactly one nonce-bearing full child dispatch tuple", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.coordinator,
+        "DISPATCH_NONCE=$(openssl rand -hex 32)",
+        "DISPATCH_NONCE=0000",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "sourceRunId: $sourceRunId, nonce: $nonce",
+        "nonce: $nonce",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "          retention-days: 1",
+        "          retention-days: 90",
+      ),
+    ];
+    for (const coordinator of mutations) {
+      expectIssue({ ...source, coordinator }, "seal exactly one nonce-bound full dispatch tuple");
+    }
+
+    const unboundDispatch = replaceRequired(
+      source.coordinator,
+      '-f dispatch_binding_sha256="$DISPATCH_BINDING_SHA256"',
+      '-f dispatch_binding_sha256="$RELEASE_BODY_SHA256"',
+    );
+    expectIssue({ ...source, coordinator: unboundDispatch }, "npm-independent child tuple");
+  });
+
   it("requires the child to accept only desktop release inputs", () => {
     const source = sources();
     const desktop = replaceRequired(
@@ -196,6 +335,45 @@ describe("desktop release workflow policy", () => {
     );
     expectIssue({ ...source, desktop }, "only the frozen desktop release tuple");
     expectIssue({ ...source, desktop }, "must not consume npm release identity");
+  });
+
+  it("requires the child source run id in the frozen dispatch tuple", () => {
+    const source = sources();
+    const desktop = replaceRequired(
+      source.desktop,
+      "      source_run_id:\n        description: Failed source run id or none\n        required: true\n        type: string\n",
+      "",
+    );
+    expectIssue({ ...source, desktop }, "only the frozen desktop release tuple");
+    expectIssue({ ...source, desktop }, "require string input source_run_id");
+  });
+
+  it("requires bot actors and one coordinator-owned dispatch binding artifact", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(source.desktop, "test \"$RUN_ACTOR\" = 'github-actions[bot]'", "true"),
+      replaceRequired(
+        source.desktop,
+        "test \"$RUN_TRIGGERING_ACTOR\" = 'github-actions[bot]'",
+        "true",
+      ),
+      replaceRequired(source.desktop, "sourceRunId: $sourceRunId, nonce: $nonce", "nonce: $nonce"),
+      replaceRequired(
+        source.desktop,
+        "[.[].artifacts[] | select(.name == $name)] | select(length == 1) | .[0]",
+        "[.[].artifacts[] | select(.name == $name)] | first",
+      ),
+    ];
+    for (const [index, desktop] of mutations.entries()) {
+      expect(
+        inspect({ ...source, desktop }).some((issue) =>
+          issue.includes(
+            "require bot actors and one coordinator-owned nonce-bound dispatch artifact",
+          ),
+        ),
+        `dispatch authorization mutation ${index}`,
+      ).toBe(true);
+    }
   });
 
   it("authorizes only the active desktop coordinator", () => {
@@ -230,13 +408,106 @@ describe("desktop release workflow policy", () => {
       ),
       replaceRequired(
         source.desktop,
-        'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${RECOVERY_REVISION}"',
+        'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${CURRENT_RECOVERY_REVISION}"',
         'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.1"',
       ),
       replaceRequired(source.desktop, "jq -r '.head_branch'", "jq -r '.head_sha'"),
     ];
     for (const desktop of mutations) {
       expectIssue({ ...source, desktop }, "authorize only its active desktop coordinator");
+    }
+  });
+
+  it("independently revalidates source run, attempt jobs, and artifact provenance", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(source.desktop, ".head_repository.full_name", ".repository.full_name"),
+      replaceRequired(
+        source.desktop,
+        "test \"$(printf '%s' \"$SOURCE\" | jq -r '.actor.login')\" = 'github-actions[bot]'",
+        "true",
+      ),
+      replaceRequired(
+        source.desktop,
+        "actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_RUN_ATTEMPT/jobs?per_page=100",
+        "actions/runs/$SOURCE_RUN_ID/jobs?per_page=100",
+      ),
+      replaceRequired(
+        source.desktop,
+        "([.[].jobs[]] | length) == .[0].total_count",
+        "([.[].jobs[]] | length) > 0",
+      ),
+      source.desktop.replaceAll(".workflow_run.head_repository_id", ".workflow_run.repository_id"),
+    ];
+    for (const desktop of mutations) {
+      expectIssue(
+        { ...source, desktop },
+        "child must independently validate source run, job, and artifact provenance",
+      );
+    }
+  });
+
+  it("independently admits public recovery only when provisional or exact-final and live-latest", () => {
+    const source = sources();
+    const candidateFetch =
+      '          CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")\n';
+    const lateCandidateFetch = replaceRequired(
+      replaceRequired(source.desktop, candidateFetch, ""),
+      "          printf '%s' \"$SOURCE_RUN_ID\" | grep -Eq '^[1-9][0-9]*$'",
+      `${candidateFetch}          printf '%s' "$SOURCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'`,
+    );
+    const mutations = [
+      lateCandidateFetch,
+      replaceRequired(
+        source.desktop,
+        "          GH_TOKEN: ${{ github.token }}",
+        '          GH_TOKEN: ""',
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$(printf \'%s\' "$CANDIDATE_RELEASE" | jq -r \'.id | tostring\')" = "$RELEASE_DRAFT_ID"',
+        "true",
+      ),
+      replaceRequired(
+        source.desktop,
+        "            test \"$SOURCE_RUN_ID\" != 'none'",
+        "            true",
+      ),
+      replaceRequired(
+        source.desktop,
+        "Desktop update validation is in progress. This release is not yet generally available.",
+        "A public body that is not the exact provisional sentinel.",
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$CANDIDATE_BODY_SHA256" = "$RELEASE_BODY_SHA256"',
+        "true",
+      ),
+      replaceRequired(
+        source.desktop,
+        "gh api -H 'Cache-Control: no-cache' \"repos/$GITHUB_REPOSITORY/releases/latest\"",
+        'gh api "repos/$GITHUB_REPOSITORY/releases/latest"',
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$(printf \'%s\' "$LATEST_RELEASE" | jq -r \'.id | tostring\')" = "$RELEASE_DRAFT_ID"',
+        "true",
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$(printf \'%s\' "$LATEST_RELEASE" | jq -r \'.tag_name\')" = "$RELEASE_TAG"',
+        "true",
+      ),
+    ];
+    for (const [index, desktop] of mutations.entries()) {
+      expect(
+        inspect({ ...source, desktop }).some((issue) =>
+          issue.includes(
+            "independently admit public recovery only as provisional or live-latest exact-final",
+          ),
+        ),
+        `public recovery admission mutation ${index}`,
+      ).toBe(true);
     }
   });
 
@@ -312,8 +583,8 @@ describe("desktop release workflow policy", () => {
     const githubTokenBinding = ["GITHUB_TOKEN", "${{ github.token }}"].join(": ");
     const desktop = replaceRequired(
       source.desktop,
-      "contents: read\n    outputs:",
-      "contents: write\n    outputs:",
+      "  sign-macos:\n    runs-on: macos-15\n    needs: authorize-coordinator\n    environment: desktop-macos-signing\n    permissions:\n      actions: read\n      contents: read",
+      "  sign-macos:\n    runs-on: macos-15\n    needs: authorize-coordinator\n    environment: desktop-macos-signing\n    permissions:\n      actions: read\n      contents: write",
     ).replaceAll(githubTokenBinding, "CSC_LINK: ${{ secrets.CSC_LINK }}");
     expectIssue({ ...source, desktop }, "macOS signing permissions");
     expectIssue({ ...source, desktop }, "escaped the signing job");
@@ -321,7 +592,11 @@ describe("desktop release workflow policy", () => {
 
   it("requires workspace dependencies and signing environment secrets before packaging", () => {
     const source = sources();
-    const noBuild = replaceRequired(source.desktop, "      - run: pnpm -r build\n", "");
+    const noBuild = replaceRequired(
+      source.desktop,
+      "      - if: ${{ inputs.source_run_id == 'none' }}\n        run: pnpm -r build\n",
+      "",
+    );
     expectIssue({ ...source, desktop: noBuild }, "build workspace dependencies before packaging");
     const unchecked = replaceRequired(
       source.desktop,
@@ -329,6 +604,140 @@ describe("desktop release workflow policy", () => {
       "for secret_name in CSC_LINK; do",
     );
     expectIssue({ ...source, desktop: unchecked }, "fail closed when an environment secret");
+  });
+
+  it("makes every signing-production step fresh-only during resume", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.desktop,
+        "      - if: ${{ inputs.source_run_id == 'none' }}\n        run: pnpm -r build",
+        "      - run: pnpm -r build",
+      ),
+      replaceRequired(
+        source.desktop,
+        "      - name: Resolve signed baseline\n        if: ${{ inputs.source_run_id == 'none' }}",
+        "      - name: Resolve signed baseline\n        if: ${{ always() }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        "      - name: Build signed and notarized macOS envelope\n        if: ${{ inputs.source_run_id == 'none' }}",
+        "      - name: Build signed and notarized macOS envelope\n        if: ${{ always() }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        "      - name: Bind candidate signing evidence\n        if: ${{ inputs.source_run_id == 'none' }}",
+        "      - name: Bind candidate signing evidence\n        if: ${{ always() }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        "      - name: Seal digest-bound release manifest\n        if: ${{ inputs.source_run_id == 'none' }}",
+        "      - name: Seal digest-bound release manifest\n        if: ${{ always() }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        "      - name: Upload sealed macOS transaction artifact\n        if: ${{ inputs.source_run_id == 'none' }}",
+        "      - name: Upload sealed macOS transaction artifact\n        if: ${{ always() }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        "      - name: Upload sealed baseline updater envelope\n        if: ${{ inputs.source_run_id == 'none' && inputs.mode == 'steady' }}",
+        "      - name: Upload sealed baseline updater envelope\n        if: ${{ inputs.mode == 'steady' }}",
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue(
+        { ...source, desktop },
+        "resume must skip build, signing, notarization, sealing, and signing-artifact upload",
+      );
+    }
+  });
+
+  it("reuses only the authorized source run's digest-bound artifacts", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.desktop,
+        "run-id: ${{ needs.authorize-coordinator.outputs.source_run_id }}",
+        "run-id: ${{ github.run_id }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        "artifact-ids: ${{ needs.authorize-coordinator.outputs.baseline_artifact_id }}",
+        "artifact-ids: ${{ needs.authorize-coordinator.outputs.artifact_id }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        "          digest-mismatch: error",
+        "          digest-mismatch: warn",
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$(jq -er \'.workflowRunId\' "$MANIFEST")" = "$SOURCE_RUN_ID"',
+        "true",
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue(
+        { ...source, desktop },
+        "resume must reuse exact digest-bound artifacts from the authorized run",
+      );
+    }
+  });
+
+  it("normalizes fresh and resumed signing evidence before downstream use", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.desktop,
+        "evidence_run_id: ${{ steps.normalized-evidence.outputs.evidence_run_id }}",
+        "evidence_run_id: ${{ github.run_id }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        'EVIDENCE_RUN_ID="$SOURCE_RUN_ID"',
+        'EVIDENCE_RUN_ID="$GITHUB_RUN_ID"',
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue({ ...source, desktop }, "normalize fresh and resumed immutable evidence");
+    }
+  });
+
+  it("uses normalized manifest baseline evidence for resumed consumers", () => {
+    const source = sources();
+    const rawBaseline = replaceRequired(
+      source.desktop,
+      "RELEASE_BASELINE_TAG: ${{ needs.sign-macos.outputs.baseline_tag }}",
+      "RELEASE_BASELINE_TAG: ${{ inputs.baseline_tag }}",
+    );
+    expectIssue({ ...source, desktop: rawBaseline }, "normalized manifest evidence");
+
+    const uncheckedMetadata = replaceRequired(
+      source.desktop,
+      'test "$INDEPENDENT_METADATA_SHA256" = "$SIGNED_METADATA_SHA256"',
+      "true",
+    );
+    expectIssue({ ...source, desktop: uncheckedMetadata }, "normalized manifest evidence");
+  });
+
+  it("uses normalized evidence run ids and digest checks on every downstream download", () => {
+    const source = sources();
+    const wrongRun = source.desktop.replaceAll(
+      "run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}",
+      "run-id: ${{ github.run_id }}",
+    );
+    expectIssue({ ...source, desktop: wrongRun }, "normalized digest-bound cross-run evidence");
+
+    const missingDigest = replaceRequired(
+      source.desktop,
+      "          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}\n          digest-mismatch: error",
+      "          run-id: ${{ needs.sign-macos.outputs.evidence_run_id }}",
+    );
+    expectIssue(
+      { ...source, desktop: missingDigest },
+      "normalized digest-bound cross-run evidence",
+    );
   });
 
   it("requires protected publication, latest, and compensation environments", () => {
@@ -366,6 +775,33 @@ describe("desktop release workflow policy", () => {
     expectIssue({ ...source, desktop: noCas }, "compare-and-swap");
   });
 
+  it("separates latest mutation from read-only reconciliation", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.desktop,
+        "needs: [sign-macos, publish-assets, request-latest]",
+        "needs: [sign-macos, publish-assets]",
+      ),
+      replaceRequired(
+        source.desktop,
+        "  reconcile-latest:\n    runs-on: ubuntu-latest\n    needs: [sign-macos, publish-assets, request-latest]\n    environment: desktop-macos-latest\n    permissions:\n      actions: read\n      contents: read",
+        "  reconcile-latest:\n    runs-on: ubuntu-latest\n    needs: [sign-macos, publish-assets, request-latest]\n    environment: desktop-macos-latest\n    permissions:\n      actions: read\n      contents: write",
+      ),
+      replaceRequired(
+        source.desktop,
+        "desktop-release:transaction reconcile --directory",
+        "desktop-release:transaction promote --directory",
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue(
+        { ...source, desktop },
+        "latest request must compare-and-swap before read-only latest reconciliation",
+      );
+    }
+  });
+
   it("requires the native production-feed round trip and gated activation", () => {
     const source = sources();
     const noRoundTrip = replaceRequired(
@@ -380,6 +816,16 @@ describe("desktop release workflow policy", () => {
       "needs.verify-production-update.result != 'failure'",
     );
     expectIssue({ ...source, desktop: bypass }, "mode-specific acceptance");
+
+    const bypassReconciliation = replaceRequired(
+      source.desktop,
+      "needs: [sign-macos, reconcile-latest]",
+      "needs: [sign-macos, request-latest]",
+    );
+    expectIssue(
+      { ...source, desktop: bypassReconciliation },
+      "production-feed N-to-N+1 round trip",
+    );
   });
 
   it("requires compensation to restore prior latest and withdraw the candidate", () => {
@@ -389,7 +835,38 @@ describe("desktop release workflow policy", () => {
       "needs.activate-release.result != 'success'",
       "needs.activate-release.result == 'failure'",
     );
-    expectIssue({ ...source, desktop }, "restore prior latest");
+    expectIssue({ ...source, desktop }, "successful reconciliation");
+
+    const beforeReconciliation = replaceRequired(
+      source.desktop,
+      "needs.reconcile-latest.result == 'success' &&\n          needs.activate-release.result != 'success'",
+      "needs.request-latest.result == 'success' &&\n          needs.activate-release.result != 'success'",
+    );
+    expectIssue({ ...source, desktop: beforeReconciliation }, "successful reconciliation");
+  });
+
+  it("keeps compensation rollback bound to normalized manifest baseline evidence", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.desktop,
+        "BASELINE_METADATA_SHA256: ${{ needs.sign-macos.outputs.baseline_metadata_sha256 }}",
+        "BASELINE_METADATA_SHA256: ${{ steps.observe.outputs.latest_metadata_sha256 }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        "EXPECTED_LATEST_TAG: ${{ needs.publish-assets.outputs.rollback_latest_tag }}",
+        "EXPECTED_LATEST_TAG: ${{ needs.publish-assets.outputs.latest_tag }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        "rollback_latest_metadata_sha256: ${{ steps.observe.outputs.rollback_latest_metadata_sha256 }}",
+        "rollback_latest_metadata_sha256: ${{ steps.observe.outputs.latest_metadata_sha256 }}",
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue({ ...source, desktop }, "normalized manifest baseline evidence");
+    }
   });
 
   it("binds recovery tooling to the coordinator and audited overlay", () => {
@@ -405,42 +882,62 @@ describe("desktop release workflow policy", () => {
       "            apps/desktop/scripts/macos-release-cli.mjs \\\n",
       "            apps/desktop/src/main/index.ts\n",
     );
-    expectIssue({ ...source, desktop: productOverlay }, "overlay only audited release tooling");
+    expectIssue({ ...source, desktop: productOverlay }, "manual signing recovery must overlay");
     const reversedAncestry = replaceRequired(
       source.desktop,
       'git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"',
       'git merge-base --is-ancestor "$RELEASE_TOOLING_COMMIT" "$RELEASE_COMMIT"',
     );
-    expectIssue({ ...source, desktop: reversedAncestry }, "overlay only audited release tooling");
+    expectIssue({ ...source, desktop: reversedAncestry }, "manual signing recovery must overlay");
     const unstagedRestore = replaceRequired(source.desktop, "--staged --worktree", "--worktree");
-    expectIssue({ ...source, desktop: unstagedRestore }, "overlay only audited release tooling");
+    expectIssue({ ...source, desktop: unstagedRestore }, "must overlay exactly");
     const unstagedOverlay = replaceRequired(
       source.desktop,
       "git diff --cached --name-only",
       "git diff --name-only",
     );
-    expectIssue({ ...source, desktop: unstagedOverlay }, "overlay only audited release tooling");
+    expectIssue({ ...source, desktop: unstagedOverlay }, "must overlay exactly");
     const allowsTrackedDrift = replaceRequired(
       source.desktop,
       'test -z "$(git diff --name-only)"',
       "true",
     );
-    expectIssue({ ...source, desktop: allowsTrackedDrift }, "overlay only audited release tooling");
+    expectIssue({ ...source, desktop: allowsTrackedDrift }, "must overlay exactly");
     const allowsUntrackedDrift = replaceRequired(
       source.desktop,
       'test -z "$(git ls-files --others --exclude-standard)"',
       "true",
     );
-    expectIssue(
-      { ...source, desktop: allowsUntrackedDrift },
-      "overlay only audited release tooling",
-    );
+    expectIssue({ ...source, desktop: allowsUntrackedDrift }, "must overlay exactly");
     const movesCandidateHead = replaceRequired(
       source.desktop,
       '          test -z "$(git ls-files --others --exclude-standard)"\n          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"',
       '          test -z "$(git ls-files --others --exclude-standard)"',
     );
-    expectIssue({ ...source, desktop: movesCandidateHead }, "overlay only audited release tooling");
+    expectIssue({ ...source, desktop: movesCandidateHead }, "must overlay exactly");
+  });
+
+  it("allows downstream recovery jobs to overlay only the transaction implementation", () => {
+    const source = sources();
+    const expandedOverlay = replaceRequired(
+      source.desktop,
+      "          test \"$(git diff --cached --name-only)\" = 'tools/desktop-release-transaction.ts'",
+      "          test \"$(git diff --cached --name-only)\" = $'apps/desktop/scripts/macos-release-cli.mjs\\ntools/desktop-release-transaction.ts'",
+    );
+    expectIssue(
+      { ...source, desktop: expandedOverlay },
+      "verify-macos-envelope recovery must overlay exactly tools/desktop-release-transaction.ts",
+    );
+
+    const missingTransaction = replaceRequired(
+      source.desktop,
+      "            tools/desktop-release-transaction.ts\n          test \"$(git diff --cached --name-only)\" = 'tools/desktop-release-transaction.ts'",
+      "            apps/desktop/scripts/macos-release-cli.mjs\n          test \"$(git diff --cached --name-only)\" = 'apps/desktop/scripts/macos-release-cli.mjs'",
+    );
+    expectIssue(
+      { ...source, desktop: missingTransaction },
+      "verify-macos-envelope recovery must overlay exactly tools/desktop-release-transaction.ts",
+    );
   });
 
   it("uses a byte-deterministic npm alias packer", () => {
@@ -472,14 +969,14 @@ describe("desktop release workflow policy", () => {
     }
   });
 
-  it("binds every consumer to the successful signing attempt", () => {
+  it("binds native verification to normalized signing evidence", () => {
     const source = sources();
     const desktop = replaceRequired(
       source.desktop,
-      "SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.workflow_run_attempt }}",
+      "SIGNING_RUN_ATTEMPT: ${{ needs.sign-macos.outputs.evidence_run_attempt }}",
       "SIGNING_RUN_ATTEMPT: ${{ github.run_attempt }}",
     );
-    expectIssue({ ...source, desktop }, "successful signing attempt");
+    expectIssue({ ...source, desktop }, "normalized immutable signing evidence");
   });
 
   it("keeps native verification on the exact-four public envelope", () => {
@@ -519,7 +1016,7 @@ describe("desktop release workflow policy", () => {
     expectIssue({ ...source, desktop: noUmask }, "created privately and always removed");
     const noCleanup = replaceRequired(
       source.desktop,
-      '      - name: Remove temporary notarization key\n        if: ${{ always() }}\n        run: rm -f "$RUNNER_TEMP/AuthKey.p8"\n',
+      "      - name: Remove temporary notarization key\n        if: ${{ always() && inputs.source_run_id == 'none' }}\n        run: rm -f \"$RUNNER_TEMP/AuthKey.p8\"\n",
       "",
     );
     expectIssue({ ...source, desktop: noCleanup }, "created privately and always removed");
@@ -529,8 +1026,8 @@ describe("desktop release workflow policy", () => {
     const source = sources();
     const desktop = replaceRequired(
       source.desktop,
-      'test "$ARTIFACT_NAME" = "desktop-release-$GITHUB_RUN_ID-$SIGNING_RUN_ATTEMPT"',
-      'test "$ARTIFACT_NAME" = "desktop-release-${{ github.run_id }}-$SIGNING_RUN_ATTEMPT"',
+      'test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"',
+      'test "$ARTIFACT_NAME" = "desktop-release-${{ github.run_id }}-$EVIDENCE_RUN_ATTEMPT"',
     );
     expectIssue({ ...source, desktop }, "run scripts must receive contexts through env");
   });

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -7,6 +7,9 @@ import { parse } from "yaml";
 
 type Mapping = Record<string, unknown>;
 
+const PROVISIONAL_RELEASE_BODY =
+  "Desktop update validation is in progress. This release is not yet generally available.";
+
 function mapping(value: unknown, label: string, issues: string[]): Mapping {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     issues.push(`${label} must be a mapping`);
@@ -36,6 +39,12 @@ function namedStep(job: Mapping, name: string): Mapping | undefined {
   return steps(job).find((step) => step.name === name);
 }
 
+function actionSteps(job: Mapping, action: string): Mapping[] {
+  return steps(job).filter(
+    (step) => typeof step.uses === "string" && step.uses.startsWith(`${action}@`),
+  );
+}
+
 function countShellLine(script: string, expected: string): number {
   return script.split(/\r?\n/u).filter((line) => line.trim() === expected).length;
 }
@@ -44,6 +53,70 @@ function exactKeys(value: Mapping, expected: string[]): boolean {
   const actual = Object.keys(value).sort();
   const wanted = [...expected].sort();
   return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
+}
+
+function exactStringSet(value: unknown, expected: string[]): boolean {
+  const actual = (Array.isArray(value) ? value.map(String) : [scalar(value)]).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length && actual.every((item, index) => item === wanted[index]);
+}
+
+function checkRecoveryOverlay(
+  job: Mapping,
+  label: string,
+  expectedPaths: string[],
+  requireAncestry: boolean,
+  issues: string[],
+): void {
+  const jobSteps = steps(job);
+  const checkoutIndex = jobSteps.findIndex(
+    (step) => typeof step.uses === "string" && step.uses.startsWith("actions/checkout@"),
+  );
+  const recoveryStep = namedStep(
+    job,
+    expectedPaths.length === 1
+      ? "Bind recovery transaction tooling"
+      : "Bind recovery release tooling",
+  );
+  const recoveryIndex = jobSteps.indexOf(recoveryStep ?? {});
+  const installIndex = jobSteps.findIndex((step) => step.run === "pnpm install --frozen-lockfile");
+  const environment = mapping(recoveryStep?.env, `${label} recovery environment`, issues);
+  const run = typeof recoveryStep?.run === "string" ? recoveryStep.run : "";
+  const observedPaths =
+    run.replaceAll("\\n", "\n").match(/\b(?:apps|packages|tools)\/[A-Za-z0-9_./@-]+/gu) ?? [];
+  const expectedDiff = expectedPaths.join("\\n");
+  const exactDiff =
+    expectedPaths.length === 1
+      ? run.includes(`test "$(git diff --cached --name-only)" = '${expectedPaths[0]}'`)
+      : run.includes(`EXPECTED_RECOVERY_DIFF=$'${expectedDiff}'`) &&
+        run.includes('test "$(git diff --cached --name-only)" = "$EXPECTED_RECOVERY_DIFF"');
+  if (
+    checkoutIndex === -1 ||
+    recoveryIndex <= checkoutIndex ||
+    installIndex <= recoveryIndex ||
+    !exactKeys(environment, ["RELEASE_COMMIT", "RELEASE_TOOLING_COMMIT"]) ||
+    environment.RELEASE_COMMIT !== "${{ inputs.commit }}" ||
+    environment.RELEASE_TOOLING_COMMIT !== "${{ inputs.tooling_commit }}" ||
+    countShellLine(run, 'test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"') !== 2 ||
+    !run.includes('if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then') ||
+    !run.includes('git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"') ||
+    (requireAncestry &&
+      !run.includes('git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"')) ||
+    countShellLine(
+      run,
+      'git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \\',
+    ) !== 1 ||
+    !exactDiff ||
+    !run.includes('test -z "$(git diff --name-only)"') ||
+    !run.includes('test -z "$(git ls-files --others --exclude-standard)"') ||
+    observedPaths.length !== expectedPaths.length * 2 ||
+    observedPaths.some((path) => !expectedPaths.includes(path)) ||
+    expectedPaths.some(
+      (path) => observedPaths.filter((observedPath) => observedPath === path).length !== 2,
+    )
+  ) {
+    issues.push(`${label} must overlay exactly ${expectedPaths.join(", ")}`);
+  }
 }
 
 function exactPermissions(
@@ -110,7 +183,15 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     "desktop coordinator.workflow_dispatch.inputs",
     issues,
   );
-  if (!exactKeys(inputs, ["tag", "desktop_mode", "desktop_baseline_tag", "recovery_tooling_tag"])) {
+  if (
+    !exactKeys(inputs, [
+      "tag",
+      "desktop_mode",
+      "desktop_baseline_tag",
+      "recovery_tooling_tag",
+      "recovery_source_run_id",
+    ])
+  ) {
     issues.push("desktop coordinator inputs must remain desktop-only");
   }
   const tagInput = mapping(inputs.tag, "desktop coordinator tag input", issues);
@@ -118,6 +199,11 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
   const recoveryToolingTagInput = mapping(
     inputs.recovery_tooling_tag,
     "desktop coordinator recovery tooling tag input",
+    issues,
+  );
+  const recoverySourceRunInput = mapping(
+    inputs.recovery_source_run_id,
+    "desktop coordinator recovery source run input",
     issues,
   );
   if (tagInput.required !== true || tagInput.type !== "string") {
@@ -136,6 +222,13 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     recoveryToolingTagInput.default !== ""
   ) {
     issues.push("desktop coordinator recovery tooling tag must be an optional string");
+  }
+  if (
+    recoverySourceRunInput.type !== "string" ||
+    recoverySourceRunInput.required !== false ||
+    recoverySourceRunInput.default !== ""
+  ) {
+    issues.push("desktop coordinator recovery source run id must be an optional string");
   }
   if (coordinator["run-name"] !== "Desktop release coordinator ${{ inputs.tag }}") {
     issues.push("desktop coordinator run name must bind the candidate tag");
@@ -160,7 +253,12 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     "desktop coordinator.jobs.dispatch-desktop-release",
     issues,
   );
-  exactPermissions(bind.permissions, { contents: "read" }, "desktop candidate binding", issues);
+  exactPermissions(
+    bind.permissions,
+    { actions: "read", contents: "read" },
+    "desktop candidate binding",
+    issues,
+  );
   exactPermissions(draft.permissions, { contents: "write" }, "desktop draft preparation", issues);
   exactPermissions(
     dispatch.permissions,
@@ -178,6 +276,7 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     tooling_commit: "${{ steps.bind.outputs.tooling_commit }}",
     mode: "${{ steps.bind.outputs.mode }}",
     baseline_tag: "${{ steps.bind.outputs.baseline_tag }}",
+    source_run_id: "${{ steps.bind.outputs.source_run_id }}",
   };
   if (
     !exactKeys(bindOutputs, Object.keys(expectedBindOutputs)) ||
@@ -191,6 +290,8 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
   if (
     bindEnvironment.RELEASE_TAG_INPUT !== "${{ inputs.tag }}" ||
     bindEnvironment.RECOVERY_TOOLING_TAG_INPUT !== "${{ inputs.recovery_tooling_tag }}" ||
+    bindEnvironment.RECOVERY_SOURCE_RUN_ID_INPUT !== "${{ inputs.recovery_source_run_id }}" ||
+    bindEnvironment.GH_TOKEN !== "${{ github.token }}" ||
     bindEnvironment.DESKTOP_ENABLED !== "${{ vars.ENABLE_DESKTOP_MACOS_RELEASE }}" ||
     bindEnvironment.WORKFLOW_REF !== "${{ github.ref }}" ||
     bindEnvironment.WORKFLOW_SHA !== "${{ github.sha }}" ||
@@ -211,6 +312,63 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
   ) {
     issues.push(
       "desktop candidate tag must be stable enduragent-desktop SemVer bound to apps/desktop/package.json",
+    );
+  }
+  if (
+    !bindRun.includes("SOURCE_RUN_ID=none") ||
+    !bindRun.includes('if [ -n "$RECOVERY_SOURCE_RUN_ID_INPUT" ]; then') ||
+    !bindRun.includes(
+      'if [ -z "$RECOVERY_TOOLING_TAG_INPUT" ] || [ "$MODE" != \'steady\' ]; then',
+    ) ||
+    !bindRun.includes("printf '%s' \"$RECOVERY_SOURCE_RUN_ID_INPUT\" | grep -Eq '^[1-9][0-9]*$'") ||
+    !bindRun.includes('SOURCE_RUN_ID="$RECOVERY_SOURCE_RUN_ID_INPUT"') ||
+    !bindRun.includes('echo "source_run_id=$SOURCE_RUN_ID" >> "$GITHUB_OUTPUT"')
+  ) {
+    issues.push(
+      "desktop coordinator recovery source run must require a steady immutable recovery tag",
+    );
+  }
+  if (
+    !bindRun.includes(
+      'SOURCE_RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")',
+    ) ||
+    !bindRun.includes(".github/workflows/desktop-release.yml") ||
+    !bindRun.includes(".event')\" = 'workflow_dispatch'") ||
+    !bindRun.includes(".status')\" = 'completed'") ||
+    !bindRun.includes(".conclusion')\" = 'failure'") ||
+    !bindRun.includes(".repository.full_name") ||
+    !bindRun.includes("SOURCE_ATTEMPT=") ||
+    !bindRun.includes('SOURCE_REVISION="${SOURCE_HEAD#"${TAG}-recovery."}"') ||
+    !bindRun.includes('test "$SOURCE_HEAD" = "${TAG}-recovery.${SOURCE_REVISION}"') ||
+    !bindRun.includes('test "$SOURCE_HEAD" != "$RECOVERY_TOOLING_TAG_INPUT"') ||
+    !bindRun.includes(
+      'test "$(git rev-parse "refs/tags/$SOURCE_HEAD^{commit}")" = "$SOURCE_SHA"',
+    ) ||
+    !bindRun.includes('git merge-base --is-ancestor "$COMMIT" "$SOURCE_SHA"') ||
+    !bindRun.includes('git merge-base --is-ancestor "$SOURCE_SHA" "$TOOLING_COMMIT"') ||
+    !bindRun.includes('git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main') ||
+    !bindRun.includes(
+      'SOURCE_JOBS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/jobs?per_page=100")',
+    ) ||
+    !bindRun.includes(
+      "for required_job in sign-macos verify-macos-envelope stage-private-draft publish-assets; do",
+    ) ||
+    !bindRun.includes('.name == "activate-release" and .conclusion == "success"') ||
+    !bindRun.includes(
+      'SOURCE_ARTIFACTS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100")',
+    ) ||
+    !bindRun.includes(
+      'for artifact_name in "desktop-release-$SOURCE_RUN_ID-$SOURCE_ATTEMPT" "desktop-baseline-$SOURCE_RUN_ID-$SOURCE_ATTEMPT"; do',
+    ) ||
+    !bindRun.includes("artifact cardinality") ||
+    !bindRun.includes(".expired") ||
+    !bindRun.includes("^sha256:[0-9a-f]{64}$") ||
+    !bindRun.includes(".workflow_run.id") ||
+    !bindRun.includes(".workflow_run.head_branch") ||
+    !bindRun.includes(".workflow_run.head_sha")
+  ) {
+    issues.push(
+      "desktop coordinator must independently validate source run, job, and artifact provenance",
     );
   }
   if (
@@ -240,28 +398,69 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
   const draftNeeds = scalar(draft.needs);
   const draftOutputs = mapping(draft.outputs, "desktop coordinator draft outputs", issues);
   const draftStep = namedStep(draft, "Create or validate bound desktop release draft");
+  const draftEnvironment = mapping(draftStep?.env, "desktop release draft environment", issues);
   const draftRun = typeof draftStep?.run === "string" ? draftStep.run : "";
+  const expectedDraftEnvironment: Mapping = {
+    GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+    RELEASE_TAG: "${{ needs.bind-release.outputs.tag }}",
+    RELEASE_VERSION: "${{ needs.bind-release.outputs.desktop_version }}",
+    RELEASE_COMMIT: "${{ needs.bind-release.outputs.commit }}",
+    RELEASE_SOURCE_RUN_ID: "${{ needs.bind-release.outputs.source_run_id }}",
+  };
+  const coordinatorPublicAdmission = [
+    "  else",
+    "    test \"$RELEASE_SOURCE_RUN_ID\" != 'none'",
+    `    if [ "$(printf '%s' "$RELEASE_JSON" | jq -r '.body')" != '${PROVISIONAL_RELEASE_BODY}' ]; then`,
+  ].join("\n");
+  const coordinatorLatestLookup =
+    "LATEST_JSON=$(gh api -H 'Cache-Control: no-cache' \"repos/$GITHUB_REPOSITORY/releases/latest\")";
   if (
     !draftNeeds.includes("bind-release") ||
     draftOutputs.draft_id !== "${{ steps.release-draft.outputs.draft_id }}" ||
     draftOutputs.body_sha256 !== "${{ steps.release-draft.outputs.body_sha256 }}" ||
+    !exactKeys(draftEnvironment, Object.keys(expectedDraftEnvironment)) ||
+    Object.entries(expectedDraftEnvironment).some(
+      ([key, value]) => draftEnvironment[key] !== value,
+    ) ||
     !draftRun.includes("apps/desktop/CHANGELOG.md") ||
     draftRun.includes("packages/cycling-coach/CHANGELOG.md") ||
     !draftRun.includes('test "$FIRST_HEADING" = "## $RELEASE_VERSION"') ||
     !draftRun.includes("--json body,databaseId,isDraft,isPrerelease,tagName") ||
-    !draftRun.includes(".isDraft')\" = 'true'") ||
     !draftRun.includes(".isPrerelease')\" = 'false'") ||
-    !draftRun.includes('test "$EXISTING_BODY_SHA256" = "$BODY_SHA256"') ||
+    !draftRun.includes(
+      "if [ \"$(printf '%s' \"$RELEASE_JSON\" | jq -r '.isDraft')\" = 'true' ]; then",
+    ) ||
+    countShellLine(draftRun, 'test "$EXISTING_BODY_SHA256" = "$BODY_SHA256"') !== 2 ||
+    !draftRun.includes(coordinatorPublicAdmission) ||
+    countShellLine(draftRun, coordinatorLatestLookup) !== 1 ||
+    !draftRun.includes(
+      "test \"$(printf '%s' \"$LATEST_JSON\" | jq -r '.id | tostring')\" = \"$(printf '%s' \"$RELEASE_JSON\" | jq -r '.databaseId | tostring')\"",
+    ) ||
+    !draftRun.includes(
+      'test "$(printf \'%s\' "$LATEST_JSON" | jq -r \'.tag_name\')" = "$RELEASE_TAG"',
+    ) ||
     !draftRun.includes(
       'gh release create "$RELEASE_TAG" --draft --latest=false --target "$RELEASE_COMMIT"',
     )
   ) {
     issues.push(
-      "desktop coordinator must create a bound non-latest draft from the desktop changelog",
+      "desktop coordinator must admit only an exact draft, recovery-provisional public release, or live-latest exact-final release",
     );
+  }
+  if (!draftRun.includes("else\n  test \"$RELEASE_SOURCE_RUN_ID\" = 'none'\n  gh release create")) {
+    issues.push("desktop coordinator recovery must never create a missing candidate release");
   }
 
   const dispatchNeeds = scalar(dispatch.needs);
+  const dispatchBindingStep = namedStep(dispatch, "Seal exact child dispatch binding");
+  const dispatchBindingEnvironment = mapping(
+    dispatchBindingStep?.env,
+    "desktop dispatch binding environment",
+    issues,
+  );
+  const dispatchBindingRun =
+    typeof dispatchBindingStep?.run === "string" ? dispatchBindingStep.run : "";
+  const dispatchBindingUploads = actionSteps(dispatch, "actions/upload-artifact");
   const dispatchStep = namedStep(
     dispatch,
     "Dispatch and await environment-bound desktop transaction",
@@ -282,8 +481,11 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     RELEASE_MODE: "${{ needs.bind-release.outputs.mode }}",
     RELEASE_BODY_SHA256: "${{ needs.prepare-release-draft.outputs.body_sha256 }}",
     RELEASE_BASELINE_TAG: "${{ needs.bind-release.outputs.baseline_tag }}",
+    RELEASE_SOURCE_RUN_ID: "${{ needs.bind-release.outputs.source_run_id }}",
     COORDINATOR_RUN_ID: "${{ github.run_id }}",
     COORDINATOR_RUN_ATTEMPT: "${{ github.run_attempt }}",
+    DISPATCH_NONCE: "${{ steps.dispatch-binding.outputs.nonce }}",
+    DISPATCH_BINDING_SHA256: "${{ steps.dispatch-binding.outputs.sha256 }}",
   };
   const dispatchedInputs = Array.from(
     dispatchRun.matchAll(/(?:^|\s)-f ([a-z0-9_]+)=/gu),
@@ -298,8 +500,11 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     "mode",
     "draft_body_sha256",
     "baseline_tag",
+    "source_run_id",
     "coordinator_run_id",
     "coordinator_run_attempt",
+    "dispatch_nonce",
+    "dispatch_binding_sha256",
   ];
   const expectedDispatchedAssignments: Mapping = {
     tag: "RELEASE_TAG",
@@ -310,9 +515,71 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     mode: "RELEASE_MODE",
     draft_body_sha256: "RELEASE_BODY_SHA256",
     baseline_tag: "RELEASE_BASELINE_TAG",
+    source_run_id: "RELEASE_SOURCE_RUN_ID",
     coordinator_run_id: "COORDINATOR_RUN_ID",
     coordinator_run_attempt: "COORDINATOR_RUN_ATTEMPT",
+    dispatch_nonce: "DISPATCH_NONCE",
+    dispatch_binding_sha256: "DISPATCH_BINDING_SHA256",
   };
+  const expectedBindingObject =
+    "{schemaVersion: 1, repository: $repository, repositoryId: $repositoryId, coordinatorRunId: $coordinatorRunId, coordinatorRunAttempt: $coordinatorRunAttempt, workflowRef: $workflowRef, workflowSha: $workflowSha, childWorkflowRef: $childWorkflowRef, tag: $tag, desktopVersion: $desktopVersion, commit: $commit, toolingCommit: $toolingCommit, draftId: $draftId, mode: $mode, draftBodySha256: $draftBodySha256, baselineTag: $baselineTag, sourceRunId: $sourceRunId, nonce: $nonce}";
+  const expectedBindingEnvironment: Mapping = {
+    RELEASE_TAG: "${{ needs.bind-release.outputs.tag }}",
+    DESKTOP_VERSION: "${{ needs.bind-release.outputs.desktop_version }}",
+    RELEASE_COMMIT: "${{ needs.bind-release.outputs.commit }}",
+    RELEASE_WORKFLOW_REF: "${{ needs.bind-release.outputs.workflow_ref }}",
+    RELEASE_TOOLING_COMMIT: "${{ needs.bind-release.outputs.tooling_commit }}",
+    RELEASE_DRAFT_ID: "${{ needs.prepare-release-draft.outputs.draft_id }}",
+    RELEASE_MODE: "${{ needs.bind-release.outputs.mode }}",
+    RELEASE_BODY_SHA256: "${{ needs.prepare-release-draft.outputs.body_sha256 }}",
+    RELEASE_BASELINE_TAG: "${{ needs.bind-release.outputs.baseline_tag }}",
+    RELEASE_SOURCE_RUN_ID: "${{ needs.bind-release.outputs.source_run_id }}",
+    COORDINATOR_RUN_ID: "${{ github.run_id }}",
+    COORDINATOR_RUN_ATTEMPT: "${{ github.run_attempt }}",
+    REPOSITORY: "${{ github.repository }}",
+    REPOSITORY_ID: "${{ github.repository_id }}",
+    WORKFLOW_REF: "${{ github.ref }}",
+    WORKFLOW_SHA: "${{ github.sha }}",
+  };
+  const bindingUploadInputs = mapping(
+    dispatchBindingUploads[0]?.with,
+    "desktop dispatch binding upload inputs",
+    issues,
+  );
+  if (
+    dispatchBindingStep?.id !== "dispatch-binding" ||
+    !exactKeys(dispatchBindingEnvironment, Object.keys(expectedBindingEnvironment)) ||
+    Object.entries(expectedBindingEnvironment).some(
+      ([key, value]) => dispatchBindingEnvironment[key] !== value,
+    ) ||
+    !dispatchBindingRun.includes("DISPATCH_NONCE=$(openssl rand -hex 32)") ||
+    !dispatchBindingRun.includes("printf '%s' \"$DISPATCH_NONCE\" | grep -Eq '^[0-9a-f]{64}$'") ||
+    !dispatchBindingRun.includes(expectedBindingObject) ||
+    !dispatchBindingRun.includes(
+      "BINDING_SHA256=$(printf '%s' \"$BINDING\" | sha256sum | awk '{print $1}')",
+    ) ||
+    !dispatchBindingRun.includes(
+      'ARTIFACT_NAME="desktop-dispatch-binding-$COORDINATOR_RUN_ID-$COORDINATOR_RUN_ATTEMPT-$BINDING_SHA256"',
+    ) ||
+    !dispatchBindingRun.includes(
+      'printf \'%s\' "$BINDING" > "$RUNNER_TEMP/desktop-dispatch-binding.json"',
+    ) ||
+    dispatchBindingUploads.length !== 1 ||
+    !exactKeys(bindingUploadInputs, [
+      "name",
+      "path",
+      "if-no-files-found",
+      "compression-level",
+      "retention-days",
+    ]) ||
+    bindingUploadInputs.name !== "${{ steps.dispatch-binding.outputs.artifact_name }}" ||
+    bindingUploadInputs.path !== "${{ runner.temp }}/desktop-dispatch-binding.json" ||
+    bindingUploadInputs["if-no-files-found"] !== "error" ||
+    bindingUploadInputs["compression-level"] !== 0 ||
+    bindingUploadInputs["retention-days"] !== 1
+  ) {
+    issues.push("desktop coordinator must seal exactly one nonce-bound full dispatch tuple");
+  }
   if (
     !dispatchNeeds.includes("bind-release") ||
     !dispatchNeeds.includes("prepare-release-draft") ||
@@ -331,6 +598,9 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     !dispatchRun.includes('--ref "$RELEASE_WORKFLOW_REF"') ||
     (dispatchRun.match(/--repo "\$GITHUB_REPOSITORY"/gu) ?? []).length !== 3 ||
     !dispatchRun.includes('--arg title "$EXPECTED_TITLE"') ||
+    !dispatchRun.includes(
+      'EXPECTED_TITLE="Desktop release $RELEASE_TAG via $COORDINATOR_RUN_ID.$COORDINATOR_RUN_ATTEMPT binding $DISPATCH_BINDING_SHA256"',
+    ) ||
     !dispatchRun.includes(
       'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
     ) ||
@@ -561,8 +831,11 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     "mode",
     "draft_body_sha256",
     "baseline_tag",
+    "source_run_id",
     "coordinator_run_id",
     "coordinator_run_attempt",
+    "dispatch_nonce",
+    "dispatch_binding_sha256",
   ];
   if (!exactKeys(inputs, expectedInputs)) {
     issues.push("desktop child must accept only the frozen desktop release tuple");
@@ -582,7 +855,7 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
   }
   if (
     desktop["run-name"] !==
-    "Desktop release ${{ inputs.tag }} via ${{ inputs.coordinator_run_id }}.${{ inputs.coordinator_run_attempt }}"
+    "Desktop release ${{ inputs.tag }} via ${{ inputs.coordinator_run_id }}.${{ inputs.coordinator_run_attempt }} binding ${{ inputs.dispatch_binding_sha256 }}"
   ) {
     issues.push("desktop child run name must bind its coordinator invocation");
   }
@@ -615,7 +888,12 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
   );
   const stage = mapping(jobs["stage-private-draft"], "desktop.jobs.stage-private-draft", issues);
   const publish = mapping(jobs["publish-assets"], "desktop.jobs.publish-assets", issues);
-  const promote = mapping(jobs["promote-latest"], "desktop.jobs.promote-latest", issues);
+  const requestLatest = mapping(jobs["request-latest"], "desktop.jobs.request-latest", issues);
+  const reconcileLatest = mapping(
+    jobs["reconcile-latest"],
+    "desktop.jobs.reconcile-latest",
+    issues,
+  );
   const roundTrip = mapping(
     jobs["verify-production-update"],
     "desktop.jobs.verify-production-update",
@@ -641,16 +919,39 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     issues,
   );
   const authorizeRun = typeof authorizeStep?.run === "string" ? authorizeStep.run : "";
+  const authorizeOutputs = mapping(authorize.outputs, "desktop authorization outputs", issues);
+  const expectedAuthorizeOutputs: Mapping = {
+    source_run_id: "${{ steps.authorize.outputs.source_run_id }}",
+    source_run_attempt: "${{ steps.authorize.outputs.source_run_attempt }}",
+    artifact_name: "${{ steps.authorize.outputs.artifact_name }}",
+    artifact_id: "${{ steps.authorize.outputs.artifact_id }}",
+    artifact_digest: "${{ steps.authorize.outputs.artifact_digest }}",
+    baseline_artifact_name: "${{ steps.authorize.outputs.baseline_artifact_name }}",
+    baseline_artifact_id: "${{ steps.authorize.outputs.baseline_artifact_id }}",
+    baseline_artifact_digest: "${{ steps.authorize.outputs.baseline_artifact_digest }}",
+  };
   if (
     sign.needs !== "authorize-coordinator" ||
     authorizeEnvironment.RELEASE_TAG !== "${{ inputs.tag }}" ||
+    authorizeEnvironment.DESKTOP_VERSION !== "${{ inputs.desktop_version }}" ||
+    authorizeEnvironment.RELEASE_DRAFT_ID !== "${{ inputs.draft_id }}" ||
+    authorizeEnvironment.RELEASE_BODY_SHA256 !== "${{ inputs.draft_body_sha256 }}" ||
+    authorizeEnvironment.RELEASE_BASELINE_TAG !== "${{ inputs.baseline_tag }}" ||
     authorizeEnvironment.RELEASE_MODE !== "${{ inputs.mode }}" ||
+    authorizeEnvironment.SOURCE_RUN_ID !== "${{ inputs.source_run_id }}" ||
+    authorizeEnvironment.DISPATCH_NONCE !== "${{ inputs.dispatch_nonce }}" ||
+    authorizeEnvironment.DISPATCH_BINDING_SHA256 !== "${{ inputs.dispatch_binding_sha256 }}" ||
+    authorizeEnvironment.RUN_ACTOR !== "${{ github.actor }}" ||
+    authorizeEnvironment.RUN_TRIGGERING_ACTOR !== "${{ github.triggering_actor }}" ||
+    authorizeEnvironment.REPOSITORY_ID !== "${{ github.repository_id }}" ||
     authorizeEnvironment.WORKFLOW_REF !== "${{ github.ref }}" ||
     authorizeEnvironment.WORKFLOW_REF_NAME !== "${{ github.ref_name }}" ||
     !authorizeRun.includes('gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID"') ||
     !authorizeRun.includes(".github/workflows/desktop-release-coordinator.yml") ||
     authorizeRun.includes(".github/workflows/release.yml") ||
-    !authorizeRun.includes(".run_attempt") ||
+    !authorizeRun.includes(
+      'test "$(printf \'%s\' "$COORDINATOR" | jq -r \'.run_attempt\')" = "$COORDINATOR_RUN_ATTEMPT"',
+    ) ||
     !authorizeRun.includes(".status") ||
     !authorizeRun.includes("in_progress") ||
     !authorizeRun.includes(".head_sha") ||
@@ -663,19 +964,183 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     !authorizeRun.includes('test "$WORKFLOW_REF" = "refs/tags/$RELEASE_TAG"') ||
     !authorizeRun.includes('test "$WORKFLOW_REF_NAME" = "$RELEASE_TAG"') ||
     !authorizeRun.includes("test \"$RELEASE_MODE\" = 'steady'") ||
-    !authorizeRun.includes('RECOVERY_REVISION="${WORKFLOW_REF_NAME#"${RELEASE_TAG}-recovery."}"') ||
+    !authorizeRun.includes(
+      'CURRENT_RECOVERY_REVISION="${WORKFLOW_REF_NAME#"${RELEASE_TAG}-recovery."}"',
+    ) ||
     !authorizeRun.includes("grep -Eq '^[1-9][0-9]*$'") ||
     !authorizeRun.includes(
-      'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${RECOVERY_REVISION}"',
+      'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${CURRENT_RECOVERY_REVISION}"',
     ) ||
     !authorizeRun.includes('test "$WORKFLOW_REF" = "refs/tags/$WORKFLOW_REF_NAME"') ||
     !authorizeRun.includes("workflow_dispatch") ||
-    authorizeRun.includes('.event == "push"')
+    authorizeRun.includes('.event == "push"') ||
+    !exactKeys(authorizeOutputs, Object.keys(expectedAuthorizeOutputs)) ||
+    Object.entries(expectedAuthorizeOutputs).some(([key, value]) => authorizeOutputs[key] !== value)
   ) {
     issues.push("desktop signing must authorize only its active desktop coordinator");
   }
+  const expectedChildBindingObject =
+    "{schemaVersion: 1, repository: $repository, repositoryId: $repositoryId, coordinatorRunId: $coordinatorRunId, coordinatorRunAttempt: $coordinatorRunAttempt, workflowRef: $workflowRef, workflowSha: $workflowSha, childWorkflowRef: $childWorkflowRef, tag: $tag, desktopVersion: $desktopVersion, commit: $commit, toolingCommit: $toolingCommit, draftId: $draftId, mode: $mode, draftBodySha256: $draftBodySha256, baselineTag: $baselineTag, sourceRunId: $sourceRunId, nonce: $nonce}";
+  const sourceValidationStart = authorizeRun.indexOf(
+    'SOURCE=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")',
+  );
+  const bindingValidationRun = authorizeRun.slice(
+    authorizeRun.indexOf("BINDING_ARTIFACT_NAME="),
+    sourceValidationStart,
+  );
+  if (
+    !authorizeRun.includes("test \"$RUN_ACTOR\" = 'github-actions[bot]'") ||
+    !authorizeRun.includes("test \"$RUN_TRIGGERING_ACTOR\" = 'github-actions[bot]'") ||
+    !authorizeRun.includes("printf '%s' \"$DISPATCH_NONCE\" | grep -Eq '^[0-9a-f]{64}$'") ||
+    !authorizeRun.includes(
+      "printf '%s' \"$DISPATCH_BINDING_SHA256\" | grep -Eq '^[0-9a-f]{64}$'",
+    ) ||
+    !authorizeRun.includes(expectedChildBindingObject) ||
+    !authorizeRun.includes(
+      'test "$(printf \'%s\' "$BINDING" | sha256sum | awk \'{print $1}\')" = "$DISPATCH_BINDING_SHA256"',
+    ) ||
+    !authorizeRun.includes(
+      'BINDING_ARTIFACT_NAME="desktop-dispatch-binding-$COORDINATOR_RUN_ID-$COORDINATOR_RUN_ATTEMPT-$DISPATCH_BINDING_SHA256"',
+    ) ||
+    !bindingValidationRun.includes("actions/runs/$COORDINATOR_RUN_ID/artifacts?per_page=100") ||
+    !bindingValidationRun.includes("([.[].artifacts[]] | length) == .[0].total_count") ||
+    !bindingValidationRun.includes(
+      "'[.[].artifacts[] | select(.name == $name)] | select(length == 1) | .[0]'",
+    ) ||
+    !bindingValidationRun.includes(".size_in_bytes") ||
+    !bindingValidationRun.includes(".workflow_run.repository_id") ||
+    !bindingValidationRun.includes(".workflow_run.head_repository_id") ||
+    !bindingValidationRun.includes(".workflow_run.head_branch") ||
+    !bindingValidationRun.includes(".workflow_run.head_sha")
+  ) {
+    issues.push(
+      "desktop child must require bot actors and one coordinator-owned nonce-bound dispatch artifact",
+    );
+  }
+  const sourceValidationRun = authorizeRun.slice(sourceValidationStart);
+  if (
+    !authorizeRun.includes("if [ \"$SOURCE_RUN_ID\" = 'none' ]; then") ||
+    !authorizeRun.includes(
+      "for output in source_run_id source_run_attempt artifact_name artifact_id artifact_digest baseline_artifact_name baseline_artifact_id baseline_artifact_digest; do",
+    ) ||
+    !authorizeRun.includes('test "$SOURCE_RUN_ID" != "$GITHUB_RUN_ID"') ||
+    !authorizeRun.includes('test "$SOURCE_RUN_ID" != "$COORDINATOR_RUN_ID"') ||
+    !authorizeRun.includes("test \"$RELEASE_MODE\" = 'steady'") ||
+    !authorizeRun.includes('test "$RELEASE_TOOLING_COMMIT" != "$RELEASE_COMMIT"') ||
+    !authorizeRun.includes("test \"$CURRENT_RECOVERY_REVISION\" != 'none'") ||
+    !authorizeRun.includes(
+      'SOURCE=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")',
+    ) ||
+    !authorizeRun.includes(".repository.full_name") ||
+    !authorizeRun.includes(".head_repository.full_name") ||
+    !authorizeRun.includes(".github/workflows/desktop-release.yml") ||
+    !authorizeRun.includes(".event')\" = 'workflow_dispatch'") ||
+    !authorizeRun.includes(".actor.login')\" = 'github-actions[bot]'") ||
+    !authorizeRun.includes(".triggering_actor.login')\" = 'github-actions[bot]'") ||
+    !authorizeRun.includes(".status')\" = 'completed'") ||
+    !authorizeRun.includes(".conclusion')\" = 'failure'") ||
+    !authorizeRun.includes("SOURCE_RUN_ATTEMPT=") ||
+    !authorizeRun.includes(
+      'SOURCE_RECOVERY_REVISION="${SOURCE_HEAD_BRANCH#"${RELEASE_TAG}-recovery."}"',
+    ) ||
+    !authorizeRun.includes(
+      'test "$SOURCE_HEAD_BRANCH" = "${RELEASE_TAG}-recovery.${SOURCE_RECOVERY_REVISION}"',
+    ) ||
+    !authorizeRun.includes('test "$SOURCE_RECOVERY_REVISION" != "$CURRENT_RECOVERY_REVISION"') ||
+    !authorizeRun.includes("sort -n | head -1") ||
+    !authorizeRun.includes(
+      'test "$(git rev-parse "refs/tags/$SOURCE_HEAD_BRANCH^{commit}")" = "$SOURCE_HEAD_SHA"',
+    ) ||
+    !authorizeRun.includes('git merge-base --is-ancestor "$RELEASE_COMMIT" "$SOURCE_HEAD_SHA"') ||
+    !authorizeRun.includes(
+      'git merge-base --is-ancestor "$SOURCE_HEAD_SHA" "$RELEASE_TOOLING_COMMIT"',
+    ) ||
+    !authorizeRun.includes(
+      'git merge-base --is-ancestor "$SOURCE_HEAD_SHA" refs/remotes/origin/main',
+    ) ||
+    !authorizeRun.includes("gh api --paginate --slurp") ||
+    !authorizeRun.includes(
+      "actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_RUN_ATTEMPT/jobs?per_page=100",
+    ) ||
+    !authorizeRun.includes("([.[].jobs[]] | length) == .[0].total_count") ||
+    !authorizeRun.includes(
+      "for job_name in sign-macos verify-macos-envelope stage-private-draft publish-assets; do",
+    ) ||
+    !authorizeRun.includes('$matches[0].conclusion == "success"') ||
+    !authorizeRun.includes('$matches[0].conclusion != "success"') ||
+    !authorizeRun.includes("actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100") ||
+    !authorizeRun.includes("([.[].artifacts[]] | length) == .[0].total_count") ||
+    !authorizeRun.includes('ARTIFACT_NAME="desktop-release-$SOURCE_RUN_ID-$SOURCE_RUN_ATTEMPT"') ||
+    !authorizeRun.includes(
+      'BASELINE_ARTIFACT_NAME="desktop-baseline-$SOURCE_RUN_ID-$SOURCE_RUN_ATTEMPT"',
+    ) ||
+    (sourceValidationRun.match(/select\(length == 1\)/gu) ?? []).length !== 2 ||
+    !authorizeRun.includes(".size_in_bytes") ||
+    !authorizeRun.includes(".workflow_run.repository_id") ||
+    !authorizeRun.includes(".workflow_run.head_repository_id") ||
+    !authorizeRun.includes(".workflow_run.head_branch") ||
+    !authorizeRun.includes(".workflow_run.head_sha") ||
+    (authorizeRun.match(/sub\("\^sha256:"; ""\)/gu) ?? []).length !== 2 ||
+    !authorizeRun.includes('echo "artifact_digest=$ARTIFACT_DIGEST" >> "$GITHUB_OUTPUT"') ||
+    !authorizeRun.includes(
+      'echo "baseline_artifact_digest=$BASELINE_ARTIFACT_DIGEST" >> "$GITHUB_OUTPUT"',
+    )
+  ) {
+    issues.push(
+      "desktop child must independently validate source run, job, and artifact provenance",
+    );
+  }
+  const candidateAdmissionStart = authorizeRun.indexOf(
+    'CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")',
+  );
+  const noSourceExitStart = authorizeRun.indexOf("if [ \"$SOURCE_RUN_ID\" = 'none' ]; then");
+  const candidateAdmissionRun =
+    candidateAdmissionStart >= 0 && noSourceExitStart > candidateAdmissionStart
+      ? authorizeRun.slice(candidateAdmissionStart, noSourceExitStart)
+      : "";
+  const childLatestLookup =
+    "LATEST_RELEASE=$(gh api -H 'Cache-Control: no-cache' \"repos/$GITHUB_REPOSITORY/releases/latest\")";
+  if (
+    authorizeEnvironment.GH_TOKEN !== "${{ github.token }}" ||
+    candidateAdmissionRun === "" ||
+    !candidateAdmissionRun.includes(
+      'test "$(printf \'%s\' "$CANDIDATE_RELEASE" | jq -r \'.id | tostring\')" = "$RELEASE_DRAFT_ID"',
+    ) ||
+    !candidateAdmissionRun.includes(
+      'test "$(printf \'%s\' "$CANDIDATE_RELEASE" | jq -r \'.tag_name\')" = "$RELEASE_TAG"',
+    ) ||
+    !candidateAdmissionRun.includes(
+      "test \"$(printf '%s' \"$CANDIDATE_RELEASE\" | jq -r '.prerelease')\" = 'false'",
+    ) ||
+    !candidateAdmissionRun.includes(
+      "if [ \"$(printf '%s' \"$CANDIDATE_RELEASE\" | jq -r '.draft')\" = 'false' ]; then\n  test \"$SOURCE_RUN_ID\" != 'none'",
+    ) ||
+    !candidateAdmissionRun.includes(
+      `if [ "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.body')" != '${PROVISIONAL_RELEASE_BODY}' ]; then`,
+    ) ||
+    !candidateAdmissionRun.includes(
+      "CANDIDATE_BODY_SHA256=$(printf '%s' \"$CANDIDATE_RELEASE\" | jq -j '.body' | shasum -a 256 | awk '{print $1}')",
+    ) ||
+    !candidateAdmissionRun.includes('test "$CANDIDATE_BODY_SHA256" = "$RELEASE_BODY_SHA256"') ||
+    countShellLine(candidateAdmissionRun, childLatestLookup) !== 1 ||
+    !candidateAdmissionRun.includes(
+      'test "$(printf \'%s\' "$LATEST_RELEASE" | jq -r \'.id | tostring\')" = "$RELEASE_DRAFT_ID"',
+    ) ||
+    !candidateAdmissionRun.includes(
+      'test "$(printf \'%s\' "$LATEST_RELEASE" | jq -r \'.tag_name\')" = "$RELEASE_TAG"',
+    )
+  ) {
+    issues.push(
+      "desktop child must independently admit public recovery only as provisional or live-latest exact-final",
+    );
+  }
 
-  exactPermissions(sign.permissions, { contents: "read" }, "macOS signing", issues);
+  exactPermissions(
+    sign.permissions,
+    { actions: "read", contents: "read" },
+    "macOS signing",
+    issues,
+  );
   exactPermissions(
     verify.permissions,
     { actions: "read", contents: "read" },
@@ -695,9 +1160,15 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     issues,
   );
   exactPermissions(
-    promote.permissions,
+    requestLatest.permissions,
     { actions: "read", contents: "write" },
-    "latest promotion",
+    "latest request",
+    issues,
+  );
+  exactPermissions(
+    reconcileLatest.permissions,
+    { actions: "read", contents: "read" },
+    "latest reconciliation",
     issues,
   );
   exactPermissions(
@@ -752,7 +1223,8 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
   if (
     stage.environment !== "desktop-macos-publication" ||
     publish.environment !== "desktop-macos-publication" ||
-    promote.environment !== "desktop-macos-latest" ||
+    requestLatest.environment !== "desktop-macos-latest" ||
+    reconcileLatest.environment !== "desktop-macos-latest" ||
     activate.environment !== "desktop-macos-latest" ||
     compensate.environment !== "desktop-macos-latest"
   ) {
@@ -764,40 +1236,76 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
 
   const stageRun = runs(stage).join("\n");
   const publishRun = runs(publish).join("\n");
-  const promoteRun = runs(promote).join("\n");
+  const requestLatestRun = runs(requestLatest).join("\n");
+  const reconcileLatestRun = runs(reconcileLatest).join("\n");
   const roundTripRun = runs(roundTrip).join("\n");
   const activateRun = runs(activate).join("\n");
   const compensateRun = runs(compensate).join("\n");
+  const publishOutputs = mapping(publish.outputs, "desktop publish outputs", issues);
+  const expectedPublishOutputs: Mapping = {
+    latest_id: "${{ steps.observe.outputs.latest_id }}",
+    latest_tag: "${{ steps.observe.outputs.latest_tag }}",
+    latest_metadata_sha256: "${{ steps.observe.outputs.latest_metadata_sha256 }}",
+    rollback_latest_id: "${{ steps.observe.outputs.rollback_latest_id }}",
+    rollback_latest_tag: "${{ steps.observe.outputs.rollback_latest_tag }}",
+    rollback_latest_metadata_sha256: "${{ steps.observe.outputs.rollback_latest_metadata_sha256 }}",
+  };
+  const observeStep = namedStep(publish, "Bind latest before public mutation");
+  const observeEnvironment = mapping(observeStep?.env, "latest observation environment", issues);
   const observeIndex = publishRun.indexOf("desktop-release:transaction observe");
   const publicationIndex = publishRun.indexOf("desktop-release:transaction publish");
   if (
     !stageRun.includes("desktop-release:transaction stage") ||
-    !scalar(publish.needs).includes("stage-private-draft") ||
+    !exactStringSet(stage.needs, ["sign-macos", "verify-macos-envelope"]) ||
+    !exactStringSet(publish.needs, ["sign-macos", "stage-private-draft"]) ||
     observeIndex === -1 ||
     publicationIndex <= observeIndex ||
     !publishRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"') ||
     !publishRun.includes('--expected-latest-tag "$EXPECTED_LATEST_TAG"') ||
     !publishRun.includes('--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"') ||
-    scalar(mapping(publish.outputs, "desktop publish outputs", issues).latest_id) !==
-      "${{ steps.observe.outputs.latest_id }}"
+    observeEnvironment.BASELINE_METADATA_SHA256 !==
+      "${{ needs.sign-macos.outputs.baseline_metadata_sha256 }}" ||
+    !publishRun.includes('--baseline-metadata-sha256 "$BASELINE_METADATA_SHA256"') ||
+    !exactKeys(publishOutputs, Object.keys(expectedPublishOutputs)) ||
+    Object.entries(expectedPublishOutputs).some(([key, value]) => publishOutputs[key] !== value)
   ) {
     issues.push("desktop publication must stage exact assets and bind latest before metadata-last");
   }
   if (
-    !scalar(promote.needs).includes("publish-assets") ||
-    !promoteRun.includes("desktop-release:transaction promote") ||
-    !promoteRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"') ||
-    !promoteRun.includes('--expected-latest-tag "$EXPECTED_LATEST_TAG"') ||
-    !promoteRun.includes('--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"')
+    observeEnvironment.BASELINE_METADATA_SHA256 !==
+      "${{ needs.sign-macos.outputs.baseline_metadata_sha256 }}" ||
+    !publishRun.includes('--baseline-metadata-sha256 "$BASELINE_METADATA_SHA256"') ||
+    publishOutputs.rollback_latest_id !== "${{ steps.observe.outputs.rollback_latest_id }}" ||
+    publishOutputs.rollback_latest_tag !== "${{ steps.observe.outputs.rollback_latest_tag }}" ||
+    publishOutputs.rollback_latest_metadata_sha256 !==
+      "${{ steps.observe.outputs.rollback_latest_metadata_sha256 }}"
   ) {
-    issues.push("desktop latest promotion must compare-and-swap the observed release");
+    issues.push("desktop rollback must remain bound to normalized manifest baseline evidence");
+  }
+  if (
+    mapping(requestLatest.permissions, "latest request permissions", issues).contents !== "write" ||
+    !exactStringSet(requestLatest.needs, ["sign-macos", "publish-assets"]) ||
+    !requestLatestRun.includes("desktop-release:transaction promote") ||
+    !requestLatestRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"') ||
+    !requestLatestRun.includes('--expected-latest-tag "$EXPECTED_LATEST_TAG"') ||
+    !requestLatestRun.includes(
+      '--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"',
+    ) ||
+    !exactStringSet(reconcileLatest.needs, ["sign-macos", "publish-assets", "request-latest"]) ||
+    mapping(reconcileLatest.permissions, "latest reconciliation permissions", issues).contents !==
+      "read" ||
+    !reconcileLatestRun.includes("desktop-release:transaction reconcile") ||
+    reconcileLatestRun.includes("desktop-release:transaction promote") ||
+    reconcileLatestRun.includes("--expected-latest-")
+  ) {
+    issues.push(
+      "desktop latest request must compare-and-swap before read-only latest reconciliation",
+    );
   }
 
-  const roundTripNeeds = scalar(roundTrip.needs);
   if (
     roundTrip.if !== "${{ inputs.mode == 'steady' }}" ||
-    !roundTripNeeds.includes("sign-macos") ||
-    !roundTripNeeds.includes("promote-latest") ||
+    !exactStringSet(roundTrip.needs, ["sign-macos", "reconcile-latest"]) ||
     !roundTripRun.includes("desktop-release:transaction public-envelope") ||
     countShellLine(
       roundTripRun,
@@ -813,14 +1321,17 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
   }
 
   const activateCondition = scalar(activate.if).replace(/\s+/gu, " ");
-  const activateNeeds = scalar(activate.needs);
   if (
-    !activateNeeds.includes("publish-assets") ||
-    !activateNeeds.includes("promote-latest") ||
-    !activateNeeds.includes("verify-production-update") ||
+    !exactStringSet(activate.needs, [
+      "sign-macos",
+      "publish-assets",
+      "request-latest",
+      "reconcile-latest",
+      "verify-production-update",
+    ]) ||
     !activateCondition.includes("always()") ||
     !activateCondition.includes("needs.publish-assets.result == 'success'") ||
-    !activateCondition.includes("needs.promote-latest.result == 'success'") ||
+    !activateCondition.includes("needs.reconcile-latest.result == 'success'") ||
     !activateCondition.includes("inputs.mode == 'genesis'") ||
     !activateCondition.includes("needs.verify-production-update.result == 'skipped'") ||
     !activateCondition.includes("inputs.mode == 'steady'") ||
@@ -834,11 +1345,24 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     );
   }
   const compensateCondition = scalar(compensate.if).replace(/\s+/gu, " ");
-  const compensateNeeds = scalar(compensate.needs);
+  const compensateStep = namedStep(compensate, "Restore prior latest and withdraw candidate");
+  const compensateEnvironment = mapping(
+    compensateStep?.env,
+    "desktop compensation environment",
+    issues,
+  );
   if (
-    !compensateNeeds.includes("activate-release") ||
+    !exactStringSet(compensate.needs, [
+      "sign-macos",
+      "publish-assets",
+      "request-latest",
+      "reconcile-latest",
+      "verify-production-update",
+      "activate-release",
+    ]) ||
     !compensateCondition.includes("always()") ||
     !compensateCondition.includes("needs.publish-assets.outputs.latest_id != ''") ||
+    !compensateCondition.includes("needs.reconcile-latest.result == 'success'") ||
     !compensateCondition.includes("needs.activate-release.result != 'success'") ||
     !compensateRun.includes("desktop-release:transaction compensate") ||
     !compensateRun.includes("apps/desktop/CHANGELOG.md") ||
@@ -846,17 +1370,26 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     !compensateRun.includes('--expected-latest-tag "$EXPECTED_LATEST_TAG"') ||
     !compensateRun.includes('--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"')
   ) {
-    issues.push("failed desktop activation must restore prior latest and withdraw the candidate");
+    issues.push(
+      "desktop compensation must require successful reconciliation and later acceptance or activation failure",
+    );
+  }
+  if (
+    compensateEnvironment.EXPECTED_LATEST_ID !==
+      "${{ needs.publish-assets.outputs.rollback_latest_id }}" ||
+    compensateEnvironment.EXPECTED_LATEST_TAG !==
+      "${{ needs.publish-assets.outputs.rollback_latest_tag }}" ||
+    compensateEnvironment.EXPECTED_LATEST_METADATA_SHA256 !==
+      "${{ needs.publish-assets.outputs.rollback_latest_metadata_sha256 }}" ||
+    !compensateRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"') ||
+    !compensateRun.includes('--expected-latest-tag "$EXPECTED_LATEST_TAG"') ||
+    !compensateRun.includes('--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"')
+  ) {
+    issues.push("desktop rollback must remain bound to normalized manifest baseline evidence");
   }
 
   const signingSteps = steps(sign);
-  const recoveryStep = namedStep(sign, "Bind recovery release tooling");
-  const recoveryRun = typeof recoveryStep?.run === "string" ? recoveryStep.run : "";
   const signingStep = namedStep(sign, "Build signed and notarized macOS envelope");
-  const signingCheckoutIndex = signingSteps.findIndex(
-    (step) => typeof step.uses === "string" && step.uses.startsWith("actions/checkout@"),
-  );
-  const recoveryIndex = signingSteps.indexOf(recoveryStep ?? {});
   const installIndex = signingSteps.findIndex(
     (step) => step.run === "pnpm install --frozen-lockfile",
   );
@@ -870,37 +1403,169 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     'printf \'%s\' "$APPLE_API_KEY_P8_BASE64" | base64 -D > "$APPLE_API_KEY"',
   );
   const privateUmask = signingRun.indexOf("umask 077");
-  const recoveryFiles = [
-    "apps/desktop/scripts/macos-release-cli.mjs",
-    "apps/desktop/scripts/macos-release-plan.mjs",
-  ];
-  const expectedRecoveryDiff = recoveryFiles.join("\\n");
-  const observedRecoveryPaths =
-    recoveryRun.match(/apps\/desktop\/scripts\/[A-Za-z0-9_.-]+/gu) ?? [];
+  checkRecoveryOverlay(
+    sign,
+    "manual signing recovery",
+    [
+      "apps/desktop/scripts/macos-release-cli.mjs",
+      "apps/desktop/scripts/macos-release-plan.mjs",
+      "tools/desktop-release-transaction.ts",
+    ],
+    true,
+    issues,
+  );
+  for (const [jobName, job] of [
+    ["verify-macos-envelope", verify],
+    ["stage-private-draft", stage],
+    ["publish-assets", publish],
+    ["request-latest", requestLatest],
+    ["reconcile-latest", reconcileLatest],
+    ["verify-production-update", roundTrip],
+    ["activate-release", activate],
+    ["compensate-publication", compensate],
+  ] as const) {
+    checkRecoveryOverlay(
+      job,
+      `${jobName} recovery`,
+      ["tools/desktop-release-transaction.ts"],
+      false,
+      issues,
+    );
+  }
+  const workspaceBuildStep = signingSteps.find((step) => step.run === "pnpm -r build");
+  const baselineStep = namedStep(sign, "Resolve signed baseline");
+  const signingEvidenceStep = namedStep(sign, "Bind candidate signing evidence");
+  const sealStep = namedStep(sign, "Seal digest-bound release manifest");
+  const sealedUploadStep = namedStep(sign, "Upload sealed macOS transaction artifact");
+  const baselineUploadStep = namedStep(sign, "Upload sealed baseline updater envelope");
+  const resumedArtifactStep = namedStep(sign, "Download resumed sealed macOS transaction artifact");
+  const resumedBaselineStep = namedStep(sign, "Download resumed sealed baseline updater envelope");
+  const resumedEvidenceStep = namedStep(sign, "Verify resumed artifact and manifest bindings");
+  const resumedEvidenceRun =
+    typeof resumedEvidenceStep?.run === "string" ? resumedEvidenceStep.run : "";
+  const freshOnly = "${{ inputs.source_run_id == 'none' }}";
+  const resumedOnly = "${{ inputs.source_run_id != 'none' }}";
   if (
-    recoveryIndex <= signingCheckoutIndex ||
-    recoveryIndex >= installIndex ||
-    countShellLine(recoveryRun, 'test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"') !== 2 ||
-    !recoveryRun.includes(
-      'git merge-base --is-ancestor "$RELEASE_COMMIT" "$RELEASE_TOOLING_COMMIT"',
-    ) ||
-    !recoveryRun.includes(
-      'git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree --',
-    ) ||
-    !recoveryRun.includes(`EXPECTED_RECOVERY_DIFF=$'${expectedRecoveryDiff}'`) ||
-    !recoveryRun.includes('test "$(git diff --cached --name-only)" = "$EXPECTED_RECOVERY_DIFF"') ||
-    !recoveryRun.includes('test -z "$(git diff --name-only)"') ||
-    !recoveryRun.includes('test -z "$(git ls-files --others --exclude-standard)"') ||
-    observedRecoveryPaths.length !== recoveryFiles.length * 2 ||
-    observedRecoveryPaths.some((path) => !recoveryFiles.includes(path)) ||
-    recoveryFiles.some(
-      (path) =>
-        (recoveryRun.match(new RegExp(path.replaceAll(".", "\\."), "gu")) ?? []).length !== 2,
-    )
+    workspaceBuildStep?.if !== freshOnly ||
+    baselineStep?.if !== freshOnly ||
+    signingStep?.if !== freshOnly ||
+    signingEvidenceStep?.if !== freshOnly ||
+    cleanupStep?.if !== "${{ always() && inputs.source_run_id == 'none' }}" ||
+    sealStep?.if !== freshOnly ||
+    sealedUploadStep?.if !== freshOnly ||
+    baselineUploadStep?.if !== "${{ inputs.source_run_id == 'none' && inputs.mode == 'steady' }}" ||
+    resumedArtifactStep?.if !== resumedOnly ||
+    resumedBaselineStep?.if !== resumedOnly ||
+    resumedEvidenceStep?.if !== resumedOnly
   ) {
     issues.push(
-      "manual recovery must bind the coordinator and overlay only audited release tooling",
+      "desktop resume must skip build, signing, notarization, sealing, and signing-artifact upload",
     );
+  }
+  const resumedDownloadSpecifications = [
+    {
+      step: resumedArtifactStep,
+      artifactId: "${{ needs.authorize-coordinator.outputs.artifact_id }}",
+      path: "${{ runner.temp }}/desktop-release",
+    },
+    {
+      step: resumedBaselineStep,
+      artifactId: "${{ needs.authorize-coordinator.outputs.baseline_artifact_id }}",
+      path: "${{ runner.temp }}/desktop-baseline",
+    },
+  ];
+  if (
+    resumedDownloadSpecifications.some(({ step, artifactId, path }) => {
+      const withInputs = mapping(step?.with, "resumed artifact download inputs", issues);
+      return (
+        typeof step?.uses !== "string" ||
+        !step.uses.startsWith("actions/download-artifact@") ||
+        !exactKeys(withInputs, [
+          "artifact-ids",
+          "path",
+          "github-token",
+          "repository",
+          "run-id",
+          "digest-mismatch",
+        ]) ||
+        withInputs["artifact-ids"] !== artifactId ||
+        withInputs.path !== path ||
+        withInputs["github-token"] !== "${{ github.token }}" ||
+        withInputs.repository !== "${{ github.repository }}" ||
+        withInputs["run-id"] !== "${{ needs.authorize-coordinator.outputs.source_run_id }}" ||
+        withInputs["digest-mismatch"] !== "error"
+      );
+    }) ||
+    !resumedEvidenceRun.includes(
+      'test "$ARTIFACT_NAME" = "desktop-release-$SOURCE_RUN_ID-$SOURCE_RUN_ATTEMPT"',
+    ) ||
+    !resumedEvidenceRun.includes(
+      'test "$BASELINE_ARTIFACT_NAME" = "desktop-baseline-$SOURCE_RUN_ID-$SOURCE_RUN_ATTEMPT"',
+    ) ||
+    !resumedEvidenceRun.includes(
+      'test "$(jq -er \'.workflowRunId\' "$MANIFEST")" = "$SOURCE_RUN_ID"',
+    ) ||
+    !resumedEvidenceRun.includes(
+      'test "$(jq -er \'.workflowRunAttempt\' "$MANIFEST")" = "$SOURCE_RUN_ATTEMPT"',
+    ) ||
+    !resumedEvidenceRun.includes('--workflow-run-id "$SOURCE_RUN_ID"') ||
+    !resumedEvidenceRun.includes('--workflow-run-attempt "$SOURCE_RUN_ATTEMPT"')
+  ) {
+    issues.push("desktop resume must reuse exact digest-bound artifacts from the authorized run");
+  }
+
+  const normalizedStep = namedStep(sign, "Normalize immutable signing and artifact evidence");
+  const normalizedRun = typeof normalizedStep?.run === "string" ? normalizedStep.run : "";
+  const signOutputs = mapping(sign.outputs, "macOS signing outputs", issues);
+  const expectedSignOutputs: Mapping = {
+    baseline_tag: "${{ steps.normalized-evidence.outputs.baseline_tag }}",
+    baseline_version: "${{ steps.normalized-evidence.outputs.baseline_version }}",
+    baseline_release_id: "${{ steps.normalized-evidence.outputs.baseline_release_id }}",
+    baseline_commit: "${{ steps.normalized-evidence.outputs.baseline_commit }}",
+    baseline_zip_sha256: "${{ steps.normalized-evidence.outputs.baseline_zip_sha256 }}",
+    baseline_metadata_sha256: "${{ steps.normalized-evidence.outputs.baseline_metadata_sha256 }}",
+    baseline_signing_identity: "${{ steps.normalized-evidence.outputs.baseline_signing_identity }}",
+    baseline_cdhash: "${{ steps.normalized-evidence.outputs.baseline_cdhash }}",
+    baseline_artifact_name: "${{ steps.normalized-evidence.outputs.baseline_artifact_name }}",
+    baseline_artifact_id: "${{ steps.normalized-evidence.outputs.baseline_artifact_id }}",
+    baseline_artifact_digest: "${{ steps.normalized-evidence.outputs.baseline_artifact_digest }}",
+    cdhash: "${{ steps.normalized-evidence.outputs.cdhash }}",
+    code_directory_sha256: "${{ steps.normalized-evidence.outputs.code_directory_sha256 }}",
+    signing_identity: "${{ steps.normalized-evidence.outputs.signing_identity }}",
+    evidence_run_id: "${{ steps.normalized-evidence.outputs.evidence_run_id }}",
+    evidence_run_attempt: "${{ steps.normalized-evidence.outputs.evidence_run_attempt }}",
+    artifact_name: "${{ steps.normalized-evidence.outputs.artifact_name }}",
+    artifact_id: "${{ steps.normalized-evidence.outputs.artifact_id }}",
+    artifact_digest: "${{ steps.normalized-evidence.outputs.artifact_digest }}",
+  };
+  if (
+    normalizedStep?.id !== "normalized-evidence" ||
+    !exactKeys(signOutputs, Object.keys(expectedSignOutputs)) ||
+    Object.entries(expectedSignOutputs).some(([key, value]) => signOutputs[key] !== value) ||
+    !normalizedRun.includes("if [ \"$SOURCE_RUN_ID\" = 'none' ]; then") ||
+    !normalizedRun.includes('EVIDENCE_RUN_ID="$GITHUB_RUN_ID"') ||
+    !normalizedRun.includes('EVIDENCE_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT"') ||
+    !normalizedRun.includes('EVIDENCE_RUN_ID="$SOURCE_RUN_ID"') ||
+    !normalizedRun.includes('EVIDENCE_RUN_ATTEMPT="$SOURCE_RUN_ATTEMPT"') ||
+    !normalizedRun.includes('ARTIFACT_ID="$FRESH_ARTIFACT_ID"') ||
+    !normalizedRun.includes('ARTIFACT_ID="$SOURCE_ARTIFACT_ID"') ||
+    !normalizedRun.includes('ARTIFACT_DIGEST="${FRESH_ARTIFACT_DIGEST#sha256:}"') ||
+    !normalizedRun.includes('ARTIFACT_DIGEST="$SOURCE_ARTIFACT_DIGEST"') ||
+    !normalizedRun.includes('BASELINE_METADATA_SHA256="$FRESH_BASELINE_METADATA_SHA256"') ||
+    !normalizedRun.includes('BASELINE_METADATA_SHA256="$RESUMED_BASELINE_METADATA_SHA256"') ||
+    !normalizedRun.includes(
+      'test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"',
+    ) ||
+    !normalizedRun.includes(
+      'test "$BASELINE_ARTIFACT_NAME" = "desktop-baseline-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"',
+    ) ||
+    !normalizedRun.includes('echo "evidence_run_id=$EVIDENCE_RUN_ID" >> "$GITHUB_OUTPUT"') ||
+    !normalizedRun.includes(
+      'echo "baseline_metadata_sha256=$BASELINE_METADATA_SHA256" >> "$GITHUB_OUTPUT"',
+    ) ||
+    !normalizedRun.includes('echo "evidence_run_attempt=$EVIDENCE_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"')
+  ) {
+    issues.push("desktop signing must normalize fresh and resumed immutable evidence");
   }
   if (
     installIndex === -1 ||
@@ -937,13 +1602,27 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     privateUmask === -1 ||
     privateUmask > keyCreation ||
     signingEnvironment.APPLE_API_KEY !== "${{ runner.temp }}/AuthKey.p8" ||
-    cleanupStep?.if !== "${{ always() }}" ||
+    cleanupStep?.if !== "${{ always() && inputs.source_run_id == 'none' }}" ||
     signingSteps.indexOf(cleanupStep ?? {}) <= signingSteps.indexOf(signingStep ?? {}) ||
     countShellLine(cleanupRun, 'rm -f "$RUNNER_TEMP/AuthKey.p8"') !== 1
   ) {
     issues.push("temporary notarization key must be created privately and always removed");
   }
 
+  const independentBaselineStep = namedStep(verify, "Resolve independent baseline");
+  const independentBaselineEnvironment = mapping(
+    independentBaselineStep?.env,
+    "independent baseline environment",
+    issues,
+  );
+  const confirmBaselineStep = namedStep(verify, "Confirm independently resolved baseline evidence");
+  const confirmBaselineEnvironment = mapping(
+    confirmBaselineStep?.env,
+    "independent baseline confirmation environment",
+    issues,
+  );
+  const confirmBaselineRun =
+    typeof confirmBaselineStep?.run === "string" ? confirmBaselineStep.run : "";
   const independentStep = namedStep(verify, "Independently verify signed updater envelope");
   const independentEnvironment = mapping(
     independentStep?.env,
@@ -967,6 +1646,17 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     independentRun.indexOf(";;", independentRun.indexOf("steady)", publicEnvelope)),
   );
   if (
+    independentBaselineEnvironment.RELEASE_BASELINE_TAG !==
+      "${{ needs.sign-macos.outputs.baseline_tag }}" ||
+    confirmBaselineEnvironment.INDEPENDENT_METADATA_SHA256 !==
+      "${{ steps.independent-baseline.outputs.baseline_metadata_sha256 }}" ||
+    confirmBaselineEnvironment.SIGNED_METADATA_SHA256 !==
+      "${{ needs.sign-macos.outputs.baseline_metadata_sha256 }}" ||
+    !confirmBaselineRun.includes('test "$INDEPENDENT_METADATA_SHA256" = "$SIGNED_METADATA_SHA256"')
+  ) {
+    issues.push("desktop baseline consumers must use normalized manifest evidence");
+  }
+  if (
     transactionVerification === -1 ||
     publicEnvelope <= transactionVerification ||
     genesisVerification <= publicEnvelope ||
@@ -986,7 +1676,7 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     !steadyCase.includes('"$PUBLIC_ENVELOPE"') ||
     !steadyCase.includes('"$INDEPENDENT_BASELINE_APP"') ||
     !steadyCase.includes('"$CANDIDATE_APP"') ||
-    source.split("\\(FA494ACVTF\\)$").length - 1 !== 3 ||
+    source.split("\\(FA494ACVTF\\)$").length - 1 !== 6 ||
     countShellLine(independentRun, 'test "$INDEPENDENT_CDHASH" = "$CANDIDATE_CDHASH"') !== 1 ||
     countShellLine(
       independentRun,
@@ -998,27 +1688,99 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     issues.push("native verification must consume the signed exact-four public envelope");
   }
   if (
-    (
-      source.match(
-        /SIGNING_RUN_ATTEMPT: \$\{\{ needs\.sign-macos\.outputs\.workflow_run_attempt \}\}/gu,
-      ) ?? []
-    ).length !== 8 ||
-    source.includes("SIGNING_RUN_ATTEMPT: ${{ github.run_attempt }}") ||
-    !independentRun.includes('--workflow-run-attempt "$SIGNING_RUN_ATTEMPT"')
+    independentEnvironment.WORKFLOW_RUN_ID !== "${{ needs.sign-macos.outputs.evidence_run_id }}" ||
+    independentEnvironment.SIGNING_RUN_ATTEMPT !==
+      "${{ needs.sign-macos.outputs.evidence_run_attempt }}" ||
+    !independentRun.includes('--workflow-run-id "$WORKFLOW_RUN_ID"') ||
+    !independentRun.includes('--workflow-run-attempt "$SIGNING_RUN_ATTEMPT"') ||
+    source.includes("SIGNING_RUN_ATTEMPT: ${{ github.run_attempt }}")
   ) {
-    issues.push("desktop verification must bind the successful signing attempt on reruns");
+    issues.push("desktop verification must bind normalized immutable signing evidence");
+  }
+
+  const candidateConsumers = [
+    ["verify-macos-envelope", verify],
+    ["stage-private-draft", stage],
+    ["publish-assets", publish],
+    ["request-latest", requestLatest],
+    ["reconcile-latest", reconcileLatest],
+    ["verify-production-update", roundTrip],
+    ["activate-release", activate],
+    ["compensate-publication", compensate],
+  ] as const;
+  let invalidNormalizedDownload = false;
+  for (const [jobName, job] of candidateConsumers) {
+    const downloads = actionSteps(job, "actions/download-artifact");
+    const candidateDownloads = downloads.filter(
+      (step) =>
+        mapping(step.with, `${jobName} download inputs`, issues).path ===
+        "${{ runner.temp }}/desktop-release",
+    );
+    if (candidateDownloads.length !== 1) {
+      invalidNormalizedDownload = true;
+      continue;
+    }
+    const withInputs = mapping(
+      candidateDownloads[0].with,
+      `${jobName} candidate download inputs`,
+      issues,
+    );
+    if (
+      !exactKeys(withInputs, [
+        "artifact-ids",
+        "path",
+        "github-token",
+        "repository",
+        "run-id",
+        "digest-mismatch",
+      ]) ||
+      withInputs["artifact-ids"] !== "${{ needs.sign-macos.outputs.artifact_id }}" ||
+      withInputs["github-token"] !== "${{ github.token }}" ||
+      withInputs.repository !== "${{ github.repository }}" ||
+      withInputs["run-id"] !== "${{ needs.sign-macos.outputs.evidence_run_id }}" ||
+      withInputs["digest-mismatch"] !== "error"
+    ) {
+      invalidNormalizedDownload = true;
+    }
+  }
+  const baselineDownloads = actionSteps(roundTrip, "actions/download-artifact").filter(
+    (step) =>
+      mapping(step.with, "production baseline download inputs", issues).path ===
+      "${{ runner.temp }}/desktop-baseline",
+  );
+  if (baselineDownloads.length !== 1) {
+    invalidNormalizedDownload = true;
+  } else {
+    const withInputs = mapping(
+      baselineDownloads[0].with,
+      "production baseline download inputs",
+      issues,
+    );
+    if (
+      !exactKeys(withInputs, [
+        "artifact-ids",
+        "path",
+        "github-token",
+        "repository",
+        "run-id",
+        "digest-mismatch",
+      ]) ||
+      withInputs["artifact-ids"] !== "${{ needs.sign-macos.outputs.baseline_artifact_id }}" ||
+      withInputs["github-token"] !== "${{ github.token }}" ||
+      withInputs.repository !== "${{ github.repository }}" ||
+      withInputs["run-id"] !== "${{ needs.sign-macos.outputs.evidence_run_id }}" ||
+      withInputs["digest-mismatch"] !== "error"
+    ) {
+      invalidNormalizedDownload = true;
+    }
   }
   if (
-    (source.match(/actions\/download-artifact@[^\n]+# v8/gu) ?? []).length !== 8 ||
-    (source.match(/digest-mismatch: error/gu) ?? []).length !== 8 ||
-    !source.includes("artifact_id: ${{ steps.sealed-artifact.outputs.artifact-id }}") ||
-    !source.includes("artifact_digest: ${{ steps.sealed-artifact.outputs.artifact-digest }}") ||
-    !source.includes("baseline_artifact_id: ${{ steps.baseline-artifact.outputs.artifact-id }}") ||
-    !source.includes(
-      "baseline_artifact_digest: ${{ steps.baseline-artifact.outputs.artifact-digest }}",
-    )
+    invalidNormalizedDownload ||
+    actionSteps(sign, "actions/download-artifact").length !== 2 ||
+    (source.match(/actions\/download-artifact@[^\n]+# v8/gu) ?? []).length !== 11 ||
+    (source.match(/digest-mismatch: error/gu) ?? []).length !== 11
   ) {
-    issues.push("desktop consumers must bind the exact digest-checked signing artifact");
+    issues.push("desktop artifact downloads must use normalized digest-bound cross-run evidence");
   }
 }
 

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -15,7 +15,9 @@ import {
   prepareDesktopBaseline,
   promoteDesktopLatest,
   publishDesktopRelease,
+  reconcileDesktopLatest,
   releaseFileNames,
+  resolveDesktopRollbackLatest,
   sealDesktopRelease,
   stageDesktopRelease,
   type DesktopReleaseManifest,
@@ -27,10 +29,37 @@ const candidateTag = `enduragent-desktop@${candidateVersion}`;
 const candidateCommit = "a".repeat(40);
 const realSetImmediate = setImmediate;
 
+async function waitForPendingFakeTimer(): Promise<void> {
+  for (let turn = 0; turn < 10_000; turn += 1) {
+    if (vi.getTimerCount() > 0) return;
+    await new Promise<void>((resolveTurn) => realSetImmediate(resolveTurn));
+  }
+  throw new TypeError("release operation did not schedule its reconciliation timer");
+}
+
+async function settleFakeTimerOperation<T>(operation: Promise<T>): Promise<T> {
+  let settled = false;
+  void operation.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  for (let turn = 0; turn < 20_000 && !settled; turn += 1) {
+    await new Promise<void>((resolveTurn) => realSetImmediate(resolveTurn));
+    if (vi.getTimerCount() > 0) await vi.runOnlyPendingTimersAsync();
+  }
+  if (!settled) throw new TypeError("release operation exceeded the fake-timer settlement bound");
+  return operation;
+}
+
 interface FakeAsset {
   id: number;
   name: string;
   size: number;
+  digest: string;
   state: "starter" | "uploaded";
   url: string;
   browser_download_url: string;
@@ -111,7 +140,12 @@ afterEach(() => {
 });
 
 class FakeGithub {
-  readonly calls: Array<{ method: string; url: string; authorization: string | null }> = [];
+  readonly calls: Array<{
+    method: string;
+    url: string;
+    authorization: string | null;
+    cacheControl: string | null;
+  }> = [];
   readonly bytes = new Map<string, Buffer>();
   readonly commits = new Map<string, string>();
   pages: FakeRelease[][] = [[]];
@@ -120,9 +154,24 @@ class FakeGithub {
   nextAssetId = 1000;
   failNextUploadWithStarter = false;
   anonymousDownloadFailures = 0;
+  nextLatestApiLagReads = 0;
+  nextLatestFeedLagReads = 0;
+  latestApiLaggedReads = 0;
+  latestFeedLaggedReads = 0;
+  private latestBeforeTransition: FakeRelease | null = null;
+  private latestApiLagReads = 0;
+  private latestFeedLagReads = 0;
   private resolveAnonymousDownloadFailure!: () => void;
+  private resolveLatestApiLagObserved!: () => void;
+  private resolveLatestFeedLagObserved!: () => void;
   readonly anonymousDownloadFailureObserved = new Promise<void>((resolveFailure) => {
     this.resolveAnonymousDownloadFailure = resolveFailure;
+  });
+  readonly latestApiLagObserved = new Promise<void>((resolveLag) => {
+    this.resolveLatestApiLagObserved = resolveLag;
+  });
+  readonly latestFeedLagObserved = new Promise<void>((resolveLag) => {
+    this.resolveLatestFeedLagObserved = resolveLag;
   });
 
   constructor(tag = candidateTag, commit = candidateCommit) {
@@ -158,6 +207,7 @@ class FakeGithub {
       id: this.nextAssetId++,
       name,
       size: bytes.length,
+      digest: `sha256:${digest(bytes, "sha256", "hex")}`,
       state,
       url: `https://api.github.com/repos/yerzhansa/enduragent/releases/assets/${this.nextAssetId - 1}`,
       browser_download_url: `https://github.com/yerzhansa/enduragent/releases/download/${release.tag_name}/${name}`,
@@ -172,6 +222,31 @@ class FakeGithub {
     return [this.candidate, ...this.pages.flat()].find((release) => release.id === id);
   }
 
+  transitionLatest(release: FakeRelease): void {
+    this.latestBeforeTransition = this.latest;
+    this.latest = release;
+    this.latestApiLagReads = this.nextLatestApiLagReads;
+    this.latestFeedLagReads = this.nextLatestFeedLagReads;
+    this.nextLatestApiLagReads = 0;
+    this.nextLatestFeedLagReads = 0;
+  }
+
+  apiLatest(): FakeRelease | null {
+    if (this.latestApiLagReads === 0) return this.latest;
+    this.latestApiLagReads -= 1;
+    this.latestApiLaggedReads += 1;
+    this.resolveLatestApiLagObserved();
+    return this.latestBeforeTransition;
+  }
+
+  feedLatest(): FakeRelease | null {
+    if (this.latestFeedLagReads === 0) return this.latest;
+    this.latestFeedLagReads -= 1;
+    this.latestFeedLaggedReads += 1;
+    this.resolveLatestFeedLagObserved();
+    return this.latestBeforeTransition;
+  }
+
   client(): GithubClient {
     return new GithubClient("yerzhansa/enduragent", "token", this.fetch);
   }
@@ -180,7 +255,12 @@ class FakeGithub {
     const url = String(input);
     const method = init.method ?? "GET";
     const headers = new Headers(init.headers);
-    this.calls.push({ method, url, authorization: headers.get("Authorization") });
+    this.calls.push({
+      method,
+      url,
+      authorization: headers.get("Authorization"),
+      cacheControl: headers.get("Cache-Control"),
+    });
     const json = (value: unknown, status = 200) => Response.json(value, { status });
     const binary = (bytes: Buffer | undefined, status = 200) =>
       new Response(
@@ -206,7 +286,10 @@ class FakeGithub {
       const page = Number(new URL(url).searchParams.get("page"));
       return json(this.pages[page - 1] ?? []);
     }
-    if (url.endsWith("/releases/latest")) return this.latest ? json(this.latest) : json({}, 404);
+    if (url.endsWith("/releases/latest")) {
+      const latest = this.apiLatest();
+      return latest ? json(latest) : json({}, 404);
+    }
     if (url.startsWith("https://uploads.github.com/") && method === "POST") {
       const name = new URL(url).searchParams.get("name")!;
       const bytes = Buffer.from((init.body as ArrayBuffer) ?? new ArrayBuffer(0));
@@ -236,12 +319,14 @@ class FakeGithub {
       };
       if (update.body !== undefined) release.body = update.body;
       if (update.draft !== undefined) release.draft = update.draft;
-      if (update.make_latest === "true") this.latest = release;
+      if (update.make_latest === "true") this.transitionLatest(release);
       if (release.draft && this.latest?.id === release.id) this.latest = null;
       return json(release);
     }
     if (url === `${DESKTOP_FEED_URL}latest-mac.yml`) {
-      const asset = this.latest?.assets.find((candidate) => candidate.name === "latest-mac.yml");
+      const asset = this.feedLatest()?.assets.find(
+        (candidate) => candidate.name === "latest-mac.yml",
+      );
       return asset ? binary(this.bytes.get(asset.url)) : binary(undefined, 404);
     }
     if (url.includes("/releases/download/") && this.anonymousDownloadFailures > 0) {
@@ -328,7 +413,9 @@ describe("GitHub desktop release transaction", () => {
     const fake = new FakeGithub();
     const { directory } = await genesisCandidate(fake);
     fake.candidate.prerelease = true;
-    await expect(stageDesktopRelease(directory, fake.client())).rejects.toThrow("draft binding");
+    await expect(stageDesktopRelease(directory, fake.client())).rejects.toThrow(
+      "candidate binding",
+    );
     expect(fake.calls.some((call) => call.method === "POST" || call.method === "PATCH")).toBe(
       false,
     );
@@ -454,6 +541,159 @@ describe("GitHub desktop release transaction", () => {
     }
   });
 
+  it("allows latest API pointer convergence beyond the tag-download retry window", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+
+    vi.useFakeTimers();
+    try {
+      fake.nextLatestApiLagReads = 35;
+      await promoteDesktopLatest(directory, fake.client(), observed);
+      expect(fake.latestApiLaggedReads).toBe(0);
+      expect(vi.getTimerCount()).toBe(0);
+      const authenticatedAssetReadsBefore = fake.calls.filter(
+        (call) =>
+          call.method === "GET" &&
+          call.authorization !== null &&
+          call.url.includes("/releases/assets/"),
+      ).length;
+      const reconciliation = reconcileDesktopLatest(directory, fake.client());
+      await fake.latestApiLagObserved;
+      await new Promise<void>((resolveTurn) => realSetImmediate(resolveTurn));
+      expect(vi.getTimerCount()).toBe(1);
+      let reconciled = false;
+      void reconciliation.then(() => {
+        reconciled = true;
+      });
+      await vi.advanceTimersByTimeAsync(175_000);
+      expect(reconciled).toBe(false);
+      await vi.advanceTimersByTimeAsync(15_000);
+      await reconciliation;
+
+      expect(fake.latestApiLaggedReads).toBe(35);
+      expect(fake.latestFeedLaggedReads).toBe(0);
+      expect(fake.latest?.id).toBe(fake.candidate.id);
+      expect(
+        fake.calls.filter(
+          (call) =>
+            call.method === "GET" &&
+            call.authorization !== null &&
+            call.url.includes("/releases/assets/"),
+        ),
+      ).toHaveLength(authenticatedAssetReadsBefore);
+      const latestApiCalls = fake.calls.filter((call) => call.url.endsWith("/releases/latest"));
+      expect(latestApiCalls.length).toBeGreaterThan(35);
+      expect(latestApiCalls.every((call) => call.cacheControl === "no-cache")).toBe(true);
+      expect(
+        fake.calls
+          .filter((call) => call.cacheControl !== null)
+          .every((call) => call.url.endsWith("/releases/latest")),
+      ).toBe(true);
+      expect(
+        fake.calls
+          .filter((call) => call.url === `${DESKTOP_FEED_URL}latest-mac.yml`)
+          .every((call) => call.cacheControl === null),
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reuses an exact public provisional release without replacing its assets", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    const uploadCount = fake.calls.filter(
+      (call) => call.method === "POST" && call.url.startsWith("https://uploads.github.com/"),
+    ).length;
+    const publicationPatchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+
+    const resumedObserved = await observeDesktopLatest(directory, fake.client());
+    await stageDesktopRelease(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), resumedObserved);
+    expect(
+      fake.calls.filter(
+        (call) => call.method === "POST" && call.url.startsWith("https://uploads.github.com/"),
+      ),
+    ).toHaveLength(uploadCount);
+    expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(
+      publicationPatchCount,
+    );
+
+    await promoteDesktopLatest(directory, fake.client(), resumedObserved);
+    const promotionPatchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+    const promotedObservation = await observeDesktopLatest(directory, fake.client());
+    await stageDesktopRelease(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), promotedObservation);
+    expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(promotionPatchCount);
+    expect(fake.candidate.body).toBe(DESKTOP_PROVISIONAL_RELEASE_BODY);
+  });
+
+  it("rejects a public recovery candidate with an unexpected body", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    fake.candidate.body = "unexpected public body";
+    const patchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+
+    await expect(stageDesktopRelease(directory, fake.client())).rejects.toThrow(
+      "public body binding mismatch",
+    );
+    expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(patchCount);
+  });
+
+  it("refuses promotion when the public candidate gained an extra asset", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    fake.addAsset(fake.candidate, "unexpected.txt", Buffer.from("unexpected"));
+    const patchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+
+    await expect(promoteDesktopLatest(directory, fake.client(), observed)).rejects.toThrow(
+      "stale release asset",
+    );
+    expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(patchCount);
+    expect(fake.latest?.id).not.toBe(fake.candidate.id);
+  });
+
+  it("allows anonymous latest-feed convergence beyond 30 polls during compensation", async () => {
+    const fake = new FakeGithub();
+    const { directory, baseline } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    await promoteDesktopLatest(directory, fake.client(), observed);
+    const bodyDirectory = mkdtempSync(join(tmpdir(), "desktop-release-body-"));
+    directories.push(bodyDirectory);
+    const bodyPath = join(bodyDirectory, "body.md");
+    writeFileSync(bodyPath, "release body");
+
+    vi.useFakeTimers();
+    try {
+      await settleFakeTimerOperation(reconcileDesktopLatest(directory, fake.client()));
+      fake.nextLatestFeedLagReads = 35;
+      const compensation = compensateDesktopRelease(directory, bodyPath, fake.client(), observed);
+      await settleFakeTimerOperation(compensation);
+
+      expect(fake.latestApiLaggedReads).toBe(0);
+      expect(fake.latestFeedLaggedReads).toBe(35);
+      expect(fake.latest?.id).toBe(baseline.id);
+      expect(fake.candidate.draft).toBe(true);
+      expect(fake.candidate.body).toBe("release body");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("activates only after promotion and restores the observed latest on compensation", async () => {
     const successful = new FakeGithub();
     const accepted = await steadyCandidate(successful);
@@ -467,22 +707,264 @@ describe("GitHub desktop release transaction", () => {
     directories.push(bodyDirectory);
     const bodyPath = join(bodyDirectory, "body.md");
     writeFileSync(bodyPath, "release body");
-    await activateDesktopRelease(accepted.directory, bodyPath, successful.client());
-    expect(successful.latest?.id).toBe(successful.candidate.id);
-    expect(successful.candidate.body).toBe("release body");
+    vi.useFakeTimers();
+    try {
+      await settleFakeTimerOperation(
+        reconcileDesktopLatest(accepted.directory, successful.client()),
+      );
+      const activation = activateDesktopRelease(accepted.directory, bodyPath, successful.client());
+      await settleFakeTimerOperation(activation);
+      expect(successful.latest?.id).toBe(successful.candidate.id);
+      expect(successful.candidate.body).toBe("release body");
 
-    const failed = new FakeGithub();
-    const compensating = await steadyCandidate(failed);
-    compensating.baseline.draft = false;
-    failed.latest = compensating.baseline;
-    await stageDesktopRelease(compensating.directory, failed.client());
-    const prior = await observeDesktopLatest(compensating.directory, failed.client());
-    await publishDesktopRelease(compensating.directory, failed.client(), prior);
-    await promoteDesktopLatest(compensating.directory, failed.client(), prior);
-    await compensateDesktopRelease(compensating.directory, bodyPath, failed.client(), prior);
-    expect(failed.latest?.id).toBe(compensating.baseline.id);
-    expect(failed.candidate.draft).toBe(true);
-    expect(failed.candidate.body).toBe("release body");
+      const failed = new FakeGithub();
+      const compensating = await steadyCandidate(failed);
+      compensating.baseline.draft = false;
+      failed.latest = compensating.baseline;
+      await stageDesktopRelease(compensating.directory, failed.client());
+      const prior = await observeDesktopLatest(compensating.directory, failed.client());
+      await publishDesktopRelease(compensating.directory, failed.client(), prior);
+      await promoteDesktopLatest(compensating.directory, failed.client(), prior);
+      await settleFakeTimerOperation(
+        reconcileDesktopLatest(compensating.directory, failed.client()),
+      );
+      const compensation = compensateDesktopRelease(
+        compensating.directory,
+        bodyPath,
+        failed.client(),
+        prior,
+      );
+      await settleFakeTimerOperation(compensation);
+      expect(failed.latest?.id).toBe(compensating.baseline.id);
+      expect(failed.candidate.draft).toBe(true);
+      expect(failed.candidate.body).toBe("release body");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("restores the manifest baseline when a resumed candidate is already latest", async () => {
+    const fake = new FakeGithub();
+    const { directory, baseline } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    await promoteDesktopLatest(directory, fake.client(), observed);
+    const bodyDirectory = mkdtempSync(join(tmpdir(), "desktop-release-body-"));
+    directories.push(bodyDirectory);
+    const bodyPath = join(bodyDirectory, "body.md");
+    writeFileSync(bodyPath, "release body");
+    const baselineMetadata = baseline.assets.find((asset) => asset.name === "latest-mac.yml")!;
+
+    vi.useFakeTimers();
+    try {
+      await settleFakeTimerOperation(reconcileDesktopLatest(directory, fake.client()));
+      const resumedCurrent = await observeDesktopLatest(directory, fake.client());
+      expect(resumedCurrent.id).toBe(fake.candidate.id);
+      const rollback = await resolveDesktopRollbackLatest(
+        directory,
+        fake.client(),
+        baselineMetadata.digest.slice("sha256:".length),
+        resumedCurrent,
+      );
+      expect(rollback).toEqual({
+        id: baseline.id,
+        tag: baseline.tag_name,
+        metadataSha256: baselineMetadata.digest.slice("sha256:".length),
+      });
+      const compensation = compensateDesktopRelease(directory, bodyPath, fake.client(), rollback);
+      await settleFakeTimerOperation(compensation);
+      expect(fake.latest?.id).toBe(baseline.id);
+      expect(fake.candidate.draft).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("treats an exact public final latest release as an idempotent terminal state", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    await promoteDesktopLatest(directory, fake.client(), observed);
+    const bodyDirectory = mkdtempSync(join(tmpdir(), "desktop-release-body-"));
+    directories.push(bodyDirectory);
+    const bodyPath = join(bodyDirectory, "body.md");
+    writeFileSync(bodyPath, "release body");
+
+    vi.useFakeTimers();
+    try {
+      await settleFakeTimerOperation(reconcileDesktopLatest(directory, fake.client()));
+      await settleFakeTimerOperation(activateDesktopRelease(directory, bodyPath, fake.client()));
+      const patchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+      const resumedObserved = await observeDesktopLatest(directory, fake.client());
+      await stageDesktopRelease(directory, fake.client());
+      await publishDesktopRelease(directory, fake.client(), resumedObserved);
+      await promoteDesktopLatest(directory, fake.client(), resumedObserved);
+      await settleFakeTimerOperation(reconcileDesktopLatest(directory, fake.client()));
+      await settleFakeTimerOperation(activateDesktopRelease(directory, bodyPath, fake.client()));
+
+      expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(patchCount);
+      expect(fake.candidate.draft).toBe(false);
+      expect(fake.candidate.body).toBe("release body");
+      expect(fake.latest?.id).toBe(fake.candidate.id);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refuses to overwrite a concurrent body edit at the activation boundary", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    await promoteDesktopLatest(directory, fake.client(), observed);
+    const bodyDirectory = mkdtempSync(join(tmpdir(), "desktop-release-body-"));
+    directories.push(bodyDirectory);
+    const bodyPath = join(bodyDirectory, "body.md");
+    writeFileSync(bodyPath, "release body");
+    let candidateReads = 0;
+    const client = new GithubClient("yerzhansa/enduragent", "token", async (input, init) => {
+      const url = String(input);
+      if (
+        (init?.method ?? "GET") === "GET" &&
+        url.endsWith(`/releases/${fake.candidate.id}`) &&
+        ++candidateReads === 2
+      ) {
+        fake.candidate.body = "concurrent operator body";
+      }
+      return fake.fetch(input, init);
+    });
+    const patchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+
+    vi.useFakeTimers();
+    try {
+      await settleFakeTimerOperation(reconcileDesktopLatest(directory, fake.client()));
+      await expect(
+        settleFakeTimerOperation(activateDesktopRelease(directory, bodyPath, client)),
+      ).rejects.toThrow("candidate changed at the mutation boundary");
+      expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(patchCount);
+      expect(fake.candidate.body).toBe("concurrent operator body");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refuses rollback when the candidate body changes at the mutation boundary", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    await promoteDesktopLatest(directory, fake.client(), observed);
+    const bodyDirectory = mkdtempSync(join(tmpdir(), "desktop-release-body-"));
+    directories.push(bodyDirectory);
+    const bodyPath = join(bodyDirectory, "body.md");
+    writeFileSync(bodyPath, "release body");
+    let candidateReads = 0;
+    const client = new GithubClient("yerzhansa/enduragent", "token", async (input, init) => {
+      const url = String(input);
+      if (
+        (init?.method ?? "GET") === "GET" &&
+        url.endsWith(`/releases/${fake.candidate.id}`) &&
+        ++candidateReads === 2
+      ) {
+        fake.candidate.body = "concurrent operator body";
+      }
+      return fake.fetch(input, init);
+    });
+    const patchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+
+    vi.useFakeTimers();
+    try {
+      await settleFakeTimerOperation(reconcileDesktopLatest(directory, fake.client()));
+      await expect(
+        settleFakeTimerOperation(compensateDesktopRelease(directory, bodyPath, client, observed)),
+      ).rejects.toThrow("candidate changed at the mutation boundary");
+      expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(patchCount);
+      expect(fake.candidate.body).toBe("concurrent operator body");
+      expect(fake.candidate.draft).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refuses to overwrite a concurrent latest release at the compensation boundary", async () => {
+    const fake = new FakeGithub();
+    const { directory, baseline } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const rollback = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), rollback);
+    await promoteDesktopLatest(directory, fake.client(), rollback);
+    const bodyDirectory = mkdtempSync(join(tmpdir(), "desktop-release-body-"));
+    directories.push(bodyDirectory);
+    const bodyPath = join(bodyDirectory, "body.md");
+    writeFileSync(bodyPath, "release body");
+    const unrelated = fake.release(999, "other@1.0.0", false);
+    let raced = false;
+    const client = new GithubClient("yerzhansa/enduragent", "token", async (input, init) => {
+      const response = await fake.fetch(input, init);
+      if (
+        !raced &&
+        (init?.method ?? "GET") === "GET" &&
+        String(input).endsWith(`/releases/${baseline.id}`)
+      ) {
+        raced = true;
+        fake.transitionLatest(unrelated);
+      }
+      return response;
+    });
+    const patchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+
+    vi.useFakeTimers();
+    try {
+      await expect(
+        settleFakeTimerOperation(compensateDesktopRelease(directory, bodyPath, client, rollback)),
+      ).rejects.toThrow("latest changed at the mutation boundary");
+      expect(raced).toBe(true);
+      expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(patchCount);
+      expect(fake.latest?.id).toBe(unrelated.id);
+      expect(fake.candidate.draft).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refuses compensation before candidate latest reconciliation without mutating releases", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    const bodyDirectory = mkdtempSync(join(tmpdir(), "desktop-release-body-"));
+    directories.push(bodyDirectory);
+    const bodyPath = join(bodyDirectory, "body.md");
+    writeFileSync(bodyPath, "release body");
+    const patchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+    const latestCallsBefore = fake.calls.filter((call) =>
+      call.url.endsWith("/releases/latest"),
+    ).length;
+
+    vi.useFakeTimers();
+    try {
+      const compensation = compensateDesktopRelease(directory, bodyPath, fake.client(), observed);
+      const refused = expect(compensation).rejects.toThrow(
+        "desktop compensation requires a reconciled candidate latest state",
+      );
+      await waitForPendingFakeTimer();
+      await vi.runAllTimersAsync();
+      await refused;
+      expect(
+        fake.calls.filter((call) => call.url.endsWith("/releases/latest")).length -
+          latestCallsBefore,
+      ).toBeLessThanOrEqual(240);
+      expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(patchCount);
+      expect(fake.candidate.draft).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("discovers a complete retained baseline on a later page", async () => {

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -59,6 +59,7 @@ interface GithubAsset {
   readonly id: number;
   readonly name: string;
   readonly size: number;
+  readonly digest: string | null;
   readonly state: "starter" | "uploaded";
   readonly url: string;
   readonly browser_download_url: string;
@@ -122,7 +123,14 @@ const legacyDesktopBaselineVersion = "0.1.0";
 const commitPattern = /^[0-9a-f]{40}$/u;
 const signingIdentityPattern = /^Developer ID Application: .+ \(FA494ACVTF\)$/u;
 const releasePropagationAttempts = 30;
+const latestReleasePropagationAttempts = 240;
+const stableLatestObservationCount = 3;
 const releasePropagationDelayMs = 2_000;
+const latestReleasePropagationDelayMs = 5_000;
+
+interface LatestPollBudget {
+  remaining: number;
+}
 
 function exactObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -936,13 +944,15 @@ export class GithubClient {
     const metadata = release.assets.find((asset) => asset.name === "latest-mac.yml");
     let metadataSha256: string | null = null;
     if (metadata) {
-      const [assetBytes, feedBytes] = await Promise.all([
-        this.bytes(metadata.url),
-        this.anonymousBytes(`${DESKTOP_FEED_URL}latest-mac.yml`),
-      ]);
-      if (!assetBytes.equals(feedBytes))
-        throw new TypeError("repository latest and updater feed bytes differ");
+      const match = /^sha256:([0-9a-f]{64})$/u.exec(metadata.digest ?? "");
+      if (metadata.state !== "uploaded" || !match || metadata.size <= 0) {
+        throw new TypeError("repository latest metadata digest is invalid");
+      }
+      const feedBytes = await this.anonymousBytes(`${DESKTOP_FEED_URL}latest-mac.yml`);
       metadataSha256 = sha256(feedBytes);
+      if (feedBytes.length !== metadata.size || metadataSha256 !== match[1]) {
+        throw new TypeError("repository latest and updater feed digest differ");
+      }
     }
     return { id: release.id, tag: release.tag_name, metadataSha256 };
   }
@@ -954,6 +964,7 @@ export class GithubClient {
         headers: {
           Accept: "application/vnd.github+json",
           Authorization: `Bearer ${this.#token}`,
+          "Cache-Control": "no-cache",
           "X-GitHub-Api-Version": "2022-11-28",
         },
       },
@@ -1073,7 +1084,56 @@ async function resolvedBaselineForManifest(
 ): Promise<Awaited<ReturnType<typeof newestDesktopRelease>>> {
   const releases = await client.releases();
   if (manifest.mode === "genesis") return newestDesktopRelease(releases, client, manifest.tag);
+  const latest = await client.latestRelease();
+  if (latest?.tag_name === manifest.tag) {
+    return exactDesktopRelease(
+      releases.find((release) => release.tag_name === manifest.baselineTag),
+      client,
+      manifest.baselineTag,
+    );
+  }
   return steadyDesktopBaseline(releases, client, manifest.baselineTag);
+}
+
+function hasFinalReleaseBody(
+  release: Pick<GithubRelease, "body">,
+  manifest: DesktopReleaseManifest,
+): boolean {
+  return sha256(Buffer.from(release.body, "utf8")) === manifest.draftBodySha256;
+}
+
+function hasRecoverablePublicBody(
+  release: Pick<GithubRelease, "body">,
+  manifest: DesktopReleaseManifest,
+): boolean {
+  return (
+    release.body === DESKTOP_PROVISIONAL_RELEASE_BODY || hasFinalReleaseBody(release, manifest)
+  );
+}
+
+async function verifyRecoverableReleaseBinding(
+  client: GithubClient,
+  manifest: DesktopReleaseManifest,
+): Promise<GithubRelease> {
+  const release = await client.release(manifest.draftId);
+  if (
+    String(release.id) !== manifest.draftId ||
+    release.prerelease ||
+    release.tag_name !== manifest.tag
+  ) {
+    throw new TypeError("GitHub recoverable candidate binding mismatch");
+  }
+  if ((await client.tagCommit(manifest.tag)) !== manifest.commit) {
+    throw new TypeError("Git tag commit binding mismatch");
+  }
+  if (release.draft) {
+    if (sha256(Buffer.from(release.body, "utf8")) !== manifest.draftBodySha256) {
+      throw new TypeError("GitHub recoverable draft body binding mismatch");
+    }
+  } else if (!hasRecoverablePublicBody(release, manifest)) {
+    throw new TypeError("GitHub recoverable public body binding mismatch");
+  }
+  return release;
 }
 
 async function verifyReleaseBinding(
@@ -1176,13 +1236,32 @@ async function stageExactAssets(
   return staged;
 }
 
+async function assertCompleteReleaseAssets(
+  client: GithubClient,
+  release: GithubRelease,
+  manifest: DesktopReleaseManifest,
+  label: string,
+): Promise<void> {
+  assertPublishableAssets(release.assets, manifest);
+  if (release.assets.length !== manifest.files.length) {
+    throw new TypeError(`${label} asset set is incomplete`);
+  }
+  for (const file of manifest.files) {
+    const asset = release.assets.find((candidate) => candidate.name === file.name);
+    if (!asset || asset.state !== "uploaded") {
+      throw new TypeError(`${label} asset is incomplete: ${file.name}`);
+    }
+    assertRemoteAsset(file, await client.bytes(asset.url));
+  }
+}
+
 export async function publishDesktopRelease(
   directory: string,
   client: GithubClient,
   observedLatest?: LatestObservation,
 ): Promise<void> {
   const manifest = await verifyDesktopRelease(directory);
-  const release = await verifyReleaseBinding(client, manifest);
+  const release = await verifyRecoverableReleaseBinding(client, manifest);
   assertPublishableAssets(release.assets, manifest);
   const baseline = await resolvedBaselineForManifest(manifest, client);
   await assertResolvedBaseline(manifest, baseline, client);
@@ -1195,20 +1274,24 @@ export async function publishDesktopRelease(
     await client.latest(),
     baseline?.version ?? null,
   );
-  await stageExactAssets(client, release, directory, manifest);
-  await client.request(`/repos/${client.repository()}/releases/${release.id}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      draft: false,
-      make_latest: "false",
-      body: DESKTOP_PROVISIONAL_RELEASE_BODY,
-    }),
-  });
-  const published = await client.release(release.id);
-  if (published.draft || published.body !== DESKTOP_PROVISIONAL_RELEASE_BODY) {
-    throw new TypeError("desktop release did not enter provisional publication");
+  let published = release;
+  if (release.draft) {
+    await stageExactAssets(client, release, directory, manifest);
+    await client.request(`/repos/${client.repository()}/releases/${release.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        draft: false,
+        make_latest: "false",
+        body: DESKTOP_PROVISIONAL_RELEASE_BODY,
+      }),
+    });
+    published = await client.release(release.id);
   }
+  if (published.draft || !hasRecoverablePublicBody(published, manifest)) {
+    throw new TypeError("desktop release did not enter a recoverable public state");
+  }
+  await assertCompleteReleaseAssets(client, published, manifest, "published release");
   for (const file of manifest.files) {
     const asset = published.assets.find((candidate) => candidate.name === file.name);
     if (!asset) throw new TypeError(`published release asset is missing: ${file.name}`);
@@ -1232,30 +1315,89 @@ export async function observeDesktopLatest(
   client: GithubClient,
 ): Promise<LatestObservation> {
   const manifest = await verifyDesktopRelease(directory);
-  const release = await verifyReleaseBinding(client, manifest);
-  assertPublishableAssets(release.assets, manifest);
+  const release = await verifyRecoverableReleaseBinding(client, manifest);
   const baseline = await resolvedBaselineForManifest(manifest, client);
   await assertResolvedBaseline(manifest, baseline, client);
-  if (release.assets.length !== manifest.files.length) {
-    throw new TypeError("observed desktop draft asset set is incomplete");
-  }
-  for (const file of manifest.files) {
-    const asset = release.assets.find((candidate) => candidate.name === file.name);
-    if (!asset || asset.state !== "uploaded") {
-      throw new TypeError(`observed desktop draft asset is incomplete: ${file.name}`);
-    }
-    assertRemoteAsset(file, await client.bytes(asset.url));
-  }
+  await assertCompleteReleaseAssets(client, release, manifest, "observed desktop release");
   return client.latest();
+}
+
+export async function resolveDesktopRollbackLatest(
+  directory: string,
+  client: GithubClient,
+  baselineMetadataSha256: string,
+  currentLatest?: LatestObservation,
+): Promise<LatestObservation> {
+  const manifest = await verifyDesktopRelease(directory);
+  const baseline = await resolvedBaselineForManifest(manifest, client);
+  await assertResolvedBaseline(manifest, baseline, client);
+  if (manifest.mode === "genesis") {
+    if (baselineMetadataSha256 !== "none") {
+      throw new TypeError("genesis rollback metadata must be none");
+    }
+    return requireObservedLatest(currentLatest ?? (await client.latest()));
+  }
+  if (!baseline || !sha256HexSchema.safeParse(baselineMetadataSha256).success) {
+    throw new TypeError("steady rollback metadata binding is invalid");
+  }
+  const metadata = baseline.release.assets.find((asset) => asset.name === "latest-mac.yml");
+  if (
+    !metadata ||
+    metadata.state !== "uploaded" ||
+    metadata.digest !== `sha256:${baselineMetadataSha256}` ||
+    metadata.size <= 0
+  ) {
+    throw new TypeError("steady rollback metadata asset binding mismatch");
+  }
+  const bytes = await client.bytes(metadata.url);
+  if (bytes.length !== metadata.size || sha256(bytes) !== baselineMetadataSha256) {
+    throw new TypeError("steady rollback metadata bytes binding mismatch");
+  }
+  return {
+    id: baseline.release.id,
+    tag: baseline.release.tag_name,
+    metadataSha256: baselineMetadataSha256,
+  };
+}
+
+async function verifyRestorableLatestObservation(
+  client: GithubClient,
+  rawObserved: LatestObservation,
+): Promise<LatestObservation> {
+  const observed = requireObservedLatest(rawObserved);
+  if (observed.id === null) return observed;
+  const release = await client.release(observed.id);
+  if (release.draft || release.prerelease || release.tag_name !== observed.tag) {
+    throw new TypeError("restorable latest release binding mismatch");
+  }
+  const metadata = release.assets.find((asset) => asset.name === "latest-mac.yml");
+  if (observed.metadataSha256 === null) {
+    if (metadata) throw new TypeError("restorable latest metadata appeared after observation");
+    return observed;
+  }
+  if (
+    !metadata ||
+    metadata.state !== "uploaded" ||
+    metadata.digest !== `sha256:${observed.metadataSha256}` ||
+    metadata.size <= 0
+  ) {
+    throw new TypeError("restorable latest metadata binding mismatch");
+  }
+  const bytes = await client.bytes(metadata.url);
+  if (bytes.length !== metadata.size || sha256(bytes) !== observed.metadataSha256) {
+    throw new TypeError("restorable latest metadata bytes mismatch");
+  }
+  return observed;
 }
 
 export async function stageDesktopRelease(directory: string, client: GithubClient): Promise<void> {
   const manifest = await verifyDesktopRelease(directory);
-  const release = await verifyReleaseBinding(client, manifest);
+  const release = await verifyRecoverableReleaseBinding(client, manifest);
   assertPublishableAssets(release.assets, manifest);
   const baseline = await resolvedBaselineForManifest(manifest, client);
   await assertResolvedBaseline(manifest, baseline, client);
-  await stageExactAssets(client, release, directory, manifest);
+  if (release.draft) await stageExactAssets(client, release, directory, manifest);
+  else await assertCompleteReleaseAssets(client, release, manifest, "resumed public release");
 }
 
 export async function promoteDesktopLatest(
@@ -1267,13 +1409,18 @@ export async function promoteDesktopLatest(
   const candidate = await client.release(manifest.draftId);
   if (candidate.draft || candidate.prerelease || candidate.tag_name !== manifest.tag)
     throw new TypeError("published candidate binding mismatch");
-  if (candidate.body !== DESKTOP_PROVISIONAL_RELEASE_BODY)
-    throw new TypeError("published release is not provisional");
+  if (!hasRecoverablePublicBody(candidate, manifest))
+    throw new TypeError("published release body is not recoverable");
+  const candidateWasFinal = hasFinalReleaseBody(candidate, manifest);
   if ((await client.tagCommit(manifest.tag)) !== manifest.commit)
     throw new TypeError("published tag commit binding mismatch");
   const current = await client.latest();
   const previous = await newestDesktopRelease(await client.releases(), client, manifest.tag);
   assertLatestCas(manifest.desktopVersion, observed, current, previous?.version ?? null);
+  assertPublishableAssets(candidate.assets, manifest);
+  if (candidate.assets.length !== manifest.files.length) {
+    throw new TypeError("promotion candidate asset set is incomplete");
+  }
   for (const file of manifest.files) {
     const asset = candidate.assets.find((candidateAsset) => candidateAsset.name === file.name);
     if (!asset || asset.state !== "uploaded")
@@ -1286,17 +1433,71 @@ export async function promoteDesktopLatest(
     await client.latest(),
     previous?.version ?? null,
   );
-  await client.request(`/repos/${client.repository()}/releases/${candidate.id}`, {
+  const rebound = await client.release(candidate.id);
+  if (
+    rebound.draft ||
+    rebound.prerelease ||
+    rebound.tag_name !== manifest.tag ||
+    !hasRecoverablePublicBody(rebound, manifest) ||
+    hasFinalReleaseBody(rebound, manifest) !== candidateWasFinal ||
+    (await client.tagCommit(manifest.tag)) !== manifest.commit
+  ) {
+    throw new TypeError("promotion candidate changed during final preflight");
+  }
+  await assertCompleteReleaseAssets(client, rebound, manifest, "promotion candidate");
+  for (const file of manifest.files) {
+    const asset = rebound.assets.find((entry) => entry.name === file.name);
+    if (!asset) throw new TypeError(`promotion candidate asset is missing: ${file.name}`);
+    await waitForAnonymousAsset(client, asset.browser_download_url, file);
+  }
+  const finalLatest = await client.latest();
+  assertLatestCas(manifest.desktopVersion, observed, finalLatest, previous?.version ?? null);
+  if (candidateWasFinal) {
+    const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
+    if (
+      !metadata ||
+      !sameLatest(finalLatest, {
+        id: rebound.id,
+        tag: manifest.tag,
+        metadataSha256: metadata.sha256,
+      })
+    ) {
+      throw new TypeError("final desktop release is not the stable latest release");
+    }
+    return;
+  }
+  await client.request(`/repos/${client.repository()}/releases/${rebound.id}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ make_latest: "true" }),
   });
+}
+
+export async function reconcileDesktopLatest(
+  directory: string,
+  client: GithubClient,
+): Promise<void> {
+  const manifest = await verifyDesktopRelease(directory);
+  const candidate = await client.release(manifest.draftId);
+  if (
+    candidate.draft ||
+    candidate.prerelease ||
+    candidate.tag_name !== manifest.tag ||
+    !hasRecoverablePublicBody(candidate, manifest) ||
+    (await client.tagCommit(manifest.tag)) !== manifest.commit
+  ) {
+    throw new TypeError("desktop latest reconciliation candidate binding mismatch");
+  }
+  assertPublishableAssets(candidate.assets, manifest);
+  if (candidate.assets.length !== manifest.files.length) {
+    throw new TypeError("desktop latest reconciliation asset set is incomplete");
+  }
   const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
   if (!metadata) throw new TypeError("desktop latest metadata is missing");
   await waitForLatest(
     client,
     { id: candidate.id, tag: manifest.tag, metadataSha256: metadata.sha256 },
-    "desktop latest promotion did not converge",
+    "desktop latest reconciliation did not converge",
   );
 }
 
@@ -1323,6 +1524,10 @@ function sameLatest(left: LatestObservation, right: LatestObservation): boolean 
 
 function pauseForReleasePropagation(): Promise<void> {
   return new Promise((resolvePause) => setTimeout(resolvePause, releasePropagationDelayMs));
+}
+
+function pauseForLatestPropagation(): Promise<void> {
+  return new Promise((resolvePause) => setTimeout(resolvePause, latestReleasePropagationDelayMs));
 }
 
 async function waitForAnonymousAsset(
@@ -1352,18 +1557,37 @@ async function waitForLatest(
   client: GithubClient,
   expected: LatestObservation | readonly LatestObservation[],
   message: string,
+  budget: LatestPollBudget = { remaining: latestReleasePropagationAttempts },
 ): Promise<LatestObservation> {
   const accepted = Array.isArray(expected) ? expected : [expected];
   let lastError: unknown;
-  for (let attempt = 1; attempt <= releasePropagationAttempts; attempt += 1) {
+  let stableObservation: LatestObservation | null = null;
+  let stableCount = 0;
+  while (budget.remaining > 0) {
+    budget.remaining -= 1;
     try {
       const current = await client.latest();
-      if (accepted.some((candidate) => sameLatest(candidate, current))) return current;
-      lastError = new TypeError("repository latest does not match the expected release");
+      const matched = accepted.some((candidate) => sameLatest(candidate, current));
+      if (matched) {
+        if (stableObservation !== null && sameLatest(stableObservation, current)) {
+          stableCount += 1;
+        } else {
+          stableObservation = current;
+          stableCount = 1;
+        }
+        if (stableCount >= stableLatestObservationCount) return current;
+        lastError = new TypeError("repository latest has not remained stable long enough");
+      } else {
+        stableObservation = null;
+        stableCount = 0;
+        lastError = new TypeError("repository latest does not match the expected release");
+      }
     } catch (error) {
+      stableObservation = null;
+      stableCount = 0;
       lastError = error;
     }
-    if (attempt < releasePropagationAttempts) await pauseForReleasePropagation();
+    if (budget.remaining > 0) await pauseForLatestPropagation();
   }
   throw new TypeError(message, { cause: lastError });
 }
@@ -1393,7 +1617,7 @@ export async function activateDesktopRelease(
     candidate.draft ||
     candidate.prerelease ||
     candidate.tag_name !== manifest.tag ||
-    candidate.body !== DESKTOP_PROVISIONAL_RELEASE_BODY ||
+    !hasRecoverablePublicBody(candidate, manifest) ||
     (await client.tagCommit(manifest.tag)) !== manifest.commit
   ) {
     throw new TypeError("desktop activation candidate binding mismatch");
@@ -1416,10 +1640,12 @@ export async function activateDesktopRelease(
     tag: manifest.tag,
     metadataSha256: metadata.sha256,
   };
+  const pollBudget: LatestPollBudget = { remaining: latestReleasePropagationAttempts };
   const latest = await waitForLatest(
     client,
     expectedLatest,
     "desktop activation latest state did not converge",
+    pollBudget,
   );
   if (
     latest.id !== candidate.id ||
@@ -1428,11 +1654,31 @@ export async function activateDesktopRelease(
   ) {
     throw new TypeError("desktop activation latest binding mismatch");
   }
-  await client.request(`/repos/${client.repository()}/releases/${candidate.id}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ body: finalBody }),
-  });
+  const mutationCandidate = await client.release(candidate.id);
+  if (
+    mutationCandidate.draft ||
+    mutationCandidate.prerelease ||
+    mutationCandidate.tag_name !== manifest.tag ||
+    mutationCandidate.body !== candidate.body ||
+    !hasRecoverablePublicBody(mutationCandidate, manifest) ||
+    (await client.tagCommit(manifest.tag)) !== manifest.commit
+  ) {
+    throw new TypeError("desktop activation candidate changed at the mutation boundary");
+  }
+  assertPublishableAssets(mutationCandidate.assets, manifest);
+  if (
+    mutationCandidate.assets.length !== manifest.files.length ||
+    !sameLatest(expectedLatest, await client.latest())
+  ) {
+    throw new TypeError("desktop activation candidate changed at the mutation boundary");
+  }
+  if (!hasFinalReleaseBody(mutationCandidate, manifest)) {
+    await client.request(`/repos/${client.repository()}/releases/${candidate.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body: finalBody }),
+    });
+  }
   const activated = await client.release(candidate.id);
   if (
     activated.draft ||
@@ -1446,6 +1692,7 @@ export async function activateDesktopRelease(
         client,
         expectedLatest,
         "desktop activation latest state changed during body activation",
+        pollBudget,
       ),
     )
   ) {
@@ -1463,7 +1710,11 @@ export async function compensateDesktopRelease(
   const finalBody = await readFinalReleaseBody(bodyPath, manifest);
   const observed = requireObservedLatest(rawObserved);
   let candidate = await client.release(manifest.draftId);
-  if (candidate.prerelease || candidate.tag_name !== manifest.tag) {
+  if (
+    candidate.prerelease ||
+    candidate.tag_name !== manifest.tag ||
+    (!candidate.draft && !hasRecoverablePublicBody(candidate, manifest))
+  ) {
     throw new TypeError("desktop compensation candidate binding mismatch");
   }
   if (candidate.draft) {
@@ -1482,26 +1733,91 @@ export async function compensateDesktopRelease(
   }
   const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
   if (!metadata) throw new TypeError("desktop compensation latest metadata is missing");
-  const current = await waitForLatest(
+  const candidateLatest = {
+    id: candidate.id,
+    tag: manifest.tag,
+    metadataSha256: metadata.sha256,
+  };
+  const pollBudget: LatestPollBudget = { remaining: latestReleasePropagationAttempts };
+  await waitForLatest(
     client,
-    [observed, { id: candidate.id, tag: manifest.tag, metadataSha256: metadata.sha256 }],
-    "desktop compensation could not resolve the public latest state",
+    candidateLatest,
+    "desktop compensation requires a reconciled candidate latest state",
+    pollBudget,
   );
-  if (current.id === candidate.id && current.tag === manifest.tag) {
-    if (observed.id !== null) {
-      const previous = await client.release(observed.id);
-      if (previous.draft || previous.prerelease || previous.tag_name !== observed.tag) {
-        throw new TypeError("desktop compensation previous latest binding mismatch");
-      }
-      await client.request(`/repos/${client.repository()}/releases/${previous.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ make_latest: "true" }),
-      });
-      await waitForLatest(client, observed, "desktop compensation latest restoration failed");
+  const resolveRollback = async (): Promise<LatestObservation> => {
+    const rebound =
+      manifest.mode === "steady"
+        ? await resolveDesktopRollbackLatest(
+            directory,
+            client,
+            observed.metadataSha256 ?? "none",
+            observed,
+          )
+        : await verifyRestorableLatestObservation(client, observed);
+    if (!sameLatest(rebound, observed)) {
+      throw new TypeError("desktop compensation rollback target binding mismatch");
     }
-  } else if (!sameLatest(observed, current)) {
-    throw new TypeError("desktop compensation refused unexpected latest state");
+    return rebound;
+  };
+  await resolveRollback();
+  await waitForLatest(
+    client,
+    candidateLatest,
+    "desktop compensation candidate changed during rollback preflight",
+    pollBudget,
+  );
+  await resolveRollback();
+  let previous: GithubRelease | null = null;
+  if (observed.id !== null) {
+    previous = await client.release(observed.id);
+    if (previous.draft || previous.prerelease || previous.tag_name !== observed.tag) {
+      throw new TypeError("desktop compensation previous latest binding mismatch");
+    }
+  }
+  candidate = await client.release(candidate.id);
+  if (
+    candidate.draft ||
+    candidate.prerelease ||
+    candidate.tag_name !== manifest.tag ||
+    !hasRecoverablePublicBody(candidate, manifest) ||
+    (await client.tagCommit(manifest.tag)) !== manifest.commit
+  ) {
+    throw new TypeError("desktop compensation candidate changed at the mutation boundary");
+  }
+  assertPublishableAssets(candidate.assets, manifest);
+  if (candidate.assets.length !== manifest.files.length) {
+    throw new TypeError("desktop compensation candidate changed at the mutation boundary");
+  }
+  if (!sameLatest(candidateLatest, await client.latest())) {
+    throw new TypeError("desktop compensation latest changed at the mutation boundary");
+  }
+  if (previous !== null) {
+    await client.request(`/repos/${client.repository()}/releases/${previous.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ make_latest: "true" }),
+    });
+    await waitForLatest(
+      client,
+      observed,
+      "desktop compensation latest restoration failed",
+      pollBudget,
+    );
+  }
+  candidate = await client.release(candidate.id);
+  if (
+    candidate.draft ||
+    candidate.prerelease ||
+    candidate.tag_name !== manifest.tag ||
+    !hasRecoverablePublicBody(candidate, manifest) ||
+    (await client.tagCommit(manifest.tag)) !== manifest.commit
+  ) {
+    throw new TypeError("desktop compensation candidate changed before withdrawal");
+  }
+  assertPublishableAssets(candidate.assets, manifest);
+  if (candidate.assets.length !== manifest.files.length) {
+    throw new TypeError("desktop compensation candidate changed before withdrawal");
   }
   await client.request(`/repos/${client.repository()}/releases/${candidate.id}`, {
     method: "PATCH",
@@ -1513,6 +1829,7 @@ export async function compensateDesktopRelease(
     client,
     observed,
     "desktop compensation latest state did not converge",
+    pollBudget,
   );
   if (!candidate.draft || candidate.body !== finalBody || !sameLatest(observed, restored)) {
     throw new TypeError("desktop compensation did not round-trip");
@@ -1539,7 +1856,7 @@ export async function prepareDesktopBaseline(
       throw new TypeError("genesis release refused after a desktop baseline exists");
     await writeFile(
       output,
-      "baseline_tag=none\nbaseline_version=none\nbaseline_release_id=none\nbaseline_commit=none\nbaseline_zip_sha256=none\nbaseline_signing_identity=none\nbaseline_cdhash=none\nbaseline_zip=none\n",
+      "baseline_tag=none\nbaseline_version=none\nbaseline_release_id=none\nbaseline_commit=none\nbaseline_zip_sha256=none\nbaseline_metadata_sha256=none\nbaseline_signing_identity=none\nbaseline_cdhash=none\nbaseline_zip=none\n",
       { flag: "a" },
     );
     return;
@@ -1552,6 +1869,7 @@ export async function prepareDesktopBaseline(
   const names = releaseFileNames(baseline.version);
   let zipSha256 = "";
   let zipPath = "";
+  let metadataSha256 = "";
   for (const name of names) {
     const asset = baseline.release.assets.find((candidate) => candidate.name === name);
     if (!asset) throw new TypeError(`desktop baseline asset is missing: ${name}`);
@@ -1565,10 +1883,11 @@ export async function prepareDesktopBaseline(
       zipSha256 = sha256(bytes);
       zipPath = path;
     }
+    if (name === "latest-mac.yml") metadataSha256 = sha256(bytes);
   }
   await writeFile(
     output,
-    `baseline_tag=${baseline.release.tag_name}\nbaseline_version=${baseline.version}\nbaseline_release_id=${baseline.release.id}\nbaseline_commit=${baseline.commit}\nbaseline_zip_sha256=${zipSha256}\nbaseline_zip=${zipPath}\n`,
+    `baseline_tag=${baseline.release.tag_name}\nbaseline_version=${baseline.version}\nbaseline_release_id=${baseline.release.id}\nbaseline_commit=${baseline.commit}\nbaseline_zip_sha256=${zipSha256}\nbaseline_metadata_sha256=${metadataSha256}\nbaseline_zip=${zipPath}\n`,
     { flag: "a" },
   );
 }
@@ -1628,10 +1947,14 @@ function latestArguments(): LatestObservation {
   };
 }
 
-async function writeLatestOutput(output: string, observed: LatestObservation): Promise<void> {
+async function writeLatestOutput(
+  output: string,
+  observed: LatestObservation,
+  rollback: LatestObservation,
+): Promise<void> {
   await writeFile(
     output,
-    `latest_id=${observed.id ?? "none"}\nlatest_tag=${observed.tag ?? "none"}\nlatest_metadata_sha256=${observed.metadataSha256 ?? "none"}\n`,
+    `latest_id=${observed.id ?? "none"}\nlatest_tag=${observed.tag ?? "none"}\nlatest_metadata_sha256=${observed.metadataSha256 ?? "none"}\nrollback_latest_id=${rollback.id ?? "none"}\nrollback_latest_tag=${rollback.tag ?? "none"}\nrollback_latest_metadata_sha256=${rollback.metadataSha256 ?? "none"}\n`,
     { flag: "a" },
   );
 }
@@ -1697,10 +2020,14 @@ async function main(): Promise<void> {
     return;
   }
   if (command === "observe") {
-    await writeLatestOutput(
-      argument("github-output"),
-      await observeDesktopLatest(directory, client),
+    const observed = await observeDesktopLatest(directory, client);
+    const rollback = await resolveDesktopRollbackLatest(
+      directory,
+      client,
+      argument("baseline-metadata-sha256"),
+      observed,
     );
+    await writeLatestOutput(argument("github-output"), observed, rollback);
     return;
   }
   if (command === "publish") {
@@ -1713,6 +2040,10 @@ async function main(): Promise<void> {
   }
   if (command === "promote") {
     await promoteDesktopLatest(directory, client, latestArguments());
+    return;
+  }
+  if (command === "reconcile") {
+    await reconcileDesktopLatest(directory, client);
     return;
   }
   if (command === "activate") {
@@ -1729,7 +2060,7 @@ async function main(): Promise<void> {
     return;
   }
   throw new TypeError(
-    "desktop release command must be verify-npm-provenance, seal, verify, public-envelope, baseline, stage, observe, publish, promote, activate, or compensate",
+    "desktop release command must be verify-npm-provenance, seal, verify, public-envelope, baseline, stage, observe, publish, promote, reconcile, activate, or compensate",
   );
 }
 


### PR DESCRIPTION
## Summary

- resume the failed macOS 0.1.1 transaction from its original sealed, signed, and notarized Actions artifacts without rebuilding or re-signing
- split latest mutation from read-only convergence, use bounded stable polling, and compensate only after the candidate was positively reconciled
- bind recovery tags, coordinator dispatch, source-run provenance, artifact digests, release bodies, exact assets, baseline rollback, and every mutation boundary fail-closed
- keep Desktop release identity independent from npm; no npm workflow, package manifest, version, or changeset changes

## Verification

- 491 focused updater/release tests passed; 8 loopback-only tests were sandbox-skipped
- desktop workflow structural checker passed with 47 mutation tests
- targeted strict TypeScript check, oxlint, oxfmt, YAML parsing, 51 embedded shell syntax checks, and `git diff --check` passed
- architecture, security, and recovery-path reviews found the implementation code-green
- local ADR-0045 accepted the already-approved Desktop/npm release-topology split and explicitly supersedes the conflicting clauses in ADR-0043 and ADR-0044

## Recovery target

After merge, the transaction will use immutable tooling tag `enduragent-desktop@0.1.1-recovery.2` to resume source run `31287964438` while preserving candidate `enduragent-desktop@0.1.1`, baseline `cycling-coach@2026.8.8`, and the original four release assets.
