### PR TITLE
fix(ci): bind desktop recovery to reusable workflow

### DIFF
--- a/.github/workflows/desktop-release-coordinator.yml
+++ b/.github/workflows/desktop-release-coordinator.yml
@@ -48,7 +48,6 @@ jobs:
       tag: ${{ steps.bind.outputs.tag }}
       desktop_version: ${{ steps.bind.outputs.desktop_version }}
       commit: ${{ steps.bind.outputs.commit }}
-      workflow_ref: ${{ steps.bind.outputs.workflow_ref }}
       tooling_commit: ${{ steps.bind.outputs.tooling_commit }}
       mode: ${{ steps.bind.outputs.mode }}
       baseline_tag: ${{ steps.bind.outputs.baseline_tag }}
@@ -70,6 +69,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_SHA: ${{ github.sha }}
+          REPOSITORY_ID: ${{ github.repository_id }}
         run: |
           set -euo pipefail
           test "$DESKTOP_ENABLED" = 'true'
@@ -96,7 +96,6 @@ jobs:
             echo "::error::Unsupported desktop release mode '$MODE'"
             exit 1
           fi
-          CHILD_WORKFLOW_REF="$TAG"
           TOOLING_COMMIT="$COMMIT"
           if [ -n "$RECOVERY_TOOLING_TAG_INPUT" ]; then
             if [ "$MODE" != 'steady' ]; then
@@ -124,7 +123,6 @@ jobs:
               echo '::error::Recovery tooling commit must be merged into main'
               exit 1
             fi
-            CHILD_WORKFLOW_REF="$RECOVERY_TAG"
           else
             test "$WORKFLOW_REF" = "refs/tags/$TAG"
             test "$WORKFLOW_SHA" = "$COMMIT"
@@ -138,32 +136,70 @@ jobs:
             printf '%s' "$RECOVERY_SOURCE_RUN_ID_INPUT" | grep -Eq '^[1-9][0-9]*$'
             SOURCE_RUN_ID="$RECOVERY_SOURCE_RUN_ID_INPUT"
             SOURCE_RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")
-            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.path')" = '.github/workflows/desktop-release.yml'
+            SOURCE_WORKFLOW_PATH_RAW=$(printf '%s' "$SOURCE_RUN" | jq -er '.path')
+            SOURCE_WORKFLOW_PATH="${SOURCE_WORKFLOW_PATH_RAW%%@*}"
+            case "$SOURCE_WORKFLOW_PATH" in
+              .github/workflows/desktop-release.yml)
+                test "$(printf '%s' "$SOURCE_RUN" | jq -r '.actor.login')" = 'github-actions[bot]'
+                test "$(printf '%s' "$SOURCE_RUN" | jq -r '.triggering_actor.login')" = 'github-actions[bot]'
+                ;;
+              .github/workflows/desktop-release-coordinator.yml)
+                ;;
+              *)
+                echo '::error::Recovery source run used an untrusted workflow'
+                exit 1
+                ;;
+            esac
             test "$(printf '%s' "$SOURCE_RUN" | jq -r '.event')" = 'workflow_dispatch'
-            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.actor.login')" = 'github-actions[bot]'
-            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.triggering_actor.login')" = 'github-actions[bot]'
             test "$(printf '%s' "$SOURCE_RUN" | jq -r '.status')" = 'completed'
             test "$(printf '%s' "$SOURCE_RUN" | jq -r '.conclusion')" = 'failure'
             test "$(printf '%s' "$SOURCE_RUN" | jq -r '.repository.full_name')" = "$GITHUB_REPOSITORY"
+            test "$(printf '%s' "$SOURCE_RUN" | jq -r '.head_repository.full_name')" = "$GITHUB_REPOSITORY"
             SOURCE_ATTEMPT=$(printf '%s' "$SOURCE_RUN" | jq -er '.run_attempt')
             printf '%s' "$SOURCE_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
             SOURCE_HEAD=$(printf '%s' "$SOURCE_RUN" | jq -er '.head_branch')
             SOURCE_SHA=$(printf '%s' "$SOURCE_RUN" | jq -er '.head_sha')
-            SOURCE_REVISION="${SOURCE_HEAD#"${TAG}-recovery."}"
-            printf '%s' "$SOURCE_REVISION" | grep -Eq '^[1-9][0-9]*$'
-            test "$SOURCE_HEAD" = "${TAG}-recovery.${SOURCE_REVISION}"
-            test "$SOURCE_HEAD" != "$RECOVERY_TOOLING_TAG_INPUT"
             printf '%s' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'
+            case "$SOURCE_WORKFLOW_PATH_RAW" in
+              "$SOURCE_WORKFLOW_PATH"|"$SOURCE_WORKFLOW_PATH@$SOURCE_HEAD"|"$SOURCE_WORKFLOW_PATH@refs/tags/$SOURCE_HEAD")
+                ;;
+              *)
+                echo '::error::Recovery source workflow path used an unexpected ref suffix'
+                exit 1
+                ;;
+            esac
+            CURRENT_RECOVERY_REVISION="${RECOVERY_TOOLING_TAG_INPUT#"${TAG}-recovery."}"
+            if [ "$SOURCE_HEAD" = "$TAG" ]; then
+              test "$SOURCE_SHA" = "$COMMIT"
+            else
+              SOURCE_REVISION="${SOURCE_HEAD#"${TAG}-recovery."}"
+              printf '%s' "$SOURCE_REVISION" | grep -Eq '^[1-9][0-9]*$'
+              test "$SOURCE_HEAD" = "${TAG}-recovery.${SOURCE_REVISION}"
+              test "$SOURCE_REVISION" -lt "$CURRENT_RECOVERY_REVISION"
+            fi
             git fetch --force --no-tags origin "refs/tags/$SOURCE_HEAD:refs/tags/$SOURCE_HEAD"
             test "$(git rev-parse "refs/tags/$SOURCE_HEAD^{commit}")" = "$SOURCE_SHA"
             git merge-base --is-ancestor "$COMMIT" "$SOURCE_SHA"
             git merge-base --is-ancestor "$SOURCE_SHA" "$TOOLING_COMMIT"
             git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main
-            SOURCE_JOBS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/jobs?per_page=100")
+            SOURCE_JOBS=$(gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_ATTEMPT/jobs?per_page=100")
+            printf '%s' "$SOURCE_JOBS" | jq -e \
+              'type == "array" and length > 0 and ([.[].jobs[]] | length) == .[0].total_count' >/dev/null
             for required_job in sign-macos verify-macos-envelope stage-private-draft publish-assets; do
-              test "$(printf '%s' "$SOURCE_JOBS" | jq --arg name "$required_job" '[.jobs[] | select(.name == $name and .conclusion == "success")] | length')" = '1'
+              printf '%s' "$SOURCE_JOBS" | jq -e --arg name "$required_job" '
+                [.[].jobs[] | select((.name | split(" / ") | last) == $name)] as $matches |
+                ($matches | length) == 1 and
+                $matches[0].status == "completed" and
+                $matches[0].conclusion == "success"
+              ' >/dev/null
             done
-            test "$(printf '%s' "$SOURCE_JOBS" | jq '[.jobs[] | select(.name == "activate-release" and .conclusion == "success")] | length')" = '0'
+            printf '%s' "$SOURCE_JOBS" | jq -e '
+              [.[].jobs[] | select((.name | split(" / ") | last) == "activate-release")] as $matches |
+              ($matches | length) == 1 and
+              $matches[0].status == "completed" and
+              $matches[0].conclusion != "success"
+            ' >/dev/null
             SOURCE_ARTIFACTS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100")
             for artifact_name in "desktop-release-$SOURCE_RUN_ID-$SOURCE_ATTEMPT" "desktop-baseline-$SOURCE_RUN_ID-$SOURCE_ATTEMPT"; do
               ARTIFACT=$(printf '%s' "$SOURCE_ARTIFACTS" | jq -ec --arg name "$artifact_name" '[.artifacts[] | select(.name == $name)] | if length == 1 then .[0] else error("artifact cardinality") end')
@@ -171,6 +207,8 @@ jobs:
               printf '%s' "$(printf '%s' "$ARTIFACT" | jq -er '.id')" | grep -Eq '^[1-9][0-9]*$'
               printf '%s' "$(printf '%s' "$ARTIFACT" | jq -er '.digest')" | grep -Eq '^sha256:[0-9a-f]{64}$'
               test "$(printf '%s' "$ARTIFACT" | jq -r '.workflow_run.id')" = "$SOURCE_RUN_ID"
+              test "$(printf '%s' "$ARTIFACT" | jq -r '.workflow_run.repository_id')" = "$REPOSITORY_ID"
+              test "$(printf '%s' "$ARTIFACT" | jq -r '.workflow_run.head_repository_id')" = "$REPOSITORY_ID"
               test "$(printf '%s' "$ARTIFACT" | jq -r '.workflow_run.head_branch')" = "$SOURCE_HEAD"
               test "$(printf '%s' "$ARTIFACT" | jq -r '.workflow_run.head_sha')" = "$SOURCE_SHA"
             done
@@ -192,7 +230,6 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "desktop_version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
-          echo "workflow_ref=$CHILD_WORKFLOW_REF" >> "$GITHUB_OUTPUT"
           echo "tooling_commit=$TOOLING_COMMIT" >> "$GITHUB_OUTPUT"
           echo "mode=$MODE" >> "$GITHUB_OUTPUT"
           echo "baseline_tag=$BASELINE_TAG" >> "$GITHUB_OUTPUT"
@@ -254,116 +291,23 @@ jobs:
           echo "draft_id=$DRAFT_ID" >> "$GITHUB_OUTPUT"
           echo "body_sha256=$BODY_SHA256" >> "$GITHUB_OUTPUT"
 
-  dispatch-desktop-release:
-    runs-on: ubuntu-latest
+  desktop-release:
     needs: [bind-release, prepare-release-draft]
+    concurrency:
+      group: stable-desktop
+      cancel-in-progress: false
+      queue: max
     permissions:
-      actions: write
-      contents: read
-    steps:
-      - name: Seal exact child dispatch binding
-        id: dispatch-binding
-        env:
-          RELEASE_TAG: ${{ needs.bind-release.outputs.tag }}
-          DESKTOP_VERSION: ${{ needs.bind-release.outputs.desktop_version }}
-          RELEASE_COMMIT: ${{ needs.bind-release.outputs.commit }}
-          RELEASE_WORKFLOW_REF: ${{ needs.bind-release.outputs.workflow_ref }}
-          RELEASE_TOOLING_COMMIT: ${{ needs.bind-release.outputs.tooling_commit }}
-          RELEASE_DRAFT_ID: ${{ needs.prepare-release-draft.outputs.draft_id }}
-          RELEASE_MODE: ${{ needs.bind-release.outputs.mode }}
-          RELEASE_BODY_SHA256: ${{ needs.prepare-release-draft.outputs.body_sha256 }}
-          RELEASE_BASELINE_TAG: ${{ needs.bind-release.outputs.baseline_tag }}
-          RELEASE_SOURCE_RUN_ID: ${{ needs.bind-release.outputs.source_run_id }}
-          COORDINATOR_RUN_ID: ${{ github.run_id }}
-          COORDINATOR_RUN_ATTEMPT: ${{ github.run_attempt }}
-          REPOSITORY: ${{ github.repository }}
-          REPOSITORY_ID: ${{ github.repository_id }}
-          WORKFLOW_REF: ${{ github.ref }}
-          WORKFLOW_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          DISPATCH_NONCE=$(openssl rand -hex 32)
-          printf '%s' "$DISPATCH_NONCE" | grep -Eq '^[0-9a-f]{64}$'
-          BINDING=$(jq -cnS \
-            --arg repository "$REPOSITORY" \
-            --arg repositoryId "$REPOSITORY_ID" \
-            --arg coordinatorRunId "$COORDINATOR_RUN_ID" \
-            --arg coordinatorRunAttempt "$COORDINATOR_RUN_ATTEMPT" \
-            --arg workflowRef "$WORKFLOW_REF" \
-            --arg workflowSha "$WORKFLOW_SHA" \
-            --arg childWorkflowRef "$RELEASE_WORKFLOW_REF" \
-            --arg tag "$RELEASE_TAG" \
-            --arg desktopVersion "$DESKTOP_VERSION" \
-            --arg commit "$RELEASE_COMMIT" \
-            --arg toolingCommit "$RELEASE_TOOLING_COMMIT" \
-            --arg draftId "$RELEASE_DRAFT_ID" \
-            --arg mode "$RELEASE_MODE" \
-            --arg draftBodySha256 "$RELEASE_BODY_SHA256" \
-            --arg baselineTag "$RELEASE_BASELINE_TAG" \
-            --arg sourceRunId "$RELEASE_SOURCE_RUN_ID" \
-            --arg nonce "$DISPATCH_NONCE" \
-            '{schemaVersion: 1, repository: $repository, repositoryId: $repositoryId, coordinatorRunId: $coordinatorRunId, coordinatorRunAttempt: $coordinatorRunAttempt, workflowRef: $workflowRef, workflowSha: $workflowSha, childWorkflowRef: $childWorkflowRef, tag: $tag, desktopVersion: $desktopVersion, commit: $commit, toolingCommit: $toolingCommit, draftId: $draftId, mode: $mode, draftBodySha256: $draftBodySha256, baselineTag: $baselineTag, sourceRunId: $sourceRunId, nonce: $nonce}')
-          BINDING_SHA256=$(printf '%s' "$BINDING" | sha256sum | awk '{print $1}')
-          printf '%s' "$BINDING_SHA256" | grep -Eq '^[0-9a-f]{64}$'
-          ARTIFACT_NAME="desktop-dispatch-binding-$COORDINATOR_RUN_ID-$COORDINATOR_RUN_ATTEMPT-$BINDING_SHA256"
-          printf '%s' "$BINDING" > "$RUNNER_TEMP/desktop-dispatch-binding.json"
-          echo "nonce=$DISPATCH_NONCE" >> "$GITHUB_OUTPUT"
-          echo "sha256=$BINDING_SHA256" >> "$GITHUB_OUTPUT"
-          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
-      - name: Upload exact child dispatch binding
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ steps.dispatch-binding.outputs.artifact_name }}
-          path: ${{ runner.temp }}/desktop-dispatch-binding.json
-          if-no-files-found: error
-          compression-level: 0
-          retention-days: 1
-      - name: Dispatch and await environment-bound desktop transaction
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.bind-release.outputs.tag }}
-          DESKTOP_VERSION: ${{ needs.bind-release.outputs.desktop_version }}
-          RELEASE_COMMIT: ${{ needs.bind-release.outputs.commit }}
-          RELEASE_WORKFLOW_REF: ${{ needs.bind-release.outputs.workflow_ref }}
-          RELEASE_TOOLING_COMMIT: ${{ needs.bind-release.outputs.tooling_commit }}
-          RELEASE_DRAFT_ID: ${{ needs.prepare-release-draft.outputs.draft_id }}
-          RELEASE_MODE: ${{ needs.bind-release.outputs.mode }}
-          RELEASE_BODY_SHA256: ${{ needs.prepare-release-draft.outputs.body_sha256 }}
-          RELEASE_BASELINE_TAG: ${{ needs.bind-release.outputs.baseline_tag }}
-          RELEASE_SOURCE_RUN_ID: ${{ needs.bind-release.outputs.source_run_id }}
-          COORDINATOR_RUN_ID: ${{ github.run_id }}
-          COORDINATOR_RUN_ATTEMPT: ${{ github.run_attempt }}
-          DISPATCH_NONCE: ${{ steps.dispatch-binding.outputs.nonce }}
-          DISPATCH_BINDING_SHA256: ${{ steps.dispatch-binding.outputs.sha256 }}
-        run: |
-          set -euo pipefail
-          EXPECTED_TITLE="Desktop release $RELEASE_TAG via $COORDINATOR_RUN_ID.$COORDINATOR_RUN_ATTEMPT binding $DISPATCH_BINDING_SHA256"
-          gh workflow run desktop-release.yml \
-            --repo "$GITHUB_REPOSITORY" \
-            --ref "$RELEASE_WORKFLOW_REF" \
-            -f tag="$RELEASE_TAG" \
-            -f desktop_version="$DESKTOP_VERSION" \
-            -f commit="$RELEASE_COMMIT" \
-            -f tooling_commit="$RELEASE_TOOLING_COMMIT" \
-            -f draft_id="$RELEASE_DRAFT_ID" \
-            -f mode="$RELEASE_MODE" \
-            -f draft_body_sha256="$RELEASE_BODY_SHA256" \
-            -f baseline_tag="$RELEASE_BASELINE_TAG" \
-            -f source_run_id="$RELEASE_SOURCE_RUN_ID" \
-            -f coordinator_run_id="$COORDINATOR_RUN_ID" \
-            -f coordinator_run_attempt="$COORDINATOR_RUN_ATTEMPT" \
-            -f dispatch_nonce="$DISPATCH_NONCE" \
-            -f dispatch_binding_sha256="$DISPATCH_BINDING_SHA256"
-          DESKTOP_RUN_ID=''
-          for attempt in $(seq 1 12); do
-            DESKTOP_RUNS=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow desktop-release.yml \
-              --event workflow_dispatch --limit 20 --json databaseId,displayTitle)
-            DESKTOP_RUN_ID=$(printf '%s' "$DESKTOP_RUNS" | jq -r --arg title "$EXPECTED_TITLE" \
-              '[.[] | select(.displayTitle == $title)] | first | .databaseId // empty')
-            if [ -n "$DESKTOP_RUN_ID" ]; then
-              break
-            fi
-            sleep 5
-          done
-          test -n "$DESKTOP_RUN_ID"
-          gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status
+      actions: read
+      contents: write
+    uses: ./.github/workflows/desktop-release.yml
+    with:
+      tag: ${{ needs.bind-release.outputs.tag }}
+      desktop_version: ${{ needs.bind-release.outputs.desktop_version }}
+      commit: ${{ needs.bind-release.outputs.commit }}
+      tooling_commit: ${{ needs.bind-release.outputs.tooling_commit }}
+      draft_id: ${{ needs.prepare-release-draft.outputs.draft_id }}
+      mode: ${{ needs.bind-release.outputs.mode }}
+      draft_body_sha256: ${{ needs.prepare-release-draft.outputs.body_sha256 }}
+      baseline_tag: ${{ needs.bind-release.outputs.baseline_tag }}
+      source_run_id: ${{ needs.bind-release.outputs.source_run_id }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,8 +1,7 @@
 name: Desktop release
-run-name: Desktop release ${{ inputs.tag }} via ${{ inputs.coordinator_run_id }}.${{ inputs.coordinator_run_attempt }} binding ${{ inputs.dispatch_binding_sha256 }}
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       tag:
         description: Exact enduragent-desktop release tag
@@ -40,30 +39,9 @@ on:
         description: Failed source run id or none
         required: true
         type: string
-      coordinator_run_id:
-        description: Parent release workflow run id
-        required: true
-        type: string
-      coordinator_run_attempt:
-        description: Parent release workflow attempt
-        required: true
-        type: string
-      dispatch_nonce:
-        description: Coordinator-generated one-time dispatch nonce
-        required: true
-        type: string
-      dispatch_binding_sha256:
-        description: SHA-256 of the coordinator-sealed child dispatch tuple
-        required: true
-        type: string
 permissions:
   actions: read
   contents: read
-
-concurrency:
-  group: stable-desktop
-  cancel-in-progress: false
-  queue: max
 
 jobs:
   authorize-coordinator:
@@ -85,12 +63,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Bind dispatch to the active release coordinator
+      - name: Bind call to the active release coordinator
         id: authorize
         env:
           GH_TOKEN: ${{ github.token }}
-          COORDINATOR_RUN_ID: ${{ inputs.coordinator_run_id }}
-          COORDINATOR_RUN_ATTEMPT: ${{ inputs.coordinator_run_attempt }}
           RELEASE_TAG: ${{ inputs.tag }}
           DESKTOP_VERSION: ${{ inputs.desktop_version }}
           RELEASE_COMMIT: ${{ inputs.commit }}
@@ -100,27 +76,29 @@ jobs:
           RELEASE_BODY_SHA256: ${{ inputs.draft_body_sha256 }}
           RELEASE_BASELINE_TAG: ${{ inputs.baseline_tag }}
           SOURCE_RUN_ID: ${{ inputs.source_run_id }}
-          DISPATCH_NONCE: ${{ inputs.dispatch_nonce }}
-          DISPATCH_BINDING_SHA256: ${{ inputs.dispatch_binding_sha256 }}
           WORKFLOW_REF: ${{ github.ref }}
           WORKFLOW_REF_NAME: ${{ github.ref_name }}
           WORKFLOW_COMMIT: ${{ github.sha }}
-          RUN_ACTOR: ${{ github.actor }}
-          RUN_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          CURRENT_RUN_ATTEMPT: ${{ github.run_attempt }}
+          EVENT_NAME: ${{ github.event_name }}
+          CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
+          CALLER_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          CALLED_WORKFLOW_REF: ${{ job.workflow_ref }}
+          CALLED_WORKFLOW_SHA: ${{ job.workflow_sha }}
+          CALLED_WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
+          CALLED_WORKFLOW_FILE_PATH: ${{ job.workflow_file_path }}
           REPOSITORY_ID: ${{ github.repository_id }}
         run: |
           set -euo pipefail
-          test "$RUN_ACTOR" = 'github-actions[bot]'
-          test "$RUN_TRIGGERING_ACTOR" = 'github-actions[bot]'
-          printf '%s' "$COORDINATOR_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
-          printf '%s' "$COORDINATOR_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$CURRENT_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+          printf '%s' "$CURRENT_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$DESKTOP_VERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
           printf '%s' "$RELEASE_DRAFT_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$RELEASE_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
           printf '%s' "$RELEASE_TOOLING_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
           printf '%s' "$RELEASE_BODY_SHA256" | grep -Eq '^[0-9a-f]{64}$'
-          printf '%s' "$DISPATCH_NONCE" | grep -Eq '^[0-9a-f]{64}$'
-          printf '%s' "$DISPATCH_BINDING_SHA256" | grep -Eq '^[0-9a-f]{64}$'
+          test "$EVENT_NAME" = 'workflow_dispatch'
           test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"
           CURRENT_RECOVERY_REVISION=none
           if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then
@@ -133,69 +111,12 @@ jobs:
             test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${CURRENT_RECOVERY_REVISION}"
             test "$WORKFLOW_REF" = "refs/tags/$WORKFLOW_REF_NAME"
           fi
-          COORDINATOR=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID")
-          test "$(printf '%s' "$COORDINATOR" | jq -r '.path')" = '.github/workflows/desktop-release-coordinator.yml'
-          test "$(printf '%s' "$COORDINATOR" | jq -r '.run_attempt')" = "$COORDINATOR_RUN_ATTEMPT"
-          test "$(printf '%s' "$COORDINATOR" | jq -r '.status')" = 'in_progress'
-          test "$(printf '%s' "$COORDINATOR" | jq -r '.head_sha')" = "$RELEASE_TOOLING_COMMIT"
-          test "$(printf '%s' "$COORDINATOR" | jq -r '.head_branch')" = "$WORKFLOW_REF_NAME"
-          test "$(printf '%s' "$COORDINATOR" | jq -r '.event')" = 'workflow_dispatch'
-          BINDING=$(jq -cnS \
-            --arg repository "$GITHUB_REPOSITORY" \
-            --arg repositoryId "$REPOSITORY_ID" \
-            --arg coordinatorRunId "$COORDINATOR_RUN_ID" \
-            --arg coordinatorRunAttempt "$COORDINATOR_RUN_ATTEMPT" \
-            --arg workflowRef "$WORKFLOW_REF" \
-            --arg workflowSha "$WORKFLOW_COMMIT" \
-            --arg childWorkflowRef "$WORKFLOW_REF_NAME" \
-            --arg tag "$RELEASE_TAG" \
-            --arg desktopVersion "$DESKTOP_VERSION" \
-            --arg commit "$RELEASE_COMMIT" \
-            --arg toolingCommit "$RELEASE_TOOLING_COMMIT" \
-            --arg draftId "$RELEASE_DRAFT_ID" \
-            --arg mode "$RELEASE_MODE" \
-            --arg draftBodySha256 "$RELEASE_BODY_SHA256" \
-            --arg baselineTag "$RELEASE_BASELINE_TAG" \
-            --arg sourceRunId "$SOURCE_RUN_ID" \
-            --arg nonce "$DISPATCH_NONCE" \
-            '{schemaVersion: 1, repository: $repository, repositoryId: $repositoryId, coordinatorRunId: $coordinatorRunId, coordinatorRunAttempt: $coordinatorRunAttempt, workflowRef: $workflowRef, workflowSha: $workflowSha, childWorkflowRef: $childWorkflowRef, tag: $tag, desktopVersion: $desktopVersion, commit: $commit, toolingCommit: $toolingCommit, draftId: $draftId, mode: $mode, draftBodySha256: $draftBodySha256, baselineTag: $baselineTag, sourceRunId: $sourceRunId, nonce: $nonce}')
-          test "$(printf '%s' "$BINDING" | sha256sum | awk '{print $1}')" = "$DISPATCH_BINDING_SHA256"
-          BINDING_ARTIFACT_NAME="desktop-dispatch-binding-$COORDINATOR_RUN_ID-$COORDINATOR_RUN_ATTEMPT-$DISPATCH_BINDING_SHA256"
-          COORDINATOR_ARTIFACTS=$(gh api --paginate --slurp \
-            "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID/artifacts?per_page=100")
-          printf '%s' "$COORDINATOR_ARTIFACTS" | jq -e \
-            'type == "array" and length > 0 and ([.[].artifacts[]] | length) == .[0].total_count' >/dev/null
-          BINDING_ARTIFACT=$(printf '%s' "$COORDINATOR_ARTIFACTS" | jq -cer --arg name "$BINDING_ARTIFACT_NAME" \
-            '[.[].artifacts[] | select(.name == $name)] | select(length == 1) | .[0]')
-          printf '%s' "$BINDING_ARTIFACT" | jq -e \
-            --arg run "$COORDINATOR_RUN_ID" \
-            --arg repo "$REPOSITORY_ID" \
-            --arg branch "$WORKFLOW_REF_NAME" \
-            --arg sha "$WORKFLOW_COMMIT" '
-            (.id | type) == "number" and .id > 0 and
-            .expired == false and
-            (.size_in_bytes | type) == "number" and .size_in_bytes > 0 and
-            (.digest | type) == "string" and (.digest | test("^sha256:[0-9a-f]{64}$")) and
-            (.workflow_run.id | tostring) == $run and
-            (.workflow_run.repository_id | tostring) == $repo and
-            (.workflow_run.head_repository_id | tostring) == $repo and
-            .workflow_run.head_branch == $branch and
-            .workflow_run.head_sha == $sha
-          ' >/dev/null
-          CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")
-          test "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.id | tostring')" = "$RELEASE_DRAFT_ID"
-          test "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.tag_name')" = "$RELEASE_TAG"
-          test "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.prerelease')" = 'false'
-          if [ "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.draft')" = 'false' ]; then
-            test "$SOURCE_RUN_ID" != 'none'
-            if [ "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.body')" != 'Desktop update validation is in progress. This release is not yet generally available.' ]; then
-              CANDIDATE_BODY_SHA256=$(printf '%s' "$CANDIDATE_RELEASE" | jq -j '.body' | shasum -a 256 | awk '{print $1}')
-              test "$CANDIDATE_BODY_SHA256" = "$RELEASE_BODY_SHA256"
-              LATEST_RELEASE=$(gh api -H 'Cache-Control: no-cache' "repos/$GITHUB_REPOSITORY/releases/latest")
-              test "$(printf '%s' "$LATEST_RELEASE" | jq -r '.id | tostring')" = "$RELEASE_DRAFT_ID"
-              test "$(printf '%s' "$LATEST_RELEASE" | jq -r '.tag_name')" = "$RELEASE_TAG"
-            fi
-          fi
+          test "$CALLER_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/desktop-release-coordinator.yml@$WORKFLOW_REF"
+          test "$CALLER_WORKFLOW_SHA" = "$WORKFLOW_COMMIT"
+          test "$CALLED_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/desktop-release.yml@$WORKFLOW_REF"
+          test "$CALLED_WORKFLOW_SHA" = "$WORKFLOW_COMMIT"
+          test "$CALLED_WORKFLOW_REPOSITORY" = "$GITHUB_REPOSITORY"
+          test "$CALLED_WORKFLOW_FILE_PATH" = '.github/workflows/desktop-release.yml'
           if [ "$SOURCE_RUN_ID" = 'none' ]; then
             for output in source_run_id source_run_attempt artifact_name artifact_id artifact_digest baseline_artifact_name baseline_artifact_id baseline_artifact_digest; do
               echo "$output=none" >> "$GITHUB_OUTPUT"
@@ -204,17 +125,27 @@ jobs:
           fi
           printf '%s' "$SOURCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
           test "$SOURCE_RUN_ID" != "$GITHUB_RUN_ID"
-          test "$SOURCE_RUN_ID" != "$COORDINATOR_RUN_ID"
           test "$RELEASE_MODE" = 'steady'
           test "$RELEASE_TOOLING_COMMIT" != "$RELEASE_COMMIT"
           test "$CURRENT_RECOVERY_REVISION" != 'none'
           SOURCE=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")
           test "$(printf '%s' "$SOURCE" | jq -r '.repository.full_name')" = "$GITHUB_REPOSITORY"
           test "$(printf '%s' "$SOURCE" | jq -r '.head_repository.full_name')" = "$GITHUB_REPOSITORY"
-          test "$(printf '%s' "$SOURCE" | jq -r '.path')" = '.github/workflows/desktop-release.yml'
+          SOURCE_WORKFLOW_PATH_RAW=$(printf '%s' "$SOURCE" | jq -er '.path')
+          SOURCE_WORKFLOW_PATH="${SOURCE_WORKFLOW_PATH_RAW%%@*}"
+          case "$SOURCE_WORKFLOW_PATH" in
+            .github/workflows/desktop-release.yml)
+              test "$(printf '%s' "$SOURCE" | jq -r '.actor.login')" = 'github-actions[bot]'
+              test "$(printf '%s' "$SOURCE" | jq -r '.triggering_actor.login')" = 'github-actions[bot]'
+              ;;
+            .github/workflows/desktop-release-coordinator.yml)
+              ;;
+            *)
+              echo '::error::Recovery source run used an untrusted workflow'
+              exit 1
+              ;;
+          esac
           test "$(printf '%s' "$SOURCE" | jq -r '.event')" = 'workflow_dispatch'
-          test "$(printf '%s' "$SOURCE" | jq -r '.actor.login')" = 'github-actions[bot]'
-          test "$(printf '%s' "$SOURCE" | jq -r '.triggering_actor.login')" = 'github-actions[bot]'
           test "$(printf '%s' "$SOURCE" | jq -r '.status')" = 'completed'
           test "$(printf '%s' "$SOURCE" | jq -r '.conclusion')" = 'failure'
           SOURCE_RUN_ATTEMPT=$(printf '%s' "$SOURCE" | jq -er '.run_attempt | tostring')
@@ -222,11 +153,22 @@ jobs:
           SOURCE_HEAD_BRANCH=$(printf '%s' "$SOURCE" | jq -er '.head_branch')
           SOURCE_HEAD_SHA=$(printf '%s' "$SOURCE" | jq -er '.head_sha')
           printf '%s' "$SOURCE_HEAD_SHA" | grep -Eq '^[0-9a-f]{40}$'
-          SOURCE_RECOVERY_REVISION="${SOURCE_HEAD_BRANCH#"${RELEASE_TAG}-recovery."}"
-          printf '%s' "$SOURCE_RECOVERY_REVISION" | grep -Eq '^[1-9][0-9]*$'
-          test "$SOURCE_HEAD_BRANCH" = "${RELEASE_TAG}-recovery.${SOURCE_RECOVERY_REVISION}"
-          test "$SOURCE_RECOVERY_REVISION" != "$CURRENT_RECOVERY_REVISION"
-          test "$(printf '%s\n%s\n' "$SOURCE_RECOVERY_REVISION" "$CURRENT_RECOVERY_REVISION" | sort -n | head -1)" = "$SOURCE_RECOVERY_REVISION"
+          case "$SOURCE_WORKFLOW_PATH_RAW" in
+            "$SOURCE_WORKFLOW_PATH"|"$SOURCE_WORKFLOW_PATH@$SOURCE_HEAD_BRANCH"|"$SOURCE_WORKFLOW_PATH@refs/tags/$SOURCE_HEAD_BRANCH")
+              ;;
+            *)
+              echo '::error::Recovery source workflow path used an unexpected ref suffix'
+              exit 1
+              ;;
+          esac
+          if [ "$SOURCE_HEAD_BRANCH" = "$RELEASE_TAG" ]; then
+            test "$SOURCE_HEAD_SHA" = "$RELEASE_COMMIT"
+          else
+            SOURCE_RECOVERY_REVISION="${SOURCE_HEAD_BRANCH#"${RELEASE_TAG}-recovery."}"
+            printf '%s' "$SOURCE_RECOVERY_REVISION" | grep -Eq '^[1-9][0-9]*$'
+            test "$SOURCE_HEAD_BRANCH" = "${RELEASE_TAG}-recovery.${SOURCE_RECOVERY_REVISION}"
+            test "$SOURCE_RECOVERY_REVISION" -lt "$CURRENT_RECOVERY_REVISION"
+          fi
           git fetch --force --no-tags origin \
             "refs/tags/$SOURCE_HEAD_BRANCH:refs/tags/$SOURCE_HEAD_BRANCH" \
             main:refs/remotes/origin/main
@@ -240,14 +182,14 @@ jobs:
             'type == "array" and length > 0 and ([.[].jobs[]] | length) == .[0].total_count' >/dev/null
           for job_name in sign-macos verify-macos-envelope stage-private-draft publish-assets; do
             printf '%s' "$SOURCE_JOBS" | jq -e --arg job "$job_name" '
-              [.[].jobs[] | select(.name == $job)] as $matches |
+              [.[].jobs[] | select((.name | split(" / ") | last) == $job)] as $matches |
               ($matches | length) == 1 and
               $matches[0].status == "completed" and
               $matches[0].conclusion == "success"
             ' >/dev/null
           done
           printf '%s' "$SOURCE_JOBS" | jq -e '
-            [.[].jobs[] | select(.name == "activate-release")] as $matches |
+            [.[].jobs[] | select((.name | split(" / ") | last) == "activate-release")] as $matches |
             ($matches | length) == 1 and
             $matches[0].status == "completed" and
             $matches[0].conclusion != "success"
@@ -1031,6 +973,29 @@ jobs:
           printf '%s' "$EVIDENCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
           printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
           test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
+      - name: Revalidate recoverable candidate state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_DRAFT_ID: ${{ inputs.draft_id }}
+          RELEASE_BODY_SHA256: ${{ inputs.draft_body_sha256 }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")
+          test "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.id | tostring')" = "$RELEASE_DRAFT_ID"
+          test "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.tag_name')" = "$RELEASE_TAG"
+          test "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.prerelease')" = 'false'
+          if [ "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.draft')" = 'false' ]; then
+            test "$SOURCE_RUN_ID" != 'none'
+            if [ "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.body')" != 'Desktop update validation is in progress. This release is not yet generally available.' ]; then
+              CANDIDATE_BODY_SHA256=$(printf '%s' "$CANDIDATE_RELEASE" | jq -j '.body' | shasum -a 256 | awk '{print $1}')
+              test "$CANDIDATE_BODY_SHA256" = "$RELEASE_BODY_SHA256"
+              LATEST_RELEASE=$(gh api -H 'Cache-Control: no-cache' "repos/$GITHUB_REPOSITORY/releases/latest")
+              test "$(printf '%s' "$LATEST_RELEASE" | jq -r '.id | tostring')" = "$RELEASE_DRAFT_ID"
+              test "$(printf '%s' "$LATEST_RELEASE" | jq -r '.tag_name')" = "$RELEASE_TAG"
+            fi
+          fi
       - name: Upload updater envelope to the private draft
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -52,7 +52,7 @@ describe("desktop release workflow policy", () => {
     expect(inspect(source)).toEqual([]);
     expect(source.coordinator).toContain("^enduragent-desktop@");
     expect(source.coordinator).toContain('git show "$COMMIT:apps/desktop/package.json"');
-    expect(source.coordinator).toContain('--ref "$RELEASE_WORKFLOW_REF"');
+    expect(source.coordinator).toContain("uses: ./.github/workflows/desktop-release.yml");
     expect(source.desktop).toContain(".github/workflows/desktop-release-coordinator.yml");
     expect(source.desktop).not.toMatch(/\bnpm_(?:version|integrity|attestation_url)\b/u);
     expect(source.version).toContain('DESKTOP_TAG="enduragent-desktop@$DESKTOP_VERSION"');
@@ -141,7 +141,7 @@ describe("desktop release workflow policy", () => {
     const mutations = [
       replaceRequired(
         source.coordinator,
-        "actions/runs/$SOURCE_RUN_ID/jobs?per_page=100",
+        "actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_ATTEMPT/jobs?per_page=100",
         "actions/runs/$SOURCE_RUN_ID/jobs?per_page=1",
       ),
       replaceRequired(
@@ -153,6 +153,167 @@ describe("desktop release workflow policy", () => {
         source.coordinator,
         'test "$(printf \'%s\' "$ARTIFACT" | jq -r \'.workflow_run.head_sha\')" = "$SOURCE_SHA"',
         "true",
+      ),
+      replaceRequired(
+        source.coordinator,
+        'test "$(printf \'%s\' "$SOURCE_RUN" | jq -r \'.head_repository.full_name\')" = "$GITHUB_REPOSITORY"',
+        "true",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "          REPOSITORY_ID: ${{ github.repository_id }}",
+        "          REPOSITORY_ID: ${{ github.repository }}",
+      ),
+      source.coordinator.replaceAll(
+        ".workflow_run.head_repository_id",
+        ".workflow_run.repository_id",
+      ),
+    ];
+    for (const coordinator of mutations) {
+      expectIssue(
+        { ...source, coordinator },
+        "independently validate source run, job, and artifact provenance",
+      );
+    }
+  });
+
+  it("allows only legacy-bot or reusable-coordinator source provenance in coordinator preflight", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.coordinator,
+        'SOURCE_WORKFLOW_PATH="${SOURCE_WORKFLOW_PATH_RAW%%@*}"',
+        'SOURCE_WORKFLOW_PATH="$SOURCE_WORKFLOW_PATH_RAW"',
+      ),
+      replaceRequired(
+        source.coordinator,
+        "              .github/workflows/desktop-release.yml)",
+        "              .github/workflows/release.yml)",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "              .github/workflows/desktop-release-coordinator.yml)\n                ;;",
+        "              .github/workflows/desktop-release-coordinator.yml)\n                ;;\n              .github/workflows/release.yml)\n                ;;",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "                test \"$(printf '%s' \"$SOURCE_RUN\" | jq -r '.actor.login')\" = 'github-actions[bot]'",
+        "                true",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "                test \"$(printf '%s' \"$SOURCE_RUN\" | jq -r '.triggering_actor.login')\" = 'github-actions[bot]'",
+        "                true",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "              .github/workflows/desktop-release-coordinator.yml)\n                ;;",
+        "              .github/workflows/desktop-release-coordinator.yml)\n                test \"$(printf '%s' \"$SOURCE_RUN\" | jq -r '.actor.login')\" = 'github-actions[bot]'\n                ;;",
+      ),
+      replaceRequired(
+        source.coordinator,
+        '"$SOURCE_WORKFLOW_PATH"|"$SOURCE_WORKFLOW_PATH@$SOURCE_HEAD"|"$SOURCE_WORKFLOW_PATH@refs/tags/$SOURCE_HEAD")',
+        '"$SOURCE_WORKFLOW_PATH"*)',
+      ),
+      replaceRequired(
+        source.coordinator,
+        "            test \"$(printf '%s' \"$SOURCE_RUN\" | jq -r '.event')\" = 'workflow_dispatch'",
+        "            true",
+      ),
+      replaceRequired(
+        source.coordinator,
+        '            test "$(printf \'%s\' "$SOURCE_RUN" | jq -r \'.repository.full_name\')" = "$GITHUB_REPOSITORY"',
+        "            true",
+      ),
+    ];
+    for (const coordinator of mutations) {
+      expectIssue(
+        { ...source, coordinator },
+        "independently validate source run, job, and artifact provenance",
+      );
+    }
+  });
+
+  it("accepts only the candidate or an earlier recovery source in coordinator preflight", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(source.coordinator, 'test "$SOURCE_SHA" = "$COMMIT"', "true"),
+      replaceRequired(
+        source.coordinator,
+        "printf '%s' \"$SOURCE_REVISION\" | grep -Eq '^[1-9][0-9]*$'",
+        "printf '%s' \"$SOURCE_REVISION\" | grep -Eq '^[0-9]+$'",
+      ),
+      replaceRequired(
+        source.coordinator,
+        'test "$SOURCE_HEAD" = "${TAG}-recovery.${SOURCE_REVISION}"',
+        "true",
+      ),
+      replaceRequired(
+        source.coordinator,
+        'test "$SOURCE_REVISION" -lt "$CURRENT_RECOVERY_REVISION"',
+        'test "$SOURCE_REVISION" != "$CURRENT_RECOVERY_REVISION"',
+      ),
+      replaceRequired(
+        source.coordinator,
+        'test "$SOURCE_REVISION" -lt "$CURRENT_RECOVERY_REVISION"',
+        'test "$SOURCE_REVISION" -le "$CURRENT_RECOVERY_REVISION"',
+      ),
+      replaceRequired(
+        source.coordinator,
+        'test "$(git rev-parse "refs/tags/$SOURCE_HEAD^{commit}")" = "$SOURCE_SHA"',
+        "true",
+      ),
+      replaceRequired(
+        source.coordinator,
+        'git merge-base --is-ancestor "$COMMIT" "$SOURCE_SHA"',
+        'git merge-base --is-ancestor "$SOURCE_SHA" "$COMMIT"',
+      ),
+      replaceRequired(
+        source.coordinator,
+        'git merge-base --is-ancestor "$SOURCE_SHA" "$TOOLING_COMMIT"',
+        'git merge-base --is-ancestor "$TOOLING_COMMIT" "$SOURCE_SHA"',
+      ),
+      replaceRequired(
+        source.coordinator,
+        'git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main',
+        'git merge-base --is-ancestor "$COMMIT" refs/remotes/origin/main',
+      ),
+    ];
+    for (const coordinator of mutations) {
+      expectIssue(
+        { ...source, coordinator },
+        "independently validate source run, job, and artifact provenance",
+      );
+    }
+  });
+
+  it("requires exact terminal source jobs and a non-successful activation in coordinator preflight", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.coordinator,
+        '[.[].jobs[] | select((.name | split(" / ") | last) == $name)] as $matches |',
+        "[.[].jobs[] | select(.name | contains($name))] as $matches |",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "                ($matches | length) == 1 and",
+        "                ($matches | length) > 0 and",
+      ),
+      replaceRequired(
+        source.coordinator,
+        '[.[].jobs[] | select((.name | split(" / ") | last) == "activate-release")] as $matches |',
+        '[.[].jobs[] | select(.name | contains("activate-release"))] as $matches |',
+      ),
+      replaceRequired(
+        source.coordinator,
+        '[.[].jobs[] | select((.name | split(" / ") | last) == "activate-release")] as $matches |\n              ($matches | length) == 1 and',
+        '[.[].jobs[] | select((.name | split(" / ") | last) == "activate-release")] as $matches |\n              ($matches | length) > 0 and',
+      ),
+      replaceRequired(
+        source.coordinator,
+        '$matches[0].conclusion != "success"',
+        '$matches[0].conclusion == "failure"',
       ),
     ];
     for (const coordinator of mutations) {
@@ -268,62 +429,58 @@ describe("desktop release workflow policy", () => {
     expectIssue({ ...source, coordinator }, "never create a missing candidate release");
   });
 
-  it("requires one bound-ref, npm-independent child dispatch and awaits it", () => {
-    const source = sources();
-    const wrongRef = replaceRequired(
-      source.coordinator,
-      '--ref "$RELEASE_WORKFLOW_REF"',
-      '--ref "$RELEASE_TAG"',
-    );
-    const wrongCandidateCommit = replaceRequired(
-      source.coordinator,
-      '-f commit="$RELEASE_COMMIT"',
-      '-f commit="$RELEASE_TOOLING_COMMIT"',
-    );
-    const npmCoupled = replaceRequired(
-      source.coordinator,
-      '            -f desktop_version="$DESKTOP_VERSION" \\\n',
-      '            -f npm_version="$DESKTOP_VERSION" \\\n            -f desktop_version="$DESKTOP_VERSION" \\\n',
-    );
-    const notAwaited = replaceRequired(
-      source.coordinator,
-      'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
-      'gh run view "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY"',
-    );
-    for (const coordinator of [wrongRef, wrongCandidateCommit, npmCoupled, notAwaited]) {
-      expectIssue({ ...source, coordinator }, "npm-independent child tuple");
-    }
-  });
-
-  it("seals exactly one nonce-bearing full child dispatch tuple", () => {
+  it("calls one exact secretless reusable workflow tuple after the draft safeguard", () => {
     const source = sources();
     const mutations = [
       replaceRequired(
         source.coordinator,
-        "DISPATCH_NONCE=$(openssl rand -hex 32)",
-        "DISPATCH_NONCE=0000",
+        "    uses: ./.github/workflows/desktop-release.yml",
+        "    uses: ./.github/workflows/release.yml",
       ),
       replaceRequired(
         source.coordinator,
-        "sourceRunId: $sourceRunId, nonce: $nonce",
-        "nonce: $nonce",
+        "    needs: [bind-release, prepare-release-draft]",
+        "    needs: bind-release",
       ),
       replaceRequired(
         source.coordinator,
-        "          retention-days: 1",
-        "          retention-days: 90",
+        "      commit: ${{ needs.bind-release.outputs.commit }}",
+        "      commit: ${{ needs.bind-release.outputs.tooling_commit }}",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "      desktop_version: ${{ needs.bind-release.outputs.desktop_version }}",
+        "      npm_version: forbidden\n      desktop_version: ${{ needs.bind-release.outputs.desktop_version }}",
+      ),
+      replaceRequired(
+        source.coordinator,
+        "    uses: ./.github/workflows/desktop-release.yml\n    with:",
+        "    uses: ./.github/workflows/desktop-release.yml\n    secrets: inherit\n    with:",
       ),
     ];
     for (const coordinator of mutations) {
-      expectIssue({ ...source, coordinator }, "seal exactly one nonce-bound full dispatch tuple");
+      expectIssue({ ...source, coordinator }, "secretless npm-independent reusable workflow tuple");
     }
+  });
 
-    const unboundDispatch = replaceRequired(
+  it("holds stable concurrency and least privilege on the reusable call job", () => {
+    const source = sources();
+    const excessivePermissions = replaceRequired(
       source.coordinator,
-      '-f dispatch_binding_sha256="$DISPATCH_BINDING_SHA256"',
-      '-f dispatch_binding_sha256="$RELEASE_BODY_SHA256"',
+      "  desktop-release:\n    needs: [bind-release, prepare-release-draft]\n    concurrency:\n      group: stable-desktop\n      cancel-in-progress: false\n      queue: max\n    permissions:\n      actions: read\n      contents: write",
+      "  desktop-release:\n    needs: [bind-release, prepare-release-draft]\n    concurrency:\n      group: stable-desktop\n      cancel-in-progress: false\n      queue: max\n    permissions:\n      actions: write\n      contents: write",
     );
-    expectIssue({ ...source, coordinator: unboundDispatch }, "npm-independent child tuple");
+    expectIssue(
+      { ...source, coordinator: excessivePermissions },
+      "permissions are not least-privilege",
+    );
+
+    const cancelling = replaceRequired(
+      source.coordinator,
+      "      cancel-in-progress: false\n      queue: max",
+      "      cancel-in-progress: true\n      queue: max",
+    );
+    expectIssue({ ...source, coordinator: cancelling }, "stable-desktop concurrency");
   });
 
   it("requires the child to accept only desktop release inputs", () => {
@@ -337,7 +494,13 @@ describe("desktop release workflow policy", () => {
     expectIssue({ ...source, desktop }, "must not consume npm release identity");
   });
 
-  it("requires the child source run id in the frozen dispatch tuple", () => {
+  it("keeps the desktop workflow reusable-call-only", () => {
+    const source = sources();
+    const desktop = replaceRequired(source.desktop, "  workflow_call:", "  workflow_dispatch:");
+    expectIssue({ ...source, desktop }, "workflow_call-only");
+  });
+
+  it("requires the child source run id in the frozen reusable tuple", () => {
     const source = sources();
     const desktop = replaceRequired(
       source.desktop,
@@ -345,51 +508,66 @@ describe("desktop release workflow policy", () => {
       "",
     );
     expectIssue({ ...source, desktop }, "only the frozen desktop release tuple");
-    expectIssue({ ...source, desktop }, "require string input source_run_id");
+    expectIssue({ ...source, desktop }, "workflow_call must require string input source_run_id");
   });
 
-  it("requires bot actors and one coordinator-owned dispatch binding artifact", () => {
+  it("rejects obsolete cross-run dispatch binding machinery", () => {
     const source = sources();
     const mutations = [
-      replaceRequired(source.desktop, "test \"$RUN_ACTOR\" = 'github-actions[bot]'", "true"),
       replaceRequired(
         source.desktop,
-        "test \"$RUN_TRIGGERING_ACTOR\" = 'github-actions[bot]'",
-        "true",
+        "      source_run_id:\n",
+        "      dispatch_nonce:\n        description: Obsolete nonce\n        required: true\n        type: string\n      source_run_id:\n",
       ),
-      replaceRequired(source.desktop, "sourceRunId: $sourceRunId, nonce: $nonce", "nonce: $nonce"),
       replaceRequired(
         source.desktop,
-        "[.[].artifacts[] | select(.name == $name)] | select(length == 1) | .[0]",
-        "[.[].artifacts[] | select(.name == $name)] | first",
+        "          set -euo pipefail\n          printf '%s' \"$CURRENT_RUN_ID\"",
+        "          set -euo pipefail\n          COORDINATOR_ARTIFACTS=desktop-dispatch-binding\n          printf '%s' \"$CURRENT_RUN_ID\"",
       ),
     ];
     for (const [index, desktop] of mutations.entries()) {
       expect(
         inspect({ ...source, desktop }).some((issue) =>
-          issue.includes(
-            "require bot actors and one coordinator-owned nonce-bound dispatch artifact",
-          ),
+          issue.includes("must not retain obsolete dispatch binding machinery"),
         ),
-        `dispatch authorization mutation ${index}`,
+        `obsolete dispatch mutation ${index}`,
       ).toBe(true);
     }
   });
 
-  it("authorizes only the active desktop coordinator", () => {
+  it("authorizes exact caller and called workflow identities in the same run", () => {
     const source = sources();
-    const wrongPath = replaceRequired(
-      source.desktop,
-      ".github/workflows/desktop-release-coordinator.yml",
-      ".github/workflows/release.yml",
-    );
-    const noAttempt = replaceRequired(
-      source.desktop,
-      'test "$(printf \'%s\' "$COORDINATOR" | jq -r \'.run_attempt\')" = "$COORDINATOR_RUN_ATTEMPT"',
-      "true",
-    );
-    for (const desktop of [wrongPath, noAttempt]) {
-      expectIssue({ ...source, desktop }, "authorize only its active desktop coordinator");
+    const mutations = [
+      replaceRequired(
+        source.desktop,
+        "          CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}",
+        "          CALLER_WORKFLOW_REF: ${{ github.ref }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        "          CALLED_WORKFLOW_REF: ${{ job.workflow_ref }}",
+        "          CALLED_WORKFLOW_REF: ${{ github.workflow_ref }}",
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$CALLER_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/desktop-release-coordinator.yml@$WORKFLOW_REF"',
+        'test "$CALLER_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@$WORKFLOW_REF"',
+      ),
+      replaceRequired(source.desktop, 'test "$CALLER_WORKFLOW_SHA" = "$WORKFLOW_COMMIT"', "true"),
+      replaceRequired(
+        source.desktop,
+        'test "$CALLED_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/desktop-release.yml@$WORKFLOW_REF"',
+        'test "$CALLED_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@$WORKFLOW_REF"',
+      ),
+      replaceRequired(source.desktop, 'test "$CALLED_WORKFLOW_SHA" = "$WORKFLOW_COMMIT"', "true"),
+      replaceRequired(
+        source.desktop,
+        "          REPOSITORY_ID: ${{ github.repository_id }}",
+        "          REPOSITORY_ID: ${{ github.repository }}",
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue({ ...source, desktop }, "same-run active coordinator and called workflow");
     }
   });
 
@@ -411,10 +589,9 @@ describe("desktop release workflow policy", () => {
         'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${CURRENT_RECOVERY_REVISION}"',
         'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.1"',
       ),
-      replaceRequired(source.desktop, "jq -r '.head_branch'", "jq -r '.head_sha'"),
     ];
     for (const desktop of mutations) {
-      expectIssue({ ...source, desktop }, "authorize only its active desktop coordinator");
+      expectIssue({ ...source, desktop }, "same-run active coordinator and called workflow");
     }
   });
 
@@ -422,11 +599,6 @@ describe("desktop release workflow policy", () => {
     const source = sources();
     const mutations = [
       replaceRequired(source.desktop, ".head_repository.full_name", ".repository.full_name"),
-      replaceRequired(
-        source.desktop,
-        "test \"$(printf '%s' \"$SOURCE\" | jq -r '.actor.login')\" = 'github-actions[bot]'",
-        "true",
-      ),
       replaceRequired(
         source.desktop,
         "actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_RUN_ATTEMPT/jobs?per_page=100",
@@ -447,21 +619,178 @@ describe("desktop release workflow policy", () => {
     }
   });
 
-  it("independently admits public recovery only when provisional or exact-final and live-latest", () => {
+  it("allows only legacy-bot or reusable-coordinator source provenance in the authorizer", () => {
     const source = sources();
-    const candidateFetch =
-      '          CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")\n';
-    const lateCandidateFetch = replaceRequired(
-      replaceRequired(source.desktop, candidateFetch, ""),
-      "          printf '%s' \"$SOURCE_RUN_ID\" | grep -Eq '^[1-9][0-9]*$'",
-      `${candidateFetch}          printf '%s' "$SOURCE_RUN_ID" | grep -Eq '^[1-9][0-9]*$'`,
-    );
     const mutations = [
-      lateCandidateFetch,
       replaceRequired(
         source.desktop,
-        "          GH_TOKEN: ${{ github.token }}",
-        '          GH_TOKEN: ""',
+        'SOURCE_WORKFLOW_PATH="${SOURCE_WORKFLOW_PATH_RAW%%@*}"',
+        'SOURCE_WORKFLOW_PATH="$SOURCE_WORKFLOW_PATH_RAW"',
+      ),
+      replaceRequired(
+        source.desktop,
+        "            .github/workflows/desktop-release.yml)",
+        "            .github/workflows/release.yml)",
+      ),
+      replaceRequired(
+        source.desktop,
+        "            .github/workflows/desktop-release-coordinator.yml)\n              ;;",
+        "            .github/workflows/desktop-release-coordinator.yml)\n              ;;\n            .github/workflows/release.yml)\n              ;;",
+      ),
+      replaceRequired(
+        source.desktop,
+        "              test \"$(printf '%s' \"$SOURCE\" | jq -r '.actor.login')\" = 'github-actions[bot]'",
+        "              true",
+      ),
+      replaceRequired(
+        source.desktop,
+        "              test \"$(printf '%s' \"$SOURCE\" | jq -r '.triggering_actor.login')\" = 'github-actions[bot]'",
+        "              true",
+      ),
+      replaceRequired(
+        source.desktop,
+        "            .github/workflows/desktop-release-coordinator.yml)\n              ;;",
+        "            .github/workflows/desktop-release-coordinator.yml)\n              test \"$(printf '%s' \"$SOURCE\" | jq -r '.actor.login')\" = 'github-actions[bot]'\n              ;;",
+      ),
+      replaceRequired(
+        source.desktop,
+        '"$SOURCE_WORKFLOW_PATH"|"$SOURCE_WORKFLOW_PATH@$SOURCE_HEAD_BRANCH"|"$SOURCE_WORKFLOW_PATH@refs/tags/$SOURCE_HEAD_BRANCH")',
+        '"$SOURCE_WORKFLOW_PATH"*)',
+      ),
+      replaceRequired(
+        source.desktop,
+        "          test \"$(printf '%s' \"$SOURCE\" | jq -r '.event')\" = 'workflow_dispatch'",
+        "          true",
+      ),
+      replaceRequired(
+        source.desktop,
+        '          test "$(printf \'%s\' "$SOURCE" | jq -r \'.repository.full_name\')" = "$GITHUB_REPOSITORY"',
+        "          true",
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue(
+        { ...source, desktop },
+        "child must independently validate source run, job, and artifact provenance",
+      );
+    }
+  });
+
+  it("accepts only the candidate or an earlier recovery source in the authorizer", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(source.desktop, 'test "$SOURCE_HEAD_SHA" = "$RELEASE_COMMIT"', "true"),
+      replaceRequired(
+        source.desktop,
+        "printf '%s' \"$SOURCE_RECOVERY_REVISION\" | grep -Eq '^[1-9][0-9]*$'",
+        "printf '%s' \"$SOURCE_RECOVERY_REVISION\" | grep -Eq '^[0-9]+$'",
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$SOURCE_HEAD_BRANCH" = "${RELEASE_TAG}-recovery.${SOURCE_RECOVERY_REVISION}"',
+        "true",
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$SOURCE_RECOVERY_REVISION" -lt "$CURRENT_RECOVERY_REVISION"',
+        'test "$SOURCE_RECOVERY_REVISION" != "$CURRENT_RECOVERY_REVISION"',
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$SOURCE_RECOVERY_REVISION" -lt "$CURRENT_RECOVERY_REVISION"',
+        'test "$SOURCE_RECOVERY_REVISION" -le "$CURRENT_RECOVERY_REVISION"',
+      ),
+      replaceRequired(
+        source.desktop,
+        'test "$(git rev-parse "refs/tags/$SOURCE_HEAD_BRANCH^{commit}")" = "$SOURCE_HEAD_SHA"',
+        "true",
+      ),
+      replaceRequired(
+        source.desktop,
+        'git merge-base --is-ancestor "$RELEASE_COMMIT" "$SOURCE_HEAD_SHA"',
+        'git merge-base --is-ancestor "$SOURCE_HEAD_SHA" "$RELEASE_COMMIT"',
+      ),
+      replaceRequired(
+        source.desktop,
+        'git merge-base --is-ancestor "$SOURCE_HEAD_SHA" "$RELEASE_TOOLING_COMMIT"',
+        'git merge-base --is-ancestor "$RELEASE_TOOLING_COMMIT" "$SOURCE_HEAD_SHA"',
+      ),
+      replaceRequired(
+        source.desktop,
+        'git merge-base --is-ancestor "$SOURCE_HEAD_SHA" refs/remotes/origin/main',
+        'git merge-base --is-ancestor "$RELEASE_COMMIT" refs/remotes/origin/main',
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue(
+        { ...source, desktop },
+        "child must independently validate source run, job, and artifact provenance",
+      );
+    }
+  });
+
+  it("requires exact terminal source jobs and a non-successful activation in the authorizer", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.desktop,
+        '[.[].jobs[] | select((.name | split(" / ") | last) == $job)] as $matches |',
+        "[.[].jobs[] | select(.name | contains($job))] as $matches |",
+      ),
+      replaceRequired(
+        source.desktop,
+        "              ($matches | length) == 1 and",
+        "              ($matches | length) > 0 and",
+      ),
+      replaceRequired(
+        source.desktop,
+        '[.[].jobs[] | select((.name | split(" / ") | last) == "activate-release")] as $matches |',
+        '[.[].jobs[] | select(.name | contains("activate-release"))] as $matches |',
+      ),
+      replaceRequired(
+        source.desktop,
+        '[.[].jobs[] | select((.name | split(" / ") | last) == "activate-release")] as $matches |\n            ($matches | length) == 1 and',
+        '[.[].jobs[] | select((.name | split(" / ") | last) == "activate-release")] as $matches |\n            ($matches | length) > 0 and',
+      ),
+      replaceRequired(
+        source.desktop,
+        '$matches[0].conclusion != "success"',
+        '$matches[0].conclusion == "failure"',
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue(
+        { ...source, desktop },
+        "child must independently validate source run, job, and artifact provenance",
+      );
+    }
+  });
+
+  it("keeps candidate release reads out of the read-only authorizer", () => {
+    const source = sources();
+    const desktop = replaceRequired(
+      source.desktop,
+      "          set -euo pipefail\n          printf '%s' \"$CURRENT_RUN_ID\"",
+      '          set -euo pipefail\n          CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")\n          printf \'%s\' "$CURRENT_RUN_ID"',
+    );
+    expectIssue(
+      { ...source, desktop },
+      "same-run active coordinator and called workflow identities",
+    );
+  });
+
+  it("revalidates recoverable candidate state at the protected staging boundary", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.desktop,
+        "      - name: Revalidate recoverable candidate state\n        env:\n          GH_TOKEN: ${{ github.token }}",
+        '      - name: Revalidate recoverable candidate state\n        env:\n          GH_TOKEN: ""',
+      ),
+      replaceRequired(
+        source.desktop,
+        "          fi\n      - name: Upload updater envelope to the private draft",
+        "          fi\n      - run: echo delayed\n      - name: Upload updater envelope to the private draft",
       ),
       replaceRequired(
         source.desktop,
@@ -502,11 +831,9 @@ describe("desktop release workflow policy", () => {
     for (const [index, desktop] of mutations.entries()) {
       expect(
         inspect({ ...source, desktop }).some((issue) =>
-          issue.includes(
-            "independently admit public recovery only as provisional or live-latest exact-final",
-          ),
+          issue.includes("protected private-draft safeguard must revalidate candidate state"),
         ),
-        `public recovery admission mutation ${index}`,
+        `private-draft safeguard mutation ${index}`,
       ).toBe(true);
     }
   });
@@ -876,7 +1203,7 @@ describe("desktop release workflow policy", () => {
       'test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"',
       "true",
     );
-    expectIssue({ ...source, desktop: unbound }, "active desktop coordinator");
+    expectIssue({ ...source, desktop: unbound }, "same-run active coordinator");
     const productOverlay = replaceRequired(
       source.desktop,
       "            apps/desktop/scripts/macos-release-cli.mjs \\\n",

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -248,11 +248,16 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     "desktop coordinator.jobs.prepare-release-draft",
     issues,
   );
-  const dispatch = mapping(
-    jobs["dispatch-desktop-release"],
-    "desktop coordinator.jobs.dispatch-desktop-release",
+  const desktopRelease = mapping(
+    jobs["desktop-release"],
+    "desktop coordinator.jobs.desktop-release",
     issues,
   );
+  if (!exactKeys(jobs, ["bind-release", "prepare-release-draft", "desktop-release"])) {
+    issues.push(
+      "desktop coordinator must contain only binding, draft safeguard, and reusable call",
+    );
+  }
   exactPermissions(
     bind.permissions,
     { actions: "read", contents: "read" },
@@ -261,9 +266,9 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
   );
   exactPermissions(draft.permissions, { contents: "write" }, "desktop draft preparation", issues);
   exactPermissions(
-    dispatch.permissions,
-    { actions: "write", contents: "read" },
-    "desktop child dispatcher",
+    desktopRelease.permissions,
+    { actions: "read", contents: "write" },
+    "desktop reusable release call",
     issues,
   );
 
@@ -272,7 +277,6 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     tag: "${{ steps.bind.outputs.tag }}",
     desktop_version: "${{ steps.bind.outputs.desktop_version }}",
     commit: "${{ steps.bind.outputs.commit }}",
-    workflow_ref: "${{ steps.bind.outputs.workflow_ref }}",
     tooling_commit: "${{ steps.bind.outputs.tooling_commit }}",
     mode: "${{ steps.bind.outputs.mode }}",
     baseline_tag: "${{ steps.bind.outputs.baseline_tag }}",
@@ -295,6 +299,7 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     bindEnvironment.DESKTOP_ENABLED !== "${{ vars.ENABLE_DESKTOP_MACOS_RELEASE }}" ||
     bindEnvironment.WORKFLOW_REF !== "${{ github.ref }}" ||
     bindEnvironment.WORKFLOW_SHA !== "${{ github.sha }}" ||
+    bindEnvironment.REPOSITORY_ID !== "${{ github.repository_id }}" ||
     (source.match(/vars\.ENABLE_DESKTOP_MACOS_RELEASE/gu) ?? []).length !== 1 ||
     !bindRun.includes("test \"$DESKTOP_ENABLED\" = 'true'") ||
     !bindRun.includes(
@@ -328,19 +333,57 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
       "desktop coordinator recovery source run must require a steady immutable recovery tag",
     );
   }
+  const coordinatorSourceWorkflowCase = `case "$SOURCE_WORKFLOW_PATH" in
+    .github/workflows/desktop-release.yml)
+      test "$(printf '%s' "$SOURCE_RUN" | jq -r '.actor.login')" = 'github-actions[bot]'
+      test "$(printf '%s' "$SOURCE_RUN" | jq -r '.triggering_actor.login')" = 'github-actions[bot]'
+      ;;
+    .github/workflows/desktop-release-coordinator.yml)
+      ;;
+    *)
+      echo '::error::Recovery source run used an untrusted workflow'
+      exit 1
+      ;;
+  esac`;
+  const coordinatorSourcePathRefCase = `case "$SOURCE_WORKFLOW_PATH_RAW" in
+    "$SOURCE_WORKFLOW_PATH"|"$SOURCE_WORKFLOW_PATH@$SOURCE_HEAD"|"$SOURCE_WORKFLOW_PATH@refs/tags/$SOURCE_HEAD")
+      ;;
+    *)
+      echo '::error::Recovery source workflow path used an unexpected ref suffix'
+      exit 1
+      ;;
+  esac`;
+  const coordinatorSourceHeadCase = `if [ "$SOURCE_HEAD" = "$TAG" ]; then
+    test "$SOURCE_SHA" = "$COMMIT"
+  else
+    SOURCE_REVISION="\${SOURCE_HEAD#"\${TAG}-recovery."}"
+    printf '%s' "$SOURCE_REVISION" | grep -Eq '^[1-9][0-9]*$'
+    test "$SOURCE_HEAD" = "\${TAG}-recovery.\${SOURCE_REVISION}"
+    test "$SOURCE_REVISION" -lt "$CURRENT_RECOVERY_REVISION"
+  fi`;
   if (
+    bindEnvironment.REPOSITORY_ID !== "${{ github.repository_id }}" ||
     !bindRun.includes(
       'SOURCE_RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")',
     ) ||
-    !bindRun.includes(".github/workflows/desktop-release.yml") ||
+    !bindRun.includes("SOURCE_WORKFLOW_PATH_RAW=$(printf '%s' \"$SOURCE_RUN\" | jq -er '.path')") ||
+    !bindRun.includes('SOURCE_WORKFLOW_PATH="${SOURCE_WORKFLOW_PATH_RAW%%@*}"') ||
+    !bindRun.includes(coordinatorSourceWorkflowCase) ||
     !bindRun.includes(".event')\" = 'workflow_dispatch'") ||
     !bindRun.includes(".status')\" = 'completed'") ||
     !bindRun.includes(".conclusion')\" = 'failure'") ||
-    !bindRun.includes(".repository.full_name") ||
+    !bindRun.includes(
+      'test "$(printf \'%s\' "$SOURCE_RUN" | jq -r \'.repository.full_name\')" = "$GITHUB_REPOSITORY"',
+    ) ||
+    !bindRun.includes(
+      'test "$(printf \'%s\' "$SOURCE_RUN" | jq -r \'.head_repository.full_name\')" = "$GITHUB_REPOSITORY"',
+    ) ||
     !bindRun.includes("SOURCE_ATTEMPT=") ||
-    !bindRun.includes('SOURCE_REVISION="${SOURCE_HEAD#"${TAG}-recovery."}"') ||
-    !bindRun.includes('test "$SOURCE_HEAD" = "${TAG}-recovery.${SOURCE_REVISION}"') ||
-    !bindRun.includes('test "$SOURCE_HEAD" != "$RECOVERY_TOOLING_TAG_INPUT"') ||
+    !bindRun.includes(coordinatorSourcePathRefCase) ||
+    !bindRun.includes(
+      'CURRENT_RECOVERY_REVISION="${RECOVERY_TOOLING_TAG_INPUT#"${TAG}-recovery."}"',
+    ) ||
+    !bindRun.includes(coordinatorSourceHeadCase) ||
     !bindRun.includes(
       'test "$(git rev-parse "refs/tags/$SOURCE_HEAD^{commit}")" = "$SOURCE_SHA"',
     ) ||
@@ -348,12 +391,23 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     !bindRun.includes('git merge-base --is-ancestor "$SOURCE_SHA" "$TOOLING_COMMIT"') ||
     !bindRun.includes('git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main') ||
     !bindRun.includes(
-      'SOURCE_JOBS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/jobs?per_page=100")',
+      "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_ATTEMPT/jobs?per_page=100",
     ) ||
+    !bindRun.includes("gh api --paginate --slurp") ||
+    !bindRun.includes("([.[].jobs[]] | length) == .[0].total_count") ||
     !bindRun.includes(
       "for required_job in sign-macos verify-macos-envelope stage-private-draft publish-assets; do",
     ) ||
-    !bindRun.includes('.name == "activate-release" and .conclusion == "success"') ||
+    !bindRun.includes(
+      '[.[].jobs[] | select((.name | split(" / ") | last) == $name)] as $matches',
+    ) ||
+    (bindRun.match(/\(\$matches \| length\) == 1/gu) ?? []).length !== 2 ||
+    (bindRun.match(/\$matches\[0\]\.status == "completed"/gu) ?? []).length !== 2 ||
+    !bindRun.includes('$matches[0].conclusion == "success"') ||
+    !bindRun.includes(
+      '[.[].jobs[] | select((.name | split(" / ") | last) == "activate-release")] as $matches',
+    ) ||
+    !bindRun.includes('$matches[0].conclusion != "success"') ||
     !bindRun.includes(
       'SOURCE_ARTIFACTS=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100")',
     ) ||
@@ -364,6 +418,8 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     !bindRun.includes(".expired") ||
     !bindRun.includes("^sha256:[0-9a-f]{64}$") ||
     !bindRun.includes(".workflow_run.id") ||
+    !bindRun.includes(".workflow_run.repository_id") ||
+    !bindRun.includes(".workflow_run.head_repository_id") ||
     !bindRun.includes(".workflow_run.head_branch") ||
     !bindRun.includes(".workflow_run.head_sha")
   ) {
@@ -372,7 +428,6 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     );
   }
   if (
-    !bindRun.includes('CHILD_WORKFLOW_REF="$TAG"') ||
     !bindRun.includes('TOOLING_COMMIT="$COMMIT"') ||
     !bindRun.includes('if [ -n "$RECOVERY_TOOLING_TAG_INPUT" ]; then') ||
     !bindRun.includes("if [ \"$MODE\" != 'steady' ]; then") ||
@@ -386,8 +441,6 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     !bindRun.includes('test "$WORKFLOW_SHA" = "$TOOLING_COMMIT"') ||
     !bindRun.includes('git merge-base --is-ancestor "$COMMIT" "$TOOLING_COMMIT"') ||
     !bindRun.includes('git merge-base --is-ancestor "$TOOLING_COMMIT" refs/remotes/origin/main') ||
-    !bindRun.includes('CHILD_WORKFLOW_REF="$RECOVERY_TAG"') ||
-    !bindRun.includes('echo "workflow_ref=$CHILD_WORKFLOW_REF" >> "$GITHUB_OUTPUT"') ||
     !bindRun.includes('echo "tooling_commit=$TOOLING_COMMIT" >> "$GITHUB_OUTPUT"')
   ) {
     issues.push(
@@ -451,163 +504,40 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     issues.push("desktop coordinator recovery must never create a missing candidate release");
   }
 
-  const dispatchNeeds = scalar(dispatch.needs);
-  const dispatchBindingStep = namedStep(dispatch, "Seal exact child dispatch binding");
-  const dispatchBindingEnvironment = mapping(
-    dispatchBindingStep?.env,
-    "desktop dispatch binding environment",
-    issues,
-  );
-  const dispatchBindingRun =
-    typeof dispatchBindingStep?.run === "string" ? dispatchBindingStep.run : "";
-  const dispatchBindingUploads = actionSteps(dispatch, "actions/upload-artifact");
-  const dispatchStep = namedStep(
-    dispatch,
-    "Dispatch and await environment-bound desktop transaction",
-  );
-  const dispatchEnvironment = mapping(
-    dispatchStep?.env,
-    "desktop coordinator dispatch environment",
-    issues,
-  );
-  const dispatchRun = typeof dispatchStep?.run === "string" ? dispatchStep.run : "";
-  const expectedDispatchEnvironment: Mapping = {
-    RELEASE_TAG: "${{ needs.bind-release.outputs.tag }}",
-    DESKTOP_VERSION: "${{ needs.bind-release.outputs.desktop_version }}",
-    RELEASE_COMMIT: "${{ needs.bind-release.outputs.commit }}",
-    RELEASE_WORKFLOW_REF: "${{ needs.bind-release.outputs.workflow_ref }}",
-    RELEASE_TOOLING_COMMIT: "${{ needs.bind-release.outputs.tooling_commit }}",
-    RELEASE_DRAFT_ID: "${{ needs.prepare-release-draft.outputs.draft_id }}",
-    RELEASE_MODE: "${{ needs.bind-release.outputs.mode }}",
-    RELEASE_BODY_SHA256: "${{ needs.prepare-release-draft.outputs.body_sha256 }}",
-    RELEASE_BASELINE_TAG: "${{ needs.bind-release.outputs.baseline_tag }}",
-    RELEASE_SOURCE_RUN_ID: "${{ needs.bind-release.outputs.source_run_id }}",
-    COORDINATOR_RUN_ID: "${{ github.run_id }}",
-    COORDINATOR_RUN_ATTEMPT: "${{ github.run_attempt }}",
-    DISPATCH_NONCE: "${{ steps.dispatch-binding.outputs.nonce }}",
-    DISPATCH_BINDING_SHA256: "${{ steps.dispatch-binding.outputs.sha256 }}",
+  const callInputs = mapping(desktopRelease.with, "desktop reusable call inputs", issues);
+  const expectedCallInputs: Mapping = {
+    tag: "${{ needs.bind-release.outputs.tag }}",
+    desktop_version: "${{ needs.bind-release.outputs.desktop_version }}",
+    commit: "${{ needs.bind-release.outputs.commit }}",
+    tooling_commit: "${{ needs.bind-release.outputs.tooling_commit }}",
+    draft_id: "${{ needs.prepare-release-draft.outputs.draft_id }}",
+    mode: "${{ needs.bind-release.outputs.mode }}",
+    draft_body_sha256: "${{ needs.prepare-release-draft.outputs.body_sha256 }}",
+    baseline_tag: "${{ needs.bind-release.outputs.baseline_tag }}",
+    source_run_id: "${{ needs.bind-release.outputs.source_run_id }}",
   };
-  const dispatchedInputs = Array.from(
-    dispatchRun.matchAll(/(?:^|\s)-f ([a-z0-9_]+)=/gu),
-    (match) => match[1],
-  );
-  const expectedDispatchedInputs = [
-    "tag",
-    "desktop_version",
-    "commit",
-    "tooling_commit",
-    "draft_id",
-    "mode",
-    "draft_body_sha256",
-    "baseline_tag",
-    "source_run_id",
-    "coordinator_run_id",
-    "coordinator_run_attempt",
-    "dispatch_nonce",
-    "dispatch_binding_sha256",
-  ];
-  const expectedDispatchedAssignments: Mapping = {
-    tag: "RELEASE_TAG",
-    desktop_version: "DESKTOP_VERSION",
-    commit: "RELEASE_COMMIT",
-    tooling_commit: "RELEASE_TOOLING_COMMIT",
-    draft_id: "RELEASE_DRAFT_ID",
-    mode: "RELEASE_MODE",
-    draft_body_sha256: "RELEASE_BODY_SHA256",
-    baseline_tag: "RELEASE_BASELINE_TAG",
-    source_run_id: "RELEASE_SOURCE_RUN_ID",
-    coordinator_run_id: "COORDINATOR_RUN_ID",
-    coordinator_run_attempt: "COORDINATOR_RUN_ATTEMPT",
-    dispatch_nonce: "DISPATCH_NONCE",
-    dispatch_binding_sha256: "DISPATCH_BINDING_SHA256",
-  };
-  const expectedBindingObject =
-    "{schemaVersion: 1, repository: $repository, repositoryId: $repositoryId, coordinatorRunId: $coordinatorRunId, coordinatorRunAttempt: $coordinatorRunAttempt, workflowRef: $workflowRef, workflowSha: $workflowSha, childWorkflowRef: $childWorkflowRef, tag: $tag, desktopVersion: $desktopVersion, commit: $commit, toolingCommit: $toolingCommit, draftId: $draftId, mode: $mode, draftBodySha256: $draftBodySha256, baselineTag: $baselineTag, sourceRunId: $sourceRunId, nonce: $nonce}";
-  const expectedBindingEnvironment: Mapping = {
-    RELEASE_TAG: "${{ needs.bind-release.outputs.tag }}",
-    DESKTOP_VERSION: "${{ needs.bind-release.outputs.desktop_version }}",
-    RELEASE_COMMIT: "${{ needs.bind-release.outputs.commit }}",
-    RELEASE_WORKFLOW_REF: "${{ needs.bind-release.outputs.workflow_ref }}",
-    RELEASE_TOOLING_COMMIT: "${{ needs.bind-release.outputs.tooling_commit }}",
-    RELEASE_DRAFT_ID: "${{ needs.prepare-release-draft.outputs.draft_id }}",
-    RELEASE_MODE: "${{ needs.bind-release.outputs.mode }}",
-    RELEASE_BODY_SHA256: "${{ needs.prepare-release-draft.outputs.body_sha256 }}",
-    RELEASE_BASELINE_TAG: "${{ needs.bind-release.outputs.baseline_tag }}",
-    RELEASE_SOURCE_RUN_ID: "${{ needs.bind-release.outputs.source_run_id }}",
-    COORDINATOR_RUN_ID: "${{ github.run_id }}",
-    COORDINATOR_RUN_ATTEMPT: "${{ github.run_attempt }}",
-    REPOSITORY: "${{ github.repository }}",
-    REPOSITORY_ID: "${{ github.repository_id }}",
-    WORKFLOW_REF: "${{ github.ref }}",
-    WORKFLOW_SHA: "${{ github.sha }}",
-  };
-  const bindingUploadInputs = mapping(
-    dispatchBindingUploads[0]?.with,
-    "desktop dispatch binding upload inputs",
-    issues,
-  );
   if (
-    dispatchBindingStep?.id !== "dispatch-binding" ||
-    !exactKeys(dispatchBindingEnvironment, Object.keys(expectedBindingEnvironment)) ||
-    Object.entries(expectedBindingEnvironment).some(
-      ([key, value]) => dispatchBindingEnvironment[key] !== value,
+    !exactKeys(desktopRelease, ["needs", "concurrency", "permissions", "uses", "with"]) ||
+    !exactStringSet(desktopRelease.needs, ["bind-release", "prepare-release-draft"]) ||
+    desktopRelease.uses !== "./.github/workflows/desktop-release.yml" ||
+    !exactKeys(callInputs, Object.keys(expectedCallInputs)) ||
+    Object.entries(expectedCallInputs).some(([key, value]) => callInputs[key] !== value) ||
+    "secrets" in desktopRelease ||
+    /secrets:\s*inherit|gh workflow run desktop-release\.yml|desktop-dispatch-binding|DISPATCH_NONCE|dispatch_binding_sha256/u.test(
+      source,
     ) ||
-    !dispatchBindingRun.includes("DISPATCH_NONCE=$(openssl rand -hex 32)") ||
-    !dispatchBindingRun.includes("printf '%s' \"$DISPATCH_NONCE\" | grep -Eq '^[0-9a-f]{64}$'") ||
-    !dispatchBindingRun.includes(expectedBindingObject) ||
-    !dispatchBindingRun.includes(
-      "BINDING_SHA256=$(printf '%s' \"$BINDING\" | sha256sum | awk '{print $1}')",
-    ) ||
-    !dispatchBindingRun.includes(
-      'ARTIFACT_NAME="desktop-dispatch-binding-$COORDINATOR_RUN_ID-$COORDINATOR_RUN_ATTEMPT-$BINDING_SHA256"',
-    ) ||
-    !dispatchBindingRun.includes(
-      'printf \'%s\' "$BINDING" > "$RUNNER_TEMP/desktop-dispatch-binding.json"',
-    ) ||
-    dispatchBindingUploads.length !== 1 ||
-    !exactKeys(bindingUploadInputs, [
-      "name",
-      "path",
-      "if-no-files-found",
-      "compression-level",
-      "retention-days",
-    ]) ||
-    bindingUploadInputs.name !== "${{ steps.dispatch-binding.outputs.artifact_name }}" ||
-    bindingUploadInputs.path !== "${{ runner.temp }}/desktop-dispatch-binding.json" ||
-    bindingUploadInputs["if-no-files-found"] !== "error" ||
-    bindingUploadInputs["compression-level"] !== 0 ||
-    bindingUploadInputs["retention-days"] !== 1
+    /npm_version|npm_integrity|npm_attestation_url/u.test(scalar(desktopRelease))
   ) {
-    issues.push("desktop coordinator must seal exactly one nonce-bound full dispatch tuple");
+    issues.push(
+      "desktop coordinator must synchronously call one secretless npm-independent reusable workflow tuple",
+    );
   }
-  if (
-    !dispatchNeeds.includes("bind-release") ||
-    !dispatchNeeds.includes("prepare-release-draft") ||
-    Object.entries(expectedDispatchEnvironment).some(
-      ([key, value]) => dispatchEnvironment[key] !== value,
-    ) ||
-    !exactKeys(
-      Object.fromEntries(dispatchedInputs.map((input) => [input, true])),
-      expectedDispatchedInputs,
-    ) ||
-    dispatchedInputs.length !== expectedDispatchedInputs.length ||
-    Object.entries(expectedDispatchedAssignments).some(
-      ([input, variable]) => !dispatchRun.includes(`-f ${input}="$${variable}"`),
-    ) ||
-    !dispatchRun.includes("gh workflow run desktop-release.yml \\") ||
-    !dispatchRun.includes('--ref "$RELEASE_WORKFLOW_REF"') ||
-    (dispatchRun.match(/--repo "\$GITHUB_REPOSITORY"/gu) ?? []).length !== 3 ||
-    !dispatchRun.includes('--arg title "$EXPECTED_TITLE"') ||
-    !dispatchRun.includes(
-      'EXPECTED_TITLE="Desktop release $RELEASE_TAG via $COORDINATOR_RUN_ID.$COORDINATOR_RUN_ATTEMPT binding $DISPATCH_BINDING_SHA256"',
-    ) ||
-    !dispatchRun.includes(
-      'gh run watch "$DESKTOP_RUN_ID" --repo "$GITHUB_REPOSITORY" --interval 15 --exit-status',
-    ) ||
-    /npm_version|npm_integrity|npm_attestation_url/u.test(dispatchRun)
-  ) {
-    issues.push("desktop coordinator must dispatch and await one npm-independent child tuple");
-  }
+  requireQueue(
+    desktopRelease.concurrency,
+    "stable-desktop",
+    "desktop reusable release call",
+    issues,
+  );
 }
 
 function checkNpmRelease(source: string, release: Mapping, issues: string[]): void {
@@ -817,11 +747,11 @@ function checkNpmRelease(source: string, release: Mapping, issues: string[]): vo
 
 function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): void {
   const workflowOn = mapping(desktop.on, "desktop child.on", issues);
-  if (Object.keys(workflowOn).length !== 1 || !("workflow_dispatch" in workflowOn)) {
-    issues.push("desktop-release.yml must be workflow_dispatch-only");
+  if (Object.keys(workflowOn).length !== 1 || !("workflow_call" in workflowOn)) {
+    issues.push("desktop-release.yml must be workflow_call-only");
   }
-  const workflowDispatch = mapping(workflowOn.workflow_dispatch, "desktop child dispatch", issues);
-  const inputs = mapping(workflowDispatch.inputs, "desktop child inputs", issues);
+  const workflowCall = mapping(workflowOn.workflow_call, "desktop reusable call", issues);
+  const inputs = mapping(workflowCall.inputs, "desktop reusable inputs", issues);
   const expectedInputs = [
     "tag",
     "desktop_version",
@@ -832,10 +762,6 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     "draft_body_sha256",
     "baseline_tag",
     "source_run_id",
-    "coordinator_run_id",
-    "coordinator_run_attempt",
-    "dispatch_nonce",
-    "dispatch_binding_sha256",
   ];
   if (!exactKeys(inputs, expectedInputs)) {
     issues.push("desktop child must accept only the frozen desktop release tuple");
@@ -843,7 +769,7 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
   for (const input of expectedInputs) {
     const declaration = mapping(inputs[input], `desktop child input ${input}`, issues);
     if (declaration.required !== true || declaration.type !== "string") {
-      issues.push(`desktop workflow_dispatch must require string input ${input}`);
+      issues.push(`desktop workflow_call must require string input ${input}`);
     }
   }
   if (
@@ -853,11 +779,15 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
   ) {
     issues.push("desktop child must not consume npm release identity or provenance");
   }
+  if ("run-name" in desktop || "concurrency" in desktop) {
+    issues.push("desktop reusable workflow must inherit caller run identity and concurrency");
+  }
   if (
-    desktop["run-name"] !==
-    "Desktop release ${{ inputs.tag }} via ${{ inputs.coordinator_run_id }}.${{ inputs.coordinator_run_attempt }} binding ${{ inputs.dispatch_binding_sha256 }}"
+    /coordinator_run_id|coordinator_run_attempt|dispatch_nonce|dispatch_binding_sha256|COORDINATOR_RUN_ID|COORDINATOR_RUN_ATTEMPT|DISPATCH_NONCE|DISPATCH_BINDING_SHA256|desktop-dispatch-binding|COORDINATOR_ARTIFACTS|BINDING_ARTIFACT/u.test(
+      source,
+    )
   ) {
-    issues.push("desktop child run name must bind its coordinator invocation");
+    issues.push("desktop reusable workflow must not retain obsolete dispatch binding machinery");
   }
   exactPermissions(
     desktop.permissions,
@@ -865,7 +795,6 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     "desktop child",
     issues,
   );
-  requireQueue(desktop.concurrency, "stable-desktop", "desktop release", issues);
 
   const requiredSigningSecrets = [
     "CSC_LINK",
@@ -912,7 +841,7 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     "desktop coordinator authorization",
     issues,
   );
-  const authorizeStep = namedStep(authorize, "Bind dispatch to the active release coordinator");
+  const authorizeStep = namedStep(authorize, "Bind call to the active release coordinator");
   const authorizeEnvironment = mapping(
     authorizeStep?.env,
     "desktop coordinator authorization environment",
@@ -930,36 +859,41 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     baseline_artifact_id: "${{ steps.authorize.outputs.baseline_artifact_id }}",
     baseline_artifact_digest: "${{ steps.authorize.outputs.baseline_artifact_digest }}",
   };
+  const expectedAuthorizeEnvironment: Mapping = {
+    GH_TOKEN: "${{ github.token }}",
+    RELEASE_TAG: "${{ inputs.tag }}",
+    DESKTOP_VERSION: "${{ inputs.desktop_version }}",
+    RELEASE_COMMIT: "${{ inputs.commit }}",
+    RELEASE_TOOLING_COMMIT: "${{ inputs.tooling_commit }}",
+    RELEASE_DRAFT_ID: "${{ inputs.draft_id }}",
+    RELEASE_MODE: "${{ inputs.mode }}",
+    RELEASE_BODY_SHA256: "${{ inputs.draft_body_sha256 }}",
+    RELEASE_BASELINE_TAG: "${{ inputs.baseline_tag }}",
+    SOURCE_RUN_ID: "${{ inputs.source_run_id }}",
+    REPOSITORY_ID: "${{ github.repository_id }}",
+    WORKFLOW_REF: "${{ github.ref }}",
+    WORKFLOW_REF_NAME: "${{ github.ref_name }}",
+    WORKFLOW_COMMIT: "${{ github.sha }}",
+    CURRENT_RUN_ID: "${{ github.run_id }}",
+    CURRENT_RUN_ATTEMPT: "${{ github.run_attempt }}",
+    EVENT_NAME: "${{ github.event_name }}",
+    CALLER_WORKFLOW_REF: "${{ github.workflow_ref }}",
+    CALLER_WORKFLOW_SHA: "${{ github.workflow_sha }}",
+    CALLED_WORKFLOW_REF: "${{ job.workflow_ref }}",
+    CALLED_WORKFLOW_SHA: "${{ job.workflow_sha }}",
+    CALLED_WORKFLOW_REPOSITORY: "${{ job.workflow_repository }}",
+    CALLED_WORKFLOW_FILE_PATH: "${{ job.workflow_file_path }}",
+  };
   if (
     sign.needs !== "authorize-coordinator" ||
-    authorizeEnvironment.RELEASE_TAG !== "${{ inputs.tag }}" ||
-    authorizeEnvironment.DESKTOP_VERSION !== "${{ inputs.desktop_version }}" ||
-    authorizeEnvironment.RELEASE_DRAFT_ID !== "${{ inputs.draft_id }}" ||
-    authorizeEnvironment.RELEASE_BODY_SHA256 !== "${{ inputs.draft_body_sha256 }}" ||
-    authorizeEnvironment.RELEASE_BASELINE_TAG !== "${{ inputs.baseline_tag }}" ||
-    authorizeEnvironment.RELEASE_MODE !== "${{ inputs.mode }}" ||
-    authorizeEnvironment.SOURCE_RUN_ID !== "${{ inputs.source_run_id }}" ||
-    authorizeEnvironment.DISPATCH_NONCE !== "${{ inputs.dispatch_nonce }}" ||
-    authorizeEnvironment.DISPATCH_BINDING_SHA256 !== "${{ inputs.dispatch_binding_sha256 }}" ||
-    authorizeEnvironment.RUN_ACTOR !== "${{ github.actor }}" ||
-    authorizeEnvironment.RUN_TRIGGERING_ACTOR !== "${{ github.triggering_actor }}" ||
-    authorizeEnvironment.REPOSITORY_ID !== "${{ github.repository_id }}" ||
-    authorizeEnvironment.WORKFLOW_REF !== "${{ github.ref }}" ||
-    authorizeEnvironment.WORKFLOW_REF_NAME !== "${{ github.ref_name }}" ||
-    !authorizeRun.includes('gh api "repos/$GITHUB_REPOSITORY/actions/runs/$COORDINATOR_RUN_ID"') ||
-    !authorizeRun.includes(".github/workflows/desktop-release-coordinator.yml") ||
-    authorizeRun.includes(".github/workflows/release.yml") ||
-    !authorizeRun.includes(
-      'test "$(printf \'%s\' "$COORDINATOR" | jq -r \'.run_attempt\')" = "$COORDINATOR_RUN_ATTEMPT"',
+    !exactKeys(authorizeEnvironment, Object.keys(expectedAuthorizeEnvironment)) ||
+    Object.entries(expectedAuthorizeEnvironment).some(
+      ([key, value]) => authorizeEnvironment[key] !== value,
     ) ||
-    !authorizeRun.includes(".status") ||
-    !authorizeRun.includes("in_progress") ||
-    !authorizeRun.includes(".head_sha") ||
+    !authorizeRun.includes("printf '%s' \"$CURRENT_RUN_ID\" | grep -Eq '^[1-9][0-9]*$'") ||
+    !authorizeRun.includes("printf '%s' \"$CURRENT_RUN_ATTEMPT\" | grep -Eq '^[1-9][0-9]*$'") ||
+    !authorizeRun.includes("test \"$EVENT_NAME\" = 'workflow_dispatch'") ||
     !authorizeRun.includes('test "$RELEASE_TOOLING_COMMIT" = "$WORKFLOW_COMMIT"') ||
-    !authorizeRun.includes(".head_branch") ||
-    !authorizeRun.includes(
-      'test "$(printf \'%s\' "$COORDINATOR" | jq -r \'.head_branch\')" = "$WORKFLOW_REF_NAME"',
-    ) ||
     !authorizeRun.includes('if [ "$RELEASE_TOOLING_COMMIT" = "$RELEASE_COMMIT" ]; then') ||
     !authorizeRun.includes('test "$WORKFLOW_REF" = "refs/tags/$RELEASE_TAG"') ||
     !authorizeRun.includes('test "$WORKFLOW_REF_NAME" = "$RELEASE_TAG"') ||
@@ -967,87 +901,93 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     !authorizeRun.includes(
       'CURRENT_RECOVERY_REVISION="${WORKFLOW_REF_NAME#"${RELEASE_TAG}-recovery."}"',
     ) ||
-    !authorizeRun.includes("grep -Eq '^[1-9][0-9]*$'") ||
     !authorizeRun.includes(
       'test "$WORKFLOW_REF_NAME" = "${RELEASE_TAG}-recovery.${CURRENT_RECOVERY_REVISION}"',
     ) ||
     !authorizeRun.includes('test "$WORKFLOW_REF" = "refs/tags/$WORKFLOW_REF_NAME"') ||
-    !authorizeRun.includes("workflow_dispatch") ||
-    authorizeRun.includes('.event == "push"') ||
+    !authorizeRun.includes(
+      'test "$CALLER_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/desktop-release-coordinator.yml@$WORKFLOW_REF"',
+    ) ||
+    !authorizeRun.includes('test "$CALLER_WORKFLOW_SHA" = "$WORKFLOW_COMMIT"') ||
+    !authorizeRun.includes(
+      'test "$CALLED_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/desktop-release.yml@$WORKFLOW_REF"',
+    ) ||
+    !authorizeRun.includes('test "$CALLED_WORKFLOW_SHA" = "$WORKFLOW_COMMIT"') ||
+    !authorizeRun.includes('test "$CALLED_WORKFLOW_REPOSITORY" = "$GITHUB_REPOSITORY"') ||
+    !authorizeRun.includes(
+      "test \"$CALLED_WORKFLOW_FILE_PATH\" = '.github/workflows/desktop-release.yml'",
+    ) ||
+    /repos\/\$GITHUB_REPOSITORY\/releases\/|gh release view|CANDIDATE_RELEASE|LATEST_RELEASE/u.test(
+      authorizeRun,
+    ) ||
     !exactKeys(authorizeOutputs, Object.keys(expectedAuthorizeOutputs)) ||
     Object.entries(expectedAuthorizeOutputs).some(([key, value]) => authorizeOutputs[key] !== value)
   ) {
-    issues.push("desktop signing must authorize only its active desktop coordinator");
+    issues.push(
+      "desktop signing must authorize only the same-run active coordinator and called workflow identities",
+    );
   }
-  const expectedChildBindingObject =
-    "{schemaVersion: 1, repository: $repository, repositoryId: $repositoryId, coordinatorRunId: $coordinatorRunId, coordinatorRunAttempt: $coordinatorRunAttempt, workflowRef: $workflowRef, workflowSha: $workflowSha, childWorkflowRef: $childWorkflowRef, tag: $tag, desktopVersion: $desktopVersion, commit: $commit, toolingCommit: $toolingCommit, draftId: $draftId, mode: $mode, draftBodySha256: $draftBodySha256, baselineTag: $baselineTag, sourceRunId: $sourceRunId, nonce: $nonce}";
   const sourceValidationStart = authorizeRun.indexOf(
     'SOURCE=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")',
   );
-  const bindingValidationRun = authorizeRun.slice(
-    authorizeRun.indexOf("BINDING_ARTIFACT_NAME="),
-    sourceValidationStart,
-  );
-  if (
-    !authorizeRun.includes("test \"$RUN_ACTOR\" = 'github-actions[bot]'") ||
-    !authorizeRun.includes("test \"$RUN_TRIGGERING_ACTOR\" = 'github-actions[bot]'") ||
-    !authorizeRun.includes("printf '%s' \"$DISPATCH_NONCE\" | grep -Eq '^[0-9a-f]{64}$'") ||
-    !authorizeRun.includes(
-      "printf '%s' \"$DISPATCH_BINDING_SHA256\" | grep -Eq '^[0-9a-f]{64}$'",
-    ) ||
-    !authorizeRun.includes(expectedChildBindingObject) ||
-    !authorizeRun.includes(
-      'test "$(printf \'%s\' "$BINDING" | sha256sum | awk \'{print $1}\')" = "$DISPATCH_BINDING_SHA256"',
-    ) ||
-    !authorizeRun.includes(
-      'BINDING_ARTIFACT_NAME="desktop-dispatch-binding-$COORDINATOR_RUN_ID-$COORDINATOR_RUN_ATTEMPT-$DISPATCH_BINDING_SHA256"',
-    ) ||
-    !bindingValidationRun.includes("actions/runs/$COORDINATOR_RUN_ID/artifacts?per_page=100") ||
-    !bindingValidationRun.includes("([.[].artifacts[]] | length) == .[0].total_count") ||
-    !bindingValidationRun.includes(
-      "'[.[].artifacts[] | select(.name == $name)] | select(length == 1) | .[0]'",
-    ) ||
-    !bindingValidationRun.includes(".size_in_bytes") ||
-    !bindingValidationRun.includes(".workflow_run.repository_id") ||
-    !bindingValidationRun.includes(".workflow_run.head_repository_id") ||
-    !bindingValidationRun.includes(".workflow_run.head_branch") ||
-    !bindingValidationRun.includes(".workflow_run.head_sha")
-  ) {
-    issues.push(
-      "desktop child must require bot actors and one coordinator-owned nonce-bound dispatch artifact",
-    );
-  }
   const sourceValidationRun = authorizeRun.slice(sourceValidationStart);
+  const childSourceWorkflowCase = `case "$SOURCE_WORKFLOW_PATH" in
+  .github/workflows/desktop-release.yml)
+    test "$(printf '%s' "$SOURCE" | jq -r '.actor.login')" = 'github-actions[bot]'
+    test "$(printf '%s' "$SOURCE" | jq -r '.triggering_actor.login')" = 'github-actions[bot]'
+    ;;
+  .github/workflows/desktop-release-coordinator.yml)
+    ;;
+  *)
+    echo '::error::Recovery source run used an untrusted workflow'
+    exit 1
+    ;;
+esac`;
+  const childSourcePathRefCase = `case "$SOURCE_WORKFLOW_PATH_RAW" in
+  "$SOURCE_WORKFLOW_PATH"|"$SOURCE_WORKFLOW_PATH@$SOURCE_HEAD_BRANCH"|"$SOURCE_WORKFLOW_PATH@refs/tags/$SOURCE_HEAD_BRANCH")
+    ;;
+  *)
+    echo '::error::Recovery source workflow path used an unexpected ref suffix'
+    exit 1
+    ;;
+esac`;
+  const childSourceHeadCase = `if [ "$SOURCE_HEAD_BRANCH" = "$RELEASE_TAG" ]; then
+  test "$SOURCE_HEAD_SHA" = "$RELEASE_COMMIT"
+else
+  SOURCE_RECOVERY_REVISION="\${SOURCE_HEAD_BRANCH#"\${RELEASE_TAG}-recovery."}"
+  printf '%s' "$SOURCE_RECOVERY_REVISION" | grep -Eq '^[1-9][0-9]*$'
+  test "$SOURCE_HEAD_BRANCH" = "\${RELEASE_TAG}-recovery.\${SOURCE_RECOVERY_REVISION}"
+  test "$SOURCE_RECOVERY_REVISION" -lt "$CURRENT_RECOVERY_REVISION"
+fi`;
   if (
     !authorizeRun.includes("if [ \"$SOURCE_RUN_ID\" = 'none' ]; then") ||
     !authorizeRun.includes(
       "for output in source_run_id source_run_attempt artifact_name artifact_id artifact_digest baseline_artifact_name baseline_artifact_id baseline_artifact_digest; do",
     ) ||
     !authorizeRun.includes('test "$SOURCE_RUN_ID" != "$GITHUB_RUN_ID"') ||
-    !authorizeRun.includes('test "$SOURCE_RUN_ID" != "$COORDINATOR_RUN_ID"') ||
     !authorizeRun.includes("test \"$RELEASE_MODE\" = 'steady'") ||
     !authorizeRun.includes('test "$RELEASE_TOOLING_COMMIT" != "$RELEASE_COMMIT"') ||
     !authorizeRun.includes("test \"$CURRENT_RECOVERY_REVISION\" != 'none'") ||
     !authorizeRun.includes(
       'SOURCE=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")',
     ) ||
-    !authorizeRun.includes(".repository.full_name") ||
-    !authorizeRun.includes(".head_repository.full_name") ||
-    !authorizeRun.includes(".github/workflows/desktop-release.yml") ||
+    !authorizeRun.includes(
+      'test "$(printf \'%s\' "$SOURCE" | jq -r \'.repository.full_name\')" = "$GITHUB_REPOSITORY"',
+    ) ||
+    !authorizeRun.includes(
+      'test "$(printf \'%s\' "$SOURCE" | jq -r \'.head_repository.full_name\')" = "$GITHUB_REPOSITORY"',
+    ) ||
+    !authorizeRun.includes(
+      "SOURCE_WORKFLOW_PATH_RAW=$(printf '%s' \"$SOURCE\" | jq -er '.path')",
+    ) ||
+    !authorizeRun.includes('SOURCE_WORKFLOW_PATH="${SOURCE_WORKFLOW_PATH_RAW%%@*}"') ||
+    !authorizeRun.includes(childSourceWorkflowCase) ||
     !authorizeRun.includes(".event')\" = 'workflow_dispatch'") ||
-    !authorizeRun.includes(".actor.login')\" = 'github-actions[bot]'") ||
-    !authorizeRun.includes(".triggering_actor.login')\" = 'github-actions[bot]'") ||
     !authorizeRun.includes(".status')\" = 'completed'") ||
     !authorizeRun.includes(".conclusion')\" = 'failure'") ||
     !authorizeRun.includes("SOURCE_RUN_ATTEMPT=") ||
-    !authorizeRun.includes(
-      'SOURCE_RECOVERY_REVISION="${SOURCE_HEAD_BRANCH#"${RELEASE_TAG}-recovery."}"',
-    ) ||
-    !authorizeRun.includes(
-      'test "$SOURCE_HEAD_BRANCH" = "${RELEASE_TAG}-recovery.${SOURCE_RECOVERY_REVISION}"',
-    ) ||
-    !authorizeRun.includes('test "$SOURCE_RECOVERY_REVISION" != "$CURRENT_RECOVERY_REVISION"') ||
-    !authorizeRun.includes("sort -n | head -1") ||
+    !authorizeRun.includes(childSourcePathRefCase) ||
+    !authorizeRun.includes(childSourceHeadCase) ||
     !authorizeRun.includes(
       'test "$(git rev-parse "refs/tags/$SOURCE_HEAD_BRANCH^{commit}")" = "$SOURCE_HEAD_SHA"',
     ) ||
@@ -1066,7 +1006,15 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     !authorizeRun.includes(
       "for job_name in sign-macos verify-macos-envelope stage-private-draft publish-assets; do",
     ) ||
+    !authorizeRun.includes(
+      '[.[].jobs[] | select((.name | split(" / ") | last) == $job)] as $matches',
+    ) ||
     !authorizeRun.includes('$matches[0].conclusion == "success"') ||
+    !authorizeRun.includes(
+      '[.[].jobs[] | select((.name | split(" / ") | last) == "activate-release")] as $matches',
+    ) ||
+    (authorizeRun.match(/\(\$matches \| length\) == 1/gu) ?? []).length !== 2 ||
+    (authorizeRun.match(/\$matches\[0\]\.status == "completed"/gu) ?? []).length !== 2 ||
     !authorizeRun.includes('$matches[0].conclusion != "success"') ||
     !authorizeRun.includes("actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100") ||
     !authorizeRun.includes("([.[].artifacts[]] | length) == .[0].total_count") ||
@@ -1090,51 +1038,6 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
       "desktop child must independently validate source run, job, and artifact provenance",
     );
   }
-  const candidateAdmissionStart = authorizeRun.indexOf(
-    'CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")',
-  );
-  const noSourceExitStart = authorizeRun.indexOf("if [ \"$SOURCE_RUN_ID\" = 'none' ]; then");
-  const candidateAdmissionRun =
-    candidateAdmissionStart >= 0 && noSourceExitStart > candidateAdmissionStart
-      ? authorizeRun.slice(candidateAdmissionStart, noSourceExitStart)
-      : "";
-  const childLatestLookup =
-    "LATEST_RELEASE=$(gh api -H 'Cache-Control: no-cache' \"repos/$GITHUB_REPOSITORY/releases/latest\")";
-  if (
-    authorizeEnvironment.GH_TOKEN !== "${{ github.token }}" ||
-    candidateAdmissionRun === "" ||
-    !candidateAdmissionRun.includes(
-      'test "$(printf \'%s\' "$CANDIDATE_RELEASE" | jq -r \'.id | tostring\')" = "$RELEASE_DRAFT_ID"',
-    ) ||
-    !candidateAdmissionRun.includes(
-      'test "$(printf \'%s\' "$CANDIDATE_RELEASE" | jq -r \'.tag_name\')" = "$RELEASE_TAG"',
-    ) ||
-    !candidateAdmissionRun.includes(
-      "test \"$(printf '%s' \"$CANDIDATE_RELEASE\" | jq -r '.prerelease')\" = 'false'",
-    ) ||
-    !candidateAdmissionRun.includes(
-      "if [ \"$(printf '%s' \"$CANDIDATE_RELEASE\" | jq -r '.draft')\" = 'false' ]; then\n  test \"$SOURCE_RUN_ID\" != 'none'",
-    ) ||
-    !candidateAdmissionRun.includes(
-      `if [ "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.body')" != '${PROVISIONAL_RELEASE_BODY}' ]; then`,
-    ) ||
-    !candidateAdmissionRun.includes(
-      "CANDIDATE_BODY_SHA256=$(printf '%s' \"$CANDIDATE_RELEASE\" | jq -j '.body' | shasum -a 256 | awk '{print $1}')",
-    ) ||
-    !candidateAdmissionRun.includes('test "$CANDIDATE_BODY_SHA256" = "$RELEASE_BODY_SHA256"') ||
-    countShellLine(candidateAdmissionRun, childLatestLookup) !== 1 ||
-    !candidateAdmissionRun.includes(
-      'test "$(printf \'%s\' "$LATEST_RELEASE" | jq -r \'.id | tostring\')" = "$RELEASE_DRAFT_ID"',
-    ) ||
-    !candidateAdmissionRun.includes(
-      'test "$(printf \'%s\' "$LATEST_RELEASE" | jq -r \'.tag_name\')" = "$RELEASE_TAG"',
-    )
-  ) {
-    issues.push(
-      "desktop child must independently admit public recovery only as provisional or live-latest exact-final",
-    );
-  }
-
   exactPermissions(
     sign.permissions,
     { actions: "read", contents: "read" },
@@ -1241,6 +1144,72 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
   const roundTripRun = runs(roundTrip).join("\n");
   const activateRun = runs(activate).join("\n");
   const compensateRun = runs(compensate).join("\n");
+  const stageSteps = steps(stage);
+  const candidateSafeguardStep = namedStep(stage, "Revalidate recoverable candidate state");
+  const stageTransactionStep = namedStep(stage, "Upload updater envelope to the private draft");
+  const candidateSafeguardEnvironment = mapping(
+    candidateSafeguardStep?.env,
+    "private draft safeguard environment",
+    issues,
+  );
+  const candidateSafeguardRun =
+    typeof candidateSafeguardStep?.run === "string" ? candidateSafeguardStep.run : "";
+  const expectedCandidateSafeguardEnvironment: Mapping = {
+    GH_TOKEN: "${{ github.token }}",
+    RELEASE_TAG: "${{ inputs.tag }}",
+    RELEASE_DRAFT_ID: "${{ inputs.draft_id }}",
+    RELEASE_BODY_SHA256: "${{ inputs.draft_body_sha256 }}",
+    SOURCE_RUN_ID: "${{ inputs.source_run_id }}",
+  };
+  const candidateLatestLookup =
+    "LATEST_RELEASE=$(gh api -H 'Cache-Control: no-cache' \"repos/$GITHUB_REPOSITORY/releases/latest\")";
+  if (
+    stage.environment !== "desktop-macos-publication" ||
+    mapping(stage.permissions, "private draft safeguard permissions", issues).contents !==
+      "write" ||
+    stageSteps.indexOf(candidateSafeguardStep ?? {}) + 1 !==
+      stageSteps.indexOf(stageTransactionStep ?? {}) ||
+    stageTransactionStep?.run !==
+      'pnpm desktop-release:transaction stage --directory "$RUNNER_TEMP/desktop-release"' ||
+    !exactKeys(candidateSafeguardEnvironment, Object.keys(expectedCandidateSafeguardEnvironment)) ||
+    Object.entries(expectedCandidateSafeguardEnvironment).some(
+      ([key, value]) => candidateSafeguardEnvironment[key] !== value,
+    ) ||
+    !candidateSafeguardRun.includes(
+      'CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")',
+    ) ||
+    !candidateSafeguardRun.includes(
+      'test "$(printf \'%s\' "$CANDIDATE_RELEASE" | jq -r \'.id | tostring\')" = "$RELEASE_DRAFT_ID"',
+    ) ||
+    !candidateSafeguardRun.includes(
+      'test "$(printf \'%s\' "$CANDIDATE_RELEASE" | jq -r \'.tag_name\')" = "$RELEASE_TAG"',
+    ) ||
+    !candidateSafeguardRun.includes(
+      "test \"$(printf '%s' \"$CANDIDATE_RELEASE\" | jq -r '.prerelease')\" = 'false'",
+    ) ||
+    !candidateSafeguardRun.includes(
+      "if [ \"$(printf '%s' \"$CANDIDATE_RELEASE\" | jq -r '.draft')\" = 'false' ]; then\n  test \"$SOURCE_RUN_ID\" != 'none'",
+    ) ||
+    !candidateSafeguardRun.includes(
+      `if [ "$(printf '%s' "$CANDIDATE_RELEASE" | jq -r '.body')" != '${PROVISIONAL_RELEASE_BODY}' ]; then`,
+    ) ||
+    !candidateSafeguardRun.includes(
+      "CANDIDATE_BODY_SHA256=$(printf '%s' \"$CANDIDATE_RELEASE\" | jq -j '.body' | shasum -a 256 | awk '{print $1}')",
+    ) ||
+    !candidateSafeguardRun.includes('test "$CANDIDATE_BODY_SHA256" = "$RELEASE_BODY_SHA256"') ||
+    countShellLine(candidateSafeguardRun, candidateLatestLookup) !== 1 ||
+    !candidateSafeguardRun.includes(
+      'test "$(printf \'%s\' "$LATEST_RELEASE" | jq -r \'.id | tostring\')" = "$RELEASE_DRAFT_ID"',
+    ) ||
+    !candidateSafeguardRun.includes(
+      'test "$(printf \'%s\' "$LATEST_RELEASE" | jq -r \'.tag_name\')" = "$RELEASE_TAG"',
+    ) ||
+    (source.match(/repos\/\$GITHUB_REPOSITORY\/releases\/\$RELEASE_DRAFT_ID/gu) ?? []).length !== 1
+  ) {
+    issues.push(
+      "protected private-draft safeguard must revalidate candidate state immediately before staging",
+    );
+  }
   const publishOutputs = mapping(publish.outputs, "desktop publish outputs", issues);
   const expectedPublishOutputs: Mapping = {
     latest_id: "${{ steps.observe.outputs.latest_id }}",


### PR DESCRIPTION
## Summary
- run the protected desktop release transaction as a same-commit reusable workflow, eliminating the private-draft read from the read-only authorizer
- bind exact caller and called workflow identities, permissions, and concurrency, then revalidate release state at the protected publication boundary
- accept sealed artifact provenance from both the legacy child run and future same-run coordinator releases without weakening tag, commit, ancestry, or artifact checks

## Testing
- 9 focused release and updater test files: 400 tests passed
- desktop release structural checker
- TypeScript check
- oxlint and oxfmt check
- YAML parsing and 50 embedded shell syntax checks

No changeset: CI and release infrastructure only. npm and desktop versions are unchanged.