### PR TITLE
fix(ci): build desktop updater verifier dependencies

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1255,6 +1255,8 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Build updater acceptance dependencies
+        run: pnpm --filter '@enduragent/desktop^...' build
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           artifact-ids: ${{ needs.sign-macos.outputs.artifact_id }}

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -1137,6 +1137,62 @@ describe("desktop release workflow policy", () => {
       "test:disabled-roundtrip",
     );
     expectIssue({ ...source, desktop: noRoundTrip }, "production-feed N-to-N+1 round trip");
+    const missingDependencyBuild = replaceRequired(
+      source.desktop,
+      "pnpm --filter '@enduragent/desktop^...' build",
+      "pnpm --filter '@enduragent/desktop^...' check",
+    );
+    expectIssue(
+      { ...source, desktop: missingDependencyBuild },
+      "production-feed N-to-N+1 round trip",
+    );
+    const dependencyBuildBeforeInstall = replaceRequired(
+      source.desktop,
+      "      - run: pnpm install --frozen-lockfile\n      - name: Build updater acceptance dependencies\n        run: pnpm --filter '@enduragent/desktop^...' build",
+      "      - name: Build updater acceptance dependencies\n        run: pnpm --filter '@enduragent/desktop^...' build\n      - run: pnpm install --frozen-lockfile",
+    );
+    expectIssue(
+      { ...source, desktop: dependencyBuildBeforeInstall },
+      "production-feed N-to-N+1 round trip",
+    );
+    const freshOnlyDependencyBuild = replaceRequired(
+      source.desktop,
+      "      - name: Build updater acceptance dependencies\n        run: pnpm --filter '@enduragent/desktop^...' build",
+      "      - name: Build updater acceptance dependencies\n        if: ${{ inputs.source_run_id == 'none' }}\n        run: pnpm --filter '@enduragent/desktop^...' build",
+    );
+    expectIssue(
+      { ...source, desktop: freshOnlyDependencyBuild },
+      "production-feed N-to-N+1 round trip",
+    );
+    const duplicateDependencyBuild = replaceRequired(
+      source.desktop,
+      "      - name: Build updater acceptance dependencies\n        run: pnpm --filter '@enduragent/desktop^...' build",
+      "      - name: Build updater acceptance dependencies\n        run: pnpm --filter '@enduragent/desktop^...' build\n      - name: Duplicate updater acceptance dependency build\n        run: pnpm --filter '@enduragent/desktop^...' build",
+    );
+    expectIssue(
+      { ...source, desktop: duplicateDependencyBuild },
+      "production-feed N-to-N+1 round trip",
+    );
+    const updaterCommandBlock =
+      '          pnpm --filter @enduragent/desktop test:macos-update-roundtrip \\\n            "$BASELINE_VERSION" \\\n            "$CANDIDATE_VERSION" \\\n            "$RUNNER_TEMP/desktop-baseline" \\\n            "$CANDIDATE_ENVELOPE" \\\n            "$EVIDENCE"';
+    const updaterRemovedFromExercise = replaceRequired(
+      source.desktop,
+      updaterCommandBlock,
+      "          echo 'updater command moved before dependency build'",
+    );
+    const updaterBeforeDependencyBuild = replaceRequired(
+      updaterRemovedFromExercise,
+      "      - name: Build updater acceptance dependencies\n        run: pnpm --filter '@enduragent/desktop^...' build",
+      `      - name: Run updater command too early
+        run: |
+${updaterCommandBlock}
+      - name: Build updater acceptance dependencies
+        run: pnpm --filter '@enduragent/desktop^...' build`,
+    );
+    expectIssue(
+      { ...source, desktop: updaterBeforeDependencyBuild },
+      "production-feed N-to-N+1 round trip",
+    );
     const bypass = replaceRequired(
       source.desktop,
       "needs.verify-production-update.result == 'success'",

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -1272,14 +1272,41 @@ fi`;
     );
   }
 
+  const roundTripSteps = steps(roundTrip);
+  const roundTripInstallIndex = roundTripSteps.findIndex(
+    (step) => step.run === "pnpm install --frozen-lockfile",
+  );
+  const dependencyBuildCommand = "pnpm --filter '@enduragent/desktop^...' build";
+  const nativeUpdaterCommand = "pnpm --filter @enduragent/desktop test:macos-update-roundtrip \\";
+  const dependencyBuildIndexes = roundTripSteps.flatMap((step, index) =>
+    step.name === "Build updater acceptance dependencies" &&
+    step.if === undefined &&
+    step.run === dependencyBuildCommand
+      ? [index]
+      : [],
+  );
+  const roundTripExerciseIndexes = roundTripSteps.flatMap((step, index) =>
+    step.name === "Exercise native production-feed update" &&
+    typeof step.run === "string" &&
+    countShellLine(step.run, nativeUpdaterCommand) === 1
+      ? [index]
+      : [],
+  );
+  const dependencyBuildIndex = dependencyBuildIndexes[0];
+  const roundTripExerciseIndex = roundTripExerciseIndexes[0];
+
   if (
+    dependencyBuildIndexes.length !== 1 ||
+    countShellLine(roundTripRun, dependencyBuildCommand) !== 1 ||
+    roundTripExerciseIndexes.length !== 1 ||
+    dependencyBuildIndex === undefined ||
+    roundTripExerciseIndex === undefined ||
+    dependencyBuildIndex <= roundTripInstallIndex ||
+    dependencyBuildIndex >= roundTripExerciseIndex ||
     roundTrip.if !== "${{ inputs.mode == 'steady' }}" ||
     !exactStringSet(roundTrip.needs, ["sign-macos", "reconcile-latest"]) ||
     !roundTripRun.includes("desktop-release:transaction public-envelope") ||
-    countShellLine(
-      roundTripRun,
-      "pnpm --filter @enduragent/desktop test:macos-update-roundtrip \\",
-    ) !== 1 ||
+    countShellLine(roundTripRun, nativeUpdaterCommand) !== 1 ||
     !roundTripRun.includes('"$RUNNER_TEMP/desktop-baseline"') ||
     !roundTripRun.includes('"$CANDIDATE_ENVELOPE"') ||
     !roundTripRun.includes('"$EVIDENCE"') ||


### PR DESCRIPTION
## Summary\n- build the complete desktop workspace dependency closure in the clean native updater acceptance job\n- enforce the exact unconditional build and its ordering before the real updater command\n- add mutation coverage for missing, conditional, duplicate, and misordered builds\n\n## Verification\n- dependency-closure build completed for all desktop prerequisites\n- updater verifier module loaded successfully in a clean job-equivalent checkout\n- 55 focused workflow-policy tests passed\n- workflow structure, TypeScript, lint, formatting, YAML parsing, and diff checks passed\n- fresh-context ship review passed after both checker findings were fixed\n\nCI/release-harness only; no package version or npm publication change.