### PR TITLE
fix(desktop): bound updater acceptance cleanup

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1222,6 +1222,7 @@ jobs:
 
   verify-production-update:
     runs-on: macos-15
+    timeout-minutes: 30
     needs: [sign-macos, reconcile-latest]
     if: ${{ inputs.mode == 'steady' }}
     permissions:
@@ -1232,7 +1233,7 @@ jobs:
         with:
           ref: ${{ inputs.commit }}
           persist-credentials: false
-      - name: Bind recovery transaction tooling
+      - name: Bind recovery release tooling
         env:
           RELEASE_COMMIT: ${{ inputs.commit }}
           RELEASE_TOOLING_COMMIT: ${{ inputs.tooling_commit }}
@@ -1244,8 +1245,10 @@ jobs:
           fi
           git fetch --no-tags origin "$RELEASE_TOOLING_COMMIT"
           git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \
+            apps/desktop/scripts/verify-updater-round-trip.mjs \
             tools/desktop-release-transaction.ts
-          test "$(git diff --cached --name-only)" = 'tools/desktop-release-transaction.ts'
+          EXPECTED_RECOVERY_DIFF=$'apps/desktop/scripts/verify-updater-round-trip.mjs\ntools/desktop-release-transaction.ts'
+          test "$(git diff --cached --name-only)" = "$EXPECTED_RECOVERY_DIFF"
           test -z "$(git diff --name-only)"
           test -z "$(git ls-files --others --exclude-standard)"
           test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"

--- a/apps/desktop/scripts/verify-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-updater-round-trip.mjs
@@ -27,6 +27,7 @@ import { connectCdp, reservePort, waitForPage } from "../tests/helpers/desktop-f
 import {
   callAcceptanceCdp,
   runAcceptanceCommand,
+  terminateAcceptanceChild,
   withAcceptanceDeadline,
 } from "../tests/fixtures/packaged-telegram/acceptance-deadline.ts";
 import {
@@ -43,6 +44,9 @@ const maximumUpdateInfoBytes = 16_384;
 const downloadTimeoutMs = 10 * 60_000;
 const transitionTimeoutMs = 2 * 60_000;
 const shutdownTimeoutMs = 30_000;
+const cleanupTerminationGraceMs = 2_000;
+const cleanupKillGraceMs = 2_000;
+const cleanupSocketGraceMs = 1_000;
 const credentialDirectoryName = "credentials-v1";
 const persistenceCredentialSlot = "openrouter";
 const persistenceChatId = "desktop";
@@ -53,6 +57,27 @@ class MacosUpdaterRoundTripError extends Error {
     super(message);
     this.name = "MacosUpdaterRoundTripError";
   }
+}
+
+const failureDiagnostics = new WeakMap();
+
+function bindFailureDiagnostic(error, phase, cleanup) {
+  const failure =
+    error instanceof Error ? error : new MacosUpdaterRoundTripError("round-trip failed");
+  failureDiagnostics.set(failure, Object.freeze({ phase, cleanup }));
+  return failure;
+}
+
+function safeFailureDiagnostic(error) {
+  if (!(error instanceof Error)) {
+    return Object.freeze({ phase: "input-validation", cleanup: "not-started" });
+  }
+  const diagnostic =
+    failureDiagnostics.get(error) ??
+    Object.freeze({ phase: "input-validation", cleanup: "not-started" });
+  return error instanceof MacosUpdaterRoundTripError
+    ? Object.freeze({ ...diagnostic, reason: error.message })
+    : diagnostic;
 }
 
 function fail(message) {
@@ -1103,301 +1128,437 @@ export function createMacosUpdaterRoundTripEvidence(input) {
   });
 }
 
-export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
-  const input = requireMacosUpdaterRoundTripInput(rawInput, {
-    platform: overrides.platform,
-    arch: overrides.arch,
-    mode: overrides.mode,
-  });
-  const verifyArtifacts = overrides.verifyArtifacts ?? verifyArtifactsForVersion;
-  const inspectApplication = overrides.inspectApplication ?? inspectMacosReleaseApplication;
-  const createScratch = overrides.createScratch ?? createPrivateScratch;
-  const removeScratch = overrides.removeScratch ?? removePrivateScratch;
-  const observeProcesses = overrides.observeProcesses ?? observeApplicationProcesses;
-  const writeEvidenceFile = overrides.writeEvidence ?? writeEvidence;
-  const baselineArtifacts = await verifyArtifacts(input.baselineEnvelope, input.baselineVersion);
-  const candidateArtifacts = await verifyArtifacts(input.candidateEnvelope, input.candidateVersion);
-  if (
-    baselineArtifacts?.version !== input.baselineVersion ||
-    candidateArtifacts?.version !== input.candidateVersion
-  ) {
-    fail("verified release envelope version is invalid");
+function closeChildHandles(child) {
+  for (const stream of [child.stdin, child.stdout, child.stderr]) {
+    try {
+      stream?.destroy();
+    } catch {}
   }
-  const [baselineDigest, candidateDigest] = await Promise.all([
-    digestStableFile(baselineArtifacts.paths.zip, "baseline release ZIP"),
-    digestStableFile(candidateArtifacts.paths.zip, "candidate release ZIP"),
-  ]);
-  requireArtifactDigest(baselineArtifacts, baselineDigest, "baseline");
-  requireArtifactDigest(candidateArtifacts, candidateDigest, "candidate");
-
-  const scratch = await createScratch();
-  let initialChild;
-  let verificationChild;
-  let relaunchedPid;
-  let debuggerConnection;
-  let verificationConnection;
-  let installedApplication;
-  let completed = false;
   try {
-    const baselineApplication = await extractSingleApplication(
-      baselineArtifacts.paths.zip,
-      join(scratch.path, "baseline"),
-    );
-    const candidateApplication = await extractSingleApplication(
-      candidateArtifacts.paths.zip,
-      join(scratch.path, "candidate"),
-    );
-    const installRoot = join(scratch.path, "installed");
-    await mkdir(installRoot, { mode: 0o700 });
-    installedApplication = join(installRoot, `${productName}.app`);
-    await installApplication(baselineApplication, installedApplication);
-    const [baselineIdentity, candidateIdentity, installedBaselineIdentity] = await Promise.all([
-      inspectApplication(baselineApplication),
-      inspectApplication(candidateApplication),
-      inspectApplication(installedApplication),
-    ]);
-    const updaterCache = join(scratch.path, "home/Library/Caches", DESKTOP_UPDATER_CACHE_DIRECTORY);
-    await requireMissing(updaterCache, "round-trip updater cache");
-    const home = join(scratch.path, "home");
-    const athleteHome = join(scratch.path, "athlete");
-    const userData = join(scratch.path, "user-data");
-    await Promise.all([
-      mkdir(home, { recursive: true, mode: 0o700 }),
-      mkdir(athleteHome, { recursive: true, mode: 0o700 }),
-      mkdir(userData, { recursive: true, mode: 0o700 }),
-    ]);
-    const durableState = await seedSyntheticDurableState(athleteHome);
-    const credentialPlaintext = `enduragent-update-${randomBytes(32).toString("hex")}`;
-    const credentialPath = join(
-      userData,
-      credentialDirectoryName,
-      `${persistenceCredentialSlot}.bin`,
-    );
-    const debuggerPort = await reservePort();
-    const executable = join(installedApplication, `Contents/MacOS/${productName}`);
-    const environment = {
-      ...process.env,
-      HOME: home,
-      ENDURAGENT_HOME: athleteHome,
-      FORCE_COLOR: undefined,
-      NO_COLOR: undefined,
-      CLICOLOR_FORCE: undefined,
-    };
-    initialChild = spawn(
-      executable,
-      [`--user-data-dir=${userData}`, `--remote-debugging-port=${debuggerPort}`],
-      { env: environment, stdio: ["ignore", "pipe", "pipe"] },
-    );
-    initialChild.stdout?.resume();
-    initialChild.stderr?.resume();
-    const childLifecycle = observeTelegramAcceptanceChild(initialChild);
-    const launch = await withAcceptanceDeadline(
-      "baseline application launch",
-      childLifecycle.launch,
-      {
-        timeoutMs: 30_000,
-      },
-    );
-    if (launch.state !== "spawned") fail("baseline application could not launch");
-    const initialPid = launch.pid;
-    const debuggerUrl = await waitForPage(debuggerPort, { timeoutMs: 60_000 });
-    if ((await debuggerListenerOwner(debuggerPort, environment)) !== initialPid) {
-      fail("baseline debugger listener is outside the installed application");
-    }
-    debuggerConnection = await connectCdp(debuggerUrl, () => undefined);
-    await callAcceptanceCdp(debuggerConnection, "Runtime.enable");
-    const persistenceInput = {
-      athleteHome,
-      credentialPath,
-      credentialPlaintext,
-      memoryPath: durableState.memoryPath,
-      sessionPath: durableState.sessionPath,
-    };
-    const beforePersistence = await seedApplicationState(debuggerConnection, persistenceInput);
-    await waitForDownloadedState(debuggerConnection, input.candidateVersion);
-    const initialProcesses = await observeProcesses(installedApplication);
-    if (initialProcesses.mainPids.length !== 1 || initialProcesses.mainPids[0] !== initialPid) {
-      fail("baseline application process identity is ambiguous");
-    }
-    const downloaded = await readDownloadedCandidate(
-      updaterCache,
-      candidateArtifacts,
-      candidateDigest,
-    );
-    await clickInstallUpdate(debuggerConnection, input.candidateVersion);
-    const terminal = await withAcceptanceDeadline(
-      "baseline application update exit",
-      childLifecycle.terminal,
-      { timeoutMs: transitionTimeoutMs },
-    );
-    debuggerConnection.socket.close();
-    debuggerConnection = undefined;
-    if (terminal.state !== "closed" || terminal.code !== 0 || terminal.signal !== null) {
-      fail("baseline application did not exit cleanly for update");
-    }
-    const initialPids = new Set(initialProcesses.bundlePids);
-    const relaunchedProcesses = await waitUntil(
-      "relaunched candidate application",
-      async () => {
-        const observation = await observeProcesses(installedApplication);
-        if (observation.bundlePids.some((pid) => initialPids.has(pid))) return false;
-        if (observation.mainPids.length !== 1 || observation.mainPids[0] === initialPid)
-          return false;
-        return observation;
-      },
-      transitionTimeoutMs,
-      250,
-    );
-    relaunchedPid = relaunchedProcesses.mainPids[0];
-    const relaunchedIdentity = await waitUntil(
-      "relaunched candidate identity",
-      async () => {
-        const identity = await inspectApplication(installedApplication);
-        return identity.version === input.candidateVersion ? identity : false;
-      },
-      transitionTimeoutMs,
-      250,
-    );
-    const identity = verifyMacosUpdaterRoundTripIdentities({
-      baselineVersion: input.baselineVersion,
-      candidateVersion: input.candidateVersion,
-      expectedFeedUrl: MACOS_UPDATER_ROUND_TRIP_FEED_URL,
-      baseline: baselineIdentity,
-      candidate: candidateIdentity,
-      installedBaseline: installedBaselineIdentity,
-      relaunched: relaunchedIdentity,
+    child.unref();
+  } catch {}
+}
+
+async function terminateRoundTripChild(child) {
+  if (child === undefined) return true;
+  if (child.exitCode !== null || child.signalCode !== null) {
+    closeChildHandles(child);
+    return true;
+  }
+  let terminated = false;
+  try {
+    terminated = await terminateAcceptanceChild(child, {
+      terminationGraceMs: cleanupTerminationGraceMs,
+      killGraceMs: cleanupKillGraceMs,
     });
-    const beforeFinalShutdown = await observeProcesses(installedApplication);
-    if (
-      beforeFinalShutdown.mainPids.length !== 1 ||
-      beforeFinalShutdown.mainPids[0] !== relaunchedPid
-    ) {
-      fail("relaunched application process identity changed before shutdown");
-    }
-    process.kill(relaunchedPid, "SIGTERM");
-    await waitUntil(
-      "relaunched application graceful shutdown",
-      async () => {
-        const observation = await observeProcesses(installedApplication);
-        return observation.bundlePids.length === 0 ? true : false;
-      },
-      shutdownTimeoutMs,
-      100,
+  } catch {}
+  closeChildHandles(child);
+  return terminated;
+}
+
+function observeRoundTripChildExit(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+  return new Promise((resolveExit) => {
+    child.once("exit", (code, signal) => resolveExit({ code, signal }));
+  });
+}
+
+async function closeRoundTripConnection(connection) {
+  if (connection === undefined) return true;
+  const socket = connection.socket;
+  if (socket.readyState === 3) return true;
+  let closed;
+  try {
+    closed = new Promise((resolveClose) =>
+      socket.addEventListener("close", () => resolveClose(true), { once: true }),
     );
-    const verificationPort = await reservePort();
-    verificationChild = spawn(
-      executable,
-      [`--user-data-dir=${userData}`, `--remote-debugging-port=${verificationPort}`],
-      { env: environment, stdio: ["ignore", "pipe", "pipe"] },
-    );
-    verificationChild.stdout?.resume();
-    verificationChild.stderr?.resume();
-    const verificationLifecycle = observeTelegramAcceptanceChild(verificationChild);
-    const verificationLaunch = await withAcceptanceDeadline(
-      "candidate persistence verification launch",
-      verificationLifecycle.launch,
-      { timeoutMs: 30_000 },
-    );
-    if (verificationLaunch.state !== "spawned") {
-      fail("candidate persistence verification could not launch");
-    }
-    const verificationUrl = await waitForPage(verificationPort, { timeoutMs: 60_000 });
-    if ((await debuggerListenerOwner(verificationPort, environment)) !== verificationLaunch.pid) {
-      fail("candidate persistence debugger listener is outside the installed application");
-    }
-    verificationConnection = await connectCdp(verificationUrl, () => undefined);
-    await callAcceptanceCdp(verificationConnection, "Runtime.enable");
-    const afterPersistence = await readPersistenceView(verificationConnection, persistenceInput);
-    verificationChild.kill("SIGTERM");
-    const verificationTerminal = await withAcceptanceDeadline(
-      "candidate persistence verification shutdown",
-      verificationLifecycle.terminal,
-      { timeoutMs: shutdownTimeoutMs },
-    );
-    verificationConnection.socket.close();
-    verificationConnection = undefined;
-    if (
-      verificationTerminal.state !== "closed" ||
-      verificationTerminal.code !== 0 ||
-      verificationTerminal.signal !== null
-    ) {
-      fail("candidate persistence verification did not exit cleanly");
-    }
-    await waitUntil(
-      "candidate persistence verification process cleanup",
-      async () => {
-        const observation = await observeProcesses(installedApplication);
-        return observation.bundlePids.length === 0 ? true : false;
-      },
-      shutdownTimeoutMs,
-      100,
-    );
-    const plaintextCredentialAbsent = await requirePlaintextAbsent(
-      [home, userData, athleteHome],
-      credentialPlaintext,
-    );
-    const persistence = verifyMacosUpdaterRoundTripPersistence({
-      before: beforePersistence,
-      after: afterPersistence,
-      plaintextCredentialAbsent,
-    });
-    const evidence = createMacosUpdaterRoundTripEvidence({
-      baselineVersion: input.baselineVersion,
-      candidateVersion: input.candidateVersion,
-      initialPid,
-      relaunchedPid,
-      identity,
-      download: {
-        fileName: downloaded.info.fileName,
-        size: downloaded.digest.size,
-        sha256: downloaded.digest.sha256,
-        sha512: downloaded.digest.sha512,
-      },
-      persistence,
-    });
-    await removeScratch(scratch);
-    await writeEvidenceFile(input.evidencePath, evidence);
-    completed = true;
-    return evidence;
-  } finally {
+    socket.close();
+  } catch {
+    return false;
+  }
+  const graceful = await withAcceptanceDeadline("updater debugger cleanup", closed, {
+    timeoutMs: cleanupSocketGraceMs,
+  }).catch(() => false);
+  if (graceful) return true;
+  try {
+    socket.terminate?.();
+  } catch {}
+  return withAcceptanceDeadline("updater debugger termination", closed, {
+    timeoutMs: cleanupSocketGraceMs,
+  }).catch(() => false);
+}
+
+function signalObservedProcesses(observation, signal) {
+  for (const pid of observation.bundlePids) {
     try {
-      debuggerConnection?.socket.close();
-    } catch {}
+      process.kill(pid, signal);
+    } catch (error) {
+      if (error?.code !== "ESRCH") return false;
+    }
+  }
+  return true;
+}
+
+async function waitForObservedProcessExit(observeProcesses, application, timeoutMs) {
+  return waitUntil(
+    "updater application cleanup",
+    async () => {
+      const observation = await observeProcesses(application);
+      return observation.bundlePids.length === 0 ? true : false;
+    },
+    timeoutMs,
+    100,
+  ).catch(() => false);
+}
+
+async function terminateObservedApplication(observeProcesses, application) {
+  if (application === undefined) return true;
+  let observation;
+  try {
+    observation = await observeProcesses(application);
+  } catch {
+    return false;
+  }
+  if (observation.bundlePids.length === 0) return true;
+  const gracefulSignalSent = signalObservedProcesses(observation, "SIGTERM");
+  if (
+    gracefulSignalSent &&
+    (await waitForObservedProcessExit(observeProcesses, application, cleanupTerminationGraceMs))
+  ) {
+    return true;
+  }
+  try {
+    observation = await observeProcesses(application);
+  } catch {
+    return false;
+  }
+  if (!signalObservedProcesses(observation, "SIGKILL")) return false;
+  return waitForObservedProcessExit(observeProcesses, application, cleanupKillGraceMs);
+}
+
+async function cleanupRoundTripResources(input) {
+  const [connectionResults, childResults] = await Promise.all([
+    Promise.all([
+      closeRoundTripConnection(input.debuggerConnection),
+      closeRoundTripConnection(input.verificationConnection),
+    ]),
+    Promise.all([
+      terminateRoundTripChild(input.initialChild),
+      terminateRoundTripChild(input.verificationChild),
+    ]),
+  ]);
+  const applicationTerminated = input.terminateApplication
+    ? await terminateObservedApplication(input.observeProcesses, input.installedApplication)
+    : true;
+  return [...connectionResults, ...childResults, applicationTerminated].every(Boolean);
+}
+
+export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
+  let phase = "input-validation";
+  let failurePhase;
+  let cleanup = "not-started";
+  try {
+    const input = requireMacosUpdaterRoundTripInput(rawInput, {
+      platform: overrides.platform,
+      arch: overrides.arch,
+      mode: overrides.mode,
+    });
+    const verifyArtifacts = overrides.verifyArtifacts ?? verifyArtifactsForVersion;
+    const inspectApplication = overrides.inspectApplication ?? inspectMacosReleaseApplication;
+    const createScratch = overrides.createScratch ?? createPrivateScratch;
+    const removeScratch = overrides.removeScratch ?? removePrivateScratch;
+    const observeProcesses = overrides.observeProcesses ?? observeApplicationProcesses;
+    const writeEvidenceFile = overrides.writeEvidence ?? writeEvidence;
+    phase = "verify-release-envelopes";
+    const baselineArtifacts = await verifyArtifacts(input.baselineEnvelope, input.baselineVersion);
+    const candidateArtifacts = await verifyArtifacts(
+      input.candidateEnvelope,
+      input.candidateVersion,
+    );
+    if (
+      baselineArtifacts?.version !== input.baselineVersion ||
+      candidateArtifacts?.version !== input.candidateVersion
+    ) {
+      fail("verified release envelope version is invalid");
+    }
+    phase = "verify-release-digests";
+    const [baselineDigest, candidateDigest] = await Promise.all([
+      digestStableFile(baselineArtifacts.paths.zip, "baseline release ZIP"),
+      digestStableFile(candidateArtifacts.paths.zip, "candidate release ZIP"),
+    ]);
+    requireArtifactDigest(baselineArtifacts, baselineDigest, "baseline");
+    requireArtifactDigest(candidateArtifacts, candidateDigest, "candidate");
+
+    phase = "prepare-scratch";
+    const scratch = await createScratch();
+    let initialChild;
+    let verificationChild;
+    let relaunchedPid;
+    let debuggerConnection;
+    let verificationConnection;
+    let installedApplication;
+    let completed = false;
     try {
-      verificationConnection?.socket.close();
-    } catch {}
-    if (!completed) {
-      if (
-        initialChild !== undefined &&
-        initialChild.exitCode === null &&
-        initialChild.signalCode === null
-      ) {
-        try {
-          initialChild.kill("SIGTERM");
-        } catch {}
+      phase = "extract-release-applications";
+      const baselineApplication = await extractSingleApplication(
+        baselineArtifacts.paths.zip,
+        join(scratch.path, "baseline"),
+      );
+      const candidateApplication = await extractSingleApplication(
+        candidateArtifacts.paths.zip,
+        join(scratch.path, "candidate"),
+      );
+      phase = "install-baseline";
+      const installRoot = join(scratch.path, "installed");
+      await mkdir(installRoot, { mode: 0o700 });
+      installedApplication = join(installRoot, `${productName}.app`);
+      await installApplication(baselineApplication, installedApplication);
+      phase = "inspect-release-identities";
+      const [baselineIdentity, candidateIdentity, installedBaselineIdentity] = await Promise.all([
+        inspectApplication(baselineApplication),
+        inspectApplication(candidateApplication),
+        inspectApplication(installedApplication),
+      ]);
+      const updaterCache = join(
+        scratch.path,
+        "home/Library/Caches",
+        DESKTOP_UPDATER_CACHE_DIRECTORY,
+      );
+      await requireMissing(updaterCache, "round-trip updater cache");
+      const home = join(scratch.path, "home");
+      const athleteHome = join(scratch.path, "athlete");
+      const userData = join(scratch.path, "user-data");
+      await Promise.all([
+        mkdir(home, { recursive: true, mode: 0o700 }),
+        mkdir(athleteHome, { recursive: true, mode: 0o700 }),
+        mkdir(userData, { recursive: true, mode: 0o700 }),
+      ]);
+      phase = "prepare-persistence";
+      const durableState = await seedSyntheticDurableState(athleteHome);
+      const credentialPlaintext = `enduragent-update-${randomBytes(32).toString("hex")}`;
+      const credentialPath = join(
+        userData,
+        credentialDirectoryName,
+        `${persistenceCredentialSlot}.bin`,
+      );
+      const debuggerPort = await reservePort();
+      const executable = join(installedApplication, `Contents/MacOS/${productName}`);
+      const environment = {
+        ...process.env,
+        HOME: home,
+        ENDURAGENT_HOME: athleteHome,
+        FORCE_COLOR: undefined,
+        NO_COLOR: undefined,
+        CLICOLOR_FORCE: undefined,
+      };
+      phase = "launch-baseline";
+      initialChild = spawn(
+        executable,
+        [`--user-data-dir=${userData}`, `--remote-debugging-port=${debuggerPort}`],
+        { env: environment, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      initialChild.stdout?.resume();
+      initialChild.stderr?.resume();
+      const childLifecycle = observeTelegramAcceptanceChild(initialChild);
+      const initialExit = observeRoundTripChildExit(initialChild);
+      const launch = await withAcceptanceDeadline(
+        "baseline application launch",
+        childLifecycle.launch,
+        {
+          timeoutMs: 30_000,
+        },
+      );
+      if (launch.state !== "spawned") fail("baseline application could not launch");
+      const initialPid = launch.pid;
+      const debuggerUrl = await waitForPage(debuggerPort, { timeoutMs: 60_000 });
+      if ((await debuggerListenerOwner(debuggerPort, environment)) !== initialPid) {
+        fail("baseline debugger listener is outside the installed application");
       }
-      if (
-        verificationChild !== undefined &&
-        verificationChild.exitCode === null &&
-        verificationChild.signalCode === null
-      ) {
-        try {
-          verificationChild.kill("SIGTERM");
-        } catch {}
+      debuggerConnection = await connectCdp(debuggerUrl, () => undefined);
+      await callAcceptanceCdp(debuggerConnection, "Runtime.enable");
+      const persistenceInput = {
+        athleteHome,
+        credentialPath,
+        credentialPlaintext,
+        memoryPath: durableState.memoryPath,
+        sessionPath: durableState.sessionPath,
+      };
+      phase = "seed-persistence";
+      const beforePersistence = await seedApplicationState(debuggerConnection, persistenceInput);
+      phase = "download-update";
+      await waitForDownloadedState(debuggerConnection, input.candidateVersion);
+      const initialProcesses = await observeProcesses(installedApplication);
+      if (initialProcesses.mainPids.length !== 1 || initialProcesses.mainPids[0] !== initialPid) {
+        fail("baseline application process identity is ambiguous");
       }
-      if (
-        installedApplication !== undefined &&
-        Number.isSafeInteger(relaunchedPid) &&
-        relaunchedPid > 0
-      ) {
-        try {
+      const downloaded = await readDownloadedCandidate(
+        updaterCache,
+        candidateArtifacts,
+        candidateDigest,
+      );
+      phase = "install-update";
+      await clickInstallUpdate(debuggerConnection, input.candidateVersion);
+      phase = "transition-update";
+      const terminal = await withAcceptanceDeadline(
+        "baseline application update exit",
+        initialExit,
+        { timeoutMs: transitionTimeoutMs },
+      );
+      debuggerConnection.socket.close();
+      if (terminal.code !== 0 || terminal.signal !== null) {
+        fail("baseline application did not exit cleanly for update");
+      }
+      const initialPids = new Set(initialProcesses.bundlePids);
+      phase = "observe-relaunch";
+      const relaunchedProcesses = await waitUntil(
+        "relaunched candidate application",
+        async () => {
           const observation = await observeProcesses(installedApplication);
-          if (observation.mainPids.includes(relaunchedPid)) {
-            process.kill(relaunchedPid, "SIGTERM");
-          }
-        } catch {}
+          if (observation.bundlePids.some((pid) => initialPids.has(pid))) return false;
+          if (observation.mainPids.length !== 1 || observation.mainPids[0] === initialPid)
+            return false;
+          return observation;
+        },
+        transitionTimeoutMs,
+        250,
+      );
+      relaunchedPid = relaunchedProcesses.mainPids[0];
+      phase = "verify-relaunch";
+      const relaunchedIdentity = await waitUntil(
+        "relaunched candidate identity",
+        async () => {
+          const identity = await inspectApplication(installedApplication);
+          return identity.version === input.candidateVersion ? identity : false;
+        },
+        transitionTimeoutMs,
+        250,
+      );
+      const identity = verifyMacosUpdaterRoundTripIdentities({
+        baselineVersion: input.baselineVersion,
+        candidateVersion: input.candidateVersion,
+        expectedFeedUrl: MACOS_UPDATER_ROUND_TRIP_FEED_URL,
+        baseline: baselineIdentity,
+        candidate: candidateIdentity,
+        installedBaseline: installedBaselineIdentity,
+        relaunched: relaunchedIdentity,
+      });
+      const beforeFinalShutdown = await observeProcesses(installedApplication);
+      if (
+        beforeFinalShutdown.mainPids.length !== 1 ||
+        beforeFinalShutdown.mainPids[0] !== relaunchedPid
+      ) {
+        fail("relaunched application process identity changed before shutdown");
+      }
+      phase = "shutdown-relaunch";
+      process.kill(relaunchedPid, "SIGTERM");
+      await waitUntil(
+        "relaunched application graceful shutdown",
+        async () => {
+          const observation = await observeProcesses(installedApplication);
+          return observation.bundlePids.length === 0 ? true : false;
+        },
+        shutdownTimeoutMs,
+        100,
+      );
+      phase = "launch-persistence-verification";
+      const verificationPort = await reservePort();
+      verificationChild = spawn(
+        executable,
+        [`--user-data-dir=${userData}`, `--remote-debugging-port=${verificationPort}`],
+        { env: environment, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      verificationChild.stdout?.resume();
+      verificationChild.stderr?.resume();
+      const verificationLifecycle = observeTelegramAcceptanceChild(verificationChild);
+      const verificationExit = observeRoundTripChildExit(verificationChild);
+      const verificationLaunch = await withAcceptanceDeadline(
+        "candidate persistence verification launch",
+        verificationLifecycle.launch,
+        { timeoutMs: 30_000 },
+      );
+      if (verificationLaunch.state !== "spawned") {
+        fail("candidate persistence verification could not launch");
+      }
+      const verificationUrl = await waitForPage(verificationPort, { timeoutMs: 60_000 });
+      if ((await debuggerListenerOwner(verificationPort, environment)) !== verificationLaunch.pid) {
+        fail("candidate persistence debugger listener is outside the installed application");
+      }
+      verificationConnection = await connectCdp(verificationUrl, () => undefined);
+      await callAcceptanceCdp(verificationConnection, "Runtime.enable");
+      phase = "verify-persistence";
+      const afterPersistence = await readPersistenceView(verificationConnection, persistenceInput);
+      phase = "shutdown-persistence-verification";
+      verificationChild.kill("SIGTERM");
+      const verificationTerminal = await withAcceptanceDeadline(
+        "candidate persistence verification shutdown",
+        verificationExit,
+        { timeoutMs: shutdownTimeoutMs },
+      );
+      verificationConnection.socket.close();
+      if (verificationTerminal.code !== 0 || verificationTerminal.signal !== null) {
+        fail("candidate persistence verification did not exit cleanly");
+      }
+      await waitUntil(
+        "candidate persistence verification process cleanup",
+        async () => {
+          const observation = await observeProcesses(installedApplication);
+          return observation.bundlePids.length === 0 ? true : false;
+        },
+        shutdownTimeoutMs,
+        100,
+      );
+      phase = "validate-persistence";
+      const plaintextCredentialAbsent = await requirePlaintextAbsent(
+        [home, userData, athleteHome],
+        credentialPlaintext,
+      );
+      const persistence = verifyMacosUpdaterRoundTripPersistence({
+        before: beforePersistence,
+        after: afterPersistence,
+        plaintextCredentialAbsent,
+      });
+      const evidence = createMacosUpdaterRoundTripEvidence({
+        baselineVersion: input.baselineVersion,
+        candidateVersion: input.candidateVersion,
+        initialPid,
+        relaunchedPid,
+        identity,
+        download: {
+          fileName: downloaded.info.fileName,
+          size: downloaded.digest.size,
+          sha256: downloaded.digest.sha256,
+          sha512: downloaded.digest.sha512,
+        },
+        persistence,
+      });
+      phase = "write-evidence";
+      await removeScratch(scratch);
+      await writeEvidenceFile(input.evidencePath, evidence);
+      completed = true;
+      return evidence;
+    } catch (error) {
+      failurePhase = phase;
+      throw error;
+    } finally {
+      phase = "cleanup";
+      const cleaned = await cleanupRoundTripResources({
+        debuggerConnection,
+        verificationConnection,
+        initialChild,
+        verificationChild,
+        installedApplication,
+        observeProcesses,
+        terminateApplication: !completed,
+      }).catch(() => false);
+      cleanup = cleaned ? "complete" : "incomplete";
+      if (!cleaned && failurePhase === undefined) {
+        fail("round-trip cleanup failed");
       }
     }
+  } catch (error) {
+    throw bindFailureDiagnostic(error, failurePhase ?? phase, cleanup);
   }
 }
 
@@ -1418,8 +1579,12 @@ async function main() {
 if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   try {
     await main();
-  } catch {
-    process.stderr.write("macOS updater round trip failed\n");
+  } catch (error) {
+    const diagnostic = safeFailureDiagnostic(error);
+    const reason = diagnostic.reason === undefined ? "" : `; reason=${diagnostic.reason}`;
+    process.stderr.write(
+      `macOS updater round trip failed; phase=${diagnostic.phase}; cleanup=${diagnostic.cleanup}${reason}\n`,
+    );
     process.exitCode = 1;
   }
 }

--- a/apps/desktop/tests/macos-update-roundtrip-cleanup.test.ts
+++ b/apps/desktop/tests/macos-update-roundtrip-cleanup.test.ts
@@ -1,0 +1,285 @@
+import type { ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { VerifiedMacosReleaseArtifacts } from "../scripts/verify-macos-release.mjs";
+
+const harness = vi.hoisted(() => {
+  let resolveParentExit!: () => void;
+  const parentExit = new Promise<void>((resolve) => {
+    resolveParentExit = resolve;
+  });
+  return {
+    children: [] as ChildProcess[],
+    closePendingAfterExit: false,
+    helperPid: undefined as number | undefined,
+    parentClosed: false,
+    parentExit,
+    resolveParentExit,
+    sensitiveArgument: "updater-cleanup-secret-must-not-appear",
+    termMarker: "",
+  };
+});
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: ((
+      _command: string,
+      _args: readonly string[],
+      options: Parameters<typeof actual.spawn>[2],
+    ) => {
+      const helperCode = [
+        'const fs = require("node:fs");',
+        'process.on("SIGTERM", () => fs.writeFileSync(process.argv[1], "SIGTERM"));',
+        'fs.writeSync(3, "ready");',
+        "setInterval(() => undefined, 1_000);",
+      ].join("");
+      const parentCode = [
+        'const { spawn } = require("node:child_process");',
+        `const helper = spawn(process.execPath, ["-e", ${JSON.stringify(helperCode)}, process.argv[1], process.argv[2]], { stdio: ["ignore", "inherit", "inherit", "pipe"] });`,
+        'helper.stdio[3].once("data", () => {',
+        "  process.stdout.write(`helper:${helper.pid}\\n`, () => process.exit(0));",
+        "});",
+      ].join("");
+      const child = actual.spawn(
+        process.execPath,
+        ["-e", parentCode, harness.termMarker, harness.sensitiveArgument],
+        { ...options, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      let stdout = "";
+      child.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString("utf8");
+        const match = stdout.match(/helper:([1-9][0-9]*)\n/u);
+        if (match?.[1] !== undefined) harness.helperPid = Number(match[1]);
+      });
+      child.once("exit", harness.resolveParentExit);
+      child.once("close", () => {
+        harness.parentClosed = true;
+      });
+      harness.children.push(child);
+      return child;
+    }) as typeof actual.spawn,
+  };
+});
+
+vi.mock("./helpers/desktop-fixture.ts", () => ({
+  connectCdp: vi.fn(),
+  reservePort: vi.fn(async () => 31_337),
+  waitForPage: vi.fn(async () => {
+    await harness.parentExit;
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    harness.closePendingAfterExit = !harness.parentClosed;
+    throw new Error("synthetic updater product failure");
+  }),
+}));
+
+vi.mock("./fixtures/packaged-telegram/acceptance-deadline.ts", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./fixtures/packaged-telegram/acceptance-deadline.ts")>();
+  return {
+    ...actual,
+    runAcceptanceCommand: vi.fn(async (command: string, args: readonly string[]) => {
+      if (command !== "/usr/bin/ditto") throw new Error("unexpected updater test command");
+      const destination = args.at(-1);
+      if (destination === undefined) throw new Error("missing updater test destination");
+      await mkdir(args[0] === "-x" ? join(destination, "Enduragent.app") : destination, {
+        recursive: true,
+        mode: 0o700,
+      });
+      return {
+        code: 0,
+        signal: null,
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+      };
+    }),
+  };
+});
+
+import {
+  MACOS_UPDATER_ROUND_TRIP_FEED_URL,
+  runMacosUpdaterRoundTrip,
+} from "../scripts/verify-updater-round-trip.mjs";
+
+const roots: string[] = [];
+
+function processIsReachable(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+async function stopProcess(pid: number | undefined): Promise<void> {
+  if (pid === undefined || !processIsReachable(pid)) return;
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+    throw error;
+  }
+  const deadline = Date.now() + 1_000;
+  while (processIsReachable(pid) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  child.kill("SIGKILL");
+  await Promise.race([exited, new Promise<void>((resolve) => setTimeout(resolve, 1_000))]);
+}
+
+afterEach(async () => {
+  await Promise.all(harness.children.map(stopChild));
+  await stopProcess(harness.helperPid);
+  harness.children.length = 0;
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function createArtifacts(
+  root: string,
+  version: string,
+  marker: string,
+): Promise<VerifiedMacosReleaseArtifacts> {
+  const directory = join(root, marker);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const names = {
+    dmg: `Enduragent-${version}-arm64.dmg`,
+    zip: `Enduragent-${version}-arm64.zip`,
+    blockmap: `Enduragent-${version}-arm64.zip.blockmap`,
+    metadata: "latest-mac.yml" as const,
+  };
+  const paths = {
+    dmg: join(directory, names.dmg),
+    zip: join(directory, names.zip),
+    blockmap: join(directory, names.blockmap),
+    metadata: join(directory, names.metadata),
+  };
+  const zip = Buffer.from(`synthetic-${marker}-zip`);
+  await Promise.all([
+    writeFile(paths.dmg, `synthetic-${marker}-dmg`),
+    writeFile(paths.zip, zip),
+    writeFile(paths.blockmap, `synthetic-${marker}-blockmap`),
+    writeFile(paths.metadata, `version: ${version}\n`),
+  ]);
+  return {
+    version,
+    names,
+    paths,
+    sizes: {
+      dmg: Buffer.byteLength(`synthetic-${marker}-dmg`),
+      zip: zip.length,
+      blockmap: Buffer.byteLength(`synthetic-${marker}-blockmap`),
+    },
+    dmgSha512: createHash("sha512").update(`synthetic-${marker}-dmg`).digest("base64"),
+    zipSha512: createHash("sha512").update(zip).digest("base64"),
+  };
+}
+
+describe("macOS updater failure cleanup", () => {
+  it("closes inherited pipes and force-kills an observed helper after its parent exits", async () => {
+    const root = await mkdtemp(join(tmpdir(), "updater-cleanup-test-"));
+    roots.push(root);
+    harness.termMarker = join(root, "helper-term.txt");
+    const baselineArtifacts = await createArtifacts(root, "0.1.0", "baseline");
+    const candidateArtifacts = await createArtifacts(root, "0.1.1", "candidate");
+    const scratchPath = join(root, "scratch");
+    await mkdir(scratchPath, { mode: 0o700 });
+    const scratchStat = await lstat(scratchPath);
+    const startedAt = Date.now();
+
+    let failure: unknown;
+    try {
+      await runMacosUpdaterRoundTrip(
+        {
+          baselineVersion: "0.1.0",
+          candidateVersion: "0.1.1",
+          baselineEnvelope: join(root, "baseline-envelope"),
+          candidateEnvelope: join(root, "candidate-envelope"),
+          evidencePath: join(root, "evidence.json"),
+        },
+        {
+          platform: "darwin",
+          arch: "arm64",
+          mode: "steady",
+          verifyArtifacts: async (_envelope, version) =>
+            version === "0.1.0" ? baselineArtifacts : candidateArtifacts,
+          createScratch: async () => ({
+            path: scratchPath,
+            identity: { dev: scratchStat.dev, ino: scratchStat.ino, mode: scratchStat.mode },
+          }),
+          inspectApplication: async (application) => {
+            const candidate = application.includes("/candidate/");
+            const codeDirectorySha256 = (candidate ? "b" : "a").repeat(64);
+            return {
+              version: candidate ? "0.1.1" : "0.1.0",
+              enduragentDesktopRelease: true,
+              feedUrl: MACOS_UPDATER_ROUND_TRIP_FEED_URL,
+              bundleIdentifier: "icu.enduragent.desktop",
+              teamIdentifier: "FA494ACVTF",
+              designatedRequirementSha256: "c".repeat(64),
+              codeDirectorySha256,
+              cdHash: codeDirectorySha256.slice(0, 40),
+            };
+          },
+          observeProcesses: async () => {
+            const helperPid = harness.helperPid;
+            return helperPid !== undefined && processIsReachable(helperPid)
+              ? { bundlePids: [helperPid], mainPids: [] }
+              : { bundlePids: [], mainPids: [] };
+          },
+        },
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    const child = harness.children.at(-1);
+    const helperPid = harness.helperPid;
+    expect(failure).toBeInstanceOf(Error);
+    expect(String(failure)).not.toContain(harness.sensitiveArgument);
+    expect(child).toBeDefined();
+    expect(child?.exitCode).toBe(0);
+    expect(child?.signalCode).toBeNull();
+    expect(harness.closePendingAfterExit).toBe(true);
+    expect(harness.parentClosed).toBe(true);
+    expect(child?.stdout?.destroyed).toBe(true);
+    expect(child?.stderr?.destroyed).toBe(true);
+    expect(helperPid).toBeDefined();
+    expect(await readFile(harness.termMarker, "utf8")).toBe("SIGTERM");
+    expect(processIsReachable(helperPid as number)).toBe(false);
+    const elapsed = Date.now() - startedAt;
+    expect(elapsed).toBeGreaterThanOrEqual(1_800);
+    expect(elapsed).toBeLessThan(4_500);
+  });
+
+  it("pins updater transitions to exit instead of inherited-pipe close", async () => {
+    const source = await readFile(
+      fileURLToPath(new URL("../scripts/verify-updater-round-trip.mjs", import.meta.url)),
+      "utf8",
+    );
+    expect(source).toContain("const initialExit = observeRoundTripChildExit(initialChild);");
+    expect(source).toContain(
+      "const verificationExit = observeRoundTripChildExit(verificationChild);",
+    );
+    expect(source).toMatch(
+      /"baseline application update exit",\s*initialExit,\s*\{ timeoutMs: transitionTimeoutMs \}/u,
+    );
+    expect(source).toMatch(
+      /"candidate persistence verification shutdown",\s*verificationExit,\s*\{ timeoutMs: shutdownTimeoutMs \}/u,
+    );
+    expect(source).not.toMatch(
+      /"(?:baseline application update exit|candidate persistence verification shutdown)",\s*\w+Lifecycle\.terminal/u,
+    );
+  });
+});

--- a/apps/desktop/tests/macos-update-roundtrip.test.ts
+++ b/apps/desktop/tests/macos-update-roundtrip.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   MACOS_UPDATER_ROUND_TRIP_FEED_URL,
@@ -10,6 +11,7 @@ import {
   type MacosUpdaterRoundTripInput,
 } from "../scripts/verify-updater-round-trip.mjs";
 import type { VerifiedMacosReleaseApplication } from "../scripts/verify-macos-release.mjs";
+import { runAcceptanceCommand } from "./fixtures/packaged-telegram/acceptance-deadline.js";
 
 const baselineVersion = "0.1.0";
 const candidateVersion = "0.1.1";
@@ -84,6 +86,76 @@ function persistenceView(overrides: Record<string, unknown> = {}) {
 }
 
 describe("macOS updater round-trip input", () => {
+  it("fails with phase-only diagnostics that do not expose CLI arguments", async () => {
+    const sensitiveArgument = "updater-cli-secret-must-not-appear";
+    const script = fileURLToPath(
+      new URL("../scripts/verify-updater-round-trip.mjs", import.meta.url),
+    );
+    const result = await runAcceptanceCommand(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        script,
+        "0.1.0",
+        "0.1.1",
+        sensitiveArgument,
+        "/private/tmp/candidate-envelope",
+        "/private/tmp/evidence.json",
+      ],
+      { allowFailure: true, timeoutMs: 5_000 },
+    );
+
+    expect(result.code).toBe(1);
+    expect(result.signal).toBeNull();
+    expect(result.stdout).toHaveLength(0);
+    expect(result.stderr.toString("utf8")).toBe(
+      "macOS updater round trip failed; phase=input-validation; cleanup=not-started; reason=round-trip requires a steady macOS arm64 runner\n",
+    );
+    expect(result.stderr.includes(sensitiveArgument)).toBe(false);
+  });
+
+  it("omits unknown error text and CLI paths from failure diagnostics", async () => {
+    const sensitiveArgument = "updater-unknown-error-secret-must-not-appear";
+    const script = fileURLToPath(
+      new URL("../scripts/verify-updater-round-trip.mjs", import.meta.url),
+    );
+    const hostPreload = `data:text/javascript,${encodeURIComponent(
+      'Object.defineProperty(process,"platform",{value:"darwin"});Object.defineProperty(process,"arch",{value:"arm64"});',
+    )}`;
+    const result = await runAcceptanceCommand(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "--import",
+        hostPreload,
+        script,
+        "0.1.0",
+        "0.1.1",
+        `/private/tmp/${sensitiveArgument}-baseline`,
+        "/private/tmp/nonexistent-candidate-envelope",
+        "/private/tmp/nonexistent-evidence.json",
+      ],
+      {
+        allowFailure: true,
+        timeoutMs: 5_000,
+        environment: {
+          ...process.env,
+          ENDURAGENT_MACOS_UPDATE_ROUNDTRIP_MODE: "steady",
+        },
+      },
+    );
+
+    expect(result.code).toBe(1);
+    expect(result.signal).toBeNull();
+    expect(result.stdout).toHaveLength(0);
+    expect(result.stderr.toString("utf8")).toBe(
+      "macOS updater round trip failed; phase=verify-release-envelopes; cleanup=not-started\n",
+    );
+    expect(result.stderr.includes(sensitiveArgument)).toBe(false);
+  });
+
   it("accepts one strictly increasing stable pair on a steady arm64 macOS runner", () => {
     expect(
       requireMacosUpdaterRoundTripInput(input, {

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -1131,6 +1131,18 @@ describe("desktop release workflow policy", () => {
 
   it("requires the native production-feed round trip and gated activation", () => {
     const source = sources();
+    const missingTimeout = replaceRequired(
+      source.desktop,
+      "  verify-production-update:\n    runs-on: macos-15\n    timeout-minutes: 30",
+      "  verify-production-update:\n    runs-on: macos-15",
+    );
+    expectIssue({ ...source, desktop: missingTimeout }, "production-feed N-to-N+1 round trip");
+    const wrongTimeout = replaceRequired(
+      source.desktop,
+      "  verify-production-update:\n    runs-on: macos-15\n    timeout-minutes: 30",
+      "  verify-production-update:\n    runs-on: macos-15\n    timeout-minutes: 31",
+    );
+    expectIssue({ ...source, desktop: wrongTimeout }, "production-feed N-to-N+1 round trip");
     const noRoundTrip = replaceRequired(
       source.desktop,
       "test:macos-update-roundtrip",
@@ -1300,7 +1312,7 @@ ${updaterCommandBlock}
     expectIssue({ ...source, desktop: movesCandidateHead }, "must overlay exactly");
   });
 
-  it("allows downstream recovery jobs to overlay only the transaction implementation", () => {
+  it("keeps non-updater downstream recovery jobs transaction-only", () => {
     const source = sources();
     const expandedOverlay = replaceRequired(
       source.desktop,
@@ -1321,6 +1333,48 @@ ${updaterCommandBlock}
       { ...source, desktop: missingTransaction },
       "verify-macos-envelope recovery must overlay exactly tools/desktop-release-transaction.ts",
     );
+  });
+
+  it("binds updater recovery to the exact ordered acceptance-tooling overlay", () => {
+    const source = sources();
+    const updaterOverlay = [
+      '          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \\',
+      "            apps/desktop/scripts/verify-updater-round-trip.mjs \\",
+      "            tools/desktop-release-transaction.ts",
+      "          EXPECTED_RECOVERY_DIFF=$'apps/desktop/scripts/verify-updater-round-trip.mjs\\ntools/desktop-release-transaction.ts'",
+      '          test "$(git diff --cached --name-only)" = "$EXPECTED_RECOVERY_DIFF"',
+    ].join("\n");
+    const mutations = [
+      [
+        '          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \\',
+        "            tools/desktop-release-transaction.ts",
+        "          test \"$(git diff --cached --name-only)\" = 'tools/desktop-release-transaction.ts'",
+      ].join("\n"),
+      [
+        '          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \\',
+        "            apps/desktop/scripts/verify-updater-round-trip.mjs",
+        "          test \"$(git diff --cached --name-only)\" = 'apps/desktop/scripts/verify-updater-round-trip.mjs'",
+      ].join("\n"),
+      [
+        '          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \\',
+        "            apps/desktop/scripts/verify-updater-round-trip.mjs \\",
+        "            apps/desktop/src/main/index.ts \\",
+        "            tools/desktop-release-transaction.ts",
+        "          EXPECTED_RECOVERY_DIFF=$'apps/desktop/scripts/verify-updater-round-trip.mjs\\napps/desktop/src/main/index.ts\\ntools/desktop-release-transaction.ts'",
+        '          test "$(git diff --cached --name-only)" = "$EXPECTED_RECOVERY_DIFF"',
+      ].join("\n"),
+      [
+        '          git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \\',
+        "            tools/desktop-release-transaction.ts \\",
+        "            apps/desktop/scripts/verify-updater-round-trip.mjs",
+        "          EXPECTED_RECOVERY_DIFF=$'apps/desktop/scripts/verify-updater-round-trip.mjs\\ntools/desktop-release-transaction.ts'",
+        '          test "$(git diff --cached --name-only)" = "$EXPECTED_RECOVERY_DIFF"',
+      ].join("\n"),
+    ];
+    for (const replacement of mutations) {
+      const desktop = replaceRequired(source.desktop, updaterOverlay, replacement);
+      expectIssue({ ...source, desktop }, "verify-production-update recovery must overlay exactly");
+    }
   });
 
   it("uses a byte-deterministic npm alias packer", () => {

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -90,6 +90,12 @@ function checkRecoveryOverlay(
       ? run.includes(`test "$(git diff --cached --name-only)" = '${expectedPaths[0]}'`)
       : run.includes(`EXPECTED_RECOVERY_DIFF=$'${expectedDiff}'`) &&
         run.includes('test "$(git diff --cached --name-only)" = "$EXPECTED_RECOVERY_DIFF"');
+  const expectedRestore = [
+    'git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \\',
+    ...expectedPaths.map(
+      (path, index) => `  ${path}${index === expectedPaths.length - 1 ? "" : " \\"}`,
+    ),
+  ].join("\n");
   if (
     checkoutIndex === -1 ||
     recoveryIndex <= checkoutIndex ||
@@ -106,6 +112,7 @@ function checkRecoveryOverlay(
       run,
       'git restore --source="$RELEASE_TOOLING_COMMIT" --staged --worktree -- \\',
     ) !== 1 ||
+    !run.includes(expectedRestore) ||
     !exactDiff ||
     !run.includes('test -z "$(git diff --name-only)"') ||
     !run.includes('test -z "$(git ls-files --others --exclude-standard)"') ||
@@ -1303,6 +1310,7 @@ fi`;
     roundTripExerciseIndex === undefined ||
     dependencyBuildIndex <= roundTripInstallIndex ||
     dependencyBuildIndex >= roundTripExerciseIndex ||
+    roundTrip["timeout-minutes"] !== 30 ||
     roundTrip.if !== "${{ inputs.mode == 'steady' }}" ||
     !exactStringSet(roundTrip.needs, ["sign-macos", "reconcile-latest"]) ||
     !roundTripRun.includes("desktop-release:transaction public-envelope") ||
@@ -1416,7 +1424,6 @@ fi`;
     ["publish-assets", publish],
     ["request-latest", requestLatest],
     ["reconcile-latest", reconcileLatest],
-    ["verify-production-update", roundTrip],
     ["activate-release", activate],
     ["compensate-publication", compensate],
   ] as const) {
@@ -1428,6 +1435,13 @@ fi`;
       issues,
     );
   }
+  checkRecoveryOverlay(
+    roundTrip,
+    "verify-production-update recovery",
+    ["apps/desktop/scripts/verify-updater-round-trip.mjs", "tools/desktop-release-transaction.ts"],
+    false,
+    issues,
+  );
   const workspaceBuildStep = signingSteps.find((step) => step.run === "pnpm -r build");
   const baselineStep = namedStep(sign, "Resolve signed baseline");
   const signingEvidenceStep = namedStep(sign, "Bind candidate signing evidence");


### PR DESCRIPTION
## Summary

- bound native updater acceptance cleanup with exit-based observation and TERM-to-KILL escalation, including orphaned Electron helpers that retain inherited pipes
- report only safe phase diagnostics, cap the CI acceptance job at 30 minutes, and bind the recovery overlay to the verifier and transaction tooling
- add regressions for the inherited-pipe hang and structural workflow safeguards

## Validation

- focused updater and workflow tests: 118 passed
- desktop release workflow structural checker
- TypeScript, oxlint, oxfmt, and diff checks

This changes only recovery verification and CI behavior. It does not rebuild or replace signed desktop assets and does not publish npm packages.
