### PR TITLE
fix(desktop): bound shutdown drain

### DIFF
--- a/.changeset/calm-shutdown-deadline.md
+++ b/.changeset/calm-shutdown-deadline.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Enduragent now exits safely instead of hanging indefinitely when background cleanup cannot finish.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -262,6 +262,7 @@ async function runDesktop(): Promise<void> {
     installDesktopTerminationSignalHandler({
       signalSource: process,
       requestQuit: () => app.quit(),
+      forceQuit: () => quitCoordinator.forceQuit(),
     });
   }
   try {

--- a/apps/desktop/src/main/quit-coordinator.ts
+++ b/apps/desktop/src/main/quit-coordinator.ts
@@ -11,14 +11,67 @@ export interface DesktopTerminationSignalSource {
 export function installDesktopTerminationSignalHandler(input: {
   readonly signalSource: DesktopTerminationSignalSource;
   readonly requestQuit: () => void;
+  readonly forceQuit: () => void;
 }): void {
   let quitRequested = false;
+  let forceRequested = false;
   const requestQuit = (): void => {
-    if (quitRequested) return;
-    quitRequested = true;
-    input.requestQuit();
+    if (!quitRequested) {
+      quitRequested = true;
+      input.requestQuit();
+      return;
+    }
+    if (forceRequested) return;
+    forceRequested = true;
+    input.forceQuit();
   };
   input.signalSource.on("SIGTERM", requestQuit);
+}
+
+interface DesktopShutdownTimerHandle {
+  unref(): void;
+}
+
+type DesktopDrainOutcome = "drained" | "failed" | "timed-out" | "cancelled";
+
+export const DESKTOP_SHUTDOWN_DEADLINE_MS = 30_000;
+
+function waitForDesktopDrain(input: {
+  readonly drain: () => Promise<void>;
+  readonly deadlineMs: number;
+  readonly signal?: AbortSignal;
+  readonly setTimeout: (callback: () => void, delayMs: number) => DesktopShutdownTimerHandle;
+  readonly clearTimeout: (handle: DesktopShutdownTimerHandle) => void;
+}): Promise<DesktopDrainOutcome> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let timer: DesktopShutdownTimerHandle | undefined;
+    const finish = (outcome: DesktopDrainOutcome): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) input.clearTimeout(timer);
+      input.signal?.removeEventListener("abort", onAbort);
+      resolve(outcome);
+    };
+    const onAbort = (): void => finish("cancelled");
+    if (input.signal?.aborted === true) {
+      finish("cancelled");
+      return;
+    }
+    input.signal?.addEventListener("abort", onAbort, { once: true });
+    const scheduled = input.setTimeout(() => finish("timed-out"), input.deadlineMs);
+    timer = scheduled;
+    if (settled) input.clearTimeout(scheduled);
+    else scheduled.unref();
+    try {
+      void input.drain().then(
+        () => finish("drained"),
+        () => finish("failed"),
+      );
+    } catch {
+      finish("failed");
+    }
+  });
 }
 
 export async function completeDesktopShutdown(input: {
@@ -26,13 +79,27 @@ export async function completeDesktopShutdown(input: {
   readonly updateController: Pick<DesktopUpdateController, "completeInstallAfterDrain">;
   readonly allowFinalQuit: () => void;
   readonly exit: (code: number) => void;
+  readonly deadlineMs?: number;
+  readonly signal?: AbortSignal;
+  readonly setTimeout?: (callback: () => void, delayMs: number) => DesktopShutdownTimerHandle;
+  readonly clearTimeout?: (handle: DesktopShutdownTimerHandle) => void;
 }): Promise<void> {
-  try {
-    await input.drain();
-  } catch {
+  const drainOutcome = await waitForDesktopDrain({
+    drain: input.drain,
+    deadlineMs: input.deadlineMs ?? DESKTOP_SHUTDOWN_DEADLINE_MS,
+    signal: input.signal,
+    setTimeout:
+      input.setTimeout ?? ((callback, delayMs) => globalThis.setTimeout(callback, delayMs)),
+    clearTimeout:
+      input.clearTimeout ??
+      ((handle) => globalThis.clearTimeout(handle as ReturnType<typeof globalThis.setTimeout>)),
+  });
+  if (drainOutcome === "cancelled") return;
+  if (drainOutcome !== "drained") {
     input.exit(1);
     return;
   }
+  if (input.signal?.aborted === true) return;
   let updateInstall: "started" | "not-requested" | "failed";
   try {
     updateInstall = input.updateController.completeInstallAfterDrain(input.allowFinalQuit);
@@ -53,22 +120,39 @@ export function createDesktopQuitCoordinator(input: {
   readonly drain: () => Promise<void>;
   readonly updateController: Pick<DesktopUpdateController, "completeInstallAfterDrain">;
   readonly exit: (code: number) => void;
+  readonly deadlineMs?: number;
+  readonly setTimeout?: (callback: () => void, delayMs: number) => DesktopShutdownTimerHandle;
+  readonly clearTimeout?: (handle: DesktopShutdownTimerHandle) => void;
 }): {
   readonly beforeQuit: (event: DesktopBeforeQuitEvent) => "allowed" | "draining";
+  readonly forceQuit: () => void;
 } {
   let drainPromise: Promise<void> | undefined;
   let finalQuitAllowed = false;
+  let terminated = false;
+  const cancellation = new AbortController();
+  const exitOnce = (code: number): void => {
+    if (terminated) return;
+    terminated = true;
+    cancellation.abort();
+    input.exit(code);
+  };
   return {
     beforeQuit(event) {
-      if (finalQuitAllowed) return "allowed";
+      if (finalQuitAllowed || terminated) return "allowed";
       event.preventDefault();
       drainPromise ??= completeDesktopShutdown({
         ...input,
+        signal: cancellation.signal,
+        exit: exitOnce,
         allowFinalQuit: () => {
           finalQuitAllowed = true;
         },
       });
       return "draining";
+    },
+    forceQuit() {
+      exitOnce(1);
     },
   };
 }

--- a/apps/desktop/tests/quit-coordinator.test.ts
+++ b/apps/desktop/tests/quit-coordinator.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import {
+  DESKTOP_SHUTDOWN_DEADLINE_MS,
   completeDesktopShutdown,
   createDesktopQuitCoordinator,
   installDesktopTerminationSignalHandler,
@@ -16,31 +17,92 @@ function deferred<T>() {
   return { promise, reject, resolve };
 }
 
+function deadlineHarness() {
+  let callback: (() => void) | undefined;
+  const handle = { unref: vi.fn() };
+  const clearTimeout = vi.fn();
+  const setTimeout = vi.fn((scheduled: () => void, _delayMs: number) => {
+    callback = scheduled;
+    return handle;
+  });
+  return {
+    clearTimeout,
+    fire: () => callback?.(),
+    handle,
+    setTimeout,
+  };
+}
+
 describe("desktop quit coordinator", () => {
-  it("routes repeated termination signals through one coordinated quit", async () => {
+  it("coordinates the first termination signal and forces exactly once on repeats", async () => {
     const signalSource = new EventEmitter();
-    const drain = vi.fn(async () => undefined);
+    const gate = deferred<void>();
+    const drain = vi.fn(() => gate.promise);
     const exit = vi.fn();
+    const install = vi.fn(() => "not-requested" as const);
+    const deadline = deadlineHarness();
     const beforeQuitEvent = { preventDefault: vi.fn() };
     const coordinator = createDesktopQuitCoordinator({
       drain,
-      updateController: {
-        completeInstallAfterDrain: () => "not-requested",
-      },
+      updateController: { completeInstallAfterDrain: install },
       exit,
+      ...deadline,
     });
     const application = new EventEmitter();
     application.on("before-quit", (event) => coordinator.beforeQuit(event));
     const requestQuit = vi.fn(() => application.emit("before-quit", beforeQuitEvent));
-    installDesktopTerminationSignalHandler({ signalSource, requestQuit });
+    const forceQuit = vi.fn(() => coordinator.forceQuit());
+    installDesktopTerminationSignalHandler({ signalSource, requestQuit, forceQuit });
 
     signalSource.emit("SIGTERM");
     signalSource.emit("SIGTERM");
-    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+    signalSource.emit("SIGTERM");
 
     expect(requestQuit).toHaveBeenCalledOnce();
+    expect(forceQuit).toHaveBeenCalledOnce();
     expect(beforeQuitEvent.preventDefault).toHaveBeenCalledOnce();
     expect(drain).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(deadline.handle.unref).toHaveBeenCalledOnce();
+    expect(deadline.clearTimeout).toHaveBeenCalledWith(deadline.handle);
+
+    gate.resolve();
+    await gate.promise;
+    await Promise.resolve();
+    expect(install).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed at the shutdown deadline and ignores late drain settlement", async () => {
+    const gate = deferred<void>();
+    const deadline = deadlineHarness();
+    const install = vi.fn(() => "started" as const);
+    const exit = vi.fn();
+    const coordinator = createDesktopQuitCoordinator({
+      drain: () => gate.promise,
+      updateController: { completeInstallAfterDrain: install },
+      exit,
+      ...deadline,
+    });
+
+    expect(coordinator.beforeQuit({ preventDefault: vi.fn() })).toBe("draining");
+    expect(deadline.setTimeout).toHaveBeenCalledWith(
+      expect.any(Function),
+      DESKTOP_SHUTDOWN_DEADLINE_MS,
+    );
+    expect(deadline.handle.unref).toHaveBeenCalledOnce();
+
+    deadline.fire();
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1));
+    expect(deadline.clearTimeout).toHaveBeenCalledWith(deadline.handle);
+    expect(install).not.toHaveBeenCalled();
+
+    gate.resolve();
+    await gate.promise;
+    await Promise.resolve();
+    expect(install).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledOnce();
   });
 
   it("blocks repeated pre-drain quits and permits only the updater-generated post-drain quit", async () => {
@@ -50,6 +112,7 @@ describe("desktop quit coordinator", () => {
     const first = { preventDefault: vi.fn() };
     const second = { preventDefault: vi.fn() };
     const updaterQuit = { preventDefault: vi.fn() };
+    const deadline = deadlineHarness();
     let coordinator!: ReturnType<typeof createDesktopQuitCoordinator>;
     const completeInstallAfterDrain = vi.fn((allowFinalQuit: () => void) => {
       allowFinalQuit();
@@ -60,6 +123,7 @@ describe("desktop quit coordinator", () => {
       drain,
       updateController: { completeInstallAfterDrain },
       exit,
+      ...deadline,
     });
 
     expect(coordinator.beforeQuit(first)).toBe("draining");
@@ -75,10 +139,13 @@ describe("desktop quit coordinator", () => {
     expect(updaterQuit.preventDefault).not.toHaveBeenCalled();
     expect(drain).toHaveBeenCalledOnce();
     expect(exit).not.toHaveBeenCalled();
+    expect(deadline.handle.unref).toHaveBeenCalledOnce();
+    expect(deadline.clearTimeout).toHaveBeenCalledWith(deadline.handle);
   });
 
   it("permits a normal final exit only after a successful drain", async () => {
     const order: string[] = [];
+    const deadline = deadlineHarness();
     const exitEvent = { preventDefault: vi.fn() };
     let coordinator!: ReturnType<typeof createDesktopQuitCoordinator>;
     const exit = vi.fn((code: number) => {
@@ -96,6 +163,7 @@ describe("desktop quit coordinator", () => {
         },
       },
       exit,
+      ...deadline,
     });
 
     coordinator.beforeQuit({ preventDefault: vi.fn() });
@@ -103,11 +171,14 @@ describe("desktop quit coordinator", () => {
 
     expect(order).toEqual(["drain", "no-install", "exit:0"]);
     expect(exitEvent.preventDefault).not.toHaveBeenCalled();
+    expect(deadline.handle.unref).toHaveBeenCalledOnce();
+    expect(deadline.clearTimeout).toHaveBeenCalledWith(deadline.handle);
   });
 
   it("never permits install after drain rejection", async () => {
     const install = vi.fn(() => "started" as const);
     const exit = vi.fn();
+    const deadline = deadlineHarness();
     await completeDesktopShutdown({
       drain: async () => {
         throw new Error("synthetic drain failure");
@@ -115,10 +186,12 @@ describe("desktop quit coordinator", () => {
       updateController: { completeInstallAfterDrain: install },
       allowFinalQuit: vi.fn(),
       exit,
+      ...deadline,
     });
 
     expect(install).not.toHaveBeenCalled();
     expect(exit).toHaveBeenCalledOnce();
     expect(exit).toHaveBeenCalledWith(1);
+    expect(deadline.clearTimeout).toHaveBeenCalledWith(deadline.handle);
   });
 });

--- a/apps/desktop/tests/quit-coordinator.test.ts
+++ b/apps/desktop/tests/quit-coordinator.test.ts
@@ -194,4 +194,24 @@ describe("desktop quit coordinator", () => {
     expect(exit).toHaveBeenCalledWith(1);
     expect(deadline.clearTimeout).toHaveBeenCalledWith(deadline.handle);
   });
+
+  it("never permits install when drain throws synchronously", async () => {
+    const install = vi.fn(() => "started" as const);
+    const exit = vi.fn();
+    const deadline = deadlineHarness();
+    await completeDesktopShutdown({
+      drain: () => {
+        throw new Error("synthetic synchronous drain failure");
+      },
+      updateController: { completeInstallAfterDrain: install },
+      allowFinalQuit: vi.fn(),
+      exit,
+      ...deadline,
+    });
+
+    expect(install).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(deadline.clearTimeout).toHaveBeenCalledWith(deadline.handle);
+  });
 });


### PR DESCRIPTION
## Summary

- cap Desktop shutdown draining at 30 seconds
- fail closed without installing an update when cleanup rejects, throws, times out, or is cancelled
- treat a repeated macOS termination signal as one explicit forced exit

## Verification

- `vitest run apps/desktop/tests/quit-coordinator.test.ts` — 6 passed
- `pnpm --filter @enduragent/desktop check`
- `pnpm --filter @enduragent/desktop build`
- changed-file Oxlint and Oxfmt checks
- `pnpm check:changeset-userfacing`
- nine-dimension code-review rubric — PASS, no blocking findings

## Scope

This PR changes only the Desktop quit coordinator used by ordinary exits and restart-to-update.
