### PR TITLE
fix(desktop): lock update actions during settings saves

### DIFF
--- a/.changeset/steady-update-actions.md
+++ b/.changeset/steady-update-actions.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop": patch
+"@enduragent/desktop-renderer": patch
+---
+
+User-facing: Desktop update actions now wait for in-progress Settings changes to finish before restarting the app.

--- a/apps/desktop-renderer/src/ui/settings/ApplicationSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/ApplicationSection.tsx
@@ -96,6 +96,7 @@ export function ApplicationSection(): ReactElement {
 
   const copy = updateCopy(update.state);
   const updateBusy =
+    mutating ||
     update.actionDisabled ||
     ["disabled", "checking", "downloading", "installing"].includes(update.state.status);
   const releaseUrl =

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -494,6 +494,52 @@ describe("settings mutation lock", () => {
     expect(screen.getByRole("region", { name: "Settings" })).not.toHaveAttribute("aria-busy");
     expect(subject.calls.some((call) => call.method === "configureRuntime")).toBe(true);
   });
+
+  it("holds the update action until the active settings mutation settles", async () => {
+    const user = userEvent.setup();
+    const pending = deferred<unknown>();
+    const subject = await renderSettings({
+      configureRuntime: () => pending.promise,
+      updateState: { status: "downloaded", version: "1998.7.7" },
+    });
+    await act(async () => {
+      await subject.startUpdate();
+    });
+
+    const updateAction = await screen.findByRole("button", {
+      name: "Restart to update to version 1998.7.7",
+    });
+    expect(updateAction).toBeEnabled();
+
+    await user.clear(screen.getByLabelText("Idle reset (minutes)"));
+    await user.type(screen.getByLabelText("Idle reset (minutes)"), "45");
+    await user.click(screen.getByRole("button", { name: "Save conversation settings" }));
+
+    await waitFor(() => {
+      expect(useEnduragentStore.getState().settings.savingOwners).toEqual(["session"]);
+    });
+    expect(updateAction).toBeDisabled();
+    expect(screen.getByRole("button", { name: "What’s new" })).toBeEnabled();
+    await user.click(updateAction);
+    expect(subject.restartToUpdate).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pending.resolve({
+        schemaVersion: 3,
+        status: "applied",
+        applied: { llm: true, intervals: true, session: true },
+      });
+      await pending.promise;
+    });
+    await waitFor(() => {
+      expect(updateAction).toBeEnabled();
+    });
+
+    await user.click(updateAction);
+    await waitFor(() => {
+      expect(subject.restartToUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe("conversation settings", () => {


### PR DESCRIPTION
## Summary

- disable the update action while any Settings mutation is active
- prevent restart-to-update from racing credential, athlete, provider, Telegram, or conversation saves
- restore the action after the mutation settles while leaving release notes available

## Verification

- `vitest run apps/desktop-renderer/tests/settings-surface.test.tsx` — 21 passed
- `pnpm --filter @enduragent/desktop-renderer check`
- `pnpm --filter @enduragent/desktop-renderer build`
- changed-file Oxlint and Oxfmt checks
- `pnpm check:changeset-userfacing`
- nine-dimension code-review rubric and UI add-ons — PASS, no blocking findings

## Scope

This PR changes only the macOS Desktop update action and its Settings test coverage.
