### PR TITLE
fix(desktop): track updater process trees

### DIFF
--- a/apps/desktop/scripts/verify-updater-round-trip.d.mts
+++ b/apps/desktop/scripts/verify-updater-round-trip.d.mts
@@ -27,6 +27,37 @@ export interface MacosApplicationProcessObservation {
   readonly mainPids: readonly number[];
 }
 
+export interface MacosProcessIdentity {
+  readonly pid: number;
+  readonly parentPid: number;
+  readonly startedAt: string;
+}
+
+export interface MacosTrackedApplicationProcessObservation extends MacosApplicationProcessObservation {
+  readonly ownedPids: readonly number[];
+  readonly ownedProcesses: readonly MacosProcessIdentity[];
+}
+
+export interface MacosApplicationProcessObserverContext {
+  readonly observeBundleProcesses?: () => Promise<MacosApplicationProcessObservation>;
+  readonly readProcessTable?: () => Promise<readonly MacosProcessIdentity[]>;
+  readonly signalProcess?: (pid: number, signal: NodeJS.Signals) => void;
+  readonly trackingIntervalMs?: number;
+}
+
+export interface MacosApplicationProcessObserver {
+  readonly close: () => Promise<void>;
+  readonly freezeAll: () => Promise<void>;
+  readonly freezeRoot: (identity: MacosProcessIdentity) => Promise<readonly MacosProcessIdentity[]>;
+  readonly observe: () => Promise<MacosTrackedApplicationProcessObservation>;
+  readonly signalAll: (signal: NodeJS.Signals) => Promise<boolean>;
+  readonly signalIdentity: (
+    identity: MacosProcessIdentity,
+    signal: NodeJS.Signals,
+  ) => Promise<boolean>;
+  readonly trackRoot: (pid: number) => Promise<MacosProcessIdentity>;
+}
+
 export interface MacosDownloadedUpdateInfo {
   readonly fileName: string;
   readonly sha512: string;
@@ -118,6 +149,7 @@ export interface MacosUpdaterRoundTripOverrides extends MacosUpdaterRoundTripCon
     readonly identity: { readonly dev: number; readonly ino: number; readonly mode: number };
   }) => Promise<void>;
   readonly observeProcesses?: (application: string) => Promise<MacosApplicationProcessObservation>;
+  readonly readProcessTable?: () => Promise<readonly MacosProcessIdentity[]>;
   readonly writeEvidence?: (path: string, evidence: MacosUpdaterRoundTripEvidence) => Promise<void>;
 }
 
@@ -145,6 +177,15 @@ export function parseMacosApplicationProcessObservation(
   bytes: Uint8Array,
   application: string,
 ): MacosApplicationProcessObservation;
+
+export function parseMacosProcessTableObservation(
+  bytes: Uint8Array,
+): readonly MacosProcessIdentity[];
+
+export function createMacosApplicationProcessObserver(
+  application: string,
+  context?: MacosApplicationProcessObserverContext,
+): MacosApplicationProcessObserver;
 
 export function verifyMacosUpdaterRoundTripPersistence(input: {
   readonly before: MacosUpdaterRoundTripPersistenceView;

--- a/apps/desktop/scripts/verify-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-updater-round-trip.mjs
@@ -682,7 +682,9 @@ export function createMacosApplicationProcessObserver(application, context = {})
   const ensureMonitor = () => {
     if (monitor !== undefined) return;
     monitor = setInterval(() => {
-      void refresh().catch(() => undefined);
+      void refresh().catch(() => {
+        trackingFailed = true;
+      });
     }, trackingIntervalMs);
     monitor.unref?.();
   };

--- a/apps/desktop/scripts/verify-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-updater-round-trip.mjs
@@ -624,9 +624,11 @@ export function createMacosApplicationProcessObserver(application, context = {})
   let closed = false;
   let monitor;
   let refreshInFlight;
+  let trackingFailed = false;
 
   const requireOpen = () => {
     if (closed) fail("application process observer is closed");
+    if (trackingFailed) fail("application process tracking failed");
   };
 
   const updateRoot = (root, table) => {
@@ -658,6 +660,7 @@ export function createMacosApplicationProcessObserver(application, context = {})
     try {
       observed = requireProcessTableObservation(await readProcessTable());
     } catch (error) {
+      trackingFailed = true;
       if (error instanceof MacosUpdaterRoundTripError) throw error;
       fail("process table observation failed");
     }
@@ -798,10 +801,11 @@ export function createMacosApplicationProcessObserver(application, context = {})
       if (leftRoot !== rightRoot) return leftRoot ? -1 : 1;
       return left.pid - right.pid;
     });
+    let signaledAll = true;
     for (const identity of ordered) {
-      if (!(await signalIdentity(identity, signal))) return false;
+      if (!(await signalIdentity(identity, signal))) signaledAll = false;
     }
-    return true;
+    return signaledAll;
   };
 
   const close = async () => {

--- a/apps/desktop/scripts/verify-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-updater-round-trip.mjs
@@ -49,6 +49,8 @@ const shutdownTimeoutMs = 30_000;
 const cleanupTerminationGraceMs = 2_000;
 const cleanupKillGraceMs = 2_000;
 const cleanupSocketGraceMs = 1_000;
+const processTrackingIntervalMs = 250;
+const maximumProcessTableBytes = 4 * 1024 * 1024;
 const rendererRpcTimeoutMs = 30_000;
 const rendererDebuggerTimeoutSlackMs = 5_000;
 const credentialDirectoryName = "credentials-v1";
@@ -511,6 +513,313 @@ async function observeApplicationProcesses(application) {
     fail("application process observation failed");
   }
   return parseMacosApplicationProcessObservation(result.stdout, application);
+}
+
+const processStartPattern =
+  /^(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat) (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2} \d{2}:\d{2}:\d{2} \d{4}$/u;
+
+export function parseMacosProcessTableObservation(bytes) {
+  if (
+    !(bytes instanceof Uint8Array) ||
+    bytes.length === 0 ||
+    bytes.length > maximumProcessTableBytes
+  ) {
+    fail("process table observation is invalid");
+  }
+  const processes = [];
+  const seen = new Set();
+  for (const rawLine of Buffer.from(bytes).toString("utf8").split(/\r?\n/u)) {
+    if (rawLine.trim() === "") continue;
+    const match = /^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/u.exec(rawLine);
+    if (match === null) fail("process table observation is malformed");
+    const pid = Number(match[1]);
+    const parentPid = Number(match[2]);
+    const startedAt = match[3].replace(/\s+/gu, " ");
+    if (
+      !Number.isSafeInteger(pid) ||
+      pid < 1 ||
+      !Number.isSafeInteger(parentPid) ||
+      parentPid < 0 ||
+      !processStartPattern.test(startedAt) ||
+      seen.has(pid)
+    ) {
+      fail("process table observation is ambiguous");
+    }
+    seen.add(pid);
+    processes.push(Object.freeze({ pid, parentPid, startedAt }));
+  }
+  if (processes.length === 0) fail("process table observation is empty");
+  processes.sort((left, right) => left.pid - right.pid);
+  return Object.freeze(processes);
+}
+
+async function observeProcessTable() {
+  const result = await runAcceptanceCommand("/bin/ps", ["-ww", "-axo", "pid=,ppid=,lstart="], {
+    allowFailure: true,
+    environment: { ...process.env, LANG: "C", LC_ALL: "C" },
+    timeoutMs: 5_000,
+  });
+  if (
+    result.code !== 0 ||
+    result.signal !== null ||
+    result.stderr.length !== 0 ||
+    result.stdout.length === 0
+  ) {
+    fail("process table observation failed");
+  }
+  return parseMacosProcessTableObservation(result.stdout);
+}
+
+function processIdentityKey(identity) {
+  return `${identity.pid}:${identity.startedAt}`;
+}
+
+function sameProcessIdentity(left, right) {
+  return left.pid === right.pid && left.startedAt === right.startedAt;
+}
+
+function requireProcessTableObservation(value) {
+  if (!Array.isArray(value) || value.length === 0) {
+    fail("process table observation is invalid");
+  }
+  const seen = new Set();
+  const processes = value.map((candidate) => {
+    if (
+      !exactKeys(candidate, ["parentPid", "pid", "startedAt"]) ||
+      !Number.isSafeInteger(candidate.pid) ||
+      candidate.pid < 1 ||
+      !Number.isSafeInteger(candidate.parentPid) ||
+      candidate.parentPid < 0 ||
+      typeof candidate.startedAt !== "string" ||
+      !processStartPattern.test(candidate.startedAt) ||
+      seen.has(candidate.pid)
+    ) {
+      fail("process table observation is ambiguous");
+    }
+    seen.add(candidate.pid);
+    return Object.freeze({
+      pid: candidate.pid,
+      parentPid: candidate.parentPid,
+      startedAt: candidate.startedAt,
+    });
+  });
+  processes.sort((left, right) => left.pid - right.pid);
+  return Object.freeze(processes);
+}
+
+export function createMacosApplicationProcessObserver(application, context = {}) {
+  if (!isAbsolute(application) || !application.endsWith(".app")) {
+    fail("application process observer is invalid");
+  }
+  const observeBundleProcesses =
+    context.observeBundleProcesses ?? (() => observeApplicationProcesses(application));
+  const readProcessTable = context.readProcessTable ?? observeProcessTable;
+  const signalProcess = context.signalProcess ?? ((pid, signal) => process.kill(pid, signal));
+  const trackingIntervalMs = context.trackingIntervalMs ?? processTrackingIntervalMs;
+  if (!Number.isSafeInteger(trackingIntervalMs) || trackingIntervalMs < 10) {
+    fail("application process observer interval is invalid");
+  }
+
+  const roots = new Map();
+  let closed = false;
+  let monitor;
+  let refreshInFlight;
+
+  const requireOpen = () => {
+    if (closed) fail("application process observer is closed");
+  };
+
+  const updateRoot = (root, table) => {
+    if (root.frozen) return;
+    const currentByPid = new Map(table.map((identity) => [identity.pid, identity]));
+    const liveOwnedPids = new Set();
+    for (const identity of root.tracked.values()) {
+      const current = currentByPid.get(identity.pid);
+      if (current !== undefined && sameProcessIdentity(identity, current)) {
+        liveOwnedPids.add(identity.pid);
+      }
+    }
+    let added = true;
+    while (added) {
+      added = false;
+      for (const identity of table) {
+        const key = processIdentityKey(identity);
+        if (root.tracked.has(key) || !liveOwnedPids.has(identity.parentPid)) continue;
+        root.tracked.set(key, identity);
+        liveOwnedPids.add(identity.pid);
+        added = true;
+      }
+    }
+  };
+
+  const readAndTrack = async () => {
+    requireOpen();
+    let observed;
+    try {
+      observed = requireProcessTableObservation(await readProcessTable());
+    } catch (error) {
+      if (error instanceof MacosUpdaterRoundTripError) throw error;
+      fail("process table observation failed");
+    }
+    for (const root of roots.values()) updateRoot(root, observed);
+    return observed;
+  };
+
+  const refresh = async () => {
+    if (refreshInFlight !== undefined) return refreshInFlight;
+    const pending = readAndTrack();
+    refreshInFlight = pending;
+    try {
+      return await pending;
+    } finally {
+      if (refreshInFlight === pending) refreshInFlight = undefined;
+    }
+  };
+
+  const ensureMonitor = () => {
+    if (monitor !== undefined) return;
+    monitor = setInterval(() => {
+      void refresh().catch(() => undefined);
+    }, trackingIntervalMs);
+    monitor.unref?.();
+  };
+
+  const liveTrackedProcesses = (table) => {
+    const currentByPid = new Map(table.map((identity) => [identity.pid, identity]));
+    const live = new Map();
+    for (const root of roots.values()) {
+      for (const identity of root.tracked.values()) {
+        const current = currentByPid.get(identity.pid);
+        if (current !== undefined && sameProcessIdentity(identity, current)) {
+          live.set(processIdentityKey(identity), current);
+        }
+      }
+    }
+    return live;
+  };
+
+  const trackRoot = async (pid) => {
+    if (!Number.isSafeInteger(pid) || pid < 1) fail("application process root is invalid");
+    const table = await refresh();
+    const identity = table.find((candidate) => candidate.pid === pid);
+    if (identity === undefined) fail("application process root is missing");
+    const key = processIdentityKey(identity);
+    let root = roots.get(key);
+    if (root === undefined) {
+      root = { frozen: false, identity, tracked: new Map([[key, identity]]) };
+      roots.set(key, root);
+      updateRoot(root, table);
+    }
+    ensureMonitor();
+    return identity;
+  };
+
+  const freezeRoot = async (identity) => {
+    const key = processIdentityKey(identity);
+    const root = roots.get(key);
+    if (root === undefined || !sameProcessIdentity(root.identity, identity)) {
+      fail("application process root is unknown");
+    }
+    const table = await refresh();
+    updateRoot(root, table);
+    root.frozen = true;
+    return Object.freeze([...root.tracked.values()]);
+  };
+
+  const freezeAll = async () => {
+    const table = await refresh();
+    for (const root of roots.values()) {
+      updateRoot(root, table);
+      root.frozen = true;
+    }
+  };
+
+  const observe = async () => {
+    requireOpen();
+    const before = await refresh();
+    const bundle = await observeBundleProcesses();
+    if (
+      !exactKeys(bundle, ["bundlePids", "mainPids"]) ||
+      !Array.isArray(bundle.bundlePids) ||
+      !Array.isArray(bundle.mainPids) ||
+      [...bundle.bundlePids, ...bundle.mainPids].some(
+        (pid) => !Number.isSafeInteger(pid) || pid < 1,
+      ) ||
+      new Set(bundle.bundlePids).size !== bundle.bundlePids.length ||
+      new Set(bundle.mainPids).size !== bundle.mainPids.length ||
+      bundle.mainPids.some((pid) => !bundle.bundlePids.includes(pid))
+    ) {
+      fail("application process observation is invalid");
+    }
+    const after = await refresh();
+    const beforeByPid = new Map(before.map((identity) => [identity.pid, identity]));
+    const afterByPid = new Map(after.map((identity) => [identity.pid, identity]));
+    const owned = liveTrackedProcesses(after);
+    for (const pid of bundle.bundlePids) {
+      const beforeIdentity = beforeByPid.get(pid);
+      const afterIdentity = afterByPid.get(pid);
+      if (
+        beforeIdentity === undefined ||
+        afterIdentity === undefined ||
+        !sameProcessIdentity(beforeIdentity, afterIdentity)
+      ) {
+        fail("application process observation changed while reading");
+      }
+      owned.set(processIdentityKey(afterIdentity), afterIdentity);
+    }
+    const ownedProcesses = [...owned.values()].sort((left, right) => left.pid - right.pid);
+    return Object.freeze({
+      bundlePids: Object.freeze([...bundle.bundlePids]),
+      mainPids: Object.freeze([...bundle.mainPids]),
+      ownedPids: Object.freeze(ownedProcesses.map((identity) => identity.pid)),
+      ownedProcesses: Object.freeze(ownedProcesses),
+    });
+  };
+
+  const signalIdentity = async (identity, signal) => {
+    // A PID can be reused after observation, so authority must survive this final birth check.
+    const table = await refresh();
+    const current = table.find((candidate) => candidate.pid === identity.pid);
+    if (current === undefined || !sameProcessIdentity(identity, current)) return true;
+    try {
+      signalProcess(identity.pid, signal);
+      return true;
+    } catch (error) {
+      return error?.code === "ESRCH";
+    }
+  };
+
+  const signalAll = async (signal) => {
+    const observation = await observe();
+    const rootKeys = new Set([...roots.values()].map((root) => processIdentityKey(root.identity)));
+    const ordered = [...observation.ownedProcesses].sort((left, right) => {
+      const leftRoot = rootKeys.has(processIdentityKey(left));
+      const rightRoot = rootKeys.has(processIdentityKey(right));
+      if (leftRoot !== rightRoot) return leftRoot ? -1 : 1;
+      return left.pid - right.pid;
+    });
+    for (const identity of ordered) {
+      if (!(await signalIdentity(identity, signal))) return false;
+    }
+    return true;
+  };
+
+  const close = async () => {
+    if (closed) return;
+    if (monitor !== undefined) clearInterval(monitor);
+    if (refreshInFlight !== undefined) await refreshInFlight.catch(() => undefined);
+    closed = true;
+  };
+
+  return Object.freeze({
+    close,
+    freezeAll,
+    freezeRoot,
+    observe,
+    signalAll,
+    signalIdentity,
+    trackRoot,
+  });
 }
 
 async function debuggerListenerOwner(port, environment) {
@@ -1227,55 +1536,46 @@ async function closeRoundTripConnection(connection) {
   }).catch(() => false);
 }
 
-function signalObservedProcesses(observation, signal) {
-  for (const pid of observation.bundlePids) {
-    try {
-      process.kill(pid, signal);
-    } catch (error) {
-      if (error?.code !== "ESRCH") return false;
-    }
-  }
-  return true;
-}
-
-async function waitForObservedProcessExit(observeProcesses, application, timeoutMs) {
+async function waitForObservedProcessExit(processObserver, timeoutMs) {
   return waitUntil(
     "updater application cleanup",
     async () => {
-      const observation = await observeProcesses(application);
-      return observation.bundlePids.length === 0 ? true : false;
+      const observation = await processObserver.observe();
+      return observation.ownedPids.length === 0 ? true : false;
     },
     timeoutMs,
     100,
   ).catch(() => false);
 }
 
-async function terminateObservedApplication(observeProcesses, application) {
-  if (application === undefined) return true;
+async function terminateObservedApplication(processObserver) {
+  if (processObserver === undefined) return true;
   let observation;
   try {
-    observation = await observeProcesses(application);
+    observation = await processObserver.observe();
   } catch {
     return false;
   }
-  if (observation.bundlePids.length === 0) return true;
-  const gracefulSignalSent = signalObservedProcesses(observation, "SIGTERM");
+  if (observation.ownedPids.length === 0) return true;
+  const gracefulSignalSent = await processObserver.signalAll("SIGTERM");
   if (
     gracefulSignalSent &&
-    (await waitForObservedProcessExit(observeProcesses, application, cleanupTerminationGraceMs))
+    (await waitForObservedProcessExit(processObserver, cleanupTerminationGraceMs))
   ) {
     return true;
   }
-  try {
-    observation = await observeProcesses(application);
-  } catch {
-    return false;
-  }
-  if (!signalObservedProcesses(observation, "SIGKILL")) return false;
-  return waitForObservedProcessExit(observeProcesses, application, cleanupKillGraceMs);
+  if (!(await processObserver.signalAll("SIGKILL"))) return false;
+  return waitForObservedProcessExit(processObserver, cleanupKillGraceMs);
 }
 
 async function cleanupRoundTripResources(input) {
+  const observerFrozen =
+    input.processObserver === undefined
+      ? true
+      : await input.processObserver
+          .freezeAll()
+          .then(() => true)
+          .catch(() => false);
   const [connectionResults, childResults] = await Promise.all([
     Promise.all([
       closeRoundTripConnection(input.debuggerConnection),
@@ -1287,9 +1587,19 @@ async function cleanupRoundTripResources(input) {
     ]),
   ]);
   const applicationTerminated = input.terminateApplication
-    ? await terminateObservedApplication(input.observeProcesses, input.installedApplication)
+    ? observerFrozen && (await terminateObservedApplication(input.processObserver))
     : true;
-  return [...connectionResults, ...childResults, applicationTerminated].every(Boolean);
+  const observerClosed = await input.processObserver
+    ?.close()
+    .then(() => true)
+    .catch(() => false);
+  return [
+    ...connectionResults,
+    ...childResults,
+    observerFrozen,
+    applicationTerminated,
+    observerClosed ?? true,
+  ].every(Boolean);
 }
 
 async function restoreRoundTripKeychain(keychain) {
@@ -1316,7 +1626,6 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
     const inspectApplication = overrides.inspectApplication ?? inspectMacosReleaseApplication;
     const createScratch = overrides.createScratch ?? createPrivateScratch;
     const removeScratch = overrides.removeScratch ?? removePrivateScratch;
-    const observeProcesses = overrides.observeProcesses ?? observeApplicationProcesses;
     const writeEvidenceFile = overrides.writeEvidence ?? writeEvidence;
     phase = "verify-release-envelopes";
     const baselineArtifacts = await verifyArtifacts(input.baselineEnvelope, input.baselineVersion);
@@ -1346,6 +1655,7 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
     let debuggerConnection;
     let verificationConnection;
     let installedApplication;
+    let processObserver;
     let keychain;
     let completed = false;
     try {
@@ -1363,6 +1673,13 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
       await mkdir(installRoot, { mode: 0o700 });
       installedApplication = join(installRoot, `${productName}.app`);
       await installApplication(baselineApplication, installedApplication);
+      processObserver = createMacosApplicationProcessObserver(installedApplication, {
+        observeBundleProcesses:
+          overrides.observeProcesses === undefined
+            ? undefined
+            : () => overrides.observeProcesses(installedApplication),
+        readProcessTable: overrides.readProcessTable,
+      });
       phase = "inspect-release-identities";
       const [baselineIdentity, candidateIdentity, installedBaselineIdentity] = await Promise.all([
         inspectApplication(baselineApplication),
@@ -1439,6 +1756,7 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
       );
       if (launch.state !== "spawned") fail("baseline application could not launch");
       const initialPid = launch.pid;
+      const initialRootIdentity = await processObserver.trackRoot(initialPid);
       const debuggerUrl = await waitForPage(debuggerPort, { timeoutMs: 60_000 });
       if ((await debuggerListenerOwner(debuggerPort, environment)) !== initialPid) {
         fail("baseline debugger listener is outside the installed application");
@@ -1457,7 +1775,7 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
       const beforePersistence = await seedApplicationState(debuggerConnection, persistenceInput);
       phase = "download-update";
       await waitForDownloadedState(debuggerConnection, input.candidateVersion);
-      const initialProcesses = await observeProcesses(installedApplication);
+      const initialProcesses = await processObserver.observe();
       if (initialProcesses.mainPids.length !== 1 || initialProcesses.mainPids[0] !== initialPid) {
         fail("baseline application process identity is ambiguous");
       }
@@ -1465,6 +1783,11 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
         updaterCache,
         candidateArtifacts,
         candidateDigest,
+      );
+      // Freeze N before installation so an updater-spawned N+1 cannot inherit N's cleanup authority.
+      const trackedInitialProcesses = await processObserver.freezeRoot(initialRootIdentity);
+      const initialProcessIdentities = new Set(
+        [...trackedInitialProcesses, ...initialProcesses.ownedProcesses].map(processIdentityKey),
       );
       phase = "install-update";
       await clickInstallUpdate(debuggerConnection, input.candidateVersion);
@@ -1478,13 +1801,18 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
       if (terminal.code !== 0 || terminal.signal !== null) {
         fail("baseline application did not exit cleanly for update");
       }
-      const initialPids = new Set(initialProcesses.bundlePids);
       phase = "observe-relaunch";
       const relaunchedProcesses = await waitUntil(
         "relaunched candidate application",
         async () => {
-          const observation = await observeProcesses(installedApplication);
-          if (observation.bundlePids.some((pid) => initialPids.has(pid))) return false;
+          const observation = await processObserver.observe();
+          if (
+            observation.ownedProcesses.some((identity) =>
+              initialProcessIdentities.has(processIdentityKey(identity)),
+            )
+          ) {
+            return false;
+          }
           if (observation.mainPids.length !== 1 || observation.mainPids[0] === initialPid)
             return false;
           return observation;
@@ -1493,6 +1821,7 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
         250,
       );
       relaunchedPid = relaunchedProcesses.mainPids[0];
+      const relaunchedRootIdentity = await processObserver.trackRoot(relaunchedPid);
       phase = "verify-relaunch";
       const relaunchedIdentity = await waitUntil(
         "relaunched candidate identity",
@@ -1512,20 +1841,23 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
         installedBaseline: installedBaselineIdentity,
         relaunched: relaunchedIdentity,
       });
-      const beforeFinalShutdown = await observeProcesses(installedApplication);
+      const beforeFinalShutdown = await processObserver.observe();
       if (
         beforeFinalShutdown.mainPids.length !== 1 ||
         beforeFinalShutdown.mainPids[0] !== relaunchedPid
       ) {
         fail("relaunched application process identity changed before shutdown");
       }
+      await processObserver.freezeRoot(relaunchedRootIdentity);
       phase = "shutdown-relaunch";
-      process.kill(relaunchedPid, "SIGTERM");
+      if (!(await processObserver.signalIdentity(relaunchedRootIdentity, "SIGTERM"))) {
+        fail("relaunched application graceful shutdown signal failed");
+      }
       await waitUntil(
         "relaunched application graceful shutdown",
         async () => {
-          const observation = await observeProcesses(installedApplication);
-          return observation.bundlePids.length === 0 ? true : false;
+          const observation = await processObserver.observe();
+          return observation.ownedPids.length === 0 ? true : false;
         },
         shutdownTimeoutMs,
         100,
@@ -1549,6 +1881,7 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
       if (verificationLaunch.state !== "spawned") {
         fail("candidate persistence verification could not launch");
       }
+      const verificationRootIdentity = await processObserver.trackRoot(verificationLaunch.pid);
       const verificationUrl = await waitForPage(verificationPort, { timeoutMs: 60_000 });
       if ((await debuggerListenerOwner(verificationPort, environment)) !== verificationLaunch.pid) {
         fail("candidate persistence debugger listener is outside the installed application");
@@ -1557,8 +1890,11 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
       await callAcceptanceCdp(verificationConnection, "Runtime.enable");
       phase = "verify-persistence";
       const afterPersistence = await readPersistenceView(verificationConnection, persistenceInput);
+      await processObserver.freezeRoot(verificationRootIdentity);
       phase = "shutdown-persistence-verification";
-      verificationChild.kill("SIGTERM");
+      if (!(await processObserver.signalIdentity(verificationRootIdentity, "SIGTERM"))) {
+        fail("candidate persistence verification shutdown signal failed");
+      }
       const verificationTerminal = await withAcceptanceDeadline(
         "candidate persistence verification shutdown",
         verificationExit,
@@ -1571,8 +1907,8 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
       await waitUntil(
         "candidate persistence verification process cleanup",
         async () => {
-          const observation = await observeProcesses(installedApplication);
-          return observation.bundlePids.length === 0 ? true : false;
+          const observation = await processObserver.observe();
+          return observation.ownedPids.length === 0 ? true : false;
         },
         shutdownTimeoutMs,
         100,
@@ -1620,8 +1956,7 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
         verificationConnection,
         initialChild,
         verificationChild,
-        installedApplication,
-        observeProcesses,
+        processObserver,
         terminateApplication: !completed,
       }).catch(() => false);
       const keychainRestored = cleaned ? await restoreRoundTripKeychain(keychain) : false;

--- a/apps/desktop/tests/macos-process-observer.test.ts
+++ b/apps/desktop/tests/macos-process-observer.test.ts
@@ -1,0 +1,183 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createMacosApplicationProcessObserver,
+  type MacosProcessIdentity,
+} from "../scripts/verify-updater-round-trip.mjs";
+
+const roots: string[] = [];
+const children: ChildProcess[] = [];
+const externalPids: number[] = [];
+
+function processIsReachable(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+async function waitUntil(probe: () => boolean | Promise<boolean>, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await probe()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("process observer test timed out");
+}
+
+async function stopChild(child: ChildProcess): Promise<void> {
+  if (child.pid === undefined || !processIsReachable(child.pid)) return;
+  child.kill("SIGKILL");
+  await waitUntil(() => !processIsReachable(child.pid as number), 1_000).catch(() => undefined);
+}
+
+async function stopProcess(pid: number): Promise<void> {
+  if (!processIsReachable(pid)) return;
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+    throw error;
+  }
+  await waitUntil(() => !processIsReachable(pid), 1_000).catch(() => undefined);
+}
+
+afterEach(async () => {
+  await Promise.all(children.splice(0).map(stopChild));
+  await Promise.all(externalPids.splice(0).map(stopProcess));
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+describe("macOS application process observer", () => {
+  it("rejects a bundle PID that is reused across the lsof observation", async () => {
+    const observations: readonly (readonly MacosProcessIdentity[])[] = [
+      [{ pid: 500, parentPid: 1, startedAt: "Sun Aug 9 16:00:00 2026" }],
+      [{ pid: 500, parentPid: 1, startedAt: "Sun Aug 9 16:00:01 2026" }],
+    ];
+    let index = 0;
+    const signaled: number[] = [];
+    const observer = createMacosApplicationProcessObserver(
+      "/private/tmp/process-observer/Enduragent.app",
+      {
+        observeBundleProcesses: async () => ({ bundlePids: [500], mainPids: [500] }),
+        readProcessTable: async () => observations[Math.min(index++, observations.length - 1)],
+        signalProcess: (pid) => signaled.push(pid),
+      },
+    );
+
+    await expect(observer.observe()).rejects.toThrow(
+      "application process observation changed while reading",
+    );
+    expect(signaled).toEqual([]);
+    await observer.close();
+  });
+
+  it("retains a reparented descendant but drops a reused PID before signaling", async () => {
+    const application = "/private/tmp/process-observer/Enduragent.app";
+    let table: readonly MacosProcessIdentity[] = [
+      { pid: 101, parentPid: 1, startedAt: "Sun Aug 9 16:00:00 2026" },
+    ];
+    const signaled: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const observer = createMacosApplicationProcessObserver(application, {
+      observeBundleProcesses: async () => ({ bundlePids: [], mainPids: [] }),
+      readProcessTable: async () => table,
+      signalProcess: (pid, signal) => signaled.push({ pid, signal }),
+      trackingIntervalMs: 60_000,
+    });
+
+    const root = await observer.trackRoot(101);
+    table = [
+      { pid: 101, parentPid: 1, startedAt: "Sun Aug 9 16:00:00 2026" },
+      { pid: 102, parentPid: 101, startedAt: "Sun Aug 9 16:00:01 2026" },
+      { pid: 103, parentPid: 102, startedAt: "Sun Aug 9 16:00:02 2026" },
+    ];
+    expect((await observer.freezeRoot(root)).map((identity) => identity.pid)).toEqual([
+      101, 102, 103,
+    ]);
+
+    table = [
+      { pid: 101, parentPid: 1, startedAt: "Sun Aug 9 16:00:00 2026" },
+      { pid: 102, parentPid: 101, startedAt: "Sun Aug 9 16:00:01 2026" },
+      { pid: 103, parentPid: 102, startedAt: "Sun Aug 9 16:00:02 2026" },
+      { pid: 202, parentPid: 103, startedAt: "Sun Aug 9 16:00:03 2026" },
+    ];
+    expect((await observer.observe()).ownedPids).toEqual([101, 102, 103]);
+
+    table = [
+      { pid: 102, parentPid: 1, startedAt: "Sun Aug 9 16:00:01 2026" },
+      { pid: 103, parentPid: 1, startedAt: "Sun Aug 9 16:01:02 2026" },
+    ];
+    expect(await observer.observe()).toMatchObject({ ownedPids: [102] });
+    expect(await observer.signalAll("SIGTERM")).toBe(true);
+    expect(signaled).toEqual([{ pid: 102, signal: "SIGTERM" }]);
+    await observer.close();
+  });
+
+  it.skipIf(process.platform !== "darwin")(
+    "finds and terminates a real out-of-bundle grandchild after its parent exits",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "updater-process-observer-"));
+      roots.push(root);
+      const application = join(root, "Enduragent.app");
+      const marker = join(root, "grandchild-terminated.txt");
+      await mkdir(application, { mode: 0o700 });
+
+      const helperCode = [
+        'const fs = require("node:fs");',
+        'process.on("SIGTERM", () => { fs.writeFileSync(process.argv[1], "SIGTERM"); process.exit(0); });',
+        "setInterval(() => undefined, 1_000);",
+      ].join("");
+      const parentCode = [
+        'const { spawn } = require("node:child_process");',
+        `const helper = spawn(process.execPath, ["-e", ${JSON.stringify(helperCode)}, process.argv[1]], { stdio: "ignore" });`,
+        "process.stdout.write(`${helper.pid}\\n`, () => setTimeout(() => process.exit(0), 750));",
+      ].join("");
+      const parent = spawn(process.execPath, ["-e", parentCode, marker], {
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      children.push(parent);
+      await new Promise<void>((resolve, reject) => {
+        parent.once("spawn", resolve);
+        parent.once("error", reject);
+      });
+      const parentPid = parent.pid as number;
+      let output = "";
+      parent.stdout?.setEncoding("utf8");
+      parent.stdout?.on("data", (chunk: string) => {
+        output += chunk;
+      });
+
+      const observer = createMacosApplicationProcessObserver(application);
+      try {
+        const parentExit = new Promise<void>((resolve) => parent.once("exit", () => resolve()));
+        await observer.trackRoot(parentPid);
+        let helperPid = 0;
+        await waitUntil(() => {
+          const match = /^(\d+)\n$/u.exec(output);
+          if (match?.[1] === undefined) return false;
+          helperPid = Number(match[1]);
+          if (!externalPids.includes(helperPid)) externalPids.push(helperPid);
+          return true;
+        });
+
+        await parentExit;
+        const afterParentExit = await observer.observe();
+        expect(afterParentExit.bundlePids).toEqual([]);
+        expect(afterParentExit.ownedPids).toContain(helperPid);
+
+        await observer.freezeAll();
+        expect(await observer.signalAll("SIGTERM")).toBe(true);
+        await waitUntil(() => !processIsReachable(helperPid));
+        expect(await readFile(marker, "utf8")).toBe("SIGTERM");
+      } finally {
+        await observer.close();
+      }
+    },
+  );
+});

--- a/apps/desktop/tests/macos-process-observer.test.ts
+++ b/apps/desktop/tests/macos-process-observer.test.ts
@@ -119,6 +119,55 @@ describe("macOS application process observer", () => {
     await observer.close();
   });
 
+  it("fails closed after a background process-table observation gap", async () => {
+    let reads = 0;
+    const observer = createMacosApplicationProcessObserver(
+      "/private/tmp/process-observer/Enduragent.app",
+      {
+        observeBundleProcesses: async () => ({ bundlePids: [], mainPids: [] }),
+        readProcessTable: async () => {
+          reads += 1;
+          if (reads > 1) throw new Error("synthetic process-table failure");
+          return [{ pid: 101, parentPid: 1, startedAt: "Sun Aug 9 16:00:00 2026" }];
+        },
+        trackingIntervalMs: 10,
+      },
+    );
+
+    await observer.trackRoot(101);
+    await waitUntil(() => reads > 1);
+    await expect(observer.observe()).rejects.toThrow("application process tracking failed");
+    await observer.close();
+  });
+
+  it("attempts every owned process when one signal fails", async () => {
+    const table: readonly MacosProcessIdentity[] = [
+      { pid: 101, parentPid: 1, startedAt: "Sun Aug 9 16:00:00 2026" },
+      { pid: 102, parentPid: 101, startedAt: "Sun Aug 9 16:00:01 2026" },
+    ];
+    const signaled: number[] = [];
+    const observer = createMacosApplicationProcessObserver(
+      "/private/tmp/process-observer/Enduragent.app",
+      {
+        observeBundleProcesses: async () => ({ bundlePids: [], mainPids: [] }),
+        readProcessTable: async () => table,
+        signalProcess: (pid) => {
+          signaled.push(pid);
+          if (pid === 101) {
+            throw Object.assign(new Error("synthetic signal failure"), { code: "EPERM" });
+          }
+        },
+        trackingIntervalMs: 60_000,
+      },
+    );
+
+    await observer.trackRoot(101);
+    await observer.freezeAll();
+    expect(await observer.signalAll("SIGTERM")).toBe(false);
+    expect(signaled).toEqual([101, 102]);
+    await observer.close();
+  });
+
   it.skipIf(process.platform !== "darwin")(
     "finds and terminates a real out-of-bundle grandchild after its parent exits",
     async () => {

--- a/apps/desktop/tests/macos-update-roundtrip-cleanup.test.ts
+++ b/apps/desktop/tests/macos-update-roundtrip-cleanup.test.ts
@@ -47,7 +47,7 @@ vi.mock("node:child_process", async (importOriginal) => {
         'const { spawn } = require("node:child_process");',
         `const helper = spawn(process.execPath, ["-e", ${JSON.stringify(helperCode)}, process.argv[1], process.argv[2]], { stdio: ["ignore", "inherit", "inherit", "pipe"] });`,
         'helper.stdio[3].once("data", () => {',
-        "  process.stdout.write(`helper:${helper.pid}\\n`, () => process.exit(0));",
+        "  process.stdout.write(`helper:${helper.pid}\\n`, () => setTimeout(() => process.exit(0), 300));",
         "});",
       ].join("");
       const child = actual.spawn(
@@ -173,6 +173,29 @@ async function stopChild(child: ChildProcess): Promise<void> {
   await Promise.race([exited, new Promise<void>((resolve) => setTimeout(resolve, 1_000))]);
 }
 
+function observedProcessTable() {
+  const processes = [
+    { pid: process.pid, parentPid: process.ppid, startedAt: "Sun Aug 9 16:00:00 2026" },
+  ];
+  const child = harness.children.at(-1);
+  if (child?.pid !== undefined && processIsReachable(child.pid)) {
+    processes.push({
+      pid: child.pid,
+      parentPid: process.pid,
+      startedAt: "Sun Aug 9 16:00:01 2026",
+    });
+  }
+  const helperPid = harness.helperPid;
+  if (helperPid !== undefined && processIsReachable(helperPid)) {
+    processes.push({
+      pid: helperPid,
+      parentPid: child?.pid !== undefined && processIsReachable(child.pid) ? child.pid : 1,
+      startedAt: "Sun Aug 9 16:00:02 2026",
+    });
+  }
+  return processes;
+}
+
 afterEach(async () => {
   await Promise.all(harness.children.map(stopChild));
   await stopProcess(harness.helperPid);
@@ -275,6 +298,7 @@ describe("macOS updater failure cleanup", () => {
               ? { bundlePids: [helperPid], mainPids: [] }
               : { bundlePids: [], mainPids: [] };
           },
+          readProcessTable: async () => observedProcessTable(),
         },
       );
     } catch (error) {

--- a/apps/desktop/tests/macos-update-roundtrip.test.ts
+++ b/apps/desktop/tests/macos-update-roundtrip.test.ts
@@ -4,6 +4,7 @@ import {
   MACOS_UPDATER_ROUND_TRIP_FEED_URL,
   createMacosUpdaterRoundTripEvidence,
   parseMacosApplicationProcessObservation,
+  parseMacosProcessTableObservation,
   parseMacosDownloadedUpdateInfo,
   requireMacosUpdaterRoundTripInput,
   verifyMacosUpdaterRoundTripIdentities,
@@ -364,6 +365,19 @@ describe("macOS application process authority", () => {
     Buffer.from(["p0", "ftxt", `n${executable}`, ""].join("\0")),
   ])("rejects malformed or out-of-authority process observations", (bytes) => {
     expect(() => parseMacosApplicationProcessObservation(bytes, application)).toThrow();
+  });
+});
+
+describe("macOS launched process-tree authority", () => {
+  it("records parentage and process birth identity without command-line data", () => {
+    const bytes = Buffer.from(
+      [" 101 1 Sun Aug  9 16:56:31 2026", " 102 101 Sun Aug  9 16:56:32 2026", ""].join("\n"),
+    );
+
+    expect(parseMacosProcessTableObservation(bytes)).toEqual([
+      { pid: 101, parentPid: 1, startedAt: "Sun Aug 9 16:56:31 2026" },
+      { pid: 102, parentPid: 101, startedAt: "Sun Aug 9 16:56:32 2026" },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- track macOS updater descendants by PID and process start time, including helpers reparented after the app exits
- reject PID reuse before signaling and freeze each app generation at the update boundary
- fail closed after process-table tracking gaps and attempt cleanup for every owned process
- close inherited child handles and finish process cleanup before restoring the disposable keychain

## Verification

- Node 24 focused updater observer and round-trip suites: 69 passed
- pnpm check:types
- pnpm lint (0 errors; inherited warnings only)
- changed-file oxfmt check
- pnpm build
- git diff --check

Repository-wide fmt:check remains red on pre-existing files outside this diff; all five files changed by this PR pass the formatter.