### PR TITLE
fix(desktop): verify DMG signing team

### DIFF
--- a/apps/desktop/scripts/verify-macos-release.mjs
+++ b/apps/desktop/scripts/verify-macos-release.mjs
@@ -91,6 +91,21 @@ function exactLine(text, pattern) {
   return values.length === 1 ? values[0] : undefined;
 }
 
+function hasCanonicalDeveloperIdApplicationIdentity(teamIdentifier, authorities) {
+  const authorityPrefix = "Developer ID Application: ";
+  const authoritySuffix = ` (${canonicalTeamIdentifier})`;
+  const leafAuthority = authorities[0];
+  return (
+    teamIdentifier === canonicalTeamIdentifier &&
+    authorities.length === 3 &&
+    typeof leafAuthority === "string" &&
+    leafAuthority.startsWith(authorityPrefix) &&
+    leafAuthority.endsWith(authoritySuffix) &&
+    authorities[1] === "Developer ID Certification Authority" &&
+    authorities[2] === "Apple Root CA"
+  );
+}
+
 function normalizeJson(value) {
   if (value === null || typeof value === "string" || typeof value === "boolean") return value;
   if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -230,11 +245,7 @@ function parseSignatureMetadata(result) {
       .split(",")
       .map((flag) => flag.trim())
       .includes("runtime") ||
-    authorities.length !== 3 ||
-    !authorities[0].startsWith("Developer ID Application: ") ||
-    !authorities[0].endsWith(` (${canonicalTeamIdentifier})`) ||
-    authorities[1] !== "Developer ID Certification Authority" ||
-    authorities[2] !== "Apple Root CA"
+    !hasCanonicalDeveloperIdApplicationIdentity(teamIdentifier, authorities)
   ) {
     fail("macOS signed identity is invalid");
   }
@@ -1506,6 +1517,18 @@ async function verifyMacosDmgSignature(dmgPath, executeFile) {
     ["--verify", "--verbose=2", dmgPath],
     "macOS DMG signature verification failed",
   );
+  let signatureResult;
+  try {
+    signatureResult = await executeFile("/usr/bin/codesign", ["--display", "--verbose=4", dmgPath]);
+  } catch {
+    fail("macOS DMG signing identity inspection failed");
+  }
+  const output = allCommandOutput(signatureResult);
+  const teamIdentifier = exactLine(output, /^TeamIdentifier=([^\r\n]+)$/gmu);
+  const authorities = Array.from(output.matchAll(/^Authority=([^\r\n]+)$/gmu), (match) => match[1]);
+  if (!hasCanonicalDeveloperIdApplicationIdentity(teamIdentifier, authorities)) {
+    fail("macOS DMG signing identity is invalid");
+  }
 }
 
 async function verifyMacosDmgNotarization(dmgPath, executeFile) {

--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -52,6 +52,21 @@ const names = {
   metadata: "latest-mac.yml",
 };
 
+function dmgSigningIdentityResult(
+  teamIdentifier = "FA494ACVTF",
+  authorityTeamIdentifier = teamIdentifier,
+) {
+  return {
+    stdout: "",
+    stderr: [
+      `Authority=Developer ID Application: Enduragent Test (${authorityTeamIdentifier})`,
+      "Authority=Developer ID Certification Authority",
+      "Authority=Apple Root CA",
+      `TeamIdentifier=${teamIdentifier}`,
+    ].join("\n"),
+  };
+}
+
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
@@ -2245,7 +2260,12 @@ describe("macOS release artifact envelope", () => {
 
   it("accepts the pinned blockmap and invokes mandatory DMG verification defaults", async () => {
     const fixture = await releaseFixture();
-    const executeFile = vi.fn(async () => {});
+    const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+      if (executable === "/usr/bin/codesign" && arguments_.includes("--display")) {
+        return dmgSigningIdentityResult();
+      }
+      return { stdout: "", stderr: "" };
+    });
     await expect(
       verifyMacosReleaseArtifacts(
         fixture.artifactDirectory,
@@ -2261,6 +2281,7 @@ describe("macOS release artifact envelope", () => {
     const dmgPath = join(fixture.artifactDirectory, names.dmg);
     expect(executeFile.mock.calls).toEqual([
       ["/usr/bin/codesign", ["--verify", "--verbose=2", dmgPath]],
+      ["/usr/bin/codesign", ["--display", "--verbose=4", dmgPath]],
       ["/usr/bin/xcrun", ["stapler", "validate", "-v", dmgPath]],
       [
         "/usr/sbin/spctl",
@@ -2303,10 +2324,14 @@ describe("macOS release artifact envelope", () => {
 
   it("fails final-envelope verification when the DMG staple is absent", async () => {
     const fixture = await releaseFixture();
-    const executeFile = vi.fn(async (executable: string) => {
+    const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+      if (executable === "/usr/bin/codesign" && arguments_.includes("--display")) {
+        return dmgSigningIdentityResult();
+      }
       if (executable === "/usr/bin/xcrun") {
         throw new Error("synthetic missing staple");
       }
+      return { stdout: "", stderr: "" };
     });
 
     await expect(
@@ -2321,8 +2346,74 @@ describe("macOS release artifact envelope", () => {
         "/usr/bin/codesign",
         ["--verify", "--verbose=2", join(fixture.artifactDirectory, names.dmg)],
       ],
+      [
+        "/usr/bin/codesign",
+        ["--display", "--verbose=4", join(fixture.artifactDirectory, names.dmg)],
+      ],
       ["/usr/bin/xcrun", ["stapler", "validate", "-v", join(fixture.artifactDirectory, names.dmg)]],
     ]);
+  });
+
+  it.each([
+    ["team identifier", "ABCDE12345", "FA494ACVTF"],
+    ["leaf authority", "FA494ACVTF", "ABCDE12345"],
+  ])(
+    "rejects a valid notarized DMG with an alternate Developer ID %s",
+    async (_label, teamIdentifier, authorityTeamIdentifier) => {
+      const fixture = await releaseFixture();
+      const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+        if (executable === "/usr/bin/codesign" && arguments_.includes("--display")) {
+          return dmgSigningIdentityResult(teamIdentifier, authorityTeamIdentifier);
+        }
+        return { stdout: "", stderr: "" };
+      });
+
+      await expect(
+        verifyMacosReleaseArtifacts(
+          fixture.artifactDirectory,
+          { repositoryRoot: fixture.repositoryRoot },
+          { executeFile },
+        ),
+      ).rejects.toThrow("macOS DMG signing identity is invalid");
+      expect(executeFile.mock.calls).toEqual([
+        [
+          "/usr/bin/codesign",
+          ["--verify", "--verbose=2", join(fixture.artifactDirectory, names.dmg)],
+        ],
+        [
+          "/usr/bin/codesign",
+          ["--display", "--verbose=4", join(fixture.artifactDirectory, names.dmg)],
+        ],
+      ]);
+    },
+  );
+
+  it("redacts DMG signing identity inspection failures", async () => {
+    const fixture = await releaseFixture();
+    const sentinel = "private alternate signing certificate output";
+    const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+      if (executable === "/usr/bin/codesign" && arguments_.includes("--display")) {
+        throw new Error(sentinel);
+      }
+      return { stdout: "", stderr: "" };
+    });
+    let failure: unknown;
+
+    try {
+      await verifyMacosReleaseArtifacts(
+        fixture.artifactDirectory,
+        { repositoryRoot: fixture.repositoryRoot },
+        { executeFile },
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(safeMacosReleaseVerificationMessage(failure)).toBe(
+      "macOS DMG signing identity inspection failed",
+    );
+    expect((failure as Error).message).not.toContain(sentinel);
+    expect(executeFile).toHaveBeenCalledTimes(2);
   });
 
   it("rejects an envelope when mandatory DMG verification fails", async () => {

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -92,6 +92,18 @@ function versionReader(version = "2026.7.2") {
   return vi.fn(async () => JSON.stringify({ version }));
 }
 
+function canonicalDmgSigningIdentityResult() {
+  return {
+    stdout: "",
+    stderr: [
+      "Authority=Developer ID Application: Enduragent Test (FA494ACVTF)",
+      "Authority=Developer ID Certification Authority",
+      "Authority=Apple Root CA",
+      "TeamIdentifier=FA494ACVTF",
+    ].join("\n"),
+  };
+}
+
 function baselineVerifier() {
   return vi.fn(async () => verifiedBaselineApplication);
 }
@@ -645,7 +657,12 @@ describe("macOS release plan", () => {
     ]);
     const sealReleaseMetadata = vi.fn(async () => {});
     const verifyPackageLayout = vi.fn(async () => {});
-    const executeFile = vi.fn(async () => {});
+    const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+      if (executable === "/usr/bin/codesign" && arguments_.includes("--display")) {
+        return canonicalDmgSigningIdentityResult();
+      }
+      return { stdout: "", stderr: "" };
+    });
     const notarize = vi.fn(async () => {});
     const verifyBaselineApplication = baselineVerifier();
     const verifyIdentityContinuity = vi.fn(async () => verifiedLooseIdentity);
@@ -729,6 +746,7 @@ describe("macOS release plan", () => {
     expect(verifyIdentityContinuity).toHaveBeenCalledTimes(2);
     expect(executeFile.mock.calls).toEqual([
       ["/usr/bin/codesign", ["--verify", "--verbose=2", dmg]],
+      ["/usr/bin/codesign", ["--display", "--verbose=4", dmg]],
       ["/usr/bin/xcrun", ["stapler", "validate", "-v", dmg]],
       [
         "/usr/sbin/spctl",
@@ -845,7 +863,12 @@ describe("macOS release plan", () => {
       throw failure;
     });
     const verifyPackageLayout = vi.fn(async () => {});
-    const executeFile = vi.fn(async () => {});
+    const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+      if (executable === "/usr/bin/codesign" && arguments_.includes("--display")) {
+        return canonicalDmgSigningIdentityResult();
+      }
+      return { stdout: "", stderr: "" };
+    });
     const notarize = vi.fn(async () => {});
     const verifyIdentityContinuity = vi.fn(async () => verifiedLooseIdentity);
     const promoteReleaseEnvelope = vi.fn(async () => "/synthetic/envelope");
@@ -876,7 +899,7 @@ describe("macOS release plan", () => {
     expect(verifyPackageLayout).toHaveBeenCalledOnce();
     expect(notarize).toHaveBeenCalledOnce();
     expect(verifyIdentityContinuity).toHaveBeenCalledOnce();
-    expect(executeFile).toHaveBeenCalledTimes(3);
+    expect(executeFile).toHaveBeenCalledTimes(4);
     expect(sealReleaseMetadata).toHaveBeenCalledOnce();
     expect(promoteReleaseEnvelope).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- inspect the outer DMG signature metadata after native signature verification
- require the pinned Team Identifier and Developer ID certificate chain
- fail closed with redacted diagnostics when identity inspection fails
- cover alternate team, alternate leaf authority, and diagnostic-redaction cases

## Verification

- Node 24 macOS release artifact and plan suites: 198 tests passed
- whole-repo and Desktop TypeScript checks passed
- changed-file lint and formatting checks passed