### PR TITLE
fix(desktop): bound release network operations

### DIFF
--- a/.github/workflows/desktop-release-coordinator.yml
+++ b/.github/workflows/desktop-release-coordinator.yml
@@ -41,6 +41,7 @@ concurrency:
 jobs:
   bind-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -237,6 +238,7 @@ jobs:
 
   prepare-release-draft:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: bind-release
     permissions:
       contents: write

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1102,6 +1102,12 @@ jobs:
       actions: read
       contents: write
     steps:
+      - name: Reserve latest mutation reconciliation window
+        id: latest-deadline
+        run: |
+          set -euo pipefail
+          DEADLINE_SECONDS=$(( $(date -u +%s) + 42 * 60 ))
+          printf 'deadline_ms=%s000\n' "$DEADLINE_SECONDS" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.commit }}
@@ -1154,12 +1160,14 @@ jobs:
       - name: Compare-and-swap repository latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TRANSACTION_DEADLINE_MS: ${{ steps.latest-deadline.outputs.deadline_ms }}
           EXPECTED_LATEST_ID: ${{ needs.publish-assets.outputs.latest_id }}
           EXPECTED_LATEST_TAG: ${{ needs.publish-assets.outputs.latest_tag }}
           EXPECTED_LATEST_METADATA_SHA256: ${{ needs.publish-assets.outputs.latest_metadata_sha256 }}
         run: |
           pnpm desktop-release:transaction promote \
             --directory "$RUNNER_TEMP/desktop-release" \
+            --transaction-deadline-ms "$TRANSACTION_DEADLINE_MS" \
             --expected-latest-id "$EXPECTED_LATEST_ID" \
             --expected-latest-tag "$EXPECTED_LATEST_TAG" \
             --expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"
@@ -1168,6 +1176,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [sign-macos, publish-assets, request-latest]
+    if: >-
+      ${{ always() && needs.sign-macos.result == 'success' &&
+          needs.publish-assets.result == 'success' }}
     environment: desktop-macos-latest
     permissions:
       actions: read

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1097,6 +1097,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [sign-macos, publish-assets]
+    outputs:
+      promotion_outcome: ${{ steps.promote.outputs.promotion_outcome }}
     environment: desktop-macos-latest
     permissions:
       actions: read
@@ -1158,6 +1160,7 @@ jobs:
           printf '%s' "$EVIDENCE_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$'
           test "$ARTIFACT_NAME" = "desktop-release-$EVIDENCE_RUN_ID-$EVIDENCE_RUN_ATTEMPT"
       - name: Compare-and-swap repository latest
+        id: promote
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TRANSACTION_DEADLINE_MS: ${{ steps.latest-deadline.outputs.deadline_ms }}
@@ -1167,6 +1170,7 @@ jobs:
         run: |
           pnpm desktop-release:transaction promote \
             --directory "$RUNNER_TEMP/desktop-release" \
+            --github-output "$GITHUB_OUTPUT" \
             --transaction-deadline-ms "$TRANSACTION_DEADLINE_MS" \
             --expected-latest-id "$EXPECTED_LATEST_ID" \
             --expected-latest-tag "$EXPECTED_LATEST_TAG" \
@@ -1236,7 +1240,22 @@ jobs:
       - name: Reconcile repository latest read-only
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: pnpm desktop-release:transaction reconcile --directory "$RUNNER_TEMP/desktop-release"
+          PROMOTION_OUTCOME: ${{ needs.request-latest.outputs.promotion_outcome }}
+        run: |
+          set -euo pipefail
+          case "$PROMOTION_OUTCOME" in
+            ''|applied|unknown)
+              ;;
+            foreign|unapplied)
+              echo "::error::Latest promotion reached a terminal $PROMOTION_OUTCOME outcome"
+              exit 1
+              ;;
+            *)
+              echo "::error::Latest promotion outcome is invalid"
+              exit 1
+              ;;
+          esac
+          pnpm desktop-release:transaction reconcile --directory "$RUNNER_TEMP/desktop-release"
 
   verify-production-update:
     runs-on: macos-15

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -46,6 +46,7 @@ permissions:
 jobs:
   authorize-coordinator:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read
@@ -236,6 +237,7 @@ jobs:
 
   sign-macos:
     runs-on: macos-15
+    timeout-minutes: 120
     needs: authorize-coordinator
     environment: desktop-macos-signing
     permissions:
@@ -717,6 +719,7 @@ jobs:
 
   verify-macos-envelope:
     runs-on: macos-15
+    timeout-minutes: 45
     needs: sign-macos
     permissions:
       actions: read
@@ -918,6 +921,7 @@ jobs:
 
   stage-private-draft:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [sign-macos, verify-macos-envelope]
     environment: desktop-macos-publication
     permissions:
@@ -1003,6 +1007,7 @@ jobs:
 
   publish-assets:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [sign-macos, stage-private-draft]
     environment: desktop-macos-publication
     permissions:
@@ -1090,6 +1095,7 @@ jobs:
 
   request-latest:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [sign-macos, publish-assets]
     environment: desktop-macos-latest
     permissions:
@@ -1160,6 +1166,7 @@ jobs:
 
   reconcile-latest:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [sign-macos, publish-assets, request-latest]
     environment: desktop-macos-latest
     permissions:
@@ -1325,6 +1332,7 @@ jobs:
 
   activate-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [sign-macos, publish-assets, request-latest, reconcile-latest, verify-production-update]
     if: >-
       ${{ always() && needs.publish-assets.result == 'success' &&
@@ -1398,6 +1406,7 @@ jobs:
 
   compensate-publication:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs:
       [
         sign-macos,

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -1193,6 +1193,60 @@ describe("desktop release workflow policy", () => {
     }
   });
 
+  it("persists terminal latest outcomes across the request and reconciliation jobs", () => {
+    const source = sources();
+    const mutations = [
+      replaceRequired(
+        source.desktop,
+        "promotion_outcome: ${{ steps.promote.outputs.promotion_outcome }}",
+        "promotion_outcome: ${{ github.run_id }}",
+      ),
+      replaceRequired(source.desktop, "        id: promote", "        id: request"),
+      replaceRequired(
+        source.desktop,
+        '--directory "$RUNNER_TEMP/desktop-release" \\\n            --github-output "$GITHUB_OUTPUT" \\\n            --transaction-deadline-ms',
+        '--directory "$RUNNER_TEMP/desktop-release" \\\n            --github-output "$RUNNER_TEMP/outcome" \\\n            --transaction-deadline-ms',
+      ),
+      replaceRequired(
+        source.desktop,
+        "PROMOTION_OUTCOME: ${{ needs.request-latest.outputs.promotion_outcome }}",
+        "PROMOTION_OUTCOME: unknown",
+      ),
+      replaceRequired(source.desktop, "            foreign|unapplied)", "            foreign)"),
+      replaceRequired(
+        source.desktop,
+        "            ''|applied|unknown)",
+        "            ''|applied|unknown|foreign)",
+      ),
+      replaceRequired(
+        source.desktop,
+        "  request-latest:\n    runs-on: ubuntu-latest",
+        "  request-latest:\n    continue-on-error: true\n    runs-on: ubuntu-latest",
+      ),
+      replaceRequired(
+        source.desktop,
+        "      - name: Compare-and-swap repository latest\n        id: promote",
+        "      - name: Compare-and-swap repository latest\n        continue-on-error: true\n        id: promote",
+      ),
+      replaceRequired(
+        source.desktop,
+        "  reconcile-latest:\n    runs-on: ubuntu-latest",
+        "  reconcile-latest:\n    continue-on-error: true\n    runs-on: ubuntu-latest",
+      ),
+      replaceRequired(
+        source.desktop,
+        "      - name: Reconcile repository latest read-only\n        env:",
+        "      - name: Reconcile repository latest read-only\n        continue-on-error: true\n        env:",
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue(
+        { ...source, desktop },
+        "terminal outcomes must remain sticky across read-only reconciliation",
+      );
+    }
+  });
+
   it("runs read-only reconciliation after request timeout without weakening later gates", () => {
     const source = sources();
     const reconciliationMutations = [

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -1129,8 +1129,8 @@ describe("desktop release workflow policy", () => {
       ),
       replaceRequired(
         source.desktop,
-        "  reconcile-latest:\n    runs-on: ubuntu-latest\n    timeout-minutes: 45\n    needs: [sign-macos, publish-assets, request-latest]\n    environment: desktop-macos-latest\n    permissions:\n      actions: read\n      contents: read",
-        "  reconcile-latest:\n    runs-on: ubuntu-latest\n    timeout-minutes: 45\n    needs: [sign-macos, publish-assets, request-latest]\n    environment: desktop-macos-latest\n    permissions:\n      actions: read\n      contents: write",
+        "  reconcile-latest:\n    runs-on: ubuntu-latest\n    timeout-minutes: 45\n    needs: [sign-macos, publish-assets, request-latest]\n    if: >-\n      ${{ always() && needs.sign-macos.result == 'success' &&\n          needs.publish-assets.result == 'success' }}\n    environment: desktop-macos-latest\n    permissions:\n      actions: read\n      contents: read",
+        "  reconcile-latest:\n    runs-on: ubuntu-latest\n    timeout-minutes: 45\n    needs: [sign-macos, publish-assets, request-latest]\n    if: >-\n      ${{ always() && needs.sign-macos.result == 'success' &&\n          needs.publish-assets.result == 'success' }}\n    environment: desktop-macos-latest\n    permissions:\n      actions: read\n      contents: write",
       ),
       replaceRequired(
         source.desktop,
@@ -1144,6 +1144,95 @@ describe("desktop release workflow policy", () => {
         "latest request must compare-and-swap before read-only latest reconciliation",
       );
     }
+  });
+
+  it("reserves reconciliation before setup and preserves the 45-minute job cap", () => {
+    const source = sources();
+    const deadlineStep = [
+      "      - name: Reserve latest mutation reconciliation window",
+      "        id: latest-deadline",
+      "        run: |",
+      "          set -euo pipefail",
+      "          DEADLINE_SECONDS=$(( $(date -u +%s) + 42 * 60 ))",
+      '          printf \'deadline_ms=%s000\\n\' "$DEADLINE_SECONDS" >> "$GITHUB_OUTPUT"',
+    ].join("\n");
+    const checkoutStep = [
+      "      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
+      "        with:",
+      "          ref: ${{ inputs.commit }}",
+      "          persist-credentials: false",
+    ].join("\n");
+    const mutations = [
+      replaceRequired(source.desktop, "+ 42 * 60", "+ 43 * 60"),
+      replaceRequired(
+        source.desktop,
+        "          DEADLINE_SECONDS=$(( $(date -u +%s) + 42 * 60 ))\n          printf",
+        "          DEADLINE_SECONDS=$(( $(date -u +%s) + 42 * 60 ))\n          DEADLINE_SECONDS=$(( DEADLINE_SECONDS + 60 ))\n          printf",
+      ),
+      replaceRequired(
+        source.desktop,
+        `${deadlineStep}\n${checkoutStep}`,
+        `${checkoutStep}\n${deadlineStep}`,
+      ),
+      replaceRequired(
+        source.desktop,
+        "  request-latest:\n    runs-on: ubuntu-latest\n    timeout-minutes: 45",
+        "  request-latest:\n    runs-on: ubuntu-latest\n    timeout-minutes: 46",
+      ),
+      replaceRequired(
+        source.desktop,
+        "TRANSACTION_DEADLINE_MS: ${{ steps.latest-deadline.outputs.deadline_ms }}",
+        "TRANSACTION_DEADLINE_MS: ${{ github.run_id }}",
+      ),
+    ];
+    for (const desktop of mutations) {
+      expectIssue(
+        { ...source, desktop },
+        "latest mutation must reserve reconciliation before compare-and-swap",
+      );
+    }
+  });
+
+  it("runs read-only reconciliation after request timeout without weakening later gates", () => {
+    const source = sources();
+    const reconciliationMutations = [
+      replaceRequired(
+        source.desktop,
+        "${{ always() && needs.sign-macos.result",
+        "${{ needs.sign-macos.result",
+      ),
+      replaceRequired(
+        source.desktop,
+        "needs.publish-assets.result == 'success' }}",
+        "needs.publish-assets.result == 'success' && needs.request-latest.result == 'success' }}",
+      ),
+    ];
+    for (const desktop of reconciliationMutations) {
+      expectIssue(
+        { ...source, desktop },
+        "latest request must compare-and-swap before read-only latest reconciliation",
+      );
+    }
+
+    const activation = replaceRequired(
+      source.desktop,
+      "needs.reconcile-latest.result == 'success' &&\n          ((inputs.mode",
+      "needs.reconcile-latest.result == 'success' &&\n          needs.request-latest.result == 'success' &&\n          ((inputs.mode",
+    );
+    expectIssue(
+      { ...source, desktop: activation },
+      "activation must follow mode-specific acceptance",
+    );
+
+    const compensation = replaceRequired(
+      source.desktop,
+      "needs.reconcile-latest.result == 'success' &&\n          needs.activate-release.result != 'success'",
+      "needs.reconcile-latest.result == 'success' &&\n          needs.request-latest.result == 'success' &&\n          needs.activate-release.result != 'success'",
+    );
+    expectIssue(
+      { ...source, desktop: compensation },
+      "compensation must require successful reconciliation",
+    );
   });
 
   it("requires the native production-feed round trip and gated activation", () => {

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -1238,6 +1238,11 @@ describe("desktop release workflow policy", () => {
         "      - name: Reconcile repository latest read-only\n        env:",
         "      - name: Reconcile repository latest read-only\n        continue-on-error: true\n        env:",
       ),
+      replaceRequired(
+        source.desktop,
+        '            --expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"\n\n  reconcile-latest:',
+        '            --expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"\n          echo \'promotion_outcome=unknown\' >> "$GITHUB_OUTPUT"\n\n  reconcile-latest:',
+      ),
     ];
     for (const desktop of mutations) {
       expectIssue(

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -58,6 +58,23 @@ describe("desktop release workflow policy", () => {
     expect(source.version).toContain('DESKTOP_TAG="enduragent-desktop@$DESKTOP_VERSION"');
   });
 
+  it("requires explicit runtime bounds on every executable release job", () => {
+    const source = sources();
+    const coordinator = replaceRequired(
+      source.coordinator,
+      ["  bind-release:", "    runs-on: ubuntu-latest", "    timeout-minutes: 30"].join("\n"),
+      ["  bind-release:", "    runs-on: ubuntu-latest"].join("\n"),
+    );
+    expectIssue({ ...source, coordinator }, "coordinator executable jobs must have bounded");
+
+    const desktop = replaceRequired(
+      source.desktop,
+      ["  request-latest:", "    runs-on: ubuntu-latest", "    timeout-minutes: 45"].join("\n"),
+      ["  request-latest:", "    runs-on: ubuntu-latest"].join("\n"),
+    );
+    expectIssue({ ...source, desktop }, "release executable jobs must have bounded");
+  });
+
   it("requires the stable desktop tag namespace, manifest version, and exact tag ref", () => {
     const source = sources();
     const mutations = [
@@ -910,8 +927,8 @@ describe("desktop release workflow policy", () => {
     const githubTokenBinding = ["GITHUB_TOKEN", "${{ github.token }}"].join(": ");
     const desktop = replaceRequired(
       source.desktop,
-      "  sign-macos:\n    runs-on: macos-15\n    needs: authorize-coordinator\n    environment: desktop-macos-signing\n    permissions:\n      actions: read\n      contents: read",
-      "  sign-macos:\n    runs-on: macos-15\n    needs: authorize-coordinator\n    environment: desktop-macos-signing\n    permissions:\n      actions: read\n      contents: write",
+      "  sign-macos:\n    runs-on: macos-15\n    timeout-minutes: 120\n    needs: authorize-coordinator\n    environment: desktop-macos-signing\n    permissions:\n      actions: read\n      contents: read",
+      "  sign-macos:\n    runs-on: macos-15\n    timeout-minutes: 120\n    needs: authorize-coordinator\n    environment: desktop-macos-signing\n    permissions:\n      actions: read\n      contents: write",
     ).replaceAll(githubTokenBinding, "CSC_LINK: ${{ secrets.CSC_LINK }}");
     expectIssue({ ...source, desktop }, "macOS signing permissions");
     expectIssue({ ...source, desktop }, "escaped the signing job");
@@ -1112,8 +1129,8 @@ describe("desktop release workflow policy", () => {
       ),
       replaceRequired(
         source.desktop,
-        "  reconcile-latest:\n    runs-on: ubuntu-latest\n    needs: [sign-macos, publish-assets, request-latest]\n    environment: desktop-macos-latest\n    permissions:\n      actions: read\n      contents: read",
-        "  reconcile-latest:\n    runs-on: ubuntu-latest\n    needs: [sign-macos, publish-assets, request-latest]\n    environment: desktop-macos-latest\n    permissions:\n      actions: read\n      contents: write",
+        "  reconcile-latest:\n    runs-on: ubuntu-latest\n    timeout-minutes: 45\n    needs: [sign-macos, publish-assets, request-latest]\n    environment: desktop-macos-latest\n    permissions:\n      actions: read\n      contents: read",
+        "  reconcile-latest:\n    runs-on: ubuntu-latest\n    timeout-minutes: 45\n    needs: [sign-macos, publish-assets, request-latest]\n    environment: desktop-macos-latest\n    permissions:\n      actions: read\n      contents: write",
       ),
       replaceRequired(
         source.desktop,

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -22,6 +22,10 @@ function scalar(value: unknown): string {
   return typeof value === "string" ? value : (JSON.stringify(value) ?? "");
 }
 
+function continuesAfterError(value: unknown): boolean {
+  return value !== undefined && value !== false;
+}
+
 function steps(job: Mapping): Mapping[] {
   return Array.isArray(job.steps)
     ? job.steps.filter(
@@ -1191,6 +1195,34 @@ fi`;
     "latest mutation environment",
     issues,
   );
+  const latestMutationRun =
+    typeof latestMutationStep?.run === "string" ? latestMutationStep.run : "";
+  const requestLatestOutputs = mapping(requestLatest.outputs, "latest request outputs", issues);
+  const reconcileLatestStep = namedStep(reconcileLatest, "Reconcile repository latest read-only");
+  const reconcileLatestEnvironment = mapping(
+    reconcileLatestStep?.env,
+    "latest reconciliation environment",
+    issues,
+  );
+  const reconcileLatestStepRun =
+    typeof reconcileLatestStep?.run === "string" ? reconcileLatestStep.run : "";
+  const expectedReconcileLatestRun = [
+    "set -euo pipefail",
+    'case "$PROMOTION_OUTCOME" in',
+    "  ''|applied|unknown)",
+    "    ;;",
+    "  foreign|unapplied)",
+    '    echo "::error::Latest promotion reached a terminal $PROMOTION_OUTCOME outcome"',
+    "    exit 1",
+    "    ;;",
+    "  *)",
+    '    echo "::error::Latest promotion outcome is invalid"',
+    "    exit 1",
+    "    ;;",
+    "esac",
+    'pnpm desktop-release:transaction reconcile --directory "$RUNNER_TEMP/desktop-release"',
+    "",
+  ].join("\n");
   const reconcileLatestCondition = scalar(reconcileLatest.if).replace(/\s+/gu, " ");
   const roundTripRun = runs(roundTrip).join("\n");
   const activateRun = runs(activate).join("\n");
@@ -1309,9 +1341,28 @@ fi`;
     latestDeadlineRun !== expectedLatestDeadlineRun ||
     latestMutationEnvironment.TRANSACTION_DEADLINE_MS !==
       "${{ steps.latest-deadline.outputs.deadline_ms }}" ||
-    !requestLatestRun.includes('--transaction-deadline-ms "$TRANSACTION_DEADLINE_MS"')
+    !latestMutationRun.includes('--transaction-deadline-ms "$TRANSACTION_DEADLINE_MS"')
   ) {
     issues.push("desktop latest mutation must reserve reconciliation before compare-and-swap");
+  }
+  if (
+    latestMutationStep?.id !== "promote" ||
+    continuesAfterError(requestLatest["continue-on-error"]) ||
+    continuesAfterError(latestMutationStep?.["continue-on-error"]) ||
+    !exactKeys(requestLatestOutputs, ["promotion_outcome"]) ||
+    requestLatestOutputs.promotion_outcome !== "${{ steps.promote.outputs.promotion_outcome }}" ||
+    !latestMutationRun.includes('--github-output "$GITHUB_OUTPUT"') ||
+    !exactKeys(reconcileLatestEnvironment, ["GITHUB_TOKEN", "PROMOTION_OUTCOME"]) ||
+    reconcileLatestEnvironment.GITHUB_TOKEN !== "${{ github.token }}" ||
+    reconcileLatestEnvironment.PROMOTION_OUTCOME !==
+      "${{ needs.request-latest.outputs.promotion_outcome }}" ||
+    continuesAfterError(reconcileLatest["continue-on-error"]) ||
+    continuesAfterError(reconcileLatestStep?.["continue-on-error"]) ||
+    reconcileLatestStepRun !== expectedReconcileLatestRun
+  ) {
+    issues.push(
+      "desktop latest terminal outcomes must remain sticky across read-only reconciliation",
+    );
   }
   if (
     mapping(requestLatest.permissions, "latest request permissions", issues).contents !== "write" ||
@@ -1327,7 +1378,6 @@ fi`;
       "${{ always() && needs.sign-macos.result == 'success' && needs.publish-assets.result == 'success' }}" ||
     mapping(reconcileLatest.permissions, "latest reconciliation permissions", issues).contents !==
       "read" ||
-    !reconcileLatestRun.includes("desktop-release:transaction reconcile") ||
     reconcileLatestRun.includes("desktop-release:transaction promote") ||
     reconcileLatestRun.includes("--expected-latest-")
   ) {

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -61,6 +61,11 @@ function exactStringSet(value: unknown, expected: string[]): boolean {
   return actual.length === wanted.length && actual.every((item, index) => item === wanted[index]);
 }
 
+function boundedJobTimeout(job: Mapping, maximumMinutes: number): boolean {
+  const value = job["timeout-minutes"];
+  return Number.isInteger(value) && Number(value) > 0 && Number(value) <= maximumMinutes;
+}
+
 function checkRecoveryOverlay(
   job: Mapping,
   label: string,
@@ -264,6 +269,9 @@ function checkCoordinator(source: string, coordinator: Mapping, issues: string[]
     issues.push(
       "desktop coordinator must contain only binding, draft safeguard, and reusable call",
     );
+  }
+  if (!boundedJobTimeout(bind, 30) || !boundedJobTimeout(draft, 30)) {
+    issues.push("desktop coordinator executable jobs must have bounded runtimes");
   }
   exactPermissions(
     bind.permissions,
@@ -841,6 +849,22 @@ function checkDesktopChild(source: string, desktop: Mapping, issues: string[]): 
     "desktop.jobs.compensate-publication",
     issues,
   );
+  if (
+    ![
+      authorize,
+      sign,
+      verify,
+      stage,
+      publish,
+      requestLatest,
+      reconcileLatest,
+      roundTrip,
+      activate,
+      compensate,
+    ].every((job) => boundedJobTimeout(job, 120))
+  ) {
+    issues.push("desktop release executable jobs must have bounded runtimes");
+  }
 
   exactPermissions(
     authorize.permissions,

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -1172,6 +1172,26 @@ fi`;
   const publishRun = runs(publish).join("\n");
   const requestLatestRun = runs(requestLatest).join("\n");
   const reconcileLatestRun = runs(reconcileLatest).join("\n");
+  const requestLatestSteps = steps(requestLatest);
+  const latestDeadlineStep = namedStep(
+    requestLatest,
+    "Reserve latest mutation reconciliation window",
+  );
+  const latestDeadlineRun =
+    typeof latestDeadlineStep?.run === "string" ? latestDeadlineStep.run : "";
+  const expectedLatestDeadlineRun = [
+    "set -euo pipefail",
+    "DEADLINE_SECONDS=$(( $(date -u +%s) + 42 * 60 ))",
+    'printf \'deadline_ms=%s000\\n\' "$DEADLINE_SECONDS" >> "$GITHUB_OUTPUT"',
+    "",
+  ].join("\n");
+  const latestMutationStep = namedStep(requestLatest, "Compare-and-swap repository latest");
+  const latestMutationEnvironment = mapping(
+    latestMutationStep?.env,
+    "latest mutation environment",
+    issues,
+  );
+  const reconcileLatestCondition = scalar(reconcileLatest.if).replace(/\s+/gu, " ");
   const roundTripRun = runs(roundTrip).join("\n");
   const activateRun = runs(activate).join("\n");
   const compensateRun = runs(compensate).join("\n");
@@ -1283,6 +1303,17 @@ fi`;
     issues.push("desktop rollback must remain bound to normalized manifest baseline evidence");
   }
   if (
+    requestLatest["timeout-minutes"] !== 45 ||
+    requestLatestSteps[0] !== latestDeadlineStep ||
+    latestDeadlineStep?.id !== "latest-deadline" ||
+    latestDeadlineRun !== expectedLatestDeadlineRun ||
+    latestMutationEnvironment.TRANSACTION_DEADLINE_MS !==
+      "${{ steps.latest-deadline.outputs.deadline_ms }}" ||
+    !requestLatestRun.includes('--transaction-deadline-ms "$TRANSACTION_DEADLINE_MS"')
+  ) {
+    issues.push("desktop latest mutation must reserve reconciliation before compare-and-swap");
+  }
+  if (
     mapping(requestLatest.permissions, "latest request permissions", issues).contents !== "write" ||
     !exactStringSet(requestLatest.needs, ["sign-macos", "publish-assets"]) ||
     !requestLatestRun.includes("desktop-release:transaction promote") ||
@@ -1292,6 +1323,8 @@ fi`;
       '--expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"',
     ) ||
     !exactStringSet(reconcileLatest.needs, ["sign-macos", "publish-assets", "request-latest"]) ||
+    reconcileLatestCondition !==
+      "${{ always() && needs.sign-macos.result == 'success' && needs.publish-assets.result == 'success' }}" ||
     mapping(reconcileLatest.permissions, "latest reconciliation permissions", issues).contents !==
       "read" ||
     !reconcileLatestRun.includes("desktop-release:transaction reconcile") ||
@@ -1364,6 +1397,7 @@ fi`;
     !activateCondition.includes("needs.verify-production-update.result == 'skipped'") ||
     !activateCondition.includes("inputs.mode == 'steady'") ||
     !activateCondition.includes("needs.verify-production-update.result == 'success'") ||
+    activateCondition.includes("needs.request-latest.result") ||
     !activateRun.includes("desktop-release:transaction activate") ||
     !activateRun.includes("apps/desktop/CHANGELOG.md") ||
     activateRun.includes("packages/cycling-coach/CHANGELOG.md")
@@ -1392,6 +1426,7 @@ fi`;
     !compensateCondition.includes("needs.publish-assets.outputs.latest_id != ''") ||
     !compensateCondition.includes("needs.reconcile-latest.result == 'success'") ||
     !compensateCondition.includes("needs.activate-release.result != 'success'") ||
+    compensateCondition.includes("needs.request-latest.result") ||
     !compensateRun.includes("desktop-release:transaction compensate") ||
     !compensateRun.includes("apps/desktop/CHANGELOG.md") ||
     !compensateRun.includes('--expected-latest-id "$EXPECTED_LATEST_ID"') ||

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -1197,6 +1197,16 @@ fi`;
   );
   const latestMutationRun =
     typeof latestMutationStep?.run === "string" ? latestMutationStep.run : "";
+  const expectedLatestMutationRun = [
+    "pnpm desktop-release:transaction promote \\",
+    '  --directory "$RUNNER_TEMP/desktop-release" \\',
+    '  --github-output "$GITHUB_OUTPUT" \\',
+    '  --transaction-deadline-ms "$TRANSACTION_DEADLINE_MS" \\',
+    '  --expected-latest-id "$EXPECTED_LATEST_ID" \\',
+    '  --expected-latest-tag "$EXPECTED_LATEST_TAG" \\',
+    '  --expected-latest-metadata-sha256 "$EXPECTED_LATEST_METADATA_SHA256"',
+    "",
+  ].join("\n");
   const requestLatestOutputs = mapping(requestLatest.outputs, "latest request outputs", issues);
   const reconcileLatestStep = namedStep(reconcileLatest, "Reconcile repository latest read-only");
   const reconcileLatestEnvironment = mapping(
@@ -1351,7 +1361,7 @@ fi`;
     continuesAfterError(latestMutationStep?.["continue-on-error"]) ||
     !exactKeys(requestLatestOutputs, ["promotion_outcome"]) ||
     requestLatestOutputs.promotion_outcome !== "${{ steps.promote.outputs.promotion_outcome }}" ||
-    !latestMutationRun.includes('--github-output "$GITHUB_OUTPUT"') ||
+    latestMutationRun !== expectedLatestMutationRun ||
     !exactKeys(reconcileLatestEnvironment, ["GITHUB_TOKEN", "PROMOTION_OUTCOME"]) ||
     reconcileLatestEnvironment.GITHUB_TOKEN !== "${{ github.token }}" ||
     reconcileLatestEnvironment.PROMOTION_OUTCOME !==

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -505,18 +505,21 @@ describe("GitHub desktop release transaction", () => {
     let fireTimeout: (() => void) | undefined;
     let cancelled = false;
     let bodyReadStarted = false;
+    let requestSignal: AbortSignal | undefined;
     const client = new GithubClient(
       "yerzhansa/enduragent",
       "sensitive-token",
-      async () =>
-        ({
+      async (_input, init) => {
+        requestSignal = init?.signal ?? undefined;
+        return {
           ok: true,
           status: 200,
           json: async () => {
             bodyReadStarted = true;
             return new Promise<never>(() => undefined);
           },
-        }) as unknown as Response,
+        } as unknown as Response;
+      },
       {
         metadataRequestTimeoutMs: 17,
         scheduleTimeout: (callback, delayMs) => {
@@ -542,6 +545,7 @@ describe("GitHub desktop release transaction", () => {
     expect((error as Error).message).toBe("GitHub metadata request timed out");
     expect((error as Error).message).not.toContain("sensitive-token");
     expect((error as Error).message).not.toContain("github.com");
+    expect(requestSignal?.aborted).toBe(true);
     expect(cancelled).toBe(true);
   });
 

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -516,7 +516,7 @@ describe("GitHub desktop release transaction", () => {
             bodyReadStarted = true;
             return new Promise<never>(() => undefined);
           },
-        }) as Response,
+        }) as unknown as Response,
       {
         metadataRequestTimeoutMs: 17,
         scheduleTimeout: (callback, delayMs) => {

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -22,6 +22,7 @@ import {
   stageDesktopRelease,
   type DesktopReleaseManifest,
   type DesktopReleaseMode,
+  type GithubClientTimingOptions,
 } from "./desktop-release-transaction.js";
 
 const candidateVersion = "0.1.7";
@@ -247,8 +248,8 @@ class FakeGithub {
     return this.latestBeforeTransition;
   }
 
-  client(): GithubClient {
-    return new GithubClient("yerzhansa/enduragent", "token", this.fetch);
+  client(timingOptions: GithubClientTimingOptions = {}): GithubClient {
+    return new GithubClient("yerzhansa/enduragent", "token", this.fetch, timingOptions);
   }
 
   fetch = async (input: string | URL | Request, init: RequestInit = {}): Promise<Response> => {
@@ -500,6 +501,78 @@ describe("GitHub desktop release transaction", () => {
     ).rejects.toThrow("outside the bound repository");
   });
 
+  it("uses injected deadlines for metadata requests without exposing secrets or URLs", async () => {
+    let fireTimeout: (() => void) | undefined;
+    let cancelled = false;
+    let bodyReadStarted = false;
+    const client = new GithubClient(
+      "yerzhansa/enduragent",
+      "sensitive-token",
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => {
+            bodyReadStarted = true;
+            return new Promise<never>(() => undefined);
+          },
+        }) as Response,
+      {
+        metadataRequestTimeoutMs: 17,
+        scheduleTimeout: (callback, delayMs) => {
+          expect(delayMs).toBe(17);
+          fireTimeout = callback;
+          return "metadata-timer";
+        },
+        cancelTimeout: (timer) => {
+          expect(timer).toBe("metadata-timer");
+          cancelled = true;
+        },
+      },
+    );
+
+    const request = client.release(123);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bodyReadStarted).toBe(true);
+    expect(fireTimeout).toBeTypeOf("function");
+    fireTimeout!();
+    const error = await request.catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(TypeError);
+    expect((error as Error).message).toBe("GitHub metadata request timed out");
+    expect((error as Error).message).not.toContain("sensitive-token");
+    expect((error as Error).message).not.toContain("github.com");
+    expect(cancelled).toBe(true);
+  });
+
+  it("bounds asset response consumption with a separate transfer budget", async () => {
+    vi.useFakeTimers();
+    try {
+      const response = {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => new Promise<ArrayBuffer>(() => undefined),
+      } as Response;
+      const client = new GithubClient("yerzhansa/enduragent", "token", async () => response, {
+        metadataRequestTimeoutMs: 10,
+        assetTransferTimeoutMs: 40,
+      });
+      let settled = false;
+      const transfer = client
+        .bytes("https://api.github.com/repos/yerzhansa/enduragent/releases/assets/123")
+        .finally(() => {
+          settled = true;
+        });
+      const assertion = expect(transfer).rejects.toThrow("GitHub asset transfer timed out");
+      await vi.advanceTimersByTimeAsync(10);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(30);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("publishes steady assets provisionally and verifies tag downloads anonymously", async () => {
     const fake = new FakeGithub();
     const { directory } = await steadyCandidate(fake);
@@ -600,6 +673,93 @@ describe("GitHub desktop release transaction", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("reconciles a promotion whose successful response was lost without retrying", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    let promotionRequests = 0;
+    const client = new GithubClient("yerzhansa/enduragent", "token", async (input, init) => {
+      const promotion =
+        (init?.method ?? "GET") === "PATCH" &&
+        JSON.parse(String(init?.body ?? "{}") || "{}").make_latest === "true";
+      if (!promotion) return fake.fetch(input, init);
+      promotionRequests += 1;
+      await fake.fetch(input, init);
+      throw new TypeError("connection closed after mutation");
+    });
+
+    vi.useFakeTimers();
+    try {
+      await settleFakeTimerOperation(promoteDesktopLatest(directory, client, observed));
+      expect(promotionRequests).toBe(1);
+      expect(fake.latest?.id).toBe(fake.candidate.id);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("classifies an unapplied promotion without an unsafe blind retry", async () => {
+    const fake = new FakeGithub();
+    const { directory, baseline } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    let promotionRequests = 0;
+    const client = new GithubClient(
+      "yerzhansa/enduragent",
+      "token",
+      async (input, init) => {
+        const promotion =
+          (init?.method ?? "GET") === "PATCH" &&
+          JSON.parse(String(init?.body ?? "{}") || "{}").make_latest === "true";
+        if (!promotion) return fake.fetch(input, init);
+        promotionRequests += 1;
+        throw new TypeError("connection closed before mutation");
+      },
+      { latestReleasePropagationTimeoutMs: 25, latestReleasePropagationDelayMs: 5 },
+    );
+
+    vi.useFakeTimers();
+    try {
+      const startedAt = Date.now();
+      await expect(
+        settleFakeTimerOperation(promoteDesktopLatest(directory, client, observed)),
+      ).rejects.toThrow("desktop latest promotion was not applied");
+      expect(promotionRequests).toBe(1);
+      expect(fake.latest?.id).toBe(baseline.id);
+      expect(Date.now() - startedAt).toBeLessThanOrEqual(25);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("classifies a foreign latest winner after an ambiguous promotion response", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    const unrelated = fake.release(999, "other@1.0.0", false);
+    let promotionRequests = 0;
+    const client = new GithubClient("yerzhansa/enduragent", "token", async (input, init) => {
+      const promotion =
+        (init?.method ?? "GET") === "PATCH" &&
+        JSON.parse(String(init?.body ?? "{}") || "{}").make_latest === "true";
+      if (!promotion) return fake.fetch(input, init);
+      promotionRequests += 1;
+      fake.transitionLatest(unrelated);
+      throw new TypeError("connection closed during concurrent mutation");
+    });
+
+    await expect(promoteDesktopLatest(directory, client, observed)).rejects.toThrow(
+      "desktop latest promotion observed a foreign latest release",
+    );
+    expect(promotionRequests).toBe(1);
+    expect(fake.latest?.id).toBe(unrelated.id);
   });
 
   it("reuses an exact public provisional release without replacing its assets", async () => {

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -721,7 +721,9 @@ describe("GitHub desktop release transaction", () => {
 
     vi.useFakeTimers();
     try {
-      await settleFakeTimerOperation(promoteDesktopLatest(directory, client, observed));
+      await expect(
+        settleFakeTimerOperation(promoteDesktopLatest(directory, client, observed)),
+      ).resolves.toBe("applied");
       expect(promotionRequests).toBe(1);
       expect(fake.latest?.id).toBe(fake.candidate.id);
     } finally {
@@ -827,7 +829,10 @@ describe("GitHub desktop release transaction", () => {
       const startedAt = Date.now();
       await expect(
         settleFakeTimerOperation(promoteDesktopLatest(directory, client, observed)),
-      ).rejects.toThrow("desktop latest promotion was not applied");
+      ).rejects.toMatchObject({
+        outcome: "unapplied",
+        message: "desktop latest promotion was not applied",
+      });
       expect(promotionRequests).toBe(1);
       expect(fake.latest?.id).toBe(baseline.id);
       expect(Date.now() - startedAt).toBeLessThanOrEqual(25);
@@ -854,11 +859,72 @@ describe("GitHub desktop release transaction", () => {
       throw new TypeError("connection closed during concurrent mutation");
     });
 
-    await expect(promoteDesktopLatest(directory, client, observed)).rejects.toThrow(
-      "desktop latest promotion observed a foreign latest release",
-    );
+    await expect(promoteDesktopLatest(directory, client, observed)).rejects.toMatchObject({
+      outcome: "foreign",
+      message: "desktop latest promotion observed a foreign latest release",
+    });
     expect(promotionRequests).toBe(1);
     expect(fake.latest?.id).toBe(unrelated.id);
+  });
+
+  it("makes a pre-mutation latest CAS violation a sticky foreign outcome", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    const unrelated = fake.release(999, "other@1.0.0", false);
+    fake.transitionLatest(unrelated);
+    const patchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+
+    await expect(promoteDesktopLatest(directory, fake.client(), observed)).rejects.toMatchObject({
+      outcome: "foreign",
+    });
+    expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(patchCount);
+    expect(fake.latest?.id).toBe(unrelated.id);
+  });
+
+  it("keeps an unapplied observation unknown after trailing reconciliation failures", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    let mutationAttempted = false;
+    let reconciliationReads = 0;
+    const client = new GithubClient(
+      "yerzhansa/enduragent",
+      "token",
+      async (input, init) => {
+        const promotion =
+          (init?.method ?? "GET") === "PATCH" &&
+          JSON.parse(String(init?.body ?? "{}") || "{}").make_latest === "true";
+        if (promotion) {
+          mutationAttempted = true;
+          throw new TypeError("connection closed before mutation");
+        }
+        if (mutationAttempted && String(input).endsWith("/releases/latest")) {
+          reconciliationReads += 1;
+          if (reconciliationReads > 2) throw new TypeError("synthetic trailing outage");
+        }
+        return fake.fetch(input, init);
+      },
+      { latestReleasePropagationTimeoutMs: 25, latestReleasePropagationDelayMs: 5 },
+    );
+
+    vi.useFakeTimers();
+    try {
+      await expect(
+        settleFakeTimerOperation(promoteDesktopLatest(directory, client, observed)),
+      ).rejects.toMatchObject({
+        outcome: "unknown",
+        message: "desktop latest promotion outcome could not be reconciled",
+      });
+      expect(reconciliationReads).toBeGreaterThan(2);
+      expect(fake.latest?.id).toBe(observed.id);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("reuses an exact public provisional release without replacing its assets", async () => {
@@ -1407,7 +1473,10 @@ describe("GitHub desktop release transaction", () => {
       metadataSha256: digest(fake.bytes.get(metadata.url)!, "sha256", "hex"),
     };
     fake.bytes.set(metadata.url, Buffer.from("changed"));
-    await expect(promoteDesktopLatest(directory, fake.client(), observed)).rejects.toThrow();
+    await expect(promoteDesktopLatest(directory, fake.client(), observed)).rejects.toMatchObject({
+      outcome: "unapplied",
+      message: "repository latest and updater feed digest differ",
+    });
     expect(
       fake.calls.some((call) => call.method === "PATCH" && call.url.endsWith("/releases/123")),
     ).toBe(false);

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -552,7 +552,7 @@ describe("GitHub desktop release transaction", () => {
         ok: true,
         status: 200,
         arrayBuffer: async () => new Promise<ArrayBuffer>(() => undefined),
-      } as Response;
+      } as unknown as Response;
       const client = new GithubClient("yerzhansa/enduragent", "token", async () => response, {
         metadataRequestTimeoutMs: 10,
         assetTransferTimeoutMs: 40,

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -549,6 +549,29 @@ describe("GitHub desktop release transaction", () => {
     expect(cancelled).toBe(true);
   });
 
+  it("derives a fixed preflight, request, and reconciliation budget", () => {
+    const client = new GithubClient(
+      "yerzhansa/enduragent",
+      "token",
+      async () => Response.json({}),
+      {
+        metadataRequestTimeoutMs: 30,
+        releasePropagationTimeoutMs: 600,
+        latestReleasePropagationTimeoutMs: 1_200,
+        now: () => 1_000,
+      },
+    );
+
+    expect(client.latestMutationDeadlines(4_000)).toEqual({
+      preflightDeadlineAt: 2_770,
+      requestDeadlineAt: 2_800,
+      reconciliationDeadlineAt: 4_000,
+    });
+    expect(() => client.latestMutationDeadlines(2_230)).toThrow(
+      "desktop latest promotion reconciliation budget is unavailable",
+    );
+  });
+
   it("bounds asset response consumption with a separate transfer budget", async () => {
     vi.useFakeTimers();
     try {
@@ -701,6 +724,78 @@ describe("GitHub desktop release transaction", () => {
       await settleFakeTimerOperation(promoteDesktopLatest(directory, client, observed));
       expect(promotionRequests).toBe(1);
       expect(fake.latest?.id).toBe(fake.candidate.id);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops aggregate promotion preflight before consuming the reconciliation reserve", async () => {
+    const fake = new FakeGithub();
+    const { directory } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    let now = 10_000;
+    let promotionRequests = 0;
+    const client = new GithubClient(
+      "yerzhansa/enduragent",
+      "token",
+      async (input, init) => {
+        now += 5;
+        if (
+          (init?.method ?? "GET") === "PATCH" &&
+          JSON.parse(String(init?.body ?? "{}") || "{}").make_latest === "true"
+        ) {
+          promotionRequests += 1;
+        }
+        return fake.fetch(input, init);
+      },
+      {
+        metadataRequestTimeoutMs: 10,
+        assetTransferTimeoutMs: 10,
+        releasePropagationTimeoutMs: 100,
+        latestReleasePropagationTimeoutMs: 50,
+        now: () => now,
+      },
+    );
+    const transactionDeadlineAt = now + 80;
+
+    await expect(
+      promoteDesktopLatest(directory, client, observed, transactionDeadlineAt),
+    ).rejects.toThrow("GitHub metadata request timed out");
+    expect(now).toBeLessThanOrEqual(transactionDeadlineAt - 60);
+    expect(promotionRequests).toBe(0);
+    expect(fake.latest?.id).toBe(observed.id);
+  });
+
+  it("read-only reconciliation classifies applied, unapplied, and foreign hard-stop outcomes", async () => {
+    const fake = new FakeGithub();
+    const { directory, baseline } = await steadyCandidate(fake);
+    await stageDesktopRelease(directory, fake.client());
+    const observed = await observeDesktopLatest(directory, fake.client());
+    await publishDesktopRelease(directory, fake.client(), observed);
+    const patchCount = fake.calls.filter((call) => call.method === "PATCH").length;
+    const client = fake.client({
+      latestReleasePropagationTimeoutMs: 25,
+      latestReleasePropagationDelayMs: 5,
+    });
+
+    vi.useFakeTimers();
+    try {
+      fake.transitionLatest(fake.candidate);
+      await settleFakeTimerOperation(reconcileDesktopLatest(directory, client));
+
+      fake.transitionLatest(baseline);
+      await expect(
+        settleFakeTimerOperation(reconcileDesktopLatest(directory, client)),
+      ).rejects.toThrow("desktop latest reconciliation did not converge");
+
+      fake.transitionLatest(fake.release(999, "other@1.0.0", false));
+      await expect(
+        settleFakeTimerOperation(reconcileDesktopLatest(directory, client)),
+      ).rejects.toThrow("desktop latest reconciliation did not converge");
+
+      expect(fake.calls.filter((call) => call.method === "PATCH")).toHaveLength(patchCount);
     } finally {
       vi.useRealTimers();
     }

--- a/tools/desktop-release-transaction.test.ts
+++ b/tools/desktop-release-transaction.test.ts
@@ -17,6 +17,7 @@ import {
   DESKTOP_FEED_URL,
   DESKTOP_MANIFEST,
   DESKTOP_RELEASE_SCHEMA_VERSION,
+  DesktopLatestPromotionOutcomeError,
   assertLatestCas,
   assertPublishableAssets,
   assertReleaseMode,
@@ -24,6 +25,7 @@ import {
   inspectNpmAttestationClaims,
   materializeDesktopPublicEnvelope,
   releaseFileNames,
+  runDesktopLatestPromotionWithOutput,
   sealDesktopRelease,
   verifyNpmProvenanceBundle,
   verifyDesktopRelease,
@@ -282,6 +284,43 @@ describe("advertised npm attestation claims", () => {
 });
 
 afterEach(() => rmSync(directory, { recursive: true, force: true }));
+
+describe("desktop latest promotion command output", () => {
+  it("records an applied outcome before resolving", async () => {
+    const output = join(directory, "github-output");
+
+    await expect(runDesktopLatestPromotionWithOutput(output, async () => "applied")).resolves.toBe(
+      "applied",
+    );
+
+    expect(readFileSync(output, "utf8")).toBe("promotion_outcome=applied\n");
+  });
+
+  it.each(["foreign", "unapplied", "unknown"] as const)(
+    "records a %s outcome before rejecting",
+    async (outcome) => {
+      const output = join(directory, "github-output");
+      const error = new DesktopLatestPromotionOutcomeError(outcome, "synthetic promotion failure");
+
+      await expect(
+        runDesktopLatestPromotionWithOutput(output, async () => Promise.reject(error)),
+      ).rejects.toBe(error);
+
+      expect(readFileSync(output, "utf8")).toBe(`promotion_outcome=${outcome}\n`);
+    },
+  );
+
+  it("records an unknown outcome for an unclassified command failure", async () => {
+    const output = join(directory, "github-output");
+    const error = new TypeError("synthetic command failure");
+
+    await expect(
+      runDesktopLatestPromotionWithOutput(output, async () => Promise.reject(error)),
+    ).rejects.toBe(error);
+
+    expect(readFileSync(output, "utf8")).toBe("promotion_outcome=unknown\n");
+  });
+});
 
 describe("desktop release envelope", () => {
   it("seals exactly four updater files with metadata last and digest bindings", async () => {

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -127,9 +127,30 @@ const latestReleasePropagationAttempts = 240;
 const stableLatestObservationCount = 3;
 const releasePropagationDelayMs = 2_000;
 const latestReleasePropagationDelayMs = 5_000;
+const metadataRequestTimeoutMs = 30_000;
+const assetTransferTimeoutMs = 10 * 60_000;
+const releasePropagationTimeoutMs = 10 * 60_000;
+const latestReleasePropagationTimeoutMs = 20 * 60_000;
+
+type DesktopReleaseTimer = unknown;
+
+export interface GithubClientTiming {
+  readonly metadataRequestTimeoutMs: number;
+  readonly assetTransferTimeoutMs: number;
+  readonly releasePropagationTimeoutMs: number;
+  readonly latestReleasePropagationTimeoutMs: number;
+  readonly releasePropagationDelayMs: number;
+  readonly latestReleasePropagationDelayMs: number;
+  readonly now: () => number;
+  readonly scheduleTimeout: (callback: () => void, delayMs: number) => DesktopReleaseTimer;
+  readonly cancelTimeout: (timer: DesktopReleaseTimer) => void;
+}
+
+export type GithubClientTimingOptions = Partial<GithubClientTiming>;
 
 interface LatestPollBudget {
   remaining: number;
+  deadlineAt: number;
 }
 
 function exactObject(value: unknown): value is Record<string, unknown> {
@@ -772,22 +793,124 @@ export type DesktopReleaseFetch = (
   init?: RequestInit,
 ) => Promise<Response>;
 
+function positiveDuration(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function githubClientTiming(options: GithubClientTimingOptions): GithubClientTiming {
+  return Object.freeze({
+    metadataRequestTimeoutMs: positiveDuration(
+      options.metadataRequestTimeoutMs ?? metadataRequestTimeoutMs,
+      "GitHub metadata timeout",
+    ),
+    assetTransferTimeoutMs: positiveDuration(
+      options.assetTransferTimeoutMs ?? assetTransferTimeoutMs,
+      "GitHub asset timeout",
+    ),
+    releasePropagationTimeoutMs: positiveDuration(
+      options.releasePropagationTimeoutMs ?? releasePropagationTimeoutMs,
+      "release propagation timeout",
+    ),
+    latestReleasePropagationTimeoutMs: positiveDuration(
+      options.latestReleasePropagationTimeoutMs ?? latestReleasePropagationTimeoutMs,
+      "latest propagation timeout",
+    ),
+    releasePropagationDelayMs: positiveDuration(
+      options.releasePropagationDelayMs ?? releasePropagationDelayMs,
+      "release propagation delay",
+    ),
+    latestReleasePropagationDelayMs: positiveDuration(
+      options.latestReleasePropagationDelayMs ?? latestReleasePropagationDelayMs,
+      "latest propagation delay",
+    ),
+    now: options.now ?? (() => Date.now()),
+    scheduleTimeout:
+      options.scheduleTimeout ?? ((callback, delayMs) => setTimeout(callback, delayMs)),
+    cancelTimeout:
+      options.cancelTimeout ?? ((timer) => clearTimeout(timer as ReturnType<typeof setTimeout>)),
+  });
+}
+
 export class GithubClient {
   readonly #repository: string;
   readonly #token: string;
   readonly #fetch: DesktopReleaseFetch;
+  readonly #timing: GithubClientTiming;
 
-  constructor(repository: string, token: string, fetchImplementation: DesktopReleaseFetch = fetch) {
+  constructor(
+    repository: string,
+    token: string,
+    fetchImplementation: DesktopReleaseFetch = fetch,
+    timingOptions: GithubClientTimingOptions = {},
+  ) {
     if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository))
       throw new TypeError("GitHub repository is invalid");
     if (token.length === 0) throw new TypeError("GitHub token is missing");
     this.#repository = repository;
     this.#token = token;
     this.#fetch = fetchImplementation;
+    this.#timing = githubClientTiming(timingOptions);
   }
 
-  async request<T>(url: string, init: RequestInit = {}): Promise<T> {
+  async #bounded<T>(
+    label: string,
+    configuredTimeoutMs: number,
+    operation: (signal: AbortSignal) => Promise<T>,
+    deadlineAt?: number,
+  ): Promise<T> {
+    const now = this.now();
+    const availableMs = deadlineAt === undefined ? configuredTimeoutMs : deadlineAt - now;
+    const timeoutMs = Math.min(configuredTimeoutMs, availableMs);
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new TypeError(`${label} timed out`);
+    }
+    const controller = new AbortController();
+    let timer: DesktopReleaseTimer;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = this.#timing.scheduleTimeout(() => {
+        reject(new TypeError(`${label} timed out`));
+        controller.abort();
+      }, timeoutMs);
+    });
+    try {
+      return await Promise.race([operation(controller.signal), timeout]);
+    } finally {
+      this.#timing.cancelTimeout(timer!);
+    }
+  }
+
+  now(): number {
+    const now = this.#timing.now();
+    if (!Number.isFinite(now)) throw new TypeError("release transaction clock is invalid");
+    return now;
+  }
+
+  propagationDeadline(kind: "release" | "latest"): number {
+    const duration =
+      kind === "release"
+        ? this.#timing.releasePropagationTimeoutMs
+        : this.#timing.latestReleasePropagationTimeoutMs;
+    return this.now() + duration;
+  }
+
+  async pauseForPropagation(kind: "release" | "latest", deadlineAt: number): Promise<void> {
+    const configuredDelay =
+      kind === "release"
+        ? this.#timing.releasePropagationDelayMs
+        : this.#timing.latestReleasePropagationDelayMs;
+    const delayMs = Math.min(configuredDelay, deadlineAt - this.now());
+    if (delayMs <= 0) return;
+    await new Promise<void>((resolvePause) => {
+      this.#timing.scheduleTimeout(resolvePause, delayMs);
+    });
+  }
+
+  async request<T>(url: string, init: RequestInit = {}, deadlineAt?: number): Promise<T> {
     if (!url.startsWith("/")) throw new TypeError("GitHub API URL must be repository-relative");
+    if (init.signal) throw new TypeError("GitHub API request signal is managed internally");
     const target = new URL(url, "https://api.github.com");
     const repositoryPrefix = `/repos/${this.#repository}/`;
     if (
@@ -798,21 +921,32 @@ export class GithubClient {
     ) {
       throw new TypeError("GitHub API URL is outside the bound repository");
     }
-    const response = await this.#fetch(target, {
-      ...init,
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${this.#token}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-        ...init.headers,
+    return this.#bounded(
+      "GitHub metadata request",
+      this.#timing.metadataRequestTimeoutMs,
+      async (signal) => {
+        const response = await this.#fetch(target, {
+          ...init,
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${this.#token}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+            ...init.headers,
+          },
+          signal,
+        });
+        if (!response.ok) {
+          await response.arrayBuffer();
+          throw new TypeError(`GitHub API request failed (${response.status})`);
+        }
+        if (response.status === 204) return undefined as T;
+        return (await response.json()) as T;
       },
-    });
-    if (!response.ok) throw new TypeError(`GitHub API request failed (${response.status})`);
-    if (response.status === 204) return undefined as T;
-    return (await response.json()) as T;
+      deadlineAt,
+    );
   }
 
-  async bytes(url: string): Promise<Buffer> {
+  async bytes(url: string, deadlineAt?: number): Promise<Buffer> {
     const target = new URL(url);
     const assetPattern = new RegExp(
       `^/repos/${this.#repository.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}/releases/assets/[1-9]\\d*$`,
@@ -828,45 +962,58 @@ export class GithubClient {
     ) {
       throw new TypeError("GitHub asset API URL is outside the bound repository");
     }
-    let current = target;
-    for (let redirect = 0; redirect <= 5; redirect += 1) {
-      const authenticated = current.origin === "https://api.github.com";
-      const response = await this.#fetch(current, {
-        headers: authenticated
-          ? {
-              Accept: "application/octet-stream",
-              Authorization: `Bearer ${this.#token}`,
-              "X-GitHub-Api-Version": "2022-11-28",
+    return this.#bounded(
+      "GitHub asset transfer",
+      this.#timing.assetTransferTimeoutMs,
+      async (signal) => {
+        let current = target;
+        for (let redirect = 0; redirect <= 5; redirect += 1) {
+          const authenticated = current.origin === "https://api.github.com";
+          const response = await this.#fetch(current, {
+            headers: authenticated
+              ? {
+                  Accept: "application/octet-stream",
+                  Authorization: `Bearer ${this.#token}`,
+                  "X-GitHub-Api-Version": "2022-11-28",
+                }
+              : { Accept: "application/octet-stream" },
+            redirect: "manual",
+            signal,
+          });
+          if (response.status >= 300 && response.status < 400) {
+            const location = response.headers.get("location");
+            await response.body?.cancel();
+            if (!location || redirect === 5)
+              throw new TypeError("GitHub asset redirect is invalid");
+            const next = new URL(location, current);
+            if (
+              next.protocol !== "https:" ||
+              next.username !== "" ||
+              next.password !== "" ||
+              ![
+                "release-assets.githubusercontent.com",
+                "objects.githubusercontent.com",
+                "github-releases.githubusercontent.com",
+              ].includes(next.hostname)
+            ) {
+              throw new TypeError("GitHub asset redirect origin is invalid");
             }
-          : { Accept: "application/octet-stream" },
-        redirect: "manual",
-      });
-      if (response.status >= 300 && response.status < 400) {
-        const location = response.headers.get("location");
-        if (!location || redirect === 5) throw new TypeError("GitHub asset redirect is invalid");
-        const next = new URL(location, current);
-        if (
-          next.protocol !== "https:" ||
-          next.username !== "" ||
-          next.password !== "" ||
-          ![
-            "release-assets.githubusercontent.com",
-            "objects.githubusercontent.com",
-            "github-releases.githubusercontent.com",
-          ].includes(next.hostname)
-        ) {
-          throw new TypeError("GitHub asset redirect origin is invalid");
+            current = next;
+            continue;
+          }
+          if (!response.ok) {
+            await response.arrayBuffer();
+            throw new TypeError(`GitHub asset download failed (${response.status})`);
+          }
+          return Buffer.from(await response.arrayBuffer());
         }
-        current = next;
-        continue;
-      }
-      if (!response.ok) throw new TypeError(`GitHub asset download failed (${response.status})`);
-      return Buffer.from(await response.arrayBuffer());
-    }
-    throw new TypeError("GitHub asset redirect bound exceeded");
+        throw new TypeError("GitHub asset redirect bound exceeded");
+      },
+      deadlineAt,
+    );
   }
 
-  async anonymousBytes(url: string): Promise<Buffer> {
+  async anonymousBytes(url: string, deadlineAt?: number): Promise<Buffer> {
     const target = new URL(url);
     const prefix = `/${this.#repository}/releases/`;
     const parts = target.pathname.split("/").map((part) => decodeURIComponent(part));
@@ -893,13 +1040,23 @@ export class GithubClient {
     ) {
       throw new TypeError("anonymous GitHub asset URL is outside the bound repository");
     }
-    const response = await this.#fetch(target, {
-      headers: { Accept: "application/octet-stream" },
-      redirect: "follow",
-    });
-    if (!response.ok)
-      throw new TypeError(`anonymous GitHub asset download failed (${response.status})`);
-    return Buffer.from(await response.arrayBuffer());
+    return this.#bounded(
+      "anonymous GitHub asset transfer",
+      this.#timing.assetTransferTimeoutMs,
+      async (signal) => {
+        const response = await this.#fetch(target, {
+          headers: { Accept: "application/octet-stream" },
+          redirect: "follow",
+          signal,
+        });
+        if (!response.ok) {
+          await response.arrayBuffer();
+          throw new TypeError(`anonymous GitHub asset download failed (${response.status})`);
+        }
+        return Buffer.from(await response.arrayBuffer());
+      },
+      deadlineAt,
+    );
   }
 
   release(id: string | number): Promise<GithubRelease> {
@@ -915,22 +1072,32 @@ export class GithubClient {
     if (release.upload_url !== expected) throw new TypeError("GitHub upload URL is invalid");
     const target = new URL(expected.slice(0, expected.indexOf("{")));
     target.searchParams.set("name", name);
-    const response = await this.#fetch(target, {
-      method: "POST",
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${this.#token}`,
-        "Content-Type": "application/octet-stream",
-        "X-GitHub-Api-Version": "2022-11-28",
+    return this.#bounded(
+      "GitHub asset upload",
+      this.#timing.assetTransferTimeoutMs,
+      async (signal) => {
+        const response = await this.#fetch(target, {
+          method: "POST",
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${this.#token}`,
+            "Content-Type": "application/octet-stream",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body: bytes.buffer.slice(
+            bytes.byteOffset,
+            bytes.byteOffset + bytes.byteLength,
+          ) as ArrayBuffer,
+          redirect: "error",
+          signal,
+        });
+        if (!response.ok) {
+          await response.arrayBuffer();
+          throw new TypeError(`GitHub asset upload failed (${response.status})`);
+        }
+        return (await response.json()) as GithubAsset;
       },
-      body: bytes.buffer.slice(
-        bytes.byteOffset,
-        bytes.byteOffset + bytes.byteLength,
-      ) as ArrayBuffer,
-      redirect: "error",
-    });
-    if (!response.ok) throw new TypeError(`GitHub asset upload failed (${response.status})`);
-    return (await response.json()) as GithubAsset;
+    );
   }
 
   deleteAsset(id: number): Promise<void> {
@@ -938,8 +1105,8 @@ export class GithubClient {
     return this.request(`/repos/${this.#repository}/releases/assets/${id}`, { method: "DELETE" });
   }
 
-  async latest(): Promise<LatestObservation> {
-    const release = await this.latestRelease();
+  async latest(deadlineAt?: number): Promise<LatestObservation> {
+    const release = await this.latestRelease(deadlineAt);
     if (!release) return { id: null, tag: null, metadataSha256: null };
     const metadata = release.assets.find((asset) => asset.name === "latest-mac.yml");
     let metadataSha256: string | null = null;
@@ -948,7 +1115,7 @@ export class GithubClient {
       if (metadata.state !== "uploaded" || !match || metadata.size <= 0) {
         throw new TypeError("repository latest metadata digest is invalid");
       }
-      const feedBytes = await this.anonymousBytes(`${DESKTOP_FEED_URL}latest-mac.yml`);
+      const feedBytes = await this.anonymousBytes(`${DESKTOP_FEED_URL}latest-mac.yml`, deadlineAt);
       metadataSha256 = sha256(feedBytes);
       if (feedBytes.length !== metadata.size || metadataSha256 !== match[1]) {
         throw new TypeError("repository latest and updater feed digest differ");
@@ -957,21 +1124,35 @@ export class GithubClient {
     return { id: release.id, tag: release.tag_name, metadataSha256 };
   }
 
-  async latestRelease(): Promise<GithubRelease | null> {
-    const response = await this.#fetch(
-      `https://api.github.com/repos/${this.#repository}/releases/latest`,
-      {
-        headers: {
-          Accept: "application/vnd.github+json",
-          Authorization: `Bearer ${this.#token}`,
-          "Cache-Control": "no-cache",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
+  async latestRelease(deadlineAt?: number): Promise<GithubRelease | null> {
+    return this.#bounded(
+      "GitHub latest metadata request",
+      this.#timing.metadataRequestTimeoutMs,
+      async (signal) => {
+        const response = await this.#fetch(
+          `https://api.github.com/repos/${this.#repository}/releases/latest`,
+          {
+            headers: {
+              Accept: "application/vnd.github+json",
+              Authorization: `Bearer ${this.#token}`,
+              "Cache-Control": "no-cache",
+              "X-GitHub-Api-Version": "2022-11-28",
+            },
+            signal,
+          },
+        );
+        if (response.status === 404) {
+          await response.arrayBuffer();
+          return null;
+        }
+        if (!response.ok) {
+          await response.arrayBuffer();
+          throw new TypeError(`GitHub latest request failed (${response.status})`);
+        }
+        return (await response.json()) as GithubRelease;
       },
+      deadlineAt,
     );
-    if (response.status === 404) return null;
-    if (!response.ok) throw new TypeError(`GitHub latest request failed (${response.status})`);
-    return (await response.json()) as GithubRelease;
   }
 
   async releases(): Promise<readonly GithubRelease[]> {
@@ -1292,6 +1473,7 @@ export async function publishDesktopRelease(
     throw new TypeError("desktop release did not enter a recoverable public state");
   }
   await assertCompleteReleaseAssets(client, published, manifest, "published release");
+  const releasePropagationDeadline = client.propagationDeadline("release");
   for (const file of manifest.files) {
     const asset = published.assets.find((candidate) => candidate.name === file.name);
     if (!asset) throw new TypeError(`published release asset is missing: ${file.name}`);
@@ -1300,7 +1482,12 @@ export async function publishDesktopRelease(
     if (!parts.includes(manifest.tag) || parts.at(-1) !== file.name) {
       throw new TypeError(`release asset is not tag-specific: ${file.name}`);
     }
-    await waitForAnonymousAsset(client, asset.browser_download_url, file);
+    await waitForAnonymousAsset(
+      client,
+      asset.browser_download_url,
+      file,
+      releasePropagationDeadline,
+    );
   }
   assertLatestCas(
     manifest.desktopVersion,
@@ -1421,11 +1608,17 @@ export async function promoteDesktopLatest(
   if (candidate.assets.length !== manifest.files.length) {
     throw new TypeError("promotion candidate asset set is incomplete");
   }
+  const releasePropagationDeadline = client.propagationDeadline("release");
   for (const file of manifest.files) {
     const asset = candidate.assets.find((candidateAsset) => candidateAsset.name === file.name);
     if (!asset || asset.state !== "uploaded")
       throw new TypeError(`promotion candidate asset is missing: ${file.name}`);
-    await waitForAnonymousAsset(client, asset.browser_download_url, file);
+    await waitForAnonymousAsset(
+      client,
+      asset.browser_download_url,
+      file,
+      releasePropagationDeadline,
+    );
   }
   assertLatestCas(
     manifest.desktopVersion,
@@ -1448,29 +1641,37 @@ export async function promoteDesktopLatest(
   for (const file of manifest.files) {
     const asset = rebound.assets.find((entry) => entry.name === file.name);
     if (!asset) throw new TypeError(`promotion candidate asset is missing: ${file.name}`);
-    await waitForAnonymousAsset(client, asset.browser_download_url, file);
+    await waitForAnonymousAsset(
+      client,
+      asset.browser_download_url,
+      file,
+      releasePropagationDeadline,
+    );
   }
   const finalLatest = await client.latest();
   assertLatestCas(manifest.desktopVersion, observed, finalLatest, previous?.version ?? null);
+  const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
+  if (!metadata) throw new TypeError("desktop latest metadata is missing");
+  const promotedLatest = {
+    id: rebound.id,
+    tag: manifest.tag,
+    metadataSha256: metadata.sha256,
+  };
   if (candidateWasFinal) {
-    const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
-    if (
-      !metadata ||
-      !sameLatest(finalLatest, {
-        id: rebound.id,
-        tag: manifest.tag,
-        metadataSha256: metadata.sha256,
-      })
-    ) {
+    if (!sameLatest(finalLatest, promotedLatest)) {
       throw new TypeError("final desktop release is not the stable latest release");
     }
     return;
   }
-  await client.request(`/repos/${client.repository()}/releases/${rebound.id}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ make_latest: "true" }),
-  });
+  try {
+    await client.request(`/repos/${client.repository()}/releases/${rebound.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ make_latest: "true" }),
+    });
+  } catch {
+    await reconcilePromotionMutation(client, finalLatest, promotedLatest);
+  }
 }
 
 export async function reconcileDesktopLatest(
@@ -1522,30 +1723,81 @@ function sameLatest(left: LatestObservation, right: LatestObservation): boolean 
   );
 }
 
-function pauseForReleasePropagation(): Promise<void> {
-  return new Promise((resolvePause) => setTimeout(resolvePause, releasePropagationDelayMs));
+function sameLatestIdentity(left: LatestObservation, right: LatestObservation): boolean {
+  return left.id === right.id && left.tag === right.tag;
 }
 
-function pauseForLatestPropagation(): Promise<void> {
-  return new Promise((resolvePause) => setTimeout(resolvePause, latestReleasePropagationDelayMs));
+function latestPollBudget(client: GithubClient): LatestPollBudget {
+  return {
+    remaining: latestReleasePropagationAttempts,
+    deadlineAt: client.propagationDeadline("latest"),
+  };
+}
+
+async function reconcilePromotionMutation(
+  client: GithubClient,
+  before: LatestObservation,
+  after: LatestObservation,
+): Promise<void> {
+  const budget = latestPollBudget(client);
+  let lastObserved: LatestObservation | null = null;
+  let stableAfterCount = 0;
+  while (budget.remaining > 0 && client.now() < budget.deadlineAt) {
+    budget.remaining -= 1;
+    let current: LatestObservation;
+    try {
+      current = await client.latest(budget.deadlineAt);
+    } catch {
+      stableAfterCount = 0;
+      if (budget.remaining > 0 && client.now() < budget.deadlineAt) {
+        await client.pauseForPropagation("latest", budget.deadlineAt);
+      }
+      continue;
+    }
+    lastObserved = current;
+    if (sameLatest(current, after)) {
+      stableAfterCount += 1;
+      if (stableAfterCount >= stableLatestObservationCount) return;
+    } else if (sameLatest(current, before) || sameLatestIdentity(current, before)) {
+      stableAfterCount = 0;
+    } else if (sameLatestIdentity(current, after)) {
+      stableAfterCount = 0;
+    } else {
+      throw new TypeError("desktop latest promotion observed a foreign latest release");
+    }
+    if (budget.remaining > 0 && client.now() < budget.deadlineAt) {
+      await client.pauseForPropagation("latest", budget.deadlineAt);
+    }
+  }
+  if (lastObserved !== null && sameLatest(lastObserved, before)) {
+    throw new TypeError("desktop latest promotion was not applied");
+  }
+  throw new TypeError("desktop latest promotion outcome could not be reconciled");
 }
 
 async function waitForAnonymousAsset(
   client: GithubClient,
   url: string,
   file: DesktopReleaseFile,
+  deadlineAt: number = client.propagationDeadline("release"),
 ): Promise<void> {
   let lastError: unknown;
-  for (let attempt = 1; attempt <= releasePropagationAttempts; attempt += 1) {
+  for (
+    let attempt = 1;
+    attempt <= releasePropagationAttempts && client.now() < deadlineAt;
+    attempt += 1
+  ) {
     try {
-      assertRemoteAsset(file, await client.anonymousBytes(url));
+      assertRemoteAsset(file, await client.anonymousBytes(url, deadlineAt));
       return;
     } catch (error) {
       lastError = error;
       if (error instanceof TypeError && error.message.startsWith("conflicting release asset:")) {
         throw error;
       }
-      if (attempt < releasePropagationAttempts) await pauseForReleasePropagation();
+      if (attempt < releasePropagationAttempts && client.now() < deadlineAt) {
+        await client.pauseForPropagation("release", deadlineAt);
+      }
     }
   }
   throw new TypeError(`tag-specific release download did not converge: ${file.name}`, {
@@ -1557,16 +1809,16 @@ async function waitForLatest(
   client: GithubClient,
   expected: LatestObservation | readonly LatestObservation[],
   message: string,
-  budget: LatestPollBudget = { remaining: latestReleasePropagationAttempts },
+  budget: LatestPollBudget = latestPollBudget(client),
 ): Promise<LatestObservation> {
   const accepted = Array.isArray(expected) ? expected : [expected];
   let lastError: unknown;
   let stableObservation: LatestObservation | null = null;
   let stableCount = 0;
-  while (budget.remaining > 0) {
+  while (budget.remaining > 0 && client.now() < budget.deadlineAt) {
     budget.remaining -= 1;
     try {
-      const current = await client.latest();
+      const current = await client.latest(budget.deadlineAt);
       const matched = accepted.some((candidate) => sameLatest(candidate, current));
       if (matched) {
         if (stableObservation !== null && sameLatest(stableObservation, current)) {
@@ -1587,7 +1839,9 @@ async function waitForLatest(
       stableCount = 0;
       lastError = error;
     }
-    if (budget.remaining > 0) await pauseForLatestPropagation();
+    if (budget.remaining > 0 && client.now() < budget.deadlineAt) {
+      await client.pauseForPropagation("latest", budget.deadlineAt);
+    }
   }
   throw new TypeError(message, { cause: lastError });
 }
@@ -1640,7 +1894,7 @@ export async function activateDesktopRelease(
     tag: manifest.tag,
     metadataSha256: metadata.sha256,
   };
-  const pollBudget: LatestPollBudget = { remaining: latestReleasePropagationAttempts };
+  const pollBudget = latestPollBudget(client);
   const latest = await waitForLatest(
     client,
     expectedLatest,
@@ -1738,7 +1992,7 @@ export async function compensateDesktopRelease(
     tag: manifest.tag,
     metadataSha256: metadata.sha256,
   };
-  const pollBudget: LatestPollBudget = { remaining: latestReleasePropagationAttempts };
+  const pollBudget = latestPollBudget(client);
   await waitForLatest(
     client,
     candidateLatest,

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -89,6 +89,22 @@ export interface LatestObservation {
   readonly metadataSha256: string | null;
 }
 
+export type DesktopLatestPromotionOutcome = "applied" | "unknown" | "unapplied" | "foreign";
+
+export class DesktopLatestPromotionOutcomeError extends TypeError {
+  readonly outcome: Exclude<DesktopLatestPromotionOutcome, "applied">;
+
+  constructor(
+    outcome: Exclude<DesktopLatestPromotionOutcome, "applied">,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "DesktopLatestPromotionOutcomeError";
+    this.outcome = outcome;
+  }
+}
+
 export interface NpmAttestationExpectation {
   readonly name: string;
   readonly version: string;
@@ -1633,110 +1649,127 @@ export async function promoteDesktopLatest(
   client: GithubClient,
   observed: LatestObservation,
   transactionDeadlineAt?: number,
-): Promise<void> {
-  const mutationDeadlines = client.latestMutationDeadlines(transactionDeadlineAt);
-  const preflightDeadlineAt = Math.min(
-    mutationDeadlines.preflightDeadlineAt,
-    client.propagationDeadline("release"),
-  );
-  const manifest = await verifyDesktopRelease(directory);
-  const candidate = await client.release(manifest.draftId, preflightDeadlineAt);
-  if (candidate.draft || candidate.prerelease || candidate.tag_name !== manifest.tag)
-    throw new TypeError("published candidate binding mismatch");
-  if (!hasRecoverablePublicBody(candidate, manifest))
-    throw new TypeError("published release body is not recoverable");
-  const candidateWasFinal = hasFinalReleaseBody(candidate, manifest);
-  if ((await client.tagCommit(manifest.tag, preflightDeadlineAt)) !== manifest.commit)
-    throw new TypeError("published tag commit binding mismatch");
-  const current = await client.latest(preflightDeadlineAt);
-  const previous = await newestDesktopRelease(
-    await client.releases(preflightDeadlineAt),
-    client,
-    manifest.tag,
-    preflightDeadlineAt,
-  );
-  assertLatestCas(manifest.desktopVersion, observed, current, previous?.version ?? null);
-  assertPublishableAssets(candidate.assets, manifest);
-  if (candidate.assets.length !== manifest.files.length) {
-    throw new TypeError("promotion candidate asset set is incomplete");
-  }
-  const releasePropagationDeadline = preflightDeadlineAt;
-  for (const file of manifest.files) {
-    const asset = candidate.assets.find((candidateAsset) => candidateAsset.name === file.name);
-    if (!asset || asset.state !== "uploaded")
-      throw new TypeError(`promotion candidate asset is missing: ${file.name}`);
-    await waitForAnonymousAsset(
-      client,
-      asset.browser_download_url,
-      file,
-      releasePropagationDeadline,
-    );
-  }
-  assertLatestCas(
-    manifest.desktopVersion,
-    observed,
-    await client.latest(preflightDeadlineAt),
-    previous?.version ?? null,
-  );
-  const rebound = await client.release(candidate.id, preflightDeadlineAt);
-  if (
-    rebound.draft ||
-    rebound.prerelease ||
-    rebound.tag_name !== manifest.tag ||
-    !hasRecoverablePublicBody(rebound, manifest) ||
-    hasFinalReleaseBody(rebound, manifest) !== candidateWasFinal ||
-    (await client.tagCommit(manifest.tag, preflightDeadlineAt)) !== manifest.commit
-  ) {
-    throw new TypeError("promotion candidate changed during final preflight");
-  }
-  await assertCompleteReleaseAssets(
-    client,
-    rebound,
-    manifest,
-    "promotion candidate",
-    preflightDeadlineAt,
-  );
-  for (const file of manifest.files) {
-    const asset = rebound.assets.find((entry) => entry.name === file.name);
-    if (!asset) throw new TypeError(`promotion candidate asset is missing: ${file.name}`);
-    await waitForAnonymousAsset(
-      client,
-      asset.browser_download_url,
-      file,
-      releasePropagationDeadline,
-    );
-  }
-  const finalLatest = await client.latest(preflightDeadlineAt);
-  assertLatestCas(manifest.desktopVersion, observed, finalLatest, previous?.version ?? null);
-  const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
-  if (!metadata) throw new TypeError("desktop latest metadata is missing");
-  const promotedLatest = {
-    id: rebound.id,
-    tag: manifest.tag,
-    metadataSha256: metadata.sha256,
-  };
-  if (candidateWasFinal) {
-    if (!sameLatest(finalLatest, promotedLatest)) {
-      throw new TypeError("final desktop release is not the stable latest release");
-    }
-    return;
-  }
+): Promise<"applied"> {
+  let mutationAttempted = false;
   try {
-    await client.request(
-      `/repos/${client.repository()}/releases/${rebound.id}`,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ make_latest: "true" }),
-      },
-      mutationDeadlines.requestDeadlineAt,
+    const mutationDeadlines = client.latestMutationDeadlines(transactionDeadlineAt);
+    const preflightDeadlineAt = Math.min(
+      mutationDeadlines.preflightDeadlineAt,
+      client.propagationDeadline("release"),
     );
-  } catch {
-    await reconcilePromotionMutation(
+    const manifest = await verifyDesktopRelease(directory);
+    const candidate = await client.release(manifest.draftId, preflightDeadlineAt);
+    if (candidate.draft || candidate.prerelease || candidate.tag_name !== manifest.tag)
+      throw new TypeError("published candidate binding mismatch");
+    if (!hasRecoverablePublicBody(candidate, manifest))
+      throw new TypeError("published release body is not recoverable");
+    const candidateWasFinal = hasFinalReleaseBody(candidate, manifest);
+    if ((await client.tagCommit(manifest.tag, preflightDeadlineAt)) !== manifest.commit)
+      throw new TypeError("published tag commit binding mismatch");
+    const current = await client.latest(preflightDeadlineAt);
+    const previous = await newestDesktopRelease(
+      await client.releases(preflightDeadlineAt),
       client,
+      manifest.tag,
+      preflightDeadlineAt,
+    );
+    assertPromotionLatestCas(manifest.desktopVersion, observed, current, previous?.version ?? null);
+    assertPublishableAssets(candidate.assets, manifest);
+    if (candidate.assets.length !== manifest.files.length) {
+      throw new TypeError("promotion candidate asset set is incomplete");
+    }
+    const releasePropagationDeadline = preflightDeadlineAt;
+    for (const file of manifest.files) {
+      const asset = candidate.assets.find((candidateAsset) => candidateAsset.name === file.name);
+      if (!asset || asset.state !== "uploaded")
+        throw new TypeError(`promotion candidate asset is missing: ${file.name}`);
+      await waitForAnonymousAsset(
+        client,
+        asset.browser_download_url,
+        file,
+        releasePropagationDeadline,
+      );
+    }
+    assertPromotionLatestCas(
+      manifest.desktopVersion,
+      observed,
+      await client.latest(preflightDeadlineAt),
+      previous?.version ?? null,
+    );
+    const rebound = await client.release(candidate.id, preflightDeadlineAt);
+    if (
+      rebound.draft ||
+      rebound.prerelease ||
+      rebound.tag_name !== manifest.tag ||
+      !hasRecoverablePublicBody(rebound, manifest) ||
+      hasFinalReleaseBody(rebound, manifest) !== candidateWasFinal ||
+      (await client.tagCommit(manifest.tag, preflightDeadlineAt)) !== manifest.commit
+    ) {
+      throw new TypeError("promotion candidate changed during final preflight");
+    }
+    await assertCompleteReleaseAssets(
+      client,
+      rebound,
+      manifest,
+      "promotion candidate",
+      preflightDeadlineAt,
+    );
+    for (const file of manifest.files) {
+      const asset = rebound.assets.find((entry) => entry.name === file.name);
+      if (!asset) throw new TypeError(`promotion candidate asset is missing: ${file.name}`);
+      await waitForAnonymousAsset(
+        client,
+        asset.browser_download_url,
+        file,
+        releasePropagationDeadline,
+      );
+    }
+    const finalLatest = await client.latest(preflightDeadlineAt);
+    assertPromotionLatestCas(
+      manifest.desktopVersion,
+      observed,
       finalLatest,
-      promotedLatest,
-      mutationDeadlines.reconciliationDeadlineAt,
+      previous?.version ?? null,
+    );
+    const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
+    if (!metadata) throw new TypeError("desktop latest metadata is missing");
+    const promotedLatest = {
+      id: rebound.id,
+      tag: manifest.tag,
+      metadataSha256: metadata.sha256,
+    };
+    if (candidateWasFinal) {
+      if (!sameLatest(finalLatest, promotedLatest)) {
+        throw new TypeError("final desktop release is not the stable latest release");
+      }
+      return "applied";
+    }
+    mutationAttempted = true;
+    try {
+      await client.request(
+        `/repos/${client.repository()}/releases/${rebound.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ make_latest: "true" }),
+        },
+        mutationDeadlines.requestDeadlineAt,
+      );
+    } catch {
+      await reconcilePromotionMutation(
+        client,
+        finalLatest,
+        promotedLatest,
+        mutationDeadlines.reconciliationDeadlineAt,
+      );
+    }
+    return "applied";
+  } catch (error) {
+    if (error instanceof DesktopLatestPromotionOutcomeError) throw error;
+    throw new DesktopLatestPromotionOutcomeError(
+      mutationAttempted ? "unknown" : "unapplied",
+      error instanceof Error ? error.message : "desktop latest promotion failed",
+      { cause: error },
     );
   }
 }
@@ -1794,6 +1827,23 @@ function sameLatestIdentity(left: LatestObservation, right: LatestObservation): 
   return left.id === right.id && left.tag === right.tag;
 }
 
+function assertPromotionLatestCas(
+  candidateVersion: string,
+  observed: LatestObservation,
+  current: LatestObservation,
+  previousDesktopVersion: string | null,
+): void {
+  try {
+    assertLatestCas(candidateVersion, observed, current, previousDesktopVersion);
+  } catch (error) {
+    throw new DesktopLatestPromotionOutcomeError(
+      "foreign",
+      error instanceof Error ? error.message : "desktop latest compare-and-swap failed",
+      { cause: error },
+    );
+  }
+}
+
 function latestPollBudget(client: GithubClient, deadlineAt?: number): LatestPollBudget {
   return {
     remaining: latestReleasePropagationAttempts,
@@ -1809,41 +1859,66 @@ async function reconcilePromotionMutation(
   before: LatestObservation,
   after: LatestObservation,
   deadlineAt?: number,
-): Promise<void> {
+): Promise<"applied"> {
   const budget = latestPollBudget(client, deadlineAt);
   let lastObserved: LatestObservation | null = null;
   let stableAfterCount = 0;
+  let stableBeforeCount = 0;
+  let lastPollSucceeded = false;
   while (budget.remaining > 0 && client.now() < budget.deadlineAt) {
     budget.remaining -= 1;
     let current: LatestObservation;
     try {
       current = await client.latest(budget.deadlineAt);
     } catch {
+      lastPollSucceeded = false;
       stableAfterCount = 0;
+      stableBeforeCount = 0;
       if (budget.remaining > 0 && client.now() < budget.deadlineAt) {
         await client.pauseForPropagation("latest", budget.deadlineAt);
       }
       continue;
     }
+    lastPollSucceeded = true;
     lastObserved = current;
     if (sameLatest(current, after)) {
       stableAfterCount += 1;
-      if (stableAfterCount >= stableLatestObservationCount) return;
-    } else if (sameLatest(current, before) || sameLatestIdentity(current, before)) {
+      stableBeforeCount = 0;
+      if (stableAfterCount >= stableLatestObservationCount) return "applied";
+    } else if (sameLatest(current, before)) {
       stableAfterCount = 0;
+      stableBeforeCount += 1;
+    } else if (sameLatestIdentity(current, before)) {
+      stableAfterCount = 0;
+      stableBeforeCount = 0;
     } else if (sameLatestIdentity(current, after)) {
       stableAfterCount = 0;
+      stableBeforeCount = 0;
     } else {
-      throw new TypeError("desktop latest promotion observed a foreign latest release");
+      throw new DesktopLatestPromotionOutcomeError(
+        "foreign",
+        "desktop latest promotion observed a foreign latest release",
+      );
     }
     if (budget.remaining > 0 && client.now() < budget.deadlineAt) {
       await client.pauseForPropagation("latest", budget.deadlineAt);
     }
   }
-  if (lastObserved !== null && sameLatest(lastObserved, before)) {
-    throw new TypeError("desktop latest promotion was not applied");
+  if (
+    lastPollSucceeded &&
+    lastObserved !== null &&
+    sameLatest(lastObserved, before) &&
+    stableBeforeCount >= stableLatestObservationCount
+  ) {
+    throw new DesktopLatestPromotionOutcomeError(
+      "unapplied",
+      "desktop latest promotion was not applied",
+    );
   }
-  throw new TypeError("desktop latest promotion outcome could not be reconciled");
+  throw new DesktopLatestPromotionOutcomeError(
+    "unknown",
+    "desktop latest promotion outcome could not be reconciled",
+  );
 }
 
 async function waitForAnonymousAsset(
@@ -2296,6 +2371,29 @@ async function writeLatestOutput(
   );
 }
 
+async function writePromotionOutcome(
+  output: string,
+  outcome: DesktopLatestPromotionOutcome,
+): Promise<void> {
+  await writeFile(output, `promotion_outcome=${outcome}\n`, { flag: "a" });
+}
+
+export async function runDesktopLatestPromotionWithOutput(
+  output: string,
+  promote: () => Promise<"applied">,
+): Promise<"applied"> {
+  let outcome: DesktopLatestPromotionOutcome = "unknown";
+  try {
+    outcome = await promote();
+  } catch (error) {
+    if (error instanceof DesktopLatestPromotionOutcomeError) outcome = error.outcome;
+    await writePromotionOutcome(output, outcome);
+    throw error;
+  }
+  await writePromotionOutcome(output, outcome);
+  return outcome;
+}
+
 async function main(): Promise<void> {
   const command = process.argv[2];
   if (command === "verify-npm-provenance") {
@@ -2376,7 +2474,9 @@ async function main(): Promise<void> {
     return;
   }
   if (command === "promote") {
-    await promoteDesktopLatest(directory, client, latestArguments(), transactionDeadlineArgument());
+    await runDesktopLatestPromotionWithOutput(argument("github-output"), () =>
+      promoteDesktopLatest(directory, client, latestArguments(), transactionDeadlineArgument()),
+    );
     return;
   }
   if (command === "reconcile") {

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -153,6 +153,12 @@ interface LatestPollBudget {
   deadlineAt: number;
 }
 
+interface LatestMutationDeadlines {
+  readonly preflightDeadlineAt: number;
+  readonly requestDeadlineAt: number;
+  readonly reconciliationDeadlineAt: number;
+}
+
 function exactObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
@@ -896,6 +902,30 @@ export class GithubClient {
     return this.now() + duration;
   }
 
+  latestMutationDeadlines(transactionDeadlineAt?: number): LatestMutationDeadlines {
+    const now = this.now();
+    const reconciliationDeadlineAt =
+      transactionDeadlineAt ??
+      now +
+        this.#timing.releasePropagationTimeoutMs +
+        this.#timing.metadataRequestTimeoutMs +
+        this.#timing.latestReleasePropagationTimeoutMs;
+    if (!Number.isFinite(reconciliationDeadlineAt) || reconciliationDeadlineAt <= now) {
+      throw new TypeError("desktop latest transaction deadline is invalid");
+    }
+    const requestDeadlineAt =
+      reconciliationDeadlineAt - this.#timing.latestReleasePropagationTimeoutMs;
+    const preflightDeadlineAt = requestDeadlineAt - this.#timing.metadataRequestTimeoutMs;
+    if (preflightDeadlineAt <= now) {
+      throw new TypeError("desktop latest promotion reconciliation budget is unavailable");
+    }
+    return Object.freeze({
+      preflightDeadlineAt,
+      requestDeadlineAt,
+      reconciliationDeadlineAt,
+    });
+  }
+
   async pauseForPropagation(kind: "release" | "latest", deadlineAt: number): Promise<void> {
     const configuredDelay =
       kind === "release"
@@ -1059,8 +1089,8 @@ export class GithubClient {
     );
   }
 
-  release(id: string | number): Promise<GithubRelease> {
-    return this.request(`/repos/${this.#repository}/releases/${id}`);
+  release(id: string | number, deadlineAt?: number): Promise<GithubRelease> {
+    return this.request(`/repos/${this.#repository}/releases/${id}`, {}, deadlineAt);
   }
 
   async uploadAsset(
@@ -1155,11 +1185,13 @@ export class GithubClient {
     );
   }
 
-  async releases(): Promise<readonly GithubRelease[]> {
+  async releases(deadlineAt?: number): Promise<readonly GithubRelease[]> {
     const releases: GithubRelease[] = [];
     for (let page = 1; ; page += 1) {
       const batch = await this.request<readonly GithubRelease[]>(
         `/repos/${this.#repository}/releases?per_page=100&page=${page}`,
+        {},
+        deadlineAt,
       );
       releases.push(...batch);
       if (batch.length < 100) return releases;
@@ -1168,15 +1200,22 @@ export class GithubClient {
     }
   }
 
-  async tagCommit(tag: string): Promise<string> {
+  async tagCommit(tag: string, deadlineAt?: number): Promise<string> {
     let object = (
       await this.request<GithubReference>(
         `/repos/${this.#repository}/git/ref/tags/${encodeURIComponent(tag)}`,
+        {},
+        deadlineAt,
       )
     ).object;
     for (let depth = 0; object.type === "tag" && depth < 8; depth += 1) {
-      object = (await this.request<GithubTag>(`/repos/${this.#repository}/git/tags/${object.sha}`))
-        .object;
+      object = (
+        await this.request<GithubTag>(
+          `/repos/${this.#repository}/git/tags/${object.sha}`,
+          {},
+          deadlineAt,
+        )
+      ).object;
     }
     if (object.type !== "commit" || !commitPattern.test(object.sha)) {
       throw new TypeError("release tag does not resolve to a commit");
@@ -1214,12 +1253,13 @@ async function newestDesktopRelease(
   releases: readonly GithubRelease[],
   client: GithubClient,
   excludingTag?: string,
+  deadlineAt?: number,
 ): Promise<{ release: GithubRelease; version: string; commit: string } | null> {
   let selected: { release: GithubRelease; version: string; commit: string } | null = null;
   for (const release of releases) {
     const version = desktopReleaseVersion(release, excludingTag);
     if (!version) continue;
-    const commit = await client.tagCommit(release.tag_name);
+    const commit = await client.tagCommit(release.tag_name, deadlineAt);
     if (!selected || compareVersions(version, selected.version) > 0) {
       selected = { release, version, commit };
     }
@@ -1422,6 +1462,7 @@ async function assertCompleteReleaseAssets(
   release: GithubRelease,
   manifest: DesktopReleaseManifest,
   label: string,
+  deadlineAt?: number,
 ): Promise<void> {
   assertPublishableAssets(release.assets, manifest);
   if (release.assets.length !== manifest.files.length) {
@@ -1432,7 +1473,7 @@ async function assertCompleteReleaseAssets(
     if (!asset || asset.state !== "uploaded") {
       throw new TypeError(`${label} asset is incomplete: ${file.name}`);
     }
-    assertRemoteAsset(file, await client.bytes(asset.url));
+    assertRemoteAsset(file, await client.bytes(asset.url, deadlineAt));
   }
 }
 
@@ -1591,24 +1632,35 @@ export async function promoteDesktopLatest(
   directory: string,
   client: GithubClient,
   observed: LatestObservation,
+  transactionDeadlineAt?: number,
 ): Promise<void> {
+  const mutationDeadlines = client.latestMutationDeadlines(transactionDeadlineAt);
+  const preflightDeadlineAt = Math.min(
+    mutationDeadlines.preflightDeadlineAt,
+    client.propagationDeadline("release"),
+  );
   const manifest = await verifyDesktopRelease(directory);
-  const candidate = await client.release(manifest.draftId);
+  const candidate = await client.release(manifest.draftId, preflightDeadlineAt);
   if (candidate.draft || candidate.prerelease || candidate.tag_name !== manifest.tag)
     throw new TypeError("published candidate binding mismatch");
   if (!hasRecoverablePublicBody(candidate, manifest))
     throw new TypeError("published release body is not recoverable");
   const candidateWasFinal = hasFinalReleaseBody(candidate, manifest);
-  if ((await client.tagCommit(manifest.tag)) !== manifest.commit)
+  if ((await client.tagCommit(manifest.tag, preflightDeadlineAt)) !== manifest.commit)
     throw new TypeError("published tag commit binding mismatch");
-  const current = await client.latest();
-  const previous = await newestDesktopRelease(await client.releases(), client, manifest.tag);
+  const current = await client.latest(preflightDeadlineAt);
+  const previous = await newestDesktopRelease(
+    await client.releases(preflightDeadlineAt),
+    client,
+    manifest.tag,
+    preflightDeadlineAt,
+  );
   assertLatestCas(manifest.desktopVersion, observed, current, previous?.version ?? null);
   assertPublishableAssets(candidate.assets, manifest);
   if (candidate.assets.length !== manifest.files.length) {
     throw new TypeError("promotion candidate asset set is incomplete");
   }
-  const releasePropagationDeadline = client.propagationDeadline("release");
+  const releasePropagationDeadline = preflightDeadlineAt;
   for (const file of manifest.files) {
     const asset = candidate.assets.find((candidateAsset) => candidateAsset.name === file.name);
     if (!asset || asset.state !== "uploaded")
@@ -1623,21 +1675,27 @@ export async function promoteDesktopLatest(
   assertLatestCas(
     manifest.desktopVersion,
     observed,
-    await client.latest(),
+    await client.latest(preflightDeadlineAt),
     previous?.version ?? null,
   );
-  const rebound = await client.release(candidate.id);
+  const rebound = await client.release(candidate.id, preflightDeadlineAt);
   if (
     rebound.draft ||
     rebound.prerelease ||
     rebound.tag_name !== manifest.tag ||
     !hasRecoverablePublicBody(rebound, manifest) ||
     hasFinalReleaseBody(rebound, manifest) !== candidateWasFinal ||
-    (await client.tagCommit(manifest.tag)) !== manifest.commit
+    (await client.tagCommit(manifest.tag, preflightDeadlineAt)) !== manifest.commit
   ) {
     throw new TypeError("promotion candidate changed during final preflight");
   }
-  await assertCompleteReleaseAssets(client, rebound, manifest, "promotion candidate");
+  await assertCompleteReleaseAssets(
+    client,
+    rebound,
+    manifest,
+    "promotion candidate",
+    preflightDeadlineAt,
+  );
   for (const file of manifest.files) {
     const asset = rebound.assets.find((entry) => entry.name === file.name);
     if (!asset) throw new TypeError(`promotion candidate asset is missing: ${file.name}`);
@@ -1648,7 +1706,7 @@ export async function promoteDesktopLatest(
       releasePropagationDeadline,
     );
   }
-  const finalLatest = await client.latest();
+  const finalLatest = await client.latest(preflightDeadlineAt);
   assertLatestCas(manifest.desktopVersion, observed, finalLatest, previous?.version ?? null);
   const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
   if (!metadata) throw new TypeError("desktop latest metadata is missing");
@@ -1664,13 +1722,22 @@ export async function promoteDesktopLatest(
     return;
   }
   try {
-    await client.request(`/repos/${client.repository()}/releases/${rebound.id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ make_latest: "true" }),
-    });
+    await client.request(
+      `/repos/${client.repository()}/releases/${rebound.id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ make_latest: "true" }),
+      },
+      mutationDeadlines.requestDeadlineAt,
+    );
   } catch {
-    await reconcilePromotionMutation(client, finalLatest, promotedLatest);
+    await reconcilePromotionMutation(
+      client,
+      finalLatest,
+      promotedLatest,
+      mutationDeadlines.reconciliationDeadlineAt,
+    );
   }
 }
 
@@ -1727,10 +1794,13 @@ function sameLatestIdentity(left: LatestObservation, right: LatestObservation): 
   return left.id === right.id && left.tag === right.tag;
 }
 
-function latestPollBudget(client: GithubClient): LatestPollBudget {
+function latestPollBudget(client: GithubClient, deadlineAt?: number): LatestPollBudget {
   return {
     remaining: latestReleasePropagationAttempts,
-    deadlineAt: client.propagationDeadline("latest"),
+    deadlineAt: Math.min(
+      deadlineAt ?? Number.POSITIVE_INFINITY,
+      client.propagationDeadline("latest"),
+    ),
   };
 }
 
@@ -1738,8 +1808,9 @@ async function reconcilePromotionMutation(
   client: GithubClient,
   before: LatestObservation,
   after: LatestObservation,
+  deadlineAt?: number,
 ): Promise<void> {
-  const budget = latestPollBudget(client);
+  const budget = latestPollBudget(client, deadlineAt);
   let lastObserved: LatestObservation | null = null;
   let stableAfterCount = 0;
   while (budget.remaining > 0 && client.now() < budget.deadlineAt) {
@@ -2201,6 +2272,18 @@ function latestArguments(): LatestObservation {
   };
 }
 
+function transactionDeadlineArgument(): number {
+  const value = argument("transaction-deadline-ms");
+  if (!/^[1-9]\d*$/u.test(value)) {
+    throw new TypeError("desktop latest transaction deadline is invalid");
+  }
+  const deadlineAt = Number(value);
+  if (!Number.isSafeInteger(deadlineAt)) {
+    throw new TypeError("desktop latest transaction deadline is invalid");
+  }
+  return deadlineAt;
+}
+
 async function writeLatestOutput(
   output: string,
   observed: LatestObservation,
@@ -2293,7 +2376,7 @@ async function main(): Promise<void> {
     return;
   }
   if (command === "promote") {
-    await promoteDesktopLatest(directory, client, latestArguments());
+    await promoteDesktopLatest(directory, client, latestArguments(), transactionDeadlineArgument());
     return;
   }
   if (command === "reconcile") {


### PR DESCRIPTION
## Summary

- add explicit runtime bounds to every executable Desktop release job
- bound GitHub metadata, asset transfer, response-body, and propagation operations
- record a 42-minute absolute promotion budget before setup and preserve 20 minutes for ambiguous-write reconciliation
- persist applied, foreign, unapplied, or unknown promotion outcomes before the command exits
- run read-only latest reconciliation after a request-job timeout while preserving terminal foreign and unapplied outcomes
- prevent `continue-on-error` from weakening promotion and reconciliation failures
- freeze the exact promotion script so terminal output cannot be overwritten after the command returns
- reconcile ambiguous latest-promotion responses without an unsafe blind retry
- enforce deadline, output propagation, and hard-stop contracts in the release workflow checker

## Verification

- Node 24 focused release suites: 129 tests passed
- full `pnpm check` passed
- changed-file lint passed with 0 warnings and 0 errors
- changed-file formatting and `git diff --check` passed
- Desktop release workflow checker passed
- 52 Desktop workflow shell blocks passed bash syntax validation
