### PR TITLE
fix(desktop): make updater recovery explicit

### DIFF
--- a/.changeset/honest-updater-timeout-recovery.md
+++ b/.changeset/honest-updater-timeout-recovery.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+"@enduragent/desktop-renderer": patch
+---
+
+User-facing: Desktop now asks you to quit and reopen the app after an update timeout instead of offering a retry that cannot run safely.
+
+Invalidate timed-out updater generations, fence late completions, and keep automated and manual checks disabled until process restart because the native macOS updater does not expose a supported instance reset.

--- a/.changeset/honest-updater-timeout-recovery.md
+++ b/.changeset/honest-updater-timeout-recovery.md
@@ -3,6 +3,6 @@
 "@enduragent/desktop-renderer": patch
 ---
 
-User-facing: Desktop now asks you to quit and reopen the app after an update timeout instead of offering a retry that cannot run safely.
+User-facing: Desktop now asks you to quit and reopen the app when an update check cannot safely continue, instead of offering a retry that cannot run.
 
-Invalidate timed-out updater generations, fence late completions, and keep automated and manual checks disabled until process restart because the native macOS updater does not expose a supported instance reset.
+Invalidate timed-out updater generations, fence late completions, and keep automated and manual checks disabled until process restart after timeouts or updater startup failures because the native macOS updater does not expose a supported instance reset.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -151,6 +151,7 @@ type DesktopUpdateState =
       readonly status: "downloading" | "downloaded" | "installing";
       readonly version: string;
     }
+  | { readonly status: "restart-required"; readonly stage: "check" | "download" }
   | { readonly status: "failed"; readonly stage: "check" | "download" };
 
 type DesktopTelegramControlErrorCode =

--- a/apps/desktop-renderer/src/ui/settings/ApplicationSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/ApplicationSection.tsx
@@ -66,7 +66,7 @@ function updateCopy(state: DesktopUpdateState): UpdateCopy {
         announcement:
           state.stage === "download"
             ? "Update download timed out. Quit and reopen Enduragent to try again."
-            : "Update check timed out. Quit and reopen Enduragent to try again.",
+            : "Updates could not start. Quit and reopen Enduragent to try again.",
       };
     default:
       return {

--- a/apps/desktop-renderer/src/ui/settings/ApplicationSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/ApplicationSection.tsx
@@ -7,7 +7,7 @@ import { RELEASE_NOTES_UNAVAILABLE_COPY } from "./copy.js";
 import styles from "./SettingsView.module.css";
 
 interface UpdateCopy {
-  readonly action: string;
+  readonly action: string | null;
   readonly label: string;
   readonly announcement: string;
 }
@@ -58,6 +58,15 @@ function updateCopy(state: DesktopUpdateState): UpdateCopy {
           state.stage === "download"
             ? "Update download failed. Try again"
             : "Update check failed. Try again",
+      };
+    case "restart-required":
+      return {
+        action: null,
+        label: "Restart Enduragent to resume updates",
+        announcement:
+          state.stage === "download"
+            ? "Update download timed out. Quit and reopen Enduragent to try again."
+            : "Update check timed out. Quit and reopen Enduragent to try again.",
       };
     default:
       return {
@@ -116,7 +125,7 @@ export function ApplicationSection(): ReactElement {
               {copy.announcement}
             </span>
           </div>
-          {update.state.status === "disabled" ? null : (
+          {update.state.status === "disabled" || copy.action === null ? null : (
             <button
               type="button"
               className={styles.button}

--- a/apps/desktop-renderer/src/update/controller.ts
+++ b/apps/desktop-renderer/src/update/controller.ts
@@ -1,6 +1,7 @@
 export type DesktopUpdateState =
   | { readonly status: "disabled" | "idle" | "checking" | "current" }
   | { readonly status: "downloading" | "downloaded" | "installing"; readonly version: string }
+  | { readonly status: "restart-required"; readonly stage: "check" | "download" }
   | { readonly status: "failed"; readonly stage: "check" | "download" };
 
 export interface DesktopUpdateBridge {
@@ -42,7 +43,9 @@ export function createDesktopUpdateController(input: {
     if (
       disposed ||
       active !== undefined ||
-      ["disabled", "checking", "downloading", "installing"].includes(state.status)
+      ["disabled", "checking", "downloading", "installing", "restart-required"].includes(
+        state.status,
+      )
     ) {
       return;
     }

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -845,22 +845,26 @@ describe("application section", () => {
     expect(subject.checkForUpdates).not.toHaveBeenCalled();
   });
 
-  it("explains timeout recovery without offering an inert update retry", async () => {
-    const subject = await renderSettings({
-      updateState: { status: "restart-required", stage: "download" },
-    });
-    await act(async () => {
-      await subject.startUpdate();
-    });
+  it.each([
+    ["download", "Update download timed out. Quit and reopen Enduragent to try again."],
+    ["check", "Updates could not start. Quit and reopen Enduragent to try again."],
+  ] as const)(
+    "explains %s recovery without offering an inert update retry",
+    async (stage, announcement) => {
+      const subject = await renderSettings({
+        updateState: { status: "restart-required", stage },
+      });
+      await act(async () => {
+        await subject.startUpdate();
+      });
 
-    const application = within(screen.getByRole("region", { name: "Application" }));
-    expect(application.getByRole("status")).toHaveTextContent(
-      "Update download timed out. Quit and reopen Enduragent to try again.",
-    );
-    expect(application.queryByRole("button", { name: /update/u })).toBeNull();
-    expect(subject.checkForUpdates).not.toHaveBeenCalled();
-    expect(subject.restartToUpdate).not.toHaveBeenCalled();
-  });
+      const application = within(screen.getByRole("region", { name: "Application" }));
+      expect(application.getByRole("status")).toHaveTextContent(announcement);
+      expect(application.queryByRole("button", { name: /update/u })).toBeNull();
+      expect(subject.checkForUpdates).not.toHaveBeenCalled();
+      expect(subject.restartToUpdate).not.toHaveBeenCalled();
+    },
+  );
 
   it("opens release notes and offers a retry when they are unavailable", async () => {
     const user = userEvent.setup();

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -845,6 +845,23 @@ describe("application section", () => {
     expect(subject.checkForUpdates).not.toHaveBeenCalled();
   });
 
+  it("explains timeout recovery without offering an inert update retry", async () => {
+    const subject = await renderSettings({
+      updateState: { status: "restart-required", stage: "download" },
+    });
+    await act(async () => {
+      await subject.startUpdate();
+    });
+
+    const application = within(screen.getByRole("region", { name: "Application" }));
+    expect(application.getByRole("status")).toHaveTextContent(
+      "Update download timed out. Quit and reopen Enduragent to try again.",
+    );
+    expect(application.queryByRole("button", { name: /update/u })).toBeNull();
+    expect(subject.checkForUpdates).not.toHaveBeenCalled();
+    expect(subject.restartToUpdate).not.toHaveBeenCalled();
+  });
+
   it("opens release notes and offers a retry when they are unavailable", async () => {
     const user = userEvent.setup();
     let attempts = 0;

--- a/apps/desktop-renderer/tests/update.test.ts
+++ b/apps/desktop-renderer/tests/update.test.ts
@@ -70,6 +70,20 @@ describe("desktop update renderer controller", () => {
     expect(subject.bridge.checkForUpdates).not.toHaveBeenCalled();
   });
 
+  it("does not offer an inert retry when the updater requires an app restart", async () => {
+    const subject = setupController({ status: "restart-required", stage: "check" });
+    await subject.controller.start();
+
+    subject.action();
+
+    expect(subject.bridge.checkForUpdates).not.toHaveBeenCalled();
+    expect(subject.bridge.restartToUpdate).not.toHaveBeenCalled();
+    expect(subject.view.render).toHaveBeenLastCalledWith({
+      status: "restart-required",
+      stage: "check",
+    });
+  });
+
   it("preserves a downloaded update and retries when restart fails", async () => {
     const downloaded = { status: "downloaded", version: "2026.7.23" } as const;
     const subject = setupController(downloaded);

--- a/apps/desktop/src/main/update-controller.ts
+++ b/apps/desktop/src/main/update-controller.ts
@@ -15,6 +15,7 @@ export type DesktopUpdateState =
   | { readonly status: "downloading"; readonly version: string }
   | { readonly status: "downloaded"; readonly version: string }
   | { readonly status: "installing"; readonly version: string }
+  | { readonly status: "restart-required"; readonly stage: "check" | "download" }
   | { readonly status: "failed"; readonly stage: "check" | "download" };
 
 export type DesktopAutoUpdater = Pick<
@@ -73,7 +74,9 @@ export const DESKTOP_UPDATE_DOWNLOAD_ABSOLUTE_TIMEOUT_MS = 60 * 60 * 1_000;
 
 export function copyDesktopUpdateState(state: DesktopUpdateState): DesktopUpdateState {
   if ("version" in state) return { status: state.status, version: state.version };
-  if (state.status === "failed") return { status: "failed", stage: state.stage };
+  if (state.status === "failed" || state.status === "restart-required") {
+    return { status: state.status, stage: state.stage };
+  }
   return { status: state.status };
 }
 
@@ -122,7 +125,9 @@ export function createDesktopUpdateController(input: {
   };
 
   const canCheck = (): boolean =>
-    !closed && active && !["downloading", "downloaded", "installing"].includes(state.status);
+    !closed &&
+    active &&
+    !["downloading", "downloaded", "installing", "restart-required"].includes(state.status);
   const isCurrent = (operation: UpdateOperation): boolean =>
     !closed && activeOperation === operation && operation.generation === generation;
   const currentState = (): DesktopUpdateState => copyDesktopUpdateState(state);
@@ -183,7 +188,11 @@ export function createDesktopUpdateController(input: {
     operation.settled = true;
     operation.resolve(currentState());
   };
-  const finishOperation = (operation: UpdateOperation, cancel: boolean): void => {
+  const finishOperation = (
+    operation: UpdateOperation,
+    cancel: boolean,
+    detachPending = false,
+  ): void => {
     clearOperationTimer(operation, "checkTimer");
     clearOperationTimer(operation, "downloadStallTimer");
     clearOperationTimer(operation, "downloadAbsoluteTimer");
@@ -195,12 +204,21 @@ export function createDesktopUpdateController(input: {
     }
     settleOperation(operation);
     if (isCurrent(operation)) generation += 1;
+    if (detachPending && activeOperation === operation) {
+      activeOperation = undefined;
+      return;
+    }
     releaseOperationIfIdle(operation);
   };
   const failOperation = (operation: UpdateOperation, stage: "check" | "download"): void => {
     if (!isCurrent(operation)) return;
     publish({ status: "failed", stage });
     finishOperation(operation, true);
+  };
+  const expireOperation = (operation: UpdateOperation, stage: "check" | "download"): void => {
+    if (!isCurrent(operation)) return;
+    publish({ status: "restart-required", stage });
+    finishOperation(operation, true, true);
   };
   const operationCallSettled = (operation: UpdateOperation): void => {
     operation.pendingCalls -= 1;
@@ -215,7 +233,7 @@ export function createDesktopUpdateController(input: {
     scheduleOperationTimer(
       operation,
       "downloadStallTimer",
-      () => failOperation(operation, "download"),
+      () => expireOperation(operation, "download"),
       DESKTOP_UPDATE_DOWNLOAD_STALL_TIMEOUT_MS,
     );
   };
@@ -259,7 +277,7 @@ export function createDesktopUpdateController(input: {
     scheduleOperationTimer(
       operation,
       "downloadAbsoluteTimer",
-      () => failOperation(operation, "download"),
+      () => expireOperation(operation, "download"),
       DESKTOP_UPDATE_DOWNLOAD_ABSOLUTE_TIMEOUT_MS,
     );
     operation.pendingCalls += 1;
@@ -304,7 +322,7 @@ export function createDesktopUpdateController(input: {
     scheduleOperationTimer(
       operation,
       "checkTimer",
-      () => failOperation(operation, "check"),
+      () => expireOperation(operation, "check"),
       DESKTOP_UPDATE_CHECK_TIMEOUT_MS,
     );
     let pending: Promise<UpdateCheckResult | null>;

--- a/apps/desktop/src/main/update-controller.ts
+++ b/apps/desktop/src/main/update-controller.ts
@@ -370,7 +370,7 @@ export function createDesktopUpdateController(input: {
     try {
       updater = await input.loadUpdater();
     } catch {
-      if (!closed) publish({ status: "failed", stage: "check" });
+      if (!closed) publish({ status: "restart-required", stage: "check" });
       return;
     }
     if (closed) return;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -682,6 +682,7 @@ function parseReleaseNotes(value: unknown): unknown {
 type PreloadUpdateState =
   | { readonly status: "disabled" | "idle" | "checking" | "current" }
   | { readonly status: "downloading" | "downloaded" | "installing"; readonly version: string }
+  | { readonly status: "restart-required"; readonly stage: "check" | "download" }
   | { readonly status: "failed"; readonly stage: "check" | "download" };
 
 function parseUpdateState(value: unknown): PreloadUpdateState {
@@ -704,13 +705,13 @@ function parseUpdateState(value: unknown): PreloadUpdateState {
     };
   }
   if (
-    value.status !== "failed" ||
+    (value.status !== "failed" && value.status !== "restart-required") ||
     !exactKeys(value, ["status", "stage"]) ||
     (value.stage !== "check" && value.stage !== "download")
   ) {
     throw new TypeError();
   }
-  return { status: "failed", stage: value.stage };
+  return { status: value.status, stage: value.stage };
 }
 
 function parseStatuses(value: unknown): unknown {

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -830,7 +830,8 @@ describe("desktop preload ChatGPT auth", () => {
     mocks.invoke
       .mockResolvedValueOnce({ status: "idle" })
       .mockResolvedValueOnce(downloaded)
-      .mockResolvedValueOnce({ status: "installing", version: "2026.7.23" });
+      .mockResolvedValueOnce({ status: "installing", version: "2026.7.23" })
+      .mockResolvedValueOnce({ status: "restart-required", stage: "check" });
 
     await expect(bridge.getUpdateState()).resolves.toEqual({ status: "idle" });
     const copy = await bridge.checkForUpdates();
@@ -840,10 +841,15 @@ describe("desktop preload ChatGPT auth", () => {
       status: "installing",
       version: "2026.7.23",
     });
+    await expect(bridge.getUpdateState()).resolves.toEqual({
+      status: "restart-required",
+      stage: "check",
+    });
     expect(mocks.invoke.mock.calls).toEqual([
       ["desktop:update:get"],
       ["desktop:update:check"],
       ["desktop:update:restart"],
+      ["desktop:update:get"],
     ]);
   });
 
@@ -879,6 +885,8 @@ describe("desktop preload ChatGPT auth", () => {
       { status: "downloaded", version: " 2026.7.23" },
       { status: "failed", stage: "install" },
       { status: "failed", stage: "check", error: "Authorization: secret" },
+      { status: "restart-required", stage: "install" },
+      { status: "restart-required", stage: "check", extra: true },
     ]) {
       mocks.invoke.mockResolvedValueOnce(value);
       await expect(bridge.getUpdateState()).rejects.toBeInstanceOf(TypeError);

--- a/apps/desktop/tests/update-controller.test.ts
+++ b/apps/desktop/tests/update-controller.test.ts
@@ -160,6 +160,31 @@ describe("desktop update controller", () => {
     expect(setInterval).not.toHaveBeenCalled();
   });
 
+  it("requires an app restart when the packaged updater fails to load", async () => {
+    const loadUpdater = vi.fn(async (): Promise<DesktopAutoUpdater> => {
+      throw new Error("synthetic packaged updater load failure");
+    });
+    const setInterval = vi.fn();
+    const controller = createDesktopUpdateController({
+      releaseEligible: true,
+      currentVersion: "0.1.0",
+      loadUpdater,
+      requestQuit: vi.fn(),
+      setInterval,
+    });
+
+    await controller.start();
+
+    expect(controller.state()).toEqual({ status: "restart-required", stage: "check" });
+    await expect(controller.check()).resolves.toEqual({
+      status: "restart-required",
+      stage: "check",
+    });
+    await controller.start();
+    expect(loadUpdater).toHaveBeenCalledOnce();
+    expect(setInterval).not.toHaveBeenCalled();
+  });
+
   it("configures a quiet updater, performs startup and unref'd daily checks, and cleans up", async () => {
     const fake = fakeUpdater();
     vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("0.1.0"));

--- a/apps/desktop/tests/update-controller.test.ts
+++ b/apps/desktop/tests/update-controller.test.ts
@@ -204,7 +204,7 @@ describe("desktop update controller", () => {
     expect(fake.updater.checkForUpdates).toHaveBeenCalledTimes(2);
   });
 
-  it("bounds a hung check while retaining its coalesced updater request until settlement", async () => {
+  it("requires an app restart after a hung check and fences its late settlement", async () => {
     const fake = fakeUpdater();
     const first = deferred<never>();
     const lateToken = fakeCancellationToken();
@@ -218,18 +218,23 @@ describe("desktop update controller", () => {
     expect(subject.timer.unref).toHaveBeenCalledOnce();
     const concurrent = subject.controller.check();
     subject.deadlines.fireLatest(DESKTOP_UPDATE_CHECK_TIMEOUT_MS);
-    await expect(concurrent).resolves.toEqual({ status: "failed", stage: "check" });
+    await expect(concurrent).resolves.toEqual({ status: "restart-required", stage: "check" });
     await startup;
     await expect(subject.controller.check()).resolves.toEqual({
-      status: "failed",
+      status: "restart-required",
       stage: "check",
     });
+    expect(fake.updater.checkForUpdates).toHaveBeenCalledOnce();
+    subject.tick();
     expect(fake.updater.checkForUpdates).toHaveBeenCalledOnce();
 
     first.resolve(updateResult("0.1.0", false, lateToken));
     await vi.waitFor(() => expect(lateToken.cancel).toHaveBeenCalledOnce());
-    await expect(subject.controller.check()).resolves.toEqual({ status: "current" });
-    expect(fake.updater.checkForUpdates).toHaveBeenCalledTimes(2);
+    await expect(subject.controller.check()).resolves.toEqual({
+      status: "restart-required",
+      stage: "check",
+    });
+    expect(fake.updater.checkForUpdates).toHaveBeenCalledOnce();
   });
 
   it("downloads only a strictly newer stable target and accepts only its exact event", async () => {
@@ -279,20 +284,29 @@ describe("desktop update controller", () => {
 
     subject.deadlines.fireLatest(DESKTOP_UPDATE_DOWNLOAD_STALL_TIMEOUT_MS);
     await expect(startup).resolves.toBeUndefined();
-    expect(subject.controller.state()).toEqual({ status: "failed", stage: "download" });
+    expect(subject.controller.state()).toEqual({
+      status: "restart-required",
+      stage: "download",
+    });
     expect(token.cancel).toHaveBeenCalledOnce();
     await expect(subject.controller.check()).resolves.toEqual({
-      status: "failed",
+      status: "restart-required",
       stage: "download",
     });
     expect(fake.updater.checkForUpdates).toHaveBeenCalledOnce();
     fake.emit("update-downloaded", { version: "0.1.1" });
-    expect(subject.controller.state()).toEqual({ status: "failed", stage: "download" });
+    expect(subject.controller.state()).toEqual({
+      status: "restart-required",
+      stage: "download",
+    });
 
     download.resolve([] as never);
     await download.promise;
-    await expect(subject.controller.check()).resolves.toEqual({ status: "current" });
-    expect(fake.updater.checkForUpdates).toHaveBeenCalledTimes(2);
+    await expect(subject.controller.check()).resolves.toEqual({
+      status: "restart-required",
+      stage: "download",
+    });
+    expect(fake.updater.checkForUpdates).toHaveBeenCalledOnce();
   });
 
   it("enforces an absolute download cap even while progress continues", async () => {
@@ -309,7 +323,10 @@ describe("desktop update controller", () => {
     fake.emit("download-progress", { transferred: 2 });
     subject.deadlines.fireLatest(DESKTOP_UPDATE_DOWNLOAD_ABSOLUTE_TIMEOUT_MS);
     await expect(startup).resolves.toBeUndefined();
-    expect(subject.controller.state()).toEqual({ status: "failed", stage: "download" });
+    expect(subject.controller.state()).toEqual({
+      status: "restart-required",
+      stage: "download",
+    });
     expect(token.cancel).toHaveBeenCalledOnce();
   });
 

--- a/apps/desktop/tests/update-ipc.test.ts
+++ b/apps/desktop/tests/update-ipc.test.ts
@@ -113,4 +113,24 @@ describe("desktop update IPC", () => {
     expect(state.ipcMain.removeHandler).toHaveBeenCalledTimes(3);
     expect(state.handlers.size).toBe(0);
   });
+
+  it("preserves restart-required recovery across request and push boundaries", async () => {
+    const state = setup();
+    vi.mocked(state.controller.check).mockResolvedValue({
+      status: "restart-required",
+      stage: "download",
+    });
+
+    await expect(state.handlers.get(DESKTOP_UPDATE_CHECK_CHANNEL)!(state.trusted)).resolves.toEqual(
+      {
+        status: "restart-required",
+        stage: "download",
+      },
+    );
+    state.publish({ status: "restart-required", stage: "check" });
+    expect(state.webContents.send).toHaveBeenLastCalledWith(DESKTOP_UPDATE_STATE_CHANNEL, {
+      status: "restart-required",
+      stage: "check",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- move timed-out update checks and downloads into an explicit restart-required state
- fence manual checks, scheduled checks, and late native updater completions until process restart
- treat a rejected packaged updater load as the same non-actionable recovery state
- carry the state through strict preload/IPC validation and remove the renderer's inert retry action

## Why

The native macOS updater does not expose a supported in-process reset after a timed-out operation, and a rejected packaged-module load cannot be recovered by repeating the same cached load. Offering a retry in either state implied recovery while the process could not safely perform it.

## Verification

- 111 focused Desktop controller, IPC, preload, renderer-controller, and Settings tests
- Desktop and Desktop renderer TypeScript checks
- Desktop and Desktop renderer production builds
- changed-file oxlint and oxfmt checks
- user-facing changeset validation
- diff hygiene check

## Review

The full nine-dimension review passed: state-machine behavior, project fit, boundary validation, regression coverage, scope, project discipline, user-facing explanation, security, and operational safety were all checked against the final diff.
