### PR TITLE
feat(desktop): check for updates every six hours

### DIFF
--- a/.changeset/frequent-desktop-update-checks.md
+++ b/.changeset/frequent-desktop-update-checks.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Desktop now checks for updates every six hours while running, in addition to checking at startup.

--- a/apps/desktop/src/main/update-controller.ts
+++ b/apps/desktop/src/main/update-controller.ts
@@ -67,7 +67,7 @@ interface UpdateOperation {
   downloadedListener?: (event: UpdateDownloadedEvent) => void;
 }
 
-export const DESKTOP_UPDATE_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+export const DESKTOP_UPDATE_INTERVAL_MS = 6 * 60 * 60 * 1_000;
 export const DESKTOP_UPDATE_CHECK_TIMEOUT_MS = 2 * 60 * 1_000;
 export const DESKTOP_UPDATE_DOWNLOAD_STALL_TIMEOUT_MS = 2 * 60 * 1_000;
 export const DESKTOP_UPDATE_DOWNLOAD_ABSOLUTE_TIMEOUT_MS = 60 * 60 * 1_000;

--- a/apps/desktop/tests/update-controller.test.ts
+++ b/apps/desktop/tests/update-controller.test.ts
@@ -141,6 +141,10 @@ function activeController(
 }
 
 describe("desktop update controller", () => {
+  it("checks for updates every six hours", () => {
+    expect(DESKTOP_UPDATE_INTERVAL_MS).toBe(6 * 60 * 60 * 1_000);
+  });
+
   it("is silent when release eligibility is disabled", async () => {
     const loadUpdater = vi.fn();
     const setInterval = vi.fn();
@@ -185,7 +189,7 @@ describe("desktop update controller", () => {
     expect(setInterval).not.toHaveBeenCalled();
   });
 
-  it("configures a quiet updater, performs startup and unref'd daily checks, and cleans up", async () => {
+  it("configures a quiet updater, performs startup and unref'd six-hour checks, and cleans up", async () => {
     const fake = fakeUpdater();
     vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("0.1.0"));
     const subject = activeController(fake.updater);


### PR DESCRIPTION
## Summary

- check for Desktop updates every six hours while the signed packaged app remains open
- preserve the existing immediate startup check
- pin the interval with a focused regression assertion and user-facing changeset

## Verification

- 112 focused Desktop controller, IPC, preload, renderer-controller, and Settings tests
- Desktop and Desktop renderer TypeScript checks
- Desktop and Desktop renderer production builds
- changed-file oxlint and oxfmt checks
- user-facing changeset validation
- diff hygiene check

## Review

The full nine-dimension review passed. The final stacked diff is limited to the interval constant, its exact regression test, corrected test wording, and the required changeset.
