### PR TITLE
test(desktop): align packaged telegram harness with settled onboarding contract

### DIFF
--- a/apps/desktop/scripts/test-packaged-telegram.ts
+++ b/apps/desktop/scripts/test-packaged-telegram.ts
@@ -787,7 +787,7 @@ async function seedCompletedOnboardingAfterStartup(
     page
       .evaluate<boolean>(`document.readyState === "complete" &&
         document.documentElement.dataset.rpc === "connected" &&
-        document.querySelector('[data-onboarding="open"]') !== null`)
+        document.querySelector('[data-onboarding="settled"]') !== null`)
       .catch(() => false),
   );
   const persisted = await page.evaluate<boolean>(
@@ -1152,10 +1152,10 @@ async function main(): Promise<void> {
     await seedCompletedOnboardingAfterStartup(page);
     await waitForButton(page, "Settings");
     await page.clickButton("Settings");
-    await waitUntil("Settings after onboarding dismissal", async () =>
+    await waitUntil("Settings after onboarding startup settled", async () =>
       page
         .evaluate<boolean>(
-          `document.querySelector('[data-view="settings"][data-onboarding="closed"]') !== null`,
+          `document.querySelector('[data-view="settings"][data-onboarding="settled"]') !== null`,
         )
         .catch(() => false),
     );


### PR DESCRIPTION
## Summary
The embedded-setup redesign changed the renderer's onboarding markers: `data-onboarding` now takes `pending`/`settled` (Shell.tsx) instead of the old `open`/`closed`. The packaged Telegram acceptance harness still polled the old values, so its "initial renderer startup" wait timed out — the sole CI failure on #547's desktop-packaged-self-test job.

Updates the two stale selectors in `test-packaged-telegram.ts` to the settled contract, keeping every check fail-closed. Onboarding storage seed constants were verified against current renderer persistence and are unchanged.

## Test plan
- Full packaged run in an isolated worktree: `ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT=1 pnpm --filter @enduragent/desktop test:telegram-packaged` → `{"ok":true, productionChain, coldStartBackground, residentLifecycle, persistedDisable, removal all true}`
- CI on #547 reruns the same chain after merge.