### PR TITLE
ci: seal npm release tarballs before the smoke test installs them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         # artifact, not in `pnpm test` — is caught before merge, not at release.
         # cycling-coach is the only publishable binary (ADR-0009); extend when
         # running-coach / duathlon-coach graduate.
+        # --ignore-scripts skips the full dependency tree, so this smoke no longer proves postinstall behavior.
         run: |
           set -euo pipefail
           PACKAGE=cycling-coach
@@ -80,7 +81,7 @@ jobs:
           mkdir -p "/tmp/smoke-consumer-$PACKAGE"
           cd "/tmp/smoke-consumer-$PACKAGE"
           npm init -y > /dev/null
-          npm install "$TARBALL"
+          npm install "$TARBALL" --ignore-scripts
           timeout 30 node "node_modules/$PACKAGE/dist/index.js" --help
 
   secrets-macos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,20 +179,15 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r build
-      - name: Pack and smoke ${{ needs.parse-tag.outputs.package }}
+      - name: Pack and verify ${{ needs.parse-tag.outputs.package }}
         id: pack
         env:
           RELEASE_PACKAGE: ${{ needs.parse-tag.outputs.package }}
           RELEASE_VERSION: ${{ needs.parse-tag.outputs.version }}
-        # Install the packed tarball as a dependency of a fresh consumer
-        # project — what end users actually do. Installing in-place via
-        # `npm install --omit=dev` doesn't work: npm resolves the full
-        # dep graph (incl. devDeps) before applying --omit, hits 404 on
-        # private workspace devDeps.
         run: |
           set -euo pipefail
           PACKAGE="$RELEASE_PACKAGE"
-          PACK_DIR="/tmp/smoke-pack-$PACKAGE"
+          PACK_DIR=$(mktemp -d "$RUNNER_TEMP/smoke-pack-$PACKAGE.XXXXXX")
           SOURCE_PACKAGE_JSON="packages/$PACKAGE/package.json"
           CANONICAL_REPOSITORY="git+https://github.com/yerzhansa/enduragent.git"
           CANONICAL_DIRECTORY="packages/$PACKAGE"
@@ -200,7 +195,6 @@ jobs:
             --arg repository "$CANONICAL_REPOSITORY" --arg directory "$CANONICAL_DIRECTORY" \
             '.name == $name and .version == $version and .repository == {"type":"git","url":$repository,"directory":$directory} and .publishConfig == null' \
             "$SOURCE_PACKAGE_JSON" >/dev/null
-          mkdir -p "$PACK_DIR"
           pnpm --dir "packages/$PACKAGE" pack --pack-destination "$PACK_DIR"
           TARBALL=$(find "$PACK_DIR" -maxdepth 1 -name '*.tgz' -print -quit)
           test -f "$TARBALL"
@@ -211,13 +205,6 @@ jobs:
             '.name == $name and .version == $version and .repository == {"type":"git","url":$repository,"directory":$directory} and .publishConfig == null' \
             "$PACKED_PACKAGE_JSON" >/dev/null
           pnpm check:published-package -- "$TARBALL"
-          mkdir -p "/tmp/smoke-consumer-$PACKAGE"
-          (
-            cd "/tmp/smoke-consumer-$PACKAGE"
-            npm init -y > /dev/null
-            npm install "$TARBALL"
-            timeout 30 node "node_modules/$PACKAGE/dist/index.js" --help
-          )
           PRIMARY_FILENAME=$(basename "$TARBALL")
           PRIMARY_SHA512=$(shasum -a 512 "$TARBALL" | awk '{print $1}')
           ALIAS_FILENAME=none
@@ -244,15 +231,37 @@ jobs:
           echo "primary_sha512=$PRIMARY_SHA512" >> "$GITHUB_OUTPUT"
           echo "alias_filename=$ALIAS_FILENAME" >> "$GITHUB_OUTPUT"
           echo "alias_sha512=$ALIAS_SHA512" >> "$GITHUB_OUTPUT"
+          echo "pack_dir=$PACK_DIR" >> "$GITHUB_OUTPUT"
       - name: Upload immutable npm release artifacts
         id: npm-artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-release-${{ github.run_id }}-${{ github.run_attempt }}-${{ needs.parse-tag.outputs.package }}
-          path: /tmp/smoke-pack-${{ needs.parse-tag.outputs.package }}/*.tgz
+          path: ${{ steps.pack.outputs.pack_dir }}/*.tgz
           if-no-files-found: error
           compression-level: 0
           retention-days: 30
+      - name: Smoke installed ${{ needs.parse-tag.outputs.package }}
+        env:
+          RELEASE_PACKAGE: ${{ needs.parse-tag.outputs.package }}
+          PACK_DIR: ${{ steps.pack.outputs.pack_dir }}
+          PRIMARY_FILENAME: ${{ steps.pack.outputs.primary_filename }}
+        # Install the sealed tarball as a dependency of a fresh consumer
+        # project — what end users actually do. Installing in-place via
+        # `npm install --omit=dev` doesn't work: npm resolves the full
+        # dep graph (incl. devDeps) before applying --omit, hits 404 on
+        # private workspace devDeps.
+        # --ignore-scripts skips the full dependency tree, so this smoke no longer proves postinstall behavior.
+        run: |
+          set -euo pipefail
+          PACKAGE="$RELEASE_PACKAGE"
+          TARBALL="$PACK_DIR/$PRIMARY_FILENAME"
+          test -f "$TARBALL"
+          CONSUMER_DIR=$(mktemp -d "$RUNNER_TEMP/smoke-consumer-$PACKAGE.XXXXXX")
+          cd "$CONSUMER_DIR"
+          npm init -y > /dev/null
+          npm install "$TARBALL" --ignore-scripts
+          timeout 30 node "node_modules/$PACKAGE/dist/index.js" --help
 
   publish-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The npm release smoke test installs the packed tarball into a fresh consumer and
executes it. Today that happens *inside* the same step that packs the tarball,
and the artifact upload that seals the bytes runs afterwards. So arbitrary
dependency code executes on the release runner while the tarballs sit unsealed
on disk, and anything it writes to them is what gets hashed, uploaded, and
published.

## What changed

`release.yml`, `smoke` job — the step order is now:

1. `pack` — metadata checks, `pnpm pack`, `check:published-package`, the
   `enduragent` alias tarball, SHA512s, outputs.
2. `npm-artifact` — upload. **The bytes are sealed here.**
3. New step — consumer install and `--help` execution.

`--ignore-scripts` added to the smoke installs in both `release.yml` and
`ci.yml`, so dependency lifecycle scripts cannot run in these jobs.

`PACK_DIR` moved from the predictable, world-readable `/tmp/smoke-pack-$PACKAGE`
to `mktemp -d` under `$RUNNER_TEMP`. The consumer directory moved the same way.

## Details worth checking on review

- **The upload path had to change with it.** `path:` was the literal
  `/tmp/smoke-pack-<pkg>/*.tgz`, evaluated as a workflow expression, not in the
  shell — a `mktemp` directory would have made it stale, and
  `if-no-files-found: error` turns that into a hard release failure rather than
  a silent one. The pack step now exports `pack_dir` through `$GITHUB_OUTPUT`
  and the upload reads `${{ steps.pack.outputs.pack_dir }}/*.tgz`.
- **Artifact contents are unchanged.** Both tarballs still upload. The glob is
  still depth-1 `*.tgz`, so the alias `extract/` subdirectory and the
  `*-package.json` intermediates that live in the same directory stay out.
- **The four `pack` outputs are untouched** — `primary_filename`,
  `primary_sha512`, `alias_filename`, `alias_sha512` — including the
  `none` sentinel used for non-`cycling-coach` packages. Three downstream jobs
  convert them to registry integrity values.
- **`--ignore-scripts` narrows what the smoke proves.** It suppresses lifecycle
  scripts for the whole transitive tree, not just the tarball under test.
  `cycling-coach` has no install/prepare/prepack/postpack scripts today, so
  nothing changes now, but the package has 13 runtime dependencies — if one ever
  needs a postinstall, this smoke would keep passing while real user installs
  break. Recorded as a comment at both call sites.
- Sealing before the smoke means a failing smoke leaves an uploaded artifact
  behind. That is harmless: `publish-npm` needs the `smoke` job, so a failure
  still blocks publication.

No action pin, job dependency, or output contract changed.
