### PR TITLE
ci: gate stable image promotion on CI success and pin build helpers

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -1,0 +1,255 @@
+name: Promote stable images
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read
+  packages: write
+  contents: read
+
+# Stable is a single release lane even when CI runs complete close together.
+concurrency:
+  group: promote-stable
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/yerzhansa/cycling-coach
+  ALIAS_IMAGE_NAME: ghcr.io/yerzhansa/enduragent
+
+jobs:
+  promote:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: source
+        name: Derive immutable source tag
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          short_sha="${HEAD_SHA::12}"
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+
+      # CI and image publication run concurrently, so tag absence alone cannot identify a path-filter skip.
+      - id: publish
+        name: Wait for matching image publication
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          readonly max_wait_seconds=$((35 * 60))
+          readonly poll_interval_seconds=25
+          readonly api_retry_interval_seconds=10
+          readonly api_max_attempts=3
+          deadline=$((SECONDS + max_wait_seconds))
+          seen_run=false
+
+          fetch_runs() {
+            local attempt response remaining_seconds request_timeout retry_delay
+
+            for ((attempt = 1; attempt <= api_max_attempts; attempt++)); do
+              remaining_seconds=$((deadline - SECONDS))
+              if ((remaining_seconds <= 0)); then
+                return 124
+              fi
+
+              request_timeout=30
+              if ((request_timeout > remaining_seconds)); then
+                request_timeout=$remaining_seconds
+              fi
+
+              if response=$(timeout "${request_timeout}s" gh api --method GET \
+                "repos/${REPOSITORY}/actions/workflows/publish-image.yml/runs" \
+                -f "head_sha=${HEAD_SHA}" \
+                -f "per_page=100" | \
+                jq -ce '.workflow_runs | if type == "array" then . else error("missing workflow_runs array") end'); then
+                printf '%s\n' "$response"
+                return 0
+              fi
+
+              if ((attempt < api_max_attempts)); then
+                remaining_seconds=$((deadline - SECONDS))
+                if ((remaining_seconds <= 0)); then
+                  break
+                fi
+
+                retry_delay=$api_retry_interval_seconds
+                if ((retry_delay > remaining_seconds)); then
+                  retry_delay=$remaining_seconds
+                fi
+                echo "::warning::GitHub Actions API request failed (attempt ${attempt}/${api_max_attempts}); retrying in ${retry_delay}s." >&2
+                sleep "$retry_delay"
+              fi
+            done
+
+            if ((SECONDS >= deadline)); then
+              return 124
+            fi
+
+            echo "::error::GitHub Actions API request or response validation failed after ${api_max_attempts} attempts." >&2
+            return 1
+          }
+
+          while true; do
+            if runs_json=$(fetch_runs); then
+              :
+            else
+              fetch_status=$?
+              if ((fetch_status == 124)); then
+                echo "::error::Timed out after ${max_wait_seconds}s waiting for publish-image.yml; stable was not promoted."
+              fi
+              exit 1
+            fi
+
+            if ! run_count=$(jq -er 'arrays | length' <<< "$runs_json"); then
+              echo "::error::GitHub Actions API returned an invalid workflow-runs response."
+              exit 1
+            fi
+
+            if ((run_count == 0)); then
+              if [[ "$seen_run" == "true" ]]; then
+                echo "::error::The matching publish-image.yml run disappeared from the API response."
+                exit 1
+              fi
+
+              echo "::notice::No publish-image.yml run exists for ${HEAD_SHA}; the push was skipped by its path filters, so stable remains unchanged."
+              echo "ready=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            seen_run=true
+
+            if ! latest_run=$(jq -cer 'max_by([.run_number, .created_at])' <<< "$runs_json"); then
+              echo "::error::Could not select the latest matching publish-image.yml run."
+              exit 1
+            fi
+
+            if ! run_id=$(jq -er '.id' <<< "$latest_run") ||
+              ! run_number=$(jq -er '.run_number' <<< "$latest_run") ||
+              ! status=$(jq -er '.status' <<< "$latest_run") ||
+              ! conclusion=$(jq -r '.conclusion // ""' <<< "$latest_run"); then
+              echo "::error::The latest publish-image.yml run is missing required state fields."
+              exit 1
+            fi
+
+            case "$status" in
+              completed)
+                if [[ "$conclusion" == "success" ]]; then
+                  echo "publish-image.yml run #${run_number} (${run_id}) succeeded."
+                  echo "ready=true" >> "$GITHUB_OUTPUT"
+                  exit 0
+                fi
+
+                echo "::error::publish-image.yml run #${run_number} (${run_id}) concluded '${conclusion:-unknown}'; stable was not promoted."
+                exit 1
+                ;;
+              queued | in_progress | requested | waiting | pending)
+                if [[ -n "$conclusion" ]]; then
+                  echo "::error::publish-image.yml run #${run_number} (${run_id}) has non-terminal status '${status}' with conclusion '${conclusion}'."
+                  exit 1
+                fi
+
+                remaining_seconds=$((deadline - SECONDS))
+                if ((remaining_seconds <= 0)); then
+                  echo "::error::Timed out after ${max_wait_seconds}s waiting for publish-image.yml run #${run_number} (${run_id}); stable was not promoted."
+                  exit 1
+                fi
+
+                sleep_seconds=$poll_interval_seconds
+                if ((sleep_seconds > remaining_seconds)); then
+                  sleep_seconds=$remaining_seconds
+                fi
+                echo "publish-image.yml run #${run_number} (${run_id}) is ${status}; checking again in ${sleep_seconds}s."
+                sleep "$sleep_seconds"
+                ;;
+              *)
+                echo "::error::publish-image.yml run #${run_number} (${run_id}) returned unexpected status '${status}' and conclusion '${conclusion:-none}'."
+                exit 1
+                ;;
+            esac
+          done
+
+      - id: images
+        name: Check immutable images
+        if: steps.publish.outputs.ready == 'true'
+        env:
+          SHORT_SHA: ${{ steps.source.outputs.short_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          expected_digest=""
+          for image in "$IMAGE_NAME" "$ALIAS_IMAGE_NAME"; do
+            source="${image}:main-${SHORT_SHA}"
+            if ! source_digest=$(docker buildx imagetools inspect "$source" --format '{{json .Manifest}}' | jq -er '.digest'); then
+              echo "::error::publish-image.yml succeeded, but immutable image $source does not exist."
+              exit 1
+            fi
+
+            if [[ -n "$expected_digest" && "$source_digest" != "$expected_digest" ]]; then
+              echo "::error::Immutable image names do not resolve to the same digest"
+              exit 1
+            fi
+            expected_digest="$source_digest"
+          done
+
+          echo "available=true" >> "$GITHUB_OUTPUT"
+
+      - name: Promote immutable images
+        if: steps.images.outputs.available == 'true'
+        env:
+          SHORT_SHA: ${{ steps.source.outputs.short_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker buildx imagetools create -t "${IMAGE_NAME}:stable" "${IMAGE_NAME}:main-${SHORT_SHA}"
+          docker buildx imagetools create -t "${ALIAS_IMAGE_NAME}:stable" "${ALIAS_IMAGE_NAME}:main-${SHORT_SHA}"
+
+      - name: Verify stable image digests
+        if: steps.images.outputs.available == 'true'
+        env:
+          SHORT_SHA: ${{ steps.source.outputs.short_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          expected_digest=""
+          for image in "$IMAGE_NAME" "$ALIAS_IMAGE_NAME"; do
+            source="${image}:main-${SHORT_SHA}"
+            stable="${image}:stable"
+            source_digest=$(docker buildx imagetools inspect "$source" --format '{{json .Manifest}}' | jq -er '.digest')
+            stable_digest=$(docker buildx imagetools inspect "$stable" --format '{{json .Manifest}}' | jq -er '.digest')
+
+            if [[ "$stable_digest" != "$source_digest" ]]; then
+              echo "::error::Digest mismatch for $stable: expected $source_digest, got $stable_digest"
+              exit 1
+            fi
+
+            if [[ -n "$expected_digest" && "$stable_digest" != "$expected_digest" ]]; then
+              echo "::error::Stable image names do not resolve to the same digest"
+              exit 1
+            fi
+            expected_digest="$stable_digest"
+          done
+
+          echo "Promoted both stable image names at digest $expected_digest"

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -39,8 +39,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        with:
+          image: docker.io/tonistiigi/binfmt@sha256:1b804311fe87047a4c96d38b4b3ef6f62fca8cd125265917a9e3dc3c996c39e6
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver-opts: image=moby/buildkit@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec
 
       - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -62,12 +66,10 @@ jobs:
 
           {
             echo "tags<<EOF"
-            echo "${IMAGE_NAME}:stable"
             echo "${IMAGE_NAME}:main-${short_sha}"
             if [[ -n "$version" ]]; then
               echo "${IMAGE_NAME}:${version}"
             fi
-            echo "${ALIAS_IMAGE_NAME}:stable"
             echo "${ALIAS_IMAGE_NAME}:main-${short_sha}"
             if [[ -n "$version" ]]; then
               echo "${ALIAS_IMAGE_NAME}:${version}"


### PR DESCRIPTION
`publish-image.yml` writes `:stable` for both image names unconditionally, on
every trigger — any push to main, any `cycling-coach@*` tag push, and any
`workflow_dispatch` from any branch. No CI result is consulted. Railway
deployments auto-pull `:stable`, so anything that can trigger this workflow
ships straight into users' running instances.

## Approach: split build from promotion

The obvious fix — convert `publish-image.yml` to a `workflow_run` trigger —
breaks three things, so this PR does not do that:

- `on.workflow_run` accepts only `workflows`, `types`, and `branches`.
  The `paths-ignore` block that keeps desktop-only pushes from rebuilding would
  be **silently ignored**.
- `version` is derived from `GITHUB_REF_TYPE == 'tag'`. Under `workflow_run`
  that is never true, so the immutable `:<version>` tag and the
  `org.opencontainers.image.version` label would silently stop being produced.
- `workflow_dispatch` is the documented recovery path for the case where a
  `GITHUB_TOKEN`-pushed tag doesn't fire its workflow and the versioned tag is
  missing while `:stable` is fine. Deleting it removes the only remedy.

So instead:

**`publish-image.yml`** keeps every trigger, `paths-ignore`, version derivation
and action pin exactly as-is. The only change is that the two `:stable` lines
are gone. It now produces `:main-<sha>` always and `:<version>` on a tag.

**`promote-stable.yml`** (new) fires on CI completion, and promotes by digest
with `docker buildx imagetools create` — no rebuild, both names land on one
identical digest, and the multi-arch manifest list is preserved. Guarded on all
of: CI concluded `success`, the event was a `push`, `head_branch == 'main'`, and
`head_repository.full_name == github.repository` (blocks forks). Serialized
behind a single global concurrency group, and the resulting `:stable` digests
are verified against the source afterwards.

## The part that needed a second pass

My first version treated "immutable tag missing" as "publish-image was skipped
by `paths-ignore`" and exited 0. That is wrong, because **CI and the image build
run concurrently from the same push.** Measured over the last 7 main pushes:

| | CI | image build |
|---|---|---|
| typical | 12–13 min | 8–9 min |
| slow (arm64 under QEMU) | — | 18–19 min |

CI finished first in 2 of those 7. In that window the promote job would have
found no tag and silently skipped, leaving `:stable` stale while the build went
on to succeed — updates would quietly stop reaching Railway users about a third
of the time, with nothing red anywhere.

The promote job now queries the Actions API for the `publish-image.yml` run at
`head_sha` and distinguishes four states:

- **no run exists** → genuinely skipped by path filters; exit 0, `:stable`
  correctly stays put.
- **queued / in progress** → poll every 25s (up to 35 min, matching the build's
  own `timeout-minutes: 30`), with three retries around transient API failures.
- **concluded `success`** → promote. A missing tag here is now **fatal**, not skipped.
- **any other conclusion, or wait timeout** → fail loudly, so stale `:stable` is visible.

## Also here (S6)

The privileged helper images are pinned by digest — `binfmt` on
`setup-qemu-action`, `moby/buildkit` via `driver-opts` on `setup-buildx-action`.
Both digests were resolved from the live registry. The `@sha` action pins
themselves are unchanged; these are added `with:` blocks.

## Known fragility worth a reviewer's eye

`workflow_run` matches the upstream workflow by **name**, not filename. If
`ci.yml`'s `name: CI` is ever changed, this workflow silently stops firing and
`:stable` stops advancing with no error. `CI` is currently unique across the six
workflows. A rename would need to update this file too.

Promotion needs no QEMU or BuildKit setup — retagging doesn't build.
