### PR TITLE
refactor(desktop): extract shared package inventory and plan helpers

### DIFF
--- a/apps/desktop/scripts/development-package-plan.mjs
+++ b/apps/desktop/scripts/development-package-plan.mjs
@@ -1,6 +1,7 @@
 import { rm } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createPackagePlan } from "./package-plan.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const canonicalDesktopRoot = resolve(scriptDirectory, "..");
@@ -15,29 +16,24 @@ export function createDevelopmentPackagePlan(input = {}) {
   if (!isAbsolute(desktopRoot)) {
     throw new TypeError("desktop root must be absolute");
   }
-  const outputPath = join(desktopRoot, DEVELOPMENT_OUTPUT_DIRECTORY);
-  const applicationPath = join(outputPath, "mac-arm64", `${DEVELOPMENT_PRODUCT_NAME}.app`);
-  return Object.freeze({
-    applicationPath,
-    executablePath: join(applicationPath, "Contents", "MacOS", DEVELOPMENT_PRODUCT_NAME),
-    outputPath,
-    builderOptions: {
-      projectDir: desktopRoot,
-      publish: "never",
-      config: {
-        extends: join(desktopRoot, "electron-builder.yml"),
-        appId: DEVELOPMENT_APP_ID,
-        productName: DEVELOPMENT_PRODUCT_NAME,
-        directories: { output: DEVELOPMENT_OUTPUT_DIRECTORY },
-        forceCodeSigning: false,
-        extraMetadata: {
-          name: DEVELOPMENT_PACKAGE_NAME,
-          enduragentDesktopDevelopment: true,
-        },
-        mac: {
-          identity: null,
-          target: [{ target: "dir", arch: ["arm64"] }],
-        },
+  return createPackagePlan({
+    desktopRoot,
+    outputDirectory: DEVELOPMENT_OUTPUT_DIRECTORY,
+    applicationRelativePath: join("mac-arm64", `${DEVELOPMENT_PRODUCT_NAME}.app`),
+    executableRelativePath: join("Contents", "MacOS", DEVELOPMENT_PRODUCT_NAME),
+    builderConfig: {
+      extends: join(desktopRoot, "electron-builder.yml"),
+      appId: DEVELOPMENT_APP_ID,
+      productName: DEVELOPMENT_PRODUCT_NAME,
+      directories: { output: DEVELOPMENT_OUTPUT_DIRECTORY },
+      forceCodeSigning: false,
+      extraMetadata: {
+        name: DEVELOPMENT_PACKAGE_NAME,
+        enduragentDesktopDevelopment: true,
+      },
+      mac: {
+        identity: null,
+        target: [{ target: "dir", arch: ["arm64"] }],
       },
     },
   });

--- a/apps/desktop/scripts/package-inventory.d.mts
+++ b/apps/desktop/scripts/package-inventory.d.mts
@@ -1,0 +1,148 @@
+import type { Stats } from "node:fs";
+
+export { contained } from "./package-plan.mjs";
+
+export interface BuilderAuthority {
+  readonly asarSourceRoot: string;
+  readonly externalSourceRoot: string;
+}
+
+export interface BuilderInventoryAuthorityOptions {
+  readonly validateEnvelopeAuthority?: (
+    configuration: Readonly<Record<string, unknown>>,
+  ) => boolean;
+  readonly hasEnvelopeExtraFiles?: (configuration: Readonly<Record<string, unknown>>) => boolean;
+}
+
+export interface PackageDirectoryEntry {
+  readonly type: "directory";
+}
+
+export interface PackageFileEntry {
+  readonly type: "file";
+  readonly bytes: Buffer;
+}
+
+export type PackageTreeEntry = PackageDirectoryEntry | PackageFileEntry;
+
+export interface AsarDirectoryEntry {
+  readonly type: "directory";
+  readonly unpacked: boolean;
+}
+
+export interface AsarFileEntry {
+  readonly type: "file";
+  readonly unpacked: boolean;
+  readonly bytes?: Buffer;
+}
+
+export type AsarTreeEntry = AsarDirectoryEntry | AsarFileEntry;
+
+export interface AsarLabels {
+  readonly archiveLabel: string;
+  readonly entryLabelRoot: string;
+}
+
+export interface UnpackedTreeLabels {
+  readonly root: string;
+  readonly entries: string;
+}
+
+export interface ManifestValidationOptions {
+  readonly development?: boolean;
+  readonly developmentPackageName?: string;
+  readonly release?: {
+    readonly version: string;
+  };
+}
+
+export class PackageLayoutError extends Error {}
+
+export function fail(message: string, path?: string): never;
+
+export function exactObject(value: unknown): value is Record<string, unknown>;
+
+export function safeLstat(path: string, label: string): Promise<Stats>;
+
+export function safeReadFile(path: string, label: string): Promise<Buffer>;
+
+export function safeReadDirectory(path: string, label: string): Promise<string[]>;
+
+export function assertRegularFile(stat: Stats, label: string): void;
+
+export function assertDirectory(stat: Stats, label: string): void;
+
+export function validateRelativePath(path: string, label: string): string;
+
+export function forbiddenPathReason(path: string): string | undefined;
+
+export function inspectPath(path: string, label: string): void;
+
+export function inspectContents(bytes: Buffer, label: string): void;
+
+export function outputChild(
+  desktopRoot: string,
+  outputRoot: string,
+  source: string,
+  label: string,
+): string;
+
+export function readBuilderConfiguration(desktopRoot: string): Promise<unknown>;
+
+export function validateBuilderInventoryAuthority(
+  config: unknown,
+  desktopRoot: string,
+  options?: BuilderInventoryAuthorityOptions,
+): BuilderAuthority;
+
+export function collectTree(
+  root: string,
+  labelRoot: string,
+  scan: boolean,
+): Promise<Map<string, PackageTreeEntry>>;
+
+export function collectAsar(archivePath: string, options: AsarLabels): Map<string, AsarTreeEntry>;
+
+export function validateUnpackedTree(
+  unpackedRoot: string,
+  asar: ReadonlyMap<string, AsarTreeEntry>,
+  present: boolean,
+  labels: UnpackedTreeLabels,
+): Promise<void>;
+
+export function compareStagedTree(
+  expected: ReadonlyMap<string, PackageTreeEntry>,
+  actual: ReadonlyMap<string, PackageTreeEntry>,
+  actualRoot: string,
+): void;
+
+export function compareAsarStaging(
+  expected: ReadonlyMap<string, PackageTreeEntry>,
+  asar: ReadonlyMap<string, AsarTreeEntry>,
+): void;
+
+export function parseManifest(bytes: Buffer, label: string): Record<string, unknown>;
+
+export function validateManifest(
+  asar: ReadonlyMap<string, AsarTreeEntry>,
+  sourceBytes: Buffer,
+  options?: ManifestValidationOptions,
+): void;
+
+export function validateRequiredAsarFiles(
+  asar: ReadonlyMap<string, AsarTreeEntry>,
+  sourceManifest: Buffer,
+  options?: ManifestValidationOptions,
+): void;
+
+export function assertNoReservedResourceNames(
+  tree: ReadonlyMap<string, PackageTreeEntry>,
+  reservedNames: ReadonlySet<string>,
+  label: string,
+): Set<string>;
+
+export function assertExactResourceNames(
+  names: readonly string[],
+  expected: ReadonlySet<string>,
+  label: string,
+): void;

--- a/apps/desktop/scripts/package-inventory.mjs
+++ b/apps/desktop/scripts/package-inventory.mjs
@@ -1,0 +1,655 @@
+import { createHash } from "node:crypto";
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { isAbsolute, join, resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { extractFile, listPackage, statFile, uncache } from "@electron/asar";
+import { parse } from "yaml";
+import { contained } from "./package-plan.mjs";
+
+export { contained } from "./package-plan.mjs";
+
+const requiredAsarFiles = [
+  "out/main/index.js",
+  "out/main/daemon-utility.js",
+  "out/preload/index.cjs",
+  "out/preload/tray.cjs",
+  "out/renderer/index.html",
+  "out/renderer/tray.html",
+  "package.json",
+  "resources/self-test/matrix.json",
+  "resources/self-test/matrix.sha256",
+];
+const telegramRuntimeRoots = ["grammy", "@grammyjs/auto-retry"];
+const requiredFilePatterns = [
+  "out/**",
+  "package.json",
+  "!**/*.map",
+  "!**/.env*",
+  "!**/{test,tests,__tests__,fixture,fixtures,dev-fixture,dev-fixtures}/**",
+  "!**/*.{test,spec}.{js,cjs,mjs,ts,cts,mts,jsx,tsx}",
+  "!**/vitest.config.{js,cjs,mjs,ts,cts,mts}",
+  "!**/vitest.workspace.{js,cjs,mjs,ts,cts,mts}",
+  "!**/node_modules/vitest/**",
+  "!**/node_modules/@vitest/**",
+  "!**/node_modules/@anthropic-ai/claude-agent-sdk-*",
+  "!**/node_modules/@anthropic-ai/claude-agent-sdk-*/**",
+];
+const vendoredAgentCliPatterns = [
+  /(?:^|\/)@anthropic-ai\/claude-agent-sdk-[a-z0-9-]+(?:\/|$)/u,
+  /(?:^|\/)@anthropic-ai\/claude-agent-sdk\/(?:.*\/)?(?:vendor\/|claude$|cli\.js$)/u,
+];
+const forbiddenDirectoryNames = new Set([
+  "test",
+  "tests",
+  "__tests__",
+  "__snapshots__",
+  "fixture",
+  "fixtures",
+  "dev-fixture",
+  "dev-fixtures",
+  "vitest",
+  "@vitest",
+]);
+const knownSecretMarkers = [
+  "desktop-sentinel-model-key",
+  "private-token-marker",
+  "sentinel-anthropic-api-key",
+  "sentinel-openai-api-key",
+  "sentinel-google-generative-ai-api-key",
+  "sentinel-deepseek-api-key",
+  "sentinel-alibaba-api-key",
+  "sentinel-minimax-api-key",
+  "sentinel-moonshot-api-key",
+  "sentinel-zai-api-key",
+  "sentinel-openrouter-api-key",
+  "sentinel-llm-api-key",
+  "sentinel-intervals-api-key",
+  "sentinel-telegram-bot-token",
+  "sentinel-my-llm-key",
+  "synthetic-secret",
+];
+const acceptanceOnlyMarkers = [
+  "enduragent_acceptance_telegram_bot_api_origin",
+  "enduragent_acceptance_os_login_launch",
+  "enduragent-desktop-telegram-acceptance",
+  "enduragentdesktoptelegramacceptance",
+];
+const removedMainManifestKeys = new Set([
+  "dist",
+  "gitHead",
+  "build",
+  "jspm",
+  "ava",
+  "xo",
+  "nyc",
+  "eslintConfig",
+  "contributors",
+  "bundleDependencies",
+  "tags",
+  "scripts",
+  "keywords",
+  "devDependencies",
+]);
+
+export class PackageLayoutError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PackageLayoutError";
+  }
+}
+
+function displayPath(path) {
+  const printable = Array.from(String(path).replaceAll("\\", "/"), (character) => {
+    const code = character.codePointAt(0);
+    return code !== undefined && (code < 32 || code === 127) ? "?" : character;
+  }).join("");
+  const normalized = printable.replace(/^\/+/u, "");
+  if (normalized.length <= 180) return normalized;
+  return `${normalized.slice(0, 177)}...`;
+}
+
+export function fail(message, path) {
+  const suffix = path === undefined ? "" : `: ${displayPath(path)}`;
+  throw new PackageLayoutError(`${message}${suffix}`);
+}
+
+export function exactObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function nested(left, right) {
+  return left !== right && contained(left, right);
+}
+
+export async function safeLstat(path, label) {
+  try {
+    return await lstat(path);
+  } catch {
+    fail("missing or unreadable package entry", label);
+  }
+}
+
+export async function safeReadFile(path, label) {
+  try {
+    return await readFile(path);
+  } catch {
+    fail("missing or unreadable package file", label);
+  }
+}
+
+export async function safeReadDirectory(path, label) {
+  try {
+    return await readdir(path);
+  } catch {
+    fail("missing or unreadable package directory", label);
+  }
+}
+
+export function assertRegularFile(stat, label) {
+  if (stat.isSymbolicLink()) fail("symbolic links are forbidden", label);
+  if (!stat.isFile()) fail("expected a regular file", label);
+}
+
+export function assertDirectory(stat, label) {
+  if (stat.isSymbolicLink()) fail("symbolic links are forbidden", label);
+  if (!stat.isDirectory()) fail("expected a directory", label);
+}
+
+export function validateRelativePath(path, label) {
+  const normalized = path.replaceAll("\\", "/").replace(/^\/+/u, "");
+  const segments = normalized.split("/");
+  if (
+    normalized.length === 0 ||
+    normalized.includes("\u0000") ||
+    segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")
+  ) {
+    fail("invalid relative package path", label);
+  }
+  return normalized;
+}
+
+export function forbiddenPathReason(path) {
+  const lower = path.toLowerCase();
+  const segments = lower.split("/");
+  const base = segments.at(-1) ?? "";
+  if (vendoredAgentCliPatterns.some((pattern) => pattern.test(lower))) return "vendored agent CLI";
+  if (base.endsWith(".map")) return "source map";
+  if (base.startsWith(".env")) return "environment file";
+  if (segments.some((segment) => forbiddenDirectoryNames.has(segment))) {
+    return "test or fixture directory";
+  }
+  if (base.endsWith(".snap")) return "test snapshot artifact";
+  if (/(?:^|\.)(?:test|spec)\.(?:d\.)?[a-z0-9]+$/u.test(base)) return "test or spec source";
+  if (/^vitest\.(?:config|workspace)\./u.test(base)) return "Vitest configuration";
+  return undefined;
+}
+
+export function inspectPath(path, label) {
+  const reason = forbiddenPathReason(path);
+  if (reason !== undefined) fail(`forbidden ${reason}`, label);
+}
+
+export function inspectContents(bytes, label) {
+  const text = bytes.toString("latin1").toLowerCase();
+  if (acceptanceOnlyMarkers.some((marker) => text.includes(marker))) {
+    fail("acceptance-only package marker", label);
+  }
+  if (
+    knownSecretMarkers.some((marker) => text.includes(marker)) ||
+    /obviously-fake-[a-z0-9-]{1,96}key\b/u.test(text) ||
+    /(?:^|[^a-z0-9])sk-secret(?:[^a-z0-9]|$)/u.test(text)
+  ) {
+    fail("known plaintext secret marker", label);
+  }
+}
+
+function fileSet(value) {
+  if (!exactObject(value) || typeof value.from !== "string" || typeof value.to !== "string") {
+    fail("invalid builder FileSet");
+  }
+  return value;
+}
+
+export function outputChild(desktopRoot, outputRoot, source, label) {
+  if (isAbsolute(source)) fail("builder source must be relative", label);
+  const resolved = resolve(desktopRoot, source);
+  if (resolved === outputRoot || !contained(outputRoot, resolved)) {
+    fail("builder source must be inside its output directory", label);
+  }
+  return resolved;
+}
+
+export async function readBuilderConfiguration(desktopRoot) {
+  if (!isAbsolute(desktopRoot)) fail("desktop root must be absolute");
+  const bytes = await safeReadFile(
+    join(desktopRoot, "electron-builder.yml"),
+    "electron-builder.yml",
+  );
+  try {
+    return parse(bytes.toString("utf8"));
+  } catch {
+    fail("invalid builder configuration", "electron-builder.yml");
+  }
+}
+
+export function validateBuilderInventoryAuthority(config, desktopRoot, options = {}) {
+  const validateEnvelopeAuthority = options.validateEnvelopeAuthority ?? (() => true);
+  const hasEnvelopeExtraFiles = options.hasEnvelopeExtraFiles ?? (() => false);
+  if (
+    !exactObject(config) ||
+    config.asar !== true ||
+    !Array.isArray(config.electronLanguages) ||
+    config.electronLanguages.length !== 1 ||
+    config.electronLanguages[0] !== "en" ||
+    !exactObject(config.directories) ||
+    config.directories.output !== "dist" ||
+    !Array.isArray(config.files) ||
+    !Array.isArray(config.extraResources) ||
+    validateEnvelopeAuthority(config) !== true
+  ) {
+    fail("invalid builder packaging authority", "electron-builder.yml");
+  }
+  if (config.extraFiles !== undefined || hasEnvelopeExtraFiles(config)) {
+    fail("alternate builder copy surfaces are forbidden", "electron-builder.yml");
+  }
+
+  const patternEntries = config.files.filter((entry) => typeof entry === "string");
+  if (
+    patternEntries.length !== requiredFilePatterns.length ||
+    new Set(patternEntries).size !== patternEntries.length ||
+    requiredFilePatterns.some((pattern) => !patternEntries.includes(pattern))
+  ) {
+    fail("builder file exclusions are incomplete", "electron-builder.yml");
+  }
+
+  const configuredFileSets = config.files.filter((entry) => typeof entry !== "string").map(fileSet);
+  const resourceSets = configuredFileSets.filter(
+    (entry) => entry.from === "resources" && entry.to === "resources",
+  );
+  if (
+    resourceSets.length !== 1 ||
+    !Array.isArray(resourceSets[0].filter) ||
+    resourceSets[0].filter.length !== 2 ||
+    !resourceSets[0].filter.includes("trayTemplate.png") ||
+    !resourceSets[0].filter.includes("trayTemplate@2x.png")
+  ) {
+    fail("builder runtime resources are incomplete", "electron-builder.yml");
+  }
+  const asarSets = configuredFileSets.filter((entry) => entry.to === ".");
+  if (configuredFileSets.length !== 2 || asarSets.length !== 1) {
+    fail("builder ASAR staging authority is ambiguous", "electron-builder.yml");
+  }
+  if (Object.keys(asarSets[0]).some((key) => !["from", "to"].includes(key))) {
+    fail("builder ASAR staging authority is filtered", "electron-builder.yml");
+  }
+  if (config.extraResources.length !== 1) {
+    fail("builder external staging authority is ambiguous", "electron-builder.yml");
+  }
+  const externalSet = fileSet(config.extraResources[0]);
+  if (
+    externalSet.to !== "." ||
+    Object.keys(externalSet).some((key) => !["from", "to"].includes(key))
+  ) {
+    fail("builder external staging authority is filtered", "electron-builder.yml");
+  }
+
+  const outputRoot = resolve(desktopRoot, "dist");
+  const asarSourceRoot = outputChild(
+    desktopRoot,
+    outputRoot,
+    asarSets[0].from,
+    "electron-builder.yml/files",
+  );
+  const externalSourceRoot = outputChild(
+    desktopRoot,
+    outputRoot,
+    externalSet.from,
+    "electron-builder.yml/extraResources",
+  );
+  if (
+    asarSourceRoot === externalSourceRoot ||
+    nested(asarSourceRoot, externalSourceRoot) ||
+    nested(externalSourceRoot, asarSourceRoot)
+  ) {
+    fail("builder staging roots must be disjoint", "electron-builder.yml");
+  }
+  return { asarSourceRoot, externalSourceRoot };
+}
+
+export async function collectTree(root, labelRoot, scan) {
+  const rootStat = await safeLstat(root, labelRoot);
+  assertDirectory(rootStat, labelRoot);
+  const tree = new Map();
+
+  async function visit(directory, relativeRoot) {
+    const names = (await safeReadDirectory(directory, labelRoot)).sort();
+    for (const name of names) {
+      const relativePath = validateRelativePath(
+        relativeRoot.length === 0 ? name : `${relativeRoot}/${name}`,
+        labelRoot,
+      );
+      const label = `${labelRoot}/${relativePath}`;
+      if (scan) inspectPath(relativePath, label);
+      const absolutePath = join(directory, name);
+      const stat = await safeLstat(absolutePath, label);
+      if (stat.isSymbolicLink()) fail("symbolic links are forbidden", label);
+      if (stat.isDirectory()) {
+        tree.set(relativePath, { type: "directory" });
+        await visit(absolutePath, relativePath);
+        continue;
+      }
+      if (!stat.isFile()) fail("unsupported package entry type", label);
+      const bytes = await safeReadFile(absolutePath, label);
+      if (scan) inspectContents(bytes, label);
+      tree.set(relativePath, { type: "file", bytes });
+    }
+  }
+
+  await visit(root, "");
+  return tree;
+}
+
+function safeAsarList(archivePath, archiveLabel) {
+  try {
+    return listPackage(archivePath);
+  } catch {
+    fail("invalid ASAR archive", archiveLabel);
+  }
+}
+
+function safeAsarStat(archivePath, path, entryLabelRoot) {
+  try {
+    return statFile(archivePath, path, false);
+  } catch {
+    fail("invalid ASAR entry", `${entryLabelRoot}/${path}`);
+  }
+}
+
+function safeAsarExtract(archivePath, path, entryLabelRoot) {
+  try {
+    return extractFile(archivePath, path, false);
+  } catch {
+    fail("unreadable ASAR entry", `${entryLabelRoot}/${path}`);
+  }
+}
+
+export function collectAsar(archivePath, options) {
+  uncache(archivePath);
+  const tree = new Map();
+  for (const listedPath of safeAsarList(archivePath, options.archiveLabel)) {
+    const path = validateRelativePath(listedPath, options.archiveLabel);
+    if (tree.has(path)) fail("duplicate ASAR entry", `${options.entryLabelRoot}/${path}`);
+    const label = `${options.entryLabelRoot}/${path}`;
+    inspectPath(path, label);
+    const metadata = safeAsarStat(archivePath, path, options.entryLabelRoot);
+    if ("link" in metadata) fail("symbolic links are forbidden", label);
+    if ("files" in metadata) {
+      tree.set(path, { type: "directory", unpacked: metadata.unpacked === true });
+      continue;
+    }
+    let bytes;
+    if (metadata.unpacked !== true) {
+      bytes = safeAsarExtract(archivePath, path, options.entryLabelRoot);
+      inspectContents(bytes, label);
+    }
+    tree.set(path, { type: "file", unpacked: metadata.unpacked === true, bytes });
+  }
+  return tree;
+}
+
+export async function validateUnpackedTree(unpackedRoot, asar, present, labels) {
+  const expected = new Map();
+  for (const [path, entry] of asar) {
+    if (entry.type !== "file" || entry.unpacked !== true) continue;
+    const segments = path.split("/");
+    for (let index = 1; index < segments.length; index += 1) {
+      expected.set(segments.slice(0, index).join("/"), { type: "directory" });
+    }
+    expected.set(path, { type: "file" });
+  }
+  if (!present) {
+    if (expected.size > 0) {
+      fail("declared unpacked resources are missing", labels.root);
+    }
+    return;
+  }
+  const actual = await collectTree(unpackedRoot, labels.root, true);
+  const expectedPaths = [...expected.keys()].sort();
+  const actualPaths = [...actual.keys()].sort();
+  if (
+    expectedPaths.length !== actualPaths.length ||
+    expectedPaths.some((path, index) => path !== actualPaths[index])
+  ) {
+    fail("undeclared unpacked resource", labels.root);
+  }
+  for (const path of expectedPaths) {
+    if (expected.get(path).type !== actual.get(path).type) {
+      fail("unpacked resource type differs from ASAR", `${labels.entries}/${path}`);
+    }
+  }
+}
+
+export function compareStagedTree(expected, actual, actualRoot) {
+  const expectedPaths = [...expected.keys()].sort();
+  const actualPaths = [...actual.keys()].sort();
+  if (
+    expectedPaths.length !== actualPaths.length ||
+    expectedPaths.some((path, index) => path !== actualPaths[index])
+  ) {
+    fail("packaged external resource tree differs from staging", actualRoot);
+  }
+  for (const path of expectedPaths) {
+    const expectedEntry = expected.get(path);
+    const actualEntry = actual.get(path);
+    if (expectedEntry.type !== actualEntry.type) {
+      fail("packaged external resource type differs from staging", `${actualRoot}/${path}`);
+    }
+    if (expectedEntry.type === "file" && !expectedEntry.bytes.equals(actualEntry.bytes)) {
+      fail("packaged external resource bytes differ from staging", `${actualRoot}/${path}`);
+    }
+  }
+}
+
+export function compareAsarStaging(expected, asar) {
+  for (const [path, expectedEntry] of expected) {
+    const actualEntry = asar.get(path);
+    if (
+      actualEntry === undefined ||
+      actualEntry.type !== expectedEntry.type ||
+      actualEntry.unpacked === true
+    ) {
+      fail("ASAR staging entry is missing or unpacked", `app.asar/${path}`);
+    }
+    if (
+      expectedEntry.type === "file" &&
+      (!Buffer.isBuffer(actualEntry.bytes) || !expectedEntry.bytes.equals(actualEntry.bytes))
+    ) {
+      fail("ASAR staging bytes differ from source", `app.asar/${path}`);
+    }
+  }
+}
+
+export function parseManifest(bytes, label) {
+  let manifest;
+  try {
+    manifest = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    fail("packaged manifest is invalid", label);
+  }
+  if (!exactObject(manifest) || manifest.main !== "out/main/index.js") {
+    fail("packaged manifest has an invalid main entry", label);
+  }
+  return manifest;
+}
+
+function asarRuntimeFile(asar, path) {
+  const entry = asar.get(path);
+  return entry !== undefined && entry.type === "file" && entry.unpacked !== true
+    ? entry
+    : undefined;
+}
+
+function resolveRuntimePackageRoot(asar, importerRoot, packageName) {
+  let directory = importerRoot;
+  while (true) {
+    const candidate =
+      directory.length === 0
+        ? `node_modules/${packageName}`
+        : `${directory}/node_modules/${packageName}`;
+    if (asarRuntimeFile(asar, `${candidate}/package.json`) !== undefined) return candidate;
+    const separator = directory.lastIndexOf("/");
+    if (separator < 0) {
+      if (directory.length === 0) break;
+      directory = "";
+    } else {
+      directory = directory.slice(0, separator);
+    }
+  }
+  fail("Telegram runtime dependency is missing from ASAR", packageName);
+}
+
+function runtimePackageEntry(manifest, packageName) {
+  const candidate = typeof manifest.main === "string" ? manifest.main : undefined;
+  if (candidate === undefined || candidate.length === 0) {
+    fail("Telegram runtime dependency has no main entry", packageName);
+  }
+  const normalized = candidate.replace(/^\.\//u, "");
+  if (
+    normalized.length === 0 ||
+    normalized.startsWith("/") ||
+    normalized.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    fail("Telegram runtime dependency has an invalid main entry", packageName);
+  }
+  return normalized;
+}
+
+function validateTelegramRuntimeClosure(asar) {
+  const coreRoot = "node_modules/@enduragent/core";
+  if (asarRuntimeFile(asar, `${coreRoot}/package.json`) === undefined) {
+    fail("Telegram runtime host is missing from ASAR", "@enduragent/core");
+  }
+  const visited = new Set();
+  const visit = (importerRoot, packageName) => {
+    const packageRoot = resolveRuntimePackageRoot(asar, importerRoot, packageName);
+    if (visited.has(packageRoot)) return;
+    visited.add(packageRoot);
+    const manifestEntry = asarRuntimeFile(asar, `${packageRoot}/package.json`);
+    let manifest;
+    try {
+      manifest = JSON.parse(manifestEntry.bytes.toString("utf8"));
+    } catch {
+      fail("Telegram runtime dependency manifest is invalid", packageName);
+    }
+    if (!exactObject(manifest) || manifest.name !== packageName) {
+      fail("Telegram runtime dependency manifest is invalid", packageName);
+    }
+    const entry = runtimePackageEntry(manifest, packageName);
+    const candidates = [entry, `${entry}.js`, `${entry}/index.js`];
+    if (!candidates.some((path) => asarRuntimeFile(asar, `${packageRoot}/${path}`) !== undefined)) {
+      fail("Telegram runtime dependency entry is missing from ASAR", packageName);
+    }
+    if (manifest.dependencies === undefined) return;
+    if (!exactObject(manifest.dependencies)) {
+      fail("Telegram runtime dependency manifest is invalid", packageName);
+    }
+    for (const dependency of Object.keys(manifest.dependencies)) visit(packageRoot, dependency);
+  };
+  for (const packageName of telegramRuntimeRoots) visit(coreRoot, packageName);
+}
+
+function validateSandboxedPreloads(asar) {
+  for (const path of ["out/preload/index.cjs", "out/preload/tray.cjs"]) {
+    const source = asarRuntimeFile(asar, path).bytes.toString("utf8");
+    if (/\b(?:require|import)\s*\(\s*["']\.\.?\//u.test(source)) {
+      fail("sandboxed preload has a relative runtime dependency", `app.asar/${path}`);
+    }
+  }
+}
+
+export function validateManifest(asar, sourceBytes, options = {}) {
+  const packagedBytes = asar.get("package.json").bytes;
+  const source = parseManifest(sourceBytes, "package.json");
+  const packaged = parseManifest(packagedBytes, "app.asar/package.json");
+  if (Object.hasOwn(source, "enduragentDesktopRelease")) {
+    fail("source manifest contains a release marker", "package.json");
+  }
+  if (Object.hasOwn(source, "enduragentDesktopDevelopment")) {
+    fail("source manifest contains a development marker", "package.json");
+  }
+  const expected = structuredClone(source);
+  if (options.release !== undefined) {
+    expected.version = options.release.version;
+    expected.enduragentDesktopRelease = true;
+  }
+  if (options.development === true) {
+    expected.name = options.developmentPackageName;
+    expected.enduragentDesktopDevelopment = true;
+  }
+  let transformed = options.release !== undefined || options.development === true;
+  for (const key of Object.keys(expected)) {
+    if (key.startsWith("_") || removedMainManifestKeys.has(key)) {
+      delete expected[key];
+      transformed = true;
+    }
+  }
+  if (
+    exactObject(expected.dependencies) &&
+    !Object.keys(expected.dependencies).some((key) => key.startsWith("babel")) &&
+    Object.hasOwn(expected, "babel")
+  ) {
+    delete expected.babel;
+    transformed = true;
+  }
+  const expectedBytes = transformed ? Buffer.from(JSON.stringify(expected, null, 2)) : sourceBytes;
+  if (!expectedBytes.equals(packagedBytes) || !isDeepStrictEqual(packaged, expected)) {
+    if (options.development === true) {
+      fail("development packaged manifest has unexpected drift", "app.asar/package.json");
+    }
+    if (options.release === undefined) {
+      fail("ordinary packaged manifest differs from source", "app.asar/package.json");
+    }
+    fail("release packaged manifest has unexpected drift", "app.asar/package.json");
+  }
+}
+
+export function validateRequiredAsarFiles(asar, sourceManifest, options = {}) {
+  for (const path of requiredAsarFiles) {
+    const entry = asar.get(path);
+    if (entry === undefined || entry.type !== "file" || entry.unpacked === true) {
+      fail("required runtime file is missing from ASAR", `app.asar/${path}`);
+    }
+  }
+  for (const path of asar.keys()) {
+    if (path.split("/").at(-1) === "self-test-runner.cjs") {
+      fail("self-test runner must remain external", `app.asar/${path}`);
+    }
+  }
+
+  validateManifest(asar, sourceManifest, options);
+  validateTelegramRuntimeClosure(asar);
+  validateSandboxedPreloads(asar);
+
+  const matrix = asar.get("resources/self-test/matrix.json").bytes;
+  const checksum = asar.get("resources/self-test/matrix.sha256").bytes;
+  const expectedChecksum = `${createHash("sha256").update(matrix).digest("hex")}  matrix.json\n`;
+  if (checksum.toString("utf8") !== expectedChecksum) {
+    fail("self-test checksum does not match its matrix", "app.asar/resources/self-test");
+  }
+}
+
+export function assertNoReservedResourceNames(tree, reservedNames, label) {
+  const topLevelNames = new Set([...tree.keys()].map((path) => path.split("/")[0]));
+  for (const name of topLevelNames) {
+    if (reservedNames.has(name)) {
+      fail("external resources collide with reserved package entries", label);
+    }
+  }
+  return topLevelNames;
+}
+
+export function assertExactResourceNames(names, expected, label) {
+  if (names.length !== expected.size || names.some((name) => !expected.has(name))) {
+    fail("undeclared package resource", label);
+  }
+}

--- a/apps/desktop/scripts/package-plan.d.mts
+++ b/apps/desktop/scripts/package-plan.d.mts
@@ -1,0 +1,26 @@
+export interface PackagePlanInput<BuilderConfig> {
+  readonly desktopRoot: string;
+  readonly outputDirectory: string;
+  readonly applicationRelativePath: string;
+  readonly executableRelativePath: string;
+  readonly builderConfig: BuilderConfig;
+}
+
+export interface PackageBuilderOptions<BuilderConfig> {
+  readonly projectDir: string;
+  readonly publish: "never";
+  readonly config: BuilderConfig;
+}
+
+export interface PackagePlan<BuilderConfig> {
+  readonly applicationPath: string;
+  readonly executablePath: string;
+  readonly outputPath: string;
+  readonly builderOptions: PackageBuilderOptions<BuilderConfig>;
+}
+
+export function contained(root: string, path: string): boolean;
+
+export function createPackagePlan<BuilderConfig>(
+  input: PackagePlanInput<BuilderConfig>,
+): PackagePlan<BuilderConfig>;

--- a/apps/desktop/scripts/package-plan.mjs
+++ b/apps/desktop/scripts/package-plan.mjs
@@ -1,0 +1,52 @@
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+export function contained(root, path) {
+  const relation = relative(root, path);
+  return (
+    relation === "" ||
+    (relation !== ".." && !relation.startsWith(`..${sep}`) && !isAbsolute(relation))
+  );
+}
+
+function resolveChild(root, path, relativeMessage, containmentMessage) {
+  if (isAbsolute(path)) throw new TypeError(relativeMessage);
+  const resolved = resolve(root, path);
+  if (relative(root, resolved) === "" || !contained(root, resolved)) {
+    throw new TypeError(containmentMessage);
+  }
+  return resolved;
+}
+
+export function createPackagePlan(input) {
+  if (!isAbsolute(input.desktopRoot)) {
+    throw new TypeError("desktop root must be absolute");
+  }
+  const outputPath = resolveChild(
+    input.desktopRoot,
+    input.outputDirectory,
+    "package output directory must be relative",
+    "package output directory must be inside desktop root",
+  );
+  const applicationPath = resolveChild(
+    outputPath,
+    input.applicationRelativePath,
+    "application path must be relative to package output",
+    "application path must be inside package output",
+  );
+  const executablePath = resolveChild(
+    applicationPath,
+    input.executableRelativePath,
+    "executable path must be relative to application",
+    "executable path must be inside application",
+  );
+  return Object.freeze({
+    applicationPath,
+    executablePath,
+    outputPath,
+    builderOptions: {
+      projectDir: input.desktopRoot,
+      publish: "never",
+      config: input.builderConfig,
+    },
+  });
+}

--- a/apps/desktop/scripts/verify-package-layout.mjs
+++ b/apps/desktop/scripts/verify-package-layout.mjs
@@ -1,10 +1,5 @@
-import { createHash } from "node:crypto";
-import { lstat, readFile, readdir } from "node:fs/promises";
-import { isAbsolute, dirname, join, relative, resolve, sep } from "node:path";
+import { isAbsolute, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { isDeepStrictEqual } from "node:util";
-import { extractFile, listPackage, statFile, uncache } from "@electron/asar";
-import { parse } from "yaml";
 import {
   parseMacosReleaseUpdaterMetadata,
   requireGenericFeedUrl,
@@ -14,42 +9,33 @@ import {
   DEVELOPMENT_PACKAGE_NAME,
   createDevelopmentPackagePlan,
 } from "./development-package-plan.mjs";
+import {
+  PackageLayoutError,
+  assertDirectory,
+  assertExactResourceNames,
+  assertNoReservedResourceNames,
+  assertRegularFile,
+  collectAsar,
+  collectTree,
+  compareAsarStaging,
+  compareStagedTree,
+  exactObject,
+  fail,
+  inspectContents,
+  readBuilderConfiguration,
+  safeLstat,
+  safeReadDirectory,
+  safeReadFile,
+  validateBuilderInventoryAuthority,
+  validateRequiredAsarFiles,
+  validateUnpackedTree,
+} from "./package-inventory.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const canonicalDesktopRoot = resolve(scriptDirectory, "..");
 const canonicalApplication = createDevelopmentPackagePlan({
   desktopRoot: canonicalDesktopRoot,
 }).applicationPath;
-const requiredAsarFiles = [
-  "out/main/index.js",
-  "out/main/daemon-utility.js",
-  "out/preload/index.cjs",
-  "out/preload/tray.cjs",
-  "out/renderer/index.html",
-  "out/renderer/tray.html",
-  "package.json",
-  "resources/self-test/matrix.json",
-  "resources/self-test/matrix.sha256",
-];
-const telegramRuntimeRoots = ["grammy", "@grammyjs/auto-retry"];
-const requiredFilePatterns = [
-  "out/**",
-  "package.json",
-  "!**/*.map",
-  "!**/.env*",
-  "!**/{test,tests,__tests__,fixture,fixtures,dev-fixture,dev-fixtures}/**",
-  "!**/*.{test,spec}.{js,cjs,mjs,ts,cts,mts,jsx,tsx}",
-  "!**/vitest.config.{js,cjs,mjs,ts,cts,mts}",
-  "!**/vitest.workspace.{js,cjs,mjs,ts,cts,mts}",
-  "!**/node_modules/vitest/**",
-  "!**/node_modules/@vitest/**",
-  "!**/node_modules/@anthropic-ai/claude-agent-sdk-*",
-  "!**/node_modules/@anthropic-ai/claude-agent-sdk-*/**",
-];
-const vendoredAgentCliPatterns = [
-  /(?:^|\/)@anthropic-ai\/claude-agent-sdk-[a-z0-9-]+(?:\/|$)/u,
-  /(?:^|\/)@anthropic-ai\/claude-agent-sdk\/(?:.*\/)?(?:vendor\/|claude$|cli\.js$)/u,
-];
 const reservedResourceNames = new Set([
   "app.asar",
   "app.asar.unpacked",
@@ -57,614 +43,14 @@ const reservedResourceNames = new Set([
   "icon.icns",
   "en.lproj",
 ]);
-const forbiddenDirectoryNames = new Set([
-  "test",
-  "tests",
-  "__tests__",
-  "__snapshots__",
-  "fixture",
-  "fixtures",
-  "dev-fixture",
-  "dev-fixtures",
-  "vitest",
-  "@vitest",
-]);
-const knownSecretMarkers = [
-  "desktop-sentinel-model-key",
-  "private-token-marker",
-  "sentinel-anthropic-api-key",
-  "sentinel-openai-api-key",
-  "sentinel-google-generative-ai-api-key",
-  "sentinel-deepseek-api-key",
-  "sentinel-alibaba-api-key",
-  "sentinel-minimax-api-key",
-  "sentinel-moonshot-api-key",
-  "sentinel-zai-api-key",
-  "sentinel-openrouter-api-key",
-  "sentinel-llm-api-key",
-  "sentinel-intervals-api-key",
-  "sentinel-telegram-bot-token",
-  "sentinel-my-llm-key",
-  "synthetic-secret",
-];
-const acceptanceOnlyMarkers = [
-  "enduragent_acceptance_telegram_bot_api_origin",
-  "enduragent_acceptance_os_login_launch",
-  "enduragent-desktop-telegram-acceptance",
-  "enduragentdesktoptelegramacceptance",
-];
-const removedMainManifestKeys = new Set([
-  "dist",
-  "gitHead",
-  "build",
-  "jspm",
-  "ava",
-  "xo",
-  "nyc",
-  "eslintConfig",
-  "contributors",
-  "bundleDependencies",
-  "tags",
-  "scripts",
-  "keywords",
-  "devDependencies",
-]);
-
-class PackageLayoutError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = "PackageLayoutError";
-  }
-}
-
-function fail(message, path) {
-  const suffix = path === undefined ? "" : `: ${displayPath(path)}`;
-  throw new PackageLayoutError(`${message}${suffix}`);
-}
-
-function displayPath(path) {
-  const printable = Array.from(String(path).replaceAll("\\", "/"), (character) => {
-    const code = character.codePointAt(0);
-    return code !== undefined && (code < 32 || code === 127) ? "?" : character;
-  }).join("");
-  const normalized = printable.replace(/^\/+/u, "");
-  if (normalized.length <= 180) return normalized;
-  return `${normalized.slice(0, 177)}...`;
-}
-
-function exactObject(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function contained(root, path) {
-  const relation = relative(root, path);
-  return (
-    relation === "" ||
-    (relation !== ".." && !relation.startsWith(`..${sep}`) && !isAbsolute(relation))
-  );
-}
-
-function nested(left, right) {
-  return left !== right && contained(left, right);
-}
-
-async function safeLstat(path, label) {
-  try {
-    return await lstat(path);
-  } catch {
-    fail("missing or unreadable package entry", label);
-  }
-}
-
-async function safeReadFile(path, label) {
-  try {
-    return await readFile(path);
-  } catch {
-    fail("missing or unreadable package file", label);
-  }
-}
-
-async function safeReadDirectory(path, label) {
-  try {
-    return await readdir(path);
-  } catch {
-    fail("missing or unreadable package directory", label);
-  }
-}
-
-function assertRegularFile(stat, label) {
-  if (stat.isSymbolicLink()) fail("symbolic links are forbidden", label);
-  if (!stat.isFile()) fail("expected a regular file", label);
-}
-
-function assertDirectory(stat, label) {
-  if (stat.isSymbolicLink()) fail("symbolic links are forbidden", label);
-  if (!stat.isDirectory()) fail("expected a directory", label);
-}
-
-function validateRelativePath(path, label) {
-  const normalized = path.replaceAll("\\", "/").replace(/^\/+/u, "");
-  const segments = normalized.split("/");
-  if (
-    normalized.length === 0 ||
-    normalized.includes("\u0000") ||
-    segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")
-  ) {
-    fail("invalid relative package path", label);
-  }
-  return normalized;
-}
-
-function forbiddenPathReason(path) {
-  const lower = path.toLowerCase();
-  const segments = lower.split("/");
-  const base = segments.at(-1) ?? "";
-  if (vendoredAgentCliPatterns.some((pattern) => pattern.test(lower))) return "vendored agent CLI";
-  if (base.endsWith(".map")) return "source map";
-  if (base.startsWith(".env")) return "environment file";
-  if (segments.some((segment) => forbiddenDirectoryNames.has(segment))) {
-    return "test or fixture directory";
-  }
-  if (base.endsWith(".snap")) return "test snapshot artifact";
-  if (/(?:^|\.)(?:test|spec)\.(?:d\.)?[a-z0-9]+$/u.test(base)) return "test or spec source";
-  if (/^vitest\.(?:config|workspace)\./u.test(base)) return "Vitest configuration";
-  return undefined;
-}
-
-function inspectPath(path, label) {
-  const reason = forbiddenPathReason(path);
-  if (reason !== undefined) fail(`forbidden ${reason}`, label);
-}
-
-function inspectContents(bytes, label) {
-  const text = bytes.toString("latin1").toLowerCase();
-  if (acceptanceOnlyMarkers.some((marker) => text.includes(marker))) {
-    fail("acceptance-only package marker", label);
-  }
-  if (
-    knownSecretMarkers.some((marker) => text.includes(marker)) ||
-    /obviously-fake-[a-z0-9-]{1,96}key\b/u.test(text) ||
-    /(?:^|[^a-z0-9])sk-secret(?:[^a-z0-9]|$)/u.test(text)
-  ) {
-    fail("known plaintext secret marker", label);
-  }
-}
-
-function fileSet(value) {
-  if (!exactObject(value) || typeof value.from !== "string" || typeof value.to !== "string") {
-    fail("invalid builder FileSet");
-  }
-  return value;
-}
-
-function outputChild(desktopRoot, outputRoot, source, label) {
-  if (isAbsolute(source)) fail("builder source must be relative", label);
-  const resolved = resolve(desktopRoot, source);
-  if (resolved === outputRoot || !contained(outputRoot, resolved)) {
-    fail("builder source must be inside its output directory", label);
-  }
-  return resolved;
-}
 
 export async function readBuilderAuthority(desktopRoot = canonicalDesktopRoot) {
-  if (!isAbsolute(desktopRoot)) fail("desktop root must be absolute");
-  const configPath = join(desktopRoot, "electron-builder.yml");
-  const bytes = await safeReadFile(configPath, "electron-builder.yml");
-  let config;
-  try {
-    config = parse(bytes.toString("utf8"));
-  } catch {
-    fail("invalid builder configuration", "electron-builder.yml");
-  }
-  if (
-    !exactObject(config) ||
-    config.asar !== true ||
-    !Array.isArray(config.electronLanguages) ||
-    config.electronLanguages.length !== 1 ||
-    config.electronLanguages[0] !== "en" ||
-    !exactObject(config.directories) ||
-    config.directories.output !== "dist" ||
-    !Array.isArray(config.files) ||
-    !Array.isArray(config.extraResources) ||
-    !exactObject(config.mac) ||
-    config.mac.icon !== "resources/app-icon.png"
-  ) {
-    fail("invalid builder packaging authority", "electron-builder.yml");
-  }
-  if (
-    config.extraFiles !== undefined ||
-    (exactObject(config.mac) && config.mac.extraFiles !== undefined)
-  ) {
-    fail("alternate builder copy surfaces are forbidden", "electron-builder.yml");
-  }
-
-  const patternEntries = config.files.filter((entry) => typeof entry === "string");
-  if (
-    patternEntries.length !== requiredFilePatterns.length ||
-    new Set(patternEntries).size !== patternEntries.length ||
-    requiredFilePatterns.some((pattern) => !patternEntries.includes(pattern))
-  ) {
-    fail("builder file exclusions are incomplete", "electron-builder.yml");
-  }
-
-  const configuredFileSets = config.files.filter((entry) => typeof entry !== "string").map(fileSet);
-  const resourceSets = configuredFileSets.filter(
-    (entry) => entry.from === "resources" && entry.to === "resources",
-  );
-  if (
-    resourceSets.length !== 1 ||
-    !Array.isArray(resourceSets[0].filter) ||
-    resourceSets[0].filter.length !== 2 ||
-    !resourceSets[0].filter.includes("trayTemplate.png") ||
-    !resourceSets[0].filter.includes("trayTemplate@2x.png")
-  ) {
-    fail("builder runtime resources are incomplete", "electron-builder.yml");
-  }
-  const asarSets = configuredFileSets.filter((entry) => entry.to === ".");
-  if (configuredFileSets.length !== 2 || asarSets.length !== 1) {
-    fail("builder ASAR staging authority is ambiguous", "electron-builder.yml");
-  }
-  if (Object.keys(asarSets[0]).some((key) => !["from", "to"].includes(key))) {
-    fail("builder ASAR staging authority is filtered", "electron-builder.yml");
-  }
-  if (config.extraResources.length !== 1) {
-    fail("builder external staging authority is ambiguous", "electron-builder.yml");
-  }
-  const externalSet = fileSet(config.extraResources[0]);
-  if (
-    externalSet.to !== "." ||
-    Object.keys(externalSet).some((key) => !["from", "to"].includes(key))
-  ) {
-    fail("builder external staging authority is filtered", "electron-builder.yml");
-  }
-
-  const outputRoot = resolve(desktopRoot, "dist");
-  const asarSourceRoot = outputChild(
-    desktopRoot,
-    outputRoot,
-    asarSets[0].from,
-    "electron-builder.yml/files",
-  );
-  const externalSourceRoot = outputChild(
-    desktopRoot,
-    outputRoot,
-    externalSet.from,
-    "electron-builder.yml/extraResources",
-  );
-  if (
-    asarSourceRoot === externalSourceRoot ||
-    nested(asarSourceRoot, externalSourceRoot) ||
-    nested(externalSourceRoot, asarSourceRoot)
-  ) {
-    fail("builder staging roots must be disjoint", "electron-builder.yml");
-  }
-  return { asarSourceRoot, externalSourceRoot };
-}
-
-async function collectTree(root, labelRoot, scan) {
-  const rootStat = await safeLstat(root, labelRoot);
-  assertDirectory(rootStat, labelRoot);
-  const tree = new Map();
-
-  async function visit(directory, relativeRoot) {
-    const names = (await safeReadDirectory(directory, labelRoot)).sort();
-    for (const name of names) {
-      const relativePath = validateRelativePath(
-        relativeRoot.length === 0 ? name : `${relativeRoot}/${name}`,
-        labelRoot,
-      );
-      const label = `${labelRoot}/${relativePath}`;
-      if (scan) inspectPath(relativePath, label);
-      const absolutePath = join(directory, name);
-      const stat = await safeLstat(absolutePath, label);
-      if (stat.isSymbolicLink()) fail("symbolic links are forbidden", label);
-      if (stat.isDirectory()) {
-        tree.set(relativePath, { type: "directory" });
-        await visit(absolutePath, relativePath);
-        continue;
-      }
-      if (!stat.isFile()) fail("unsupported package entry type", label);
-      const bytes = await safeReadFile(absolutePath, label);
-      if (scan) inspectContents(bytes, label);
-      tree.set(relativePath, { type: "file", bytes });
-    }
-  }
-
-  await visit(root, "");
-  return tree;
-}
-
-function safeAsarList(archivePath) {
-  try {
-    return listPackage(archivePath);
-  } catch {
-    fail("invalid ASAR archive", "Contents/Resources/app.asar");
-  }
-}
-
-function safeAsarStat(archivePath, path) {
-  try {
-    return statFile(archivePath, path, false);
-  } catch {
-    fail("invalid ASAR entry", `app.asar/${path}`);
-  }
-}
-
-function safeAsarExtract(archivePath, path) {
-  try {
-    return extractFile(archivePath, path, false);
-  } catch {
-    fail("unreadable ASAR entry", `app.asar/${path}`);
-  }
-}
-
-function collectAsar(archivePath) {
-  uncache(archivePath);
-  const tree = new Map();
-  for (const listedPath of safeAsarList(archivePath)) {
-    const path = validateRelativePath(listedPath, "Contents/Resources/app.asar");
-    if (tree.has(path)) fail("duplicate ASAR entry", `app.asar/${path}`);
-    const label = `app.asar/${path}`;
-    inspectPath(path, label);
-    const metadata = safeAsarStat(archivePath, path);
-    if ("link" in metadata) fail("symbolic links are forbidden", label);
-    if ("files" in metadata) {
-      tree.set(path, { type: "directory", unpacked: metadata.unpacked === true });
-      continue;
-    }
-    let bytes;
-    if (metadata.unpacked !== true) {
-      bytes = safeAsarExtract(archivePath, path);
-      inspectContents(bytes, label);
-    }
-    tree.set(path, { type: "file", unpacked: metadata.unpacked === true, bytes });
-  }
-  return tree;
-}
-
-async function validateUnpackedTree(resourcesRoot, asar, present) {
-  const expected = new Map();
-  for (const [path, entry] of asar) {
-    if (entry.type !== "file" || entry.unpacked !== true) continue;
-    const segments = path.split("/");
-    for (let index = 1; index < segments.length; index += 1) {
-      expected.set(segments.slice(0, index).join("/"), { type: "directory" });
-    }
-    expected.set(path, { type: "file" });
-  }
-  if (!present) {
-    if (expected.size > 0) {
-      fail("declared unpacked resources are missing", "Contents/Resources/app.asar.unpacked");
-    }
-    return;
-  }
-  const actual = await collectTree(
-    join(resourcesRoot, "app.asar.unpacked"),
-    "Contents/Resources/app.asar.unpacked",
-    true,
-  );
-  const expectedPaths = [...expected.keys()].sort();
-  const actualPaths = [...actual.keys()].sort();
-  if (
-    expectedPaths.length !== actualPaths.length ||
-    expectedPaths.some((path, index) => path !== actualPaths[index])
-  ) {
-    fail("undeclared unpacked resource", "Contents/Resources/app.asar.unpacked");
-  }
-  for (const path of expectedPaths) {
-    if (expected.get(path).type !== actual.get(path).type) {
-      fail("unpacked resource type differs from ASAR", `app.asar.unpacked/${path}`);
-    }
-  }
-}
-
-function compareStagedTree(expected, actual, actualRoot) {
-  const expectedPaths = [...expected.keys()].sort();
-  const actualPaths = [...actual.keys()].sort();
-  if (
-    expectedPaths.length !== actualPaths.length ||
-    expectedPaths.some((path, index) => path !== actualPaths[index])
-  ) {
-    fail("packaged external resource tree differs from staging", actualRoot);
-  }
-  for (const path of expectedPaths) {
-    const expectedEntry = expected.get(path);
-    const actualEntry = actual.get(path);
-    if (expectedEntry.type !== actualEntry.type) {
-      fail("packaged external resource type differs from staging", `${actualRoot}/${path}`);
-    }
-    if (expectedEntry.type === "file" && !expectedEntry.bytes.equals(actualEntry.bytes)) {
-      fail("packaged external resource bytes differ from staging", `${actualRoot}/${path}`);
-    }
-  }
-}
-
-function compareAsarStaging(expected, asar) {
-  for (const [path, expectedEntry] of expected) {
-    const actualEntry = asar.get(path);
-    if (
-      actualEntry === undefined ||
-      actualEntry.type !== expectedEntry.type ||
-      actualEntry.unpacked === true
-    ) {
-      fail("ASAR staging entry is missing or unpacked", `app.asar/${path}`);
-    }
-    if (
-      expectedEntry.type === "file" &&
-      (!Buffer.isBuffer(actualEntry.bytes) || !expectedEntry.bytes.equals(actualEntry.bytes))
-    ) {
-      fail("ASAR staging bytes differ from source", `app.asar/${path}`);
-    }
-  }
-}
-
-function parseManifest(bytes, label) {
-  let manifest;
-  try {
-    manifest = JSON.parse(bytes.toString("utf8"));
-  } catch {
-    fail("packaged manifest is invalid", label);
-  }
-  if (!exactObject(manifest) || manifest.main !== "out/main/index.js") {
-    fail("packaged manifest has an invalid main entry", label);
-  }
-  return manifest;
-}
-
-function asarRuntimeFile(asar, path) {
-  const entry = asar.get(path);
-  return entry !== undefined && entry.type === "file" && entry.unpacked !== true
-    ? entry
-    : undefined;
-}
-
-function resolveRuntimePackageRoot(asar, importerRoot, packageName) {
-  let directory = importerRoot;
-  while (true) {
-    const candidate =
-      directory.length === 0
-        ? `node_modules/${packageName}`
-        : `${directory}/node_modules/${packageName}`;
-    if (asarRuntimeFile(asar, `${candidate}/package.json`) !== undefined) return candidate;
-    const separator = directory.lastIndexOf("/");
-    if (separator < 0) {
-      if (directory.length === 0) break;
-      directory = "";
-    } else {
-      directory = directory.slice(0, separator);
-    }
-  }
-  fail("Telegram runtime dependency is missing from ASAR", packageName);
-}
-
-function runtimePackageEntry(manifest, packageName) {
-  const candidate = typeof manifest.main === "string" ? manifest.main : undefined;
-  if (candidate === undefined || candidate.length === 0) {
-    fail("Telegram runtime dependency has no main entry", packageName);
-  }
-  const normalized = candidate.replace(/^\.\//u, "");
-  if (
-    normalized.length === 0 ||
-    normalized.startsWith("/") ||
-    normalized.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
-  ) {
-    fail("Telegram runtime dependency has an invalid main entry", packageName);
-  }
-  return normalized;
-}
-
-function validateTelegramRuntimeClosure(asar) {
-  const coreRoot = "node_modules/@enduragent/core";
-  if (asarRuntimeFile(asar, `${coreRoot}/package.json`) === undefined) {
-    fail("Telegram runtime host is missing from ASAR", "@enduragent/core");
-  }
-  const visited = new Set();
-  const visit = (importerRoot, packageName) => {
-    const packageRoot = resolveRuntimePackageRoot(asar, importerRoot, packageName);
-    if (visited.has(packageRoot)) return;
-    visited.add(packageRoot);
-    const manifestEntry = asarRuntimeFile(asar, `${packageRoot}/package.json`);
-    let manifest;
-    try {
-      manifest = JSON.parse(manifestEntry.bytes.toString("utf8"));
-    } catch {
-      fail("Telegram runtime dependency manifest is invalid", packageName);
-    }
-    if (!exactObject(manifest) || manifest.name !== packageName) {
-      fail("Telegram runtime dependency manifest is invalid", packageName);
-    }
-    const entry = runtimePackageEntry(manifest, packageName);
-    const candidates = [entry, `${entry}.js`, `${entry}/index.js`];
-    if (!candidates.some((path) => asarRuntimeFile(asar, `${packageRoot}/${path}`) !== undefined)) {
-      fail("Telegram runtime dependency entry is missing from ASAR", packageName);
-    }
-    if (manifest.dependencies === undefined) return;
-    if (!exactObject(manifest.dependencies)) {
-      fail("Telegram runtime dependency manifest is invalid", packageName);
-    }
-    for (const dependency of Object.keys(manifest.dependencies)) visit(packageRoot, dependency);
-  };
-  for (const packageName of telegramRuntimeRoots) visit(coreRoot, packageName);
-}
-
-function validateSandboxedPreloads(asar) {
-  for (const path of ["out/preload/index.cjs", "out/preload/tray.cjs"]) {
-    const source = asarRuntimeFile(asar, path).bytes.toString("utf8");
-    if (/\b(?:require|import)\s*\(\s*["']\.\.?\//u.test(source)) {
-      fail("sandboxed preload has a relative runtime dependency", `app.asar/${path}`);
-    }
-  }
-}
-
-function validateManifest(asar, sourceBytes, release, development) {
-  const packagedBytes = asar.get("package.json").bytes;
-  const source = parseManifest(sourceBytes, "package.json");
-  const packaged = parseManifest(packagedBytes, "app.asar/package.json");
-  if (Object.hasOwn(source, "enduragentDesktopRelease")) {
-    fail("source manifest contains a release marker", "package.json");
-  }
-  if (Object.hasOwn(source, "enduragentDesktopDevelopment")) {
-    fail("source manifest contains a development marker", "package.json");
-  }
-  const expected = structuredClone(source);
-  if (release !== undefined) {
-    expected.version = release.version;
-    expected.enduragentDesktopRelease = true;
-  }
-  if (development) {
-    expected.name = DEVELOPMENT_PACKAGE_NAME;
-    expected.enduragentDesktopDevelopment = true;
-  }
-  let transformed = release !== undefined || development;
-  for (const key of Object.keys(expected)) {
-    if (key.startsWith("_") || removedMainManifestKeys.has(key)) {
-      delete expected[key];
-      transformed = true;
-    }
-  }
-  if (
-    exactObject(expected.dependencies) &&
-    !Object.keys(expected.dependencies).some((key) => key.startsWith("babel")) &&
-    Object.hasOwn(expected, "babel")
-  ) {
-    delete expected.babel;
-    transformed = true;
-  }
-  const expectedBytes = transformed ? Buffer.from(JSON.stringify(expected, null, 2)) : sourceBytes;
-  if (!expectedBytes.equals(packagedBytes) || !isDeepStrictEqual(packaged, expected)) {
-    if (development) {
-      fail("development packaged manifest has unexpected drift", "app.asar/package.json");
-    }
-    if (release === undefined) {
-      fail("ordinary packaged manifest differs from source", "app.asar/package.json");
-    }
-    fail("release packaged manifest has unexpected drift", "app.asar/package.json");
-  }
-}
-
-function validateRequiredAsarFiles(asar, sourceManifest, release, development) {
-  for (const path of requiredAsarFiles) {
-    const entry = asar.get(path);
-    if (entry === undefined || entry.type !== "file" || entry.unpacked === true) {
-      fail("required runtime file is missing from ASAR", `app.asar/${path}`);
-    }
-  }
-  for (const path of asar.keys()) {
-    if (path.split("/").at(-1) === "self-test-runner.cjs") {
-      fail("self-test runner must remain external", `app.asar/${path}`);
-    }
-  }
-
-  validateManifest(asar, sourceManifest, release, development);
-  validateTelegramRuntimeClosure(asar);
-  validateSandboxedPreloads(asar);
-
-  const matrix = asar.get("resources/self-test/matrix.json").bytes;
-  const checksum = asar.get("resources/self-test/matrix.sha256").bytes;
-  const expectedChecksum = `${createHash("sha256").update(matrix).digest("hex")}  matrix.json\n`;
-  if (checksum.toString("utf8") !== expectedChecksum) {
-    fail("self-test checksum does not match its matrix", "app.asar/resources/self-test");
-  }
+  const config = await readBuilderConfiguration(desktopRoot);
+  return validateBuilderInventoryAuthority(config, desktopRoot, {
+    validateEnvelopeAuthority: (value) =>
+      exactObject(value.mac) && value.mac.icon === "resources/app-icon.png",
+    hasEnvelopeExtraFiles: (value) => exactObject(value.mac) && value.mac.extraFiles !== undefined,
+  });
 }
 
 function validateAppUpdate(bytes, release) {
@@ -681,18 +67,15 @@ function validateAppUpdate(bytes, release) {
 
 async function validateResourceEnvelope(resourcesRoot, externalSource, release) {
   const names = (await safeReadDirectory(resourcesRoot, "Contents/Resources")).sort();
-  const sourceTopLevel = new Set([...externalSource.keys()].map((path) => path.split("/")[0]));
-  for (const name of sourceTopLevel) {
-    if (reservedResourceNames.has(name)) {
-      fail("external resources collide with reserved package entries", "dist/extra-resources");
-    }
-  }
+  const sourceTopLevel = assertNoReservedResourceNames(
+    externalSource,
+    reservedResourceNames,
+    "dist/extra-resources",
+  );
   const expected = new Set(["app.asar", "icon.icns", "en.lproj", ...sourceTopLevel]);
   if (release !== undefined) expected.add("app-update.yml");
   if (names.includes("app.asar.unpacked")) expected.add("app.asar.unpacked");
-  if (names.length !== expected.size || names.some((name) => !expected.has(name))) {
-    fail("undeclared package resource", "Contents/Resources");
-  }
+  assertExactResourceNames(names, expected, "Contents/Resources");
 
   const iconPath = join(resourcesRoot, "icon.icns");
   const iconLabel = "Contents/Resources/icon.icns";
@@ -761,8 +144,15 @@ export async function verifyPackageLayout(application, options = {}) {
     const archivePath = join(resourcesRoot, "app.asar");
     const archiveStat = await safeLstat(archivePath, "Contents/Resources/app.asar");
     assertRegularFile(archiveStat, "Contents/Resources/app.asar");
-    const asar = collectAsar(archivePath);
-    validateRequiredAsarFiles(asar, sourceManifest, release, development);
+    const asar = collectAsar(archivePath, {
+      archiveLabel: "Contents/Resources/app.asar",
+      entryLabelRoot: "app.asar",
+    });
+    validateRequiredAsarFiles(asar, sourceManifest, {
+      release,
+      development,
+      developmentPackageName: DEVELOPMENT_PACKAGE_NAME,
+    });
     compareAsarStaging(asarStaging, asar);
 
     const externalPackaged = new Map();
@@ -789,7 +179,10 @@ export async function verifyPackageLayout(application, options = {}) {
     const unpackedPresent = (await safeReadDirectory(resourcesRoot, "Contents/Resources")).includes(
       "app.asar.unpacked",
     );
-    await validateUnpackedTree(resourcesRoot, asar, unpackedPresent);
+    await validateUnpackedTree(join(resourcesRoot, "app.asar.unpacked"), asar, unpackedPresent, {
+      root: "Contents/Resources/app.asar.unpacked",
+      entries: "app.asar.unpacked",
+    });
   } catch (error) {
     if (error instanceof PackageLayoutError) throw error;
     fail("package layout verification failed");

--- a/apps/desktop/tests/package-contract.test.ts
+++ b/apps/desktop/tests/package-contract.test.ts
@@ -1,0 +1,587 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { finished } from "node:stream/promises";
+import { createPackage, createPackageWithOptions } from "@electron/asar";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertExactResourceNames,
+  assertNoReservedResourceNames,
+  collectAsar,
+  collectTree,
+  compareAsarStaging,
+  compareStagedTree,
+  contained,
+  forbiddenPathReason,
+  inspectContents,
+  inspectPath,
+  outputChild,
+  parseManifest,
+  validateManifest,
+  validateRelativePath,
+  validateUnpackedTree,
+} from "../scripts/package-inventory.mjs";
+import type { AsarTreeEntry, PackageTreeEntry } from "../scripts/package-inventory.mjs";
+import { createPackagePlan } from "../scripts/package-plan.mjs";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "desktop-package-contract-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+async function makeAsar(
+  files: Readonly<Record<string, string | Buffer>>,
+  unpack?: string,
+): Promise<{ archive: string; source: string }> {
+  const root = await temporaryRoot();
+  const source = join(root, "source");
+  const archive = join(root, "runtime.asar");
+  await mkdir(source, { recursive: true });
+  await Promise.all(
+    Object.entries(files).map(async ([path, bytes]) => {
+      const target = join(source, path);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, bytes);
+    }),
+  );
+  const stream =
+    unpack === undefined
+      ? await createPackage(source, archive)
+      : await createPackageWithOptions(source, archive, { unpack });
+  await finished(stream);
+  return { archive, source };
+}
+
+function packageFile(bytes: string): PackageTreeEntry {
+  return { type: "file", bytes: Buffer.from(bytes) };
+}
+
+function asarFile(bytes: string, unpacked = false): AsarTreeEntry {
+  return {
+    type: "file",
+    unpacked,
+    bytes: unpacked ? undefined : Buffer.from(bytes),
+  };
+}
+
+function manifestAsar(bytes: Buffer): Map<string, AsarTreeEntry> {
+  return new Map([["package.json", { type: "file", unpacked: false, bytes }]]);
+}
+
+describe("shared package plan", () => {
+  it("constructs the frozen plan shape while preserving caller-owned configuration", async () => {
+    const desktopRoot = await temporaryRoot();
+    const builderConfig = { identity: "development", nested: { enabled: true } };
+    const plan = createPackagePlan({
+      desktopRoot,
+      outputDirectory: "artifacts/development",
+      applicationRelativePath: "desktop-bundle",
+      executableRelativePath: "bin/launcher",
+      builderConfig,
+    });
+
+    expect(plan).toEqual({
+      applicationPath: join(desktopRoot, "artifacts/development/desktop-bundle"),
+      executablePath: join(desktopRoot, "artifacts/development/desktop-bundle/bin/launcher"),
+      outputPath: join(desktopRoot, "artifacts/development"),
+      builderOptions: {
+        projectDir: desktopRoot,
+        publish: "never",
+        config: builderConfig,
+      },
+    });
+    expect(Object.isFrozen(plan)).toBe(true);
+    expect(Object.isFrozen(plan.builderOptions)).toBe(false);
+    expect(plan.builderOptions.config).toBe(builderConfig);
+  });
+
+  it("rejects relative and escaping plan paths at each boundary", async () => {
+    const desktopRoot = await temporaryRoot();
+    const valid = {
+      desktopRoot,
+      outputDirectory: "artifacts",
+      applicationRelativePath: "bundle",
+      executableRelativePath: "bin/launcher",
+      builderConfig: {},
+    };
+
+    expect(() => createPackagePlan({ ...valid, desktopRoot: "relative" })).toThrow(
+      "desktop root must be absolute",
+    );
+    expect(() =>
+      createPackagePlan({ ...valid, outputDirectory: resolve(desktopRoot, "absolute-output") }),
+    ).toThrow("package output directory must be relative");
+    expect(() => createPackagePlan({ ...valid, outputDirectory: "." })).toThrow(
+      "package output directory must be inside desktop root",
+    );
+    expect(() => createPackagePlan({ ...valid, outputDirectory: "../escape" })).toThrow(
+      "package output directory must be inside desktop root",
+    );
+    expect(() =>
+      createPackagePlan({
+        ...valid,
+        applicationRelativePath: resolve(desktopRoot, "absolute-bundle"),
+      }),
+    ).toThrow("application path must be relative to package output");
+    expect(() => createPackagePlan({ ...valid, applicationRelativePath: "../escape" })).toThrow(
+      "application path must be inside package output",
+    );
+    expect(() =>
+      createPackagePlan({
+        ...valid,
+        executableRelativePath: resolve(desktopRoot, "absolute-launcher"),
+      }),
+    ).toThrow("executable path must be relative to application");
+    expect(() => createPackagePlan({ ...valid, executableRelativePath: "../escape" })).toThrow(
+      "executable path must be inside application",
+    );
+  });
+
+  it("uses lexical containment for staging sources", async () => {
+    const desktopRoot = await temporaryRoot();
+    const outputRoot = resolve(desktopRoot, "artifacts");
+
+    expect(contained(outputRoot, outputRoot)).toBe(true);
+    expect(contained(outputRoot, resolve(outputRoot, "staging"))).toBe(true);
+    expect(contained(outputRoot, resolve(desktopRoot, "artifacts-other"))).toBe(false);
+    expect(outputChild(desktopRoot, outputRoot, "artifacts/staging", "authority")).toBe(
+      resolve(outputRoot, "staging"),
+    );
+    expect(() =>
+      outputChild(desktopRoot, outputRoot, resolve(outputRoot, "staging"), "authority"),
+    ).toThrow("builder source must be relative: authority");
+    expect(() => outputChild(desktopRoot, outputRoot, "artifacts", "authority")).toThrow(
+      "builder source must be inside its output directory: authority",
+    );
+    expect(() => outputChild(desktopRoot, outputRoot, "artifacts-other", "authority")).toThrow(
+      "builder source must be inside its output directory: authority",
+    );
+  });
+});
+
+describe("shared package path and content policy", () => {
+  it("normalizes accepted inventory paths", () => {
+    expect(validateRelativePath("/nested\\entry.js", "inventory")).toBe("nested/entry.js");
+    expect(validateRelativePath("nested/entry.js", "inventory")).toBe("nested/entry.js");
+  });
+
+  it.each(["", "/", "a//b", "a/./b", "a/../b", "a\u0000b"])(
+    "rejects the invalid inventory path %j",
+    (path) => {
+      expect(() => validateRelativePath(path, "inventory")).toThrow(
+        "invalid relative package path: inventory",
+      );
+    },
+  );
+
+  it.each([
+    ["node_modules/@anthropic-ai/claude-agent-sdk-runtime/launcher", "vendored agent CLI"],
+    ["out/runtime.js.map", "source map"],
+    ["out/.ENV.production", "environment file"],
+    ["out/TeStS/runtime.js", "test or fixture directory"],
+    ["out/runtime.spec.d.ts", "test or spec source"],
+    ["out/runtime.snap", "test snapshot artifact"],
+    ["out/vitest.workspace.mts", "Vitest configuration"],
+  ])("classifies the forbidden path %s", (path, reason) => {
+    expect(forbiddenPathReason(path)).toBe(reason);
+    expect(() => inspectPath(path, "inventory-entry")).toThrow(
+      `forbidden ${reason}: inventory-entry`,
+    );
+  });
+
+  it.each([
+    "node_modules/@modelcontextprotocol/sdk/dist/spec.types.js",
+    "out/test.helpers.js",
+    "out/snapshot.js",
+    "out/snapshots/index.js",
+    "node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs",
+  ])("allows the runtime path %s", (path) => {
+    expect(forbiddenPathReason(path)).toBeUndefined();
+    expect(() => inspectPath(path, "inventory-entry")).not.toThrow();
+  });
+
+  it("rejects secret patterns and gives acceptance-only markers precedence", () => {
+    expect(() => inspectContents(Buffer.from("SENTINEL-OPENAI-API-KEY"), "payload")).toThrow(
+      "known plaintext secret marker: payload",
+    );
+    expect(() => inspectContents(Buffer.from("obviously-fake-provider-key"), "payload")).toThrow(
+      "known plaintext secret marker: payload",
+    );
+    expect(() => inspectContents(Buffer.from("prefix sk-SECRET suffix"), "payload")).toThrow(
+      "known plaintext secret marker: payload",
+    );
+    expect(() =>
+      inspectContents(
+        Buffer.from("ENDURAGENT_ACCEPTANCE_OS_LOGIN_LAUNCH sentinel-openai-api-key"),
+        "payload",
+      ),
+    ).toThrow("acceptance-only package marker: payload");
+    expect(() => inspectContents(Buffer.from("ordinary runtime bytes"), "payload")).not.toThrow();
+  });
+});
+
+describe("shared package trees", () => {
+  it("collects deterministic directory and byte entries with optional scanning", async () => {
+    const root = await temporaryRoot();
+    await Promise.all([
+      mkdir(join(root, "a"), { recursive: true }),
+      mkdir(join(root, "z-empty"), { recursive: true }),
+    ]);
+    await writeFile(join(root, "a/private.test.js"), "synthetic-secret");
+
+    const tree = await collectTree(root, "tree", false);
+    expect([...tree.entries()]).toEqual([
+      ["a", { type: "directory" }],
+      ["a/private.test.js", { type: "file", bytes: Buffer.from("synthetic-secret") }],
+      ["z-empty", { type: "directory" }],
+    ]);
+    await expect(collectTree(root, "tree", true)).rejects.toThrow(
+      "forbidden test or spec source: tree/a/private.test.js",
+    );
+  });
+
+  it("scans file contents and rejects symbolic links", async () => {
+    const contentRoot = await temporaryRoot();
+    await writeFile(join(contentRoot, "runtime.bin"), "synthetic-secret");
+    await expect(collectTree(contentRoot, "content-tree", true)).rejects.toThrow(
+      "known plaintext secret marker: content-tree/runtime.bin",
+    );
+
+    const linkRoot = await temporaryRoot();
+    await writeFile(join(linkRoot, "target.bin"), "runtime");
+    await symlink("target.bin", join(linkRoot, "link.bin"));
+    await expect(collectTree(linkRoot, "link-tree", false)).rejects.toThrow(
+      "symbolic links are forbidden: link-tree/link.bin",
+    );
+  });
+
+  it("compares exact staged paths, types, and bytes", () => {
+    const expected = new Map<string, PackageTreeEntry>([
+      ["assets", { type: "directory" }],
+      ["assets/runtime.bin", packageFile("expected")],
+    ]);
+    const exact = new Map<string, PackageTreeEntry>([
+      ["assets", { type: "directory" }],
+      ["assets/runtime.bin", packageFile("expected")],
+    ]);
+    expect(() => compareStagedTree(expected, exact, "packaged-tree")).not.toThrow();
+
+    const unexpected = new Map(exact);
+    unexpected.set("extra.bin", packageFile("extra"));
+    expect(() => compareStagedTree(expected, unexpected, "packaged-tree")).toThrow(
+      "packaged external resource tree differs from staging: packaged-tree",
+    );
+
+    const wrongType = new Map(exact);
+    wrongType.set("assets/runtime.bin", { type: "directory" });
+    expect(() => compareStagedTree(expected, wrongType, "packaged-tree")).toThrow(
+      "packaged external resource type differs from staging: packaged-tree/assets/runtime.bin",
+    );
+
+    const wrongBytes = new Map(exact);
+    wrongBytes.set("assets/runtime.bin", packageFile("different"));
+    expect(() => compareStagedTree(expected, wrongBytes, "packaged-tree")).toThrow(
+      "packaged external resource bytes differ from staging: packaged-tree/assets/runtime.bin",
+    );
+  });
+});
+
+describe("shared ASAR inventory", () => {
+  it("collects packed entries and invalidates the ASAR cache between reads", async () => {
+    const fixture = await makeAsar({ "nested/runtime.bin": "first" });
+    const options = { archiveLabel: "archive", entryLabelRoot: "archive-entry" };
+    const first = collectAsar(fixture.archive, options);
+    expect(first.get("nested")).toEqual({ type: "directory", unpacked: false });
+    expect(first.get("nested/runtime.bin")).toEqual({
+      type: "file",
+      unpacked: false,
+      bytes: Buffer.from("first"),
+    });
+
+    await writeFile(join(fixture.source, "nested/runtime.bin"), "second");
+    await rm(fixture.archive);
+    const stream = await createPackage(fixture.source, fixture.archive);
+    await finished(stream);
+    expect(collectAsar(fixture.archive, options).get("nested/runtime.bin")).toEqual({
+      type: "file",
+      unpacked: false,
+      bytes: Buffer.from("second"),
+    });
+  });
+
+  it("rejects invalid archives and scans ASAR paths and packed contents", async () => {
+    const root = await temporaryRoot();
+    const invalid = join(root, "invalid.asar");
+    await writeFile(invalid, "invalid archive bytes");
+    expect(() =>
+      collectAsar(invalid, { archiveLabel: "archive", entryLabelRoot: "archive-entry" }),
+    ).toThrow("invalid ASAR archive: archive");
+
+    const forbidden = await makeAsar({ "tests/runtime.js": "runtime" });
+    expect(() =>
+      collectAsar(forbidden.archive, {
+        archiveLabel: "archive",
+        entryLabelRoot: "archive-entry",
+      }),
+    ).toThrow("forbidden test or fixture directory: archive-entry/tests");
+
+    const secret = await makeAsar({ "runtime.bin": "synthetic-secret" });
+    expect(() =>
+      collectAsar(secret.archive, {
+        archiveLabel: "archive",
+        entryLabelRoot: "archive-entry",
+      }),
+    ).toThrow("known plaintext secret marker: archive-entry/runtime.bin");
+  });
+
+  it("validates declared unpacked paths and entry types", async () => {
+    const fixture = await makeAsar({ "native/addon.node": "native bytes" }, "**/*.node");
+    const asar = collectAsar(fixture.archive, {
+      archiveLabel: "archive",
+      entryLabelRoot: "archive-entry",
+    });
+    const unpackedRoot = `${fixture.archive}.unpacked`;
+    const labels = { root: "unpacked-tree", entries: "unpacked-entry" };
+
+    expect(asar.get("native/addon.node")).toEqual({
+      type: "file",
+      unpacked: true,
+      bytes: undefined,
+    });
+    await expect(validateUnpackedTree(unpackedRoot, asar, true, labels)).resolves.toBeUndefined();
+    await expect(validateUnpackedTree(unpackedRoot, asar, false, labels)).rejects.toThrow(
+      "declared unpacked resources are missing: unpacked-tree",
+    );
+
+    await writeFile(join(unpackedRoot, "unexpected.bin"), "unexpected");
+    await expect(validateUnpackedTree(unpackedRoot, asar, true, labels)).rejects.toThrow(
+      "undeclared unpacked resource: unpacked-tree",
+    );
+    await rm(join(unpackedRoot, "unexpected.bin"));
+    await rm(join(unpackedRoot, "native/addon.node"));
+    await mkdir(join(unpackedRoot, "native/addon.node"));
+    await expect(validateUnpackedTree(unpackedRoot, asar, true, labels)).rejects.toThrow(
+      "unpacked resource type differs from ASAR: unpacked-entry/native/addon.node",
+    );
+  });
+
+  it("compares staged entries while allowing unrelated archive inventory", () => {
+    const expected = new Map<string, PackageTreeEntry>([
+      ["runtime", { type: "directory" }],
+      ["runtime/data.bin", packageFile("expected")],
+    ]);
+    const exact = new Map<string, AsarTreeEntry>([
+      ["runtime", { type: "directory", unpacked: false }],
+      ["runtime/data.bin", asarFile("expected")],
+      ["unrelated.bin", asarFile("extra")],
+    ]);
+    expect(() => compareAsarStaging(expected, exact)).not.toThrow();
+
+    const missing = new Map(exact);
+    missing.delete("runtime/data.bin");
+    expect(() => compareAsarStaging(expected, missing)).toThrow(
+      "ASAR staging entry is missing or unpacked: app.asar/runtime/data.bin",
+    );
+
+    const unpacked = new Map(exact);
+    unpacked.set("runtime/data.bin", asarFile("expected", true));
+    expect(() => compareAsarStaging(expected, unpacked)).toThrow(
+      "ASAR staging entry is missing or unpacked: app.asar/runtime/data.bin",
+    );
+
+    const stale = new Map(exact);
+    stale.set("runtime/data.bin", asarFile("different"));
+    expect(() => compareAsarStaging(expected, stale)).toThrow(
+      "ASAR staging bytes differ from source: app.asar/runtime/data.bin",
+    );
+  });
+});
+
+describe("shared manifest validation", () => {
+  it("parses only object manifests with the canonical main entry", () => {
+    expect(parseManifest(Buffer.from('{"main":"out/main/index.js"}'), "manifest")).toEqual({
+      main: "out/main/index.js",
+    });
+    expect(() => parseManifest(Buffer.from("{"), "manifest")).toThrow(
+      "packaged manifest is invalid: manifest",
+    );
+    expect(() => parseManifest(Buffer.from("[]"), "manifest")).toThrow(
+      "packaged manifest has an invalid main entry: manifest",
+    );
+    expect(() => parseManifest(Buffer.from('{"main":"other.js"}'), "manifest")).toThrow(
+      "packaged manifest has an invalid main entry: manifest",
+    );
+  });
+
+  it("keeps untransformed ordinary manifests byte-exact", () => {
+    const manifest = { name: "desktop-runtime", main: "out/main/index.js" };
+    const source = Buffer.from(`${JSON.stringify(manifest)}\n`);
+    expect(() => validateManifest(manifestAsar(source), source)).not.toThrow();
+
+    const reformatted = Buffer.from(JSON.stringify(manifest, null, 2));
+    expect(() => validateManifest(manifestAsar(reformatted), source)).toThrow(
+      "ordinary packaged manifest differs from source: app.asar/package.json",
+    );
+  });
+
+  it("projects removed keys and applies the conditional Babel rule", () => {
+    const removedKeys = [
+      "dist",
+      "gitHead",
+      "build",
+      "jspm",
+      "ava",
+      "xo",
+      "nyc",
+      "eslintConfig",
+      "contributors",
+      "bundleDependencies",
+      "tags",
+      "scripts",
+      "keywords",
+      "devDependencies",
+    ];
+    const sourceManifest = {
+      name: "desktop-runtime",
+      main: "out/main/index.js",
+      dependencies: { runtime: "1.0.0" },
+      babel: { presets: ["runtime"] },
+      _private: true,
+      ...Object.fromEntries(removedKeys.map((key) => [key, { removed: true }])),
+    };
+    const expected = {
+      name: "desktop-runtime",
+      main: "out/main/index.js",
+      dependencies: { runtime: "1.0.0" },
+    };
+    expect(() =>
+      validateManifest(
+        manifestAsar(Buffer.from(JSON.stringify(expected, null, 2))),
+        Buffer.from(JSON.stringify(sourceManifest)),
+      ),
+    ).not.toThrow();
+
+    const retainedBabelSource = {
+      name: "desktop-runtime",
+      main: "out/main/index.js",
+      dependencies: { "babel-runtime": "1.0.0" },
+      babel: { presets: ["runtime"] },
+      scripts: { test: "runner" },
+    };
+    const retainedBabelExpected = {
+      name: "desktop-runtime",
+      main: "out/main/index.js",
+      dependencies: { "babel-runtime": "1.0.0" },
+      babel: { presets: ["runtime"] },
+    };
+    expect(() =>
+      validateManifest(
+        manifestAsar(Buffer.from(JSON.stringify(retainedBabelExpected, null, 2))),
+        Buffer.from(JSON.stringify(retainedBabelSource)),
+      ),
+    ).not.toThrow();
+  });
+
+  it("validates exact development and release overlays", () => {
+    const sourceManifest = {
+      name: "desktop-runtime",
+      version: "1.0.0",
+      main: "out/main/index.js",
+    };
+    const source = Buffer.from(JSON.stringify(sourceManifest));
+    const development = {
+      ...sourceManifest,
+      name: "desktop-runtime-development",
+      enduragentDesktopDevelopment: true,
+    };
+    expect(() =>
+      validateManifest(manifestAsar(Buffer.from(JSON.stringify(development, null, 2))), source, {
+        development: true,
+        developmentPackageName: "desktop-runtime-development",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateManifest(
+        manifestAsar(Buffer.from(JSON.stringify({ ...development, unexpected: true }, null, 2))),
+        source,
+        {
+          development: true,
+          developmentPackageName: "desktop-runtime-development",
+        },
+      ),
+    ).toThrow("development packaged manifest has unexpected drift: app.asar/package.json");
+
+    const release = {
+      ...sourceManifest,
+      version: "2.0.0",
+      enduragentDesktopRelease: true,
+    };
+    expect(() =>
+      validateManifest(manifestAsar(Buffer.from(JSON.stringify(release, null, 2))), source, {
+        release: { version: "2.0.0" },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateManifest(
+        manifestAsar(Buffer.from(JSON.stringify({ ...release, unexpected: true }, null, 2))),
+        source,
+        { release: { version: "2.0.0" } },
+      ),
+    ).toThrow("release packaged manifest has unexpected drift: app.asar/package.json");
+  });
+
+  it.each(["enduragentDesktopRelease", "enduragentDesktopDevelopment"])(
+    "rejects the source marker %s even when false",
+    (marker) => {
+      const manifest = {
+        name: "desktop-runtime",
+        main: "out/main/index.js",
+        [marker]: false,
+      };
+      const bytes = Buffer.from(JSON.stringify(manifest));
+      const expected =
+        marker === "enduragentDesktopRelease"
+          ? "source manifest contains a release marker: package.json"
+          : "source manifest contains a development marker: package.json";
+      expect(() => validateManifest(manifestAsar(bytes), bytes)).toThrow(expected);
+    },
+  );
+});
+
+describe("shared package resource inventory", () => {
+  it("derives top-level names and rejects reserved collisions", () => {
+    const tree = new Map<string, PackageTreeEntry>([
+      ["assets", { type: "directory" }],
+      ["assets/runtime.bin", packageFile("runtime")],
+      ["data/config.json", packageFile("{}")],
+    ]);
+    expect(assertNoReservedResourceNames(tree, new Set(["reserved"]), "external-tree")).toEqual(
+      new Set(["assets", "data"]),
+    );
+    expect(() => assertNoReservedResourceNames(tree, new Set(["assets"]), "external-tree")).toThrow(
+      "external resources collide with reserved package entries: external-tree",
+    );
+  });
+
+  it("requires the exact declared resource names", () => {
+    const expected = new Set(["alpha", "beta"]);
+    expect(() =>
+      assertExactResourceNames(["beta", "alpha"], expected, "resource-root"),
+    ).not.toThrow();
+    expect(() => assertExactResourceNames(["alpha"], expected, "resource-root")).toThrow(
+      "undeclared package resource: resource-root",
+    );
+    expect(() =>
+      assertExactResourceNames(["alpha", "beta", "gamma"], expected, "resource-root"),
+    ).toThrow("undeclared package resource: resource-root");
+  });
+});


### PR DESCRIPTION
Extracts the platform-neutral packaging rules out of the macOS-only desktop packaging scripts into two shared modules, so an upcoming Windows package plan can reuse them without touching macOS verification.

- New apps/desktop/scripts/package-plan.mjs (+.d.mts): platform-neutral package-plan factory (desktop root, output directory, relative application/executable paths, caller-owned builder config -> frozen plan) with containment/absoluteness checks at each path boundary; development-package-plan.mjs delegates to it and keeps all macOS-specific values at the call site.
- New apps/desktop/scripts/package-inventory.mjs (+.d.mts): the full inventory/verification rule set moved verbatim from verify-package-layout.mjs — required-file and asar inventories, forbidden-directory and secret/acceptance markers, manifest projection and drift checks, tree/asar collection and staging comparisons, Telegram runtime closure, sandboxed-preload scan, self-test checksum, unpacked-tree validation, builder-authority validation. Platform specifics are injected (label strings, manifest options, and two envelope callbacks that the macOS verifier supplies with its exact former predicates), so every macOS check and error string is byte-identical to before.
- verify-package-layout.mjs retains only macOS-envelope logic and orchestration.
- New apps/desktop/tests/package-contract.test.ts exercises the shared modules directly (38 tests): plan shape and containment, path policy, tree determinism and symlink rejection, real ASAR fixtures, manifest projection, resource-name assertions.

Verification: desktop tsc clean; desktop vitest suite green (three integration files that failed pre-build re-ran green after a real build); pnpm package:dir performed a full electron-vite + electron-builder macOS build and its layout verifier passed against the built package; repo-root pnpm check clean. No behavior change on the macOS path; no Windows code in this PR.