### PR TITLE
test(desktop): run windowed acceptance launches hidden

### DIFF
--- a/apps/desktop/scripts/accept-residency.mjs
+++ b/apps/desktop/scripts/accept-residency.mjs
@@ -5,6 +5,14 @@ import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 
+if (process.env.ENDURAGENT_WINDOWED_ACK !== "1") {
+  process.stderr.write(
+    "accept:residency launches a real focused window on this display. " +
+      "Announce the run to the operator first, then re-run with ENDURAGENT_WINDOWED_ACK=1.\n",
+  );
+  process.exit(2);
+}
+
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const fixtureRoot = join(desktopRoot, "tests", "fixtures", "residency");
 const processDeadlineMs = 20_000;

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -115,6 +115,7 @@ async function runtime() {
         ...process.env,
         FORCE_COLOR: undefined,
         CLICOLOR_FORCE: undefined,
+        ENDURAGENT_ACCEPTANCE_HIDDEN: "1",
       },
       [`--user-data-dir=${userDataDirectory}`],
     );
@@ -239,6 +240,7 @@ async function security() {
     const launchEnvironment = {
       ...createSecuritySmokeLaunchEnvironment(process.env, environment, process.platform),
       ...(mode === "packaged" ? { ELECTRON_RENDERER_URL: ":///synthetic-malformed-renderer" } : {}),
+      ENDURAGENT_ACCEPTANCE_HIDDEN: "1",
     };
     running = await startElectron(
       "--desktop-security-smoke",

--- a/apps/desktop/scripts/test-packaged-telegram.ts
+++ b/apps/desktop/scripts/test-packaged-telegram.ts
@@ -1125,6 +1125,7 @@ async function main(): Promise<void> {
       HOME: operatorHome,
       ENDURAGENT_HOME: athleteHome,
       ENDURAGENT_ACCEPTANCE_TELEGRAM_BOT_API_ORIGIN: telegram.origin,
+      ENDURAGENT_ACCEPTANCE_HIDDEN: "1",
       FORCE_COLOR: undefined,
       CLICOLOR_FORCE: undefined,
     });

--- a/apps/desktop/scripts/test-safe-storage-packaged.mjs
+++ b/apps/desktop/scripts/test-safe-storage-packaged.mjs
@@ -228,6 +228,7 @@ try {
     HOME: operatorHome,
     ENDURAGENT_HOME: athleteHome,
     W9_SAFE_STORAGE_COMMAND: commandPath,
+    ENDURAGENT_ACCEPTANCE_HIDDEN: "1",
     FORCE_COLOR: undefined,
     CLICOLOR_FORCE: undefined,
   };

--- a/apps/desktop/scripts/verify-packaged-self-test.mjs
+++ b/apps/desktop/scripts/verify-packaged-self-test.mjs
@@ -88,6 +88,7 @@ function applicationEnvironment(athleteHome) {
     if (process.env[name] !== undefined) environment[name] = process.env[name];
   }
   environment.ENDURAGENT_HOME = athleteHome;
+  environment.ENDURAGENT_ACCEPTANCE_HIDDEN = "1";
   return environment;
 }
 

--- a/apps/desktop/scripts/verify-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-updater-round-trip.mjs
@@ -1739,6 +1739,7 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
         ...process.env,
         HOME: home,
         ENDURAGENT_HOME: athleteHome,
+        ENDURAGENT_ACCEPTANCE_HIDDEN: "1",
         FORCE_COLOR: undefined,
         NO_COLOR: undefined,
         CLICOLOR_FORCE: undefined,

--- a/apps/desktop/scripts/verify-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-updater-round-trip.mjs
@@ -1992,6 +1992,14 @@ async function main() {
 }
 
 if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  if (!process.env.CI && process.env.ENDURAGENT_WINDOWED_ACK !== "1") {
+    process.stderr.write(
+      "test:macos-update-roundtrip includes an updater-relaunched app instance that opens a real window on this display. " +
+        "Announce the run to the operator first, then re-run with ENDURAGENT_WINDOWED_ACK=1.\n",
+    );
+    process.exit(2);
+  }
+
   try {
     await main();
   } catch (error) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -122,6 +122,7 @@ function disableChromiumMediaSessionIntegration(): void {
 
 let desktopIsClosing = false;
 let desktopStartedInBackground = false;
+const desktopAcceptanceHidden = process.env.ENDURAGENT_ACCEPTANCE_HIDDEN === "1";
 
 const mainDirectory = dirname(fileURLToPath(import.meta.url));
 const utilityEntry = resolve(mainDirectory, "daemon-utility.js");
@@ -129,6 +130,7 @@ const preloadEntry = resolve(mainDirectory, "../preload/index.cjs");
 
 async function runRuntimeSmoke(): Promise<void> {
   await app.whenReady();
+  if (desktopAcceptanceHidden) app.dock?.hide();
   const child = utilityProcess.fork(utilityEntry, ["--desktop-runtime-smoke"], {
     serviceName: "enduragent desktop runtime",
     stdio: "pipe",
@@ -156,6 +158,7 @@ async function runDesktop(): Promise<void> {
   });
   app.on("window-all-closed", () => {});
   await app.whenReady();
+  if (desktopAcceptanceHidden) app.dock?.hide();
   const backgroundAtLoginPreference = createBackgroundAtLoginPreferenceStore({
     root: join(app.getPath("userData"), BACKGROUND_AT_LOGIN_PREFERENCE_DIRECTORY_NAME),
   });
@@ -270,7 +273,7 @@ async function runDesktop(): Promise<void> {
     if (resolution.status === "refused") {
       if (!controller.signal.aborted && resolution.cause !== "cancelled") {
         const copy = startupRefusalCopy(resolution.cause);
-        if (desktopStartedInBackground) {
+        if (desktopStartedInBackground || desktopAcceptanceHidden) {
           process.stderr.write(`desktop-startup-refusal ${resolution.cause}\n`);
         } else {
           dialog.showErrorBox(copy.title, copy.content);
@@ -398,7 +401,7 @@ async function runDesktop(): Promise<void> {
       const copy =
         controller.signal.aborted || desktopIsClosing ? undefined : lifecycleErrorCopy(state);
       if (copy !== undefined) {
-        if (desktopStartedInBackground && currentWindow() === null) {
+        if (desktopAcceptanceHidden || (desktopStartedInBackground && currentWindow() === null)) {
           process.stderr.write(`desktop-daemon-background-failure ${state.status}\n`);
         } else {
           dialog.showErrorBox(copy.title, copy.content);
@@ -722,13 +725,22 @@ async function runDesktop(): Promise<void> {
         if (windowCreation !== undefined) return windowCreation;
         const current = mainWindow.current();
         if (current !== null) {
-          if (current.isMinimized()) current.restore();
-          current.show();
-          current.focus();
+          if (!desktopAcceptanceHidden) {
+            if (current.isMinimized()) current.restore();
+            current.show();
+            current.focus();
+          }
           return Promise.resolve(current);
         }
         windowCreation = (async () => {
-          const created = new BrowserWindow(desktopWindowOptions(preloadEntry));
+          const windowOptions = desktopWindowOptions(preloadEntry);
+          if (desktopAcceptanceHidden) {
+            windowOptions.webPreferences = {
+              ...windowOptions.webPreferences,
+              backgroundThrottling: false,
+            };
+          }
+          const created = new BrowserWindow(windowOptions);
           window = created;
           rendererConsoleCapture.attach(created.webContents);
           hardenDesktopWindow(created);
@@ -791,9 +803,11 @@ async function runDesktop(): Promise<void> {
             }
           });
           await created.loadURL(DESKTOP_RENDERER_URL);
-          if (created.isMinimized()) created.restore();
-          created.show();
-          created.focus();
+          if (!desktopAcceptanceHidden) {
+            if (created.isMinimized()) created.restore();
+            created.show();
+            created.focus();
+          }
           return created;
         })().finally(() => {
           windowCreation = undefined;
@@ -967,7 +981,7 @@ if (!primaryInstance) {
     : runDesktop;
   void runPrimaryDesktop().catch((error: unknown) => {
     console.error("desktop startup failed", error);
-    if (!desktopIsClosing && !desktopStartedInBackground) {
+    if (!desktopIsClosing && !desktopStartedInBackground && !desktopAcceptanceHidden) {
       dialog.showErrorBox(unexpectedStartupCopy.title, unexpectedStartupCopy.content);
     }
     app.exit(1);

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -326,6 +326,7 @@ export async function launchDesktopFixture(input: {
       env: {
         ...process.env,
         ENDURAGENT_HOME: athleteHome,
+        ENDURAGENT_ACCEPTANCE_HIDDEN: "1",
         FORCE_COLOR: undefined,
         NO_COLOR: undefined,
         CLICOLOR_FORCE: undefined,

--- a/apps/desktop/tests/macos-update-roundtrip.test.ts
+++ b/apps/desktop/tests/macos-update-roundtrip.test.ts
@@ -105,7 +105,14 @@ describe("macOS updater round-trip input", () => {
         "/private/tmp/candidate-envelope",
         "/private/tmp/evidence.json",
       ],
-      { allowFailure: true, timeoutMs: 5_000 },
+      {
+        allowFailure: true,
+        timeoutMs: 5_000,
+        environment: {
+          ...process.env,
+          ENDURAGENT_WINDOWED_ACK: "1",
+        },
+      },
     );
 
     expect(result.code).toBe(1);
@@ -145,6 +152,7 @@ describe("macOS updater round-trip input", () => {
         environment: {
           ...process.env,
           ENDURAGENT_MACOS_UPDATE_ROUNDTRIP_MODE: "steady",
+          ENDURAGENT_WINDOWED_ACK: "1",
         },
       },
     );


### PR DESCRIPTION
## Problem

Every desktop acceptance/smoke harness and the vitest integration fixture launch the real Electron app, and the app eagerly `show()`s + `focus()`es its window on startup. During any test run the app flashed over whatever the operator was doing and stole keyboard focus, several times per run (the updater round-trip launches the app three times).

## Fix

A single env flag, `ENDURAGENT_ACCEPTANCE_HIDDEN=1`, makes the main process never reveal UI:

- window reveal paths (`restore()`/`show()`/`focus()` for both the existing-window and freshly-created-window flows) are skipped; windows are still **created**, so the renderer loads, CDP pages exist, and `capturePage()` screenshots keep working
- the dock icon is hidden in both `runDesktop()` and `runRuntimeSmoke()`
- the three blocking `dialog.showErrorBox` sites route to stderr instead
- hidden acceptance windows get `backgroundThrottling: false` so timers behave as if visible

All six windowed harnesses set the flag (runtime smoke, security smoke, packaged self-test, safe-storage packaged test, packaged Telegram acceptance, updater round-trip baseline/verification instances), plus the vitest desktop fixture — so `pnpm test` is now fully windowless.

## The two runs that still need a display

- `accept:residency` genuinely exercises a focused window. It now refuses to run unless `ENDURAGENT_WINDOWED_ACK=1` is set (exit 2 with an announcement message).
- `test:macos-update-roundtrip` has a middle instance relaunched by the production updater itself (`quitAndInstall`); that relaunch starts with a fresh session environment, so no env flag can reach it without baking a test backdoor into prod code — and the real relaunch UX is exactly what the test verifies. The script gets the same `ENDURAGENT_WINDOWED_ACK` gate, exempt when `CI` is set, so the release workflow is unaffected (GitHub Actions always sets `CI=true`). The gate lives on the direct-execution path only; the unit suites that import the script's exports are untouched, and the two diagnostic tests that spawn it as a subprocess carry the ack (they fail at input validation long before any Electron launch).

## Why this is safe for CI and packaging

- The packaged-layout acceptance-marker scan matches exact lowercase strings via `includes`; neither new env name contains a listed marker (precedent: the `--desktop-security-smoke` argv flag already ships in canonical code).
- The security-smoke exact-environment test still holds: the flag is spread into the launch env *after* `createSecuritySmokeLaunchEnvironment(...)`, whose output the test asserts on.
- No test asserts native window visibility or focus; matches are DOM focus assertions or mocked tray behavior.
- Production behavior is unchanged: with the flag unset, every reveal path executes exactly as before.

## Verification

- Security smoke passes fully hidden, including a real 2360×1576 `capturePage()` evidence screenshot from a never-shown window; runtime smoke passes hidden.
- Full desktop vitest suite on this branch (rebased on main): 1526/1532, zero windows appearing during the run. The 6 failures (chat-panels, onboarding-first-run, spend-meter integration) are unrelated to this diff: they fail identically with the hidden flag removed and with the fixture + test files taken verbatim from origin/main (and on a freshly re-downloaded Electron dist), they pass in GitHub Actions, and the same three files ran green in a clean worktree of post-merge main on the same machine — isolating the cause to this checkout's dependency state after an interrupted reinstall, not to any code on main or this branch. A fresh `pnpm install` in the checkout is expected to clear them.
- Round-trip diagnostics suites pass (69/69); running `test:macos-update-roundtrip` without the ack exits 2 with the refusal message before any Electron process spawns.
- Independent read-only audits of the diff confirmed the gating call-site enumeration in `src/main/index.ts` (every reveal/dialog site gated), harness coverage of every Electron launcher, and the CI/packaging properties above.
