### PR TITLE
feat(coach): add platform-neutral desktop registration seam

### DIFF
--- a/.changeset/safe-windows-daemon-ownership.md
+++ b/.changeset/safe-windows-daemon-ownership.md
@@ -1,0 +1,4 @@
+---
+"@enduragent/desktop": patch
+---
+

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -184,6 +184,7 @@ async function runDesktop(): Promise<void> {
       env: environment,
       executablePath: process.execPath,
       appVersion: app.getVersion(),
+      platform: process.platform,
       signal: controller.signal,
     },
     utilityEntry,
@@ -275,8 +276,17 @@ async function runDesktop(): Promise<void> {
     if (resolution.status === "refused") {
       if (!controller.signal.aborted && resolution.cause !== "cancelled") {
         const copy = startupRefusalCopy(resolution.cause);
+        const unownedDaemon =
+          process.platform === "win32" &&
+          resolution.cause === "contention" &&
+          !resolution.retryable;
+        if (unownedDaemon) {
+          process.stderr.write("desktop-daemon-ownership-refusal unowned\n");
+        }
         if (desktopStartedInBackground || desktopAcceptanceHidden) {
-          process.stderr.write(`desktop-startup-refusal ${resolution.cause}\n`);
+          if (!unownedDaemon) {
+            process.stderr.write(`desktop-startup-refusal ${resolution.cause}\n`);
+          }
         } else {
           dialog.showErrorBox(copy.title, copy.content);
         }
@@ -403,8 +413,17 @@ async function runDesktop(): Promise<void> {
       const copy =
         controller.signal.aborted || desktopIsClosing ? undefined : lifecycleErrorCopy(state);
       if (copy !== undefined) {
+        const unownedDaemon =
+          process.platform === "win32" &&
+          state.status === "terminal" &&
+          state.cause === "contention";
+        if (unownedDaemon) {
+          process.stderr.write("desktop-daemon-ownership-refusal unowned\n");
+        }
         if (desktopAcceptanceHidden || (desktopStartedInBackground && currentWindow() === null)) {
-          process.stderr.write(`desktop-daemon-background-failure ${state.status}\n`);
+          if (!unownedDaemon) {
+            process.stderr.write(`desktop-daemon-background-failure ${state.status}\n`);
+          }
         } else {
           dialog.showErrorBox(copy.title, copy.content);
         }

--- a/apps/desktop/src/main/supervisor.ts
+++ b/apps/desktop/src/main/supervisor.ts
@@ -342,7 +342,9 @@ export class DesktopDaemonSupervisor {
   private closing = false;
 
   constructor(
-    private readonly input: Omit<ResolveDesktopDaemonInput, "startAppSupervisedDaemon">,
+    private readonly input: Omit<ResolveDesktopDaemonInput, "startAppSupervisedDaemon"> & {
+      readonly platform?: NodeJS.Platform;
+    },
     private readonly utilityEntry: string,
     private readonly resolveDaemon: typeof resolveDesktopDaemon = resolveDesktopDaemon,
   ) {}
@@ -383,6 +385,37 @@ export class DesktopDaemonSupervisor {
         if (resolution.status === "refused") {
           if (this.active === generation) this.active = undefined;
           return resolution;
+        }
+        if ((this.input.platform ?? process.platform) === "win32") {
+          let owned = false;
+          try {
+            owned =
+              resolution.supervision === "app-supervised" &&
+              resolution.owner === "app-supervised" &&
+              resolution.isAlive();
+          } catch {}
+          if (!owned) {
+            try {
+              await resolution.close();
+            } catch {
+              if (this.active === generation) this.active = undefined;
+              return {
+                status: "refused" as const,
+                exitCode: 3 as const,
+                classification: "contention-family" as const,
+                cause: "termination-failed" as const,
+                retryable: false,
+              };
+            }
+            if (this.active === generation) this.active = undefined;
+            return {
+              status: "refused" as const,
+              exitCode: 3 as const,
+              classification: "contention-family" as const,
+              cause: "contention" as const,
+              retryable: false,
+            };
+          }
         }
         let closePromise: Promise<void> | undefined;
         const wrapped = {

--- a/apps/desktop/tests/supervisor.test.ts
+++ b/apps/desktop/tests/supervisor.test.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from "node:events";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({ utilityProcess: { fork: vi.fn() } }));
@@ -136,6 +138,103 @@ describe("desktop main supervisor", () => {
     expect(close).toHaveBeenCalledTimes(1);
     await supervisor.resolve();
     expect(resolveDaemon).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts a live app-supervised Windows resolution", async () => {
+    const exit = deferred<{ readonly exitCode: number | null }>();
+    const resolution = connected(45_001, exit);
+    const supervisor = new DesktopDaemonSupervisor(
+      {
+        env: {},
+        executablePath: "C:\\Program Files\\Enduragent\\Enduragent.exe",
+        appVersion: "0.1.0",
+        platform: "win32",
+        signal: new AbortController().signal,
+      },
+      "C:\\Program Files\\Enduragent\\daemon-utility.js",
+      vi.fn(async () => resolution),
+    );
+
+    await expect(supervisor.resolve()).resolves.toMatchObject({
+      status: "connected",
+      supervision: "app-supervised",
+    });
+    expect(resolution.close).not.toHaveBeenCalled();
+  });
+
+  it("refuses a Windows daemon without a current app child handle", async () => {
+    const close = vi.fn(async () => {});
+    const attached: DesktopDaemonResolution = {
+      status: "connected",
+      url: "ws://127.0.0.1:45001/rpc",
+      token: "s".repeat(43),
+      athleteHome: "C:\\synthetic\\athlete",
+      rendererCapability: capability("r"),
+      owner: "app-supervised",
+      supervision: "attached",
+      close,
+    };
+    const supervisor = new DesktopDaemonSupervisor(
+      {
+        env: {},
+        executablePath: "C:\\Program Files\\Enduragent\\Enduragent.exe",
+        appVersion: "0.1.0",
+        platform: "win32",
+        signal: new AbortController().signal,
+      },
+      "C:\\Program Files\\Enduragent\\daemon-utility.js",
+      vi.fn(async () => attached),
+    );
+
+    await expect(supervisor.resolve()).resolves.toEqual({
+      status: "refused",
+      exitCode: 3,
+      classification: "contention-family",
+      cause: "contention",
+      retryable: false,
+    });
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("refuses a dead Windows app child instead of claiming ownership", async () => {
+    const close = vi.fn(async () => {});
+    const resolution: DesktopDaemonResolution = {
+      status: "connected",
+      url: "ws://127.0.0.1:45001/rpc",
+      token: "s".repeat(43),
+      athleteHome: "C:\\synthetic\\athlete",
+      rendererCapability: capability("r"),
+      owner: "app-supervised",
+      supervision: "app-supervised",
+      exited: Promise.resolve({ exitCode: 1 }),
+      isAlive: () => false,
+      close,
+    };
+    const supervisor = new DesktopDaemonSupervisor(
+      {
+        env: {},
+        executablePath: "C:\\Program Files\\Enduragent\\Enduragent.exe",
+        appVersion: "0.1.0",
+        platform: "win32",
+        signal: new AbortController().signal,
+      },
+      "C:\\Program Files\\Enduragent\\daemon-utility.js",
+      vi.fn(async () => resolution),
+    );
+
+    await expect(supervisor.resolve()).resolves.toMatchObject({
+      status: "refused",
+      cause: "contention",
+      retryable: false,
+    });
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("uses one closed path-free stage for Windows ownership refusal at startup and recovery", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+
+    expect(source.match(/desktop-daemon-ownership-refusal unowned\\n/g)).toHaveLength(2);
+    expect(source).not.toContain("desktop-daemon-ownership-refusal ${");
   });
 
   it("propagates an active resolution close rejection", async () => {

--- a/packages/coach/src/desktop-registration.ts
+++ b/packages/coach/src/desktop-registration.ts
@@ -1,0 +1,56 @@
+import type { ServiceRegistrationState } from "@enduragent/coach-cli";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import type { LaunchdServiceStatus } from "@enduragent/kernel-node/service";
+
+export interface DesktopRegistrationInput {
+  readonly platform: NodeJS.Platform;
+  readonly home: AthleteHome;
+  readonly executablePath: string;
+}
+
+export type DesktopRegistrationResult =
+  | {
+      readonly source: "launchd";
+      readonly registration: ServiceRegistrationState;
+      readonly status: LaunchdServiceStatus;
+    }
+  | {
+      readonly source: "app-supervised";
+      readonly registration: "absent";
+    }
+  | {
+      readonly source: "override";
+      readonly registration: ServiceRegistrationState;
+    };
+
+export interface DesktopRegistrationDependencies {
+  readonly readServiceStatus: (input: {
+    readonly home: AthleteHome;
+    readonly executablePath: string;
+  }) => Promise<LaunchdServiceStatus>;
+  readonly serviceRegistrationState?: () => Promise<ServiceRegistrationState>;
+}
+
+export async function readDesktopRegistration(
+  input: DesktopRegistrationInput,
+  dependencies: DesktopRegistrationDependencies,
+): Promise<DesktopRegistrationResult> {
+  if (input.platform === "win32") {
+    return { source: "app-supervised", registration: "absent" };
+  }
+  if (dependencies.serviceRegistrationState !== undefined) {
+    return {
+      source: "override",
+      registration: await dependencies.serviceRegistrationState(),
+    };
+  }
+  const status = await dependencies.readServiceStatus({
+    home: input.home,
+    executablePath: input.executablePath,
+  });
+  return {
+    source: "launchd",
+    registration: status.kind === "registered" ? "present" : status.kind,
+    status,
+  };
+}

--- a/packages/coach/src/enduragent.ts
+++ b/packages/coach/src/enduragent.ts
@@ -53,7 +53,6 @@ import {
 } from "@enduragent/kernel-node/home";
 import { PORT_FILE_NAME, type PeerHealthyOutcome } from "@enduragent/kernel-node/lock";
 import {
-  canonicalizeAthleteHome,
   createLaunchdServiceIdentity,
   installLaunchdService,
   readLaunchdServiceStatus,
@@ -92,6 +91,7 @@ import {
 import type { ReadinessFailureStatus } from "./readiness.js";
 export type { ReadinessFailureStatus } from "./readiness.js";
 import { serializeBoundaryError } from "./daemon/error-boundary.js";
+import { readDesktopRegistration, type DesktopRegistrationResult } from "./desktop-registration.js";
 import { CoachStoreWriterError } from "./runtime.js";
 import { runCoachServe } from "./serve.js";
 
@@ -143,6 +143,7 @@ export interface EnduragentDependencies {
     readonly home: AthleteHome;
     readonly executablePath: string;
   }) => Promise<LaunchdServiceStatus>;
+  readonly createLaunchdServiceIdentity?: typeof createLaunchdServiceIdentity;
   readonly resumeService?: (input: {
     readonly home: AthleteHome;
     readonly executablePath: string;
@@ -159,6 +160,10 @@ export interface EnduragentDependencies {
 }
 
 export type ServiceRegistrationClass = "absent" | "registered" | "unknown";
+
+function desktopRegistrationClass(result: DesktopRegistrationResult): ServiceRegistrationClass {
+  return result.registration === "present" ? "registered" : result.registration;
+}
 
 export interface AppSupervisedChildHandle {
   readonly pid: number;
@@ -456,6 +461,7 @@ const defaultDependencies: EnduragentDependencies = Object.freeze({
   monotonicNow: () => performance.now(),
   resolveExecutablePath,
   createDaemonController,
+  createLaunchdServiceIdentity,
   readServiceStatus: defaultReadServiceStatus,
   resumeService: defaultResumeService,
   observeDaemonState,
@@ -822,7 +828,20 @@ function sameAthleteHome(left: AthleteHome, right: AthleteHome): boolean {
 }
 
 function canonicalHome(home: AthleteHome): AthleteHome {
-  const canonical = canonicalizeAthleteHome(home);
+  const root = resolve(home.root);
+  const canonical = Object.freeze({
+    root,
+    storeDir: resolve(home.storeDir),
+    archiveDir: resolve(home.archiveDir),
+    configDir: resolve(home.configDir),
+  });
+  if (
+    canonical.storeDir !== join(root, "store") ||
+    canonical.archiveDir !== join(root, "archive") ||
+    canonical.configDir !== join(root, "config")
+  ) {
+    throw new TypeError("athlete home paths are inconsistent");
+  }
   return sameAthleteHome(home, canonical) ? home : canonical;
 }
 
@@ -844,7 +863,7 @@ function validateSuccessorInput(home: AthleteHome, input: DesignatedSuccessorInp
 }
 
 export interface ServiceUpgradeBindingDependencies {
-  readonly readStatus: () => Promise<LaunchdServiceStatus>;
+  readonly readRegistration: () => Promise<ServiceRegistrationClass>;
   readonly restartInstalled: (input: DesignatedSuccessorInput) => Promise<void>;
   readonly resumeAfterEphemeral: (input: DesignatedSuccessorInput) => Promise<void>;
   readonly startEphemeral: (input: DesignatedSuccessorInput) => Promise<void>;
@@ -857,9 +876,9 @@ export function createServiceUpgradePort(
   return {
     async isInstalled(inputHome) {
       if (home.root !== inputHome.root) throw new TypeError("athlete home changed");
-      const status = await dependencies.readStatus();
-      if (status.kind === "registered") return true;
-      if (status.kind === "absent") return false;
+      const registration = await dependencies.readRegistration();
+      if (registration === "registered") return true;
+      if (registration === "absent") return false;
       throw new Error("service status unavailable");
     },
     async restartInstalledService(input) {
@@ -1023,28 +1042,49 @@ function createSecondStarterCoreDependencies(input: {
   };
 }
 
-function createSecondStarterDependencies(input: {
+export function createSecondStarterDependencies(input: {
   readonly home: AthleteHome;
   readonly executablePath: string;
   readonly dependencies: EnduragentDependencies;
 }): ResolveSecondStarterDependencies {
-  const identity = createLaunchdServiceIdentity({
-    home: input.home,
-    executablePath: input.executablePath,
-  });
+  const platform = input.dependencies.platform!;
+  const identity =
+    platform === "win32"
+      ? undefined
+      : input.dependencies.createLaunchdServiceIdentity!({
+          home: input.home,
+          executablePath: input.executablePath,
+        });
+  const startEphemeral = input.dependencies.startEphemeralSuccessor!;
   const serviceUpgrade = createServiceUpgradePort(input.home, {
-    readStatus: () =>
-      input.dependencies.readServiceStatus!({
-        home: input.home,
-        executablePath: input.executablePath,
-      }),
+    readRegistration: async () =>
+      desktopRegistrationClass(
+        await readDesktopRegistration(
+          {
+            platform,
+            home: input.home,
+            executablePath: input.executablePath,
+          },
+          {
+            readServiceStatus: input.dependencies.readServiceStatus!,
+          },
+        ),
+      ),
     restartInstalled: async (successor) => {
+      if (identity === undefined) {
+        await startEphemeral(successor);
+        return;
+      }
       await restartLaunchdServiceForUpgrade(identity, successor);
     },
     resumeAfterEphemeral: async (successor) => {
+      if (identity === undefined) {
+        await startEphemeral(successor);
+        return;
+      }
       await resumeLaunchdServiceAfterEphemeral(identity, successor);
     },
-    startEphemeral: input.dependencies.startEphemeralSuccessor!,
+    startEphemeral,
   });
   return createSecondStarterCoreDependencies({
     dependencies: input.dependencies,
@@ -1052,10 +1092,19 @@ function createSecondStarterDependencies(input: {
   });
 }
 
+function customServiceRegistrationState(
+  dependencies: EnduragentDependencies,
+): (() => Promise<ServiceRegistrationState>) | undefined {
+  return dependencies.serviceRegistrationState === defaultDependencies.serviceRegistrationState
+    ? undefined
+    : dependencies.serviceRegistrationState;
+}
+
 export interface ResolveDesktopDaemonInput {
   readonly env: Record<string, string | undefined>;
   readonly executablePath: string;
   readonly appVersion: string;
+  readonly platform?: NodeJS.Platform;
   readonly signal: AbortSignal;
   readonly startAppSupervisedDaemon: (
     input: StartAppSupervisedDaemonInput,
@@ -1069,6 +1118,8 @@ export type DesktopDaemonDependencies = Required<
     EnduragentDependencies,
     | "resolveAthleteHome"
     | "prepareAthleteHome"
+    | "platform"
+    | "createLaunchdServiceIdentity"
     | "readServiceStatus"
     | "resumeService"
     | "observeDaemonState"
@@ -1128,6 +1179,8 @@ const DESKTOP_EPHEMERAL_START_DEADLINE_MS = 90_000;
 const desktopDaemonDependencies: DesktopDaemonDependencies = {
   resolveAthleteHome: defaultDependencies.resolveAthleteHome,
   prepareAthleteHome: defaultDependencies.prepareAthleteHome!,
+  platform: defaultDependencies.platform!,
+  createLaunchdServiceIdentity: defaultDependencies.createLaunchdServiceIdentity!,
   readServiceStatus: defaultDependencies.readServiceStatus!,
   resumeService: defaultDependencies.resumeService!,
   observeDaemonState: defaultDependencies.observeDaemonState!,
@@ -1172,6 +1225,16 @@ function refusedDesktop(
       cause !== "malformed" &&
       cause !== "version-mismatch" &&
       cause !== "termination-failed",
+  };
+}
+
+function refusedUnownedDesktop(): DesktopDaemonResolution {
+  return {
+    status: "refused",
+    exitCode: EXIT_DAEMON_UNAVAILABLE,
+    classification: "contention-family",
+    cause: "contention",
+    retryable: false,
   };
 }
 
@@ -1248,6 +1311,38 @@ function connectedDesktop(
         isAlive: child.isAlive,
         close,
       };
+}
+
+async function refuseUnownedWindowsDesktop(
+  child: AppSupervisedChildHandle | undefined,
+): Promise<DesktopDaemonResolution> {
+  if (!(await stopAppChild(child))) {
+    return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+  }
+  return refusedUnownedDesktop();
+}
+
+async function connectOwnedWindowsDesktop(
+  observation: Extract<DaemonStateObservation, { readonly kind: "compatible-healthy" }>,
+  child: AppSupervisedChildHandle | undefined,
+): Promise<DesktopDaemonResolution> {
+  let owned = false;
+  try {
+    owned =
+      child !== undefined &&
+      child.isAlive() &&
+      observation.peer.pid === child.pid &&
+      observation.authenticated.handshake.owner === "app-supervised";
+  } catch {}
+  if (!owned) {
+    return refuseUnownedWindowsDesktop(child);
+  }
+  return connectedDesktop(
+    observation.authenticated.coordinates.port,
+    observation.authenticated.coordinates.token,
+    observation.authenticated.handshake,
+    child,
+  );
 }
 
 type DesktopPublicationOutcome =
@@ -1343,7 +1438,7 @@ async function waitForDesktopDaemon(input: {
 function createDesktopSecondStarterBinding(input: {
   readonly home: AthleteHome;
   readonly executablePath: string;
-  readonly serviceStatus: LaunchdServiceStatus;
+  readonly registration: DesktopRegistrationResult;
   readonly previousChild?: AppSupervisedChildHandle;
   readonly dependencies: DesktopDaemonDependencies;
   readonly startAppSupervisedDaemon: ResolveDesktopDaemonInput["startAppSupervisedDaemon"];
@@ -1351,10 +1446,13 @@ function createDesktopSecondStarterBinding(input: {
   readonly dependencies: ResolveSecondStarterDependencies;
   takeStartedAppChild(): AppSupervisedChildHandle | undefined;
 } {
-  const identity = createLaunchdServiceIdentity({
-    home: input.home,
-    executablePath: input.executablePath,
-  });
+  const identity =
+    input.registration.source === "launchd"
+      ? input.dependencies.createLaunchdServiceIdentity({
+          home: input.home,
+          executablePath: input.executablePath,
+        })
+      : undefined;
   let startedChild: AppSupervisedChildHandle | undefined;
   let taken = false;
   let retirePromise: Promise<void> | undefined;
@@ -1362,24 +1460,33 @@ function createDesktopSecondStarterBinding(input: {
     retirePromise ??= requireStoppedAppChild(input.previousChild);
     return retirePromise;
   };
+  const startAppSuccessor = async (successor: DesignatedSuccessorInput): Promise<void> => {
+    if (startedChild !== undefined || taken) throw new Error("app child already started");
+    await retirePreviousChild();
+    startedChild = await input.startAppSupervisedDaemon({
+      home: successor.home,
+      handoffCapability: successor.handoffCapability,
+    });
+  };
   const serviceUpgrade = createServiceUpgradePort(input.home, {
-    readStatus: async () => input.serviceStatus,
+    readRegistration: async () => desktopRegistrationClass(input.registration),
     restartInstalled: async (successor) => {
+      if (identity === undefined) {
+        await startAppSuccessor(successor);
+        return;
+      }
       await retirePreviousChild();
       await restartLaunchdServiceForUpgrade(identity, successor);
     },
     resumeAfterEphemeral: async (successor) => {
+      if (identity === undefined) {
+        await startAppSuccessor(successor);
+        return;
+      }
       await retirePreviousChild();
       await resumeLaunchdServiceAfterEphemeral(identity, successor);
     },
-    startEphemeral: async (successor) => {
-      if (startedChild !== undefined || taken) throw new Error("app child already started");
-      await retirePreviousChild();
-      startedChild = await input.startAppSupervisedDaemon({
-        home: successor.home,
-        handoffCapability: successor.handoffCapability,
-      });
-    },
+    startEphemeral: startAppSuccessor,
   });
   return {
     dependencies: createSecondStarterCoreDependencies({
@@ -1406,6 +1513,7 @@ export async function resolveDesktopDaemon(
   if (!isAbsolute(input.executablePath) || input.appVersion.length === 0) {
     throw new TypeError("invalid desktop daemon input");
   }
+  const platform = input.platform ?? dependencies.platform;
   let home: AthleteHome;
   try {
     home = await prepareDesktopAthleteHome(input.env, dependencies);
@@ -1415,14 +1523,14 @@ export async function resolveDesktopDaemon(
       input.signal.aborted ? "cancelled" : "unavailable",
     );
   }
-  let serviceStatus: LaunchdServiceStatus;
+  let registrationResult: DesktopRegistrationResult;
   let registration: ServiceRegistrationClass;
   try {
-    serviceStatus = await dependencies.readServiceStatus({
-      home,
-      executablePath: input.executablePath,
-    });
-    registration = serviceStatus.kind;
+    registrationResult = await readDesktopRegistration(
+      { platform, home, executablePath: input.executablePath },
+      { readServiceStatus: dependencies.readServiceStatus },
+    );
+    registration = desktopRegistrationClass(registrationResult);
   } catch {
     return refusedDesktop(
       EXIT_DAEMON_UNAVAILABLE,
@@ -1440,6 +1548,9 @@ export async function resolveDesktopDaemon(
   }
   if (input.observationOnly) {
     if (observation.kind === "compatible-healthy") {
+      if (platform === "win32") {
+        return connectOwnedWindowsDesktop(observation, undefined);
+      }
       return connectedDesktop(
         observation.authenticated.coordinates.port,
         observation.authenticated.coordinates.token,
@@ -1464,6 +1575,9 @@ export async function resolveDesktopDaemon(
 
   while (!input.signal.aborted) {
     if (observation.kind === "compatible-healthy") {
+      if (platform === "win32") {
+        return connectOwnedWindowsDesktop(observation, ownedChild);
+      }
       return connectedDesktop(
         observation.authenticated.coordinates.port,
         observation.authenticated.coordinates.token,
@@ -1481,7 +1595,7 @@ export async function resolveDesktopDaemon(
       const binding = createDesktopSecondStarterBinding({
         home,
         executablePath: input.executablePath,
-        serviceStatus,
+        registration: registrationResult,
         ...(ownedChild === undefined ? {} : { previousChild: ownedChild }),
         dependencies,
         startAppSupervisedDaemon: input.startAppSupervisedDaemon,
@@ -1534,6 +1648,18 @@ export async function resolveDesktopDaemon(
         ownedChild = undefined;
       }
       if (starter.status === "attach") {
+        if (platform === "win32") {
+          let attached: DaemonStateObservation;
+          try {
+            attached = await dependencies.observeDaemonState({ home });
+          } catch {
+            return refuseUnownedWindowsDesktop(ownedChild);
+          }
+          if (attached.kind !== "compatible-healthy" || attached.peer.port !== starter.port) {
+            return refuseUnownedWindowsDesktop(ownedChild);
+          }
+          return connectOwnedWindowsDesktop(attached, ownedChild);
+        }
         return connectedDesktop(
           starter.port,
           observation.authenticated.coordinates.token,
@@ -1660,6 +1786,14 @@ export async function resolveDesktopDaemon(
       if (published.kind === "cancelled") {
         return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "cancelled");
       }
+      if (platform === "win32" && published.kind === "child-exited") {
+        try {
+          observation = await dependencies.observeDaemonState({ home });
+        } catch {
+          return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "unavailable");
+        }
+        continue;
+      }
       observation = published.kind === "deadline" ? published.observation : { kind: "absent" };
       continue;
     }
@@ -1709,18 +1843,19 @@ async function serviceRegistrationClass(input: {
   readonly executablePath: string;
   readonly dependencies: EnduragentDependencies;
 }): Promise<ServiceRegistrationClass> {
-  if (
-    input.dependencies.serviceRegistrationState !== defaultDependencies.serviceRegistrationState
-  ) {
-    const state = await input.dependencies.serviceRegistrationState!();
-    return state === "present" ? "registered" : state;
-  }
-  return (
-    await input.dependencies.readServiceStatus!({
-      home: input.home,
-      executablePath: input.executablePath,
-    })
-  ).kind;
+  return desktopRegistrationClass(
+    await readDesktopRegistration(
+      {
+        platform: input.dependencies.platform!,
+        home: input.home,
+        executablePath: input.executablePath,
+      },
+      {
+        readServiceStatus: input.dependencies.readServiceStatus!,
+        serviceRegistrationState: customServiceRegistrationState(input.dependencies),
+      },
+    ),
+  );
 }
 
 async function connectAfterEphemeralStart(input: {
@@ -2063,6 +2198,9 @@ async function runServeInvocation(input: {
       if (!(error instanceof CoachStoreWriterError) || error.code !== "writer-lock-held") {
         if (successor !== undefined) await successor.fence.release().catch(() => {});
         throw error;
+      }
+      if (input.invocationOwner === "app-supervised" && input.dependencies.platform === "win32") {
+        return EXIT_SUCCESS;
       }
       let classified: ReadOnlyPeerClassification;
       try {

--- a/packages/coach/tests/desktop-registration.test.ts
+++ b/packages/coach/tests/desktop-registration.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import {
+  UnsupportedLaunchdPlatformError,
+  type LaunchdServiceStatus,
+} from "@enduragent/kernel-node/service";
+import { readDesktopRegistration } from "../src/desktop-registration.js";
+
+const home: AthleteHome = {
+  root: "/tmp/synthetic-athlete",
+  storeDir: "/tmp/synthetic-athlete/store",
+  archiveDir: "/tmp/synthetic-athlete/archive",
+  configDir: "/tmp/synthetic-athlete/config",
+};
+
+const status: LaunchdServiceStatus = {
+  kind: "registered",
+  registered: true,
+  installed: true,
+  loaded: true,
+  running: true,
+  label: "ai.enduragent.coach.synthetic",
+  pid: 91,
+  lastExitStatus: null,
+  paths: {
+    launchAgentsDir: "/tmp/LaunchAgents",
+    plistPath: "/tmp/LaunchAgents/ai.enduragent.coach.synthetic.plist",
+    stateDir: "/tmp/synthetic-athlete/config/service",
+    envPath: "/tmp/synthetic-athlete/config/service/service.env",
+    wrapperPath: "/tmp/synthetic-athlete/config/service/service.sh",
+    handoffPath: "/tmp/synthetic-athlete/config/service/service.handoff",
+  },
+};
+
+describe("desktop registration", () => {
+  it("delegates Darwin observation and preserves the exact launchd result", async () => {
+    const readServiceStatus = vi.fn(async () => status);
+
+    const result = await readDesktopRegistration(
+      { platform: "darwin", home, executablePath: "/tmp/enduragent" },
+      { readServiceStatus },
+    );
+
+    expect(result).toEqual({ source: "launchd", registration: "present", status });
+    if (result.source === "launchd") expect(result.status).toBe(status);
+    expect(readServiceStatus).toHaveBeenCalledOnce();
+    expect(readServiceStatus).toHaveBeenCalledWith({
+      home,
+      executablePath: "/tmp/enduragent",
+    });
+  });
+
+  it("classifies Windows as absent without invoking any launchd-shaped observer", async () => {
+    const readServiceStatus = vi.fn(async () => status);
+    const serviceRegistrationState = vi.fn(async () => "present" as const);
+
+    await expect(
+      readDesktopRegistration(
+        { platform: "win32", home, executablePath: "C:\\Enduragent\\enduragent.exe" },
+        { readServiceStatus, serviceRegistrationState },
+      ),
+    ).resolves.toEqual({ source: "app-supervised", registration: "absent" });
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(serviceRegistrationState).not.toHaveBeenCalled();
+  });
+
+  it("keeps other platforms on the existing launchd observation path", async () => {
+    const failure = new UnsupportedLaunchdPlatformError();
+    const readServiceStatus = vi.fn(async () => {
+      throw failure;
+    });
+
+    await expect(
+      readDesktopRegistration(
+        { platform: "linux", home, executablePath: "/tmp/enduragent" },
+        { readServiceStatus },
+      ),
+    ).rejects.toBe(failure);
+    expect(readServiceStatus).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/coach/tests/desktop-supervisor.test.ts
+++ b/packages/coach/tests/desktop-supervisor.test.ts
@@ -63,8 +63,10 @@ function status(kind: "absent" | "registered"): LaunchdServiceStatus {
 
 function healthy(
   owner: "service-managed" | "unmanaged-foreground" | "app-supervised",
+  pid = 12,
+  port = 45_001,
 ): DaemonStateObservation {
-  const peer = { status: "peer-healthy", pid: 12, port: 45_001, peerVersion: "0.1.0" } as const;
+  const peer = { status: "peer-healthy", pid, port, peerVersion: "0.1.0" } as const;
   const handshake = createAcceptedServerHandshakeFrame(owner, PROTOCOL_VERSION, acceptedBinding());
   return {
     kind: "compatible-healthy",
@@ -77,8 +79,10 @@ function healthy(
 function mismatch(
   owner: "service-managed" | "ephemeral-client-started" | "unmanaged-foreground" | "app-supervised",
   direction: "client-older" | "client-newer",
+  pid = 12,
+  port = 45_001,
 ): DaemonStateObservation {
-  const peer = { status: "peer-healthy", pid: 12, port: 45_001, peerVersion: "0.1.0" } as const;
+  const peer = { status: "peer-healthy", pid, port, peerVersion: "0.1.0" } as const;
   const handshake =
     direction === "client-newer"
       ? createVersionMismatchServerHandshakeFrame(owner, PROTOCOL_VERSION, PROTOCOL_VERSION - 1)
@@ -97,8 +101,14 @@ function dependencies(input: {
   const queue = [...input.observations];
   let now = 0;
   return {
+    platform: "darwin",
     resolveAthleteHome: () => home,
     prepareAthleteHome: async (selectedHome) => selectedHome,
+    createLaunchdServiceIdentity: ({ home: selectedHome, executablePath }) => ({
+      label: "icu.enduragent.synthetic",
+      home: selectedHome,
+      executablePath,
+    }),
     readServiceStatus: async () => status(input.registration),
     resumeService: async () => "resumed",
     observeDaemonState: async () => queue.shift() ?? input.observations.at(-1)!,
@@ -110,7 +120,7 @@ function dependencies(input: {
   };
 }
 
-function child(): AppSupervisedChildHandle & { readonly stop: ReturnType<typeof vi.fn> } {
+function child(pid = 90): AppSupervisedChildHandle & { readonly stop: ReturnType<typeof vi.fn> } {
   let alive = true;
   let resolveExit!: (value: { readonly exitCode: number | null }) => void;
   const exited = new Promise<{ readonly exitCode: number | null }>((resolve) => {
@@ -121,7 +131,18 @@ function child(): AppSupervisedChildHandle & { readonly stop: ReturnType<typeof 
     alive = false;
     resolveExit({ exitCode: 0 });
   });
-  return { pid: 90, exited, isAlive: () => alive, stop };
+  return { pid, exited, isAlive: () => alive, stop };
+}
+
+function exitedChild(
+  pid: number,
+): AppSupervisedChildHandle & { readonly stop: ReturnType<typeof vi.fn> } {
+  return {
+    pid,
+    exited: Promise.resolve({ exitCode: 0 }),
+    isAlive: () => false,
+    stop: vi.fn(async () => {}),
+  };
 }
 
 describe("desktop daemon arbitration", () => {
@@ -231,6 +252,253 @@ describe("desktop daemon arbitration", () => {
     expect(start).toHaveBeenCalledTimes(1);
     if (result.status === "connected") await result.close();
     expect(owned.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the Windows app-supervised path only for the matching live child", async () => {
+    const owned = child(90);
+    const start = vi.fn(async () => owned);
+    const base = dependencies({
+      registration: "registered",
+      observations: [{ kind: "absent" }, healthy("app-supervised", 90)],
+    });
+    const readServiceStatus = vi.fn(base.readServiceStatus);
+    const createLaunchdServiceIdentity = vi.fn(base.createLaunchdServiceIdentity);
+
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        platform: "win32",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: start,
+      },
+      { ...base, platform: "win32", readServiceStatus, createLaunchdServiceIdentity },
+    );
+
+    expect(result).toMatchObject({
+      status: "connected",
+      owner: "app-supervised",
+      supervision: "app-supervised",
+    });
+    expect(start).toHaveBeenCalledOnce();
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(createLaunchdServiceIdentity).not.toHaveBeenCalled();
+    if (result.status === "connected") await result.close();
+    expect(owned.stop).toHaveBeenCalledOnce();
+  });
+
+  it("refuses a healthy Windows daemon that predates the current desktop main", async () => {
+    const start = vi.fn();
+    const base = dependencies({
+      registration: "registered",
+      observations: [healthy("app-supervised", 90)],
+    });
+    const readServiceStatus = vi.fn(base.readServiceStatus);
+    const createLaunchdServiceIdentity = vi.fn(base.createLaunchdServiceIdentity);
+
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        platform: "win32",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: start,
+      },
+      { ...base, platform: "win32", readServiceStatus, createLaunchdServiceIdentity },
+    );
+
+    expect(result).toEqual({
+      status: "refused",
+      exitCode: 3,
+      classification: "contention-family",
+      cause: "contention",
+      retryable: false,
+    });
+    expect(start).not.toHaveBeenCalled();
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(createLaunchdServiceIdentity).not.toHaveBeenCalled();
+  });
+
+  it("refuses a raced Windows daemon and stops only its mismatched child handle", async () => {
+    const owned = child(90);
+    const base = dependencies({
+      registration: "registered",
+      observations: [{ kind: "absent" }, healthy("app-supervised", 91)],
+    });
+    const readServiceStatus = vi.fn(base.readServiceStatus);
+    const createLaunchdServiceIdentity = vi.fn(base.createLaunchdServiceIdentity);
+
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        platform: "win32",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: vi.fn(async () => owned),
+      },
+      { ...base, platform: "win32", readServiceStatus, createLaunchdServiceIdentity },
+    );
+
+    expect(result).toMatchObject({
+      status: "refused",
+      classification: "contention-family",
+      cause: "contention",
+      retryable: false,
+    });
+    expect(owned.stop).toHaveBeenCalledOnce();
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(createLaunchdServiceIdentity).not.toHaveBeenCalled();
+  });
+
+  it("keeps Windows recovery on the app-supervised path without launchd observation", async () => {
+    const budget = { remainingAttempts: 3, deadline: 60_000 };
+    const owned = child(92);
+    const base = dependencies({
+      registration: "registered",
+      observations: [{ kind: "absent" }, healthy("app-supervised", 92)],
+    });
+    const readServiceStatus = vi.fn(base.readServiceStatus);
+    const createLaunchdServiceIdentity = vi.fn(base.createLaunchdServiceIdentity);
+
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        platform: "win32",
+        signal: new AbortController().signal,
+        startBudget: budget,
+        startAppSupervisedDaemon: vi.fn(async () => owned),
+      },
+      { ...base, platform: "win32", readServiceStatus, createLaunchdServiceIdentity },
+    );
+
+    expect(result).toMatchObject({ status: "connected", supervision: "app-supervised" });
+    expect(budget.remainingAttempts).toBe(2);
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(createLaunchdServiceIdentity).not.toHaveBeenCalled();
+    if (result.status === "connected") await result.close();
+  });
+
+  it("routes a Windows second-starter restart to a verified app child without launchd", async () => {
+    const successor = child(93);
+    const start = vi.fn(async () => successor);
+    const base = dependencies({
+      registration: "registered",
+      observations: [
+        mismatch("service-managed", "client-newer"),
+        healthy("app-supervised", 93, 45_002),
+      ],
+    });
+    const readServiceStatus = vi.fn(base.readServiceStatus);
+    const createLaunchdServiceIdentity = vi.fn(base.createLaunchdServiceIdentity);
+    const resolveSecondStarter = vi.fn(async (_input, binding) => {
+      expect(await binding.serviceUpgrade.isInstalled(home)).toBe(false);
+      await binding.serviceUpgrade.restartInstalledService({
+        home,
+        targetProtocolVersion: PROTOCOL_VERSION,
+        handoffCapability: "h".repeat(43),
+      });
+      return {
+        status: "attach" as const,
+        port: 45_002,
+        handshake: createAcceptedServerHandshakeFrame(
+          "app-supervised",
+          PROTOCOL_VERSION,
+          acceptedBinding(),
+        ),
+      };
+    });
+
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        platform: "win32",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: start,
+      },
+      {
+        ...base,
+        platform: "win32",
+        readServiceStatus,
+        createLaunchdServiceIdentity,
+        resolveSecondStarter,
+      },
+    );
+
+    expect(result).toMatchObject({ status: "connected", supervision: "app-supervised" });
+    expect(resolveSecondStarter).toHaveBeenCalledOnce();
+    expect(start).toHaveBeenCalledOnce();
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(createLaunchdServiceIdentity).not.toHaveBeenCalled();
+    if (result.status === "connected") await result.close();
+  });
+
+  it("returns a Windows utility writer race to Electron for owned second-starter arbitration", async () => {
+    const raced = exitedChild(94);
+    const successor = child(95);
+    const start = vi
+      .fn<() => Promise<AppSupervisedChildHandle>>()
+      .mockResolvedValueOnce(raced)
+      .mockResolvedValueOnce(successor);
+    const base = dependencies({
+      registration: "registered",
+      observations: [
+        { kind: "absent" },
+        mismatch("app-supervised", "client-newer", 93, 45_002),
+        mismatch("app-supervised", "client-newer", 93, 45_002),
+        healthy("app-supervised", 95, 45_003),
+      ],
+    });
+    const readServiceStatus = vi.fn(base.readServiceStatus);
+    const createLaunchdServiceIdentity = vi.fn(base.createLaunchdServiceIdentity);
+    const resolveSecondStarter = vi.fn(async (_input, binding) => {
+      await binding.serviceUpgrade.startEphemeralSuccessor({
+        home,
+        targetProtocolVersion: PROTOCOL_VERSION,
+        handoffCapability: "h".repeat(43),
+      });
+      return {
+        status: "attach" as const,
+        port: 45_003,
+        handshake: createAcceptedServerHandshakeFrame(
+          "app-supervised",
+          PROTOCOL_VERSION,
+          acceptedBinding(),
+        ),
+      };
+    });
+
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        platform: "win32",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: start,
+      },
+      {
+        ...base,
+        platform: "win32",
+        readServiceStatus,
+        createLaunchdServiceIdentity,
+        resolveSecondStarter,
+      },
+    );
+
+    expect(result).toMatchObject({ status: "connected", supervision: "app-supervised" });
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(raced.stop).toHaveBeenCalledOnce();
+    expect(resolveSecondStarter).toHaveBeenCalledOnce();
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(createLaunchdServiceIdentity).not.toHaveBeenCalled();
+    if (result.status === "connected") await result.close();
   });
 
   it("refuses a daemon that never publishes after three starts", async () => {

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -10,6 +10,7 @@ import {
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import type { LaunchdServiceStatus } from "@enduragent/kernel-node/service";
 import {
+  createSecondStarterDependencies,
   createServiceUpgradePort,
   decideServiceAwareAutoStart,
   observeDaemonState,
@@ -52,27 +53,6 @@ const home: AthleteHome = {
   configDir: "/tmp/synthetic-athlete/config",
 };
 const rendererCapability = Buffer.alloc(32, 2).toString("base64url");
-
-const paths = {
-  launchAgentsDir: "/tmp/LaunchAgents",
-  plistPath: "/tmp/LaunchAgents/ai.enduragent.coach.synthetic.plist",
-  stateDir: "/tmp/synthetic-athlete/config/service",
-  envPath: "/tmp/synthetic-athlete/config/service/service.env",
-  wrapperPath: "/tmp/synthetic-athlete/config/service/service.sh",
-  handoffPath: "/tmp/synthetic-athlete/config/service/service.handoff",
-};
-
-const registeredStatus: LaunchdServiceStatus = {
-  kind: "registered",
-  registered: true,
-  installed: true,
-  loaded: true,
-  running: false,
-  label: "ai.enduragent.coach.synthetic",
-  pid: null,
-  lastExitStatus: 0,
-  paths,
-};
 
 describe("service-aware arbitration", () => {
   it("implements every registration and peer decision row", () => {
@@ -244,7 +224,7 @@ describe("launchd composition", () => {
     const resumeAfterEphemeral = vi.fn(async () => {});
     const startEphemeral = vi.fn(async () => {});
     const service = createServiceUpgradePort(home, {
-      readStatus: async () => registeredStatus,
+      readRegistration: async () => "registered",
       restartInstalled,
       resumeAfterEphemeral,
       startEphemeral,
@@ -258,22 +238,81 @@ describe("launchd composition", () => {
     expect(startEphemeral).toHaveBeenCalledWith(input);
     await expect(
       createServiceUpgradePort(home, {
-        readStatus: async () => ({
-          ...registeredStatus,
-          kind: "unknown",
-          registered: null,
-          installed: null,
-          loaded: null,
-          running: null,
-          pid: null,
-          lastExitStatus: null,
-          detail: "launchd status unavailable",
-        }),
+        readRegistration: async () => "unknown",
         restartInstalled,
         resumeAfterEphemeral,
         startEphemeral,
       }).isInstalled(home),
     ).rejects.toThrow("service status unavailable");
+  });
+
+  it("keeps Darwin second-starter registration on the launchd observer", async () => {
+    const readServiceStatus = vi.fn(async () => ({ kind: "registered" }) as LaunchdServiceStatus);
+    const serviceRegistrationState = vi.fn(async () => "absent" as const);
+    const createIdentity = vi.fn(({ home: selectedHome, executablePath }) => ({
+      label: "icu.enduragent.synthetic",
+      home: selectedHome,
+      executablePath,
+    }));
+    const binding = createSecondStarterDependencies({
+      home,
+      executablePath: "/tmp/enduragent",
+      dependencies: {
+        resolveAthleteHome: () => home,
+        withLocalCoach: vi.fn(),
+        readPackageVersion: async () => "unused",
+        platform: "darwin",
+        monotonicNow: () => 0,
+        readServiceStatus,
+        serviceRegistrationState,
+        createLaunchdServiceIdentity: createIdentity,
+        startEphemeralSuccessor: vi.fn(async () => {}),
+      },
+    });
+
+    await expect(binding.serviceUpgrade.isInstalled(home)).resolves.toBe(true);
+    expect(createIdentity).toHaveBeenCalledOnce();
+    expect(readServiceStatus).toHaveBeenCalledOnce();
+    expect(serviceRegistrationState).not.toHaveBeenCalled();
+  });
+
+  it("keeps Windows second-starter restart free of every launchd-shaped dependency", async () => {
+    const createIdentity = vi.fn(() => {
+      throw new Error("launchd identity must not be constructed");
+    });
+    const readServiceStatus = vi.fn(async () => {
+      throw new Error("launchd status must not be observed");
+    });
+    const serviceRegistrationState = vi.fn(async () => "present" as const);
+    const startEphemeralSuccessor = vi.fn(async () => {});
+    const binding = createSecondStarterDependencies({
+      home,
+      executablePath: "C:\\Enduragent\\enduragent.exe",
+      dependencies: {
+        resolveAthleteHome: () => home,
+        withLocalCoach: vi.fn(),
+        readPackageVersion: async () => "unused",
+        platform: "win32",
+        monotonicNow: () => 0,
+        readServiceStatus,
+        serviceRegistrationState,
+        createLaunchdServiceIdentity: createIdentity,
+        startEphemeralSuccessor,
+      },
+    });
+    const successor = {
+      home,
+      targetProtocolVersion: PROTOCOL_VERSION,
+      handoffCapability: "h".repeat(43),
+    };
+
+    await expect(binding.serviceUpgrade.isInstalled(home)).resolves.toBe(false);
+    await binding.serviceUpgrade.restartInstalledService(successor);
+    await binding.serviceUpgrade.kickstartInstalledServiceAfterEphemeral(successor);
+    expect(createIdentity).not.toHaveBeenCalled();
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(serviceRegistrationState).not.toHaveBeenCalled();
+    expect(startEphemeralSuccessor).toHaveBeenCalledTimes(2);
   });
 
   it("short-circuits unsupported daemon verbs before resolving home or executable", async () => {
@@ -412,6 +451,62 @@ describe("launchd composition", () => {
     ).resolves.toBe(EXIT_SUCCESS);
     expect(resumeService).toHaveBeenCalledTimes(1);
     expect(startEphemeralDaemon).not.toHaveBeenCalled();
+    expect(io.stdout.read()).toBe("ok\n");
+  });
+
+  it("starts a Windows CLI daemon without observing launchd registration", async () => {
+    const io = terminal();
+    const transport: CoachVerbTransport = {
+      kind: "remote",
+      async request(request) {
+        const envelope = { jsonrpc: "2.0" as const, id: 1, result: { text: "ok" } };
+        request.onTerminalEnvelope(envelope);
+        return envelope;
+      },
+      close: async () => {},
+    };
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new CoachRemoteError({ kind: "unavailable" }))
+      .mockResolvedValueOnce(transport);
+    const readServiceStatus = vi.fn(async () => {
+      throw new Error("launchd must not be observed");
+    });
+    const serviceRegistrationState = vi.fn(async () => "present" as const);
+    const detachAfterHealthy = vi.fn();
+    const startEphemeralDaemon = vi.fn(async () => ({
+      disposeAfterFailedStart: vi.fn(async () => {}),
+      detachAfterHealthy,
+    }));
+
+    await expect(
+      runEnduragent(
+        {
+          argv: ["ask", "hello"],
+          env: {},
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: vi.fn(),
+          readPackageVersion: async () => "unused",
+          connectRemoteTransport: connect,
+          serviceRegistrationState,
+          readServiceStatus,
+          observeDaemonState: async () => ({ kind: "absent" }),
+          resolveExecutablePath: async () => "/tmp/real-enduragent",
+          startEphemeralDaemon,
+          delay: async () => {},
+          monotonicNow: () => 0,
+          platform: "win32",
+        },
+      ),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(serviceRegistrationState).not.toHaveBeenCalled();
+    expect(startEphemeralDaemon).toHaveBeenCalledOnce();
+    expect(detachAfterHealthy).toHaveBeenCalledOnce();
     expect(io.stdout.read()).toBe("ok\n");
   });
 });

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -545,6 +545,64 @@ describe("enduragent executable composition", () => {
     },
   );
 
+  it("returns a Windows app-supervised writer race to Electron without launching a successor", async () => {
+    const io = terminal();
+    const contention = new CoachStoreWriterError("writer-lock-held", null, undefined, {
+      kind: "holder",
+      pid: 42,
+      port: 43_101,
+    });
+    const resolveSecondStarter = vi.fn(
+      async () =>
+        ({
+          status: "refuse",
+          exitCode: 3,
+          stdout: "",
+          stderr: "",
+        }) as const,
+    );
+    const createLaunchdServiceIdentity = vi.fn(() => {
+      throw new Error("launchd identity must not be constructed");
+    });
+    const readServiceStatus = vi.fn(async () => {
+      throw new Error("launchd status must not be observed");
+    });
+    const serviceRegistrationState = vi.fn(async () => "present" as const);
+    const startEphemeralSuccessor = vi.fn(async () => {});
+
+    await expect(
+      runAppSupervisedEnduragent(
+        {
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+          appVersion: "2026.8.0",
+        },
+        {
+          resolveAthleteHome: () => home,
+          prepareAthleteHome: async (selectedHome) => selectedHome,
+          withLocalCoach: async () => {
+            throw contention;
+          },
+          readPackageVersion: async () => "unused",
+          platform: "win32",
+          resolveSecondStarter,
+          createLaunchdServiceIdentity,
+          readServiceStatus,
+          serviceRegistrationState,
+          startEphemeralSuccessor,
+        },
+      ),
+    ).resolves.toEqual({ exitCode: EXIT_SUCCESS });
+    expect(resolveSecondStarter).not.toHaveBeenCalled();
+    expect(createLaunchdServiceIdentity).not.toHaveBeenCalled();
+    expect(readServiceStatus).not.toHaveBeenCalled();
+    expect(serviceRegistrationState).not.toHaveBeenCalled();
+    expect(startEphemeralSuccessor).not.toHaveBeenCalled();
+    expect(io.stdout.read()).toBe("");
+    expect(io.stderr.read()).toBe("");
+  });
+
   it("preserves FIFO and lifecycle close ordering after physical EOF", async () => {
     const trace: string[] = [];
     const first = deferred<{ text: string }>();


### PR DESCRIPTION
Routes every daemon service-status observation through a new platform-neutral registration seam so Windows bypasses launchd entirely and reaches the app-supervised daemon path, while macOS behavior stays byte-identical.

- New packages/coach/src/desktop-registration.ts: readDesktopRegistration classifies registration per platform — win32 returns app-supervised/absent without ever touching launchd-shaped observers; an injected override returns source "override"; darwin and other platforms delegate to the existing observation unchanged, preserving the exact status object.
- packages/coach/src/enduragent.ts consumes the seam everywhere it previously read launchd status directly: upgrade-binding readStatus becomes registration-driven with unchanged error strings; second-starter and desktop bindings construct a launchd identity only when the registration source is launchd, routing restart and resume paths to the app-supervised successor starter on win32; the athlete-home canonicalization is inlined byte-equivalently so coach no longer imports it from the launchd module.
- Safe Windows daemon ownership: on win32 a compatible healthy daemon connects only when a live child handle exists, its pid matches the observed peer, and the handshake owner is app-supervised. Observation-only healthy daemons, daemons predating the current Electron main, and raced children are refused — never adopted — as a non-retryable refusal; the app-supervised writer race returns to Electron instead of launching a successor.
- apps/desktop supervisor re-verifies ownership on every resolution under win32 and closes/refuses otherwise; startup and lifecycle-recovery refusals emit the constant, path-free stage code "desktop-daemon-ownership-refusal unowned" with stop-and-reopen guidance.
- Out of scope by design: upgrade-fence transport (next package) and termination semantics (the one after); both untouched.
- Tests: new registration-seam suite (darwin delegation preserving the exact status object, win32 absent classification without invoking observers, passthrough incl. error identity) plus win32 ownership-gate coverage across coach and desktop suites — live-child connect, predating-daemon refusal, raced-child refusal, launchd-free recovery/second-starter/restart paths, writer-race return, and a stage-code guard asserting no interpolation. Adjusted assertions only swap status fixtures for equivalent registration classes.
- Changeset: patch bump for the desktop package without a release-notes line (internal behavior, not athlete-visible).

Verification: coach tests 61 files / 711 tests green (repo-root cwd); desktop tsc clean; desktop suite 82 files / 1572 tests green; macOS package:dir and Windows package:win-dir regressions both green; repo-root pnpm check clean. Zero fix rounds were needed.