### PR TITLE
feat(coach): add windows upgrade-fence transport

### DIFF
--- a/packages/coach/src/daemon/upgrade-fence-protocol.ts
+++ b/packages/coach/src/daemon/upgrade-fence-protocol.ts
@@ -1,0 +1,160 @@
+import type { Socket } from "node:net";
+import { performance } from "node:perf_hooks";
+import { TextDecoder } from "node:util";
+import { EXIT_DAEMON_UNAVAILABLE } from "@enduragent/coach-contract";
+
+export const HANDOFF_CAPABILITY_BYTES = 32 as const;
+export const UPGRADE_FENCE_FRAME_MAX_BYTES = 4_096 as const;
+export const UPGRADE_FENCE_IO_TIMEOUT_MS = 5_000 as const;
+export const HANDOFF_RESERVED_MESSAGE =
+  "Enduragent cannot start: an authenticated upgrade handoff already reserves this athlete home.\n";
+
+export interface ScheduledMonotonicTimer {
+  cancel(): void;
+}
+
+export interface MonotonicTimer {
+  nowMs(): number;
+  schedule(delayMs: number, callback: () => void): ScheduledMonotonicTimer;
+}
+
+export type UpgradeFenceAdmission =
+  | { readonly status: "clear" }
+  | { readonly status: "designated" }
+  | {
+      readonly status: "reserved";
+      readonly exitCode: 3;
+      readonly message: typeof HANDOFF_RESERVED_MESSAGE;
+    };
+
+export interface UpgradeFenceHandle {
+  readonly socketPath: string;
+  readonly handoffCapability: string;
+  release(): Promise<void>;
+}
+
+export interface AcquireUpgradeFenceInput {
+  readonly configDir: string;
+  readonly randomBytes?: (size: number) => Buffer;
+  readonly timer?: MonotonicTimer;
+  readonly platform?: NodeJS.Platform;
+}
+
+export type AcquireUpgradeFenceResult =
+  | { readonly status: "acquired"; readonly handle: UpgradeFenceHandle }
+  | {
+      readonly status: "reserved";
+      readonly exitCode: 3;
+      readonly message: typeof HANDOFF_RESERVED_MESSAGE;
+    };
+
+const decoder = new TextDecoder("utf-8", { fatal: true });
+
+function productionTimer(): MonotonicTimer {
+  return {
+    nowMs: () => performance.now(),
+    schedule(delayMs, callback) {
+      const handle = setTimeout(callback, Math.max(0, delayMs));
+      handle.unref?.();
+      return { cancel: () => clearTimeout(handle) };
+    },
+  };
+}
+
+function reserved(): Extract<UpgradeFenceAdmission, { status: "reserved" }> {
+  return {
+    status: "reserved",
+    exitCode: EXIT_DAEMON_UNAVAILABLE,
+    message: HANDOFF_RESERVED_MESSAGE,
+  };
+}
+
+function readFrame(socket: Socket, timer: MonotonicTimer): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let bytes = Buffer.alloc(0);
+    let settled = false;
+    const deadline = timer.schedule(UPGRADE_FENCE_IO_TIMEOUT_MS, () => finish(new Error("timeout")));
+    const cleanup = (): void => {
+      deadline.cancel();
+      socket.off("data", onData);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+    };
+    const finish = (error?: Error, value?: string): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error === undefined) resolve(value!);
+      else reject(error);
+    };
+    const onError = (): void => finish(new Error("io"));
+    const onClose = (): void => finish(new Error("closed"));
+    const onData = (chunk: Buffer): void => {
+      bytes = Buffer.concat([bytes, chunk]);
+      if (bytes.length > UPGRADE_FENCE_FRAME_MAX_BYTES) {
+        finish(new Error("oversized"));
+        return;
+      }
+      const newline = bytes.indexOf(0x0a);
+      if (newline === -1) return;
+      if (newline !== bytes.length - 1 || bytes.indexOf(0x0a, newline + 1) !== -1) {
+        finish(new Error("trailing"));
+        return;
+      }
+      try {
+        finish(undefined, decoder.decode(bytes.subarray(0, -1)));
+      } catch {
+        finish(new Error("encoding"));
+      }
+    };
+    socket.on("data", onData);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+  });
+}
+
+function canonicalCapability(value: unknown): Buffer | undefined {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(value)) return undefined;
+  const decoded = Buffer.from(value, "base64url");
+  if (
+    decoded.length !== HANDOFF_CAPABILITY_BYTES
+    || decoded.toString("base64url") !== value
+  ) {
+    return undefined;
+  }
+  return decoded;
+}
+
+function strictRequest(value: unknown):
+  | { readonly kind: "ordinary-starter" }
+  | { readonly kind: "designated-successor"; readonly handoffCapability: string }
+  | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (keys.length === 1 && keys[0] === "kind" && record.kind === "ordinary-starter") {
+    return { kind: "ordinary-starter" };
+  }
+  if (
+    keys.length === 2
+    && keys[0] === "handoffCapability"
+    && keys[1] === "kind"
+    && record.kind === "designated-successor"
+    && typeof record.handoffCapability === "string"
+  ) {
+    return { kind: "designated-successor", handoffCapability: record.handoffCapability };
+  }
+  return undefined;
+}
+
+function strictResponse(value: unknown): "reserved" | "designated" | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  return keys.length === 1 && keys[0] === "status"
+    && (record.status === "reserved" || record.status === "designated")
+    ? record.status
+    : undefined;
+}
+
+export { canonicalCapability, productionTimer, readFrame, reserved, strictRequest, strictResponse };

--- a/packages/coach/src/daemon/upgrade-fence.ts
+++ b/packages/coach/src/daemon/upgrade-fence.ts
@@ -2,81 +2,46 @@ import { randomBytes as cryptoRandomBytes, timingSafeEqual } from "node:crypto";
 import { chmod, link, lstat, mkdir, mkdtemp, rename, rmdir, unlink } from "node:fs/promises";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
 import { join } from "node:path";
-import { performance } from "node:perf_hooks";
-import { TextDecoder } from "node:util";
-import { EXIT_DAEMON_UNAVAILABLE } from "@enduragent/coach-contract";
+import {
+  HANDOFF_CAPABILITY_BYTES,
+  canonicalCapability,
+  productionTimer,
+  readFrame,
+  reserved,
+  strictRequest,
+  strictResponse,
+  type AcquireUpgradeFenceInput,
+  type AcquireUpgradeFenceResult,
+  type MonotonicTimer,
+  type UpgradeFenceAdmission,
+} from "./upgrade-fence-protocol.js";
+import {
+  acquireWindowsUpgradeFence,
+  admitStartupThroughWindowsUpgradeFence,
+} from "./windows-upgrade-fence.js";
 
 export const UPGRADE_FENCE_SOCKET_NAME = "upgrade.sock" as const;
-export const HANDOFF_CAPABILITY_BYTES = 32 as const;
-export const UPGRADE_FENCE_FRAME_MAX_BYTES = 4_096 as const;
-export const UPGRADE_FENCE_IO_TIMEOUT_MS = 5_000 as const;
-export const HANDOFF_RESERVED_MESSAGE =
-  "Enduragent cannot start: an authenticated upgrade handoff already reserves this athlete home.\n";
-
-export interface ScheduledMonotonicTimer {
-  cancel(): void;
-}
-
-export interface MonotonicTimer {
-  nowMs(): number;
-  schedule(delayMs: number, callback: () => void): ScheduledMonotonicTimer;
-}
-
-export type UpgradeFenceAdmission =
-  | { readonly status: "clear" }
-  | { readonly status: "designated" }
-  | {
-      readonly status: "reserved";
-      readonly exitCode: 3;
-      readonly message: typeof HANDOFF_RESERVED_MESSAGE;
-    };
-
-export interface UpgradeFenceHandle {
-  readonly socketPath: string;
-  readonly handoffCapability: string;
-  release(): Promise<void>;
-}
-
-export interface AcquireUpgradeFenceInput {
-  readonly configDir: string;
-  readonly randomBytes?: (size: number) => Buffer;
-  readonly timer?: MonotonicTimer;
-}
-
-export type AcquireUpgradeFenceResult =
-  | { readonly status: "acquired"; readonly handle: UpgradeFenceHandle }
-  | {
-      readonly status: "reserved";
-      readonly exitCode: 3;
-      readonly message: typeof HANDOFF_RESERVED_MESSAGE;
-    };
+export {
+  HANDOFF_CAPABILITY_BYTES,
+  HANDOFF_RESERVED_MESSAGE,
+  UPGRADE_FENCE_FRAME_MAX_BYTES,
+  UPGRADE_FENCE_IO_TIMEOUT_MS,
+} from "./upgrade-fence-protocol.js";
+export type {
+  AcquireUpgradeFenceInput,
+  AcquireUpgradeFenceResult,
+  MonotonicTimer,
+  ScheduledMonotonicTimer,
+  UpgradeFenceAdmission,
+  UpgradeFenceHandle,
+} from "./upgrade-fence-protocol.js";
 
 interface FileIdentity {
   readonly dev: number;
   readonly ino: number;
 }
 
-const decoder = new TextDecoder("utf-8", { fatal: true });
 let staleSequence = 0;
-
-function productionTimer(): MonotonicTimer {
-  return {
-    nowMs: () => performance.now(),
-    schedule(delayMs, callback) {
-      const handle = setTimeout(callback, Math.max(0, delayMs));
-      handle.unref?.();
-      return { cancel: () => clearTimeout(handle) };
-    },
-  };
-}
-
-function reserved(): Extract<UpgradeFenceAdmission, { status: "reserved" }> {
-  return {
-    status: "reserved",
-    exitCode: EXIT_DAEMON_UNAVAILABLE,
-    message: HANDOFF_RESERVED_MESSAGE,
-  };
-}
 
 async function identity(path: string): Promise<FileIdentity | undefined> {
   try {
@@ -113,94 +78,6 @@ async function reclaimStaleSocket(path: string, expected: FileIdentity): Promise
   }
   await unlinkIdentity(stalePath, expected);
   return true;
-}
-
-function readFrame(socket: Socket, timer: MonotonicTimer): Promise<string> {
-  return new Promise((resolve, reject) => {
-    let bytes = Buffer.alloc(0);
-    let settled = false;
-    const deadline = timer.schedule(UPGRADE_FENCE_IO_TIMEOUT_MS, () => finish(new Error("timeout")));
-    const cleanup = (): void => {
-      deadline.cancel();
-      socket.off("data", onData);
-      socket.off("error", onError);
-      socket.off("close", onClose);
-    };
-    const finish = (error?: Error, value?: string): void => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      if (error === undefined) resolve(value!);
-      else reject(error);
-    };
-    const onError = (): void => finish(new Error("io"));
-    const onClose = (): void => finish(new Error("closed"));
-    const onData = (chunk: Buffer): void => {
-      bytes = Buffer.concat([bytes, chunk]);
-      if (bytes.length > UPGRADE_FENCE_FRAME_MAX_BYTES) {
-        finish(new Error("oversized"));
-        return;
-      }
-      const newline = bytes.indexOf(0x0a);
-      if (newline === -1) return;
-      if (newline !== bytes.length - 1 || bytes.indexOf(0x0a, newline + 1) !== -1) {
-        finish(new Error("trailing"));
-        return;
-      }
-      try {
-        finish(undefined, decoder.decode(bytes.subarray(0, -1)));
-      } catch {
-        finish(new Error("encoding"));
-      }
-    };
-    socket.on("data", onData);
-    socket.once("error", onError);
-    socket.once("close", onClose);
-  });
-}
-
-function canonicalCapability(value: unknown): Buffer | undefined {
-  if (typeof value !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(value)) return undefined;
-  const decoded = Buffer.from(value, "base64url");
-  if (
-    decoded.length !== HANDOFF_CAPABILITY_BYTES
-    || decoded.toString("base64url") !== value
-  ) {
-    return undefined;
-  }
-  return decoded;
-}
-
-function strictRequest(value: unknown):
-  | { readonly kind: "ordinary-starter" }
-  | { readonly kind: "designated-successor"; readonly handoffCapability: string }
-  | undefined {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
-  const record = value as Record<string, unknown>;
-  const keys = Object.keys(record).sort();
-  if (keys.length === 1 && keys[0] === "kind" && record.kind === "ordinary-starter") {
-    return { kind: "ordinary-starter" };
-  }
-  if (
-    keys.length === 2
-    && keys[0] === "handoffCapability"
-    && keys[1] === "kind"
-    && record.kind === "designated-successor"
-    && typeof record.handoffCapability === "string"
-  ) {
-    return { kind: "designated-successor", handoffCapability: record.handoffCapability };
-  }
-  return undefined;
-}
-
-function strictResponse(value: unknown): "reserved" | "designated" | undefined {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
-  const record = value as Record<string, unknown>;
-  const keys = Object.keys(record);
-  return keys.length === 1 && keys[0] === "status"
-    && (record.status === "reserved" || record.status === "designated")
-    ? record.status
-    : undefined;
 }
 
 function listen(server: Server, socketPath: string): Promise<void> {
@@ -248,6 +125,7 @@ async function ensureConfigDir(configDir: string): Promise<void> {
 export async function acquireUpgradeFence(
   input: AcquireUpgradeFenceInput,
 ): Promise<AcquireUpgradeFenceResult> {
+  if ((input.platform ?? process.platform) === "win32") return acquireWindowsUpgradeFence(input);
   await ensureConfigDir(input.configDir);
   const socketPath = join(input.configDir, UPGRADE_FENCE_SOCKET_NAME);
   const timer = input.timer ?? productionTimer();
@@ -373,7 +251,9 @@ export async function admitStartupThroughUpgradeFence(input: {
   readonly configDir: string;
   readonly handoffCapability?: string;
   readonly timer?: MonotonicTimer;
+  readonly platform?: NodeJS.Platform;
 }): Promise<UpgradeFenceAdmission> {
+  if ((input.platform ?? process.platform) === "win32") return admitStartupThroughWindowsUpgradeFence(input);
   await ensureConfigDir(input.configDir);
   const socketPath = join(input.configDir, UPGRADE_FENCE_SOCKET_NAME);
   const timer = input.timer ?? productionTimer();

--- a/packages/coach/src/daemon/windows-upgrade-fence.ts
+++ b/packages/coach/src/daemon/windows-upgrade-fence.ts
@@ -1,0 +1,446 @@
+import { randomBytes as cryptoRandomBytes, timingSafeEqual } from "node:crypto";
+import { chmod, link, lstat, mkdir, readFile, rename, unlink } from "node:fs/promises";
+import {
+  createConnection,
+  createServer,
+  type AddressInfo,
+  type Server,
+  type Socket,
+} from "node:net";
+import { join } from "node:path";
+import { writeTempThenPublish } from "@enduragent/kernel-node/lock";
+import {
+  HANDOFF_CAPABILITY_BYTES,
+  UPGRADE_FENCE_IO_TIMEOUT_MS,
+  canonicalCapability,
+  productionTimer,
+  readFrame,
+  reserved,
+  strictRequest,
+  type AcquireUpgradeFenceInput,
+  type AcquireUpgradeFenceResult,
+  type MonotonicTimer,
+  type UpgradeFenceAdmission,
+} from "./upgrade-fence-protocol.js";
+
+export const WINDOWS_UPGRADE_FENCE_CLAIM_NAME = "upgrade.fence" as const;
+
+interface FileIdentity {
+  readonly dev: number;
+  readonly ino: number;
+}
+
+interface WindowsUpgradeFenceClaim {
+  readonly fence: string;
+  readonly port: number;
+}
+
+type ClaimRead =
+  | { readonly kind: "absent" }
+  | { readonly kind: "unreadable" }
+  | {
+      readonly kind: "readable";
+      readonly claim: WindowsUpgradeFenceClaim;
+      readonly identity: FileIdentity;
+    };
+
+type ProbeResult =
+  | { readonly kind: "response"; readonly status: "reserved" | "designated" }
+  | { readonly kind: "connection-refused" }
+  | { readonly kind: "echo-invalid" }
+  | { readonly kind: "other-error" };
+
+let staleSequence = 0;
+
+function isErrorCode(error: unknown, codes: readonly string[]): boolean {
+  return codes.includes((error as NodeJS.ErrnoException).code ?? "");
+}
+
+async function ensureConfigDir(configDir: string): Promise<void> {
+  try {
+    await mkdir(configDir, { recursive: true, mode: 0o700 });
+    await chmod(configDir, 0o700);
+  } catch {
+    throw new Error("upgrade fence config directory unavailable");
+  }
+}
+
+async function identity(path: string): Promise<FileIdentity | undefined> {
+  try {
+    const metadata = await lstat(path);
+    return { dev: metadata.dev, ino: metadata.ino };
+  } catch (error) {
+    if (isErrorCode(error, ["ENOENT"])) return undefined;
+    throw error;
+  }
+}
+
+function sameIdentity(left: FileIdentity | undefined, right: FileIdentity): boolean {
+  return left?.dev === right.dev && left.ino === right.ino;
+}
+
+async function unlinkIdentity(path: string, expected: FileIdentity): Promise<boolean> {
+  let observed: FileIdentity | undefined;
+  try {
+    observed = await identity(path);
+  } catch (error) {
+    if (isErrorCode(error, ["EPERM", "EBUSY", "EACCES"])) return false;
+    throw new Error("upgrade fence claim identity unavailable");
+  }
+  if (!sameIdentity(observed, expected)) return false;
+  try {
+    await unlink(path);
+    return true;
+  } catch (error) {
+    if (isErrorCode(error, ["ENOENT"])) return true;
+    if (isErrorCode(error, ["EPERM", "EBUSY", "EACCES"])) return false;
+    throw new Error("upgrade fence claim unlink failed");
+  }
+}
+
+async function reclaimStaleClaim(path: string, expected: FileIdentity): Promise<boolean> {
+  let observed: FileIdentity | undefined;
+  try {
+    observed = await identity(path);
+  } catch (error) {
+    if (isErrorCode(error, ["EPERM", "EBUSY", "EACCES"])) return false;
+    throw new Error("upgrade fence claim identity unavailable");
+  }
+  if (!sameIdentity(observed, expected)) return false;
+  staleSequence += 1;
+  const stalePath = `${path}.stale.${process.pid}.${staleSequence}`;
+  try {
+    await rename(path, stalePath);
+  } catch (error) {
+    if (isErrorCode(error, ["ENOENT", "EEXIST", "EPERM", "EBUSY", "EACCES"])) return false;
+    throw new Error("upgrade fence claim reclaim failed");
+  }
+  return unlinkIdentity(stalePath, expected);
+}
+
+function strictClaim(value: unknown): WindowsUpgradeFenceClaim | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (keys.length !== 2 || keys[0] !== "fence" || keys[1] !== "port") return undefined;
+  if (typeof record.fence !== "string" || !/^[A-Za-z0-9_-]{22}$/.test(record.fence)) {
+    return undefined;
+  }
+  const decodedFence = Buffer.from(record.fence, "base64url");
+  if (decodedFence.length !== 16 || decodedFence.toString("base64url") !== record.fence) {
+    return undefined;
+  }
+  if (
+    !Number.isInteger(record.port) ||
+    (record.port as number) < 1 ||
+    (record.port as number) > 65_535
+  ) {
+    return undefined;
+  }
+  return { fence: record.fence, port: record.port as number };
+}
+
+async function readClaim(path: string): Promise<ClaimRead> {
+  let before: FileIdentity | undefined;
+  try {
+    before = await identity(path);
+  } catch {
+    return { kind: "unreadable" };
+  }
+  if (before === undefined) return { kind: "absent" };
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return { kind: "unreadable" };
+  }
+  let after: FileIdentity | undefined;
+  try {
+    after = await identity(path);
+  } catch {
+    return { kind: "unreadable" };
+  }
+  if (!sameIdentity(after, before)) return { kind: "unreadable" };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { kind: "unreadable" };
+  }
+  const claim = strictClaim(parsed);
+  return claim === undefined
+    ? { kind: "unreadable" }
+    : { kind: "readable", claim, identity: before };
+}
+
+function windowsStrictResponse(
+  value: unknown,
+  expectedFence: string,
+): "reserved" | "designated" | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  return keys.length === 2 &&
+    keys[0] === "fence" &&
+    keys[1] === "status" &&
+    record.fence === expectedFence &&
+    (record.status === "reserved" || record.status === "designated")
+    ? record.status
+    : undefined;
+}
+
+function waitForConnection(socket: Socket, timer: MonotonicTimer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const deadline = timer.schedule(UPGRADE_FENCE_IO_TIMEOUT_MS, () =>
+      finish(new Error("upgrade fence connection timeout")),
+    );
+    const cleanup = (): void => {
+      deadline.cancel();
+      socket.off("connect", onConnect);
+      socket.off("error", onError);
+    };
+    const finish = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error === undefined) resolve();
+      else reject(error);
+    };
+    const onConnect = (): void => finish();
+    const onError = (error: Error): void => finish(error);
+    socket.once("connect", onConnect);
+    socket.once("error", onError);
+  });
+}
+
+async function requestAdmission(
+  claim: WindowsUpgradeFenceClaim,
+  request:
+    | { readonly kind: "ordinary-starter" }
+    | { readonly kind: "designated-successor"; readonly handoffCapability: string },
+  timer: MonotonicTimer,
+): Promise<ProbeResult> {
+  const socket = createConnection({ host: "127.0.0.1", port: claim.port });
+  try {
+    try {
+      await waitForConnection(socket, timer);
+    } catch (error) {
+      return isErrorCode(error, ["ECONNREFUSED"])
+        ? { kind: "connection-refused" }
+        : { kind: "other-error" };
+    }
+    let raw: string;
+    try {
+      const response = readFrame(socket, timer);
+      socket.end(`${JSON.stringify(request)}\n`);
+      raw = await response;
+    } catch {
+      return { kind: "other-error" };
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { kind: "echo-invalid" };
+    }
+    const status = windowsStrictResponse(parsed, claim.fence);
+    return status === undefined ? { kind: "echo-invalid" } : { kind: "response", status };
+  } finally {
+    socket.destroy();
+  }
+}
+
+function createFenceServer(
+  fence: string,
+  capabilityBytes: Buffer,
+  timer: MonotonicTimer,
+): { readonly server: Server; readonly sockets: Set<Socket> } {
+  let consumed = false;
+  const sockets = new Set<Socket>();
+  const server = createServer({ allowHalfOpen: true }, (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+    socket.once("error", () => socket.destroy());
+    void readFrame(socket, timer)
+      .then((raw) => {
+        let request: ReturnType<typeof strictRequest>;
+        try {
+          request = strictRequest(JSON.parse(raw));
+        } catch {
+          request = undefined;
+        }
+        let status: "reserved" | "designated" = "reserved";
+        if (request?.kind === "designated-successor" && !consumed) {
+          const received = canonicalCapability(request.handoffCapability);
+          const matches =
+            received !== undefined &&
+            received.length === capabilityBytes.length &&
+            timingSafeEqual(received, capabilityBytes);
+          received?.fill(0);
+          if (matches) {
+            consumed = true;
+            status = "designated";
+          }
+        }
+        socket.end(`${JSON.stringify({ fence, status })}\n`);
+      })
+      .catch(() => socket.end(`${JSON.stringify({ fence, status: "reserved" })}\n`));
+  });
+  return { server, sockets };
+}
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const onError = (): void => reject(new Error("upgrade fence listener unavailable"));
+    server.once("error", onError);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("upgrade fence listener unavailable"));
+        return;
+      }
+      resolve((address as AddressInfo).port);
+    });
+  });
+}
+
+function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
+  for (const socket of sockets) socket.destroy();
+  return new Promise((resolve) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close(() => resolve());
+  });
+}
+
+export async function acquireWindowsUpgradeFence(
+  input: AcquireUpgradeFenceInput,
+): Promise<AcquireUpgradeFenceResult> {
+  await ensureConfigDir(input.configDir);
+  const claimPath = join(input.configDir, WINDOWS_UPGRADE_FENCE_CLAIM_NAME);
+  const timer = input.timer ?? productionTimer();
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const capabilityBytes = Buffer.from(
+      (input.randomBytes ?? cryptoRandomBytes)(HANDOFF_CAPABILITY_BYTES),
+    );
+    if (capabilityBytes.length !== HANDOFF_CAPABILITY_BYTES) {
+      throw new Error("upgrade fence capability generation failed");
+    }
+    let retained = false;
+    let server: Server | undefined;
+    let sockets: Set<Socket> | undefined;
+    let closePromise: Promise<void> | undefined;
+    const close = (): Promise<void> => {
+      if (server === undefined || sockets === undefined) return Promise.resolve();
+      closePromise ??= closeServer(server, sockets);
+      return closePromise;
+    };
+    try {
+      const fence = cryptoRandomBytes(16).toString("base64url");
+      ({ server, sockets } = createFenceServer(fence, capabilityBytes, timer));
+      const port = await listen(server);
+      try {
+        await writeTempThenPublish(
+          claimPath,
+          `${JSON.stringify({ fence, port })}\n`,
+          (tempPath: string, targetPath: string) => link(tempPath, targetPath),
+        );
+      } catch (error) {
+        await close();
+        if (!isErrorCode(error, ["EEXIST"])) {
+          throw new Error("upgrade fence claim publication failed");
+        }
+        const other = await readClaim(claimPath);
+        if (other.kind === "absent") continue;
+        if (other.kind === "unreadable") return reserved();
+        const probe = await requestAdmission(other.claim, { kind: "ordinary-starter" }, timer);
+        if (probe.kind === "response") return reserved();
+        if (probe.kind !== "connection-refused" && probe.kind !== "echo-invalid") {
+          return reserved();
+        }
+        try {
+          if (!(await reclaimStaleClaim(claimPath, other.identity))) return reserved();
+        } catch {
+          return reserved();
+        }
+        continue;
+      }
+      let ownedIdentity: FileIdentity | undefined;
+      try {
+        ownedIdentity = await identity(claimPath);
+      } catch {
+        throw new Error("upgrade fence claim identity unavailable");
+      }
+      if (ownedIdentity === undefined) {
+        throw new Error("upgrade fence claim identity unavailable");
+      }
+      const handoffCapability = capabilityBytes.toString("base64url");
+      let releasePromise: Promise<void> | undefined;
+      retained = true;
+      return {
+        status: "acquired",
+        handle: {
+          socketPath: claimPath,
+          handoffCapability,
+          release() {
+            releasePromise ??= (async () => {
+              try {
+                await close();
+                await unlinkIdentity(claimPath, ownedIdentity);
+              } finally {
+                capabilityBytes.fill(0);
+              }
+            })();
+            return releasePromise;
+          },
+        },
+      };
+    } finally {
+      if (!retained) {
+        await close();
+        capabilityBytes.fill(0);
+      }
+    }
+  }
+  return reserved();
+}
+
+export async function admitStartupThroughWindowsUpgradeFence(input: {
+  readonly configDir: string;
+  readonly handoffCapability?: string;
+  readonly timer?: MonotonicTimer;
+  readonly platform?: NodeJS.Platform;
+}): Promise<UpgradeFenceAdmission> {
+  await ensureConfigDir(input.configDir);
+  const claimPath = join(input.configDir, WINDOWS_UPGRADE_FENCE_CLAIM_NAME);
+  const timer = input.timer ?? productionTimer();
+  const request =
+    input.handoffCapability === undefined
+      ? { kind: "ordinary-starter" as const }
+      : {
+          kind: "designated-successor" as const,
+          handoffCapability: input.handoffCapability,
+        };
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const other = await readClaim(claimPath);
+    if (other.kind === "absent") return { status: "clear" };
+    if (other.kind === "unreadable") return reserved();
+    const probe = await requestAdmission(other.claim, request, timer);
+    if (probe.kind === "response") {
+      return probe.status === "designated" ? { status: "designated" } : reserved();
+    }
+    if (probe.kind !== "connection-refused" && probe.kind !== "echo-invalid") {
+      return reserved();
+    }
+    try {
+      if (!(await reclaimStaleClaim(claimPath, other.identity))) return reserved();
+    } catch {
+      return reserved();
+    }
+  }
+  return reserved();
+}

--- a/packages/coach/tests/daemon-handoff-windows.integration.test.ts
+++ b/packages/coach/tests/daemon-handoff-windows.integration.test.ts
@@ -1,0 +1,187 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { HANDOFF_RESERVED_MESSAGE } from "../src/daemon/handshake.js";
+
+const fixture = fileURLToPath(new URL("./fixtures/daemon-process.ts", import.meta.url));
+const roots: string[] = [];
+const children = new Set<ChildProcess>();
+
+afterEach(async () => {
+  const active = [...children];
+  const exits = active.map((child) =>
+    child.exitCode !== null || child.signalCode !== null
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => child.once("exit", () => resolve())),
+  );
+  for (const child of active) child.kill("SIGKILL");
+  await Promise.all(exits);
+  children.clear();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function syntheticHome(): Promise<AthleteHome> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "daemon-handoff-windows-"));
+  roots.push(root);
+  return {
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  };
+}
+
+function spawn(role: string, home: AthleteHome): ChildProcess {
+  const env = { ...process.env };
+  delete env.FORCE_COLOR;
+  delete env.CLICOLOR_FORCE;
+  for (const name of [
+    "HOME",
+    "ENDURAGENT_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "TMPDIR",
+    "UV_CACHE_DIR",
+  ]) {
+    env[name] = home.root;
+  }
+  const child = fork(fixture, [role], {
+    execArgv: ["--import", "tsx"],
+    env,
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  children.add(child);
+  child.once("exit", () => children.delete(child));
+  return child;
+}
+
+function nextMessage<T>(child: ChildProcess, type: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (value: unknown): void => {
+      const record = value as { readonly type?: unknown };
+      if (record.type === "error") {
+        cleanup();
+        reject(new Error("fixture failed"));
+      } else if (record.type === type) {
+        cleanup();
+        resolve(value as T);
+      }
+    };
+    const onExit = (code: number | null): void => {
+      cleanup();
+      reject(new Error(`fixture exited before ${type}: ${code}`));
+    };
+    const cleanup = (): void => {
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    };
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+  });
+}
+
+function send(child: ChildProcess, value: Parameters<ChildProcess["send"]>[0]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    child.send(value, (error) => (error === null ? resolve() : reject(error)));
+  });
+}
+
+function exited(child: ChildProcess): Promise<void> {
+  return child.exitCode !== null || child.signalCode !== null
+    ? Promise.resolve()
+    : new Promise((resolve) => child.once("exit", () => resolve()));
+}
+
+describe("real successor-held Windows handoff fence", () => {
+  it("reserves every third starter, consumes one capability, coalesces controllers, and crash-releases", async () => {
+    const home = await syntheticHome();
+    const events: Array<{ readonly name: string; readonly at: number }> = [];
+    const holder = spawn("fence-holder", home);
+    const holderReady = nextMessage<{
+      readonly result: {
+        readonly status: "acquired";
+        readonly handoffCapability: string;
+      };
+    }>(holder, "fence");
+    await send(holder, { type: "start", home, platform: "win32" });
+    const fence = await holderReady;
+    events.push({ name: "fence-acquired", at: performance.now() });
+
+    const ordinary = spawn("fence-admit", home);
+    const ordinaryResult = nextMessage<{
+      readonly result: {
+        readonly status: string;
+        readonly exitCode: number;
+        readonly message: string;
+      };
+    }>(ordinary, "admission");
+    await send(ordinary, { type: "start", home, platform: "win32" });
+    await expect(ordinaryResult).resolves.toMatchObject({
+      result: {
+        status: "reserved",
+        exitCode: 3,
+        message: HANDOFF_RESERVED_MESSAGE,
+      },
+    });
+
+    const designated = spawn("fence-admit", home);
+    const designatedResult = nextMessage(designated, "admission");
+    await send(designated, {
+      type: "start",
+      home,
+      platform: "win32",
+      handoffCapability: fence.result.handoffCapability,
+    });
+    await expect(designatedResult).resolves.toMatchObject({
+      result: { status: "designated" },
+    });
+    events.push({ name: "designated-admitted", at: performance.now() });
+
+    const replay = spawn("fence-admit", home);
+    const concurrentController = spawn("fence-admit", home);
+    const replayResult = nextMessage(replay, "admission");
+    const concurrentResult = nextMessage(concurrentController, "admission");
+    await Promise.all([
+      send(replay, {
+        type: "start",
+        home,
+        platform: "win32",
+        handoffCapability: fence.result.handoffCapability,
+      }),
+      send(concurrentController, { type: "start", home, platform: "win32" }),
+    ]);
+    await expect(replayResult).resolves.toMatchObject({ result: { status: "reserved" } });
+    const losing = (await concurrentResult) as {
+      readonly result: { readonly status: string; readonly message: string };
+    };
+    expect(losing.result).toMatchObject({
+      status: "reserved",
+      message: HANDOFF_RESERVED_MESSAGE,
+    });
+    expect(losing.result.message).not.toContain("handoff-reservation-refused");
+
+    const holderExit = exited(holder);
+    holder.kill("SIGKILL");
+    await holderExit;
+    events.push({ name: "fence-crashed", at: performance.now() });
+    const recovery = spawn("fence-admit", home);
+    const recoveryResult = nextMessage(recovery, "admission");
+    await send(recovery, { type: "start", home, platform: "win32" });
+    await expect(recoveryResult).resolves.toMatchObject({ result: { status: "clear" } });
+    events.push({ name: "recovery-clear", at: performance.now() });
+    expect(events.map((event) => event.name)).toEqual([
+      "fence-acquired",
+      "designated-admitted",
+      "fence-crashed",
+      "recovery-clear",
+    ]);
+    expect(events.every((event, index) => index === 0 || event.at >= events[index - 1]!.at)).toBe(
+      true,
+    );
+  });
+});

--- a/packages/coach/tests/fixtures/daemon-process.ts
+++ b/packages/coach/tests/fixtures/daemon-process.ts
@@ -12,6 +12,7 @@ interface StartMessage {
   readonly home: AthleteHome;
   readonly mode?: "healthy" | "bound" | "foreign";
   readonly handoffCapability?: string;
+  readonly platform?: NodeJS.Platform;
 }
 
 function send(value: unknown): void {
@@ -68,7 +69,10 @@ async function main(): Promise<void> {
     return;
   }
   if (role === "fence-holder") {
-    const acquired = await acquireUpgradeFence({ configDir: message.home.configDir });
+    const acquired = await acquireUpgradeFence({
+      configDir: message.home.configDir,
+      ...(message.platform === undefined ? {} : { platform: message.platform }),
+    });
     if (acquired.status !== "acquired") {
       send({ type: "fence", result: acquired });
       return;
@@ -94,6 +98,7 @@ async function main(): Promise<void> {
       type: "admission",
       result: await admitStartupThroughUpgradeFence({
         configDir: message.home.configDir,
+        ...(message.platform === undefined ? {} : { platform: message.platform }),
         ...(message.handoffCapability === undefined
           ? {}
           : { handoffCapability: message.handoffCapability }),

--- a/packages/coach/tests/upgrade-fence.test.ts
+++ b/packages/coach/tests/upgrade-fence.test.ts
@@ -21,6 +21,10 @@ import {
   type MonotonicTimer,
   type ScheduledMonotonicTimer,
 } from "../src/daemon/upgrade-fence.js";
+import {
+  WINDOWS_UPGRADE_FENCE_CLAIM_NAME,
+  acquireWindowsUpgradeFence,
+} from "../src/daemon/windows-upgrade-fence.js";
 
 const roots: string[] = [];
 
@@ -115,6 +119,50 @@ async function unixSocketAvailable(): Promise<boolean> {
 }
 
 const hasUnixSockets = await unixSocketAvailable();
+
+describe("upgrade fence platform dispatch", () => {
+  it("routes acquisition to the Windows claim-file transport", async () => {
+    const dir = await configDir();
+    const acquired = await acquireUpgradeFence({ configDir: dir, platform: "win32" });
+    expect(acquired.status).toBe("acquired");
+    if (acquired.status !== "acquired") return;
+    try {
+      const claimPath = join(dir, WINDOWS_UPGRADE_FENCE_CLAIM_NAME);
+      expect(acquired.handle.socketPath).toBe(claimPath);
+      expect((await lstat(claimPath)).isFile()).toBe(true);
+      await expect(lstat(join(dir, UPGRADE_FENCE_SOCKET_NAME))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await acquired.handle.release();
+    }
+  });
+
+  it("routes admission to the Windows claim-file transport", async () => {
+    const dir = await configDir();
+    const acquired = await acquireWindowsUpgradeFence({ configDir: dir });
+    expect(acquired.status).toBe("acquired");
+    if (acquired.status !== "acquired") return;
+    try {
+      expect((await lstat(join(dir, WINDOWS_UPGRADE_FENCE_CLAIM_NAME))).isFile()).toBe(true);
+      await expect(
+        admitStartupThroughUpgradeFence({
+          configDir: dir,
+          platform: "win32",
+        }),
+      ).resolves.toEqual({
+        status: "reserved",
+        exitCode: 3,
+        message: HANDOFF_RESERVED_MESSAGE,
+      });
+      await expect(lstat(join(dir, UPGRADE_FENCE_SOCKET_NAME))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await acquired.handle.release();
+    }
+  });
+});
 
 describe.skipIf(!hasUnixSockets)("upgrade fence", () => {
   it.skipIf(process.platform !== "darwin")("reports an unusably long socket path", async () => {

--- a/packages/coach/tests/windows-upgrade-fence.test.ts
+++ b/packages/coach/tests/windows-upgrade-fence.test.ts
@@ -1,0 +1,362 @@
+import { lstat, mkdir, mkdtemp, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { createConnection, createServer, type AddressInfo, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  HANDOFF_RESERVED_MESSAGE,
+  UPGRADE_FENCE_FRAME_MAX_BYTES,
+  UPGRADE_FENCE_IO_TIMEOUT_MS,
+  type AcquireUpgradeFenceResult,
+  type MonotonicTimer,
+  type ScheduledMonotonicTimer,
+} from "../src/daemon/upgrade-fence.js";
+import {
+  WINDOWS_UPGRADE_FENCE_CLAIM_NAME,
+  acquireWindowsUpgradeFence,
+  admitStartupThroughWindowsUpgradeFence,
+} from "../src/daemon/windows-upgrade-fence.js";
+
+const roots: string[] = [];
+const cleanups = new Set<() => Promise<void>>();
+const FENCE = Buffer.alloc(16, 11).toString("base64url");
+const OTHER_FENCE = Buffer.alloc(16, 12).toString("base64url");
+
+afterEach(async () => {
+  const cleanupResults = await Promise.allSettled([...cleanups].map((cleanup) => cleanup()));
+  cleanups.clear();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  const failed = cleanupResults.find((result) => result.status === "rejected");
+  if (failed?.status === "rejected") throw failed.reason;
+});
+
+async function configDir(): Promise<string> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "windows-upgrade-fence-"));
+  roots.push(root);
+  return join(root, "config");
+}
+
+function claimPath(dir: string): string {
+  return join(dir, WINDOWS_UPGRADE_FENCE_CLAIM_NAME);
+}
+
+async function readClaim(dir: string): Promise<{ readonly fence: string; readonly port: number }> {
+  return JSON.parse(await readFile(claimPath(dir), "utf8")) as {
+    readonly fence: string;
+    readonly port: number;
+  };
+}
+
+async function writeClaim(
+  dir: string,
+  claim: { readonly fence: string; readonly port: number },
+): Promise<string> {
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  const contents = `${JSON.stringify(claim)}\n`;
+  await writeFile(claimPath(dir), contents, { mode: 0o600 });
+  return contents;
+}
+
+function trackAcquired(result: AcquireUpgradeFenceResult): void {
+  if (result.status === "acquired") cleanups.add(() => result.handle.release());
+}
+
+class FakeTimer implements MonotonicTimer {
+  private now = 0;
+  private scheduleCount = 0;
+  private readonly scheduleWaiters = new Set<{
+    readonly after: number;
+    readonly resolve: () => void;
+  }>();
+  private readonly scheduled = new Set<{
+    readonly at: number;
+    readonly callback: () => void;
+    cancelled: boolean;
+  }>();
+
+  nowMs(): number {
+    return this.now;
+  }
+
+  schedule(delayMs: number, callback: () => void): ScheduledMonotonicTimer {
+    const item = { at: this.now + delayMs, callback, cancelled: false };
+    this.scheduled.add(item);
+    this.scheduleCount += 1;
+    for (const waiter of this.scheduleWaiters) {
+      if (this.scheduleCount > waiter.after) {
+        this.scheduleWaiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
+    return {
+      cancel: () => {
+        item.cancelled = true;
+        this.scheduled.delete(item);
+      },
+    };
+  }
+
+  waitForScheduleAfter(count: number): Promise<void> {
+    if (this.scheduleCount > count) return Promise.resolve();
+    return new Promise((resolve) => this.scheduleWaiters.add({ after: count, resolve }));
+  }
+
+  get totalSchedules(): number {
+    return this.scheduleCount;
+  }
+
+  advance(ms: number): void {
+    this.now += ms;
+    for (const item of this.scheduled) {
+      if (!item.cancelled && item.at <= this.now) {
+        this.scheduled.delete(item);
+        item.callback();
+      }
+    }
+  }
+}
+
+function rawAdmission(port: number, bytes: Buffer): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ host: "127.0.0.1", port });
+    const chunks: Buffer[] = [];
+    socket.once("error", reject);
+    socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+    socket.once("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    socket.once("connect", () => socket.end(bytes));
+  });
+}
+
+interface TestServer {
+  readonly port: number;
+  close(): Promise<void>;
+}
+
+async function startServer(onSocket: (socket: Socket) => void): Promise<TestServer> {
+  const sockets = new Set<Socket>();
+  const server = createServer({ allowHalfOpen: true }, (socket) => {
+    sockets.add(socket);
+    socket.on("error", () => {});
+    socket.once("close", () => sockets.delete(socket));
+    onSocket(socket);
+  });
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => reject(error);
+    server.once("error", onError);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+  const port = (server.address() as AddressInfo).port;
+  let closePromise: Promise<void> | undefined;
+  const close = (): Promise<void> => {
+    closePromise ??= new Promise<void>((resolve, reject) => {
+      for (const socket of sockets) socket.destroy();
+      if (!server.listening) {
+        resolve();
+        return;
+      }
+      server.close((error) => (error === undefined ? resolve() : reject(error)));
+    });
+    return closePromise;
+  };
+  cleanups.add(close);
+  return { port, close };
+}
+
+async function respondingServer(response: string): Promise<TestServer> {
+  return startServer((socket) => {
+    socket.once("data", () => socket.end(response));
+  });
+}
+
+function reservedResponse(fence: string): string {
+  return `${JSON.stringify({ fence, status: "reserved" })}\n`;
+}
+
+describe("Windows upgrade fence", () => {
+  it("matches admission, one-shot capability, release, and permission contracts", async () => {
+    const dir = await configDir();
+    const acquired = await acquireWindowsUpgradeFence({
+      configDir: dir,
+      randomBytes: (size) => Buffer.alloc(size, 7),
+    });
+    trackAcquired(acquired);
+    expect(acquired.status).toBe("acquired");
+    if (acquired.status !== "acquired") return;
+
+    const ordinary = await admitStartupThroughWindowsUpgradeFence({ configDir: dir });
+    expect(ordinary).toEqual({
+      status: "reserved",
+      exitCode: 3,
+      message: HANDOFF_RESERVED_MESSAGE,
+    });
+    if (ordinary.status !== "reserved") return;
+    expect(Buffer.from(ordinary.message)).toEqual(Buffer.from(HANDOFF_RESERVED_MESSAGE));
+
+    await expect(
+      admitStartupThroughWindowsUpgradeFence({
+        configDir: dir,
+        handoffCapability: Buffer.alloc(32, 8).toString("base64url"),
+      }),
+    ).resolves.toMatchObject({ status: "reserved" });
+    await expect(
+      admitStartupThroughWindowsUpgradeFence({
+        configDir: dir,
+        handoffCapability: acquired.handle.handoffCapability,
+      }),
+    ).resolves.toEqual({ status: "designated" });
+    await expect(
+      admitStartupThroughWindowsUpgradeFence({
+        configDir: dir,
+        handoffCapability: acquired.handle.handoffCapability,
+      }),
+    ).resolves.toMatchObject({ status: "reserved" });
+
+    if (process.platform !== "win32") {
+      expect((await lstat(dir)).mode & 0o777).toBe(0o700);
+      expect((await lstat(claimPath(dir))).mode & 0o777).toBe(0o600);
+    }
+
+    await acquired.handle.release();
+    await acquired.handle.release();
+    await expect(admitStartupThroughWindowsUpgradeFence({ configDir: dir })).resolves.toEqual({
+      status: "clear",
+    });
+    await expect(lstat(claimPath(dir))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("enforces byte boundaries and the incomplete-frame monotonic deadline", async () => {
+    const dir = await configDir();
+    const timer = new FakeTimer();
+    const acquired = await acquireWindowsUpgradeFence({ configDir: dir, timer });
+    trackAcquired(acquired);
+    expect(acquired.status).toBe("acquired");
+    if (acquired.status !== "acquired") return;
+    const claim = await readClaim(dir);
+    const ordinary = JSON.stringify({ kind: "ordinary-starter" });
+    const exact = Buffer.from(`${ordinary.padEnd(UPGRADE_FENCE_FRAME_MAX_BYTES - 1, " ")}\n`);
+    expect(exact.length).toBe(UPGRADE_FENCE_FRAME_MAX_BYTES);
+    await expect(rawAdmission(claim.port, exact)).resolves.toBe(reservedResponse(claim.fence));
+
+    const oversized = Buffer.from(`${ordinary.padEnd(UPGRADE_FENCE_FRAME_MAX_BYTES, " ")}\n`);
+    expect(oversized.length).toBe(UPGRADE_FENCE_FRAME_MAX_BYTES + 1);
+    await expect(rawAdmission(claim.port, oversized)).resolves.toBe(reservedResponse(claim.fence));
+
+    const incompleteBytes = Buffer.alloc(UPGRADE_FENCE_FRAME_MAX_BYTES - 1, "é");
+    expect(incompleteBytes.length).toBe(UPGRADE_FENCE_FRAME_MAX_BYTES - 1);
+    const priorSchedules = timer.totalSchedules;
+    const incomplete = rawAdmission(claim.port, incompleteBytes);
+    await timer.waitForScheduleAfter(priorSchedules);
+    timer.advance(UPGRADE_FENCE_IO_TIMEOUT_MS);
+    await expect(incomplete).resolves.toBe(reservedResponse(claim.fence));
+  });
+
+  it("does not unlink a replacement claim inode during release", async () => {
+    const dir = await configDir();
+    const acquired = await acquireWindowsUpgradeFence({ configDir: dir });
+    trackAcquired(acquired);
+    expect(acquired.status).toBe("acquired");
+    if (acquired.status !== "acquired") return;
+    const path = claimPath(dir);
+    const moved = `${path}.moved`;
+    await rename(path, moved);
+    await writeFile(path, "replacement\n", { mode: 0o600 });
+    await acquired.handle.release();
+    await expect(readFile(path, "utf8")).resolves.toBe("replacement\n");
+  });
+
+  it("recovers a claim left behind by a crashed holder and permits a fresh acquisition", async () => {
+    const dir = await configDir();
+    const holder = await startServer((socket) => socket.resume());
+    await writeClaim(dir, { fence: FENCE, port: holder.port });
+    await holder.close();
+    await expect(lstat(claimPath(dir))).resolves.toBeDefined();
+
+    await expect(admitStartupThroughWindowsUpgradeFence({ configDir: dir })).resolves.toEqual({
+      status: "clear",
+    });
+    await expect(lstat(claimPath(dir))).rejects.toMatchObject({ code: "ENOENT" });
+
+    const acquired = await acquireWindowsUpgradeFence({ configDir: dir });
+    trackAcquired(acquired);
+    expect(acquired.status).toBe("acquired");
+  });
+
+  it("reserves a hung holder after the monotonic deadline without reclaiming its claim", async () => {
+    const dir = await configDir();
+    const holder = await startServer(() => {});
+    const contents = await writeClaim(dir, { fence: FENCE, port: holder.port });
+    const timer = new FakeTimer();
+    const admission = admitStartupThroughWindowsUpgradeFence({ configDir: dir, timer });
+    await timer.waitForScheduleAfter(1);
+    timer.advance(UPGRADE_FENCE_IO_TIMEOUT_MS);
+    await expect(admission).resolves.toEqual({
+      status: "reserved",
+      exitCode: 3,
+      message: HANDOFF_RESERVED_MESSAGE,
+    });
+    await expect(readFile(claimPath(dir), "utf8")).resolves.toBe(contents);
+  });
+
+  it.each([
+    ["garbage", "not-json\n"],
+    ["wrong nonce", reservedResponse(OTHER_FENCE)],
+    ["status-only response", `${JSON.stringify({ status: "reserved" })}\n`],
+  ])("reclaims a port squatter returning %s", async (_name, response) => {
+    const dir = await configDir();
+    const squatter = await respondingServer(response);
+    await writeClaim(dir, { fence: FENCE, port: squatter.port });
+    await expect(admitStartupThroughWindowsUpgradeFence({ configDir: dir })).resolves.toEqual({
+      status: "clear",
+    });
+    await expect(lstat(claimPath(dir))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("keeps a live claim when the holder returns the correct nonce echo", async () => {
+    const dir = await configDir();
+    const holder = await respondingServer(reservedResponse(FENCE));
+    const contents = await writeClaim(dir, { fence: FENCE, port: holder.port });
+    await expect(admitStartupThroughWindowsUpgradeFence({ configDir: dir })).resolves.toEqual({
+      status: "reserved",
+      exitCode: 3,
+      message: HANDOFF_RESERVED_MESSAGE,
+    });
+    await expect(readFile(claimPath(dir), "utf8")).resolves.toBe(contents);
+  });
+
+  it("arbitrates concurrent acquisitions with exactly one winner", async () => {
+    const dir = await configDir();
+    const results = await Promise.all([
+      acquireWindowsUpgradeFence({ configDir: dir }),
+      acquireWindowsUpgradeFence({ configDir: dir }),
+    ]);
+    for (const result of results) trackAcquired(result);
+    expect(results.filter((result) => result.status === "acquired")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "reserved")).toHaveLength(1);
+  });
+
+  it.each([
+    ["invalid JSON", "not-json\n"],
+    ["wrong keys", `${JSON.stringify({ nonce: FENCE, port: 31_337 })}\n`],
+  ])("fails safe on a corrupt claim with %s", async (_name, contents) => {
+    const dir = await configDir();
+    await mkdir(dir, { recursive: true });
+    await writeFile(claimPath(dir), contents, { mode: 0o600 });
+
+    await expect(admitStartupThroughWindowsUpgradeFence({ configDir: dir })).resolves.toEqual({
+      status: "reserved",
+      exitCode: 3,
+      message: HANDOFF_RESERVED_MESSAGE,
+    });
+    const acquired = await acquireWindowsUpgradeFence({ configDir: dir });
+    trackAcquired(acquired);
+    expect(acquired).toEqual({
+      status: "reserved",
+      exitCode: 3,
+      message: HANDOFF_RESERVED_MESSAGE,
+    });
+    await expect(readFile(claimPath(dir), "utf8")).resolves.toBe(contents);
+  });
+});

--- a/packages/kernel-node/src/lock/index.ts
+++ b/packages/kernel-node/src/lock/index.ts
@@ -19,3 +19,4 @@ export type { LockfileBody } from "./lockfile-body.js";
 export { readLockfile } from "./lockfile-body.js";
 export type { HealthzVerdict, HealthzProbe } from "./healthz-probe.js";
 export { classifyHealthzResponse, HEALTHZ_SERVICE_MARKER } from "./healthz-probe.js";
+export { writeTempThenPublish } from "./write-temp.js";


### PR DESCRIPTION
Adds the Windows transport for the daemon upgrade fence: a kernel-atomic claim file plus a loopback TCP admission endpoint, keeping the fence state machine, admission protocol, capability semantics, and error surface byte-identical on Unix.

Why not named pipes: implementation proved a pure node:net named-pipe fence cannot honor the fence's dead-owner recovery contract — a Windows pipe instance survives while any client handle remains open, so a crashed owner plus one hung client permanently blocks the successor's first-instance re-bind, and Node exposes no unlink or force-disconnect to reclaim the name; omitting first-instance binding would instead permit simultaneous owners. The replacement reuses the repository's existing cross-platform arbitration idiom (the store writer lock): exclusive-create claim publication born with its body, an ephemeral loopback listener whose port and per-claim nonce ride in the claim file, nonce-echo peer authentication against port squatters, ECONNREFUSED as the dead-owner proof (the kernel closes a crashed owner's listener regardless of surviving client handles), and identity-checked rename-then-unlink reclaim.

- New packages/coach/src/daemon/upgrade-fence-protocol.ts: verbatim extraction of the shared protocol pieces (constants, timer types, admission/handle/input/result types, framing, capability canonicalization, strict request/response validation) so the Windows module imports them without a cycle; every previously exported name is re-exported from upgrade-fence.ts unchanged.
- New packages/coach/src/daemon/windows-upgrade-fence.ts: the transport. Claim file carries only a random per-claim nonce and the listener port — the handoff capability never touches disk and is zero-filled on release. All failure edges degrade to the fail-safe reserved refusal (hung holder is not treated as dead; unreadable or AV-pinned claims self-heal on the next start attempt); all diagnostics are constant, path-free strings.
- upgrade-fence.ts gains an optional platform field and two one-line win32 dispatches; Unix bodies are otherwise unchanged, and every pre-existing fence test passes textually unmodified.
- kernel-node: one additive export line (the claim-publication helper the writer lock already uses internally).
- Tests: eight new case families for the Windows transport (contract parity with byte-equal reserved message, framing deadlines on a fake timer, replaced-inode release safety, crashed-holder recovery, hung-holder non-reclaim, port-squatter reclaim with a live-holder control, concurrent acquire race, corrupt claim fail-safe) plus a real-child-process four-event handoff choreography for win32 dispatch — all runnable on macOS.
- No changeset: this precedes any shipped Windows build, so it is pure infrastructure for released platforms.

Verification: targeted fence battery 4 files / 20 tests green; full coach suite 63 files / 726 tests green (repo-root cwd); desktop tsc clean and full desktop suite 82 files / 1572 tests green; repo-root pnpm check exit 0. Zero fix rounds were needed.