### PR TITLE
feat(desktop): refuse updater downgrades below the highest version ever run

### DIFF
--- a/.changeset/updater-downgrade-floor.md
+++ b/.changeset/updater-downgrade-floor.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: The desktop app now refuses update feeds that would downgrade it below the highest version it has ever run, protecting against replaced release assets.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -30,6 +30,9 @@ extraResources:
     to: .
 mac:
   icon: resources/app-icon.png
+  # Squirrel.Mac otherwise accepts older builds that remain validly signed.
+  extendInfo:
+    ElectronSquirrelPreventDowngrades: true
   target:
     - target: dir
       arch: [arm64]

--- a/apps/desktop/src/main/desktop-version.ts
+++ b/apps/desktop/src/main/desktop-version.ts
@@ -13,14 +13,18 @@ export function isStableDesktopVersion(value: unknown): value is string {
   return stableSemVerParts(value) !== null;
 }
 
-export function isDesktopUpdateAvailable(candidate: string, current: string): boolean {
-  const candidateParts = stableSemVerParts(candidate);
-  const currentParts = stableSemVerParts(current);
-  if (candidateParts === null || currentParts === null) return false;
-  for (let index = 0; index < candidateParts.length; index += 1) {
-    if (candidateParts[index] !== currentParts[index]) {
-      return candidateParts[index] > currentParts[index];
+export function compareDesktopVersions(left: string, right: string): -1 | 0 | 1 | null {
+  const leftParts = stableSemVerParts(left);
+  const rightParts = stableSemVerParts(right);
+  if (leftParts === null || rightParts === null) return null;
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] > rightParts[index] ? 1 : -1;
     }
   }
-  return false;
+  return 0;
+}
+
+export function isDesktopUpdateAvailable(candidate: string, current: string): boolean {
+  return compareDesktopVersions(candidate, current) === 1;
 }

--- a/apps/desktop/src/main/durable-atomic-replace.ts
+++ b/apps/desktop/src/main/durable-atomic-replace.ts
@@ -30,7 +30,10 @@ export interface ReversibleDurableReplaceInput extends DurableAtomicReplaceInput
   readonly readCurrent?: (target: string) => Promise<Buffer | undefined>;
 }
 
-async function syncDirectory(root: string, openDirectory: typeof open): Promise<void> {
+export async function syncDirectory(
+  root: string,
+  openDirectory: typeof open = open,
+): Promise<void> {
   const directory = await openDirectory(root, "r");
   try {
     await directory.sync();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -83,6 +83,7 @@ import {
 import { createDesktopUpdateController } from "./update-controller.js";
 import { isDesktopUpdateReleaseEligible } from "./update-eligibility.js";
 import { installDesktopUpdateIpc } from "./update-ipc.js";
+import { createDesktopUpdateVersionFloor } from "./update-version-floor.js";
 import {
   createTelegramControlCoordinator,
   type TelegramDaemonBinding,
@@ -161,8 +162,13 @@ async function runDesktop(): Promise<void> {
   app.on("window-all-closed", () => {});
   await app.whenReady();
   if (desktopAcceptanceHidden) app.dock?.hide();
+  const desktopPreferencesRoot = join(
+    app.getPath("userData"),
+    BACKGROUND_AT_LOGIN_PREFERENCE_DIRECTORY_NAME,
+  );
+  const updateVersionFloor = createDesktopUpdateVersionFloor({ root: desktopPreferencesRoot });
   const backgroundAtLoginPreference = createBackgroundAtLoginPreferenceStore({
-    root: join(app.getPath("userData"), BACKGROUND_AT_LOGIN_PREFERENCE_DIRECTORY_NAME),
+    root: desktopPreferencesRoot,
   });
   desktopStartedInBackground =
     !securitySmokeMode && (await shouldStartInBackgroundAtLogin(app, backgroundAtLoginPreference));
@@ -212,6 +218,7 @@ async function runDesktop(): Promise<void> {
       currentVersion: app.getVersion(),
     }),
     currentVersion: app.getVersion(),
+    versionFloor: updateVersionFloor,
     loadUpdater: async () => {
       const { autoUpdater } = await import("electron-updater");
       return autoUpdater;

--- a/apps/desktop/src/main/safe-log.ts
+++ b/apps/desktop/src/main/safe-log.ts
@@ -1,0 +1,14 @@
+export function createSafeLog(
+  log?: (message: string) => void,
+): (message: string) => void {
+  const outputLog =
+    log ??
+    ((message: string): void => {
+      process.stderr.write(`${message}\n`);
+    });
+  return (message: string): void => {
+    try {
+      outputLog(message);
+    } catch {}
+  };
+}

--- a/apps/desktop/src/main/update-controller.ts
+++ b/apps/desktop/src/main/update-controller.ts
@@ -10,6 +10,7 @@ import {
   isDesktopUpdateAvailable,
   isStableDesktopVersion,
 } from "./desktop-version.js";
+import { createSafeLog } from "./safe-log.js";
 import type {
   DesktopUpdateVersionFloor,
   DesktopUpdateVersionFloorResult,
@@ -125,16 +126,7 @@ export function createDesktopUpdateController(input: {
   let installInvoked = false;
   let floorVersion: string | undefined;
   let updaterInitialization: Promise<boolean> | undefined;
-  const outputLog =
-    input.log ??
-    ((message: string): void => {
-      process.stderr.write(`${message}\n`);
-    });
-  const log = (message: string): void => {
-    try {
-      outputLog(message);
-    } catch {}
-  };
+  const log = createSafeLog(input.log);
 
   const publish = (next: DesktopUpdateState): void => {
     if (closed) return;

--- a/apps/desktop/src/main/update-controller.ts
+++ b/apps/desktop/src/main/update-controller.ts
@@ -5,7 +5,15 @@ import type {
   UpdateCheckResult,
   UpdateDownloadedEvent,
 } from "electron-updater";
-import { isDesktopUpdateAvailable, isStableDesktopVersion } from "./desktop-version.js";
+import {
+  compareDesktopVersions,
+  isDesktopUpdateAvailable,
+  isStableDesktopVersion,
+} from "./desktop-version.js";
+import type {
+  DesktopUpdateVersionFloor,
+  DesktopUpdateVersionFloorResult,
+} from "./update-version-floor.js";
 
 export type DesktopUpdateState =
   | { readonly status: "disabled" }
@@ -83,8 +91,10 @@ export function copyDesktopUpdateState(state: DesktopUpdateState): DesktopUpdate
 export function createDesktopUpdateController(input: {
   readonly releaseEligible: boolean;
   readonly currentVersion: string;
+  readonly versionFloor: DesktopUpdateVersionFloor;
   readonly loadUpdater: () => Promise<DesktopAutoUpdater>;
   readonly requestQuit: () => void;
+  readonly log?: (message: string) => void;
   readonly setInterval?: (callback: () => void, interval: number) => TimerHandle;
   readonly clearInterval?: (handle: TimerHandle) => void;
   readonly setTimeout?: (callback: () => void, timeout: number) => TimerHandle;
@@ -113,6 +123,18 @@ export function createDesktopUpdateController(input: {
   let activeOperation: UpdateOperation | undefined;
   let installRequested = false;
   let installInvoked = false;
+  let floorVersion: string | undefined;
+  let updaterInitialization: Promise<boolean> | undefined;
+  const outputLog =
+    input.log ??
+    ((message: string): void => {
+      process.stderr.write(`${message}\n`);
+    });
+  const log = (message: string): void => {
+    try {
+      outputLog(message);
+    } catch {}
+  };
 
   const publish = (next: DesktopUpdateState): void => {
     if (closed) return;
@@ -300,7 +322,7 @@ export function createDesktopUpdateController(input: {
       .catch(() => failOperation(operation, "download"));
   };
 
-  const check = (): Promise<DesktopUpdateState> => {
+  const runCheck = (): Promise<DesktopUpdateState> => {
     if (activeOperation !== undefined) return activeOperation.promise;
     if (!canCheck() || updater === undefined) return Promise.resolve(currentState());
     let resolveOperation!: (state: DesktopUpdateState) => void;
@@ -353,6 +375,21 @@ export function createDesktopUpdateController(input: {
             finishOperation(operation, false);
             return;
           }
+          if (floorVersion === undefined) {
+            operation.cancellationToken = result.cancellationToken;
+            log("desktop-update-version-floor-unavailable");
+            publish({ status: "failed", stage: "check" });
+            finishOperation(operation, true);
+            return;
+          }
+          const floorComparison = compareDesktopVersions(version, floorVersion);
+          if (floorComparison === null || floorComparison < 0) {
+            operation.cancellationToken = result.cancellationToken;
+            log(`desktop-update-downgrade-refused candidate=${version} floor=${floorVersion}`);
+            publish({ status: "failed", stage: "check" });
+            finishOperation(operation, true);
+            return;
+          }
           beginDownload(operation, result);
         },
         () => {
@@ -364,38 +401,86 @@ export function createDesktopUpdateController(input: {
     return operation.promise;
   };
 
-  const start = async (): Promise<void> => {
-    if (started || closed || !active) return;
-    started = true;
-    try {
-      updater = await input.loadUpdater();
-    } catch {
-      if (!closed) publish({ status: "restart-required", stage: "check" });
-      return;
-    }
-    if (closed) return;
-    try {
-      updater.logger = null;
-      updater.autoDownload = false;
-      updater.autoInstallOnAppQuit = false;
-      updater.autoRunAppAfterInstall = true;
-      updater.allowPrerelease = false;
-      updater.allowDowngrade = false;
-      intervalTimer = scheduleInterval(() => {
-        void check();
-      }, DESKTOP_UPDATE_INTERVAL_MS);
-      intervalTimer.unref();
-    } catch {
-      if (intervalTimer !== undefined) {
+  const initializeUpdater = (): Promise<boolean> => {
+    if (closed) return Promise.resolve(false);
+    if (updater !== undefined) return Promise.resolve(true);
+    if (updaterInitialization !== undefined) return updaterInitialization;
+    const attempt = (async (): Promise<boolean> => {
+      if (floorVersion === undefined) {
+        let recordedFloor: DesktopUpdateVersionFloorResult;
         try {
-          unscheduleInterval(intervalTimer);
-        } catch {}
-        intervalTimer = undefined;
+          recordedFloor = await input.versionFloor.recordRunningVersion(input.currentVersion);
+        } catch {
+          recordedFloor = { status: "unavailable" };
+        }
+        if (closed) return false;
+        if (recordedFloor.status !== "ready") {
+          log("desktop-update-version-floor-unavailable");
+          if (active) publish({ status: "failed", stage: "check" });
+          return false;
+        }
+        if (!isStableDesktopVersion(recordedFloor.version)) {
+          log("desktop-update-version-floor-unavailable");
+          if (active) publish({ status: "failed", stage: "check" });
+          return false;
+        }
+        floorVersion = recordedFloor.version;
       }
-      if (!closed) publish({ status: "failed", stage: "check" });
-      return;
-    }
-    await check();
+      if (!active) return false;
+      try {
+        updater = await input.loadUpdater();
+      } catch {
+        if (!closed) publish({ status: "restart-required", stage: "check" });
+        return false;
+      }
+      if (closed) return false;
+      try {
+        updater.logger = null;
+        updater.autoDownload = false;
+        updater.autoInstallOnAppQuit = false;
+        updater.autoRunAppAfterInstall = true;
+        updater.allowPrerelease = false;
+        updater.allowDowngrade = false;
+        intervalTimer = scheduleInterval(() => {
+          void check();
+        }, DESKTOP_UPDATE_INTERVAL_MS);
+        intervalTimer.unref();
+      } catch {
+        if (intervalTimer !== undefined) {
+          try {
+            unscheduleInterval(intervalTimer);
+          } catch {}
+          intervalTimer = undefined;
+        }
+        if (!closed) publish({ status: "failed", stage: "check" });
+        return false;
+      }
+      return true;
+    })();
+    updaterInitialization = attempt;
+    void attempt.then(
+      () => {
+        if (updaterInitialization === attempt) updaterInitialization = undefined;
+      },
+      () => {
+        if (updaterInitialization === attempt) updaterInitialization = undefined;
+      },
+    );
+    return attempt;
+  };
+
+  const check = (): Promise<DesktopUpdateState> => {
+    if (activeOperation !== undefined) return activeOperation.promise;
+    if (!canCheck()) return Promise.resolve(currentState());
+    if (updater !== undefined) return runCheck();
+    return initializeUpdater().then((ready) => (ready ? runCheck() : currentState()));
+  };
+
+  const start = async (): Promise<void> => {
+    if (started || closed) return;
+    started = true;
+    if (!(await initializeUpdater())) return;
+    await runCheck();
   };
 
   return {

--- a/apps/desktop/src/main/update-version-floor.ts
+++ b/apps/desktop/src/main/update-version-floor.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from "node:crypto";
+import { constants, type Stats } from "node:fs";
+import { lstat, mkdir, open, readdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { compareDesktopVersions, isStableDesktopVersion } from "./desktop-version.js";
+import { durableAtomicReplace } from "./durable-atomic-replace.js";
+
+export const DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME = "highest-desktop-version.json" as const;
+export const DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE = 0o700;
+export const DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE = 0o600;
+
+const MAX_VERSION_FLOOR_FILE_BYTES = 256;
+
+type StoredVersionFloor =
+  | Readonly<{ status: "missing" }>
+  | Readonly<{ status: "corrupt" }>
+  | Readonly<{ status: "ready"; version: string }>;
+
+export type DesktopUpdateVersionFloorResult =
+  | Readonly<{ status: "ready"; version: string }>
+  | Readonly<{ status: "unavailable" }>;
+
+export interface DesktopUpdateVersionFloor {
+  recordRunningVersion(version: string): Promise<DesktopUpdateVersionFloorResult>;
+}
+
+function permissions(mode: number): number {
+  return mode & 0o777;
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function assertOwner(metadata: Stats, mode: number): void {
+  if (
+    metadata.isSymbolicLink() ||
+    permissions(metadata.mode) !== mode ||
+    (typeof process.getuid === "function" && metadata.uid !== process.getuid())
+  ) {
+    throw new TypeError("unsafe update version floor path");
+  }
+}
+
+function parseVersionFloor(contents: string): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const record = parsed as Record<string, unknown>;
+  if (
+    !Number.isSafeInteger(record.schemaVersion) ||
+    (record.schemaVersion as number) < 1 ||
+    !isStableDesktopVersion(record.version)
+  ) {
+    return undefined;
+  }
+  return record.version;
+}
+
+async function synchronizeDirectory(root: string): Promise<void> {
+  const directory = await open(root, "r");
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close().catch(() => undefined);
+  }
+}
+
+export function createDesktopUpdateVersionFloor(input: {
+  readonly root: string;
+  readonly createId?: () => string;
+  readonly log?: (message: string) => void;
+}): DesktopUpdateVersionFloor {
+  const target = join(input.root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
+  const createId = input.createId ?? randomUUID;
+  const outputLog =
+    input.log ??
+    ((message: string): void => {
+      process.stderr.write(`${message}\n`);
+    });
+  let pending: Promise<void> = Promise.resolve();
+
+  const log = (message: string): void => {
+    try {
+      outputLog(message);
+    } catch {}
+  };
+
+  const serialize = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = pending.then(operation);
+    pending = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  const prepareRoot = async (): Promise<void> => {
+    let created = false;
+    try {
+      await lstat(input.root);
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+      await mkdir(input.root, {
+        recursive: true,
+        mode: DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE,
+      });
+      created = true;
+    }
+    const metadata = await lstat(input.root);
+    if (!metadata.isDirectory()) throw new TypeError("invalid update version floor root");
+    assertOwner(metadata, DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE);
+    if (created) await synchronizeDirectory(dirname(input.root));
+    const prefix = `.${DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME}.`;
+    for (const entry of await readdir(input.root)) {
+      if (
+        entry.startsWith(prefix) &&
+        entry.endsWith(".tmp") &&
+        /^[A-Za-z0-9-]{1,128}$/.test(entry.slice(prefix.length, -4))
+      ) {
+        await rm(join(input.root, entry), { force: true });
+      }
+    }
+    await synchronizeDirectory(input.root);
+  };
+
+  const readFloor = async (): Promise<StoredVersionFloor> => {
+    let before: Stats;
+    try {
+      before = await lstat(target);
+    } catch (error) {
+      if (isMissing(error)) return { status: "missing" };
+      throw error;
+    }
+    if (!before.isFile()) throw new TypeError("invalid update version floor file");
+    assertOwner(before, DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE);
+    if (before.size > MAX_VERSION_FLOOR_FILE_BYTES) return { status: "corrupt" };
+    const handle = await open(target, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    try {
+      const opened = await handle.stat();
+      if (
+        !opened.isFile() ||
+        opened.dev !== before.dev ||
+        opened.ino !== before.ino ||
+        opened.size > MAX_VERSION_FLOOR_FILE_BYTES
+      ) {
+        throw new TypeError("update version floor changed while opening");
+      }
+      assertOwner(opened, DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE);
+      const contents = await handle.readFile({ encoding: "utf8" });
+      const version = parseVersionFloor(contents);
+      return version === undefined
+        ? { status: "corrupt" }
+        : { status: "ready", version };
+    } finally {
+      await handle.close();
+    }
+  };
+
+  const writeFloor = (version: string) =>
+    durableAtomicReplace({
+      root: input.root,
+      fileName: DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME,
+      contents: `${JSON.stringify({ schemaVersion: 1, version })}\n`,
+      mode: DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE,
+      createId,
+    });
+
+  return {
+    recordRunningVersion(version) {
+      return serialize(async () => {
+        if (!isStableDesktopVersion(version)) return { status: "unavailable" };
+        try {
+          await prepareRoot();
+          const existing = await readFloor();
+          if (existing.status === "ready") {
+            const comparison = compareDesktopVersions(existing.version, version);
+            if (comparison === null) return { status: "unavailable" };
+            if (comparison >= 0) return { status: "ready", version: existing.version };
+          }
+          const outcome = await writeFloor(version);
+          if (outcome.state !== "durably-committed") return { status: "unavailable" };
+          if (existing.status === "corrupt") log("desktop-update-version-floor-recovered");
+          return { status: "ready", version };
+        } catch {
+          return { status: "unavailable" };
+        }
+      });
+    },
+  };
+}

--- a/apps/desktop/src/main/update-version-floor.ts
+++ b/apps/desktop/src/main/update-version-floor.ts
@@ -1,9 +1,9 @@
-import { randomUUID } from "node:crypto";
 import { constants, type Stats } from "node:fs";
 import { lstat, mkdir, open, readdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { compareDesktopVersions, isStableDesktopVersion } from "./desktop-version.js";
-import { durableAtomicReplace } from "./durable-atomic-replace.js";
+import { durableAtomicReplace, syncDirectory } from "./durable-atomic-replace.js";
+import { createSafeLog } from "./safe-log.js";
 
 export const DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME = "highest-desktop-version.json" as const;
 export const DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE = 0o700;
@@ -61,34 +61,13 @@ function parseVersionFloor(contents: string): string | undefined {
   return record.version;
 }
 
-async function synchronizeDirectory(root: string): Promise<void> {
-  const directory = await open(root, "r");
-  try {
-    await directory.sync();
-  } finally {
-    await directory.close().catch(() => undefined);
-  }
-}
-
 export function createDesktopUpdateVersionFloor(input: {
   readonly root: string;
-  readonly createId?: () => string;
   readonly log?: (message: string) => void;
 }): DesktopUpdateVersionFloor {
   const target = join(input.root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
-  const createId = input.createId ?? randomUUID;
-  const outputLog =
-    input.log ??
-    ((message: string): void => {
-      process.stderr.write(`${message}\n`);
-    });
+  const log = createSafeLog(input.log);
   let pending: Promise<void> = Promise.resolve();
-
-  const log = (message: string): void => {
-    try {
-      outputLog(message);
-    } catch {}
-  };
 
   const serialize = <T>(operation: () => Promise<T>): Promise<T> => {
     const result = pending.then(operation);
@@ -101,8 +80,9 @@ export function createDesktopUpdateVersionFloor(input: {
 
   const prepareRoot = async (): Promise<void> => {
     let created = false;
+    let metadata: Stats;
     try {
-      await lstat(input.root);
+      metadata = await lstat(input.root);
     } catch (error) {
       if (!isMissing(error)) throw error;
       await mkdir(input.root, {
@@ -110,12 +90,13 @@ export function createDesktopUpdateVersionFloor(input: {
         mode: DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE,
       });
       created = true;
+      metadata = await lstat(input.root);
     }
-    const metadata = await lstat(input.root);
     if (!metadata.isDirectory()) throw new TypeError("invalid update version floor root");
     assertOwner(metadata, DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE);
-    if (created) await synchronizeDirectory(dirname(input.root));
+    if (created) await syncDirectory(dirname(input.root));
     const prefix = `.${DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME}.`;
+    let removed = false;
     for (const entry of await readdir(input.root)) {
       if (
         entry.startsWith(prefix) &&
@@ -123,9 +104,10 @@ export function createDesktopUpdateVersionFloor(input: {
         /^[A-Za-z0-9-]{1,128}$/.test(entry.slice(prefix.length, -4))
       ) {
         await rm(join(input.root, entry), { force: true });
+        removed = true;
       }
     }
-    await synchronizeDirectory(input.root);
+    if (removed) await syncDirectory(input.root);
   };
 
   const readFloor = async (): Promise<StoredVersionFloor> => {
@@ -167,7 +149,6 @@ export function createDesktopUpdateVersionFloor(input: {
       fileName: DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME,
       contents: `${JSON.stringify({ schemaVersion: 1, version })}\n`,
       mode: DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE,
-      createId,
     });
 
   return {

--- a/apps/desktop/tests/development-package-plan.test.ts
+++ b/apps/desktop/tests/development-package-plan.test.ts
@@ -82,7 +82,10 @@ describe("Desktop development package plan", () => {
       appId: "icu.enduragent.desktop",
       productName: "Enduragent",
       directories: { output: "dist" },
-      mac: { icon: "resources/app-icon.png" },
+      mac: {
+        icon: "resources/app-icon.png",
+        extendInfo: { ElectronSquirrelPreventDowngrades: true },
+      },
     });
     const release = await createMacosReleasePlan(
       {

--- a/apps/desktop/tests/update-controller.test.ts
+++ b/apps/desktop/tests/update-controller.test.ts
@@ -7,6 +7,7 @@ import {
   DESKTOP_UPDATE_INTERVAL_MS,
   type DesktopAutoUpdater,
 } from "../src/main/update-controller.js";
+import type { DesktopUpdateVersionFloor } from "../src/main/update-version-floor.js";
 
 interface Deferred<T> {
   readonly promise: Promise<T>;
@@ -34,6 +35,15 @@ function updateResult(
 
 function fakeCancellationToken() {
   return { cancel: vi.fn() };
+}
+
+function readyVersionFloor(version?: string): DesktopUpdateVersionFloor {
+  return {
+    recordRunningVersion: vi.fn(async (runningVersion) => ({
+      status: "ready",
+      version: version ?? runningVersion,
+    })),
+  };
 }
 
 function fakeDeadlines() {
@@ -125,6 +135,7 @@ function activeController(
   const controller = createDesktopUpdateController({
     releaseEligible: true,
     currentVersion: "0.1.0",
+    versionFloor: readyVersionFloor(),
     loadUpdater: vi.fn(async () => updater),
     requestQuit: quit,
     setInterval: vi.fn((callback, interval) => {
@@ -148,9 +159,11 @@ describe("desktop update controller", () => {
   it("is silent when release eligibility is disabled", async () => {
     const loadUpdater = vi.fn();
     const setInterval = vi.fn();
+    const versionFloor = readyVersionFloor();
     const controller = createDesktopUpdateController({
       releaseEligible: false,
       currentVersion: "0.1.0",
+      versionFloor,
       loadUpdater,
       requestQuit: vi.fn(),
       setInterval,
@@ -160,6 +173,8 @@ describe("desktop update controller", () => {
     await controller.check();
 
     expect(controller.state()).toEqual({ status: "disabled" });
+    expect(versionFloor.recordRunningVersion).toHaveBeenCalledOnce();
+    expect(versionFloor.recordRunningVersion).toHaveBeenCalledWith("0.1.0");
     expect(loadUpdater).not.toHaveBeenCalled();
     expect(setInterval).not.toHaveBeenCalled();
   });
@@ -172,6 +187,7 @@ describe("desktop update controller", () => {
     const controller = createDesktopUpdateController({
       releaseEligible: true,
       currentVersion: "0.1.0",
+      versionFloor: readyVersionFloor(),
       loadUpdater,
       requestQuit: vi.fn(),
       setInterval,
@@ -187,6 +203,45 @@ describe("desktop update controller", () => {
     await controller.start();
     expect(loadUpdater).toHaveBeenCalledOnce();
     expect(setInterval).not.toHaveBeenCalled();
+  });
+
+  it("retries floor initialization on a manual check after failing closed", async () => {
+    const fake = fakeUpdater();
+    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("0.1.0"));
+    const recordRunningVersion = vi
+      .fn<DesktopUpdateVersionFloor["recordRunningVersion"]>()
+      .mockResolvedValueOnce({ status: "unavailable" })
+      .mockResolvedValueOnce({ status: "ready", version: "0.1.0" });
+    const loadUpdater = vi.fn(async () => fake.updater);
+    const log = vi.fn();
+    const timer = { unref: vi.fn() };
+    const setInterval = vi.fn(() => timer);
+    const controller = createDesktopUpdateController({
+      releaseEligible: true,
+      currentVersion: "0.1.0",
+      versionFloor: { recordRunningVersion },
+      loadUpdater,
+      requestQuit: vi.fn(),
+      log,
+      setInterval,
+    });
+
+    await controller.start();
+
+    expect(controller.state()).toEqual({ status: "failed", stage: "check" });
+    expect(log).toHaveBeenCalledWith("desktop-update-version-floor-unavailable");
+    expect(loadUpdater).not.toHaveBeenCalled();
+
+    await expect(Promise.all([controller.check(), controller.check()])).resolves.toEqual([
+      { status: "current" },
+      { status: "current" },
+    ]);
+    expect(recordRunningVersion).toHaveBeenCalledTimes(2);
+    expect(loadUpdater).toHaveBeenCalledOnce();
+    expect(setInterval).toHaveBeenCalledOnce();
+    expect(fake.updater.checkForUpdates).toHaveBeenCalledOnce();
+    expect(controller.state()).toEqual({ status: "current" });
+    controller.close();
   });
 
   it("configures a quiet updater, performs startup and unref'd six-hour checks, and cleans up", async () => {
@@ -289,6 +344,57 @@ describe("desktop update controller", () => {
     expect(JSON.stringify(subject.controller.state())).not.toContain("raw.zip");
   });
 
+  it("accepts a candidate equal to the recorded version floor", async () => {
+    const fake = fakeUpdater();
+    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("0.2.0"));
+    const subject = activeController(fake.updater, {
+      versionFloor: readyVersionFloor("0.2.0"),
+    });
+
+    const startup = subject.controller.start();
+    await vi.waitFor(() => expect(fake.updater.downloadUpdate).toHaveBeenCalledOnce());
+    expect(subject.controller.state()).toEqual({ status: "downloading", version: "0.2.0" });
+    fake.emit("update-downloaded", { version: "0.2.0" });
+    await startup;
+  });
+
+  it("accepts a candidate higher than the recorded version floor", async () => {
+    const fake = fakeUpdater();
+    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("0.3.0"));
+    const subject = activeController(fake.updater, {
+      versionFloor: readyVersionFloor("0.2.0"),
+    });
+
+    const startup = subject.controller.start();
+    await vi.waitFor(() => expect(fake.updater.downloadUpdate).toHaveBeenCalledOnce());
+    expect(subject.controller.state()).toEqual({ status: "downloading", version: "0.3.0" });
+    fake.emit("update-downloaded", { version: "0.3.0" });
+    await startup;
+  });
+
+  it("refuses and reports a candidate lower than the recorded version floor", async () => {
+    const fake = fakeUpdater();
+    const token = fakeCancellationToken();
+    const log = vi.fn();
+    vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult("0.1.1", true, token));
+    const subject = activeController(fake.updater, {
+      versionFloor: readyVersionFloor("0.2.0"),
+      log,
+    });
+    const states: unknown[] = [];
+    subject.controller.subscribe((state) => states.push(state));
+
+    await subject.controller.start();
+
+    expect(subject.controller.state()).toEqual({ status: "failed", stage: "check" });
+    expect(states).toContainEqual({ status: "failed", stage: "check" });
+    expect(log).toHaveBeenCalledWith(
+      "desktop-update-downgrade-refused candidate=0.1.1 floor=0.2.0",
+    );
+    expect(token.cancel).toHaveBeenCalledOnce();
+    expect(fake.updater.downloadUpdate).not.toHaveBeenCalled();
+  });
+
   it("resets the no-progress deadline only when transferred bytes advance", async () => {
     const fake = fakeUpdater();
     const download = deferred<never>();
@@ -359,8 +465,15 @@ describe("desktop update controller", () => {
     expect(token.cancel).toHaveBeenCalledOnce();
   });
 
-  it.each(["0.1.0", "0.0.9", "0.1.1-beta.1", "0.01.1", "0.1.9007199254740992", "not-a-version"])(
-    "refuses non-newer or non-stable target %s",
+  it.each([
+    "0.1.0",
+    "0.0.9",
+    "0.1.1-beta.1",
+    "0.01.1",
+    "0.1.9007199254740992",
+    "not-a-version",
+  ])(
+    "does not download a non-newer or non-stable target %s",
     async (version) => {
       const fake = fakeUpdater();
       vi.mocked(fake.updater.checkForUpdates).mockResolvedValue(updateResult(version));

--- a/apps/desktop/tests/update-controller.test.ts
+++ b/apps/desktop/tests/update-controller.test.ts
@@ -39,8 +39,8 @@ function fakeCancellationToken() {
 
 function readyVersionFloor(version?: string): DesktopUpdateVersionFloor {
   return {
-    recordRunningVersion: vi.fn(async (runningVersion) => ({
-      status: "ready",
+    recordRunningVersion: vi.fn(async (runningVersion: string) => ({
+      status: "ready" as const,
       version: version ?? runningVersion,
     })),
   };

--- a/apps/desktop/tests/update-version-floor.test.ts
+++ b/apps/desktop/tests/update-version-floor.test.ts
@@ -1,0 +1,116 @@
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDesktopUpdateVersionFloor,
+  DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE,
+  DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE,
+  DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME,
+} from "../src/main/update-version-floor.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("desktop update version floor", () => {
+  it("survives a restart and never falls below the highest version run", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-update-version-floor-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = join(temporaryRoot, "desktop-preferences-v1");
+    const firstProcess = createDesktopUpdateVersionFloor({ root });
+
+    await expect(firstProcess.recordRunningVersion("2.3.4")).resolves.toEqual({
+      status: "ready",
+      version: "2.3.4",
+    });
+
+    const restartedProcess = createDesktopUpdateVersionFloor({ root });
+    await expect(restartedProcess.recordRunningVersion("1.9.9")).resolves.toEqual({
+      status: "ready",
+      version: "2.3.4",
+    });
+  });
+
+  it("self-heals a corrupt record with the running version and survives another restart", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-update-version-floor-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = join(temporaryRoot, "desktop-preferences-v1");
+    const target = join(root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
+    const initial = createDesktopUpdateVersionFloor({ root });
+    await initial.recordRunningVersion("2.3.4");
+    await writeFile(target, "not-json\n");
+    const log = vi.fn();
+
+    const recovered = createDesktopUpdateVersionFloor({ root, log });
+    await expect(recovered.recordRunningVersion("1.2.3")).resolves.toEqual({
+      status: "ready",
+      version: "1.2.3",
+    });
+
+    expect(log).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith("desktop-update-version-floor-recovered");
+    await expect(readFile(target, "utf8")).resolves.toBe(
+      `${JSON.stringify({ schemaVersion: 1, version: "1.2.3" })}\n`,
+    );
+    expect((await lstat(root)).mode & 0o777).toBe(DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE);
+    expect((await lstat(target)).mode & 0o777).toBe(DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE);
+
+    const restarted = createDesktopUpdateVersionFloor({ root });
+    await expect(restarted.recordRunningVersion("1.0.0")).resolves.toEqual({
+      status: "ready",
+      version: "1.2.3",
+    });
+  });
+
+  it("accepts a valid future-schema floor with additional fields", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-update-version-floor-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = join(temporaryRoot, "desktop-preferences-v1");
+    const target = join(root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
+    await mkdir(root, { mode: DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE });
+    await chmod(root, DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE);
+    const contents = `${JSON.stringify({
+      schemaVersion: 2,
+      version: "3.4.5",
+      additionalField: true,
+    })}\n`;
+    await writeFile(target, contents, { mode: DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE });
+    await chmod(target, DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE);
+    const log = vi.fn();
+
+    const floor = createDesktopUpdateVersionFloor({ root, log });
+    await expect(floor.recordRunningVersion("2.0.0")).resolves.toEqual({
+      status: "ready",
+      version: "3.4.5",
+    });
+
+    await expect(readFile(target, "utf8")).resolves.toBe(contents);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("self-heals a future-schema record whose version is invalid", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-update-version-floor-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = join(temporaryRoot, "desktop-preferences-v1");
+    const target = join(root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
+    await mkdir(root, { mode: DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE });
+    await chmod(root, DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE);
+    await writeFile(target, JSON.stringify({ schemaVersion: 2, version: "invalid" }), {
+      mode: DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE,
+    });
+    await chmod(target, DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE);
+    const log = vi.fn();
+
+    const floor = createDesktopUpdateVersionFloor({ root, log });
+    await expect(floor.recordRunningVersion("1.2.3")).resolves.toEqual({
+      status: "ready",
+      version: "1.2.3",
+    });
+    expect(log).toHaveBeenCalledWith("desktop-update-version-floor-recovered");
+  });
+});


### PR DESCRIPTION
The desktop updater installs whatever the release feed serves as long as it is
validly signed. A replaced release asset — or a feed re-serving an older signed
build — installs as a normal "update". Signature checks cannot catch this: every
downgrade candidate carries the same Developer ID.

## What changed

**Persisted version floor.** The app records the highest version it has ever
run, in the same `desktop-preferences-v1` root and with the same
atomic-replace / 0700-0600 / symlink-and-owner hardening as the login-item
preference. Before downloading an update the controller compares the candidate
against the floor and refuses anything below it with a logged
`desktop-update-downgrade-refused` line and a published failed state — never
silently.

**Native protection.** `ElectronSquirrelPreventDowngrades` is enabled via
`extendInfo` for the mac build (the only shipped target), so Squirrel.Mac
enforces the same property below the app layer.

## Failure modes were the hard part (first attempt was rejected in review)

- **Corrupt floor file self-heals.** An unparseable, oversized, or
  newer-schema file is rewritten with the current running version — the floor
  the app can honestly attest to — and logged as
  `desktop-update-version-floor-recovered`. The first attempt permanently
  disabled auto-update for the install in this case, which is precisely the
  silent staleness this feature exists to prevent.
- **Failed floor initialization retries.** The updater is not loaded until the
  floor is established; a failed attempt resets so the next manual check
  retries instead of no-oping on cached state forever.
- **Legitimate publisher rollback keeps the old UX.** A feed whose latest is
  older than the installed version reports "up to date", exactly as before.
  The loud refusal is reserved for the genuine guard case: a candidate newer
  than the running version but below the persisted floor (possible after
  reinstalling an older build, since the floor survives).
- **Forward compatibility.** The floor parser tolerates newer schema versions
  and extra fields (same idiom as the login-item preference), so a future
  build's file cannot brick updates on an older build.

## Verification

- `pnpm --filter @enduragent/desktop check` (tsc) — clean, re-run after
  rebasing onto current main.
- 32/32 tests across the floor store, controller, and package plan, covering:
  equal/higher accepted, below-floor refused, older-than-current reports
  current, floor survives restart, corrupt file self-heals and the next check
  works.
- Independently re-verified by a fresh-context reviewer that ran both commands
  itself.

Includes a `@enduragent/desktop` patch changeset.
