### PR TITLE
ci: exit quietly when a superseded image build was cancelled

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -110,6 +110,48 @@ jobs:
             return 1
           }
 
+          fetch_main_tip() {
+            local attempt response remaining_seconds request_timeout retry_delay
+
+            for ((attempt = 1; attempt <= api_max_attempts; attempt++)); do
+              remaining_seconds=$((deadline - SECONDS))
+              if ((remaining_seconds <= 0)); then
+                return 124
+              fi
+
+              request_timeout=30
+              if ((request_timeout > remaining_seconds)); then
+                request_timeout=$remaining_seconds
+              fi
+
+              if response=$(timeout "${request_timeout}s" gh api --method GET \
+                "repos/${REPOSITORY}/commits/heads/main" | jq -er '.sha'); then
+                printf '%s\n' "$response"
+                return 0
+              fi
+
+              if ((attempt >= api_max_attempts)); then
+                echo "::warning::GitHub commits API request failed (attempt ${attempt}/${api_max_attempts})." >&2
+                break
+              fi
+
+              remaining_seconds=$((deadline - SECONDS))
+              if ((remaining_seconds <= 0)); then
+                echo "::warning::GitHub commits API request failed (attempt ${attempt}/${api_max_attempts}); the wait deadline was reached." >&2
+                break
+              fi
+
+              retry_delay=$api_retry_interval_seconds
+              if ((retry_delay > remaining_seconds)); then
+                retry_delay=$remaining_seconds
+              fi
+              echo "::warning::GitHub commits API request failed (attempt ${attempt}/${api_max_attempts}); retrying in ${retry_delay}s." >&2
+              sleep "$retry_delay"
+            done
+
+            return 1
+          }
+
           while true; do
             if runs_json=$(fetch_runs); then
               :
@@ -157,6 +199,21 @@ jobs:
                   echo "publish-image.yml run #${run_number} (${run_id}) succeeded."
                   echo "ready=true" >> "$GITHUB_OUTPUT"
                   exit 0
+                fi
+
+                if [[ "$conclusion" == "cancelled" ]]; then
+                  if tip_sha=$(fetch_main_tip); then
+                    :
+                  else
+                    echo "::error::Could not determine the current main branch tip after publish-image.yml run #${run_number} (${run_id}) was cancelled; stable was not promoted."
+                    exit 1
+                  fi
+
+                  if [[ "$HEAD_SHA" != "$tip_sha" ]]; then
+                    echo "::notice::publish-image.yml run #${run_number} (${run_id}) for ${HEAD_SHA} was cancelled after main advanced to ${tip_sha}; a newer commit's promotion will set stable."
+                    echo "ready=false" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
                 fi
 
                 echo "::error::publish-image.yml run #${run_number} (${run_id}) concluded '${conclusion:-unknown}'; stable was not promoted."

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -64,7 +64,9 @@ jobs:
           deadline=$((SECONDS + max_wait_seconds))
           seen_run=false
 
-          fetch_runs() {
+          fetch_api() {
+            local label=$1 jq_program=$2
+            shift 2
             local attempt response remaining_seconds request_timeout retry_delay
 
             for ((attempt = 1; attempt <= api_max_attempts; attempt++)); do
@@ -78,11 +80,7 @@ jobs:
                 request_timeout=$remaining_seconds
               fi
 
-              if response=$(timeout "${request_timeout}s" gh api --method GET \
-                "repos/${REPOSITORY}/actions/workflows/publish-image.yml/runs" \
-                -f "head_sha=${HEAD_SHA}" \
-                -f "per_page=100" | \
-                jq -ce '.workflow_runs | if type == "array" then . else error("missing workflow_runs array") end'); then
+              if response=$(timeout "${request_timeout}s" gh api --method GET "$@" | jq -cer "$jq_program"); then
                 printf '%s\n' "$response"
                 return 0
               fi
@@ -97,7 +95,7 @@ jobs:
                 if ((retry_delay > remaining_seconds)); then
                   retry_delay=$remaining_seconds
                 fi
-                echo "::warning::GitHub Actions API request failed (attempt ${attempt}/${api_max_attempts}); retrying in ${retry_delay}s." >&2
+                echo "::warning::${label} request failed (attempt ${attempt}/${api_max_attempts}); retrying in ${retry_delay}s." >&2
                 sleep "$retry_delay"
               fi
             done
@@ -106,50 +104,20 @@ jobs:
               return 124
             fi
 
-            echo "::error::GitHub Actions API request or response validation failed after ${api_max_attempts} attempts." >&2
+            echo "::error::${label} request or response validation failed after ${api_max_attempts} attempts." >&2
             return 1
           }
 
+          fetch_runs() {
+            fetch_api "GitHub Actions API" \
+              '.workflow_runs | if type == "array" then . else error("missing workflow_runs array") end' \
+              "repos/${REPOSITORY}/actions/workflows/publish-image.yml/runs" \
+              -f "head_sha=${HEAD_SHA}" \
+              -f "per_page=100"
+          }
+
           fetch_main_tip() {
-            local attempt response remaining_seconds request_timeout retry_delay
-
-            for ((attempt = 1; attempt <= api_max_attempts; attempt++)); do
-              remaining_seconds=$((deadline - SECONDS))
-              if ((remaining_seconds <= 0)); then
-                return 124
-              fi
-
-              request_timeout=30
-              if ((request_timeout > remaining_seconds)); then
-                request_timeout=$remaining_seconds
-              fi
-
-              if response=$(timeout "${request_timeout}s" gh api --method GET \
-                "repos/${REPOSITORY}/commits/heads/main" | jq -er '.sha'); then
-                printf '%s\n' "$response"
-                return 0
-              fi
-
-              if ((attempt >= api_max_attempts)); then
-                echo "::warning::GitHub commits API request failed (attempt ${attempt}/${api_max_attempts})." >&2
-                break
-              fi
-
-              remaining_seconds=$((deadline - SECONDS))
-              if ((remaining_seconds <= 0)); then
-                echo "::warning::GitHub commits API request failed (attempt ${attempt}/${api_max_attempts}); the wait deadline was reached." >&2
-                break
-              fi
-
-              retry_delay=$api_retry_interval_seconds
-              if ((retry_delay > remaining_seconds)); then
-                retry_delay=$remaining_seconds
-              fi
-              echo "::warning::GitHub commits API request failed (attempt ${attempt}/${api_max_attempts}); retrying in ${retry_delay}s." >&2
-              sleep "$retry_delay"
-            done
-
-            return 1
+            fetch_api "GitHub commits API" '.object.sha' "repos/${REPOSITORY}/git/ref/heads/main"
           }
 
           while true; do


### PR DESCRIPTION
Observed on the first live day of `promote-stable.yml`: three commits merged to
main within ninety seconds, GitHub cancelled the middle commit's pending
`publish-image` run (documented concurrency behaviour), and the promote job
failed loudly for that commit — even though the tip promoted `:stable`
correctly moments later. Pure noise, and rapid back-to-back merges will
reproduce it regularly.

## What changed

When the publish-image run concluded `cancelled`, the job now checks whether
its commit is still the tip of `main`:

- **No longer the tip** → superseded; exit 0 with a `::notice::` and no
  promotion. The newer commit's own promotion sets `:stable`.
- **Still the tip** → genuine stale-`:stable` condition; the loud failure is
  kept unchanged.

The tip lookup goes through a `fetch_main_tip` helper with the same resilience
idiom as the existing run lookup — bounded request timeout, three attempts,
`::warning::` per failed attempt — because a review of the first version
caught that a bare `gh api` call here would reproduce the exact transient red
this change exists to remove. If the tip cannot be determined at all, the job
still fails loudly rather than swallowing the cancelled case.

Every other conclusion (`failure`, `timed_out`, wait-timeout) keeps its loud
behaviour. The four-part `workflow_run` guard, concurrency group, and digest
verification are untouched.

## Accepted edge

If main advances for an unrelated reason between a genuine (non-superseded)
cancellation and the tip check, the skip is quiet — accepted, because the newer
commit's promotion supersedes it anyway, and its own CI/promotion failures are
independently visible.
