### PR TITLE
chore(ci): add weekly npm Dependabot coverage for the workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,22 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  # Dependabot discovers pnpm workspace members from pnpm-workspace.yaml, so one root entry covers their manifests.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "fit-file-parser"
+    # Bundle compatible routine updates to keep PR volume manageable; major
+    # upgrades remain separate so their migration risk can be reviewed alone.
+    groups:
+      routine-updates:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: docker
     directory: /packages/cycling-coach
     schedule:


### PR DESCRIPTION
Adds weekly npm Dependabot coverage for the pnpm workspace alongside the
existing `github-actions` and `docker` entries. Patch/minor updates are grouped
into a single routine PR to bound volume for a solo maintainer; majors surface
individually.

Two deliberate details, both from review findings:

- **`fit-file-parser` is excluded.** Its exact pin carries a version-keyed pnpm
  patch (`patches/fit-file-parser@3.0.2.patch`); an automated bump would leave
  the patch key matching no installed version — a self-breaking PR.
- **Scope honesty:** Dependabot version updates rewrite manifests and do not
  bump transitive-only dependencies. The remaining audit advisories
  (`fast-uri`, `valibot`, `hono`) are all transitive; if they need closing it
  will be via pnpm overrides, the mechanism this repo already uses. This PR is
  the recurrence guard for direct dependencies, not the fix for those
  advisories.
