### PR TITLE
feat(desktop): add Intervals.icu clipboard credential lane

### DIFF
--- a/.changeset/copied-intervals-credential.md
+++ b/.changeset/copied-intervals-credential.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Connect Intervals.icu by copying your API key - no typing it into the app.

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -312,6 +312,7 @@ async function security() {
             "onChatgptLoginProgress",
             "onDroppedImportFiles",
             "onUpdateState",
+            "pasteIntervalsApiKeyFromClipboard",
             "pasteTelegramTokenFromClipboard",
             "reconcileTelegram",
             "releaseNotes",

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -14,6 +14,8 @@ export const DESKTOP_UPDATE_GET_CHANNEL = "desktop:update:get" as const;
 export const DESKTOP_UPDATE_CHECK_CHANNEL = "desktop:update:check" as const;
 export const DESKTOP_UPDATE_RESTART_CHANNEL = "desktop:update:restart" as const;
 export const DESKTOP_UPDATE_STATE_CHANNEL = "desktop:update:state" as const;
+export const DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL =
+  "desktop:intervals:paste-credential" as const;
 export const DESKTOP_TELEGRAM_STATUS_CHANNEL = "desktop:telegram:status" as const;
 export const DESKTOP_TELEGRAM_PASTE_CREDENTIAL_CHANNEL =
   "desktop:telegram:paste-credential" as const;

--- a/apps/desktop/src/main/credential-runtime.ts
+++ b/apps/desktop/src/main/credential-runtime.ts
@@ -6,7 +6,11 @@ import {
   type RuntimeConfigSnapshot,
 } from "@enduragent/coach-contract";
 import { CHATGPT_PROFILE_NAME } from "./chatgpt-auth.js";
-import type { CredentialRuntimeState, DesktopCredentialSlot } from "./credential-vault.js";
+import {
+  CredentialRuntimeRefusal,
+  type CredentialRuntimeState,
+  type DesktopCredentialSlot,
+} from "./credential-vault.js";
 import { runtimeConfigurationForCredential } from "./onboarding-ipc.js";
 
 export type DesktopManagedCredential = DesktopCredentialSlot | typeof CHATGPT_PROFILE_NAME;
@@ -51,7 +55,7 @@ export interface RuntimeConfigurationAuthority {
   clearCredential(
     credential: DesktopManagedCredential,
   ): Promise<"cleared" | "not-active" | "managed-by-environment">;
-  getRuntimeConfig(): Promise<RuntimeConfigSnapshot>;
+  getRuntimeConfig(signal?: AbortSignal): Promise<RuntimeConfigSnapshot>;
 }
 
 export function runtimeConfigurationForCredentialDeletion(
@@ -113,6 +117,9 @@ export function createConnectionRuntimeAuthority(
             : client.call("configureRuntime", request, { signal }),
         signal,
       );
+      if ("status" in result && result.status === "refused") {
+        throw new CredentialRuntimeRefusal(result.reason);
+      }
       if (
         !("status" in result) ||
         result.status !== "applied" ||
@@ -142,8 +149,14 @@ export function createConnectionRuntimeAuthority(
       }
       return "cleared";
     },
-    getRuntimeConfig() {
-      return call((client) => client.call("getRuntimeConfig", {}));
+    getRuntimeConfig(signal) {
+      return call(
+        (client) =>
+          signal === undefined
+            ? client.call("getRuntimeConfig", {})
+            : client.call("getRuntimeConfig", {}, { signal }),
+        signal,
+      );
     },
   };
 }

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { lstat, mkdir, open, readFile, readdir, rename, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { isKeylessProvider } from "@enduragent/coach-contract";
+import {
+  isKeylessProvider,
+  type ConfigureRuntimeRpcRefusalReason,
+} from "@enduragent/coach-contract";
 import {
   parseOnboardingLlmSelection,
   type OnboardingLlmSelection,
@@ -47,7 +50,8 @@ export type CredentialWriteResult =
         | "encryption-unavailable"
         | "unsafe-backend"
         | "storage-failed"
-        | "runtime-unavailable";
+        | "runtime-unavailable"
+        | "training-account-mismatch";
     }
   | {
       readonly slot: DesktopCredentialSlot;
@@ -77,6 +81,31 @@ export type CredentialDeleteResult =
       readonly reason: "storage-uncertain";
     };
 
+export interface CredentialWriteInput {
+  readonly slot: DesktopCredentialSlot;
+  readonly value: string;
+  readonly selection?: OnboardingLlmSelection;
+}
+
+export interface CredentialWriteBehavior {
+  readonly activate?: boolean;
+  readonly rollbackOnRuntimeRefusal?: boolean;
+}
+
+export interface CredentialVaultMutation {
+  writeCredential(
+    input: CredentialWriteInput,
+    behavior?: CredentialWriteBehavior,
+  ): Promise<CredentialWriteResult>;
+  credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
+}
+
+export class CredentialRuntimeRefusal extends Error {
+  constructor(readonly reason: ConfigureRuntimeRpcRefusalReason) {
+    super();
+  }
+}
+
 export const CREDENTIAL_DIRECTORY_NAME = "credentials-v1" as const;
 export const CREDENTIAL_DIRECTORY_MODE = 0o700;
 export const CREDENTIAL_FILE_MODE = 0o600;
@@ -91,15 +120,10 @@ export interface CredentialEncryptionPort {
 
 export interface CredentialVault {
   writeCredential(
-    input: {
-      readonly slot: DesktopCredentialSlot;
-      readonly value: string;
-      readonly selection?: OnboardingLlmSelection;
-    },
-    behavior?: {
-      readonly activate?: boolean;
-    },
+    input: CredentialWriteInput,
+    behavior?: CredentialWriteBehavior,
   ): Promise<CredentialWriteResult>;
+  runExclusiveMutation<T>(operation: (mutation: CredentialVaultMutation) => Promise<T>): Promise<T>;
   applyLlmSelection(input: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
   deleteCredential(slot: DesktopCredentialSlot): Promise<CredentialDeleteResult>;
@@ -471,117 +495,203 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     }
   };
 
-  return {
-    writeCredential(input, behavior): Promise<CredentialWriteResult> {
-      return exclusive(async () => {
-        if (!isCredentialSlot(input?.slot) || typeof input.value !== "string") {
-          return {
-            slot: isCredentialSlot(input?.slot) ? input.slot : "anthropic",
-            status: "refused",
-            reason: "invalid-input",
-          };
+  const writeCredential = async (
+    input: CredentialWriteInput,
+    behavior?: CredentialWriteBehavior,
+  ): Promise<CredentialWriteResult> => {
+    if (!isCredentialSlot(input?.slot) || typeof input.value !== "string") {
+      return {
+        slot: isCredentialSlot(input?.slot) ? input.slot : "anthropic",
+        status: "refused",
+        reason: "invalid-input",
+      };
+    }
+    let selection: OnboardingLlmSelection | undefined;
+    try {
+      if (input.selection !== undefined) {
+        selection = parseOnboardingLlmSelection(input.selection);
+        if (input.slot === "intervals-icu" || selection.provider !== input.slot) {
+          throw new TypeError();
         }
-        let selection: OnboardingLlmSelection | undefined;
-        try {
-          if (input.selection !== undefined) {
-            selection = parseOnboardingLlmSelection(input.selection);
-            if (input.slot === "intervals-icu" || selection.provider !== input.slot) {
-              throw new TypeError();
+      }
+    } catch {
+      return { slot: input.slot, status: "refused", reason: "invalid-input" };
+    }
+    const value = input.value.trim();
+    if (value.length === 0) {
+      return { slot: input.slot, status: "refused", reason: "invalid-input" };
+    }
+    try {
+      if (!options.encryption.isEncryptionAvailable()) {
+        return { slot: input.slot, status: "refused", reason: "encryption-unavailable" };
+      }
+      if (options.encryption.getSelectedStorageBackend?.() === UNSAFE_STORAGE_BACKEND) {
+        return { slot: input.slot, status: "refused", reason: "unsafe-backend" };
+      }
+    } catch {
+      return { slot: input.slot, status: "refused", reason: "encryption-unavailable" };
+    }
+    const durability = await reconcileDurability();
+    if (durability === "uncertain") {
+      return { slot: input.slot, status: "uncertain", reason: "storage-uncertain" };
+    }
+    if (durability !== "verified") {
+      return { slot: input.slot, status: "refused", reason: "storage-failed" };
+    }
+    if (!(await secureDirectory(options.root))) {
+      return { slot: input.slot, status: "refused", reason: "storage-failed" };
+    }
+    if (!parentDirectoryVerified) {
+      try {
+        await syncCredentialParentDirectory(dirname(options.root));
+        parentDirectoryVerified = true;
+      } catch {
+        return { slot: input.slot, status: "refused", reason: "storage-failed" };
+      }
+    }
+    const target = join(options.root, `${input.slot}.bin`);
+    if (!(await validTarget(target))) {
+      return { slot: input.slot, status: "refused", reason: "storage-failed" };
+    }
+    const previousRuntimeState = runtimeState.get(input.slot);
+    let encrypted: Buffer | undefined;
+    let previous: Buffer | undefined;
+    try {
+      try {
+        previous = await readCredentialFile(target);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+      encrypted = options.encryption.encryptString(value);
+      if (!Buffer.isBuffer(encrypted) || encrypted.length === 0) throw new TypeError();
+      const stored = await durablyReplaceReversible({
+        root: options.root,
+        fileName: `${input.slot}.bin`,
+        contents: encrypted,
+        previousContents: previous,
+        mode: CREDENTIAL_FILE_MODE,
+        createId,
+        renameFile: renameCredentialFile,
+        removeFile: removeCredentialFile,
+        syncDirectory: syncCredentialDirectory,
+      });
+      if (stored.state === "refused") {
+        uncertainSlots.delete(input.slot);
+        return { slot: input.slot, status: "refused", reason: "storage-failed" };
+      }
+      if (stored.state === "uncertain") {
+        uncertainSlots.add(input.slot);
+        return { slot: input.slot, status: "uncertain", reason: "storage-uncertain" };
+      }
+      uncertainSlots.delete(input.slot);
+      setRuntimeState(input.slot, "failed");
+      if (behavior?.activate === false) {
+        setRuntimeState(input.slot, "stored-inactive");
+        return { slot: input.slot, status: "configured", runtimeReady: false };
+      }
+      try {
+        const canPublish = options.createRuntimePublicationGuard?.(input.slot);
+        if (selection === undefined) {
+          await options.applyCredential(input.slot, value);
+        } else {
+          await options.applyCredential(input.slot, value, selection);
+        }
+        if (canPublish !== undefined && !canPublish()) throw new TypeError();
+        setRuntimeState(input.slot, "active");
+        return { slot: input.slot, status: "configured", runtimeReady: true };
+      } catch (error) {
+        if (
+          behavior?.rollbackOnRuntimeRefusal === true &&
+          error instanceof CredentialRuntimeRefusal
+        ) {
+          let storageRestored = false;
+          try {
+            if (previous === undefined) {
+              const removed = await removeStoredCredential(input.slot);
+              storageRestored = removed === "deleted" || removed === "cleanup-pending";
+            } else {
+              const restored = await durablyReplaceReversible({
+                root: options.root,
+                fileName: `${input.slot}.bin`,
+                contents: previous,
+                previousContents: encrypted,
+                mode: CREDENTIAL_FILE_MODE,
+                createId,
+                renameFile: renameCredentialFile,
+                removeFile: removeCredentialFile,
+                syncDirectory: syncCredentialDirectory,
+              });
+              storageRestored = restored.state === "applied";
             }
-          }
-        } catch {
-          return { slot: input.slot, status: "refused", reason: "invalid-input" };
-        }
-        const value = input.value.trim();
-        if (value.length === 0) {
-          return { slot: input.slot, status: "refused", reason: "invalid-input" };
-        }
-        try {
-          if (!options.encryption.isEncryptionAvailable()) {
-            return { slot: input.slot, status: "refused", reason: "encryption-unavailable" };
-          }
-          if (options.encryption.getSelectedStorageBackend?.() === UNSAFE_STORAGE_BACKEND) {
-            return { slot: input.slot, status: "refused", reason: "unsafe-backend" };
-          }
-        } catch {
-          return { slot: input.slot, status: "refused", reason: "encryption-unavailable" };
-        }
-        const durability = await reconcileDurability();
-        if (durability === "uncertain") {
-          return { slot: input.slot, status: "uncertain", reason: "storage-uncertain" };
-        }
-        if (durability !== "verified") {
-          return { slot: input.slot, status: "refused", reason: "storage-failed" };
-        }
-        if (!(await secureDirectory(options.root))) {
-          return { slot: input.slot, status: "refused", reason: "storage-failed" };
-        }
-        if (!parentDirectoryVerified) {
-          try {
-            await syncCredentialParentDirectory(dirname(options.root));
-            parentDirectoryVerified = true;
-          } catch {
-            return { slot: input.slot, status: "refused", reason: "storage-failed" };
-          }
-        }
-        const target = join(options.root, `${input.slot}.bin`);
-        if (!(await validTarget(target))) {
-          return { slot: input.slot, status: "refused", reason: "storage-failed" };
-        }
-        let encrypted: Buffer | undefined;
-        let previous: Buffer | undefined;
-        try {
-          try {
-            previous = await readCredentialFile(target);
-          } catch (error) {
-            if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-          }
-          encrypted = options.encryption.encryptString(value);
-          if (!Buffer.isBuffer(encrypted) || encrypted.length === 0) throw new TypeError();
-          const stored = await durablyReplaceReversible({
-            root: options.root,
-            fileName: `${input.slot}.bin`,
-            contents: encrypted,
-            previousContents: previous,
-            mode: CREDENTIAL_FILE_MODE,
-            createId,
-            renameFile: renameCredentialFile,
-            removeFile: removeCredentialFile,
-            syncDirectory: syncCredentialDirectory,
-          });
-          if (stored.state === "refused") {
-            uncertainSlots.delete(input.slot);
-            return { slot: input.slot, status: "refused", reason: "storage-failed" };
-          }
-          if (stored.state === "uncertain") {
+          } catch {}
+          if (!storageRestored) {
             uncertainSlots.add(input.slot);
+            setRuntimeState(input.slot, "failed");
             return { slot: input.slot, status: "uncertain", reason: "storage-uncertain" };
           }
           uncertainSlots.delete(input.slot);
-          setRuntimeState(input.slot, "failed");
-        } catch {
-          return { slot: input.slot, status: "refused", reason: "storage-failed" };
-        } finally {
-          previous?.fill(0);
-          encrypted?.fill(0);
-        }
-        if (behavior?.activate === false) {
-          setRuntimeState(input.slot, "stored-inactive");
-          return { slot: input.slot, status: "configured", runtimeReady: false };
-        }
-        try {
-          const canPublish = options.createRuntimePublicationGuard?.(input.slot);
-          if (selection === undefined) {
-            await options.applyCredential(input.slot, value);
+          if (previous === undefined) {
+            clearRuntimeState(input.slot);
           } else {
-            await options.applyCredential(input.slot, value, selection);
+            setRuntimeState(input.slot, previousRuntimeState ?? "stored-inactive");
           }
-          if (canPublish !== undefined && !canPublish()) throw new TypeError();
-          setRuntimeState(input.slot, "active");
-          return { slot: input.slot, status: "configured", runtimeReady: true };
-        } catch {
-          setRuntimeState(input.slot, "failed");
-          return { slot: input.slot, status: "configured", runtimeReady: false };
+          return {
+            slot: input.slot,
+            status: "refused",
+            reason:
+              error.reason === "training-account-mismatch"
+                ? "training-account-mismatch"
+                : "runtime-unavailable",
+          };
+        }
+        setRuntimeState(input.slot, "failed");
+        return { slot: input.slot, status: "configured", runtimeReady: false };
+      }
+    } catch {
+      return { slot: input.slot, status: "refused", reason: "storage-failed" };
+    } finally {
+      previous?.fill(0);
+      encrypted?.fill(0);
+    }
+  };
+
+  const credentialStatuses = async (): Promise<readonly CredentialSlotStatus[]> => {
+    const entries = await readAll();
+    return entries.map((entry) => ({
+      slot: entry.slot,
+      state: entry.state,
+      runtimeState:
+        entry.state === "configured" ? (runtimeState.get(entry.slot) ?? "stored-inactive") : null,
+    }));
+  };
+
+  return {
+    writeCredential(input, behavior): Promise<CredentialWriteResult> {
+      return exclusive(() => writeCredential(input, behavior));
+    },
+
+    runExclusiveMutation<T>(
+      operation: (current: CredentialVaultMutation) => Promise<T>,
+    ): Promise<T> {
+      return exclusive(async () => {
+        let active = true;
+        const mutation = Object.freeze({
+          writeCredential(
+            input: CredentialWriteInput,
+            behavior?: CredentialWriteBehavior,
+          ): Promise<CredentialWriteResult> {
+            if (!active) throw new TypeError();
+            return writeCredential(input, behavior);
+          },
+          credentialStatuses(): Promise<readonly CredentialSlotStatus[]> {
+            if (!active) throw new TypeError();
+            return credentialStatuses();
+          },
+        }) satisfies CredentialVaultMutation;
+        try {
+          return await operation(mutation);
+        } finally {
+          active = false;
         }
       });
     },
@@ -617,17 +727,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     },
 
     credentialStatuses(): Promise<readonly CredentialSlotStatus[]> {
-      return exclusive(async () => {
-        const entries = await readAll();
-        return entries.map((entry) => ({
-          slot: entry.slot,
-          state: entry.state,
-          runtimeState:
-            entry.state === "configured"
-              ? (runtimeState.get(entry.slot) ?? "stored-inactive")
-              : null,
-        }));
-      });
+      return exclusive(credentialStatuses);
     },
 
     deleteCredential(slot): Promise<CredentialDeleteResult> {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -24,6 +24,10 @@ import { installDesktopConnectionIpc } from "./connection-ipc.js";
 import { installDesktopExternalLinkIpc } from "./external-link-ipc.js";
 import { DESKTOP_LIFECYCLE_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
 import {
+  createDesktopIntervalsCredentialVerifier,
+  installDesktopIntervalsIpc,
+} from "./intervals-ipc.js";
+import {
   createConnectionRuntimeAuthority,
   createCredentialRuntimeApplication,
   intervalsAthleteIdForOwnership,
@@ -197,6 +201,7 @@ async function runDesktop(): Promise<void> {
   let disposeExternalLinkIpc: (() => void) | undefined;
   let disposeReleaseNotesIpc: (() => void) | undefined;
   let disposeUpdateIpc: (() => void) | undefined;
+  let disposeIntervalsIpc: (() => Promise<void>) | undefined;
   let disposeTelegramIpc: (() => Promise<void>) | undefined;
   let disposeOnboarding: (() => void) | undefined;
   let telegramPower: DesktopTelegramPowerLifecycle | undefined;
@@ -222,10 +227,12 @@ async function runDesktop(): Promise<void> {
     shutdownPromise ??= (async () => {
       const residencyClose = residency?.close();
       residency = undefined;
+      const intervalsIpcClose = disposeIntervalsIpc?.();
+      disposeIntervalsIpc = undefined;
       const telegramIpcClose = disposeTelegramIpc?.();
       disposeTelegramIpc = undefined;
       await residencyClose;
-      await telegramIpcClose;
+      await Promise.all([intervalsIpcClose, telegramIpcClose]);
       controller.abort();
       disposeConnectionIpc?.();
       disposeConnectionIpc = undefined;
@@ -298,6 +305,7 @@ async function runDesktop(): Promise<void> {
     const selectedAthleteHome = AthleteHomeIdentitySchema.parse(
       await realpath(resolveDesktopAthleteHome(environment)),
     );
+    const intervalsStorePath = join(selectedAthleteHome, "store", "store.db");
     requireDesktopDaemonHome(selectedAthleteHome, resolution.athleteHome);
     const telegramSecureStorageDiagnostics = createTelegramSecureStorageDiagnostics();
     const telegramVault = createTelegramCredentialVault({
@@ -479,11 +487,11 @@ async function runDesktop(): Promise<void> {
       token: resolution.token,
       athleteHome: resolution.athleteHome,
     });
-    const readActiveRuntimeConfig = async () => {
+    const readActiveRuntimeConfig = async (signal?: AbortSignal) => {
       const binding = activeRuntimeBinding;
       const lifecycleState = daemonLifecycle?.snapshot();
       if (binding === undefined || lifecycleState?.status !== "ready") throw new TypeError();
-      const snapshot = await binding.authority.getRuntimeConfig();
+      const snapshot = await binding.authority.getRuntimeConfig(signal);
       const currentLifecycleState = daemonLifecycle?.snapshot();
       if (
         activeRuntimeBinding !== binding ||
@@ -802,16 +810,13 @@ async function runDesktop(): Promise<void> {
             },
             checkIntervalsCredentialOwner: async (value) => {
               const snapshot = await activeRuntimeBinding!.authority.getRuntimeConfig();
-              return checkIntervalsStoreOwnerAtPath(
-                join(selectedAthleteHome, "store", "store.db"),
-                {
-                  apiKey: value,
-                  athleteId: intervalsAthleteIdForOwnership(snapshot),
-                  historyNewestDate: "1970-01-01",
-                  clock: { now: () => Date.now(), monotonicNow: () => performance.now() },
-                  signal: controller.signal,
-                },
-              );
+              return checkIntervalsStoreOwnerAtPath(intervalsStorePath, {
+                apiKey: value,
+                athleteId: intervalsAthleteIdForOwnership(snapshot),
+                historyNewestDate: "1970-01-01",
+                clock: { now: () => Date.now(), monotonicNow: () => performance.now() },
+                signal: controller.signal,
+              });
             },
             isTrusted: (event) =>
               isTrustedConnectionRequest(event, mainWindow.current() ?? undefined),
@@ -877,6 +882,17 @@ async function runDesktop(): Promise<void> {
       currentWindow: () => mainWindow.current() ?? undefined,
       isTrusted: (event) => isTrustedConnectionRequest(event, mainWindow.current() ?? undefined),
       controller: updateController,
+    });
+    disposeIntervalsIpc = installDesktopIntervalsIpc({
+      ipcMain,
+      clipboard,
+      vault,
+      signal: controller.signal,
+      isTrusted: (event) => isTrustedConnectionRequest(event, mainWindow.current() ?? undefined),
+      verifyCredential: createDesktopIntervalsCredentialVerifier({
+        storePath: intervalsStorePath,
+        readRuntimeConfig: readActiveRuntimeConfig,
+      }),
     });
     disposeTelegramIpc = installDesktopTelegramIpc({
       ipcMain,

--- a/apps/desktop/src/main/intervals-ipc.ts
+++ b/apps/desktop/src/main/intervals-ipc.ts
@@ -1,0 +1,437 @@
+import {
+  INTERVALS_CREDENTIAL_VERIFICATION_TIMEOUT_MS,
+  verifyIntervalsCredentialAtPath,
+  type IntervalsCredentialVerificationRefusalReason,
+  type IntervalsCredentialVerificationResult,
+} from "@enduragent/coach/backfill";
+import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
+import type { Clipboard, IpcMain, IpcMainInvokeEvent } from "electron";
+import { DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL } from "./constants.js";
+import { intervalsAthleteIdForOwnership } from "./credential-runtime.js";
+import type {
+  CredentialRuntimeState,
+  CredentialState,
+  CredentialVault,
+} from "./credential-vault.js";
+
+const VERIFICATION_REFUSAL_REASONS = new Set<IntervalsCredentialVerificationRefusalReason>([
+  "credential-rejected",
+  "malformed-athlete-response",
+  "validation-timeout",
+  "validation-aborted",
+  "validation-unavailable",
+  "training-account-mismatch",
+  "owner-unresolved",
+  "store-unavailable",
+]);
+const STORAGE_REFUSAL_REASONS = new Set([
+  "encryption-unavailable",
+  "unsafe-backend",
+  "storage-failed",
+  "runtime-unavailable",
+]);
+const INTERVALS_API_KEY_MAX_LENGTH = 256;
+
+export interface DesktopIntervalsCredentialStatus {
+  readonly slot: "intervals-icu";
+  readonly state: CredentialState;
+  readonly runtimeState: CredentialRuntimeState | null;
+}
+
+export type DesktopIntervalsMutationRefusalReason =
+  | "clipboard-unavailable"
+  | "clipboard-clear-failed"
+  | "invalid-key-format"
+  | IntervalsCredentialVerificationRefusalReason
+  | "encryption-unavailable"
+  | "unsafe-backend"
+  | "storage-failed"
+  | "runtime-unavailable";
+
+export type DesktopIntervalsMutationResult =
+  | Readonly<{ outcome: "applied"; current: DesktopIntervalsCredentialStatus }>
+  | Readonly<{
+      outcome: "refused";
+      reason: DesktopIntervalsMutationRefusalReason;
+      current: DesktopIntervalsCredentialStatus;
+    }>
+  | Readonly<{
+      outcome: "uncertain";
+      reason: "storage-uncertain" | "runtime-uncertain";
+      current: DesktopIntervalsCredentialStatus;
+    }>;
+
+export function createDesktopIntervalsCredentialVerifier(input: {
+  readonly storePath: string;
+  readonly readRuntimeConfig: (signal?: AbortSignal) => Promise<RuntimeConfigSnapshot>;
+}): (apiKey: string, signal: AbortSignal) => Promise<IntervalsCredentialVerificationResult> {
+  return async (apiKey, signal) => {
+    let snapshot: RuntimeConfigSnapshot;
+    try {
+      snapshot = await input.readRuntimeConfig(signal);
+    } catch {
+      return { status: "refused", reason: "validation-unavailable" };
+    }
+    return verifyIntervalsCredentialAtPath(input.storePath, {
+      apiKey,
+      athleteId: intervalsAthleteIdForOwnership(snapshot),
+      historyNewestDate: "1970-01-01",
+      clock: { now: () => Date.now(), monotonicNow: () => performance.now() },
+      signal,
+    });
+  };
+}
+
+type DesktopIntervalsMutationCore =
+  | Readonly<{ outcome: "applied" }>
+  | Readonly<{ outcome: "refused"; reason: DesktopIntervalsMutationRefusalReason }>
+  | Readonly<{
+      outcome: "uncertain";
+      reason: "storage-uncertain" | "runtime-uncertain";
+    }>;
+
+type DesktopIntervalsMutationTransaction = Readonly<{
+  mutation: unknown;
+  current: unknown;
+}>;
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if (codePoint <= 31 || (codePoint >= 127 && codePoint <= 159)) return true;
+  }
+  return false;
+}
+
+function copyStatus(value: unknown): DesktopIntervalsCredentialStatus | undefined {
+  if (
+    !record(value) ||
+    !exactKeys(value, ["runtimeState", "slot", "state"]) ||
+    value.slot !== "intervals-icu" ||
+    (value.state !== "missing" && value.state !== "configured" && value.state !== "re-prompt")
+  ) {
+    return undefined;
+  }
+  if (value.state === "configured") {
+    if (
+      value.runtimeState !== "active" &&
+      value.runtimeState !== "stored-inactive" &&
+      value.runtimeState !== "failed"
+    ) {
+      return undefined;
+    }
+    return { slot: "intervals-icu", state: value.state, runtimeState: value.runtimeState };
+  }
+  if (value.runtimeState !== null) return undefined;
+  return { slot: "intervals-icu", state: value.state, runtimeState: null };
+}
+
+function closedStatus(): DesktopIntervalsCredentialStatus {
+  return { slot: "intervals-icu", state: "re-prompt", runtimeState: null };
+}
+
+function copyVerification(value: unknown): IntervalsCredentialVerificationResult {
+  if (!record(value) || typeof value.status !== "string") throw new TypeError();
+  if (value.status === "verified" && exactKeys(value, ["status"])) {
+    return { status: "verified" };
+  }
+  if (
+    value.status === "refused" &&
+    typeof value.reason === "string" &&
+    VERIFICATION_REFUSAL_REASONS.has(
+      value.reason as IntervalsCredentialVerificationRefusalReason,
+    ) &&
+    exactKeys(value, ["reason", "status"])
+  ) {
+    return {
+      status: "refused",
+      reason: value.reason as IntervalsCredentialVerificationRefusalReason,
+    };
+  }
+  throw new TypeError();
+}
+
+function copyMutation(value: unknown): DesktopIntervalsMutationCore {
+  if (!record(value) || typeof value.outcome !== "string") throw new TypeError();
+  if (value.outcome === "applied" && exactKeys(value, ["outcome"])) {
+    return { outcome: "applied" };
+  }
+  if (
+    value.outcome === "refused" &&
+    typeof value.reason === "string" &&
+    (VERIFICATION_REFUSAL_REASONS.has(
+      value.reason as IntervalsCredentialVerificationRefusalReason,
+    ) ||
+      STORAGE_REFUSAL_REASONS.has(value.reason)) &&
+    exactKeys(value, ["outcome", "reason"])
+  ) {
+    return { outcome: "refused", reason: value.reason as DesktopIntervalsMutationRefusalReason };
+  }
+  if (
+    value.outcome === "uncertain" &&
+    (value.reason === "storage-uncertain" || value.reason === "runtime-uncertain") &&
+    exactKeys(value, ["outcome", "reason"])
+  ) {
+    return { outcome: "uncertain", reason: value.reason };
+  }
+  throw new TypeError();
+}
+
+function mutationFromWrite(value: unknown): DesktopIntervalsMutationCore {
+  if (!record(value) || value.slot !== "intervals-icu" || typeof value.status !== "string") {
+    throw new TypeError();
+  }
+  if (
+    value.status === "configured" &&
+    typeof value.runtimeReady === "boolean" &&
+    exactKeys(value, ["runtimeReady", "slot", "status"])
+  ) {
+    return value.runtimeReady
+      ? { outcome: "applied" }
+      : { outcome: "uncertain", reason: "runtime-uncertain" };
+  }
+  if (
+    value.status === "uncertain" &&
+    value.reason === "storage-uncertain" &&
+    exactKeys(value, ["reason", "slot", "status"])
+  ) {
+    return { outcome: "uncertain", reason: "storage-uncertain" };
+  }
+  if (
+    value.status === "refused" &&
+    typeof value.reason === "string" &&
+    (STORAGE_REFUSAL_REASONS.has(value.reason) ||
+      VERIFICATION_REFUSAL_REASONS.has(
+        value.reason as IntervalsCredentialVerificationRefusalReason,
+      )) &&
+    exactKeys(value, ["reason", "slot", "status"])
+  ) {
+    return { outcome: "refused", reason: value.reason as DesktopIntervalsMutationRefusalReason };
+  }
+  throw new TypeError();
+}
+
+async function withAbort<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  signal.throwIfAborted();
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function captureClipboard(clipboard: Pick<Clipboard, "readText" | "clear">):
+  | { readonly status: "captured"; readonly apiKey: string }
+  | {
+      readonly status: "refused";
+      readonly reason: "clipboard-unavailable" | "clipboard-clear-failed" | "invalid-key-format";
+    } {
+  let value: unknown;
+  let cleared = false;
+  try {
+    value = clipboard.readText();
+  } catch {
+  } finally {
+    try {
+      clipboard.clear();
+      cleared = true;
+    } catch {}
+  }
+  if (!cleared) return { status: "refused", reason: "clipboard-clear-failed" };
+  if (typeof value !== "string") {
+    return { status: "refused", reason: "clipboard-unavailable" };
+  }
+  const apiKey = value.trim();
+  if (
+    apiKey.length === 0 ||
+    apiKey.length > INTERVALS_API_KEY_MAX_LENGTH ||
+    hasControlCharacter(apiKey)
+  ) {
+    return { status: "refused", reason: "invalid-key-format" };
+  }
+  return { status: "captured", apiKey };
+}
+
+export function installDesktopIntervalsIpc(input: {
+  readonly ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
+  readonly clipboard: Pick<Clipboard, "readText" | "clear">;
+  readonly isTrusted: (event: Pick<IpcMainInvokeEvent, "sender" | "senderFrame">) => boolean;
+  readonly signal: AbortSignal;
+  readonly vault: Pick<CredentialVault, "credentialStatuses" | "runExclusiveMutation">;
+  readonly verifyCredential: (
+    apiKey: string,
+    signal: AbortSignal,
+  ) => Promise<IntervalsCredentialVerificationResult>;
+}): () => Promise<void> {
+  let accepting = true;
+  let closePromise: Promise<void> | undefined;
+  let operationQueue = Promise.resolve();
+  const pendingVerifications = new Set<Promise<IntervalsCredentialVerificationResult>>();
+  const closeController = new AbortController();
+  const verificationSignal = AbortSignal.any([input.signal, closeController.signal]);
+  const serialize = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = operationQueue.then(operation, operation);
+    operationQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+  const trustedZeroArgument = (
+    event: Pick<IpcMainInvokeEvent, "sender" | "senderFrame">,
+    args: readonly unknown[],
+  ): void => {
+    if (!accepting) throw new TypeError();
+    if (!input.isTrusted(event)) throw new Error("untrusted desktop Intervals request");
+    if (args.length !== 0) throw new TypeError("invalid desktop Intervals request");
+  };
+  const readStatus = async (): Promise<DesktopIntervalsCredentialStatus> => {
+    try {
+      const statuses = await input.vault.credentialStatuses();
+      const intervals = statuses.find((status) => status.slot === "intervals-icu");
+      return copyStatus(intervals) ?? closedStatus();
+    } catch {
+      return closedStatus();
+    }
+  };
+  const verifyCandidate = async (
+    apiKey: string,
+  ): Promise<IntervalsCredentialVerificationResult> => {
+    if (verificationSignal.aborted) {
+      return { status: "refused", reason: "validation-aborted" };
+    }
+    const timeoutController = new AbortController();
+    const timeout = setTimeout(
+      () => timeoutController.abort(new DOMException("", "TimeoutError")),
+      INTERVALS_CREDENTIAL_VERIFICATION_TIMEOUT_MS,
+    );
+    timeout.unref();
+    const signal = AbortSignal.any([verificationSignal, timeoutController.signal]);
+    try {
+      try {
+        const operation = input.verifyCredential(apiKey, signal);
+        pendingVerifications.add(operation);
+        void operation.then(
+          () => pendingVerifications.delete(operation),
+          () => pendingVerifications.delete(operation),
+        );
+        const verification = copyVerification(await withAbort(operation, signal));
+        if (verificationSignal.aborted) {
+          return { status: "refused", reason: "validation-aborted" };
+        }
+        if (timeoutController.signal.aborted) {
+          return { status: "refused", reason: "validation-timeout" };
+        }
+        return verification;
+      } catch {
+        return {
+          status: "refused",
+          reason: verificationSignal.aborted
+            ? "validation-aborted"
+            : timeoutController.signal.aborted
+              ? "validation-timeout"
+              : "validation-unavailable",
+        };
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+  const runMutation = (
+    operation: () => Promise<DesktopIntervalsMutationTransaction>,
+  ): Promise<DesktopIntervalsMutationResult> =>
+    serialize(async () => {
+      try {
+        const transaction = await operation();
+        if (!record(transaction) || !exactKeys(transaction, ["current", "mutation"])) {
+          throw new TypeError();
+        }
+        const current = copyStatus(transaction.current);
+        if (current === undefined) throw new TypeError();
+        return { ...copyMutation(transaction.mutation), current };
+      } catch {
+        return {
+          outcome: "uncertain",
+          reason: "storage-uncertain",
+          current: closedStatus(),
+        };
+      }
+    });
+  const localRefusal = (
+    reason: "clipboard-unavailable" | "clipboard-clear-failed" | "invalid-key-format",
+  ): Promise<DesktopIntervalsMutationResult> =>
+    serialize(async () => ({ outcome: "refused", reason, current: await readStatus() }));
+  const handlers = [
+    [
+      DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL,
+      (event: IpcMainInvokeEvent, ...args: unknown[]) => {
+        trustedZeroArgument(event, args);
+        const captured = captureClipboard(input.clipboard);
+        if (captured.status === "refused") return localRefusal(captured.reason);
+        return runMutation(() =>
+          input.vault.runExclusiveMutation(async (mutation) => {
+            const verification = await verifyCandidate(captured.apiKey);
+            let result: DesktopIntervalsMutationCore;
+            if (verification.status === "refused") {
+              result = { outcome: "refused", reason: verification.reason };
+            } else {
+              result = mutationFromWrite(
+                await mutation.writeCredential(
+                  {
+                    slot: "intervals-icu",
+                    value: captured.apiKey,
+                  },
+                  { rollbackOnRuntimeRefusal: true },
+                ),
+              );
+            }
+            const statuses = await mutation.credentialStatuses();
+            return {
+              mutation: result,
+              current: statuses.find((entry) => entry.slot === "intervals-icu"),
+            };
+          }),
+        );
+      },
+    ],
+  ] as const;
+  for (const [channel, handler] of handlers) input.ipcMain.handle(channel, handler);
+  return () => {
+    if (closePromise !== undefined) return closePromise;
+    accepting = false;
+    for (const [channel] of handlers) input.ipcMain.removeHandler(channel);
+    closeController.abort();
+    closePromise = Promise.all([
+      operationQueue,
+      ...[...pendingVerifications].map((operation) =>
+        operation.then(
+          () => undefined,
+          () => undefined,
+        ),
+      ),
+    ]).then(() => undefined);
+    return closePromise;
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 import {
   DESKTOP_CONNECTION_CHANNEL,
+  DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL,
   DESKTOP_LIFECYCLE_CHANNEL,
   DESKTOP_OPEN_EXTERNAL_CHANNEL,
   DESKTOP_RELEASE_NOTES_CHANNEL,
@@ -165,6 +166,23 @@ const TELEGRAM_MUTATION_REFUSAL_REASONS = new Set([
   "polling-conflict",
   "control-unavailable",
   "invalid-state",
+]);
+const INTERVALS_CREDENTIAL_REFUSAL_REASONS = new Set([
+  "clipboard-unavailable",
+  "clipboard-clear-failed",
+  "invalid-key-format",
+  "credential-rejected",
+  "malformed-athlete-response",
+  "validation-timeout",
+  "validation-aborted",
+  "validation-unavailable",
+  "training-account-mismatch",
+  "owner-unresolved",
+  "store-unavailable",
+  "encryption-unavailable",
+  "unsafe-backend",
+  "storage-failed",
+  "runtime-unavailable",
 ]);
 const RELEASES_URL = "https://github.com/yerzhansa/enduragent/releases";
 const RELEASE_NOTES_MAX_TOTAL_BYTES = 64 * 1024;
@@ -1179,6 +1197,59 @@ function parseTelegramMutationResult(value: unknown): unknown {
   throw new TypeError();
 }
 
+function parseIntervalsCredentialCurrent(value: unknown): unknown {
+  if (
+    !record(value) ||
+    !exactKeys(value, ["runtimeState", "slot", "state"]) ||
+    value.slot !== "intervals-icu" ||
+    (value.state !== "missing" && value.state !== "configured" && value.state !== "re-prompt") ||
+    (value.state === "configured"
+      ? !RUNTIME_STATES.has(value.runtimeState as string)
+      : value.runtimeState !== null)
+  ) {
+    throw new TypeError();
+  }
+  return {
+    slot: "intervals-icu",
+    state: value.state,
+    runtimeState: value.runtimeState,
+  };
+}
+
+function parseIntervalsCredentialMutationResult(value: unknown): unknown {
+  if (!record(value) || typeof value.outcome !== "string") throw new TypeError();
+  if (value.outcome === "applied" && exactKeys(value, ["current", "outcome"])) {
+    return {
+      outcome: "applied",
+      current: parseIntervalsCredentialCurrent(value.current),
+    };
+  }
+  if (
+    value.outcome === "refused" &&
+    typeof value.reason === "string" &&
+    INTERVALS_CREDENTIAL_REFUSAL_REASONS.has(value.reason) &&
+    exactKeys(value, ["current", "outcome", "reason"])
+  ) {
+    return {
+      outcome: "refused",
+      reason: value.reason,
+      current: parseIntervalsCredentialCurrent(value.current),
+    };
+  }
+  if (
+    value.outcome === "uncertain" &&
+    (value.reason === "storage-uncertain" || value.reason === "runtime-uncertain") &&
+    exactKeys(value, ["current", "outcome", "reason"])
+  ) {
+    return {
+      outcome: "uncertain",
+      reason: value.reason,
+      current: parseIntervalsCredentialCurrent(value.current),
+    };
+  }
+  throw new TypeError();
+}
+
 function parseTelegramSenderInput(value: unknown): { readonly senderId: number } {
   if (
     !record(value) ||
@@ -1254,6 +1325,16 @@ function requireZeroArguments(args: readonly unknown[]): void {
 async function invokeTelegramMutation(channel: string): Promise<unknown> {
   try {
     return parseTelegramMutationResult(await ipcRenderer.invoke(channel));
+  } catch {
+    throw new TypeError();
+  }
+}
+
+async function invokeIntervalsCredentialMutation(): Promise<unknown> {
+  try {
+    return parseIntervalsCredentialMutationResult(
+      await ipcRenderer.invoke(DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL),
+    );
   } catch {
     throw new TypeError();
   }
@@ -1424,6 +1505,10 @@ contextBridge.exposeInMainWorld(
     telegramStatus: async (...args: unknown[]) => {
       requireZeroArguments(args);
       return invokeTelegramStatus();
+    },
+    pasteIntervalsApiKeyFromClipboard: async (...args: unknown[]) => {
+      requireZeroArguments(args);
+      return invokeIntervalsCredentialMutation();
     },
     pasteTelegramTokenFromClipboard: async (...args: unknown[]) => {
       requireZeroArguments(args);

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1064,6 +1064,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "onChatgptLoginProgress",
         "onDroppedImportFiles",
         "onUpdateState",
+        "pasteIntervalsApiKeyFromClipboard",
         "pasteTelegramTokenFromClipboard",
         "reconcileTelegram",
         "releaseNotes",

--- a/apps/desktop/tests/credential-runtime.test.ts
+++ b/apps/desktop/tests/credential-runtime.test.ts
@@ -17,6 +17,7 @@ import {
   type CredentialRuntimeApplication,
 } from "../src/main/credential-runtime.js";
 import {
+  CredentialRuntimeRefusal,
   createCredentialVault,
   type CredentialEncryptionPort,
   type CredentialVault,
@@ -118,6 +119,12 @@ function fakeVault(initialRuntime: CredentialRuntimeApplication) {
         runtimeConfigurationForCredential(input.slot, randomUUID(), input.selection),
       );
       return { slot: input.slot, status: "configured", runtimeReady: true };
+    },
+    async runExclusiveMutation(operation) {
+      return operation({
+        writeCredential: (input, behavior) => port.writeCredential(input, behavior),
+        credentialStatuses: () => port.credentialStatuses(),
+      });
     },
     async applyLlmSelection() {
       return { status: "configured", runtimeReady: true };
@@ -785,19 +792,27 @@ describe("desktop credential runtime precedence", () => {
 
   it("binds successor reads and credential replay to the supplied connection", async () => {
     const calls: string[] = [];
-    const connect = vi.fn(async (_options: { readonly url: string; readonly token: string }) => ({
-      handshake: {} as never,
-      async call(method: string) {
-        calls.push(method);
-        if (method === "getRuntimeConfig") return runtimeSnapshot("anthropic");
-        return {
-          schemaVersion: 3,
-          status: "applied",
-          applied: { llm: true, intervals: false, session: false },
-        };
-      },
-      async close() {},
-    }));
+    const callSignals: (AbortSignal | undefined)[] = [];
+    const connect = vi.fn(
+      async (_options: {
+        readonly url: string;
+        readonly token: string;
+        readonly signal?: AbortSignal;
+      }) => ({
+        handshake: {} as never,
+        async call(method: string, _params: unknown, options?: { readonly signal?: AbortSignal }) {
+          calls.push(method);
+          callSignals.push(options?.signal);
+          if (method === "getRuntimeConfig") return runtimeSnapshot("anthropic");
+          return {
+            schemaVersion: 3,
+            status: "applied",
+            applied: { llm: true, intervals: false, session: false },
+          };
+        },
+        async close() {},
+      }),
+    );
     const successor = createConnectionRuntimeAuthority(
       {
         url: "ws://127.0.0.1:45002/rpc",
@@ -807,7 +822,10 @@ describe("desktop credential runtime precedence", () => {
       connect as never,
     );
 
-    await expect(successor.getRuntimeConfig()).resolves.toEqual(runtimeSnapshot("anthropic"));
+    const controller = new AbortController();
+    await expect(successor.getRuntimeConfig(controller.signal)).resolves.toEqual(
+      runtimeSnapshot("anthropic"),
+    );
     await successor.configureRuntime({
       llm: { provider: "anthropic", api_key: "obviously-fake-successor-key" },
     });
@@ -817,6 +835,7 @@ describe("desktop credential runtime precedence", () => {
       url: "ws://127.0.0.1:45002/rpc",
       token: "obviously-fake-successor-token",
       expectedAthleteHome: "/synthetic/athlete",
+      signal: controller.signal,
     });
     expect(connect).toHaveBeenNthCalledWith(2, {
       url: "ws://127.0.0.1:45002/rpc",
@@ -824,6 +843,7 @@ describe("desktop credential runtime precedence", () => {
       expectedAthleteHome: "/synthetic/athlete",
     });
     expect(calls).toEqual(["getRuntimeConfig", "configureRuntime"]);
+    expect(callSignals).toEqual([controller.signal, undefined]);
   });
 
   it.each([
@@ -851,14 +871,6 @@ describe("desktop credential runtime precedence", () => {
         applied: { llm: false, intervals: false, session: false },
       },
     ],
-    [
-      { intervals: { athlete_id: "candidate-athlete" } },
-      {
-        schemaVersion: 3,
-        status: "refused",
-        reason: "training-account-mismatch",
-      },
-    ],
   ] as const)(
     "accepts only an applied result for every requested runtime slot",
     async (request, result) => {
@@ -879,6 +891,33 @@ describe("desktop credential runtime precedence", () => {
       await expect(authority.configureRuntime(request)).rejects.toBeInstanceOf(TypeError);
     },
   );
+
+  it("preserves a structured runtime refusal", async () => {
+    const connect = vi.fn(async () => ({
+      handshake: {} as never,
+      call: vi.fn(async () => ({
+        schemaVersion: 3,
+        status: "refused" as const,
+        reason: "training-account-mismatch" as const,
+      })),
+      close: vi.fn(async () => {}),
+    }));
+    const authority = createConnectionRuntimeAuthority(
+      {
+        url: "ws://127.0.0.1:45004/rpc",
+        token: "obviously-fake-successor-token",
+        athleteHome: "/synthetic/athlete",
+      },
+      connect as never,
+    );
+
+    const failure = await authority
+      .configureRuntime({ intervals: { athlete_id: "candidate-athlete" } })
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(CredentialRuntimeRefusal);
+    expect((failure as CredentialRuntimeRefusal).reason).toBe("training-account-mismatch");
+  });
 
   it.each([
     ["externally configured provider", runtimeSnapshot("google", "external-model", true)],

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -18,10 +18,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CREDENTIAL_DIRECTORY_MODE,
   CREDENTIAL_FILE_MODE,
+  CredentialRuntimeRefusal,
   createCredentialVault,
   markUnselectedModelCredentialsInactive,
   replaceCredentialRuntimeStates,
   type CredentialEncryptionPort,
+  type CredentialVaultMutation,
 } from "../src/main/credential-vault.js";
 
 const roots: string[] = [];
@@ -456,6 +458,26 @@ describe("desktop credential vault", () => {
     });
     await replay;
     expect(applySuccessorCredential).toHaveBeenCalledWith("anthropic", "synthetic-old");
+  });
+
+  it("rejects an exclusive mutation handle after its section completes", async () => {
+    const root = await temporaryRoot();
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential: vi.fn(async () => undefined),
+    });
+    let escaped: CredentialVaultMutation | undefined;
+
+    await vault.runExclusiveMutation(async (mutation) => {
+      escaped = mutation;
+    });
+
+    expect(() => escaped!.credentialStatuses()).toThrow(TypeError);
+    expect(() =>
+      escaped!.writeCredential({ slot: "anthropic", value: "synthetic-secret" }),
+    ).toThrow(TypeError);
+    await expect(lstat(join(root, "anthropic.bin"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("reopens a visible old credential only after cleaning owned transients and syncing", async () => {
@@ -963,6 +985,34 @@ describe("desktop credential vault", () => {
       runtimeState: "active",
     });
     expect(applied).toContain("google");
+  });
+
+  it("keeps a legacy write stored when runtime returns a structured refusal", async () => {
+    const root = await temporaryRoot();
+    const encryptionPort = encryption();
+    const vault = createCredentialVault({
+      root,
+      encryption: encryptionPort,
+      applyCredential: vi.fn(async () => {
+        throw new CredentialRuntimeRefusal("ownership-unavailable");
+      }),
+    });
+
+    await expect(
+      vault.writeCredential({ slot: "intervals-icu", value: "synthetic-intervals-key" }),
+    ).resolves.toEqual({
+      slot: "intervals-icu",
+      status: "configured",
+      runtimeReady: false,
+    });
+    expect(encryptionPort.decryptString(await readFile(join(root, "intervals-icu.bin")))).toBe(
+      "synthetic-intervals-key",
+    );
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "intervals-icu",
+      state: "configured",
+      runtimeState: "failed",
+    });
   });
 
   it("routes passive replay separately from an explicit credential selection", async () => {

--- a/apps/desktop/tests/intervals-ipc.test.ts
+++ b/apps/desktop/tests/intervals-ipc.test.ts
@@ -1,0 +1,1026 @@
+import {
+  INTERVALS_CREDENTIAL_REQUEST_TIMEOUT_MS,
+  INTERVALS_CREDENTIAL_VERIFICATION_TIMEOUT_MS,
+  verifyIntervalsCredentialAtPath,
+  type IntervalsCredentialVerificationResult,
+} from "@enduragent/coach/backfill";
+import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import { DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL } from "../src/main/constants.js";
+import {
+  CredentialRuntimeRefusal,
+  createCredentialVault,
+  type CredentialVault,
+  type CredentialWriteBehavior,
+  type CredentialWriteResult,
+} from "../src/main/credential-vault.js";
+import {
+  createDesktopIntervalsCredentialVerifier,
+  installDesktopIntervalsIpc,
+  type DesktopIntervalsCredentialStatus,
+} from "../src/main/intervals-ipc.js";
+
+const API_KEY = "synthetic-intervals-api-key";
+const EXISTING_API_KEY = "synthetic-existing-intervals-key";
+const PRIVATE_DETAIL = `${API_KEY} at /Users/private/id_ed25519 PRIVATE_KEY`;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function status(
+  state: DesktopIntervalsCredentialStatus["state"] = "missing",
+  runtimeState: DesktopIntervalsCredentialStatus["runtimeState"] = null,
+): DesktopIntervalsCredentialStatus {
+  return { slot: "intervals-icu", state, runtimeState };
+}
+
+function setup(
+  options: {
+    readonly trusted?: boolean;
+    readonly current?: DesktopIntervalsCredentialStatus;
+    readonly verification?: IntervalsCredentialVerificationResult;
+    readonly verifyCredential?: (
+      apiKey: string,
+      signal: AbortSignal,
+    ) => Promise<IntervalsCredentialVerificationResult>;
+    readonly writeResult?: CredentialWriteResult;
+    readonly vault?: Pick<CredentialVault, "credentialStatuses" | "runExclusiveMutation">;
+    readonly clipboardValue?: string;
+  } = {},
+) {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  const removed: string[] = [];
+  const trace: string[] = [];
+  let current = options.current ?? status();
+  const writeCredential = vi.fn(
+    async (input: { readonly value: string }, _behavior?: CredentialWriteBehavior) => {
+      trace.push(`write:${input.value}`);
+      const result =
+        options.writeResult ??
+        ({
+          slot: "intervals-icu",
+          status: "configured",
+          runtimeReady: true,
+        } as const);
+      if (result.status === "configured") {
+        current = status("configured", result.runtimeReady ? "active" : "failed");
+      }
+      return result;
+    },
+  );
+  const credentialStatuses = vi.fn(async () => [current]);
+  const defaultVault = {
+    credentialStatuses,
+    runExclusiveMutation: vi.fn(
+      async (
+        operation: (mutation: {
+          writeCredential: typeof writeCredential;
+          credentialStatuses: () => Promise<readonly DesktopIntervalsCredentialStatus[]>;
+        }) => Promise<unknown>,
+      ) =>
+        operation({
+          writeCredential,
+          credentialStatuses,
+        }),
+    ),
+  };
+  const vault = options.vault ?? defaultVault;
+  const clipboard = {
+    readText: vi.fn(() => {
+      trace.push("read");
+      return options.clipboardValue ?? `  ${API_KEY}  `;
+    }),
+    clear: vi.fn(() => {
+      trace.push("clear");
+    }),
+  };
+  const verifyCredential = vi.fn(
+    options.verifyCredential ??
+      (async (apiKey: string) => {
+        trace.push(`verify:${apiKey}`);
+        return options.verification ?? ({ status: "verified" } as const);
+      }),
+  );
+  const appController = new AbortController();
+  const dispose = installDesktopIntervalsIpc({
+    ipcMain: {
+      handle: (channel, handler) => handlers.set(channel, handler as never),
+      removeHandler: (channel) => removed.push(channel),
+    },
+    clipboard,
+    isTrusted: () => options.trusted ?? true,
+    signal: appController.signal,
+    vault: vault as never,
+    verifyCredential,
+  });
+  const invoke = (...args: unknown[]) =>
+    handlers.get(DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL)!(
+      { sender: {}, senderFrame: {} },
+      ...args,
+    );
+  return {
+    appController,
+    clipboard,
+    defaultVault,
+    dispose,
+    handlers,
+    invoke,
+    removed,
+    trace,
+    vault,
+    verifyCredential,
+    writeCredential,
+  };
+}
+
+function testEncryption(options: { readonly available?: boolean; readonly backend?: string } = {}) {
+  return {
+    isEncryptionAvailable: () => options.available ?? true,
+    getSelectedStorageBackend: () => options.backend ?? "keychain",
+    encryptString: (value: string) => Buffer.from(`sealed:${value}`, "utf8"),
+    decryptString: (value: Buffer) => value.toString("utf8").slice("sealed:".length),
+  };
+}
+
+async function temporaryVault(options: {
+  readonly available?: boolean;
+  readonly backend?: string;
+  readonly encryption?: ReturnType<typeof testEncryption>;
+  readonly trace?: string[];
+}) {
+  const base = await mkdtemp(join(await realpath(tmpdir()), "intervals-ipc-"));
+  await mkdir(join(base, "athlete-home"), { mode: 0o700 });
+  const trace = options.trace ?? [];
+  const clearCredential = vi.fn(async () => {
+    trace.push("clear-runtime");
+    return "cleared" as const;
+  });
+  const applyCredential = vi.fn(async (slot: string, value: string) => {
+    trace.push(`apply:${slot}:${value}`);
+  });
+  const root = join(base, "credentials-v1");
+  const runtimeState = new Map();
+  const vault = createCredentialVault({
+    root,
+    encryption: options.encryption ?? testEncryption(options),
+    runtimeState,
+    applyCredential,
+    clearCredential,
+  });
+  return { applyCredential, base, clearCredential, root, runtimeState, trace, vault };
+}
+
+function athleteResponse(account = "synthetic-athlete"): Response {
+  return new Response(
+    JSON.stringify({
+      sportSettings: [{ id: 1, athlete_id: account, types: ["Ride"], updated: "2010-01-01" }],
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function verificationOptions(input: {
+  readonly baseFetch: typeof globalThis.fetch;
+  readonly signal?: AbortSignal;
+  readonly compareOwner?: () => Promise<"unowned" | "matched" | "mismatch" | "store-unavailable">;
+  readonly overallTimeoutMs?: number;
+  readonly perRequestTimeoutMs?: number;
+}) {
+  return {
+    apiKey: API_KEY,
+    athleteId: "0",
+    historyNewestDate: "1970-01-01",
+    clock: { now: () => Date.now(), monotonicNow: () => performance.now() },
+    signal: input.signal ?? new AbortController().signal,
+    baseFetch: input.baseFetch,
+    ...(input.compareOwner === undefined ? {} : { compareOwner: input.compareOwner }),
+    ...(input.overallTimeoutMs === undefined ? {} : { overallTimeoutMs: input.overallTimeoutMs }),
+    ...(input.perRequestTimeoutMs === undefined
+      ? {}
+      : { perRequestTimeoutMs: input.perRequestTimeoutMs }),
+  };
+}
+
+describe("Desktop Intervals.icu clipboard IPC", () => {
+  it("registers one semantic handler and removes it", () => {
+    const runtime = setup();
+
+    expect([...runtime.handlers.keys()]).toEqual([DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL]);
+    const close = runtime.dispose();
+    expect(runtime.removed).toEqual([DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL]);
+    return close;
+  });
+
+  it("fences new requests, aborts verification, and drains accepted work", async () => {
+    const verification = deferred<IntervalsCredentialVerificationResult>();
+    let acceptedSignal: AbortSignal | undefined;
+    const runtime = setup({
+      verifyCredential: async (_apiKey, signal) => {
+        acceptedSignal = signal;
+        return verification.promise;
+      },
+    });
+
+    const accepted = Promise.resolve(runtime.invoke());
+    await vi.waitFor(() => expect(runtime.verifyCredential).toHaveBeenCalledOnce());
+    const firstClose = runtime.dispose();
+    const secondClose = runtime.dispose();
+
+    expect(secondClose).toBe(firstClose);
+    expect(acceptedSignal?.aborted).toBe(true);
+    expect(() => runtime.invoke()).toThrow(TypeError);
+    await expect(accepted).resolves.toEqual({
+      outcome: "refused",
+      reason: "validation-aborted",
+      current: status(),
+    });
+    let drained = false;
+    void firstClose.then(() => {
+      drained = true;
+    });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+    expect(runtime.writeCredential).not.toHaveBeenCalled();
+    verification.resolve({ status: "verified" });
+    await firstClose;
+    expect(drained).toBe(true);
+  });
+
+  it("bounds the complete verification callback with the production overall deadline", async () => {
+    vi.useFakeTimers();
+    const verification = deferred<IntervalsCredentialVerificationResult>();
+    const runtime = setup({ verifyCredential: async () => verification.promise });
+    try {
+      const pending = Promise.resolve(runtime.invoke());
+      await vi.advanceTimersByTimeAsync(0);
+      expect(runtime.verifyCredential).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(INTERVALS_CREDENTIAL_VERIFICATION_TIMEOUT_MS);
+
+      await expect(pending).resolves.toEqual({
+        outcome: "refused",
+        reason: "validation-timeout",
+        current: status(),
+      });
+      expect(runtime.writeCredential).not.toHaveBeenCalled();
+      const close = runtime.dispose();
+      verification.resolve({ status: "verified" });
+      await close;
+    } finally {
+      verification.resolve({ status: "verified" });
+      vi.useRealTimers();
+    }
+  });
+
+  it("reads and clears synchronously before verification or vault work", async () => {
+    const runtime = setup();
+
+    const pending = runtime.invoke();
+    expect(runtime.trace).toEqual(["read", "clear"]);
+    expect(runtime.verifyCredential).not.toHaveBeenCalled();
+    expect(runtime.defaultVault.runExclusiveMutation).not.toHaveBeenCalled();
+
+    await expect(pending).resolves.toEqual({
+      outcome: "applied",
+      current: status("configured", "active"),
+    });
+    expect(runtime.trace).toEqual(["read", "clear", `verify:${API_KEY}`, `write:${API_KEY}`]);
+    expect(runtime.verifyCredential).toHaveBeenCalledWith(API_KEY, expect.any(AbortSignal));
+    expect(runtime.writeCredential).toHaveBeenCalledWith(
+      { slot: "intervals-icu", value: API_KEY },
+      { rollbackOnRuntimeRefusal: true },
+    );
+  });
+
+  it.each(["", "   ", "a\u0000b", "a\nb", "a\u007fb", "a\u0085b", "x".repeat(257)])(
+    "refuses the invalid key shape without verification: %j",
+    async (candidate) => {
+      const runtime = setup({ clipboardValue: candidate, current: status("configured", "active") });
+
+      await expect(runtime.invoke()).resolves.toEqual({
+        outcome: "refused",
+        reason: "invalid-key-format",
+        current: status("configured", "active"),
+      });
+      expect(runtime.clipboard.clear).toHaveBeenCalledOnce();
+      expect(runtime.verifyCredential).not.toHaveBeenCalled();
+      expect(runtime.writeCredential).not.toHaveBeenCalled();
+    },
+  );
+
+  it("attempts clear after read failure and refuses the unavailable clipboard", async () => {
+    const runtime = setup();
+    runtime.clipboard.readText.mockImplementationOnce(() => {
+      runtime.trace.push("read-failed");
+      throw new Error(PRIVATE_DETAIL);
+    });
+
+    const result = await runtime.invoke();
+
+    expect(result).toEqual({
+      outcome: "refused",
+      reason: "clipboard-unavailable",
+      current: status(),
+    });
+    expect(runtime.clipboard.clear).toHaveBeenCalledOnce();
+    expect(runtime.verifyCredential).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain(API_KEY);
+    expect(JSON.stringify(result)).not.toContain("PRIVATE_KEY");
+  });
+
+  it("gives clear failure precedence over a captured credential", async () => {
+    const runtime = setup();
+    runtime.clipboard.clear.mockImplementationOnce(() => {
+      runtime.trace.push("clear-failed");
+      throw new Error(PRIVATE_DETAIL);
+    });
+
+    await expect(runtime.invoke()).resolves.toEqual({
+      outcome: "refused",
+      reason: "clipboard-clear-failed",
+      current: status(),
+    });
+    expect(runtime.verifyCredential).not.toHaveBeenCalled();
+    expect(runtime.writeCredential).not.toHaveBeenCalled();
+  });
+
+  it("closes thrown and malformed verification failures without private details", async () => {
+    const thrown = setup({
+      verifyCredential: async () => {
+        throw new Error(PRIVATE_DETAIL);
+      },
+    });
+    const thrownResult = await thrown.invoke();
+    expect(thrownResult).toEqual({
+      outcome: "refused",
+      reason: "validation-unavailable",
+      current: status(),
+    });
+
+    const malformed = setup({
+      verifyCredential: async () =>
+        ({
+          status: "refused",
+          reason: "credential-rejected",
+          apiKey: API_KEY,
+        }) as never,
+    });
+    const malformedResult = await malformed.invoke();
+    expect(malformedResult).toEqual({
+      outcome: "refused",
+      reason: "validation-unavailable",
+      current: status(),
+    });
+
+    for (const result of [thrownResult, malformedResult]) {
+      expect(JSON.stringify(result)).not.toContain(API_KEY);
+      expect(JSON.stringify(result)).not.toContain("PRIVATE_KEY");
+    }
+    expect(thrown.writeCredential).not.toHaveBeenCalled();
+    expect(malformed.writeCredential).not.toHaveBeenCalled();
+  });
+
+  it.each(["encryption-unavailable", "unsafe-backend"] as const)(
+    "passes through the closed %s storage refusal",
+    async (reason) => {
+      const value = await temporaryVault({
+        available: reason !== "encryption-unavailable",
+        ...(reason === "unsafe-backend" ? { backend: "basic_text" } : {}),
+      });
+      try {
+        const runtime = setup({ vault: value.vault });
+        const result = await runtime.invoke();
+
+        expect(result).toEqual({ outcome: "refused", reason, current: status() });
+        expect(value.applyCredential).not.toHaveBeenCalled();
+        expect(JSON.stringify(result)).not.toContain(API_KEY);
+      } finally {
+        await rm(value.base, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each(["encryption-unavailable", "unsafe-backend"] as const)(
+    "preserves an existing key across the %s storage refusal",
+    async (reason) => {
+      const security = { available: true, backend: "keychain" };
+      const encryption = {
+        isEncryptionAvailable: () => security.available,
+        getSelectedStorageBackend: () => security.backend,
+        encryptString: (value: string) => Buffer.from(`sealed:${value}`, "utf8"),
+        decryptString: (value: Buffer) => value.toString("utf8").slice("sealed:".length),
+      };
+      const value = await temporaryVault({ encryption });
+      try {
+        await value.vault.writeCredential({ slot: "intervals-icu", value: EXISTING_API_KEY });
+        const before = await readFile(join(value.root, "intervals-icu.bin"));
+        value.applyCredential.mockClear();
+        if (reason === "encryption-unavailable") security.available = false;
+        else security.backend = "basic_text";
+        const runtime = setup({ vault: value.vault });
+
+        await expect(runtime.invoke()).resolves.toEqual({
+          outcome: "refused",
+          reason,
+          current: status("configured", "active"),
+        });
+        expect(await readFile(join(value.root, "intervals-icu.bin"))).toEqual(before);
+        expect(value.applyCredential).not.toHaveBeenCalled();
+      } finally {
+        await rm(value.base, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("rejects widened vault results without copying secrets", async () => {
+    const runtime = setup({
+      writeResult: {
+        slot: "intervals-icu",
+        status: "configured",
+        runtimeReady: true,
+        apiKey: API_KEY,
+      } as never,
+    });
+
+    const result = await runtime.invoke();
+
+    expect(result).toEqual({
+      outcome: "uncertain",
+      reason: "storage-uncertain",
+      current: status("re-prompt", null),
+    });
+    expect(JSON.stringify(result)).not.toContain(API_KEY);
+    expect(JSON.stringify(result)).not.toContain("PRIVATE_KEY");
+    expect(runtime.defaultVault.credentialStatuses).not.toHaveBeenCalled();
+  });
+
+  it("rejects widened status snapshots without copying secrets", async () => {
+    const runtime = setup();
+    runtime.defaultVault.credentialStatuses.mockResolvedValueOnce([
+      { ...status("configured", "active"), privateDetail: PRIVATE_DETAIL },
+    ] as never);
+
+    const result = await runtime.invoke();
+
+    expect(result).toEqual({
+      outcome: "uncertain",
+      reason: "storage-uncertain",
+      current: status("re-prompt", null),
+    });
+    expect(runtime.writeCredential).toHaveBeenCalledOnce();
+    expect(runtime.defaultVault.credentialStatuses).toHaveBeenCalledOnce();
+    expect(JSON.stringify(result)).not.toContain(API_KEY);
+    expect(JSON.stringify(result)).not.toContain("PRIVATE_KEY");
+  });
+
+  it("rejects untrusted and extra-argument calls before clipboard access", () => {
+    const untrusted = setup({ trusted: false });
+    expect(() => untrusted.invoke()).toThrow("untrusted desktop Intervals request");
+    expect(untrusted.clipboard.readText).not.toHaveBeenCalled();
+    expect(untrusted.clipboard.clear).not.toHaveBeenCalled();
+
+    const extra = setup();
+    expect(() => extra.invoke(API_KEY)).toThrow(TypeError);
+    expect(extra.clipboard.readText).not.toHaveBeenCalled();
+    expect(extra.clipboard.clear).not.toHaveBeenCalled();
+    expect(extra.verifyCredential).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "credential-rejected",
+    "malformed-athlete-response",
+    "validation-timeout",
+    "validation-aborted",
+    "validation-unavailable",
+    "training-account-mismatch",
+    "owner-unresolved",
+    "store-unavailable",
+  ] as const)("passes through the metadata-only %s verification refusal", async (reason) => {
+    const runtime = setup({
+      current: status("configured", "active"),
+      verification: { status: "refused", reason },
+    });
+
+    const result = await runtime.invoke();
+
+    expect(result).toEqual({
+      outcome: "refused",
+      reason,
+      current: status("configured", "active"),
+    });
+    expect(runtime.writeCredential).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain(API_KEY);
+  });
+
+  it("keeps an existing encrypted key and runtime state unchanged after verification refusal", async () => {
+    const value = await temporaryVault({});
+    try {
+      await expect(
+        value.vault.writeCredential({ slot: "intervals-icu", value: EXISTING_API_KEY }),
+      ).resolves.toMatchObject({ status: "configured", runtimeReady: true });
+      const before = await readFile(join(value.root, "intervals-icu.bin"));
+      value.applyCredential.mockClear();
+      const runtime = setup({
+        vault: value.vault,
+        verification: { status: "refused", reason: "training-account-mismatch" },
+      });
+
+      await expect(runtime.invoke()).resolves.toEqual({
+        outcome: "refused",
+        reason: "training-account-mismatch",
+        current: status("configured", "active"),
+      });
+
+      expect(await readFile(join(value.root, "intervals-icu.bin"))).toEqual(before);
+      expect(value.applyCredential).not.toHaveBeenCalled();
+      await expect(value.vault.credentialStatuses()).resolves.toContainEqual(
+        status("configured", "active"),
+      );
+    } finally {
+      await rm(value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("retains a coherent verified candidate when runtime application is uncertain", async () => {
+    const value = await temporaryVault({});
+    try {
+      await expect(
+        value.vault.writeCredential({ slot: "intervals-icu", value: EXISTING_API_KEY }),
+      ).resolves.toMatchObject({ status: "configured", runtimeReady: true });
+      const before = await readFile(join(value.root, "intervals-icu.bin"));
+      let appliedRuntimeKey = EXISTING_API_KEY;
+      value.applyCredential.mockReset();
+      value.applyCredential.mockImplementationOnce(async (_slot, candidate) => {
+        appliedRuntimeKey = candidate;
+        throw new Error(PRIVATE_DETAIL);
+      });
+      const runtime = setup({ vault: value.vault });
+
+      const result = await runtime.invoke();
+
+      expect(result).toEqual({
+        outcome: "uncertain",
+        reason: "runtime-uncertain",
+        current: status("configured", "failed"),
+      });
+      expect(await readFile(join(value.root, "intervals-icu.bin"))).not.toEqual(before);
+      expect(await readFile(join(value.root, "intervals-icu.bin"))).toEqual(
+        Buffer.from(`sealed:${API_KEY}`, "utf8"),
+      );
+      expect(appliedRuntimeKey).toBe(API_KEY);
+      expect(value.applyCredential).toHaveBeenCalledOnce();
+      await expect(value.vault.credentialStatuses()).resolves.toContainEqual(
+        status("configured", "failed"),
+      );
+      expect(JSON.stringify(result)).not.toContain(API_KEY);
+      expect(JSON.stringify(result)).not.toContain(PRIVATE_DETAIL);
+    } finally {
+      await rm(value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("retains an initial verified candidate when runtime application is uncertain", async () => {
+    const value = await temporaryVault({});
+    try {
+      let ownerClaimed = false;
+      value.applyCredential.mockImplementationOnce(async () => {
+        ownerClaimed = true;
+        throw new Error(PRIVATE_DETAIL);
+      });
+      const runtime = setup({ vault: value.vault });
+
+      await expect(runtime.invoke()).resolves.toEqual({
+        outcome: "uncertain",
+        reason: "runtime-uncertain",
+        current: status("configured", "failed"),
+      });
+      expect(await readFile(join(value.root, "intervals-icu.bin"))).toEqual(
+        Buffer.from(`sealed:${API_KEY}`, "utf8"),
+      );
+      expect(ownerClaimed).toBe(true);
+      expect(value.clearCredential).not.toHaveBeenCalled();
+      await expect(value.vault.credentialStatuses()).resolves.toContainEqual(
+        status("configured", "failed"),
+      );
+    } finally {
+      await rm(value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls back a known late training-account mismatch", async () => {
+    const value = await temporaryVault({});
+    try {
+      await value.vault.writeCredential({ slot: "intervals-icu", value: EXISTING_API_KEY });
+      const before = await readFile(join(value.root, "intervals-icu.bin"));
+      value.applyCredential.mockReset();
+      value.applyCredential.mockRejectedValueOnce(
+        new CredentialRuntimeRefusal("training-account-mismatch"),
+      );
+      const runtime = setup({ vault: value.vault });
+
+      await expect(runtime.invoke()).resolves.toEqual({
+        outcome: "refused",
+        reason: "training-account-mismatch",
+        current: status("configured", "active"),
+      });
+      expect(await readFile(join(value.root, "intervals-icu.bin"))).toEqual(before);
+      expect(value.applyCredential).toHaveBeenCalledOnce();
+      await expect(value.vault.credentialStatuses()).resolves.toContainEqual(
+        status("configured", "active"),
+      );
+    } finally {
+      await rm(value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("removes an initial write and clears its runtime state after a known late refusal", async () => {
+    const value = await temporaryVault({});
+    try {
+      value.applyCredential.mockRejectedValueOnce(
+        new CredentialRuntimeRefusal("training-account-mismatch"),
+      );
+      const runtime = setup({ vault: value.vault });
+
+      await expect(runtime.invoke()).resolves.toEqual({
+        outcome: "refused",
+        reason: "training-account-mismatch",
+        current: status(),
+      });
+      await expect(readFile(join(value.root, "intervals-icu.bin"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(value.vault.credentialStatuses()).resolves.toContainEqual(status());
+      expect(value.runtimeState.has("intervals-icu")).toBe(false);
+      expect(value.clearCredential).not.toHaveBeenCalled();
+    } finally {
+      await rm(value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("reports storage uncertainty when restoring the previous ciphertext fails", async () => {
+    const value = await temporaryVault({});
+    try {
+      await value.vault.writeCredential({ slot: "intervals-icu", value: EXISTING_API_KEY });
+      const before = await readFile(join(value.root, "intervals-icu.bin"));
+      let createIdCalls = 0;
+      const applyCredential = vi.fn(async () => {
+        throw new CredentialRuntimeRefusal("training-account-mismatch");
+      });
+      const vault = createCredentialVault({
+        root: value.root,
+        encryption: testEncryption(),
+        applyCredential,
+        createId: () => {
+          createIdCalls += 1;
+          if (createIdCalls === 2) throw new TypeError(PRIVATE_DETAIL);
+          return "candidate-write";
+        },
+      });
+      const runtime = setup({ vault });
+
+      const result = await runtime.invoke();
+
+      expect(result).toEqual({
+        outcome: "uncertain",
+        reason: "storage-uncertain",
+        current: status("re-prompt", null),
+      });
+      expect(await readFile(join(value.root, "intervals-icu.bin"))).not.toEqual(before);
+      expect(createIdCalls).toBe(2);
+      expect(applyCredential).toHaveBeenCalledOnce();
+      expect(JSON.stringify(result)).not.toContain(API_KEY);
+      expect(JSON.stringify(result)).not.toContain("PRIVATE_KEY");
+    } finally {
+      await rm(value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("maps other late runtime refusals to runtime unavailable", async () => {
+    const value = await temporaryVault({});
+    try {
+      value.applyCredential.mockRejectedValueOnce(
+        new CredentialRuntimeRefusal("ownership-unavailable"),
+      );
+      const runtime = setup({ vault: value.vault });
+
+      const result = await runtime.invoke();
+
+      expect(result).toEqual({
+        outcome: "refused",
+        reason: "runtime-unavailable",
+        current: status(),
+      });
+      await expect(readFile(join(value.root, "intervals-icu.bin"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      expect(JSON.stringify(result)).not.toContain(API_KEY);
+    } finally {
+      await rm(value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("serializes verification and commit with generic vault writes and deletes", async () => {
+    const trace: string[] = [];
+    const value = await temporaryVault({ trace });
+    try {
+      await value.vault.writeCredential({ slot: "intervals-icu", value: EXISTING_API_KEY });
+      trace.splice(0);
+      const verification = deferred<IntervalsCredentialVerificationResult>();
+      const runtime = setup({
+        vault: value.vault,
+        verifyCredential: async () => {
+          trace.push("verify");
+          return verification.promise;
+        },
+      });
+
+      const paste = Promise.resolve(runtime.invoke());
+      await vi.waitFor(() => expect(trace).toEqual(["verify"]));
+      const genericWrite = value.vault.writeCredential({
+        slot: "anthropic",
+        value: "synthetic-model-key",
+      });
+      const genericDelete = value.vault.deleteCredential("intervals-icu");
+      await Promise.resolve();
+
+      expect(trace).toEqual(["verify"]);
+      expect(value.clearCredential).not.toHaveBeenCalled();
+
+      verification.resolve({ status: "verified" });
+      await expect(genericWrite).resolves.toMatchObject({ status: "configured" });
+      await expect(genericDelete).resolves.toMatchObject({ status: "deleted" });
+      await expect(paste).resolves.toEqual({
+        outcome: "applied",
+        current: status("configured", "active"),
+      });
+      expect(trace).toEqual([
+        "verify",
+        `apply:intervals-icu:${API_KEY}`,
+        "apply:anthropic:synthetic-model-key",
+        "clear-runtime",
+      ]);
+    } finally {
+      await rm(value.base, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Intervals.icu credential verification", () => {
+  it("pins the overall and per-request production deadlines", () => {
+    expect(INTERVALS_CREDENTIAL_VERIFICATION_TIMEOUT_MS).toBe(20_000);
+    expect(INTERVALS_CREDENTIAL_REQUEST_TIMEOUT_MS).toBe(8_000);
+  });
+
+  it("refuses verification when the active runtime configuration is unavailable", async () => {
+    const signal = new AbortController().signal;
+    const readRuntimeConfig = vi.fn(async () => {
+      throw new Error(PRIVATE_DETAIL);
+    });
+    const verifyCredential = createDesktopIntervalsCredentialVerifier({
+      storePath: "/synthetic/unavailable-store.db",
+      readRuntimeConfig,
+    });
+
+    const result = await verifyCredential(API_KEY, signal);
+
+    expect(result).toEqual({ status: "refused", reason: "validation-unavailable" });
+    expect(readRuntimeConfig).toHaveBeenCalledOnce();
+    expect(readRuntimeConfig).toHaveBeenCalledWith(signal);
+    expect(JSON.stringify(result)).not.toContain(API_KEY);
+    expect(JSON.stringify(result)).not.toContain("PRIVATE_KEY");
+  });
+
+  it("verifies a valid key before accepting a matching or ownerless store", async () => {
+    for (const comparison of ["matched", "unowned"] as const) {
+      const compareOwner = vi.fn(async () => comparison);
+
+      await expect(
+        verifyIntervalsCredentialAtPath(
+          "/synthetic/store.db",
+          verificationOptions({
+            baseFetch: vi.fn(async () => athleteResponse()),
+            compareOwner,
+          }),
+        ),
+      ).resolves.toEqual({ status: "verified" });
+      expect(compareOwner).toHaveBeenCalledWith(
+        "/synthetic/store.db",
+        expect.stringMatching(/^[0-9a-f]{64}$/),
+      );
+    }
+  });
+
+  it("does not claim an ownerless store while validating it", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "intervals-owner-"));
+    const storePath = join(root, "store.db");
+    const store = new DatabaseSync(storePath);
+    store.exec(
+      "CREATE TABLE store_owner (singleton INTEGER PRIMARY KEY, account_fingerprint TEXT NOT NULL)",
+    );
+    store.close();
+    try {
+      await expect(
+        verifyIntervalsCredentialAtPath(
+          storePath,
+          verificationOptions({ baseFetch: vi.fn(async () => athleteResponse()) }),
+        ),
+      ).resolves.toEqual({ status: "verified" });
+
+      const reopened = new DatabaseSync(storePath, { readOnly: true });
+      try {
+        expect(reopened.prepare("SELECT count(*) AS count FROM store_owner").get()).toEqual({
+          count: 0,
+        });
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each([401, 403])("classifies HTTP %s as a credential rejection", async (httpStatus) => {
+    const result = await verifyIntervalsCredentialAtPath(
+      "/synthetic/store.db",
+      verificationOptions({
+        baseFetch: vi.fn(
+          async () =>
+            new Response("", {
+              status: httpStatus,
+              headers: { "content-type": "application/json" },
+            }),
+        ),
+      }),
+    );
+
+    expect(result).toEqual({ status: "refused", reason: "credential-rejected" });
+    expect(JSON.stringify(result)).not.toContain(API_KEY);
+  });
+
+  it("classifies a malformed athlete response without exposing it", async () => {
+    for (const body of [
+      `{"private":"${PRIVATE_DETAIL}"`,
+      JSON.stringify({
+        sportSettings: [{ id: 1, types: ["Ride"], updated: "2010-01-01" }],
+      }),
+    ]) {
+      const result = await verifyIntervalsCredentialAtPath(
+        "/synthetic/store.db",
+        verificationOptions({
+          baseFetch: vi.fn(
+            async () =>
+              new Response(body, {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+          ),
+        }),
+      );
+
+      expect(result).toEqual({ status: "refused", reason: "malformed-athlete-response" });
+      expect(JSON.stringify(result)).not.toContain(API_KEY);
+      expect(JSON.stringify(result)).not.toContain("PRIVATE_KEY");
+    }
+  });
+
+  it("preserves transport and timeout classification while reading the response body", async () => {
+    const failedBody = (): ReadableStream<Uint8Array> =>
+      new ReadableStream({
+        start(controller) {
+          controller.error(new Error(PRIVATE_DETAIL));
+        },
+      });
+
+    await expect(
+      verifyIntervalsCredentialAtPath(
+        "/synthetic/store.db",
+        verificationOptions({
+          baseFetch: vi.fn(
+            async () =>
+              new Response(failedBody(), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+          ),
+        }),
+      ),
+    ).resolves.toEqual({ status: "refused", reason: "validation-unavailable" });
+
+    await expect(
+      verifyIntervalsCredentialAtPath(
+        "/synthetic/store.db",
+        verificationOptions({
+          baseFetch: vi.fn(
+            async () =>
+              new Response(failedBody(), {
+                status: 401,
+                headers: { "content-type": "application/json" },
+              }),
+          ),
+        }),
+      ),
+    ).resolves.toEqual({ status: "refused", reason: "credential-rejected" });
+
+    await expect(
+      verifyIntervalsCredentialAtPath(
+        "/synthetic/store.db",
+        verificationOptions({
+          baseFetch: vi.fn(
+            async () =>
+              new Response(new ReadableStream<Uint8Array>({ start() {} }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+          ),
+          overallTimeoutMs: 100,
+          perRequestTimeoutMs: 5,
+        }),
+      ),
+    ).resolves.toEqual({ status: "refused", reason: "validation-timeout" });
+  });
+
+  it("distinguishes an owner-unresolved valid response", async () => {
+    const compareOwner = vi.fn();
+    const result = await verifyIntervalsCredentialAtPath(
+      "/synthetic/store.db",
+      verificationOptions({
+        baseFetch: vi.fn(
+          async () =>
+            new Response(JSON.stringify({ sportSettings: [] }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+        ),
+        compareOwner,
+      }),
+    );
+
+    expect(result).toEqual({ status: "refused", reason: "owner-unresolved" });
+    expect(compareOwner).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes request timeout, shutdown abort, and offline transport", async () => {
+    const neverFetch = vi.fn(() => new Promise<Response>(() => {}));
+    await expect(
+      verifyIntervalsCredentialAtPath(
+        "/synthetic/store.db",
+        verificationOptions({
+          baseFetch: neverFetch,
+          overallTimeoutMs: 100,
+          perRequestTimeoutMs: 5,
+        }),
+      ),
+    ).resolves.toEqual({ status: "refused", reason: "validation-timeout" });
+
+    const shutdown = new AbortController();
+    const aborted = verifyIntervalsCredentialAtPath(
+      "/synthetic/store.db",
+      verificationOptions({
+        baseFetch: neverFetch,
+        signal: shutdown.signal,
+        overallTimeoutMs: 100,
+        perRequestTimeoutMs: 50,
+      }),
+    );
+    shutdown.abort(new Error(PRIVATE_DETAIL));
+    await expect(aborted).resolves.toEqual({
+      status: "refused",
+      reason: "validation-aborted",
+    });
+
+    await expect(
+      verifyIntervalsCredentialAtPath(
+        "/synthetic/store.db",
+        verificationOptions({
+          baseFetch: vi.fn(async () => {
+            throw new Error(PRIVATE_DETAIL);
+          }),
+        }),
+      ),
+    ).resolves.toEqual({ status: "refused", reason: "validation-unavailable" });
+  });
+
+  it.each([
+    ["mismatch", "training-account-mismatch"],
+    ["store-unavailable", "store-unavailable"],
+  ] as const)("maps %s store comparison without writing", async (comparison, reason) => {
+    const result = await verifyIntervalsCredentialAtPath(
+      "/synthetic/store.db",
+      verificationOptions({
+        baseFetch: vi.fn(async () => athleteResponse()),
+        compareOwner: async () => comparison,
+      }),
+    );
+
+    expect(result).toEqual({ status: "refused", reason });
+    expect(JSON.stringify(result)).not.toContain(API_KEY);
+  });
+});

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -25,7 +25,11 @@ import {
   type OnboardingLlmSelection,
   type OnboardingLlmSelectionResult,
 } from "../src/main/llm-selection.js";
-import type { CredentialVault } from "../src/main/credential-vault.js";
+import type {
+  CredentialVault,
+  CredentialWriteBehavior,
+  CredentialWriteInput,
+} from "../src/main/credential-vault.js";
 
 type Handler = (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown;
 type OwnershipCheck = (
@@ -80,6 +84,13 @@ function harness(
       status: "configured" as const,
       runtimeReady: behavior?.activate !== false,
     })),
+    runExclusiveMutation: vi.fn(async (operation) =>
+      operation({
+        writeCredential: (input: CredentialWriteInput, behavior?: CredentialWriteBehavior) =>
+          vault.writeCredential(input, behavior),
+        credentialStatuses: () => vault.credentialStatuses(),
+      }),
+    ),
     applyLlmSelection: vi.fn(async () => ({
       status: "configured" as const,
       runtimeReady: true as const,
@@ -401,6 +412,25 @@ describe("desktop onboarding IPC", () => {
       cleanupPending: false,
     });
     expect(subject.chatGptAuth.deleteCredential).toHaveBeenCalledOnce();
+  });
+
+  it("deletes a locally stored Intervals.icu credential through the existing channel", async () => {
+    const subject = harness();
+    vi.mocked(subject.vault.credentialStatuses).mockResolvedValueOnce([
+      { slot: "intervals-icu", state: "configured", runtimeState: "active" },
+    ]);
+
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_DELETE_CHANNEL, subject.trustedEvent, {
+        credential: "intervals-icu",
+      }),
+    ).resolves.toEqual({
+      credential: "intervals-icu",
+      status: "deleted",
+      cleanupPending: false,
+    });
+    expect(subject.vault.deleteCredential).toHaveBeenCalledWith("intervals-icu");
+    expect(subject.getRuntimeConfig).not.toHaveBeenCalled();
   });
 
   it("projects credential deletion uncertainty as its exact slot envelope", async () => {

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -59,6 +59,7 @@ interface AuthBridge {
   claudeCliStatus(): Promise<unknown>;
   claudeCliRecheck(): Promise<unknown>;
   telegramStatus(): Promise<unknown>;
+  pasteIntervalsApiKeyFromClipboard(): Promise<unknown>;
   pasteTelegramTokenFromClipboard(): Promise<unknown>;
   enableTelegram(): Promise<unknown>;
   disableTelegram(): Promise<unknown>;
@@ -254,6 +255,7 @@ describe("desktop preload ChatGPT auth", () => {
         "onDroppedImportFiles",
         "onChatgptLoginProgress",
         "onUpdateState",
+        "pasteIntervalsApiKeyFromClipboard",
         "pasteTelegramTokenFromClipboard",
         "reconcileTelegram",
         "releaseNotes",
@@ -384,6 +386,126 @@ describe("desktop preload ChatGPT auth", () => {
       });
       await expect(bridge.telegramStatus()).rejects.toBeInstanceOf(TypeError);
     }
+  });
+
+  it("exposes a zero-argument Intervals.icu clipboard lane with a copied result", async () => {
+    const current = {
+      slot: "intervals-icu",
+      state: "configured",
+      runtimeState: "active",
+    };
+    const result = { outcome: "applied", current };
+    mocks.invoke.mockResolvedValueOnce(result);
+
+    const copied = (await bridge.pasteIntervalsApiKeyFromClipboard()) as typeof result;
+
+    expect(copied).toEqual(result);
+    expect(copied).not.toBe(result);
+    expect(copied.current).not.toBe(current);
+    expect(mocks.invoke).toHaveBeenCalledWith("desktop:intervals:paste-credential");
+
+    mocks.invoke.mockClear();
+    await expect(
+      (
+        bridge.pasteIntervalsApiKeyFromClipboard as unknown as (
+          ...args: unknown[]
+        ) => Promise<unknown>
+      )("must-not-cross"),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "clipboard-unavailable",
+    "clipboard-clear-failed",
+    "invalid-key-format",
+    "credential-rejected",
+    "malformed-athlete-response",
+    "validation-timeout",
+    "validation-aborted",
+    "validation-unavailable",
+    "training-account-mismatch",
+    "owner-unresolved",
+    "store-unavailable",
+    "encryption-unavailable",
+    "unsafe-backend",
+    "storage-failed",
+    "runtime-unavailable",
+  ] as const)("accepts the closed Intervals.icu refusal reason %s", async (reason) => {
+    const result = {
+      outcome: "refused",
+      reason,
+      current: { slot: "intervals-icu", state: "missing", runtimeState: null },
+    };
+    mocks.invoke.mockResolvedValueOnce(result);
+
+    const copied = (await bridge.pasteIntervalsApiKeyFromClipboard()) as typeof result;
+
+    expect(copied).toEqual(result);
+    expect(copied).not.toBe(result);
+    expect(copied.current).not.toBe(result.current);
+  });
+
+  it("accepts only exact secret-safe Intervals.icu clipboard envelopes", async () => {
+    const current = { slot: "intervals-icu", state: "re-prompt", runtimeState: null };
+    const uncertain = { outcome: "uncertain", reason: "storage-uncertain", current };
+    mocks.invoke.mockResolvedValueOnce(uncertain);
+
+    const copied = (await bridge.pasteIntervalsApiKeyFromClipboard()) as typeof uncertain;
+
+    expect(copied).toEqual(uncertain);
+    expect(copied).not.toBe(uncertain);
+    expect(copied.current).not.toBe(current);
+
+    const runtimeUncertain = { ...uncertain, reason: "runtime-uncertain" };
+    mocks.invoke.mockResolvedValueOnce(runtimeUncertain);
+    const copiedRuntimeUncertain =
+      (await bridge.pasteIntervalsApiKeyFromClipboard()) as typeof runtimeUncertain;
+    expect(copiedRuntimeUncertain).toEqual(runtimeUncertain);
+    expect(copiedRuntimeUncertain).not.toBe(runtimeUncertain);
+    expect(copiedRuntimeUncertain.current).not.toBe(current);
+
+    for (const malformed of [
+      { ...uncertain, apiKey: "must-not-cross" },
+      { ...uncertain, reason: "storage-failed" },
+      { ...uncertain, current: { ...current, owner: "private" } },
+      {
+        outcome: "applied",
+        current: { slot: "intervals-icu", state: "configured", runtimeState: null },
+      },
+      {
+        outcome: "refused",
+        reason: "private-network-detail",
+        current,
+      },
+      {
+        outcome: "refused",
+        reason: "credential-rejected",
+        current: { slot: "other", state: "missing", runtimeState: null },
+      },
+    ]) {
+      mocks.invoke.mockResolvedValueOnce(malformed);
+      const failure = await bridge
+        .pasteIntervalsApiKeyFromClipboard()
+        .catch((error: unknown) => error);
+      expect(failure).toBeInstanceOf(TypeError);
+      expect((failure as TypeError).message).toBe("");
+    }
+  });
+
+  it("redacts Intervals.icu clipboard invocation failures", async () => {
+    const privateDetail =
+      "private-api-key at /Users/private/intervals-key and athlete-response-body";
+    mocks.invoke.mockRejectedValueOnce(new Error(privateDetail));
+
+    const failure = await bridge
+      .pasteIntervalsApiKeyFromClipboard()
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(TypeError);
+    expect((failure as TypeError).message).toBe("");
+    expect(String(failure)).not.toContain(privateDetail);
+    expect(String(failure)).not.toContain("/Users/private/intervals-key");
   });
 
   it("accepts only closed secret-safe Telegram mutation envelopes", async () => {
@@ -1168,6 +1290,23 @@ describe("desktop preload ChatGPT auth", () => {
     await expect(bridge.deleteCredential({ credential: "anthropic" })).rejects.toBeInstanceOf(
       TypeError,
     );
+  });
+
+  it("accepts a successful Intervals.icu credential deletion result", async () => {
+    const result = {
+      credential: "intervals-icu",
+      status: "deleted",
+      cleanupPending: false,
+    };
+    mocks.invoke.mockResolvedValueOnce(result);
+
+    const copied = await bridge.deleteCredential({ credential: "intervals-icu" });
+
+    expect(copied).toEqual(result);
+    expect(copied).not.toBe(result);
+    expect(mocks.invoke).toHaveBeenCalledWith("enduragent:settings:credential-delete", {
+      credential: "intervals-icu",
+    });
   });
 
   it("accepts only the exact credential deletion uncertainty envelope", async () => {

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -418,6 +418,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "onChatgptLoginProgress",
       "onDroppedImportFiles",
       "onUpdateState",
+      "pasteIntervalsApiKeyFromClipboard",
       "pasteTelegramTokenFromClipboard",
       "reconcileTelegram",
       "releaseNotes",

--- a/packages/coach/src/backfill.ts
+++ b/packages/coach/src/backfill.ts
@@ -19,7 +19,9 @@ import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { openReadonlySqliteStorage } from "@enduragent/kernel-node/sqlite";
 import {
   createIntervalsIcuSource,
+  IntervalsHttpError,
   REQUEST_ATTEMPTS,
+  SyncBudgetExceededError,
   type IntervalsIcuArtifact,
   type IntervalsIcuSource,
   type IntervalsLandingAcl,
@@ -88,6 +90,29 @@ export type StoreOwnerCheckResult =
   | "unresolved"
   | "store-unavailable";
 
+export type IntervalsCredentialVerificationRefusalReason =
+  | "credential-rejected"
+  | "malformed-athlete-response"
+  | "validation-timeout"
+  | "validation-aborted"
+  | "validation-unavailable"
+  | "training-account-mismatch"
+  | "owner-unresolved"
+  | "store-unavailable";
+
+export type IntervalsCredentialVerificationResult =
+  | Readonly<{ status: "verified" }>
+  | Readonly<{
+      status: "refused";
+      reason: IntervalsCredentialVerificationRefusalReason;
+    }>;
+
+export type IntervalsStoreOwnerComparison =
+  | "unowned"
+  | "matched"
+  | "mismatch"
+  | "store-unavailable";
+
 const lookupArchiveResult: ArchiveWriteResult = Object.freeze({
   address: "0".repeat(64),
   relPath: "1970/01/lookup.json.gz",
@@ -108,6 +133,14 @@ const CLAIM_STORE_OWNER_SQL =
 const STORE_OWNER_CHECK_BUSY_TIMEOUT_MS = 5_000;
 const RUNTIME_ATHLETE_OWNER_TIMEOUT_MS = 20_000;
 const RUNTIME_ATHLETE_OWNER_REQUEST_TIMEOUT_MS = 8_000;
+export const INTERVALS_CREDENTIAL_VERIFICATION_TIMEOUT_MS = 20_000;
+export const INTERVALS_CREDENTIAL_REQUEST_TIMEOUT_MS = 8_000;
+
+class IntervalsCredentialTransportError extends Error {
+  constructor(readonly status?: number) {
+    super();
+  }
+}
 
 async function readStoreOwnerFingerprint(
   store: Pick<SqlStore, "get">,
@@ -168,9 +201,9 @@ export async function resolveIntervalsStoreOwnerFingerprint(
   )) {
     if (artifact.kind !== "snapshot" || artifact.lane !== "settings") continue;
     const payload = artifact.payload;
-    if (payload === null || typeof payload !== "object" || Array.isArray(payload)) return null;
+    if (payload === null || typeof payload !== "object" || Array.isArray(payload)) throw new TypeError();
     const value = (payload as Record<string, unknown>).athlete_id;
-    if (typeof value !== "string" || value.length === 0) return null;
+    if (typeof value !== "string" || value.length === 0) throw new TypeError();
     resolved.add(value);
   }
   if (resolved.size !== 1) return null;
@@ -223,6 +256,23 @@ export async function assertRuntimeAthleteOwner(
     if (fingerprint === null) throw new RuntimeAthleteOwnerRefusal(reason);
     return fingerprint;
   };
+  const pendingClaim = (
+    fingerprint: string,
+    reason: Extract<
+      RuntimeAthleteOwnerRefusalReason,
+      "current-unresolved" | "candidate-unresolved"
+    >,
+  ): RuntimeAthleteOwnerClaim =>
+    Object.freeze({
+      async claim() {
+        try {
+          signal.throwIfAborted();
+        } catch {
+          throw new RuntimeAthleteOwnerRefusal(reason);
+        }
+        await store.run(CLAIM_STORE_OWNER_SQL, [fingerprint]);
+      },
+    });
 
   try {
     if ((await readStoreOwnerFingerprint(store)) === undefined) {
@@ -231,16 +281,7 @@ export async function assertRuntimeAthleteOwner(
           options.candidate,
           "candidate-unresolved",
         );
-        return Object.freeze({
-          async claim() {
-            try {
-              signal.throwIfAborted();
-            } catch {
-              throw new RuntimeAthleteOwnerRefusal("candidate-unresolved");
-            }
-            await store.run(CLAIM_STORE_OWNER_SQL, [candidateFingerprint]);
-          },
-        });
+        return pendingClaim(candidateFingerprint, "candidate-unresolved");
       }
       if (options.current.apiKey.length === 0) {
         throw new RuntimeAthleteOwnerRefusal("current-credential-missing");
@@ -249,23 +290,20 @@ export async function assertRuntimeAthleteOwner(
         options.current,
         "current-unresolved",
       );
-      try {
-        signal.throwIfAborted();
-      } catch {
-        throw new RuntimeAthleteOwnerRefusal("current-unresolved");
-      }
-      await store.run(CLAIM_STORE_OWNER_SQL, [currentFingerprint]);
-      try {
-        signal.throwIfAborted();
-      } catch {
-        throw new RuntimeAthleteOwnerRefusal("current-unresolved");
-      }
       if (
         options.current.apiKey === options.candidate.apiKey &&
         options.current.athleteId === options.candidate.athleteId
       ) {
-        return;
+        return pendingClaim(currentFingerprint, "current-unresolved");
       }
+      const candidateFingerprint = await resolveRequiredFingerprint(
+        options.candidate,
+        "candidate-unresolved",
+      );
+      if (candidateFingerprint !== currentFingerprint) {
+        throw new RuntimeAthleteOwnerRefusal("mismatch");
+      }
+      return pendingClaim(candidateFingerprint, "candidate-unresolved");
     }
 
     const candidateFingerprint = await resolveRequiredFingerprint(
@@ -344,6 +382,208 @@ export async function checkIntervalsStoreOwnerAtPath(
   } catch {
     await store?.close().catch(() => undefined);
     return "store-unavailable";
+  }
+}
+
+export async function compareIntervalsStoreOwnerFingerprintAtPath(
+  storePath: string,
+  fingerprint: string,
+): Promise<IntervalsStoreOwnerComparison> {
+  let store: ReturnType<typeof openReadonlySqliteStorage> | undefined;
+  let comparison: Exclude<IntervalsStoreOwnerComparison, "store-unavailable">;
+  try {
+    store = openReadonlySqliteStorage(storePath);
+    const timeout = await store.get(`PRAGMA busy_timeout = ${STORE_OWNER_CHECK_BUSY_TIMEOUT_MS}`);
+    if (timeout?.timeout !== STORE_OWNER_CHECK_BUSY_TIMEOUT_MS) throw new TypeError();
+    comparison = await compareStoreOwner(store, fingerprint);
+  } catch {
+    await store?.close().catch(() => undefined);
+    return "store-unavailable";
+  }
+  try {
+    await store.close();
+    return comparison;
+  } catch {
+    return "store-unavailable";
+  }
+}
+
+function abortableIntervalsCredentialFetch(
+  baseFetch: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    const signal = init?.signal;
+    try {
+      signal?.throwIfAborted();
+      const response =
+        signal == null
+          ? await baseFetch(input, init)
+          : await withIntervalsCredentialAbort(baseFetch(input, init), signal);
+      return new Proxy(response, {
+        get(target, property) {
+          if (property === "arrayBuffer") {
+            return async (): Promise<ArrayBuffer> => {
+              try {
+                const body = target.arrayBuffer();
+                return signal == null
+                  ? await body
+                  : await withIntervalsCredentialAbort(body, signal);
+              } catch {
+                if (signal?.aborted) throw signal.reason;
+                throw new IntervalsCredentialTransportError(target.status);
+              }
+            };
+          }
+          const value = Reflect.get(target, property, target) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+    } catch {
+      if (signal?.aborted) throw signal.reason;
+      throw new IntervalsCredentialTransportError();
+    }
+  };
+}
+
+async function withIntervalsCredentialAbort<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  signal.throwIfAborted();
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function timeoutFailure(error: unknown): boolean {
+  return (
+    error instanceof SyncBudgetExceededError ||
+    (typeof error === "object" &&
+      error !== null &&
+      "name" in error &&
+      error.name === "TimeoutError")
+  );
+}
+
+export async function verifyIntervalsCredentialAtPath(
+  storePath: string,
+  options: Omit<StoreOwnerCheckOptions, "signal" | "budget"> & {
+    readonly signal: AbortSignal;
+    readonly overallTimeoutMs?: number;
+    readonly perRequestTimeoutMs?: number;
+    readonly compareOwner?: (
+      storePath: string,
+      fingerprint: string,
+    ) => Promise<IntervalsStoreOwnerComparison>;
+  },
+): Promise<IntervalsCredentialVerificationResult> {
+  const overallTimeoutMs = options.overallTimeoutMs ?? INTERVALS_CREDENTIAL_VERIFICATION_TIMEOUT_MS;
+  const perRequestTimeoutMs =
+    options.perRequestTimeoutMs ?? INTERVALS_CREDENTIAL_REQUEST_TIMEOUT_MS;
+  if (
+    !Number.isSafeInteger(overallTimeoutMs) ||
+    overallTimeoutMs <= 0 ||
+    !Number.isSafeInteger(perRequestTimeoutMs) ||
+    perRequestTimeoutMs <= 0
+  ) {
+    throw new TypeError();
+  }
+  if (options.signal.aborted) {
+    return { status: "refused", reason: "validation-aborted" };
+  }
+  const overallController = new AbortController();
+  const timeout = setTimeout(
+    () => overallController.abort(new DOMException("", "TimeoutError")),
+    overallTimeoutMs,
+  );
+  timeout.unref();
+  const shutdownSignal = options.signal;
+  const signal = AbortSignal.any([shutdownSignal, overallController.signal]);
+  const budget: SyncBudget = {
+    signal,
+    clock: { monotonicNow: () => options.clock.monotonicNow() },
+    deadlineMonotonicMs: options.clock.monotonicNow() + overallTimeoutMs,
+    perRequestTimeoutMs,
+    maxRequests: REQUEST_ATTEMPTS,
+    maxArtifacts: 1_000,
+  };
+  try {
+    let fingerprint: string | null;
+    try {
+      fingerprint = await resolveIntervalsStoreOwnerFingerprint({
+        ...options,
+        signal,
+        budget,
+        baseFetch: abortableIntervalsCredentialFetch(options.baseFetch ?? globalThis.fetch),
+      });
+      signal.throwIfAborted();
+    } catch (error) {
+      if (shutdownSignal.aborted) {
+        return { status: "refused", reason: "validation-aborted" };
+      }
+      if (overallController.signal.aborted || timeoutFailure(error)) {
+        return { status: "refused", reason: "validation-timeout" };
+      }
+      if (error instanceof IntervalsHttpError) {
+        return {
+          status: "refused",
+          reason:
+            error.status === 401 || error.status === 403
+              ? "credential-rejected"
+              : "validation-unavailable",
+        };
+      }
+      return {
+        status: "refused",
+        reason:
+          error instanceof IntervalsCredentialTransportError
+            ? error.status === 401 || error.status === 403
+              ? "credential-rejected"
+              : "validation-unavailable"
+            : "malformed-athlete-response",
+      };
+    }
+    if (fingerprint === null) return { status: "refused", reason: "owner-unresolved" };
+    let comparison: IntervalsStoreOwnerComparison;
+    try {
+      comparison = await withIntervalsCredentialAbort(
+        (options.compareOwner ?? compareIntervalsStoreOwnerFingerprintAtPath)(
+          storePath,
+          fingerprint,
+        ),
+        signal,
+      );
+      signal.throwIfAborted();
+    } catch {
+      if (shutdownSignal.aborted) {
+        return { status: "refused", reason: "validation-aborted" };
+      }
+      if (overallController.signal.aborted) {
+        return { status: "refused", reason: "validation-timeout" };
+      }
+      comparison = "store-unavailable";
+    }
+    if (comparison === "matched" || comparison === "unowned") return { status: "verified" };
+    if (comparison === "mismatch") {
+      return { status: "refused", reason: "training-account-mismatch" };
+    }
+    return { status: "refused", reason: "store-unavailable" };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -497,26 +497,20 @@ describe("incremental backfill pages", () => {
     expect(mismatchFetch).toHaveBeenCalledOnce();
   });
 
-  it("claims an ownerless store from the current account before resolving the candidate", async () => {
+  it("defers an ownerless current-account claim until the matching candidate is accepted", async () => {
     const value = await fresh();
     const fingerprint = "a".repeat(64);
     const resolveFingerprint = vi.fn(
       async (options: { readonly apiKey: string; readonly athleteId: string }) => {
-        if (options.apiKey === "current-key") {
-          expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
-            count: 0,
-          });
-        } else {
-          expect(options.apiKey).toBe("candidate-key");
-          expect(await value.store.get("SELECT account_fingerprint FROM store_owner")).toEqual({
-            account_fingerprint: fingerprint,
-          });
-        }
+        if (options.apiKey !== "current-key") expect(options.apiKey).toBe("candidate-key");
+        expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+          count: 0,
+        });
         return fingerprint;
       },
     );
     try {
-      await assertRuntimeAthleteOwner(
+      const pendingClaim = await assertRuntimeAthleteOwner(
         value.store,
         {
           current: {
@@ -540,6 +534,13 @@ describe("incremental backfill pages", () => {
         "current-athlete",
         "candidate-athlete",
       ]);
+      expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+        count: 0,
+      });
+      await pendingClaim?.claim();
+      expect(await value.store.get("SELECT account_fingerprint FROM store_owner")).toEqual({
+        account_fingerprint: fingerprint,
+      });
     } finally {
       await value.store.close();
     }
@@ -804,10 +805,8 @@ describe("incremental backfill pages", () => {
           resolveFingerprint,
         ),
       ).rejects.toMatchObject({ reason: "candidate-unresolved" });
-      expect(
-        await candidateUnresolved.store.get("SELECT account_fingerprint FROM store_owner"),
-      ).toEqual({
-        account_fingerprint: fingerprint,
+      expect(await candidateUnresolved.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+        count: 0,
       });
     } finally {
       await candidateUnresolved.store.close();
@@ -844,8 +843,8 @@ describe("incremental backfill pages", () => {
           resolveFingerprint,
         ),
       ).rejects.toMatchObject({ reason: "mismatch" });
-      expect(await value.store.get("SELECT account_fingerprint FROM store_owner")).toEqual({
-        account_fingerprint: currentFingerprint,
+      expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+        count: 0,
       });
     } finally {
       await value.store.close();


### PR DESCRIPTION
## What

Adds a clipboard-capture lane for the Intervals.icu API key in the desktop main process and preload — the athlete copies their API key and the app captures it without the key ever being typed into, displayed by, or passed through the renderer. No UI changes in this PR; the renderer surface that uses this lane ships separately.

- New trusted IPC channel `desktop:intervals:paste-credential` with a zero-argument contract enforced in both main and preload.
- New `apps/desktop/src/main/intervals-ipc.ts` mirroring the Telegram clipboard lane one-for-one: exact trusted-frame guard, synchronous clipboard read-then-clear before any async work, clear attempted even on failure (a failed clear refuses the credential), secure-storage requirement with `basic_text` refusal, metadata-only result envelopes with allowlisted reason codes, draining disposer on shutdown.
- Preload exposes zero-arg `pasteIntervalsApiKeyFromClipboard()` with strict envelope reparse and error masking; all four bridge-key pin sites (preload-auth test, chat-panels integration, spend-meter integration, electron-smoke script) move together.

## Fail-closed verification

Unlike the existing onboarding save path (which stores a key on unresolved/unowned/unavailable ownership checks), this lane verifies before it writes: the key is validated against intervals.icu and owner-compared against any existing store owner (20 s overall / 8 s per-request deadlines, composed with app shutdown) with no claiming during validation. Every non-verified outcome — invalid shape, 401/403, malformed response, timeout, offline, owner mismatch, owner unresolved, store unavailable — leaves existing state unchanged and returns a distinct reason code.

The rollback-on-refusal behavior is opt-in via a write-behavior flag that only this lane passes: the legacy onboarding save path's observable behavior is byte-identical to `main` (verified against HEAD semantics; apply failures there still keep the stored key with `runtimeReady: false`).

Writes serialize with the generic vault's write/delete operations through a shared exclusive-mutation seam, closing a race between the clipboard write and a concurrent Settings delete.

## Tests

- New `intervals-ipc.test.ts` (49 tests): clipboard read/clear ordering trace, invalid-format table, read/clear/validation failure paths, clear-failure refusal, secure-storage refusals, redaction across result/error/log surfaces, untrusted-sender and extra-argument rejection at the registered handler, verification outcomes (valid key, 401/403, malformed response, timeout/abort, owner mismatch, owner-unresolved, unchanged-existing-key), write/delete serialization, and rollback branches. The initial-write cleanup assertion is mutation-checked (test fails with the cleanup line removed, passes with it restored).
- Added missing successful `deleteCredential({credential:"intervals-icu"})` IPC/preload coverage (previously only the environment-managed refusal was tested).
- Legacy-path refusal semantics re-pinned in `credential-vault.test.ts` / `credential-runtime.test.ts`.

## Known accepted trade-off

The up-to-20 s network verification holds the vault's exclusive queue, so concurrent credential operations (including status reads) wait behind it. This is the deliberate serialization choice for correctness; if it proves noticeable in practice, moving the network round-trip ahead of the exclusive section is the follow-up.
