### PR TITLE
refactor(kernel): add windows private-path policy behind platform dispatch

### DIFF
--- a/packages/core/src/io/atomic-write-file-sync.ts
+++ b/packages/core/src/io/atomic-write-file-sync.ts
@@ -7,6 +7,10 @@ import {
   writeSync,
 } from "node:fs";
 import { randomBytes } from "node:crypto";
+import {
+  classifyWindowsPrivatePathFailure,
+  type WindowsPrivatePathPolicyStage,
+} from "./windows-private-path-policy.js";
 
 /**
  * Synchronous atomic-write of UTF-8 text content. Writes to a temp sibling,
@@ -17,15 +21,22 @@ import { randomBytes } from "node:crypto";
  * renameSection, appendDailyNote). The Reference module uses the async
  * `atomicWriteJson` helper for its persisted state.
  */
-export function atomicWriteFileSync(path: string, content: string): void {
+export function atomicWriteFileSync(
+  path: string,
+  content: string,
+  options: { readonly platform?: NodeJS.Platform } = {},
+): void {
   const tempPath = `${path}.tmp.${randomBytes(4).toString("hex")}`;
   let fd: number | null = null;
+  let stage: WindowsPrivatePathPolicyStage = "content-write";
   try {
     fd = openSync(tempPath, "w", 0o600);
     writeSync(fd, content, null, "utf-8");
+    stage = "file-flush";
     fdatasyncSync(fd);
     closeSync(fd);
     fd = null;
+    stage = "rename";
     renameSync(tempPath, path);
   } catch (err) {
     if (fd !== null) {
@@ -40,6 +51,8 @@ export function atomicWriteFileSync(path: string, content: string): void {
     } catch {
       // Temp may not exist (open failed) or rename succeeded already.
     }
-    throw err;
+    throw (options.platform ?? process.platform) === "win32"
+      ? classifyWindowsPrivatePathFailure(stage, err)
+      : err;
   }
 }

--- a/packages/core/src/io/atomic-write-json.ts
+++ b/packages/core/src/io/atomic-write-json.ts
@@ -1,5 +1,9 @@
 import { open, rename, unlink } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
+import {
+  classifyWindowsPrivatePathFailure,
+  type WindowsPrivatePathPolicyStage,
+} from "./windows-private-path-policy.js";
 
 /**
  * Atomically write a JSON-serialized value to `path` via write-to-temp +
@@ -15,7 +19,7 @@ import { randomBytes } from "node:crypto";
 export async function atomicWriteJson(
   path: string,
   value: unknown,
-  opts?: { signal?: AbortSignal },
+  opts?: { signal?: AbortSignal; platform?: NodeJS.Platform },
 ): Promise<void> {
   // Serialize FIRST so circular-reference / BigInt failures don't leave a
   // half-baked temp file on disk.
@@ -25,9 +29,11 @@ export async function atomicWriteJson(
   const tempPath = `${path}.tmp.${suffix}`;
 
   let fh: Awaited<ReturnType<typeof open>> | null = null;
+  let stage: WindowsPrivatePathPolicyStage = "content-write";
   try {
     fh = await open(tempPath, "w", 0o600);
     await fh.writeFile(body, "utf-8");
+    stage = "file-flush";
     await fh.sync();
     await fh.close();
     fh = null;
@@ -45,6 +51,7 @@ export async function atomicWriteJson(
       }
       return;
     }
+    stage = "rename";
     await rename(tempPath, path);
   } catch (err) {
     if (fh !== null) {
@@ -59,6 +66,8 @@ export async function atomicWriteJson(
     } catch {
       // Temp file may not exist (open failed) or rename succeeded already.
     }
-    throw err;
+    throw (opts?.platform ?? process.platform) === "win32"
+      ? classifyWindowsPrivatePathFailure(stage, err)
+      : err;
   }
 }

--- a/packages/core/src/io/windows-private-path-policy.ts
+++ b/packages/core/src/io/windows-private-path-policy.ts
@@ -1,0 +1,64 @@
+import {
+  classifyPrivatePathDurability,
+  classifyPrivatePathErrorCode,
+  decidePrivatePathEntry,
+  decidePrivatePathRead,
+  type PrivatePathDurabilityClassification,
+  type PrivatePathDurabilityStage,
+  type PrivatePathEntryDecisionInput,
+  type PrivatePathPolicyDecision,
+  type PrivatePathPolicyErrorCategory,
+  type PrivatePathReadDecisionInput,
+} from "@enduragent/kernel/ports";
+
+export type WindowsPrivatePathPolicyStage =
+  | Exclude<PrivatePathDurabilityStage, "directory-sync">
+  | "entry-check"
+  | "read-check";
+
+export class WindowsPrivatePathPolicyError extends Error {
+  override readonly name = "WindowsPrivatePathPolicyError";
+  readonly stage: WindowsPrivatePathPolicyStage;
+  readonly category: PrivatePathPolicyErrorCategory;
+
+  constructor(stage: WindowsPrivatePathPolicyStage, category: PrivatePathPolicyErrorCategory) {
+    super("Windows private path policy failed");
+    this.stage = stage;
+    this.category = category;
+  }
+}
+
+function errorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+}
+
+function assertDecision(
+  stage: WindowsPrivatePathPolicyStage,
+  decision: PrivatePathPolicyDecision,
+): void {
+  if (decision.kind === "reject") {
+    throw new WindowsPrivatePathPolicyError(stage, decision.category);
+  }
+}
+
+export function classifyWindowsPrivatePathDurability(
+  stage: PrivatePathDurabilityStage,
+): PrivatePathDurabilityClassification {
+  return classifyPrivatePathDurability({ platform: "windows", stage });
+}
+
+export function classifyWindowsPrivatePathFailure(
+  stage: WindowsPrivatePathPolicyStage,
+  error: unknown,
+): WindowsPrivatePathPolicyError {
+  if (error instanceof WindowsPrivatePathPolicyError) return error;
+  return new WindowsPrivatePathPolicyError(stage, classifyPrivatePathErrorCode(errorCode(error)));
+}
+
+export function assertWindowsPrivatePathEntry(input: PrivatePathEntryDecisionInput): void {
+  assertDecision("entry-check", decidePrivatePathEntry(input));
+}
+
+export function assertWindowsPrivatePathRead(input: PrivatePathReadDecisionInput): void {
+  assertDecision("read-check", decidePrivatePathRead(input));
+}

--- a/packages/core/tests/io-atomic-write-file-sync.test.ts
+++ b/packages/core/tests/io-atomic-write-file-sync.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { atomicWriteFileSync } from "../src/io/atomic-write-file-sync.js";
+import { WindowsPrivatePathPolicyError } from "../src/io/windows-private-path-policy.js";
 
 let tempDir: string;
 
@@ -30,22 +31,28 @@ describe("atomicWriteFileSync", () => {
     expect(readFileSync(target, "utf-8")).toBe("## profile\nFTP 247W, 72kg\n");
   });
 
-  it("creates the target with owner-only 0o600 permissions", () => {
-    const target = join(tempDir, "private.md");
-    atomicWriteFileSync(target, "resting HR 44\n");
+  it.runIf(process.platform !== "win32")(
+    "creates the target with owner-only 0o600 permissions",
+    () => {
+      const target = join(tempDir, "private.md");
+      atomicWriteFileSync(target, "resting HR 44\n");
 
-    expect(statSync(target).mode & 0o777).toBe(0o600);
-  });
+      expect(statSync(target).mode & 0o777).toBe(0o600);
+    },
+  );
 
-  it("tightens a pre-existing world-readable target to 0o600 on overwrite", () => {
-    const target = join(tempDir, "was-readable.md");
-    writeFileSync(target, "old\n", { encoding: "utf-8", mode: 0o644 });
+  it.runIf(process.platform !== "win32")(
+    "tightens a pre-existing world-readable target to 0o600 on overwrite",
+    () => {
+      const target = join(tempDir, "was-readable.md");
+      writeFileSync(target, "old\n", { encoding: "utf-8", mode: 0o644 });
 
-    atomicWriteFileSync(target, "new\n");
+      atomicWriteFileSync(target, "new\n");
 
-    expect(readFileSync(target, "utf-8")).toBe("new\n");
-    expect(statSync(target).mode & 0o777).toBe(0o600);
-  });
+      expect(readFileSync(target, "utf-8")).toBe("new\n");
+      expect(statSync(target).mode & 0o777).toBe(0o600);
+    },
+  );
 
   it("leaves no dangling temp siblings after repeated writes", () => {
     const target = join(tempDir, "repeated.md");
@@ -56,5 +63,20 @@ describe("atomicWriteFileSync", () => {
     const entries = readdirSync(tempDir);
     expect(entries).toContain("repeated.md");
     expect(entries.filter((e) => e.startsWith("repeated.md.tmp"))).toEqual([]);
+  });
+
+  it("keeps Windows write failures path-free and stage-coded", () => {
+    const target = join(tempDir, "missing", "private-athlete.md");
+    let failure: unknown;
+    try {
+      atomicWriteFileSync(target, "private\n", { platform: "win32" });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "content-write", category: "io-failure" });
+    expect(String(failure)).not.toContain(target);
+    expect(JSON.stringify(failure)).not.toContain(target);
   });
 });

--- a/packages/core/tests/io-atomic-write-json.test.ts
+++ b/packages/core/tests/io-atomic-write-json.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { atomicWriteJson } from "../src/io/atomic-write-json.js";
+import { WindowsPrivatePathPolicyError } from "../src/io/windows-private-path-policy.js";
 
 let tempDir: string;
 
@@ -54,21 +55,27 @@ describe("atomicWriteJson — happy path", () => {
     expect(onDisk).toEqual({ fresh: 42 });
   });
 
-  it("creates the target with owner-only 0o600 permissions", async () => {
-    const target = join(tempDir, "private.json");
-    await atomicWriteJson(target, { hrv: 62 });
+  it.runIf(process.platform !== "win32")(
+    "creates the target with owner-only 0o600 permissions",
+    async () => {
+      const target = join(tempDir, "private.json");
+      await atomicWriteJson(target, { hrv: 62 });
 
-    expect(statSync(target).mode & 0o777).toBe(0o600);
-  });
+      expect(statSync(target).mode & 0o777).toBe(0o600);
+    },
+  );
 
-  it("tightens a pre-existing world-readable target to 0o600 on overwrite", async () => {
-    const target = join(tempDir, "was-readable.json");
-    writeFileSync(target, JSON.stringify({ old: true }), { encoding: "utf-8", mode: 0o644 });
+  it.runIf(process.platform !== "win32")(
+    "tightens a pre-existing world-readable target to 0o600 on overwrite",
+    async () => {
+      const target = join(tempDir, "was-readable.json");
+      writeFileSync(target, JSON.stringify({ old: true }), { encoding: "utf-8", mode: 0o644 });
 
-    await atomicWriteJson(target, { fresh: true });
+      await atomicWriteJson(target, { fresh: true });
 
-    expect(statSync(target).mode & 0o777).toBe(0o600);
-  });
+      expect(statSync(target).mode & 0o777).toBe(0o600);
+    },
+  );
 
   it("handles repeated writes without leaving dangling temp files", async () => {
     const target = join(tempDir, "repeated.json");
@@ -80,6 +87,18 @@ describe("atomicWriteJson — happy path", () => {
     // No `repeated.json.tmp.*` siblings should linger on a clean run.
     const orphans = entries.filter((e) => e.startsWith("repeated.json.tmp"));
     expect(orphans).toEqual([]);
+  });
+
+  it("keeps Windows write failures path-free and stage-coded", async () => {
+    const target = join(tempDir, "missing", "private-athlete.json");
+    const failure = await atomicWriteJson(target, { private: true }, { platform: "win32" }).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "content-write", category: "io-failure" });
+    expect(String(failure)).not.toContain(target);
+    expect(JSON.stringify(failure)).not.toContain(target);
   });
 });
 

--- a/packages/core/tests/windows-private-path-policy.test.ts
+++ b/packages/core/tests/windows-private-path-policy.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  WindowsPrivatePathPolicyError,
+  assertWindowsPrivatePathEntry,
+  assertWindowsPrivatePathRead,
+  classifyWindowsPrivatePathDurability,
+  classifyWindowsPrivatePathFailure,
+} from "../src/io/windows-private-path-policy.js";
+
+function captureFailure(action: () => unknown): unknown {
+  try {
+    action();
+  } catch (error) {
+    return error;
+  }
+  throw new TypeError("expected Windows private path failure");
+}
+
+describe("Windows private path policy", () => {
+  it.each([
+    ["content-write", "required"],
+    ["file-flush", "required"],
+    ["rename", "required"],
+    ["directory-sync", "unavailable"],
+  ] as const)("classifies %s durability as %s", (stage, kind) => {
+    expect(classifyWindowsPrivatePathDurability(stage)).toEqual({ kind });
+  });
+
+  it.each(["EBUSY", "EPERM", "EACCES"])("maps %s to a path-free sharing violation", (code) => {
+    const privatePath = String.raw`C:\Users\Athlete Name\.enduragent\data\state.json`;
+    const failure = classifyWindowsPrivatePathFailure(
+      "rename",
+      Object.assign(new Error(`cannot replace ${privatePath}`), { code, path: privatePath }),
+    );
+
+    expect(failure).toMatchObject({
+      name: "WindowsPrivatePathPolicyError",
+      message: "Windows private path policy failed",
+      stage: "rename",
+      category: "sharing-violation",
+    });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(privatePath);
+    expect(JSON.stringify(failure)).not.toContain(privatePath);
+  });
+
+  it("maps other Node failures to a path-free I/O category", () => {
+    expect(classifyWindowsPrivatePathFailure("file-flush", { code: "EIO" })).toMatchObject({
+      stage: "file-flush",
+      category: "io-failure",
+    });
+  });
+
+  it.each([
+    {
+      bounded: false,
+      identityStable: true,
+      contentValid: true,
+      authenticatedHomeBinding: true,
+    },
+    {
+      bounded: true,
+      identityStable: false,
+      contentValid: true,
+      authenticatedHomeBinding: true,
+    },
+    {
+      bounded: true,
+      identityStable: true,
+      contentValid: false,
+      authenticatedHomeBinding: true,
+    },
+    {
+      bounded: true,
+      identityStable: true,
+      contentValid: true,
+      authenticatedHomeBinding: false,
+    },
+  ])("classifies an invalid stable-read assertion as corruption", (input) => {
+    const failure = captureFailure(() => assertWindowsPrivatePathRead(input));
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+  });
+
+  it("distinguishes entry type and link-shaped failures", () => {
+    expect(
+      captureFailure(() =>
+        assertWindowsPrivatePathEntry({
+          expectedType: "file",
+          actualType: "directory",
+          linkOrReparseShaped: false,
+        }),
+      ),
+    ).toMatchObject({ stage: "entry-check", category: "entry-type" });
+    expect(
+      captureFailure(() =>
+        assertWindowsPrivatePathEntry({
+          expectedType: "directory",
+          actualType: "other",
+          linkOrReparseShaped: true,
+        }),
+      ),
+    ).toMatchObject({ stage: "entry-check", category: "link-reparse-shaped" });
+  });
+
+  it("accepts a bounded stable read bound to the authenticated home", () => {
+    expect(() =>
+      assertWindowsPrivatePathRead({
+        bounded: true,
+        identityStable: true,
+        contentValid: true,
+        authenticatedHomeBinding: true,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/kernel-node/src/cli/coach-dev.ts
+++ b/packages/kernel-node/src/cli/coach-dev.ts
@@ -4,7 +4,11 @@ import { pathToFileURL } from "node:url";
 import type { ImportReport } from "@enduragent/kernel/ingest";
 import { runMigrations } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
-import { prepareAthleteHome, resolveAthleteHome } from "../home/index.js";
+import {
+  ensureWindowsPrivateDirectory,
+  prepareAthleteHome,
+  resolveAthleteHome,
+} from "../home/index.js";
 import type { AthleteHome } from "../home/index.js";
 import { importFilesWithReport } from "../ingest/index.js";
 import {
@@ -25,6 +29,7 @@ type CliResult = {
 const defaultWriterDeps = {
   resolveAthleteHome,
   prepareAthleteHome,
+  ensureWindowsPrivateDirectory,
   acquireWriteLock,
   mkdir,
   chmod,
@@ -62,6 +67,7 @@ export interface CoachDevWriterContext {
 export interface RunCoachDevWriterOptions<T> {
   readonly env: Record<string, string | undefined>;
   readonly writerVersion: string;
+  readonly platform?: NodeJS.Platform;
   readonly beforeStoreOpen?: (home: AthleteHome) => Promise<void>;
   readonly operation: (context: CoachDevWriterContext) => Promise<T>;
 }
@@ -137,9 +143,14 @@ export async function runCoachDevWriter<T>(
   options: RunCoachDevWriterOptions<T>,
   deps: CoachDevWriterDependencies = defaultWriterDeps,
 ): Promise<CoachDevWriterResult<T>> {
+  const platform = options.platform ?? process.platform;
   let home: AthleteHome;
   try {
-    home = await deps.prepareAthleteHome(deps.resolveAthleteHome(options.env));
+    const unresolved = deps.resolveAthleteHome(options.env);
+    home =
+      options.platform === undefined
+        ? await deps.prepareAthleteHome(unresolved)
+        : await deps.prepareAthleteHome(unresolved, { platform });
   } catch (error) {
     return failedWriterResult("resolve home", error);
   }
@@ -150,6 +161,7 @@ export async function runCoachDevWriter<T>(
       configDir: home.configDir,
       athleteHome: home.root,
       version: options.writerVersion,
+      ...(options.platform === undefined ? {} : { platform }),
     });
   } catch (error) {
     if (error instanceof WriteLockContentionError) {
@@ -204,7 +216,11 @@ export async function runCoachDevWriter<T>(
 
       if (failureStage === undefined) {
         try {
-          await deps.chmod(home.storeDir, 0o700);
+          if (platform === "win32") {
+            await deps.ensureWindowsPrivateDirectory(home.storeDir);
+          } else {
+            await deps.chmod(home.storeDir, 0o700);
+          }
         } catch (error) {
           failureStage = "secure store directory";
           failureCause = error;

--- a/packages/kernel-node/src/filesystem/index.ts
+++ b/packages/kernel-node/src/filesystem/index.ts
@@ -2,6 +2,7 @@ import { randomBytes as nodeRandomBytes } from "node:crypto";
 import { dirname } from "node:path";
 import { chmod, mkdir, open, readFile, readdir, rename, stat, unlink } from "node:fs/promises";
 import type { FileSystemPort } from "@enduragent/kernel/ports";
+import { ensureWindowsPrivateDirectory } from "../home/windows-home-policy.js";
 import { createFitDecoder } from "../ingest/fit-decoder.js";
 import { parseXmlBytes } from "../ingest/xml-file.js";
 
@@ -68,7 +69,14 @@ export function nodeFileSystem(): FileSystemPort {
   };
 }
 
-export async function ensurePrivateDirectory(path: string): Promise<void> {
+export async function ensurePrivateDirectory(
+  path: string,
+  options: { readonly platform?: NodeJS.Platform } = {},
+): Promise<void> {
+  if ((options.platform ?? process.platform) === "win32") {
+    await ensureWindowsPrivateDirectory(path);
+    return;
+  }
   await mkdir(path, { recursive: true, mode: 0o700 });
   await chmod(path, 0o700);
 }

--- a/packages/kernel-node/src/home/index.ts
+++ b/packages/kernel-node/src/home/index.ts
@@ -1,6 +1,13 @@
 export { ATHLETE_HOME_ENV, expandTilde, resolveAthleteHome } from "./resolve-athlete-home.js";
 export type { AthleteHome } from "./resolve-athlete-home.js";
 export { prepareAthleteHome } from "./prepare-athlete-home.js";
+export type { PrepareAthleteHomeOptions } from "./prepare-athlete-home.js";
+export {
+  WindowsAthleteHomePolicyError,
+  ensureWindowsPrivateDirectory,
+  prepareWindowsAthleteHome,
+} from "./windows-home-policy.js";
+export type { WindowsAthleteHomePolicyStage } from "./windows-home-policy.js";
 
 export {
   FTP_HISTORY_SCHEMA_VERSION,

--- a/packages/kernel-node/src/home/prepare-athlete-home.ts
+++ b/packages/kernel-node/src/home/prepare-athlete-home.ts
@@ -1,6 +1,7 @@
 import { chmod, lstat, mkdir, realpath, stat } from "node:fs/promises";
 import { isAbsolute, join, parse, resolve } from "node:path";
 import type { AthleteHome } from "./resolve-athlete-home.js";
+import { prepareWindowsAthleteHome } from "./windows-home-policy.js";
 
 const PRIVATE_DIRECTORY_MODE = 0o700;
 
@@ -77,7 +78,17 @@ async function prepareRootDirectory(path: string): Promise<string> {
   return physicalPath;
 }
 
-export async function prepareAthleteHome(home: AthleteHome): Promise<AthleteHome> {
+export interface PrepareAthleteHomeOptions {
+  readonly platform?: NodeJS.Platform;
+}
+
+export async function prepareAthleteHome(
+  home: AthleteHome,
+  options: PrepareAthleteHomeOptions = {},
+): Promise<AthleteHome> {
+  if ((options.platform ?? process.platform) === "win32") {
+    return prepareWindowsAthleteHome(home);
+  }
   validateChildLayout(home);
   const root = await prepareRootDirectory(home.root);
 

--- a/packages/kernel-node/src/home/windows-home-policy.ts
+++ b/packages/kernel-node/src/home/windows-home-policy.ts
@@ -1,0 +1,256 @@
+import { lstat, mkdir, realpath } from "node:fs/promises";
+import { dirname, isAbsolute, join, parse, resolve } from "node:path";
+import {
+  classifyPrivatePathErrorCode,
+  decidePrivatePathBinding,
+  decidePrivatePathEntry,
+  decidePrivatePathRoot,
+  type PrivatePathEntryType,
+  type PrivatePathPolicyDecision,
+  type PrivatePathPolicyErrorCategory,
+} from "@enduragent/kernel/ports";
+import type { AthleteHome } from "./resolve-athlete-home.js";
+
+type PathMetadata = Awaited<ReturnType<typeof lstat>>;
+
+interface PathIdentity {
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+}
+
+interface DirectoryBinding {
+  readonly path: string;
+  readonly identity: PathIdentity;
+}
+
+export type WindowsAthleteHomePolicyStage =
+  | "layout"
+  | "root-create"
+  | "root-entry"
+  | "root-bind"
+  | "child-create"
+  | "child-entry"
+  | "child-bind"
+  | "directory-create"
+  | "directory-entry"
+  | "directory-bind";
+
+export class WindowsAthleteHomePolicyError extends Error {
+  override readonly name = "WindowsAthleteHomePolicyError";
+  readonly stage: WindowsAthleteHomePolicyStage;
+  readonly category: PrivatePathPolicyErrorCategory;
+
+  constructor(stage: WindowsAthleteHomePolicyStage, category: PrivatePathPolicyErrorCategory) {
+    super("Windows athlete home policy failed");
+    this.stage = stage;
+    this.category = category;
+  }
+}
+
+function errorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+}
+
+function policyFailure(
+  stage: WindowsAthleteHomePolicyStage,
+  error: unknown,
+): WindowsAthleteHomePolicyError {
+  if (error instanceof WindowsAthleteHomePolicyError) return error;
+  return new WindowsAthleteHomePolicyError(stage, classifyPrivatePathErrorCode(errorCode(error)));
+}
+
+function assertDecision(
+  stage: WindowsAthleteHomePolicyStage,
+  decision: PrivatePathPolicyDecision,
+): void {
+  if (decision.kind === "reject") {
+    throw new WindowsAthleteHomePolicyError(stage, decision.category);
+  }
+}
+
+function entryType(metadata: PathMetadata): PrivatePathEntryType {
+  if (metadata.isFile()) return "file";
+  if (metadata.isDirectory()) return "directory";
+  return "other";
+}
+
+function pathIdentity(metadata: PathMetadata): PathIdentity {
+  return { dev: metadata.dev, ino: metadata.ino };
+}
+
+function sameIdentity(left: PathIdentity, right: PathIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function assertDirectoryEntry(stage: WindowsAthleteHomePolicyStage, metadata: PathMetadata): void {
+  assertDecision(
+    stage,
+    decidePrivatePathEntry({
+      expectedType: "directory",
+      actualType: entryType(metadata),
+      linkOrReparseShaped: metadata.isSymbolicLink(),
+    }),
+  );
+}
+
+async function optionalEntry(
+  path: string,
+  stage: WindowsAthleteHomePolicyStage,
+): Promise<PathMetadata | undefined> {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return undefined;
+    throw policyFailure(stage, error);
+  }
+}
+
+async function requiredEntry(
+  path: string,
+  stage: WindowsAthleteHomePolicyStage,
+): Promise<PathMetadata> {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    throw policyFailure(stage, error);
+  }
+}
+
+async function ensureDirectory(
+  path: string,
+  recursive: boolean,
+  createStage: WindowsAthleteHomePolicyStage,
+  entryStage: WindowsAthleteHomePolicyStage,
+): Promise<PathMetadata> {
+  let metadata = await optionalEntry(path, entryStage);
+  if (metadata === undefined) {
+    try {
+      await mkdir(path, { recursive });
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") throw policyFailure(createStage, error);
+    }
+    metadata = await requiredEntry(path, entryStage);
+  }
+  assertDirectoryEntry(entryStage, metadata);
+  return metadata;
+}
+
+async function observeDirectoryBinding(
+  path: string,
+  before: PathMetadata,
+  entryStage: WindowsAthleteHomePolicyStage,
+  bindStage: WindowsAthleteHomePolicyStage,
+): Promise<{
+  readonly physicalPath: string;
+  readonly identityStable: boolean;
+  readonly authenticatedBinding: boolean;
+}> {
+  let physicalPath: string;
+  try {
+    physicalPath = await realpath(path);
+  } catch (error) {
+    throw policyFailure(bindStage, error);
+  }
+  const physical = await requiredEntry(physicalPath, entryStage);
+  const after = await requiredEntry(path, entryStage);
+  assertDirectoryEntry(entryStage, physical);
+  assertDirectoryEntry(entryStage, after);
+  const beforeIdentity = pathIdentity(before);
+  return {
+    physicalPath,
+    identityStable: sameIdentity(beforeIdentity, pathIdentity(after)),
+    authenticatedBinding: sameIdentity(beforeIdentity, pathIdentity(physical)),
+  };
+}
+
+function validateLayout(home: AthleteHome): void {
+  if (!isAbsolute(home.root)) {
+    throw new WindowsAthleteHomePolicyError("layout", "corruption");
+  }
+  const root = resolve(home.root);
+  for (const [name, path] of [
+    ["store", home.storeDir],
+    ["archive", home.archiveDir],
+    ["config", home.configDir],
+  ] as const) {
+    if (resolve(path) !== join(root, name)) {
+      throw new WindowsAthleteHomePolicyError("layout", "corruption");
+    }
+  }
+}
+
+async function prepareRoot(path: string): Promise<DirectoryBinding> {
+  const before = await ensureDirectory(path, true, "root-create", "root-entry");
+  const observed = await observeDirectoryBinding(path, before, "root-entry", "root-bind");
+  assertDecision(
+    "root-bind",
+    decidePrivatePathRoot({
+      ordinary: observed.physicalPath !== parse(observed.physicalPath).root,
+      identityStable: observed.identityStable,
+      authenticatedHomeBinding: observed.authenticatedBinding,
+    }),
+  );
+  return { path: observed.physicalPath, identity: pathIdentity(before) };
+}
+
+async function prepareChild(path: string, parent: DirectoryBinding): Promise<void> {
+  const before = await ensureDirectory(path, false, "child-create", "child-entry");
+  const observed = await observeDirectoryBinding(path, before, "child-entry", "child-bind");
+  const currentParent = await requiredEntry(parent.path, "child-bind");
+  const physicalParent = await requiredEntry(dirname(observed.physicalPath), "child-bind");
+  assertDirectoryEntry("child-entry", currentParent);
+  assertDirectoryEntry("child-entry", physicalParent);
+  assertDecision(
+    "child-bind",
+    decidePrivatePathBinding({
+      identityStable: observed.identityStable,
+      authenticatedHomeBinding:
+        observed.authenticatedBinding &&
+        sameIdentity(parent.identity, pathIdentity(currentParent)) &&
+        sameIdentity(parent.identity, pathIdentity(physicalParent)),
+    }),
+  );
+}
+
+export async function ensureWindowsPrivateDirectory(path: string): Promise<string> {
+  if (!isAbsolute(path)) {
+    throw new WindowsAthleteHomePolicyError("directory-bind", "corruption");
+  }
+  const before = await ensureDirectory(path, true, "directory-create", "directory-entry");
+  const observed = await observeDirectoryBinding(path, before, "directory-entry", "directory-bind");
+  assertDecision(
+    "directory-bind",
+    decidePrivatePathRoot({
+      ordinary: observed.physicalPath !== parse(observed.physicalPath).root,
+      identityStable: observed.identityStable,
+      authenticatedHomeBinding: observed.authenticatedBinding,
+    }),
+  );
+  return observed.physicalPath;
+}
+
+export async function prepareWindowsAthleteHome(home: AthleteHome): Promise<AthleteHome> {
+  validateLayout(home);
+  const root = await prepareRoot(home.root);
+  const prepared = {
+    root: root.path,
+    storeDir: join(root.path, "store"),
+    archiveDir: join(root.path, "archive"),
+    configDir: join(root.path, "config"),
+  } satisfies AthleteHome;
+
+  for (const path of [prepared.storeDir, prepared.archiveDir, prepared.configDir]) {
+    await prepareChild(path, root);
+  }
+
+  const finalRoot = await requiredEntry(root.path, "root-bind");
+  assertDirectoryEntry("root-entry", finalRoot);
+  assertDecision(
+    "root-bind",
+    decidePrivatePathBinding({
+      identityStable: sameIdentity(root.identity, pathIdentity(finalRoot)),
+      authenticatedHomeBinding: true,
+    }),
+  );
+  return Object.freeze(prepared);
+}

--- a/packages/kernel-node/src/lock/acquire.ts
+++ b/packages/kernel-node/src/lock/acquire.ts
@@ -12,6 +12,7 @@ import type { Duplex } from "node:stream";
 import { claimLockfile, readLockfile } from "./lockfile-body.js";
 import { readPortFile, writePortFile } from "./port-file.js";
 import { defaultHealthzProbe, isPortBound, type HealthzProbe } from "./healthz-probe.js";
+import { ensureWindowsPrivateDirectory } from "../home/windows-home-policy.js";
 
 export type WriterContentionDiagnostic =
   | {
@@ -45,6 +46,7 @@ export interface AcquireWriteLockOptions {
   readonly athleteHome: string;
   readonly version: string;
   readonly probeHealthz?: HealthzProbe;
+  readonly platform?: NodeJS.Platform;
 }
 
 export interface WriterProtocolHandlers {
@@ -272,7 +274,11 @@ export async function acquireWriteLock(
   opts: AcquireWriteLockOptions,
 ): Promise<AcquireWriteLockResult> {
   const probe = opts.probeHealthz ?? defaultHealthzProbe;
-  ensureConfigDirSecure(opts.configDir);
+  if ((opts.platform ?? process.platform) === "win32") {
+    await ensureWindowsPrivateDirectory(opts.configDir);
+  } else {
+    ensureConfigDirSecure(opts.configDir);
+  }
   const lockfilePath = join(opts.configDir, LOCKFILE_NAME);
   const portFilePath = join(opts.configDir, PORT_FILE_NAME);
 

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -328,6 +328,7 @@ async function runChild(
 type InjectedStage =
   | "resolve"
   | "prepare"
+  | "windows-directory"
   | "acquire"
   | "mkdir"
   | "chmod"
@@ -371,6 +372,7 @@ function injected(options: InjectedOptions = {}) {
     }
   };
   const observed: {
+    prepare?: unknown;
     mkdir?: readonly [string, unknown];
     chmod?: readonly [string, number];
     open?: string;
@@ -420,9 +422,10 @@ function injected(options: InjectedOptions = {}) {
       fail("resolve");
       return home;
     },
-    async prepareAthleteHome(value: typeof home) {
+    async prepareAthleteHome(value: typeof home, prepareOptions?: unknown) {
       calls.push("prepare");
       expect(value).toBe(home);
+      observed.prepare = prepareOptions;
       fail("prepare");
       return preparedHome;
     },
@@ -431,6 +434,12 @@ function injected(options: InjectedOptions = {}) {
       observed.lock = value;
       fail("acquire");
       return handle;
+    },
+    async ensureWindowsPrivateDirectory(path: string) {
+      calls.push("windows-directory");
+      expect(path).toBe(preparedHome.storeDir);
+      fail("windows-directory");
+      return path;
     },
     async mkdir(path: string, mkdirOptions: unknown) {
       calls.push("mkdir");
@@ -858,6 +867,67 @@ describe("coach-dev import --report", () => {
     for (const privateValue of privateValues) {
       expect(serialized).not.toContain(privateValue);
     }
+  });
+
+  it("uses Windows structural policy without invoking the POSIX store chmod stage", async () => {
+    const scenario = injected({ fail: { chmod: new Error("must not run") } });
+
+    const result = await runCoachDevWriter(
+      {
+        env: {},
+        writerVersion: "windows-writer/1",
+        platform: "win32",
+        operation: async () => "done",
+      },
+      scenario.deps,
+    );
+
+    expect(result).toEqual({ status: "completed", value: "done" });
+    expect(scenario.calls).toEqual([
+      "resolve",
+      "prepare",
+      "acquire",
+      "mkdir",
+      "windows-directory",
+      "open",
+      "migrate",
+      "close",
+      "release",
+    ]);
+    expect(scenario.observed.prepare).toEqual({ platform: "win32" });
+    expect(scenario.observed.lock).toEqual({
+      configDir: scenario.home.configDir,
+      athleteHome: scenario.home.root,
+      version: "windows-writer/1",
+      platform: "win32",
+    });
+    expect(scenario.observed.chmod).toBeUndefined();
+  });
+
+  it("fails before store open when the Windows store-directory assertion fails", async () => {
+    const assertionFailure = new Error("private Windows assertion detail");
+    const scenario = injected({ fail: { "windows-directory": assertionFailure } });
+
+    const result = await runCoachDevWriter(
+      {
+        env: {},
+        writerVersion: "windows-writer/1",
+        platform: "win32",
+        operation: async () => "unreachable",
+      },
+      scenario.deps,
+    );
+
+    expect(result).toEqual({ status: "failed", stage: "secure store directory" });
+    expect(result.status === "failed" && result.cause).toBe(assertionFailure);
+    expect(scenario.calls).toEqual([
+      "resolve",
+      "prepare",
+      "acquire",
+      "mkdir",
+      "windows-directory",
+      "release",
+    ]);
   });
 
   it("runs the pre-open hook under the writer before store effects and releases on failure", async () => {

--- a/packages/kernel-node/tests/filesystem.test.ts
+++ b/packages/kernel-node/tests/filesystem.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -42,16 +42,31 @@ describe("Node filesystem adapter", () => {
     await writeFile(target, "old\n");
     await nodeFileSystem().writeFile(target, "replacement\n", { mode: 0o600 });
     expect(await readFile(target, "utf8")).toBe("replacement\n");
-    expect((await stat(target)).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect((await stat(target)).mode & 0o777).toBe(0o600);
+    }
   });
 
-  it("secures private directories to mode 0700", async () => {
+  it.runIf(process.platform !== "win32")("secures private directories to mode 0700", async () => {
     const directory = join(await root(), "private");
     await ensurePrivateDirectory(directory);
     expect((await stat(directory)).mode & 0o777).toBe(0o700);
     await ensurePrivateDirectory(directory);
     expect((await stat(directory)).mode & 0o777).toBe(0o700);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "uses structural checks instead of POSIX mode changes on Windows",
+    async () => {
+      const directory = join(await root(), "private");
+      await mkdir(directory, { mode: 0o755 });
+      const before = (await stat(directory)).mode & 0o777;
+
+      await ensurePrivateDirectory(directory, { platform: "win32" });
+
+      expect((await stat(directory)).mode & 0o777).toBe(before);
+    },
+  );
 
   it("removes absent files idempotently and rethrows other errors", async () => {
     const directory = await root();

--- a/packages/kernel-node/tests/lock.test.ts
+++ b/packages/kernel-node/tests/lock.test.ts
@@ -4,12 +4,14 @@
 // four-case matrix against a real daemon /healthz responder arms at W8.
 
 import {
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
   realpathSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -143,6 +145,29 @@ afterEach(async () => {
 });
 
 describe.skipIf(!hasLoopback)("acquireWriteLock", () => {
+  it.runIf(process.platform !== "win32")(
+    "uses Windows structural checks without rewriting POSIX config mode bits",
+    async () => {
+      const athleteHome = freshDir();
+      const configDir = join(athleteHome, "config");
+      mkdirSync(configDir, { mode: 0o755 });
+      const before = statSync(configDir).mode & 0o777;
+
+      const result = trackHandle(
+        await acquireWriteLock({
+          configDir,
+          athleteHome,
+          version: "1.0.0",
+          platform: "win32",
+        }),
+      );
+
+      expect(statSync(configDir).mode & 0o777).toBe(before);
+      await result.release();
+      heldHandles.length = 0;
+    },
+  );
+
   it("(bind) port-bind singleton is authoritative", async () => {
     const configDir = freshDir();
     const result = trackHandle(

--- a/packages/kernel-node/tests/prepare-athlete-home.test.ts
+++ b/packages/kernel-node/tests/prepare-athlete-home.test.ts
@@ -33,7 +33,9 @@ describe("prepareAthleteHome", () => {
     for (const path of [home.root, home.storeDir, home.archiveDir, home.configDir]) {
       expect((await lstat(path)).isDirectory()).toBe(true);
       expect(await realpath(path)).toBe(path);
-      expect((await stat(path)).mode & 0o777).toBe(0o700);
+      if (process.platform !== "win32") {
+        expect((await stat(path)).mode & 0o777).toBe(0o700);
+      }
     }
   });
 
@@ -53,31 +55,40 @@ describe("prepareAthleteHome", () => {
     expect(homes.every((home) => home.root === homes[0]!.root)).toBe(true);
   });
 
-  it("converges a root symlink and its physical path on one athlete-home identity", async () => {
-    const alias = await freshPath();
-    const physicalRoot = join(alias, "..", "physical-athlete");
-    await mkdir(physicalRoot);
-    await symlink(physicalRoot, alias, "dir");
+  it.runIf(process.platform !== "win32")(
+    "converges a root symlink and its physical path on one athlete-home identity",
+    async () => {
+      const alias = await freshPath();
+      const physicalRoot = join(alias, "..", "physical-athlete");
+      await mkdir(physicalRoot);
+      await symlink(physicalRoot, alias, "dir");
 
-    const throughAlias = await prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: alias }));
-    const throughPhysicalPath = await prepareAthleteHome(
-      resolveAthleteHome({ ENDURAGENT_HOME: physicalRoot }),
-    );
+      const throughAlias = await prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: alias }));
+      const throughPhysicalPath = await prepareAthleteHome(
+        resolveAthleteHome({ ENDURAGENT_HOME: physicalRoot }),
+      );
 
-    expect(throughAlias).toEqual(throughPhysicalPath);
-    expect(throughAlias.root).toBe(await realpath(physicalRoot));
-  });
+      expect(throughAlias).toEqual(throughPhysicalPath);
+      expect(throughAlias.root).toBe(await realpath(physicalRoot));
+    },
+  );
 
   it("rejects a child-directory symlink instead of following it", async () => {
     const root = await freshPath();
     const outside = join(root, "..", "outside-store");
     await mkdir(root);
     await mkdir(outside);
-    await symlink(outside, join(root, "store"), "dir");
+    await symlink(outside, join(root, "store"), process.platform === "win32" ? "junction" : "dir");
 
-    await expect(prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }))).rejects.toThrow(
-      /store.*symbolic link/i,
-    );
+    const preparation = prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }));
+    if (process.platform === "win32") {
+      await expect(preparation).rejects.toMatchObject({
+        stage: "child-entry",
+        category: "link-reparse-shaped",
+      });
+    } else {
+      await expect(preparation).rejects.toThrow(/store.*symbolic link/i);
+    }
   });
 
   it.each(["root", "store"] as const)(
@@ -97,41 +108,66 @@ describe("prepareAthleteHome", () => {
     },
   );
 
-  it("rejects a root symlink to a file without changing the target mode", async () => {
-    const root = await freshPath();
-    const target = join(root, "..", "athlete-file");
-    await writeFile(target, "not-a-directory", { mode: 0o600 });
-    await symlink(target, root, "file");
+  it.runIf(process.platform !== "win32")(
+    "rejects a root symlink to a file without changing the target mode",
+    async () => {
+      const root = await freshPath();
+      const target = join(root, "..", "athlete-file");
+      await writeFile(target, "not-a-directory", { mode: 0o600 });
+      await symlink(target, root, "file");
 
-    await expect(prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }))).rejects.toThrow(
-      /root.*directory/i,
-    );
-    expect((await stat(target)).mode & 0o777).toBe(0o600);
-  });
+      const preparation = prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }));
+      await expect(preparation).rejects.toThrow(/root.*directory/i);
+      expect((await stat(target)).mode & 0o777).toBe(0o600);
+    },
+  );
 
   it("rejects an athlete-home value whose child paths do not use the fixed layout", async () => {
     const root = await freshPath();
     const home = resolveAthleteHome({ ENDURAGENT_HOME: root });
 
-    await expect(
-      prepareAthleteHome({ ...home, archiveDir: join(root, "..", "outside-archive") }),
-    ).rejects.toThrow(/fixed child layout/i);
+    const preparation = prepareAthleteHome({
+      ...home,
+      archiveDir: join(root, "..", "outside-archive"),
+    });
+    if (process.platform === "win32") {
+      await expect(preparation).rejects.toMatchObject({
+        stage: "layout",
+        category: "corruption",
+      });
+    } else {
+      await expect(preparation).rejects.toThrow(/fixed child layout/i);
+    }
   });
 
   it("rejects a relative athlete-home root before creating it", async () => {
     const relativeRoot = `relative-athlete-home-${process.pid}`;
     roots.push(resolvePath(relativeRoot));
 
-    await expect(
-      prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: relativeRoot })),
-    ).rejects.toThrow(/absolute/i);
+    const preparation = prepareAthleteHome(
+      resolveAthleteHome({ ENDURAGENT_HOME: relativeRoot }),
+    );
+    if (process.platform === "win32") {
+      await expect(preparation).rejects.toMatchObject({
+        stage: "layout",
+        category: "corruption",
+      });
+    } else {
+      await expect(preparation).rejects.toThrow(/absolute/i);
+    }
   });
 
   it("rejects the filesystem root before changing its permissions", async () => {
     const root = resolvePath("/");
 
-    await expect(prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }))).rejects.toThrow(
-      /filesystem root/i,
-    );
+    const preparation = prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }));
+    if (process.platform === "win32") {
+      await expect(preparation).rejects.toMatchObject({
+        stage: "root-bind",
+        category: "corruption",
+      });
+    } else {
+      await expect(preparation).rejects.toThrow(/filesystem root/i);
+    }
   });
 });

--- a/packages/kernel-node/tests/windows-home-policy.test.ts
+++ b/packages/kernel-node/tests/windows-home-policy.test.ts
@@ -1,0 +1,167 @@
+import { lstat, mkdir, mkdtemp, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, parse } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareAthleteHome } from "../src/home/prepare-athlete-home.js";
+import { resolveAthleteHome } from "../src/home/resolve-athlete-home.js";
+import {
+  WindowsAthleteHomePolicyError,
+  ensureWindowsPrivateDirectory,
+} from "../src/home/windows-home-policy.js";
+
+const roots: string[] = [];
+
+async function freshPath(): Promise<string> {
+  const base = await mkdtemp(join(await realpath(tmpdir()), "windows-home-policy-"));
+  roots.push(base);
+  return join(base, "athlete");
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("Windows athlete home policy", () => {
+  it("creates and binds the fixed athlete-home layout without inspecting POSIX modes", async () => {
+    const root = await freshPath();
+
+    const home = await prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }), {
+      platform: "win32",
+    });
+
+    expect(home).toEqual({
+      root: await realpath(root),
+      storeDir: join(await realpath(root), "store"),
+      archiveDir: join(await realpath(root), "archive"),
+      configDir: join(await realpath(root), "config"),
+    });
+    expect(Object.isFrozen(home)).toBe(true);
+    for (const path of [home.root, home.storeDir, home.archiveDir, home.configDir]) {
+      expect((await lstat(path)).isDirectory()).toBe(true);
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "leaves existing POSIX mode bits untouched under injected Windows semantics",
+    async () => {
+      const root = await freshPath();
+      await mkdir(root, { mode: 0o755 });
+      for (const name of ["store", "archive", "config"]) {
+        await mkdir(join(root, name), { mode: 0o755 });
+      }
+      const before = await Promise.all(
+        [root, join(root, "store"), join(root, "archive"), join(root, "config")].map(
+          async (path) => (await stat(path)).mode & 0o777,
+        ),
+      );
+
+      const home = await prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }), {
+        platform: "win32",
+      });
+
+      const after = await Promise.all(
+        [home.root, home.storeDir, home.archiveDir, home.configDir].map(
+          async (path) => (await stat(path)).mode & 0o777,
+        ),
+      );
+      expect(after).toEqual(before);
+    },
+  );
+
+  it("allows concurrent Windows first-start preparation to converge", async () => {
+    const root = await freshPath();
+    const unresolved = resolveAthleteHome({ ENDURAGENT_HOME: root });
+
+    const homes = await Promise.all(
+      Array.from({ length: 8 }, async () => prepareAthleteHome(unresolved, { platform: "win32" })),
+    );
+
+    expect(homes).toHaveLength(8);
+    expect(homes.every((home) => home.root === homes[0]!.root)).toBe(true);
+  });
+
+  it.each(["root", "store"] as const)(
+    "rejects a link or reparse-shaped %s entry",
+    async (entry) => {
+      const root = await freshPath();
+      const outside = join(root, "..", `outside-${entry}`);
+      await mkdir(outside);
+      if (entry === "root") {
+        await symlink(outside, root, process.platform === "win32" ? "junction" : "dir");
+      } else {
+        await mkdir(root);
+        await symlink(
+          outside,
+          join(root, entry),
+          process.platform === "win32" ? "junction" : "dir",
+        );
+      }
+
+      await expect(
+        prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }), {
+          platform: "win32",
+        }),
+      ).rejects.toMatchObject({ category: "link-reparse-shaped" });
+    },
+  );
+
+  it.each(["root", "store"] as const)("rejects the wrong %s entry type", async (entry) => {
+    const root = await freshPath();
+    if (entry === "root") {
+      await writeFile(root, "not-a-directory");
+    } else {
+      await mkdir(root);
+      await writeFile(join(root, entry), "not-a-directory");
+    }
+
+    await expect(
+      prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }), {
+        platform: "win32",
+      }),
+    ).rejects.toMatchObject({ category: "entry-type" });
+  });
+
+  it("rejects a filesystem root as non-ordinary", async () => {
+    await expect(
+      ensureWindowsPrivateDirectory(parse(await realpath(tmpdir())).root),
+    ).rejects.toMatchObject({ stage: "directory-bind", category: "corruption" });
+  });
+
+  it("returns path-free, cause-free diagnostics for Node failures", async () => {
+    const base = await freshPath();
+    const privateMarker = "Private Athlete";
+    const root = `${base}-${privateMarker}\0`;
+    const failure = await prepareAthleteHome(resolveAthleteHome({ ENDURAGENT_HOME: root }), {
+      platform: "win32",
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(WindowsAthleteHomePolicyError);
+    expect(failure).toMatchObject({
+      name: "WindowsAthleteHomePolicyError",
+      message: "Windows athlete home policy failed",
+      stage: "root-entry",
+      category: "io-failure",
+    });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(privateMarker);
+    expect(JSON.stringify(failure)).not.toContain(privateMarker);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a link-shaped reusable private directory without changing its target",
+    async () => {
+      const path = await freshPath();
+      const target = join(path, "..", "private-target");
+      await mkdir(target, { mode: 0o755 });
+      const before = (await stat(target)).mode & 0o777;
+      await symlink(target, path, "dir");
+
+      await expect(ensureWindowsPrivateDirectory(path)).rejects.toMatchObject({
+        stage: "directory-entry",
+        category: "link-reparse-shaped",
+      });
+      expect((await stat(target)).mode & 0o777).toBe(before);
+    },
+  );
+});

--- a/packages/kernel/src/ports/index.ts
+++ b/packages/kernel/src/ports/index.ts
@@ -4,3 +4,4 @@ export * from "./crypto.js";
 export * from "./clock.js";
 export * from "./http.js";
 export * from "./logger.js";
+export * from "./private-path-policy.js";

--- a/packages/kernel/src/ports/private-path-policy.ts
+++ b/packages/kernel/src/ports/private-path-policy.ts
@@ -1,0 +1,115 @@
+export type PrivatePathEntryType = "file" | "directory" | "other";
+
+export type PrivatePathExpectedEntryType = Exclude<PrivatePathEntryType, "other">;
+
+export type PrivatePathPolicyErrorCategory =
+  | "corruption"
+  | "sharing-violation"
+  | "entry-type"
+  | "link-reparse-shaped"
+  | "io-failure";
+
+export type PrivatePathPolicyDecision =
+  | Readonly<{ kind: "accept" }>
+  | Readonly<{ kind: "reject"; category: PrivatePathPolicyErrorCategory }>;
+
+export type PrivatePathPlatformSemantics = "windows" | "posix";
+
+export type PrivatePathDurabilityStage =
+  | "content-write"
+  | "file-flush"
+  | "rename"
+  | "directory-sync";
+
+export type PrivatePathDurabilityClassification =
+  | Readonly<{ kind: "required" }>
+  | Readonly<{ kind: "unavailable" }>;
+
+export interface PrivatePathDurabilityInput {
+  readonly platform: PrivatePathPlatformSemantics;
+  readonly stage: PrivatePathDurabilityStage;
+}
+
+export interface PrivatePathEntryDecisionInput {
+  readonly expectedType: PrivatePathExpectedEntryType;
+  readonly actualType: PrivatePathEntryType;
+  readonly linkOrReparseShaped: boolean;
+}
+
+export interface PrivatePathBindingDecisionInput {
+  readonly identityStable: boolean;
+  readonly authenticatedHomeBinding: boolean;
+}
+
+export interface PrivatePathRootDecisionInput extends PrivatePathBindingDecisionInput {
+  readonly ordinary: boolean;
+}
+
+export interface PrivatePathReadDecisionInput extends PrivatePathBindingDecisionInput {
+  readonly bounded: boolean;
+  readonly contentValid: boolean;
+}
+
+const ACCEPT = Object.freeze({ kind: "accept" } as const);
+const REQUIRED = Object.freeze({ kind: "required" } as const);
+const UNAVAILABLE = Object.freeze({ kind: "unavailable" } as const);
+const CORRUPTION = Object.freeze({ kind: "reject", category: "corruption" } as const);
+const ENTRY_TYPE = Object.freeze({ kind: "reject", category: "entry-type" } as const);
+const LINK_REPARSE_SHAPED = Object.freeze({
+  kind: "reject",
+  category: "link-reparse-shaped",
+} as const);
+
+export function classifyPrivatePathDurability({
+  platform,
+  stage,
+}: PrivatePathDurabilityInput): PrivatePathDurabilityClassification {
+  if (platform === "windows" && stage === "directory-sync") return UNAVAILABLE;
+  return REQUIRED;
+}
+
+export function classifyPrivatePathErrorCode(
+  code: unknown,
+): Extract<PrivatePathPolicyErrorCategory, "sharing-violation" | "io-failure"> {
+  if (code === "EBUSY" || code === "EPERM" || code === "EACCES") {
+    return "sharing-violation";
+  }
+  return "io-failure";
+}
+
+export function decidePrivatePathEntry({
+  expectedType,
+  actualType,
+  linkOrReparseShaped,
+}: PrivatePathEntryDecisionInput): PrivatePathPolicyDecision {
+  if (linkOrReparseShaped) return LINK_REPARSE_SHAPED;
+  if (actualType !== expectedType) return ENTRY_TYPE;
+  return ACCEPT;
+}
+
+export function decidePrivatePathBinding({
+  identityStable,
+  authenticatedHomeBinding,
+}: PrivatePathBindingDecisionInput): PrivatePathPolicyDecision {
+  if (!identityStable || !authenticatedHomeBinding) return CORRUPTION;
+  return ACCEPT;
+}
+
+export function decidePrivatePathRoot({
+  ordinary,
+  identityStable,
+  authenticatedHomeBinding,
+}: PrivatePathRootDecisionInput): PrivatePathPolicyDecision {
+  if (!ordinary) return CORRUPTION;
+  return decidePrivatePathBinding({ identityStable, authenticatedHomeBinding });
+}
+
+export function decidePrivatePathRead({
+  bounded,
+  identityStable,
+  contentValid,
+  authenticatedHomeBinding,
+}: PrivatePathReadDecisionInput): PrivatePathPolicyDecision {
+  if (!bounded || !contentValid) return CORRUPTION;
+  return decidePrivatePathBinding({ identityStable, authenticatedHomeBinding });
+}

--- a/packages/kernel/tests/private-path-policy.test.ts
+++ b/packages/kernel/tests/private-path-policy.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyPrivatePathDurability,
+  classifyPrivatePathErrorCode,
+  decidePrivatePathBinding,
+  decidePrivatePathEntry,
+  decidePrivatePathRead,
+  decidePrivatePathRoot,
+} from "../src/ports/private-path-policy.js";
+import type { PrivatePathPolicyErrorCategory } from "../src/ports/private-path-policy.js";
+
+describe("private path policy", () => {
+  it.each([
+    ["posix", "content-write", "required"],
+    ["posix", "file-flush", "required"],
+    ["posix", "rename", "required"],
+    ["posix", "directory-sync", "required"],
+    ["windows", "content-write", "required"],
+    ["windows", "file-flush", "required"],
+    ["windows", "rename", "required"],
+    ["windows", "directory-sync", "unavailable"],
+  ] as const)("classifies %s %s durability as %s", (platform, stage, kind) => {
+    expect(classifyPrivatePathDurability({ platform, stage })).toEqual({ kind });
+  });
+
+  it.each(["EBUSY", "EPERM", "EACCES"])("classifies %s as a sharing violation", (code) => {
+    expect(classifyPrivatePathErrorCode(code)).toBe("sharing-violation");
+  });
+
+  it.each(["ENOENT", "EIO", "ebusy", "", undefined, null, 0])(
+    "classifies every other error code as an I/O failure",
+    (code) => {
+      expect(classifyPrivatePathErrorCode(code)).toBe("io-failure");
+    },
+  );
+
+  it.each([
+    ["file", "file"],
+    ["directory", "directory"],
+  ] as const)("accepts an ordinary %s entry when %s is expected", (actualType, expectedType) => {
+    expect(
+      decidePrivatePathEntry({ actualType, expectedType, linkOrReparseShaped: false }),
+    ).toEqual({ kind: "accept" });
+  });
+
+  it.each([
+    ["file", "directory"],
+    ["directory", "file"],
+    ["other", "file"],
+  ] as const)("rejects an ordinary %s entry when %s is expected", (actualType, expectedType) => {
+    expect(
+      decidePrivatePathEntry({ actualType, expectedType, linkOrReparseShaped: false }),
+    ).toEqual({ kind: "reject", category: "entry-type" });
+  });
+
+  it("gives a link or reparse-shaped entry precedence over an entry-type mismatch", () => {
+    expect(
+      decidePrivatePathEntry({
+        actualType: "other",
+        expectedType: "directory",
+        linkOrReparseShaped: true,
+      }),
+    ).toEqual({ kind: "reject", category: "link-reparse-shaped" });
+  });
+
+  it.each([
+    [true, true, "accept", undefined],
+    [false, true, "reject", "corruption"],
+    [true, false, "reject", "corruption"],
+    [false, false, "reject", "corruption"],
+  ] as const)(
+    "decides stable=%s authenticated=%s bindings",
+    (identityStable, authenticatedHomeBinding, kind, category) => {
+      expect(decidePrivatePathBinding({ identityStable, authenticatedHomeBinding })).toEqual(
+        category === undefined ? { kind } : { kind, category },
+      );
+    },
+  );
+
+  it("accepts only an ordinary, stable, authenticated root", () => {
+    expect(
+      decidePrivatePathRoot({
+        ordinary: true,
+        identityStable: true,
+        authenticatedHomeBinding: true,
+      }),
+    ).toEqual({ kind: "accept" });
+
+    for (const input of [
+      { ordinary: false, identityStable: true, authenticatedHomeBinding: true },
+      { ordinary: true, identityStable: false, authenticatedHomeBinding: true },
+      { ordinary: true, identityStable: true, authenticatedHomeBinding: false },
+      { ordinary: false, identityStable: false, authenticatedHomeBinding: false },
+    ]) {
+      expect(decidePrivatePathRoot(input)).toEqual({ kind: "reject", category: "corruption" });
+    }
+  });
+
+  it("accepts only a bounded, stable, valid, authenticated read", () => {
+    expect(
+      decidePrivatePathRead({
+        bounded: true,
+        identityStable: true,
+        contentValid: true,
+        authenticatedHomeBinding: true,
+      }),
+    ).toEqual({ kind: "accept" });
+
+    for (const input of [
+      {
+        bounded: false,
+        identityStable: true,
+        contentValid: true,
+        authenticatedHomeBinding: true,
+      },
+      {
+        bounded: true,
+        identityStable: false,
+        contentValid: true,
+        authenticatedHomeBinding: true,
+      },
+      {
+        bounded: true,
+        identityStable: true,
+        contentValid: false,
+        authenticatedHomeBinding: true,
+      },
+      {
+        bounded: true,
+        identityStable: true,
+        contentValid: true,
+        authenticatedHomeBinding: false,
+      },
+    ]) {
+      expect(decidePrivatePathRead(input)).toEqual({ kind: "reject", category: "corruption" });
+    }
+  });
+
+  it("exposes the complete error-category taxonomy", () => {
+    const categories = [
+      "corruption",
+      "sharing-violation",
+      "entry-type",
+      "link-reparse-shaped",
+      "io-failure",
+    ] satisfies readonly PrivatePathPolicyErrorCategory[];
+
+    expect(categories).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## What

Freezes a pure private-path policy contract so the packaged Windows app can pass startup-reached athlete-home and durability assertions without POSIX mode/UID semantics. Three new modules: a pure Kernel policy (types, decisions, durability/corruption/sharing error taxonomy — no Node imports), a kernel-node Windows athlete-home policy (lstat/realpath identity, ordinary-root and link/junction rejection, entry-type validation, authenticated parent binding), and a Core-owned Windows store-check policy for the atomic writers. Startup-reached call sites (prepareAthleteHome, ensurePrivateDirectory, write-lock config-directory preparation, atomic writers) dispatch by an injected platform parameter defaulting to process.platform; win32 routes through the new policy, every other platform keeps the pre-change code path byte-identical. Athlete home stays join(homedir(), ".enduragent") — natively %USERPROFILE%\.enduragent on Windows. Windows directory sync is classified explicitly unavailable; content-write, flush, rename, sharing, and corruption failures are never swallowed. kernel-node does not depend on core.

## Non-goals (deliberate)

- Chat/transcript, auth/profile, memory, usage, credential-vault, first-run config, Telegram, RPC-server, composition, desktop, and renderer stores are untouched (later packages own them).
- interprocess-file-lock-sync.ts investigated and left unchanged: its reached win32 branches already avoid POSIX mode comparisons and preserve write/fsync/rename/sharing failures.
- No changeset: no user-visible behavior change on any currently shipped platform.

## Verification

- kernel + kernel-node suites: 950 passed / 0 failed / 1 skipped
- core suite: 2598 passed / 0 failed / 5 skipped
- coach suite (repo-root cwd): 726 passed / 0 failed
- apps/desktop suite: 1205 passed / 0 failed
- Root pnpm check: pass (oxlint 0 errors)
