### PR TITLE
feat(core): make conversation storage survive packaged windows restart

### DIFF
--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -167,6 +167,7 @@ export interface LocalCoachCompositionDependencies {
   readonly createRepository?: (store: CoachStoreWriterContext["store"]) => AnchorRepository;
   readonly createResolver?: (repository: AnchorRepository) => CyclingFtpAnchorResolver;
   readonly now?: () => number;
+  readonly platform?: NodeJS.Platform;
   readonly randomId?: () => string;
   readonly modelTransportDecorator?: ModelTransportDecorator;
   readonly onToolsAssembled?: (names: readonly string[]) => void;
@@ -835,6 +836,7 @@ export async function createLocalCoachComposition(
       const conversationStore = createConversationStore(
         input.home.root,
         config.session.resetArchiveRetentionDays,
+        { platform: dependencies.platform },
       );
       const projectedConfig = engineConfigFromConfig(effectiveConfig);
       const legacyClient =

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -1,7 +1,19 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { constants } from "node:fs";
 import { lstat, open } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import {
+  WindowsPrivatePathPolicyError,
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivateFileBinding,
+  assertWindowsPrivateFileMetadata,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathFailure,
+  sameWindowsPrivatePathIdentity,
+  windowsPrivatePathIdentity,
+  type WindowsPrivateDirectoryBinding,
+} from "@enduragent/core";
 import {
   ClientHandshakeFrameSchema,
   COACH_RPC_METHOD_REGISTRY,
@@ -45,6 +57,7 @@ import { serializeBoundaryError } from "./error-boundary.js";
 import type { DesktopTelegramController } from "../desktop-telegram-controller.js";
 
 const AUTH_TIMEOUT_MS = 1_000;
+const MAX_DAEMON_TOKEN_FILE_BYTES = 44;
 const MAX_PAYLOAD_BYTES = 1_048_576;
 const MAX_FRAGMENTS_PER_MESSAGE = 64;
 const MAX_BUFFERED_CHUNKS_PER_MESSAGE = 256;
@@ -85,11 +98,94 @@ export interface DaemonToken {
 }
 
 export interface DaemonTokenDependencies {
+  readonly openFile?: typeof open;
   readonly randomBytes?: typeof randomBytes;
+  readonly platform?: NodeJS.Platform;
 }
 
 function validToken(value: string): boolean {
   return /^[A-Za-z0-9_-]{43}$/.test(value);
+}
+
+async function readExistingWindowsToken(
+  path: string,
+  directory: WindowsPrivateDirectoryBinding,
+  openFile: typeof open,
+): Promise<DaemonToken> {
+  let metadata: Awaited<ReturnType<typeof lstat>>;
+  try {
+    metadata = await lstat(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") throw error;
+    throw classifyWindowsPrivatePathFailure("entry-check", error);
+  }
+  assertWindowsPrivateFileMetadata(metadata);
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let result: DaemonToken | undefined;
+  let failure: WindowsPrivatePathPolicyError | undefined;
+  try {
+    handle = await openFile(path, constants.O_RDONLY);
+    const openedMetadata = await handle.stat();
+    assertWindowsPrivateFileMetadata(openedMetadata);
+    if (
+      !sameWindowsPrivatePathIdentity(
+        windowsPrivatePathIdentity(metadata),
+        windowsPrivatePathIdentity(openedMetadata),
+      )
+    ) {
+      throw new WindowsPrivatePathPolicyError("binding-check", "corruption");
+    }
+    assertWindowsPrivateFileBinding(directory, path, windowsPrivatePathIdentity(openedMetadata));
+    const bytes = Buffer.allocUnsafe(MAX_DAEMON_TOKEN_FILE_BYTES + 1);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const read = await handle.read(bytes, offset, bytes.length - offset, offset);
+      if (read.bytesRead === 0) break;
+      offset += read.bytesRead;
+    }
+    const afterRead = await handle.stat();
+    assertWindowsPrivateFileMetadata(afterRead);
+    const current = assertWindowsPrivateFileBinding(
+      directory,
+      path,
+      windowsPrivatePathIdentity(afterRead),
+    );
+    const raw = bytes.subarray(0, offset).toString("utf8");
+    const value = raw.endsWith("\n") ? raw.slice(0, -1) : "";
+    const contentValid =
+      offset === MAX_DAEMON_TOKEN_FILE_BYTES && validToken(value) && raw === `${value}\n`;
+    assertWindowsPrivatePathRead({
+      bounded: offset <= MAX_DAEMON_TOKEN_FILE_BYTES,
+      identityStable:
+        sameWindowsPrivatePathIdentity(
+          windowsPrivatePathIdentity(openedMetadata),
+          windowsPrivatePathIdentity(afterRead),
+        ) &&
+        openedMetadata.size === afterRead.size &&
+        openedMetadata.size === current.size &&
+        openedMetadata.mtimeMs === afterRead.mtimeMs &&
+        openedMetadata.mtimeMs === current.mtimeMs &&
+        openedMetadata.ctimeMs === afterRead.ctimeMs &&
+        openedMetadata.ctimeMs === current.ctimeMs,
+      contentValid,
+      authenticatedHomeBinding: true,
+    });
+    result = { path, value };
+  } catch (error) {
+    failure = classifyWindowsPrivatePathFailure("read-check", error);
+  }
+  if (handle !== undefined) {
+    try {
+      await handle.close();
+    } catch (error) {
+      failure ??= classifyWindowsPrivatePathFailure("read-check", error);
+    }
+  }
+  if (failure !== undefined) throw failure;
+  if (result === undefined) {
+    throw new WindowsPrivatePathPolicyError("read-check", "io-failure");
+  }
+  return result;
 }
 
 async function readExistingToken(path: string): Promise<DaemonToken> {
@@ -120,10 +216,65 @@ async function readExistingToken(path: string): Promise<DaemonToken> {
   return { path, value };
 }
 
+async function ensureWindowsDaemonToken(
+  configDir: string,
+  dependencies: DaemonTokenDependencies,
+): Promise<DaemonToken> {
+  const path = join(configDir, "daemon.token");
+  const openFile = dependencies.openFile ?? open;
+  const directory = bindWindowsPrivateDirectory(dirname(configDir), configDir);
+  try {
+    return await readExistingWindowsToken(path, directory, openFile);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  const value = (dependencies.randomBytes ?? randomBytes)(32).toString("base64url");
+  if (!validToken(value)) throw new Error("daemon token generation failed");
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let stage: "content-write" | "file-flush" = "content-write";
+  let failure: WindowsPrivatePathPolicyError | undefined;
+  try {
+    assertWindowsPrivateDirectoryStable(directory);
+    handle = await openFile(path, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+    const created = await handle.stat();
+    assertWindowsPrivateFileMetadata(created);
+    assertWindowsPrivateFileBinding(directory, path, windowsPrivatePathIdentity(created));
+    await handle.writeFile(`${value}\n`, "utf8");
+    stage = "file-flush";
+    await handle.sync();
+    const synced = await handle.stat();
+    assertWindowsPrivateFileMetadata(synced);
+    assertWindowsPrivateFileBinding(directory, path, windowsPrivatePathIdentity(synced));
+    await handle.close();
+    handle = undefined;
+  } catch (error) {
+    if (handle === undefined && (error as NodeJS.ErrnoException).code === "EEXIST") {
+      return readExistingWindowsToken(path, directory, openFile);
+    }
+    failure = classifyWindowsPrivatePathFailure(stage, error);
+  }
+  if (handle !== undefined) {
+    try {
+      await handle.close();
+    } catch (error) {
+      failure ??= classifyWindowsPrivatePathFailure(stage, error);
+    }
+  }
+  if (failure !== undefined) throw failure;
+  const persisted = await readExistingWindowsToken(path, directory, openFile);
+  if (persisted.value !== value) {
+    throw new WindowsPrivatePathPolicyError("read-check", "corruption");
+  }
+  return persisted;
+}
+
 export async function ensureDaemonToken(
   configDir: string,
   dependencies: DaemonTokenDependencies = {},
 ): Promise<DaemonToken> {
+  if ((dependencies.platform ?? process.platform) === "win32") {
+    return ensureWindowsDaemonToken(configDir, dependencies);
+  }
   const path = join(configDir, "daemon.token");
   try {
     return await readExistingToken(path);

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -17,7 +17,11 @@ import { join } from "node:path";
 import { Duplex } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
-import type { CreateTelegramChannelInput, TelegramChannelRuntime } from "@enduragent/core";
+import {
+  WindowsPrivatePathPolicyError,
+  type CreateTelegramChannelInput,
+  type TelegramChannelRuntime,
+} from "@enduragent/core";
 import {
   COACH_RPC_METHOD_REGISTRY,
   PROTOCOL_VERSION,
@@ -371,6 +375,117 @@ describe("daemon token", () => {
       await expect(ensureDaemonToken(root)).rejects.toThrow("daemon token file is invalid");
       if (fixture === "mode") expect((await lstat(path)).mode & 0o777).toBe(0o644);
     }
+  });
+
+  it("creates and reuses a token through injected Windows semantics", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "daemon-token-windows-"));
+    roots.push(root);
+    const bytes = Buffer.alloc(32, 9);
+
+    const created = await ensureDaemonToken(root, {
+      platform: "win32",
+      randomBytes: () => bytes,
+    });
+
+    await expect(ensureDaemonToken(root, { platform: "win32" })).resolves.toEqual(created);
+    expect(await readFile(created.path, "utf8")).toBe(`${created.value}\n`);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "does not inspect or repair POSIX token modes under injected Windows semantics",
+    async () => {
+      const root = await mkdtemp(join(await realpath(tmpdir()), "daemon-token-windows-mode-"));
+      roots.push(root);
+      const path = join(root, "daemon.token");
+      await writeFile(path, `${"x".repeat(43)}\n`, { mode: 0o644 });
+      await chmod(path, 0o644);
+
+      await expect(ensureDaemonToken(root, { platform: "win32" })).resolves.toEqual({
+        path,
+        value: "x".repeat(43),
+      });
+      expect((await lstat(path)).mode & 0o777).toBe(0o644);
+    },
+  );
+
+  it("rejects oversized Windows token state as path-free corruption", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "daemon-token-windows-corrupt-"));
+    roots.push(root);
+    const path = join(root, "daemon.token");
+    const corrupt = `${"x".repeat(44)}\n`;
+    await writeFile(path, corrupt, { mode: 0o600 });
+
+    const failure = await ensureDaemonToken(root, { platform: "win32" }).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(path);
+    expect(JSON.stringify(failure)).not.toContain(path);
+    expect(await readFile(path, "utf8")).toBe(corrupt);
+  });
+
+  it("does not swallow a Windows sharing violation during token creation", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "daemon-token-windows-locked-"));
+    roots.push(root);
+    const path = join(root, "daemon.token");
+
+    const failure = await ensureDaemonToken(root, {
+      platform: "win32",
+      openFile: async () => {
+        throw Object.assign(new Error(`locked ${path}`), { code: "EACCES", path });
+      },
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "content-write", category: "sharing-violation" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(path);
+    expect(JSON.stringify(failure)).not.toContain(path);
+  });
+
+  it("rejects a sharing-locked Windows token on restart", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "daemon-token-windows-read-lock-"));
+    roots.push(root);
+    const path = join(root, "daemon.token");
+    const persisted = `${"x".repeat(43)}\n`;
+    await writeFile(path, persisted, { mode: 0o600 });
+
+    const failure = await ensureDaemonToken(root, {
+      platform: "win32",
+      openFile: async () => {
+        throw Object.assign(new Error(`locked ${path}`), { code: "EACCES", path });
+      },
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "sharing-violation" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(path);
+    expect(JSON.stringify(failure)).not.toContain(path);
+    expect(await readFile(path, "utf8")).toBe(persisted);
+  });
+
+  it("keeps a missing Windows config binding path-free and stage-coded", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "daemon-token-windows-missing-"));
+    roots.push(root);
+    const configDir = join(root, "missing-config");
+
+    const failure = await ensureDaemonToken(configDir, { platform: "win32" }).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "binding-check", category: "io-failure" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(configDir);
+    expect(JSON.stringify(failure)).not.toContain(configDir);
   });
 });
 

--- a/packages/core/src/agent/chat-store.ts
+++ b/packages/core/src/agent/chat-store.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   readFileSync,
   writeFileSync,
@@ -15,9 +16,11 @@ import {
   mkdirSync,
   openSync,
   readdirSync,
+  readSync,
   unlinkSync,
 } from "node:fs";
 import { join } from "node:path";
+import { TextDecoder } from "node:util";
 import type { ModelMessage } from "ai";
 import type { ChatLineage } from "@enduragent/engine";
 import { messageText } from "@enduragent/engine/sport";
@@ -28,8 +31,24 @@ import {
   setMessageProvenance,
   type SourceProvenance,
 } from "../provenance.js";
+import {
+  WindowsPrivatePathPolicyError,
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivateFileBinding,
+  assertWindowsPrivateFileMetadata,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  classifyWindowsPrivatePathFailure,
+  sameWindowsPrivatePathIdentity,
+  windowsPrivatePathIdentity,
+  type WindowsPrivateDirectoryBinding,
+  type WindowsPrivatePathPolicyStage,
+} from "../io/windows-private-path-policy.js";
 
 const MS_PER_DAY = 86_400_000;
+export const MAX_CHAT_SESSION_BYTES = 67_108_864;
+const STRICT_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 // Recorded in history when a turn fails before producing a reply, so the
 // athlete's (durably persisted) message is visibly unanswered rather than
@@ -43,9 +62,16 @@ interface FileIdentity {
 }
 
 interface ChatStoreHooks {
+  readonly rename?: typeof renameSync;
   readonly syncFile?: (descriptor: number) => void;
   readonly syncDirectory?: (descriptor: number) => void;
 }
+
+interface ChatStoreOptions {
+  readonly platform?: NodeJS.Platform;
+}
+
+type DirectoryDescriptor = number | null;
 
 interface DurableChatReset {
   readonly resetId: string;
@@ -149,54 +175,68 @@ export class ChatStore {
   private readonly sessionsDir: string;
   private readonly resetArchiveRetentionDays: number;
   private readonly sessionsDirectoryIdentity: FileIdentity;
+  private readonly platform: NodeJS.Platform;
+  private readonly windowsDirectoryBinding: WindowsPrivateDirectoryBinding | undefined;
 
-  constructor(dataDir: string, resetArchiveRetentionDays = 0) {
+  constructor(dataDir: string, resetArchiveRetentionDays = 0, options: ChatStoreOptions = {}) {
     this.sessionsDir = join(dataDir, "sessions");
     this.resetArchiveRetentionDays = resetArchiveRetentionDays;
+    this.platform = options.platform ?? process.platform;
     let created = false;
     try {
       mkdirSync(this.sessionsDir, { mode: 0o700 });
       created = true;
     } catch (error) {
-      if (!isExists(error)) throw error;
+      if (!isExists(error)) {
+        throw this.platform === "win32"
+          ? classifyWindowsPrivatePathFailure("entry-check", error)
+          : error;
+      }
     }
 
-    const beforeOpen = lstatSync(this.sessionsDir);
-    if (beforeOpen.isSymbolicLink() || !beforeOpen.isDirectory()) {
-      throw new Error("Sessions directory is unsafe.");
-    }
-    let descriptor: number;
-    try {
-      descriptor = openSync(
-        this.sessionsDir,
-        constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
-      );
-    } catch {
-      throw new Error("Sessions directory is unsafe.");
-    }
-    try {
-      let hardened = true;
-      if (created || !isStrictPrivateDirectory(fstatSync(descriptor))) {
-        try {
-          fchmodSync(descriptor, 0o700);
-        } catch {
-          hardened = false;
-        }
-      }
-      const opened = fstatSync(descriptor);
-      const afterOpen = lstatSync(this.sessionsDir);
-      if (
-        !hardened ||
-        !isStrictPrivateDirectory(opened) ||
-        !isStrictPrivateDirectory(afterOpen) ||
-        !sameIdentity(identity(beforeOpen), identity(opened)) ||
-        !sameIdentity(identity(opened), identity(afterOpen))
-      ) {
+    if (this.platform === "win32") {
+      const binding = bindWindowsPrivateDirectory(dataDir, this.sessionsDir);
+      this.windowsDirectoryBinding = binding;
+      this.sessionsDirectoryIdentity = binding.identity;
+    } else {
+      this.windowsDirectoryBinding = undefined;
+      const beforeOpen = lstatSync(this.sessionsDir);
+      if (beforeOpen.isSymbolicLink() || !beforeOpen.isDirectory()) {
         throw new Error("Sessions directory is unsafe.");
       }
-      this.sessionsDirectoryIdentity = identity(opened);
-    } finally {
-      closeSync(descriptor);
+      let descriptor: number;
+      try {
+        descriptor = openSync(
+          this.sessionsDir,
+          constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+        );
+      } catch {
+        throw new Error("Sessions directory is unsafe.");
+      }
+      try {
+        let hardened = true;
+        if (created || !isStrictPrivateDirectory(fstatSync(descriptor))) {
+          try {
+            fchmodSync(descriptor, 0o700);
+          } catch {
+            hardened = false;
+          }
+        }
+        const opened = fstatSync(descriptor);
+        const afterOpen = lstatSync(this.sessionsDir);
+        if (
+          !hardened ||
+          !isStrictPrivateDirectory(opened) ||
+          !isStrictPrivateDirectory(afterOpen) ||
+          !sameIdentity(identity(beforeOpen), identity(opened)) ||
+          !sameIdentity(identity(opened), identity(afterOpen))
+        ) {
+          throw new Error("Sessions directory is unsafe.");
+        }
+        this.sessionsDirectoryIdentity = identity(opened);
+      } finally {
+        closeSync(descriptor);
+      }
     }
 
     DURABLE_RESET_OPERATIONS.set(this, (chatId, reset) => {
@@ -209,20 +249,472 @@ export class ChatStore {
   }
 
   private filePath(chatId: string): string {
-    return join(this.sessionsDir, `${chatId}.jsonl`);
+    const fileName = this.platform === "win32" ? this.chatDigest(chatId) : chatId;
+    return join(this.sessionsDir, `${fileName}.jsonl`);
+  }
+
+  private chatDigest(chatId: string): string {
+    return createHash("sha256").update(chatId, "utf8").digest("hex");
+  }
+
+  private sessionExists(path: string): boolean {
+    if (this.platform !== "win32") return existsSync(path);
+    return this.withSessionsDirectory((directoryDescriptor) => {
+      let metadata: import("node:fs").Stats;
+      try {
+        metadata = lstatSync(path);
+      } catch (error) {
+        if (isMissing(error)) {
+          this.assertSessionsDirectoryStable(directoryDescriptor);
+          return false;
+        }
+        throw error;
+      }
+      assertWindowsPrivateFileMetadata(metadata);
+      assertWindowsPrivateFileBinding(
+        this.windowsDirectoryBinding!,
+        path,
+        windowsPrivatePathIdentity(metadata),
+      );
+      return true;
+    });
+  }
+
+  private openWindowsSessionFile(
+    directoryDescriptor: DirectoryDescriptor,
+    path: string,
+    flags: number,
+    allowedLinks: 1 | 2 = 1,
+  ): number {
+    const beforeOpen = lstatSync(path);
+    assertWindowsPrivateFileMetadata(beforeOpen, allowedLinks);
+    this.assertSessionsDirectoryStable(directoryDescriptor);
+    const descriptor = openSync(path, flags);
+    try {
+      const opened = fstatSync(descriptor);
+      assertWindowsPrivateFileMetadata(opened, allowedLinks);
+      if (
+        !sameWindowsPrivatePathIdentity(
+          windowsPrivatePathIdentity(beforeOpen),
+          windowsPrivatePathIdentity(opened),
+        )
+      ) {
+        throw new WindowsPrivatePathPolicyError("binding-check", "corruption");
+      }
+      assertWindowsPrivateFileBinding(
+        this.windowsDirectoryBinding!,
+        path,
+        windowsPrivatePathIdentity(opened),
+        allowedLinks,
+      );
+      return descriptor;
+    } catch (error) {
+      closeSync(descriptor);
+      throw error;
+    }
+  }
+
+  private readSessionText(path: string, allowedLinks: 1 | 2 = 1): string {
+    if (this.platform !== "win32") return readFileSync(path, "utf-8");
+    return this.withSessionsDirectory((directoryDescriptor) => {
+      const descriptor = this.openWindowsSessionFile(
+        directoryDescriptor,
+        path,
+        constants.O_RDONLY,
+        allowedLinks,
+      );
+      try {
+        return this.readWindowsSessionDescriptor(
+          directoryDescriptor,
+          descriptor,
+          path,
+          allowedLinks,
+        );
+      } finally {
+        closeSync(descriptor);
+      }
+    });
+  }
+
+  private readWindowsSessionDescriptor(
+    directoryDescriptor: DirectoryDescriptor,
+    descriptor: number,
+    path: string,
+    allowedLinks: 1 | 2 = 1,
+  ): string {
+    const beforeRead = fstatSync(descriptor);
+    const bounded =
+      Number.isSafeInteger(beforeRead.size) &&
+      beforeRead.size >= 0 &&
+      beforeRead.size <= MAX_CHAT_SESSION_BYTES;
+    if (!bounded) {
+      assertWindowsPrivatePathRead({
+        bounded: false,
+        identityStable: true,
+        contentValid: true,
+        authenticatedHomeBinding: true,
+      });
+    }
+    const contents = Buffer.allocUnsafe(beforeRead.size);
+    let offset = 0;
+    while (offset < contents.length) {
+      const bytesRead = readSync(descriptor, contents, offset, contents.length - offset, offset);
+      if (bytesRead <= 0) {
+        assertWindowsPrivatePathRead({
+          bounded: true,
+          identityStable: true,
+          contentValid: false,
+          authenticatedHomeBinding: true,
+        });
+      }
+      offset += bytesRead;
+    }
+    const afterRead = fstatSync(descriptor);
+    assertWindowsPrivateFileMetadata(afterRead, allowedLinks);
+    const current = assertWindowsPrivateFileBinding(
+      this.windowsDirectoryBinding!,
+      path,
+      windowsPrivatePathIdentity(afterRead),
+      allowedLinks,
+    );
+    let decoded = "";
+    let contentValid = true;
+    try {
+      decoded = STRICT_UTF8_DECODER.decode(contents);
+    } catch {
+      contentValid = false;
+    }
+    assertWindowsPrivatePathRead({
+      bounded: true,
+      identityStable:
+        sameWindowsPrivatePathIdentity(
+          windowsPrivatePathIdentity(beforeRead),
+          windowsPrivatePathIdentity(afterRead),
+        ) &&
+        beforeRead.size === afterRead.size &&
+        beforeRead.size === current.size &&
+        beforeRead.mtimeMs === afterRead.mtimeMs &&
+        beforeRead.mtimeMs === current.mtimeMs &&
+        beforeRead.ctimeMs === afterRead.ctimeMs &&
+        beforeRead.ctimeMs === current.ctimeMs,
+      contentValid,
+      authenticatedHomeBinding: true,
+    });
+    this.assertSessionsDirectoryStable(directoryDescriptor);
+    return decoded;
+  }
+
+  private assertWindowsSessionContent(contents: string): void {
+    assertWindowsPrivatePathRead({
+      bounded: Buffer.byteLength(contents, "utf8") <= MAX_CHAT_SESSION_BYTES,
+      identityStable: true,
+      contentValid:
+        (contents.length === 0 || contents.endsWith("\n")) &&
+        contents.split("\n").every((line) => line.trim() === "" || parseSessionLine(line) !== null),
+      authenticatedHomeBinding: true,
+    });
+  }
+
+  private assertWindowsSessionSize(size: number): void {
+    assertWindowsPrivatePathRead({
+      bounded: Number.isSafeInteger(size) && size >= 0 && size <= MAX_CHAT_SESSION_BYTES,
+      identityStable: true,
+      contentValid: true,
+      authenticatedHomeBinding: true,
+    });
+  }
+
+  private isPrivateFile(stats: import("node:fs").Stats, links: 1 | 2): boolean {
+    if (this.platform === "win32") {
+      assertWindowsPrivateFileMetadata(stats, links);
+      return true;
+    }
+    return isStrictPrivateFile(stats, links);
+  }
+
+  private unsafeTarget(message: string): Error {
+    return this.platform === "win32"
+      ? new WindowsPrivatePathPolicyError("binding-check", "corruption")
+      : new Error(message);
+  }
+
+  private createWindowsSessionFile(
+    directoryDescriptor: DirectoryDescriptor,
+    path: string,
+    extraFlags = 0,
+  ): number {
+    this.assertSessionsDirectoryStable(directoryDescriptor);
+    const descriptor = openSync(
+      path,
+      constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | extraFlags,
+      0o600,
+    );
+    try {
+      const opened = fstatSync(descriptor);
+      assertWindowsPrivateFileMetadata(opened);
+      assertWindowsPrivateFileBinding(
+        this.windowsDirectoryBinding!,
+        path,
+        windowsPrivatePathIdentity(opened),
+      );
+      return descriptor;
+    } catch (error) {
+      closeSync(descriptor);
+      throw error;
+    }
+  }
+
+  private appendSessionContent(path: string, content: string): void {
+    if (this.platform !== "win32") {
+      appendFileSync(path, content, { encoding: "utf-8", mode: 0o600 });
+      return;
+    }
+    this.withSessionsDirectory((directoryDescriptor) => {
+      let descriptor: number;
+      let created = false;
+      try {
+        descriptor = this.openWindowsSessionFile(
+          directoryDescriptor,
+          path,
+          constants.O_RDWR | constants.O_APPEND,
+        );
+      } catch (error) {
+        if (!isMissing(error)) throw error;
+        try {
+          descriptor = this.createWindowsSessionFile(directoryDescriptor, path, constants.O_APPEND);
+          created = true;
+        } catch (createError) {
+          if (!isExists(createError)) throw createError;
+          descriptor = this.openWindowsSessionFile(
+            directoryDescriptor,
+            path,
+            constants.O_RDWR | constants.O_APPEND,
+          );
+        }
+      }
+      try {
+        this.assertWindowsSessionContent(
+          this.readWindowsSessionDescriptor(directoryDescriptor, descriptor, path),
+        );
+        const beforeWrite = fstatSync(descriptor);
+        const contentBytes = Buffer.byteLength(content, "utf8");
+        this.assertWindowsSessionSize(beforeWrite.size);
+        this.assertWindowsSessionSize(beforeWrite.size + contentBytes);
+        writeFileSync(descriptor, content, "utf8");
+        this.syncFile(descriptor);
+        const written = fstatSync(descriptor);
+        assertWindowsPrivateFileMetadata(written);
+        if (written.size !== beforeWrite.size + contentBytes) {
+          throw new WindowsPrivatePathPolicyError("content-write", "corruption");
+        }
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          path,
+          windowsPrivatePathIdentity(written),
+        );
+        if (created) this.syncDirectory(directoryDescriptor);
+      } finally {
+        closeSync(descriptor);
+      }
+    }, "content-write");
+  }
+
+  private replaceSessionContent(path: string, content: string): void {
+    if (this.platform !== "win32") {
+      const tmpPath = `${path}.tmp`;
+      writeFileSync(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
+      renameSync(tmpPath, path);
+      return;
+    }
+    const tmpPath = `${path}.tmp`;
+    this.withSessionsDirectory((directoryDescriptor) => {
+      const contentBytes = Buffer.byteLength(content, "utf8");
+      this.assertWindowsSessionSize(contentBytes);
+      let descriptor: number;
+      try {
+        descriptor = this.createWindowsSessionFile(directoryDescriptor, tmpPath);
+      } catch (error) {
+        if (isExists(error)) throw this.unsafeTarget("Session replacement target is unsafe.");
+        throw error;
+      }
+      try {
+        writeFileSync(descriptor, content, "utf8");
+        this.syncFile(descriptor);
+        const written = fstatSync(descriptor);
+        assertWindowsPrivateFileMetadata(written);
+        if (written.size !== contentBytes) {
+          throw new WindowsPrivatePathPolicyError("content-write", "corruption");
+        }
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          tmpPath,
+          windowsPrivatePathIdentity(written),
+        );
+        if (this.sessionExists(path)) this.assertSessionsDirectoryStable(directoryDescriptor);
+        try {
+          (CHAT_STORE_HOOKS.get(this)?.rename ?? renameSync)(tmpPath, path);
+        } catch (error) {
+          throw classifyWindowsPrivatePathFailure("rename", error);
+        }
+        const replaced = lstatSync(path);
+        assertWindowsPrivateFileMetadata(replaced);
+        if (
+          !sameWindowsPrivatePathIdentity(
+            windowsPrivatePathIdentity(written),
+            windowsPrivatePathIdentity(replaced),
+          )
+        ) {
+          throw new WindowsPrivatePathPolicyError("binding-check", "corruption");
+        }
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          path,
+          windowsPrivatePathIdentity(replaced),
+        );
+        this.syncDirectory(directoryDescriptor);
+      } finally {
+        closeSync(descriptor);
+      }
+    }, "content-write");
+  }
+
+  private renameSessionPath(source: string, target: string): void {
+    if (this.platform !== "win32") {
+      renameSync(source, target);
+      return;
+    }
+    this.withSessionsDirectory((directoryDescriptor) => {
+      const descriptor = this.openWindowsSessionFile(
+        directoryDescriptor,
+        source,
+        constants.O_RDONLY,
+      );
+      try {
+        this.assertWindowsSessionContent(
+          this.readWindowsSessionDescriptor(directoryDescriptor, descriptor, source),
+        );
+        const beforeRename = fstatSync(descriptor);
+        this.assertWindowsSessionSize(beforeRename.size);
+        try {
+          (CHAT_STORE_HOOKS.get(this)?.rename ?? renameSync)(source, target);
+        } catch (error) {
+          throw classifyWindowsPrivatePathFailure("rename", error);
+        }
+        const moved = lstatSync(target);
+        assertWindowsPrivateFileMetadata(moved);
+        if (
+          !sameWindowsPrivatePathIdentity(
+            windowsPrivatePathIdentity(beforeRename),
+            windowsPrivatePathIdentity(moved),
+          )
+        ) {
+          throw new WindowsPrivatePathPolicyError("binding-check", "corruption");
+        }
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          target,
+          windowsPrivatePathIdentity(moved),
+        );
+      } finally {
+        closeSync(descriptor);
+      }
+    }, "rename");
+  }
+
+  private unlinkSessionPath(path: string): void {
+    if (this.platform !== "win32") {
+      unlinkSync(path);
+      return;
+    }
+    if (!this.sessionExists(path)) return;
+    this.assertWindowsSessionContent(this.readSessionText(path));
+    try {
+      unlinkSync(path);
+    } catch (error) {
+      throw classifyWindowsPrivatePathFailure("rename", error);
+    }
+    this.syncSessionsDirectory();
+  }
+
+  private copySessionPath(source: string, target: string): void {
+    if (this.platform !== "win32") {
+      copyFileSync(source, target);
+      return;
+    }
+    this.withSessionsDirectory((directoryDescriptor) => {
+      if (!this.sessionExists(source) || this.sessionExists(target)) {
+        throw this.unsafeTarget("Session archive target is unsafe.");
+      }
+      const sourceDescriptor = this.openWindowsSessionFile(
+        directoryDescriptor,
+        source,
+        constants.O_RDONLY,
+      );
+      try {
+        const sourceContent = this.readWindowsSessionDescriptor(
+          directoryDescriptor,
+          sourceDescriptor,
+          source,
+        );
+        this.assertWindowsSessionContent(sourceContent);
+        const sourceBefore = fstatSync(sourceDescriptor);
+        this.assertWindowsSessionSize(sourceBefore.size);
+        copyFileSync(source, target, constants.COPYFILE_EXCL);
+        const targetDescriptor = this.openWindowsSessionFile(
+          directoryDescriptor,
+          target,
+          constants.O_RDWR,
+        );
+        try {
+          this.syncFile(targetDescriptor);
+          const targetMetadata = fstatSync(targetDescriptor);
+          if (targetMetadata.size !== sourceBefore.size) {
+            throw new WindowsPrivatePathPolicyError("content-write", "corruption");
+          }
+        } finally {
+          closeSync(targetDescriptor);
+        }
+        const targetContent = this.readSessionText(target);
+        this.assertWindowsSessionContent(targetContent);
+        if (targetContent !== sourceContent) {
+          throw new WindowsPrivatePathPolicyError("content-write", "corruption");
+        }
+        const sourceAfter = fstatSync(sourceDescriptor);
+        assertWindowsPrivateFileMetadata(sourceAfter);
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          source,
+          windowsPrivatePathIdentity(sourceAfter),
+        );
+        if (
+          !sameWindowsPrivatePathIdentity(
+            windowsPrivatePathIdentity(sourceBefore),
+            windowsPrivatePathIdentity(sourceAfter),
+          ) ||
+          sourceBefore.size !== sourceAfter.size ||
+          sourceBefore.mtimeMs !== sourceAfter.mtimeMs ||
+          sourceBefore.ctimeMs !== sourceAfter.ctimeMs
+        ) {
+          throw new WindowsPrivatePathPolicyError("binding-check", "corruption");
+        }
+      } finally {
+        closeSync(sourceDescriptor);
+      }
+      this.syncDirectory(directoryDescriptor);
+    }, "content-write");
   }
 
   hasSession(chatId: string): boolean {
-    return existsSync(this.filePath(chatId));
+    return this.sessionExists(this.filePath(chatId));
   }
 
   load(chatId: string): { messages: ModelMessage[]; lastMessageTime: string | null } {
     const path = this.filePath(chatId);
-    if (!existsSync(path)) return { messages: [], lastMessageTime: null };
+    if (!this.sessionExists(path)) return { messages: [], lastMessageTime: null };
 
-    const lines = readFileSync(path, "utf-8")
-      .split("\n")
-      .filter((line) => line.trim() !== "");
+    const contents = this.readSessionText(path);
+    if (this.platform === "win32") this.assertWindowsSessionContent(contents);
+    const lines = contents.split("\n").filter((line) => line.trim() !== "");
     const good: string[] = [];
     const corrupt: string[] = [];
     const parsed: JsonlLine[] = [];
@@ -240,6 +732,7 @@ export class ChatStore {
       try {
         this.quarantineCorruptLines(chatId, good, corrupt);
       } catch (err) {
+        if (this.platform === "win32") throw err;
         console.warn(
           "Failed to quarantine corrupt session lines; continuing with parseable lines",
           err,
@@ -283,7 +776,7 @@ export class ChatStore {
       lineage === undefined
         ? { role, content, ts: new Date().toISOString() }
         : { role, content, ts: new Date().toISOString(), ...lineage };
-    appendFileSync(path, JSON.stringify(line) + "\n", { encoding: "utf-8", mode: 0o600 });
+    this.appendSessionContent(path, JSON.stringify(line) + "\n");
   }
 
   appendTurn(
@@ -311,12 +804,11 @@ export class ChatStore {
     // Both lines in one buffer and one write so the pair lands together or not
     // at all — a partial write can never leave a dangling user line.
     const buffer = JSON.stringify(userLine) + "\n" + JSON.stringify(assistantLine) + "\n";
-    appendFileSync(path, buffer, { encoding: "utf-8", mode: 0o600 });
+    this.appendSessionContent(path, buffer);
   }
 
   overwriteHistory(chatId: string, messages: ModelMessage[]): void {
     const path = this.filePath(chatId);
-    const tmpPath = `${path}.tmp`;
     const now = new Date().toISOString();
 
     // Preserve the original timestamp of a message that survives the rewrite so
@@ -326,8 +818,10 @@ export class ChatStore {
     // duplicate lines keep the stamp whose source label matches the surviving
     // message, falling back to occurrence order when the labels are identical.
     const preservedByKey = new Map<string, Array<{ ts: string; provenance?: SourceProvenance }>>();
-    if (existsSync(path)) {
-      for (const line of readFileSync(path, "utf-8").split("\n")) {
+    if (this.sessionExists(path)) {
+      const contents = this.readSessionText(path);
+      if (this.platform === "win32") this.assertWindowsSessionContent(contents);
+      for (const line of contents.split("\n")) {
         if (line.trim() === "") continue;
         const entry = parseSessionLine(line);
         if (entry === null || entry.role === "system") continue;
@@ -368,8 +862,7 @@ export class ChatStore {
           return JSON.stringify(line);
         })
         .join("\n") + "\n";
-    writeFileSync(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
-    renameSync(tmpPath, path);
+    this.replaceSessionContent(path, content);
   }
 
   // Terminal failure marker: makes a turn that died before producing a reply
@@ -378,37 +871,37 @@ export class ChatStore {
   // records that the turn did not complete. No-op when no session file exists.
   appendFailureMarker(chatId: string): void {
     const path = this.filePath(chatId);
-    if (!existsSync(path)) return;
+    if (!this.sessionExists(path)) return;
     const line: JsonlLine = {
       role: "system",
       content: TURN_FAILURE_MARKER,
       ts: new Date().toISOString(),
     };
-    appendFileSync(path, JSON.stringify(line) + "\n", { encoding: "utf-8", mode: 0o600 });
+    this.appendSessionContent(path, JSON.stringify(line) + "\n");
   }
 
   archiveAndReset(chatId: string): void {
     const path = this.filePath(chatId);
     const ts = new Date().toISOString().replace(/:/g, "-");
     const archivePath = `${path}.reset.${ts}`;
-    const sessionExists = existsSync(path);
-    const archiveExists = existsSync(archivePath);
+    const sessionExists = this.sessionExists(path);
+    const archiveExists = this.sessionExists(archivePath);
     if (sessionExists && archiveExists) {
-      throw new Error("Reset archive and active session both exist.");
+      throw this.unsafeTarget("Reset archive and active session both exist.");
     }
     if (!sessionExists) return;
 
-    renameSync(path, archivePath);
+    this.renameSessionPath(path, archivePath);
     this.syncSessionsDirectory();
     this.pruneArchives(chatId, "reset");
   }
 
   archivePreCompact(chatId: string): void {
     const path = this.filePath(chatId);
-    if (!existsSync(path)) return;
+    if (!this.sessionExists(path)) return;
 
     const ts = new Date().toISOString().replace(/:/g, "-");
-    copyFileSync(path, `${path}.precompact.${ts}`);
+    this.copySessionPath(path, `${path}.precompact.${ts}`);
     this.pruneArchives(chatId, "precompact");
   }
 
@@ -416,33 +909,44 @@ export class ChatStore {
     const path = this.filePath(chatId);
     const ts = new Date().toISOString().replace(/:/g, "-");
     const sidecarPath = `${path}.corrupt.${ts}`;
-    appendFileSync(sidecarPath, corrupt.join("\n") + "\n", { encoding: "utf-8", mode: 0o600 });
+    this.appendSessionContent(sidecarPath, corrupt.join("\n") + "\n");
     if (good.length === 0) {
-      unlinkSync(path);
+      this.unlinkSessionPath(path);
       console.warn(
-        `Quarantined ${corrupt.length} corrupt session line(s) to ${sidecarPath}; removed empty session`,
+        this.platform === "win32"
+          ? `Quarantined ${corrupt.length} corrupt session line(s); removed empty session`
+          : `Quarantined ${corrupt.length} corrupt session line(s) to ${sidecarPath}; removed empty session`,
       );
       return;
     }
-    const tmpPath = `${path}.tmp`;
-    writeFileSync(tmpPath, good.join("\n") + "\n", { encoding: "utf-8", mode: 0o600 });
-    renameSync(tmpPath, path);
+    this.replaceSessionContent(path, good.join("\n") + "\n");
     console.warn(
-      `Quarantined ${corrupt.length} corrupt session line(s) to ${sidecarPath}; kept ${good.length} valid line(s)`,
+      this.platform === "win32"
+        ? `Quarantined ${corrupt.length} corrupt session line(s); kept ${good.length} valid line(s)`
+        : `Quarantined ${corrupt.length} corrupt session line(s) to ${sidecarPath}; kept ${good.length} valid line(s)`,
     );
   }
 
   private pruneArchives(chatId: string, suffix: "reset" | "precompact"): void {
     if (this.resetArchiveRetentionDays <= 0) return;
-    const prefix = `${chatId}.jsonl.${suffix}.`;
+    const fileName = this.platform === "win32" ? this.chatDigest(chatId) : chatId;
+    const prefix = `${fileName}.jsonl.${suffix}.`;
     const cutoffMs = Date.now() - this.resetArchiveRetentionDays * MS_PER_DAY;
-    for (const name of readdirSync(this.sessionsDir)) {
+    let names: string[];
+    try {
+      names = readdirSync(this.sessionsDir);
+    } catch (error) {
+      throw this.platform === "win32"
+        ? classifyWindowsPrivatePathFailure("read-check", error)
+        : error;
+    }
+    for (const name of names) {
       if (!name.startsWith(prefix)) continue;
       const archivedAtMs = parseArchiveTimestampMs(name.slice(prefix.length));
       // Unparseable timestamps are kept: never delete an archive that
       // cannot be dated.
       if (archivedAtMs !== null && archivedAtMs < cutoffMs) {
-        unlinkSync(join(this.sessionsDir, name));
+        this.unlinkSessionPath(join(this.sessionsDir, name));
       }
     }
   }
@@ -451,7 +955,7 @@ export class ChatStore {
     this.withSessionsDirectory((descriptor) => {
       this.syncDirectory(descriptor);
       this.assertSessionsDirectoryStable(descriptor);
-    });
+    }, "rename");
   }
 
   private completeDurableReset(path: string, archivePath: string): void {
@@ -468,8 +972,16 @@ export class ChatStore {
       const archive = readStats(archivePath);
       if (active === null) {
         if (archive !== null) {
-          if (!isStrictPrivateFile(archive, 1)) {
-            throw new Error("Reset archive target is unsafe.");
+          if (!this.isPrivateFile(archive, 1)) {
+            throw this.unsafeTarget("Reset archive target is unsafe.");
+          }
+          if (this.platform === "win32") {
+            assertWindowsPrivateFileBinding(
+              this.windowsDirectoryBinding!,
+              archivePath,
+              windowsPrivatePathIdentity(archive),
+            );
+            this.assertWindowsSessionContent(this.readSessionText(archivePath));
           }
           this.assertSessionsDirectoryStable(directoryDescriptor);
           this.syncDirectory(directoryDescriptor);
@@ -477,13 +989,16 @@ export class ChatStore {
         }
         return;
       }
+      if (this.platform === "win32") {
+        this.assertWindowsSessionContent(this.readSessionText(path, archive === null ? 1 : 2));
+      }
       if (archive !== null) {
         this.assertLinkedResetTargets(active, archive);
         this.syncStableSessionFile(directoryDescriptor, path, identity(active), 2);
         this.assertLinkedResetPaths(directoryDescriptor, path, archivePath, identity(active));
       } else {
-        if (!isStrictPrivateFile(active, 1)) {
-          throw new Error("Active reset session target is unsafe.");
+        if (!this.isPrivateFile(active, 1)) {
+          throw this.unsafeTarget("Active reset session target is unsafe.");
         }
         this.syncStableSessionFile(directoryDescriptor, path, identity(active), 1);
         linkSync(path, archivePath);
@@ -499,43 +1014,75 @@ export class ChatStore {
       this.assertSessionsDirectoryStable(directoryDescriptor);
       const completed = lstatSync(archivePath);
       if (
-        !isStrictPrivateFile(completed, 1) ||
+        !this.isPrivateFile(completed, 1) ||
         !sameIdentity(identity(completed), identity(active))
       ) {
-        throw new Error("Reset archive did not complete safely.");
+        throw this.unsafeTarget("Reset archive did not complete safely.");
       }
-    });
+      if (this.platform === "win32") {
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          archivePath,
+          windowsPrivatePathIdentity(completed),
+        );
+      }
+    }, "rename");
   }
 
   private syncStableSessionFile(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     path: string,
     expectedIdentity: FileIdentity,
     expectedLinks: 1 | 2,
   ): void {
-    const descriptor = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const descriptor = openSync(
+      path,
+      this.platform === "win32" ? constants.O_RDWR : constants.O_RDONLY | constants.O_NOFOLLOW,
+    );
     try {
+      if (this.platform === "win32") {
+        this.assertWindowsSessionContent(
+          this.readWindowsSessionDescriptor(directoryDescriptor, descriptor, path, expectedLinks),
+        );
+      }
       const opened = fstatSync(descriptor);
       const current = lstatSync(path);
+      if (this.platform === "win32") this.assertWindowsSessionSize(opened.size);
       if (
-        !isStrictPrivateFile(opened, expectedLinks) ||
-        !isStrictPrivateFile(current, expectedLinks) ||
+        !this.isPrivateFile(opened, expectedLinks) ||
+        !this.isPrivateFile(current, expectedLinks) ||
         !sameIdentity(identity(opened), expectedIdentity) ||
         !sameIdentity(identity(current), expectedIdentity)
       ) {
-        throw new Error("Active reset session was raced.");
+        throw this.unsafeTarget("Active reset session was raced.");
+      }
+      if (this.platform === "win32") {
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          path,
+          windowsPrivatePathIdentity(opened),
+          expectedLinks,
+        );
       }
       this.assertSessionsDirectoryStable(directoryDescriptor);
-      (CHAT_STORE_HOOKS.get(this)?.syncFile ?? fsyncSync)(descriptor);
+      this.syncFile(descriptor);
       const synced = fstatSync(descriptor);
       const afterSync = lstatSync(path);
       if (
-        !isStrictPrivateFile(synced, expectedLinks) ||
-        !isStrictPrivateFile(afterSync, expectedLinks) ||
+        !this.isPrivateFile(synced, expectedLinks) ||
+        !this.isPrivateFile(afterSync, expectedLinks) ||
         !sameIdentity(identity(synced), expectedIdentity) ||
         !sameIdentity(identity(afterSync), expectedIdentity)
       ) {
-        throw new Error("Active reset session was raced.");
+        throw this.unsafeTarget("Active reset session was raced.");
+      }
+      if (this.platform === "win32") {
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          path,
+          windowsPrivatePathIdentity(synced),
+          expectedLinks,
+        );
       }
       this.assertSessionsDirectoryStable(directoryDescriptor);
     } finally {
@@ -548,16 +1095,16 @@ export class ChatStore {
     archive: import("node:fs").Stats,
   ): void {
     if (
-      !isStrictPrivateFile(active, 2) ||
-      !isStrictPrivateFile(archive, 2) ||
+      !this.isPrivateFile(active, 2) ||
+      !this.isPrivateFile(archive, 2) ||
       !sameIdentity(identity(active), identity(archive))
     ) {
-      throw new Error("Reset archive and active session do not agree.");
+      throw this.unsafeTarget("Reset archive and active session do not agree.");
     }
   }
 
   private assertLinkedResetPaths(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     path: string,
     archivePath: string,
     expectedIdentity: FileIdentity,
@@ -566,12 +1113,53 @@ export class ChatStore {
     const archive = lstatSync(archivePath);
     this.assertLinkedResetTargets(active, archive);
     if (!sameIdentity(identity(active), expectedIdentity)) {
-      throw new Error("Reset archive publication was raced.");
+      throw this.unsafeTarget("Reset archive publication was raced.");
+    }
+    if (this.platform === "win32") {
+      assertWindowsPrivateFileBinding(
+        this.windowsDirectoryBinding!,
+        path,
+        windowsPrivatePathIdentity(active),
+        2,
+      );
+      assertWindowsPrivateFileBinding(
+        this.windowsDirectoryBinding!,
+        archivePath,
+        windowsPrivatePathIdentity(archive),
+        2,
+      );
     }
     this.assertSessionsDirectoryStable(directoryDescriptor);
   }
 
-  private withSessionsDirectory<T>(operation: (descriptor: number) => T): T {
+  private syncFile(descriptor: number): void {
+    try {
+      (CHAT_STORE_HOOKS.get(this)?.syncFile ?? fsyncSync)(descriptor);
+    } catch (error) {
+      throw this.platform === "win32"
+        ? classifyWindowsPrivatePathFailure("file-flush", error)
+        : error;
+    }
+  }
+
+  private withSessionsDirectory<T>(
+    operation: (descriptor: DirectoryDescriptor) => T,
+    failureStage: WindowsPrivatePathPolicyStage = "read-check",
+  ): T {
+    if (this.platform === "win32") {
+      try {
+        this.assertSessionsDirectoryStable(null);
+        return operation(null);
+      } catch (error) {
+        if (
+          error instanceof WindowsPrivatePathPolicyError ||
+          (typeof error === "object" && error !== null && "code" in error)
+        ) {
+          throw classifyWindowsPrivatePathFailure(failureStage, error);
+        }
+        throw error;
+      }
+    }
     const beforeOpen = lstatSync(this.sessionsDir);
     if (
       !isStrictPrivateDirectory(beforeOpen) ||
@@ -591,9 +1179,13 @@ export class ChatStore {
     }
   }
 
-  private assertSessionsDirectoryStable(descriptor: number): void {
+  private assertSessionsDirectoryStable(descriptor: DirectoryDescriptor): void {
+    if (this.platform === "win32") {
+      assertWindowsPrivateDirectoryStable(this.windowsDirectoryBinding!);
+      return;
+    }
     const current = lstatSync(this.sessionsDir);
-    const opened = fstatSync(descriptor);
+    const opened = fstatSync(descriptor!);
     if (
       !isStrictPrivateDirectory(current) ||
       !isStrictPrivateDirectory(opened) ||
@@ -604,8 +1196,11 @@ export class ChatStore {
     }
   }
 
-  private syncDirectory(descriptor: number): void {
-    (CHAT_STORE_HOOKS.get(this)?.syncDirectory ?? fsyncSync)(descriptor);
+  private syncDirectory(descriptor: DirectoryDescriptor): void {
+    if (this.platform === "win32") {
+      if (classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable") return;
+    }
+    (CHAT_STORE_HOOKS.get(this)?.syncDirectory ?? fsyncSync)(descriptor!);
   }
 }
 
@@ -613,8 +1208,9 @@ export function createChatStoreWithHooks(
   dataDir: string,
   resetArchiveRetentionDays: number,
   hooks: ChatStoreHooks,
+  options: ChatStoreOptions = {},
 ): ChatStore {
-  const store = new ChatStore(dataDir, resetArchiveRetentionDays);
+  const store = new ChatStore(dataDir, resetArchiveRetentionDays, options);
   CHAT_STORE_HOOKS.set(store, hooks);
   return store;
 }

--- a/packages/core/src/agent/conversation-store.ts
+++ b/packages/core/src/agent/conversation-store.ts
@@ -29,11 +29,16 @@ export interface ConversationStorePort extends ChatStorePort, TranscriptWriterPo
   ): TranscriptPageResult;
 }
 
+export interface ConversationStoreOptions {
+  readonly platform?: NodeJS.Platform;
+}
+
 export function createConversationStore(
   dataDir: string,
   resetArchiveRetentionDays = 0,
+  options: ConversationStoreOptions = {},
 ): ConversationStorePort {
-  return ConversationStore.create(dataDir, resetArchiveRetentionDays);
+  return ConversationStore.create(dataDir, resetArchiveRetentionDays, options);
 }
 
 export class ConversationRecoveryError extends Error {
@@ -48,10 +53,14 @@ export class ConversationRecoveryError extends Error {
 export class ConversationStore implements ConversationStorePort {
   private readonly blockedChats = new Map<string, unknown>();
 
-  static create(dataDir: string, resetArchiveRetentionDays = 0): ConversationStore {
+  static create(
+    dataDir: string,
+    resetArchiveRetentionDays = 0,
+    options: ConversationStoreOptions = {},
+  ): ConversationStore {
     return new ConversationStore(
-      new ChatStore(dataDir, resetArchiveRetentionDays),
-      new TranscriptStore(dataDir),
+      new ChatStore(dataDir, resetArchiveRetentionDays, options),
+      new TranscriptStore(dataDir, { platform: options.platform }),
     );
   }
 

--- a/packages/core/src/agent/transcript-store.ts
+++ b/packages/core/src/agent/transcript-store.ts
@@ -24,10 +24,25 @@ import type {
   TranscriptConversationBoundaryReason,
   TranscriptWriterPort,
 } from "@enduragent/engine";
+import {
+  WindowsPrivatePathPolicyError,
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivateFileBinding,
+  assertWindowsPrivateFileMetadata,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  classifyWindowsPrivatePathFailure,
+  sameWindowsPrivatePathIdentity,
+  windowsPrivatePathIdentity,
+  type WindowsPrivateDirectoryBinding,
+  type WindowsPrivatePathPolicyStage,
+} from "../io/windows-private-path-policy.js";
 
 const TRANSCRIPT_SCHEMA_VERSION = 1 as const;
 const RESET_INTENT_SCHEMA_VERSION = 1 as const;
 export const MAX_TRANSCRIPT_RECORD_BYTES = 262_144;
+export const MAX_TRANSCRIPT_FILE_BYTES = 67_108_864;
 export const MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES = MAX_TRANSCRIPT_RECORD_BYTES + 4_096;
 export const MAX_TRANSCRIPT_PAGE_TURNS = 50;
 const STRICT_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
@@ -55,7 +70,10 @@ interface TranscriptStoreHooks {
   readonly syncDirectory?: (descriptor: number) => void;
   readonly beforeExistingFileOpen?: (path: string) => void;
   readonly afterChildOpen?: (path: string, descriptor: number) => void;
+  readonly platform?: NodeJS.Platform;
 }
+
+type DirectoryDescriptor = number | null;
 
 interface FileIdentity {
   readonly dev: number | bigint;
@@ -615,49 +633,94 @@ export class TranscriptStore implements TranscriptWriterPort {
   private readonly transcriptsDir: string;
   private readonly directoryIdentity: FileIdentity;
   private readonly hooks: TranscriptStoreHooks;
+  private readonly platform: NodeJS.Platform;
+  private readonly windowsDirectoryBinding: WindowsPrivateDirectoryBinding | undefined;
 
   constructor(dataDir: string, hooks: TranscriptStoreHooks = {}) {
     this.transcriptsDir = join(dataDir, "transcripts");
     this.hooks = hooks;
+    this.platform = hooks.platform ?? process.platform;
     let created = false;
     try {
       mkdirSync(this.transcriptsDir, { mode: 0o700 });
       created = true;
     } catch (error) {
-      if (!isExists(error)) throw error;
+      if (!isExists(error)) {
+        throw this.platform === "win32"
+          ? classifyWindowsPrivatePathFailure("entry-check", error)
+          : error;
+      }
     }
 
-    const beforeOpen = lstatSync(this.transcriptsDir);
-    if (beforeOpen.isSymbolicLink() || !beforeOpen.isDirectory()) {
-      throw new UnsafeTranscriptTargetError();
-    }
-    const descriptor = openSync(
-      this.transcriptsDir,
-      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
-    );
-    try {
-      if (created) fchmodSync(descriptor, 0o700);
-      const opened = fstatSync(descriptor);
-      if (
-        !sameIdentity(identity(beforeOpen), identity(opened)) ||
-        !opened.isDirectory() ||
-        (opened.mode & 0o7777) !== 0o700
-      ) {
-        throw new UnsafeTranscriptTargetError();
-      }
-      const afterOpen = lstatSync(this.transcriptsDir);
-      if (
-        afterOpen.isSymbolicLink() ||
-        !afterOpen.isDirectory() ||
-        (afterOpen.mode & 0o7777) !== 0o700 ||
-        !sameIdentity(identity(afterOpen), identity(opened))
-      ) {
-        throw new UnsafeTranscriptTargetError();
-      }
-      this.directoryIdentity = identity(opened);
+    if (this.platform === "win32") {
+      const binding = bindWindowsPrivateDirectory(dataDir, this.transcriptsDir);
+      this.windowsDirectoryBinding = binding;
+      this.directoryIdentity = binding.identity;
       if (created) this.syncParentDirectory(dataDir);
-    } finally {
-      closeSync(descriptor);
+    } else {
+      this.windowsDirectoryBinding = undefined;
+      const beforeOpen = lstatSync(this.transcriptsDir);
+      if (beforeOpen.isSymbolicLink() || !beforeOpen.isDirectory()) {
+        throw new UnsafeTranscriptTargetError();
+      }
+      const descriptor = openSync(
+        this.transcriptsDir,
+        constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+      );
+      try {
+        if (created) fchmodSync(descriptor, 0o700);
+        const opened = fstatSync(descriptor);
+        if (
+          !sameIdentity(identity(beforeOpen), identity(opened)) ||
+          !opened.isDirectory() ||
+          (opened.mode & 0o7777) !== 0o700
+        ) {
+          throw new UnsafeTranscriptTargetError();
+        }
+        const afterOpen = lstatSync(this.transcriptsDir);
+        if (
+          afterOpen.isSymbolicLink() ||
+          !afterOpen.isDirectory() ||
+          (afterOpen.mode & 0o7777) !== 0o700 ||
+          !sameIdentity(identity(afterOpen), identity(opened))
+        ) {
+          throw new UnsafeTranscriptTargetError();
+        }
+        this.directoryIdentity = identity(opened);
+        if (created) this.syncParentDirectory(dataDir);
+      } finally {
+        closeSync(descriptor);
+      }
+    }
+  }
+
+  private unsafeTarget(message?: string): Error {
+    return this.platform === "win32"
+      ? new WindowsPrivatePathPolicyError("read-check", "corruption")
+      : message === undefined
+        ? new UnsafeTranscriptTargetError()
+        : new Error(message);
+  }
+
+  private isPrivateFile(metadata: Stats, allowedLinks: 1 | 2 = 1): boolean {
+    if (this.platform === "win32") {
+      assertWindowsPrivateFileMetadata(metadata, allowedLinks);
+      return true;
+    }
+    return isStrictPrivateFile(metadata, allowedLinks);
+  }
+
+  private selectArchivedSegment(
+    segments: readonly ArchivedTranscriptSegment[],
+    boundaryRef: string,
+  ): ArchivedTranscriptSegment | null {
+    try {
+      return selectArchivedSegment(segments, boundaryRef);
+    } catch (error) {
+      if (this.platform === "win32") {
+        throw this.unsafeTarget("Transcript contains duplicate reset boundaries.");
+      }
+      throw error;
     }
   }
 
@@ -672,7 +735,8 @@ export class TranscriptStore implements TranscriptWriterPort {
       const descriptor = this.openExistingFile(directoryDescriptor, path, constants.O_RDONLY, true);
       if (descriptor === null) return [];
       try {
-        const contents = this.readSnapshot(descriptor);
+        const contents = this.readSnapshot(directoryDescriptor, descriptor, path);
+        if (this.platform === "win32") this.assertWindowsTranscriptContent(contents, chatId);
         const window = parseCurrentWindow(contents, chatId);
         this.assertOpenedFileSafe(descriptor);
         this.assertDirectoryStable(directoryDescriptor);
@@ -696,7 +760,8 @@ export class TranscriptStore implements TranscriptWriterPort {
         return request.cursor === null ? pageResult([], null) : restartRequiredPage();
       }
       try {
-        const contents = this.readSnapshot(descriptor);
+        const contents = this.readSnapshot(directoryDescriptor, descriptor, path);
+        if (this.platform === "win32") this.assertWindowsTranscriptContent(contents, chatId);
         const current = parseCurrentWindow(contents, chatId);
         const chatDigest = Buffer.from(this.chatDigest(chatId), "hex");
         let snapshot = contents;
@@ -773,11 +838,12 @@ export class TranscriptStore implements TranscriptWriterPort {
         return { schemaVersion: 1, conversations: [], truncated: false };
       }
       try {
-        const contents = this.readSnapshot(descriptor);
+        const contents = this.readSnapshot(directoryDescriptor, descriptor, path);
+        if (this.platform === "win32") this.assertWindowsTranscriptContent(contents, chatId);
         const segments = parseArchivedSegments(contents, chatId);
         const refs = new Set(segments.map((segment) => segment.boundary.resetId));
         if (refs.size !== segments.length) {
-          throw new Error("Transcript contains duplicate reset boundaries.");
+          throw this.unsafeTarget("Transcript contains duplicate reset boundaries.");
         }
         this.assertOpenedFileSafe(descriptor);
         this.assertDirectoryStable(directoryDescriptor);
@@ -817,12 +883,13 @@ export class TranscriptStore implements TranscriptWriterPort {
       const descriptor = this.openExistingFile(directoryDescriptor, path, constants.O_RDONLY, true);
       if (descriptor === null) return restartRequiredPage();
       try {
-        const contents = this.readSnapshot(descriptor);
+        const contents = this.readSnapshot(directoryDescriptor, descriptor, path);
+        if (this.platform === "win32") this.assertWindowsTranscriptContent(contents, chatId);
         const chatDigest = Buffer.from(this.chatDigest(chatId), "hex");
         const fence = Buffer.from(boundaryRef, "hex");
         let result: TranscriptPageResult;
         if (request.cursor === null) {
-          const target = selectArchivedSegment(
+          const target = this.selectArchivedSegment(
             parseArchivedSegments(contents, chatId),
             boundaryRef,
           );
@@ -860,7 +927,7 @@ export class TranscriptStore implements TranscriptWriterPort {
           if (!createHash("sha256").update(snapshot).digest().equals(decoded.snapshotHash)) {
             throw new TypeError("Transcript page cursor is invalid.");
           }
-          const target = selectArchivedSegment(
+          const target = this.selectArchivedSegment(
             parseArchivedSegments(snapshot, chatId),
             boundaryRef,
           );
@@ -899,31 +966,62 @@ export class TranscriptStore implements TranscriptWriterPort {
         const bytes = Buffer.from(`${JSON.stringify(intent)}\n`, "utf8");
         this.writeComplete(tempDescriptor, bytes);
         this.syncFile(tempDescriptor);
-        closeSync(tempDescriptor);
-        tempDescriptor = null;
+        if (this.platform === "win32") {
+          this.assertOpenedPathSafe(directoryDescriptor, tempDescriptor, tempPath);
+        } else {
+          closeSync(tempDescriptor);
+          tempDescriptor = null;
+        }
 
         this.assertPathMissing(targetPath);
         try {
           linkSync(tempPath, targetPath);
         } catch (error) {
-          if (isExists(error)) throw new UnsafeTranscriptTargetError();
-          throw error;
+          if (isExists(error)) throw this.unsafeTarget();
+          throw this.platform === "win32"
+            ? classifyWindowsPrivatePathFailure("rename", error)
+            : error;
         }
         linked = true;
+        if (this.platform === "win32") {
+          this.assertOpenedPathSafe(directoryDescriptor, tempDescriptor!, tempPath, 2);
+          const target = lstatSync(targetPath);
+          const opened = fstatSync(tempDescriptor!);
+          if (!this.isPrivateFile(target, 2) || !sameIdentity(identity(target), identity(opened))) {
+            throw this.unsafeTarget();
+          }
+          assertWindowsPrivateFileBinding(
+            this.windowsDirectoryBinding!,
+            targetPath,
+            windowsPrivatePathIdentity(opened),
+            2,
+          );
+        }
         this.syncDirectory(directoryDescriptor);
         this.unlinkMatchingTemp(directoryDescriptor, tempPath, targetPath);
         this.assertIntentTarget(directoryDescriptor, targetPath, intent);
+        if (tempDescriptor !== null) {
+          const descriptor = tempDescriptor;
+          tempDescriptor = null;
+          closeSync(descriptor);
+        }
       } catch (error) {
+        if (this.platform === "win32") {
+          if (tempDescriptor !== null) {
+            try {
+              closeSync(tempDescriptor);
+            } catch {}
+          }
+          throw classifyWindowsPrivatePathFailure("content-write", error);
+        }
         if (tempDescriptor !== null) closeSync(tempDescriptor);
         try {
           if (linked) this.unlinkMatchingTemp(directoryDescriptor, tempPath, targetPath);
           else this.unlinkPrivateFileIfPresent(directoryDescriptor, tempPath, 1);
-        } catch {
-          // The caller will fail closed; construction/access recovery rechecks the artifact.
-        }
+        } catch {}
         throw error;
       }
-    });
+    }, "content-write");
   }
 
   readResetIntent(chatId: string): ResetIntentRecord | null {
@@ -941,14 +1039,14 @@ export class TranscriptStore implements TranscriptWriterPort {
       const intents: ResetIntentRecord[] = [];
       for (const name of names) {
         if (name.endsWith(".reset-intent.json") && !INTENT_TARGET_PATTERN.test(name)) {
-          throw new UnsafeTranscriptTargetError();
+          throw this.unsafeTarget();
         }
         const match = INTENT_TARGET_PATTERN.exec(name);
         if (match === null) continue;
         const path = join(this.transcriptsDir, name);
         const intent = this.readIntentPath(directoryDescriptor, path);
         if (intent === null || this.chatDigest(intent.chatId) !== match[1]) {
-          throw new UnsafeTranscriptTargetError();
+          throw this.unsafeTarget();
         }
         intents.push(intent);
       }
@@ -969,22 +1067,22 @@ export class TranscriptStore implements TranscriptWriterPort {
       );
       if (descriptor === null) return;
       try {
-        const actual = parseResetIntent(readFileSync(descriptor));
+        const actual = parseResetIntent(this.readOpenedFile(directoryDescriptor, descriptor, path));
         if (actual === null || JSON.stringify(actual) !== JSON.stringify(intent)) {
-          throw new UnsafeTranscriptTargetError();
+          throw this.unsafeTarget();
         }
         const pathStats = lstatSync(path);
         const openedStats = fstatSync(descriptor);
         if (!sameIdentity(identity(pathStats), identity(openedStats))) {
-          throw new UnsafeTranscriptTargetError();
+          throw this.unsafeTarget();
         }
         this.assertDirectoryStable(directoryDescriptor);
-        unlinkSync(path);
+        this.unlinkPath(path);
         this.syncDirectory(directoryDescriptor);
       } finally {
         closeSync(descriptor);
       }
-    });
+    }, "rename");
   }
 
   hasConversationBoundary(chatId: string, resetId: string): boolean {
@@ -996,28 +1094,27 @@ export class TranscriptStore implements TranscriptWriterPort {
     const intent = resetIntentRecord(input);
     const bytes = serializeTranscriptRecord(conversationBoundaryRecord(intent));
     const before = this.boundaryCount(intent.chatId, intent.resetId);
-    if (before > 1) throw new Error("Transcript contains duplicate reset boundaries.");
+    if (before > 1) {
+      throw this.unsafeTarget("Transcript contains duplicate reset boundaries.");
+    }
     if (before === 1) {
       this.syncTranscriptFileAndDirectory(intent.chatId);
       return;
     }
     this.appendRecord(intent.chatId, bytes, true);
     if (this.boundaryCount(intent.chatId, intent.resetId) !== 1) {
-      throw new Error("Conversation boundary was not durably persisted exactly once.");
+      throw this.unsafeTarget("Conversation boundary was not durably persisted exactly once.");
     }
   }
 
   private boundaryCount(chatId: string, resetId: string): number {
     return this.withDirectory((directoryDescriptor) => {
-      const descriptor = this.openExistingFile(
-        directoryDescriptor,
-        this.transcriptPath(chatId),
-        constants.O_RDONLY,
-        true,
-      );
+      const path = this.transcriptPath(chatId);
+      const descriptor = this.openExistingFile(directoryDescriptor, path, constants.O_RDONLY, true);
       if (descriptor === null) return 0;
       try {
-        const contents = readFileSync(descriptor);
+        const contents = this.readOpenedFile(directoryDescriptor, descriptor, path);
+        if (this.platform === "win32") this.assertWindowsTranscriptContent(contents, chatId);
         let count = 0;
         let lineStart = 0;
         for (let index = 0; index < contents.length; index += 1) {
@@ -1052,6 +1149,10 @@ export class TranscriptStore implements TranscriptWriterPort {
       const { descriptor, created } = this.openForAppend(directoryDescriptor, path);
       const beforeAppend = fstatSync(descriptor);
       try {
+        if (this.platform === "win32") {
+          const existing = this.readSnapshot(directoryDescriptor, descriptor, path);
+          this.assertWindowsTranscriptContent(existing, chatId);
+        }
         let prefix = "";
         if (beforeAppend.size > 0) {
           const tail = Buffer.allocUnsafe(1);
@@ -1061,8 +1162,17 @@ export class TranscriptStore implements TranscriptWriterPort {
         }
         const bytes =
           prefix === "" ? recordBytes : Buffer.concat([Buffer.from(prefix), recordBytes]);
+        if (this.platform === "win32") {
+          this.assertWindowsTranscriptSize(beforeAppend.size + bytes.length);
+        }
         this.writeComplete(descriptor, bytes);
         this.syncFile(descriptor);
+        if (this.platform === "win32") {
+          const afterAppend = fstatSync(descriptor);
+          if (afterAppend.size !== beforeAppend.size + bytes.length) {
+            throw new WindowsPrivatePathPolicyError("content-write", "corruption");
+          }
+        }
         this.assertOpenedPathSafe(directoryDescriptor, descriptor, path);
         this.syncDirectory(directoryDescriptor);
         this.assertOpenedPathSafe(directoryDescriptor, descriptor, path);
@@ -1074,13 +1184,19 @@ export class TranscriptStore implements TranscriptWriterPort {
           error.bytesWritten === 0 &&
           this.openedPathIsUnchanged(directoryDescriptor, descriptor, path, beforeAppend)
         ) {
-          throw new TranscriptBoundaryTargetUnchangedError(error);
+          throw new TranscriptBoundaryTargetUnchangedError(
+            this.platform === "win32"
+              ? classifyWindowsPrivatePathFailure("content-write", error)
+              : error,
+          );
         }
-        throw error;
+        throw this.platform === "win32"
+          ? classifyWindowsPrivatePathFailure("content-write", error)
+          : error;
       } finally {
         closeSync(descriptor);
       }
-    });
+    }, "content-write");
   }
 
   private syncTranscriptFileAndDirectory(chatId: string): void {
@@ -1089,10 +1205,10 @@ export class TranscriptStore implements TranscriptWriterPort {
       const descriptor = this.openExistingFile(
         directoryDescriptor,
         path,
-        constants.O_RDONLY,
+        this.platform === "win32" ? constants.O_RDWR : constants.O_RDONLY,
         false,
       );
-      if (descriptor === null) throw new UnsafeTranscriptTargetError();
+      if (descriptor === null) throw this.unsafeTarget();
       try {
         this.syncFile(descriptor);
         this.assertOpenedPathSafe(directoryDescriptor, descriptor, path);
@@ -1101,24 +1217,133 @@ export class TranscriptStore implements TranscriptWriterPort {
       } finally {
         closeSync(descriptor);
       }
-    });
+    }, "file-flush");
   }
 
-  private readSnapshot(descriptor: number): Buffer {
-    const size = fstatSync(descriptor).size;
-    if (!Number.isSafeInteger(size) || size < 0) throw new UnsafeTranscriptTargetError();
+  private readSnapshot(
+    directoryDescriptor: DirectoryDescriptor,
+    descriptor: number,
+    path: string,
+    allowedLinks: 1 | 2 = 1,
+  ): Buffer {
+    const beforeRead = fstatSync(descriptor);
+    const size = beforeRead.size;
+    if (
+      !Number.isSafeInteger(size) ||
+      size < 0 ||
+      (this.platform === "win32" && size > MAX_TRANSCRIPT_FILE_BYTES)
+    ) {
+      if (this.platform === "win32") {
+        assertWindowsPrivatePathRead({
+          bounded: false,
+          identityStable: true,
+          contentValid: true,
+          authenticatedHomeBinding: true,
+        });
+      }
+      throw this.unsafeTarget();
+    }
     const contents = Buffer.allocUnsafe(size);
     let offset = 0;
     while (offset < size) {
       const bytesRead = readSync(descriptor, contents, offset, size - offset, offset);
-      if (bytesRead <= 0) throw new Error("Transcript snapshot could not be read.");
+      if (bytesRead <= 0) {
+        if (this.platform === "win32") {
+          assertWindowsPrivatePathRead({
+            bounded: true,
+            identityStable: true,
+            contentValid: false,
+            authenticatedHomeBinding: true,
+          });
+        }
+        throw new Error("Transcript snapshot could not be read.");
+      }
       offset += bytesRead;
+    }
+    if (this.platform === "win32") {
+      const afterRead = fstatSync(descriptor);
+      assertWindowsPrivateFileMetadata(beforeRead, allowedLinks);
+      assertWindowsPrivateFileMetadata(afterRead, allowedLinks);
+      const current = assertWindowsPrivateFileBinding(
+        this.windowsDirectoryBinding!,
+        path,
+        windowsPrivatePathIdentity(afterRead),
+        allowedLinks,
+      );
+      assertWindowsPrivatePathRead({
+        bounded: true,
+        identityStable:
+          sameWindowsPrivatePathIdentity(
+            windowsPrivatePathIdentity(beforeRead),
+            windowsPrivatePathIdentity(afterRead),
+          ) &&
+          beforeRead.size === afterRead.size &&
+          beforeRead.size === current.size &&
+          beforeRead.mtimeMs === afterRead.mtimeMs &&
+          beforeRead.mtimeMs === current.mtimeMs &&
+          beforeRead.ctimeMs === afterRead.ctimeMs &&
+          beforeRead.ctimeMs === current.ctimeMs,
+        contentValid: offset === size,
+        authenticatedHomeBinding: true,
+      });
+      this.assertDirectoryStable(directoryDescriptor);
     }
     return contents;
   }
 
+  private assertWindowsTranscriptSize(size: number): void {
+    assertWindowsPrivatePathRead({
+      bounded: Number.isSafeInteger(size) && size >= 0 && size <= MAX_TRANSCRIPT_FILE_BYTES,
+      identityStable: true,
+      contentValid: true,
+      authenticatedHomeBinding: true,
+    });
+  }
+
+  private assertWindowsTranscriptContent(contents: Buffer, chatId: string): void {
+    let contentValid = contents.length === 0;
+    let lineStart = 0;
+    const resetIds = new Set<string>();
+    for (let index = 0; index < contents.length; index += 1) {
+      if (contents[index] !== 0x0a) continue;
+      const line = contents.subarray(lineStart, index);
+      lineStart = index + 1;
+      const record = line.length === 0 ? null : parseRecordBytes(line);
+      if (record === null || record.chatId !== chatId) {
+        contentValid = false;
+        break;
+      }
+      if (record.kind === "conversation-boundary") {
+        if (resetIds.has(record.resetId)) {
+          contentValid = false;
+          break;
+        }
+        resetIds.add(record.resetId);
+      }
+      contentValid = true;
+    }
+    if (lineStart !== contents.length) contentValid = false;
+    assertWindowsPrivatePathRead({
+      bounded: contents.length <= MAX_TRANSCRIPT_FILE_BYTES,
+      identityStable: true,
+      contentValid,
+      authenticatedHomeBinding: true,
+    });
+  }
+
+  private readOpenedFile(
+    directoryDescriptor: DirectoryDescriptor,
+    descriptor: number,
+    path: string,
+    allowedLinks: 1 | 2 = 1,
+  ): Buffer {
+    return this.platform === "win32"
+      ? this.readSnapshot(directoryDescriptor, descriptor, path, allowedLinks)
+      : readFileSync(descriptor);
+  }
+
   private openForAppend(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     path: string,
   ): { readonly descriptor: number; readonly created: boolean } {
     const existing = this.openExistingFile(
@@ -1141,13 +1366,13 @@ export class TranscriptStore implements TranscriptWriterPort {
         constants.O_RDWR | constants.O_APPEND,
         false,
       );
-      if (raced === null) throw new UnsafeTranscriptTargetError();
+      if (raced === null) throw this.unsafeTarget();
       return { descriptor: raced, created: false };
     }
   }
 
   private openExistingFile(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     path: string,
     flags: number,
     missingAllowed: boolean,
@@ -1163,18 +1388,18 @@ export class TranscriptStore implements TranscriptWriterPort {
       }
       throw error;
     }
-    if (beforeOpen.isSymbolicLink() || !isStrictPrivateFile(beforeOpen, allowedLinks)) {
-      throw new UnsafeTranscriptTargetError();
+    if (!this.isPrivateFile(beforeOpen, allowedLinks)) {
+      throw this.unsafeTarget();
     }
     this.hooks.beforeExistingFileOpen?.(path);
     this.assertDirectoryStable(directoryDescriptor);
     let descriptor: number;
     try {
-      descriptor = openSync(path, flags | constants.O_NOFOLLOW);
+      descriptor = openSync(path, flags | (this.platform === "win32" ? 0 : constants.O_NOFOLLOW));
     } catch (error) {
       const code = (error as NodeJS.ErrnoException | undefined)?.code;
       if (code === "ELOOP" || code === "EISDIR" || code === "ENOTDIR") {
-        throw new UnsafeTranscriptTargetError();
+        throw this.unsafeTarget();
       }
       throw error;
     }
@@ -1184,16 +1409,24 @@ export class TranscriptStore implements TranscriptWriterPort {
       const opened = fstatSync(descriptor);
       if (
         !sameIdentity(identity(beforeOpen), identity(opened)) ||
-        !isStrictPrivateFile(opened, allowedLinks)
+        !this.isPrivateFile(opened, allowedLinks)
       ) {
-        throw new UnsafeTranscriptTargetError();
+        throw this.unsafeTarget();
       }
       const afterOpen = lstatSync(path);
       if (
-        !isStrictPrivateFile(afterOpen, allowedLinks) ||
+        !this.isPrivateFile(afterOpen, allowedLinks) ||
         !sameIdentity(identity(afterOpen), identity(opened))
       ) {
-        throw new UnsafeTranscriptTargetError();
+        throw this.unsafeTarget();
+      }
+      if (this.platform === "win32") {
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          path,
+          windowsPrivatePathIdentity(opened),
+          allowedLinks,
+        );
       }
       this.assertDirectoryStable(directoryDescriptor);
       return descriptor;
@@ -1204,7 +1437,7 @@ export class TranscriptStore implements TranscriptWriterPort {
   }
 
   private openNewFile(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     path: string,
     extraFlags = 0,
     syncOnCreate = true,
@@ -1212,23 +1445,38 @@ export class TranscriptStore implements TranscriptWriterPort {
     this.assertDirectoryStable(directoryDescriptor);
     const descriptor = openSync(
       path,
-      constants.O_RDWR | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW | extraFlags,
+      constants.O_RDWR |
+        constants.O_CREAT |
+        constants.O_EXCL |
+        (this.platform === "win32" ? 0 : constants.O_NOFOLLOW) |
+        extraFlags,
       0o600,
     );
     try {
       this.hooks.afterChildOpen?.(path, descriptor);
       this.assertDirectoryStable(directoryDescriptor);
       const created = fstatSync(descriptor);
-      if (!created.isFile() || created.nlink !== 1) throw new UnsafeTranscriptTargetError();
-      fchmodSync(descriptor, 0o600);
+      if (this.platform === "win32") {
+        assertWindowsPrivateFileMetadata(created);
+      } else {
+        if (!created.isFile() || created.nlink !== 1) throw new UnsafeTranscriptTargetError();
+        fchmodSync(descriptor, 0o600);
+      }
       const opened = fstatSync(descriptor);
       const afterOpen = lstatSync(path);
       if (
-        !isStrictPrivateFile(opened) ||
-        !isStrictPrivateFile(afterOpen) ||
+        !this.isPrivateFile(opened) ||
+        !this.isPrivateFile(afterOpen) ||
         !sameIdentity(identity(afterOpen), identity(opened))
       ) {
-        throw new UnsafeTranscriptTargetError();
+        throw this.unsafeTarget();
+      }
+      if (this.platform === "win32") {
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          path,
+          windowsPrivatePathIdentity(opened),
+        );
       }
       this.assertDirectoryStable(directoryDescriptor);
       if (syncOnCreate) this.syncDirectory(directoryDescriptor);
@@ -1240,13 +1488,13 @@ export class TranscriptStore implements TranscriptWriterPort {
   }
 
   private assertOpenedFileSafe(descriptor: number, allowedLinks: 1 | 2 = 1): void {
-    if (!isStrictPrivateFile(fstatSync(descriptor), allowedLinks)) {
-      throw new UnsafeTranscriptTargetError();
+    if (!this.isPrivateFile(fstatSync(descriptor), allowedLinks)) {
+      throw this.unsafeTarget();
     }
   }
 
   private assertOpenedPathSafe(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     descriptor: number,
     path: string,
     allowedLinks: 1 | 2 = 1,
@@ -1254,17 +1502,25 @@ export class TranscriptStore implements TranscriptWriterPort {
     const opened = fstatSync(descriptor);
     const current = lstatSync(path);
     if (
-      !isStrictPrivateFile(opened, allowedLinks) ||
-      !isStrictPrivateFile(current, allowedLinks) ||
+      !this.isPrivateFile(opened, allowedLinks) ||
+      !this.isPrivateFile(current, allowedLinks) ||
       !sameIdentity(identity(opened), identity(current))
     ) {
-      throw new UnsafeTranscriptTargetError();
+      throw this.unsafeTarget();
+    }
+    if (this.platform === "win32") {
+      assertWindowsPrivateFileBinding(
+        this.windowsDirectoryBinding!,
+        path,
+        windowsPrivatePathIdentity(opened),
+        allowedLinks,
+      );
     }
     this.assertDirectoryStable(directoryDescriptor);
   }
 
   private openedPathIsUnchanged(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     descriptor: number,
     path: string,
     before: Stats,
@@ -1273,22 +1529,49 @@ export class TranscriptStore implements TranscriptWriterPort {
       const opened = fstatSync(descriptor);
       const current = lstatSync(path);
       this.assertDirectoryStable(directoryDescriptor);
-      return (
-        isStrictPrivateFile(before) &&
-        isStrictPrivateFile(opened) &&
-        isStrictPrivateFile(current) &&
+      const unchanged =
+        this.isPrivateFile(before) &&
+        this.isPrivateFile(opened) &&
+        this.isPrivateFile(current) &&
         sameIdentity(identity(before), identity(opened)) &&
         sameIdentity(identity(opened), identity(current)) &&
         before.size === opened.size &&
         before.mtimeMs === opened.mtimeMs &&
-        before.ctimeMs === opened.ctimeMs
-      );
-    } catch {
+        before.ctimeMs === opened.ctimeMs;
+      if (unchanged && this.platform === "win32") {
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          path,
+          windowsPrivatePathIdentity(opened),
+        );
+      }
+      return unchanged;
+    } catch (error) {
+      if (this.platform === "win32") {
+        throw classifyWindowsPrivatePathFailure("binding-check", error);
+      }
       return false;
     }
   }
 
-  private withDirectory<T>(operation: (descriptor: number) => T): T {
+  private withDirectory<T>(
+    operation: (descriptor: DirectoryDescriptor) => T,
+    failureStage: WindowsPrivatePathPolicyStage = "read-check",
+  ): T {
+    if (this.platform === "win32") {
+      try {
+        this.assertDirectoryStable(null);
+        return operation(null);
+      } catch (error) {
+        if (
+          error instanceof WindowsPrivatePathPolicyError ||
+          (typeof error === "object" && error !== null && "code" in error)
+        ) {
+          throw classifyWindowsPrivatePathFailure(failureStage, error);
+        }
+        throw error;
+      }
+    }
     const beforeOpen = lstatSync(this.transcriptsDir);
     if (
       beforeOpen.isSymbolicLink() ||
@@ -1310,9 +1593,13 @@ export class TranscriptStore implements TranscriptWriterPort {
     }
   }
 
-  private assertDirectoryStable(descriptor: number): void {
+  private assertDirectoryStable(descriptor: DirectoryDescriptor): void {
+    if (this.platform === "win32") {
+      assertWindowsPrivateDirectoryStable(this.windowsDirectoryBinding!);
+      return;
+    }
     const pathStats = lstatSync(this.transcriptsDir);
-    const openedStats = fstatSync(descriptor);
+    const openedStats = fstatSync(descriptor!);
     if (
       pathStats.isSymbolicLink() ||
       !pathStats.isDirectory() ||
@@ -1327,6 +1614,10 @@ export class TranscriptStore implements TranscriptWriterPort {
   }
 
   private syncParentDirectory(dataDir: string): void {
+    if (this.platform === "win32") {
+      this.syncDirectory(null);
+      return;
+    }
     const descriptor = openSync(
       dataDir,
       constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
@@ -1339,11 +1630,20 @@ export class TranscriptStore implements TranscriptWriterPort {
   }
 
   private syncFile(descriptor: number): void {
-    (this.hooks.syncFile ?? fsyncSync)(descriptor);
+    try {
+      (this.hooks.syncFile ?? fsyncSync)(descriptor);
+    } catch (error) {
+      throw this.platform === "win32"
+        ? classifyWindowsPrivatePathFailure("file-flush", error)
+        : error;
+    }
   }
 
-  private syncDirectory(descriptor: number): void {
-    (this.hooks.syncDirectory ?? fsyncSync)(descriptor);
+  private syncDirectory(descriptor: DirectoryDescriptor): void {
+    if (this.platform === "win32") {
+      if (classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable") return;
+    }
+    (this.hooks.syncDirectory ?? fsyncSync)(descriptor!);
   }
 
   private writeComplete(descriptor: number, bytes: Buffer): void {
@@ -1358,31 +1658,31 @@ export class TranscriptStore implements TranscriptWriterPort {
       if (isMissing(error)) return;
       throw error;
     }
-    throw new UnsafeTranscriptTargetError();
+    throw this.unsafeTarget();
   }
 
   private assertIntentTarget(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     path: string,
     expected: ResetIntentRecord,
   ): void {
     const actual = this.readIntentPath(directoryDescriptor, path, expected.chatId);
     if (actual === null || JSON.stringify(actual) !== JSON.stringify(expected)) {
-      throw new UnsafeTranscriptTargetError();
+      throw this.unsafeTarget();
     }
   }
 
   private readIntentPath(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     path: string,
     expectedChatId?: string,
   ): ResetIntentRecord | null {
     const descriptor = this.openExistingFile(directoryDescriptor, path, constants.O_RDONLY, true);
     if (descriptor === null) return null;
     try {
-      const intent = parseResetIntent(readFileSync(descriptor));
+      const intent = parseResetIntent(this.readOpenedFile(directoryDescriptor, descriptor, path));
       if (intent === null || (expectedChatId !== undefined && intent.chatId !== expectedChatId)) {
-        throw new UnsafeTranscriptTargetError();
+        throw this.unsafeTarget();
       }
       this.assertOpenedFileSafe(descriptor);
       this.assertDirectoryStable(directoryDescriptor);
@@ -1392,12 +1692,12 @@ export class TranscriptStore implements TranscriptWriterPort {
     }
   }
 
-  private reconcileResetTemps(directoryDescriptor: number, onlyDigest?: string): void {
+  private reconcileResetTemps(directoryDescriptor: DirectoryDescriptor, onlyDigest?: string): void {
     const names = readdirSync(this.transcriptsDir);
     this.assertDirectoryStable(directoryDescriptor);
     for (const name of names) {
       if (name.endsWith(".reset-intent.tmp") && !INTENT_TEMP_PATTERN.test(name)) {
-        throw new UnsafeTranscriptTargetError();
+        throw this.unsafeTarget();
       }
       const match = INTENT_TEMP_PATTERN.exec(name);
       if (match === null || (onlyDigest !== undefined && match[1] !== onlyDigest)) continue;
@@ -1418,10 +1718,27 @@ export class TranscriptStore implements TranscriptWriterPort {
         false,
         allowedLinks,
       );
-      if (descriptor === null) throw new UnsafeTranscriptTargetError();
+      if (descriptor === null) throw this.unsafeTarget();
       if (targetStats === null) {
-        closeSync(descriptor);
-        if (allowedLinks !== 1) throw new UnsafeTranscriptTargetError();
+        if (this.platform === "win32") {
+          try {
+            const intent = parseResetIntent(
+              this.readOpenedFile(directoryDescriptor, descriptor, tempPath, allowedLinks),
+            );
+            if (
+              intent === null ||
+              this.chatDigest(intent.chatId) !== match[1] ||
+              intent.resetId !== match[2]
+            ) {
+              throw this.unsafeTarget();
+            }
+          } finally {
+            closeSync(descriptor);
+          }
+        } else {
+          closeSync(descriptor);
+        }
+        if (allowedLinks !== 1) throw this.unsafeTarget();
         this.unlinkPrivateFileIfPresent(directoryDescriptor, tempPath, 1);
         continue;
       }
@@ -1429,19 +1746,29 @@ export class TranscriptStore implements TranscriptWriterPort {
         const tempStats = lstatSync(tempPath);
         if (
           allowedLinks !== 2 ||
-          !isStrictPrivateFile(tempStats, 2) ||
-          !isStrictPrivateFile(targetStats, 2) ||
+          !this.isPrivateFile(tempStats, 2) ||
+          !this.isPrivateFile(targetStats, 2) ||
           !sameIdentity(identity(tempStats), identity(targetStats))
         ) {
-          throw new UnsafeTranscriptTargetError();
+          throw this.unsafeTarget();
         }
-        const intent = parseResetIntent(readFileSync(descriptor));
+        if (this.platform === "win32") {
+          assertWindowsPrivateFileBinding(
+            this.windowsDirectoryBinding!,
+            targetPath,
+            windowsPrivatePathIdentity(targetStats),
+            2,
+          );
+        }
+        const intent = parseResetIntent(
+          this.readOpenedFile(directoryDescriptor, descriptor, tempPath, allowedLinks),
+        );
         if (
           intent === null ||
           this.chatDigest(intent.chatId) !== match[1] ||
           intent.resetId !== match[2]
         ) {
-          throw new UnsafeTranscriptTargetError();
+          throw this.unsafeTarget();
         }
       } finally {
         closeSync(descriptor);
@@ -1451,7 +1778,7 @@ export class TranscriptStore implements TranscriptWriterPort {
   }
 
   private unlinkMatchingTemp(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     tempPath: string,
     targetPath: string,
   ): void {
@@ -1464,19 +1791,33 @@ export class TranscriptStore implements TranscriptWriterPort {
     }
     const targetStats = lstatSync(targetPath);
     if (
-      !isStrictPrivateFile(tempStats, 2) ||
-      !isStrictPrivateFile(targetStats, 2) ||
+      !this.isPrivateFile(tempStats, 2) ||
+      !this.isPrivateFile(targetStats, 2) ||
       !sameIdentity(identity(tempStats), identity(targetStats))
     ) {
-      throw new UnsafeTranscriptTargetError();
+      throw this.unsafeTarget();
+    }
+    if (this.platform === "win32") {
+      assertWindowsPrivateFileBinding(
+        this.windowsDirectoryBinding!,
+        tempPath,
+        windowsPrivatePathIdentity(tempStats),
+        2,
+      );
+      assertWindowsPrivateFileBinding(
+        this.windowsDirectoryBinding!,
+        targetPath,
+        windowsPrivatePathIdentity(targetStats),
+        2,
+      );
     }
     this.assertDirectoryStable(directoryDescriptor);
-    unlinkSync(tempPath);
+    this.unlinkPath(tempPath);
     this.syncDirectory(directoryDescriptor);
   }
 
   private unlinkPrivateFileIfPresent(
-    directoryDescriptor: number,
+    directoryDescriptor: DirectoryDescriptor,
     path: string,
     links: 1 | 2,
   ): void {
@@ -1487,12 +1828,28 @@ export class TranscriptStore implements TranscriptWriterPort {
       if (isMissing(error)) return;
       throw error;
     }
-    if (stats.isSymbolicLink() || !isStrictPrivateFile(stats, links)) {
-      throw new UnsafeTranscriptTargetError();
+    if (!this.isPrivateFile(stats, links)) {
+      throw this.unsafeTarget();
+    }
+    if (this.platform === "win32") {
+      assertWindowsPrivateFileBinding(
+        this.windowsDirectoryBinding!,
+        path,
+        windowsPrivatePathIdentity(stats),
+        links,
+      );
     }
     this.assertDirectoryStable(directoryDescriptor);
-    unlinkSync(path);
+    this.unlinkPath(path);
     this.syncDirectory(directoryDescriptor);
+  }
+
+  private unlinkPath(path: string): void {
+    try {
+      unlinkSync(path);
+    } catch (error) {
+      throw this.platform === "win32" ? classifyWindowsPrivatePathFailure("rename", error) : error;
+    }
   }
 
   private transcriptPath(chatId: string): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,6 +124,7 @@ export { ChatStore } from "./agent/chat-store.js";
 export {
   ConversationRecoveryError,
   createConversationStore,
+  type ConversationStoreOptions,
   type ConversationStorePort,
 } from "./agent/conversation-store.js";
 export {
@@ -140,6 +141,22 @@ export type {
   TranscriptPageResult,
   TranscriptPageTurn,
 } from "./agent/transcript-store.js";
+export {
+  WindowsPrivatePathPolicyError,
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivateFileBinding,
+  assertWindowsPrivateFileMetadata,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathFailure,
+  sameWindowsPrivatePathIdentity,
+  windowsPrivatePathIdentity,
+} from "./io/windows-private-path-policy.js";
+export type {
+  WindowsPrivateDirectoryBinding,
+  WindowsPrivatePathIdentity,
+  WindowsPrivatePathPolicyStage,
+} from "./io/windows-private-path-policy.js";
 export { engineConfigFromConfig } from "./agent/engine-host-adapter.js";
 export { classifyFailure, extractRetryAfterMs } from "./agent/token-utils.js";
 export {

--- a/packages/core/src/io/windows-private-path-policy.ts
+++ b/packages/core/src/io/windows-private-path-policy.ts
@@ -1,8 +1,12 @@
+import { lstatSync, realpathSync, type Stats } from "node:fs";
+import { dirname } from "node:path";
 import {
   classifyPrivatePathDurability,
   classifyPrivatePathErrorCode,
+  decidePrivatePathBinding,
   decidePrivatePathEntry,
   decidePrivatePathRead,
+  type PrivatePathBindingDecisionInput,
   type PrivatePathDurabilityClassification,
   type PrivatePathDurabilityStage,
   type PrivatePathEntryDecisionInput,
@@ -13,8 +17,21 @@ import {
 
 export type WindowsPrivatePathPolicyStage =
   | Exclude<PrivatePathDurabilityStage, "directory-sync">
+  | "binding-check"
   | "entry-check"
   | "read-check";
+
+export interface WindowsPrivatePathIdentity {
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+}
+
+export interface WindowsPrivateDirectoryBinding {
+  readonly path: string;
+  readonly parentPath: string;
+  readonly identity: WindowsPrivatePathIdentity;
+  readonly parentIdentity: WindowsPrivatePathIdentity;
+}
 
 export class WindowsPrivatePathPolicyError extends Error {
   override readonly name = "WindowsPrivatePathPolicyError";
@@ -59,6 +76,136 @@ export function assertWindowsPrivatePathEntry(input: PrivatePathEntryDecisionInp
   assertDecision("entry-check", decidePrivatePathEntry(input));
 }
 
+export function assertWindowsPrivatePathBinding(input: PrivatePathBindingDecisionInput): void {
+  assertDecision("binding-check", decidePrivatePathBinding(input));
+}
+
 export function assertWindowsPrivatePathRead(input: PrivatePathReadDecisionInput): void {
   assertDecision("read-check", decidePrivatePathRead(input));
+}
+
+export function windowsPrivatePathIdentity(metadata: Stats): WindowsPrivatePathIdentity {
+  return { dev: metadata.dev, ino: metadata.ino };
+}
+
+export function sameWindowsPrivatePathIdentity(
+  left: WindowsPrivatePathIdentity,
+  right: WindowsPrivatePathIdentity,
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function entryType(metadata: Stats): PrivatePathEntryDecisionInput["actualType"] {
+  if (metadata.isFile()) return "file";
+  if (metadata.isDirectory()) return "directory";
+  return "other";
+}
+
+function assertDirectoryEntry(metadata: Stats): void {
+  assertWindowsPrivatePathEntry({
+    expectedType: "directory",
+    actualType: entryType(metadata),
+    linkOrReparseShaped: metadata.isSymbolicLink(),
+  });
+}
+
+export function assertWindowsPrivateFileMetadata(metadata: Stats, allowedLinks: 1 | 2 = 1): void {
+  assertWindowsPrivatePathEntry({
+    expectedType: "file",
+    actualType: entryType(metadata),
+    linkOrReparseShaped: metadata.isSymbolicLink(),
+  });
+  assertWindowsPrivatePathBinding({
+    identityStable: true,
+    authenticatedHomeBinding: metadata.nlink === allowedLinks,
+  });
+}
+
+function observeDirectoryBinding(parentPath: string, path: string): WindowsPrivateDirectoryBinding {
+  const parentBefore = lstatSync(parentPath);
+  const parentPhysicalPath = realpathSync(parentPath);
+  const parentPhysical = lstatSync(parentPhysicalPath);
+  const parentAfter = lstatSync(parentPath);
+  const before = lstatSync(path);
+  const physicalPath = realpathSync(path);
+  const physical = lstatSync(physicalPath);
+  const after = lstatSync(path);
+  const physicalParent = lstatSync(dirname(physicalPath));
+  for (const metadata of [parentBefore, parentPhysical, parentAfter, before, physical, after]) {
+    assertDirectoryEntry(metadata);
+  }
+  assertDirectoryEntry(physicalParent);
+  const parentIdentity = windowsPrivatePathIdentity(parentBefore);
+  const pathIdentity = windowsPrivatePathIdentity(before);
+  assertWindowsPrivatePathBinding({
+    identityStable:
+      sameWindowsPrivatePathIdentity(parentIdentity, windowsPrivatePathIdentity(parentPhysical)) &&
+      sameWindowsPrivatePathIdentity(parentIdentity, windowsPrivatePathIdentity(parentAfter)) &&
+      sameWindowsPrivatePathIdentity(pathIdentity, windowsPrivatePathIdentity(physical)) &&
+      sameWindowsPrivatePathIdentity(pathIdentity, windowsPrivatePathIdentity(after)),
+    authenticatedHomeBinding: sameWindowsPrivatePathIdentity(
+      parentIdentity,
+      windowsPrivatePathIdentity(physicalParent),
+    ),
+  });
+  return { path, parentPath, identity: pathIdentity, parentIdentity };
+}
+
+export function bindWindowsPrivateDirectory(
+  parentPath: string,
+  path: string,
+): WindowsPrivateDirectoryBinding {
+  try {
+    return observeDirectoryBinding(parentPath, path);
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure("binding-check", error);
+  }
+}
+
+export function assertWindowsPrivateDirectoryStable(binding: WindowsPrivateDirectoryBinding): void {
+  try {
+    const observed = observeDirectoryBinding(binding.parentPath, binding.path);
+    assertWindowsPrivatePathBinding({
+      identityStable:
+        sameWindowsPrivatePathIdentity(binding.identity, observed.identity) &&
+        sameWindowsPrivatePathIdentity(binding.parentIdentity, observed.parentIdentity),
+      authenticatedHomeBinding: true,
+    });
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure("binding-check", error);
+  }
+}
+
+export function assertWindowsPrivateFileBinding(
+  directory: WindowsPrivateDirectoryBinding,
+  path: string,
+  expectedIdentity: WindowsPrivatePathIdentity,
+  allowedLinks: 1 | 2 = 1,
+): Stats {
+  try {
+    assertWindowsPrivateDirectoryStable(directory);
+    const before = lstatSync(path);
+    const physicalPath = realpathSync(path);
+    const physical = lstatSync(physicalPath);
+    const after = lstatSync(path);
+    const physicalParent = lstatSync(dirname(physicalPath));
+    assertWindowsPrivateFileMetadata(before, allowedLinks);
+    assertWindowsPrivateFileMetadata(physical, allowedLinks);
+    assertWindowsPrivateFileMetadata(after, allowedLinks);
+    assertDirectoryEntry(physicalParent);
+    assertWindowsPrivatePathBinding({
+      identityStable:
+        sameWindowsPrivatePathIdentity(expectedIdentity, windowsPrivatePathIdentity(before)) &&
+        sameWindowsPrivatePathIdentity(expectedIdentity, windowsPrivatePathIdentity(physical)) &&
+        sameWindowsPrivatePathIdentity(expectedIdentity, windowsPrivatePathIdentity(after)),
+      authenticatedHomeBinding: sameWindowsPrivatePathIdentity(
+        directory.identity,
+        windowsPrivatePathIdentity(physicalParent),
+      ),
+    });
+    assertWindowsPrivateDirectoryStable(directory);
+    return after;
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure("binding-check", error);
+  }
 }

--- a/packages/core/tests/chat-store.test.ts
+++ b/packages/core/tests/chat-store.test.ts
@@ -1,22 +1,34 @@
+import { createHash } from "node:crypto";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   chmodSync,
   existsSync,
+  fsyncSync,
   linkSync,
   lstatSync,
   mkdtempSync,
   mkdirSync,
   readdirSync,
   readFileSync,
+  readSync,
   renameSync,
   rmSync,
   statSync,
   symlinkSync,
+  truncateSync,
   writeFileSync,
+  writeSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { archiveAndResetDurably, ChatStore, TURN_FAILURE_MARKER } from "../src/agent/chat-store.js";
+import { basename, join } from "node:path";
+import {
+  archiveAndResetDurably,
+  ChatStore,
+  createChatStoreWithHooks,
+  MAX_CHAT_SESSION_BYTES,
+  TURN_FAILURE_MARKER,
+} from "../src/agent/chat-store.js";
+import { WindowsPrivatePathPolicyError } from "../src/io/windows-private-path-policy.js";
 import { makeSummaryMessage } from "@enduragent/engine";
 
 // ESM module namespaces are non-configurable, so vi.spyOn cannot intercept a
@@ -79,6 +91,17 @@ function durableArchivePath(chatId: string): string {
     sessionsDir,
     `${chatId}.jsonl.reset.${DURABLE_RESET.boundaryAt.replace(/:/g, "-")}.${DURABLE_RESET.resetId}`,
   );
+}
+
+function windowsSessionPath(chatId: string): string {
+  const digest = createHash("sha256").update(chatId, "utf8").digest("hex");
+  return join(sessionsDir, `${digest}.jsonl`);
+}
+
+function windowsDurableArchivePath(chatId: string): string {
+  return `${windowsSessionPath(chatId)}.reset.${DURABLE_RESET.boundaryAt.replace(/:/g, "-")}.${
+    DURABLE_RESET.resetId
+  }`;
 }
 
 function listArchives(chatId: string): string[] {
@@ -174,6 +197,255 @@ describe("ChatStore — on-disk permissions", () => {
 
     expect(() => new ChatStore(dataDir)).toThrow("Sessions directory is unsafe.");
     expect(lstatSync(sessionsDir).isFile()).toBe(true);
+  });
+});
+
+describe("ChatStore — Windows private paths", () => {
+  it("persists and reopens a session through injected Windows semantics", () => {
+    const chatId = "telegram:synthetic-restart";
+    const first = new ChatStore(dataDir, 0, { platform: "win32" });
+    first.appendTurn(chatId, "synthetic athlete", "synthetic coach", LINEAGE);
+    first.archivePreCompact(chatId);
+
+    const reopened = new ChatStore(dataDir, 0, { platform: "win32" });
+
+    expect(reopened.load(chatId).messages).toEqual([
+      { role: "user", content: "synthetic athlete" },
+      { role: "assistant", content: "synthetic coach" },
+    ]);
+    expect(readdirSync(sessionsDir)).toHaveLength(2);
+    expect(
+      readdirSync(sessionsDir).every((name) => /^[a-f0-9]{64}\.jsonl(?:\.|$)/.test(name)),
+    ).toBe(true);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "does not inspect or repair POSIX modes under injected Windows semantics",
+    () => {
+      mkdirSync(sessionsDir, { mode: 0o755 });
+      chmodSync(sessionsDir, 0o755);
+      const path = windowsSessionPath("mode");
+      writeFileSync(
+        path,
+        '{"role":"user","content":"synthetic","ts":"2026-07-22T00:00:00.000Z"}\n',
+        { mode: 0o644 },
+      );
+      chmodSync(path, 0o644);
+
+      const store = new ChatStore(dataDir, 0, { platform: "win32" });
+
+      expect(store.load("mode").messages).toEqual([{ role: "user", content: "synthetic" }]);
+      expect(lstatSync(sessionsDir).mode & 0o7777).toBe(0o755);
+      expect(lstatSync(path).mode & 0o7777).toBe(0o644);
+    },
+  );
+
+  it("rejects a replaced sessions directory as path-free corruption", () => {
+    const store = new ChatStore(dataDir, 0, { platform: "win32" });
+    store.appendTurn("directory-swap", "synthetic athlete", "synthetic coach", LINEAGE);
+    const original = `${sessionsDir}.original`;
+    renameSync(sessionsDir, original);
+    mkdirSync(sessionsDir, { mode: 0o700 });
+
+    let failure: unknown;
+    try {
+      store.load("directory-swap");
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "binding-check", category: "corruption" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(sessionsDir);
+    expect(JSON.stringify(failure)).not.toContain(sessionsDir);
+    expect(existsSync(join(original, basename(windowsSessionPath("directory-swap"))))).toBe(true);
+  });
+
+  it("rejects an oversized Windows session before allocating its contents", () => {
+    const chatId = "telegram:synthetic-oversized";
+    const store = new ChatStore(dataDir, 0, { platform: "win32" });
+    store.appendTurn(chatId, "synthetic athlete", "synthetic coach", LINEAGE);
+    const path = windowsSessionPath(chatId);
+    truncateSync(path, MAX_CHAT_SESSION_BYTES + 1);
+
+    let failure: unknown;
+    try {
+      store.load(chatId);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(path);
+    expect(JSON.stringify(failure)).not.toContain(path);
+    expect(lstatSync(path).size).toBe(MAX_CHAT_SESSION_BYTES + 1);
+  });
+
+  it("rejects malformed Windows session content without quarantining or rewriting it", () => {
+    const chatId = "telegram:synthetic-corrupt";
+    const store = new ChatStore(dataDir, 0, { platform: "win32" });
+    const path = windowsSessionPath(chatId);
+    const corrupt = '{"role":"user","content":}\n';
+    writeFileSync(path, corrupt, { mode: 0o600 });
+
+    let loadFailure: unknown;
+    try {
+      store.load(chatId);
+    } catch (error) {
+      loadFailure = error;
+    }
+    let appendFailure: unknown;
+    try {
+      store.appendTurn(chatId, "synthetic athlete", "synthetic coach", LINEAGE);
+    } catch (error) {
+      appendFailure = error;
+    }
+
+    for (const failure of [loadFailure, appendFailure]) {
+      expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+      expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+      expect(failure).not.toHaveProperty("path");
+      expect(failure).not.toHaveProperty("cause");
+      expect(String(failure)).not.toContain(path);
+      expect(JSON.stringify(failure)).not.toContain(path);
+    }
+    expect(readFileSync(path, "utf8")).toBe(corrupt);
+    expect(readdirSync(sessionsDir)).toEqual([basename(path)]);
+  });
+
+  it("classifies directory sync as unavailable while retaining file flushes", () => {
+    const syncDirectory = vi.fn(() => {
+      throw new Error("Windows directory sync hook must not run");
+    });
+    const syncFile = vi.fn((descriptor: number) => fsyncSync(descriptor));
+    const store = createChatStoreWithHooks(
+      dataDir,
+      0,
+      { syncDirectory, syncFile },
+      { platform: "win32" },
+    );
+    store.appendTurn("durable", "synthetic athlete", "synthetic coach", LINEAGE);
+
+    archiveAndResetDurably(store, "durable", DURABLE_RESET);
+
+    expect(syncDirectory).not.toHaveBeenCalled();
+    expect(syncFile).toHaveBeenCalledTimes(2);
+    expect(existsSync(windowsDurableArchivePath("durable"))).toBe(true);
+  });
+
+  it("opens copied and reset session targets with writable Windows flush handles", () => {
+    let syncs = 0;
+    const store = createChatStoreWithHooks(
+      dataDir,
+      0,
+      {
+        syncFile: (descriptor) => {
+          syncs += 1;
+          if (syncs > 1) {
+            const firstByte = Buffer.allocUnsafe(1);
+            expect(readSync(descriptor, firstByte, 0, 1, 0)).toBe(1);
+            expect(writeSync(descriptor, firstByte, 0, 1, 0)).toBe(1);
+          }
+          fsyncSync(descriptor);
+        },
+      },
+      { platform: "win32" },
+    );
+    store.appendTurn("writable-flush", "synthetic athlete", "synthetic coach", LINEAGE);
+
+    store.archivePreCompact("writable-flush");
+    archiveAndResetDurably(store, "writable-flush", DURABLE_RESET);
+
+    expect(syncs).toBe(3);
+    expect(existsSync(windowsDurableArchivePath("writable-flush"))).toBe(true);
+  });
+
+  it("rejects a hardlinked active session as path-free corruption", () => {
+    const store = new ChatStore(dataDir, 0, { platform: "win32" });
+    store.appendTurn("linked", "synthetic athlete", "synthetic coach", LINEAGE);
+    const active = windowsSessionPath("linked");
+    linkSync(active, join(dataDir, "synthetic-shared-session.jsonl"));
+
+    let failure: unknown;
+    try {
+      archiveAndResetDurably(store, "linked", DURABLE_RESET);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "binding-check", category: "corruption" });
+    expect(String(failure)).not.toContain(active);
+    expect(JSON.stringify(failure)).not.toContain(active);
+  });
+
+  it("does not swallow a Windows sharing violation during file flush", () => {
+    const active = windowsSessionPath("locked");
+    let syncs = 0;
+    const store = createChatStoreWithHooks(
+      dataDir,
+      0,
+      {
+        syncFile: (descriptor) => {
+          syncs += 1;
+          if (syncs === 2) {
+            throw Object.assign(new Error(`locked ${active}`), { code: "EACCES", path: active });
+          }
+          fsyncSync(descriptor);
+        },
+      },
+      { platform: "win32" },
+    );
+    store.appendTurn("locked", "synthetic athlete", "synthetic coach", LINEAGE);
+
+    let failure: unknown;
+    try {
+      archiveAndResetDurably(store, "locked", DURABLE_RESET);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "file-flush", category: "sharing-violation" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(active);
+    expect(JSON.stringify(failure)).not.toContain(active);
+  });
+
+  it("does not swallow a Windows sharing violation during archive rename", () => {
+    const active = windowsSessionPath("rename-locked");
+    const store = createChatStoreWithHooks(
+      dataDir,
+      0,
+      {
+        rename: () => {
+          throw Object.assign(new Error(`locked ${active}`), { code: "EACCES", path: active });
+        },
+      },
+      { platform: "win32" },
+    );
+    store.appendTurn("rename-locked", "synthetic athlete", "synthetic coach", LINEAGE);
+
+    let failure: unknown;
+    try {
+      store.archiveAndReset("rename-locked");
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "rename", category: "sharing-violation" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(active);
+    expect(JSON.stringify(failure)).not.toContain(active);
+    expect(existsSync(active)).toBe(true);
   });
 });
 

--- a/packages/core/tests/conversation-store.test.ts
+++ b/packages/core/tests/conversation-store.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../src/agent/chat-store.js";
 import { ConversationRecoveryError, ConversationStore } from "../src/agent/conversation-store.js";
 import { TranscriptStore, type ResetIntentRecord } from "../src/agent/transcript-store.js";
+import { WindowsPrivatePathPolicyError } from "../src/io/windows-private-path-policy.js";
 
 const roots: string[] = [];
 const RESET_ID = "c".repeat(64);
@@ -73,6 +74,18 @@ function seedSession(store: ChatStore, chatId: string): void {
 function resetArchives(dataDir: string, chatId: string): string[] {
   return readdirSync(join(dataDir, "sessions")).filter((name) =>
     name.startsWith(`${chatId}.jsonl.reset.`),
+  );
+}
+
+function windowsSessionPath(dataDir: string, chatId: string): string {
+  const digest = createHash("sha256").update(chatId, "utf8").digest("hex");
+  return join(dataDir, "sessions", `${digest}.jsonl`);
+}
+
+function windowsResetArchives(dataDir: string, chatId: string): string[] {
+  const digest = createHash("sha256").update(chatId, "utf8").digest("hex");
+  return readdirSync(join(dataDir, "sessions")).filter((name) =>
+    name.startsWith(`${digest}.jsonl.reset.`),
   );
 }
 
@@ -745,5 +758,94 @@ describe("ConversationStore reset transaction recovery", () => {
     expect(() => store.readCurrentConversation(reset.chatId)).toThrow(ConversationRecoveryError);
     expect(chat.hasSession(reset.chatId)).toBe(true);
     expect(boundaryCount(dataDir, reset.chatId)).toBe(0);
+  });
+});
+
+describe("ConversationStore Windows restart recovery", () => {
+  it("reopens completed archives without changing the recovered conversation", () => {
+    const dataDir = makeDataDir();
+    const chatId = "telegram:synthetic-windows-restart";
+    const first = new ConversationStore(
+      new ChatStore(dataDir, 0, { platform: "win32" }),
+      new TranscriptStore(dataDir, { platform: "win32" }),
+      () => RESET_ID,
+    );
+    first.appendTurn(chatId, "synthetic athlete", "synthetic coach", LINEAGE);
+    first.appendCompletedTurn({
+      chatId,
+      turnId: "turn-1",
+      completedAt: "2026-07-22T00:00:00.000Z",
+      athleteText: "synthetic athlete",
+      coachText: "synthetic coach",
+    });
+    first.resetConversation({
+      chatId,
+      boundaryAt: "2026-07-22T01:02:03.000Z",
+      reason: "explicit-reset",
+    });
+
+    const reopened = new ConversationStore(
+      new ChatStore(dataDir, 0, { platform: "win32" }),
+      new TranscriptStore(dataDir, { platform: "win32" }),
+    );
+
+    expect(reopened.hasSession(chatId)).toBe(false);
+    expect(reopened.listArchivedConversations(chatId)).toEqual({
+      schemaVersion: 1,
+      conversations: [
+        {
+          boundaryRef: RESET_ID,
+          boundaryAt: "2026-07-22T01:02:03.000Z",
+          reason: "explicit-reset",
+          turnCount: 1,
+        },
+      ],
+      truncated: false,
+    });
+    expect(
+      reopened
+        .readArchivedConversationPage(chatId, RESET_ID, { cursor: null, limit: 25 })
+        .turns.map((record) => record.turnId),
+    ).toEqual(["turn-1"]);
+  });
+
+  it("keeps corrupt recovery scoped to its chat and completes an unrelated intent", () => {
+    const dataDir = makeDataDir();
+    const chat = new ChatStore(dataDir, 0, { platform: "win32" });
+    const transcript = new TranscriptStore(dataDir, { platform: "win32" });
+    const corrupt = resetIntent("telegram:synthetic-windows-corrupt", "a".repeat(64));
+    const unrelated = resetIntent("telegram:synthetic-windows-unrelated", "b".repeat(64));
+    seedSession(chat, corrupt.chatId);
+    seedSession(chat, unrelated.chatId);
+    transcript.createResetIntent(corrupt);
+    transcript.createResetIntent(unrelated);
+    const corruptActive = windowsSessionPath(dataDir, corrupt.chatId);
+    linkSync(corruptActive, join(dataDir, "synthetic-shared-session.jsonl"));
+
+    const recovered = new ConversationStore(chat, transcript);
+
+    let failure: unknown;
+    try {
+      recovered.load(corrupt.chatId);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(ConversationRecoveryError);
+    expect((failure as Error & { cause?: unknown }).cause).toBeInstanceOf(
+      WindowsPrivatePathPolicyError,
+    );
+    expect((failure as Error & { cause?: unknown }).cause).toMatchObject({
+      stage: "binding-check",
+      category: "corruption",
+    });
+    expect(String(failure)).not.toContain(corruptActive);
+    expect(JSON.stringify(failure)).not.toContain(corruptActive);
+    expect(existsSync(corruptActive)).toBe(true);
+    expect(existsSync(intentPath(dataDir, corrupt.chatId))).toBe(true);
+    expect(windowsResetArchives(dataDir, corrupt.chatId)).toHaveLength(0);
+    expect(recovered.hasSession(unrelated.chatId)).toBe(false);
+    expect(existsSync(intentPath(dataDir, unrelated.chatId))).toBe(false);
+    expect(windowsResetArchives(dataDir, unrelated.chatId)).toHaveLength(1);
   });
 });

--- a/packages/core/tests/transcript-store.test.ts
+++ b/packages/core/tests/transcript-store.test.ts
@@ -11,8 +11,10 @@ import {
   readFileSync,
   readdirSync,
   renameSync,
+  readSync,
   rmSync,
   symlinkSync,
+  truncateSync,
   writeFileSync,
   writeSync,
 } from "node:fs";
@@ -21,6 +23,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   MAX_ARCHIVED_CONVERSATION_ENTRIES,
+  MAX_TRANSCRIPT_FILE_BYTES,
   MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES,
   MAX_TRANSCRIPT_PAGE_TURNS,
   MAX_TRANSCRIPT_RECORD_BYTES,
@@ -29,6 +32,7 @@ import {
   UnsafeTranscriptTargetError,
   type ResetIntentRecord,
 } from "../src/agent/transcript-store.js";
+import { WindowsPrivatePathPolicyError } from "../src/io/windows-private-path-policy.js";
 
 const roots: string[] = [];
 const RESET_ID_A = "a".repeat(64);
@@ -1087,5 +1091,295 @@ describe("TranscriptStore private race-checked targets", () => {
     linkSync(intentPath(dataDir, reset.chatId), join(dataDir, "shared-intent.json"));
 
     expect(() => store.readResetIntent(reset.chatId)).toThrow(UnsafeTranscriptTargetError);
+  });
+});
+
+describe("TranscriptStore Windows private paths", () => {
+  it("persists and reopens transcript records through injected Windows semantics", () => {
+    const dataDir = makeDataDir();
+    const first = new TranscriptStore(dataDir, { platform: "win32" });
+    first.appendCompletedTurn(turn("restart", "turn-1"));
+
+    const reopened = new TranscriptStore(dataDir, { platform: "win32" });
+
+    expect(reopened.readCurrentConversation("restart").map((record) => record.turnId)).toEqual([
+      "turn-1",
+    ]);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "does not inspect or repair POSIX modes under injected Windows semantics",
+    () => {
+      const dataDir = makeDataDir();
+      const directory = join(dataDir, "transcripts");
+      mkdirSync(directory, { mode: 0o755 });
+      chmodSync(directory, 0o755);
+      const path = transcriptPath(dataDir, "mode");
+      writeFileSync(path, serializedTurn(turn("mode", "turn-1")), { mode: 0o644 });
+      chmodSync(path, 0o644);
+
+      const store = new TranscriptStore(dataDir, { platform: "win32" });
+
+      expect(store.readCurrentConversation("mode").map((record) => record.turnId)).toEqual([
+        "turn-1",
+      ]);
+      expect(lstatSync(directory).mode & 0o7777).toBe(0o755);
+      expect(lstatSync(path).mode & 0o7777).toBe(0o644);
+    },
+  );
+
+  it("rejects a replaced transcript directory as path-free corruption", () => {
+    const dataDir = makeDataDir();
+    const store = new TranscriptStore(dataDir, { platform: "win32" });
+    store.appendCompletedTurn(turn("directory-swap", "turn-1"));
+    const directory = join(dataDir, "transcripts");
+    renameSync(directory, `${directory}.original`);
+    mkdirSync(directory, { mode: 0o700 });
+
+    let failure: unknown;
+    try {
+      store.readCurrentConversation("directory-swap");
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "binding-check", category: "corruption" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(directory);
+    expect(JSON.stringify(failure)).not.toContain(directory);
+  });
+
+  it("classifies an incomplete Windows content write without swallowing it", () => {
+    const dataDir = makeDataDir();
+    const path = transcriptPath(dataDir, "short-write");
+    const store = new TranscriptStore(dataDir, {
+      platform: "win32",
+      write: () => 0,
+    });
+
+    let failure: unknown;
+    try {
+      store.appendCompletedTurn(turn("short-write", "turn-1"));
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "content-write", category: "io-failure" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(path);
+    expect(JSON.stringify(failure)).not.toContain(path);
+  });
+
+  it("rejects an oversized Windows transcript before allocating its contents", () => {
+    const dataDir = makeDataDir();
+    const chatId = "oversized";
+    const store = new TranscriptStore(dataDir, { platform: "win32" });
+    store.appendCompletedTurn(turn(chatId, "turn-1"));
+    const path = transcriptPath(dataDir, chatId);
+    truncateSync(path, MAX_TRANSCRIPT_FILE_BYTES + 1);
+
+    let failure: unknown;
+    try {
+      store.readCurrentConversation(chatId);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(path);
+    expect(JSON.stringify(failure)).not.toContain(path);
+    expect(lstatSync(path).size).toBe(MAX_TRANSCRIPT_FILE_BYTES + 1);
+  });
+
+  it("rejects malformed Windows transcript content without appending to it", () => {
+    const dataDir = makeDataDir();
+    const chatId = "corrupt-transcript";
+    const store = new TranscriptStore(dataDir, { platform: "win32" });
+    const path = transcriptPath(dataDir, chatId);
+    const corrupt = "{not-valid-json}\n";
+    writeFileSync(path, corrupt, { mode: 0o600 });
+
+    let readFailure: unknown;
+    try {
+      store.readCurrentConversation(chatId);
+    } catch (error) {
+      readFailure = error;
+    }
+    let appendFailure: unknown;
+    try {
+      store.appendCompletedTurn(turn(chatId, "turn-1"));
+    } catch (error) {
+      appendFailure = error;
+    }
+
+    expect(readFailure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(readFailure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect(appendFailure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(appendFailure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect(String(readFailure)).not.toContain(path);
+    expect(String(appendFailure)).not.toContain(path);
+    expect(readFileSync(path, "utf8")).toBe(corrupt);
+  });
+
+  it("rejects duplicate Windows reset boundaries on every transcript read", () => {
+    const dataDir = makeDataDir();
+    const chatId = "duplicate-boundary";
+    const store = new TranscriptStore(dataDir, { platform: "win32" });
+    const reset = intent(chatId);
+    const boundary = `${JSON.stringify({
+      version: 1,
+      kind: "conversation-boundary",
+      resetId: reset.resetId,
+      chatId,
+      boundaryAt: reset.boundaryAt,
+      reason: reset.reason,
+    })}\n`;
+    const path = transcriptPath(dataDir, chatId);
+    writeFileSync(path, boundary + boundary, { mode: 0o600 });
+
+    let failure: unknown;
+    try {
+      store.readCurrentConversation(chatId);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(path);
+    expect(JSON.stringify(failure)).not.toContain(path);
+    expect(readFileSync(path, "utf8")).toBe(boundary + boundary);
+  });
+
+  it("classifies directory sync as unavailable while retaining file flushes", () => {
+    const dataDir = makeDataDir();
+    let directorySyncs = 0;
+    let fileSyncs = 0;
+    const store = new TranscriptStore(dataDir, {
+      platform: "win32",
+      syncDirectory: () => {
+        directorySyncs += 1;
+        throw new Error("Windows directory sync hook must not run");
+      },
+      syncFile: (descriptor) => {
+        fileSyncs += 1;
+        fsyncSync(descriptor);
+      },
+    });
+
+    store.appendCompletedTurn(turn("durable", "turn-1"));
+
+    expect(directorySyncs).toBe(0);
+    expect(fileSyncs).toBe(1);
+    expect(
+      new TranscriptStore(dataDir, { platform: "win32" })
+        .readCurrentConversation("durable")
+        .map((record) => record.turnId),
+    ).toEqual(["turn-1"]);
+  });
+
+  it("reopens an existing boundary with a writable Windows flush handle", () => {
+    const dataDir = makeDataDir();
+    const reset = intent("writable-flush");
+    const first = new TranscriptStore(dataDir, { platform: "win32" });
+    first.appendCompletedTurn(turn(reset.chatId, "turn-1"));
+    first.createResetIntent(reset);
+    first.ensureConversationBoundary(reset);
+    let syncs = 0;
+    const reopened = new TranscriptStore(dataDir, {
+      platform: "win32",
+      syncFile: (descriptor) => {
+        syncs += 1;
+        const firstByte = Buffer.allocUnsafe(1);
+        expect(readSync(descriptor, firstByte, 0, 1, 0)).toBe(1);
+        expect(writeSync(descriptor, firstByte, 0, 1, 0)).toBe(1);
+        fsyncSync(descriptor);
+      },
+    });
+
+    reopened.ensureConversationBoundary(reset);
+
+    expect(syncs).toBe(1);
+    expect(reopened.hasConversationBoundary(reset.chatId, reset.resetId)).toBe(true);
+  });
+
+  it("rejects malformed reset state as path-free corruption", () => {
+    const dataDir = makeDataDir();
+    const store = new TranscriptStore(dataDir, { platform: "win32" });
+    const path = intentPath(dataDir, "corrupt-intent");
+    writeFileSync(path, "{not-valid-json}\n", { mode: 0o644 });
+
+    let failure: unknown;
+    try {
+      store.readResetIntent("corrupt-intent");
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(path);
+    expect(JSON.stringify(failure)).not.toContain(path);
+    expect(readFileSync(path, "utf8")).toBe("{not-valid-json}\n");
+  });
+
+  it("rejects a malformed orphan reset temp without deleting it during recovery", () => {
+    const dataDir = makeDataDir();
+    const reset = intent("corrupt-orphan-temp");
+    const digest = createHash("sha256").update(reset.chatId, "utf8").digest("hex");
+    const path = join(dataDir, "transcripts", `${digest}.${reset.resetId}.reset-intent.tmp`);
+    const store = new TranscriptStore(dataDir, { platform: "win32" });
+    writeFileSync(path, "{not-valid-json}\n", { mode: 0o600 });
+
+    let failure: unknown;
+    try {
+      store.readResetIntent(reset.chatId);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(path);
+    expect(JSON.stringify(failure)).not.toContain(path);
+    expect(readFileSync(path, "utf8")).toBe("{not-valid-json}\n");
+  });
+
+  it("does not swallow a Windows sharing violation during file flush", () => {
+    const dataDir = makeDataDir();
+    const path = transcriptPath(dataDir, "locked");
+    const store = new TranscriptStore(dataDir, {
+      platform: "win32",
+      syncFile: () => {
+        throw Object.assign(new Error(`locked ${path}`), { code: "EACCES", path });
+      },
+    });
+
+    let failure: unknown;
+    try {
+      store.appendCompletedTurn(turn("locked", "turn-1"));
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "file-flush", category: "sharing-violation" });
+    expect(failure).not.toHaveProperty("path");
+    expect(failure).not.toHaveProperty("cause");
+    expect(String(failure)).not.toContain(path);
+    expect(JSON.stringify(failure)).not.toContain(path);
   });
 });

--- a/packages/core/tests/windows-private-path-policy.test.ts
+++ b/packages/core/tests/windows-private-path-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   WindowsPrivatePathPolicyError,
+  assertWindowsPrivatePathBinding,
   assertWindowsPrivatePathEntry,
   assertWindowsPrivatePathRead,
   classifyWindowsPrivatePathDurability,
@@ -103,6 +104,25 @@ describe("Windows private path policy", () => {
         }),
       ),
     ).toMatchObject({ stage: "entry-check", category: "link-reparse-shaped" });
+  });
+
+  it("classifies an unstable or unauthenticated binding as corruption", () => {
+    expect(
+      captureFailure(() =>
+        assertWindowsPrivatePathBinding({
+          identityStable: false,
+          authenticatedHomeBinding: true,
+        }),
+      ),
+    ).toMatchObject({ stage: "binding-check", category: "corruption" });
+    expect(
+      captureFailure(() =>
+        assertWindowsPrivatePathBinding({
+          identityStable: true,
+          authenticatedHomeBinding: false,
+        }),
+      ),
+    ).toMatchObject({ stage: "binding-check", category: "corruption" });
   });
 
   it("accepts a bounded stable read bound to the authenticated home", () => {


### PR DESCRIPTION
## What

Makes the daemon token, Chat sessions, transcripts, and conversation archives survive a packaged Windows restart and reject corrupt or locked state. The chat, transcript, and conversation stores and the daemon RPC token path gain win32 dispatch through the existing Windows private-path policy (entry shape, authenticated binding, bounded stable reads, durability/corruption/sharing classification) via the injected platform parameter defaulting to process.platform; every other platform keeps its code path byte-identical, including the POSIX strict-private-directory checks, O_NOFOLLOW opens, and directory-descriptor fsync order. Corrupt or locked state fails closed with stage-coded, path-free diagnostics and never resets unrelated state.

## New limits (win32 policy paths only)

- MAX_DAEMON_TOKEN_FILE_BYTES = 44 (packages/coach/src/daemon/rpc-server.ts) — the daemon token file has a fixed encoded length; a larger file is corrupt and must fail closed, not be read unbounded.
- MAX_CHAT_SESSION_BYTES = 67108864 (packages/core/src/agent/chat-store.ts) — bounded stable read for chat session files; an unbounded read of a corrupt file could stall startup.
- MAX_TRANSCRIPT_FILE_BYTES = 67108864 (packages/core/src/agent/transcript-store.ts) — same bound for transcript files.

All three are enforced only on the win32 policy paths; non-Windows behavior is unchanged.

## Non-goals (deliberate)

- Credential vaults, first-run config, Desktop preferences, auth/profile, memory, usage, and Telegram stores are untouched (later packages own them).
- No changeset: no user-visible behavior change on any currently shipped platform.

## Verification

- core suite: 2623 passed / 0 failed / 5 skipped
- coach suite (repo-root cwd, Node 24): 732 passed / 0 failed
- apps/desktop suite: 1279 passed / 0 failed
- Root pnpm check: pass

Note: the pre-existing coach upgrade-fence long-socket-path test is Node-version-sensitive on darwin (passes under Node 24, fails under Node 22 for reasons unrelated to this diff); tracked internally.
