### PR TITLE
fix(desktop): record and retrigger round-trip updater checks

### DIFF
--- a/apps/desktop/scripts/verify-updater-round-trip.d.mts
+++ b/apps/desktop/scripts/verify-updater-round-trip.d.mts
@@ -22,6 +22,31 @@ export interface MacosUpdaterRoundTripContext {
   readonly mode?: string;
 }
 
+export interface MacosUpdaterDownloadedStateProbeContext {
+  readonly candidateVersion: string;
+  readonly observe: () => Promise<{
+    readonly state: unknown;
+    readonly recheckFailures: number;
+  }>;
+  readonly retrigger: () => Promise<void>;
+  readonly now?: () => number;
+}
+
+export interface MacosUpdaterDownloadedStateProbe {
+  readonly probe: () => Promise<unknown>;
+  readonly timeoutFailure: (lastError?: unknown) => Error;
+}
+
+export type MacosUpdaterRoundTripFailureDiagnostic = Readonly<{
+  phase: string;
+  cleanup: string;
+  reason?: string;
+  observedState?: string;
+  recheckAttempts?: number;
+  recheckFailures?: number;
+  lastErrorReason?: string;
+}>;
+
 export interface MacosApplicationProcessObservation {
   readonly bundlePids: readonly number[];
   readonly mainPids: readonly number[];
@@ -172,6 +197,48 @@ export function parseMacosDownloadedUpdateInfo(
   value: unknown,
   expected: { readonly fileName: string; readonly sha512: string },
 ): MacosDownloadedUpdateInfo;
+
+export function sanitizeMacosUpdaterObservedState(value: unknown): string;
+
+export function shouldRetriggerMacosUpdaterCheck(
+  state: unknown,
+  candidateAdvertised: boolean,
+): boolean;
+
+export function createMacosUpdaterDownloadedStateProbe(
+  context: MacosUpdaterDownloadedStateProbeContext,
+): Readonly<MacosUpdaterDownloadedStateProbe>;
+
+export function observeMacosUpdaterState(
+  evaluate: (expression: string) => Promise<unknown>,
+): Promise<{ readonly state: unknown; readonly recheckFailures: number }>;
+
+export function retriggerMacosUpdaterCheck(
+  evaluate: (expression: string) => Promise<unknown>,
+): Promise<void>;
+
+export function waitForMacosUpdaterDownloadedState(
+  evaluate: (expression: string) => Promise<unknown>,
+  candidateVersion: string,
+): Promise<unknown>;
+
+export function waitForMacosUpdaterCondition<T>(
+  description: string,
+  probe: () => Promise<T | false | undefined>,
+  timeoutMs: number,
+  intervalMs?: number,
+  timeoutFailure?: (lastError?: unknown) => Error,
+): Promise<T>;
+
+export function describeMacosUpdaterRoundTripFailure(
+  error: unknown,
+): MacosUpdaterRoundTripFailureDiagnostic;
+
+export function bindMacosUpdaterRoundTripFailureDiagnostic(
+  error: unknown,
+  phase: string,
+  cleanup: string,
+): Error;
 
 export function parseMacosApplicationProcessObservation(
   bytes: Uint8Array,

--- a/apps/desktop/scripts/verify-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-updater-round-trip.mjs
@@ -44,6 +44,7 @@ export const MACOS_UPDATER_ROUND_TRIP_FEED_URL =
 const productName = "Enduragent";
 const maximumUpdateInfoBytes = 16_384;
 const downloadTimeoutMs = 10 * 60_000;
+const updateRecheckBackoffMs = 45_000;
 const transitionTimeoutMs = 2 * 60_000;
 const shutdownTimeoutMs = 30_000;
 const cleanupTerminationGraceMs = 2_000;
@@ -57,6 +58,11 @@ const credentialDirectoryName = "credentials-v1";
 const persistenceCredentialSlot = "openrouter";
 const persistenceChatId = "desktop";
 const maximumPersistenceFiles = 20_000;
+const observedStateStringValueLimit = 64;
+const observedStateSerializedLimit = 256;
+const observedStateNonPrimitive = "[non-primitive]";
+const observedStateRedacted = "[redacted]";
+const updateRecheckFailureProperty = "__enduragentUpdaterRoundTripRecheckFailures";
 
 class MacosUpdaterRoundTripError extends Error {
   constructor(message) {
@@ -65,12 +71,22 @@ class MacosUpdaterRoundTripError extends Error {
   }
 }
 
+class MacosUpdaterRoundTripFatalError extends MacosUpdaterRoundTripError {
+  constructor(message) {
+    super(message);
+    this.name = "MacosUpdaterRoundTripFatalError";
+  }
+}
+
 const failureDiagnostics = new WeakMap();
 
 function bindFailureDiagnostic(error, phase, cleanup) {
   const failure =
     error instanceof Error ? error : new MacosUpdaterRoundTripError("round-trip failed");
-  failureDiagnostics.set(failure, Object.freeze({ phase, cleanup }));
+  failureDiagnostics.set(
+    failure,
+    Object.freeze({ ...failureDiagnostics.get(failure), phase, cleanup }),
+  );
   return failure;
 }
 
@@ -78,13 +94,18 @@ function safeFailureDiagnostic(error) {
   if (!(error instanceof Error)) {
     return Object.freeze({ phase: "input-validation", cleanup: "not-started" });
   }
-  const diagnostic =
-    failureDiagnostics.get(error) ??
-    Object.freeze({ phase: "input-validation", cleanup: "not-started" });
+  const diagnostic = Object.freeze({
+    phase: "input-validation",
+    cleanup: "not-started",
+    ...failureDiagnostics.get(error),
+  });
   return error instanceof MacosUpdaterRoundTripError
     ? Object.freeze({ ...diagnostic, reason: error.message })
     : diagnostic;
 }
+
+export { bindFailureDiagnostic as bindMacosUpdaterRoundTripFailureDiagnostic };
+export { safeFailureDiagnostic as describeMacosUpdaterRoundTripFailure };
 
 function fail(message) {
   throw new MacosUpdaterRoundTripError(message);
@@ -102,6 +123,72 @@ function exactKeys(value, expected) {
     actual.length === sortedExpected.length &&
     actual.every((key, index) => key === sortedExpected[index])
   );
+}
+
+export function sanitizeMacosUpdaterObservedState(value) {
+  try {
+    if (!exactObject(value)) return "unavailable";
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) return "unavailable";
+    const entries = [];
+    for (const key of Object.keys(value).sort()) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      const candidate =
+        descriptor !== undefined && "value" in descriptor ? descriptor.value : undefined;
+      let sanitized = observedStateNonPrimitive;
+      if (candidate === null || typeof candidate === "boolean") {
+        sanitized = candidate;
+      } else if (typeof candidate === "number" && Number.isFinite(candidate)) {
+        sanitized = candidate;
+      } else if (typeof candidate === "string") {
+        sanitized =
+          candidate.includes("/") || candidate.includes("\\")
+            ? observedStateRedacted
+            : candidate.slice(0, observedStateStringValueLimit);
+      }
+      entries.push(`${JSON.stringify(key)}:${JSON.stringify(sanitized)}`);
+    }
+    return `{${entries.join(",")}}`.slice(0, observedStateSerializedLimit);
+  } catch {
+    return "unavailable";
+  }
+}
+
+export function shouldRetriggerMacosUpdaterCheck(state, candidateAdvertised) {
+  if (
+    exactKeys(state, ["stage", "status"]) &&
+    state.status === "failed" &&
+    ["check", "download"].includes(state.stage)
+  ) {
+    return true;
+  }
+  return (
+    candidateAdvertised === true &&
+    exactKeys(state, ["status"]) &&
+    ["current", "idle"].includes(state.status)
+  );
+}
+
+function createObservedStateFailure(message, state, detail = {}) {
+  const observedState = sanitizeMacosUpdaterObservedState(state);
+  const { recheckAttempts, recheckFailures, lastError, fatal } = detail;
+  const recheckDiagnostic =
+    recheckAttempts === undefined
+      ? ""
+      : `; recheckAttempts=${recheckAttempts}; recheckFailures=${recheckFailures}`;
+  const lastErrorReason =
+    lastError instanceof MacosUpdaterRoundTripError ? lastError.message : undefined;
+  const lastErrorDiagnostic = lastErrorReason === undefined ? "" : `; lastError=${lastErrorReason}`;
+  const text = `${message}; observedState=${observedState}${recheckDiagnostic}${lastErrorDiagnostic}`;
+  const failure =
+    fatal === true
+      ? new MacosUpdaterRoundTripFatalError(text)
+      : new MacosUpdaterRoundTripError(text);
+  failureDiagnostics.set(
+    failure,
+    Object.freeze({ observedState, recheckAttempts, recheckFailures, lastErrorReason }),
+  );
+  return failure;
 }
 
 function olderStableSemVer(left, right) {
@@ -837,7 +924,7 @@ async function debuggerListenerOwner(port, environment) {
   return telegramAcceptanceDebuggerListenerOwner(result);
 }
 
-async function waitUntil(description, probe, timeoutMs, intervalMs = 100) {
+async function waitUntil(description, probe, timeoutMs, intervalMs = 100, timeoutFailure) {
   const deadline = Date.now() + timeoutMs;
   let lastError;
   while (Date.now() < deadline) {
@@ -845,13 +932,17 @@ async function waitUntil(description, probe, timeoutMs, intervalMs = 100) {
       const value = await probe();
       if (value !== false && value !== undefined) return value;
     } catch (error) {
+      if (error instanceof MacosUpdaterRoundTripFatalError) throw error;
       lastError = error;
     }
     await new Promise((resolveDelay) => setTimeout(resolveDelay, intervalMs));
   }
+  if (timeoutFailure !== undefined) throw timeoutFailure(lastError);
   if (lastError instanceof MacosUpdaterRoundTripError) throw lastError;
   fail(`${description} timed out`);
 }
+
+export { waitUntil as waitForMacosUpdaterCondition };
 
 async function evaluateRenderer(connection, expression, timeoutMs = 5_000) {
   const response = await callAcceptanceCdp(
@@ -1247,23 +1338,113 @@ function exactDownloadedState(value, version) {
   );
 }
 
-async function waitForDownloadedState(connection, candidateVersion) {
-  return waitUntil(
-    "downloaded update state",
-    async () => {
-      const state = await evaluateRenderer(connection, "window.enduragentAuth.getUpdateState()");
-      if (exactDownloadedState(state, candidateVersion)) return state;
-      if (
-        !exactObject(state) ||
-        !["idle", "checking", "downloading"].includes(state.status) ||
-        (state.status === "downloading" && state.version !== candidateVersion)
-      ) {
-        fail("application did not enter the expected downloaded update state");
+export async function observeMacosUpdaterState(evaluate) {
+  const property = JSON.stringify(updateRecheckFailureProperty);
+  const observation = await evaluate(
+    `(async () => ({
+      state: await window.enduragentAuth.getUpdateState(),
+      recheckFailures: window[${property}] ?? 0,
+    }))()`,
+  );
+  if (
+    !exactKeys(observation, ["recheckFailures", "state"]) ||
+    !Number.isSafeInteger(observation.recheckFailures) ||
+    observation.recheckFailures < 0
+  ) {
+    fail("updater state observation failed");
+  }
+  return Object.freeze({
+    state: observation.state,
+    recheckFailures: observation.recheckFailures,
+  });
+}
+
+export async function retriggerMacosUpdaterCheck(evaluate) {
+  const property = JSON.stringify(updateRecheckFailureProperty);
+  const invoked = await evaluate(
+    `(() => {
+      const property = ${property};
+      if (!Number.isSafeInteger(window[property]) || window[property] < 0) window[property] = 0;
+      Promise.resolve()
+        .then(() => window.enduragentAuth.checkForUpdates())
+        .catch(() => {
+          window[property] += 1;
+        });
+      return true;
+    })()`,
+  );
+  if (invoked !== true) fail("updater check re-trigger failed");
+}
+
+export function createMacosUpdaterDownloadedStateProbe(context) {
+  const { candidateVersion, observe, retrigger, now = Date.now } = context;
+  let observedState;
+  let lastRecheckAt = -Infinity;
+  let recheckAttempts = 0;
+  let recheckInvocationFailures = 0;
+  let recheckPromiseFailures = 0;
+  const probe = async () => {
+    const observation = await observe();
+    const state = observation.state;
+    observedState = state;
+    recheckPromiseFailures = observation.recheckFailures;
+    if (exactDownloadedState(state, candidateVersion)) return state;
+    if (shouldRetriggerMacosUpdaterCheck(state, true)) {
+      if (now() - lastRecheckAt >= updateRecheckBackoffMs) {
+        lastRecheckAt = now();
+        recheckAttempts += 1;
+        try {
+          await retrigger();
+        } catch {
+          recheckInvocationFailures += 1;
+        }
       }
       return false;
-    },
-    downloadTimeoutMs,
-    250,
+    }
+    if (
+      (exactKeys(state, ["status"]) && ["idle", "checking"].includes(state.status)) ||
+      (exactKeys(state, ["status", "version"]) &&
+        state.status === "downloading" &&
+        state.version === candidateVersion)
+    ) {
+      return false;
+    }
+    throw createObservedStateFailure(
+      "application did not enter the expected downloaded update state",
+      state,
+      {
+        fatal: true,
+        recheckAttempts,
+        recheckFailures: recheckInvocationFailures + recheckPromiseFailures,
+      },
+    );
+  };
+  const timeoutFailure = (lastError) =>
+    createObservedStateFailure(
+      "application did not enter the expected downloaded update state",
+      observedState,
+      {
+        recheckAttempts,
+        recheckFailures: recheckInvocationFailures + recheckPromiseFailures,
+        lastError,
+      },
+    );
+  return Object.freeze({ probe, timeoutFailure });
+}
+
+export function waitForMacosUpdaterDownloadedState(evaluate, candidateVersion) {
+  const { probe, timeoutFailure } = createMacosUpdaterDownloadedStateProbe({
+    candidateVersion,
+    observe: () => observeMacosUpdaterState(evaluate),
+    retrigger: () => retriggerMacosUpdaterCheck(evaluate),
+  });
+  return waitUntil("downloaded update state", probe, downloadTimeoutMs, 250, timeoutFailure);
+}
+
+async function waitForDownloadedState(connection, candidateVersion) {
+  return waitForMacosUpdaterDownloadedState(
+    (expression) => evaluateRenderer(connection, expression),
+    candidateVersion,
   );
 }
 
@@ -1809,10 +1990,12 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
         fail("baseline application did not exit cleanly for update");
       }
       phase = "observe-relaunch";
+      let relaunchedProcessObservation;
       const relaunchedProcesses = await waitUntil(
         "relaunched candidate application",
         async () => {
           const observation = await processObserver.observe();
+          relaunchedProcessObservation = observation;
           if (
             observation.ownedProcesses.some((identity) =>
               initialProcessIdentities.has(processIdentityKey(identity)),
@@ -1826,18 +2009,32 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
         },
         transitionTimeoutMs,
         250,
+        (lastError) =>
+          createObservedStateFailure(
+            "relaunched candidate application timed out",
+            relaunchedProcessObservation,
+            { lastError },
+          ),
       );
       relaunchedPid = relaunchedProcesses.mainPids[0];
       const relaunchedRootIdentity = await processObserver.trackRoot(relaunchedPid);
       phase = "verify-relaunch";
+      let observedRelaunchedIdentity;
       const relaunchedIdentity = await waitUntil(
         "relaunched candidate identity",
         async () => {
           const identity = await inspectApplication(installedApplication);
+          observedRelaunchedIdentity = identity;
           return identity.version === input.candidateVersion ? identity : false;
         },
         transitionTimeoutMs,
         250,
+        (lastError) =>
+          createObservedStateFailure(
+            "relaunched candidate identity timed out",
+            observedRelaunchedIdentity,
+            { lastError },
+          ),
       );
       const identity = verifyMacosUpdaterRoundTripIdentities({
         baselineVersion: input.baselineVersion,
@@ -1860,14 +2057,22 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
       if (!(await processObserver.signalIdentity(relaunchedRootIdentity, "SIGTERM"))) {
         fail("relaunched application graceful shutdown signal failed");
       }
+      let finalShutdownObservation;
       await waitUntil(
         "relaunched application graceful shutdown",
         async () => {
           const observation = await processObserver.observe();
+          finalShutdownObservation = observation;
           return observation.ownedPids.length === 0 ? true : false;
         },
         shutdownTimeoutMs,
         100,
+        (lastError) =>
+          createObservedStateFailure(
+            "relaunched application graceful shutdown timed out",
+            finalShutdownObservation,
+            { lastError },
+          ),
       );
       phase = "launch-persistence-verification";
       const verificationPort = await reservePort();
@@ -1911,14 +2116,22 @@ export async function runMacosUpdaterRoundTrip(rawInput, overrides = {}) {
       if (verificationTerminal.code !== 0 || verificationTerminal.signal !== null) {
         fail("candidate persistence verification did not exit cleanly");
       }
+      let verificationCleanupObservation;
       await waitUntil(
         "candidate persistence verification process cleanup",
         async () => {
           const observation = await processObserver.observe();
+          verificationCleanupObservation = observation;
           return observation.ownedPids.length === 0 ? true : false;
         },
         shutdownTimeoutMs,
         100,
+        (lastError) =>
+          createObservedStateFailure(
+            "candidate persistence verification process cleanup timed out",
+            verificationCleanupObservation,
+            { lastError },
+          ),
       );
       phase = "validate-persistence";
       const plaintextCredentialAbsent = await requirePlaintextAbsent(

--- a/apps/desktop/tests/macos-update-roundtrip.test.ts
+++ b/apps/desktop/tests/macos-update-roundtrip.test.ts
@@ -2,13 +2,22 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   MACOS_UPDATER_ROUND_TRIP_FEED_URL,
+  bindMacosUpdaterRoundTripFailureDiagnostic,
+  createMacosUpdaterDownloadedStateProbe,
   createMacosUpdaterRoundTripEvidence,
+  describeMacosUpdaterRoundTripFailure,
+  observeMacosUpdaterState,
   parseMacosApplicationProcessObservation,
   parseMacosProcessTableObservation,
   parseMacosDownloadedUpdateInfo,
   requireMacosUpdaterRoundTripInput,
+  retriggerMacosUpdaterCheck,
+  sanitizeMacosUpdaterObservedState,
+  shouldRetriggerMacosUpdaterCheck,
   verifyMacosUpdaterRoundTripIdentities,
   verifyMacosUpdaterRoundTripPersistence,
+  waitForMacosUpdaterCondition,
+  waitForMacosUpdaterDownloadedState,
   type MacosUpdaterRoundTripInput,
 } from "../scripts/verify-updater-round-trip.mjs";
 import type { VerifiedMacosReleaseApplication } from "../scripts/verify-macos-release.mjs";
@@ -288,6 +297,351 @@ describe("downloaded updater cache binding", () => {
     expect(() => parseMacosDownloadedUpdateInfo(value, expected)).toThrow(
       "downloaded update metadata does not match the candidate",
     );
+  });
+});
+
+describe("macOS updater state recovery diagnostics", () => {
+  it("sanitizes observed state with deterministic bounds and redactions", () => {
+    const sanitized = sanitizeMacosUpdaterObservedState({
+      zulu: "z".repeat(80),
+      path: "/private/tmp/update.zip",
+      nested: { error: "private" },
+      count: 12,
+      active: true,
+      absent: null,
+      infinite: Number.POSITIVE_INFINITY,
+      windowsPath: "C:\\Users\\athlete\\update.zip",
+    });
+
+    expect(sanitized).toBe(
+      `{"absent":null,"active":true,"count":12,"infinite":"[non-primitive]","nested":"[non-primitive]","path":"[redacted]","windowsPath":"[redacted]","zulu":"${"z".repeat(64)}"}`,
+    );
+    expect(sanitized.length).toBeLessThanOrEqual(256);
+  });
+
+  it("bounds the whole state serialization and rejects non-objects", () => {
+    const sanitized = sanitizeMacosUpdaterObservedState(
+      Object.fromEntries(
+        Array.from({ length: 20 }, (_value, index) => [`field-${index}`, "v".repeat(64)]),
+      ),
+    );
+
+    expect(sanitized.length).toBe(256);
+    expect(sanitizeMacosUpdaterObservedState(null)).toBe("unavailable");
+    expect(sanitizeMacosUpdaterObservedState(["idle"])).toBe("unavailable");
+    expect(sanitizeMacosUpdaterObservedState("idle")).toBe("unavailable");
+  });
+
+  it.each([
+    [{ status: "failed", stage: "check" }, false, true],
+    [{ status: "failed", stage: "download" }, false, true],
+    [{ status: "current" }, true, true],
+    [{ status: "idle" }, true, true],
+    [{ status: "current" }, false, false],
+    [{ status: "checking" }, true, false],
+    [{ status: "downloading", version: candidateVersion }, true, false],
+    [{ status: "downloaded", version: candidateVersion }, true, false],
+    [{ status: "failed", stage: "install" }, true, false],
+  ])(
+    "decides whether a settled updater state should be re-triggered",
+    (state, advertised, expected) => {
+      expect(shouldRetriggerMacosUpdaterCheck(state, advertised)).toBe(expected);
+    },
+  );
+});
+
+describe("macOS updater downloaded-state recovery", () => {
+  function createProbeForState(
+    state: unknown,
+    options: {
+      readonly recheckFailures?: number;
+      readonly retrigger?: () => Promise<void>;
+      readonly now?: () => number;
+    } = {},
+  ) {
+    return createMacosUpdaterDownloadedStateProbe({
+      candidateVersion,
+      observe: async () => ({
+        state,
+        recheckFailures: options.recheckFailures ?? 0,
+      }),
+      retrigger: options.retrigger ?? (async () => {}),
+      now: options.now ?? (() => 0),
+    });
+  }
+
+  it("resolves the exact candidate download without re-triggering", async () => {
+    const state = { status: "downloaded", version: candidateVersion };
+    let retriggerCalls = 0;
+    const { probe, timeoutFailure } = createProbeForState(state, {
+      retrigger: async () => {
+        retriggerCalls += 1;
+      },
+    });
+
+    await expect(
+      waitForMacosUpdaterCondition("downloaded update state", probe, 20, 1, timeoutFailure),
+    ).resolves.toEqual(state);
+    expect(retriggerCalls).toBe(0);
+  });
+
+  it("gates re-trigger attempts with the 45-second backoff", async () => {
+    let clock = 0;
+    const retriggeredAt: number[] = [];
+    const { probe } = createProbeForState(
+      { status: "failed", stage: "check" },
+      {
+        now: () => clock,
+        retrigger: async () => {
+          retriggeredAt.push(clock);
+        },
+      },
+    );
+
+    await expect(probe()).resolves.toBe(false);
+    clock = 44_999;
+    await expect(probe()).resolves.toBe(false);
+    clock = 45_000;
+    await expect(probe()).resolves.toBe(false);
+
+    expect(retriggeredAt).toHaveLength(2);
+    expect(retriggeredAt).toEqual([0, 45_000]);
+  });
+
+  it("re-triggers an advertised current state but permits active transitions", async () => {
+    let currentRetriggerCalls = 0;
+    const current = createProbeForState(
+      { status: "current" },
+      {
+        retrigger: async () => {
+          currentRetriggerCalls += 1;
+        },
+      },
+    );
+    await expect(current.probe()).resolves.toBe(false);
+
+    let transitionRetriggerCalls = 0;
+    for (const state of [
+      { status: "checking" },
+      { status: "downloading", version: candidateVersion },
+    ]) {
+      const transition = createProbeForState(state, {
+        retrigger: async () => {
+          transitionRetriggerCalls += 1;
+        },
+      });
+      await expect(transition.probe()).resolves.toBe(false);
+    }
+
+    expect(currentRetriggerCalls).toBe(1);
+    expect(transitionRetriggerCalls).toBe(0);
+  });
+
+  it.each([
+    { status: "disabled" },
+    { status: "installing", version: candidateVersion },
+    { status: "downloading", version: baselineVersion },
+    { status: "downloaded", version: baselineVersion },
+    { status: "restart-required", stage: "check" },
+    { status: "checking", extra: true },
+    { status: "idle", extra: true },
+    { status: "downloading", version: candidateVersion, extra: true },
+    "idle",
+    null,
+    ["idle"],
+  ])("rejects a state outside the transition envelope immediately", async (state) => {
+    const { probe, timeoutFailure } = createProbeForState(state);
+    const startedAt = Date.now();
+
+    await expect(
+      waitForMacosUpdaterCondition("downloaded update state", probe, 60_000, 1, timeoutFailure),
+    ).rejects.toThrow("observedState=");
+    expect(Date.now() - startedAt).toBeLessThan(500);
+  });
+
+  it("counts local and observed re-trigger failures in timeout diagnostics", async () => {
+    let retriggerCalls = 0;
+    const { probe, timeoutFailure } = createProbeForState(
+      { status: "failed", stage: "check" },
+      {
+        recheckFailures: 2,
+        retrigger: async () => {
+          retriggerCalls += 1;
+          throw new Error("private re-trigger failure");
+        },
+      },
+    );
+
+    await expect(probe()).resolves.toBe(false);
+    const failure = timeoutFailure();
+
+    expect(retriggerCalls).toBe(1);
+    expect(failure.message).toContain("recheckAttempts=1; recheckFailures=3");
+    expect(failure.message).not.toContain("private re-trigger failure");
+  });
+
+  async function timedOutFailure(lastError: unknown) {
+    const observed = createProbeForState({ status: "checking" });
+    await expect(observed.probe()).resolves.toBe(false);
+    let failure: Error | undefined;
+    try {
+      await waitForMacosUpdaterCondition(
+        "downloaded update state",
+        async () => {
+          throw lastError;
+        },
+        20,
+        1,
+        observed.timeoutFailure,
+      );
+    } catch (error) {
+      if (error instanceof Error) failure = error;
+    }
+    return failure;
+  }
+
+  it("preserves a round-trip probe reason alongside the observed state", async () => {
+    let probeError: unknown;
+    try {
+      parseMacosDownloadedUpdateInfo(null, {
+        fileName: "Enduragent-0.1.1-arm64.zip",
+        sha512: "candidate-sha512",
+      });
+    } catch (error) {
+      probeError = error;
+    }
+
+    const failure = await timedOutFailure(probeError);
+
+    expect(failure?.message).toContain('observedState={"status":"checking"}');
+    expect(failure?.message).toContain(
+      "lastError=downloaded update metadata does not match the candidate",
+    );
+  });
+
+  it("omits unknown probe error text from timeout diagnostics", async () => {
+    const failure = await timedOutFailure(new Error("private renderer detail"));
+
+    expect(failure?.message).toContain('observedState={"status":"checking"}');
+    expect(failure?.message).not.toContain("private renderer detail");
+    expect(failure?.message).not.toContain("lastError=");
+  });
+
+  it("preserves state diagnostics when phase and cleanup are bound", async () => {
+    const { probe, timeoutFailure } = createProbeForState(
+      { status: "failed", stage: "check" },
+      {
+        recheckFailures: 2,
+        retrigger: async () => {
+          throw new Error("re-trigger failed");
+        },
+      },
+    );
+    await expect(probe()).resolves.toBe(false);
+    const failure = timeoutFailure();
+
+    expect(
+      bindMacosUpdaterRoundTripFailureDiagnostic(failure, "download-update", "completed"),
+    ).toBe(failure);
+    expect(describeMacosUpdaterRoundTripFailure(failure)).toMatchObject({
+      phase: "download-update",
+      cleanup: "completed",
+      reason: failure.message,
+      observedState: '{"stage":"check","status":"failed"}',
+      recheckAttempts: 1,
+      recheckFailures: 3,
+    });
+  });
+
+  it("reports default phase and cleanup for an unbound failure", () => {
+    const { timeoutFailure } = createProbeForState({ status: "checking" });
+
+    expect(describeMacosUpdaterRoundTripFailure(timeoutFailure())).toMatchObject({
+      phase: "input-validation",
+      cleanup: "not-started",
+      observedState: "unavailable",
+    });
+  });
+});
+
+describe("macOS updater renderer bridge", () => {
+  it("reads the updater state and re-check failure tally from the bridge", async () => {
+    const expressions: string[] = [];
+
+    await expect(
+      observeMacosUpdaterState(async (expression) => {
+        expressions.push(expression);
+        return { state: { status: "checking" }, recheckFailures: 3 };
+      }),
+    ).resolves.toEqual({ state: { status: "checking" }, recheckFailures: 3 });
+    expect(expressions).toHaveLength(1);
+    expect(expressions[0]).toContain("window.enduragentAuth.getUpdateState()");
+  });
+
+  it("rejects a malformed updater state observation", async () => {
+    await expect(
+      observeMacosUpdaterState(async () => ({
+        state: { status: "checking" },
+        recheckFailures: -1,
+      })),
+    ).rejects.toThrow("updater state observation failed");
+    await expect(observeMacosUpdaterState(async () => ({ status: "checking" }))).rejects.toThrow(
+      "updater state observation failed",
+    );
+  });
+
+  it("re-triggers the update check through the exposed bridge", async () => {
+    const expressions: string[] = [];
+
+    await retriggerMacosUpdaterCheck(async (expression) => {
+      expressions.push(expression);
+      return true;
+    });
+
+    expect(expressions).toHaveLength(1);
+    expect(expressions[0]).toContain("window.enduragentAuth.checkForUpdates()");
+  });
+
+  it("fails when the bridge does not confirm the re-trigger", async () => {
+    await expect(retriggerMacosUpdaterCheck(async () => false)).rejects.toThrow(
+      "updater check re-trigger failed",
+    );
+  });
+
+  it("recovers a failed check and resolves the candidate download over the bridge", async () => {
+    const states: readonly unknown[] = [
+      { status: "failed", stage: "check" },
+      { status: "downloading", version: candidateVersion },
+      { status: "downloaded", version: candidateVersion },
+    ];
+    const rechecks: string[] = [];
+    let observations = 0;
+
+    await expect(
+      waitForMacosUpdaterDownloadedState(async (expression) => {
+        if (expression.includes("window.enduragentAuth.checkForUpdates()")) {
+          rechecks.push(expression);
+          return true;
+        }
+        const state = states[Math.min(observations, states.length - 1)];
+        observations += 1;
+        return { state, recheckFailures: 0 };
+      }, candidateVersion),
+    ).resolves.toEqual({ status: "downloaded", version: candidateVersion });
+    expect(rechecks).toHaveLength(1);
+    expect(observations).toBe(3);
+  });
+
+  it("fails closed without burning the download deadline over the bridge", async () => {
+    const startedAt = Date.now();
+
+    await expect(
+      waitForMacosUpdaterDownloadedState(
+        async () => ({ state: { status: "disabled" }, recheckFailures: 0 }),
+        candidateVersion,
+      ),
+    ).rejects.toThrow('observedState={"status":"disabled"}');
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
   });
 });
 


### PR DESCRIPTION
## What changes

The macOS release round-trip verifier waits for the baseline app to reach the exact downloaded-update state before it installs the candidate. Two things were wrong with that wait.

**It reported a fixed literal instead of what it saw.** Every timeout produced the same message regardless of the state the app was actually in, so a failed run told you nothing about why.

**It had no recovery.** If the baseline's update check settled into a failed or already-current state before the wait began — the check fires on its own schedule, and the wait starts after launch — nothing would ever move it again. The verifier sat there until the deadline expired on a run that could have succeeded.

Now the wait:

- Records the observed state in the failure reason and in the structured diagnostic. Values are sanitized: strings are truncated at 64 characters, path-like strings are redacted, non-primitives are elided, and the whole serialization is capped at 256 characters.
- Re-triggers the update check through the baseline's own `checkForUpdates()` bridge when the state is recoverable — a failed check or download, or an idle/current state while a candidate is advertised. Re-triggers are gated at one per 45 seconds, and both invocation failures and rejected in-page promises are counted into the diagnostic.
- Fails closed immediately on anything outside the allowed transition set, so a wrong-version download, a disabled updater, an installing or restart-required state, or a malformed payload aborts at once instead of burning the full ten minutes.

The existing 10-minute download deadline is unchanged; recovery happens inside it. The downloaded-state acceptance assertion is untouched and still requires exact keys, status, and candidate version.

## Review resolutions

Two rounds of fresh-context review ran against the change. Every finding is addressed:

- **Fail-closed envelope restored.** The first revision dropped the rejection of out-of-envelope states entirely. It is back, and it now aborts the wait rather than merely being recorded: the envelope throws a fatal error subtype that the polling loop rethrows instead of stashing as `lastError`. Ordinary transient probe errors stay retryable.
- **Envelope validates exact shapes.** It uses exact-key matching rather than a status-membership test, so an object carrying extra keys fails closed instead of polling to the deadline.
- **Specific probe errors are no longer masked.** The timeout diagnostic previously replaced `lastError` with the generic observed-state message. It now carries both. The existing privacy rule holds: only a round-trip error's text is included, never an unknown error's.
- **Diagnostic defaults merge instead of replacing,** so an unbound failure still reports a phase and cleanup and matches its exported declaration.
- **Real regression coverage.** The recovery path was previously covered only through two pure helpers. The renderer bridge is now reached through an injected evaluate callback, so tests assert the actual `getUpdateState()` and `checkForUpdates()` expressions, the composed recovery path, the 45-second backoff gate, the timeout branch, the diagnostic merge, and immediate envelope rejection.

## Validation

- `pnpm vitest run apps/desktop/tests/macos-update-roundtrip.test.ts tools/check-desktop-release-workflow.test.ts` — 160 passed.
- `pnpm check:desktop-release-workflow` — the verifier's relative-import closure is unchanged, so the release recovery overlay still covers it. No import was added.
- `pnpm check:types`, `pnpm -r build`, `oxfmt --check`, `oxlint` — clean.
- Mutation check: reverting the exact-shape envelope makes the three extra-key cases fail on the promptness assertion, confirming the new tests bite.
