### PR TITLE
feat(desktop): make credential vaults and first-run config windows-safe

### DIFF
--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -6,11 +6,24 @@ import {
   type ConfigureRuntimeRpcRefusalReason,
 } from "@enduragent/coach-contract";
 import {
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  WindowsPrivatePathPolicyError,
+  type WindowsPrivateDirectoryBinding,
+} from "@enduragent/core";
+import {
   parseOnboardingLlmSelection,
   type OnboardingLlmSelection,
   type OnboardingLlmSelectionResult,
 } from "./llm-selection.js";
 import { durablyReplaceReversible } from "./durable-atomic-replace.js";
+import {
+  assertWindowsPrivateFileAtPath,
+  MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+  readWindowsPrivateFile,
+} from "./windows-private-file.js";
 
 export const DESKTOP_CREDENTIAL_SLOTS = [
   "anthropic",
@@ -153,10 +166,12 @@ interface CredentialVaultOptions {
   readonly renameCredentialFile?: typeof rename;
   readonly removeCredentialFile?: typeof rm;
   readonly readCredentialFile?: typeof readFile;
+  readonly openCredentialFile?: typeof open;
   readonly openCredentialDirectory?: typeof open;
   readonly syncCredentialDirectory?: (root: string) => Promise<void>;
   readonly syncCredentialParentDirectory?: (root: string) => Promise<void>;
   readonly createId?: () => string;
+  readonly platform?: NodeJS.Platform;
 }
 
 export function replaceCredentialRuntimeStates(
@@ -200,6 +215,8 @@ interface ReadCredential {
 
 type CredentialVaultDurabilityState = "pending" | "verified" | "unsafe" | "uncertain";
 
+type CredentialEncryptionRefusal = "encryption-unavailable" | "unsafe-backend";
+
 function isCredentialSlot(value: unknown): value is DesktopCredentialSlot {
   return (
     typeof value === "string" && (DESKTOP_CREDENTIAL_SLOTS as readonly string[]).includes(value)
@@ -208,6 +225,24 @@ function isCredentialSlot(value: unknown): value is DesktopCredentialSlot {
 
 function permissions(mode: number): number {
   return mode & 0o777;
+}
+
+function encryptionRefusal(
+  encryption: CredentialEncryptionPort,
+  platform: NodeJS.Platform,
+): CredentialEncryptionRefusal | undefined {
+  try {
+    if (!encryption.isEncryptionAvailable()) return "encryption-unavailable";
+    if (
+      platform !== "win32" &&
+      encryption.getSelectedStorageBackend?.() === UNSAFE_STORAGE_BACKEND
+    ) {
+      return "unsafe-backend";
+    }
+    return undefined;
+  } catch {
+    return "encryption-unavailable";
+  }
 }
 
 function transientCredentialSlot(entry: string): DesktopCredentialSlot | undefined {
@@ -241,10 +276,18 @@ function serializeCredentialRoot<T>(root: string, operation: () => Promise<T>): 
   return result;
 }
 
-async function secureDirectory(root: string): Promise<boolean> {
+async function secureDirectory(
+  root: string,
+  platform: NodeJS.Platform,
+  bindWindowsDirectory: () => WindowsPrivateDirectoryBinding,
+): Promise<boolean> {
   try {
     await mkdir(root, { recursive: true, mode: CREDENTIAL_DIRECTORY_MODE });
     const entry = await lstat(root);
+    if (platform === "win32") {
+      bindWindowsDirectory();
+      return true;
+    }
     return (
       entry.isDirectory() &&
       !entry.isSymbolicLink() &&
@@ -255,9 +298,23 @@ async function secureDirectory(root: string): Promise<boolean> {
   }
 }
 
-async function validTarget(path: string): Promise<boolean> {
+async function validTarget(
+  path: string,
+  platform: NodeJS.Platform,
+  windowsDirectory: WindowsPrivateDirectoryBinding | undefined,
+): Promise<boolean> {
   try {
     const entry = await lstat(path);
+    if (platform === "win32") {
+      assertWindowsPrivateFileAtPath(
+        windowsDirectory!,
+        path,
+        entry,
+        1,
+        MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+      );
+      return true;
+    }
     return (
       entry.isFile() &&
       !entry.isSymbolicLink() &&
@@ -270,6 +327,7 @@ async function validTarget(path: string): Promise<boolean> {
 }
 
 export function createCredentialVault(options: CredentialVaultOptions): CredentialVault {
+  const platform = options.platform ?? process.platform;
   const runtimeState =
     options.runtimeState ?? new Map<DesktopCredentialSlot, CredentialRuntimeState>();
   const setRuntimeState = (slot: DesktopCredentialSlot, state: CredentialRuntimeState): void => {
@@ -283,7 +341,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     runtimeState.delete(slot);
     options.onRuntimeStateChange?.(slot);
   };
-  const syncCredentialDirectory =
+  const rawSyncCredentialDirectory =
     options.syncCredentialDirectory ??
     (async (root: string): Promise<void> => {
       const directory = await (options.openCredentialDirectory ?? open)(root, "r");
@@ -295,7 +353,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
       }
       await directory.close().catch(() => undefined);
     });
-  const syncCredentialParentDirectory =
+  const rawSyncCredentialParentDirectory =
     options.syncCredentialParentDirectory ??
     (async (root: string): Promise<void> => {
       const directory = await open(root, "r");
@@ -307,6 +365,24 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
       }
       await directory.close().catch(() => undefined);
     });
+  const syncCredentialDirectory = async (root: string): Promise<void> => {
+    if (
+      platform === "win32" &&
+      classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable"
+    ) {
+      return;
+    }
+    await rawSyncCredentialDirectory(root);
+  };
+  const syncCredentialParentDirectory = async (root: string): Promise<void> => {
+    if (
+      platform === "win32" &&
+      classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable"
+    ) {
+      return;
+    }
+    await rawSyncCredentialParentDirectory(root);
+  };
   const renameCredentialFile = options.renameCredentialFile ?? rename;
   const removeCredentialFile = options.removeCredentialFile ?? rm;
   const readCredentialFile = options.readCredentialFile ?? readFile;
@@ -315,6 +391,16 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
   let durabilityState: CredentialVaultDurabilityState = "pending";
   let durabilityReconciliation: Promise<CredentialVaultDurabilityState> | undefined;
   let parentDirectoryVerified = false;
+  let windowsDirectory: WindowsPrivateDirectoryBinding | undefined;
+
+  const bindCredentialDirectory = (): WindowsPrivateDirectoryBinding => {
+    if (windowsDirectory === undefined) {
+      windowsDirectory = bindWindowsPrivateDirectory(dirname(options.root), options.root);
+    } else {
+      assertWindowsPrivateDirectoryStable(windowsDirectory);
+    }
+    return windowsDirectory;
+  };
 
   const exclusive = <T>(operation: () => Promise<T>): Promise<T> =>
     serializeCredentialRoot(options.root, operation);
@@ -325,7 +411,9 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     durabilityReconciliation = (async (): Promise<CredentialVaultDurabilityState> => {
       try {
         const directory = await lstat(options.root);
-        if (
+        if (platform === "win32") {
+          bindCredentialDirectory();
+        } else if (
           !directory.isDirectory() ||
           directory.isSymbolicLink() ||
           permissions(directory.mode) !== CREDENTIAL_DIRECTORY_MODE
@@ -338,7 +426,12 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
           durabilityState = "verified";
           return durabilityState;
         }
-        durabilityState = "uncertain";
+        durabilityState =
+          error instanceof WindowsPrivatePathPolicyError &&
+          error.category !== "sharing-violation" &&
+          error.category !== "io-failure"
+            ? "unsafe"
+            : "uncertain";
         return durabilityState;
       }
 
@@ -405,6 +498,28 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     let encrypted: Buffer | undefined;
     try {
       const directory = await lstat(options.root);
+      if (platform === "win32") {
+        const snapshot = await readWindowsPrivateFile({
+          directory: bindCredentialDirectory(),
+          path,
+          minimumBytes: 1,
+          maximumBytes: MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+          openFile: options.openCredentialFile,
+        });
+        if (snapshot === undefined) return { slot, state: "missing", modifiedAt: 0 };
+        encrypted = snapshot.contents;
+        if (encryptionRefusal(options.encryption, platform) !== undefined) {
+          return { slot, state: "re-prompt", modifiedAt: snapshot.modifiedAt };
+        }
+        const value = options.encryption.decryptString(encrypted).trim();
+        assertWindowsPrivatePathRead({
+          bounded: true,
+          identityStable: true,
+          contentValid: value.length > 0,
+          authenticatedHomeBinding: true,
+        });
+        return { slot, state: "configured", value, modifiedAt: snapshot.modifiedAt };
+      }
       if (
         !directory.isDirectory() ||
         directory.isSymbolicLink() ||
@@ -521,15 +636,9 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     if (value.length === 0) {
       return { slot: input.slot, status: "refused", reason: "invalid-input" };
     }
-    try {
-      if (!options.encryption.isEncryptionAvailable()) {
-        return { slot: input.slot, status: "refused", reason: "encryption-unavailable" };
-      }
-      if (options.encryption.getSelectedStorageBackend?.() === UNSAFE_STORAGE_BACKEND) {
-        return { slot: input.slot, status: "refused", reason: "unsafe-backend" };
-      }
-    } catch {
-      return { slot: input.slot, status: "refused", reason: "encryption-unavailable" };
+    const encryptionFailure = encryptionRefusal(options.encryption, platform);
+    if (encryptionFailure !== undefined) {
+      return { slot: input.slot, status: "refused", reason: encryptionFailure };
     }
     const durability = await reconcileDurability();
     if (durability === "uncertain") {
@@ -538,7 +647,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     if (durability !== "verified") {
       return { slot: input.slot, status: "refused", reason: "storage-failed" };
     }
-    if (!(await secureDirectory(options.root))) {
+    if (!(await secureDirectory(options.root, platform, bindCredentialDirectory))) {
       return { slot: input.slot, status: "refused", reason: "storage-failed" };
     }
     if (!parentDirectoryVerified) {
@@ -550,20 +659,42 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
       }
     }
     const target = join(options.root, `${input.slot}.bin`);
-    if (!(await validTarget(target))) {
+    if (!(await validTarget(target, platform, windowsDirectory))) {
       return { slot: input.slot, status: "refused", reason: "storage-failed" };
     }
     const previousRuntimeState = runtimeState.get(input.slot);
     let encrypted: Buffer | undefined;
     let previous: Buffer | undefined;
+    let plaintext: Buffer | undefined;
     try {
-      try {
-        previous = await readCredentialFile(target);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      if (platform === "win32") {
+        previous = (
+          await readWindowsPrivateFile({
+            directory: bindCredentialDirectory(),
+            path: target,
+            minimumBytes: 1,
+            maximumBytes: MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+            openFile: options.openCredentialFile,
+          })
+        )?.contents;
+      } else {
+        try {
+          previous = await readCredentialFile(target);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        }
       }
       encrypted = options.encryption.encryptString(value);
       if (!Buffer.isBuffer(encrypted) || encrypted.length === 0) throw new TypeError();
+      if (platform === "win32") {
+        plaintext = Buffer.from(value, "utf8");
+        assertWindowsPrivatePathRead({
+          bounded: encrypted.length <= MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+          identityStable: true,
+          contentValid: !encrypted.includes(plaintext),
+          authenticatedHomeBinding: true,
+        });
+      }
       const stored = await durablyReplaceReversible({
         root: options.root,
         fileName: `${input.slot}.bin`,
@@ -574,6 +705,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
         renameFile: renameCredentialFile,
         removeFile: removeCredentialFile,
         syncDirectory: syncCredentialDirectory,
+        platform,
       });
       if (stored.state === "refused") {
         uncertainSlots.delete(input.slot);
@@ -620,6 +752,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
                 renameFile: renameCredentialFile,
                 removeFile: removeCredentialFile,
                 syncDirectory: syncCredentialDirectory,
+                platform,
               });
               storageRestored = restored.state === "applied";
             }
@@ -652,6 +785,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     } finally {
       previous?.fill(0);
       encrypted?.fill(0);
+      plaintext?.fill(0);
     }
   };
 

--- a/apps/desktop/src/main/durable-atomic-replace.ts
+++ b/apps/desktop/src/main/durable-atomic-replace.ts
@@ -1,6 +1,20 @@
 import { randomUUID } from "node:crypto";
-import { open, readFile, rename, rm } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { lstat, open, readFile, rename, rm } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import {
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivateFileBinding,
+  assertWindowsPrivateFileMetadata,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  classifyWindowsPrivatePathFailure,
+  sameWindowsPrivatePathIdentity,
+  windowsPrivatePathIdentity,
+  WindowsPrivatePathPolicyError,
+  type WindowsPrivateDirectoryBinding,
+  type WindowsPrivatePathIdentity,
+  type WindowsPrivatePathPolicyStage,
+} from "@enduragent/core";
 
 export type DurableReplaceOutcome =
   | Readonly<{ state: "not-committed" }>
@@ -12,6 +26,7 @@ export interface DurableAtomicReplaceInput {
   readonly fileName: string;
   readonly contents: string | Buffer;
   readonly mode: number;
+  readonly platform?: NodeJS.Platform;
   readonly createId?: () => string;
   readonly openFile?: typeof open;
   readonly openDirectory?: typeof open;
@@ -51,8 +66,17 @@ export async function durableAtomicReplace(
   ) {
     throw new TypeError("invalid durable replacement target");
   }
+  const platform = input.platform ?? process.platform;
   const createId = input.createId ?? randomUUID;
-  const id = createId();
+  let id: string;
+  try {
+    id = createId();
+  } catch (error) {
+    if (platform === "win32") {
+      throw classifyWindowsPrivatePathFailure("content-write", error);
+    }
+    throw error;
+  }
   if (!/^[A-Za-z0-9-]{1,128}$/.test(id)) {
     throw new TypeError("invalid durable replacement temporary id");
   }
@@ -69,18 +93,70 @@ export async function durableAtomicReplace(
     : Buffer.from(input.contents, "utf8");
   let handle: Awaited<ReturnType<typeof open>> | undefined;
   let renamed = false;
+  let stage: WindowsPrivatePathPolicyStage = "content-write";
+  let windowsDirectory: WindowsPrivateDirectoryBinding | undefined;
+  let windowsTemporaryIdentity: WindowsPrivatePathIdentity | undefined;
   try {
+    if (platform === "win32") {
+      windowsDirectory = bindWindowsPrivateDirectory(dirname(input.root), input.root);
+    }
     handle = await openFile(temporary, "wx", input.mode);
+    if (platform === "win32") {
+      const opened = await handle.stat();
+      assertWindowsPrivateFileMetadata(opened);
+      windowsTemporaryIdentity = windowsPrivatePathIdentity(opened);
+      assertWindowsPrivateFileBinding(windowsDirectory!, temporary, windowsTemporaryIdentity);
+    }
     await handle.writeFile(contents);
-    await handle.chmod(input.mode);
+    if (platform === "win32") {
+      const written = await handle.stat();
+      assertWindowsPrivateFileMetadata(written);
+      if (
+        !sameWindowsPrivatePathIdentity(
+          windowsTemporaryIdentity!,
+          windowsPrivatePathIdentity(written),
+        )
+      ) {
+        throw new WindowsPrivatePathPolicyError("binding-check", "corruption");
+      }
+      assertWindowsPrivateFileBinding(windowsDirectory!, temporary, windowsTemporaryIdentity!);
+    } else {
+      await handle.chmod(input.mode);
+    }
+    stage = "file-flush";
     await handle.sync();
+    if (platform === "win32") {
+      const flushed = await handle.stat();
+      assertWindowsPrivateFileMetadata(flushed);
+      if (
+        !sameWindowsPrivatePathIdentity(
+          windowsTemporaryIdentity!,
+          windowsPrivatePathIdentity(flushed),
+        )
+      ) {
+        throw new WindowsPrivatePathPolicyError("binding-check", "corruption");
+      }
+      assertWindowsPrivateFileBinding(windowsDirectory!, temporary, windowsTemporaryIdentity!);
+      assertWindowsPrivateDirectoryStable(windowsDirectory!);
+    }
     await handle.close();
     handle = undefined;
+    stage = "rename";
     await renameFile(temporary, target);
     renamed = true;
+    if (platform === "win32") {
+      assertWindowsPrivateFileBinding(windowsDirectory!, target, windowsTemporaryIdentity!);
+      assertWindowsPrivateDirectoryStable(windowsDirectory!);
+      if (classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable") {
+        return { state: "durably-committed" };
+      }
+    }
     await sync(input.root);
     return { state: "durably-committed" };
-  } catch {
+  } catch (error) {
+    if (platform === "win32" && !renamed) {
+      throw classifyWindowsPrivatePathFailure(stage, error);
+    }
     return { state: renamed ? "commit-uncertain" : "not-committed" };
   } finally {
     contents.fill(0);
@@ -94,6 +170,7 @@ export async function durableAtomicReplace(
 interface DurableAtomicRemoveInput {
   readonly root: string;
   readonly fileName: string;
+  readonly platform?: NodeJS.Platform;
   readonly createId?: () => string;
   readonly openDirectory?: typeof open;
   readonly renameFile?: typeof rename;
@@ -104,8 +181,17 @@ interface DurableAtomicRemoveInput {
 async function durableAtomicRemove(
   input: DurableAtomicRemoveInput,
 ): Promise<DurableReplaceOutcome> {
+  const platform = input.platform ?? process.platform;
   const createId = input.createId ?? randomUUID;
-  const id = createId();
+  let id: string;
+  try {
+    id = createId();
+  } catch (error) {
+    if (platform === "win32") {
+      throw classifyWindowsPrivatePathFailure("content-write", error);
+    }
+    throw error;
+  }
   if (!/^[A-Za-z0-9-]{1,128}$/.test(id)) {
     throw new TypeError("invalid durable removal temporary id");
   }
@@ -116,20 +202,46 @@ async function durableAtomicRemove(
     ((root: string): Promise<void> => syncDirectory(root, input.openDirectory ?? open));
   const target = join(input.root, input.fileName);
   const tombstone = join(input.root, `.${input.fileName}.${id}.deleted`);
+  let windowsDirectory: WindowsPrivateDirectoryBinding | undefined;
+  let windowsTargetIdentity: WindowsPrivatePathIdentity | undefined;
   try {
+    if (platform === "win32") {
+      windowsDirectory = bindWindowsPrivateDirectory(dirname(input.root), input.root);
+      const targetMetadata = await lstat(target);
+      assertWindowsPrivateFileMetadata(targetMetadata);
+      windowsTargetIdentity = windowsPrivatePathIdentity(targetMetadata);
+      assertWindowsPrivateFileBinding(windowsDirectory, target, windowsTargetIdentity);
+    }
     await renameFile(target, tombstone);
+    if (platform === "win32") {
+      assertWindowsPrivateFileBinding(windowsDirectory!, tombstone, windowsTargetIdentity!);
+      assertWindowsPrivateDirectoryStable(windowsDirectory!);
+    }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      if (platform === "win32") {
+        throw classifyWindowsPrivatePathFailure("rename", error);
+      }
       return { state: "not-committed" };
     }
   }
-  try {
-    await sync(input.root);
-  } catch {
-    return { state: "commit-uncertain" };
+  if (
+    platform !== "win32" ||
+    classifyWindowsPrivatePathDurability("directory-sync").kind !== "unavailable"
+  ) {
+    try {
+      await sync(input.root);
+    } catch {
+      return { state: "commit-uncertain" };
+    }
   }
   await removeFile(tombstone, { force: true }).catch(() => undefined);
-  await sync(input.root).catch(() => undefined);
+  if (
+    platform !== "win32" ||
+    classifyWindowsPrivatePathDurability("directory-sync").kind !== "unavailable"
+  ) {
+    await sync(input.root).catch(() => undefined);
+  }
   return { state: "durably-committed" };
 }
 

--- a/apps/desktop/src/main/first-run-config.ts
+++ b/apps/desktop/src/main/first-run-config.ts
@@ -1,7 +1,19 @@
 import { randomUUID } from "node:crypto";
-import { link, lstat, mkdir, rm, writeFile } from "node:fs/promises";
+import { link, lstat, mkdir, open, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import {
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivateFileBinding,
+  assertWindowsPrivateFileMetadata,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  classifyWindowsPrivatePathFailure,
+  sameWindowsPrivatePathIdentity,
+  windowsPrivatePathIdentity,
+  WindowsPrivatePathPolicyError,
+  type WindowsPrivatePathPolicyStage,
+} from "@enduragent/core";
 
 export const FIRST_RUN_CONFIG_DIRECTORY_MODE = 0o700;
 export const FIRST_RUN_CONFIG_FILE_MODE = 0o600;
@@ -22,11 +34,13 @@ export interface FirstRunConfigDependencies {
   readonly fileSystem?: FirstRunConfigFileSystem;
   readonly timezone?: () => string | undefined;
   readonly createId?: () => string;
+  readonly openFile?: typeof open;
 }
 
 export interface SeedFirstRunConfigInput {
   readonly env?: Record<string, string | undefined>;
   readonly dependencies?: FirstRunConfigDependencies;
+  readonly platform?: NodeJS.Platform;
 }
 
 const nodeFileSystem: FirstRunConfigFileSystem = {
@@ -102,13 +116,151 @@ async function exists(fileSystem: FirstRunConfigFileSystem, path: string): Promi
   }
 }
 
+async function assertWindowsConfigFile(
+  directory: ReturnType<typeof bindWindowsPrivateDirectory>,
+  path: string,
+  allowedLinks: 1 | 2 = 1,
+): Promise<void> {
+  const metadata = await lstat(path);
+  assertWindowsPrivateFileMetadata(metadata, allowedLinks);
+  assertWindowsPrivateFileBinding(
+    directory,
+    path,
+    windowsPrivatePathIdentity(metadata),
+    allowedLinks,
+  );
+}
+
+async function windowsConfigExists(
+  homeRoot: string,
+  configDirectory: string,
+  target: string,
+): Promise<boolean> {
+  try {
+    await lstat(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw classifyWindowsPrivatePathFailure("entry-check", error);
+  }
+  try {
+    const directory = bindWindowsPrivateDirectory(homeRoot, configDirectory);
+    await assertWindowsConfigFile(directory, target);
+    assertWindowsPrivateDirectoryStable(directory);
+    return true;
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure("entry-check", error);
+  }
+}
+
+async function seedWindowsFirstRunConfig(input: {
+  readonly fileSystem: FirstRunConfigFileSystem;
+  readonly openFile: typeof open;
+  readonly homeRoot: string;
+  readonly configDirectory: string;
+  readonly target: string;
+  readonly contents: () => string;
+  readonly createId: () => string;
+}): Promise<"seeded" | "existing"> {
+  if (await windowsConfigExists(input.homeRoot, input.configDirectory, input.target)) {
+    return "existing";
+  }
+  try {
+    await input.fileSystem.mkdir(input.configDirectory, {
+      recursive: true,
+      mode: FIRST_RUN_CONFIG_DIRECTORY_MODE,
+    });
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure("binding-check", error);
+  }
+  let directory: ReturnType<typeof bindWindowsPrivateDirectory>;
+  try {
+    directory = bindWindowsPrivateDirectory(input.homeRoot, input.configDirectory);
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure("binding-check", error);
+  }
+  let id: string;
+  try {
+    id = input.createId();
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure("content-write", error);
+  }
+  if (!/^[A-Za-z0-9-]{1,128}$/.test(id)) {
+    throw new WindowsPrivatePathPolicyError("content-write", "corruption");
+  }
+  const temporary = join(input.configDirectory, `.config.${id}.tmp`);
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let identity: ReturnType<typeof windowsPrivatePathIdentity> | undefined;
+  let stage: WindowsPrivatePathPolicyStage = "content-write";
+  try {
+    handle = await input.openFile(temporary, "wx", FIRST_RUN_CONFIG_FILE_MODE);
+    const opened = await handle.stat();
+    assertWindowsPrivateFileMetadata(opened);
+    identity = windowsPrivatePathIdentity(opened);
+    assertWindowsPrivateFileBinding(directory, temporary, identity);
+    await handle.writeFile(input.contents(), "utf8");
+    stage = "file-flush";
+    await handle.sync();
+    const flushed = await handle.stat();
+    assertWindowsPrivateFileMetadata(flushed);
+    if (!sameWindowsPrivatePathIdentity(identity, windowsPrivatePathIdentity(flushed))) {
+      throw new WindowsPrivatePathPolicyError("binding-check", "corruption");
+    }
+    assertWindowsPrivateFileBinding(directory, temporary, identity);
+    assertWindowsPrivateDirectoryStable(directory);
+    await handle.close();
+    handle = undefined;
+    stage = "rename";
+    try {
+      await input.fileSystem.link(temporary, input.target);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      await input.fileSystem.rm(temporary, { force: true });
+      await assertWindowsConfigFile(directory, input.target);
+      assertWindowsPrivateDirectoryStable(directory);
+      return "existing";
+    }
+    await assertWindowsConfigFile(directory, temporary, 2);
+    await assertWindowsConfigFile(directory, input.target, 2);
+    await input.fileSystem.rm(temporary, { force: true });
+    await assertWindowsConfigFile(directory, input.target);
+    assertWindowsPrivateDirectoryStable(directory);
+    if (classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable") {
+      return "seeded";
+    }
+    throw new WindowsPrivatePathPolicyError("rename", "io-failure");
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await input.fileSystem.rm(temporary, { force: true }).catch(() => undefined);
+    throw classifyWindowsPrivatePathFailure(stage, error);
+  }
+}
+
 export async function seedFirstRunConfig(
   input: SeedFirstRunConfigInput = {},
 ): Promise<"seeded" | "existing"> {
   const fileSystem = input.dependencies?.fileSystem ?? nodeFileSystem;
+  const platform = input.platform ?? process.platform;
   const homeRoot = resolveDesktopAthleteHome(input.env);
   const configDirectory = join(homeRoot, "config");
   const target = join(configDirectory, "config.yaml");
+  if (platform === "win32") {
+    return seedWindowsFirstRunConfig({
+      fileSystem,
+      openFile: input.dependencies?.openFile ?? open,
+      homeRoot,
+      configDirectory,
+      target,
+      contents: () => {
+        const resolvedTimezone = (input.dependencies?.timezone ?? defaultTimezone)();
+        const timezone =
+          resolvedTimezone === undefined || resolvedTimezone.length === 0
+            ? "UTC"
+            : resolvedTimezone;
+        return configContents(homeRoot, timezone);
+      },
+      createId: input.dependencies?.createId ?? randomUUID,
+    });
+  }
   if (await exists(fileSystem, target)) return "existing";
 
   await fileSystem.mkdir(configDirectory, {

--- a/apps/desktop/src/main/login-item.ts
+++ b/apps/desktop/src/main/login-item.ts
@@ -4,9 +4,17 @@ import { lstat, mkdir, open, readdir, rename, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { App, LoginItemSettings } from "electron";
 import {
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  type WindowsPrivateDirectoryBinding,
+} from "@enduragent/core";
+import {
   durablyReplaceReversible,
   type ReversibleDurableReplaceOutcome,
 } from "./durable-atomic-replace.js";
+import { assertWindowsPrivateFileAtPath, readWindowsPrivateFile } from "./windows-private-file.js";
 
 export const CLEAN_LOGIN_ITEM_STATUSES = ["not-found", "not-registered"] as const;
 export const BACKGROUND_AT_LOGIN_PREFERENCE_DIRECTORY_NAME = "desktop-preferences-v1" as const;
@@ -52,6 +60,8 @@ export interface CreateBackgroundAtLoginPreferenceStoreInput {
   readonly removeFile?: typeof rm;
   readonly syncDirectory?: (root: string) => Promise<void>;
   readonly syncParentDirectory?: (root: string) => Promise<void>;
+  readonly platform?: NodeJS.Platform;
+  readonly openFile?: typeof open;
 }
 
 interface LegacyBackgroundAtLoginPreferenceRecord {
@@ -129,6 +139,7 @@ function parsePreference(contents: string): StoredBackgroundAtLoginPreferenceRec
 export function createBackgroundAtLoginPreferenceStore(
   input: CreateBackgroundAtLoginPreferenceStoreInput,
 ): BackgroundAtLoginPreferenceStore {
+  const platform = input.platform ?? process.platform;
   const target = join(input.root, BACKGROUND_AT_LOGIN_PREFERENCE_FILE_NAME);
   const createId = input.createId ?? randomUUID;
   let namespaceState: "pending" | "verified" | "uncertain" = "pending";
@@ -153,8 +164,35 @@ export function createBackgroundAtLoginPreferenceStore(
     }
     await directory.close().catch(() => undefined);
   };
-  const synchronizeDirectory = input.syncDirectory ?? defaultSynchronizeDirectory;
-  const synchronizeParentDirectory = input.syncParentDirectory ?? defaultSynchronizeDirectory;
+  const rawSynchronizeDirectory = input.syncDirectory ?? defaultSynchronizeDirectory;
+  const rawSynchronizeParentDirectory = input.syncParentDirectory ?? defaultSynchronizeDirectory;
+  const synchronizeDirectory = async (root: string): Promise<void> => {
+    if (
+      platform === "win32" &&
+      classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable"
+    ) {
+      return;
+    }
+    await rawSynchronizeDirectory(root);
+  };
+  const synchronizeParentDirectory = async (root: string): Promise<void> => {
+    if (
+      platform === "win32" &&
+      classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable"
+    ) {
+      return;
+    }
+    await rawSynchronizeParentDirectory(root);
+  };
+  let windowsDirectory: WindowsPrivateDirectoryBinding | undefined;
+  const bindPreferenceDirectory = (): WindowsPrivateDirectoryBinding => {
+    if (windowsDirectory === undefined) {
+      windowsDirectory = bindWindowsPrivateDirectory(dirname(input.root), input.root);
+    } else {
+      assertWindowsPrivateDirectoryStable(windowsDirectory);
+    }
+    return windowsDirectory;
+  };
   const ownedTransient = (entry: string): boolean => {
     const prefix = `.${BACKGROUND_AT_LOGIN_PREFERENCE_FILE_NAME}.`;
     if (!entry.startsWith(prefix)) return false;
@@ -180,8 +218,12 @@ export function createBackgroundAtLoginPreferenceStore(
         }
         throw error;
       }
-      if (!rootMetadata.isDirectory()) throw new TypeError("invalid login preference root");
-      assertOwner(rootMetadata, LOGIN_ITEM_PREFERENCE_DIRECTORY_MODE);
+      if (platform === "win32") {
+        bindPreferenceDirectory();
+      } else {
+        if (!rootMetadata.isDirectory()) throw new TypeError("invalid login preference root");
+        assertOwner(rootMetadata, LOGIN_ITEM_PREFERENCE_DIRECTORY_MODE);
+      }
       for (const entry of await readdir(input.root)) {
         if (ownedTransient(entry)) {
           await (input.removeFile ?? rm)(join(input.root, entry), { force: true });
@@ -202,6 +244,16 @@ export function createBackgroundAtLoginPreferenceStore(
     } catch (error) {
       if (isMissing(error)) return undefined;
       throw error;
+    }
+    if (platform === "win32") {
+      return (
+        await readWindowsPrivateFile({
+          directory: bindPreferenceDirectory(),
+          path: target,
+          maximumBytes: MAX_PREFERENCE_FILE_BYTES,
+          openFile: input.openFile,
+        })
+      )?.contents;
     }
     if (!rootMetadata.isDirectory()) throw new TypeError("invalid login preference root");
     assertOwner(rootMetadata, LOGIN_ITEM_PREFERENCE_DIRECTORY_MODE);
@@ -238,7 +290,17 @@ export function createBackgroundAtLoginPreferenceStore(
     if (contents === undefined) return { schemaVersion: 1, enabled: false };
     try {
       const record = parsePreference(contents.toString("utf8"));
-      if (record === undefined) throw new TypeError("invalid login preference record");
+      if (record === undefined) {
+        if (platform === "win32") {
+          assertWindowsPrivatePathRead({
+            bounded: true,
+            identityStable: true,
+            contentValid: false,
+            authenticatedHomeBinding: true,
+          });
+        }
+        throw new TypeError("invalid login preference record");
+      }
       return record;
     } finally {
       contents.fill(0);
@@ -249,16 +311,30 @@ export function createBackgroundAtLoginPreferenceStore(
   ): Promise<ReversibleDurableReplaceOutcome> => {
     await mkdir(input.root, { recursive: true, mode: LOGIN_ITEM_PREFERENCE_DIRECTORY_MODE });
     const rootMetadata = await lstat(input.root);
-    if (!rootMetadata.isDirectory()) throw new TypeError("invalid login preference root");
-    assertOwner(rootMetadata, LOGIN_ITEM_PREFERENCE_DIRECTORY_MODE);
+    if (platform === "win32") {
+      bindPreferenceDirectory();
+    } else {
+      if (!rootMetadata.isDirectory()) throw new TypeError("invalid login preference root");
+      assertOwner(rootMetadata, LOGIN_ITEM_PREFERENCE_DIRECTORY_MODE);
+    }
     if (!parentDirectoryVerified) {
       await synchronizeParentDirectory(dirname(input.root));
       parentDirectoryVerified = true;
     }
     try {
       const existing = await lstat(target);
-      if (!existing.isFile()) throw new TypeError("invalid login preference target");
-      assertOwner(existing, LOGIN_ITEM_PREFERENCE_FILE_MODE);
+      if (platform === "win32") {
+        assertWindowsPrivateFileAtPath(
+          bindPreferenceDirectory(),
+          target,
+          existing,
+          0,
+          MAX_PREFERENCE_FILE_BYTES,
+        );
+      } else {
+        if (!existing.isFile()) throw new TypeError("invalid login preference target");
+        assertOwner(existing, LOGIN_ITEM_PREFERENCE_FILE_MODE);
+      }
     } catch (error) {
       if (!isMissing(error)) throw error;
     }
@@ -277,7 +353,8 @@ export function createBackgroundAtLoginPreferenceStore(
         createId: () => id,
         renameFile: input.renameFile,
         removeFile: input.removeFile,
-        syncDirectory: input.syncDirectory,
+        syncDirectory: platform === "win32" ? synchronizeDirectory : input.syncDirectory,
+        platform,
       });
     } finally {
       previous?.fill(0);

--- a/apps/desktop/src/main/telegram-credential-vault.ts
+++ b/apps/desktop/src/main/telegram-credential-vault.ts
@@ -11,6 +11,13 @@ import {
   type TelegramBotUsername,
   type TelegramCredential,
 } from "@enduragent/coach-contract";
+import {
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  type WindowsPrivateDirectoryBinding,
+} from "@enduragent/core";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
 import {
   durablyReplaceReversible,
@@ -21,6 +28,11 @@ import {
   type TelegramSecureStorageObserver,
   type TelegramSecureStorageStage,
 } from "./telegram-secure-storage-diagnostics.js";
+import {
+  assertWindowsPrivateFileAtPath,
+  MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+  readWindowsPrivateFile,
+} from "./windows-private-file.js";
 
 export const TELEGRAM_CREDENTIAL_DIRECTORY_NAME = "telegram-channel-v1" as const;
 export const TELEGRAM_PROFILE_FILE_NAME = "profile.bin" as const;
@@ -136,6 +148,8 @@ export interface TelegramCredentialVaultOptions {
   readonly syncDirectory?: (root: string) => Promise<void>;
   readonly syncParentDirectory?: (root: string) => Promise<void>;
   readonly observeSecureStorageFailure?: TelegramSecureStorageObserver;
+  readonly platform?: NodeJS.Platform;
+  readonly openFile?: typeof open;
 }
 
 interface TelegramDesiredStateRecord {
@@ -263,10 +277,16 @@ function parseDesiredStateRecord(value: string): TelegramDesiredStateRecord | un
   return { schemaVersion: 1, athleteHome, enabled: record.enabled };
 }
 
-function encryptionRefusal(encryption: CredentialEncryptionPort): EncryptionRefusal | undefined {
+function encryptionRefusal(
+  encryption: CredentialEncryptionPort,
+  platform: NodeJS.Platform,
+): EncryptionRefusal | undefined {
   try {
     if (!encryption.isEncryptionAvailable()) return "encryption-unavailable";
-    if (encryption.getSelectedStorageBackend?.() === UNSAFE_STORAGE_BACKEND) {
+    if (
+      platform !== "win32" &&
+      encryption.getSelectedStorageBackend?.() === UNSAFE_STORAGE_BACKEND
+    ) {
       return "unsafe-backend";
     }
     return undefined;
@@ -275,9 +295,17 @@ function encryptionRefusal(encryption: CredentialEncryptionPort): EncryptionRefu
   }
 }
 
-async function secureDirectoryState(root: string): Promise<"missing" | "secure" | "unsafe"> {
+async function secureDirectoryState(
+  root: string,
+  platform: NodeJS.Platform,
+  bindWindowsDirectory: () => WindowsPrivateDirectoryBinding,
+): Promise<"missing" | "secure" | "unsafe"> {
   try {
     const entry = await lstat(root);
+    if (platform === "win32") {
+      bindWindowsDirectory();
+      return "secure";
+    }
     return entry.isDirectory() &&
       !entry.isSymbolicLink() &&
       permissions(entry.mode) === TELEGRAM_CREDENTIAL_DIRECTORY_MODE
@@ -288,18 +316,36 @@ async function secureDirectoryState(root: string): Promise<"missing" | "secure" 
   }
 }
 
-async function ensureSecureDirectory(root: string): Promise<boolean> {
+async function ensureSecureDirectory(
+  root: string,
+  platform: NodeJS.Platform,
+  bindWindowsDirectory: () => WindowsPrivateDirectoryBinding,
+): Promise<boolean> {
   try {
     await mkdir(root, { recursive: true, mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
-    return (await secureDirectoryState(root)) === "secure";
+    return (await secureDirectoryState(root, platform, bindWindowsDirectory)) === "secure";
   } catch {
     return false;
   }
 }
 
-async function targetState(path: string): Promise<TargetState> {
+async function targetState(
+  path: string,
+  platform: NodeJS.Platform,
+  windowsDirectory: WindowsPrivateDirectoryBinding | undefined,
+): Promise<TargetState> {
   try {
     const entry = await lstat(path);
+    if (platform === "win32") {
+      assertWindowsPrivateFileAtPath(
+        windowsDirectory!,
+        path,
+        entry,
+        1,
+        MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+      );
+      return "valid";
+    }
     return entry.isFile() &&
       !entry.isSymbolicLink() &&
       entry.size > 0 &&
@@ -328,19 +374,48 @@ export function createTelegramCredentialVault(
   if (typeof options.root !== "string" || options.root.length === 0) {
     throw new TypeError("invalid Telegram credential vault root");
   }
+  const platform = options.platform ?? process.platform;
   const athleteHome = AthleteHomeIdentitySchema.parse(options.athleteHome);
   const createId = options.createId ?? randomUUID;
   const createProfileId = options.createProfileId ?? randomUUID;
   const renameFile = options.renameFile ?? rename;
   const removeFile = options.removeFile ?? rm;
-  const sync = options.syncDirectory ?? syncDirectory;
-  const syncParent = options.syncParentDirectory ?? syncDirectory;
+  const rawSync = options.syncDirectory ?? syncDirectory;
+  const rawSyncParent = options.syncParentDirectory ?? syncDirectory;
+  const sync = async (root: string): Promise<void> => {
+    if (
+      platform === "win32" &&
+      classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable"
+    ) {
+      return;
+    }
+    await rawSync(root);
+  };
+  const syncParent = async (root: string): Promise<void> => {
+    if (
+      platform === "win32" &&
+      classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable"
+    ) {
+      return;
+    }
+    await rawSyncParent(root);
+  };
   let operationQueue = Promise.resolve();
   let namespaceVerification: NamespaceVerification = "pending";
   let transientArtifactsMayExist = false;
   let profileUncertain = false;
   let desiredStateUncertain = false;
   let parentDirectoryVerified = false;
+  let windowsDirectory: WindowsPrivateDirectoryBinding | undefined;
+
+  const bindCredentialDirectory = (): WindowsPrivateDirectoryBinding => {
+    if (windowsDirectory === undefined) {
+      windowsDirectory = bindWindowsPrivateDirectory(dirname(options.root), options.root);
+    } else {
+      assertWindowsPrivateDirectoryStable(windowsDirectory);
+    }
+    return windowsDirectory;
+  };
 
   const observeFailure = (
     stage: TelegramSecureStorageStage,
@@ -350,7 +425,7 @@ export function createTelegramCredentialVault(
   };
 
   const observedEncryptionRefusal = (): EncryptionRefusal | undefined => {
-    const reason = encryptionRefusal(options.encryption);
+    const reason = encryptionRefusal(options.encryption, platform);
     if (reason !== undefined) observeFailure("encryption-availability", reason);
     return reason;
   };
@@ -365,7 +440,7 @@ export function createTelegramCredentialVault(
   };
 
   const reconcileOwnedTransients = async (forceSync: boolean): Promise<boolean> => {
-    const directory = await secureDirectoryState(options.root);
+    const directory = await secureDirectoryState(options.root, platform, bindCredentialDirectory);
     if (directory !== "secure") return true;
     let entries: readonly string[];
     try {
@@ -411,14 +486,14 @@ export function createTelegramCredentialVault(
   };
 
   const readProfile = async (): Promise<ReadProfile> => {
-    const directory = await secureDirectoryState(options.root);
+    const directory = await secureDirectoryState(options.root, platform, bindCredentialDirectory);
     if (directory === "missing") return { state: "missing" };
     if (directory === "unsafe") {
       observeFailure("namespace", "storage-failed");
       return { state: "re-prompt", reason: "storage-failed" };
     }
     const path = join(options.root, TELEGRAM_PROFILE_FILE_NAME);
-    const file = await targetState(path);
+    const file = await targetState(path, platform, windowsDirectory);
     if (file === "missing") return { state: "missing" };
     if (file === "unsafe") {
       observeFailure("profile-atomic-write", "storage-failed");
@@ -430,7 +505,19 @@ export function createTelegramCredentialVault(
     }
     let encrypted: Buffer | undefined;
     try {
-      encrypted = await readFile(path);
+      if (platform === "win32") {
+        const snapshot = await readWindowsPrivateFile({
+          directory: bindCredentialDirectory(),
+          path,
+          minimumBytes: 1,
+          maximumBytes: MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+          openFile: options.openFile,
+        });
+        if (snapshot === undefined) throw new TypeError();
+        encrypted = snapshot.contents;
+      } else {
+        encrypted = await readFile(path);
+      }
     } catch {
       observeFailure("profile-atomic-write", "storage-failed");
       return { state: "re-prompt", reason: "storage-failed" };
@@ -438,6 +525,14 @@ export function createTelegramCredentialVault(
     try {
       const profile = parseProfileRecord(options.encryption.decryptString(encrypted));
       if (profile === undefined) {
+        if (platform === "win32") {
+          assertWindowsPrivatePathRead({
+            bounded: true,
+            identityStable: true,
+            contentValid: false,
+            authenticatedHomeBinding: true,
+          });
+        }
         observeFailure("encryption-availability", "storage-failed");
         return { state: "re-prompt", reason: "decrypt-failed" };
       }
@@ -452,22 +547,46 @@ export function createTelegramCredentialVault(
   };
 
   const readDesiredState = async (): Promise<TelegramDesiredState> => {
-    const directory = await secureDirectoryState(options.root);
+    const directory = await secureDirectoryState(options.root, platform, bindCredentialDirectory);
     if (directory === "missing") return { state: "missing", enabled: false };
     if (directory === "unsafe") {
       observeFailure("namespace", "storage-failed");
       return { state: "re-prompt", enabled: false };
     }
     const path = join(options.root, TELEGRAM_DESIRED_STATE_FILE_NAME);
-    const file = await targetState(path);
+    const file = await targetState(path, platform, windowsDirectory);
     if (file === "missing") return { state: "missing", enabled: false };
     if (file === "unsafe") {
       observeFailure("desired-state-write", "storage-failed");
       return { state: "re-prompt", enabled: false };
     }
+    let contents: Buffer | undefined;
     try {
-      const record = parseDesiredStateRecord(await readFile(path, "utf8"));
+      let serialized: string;
+      if (platform === "win32") {
+        contents = (
+          await readWindowsPrivateFile({
+            directory: bindCredentialDirectory(),
+            path,
+            minimumBytes: 1,
+            maximumBytes: MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+            openFile: options.openFile,
+          })
+        )?.contents;
+        serialized = contents?.toString("utf8") ?? "";
+      } else {
+        serialized = await readFile(path, "utf8");
+      }
+      const record = parseDesiredStateRecord(serialized);
       if (record === undefined) {
+        if (platform === "win32") {
+          assertWindowsPrivatePathRead({
+            bounded: true,
+            identityStable: true,
+            contentValid: false,
+            authenticatedHomeBinding: true,
+          });
+        }
         observeFailure("desired-state-write", "storage-failed");
         return { state: "re-prompt", enabled: false };
       }
@@ -476,6 +595,8 @@ export function createTelegramCredentialVault(
     } catch {
       observeFailure("desired-state-write", "storage-failed");
       return { state: "re-prompt", enabled: false };
+    } finally {
+      contents?.fill(0);
     }
   };
 
@@ -484,7 +605,7 @@ export function createTelegramCredentialVault(
     candidate: Buffer,
     stage: Extract<TelegramSecureStorageStage, "profile-atomic-write" | "desired-state-write">,
   ): Promise<ReversibleDurableReplaceOutcome> => {
-    if (!(await ensureSecureDirectory(options.root))) {
+    if (!(await ensureSecureDirectory(options.root, platform, bindCredentialDirectory))) {
       observeFailure("namespace", "storage-failed");
       return { state: "refused" };
     }
@@ -498,14 +619,36 @@ export function createTelegramCredentialVault(
       }
     }
     const target = join(options.root, fileName);
-    const state = await targetState(target);
+    const state = await targetState(target, platform, windowsDirectory);
     if (state === "unsafe") {
       observeFailure(stage, "storage-failed");
       return { state: "refused" };
     }
     let previous: Buffer | undefined;
     try {
-      if (state === "valid") previous = await readFile(target);
+      if (platform === "win32") {
+        assertWindowsPrivatePathRead({
+          bounded: candidate.length <= MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+          identityStable: true,
+          contentValid: candidate.length > 0,
+          authenticatedHomeBinding: true,
+        });
+      }
+      if (state === "valid") {
+        previous =
+          platform === "win32"
+            ? (
+                await readWindowsPrivateFile({
+                  directory: bindCredentialDirectory(),
+                  path: target,
+                  minimumBytes: 1,
+                  maximumBytes: MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
+                  openFile: options.openFile,
+                })
+              )?.contents
+            : await readFile(target);
+        if (previous === undefined) throw new TypeError();
+      }
       transientArtifactsMayExist = true;
       const stored = await durablyReplaceReversible({
         root: options.root,
@@ -517,6 +660,7 @@ export function createTelegramCredentialVault(
         renameFile,
         removeFile,
         syncDirectory: sync,
+        platform,
       });
       if (stored.state !== "applied") {
         observeFailure(
@@ -536,9 +680,13 @@ export function createTelegramCredentialVault(
   const removeStoredProfile = async (): Promise<
     "deleted" | "cleanup-pending" | "retained" | "uncertain"
   > => {
-    if ((await secureDirectoryState(options.root)) !== "secure") return "retained";
+    if (
+      (await secureDirectoryState(options.root, platform, bindCredentialDirectory)) !== "secure"
+    ) {
+      return "retained";
+    }
     const target = join(options.root, TELEGRAM_PROFILE_FILE_NAME);
-    if ((await targetState(target)) !== "valid") return "retained";
+    if ((await targetState(target, platform, windowsDirectory)) !== "valid") return "retained";
     let id: string;
     try {
       id = createId();
@@ -635,10 +783,26 @@ export function createTelegramCredentialVault(
           bot,
         };
         let encrypted: Buffer | undefined;
+        let plaintext: Buffer | undefined;
+        let tokenPlaintext: Buffer | undefined;
         try {
-          encrypted = options.encryption.encryptString(JSON.stringify(profile));
+          const serialized = JSON.stringify(profile);
+          encrypted = options.encryption.encryptString(serialized);
           if (!Buffer.isBuffer(encrypted) || encrypted.length === 0) throw new TypeError();
+          if (platform === "win32") {
+            plaintext = Buffer.from(serialized, "utf8");
+            tokenPlaintext = Buffer.from(token, "utf8");
+            assertWindowsPrivatePathRead({
+              bounded: true,
+              identityStable: true,
+              contentValid: !encrypted.includes(plaintext) && !encrypted.includes(tokenPlaintext),
+              authenticatedHomeBinding: true,
+            });
+          }
         } catch {
+          encrypted?.fill(0);
+          plaintext?.fill(0);
+          tokenPlaintext?.fill(0);
           observeFailure("encryption-availability", "storage-failed");
           return { outcome: "refused", reason: "storage-failed" };
         }
@@ -660,6 +824,8 @@ export function createTelegramCredentialVault(
           return { outcome: "refused", reason: "storage-failed" };
         } finally {
           encrypted?.fill(0);
+          plaintext?.fill(0);
+          tokenPlaintext?.fill(0);
         }
       });
     },

--- a/apps/desktop/src/main/telegram-power.ts
+++ b/apps/desktop/src/main/telegram-power.ts
@@ -4,7 +4,15 @@ import { lstat, mkdir, open, readdir, rename, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { AthleteHomeIdentitySchema, type AthleteHomeIdentity } from "@enduragent/coach-contract";
 import type { PowerMonitor } from "electron";
+import {
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  type WindowsPrivateDirectoryBinding,
+} from "@enduragent/core";
 import { durableAtomicReplace, type DurableReplaceOutcome } from "./durable-atomic-replace.js";
+import { assertWindowsPrivateFileAtPath, readWindowsPrivateFile } from "./windows-private-file.js";
 
 export const TELEGRAM_POWER_STATE_FILE_NAME = "power-state.json" as const;
 export const TELEGRAM_POWER_STATE_DIRECTORY_MODE = 0o700;
@@ -53,6 +61,8 @@ export interface CreateDesktopTelegramPowerLifecycleInput {
   readonly syncParentDirectory?: (root: string) => Promise<void>;
   readonly reportFailure?: (failure: TelegramPowerFailure) => void;
   readonly observeWarning?: (warning: TelegramGapWarning) => void;
+  readonly platform?: NodeJS.Platform;
+  readonly openFile?: typeof open;
 }
 
 interface TelegramPowerStateRecord {
@@ -197,9 +207,18 @@ function assertOwner(metadata: Stats, mode: number): void {
   }
 }
 
-async function assertDirectory(root: string, create: boolean): Promise<void> {
+async function assertDirectory(
+  root: string,
+  create: boolean,
+  platform: NodeJS.Platform,
+  bindWindowsDirectory: () => WindowsPrivateDirectoryBinding,
+): Promise<void> {
   if (create) await mkdir(root, { recursive: true, mode: TELEGRAM_POWER_STATE_DIRECTORY_MODE });
   const metadata = await lstat(root);
+  if (platform === "win32") {
+    bindWindowsDirectory();
+    return;
+  }
   if (!metadata.isDirectory()) throw new TypeError("Telegram power state root is not a directory");
   assertOwner(metadata, TELEGRAM_POWER_STATE_DIRECTORY_MODE);
 }
@@ -223,6 +242,8 @@ function createStateStore(input: {
   readonly removeFile?: typeof rm;
   readonly syncDirectory?: (root: string) => Promise<void>;
   readonly syncParentDirectory?: (root: string) => Promise<void>;
+  readonly platform: NodeJS.Platform;
+  readonly openFile?: typeof open;
 }) {
   const target = join(input.root, TELEGRAM_POWER_STATE_FILE_NAME);
   let namespaceState: "pending" | "verified" | "uncertain" = "pending";
@@ -237,14 +258,41 @@ function createStateStore(input: {
     }
     await directory.close().catch(() => undefined);
   };
-  const synchronizeDirectory = input.syncDirectory ?? defaultSynchronizeDirectory;
-  const synchronizeParentDirectory = input.syncParentDirectory ?? defaultSynchronizeDirectory;
+  const rawSynchronizeDirectory = input.syncDirectory ?? defaultSynchronizeDirectory;
+  const rawSynchronizeParentDirectory = input.syncParentDirectory ?? defaultSynchronizeDirectory;
+  const synchronizeDirectory = async (root: string): Promise<void> => {
+    if (
+      input.platform === "win32" &&
+      classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable"
+    ) {
+      return;
+    }
+    await rawSynchronizeDirectory(root);
+  };
+  const synchronizeParentDirectory = async (root: string): Promise<void> => {
+    if (
+      input.platform === "win32" &&
+      classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable"
+    ) {
+      return;
+    }
+    await rawSynchronizeParentDirectory(root);
+  };
+  let windowsDirectory: WindowsPrivateDirectoryBinding | undefined;
+  const bindStateDirectory = (): WindowsPrivateDirectoryBinding => {
+    if (windowsDirectory === undefined) {
+      windowsDirectory = bindWindowsPrivateDirectory(dirname(input.root), input.root);
+    } else {
+      assertWindowsPrivateDirectoryStable(windowsDirectory);
+    }
+    return windowsDirectory;
+  };
   const reconcileNamespace = async (): Promise<void> => {
     if (namespaceState === "verified") return;
     if (namespaceState === "uncertain") throw new TypeError("Telegram power state is uncertain");
     try {
       try {
-        await assertDirectory(input.root, false);
+        await assertDirectory(input.root, false, input.platform, bindStateDirectory);
       } catch (error) {
         if (isMissing(error)) {
           namespaceState = "verified";
@@ -276,6 +324,29 @@ function createStateStore(input: {
     } catch (error) {
       if (isMissing(error)) return emptyState(input.athleteHome);
       throw error;
+    }
+    if (input.platform === "win32") {
+      const snapshot = await readWindowsPrivateFile({
+        directory: bindStateDirectory(),
+        path: target,
+        maximumBytes: MAX_STATE_FILE_BYTES,
+        openFile: input.openFile,
+      });
+      if (snapshot === undefined) return emptyState(input.athleteHome);
+      try {
+        const state = parseState(snapshot.contents.toString("utf8"), input.athleteHome);
+        if (state === undefined) {
+          assertWindowsPrivatePathRead({
+            bounded: true,
+            identityStable: true,
+            contentValid: false,
+            authenticatedHomeBinding: true,
+          });
+        }
+        return state!;
+      } finally {
+        snapshot.contents.fill(0);
+      }
     }
     if (!rootMetadata.isDirectory()) throw new TypeError("invalid Telegram power state root");
     assertOwner(rootMetadata, TELEGRAM_POWER_STATE_DIRECTORY_MODE);
@@ -315,15 +386,25 @@ function createStateStore(input: {
 
   const write = async (state: TelegramPowerStateRecord): Promise<DurableReplaceOutcome> => {
     await reconcileNamespace();
-    await assertDirectory(input.root, true);
+    await assertDirectory(input.root, true, input.platform, bindStateDirectory);
     if (!parentDirectoryVerified) {
       await synchronizeParentDirectory(dirname(input.root));
       parentDirectoryVerified = true;
     }
     try {
       const existing = await lstat(target);
-      if (!existing.isFile()) throw new TypeError("invalid Telegram power state target");
-      assertOwner(existing, TELEGRAM_POWER_STATE_FILE_MODE);
+      if (input.platform === "win32") {
+        assertWindowsPrivateFileAtPath(
+          bindStateDirectory(),
+          target,
+          existing,
+          0,
+          MAX_STATE_FILE_BYTES,
+        );
+      } else {
+        if (!existing.isFile()) throw new TypeError("invalid Telegram power state target");
+        assertOwner(existing, TELEGRAM_POWER_STATE_FILE_MODE);
+      }
     } catch (error) {
       if (!isMissing(error)) throw error;
     }
@@ -339,7 +420,8 @@ function createStateStore(input: {
         createId: () => id,
         renameFile: input.renameFile,
         removeFile: input.removeFile,
-        syncDirectory: input.syncDirectory,
+        syncDirectory: input.platform === "win32" ? synchronizeDirectory : input.syncDirectory,
+        platform: input.platform,
       });
       namespaceState = outcome.state === "commit-uncertain" ? "uncertain" : "verified";
       return outcome;
@@ -378,6 +460,8 @@ export function createDesktopTelegramPowerLifecycle(
     removeFile: input.removeFile,
     syncDirectory: input.syncDirectory,
     syncParentDirectory: input.syncParentDirectory,
+    platform: input.platform ?? process.platform,
+    openFile: input.openFile,
   });
   let cached: TelegramGapWarning = CLEAR_WARNING;
   let pending: Promise<void> = Promise.resolve();

--- a/apps/desktop/src/main/windows-private-file.ts
+++ b/apps/desktop/src/main/windows-private-file.ts
@@ -1,0 +1,166 @@
+import { constants, type Stats } from "node:fs";
+import { lstat, open } from "node:fs/promises";
+import {
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivateFileBinding,
+  assertWindowsPrivateFileMetadata,
+  assertWindowsPrivatePathRead,
+  classifyWindowsPrivatePathFailure,
+  sameWindowsPrivatePathIdentity,
+  windowsPrivatePathIdentity,
+  type WindowsPrivateDirectoryBinding,
+} from "@enduragent/core";
+
+export const MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES = 262_144;
+
+export interface WindowsPrivateFileSnapshot {
+  readonly contents: Buffer;
+  readonly modifiedAt: number;
+}
+
+export interface ReadWindowsPrivateFileInput {
+  readonly directory: WindowsPrivateDirectoryBinding;
+  readonly path: string;
+  readonly minimumBytes?: number;
+  readonly maximumBytes: number;
+  readonly allowedLinks?: 1 | 2;
+  readonly openFile?: typeof open;
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function assertBounded(metadata: Stats, minimumBytes: number, maximumBytes: number): void {
+  assertWindowsPrivatePathRead({
+    bounded:
+      Number.isSafeInteger(metadata.size) &&
+      metadata.size >= minimumBytes &&
+      metadata.size <= maximumBytes,
+    identityStable: true,
+    contentValid: true,
+    authenticatedHomeBinding: true,
+  });
+}
+
+export function assertWindowsPrivateFileAtPath(
+  directory: WindowsPrivateDirectoryBinding,
+  path: string,
+  metadata: Stats,
+  minimumBytes: number,
+  maximumBytes: number,
+  allowedLinks: 1 | 2 = 1,
+): void {
+  assertWindowsPrivateFileMetadata(metadata, allowedLinks);
+  assertBounded(metadata, minimumBytes, maximumBytes);
+  assertWindowsPrivateFileBinding(
+    directory,
+    path,
+    windowsPrivatePathIdentity(metadata),
+    allowedLinks,
+  );
+}
+
+export async function readWindowsPrivateFile(
+  input: ReadWindowsPrivateFileInput,
+): Promise<WindowsPrivateFileSnapshot | undefined> {
+  const minimumBytes = input.minimumBytes ?? 0;
+  const allowedLinks = input.allowedLinks ?? 1;
+  try {
+    assertWindowsPrivateDirectoryStable(input.directory);
+    let beforeOpen: Stats;
+    try {
+      beforeOpen = await lstat(input.path);
+    } catch (error) {
+      if (isMissing(error)) {
+        assertWindowsPrivateDirectoryStable(input.directory);
+        return undefined;
+      }
+      throw error;
+    }
+    assertWindowsPrivateFileAtPath(
+      input.directory,
+      input.path,
+      beforeOpen,
+      minimumBytes,
+      input.maximumBytes,
+      allowedLinks,
+    );
+    const handle = await (input.openFile ?? open)(input.path, constants.O_RDONLY);
+    let contents: Buffer | undefined;
+    try {
+      const opened = await handle.stat();
+      assertWindowsPrivateFileMetadata(opened, allowedLinks);
+      assertBounded(opened, minimumBytes, input.maximumBytes);
+      assertWindowsPrivatePathRead({
+        bounded: true,
+        identityStable: sameWindowsPrivatePathIdentity(
+          windowsPrivatePathIdentity(beforeOpen),
+          windowsPrivatePathIdentity(opened),
+        ),
+        contentValid: true,
+        authenticatedHomeBinding: true,
+      });
+      assertWindowsPrivateFileBinding(
+        input.directory,
+        input.path,
+        windowsPrivatePathIdentity(opened),
+        allowedLinks,
+      );
+      contents = Buffer.allocUnsafe(opened.size);
+      let offset = 0;
+      while (offset < contents.length) {
+        const read = await handle.read(contents, offset, contents.length - offset, offset);
+        if (read.bytesRead <= 0) {
+          assertWindowsPrivatePathRead({
+            bounded: true,
+            identityStable: true,
+            contentValid: false,
+            authenticatedHomeBinding: true,
+          });
+        }
+        offset += read.bytesRead;
+      }
+      const probe = Buffer.allocUnsafe(1);
+      const extra = await handle.read(probe, 0, probe.length, offset);
+      probe.fill(0);
+      const afterRead = await handle.stat();
+      assertWindowsPrivateFileMetadata(afterRead, allowedLinks);
+      const current = assertWindowsPrivateFileBinding(
+        input.directory,
+        input.path,
+        windowsPrivatePathIdentity(afterRead),
+        allowedLinks,
+      );
+      assertWindowsPrivatePathRead({
+        bounded: true,
+        identityStable:
+          sameWindowsPrivatePathIdentity(
+            windowsPrivatePathIdentity(beforeOpen),
+            windowsPrivatePathIdentity(opened),
+          ) &&
+          sameWindowsPrivatePathIdentity(
+            windowsPrivatePathIdentity(opened),
+            windowsPrivatePathIdentity(afterRead),
+          ) &&
+          opened.size === afterRead.size &&
+          opened.size === current.size &&
+          opened.mtimeMs === afterRead.mtimeMs &&
+          opened.mtimeMs === current.mtimeMs &&
+          opened.ctimeMs === afterRead.ctimeMs &&
+          opened.ctimeMs === current.ctimeMs,
+        contentValid: offset === opened.size && extra.bytesRead === 0,
+        authenticatedHomeBinding: true,
+      });
+      assertWindowsPrivateDirectoryStable(input.directory);
+      await handle.close();
+      return { contents, modifiedAt: afterRead.mtimeMs };
+    } catch (error) {
+      contents?.fill(0);
+      await handle.close().catch(() => undefined);
+      throw error;
+    }
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure("read-check", error);
+  }
+}

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -145,6 +145,25 @@ describe("desktop credential vault", () => {
     await expect(lstat(root)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("refuses a Windows encryption result containing plaintext", async () => {
+    const root = await temporaryRoot();
+    const vault = createCredentialVault({
+      root,
+      platform: "win32",
+      encryption: {
+        isEncryptionAvailable: () => true,
+        encryptString: (value) => Buffer.concat([Buffer.from([0]), Buffer.from(value, "utf8")]),
+        decryptString: (value) => value.toString("utf8"),
+      },
+      applyCredential: vi.fn(),
+    });
+
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: "test-token-placeholder" }),
+    ).resolves.toEqual({ slot: "anthropic", status: "refused", reason: "storage-failed" });
+    await expect(lstat(join(root, "anthropic.bin"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("accepts the macOS encryption shape and writes one atomic secure ciphertext", async () => {
     const root = await temporaryRoot();
     const sentinel = "desktop-sentinel-model-key";
@@ -1413,6 +1432,62 @@ describe("desktop credential vault", () => {
       }),
     ).resolves.toEqual({ status: "refused", reason: "invalid-input" });
     expect(applyCredential).not.toHaveBeenCalled();
+  });
+
+  it("reopens DPAPI-shaped Windows ciphertext without POSIX modes or directory sync", async () => {
+    const root = await temporaryRoot();
+    const backend = vi.fn(() => {
+      throw new TypeError("Linux-only backend probe");
+    });
+    const encryptionPort = { ...encryption(), getSelectedStorageBackend: backend };
+    const syncCredentialDirectory = vi.fn(async () => {
+      throw new TypeError("Windows directory sync must stay unavailable");
+    });
+    const syncCredentialParentDirectory = vi.fn(async () => {
+      throw new TypeError("Windows parent sync must stay unavailable");
+    });
+    const vault = createCredentialVault({
+      root,
+      platform: "win32",
+      encryption: encryptionPort,
+      applyCredential: vi.fn(async () => undefined),
+      createId: () => randomUUID(),
+      syncCredentialDirectory,
+      syncCredentialParentDirectory,
+    });
+
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: "synthetic-windows-anthropic" }),
+    ).resolves.toMatchObject({ status: "configured" });
+    await expect(
+      vault.writeCredential({ slot: "openrouter", value: "synthetic-windows-openrouter" }),
+    ).resolves.toMatchObject({ status: "configured" });
+    expect(
+      (await readFile(join(root, "anthropic.bin"))).includes("synthetic-windows-anthropic"),
+    ).toBe(false);
+    expect(
+      (await readFile(join(root, "openrouter.bin"))).includes("synthetic-windows-openrouter"),
+    ).toBe(false);
+
+    await chmod(root, 0o755);
+    await writeFile(join(root, "anthropic.bin"), "corrupt-ciphertext");
+    const reopened = createCredentialVault({
+      root,
+      platform: "win32",
+      encryption: encryptionPort,
+      applyCredential: vi.fn(async () => undefined),
+      syncCredentialDirectory,
+      syncCredentialParentDirectory,
+    });
+    await expect(reopened.credentialStatuses()).resolves.toEqual(
+      expect.arrayContaining([
+        { slot: "anthropic", state: "re-prompt", runtimeState: null },
+        { slot: "openrouter", state: "configured", runtimeState: "stored-inactive" },
+      ]),
+    );
+    expect(backend).not.toHaveBeenCalled();
+    expect(syncCredentialDirectory).not.toHaveBeenCalled();
+    expect(syncCredentialParentDirectory).not.toHaveBeenCalled();
   });
 
   it("marks model credentials inactive when a profile becomes selected", () => {

--- a/apps/desktop/tests/durable-atomic-replace.test.ts
+++ b/apps/desktop/tests/durable-atomic-replace.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { WindowsPrivatePathPolicyError } from "@enduragent/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   durableAtomicReplace,
@@ -296,5 +297,71 @@ describe("durable atomic replace", () => {
     await expect(readFile(target, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     expect((await readdir(root)).filter((entry) => entry.endsWith(".deleted"))).toEqual([]);
     expect(idCount).toBe(1);
+  });
+
+  it("uses the Windows durability taxonomy without chmod or directory sync", async () => {
+    const root = await temporaryRoot();
+    const synchronizeDirectory = vi.fn(async () => {
+      throw new TypeError("Windows directory sync must stay unavailable");
+    });
+    const chmod = vi.fn(async () => {
+      throw new TypeError("Windows must not apply a POSIX mode");
+    });
+
+    const result = await durableAtomicReplace({
+      root,
+      fileName: "setting.json",
+      contents: "candidate",
+      mode: 0o600,
+      platform: "win32",
+      createId: () => "windows-write",
+      openFile: (async (path, flags, mode) => {
+        const handle = await open(path, flags, mode);
+        return new Proxy(handle, {
+          get(target, property) {
+            if (property === "chmod") return chmod;
+            const value = Reflect.get(target, property);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        });
+      }) as typeof open,
+      syncDirectory: synchronizeDirectory,
+    });
+
+    expect(result).toEqual({ state: "durably-committed" });
+    await expect(readFile(join(root, "setting.json"), "utf8")).resolves.toBe("candidate");
+    expect(chmod).not.toHaveBeenCalled();
+    expect(synchronizeDirectory).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a path-free Windows sharing failure at the rename stage", async () => {
+    const root = await temporaryRoot();
+    const failure = Object.assign(new Error(`${root} synthetic-secret`), { code: "EBUSY" });
+    let observed: unknown;
+
+    try {
+      await durableAtomicReplace({
+        root,
+        fileName: "setting.json",
+        contents: "candidate",
+        mode: 0o600,
+        platform: "win32",
+        createId: () => "windows-sharing",
+        renameFile: async () => {
+          throw failure;
+        },
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(observed).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(observed).toMatchObject({
+      message: "Windows private path policy failed",
+      stage: "rename",
+      category: "sharing-violation",
+    });
+    expect(JSON.stringify(observed)).not.toContain(root);
+    expect(JSON.stringify(observed)).not.toContain("synthetic-secret");
   });
 });

--- a/apps/desktop/tests/first-run-config.test.ts
+++ b/apps/desktop/tests/first-run-config.test.ts
@@ -1,8 +1,10 @@
 import {
+  chmod,
   lstat as fileLstat,
   link as fileLink,
   mkdir as fileMkdir,
   mkdtemp,
+  open as fileOpen,
   readFile,
   realpath,
   readdir,
@@ -11,6 +13,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { WindowsPrivatePathPolicyError } from "@enduragent/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
 import {
@@ -183,6 +186,84 @@ describe("desktop first-run configuration", () => {
       session: { timezone: string };
     };
     expect(parsed.session.timezone).toBe("UTC");
+  });
+
+  it("seeds and reopens a Windows configuration without POSIX mode assertions", async () => {
+    const home = await temporaryHome();
+    const timezone = vi.fn(() => "Asia/Almaty");
+
+    await expect(
+      seedFirstRunConfig({
+        env: { ENDURAGENT_HOME: home },
+        platform: "win32",
+        dependencies: { timezone, createId: () => "windows-seed" },
+      }),
+    ).resolves.toBe("seeded");
+
+    const configDirectory = join(home, "config");
+    const configPath = join(configDirectory, "config.yaml");
+    expect((await fileLstat(configPath)).nlink).toBe(1);
+    expect(parseYaml(await readFile(configPath, "utf8"))).toMatchObject({
+      data_dir: resolve(home),
+      session: { timezone: "Asia/Almaty" },
+    });
+    await chmod(configDirectory, 0o755);
+    await chmod(configPath, 0o644);
+    const existingTimezone = vi.fn(() => "UTC");
+    await expect(
+      seedFirstRunConfig({
+        env: { ENDURAGENT_HOME: home },
+        platform: "win32",
+        dependencies: { timezone: existingTimezone },
+      }),
+    ).resolves.toBe("existing");
+    expect(existingTimezone).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a path-free Windows first-run file-flush failure", async () => {
+    const home = await temporaryHome();
+    let observed: unknown;
+
+    try {
+      await seedFirstRunConfig({
+        env: { ENDURAGENT_HOME: home },
+        platform: "win32",
+        dependencies: {
+          timezone: () => "UTC",
+          createId: () => "windows-flush-failure",
+          openFile: (async (path, flags, mode) => {
+            const handle = await fileOpen(path, flags, mode);
+            return new Proxy(handle, {
+              get(target, property) {
+                if (property === "sync") {
+                  return async () => {
+                    throw Object.assign(new Error(`${home} synthetic-private-value`), {
+                      code: "EIO",
+                    });
+                  };
+                }
+                const value = Reflect.get(target, property);
+                return typeof value === "function" ? value.bind(target) : value;
+              },
+            });
+          }) as typeof fileOpen,
+        },
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(observed).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(observed).toMatchObject({
+      message: "Windows private path policy failed",
+      stage: "file-flush",
+      category: "io-failure",
+    });
+    expect(JSON.stringify(observed)).not.toContain(home);
+    expect(JSON.stringify(observed)).not.toContain("synthetic-private-value");
+    await expect(fileLstat(join(home, "config", "config.yaml"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("prepares the home before seeding and constructing the daemon supervisor", async () => {

--- a/apps/desktop/tests/login-item.test.ts
+++ b/apps/desktop/tests/login-item.test.ts
@@ -325,6 +325,44 @@ describe("background-at-login preference", () => {
     expect((await lstat(owned)).isFile()).toBe(true);
   });
 
+  it("persists the Windows preference without POSIX ownership or directory sync", async () => {
+    const root = join(await scratch(), "preferences");
+    const synchronizeDirectory = vi.fn(async () => {
+      throw new TypeError("Windows directory sync must stay unavailable");
+    });
+    const synchronizeParentDirectory = vi.fn(async () => {
+      throw new TypeError("Windows parent sync must stay unavailable");
+    });
+    const store = createBackgroundAtLoginPreferenceStore({
+      root,
+      platform: "win32",
+      createId: () => "windows-preference",
+      syncDirectory: synchronizeDirectory,
+      syncParentDirectory: synchronizeParentDirectory,
+    });
+
+    await expect(store.set(true)).resolves.toEqual({ status: "stored", enabled: true });
+    const target = join(root, BACKGROUND_AT_LOGIN_PREFERENCE_FILE_NAME);
+    await chmod(root, 0o755);
+    await chmod(target, 0o644);
+    const reopened = createBackgroundAtLoginPreferenceStore({
+      root,
+      platform: "win32",
+      syncDirectory: synchronizeDirectory,
+      syncParentDirectory: synchronizeParentDirectory,
+    });
+    await expect(reopened.read()).resolves.toEqual({
+      state: "configured",
+      enabled: true,
+      loginLaunchBehavior: "background",
+    });
+    expect(synchronizeDirectory).not.toHaveBeenCalled();
+    expect(synchronizeParentDirectory).not.toHaveBeenCalled();
+
+    await writeFile(target, '{"schemaVersion":2}\n');
+    await expect(reopened.read()).resolves.toEqual({ state: "unavailable", enabled: false });
+  });
+
   it("starts in background only for an OS-login launch with the preference enabled", async () => {
     const read = vi.fn(async () => ({ state: "configured", enabled: true }) as const);
     const manualLaunch = {

--- a/apps/desktop/tests/telegram-credential-vault.test.ts
+++ b/apps/desktop/tests/telegram-credential-vault.test.ts
@@ -1144,6 +1144,60 @@ describe("Telegram credential vault", () => {
     expect(apply).not.toHaveBeenCalled();
   });
 
+  it("keeps Windows DPAPI ciphertext isolated from a corrupt profile and desired state", async () => {
+    const value = await fixture();
+    const backend = vi.fn(() => {
+      throw new TypeError("Linux-only backend probe");
+    });
+    const encryptionPort = { ...encryption(), getSelectedStorageBackend: backend };
+    const synchronizeDirectory = vi.fn(async () => {
+      throw new TypeError("Windows directory sync must stay unavailable");
+    });
+    const synchronizeParentDirectory = vi.fn(async () => {
+      throw new TypeError("Windows parent sync must stay unavailable");
+    });
+    const vault = createTelegramCredentialVault({
+      ...value,
+      platform: "win32",
+      encryption: encryptionPort,
+      createProfileId: () => PROFILE_A,
+      syncDirectory: synchronizeDirectory,
+      syncParentDirectory: synchronizeParentDirectory,
+    });
+
+    await expect(
+      vault.replaceProfile({
+        token: "test-token-placeholder",
+        bot: BOT_A,
+        authenticatedAthleteHome: value.athleteHome,
+      }),
+    ).resolves.toMatchObject({ outcome: "applied", profileId: PROFILE_A });
+    await expect(vault.setDesiredState(true)).resolves.toEqual({ status: "stored", enabled: true });
+    expect(
+      (await readFile(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).includes(
+        "test-token-placeholder",
+      ),
+    ).toBe(false);
+
+    await chmod(value.root, 0o755);
+    await writeFile(join(value.root, TELEGRAM_PROFILE_FILE_NAME), "corrupt-ciphertext");
+    const reopened = createTelegramCredentialVault({
+      ...value,
+      platform: "win32",
+      encryption: encryptionPort,
+      syncDirectory: synchronizeDirectory,
+      syncParentDirectory: synchronizeParentDirectory,
+    });
+    await expect(reopened.profileStatus()).resolves.toEqual({
+      state: "re-prompt",
+      reason: "storage-failed",
+    });
+    await expect(reopened.desiredState()).resolves.toEqual({ state: "configured", enabled: true });
+    expect(backend).not.toHaveBeenCalled();
+    expect(synchronizeDirectory).not.toHaveBeenCalled();
+    expect(synchronizeParentDirectory).not.toHaveBeenCalled();
+  });
+
   it("serializes plaintext application with profile deletion", async () => {
     const value = await fixture();
     await seedProfile(value);
@@ -1163,5 +1217,33 @@ describe("Telegram credential vault", () => {
 
     await expect(apply).resolves.toMatchObject({ outcome: "applied", profileId: PROFILE_A });
     await expect(deletion).resolves.toEqual({ outcome: "applied", cleanupPending: false });
+  });
+
+  it("refuses a Windows Telegram encryption result containing plaintext", async () => {
+    const value = await fixture();
+    const unsafePort = {
+      ...encryption(),
+      encryptString(contents: string) {
+        const profile = JSON.parse(contents) as TelegramProfileRecord;
+        return Buffer.concat([Buffer.from([0]), Buffer.from(profile.token)]);
+      },
+    };
+    const vault = createTelegramCredentialVault({
+      ...value,
+      platform: "win32",
+      encryption: unsafePort,
+      createProfileId: () => PROFILE_A,
+    });
+
+    await expect(
+      vault.replaceProfile({
+        token: "test-token-placeholder",
+        bot: BOT_A,
+        authenticatedAthleteHome: value.athleteHome,
+      }),
+    ).resolves.toEqual({ outcome: "refused", reason: "storage-failed" });
+    await expect(lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 });

--- a/apps/desktop/tests/telegram-power.test.ts
+++ b/apps/desktop/tests/telegram-power.test.ts
@@ -686,6 +686,55 @@ describe("Desktop Telegram power lifecycle", () => {
     expect(failures).toContain("read-state");
   });
 
+  it("reopens Windows power state without POSIX ownership or directory sync", async () => {
+    const files = await fixture();
+    const observedAt = Date.parse("2026-08-01T00:00:00.000Z");
+    const synchronizeDirectory = vi.fn(async () => {
+      throw new TypeError("Windows directory sync must stay unavailable");
+    });
+    const synchronizeParentDirectory = vi.fn(async () => {
+      throw new TypeError("Windows parent sync must stay unavailable");
+    });
+    const firstController = controller();
+    firstController.status.mockResolvedValue(pollingStatus("online"));
+    const lifecycle = createDesktopTelegramPowerLifecycle({
+      ...files,
+      platform: "win32",
+      powerMonitor: monitor(),
+      controller: firstController,
+      now: () => observedAt,
+      createId: () => "windows-power-state",
+      syncDirectory: synchronizeDirectory,
+      syncParentDirectory: synchronizeParentDirectory,
+    });
+
+    await expect(lifecycle.start()).resolves.toEqual({ state: "clear" });
+    await lifecycle.close();
+    const target = join(files.root, TELEGRAM_POWER_STATE_FILE_NAME);
+    await chmod(files.root, 0o755);
+    await chmod(target, 0o644);
+    const secondController = controller();
+    secondController.status.mockResolvedValue(pollingStatus("online"));
+    const reopened = createDesktopTelegramPowerLifecycle({
+      ...files,
+      platform: "win32",
+      powerMonitor: monitor(),
+      controller: secondController,
+      now: () => observedAt,
+      createId: () => "windows-power-reopen",
+      syncDirectory: synchronizeDirectory,
+      syncParentDirectory: synchronizeParentDirectory,
+    });
+    await expect(reopened.start()).resolves.toEqual({ state: "clear" });
+    expect(JSON.parse(await readFile(target, "utf8"))).toMatchObject({
+      schemaVersion: 2,
+      athleteHome: files.athleteHome,
+    });
+    expect(synchronizeDirectory).not.toHaveBeenCalled();
+    expect(synchronizeParentDirectory).not.toHaveBeenCalled();
+    await reopened.close();
+  });
+
   it("does not block suspend and still reconciles when stopping a stale poll fails", async () => {
     const files = await fixture();
     const powerMonitor = monitor();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -148,6 +148,7 @@ export {
   assertWindowsPrivateFileMetadata,
   assertWindowsPrivatePathRead,
   bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
   classifyWindowsPrivatePathFailure,
   sameWindowsPrivatePathIdentity,
   windowsPrivatePathIdentity,


### PR DESCRIPTION
## What

Makes the API-key and Telegram credential vaults, first-run config seeding, and Desktop preference writers correct on packaged Windows. Win32 paths dispatch through the established private-path policy via a new thin package-local adapter (apps/desktop/src/main/windows-private-file.ts) that consumes the Core policy exports; DPAPI-backed safeStorage stays the only encryption mechanism, and unavailable encryption or corrupt ciphertext fails closed with stage-coded, path-free, secret-free diagnostics that surface recovery without resetting unrelated state. The durable-atomic-replace writer classifies Windows directory-sync unavailability through the policy taxonomy instead of skipping it silently. Every non-Windows path is byte-identical to HEAD, including the macOS durable-replace sequence and POSIX checks. No plaintext secret is ever written on any platform.

## Placement decision

First-run config (config.yaml) intentionally stays in the athlete home (%USERPROFILE%\.enduragent) rather than LocalAppData: it is shared athlete state that the CLI also reads, and the frozen two-root contract puts only Desktop-private Electron state under %LOCALAPPDATA%\Enduragent. Moving it would break shared-state parity with macOS.

## New limit (win32 only)

- MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES = 262144 (apps/desktop/src/main/windows-private-file.ts) — bounded stable read for vault/config files; an unbounded read of a corrupt vault file could stall startup.

## Non-goals (deliberate)

- Chat/transcript/conversation stores, daemon RPC, auth/profile, memory, usage, Telegram runtime beyond the preference writers, renderer, and packaging scripts are untouched.
- No changeset: no user-visible behavior change on any currently shipped platform.

## Verification

- apps/desktop suite: 1289 passed / 0 failed
- core suite: 2623 passed / 0 failed / 5 skipped
- coach suite (repo-root cwd, Node 24): 732 passed / 0 failed
- Root pnpm check: pass
