### PR TITLE
chore: drop the duplicate desktop sidebar changeset

### DIFF
--- a/.changeset/clean-desktop-sidebar.md
+++ b/.changeset/clean-desktop-sidebar.md
@@ -1,9 +1,0 @@
----
-"cycling-coach": patch
-"@enduragent/desktop": patch
-"@enduragent/desktop-renderer": patch
----
-
-User-facing: Desktop now uses the Enduragent logo as its app icon and has a simpler sidebar with clearer training-data sync status.
-
-Replace the default packaged application icon with the website mark, remove sidebar surfaces that duplicate Chat navigation or expose internal process state, and label successful refreshes as "Training data synced."


### PR DESCRIPTION
Removes `.changeset/clean-desktop-sidebar.md`, which is a duplicate of a changeset that has already been released.

**It was already consumed and shipped.** Its `User-facing:` line and body appear verbatim in `apps/desktop/CHANGELOG.md` under `## 0.1.1` as entry `0da7580`. The file was then accidentally re-added when a long-lived branch landed back on `main`, resurrecting a byte-identical copy of the already-consumed file.

**Left in place, it would print the same release note to athletes twice** — once in the shipped 0.1.1 changelog and again in the next release's notes, for work that has not changed since.

**Its macOS icon claim is also false for this release.** The packaged mac icon is byte-identical across this version range, so "Desktop now uses the Enduragent logo as its app icon" would describe a change that does not exist in these release notes.

Nothing is lost by the deletion: the genuine sidebar change in this release is already covered by `.changeset/calm-coaches-chat.md`.

## Test plan

- `.changeset/clean-desktop-sidebar.md` is gone; no other file changes.
- Existing CI (build, lint, tests, packaged self-test) passes.
- The pending Version Packages PR no longer carries the duplicated sidebar/icon note.
