### PR TITLE
chore(config): finish delete-only copy sweep in pending changeset

### DIFF
--- a/.changeset/calm-coaches-chat.md
+++ b/.changeset/calm-coaches-chat.md
@@ -11,4 +11,4 @@ Setup now stays in Chat until the coach is ready and remains available at the to
 
 Desktop setup readiness is rechecked from durable runtime state on every launch, and chat actions fail closed until the provider, training data, and saved safety intake are ready.
 
-Chat setup can verify or replace a Telegram bot from a copied BotFather token, remove its local credential safely, and always keeps pairing and access management in Settings.
+Chat setup can connect a Telegram bot from a copied BotFather token and safely delete its connection from this Mac, and always keeps pairing and access management in Settings.


### PR DESCRIPTION
## What

Rewrites the last surviving replacement-era promise in the repo: the pending `calm-coaches-chat` changeset still said Chat setup can "verify or replace a Telegram bot". Since #588, Telegram management is delete-and-reconnect — the release note now says exactly that.

A repo-wide sweep at current main (`Replace token`, `replace it from the clipboard`, `replace the bot token`, `verify or replace`, `Cancel replacement` across packages, apps, changesets, README) confirms this was the only remaining hit; #583 and #588 already cleaned every product surface.

## Verification

Changeset body copy only — no code, no `User-facing:` line changes; CI validates changeset structure.