### PR TITLE
test(desktop): align first-run integration test with clipboard-only training setup

### DIFF
--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -37,7 +37,7 @@ interface FixtureIntake {
 
 function makeScript(): DesktopFixtureScript {
   let savedIntake: FixtureIntake | null = null;
-  let durableTrainingData = false;
+  let durableTrainingData = true;
   return {
     onRequest(value) {
       const request = value as ScriptRequest;
@@ -228,10 +228,14 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
       panelButton("api-key", "Save")?.click();
       await waitGone('[data-setup-panel="api-key"]');
       document.querySelector('[data-setup-trigger="training"]')?.click();
-      await waitFor('[data-setup-panel="training"]');
-      fill('input[data-slot="intervals-icu"]', "synthetic-training-key");
-      panelButton("training", "Save")?.click();
-      await waitFor('[data-setup-row="training"][data-state="ready"]');
+      const trainingPanel = await waitFor('[data-setup-panel="training"]');
+      if (panelButton("training", "Use copied API key") === undefined) {
+        throw new Error("missing Use copied API key action");
+      }
+      if (trainingPanel.querySelector('input[data-slot="intervals-icu"]') !== null) {
+        throw new Error("unexpected Intervals.icu credential input");
+      }
+      await waitFor('[data-setup-readiness="2"]');
       pick("onboarding-injury-status", "none");
       await new Promise((resolve) => setTimeout(resolve, 60));
       button("Start coaching")?.click();


### PR DESCRIPTION
## What

Test-only fix. The first-run integration test (`onboarding-first-run.integration.test.ts`) has been un-passable on `main` since #583 merged: it completed training setup by filling `input[data-slot="intervals-icu"]` and clicking Save — UI that #583 removed in favor of clipboard-only connect. The failure never surfaced on CI because the `test` job runs on ubuntu and every desktop integration suite is darwin-only (skipIf), and locally it hid behind launch-timeout flakiness under heavy machine load.

The clipboard lane fail-closes on real remote verification, so a synthetic key cannot connect in a test. The fix reaches training readiness the way the product allows: the test's own fixture daemon now reports durable training data, making the training row ready without a credential. The training panel interaction now pins the shipped flow instead of silently depending on removed UI — it fails if `Use copied API key` is missing or if an Intervals key input ever reappears — then waits for the 2-of-3 readiness state before finishing setup. Every downstream assertion is unchanged.

## Verification

The fixed test passes against the built app (1/1). Full desktop suite on an idle machine: 60 files, 1,325/1,325 — including the launch-sensitive chat-panels and spend-meter suites. Desktop type check passes. One file changed, +9/−5, no production code touched.

Worth considering separately: running the desktop integration suites on a macOS CI runner so a break in this family cannot ship silently again.