### PR TITLE
feat(core): make remaining desktop-reachable stores windows-safe

### DIFF
--- a/packages/coach/src/capture.ts
+++ b/packages/coach/src/capture.ts
@@ -50,6 +50,7 @@ export interface RunReferenceCaptureOptions {
   readonly budget?: SyncBudget;
   readonly baseFetch?: typeof globalThis.fetch;
   readonly attemptLedger?: PhysicalRequestLedger;
+  readonly platform?: NodeJS.Platform;
 }
 
 export interface RunReferenceCaptureDependencies {
@@ -235,9 +236,15 @@ export async function runReferenceCapture(
     try {
       const committed = await (dependencies.writeSidecars ?? writeReferenceCaptureSidecars)({
         root: home.root, manifest, review, assertReplayable,
+        ...(options.platform === undefined ? {} : { platform: options.platform }),
       });
       if (dependencies.loadSidecars !== undefined) {
-        const loaded = await dependencies.loadSidecars({ root: home.root, captureId, assertReplayable });
+        const loaded = await dependencies.loadSidecars({
+          root: home.root,
+          captureId,
+          assertReplayable,
+          ...(options.platform === undefined ? {} : { platform: options.platform }),
+        });
         return loaded.manifest;
       }
       return committed.manifest;

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -793,6 +793,7 @@ export async function createLocalCoachComposition(
       reference,
       writerContext: input.context,
       dependencies: dependencies.runtimeDependencies,
+      ...(dependencies.platform === undefined ? {} : { platform: dependencies.platform }),
     };
     runtime =
       dependencies.createRuntime === undefined
@@ -832,7 +833,7 @@ export async function createLocalCoachComposition(
               ...config,
               session: { ...config.session, timezone },
             };
-      const memory = new Memory(input.home.root, timezone);
+      const memory = new Memory(input.home.root, timezone, { platform: dependencies.platform });
       const conversationStore = createConversationStore(
         input.home.root,
         config.session.resetArchiveRetentionDays,

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -70,6 +70,7 @@ export interface StoreRuntimeOptions {
   readonly reference: ReferenceRuntime;
   readonly writerContext?: CoachStoreWriterContext;
   readonly dependencies?: StoreRuntimeDependencies;
+  readonly platform?: NodeJS.Platform;
 }
 
 function sameHome(left: AthleteHome, right: AthleteHome): boolean {
@@ -402,6 +403,9 @@ LIMIT 1`,
                 : { replacesCaptureId: this.snapshotValue.captureId }),
               budget,
               attemptLedger: ledger,
+              ...(this.options.platform === undefined
+                ? {}
+                : { platform: this.options.platform }),
             });
       const legacyPromise = this.options.reference.runScheduledOnce();
       const [captureResult, legacyResult] = await Promise.allSettled([

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -67,6 +67,7 @@ async function makeRuntime(
   runtimeConfig: Config = config,
   readConfig?: () => Config,
   readonlyStore: SqlReadStore = emptyReadonlyStore(),
+  platform?: NodeJS.Platform,
 ) {
   const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-"));
   roots.push(root);
@@ -114,6 +115,7 @@ async function makeRuntime(
       configDir: join(root, "config"),
     },
     reference,
+    ...(platform === undefined ? {} : { platform }),
     dependencies: {
       capture,
       refreshCurves,
@@ -127,6 +129,15 @@ async function makeRuntime(
 }
 
 describe("StoreRuntime", () => {
+  it("threads injected win32 semantics into Reference capture", async () => {
+    const { runtime, capture } = await makeRuntime(config, undefined, emptyReadonlyStore(), "win32");
+
+    await runtime.runWindow();
+
+    expect(capture).toHaveBeenCalledWith(expect.objectContaining({ platform: "win32" }));
+    await runtime.close();
+  });
+
   it("runs base capture, curve acquisition, and legacy refresh in one ledger window", async () => {
     const { runtime, capture, refreshCurves, produce, reference } = await makeRuntime();
     const result = await runtime.runWindow();

--- a/packages/core/src/channels/allowed-senders.ts
+++ b/packages/core/src/channels/allowed-senders.ts
@@ -4,26 +4,52 @@ import {
   closeSync,
   createReadStream,
   existsSync,
+  fstatSync,
+  ftruncateSync,
   fsyncSync,
   linkSync,
   lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
+  readSync,
   renameSync,
   statSync,
   unlinkSync,
   writeFileSync,
+  type Stats,
 } from "node:fs";
 import { constants as fsConstants } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { TextDecoder } from "node:util";
 import { z } from "zod";
+import {
+  WindowsPrivatePathPolicyError,
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivateFileBinding,
+  assertWindowsPrivateFileMetadata,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  classifyWindowsPrivatePathFailure,
+  sameWindowsPrivatePathIdentity,
+  windowsPrivatePathIdentity,
+  type WindowsPrivateDirectoryBinding,
+  type WindowsPrivatePathIdentity,
+  type WindowsPrivatePathPolicyStage,
+} from "../io/windows-private-path-policy.js";
 import { enumerateTelegramSessions } from "./telegram-sessions.js";
 
 export type DmPolicy = "pairing" | "allowlist" | "open";
 
 export const ALLOWED_SENDERS_FILE = "allowed-senders.json";
+export const MAX_ALLOWED_SENDERS_FILE_BYTES = 1_048_576;
 const ACCESS_RESET_MARKER = ".telegram-access-reset";
+const STRICT_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+
+export interface AllowedSendersStorageOptions {
+  readonly platform?: NodeJS.Platform;
+}
 
 export interface AllowedSenders {
   version: 1;
@@ -85,7 +111,11 @@ const senderIdSchema = z
   .transform((v) => String(v))
   .refine((s) => SENDER_ID_RE.test(s));
 
-function validateSchema(parsed: unknown, path: string): AllowedSenders | null {
+function validateSchema(
+  parsed: unknown,
+  diagnostic: string,
+  discloseInvalidEntries = true,
+): AllowedSenders | null {
   const schema = z
     .object({
       version: z.literal(1),
@@ -97,7 +127,9 @@ function validateSchema(parsed: unknown, path: string): AllowedSenders | null {
           if (r.success) out.push(r.data);
           else
             console.error(
-              `[security] ${path}: dropped invalid allowFrom entry ${JSON.stringify(item)}.`,
+              discloseInvalidEntries
+                ? `[security] ${diagnostic}: dropped invalid allowFrom entry ${JSON.stringify(item)}.`
+                : `[security] ${diagnostic}: dropped invalid allowFrom entry.`,
             );
         }
         return out;
@@ -113,36 +145,154 @@ function validateSchema(parsed: unknown, path: string): AllowedSenders | null {
   if (!result.success) {
     const issue = result.error.issues[0];
     const field = issue.path.join(".") || "root";
-    console.error(`[security] ${path}: invalid ${field}; falling back to default-pairing.`);
+    console.error(`[security] ${diagnostic}: invalid ${field}; falling back to default-pairing.`);
     return null;
   }
   if (result.data.allowFrom.length === 0 && result.data.dmPolicy === "allowlist") {
     console.error(
-      `[security] ${path}: allowlist mode with no valid allowFrom entries; falling back to default-pairing.`,
+      `[security] ${diagnostic}: allowlist mode with no valid allowFrom entries; falling back to default-pairing.`,
     );
     return null;
   }
   return result.data as AllowedSenders;
 }
 
-function loadFromFile(dataDir: string): AllowedSenders | null {
+function readWindowsAllowedSendersFile(dataDir: string, path: string): string | null {
+  let descriptor: number | undefined;
+  let contents: Buffer | undefined;
+  try {
+    const directory = bindWindowsPrivateDirectory(dirname(dataDir), dataDir);
+    let beforeOpen;
+    try {
+      beforeOpen = lstatSync(path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        assertWindowsPrivateDirectoryStable(directory);
+        return null;
+      }
+      throw error;
+    }
+    assertWindowsPrivateFileMetadata(beforeOpen);
+    assertWindowsPrivatePathRead({
+      bounded:
+        Number.isSafeInteger(beforeOpen.size) && beforeOpen.size <= MAX_ALLOWED_SENDERS_FILE_BYTES,
+      identityStable: true,
+      contentValid: true,
+      authenticatedHomeBinding: true,
+    });
+    const expectedIdentity = windowsPrivatePathIdentity(beforeOpen);
+    assertWindowsPrivateFileBinding(directory, path, expectedIdentity);
+    descriptor = openSync(path, fsConstants.O_RDONLY);
+    const opened = fstatSync(descriptor);
+    assertWindowsPrivateFileMetadata(opened);
+    assertWindowsPrivatePathRead({
+      bounded: Number.isSafeInteger(opened.size) && opened.size <= MAX_ALLOWED_SENDERS_FILE_BYTES,
+      identityStable: sameWindowsPrivatePathIdentity(
+        expectedIdentity,
+        windowsPrivatePathIdentity(opened),
+      ),
+      contentValid: true,
+      authenticatedHomeBinding: true,
+    });
+    assertWindowsPrivateFileBinding(directory, path, windowsPrivatePathIdentity(opened));
+    contents = Buffer.allocUnsafe(opened.size);
+    let offset = 0;
+    while (offset < contents.length) {
+      const bytesRead = readSync(descriptor, contents, offset, contents.length - offset, offset);
+      if (bytesRead <= 0) {
+        throw new WindowsPrivatePathPolicyError("read-check", "corruption");
+      }
+      offset += bytesRead;
+    }
+    const probe = Buffer.allocUnsafe(1);
+    const extraBytes = readSync(descriptor, probe, 0, probe.length, offset);
+    probe.fill(0);
+    const afterRead = fstatSync(descriptor);
+    assertWindowsPrivateFileMetadata(afterRead);
+    const current = assertWindowsPrivateFileBinding(
+      directory,
+      path,
+      windowsPrivatePathIdentity(afterRead),
+    );
+    assertWindowsPrivatePathRead({
+      bounded: true,
+      identityStable:
+        sameWindowsPrivatePathIdentity(
+          expectedIdentity,
+          windowsPrivatePathIdentity(opened),
+        ) &&
+        sameWindowsPrivatePathIdentity(
+          windowsPrivatePathIdentity(opened),
+          windowsPrivatePathIdentity(afterRead),
+        ) &&
+        opened.size === afterRead.size &&
+        opened.size === current.size &&
+        opened.mtimeMs === afterRead.mtimeMs &&
+        opened.mtimeMs === current.mtimeMs &&
+        opened.ctimeMs === afterRead.ctimeMs &&
+        opened.ctimeMs === current.ctimeMs,
+      contentValid: offset === opened.size && extraBytes === 0,
+      authenticatedHomeBinding: true,
+    });
+    assertWindowsPrivateDirectoryStable(directory);
+    closeSync(descriptor);
+    descriptor = undefined;
+    let result: string;
+    try {
+      result = STRICT_UTF8_DECODER.decode(contents);
+    } catch {
+      throw new WindowsPrivatePathPolicyError("read-check", "corruption");
+    }
+    contents.fill(0);
+    contents = undefined;
+    return result;
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure("read-check", error);
+  } finally {
+    contents?.fill(0);
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor);
+      } catch {}
+    }
+  }
+}
+
+function loadFromFile(dataDir: string, platform: NodeJS.Platform): AllowedSenders | null {
   const path = join(dataDir, ALLOWED_SENDERS_FILE);
   let raw: string;
-  try {
-    raw = readFileSync(path, "utf-8");
-  } catch {
-    return null;
+  if (platform === "win32") {
+    const windowsRaw = readWindowsAllowedSendersFile(dataDir, path);
+    if (windowsRaw === null) return null;
+    raw = windowsRaw;
+  } else {
+    try {
+      raw = readFileSync(path, "utf-8");
+    } catch {
+      return null;
+    }
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
+    if (platform === "win32") {
+      throw new WindowsPrivatePathPolicyError("read-check", "corruption");
+    }
     console.error(
       `[security] ${path} is not valid JSON (${err instanceof Error ? err.message : String(err)}); falling back to default-pairing.`,
     );
     return null;
   }
-  return validateSchema(parsed, path);
+  const validated = validateSchema(
+    parsed,
+    platform === "win32" ? "Telegram sender authorization" : path,
+    platform !== "win32",
+  );
+  if (validated === null && platform === "win32") {
+    throw new WindowsPrivatePathPolicyError("read-check", "corruption");
+  }
+  return validated;
 }
 
 // Cache parsed AllowedSenders by file identity. The auth middleware calls
@@ -194,14 +344,28 @@ function pathExistsOrIsUninspectable(path: string): boolean {
   }
 }
 
-function accessFenceActive(dataDir: string): boolean {
+function accessFenceActive(dataDir: string, platform: NodeJS.Platform): boolean {
+  const markerPath = join(dataDir, ACCESS_RESET_MARKER);
+  if (platform === "win32" && !uncertainAccessFences.has(dataDir)) {
+    try {
+      lstatSync(markerPath);
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw classifyWindowsPrivatePathFailure("read-check", error);
+    }
+  }
   return (
     uncertainAccessFences.has(dataDir) ||
-    pathExistsOrIsUninspectable(join(dataDir, ACCESS_RESET_MARKER))
+    pathExistsOrIsUninspectable(markerPath)
   );
 }
 
-function loadFromFileCached(dataDir: string): AllowedSenders | null {
+function loadFromFileCached(dataDir: string, platform: NodeJS.Platform): AllowedSenders | null {
+  if (platform === "win32") {
+    fileCache.delete(dataDir);
+    return loadFromFile(dataDir, platform);
+  }
   const path = join(dataDir, ALLOWED_SENDERS_FILE);
   let identity: AllowedSendersFileIdentity;
   try {
@@ -212,7 +376,7 @@ function loadFromFileCached(dataDir: string): AllowedSenders | null {
   }
   const cached = fileCache.get(dataDir);
   if (cached && sameAllowedSendersFileIdentity(cached.identity, identity)) return cached.value;
-  const fresh = loadFromFile(dataDir);
+  const fresh = loadFromFile(dataDir, platform);
   if (fresh) fileCache.set(dataDir, { identity, value: fresh });
   else fileCache.delete(dataDir);
   return fresh;
@@ -225,11 +389,15 @@ export interface AllowedSendersLoad {
   source: AllowedSendersSource;
 }
 
-export function loadAllowedSendersWithSource(dataDir: string): AllowedSendersLoad {
-  if (accessFenceActive(dataDir)) {
+export function loadAllowedSendersWithSource(
+  dataDir: string,
+  options: AllowedSendersStorageOptions = {},
+): AllowedSendersLoad {
+  const platform = options.platform ?? process.platform;
+  if (accessFenceActive(dataDir, platform)) {
     return { state: defaultPairingState(), source: "default-pairing" };
   }
-  const fromFile = loadFromFileCached(dataDir);
+  const fromFile = loadFromFileCached(dataDir, platform);
   const baseAndSource: AllowedSendersLoad = fromFile
     ? { state: fromFile, source: "file" }
     : (() => {
@@ -249,13 +417,20 @@ export function loadAllowedSendersWithSource(dataDir: string): AllowedSendersLoa
   return baseAndSource;
 }
 
-export function loadAllowedSenders(dataDir: string): AllowedSenders {
-  return loadAllowedSendersWithSource(dataDir).state;
+export function loadAllowedSenders(
+  dataDir: string,
+  options: AllowedSendersStorageOptions = {},
+): AllowedSenders {
+  return loadAllowedSendersWithSource(dataDir, options).state;
 }
 
-export function loadAllowedSendersFromFile(dataDir: string): AllowedSenders {
-  if (accessFenceActive(dataDir)) return defaultPairingState();
-  return loadFromFileCached(dataDir) ?? defaultPairingState();
+export function loadAllowedSendersFromFile(
+  dataDir: string,
+  options: AllowedSendersStorageOptions = {},
+): AllowedSenders {
+  const platform = options.platform ?? process.platform;
+  if (accessFenceActive(dataDir, platform)) return defaultPairingState();
+  return loadFromFileCached(dataDir, platform) ?? defaultPairingState();
 }
 
 export interface DesktopAllowedSender {
@@ -307,16 +482,34 @@ export class LockfileContentionError extends Error {
   }
 }
 
+class WindowsLockfileContentionError extends LockfileContentionError {
+  readonly stage = "binding-check";
+  readonly category = "sharing-violation";
+
+  constructor() {
+    super("Telegram sender authorization lock is held.");
+  }
+}
+
 export class AllowedSendersRecoveryRequiredError extends Error {
-  constructor(dataDir: string) {
-    super(`Telegram sender authorization recovery is required for ${dataDir}.`);
+  constructor(dataDir: string, options: AllowedSendersStorageOptions = {}) {
+    super(
+      (options.platform ?? process.platform) === "win32"
+        ? "Telegram sender authorization recovery is required."
+        : `Telegram sender authorization recovery is required for ${dataDir}.`,
+    );
     this.name = "AllowedSendersRecoveryRequiredError";
   }
 }
 
 export class AllowedSendersCommitUncertainError extends Error {
-  constructor(dataDir: string, cause: unknown) {
-    super(`Telegram sender authorization commit is uncertain for ${dataDir}.`, { cause });
+  constructor(dataDir: string, cause: unknown, options: AllowedSendersStorageOptions = {}) {
+    super(
+      (options.platform ?? process.platform) === "win32"
+        ? "Telegram sender authorization commit is uncertain."
+        : `Telegram sender authorization commit is uncertain for ${dataDir}.`,
+      { cause },
+    );
     this.name = "AllowedSendersCommitUncertainError";
   }
 }
@@ -345,22 +538,81 @@ function lockfileIsStale(lockPath: string): boolean {
   return !isProcessAlive(pid);
 }
 
+function windowsLockfileIsStale(dataDir: string, lockPath: string): boolean {
+  const raw = readWindowsAllowedSendersFile(dataDir, lockPath);
+  if (raw === null) return true;
+  const parts = raw.split("\n");
+  const pid = Number(parts[0]);
+  if (
+    parts.length !== 3 ||
+    !Number.isSafeInteger(pid) ||
+    pid <= 0 ||
+    !Number.isFinite(Date.parse(parts[1] ?? "")) ||
+    (parts[2]?.length ?? 0) === 0
+  ) {
+    throw new WindowsPrivatePathPolicyError("read-check", "corruption");
+  }
+  return !isProcessAlive(pid);
+}
+
 interface LockfileOwnership {
   path: string;
   content: string;
+  windowsIdentity?: WindowsPrivatePathIdentity;
 }
 
-function prepareLockfileClaim(lockPath: string, content: string, token: string): string {
+interface AllowedSendersStorageContext {
+  readonly platform: NodeJS.Platform;
+  readonly windowsDirectory?: WindowsPrivateDirectoryBinding;
+}
+
+function assertWindowsIdentity(expected: WindowsPrivatePathIdentity, metadata: Stats): void {
+  if (!sameWindowsPrivatePathIdentity(expected, windowsPrivatePathIdentity(metadata))) {
+    throw new WindowsPrivatePathPolicyError("binding-check", "corruption");
+  }
+}
+
+function prepareLockfileClaim(
+  lockPath: string,
+  content: string,
+  token: string,
+  context: AllowedSendersStorageContext,
+): string {
   const tempPath = `${lockPath}.tmp.${token}`;
   let descriptor: number | undefined;
+  let stage: WindowsPrivatePathPolicyStage = "content-write";
   try {
     descriptor = openSync(
       tempPath,
-      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW,
+      fsConstants.O_CREAT |
+        fsConstants.O_EXCL |
+        fsConstants.O_WRONLY |
+        (context.platform === "win32" ? 0 : fsConstants.O_NOFOLLOW),
       0o600,
     );
+    let windowsIdentity: WindowsPrivatePathIdentity | undefined;
+    if (context.platform === "win32") {
+      const opened = fstatSync(descriptor);
+      assertWindowsPrivateFileMetadata(opened);
+      windowsIdentity = windowsPrivatePathIdentity(opened);
+      assertWindowsPrivateFileBinding(context.windowsDirectory!, tempPath, windowsIdentity);
+    }
     writeFileSync(descriptor, content, "utf8");
+    if (context.platform === "win32") {
+      const written = fstatSync(descriptor);
+      assertWindowsPrivateFileMetadata(written);
+      assertWindowsIdentity(windowsIdentity!, written);
+      assertWindowsPrivateFileBinding(context.windowsDirectory!, tempPath, windowsIdentity!);
+    }
+    stage = "file-flush";
     fsyncSync(descriptor);
+    if (context.platform === "win32") {
+      const flushed = fstatSync(descriptor);
+      assertWindowsPrivateFileMetadata(flushed);
+      assertWindowsIdentity(windowsIdentity!, flushed);
+      assertWindowsPrivateFileBinding(context.windowsDirectory!, tempPath, windowsIdentity!);
+      assertWindowsPrivateDirectoryStable(context.windowsDirectory!);
+    }
     closeSync(descriptor);
     descriptor = undefined;
     return tempPath;
@@ -373,44 +625,109 @@ function prepareLockfileClaim(lockPath: string, content: string, token: string):
     try {
       unlinkSync(tempPath);
     } catch {}
-    throw error;
+    throw context.platform === "win32"
+      ? classifyWindowsPrivatePathFailure(stage, error)
+      : error;
   }
 }
 
-function acquireLockfile(dataDir: string): LockfileOwnership {
+function acquireLockfile(dataDir: string, context: AllowedSendersStorageContext): LockfileOwnership {
   const lockPath = join(dataDir, LOCK_FILE);
   const token = randomUUID();
   const content = `${process.pid}\n${new Date().toISOString()}\n${token}`;
-  const tempPath = prepareLockfileClaim(lockPath, content, token);
+  const tempPath = prepareLockfileClaim(lockPath, content, token, context);
+  let windowsIdentity: WindowsPrivatePathIdentity | undefined;
   try {
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
         linkSync(tempPath, lockPath);
-        return { path: lockPath, content };
+        if (context.platform === "win32") {
+          const linked = lstatSync(tempPath);
+          assertWindowsPrivateFileMetadata(linked, 2);
+          windowsIdentity = windowsPrivatePathIdentity(linked);
+          assertWindowsPrivateFileBinding(context.windowsDirectory!, tempPath, windowsIdentity, 2);
+          assertWindowsPrivateFileBinding(context.windowsDirectory!, lockPath, windowsIdentity, 2);
+        }
+        return { path: lockPath, content, windowsIdentity };
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-        if (lockfileIsStale(lockPath)) {
+        const stale = context.platform === "win32"
+          ? windowsLockfileIsStale(dataDir, lockPath)
+          : lockfileIsStale(lockPath);
+        if (stale) {
           try {
             unlinkSync(lockPath);
-          } catch {
-            /* race: another process cleaned it */
+            if (context.platform === "win32") {
+              assertWindowsPrivateDirectoryStable(context.windowsDirectory!);
+            }
+          } catch (error) {
+            if (context.platform === "win32" && (error as NodeJS.ErrnoException).code !== "ENOENT") {
+              throw classifyWindowsPrivatePathFailure("rename", error);
+            }
           }
           continue;
         }
+        if (context.platform === "win32") throw new WindowsLockfileContentionError();
         throw new LockfileContentionError(
           `Another ${process.argv[1] ?? "cycling-coach"} process holds ${lockPath}; try again in a moment.`,
         );
       }
     }
+    if (context.platform === "win32") throw new WindowsLockfileContentionError();
     throw new LockfileContentionError(`Failed to acquire ${lockPath} after stale-reclaim retry.`);
+  } catch (error) {
+    throw context.platform === "win32" && !(error instanceof LockfileContentionError)
+      ? classifyWindowsPrivatePathFailure("rename", error)
+      : error;
   } finally {
-    try {
-      unlinkSync(tempPath);
-    } catch {}
+    removeLockfileClaim(tempPath, context);
+    if (context.platform === "win32" && windowsIdentity !== undefined) {
+      assertWindowsPrivateFileBinding(context.windowsDirectory!, lockPath, windowsIdentity);
+    }
   }
 }
 
-function releaseLockfile(ownership: LockfileOwnership): void {
+function removeLockfileClaim(path: string, context: AllowedSendersStorageContext): void {
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    if (context.platform === "win32" && (error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw classifyWindowsPrivatePathFailure("rename", error);
+    }
+  }
+}
+
+function releaseLockfile(ownership: LockfileOwnership, context: AllowedSendersStorageContext): void {
+  if (context.platform === "win32") {
+    let stage: WindowsPrivatePathPolicyStage = "read-check";
+    try {
+      const metadata = lstatSync(ownership.path);
+      assertWindowsPrivateFileMetadata(metadata);
+      assertWindowsPrivateFileBinding(
+        context.windowsDirectory!,
+        ownership.path,
+        ownership.windowsIdentity!,
+      );
+      const observed = readWindowsAllowedSendersFile(
+        context.windowsDirectory!.path,
+        ownership.path,
+      );
+      if (observed === null || observed !== ownership.content) {
+        throw new WindowsPrivatePathPolicyError("read-check", "corruption");
+      }
+      assertWindowsPrivateFileBinding(
+        context.windowsDirectory!,
+        ownership.path,
+        ownership.windowsIdentity!,
+      );
+      stage = "rename";
+      unlinkSync(ownership.path);
+      assertWindowsPrivateDirectoryStable(context.windowsDirectory!);
+      return;
+    } catch (error) {
+      throw classifyWindowsPrivatePathFailure(stage, error);
+    }
+  }
   try {
     if (readFileSync(ownership.path, "utf8") !== ownership.content) return;
     unlinkSync(ownership.path);
@@ -419,7 +736,18 @@ function releaseLockfile(ownership: LockfileOwnership): void {
   }
 }
 
-export function ensureDataDirSecure(dataDir: string): void {
+function secureDataDir(
+  dataDir: string,
+  platform: NodeJS.Platform,
+): WindowsPrivateDirectoryBinding | undefined {
+  if (platform === "win32") {
+    try {
+      mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+      return bindWindowsPrivateDirectory(dirname(dataDir), dataDir);
+    } catch (error) {
+      throw classifyWindowsPrivatePathFailure("entry-check", error);
+    }
+  }
   // mkdirSync with `mode` is a no-op on existing dirs, so explicit chmod is the
   // only path that tightens upgrade installs that pre-date this enforcement.
   if (existsSync(dataDir)) {
@@ -433,9 +761,21 @@ export function ensureDataDirSecure(dataDir: string): void {
   } else {
     mkdirSync(dataDir, { recursive: true, mode: 0o700 });
   }
+  return undefined;
 }
 
-function syncDirectory(dataDir: string): void {
+export function ensureDataDirSecure(
+  dataDir: string,
+  options: AllowedSendersStorageOptions = {},
+): void {
+  secureDataDir(dataDir, options.platform ?? process.platform);
+}
+
+function syncDirectory(dataDir: string, context: AllowedSendersStorageContext): void {
+  if (context.platform === "win32") {
+    assertWindowsPrivateDirectoryStable(context.windowsDirectory!);
+    if (classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable") return;
+  }
   const descriptor = openSync(
     dataDir,
     fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
@@ -447,7 +787,77 @@ function syncDirectory(dataDir: string): void {
   }
 }
 
-function writeFileDurably(path: string, contents: string): void {
+function writeWindowsFileDurably(
+  path: string,
+  contents: string,
+  directory: WindowsPrivateDirectoryBinding,
+): WindowsPrivatePathIdentity {
+  let descriptor: number | undefined;
+  let identity: WindowsPrivatePathIdentity | undefined;
+  let stage: WindowsPrivatePathPolicyStage = "content-write";
+  try {
+    assertWindowsPrivateDirectoryStable(directory);
+    let beforeOpen;
+    try {
+      beforeOpen = lstatSync(path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    if (beforeOpen === undefined) {
+      descriptor = openSync(
+        path,
+        fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+        0o600,
+      );
+      const opened = fstatSync(descriptor);
+      assertWindowsPrivateFileMetadata(opened);
+      identity = windowsPrivatePathIdentity(opened);
+    } else {
+      assertWindowsPrivateFileMetadata(beforeOpen);
+      identity = windowsPrivatePathIdentity(beforeOpen);
+      assertWindowsPrivateFileBinding(directory, path, identity);
+      descriptor = openSync(path, fsConstants.O_WRONLY);
+      const opened = fstatSync(descriptor);
+      assertWindowsPrivateFileMetadata(opened);
+      assertWindowsIdentity(identity, opened);
+      assertWindowsPrivateFileBinding(directory, path, identity);
+      ftruncateSync(descriptor, 0);
+    }
+    assertWindowsPrivateFileBinding(directory, path, identity);
+    writeFileSync(descriptor, contents, "utf8");
+    const written = fstatSync(descriptor);
+    assertWindowsPrivateFileMetadata(written);
+    assertWindowsIdentity(identity, written);
+    assertWindowsPrivateFileBinding(directory, path, identity);
+    stage = "file-flush";
+    fsyncSync(descriptor);
+    const flushed = fstatSync(descriptor);
+    assertWindowsPrivateFileMetadata(flushed);
+    assertWindowsIdentity(identity, flushed);
+    assertWindowsPrivateFileBinding(directory, path, identity);
+    assertWindowsPrivateDirectoryStable(directory);
+    closeSync(descriptor);
+    descriptor = undefined;
+    return identity;
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure(stage, error);
+  } finally {
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor);
+      } catch {}
+    }
+  }
+}
+
+function writeFileDurably(
+  path: string,
+  contents: string,
+  context: AllowedSendersStorageContext,
+): WindowsPrivatePathIdentity | undefined {
+  if (context.platform === "win32") {
+    return writeWindowsFileDurably(path, contents, context.windowsDirectory!);
+  }
   const descriptor = openSync(
     path,
     fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW,
@@ -459,42 +869,55 @@ function writeFileDurably(path: string, contents: string): void {
   } finally {
     closeSync(descriptor);
   }
+  return undefined;
 }
 
-function withAllowedSendersLock<T>(dataDir: string, operation: () => T): T {
-  ensureDataDirSecure(dataDir);
-  const ownership = acquireLockfile(dataDir);
+function withAllowedSendersLock<T>(
+  dataDir: string,
+  operation: (context: AllowedSendersStorageContext) => T,
+  options: AllowedSendersStorageOptions,
+): T {
+  const platform = options.platform ?? process.platform;
+  const context = { platform, windowsDirectory: secureDataDir(dataDir, platform) };
+  const ownership = acquireLockfile(dataDir, context);
   try {
-    return operation();
+    return operation(context);
   } finally {
-    releaseLockfile(ownership);
+    releaseLockfile(ownership, context);
   }
 }
 
-function publishAccessFenceLocked(dataDir: string): void {
+function publishAccessFenceLocked(dataDir: string, context: AllowedSendersStorageContext): void {
   uncertainAccessFences.add(dataDir);
   fileCache.delete(dataDir);
-  writeFileDurably(join(dataDir, ACCESS_RESET_MARKER), "reset\n");
-  syncDirectory(dataDir);
+  writeFileDurably(join(dataDir, ACCESS_RESET_MARKER), "reset\n", context);
+  syncDirectory(dataDir, context);
 }
 
-function removeAccessFenceLocked(dataDir: string): void {
+function removeAccessFenceLocked(dataDir: string, context: AllowedSendersStorageContext): void {
   const markerPath = join(dataDir, ACCESS_RESET_MARKER);
   let unlinked = false;
   try {
     unlinkSync(markerPath);
     unlinked = true;
-    syncDirectory(dataDir);
+    syncDirectory(dataDir, context);
     uncertainAccessFences.delete(dataDir);
   } catch (error) {
     uncertainAccessFences.add(dataDir);
     if (unlinked) {
-      try {
-        writeFileDurably(markerPath, "reset\n");
-        syncDirectory(dataDir);
-      } catch {}
+      if (context.platform === "win32") {
+        writeFileDurably(markerPath, "reset\n", context);
+        syncDirectory(dataDir, context);
+      } else {
+        try {
+          writeFileDurably(markerPath, "reset\n", context);
+          syncDirectory(dataDir, context);
+        } catch {}
+      }
     }
-    throw error;
+    throw context.platform === "win32"
+      ? classifyWindowsPrivatePathFailure("rename", error)
+      : error;
   }
 }
 
@@ -507,31 +930,47 @@ function refreshAllowedSendersCache(dataDir: string, next: AllowedSenders): void
   }
 }
 
-function replaceAllowedSendersLocked(dataDir: string, next: AllowedSenders): void {
+function replaceAllowedSendersLocked(
+  dataDir: string,
+  next: AllowedSenders,
+  context: AllowedSendersStorageContext,
+): void {
   const path = join(dataDir, ALLOWED_SENDERS_FILE);
   const tmp = `${path}.tmp`;
   let renamed = false;
   try {
-    writeFileDurably(tmp, JSON.stringify(next, null, 2));
+    const windowsIdentity = writeFileDurably(tmp, JSON.stringify(next, null, 2), context);
     renameSync(tmp, path);
     renamed = true;
-    syncDirectory(dataDir);
+    if (context.platform === "win32") {
+      assertWindowsPrivateFileBinding(context.windowsDirectory!, path, windowsIdentity!);
+      assertWindowsPrivateDirectoryStable(context.windowsDirectory!);
+    }
+    syncDirectory(dataDir, context);
   } catch (error) {
     try {
       unlinkSync(tmp);
     } catch {}
+    if (context.platform === "win32") {
+      throw classifyWindowsPrivatePathFailure(renamed ? "binding-check" : "rename", error);
+    }
     if (renamed) throw new AllowedSendersCommitUncertainError(dataDir, error);
     throw error;
   }
 }
 
-function commitAllowedSendersLocked(dataDir: string, next: AllowedSenders): AllowedSenders {
-  publishAccessFenceLocked(dataDir);
+function commitAllowedSendersLocked(
+  dataDir: string,
+  next: AllowedSenders,
+  context: AllowedSendersStorageContext,
+): AllowedSenders {
+  publishAccessFenceLocked(dataDir, context);
   try {
-    replaceAllowedSendersLocked(dataDir, next);
+    replaceAllowedSendersLocked(dataDir, next, context);
     try {
-      removeAccessFenceLocked(dataDir);
+      removeAccessFenceLocked(dataDir, context);
     } catch (error) {
+      if (context.platform === "win32") throw error;
       throw new AllowedSendersCommitUncertainError(dataDir, error);
     }
   } catch (error) {
@@ -554,46 +993,58 @@ function mutateAllowedSenders(
   dataDir: string,
   transform: (current: AllowedSenders | null) => AllowedSenders,
   recoverPendingFence: boolean,
+  options: AllowedSendersStorageOptions,
 ): AllowedSenders {
-  return withAllowedSendersLock(dataDir, () => {
-    let current = loadFromFile(dataDir);
-    if (accessFenceActive(dataDir)) {
-      if (!recoverPendingFence) throw new AllowedSendersRecoveryRequiredError(dataDir);
-      current = commitAllowedSendersLocked(dataDir, recoveryState(current));
+  return withAllowedSendersLock(dataDir, (context) => {
+    let current = loadFromFile(dataDir, context.platform);
+    if (accessFenceActive(dataDir, context.platform)) {
+      if (!recoverPendingFence) {
+        throw new AllowedSendersRecoveryRequiredError(dataDir, { platform: context.platform });
+      }
+      current = commitAllowedSendersLocked(dataDir, recoveryState(current), context);
     }
     const next = transform(current);
     if (next === current) return next;
-    return commitAllowedSendersLocked(dataDir, next);
-  });
+    return commitAllowedSendersLocked(dataDir, next, context);
+  }, options);
 }
 
 export function saveAllowedSenders(
   dataDir: string,
   transform: (current: AllowedSenders | null) => AllowedSenders,
+  options: AllowedSendersStorageOptions = {},
 ): AllowedSenders {
-  return mutateAllowedSenders(dataDir, transform, false);
+  return mutateAllowedSenders(dataDir, transform, false, options);
 }
 
-export function resetDesktopAllowedSenders(dataDir: string): void {
-  withAllowedSendersLock(dataDir, () => {
-    commitAllowedSendersLocked(dataDir, recoveryState(loadFromFile(dataDir)));
-  });
+export function resetDesktopAllowedSenders(
+  dataDir: string,
+  options: AllowedSendersStorageOptions = {},
+): void {
+  withAllowedSendersLock(dataDir, (context) => {
+    commitAllowedSendersLocked(
+      dataDir,
+      recoveryState(loadFromFile(dataDir, context.platform)),
+      context,
+    );
+  }, options);
 }
 
 export function bindDesktopTelegramAccess(
   dataDir: string,
   desktopBotId: string,
+  options: AllowedSendersStorageOptions = {},
 ): "preserved" | "reset" {
   if (!SENDER_ID_RE.test(desktopBotId)) {
     throw new TypeError("invalid Desktop Telegram bot id");
   }
-  return withAllowedSendersLock(dataDir, () => {
-    const pendingReset = accessFenceActive(dataDir);
-    const current = loadFromFile(dataDir);
+  return withAllowedSendersLock(dataDir, (context) => {
+    const pendingReset = accessFenceActive(dataDir, context.platform);
+    const current = loadFromFile(dataDir, context.platform);
     if (!pendingReset && current?.desktopBotId === desktopBotId) return "preserved";
-    commitAllowedSendersLocked(dataDir, { ...defaultPairingState(), desktopBotId });
+    commitAllowedSendersLocked(dataDir, { ...defaultPairingState(), desktopBotId }, context);
     return "reset";
-  });
+  }, options);
 }
 
 function assertSenderId(id: string): void {
@@ -647,13 +1098,22 @@ function exitDesktopMutation<T>(result: T): never {
   throw new DesktopSenderMutationExit(result);
 }
 
-function allowedSendersFileExists(dataDir: string): boolean {
-  return pathExistsOrIsUninspectable(join(dataDir, ALLOWED_SENDERS_FILE));
+function allowedSendersFileExists(dataDir: string, platform: NodeJS.Platform): boolean {
+  const path = join(dataDir, ALLOWED_SENDERS_FILE);
+  if (platform !== "win32") return pathExistsOrIsUninspectable(path);
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw classifyWindowsPrivatePathFailure("read-check", error);
+  }
 }
 
 export function claimPrimaryOperator(
   dataDir: string,
   senderId: string,
+  options: AllowedSendersStorageOptions = {},
 ): ClaimPrimaryOperatorResult {
   assertSenderId(senderId);
   const nowIso = new Date().toISOString();
@@ -661,7 +1121,7 @@ export function claimPrimaryOperator(
 
   try {
     saveAllowedSenders(dataDir, (current) => {
-      if (!current && allowedSendersFileExists(dataDir)) {
+      if (!current && allowedSendersFileExists(dataDir, options.platform ?? process.platform)) {
         return exitDesktopMutation({ status: "refused", reason: "inconsistent-state" });
       }
 
@@ -689,7 +1149,7 @@ export function claimPrimaryOperator(
       };
       result = { status: "claimed", sender: desktopSender(next, senderId) };
       return next;
-    });
+    }, options);
   } catch (err) {
     if (err instanceof DesktopSenderMutationExit) {
       return err.result as ClaimPrimaryOperatorResult;
@@ -706,14 +1166,18 @@ export function claimPrimaryOperator(
   return result as ClaimPrimaryOperatorResult;
 }
 
-export function addSecondarySender(dataDir: string, senderId: string): AddSecondarySenderResult {
+export function addSecondarySender(
+  dataDir: string,
+  senderId: string,
+  options: AllowedSendersStorageOptions = {},
+): AddSecondarySenderResult {
   assertSenderId(senderId);
   const nowIso = new Date().toISOString();
   let result: AddSecondarySenderResult | undefined;
 
   try {
     saveAllowedSenders(dataDir, (current) => {
-      if (!current && allowedSendersFileExists(dataDir)) {
+      if (!current && allowedSendersFileExists(dataDir, options.platform ?? process.platform)) {
         return exitDesktopMutation({ status: "refused", reason: "inconsistent-state" });
       }
 
@@ -738,7 +1202,7 @@ export function addSecondarySender(dataDir: string, senderId: string): AddSecond
       };
       result = { status: "added", sender: desktopSender(next, senderId) };
       return next;
-    });
+    }, options);
   } catch (err) {
     if (err instanceof DesktopSenderMutationExit) {
       return err.result as AddSecondarySenderResult;
@@ -758,6 +1222,7 @@ export function addSecondarySender(dataDir: string, senderId: string): AddSecond
 export function removeSecondarySender(
   dataDir: string,
   senderId: string,
+  options: AllowedSendersStorageOptions = {},
 ): RemoveSecondarySenderResult {
   assertSenderId(senderId);
   let result: RemoveSecondarySenderResult | undefined;
@@ -766,7 +1231,7 @@ export function removeSecondarySender(
     mutateAllowedSenders(
       dataDir,
       (current) => {
-        if (!current && allowedSendersFileExists(dataDir)) {
+        if (!current && allowedSendersFileExists(dataDir, options.platform ?? process.platform)) {
           return exitDesktopMutation({ status: "refused", reason: "inconsistent-state" });
         }
 
@@ -793,6 +1258,7 @@ export function removeSecondarySender(
         };
       },
       true,
+      options,
     );
   } catch (err) {
     if (err instanceof DesktopSenderMutationExit) {
@@ -807,12 +1273,19 @@ export function removeSecondarySender(
   return result as RemoveSecondarySenderResult;
 }
 
-export function listDesktopAllowedSenders(dataDir: string): DesktopAllowedSender[] {
-  const state = loadAllowedSendersFromFile(dataDir);
+export function listDesktopAllowedSenders(
+  dataDir: string,
+  options: AllowedSendersStorageOptions = {},
+): DesktopAllowedSender[] {
+  const state = loadAllowedSendersFromFile(dataDir, options);
   return state.allowFrom.map((senderId) => desktopSender(state, senderId));
 }
 
-export function addSender(dataDir: string, senderId: string): void {
+export function addSender(
+  dataDir: string,
+  senderId: string,
+  options: AllowedSendersStorageOptions = {},
+): void {
   assertSenderId(senderId);
   const nowIso = new Date().toISOString();
   saveAllowedSenders(dataDir, (current) => {
@@ -831,7 +1304,7 @@ export function addSender(dataDir: string, senderId: string): void {
       addedAt: { ...base.addedAt, [senderId]: nowIso },
       primaryOperator: base.primaryOperator ?? senderId,
     };
-  });
+  }, options);
 }
 
 interface SessionCandidate {
@@ -871,17 +1344,24 @@ export async function readKnownSessions(dataDir: string): Promise<SessionCandida
   );
 }
 
-export async function listSenders(dataDir: string): Promise<{
+export async function listSenders(
+  dataDir: string,
+  options: AllowedSendersStorageOptions = {},
+): Promise<{
   senders: AllowedSenders;
   sessionCandidates: SessionCandidate[];
 }> {
   return {
-    senders: loadAllowedSenders(dataDir),
+    senders: loadAllowedSenders(dataDir, options),
     sessionCandidates: await readKnownSessions(dataDir),
   };
 }
 
-export function removeSender(dataDir: string, senderId: string): void {
+export function removeSender(
+  dataDir: string,
+  senderId: string,
+  options: AllowedSendersStorageOptions = {},
+): void {
   mutateAllowedSenders(
     dataDir,
     (current) => {
@@ -898,5 +1378,6 @@ export function removeSender(dataDir: string, senderId: string): void {
       };
     },
     true,
+    options,
   );
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,7 +69,7 @@ export type { LogLine, LogLevel, SubsystemLogger, Subsystem } from "./logging/in
 
 // ─── Memory ───────────────────────────────────────────────────────────
 export type { MemorySnapshot, MemoryStore, MemoryWriteSource } from "./memory.js";
-export { Memory } from "./memory/store.js";
+export { Memory, type MemoryOptions } from "./memory/store.js";
 export type { MemoryJournalEntry } from "./memory/journal.js";
 
 // ─── Secrets ──────────────────────────────────────────────────────────
@@ -325,6 +325,7 @@ export {
   listDesktopAllowedSenders,
   loadAllowedSendersFromFile,
   loadAllowedSendersWithSource,
+  MAX_ALLOWED_SENDERS_FILE_BYTES,
   removeSecondarySender,
   resetDesktopAllowedSenders,
   bindDesktopTelegramAccess,
@@ -332,6 +333,7 @@ export {
 } from "./channels/allowed-senders.js";
 export type {
   AddSecondarySenderResult,
+  AllowedSendersStorageOptions,
   ClaimPrimaryOperatorResult,
   DesktopAllowedSender,
   RemoveSecondarySenderResult,

--- a/packages/core/src/memory/provenance-metadata.ts
+++ b/packages/core/src/memory/provenance-metadata.ts
@@ -1,21 +1,43 @@
 import {
   appendFileSync,
   closeSync,
+  constants as fsConstants,
   existsSync,
   fdatasyncSync,
   fstatSync,
   fsyncSync,
+  lstatSync,
   openSync,
   readFileSync,
   readSync,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { TextDecoder } from "node:util";
 import {
   UNKNOWN_PROVENANCE,
   contentDigest,
   isSourceProvenance,
   type SourceProvenance,
 } from "../provenance.js";
+import {
+  WindowsPrivatePathPolicyError,
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivateFileBinding,
+  assertWindowsPrivateFileMetadata,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  classifyWindowsPrivatePathFailure,
+  sameWindowsPrivatePathIdentity,
+  windowsPrivatePathIdentity,
+  type WindowsPrivateDirectoryBinding,
+  type WindowsPrivatePathIdentity,
+  type WindowsPrivatePathPolicyStage,
+} from "../io/windows-private-path-policy.js";
+
+export const MAX_PROVENANCE_METADATA_BYTES = 67_108_864;
+
+const STRICT_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 interface Entry {
   readonly digest: string;
@@ -35,6 +57,21 @@ interface DeleteRecord {
 }
 
 type JournalRecord = PutRecord | DeleteRecord;
+
+export interface ProvenanceMetadataOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly syncFile?: (descriptor: number) => void;
+  readonly syncDirectory?: (path: string) => void;
+}
+
+function syncDirectory(path: string): void {
+  const directoryFd = openSync(path, "r");
+  try {
+    fsyncSync(directoryFd);
+  } finally {
+    closeSync(directoryFd);
+  }
+}
 
 function parseRecord(value: unknown): JournalRecord | undefined {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
@@ -60,12 +97,23 @@ function parseRecord(value: unknown): JournalRecord | undefined {
 export class ProvenanceMetadata {
   private readonly directoryPath: string;
   private readonly path: string;
+  private readonly platform: NodeJS.Platform;
+  private readonly syncFile: (descriptor: number) => void;
+  private readonly syncDirectory: (path: string) => void;
+  private readonly windowsDirectory: WindowsPrivateDirectoryBinding | undefined;
   private cached?: Map<string, Entry>;
   private directorySynced = false;
 
-  constructor(memoryDir: string) {
+  constructor(memoryDir: string, options: ProvenanceMetadataOptions = {}) {
     this.directoryPath = memoryDir;
     this.path = join(memoryDir, ".source-provenance.jsonl");
+    this.platform = options.platform ?? process.platform;
+    this.syncFile = options.syncFile ?? fdatasyncSync;
+    this.syncDirectory = options.syncDirectory ?? syncDirectory;
+    this.windowsDirectory =
+      this.platform === "win32"
+        ? bindWindowsPrivateDirectory(dirname(memoryDir), memoryDir)
+        : undefined;
   }
 
   read(key: string, content: string): SourceProvenance {
@@ -117,37 +165,278 @@ export class ProvenanceMetadata {
     if (records.length === 0) return;
 
     const serialized = records.map((record) => JSON.stringify(record)).join("\n") + "\n";
-    const fd = openSync(this.path, "a+", 0o600);
-    try {
-      const size = fstatSync(fd).size;
-      const lastByte = Buffer.allocUnsafe(1);
-      const boundary =
-        size > 0 && readSync(fd, lastByte, 0, 1, size - 1) === 1 && lastByte[0] !== 0x0a
-          ? "\n"
-          : "";
-      appendFileSync(fd, boundary + serialized, { encoding: "utf8" });
-      fdatasyncSync(fd);
-      if (!this.directorySynced) {
-        const directoryFd = openSync(this.directoryPath, "r");
-        try {
-          fsyncSync(directoryFd);
-          this.directorySynced = true;
-        } finally {
-          closeSync(directoryFd);
+    let windowsCache: Map<string, Entry> | undefined;
+    if (this.platform === "win32") {
+      windowsCache = this.load();
+      this.appendWindows(serialized);
+    } else {
+      const fd = openSync(this.path, "a+", 0o600);
+      try {
+        const size = fstatSync(fd).size;
+        const lastByte = Buffer.allocUnsafe(1);
+        const boundary =
+          size > 0 && readSync(fd, lastByte, 0, 1, size - 1) === 1 && lastByte[0] !== 0x0a
+            ? "\n"
+            : "";
+        appendFileSync(fd, boundary + serialized, { encoding: "utf8" });
+        fdatasyncSync(fd);
+        if (!this.directorySynced) {
+          const directoryFd = openSync(this.directoryPath, "r");
+          try {
+            fsyncSync(directoryFd);
+            this.directorySynced = true;
+          } finally {
+            closeSync(directoryFd);
+          }
         }
+      } finally {
+        closeSync(fd);
       }
-    } finally {
-      closeSync(fd);
     }
 
-    const cache = this.load();
+    const cache = windowsCache ?? this.load();
     for (const record of records) {
       if (record.op === "delete") cache.delete(record.key);
       else cache.set(record.key, { digest: record.digest, provenance: record.provenance });
     }
   }
 
+  private appendWindows(serialized: string): void {
+    let fd: number | undefined;
+    let stage: WindowsPrivatePathPolicyStage = "content-write";
+    try {
+      const opened = this.openWindowsFile(fsConstants.O_RDWR | fsConstants.O_APPEND);
+      if (opened === undefined) {
+        assertWindowsPrivateDirectoryStable(this.windowsDirectory!);
+        fd = openSync(
+          this.path,
+          fsConstants.O_RDWR |
+            fsConstants.O_APPEND |
+            fsConstants.O_CREAT |
+            fsConstants.O_EXCL,
+          0o600,
+        );
+        const created = fstatSync(fd);
+        assertWindowsPrivateFileMetadata(created);
+        const identity = windowsPrivatePathIdentity(created);
+        assertWindowsPrivateFileBinding(this.windowsDirectory!, this.path, identity);
+        stage = "read-check";
+        const contents = this.readWindowsDescriptor(fd, identity);
+        this.assertWindowsRecords(contents);
+        stage = "content-write";
+        this.appendWindowsDescriptor(fd, identity, created.size, contents, serialized);
+      } else {
+        fd = opened.fd;
+        stage = "read-check";
+        const contents = this.readWindowsDescriptor(fd, opened.identity);
+        this.assertWindowsRecords(contents);
+        stage = "content-write";
+        this.appendWindowsDescriptor(
+          fd,
+          opened.identity,
+          fstatSync(fd).size,
+          contents,
+          serialized,
+        );
+      }
+      stage = "file-flush";
+      this.syncFile(fd);
+      const flushed = fstatSync(fd);
+      assertWindowsPrivateFileMetadata(flushed);
+      assertWindowsPrivateFileBinding(
+        this.windowsDirectory!,
+        this.path,
+        windowsPrivatePathIdentity(flushed),
+      );
+      closeSync(fd);
+      fd = undefined;
+      assertWindowsPrivateDirectoryStable(this.windowsDirectory!);
+      if (!this.directorySynced) {
+        if (classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable") {
+          this.directorySynced = true;
+        } else {
+          this.syncDirectory(this.directoryPath);
+          this.directorySynced = true;
+        }
+      }
+    } catch (error) {
+      throw classifyWindowsPrivatePathFailure(stage, error);
+    } finally {
+      if (fd !== undefined) {
+        try {
+          closeSync(fd);
+        } catch {}
+      }
+    }
+  }
+
+  private openWindowsFile(
+    flags: number,
+  ): { readonly fd: number; readonly identity: WindowsPrivatePathIdentity } | undefined {
+    assertWindowsPrivateDirectoryStable(this.windowsDirectory!);
+    let before;
+    try {
+      before = lstatSync(this.path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        assertWindowsPrivateDirectoryStable(this.windowsDirectory!);
+        return undefined;
+      }
+      throw error;
+    }
+    assertWindowsPrivateFileMetadata(before);
+    const identity = windowsPrivatePathIdentity(before);
+    assertWindowsPrivateFileBinding(this.windowsDirectory!, this.path, identity);
+    const fd = openSync(this.path, flags);
+    try {
+      const opened = fstatSync(fd);
+      assertWindowsPrivateFileMetadata(opened);
+      if (!sameWindowsPrivatePathIdentity(identity, windowsPrivatePathIdentity(opened))) {
+        throw new WindowsPrivatePathPolicyError("binding-check", "corruption");
+      }
+      assertWindowsPrivateFileBinding(this.windowsDirectory!, this.path, identity);
+      return { fd, identity };
+    } catch (error) {
+      closeSync(fd);
+      throw error;
+    }
+  }
+
+  private readWindowsDescriptor(fd: number, identity: WindowsPrivatePathIdentity): string {
+    const before = fstatSync(fd);
+    assertWindowsPrivateFileMetadata(before);
+    assertWindowsPrivatePathRead({
+      bounded:
+        Number.isSafeInteger(before.size) &&
+        before.size >= 0 &&
+        before.size <= MAX_PROVENANCE_METADATA_BYTES,
+      identityStable: sameWindowsPrivatePathIdentity(
+        identity,
+        windowsPrivatePathIdentity(before),
+      ),
+      contentValid: true,
+      authenticatedHomeBinding: true,
+    });
+    const buffer = Buffer.alloc(before.size + 1);
+    try {
+      let offset = 0;
+      while (offset < before.size) {
+        const bytesRead = readSync(fd, buffer, offset, before.size - offset, offset);
+        if (bytesRead <= 0) break;
+        offset += bytesRead;
+      }
+      const extraBytes = readSync(fd, buffer, before.size, 1, before.size);
+      const after = fstatSync(fd);
+      assertWindowsPrivateFileMetadata(after);
+      const current = assertWindowsPrivateFileBinding(
+        this.windowsDirectory!,
+        this.path,
+        identity,
+      );
+      let contents = "";
+      let contentValid = true;
+      try {
+        contents = STRICT_UTF8_DECODER.decode(buffer.subarray(0, before.size));
+      } catch {
+        contentValid = false;
+      }
+      assertWindowsPrivatePathRead({
+        bounded: offset === before.size && extraBytes === 0,
+        identityStable:
+          sameWindowsPrivatePathIdentity(identity, windowsPrivatePathIdentity(after)) &&
+          before.size === after.size &&
+          before.size === current.size &&
+          before.mtimeMs === after.mtimeMs &&
+          before.mtimeMs === current.mtimeMs &&
+          before.ctimeMs === after.ctimeMs &&
+          before.ctimeMs === current.ctimeMs,
+        contentValid,
+        authenticatedHomeBinding: true,
+      });
+      assertWindowsPrivateDirectoryStable(this.windowsDirectory!);
+      return contents;
+    } finally {
+      buffer.fill(0);
+    }
+  }
+
+  private appendWindowsDescriptor(
+    fd: number,
+    identity: WindowsPrivatePathIdentity,
+    size: number,
+    contents: string,
+    serialized: string,
+  ): void {
+    const boundary = contents.length > 0 && !contents.endsWith("\n") ? "\n" : "";
+    const payload = boundary + serialized;
+    const expectedSize = size + Buffer.byteLength(payload, "utf8");
+    assertWindowsPrivatePathRead({
+      bounded:
+        Number.isSafeInteger(expectedSize) && expectedSize <= MAX_PROVENANCE_METADATA_BYTES,
+      identityStable: true,
+      contentValid: true,
+      authenticatedHomeBinding: true,
+    });
+    appendFileSync(fd, payload, { encoding: "utf8" });
+    const written = fstatSync(fd);
+    assertWindowsPrivateFileMetadata(written);
+    if (
+      !sameWindowsPrivatePathIdentity(identity, windowsPrivatePathIdentity(written)) ||
+      written.size !== expectedSize
+    ) {
+      throw new WindowsPrivatePathPolicyError("content-write", "corruption");
+    }
+    assertWindowsPrivateFileBinding(this.windowsDirectory!, this.path, identity);
+  }
+
+  private assertWindowsRecords(contents: string): Map<string, Entry> {
+    const entries = new Map<string, Entry>();
+    for (const line of contents.split("\n")) {
+      if (line === "") continue;
+      let record: JournalRecord | undefined;
+      try {
+        record = parseRecord(JSON.parse(line) as unknown);
+      } catch {
+        throw new WindowsPrivatePathPolicyError("read-check", "corruption");
+      }
+      if (record === undefined) {
+        throw new WindowsPrivatePathPolicyError("read-check", "corruption");
+      }
+      if (record.op === "delete") entries.delete(record.key);
+      else entries.set(record.key, { digest: record.digest, provenance: record.provenance });
+    }
+    return entries;
+  }
+
+  private loadWindows(): Map<string, Entry> {
+    let fd: number | undefined;
+    try {
+      const opened = this.openWindowsFile(fsConstants.O_RDONLY);
+      if (opened === undefined) return new Map();
+      fd = opened.fd;
+      const entries = this.assertWindowsRecords(
+        this.readWindowsDescriptor(fd, opened.identity),
+      );
+      closeSync(fd);
+      fd = undefined;
+      return entries;
+    } catch (error) {
+      throw classifyWindowsPrivatePathFailure("read-check", error);
+    } finally {
+      if (fd !== undefined) {
+        try {
+          closeSync(fd);
+        } catch {}
+      }
+    }
+  }
+
   private load(): Map<string, Entry> {
+    if (this.platform === "win32") {
+      const entries = this.loadWindows();
+      this.cached = entries;
+      return entries;
+    }
     if (this.cached !== undefined) return this.cached;
     const entries = new Map<string, Entry>();
     if (!existsSync(this.path)) {

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -95,6 +95,10 @@ function hasLogicalSectionContent(stamped: string): boolean {
 
 type RenameOutcome = "renamed" | "noop" | "merged";
 
+export interface MemoryOptions {
+  readonly platform?: NodeJS.Platform;
+}
+
 /**
  * Apply a single section rename to `parts` IN PLACE. Shared between
  * `renameSection` (one rename + write) and `renameSections` (chain of
@@ -124,15 +128,17 @@ export class Memory implements MemoryStore {
   private plansDir: string;
   private tz: string;
   private provenance: ProvenanceMetadata;
+  private readonly platform: NodeJS.Platform;
   private readonly writeProvenance = new AsyncLocalStorage<SourceProvenance>();
 
-  constructor(dataDir: string, tz: string = "UTC") {
+  constructor(dataDir: string, tz: string = "UTC", options: MemoryOptions = {}) {
     this.memoryDir = join(dataDir, "memory");
     this.plansDir = join(dataDir, "plans");
     this.tz = tz;
+    this.platform = options.platform ?? process.platform;
     mkdirSync(this.memoryDir, { recursive: true, mode: 0o700 });
     mkdirSync(this.plansDir, { recursive: true, mode: 0o700 });
-    this.provenance = new ProvenanceMetadata(this.memoryDir);
+    this.provenance = new ProvenanceMetadata(this.memoryDir, { platform: this.platform });
   }
 
   runWithWriteProvenance<T>(provenance: SourceProvenance, fn: () => T): T {
@@ -244,7 +250,7 @@ export class Memory implements MemoryStore {
     });
 
     if (!existing) {
-      atomicWriteFileSync(path, newBlock);
+      atomicWriteFileSync(path, newBlock, { platform: this.platform });
       return;
     }
 
@@ -253,10 +259,12 @@ export class Memory implements MemoryStore {
 
     if (idx >= 0) {
       parts[idx] = newBlock;
-      atomicWriteFileSync(path, parts.join(""));
+      atomicWriteFileSync(path, parts.join(""), { platform: this.platform });
     } else {
       // Append at end (preserves legacy content not covered by any known section)
-      atomicWriteFileSync(path, existing.trimEnd() + "\n\n" + newBlock);
+      atomicWriteFileSync(path, existing.trimEnd() + "\n\n" + newBlock, {
+        platform: this.platform,
+      });
     }
   }
 
@@ -305,7 +313,7 @@ export class Memory implements MemoryStore {
       newBody: updated,
       source,
     });
-    atomicWriteFileSync(path, updated);
+    atomicWriteFileSync(path, updated, { platform: this.platform });
     return outcome;
   }
 
@@ -338,7 +346,7 @@ export class Memory implements MemoryStore {
         newBody: updated,
         source,
       });
-      atomicWriteFileSync(path, updated);
+      atomicWriteFileSync(path, updated, { platform: this.platform });
     }
     return outcomes;
   }
@@ -414,7 +422,7 @@ export class Memory implements MemoryStore {
       });
     }
     this.provenance.writeMany(metadataWrites);
-    atomicWriteFileSync(path, updated);
+    atomicWriteFileSync(path, updated, { platform: this.platform });
   }
 
   readDailyNotesInRange(from: string, to: string): Array<{ date: string; text: string }> {
@@ -460,7 +468,7 @@ export class Memory implements MemoryStore {
       newBody,
       source,
     });
-    atomicWriteFileSync(path, newBody);
+    atomicWriteFileSync(path, newBody, { platform: this.platform });
   }
 
   loadPlan(): unknown | null {

--- a/packages/core/tests/allowed-senders.test.ts
+++ b/packages/core/tests/allowed-senders.test.ts
@@ -125,6 +125,7 @@ import {
   AllowedSendersCommitUncertainError,
   AllowedSendersRecoveryRequiredError,
   LockfileContentionError,
+  MAX_ALLOWED_SENDERS_FILE_BYTES,
   loadAllowedSenders,
   loadAllowedSendersFromFile,
   saveAllowedSenders,
@@ -141,6 +142,7 @@ import {
   readKnownSessions,
   type AllowedSenders,
 } from "../src/channels/allowed-senders.js";
+import { WindowsPrivatePathPolicyError } from "../src/io/windows-private-path-policy.js";
 
 let dataDir: string;
 const ENV_KEYS = ["CYCLING_COACH_OPERATOR_ID", "CYCLING_COACH_DM_POLICY"];
@@ -1348,5 +1350,169 @@ describe("saveAllowedSenders — data-dir perms (S3)", () => {
     expect(statSync(dataDir).mode & 0o777).toBe(0o700);
     expect(errSpy).toHaveBeenCalledWith(expect.stringMatching(/\[security\].*permissions.*0o700/));
     errSpy.mockRestore();
+  });
+});
+
+describe("win32 sender authorization storage", () => {
+  const windows = { platform: "win32" as const };
+
+  it("preserves structurally bound state without POSIX mode checks or directory sync", () => {
+    chmodSync(dataDir, 0o755);
+    traceDurability();
+
+    expect(bindDesktopTelegramAccess(dataDir, "10001", windows)).toBe("reset");
+    expect(claimPrimaryOperator(dataDir, "12345", windows).status).toBe("claimed");
+
+    expect(statSync(dataDir).mode & 0o777).toBe(0o755);
+    expect(durabilityFs.events).not.toContain("fsync:directory");
+    expect(loadAllowedSendersFromFile(dataDir, windows)).toMatchObject({
+      desktopBotId: "10001",
+      primaryOperator: "12345",
+      allowFrom: ["12345"],
+    });
+  });
+
+  it("rejects corrupt state with path-free stage diagnostics", () => {
+    const path = join(dataDir, "allowed-senders.json");
+    writeFileSync(path, "{invalid", { mode: 0o600 });
+
+    const failure = (() => {
+      try {
+        loadAllowedSendersFromFile(dataDir, windows);
+      } catch (error) {
+        return error;
+      }
+      return undefined;
+    })();
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect((failure as Error).message).not.toContain(dataDir);
+  });
+
+  it("rejects invalid UTF-8 state with path-free stage diagnostics", () => {
+    const path = join(dataDir, "allowed-senders.json");
+    writeFileSync(path, Buffer.from([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d]));
+
+    const failure = (() => {
+      try {
+        loadAllowedSendersFromFile(dataDir, windows);
+      } catch (error) {
+        return error;
+      }
+      return undefined;
+    })();
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect((failure as Error).message).not.toContain(dataDir);
+  });
+
+  it("rejects oversized state before parsing", () => {
+    const path = join(dataDir, "allowed-senders.json");
+    writeFileSync(path, Buffer.alloc(MAX_ALLOWED_SENDERS_FILE_BYTES + 1, 0x20));
+
+    const failure = (() => {
+      try {
+        loadAllowedSendersFromFile(dataDir, windows);
+      } catch (error) {
+        return error;
+      }
+      return undefined;
+    })();
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+  });
+
+  it("rejects an uninspectable reset fence with stage diagnostics", () => {
+    traceDurability("lstat:reset-marker");
+
+    const failure = (() => {
+      try {
+        loadAllowedSendersFromFile(dataDir, windows);
+      } catch (error) {
+        return error;
+      }
+      return undefined;
+    })();
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "io-failure" });
+    expect((failure as Error).message).not.toContain(dataDir);
+  });
+
+  it("does not swallow file flush failures", () => {
+    traceDurability("fsync:allowlist-temp");
+
+    const failure = (() => {
+      try {
+        bindDesktopTelegramAccess(dataDir, "10001", windows);
+      } catch (error) {
+        return error;
+      }
+      return undefined;
+    })();
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "file-flush", category: "io-failure" });
+    expect((failure as Error).message).not.toContain(dataDir);
+  });
+
+  it("does not swallow rename failures", () => {
+    traceDurability("rename:allowlist");
+
+    const failure = (() => {
+      try {
+        bindDesktopTelegramAccess(dataDir, "10001", windows);
+      } catch (error) {
+        return error;
+      }
+      return undefined;
+    })();
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "rename", category: "io-failure" });
+    expect((failure as Error).message).not.toContain(dataDir);
+  });
+
+  it("rejects a live lock with path-free sharing diagnostics", () => {
+    writeFileSync(
+      join(dataDir, ".allowed-senders.lock"),
+      `${process.pid}\n${new Date().toISOString()}\nlock-token`,
+      { mode: 0o600 },
+    );
+
+    const failure = (() => {
+      try {
+        bindDesktopTelegramAccess(dataDir, "10001", windows);
+      } catch (error) {
+        return error;
+      }
+      return undefined;
+    })();
+
+    expect(failure).toBeInstanceOf(LockfileContentionError);
+    expect(failure).toMatchObject({ stage: "binding-check", category: "sharing-violation" });
+    expect((failure as Error).message).not.toContain(dataDir);
+  });
+
+  it("rejects a corrupt lock without reclaiming it", () => {
+    const lockPath = join(dataDir, ".allowed-senders.lock");
+    writeFileSync(lockPath, "invalid", { mode: 0o600 });
+
+    const failure = (() => {
+      try {
+        bindDesktopTelegramAccess(dataDir, "10001", windows);
+      } catch (error) {
+        return error;
+      }
+      return undefined;
+    })();
+
+    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect(readFileSync(lockPath, "utf8")).toBe("invalid");
+    expect((failure as Error).message).not.toContain(dataDir);
   });
 });

--- a/packages/core/tests/provenance-persistence.test.ts
+++ b/packages/core/tests/provenance-persistence.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ChatStore } from "../src/agent/chat-store.js";
@@ -10,8 +19,12 @@ import {
   unwrapBoundToolResult,
 } from "@enduragent/engine";
 import { Memory } from "../src/memory/store.js";
-import { ProvenanceMetadata } from "../src/memory/provenance-metadata.js";
+import {
+  MAX_PROVENANCE_METADATA_BYTES,
+  ProvenanceMetadata,
+} from "../src/memory/provenance-metadata.js";
 import { contentDigest, getMessageProvenance, setMessageProvenance } from "../src/provenance.js";
+import { WindowsPrivatePathPolicyError } from "../src/io/windows-private-path-policy.js";
 
 const GARMIN = { garmin: true, nonGarmin: false, unknown: false };
 const UNKNOWN = { garmin: false, nonGarmin: false, unknown: true };
@@ -218,6 +231,133 @@ describe("memory, daily-note, plan, and ledger digest binding", () => {
       expect(secondWrite.length).toBeGreaterThan(firstWrite.length);
       expect(metadata.read("first", "one")).toEqual(GARMIN);
       expect(metadata.read("second", "two")).toEqual(UNKNOWN);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists provenance on win32 without attempting directory sync", () => {
+    const dir = tempDir("cc-memory-provenance-win32-");
+    try {
+      const memoryDir = join(dir, "memory");
+      mkdirSync(memoryDir, { recursive: true });
+      let directorySyncs = 0;
+      const metadata = new ProvenanceMetadata(memoryDir, {
+        platform: "win32",
+        syncDirectory: () => {
+          directorySyncs += 1;
+          throw new Error("directory sync is unavailable");
+        },
+      });
+
+      metadata.write("first", "one", GARMIN);
+
+      expect(directorySyncs).toBe(0);
+      expect(metadata.read("first", "one")).toEqual(GARMIN);
+      expect(readFileSync(join(memoryDir, ".source-provenance.jsonl"), "utf8")).toContain(
+        '"key":"first"',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("threads injected win32 semantics through Memory writes", () => {
+    const dir = tempDir("cc-memory-win32-");
+    try {
+      const memory = new Memory(dir, "UTC", { platform: "win32" });
+
+      memory.writeSection("profile", "Private note", "chat-tool", GARMIN);
+
+      expect(memory.provenanceForSection("profile")).toEqual(GARMIN);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects corrupt win32 provenance with path-free stage diagnostics", () => {
+    const dir = tempDir("cc-memory-provenance-corrupt-win32-");
+    try {
+      const memoryDir = join(dir, "memory");
+      mkdirSync(memoryDir, { recursive: true });
+      writeFileSync(join(memoryDir, ".source-provenance.jsonl"), "{invalid\n");
+      const metadata = new ProvenanceMetadata(memoryDir, { platform: "win32" });
+      const failure = (() => {
+        try {
+          metadata.read("first", "one");
+        } catch (error) {
+          return error;
+        }
+        return undefined;
+      })();
+
+      expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+      expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+      expect((failure as Error).message).not.toContain(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts structurally bound win32 provenance without POSIX mode checks", () => {
+    const dir = tempDir("cc-memory-provenance-mode-win32-");
+    try {
+      const memoryDir = join(dir, "memory");
+      mkdirSync(memoryDir, { recursive: true });
+      const path = join(memoryDir, ".source-provenance.jsonl");
+      const metadata = new ProvenanceMetadata(memoryDir, { platform: "win32" });
+      metadata.write("first", "one", GARMIN);
+      chmodSync(memoryDir, 0o755);
+      chmodSync(path, 0o644);
+
+      expect(new ProvenanceMetadata(memoryDir, { platform: "win32" }).read("first", "one"))
+        .toEqual(GARMIN);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects oversized win32 provenance before reading it", () => {
+    const dir = tempDir("cc-memory-provenance-oversized-win32-");
+    try {
+      const memoryDir = join(dir, "memory");
+      mkdirSync(memoryDir, { recursive: true });
+      const path = join(memoryDir, ".source-provenance.jsonl");
+      writeFileSync(path, "");
+      truncateSync(path, MAX_PROVENANCE_METADATA_BYTES + 1);
+      const metadata = new ProvenanceMetadata(memoryDir, { platform: "win32" });
+
+      expect(() => metadata.read("first", "one")).toThrow(
+        expect.objectContaining({ stage: "read-check", category: "corruption" }),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not swallow win32 provenance file flush failures", () => {
+    const dir = tempDir("cc-memory-provenance-flush-win32-");
+    try {
+      const memoryDir = join(dir, "memory");
+      mkdirSync(memoryDir, { recursive: true });
+      const metadata = new ProvenanceMetadata(memoryDir, {
+        platform: "win32",
+        syncFile: () => {
+          throw Object.assign(new Error(`locked ${dir}`), { code: "EBUSY" });
+        },
+      });
+      const failure = (() => {
+        try {
+          metadata.write("first", "one", GARMIN);
+        } catch (error) {
+          return error;
+        }
+        return undefined;
+      })();
+
+      expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
+      expect(failure).toMatchObject({ stage: "file-flush", category: "sharing-violation" });
+      expect((failure as Error).message).not.toContain(dir);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/kernel-node/src/capture-manifest/index.ts
+++ b/packages/kernel-node/src/capture-manifest/index.ts
@@ -1,5 +1,6 @@
-import { chmod, lstat, mkdir, rename, rm } from "node:fs/promises";
-import { join } from "node:path";
+import { constants } from "node:fs";
+import { chmod, lstat, mkdir, open, realpath, rename, rm, rmdir, unlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { gunzipSync } from "node:zlib";
 import { canonicalJson, toHex, type ArchiveManager } from "@enduragent/kernel/archive";
 import {
@@ -9,7 +10,17 @@ import {
   type ReferenceCaptureManifest,
   type SnapshotRef,
 } from "@enduragent/kernel/reference/capture";
-import type { CryptoPort } from "@enduragent/kernel/ports";
+import {
+  classifyPrivatePathDurability,
+  classifyPrivatePathErrorCode,
+  decidePrivatePathBinding,
+  decidePrivatePathEntry,
+  decidePrivatePathRead,
+  type CryptoPort,
+  type PrivatePathEntryType,
+  type PrivatePathPolicyDecision,
+  type PrivatePathPolicyErrorCategory,
+} from "@enduragent/kernel/ports";
 import { z } from "zod";
 import { ensurePrivateDirectory, nodeFileSystem } from "../filesystem/index.js";
 
@@ -17,6 +28,321 @@ const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-
 const DATE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
 const HEX = /^[0-9a-f]{64}$/;
 const SNAPSHOT_PATH = /^[0-9]{4}\/[0-9]{2}\/[0-9a-f]{64}\.json\.gz$/;
+
+export const MAX_REFERENCE_CAPTURE_SIDECAR_BYTES = 67_108_864;
+
+export type WindowsReferenceCaptureSidecarStage =
+  | "entry-check"
+  | "binding-check"
+  | "read-check"
+  | "content-write"
+  | "file-flush"
+  | "rename";
+
+export class WindowsReferenceCaptureSidecarError extends Error {
+  override readonly name = "WindowsReferenceCaptureSidecarError";
+  readonly stage: WindowsReferenceCaptureSidecarStage;
+  readonly category: PrivatePathPolicyErrorCategory;
+
+  constructor(stage: WindowsReferenceCaptureSidecarStage, category: PrivatePathPolicyErrorCategory) {
+    super("Windows Reference capture sidecar policy failed");
+    this.stage = stage;
+    this.category = category;
+  }
+}
+
+type CapturePathMetadata = Awaited<ReturnType<typeof lstat>>;
+
+interface CapturePathIdentity {
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+}
+
+interface CaptureDirectoryBinding {
+  readonly path: string;
+  readonly parentPath: string;
+  readonly identity: CapturePathIdentity;
+  readonly parentIdentity: CapturePathIdentity;
+}
+
+function captureErrorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+}
+
+function captureFailure(
+  stage: WindowsReferenceCaptureSidecarStage,
+  error: unknown,
+): WindowsReferenceCaptureSidecarError {
+  if (error instanceof WindowsReferenceCaptureSidecarError) return error;
+  return new WindowsReferenceCaptureSidecarError(
+    stage,
+    classifyPrivatePathErrorCode(captureErrorCode(error)),
+  );
+}
+
+function assertCaptureDecision(
+  stage: WindowsReferenceCaptureSidecarStage,
+  decision: PrivatePathPolicyDecision,
+): void {
+  if (decision.kind === "reject") {
+    throw new WindowsReferenceCaptureSidecarError(stage, decision.category);
+  }
+}
+
+function captureEntryType(metadata: CapturePathMetadata): PrivatePathEntryType {
+  if (metadata.isFile()) return "file";
+  if (metadata.isDirectory()) return "directory";
+  return "other";
+}
+
+function capturePathIdentity(metadata: CapturePathMetadata): CapturePathIdentity {
+  return { dev: metadata.dev, ino: metadata.ino };
+}
+
+function sameCapturePathIdentity(left: CapturePathIdentity, right: CapturePathIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function assertCaptureDirectoryEntry(metadata: CapturePathMetadata): void {
+  assertCaptureDecision("entry-check", decidePrivatePathEntry({
+    expectedType: "directory",
+    actualType: captureEntryType(metadata),
+    linkOrReparseShaped: metadata.isSymbolicLink(),
+  }));
+}
+
+function assertCaptureFileEntry(metadata: CapturePathMetadata): void {
+  assertCaptureDecision("entry-check", decidePrivatePathEntry({
+    expectedType: "file",
+    actualType: captureEntryType(metadata),
+    linkOrReparseShaped: metadata.isSymbolicLink(),
+  }));
+  assertCaptureDecision("binding-check", decidePrivatePathBinding({
+    identityStable: true,
+    authenticatedHomeBinding: metadata.nlink === 1,
+  }));
+}
+
+async function observeCaptureDirectoryBinding(
+  parentPath: string,
+  path: string,
+): Promise<CaptureDirectoryBinding> {
+  const parentBefore = await lstat(parentPath);
+  const parentPhysicalPath = await realpath(parentPath);
+  const parentPhysical = await lstat(parentPhysicalPath);
+  const parentAfter = await lstat(parentPath);
+  const before = await lstat(path);
+  const physicalPath = await realpath(path);
+  const physical = await lstat(physicalPath);
+  const after = await lstat(path);
+  const physicalParent = await lstat(dirname(physicalPath));
+  for (const metadata of [parentBefore, parentPhysical, parentAfter, before, physical, after]) {
+    assertCaptureDirectoryEntry(metadata);
+  }
+  assertCaptureDirectoryEntry(physicalParent);
+  const parentIdentity = capturePathIdentity(parentBefore);
+  const identity = capturePathIdentity(before);
+  assertCaptureDecision("binding-check", decidePrivatePathBinding({
+    identityStable:
+      sameCapturePathIdentity(parentIdentity, capturePathIdentity(parentPhysical)) &&
+      sameCapturePathIdentity(parentIdentity, capturePathIdentity(parentAfter)) &&
+      sameCapturePathIdentity(identity, capturePathIdentity(physical)) &&
+      sameCapturePathIdentity(identity, capturePathIdentity(after)),
+    authenticatedHomeBinding: sameCapturePathIdentity(
+      parentIdentity,
+      capturePathIdentity(physicalParent),
+    ),
+  }));
+  return { path, parentPath, identity, parentIdentity };
+}
+
+async function bindCaptureDirectory(
+  parentPath: string,
+  path: string,
+): Promise<CaptureDirectoryBinding> {
+  try {
+    return await observeCaptureDirectoryBinding(parentPath, path);
+  } catch (error) {
+    throw captureFailure("binding-check", error);
+  }
+}
+
+async function assertCaptureDirectoryStable(binding: CaptureDirectoryBinding): Promise<void> {
+  try {
+    const observed = await observeCaptureDirectoryBinding(binding.parentPath, binding.path);
+    assertCaptureDecision("binding-check", decidePrivatePathBinding({
+      identityStable:
+        sameCapturePathIdentity(binding.identity, observed.identity) &&
+        sameCapturePathIdentity(binding.parentIdentity, observed.parentIdentity),
+      authenticatedHomeBinding: true,
+    }));
+  } catch (error) {
+    throw captureFailure("binding-check", error);
+  }
+}
+
+async function assertCaptureFileBinding(
+  directory: CaptureDirectoryBinding,
+  path: string,
+  expectedIdentity: CapturePathIdentity,
+): Promise<CapturePathMetadata> {
+  try {
+    await assertCaptureDirectoryStable(directory);
+    const before = await lstat(path);
+    const physicalPath = await realpath(path);
+    const physical = await lstat(physicalPath);
+    const after = await lstat(path);
+    const physicalParent = await lstat(dirname(physicalPath));
+    assertCaptureFileEntry(before);
+    assertCaptureFileEntry(physical);
+    assertCaptureFileEntry(after);
+    assertCaptureDirectoryEntry(physicalParent);
+    assertCaptureDecision("binding-check", decidePrivatePathBinding({
+      identityStable:
+        sameCapturePathIdentity(expectedIdentity, capturePathIdentity(before)) &&
+        sameCapturePathIdentity(expectedIdentity, capturePathIdentity(physical)) &&
+        sameCapturePathIdentity(expectedIdentity, capturePathIdentity(after)),
+      authenticatedHomeBinding: sameCapturePathIdentity(
+        directory.identity,
+        capturePathIdentity(physicalParent),
+      ),
+    }));
+    await assertCaptureDirectoryStable(directory);
+    return after;
+  } catch (error) {
+    throw captureFailure("binding-check", error);
+  }
+}
+
+function classifyCaptureDirectorySync(): void {
+  const classification = classifyPrivatePathDurability({
+    platform: "windows",
+    stage: "directory-sync",
+  });
+  if (classification.kind !== "unavailable") {
+    throw new WindowsReferenceCaptureSidecarError("file-flush", "io-failure");
+  }
+}
+
+async function writeWindowsCaptureFile(
+  directory: CaptureDirectoryBinding,
+  path: string,
+  bytes: string,
+  dependencies: ReferenceCaptureSidecarDependencies | undefined,
+  recordIdentity: (identity: CapturePathIdentity) => void,
+): Promise<CapturePathIdentity> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    await assertCaptureDirectoryStable(directory);
+    try {
+      handle = await (dependencies?.openFile ?? open)(
+        path,
+        constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
+        0o600,
+      );
+    } catch (error) {
+      throw captureFailure("content-write", error);
+    }
+    const opened = await handle.stat();
+    assertCaptureFileEntry(opened);
+    const identity = capturePathIdentity(opened);
+    await assertCaptureFileBinding(directory, path, identity);
+    recordIdentity(identity);
+    try {
+      await handle.writeFile(bytes);
+    } catch (error) {
+      throw captureFailure("content-write", error);
+    }
+    try {
+      if (dependencies?.syncFile === undefined) await handle.sync();
+      else await dependencies.syncFile(handle);
+    } catch (error) {
+      throw captureFailure("file-flush", error);
+    }
+    const flushed = await handle.stat();
+    assertCaptureFileEntry(flushed);
+    if (flushed.size !== Buffer.byteLength(bytes)) {
+      throw new WindowsReferenceCaptureSidecarError("content-write", "corruption");
+    }
+    assertCaptureDecision("binding-check", decidePrivatePathBinding({
+      identityStable: sameCapturePathIdentity(identity, capturePathIdentity(flushed)),
+      authenticatedHomeBinding: true,
+    }));
+    try {
+      await handle.close();
+      handle = undefined;
+    } catch (error) {
+      throw captureFailure("file-flush", error);
+    }
+    await assertCaptureFileBinding(directory, path, identity);
+    return identity;
+  } finally {
+    if (handle !== undefined) {
+      await handle.close().catch(() => undefined);
+    }
+  }
+}
+
+async function readWindowsCaptureFile(
+  directory: CaptureDirectoryBinding,
+  path: string,
+  openFile: typeof open = open,
+): Promise<Uint8Array> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let buffer: Buffer | undefined;
+  try {
+    await assertCaptureDirectoryStable(directory);
+    const before = await lstat(path);
+    assertCaptureFileEntry(before);
+    const identity = capturePathIdentity(before);
+    handle = await openFile(path, constants.O_RDONLY);
+    const opened = await handle.stat();
+    assertCaptureFileEntry(opened);
+    const bounded = Number.isSafeInteger(opened.size) && opened.size >= 0 &&
+      opened.size <= MAX_REFERENCE_CAPTURE_SIDECAR_BYTES;
+    assertCaptureDecision("read-check", decidePrivatePathRead({
+      bounded,
+      identityStable: sameCapturePathIdentity(identity, capturePathIdentity(opened)),
+      contentValid: true,
+      authenticatedHomeBinding: opened.nlink === 1,
+    }));
+    buffer = Buffer.alloc(opened.size + 1);
+    let offset = 0;
+    while (offset < opened.size) {
+      const result = await handle.read(buffer, offset, opened.size - offset, offset);
+      if (result.bytesRead === 0) break;
+      offset += result.bytesRead;
+    }
+    const probe = await handle.read(buffer, opened.size, 1, opened.size);
+    const after = await handle.stat();
+    assertCaptureFileEntry(after);
+    await handle.close();
+    handle = undefined;
+    const current = await assertCaptureFileBinding(directory, path, identity);
+    assertCaptureDecision("read-check", decidePrivatePathRead({
+      bounded: offset === opened.size && probe.bytesRead === 0,
+      identityStable:
+        sameCapturePathIdentity(identity, capturePathIdentity(after)) &&
+        sameCapturePathIdentity(capturePathIdentity(opened), capturePathIdentity(after)) &&
+        opened.size === after.size &&
+        opened.size === current.size &&
+        opened.mtimeMs === after.mtimeMs &&
+        opened.mtimeMs === current.mtimeMs &&
+        opened.ctimeMs === after.ctimeMs &&
+        opened.ctimeMs === current.ctimeMs,
+      contentValid: true,
+      authenticatedHomeBinding: after.nlink === 1,
+    }));
+    return new Uint8Array(buffer.subarray(0, opened.size));
+  } catch (error) {
+    throw captureFailure("read-check", error);
+  } finally {
+    buffer?.fill(0);
+    if (handle !== undefined) {
+      await handle.close().catch(() => undefined);
+    }
+  }
+}
 
 function realDate(value: string): boolean {
   if (!DATE.test(value)) return false;
@@ -92,6 +418,12 @@ export async function readVerifiedReferenceSnapshot(
 
 export type AssertReferenceCaptureReplayable = (manifest: ReferenceCaptureManifest) => Promise<void>;
 
+interface ReferenceCaptureSidecarDependencies {
+  readonly beforeRename?: () => void | Promise<void>;
+  readonly openFile?: typeof open;
+  readonly syncFile?: (handle: Awaited<ReturnType<typeof open>>) => Promise<void>;
+}
+
 export interface ReferenceCaptureSidecars {
   readonly manifest: ReferenceCaptureManifest;
   readonly review: ReferenceCaptureReview;
@@ -115,11 +447,39 @@ export async function loadReferenceCaptureSidecars(input: {
   readonly root: string;
   readonly captureId: string;
   readonly assertReplayable: AssertReferenceCaptureReplayable;
+  readonly platform?: NodeJS.Platform;
+  readonly openFile?: typeof open;
 }): Promise<ReferenceCaptureSidecars> {
   if (typeof input.assertReplayable !== "function") throw new TypeError("capture replay assertion is invalid");
   const captures = join(input.root, "captures");
   const directory = captureDirectory(input.root, input.captureId);
   const manifestPath = join(directory, "manifest.json"), reviewPath = join(directory, "review.json");
+  if ((input.platform ?? process.platform) === "win32") {
+    const rootBinding = await bindCaptureDirectory(dirname(input.root), input.root);
+    const capturesBinding = await bindCaptureDirectory(input.root, captures);
+    const directoryBinding = await bindCaptureDirectory(captures, directory);
+    let manifest: ReferenceCaptureManifest;
+    let review: ReferenceCaptureReview;
+    try {
+      manifest = parseReferenceCaptureManifest(
+        await readWindowsCaptureFile(directoryBinding, manifestPath, input.openFile),
+      );
+      review = parseReferenceCaptureReview(
+        await readWindowsCaptureFile(directoryBinding, reviewPath, input.openFile),
+      );
+    } catch (error) {
+      if (error instanceof WindowsReferenceCaptureSidecarError) throw error;
+      throw new WindowsReferenceCaptureSidecarError("read-check", "corruption");
+    }
+    if (manifest.capture_id !== input.captureId || review.capture_id !== input.captureId) {
+      throw new WindowsReferenceCaptureSidecarError("read-check", "corruption");
+    }
+    await assertCaptureDirectoryStable(directoryBinding);
+    await assertCaptureDirectoryStable(capturesBinding);
+    await assertCaptureDirectoryStable(rootBinding);
+    await input.assertReplayable(manifest);
+    return Object.freeze({ manifest, review });
+  }
   await assertCommittedMode(captures, "directory", 0o700);
   await assertCommittedMode(directory, "directory", 0o700);
   await assertCommittedMode(manifestPath, "file", 0o444);
@@ -134,26 +494,205 @@ export async function loadReferenceCaptureSidecars(input: {
   return Object.freeze({ manifest, review });
 }
 
-export async function writeReferenceCaptureSidecars(input: {
-  readonly root: string;
-  readonly manifest: ReferenceCaptureManifest;
-  readonly review: ReferenceCaptureReview;
-  readonly assertReplayable: AssertReferenceCaptureReplayable;
-}, dependencies?: { readonly beforeRename?: () => void | Promise<void> }): Promise<ReferenceCaptureSidecars> {
-  if (typeof input.assertReplayable !== "function") throw new TypeError("capture replay assertion is invalid");
-  const manifest = validateReferenceCaptureManifest(input.manifest);
-  const review = validateReferenceCaptureReview(input.review);
-  if (manifest.capture_id !== review.capture_id) throw new Error("capture sidecar IDs disagree");
+async function assertWindowsCapturePathMissing(path: string): Promise<void> {
+  try {
+    await lstat(path);
+    throw new WindowsReferenceCaptureSidecarError("entry-check", "corruption");
+  } catch (error) {
+    if (captureErrorCode(error) === "ENOENT") return;
+    throw captureFailure("entry-check", error);
+  }
+}
+
+async function removeWindowsCaptureFile(
+  directory: CaptureDirectoryBinding,
+  path: string,
+  identity: CapturePathIdentity | undefined,
+): Promise<void> {
+  if (identity === undefined) return;
+  await assertCaptureFileBinding(directory, path, identity);
+  try {
+    await unlink(path);
+  } catch (error) {
+    throw captureFailure("rename", error);
+  }
+  await assertCaptureDirectoryStable(directory);
+}
+
+async function writeWindowsReferenceCaptureSidecars(
+  input: {
+    readonly root: string;
+    readonly manifest: ReferenceCaptureManifest;
+    readonly review: ReferenceCaptureReview;
+    readonly assertReplayable: AssertReferenceCaptureReplayable;
+  },
+  dependencies: ReferenceCaptureSidecarDependencies | undefined,
+): Promise<ReferenceCaptureSidecars> {
+  const { manifest, review } = input;
   if (review.replaces_capture_id !== null) {
-    await loadReferenceCaptureSidecars({ root: input.root, captureId: review.replaces_capture_id,
-      assertReplayable: input.assertReplayable });
+    await loadReferenceCaptureSidecars({
+      root: input.root,
+      captureId: review.replaces_capture_id,
+      assertReplayable: input.assertReplayable,
+      platform: "win32",
+    });
   }
   const captures = join(input.root, "captures");
   const finalDirectory = captureDirectory(input.root, manifest.capture_id);
   const pendingName = `.pending-${manifest.capture_id}`;
   const pendingDirectory = join(captures, pendingName);
-  await ensurePrivateDirectory(input.root);
-  await ensurePrivateDirectory(captures);
+  await ensurePrivateDirectory(input.root, { platform: "win32" });
+  await ensurePrivateDirectory(captures, { platform: "win32" });
+  const rootBinding = await bindCaptureDirectory(dirname(input.root), input.root);
+  const capturesBinding = await bindCaptureDirectory(input.root, captures);
+  await assertWindowsCapturePathMissing(finalDirectory);
+  await assertWindowsCapturePathMissing(pendingDirectory);
+
+  let createdPending = false;
+  let renamed = false;
+  let pendingBinding: CaptureDirectoryBinding | undefined;
+  let manifestIdentity: CapturePathIdentity | undefined;
+  let reviewIdentity: CapturePathIdentity | undefined;
+  try {
+    try {
+      await mkdir(pendingDirectory, { mode: 0o700 });
+    } catch (error) {
+      throw captureFailure("content-write", error);
+    }
+    createdPending = true;
+    pendingBinding = await bindCaptureDirectory(captures, pendingDirectory);
+    const manifestPath = join(pendingDirectory, "manifest.json");
+    const reviewPath = join(pendingDirectory, "review.json");
+    const manifestBytes = serializeReferenceCaptureManifest(manifest);
+    const reviewBytes = serializeReferenceCaptureReview(review);
+    if (
+      Buffer.byteLength(manifestBytes) > MAX_REFERENCE_CAPTURE_SIDECAR_BYTES ||
+      Buffer.byteLength(reviewBytes) > MAX_REFERENCE_CAPTURE_SIDECAR_BYTES
+    ) {
+      throw new WindowsReferenceCaptureSidecarError("read-check", "corruption");
+    }
+    manifestIdentity = await writeWindowsCaptureFile(
+      pendingBinding,
+      manifestPath,
+      manifestBytes,
+      dependencies,
+      (identity) => {
+        manifestIdentity = identity;
+      },
+    );
+    reviewIdentity = await writeWindowsCaptureFile(
+      pendingBinding,
+      reviewPath,
+      reviewBytes,
+      dependencies,
+      (identity) => {
+        reviewIdentity = identity;
+      },
+    );
+    try {
+      await chmod(manifestPath, 0o444);
+      await chmod(reviewPath, 0o444);
+    } catch (error) {
+      throw captureFailure("content-write", error);
+    }
+    await assertCaptureFileBinding(pendingBinding, manifestPath, manifestIdentity);
+    await assertCaptureFileBinding(pendingBinding, reviewPath, reviewIdentity);
+    classifyCaptureDirectorySync();
+    await input.assertReplayable(manifest);
+    await assertCaptureDirectoryStable(pendingBinding);
+    await assertCaptureDirectoryStable(capturesBinding);
+    try {
+      await dependencies?.beforeRename?.();
+    } catch (error) {
+      throw captureFailure("rename", error);
+    }
+    try {
+      await rename(pendingDirectory, finalDirectory);
+    } catch (error) {
+      throw captureFailure("rename", error);
+    }
+    renamed = true;
+    const finalBinding = await bindCaptureDirectory(captures, finalDirectory);
+    assertCaptureDecision("binding-check", decidePrivatePathBinding({
+      identityStable: sameCapturePathIdentity(pendingBinding.identity, finalBinding.identity),
+      authenticatedHomeBinding: true,
+    }));
+    await assertCaptureFileBinding(finalBinding, join(finalDirectory, "manifest.json"), manifestIdentity);
+    await assertCaptureFileBinding(finalBinding, join(finalDirectory, "review.json"), reviewIdentity);
+    await assertCaptureDirectoryStable(capturesBinding);
+    await assertCaptureDirectoryStable(rootBinding);
+    classifyCaptureDirectorySync();
+  } catch (error) {
+    if (createdPending && !renamed) {
+      if (pendingName !== `.pending-${manifest.capture_id}` || dirname(pendingDirectory) !== captures) {
+        throw new WindowsReferenceCaptureSidecarError("binding-check", "corruption");
+      }
+      try {
+        const cleanupBinding = pendingBinding ?? await bindCaptureDirectory(captures, pendingDirectory);
+        await assertCaptureDirectoryStable(cleanupBinding);
+        await removeWindowsCaptureFile(
+          cleanupBinding,
+          join(pendingDirectory, "review.json"),
+          reviewIdentity,
+        );
+        await removeWindowsCaptureFile(
+          cleanupBinding,
+          join(pendingDirectory, "manifest.json"),
+          manifestIdentity,
+        );
+        await rmdir(pendingDirectory);
+        await assertCaptureDirectoryStable(capturesBinding);
+      } catch (cleanupError) {
+        throw captureFailure("rename", cleanupError);
+      }
+    }
+    throw error;
+  }
+  return loadReferenceCaptureSidecars({
+    root: input.root,
+    captureId: manifest.capture_id,
+    assertReplayable: input.assertReplayable,
+    platform: "win32",
+  });
+}
+
+export async function writeReferenceCaptureSidecars(input: {
+  readonly root: string;
+  readonly manifest: ReferenceCaptureManifest;
+  readonly review: ReferenceCaptureReview;
+  readonly assertReplayable: AssertReferenceCaptureReplayable;
+  readonly platform?: NodeJS.Platform;
+}, dependencies?: ReferenceCaptureSidecarDependencies): Promise<ReferenceCaptureSidecars> {
+  if (typeof input.assertReplayable !== "function") {
+    throw new TypeError("capture replay assertion is invalid");
+  }
+  const manifest = validateReferenceCaptureManifest(input.manifest);
+  const review = validateReferenceCaptureReview(input.review);
+  if (manifest.capture_id !== review.capture_id) throw new Error("capture sidecar IDs disagree");
+  if ((input.platform ?? process.platform) === "win32") {
+    return writeWindowsReferenceCaptureSidecars({
+      root: input.root,
+      manifest,
+      review,
+      assertReplayable: input.assertReplayable,
+    }, dependencies);
+  }
+  if (review.replaces_capture_id !== null) {
+    await loadReferenceCaptureSidecars({ root: input.root, captureId: review.replaces_capture_id,
+      assertReplayable: input.assertReplayable,
+      ...(input.platform === undefined ? {} : { platform: input.platform }) });
+  }
+  const captures = join(input.root, "captures");
+  const finalDirectory = captureDirectory(input.root, manifest.capture_id);
+  const pendingName = `.pending-${manifest.capture_id}`;
+  const pendingDirectory = join(captures, pendingName);
+  if (input.platform === undefined) {
+    await ensurePrivateDirectory(input.root);
+    await ensurePrivateDirectory(captures);
+  } else {
+    await ensurePrivateDirectory(input.root, { platform: input.platform });
+    await ensurePrivateDirectory(captures, { platform: input.platform });
+  }
   await assertCommittedMode(captures, "directory", 0o700);
   try { await lstat(finalDirectory); throw new Error("capture sidecars already exist"); }
   catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
@@ -188,5 +727,6 @@ export async function writeReferenceCaptureSidecars(input: {
     throw error;
   }
   return loadReferenceCaptureSidecars({ root: input.root, captureId: manifest.capture_id,
-    assertReplayable: input.assertReplayable });
+    assertReplayable: input.assertReplayable,
+    ...(input.platform === undefined ? {} : { platform: input.platform }) });
 }

--- a/packages/kernel-node/tests/capture-manifest.test.ts
+++ b/packages/kernel-node/tests/capture-manifest.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, mkdir, readFile, readdir, stat, symlink } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, open, readFile, readdir, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { gzipSync } from "node:zlib";
@@ -12,6 +12,7 @@ import {
   loadReferenceCaptureSidecars,
   parseReferenceCaptureReview,
   readVerifiedReferenceSnapshot,
+  WindowsReferenceCaptureSidecarError,
   writeReferenceCaptureSidecars,
 } from "../src/capture-manifest/index.js";
 
@@ -104,5 +105,138 @@ describe("immutable Reference capture sidecars", () => {
     await writeReferenceCaptureSidecars({ root, manifest: manifest(SECOND),
       review: { schema_version: 1, capture_id: SECOND, reviewed_on: "1998-07-19", replaces_capture_id: FIRST, reason: "provider-refresh" }, assertReplayable: replay });
     expect(await readFile(join(root, "captures", FIRST, "manifest.json"), "utf8")).toContain(FIRST);
+  });
+
+  it("uses structural bindings on win32 without comparing POSIX modes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-")), replay = vi.fn(async () => {});
+    const result = await writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: replay, platform: "win32" });
+    const captures = join(root, "captures"), directory = join(captures, FIRST);
+    await chmod(captures, 0o755);
+    await chmod(directory, 0o755);
+    await chmod(join(directory, "manifest.json"), 0o644);
+    await chmod(join(directory, "review.json"), 0o644);
+    await expect(loadReferenceCaptureSidecars({ root, captureId: FIRST,
+      assertReplayable: replay, platform: "win32" })).resolves.toEqual(result);
+    expect(replay).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects corrupt win32 sidecars with path-free stage diagnostics", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-"));
+    await writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: async () => {}, platform: "win32" });
+    const manifestPath = join(root, "captures", FIRST, "manifest.json");
+    await chmod(manifestPath, 0o600);
+    await writeFile(manifestPath, "{invalid");
+    const failure = await loadReferenceCaptureSidecars({ root, captureId: FIRST,
+      assertReplayable: async () => {}, platform: "win32" }).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(WindowsReferenceCaptureSidecarError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
+    expect((failure as Error).message).not.toContain(root);
+  });
+
+  it("rejects locked win32 sidecars with path-free sharing diagnostics", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-"));
+    await writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: async () => {}, platform: "win32" });
+    const openFile = vi.fn(async () => {
+      throw Object.assign(new Error(`locked ${root}`), { code: "EBUSY" });
+    }) as unknown as typeof open;
+    const failure = await loadReferenceCaptureSidecars({ root, captureId: FIRST,
+      assertReplayable: async () => {}, platform: "win32", openFile })
+      .catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(WindowsReferenceCaptureSidecarError);
+    expect(failure).toMatchObject({ stage: "read-check", category: "sharing-violation" });
+    expect((failure as Error).message).not.toContain(root);
+  });
+
+  it("does not swallow win32 file flush failures", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-"));
+    const failure = await writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: async () => {}, platform: "win32" }, {
+      syncFile: async () => {
+        throw Object.assign(new Error(`flush ${root}`), { code: "EIO" });
+      },
+    }).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(WindowsReferenceCaptureSidecarError);
+    expect(failure).toMatchObject({ stage: "file-flush", category: "io-failure" });
+    expect((failure as Error).message).not.toContain(root);
+    await expect(stat(join(root, "captures", `.pending-${FIRST}`))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("preserves win32 replay validation failures", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-"));
+    const validationFailure = new Error("replay validation failed");
+    const failure = await writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: async () => { throw validationFailure; }, platform: "win32" })
+      .catch((error: unknown) => error);
+    expect(failure).toBe(validationFailure);
+    await expect(stat(join(root, "captures", `.pending-${FIRST}`))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("classifies win32 pre-publication failures without disclosing paths", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-"));
+    const failure = await writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: async () => {}, platform: "win32" }, {
+      beforeRename: async () => {
+        throw Object.assign(new Error(`publication ${root}`), { code: "EBUSY" });
+      },
+    }).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(WindowsReferenceCaptureSidecarError);
+    expect(failure).toMatchObject({ stage: "rename", category: "sharing-violation" });
+    expect((failure as Error).message).not.toContain(root);
+  });
+
+  it("preserves unrelated state when a win32 publication rename fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-"));
+    const finalDirectory = join(root, "captures", FIRST);
+    const unrelated = join(finalDirectory, "unrelated.txt");
+    const failure = await writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: async () => {}, platform: "win32" }, {
+      beforeRename: async () => {
+        await mkdir(finalDirectory);
+        await writeFile(unrelated, "preserve");
+      },
+    }).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(WindowsReferenceCaptureSidecarError);
+    expect(failure).toMatchObject({ stage: "rename", category: "io-failure" });
+    await expect(readFile(unrelated, "utf8")).resolves.toBe("preserve");
+    await expect(stat(join(root, "captures", `.pending-${FIRST}`))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("does not remove unrelated state from a failed win32 pending directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-"));
+    const pendingDirectory = join(root, "captures", `.pending-${FIRST}`);
+    const unrelated = join(pendingDirectory, "unrelated.txt");
+    const failure = await writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: async () => {}, platform: "win32" }, {
+      beforeRename: async () => {
+        await writeFile(unrelated, "preserve");
+        throw Object.assign(new Error(`publication ${root}`), { code: "EIO" });
+      },
+    }).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(WindowsReferenceCaptureSidecarError);
+    expect(failure).toMatchObject({ stage: "rename", category: "io-failure" });
+    await expect(readFile(unrelated, "utf8")).resolves.toBe("preserve");
+    await expect(stat(join(pendingDirectory, "manifest.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(stat(join(pendingDirectory, "review.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 });


### PR DESCRIPTION
## What

Closes the Windows storage slice: the remaining Desktop-reachable stores gain win32 dispatch through the established private-path policy. Patched: the Memory store and provenance metadata journal, Telegram allowed-senders channel state, the reference-capture manifest/sidecars (kernel-node), and their coach wiring (capture, composition, store-runtime). Left unchanged with verified reasons: auth profile-store and usage-ledger (their reached startup paths are already win32-safe — no POSIX mode/UID assertions, no O_NOFOLLOW-dependent opens on the Desktop path). Every non-Windows path is byte-identical to HEAD, including provenance fsync order; corrupt or locked state fails closed with stage-coded, path-free diagnostics and never resets unrelated state.

## New limits (win32 policy paths only)

- MAX_ALLOWED_SENDERS_FILE_BYTES = 1048576 (packages/core/src/channels/allowed-senders.ts) — bounded stable read of the allowed-senders file; corrupt-file reads must not stall startup.
- MAX_PROVENANCE_METADATA_BYTES = 67108864 (packages/core/src/memory/provenance-metadata.ts) — same bound for the provenance journal.
- MAX_REFERENCE_CAPTURE_SIDECAR_BYTES = 67108864 (packages/kernel-node/src/capture-manifest/index.ts) — same bound for capture sidecars.

## Behavior note (win32, deliberate)

A corrupt allowed-senders.json on Windows requires manual file deletion: reset/recovery rejects fail-closed at the corruption check before recovery state runs, whereas POSIX reset can recover in place. This follows the fail-closed policy (recovery never resets unrelated state); a friendlier recovery path can ride a later package if wanted.

## Non-goals (deliberate)

- Chat/transcript/conversation stores, daemon RPC, credential vaults, first-run config, renderer, and packaging are untouched (earlier packages own them).
- No changeset: no user-visible behavior change on any currently shipped platform.

## Verification

- kernel + kernel-node suites (Node 24): 958 passed / 0 failed
- core suite: 2638 passed / 0 failed / 5 skipped
- coach suite (repo-root cwd, Node 24): 733 passed / 0 failed
- apps/desktop suite: 1324 passed / 1 failed — the single failure is onboarding-first-run.integration.test.ts, pre-existing on this branch base (broken on main by #583, already fixed on main by test-only #591; the suite is platform-skipped on CI). Not caused by this diff.
- Root pnpm check: pass
