### PR TITLE
fix(ci): grant the desktop authorize gate its draft read permission

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       actions: read
-      contents: read
+      contents: write
     outputs:
       source_run_id: ${{ steps.authorize.outputs.source_run_id }}
       source_run_attempt: ${{ steps.authorize.outputs.source_run_attempt }}

--- a/tools/check-desktop-release-workflow.test.ts
+++ b/tools/check-desktop-release-workflow.test.ts
@@ -131,6 +131,26 @@ describe("desktop release workflow policy", () => {
     expectIssue({ ...source, desktop }, "release executable jobs must have bounded");
   });
 
+  it("requires write permission for a job that reads a draft release", () => {
+    const source = sources();
+    const desktop = replaceRequired(
+      source.desktop,
+      "  authorize-coordinator:\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n    permissions:\n      actions: read\n      contents: write",
+      "  authorize-coordinator:\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n    permissions:\n      actions: read\n      contents: read",
+    );
+    expectIssue({ ...source, desktop }, "draft release reads require exact contents permission");
+  });
+
+  it("rejects write permission for a job that reads only the latest release", () => {
+    const source = sources();
+    const desktop = replaceRequired(
+      source.desktop,
+      'CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")',
+      'CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest")',
+    );
+    expectIssue({ ...source, desktop }, "draft release reads require exact contents permission");
+  });
+
   it("requires the stable desktop tag namespace, manifest version, and exact tag ref", () => {
     const source = sources();
     const mutations = [

--- a/tools/check-desktop-release-workflow.ts
+++ b/tools/check-desktop-release-workflow.ts
@@ -348,6 +348,51 @@ function exactPermissions(
   }
 }
 
+function checkDraftReleaseReadPermissions(
+  workflow: Mapping,
+  label: string,
+  issues: string[],
+): void {
+  const jobs = mapping(workflow.jobs, `${label}.jobs`, issues);
+  for (const [jobName, rawJob] of Object.entries(jobs)) {
+    const job = mapping(rawJob, `${label}.jobs.${jobName}`, issues);
+    const commands = runs(job).flatMap(shellCommands);
+    const releaseTargets = commands.flatMap((command) => {
+      if (!/\bgh api\b/u.test(command)) return [];
+      const method = command.match(/\b(?:--method|-X)\s+([A-Za-z]+)/u)?.[1]?.toUpperCase();
+      if (
+        (method !== undefined && method !== "GET") ||
+        /\s(?:-f|-F|--field|--raw-field)(?:\s|=)/u.test(command)
+      ) {
+        return [];
+      }
+      return [
+        ...command.matchAll(/\brepos\/[^"'\s]+\/releases\/([^/"'\s)?#]+)(?=[?"'\s)]|$)/gu),
+      ].map((match) => match[1]);
+    });
+    if (releaseTargets.length === 0) continue;
+    const mutatesReleases = commands.some((command) => {
+      if (/\bgh release (?:create|delete|edit|upload)\b/u.test(command)) return true;
+      if (!/\brepos\/[^"'\s]+\/releases(?:\/|[?"'\s)]|$)/u.test(command)) return false;
+      const method = command.match(/\b(?:--method|-X)\s+([A-Za-z]+)/u)?.[1]?.toUpperCase();
+      return (
+        (method !== undefined && method !== "GET") ||
+        /\s(?:-f|-F|--field|--raw-field)(?:\s|=)/u.test(command)
+      );
+    });
+    const requiredContents =
+      mutatesReleases || releaseTargets.some((target) => target !== "latest") ? "write" : "read";
+    const permissions = mapping(
+      job.permissions,
+      `${label}.jobs.${jobName} draft release read permissions`,
+      issues,
+    );
+    if (permissions.contents !== requiredContents) {
+      issues.push(`${label}.jobs.${jobName} draft release reads require exact contents permission`);
+    }
+  }
+}
+
 function requireQueue(
   concurrencyValue: unknown,
   group: string,
@@ -1114,7 +1159,7 @@ function checkDesktopChild(
 
   exactPermissions(
     authorize.permissions,
-    { actions: "read", contents: "read" },
+    { actions: "read", contents: "write" },
     "desktop coordinator authorization",
     issues,
   );
@@ -2343,6 +2388,10 @@ export function inspectDesktopReleaseWorkflows(
   checkCheckouts(coordinator, "desktop coordinator", issues);
   checkCheckouts(desktop, "desktop child", issues);
   checkCheckouts(version, "version", issues);
+  checkDraftReleaseReadPermissions(release, "npm release", issues);
+  checkDraftReleaseReadPermissions(coordinator, "desktop coordinator", issues);
+  checkDraftReleaseReadPermissions(desktop, "desktop child", issues);
+  checkDraftReleaseReadPermissions(version, "version", issues);
   checkNpmRelease(releaseSource, release, issues);
   checkCoordinator(coordinatorSource, coordinator, issues);
   checkDesktopChild(desktopSource, desktop, issues, resolve(root));


### PR DESCRIPTION
## The failure

Every desktop release dispatch fails ~0.5s into the `authorize-coordinator` job's "Bind call to the active release coordinator" step, on both the coordinator lane and the direct `workflow_dispatch` lane. No desktop release of any version can authorize on any dispatch path.

The step runs:

```
CANDIDATE_RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")
```

Reading a **draft** release requires push access. The job declared `contents: read`, so `GITHUB_TOKEN` gets `HTTP 403 Resource not accessible by integration`.

## Three proofs

1. In one coordinator run, `prepare-release-draft` (`contents: write`) successfully created **and read** the same draft id, while `authorize-coordinator` (`contents: read`) 403'd on that exact id.
2. At the 0.1.1 tag commit the authorize step's only `gh` call was `gh api repos/.../actions/runs/<id>`, covered by `actions: read`, and it succeeded. The draft-release read is new — it arrived with #586.
3. Reproduced identically on both dispatch lanes (coordinator-invoked and direct operator dispatch).

Nothing in the ~70 lines preceding the call makes a `gh` request, which is why the failure lands almost immediately.

## The fix

`authorize-coordinator` alone gets `contents: write`. Job-level permissions replace the workflow-level default, so this is scoped to the one job that needs it:

- the workflow-level default stays `actions: read` / `contents: read`;
- no other job's permissions changed;
- no `secrets: inherit` was added, and the secretless-coordinator assertions are untouched;
- the reusable-workflow cap holds — the coordinator's calling job already grants `actions: read` / `contents: write`, and a caller can only downgrade a called workflow's permissions, so the direct and coordinator lanes both authorize now.

`contents: write` is the least privilege available: GitHub permissions are per-scope `none`/`read`/`write`, and draft visibility is gated on push access, so there is no narrower grant that makes the read succeed.

Every assertion in the authorize step is byte-for-byte unchanged, including the draft-body-digest binding that pins the fetched release body to the digest derived from `apps/desktop/CHANGELOG.md` at the release commit.

## Guard extension

`tools/check-desktop-release-workflow.ts` pinned each job's exact permission set but had no notion of what the job's own shell actually calls, so it accepted a job that reads a draft with `contents: read`. It now derives the requirement from the workflow source: any job whose run scripts perform a `gh api repos/<repo>/releases/<id>` read must declare `contents: write`, while a job whose only release read is `releases/latest` must declare `contents: read`. Exact equality means the check bites in both directions — a missing permission and an unnecessary widening both fail.

The `exactPermissions` pin for `authorize-coordinator` is updated to `{ actions: read, contents: write }`, so a future narrowing breaks the checker instead of production.

## Validation

- `pnpm check:desktop-release-workflow` passes.
- `pnpm vitest run tools/check-desktop-release-workflow.test.ts` — 68 passed, including two new mutation tests covering both directions.
- All seven `.github/workflows/*.yml` files still parse as YAML.
- Mutation-checked against the real workflow: reverting the permission line makes the checker reject with both `draft release reads require exact contents permission` and `permissions are not least-privilege`; widening an unrelated job also rejects.
