### PR TITLE
feat(desktop): add installed Windows residency (tray, login item, lifecycle)

### DIFF
--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -1,4 +1,5 @@
 export const DESKTOP_SCHEME = "enduragent" as const;
+export const DESKTOP_APP_USER_MODEL_ID = "icu.enduragent.desktop" as const;
 export const DESKTOP_HOST = "app" as const;
 export const DESKTOP_RENDERER_ORIGIN = "enduragent://app" as const;
 export const DESKTOP_RENDERER_URL = "enduragent://app/index.html" as const;

--- a/apps/desktop/src/main/desktop-lifecycle.ts
+++ b/apps/desktop/src/main/desktop-lifecycle.ts
@@ -1,0 +1,60 @@
+import type { App } from "electron";
+import { DESKTOP_APP_USER_MODEL_ID } from "./constants.js";
+
+export type DesktopIdentityAppPort = Pick<App, "setAppUserModelId">;
+
+export class DesktopIdentityBindingError extends Error {
+  override readonly name = "DesktopIdentityBindingError";
+  readonly stage = "set-app-user-model-id" as const;
+
+  constructor() {
+    super("Windows desktop identity binding failed");
+  }
+}
+
+export function bindDesktopAppUserModelId(
+  app: DesktopIdentityAppPort,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (platform !== "win32") return;
+  try {
+    app.setAppUserModelId(DESKTOP_APP_USER_MODEL_ID);
+  } catch {
+    throw new DesktopIdentityBindingError();
+  }
+}
+
+export interface DesktopActivationTarget {
+  showMainWindow(): Promise<unknown>;
+}
+
+export interface DesktopActivationRelay {
+  request(): void;
+  bind(target: DesktopActivationTarget): Promise<void>;
+  unbind(target: DesktopActivationTarget): void;
+}
+
+export function createDesktopActivationRelay(
+  platform: NodeJS.Platform = process.platform,
+): DesktopActivationRelay {
+  let target: DesktopActivationTarget | undefined;
+  let pendingWindowsActivation = false;
+  return {
+    request() {
+      if (target !== undefined) {
+        void target.showMainWindow();
+      } else if (platform === "win32") {
+        pendingWindowsActivation = true;
+      }
+    },
+    async bind(next) {
+      target = next;
+      if (platform !== "win32" || !pendingWindowsActivation) return;
+      pendingWindowsActivation = false;
+      await next.showMainWindow();
+    },
+    unbind(current) {
+      if (target === current) target = undefined;
+    },
+  };
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -21,6 +21,7 @@ import {
 import { createChatGptAuth, hasChatGptProfile } from "./chatgpt-auth.js";
 import { createClaudeCliStatus, readClaudeCliSettings } from "./claude-cli-status.js";
 import { installDesktopConnectionIpc } from "./connection-ipc.js";
+import { bindDesktopAppUserModelId, createDesktopActivationRelay } from "./desktop-lifecycle.js";
 import { installDesktopExternalLinkIpc } from "./external-link-ipc.js";
 import { DESKTOP_LIFECYCLE_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
 import {
@@ -113,6 +114,7 @@ import {
   type DesktopTrainingExporter,
 } from "./training-export-ipc.js";
 
+bindDesktopAppUserModelId(app);
 bindWindowsUserData(app);
 registerDesktopScheme();
 
@@ -156,11 +158,14 @@ async function runDesktop(): Promise<void> {
   const securitySmokeMode = process.argv.includes("--desktop-security-smoke");
   const rendererConsoleCapture = createDesktopRendererConsoleCapture(securitySmokeMode);
   let residency: DesktopResidency | undefined;
+  const activation = createDesktopActivationRelay();
   app.on("second-instance", () => {
-    void residency?.showMainWindow();
+    if (process.platform === "win32") activation.request();
+    else void residency?.showMainWindow();
   });
   app.on("activate", () => {
-    void residency?.showMainWindow();
+    if (process.platform === "win32") activation.request();
+    else void residency?.showMainWindow();
   });
   app.on("window-all-closed", () => {});
   await app.whenReady();
@@ -225,7 +230,9 @@ async function runDesktop(): Promise<void> {
   });
   const shutdown = (): Promise<void> => {
     shutdownPromise ??= (async () => {
-      const residencyClose = residency?.close();
+      const closingResidency = residency;
+      const residencyClose = closingResidency?.close();
+      if (closingResidency !== undefined) activation.unbind(closingResidency);
       residency = undefined;
       const intervalsIpcClose = disposeIntervalsIpc?.();
       disposeIntervalsIpc = undefined;
@@ -771,6 +778,7 @@ async function runDesktop(): Promise<void> {
           }
           const created = new BrowserWindow(windowOptions);
           window = created;
+          residency?.manageMainWindow(created);
           rendererConsoleCapture.attach(created.webContents);
           hardenDesktopWindow(created);
           disposeOnboarding?.();
@@ -913,6 +921,8 @@ async function runDesktop(): Promise<void> {
       ),
       trayPopoverUrl: rendererSource.trayPopoverUrl,
       trayPreloadPath: resolve(mainDirectory, "../preload/tray.cjs"),
+      platform: process.platform,
+      loginItemExecutablePath: process.execPath,
       persistLoginPreference: (enabled) => backgroundAtLoginPreference.set(enabled),
       telegramStatus: async () => {
         const snapshot = await telegramCoordinator.status();
@@ -926,6 +936,7 @@ async function runDesktop(): Promise<void> {
         process.stderr.write(`desktop-residency-failure ${operation}\n`);
       },
     });
+    if (process.platform === "win32") await activation.bind(residency);
     await residency.start();
     const initialWindow = desktopStartedInBackground ? undefined : await mainWindow.show();
     void updateController.start();

--- a/apps/desktop/src/main/login-item.ts
+++ b/apps/desktop/src/main/login-item.ts
@@ -14,6 +14,7 @@ import {
   durablyReplaceReversible,
   type ReversibleDurableReplaceOutcome,
 } from "./durable-atomic-replace.js";
+import { DESKTOP_APP_USER_MODEL_ID } from "./constants.js";
 import { assertWindowsPrivateFileAtPath, readWindowsPrivateFile } from "./windows-private-file.js";
 
 export const CLEAN_LOGIN_ITEM_STATUSES = ["not-found", "not-registered"] as const;
@@ -21,6 +22,7 @@ export const BACKGROUND_AT_LOGIN_PREFERENCE_DIRECTORY_NAME = "desktop-preference
 export const BACKGROUND_AT_LOGIN_PREFERENCE_FILE_NAME = "background-at-login.json" as const;
 export const LOGIN_ITEM_PREFERENCE_DIRECTORY_MODE = 0o700;
 export const LOGIN_ITEM_PREFERENCE_FILE_MODE = 0o600;
+export const WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT = "--enduragent-background-at-login" as const;
 
 const MAX_PREFERENCE_FILE_BYTES = 1_024;
 
@@ -29,11 +31,20 @@ export type CleanLoginItemStatus = (typeof CLEAN_LOGIN_ITEM_STATUSES)[number];
 export interface LoginItemResidencyState {
   readonly openAtLogin: boolean;
   readonly executableWillLaunchAtLogin: boolean;
-  readonly status: LoginItemSettings["status"];
+  readonly status: LoginItemSettings["status"] | undefined;
 }
 
 export type LoginItemAppPort = Pick<App, "getLoginItemSettings" | "setLoginItemSettings">;
 export type LoginLaunchAppPort = Pick<App, "getLoginItemSettings">;
+
+export interface LoginItemResidencyOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly executablePath?: string;
+}
+
+export interface LoginLaunchOptions extends LoginItemResidencyOptions {
+  readonly commandLine?: readonly string[];
+}
 
 export type BackgroundAtLoginPreference =
   | Readonly<{
@@ -418,8 +429,17 @@ export function createBackgroundAtLoginPreferenceStore(
 export async function shouldStartInBackgroundAtLogin(
   app: LoginLaunchAppPort,
   preference: Pick<BackgroundAtLoginPreferenceStore, "read">,
+  options: LoginLaunchOptions = {},
 ): Promise<boolean> {
-  if (app.getLoginItemSettings().wasOpenedAtLogin !== true) return false;
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") {
+    const commandLine = options.commandLine ?? process.argv;
+    if (!commandLine.includes(WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT)) return false;
+    const state = readLoginItemResidency(app, options);
+    if (!isLoginItemResidencyEnabled(state, platform)) return false;
+  } else if (app.getLoginItemSettings().wasOpenedAtLogin !== true) {
+    return false;
+  }
   const stored = await preference.read();
   if (stored.state === "uncertain") return true;
   return (
@@ -427,8 +447,18 @@ export async function shouldStartInBackgroundAtLogin(
   );
 }
 
-export function readLoginItemResidency(app: LoginItemAppPort): LoginItemResidencyState {
-  const settings = app.getLoginItemSettings();
+export function readLoginItemResidency(
+  app: LoginLaunchAppPort,
+  options: LoginItemResidencyOptions = {},
+): LoginItemResidencyState {
+  const platform = options.platform ?? process.platform;
+  const settings =
+    platform === "win32"
+      ? app.getLoginItemSettings({
+          path: options.executablePath ?? process.execPath,
+          args: [WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT],
+        })
+      : app.getLoginItemSettings();
   return {
     openAtLogin: settings.openAtLogin,
     executableWillLaunchAtLogin: settings.executableWillLaunchAtLogin,
@@ -439,9 +469,36 @@ export function readLoginItemResidency(app: LoginItemAppPort): LoginItemResidenc
 export function setLoginItemResidency(
   app: LoginItemAppPort,
   openAtLogin: boolean,
+  options: LoginItemResidencyOptions = {},
 ): LoginItemResidencyState {
-  app.setLoginItemSettings({ openAtLogin });
-  return readLoginItemResidency(app);
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") {
+    app.setLoginItemSettings({
+      openAtLogin,
+      path: options.executablePath ?? process.execPath,
+      args: [WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT],
+      enabled: openAtLogin,
+      name: DESKTOP_APP_USER_MODEL_ID,
+    });
+  } else {
+    app.setLoginItemSettings({ openAtLogin });
+  }
+  return readLoginItemResidency(app, options);
+}
+
+export function isLoginItemResidencyEnabled(
+  state: LoginItemResidencyState,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return state.openAtLogin && (platform !== "win32" || state.executableWillLaunchAtLogin === true);
+}
+
+export function loginItemResidencyMatchesRequest(
+  state: LoginItemResidencyState,
+  openAtLogin: boolean,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return openAtLogin ? isLoginItemResidencyEnabled(state, platform) : !state.openAtLogin;
 }
 
 export function isCleanUnregisteredLoginItem(

--- a/apps/desktop/src/main/residency.ts
+++ b/apps/desktop/src/main/residency.ts
@@ -7,6 +7,8 @@ import {
   type MenuItemConstructorOptions,
 } from "electron";
 import {
+  isLoginItemResidencyEnabled,
+  loginItemResidencyMatchesRequest,
   readLoginItemResidency,
   setLoginItemResidency,
   type BackgroundAtLoginPreferenceWriteResult,
@@ -40,6 +42,8 @@ export interface DesktopResidencyInput {
   readonly trayIconPath: string;
   readonly trayPopoverUrl: string;
   readonly trayPreloadPath: string;
+  readonly platform?: NodeJS.Platform;
+  readonly loginItemExecutablePath?: string;
   readonly telegramStatus: () => Promise<TrayTelegramStatus>;
   readonly persistLoginPreference: (
     enabled: boolean,
@@ -70,11 +74,13 @@ export interface TrayTelegramStatus {
 export interface DesktopResidency {
   start(): Promise<void>;
   showMainWindow(): Promise<void>;
+  manageMainWindow(window: BrowserWindow): void;
   quit(): void;
   close(): Promise<void>;
 }
 
 export function createDesktopResidency(input: DesktopResidencyInput): DesktopResidency {
+  const platform = input.platform ?? process.platform;
   let tray: Tray | undefined;
   let popover: TrayPopover | undefined;
   let startPromise: Promise<void> | undefined;
@@ -82,13 +88,24 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
   let closed = false;
   let closePromise: Promise<void> | undefined;
   let loginItemMutation: Promise<void> = Promise.resolve();
+  const managedWindows = new WeakSet<BrowserWindow>();
 
   const hidePopover = (): void => popover?.hide();
+  const manageMainWindow = (window: BrowserWindow): void => {
+    if (platform !== "win32" || managedWindows.has(window)) return;
+    managedWindows.add(window);
+    window.on("close", (event) => {
+      if (closed || quitRequested) return;
+      event.preventDefault();
+      window.hide();
+    });
+  };
   const showMainWindow = async (): Promise<void> => {
     if (closed) return;
     hidePopover();
     try {
-      await input.mainWindow.show();
+      const window = await input.mainWindow.show();
+      manageMainWindow(window);
       if (!closed) input.observe?.({ type: "main-window-shown" });
     } catch {
       if (!closed) input.reportFailure("show-window");
@@ -125,7 +142,10 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
   };
   const readLoginState = (): LoginItemResidencyState | undefined => {
     try {
-      const state = readLoginItemResidency(input.app);
+      const state = readLoginItemResidency(input.app, {
+        platform,
+        executablePath: input.loginItemExecutablePath,
+      });
       input.observe?.({ type: "login-item-read", state });
       return state;
     } catch {
@@ -138,6 +158,7 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
     const mutation = loginItemMutation.then(async () => {
       const previous = readLoginState();
       if (previous === undefined) return;
+      const previousEnabled = isLoginItemResidencyEnabled(previous, platform);
       let stored: BackgroundAtLoginPreferenceWriteResult;
       try {
         stored = await input.persistLoginPreference(openAtLogin);
@@ -151,8 +172,11 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
       }
       let applied: LoginItemResidencyState | undefined;
       try {
-        const state = setLoginItemResidency(input.app, openAtLogin);
-        if (state.openAtLogin !== openAtLogin) throw new TypeError();
+        const state = setLoginItemResidency(input.app, openAtLogin, {
+          platform,
+          executablePath: input.loginItemExecutablePath,
+        });
+        if (!loginItemResidencyMatchesRequest(state, openAtLogin, platform)) throw new TypeError();
         applied = state;
       } catch {}
       if (applied !== undefined) {
@@ -161,7 +185,7 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
       }
       let compensation: BackgroundAtLoginPreferenceWriteResult = { status: "uncertain" };
       try {
-        compensation = await input.persistLoginPreference(previous.openAtLogin);
+        compensation = await input.persistLoginPreference(previousEnabled);
       } catch {}
       let convergenceTarget: boolean | undefined;
       if (compensation.status === "stored") {
@@ -173,8 +197,13 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
       if (convergenceTarget !== undefined) {
         let converged = false;
         try {
-          const state = setLoginItemResidency(input.app, convergenceTarget);
-          if (state.openAtLogin !== convergenceTarget) throw new TypeError();
+          const state = setLoginItemResidency(input.app, convergenceTarget, {
+            platform,
+            executablePath: input.loginItemExecutablePath,
+          });
+          if (!loginItemResidencyMatchesRequest(state, convergenceTarget, platform)) {
+            throw new TypeError();
+          }
           input.observe?.({ type: "login-item-set", state });
           converged = true;
         } catch {}
@@ -201,7 +230,7 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
       {
         label: "Start in background at login",
         type: "checkbox",
-        checked: state?.openAtLogin ?? false,
+        checked: state === undefined ? false : isLoginItemResidencyEnabled(state, platform),
         enabled: state !== undefined,
         click: (menuItem) => setLoginState(menuItem.checked),
       },
@@ -222,10 +251,13 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
           if (closed || tray !== undefined) return;
           const image = nativeImage.createFromPath(input.trayIconPath);
           if (image.isEmpty()) throw new TypeError();
-          image.setTemplateImage(true);
+          if (platform !== "win32") image.setTemplateImage(true);
           tray = new Tray(image);
           tray.setToolTip(TRAY_TOOLTIP);
-          tray.on("click", () => ensurePopover().toggle());
+          tray.on("click", () => {
+            if (platform === "win32") void showMainWindow();
+            else ensurePopover().toggle();
+          });
           tray.on("right-click", showContextMenu);
           input.observe?.({ type: "tray-created" });
         })
@@ -235,6 +267,7 @@ export function createDesktopResidency(input: DesktopResidencyInput): DesktopRes
       return startPromise;
     },
     showMainWindow,
+    manageMainWindow,
     quit() {
       if (quitRequested) return;
       quitRequested = true;

--- a/apps/desktop/tests/desktop-lifecycle.test.ts
+++ b/apps/desktop/tests/desktop-lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import { DESKTOP_APP_USER_MODEL_ID } from "../src/main/constants.js";
+import {
+  bindDesktopAppUserModelId,
+  createDesktopActivationRelay,
+  DesktopIdentityBindingError,
+} from "../src/main/desktop-lifecycle.js";
+
+describe("desktop platform lifecycle", () => {
+  it("binds the frozen AppUserModelID only on Windows", () => {
+    const setAppUserModelId = vi.fn();
+
+    bindDesktopAppUserModelId({ setAppUserModelId } as never, "win32");
+
+    expect(setAppUserModelId).toHaveBeenCalledOnce();
+    expect(setAppUserModelId).toHaveBeenCalledWith(DESKTOP_APP_USER_MODEL_ID);
+
+    setAppUserModelId.mockClear();
+    bindDesktopAppUserModelId({ setAppUserModelId } as never, "darwin");
+    expect(setAppUserModelId).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when Windows rejects the AppUserModelID", () => {
+    const sensitiveDetail = String.raw`C:\Users\Private Athlete\identity failure`;
+    let failure: unknown;
+    try {
+      bindDesktopAppUserModelId(
+        {
+          setAppUserModelId() {
+            throw new TypeError(sensitiveDetail);
+          },
+        },
+        "win32",
+      );
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(DesktopIdentityBindingError);
+    expect(failure).toMatchObject({
+      name: "DesktopIdentityBindingError",
+      message: "Windows desktop identity binding failed",
+      stage: "set-app-user-model-id",
+    });
+    expect(failure).not.toHaveProperty("cause");
+    expect(JSON.stringify(failure)).not.toContain(sensitiveDetail);
+  });
+
+  it("binds identity before scheme, lock, and window interaction in the production entry", async () => {
+    const source = await readFile(new URL("../src/main/index.ts", import.meta.url), "utf8");
+    const identity = source.indexOf("bindDesktopAppUserModelId(app);");
+
+    expect(identity).toBeGreaterThanOrEqual(0);
+    expect(identity).toBeLessThan(source.indexOf("registerDesktopScheme();"));
+    expect(identity).toBeLessThan(source.indexOf("app.requestSingleInstanceLock();"));
+    expect(identity).toBeLessThan(source.indexOf("new BrowserWindow("));
+  });
+
+  it("restores, shows, and focuses the resident window for a second launch", async () => {
+    const source = await readFile(new URL("../src/main/index.ts", import.meta.url), "utf8");
+    const currentWindow = source.indexOf("const current = mainWindow.current();");
+    const currentReturn = source.indexOf("return Promise.resolve(current);", currentWindow);
+    const presentation = source.slice(currentWindow, currentReturn);
+
+    expect(presentation.indexOf("current.restore();")).toBeGreaterThanOrEqual(0);
+    expect(presentation.indexOf("current.show();")).toBeGreaterThan(
+      presentation.indexOf("current.restore();"),
+    );
+    expect(presentation.indexOf("current.focus();")).toBeGreaterThan(
+      presentation.indexOf("current.show();"),
+    );
+  });
+
+  it("coalesces early Windows activation and presents every later second launch", async () => {
+    const first = { showMainWindow: vi.fn(async () => {}) };
+    const second = { showMainWindow: vi.fn(async () => {}) };
+    const relay = createDesktopActivationRelay("win32");
+
+    relay.request();
+    relay.request();
+    await relay.bind(first);
+    expect(first.showMainWindow).toHaveBeenCalledOnce();
+
+    relay.request();
+    expect(first.showMainWindow).toHaveBeenCalledTimes(2);
+
+    relay.unbind(first);
+    relay.request();
+    await relay.bind(second);
+    expect(second.showMainWindow).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the macOS no-target activation behavior", async () => {
+    const target = { showMainWindow: vi.fn(async () => {}) };
+    const relay = createDesktopActivationRelay("darwin");
+
+    relay.request();
+    await relay.bind(target);
+    expect(target.showMainWindow).not.toHaveBeenCalled();
+
+    relay.request();
+    expect(target.showMainWindow).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/tests/login-item.test.ts
+++ b/apps/desktop/tests/login-item.test.ts
@@ -13,15 +13,19 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { DESKTOP_APP_USER_MODEL_ID } from "../src/main/constants.js";
 import {
   BACKGROUND_AT_LOGIN_PREFERENCE_FILE_NAME,
   createBackgroundAtLoginPreferenceStore,
   isCleanUnregisteredLoginItem,
   LOGIN_ITEM_PREFERENCE_DIRECTORY_MODE,
   LOGIN_ITEM_PREFERENCE_FILE_MODE,
+  isLoginItemResidencyEnabled,
+  loginItemResidencyMatchesRequest,
   readLoginItemResidency,
   setLoginItemResidency,
   shouldStartInBackgroundAtLogin,
+  WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT,
   type LoginItemAppPort,
   type LoginItemResidencyState,
 } from "../src/main/login-item.js";
@@ -132,6 +136,60 @@ describe("login-item residency", () => {
     expect(() => readLoginItemResidency(getApp)).toThrow(getterError);
     expect(() => setLoginItemResidency(setApp, true)).toThrow(setterError);
     expect(setApp.getLoginItemSettings).not.toHaveBeenCalled();
+  });
+
+  it("reads the exact argument-marked Windows registration", () => {
+    const executablePath = String.raw`C:\Users\Athlete\AppData\Local\Programs\Enduragent\Enduragent.exe`;
+    const getLoginItemSettings = vi.fn(() => state("enabled", true, true));
+    const app = { getLoginItemSettings } as never;
+
+    expect(readLoginItemResidency(app, { platform: "win32", executablePath })).toEqual({
+      openAtLogin: true,
+      executableWillLaunchAtLogin: true,
+      status: "enabled",
+    });
+    expect(getLoginItemSettings).toHaveBeenCalledWith({
+      path: executablePath,
+      args: [WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT],
+    });
+  });
+
+  it.each([true, false])(
+    "writes and verifies the named per-user Windows registration when enabled=%s",
+    (openAtLogin) => {
+      const executablePath = String.raw`C:\Program Files\Enduragent\Enduragent.exe`;
+      const setLoginItemSettings = vi.fn();
+      const getLoginItemSettings = vi.fn(() =>
+        state(openAtLogin ? "enabled" : "not-registered", openAtLogin, openAtLogin),
+      );
+      const app = { getLoginItemSettings, setLoginItemSettings } as never;
+
+      const observed = setLoginItemResidency(app, openAtLogin, {
+        platform: "win32",
+        executablePath,
+      });
+
+      expect(setLoginItemSettings).toHaveBeenCalledWith({
+        openAtLogin,
+        path: executablePath,
+        args: [WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT],
+        enabled: openAtLogin,
+        name: DESKTOP_APP_USER_MODEL_ID,
+      });
+      expect(getLoginItemSettings).toHaveBeenCalledWith({
+        path: executablePath,
+        args: [WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT],
+      });
+      expect(loginItemResidencyMatchesRequest(observed, openAtLogin, "win32")).toBe(true);
+    },
+  );
+
+  it("treats an OS-disabled Windows startup entry as off without hiding its registration", () => {
+    const disabled = state("enabled", true, false) as never;
+
+    expect(isLoginItemResidencyEnabled(disabled, "win32")).toBe(false);
+    expect(loginItemResidencyMatchesRequest(disabled, true, "win32")).toBe(false);
+    expect(loginItemResidencyMatchesRequest(disabled, false, "win32")).toBe(false);
   });
 });
 
@@ -383,6 +441,58 @@ describe("background-at-login preference", () => {
     await expect(shouldStartInBackgroundAtLogin(loginLaunch as never, { read })).resolves.toBe(
       true,
     );
+    expect(read).toHaveBeenCalledOnce();
+  });
+
+  it("starts in the Windows background only for the exact enabled login invocation", async () => {
+    const executablePath = String.raw`C:\Users\Athlete\Enduragent.exe`;
+    const read = vi.fn(async () => ({ state: "configured", enabled: true }) as const);
+    const getLoginItemSettings = vi.fn(() => state("enabled", true, true));
+    const app = { getLoginItemSettings } as never;
+
+    await expect(
+      shouldStartInBackgroundAtLogin(
+        app,
+        { read },
+        {
+          platform: "win32",
+          executablePath,
+          commandLine: [executablePath],
+        },
+      ),
+    ).resolves.toBe(false);
+    expect(getLoginItemSettings).not.toHaveBeenCalled();
+    expect(read).not.toHaveBeenCalled();
+
+    await expect(
+      shouldStartInBackgroundAtLogin(
+        app,
+        { read },
+        {
+          platform: "win32",
+          executablePath,
+          commandLine: [executablePath, WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT],
+        },
+      ),
+    ).resolves.toBe(true);
+    expect(getLoginItemSettings).toHaveBeenCalledWith({
+      path: executablePath,
+      args: [WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT],
+    });
+    expect(read).toHaveBeenCalledOnce();
+
+    getLoginItemSettings.mockReturnValueOnce(state("enabled", true, false));
+    await expect(
+      shouldStartInBackgroundAtLogin(
+        app,
+        { read },
+        {
+          platform: "win32",
+          executablePath,
+          commandLine: [WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT],
+        },
+      ),
+    ).resolves.toBe(false);
     expect(read).toHaveBeenCalledOnce();
   });
 

--- a/apps/desktop/tests/residency.test.ts
+++ b/apps/desktop/tests/residency.test.ts
@@ -61,6 +61,7 @@ const mocks = vi.hoisted(() => {
     commandLine: { getSwitchValue: vi.fn(() => ""), appendSwitch: vi.fn() },
   });
   return {
+    Emitter,
     order,
     image,
     FakeTray,
@@ -124,6 +125,7 @@ import {
   createBackgroundAtLoginPreferenceStore,
   LOGIN_ITEM_PREFERENCE_FILE_MODE,
   shouldStartInBackgroundAtLogin,
+  WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT,
   type BackgroundAtLoginPreferenceWriteResult,
 } from "../src/main/login-item.js";
 
@@ -150,12 +152,20 @@ function loginState(
   return { openAtLogin, executableWillLaunchAtLogin: openAtLogin, status };
 }
 
-function setup() {
+function setup(
+  options: {
+    readonly platform?: NodeJS.Platform;
+    readonly loginItemExecutablePath?: string;
+  } = {},
+) {
   const events: unknown[] = [];
   const reportFailure = vi.fn();
+  const browserWindow = Object.assign(new mocks.Emitter(), {
+    hide: vi.fn(),
+  });
   const mainWindow = {
     current: vi.fn(() => null),
-    show: vi.fn(async () => ({ id: 1 })),
+    show: vi.fn(async () => browserWindow),
   };
   const telegramStatus = vi.fn(async () => ({
     channelState: "online" as const,
@@ -171,6 +181,8 @@ function setup() {
     trayIconPath: "/synthetic/trayTemplate.png",
     trayPopoverUrl: "enduragent://app/tray.html",
     trayPreloadPath: "/synthetic/tray.cjs",
+    platform: options.platform,
+    loginItemExecutablePath: options.loginItemExecutablePath,
     telegramStatus,
     persistLoginPreference,
     reportFailure,
@@ -181,6 +193,7 @@ function setup() {
     events,
     reportFailure,
     mainWindow,
+    browserWindow,
     telegramStatus,
     persistLoginPreference,
   };
@@ -229,6 +242,57 @@ describe("desktop residency", () => {
     expect(mocks.popover.toggle).toHaveBeenCalledTimes(2);
     expect(mocks.app.getLoginItemSettings).not.toHaveBeenCalled();
     expect(events).toContainEqual({ type: "tray-created" });
+  });
+
+  it("uses the Windows tray icon as-is and opens the main window on left click", async () => {
+    const { residency, mainWindow } = setup({ platform: "win32" });
+
+    await residency.start();
+    const tray = mocks.FakeTray.instances[0]!;
+    tray.emit("click");
+    tray.emit("click");
+
+    await vi.waitFor(() => expect(mainWindow.show).toHaveBeenCalledTimes(2));
+    expect(mocks.image.setTemplateImage).not.toHaveBeenCalled();
+    expect(mocks.createTrayPopover).not.toHaveBeenCalled();
+    expect(tray.listenerCount("right-click")).toBe(1);
+  });
+
+  it("hides a Windows main window on close and allows explicit Quit to close it", async () => {
+    const { residency, browserWindow } = setup({ platform: "win32" });
+
+    await residency.showMainWindow();
+    const closeToTray = { preventDefault: vi.fn() };
+    browserWindow.emit("close", closeToTray);
+    expect(closeToTray.preventDefault).toHaveBeenCalledOnce();
+    expect(browserWindow.hide).toHaveBeenCalledOnce();
+
+    residency.quit();
+    const explicitQuit = { preventDefault: vi.fn() };
+    browserWindow.emit("close", explicitQuit);
+    expect(explicitQuit.preventDefault).not.toHaveBeenCalled();
+    expect(browserWindow.hide).toHaveBeenCalledOnce();
+    expect(mocks.app.quit).toHaveBeenCalledOnce();
+  });
+
+  it("uses effective Windows Startup Apps truth in the native menu", async () => {
+    const executablePath = String.raw`C:\Users\Athlete\Enduragent.exe`;
+    const { residency } = setup({ platform: "win32", loginItemExecutablePath: executablePath });
+    mocks.app.getLoginItemSettings.mockReturnValue(loginState("enabled", true) as never);
+    mocks.app.getLoginItemSettings.mockReturnValueOnce({
+      ...loginState("enabled", true),
+      executableWillLaunchAtLogin: false,
+    } as never);
+
+    await residency.start();
+    mocks.FakeTray.instances[0]!.emit("right-click");
+
+    const menu = mocks.buildFromTemplate.mock.calls[0]![0] as Array<Record<string, unknown>>;
+    expect(menu[2]).toMatchObject({ type: "checkbox", checked: false, enabled: true });
+    expect(mocks.app.getLoginItemSettings).toHaveBeenCalledWith({
+      path: executablePath,
+      args: [WINDOWS_BACKGROUND_AT_LOGIN_ARGUMENT],
+    });
   });
 
   it("refreshes a redacted Telegram projection whenever the popover is shown", async () => {

--- a/apps/desktop/tests/telegram-power.test.ts
+++ b/apps/desktop/tests/telegram-power.test.ts
@@ -715,10 +715,12 @@ describe("Desktop Telegram power lifecycle", () => {
     await chmod(target, 0o644);
     const secondController = controller();
     secondController.status.mockResolvedValue(pollingStatus("online"));
+    secondController.resumePolling.mockResolvedValue(pollingStatus("online"));
+    const secondMonitor = monitor();
     const reopened = createDesktopTelegramPowerLifecycle({
       ...files,
       platform: "win32",
-      powerMonitor: monitor(),
+      powerMonitor: secondMonitor,
       controller: secondController,
       now: () => observedAt,
       createId: () => "windows-power-reopen",
@@ -732,6 +734,14 @@ describe("Desktop Telegram power lifecycle", () => {
     });
     expect(synchronizeDirectory).not.toHaveBeenCalled();
     expect(synchronizeParentDirectory).not.toHaveBeenCalled();
+
+    secondMonitor.emit("suspend");
+    await reopened.warning();
+    expect(secondController.stopPolling).toHaveBeenCalledOnce();
+    secondMonitor.emit("resume");
+    await reopened.warning();
+    expect(secondController.stopPolling).toHaveBeenCalledTimes(2);
+    expect(secondController.resumePolling).toHaveBeenCalledOnce();
     await reopened.close();
   });
 

--- a/apps/desktop/tests/windows-icons.test.ts
+++ b/apps/desktop/tests/windows-icons.test.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import { DESKTOP_APP_USER_MODEL_ID } from "../src/main/constants.js";
 
 interface WindowsIconGeneratorModule {
   readonly APPLICATION_ICON_SIZES: readonly number[];
@@ -57,6 +58,7 @@ describe("Windows icon generation", () => {
   it("keeps the Windows builder wired to the committed ICO resources", async () => {
     const builder = parse(await readFile(join(desktopRoot, "electron-builder.yml"), "utf8"));
 
+    expect(builder.appId).toBe(DESKTOP_APP_USER_MODEL_ID);
     expect(builder.win).toEqual({
       icon: "resources/app-icon.ico",
       signExecutable: false,
@@ -64,6 +66,14 @@ describe("Windows icon generation", () => {
       files: ["resources/tray.ico"],
       target: [{ target: "nsis", arch: ["x64"] }],
     });
+  });
+
+  it("keeps the runtime login value name aligned with the uninstall hook", async () => {
+    const installer = await readFile(join(desktopRoot, "build", "installer.nsh"), "utf8");
+
+    expect(installer).toContain(
+      `DeleteRegValue HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Run" "${DESKTOP_APP_USER_MODEL_ID}"`,
+    );
   });
 
   it.each(["app-icon.ico", "tray.ico"])(


### PR DESCRIPTION
## Summary
- W11 of the Windows-parity initiative (ADR-0048): installed Windows residency for the Electron desktop app.
- Binds AppUserModelID `icu.enduragent.desktop` on win32 before any window, single-instance-lock, or tray interaction. The literal has one production source (`DESKTOP_APP_USER_MODEL_ID` in `constants.ts`); new `desktop-lifecycle.ts` owns the fail-closed identity binding and the second-launch activation relay (coalesces pre-bind activations, flushes once on bind, identity-guarded unbind).
- Windows tray: reuses the committed `resources/tray.ico` (the platform-conditional icon path pre-existed), skips `setTemplateImage` on win32 so the color icon renders as-is, and routes tray left-click to showing the main window instead of the macOS popover (the popover is never constructed on win32). Context-menu Quit unchanged.
- Close-to-tray on win32: window close hides to the tray; explicit Quit routes through the existing quit coordinator and supervisor drain — no new or duplicated termination logic.
- Login start: opt-in, per-user, no elevation, via `setLoginItemSettings` with `name: icu.enduragent.desktop` — exactly the registration the NSIS uninstall hook removes. The tray menu checkbox reads live OS state on every open, including `executableWillLaunchAtLogin`, so an externally disabled entry shows as disabled.
- darwin behavior is byte-identical: all new branches gate on an injected `platform` defaulting to `process.platform`.

## Verification
- `pnpm --filter '@enduragent/desktop^...' build`, renderer build, desktop build — all pass.
- `pnpm exec vitest run apps/desktop/tests` — 1373 passed, 0 failed, 0 skipped (63 files).
- Root `pnpm check` — clean.
- Fresh-context read-only audit confirmed: scope, AppUserModelID single-sourcing and bind ordering, login-item registration matching the uninstall hook, Quit wired to the existing supervisor guarantees, darwin parity, no code comments, no new numeric limits.

## Limits
None.

## Notes
- Low-severity follow-up (audit finding): uninstall leaves a stale `HKCU\...\Explorer\StartupApproved\Run` value — Task Manager metadata only; nothing launches without the `Run` value the hook already deletes. A future packaging change can add a second `DeleteRegValue`.
- Windows-host-only behavior (taskbar grouping and focus, real tray interaction, login/reboot, suspend/resume) is deferred to the Windows VM acceptance pass.
