### PR TITLE
chore(desktop): mint the 0.1.3 desktop release

### DIFF
--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @enduragent/desktop
 
-## 0.1.2
+## 0.1.3
 
 ### Patch Changes
 
@@ -22,7 +22,6 @@
 
   Invalidate timed-out updater generations, fence late completions, and keep automated and manual checks disabled until process restart after timeouts or updater startup failures because the native macOS updater does not expose a supported instance reset.
 
-- 873adab:
 - da84213: User-facing: Desktop update actions now wait for in-progress Settings changes to finish before restarting the app.
 - 41fe0aa: User-facing: Telegram bot management is now delete-and-reconnect - delete the connection, then connect a new bot with a copied token.
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enduragent/desktop",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "main": "out/main/index.js",


### PR DESCRIPTION
## What

Advances the desktop SemVer sequence to `0.1.3` and carries the accumulated release notes onto that heading.

Two files, three lines: `apps/desktop/package.json` version, the changelog heading, and one empty generator bullet.

## Why a new version instead of releasing 0.1.2

`0.1.2` was staged but never signed, published, or exposed to any user — its draft release holds zero assets. Its tag points at a commit that predates the authorize-gate permission fix (#593), so a `0.1.2` dispatch would run the workflow from the tag ref and fail the same way it did before.

The tag cannot be moved: the "Protect desktop release lineage tags" ruleset blocks both `update` and `deletion` on `enduragent-desktop@*` with no bypass actors. That protection is working as intended, so this mints a new version rather than weakening it.

## Why the notes move rather than starting a new section

The release body is derived from the *first* changelog section alone. Starting a fresh `## 0.1.3` section would have shipped a release whose notes omitted setup-in-chat, the Intervals.icu clipboard connect flow, and the update-recovery work — all of which are attached to the `0.1.2` heading. Since no user ever saw a `0.1.2` release, relabelling rewrites nothing user-visible.

## Also

Removed the bare `- 873adab:` bullet. That changeset (#574, Windows daemon-ownership groundwork) carried no release-note body, so the generator emitted an empty bullet that would have rendered in the release notes.

Windows work in #594/#595 landed without changesets and stays unannounced here — it is unshipped platform scaffolding, not user-facing on a macOS release.

## Verification

`pnpm check` green on Node 24.11.1 (build, per-package check, types, lint, and every `check:*` gate including `check:desktop-release-workflow`). Full `vitest run` cross-check in progress.