### PR TITLE
feat(engine): add Windows Claude CLI discovery, validated .cmd launch, and readiness

### DIFF
--- a/apps/desktop/src/main/claude-cli-status.ts
+++ b/apps/desktop/src/main/claude-cli-status.ts
@@ -52,7 +52,11 @@ export interface ClaudeCliStatusController {
 
 export type ClaudeCliStatusDependencies = Pick<
   EnsureClaudeCliReadyDeps,
-  "resolveBinary" | "probeVersion" | "probeAccount"
+  | "resolveBinary"
+  | "probeVersion"
+  | "probeAccount"
+  | "preflightMcpConfigTransform"
+  | "windowsMcpConfigFileSystem"
 > & {
   readonly ensureReady?: typeof ensureClaudeCliReady;
   readonly invalidateProbeCache?: () => void;
@@ -61,6 +65,7 @@ export type ClaudeCliStatusDependencies = Pick<
 export interface CreateClaudeCliStatusOptions {
   readonly settings: () => ClaudeCliSettings | Promise<ClaudeCliSettings>;
   readonly environment?: () => Readonly<Record<string, string | undefined>>;
+  readonly platform?: NodeJS.Platform;
   readonly applyRuntimeConfig: (request: ConfigureRuntimeRpcParams) => Promise<void>;
   readonly dependencies?: ClaudeCliStatusDependencies;
 }
@@ -121,6 +126,10 @@ function stateForFailure(error: unknown): ClaudeCliStatusState {
   switch (error.kind) {
     case "binary-missing":
     case "version-below-floor":
+    case "unsupported-windows-executable":
+    case "unsafe-windows-command-shim":
+    case "windows-mcp-config-write":
+    case "windows-mcp-config-cleanup":
       return "absent-binary";
     case "api-key-identity":
     case "api-key-unapproved":
@@ -138,6 +147,7 @@ export function createClaudeCliStatus(
   const invalidate =
     options.dependencies?.invalidateProbeCache ?? invalidateClaudeAccountProbeCache;
   const environment = options.environment ?? (() => process.env);
+  const platform = options.platform ?? process.platform;
   const probeDependencies: EnsureClaudeCliReadyDeps = {
     ...(options.dependencies?.resolveBinary === undefined
       ? {}
@@ -148,6 +158,12 @@ export function createClaudeCliStatus(
     ...(options.dependencies?.probeAccount === undefined
       ? {}
       : { probeAccount: options.dependencies.probeAccount }),
+    ...(options.dependencies?.preflightMcpConfigTransform === undefined
+      ? {}
+      : { preflightMcpConfigTransform: options.dependencies.preflightMcpConfigTransform }),
+    ...(options.dependencies?.windowsMcpConfigFileSystem === undefined
+      ? {}
+      : { windowsMcpConfigFileSystem: options.dependencies.windowsMcpConfigFileSystem }),
   };
 
   const read = async (forceRecheck: boolean): Promise<ClaudeCliStatus> => {
@@ -157,7 +173,8 @@ export function createClaudeCliStatus(
     } catch {
       return { state: "not-logged-in" };
     }
-    if (!isClaudeCliLaneEligible({ environment: environment(), enabled: settings.enabled })) {
+    const baseEnv = { ...environment() };
+    if (!isClaudeCliLaneEligible({ environment: baseEnv, enabled: settings.enabled })) {
       return { state: "disabled" };
     }
     try {
@@ -167,6 +184,8 @@ export function createClaudeCliStatus(
             ...(settings.binaryPath === undefined ? {} : { binaryPath: settings.binaryPath }),
             ...(settings.configDir === undefined ? {} : { configDir: settings.configDir }),
             billing: settings.billing,
+            baseEnv,
+            platform,
             ...(forceRecheck ? { forceRecheck: true } : {}),
           },
           probeDependencies,

--- a/apps/desktop/tests/claude-cli-status.test.ts
+++ b/apps/desktop/tests/claude-cli-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ClaudeAccountProbeResult } from "@enduragent/core";
+import { ClaudeCliConfigError, type ClaudeAccountProbeResult } from "@enduragent/core";
 import {
   createClaudeCliStatus,
   readClaudeCliSettings,
@@ -32,23 +32,28 @@ function harness(input: {
   readonly binary?: string | null;
   readonly version?: string;
   readonly environment?: Record<string, string | undefined>;
+  readonly platform?: NodeJS.Platform;
+  readonly preflightMcpConfigTransform?: () => void;
   readonly applyRuntimeConfig?: (request: unknown) => Promise<void>;
 }) {
   const resolveBinary = vi.fn(async () => (input.binary === undefined ? BINARY : input.binary));
   const probeVersion = vi.fn(async () => input.version ?? "2.9.0");
   const probeAccount = vi.fn(async () => input.probe ?? subscriptionProbe());
+  const preflightMcpConfigTransform = vi.fn(input.preflightMcpConfigTransform ?? (() => {}));
   const invalidateProbeCache = vi.fn();
   const applyRuntimeConfig = vi.fn(input.applyRuntimeConfig ?? (async () => {}));
   const dependencies: ClaudeCliStatusDependencies = {
     resolveBinary,
     probeVersion,
     probeAccount,
+    preflightMcpConfigTransform,
     invalidateProbeCache,
   };
   const readSettings = vi.fn(async () => input.settings ?? settings());
   const controller = createClaudeCliStatus({
     settings: readSettings,
     environment: () => input.environment ?? {},
+    ...(input.platform === undefined ? {} : { platform: input.platform }),
     applyRuntimeConfig,
     dependencies,
   });
@@ -57,6 +62,7 @@ function harness(input: {
     resolveBinary,
     probeVersion,
     probeAccount,
+    preflightMcpConfigTransform,
     invalidateProbeCache,
     applyRuntimeConfig,
     readSettings,
@@ -147,6 +153,59 @@ describe("desktop claude-cli status controller", () => {
     const subject = harness({ version: "1.0.0" });
 
     await expect(subject.controller.status()).resolves.toEqual({ state: "absent-binary" });
+    expect(subject.probeAccount).not.toHaveBeenCalled();
+  });
+
+  it("runs Windows readiness against the desktop environment and resolved .cmd shim", async () => {
+    const environment = {
+      Path: "C:\\Windows\\System32",
+      userprofile: "C:\\Users\\Rider",
+      appdata: "C:\\Users\\Rider\\AppData\\Roaming",
+      SystemRoot: "C:\\Windows",
+    };
+    const shim = "C:\\Users\\Rider\\AppData\\Roaming\\npm\\claude.cmd";
+    const subject = harness({
+      platform: "win32",
+      environment,
+      binary: shim,
+      version: "2.1.220",
+    });
+
+    await expect(subject.controller.status()).resolves.toMatchObject({
+      state: "ready",
+      version: "2.1.220",
+    });
+    expect(subject.resolveBinary).toHaveBeenCalledWith(
+      expect.objectContaining({ env: environment, platform: "win32" }),
+    );
+    expect(subject.probeVersion).toHaveBeenCalledWith(
+      shim,
+      expect.objectContaining({ baseEnv: environment, platform: "win32" }),
+    );
+    expect(subject.probeAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ baseEnv: environment, platform: "win32" }),
+      expect.any(Object),
+    );
+    expect(subject.preflightMcpConfigTransform).toHaveBeenCalledOnce();
+  });
+
+  it("does not report ready when the Windows .cmd MCP transform preflight fails", async () => {
+    const subject = harness({
+      platform: "win32",
+      environment: {
+        Path: "C:\\Windows\\System32",
+        userprofile: "C:\\Users\\Rider",
+        SystemRoot: "C:\\Windows",
+      },
+      binary: "C:\\Users\\Rider\\AppData\\Roaming\\npm\\claude.cmd",
+      version: "2.1.220",
+      preflightMcpConfigTransform: () => {
+        throw new ClaudeCliConfigError("windows-mcp-config-write", "synthetic transform refusal");
+      },
+    });
+
+    await expect(subject.controller.status()).resolves.toEqual({ state: "absent-binary" });
+    expect(subject.preflightMcpConfigTransform).toHaveBeenCalledOnce();
     expect(subject.probeAccount).not.toHaveBeenCalled();
   });
 

--- a/packages/engine/src/agent/claude-cli/bridge.ts
+++ b/packages/engine/src/agent/claude-cli/bridge.ts
@@ -552,9 +552,7 @@ async function runGeneration(
     ? [{ role: "user", content: opts.prompt }]
     : (opts.messages ?? []);
   const surface =
-    plan.mode === "stateless" ||
-    opts.tools === undefined ||
-    Object.keys(opts.tools).length === 0
+    plan.mode === "stateless" || opts.tools === undefined || Object.keys(opts.tools).length === 0
       ? null
       : buildCoachToolSurface(opts.tools, {
           messages: initialMessages,
@@ -572,6 +570,7 @@ async function runGeneration(
     streamed: false,
     compactBoundary: false,
   };
+  let iterationFailure: unknown;
   try {
     const iterator = generation.frames()[Symbol.asyncIterator]();
     for (;;) {
@@ -585,32 +584,44 @@ async function runGeneration(
       });
     }
   } catch (err) {
-    if (generation.lastResult() === null) {
-      const normalized = normalizeClaudeCliError(err, { retryAfterMs: collector.retryAfterMs });
-      const carrier = normalized as Error & { retryAfterMs?: number };
-      if (carrier.retryAfterMs === undefined && collector.retryAfterMs !== undefined) {
-        carrier.retryAfterMs = collector.retryAfterMs;
-      }
-      throw normalized;
-    }
+    iterationFailure = err;
   } finally {
     release();
     await generation.close();
   }
 
   const result = generation.lastResult();
+  const cleanupFailure = generation.cleanupError();
   if (result === null) {
-    throw normalizeClaudeCliError(new Error("Claude Code CLI ended without a result frame"), {
-      retryAfterMs: collector.retryAfterMs,
-    });
+    const normalized = normalizeClaudeCliError(
+      iterationFailure ?? new Error("Claude Code CLI ended without a result frame"),
+      { retryAfterMs: collector.retryAfterMs },
+    );
+    const carrier = normalized as Error & {
+      retryAfterMs?: number;
+      cleanupFailure?: ClaudeCliConfigError;
+    };
+    if (carrier.retryAfterMs === undefined && collector.retryAfterMs !== undefined) {
+      carrier.retryAfterMs = collector.retryAfterMs;
+    }
+    if (cleanupFailure !== null && cleanupFailure !== normalized) {
+      carrier.cleanupFailure = cleanupFailure;
+    }
+    throw normalized;
   }
 
   if (result.is_error === true && result.subtype !== "error_max_turns") {
     const failure = new Error(resultErrorMessage(result)) as Error & { httpStatus?: number };
     const status = (result as { api_error_status?: unknown }).api_error_status;
     if (validToken(status)) failure.httpStatus = status;
-    throw normalizeClaudeCliError(failure, { retryAfterMs: collector.retryAfterMs });
+    const normalized = normalizeClaudeCliError(failure, {
+      retryAfterMs: collector.retryAfterMs,
+    }) as Error & { cleanupFailure?: ClaudeCliConfigError };
+    if (cleanupFailure !== null) normalized.cleanupFailure = cleanupFailure;
+    throw normalized;
   }
+
+  if (cleanupFailure !== null) throw cleanupFailure;
 
   const text = result.subtype === "success" ? result.result : collector.text;
   const usage = mapUsage(tokenTotalsFromResult(result));

--- a/packages/engine/src/agent/claude-cli/env.ts
+++ b/packages/engine/src/agent/claude-cli/env.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { isAbsolute, resolve as resolvePath } from "node:path";
+import { isAbsolute, resolve as resolvePath, win32 } from "node:path";
 
 export type ClaudeCliBilling = "subscription" | "api-key";
 
@@ -35,6 +35,15 @@ export const CHILD_ENV_ALLOWLIST: readonly string[] = [
   "XDG_CACHE_HOME",
 ];
 
+export const WINDOWS_CHILD_ENV_ALLOWLIST: readonly string[] = [
+  "USERPROFILE",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "PATHEXT",
+  "SYSTEMROOT",
+  "COMSPEC",
+];
+
 export const FORBIDDEN_ENV_KEYS: readonly string[] = [
   "ANTHROPIC_API_KEY",
   "ANTHROPIC_AUTH_TOKEN",
@@ -66,42 +75,119 @@ function strictAssertions(): boolean {
   return mode === "test" || mode === "development";
 }
 
-export function expandTilde(value: string): string {
-  if (value === "~") return homedir();
-  if (value.startsWith("~/")) return resolvePath(homedir(), value.slice(2));
+export interface ClaudeCliPathOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly home?: string;
+}
+
+export function readEnvironmentValue(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  platform: NodeJS.Platform = process.platform,
+): string | undefined {
+  const exact = env[key];
+  if (exact !== undefined || platform !== "win32") return exact;
+  const normalized = key.toUpperCase();
+  for (const [candidate, value] of Object.entries(env)) {
+    if (candidate.toUpperCase() === normalized && value !== undefined) return value;
+  }
+  return undefined;
+}
+
+function resolvedHome(options: ClaudeCliPathOptions): string {
+  const platform = options.platform ?? process.platform;
+  if (options.home !== undefined) return options.home;
+  if (platform === "win32" && options.env !== undefined) {
+    const profile = readEnvironmentValue(options.env, "USERPROFILE", platform);
+    if (profile !== undefined && profile !== "") return profile;
+  }
+  return homedir();
+}
+
+export function expandTilde(value: string, options: ClaudeCliPathOptions = {}): string {
+  const platform = options.platform ?? process.platform;
+  const home = resolvedHome(options);
+  if (value === "~") return home;
+  if (platform === "win32" && (value.startsWith("~/") || value.startsWith("~\\"))) {
+    return win32.resolve(home, value.slice(2));
+  }
+  if (value.startsWith("~/")) return resolvePath(home, value.slice(2));
   return value;
 }
 
-function resolveConfigDir(value: string): string {
-  const expanded = expandTilde(value);
+function resolveConfigDir(value: string, options: ClaudeCliPathOptions): string {
+  const platform = options.platform ?? process.platform;
+  const expanded = expandTilde(value, options);
+  if (platform === "win32") {
+    return win32.isAbsolute(expanded) ? expanded : win32.resolve(expanded);
+  }
   return isAbsolute(expanded) ? expanded : resolvePath(expanded);
 }
 
 export function assertNoForbiddenChildEnv(
   env: NodeJS.ProcessEnv,
   introduced: readonly string[] = [],
+  platform: NodeJS.Platform = process.platform,
 ): NodeJS.ProcessEnv {
-  const allowed = new Set(introduced);
+  const allowed = new Set(
+    platform === "win32" ? introduced.map((key) => key.toUpperCase()) : introduced,
+  );
   const strict = strictAssertions();
   for (const key of Object.keys(env)) {
-    if (allowed.has(key)) continue;
-    if (!FORBIDDEN_ENV_KEYS.includes(key) && !CREDENTIAL_PREFIX_PATTERN.test(key)) continue;
+    const compared = platform === "win32" ? key.toUpperCase() : key;
+    if (allowed.has(compared)) continue;
+    if (!FORBIDDEN_ENV_KEYS.includes(compared) && !CREDENTIAL_PREFIX_PATTERN.test(compared)) {
+      continue;
+    }
     if (strict) throw new ForbiddenChildEnvKeyError(key);
     delete env[key];
   }
   return env;
 }
 
-export function buildChildEnv(base: NodeJS.ProcessEnv, rt: ClaudeCliRuntime): NodeJS.ProcessEnv {
+export type BuildClaudeCliChildEnvOptions = ClaudeCliPathOptions;
+
+function windowsRuntimeEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const normalized = { ...env };
+  for (const key of ["CLAUDE_CONFIG_DIR", "ANTHROPIC_API_KEY"]) {
+    const value = readEnvironmentValue(env, key, "win32");
+    if (value !== undefined) normalized[key] = value;
+  }
+  return normalized;
+}
+
+export function buildChildEnv(
+  inputEnv: NodeJS.ProcessEnv,
+  rt: ClaudeCliRuntime,
+  options: BuildClaudeCliChildEnvOptions = {},
+): NodeJS.ProcessEnv {
+  const platform = options.platform ?? process.platform;
+  const base = platform === "win32" ? windowsRuntimeEnvironment(inputEnv) : inputEnv;
   const out: NodeJS.ProcessEnv = {};
 
-  for (const key of CHILD_ENV_ALLOWLIST) {
-    const value = base[key];
-    if (value !== undefined) out[key] = value;
+  if (platform === "win32") {
+    const seen = new Set<string>();
+    for (const key of [...CHILD_ENV_ALLOWLIST, ...WINDOWS_CHILD_ENV_ALLOWLIST]) {
+      const canonical = key.toUpperCase();
+      if (seen.has(canonical)) continue;
+      seen.add(canonical);
+      const value = readEnvironmentValue(base, key, platform);
+      if (value !== undefined) out[canonical] = value;
+    }
+  } else {
+    for (const key of CHILD_ENV_ALLOWLIST) {
+      const value = base[key];
+      if (value !== undefined) out[key] = value;
+    }
   }
 
   if (rt.configDir !== undefined && rt.configDir !== "") {
-    out.CLAUDE_CONFIG_DIR = resolveConfigDir(rt.configDir);
+    out.CLAUDE_CONFIG_DIR = resolveConfigDir(rt.configDir, {
+      ...options,
+      platform,
+      env: options.env ?? base,
+    });
   } else if (base.CLAUDE_CONFIG_DIR !== undefined) {
     out.CLAUDE_CONFIG_DIR = base.CLAUDE_CONFIG_DIR;
   }

--- a/packages/engine/src/agent/claude-cli/errors.ts
+++ b/packages/engine/src/agent/claude-cli/errors.ts
@@ -3,6 +3,10 @@ import { markProviderAuthFailure } from "../../provider-auth-failure.js";
 export type ClaudeCliConfigErrorKind =
   | "binary-missing"
   | "version-below-floor"
+  | "unsupported-windows-executable"
+  | "unsafe-windows-command-shim"
+  | "windows-mcp-config-write"
+  | "windows-mcp-config-cleanup"
   | "not-signed-in"
   | "probe-timeout"
   | "api-key-identity"
@@ -19,8 +23,34 @@ export class ClaudeCliConfigError extends Error {
   }
 }
 
+export type ClaudeCliWindowsMcpConfigStage = "private-path" | "content-write" | "cleanup";
+
+export class ClaudeCliWindowsMcpConfigError extends ClaudeCliConfigError {
+  readonly stage: ClaudeCliWindowsMcpConfigStage;
+  readonly cleanupFailure?: ClaudeCliWindowsMcpConfigError;
+
+  constructor(
+    kind: Extract<
+      ClaudeCliConfigErrorKind,
+      "windows-mcp-config-write" | "windows-mcp-config-cleanup"
+    >,
+    stage: ClaudeCliWindowsMcpConfigStage,
+    message: string,
+    cleanupFailure?: ClaudeCliWindowsMcpConfigError,
+  ) {
+    super(kind, message);
+    this.name = "ClaudeCliWindowsMcpConfigError";
+    this.stage = stage;
+    if (cleanupFailure !== undefined) this.cleanupFailure = cleanupFailure;
+  }
+}
+
 const LAUNCHD_PATH_HINT =
   "(Mac launchd users: set an absolute path like '/opt/homebrew/bin/claude'.)";
+
+export const WINDOWS_CLAUDE_INSTALL_COMMAND = "irm https://claude.ai/install.ps1 | iex";
+
+const WINDOWS_INSTALL_AND_PATH_HINT = `Open PowerShell and run: ${WINDOWS_CLAUDE_INSTALL_COMMAND}. Then restart Enduragent so it reads the updated PATH, or set llm.claude_cli.binary_path to an absolute claude.exe or claude.cmd path.`;
 
 export const NOT_SIGNED_IN_MESSAGE =
   "Claude Code CLI is not signed in. Open a terminal, run claude, and sign in with your Claude subscription. Enduragent never signs in for you.";
@@ -34,30 +64,89 @@ export const API_KEY_IDENTITY_MESSAGE =
 export const API_KEY_UNAPPROVED_MESSAGE =
   "Your API key is not approved in the Claude CLI — run claude once with it and approve, or set llm.claude_cli.billing: subscription.";
 
-export function binaryMissingMessage(binaryPath: string): string {
+export function binaryMissingMessage(
+  binaryPath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return `Claude Code CLI was not found on Windows. ${WINDOWS_INSTALL_AND_PATH_HINT}`;
+  }
   return `Claude Code CLI not found at ${binaryPath}. Install it (https://claude.com/claude-code) or set llm.claude_cli.binary_path. ${LAUNCHD_PATH_HINT}`;
 }
 
-export function versionBelowFloorMessage(version: string, floor: string): string {
+export function versionBelowFloorMessage(
+  version: string,
+  floor: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return `Claude Code CLI ${version} is older than the minimum supported ${floor}. ${WINDOWS_INSTALL_AND_PATH_HINT}`;
+  }
   return `Claude Code CLI ${version} is older than the minimum supported ${floor}. Run: claude update`;
+}
+
+export function unsupportedWindowsExecutableMessage(): string {
+  return `Claude Code CLI on Windows requires an absolute .exe or .cmd path. ${WINDOWS_INSTALL_AND_PATH_HINT}`;
+}
+
+export function unsafeWindowsCommandShimMessage(): string {
+  return `Enduragent refused the Claude Code .cmd shim because its path or arguments cannot be quoted safely. ${WINDOWS_INSTALL_AND_PATH_HINT}`;
+}
+
+export function windowsMcpConfigMessage(stage: ClaudeCliWindowsMcpConfigStage): string {
+  if (stage === "cleanup") {
+    return "Enduragent could not remove the private Claude Code tool configuration on Windows (stage: cleanup).";
+  }
+  return `Enduragent could not prepare the private Claude Code tool configuration on Windows (stage: ${stage}). ${WINDOWS_INSTALL_AND_PATH_HINT}`;
 }
 
 export function unrecognizedAuthSourceMessage(raw: string): string {
   return `Unrecognized Claude CLI auth source '${raw}' — update enduragent, or opt in with llm.claude_cli.billing: api-key.`;
 }
 
-export function binaryMissingError(binaryPath: string): ClaudeCliConfigError {
-  return new ClaudeCliConfigError("binary-missing", binaryMissingMessage(binaryPath));
+export function binaryMissingError(
+  binaryPath: string,
+  platform: NodeJS.Platform = process.platform,
+): ClaudeCliConfigError {
+  return new ClaudeCliConfigError("binary-missing", binaryMissingMessage(binaryPath, platform));
 }
 
-export function versionBelowFloorError(version: string, floor: string): ClaudeCliConfigError {
-  return new ClaudeCliConfigError("version-below-floor", versionBelowFloorMessage(version, floor));
+export function versionBelowFloorError(
+  version: string,
+  floor: string,
+  platform: NodeJS.Platform = process.platform,
+): ClaudeCliConfigError {
+  return new ClaudeCliConfigError(
+    "version-below-floor",
+    versionBelowFloorMessage(version, floor, platform),
+  );
+}
+
+export function unsupportedWindowsExecutableError(): ClaudeCliConfigError {
+  return new ClaudeCliConfigError(
+    "unsupported-windows-executable",
+    unsupportedWindowsExecutableMessage(),
+  );
+}
+
+export function unsafeWindowsCommandShimError(): ClaudeCliConfigError {
+  return new ClaudeCliConfigError("unsafe-windows-command-shim", unsafeWindowsCommandShimMessage());
+}
+
+export function windowsMcpConfigError(
+  stage: ClaudeCliWindowsMcpConfigStage,
+  cleanupFailure?: ClaudeCliWindowsMcpConfigError,
+): ClaudeCliWindowsMcpConfigError {
+  return new ClaudeCliWindowsMcpConfigError(
+    stage === "cleanup" ? "windows-mcp-config-cleanup" : "windows-mcp-config-write",
+    stage,
+    windowsMcpConfigMessage(stage),
+    cleanupFailure,
+  );
 }
 
 export function notSignedInError(): ClaudeCliConfigError {
-  return markProviderAuthFailure(
-    new ClaudeCliConfigError("not-signed-in", NOT_SIGNED_IN_MESSAGE),
-  );
+  return markProviderAuthFailure(new ClaudeCliConfigError("not-signed-in", NOT_SIGNED_IN_MESSAGE));
 }
 
 export function probeTimeoutError(): ClaudeCliConfigError {

--- a/packages/engine/src/agent/claude-cli/executable.ts
+++ b/packages/engine/src/agent/claude-cli/executable.ts
@@ -2,10 +2,11 @@ import { spawn } from "node:child_process";
 import { constants as fsConstants } from "node:fs";
 import { access } from "node:fs/promises";
 import { homedir } from "node:os";
-import { delimiter, isAbsolute, join, resolve as resolvePath } from "node:path";
+import { delimiter, isAbsolute, join, resolve as resolvePath, win32 } from "node:path";
 
-import { buildChildEnv, expandTilde, type ClaudeCliRuntime } from "./env.js";
+import { buildChildEnv, expandTilde, readEnvironmentValue, type ClaudeCliRuntime } from "./env.js";
 import { ClaudeCliConfigError, binaryMissingError, versionBelowFloorError } from "./errors.js";
+import { buildClaudeCliSpawnInvocation } from "./session.js";
 
 export const CLAUDE_CLI_VERSION_FLOOR = "2.1.220";
 
@@ -13,7 +14,28 @@ const VERSION_PROBE_TIMEOUT_MS = 15_000;
 const VERSION_PROBE_MAX_BYTES = 64 * 1024;
 const VERSION_PATTERN = /(\d+)\.(\d+)\.(\d+)/;
 
-export function wellKnownClaudePaths(home: string): string[] {
+export interface WellKnownClaudePathsOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+export function wellKnownClaudePaths(
+  home: string,
+  options: WellKnownClaudePathsOptions = {},
+): string[] {
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") {
+    const env = options.env ?? process.env;
+    const appData =
+      readEnvironmentValue(env, "APPDATA", platform) ?? win32.join(home, "AppData", "Roaming");
+    const localAppData =
+      readEnvironmentValue(env, "LOCALAPPDATA", platform) ?? win32.join(home, "AppData", "Local");
+    return [
+      win32.join(home, ".local", "bin", "claude.exe"),
+      win32.join(localAppData, "Microsoft", "WinGet", "Links", "claude.exe"),
+      win32.join(appData, "npm", "claude.cmd"),
+    ];
+  }
   return [
     "/opt/homebrew/bin/claude",
     "/usr/local/bin/claude",
@@ -22,9 +44,15 @@ export function wellKnownClaudePaths(home: string): string[] {
   ];
 }
 
-async function defaultIsExecutable(candidate: string): Promise<boolean> {
+export function hasSupportedWindowsClaudeExtension(candidate: string): boolean {
+  const extension = win32.extname(candidate).toLowerCase();
+  return extension === ".exe" || extension === ".cmd";
+}
+
+async function defaultIsExecutable(candidate: string, platform: NodeJS.Platform): Promise<boolean> {
+  if (platform === "win32" && !hasSupportedWindowsClaudeExtension(candidate)) return false;
   try {
-    await access(candidate, fsConstants.X_OK);
+    await access(candidate, platform === "win32" ? fsConstants.F_OK : fsConstants.X_OK);
     return true;
   } catch {
     return false;
@@ -35,31 +63,56 @@ export interface ResolveClaudeBinaryOptions {
   explicitPath?: string;
   env?: NodeJS.ProcessEnv;
   home?: string;
+  platform?: NodeJS.Platform;
   isExecutable?: (candidate: string) => Promise<boolean>;
 }
 
 export async function resolveClaudeBinary(
   options: ResolveClaudeBinaryOptions = {},
 ): Promise<string | null> {
+  const platform = options.platform ?? process.platform;
   const env = options.env ?? process.env;
-  const home = options.home ?? env.HOME ?? homedir();
-  const isExecutable = options.isExecutable ?? defaultIsExecutable;
+  const home =
+    options.home ??
+    (platform === "win32" ? readEnvironmentValue(env, "USERPROFILE", platform) : env.HOME) ??
+    homedir();
+  const isExecutable =
+    options.isExecutable ?? ((candidate: string) => defaultIsExecutable(candidate, platform));
+  const canUse = async (candidate: string): Promise<boolean> => {
+    if (platform === "win32" && !hasSupportedWindowsClaudeExtension(candidate)) return false;
+    return await isExecutable(candidate);
+  };
 
   const explicit = options.explicitPath;
   if (explicit !== undefined && explicit !== "") {
-    const expanded = expandTilde(explicit);
-    return isAbsolute(expanded) ? expanded : resolvePath(expanded);
+    const expanded =
+      platform === "win32" ? expandTilde(explicit, { platform, env, home }) : expandTilde(explicit);
+    const resolved =
+      platform === "win32"
+        ? win32.isAbsolute(expanded)
+          ? expanded
+          : win32.resolve(expanded)
+        : isAbsolute(expanded)
+          ? expanded
+          : resolvePath(expanded);
+    if (platform !== "win32") return resolved;
+    return (await canUse(resolved)) ? resolved : null;
   }
 
-  const pathValue = env.PATH ?? "";
-  for (const entry of pathValue.split(delimiter)) {
+  const pathValue = readEnvironmentValue(env, "PATH", platform) ?? "";
+  const pathDelimiter = platform === "win32" ? win32.delimiter : delimiter;
+  const pathJoin = platform === "win32" ? win32.join : join;
+  const executableNames = platform === "win32" ? ["claude.exe", "claude.cmd"] : ["claude"];
+  for (const entry of pathValue.split(pathDelimiter)) {
     if (entry === "") continue;
-    const candidate = join(entry, "claude");
-    if (await isExecutable(candidate)) return candidate;
+    for (const name of executableNames) {
+      const candidate = pathJoin(entry, name);
+      if (await canUse(candidate)) return candidate;
+    }
   }
 
-  for (const candidate of wellKnownClaudePaths(home)) {
-    if (await isExecutable(candidate)) return candidate;
+  for (const candidate of wellKnownClaudePaths(home, { platform, env })) {
+    if (await canUse(candidate)) return candidate;
   }
 
   return null;
@@ -68,8 +121,11 @@ export async function resolveClaudeBinary(
 export interface ProbeVersionOptions {
   runtime?: ClaudeCliRuntime;
   baseEnv?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  home?: string;
   timeoutMs?: number;
   maxBytes?: number;
+  spawn?: typeof spawn;
 }
 
 export function parseClaudeVersion(output: string): string | null {
@@ -89,27 +145,45 @@ export function compareVersions(a: string, b: string): number {
   return 0;
 }
 
-export function assertVersionAtLeast(version: string, floor = CLAUDE_CLI_VERSION_FLOOR): void {
-  if (compareVersions(version, floor) < 0) throw versionBelowFloorError(version, floor);
+export function assertVersionAtLeast(
+  version: string,
+  floor = CLAUDE_CLI_VERSION_FLOOR,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (compareVersions(version, floor) < 0) {
+    throw versionBelowFloorError(version, floor, platform);
+  }
 }
 
 export async function probeVersion(
   binaryPath: string,
   options: ProbeVersionOptions = {},
 ): Promise<string> {
+  const platform = options.platform ?? process.platform;
   const timeoutMs = options.timeoutMs ?? VERSION_PROBE_TIMEOUT_MS;
   const maxBytes = options.maxBytes ?? VERSION_PROBE_MAX_BYTES;
   const runtime: ClaudeCliRuntime = options.runtime ?? {
     binaryPath,
     billing: "subscription",
   };
-  const env = buildChildEnv(options.baseEnv ?? process.env, runtime);
+  const env = buildChildEnv(options.baseEnv ?? process.env, runtime, {
+    platform,
+    ...(options.home === undefined ? {} : { home: options.home }),
+  });
+  const invocation = buildClaudeCliSpawnInvocation({
+    binaryPath,
+    args: ["--version"],
+    env,
+    platform,
+  });
+  const launch = options.spawn ?? spawn;
 
   const raw = await new Promise<string>((resolve, reject) => {
-    const child = spawn(binaryPath, ["--version"], {
-      shell: false,
+    const child = launch(invocation.command, [...invocation.args], {
+      shell: invocation.shell,
       stdio: ["ignore", "pipe", "pipe"],
-      windowsHide: true,
+      windowsHide: invocation.windowsHide,
+      ...(invocation.windowsVerbatimArguments === true ? { windowsVerbatimArguments: true } : {}),
       env,
     });
 
@@ -157,7 +231,11 @@ export async function probeVersion(
       settled = true;
       clearTimeout(timer);
       if (err.code === "ENOENT") {
-        reject(binaryMissingError(binaryPath));
+        reject(binaryMissingError(binaryPath, platform));
+        return;
+      }
+      if (platform === "win32") {
+        reject(binaryMissingError(binaryPath, platform));
         return;
       }
       reject(
@@ -195,6 +273,15 @@ export async function probeVersion(
         return;
       }
       if (code !== 0) {
+        if (platform === "win32") {
+          reject(
+            new ClaudeCliConfigError(
+              "binary-missing",
+              `Claude Code CLI version probe exited with code ${code}. ${binaryMissingError(binaryPath, platform).message}`,
+            ),
+          );
+          return;
+        }
         const tail = stderr.slice(-200).trim();
         reject(
           new ClaudeCliConfigError(
@@ -210,6 +297,12 @@ export async function probeVersion(
 
   const version = parseClaudeVersion(raw);
   if (version === null) {
+    if (platform === "win32") {
+      throw new ClaudeCliConfigError(
+        "binary-missing",
+        `Claude Code CLI did not report a version. ${binaryMissingError(binaryPath, platform).message}`,
+      );
+    }
     throw new ClaudeCliConfigError(
       "binary-missing",
       `Claude Code CLI at ${binaryPath} did not report a version: ${raw.slice(0, 200).trim()}`,

--- a/packages/engine/src/agent/claude-cli/probe.ts
+++ b/packages/engine/src/agent/claude-cli/probe.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, win32 } from "node:path";
 
 import {
   query as sdkQuery,
@@ -9,15 +9,20 @@ import {
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 
-import type { ClaudeCliBilling, ClaudeCliRuntime } from "./env.js";
+import {
+  expandTilde,
+  readEnvironmentValue,
+  type ClaudeCliBilling,
+  type ClaudeCliRuntime,
+} from "./env.js";
 import {
   apiKeyIdentityError,
   apiKeyUnapprovedError,
   binaryMissingError,
+  ClaudeCliConfigError,
   notSignedInError,
   probeTimeoutError,
   unrecognizedAuthSourceError,
-  type ClaudeCliConfigError,
 } from "./errors.js";
 import {
   assertVersionAtLeast,
@@ -25,7 +30,11 @@ import {
   resolveClaudeBinary,
   CLAUDE_CLI_VERSION_FLOOR,
 } from "./executable.js";
-import { buildQueryOptions } from "./session.js";
+import {
+  buildQueryOptions,
+  preflightWindowsMcpConfigTransform,
+  type WindowsMcpConfigFileSystemDeps,
+} from "./session.js";
 
 export const ACCOUNT_PROBE_TIMEOUT_MS = 25_000;
 export const ACCOUNT_PROBE_RETRY_DELAY_MS = 750;
@@ -109,17 +118,34 @@ export function classifyAccountInfo(account: AccountInfo | null | undefined): {
 export interface ReadFallbackEmailDeps {
   readFile?: (path: string) => Promise<string>;
   home?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
 }
 
 export async function readFallbackEmail(
   configDir: string | undefined,
   deps: ReadFallbackEmailDeps = {},
 ): Promise<string | undefined> {
+  const platform = deps.platform ?? process.platform;
+  const env = deps.env ?? process.env;
   const read = deps.readFile ?? ((path: string) => readFile(path, "utf8"));
-  const dir = configDir !== undefined && configDir !== "" ? configDir : (deps.home ?? homedir());
+  const home =
+    deps.home ??
+    (platform === "win32" ? readEnvironmentValue(env, "USERPROFILE", platform) : undefined) ??
+    homedir();
+  const configured =
+    configDir !== undefined && configDir !== ""
+      ? platform === "win32"
+        ? expandTilde(configDir, { platform, env, home })
+        : configDir
+      : home;
+  const path =
+    platform === "win32"
+      ? win32.join(configured, ".claude.json")
+      : join(configured, ".claude.json");
   let raw: string;
   try {
-    raw = await read(join(dir, ".claude.json"));
+    raw = await read(path);
   } catch {
     return undefined;
   }
@@ -162,6 +188,8 @@ function withTimeout<T>(
 export interface ProbeClaudeAccountInput {
   runtime: ClaudeCliRuntime;
   baseEnv?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  home?: string;
   model?: string;
   cwd?: string;
   timeoutMs?: number;
@@ -171,6 +199,7 @@ export interface ProbeClaudeAccountDeps {
   query?: typeof sdkQuery;
   sleep?: (ms: number) => Promise<void>;
   readFallbackEmail?: typeof readFallbackEmail;
+  windowsMcpConfigFileSystem?: WindowsMcpConfigFileSystemDeps;
 }
 
 async function accountFromQuery(active: Query): Promise<AccountInfo | null> {
@@ -202,12 +231,17 @@ async function probeOnce(
     const options = buildQueryOptions({
       runtime: input.runtime,
       baseEnv: input.baseEnv ?? process.env,
+      platform: input.platform ?? process.platform,
+      ...(input.home === undefined ? {} : { home: input.home }),
       model: input.model ?? ACCOUNT_PROBE_MODEL,
       allowedTools: [],
       mcpServers: {},
       persistSession: false,
       abortController,
       stderr: () => {},
+      ...(deps.windowsMcpConfigFileSystem === undefined
+        ? {}
+        : { windowsMcpConfigFileSystem: deps.windowsMcpConfigFileSystem }),
       ...(input.cwd === undefined ? {} : { cwd: input.cwd }),
     });
     active = run({ prompt: pendingPrompt(abortController.signal), options });
@@ -216,7 +250,10 @@ async function probeOnce(
       input.timeoutMs ?? ACCOUNT_PROBE_TIMEOUT_MS,
       sleep,
     );
-  } catch {
+  } catch (error) {
+    if ((input.platform ?? process.platform) === "win32" && error instanceof ClaudeCliConfigError) {
+      throw error;
+    }
     return null;
   } finally {
     abortController.abort();
@@ -267,7 +304,13 @@ export async function probeClaudeAccount(
   }
 
   const readEmail = deps.readFallbackEmail ?? readFallbackEmail;
-  const email = classified.email ?? (await readEmail(input.runtime.configDir));
+  const email =
+    classified.email ??
+    (await readEmail(input.runtime.configDir, {
+      platform: input.platform ?? process.platform,
+      env: input.baseEnv ?? process.env,
+      ...(input.home === undefined ? {} : { home: input.home }),
+    }));
 
   return {
     verified: true,
@@ -363,6 +406,8 @@ export interface EnsureClaudeCliReadyInput {
   configDir?: string;
   billing?: ClaudeCliBilling;
   baseEnv?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  home?: string;
   model?: string;
   cwd?: string;
   timeoutMs?: number;
@@ -373,16 +418,19 @@ export interface EnsureClaudeCliReadyDeps extends CachedProbeDeps {
   resolveBinary?: typeof resolveClaudeBinary;
   probeVersion?: typeof probeVersion;
   probeAccount?: typeof probeClaudeAccount;
+  preflightMcpConfigTransform?: typeof preflightWindowsMcpConfigTransform;
 }
 
 export async function ensureClaudeCliReady(
   input: EnsureClaudeCliReadyInput = {},
   deps: EnsureClaudeCliReadyDeps = {},
 ): Promise<ClaudeCliReadiness> {
+  const platform = input.platform ?? process.platform;
   const billing = input.billing ?? "subscription";
   const baseEnv = input.baseEnv ?? process.env;
   const resolveBinary = deps.resolveBinary ?? resolveClaudeBinary;
   const readVersion = deps.probeVersion ?? probeVersion;
+  const preflightMcpConfig = deps.preflightMcpConfigTransform ?? preflightWindowsMcpConfigTransform;
   const probeAccount =
     deps.probeAccount ??
     (input.forceRecheck === true ? recheckClaudeAccount : probeClaudeAccountCached);
@@ -390,8 +438,10 @@ export async function ensureClaudeCliReady(
   const resolved = await resolveBinary({
     ...(input.binaryPath === undefined ? {} : { explicitPath: input.binaryPath }),
     env: baseEnv,
+    platform,
+    ...(input.home === undefined ? {} : { home: input.home }),
   });
-  if (resolved === null) throw binaryMissingError(input.binaryPath ?? "claude");
+  if (resolved === null) throw binaryMissingError(input.binaryPath ?? "claude", platform);
 
   const runtime: ClaudeCliRuntime = {
     binaryPath: resolved,
@@ -399,13 +449,44 @@ export async function ensureClaudeCliReady(
     ...(input.configDir === undefined ? {} : { configDir: input.configDir }),
   };
 
-  const version = await readVersion(resolved, { runtime, baseEnv });
-  assertVersionAtLeast(version, CLAUDE_CLI_VERSION_FLOOR);
+  const version = await readVersion(resolved, {
+    runtime,
+    baseEnv,
+    platform,
+    ...(input.home === undefined ? {} : { home: input.home }),
+  });
+  assertVersionAtLeast(version, CLAUDE_CLI_VERSION_FLOOR, platform);
+
+  if (platform === "win32" && win32.extname(resolved).toLowerCase() === ".cmd") {
+    const preflightOptions = buildQueryOptions({
+      runtime,
+      baseEnv,
+      platform,
+      ...(input.home === undefined ? {} : { home: input.home }),
+      model: input.model ?? ACCOUNT_PROBE_MODEL,
+      allowedTools: [],
+      mcpServers: {},
+      persistSession: false,
+      ...(deps.windowsMcpConfigFileSystem === undefined
+        ? {}
+        : { windowsMcpConfigFileSystem: deps.windowsMcpConfigFileSystem }),
+    });
+    preflightMcpConfig({
+      binaryPath: resolved,
+      env: preflightOptions.env,
+      platform,
+      ...(deps.windowsMcpConfigFileSystem === undefined
+        ? {}
+        : { fileSystem: deps.windowsMcpConfigFileSystem }),
+    });
+  }
 
   const result = await probeAccount(
     {
       runtime,
       baseEnv,
+      platform,
+      ...(input.home === undefined ? {} : { home: input.home }),
       ...(input.model === undefined ? {} : { model: input.model }),
       ...(input.cwd === undefined ? {} : { cwd: input.cwd }),
       ...(input.timeoutMs === undefined ? {} : { timeoutMs: input.timeoutMs }),

--- a/packages/engine/src/agent/claude-cli/session.ts
+++ b/packages/engine/src/agent/claude-cli/session.ts
@@ -1,3 +1,21 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import {
+  constants,
+  closeSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  realpathSync,
+  rmdirSync,
+  unlinkSync,
+  writeSync,
+  type Stats,
+} from "node:fs";
+import { win32 } from "node:path";
+
 import {
   query as sdkQuery,
   type Options,
@@ -5,10 +23,18 @@ import {
   type SDKMessage,
   type SDKResultMessage,
   type SDKUserMessage,
+  type SpawnOptions as SdkSpawnOptions,
+  type SpawnedProcess,
 } from "@anthropic-ai/claude-agent-sdk";
 
-import { buildChildEnv, type ClaudeCliRuntime } from "./env.js";
-import { normalizeClaudeCliError } from "./errors.js";
+import { buildChildEnv, readEnvironmentValue, type ClaudeCliRuntime } from "./env.js";
+import {
+  ClaudeCliWindowsMcpConfigError,
+  normalizeClaudeCliError,
+  unsafeWindowsCommandShimError,
+  unsupportedWindowsExecutableError,
+  windowsMcpConfigError,
+} from "./errors.js";
 
 export type ClaudeCliPrompt = string | AsyncIterable<SDKUserMessage>;
 
@@ -18,9 +44,604 @@ export type SanitizedQueryOptions = Options & {
   model: string;
 };
 
+const WINDOWS_COMMAND_SHIM_PATH_PATTERN = /^(?:[A-Za-z]:\\|\\\\)[A-Za-z0-9 ._\\-]+\.cmd$/i;
+const WINDOWS_COMMAND_ARGUMENT_PATTERN = /^[A-Za-z0-9 ._/:=,@\\-]*$/;
+const WINDOWS_SYSTEM_PATH_PATTERN = /^(?:[A-Za-z]:\\|\\\\)[A-Za-z0-9 ._\\-]+$/;
+const WINDOWS_MCP_CONFIG_FLAG = "--mcp-config";
+const WINDOWS_MCP_CONFIG_ROOT = ".enduragent";
+const WINDOWS_MCP_CONFIG_PREFIX = "claude-cli-mcp-";
+const WINDOWS_MCP_CONFIG_FILE = "mcp.json";
+const WINDOWS_MCP_CONFIG_PREFLIGHT = JSON.stringify({
+  mcpServers: {
+    "enduragent-readiness": { type: "stdio", command: "node" },
+  },
+});
+
+interface WindowsPrivatePathIdentity {
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+}
+
+interface WindowsPrivateDirectoryBinding {
+  readonly path: string;
+  readonly parentPath: string;
+  readonly identity: WindowsPrivatePathIdentity;
+  readonly parentIdentity: WindowsPrivatePathIdentity;
+}
+
+export interface WindowsMcpConfigFileSystem {
+  readonly closeSync: typeof closeSync;
+  readonly fstatSync: typeof fstatSync;
+  readonly fsyncSync: typeof fsyncSync;
+  readonly lstatSync: typeof lstatSync;
+  readonly mkdirSync: typeof mkdirSync;
+  readonly mkdtempSync: typeof mkdtempSync;
+  readonly openSync: typeof openSync;
+  readonly realpathSync: typeof realpathSync;
+  readonly rmdirSync: typeof rmdirSync;
+  readonly unlinkSync: typeof unlinkSync;
+  readonly writeSync: typeof writeSync;
+}
+
+export type WindowsMcpConfigFileSystemDeps = Partial<WindowsMcpConfigFileSystem>;
+
+const nodeWindowsMcpConfigFileSystem: WindowsMcpConfigFileSystem = {
+  closeSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  realpathSync,
+  rmdirSync,
+  unlinkSync,
+  writeSync,
+};
+
+function windowsMcpConfigFileSystem(
+  deps: WindowsMcpConfigFileSystemDeps = {},
+): WindowsMcpConfigFileSystem {
+  return { ...nodeWindowsMcpConfigFileSystem, ...deps };
+}
+
+function privatePathIdentity(metadata: Stats): WindowsPrivatePathIdentity {
+  return { dev: metadata.dev, ino: metadata.ino };
+}
+
+function samePrivatePathIdentity(
+  left: WindowsPrivatePathIdentity,
+  right: WindowsPrivatePathIdentity,
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function assertPrivateDirectoryMetadata(metadata: Stats): void {
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) throw new Error("private directory");
+}
+
+function assertPrivateFileMetadata(metadata: Stats): void {
+  if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1) {
+    throw new Error("private file");
+  }
+}
+
+function observePrivateDirectory(
+  parentPath: string,
+  path: string,
+  fileSystem: WindowsMcpConfigFileSystem,
+): WindowsPrivateDirectoryBinding {
+  const parentBefore = fileSystem.lstatSync(parentPath);
+  const parentPhysicalPath = fileSystem.realpathSync(parentPath);
+  const parentPhysical = fileSystem.lstatSync(parentPhysicalPath);
+  const parentAfter = fileSystem.lstatSync(parentPath);
+  const before = fileSystem.lstatSync(path);
+  const physicalPath = fileSystem.realpathSync(path);
+  const physical = fileSystem.lstatSync(physicalPath);
+  const after = fileSystem.lstatSync(path);
+  const physicalParent = fileSystem.lstatSync(win32.dirname(physicalPath));
+  for (const metadata of [
+    parentBefore,
+    parentPhysical,
+    parentAfter,
+    before,
+    physical,
+    after,
+    physicalParent,
+  ]) {
+    assertPrivateDirectoryMetadata(metadata);
+  }
+  const parentIdentity = privatePathIdentity(parentBefore);
+  const identity = privatePathIdentity(before);
+  if (
+    !samePrivatePathIdentity(parentIdentity, privatePathIdentity(parentPhysical)) ||
+    !samePrivatePathIdentity(parentIdentity, privatePathIdentity(parentAfter)) ||
+    !samePrivatePathIdentity(identity, privatePathIdentity(physical)) ||
+    !samePrivatePathIdentity(identity, privatePathIdentity(after)) ||
+    !samePrivatePathIdentity(parentIdentity, privatePathIdentity(physicalParent))
+  ) {
+    throw new Error("private directory binding");
+  }
+  return { path, parentPath, identity, parentIdentity };
+}
+
+function assertPrivateDirectoryStable(
+  binding: WindowsPrivateDirectoryBinding,
+  fileSystem: WindowsMcpConfigFileSystem,
+): void {
+  const observed = observePrivateDirectory(binding.parentPath, binding.path, fileSystem);
+  if (
+    !samePrivatePathIdentity(binding.identity, observed.identity) ||
+    !samePrivatePathIdentity(binding.parentIdentity, observed.parentIdentity)
+  ) {
+    throw new Error("private directory stability");
+  }
+}
+
+function assertPrivateFileBinding(
+  directory: WindowsPrivateDirectoryBinding,
+  path: string,
+  expectedIdentity: WindowsPrivatePathIdentity,
+  fileSystem: WindowsMcpConfigFileSystem,
+): void {
+  assertPrivateDirectoryStable(directory, fileSystem);
+  const before = fileSystem.lstatSync(path);
+  const physicalPath = fileSystem.realpathSync(path);
+  const physical = fileSystem.lstatSync(physicalPath);
+  const after = fileSystem.lstatSync(path);
+  const physicalParent = fileSystem.lstatSync(win32.dirname(physicalPath));
+  for (const metadata of [before, physical, after]) assertPrivateFileMetadata(metadata);
+  assertPrivateDirectoryMetadata(physicalParent);
+  if (
+    !samePrivatePathIdentity(expectedIdentity, privatePathIdentity(before)) ||
+    !samePrivatePathIdentity(expectedIdentity, privatePathIdentity(physical)) ||
+    !samePrivatePathIdentity(expectedIdentity, privatePathIdentity(after)) ||
+    !samePrivatePathIdentity(directory.identity, privatePathIdentity(physicalParent))
+  ) {
+    throw new Error("private file binding");
+  }
+  assertPrivateDirectoryStable(directory, fileSystem);
+}
+
+function missingPath(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function cleanupWindowsMcpConfigFile(
+  directory: WindowsPrivateDirectoryBinding,
+  filePath: string | undefined,
+  fileIdentity: WindowsPrivatePathIdentity | undefined,
+  fileSystem: WindowsMcpConfigFileSystem,
+): void {
+  try {
+    assertPrivateDirectoryStable(directory, fileSystem);
+    if (filePath !== undefined) {
+      let exists = true;
+      try {
+        fileSystem.lstatSync(filePath);
+      } catch (error) {
+        if (!missingPath(error)) throw error;
+        exists = false;
+      }
+      if (exists) {
+        try {
+          if (fileIdentity === undefined) throw new Error("private file identity");
+          assertPrivateFileBinding(directory, filePath, fileIdentity, fileSystem);
+          fileSystem.unlinkSync(filePath);
+        } catch (error) {
+          if (!missingPath(error)) throw error;
+        }
+      }
+    }
+    assertPrivateDirectoryStable(directory, fileSystem);
+    fileSystem.rmdirSync(directory.path);
+  } catch {
+    throw windowsMcpConfigError("cleanup");
+  }
+}
+
+function attachCleanupFailure(
+  primary: unknown,
+  cleanupFailure: ClaudeCliWindowsMcpConfigError,
+): unknown {
+  if ((typeof primary === "object" && primary !== null) || typeof primary === "function") {
+    try {
+      Object.defineProperty(primary, "cleanupFailure", {
+        configurable: true,
+        value: cleanupFailure,
+      });
+      return primary;
+    } catch {}
+  }
+  return cleanupFailure;
+}
+
+export interface WindowsMcpConfigFile {
+  readonly commandPath: string;
+  cleanup(): void;
+}
+
+export interface CreateWindowsMcpConfigFileInput {
+  readonly contents: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly fileSystem?: WindowsMcpConfigFileSystemDeps;
+}
+
+export function createWindowsMcpConfigFile(
+  input: CreateWindowsMcpConfigFileInput,
+): WindowsMcpConfigFile {
+  const fileSystem = windowsMcpConfigFileSystem(input.fileSystem);
+  let stage: "private-path" | "content-write" = "private-path";
+  let directory: WindowsPrivateDirectoryBinding | undefined;
+  let filePath: string | undefined;
+  let fileIdentity: WindowsPrivatePathIdentity | undefined;
+  let descriptor: number | undefined;
+  let contents: Buffer | undefined;
+  try {
+    const configuredProfile = readEnvironmentValue(input.env, "USERPROFILE", "win32");
+    if (configuredProfile === undefined || configuredProfile === "") throw new Error("profile");
+    const profile = win32.resolve(configuredProfile);
+    const profileParent = win32.dirname(profile);
+    if (
+      profileParent === profile ||
+      !win32.isAbsolute(profile) ||
+      !WINDOWS_SYSTEM_PATH_PATTERN.test(profile)
+    ) {
+      throw new Error("profile path");
+    }
+    observePrivateDirectory(profileParent, profile, fileSystem);
+    const root = win32.join(profile, WINDOWS_MCP_CONFIG_ROOT);
+    fileSystem.mkdirSync(root, { recursive: true, mode: 0o700 });
+    const rootBinding = observePrivateDirectory(profile, root, fileSystem);
+    const temporary = fileSystem.mkdtempSync(win32.join(root, WINDOWS_MCP_CONFIG_PREFIX));
+    directory = observePrivateDirectory(rootBinding.path, temporary, fileSystem);
+    filePath = win32.join(temporary, WINDOWS_MCP_CONFIG_FILE);
+    const commandPath = filePath.replaceAll("\\", "/");
+    if (!WINDOWS_COMMAND_ARGUMENT_PATTERN.test(commandPath)) throw new Error("command path");
+    stage = "content-write";
+    descriptor = fileSystem.openSync(
+      filePath,
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+      0o600,
+    );
+    const opened = fileSystem.fstatSync(descriptor);
+    assertPrivateFileMetadata(opened);
+    fileIdentity = privatePathIdentity(opened);
+    assertPrivateFileBinding(directory, filePath, fileIdentity, fileSystem);
+    contents = Buffer.from(input.contents, "utf8");
+    let offset = 0;
+    while (offset < contents.length) {
+      const written = fileSystem.writeSync(
+        descriptor,
+        contents,
+        offset,
+        contents.length - offset,
+        null,
+      );
+      if (written <= 0) throw new Error("content write");
+      offset += written;
+    }
+    fileSystem.fsyncSync(descriptor);
+    const written = fileSystem.fstatSync(descriptor);
+    assertPrivateFileMetadata(written);
+    if (!samePrivatePathIdentity(fileIdentity, privatePathIdentity(written))) {
+      throw new Error("file identity");
+    }
+    assertPrivateFileBinding(directory, filePath, fileIdentity, fileSystem);
+    fileSystem.closeSync(descriptor);
+    descriptor = undefined;
+    assertPrivateFileBinding(directory, filePath, fileIdentity, fileSystem);
+    return {
+      commandPath,
+      cleanup: () => cleanupWindowsMcpConfigFile(directory!, filePath, fileIdentity, fileSystem),
+    };
+  } catch {
+    let cleanupFailure: ClaudeCliWindowsMcpConfigError | undefined;
+    if (descriptor !== undefined) {
+      try {
+        fileSystem.closeSync(descriptor);
+      } catch {
+        cleanupFailure = windowsMcpConfigError("cleanup");
+      }
+    }
+    if (directory !== undefined) {
+      try {
+        cleanupWindowsMcpConfigFile(directory, filePath, fileIdentity, fileSystem);
+      } catch (error) {
+        cleanupFailure =
+          error instanceof ClaudeCliWindowsMcpConfigError
+            ? error
+            : windowsMcpConfigError("cleanup");
+      }
+    }
+    throw windowsMcpConfigError(stage, cleanupFailure);
+  } finally {
+    contents?.fill(0);
+  }
+}
+
+interface PreparedWindowsCommandArguments {
+  readonly args: readonly string[];
+  readonly cleanup?: () => void;
+}
+
+function serializedMcpConfig(value: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return false;
+    const servers = (parsed as Record<string, unknown>).mcpServers;
+    return (
+      typeof servers === "object" &&
+      servers !== null &&
+      !Array.isArray(servers) &&
+      Object.keys(servers).length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+function prepareWindowsCommandArguments(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  fileSystem?: WindowsMcpConfigFileSystemDeps,
+): PreparedWindowsCommandArguments {
+  let inlineIndex = -1;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === WINDOWS_MCP_CONFIG_FLAG) {
+      const value = args[index + 1];
+      if (value === undefined || inlineIndex !== -1) throw unsafeWindowsCommandShimError();
+      if (WINDOWS_COMMAND_ARGUMENT_PATTERN.test(value)) {
+        index += 1;
+        continue;
+      }
+      if (!serializedMcpConfig(value)) throw unsafeWindowsCommandShimError();
+      inlineIndex = index + 1;
+      index += 1;
+      continue;
+    }
+    if (!WINDOWS_COMMAND_ARGUMENT_PATTERN.test(argument)) {
+      throw unsafeWindowsCommandShimError();
+    }
+  }
+  if (inlineIndex === -1) return { args: [...args] };
+  const file = createWindowsMcpConfigFile({
+    contents: args[inlineIndex]!,
+    env,
+    ...(fileSystem === undefined ? {} : { fileSystem }),
+  });
+  const transformed = [...args];
+  transformed[inlineIndex] = file.commandPath;
+  return { args: transformed, cleanup: file.cleanup };
+}
+
+export interface PreflightWindowsMcpConfigTransformInput {
+  readonly binaryPath: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly platform?: NodeJS.Platform;
+  readonly fileSystem?: WindowsMcpConfigFileSystemDeps;
+}
+
+export function preflightWindowsMcpConfigTransform(
+  input: PreflightWindowsMcpConfigTransformInput,
+): void {
+  const platform = input.platform ?? process.platform;
+  if (platform !== "win32" || win32.extname(input.binaryPath).toLowerCase() !== ".cmd") return;
+  buildClaudeCliSpawnInvocation({
+    binaryPath: input.binaryPath,
+    args: [],
+    env: input.env,
+    platform,
+  });
+  const prepared = prepareWindowsCommandArguments(
+    [WINDOWS_MCP_CONFIG_FLAG, WINDOWS_MCP_CONFIG_PREFLIGHT],
+    input.env,
+    input.fileSystem,
+  );
+  try {
+    buildClaudeCliSpawnInvocation({
+      binaryPath: input.binaryPath,
+      args: prepared.args,
+      env: input.env,
+      platform,
+    });
+  } catch (error) {
+    try {
+      prepared.cleanup?.();
+    } catch (cleanupError) {
+      throw attachCleanupFailure(
+        error,
+        cleanupError instanceof ClaudeCliWindowsMcpConfigError
+          ? cleanupError
+          : windowsMcpConfigError("cleanup"),
+      );
+    }
+    throw error;
+  }
+  prepared.cleanup?.();
+}
+
+export interface ClaudeCliSpawnInvocation {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly shell: false;
+  readonly windowsHide: true;
+  readonly windowsVerbatimArguments?: true;
+}
+
+export interface BuildClaudeCliSpawnInvocationInput {
+  readonly binaryPath: string;
+  readonly args: readonly string[];
+  readonly env: NodeJS.ProcessEnv;
+  readonly platform?: NodeJS.Platform;
+}
+
+function directInvocation(binaryPath: string, args: readonly string[]): ClaudeCliSpawnInvocation {
+  return {
+    command: binaryPath,
+    args: [...args],
+    shell: false,
+    windowsHide: true,
+  };
+}
+
+function windowsCommandProcessor(env: NodeJS.ProcessEnv): string {
+  const systemRoot = readEnvironmentValue(env, "SYSTEMROOT", "win32") ?? "C:\\Windows";
+  if (!win32.isAbsolute(systemRoot) || !WINDOWS_SYSTEM_PATH_PATTERN.test(systemRoot)) {
+    throw unsafeWindowsCommandShimError();
+  }
+  return win32.join(systemRoot, "System32", "cmd.exe");
+}
+
+function quoteWindowsCommandArgument(argument: string): string {
+  const trailingBackslashes = /\\+$/.exec(argument)?.[0] ?? "";
+  return `"${argument}${trailingBackslashes}"`;
+}
+
+export function buildClaudeCliSpawnInvocation(
+  input: BuildClaudeCliSpawnInvocationInput,
+): ClaudeCliSpawnInvocation {
+  const platform = input.platform ?? process.platform;
+  if (platform !== "win32") return directInvocation(input.binaryPath, input.args);
+
+  const extension = win32.extname(input.binaryPath).toLowerCase();
+  if (extension === ".exe") return directInvocation(input.binaryPath, input.args);
+  if (extension !== ".cmd") throw unsupportedWindowsExecutableError();
+  if (
+    !win32.isAbsolute(input.binaryPath) ||
+    !WINDOWS_COMMAND_SHIM_PATH_PATTERN.test(input.binaryPath) ||
+    input.args.some((argument) => !WINDOWS_COMMAND_ARGUMENT_PATTERN.test(argument))
+  ) {
+    throw unsafeWindowsCommandShimError();
+  }
+
+  const commandLine = [
+    `"${input.binaryPath}"`,
+    ...input.args.map(quoteWindowsCommandArgument),
+  ].join(" ");
+
+  return {
+    command: windowsCommandProcessor(input.env),
+    args: ["/d", "/s", "/c", `"${commandLine}"`],
+    shell: false,
+    windowsHide: true,
+    windowsVerbatimArguments: true,
+  };
+}
+
+export interface SpawnClaudeCliProcessDeps {
+  readonly platform?: NodeJS.Platform;
+  readonly spawn?: typeof nodeSpawn;
+  readonly windowsMcpConfigFileSystem?: WindowsMcpConfigFileSystemDeps;
+  readonly onWindowsMcpConfigCleanup?: (cleanup: () => void) => void;
+  readonly onWindowsMcpConfigCleanupFailure?: (error: ClaudeCliWindowsMcpConfigError) => void;
+}
+
+export function spawnClaudeCliProcess(
+  options: SdkSpawnOptions,
+  deps: SpawnClaudeCliProcessDeps = {},
+): SpawnedProcess {
+  const platform = deps.platform ?? process.platform;
+  let prepared: PreparedWindowsCommandArguments = { args: options.args };
+  if (platform === "win32" && win32.extname(options.command).toLowerCase() === ".cmd") {
+    buildClaudeCliSpawnInvocation({
+      binaryPath: options.command,
+      args: [],
+      env: options.env,
+      platform,
+    });
+    prepared = prepareWindowsCommandArguments(
+      options.args,
+      options.env,
+      deps.windowsMcpConfigFileSystem,
+    );
+  }
+
+  let invocation: ClaudeCliSpawnInvocation;
+  try {
+    invocation = buildClaudeCliSpawnInvocation({
+      binaryPath: options.command,
+      args: prepared.args,
+      env: options.env,
+      platform,
+    });
+  } catch (error) {
+    try {
+      prepared.cleanup?.();
+    } catch (cleanupError) {
+      throw attachCleanupFailure(
+        error,
+        cleanupError instanceof ClaudeCliWindowsMcpConfigError
+          ? cleanupError
+          : windowsMcpConfigError("cleanup"),
+      );
+    }
+    throw error;
+  }
+
+  let child: SpawnedProcess;
+  try {
+    child = (deps.spawn ?? nodeSpawn)(invocation.command, [...invocation.args], {
+      cwd: options.cwd,
+      env: options.env,
+      shell: invocation.shell,
+      windowsHide: invocation.windowsHide,
+      ...(invocation.windowsVerbatimArguments === true ? { windowsVerbatimArguments: true } : {}),
+      signal: options.signal,
+      stdio: ["pipe", "pipe", "ignore"],
+    }) as unknown as SpawnedProcess;
+  } catch (error) {
+    try {
+      prepared.cleanup?.();
+    } catch (cleanupError) {
+      throw attachCleanupFailure(
+        error,
+        cleanupError instanceof ClaudeCliWindowsMcpConfigError
+          ? cleanupError
+          : windowsMcpConfigError("cleanup"),
+      );
+    }
+    throw error;
+  }
+
+  if (prepared.cleanup !== undefined) {
+    let cleaned = false;
+    const cleanup = (): void => {
+      if (cleaned) return;
+      try {
+        prepared.cleanup?.();
+        cleaned = true;
+      } catch (error) {
+        deps.onWindowsMcpConfigCleanupFailure?.(
+          error instanceof ClaudeCliWindowsMcpConfigError
+            ? error
+            : windowsMcpConfigError("cleanup"),
+        );
+      }
+    };
+    deps.onWindowsMcpConfigCleanup?.(cleanup);
+    child.once("error", cleanup);
+    child.once("exit", cleanup);
+  }
+  return child;
+}
+
+interface WindowsMcpConfigQueryState {
+  cleanup?: () => void;
+  cleanupFailure: ClaudeCliWindowsMcpConfigError | null;
+}
+
+const windowsMcpConfigQueryStates = new WeakMap<
+  SanitizedQueryOptions,
+  WindowsMcpConfigQueryState
+>();
+
 export interface BuildQueryOptionsInput {
   runtime: ClaudeCliRuntime;
   baseEnv: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  home?: string;
   model: string;
   systemPrompt?: string;
   mcpServers?: Options["mcpServers"];
@@ -35,9 +656,11 @@ export interface BuildQueryOptionsInput {
   includePartialMessages?: boolean;
   abortController?: AbortController;
   stderr?: (data: string) => void;
+  windowsMcpConfigFileSystem?: WindowsMcpConfigFileSystemDeps;
 }
 
 export function buildQueryOptions(input: BuildQueryOptionsInput): SanitizedQueryOptions {
+  const platform = input.platform ?? process.platform;
   const binaryPath = input.runtime.binaryPath;
   if (binaryPath === undefined || binaryPath === "") {
     throw new Error("Claude CLI query options require an explicit resolved binary path.");
@@ -50,9 +673,19 @@ export function buildQueryOptions(input: BuildQueryOptionsInput): SanitizedQuery
   }
 
   const env = {
-    ...buildChildEnv(input.baseEnv, input.runtime),
+    ...buildChildEnv(input.baseEnv, input.runtime, {
+      platform,
+      ...(input.home === undefined ? {} : { home: input.home }),
+    }),
     ENABLE_CLAUDEAI_MCP_SERVERS: "false",
   };
+
+  buildClaudeCliSpawnInvocation({
+    binaryPath,
+    args: [],
+    env,
+    platform,
+  });
 
   const options: SanitizedQueryOptions = {
     pathToClaudeCodeExecutable: binaryPath,
@@ -62,6 +695,24 @@ export function buildQueryOptions(input: BuildQueryOptionsInput): SanitizedQuery
     settingSources: [],
     mcpServers: input.mcpServers ?? {},
   };
+
+  if (platform === "win32" && win32.extname(binaryPath).toLowerCase() === ".cmd") {
+    const state: WindowsMcpConfigQueryState = { cleanupFailure: null };
+    windowsMcpConfigQueryStates.set(options, state);
+    options.spawnClaudeCodeProcess = (spawnOptions) =>
+      spawnClaudeCliProcess(spawnOptions, {
+        platform,
+        ...(input.windowsMcpConfigFileSystem === undefined
+          ? {}
+          : { windowsMcpConfigFileSystem: input.windowsMcpConfigFileSystem }),
+        onWindowsMcpConfigCleanup: (cleanup) => {
+          state.cleanup = cleanup;
+        },
+        onWindowsMcpConfigCleanupFailure: (error) => {
+          state.cleanupFailure ??= error;
+        },
+      });
+  }
 
   if (input.systemPrompt !== undefined) options.systemPrompt = input.systemPrompt;
   if (input.tools !== undefined) options.tools = input.tools;
@@ -87,6 +738,7 @@ export interface ClaudeCliGeneration {
   close(): Promise<void>;
   lastResult(): SDKResultMessage | null;
   iterationError(): unknown;
+  cleanupError(): ClaudeCliWindowsMcpConfigError | null;
 }
 
 export interface StartGenerationDeps {
@@ -104,6 +756,7 @@ export function startGeneration(
 ): ClaudeCliGeneration {
   const run = deps.query ?? sdkQuery;
   const active: Query = run({ prompt: spec.prompt, options: spec.options });
+  const windowsMcpConfigState = windowsMcpConfigQueryStates.get(spec.options);
 
   let started = false;
   let closed = false;
@@ -116,7 +769,8 @@ export function startGeneration(
     try {
       await active.return(undefined);
     } catch {
-      return;
+    } finally {
+      windowsMcpConfigState?.cleanup?.();
     }
   };
 
@@ -125,6 +779,7 @@ export function startGeneration(
       throw new Error("Claude CLI generation frames() may only be consumed once.");
     }
     started = true;
+    let cleanupOnlyFailure: ClaudeCliWindowsMcpConfigError | null = null;
     try {
       for await (const message of active) {
         if (message.type === "result") result = message;
@@ -137,7 +792,17 @@ export function startGeneration(
       }
     } finally {
       await close();
+      if (
+        result === null &&
+        caught === null &&
+        windowsMcpConfigState?.cleanupFailure !== null &&
+        windowsMcpConfigState?.cleanupFailure !== undefined
+      ) {
+        caught = windowsMcpConfigState.cleanupFailure;
+        cleanupOnlyFailure = windowsMcpConfigState.cleanupFailure;
+      }
     }
+    if (cleanupOnlyFailure !== null) throw cleanupOnlyFailure;
   };
 
   return {
@@ -149,5 +814,6 @@ export function startGeneration(
     close,
     lastResult: () => result,
     iterationError: () => caught,
+    cleanupError: () => windowsMcpConfigState?.cleanupFailure ?? null,
   };
 }

--- a/packages/engine/tests/claude-cli/env.test.ts
+++ b/packages/engine/tests/claude-cli/env.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, win32 } from "node:path";
 
 import {
   CHILD_ENV_ALLOWLIST,
   FORBIDDEN_ENV_KEYS,
   ForbiddenChildEnvKeyError,
+  WINDOWS_CHILD_ENV_ALLOWLIST,
   assertNoForbiddenChildEnv,
   buildChildEnv,
   type ClaudeCliRuntime,
@@ -115,11 +116,48 @@ describe("buildChildEnv allowlist", () => {
 
   it("keeps every allowlist entry unique", () => {
     expect(new Set(CHILD_ENV_ALLOWLIST).size).toBe(CHILD_ENV_ALLOWLIST.length);
+    expect(new Set(WINDOWS_CHILD_ENV_ALLOWLIST).size).toBe(WINDOWS_CHILD_ENV_ALLOWLIST.length);
   });
 
   it("never sets or modifies HOME", () => {
     const env = buildChildEnv(pollutedBase(), { ...SUBSCRIPTION, configDir: "/custom/claude" });
     expect(env.HOME).toBe("/Users/tester");
+  });
+
+  it("canonicalizes case-insensitive Windows keys and carries Windows process plumbing", () => {
+    const env = buildChildEnv(
+      {
+        Path: "C:\\Windows\\System32;C:\\Tools",
+        userprofile: "C:\\Users\\Rider",
+        appdata: "C:\\Users\\Rider\\AppData\\Roaming",
+        LocalAppData: "C:\\Users\\Rider\\AppData\\Local",
+        PathExt: ".COM;.EXE;.CMD",
+        SystemRoot: "C:\\Windows",
+        ComSpec: "C:\\Windows\\System32\\cmd.exe",
+        http_proxy: "http://proxy:3128",
+        claude_config_dir: "C:\\ClaudeConfig",
+        anthropic_api_key: SENTINEL,
+        claude_code_oauth_token: SENTINEL,
+      },
+      { ...API_KEY_MODE, binaryPath: "C:\\Tools\\claude.exe" },
+      { platform: "win32" },
+    );
+
+    expect(env).toMatchObject({
+      PATH: "C:\\Windows\\System32;C:\\Tools",
+      USERPROFILE: "C:\\Users\\Rider",
+      APPDATA: "C:\\Users\\Rider\\AppData\\Roaming",
+      LOCALAPPDATA: "C:\\Users\\Rider\\AppData\\Local",
+      PATHEXT: ".COM;.EXE;.CMD",
+      SYSTEMROOT: "C:\\Windows",
+      COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+      HTTP_PROXY: "http://proxy:3128",
+      CLAUDE_CONFIG_DIR: "C:\\ClaudeConfig",
+      ANTHROPIC_API_KEY: SENTINEL,
+    });
+    expect(env.Path).toBeUndefined();
+    expect(env.http_proxy).toBeUndefined();
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
   });
 });
 
@@ -195,6 +233,13 @@ describe("assertNoForbiddenChildEnv", () => {
     const env = assertNoForbiddenChildEnv({ ANTHROPIC_API_KEY: SENTINEL }, ["ANTHROPIC_API_KEY"]);
     expect(env.ANTHROPIC_API_KEY).toBe(SENTINEL);
   });
+
+  it("treats forbidden Windows environment keys case-insensitively", () => {
+    process.env.NODE_ENV = "test";
+    expect(() =>
+      assertNoForbiddenChildEnv({ anthropic_auth_token: SENTINEL }, [], "win32"),
+    ).toThrow(ForbiddenChildEnvKeyError);
+  });
 });
 
 describe("CLAUDE_CONFIG_DIR matrix", () => {
@@ -230,5 +275,18 @@ describe("CLAUDE_CONFIG_DIR matrix", () => {
     const env = buildChildEnv(pollutedBase(), { ...SUBSCRIPTION, configDir: "relative/claude" });
     expect(env.CLAUDE_CONFIG_DIR?.startsWith("/")).toBe(true);
     expect(env.CLAUDE_CONFIG_DIR?.endsWith("relative/claude")).toBe(true);
+  });
+
+  it("expands a Windows tilde from USERPROFILE regardless of environment-key casing", () => {
+    const env = buildChildEnv(
+      { userprofile: "C:\\Users\\Rider" },
+      {
+        ...SUBSCRIPTION,
+        binaryPath: "C:\\Users\\Rider\\.local\\bin\\claude.exe",
+        configDir: "~\\claude-alt",
+      },
+      { platform: "win32" },
+    );
+    expect(env.CLAUDE_CONFIG_DIR).toBe(win32.join("C:\\Users\\Rider", "claude-alt"));
   });
 });

--- a/packages/engine/tests/claude-cli/errors.test.ts
+++ b/packages/engine/tests/claude-cli/errors.test.ts
@@ -6,6 +6,7 @@ import {
   ClaudeCliConfigError,
   NOT_SIGNED_IN_MESSAGE,
   PROBE_TIMEOUT_MESSAGE,
+  WINDOWS_CLAUDE_INSTALL_COMMAND,
   apiKeyIdentityError,
   apiKeyUnapprovedError,
   binaryMissingError,
@@ -13,7 +14,10 @@ import {
   notSignedInError,
   probeTimeoutError,
   unrecognizedAuthSourceError,
+  unsafeWindowsCommandShimError,
+  unsupportedWindowsExecutableError,
   versionBelowFloorError,
+  windowsMcpConfigError,
 } from "../../src/agent/claude-cli/errors.js";
 import { isProviderAuthFailure } from "../../src/provider-auth-failure.js";
 
@@ -30,6 +34,49 @@ describe("user-facing configuration messages", () => {
     expect(versionBelowFloorError("2.0.1", "2.1.220").message).toBe(
       "Claude Code CLI 2.0.1 is older than the minimum supported 2.1.220. Run: claude update",
     );
+  });
+
+  it("gives Windows users an install command and a PATH recovery without leaking a path", () => {
+    const privatePath = "C:\\Users\\Private Rider\\Secret\\claude.exe";
+    const missing = binaryMissingError(privatePath, "win32");
+    const belowFloor = versionBelowFloorError("2.0.1", "2.1.220", "win32");
+
+    for (const error of [missing, belowFloor]) {
+      expect(error.message).toContain(WINDOWS_CLAUDE_INSTALL_COMMAND);
+      expect(error.message).toContain("updated PATH");
+      expect(error.message).toContain("claude.exe or claude.cmd");
+      expect(error.message).not.toContain(privatePath);
+      expect(error.message).not.toContain("launchd");
+    }
+  });
+
+  it("uses stage-coded, actionable refusals for unsafe Windows launch targets", () => {
+    const unsupported = unsupportedWindowsExecutableError();
+    const unsafe = unsafeWindowsCommandShimError();
+
+    expect(unsupported.kind).toBe("unsupported-windows-executable");
+    expect(unsafe.kind).toBe("unsafe-windows-command-shim");
+    for (const error of [unsupported, unsafe]) {
+      expect(error.message).toContain(WINDOWS_CLAUDE_INSTALL_COMMAND);
+      expect(error.message).toContain("llm.claude_cli.binary_path");
+    }
+  });
+
+  it("keeps Windows MCP file failures stage-coded, path-free, and credential-free", () => {
+    const privatePath = "C:\\Users\\Private Rider\\.enduragent\\mcp.json";
+    const credential = "synthetic-private-token";
+    const write = windowsMcpConfigError("content-write");
+    const cleanup = windowsMcpConfigError("cleanup");
+
+    expect(write).toMatchObject({ kind: "windows-mcp-config-write", stage: "content-write" });
+    expect(cleanup).toMatchObject({
+      kind: "windows-mcp-config-cleanup",
+      stage: "cleanup",
+    });
+    for (const error of [write, cleanup]) {
+      expect(error.message).not.toContain(privatePath);
+      expect(error.message).not.toContain(credential);
+    }
   });
 
   it("never offers to sign the athlete in", () => {
@@ -101,6 +148,10 @@ describe("normalizeClaudeCliError", () => {
       apiKeyIdentityError(),
       apiKeyUnapprovedError(),
       unrecognizedAuthSourceError("quantumToken"),
+      unsupportedWindowsExecutableError(),
+      unsafeWindowsCommandShimError(),
+      windowsMcpConfigError("content-write"),
+      windowsMcpConfigError("cleanup"),
       normalizeClaudeCliError(new Error("usage limit reached")),
       normalizeClaudeCliError(new Error("prompt is too long")),
     ]) {

--- a/packages/engine/tests/claude-cli/executable.test.ts
+++ b/packages/engine/tests/claude-cli/executable.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, win32 } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { HANG_VERSION, createFakeClaude, type FakeClaude } from "./helpers/fake-claude.js";
 import {
@@ -41,6 +43,29 @@ function baseEnvWithSecrets(): NodeJS.ProcessEnv {
 
 function onlyExecutable(match: string) {
   return async (candidate: string) => candidate === match;
+}
+
+function fakeVersionSpawn(stdoutText: string, exitCode: number, stderrText = "") {
+  const launch = vi.fn((_command: string, _args: readonly string[], _options: object) => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.kill = vi.fn(() => true);
+    queueMicrotask(() => {
+      child.stdout.end(stdoutText);
+      child.stderr.end(stderrText);
+      child.emit("close", exitCode, null);
+    });
+    return child;
+  });
+  return {
+    launch,
+    spawn: launch as unknown as typeof import("node:child_process").spawn,
+  };
 }
 
 describe("resolveClaudeBinary", () => {
@@ -89,6 +114,66 @@ describe("resolveClaudeBinary", () => {
       isExecutable: async () => false,
     });
     expect(resolved).toBeNull();
+  });
+
+  it("probes Windows PATH entries in order with .exe before .cmd and never probes a bare name", async () => {
+    const seen: string[] = [];
+    const expected = "D:\\Second\\claude.exe";
+    const resolved = await resolveClaudeBinary({
+      platform: "win32",
+      env: { Path: "C:\\First;D:\\Second", userprofile: "C:\\Users\\Rider" },
+      isExecutable: async (candidate) => {
+        seen.push(candidate);
+        return candidate === expected;
+      },
+    });
+
+    expect(resolved).toBe(expected);
+    expect(seen).toEqual([
+      "C:\\First\\claude.exe",
+      "C:\\First\\claude.cmd",
+      "D:\\Second\\claude.exe",
+    ]);
+    expect(seen).not.toContain("C:\\First\\claude");
+  });
+
+  it("uses explicit current Windows native, WinGet, and npm-shim locations", () => {
+    expect(
+      wellKnownClaudePaths("C:\\Users\\Rider", {
+        platform: "win32",
+        env: {
+          LocalAppData: "D:\\Profiles\\Rider\\Local",
+          appdata: "D:\\Profiles\\Rider\\Roaming",
+        },
+      }),
+    ).toEqual([
+      "C:\\Users\\Rider\\.local\\bin\\claude.exe",
+      "D:\\Profiles\\Rider\\Local\\Microsoft\\WinGet\\Links\\claude.exe",
+      "D:\\Profiles\\Rider\\Roaming\\npm\\claude.cmd",
+    ]);
+  });
+
+  it("honors USERPROFILE and enforces existence plus .exe-or-.cmd for explicit Windows paths", async () => {
+    const checker = vi.fn(async () => true);
+    const resolved = await resolveClaudeBinary({
+      explicitPath: "~\\bin\\claude.cmd",
+      platform: "win32",
+      env: { userprofile: "C:\\Users\\Rider", Path: "" },
+      isExecutable: checker,
+    });
+    expect(resolved).toBe(win32.join("C:\\Users\\Rider", "bin", "claude.cmd"));
+    expect(checker).toHaveBeenCalledOnce();
+
+    checker.mockClear();
+    await expect(
+      resolveClaudeBinary({
+        explicitPath: "C:\\Tools\\claude.ps1",
+        platform: "win32",
+        env: { userprofile: "C:\\Users\\Rider", Path: "" },
+        isExecutable: checker,
+      }),
+    ).resolves.toBeNull();
+    expect(checker).not.toHaveBeenCalled();
   });
 });
 
@@ -205,5 +290,43 @@ describe("probeVersion", () => {
     await expect(probeVersion(silent, { baseEnv: baseEnvWithSecrets() })).rejects.toThrow(
       /did not report a version/,
     );
+  });
+
+  it("probes a Windows .cmd shim through cmd.exe with shell disabled", async () => {
+    const shim = "C:\\Users\\Rider Name\\AppData\\Roaming\\npm\\claude.cmd";
+    const fakeSpawn = fakeVersionSpawn("2.1.220 (Claude Code)\n", 0);
+
+    await expect(
+      probeVersion(shim, {
+        platform: "win32",
+        baseEnv: { Path: "C:\\Windows\\System32", SystemRoot: "C:\\Windows" },
+        spawn: fakeSpawn.spawn,
+      }),
+    ).resolves.toBe("2.1.220");
+    expect(fakeSpawn.launch).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\cmd.exe",
+      ["/d", "/s", "/c", `""${shim}" "--version""`],
+      expect.objectContaining({
+        shell: false,
+        windowsHide: true,
+        windowsVerbatimArguments: true,
+      }),
+    );
+  });
+
+  it("maps a non-zero Windows cmd exit without exposing paths or stderr", async () => {
+    const shim = "C:\\Users\\Private Rider\\AppData\\Roaming\\npm\\claude.cmd";
+    const privateDiagnostic = "C:\\Users\\Private Rider\\token-store";
+    const fakeSpawn = fakeVersionSpawn("", 7, privateDiagnostic);
+
+    const failure = await probeVersion(shim, {
+      platform: "win32",
+      baseEnv: { SystemRoot: "C:\\Windows" },
+      spawn: fakeSpawn.spawn,
+    }).catch((error: unknown) => error);
+    expect(failure).toMatchObject({ kind: "binary-missing" });
+    expect((failure as Error).message).toContain("exited with code 7");
+    expect((failure as Error).message).not.toContain(shim);
+    expect((failure as Error).message).not.toContain(privateDiagnostic);
   });
 });

--- a/packages/engine/tests/claude-cli/probe.test.ts
+++ b/packages/engine/tests/claude-cli/probe.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { win32 } from "node:path";
 import type { AccountInfo, query as sdkQuery } from "@anthropic-ai/claude-agent-sdk";
 
 import type { ClaudeCliRuntime } from "../../src/agent/claude-cli/env.js";
-import { ClaudeCliConfigError } from "../../src/agent/claude-cli/errors.js";
+import { ClaudeCliConfigError, windowsMcpConfigError } from "../../src/agent/claude-cli/errors.js";
 import {
   ACCOUNT_PROBE_CACHE_TTL_MS,
   API_KEY_BILLING_IDENTITY_LINE,
@@ -188,6 +189,20 @@ describe("readFallbackEmail", () => {
       readFallbackEmail("/tmp/cfg", { readFile: async () => "{not json" }),
     ).resolves.toBeUndefined();
   });
+
+  it("uses USERPROFILE for the default Windows config path with case-insensitive keys", async () => {
+    const paths: string[] = [];
+    const email = await readFallbackEmail(undefined, {
+      platform: "win32",
+      env: { userprofile: "C:\\Users\\Rider" },
+      readFile: async (path) => {
+        paths.push(path);
+        return JSON.stringify({ oauthAccount: { emailAddress: "rider@example.test" } });
+      },
+    });
+    expect(email).toBe("rider@example.test");
+    expect(paths).toEqual([win32.join("C:\\Users\\Rider", ".claude.json")]);
+  });
 });
 
 describe("probeClaudeAccount", () => {
@@ -301,6 +316,55 @@ describe("probeClaudeAccount", () => {
     );
     expect(result.email).toBe("fallback@example.test");
     expect(result.accountClass).toBe("subscription");
+  });
+
+  it("builds the real Windows .cmd account probe with the validated custom spawner", async () => {
+    const { fn, state } = makeQuery({
+      email: "rider@example.test",
+      subscriptionType: "Claude Max",
+      apiProvider: "firstParty",
+    });
+    const shim = "C:\\Users\\Rider Name\\AppData\\Roaming\\npm\\claude.cmd";
+    await expect(
+      probeClaudeAccount(
+        {
+          runtime: { binaryPath: shim, billing: "subscription" },
+          platform: "win32",
+          baseEnv: {
+            Path: "C:\\Windows\\System32",
+            userprofile: "C:\\Users\\Rider Name",
+            SystemRoot: "C:\\Windows",
+          },
+        },
+        { query: fn },
+      ),
+    ).resolves.toMatchObject({ verified: true, accountClass: "subscription" });
+    expect(state.lastOptions?.pathToClaudeCodeExecutable).toBe(shim);
+    expect(state.lastOptions?.spawnClaudeCodeProcess).toEqual(expect.any(Function));
+    expect(state.lastOptions?.env).toMatchObject({
+      PATH: "C:\\Windows\\System32",
+      USERPROFILE: "C:\\Users\\Rider Name",
+      SYSTEMROOT: "C:\\Windows",
+    });
+  });
+
+  it("preserves an unsafe Windows .cmd refusal instead of collapsing it to signed-out", async () => {
+    const { fn, state } = makeQuery({
+      subscriptionType: "Claude Max",
+      apiProvider: "firstParty",
+    });
+    const unsafe = "C:\\Users\\Rider&Other\\npm\\claude.cmd";
+    const failure = await probeClaudeAccount(
+      {
+        runtime: { binaryPath: unsafe, billing: "subscription" },
+        platform: "win32",
+        baseEnv: { SystemRoot: "C:\\Windows" },
+      },
+      { query: fn },
+    ).catch((error: unknown) => error);
+    expect(failure).toMatchObject({ kind: "unsafe-windows-command-shim" });
+    expect((failure as Error).message).not.toContain(unsafe);
+    expect(state.calls).toBe(0);
   });
 });
 
@@ -615,5 +679,103 @@ describe("ensureClaudeCliReady", () => {
     ).catch((err: unknown) => err);
     expect(failure).toBeInstanceOf(ClaudeCliConfigError);
     expect((failure as ClaudeCliConfigError).kind).toBe("unrecognized-auth-source");
+  });
+
+  it("threads the injected Windows platform, environment, and home through real readiness", async () => {
+    const windowsEnv = {
+      Path: "C:\\Windows\\System32",
+      userprofile: "C:\\Users\\Rider",
+      appdata: "C:\\Users\\Rider\\AppData\\Roaming",
+    };
+    const shim = "C:\\Users\\Rider\\AppData\\Roaming\\npm\\claude.cmd";
+    const resolveBinary = vi.fn(async () => shim);
+    const probeVersion = vi.fn(async () => "2.1.220");
+    const preflightMcpConfigTransform = vi.fn();
+    const probeAccount = vi.fn(async () => ({
+      verified: true as const,
+      accountClass: "subscription" as const,
+      email: "rider@example.test",
+      plan: "Max",
+    }));
+
+    await expect(
+      ensureClaudeCliReady(
+        {
+          baseEnv: windowsEnv,
+          platform: "win32",
+          home: "D:\\Profiles\\Rider",
+          configDir: "~\\claude-config",
+        },
+        { resolveBinary, probeVersion, preflightMcpConfigTransform, probeAccount },
+      ),
+    ).resolves.toMatchObject({ binaryPath: shim, version: "2.1.220" });
+    expect(resolveBinary).toHaveBeenCalledWith({
+      env: windowsEnv,
+      platform: "win32",
+      home: "D:\\Profiles\\Rider",
+    });
+    expect(probeVersion).toHaveBeenCalledWith(
+      shim,
+      expect.objectContaining({
+        baseEnv: windowsEnv,
+        platform: "win32",
+        home: "D:\\Profiles\\Rider",
+      }),
+    );
+    expect(preflightMcpConfigTransform).toHaveBeenCalledWith({
+      binaryPath: shim,
+      env: expect.objectContaining({
+        PATH: "C:\\Windows\\System32",
+        USERPROFILE: "C:\\Users\\Rider",
+      }),
+      platform: "win32",
+    });
+    expect(probeAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseEnv: windowsEnv,
+        platform: "win32",
+        home: "D:\\Profiles\\Rider",
+        runtime: {
+          binaryPath: shim,
+          billing: "subscription",
+          configDir: "~\\claude-config",
+        },
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("refuses readiness when the Windows .cmd MCP transform preflight cannot write", async () => {
+    const shim = "C:\\Users\\Rider\\AppData\\Roaming\\npm\\claude.cmd";
+    const probeAccount = vi.fn(async () => ({
+      verified: true as const,
+      accountClass: "subscription" as const,
+    }));
+    const preflightMcpConfigTransform = vi.fn(() => {
+      throw windowsMcpConfigError("content-write");
+    });
+
+    await expect(
+      ensureClaudeCliReady(
+        {
+          baseEnv: {
+            Path: "C:\\Windows\\System32",
+            userprofile: "C:\\Users\\Rider",
+          },
+          platform: "win32",
+        },
+        {
+          resolveBinary: async () => shim,
+          probeVersion: async () => "2.1.220",
+          preflightMcpConfigTransform,
+          probeAccount,
+        },
+      ),
+    ).rejects.toMatchObject({
+      kind: "windows-mcp-config-write",
+      stage: "content-write",
+    });
+    expect(preflightMcpConfigTransform).toHaveBeenCalledOnce();
+    expect(probeAccount).not.toHaveBeenCalled();
   });
 });

--- a/packages/engine/tests/claude-cli/session.test.ts
+++ b/packages/engine/tests/claude-cli/session.test.ts
@@ -1,11 +1,19 @@
-import { describe, expect, it } from "vitest";
-import type { query as sdkQuery, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { EventEmitter } from "node:events";
+import { constants, type Stats } from "node:fs";
+import { win32 } from "node:path";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import type { query as sdkQuery, SDKMessage, SpawnOptions } from "@anthropic-ai/claude-agent-sdk";
 
 import type { ClaudeCliRuntime } from "../../src/agent/claude-cli/env.js";
 import {
+  buildClaudeCliSpawnInvocation,
   buildQueryOptions,
+  preflightWindowsMcpConfigTransform,
+  spawnClaudeCliProcess,
   startGeneration,
   type SanitizedQueryOptions,
+  type WindowsMcpConfigFileSystemDeps,
 } from "../../src/agent/claude-cli/session.js";
 
 const SENTINEL = "sk-ant-sentinel-session-0000";
@@ -23,6 +31,114 @@ function baseEnv(): NodeJS.ProcessEnv {
     ANTHROPIC_API_KEY: SENTINEL,
     CLAUDE_CODE_OAUTH_TOKEN: SENTINEL,
   };
+}
+
+function fakeMetadata(kind: "directory" | "file", ino: number): Stats {
+  return {
+    dev: 7,
+    ino,
+    nlink: 1,
+    isDirectory: () => kind === "directory",
+    isFile: () => kind === "file",
+    isSymbolicLink: () => false,
+  } as Stats;
+}
+
+function missingFile(): NodeJS.ErrnoException {
+  return Object.assign(new Error("missing"), { code: "ENOENT" });
+}
+
+interface FakeWindowsMcpFileSystem {
+  readonly deps: WindowsMcpConfigFileSystemDeps;
+  readonly profile: string;
+  readonly root: string;
+  readonly temporary: string;
+  readonly file: string;
+  readonly mkdir: ReturnType<typeof vi.fn>;
+  readonly open: ReturnType<typeof vi.fn>;
+  readonly unlink: ReturnType<typeof vi.fn>;
+  readonly rmdir: ReturnType<typeof vi.fn>;
+  readonly written: string[];
+}
+
+function fakeWindowsMcpFileSystem(
+  failure: "write" | "cleanup" | null = null,
+): FakeWindowsMcpFileSystem {
+  const profile = "C:\\Users\\Rider";
+  const root = win32.join(profile, ".enduragent");
+  const temporary = win32.join(root, "claude-cli-mcp-ABC123");
+  const file = win32.join(temporary, "mcp.json");
+  const entries = new Map<string, Stats>([
+    [win32.dirname(profile), fakeMetadata("directory", 1)],
+    [profile, fakeMetadata("directory", 2)],
+  ]);
+  const written: string[] = [];
+  const mkdir = vi.fn((path: string) => {
+    expect(path).toBe(root);
+    entries.set(root, fakeMetadata("directory", 3));
+    return root;
+  });
+  const open = vi.fn((path: string) => {
+    expect(path).toBe(file);
+    entries.set(file, fakeMetadata("file", 5));
+    return 41;
+  });
+  const unlink = vi.fn((path: string) => {
+    expect(path).toBe(file);
+    if (failure === "cleanup") throw new Error(`private ${path} ${SENTINEL}`);
+    entries.delete(file);
+  });
+  const rmdir = vi.fn((path: string) => {
+    expect(path).toBe(temporary);
+    entries.delete(temporary);
+  });
+  const deps = {
+    mkdirSync: mkdir,
+    mkdtempSync: vi.fn((prefix: string) => {
+      expect(prefix).toBe(win32.join(root, "claude-cli-mcp-"));
+      entries.set(temporary, fakeMetadata("directory", 4));
+      return temporary;
+    }),
+    lstatSync: vi.fn((path: string) => {
+      const metadata = entries.get(path);
+      if (metadata === undefined) throw missingFile();
+      return metadata;
+    }),
+    realpathSync: vi.fn((path: string) => path),
+    openSync: open,
+    fstatSync: vi.fn(() => entries.get(file) ?? fakeMetadata("file", 5)),
+    writeSync: vi.fn((_descriptor: number, buffer: Buffer, offset: number, length: number) => {
+      if (failure === "write") throw new Error(`private ${file} ${SENTINEL}`);
+      written.push(buffer.subarray(offset, offset + length).toString("utf8"));
+      return length;
+    }),
+    fsyncSync: vi.fn(),
+    closeSync: vi.fn(),
+    unlinkSync: unlink,
+    rmdirSync: rmdir,
+  } as unknown as WindowsMcpConfigFileSystemDeps;
+  return { deps, profile, root, temporary, file, mkdir, open, unlink, rmdir, written };
+}
+
+function fakeSpawnedChild(): EventEmitter & {
+  stdin: PassThrough;
+  stdout: PassThrough;
+  killed: boolean;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill: () => boolean;
+} {
+  const child = new EventEmitter() as ReturnType<typeof fakeSpawnedChild>;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.killed = false;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  return child;
 }
 
 function options(overrides: Partial<Parameters<typeof buildQueryOptions>[0]> = {}) {
@@ -169,6 +285,322 @@ describe("buildQueryOptions", () => {
 
   it("refuses both resume and a fresh session id at once", () => {
     expect(() => options({ resume: "a", sessionId: "b" })).toThrow(/resume or sessionId/);
+  });
+
+  it("keeps a Windows .exe on the direct shell-disabled SDK spawn path", () => {
+    const executable = "C:\\Program Files (x86)\\Claude\\claude.exe";
+    const invocation = buildClaudeCliSpawnInvocation({
+      binaryPath: executable,
+      args: ["--version"],
+      env: { SystemRoot: "C:\\Windows" },
+      platform: "win32",
+    });
+    expect(invocation).toEqual({
+      command: executable,
+      args: ["--version"],
+      shell: false,
+      windowsHide: true,
+    });
+
+    const built = options({
+      runtime: { binaryPath: executable, billing: "subscription" },
+      baseEnv: { Path: "C:\\Windows\\System32", userprofile: "C:\\Users\\Rider" },
+      platform: "win32",
+    });
+    expect(built.spawnClaudeCodeProcess).toBeUndefined();
+  });
+
+  it("routes a validated Windows .cmd shim through cmd.exe with explicit quoting", () => {
+    const shim = "C:\\Users\\Rider Name\\AppData\\Roaming\\npm\\claude.cmd";
+    const invocation = buildClaudeCliSpawnInvocation({
+      binaryPath: shim,
+      args: ["--output-format", "stream-json", "--model", "Claude Model", "C:\\Training\\"],
+      env: { systemroot: "C:\\Windows" },
+      platform: "win32",
+    });
+    expect(invocation).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        `""${shim}" "--output-format" "stream-json" "--model" "Claude Model" "C:\\Training\\\\""`,
+      ],
+      shell: false,
+      windowsHide: true,
+      windowsVerbatimArguments: true,
+    });
+
+    const built = options({
+      runtime: {
+        binaryPath: shim,
+        billing: "subscription",
+        configDir: "~\\claude-config",
+      },
+      baseEnv: { SystemRoot: "C:\\Windows", userprofile: "C:\\Users\\Rider Name" },
+      platform: "win32",
+      home: "D:\\Profiles\\Rider",
+    });
+    expect(built.spawnClaudeCodeProcess).toEqual(expect.any(Function));
+    expect(built.env.CLAUDE_CONFIG_DIR).toBe("D:\\Profiles\\Rider\\claude-config");
+  });
+
+  it("writes inline SDK MCP JSON privately and launches the .cmd shim with its file path", () => {
+    const fileSystem = fakeWindowsMcpFileSystem();
+    const child = fakeSpawnedChild();
+    const launch = vi.fn((_command: string, _args: readonly string[], _options: object) => child);
+    const shim = "C:\\Users\\Rider\\AppData\\Roaming\\npm\\claude.cmd";
+    const inline = JSON.stringify({
+      mcpServers: {
+        coach: {
+          type: "stdio",
+          command: "node",
+          args: ["server.mjs"],
+          env: { PRIVATE_TOKEN: SENTINEL },
+        },
+      },
+    });
+    const controller = new AbortController();
+
+    const spawned = spawnClaudeCliProcess(
+      {
+        command: shim,
+        args: ["--output-format", "stream-json", "--mcp-config", inline, "--strict-mcp-config"],
+        env: { SystemRoot: "C:\\Windows", USERPROFILE: fileSystem.profile },
+        signal: controller.signal,
+      },
+      {
+        platform: "win32",
+        spawn: launch as unknown as typeof import("node:child_process").spawn,
+        windowsMcpConfigFileSystem: fileSystem.deps,
+      },
+    );
+
+    expect(spawned).toBe(child);
+    expect(fileSystem.mkdir).toHaveBeenCalledWith(fileSystem.root, {
+      recursive: true,
+      mode: 0o700,
+    });
+    expect(fileSystem.open).toHaveBeenCalledWith(
+      fileSystem.file,
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+      0o600,
+    );
+    expect(fileSystem.written.join("")).toBe(inline);
+    const spawnedArguments = launch.mock.calls[0]?.[1] as string[] | undefined;
+    const commandLine = spawnedArguments?.[3] ?? "";
+    expect(commandLine).toContain(`"--mcp-config" "${fileSystem.file.replaceAll("\\", "/")}"`);
+    expect(commandLine).not.toContain(inline);
+    expect(commandLine).not.toContain(SENTINEL);
+    expect(commandLine).not.toContain("{");
+    expect(launch).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\cmd.exe",
+      expect.any(Array),
+      expect.objectContaining({
+        shell: false,
+        windowsVerbatimArguments: true,
+      }),
+    );
+
+    child.emit("exit", 0, null);
+    expect(fileSystem.unlink).toHaveBeenCalledOnce();
+    expect(fileSystem.rmdir).toHaveBeenCalledOnce();
+  });
+
+  it("preflights a representative non-empty MCP config through the same private transform", () => {
+    const fileSystem = fakeWindowsMcpFileSystem();
+
+    preflightWindowsMcpConfigTransform({
+      binaryPath: "C:\\Users\\Rider\\AppData\\Roaming\\npm\\claude.cmd",
+      env: { SystemRoot: "C:\\Windows", USERPROFILE: fileSystem.profile },
+      platform: "win32",
+      fileSystem: fileSystem.deps,
+    });
+
+    const serialized = JSON.parse(fileSystem.written.join("")) as {
+      mcpServers?: Record<string, unknown>;
+    };
+    expect(Object.keys(serialized.mcpServers ?? {})).toEqual(["enduragent-readiness"]);
+    expect(fileSystem.unlink).toHaveBeenCalledOnce();
+    expect(fileSystem.rmdir).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed with a private stage-coded error when the MCP file write fails", () => {
+    const fileSystem = fakeWindowsMcpFileSystem("write");
+    const launch = vi.fn();
+    const inline = JSON.stringify({
+      mcpServers: { coach: { type: "stdio", command: "node", env: { TOKEN: SENTINEL } } },
+    });
+
+    const failure = (() => {
+      try {
+        spawnClaudeCliProcess(
+          {
+            command: "C:\\Users\\Rider\\AppData\\Roaming\\npm\\claude.cmd",
+            args: ["--mcp-config", inline],
+            env: { SystemRoot: "C:\\Windows", USERPROFILE: fileSystem.profile },
+            signal: new AbortController().signal,
+          },
+          {
+            platform: "win32",
+            spawn: launch as unknown as typeof import("node:child_process").spawn,
+            windowsMcpConfigFileSystem: fileSystem.deps,
+          },
+        );
+        return null;
+      } catch (error) {
+        return error;
+      }
+    })();
+
+    expect(failure).toMatchObject({
+      kind: "windows-mcp-config-write",
+      stage: "content-write",
+    });
+    expect((failure as Error).message).not.toContain(fileSystem.file);
+    expect((failure as Error).message).not.toContain(SENTINEL);
+    expect(launch).not.toHaveBeenCalled();
+    expect(fileSystem.unlink).toHaveBeenCalledOnce();
+    expect(fileSystem.rmdir).toHaveBeenCalledOnce();
+  });
+
+  it("classifies cleanup failure without suppressing the child process exit", () => {
+    const fileSystem = fakeWindowsMcpFileSystem("cleanup");
+    const child = fakeSpawnedChild();
+    const cleanupFailures = vi.fn();
+    const inline = JSON.stringify({
+      mcpServers: { coach: { type: "stdio", command: "node" } },
+    });
+    const spawned = spawnClaudeCliProcess(
+      {
+        command: "C:\\Users\\Rider\\AppData\\Roaming\\npm\\claude.cmd",
+        args: ["--mcp-config", inline],
+        env: { SystemRoot: "C:\\Windows", USERPROFILE: fileSystem.profile },
+        signal: new AbortController().signal,
+      },
+      {
+        platform: "win32",
+        spawn: vi.fn(() => child) as unknown as typeof import("node:child_process").spawn,
+        windowsMcpConfigFileSystem: fileSystem.deps,
+        onWindowsMcpConfigCleanupFailure: cleanupFailures,
+      },
+    );
+    const exit = vi.fn();
+    spawned.on("exit", exit);
+
+    child.emit("exit", 23, null);
+
+    expect(exit).toHaveBeenCalledWith(23, null);
+    expect(cleanupFailures).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "windows-mcp-config-cleanup", stage: "cleanup" }),
+    );
+    const cleanupFailure = cleanupFailures.mock.calls[0]?.[0] as Error;
+    expect(cleanupFailure.message).not.toContain(fileSystem.file);
+    expect(cleanupFailure.message).not.toContain(SENTINEL);
+  });
+
+  it.each([
+    "C:\\Users\\Rider&Other\\npm\\claude.cmd",
+    "C:\\Users\\Rider%TEMP%\\npm\\claude.cmd",
+    "C:\\Program Files (x86)\\npm\\claude.cmd",
+    'C:\\Users\\Rider"Other\\npm\\claude.cmd',
+  ])("rejects an unsafe Windows .cmd path without echoing it: %s", (shim) => {
+    const failure = (() => {
+      try {
+        buildClaudeCliSpawnInvocation({
+          binaryPath: shim,
+          args: ["--version"],
+          env: { SystemRoot: "C:\\Windows" },
+          platform: "win32",
+        });
+        return null;
+      } catch (error) {
+        return error;
+      }
+    })();
+    expect(failure).toMatchObject({ kind: "unsafe-windows-command-shim" });
+    expect((failure as Error).message).not.toContain(shim);
+  });
+
+  it("rejects shell metacharacters in Windows .cmd arguments before launch", () => {
+    expect(() =>
+      buildClaudeCliSpawnInvocation({
+        binaryPath: "C:\\Users\\Rider\\npm\\claude.cmd",
+        args: ["--model", "sonnet&whoami"],
+        env: { SystemRoot: "C:\\Windows" },
+        platform: "win32",
+      }),
+    ).toThrow(expect.objectContaining({ kind: "unsafe-windows-command-shim" }));
+  });
+
+  it("rejects Windows executable types other than .exe and .cmd", () => {
+    expect(() =>
+      buildClaudeCliSpawnInvocation({
+        binaryPath: "C:\\Tools\\claude.bat",
+        args: [],
+        env: { SystemRoot: "C:\\Windows" },
+        platform: "win32",
+      }),
+    ).toThrow(expect.objectContaining({ kind: "unsupported-windows-executable" }));
+  });
+
+  it("forwards cancellation, kill, and exit status through the Windows cmd child", () => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdin: PassThrough;
+      stdout: PassThrough;
+      killed: boolean;
+      exitCode: number | null;
+      signalCode: NodeJS.Signals | null;
+      kill: () => boolean;
+    };
+    child.stdin = new PassThrough();
+    child.stdout = new PassThrough();
+    child.killed = false;
+    child.exitCode = null;
+    child.signalCode = null;
+    child.kill = vi.fn(() => {
+      child.killed = true;
+      return true;
+    });
+    const launch = vi.fn((_command: string, _args: readonly string[], spawnOptions: object) => {
+      const signal = (spawnOptions as { signal: AbortSignal }).signal;
+      signal.addEventListener("abort", () => child.kill());
+      return child;
+    });
+    const controller = new AbortController();
+    const shim = "C:\\Users\\Rider Name\\AppData\\Roaming\\npm\\claude.cmd";
+    const spawnOptions: SpawnOptions = {
+      command: shim,
+      args: ["--output-format", "stream-json"],
+      cwd: "C:\\Training",
+      env: { SystemRoot: "C:\\Windows" },
+      signal: controller.signal,
+    };
+
+    const spawned = spawnClaudeCliProcess(spawnOptions, {
+      platform: "win32",
+      spawn: launch as unknown as typeof import("node:child_process").spawn,
+    });
+    expect(spawned).toBe(child);
+    expect(launch).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\cmd.exe",
+      ["/d", "/s", "/c", `""${shim}" "--output-format" "stream-json""`],
+      expect.objectContaining({
+        cwd: "C:\\Training",
+        shell: false,
+        signal: controller.signal,
+        stdio: ["pipe", "pipe", "ignore"],
+        windowsVerbatimArguments: true,
+      }),
+    );
+
+    const onExit = vi.fn();
+    spawned.on("exit", onExit);
+    child.emit("exit", 23, null);
+    expect(onExit).toHaveBeenCalledWith(23, null);
+
+    controller.abort();
+    expect(child.kill).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
## Summary
- W12 of the Windows-parity initiative (ADR-0048): Windows Claude CLI support — discovery, invocation, errors, and a real readiness check.
- Discovery on win32 considers `claude.exe` and the npm `claude.cmd` shim, resolves home via `USERPROFILE`, adds explicit Windows well-known locations, and uses an existence+extension executability contract (POSIX `X_OK` is meaningless on Windows). POSIX discovery unchanged.
- Invocation split: a resolved `.exe` keeps the existing `shell: false` spawn contract. A resolved `.cmd` goes through a validated `cmd.exe /d /s /c` strategy — fail-closed allowlists on the shim path and every argument (every cmd metacharacter banned), `windowsVerbatimArguments` with per-token quoting, so injection is structurally impossible rather than escaped. Never `shell: true`.
- `--mcp-config` transform: inline JSON can never cross the argument allowlist, so the launch strategy rewrites it to a private config file (`0o700` dir, `0o600` `O_EXCL` file under `%USERPROFILE%\.enduragent`, fsync'd, deleted on session end; the installed CLI documents `--mcp-config` accepts JSON files). On the pinned SDK 0.3.220 this lane is dormant for real coach sessions — the SDK carries type-`sdk` in-process servers over its control channel, not argv — so the transform future-proofs stdio-type servers and SDK serialization changes rather than fixing a live failure.
- Readiness is truthful for the `.cmd` lane: `ensureClaudeCliReady` statically preflights the same transform lane a real session uses (secret-free representative config through the real writer, allowlist, and invocation builder), so `ready` cannot coexist with a statically broken launch path; failures map to the existing recovery states.
- Windows recovery guidance on binary-missing and version-floor errors; all new diagnostics stage-coded, path-free, credential-free. darwin/POSIX behavior byte-identical.

## Verification
- deps/renderer/desktop builds pass.
- `pnpm exec vitest run packages/engine/tests/claude-cli packages/engine/tests/retry-loop-claude-cli.test.ts` — 258 passed, 0 failed, 4 skipped (real-CLI e2e self-skip).
- `pnpm exec vitest run apps/desktop/tests` — 1375 passed, 0 failed.
- Root `pnpm check` — clean.
- Two fresh-context read-only audits (one per build round): the injection strategy passed a line-by-line review (allowlist patterns byte-identical across rounds, zero `shell: true`), POSIX parity, scope, and readiness truthfulness confirmed.

## Limits
None (no new resource bounds). For operator awareness, two new file-privacy modes: `0o700` config dir and `0o600` `mcp.json` in `session.ts`, matching the existing vault/cursor-store convention.

## Notes / delegate decisions
- Cleanup-failure handling: a classified mcp-config cleanup failure after a successful session is thrown (fail-closed) rather than silently dropped — the generation result has no warning channel to carry it. Zero practical impact while the lane is dormant; revisiting is tracked for the day a stdio-type server activates the lane.
- Deliberate: the `.cmd` path allowlist is ASCII-only; non-ASCII Windows profiles lose the npm-shim lane fail-closed with native-installer recovery guidance (`.exe` installs unaffected).
- Windows-host-only proof deferred to VM acceptance: real `.cmd` execution and quoting, control-channel tool calls end-to-end, process-tree cancellation, PATH/PATHEXT resolution, clean-host install layouts.
