### PR TITLE
ci(desktop): run darwin integration suites on a macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,23 @@ jobs:
       - run: pnpm --filter @enduragent/desktop test:telegram-packaged
         env:
           ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT: "1"
+
+  desktop-integration-macos:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    env:
+      CI: macos
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: test "$(uname -m)" = "arm64"
+      - run: pnpm install --frozen-lockfile
+      - name: Build Desktop
+        run: pnpm --filter @enduragent/desktop... build
+      - name: Test Darwin desktop integrations
+        run: pnpm --filter @enduragent/desktop exec vitest run tests/onboarding-first-run.integration.test.ts tests/spend-meter.integration.test.ts tests/chat-panels.integration.test.ts --maxWorkers=1

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -655,7 +655,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         params: { cursor: transcriptCursor, limit: 25 },
       },
     ]);
-  }, 30_000);
+  }, 90_000);
 
   it("preserves IME composition until committed Enter", async () => {
     const { fixture, calls } = await launch({ width: 1440, height: 900, reducedMotion: false });
@@ -813,7 +813,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         params: { chatId: "desktop", message: committedMessage },
       },
     ]);
-  }, 30_000);
+  }, 90_000);
 
   it("streams chat, proves no-change sync, preserves focus, and fits desktop geometry", async () => {
     const { fixture, calls } = await launch({ width: 1440, height: 900, reducedMotion: false });
@@ -1864,7 +1864,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     }
     expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
     fixtures.splice(fixtures.indexOf(fixture), 1);
-  }, 30_000);
+  }, 90_000);
 
   it("keeps the long partial-sync status reachable and wrapped at 720×800", async () => {
     const { fixture, calls } = await launch({
@@ -1950,7 +1950,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     ).toHaveLength(1);
     expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
     fixtures.splice(fixtures.indexOf(fixture), 1);
-  }, 30_000);
+  }, 90_000);
 
   it("honors reduced motion at the compact viewport", async () => {
     const { fixture } = await launch({ width: 720, height: 800, reducedMotion: true });
@@ -1969,5 +1969,5 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     ).toEqual({ reduced: true, overflow: false, railWidth: 184 });
     expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
     fixtures.splice(fixtures.indexOf(fixture), 1);
-  }, 30_000);
+  }, 90_000);
 });

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -42,6 +42,7 @@ interface ScriptRequest {
 
 const require = createRequire(import.meta.url);
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const DESKTOP_FIXTURE_LAUNCH_TIMEOUT_MS = 45_000;
 const disabledTelegramSnapshot: TelegramControlSnapshot = {
   channel: { desiredState: "disabled", state: "disabled" },
   bot: { state: "unconfigured" },
@@ -369,7 +370,9 @@ export async function launchDesktopFixture(input: {
   };
   let closed = false;
   try {
-    const debuggerUrl = await waitForPage(debuggerPort);
+    const debuggerUrl = await waitForPage(debuggerPort, {
+      timeoutMs: DESKTOP_FIXTURE_LAUNCH_TIMEOUT_MS,
+    });
     cdp = await connectCdp(debuggerUrl, (message) => {
       if (message.method !== "Runtime.consoleAPICalled") return;
       const args =

--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -277,5 +277,5 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
       finished: true,
       chatWorking: true,
     });
-  }, 30_000);
+  }, 90_000);
 });

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -367,7 +367,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       };
     `);
     expect(narrow).toEqual({ visible: true, overflow: false });
-  });
+  }, 60_000);
 
   it("preserves the closed bridge, sidebar sync chip, hardened renderer, and token containment", async () => {
     const { fixture } = await launch();
@@ -445,7 +445,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       expect(surface).not.toContain(token);
     }
     await expect(fixture.close()).resolves.toEqual({ livePids: [], listenerCount: 0 });
-  });
+  }, 60_000);
 
   it("renders complete and provider-dependent details, saves an unknown cap, and preserves it as stale", async () => {
     const { fixture, calls, failSpend } = await launch("complete");
@@ -522,5 +522,5 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
     `);
     expect(stale).toContain("Spend data may be out of date.");
     expect(calls.filter((call) => call.method === "chat")).toHaveLength(1);
-  }, 15_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## What

CI's `test` job runs on `ubuntu-latest`, and the desktop integration suites are gated by `describe.skipIf(process.platform !== "darwin" || !hasLoopback)` — so they have never executed on CI. Two real breaks shipped green last week because of this blind spot (the only covered case today is the IME test, cherry-picked by `desktop-packaged-self-test`).

This adds a `desktop-integration-macos` job that runs the three darwin-gated files (nine cases) on `macos-latest`, mirroring the existing `desktop-packaged-self-test` setup, plus timeout raises sized for shared runners.

## Changes

- New `desktop-integration-macos` job in `ci.yml`: build the desktop chain, then `vitest run` the three integration files with `--maxWorkers=1`. `continue-on-error: true` at first.
- `launchDesktopFixture` now passes an explicit launch timeout to `waitForPage` instead of relying on the general 20s default.
- Case timeouts raised: onboarding-first-run 30s → 90s, spend-meter (all three cases, one had 15s) → 60s, chat-panels (all five) 30s → 90s.

## Limits

- `DESKTOP_FIXTURE_LAUNCH_TIMEOUT_MS = 45_000` — Electron launch on shared macOS runners is slower than local; the previous 20s default is the documented local flake source.
- Case timeouts `60_000` / `90_000` — must exceed the launch timeout plus test work on a loaded runner.
- Job `timeout-minutes: 30` — bounds a hung run.
- `continue-on-error: true` — rollout gate: non-blocking until 7 consecutive green days, then promote to a required check.

## Verification

- Local (Apple Silicon, windowless): `pnpm --filter @enduragent/desktop check` clean; `vitest run` of the three files with `--maxWorkers=1` → 3 files, 9/9 passed, 0 skipped, 21s.
- The first CI run on this PR doubles as the probe for hosted-runner Keychain behavior; a Keychain failure there is infrastructure evidence to fix (disposable-Keychain provisioning exists), never grounds for a bypass env.

No changeset: CI/test-only.