### PR TITLE
fix(telegram): cancel pairing lease on delete and finish delete offline

### DIFF
--- a/.changeset/brisk-lanterns-rest.md
+++ b/.changeset/brisk-lanterns-rest.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Deleting the Telegram connection now completes while offline and cancels any pending pairing.

--- a/apps/desktop/src/main/telegram-control.ts
+++ b/apps/desktop/src/main/telegram-control.ts
@@ -1590,6 +1590,9 @@ export function createTelegramControlCoordinator(
             : await guardedSnapshotCall(checked.active, () =>
                 checked.active.resetTelegramAccess({}),
               );
+        if (reset?.channel.state === "disabled" && reset.pairing.state === "unpaired") {
+          clearPairingLease();
+        }
         const forgotten =
           reset?.channel.state !== "disabled" || reset.pairing.state !== "unpaired"
             ? undefined

--- a/apps/desktop/tests/telegram-control.test.ts
+++ b/apps/desktop/tests/telegram-control.test.ts
@@ -1895,6 +1895,48 @@ describe("Telegram main-process control coordinator", () => {
     expect(runtime.binding.drainTelegram).toHaveBeenCalledOnce();
   });
 
+  it("cancels an armed pairing lease after deletion", async () => {
+    const clock = leaseScheduler();
+    const awaiting = snapshot(undefined, {
+      pairing: {
+        state: "awaiting-code",
+        code: "ABCDEF",
+        expiresAt: "2026-08-05T12:01:00.000Z",
+      },
+    });
+    const runtime = harness({
+      enabled: false,
+      pairingLease: clock.port,
+      daemonSnapshot: snapshot(undefined, { pairing: { state: "unpaired" } }),
+    });
+    runtime.setSenders({ senders: [] });
+    vi.mocked(runtime.binding.beginTelegramPairing).mockImplementationOnce(async () => {
+      runtime.setSnapshot(awaiting);
+      return awaiting;
+    });
+
+    await runtime.coordinator.beginPairing();
+    expect(clock.entries).toHaveLength(1);
+    await expect(runtime.coordinator.remove()).resolves.toMatchObject({ outcome: "applied" });
+    expect(runtime.vault.deleteProfile).toHaveBeenCalledOnce();
+    expect(clock.entries[0]?.cancelled).toBe(true);
+
+    vi.mocked(runtime.binding.cancelTelegramPairing).mockClear();
+    vi.mocked(runtime.binding.disableTelegram).mockClear();
+    vi.mocked(runtime.binding.drainTelegram).mockClear();
+    vi.mocked(runtime.binding.enableTelegram).mockClear();
+    vi.mocked(runtime.binding.reconcileTelegram).mockClear();
+    clock.setNow("2026-08-05T12:01:00.000Z");
+    clock.fire(0, true);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(runtime.binding.cancelTelegramPairing).not.toHaveBeenCalled();
+    expect(runtime.binding.disableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.drainTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.reconcileTelegram).not.toHaveBeenCalled();
+  });
+
   it("preserves durable enabled truth when a pairing claim wins at lease expiry", async () => {
     const clock = leaseScheduler();
     const awaiting = snapshot(undefined, {

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -404,7 +404,14 @@ export function createTelegramBot(input: CreateTelegramChannelInput): TelegramCh
     return { wait: () => waitForSnapshot(snapshot) };
   };
 
-  const stopPolling = (): Promise<void> => ledger.stopCurrentGeneration(() => bot.stop());
+  const stopPolling = (): Promise<void> =>
+    ledger.stopCurrentGeneration(async () => {
+      try {
+        await bot.stop();
+      } catch (error) {
+        if (bot.isRunning()) throw error;
+      }
+    });
 
   const drainPending = async (): Promise<void> => {
     while (true) {

--- a/packages/core/tests/telegram-generation-lifecycle.test.ts
+++ b/packages/core/tests/telegram-generation-lifecycle.test.ts
@@ -41,6 +41,7 @@ function createComposingBot(
     rawApi?: ApiCall;
     start?: (callApi: ApiCall) => Promise<void>;
     stop?: (callApi: ApiCall) => Promise<void>;
+    isRunning?: () => boolean;
   } = {},
 ) {
   const middleware: Middleware[] = [];
@@ -78,6 +79,7 @@ function createComposingBot(
     }),
     start: vi.fn(() => options.start?.(callApi) ?? Promise.resolve()),
     stop: vi.fn(() => options.stop?.(callApi) ?? Promise.resolve()),
+    isRunning: vi.fn(() => options.isRunning?.() ?? true),
     dispatch: (ctx: any) => {
       const command = /^\/([^\s]+)/.exec(ctx.message?.text ?? "")?.[1];
       const terminal =
@@ -526,6 +528,88 @@ describe("Telegram polling generation release", () => {
     finalOffset.resolve({ ok: true, result: [] });
     await stopping;
     await Promise.all([startSettled, runtime.captureDrain().wait()]);
+  });
+
+  it("drains a sealed generation when final-offset confirmation fails after polling stops", async () => {
+    const offline = new Error("offline");
+    const polling = deferred<void>();
+    let running = false;
+    const bot = createComposingBot({
+      rawApi: (method, payload) =>
+        method === "getUpdates" && payload.timeout === 0
+          ? Promise.reject(offline)
+          : Promise.resolve({ ok: true, result: true }),
+      start: async () => {
+        running = true;
+        await polling.promise;
+      },
+      stop: (callApi) => {
+        running = false;
+        return callApi("getUpdates", { offset: 8, timeout: 0 }).then(() => undefined);
+      },
+      isRunning: () => running,
+    });
+    vi.doMock("grammy", () => ({
+      Bot: function FakeBot() {
+        return bot;
+      },
+      InputFile: class {},
+    }));
+    vi.doMock("@grammyjs/auto-retry", () => ({
+      autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
+        previous(method, payload),
+    }));
+    const { createTelegramBot } = await import("../src/channels/telegram.js");
+    const runtime = createTelegramBot(makeRuntimeInput());
+
+    const pollingSettled = runtime.start();
+    await expect(runtime.stop()).resolves.toBeUndefined();
+    await expect(runtime.sendMessage("12345", "late")).rejects.toMatchObject({
+      code: "telegram-generation-sealed",
+    });
+    let drained = false;
+    const draining = runtime
+      .captureDrain()
+      .wait()
+      .then(() => {
+        drained = true;
+      });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+
+    polling.resolve();
+    await Promise.all([pollingSettled, draining]);
+    expect(drained).toBe(true);
+    expect(bot.isRunning).toHaveBeenCalledOnce();
+  });
+
+  it("keeps final-offset failure fatal while polling remains running", async () => {
+    const stopFailure = new Error("stop failed");
+    const bot = createComposingBot({
+      rawApi: (method, payload) =>
+        method === "getUpdates" && payload.timeout === 0
+          ? Promise.reject(stopFailure)
+          : Promise.resolve({ ok: true, result: true }),
+      stop: (callApi) =>
+        callApi("getUpdates", { offset: 8, timeout: 0 }).then(() => undefined),
+      isRunning: () => true,
+    });
+    vi.doMock("grammy", () => ({
+      Bot: function FakeBot() {
+        return bot;
+      },
+      InputFile: class {},
+    }));
+    vi.doMock("@grammyjs/auto-retry", () => ({
+      autoRetry: () => (previous: ApiCall, method: string, payload: Record<string, unknown>) =>
+        previous(method, payload),
+    }));
+    const { createTelegramBot } = await import("../src/channels/telegram.js");
+    const runtime = createTelegramBot(makeRuntimeInput());
+
+    await expect(runtime.stop()).rejects.toBe(stopFailure);
+    expect(bot.isRunning).toHaveBeenCalledOnce();
+    expect(() => runtime.captureDrain()).toThrow(/must stop before/);
   });
 
   it("tracks a retry-wrapped 429 request through its final API attempt", async () => {


### PR DESCRIPTION
## What

Two bugs in the Telegram Delete path, found while investigating remote-state cleanup (which was deliberately NOT added — the app never registers webhooks, so there is no remote state of ours to clean):

1. **Delete left a scheduled pairing lease alive.** `remove()` disabled the channel, reset access, forgot the credential, and deleted the vault profile — but never cancelled the pairing-lease timer. A pending lease could fire daemon mutations after deletion. `remove()` now clears the lease at the point where pairing is proven `unpaired`, before credential forget.

2. **Delete failed while offline.** grammY's `bot.stop()` awaits one final `getUpdates` to confirm the polling offset; offline, that rejection propagated and made delete return uncertain before any local wipe. `stopPolling()` now treats that failure as non-fatal only when grammY reports polling has stopped (`bot.isRunning()` false); a stop failure while the bot still runs stays fatal. The durable update-offset guard bounds replay risk for the unconfirmed final offset.

## Not in scope

No Telegram Bot API calls added to the delete path — no `deleteWebhook`, no `logOut` (operator decision 2026-08-11).

## Limits

None added or changed.

## Verification

- `packages/core` `telegram-generation-lifecycle.test.ts`: 15/15 (two new cases: drain proceeds when final-offset confirmation fails after polling stops; failure stays fatal while polling runs).
- `apps/desktop` `telegram-control.test.ts`: 135/135 (new case: armed pairing lease is cancelled by delete; force-fired timer performs zero daemon mutations after deletion).
- `tsc --noEmit` clean in both packages.