### PR TITLE
feat(desktop): freeze Chat/Settings Windows parity manifest and platform copy

### DIFF
--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -38,6 +38,7 @@ import {
   createOnboardingController,
   onboardingCredentialMutationActive,
 } from "./onboarding/controller.js";
+import { rendererPlatformProjection } from "./platform-copy.js";
 import { createTrainingContextController } from "./training-context/controller.js";
 import { createManualSyncController } from "./training-context/manual-sync.js";
 import { createTrainingSyncCoordinator } from "./training-sync.js";
@@ -73,6 +74,7 @@ export function onboardingCredentialMutationsBlocked(
 
 export function bootRenderer(): Disposer {
   const store = useEnduragentStore;
+  const platform = rendererPlatformProjection(window.enduragentAuth.platform);
   store.getState().setOnboardingStartupSettled(false);
   const onLifecycle = (event: WindowEventMap["enduragent-lifecycle"]): void => {
     document.documentElement.dataset.rpc = event.detail.status;
@@ -304,6 +306,7 @@ export function bootRenderer(): Disposer {
       );
     },
     credentialMutationsBlocked: () => onboardingCredentialMutationsBlocked(store.getState()),
+    codexAgentSupported: platform.capabilities.codexAgent,
   });
   store.getState().bindOnboardingActions(onboarding);
   const closePanes = (): void => {
@@ -366,6 +369,7 @@ export function bootRenderer(): Disposer {
     apply: (selection) => window.enduragentAuth.applyLlmSelection(selection),
     openSetup: openSetupFromSettings,
     beginMutation: () => store.getState().beginSettingsMutation("provider-model"),
+    codexAgentSupported: platform.capabilities.codexAgent,
     view: coachAdapter.view,
   });
   const telegramSettingsController = createTelegramSettingsController({

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -1,4 +1,5 @@
 interface EnduragentAuth {
+  readonly platform: DesktopPlatformProjection;
   getDaemonConnection(failedGeneration?: number): Promise<{
     readonly url: `ws://127.0.0.1:${number}/rpc`;
     readonly rendererCapability: string;
@@ -59,6 +60,8 @@ interface EnduragentAuth {
   restartToUpdate(): Promise<DesktopUpdateState>;
   onUpdateState(listener: (state: DesktopUpdateState) => void): () => void;
 }
+
+type DesktopPlatformProjection = import("./platform-copy").DesktopPlatformProjection;
 
 type DesktopTrainingExportRequest =
   | {

--- a/apps/desktop-renderer/src/onboarding/controller.ts
+++ b/apps/desktop-renderer/src/onboarding/controller.ts
@@ -155,6 +155,7 @@ export interface OnboardingControllerOptions {
   readonly credentialMutationsBlocked?: () => boolean;
   readonly createOperationId?: () => string;
   readonly afterPaint?: (callback: () => void) => () => void;
+  readonly codexAgentSupported?: boolean;
 }
 
 export const CHATGPT_PROGRESS_DETAIL_DELAY_MS = 3_000;
@@ -359,6 +360,7 @@ export function createOnboardingController(
 
   const activeProviderIsReady = (): boolean => {
     const active = llmConfiguration?.active ?? null;
+    if (active?.provider === "codex-agent" && options.codexAgentSupported === false) return false;
     return selectedProviderReady(state, active, active);
   };
 

--- a/apps/desktop-renderer/src/onboarding/credential-presentation.ts
+++ b/apps/desktop-renderer/src/onboarding/credential-presentation.ts
@@ -1,5 +1,6 @@
 import type { ClaudeCliState } from "./constants.js";
 import type { ClaudeCliStatus, CredentialSlotStatus } from "./machine.js";
+import { PLATFORM_COPY } from "../platform-copy.js";
 
 export const CLAUDE_CLI_API_KEY_IDENTITY =
   "Using Anthropic API key billing - usage is charged to your API account.";
@@ -34,14 +35,14 @@ const CLAUDE_CLI_PRESENTATION: Readonly<Record<ClaudeCliState, ClaudeCliPresenta
   disabled: {
     runtimeState: "stored-inactive",
     badge: "Turned off",
-    detail: "The Claude subscription lane is turned off on this Mac. Choose another provider.",
+    detail: `The Claude subscription lane is turned off on ${PLATFORM_COPY.computer}. Choose another provider.`,
   },
 };
 
 const CLAUDE_CLI_UNKNOWN_PRESENTATION: ClaudeCliPresentation = {
   runtimeState: "stored-inactive",
   badge: "Checking",
-  detail: "Checking the Claude Code CLI sign-in on this Mac…",
+  detail: `Checking the Claude Code CLI sign-in on ${PLATFORM_COPY.computer}…`,
 };
 
 export function claudeCliPresentation(state: ClaudeCliState | null): ClaudeCliPresentation {

--- a/apps/desktop-renderer/src/platform-copy.ts
+++ b/apps/desktop-renderer/src/platform-copy.ts
@@ -1,0 +1,42 @@
+export interface DesktopPlatformProjection {
+  readonly platform: "darwin" | "win32";
+  readonly capabilities: {
+    readonly codexAgent: boolean;
+  };
+  readonly copy: {
+    readonly computer: "this Mac" | "this PC";
+    readonly operatingSystem: "macOS" | "Windows";
+    readonly credentialEncryptionUnavailable: string;
+    readonly credentialRecoveryAction: string;
+    readonly restartComputer: "restart your Mac" | "restart your PC";
+  };
+}
+
+const DARWIN_FALLBACK: DesktopPlatformProjection = Object.freeze({
+  platform: "darwin",
+  capabilities: Object.freeze({ codexAgent: true }),
+  copy: Object.freeze({
+    computer: "this Mac",
+    operatingSystem: "macOS",
+    credentialEncryptionUnavailable:
+      "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
+    credentialRecoveryAction: "unlock or approve Keychain access",
+    restartComputer: "restart your Mac",
+  }),
+});
+
+export function rendererPlatformProjection(
+  projection?: DesktopPlatformProjection,
+): DesktopPlatformProjection {
+  if (projection !== undefined) return projection;
+  if (typeof window === "undefined") return DARWIN_FALLBACK;
+  return (
+    (
+      window as unknown as {
+        readonly enduragentAuth?: { readonly platform?: DesktopPlatformProjection };
+      }
+    ).enduragentAuth?.platform ?? DARWIN_FALLBACK
+  );
+}
+
+export const PLATFORM_COPY = rendererPlatformProjection().copy;

--- a/apps/desktop-renderer/src/settings/provider-model-controller.ts
+++ b/apps/desktop-renderer/src/settings/provider-model-controller.ts
@@ -25,6 +25,7 @@ export interface ProviderModelFormState {
   readonly providers: readonly OnboardingLlmProviderConfiguration[];
   readonly active: OnboardingLlmConfiguration["active"];
   readonly draft: ProviderModelDraft | null;
+  readonly providerChangeRequired: boolean;
   readonly dirty: boolean;
   readonly validationError: ProviderModelValidationError | null;
 }
@@ -117,11 +118,12 @@ function isDirty(
   return active.provider !== draft.provider.provider || active.model !== selectedModel(draft);
 }
 
-function formState(editable: EditableState): ProviderModelFormState {
+function formState(editable: EditableState, codexAgentSupported: boolean): ProviderModelFormState {
   return {
     providers: editable.providers,
     active: editable.active,
     draft: editable.draft,
+    providerChangeRequired: !codexAgentSupported && editable.active?.provider === "codex-agent",
     dirty: isDirty(editable.active, editable.draft),
     validationError: validationError(editable.draft),
   };
@@ -145,6 +147,7 @@ export function createProviderModelSettingsController(input: {
   readonly openSetup: () => void;
   readonly view: ProviderModelSettingsView;
   readonly beginMutation?: () => (() => void) | null;
+  readonly codexAgentSupported?: boolean;
 }): ProviderModelSettingsController {
   let currentState: ProviderModelSettingsState = { status: "closed" };
   let generation = 0;
@@ -190,11 +193,14 @@ export function createProviderModelSettingsController(input: {
           if (draft !== null) providerDrafts.set(draft.provider.provider, draft);
           render({
             status: "ready",
-            ...formState({
-              providers: configuration.providers,
-              active: configuration.active,
-              draft,
-            }),
+            ...formState(
+              {
+                providers: configuration.providers,
+                active: configuration.active,
+                draft,
+              },
+              input.codexAgentSupported ?? true,
+            ),
           });
         },
         () => {
@@ -230,7 +236,7 @@ export function createProviderModelSettingsController(input: {
     providerDrafts.set(draft.provider.provider, draft);
     render({
       status: "ready",
-      ...formState({ ...editable, draft }),
+      ...formState({ ...editable, draft }, input.codexAgentSupported ?? true),
     });
   };
 
@@ -271,7 +277,7 @@ export function createProviderModelSettingsController(input: {
     if (disposed || saveOperation !== undefined) return saveOperation ?? Promise.resolve();
     const editable = editableState(currentState);
     if (editable === null || currentState.status === "saving") return Promise.resolve();
-    const form = formState(editable);
+    const form = formState(editable, input.codexAgentSupported ?? true);
     if (form.draft === null || !form.dirty || form.validationError !== null) {
       return Promise.resolve();
     }
@@ -301,11 +307,14 @@ export function createProviderModelSettingsController(input: {
           const active = { provider: selection.provider, model: selection.model };
           render({
             status: "saved",
-            ...formState({
-              providers: form.providers,
-              active,
-              draft: form.draft,
-            }),
+            ...formState(
+              {
+                providers: form.providers,
+                active,
+                draft: form.draft,
+              },
+              input.codexAgentSupported ?? true,
+            ),
           });
         },
         () => {

--- a/apps/desktop-renderer/src/settings/telegram-controller.ts
+++ b/apps/desktop-renderer/src/settings/telegram-controller.ts
@@ -1,3 +1,5 @@
+import { PLATFORM_COPY } from "../platform-copy.js";
+
 export type TelegramControlErrorCode =
   | "telegram-invalid-token"
   | "telegram-polling-conflict"
@@ -264,11 +266,11 @@ function mutationFailureCopy(
   }
   if (result.reason === "encryption-unavailable") {
     if (action !== "paste-token") {
-      return "Secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, then choose Check again.";
+      return `Secure token storage is unavailable. Quit and reopen Enduragent, ${PLATFORM_COPY.credentialRecoveryAction}, then choose Check again.`;
     }
     return result.current.credentialConfigured
-      ? "The current Telegram bot is unchanged because secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, copy the bot token again, then retry."
-      : "Secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, copy the bot token again, then retry.";
+      ? `The current Telegram bot is unchanged because secure token storage is unavailable. Quit and reopen Enduragent, ${PLATFORM_COPY.credentialRecoveryAction}, copy the bot token again, then retry.`
+      : `Secure token storage is unavailable. Quit and reopen Enduragent, ${PLATFORM_COPY.credentialRecoveryAction}, copy the bot token again, then retry.`;
   }
   if (result.reason === "unsafe-backend") {
     if (action !== "paste-token") {
@@ -292,7 +294,7 @@ function mutationFailureCopy(
         return "Telegram could not verify the copied token right now. The current Telegram bot is unchanged.";
       case "webhook-removal-required":
         return result.current.bot.state === "webhook-removal-required"
-          ? "The copied bot still uses a webhook. Remove the webhook before pairing it with this Mac."
+          ? `The copied bot still uses a webhook. Remove the webhook before pairing it with ${PLATFORM_COPY.computer}.`
           : "The copied bot still uses a webhook. Remove the webhook, then delete the current connection and connect this bot.";
       case "storage-failed":
         return "The copied token could not be stored. The current Telegram bot is unchanged.";
@@ -329,7 +331,7 @@ function channelHealthCopy(status: TelegramControlStatus): string {
   if (status.channel.state === "online") return "Telegram is online.";
   if (status.channel.state === "starting") return "Telegram is connecting.";
   if (status.channel.state === "suspended") {
-    return "Telegram polling is paused while this Mac sleeps.";
+    return `Telegram polling is paused while ${PLATFORM_COPY.computer} sleeps.`;
   }
   if (status.channel.state === "disabled") return "Telegram is off.";
   if (status.channel.state === "waiting-for-credential") {
@@ -345,7 +347,7 @@ function channelHealthCopy(status: TelegramControlStatus): string {
     return "This bot is still owned by another Desktop installation. Delete the connection there before connecting it here.";
   }
   if (status.channel.state === "offline-retrying") {
-    return "Telegram is offline. Enduragent will keep trying while this Mac is awake and online.";
+    return `Telegram is offline. Enduragent will keep trying while ${PLATFORM_COPY.computer} is awake and online.`;
   }
   return "Telegram needs attention. Keep the app open, check the connection, and try again.";
 }
@@ -355,7 +357,7 @@ function resultCopy(action: TelegramSettingsAction, status: TelegramControlStatu
     return "Telegram reconnected after a long gap. Some messages may not have arrived.";
   }
   if (status.bot.state === "webhook-removal-required") {
-    return "Bot verified. Remove its webhook before pairing it with this Mac.";
+    return `Bot verified. Remove its webhook before pairing it with ${PLATFORM_COPY.computer}.`;
   }
   if (hasActiveTelegramPairingCode(status)) {
     return "Pairing code ready. Send it to the bot in Telegram.";
@@ -364,7 +366,7 @@ function resultCopy(action: TelegramSettingsAction, status: TelegramControlStatu
     return "Telegram is paired with its primary user.";
   }
   if (status.channel.state === "disabled" && action === "remove") {
-    return "Telegram connection deleted from this Mac.";
+    return `Telegram connection deleted from ${PLATFORM_COPY.computer}.`;
   }
   return channelHealthCopy(status);
 }
@@ -435,7 +437,7 @@ function pairingTransitionCopy(
   const previousBot = botUsername(previous.bot);
   const currentBot = botUsername(current.bot);
   if (previousBot !== currentBot) {
-    if (currentBot === null) return "Telegram connection deleted from this Mac.";
+    if (currentBot === null) return `Telegram connection deleted from ${PLATFORM_COPY.computer}.`;
     if (previousBot !== null || action === "paste-token") {
       return `Telegram connected to @${currentBot}. Pairing needs to be set up.`;
     }

--- a/apps/desktop-renderer/src/ui/chat/NewConversationDialog.tsx
+++ b/apps/desktop-renderer/src/ui/chat/NewConversationDialog.tsx
@@ -1,12 +1,12 @@
 import { useLayoutEffect, useRef, type ReactElement } from "react";
+import { PLATFORM_COPY } from "../../platform-copy.js";
 import { focusNewConversationOpener } from "../../state/new-conversation-opener.js";
 import { useEnduragentStore } from "../../state/store.js";
 import styles from "./NewConversationDialog.module.css";
 
 const BASE_COPY =
   "Your visible conversation will be cleared. Your training data and saved coach memory will remain.";
-const HYDRATED_COPY =
-  "Your visible conversation and the earlier messages restored on this Mac will be cleared. Your training data and saved coach memory will remain.";
+const HYDRATED_COPY = `Your visible conversation and the earlier messages restored on ${PLATFORM_COPY.computer} will be cleared. Your training data and saved coach memory will remain.`;
 
 export function NewConversationDialog(props: {
   readonly onComposerReset: () => void;

--- a/apps/desktop-renderer/src/ui/onboarding/TelegramRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/TelegramRow.tsx
@@ -4,6 +4,7 @@ import type {
   TelegramSettingsFeedback,
   TelegramSettingsState,
 } from "../../settings/telegram-controller.js";
+import { PLATFORM_COPY } from "../../platform-copy.js";
 import { settingsMutationActive, type TelegramSettingsPort } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
 import {
@@ -73,7 +74,7 @@ function fallbackFeedback(action: TelegramAction): TelegramSettingsFeedback {
     message:
       action === "paste-token"
         ? "The copied token was not applied. The current Telegram bot is unchanged."
-        : "The Telegram connection was not deleted from this Mac.",
+        : `The Telegram connection was not deleted from ${PLATFORM_COPY.computer}.`,
   };
 }
 

--- a/apps/desktop-renderer/src/ui/onboarding/copy.ts
+++ b/apps/desktop-renderer/src/ui/onboarding/copy.ts
@@ -1,13 +1,13 @@
 import type { ChatGptLoginRefusalReason } from "../../onboarding/constants.js";
 import type { SetupLane } from "../../onboarding/lanes.js";
 import type { ChatGptUiPhase, OnboardingErrorCode } from "../../onboarding/machine.js";
+import { PLATFORM_COPY } from "../../platform-copy.js";
 
 export const ERROR_COPY: Readonly<Record<OnboardingErrorCode, string>> = {
   "credential-required": "Sign in with ChatGPT or add at least one model key to continue.",
   "credential-save-failed": "That key could not be saved. Try entering it again.",
   "invalid-input": "That key was not accepted. Check it and enter it again.",
-  "encryption-unavailable":
-    "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
+  "encryption-unavailable": PLATFORM_COPY.credentialEncryptionUnavailable,
   "unsafe-backend": "The app cannot safely store that key with the current storage backend.",
   "storage-failed":
     "The app could not confirm that key was saved securely. Check that secure storage is available and try again.",
@@ -34,8 +34,7 @@ export const ERROR_COPY: Readonly<Record<OnboardingErrorCode, string>> = {
     "Intervals.icu didn’t accept the copied API key. Copy a current API key, then try again.",
   "intervals-validation-unavailable":
     "Enduragent couldn’t verify the copied API key with Intervals.icu. Check your connection, then try again.",
-  "intervals-owner-unavailable":
-    "Enduragent couldn’t confirm that the copied API key matches the training data on this Mac. Try again when training data is available.",
+  "intervals-owner-unavailable": `Enduragent couldn’t confirm that the copied API key matches the training data on ${PLATFORM_COPY.computer}. Try again when training data is available.`,
   "intervals-storage-uncertain":
     "Enduragent couldn’t confirm whether the copied API key was saved. Reload credential status before trying again.",
   "intervals-runtime-unavailable":
@@ -47,8 +46,7 @@ export const ERROR_COPY: Readonly<Record<OnboardingErrorCode, string>> = {
   "intake-save-failed": "Your answers could not be saved. Please try again.",
 };
 
-export const CLAUDE_CLI_LANE_COPY =
-  "Uses the Claude Code CLI already installed and signed in on this Mac. No API key needed.";
+export const CLAUDE_CLI_LANE_COPY = `Uses the Claude Code CLI already installed and signed in on ${PLATFORM_COPY.computer}. No API key needed.`;
 
 export const CLAUDE_CLI_RECHECK_LABEL = "Check again";
 
@@ -83,7 +81,7 @@ export const SETUP_LANE_LABELS = {
 } as const satisfies Readonly<Record<SetupLane, string>>;
 
 export const SETUP_LANE_MENU_HINTS = {
-  "claude-cli": "Detected on this Mac",
+  "claude-cli": `Detected on ${PLATFORM_COPY.computer}`,
   "openai-codex": "Use the plan you already pay for",
   "api-key": "9 providers · pay per use",
 } as const satisfies Readonly<Record<SetupLane, string>>;
@@ -120,7 +118,7 @@ export const AI_PANEL_ANNOUNCEMENTS = {
 export const AI_ROW_TOOLTIP = {
   label: "About the AI that powers your coach",
   lead: "Enduragent has no AI of its own",
-  body: "It runs on a ChatGPT subscription, a Claude Code sign-in, or an API key you supply. Whichever you pick stays on this Mac.",
+  body: `It runs on a ChatGPT subscription, a Claude Code sign-in, or an API key you supply. Whichever you pick stays on ${PLATFORM_COPY.computer}.`,
 } as const;
 
 export const CHATGPT_SIGN_IN_LABEL = "Sign in with ChatGPT";
@@ -180,8 +178,7 @@ export const TELEGRAM_ROW_TITLE = "Telegram";
 
 export const TELEGRAM_OPTIONAL_LABEL = "Optional";
 
-export const TELEGRAM_AVAILABILITY_COPY =
-  "Telegram works while Enduragent is running and this Mac is awake and online.";
+export const TELEGRAM_AVAILABILITY_COPY = `Telegram works while Enduragent is running and ${PLATFORM_COPY.computer} is awake and online.`;
 
 export const TELEGRAM_VERIFIED_PREFIX = "Bot verified";
 
@@ -194,14 +191,13 @@ export const TELEGRAM_CREATE_COPY = `Ask @BotFather ${TELEGRAM_CREATE_COPY_AFTER
 
 export const TELEGRAM_DELETE_TITLE = "Delete the Telegram connection?";
 
-export const TELEGRAM_DELETE_COPY =
-  "This turns Telegram off and deletes the encrypted token and allowed-user access from this Mac. The Telegram bot and chat remain in Telegram.";
+export const TELEGRAM_DELETE_COPY = `This turns Telegram off and deletes the encrypted token and allowed-user access from ${PLATFORM_COPY.computer}. The Telegram bot and chat remain in Telegram.`;
 
 export const RETRY_SAVED_KEYS_LABEL = "Retry saved keys";
 
 export const RETRY_INTAKE_SAVE_LABEL = "Retry saving answers";
 
-export const FOOTER_NOTE = "Everything stays on this Mac.";
+export const FOOTER_NOTE = `Everything stays on ${PLATFORM_COPY.computer}.`;
 
 export const OUTSTANDING_NOTE = {
   coach: "Choose what powers your coach to finish.",

--- a/apps/desktop-renderer/src/ui/settings/CoachSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CoachSection.tsx
@@ -81,8 +81,15 @@ export function CoachSection(): ReactElement {
   const feedback = feedbackCopy(state);
   const routeSummary = editable === null ? null : routeLabel(editable);
   const route = routeSummary ?? "Not configured";
+  const providerChangeRequired = editable?.providerChangeRequired === true;
   const routeState =
-    routeSummary === null ? "Not active" : editable?.dirty === true ? "Unsaved" : "Active";
+    routeSummary === null
+      ? "Not active"
+      : providerChangeRequired
+        ? "Change required"
+        : editable?.dirty === true
+          ? "Unsaved"
+          : "Active";
   const validation =
     editable?.validationError == null ? "" : COACH_VALIDATION_COPY[editable.validationError];
 
@@ -95,12 +102,22 @@ export function CoachSection(): ReactElement {
             <div className={styles.rowTitle}>Coach route</div>
             <div className={styles.rowDetail}>{route}</div>
           </div>
-          <span className={styles.runtime} data-state={routeSummary === null ? "failed" : "active"}>
+          <span
+            className={styles.runtime}
+            data-state={routeSummary === null || providerChangeRequired ? "failed" : "active"}
+          >
             {routeState}
           </span>
         </div>
         {editable === null ? null : (
           <>
+            {providerChangeRequired ? (
+              <p className={styles.feedback} role="alert">
+                Codex agent isn’t supported on Windows. Choose Claude subscription or an API-key
+                provider, then save the coach route. Your credentials, athlete data, conversations,
+                and other settings stay unchanged.
+              </p>
+            ) : null}
             <div className={styles.row}>
               <label className={styles.label} htmlFor="coach-provider">
                 <span className={styles.rowTitle}>Provider</span>

--- a/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
@@ -3,6 +3,7 @@ import type { DesktopCredentialId } from "../../onboarding/bridge.js";
 import { DESKTOP_CREDENTIAL_SLOTS } from "../../onboarding/constants.js";
 import { onboardingCredentialMutationActive } from "../../onboarding/controller.js";
 import { claudeCliPresentation } from "../../onboarding/credential-presentation.js";
+import { PLATFORM_COPY } from "../../platform-copy.js";
 import type {
   CredentialSettingsEntry,
   CredentialSettingsState,
@@ -154,8 +155,8 @@ export function CredentialDeleteConfirmation(props: {
       }
       copy={
         intervals
-          ? "Your saved API key and imported connection will be removed. Your synced rides and past chats stay on this Mac."
-          : "This removes it from this Mac only. Enduragent will stop using it if it is active. Your provider account is unchanged."
+          ? `Your saved API key and imported connection will be removed. Your synced rides and past chats stay on ${PLATFORM_COPY.computer}.`
+          : `This removes it from ${PLATFORM_COPY.computer} only. Enduragent will stop using it if it is active. Your provider account is unchanged.`
       }
       confirmLabel={intervals ? "Delete connection" : "Delete credential"}
       {...(intervals

--- a/apps/desktop-renderer/src/ui/settings/PreferencesSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/PreferencesSection.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { PLATFORM_COPY } from "../../platform-copy.js";
 import { useEnduragentStore } from "../../state/store.js";
 import { AppearanceControl } from "./AppearanceControl.js";
 import { PalettePicker } from "./PalettePicker.js";
@@ -28,7 +29,9 @@ export function PreferencesSection(): ReactElement {
         <div className={styles.row}>
           <div className={styles.label}>
             <div className={styles.rowTitle}>Appearance</div>
-            <div className={styles.rowDetail}>System follows your macOS light and dark setting</div>
+            <div className={styles.rowDetail}>
+              System follows your {PLATFORM_COPY.operatingSystem} light and dark setting
+            </div>
           </div>
           <AppearanceControl />
         </div>

--- a/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
@@ -11,6 +11,7 @@ import {
   type TelegramControlStatus,
   type TelegramSettingsState,
 } from "../../settings/telegram-controller.js";
+import { PLATFORM_COPY } from "../../platform-copy.js";
 import { settingsMutationActive } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
 import {
@@ -80,7 +81,7 @@ function attentionCopy(status: TelegramControlStatus): string | null {
   }
   if (status.channel.state === "failed") {
     if (status.channel.errorCode === "telegram-credential-encryption-unavailable") {
-      return "Secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, then choose Check again.";
+      return `Secure token storage is unavailable. Quit and reopen Enduragent, ${PLATFORM_COPY.credentialRecoveryAction}, then choose Check again.`;
     }
     if (status.channel.errorCode === "telegram-credential-unsafe-backend") {
       return "No secure credential backend is available, so Enduragent refused to access the saved bot token without encryption. Quit and reopen Enduragent, then choose Check again.";
@@ -106,7 +107,7 @@ function attentionCopy(status: TelegramControlStatus): string | null {
     return "Telegram could not start. Keep Enduragent open, check the internet connection, then choose Check again.";
   }
   if (status.channel.state === "offline-retrying") {
-    return "Telegram is temporarily offline. Enduragent will retry while this Mac is awake and online.";
+    return `Telegram is temporarily offline. Enduragent will retry while ${PLATFORM_COPY.computer} is awake and online.`;
   }
   return null;
 }
@@ -259,15 +260,15 @@ export function TelegramSection(): ReactElement {
           )}
         </div>
         <p className="m-0 border-b border-line px-4 py-[13px] text-[13px] text-ink-2">
-          Telegram works only while Enduragent and its local coaching service are running, and this
-          Mac is awake and online.
+          Telegram works only while Enduragent and its local coaching service are running, and{" "}
+          {PLATFORM_COPY.computer} is awake and online.
         </p>
         <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
           {healthAnnouncement}
         </span>
         {telegram?.channel.state === "suspended" ? (
           <p className="m-0 border-b border-line px-4 py-[13px] text-[13px] text-ink-2">
-            Telegram polling resumes when this Mac wakes.
+            Telegram polling resumes when {PLATFORM_COPY.computer} wakes.
           </p>
         ) : null}
 
@@ -476,8 +477,8 @@ export function TelegramSection(): ReactElement {
         {telegram?.credentialConfigured === true && botUsername !== null && confirmRemove ? (
           <InlineConfirmation
             name="delete-telegram"
-            title={`Delete @${botUsername} from this Mac?`}
-            copy="This turns the bot off, deletes its encrypted token and allowed-user access from this Mac. The Telegram bot and its chat remain in Telegram."
+            title={`Delete @${botUsername} from ${PLATFORM_COPY.computer}?`}
+            copy={`This turns the bot off, deletes its encrypted token and allowed-user access from ${PLATFORM_COPY.computer}. The Telegram bot and its chat remain in Telegram.`}
             confirmLabel="Delete connection"
             focusTarget={null}
             cancelDisabled={busy}
@@ -498,8 +499,8 @@ export function TelegramSection(): ReactElement {
             <div>
               <p className={CONFIRMATION_TITLE_CLASS}>Remove the existing webhook</p>
               <p className={CONFIRMATION_COPY_CLASS}>
-                Telegram cannot deliver to a webhook and this Mac at the same time. This explicit
-                action keeps pending updates and lets Desktop begin polling.
+                Telegram cannot deliver to a webhook and {PLATFORM_COPY.computer} at the same time.
+                This explicit action keeps pending updates and lets Desktop begin polling.
               </p>
             </div>
             <button
@@ -556,7 +557,7 @@ export function TelegramSection(): ReactElement {
               <div className={ROW_TITLE_CLASS}>Pair the primary user</div>
               <div className={ROW_DETAIL_CLASS}>
                 {pairingFailure ??
-                  "A one-minute code ensures only the person with access to this Mac can claim the bot."}
+                  `A one-minute code ensures only the person with access to ${PLATFORM_COPY.computer} can claim the bot.`}
               </div>
             </div>
             <button

--- a/apps/desktop-renderer/tests/onboarding-harness.tsx
+++ b/apps/desktop-renderer/tests/onboarding-harness.tsx
@@ -91,6 +91,7 @@ export function mountWizard(input: {
   readonly createOperationId?: () => string;
   readonly afterPaint?: (callback: () => void) => () => void;
   readonly placement?: "chat" | "settings";
+  readonly codexAgentSupported?: boolean;
 }): MountedWizard {
   const focusOpener = vi.fn<() => void>();
   const adapter = createOnboardingViewAdapter({
@@ -113,6 +114,9 @@ export function mountWizard(input: {
       ? {}
       : { createOperationId: input.createOperationId }),
     ...(input.afterPaint === undefined ? {} : { afterPaint: input.afterPaint }),
+    ...(input.codexAgentSupported === undefined
+      ? {}
+      : { codexAgentSupported: input.codexAgentSupported }),
   });
   useEnduragentStore.getState().bindOnboardingActions(controller);
   const rendered = render(

--- a/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
@@ -211,6 +211,26 @@ describe("setup card", () => {
     wizard.controller.dispose();
   });
 
+  it("does not treat an active Codex-agent profile as ready when Windows excludes it", async () => {
+    const bridge = readyEverythingBridge();
+    bridge.llmConfiguration.mockResolvedValue({
+      ...CLAUDE_CONFIGURATION,
+      active: { provider: "codex-agent", model: "synthetic-codex" },
+    });
+    const wizard = mountWizard({
+      bridge,
+      placement: "settings",
+      codexAgentSupported: false,
+    });
+    await wizard.open();
+
+    expect(rowState("ai")).toBe("pending");
+    expect(useEnduragentStore.getState().onboarding.readiness.provider).toBe(false);
+    expect(setupRow("ai").textContent).toContain("Required — Enduragent doesn't include one");
+    expect(screen.getByRole("button", { name: "Choose what powers your coach" })).toBeEnabled();
+    wizard.controller.dispose();
+  });
+
   it("keeps the completion footer in Chat and omits it from Settings", async () => {
     const chat = mountWizard({ bridge: readyEverythingBridge() });
     await chat.open();

--- a/apps/desktop-renderer/tests/provider-model-settings.test.ts
+++ b/apps/desktop-renderer/tests/provider-model-settings.test.ts
@@ -94,6 +94,7 @@ function createSubject(input: {
   readonly load?: () => Promise<OnboardingLlmConfiguration>;
   readonly apply?: () => Promise<OnboardingLlmSelectionResult>;
   readonly openSetup?: () => void;
+  readonly codexAgentSupported?: boolean;
 }) {
   const subject = fakeView();
   const load = input.load ?? vi.fn(async () => configuration());
@@ -104,6 +105,9 @@ function createSubject(input: {
     load,
     apply,
     openSetup: input.openSetup ?? vi.fn(),
+    ...(input.codexAgentSupported === undefined
+      ? {}
+      : { codexAgentSupported: input.codexAgentSupported }),
     view: subject.view,
   });
   return { controller, subject, load, apply };
@@ -222,6 +226,34 @@ describe("provider and model settings controller", () => {
     });
     expect(formState(controller)).toMatchObject({
       active: { provider: "openai", model: "gpt-standard" },
+      dirty: false,
+    });
+  });
+
+  it("requires a provider change when Windows reports Codex agent unsupported", async () => {
+    const { controller, subject, apply } = createSubject({
+      load: vi.fn(async () => configuration({ provider: "codex-agent", model: "gpt-codex" })),
+      codexAgentSupported: false,
+    });
+
+    await controller.activate();
+    expect(formState(controller)).toMatchObject({
+      active: { provider: "codex-agent", model: "gpt-codex" },
+      draft: null,
+      providerChangeRequired: true,
+    });
+
+    subject.provider("anthropic");
+    subject.save();
+    await vi.waitFor(() => expect(controller.state().status).toBe("saved"));
+    expect(apply).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "claude-sonnet",
+      endpoint: { mode: "automatic" },
+    });
+    expect(formState(controller)).toMatchObject({
+      active: { provider: "anthropic", model: "claude-sonnet" },
+      providerChangeRequired: false,
       dirty: false,
     });
   });

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -180,6 +180,7 @@ interface HarnessOptions {
   readonly updateState?: DesktopUpdateState;
   readonly spend?: () => Promise<SpendSummary>;
   readonly telegram?: TelegramControlStatus;
+  readonly codexAgentSupported?: boolean;
 }
 
 function createHarness(options: HarnessOptions = {}) {
@@ -303,6 +304,9 @@ function createHarness(options: HarnessOptions = {}) {
     apply: applyLlmSelection,
     openSetup,
     beginMutation: () => store.getState().beginSettingsMutation("provider-model"),
+    ...(options.codexAgentSupported === undefined
+      ? {}
+      : { codexAgentSupported: options.codexAgentSupported }),
     view: coachAdapter.view,
   });
   const appliedTelegram = (current: TelegramControlStatus) =>
@@ -519,9 +523,7 @@ describe("settings setup inventory", () => {
       async (): Promise<readonly CredentialSlotStatus[]> => [
         { slot: "anthropic", state: "configured", runtimeState: "active" },
         ...(intervalsConnected
-          ? ([
-              { slot: "intervals-icu", state: "configured", runtimeState: "active" },
-            ] as const)
+          ? ([{ slot: "intervals-icu", state: "configured", runtimeState: "active" }] as const)
           : []),
       ],
     );
@@ -1555,6 +1557,37 @@ describe("coach route", () => {
       coach.getByText("Currently active: Codex agent (experimental) · synthetic-codex"),
     ).toBeInTheDocument();
     expect(coach.queryByText("Not configured")).toBeNull();
+  });
+
+  it("requires a supported provider change for an active Windows Codex-agent profile", async () => {
+    const user = userEvent.setup();
+    const subject = await renderSettings({
+      codexAgentSupported: false,
+      llm: () => ({
+        ...llmConfiguration(),
+        active: { provider: "codex-agent", model: "synthetic-codex" },
+      }),
+    });
+
+    const coach = within(screen.getByRole("region", { name: "Coach" }));
+    expect(coach.getByText("Change required")).toHaveAttribute("data-state", "failed");
+    expect(coach.getByRole("alert")).toHaveTextContent("Codex agent isn’t supported on Windows");
+    expect(coach.getByRole("alert")).toHaveTextContent(
+      "credentials, athlete data, conversations, and other settings stay unchanged",
+    );
+
+    await user.selectOptions(coach.getByRole("combobox", { name: /Provider/u }), "anthropic");
+    await user.click(coach.getByRole("button", { name: "Save coach route" }));
+    await screen.findByText("Coach settings saved.");
+
+    expect(subject.applyLlmSelection).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "synthetic-model",
+      endpoint: { mode: "automatic" },
+    });
+    expect(subject.deleteCredential).not.toHaveBeenCalled();
+    expect(coach.getByText("Active")).toHaveAttribute("data-state", "active");
+    expect(coach.queryByText("Change required")).toBeNull();
   });
 
   it("marks the route not configured when no provider is active", async () => {

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -314,6 +314,7 @@ async function security() {
             "onUpdateState",
             "pasteIntervalsApiKeyFromClipboard",
             "pasteTelegramTokenFromClipboard",
+            "platform",
             "reconcileTelegram",
             "releaseNotes",
             "removeTelegram",

--- a/apps/desktop/scripts/windows-parity-scenarios.d.mts
+++ b/apps/desktop/scripts/windows-parity-scenarios.d.mts
@@ -1,0 +1,57 @@
+export type WindowsParityScenario =
+  | {
+      readonly id: string;
+      readonly surface: string;
+      readonly expected: string;
+      readonly automation: "deterministic";
+      readonly test: string;
+    }
+  | {
+      readonly id: string;
+      readonly surface: string;
+      readonly expected: string;
+      readonly automation: "deterministic";
+      readonly tests: readonly string[];
+    }
+  | {
+      readonly id: string;
+      readonly surface: string;
+      readonly expected: string;
+      readonly automation: "vm-only";
+    };
+
+export type WindowsParityScenarioManifestStage =
+  | "configuration"
+  | "read"
+  | "size"
+  | "parse"
+  | "schema"
+  | "duplicate-id";
+
+export class WindowsParityScenarioManifestError extends Error {
+  readonly stage: WindowsParityScenarioManifestStage;
+  constructor(stage: WindowsParityScenarioManifestStage);
+}
+
+export interface WindowsParityScenarioLoaderInput {
+  readonly directory?: string;
+  readonly manifestNames?: readonly string[];
+}
+
+export interface WindowsParityScenarioLoaderDependencies {
+  readonly readFile?: (path: string, encoding: "utf8") => Promise<string>;
+}
+
+export interface WindowsParityScenarioCollection {
+  readonly schemaVersion: 1;
+  readonly manifests: readonly string[];
+  readonly scenarios: readonly WindowsParityScenario[];
+}
+
+export const WINDOWS_PARITY_SCENARIO_MANIFEST_MAX_BYTES: 1048576;
+export const DEFAULT_WINDOWS_PARITY_SCENARIO_MANIFESTS: readonly ["chat-settings.scenarios.json"];
+
+export function loadWindowsParityScenarios(
+  input?: WindowsParityScenarioLoaderInput,
+  dependencies?: WindowsParityScenarioLoaderDependencies,
+): Promise<WindowsParityScenarioCollection>;

--- a/apps/desktop/scripts/windows-parity-scenarios.mjs
+++ b/apps/desktop/scripts/windows-parity-scenarios.mjs
@@ -1,0 +1,169 @@
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const canonicalManifestDirectory = resolve(scriptDirectory, "../tests/fixtures/windows-parity");
+const manifestNamePattern = /^[a-z][a-z0-9-]*\.scenarios\.json$/u;
+const scenarioIdPattern = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/u;
+const surfacePattern = /^[a-z][a-z0-9-]*$/u;
+
+export const WINDOWS_PARITY_SCENARIO_MANIFEST_MAX_BYTES = 1_048_576;
+export const DEFAULT_WINDOWS_PARITY_SCENARIO_MANIFESTS = Object.freeze([
+  "chat-settings.scenarios.json",
+]);
+
+export class WindowsParityScenarioManifestError extends Error {
+  constructor(stage) {
+    super(`windows-parity scenario manifest rejected at ${stage}`);
+    this.name = "WindowsParityScenarioManifestError";
+    this.stage = stage;
+  }
+}
+
+function reject(stage) {
+  throw new WindowsParityScenarioManifestError(stage);
+}
+
+function record(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function exactKeys(value, keys) {
+  return JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+}
+
+function boundedText(value) {
+  if (typeof value !== "string" || value.length === 0 || value.trim() !== value) return false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return false;
+  }
+  return true;
+}
+
+function boundedTests(value) {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(boundedText) &&
+    new Set(value).size === value.length
+  );
+}
+
+function configuredManifestNames(value) {
+  if (!Array.isArray(value) || value.length === 0) reject("configuration");
+  const names = value.map((name) => {
+    if (typeof name !== "string" || !manifestNamePattern.test(name)) reject("configuration");
+    return name;
+  });
+  if (new Set(names).size !== names.length) reject("configuration");
+  return names;
+}
+
+function parseScenario(value) {
+  if (!record(value) || typeof value.automation !== "string") reject("schema");
+  const hasTest = Object.hasOwn(value, "test");
+  const hasTests = Object.hasOwn(value, "tests");
+  if (value.automation === "deterministic" && hasTest === hasTests) reject("schema");
+  const expectedKeys =
+    value.automation === "deterministic"
+      ? ["automation", "expected", "id", "surface", hasTest ? "test" : "tests"]
+      : value.automation === "vm-only"
+        ? ["automation", "expected", "id", "surface"]
+        : reject("schema");
+  if (!exactKeys(value, expectedKeys)) reject("schema");
+  if (
+    !boundedText(value.id) ||
+    !scenarioIdPattern.test(value.id) ||
+    !boundedText(value.surface) ||
+    !surfacePattern.test(value.surface) ||
+    !boundedText(value.expected)
+  ) {
+    reject("schema");
+  }
+  if (
+    value.automation === "deterministic" &&
+    ((hasTest && !boundedText(value.test)) || (hasTests && !boundedTests(value.tests)))
+  ) {
+    reject("schema");
+  }
+  return Object.freeze(
+    value.automation === "deterministic"
+      ? hasTest
+        ? {
+            id: value.id,
+            surface: value.surface,
+            expected: value.expected,
+            automation: value.automation,
+            test: value.test,
+          }
+        : {
+            id: value.id,
+            surface: value.surface,
+            expected: value.expected,
+            automation: value.automation,
+            tests: Object.freeze([...value.tests]),
+          }
+      : {
+          id: value.id,
+          surface: value.surface,
+          expected: value.expected,
+          automation: value.automation,
+        },
+  );
+}
+
+function parseManifest(source) {
+  let value;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    reject("parse");
+  }
+  if (
+    !record(value) ||
+    !exactKeys(value, ["schemaVersion", "scenarios"]) ||
+    value.schemaVersion !== 1 ||
+    !Array.isArray(value.scenarios) ||
+    value.scenarios.length === 0
+  ) {
+    reject("schema");
+  }
+  return value.scenarios.map(parseScenario);
+}
+
+export async function loadWindowsParityScenarios(input = {}, dependencies = {}) {
+  const directory = input.directory ?? canonicalManifestDirectory;
+  if (!isAbsolute(directory)) reject("configuration");
+  const manifestNames = configuredManifestNames(
+    input.manifestNames ?? DEFAULT_WINDOWS_PARITY_SCENARIO_MANIFESTS,
+  );
+  const read = dependencies.readFile ?? readFile;
+  const scenarios = [];
+  const ids = new Set();
+  for (const manifestName of manifestNames) {
+    let source;
+    try {
+      source = await read(join(directory, manifestName), "utf8");
+    } catch {
+      reject("read");
+    }
+    if (
+      typeof source !== "string" ||
+      Buffer.byteLength(source, "utf8") > WINDOWS_PARITY_SCENARIO_MANIFEST_MAX_BYTES
+    ) {
+      reject("size");
+    }
+    for (const scenario of parseManifest(source)) {
+      if (ids.has(scenario.id)) reject("duplicate-id");
+      ids.add(scenario.id);
+      scenarios.push(scenario);
+    }
+  }
+  return Object.freeze({
+    schemaVersion: 1,
+    manifests: Object.freeze([...manifestNames]),
+    scenarios: Object.freeze(scenarios),
+  });
+}

--- a/apps/desktop/src/main/lifecycle-messages.ts
+++ b/apps/desktop/src/main/lifecycle-messages.ts
@@ -1,5 +1,6 @@
 import type { DesktopDaemonResolution } from "@enduragent/coach/enduragent";
 import type { DesktopDaemonLifecycleState } from "./daemon-lifecycle.js";
+import { desktopPlatformProjection } from "./platform-copy.js";
 
 export interface DesktopErrorCopy {
   readonly title: string;
@@ -8,6 +9,7 @@ export interface DesktopErrorCopy {
 
 export function startupRefusalCopy(
   cause: Extract<DesktopDaemonResolution, { status: "refused" }>["cause"],
+  platform: NodeJS.Platform = process.platform,
 ): DesktopErrorCopy {
   if (cause === "not-configured") {
     return {
@@ -45,8 +47,7 @@ export function startupRefusalCopy(
   }
   return {
     title: "Enduragent couldn’t start its background service",
-    content:
-      "The background service could not start or its saved connection state could not be read. Quit Enduragent and reopen it. If the problem continues, restart your Mac before trying again.",
+    content: `The background service could not start or its saved connection state could not be read. Quit Enduragent and reopen it. If the problem continues, ${desktopPlatformProjection(platform).copy.restartComputer} before trying again.`,
   };
 }
 

--- a/apps/desktop/src/main/platform-copy.ts
+++ b/apps/desktop/src/main/platform-copy.ts
@@ -1,0 +1,45 @@
+export interface DesktopPlatformProjection {
+  readonly platform: "darwin" | "win32";
+  readonly capabilities: {
+    readonly codexAgent: boolean;
+  };
+  readonly copy: {
+    readonly computer: "this Mac" | "this PC";
+    readonly operatingSystem: "macOS" | "Windows";
+    readonly credentialEncryptionUnavailable: string;
+    readonly credentialRecoveryAction: string;
+    readonly restartComputer: "restart your Mac" | "restart your PC";
+  };
+}
+
+const DARWIN_PLATFORM_PROJECTION: DesktopPlatformProjection = Object.freeze({
+  platform: "darwin",
+  capabilities: Object.freeze({ codexAgent: true }),
+  copy: Object.freeze({
+    computer: "this Mac",
+    operatingSystem: "macOS",
+    credentialEncryptionUnavailable:
+      "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
+    credentialRecoveryAction: "unlock or approve Keychain access",
+    restartComputer: "restart your Mac",
+  }),
+});
+
+const WINDOWS_PLATFORM_PROJECTION: DesktopPlatformProjection = Object.freeze({
+  platform: "win32",
+  capabilities: Object.freeze({ codexAgent: false }),
+  copy: Object.freeze({
+    computer: "this PC",
+    operatingSystem: "Windows",
+    credentialEncryptionUnavailable:
+      "Windows credential encryption (DPAPI) is unavailable. Quit and reopen Enduragent, then try again.",
+    credentialRecoveryAction: "make sure Windows credential encryption (DPAPI) is available",
+    restartComputer: "restart your PC",
+  }),
+});
+
+export function desktopPlatformProjection(
+  platform: NodeJS.Platform = process.platform,
+): DesktopPlatformProjection {
+  return platform === "win32" ? WINDOWS_PLATFORM_PROJECTION : DARWIN_PLATFORM_PROJECTION;
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
+import { desktopPlatformProjection } from "../main/platform-copy.js";
 import {
   DESKTOP_CONNECTION_CHANNEL,
   DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL,
@@ -1424,6 +1425,7 @@ ipcRenderer.on(DESKTOP_CHATGPT_LOGIN_PROGRESS_CHANNEL, (_event, value: unknown) 
 contextBridge.exposeInMainWorld(
   "enduragentAuth",
   Object.freeze({
+    platform: desktopPlatformProjection(),
     getDaemonConnection: (failedGeneration?: number) => {
       if (
         failedGeneration !== undefined &&

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1066,6 +1066,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "onUpdateState",
         "pasteIntervalsApiKeyFromClipboard",
         "pasteTelegramTokenFromClipboard",
+        "platform",
         "reconcileTelegram",
         "releaseNotes",
         "removeTelegram",

--- a/apps/desktop/tests/fixtures/windows-parity/chat-settings.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/chat-settings.scenarios.json
@@ -1,0 +1,320 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "chat.send.keyboard",
+      "surface": "chat",
+      "expected": "Enter sends a nonblank draft, Shift+Enter inserts a newline, and blank drafts do not send.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-surface.test.tsx > composer > keeps Shift+Enter as a newline and ignores blank drafts"
+    },
+    {
+      "id": "chat.send.ime-composition",
+      "surface": "chat",
+      "expected": "An Enter key event never submits while an IME composition is in progress.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-surface.test.tsx > composer > never submits while an IME composition is in flight"
+    },
+    {
+      "id": "chat.streaming.ordered",
+      "surface": "chat",
+      "expected": "The coach response streams ordered deltas immediately and settles once to the canonical final text.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-controller.test.ts > renders ordered deltas immediately and canonical final text once without turn-start"
+    },
+    {
+      "id": "chat.streaming.type-ahead",
+      "surface": "chat",
+      "expected": "The composer remains enabled while a coach turn streams so the athlete can type and submit the next message.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-surface.test.tsx > composer > keeps sending available while a turn streams so the message can queue"
+    },
+    {
+      "id": "chat.streaming.interruption-retry",
+      "surface": "chat",
+      "expected": "An interrupted turn preserves partial coach text and the athlete message, then offers an explicit retry without duplicating the athlete row.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-controller.test.ts > preserves a disconnected draft and retries explicitly without duplicating the user row"
+    },
+    {
+      "id": "chat.queue.drain",
+      "surface": "chat",
+      "expected": "A message sent during streaming is shown as queued and dispatches exactly once after the active turn succeeds.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-controller.test.ts > queues a message sent while the coach streams and dispatches it once the turn settles"
+    },
+    {
+      "id": "chat.queue.coalescing",
+      "surface": "chat",
+      "expected": "Queued free text coalesces into one next turn while each queued slash command remains its own turn.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-controller.test.ts > coalesces queued free text into one turn and keeps each command on its own turn"
+    },
+    {
+      "id": "chat.queue.hold-and-remove",
+      "surface": "chat",
+      "expected": "Queued messages remain held after a failed or interrupted turn and each queued item can be removed before dispatch.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-controller.test.ts > keeps a queued message un-drained after a failed turn and removes it on request"
+    },
+    {
+      "id": "chat.commands.slash-picker",
+      "surface": "chat",
+      "expected": "The slash picker filters the shipped /start, /plan, /workout, /status, /review, /sync, /version, /whatsnew, and /update commands and supports keyboard or click selection without sending on selection.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-surface.test.tsx > slash command picker > moves the selection with the arrow keys and accepts with Enter"
+    },
+    {
+      "id": "chat.commands.quick-actions",
+      "surface": "chat",
+      "expected": "Quick actions submit the shipped plan, workout, status, and review commands and restore keyboard focus after the turn settles.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-surface.test.tsx > composer > restores focus to a keyboard-activated quick action once the turn settles"
+    },
+    {
+      "id": "chat.history.current-conversation",
+      "surface": "chat",
+      "expected": "The current conversation hydrates saved turns, offers earlier pages only when available, and automatically requests an earlier page at the scroll top.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-surface.test.tsx > history controls > auto-loads earlier pages when the transcript is scrolled to the top"
+    },
+    {
+      "id": "chat.history.current-recovery",
+      "surface": "chat",
+      "expected": "A current-conversation history failure replaces paging with clear unavailable copy and a retry action.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-surface.test.tsx > history controls > swaps to the failure copy and a retry control when history is unavailable"
+    },
+    {
+      "id": "chat.history.past-list",
+      "surface": "chat",
+      "expected": "Past conversations load newest first, expose truncation when older entries are omitted, and recover a list failure through retry.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/archive-controller.test.ts > publishes the newest-first list and the truncation signal"
+    },
+    {
+      "id": "chat.history.past-viewer",
+      "surface": "chat",
+      "expected": "Opening a past conversation shows a read-only transcript with back navigation, no composer, and paged earlier messages.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/archive-surface.test.tsx > renders a read-only transcript with back navigation and no composer"
+    },
+    {
+      "id": "chat.history.past-recovery",
+      "surface": "chat",
+      "expected": "A failed past-conversation page can retry the exact request, while a superseded archive is shown as unavailable without an invalid retry.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/archive-controller.test.ts > retries the exact failed page request"
+    },
+    {
+      "id": "chat.new-conversation.cancel",
+      "surface": "chat",
+      "expected": "Cancelling the new-conversation confirmation preserves the conversation and restores focus to the opener.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-surface.test.tsx > new conversation dialog > returns focus to the opener when the athlete cancels"
+    },
+    {
+      "id": "chat.new-conversation.confirm",
+      "surface": "chat",
+      "expected": "Confirming a new conversation clears visible and restored conversation messages while retaining training data and saved coach memory.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-surface.test.tsx > new conversation dialog > walks the confirm flow and hands focus back to the composer"
+    },
+    {
+      "id": "chat.archive.on-reset",
+      "surface": "chat",
+      "expected": "A completed new-conversation reset archives the preceding conversation once so it is available from Past conversations.",
+      "automation": "deterministic",
+      "test": "packages/core/tests/conversation-store.test.ts > surfaces the pre-reset conversation as an archived read after a completed reset"
+    },
+    {
+      "id": "chat.markdown.safe-subset",
+      "surface": "chat",
+      "expected": "Settled coach text renders the shipped finite Markdown subset while raw HTML and image syntax remain literal and cannot create network-capable elements.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-markdown.test.ts > keeps raw HTML and image syntax literal without creating network-capable elements"
+    },
+    {
+      "id": "settings.setup.inventory",
+      "surface": "settings",
+      "expected": "Setup appears first and contains the shipped coach provider, Intervals.icu, injury status, conditional clinician clearance, and Settings credential rows; Telegram remains optional in Chat setup.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > renders every required row in order and admits the clearance row to the same card"
+    },
+    {
+      "id": "settings.setup.readiness-gate",
+      "surface": "settings",
+      "expected": "First-run coaching remains blocked until a supported coach provider, durable training data, and the required intake are ready; Telegram never blocks Chat.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > keeps Start coaching disabled until every requirement is met"
+    },
+    {
+      "id": "settings.providers.lanes",
+      "surface": "settings",
+      "expected": "Provider setup offers only lanes reported by production: Claude subscription when eligible, ChatGPT subscription, and the API-key provider catalogue, with the current lane identified.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > opens a menu of the offered lanes with the current one ticked"
+    },
+    {
+      "id": "settings.providers.chatgpt-sign-in",
+      "surface": "settings",
+      "expected": "Starting ChatGPT subscription sign-in requests browser authorization once, shows Waiting for browser, Completing sign-in, Signed in, Activating coach, and Ready in order, stores the profile before activation, and retries activation without signing in again.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/onboarding-surface.test.tsx > runs ChatGPT sign-in through pending to a ready row",
+        "apps/desktop-renderer/tests/onboarding-chatgpt-lifecycle.test.tsx > renders every phase and replaces generic progress at exactly three seconds",
+        "apps/desktop-renderer/tests/onboarding-chatgpt-lifecycle.test.tsx > retries activation without starting OAuth again",
+        "apps/desktop/tests/chatgpt-auth.test.ts > forwards the separate login limits and closed progress phases",
+        "apps/desktop/tests/chatgpt-auth.test.ts > publishes stored before a separate keyless runtime activation"
+      ]
+    },
+    {
+      "id": "settings.providers.chatgpt-refusals",
+      "surface": "settings",
+      "expected": "ChatGPT refusal copy distinguishes an existing sign-in, an unavailable callback, timeout, cancellation, failed exchange, failed profile storage, and unavailable runtime activation; a refused sign-in stays in the panel with sign-in enabled for retry.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/onboarding-surface.test.tsx > renders the refusal state inside the ChatGPT panel",
+        "apps/desktop/tests/chatgpt-auth.test.ts > maps timeout, browser cancellation, and exchange failures",
+        "apps/desktop/tests/chatgpt-auth.test.ts > refuses concurrent login and maps callback, storage, and runtime failures"
+      ]
+    },
+    {
+      "id": "settings.providers.claude-readiness",
+      "surface": "settings",
+      "expected": "Claude CLI shows checking, signed-in subscription, API-key billing, missing or outdated binary, signed-out, token-only, and disabled readiness truth with Check again recovery.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx > opens Setup before the account probe answers and explains it is still checking",
+        "apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx > offers the lane and carries the signed-in identity into the row",
+        "apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx > falls back to the email alone when the probe reports no plan",
+        "apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx > names API key billing instead of claiming a subscription",
+        "apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx > leaves the lane out of the menu and explains $state in place",
+        "apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx > rechecks the account from the menu note and never grows a key field"
+      ]
+    },
+    {
+      "id": "settings.providers.coach-route",
+      "surface": "settings",
+      "expected": "The athlete can change the active provider and model, use a custom model, and save through the existing coach-route flow; credential-required failures lead back to Setup.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/settings-surface.test.tsx > saves a custom model through the sentinel option"
+    },
+    {
+      "id": "settings.providers.credential-management",
+      "surface": "settings",
+      "expected": "Saved provider credentials show active or saved-not-in-use truth, require two-step deletion, and explain that local deletion does not change the provider account.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/settings-surface.test.tsx > confirms in two steps and restores focus when cancelled"
+    },
+    {
+      "id": "settings.providers.windows-codex-recovery",
+      "surface": "settings",
+      "expected": "On Windows an active codex-agent profile is not treated as ready, is labeled Change required, and can be replaced through the existing Claude CLI or API-key provider flow without deleting unrelated state.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/settings-surface.test.tsx > requires a supported provider change for an active Windows Codex-agent profile"
+    },
+    {
+      "id": "settings.intervals.connect",
+      "surface": "settings",
+      "expected": "Intervals.icu setup reads a copied API key without rendering the secret, validates ownership, and activates the connection only after an authoritative applied result.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > connects Intervals.icu from copied metadata without rendering a secret field"
+    },
+    {
+      "id": "settings.intervals.delete-only",
+      "surface": "settings",
+      "expected": "A connected Intervals.icu account offers Delete rather than replacement, requires confirmation, and retains synced rides and past chats after deleting the saved connection.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > keeps AI changes quiet and gives connected Intervals only Delete"
+    },
+    {
+      "id": "settings.telegram.delete-only",
+      "surface": "settings",
+      "expected": "A connected Telegram bot exposes deletion rather than token replacement, requires explicit confirmation, and keeps the bot and chat in Telegram while deleting the local encrypted token and allowed-user access.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/telegram-settings-surface.test.tsx > requires confirmation before deleting the encrypted bot credential"
+    },
+    {
+      "id": "settings.training-account.identity",
+      "surface": "settings",
+      "expected": "The training account identifies the active Intervals.icu athlete and routes account changes through supported connection setup rather than an in-place athlete switch.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/athlete-settings.test.ts > sends only the exact athlete patch for %s and rereads authority"
+    },
+    {
+      "id": "settings.conversation.lifecycle",
+      "surface": "settings",
+      "expected": "Conversation settings expose timezone, daily reset hour, idle reset minutes, archive retention days, and history budget; only dirty unmanaged fields are saved and lifecycle effects are disclosed.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/settings-surface.test.tsx > sends only the dirty fields"
+    },
+    {
+      "id": "settings.spend.daily-cap",
+      "surface": "settings",
+      "expected": "Spend shows the current daily cap and usage truth, publishes the cap warning to Chat, and saves a revised cap without losing an in-progress edit on refresh.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/settings-surface.test.tsx > publishes the cap warning for the chat surface and saves a new cap"
+    },
+    {
+      "id": "settings.preferences.units",
+      "surface": "settings",
+      "expected": "Units can switch between metric and imperial for distance and body mass while cycling power-to-weight remains W/kg.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/training-context.test.ts > renders only the authoritative units result and retains selection on failed save"
+    },
+    {
+      "id": "settings.preferences.theme",
+      "surface": "settings",
+      "expected": "Appearance supports System, Light, and Dark, with System following the host light/dark setting and the choice persisting.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/settings-preferences.test.tsx > follows the system colour scheme when the appearance is System"
+    },
+    {
+      "id": "settings.preferences.palette",
+      "surface": "settings",
+      "expected": "Every shipped app palette is selectable, the active palette is marked, and a selection applies and persists immediately across both themes.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/settings-preferences.test.tsx > applies and persists a palette choice"
+    },
+    {
+      "id": "settings.application.update",
+      "surface": "settings",
+      "expected": "The application row reflects update state and invokes the available check, download, or restart action while other settings mutations hold it disabled.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/settings-surface.test.tsx > runs the update action the state calls for"
+    },
+    {
+      "id": "settings.application.release-notes",
+      "surface": "settings",
+      "expected": "Release notes open from Settings, render the available version notes, and expose retry when notes are unavailable.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/settings-surface.test.tsx > opens release notes and offers a retry when they are unavailable"
+    },
+    {
+      "id": "settings.application.reset-conversation",
+      "surface": "settings",
+      "expected": "Reset conversation uses the same confirmation flow as Chat and clears conversation history without removing training data or saved coach memory.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/chat-surface.test.tsx > new conversation dialog > walks the confirm flow and hands focus back to the composer"
+    },
+    {
+      "id": "settings.windows.credential-wording",
+      "surface": "settings",
+      "expected": "Installed Windows surfaces identify DPAPI-backed credential encryption instead of macOS or Keychain when secure credential storage needs explanation or recovery.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "settings.windows.login-start",
+      "surface": "settings",
+      "expected": "The installed Windows tray menu shows Start in background at login, reflects authoritative Windows Startup Apps truth, and persists the background preference without elevating or changing OS registration unexpectedly.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "settings.windows.tray-language",
+      "surface": "settings",
+      "expected": "The installed Windows app uses tray language where residency is visible, opens the main window on tray left click, and never presents the macOS menu-bar popover copy.",
+      "automation": "vm-only"
+    }
+  ]
+}

--- a/apps/desktop/tests/platform-copy.test.ts
+++ b/apps/desktop/tests/platform-copy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { desktopPlatformProjection } from "../src/main/platform-copy.js";
+import { startupRefusalCopy } from "../src/main/lifecycle-messages.js";
+
+describe("desktop platform projection", () => {
+  it("keeps the Darwin capability and rendered copy byte-identical", () => {
+    expect(desktopPlatformProjection("darwin")).toEqual({
+      platform: "darwin",
+      capabilities: { codexAgent: true },
+      copy: {
+        computer: "this Mac",
+        operatingSystem: "macOS",
+        credentialEncryptionUnavailable:
+          "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
+        credentialRecoveryAction: "unlock or approve Keychain access",
+        restartComputer: "restart your Mac",
+      },
+    });
+  });
+
+  it("projects Windows capability and path-free DPAPI-backed wording", () => {
+    const projection = desktopPlatformProjection("win32");
+
+    expect(projection).toEqual({
+      platform: "win32",
+      capabilities: { codexAgent: false },
+      copy: {
+        computer: "this PC",
+        operatingSystem: "Windows",
+        credentialEncryptionUnavailable:
+          "Windows credential encryption (DPAPI) is unavailable. Quit and reopen Enduragent, then try again.",
+        credentialRecoveryAction: "make sure Windows credential encryption (DPAPI) is available",
+        restartComputer: "restart your PC",
+      },
+    });
+    expect(JSON.stringify(projection)).not.toMatch(/[\\/](?:Users|home|tmp)[\\/]/u);
+    expect(Object.isFrozen(projection)).toBe(true);
+    expect(Object.isFrozen(projection.capabilities)).toBe(true);
+    expect(Object.isFrozen(projection.copy)).toBe(true);
+  });
+
+  it("retains legacy non-Windows copy and changes only the Windows restart noun", () => {
+    expect(startupRefusalCopy("unavailable", "darwin").content).toBe(
+      "The background service could not start or its saved connection state could not be read. Quit Enduragent and reopen it. If the problem continues, restart your Mac before trying again.",
+    );
+    expect(startupRefusalCopy("unavailable", "win32").content).toBe(
+      "The background service could not start or its saved connection state could not be read. Quit Enduragent and reopen it. If the problem continues, restart your PC before trying again.",
+    );
+  });
+});

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -41,6 +41,7 @@ vi.mock("electron", () => ({
 }));
 
 interface AuthBridge {
+  readonly platform: unknown;
   getDaemonConnection(failedGeneration?: number): Promise<unknown>;
   getTranscriptPage(input: unknown): Promise<unknown>;
   listArchivedConversations(): Promise<unknown>;
@@ -257,6 +258,7 @@ describe("desktop preload ChatGPT auth", () => {
         "onUpdateState",
         "pasteIntervalsApiKeyFromClipboard",
         "pasteTelegramTokenFromClipboard",
+        "platform",
         "reconcileTelegram",
         "releaseNotes",
         "removeTelegram",

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -420,6 +420,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "onUpdateState",
       "pasteIntervalsApiKeyFromClipboard",
       "pasteTelegramTokenFromClipboard",
+      "platform",
       "reconcileTelegram",
       "releaseNotes",
       "removeTelegram",

--- a/apps/desktop/tests/windows-parity-scenarios.test.ts
+++ b/apps/desktop/tests/windows-parity-scenarios.test.ts
@@ -1,0 +1,311 @@
+import { basename } from "node:path";
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_WINDOWS_PARITY_SCENARIO_MANIFESTS,
+  loadWindowsParityScenarios,
+  WINDOWS_PARITY_SCENARIO_MANIFEST_MAX_BYTES,
+  WindowsParityScenarioManifestError,
+  type WindowsParityScenarioManifestStage,
+} from "../scripts/windows-parity-scenarios.mjs";
+
+function deterministic(id = "chat.synthetic") {
+  return {
+    id,
+    surface: "chat",
+    expected: "The synthetic behavior remains available.",
+    automation: "deterministic",
+    test: "apps/desktop/tests/synthetic.test.ts > proves the synthetic behavior",
+  } as const;
+}
+
+function deterministicWithTests(id = "chat.multi-citation") {
+  return {
+    id,
+    surface: "chat",
+    expected: "The synthetic behavior has multiple independent proofs.",
+    automation: "deterministic",
+    tests: [
+      "apps/desktop/tests/synthetic.test.ts > proves the first behavior",
+      "apps/desktop-renderer/tests/synthetic.test.tsx > proves the second behavior",
+    ],
+  } as const;
+}
+
+function manifest(scenarios: readonly unknown[], extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({ schemaVersion: 1, scenarios, ...extra });
+}
+
+function reader(files: Readonly<Record<string, string>>) {
+  return vi.fn(async (path: string, encoding: "utf8") => {
+    expect(encoding).toBe("utf8");
+    const source = files[basename(path)];
+    if (source === undefined) {
+      const error = new Error("private missing path") as NodeJS.ErrnoException;
+      error.code = "ENOENT";
+      throw error;
+    }
+    return source;
+  });
+}
+
+async function expectStage(
+  operation: Promise<unknown>,
+  stage: WindowsParityScenarioManifestStage,
+): Promise<void> {
+  await expect(operation).rejects.toMatchObject({
+    name: "WindowsParityScenarioManifestError",
+    message: `windows-parity scenario manifest rejected at ${stage}`,
+    stage,
+  });
+  await expect(operation).rejects.not.toThrow("private");
+}
+
+describe("Windows parity scenario manifests", () => {
+  it("loads the frozen Chat and Settings manifest with unique tested deterministic rows", async () => {
+    const collection = await loadWindowsParityScenarios();
+
+    expect(collection.schemaVersion).toBe(1);
+    expect(collection.manifests).toEqual(DEFAULT_WINDOWS_PARITY_SCENARIO_MANIFESTS);
+    expect({
+      total: collection.scenarios.length,
+      deterministic: collection.scenarios.filter(
+        (scenario) => scenario.automation === "deterministic",
+      ).length,
+      vmOnly: collection.scenarios.filter((scenario) => scenario.automation === "vm-only").length,
+    }).toEqual({ total: 43, deterministic: 40, vmOnly: 3 });
+    expect(new Set(collection.scenarios.map((scenario) => scenario.id)).size).toBe(
+      collection.scenarios.length,
+    );
+    for (const scenario of collection.scenarios) {
+      expect(scenario.expected).not.toBe("");
+      if (scenario.automation === "deterministic") {
+        const citations = "test" in scenario ? [scenario.test] : scenario.tests;
+        expect(citations.length).toBeGreaterThan(0);
+        for (const citation of citations) {
+          const [testPath, ...testSegments] = citation.split(" > ");
+          const testName = testSegments.at(-1);
+          expect(testPath).toMatch(/^(?:apps|packages)\//u);
+          expect(testName).toBeTruthy();
+          expect(await readFile(testPath!, "utf8")).toContain(JSON.stringify(testName));
+        }
+        if ("tests" in scenario) expect(Object.isFrozen(scenario.tests)).toBe(true);
+      } else {
+        expect(scenario).not.toHaveProperty("test");
+        expect(scenario).not.toHaveProperty("tests");
+      }
+    }
+    expect(
+      collection.scenarios.flatMap((scenario) =>
+        scenario.automation === "deterministic" && "tests" in scenario ? [scenario.id] : [],
+      ),
+    ).toEqual([
+      "settings.providers.chatgpt-sign-in",
+      "settings.providers.chatgpt-refusals",
+      "settings.providers.claude-readiness",
+    ]);
+    expect(Object.isFrozen(collection)).toBe(true);
+    expect(Object.isFrozen(collection.manifests)).toBe(true);
+    expect(Object.isFrozen(collection.scenarios)).toBe(true);
+    expect(collection.scenarios.every(Object.isFrozen)).toBe(true);
+  });
+
+  it("loads exact multiple deterministic citations and freezes nested evidence", async () => {
+    const collection = await loadWindowsParityScenarios(
+      { directory: "/synthetic/windows-parity" },
+      {
+        readFile: reader({
+          "chat-settings.scenarios.json": manifest([deterministicWithTests()]),
+        }),
+      },
+    );
+
+    expect(collection.scenarios).toEqual([deterministicWithTests()]);
+    const [scenario] = collection.scenarios;
+    if (scenario?.automation !== "deterministic" || !("tests" in scenario)) {
+      throw new TypeError("multiple citation shape missing");
+    }
+    expect(Object.isFrozen(scenario.tests)).toBe(true);
+  });
+
+  it("registers future Training and Telegram manifests without changing the loader contract", async () => {
+    const readFile = reader({
+      "chat-settings.scenarios.json": manifest([deterministic()]),
+      "training.scenarios.json": manifest([
+        {
+          id: "training.synthetic",
+          surface: "training",
+          expected: "The synthetic training behavior remains available.",
+          automation: "vm-only",
+        },
+      ]),
+      "telegram.scenarios.json": manifest([deterministic("telegram.synthetic")]),
+    });
+
+    const collection = await loadWindowsParityScenarios(
+      {
+        directory: "/synthetic/windows-parity",
+        manifestNames: [
+          "chat-settings.scenarios.json",
+          "training.scenarios.json",
+          "telegram.scenarios.json",
+        ],
+      },
+      { readFile },
+    );
+
+    expect(collection.manifests).toEqual([
+      "chat-settings.scenarios.json",
+      "training.scenarios.json",
+      "telegram.scenarios.json",
+    ]);
+    expect(collection.scenarios.map((scenario) => scenario.id)).toEqual([
+      "chat.synthetic",
+      "training.synthetic",
+      "telegram.synthetic",
+    ]);
+    expect(readFile).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    { manifestNames: [] },
+    { manifestNames: ["chat-settings.scenarios.json", "chat-settings.scenarios.json"] },
+    { manifestNames: ["../chat-settings.scenarios.json"] },
+    { manifestNames: ["training.json"] },
+    { directory: "relative/windows-parity" },
+  ])("rejects malformed loader configuration %#", async (input) => {
+    await expectStage(loadWindowsParityScenarios(input), "configuration");
+  });
+
+  it("fails closed when any configured manifest is missing", async () => {
+    const operation = loadWindowsParityScenarios(
+      {
+        directory: "/synthetic/windows-parity",
+        manifestNames: ["chat-settings.scenarios.json", "training.scenarios.json"],
+      },
+      { readFile: reader({ "chat-settings.scenarios.json": manifest([deterministic()]) }) },
+    );
+
+    await expectStage(operation, "read");
+  });
+
+  it("rejects malformed JSON without exposing parser or path details", async () => {
+    const operation = loadWindowsParityScenarios(
+      { directory: "/synthetic/windows-parity" },
+      { readFile: reader({ "chat-settings.scenarios.json": "{private" }) },
+    );
+
+    await expectStage(operation, "parse");
+  });
+
+  it("rejects a manifest over the bounded byte budget before parsing", async () => {
+    const operation = loadWindowsParityScenarios(
+      { directory: "/synthetic/windows-parity" },
+      {
+        readFile: reader({
+          "chat-settings.scenarios.json": "x".repeat(
+            WINDOWS_PARITY_SCENARIO_MANIFEST_MAX_BYTES + 1,
+          ),
+        }),
+      },
+    );
+
+    await expectStage(operation, "size");
+  });
+
+  it.each([
+    JSON.stringify([]),
+    JSON.stringify({ schemaVersion: 2, scenarios: [deterministic()] }),
+    JSON.stringify({ schemaVersion: 1, scenarios: [] }),
+    manifest([deterministic()], { unexpected: true }),
+    manifest([{ ...deterministic(), unexpected: true }]),
+    manifest([{ ...deterministic(), id: "Chat synthetic" }]),
+    manifest([{ ...deterministic(), surface: "Chat settings" }]),
+    manifest([{ ...deterministic(), expected: "" }]),
+    manifest([{ ...deterministic(), automation: "manual" }]),
+    manifest([{ ...deterministic(), test: ["apps/desktop/tests/synthetic.test.ts"] }]),
+    manifest([{ ...deterministicWithTests(), test: deterministic().test }]),
+    manifest([{ ...deterministicWithTests(), tests: [] }]),
+    manifest([{ ...deterministicWithTests(), tests: [""] }]),
+    manifest([
+      {
+        ...deterministicWithTests(),
+        tests: [deterministic().test, deterministic().test],
+      },
+    ]),
+    manifest([
+      {
+        id: "chat.synthetic",
+        surface: "chat",
+        expected: "The synthetic behavior remains available.",
+        automation: "deterministic",
+      },
+    ]),
+    manifest([
+      {
+        id: "chat.synthetic",
+        surface: "chat",
+        expected: "The synthetic behavior remains available.",
+        automation: "vm-only",
+        test: "apps/desktop/tests/synthetic.test.ts > unexpected proof",
+      },
+    ]),
+    manifest([
+      {
+        id: "chat.synthetic",
+        surface: "chat",
+        expected: "The synthetic behavior remains available.",
+        automation: "vm-only",
+        tests: ["apps/desktop/tests/synthetic.test.ts > unexpected proof"],
+      },
+    ]),
+  ])("rejects malformed roots and rows %#", async (source) => {
+    const operation = loadWindowsParityScenarios(
+      { directory: "/synthetic/windows-parity" },
+      { readFile: reader({ "chat-settings.scenarios.json": source }) },
+    );
+
+    await expectStage(operation, "schema");
+  });
+
+  it("rejects duplicate IDs inside one manifest and across the configured family", async () => {
+    const within = loadWindowsParityScenarios(
+      { directory: "/synthetic/windows-parity" },
+      {
+        readFile: reader({
+          "chat-settings.scenarios.json": manifest([
+            deterministic(),
+            deterministic("chat.synthetic"),
+          ]),
+        }),
+      },
+    );
+    await expectStage(within, "duplicate-id");
+
+    const across = loadWindowsParityScenarios(
+      {
+        directory: "/synthetic/windows-parity",
+        manifestNames: ["chat-settings.scenarios.json", "training.scenarios.json"],
+      },
+      {
+        readFile: reader({
+          "chat-settings.scenarios.json": manifest([deterministic()]),
+          "training.scenarios.json": manifest([deterministic()]),
+        }),
+      },
+    );
+    await expectStage(across, "duplicate-id");
+  });
+
+  it("uses a stage-coded path-free error type", () => {
+    const error = new WindowsParityScenarioManifestError("schema");
+
+    expect(error).toEqual(
+      expect.objectContaining({
+        name: "WindowsParityScenarioManifestError",
+        message: "windows-parity scenario manifest rejected at schema",
+        stage: "schema",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- W13 of the Windows-parity initiative (ADR-0048): Chat/Settings Windows installed parity.
- Freezes the Chat/Settings scenario manifest: `apps/desktop/tests/fixtures/windows-parity/chat-settings.scenarios.json` — 43 rows (19 chat, 24 settings; 40 deterministic, 3 vm-only). Every deterministic row cites the real test(s) proving it; the three vm-only rows (DPAPI credential wording, Windows start-at-login, tray language) are the installed-Windows-only behaviors.
- Adds an exact manifest aggregator (`apps/desktop/scripts/windows-parity-scenarios.{mjs,d.mts}` + tests): fail-closed rejection of duplicate IDs, malformed rows, unexpected fields, missing configured files, and oversize manifests; supports multi-test citations per row; W14/W15 register their fixture files later without contract edits.
- Adds a minimized platform capability/copy projection (`platform-copy.ts` in main and renderer, exposed via the preload bridge as `platform`): Keychain wording becomes Windows credential wording, popover/menu-bar wording becomes tray wording, Cmd accelerators become Ctrl — only where shown on Windows; darwin-rendered copy byte-identical; copy strings only, zero styling churn, no Windows-specific UI components.
- Recoverable Codex-profile provider change on win32 (Codex delegation is excluded from Windows parity): the projection reports `capabilities.codexAgent: false` on Windows; an existing codex-agent profile surfaces a "Change required" state in Settings and first-run gating, and the athlete saves a supported provider through the unchanged apply path — tests prove no credential deletion and no unrelated state loss. darwin behavior unchanged.

## Verification
- Renderer suite: 850 passed, 0 failed (53 files). Desktop suite: 1416 passed, 0 failed (66 files). Root `pnpm check` clean.
- Fresh-context read-only audit: all 40 deterministic rows mechanically traced to their named tests (0 failures); 9 rows spot-checked in depth against shipped behavior; aggregator rejection paths, copy projection, Codex-profile flow, and darwin parity confirmed. An audit finding (the shipped ChatGPT sign-in flow lacked manifest rows) was fixed in a scoped second round — rows `settings.providers.chatgpt-sign-in` and `settings.providers.chatgpt-refusals` added with verified citations.

## Limits
- `WINDOWS_PARITY_SCENARIO_MANIFEST_MAX_BYTES = 1_048_576` (`windows-parity-scenarios.mjs`) — bounds per-manifest read size before JSON.parse, enforced fail-closed.

## Notes
- The manifest freezes what IS shipped: chat cancel/stop and transcript export have no rows because no such controls exist at HEAD.
- Windows-host-only proof (real DPAPI wording context, start-at-login, tray language) is deferred to the VM acceptance pass, mapped to the three vm-only row IDs.
