### PR TITLE
perf(desktop): connect intervals.icu with a single remote verification

### DIFF
--- a/.changeset/swift-intervals-approval.md
+++ b/.changeset/swift-intervals-approval.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Connecting intervals.icu after pasting an API key is now faster while keeping account verification in place.

--- a/apps/desktop/src/main/credential-runtime.ts
+++ b/apps/desktop/src/main/credential-runtime.ts
@@ -1,9 +1,14 @@
-import { connectCoachClient, type CoachClient } from "@enduragent/coach-client";
+import {
+  CoachRpcRemoteError,
+  connectCoachClient,
+  type CoachClient,
+} from "@enduragent/coach-client";
 import {
   isKeylessProvider,
   type ConfigureRuntimeRpcParams,
   type LlmProvider,
   type RuntimeConfigSnapshot,
+  type VerifyIntervalsCredentialRpcResult,
 } from "@enduragent/coach-contract";
 import { CHATGPT_PROFILE_NAME } from "./chatgpt-auth.js";
 import {
@@ -21,7 +26,11 @@ export interface LlmProviderSelectionEvidence {
 }
 
 export interface CredentialRuntimeApplication {
-  applyExplicit(request: ConfigureRuntimeRpcParams, signal?: AbortSignal): Promise<void>;
+  applyExplicit(
+    request: ConfigureRuntimeRpcParams,
+    signal?: AbortSignal,
+    verificationApproval?: string,
+  ): Promise<void>;
   applyExistingLlmSelection(
     provider: LlmProvider,
     request: ConfigureRuntimeRpcParams,
@@ -35,6 +44,15 @@ export interface CredentialRuntimeApplication {
   clearCredential(
     credential: DesktopManagedCredential,
   ): Promise<"cleared" | "not-active" | "managed-by-environment">;
+}
+
+export function applyExplicitCredentialToRuntime(
+  runtime: Pick<CredentialRuntimeApplication, "applyExplicit">,
+  request: ConfigureRuntimeRpcParams,
+  verificationApproval?: string,
+): Promise<void> {
+  if (verificationApproval === undefined) return runtime.applyExplicit(request);
+  return runtime.applyExplicit(request, undefined, verificationApproval);
 }
 
 interface CredentialRuntimeApplicationOptions {
@@ -52,10 +70,60 @@ interface CredentialRuntimeApplicationOptions {
 
 export interface RuntimeConfigurationAuthority {
   configureRuntime(request: ConfigureRuntimeRpcParams, signal?: AbortSignal): Promise<void>;
+  verifyIntervalsCredential(
+    apiKey: string,
+    signal?: AbortSignal,
+  ): Promise<VerifyIntervalsCredentialRpcResult>;
   clearCredential(
     credential: DesktopManagedCredential,
   ): Promise<"cleared" | "not-active" | "managed-by-environment">;
   getRuntimeConfig(signal?: AbortSignal): Promise<RuntimeConfigSnapshot>;
+}
+
+export interface ActiveIntervalsCredentialBinding {
+  readonly authority: Pick<RuntimeConfigurationAuthority, "verifyIntervalsCredential">;
+}
+
+export interface ActiveIntervalsCredentialLifecycleSnapshot {
+  readonly status: string;
+  readonly generation?: number;
+}
+
+export function createActiveIntervalsCredentialPreflight(input: {
+  readonly currentBinding: () => ActiveIntervalsCredentialBinding | undefined;
+  readonly lifecycleSnapshot: () => ActiveIntervalsCredentialLifecycleSnapshot | undefined;
+}): (
+  apiKey: string,
+  signal: AbortSignal,
+) => Promise<VerifyIntervalsCredentialRpcResult | undefined> {
+  return async (apiKey, signal) => {
+    const binding = input.currentBinding();
+    const lifecycleState = input.lifecycleSnapshot();
+    if (
+      binding === undefined ||
+      lifecycleState?.status !== "ready" ||
+      typeof lifecycleState.generation !== "number"
+    ) {
+      return undefined;
+    }
+    let result: VerifyIntervalsCredentialRpcResult;
+    try {
+      result = await binding.authority.verifyIntervalsCredential(apiKey, signal);
+    } catch (error) {
+      signal.throwIfAborted();
+      if (error instanceof CoachRpcRemoteError && error.code === -32601) return undefined;
+      throw error;
+    }
+    const currentLifecycleState = input.lifecycleSnapshot();
+    if (
+      input.currentBinding() !== binding ||
+      currentLifecycleState?.status !== "ready" ||
+      currentLifecycleState.generation !== lifecycleState.generation
+    ) {
+      throw new TypeError();
+    }
+    return result;
+  };
 }
 
 export function runtimeConfigurationForCredentialDeletion(
@@ -149,6 +217,15 @@ export function createConnectionRuntimeAuthority(
       }
       return "cleared";
     },
+    verifyIntervalsCredential(apiKey, signal) {
+      return call(
+        (client) =>
+          signal === undefined
+            ? client.call("verify_intervals_credential", { api_key: apiKey })
+            : client.call("verify_intervals_credential", { api_key: apiKey }, { signal }),
+        signal,
+      );
+    },
     getRuntimeConfig(signal) {
       return call(
         (client) =>
@@ -198,10 +275,26 @@ export function createCredentialRuntimeApplication(
   };
 
   return {
-    applyExplicit(request, signal) {
+    applyExplicit(request, signal, verificationApproval) {
       return serialize(() => {
         signal?.throwIfAborted();
-        return options.configureRuntime(request, signal);
+        if (verificationApproval === undefined) return options.configureRuntime(request, signal);
+        if (
+          !/^[0-9a-f]{64}$/.test(verificationApproval) ||
+          request.intervals?.api_key === undefined
+        ) {
+          throw new TypeError();
+        }
+        return options.configureRuntime(
+          {
+            ...request,
+            intervals: {
+              ...request.intervals,
+              verification_approval: verificationApproval,
+            },
+          },
+          signal,
+        );
       });
     },
     applyExistingLlmSelection(provider, request, signal) {

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -103,6 +103,7 @@ export interface CredentialWriteInput {
 export interface CredentialWriteBehavior {
   readonly activate?: boolean;
   readonly rollbackOnRuntimeRefusal?: boolean;
+  readonly verificationApproval?: string;
 }
 
 export interface CredentialVaultMutation {
@@ -154,6 +155,7 @@ interface CredentialVaultOptions {
     slot: DesktopCredentialSlot,
     value: string,
     selection?: OnboardingLlmSelection,
+    verificationApproval?: string,
   ) => Promise<void>;
   readonly reapplyCredential?: (
     slot: DesktopCredentialSlot,
@@ -636,6 +638,14 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     if (value.length === 0) {
       return { slot: input.slot, status: "refused", reason: "invalid-input" };
     }
+    if (
+      behavior?.verificationApproval !== undefined &&
+      (input.slot !== "intervals-icu" ||
+        behavior.activate === false ||
+        !/^[0-9a-f]{64}$/.test(behavior.verificationApproval))
+    ) {
+      return { slot: input.slot, status: "refused", reason: "invalid-input" };
+    }
     const encryptionFailure = encryptionRefusal(options.encryption, platform);
     if (encryptionFailure !== undefined) {
       return { slot: input.slot, status: "refused", reason: encryptionFailure };
@@ -723,7 +733,14 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
       }
       try {
         const canPublish = options.createRuntimePublicationGuard?.(input.slot);
-        if (selection === undefined) {
+        if (behavior?.verificationApproval !== undefined) {
+          await options.applyCredential(
+            input.slot,
+            value,
+            selection,
+            behavior.verificationApproval,
+          );
+        } else if (selection === undefined) {
           await options.applyCredential(input.slot, value);
         } else {
           await options.applyCredential(input.slot, value, selection);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -29,6 +29,8 @@ import {
   installDesktopIntervalsIpc,
 } from "./intervals-ipc.js";
 import {
+  applyExplicitCredentialToRuntime,
+  createActiveIntervalsCredentialPreflight,
   createConnectionRuntimeAuthority,
   createCredentialRuntimeApplication,
   intervalsAthleteIdForOwnership,
@@ -516,6 +518,10 @@ async function runDesktop(): Promise<void> {
       }
       return snapshot;
     };
+    const verifyActiveIntervalsCredential = createActiveIntervalsCredentialPreflight({
+      currentBinding: () => activeRuntimeBinding,
+      lifecycleSnapshot: () => daemonLifecycle?.snapshot(),
+    });
     const readActiveTranscript = async <T>(
       read: (reader: DesktopTranscriptReader) => Promise<T>,
     ): Promise<T> => {
@@ -554,12 +560,15 @@ async function runDesktop(): Promise<void> {
           return canPublish;
         };
       },
-      async applyCredential(slot, value, selection) {
+      async applyCredential(slot, value, selection, verificationApproval) {
         const binding = activeRuntimeBinding!;
         const lifecycleState = daemonLifecycle?.snapshot();
         if (lifecycleState?.status !== "ready") throw new TypeError();
-        await binding.credentials.applyExplicit(
-          runtimeConfigurationForCredential(slot, value, selection),
+        const request = runtimeConfigurationForCredential(slot, value, selection);
+        await applyExplicitCredentialToRuntime(
+          binding.credentials,
+          request,
+          verificationApproval,
         );
         const currentLifecycleState = daemonLifecycle?.snapshot();
         if (
@@ -907,6 +916,7 @@ async function runDesktop(): Promise<void> {
       verifyCredential: createDesktopIntervalsCredentialVerifier({
         storePath: intervalsStorePath,
         readRuntimeConfig: readActiveRuntimeConfig,
+        verifyWithDaemon: verifyActiveIntervalsCredential,
       }),
     });
     disposeTelegramIpc = installDesktopTelegramIpc({

--- a/apps/desktop/src/main/intervals-ipc.ts
+++ b/apps/desktop/src/main/intervals-ipc.ts
@@ -2,10 +2,12 @@ import {
   INTERVALS_CREDENTIAL_VERIFICATION_TIMEOUT_MS,
   verifyIntervalsCredentialAtPath,
   type IntervalsCredentialVerificationRefusalReason,
-  type IntervalsCredentialVerificationResult,
 } from "@enduragent/coach/account-identity";
 import { awaitWithSignal } from "@enduragent/coach/abortable-operation";
-import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
+import type {
+  RuntimeConfigSnapshot,
+  VerifyIntervalsCredentialRpcResult,
+} from "@enduragent/coach-contract";
 import type { Clipboard, IpcMain, IpcMainInvokeEvent } from "electron";
 import { DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL } from "./constants.js";
 import { intervalsAthleteIdForOwnership } from "./credential-runtime.js";
@@ -32,6 +34,14 @@ const STORAGE_REFUSAL_REASONS = new Set([
   "runtime-unavailable",
 ]);
 const INTERVALS_API_KEY_MAX_LENGTH = 256;
+const INTERVALS_VERIFICATION_APPROVAL_PATTERN = /^[0-9a-f]{64}$/;
+
+export type DesktopIntervalsCredentialVerificationResult =
+  | Readonly<{ status: "verified"; verificationApproval?: string }>
+  | Readonly<{
+      status: "refused";
+      reason: IntervalsCredentialVerificationRefusalReason;
+    }>;
 
 export interface DesktopIntervalsCredentialStatus {
   readonly slot: "intervals-icu";
@@ -52,8 +62,49 @@ type DesktopIntervalsMutationRefusalReason =
 export function createDesktopIntervalsCredentialVerifier(input: {
   readonly storePath: string;
   readonly readRuntimeConfig: (signal?: AbortSignal) => Promise<RuntimeConfigSnapshot>;
-}): (apiKey: string, signal: AbortSignal) => Promise<IntervalsCredentialVerificationResult> {
+  readonly verifyWithDaemon?: (
+    apiKey: string,
+    signal: AbortSignal,
+  ) => Promise<VerifyIntervalsCredentialRpcResult | undefined>;
+}): (
+  apiKey: string,
+  signal: AbortSignal,
+) => Promise<DesktopIntervalsCredentialVerificationResult> {
   return async (apiKey, signal) => {
+    if (input.verifyWithDaemon !== undefined) {
+      let result: unknown;
+      try {
+        result = await input.verifyWithDaemon(apiKey, signal);
+        signal.throwIfAborted();
+      } catch {
+        signal.throwIfAborted();
+        return { status: "refused", reason: "validation-unavailable" };
+      }
+      if (result !== undefined) {
+        if (
+          record(result) &&
+          typeof result.approval === "string" &&
+          INTERVALS_VERIFICATION_APPROVAL_PATTERN.test(result.approval) &&
+          exactKeys(result, ["approval"])
+        ) {
+          return { status: "verified", verificationApproval: result.approval };
+        }
+        if (
+          record(result) &&
+          typeof result.reason === "string" &&
+          VERIFICATION_REFUSAL_REASONS.has(
+            result.reason as IntervalsCredentialVerificationRefusalReason,
+          ) &&
+          exactKeys(result, ["reason"])
+        ) {
+          return {
+            status: "refused",
+            reason: result.reason as IntervalsCredentialVerificationRefusalReason,
+          };
+        }
+        return { status: "refused", reason: "validation-unavailable" };
+      }
+    }
     let snapshot: RuntimeConfigSnapshot;
     try {
       snapshot = await input.readRuntimeConfig(signal);
@@ -126,10 +177,18 @@ function closedStatus(): DesktopIntervalsCredentialStatus {
   return { slot: "intervals-icu", state: "re-prompt", runtimeState: null };
 }
 
-function copyVerification(value: unknown): IntervalsCredentialVerificationResult {
+function copyVerification(value: unknown): DesktopIntervalsCredentialVerificationResult {
   if (!record(value) || typeof value.status !== "string") throw new TypeError();
   if (value.status === "verified" && exactKeys(value, ["status"])) {
     return { status: "verified" };
+  }
+  if (
+    value.status === "verified" &&
+    typeof value.verificationApproval === "string" &&
+    INTERVALS_VERIFICATION_APPROVAL_PATTERN.test(value.verificationApproval) &&
+    exactKeys(value, ["status", "verificationApproval"])
+  ) {
+    return { status: "verified", verificationApproval: value.verificationApproval };
   }
   if (
     value.status === "refused" &&
@@ -248,12 +307,12 @@ export function installDesktopIntervalsIpc(input: {
   readonly verifyCredential: (
     apiKey: string,
     signal: AbortSignal,
-  ) => Promise<IntervalsCredentialVerificationResult>;
+  ) => Promise<DesktopIntervalsCredentialVerificationResult>;
 }): () => Promise<void> {
   let accepting = true;
   let closePromise: Promise<void> | undefined;
   let operationQueue = Promise.resolve();
-  const pendingVerifications = new Set<Promise<IntervalsCredentialVerificationResult>>();
+  const pendingVerifications = new Set<Promise<DesktopIntervalsCredentialVerificationResult>>();
   const closeController = new AbortController();
   const verificationSignal = AbortSignal.any([input.signal, closeController.signal]);
   const serialize = <T>(operation: () => Promise<T>): Promise<T> => {
@@ -283,7 +342,7 @@ export function installDesktopIntervalsIpc(input: {
   };
   const verifyCandidate = async (
     apiKey: string,
-  ): Promise<IntervalsCredentialVerificationResult> => {
+  ): Promise<DesktopIntervalsCredentialVerificationResult> => {
     if (verificationSignal.aborted) {
       return { status: "refused", reason: "validation-aborted" };
     }
@@ -334,13 +393,19 @@ export function installDesktopIntervalsIpc(input: {
           if (verification.status === "refused") {
             result = { outcome: "refused", reason: verification.reason };
           } else {
+            const behavior = {
+              rollbackOnRuntimeRefusal: true,
+              ...(verification.verificationApproval === undefined
+                ? {}
+                : { verificationApproval: verification.verificationApproval }),
+            };
             result = mutationFromWrite(
               await mutation.writeCredential(
                 {
                   slot: "intervals-icu",
                   value: apiKey,
                 },
-                { rollbackOnRuntimeRefusal: true },
+                behavior,
               ),
             );
           }

--- a/apps/desktop/tests/credential-runtime.test.ts
+++ b/apps/desktop/tests/credential-runtime.test.ts
@@ -2,6 +2,10 @@ import { randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  CoachClientTransportUnavailableError,
+  CoachRpcRemoteError,
+} from "@enduragent/coach-client";
 import type {
   ConfigureRuntimeRpcParams,
   LlmProvider,
@@ -9,6 +13,8 @@ import type {
 } from "@enduragent/coach-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  applyExplicitCredentialToRuntime,
+  createActiveIntervalsCredentialPreflight,
   createConnectionRuntimeAuthority,
   createCredentialRuntimeApplication,
   intervalsAthleteIdForOwnership,
@@ -30,6 +36,7 @@ import {
 } from "../src/main/onboarding-ipc.js";
 
 const roots: string[] = [];
+const VERIFICATION_APPROVAL = "c".repeat(64);
 
 function encryption(): CredentialEncryptionPort {
   return {
@@ -301,6 +308,69 @@ describe("desktop credential runtime precedence", () => {
     });
   });
 
+  it("calls daemon credential preflight with the candidate key and abort signal", async () => {
+    const controller = new AbortController();
+    const call = vi.fn(async () => ({ approval: VERIFICATION_APPROVAL }));
+    const connect = vi.fn(async () => ({
+      handshake: {} as never,
+      call,
+      close: vi.fn(async () => {}),
+    }));
+    const authority = createConnectionRuntimeAuthority(
+      {
+        url: "ws://127.0.0.1:45005/rpc",
+        token: "x".repeat(43),
+        athleteHome: "/synthetic/athlete",
+      },
+      connect as never,
+    );
+
+    await expect(
+      authority.verifyIntervalsCredential("synthetic-intervals-key", controller.signal),
+    ).resolves.toEqual({ approval: VERIFICATION_APPROVAL });
+    expect(call).toHaveBeenCalledWith(
+      "verify_intervals_credential",
+      { api_key: "synthetic-intervals-key" },
+      { signal: controller.signal },
+    );
+    expect(connect).toHaveBeenCalledWith({
+      url: "ws://127.0.0.1:45005/rpc",
+      token: "x".repeat(43),
+      expectedAthleteHome: "/synthetic/athlete",
+      signal: controller.signal,
+    });
+  });
+
+  it("falls back only for method absence or a lifecycle that cannot attempt preflight", async () => {
+    const lifecycle = { status: "ready", generation: 1 };
+    const verifyIntervalsCredential = vi.fn(
+      async (_apiKey: string, _signal?: AbortSignal) => ({ approval: VERIFICATION_APPROVAL }),
+    );
+    const binding = { authority: { verifyIntervalsCredential } };
+    const preflight = createActiveIntervalsCredentialPreflight({
+      currentBinding: () => binding,
+      lifecycleSnapshot: () => lifecycle,
+    });
+    const signal = new AbortController().signal;
+
+    verifyIntervalsCredential.mockRejectedValueOnce(
+      new CoachRpcRemoteError(-32601, "synthetic method unavailable"),
+    );
+    await expect(preflight("synthetic-intervals-key", signal)).resolves.toBeUndefined();
+    expect(verifyIntervalsCredential).toHaveBeenCalledOnce();
+
+    verifyIntervalsCredential.mockClear();
+    const transportError = new CoachClientTransportUnavailableError();
+    verifyIntervalsCredential.mockRejectedValueOnce(transportError);
+    await expect(preflight("synthetic-intervals-key", signal)).rejects.toBe(transportError);
+    expect(verifyIntervalsCredential).toHaveBeenCalledOnce();
+
+    verifyIntervalsCredential.mockClear();
+    lifecycle.status = "starting";
+    await expect(preflight("synthetic-intervals-key", signal)).resolves.toBeUndefined();
+    expect(verifyIntervalsCredential).not.toHaveBeenCalled();
+  });
+
   it("does not start a queued runtime mutation after its activation deadline", async () => {
     let release!: () => void;
     let started!: () => void;
@@ -366,6 +436,54 @@ describe("desktop credential runtime precedence", () => {
     expect(configureRuntime).toHaveBeenCalledWith({
       intervals: { api_key: "obviously-fake-intervals-key" },
     });
+  });
+
+  it("adds an approval only to its explicit Intervals activation request", async () => {
+    const configureRuntime = vi.fn(async () => {});
+    const runtime = createCredentialRuntimeApplication({
+      selectedLlmProvider: async () => undefined,
+      configureRuntime,
+    });
+
+    await runtime.applyExplicit(
+      { intervals: { api_key: "synthetic-intervals-key" } },
+      undefined,
+      VERIFICATION_APPROVAL,
+    );
+
+    expect(configureRuntime).toHaveBeenNthCalledWith(
+      1,
+      {
+        intervals: {
+          api_key: "synthetic-intervals-key",
+          verification_approval: VERIFICATION_APPROVAL,
+        },
+      },
+      undefined,
+    );
+
+    await runtime.reapplyStoredCredential("intervals-icu", "synthetic-intervals-key", [
+      "intervals-icu",
+    ]);
+
+    expect(configureRuntime).toHaveBeenNthCalledWith(2, {
+      intervals: { api_key: "synthetic-intervals-key" },
+    });
+    expect(JSON.stringify(configureRuntime.mock.calls[1])).not.toContain(VERIFICATION_APPROVAL);
+  });
+
+  it("keeps legacy activation tokenless and forwards an approval only when present", async () => {
+    const applyExplicit = vi.fn(async () => {});
+    const runtime = { applyExplicit };
+    const request = { intervals: { api_key: "synthetic-intervals-key" } } as const;
+
+    await applyExplicitCredentialToRuntime(runtime, request);
+    await applyExplicitCredentialToRuntime(runtime, request, VERIFICATION_APPROVAL);
+
+    expect(applyExplicit.mock.calls).toEqual([
+      [request],
+      [request, undefined, VERIFICATION_APPROVAL],
+    ]);
   });
 
   it("self-heals a stored provider after the first-run seed outlives a failed apply", async () => {

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../src/main/credential-vault.js";
 
 const roots: string[] = [];
+const VERIFICATION_APPROVAL = "b".repeat(64);
 
 async function temporaryRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "desktop-vault-"));
@@ -1032,6 +1033,92 @@ describe("desktop credential vault", () => {
       state: "configured",
       runtimeState: "failed",
     });
+  });
+
+  it("forwards an approval once without persisting or replaying it", async () => {
+    const root = await temporaryRoot();
+    const encryptionPort = encryption();
+    const applyCredential = vi.fn(async () => {});
+    const reapplyCredential = vi.fn(async () => "active" as const);
+    const vault = createCredentialVault({
+      root,
+      encryption: encryptionPort,
+      applyCredential,
+      reapplyCredential,
+    });
+
+    await expect(
+      vault.writeCredential(
+        { slot: "intervals-icu", value: "synthetic-intervals-key" },
+        { verificationApproval: VERIFICATION_APPROVAL },
+      ),
+    ).resolves.toEqual({
+      slot: "intervals-icu",
+      status: "configured",
+      runtimeReady: true,
+    });
+    expect(applyCredential).toHaveBeenCalledWith(
+      "intervals-icu",
+      "synthetic-intervals-key",
+      undefined,
+      VERIFICATION_APPROVAL,
+    );
+    const persisted = await readFile(join(root, "intervals-icu.bin"));
+    expect(encryptionPort.decryptString(persisted)).toBe("synthetic-intervals-key");
+    expect(persisted.includes(Buffer.from(VERIFICATION_APPROVAL))).toBe(false);
+    expect(JSON.stringify(await vault.credentialStatuses())).not.toContain(VERIFICATION_APPROVAL);
+
+    applyCredential.mockClear();
+    await vault.reapplyConfigured();
+
+    expect(applyCredential).not.toHaveBeenCalled();
+    expect(reapplyCredential).toHaveBeenCalledWith(
+      "intervals-icu",
+      "synthetic-intervals-key",
+      ["intervals-icu"],
+    );
+    expect(JSON.stringify(reapplyCredential.mock.calls)).not.toContain(VERIFICATION_APPROVAL);
+  });
+
+  it("keeps legacy Intervals activation tokenless when no approval is present", async () => {
+    const root = await temporaryRoot();
+    const applyCredential = vi.fn(async () => {});
+    const vault = createCredentialVault({ root, encryption: encryption(), applyCredential });
+
+    await expect(
+      vault.writeCredential(
+        { slot: "intervals-icu", value: "synthetic-intervals-key" },
+        { rollbackOnRuntimeRefusal: true },
+      ),
+    ).resolves.toEqual({
+      slot: "intervals-icu",
+      status: "configured",
+      runtimeReady: true,
+    });
+    expect(applyCredential.mock.calls).toEqual([
+      ["intervals-icu", "synthetic-intervals-key"],
+    ]);
+  });
+
+  it("refuses approval data outside an explicit Intervals activation", async () => {
+    const root = await temporaryRoot();
+    const applyCredential = vi.fn(async () => {});
+    const vault = createCredentialVault({ root, encryption: encryption(), applyCredential });
+
+    await expect(
+      vault.writeCredential(
+        { slot: "anthropic", value: "synthetic-model-key" },
+        { verificationApproval: VERIFICATION_APPROVAL },
+      ),
+    ).resolves.toEqual({ slot: "anthropic", status: "refused", reason: "invalid-input" });
+    await expect(
+      vault.writeCredential(
+        { slot: "intervals-icu", value: "synthetic-intervals-key" },
+        { activate: false, verificationApproval: VERIFICATION_APPROVAL },
+      ),
+    ).resolves.toEqual({ slot: "intervals-icu", status: "refused", reason: "invalid-input" });
+    expect(applyCredential).not.toHaveBeenCalled();
+    await expect(lstat(root)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("routes passive replay separately from an explicit credential selection", async () => {

--- a/apps/desktop/tests/intervals-ipc.test.ts
+++ b/apps/desktop/tests/intervals-ipc.test.ts
@@ -905,7 +905,7 @@ describe("Intervals.icu credential verification", () => {
       "CREATE TABLE store_owner (singleton INTEGER PRIMARY KEY, account_fingerprint TEXT NOT NULL)",
     );
     store.close();
-    const readRuntimeConfig = vi.fn(async () => runtimeSnapshot(""));
+    const readRuntimeConfig = vi.fn(async (_signal?: AbortSignal) => runtimeSnapshot(""));
     const verifyIntervalsCredential = vi.fn(async () => {
       throw new CoachRpcRemoteError(-32601, "synthetic method unavailable");
     });

--- a/apps/desktop/tests/intervals-ipc.test.ts
+++ b/apps/desktop/tests/intervals-ipc.test.ts
@@ -4,12 +4,18 @@ import {
   verifyIntervalsCredentialAtPath,
   type IntervalsCredentialVerificationResult,
 } from "@enduragent/coach/backfill";
+import {
+  CoachClientTransportUnavailableError,
+  CoachRpcRemoteError,
+} from "@enduragent/coach-client";
+import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
 import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 import { DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL } from "../src/main/constants.js";
+import { createActiveIntervalsCredentialPreflight } from "../src/main/credential-runtime.js";
 import {
   CredentialRuntimeRefusal,
   createCredentialVault,
@@ -20,11 +26,13 @@ import {
 import {
   createDesktopIntervalsCredentialVerifier,
   installDesktopIntervalsIpc,
+  type DesktopIntervalsCredentialVerificationResult,
   type DesktopIntervalsCredentialStatus,
 } from "../src/main/intervals-ipc.js";
 
 const API_KEY = "synthetic-intervals-api-key";
 const EXISTING_API_KEY = "synthetic-existing-intervals-key";
+const APPROVAL = "a".repeat(64);
 const PRIVATE_DETAIL = `${API_KEY} at /Users/private/id_ed25519 PRIVATE_KEY`;
 
 function deferred<T>() {
@@ -42,15 +50,45 @@ function status(
   return { slot: "intervals-icu", state, runtimeState };
 }
 
+function runtimeSnapshot(athleteId = "synthetic-athlete"): RuntimeConfigSnapshot {
+  return {
+    schemaVersion: 3,
+    llm: {
+      provider: "anthropic",
+      model: "synthetic-model",
+      credential_configured: false,
+    },
+    intervals: {
+      athlete_id: athleteId,
+      credential_configured: true,
+      managedByEnvironment: { athleteId: false },
+    },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+      managedByEnvironment: {
+        historyTokenBudgetRatio: false,
+        idleMinutes: false,
+        dailyResetHour: false,
+        resetArchiveRetentionDays: false,
+        timezone: false,
+      },
+    },
+  };
+}
+
 function setup(
   options: {
     readonly trusted?: boolean;
     readonly current?: DesktopIntervalsCredentialStatus;
-    readonly verification?: IntervalsCredentialVerificationResult;
+    readonly verification?: DesktopIntervalsCredentialVerificationResult;
     readonly verifyCredential?: (
       apiKey: string,
       signal: AbortSignal,
-    ) => Promise<IntervalsCredentialVerificationResult>;
+    ) => Promise<DesktopIntervalsCredentialVerificationResult>;
     readonly writeResult?: CredentialWriteResult;
     readonly vault?: Pick<CredentialVault, "credentialStatuses" | "runExclusiveMutation">;
     readonly clipboardValue?: string;
@@ -298,6 +336,30 @@ describe("Desktop Intervals.icu clipboard IPC", () => {
       { slot: "intervals-icu", value: API_KEY },
       { rollbackOnRuntimeRefusal: true },
     );
+  });
+
+  it("forwards a daemon approval only to activation and never returns it to the renderer", async () => {
+    const runtime = setup({
+      verifyCredential: async (apiKey) => {
+        runtime.trace.push(`preflight:${apiKey}`);
+        return { status: "verified", verificationApproval: APPROVAL };
+      },
+    });
+
+    const result = await runtime.invoke();
+
+    expect(runtime.trace).toEqual([
+      "read",
+      "clear",
+      `preflight:${API_KEY}`,
+      `write:${API_KEY}`,
+    ]);
+    expect(runtime.writeCredential).toHaveBeenCalledWith(
+      { slot: "intervals-icu", value: API_KEY },
+      { rollbackOnRuntimeRefusal: true, verificationApproval: APPROVAL },
+    );
+    expect(result).toEqual({ outcome: "applied", current: status("configured", "active") });
+    expect(JSON.stringify(result)).not.toContain(APPROVAL);
   });
 
   it.each(["", "   ", "a\u0000b", "a\nb", "a\u007fb", "a\u0085b", "x".repeat(257)])(
@@ -796,6 +858,171 @@ describe("Intervals.icu credential verification", () => {
     expect(readRuntimeConfig).toHaveBeenCalledWith(signal);
     expect(JSON.stringify(result)).not.toContain(API_KEY);
     expect(JSON.stringify(result)).not.toContain("PRIVATE_KEY");
+  });
+
+  it("uses daemon preflight without a main-process fetch and preserves refusal mappings", async () => {
+    const readRuntimeConfig = vi.fn(async () => runtimeSnapshot());
+    const accepted = createDesktopIntervalsCredentialVerifier({
+      storePath: "/synthetic/store.db",
+      readRuntimeConfig,
+      verifyWithDaemon: async () => ({ approval: APPROVAL }),
+    });
+
+    await expect(accepted(API_KEY, new AbortController().signal)).resolves.toEqual({
+      status: "verified",
+      verificationApproval: APPROVAL,
+    });
+    expect(readRuntimeConfig).not.toHaveBeenCalled();
+
+    for (const reason of [
+      "credential-rejected",
+      "malformed-athlete-response",
+      "validation-timeout",
+      "validation-aborted",
+      "validation-unavailable",
+      "training-account-mismatch",
+      "owner-unresolved",
+      "store-unavailable",
+    ] as const) {
+      const refused = createDesktopIntervalsCredentialVerifier({
+        storePath: "/synthetic/store.db",
+        readRuntimeConfig,
+        verifyWithDaemon: async () => ({ reason }),
+      });
+      await expect(refused(API_KEY, new AbortController().signal)).resolves.toEqual({
+        status: "refused",
+        reason,
+      });
+    }
+    expect(readRuntimeConfig).not.toHaveBeenCalled();
+  });
+
+  it("uses the legacy tokenless lane when an old daemon has no preflight method", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "intervals-fallback-"));
+    const storePath = join(root, "store.db");
+    const store = new DatabaseSync(storePath);
+    store.exec(
+      "CREATE TABLE store_owner (singleton INTEGER PRIMARY KEY, account_fingerprint TEXT NOT NULL)",
+    );
+    store.close();
+    const readRuntimeConfig = vi.fn(async () => runtimeSnapshot(""));
+    const verifyIntervalsCredential = vi.fn(async () => {
+      throw new CoachRpcRemoteError(-32601, "synthetic method unavailable");
+    });
+    const binding = { authority: { verifyIntervalsCredential } };
+    const verifyWithDaemon = vi.fn(
+      createActiveIntervalsCredentialPreflight({
+        currentBinding: () => binding,
+        lifecycleSnapshot: () => ({ status: "ready", generation: 1 }),
+      }),
+    );
+    const fetch = vi.fn(async () => athleteResponse());
+    vi.stubGlobal("fetch", fetch);
+    try {
+      const verifyCredential = createDesktopIntervalsCredentialVerifier({
+        storePath,
+        readRuntimeConfig,
+        verifyWithDaemon,
+      });
+      const runtime = setup({ verifyCredential });
+
+      await expect(runtime.invoke()).resolves.toEqual({
+        outcome: "applied",
+        current: status("configured", "active"),
+      });
+      expect(verifyWithDaemon).toHaveBeenCalledOnce();
+      expect(verifyWithDaemon).toHaveBeenCalledWith(API_KEY, expect.any(AbortSignal));
+      expect(verifyIntervalsCredential).toHaveBeenCalledOnce();
+      expect(readRuntimeConfig).toHaveBeenCalledOnce();
+      expect(readRuntimeConfig).toHaveBeenCalledWith(expect.any(AbortSignal));
+      expect(readRuntimeConfig.mock.calls[0]?.[0]).toBe(verifyWithDaemon.mock.calls[0]?.[1]);
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(runtime.writeCredential).toHaveBeenCalledOnce();
+      expect(runtime.writeCredential.mock.calls[0]?.[1]).toEqual({
+        rollbackOnRuntimeRefusal: true,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses after one transport attempt without reading config or writing the vault", async () => {
+    const readRuntimeConfig = vi.fn(async () => runtimeSnapshot(""));
+    const verifyIntervalsCredential = vi.fn(async () => {
+      throw new CoachClientTransportUnavailableError();
+    });
+    const binding = { authority: { verifyIntervalsCredential } };
+    const verifyWithDaemon = vi.fn(
+      createActiveIntervalsCredentialPreflight({
+        currentBinding: () => binding,
+        lifecycleSnapshot: () => ({ status: "ready", generation: 1 }),
+      }),
+    );
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    try {
+      const verifyCredential = createDesktopIntervalsCredentialVerifier({
+        storePath: "/synthetic/store.db",
+        readRuntimeConfig,
+        verifyWithDaemon,
+      });
+      const runtime = setup({ verifyCredential });
+
+      await expect(runtime.invoke()).resolves.toEqual({
+        outcome: "refused",
+        reason: "validation-unavailable",
+        current: status(),
+      });
+      expect(verifyWithDaemon).toHaveBeenCalledOnce();
+      expect(verifyIntervalsCredential).toHaveBeenCalledOnce();
+      expect(readRuntimeConfig).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
+      expect(runtime.writeCredential).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps the lifecycle-not-ready refusal on the zero-connection legacy lane", async () => {
+    const lifecycle = { status: "starting", generation: 1 };
+    const verifyIntervalsCredential = vi.fn(async () => ({ approval: APPROVAL }));
+    const binding = { authority: { verifyIntervalsCredential } };
+    const configConnection = vi.fn(async () => runtimeSnapshot(""));
+    const verifyWithDaemon = vi.fn(
+      createActiveIntervalsCredentialPreflight({
+        currentBinding: () => binding,
+        lifecycleSnapshot: () => lifecycle,
+      }),
+    );
+    const readRuntimeConfig = vi.fn(async () => {
+      if (lifecycle.status !== "ready") throw new TypeError();
+      return configConnection();
+    });
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    try {
+      const verifyCredential = createDesktopIntervalsCredentialVerifier({
+        storePath: "/synthetic/store.db",
+        readRuntimeConfig,
+        verifyWithDaemon,
+      });
+      const runtime = setup({ verifyCredential });
+
+      await expect(runtime.invoke()).resolves.toEqual({
+        outcome: "refused",
+        reason: "validation-unavailable",
+        current: status(),
+      });
+      expect(verifyWithDaemon).toHaveBeenCalledOnce();
+      expect(readRuntimeConfig).toHaveBeenCalledOnce();
+      expect(verifyIntervalsCredential).not.toHaveBeenCalled();
+      expect(configConnection).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
+      expect(runtime.writeCredential).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("verifies a valid key before accepting a matching or ownerless store", async () => {

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -124,6 +124,7 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   getSetupStatus: 30_000,
   saveIntake: 30_000,
   configureRuntime: 30_000,
+  verify_intervals_credential: 30_000,
   getRuntimeConfig: 30_000,
   getUnitsPreference: 30_000,
   setUnitsPreference: 30_000,

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -81,6 +81,7 @@ const rpcDeadlineCases = [
     30_000,
   ],
   ["configureRuntime", { llm: { provider: "openai" } }, 30_000],
+  ["verify_intervals_credential", { api_key: "placeholder" }, 30_000],
   ["getRuntimeConfig", {}, 30_000],
   ["getUnitsPreference", {}, 30_000],
   ["setUnitsPreference", { value: "metric" }, 30_000],
@@ -848,6 +849,7 @@ describe("RPC receive and observers", () => {
           status: "applied",
           applied: { llm: true, intervals: false, session: false },
         },
+        verify_intervals_credential: { approval: "a".repeat(64) },
         getRuntimeConfig: {
           schemaVersion: 3,
           llm: {
@@ -1131,6 +1133,14 @@ describe("RPC receive and observers", () => {
       "getSpendSummary",
       "setDailySpendCap",
     ]);
+    await expect(
+      client.call("verify_intervals_credential", { api_key: "placeholder" }),
+    ).resolves.toEqual({ approval: "a".repeat(64) });
+    expect(received.at(-1)).toMatchObject({
+      id: 36,
+      method: "verify_intervals_credential",
+      params: { api_key: "placeholder" },
+    });
     socket.closeSynchronously = true;
     await client.close();
   });

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -161,6 +161,7 @@ export const COACH_RPC_METHOD_NAMES = [
   "getSetupStatus",
   "saveIntake",
   "configureRuntime",
+  "verify_intervals_credential",
   "getRuntimeConfig",
   "getUnitsPreference",
   "setUnitsPreference",
@@ -633,6 +634,7 @@ const RuntimeIntervalsSchema = z
     api_key: z.string().min(1).max(16_384).optional(),
     clear_credential: z.literal(true).optional(),
     athlete_id: z.string().min(1).max(512).optional(),
+    verification_approval: z.string().length(64).regex(/^[0-9a-f]{64}$/).optional(),
   })
   .strict()
   .superRefine((value, context) => {
@@ -641,6 +643,13 @@ const RuntimeIntervalsSchema = z
         code: "custom",
         path: ["clear_credential"],
         message: "clear_credential must be the only intervals patch field",
+      });
+    }
+    if (value.verification_approval !== undefined && value.api_key === undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["verification_approval"],
+        message: "verification_approval requires api_key",
       });
     }
     if (Object.keys(value).length === 0) {
@@ -737,6 +746,43 @@ export const ConfigureRuntimeRpcResultSchema = z.discriminatedUnion("status", [
     .strict(),
 ]);
 export type ConfigureRuntimeRpcResult = z.infer<typeof ConfigureRuntimeRpcResultSchema>;
+
+export const IntervalsCredentialVerificationRefusalReasonSchema = z.enum([
+  "credential-rejected",
+  "malformed-athlete-response",
+  "validation-timeout",
+  "validation-aborted",
+  "validation-unavailable",
+  "training-account-mismatch",
+  "owner-unresolved",
+  "store-unavailable",
+]);
+export type IntervalsCredentialVerificationRefusalReason = z.infer<
+  typeof IntervalsCredentialVerificationRefusalReasonSchema
+>;
+
+export const IntervalsCredentialApprovalSchema = z
+  .string()
+  .length(64)
+  .regex(/^[0-9a-f]{64}$/);
+export type IntervalsCredentialApproval = z.infer<typeof IntervalsCredentialApprovalSchema>;
+
+export const VerifyIntervalsCredentialRpcParamsSchema = z
+  .object({
+    api_key: z.string().min(1).max(16_384),
+  })
+  .strict();
+export type VerifyIntervalsCredentialRpcParams = z.infer<
+  typeof VerifyIntervalsCredentialRpcParamsSchema
+>;
+
+export const VerifyIntervalsCredentialRpcResultSchema = z.union([
+  z.object({ approval: IntervalsCredentialApprovalSchema }).strict(),
+  z.object({ reason: IntervalsCredentialVerificationRefusalReasonSchema }).strict(),
+]);
+export type VerifyIntervalsCredentialRpcResult = z.infer<
+  typeof VerifyIntervalsCredentialRpcResultSchema
+>;
 
 export const RuntimeConfigSnapshotSchema = z
   .object({
@@ -868,6 +914,10 @@ export interface CoachOperations {
     request: ConfigureRuntimeRpcParams,
     signal?: AbortSignal,
   ): Promise<ConfigureRuntimeRpcResult>;
+  verify_intervals_credential?(
+    request: VerifyIntervalsCredentialRpcParams,
+    signal?: AbortSignal,
+  ): Promise<VerifyIntervalsCredentialRpcResult>;
   getRuntimeConfig(request: GetRuntimeConfigRpcParams): Promise<GetRuntimeConfigRpcResult>;
   getUnitsPreference?(request: GetUnitsPreferenceRpcParams): Promise<GetUnitsPreferenceRpcResult>;
   setUnitsPreference?(request: SetUnitsPreferenceRpcParams): Promise<SetUnitsPreferenceRpcResult>;
@@ -1023,6 +1073,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("configureRuntime"),
       params: ConfigureRuntimeRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("verify_intervals_credential"),
+      params: VerifyIntervalsCredentialRpcParamsSchema,
     })
     .strict(),
   z
@@ -1384,6 +1442,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "configureRuntime",
     requestSchema: ConfigureRuntimeRpcParamsSchema,
     responseSchema: ConfigureRuntimeRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  verify_intervals_credential: {
+    wireName: "verify_intervals_credential",
+    requestSchema: VerifyIntervalsCredentialRpcParamsSchema,
+    responseSchema: VerifyIntervalsCredentialRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
   getRuntimeConfig: {

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -35,6 +35,8 @@ import {
   ImportFilesRpcParamsSchema,
   ImportFilesRpcResultSchema,
   InspectTelegramCredentialRpcParamsSchema,
+  IntervalsCredentialApprovalSchema,
+  IntervalsCredentialVerificationRefusalReasonSchema,
   OperationProgressEventSchema,
   Protocol11AcceptedServerHandshakeFrameSchema,
   SaveIntakeRpcParamsSchema,
@@ -73,6 +75,8 @@ import {
   ServerHandshakeFrameSchema,
   TurnEventSchema,
   UNKNOWN_CYCLING_TRAINING_CONTEXT,
+  VerifyIntervalsCredentialRpcParamsSchema,
+  VerifyIntervalsCredentialRpcResultSchema,
   compareProtocolVersions,
   createAcceptedServerHandshakeFrame,
   createClientHandshakeFrame,
@@ -122,6 +126,7 @@ function transcriptCursor(): string {
 }
 
 const BOUNDARY_REF = "a".repeat(64);
+const INTERVALS_APPROVAL = "b".repeat(64);
 
 describe("Telegram clipboard credentials", () => {
   it("accepts representative bot-token syntax without claiming provenance or narrowing the wire credential", () => {
@@ -290,6 +295,12 @@ describe("coach request and event projection", () => {
         id: 8,
         method: "configureRuntime",
         params: { llm: { provider: "anthropic", api_key: "placeholder" } },
+      },
+      {
+        jsonrpc: "2.0",
+        id: 37,
+        method: "verify_intervals_credential",
+        params: { api_key: "placeholder" },
       },
       { jsonrpc: "2.0", id: 9, method: "getRuntimeConfig", params: {} },
       { jsonrpc: "2.0", id: 10, method: "getUnitsPreference", params: {} },
@@ -699,6 +710,12 @@ describe("coach request and event projection", () => {
       { llm: { model: "model-only" } },
       { llm: { provider: "anthropic", clear_credential: true } },
       { intervals },
+      {
+        intervals: {
+          api_key: "placeholder",
+          verification_approval: INTERVALS_APPROVAL,
+        },
+      },
       { intervals: { athlete_id: "athlete-a" } },
       { intervals: { clear_credential: true } },
       {
@@ -759,6 +776,9 @@ describe("coach request and event projection", () => {
         session: { timezone: "UTC" },
       },
       { intervals: { api_key: "" } },
+      { intervals: { verification_approval: INTERVALS_APPROVAL } },
+      { intervals: { api_key: "placeholder", verification_approval: "A".repeat(64) } },
+      { intervals: { api_key: "placeholder", verification_approval: "a".repeat(63) } },
       { intervals: { clear_credential: true, athlete_id: "athlete-a" } },
       {
         llm: { provider: "anthropic", clear_credential: true },
@@ -796,6 +816,33 @@ describe("coach request and event projection", () => {
       }).success,
     ).toBe(false);
     expect(JSON.stringify(result)).not.toContain("placeholder");
+    expect(IntervalsCredentialApprovalSchema.parse(INTERVALS_APPROVAL)).toBe(
+      INTERVALS_APPROVAL,
+    );
+    expect(
+      VerifyIntervalsCredentialRpcParamsSchema.parse({ api_key: "placeholder" }),
+    ).toEqual({ api_key: "placeholder" });
+    for (const invalid of [
+      {},
+      { api_key: "" },
+      { api_key: "placeholder", athlete_id: "athlete-a" },
+    ]) {
+      expect(VerifyIntervalsCredentialRpcParamsSchema.safeParse(invalid).success).toBe(false);
+    }
+    expect(
+      VerifyIntervalsCredentialRpcResultSchema.parse({ approval: INTERVALS_APPROVAL }),
+    ).toEqual({ approval: INTERVALS_APPROVAL });
+    for (const reason of IntervalsCredentialVerificationRefusalReasonSchema.options) {
+      expect(VerifyIntervalsCredentialRpcResultSchema.parse({ reason })).toEqual({ reason });
+    }
+    for (const invalid of [
+      { approval: "A".repeat(64) },
+      { approval: INTERVALS_APPROVAL, reason: "credential-rejected" },
+      { reason: "credential-rejected", status: "refused" },
+      { reason: "unknown" },
+    ]) {
+      expect(VerifyIntervalsCredentialRpcResultSchema.safeParse(invalid).success).toBe(false);
+    }
     const snapshot = {
       schemaVersion: 3,
       llm: {
@@ -1001,6 +1048,7 @@ describe("coach request and event projection", () => {
           session: session !== undefined,
         },
       }),
+      verify_intervals_credential: async () => ({ approval: INTERVALS_APPROVAL }),
       getRuntimeConfig: async () => ({
         schemaVersion: 3,
         llm: { provider: "anthropic", model: "model", credential_configured: false },
@@ -1134,6 +1182,12 @@ describe("coach request and event projection", () => {
       wireName: "configureRuntime",
       requestSchema: ConfigureRuntimeRpcParamsSchema,
       responseSchema: ConfigureRuntimeRpcResultSchema,
+      eventSchema: NoRpcEventSchema,
+    });
+    expect(COACH_RPC_METHOD_REGISTRY.verify_intervals_credential).toEqual({
+      wireName: "verify_intervals_credential",
+      requestSchema: VerifyIntervalsCredentialRpcParamsSchema,
+      responseSchema: VerifyIntervalsCredentialRpcResultSchema,
       eventSchema: NoRpcEventSchema,
     });
     expect(COACH_RPC_METHOD_REGISTRY.getRuntimeConfig).toEqual({
@@ -1283,6 +1337,7 @@ describe("coach request and event projection", () => {
       "getAthleteState",
       "saveIntake",
       "configureRuntime",
+      "verify_intervals_credential",
       "getRuntimeConfig",
       "getUnitsPreference",
       "setUnitsPreference",

--- a/packages/coach/src/account-identity.ts
+++ b/packages/coach/src/account-identity.ts
@@ -90,6 +90,25 @@ export type IntervalsCredentialVerificationResult =
 
 export type IntervalsStoreOwnerComparison = Exclude<StoreOwnerCheckResult, "unresolved">;
 
+export type IntervalsStoreOwnerState =
+  | Readonly<{ status: "unowned" }>
+  | Readonly<{ status: "owned"; fingerprint: string }>;
+
+export interface IntervalsCredentialVerificationEvidence {
+  readonly verifiedFingerprint: string;
+  readonly ownerState: IntervalsStoreOwnerState;
+}
+
+export type IntervalsCredentialVerificationWithEvidenceResult =
+  | Readonly<{
+      status: "verified";
+      evidence: IntervalsCredentialVerificationEvidence;
+    }>
+  | Readonly<{
+      status: "refused";
+      reason: IntervalsCredentialVerificationRefusalReason;
+    }>;
+
 const lookupArchiveResult: ArchiveWriteResult = Object.freeze({
   address: "0".repeat(64),
   relPath: "1970/01/lookup.json.gz",
@@ -134,6 +153,15 @@ async function readStoreOwnerFingerprint(
     throw new Error("invalid store owner row");
   }
   return current.account_fingerprint;
+}
+
+export async function readIntervalsStoreOwnerState(
+  store: Pick<SqlStore, "get">,
+): Promise<IntervalsStoreOwnerState> {
+  const fingerprint = await readStoreOwnerFingerprint(store);
+  return fingerprint === undefined
+    ? Object.freeze({ status: "unowned" })
+    : Object.freeze({ status: "owned", fingerprint });
 }
 
 async function compareStoreOwner(
@@ -301,6 +329,43 @@ export async function assertRuntimeAthleteOwner(
   }
 }
 
+export async function assertRuntimeAthleteOwnerFromEvidence(
+  store: SqlStore,
+  evidence: IntervalsCredentialVerificationEvidence,
+  signal: AbortSignal,
+): Promise<RuntimeAthleteOwnerClaim | undefined> {
+  if (
+    !/^[0-9a-f]{64}$/.test(evidence.verifiedFingerprint) ||
+    (evidence.ownerState.status === "owned" &&
+      evidence.ownerState.fingerprint !== evidence.verifiedFingerprint)
+  ) {
+    throw new TypeError("invalid intervals credential verification evidence");
+  }
+  try {
+    signal.throwIfAborted();
+  } catch {
+    throw new RuntimeAthleteOwnerRefusal("candidate-unresolved");
+  }
+  const ownership = await compareStoreOwner(store, evidence.verifiedFingerprint);
+  try {
+    signal.throwIfAborted();
+  } catch {
+    throw new RuntimeAthleteOwnerRefusal("candidate-unresolved");
+  }
+  if (ownership === "mismatch") throw new RuntimeAthleteOwnerRefusal("mismatch");
+  if (ownership === "matched") return undefined;
+  return Object.freeze({
+    async claim() {
+      try {
+        signal.throwIfAborted();
+      } catch {
+        throw new RuntimeAthleteOwnerRefusal("candidate-unresolved");
+      }
+      await store.run(CLAIM_STORE_OWNER_SQL, [evidence.verifiedFingerprint]);
+    },
+  });
+}
+
 export async function enforceIntervalsStoreOwner(
   store: SqlStore,
   options: StoreOwnerCheckOptions,
@@ -440,7 +505,7 @@ function timeoutFailure(error: unknown): boolean {
   );
 }
 
-export async function verifyIntervalsCredentialAtPath(
+export async function verifyIntervalsCredentialAtPathWithEvidence(
   storePath: string,
   options: Omit<StoreOwnerCheckOptions, "signal" | "budget"> & {
     readonly signal: AbortSignal;
@@ -451,7 +516,7 @@ export async function verifyIntervalsCredentialAtPath(
       fingerprint: string,
     ) => Promise<IntervalsStoreOwnerComparison>;
   },
-): Promise<IntervalsCredentialVerificationResult> {
+): Promise<IntervalsCredentialVerificationWithEvidenceResult> {
   const overallTimeoutMs = options.overallTimeoutMs ?? INTERVALS_CREDENTIAL_VERIFICATION_TIMEOUT_MS;
   const perRequestTimeoutMs =
     options.perRequestTimeoutMs ?? INTERVALS_CREDENTIAL_REQUEST_TIMEOUT_MS;
@@ -536,7 +601,16 @@ export async function verifyIntervalsCredentialAtPath(
       }
       comparison = "store-unavailable";
     }
-    if (comparison === "matched" || comparison === "unowned") return { status: "verified" };
+    if (comparison === "matched" || comparison === "unowned") {
+      const ownerState: IntervalsStoreOwnerState =
+        comparison === "unowned"
+          ? Object.freeze({ status: "unowned" })
+          : Object.freeze({ status: "owned", fingerprint });
+      return {
+        status: "verified",
+        evidence: Object.freeze({ verifiedFingerprint: fingerprint, ownerState }),
+      };
+    }
     if (comparison === "mismatch") {
       return { status: "refused", reason: "training-account-mismatch" };
     }
@@ -544,4 +618,20 @@ export async function verifyIntervalsCredentialAtPath(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export async function verifyIntervalsCredentialAtPath(
+  storePath: string,
+  options: Omit<StoreOwnerCheckOptions, "signal" | "budget"> & {
+    readonly signal: AbortSignal;
+    readonly overallTimeoutMs?: number;
+    readonly perRequestTimeoutMs?: number;
+    readonly compareOwner?: (
+      storePath: string,
+      fingerprint: string,
+    ) => Promise<IntervalsStoreOwnerComparison>;
+  },
+): Promise<IntervalsCredentialVerificationResult> {
+  const result = await verifyIntervalsCredentialAtPathWithEvidence(storePath, options);
+  return result.status === "verified" ? { status: "verified" } : result;
 }

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -80,6 +80,8 @@ import {
   type ListArchivedConversationsRpcParams,
   type ListArchivedConversationsRpcResult,
   type GetRuntimeConfigRpcResult,
+  type VerifyIntervalsCredentialRpcParams,
+  type VerifyIntervalsCredentialRpcResult,
 } from "@enduragent/coach-contract";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import { createPersistedAthleteStateSource } from "./athlete-state-reader.js";
@@ -90,6 +92,16 @@ import {
   RuntimeAthleteOwnerRefusal,
   type RuntimeAthleteOwnerClaim,
 } from "./backfill.js";
+import {
+  assertRuntimeAthleteOwnerFromEvidence,
+  readIntervalsStoreOwnerState,
+  verifyIntervalsCredentialAtPathWithEvidence,
+} from "./account-identity.js";
+import {
+  createIntervalsCredentialApprovalStore,
+  digestIntervalsCredential,
+  normalizeIntervalsAthleteSelector,
+} from "./intervals-credential-approval.js";
 import { createCoachEngineAdapter } from "./coach-engine-adapter.js";
 import {
   createStoreRuntime,
@@ -729,6 +741,8 @@ export async function createLocalCoachComposition(
   }
   const now = dependencies.now ?? Date.now;
   const ownerClock = { now, monotonicNow: () => performance.now() };
+  const intervalsCredentialApprovals = createIntervalsCredentialApprovalStore({ now });
+  let intervalsConfigRevision = 0;
   const ownerLookup = (intervals: Config["intervals"]) => ({
     apiKey: intervals.apiKey,
     athleteId: intervals.athleteId.length === 0 ? "0" : intervals.athleteId,
@@ -740,7 +754,30 @@ export async function createLocalCoachComposition(
     candidate: Config["intervals"],
     signal: AbortSignal,
     claimUnownedCandidateWithoutCurrent = false,
+    verificationApproval?: string,
   ): Promise<RuntimeAthleteOwnerClaim | undefined> => {
+    if (verificationApproval !== undefined) {
+      let ownerState: Awaited<ReturnType<typeof readIntervalsStoreOwnerState>> | undefined;
+      try {
+        ownerState = await readIntervalsStoreOwnerState(input.context.store);
+      } catch {}
+      if (ownerState !== undefined) {
+        const evidence = intervalsCredentialApprovals.consume({
+          approval: verificationApproval,
+          credentialDigest: digestIntervalsCredential(candidate.apiKey),
+          athleteSelector: normalizeIntervalsAthleteSelector(candidate.athleteId),
+          ownerState,
+          configRevision: intervalsConfigRevision,
+        });
+        if (evidence !== undefined) {
+          return await assertRuntimeAthleteOwnerFromEvidence(
+            input.context.store,
+            evidence,
+            signal,
+          );
+        }
+      }
+    }
     const approval = await (dependencies.assertRuntimeAthleteOwner ?? assertRuntimeAthleteOwner)(
       input.context.store,
       {
@@ -761,6 +798,33 @@ export async function createLocalCoachComposition(
       intervals: { ...activeConfig.intervals, athleteId: "0" },
     };
   }
+  const verifyIntervalsCredential = async (
+    request: VerifyIntervalsCredentialRpcParams,
+    signal: AbortSignal,
+  ): Promise<VerifyIntervalsCredentialRpcResult> => {
+    const athleteSelector = normalizeIntervalsAthleteSelector(activeConfig.intervals.athleteId);
+    const configRevision = intervalsConfigRevision;
+    const verification = await verifyIntervalsCredentialAtPathWithEvidence(
+      join(input.home.storeDir, "store.db"),
+      {
+        apiKey: request.api_key,
+        athleteId: athleteSelector,
+        historyNewestDate: new Date(now()).toISOString().slice(0, 10),
+        clock: ownerClock,
+        signal,
+      },
+    );
+    if (verification.status === "refused") return { reason: verification.reason };
+    signal.throwIfAborted();
+    return {
+      approval: intervalsCredentialApprovals.issue({
+        apiKey: request.api_key,
+        athleteSelector,
+        evidence: verification.evidence,
+        configRevision,
+      }),
+    };
+  };
   let runtime: LocalStoreRuntime | undefined;
   let reference: LocalReferenceRuntime | undefined;
   let closePromise: Promise<void> | undefined;
@@ -959,6 +1023,9 @@ export async function createLocalCoachComposition(
         (request.intervals?.api_key !== undefined ||
           request.intervals?.clear_credential === true) &&
         candidate.intervals.apiKey !== activeConfig.intervals.apiKey;
+      const intervalsConfigChanged =
+        candidate.intervals.apiKey !== activeConfig.intervals.apiKey ||
+        candidate.intervals.athleteId !== activeConfig.intervals.athleteId;
       let pendingOwnerClaim: RuntimeAthleteOwnerClaim | undefined;
       if (athleteIdChanged || (apiKeyChanged && request.intervals?.clear_credential !== true)) {
         if (
@@ -974,6 +1041,7 @@ export async function createLocalCoachComposition(
             candidate.intervals,
             signal,
             activeConfig.intervals.apiKey.length === 0 && candidate.intervals.apiKey.length > 0,
+            request.intervals?.verification_approval,
           );
         } catch (error) {
           if (!(error instanceof RuntimeAthleteOwnerRefusal)) throw error;
@@ -1024,6 +1092,7 @@ export async function createLocalCoachComposition(
           throw error;
         }
         activeConfig = candidate;
+        if (intervalsConfigChanged) intervalsConfigRevision += 1;
         activeTimezone = replacement.timezone;
         return replacement;
       });
@@ -1116,6 +1185,7 @@ export async function createLocalCoachComposition(
           readArchivedTranscriptPage: (request) =>
             reconfigurable.getArchivedTranscriptPage(request),
           applyRuntimeConfig,
+          verifyIntervalsCredential,
           readRuntimeConfig: () =>
             runtimeConfigSnapshot(input.home.configDir, activeConfig, input.env, activeTimezone),
         },

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -1082,6 +1082,23 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               invocationFailure = { error };
             }
             break;
+          case "verify_intervals_credential":
+            try {
+              const request =
+                COACH_RPC_METHOD_REGISTRY.verify_intervals_credential.requestSchema.parse(
+                  generic.data.params,
+                );
+              if (input.operations.verify_intervals_credential === undefined) {
+                throw new TypeError("Intervals credential verification is unavailable.");
+              }
+              result = await input.operations.verify_intervals_credential(
+                request,
+                state.detachController.signal,
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
           case "getRuntimeConfig":
             try {
               const request = COACH_RPC_METHOD_REGISTRY.getRuntimeConfig.requestSchema.parse(

--- a/packages/coach/src/intervals-credential-approval.ts
+++ b/packages/coach/src/intervals-credential-approval.ts
@@ -1,0 +1,185 @@
+import { createHash, randomBytes as systemRandomBytes, timingSafeEqual } from "node:crypto";
+import type {
+  IntervalsCredentialVerificationEvidence,
+  IntervalsStoreOwnerState,
+} from "./account-identity.js";
+
+export const INTERVALS_CREDENTIAL_APPROVAL_TTL_MS = 60_000;
+export const INTERVALS_PENDING_APPROVALS_PER_GENERATION = 1;
+export const INTERVALS_APPROVAL_TOKEN_BYTES = 32;
+
+export interface IntervalsCredentialApprovalIssue {
+  readonly apiKey: string;
+  readonly athleteSelector: string;
+  readonly evidence: IntervalsCredentialVerificationEvidence;
+  readonly configRevision: number;
+}
+
+export interface IntervalsCredentialApprovalConsumption {
+  readonly approval: string;
+  readonly credentialDigest: string;
+  readonly athleteSelector: string;
+  readonly ownerState: IntervalsStoreOwnerState;
+  readonly configRevision: number;
+}
+
+export interface IntervalsCredentialApprovalStore {
+  issue(input: IntervalsCredentialApprovalIssue): string;
+  consume(
+    input: IntervalsCredentialApprovalConsumption,
+  ): IntervalsCredentialVerificationEvidence | undefined;
+}
+
+export interface IntervalsCredentialApprovalStoreDependencies {
+  readonly now?: () => number;
+  readonly randomBytes?: (size: number) => Uint8Array;
+}
+
+type PendingApproval = Readonly<{
+  token: string;
+  credentialDigest: string;
+  athleteSelector: string;
+  evidence: IntervalsCredentialVerificationEvidence;
+  configRevision: number;
+  expiresAtMs: number;
+}>;
+
+export function digestIntervalsCredential(apiKey: string): string {
+  if (typeof apiKey !== "string") throw new TypeError("invalid intervals credential");
+  return createHash("sha256").update(apiKey).digest("hex");
+}
+
+export function normalizeIntervalsAthleteSelector(athleteSelector: string): string {
+  if (typeof athleteSelector !== "string") {
+    throw new TypeError("invalid intervals athlete selector");
+  }
+  return athleteSelector.length === 0 ? "0" : athleteSelector;
+}
+
+function validFingerprint(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
+}
+
+function validOwnerState(value: unknown): value is IntervalsStoreOwnerState {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (record.status === "unowned") return Object.keys(record).length === 1;
+  return (
+    record.status === "owned" &&
+    Object.keys(record).length === 2 &&
+    validFingerprint(record.fingerprint)
+  );
+}
+
+function validRevision(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function ownerStatesMatch(
+  left: IntervalsStoreOwnerState,
+  right: IntervalsStoreOwnerState,
+): boolean {
+  return (
+    left.status === right.status &&
+    (left.status === "unowned" ||
+      (right.status === "owned" && left.fingerprint === right.fingerprint))
+  );
+}
+
+function tokensMatch(left: string, right: string): boolean {
+  if (!/^[0-9a-f]{64}$/.test(left) || !/^[0-9a-f]{64}$/.test(right)) return false;
+  return timingSafeEqual(Buffer.from(left, "hex"), Buffer.from(right, "hex"));
+}
+
+function copyEvidence(
+  evidence: IntervalsCredentialVerificationEvidence,
+): IntervalsCredentialVerificationEvidence {
+  if (
+    !validFingerprint(evidence.verifiedFingerprint) ||
+    !validOwnerState(evidence.ownerState) ||
+    (evidence.ownerState.status === "owned" &&
+      evidence.ownerState.fingerprint !== evidence.verifiedFingerprint)
+  ) {
+    throw new TypeError("invalid intervals credential verification evidence");
+  }
+  const ownerState: IntervalsStoreOwnerState =
+    evidence.ownerState.status === "unowned"
+      ? Object.freeze({ status: "unowned" })
+      : Object.freeze({ status: "owned", fingerprint: evidence.ownerState.fingerprint });
+  return Object.freeze({
+    verifiedFingerprint: evidence.verifiedFingerprint,
+    ownerState,
+  });
+}
+
+export function createIntervalsCredentialApprovalStore(
+  dependencies: IntervalsCredentialApprovalStoreDependencies = {},
+): IntervalsCredentialApprovalStore {
+  const now = dependencies.now ?? Date.now;
+  const randomBytes = dependencies.randomBytes ?? systemRandomBytes;
+  let pending: PendingApproval | undefined;
+
+  return Object.freeze({
+    issue(input: IntervalsCredentialApprovalIssue) {
+      if (typeof input.apiKey !== "string" || input.apiKey.length === 0) {
+        throw new TypeError("invalid intervals credential");
+      }
+      if (!validRevision(input.configRevision)) {
+        throw new TypeError("invalid intervals config revision");
+      }
+      const issuedAtMs = now();
+      const expiresAtMs = issuedAtMs + INTERVALS_CREDENTIAL_APPROVAL_TTL_MS;
+      if (!Number.isSafeInteger(issuedAtMs) || !Number.isSafeInteger(expiresAtMs)) {
+        throw new TypeError("invalid intervals approval time");
+      }
+      const previousToken = pending?.token;
+      let token: string | undefined;
+      for (let attempt = 0; attempt < 8 && token === undefined; attempt += 1) {
+        const bytes = randomBytes(INTERVALS_APPROVAL_TOKEN_BYTES);
+        if (bytes.byteLength !== INTERVALS_APPROVAL_TOKEN_BYTES) {
+          throw new TypeError("invalid intervals approval entropy");
+        }
+        const candidate = Buffer.from(bytes).toString("hex");
+        if (candidate !== previousToken) token = candidate;
+      }
+      if (token === undefined) throw new TypeError("intervals approval entropy repeated");
+      pending = Object.freeze({
+        token,
+        credentialDigest: digestIntervalsCredential(input.apiKey),
+        athleteSelector: normalizeIntervalsAthleteSelector(input.athleteSelector),
+        evidence: copyEvidence(input.evidence),
+        configRevision: input.configRevision,
+        expiresAtMs,
+      });
+      return token;
+    },
+
+    consume(input: IntervalsCredentialApprovalConsumption) {
+      const selected = pending;
+      pending = undefined;
+      if (selected === undefined) return undefined;
+      const consumedAtMs = now();
+      const athleteSelector =
+        typeof input.athleteSelector === "string"
+          ? input.athleteSelector.length === 0
+            ? "0"
+            : input.athleteSelector
+          : undefined;
+      if (
+        !Number.isSafeInteger(consumedAtMs) ||
+        consumedAtMs >= selected.expiresAtMs ||
+        !tokensMatch(selected.token, input.approval) ||
+        !/^[0-9a-f]{64}$/.test(input.credentialDigest) ||
+        selected.credentialDigest !== input.credentialDigest ||
+        selected.athleteSelector !== athleteSelector ||
+        !validOwnerState(input.ownerState) ||
+        !ownerStatesMatch(selected.evidence.ownerState, input.ownerState) ||
+        !validRevision(input.configRevision) ||
+        selected.configRevision !== input.configRevision
+      ) {
+        return undefined;
+      }
+      return selected.evidence;
+    },
+  });
+}

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -22,6 +22,8 @@ import {
   SetUnitsPreferenceRpcResultSchema,
   SyncRpcParamsSchema,
   SyncRpcResultSchema,
+  VerifyIntervalsCredentialRpcParamsSchema,
+  VerifyIntervalsCredentialRpcResultSchema,
   type ConfigureRuntimeRpcParams,
   type ConfigureRuntimeRpcRefusalReason,
   type ConfigureRuntimeRpcResult,
@@ -47,6 +49,8 @@ import {
   type SetUnitsPreferenceRpcResult,
   type SyncRpcParams,
   type SyncRpcResult,
+  type VerifyIntervalsCredentialRpcParams,
+  type VerifyIntervalsCredentialRpcResult,
 } from "@enduragent/coach-contract";
 import { createIntakeRepository, createUnitsPreferenceRepository } from "@enduragent/kernel/store";
 import {
@@ -82,6 +86,10 @@ export interface CreateCoachOperationsInput {
     request: ConfigureRuntimeRpcParams,
     signal: AbortSignal,
   ) => Promise<ConfigureRuntimeRpcRefusalReason | void>;
+  readonly verifyIntervalsCredential?: (
+    request: VerifyIntervalsCredentialRpcParams,
+    signal: AbortSignal,
+  ) => Promise<VerifyIntervalsCredentialRpcResult>;
   readonly readRuntimeConfig?: () => GetRuntimeConfigRpcResult;
 }
 
@@ -353,6 +361,21 @@ export function createCoachOperations(
           });
         };
         return parsedRequest.intervals === undefined ? apply() : input.runtime.runExclusive(apply);
+      });
+    },
+    verify_intervals_credential(
+      request: VerifyIntervalsCredentialRpcParams,
+      callerSignal?: AbortSignal,
+    ): Promise<VerifyIntervalsCredentialRpcResult> {
+      const parsedRequest = VerifyIntervalsCredentialRpcParamsSchema.parse(request);
+      if (input.verifyIntervalsCredential === undefined) {
+        throw new TypeError("Intervals credential verification is unavailable.");
+      }
+      const signal = callerSignal ?? new AbortController().signal;
+      signal.throwIfAborted();
+      return input.verifyIntervalsCredential(parsedRequest, signal).then((result) => {
+        signal.throwIfAborted();
+        return VerifyIntervalsCredentialRpcResultSchema.parse(result);
       });
     },
     getRuntimeConfig(request: GetRuntimeConfigRpcParams): Promise<GetRuntimeConfigRpcResult> {

--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -13,7 +13,10 @@ import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import {
   assertRuntimeAthleteOwner,
+  assertRuntimeAthleteOwnerFromEvidence,
   checkIntervalsStoreOwnerAtPath,
+  verifyIntervalsCredentialAtPath,
+  verifyIntervalsCredentialAtPathWithEvidence,
 } from "../src/account-identity.js";
 import {
   runIntervalsBackfill,
@@ -37,6 +40,7 @@ describe("account identity", () => {
   }>;
   const roots: string[] = [];
   afterEach(() => {
+    vi.unstubAllGlobals();
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
   });
   async function fresh() {
@@ -748,6 +752,161 @@ describe("account identity", () => {
       expect(sync.result).toMatchObject({ pages: 2, artifacts: 0 });
       expect(saveFetch).toHaveBeenCalledOnce();
       expect(sync.baseFetch).toHaveBeenCalledOnce();
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("returns verified fingerprint evidence with the observed owner state", async () => {
+    const compareOwner = vi.fn(async () => "matched" as const);
+    const result = await verifyIntervalsCredentialAtPathWithEvidence("synthetic-store", {
+      apiKey: "synthetic-key",
+      athleteId: "0",
+      historyNewestDate: "1900-12-31",
+      clock,
+      signal: new AbortController().signal,
+      sleep: async () => {},
+      baseFetch: profileFetch("synthetic-athlete"),
+      compareOwner,
+    });
+
+    expect(result).toEqual({
+      status: "verified",
+      evidence: {
+        verifiedFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/),
+        ownerState: {
+          status: "owned",
+          fingerprint: expect.stringMatching(/^[0-9a-f]{64}$/),
+        },
+      },
+    });
+    if (result.status !== "verified" || result.evidence.ownerState.status !== "owned") {
+      throw new Error("expected owned verification evidence");
+    }
+    expect(result.evidence.ownerState.fingerprint).toBe(result.evidence.verifiedFingerprint);
+    expect(compareOwner).toHaveBeenCalledWith(
+      "synthetic-store",
+      result.evidence.verifiedFingerprint,
+    );
+  });
+
+  it.each([
+    {
+      reason: "credential-rejected" as const,
+      options: () => ({
+        baseFetch: vi.fn(async () => new Response(null, { status: 401 })),
+      }),
+    },
+    {
+      reason: "malformed-athlete-response" as const,
+      options: () => ({
+        baseFetch: vi.fn(
+          async () =>
+            new Response(JSON.stringify({ sportSettings: "invalid" }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+        ),
+      }),
+    },
+    {
+      reason: "validation-timeout" as const,
+      options: () => ({
+        baseFetch: vi.fn(async () => await new Promise<Response>(() => {})),
+        overallTimeoutMs: 5,
+      }),
+    },
+    {
+      reason: "validation-aborted" as const,
+      options: () => {
+        const controller = new AbortController();
+        controller.abort(new Error("synthetic shutdown"));
+        return { signal: controller.signal };
+      },
+    },
+    {
+      reason: "validation-unavailable" as const,
+      options: () => ({
+        baseFetch: vi.fn(async () => {
+          throw new Error("synthetic transport failure");
+        }),
+      }),
+    },
+    {
+      reason: "training-account-mismatch" as const,
+      options: () => ({
+        baseFetch: profileFetch("synthetic-athlete"),
+        compareOwner: vi.fn(async () => "mismatch" as const),
+      }),
+    },
+    {
+      reason: "owner-unresolved" as const,
+      options: () => ({ baseFetch: unresolvedProfileFetch() }),
+    },
+    {
+      reason: "store-unavailable" as const,
+      options: () => ({
+        baseFetch: profileFetch("synthetic-athlete"),
+        compareOwner: vi.fn(async () => "store-unavailable" as const),
+      }),
+    },
+  ])("keeps $reason refusal parity in the evidence verifier", async ({ reason, options }) => {
+    const run = async (
+      verify: typeof verifyIntervalsCredentialAtPath,
+    ) => {
+      const selected = options();
+      return await verify("synthetic-store", {
+        apiKey: "synthetic-key",
+        athleteId: "0",
+        historyNewestDate: "1900-12-31",
+        clock,
+        signal: new AbortController().signal,
+        sleep: async () => {},
+        compareOwner: async () => "matched",
+        ...selected,
+      });
+    };
+
+    const expected = { status: "refused", reason } as const;
+    await expect(run(verifyIntervalsCredentialAtPath)).resolves.toEqual(expected);
+    await expect(run(verifyIntervalsCredentialAtPathWithEvidence)).resolves.toEqual(expected);
+  });
+
+  it("compares and claims verified evidence locally without fetching", async () => {
+    const value = await fresh();
+    const baseFetch = vi.fn();
+    vi.stubGlobal("fetch", baseFetch);
+    const fingerprint = "a".repeat(64);
+    const signal = new AbortController().signal;
+    try {
+      const claim = await assertRuntimeAthleteOwnerFromEvidence(
+        value.store,
+        {
+          verifiedFingerprint: fingerprint,
+          ownerState: { status: "unowned" },
+        },
+        signal,
+      );
+
+      expect(baseFetch).not.toHaveBeenCalled();
+      expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+        count: 0,
+      });
+      await claim?.claim();
+      expect(await value.store.get("SELECT account_fingerprint FROM store_owner")).toEqual({
+        account_fingerprint: fingerprint,
+      });
+      await expect(
+        assertRuntimeAthleteOwnerFromEvidence(
+          value.store,
+          {
+            verifiedFingerprint: fingerprint,
+            ownerState: { status: "owned", fingerprint },
+          },
+          signal,
+        ),
+      ).resolves.toBeUndefined();
+      expect(baseFetch).not.toHaveBeenCalled();
     } finally {
       await value.store.close();
     }

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -36,6 +36,7 @@ import {
   type LocalStoreRuntimeOptions,
 } from "../src/composition.js";
 import { RuntimeAthleteOwnerRefusal } from "../src/backfill.js";
+import { INTERVALS_CREDENTIAL_APPROVAL_TTL_MS } from "../src/intervals-credential-approval.js";
 import { checkHomeReadiness } from "../src/readiness.js";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
 
@@ -272,6 +273,50 @@ function fakeContext(home: AthleteHome): CoachStoreWriterContext {
       },
     },
   };
+}
+
+async function intervalsApprovalFixture(now: () => number) {
+  const home = await freshHome();
+  await mkdir(home.storeDir, { recursive: true });
+  const store = openSqliteStorage(join(home.storeDir, "store.db"));
+  stores.push(store);
+  await runMigrations(store, MIGRATIONS);
+  const fetchStub = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.pathname !== "/api/v1/athlete/0") throw new Error("unexpected request");
+    return new Response(
+      JSON.stringify({
+        sportSettings: [
+          {
+            id: 1,
+            athlete_id: "synthetic-approved-owner",
+            types: ["Ride"],
+            updated: "2026-01-01",
+          },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  });
+  const ownerGuard = vi.fn(async () => {});
+  const lifecycle = await compose(
+    home,
+    {
+      bootstrap: async () => reference(),
+      createRuntime: () => runtime(),
+      createBackend: () => backend(),
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
+      createResolver: () => missingResolver(),
+      assertRuntimeAthleteOwner: ownerGuard,
+      now,
+    },
+    { home, store, listener: inertWriterProtocolListener },
+    { apiKey: "", athleteId: "" },
+  );
+  return { lifecycle, ownerGuard, fetchStub };
 }
 
 async function compose(
@@ -2150,6 +2195,68 @@ describe("local coach composition", () => {
     },
   );
 
+  it("uses a fresh daemon approval without repeating the owner guard request", async () => {
+    const { lifecycle, ownerGuard, fetchStub } = await intervalsApprovalFixture(() =>
+      Date.parse("2026-08-11T00:00:00.000Z"),
+    );
+    const verification = await lifecycle.operations.verify_intervals_credential!({
+      api_key: "candidate-key",
+    });
+    if (!("approval" in verification)) throw new Error("expected credential approval");
+
+    expect(fetchStub).toHaveBeenCalledOnce();
+    expect(ownerGuard).not.toHaveBeenCalled();
+    await expect(
+      lifecycle.operations.configureRuntime({
+        intervals: {
+          api_key: "candidate-key",
+          verification_approval: verification.approval,
+        },
+      }),
+    ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
+    expect(fetchStub).toHaveBeenCalledOnce();
+    expect(ownerGuard).not.toHaveBeenCalled();
+    await lifecycle.close();
+  });
+
+  it.each(["invalid", "expired", "reused"] as const)(
+    "falls back to the existing owner guard for an %s approval",
+    async (scenario) => {
+      let now = Date.parse("2026-08-11T00:00:00.000Z");
+      const { lifecycle, ownerGuard, fetchStub } = await intervalsApprovalFixture(() => now);
+      const verification = await lifecycle.operations.verify_intervals_credential!({
+        api_key: "candidate-key",
+      });
+      if (!("approval" in verification)) throw new Error("expected credential approval");
+      let approval = verification.approval;
+
+      if (scenario === "invalid") {
+        approval = `${approval[0] === "0" ? "1" : "0"}${approval.slice(1)}`;
+      } else if (scenario === "expired") {
+        now += INTERVALS_CREDENTIAL_APPROVAL_TTL_MS;
+      } else {
+        await expect(
+          lifecycle.operations.configureRuntime({
+            intervals: { api_key: "candidate-key", verification_approval: approval },
+          }),
+        ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
+        await expect(
+          lifecycle.operations.configureRuntime({ intervals: { clear_credential: true } }),
+        ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
+      }
+
+      const ownerCallsBefore = ownerGuard.mock.calls.length;
+      await expect(
+        lifecycle.operations.configureRuntime({
+          intervals: { api_key: "candidate-key", verification_approval: approval },
+        }),
+      ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
+      expect(ownerGuard.mock.calls.length - ownerCallsBefore).toBe(1);
+      expect(fetchStub).toHaveBeenCalledOnce();
+      await lifecycle.close();
+    },
+  );
+
   it("refuses an environment-managed athlete field even when the requested value is unchanged", async () => {
     const home = await freshHome();
     const initialYaml = "sentinel: unchanged\n";
@@ -2491,6 +2598,7 @@ describe("local coach composition", () => {
     );
 
     expect(trace.slice(0, 3)).toEqual(["owner:0", "runtime:0", "window:0"]);
+    expect(assertRuntimeAthleteOwner).toHaveBeenCalledOnce();
     await lifecycle.close();
   });
 

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -955,6 +955,115 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     await client.close();
   });
 
+  it("dispatches strict intervals credential preflight results without echoing the candidate", async () => {
+    const token = "x".repeat(43);
+    let refuse = false;
+    const verifyIntervalsCredential = vi.fn(async () =>
+      refuse
+        ? ({ reason: "credential-rejected" as const })
+        : ({ approval: "a".repeat(64) }),
+    );
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: { ...operations, verify_intervals_credential: verifyIntervalsCredential },
+      token,
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "intervals-preflight",
+        method: "verify_intervals_credential",
+        params: { api_key: "synthetic-candidate-key" },
+      }),
+    );
+    const approved = parseCoachRpcEnvelope(await client.frames.next());
+    expect(approved).toEqual({
+      jsonrpc: "2.0",
+      id: "intervals-preflight",
+      result: { approval: "a".repeat(64) },
+    });
+    expect(JSON.stringify(approved)).not.toContain("synthetic-candidate-key");
+    expect(verifyIntervalsCredential).toHaveBeenLastCalledWith(
+      { api_key: "synthetic-candidate-key" },
+      expect.any(AbortSignal),
+    );
+
+    refuse = true;
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "intervals-refusal",
+        method: "verify_intervals_credential",
+        params: { api_key: "synthetic-candidate-key" },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "intervals-refusal",
+      result: { reason: "credential-rejected" },
+    });
+
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "intervals-invalid",
+        method: "verify_intervals_credential",
+        params: { api_key: "synthetic-candidate-key", athlete_id: "synthetic-athlete" },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+      id: "intervals-invalid",
+      error: { code: -32602, message: "Invalid params" },
+    });
+    expect(verifyIntervalsCredential).toHaveBeenCalledTimes(2);
+    await client.close();
+  });
+
+  it("aborts intervals credential preflight when its requesting connection detaches", async () => {
+    const token = "x".repeat(43);
+    const started = deferred<void>();
+    let operationSignal: AbortSignal | undefined;
+    const verifyIntervalsCredential = vi.fn(
+      async (_request, signal?: AbortSignal): Promise<never> => {
+        operationSignal = signal;
+        started.resolve(undefined);
+        return await new Promise<never>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      },
+    );
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: { ...operations, verify_intervals_credential: verifyIntervalsCredential },
+      token,
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "intervals-preflight-detach",
+        method: "verify_intervals_credential",
+        params: { api_key: "synthetic-candidate-key" },
+      }),
+    );
+    await started.promise;
+
+    const closed = new Promise<void>((resolve) => client.ws.once("close", () => resolve()));
+    client.ws.close();
+    await closed;
+    await vi.waitFor(() => expect(operationSignal?.aborted).toBe(true));
+
+    await client.close();
+  });
+
   it("aborts activity analysis when its requesting connection detaches", async () => {
     const token = "x".repeat(43);
     const started = deferred<void>();

--- a/packages/coach/tests/intervals-credential-approval.test.ts
+++ b/packages/coach/tests/intervals-credential-approval.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  createIntervalsCredentialApprovalStore,
+  digestIntervalsCredential,
+  INTERVALS_APPROVAL_TOKEN_BYTES,
+  INTERVALS_CREDENTIAL_APPROVAL_TTL_MS,
+  INTERVALS_PENDING_APPROVALS_PER_GENERATION,
+} from "../src/intervals-credential-approval.js";
+import type {
+  IntervalsCredentialVerificationEvidence,
+  IntervalsStoreOwnerState,
+} from "../src/account-identity.js";
+
+const fingerprint = "a".repeat(64);
+const evidence: IntervalsCredentialVerificationEvidence = Object.freeze({
+  verifiedFingerprint: fingerprint,
+  ownerState: Object.freeze({ status: "unowned" }),
+});
+
+function fixture() {
+  let now = 1_000;
+  let entropy = 0;
+  const store = createIntervalsCredentialApprovalStore({
+    now: () => now,
+    randomBytes: (size) => Buffer.alloc(size, ++entropy),
+  });
+  const issue = () =>
+    store.issue({
+      apiKey: "candidate-key",
+      athleteSelector: "",
+      evidence,
+      configRevision: 7,
+    });
+  const consume = (
+    approval: string,
+    overrides: Partial<{
+      credentialDigest: string;
+      athleteSelector: string;
+      ownerState: IntervalsStoreOwnerState;
+      configRevision: number;
+    }> = {},
+  ) =>
+    store.consume({
+      approval,
+      credentialDigest: digestIntervalsCredential("candidate-key"),
+      athleteSelector: "0",
+      ownerState: { status: "unowned" },
+      configRevision: 7,
+      ...overrides,
+    });
+  return {
+    store,
+    issue,
+    consume,
+    advance(ms: number) {
+      now += ms;
+    },
+  };
+}
+
+describe("intervals credential approval", () => {
+  it("issues a 32-byte lowercase hex token and consumes it once", () => {
+    const value = fixture();
+    const approval = value.issue();
+
+    expect(INTERVALS_APPROVAL_TOKEN_BYTES).toBe(32);
+    expect(approval).toMatch(/^[0-9a-f]{64}$/);
+    expect(value.consume(approval)).toEqual(evidence);
+    expect(value.consume(approval)).toBeUndefined();
+  });
+
+  it("expires at the configured TTL and drops the expired entry", () => {
+    const value = fixture();
+    const approval = value.issue();
+
+    expect(INTERVALS_CREDENTIAL_APPROVAL_TTL_MS).toBe(60_000);
+    value.advance(INTERVALS_CREDENTIAL_APPROVAL_TTL_MS);
+    expect(value.consume(approval)).toBeUndefined();
+    value.advance(-1);
+    expect(value.consume(approval)).toBeUndefined();
+  });
+
+  it("replaces a pending approval when another is issued", () => {
+    const value = fixture();
+    const replaced = value.issue();
+    const current = value.issue();
+
+    expect(current).not.toBe(replaced);
+    expect(value.consume(current)).toEqual(evidence);
+    expect(value.consume(replaced)).toBeUndefined();
+  });
+
+  it.each([
+    {
+      binding: "candidate digest",
+      overrides: { credentialDigest: "b".repeat(64) },
+    },
+    {
+      binding: "athlete selector",
+      overrides: { athleteSelector: "different-athlete" },
+    },
+    {
+      binding: "owner state",
+      overrides: {
+        ownerState: { status: "owned", fingerprint } as const,
+      },
+    },
+    {
+      binding: "config revision",
+      overrides: { configRevision: 8 },
+    },
+  ])("drops the entry on a wrong $binding", ({ overrides }) => {
+    const value = fixture();
+    const approval = value.issue();
+
+    expect(value.consume(approval, overrides)).toBeUndefined();
+    expect(value.consume(approval)).toBeUndefined();
+  });
+
+  it("drops the pending entry when a different token is presented", () => {
+    const value = fixture();
+    const approval = value.issue();
+
+    expect(value.consume("f".repeat(64))).toBeUndefined();
+    expect(value.consume(approval)).toBeUndefined();
+  });
+
+  it("keeps one pending entry across repeated issues", () => {
+    const value = fixture();
+    const approvals = Array.from({ length: 10 }, () => value.issue());
+
+    expect(INTERVALS_PENDING_APPROVALS_PER_GENERATION).toBe(1);
+    expect(value.consume(approvals.at(-1)!)).toEqual(evidence);
+    for (const approval of approvals.slice(0, -1)) {
+      expect(value.consume(approval)).toBeUndefined();
+    }
+  });
+});

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -894,6 +894,104 @@ describe("coach operations", () => {
     expect(observedSignal?.aborted).toBe(true);
   });
 
+  it("validates intervals credential preflight requests and results", async () => {
+    const verifyIntervalsCredential = vi.fn(async () => ({ approval: "a".repeat(64) }));
+    const operations = createCoachOperations({
+      home,
+      context: context(),
+      runtime: operationRuntime(),
+      intervalsCredentials: intervalsCredentials(),
+      historyNewestDate: () => "1998-07-18",
+      applyRuntimeConfig: async () => {},
+      verifyIntervalsCredential,
+    });
+
+    await expect(
+      operations.verify_intervals_credential!({ api_key: "synthetic-candidate-key" }),
+    ).resolves.toEqual({ approval: "a".repeat(64) });
+    expect(verifyIntervalsCredential).toHaveBeenCalledWith(
+      { api_key: "synthetic-candidate-key" },
+      expect.any(AbortSignal),
+    );
+    expect(() =>
+      operations.verify_intervals_credential!({
+        api_key: "synthetic-candidate-key",
+        extra: true,
+      } as never),
+    ).toThrow();
+    expect(verifyIntervalsCredential).toHaveBeenCalledOnce();
+
+    const refused = createCoachOperations({
+      home,
+      context: context(),
+      runtime: operationRuntime(),
+      intervalsCredentials: intervalsCredentials(),
+      historyNewestDate: () => "1998-07-18",
+      applyRuntimeConfig: async () => {},
+      verifyIntervalsCredential: async () => ({ reason: "credential-rejected" }),
+    });
+    await expect(
+      refused.verify_intervals_credential!({ api_key: "synthetic-candidate-key" }),
+    ).resolves.toEqual({ reason: "credential-rejected" });
+
+    const malformed = createCoachOperations({
+      home,
+      context: context(),
+      runtime: operationRuntime(),
+      intervalsCredentials: intervalsCredentials(),
+      historyNewestDate: () => "1998-07-18",
+      applyRuntimeConfig: async () => {},
+      verifyIntervalsCredential: async () => ({ approval: "A".repeat(64) }),
+    });
+    await expect(
+      malformed.verify_intervals_credential!({ api_key: "synthetic-candidate-key" }),
+    ).rejects.toThrow();
+
+    const unavailable = createCoachOperations({
+      home,
+      context: context(),
+      runtime: operationRuntime(),
+      intervalsCredentials: intervalsCredentials(),
+      historyNewestDate: () => "1998-07-18",
+      applyRuntimeConfig: async () => {},
+    });
+    expect(() =>
+      unavailable.verify_intervals_credential!({ api_key: "synthetic-candidate-key" }),
+    ).toThrow("Intervals credential verification is unavailable.");
+  });
+
+  it("propagates caller cancellation into intervals credential preflight", async () => {
+    const started = promiseGate();
+    let observedSignal: AbortSignal | undefined;
+    const operations = createCoachOperations({
+      home,
+      context: context(),
+      runtime: operationRuntime(),
+      intervalsCredentials: intervalsCredentials(),
+      historyNewestDate: () => "1998-07-18",
+      applyRuntimeConfig: async () => {},
+      verifyIntervalsCredential: async (_request, signal): Promise<never> => {
+        observedSignal = signal;
+        started.release();
+        return await new Promise<never>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      },
+    });
+    const controller = new AbortController();
+    const pending = operations.verify_intervals_credential!(
+      { api_key: "synthetic-candidate-key" },
+      controller.signal,
+    );
+    await started.promise;
+
+    controller.abort(new DOMException("Detached", "AbortError"));
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(observedSignal).toBe(controller.signal);
+    expect(observedSignal?.aborted).toBe(true);
+  });
+
   it.each([
     "credential-required",
     "ownership-unavailable",


### PR DESCRIPTION
## What

A successful clipboard connect used to verify the pasted intervals.icu key remotely twice back-to-back: once in the main process before saving (fail-closed preflight), then again inside the daemon's ownership guard during `configureRuntime` — same endpoint, same derived owner fingerprint. Connect latency roughly doubled on the happy path.

Now the daemon performs the one verification itself and mints a single-use approval; activation consumes it and skips only the duplicate remote fetch:

- New `verify_intervals_credential` RPC: the daemon verifies the key against intervals.icu (unchanged fail-closed semantics and deadlines) and returns either a typed refusal or a 64-hex opaque token.
- New in-memory approval store (`packages/coach/src/intervals-credential-approval.ts`): the token is bound to the credential digest, athlete selector, verified owner snapshot, and an intervals config revision; timing-safe compare; consume is atomic single-use and burns the entry even on mismatch.
- `configureRuntime` consumes the approval, re-reads owner state from its own store, and uses a local compare/claim; on ANY miss (expired, reused, wrong candidate/owner/revision, daemon restart) it falls back to the existing remote guard unchanged.
- Desktop threads the token as an ephemeral activation-only field: never in vault bytes, persisted config, status objects, renderer IPC, startup replays, or `reapplyConfigured`.

## Compatibility / fallback contract (review-hardened)

- Preflight verified → token lane.
- Preflight refusal → same refusal mapping as before.
- Remote JSON-RPC `-32601` (an already-attached daemon from before this change) → legacy lane: `getRuntimeConfig` + main-local verification + tokenless activation. Typed detection (`CoachRpcRemoteError.code === -32601`), no message matching.
- No attempt possible (binding absent, lifecycle not ready) → legacy lane, HEAD-identical fast refusal, zero connections.
- Attempted connection failed (handshake/transport) → immediate `validation-unavailable`, exactly one connection attempt, vault untouched.

Startup ownership verification and every tokenless `configureRuntime` path are behavior-identical to HEAD.

## Limits

- `INTERVALS_CREDENTIAL_APPROVAL_TTL_MS = 60_000` — bounds the life of an unconsumed approval.
- `INTERVALS_PENDING_APPROVALS_PER_GENERATION = 1` — paste is serialized; replace-on-reissue keeps state bounded.
- `INTERVALS_APPROVAL_TOKEN_BYTES = 32` — 256-bit crypto-random token (64 lowercase hex).
- Existing 20s/8s verification and 25s configure deadlines unchanged.

## Verification

- Full suites in the worktree (Apple Silicon, Node 24): coach 760/760, coach-contract + coach-client 176/176, desktop 1709/1710 — the single failure is `windows-parity-scenarios.test.ts`, broken identically on clean main (`0089c24c`, PR #608) with this diff stashed; not touched by this change.
- Integration trio (onboarding/spend-meter/chat-panels) 9/9 windowless.
- `tsc --noEmit` clean in all four packages.
- Adversarial review: three read-only reviewer passes (trust model, behavior parity, secret leakage). Confirmed findings from round one — older same-version daemon hitting `-32601`, a disk-config fallback that could persist a key the daemon couldn't activate, and doubled connection attempts — are fixed above with regression tests (one-connection-max, vault non-mutation, per-scenario refusal reasons). Remaining round-two notes were judged non-blocking: the fail-open generic onboarding credential bridge predates this PR (tracked separately), approval-after-policy-refusal requires an env-controlled athlete id the desktop never sets, and wall-clock TTL manipulation requires the machine owner to rewind their own clock.