### PR TITLE
feat(desktop): freeze Training Windows parity manifest

### DIFF
--- a/apps/desktop-renderer/src/platform-copy.ts
+++ b/apps/desktop-renderer/src/platform-copy.ts
@@ -9,6 +9,7 @@ export interface DesktopPlatformProjection {
     readonly credentialEncryptionUnavailable: string;
     readonly credentialRecoveryAction: string;
     readonly restartComputer: "restart your Mac" | "restart your PC";
+    readonly rideImportDescription: string;
   };
 }
 
@@ -22,6 +23,8 @@ const DARWIN_FALLBACK: DesktopPlatformProjection = Object.freeze({
       "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
     credentialRecoveryAction: "unlock or approve Keychain access",
     restartComputer: "restart your Mac",
+    rideImportDescription:
+      "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.",
   }),
 });
 

--- a/apps/desktop-renderer/src/ui/training/copy.ts
+++ b/apps/desktop-renderer/src/ui/training/copy.ts
@@ -7,6 +7,7 @@ import type {
   PowerProgressUnavailableReason,
   TrainingContextUnknownReason,
 } from "@enduragent/coach-contract";
+import { PLATFORM_COPY } from "../../platform-copy.js";
 import type { TrainingContextStatus } from "../../training-context/controller.js";
 
 export const MAX_VISIBLE_PLAN_ITEMS = 7;
@@ -64,8 +65,7 @@ export const POWER_PROGRESS_FRESHNESS_COPY: Readonly<
   critical: "Very stale",
 };
 
-export const RIDE_IMPORT_DESCRIPTION =
-  "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.";
+export const RIDE_IMPORT_DESCRIPTION = PLATFORM_COPY.rideImportDescription;
 
 export function analysisUnavailableCopy(reason: AnalysisUnavailableReason): string {
   switch (reason) {

--- a/apps/desktop-renderer/tests/training-export.test.ts
+++ b/apps/desktop-renderer/tests/training-export.test.ts
@@ -57,6 +57,9 @@ describe("training export controller", () => {
       status: "cancelled",
       target: "workout-archive",
     });
+    expect(trainingExportStatusCopy(cancelled.states.at(-1)!)).toBe(
+      "Export cancelled. No file was changed.",
+    );
 
     const refused = subject(
       vi.fn(async () => ({ status: "refused" as const, reason: "rate-limited" as const })),

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -312,6 +312,11 @@ describe("training page", () => {
     expect(screen.getByText("2 cycling activities have no platform Load")).toBeInTheDocument();
     expect(screen.getByText("80%")).toBeInTheDocument();
     expect(screen.getByText("4/5 planned days matched")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.",
+      ),
+    ).toBeInTheDocument();
     expect(document.querySelector(".training-status")).toHaveProperty("hidden", true);
   });
 
@@ -341,7 +346,7 @@ describe("training page", () => {
     ).toHaveFocus();
   });
 
-  it("exports a ride through the bound desktop action without rendering its canonical ID", async () => {
+  it("offers FIT and GPX and exports a ride without rendering its canonical ID", async () => {
     const user = userEvent.setup();
     const exportActivity = vi.fn(async () => {});
     const exportWorkoutArchive = vi.fn(async () => {});
@@ -356,6 +361,17 @@ describe("training page", () => {
     );
 
     const panel = screen.getByRole("region", { name: "Export ride" });
+    expect(
+      within(panel)
+        .getAllByRole("option")
+        .map((option) => ({
+          label: option.textContent,
+          value: (option as HTMLOptionElement).value,
+        })),
+    ).toEqual([
+      { label: "FIT", value: "fit" },
+      { label: "GPX", value: "gpx" },
+    ]);
     await user.selectOptions(within(panel).getByRole("combobox", { name: "File format" }), "gpx");
     await user.click(within(panel).getByRole("button", { name: "Export ride" }));
     expect(exportActivity).toHaveBeenCalledWith({
@@ -873,7 +889,7 @@ describe("training page", () => {
     expect(plan.queryByText("Endurance ride 8")).toBeNull();
   });
 
-  it("exports exactly the visible planned-workout date range", async () => {
+  it("offers every workout format and exports exactly the visible planned-workout date range", async () => {
     const user = userEvent.setup();
     const exportWorkoutArchive = vi.fn(async () => {});
     useEnduragentStore.setState({
@@ -882,6 +898,19 @@ describe("training page", () => {
     render(<TrainingView />);
 
     const plan = screen.getByRole("region", { name: "Plan" });
+    expect(
+      within(plan)
+        .getAllByRole("option")
+        .map((option) => ({
+          label: option.textContent,
+          value: (option as HTMLOptionElement).value,
+        })),
+    ).toEqual([
+      { label: "ZWO", value: "zwo" },
+      { label: "MRC", value: "mrc" },
+      { label: "ERG", value: "erg" },
+      { label: "FIT", value: "fit" },
+    ]);
     await user.selectOptions(within(plan).getByRole("combobox", { name: "Workout format" }), "fit");
     await user.click(within(plan).getByRole("button", { name: "Export workouts" }));
     expect(exportWorkoutArchive).toHaveBeenCalledWith({
@@ -904,7 +933,7 @@ describe("training page", () => {
     expect(within(wellness).getAllByText("No readings")).toHaveLength(2);
   });
 
-  it("explains every unknown panel and announces the loading status", () => {
+  it("explains every unknown panel and announces loading and unavailable status", () => {
     useEnduragentStore.setState({
       training: ready({ status: "loading", metadata: null, trainingContext: unknownContext }),
     });
@@ -924,6 +953,22 @@ describe("training page", () => {
       expect(screen.getByText(copy)).toBeInTheDocument();
     }
     expect(document.querySelector(".training-metadata")?.children).toHaveLength(0);
+
+    update({
+      training: ready({ status: "unavailable", metadata: null, trainingContext: unknownContext }),
+    });
+    expect(screen.getByText("Training data unavailable")).toBeVisible();
+    expect(screen.getByRole("region", { name: "Training" })).not.toHaveAttribute("aria-busy");
+
+    update({
+      training: ready({
+        status: "refresh-unavailable",
+        metadata: null,
+        trainingContext: unknownContext,
+      }),
+    });
+    expect(screen.getByText("Refresh unavailable")).toBeVisible();
+    expect(screen.getByRole("region", { name: "Training" })).not.toHaveAttribute("aria-busy");
   });
 });
 
@@ -978,7 +1023,7 @@ describe("training page sync", () => {
     expect(request).toHaveBeenNthCalledWith(2, "keyboard");
   });
 
-  it("walks the queued, running and terminal sync states", () => {
+  it("walks queued, running, success, retryable failure and protocol sync states", () => {
     useEnduragentStore.setState({ syncActions: { request: vi.fn() } });
     render(<TrainingView />);
 
@@ -1002,6 +1047,32 @@ describe("training page sync", () => {
     expect(settled).toBeEnabled();
     expect(settled).not.toHaveAttribute("aria-busy");
     expect(message).toHaveTextContent("Local training-data processing completed.");
+
+    update({
+      sync: toManualSyncViewState({
+        status: "failed",
+        operation: 1,
+        kind: "partial",
+        retryable: true,
+      }),
+    });
+    expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
+    expect(message).toHaveTextContent(
+      "Training-data processing partially completed. Try again to finish.",
+    );
+
+    update({
+      sync: toManualSyncViewState({
+        status: "failed",
+        operation: 1,
+        kind: "indeterminate",
+        retryable: true,
+      }),
+    });
+    expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
+    expect(message).toHaveTextContent(
+      "Connection interrupted. The sync may still be finishing. Enduragent won’t retry it automatically.",
+    );
 
     update({
       sync: toManualSyncViewState({

--- a/apps/desktop/scripts/windows-parity-scenarios.d.mts
+++ b/apps/desktop/scripts/windows-parity-scenarios.d.mts
@@ -49,7 +49,10 @@ export interface WindowsParityScenarioCollection {
 }
 
 export const WINDOWS_PARITY_SCENARIO_MANIFEST_MAX_BYTES: 1048576;
-export const DEFAULT_WINDOWS_PARITY_SCENARIO_MANIFESTS: readonly ["chat-settings.scenarios.json"];
+export const DEFAULT_WINDOWS_PARITY_SCENARIO_MANIFESTS: readonly [
+  "chat-settings.scenarios.json",
+  "training.scenarios.json",
+];
 
 export function loadWindowsParityScenarios(
   input?: WindowsParityScenarioLoaderInput,

--- a/apps/desktop/scripts/windows-parity-scenarios.mjs
+++ b/apps/desktop/scripts/windows-parity-scenarios.mjs
@@ -11,6 +11,7 @@ const surfacePattern = /^[a-z][a-z0-9-]*$/u;
 export const WINDOWS_PARITY_SCENARIO_MANIFEST_MAX_BYTES = 1_048_576;
 export const DEFAULT_WINDOWS_PARITY_SCENARIO_MANIFESTS = Object.freeze([
   "chat-settings.scenarios.json",
+  "training.scenarios.json",
 ]);
 
 export class WindowsParityScenarioManifestError extends Error {

--- a/apps/desktop/src/main/platform-copy.ts
+++ b/apps/desktop/src/main/platform-copy.ts
@@ -9,6 +9,7 @@ export interface DesktopPlatformProjection {
     readonly credentialEncryptionUnavailable: string;
     readonly credentialRecoveryAction: string;
     readonly restartComputer: "restart your Mac" | "restart your PC";
+    readonly rideImportDescription: string;
   };
 }
 
@@ -22,6 +23,8 @@ const DARWIN_PLATFORM_PROJECTION: DesktopPlatformProjection = Object.freeze({
       "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
     credentialRecoveryAction: "unlock or approve Keychain access",
     restartComputer: "restart your Mac",
+    rideImportDescription:
+      "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.",
   }),
 });
 
@@ -35,6 +38,8 @@ const WINDOWS_PLATFORM_PROJECTION: DesktopPlatformProjection = Object.freeze({
       "Windows credential encryption (DPAPI) is unavailable. Quit and reopen Enduragent, then try again.",
     credentialRecoveryAction: "make sure Windows credential encryption (DPAPI) is available",
     restartComputer: "restart your PC",
+    rideImportDescription:
+      "Add FIT, TCX or GPX files from this PC. You can also drop them onto the window.",
   }),
 });
 

--- a/apps/desktop/tests/fixtures/windows-parity/training.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/training.scenarios.json
@@ -1,0 +1,349 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "training.setup.intervals-clipboard-connect",
+      "surface": "training-setup",
+      "expected": "Intervals.icu setup has no secret field, reads and clears the copied API key before privileged work, verifies the key and training-history owner, and becomes connected only after an authoritative active result.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > connects Intervals.icu from copied metadata without rendering a secret field",
+        "apps/desktop/tests/intervals-ipc.test.ts > reads and clears synchronously before verification or vault work",
+        "apps/desktop/tests/intervals-ipc.test.ts > verifies a valid key before accepting a matching or ownerless store",
+        "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > uses a copied Intervals API key, closes the panel, and focuses Delete"
+      ]
+    },
+    {
+      "id": "training.setup.intervals-verification",
+      "surface": "training-setup",
+      "expected": "Invalid clipboard content, a clipboard-clear failure, timed-out or malformed verification, and training-account mismatch fail closed without writing a candidate over an existing encrypted key or exposing secret details.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/intervals-ipc.test.ts > refuses the invalid key shape without verification: %j",
+        "apps/desktop/tests/intervals-ipc.test.ts > gives clear failure precedence over a captured credential",
+        "apps/desktop/tests/intervals-ipc.test.ts > bounds the complete verification callback with the production overall deadline",
+        "apps/desktop/tests/intervals-ipc.test.ts > closes thrown and malformed verification failures without private details",
+        "apps/desktop/tests/intervals-ipc.test.ts > keeps an existing encrypted key and runtime state unchanged after verification refusal"
+      ]
+    },
+    {
+      "id": "training.setup.intervals-delete-only",
+      "surface": "training-setup",
+      "expected": "A connected Intervals.icu account offers Delete and no in-place replacement, requires confirmation, removes only the local credential, and leaves durable rides, training readiness, and past chats in place.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/settings-surface.test.tsx > renders setup first without standalone Credentials or Application setup actions",
+        "apps/desktop-renderer/tests/settings-surface.test.tsx > opens and focuses first-time Intervals setup after deletion without lowering durable readiness",
+        "apps/desktop-renderer/tests/settings-surface.test.tsx > keeps Intervals secrets out of the DOM and preserves repair feedback after uncertainty",
+        "apps/desktop/tests/onboarding-ipc.test.ts > deletes a locally stored Intervals.icu credential through the existing channel"
+      ]
+    },
+    {
+      "id": "training.setup.readiness-sources",
+      "surface": "training-setup",
+      "expected": "Training-data readiness is satisfied by an active Intervals.icu connection or durable locally imported rides, while the visible Intervals.icu row continues to report its own connected or connectable state.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/setup-readiness.test.tsx > hydrates saved safety intake and accepts durable local rides without a training credential",
+        "apps/desktop-renderer/tests/setup-readiness.test.tsx > re-evaluates retained training data after an Intervals deletion refresh when provider ready is $providerReady, intake saved is $hasSavedIntake, and durable data is $durableTrainingData",
+        "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > keeps durable training ready while showing the exact first-time Intervals row"
+      ]
+    },
+    {
+      "id": "training.setup.readiness-recovery",
+      "surface": "training-setup",
+      "expected": "Setup remains locked while authoritative readiness is loading or unavailable, disables its mutation controls, and restores them only after Retry returns a complete provider, training-data, and intake result.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/setup-readiness.test.tsx > fails closed while the durable setup read is still loading",
+        "apps/desktop-renderer/tests/setup-readiness.test.tsx > shows unavailable setup status, disables controls, and recovers through Retry",
+        "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > keeps Start coaching disabled until every requirement is met"
+      ]
+    },
+    {
+      "id": "training.setup.file-import-fallback",
+      "surface": "training-setup",
+      "expected": "Intervals.icu setup offers Import ride files instead, and a successful local ride import can satisfy training-data readiness without connecting or hiding the still-connectable Intervals.icu row.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > connects Intervals.icu from copied metadata without rendering a secret field",
+        "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > keeps the first-time Intervals row after a ride import makes training ready"
+      ]
+    },
+    {
+      "id": "training.first-sync.provider-backfill",
+      "surface": "first-sync",
+      "expected": "Completing provider-backed setup starts one shared training-history sync, shows the first-sync progress card only while it is active, refreshes training context before publishing success, and then focuses Chat once.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/first-sync.test.ts > strictly validates completion and joins one synchronous coordinator flight",
+        "apps/desktop-renderer/tests/training-sync.test.ts > queues synchronously, validates the exact progress sequence, and announces only after refresh",
+        "apps/desktop-renderer/tests/chat-surface.test.tsx > first sync card > shows nothing until the first sync is under way"
+      ]
+    },
+    {
+      "id": "training.first-sync.file-only",
+      "surface": "first-sync",
+      "expected": "Completing setup from durable local ride files skips provider sync, clears any stale first-sync failure, keeps the card hidden, and focuses the composer once.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/first-sync.test.ts > skips provider sync for file-only completion and leaves retry inert",
+        "apps/desktop-renderer/tests/first-sync.test.ts > clears a stale first-sync failure when file-only setup completes",
+        "apps/desktop-renderer/tests/chat-surface.test.tsx > first sync card > shows nothing until the first sync is under way"
+      ]
+    },
+    {
+      "id": "training.first-sync.failure-recovery",
+      "surface": "first-sync",
+      "expected": "Retryable first-sync failures preserve saved progress and offer Retry sync; an interrupted connection remains retryable, while an unverifiable protocol result requires relaunch and offers no retry.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/first-sync.test.ts > preserves first-sync mapping for %o",
+        "apps/desktop-renderer/tests/first-sync.test.ts > retries only a retryable shared outcome and focuses the composer once",
+        "apps/desktop-renderer/tests/chat-surface.test.tsx > first sync card > retries a recoverable sync failure and refuses one that needs a relaunch"
+      ]
+    },
+    {
+      "id": "training.import.picker",
+      "surface": "training-import",
+      "expected": "Import ride files opens the bounded multi-file chooser for FIT, TCX, and GPX, treats chooser cancellation as no selection, validates selected absolute ride paths, and dispatches each accepted attempt once.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/onboarding-ipc.test.ts > uses the bounded native chooser and filters its result",
+        "apps/desktop-renderer/tests/ride-import.test.ts > uses the picker, validates picker and drop paths, and dispatches each valid attempt once",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page ride import > hands the import request to the resident controller"
+      ]
+    },
+    {
+      "id": "training.import.drop-routing",
+      "surface": "training-import",
+      "expected": "Dropped ride files go to Setup while Setup owns the import surface and otherwise go to resident Training, using one disposable subscription and never overlapping an active picker or drop import.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/ride-import.test.ts > prevents picker and drop attempts from overlapping one in-flight RPC",
+        "apps/desktop-renderer/tests/ride-import.test.ts > dropped ride import routing > creates one disposable subscription and selects the current wizard or resident owner"
+      ]
+    },
+    {
+      "id": "training.import.progress-results",
+      "surface": "training-import",
+      "expected": "Training announces chooser, import, and file progress, reports imported and quarantined counts, distinguishes unavailable publication from confirmed availability, and fails closed when the result cannot be confirmed.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page ride import > reports the picker, progress, success and failure stages",
+        "apps/desktop-renderer/tests/ride-import.test.ts > uses returned partial and zero-import counts, retaining prior success without stale state",
+        "apps/desktop-renderer/tests/ride-import.test.ts > keeps durable ingestion across an idempotent publication retry",
+        "apps/desktop-renderer/tests/ride-import-adapter.test.tsx > walks the picker, import and success stages onto the training page"
+      ]
+    },
+    {
+      "id": "training.view.panel-inventory",
+      "surface": "training",
+      "expected": "Training renders Sync, Power progress, Recent rides, Current cycling anchor, Cycling Load, Plan, Adherence, Wellness trend, and Import ride files in the shipped order with each panel's own known or unknown state.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > renders every panel in the pinned order with the training data as of its own timestamps",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > explains every unknown panel and announces loading and unavailable status"
+      ]
+    },
+    {
+      "id": "training.view.readiness-states",
+      "surface": "training",
+      "expected": "Training announces Loading training data, Training data unavailable, and Refresh unavailable truthfully, marks only loading as busy, and never renders raw invalid sync timestamps.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > explains every unknown panel and announces loading and unavailable status",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page sync > keeps an unparsable sync instant out of the markup"
+      ]
+    },
+    {
+      "id": "training.view.context-recovery",
+      "surface": "training",
+      "expected": "A failed refresh retains the last good training context, a later explicit refresh reconnects after disconnection, and a newer healthy client is reused instead of reconnecting a stale generation.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-context.test.ts > uses the explicit fallback for an older state and retains it on refresh failure",
+        "apps/desktop-renderer/tests/training-context.test.ts > reconnects the next athlete-state read after a disconnect",
+        "apps/desktop-renderer/tests/training-context.test.ts > uses a shared recovered client instead of reconnecting a stale failed instance"
+      ]
+    },
+    {
+      "id": "training.ride-review.navigation",
+      "surface": "ride-review",
+      "expected": "A recent ride opens a focused Ride review with date, duration, unit-aware distance, and explicit unavailable metadata; Back to training restores focus without rendering the canonical activity identifier.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > opens a local ride review and restores focus without exposing its canonical identifier",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > uses the cycling unit preference and explicit unavailable ride metadata"
+      ]
+    },
+    {
+      "id": "training.ride-review.local-analysis",
+      "surface": "ride-review",
+      "expected": "Ride review shows a neutral time-weighted aerobic-drift estimate with coverage and limitations, ordered intervals and group metrics with missing values marked unavailable, and five-minute efforts scoped only to the selected ride.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > shows a neutral, time-weighted local aerobic drift estimate with its limitations",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > shows ordered intervals and explicitly scoped five-minute best efforts",
+        "apps/desktop-renderer/tests/ride-interval-evidence.test.tsx > shows complete interval and group metrics while keeping missing values unavailable"
+      ]
+    },
+    {
+      "id": "training.ride-review.response-analysis",
+      "surface": "ride-review",
+      "expected": "Ride response review keeps power and heart-rate distributions independently accessible and presents the provider-cleaned, lag-adjusted power and heart-rate relationship with coverage, fitted curves, and tabular raw evidence distinct from local aerobic drift.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/training-surface.test.tsx > training page > shows independent accessible distributions and a distinct server power/HR response"
+    },
+    {
+      "id": "training.ride-review.analysis-recovery",
+      "surface": "ride-review",
+      "expected": "Refreshing one ride-analysis section preserves completed evidence, isolates the failed section without exposing transport details, and omits a pointless retry for deterministic data-unsuitability results.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/activity-analysis-controller.test.ts > preserves completed evidence when a refresh transport fails",
+        "apps/desktop-renderer/tests/activity-analysis-controller.test.ts > tracks a failed section without marking completed sibling evidence as failed",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > explains deterministic unavailable states without offering a pointless retry"
+      ]
+    },
+    {
+      "id": "training.power-progress.comparison",
+      "surface": "power-progress",
+      "expected": "Power progress compares five shipped effort durations across the current and prior 28 days with accessible direction labels, unavailable values, optional heart-rate response, freshness, and 42-day durability context.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/training-surface.test.tsx > training page > renders an accessible five-effort Power Progress comparison with secondary context"
+    },
+    {
+      "id": "training.power-progress.recovery",
+      "surface": "power-progress",
+      "expected": "Unavailable Power progress explains why it cannot be shown, while a failed refresh labels and timestamps the failure and retains the last complete comparison as stale evidence.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/training-surface.test.tsx > training page > explains unavailable data and clearly labels a stale last-good comparison"
+    },
+    {
+      "id": "training.wellness.trend",
+      "surface": "wellness",
+      "expected": "Wellness trend renders the latest HRV, sleep, and resting heart-rate values from the seven-morning athlete state, draws a sparkline only for populated series, and labels empty series No readings.",
+      "automation": "deterministic",
+      "test": "apps/desktop-renderer/tests/training-surface.test.tsx > training page > draws a sparkline per wellness series from the athlete-state readings"
+    },
+    {
+      "id": "training.view.anchor-load-plan-adherence",
+      "surface": "training",
+      "expected": "Training shows the current cycling anchor and power zones, seven-day Cycling Load and missing-Load count, at most seven upcoming workouts, and matched-versus-planned adherence using plain-English metrics.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > renders every panel in the pinned order with the training data as of its own timestamps",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > renders the power zones and caps the plan at seven upcoming workouts"
+      ]
+    },
+    {
+      "id": "training.export.activity-formats",
+      "surface": "training-export",
+      "expected": "Ride review offers FIT and GPX, sends the selected canonical ride without rendering its identifier, and lets the trusted main process add the chosen destination through the native save dialog.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > offers FIT and GPX and exports a ride without rendering its canonical ID",
+        "apps/desktop-renderer/tests/training-export.test.ts > sends a closed ride request and publishes a saved result",
+        "apps/desktop/tests/training-export-ipc.test.ts > uses the native save dialog and adds the destination only in the trusted main process"
+      ]
+    },
+    {
+      "id": "training.export.workout-formats",
+      "surface": "training-export",
+      "expected": "Plan export offers ZWO, MRC, ERG, and FIT in a ZIP and exports exactly the date range of the seven visible planned workouts without changing the plan.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page > offers every workout format and exports exactly the visible planned-workout date range",
+        "apps/desktop-renderer/tests/training-export.test.ts > routes workout archives and preserves cancellations and refusal reasons",
+        "apps/desktop/tests/training-export-ipc.test.ts > routes a closed workout archive request and handles cancellation without daemon work"
+      ]
+    },
+    {
+      "id": "training.export.cancellation-failures",
+      "surface": "training-export",
+      "expected": "Cancelling the save dialog performs no daemon export and reports that no file changed; dialog, daemon, malformed-result, and transport failures collapse to the shipped path-free refusal copy.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-export.test.ts > routes workout archives and preserves cancellations and refusal reasons",
+        "apps/desktop-renderer/tests/training-export.test.ts > is single-flight and turns transport failures into a generic local refusal",
+        "apps/desktop/tests/training-export-ipc.test.ts > routes a closed workout archive request and handles cancellation without daemon work",
+        "apps/desktop/tests/training-export-ipc.test.ts > redacts dialog, daemon, and malformed-result failures"
+      ]
+    },
+    {
+      "id": "training.sync.lifecycle",
+      "surface": "training-sync",
+      "expected": "Sync now admits one shared operation, announces queued and running states, refreshes Training before publishing a verified success, and distinguishes a published training-data check from a successful no-change local processing result.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-sync.test.ts > queues synchronously, validates the exact progress sequence, and announces only after refresh",
+        "apps/desktop-renderer/tests/training-sync.test.ts > maps published=%s Reference-success=%s after exactly one refresh",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page sync > walks queued, running, success, retryable failure and protocol sync states"
+      ]
+    },
+    {
+      "id": "training.sync.retryable-recovery",
+      "surface": "training-sync",
+      "expected": "Partial, operation, and indeterminate sync failures remain explicit and retryable; an interrupted admitted sync is never retried automatically, and a later athlete action reconnects once, submits one new call, and restores keyboard focus.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-sync.test.ts > maps published=%s Reference-success=%s after exactly one refresh",
+        "apps/desktop-renderer/tests/training-sync.test.ts > settles %s without a terminal as indeterminate and never refreshes",
+        "apps/desktop-renderer/tests/training-sync.test.ts > recovers only on a later explicit retry and submits exactly one new call",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page sync > walks queued, running, success, retryable failure and protocol sync states",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page sync > returns keyboard focus to the sync action once a recoverable failure settles"
+      ]
+    },
+    {
+      "id": "training.sync.protocol-failure",
+      "surface": "training-sync",
+      "expected": "Malformed, missing, reordered, duplicated, or miscorrelated progress and terminal envelopes fail closed without refreshing, latch Sync unavailable, move keyboard focus to the relaunch status, and cannot retry in place.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-sync.test.ts > latches %s progress as a protocol fault without observer throws",
+        "apps/desktop-renderer/tests/training-sync.test.ts > requires an observed terminal even when a typed result resolves",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page sync > walks queued, running, success, retryable failure and protocol sync states",
+        "apps/desktop-renderer/tests/training-surface.test.tsx > training page sync > holds keyboard focus on the sync status when the action becomes unavailable"
+      ]
+    },
+    {
+      "id": "training.windows.ride-import-copy",
+      "surface": "training-import",
+      "expected": "The installed Windows Training page says ride files can be added from this PC and never labels the Windows machine as a Mac.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "training.windows.ride-import-native",
+      "surface": "training-import",
+      "expected": "The installed Windows Import ride files action opens a native multi-select chooser for FIT, TCX, and GPX, accepts Windows absolute paths, and routes Explorer drag-and-drop to the active import surface.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "training.windows.export-native",
+      "surface": "training-export",
+      "expected": "Installed Windows save dialogs present the shipped ride and workout format filters and filenames, save to the selected location, and close on Cancel without changing a file.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "training.ride-review.temporary-failure",
+      "surface": "ride-review",
+      "expected": "A temporary recent-rides refresh failure shows the retry copy, preserves the selected ride, and reconciles the authoritative list once refresh succeeds.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/training-surface.test.tsx > preserves a selected ride across temporary refresh failure and reconciles authoritative lists"
+      ]
+    },
+    {
+      "id": "training.sidebar.sync-chip",
+      "surface": "training-sync",
+      "expected": "The sidebar sync chip walks the loading, synced, syncing, and attention states, reports never-synced and unavailable training data honestly, and a manual sync request restores keyboard focus to the activator.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop-renderer/tests/sidebar-surface.test.tsx > walks the loading, synced, syncing and attention states",
+        "apps/desktop-renderer/tests/sidebar-surface.test.tsx > reports never-synced and unavailable training data honestly",
+        "apps/desktop-renderer/tests/sidebar-surface.test.tsx > requests a manual sync and restores keyboard focus to the activator"
+      ]
+    }
+  ]
+}

--- a/apps/desktop/tests/platform-copy.test.ts
+++ b/apps/desktop/tests/platform-copy.test.ts
@@ -14,6 +14,8 @@ describe("desktop platform projection", () => {
           "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
         credentialRecoveryAction: "unlock or approve Keychain access",
         restartComputer: "restart your Mac",
+        rideImportDescription:
+          "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.",
       },
     });
   });
@@ -31,6 +33,8 @@ describe("desktop platform projection", () => {
           "Windows credential encryption (DPAPI) is unavailable. Quit and reopen Enduragent, then try again.",
         credentialRecoveryAction: "make sure Windows credential encryption (DPAPI) is available",
         restartComputer: "restart your PC",
+        rideImportDescription:
+          "Add FIT, TCX or GPX files from this PC. You can also drop them onto the window.",
       },
     });
     expect(JSON.stringify(projection)).not.toMatch(/[\\/](?:Users|home|tmp)[\\/]/u);

--- a/apps/desktop/tests/windows-parity-scenarios.test.ts
+++ b/apps/desktop/tests/windows-parity-scenarios.test.ts
@@ -62,7 +62,7 @@ async function expectStage(
 }
 
 describe("Windows parity scenario manifests", () => {
-  it("loads the frozen Chat and Settings manifest with unique tested deterministic rows", async () => {
+  it("loads the frozen Chat, Settings and Training manifests with tested deterministic rows", async () => {
     const collection = await loadWindowsParityScenarios();
 
     expect(collection.schemaVersion).toBe(1);
@@ -73,7 +73,7 @@ describe("Windows parity scenario manifests", () => {
         (scenario) => scenario.automation === "deterministic",
       ).length,
       vmOnly: collection.scenarios.filter((scenario) => scenario.automation === "vm-only").length,
-    }).toEqual({ total: 43, deterministic: 40, vmOnly: 3 });
+    }).toEqual({ total: 77, deterministic: 71, vmOnly: 6 });
     expect(new Set(collection.scenarios.map((scenario) => scenario.id)).size).toBe(
       collection.scenarios.length,
     );
@@ -103,6 +103,33 @@ describe("Windows parity scenario manifests", () => {
       "settings.providers.chatgpt-sign-in",
       "settings.providers.chatgpt-refusals",
       "settings.providers.claude-readiness",
+      "training.setup.intervals-clipboard-connect",
+      "training.setup.intervals-verification",
+      "training.setup.intervals-delete-only",
+      "training.setup.readiness-sources",
+      "training.setup.readiness-recovery",
+      "training.setup.file-import-fallback",
+      "training.first-sync.provider-backfill",
+      "training.first-sync.file-only",
+      "training.first-sync.failure-recovery",
+      "training.import.picker",
+      "training.import.drop-routing",
+      "training.import.progress-results",
+      "training.view.panel-inventory",
+      "training.view.readiness-states",
+      "training.view.context-recovery",
+      "training.ride-review.navigation",
+      "training.ride-review.local-analysis",
+      "training.ride-review.analysis-recovery",
+      "training.view.anchor-load-plan-adherence",
+      "training.export.activity-formats",
+      "training.export.workout-formats",
+      "training.export.cancellation-failures",
+      "training.sync.lifecycle",
+      "training.sync.retryable-recovery",
+      "training.sync.protocol-failure",
+      "training.ride-review.temporary-failure",
+      "training.sidebar.sync-chip",
     ]);
     expect(Object.isFrozen(collection)).toBe(true);
     expect(Object.isFrozen(collection.manifests)).toBe(true);
@@ -112,7 +139,10 @@ describe("Windows parity scenario manifests", () => {
 
   it("loads exact multiple deterministic citations and freezes nested evidence", async () => {
     const collection = await loadWindowsParityScenarios(
-      { directory: "/synthetic/windows-parity" },
+      {
+        directory: "/synthetic/windows-parity",
+        manifestNames: ["chat-settings.scenarios.json"],
+      },
       {
         readFile: reader({
           "chat-settings.scenarios.json": manifest([deterministicWithTests()]),


### PR DESCRIPTION
## Summary
- W14 of the Windows-parity initiative (ADR-0048): the frozen Training scenario manifest.
- Adds `apps/desktop/tests/fixtures/windows-parity/training.scenarios.json` — 34 rows (31 deterministic with verified test citations, 3 vm-only: installed copy rendering, native chooser/Explorer drop, native save dialogs). Covers the intervals.icu clipboard-connect lane (verification, delete-only management), first-sync/backfill states, ride-file import fallback, the TrainingView panel inventory and readiness/recovery states, ride review incl. temporary-failure recovery, the sidebar sync chip, export formats and cancellation, and sync lifecycle/error states.
- Registers the manifest with the W13 aggregator through its registration seam: the aggregator delta is exactly one array entry plus its mirrored type literal — validation semantics, row schema, rejection behavior, size limit, and function signatures are byte-identical.
- Extends the platform copy projection with the Windows ride-import wording; the win32 string lives only in the win32 projection and darwin output is byte-identical.
- No Training behavior changes: this package freezes and proves the shipped surface.

## Verification
- Combined registered collection: 77 rows (71 deterministic, 6 vm-only) across Chat/Settings + Training; the aggregator test re-verifies every citation at runtime (cited file must contain the exact test title).
- Focused manifest/platform tests 33 passed; desktop suite 1312 passed, 0 failed (63 files); renderer suite 850 passed, 0 failed; root `pnpm check` clean.
- Fresh-context read-only audit: registration-only aggregator delta adjudicated line-by-line; all 72 deterministic citations mechanically verified; 6+ rows deep-checked against shipped sources; darwin parity, test integrity, and vm-only honesty confirmed. Two audit-found low-severity coverage gaps (ride-list temporary-failure sub-state, sidebar sync chip) were fixed by adding cited rows before landing.

## Limits
None (the existing 1 MiB aggregator limit is unchanged).

## Notes
- Deliberately absent rows (controls that do not exist at HEAD): no replacement control while an Intervals connection exists (delete-only), export cancellation is the native dialog.
- Windows-host-only proof is deferred to the VM acceptance pass, mapped to the three vm-only row IDs.
