### PR TITLE
test(desktop): freeze shell-lifecycle manifest + Windows installed-acceptance runner (W16)

### DIFF
--- a/apps/desktop/scripts/accept-windows-installed.d.mts
+++ b/apps/desktop/scripts/accept-windows-installed.d.mts
@@ -1,0 +1,222 @@
+import type { WindowsParityScenarioCollection } from "./windows-parity-scenarios.mjs";
+
+export type WindowsInstalledChecklistResult = "pass" | "fail" | "incomplete";
+
+export type WindowsInstalledAcceptanceStage =
+  | "architecture"
+  | "automation"
+  | "closure-shape"
+  | "coverage-class"
+  | "coverage-content"
+  | "coverage-duplicate"
+  | "coverage-missing"
+  | "coverage-shape"
+  | "coverage-unknown"
+  | "execution"
+  | "live-smoke-result"
+  | "live-smoke-separation"
+  | "mode"
+  | "plan-input"
+  | "platform"
+  | "result"
+  | "result-duplicate"
+  | "result-integrity"
+  | "result-plan"
+  | "result-privacy"
+  | "result-shape"
+  | "scenario-citations"
+  | "source-duplicate"
+  | "totals"
+  | "uninstall-duplicate"
+  | "uninstall-missing"
+  | "uninstall-protocol"
+  | "uninstall-unknown"
+  | "validation-input";
+
+export class WindowsInstalledAcceptanceError extends Error {
+  readonly stage: WindowsInstalledAcceptanceStage;
+  constructor(stage: WindowsInstalledAcceptanceStage);
+}
+
+export interface WindowsInstalledAcceptanceTotals {
+  readonly total: number;
+  readonly deterministic: number;
+  readonly vmOnly: number;
+}
+
+export interface WindowsInstalledEvidenceContract {
+  readonly checklistResult: readonly ["pass", "fail", "incomplete"];
+  readonly evidence: {
+    readonly type: "free-text";
+    readonly pathPolicy: "path-free";
+    readonly credentialPolicy: "credential-free";
+  };
+}
+
+export interface WindowsInstalledAutomatedEvidenceStep {
+  readonly rowId: string;
+  readonly surface: string;
+  readonly expected: string;
+  readonly tests: readonly string[];
+}
+
+export interface WindowsInstalledManualChecklistItem {
+  readonly rowId: string;
+  readonly surface: string;
+  readonly reason: string;
+  readonly evidenceContract: WindowsInstalledEvidenceContract;
+}
+
+export type WindowsInstalledUninstallPhase = "seed" | "uninstall" | "reinstall";
+
+export interface WindowsInstalledUninstallReinstallSection {
+  readonly phaseOrder: readonly ["seed", "uninstall", "reinstall"];
+  readonly phases: readonly {
+    readonly id: WindowsInstalledUninstallPhase;
+    readonly requirement: string;
+  }[];
+  readonly rowMappings: readonly {
+    readonly rowId: string;
+    readonly phases: readonly ["seed", "uninstall", "reinstall"];
+  }[];
+  readonly durableInventory: readonly {
+    readonly rowId: string;
+    readonly durableClass: string;
+  }[];
+  readonly preservedDataRoots: readonly ["athlete-data root", "desktop user-data root"];
+  readonly removedIntegrationState: readonly string[];
+  readonly transientInventory: readonly [
+    "updater cache and staging",
+    "runtime locks",
+    "daemon PID and port coordinates",
+    "upgrade-fence claim coordinates",
+    "crash temporaries",
+  ];
+  readonly transientAssertion: string;
+}
+
+export interface WindowsInstalledLiveSmoke {
+  readonly id: string;
+  readonly name: string;
+  readonly check: string;
+}
+
+export interface WindowsInstalledAcceptancePlan {
+  readonly schemaVersion: 1;
+  readonly kind: "windows-installed-acceptance-plan";
+  readonly manifests: readonly string[];
+  readonly totals: WindowsInstalledAcceptanceTotals;
+  readonly automatedEvidence: readonly WindowsInstalledAutomatedEvidenceStep[];
+  readonly manualChecklist: readonly WindowsInstalledManualChecklistItem[];
+  readonly uninstallReinstall: WindowsInstalledUninstallReinstallSection;
+  readonly liveSmokeLane: {
+    readonly mode: "live-smoke";
+    readonly includedInDeterministicLane: false;
+    readonly outputPolicy: {
+      readonly secrets: "never";
+      readonly identifiers: "redacted";
+    };
+    readonly smokes: readonly WindowsInstalledLiveSmoke[];
+  };
+}
+
+export interface WindowsInstalledAcceptanceClosure {
+  readonly valid: true;
+  readonly totals: WindowsInstalledAcceptanceTotals;
+}
+
+export interface WindowsInstalledOutcomeInput {
+  readonly checklistResult: WindowsInstalledChecklistResult;
+  readonly evidence: string;
+}
+
+export interface WindowsInstalledRowOutcome extends WindowsInstalledOutcomeInput {
+  readonly rowId: string;
+  readonly lane: "automated" | "manual";
+}
+
+export interface WindowsInstalledAcceptanceResult {
+  readonly schemaVersion: 1;
+  readonly kind: "windows-installed-acceptance-result";
+  readonly status: WindowsInstalledChecklistResult;
+  readonly complete: boolean;
+  readonly passed: boolean;
+  readonly totals: {
+    readonly total: number;
+    readonly passed: number;
+    readonly failed: number;
+    readonly incomplete: number;
+  };
+  readonly rows: readonly WindowsInstalledRowOutcome[];
+}
+
+export interface WindowsInstalledAcceptanceExecutionEntry {
+  readonly lane: "automated" | "manual";
+  readonly step: WindowsInstalledAutomatedEvidenceStep | WindowsInstalledManualChecklistItem;
+}
+
+export interface WindowsInstalledExecutionDependencies {
+  readonly platform?: NodeJS.Platform;
+  readonly architecture?: string;
+  readonly collectOutcome?: (
+    entry: WindowsInstalledAcceptanceExecutionEntry,
+  ) => WindowsInstalledOutcomeInput | Promise<WindowsInstalledOutcomeInput>;
+}
+
+export interface WindowsInstalledLiveSmokeExecutionDependencies {
+  readonly platform?: NodeJS.Platform;
+  readonly architecture?: string;
+  readonly collectOutcome?: (
+    smoke: WindowsInstalledLiveSmoke,
+  ) => WindowsInstalledOutcomeInput | Promise<WindowsInstalledOutcomeInput>;
+}
+
+export interface WindowsInstalledLiveSmokeResult {
+  readonly schemaVersion: 1;
+  readonly kind: "windows-installed-live-smoke-result";
+  readonly status: WindowsInstalledChecklistResult;
+  readonly complete: boolean;
+  readonly passed: boolean;
+  readonly totals: {
+    readonly total: number;
+    readonly passed: number;
+    readonly failed: number;
+    readonly incomplete: number;
+  };
+  readonly rows: readonly {
+    readonly smokeId: string;
+    readonly checklistResult: WindowsInstalledChecklistResult;
+    readonly evidence: string;
+  }[];
+}
+
+export const WINDOWS_INSTALLED_ACCEPTANCE_MAX_UNBROKEN_TOKEN_RUN: 32;
+export const WINDOWS_INSTALLED_ACCEPTANCE_LIVE_SMOKES: readonly WindowsInstalledLiveSmoke[];
+
+export function createWindowsInstalledAcceptancePlan(
+  collection: WindowsParityScenarioCollection,
+): WindowsInstalledAcceptancePlan;
+export function buildWindowsInstalledAcceptancePlan(): Promise<WindowsInstalledAcceptancePlan>;
+export function validateWindowsInstalledAcceptanceClosure(
+  collection: WindowsParityScenarioCollection,
+  plan: WindowsInstalledAcceptancePlan,
+): WindowsInstalledAcceptanceClosure;
+export function requireWindowsInstalledExecutionPlatform(
+  platform?: NodeJS.Platform,
+  architecture?: string,
+): void;
+export function createWindowsInstalledAcceptanceResult(
+  plan: WindowsInstalledAcceptancePlan,
+  outcomes?: readonly (WindowsInstalledOutcomeInput & { readonly rowId: string })[],
+): WindowsInstalledAcceptanceResult;
+export function validateWindowsInstalledAcceptanceResult(
+  plan: WindowsInstalledAcceptancePlan,
+  artifact: unknown,
+): WindowsInstalledAcceptanceResult;
+export function executeWindowsInstalledAcceptance(
+  input?: { readonly plan?: WindowsInstalledAcceptancePlan },
+  dependencies?: WindowsInstalledExecutionDependencies,
+): Promise<WindowsInstalledAcceptanceResult>;
+export function executeWindowsInstalledLiveSmokes(
+  dependencies?: WindowsInstalledLiveSmokeExecutionDependencies,
+): Promise<WindowsInstalledLiveSmokeResult>;

--- a/apps/desktop/scripts/accept-windows-installed.mjs
+++ b/apps/desktop/scripts/accept-windows-installed.mjs
@@ -1,0 +1,684 @@
+import { resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+import { loadWindowsParityScenarios } from "./windows-parity-scenarios.mjs";
+
+export const WINDOWS_INSTALLED_ACCEPTANCE_MAX_UNBROKEN_TOKEN_RUN = 32;
+
+const unsafeUnbrokenTokenRunPattern = new RegExp(
+  `[A-Za-z0-9+/=_-]{${WINDOWS_INSTALLED_ACCEPTANCE_MAX_UNBROKEN_TOKEN_RUN},}`,
+  "u",
+);
+const checklistResults = Object.freeze(["pass", "fail", "incomplete"]);
+const uninstallPhaseOrder = Object.freeze(["seed", "uninstall", "reinstall"]);
+const resultKinds = Object.freeze({
+  installed: "windows-installed-acceptance-result",
+  liveSmoke: "windows-installed-live-smoke-result",
+});
+const evidenceContract = Object.freeze({
+  checklistResult: checklistResults,
+  evidence: Object.freeze({
+    type: "free-text",
+    pathPolicy: "path-free",
+    credentialPolicy: "credential-free",
+  }),
+});
+const uninstallPhases = Object.freeze([
+  Object.freeze({
+    id: "seed",
+    requirement:
+      "Seed every durable class with synthetic acceptance values and record path-free baselines before uninstall.",
+  }),
+  Object.freeze({
+    id: "uninstall",
+    requirement:
+      "Uninstall and verify program and integration state is removed while both athlete-data and desktop user-data roots remain preserved.",
+  }),
+  Object.freeze({
+    id: "reinstall",
+    requirement:
+      "Reinstall as the same Windows user, verify every durable class reopens unchanged, verify owning-user DPAPI secrets still decrypt without recording them, and verify transient residue cannot block reinstall or relaunch.",
+  }),
+]);
+const transientInventory = Object.freeze([
+  "updater cache and staging",
+  "runtime locks",
+  "daemon PID and port coordinates",
+  "upgrade-fence claim coordinates",
+  "crash temporaries",
+]);
+const preservedDataRoots = Object.freeze(["athlete-data root", "desktop user-data root"]);
+const removedIntegrationState = Object.freeze([
+  "program installation",
+  "Start menu shortcut",
+  "Apps list entry",
+  "uninstaller",
+  "tray process",
+  "owned per-user login registration",
+]);
+const transientAssertion =
+  "No transient inventory item may block same-user reinstall or a clean relaunch.";
+
+export const WINDOWS_INSTALLED_ACCEPTANCE_LIVE_SMOKES = Object.freeze([
+  Object.freeze({
+    id: "chatgpt",
+    name: "ChatGPT",
+    check:
+      "Confirm a redacted installed-app exchange succeeds without displaying account or conversation identifiers.",
+  }),
+  Object.freeze({
+    id: "claude-cli",
+    name: "Claude CLI",
+    check:
+      "Confirm a redacted installed-app exchange succeeds without displaying account or conversation identifiers.",
+  }),
+  Object.freeze({
+    id: "intervals-icu",
+    name: "Intervals.icu",
+    check:
+      "Confirm a credential-safe refresh succeeds without displaying athlete or activity identifiers.",
+  }),
+  Object.freeze({
+    id: "telegram",
+    name: "Telegram",
+    check:
+      "Confirm a credential-safe round trip succeeds without displaying bot, chat, or user identifiers.",
+  }),
+  Object.freeze({
+    id: "api-key-provider",
+    name: "One API-key provider",
+    check:
+      "Confirm one configured API-key provider completes a redacted exchange without displaying the key or account identifiers.",
+  }),
+]);
+
+export class WindowsInstalledAcceptanceError extends Error {
+  constructor(stage) {
+    super(`windows-installed acceptance refused at ${stage}`);
+    this.name = "WindowsInstalledAcceptanceError";
+    this.stage = stage;
+  }
+}
+
+function reject(stage) {
+  throw new WindowsInstalledAcceptanceError(stage);
+}
+
+function record(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function exactKeys(value, keys) {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function sameValues(left, right) {
+  return isDeepStrictEqual(left, right);
+}
+
+function scenarioCitations(scenario) {
+  if (Object.hasOwn(scenario, "test") && typeof scenario.test === "string") {
+    return [scenario.test];
+  }
+  if (
+    Object.hasOwn(scenario, "tests") &&
+    Array.isArray(scenario.tests) &&
+    scenario.tests.every((test) => typeof test === "string")
+  ) {
+    return [...scenario.tests];
+  }
+  reject("scenario-citations");
+}
+
+function durableClassName(rowId) {
+  return rowId.slice("uninstall.durable.".length).replaceAll("-", " ");
+}
+
+function createUninstallReinstallSection(scenarios) {
+  const uninstallRows = scenarios.filter((scenario) => scenario.id.startsWith("uninstall."));
+  const durableRows = uninstallRows.filter((scenario) =>
+    scenario.id.startsWith("uninstall.durable."),
+  );
+  return Object.freeze({
+    phaseOrder: uninstallPhaseOrder,
+    phases: uninstallPhases,
+    rowMappings: Object.freeze(
+      uninstallRows.map((scenario) =>
+        Object.freeze({ rowId: scenario.id, phases: uninstallPhaseOrder }),
+      ),
+    ),
+    durableInventory: Object.freeze(
+      durableRows.map((scenario) =>
+        Object.freeze({ rowId: scenario.id, durableClass: durableClassName(scenario.id) }),
+      ),
+    ),
+    preservedDataRoots,
+    removedIntegrationState,
+    transientInventory,
+    transientAssertion,
+  });
+}
+
+function validateScenarioSource(collection) {
+  if (
+    !record(collection) ||
+    !Array.isArray(collection.manifests) ||
+    !collection.manifests.every((manifest) => typeof manifest === "string") ||
+    !Array.isArray(collection.scenarios)
+  ) {
+    reject("plan-input");
+  }
+  const ids = new Set();
+  for (const scenario of collection.scenarios) {
+    if (
+      !record(scenario) ||
+      typeof scenario.id !== "string" ||
+      typeof scenario.surface !== "string" ||
+      typeof scenario.expected !== "string"
+    ) {
+      reject("plan-input");
+    }
+    if (ids.has(scenario.id)) reject("source-duplicate");
+    ids.add(scenario.id);
+    if (scenario.automation === "deterministic") scenarioCitations(scenario);
+    else if (scenario.automation !== "vm-only") reject("automation");
+  }
+}
+
+export function createWindowsInstalledAcceptancePlan(collection) {
+  validateScenarioSource(collection);
+  const automatedEvidence = [];
+  const manualChecklist = [];
+  for (const scenario of collection.scenarios) {
+    if (scenario.automation === "deterministic") {
+      automatedEvidence.push(
+        Object.freeze({
+          rowId: scenario.id,
+          surface: scenario.surface,
+          expected: scenario.expected,
+          tests: Object.freeze(scenarioCitations(scenario)),
+        }),
+      );
+    } else if (scenario.automation === "vm-only") {
+      manualChecklist.push(
+        Object.freeze({
+          rowId: scenario.id,
+          surface: scenario.surface,
+          reason: scenario.expected,
+          evidenceContract,
+        }),
+      );
+    } else {
+      reject("automation");
+    }
+  }
+  const plan = Object.freeze({
+    schemaVersion: 1,
+    kind: "windows-installed-acceptance-plan",
+    manifests: Object.freeze([...collection.manifests]),
+    totals: Object.freeze({
+      total: automatedEvidence.length + manualChecklist.length,
+      deterministic: automatedEvidence.length,
+      vmOnly: manualChecklist.length,
+    }),
+    automatedEvidence: Object.freeze(automatedEvidence),
+    manualChecklist: Object.freeze(manualChecklist),
+    uninstallReinstall: createUninstallReinstallSection(collection.scenarios),
+    liveSmokeLane: Object.freeze({
+      mode: "live-smoke",
+      includedInDeterministicLane: false,
+      outputPolicy: Object.freeze({ secrets: "never", identifiers: "redacted" }),
+      smokes: WINDOWS_INSTALLED_ACCEPTANCE_LIVE_SMOKES,
+    }),
+  });
+  validateWindowsInstalledAcceptanceClosure(collection, plan);
+  return plan;
+}
+
+export async function buildWindowsInstalledAcceptancePlan() {
+  return createWindowsInstalledAcceptancePlan(await loadWindowsParityScenarios());
+}
+
+function validateCoverageStep(step, scenario, expectedAutomation) {
+  if (!record(step) || typeof step.rowId !== "string") reject("coverage-shape");
+  if (scenario.automation !== expectedAutomation) reject("coverage-class");
+  if (step.surface !== scenario.surface) reject("coverage-content");
+  if (expectedAutomation === "deterministic") {
+    if (
+      !exactKeys(step, ["rowId", "surface", "expected", "tests"]) ||
+      step.expected !== scenario.expected ||
+      !sameValues(step.tests, scenarioCitations(scenario))
+    ) {
+      reject("coverage-content");
+    }
+  } else if (
+    !exactKeys(step, ["rowId", "surface", "reason", "evidenceContract"]) ||
+    step.reason !== scenario.expected ||
+    !sameValues(step.evidenceContract, evidenceContract)
+  ) {
+    reject("coverage-content");
+  }
+}
+
+function validateUninstallReinstallSection(scenarios, section) {
+  if (
+    !record(section) ||
+    !sameValues(section.phaseOrder, uninstallPhaseOrder) ||
+    !sameValues(section.phases, uninstallPhases) ||
+    !Array.isArray(section.rowMappings) ||
+    !Array.isArray(section.durableInventory) ||
+    !sameValues(section.preservedDataRoots, preservedDataRoots) ||
+    !sameValues(section.removedIntegrationState, removedIntegrationState) ||
+    !sameValues(section.transientInventory, transientInventory) ||
+    section.transientAssertion !== transientAssertion
+  ) {
+    reject("uninstall-protocol");
+  }
+  const expectedRows = scenarios
+    .filter((scenario) => scenario.id.startsWith("uninstall."))
+    .map((scenario) => scenario.id);
+  const expectedIds = new Set(expectedRows);
+  const mappedIds = new Set();
+  for (const mapping of section.rowMappings) {
+    if (
+      !record(mapping) ||
+      typeof mapping.rowId !== "string" ||
+      !sameValues(mapping.phases, uninstallPhaseOrder)
+    ) {
+      reject("uninstall-protocol");
+    }
+    if (!expectedIds.has(mapping.rowId)) reject("uninstall-unknown");
+    if (mappedIds.has(mapping.rowId)) reject("uninstall-duplicate");
+    mappedIds.add(mapping.rowId);
+  }
+  if (expectedRows.some((rowId) => !mappedIds.has(rowId))) reject("uninstall-missing");
+  const expectedDurableInventory = expectedRows
+    .filter((rowId) => rowId.startsWith("uninstall.durable."))
+    .map((rowId) => ({ rowId, durableClass: durableClassName(rowId) }));
+  if (!sameValues(section.durableInventory, expectedDurableInventory)) {
+    reject("uninstall-protocol");
+  }
+}
+
+function validateLiveSmokeLane(lane) {
+  if (
+    !record(lane) ||
+    lane.mode !== "live-smoke" ||
+    lane.includedInDeterministicLane !== false ||
+    !sameValues(lane.smokes, WINDOWS_INSTALLED_ACCEPTANCE_LIVE_SMOKES) ||
+    !sameValues(lane.outputPolicy, { secrets: "never", identifiers: "redacted" })
+  ) {
+    reject("live-smoke-separation");
+  }
+}
+
+export function validateWindowsInstalledAcceptanceClosure(collection, plan) {
+  validateScenarioSource(collection);
+  if (
+    !record(plan) ||
+    plan.schemaVersion !== 1 ||
+    plan.kind !== "windows-installed-acceptance-plan" ||
+    !sameValues(plan.manifests, collection.manifests) ||
+    !Array.isArray(plan.automatedEvidence) ||
+    !Array.isArray(plan.manualChecklist)
+  ) {
+    reject("closure-shape");
+  }
+  const scenariosById = new Map(collection.scenarios.map((scenario) => [scenario.id, scenario]));
+  const coverage = [
+    ...plan.automatedEvidence.map((step) => ({ step, automation: "deterministic" })),
+    ...plan.manualChecklist.map((step) => ({ step, automation: "vm-only" })),
+  ];
+  const coveredIds = new Set();
+  for (const entry of coverage) {
+    if (!record(entry.step) || typeof entry.step.rowId !== "string") reject("coverage-shape");
+    if (coveredIds.has(entry.step.rowId)) reject("coverage-duplicate");
+    const scenario = scenariosById.get(entry.step.rowId);
+    if (scenario === undefined) reject("coverage-unknown");
+    coveredIds.add(entry.step.rowId);
+    validateCoverageStep(entry.step, scenario, entry.automation);
+  }
+  if (collection.scenarios.some((scenario) => !coveredIds.has(scenario.id))) {
+    reject("coverage-missing");
+  }
+  const totals = {
+    total: collection.scenarios.length,
+    deterministic: collection.scenarios.filter(
+      (scenario) => scenario.automation === "deterministic",
+    ).length,
+    vmOnly: collection.scenarios.filter((scenario) => scenario.automation === "vm-only").length,
+  };
+  if (!sameValues(plan.totals, totals)) reject("totals");
+  validateUninstallReinstallSection(collection.scenarios, plan.uninstallReinstall);
+  validateLiveSmokeLane(plan.liveSmokeLane);
+  return Object.freeze({ valid: true, totals: Object.freeze(totals) });
+}
+
+export function requireWindowsInstalledExecutionPlatform(
+  platform = process.platform,
+  architecture = process.arch,
+) {
+  if (platform !== "win32") reject("platform");
+  if (architecture !== "x64") reject("architecture");
+}
+
+function requireChecklistResult(value, stage = "result") {
+  if (!checklistResults.includes(value)) reject(stage);
+  return value;
+}
+
+function hasControlCharacters(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function requireSafeEvidence(value) {
+  if (
+    typeof value !== "string" ||
+    value.trim() !== value ||
+    hasControlCharacters(value) ||
+    unsafeUnbrokenTokenRunPattern.test(value) ||
+    /[\\/]/u.test(value) ||
+    /\S+@\S+/u.test(value) ||
+    /(?:^|\s)@[a-z0-9_]/iu.test(value) ||
+    /\b(?:athlete|account|chat|user)\s+(?:id|identifier)\s*[:=]/iu.test(value) ||
+    /\b(?:api[ -]?key|authorization|bearer|password|passphrase|secret|token)\s*[:=]/iu.test(
+      value,
+    ) ||
+    /-----BEGIN [A-Z ]+PRIVATE KEY-----/u.test(value)
+  ) {
+    reject("result-privacy");
+  }
+  return value;
+}
+
+function planExecutionEntries(plan) {
+  if (
+    !record(plan) ||
+    !Array.isArray(plan.automatedEvidence) ||
+    !Array.isArray(plan.manualChecklist)
+  ) {
+    reject("result-plan");
+  }
+  return [
+    ...plan.automatedEvidence.map((step) => Object.freeze({ lane: "automated", step })),
+    ...plan.manualChecklist.map((step) => Object.freeze({ lane: "manual", step })),
+  ];
+}
+
+function summarizeResults(rows) {
+  const totals = {
+    total: rows.length,
+    passed: rows.filter((row) => row.checklistResult === "pass").length,
+    failed: rows.filter((row) => row.checklistResult === "fail").length,
+    incomplete: rows.filter((row) => row.checklistResult === "incomplete").length,
+  };
+  const complete = totals.incomplete === 0;
+  const passed = complete && totals.failed === 0;
+  return Object.freeze({
+    status: complete ? (passed ? "pass" : "fail") : "incomplete",
+    complete,
+    passed,
+    totals: Object.freeze(totals),
+  });
+}
+
+export function createWindowsInstalledAcceptanceResult(plan, outcomes = []) {
+  if (!Array.isArray(outcomes)) reject("result-shape");
+  const entries = planExecutionEntries(plan);
+  const expectedIds = new Set(entries.map((entry) => entry.step.rowId));
+  const supplied = new Map();
+  for (const outcome of outcomes) {
+    if (
+      !record(outcome) ||
+      !exactKeys(outcome, ["rowId", "checklistResult", "evidence"]) ||
+      typeof outcome.rowId !== "string" ||
+      !expectedIds.has(outcome.rowId)
+    ) {
+      reject("result-shape");
+    }
+    if (supplied.has(outcome.rowId)) reject("result-duplicate");
+    supplied.set(
+      outcome.rowId,
+      Object.freeze({
+        checklistResult: requireChecklistResult(outcome.checklistResult),
+        evidence: requireSafeEvidence(outcome.evidence),
+      }),
+    );
+  }
+  const rows = Object.freeze(
+    entries.map((entry) => {
+      const outcome = supplied.get(entry.step.rowId) ?? {
+        checklistResult: "incomplete",
+        evidence: "",
+      };
+      return Object.freeze({
+        rowId: entry.step.rowId,
+        lane: entry.lane,
+        checklistResult: outcome.checklistResult,
+        evidence: outcome.evidence,
+      });
+    }),
+  );
+  const summary = summarizeResults(rows);
+  return Object.freeze({
+    schemaVersion: 1,
+    kind: resultKinds.installed,
+    status: summary.status,
+    complete: summary.complete,
+    passed: summary.passed,
+    totals: summary.totals,
+    rows,
+  });
+}
+
+export function validateWindowsInstalledAcceptanceResult(plan, artifact) {
+  if (
+    !record(artifact) ||
+    !Array.isArray(artifact.rows) ||
+    artifact.kind !== resultKinds.installed
+  ) {
+    reject("result-shape");
+  }
+  const outcomes = artifact.rows.map((row) => {
+    if (!record(row)) reject("result-shape");
+    return {
+      rowId: row.rowId,
+      checklistResult: row.checklistResult,
+      evidence: row.evidence,
+    };
+  });
+  const canonical = createWindowsInstalledAcceptanceResult(plan, outcomes);
+  if (!sameValues(artifact, canonical)) reject("result-integrity");
+  return canonical;
+}
+
+function createWindowsInstalledLiveSmokeResult(outcomes = []) {
+  if (!Array.isArray(outcomes)) reject("live-smoke-result");
+  const expectedIds = new Set(WINDOWS_INSTALLED_ACCEPTANCE_LIVE_SMOKES.map((smoke) => smoke.id));
+  const supplied = new Map();
+  for (const outcome of outcomes) {
+    if (
+      !record(outcome) ||
+      typeof outcome.smokeId !== "string" ||
+      !expectedIds.has(outcome.smokeId) ||
+      typeof outcome.evidence !== "string"
+    ) {
+      reject("live-smoke-result");
+    }
+    if (supplied.has(outcome.smokeId)) reject("live-smoke-result");
+    supplied.set(outcome.smokeId, {
+      checklistResult: requireChecklistResult(outcome.checklistResult, "live-smoke-result"),
+      evidence: outcome.evidence.length === 0 ? "" : "Evidence recorded and redacted.",
+    });
+  }
+  const rows = Object.freeze(
+    WINDOWS_INSTALLED_ACCEPTANCE_LIVE_SMOKES.map((smoke) => {
+      const outcome = supplied.get(smoke.id) ?? {
+        checklistResult: "incomplete",
+        evidence: "",
+      };
+      return Object.freeze({
+        smokeId: smoke.id,
+        checklistResult: outcome.checklistResult,
+        evidence: outcome.evidence,
+      });
+    }),
+  );
+  const summary = summarizeResults(rows);
+  return Object.freeze({
+    schemaVersion: 1,
+    kind: resultKinds.liveSmoke,
+    status: summary.status,
+    complete: summary.complete,
+    passed: summary.passed,
+    totals: summary.totals,
+    rows,
+  });
+}
+
+export async function executeWindowsInstalledAcceptance(input = {}, dependencies = {}) {
+  requireWindowsInstalledExecutionPlatform(
+    dependencies.platform ?? process.platform,
+    dependencies.architecture ?? process.arch,
+  );
+  const plan = input.plan ?? (await buildWindowsInstalledAcceptancePlan());
+  const collectOutcome = dependencies.collectOutcome;
+  const outcomes = [];
+  if (collectOutcome !== undefined) {
+    for (const entry of planExecutionEntries(plan)) {
+      const outcome = await collectOutcome(entry);
+      outcomes.push({ rowId: entry.step.rowId, ...outcome });
+    }
+  }
+  return createWindowsInstalledAcceptanceResult(plan, outcomes);
+}
+
+export async function executeWindowsInstalledLiveSmokes(dependencies = {}) {
+  requireWindowsInstalledExecutionPlatform(
+    dependencies.platform ?? process.platform,
+    dependencies.architecture ?? process.arch,
+  );
+  const collectOutcome = dependencies.collectOutcome;
+  const outcomes = [];
+  if (collectOutcome !== undefined) {
+    for (const smoke of WINDOWS_INSTALLED_ACCEPTANCE_LIVE_SMOKES) {
+      const outcome = await collectOutcome(smoke);
+      outcomes.push({ smokeId: smoke.id, ...outcome });
+    }
+  }
+  return createWindowsInstalledLiveSmokeResult(outcomes);
+}
+
+async function collectCliOutcome(lines, title, detail) {
+  process.stderr.write(`${title}\n${detail}\n`);
+  let checklistResult;
+  while (checklistResult === undefined) {
+    const candidate = (await lines.question("Checklist result (pass, fail, incomplete): ")).trim();
+    if (checklistResults.includes(candidate)) checklistResult = candidate;
+  }
+  let evidence;
+  while (evidence === undefined) {
+    const candidate = (
+      await lines.question("Path-free, credential-free evidence (free text, may be empty): ")
+    ).trim();
+    try {
+      evidence = requireSafeEvidence(candidate);
+    } catch {
+      process.stderr.write("Evidence refused at result-privacy.\n");
+    }
+  }
+  return { checklistResult, evidence };
+}
+
+async function readJsonFromStandardInput() {
+  let source = "";
+  for await (const chunk of process.stdin) source += chunk;
+  try {
+    return JSON.parse(source);
+  } catch {
+    reject("validation-input");
+  }
+}
+
+async function main() {
+  if (process.argv.length !== 3) reject("mode");
+  const mode = process.argv[2];
+  if (mode === "plan") {
+    process.stdout.write(`${JSON.stringify(await buildWindowsInstalledAcceptancePlan())}\n`);
+    return;
+  }
+  if (mode === "closure") {
+    const collection = await loadWindowsParityScenarios();
+    const plan = createWindowsInstalledAcceptancePlan(collection);
+    process.stdout.write(
+      `${JSON.stringify(validateWindowsInstalledAcceptanceClosure(collection, plan))}\n`,
+    );
+    return;
+  }
+  if (mode === "validate") {
+    const plan = await buildWindowsInstalledAcceptancePlan();
+    const result = validateWindowsInstalledAcceptanceResult(
+      plan,
+      await readJsonFromStandardInput(),
+    );
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+  if (mode === "execute") {
+    const lines = createInterface({ input: process.stdin, output: process.stderr });
+    try {
+      const result = await executeWindowsInstalledAcceptance(
+        {},
+        {
+          collectOutcome(entry) {
+            const detail =
+              entry.lane === "automated"
+                ? `${entry.step.expected}\n${entry.step.tests.join("\n")}`
+                : entry.step.reason;
+            return collectCliOutcome(
+              lines,
+              `${entry.lane.toUpperCase()} ${entry.step.rowId}`,
+              detail,
+            );
+          },
+        },
+      );
+      process.stdout.write(`${JSON.stringify(result)}\n`);
+    } finally {
+      lines.close();
+    }
+    return;
+  }
+  if (mode === "live-smoke") {
+    const lines = createInterface({ input: process.stdin, output: process.stderr });
+    try {
+      const result = await executeWindowsInstalledLiveSmokes({
+        collectOutcome(smoke) {
+          return collectCliOutcome(lines, `LIVE SMOKE ${smoke.name}`, smoke.check);
+        },
+      });
+      process.stdout.write(`${JSON.stringify(result)}\n`);
+    } finally {
+      lines.close();
+    }
+    return;
+  }
+  reject("mode");
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    const stage = error instanceof WindowsInstalledAcceptanceError ? error.stage : "execution";
+    process.stderr.write(`windows-installed acceptance refused at ${stage}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/apps/desktop/scripts/windows-parity-scenarios.d.mts
+++ b/apps/desktop/scripts/windows-parity-scenarios.d.mts
@@ -53,6 +53,7 @@ export const DEFAULT_WINDOWS_PARITY_SCENARIO_MANIFESTS: readonly [
   "chat-settings.scenarios.json",
   "training.scenarios.json",
   "telegram.scenarios.json",
+  "shell-lifecycle.scenarios.json",
 ];
 
 export function loadWindowsParityScenarios(

--- a/apps/desktop/scripts/windows-parity-scenarios.mjs
+++ b/apps/desktop/scripts/windows-parity-scenarios.mjs
@@ -13,6 +13,7 @@ export const DEFAULT_WINDOWS_PARITY_SCENARIO_MANIFESTS = Object.freeze([
   "chat-settings.scenarios.json",
   "training.scenarios.json",
   "telegram.scenarios.json",
+  "shell-lifecycle.scenarios.json",
 ]);
 
 export class WindowsParityScenarioManifestError extends Error {

--- a/apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json
@@ -1,0 +1,362 @@
+{
+  "schemaVersion": 1,
+  "scenarios": [
+    {
+      "id": "shell.bootstrap.user-data",
+      "surface": "shell-bootstrap",
+      "expected": "Windows binds Electron user data exactly once under Local AppData and fails closed with a path-free stage when the location cannot be applied.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/windows-user-data.test.ts > uses LOCALAPPDATA as the primary Windows location",
+        "apps/desktop/tests/windows-user-data.test.ts > sets userData exactly once to the decided Windows path",
+        "apps/desktop/tests/windows-user-data.test.ts > reports only the set-user-data stage when Electron rejects the path"
+      ]
+    },
+    {
+      "id": "shell.bootstrap.app-identity",
+      "surface": "shell-bootstrap",
+      "expected": "Windows binds the frozen AppUserModelID before scheme registration, the single-instance lock, or window interaction, and an identity failure stops bootstrap without private details.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/desktop-lifecycle.test.ts > binds the frozen AppUserModelID only on Windows",
+        "apps/desktop/tests/desktop-lifecycle.test.ts > fails closed when Windows rejects the AppUserModelID",
+        "apps/desktop/tests/desktop-lifecycle.test.ts > binds identity before scheme, lock, and window interaction in the production entry"
+      ]
+    },
+    {
+      "id": "shell.single-instance.activation",
+      "surface": "shell-activation",
+      "expected": "A losing Windows launch exits before desktop bootstrap, while its activation is relayed to restore, show, and focus the resident main window; early duplicate activations coalesce once.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/desktop-lifecycle.test.ts > restores, shows, and focuses the resident window for a second launch",
+        "apps/desktop/tests/desktop-lifecycle.test.ts > coalesces early Windows activation and presents every later second launch",
+        "apps/desktop/tests/residency.test.ts > keeps the production failure adapter closed and gates the loser before bootstrap"
+      ]
+    },
+    {
+      "id": "shell.tray.window-residency",
+      "surface": "shell-tray",
+      "expected": "Closing the Windows main window hides it without quitting, tray left-click opens it, and explicit Quit permits the window and application to close.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/residency.test.ts > uses the Windows tray icon as-is and opens the main window on left click",
+        "apps/desktop/tests/residency.test.ts > hides a Windows main window on close and allows explicit Quit to close it"
+      ]
+    },
+    {
+      "id": "shell.tray.native-menu",
+      "surface": "shell-tray",
+      "expected": "Windows tray right-click builds a fresh native Open Enduragent, Start in background at login, and Quit Enduragent menu from current Startup Apps truth, without creating the macOS popover.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/residency.test.ts > uses the Windows tray icon as-is and opens the main window on left click",
+        "apps/desktop/tests/residency.test.ts > uses effective Windows Startup Apps truth in the native menu",
+        "apps/desktop/tests/residency.test.ts > builds a fresh exact native menu and uses current checkbox truth"
+      ]
+    },
+    {
+      "id": "shell.login.registration",
+      "surface": "shell-login",
+      "expected": "Login start reads, writes, and verifies the named per-user Windows registration for the installed executable and background argument, and uninstall deletes the matching HKCU Run value.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/login-item.test.ts > reads the exact argument-marked Windows registration",
+        "apps/desktop/tests/login-item.test.ts > writes and verifies the named per-user Windows registration when enabled=%s",
+        "apps/desktop/tests/windows-icons.test.ts > keeps the runtime login value name aligned with the uninstall hook"
+      ]
+    },
+    {
+      "id": "shell.login.background-launch",
+      "surface": "shell-login",
+      "expected": "Only the exact enabled Windows login invocation starts resident in the background; manual launches remain foreground and the background preference reopens durably without POSIX-only assumptions.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/login-item.test.ts > defaults to foreground and persists a restart-safe background preference",
+        "apps/desktop/tests/login-item.test.ts > persists the Windows preference without POSIX ownership or directory sync",
+        "apps/desktop/tests/login-item.test.ts > starts in the Windows background only for the exact enabled login invocation"
+      ]
+    },
+    {
+      "id": "shell.windows.login-reboot",
+      "surface": "shell-login",
+      "expected": "After enabling Start in background at login and rebooting Windows, the owning user signs in to one background-resident Enduragent instance with a tray icon and no foreground window until opened. This remains VM-only because it requires a real reboot and Windows Startup Apps invocation.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "shell.windows.power-events",
+      "surface": "shell-power",
+      "expected": "A real Windows suspend and resume leaves the installed resident shell available from the tray and lets the shipped power lifecycle reconcile without changing durable login or channel intent. This remains VM-only because synthetic event emitters cannot prove OS power delivery or post-wake shell residency.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "upgrade-fence.transport.admission",
+      "surface": "upgrade-fence",
+      "expected": "Windows dispatches upgrade acquisition and startup admission to a claim file backed by loopback TCP: ordinary or wrong callers are reserved, one designated capability is admitted once, and release returns admission to clear.",
+      "automation": "deterministic",
+      "tests": [
+        "packages/coach/tests/upgrade-fence.test.ts > routes acquisition to the Windows claim-file transport",
+        "packages/coach/tests/upgrade-fence.test.ts > routes admission to the Windows claim-file transport",
+        "packages/coach/tests/windows-upgrade-fence.test.ts > matches admission, one-shot capability, release, and permission contracts"
+      ]
+    },
+    {
+      "id": "upgrade-fence.transport.contention",
+      "surface": "upgrade-fence",
+      "expected": "A live or nonresponsive holder keeps startup reserved, its nonce-authenticated claim stays intact, and simultaneous Windows acquisitions produce exactly one owner and one reserved contender.",
+      "automation": "deterministic",
+      "tests": [
+        "packages/coach/tests/windows-upgrade-fence.test.ts > reserves a hung holder after the monotonic deadline without reclaiming its claim",
+        "packages/coach/tests/windows-upgrade-fence.test.ts > keeps a live claim when the holder returns the correct nonce echo",
+        "packages/coach/tests/windows-upgrade-fence.test.ts > arbitrates concurrent acquisitions with exactly one winner"
+      ]
+    },
+    {
+      "id": "upgrade-fence.transport.stale-claim",
+      "surface": "upgrade-fence",
+      "expected": "A dead holder or nonce-invalid loopback squatter has its stale Windows claim reclaimed so a fresh owner can acquire, while release never unlinks a replacement claim inode it does not own.",
+      "automation": "deterministic",
+      "tests": [
+        "packages/coach/tests/windows-upgrade-fence.test.ts > does not unlink a replacement claim inode during release",
+        "packages/coach/tests/windows-upgrade-fence.test.ts > recovers a claim left behind by a crashed holder and permits a fresh acquisition",
+        "packages/coach/tests/windows-upgrade-fence.test.ts > reclaims a port squatter returning %s"
+      ]
+    },
+    {
+      "id": "daemon.supervision.windows-ownership",
+      "surface": "daemon-supervision",
+      "expected": "Windows accepts only a live app-supervised daemon with the current utility child handle and refuses an attached or dead peer without claiming, killing, or hard-stopping an unowned process.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/supervisor.test.ts > accepts a live app-supervised Windows resolution",
+        "apps/desktop/tests/supervisor.test.ts > refuses a Windows daemon without a current app child handle",
+        "apps/desktop/tests/supervisor.test.ts > refuses a dead Windows app child instead of claiming ownership"
+      ]
+    },
+    {
+      "id": "daemon.supervision.start-stop",
+      "surface": "daemon-supervision",
+      "expected": "The desktop starts its owned daemon through strict utility control frames, acknowledges one exact terminal frame, requests graceful shutdown, observes exit, and does not restart an intentionally stopped child.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/utility-protocol.test.ts > accepts only strict start and shutdown control frames",
+        "apps/desktop/tests/supervisor.test.ts > starts over the closed control protocol and acknowledges one exact terminal frame",
+        "apps/desktop/tests/supervisor.test.ts > does not restart when shutdown requested the child exit"
+      ]
+    },
+    {
+      "id": "daemon.supervision.crash-restart",
+      "surface": "daemon-supervision",
+      "expected": "An unexpected owned-daemon exit triggers bounded backoff, prepares successor coordinates before publishing the next generation, and ends in a truthful terminal state after the restart budget is exhausted.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/supervisor.test.ts > restarts after an unexpected child exit and publishes the new live coordinates",
+        "apps/desktop/tests/supervisor.test.ts > prepares the successor coordinates before publishing them",
+        "apps/desktop/tests/supervisor.test.ts > stops after three quick restart attempts when children keep dying"
+      ]
+    },
+    {
+      "id": "daemon.shutdown.quit-drain",
+      "surface": "daemon-shutdown",
+      "expected": "Explicit Quit is deduplicated, closes resident tray resources, drains accepted desktop work before normal exit, blocks repeated pre-drain exits, and never restarts the intentionally stopped daemon.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/residency.test.ts > deduplicates quit and destroys popover before tray exactly once",
+        "apps/desktop/tests/quit-coordinator.test.ts > blocks repeated pre-drain quits and permits only the updater-generated post-drain quit",
+        "apps/desktop/tests/quit-coordinator.test.ts > permits a normal final exit only after a successful drain",
+        "apps/desktop/tests/supervisor.test.ts > does not restart when shutdown requested the child exit"
+      ]
+    },
+    {
+      "id": "package.startup.mode",
+      "surface": "packaged-startup",
+      "expected": "The packaged-acceptance startup adapter consumes only the exact one-shot OS-login marker, forces an unmarked acceptance launch to manual, and deletes and rejects every non-exact marker.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/packaged-startup-mode.test.ts > consumes an exact marker and injects one OS-login observation",
+        "apps/desktop/tests/packaged-startup-mode.test.ts > injects one manual observation for an unmarked acceptance launch",
+        "apps/desktop/tests/packaged-startup-mode.test.ts > deletes and rejects every non-exact marker"
+      ]
+    },
+    {
+      "id": "package.process.safety",
+      "surface": "packaged-process",
+      "expected": "Packaged acceptance installs its exact quit control before production startup, treats only spawn followed by exit zero without a signal as clean, and permits release only after successful execution and a clear process scan.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/packaged-process-safety.test.ts > registers an exact, fragmented stdin quit frame before production startup",
+        "apps/desktop/tests/packaged-process-safety.test.ts > requires spawn followed by close zero with no signal",
+        "apps/desktop/tests/packaged-process-safety.test.ts > permits release only after successful execution, clean direct exits, and a clear scan"
+      ]
+    },
+    {
+      "id": "package.nsis.install-plan",
+      "surface": "windows-installer",
+      "expected": "The private Windows artifact is one-click, unsigned x64 NSIS, per-user and as-invoker with no elevation helper, a Start menu shortcut but no desktop shortcut, and the committed application and tray icons.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/windows-package-plan.test.ts > seals every frozen identity value in the unsigned x64 NSIS plan",
+        "apps/desktop/tests/windows-icons.test.ts > keeps the Windows builder wired to the committed ICO resources",
+        "apps/desktop/tests/windows-package-layout.test.ts > accepts the exact x64 application and unsigned NSIS package"
+      ]
+    },
+    {
+      "id": "package.nsis.runtime-layout",
+      "surface": "windows-package",
+      "expected": "The Windows application has only its declared x64 runtime, ASAR, icons, and self-test resources; source maps, tests, fixtures, undeclared resources, and native packages are rejected as development or unsafe residue.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/windows-package-layout.test.ts > accepts the exact x64 application and unsigned NSIS package",
+        "apps/desktop/tests/windows-package-layout.test.ts > rejects forbidden ASAR path %s",
+        "apps/desktop/tests/windows-package-layout.test.ts > rejects undeclared package resources",
+        "apps/desktop/tests/windows-package-layout.test.ts > rejects native packages inside the ASAR"
+      ]
+    },
+    {
+      "id": "package.nsis.verification",
+      "surface": "windows-package",
+      "expected": "Packaging cleans output, builds one exact versioned installer, and verifies it before release; signed, renamed, non-NSIS, missing, or undeclared installer contents fail closed.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/windows-package-plan.test.ts > cleans, builds, checks the singleton artifact, and verifies in order",
+        "apps/desktop/tests/windows-package-layout.test.ts > rejects signed, renamed, and non-NSIS installer artifacts",
+        "apps/desktop/tests/windows-package-layout.test.ts > rejects undeclared and missing entries inside the installer"
+      ]
+    },
+    {
+      "id": "updater.unsigned.package-truth",
+      "surface": "windows-updater",
+      "expected": "The unsigned Windows package is update-ineligible, contains no release marker or updater metadata, leaves updater loading and scheduling off, and never shows the sidebar's Update available action while disabled.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/windows-package-plan.test.ts > seals every frozen identity value in the unsigned x64 NSIS plan",
+        "apps/desktop/tests/windows-package-layout.test.ts > keeps ordinary Windows packages updater-inert",
+        "apps/desktop/tests/update-controller.test.ts > is silent when release eligibility is disabled",
+        "apps/desktop-renderer/tests/sidebar-surface.test.tsx > appears only when an update is ready and names its version"
+      ]
+    },
+    {
+      "id": "updater.unsigned.version-floor",
+      "surface": "windows-updater",
+      "expected": "Even when updates are disabled, startup records the running desktop version; the durable highest-version floor survives restart and a future eligible update path refuses any lower candidate.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/update-controller.test.ts > is silent when release eligibility is disabled",
+        "apps/desktop/tests/update-version-floor.test.ts > survives a restart and never falls below the highest version run",
+        "apps/desktop/tests/update-controller.test.ts > refuses and reports a candidate lower than the recorded version floor"
+      ]
+    },
+    {
+      "id": "storage.first-run.configuration",
+      "surface": "shell-storage",
+      "expected": "Windows prepares the athlete home, seeds a parseable first-run configuration only when absent, reopens an existing configuration unchanged, and completes this work before constructing the daemon supervisor.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/first-run-config.test.ts > leaves an existing arbitrary configuration byte-identical",
+        "apps/desktop/tests/first-run-config.test.ts > seeds and reopens a Windows configuration without POSIX mode assertions",
+        "apps/desktop/tests/first-run-config.test.ts > prepares the home before seeding and constructing the daemon supervisor"
+      ]
+    },
+    {
+      "id": "storage.windows.durable-writes",
+      "surface": "shell-storage",
+      "expected": "Windows shell stores use file-flush and private-path durability without unsupported POSIX ownership or directory-sync assumptions, and sharing failures remain path-free and stage-coded.",
+      "automation": "deterministic",
+      "tests": [
+        "apps/desktop/tests/durable-atomic-replace.test.ts > uses the Windows durability taxonomy without chmod or directory sync",
+        "apps/desktop/tests/durable-atomic-replace.test.ts > surfaces a path-free Windows sharing failure at the rename stage",
+        "apps/desktop/tests/login-item.test.ts > persists the Windows preference without POSIX ownership or directory sync"
+      ]
+    },
+    {
+      "id": "shell.windows.second-launch",
+      "surface": "shell-activation",
+      "expected": "Launching the installed Start menu shortcut twice leaves one Enduragent process family and brings the existing main window to the foreground from normal, minimized, and close-to-tray states. This remains VM-only because it requires the real Windows single-instance lock, process table, and foreground activation policy.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "shell.windows.tray-residency",
+      "surface": "shell-tray",
+      "expected": "The installed tray survives main-window close, left-click opens the window, right-click shows the native residency menu without a popover, and Quit removes the tray and process family. This remains VM-only because Electron doubles cannot prove Explorer tray interaction or native menu behavior.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "package.windows.installation",
+      "surface": "windows-installer",
+      "expected": "Running the unsigned installer as a standard user completes without elevation, installs per-user, exposes the correct Start menu and Apps list identity and icons, creates no desktop shortcut, and contains no development resources. This remains VM-only because archive verification cannot prove Windows installer UI, shell integration, or elevation behavior.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "package.windows.process-release",
+      "surface": "packaged-process",
+      "expected": "After explicit Quit, no installed Enduragent main, utility, renderer, crash handler, or other helper process retains the installation or user-data trees. This remains VM-only because proving the complete Windows process tree and open handles requires kernel-backed observations in the installed VM.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "updater.windows.unsigned-ui",
+      "surface": "windows-updater",
+      "expected": "The installed unsigned package starts and remains updater-disabled with no download traffic, staged update, Update available chip, or restart-to-install prompt. This remains VM-only because the final proof spans packaged metadata, the real runtime, network observation, and rendered Windows UI.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "uninstall.windows.integration-cleanup",
+      "surface": "windows-uninstall",
+      "expected": "After seeded use, uninstall removes the program directory, Start menu shortcut, Apps list entry, uninstaller, tray process, and owned HKCU Run value without deleting athlete or user-data roots. This remains VM-only because it requires executing the real NSIS uninstaller and inspecting Windows shell and registry state.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "uninstall.durable.athlete-config",
+      "surface": "windows-reinstall",
+      "expected": "After seed, uninstall, and same-user reinstall, athlete configuration, selected provider and model, intake, training account identity, and stored subscription profile reopen byte-for-byte or semantically unchanged. This remains VM-only because it crosses the real NSIS boundary and reopens the owning user's athlete-home configuration.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "uninstall.durable.training-store",
+      "surface": "windows-reinstall",
+      "expected": "After seed, uninstall, and same-user reinstall, the SQLite training store reopens with imported and synced activities, athlete identity, analyses, and readiness unchanged. This remains VM-only because it requires a real uninstall boundary and reopening the installed Windows SQLite runtime against the preserved store.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "uninstall.durable.training-archive",
+      "surface": "windows-reinstall",
+      "expected": "After seed, uninstall, and same-user reinstall, archived source training files remain byte-identical and usable for repeat-safe recovery. This remains VM-only because it requires a real uninstall boundary and byte comparison of the preserved athlete archive.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "uninstall.durable.coaching-data",
+      "surface": "windows-reinstall",
+      "expected": "After seed, uninstall, and same-user reinstall, current and past conversations, coach memory and provenance, Reference snapshots, sync history, spend state, and Telegram allowed-user access reopen unchanged. This remains VM-only because it requires inventorying and reopening every durable athlete-data class across the real uninstall boundary.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "uninstall.durable.desktop-credentials",
+      "surface": "windows-reinstall",
+      "expected": "After seed, uninstall, and same-user reinstall, every configured provider and Intervals.icu credential remains ciphertext at rest and decrypts to a usable value only for the owning Windows user. This remains VM-only because DPAPI continuity and ownership cannot be proved without the original Windows user profile across uninstall and reinstall.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "uninstall.durable.telegram-channel",
+      "surface": "windows-reinstall",
+      "expected": "After seed, uninstall, and same-user reinstall, the Telegram bot profile still decrypts, and its enabled intent, power-gap state, pairing identity, and allowed-user access reopen unchanged. This remains VM-only because it requires real DPAPI, daemon, and preserved user-data behavior across uninstall and reinstall.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "uninstall.durable.desktop-preferences",
+      "surface": "windows-reinstall",
+      "expected": "After seed, uninstall, and same-user reinstall, the background-at-login preference and highest desktop version floor reopen unchanged while the removed Run registration stays off until explicitly enabled again. This remains VM-only because it crosses both preserved user-data and removed Windows registry state.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "uninstall.durable.renderer-preferences",
+      "surface": "windows-reinstall",
+      "expected": "After seed, uninstall, and same-user reinstall, the chosen appearance and app palette reopen from the preserved renderer local storage while session-only storage is not treated as durable. This remains VM-only because Chromium storage preservation is observable only in the installed owning-user profile across the NSIS boundary.",
+      "automation": "vm-only"
+    },
+    {
+      "id": "uninstall.transients.relaunch",
+      "surface": "windows-reinstall",
+      "expected": "Stale updater cache or staging, lock files, daemon PID and port registrations, upgrade-fence claim coordinates, crash breadcrumbs, and owned temporary files never block same-user reinstall or a clean relaunch. This remains VM-only because it requires seeding real cross-process crash residue and exercising installer and runtime recovery on Windows.",
+      "automation": "vm-only"
+    }
+  ]
+}

--- a/apps/desktop/tests/windows-installed-acceptance.test.ts
+++ b/apps/desktop/tests/windows-installed-acceptance.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WINDOWS_INSTALLED_ACCEPTANCE_LIVE_SMOKES,
+  buildWindowsInstalledAcceptancePlan,
+  createWindowsInstalledAcceptancePlan,
+  createWindowsInstalledAcceptanceResult,
+  executeWindowsInstalledAcceptance,
+  executeWindowsInstalledLiveSmokes,
+  validateWindowsInstalledAcceptanceClosure,
+  validateWindowsInstalledAcceptanceResult,
+  type WindowsInstalledAcceptancePlan,
+  type WindowsInstalledAcceptanceStage,
+} from "../scripts/accept-windows-installed.mjs";
+import {
+  loadWindowsParityScenarios,
+  type WindowsParityScenarioCollection,
+} from "../scripts/windows-parity-scenarios.mjs";
+
+function syntheticCollection(): WindowsParityScenarioCollection {
+  return {
+    schemaVersion: 1,
+    manifests: ["synthetic.scenarios.json"],
+    scenarios: [
+      {
+        id: "shell.synthetic.automated",
+        surface: "shell",
+        expected: "The synthetic automated behavior is proved.",
+        automation: "deterministic",
+        test: "apps/desktop/tests/synthetic.test.ts > proves automated behavior",
+      },
+      {
+        id: "shell.synthetic.manual",
+        surface: "shell",
+        expected: "The synthetic installed behavior needs host observation.",
+        automation: "vm-only",
+      },
+    ],
+  };
+}
+
+function expectStage(operation: () => unknown, stage: WindowsInstalledAcceptanceStage): void {
+  expect(operation).toThrowError(
+    expect.objectContaining({
+      name: "WindowsInstalledAcceptanceError",
+      message: `windows-installed acceptance refused at ${stage}`,
+      stage,
+    }),
+  );
+}
+
+describe("Windows installed acceptance", () => {
+  it("builds exact closure over all real manifests with totals derived from their rows", async () => {
+    const collection = await loadWindowsParityScenarios();
+    const plan = await buildWindowsInstalledAcceptancePlan();
+    const derivedTotals = {
+      total: collection.scenarios.length,
+      deterministic: collection.scenarios.filter(
+        (scenario) => scenario.automation === "deterministic",
+      ).length,
+      vmOnly: collection.scenarios.filter((scenario) => scenario.automation === "vm-only").length,
+    };
+
+    expect(plan.manifests).toEqual(collection.manifests);
+    expect(plan.totals).toEqual(derivedTotals);
+    expect(plan.totals.total).toBe(140);
+    expect(plan.automatedEvidence).toHaveLength(derivedTotals.deterministic);
+    expect(plan.manualChecklist).toHaveLength(derivedTotals.vmOnly);
+    expect(
+      [
+        ...plan.automatedEvidence.map((step) => step.rowId),
+        ...plan.manualChecklist.map((item) => item.rowId),
+      ].sort(),
+    ).toEqual(collection.scenarios.map((scenario) => scenario.id).sort());
+    expect(validateWindowsInstalledAcceptanceClosure(collection, plan)).toEqual({
+      valid: true,
+      totals: derivedTotals,
+    });
+    expect(
+      plan.automatedEvidence.every((step) => step.tests.length > 0 && Object.isFrozen(step.tests)),
+    ).toBe(true);
+    expect(
+      plan.manualChecklist.every(
+        (item) =>
+          item.reason.length > 0 &&
+          item.evidenceContract.evidence.pathPolicy === "path-free" &&
+          item.evidenceContract.evidence.credentialPolicy === "credential-free",
+      ),
+    ).toBe(true);
+  });
+
+  it("fails closed for unknown automation and duplicate, unknown, or missing row coverage", () => {
+    const collection = syntheticCollection();
+    const plan = createWindowsInstalledAcceptancePlan(collection);
+    const unknownAutomation = {
+      ...collection,
+      scenarios: [
+        {
+          ...collection.scenarios[0],
+          automation: "operator-only",
+        },
+      ],
+    } as unknown as WindowsParityScenarioCollection;
+    expectStage(() => createWindowsInstalledAcceptancePlan(unknownAutomation), "automation");
+
+    const duplicate = {
+      ...plan,
+      automatedEvidence: [...plan.automatedEvidence, plan.automatedEvidence[0]],
+    } as unknown as WindowsInstalledAcceptancePlan;
+    expectStage(
+      () => validateWindowsInstalledAcceptanceClosure(collection, duplicate),
+      "coverage-duplicate",
+    );
+
+    const unknown = {
+      ...plan,
+      automatedEvidence: [
+        {
+          ...plan.automatedEvidence[0],
+          rowId: "shell.synthetic.unknown",
+        },
+      ],
+    } as unknown as WindowsInstalledAcceptancePlan;
+    expectStage(
+      () => validateWindowsInstalledAcceptanceClosure(collection, unknown),
+      "coverage-unknown",
+    );
+
+    const missing = {
+      ...plan,
+      manualChecklist: [],
+    } as unknown as WindowsInstalledAcceptancePlan;
+    expectStage(
+      () => validateWindowsInstalledAcceptanceClosure(collection, missing),
+      "coverage-missing",
+    );
+  });
+
+  it("maps every uninstall row through seed, uninstall, and reinstall inventory", async () => {
+    const collection = await loadWindowsParityScenarios();
+    const plan = createWindowsInstalledAcceptancePlan(collection);
+    const uninstallRows = collection.scenarios
+      .filter((scenario) => scenario.id.startsWith("uninstall."))
+      .map((scenario) => scenario.id);
+    const durableRows = uninstallRows.filter((rowId) => rowId.startsWith("uninstall.durable."));
+
+    expect(plan.uninstallReinstall.phaseOrder).toEqual(["seed", "uninstall", "reinstall"]);
+    expect(plan.uninstallReinstall.rowMappings.map((mapping) => mapping.rowId)).toEqual(
+      uninstallRows,
+    );
+    expect(
+      plan.uninstallReinstall.rowMappings.every((mapping) => Object.isFrozen(mapping.phases)),
+    ).toBe(true);
+    expect(plan.uninstallReinstall.rowMappings.map((mapping) => mapping.phases)).toEqual(
+      uninstallRows.map(() => ["seed", "uninstall", "reinstall"]),
+    );
+    expect(plan.uninstallReinstall.durableInventory.map((item) => item.rowId)).toEqual(durableRows);
+    expect(plan.uninstallReinstall.phases.map((phase) => phase.requirement).join(" ")).toMatch(
+      /every durable class.*program and integration state.*both athlete-data and desktop user-data roots.*DPAPI secrets still decrypt/iu,
+    );
+    expect(plan.uninstallReinstall.transientInventory).toEqual([
+      "updater cache and staging",
+      "runtime locks",
+      "daemon PID and port coordinates",
+      "upgrade-fence claim coordinates",
+      "crash temporaries",
+    ]);
+    expect(plan.uninstallReinstall.transientAssertion).toContain(
+      "block same-user reinstall or a clean relaunch",
+    );
+  });
+
+  it("keeps credential-safe live smokes out of the installed deterministic lane", async () => {
+    const plan = createWindowsInstalledAcceptancePlan(syntheticCollection());
+    const mainEntries: string[] = [];
+    const mainResult = await executeWindowsInstalledAcceptance(
+      { plan },
+      {
+        platform: "win32",
+        architecture: "x64",
+        collectOutcome(entry) {
+          mainEntries.push(entry.step.rowId);
+          return { checklistResult: "pass", evidence: "Synthetic check passed." };
+        },
+      },
+    );
+
+    expect(plan.liveSmokeLane.includedInDeterministicLane).toBe(false);
+    expect(plan.liveSmokeLane.mode).toBe("live-smoke");
+    expect(plan.liveSmokeLane.smokes.map((smoke) => smoke.name)).toEqual([
+      "ChatGPT",
+      "Claude CLI",
+      "Intervals.icu",
+      "Telegram",
+      "One API-key provider",
+    ]);
+    expect(mainEntries).toEqual([
+      ...plan.automatedEvidence.map((step) => step.rowId),
+      ...plan.manualChecklist.map((item) => item.rowId),
+    ]);
+    expect(
+      mainEntries.some((rowId) =>
+        WINDOWS_INSTALLED_ACCEPTANCE_LIVE_SMOKES.some((smoke) => smoke.id === rowId),
+      ),
+    ).toBe(false);
+    expect(mainResult.kind).toBe("windows-installed-acceptance-result");
+
+    const liveResult = await executeWindowsInstalledLiveSmokes({
+      platform: "win32",
+      architecture: "x64",
+      collectOutcome() {
+        return { checklistResult: "pass", evidence: "Sensitive identifiers observed." };
+      },
+    });
+    expect(liveResult.rows.map((row) => row.smokeId)).toEqual(
+      WINDOWS_INSTALLED_ACCEPTANCE_LIVE_SMOKES.map((smoke) => smoke.id),
+    );
+    expect(liveResult.rows.every((row) => row.evidence === "Evidence recorded and redacted.")).toBe(
+      true,
+    );
+    expect(JSON.stringify(liveResult)).not.toContain("Sensitive identifiers observed.");
+  });
+
+  it("refuses execution off win32 before collecting evidence with a path-free stage", async () => {
+    const collectOutcome = vi.fn();
+    const operation = executeWindowsInstalledAcceptance(
+      { plan: createWindowsInstalledAcceptancePlan(syntheticCollection()) },
+      { platform: "darwin", architecture: "arm64", collectOutcome },
+    );
+
+    await expect(operation).rejects.toMatchObject({
+      name: "WindowsInstalledAcceptanceError",
+      message: "windows-installed acceptance refused at platform",
+      stage: "platform",
+    });
+    await expect(operation).rejects.not.toThrow(/[\\/]/u);
+    expect(collectOutcome).not.toHaveBeenCalled();
+  });
+
+  it("refuses live-smoke execution off win32 before collecting evidence", async () => {
+    const collectOutcome = vi.fn();
+    const operation = executeWindowsInstalledLiveSmokes({
+      platform: "darwin",
+      architecture: "arm64",
+      collectOutcome,
+    });
+
+    await expect(operation).rejects.toMatchObject({
+      name: "WindowsInstalledAcceptanceError",
+      message: "windows-installed acceptance refused at platform",
+      stage: "platform",
+    });
+    await expect(operation).rejects.not.toThrow(/[\\/]/u);
+    expect(collectOutcome).not.toHaveBeenCalled();
+  });
+
+  it("accepts realistic prose evidence", () => {
+    const plan = createWindowsInstalledAcceptancePlan(syntheticCollection());
+    const [automated] = plan.automatedEvidence;
+    const evidence =
+      "Installed startup, settings persistence, and clean relaunch matched expectations.";
+    const result = createWindowsInstalledAcceptanceResult(plan, [
+      { rowId: automated.rowId, checklistResult: "pass", evidence },
+    ]);
+
+    expect(result.rows.find((row) => row.rowId === automated.rowId)?.evidence).toBe(evidence);
+  });
+
+  it("refuses a bare 40-character hexadecimal token at the evidence privacy stage", () => {
+    const plan = createWindowsInstalledAcceptancePlan(syntheticCollection());
+    const [automated] = plan.automatedEvidence;
+
+    expectStage(
+      () =>
+        createWindowsInstalledAcceptanceResult(plan, [
+          {
+            rowId: automated.rowId,
+            checklistResult: "pass",
+            evidence: "0123456789abcdef0123456789abcdef01234567",
+          },
+        ]),
+      "result-privacy",
+    );
+  });
+
+  it("records missing outcomes as incomplete and never promotes them to pass", () => {
+    const plan = createWindowsInstalledAcceptancePlan(syntheticCollection());
+    const [automated] = plan.automatedEvidence;
+    const [manual] = plan.manualChecklist;
+    const incomplete = createWindowsInstalledAcceptanceResult(plan, [
+      {
+        rowId: automated.rowId,
+        checklistResult: "pass",
+        evidence: "Automated evidence passed.",
+      },
+    ]);
+
+    expect(incomplete).toMatchObject({
+      status: "incomplete",
+      complete: false,
+      passed: false,
+      totals: { total: 2, passed: 1, failed: 0, incomplete: 1 },
+    });
+    expect(incomplete.rows.find((row) => row.rowId === manual.rowId)).toMatchObject({
+      checklistResult: "incomplete",
+      evidence: "",
+    });
+    expect(validateWindowsInstalledAcceptanceResult(plan, incomplete)).toEqual(incomplete);
+
+    const dishonest = { ...incomplete, status: "pass", passed: true };
+    expectStage(
+      () => validateWindowsInstalledAcceptanceResult(plan, dishonest),
+      "result-integrity",
+    );
+
+    const complete = createWindowsInstalledAcceptanceResult(
+      plan,
+      [automated.rowId, manual.rowId].map((rowId) => ({
+        rowId,
+        checklistResult: "pass" as const,
+        evidence: "Acceptance evidence passed.",
+      })),
+    );
+    expect(complete).toMatchObject({ status: "pass", complete: true, passed: true });
+  });
+});

--- a/apps/desktop/tests/windows-parity-scenarios.test.ts
+++ b/apps/desktop/tests/windows-parity-scenarios.test.ts
@@ -62,7 +62,7 @@ async function expectStage(
 }
 
 describe("Windows parity scenario manifests", () => {
-  it("loads the frozen Chat, Settings, Training and Telegram manifests with tested deterministic rows", async () => {
+  it("loads the frozen Chat, Settings, Training, Telegram and Shell/Lifecycle manifests with tested deterministic rows", async () => {
     const collection = await loadWindowsParityScenarios();
 
     expect(collection.schemaVersion).toBe(1);
@@ -73,7 +73,7 @@ describe("Windows parity scenario manifests", () => {
         (scenario) => scenario.automation === "deterministic",
       ).length,
       vmOnly: collection.scenarios.filter((scenario) => scenario.automation === "vm-only").length,
-    }).toEqual({ total: 100, deterministic: 89, vmOnly: 11 });
+    }).toEqual({ total: 140, deterministic: 112, vmOnly: 28 });
     expect(new Set(collection.scenarios.map((scenario) => scenario.id)).size).toBe(
       collection.scenarios.length,
     );
@@ -148,6 +148,29 @@ describe("Windows parity scenario manifests", () => {
       "telegram.storage.diagnostics",
       "telegram.tray.status-projection",
       "telegram.release-chain.shutdown-drain",
+      "shell.bootstrap.user-data",
+      "shell.bootstrap.app-identity",
+      "shell.single-instance.activation",
+      "shell.tray.window-residency",
+      "shell.tray.native-menu",
+      "shell.login.registration",
+      "shell.login.background-launch",
+      "upgrade-fence.transport.admission",
+      "upgrade-fence.transport.contention",
+      "upgrade-fence.transport.stale-claim",
+      "daemon.supervision.windows-ownership",
+      "daemon.supervision.start-stop",
+      "daemon.supervision.crash-restart",
+      "daemon.shutdown.quit-drain",
+      "package.startup.mode",
+      "package.process.safety",
+      "package.nsis.install-plan",
+      "package.nsis.runtime-layout",
+      "package.nsis.verification",
+      "updater.unsigned.package-truth",
+      "updater.unsigned.version-floor",
+      "storage.first-run.configuration",
+      "storage.windows.durable-writes",
     ]);
     expect(Object.isFrozen(collection)).toBe(true);
     expect(Object.isFrozen(collection.manifests)).toBe(true);


### PR DESCRIPTION
## Summary

Closes the installed-parity manifest set and ships the Windows installed-acceptance runner — the final package of the installed-parity slice before local acceptance execution.

**Fourth and final scenario manifest** — `apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json`: 40 rows (23 `deterministic` with runtime-verified multi-test citations, 17 `vm-only`). Covers bootstrap/AUMID fail-closed bind, single-instance second-launch relay, tray residency, login start and its uninstall expectations, sleep/wake, the claim-file + loopback upgrade fence (citing `packages/coach` tests — cross-package citations resolve through the existing aggregator test unchanged), supervised daemon lifecycle, packaged startup mode and process safety, NSIS user-visible install invariants, updater truthfulness in the unsigned package, and the uninstall/reinstall durable-class + transient inventory. Registered through the aggregator's registration seam only (one array entry + mirrored tuple literal); validation semantics untouched. Combined frozen collection: **140 rows — 112 deterministic, 28 vm-only** across four manifests; both freeze assertions updated (count object + 71-entry deterministic-row-ID array).

**Installed-acceptance runner** — `apps/desktop/scripts/accept-windows-installed.{mjs,d.mts}` with CLI modes `plan`, `closure`, `validate`, `execute`, `live-smoke`:

- Pure plan construction over all four manifests via the aggregator's public API; totals re-derived, never hardcoded.
- Fail-closed exact-closure validation: unknown automation class, duplicate or unknown coverage, missing rows, and total mismatches are hard errors.
- Uninstall/reinstall protocol: every `uninstall.*` row maps exactly once through seed → uninstall → reinstall; both data roots preserved; owning-user DPAPI secrets must decrypt without being recorded; the transient inventory (updater cache/staging, runtime locks, PID/port/fence coordinates, crash temporaries) must never block reinstall or relaunch.
- Live smokes (ChatGPT, Claude CLI, Intervals.icu, Telegram, one API-key provider) live only in the separate `live-smoke` lane with a fixed redaction marker; evidence text is filtered against labeled credentials, PEM blocks, emails, paths, and unbroken token runs.
- `execute`/`live-smoke` refuse off-win32 before any evidence collection with a path-free stage-coded message; `plan`/`closure`/`validate` run anywhere — that is what macOS CI proves.
- Result artifacts are path-free and credential-free; an incomplete run can never serialize as passed.

**Contract tests** — `apps/desktop/tests/windows-installed-acceptance.test.ts` (9 tests): closure over the real manifests, synthetic closure violations, the uninstall three-phase mapping, live-smoke isolation and redaction, off-win32 refusal for both executors, evidence-token rejection, and incomplete-result honesty.

No production or renderer file changed; darwin behavior is byte-identical. No changeset: test/tooling-only, not user-facing.

Installed execution of the plan on a native Windows 11 x64 host is the operator's next step and intentionally not part of this PR.

## New limit (operator review)

- `WINDOWS_INSTALLED_ACCEPTANCE_MAX_UNBROKEN_TOKEN_RUN = 32` (`accept-windows-installed.mjs`) — evidence text containing an unbroken run of 32+ characters from `[A-Za-z0-9+/=_-]` is rejected as an unlabeled-token leak risk; legitimate prose evidence never contains such runs.

Accepted residual: the heuristic targets accidental pastes — a token deliberately obfuscated with invisible Unicode separators (e.g. zero-width space) would pass. The evidence author is the sole operator writing their own local acceptance record, so deliberate self-obfuscation is outside the threat model.

## Verification

- Three builds green; focused manifest + acceptance tests green; runner CLI `closure` reports exactly `{"valid":true,"totals":{"total":140,"deterministic":112,"vmOnly":28}}` and `execute` refuses on macOS with `windows-installed acceptance refused at platform` (exit 1)
- `pnpm exec vitest run apps/desktop/tests` — full suite green (includes the new contract tests)
- `pnpm exec vitest run packages/coach/tests/upgrade-fence.test.ts packages/coach/tests/windows-upgrade-fence.test.ts` — all 18 listener-dependent tests executed and passed
- `pnpm check` — exit 0
- Three independent read-only audits across the build rounds: manifest citations (23/23 rows, assertion coverage), vm-only justification (none lazily classified), aggregator delta registration-only, closure/uninstall/live-smoke/platform-gating/result-honesty semantics, helper-residue sweep — all clean; three LOW findings from the runner audit fixed in-branch (phantom type-union stage removed, live-smoke off-win32 gate test added, evidence token heuristic added)
