### PR TITLE
fix(tools): make sport codegen and coach-contract DTS emission Windows-portable

### DIFF
--- a/packages/coach-contract/package.json
+++ b/packages/coach-contract/package.json
@@ -14,7 +14,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc --emitDeclarationOnly",
     "check": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/coach-contract/tsup.config.ts
+++ b/packages/coach-contract/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: { index: "src/index.ts" },
   format: ["esm"],
-  dts: true,
+  dts: false,
   sourcemap: true,
   clean: true,
   splitting: false,

--- a/packages/sport-cycling/package.json
+++ b/packages/sport-cycling/package.json
@@ -18,7 +18,7 @@
     "build": "npm run codegen && tsup",
     "check": "tsc --noEmit",
     "test": "vitest run",
-    "codegen": "tsx ../../tools/generate-sport-skills.ts $PWD"
+    "codegen": "node --import tsx ../../tools/generate-sport-skills.ts"
   },
   "dependencies": {
     "@enduragent/engine": "workspace:*",

--- a/packages/sport-running/package.json
+++ b/packages/sport-running/package.json
@@ -17,7 +17,7 @@
     "build": "npm run codegen && tsup",
     "check": "tsc --noEmit",
     "test": "vitest run",
-    "codegen": "tsx ../../tools/generate-sport-skills.ts $PWD"
+    "codegen": "node --import tsx ../../tools/generate-sport-skills.ts"
   },
   "dependencies": {
     "@enduragent/engine": "workspace:*",

--- a/tools/generate-sport-skills.ts
+++ b/tools/generate-sport-skills.ts
@@ -11,11 +11,7 @@ import { readdirSync, writeFileSync, renameSync, mkdtempSync } from "node:fs";
 import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
 
-const pkgDir = process.argv[2];
-if (!pkgDir) {
-  console.error("usage: generate-sport-skills.ts <packageDirectory>");
-  process.exit(1);
-}
+const pkgDir = process.argv[2] ?? process.cwd();
 
 const skillsDir = join(pkgDir, "skills");
 const targetFile = join(pkgDir, "src", "skills.generated.ts");


### PR DESCRIPTION
Child C5 of the epic/windows win32 test-lane fix wave. Fixes the two build blockers found during the first Windows build of the workspace (issues 278/279 in the local tracker).

## Codegen `$PWD` unix-ism

`packages/sport-cycling` and `packages/sport-running` passed `$PWD` to `tools/generate-sport-skills.ts`; under `cmd.exe` the literal string `$PWD` reaches the generator and it fails ENOENT. The generator now defaults to `process.cwd()` and the scripts pass no argument. The runner is `node --import tsx` because the macOS seatbelt sandbox denies the `tsx` CLI's IPC socket; behavior is identical.

## DTS race in recursive builds

`@enduragent/coach-client` DTS generation intermittently failed with TS2307 (missing `@enduragent/coach-contract` types) when DTS is slow — reliably reproduced under Windows-on-ARM emulation (~13s DTS). Root cause: tsup's async DTS worker lets the producer's build script exit before `.d.ts` files land, so the topologically-next package starts too early. Fix at package level: `coach-contract` now emits declarations synchronously via `tsc --emitDeclarationOnly` after `tsup` (tsup `dts: false`). No global concurrency pin.

## Verification

- `pnpm -r build` twice, clean (macOS).
- Root `pnpm check` clean.
- Read-only audit: no findings above LOW; both LOWs (the runner swap noted above; win32 proof pending) disclosed here.
- Windows proof: a `pnpm -r build` spot-check in the Windows VM is scheduled before the wave closes.

Limits: none added or changed.