### PR TITLE
fix(desktop): resolve ASAR inventory entries with raw listed paths on Windows

### DIFF
--- a/apps/desktop/scripts/package-inventory.mjs
+++ b/apps/desktop/scripts/package-inventory.mjs
@@ -357,7 +357,8 @@ function safeAsarList(archivePath, archiveLabel) {
   }
 }
 
-function safeAsarStat(archivePath, path, entryLabelRoot) {
+function safeAsarStat(archivePath, listedPath, entryLabelRoot) {
+  const path = listedPath.replace(/^[/\\]+/u, "");
   try {
     return statFile(archivePath, path, false);
   } catch {
@@ -365,7 +366,8 @@ function safeAsarStat(archivePath, path, entryLabelRoot) {
   }
 }
 
-function safeAsarExtract(archivePath, path, entryLabelRoot) {
+function safeAsarExtract(archivePath, listedPath, entryLabelRoot) {
+  const path = listedPath.replace(/^[/\\]+/u, "");
   try {
     return extractFile(archivePath, path, false);
   } catch {
@@ -381,7 +383,7 @@ export function collectAsar(archivePath, options) {
     if (tree.has(path)) fail("duplicate ASAR entry", `${options.entryLabelRoot}/${path}`);
     const label = `${options.entryLabelRoot}/${path}`;
     inspectPath(path, label);
-    const metadata = safeAsarStat(archivePath, path, options.entryLabelRoot);
+    const metadata = safeAsarStat(archivePath, listedPath, options.entryLabelRoot);
     if ("link" in metadata) fail("symbolic links are forbidden", label);
     if ("files" in metadata) {
       tree.set(path, { type: "directory", unpacked: metadata.unpacked === true });
@@ -389,7 +391,7 @@ export function collectAsar(archivePath, options) {
     }
     let bytes;
     if (metadata.unpacked !== true) {
-      bytes = safeAsarExtract(archivePath, path, options.entryLabelRoot);
+      bytes = safeAsarExtract(archivePath, listedPath, options.entryLabelRoot);
       inspectContents(bytes, label);
     }
     tree.set(path, { type: "file", unpacked: metadata.unpacked === true, bytes });

--- a/apps/desktop/tests/package-inventory-win32.test.ts
+++ b/apps/desktop/tests/package-inventory-win32.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+const asar = vi.hoisted(() => {
+  const directoryPath = "nested";
+  const filePath = "nested\\runtime.bin";
+  return {
+    directoryPath,
+    filePath,
+    extractFile: vi.fn((_archivePath: string, listedPath: string) => {
+      if (listedPath !== filePath) throw new Error(`unexpected ASAR extraction path: ${listedPath}`);
+      return Buffer.from("runtime");
+    }),
+    listPackage: vi.fn(() => [`\\${directoryPath}`, `\\${filePath}`]),
+    statFile: vi.fn((_archivePath: string, listedPath: string) => {
+      if (listedPath === directoryPath) return { files: {}, unpacked: false };
+      if (listedPath === filePath) return { size: 7, unpacked: false };
+      throw new Error(`unexpected ASAR stat path: ${listedPath}`);
+    }),
+    uncache: vi.fn(),
+  };
+});
+
+vi.mock("@electron/asar", () => ({
+  extractFile: asar.extractFile,
+  listPackage: asar.listPackage,
+  statFile: asar.statFile,
+  uncache: asar.uncache,
+}));
+
+import { collectAsar } from "../scripts/package-inventory.mjs";
+
+describe("win32 ASAR inventory paths", () => {
+  it("uses raw listed paths for ASAR reads and POSIX paths for inventory keys", () => {
+    const inventory = collectAsar("synthetic.asar", {
+      archiveLabel: "archive",
+      entryLabelRoot: "archive-entry",
+    });
+
+    expect([...inventory.keys()]).toEqual(["nested", "nested/runtime.bin"]);
+    expect(inventory.get("nested/runtime.bin")).toEqual({
+      type: "file",
+      unpacked: false,
+      bytes: Buffer.from("runtime"),
+    });
+    expect(asar.statFile).toHaveBeenNthCalledWith(1, "synthetic.asar", "nested", false);
+    expect(asar.statFile).toHaveBeenNthCalledWith(2, "synthetic.asar", "nested\\runtime.bin", false);
+    expect(asar.extractFile).toHaveBeenCalledWith(
+      "synthetic.asar",
+      "nested\\runtime.bin",
+      false,
+    );
+  });
+});


### PR DESCRIPTION
Child C2 of the epic/windows win32 test-lane fix wave. Fixes issue 280 in the local tracker: the package verifier rejected every valid package when the verifier itself ran on a Windows host — 83 test failures in the first real-win32 suite run.

## Mechanism

`collectAsar` normalized each listed path to POSIX form and then passed that normalized path into `@electron/asar`'s `statFile`/`extractFile`. Those APIs resolve entries by splitting on `path.sep`; on win32 (`path.sep === "\\"`) a forward-slash path never splits, so every entry at depth ≥ 2 was reported missing (`invalid ASAR entry`). Additionally, `listPackage` roots its listing at the host separator, so listed paths carry a leading separator.

## Fix

`safeAsarStat`/`safeAsarExtract` now receive the raw listed path with only the leading separator stripped, matching what the asar API can resolve on any host. The POSIX-normalized path remains the inventory tree key, duplicate-detection key, and entry label. `validateRelativePath` is unchanged.

A new regression test mocks `@electron/asar` with win32-shaped listed paths (leading and interior backslashes) whose `statFile`/`extractFile` reject the normalized variant — removing either part of the fix fails the test.

## Verification

- `vitest run` package-layout + windows-package-layout + the new regression test: 124 tests green (macOS).
- Root `pnpm check` clean.
- Read-only audit: one MED (regression mock originally lacked the leading separator, leaving the strip untested) — fixed by the orchestrator as adjudicated mechanical test data; suites re-run green. Two LOWs disclosed: the leading-separator strip was a necessary discovery beyond the brief's literal mechanism, and on win32 failure labels now carry the raw (backslash) path.
- Windows proof: a targeted VM spot-check of the two package suites is scheduled before the wave closes.

Limits: none added or changed.