### PR TITLE
test(desktop): gate macOS-release suites off win32 hosts

### DIFF
--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -68,7 +68,7 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
-describe("safe macOS release verification diagnostics", () => {
+describe.skipIf(process.platform === "win32")("safe macOS release verification diagnostics", () => {
   it("reports only failures created by the release verifier", async () => {
     let verificationFailure: unknown;
     try {
@@ -348,7 +348,7 @@ async function signedIdentityFixture() {
   return { baseline, candidate, executeFile, extractAsarFile, metadata };
 }
 
-describe("macOS signed identity continuity", () => {
+describe.skipIf(process.platform === "win32")("macOS signed identity continuity", () => {
   it("inspects one marked release application through the canonical native identity pipeline", async () => {
     const fixture = await signedIdentityFixture();
     const uncacheAsar = vi.fn(uncache);
@@ -1365,7 +1365,7 @@ async function packagedApplicationFixture(
   };
 }
 
-describe("macOS packaged application identity binding", () => {
+describe.skipIf(process.platform === "win32")("macOS packaged application identity binding", () => {
   it("binds both mandatory packaged applications to the loose candidate before cleanup", async () => {
     const fixture = await packagedApplicationFixture();
 
@@ -1835,7 +1835,7 @@ describe("macOS packaged application identity binding", () => {
   });
 });
 
-describe("macOS release artifact envelope", () => {
+describe.skipIf(process.platform === "win32")("macOS release artifact envelope", () => {
   it("verifies artifacts, the loose candidate, and packaged applications as one envelope", async () => {
     const fixture = await releaseFixture();
     const baselineApplication = "/synthetic/baseline/Enduragent.app";

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -162,7 +162,7 @@ async function metadataSealFixture() {
   };
 }
 
-describe("macOS release plan", () => {
+describe.skipIf(process.platform === "win32")("macOS release plan", () => {
   it("exposes only controlled release-plan failures to the release log", () => {
     expect(
       safeMacosReleasePlanMessage(new TypeError("release envelope changed during verification")),


### PR DESCRIPTION
Child C1 of the epic/windows win32 test-lane fix wave.

The macos-release-artifacts and macos-release-plan suites verify macOS DMG/codesign release structures; on a real Windows host they failed 89 and 3 tests respectively (POSIX fixtures, symlinks, mode semantics). Every top-level describe (5 across the two files) is now gated with `describe.skipIf(process.platform === "win32")` — the existing repo idiom. Linux and macOS coverage unchanged.

Verification: both suites green on macOS (184 tests), root `pnpm check` clean, read-only audit zero findings (verified all 5 describes are the only ones in the files; one-line changes only).

Note: the first codex round for this child died at launch on a failed SessionStart hook and produced no work; this is the free-retry round. Limits: none.