### PR TITLE
fix(desktop): enforce the update downgrade floor on Windows

### DIFF
--- a/.changeset/windows-update-floor.md
+++ b/.changeset/windows-update-floor.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: The Windows app now enforces the update downgrade floor; previously it was silently inactive on Windows.

--- a/apps/desktop/src/main/update-version-floor.ts
+++ b/apps/desktop/src/main/update-version-floor.ts
@@ -1,9 +1,18 @@
 import { constants, type Stats } from "node:fs";
 import { lstat, mkdir, open, readdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import {
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  type WindowsPrivateDirectoryBinding,
+} from "@enduragent/core";
 import { compareDesktopVersions, isStableDesktopVersion } from "./desktop-version.js";
 import { durableAtomicReplace, syncDirectory } from "./durable-atomic-replace.js";
 import { createSafeLog } from "./safe-log.js";
+import {
+  readWindowsPrivateFile,
+  WindowsPrivateFileMaximumBytesExceededError,
+} from "./windows-private-file.js";
 
 export const DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME = "highest-desktop-version.json" as const;
 export const DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE = 0o700;
@@ -64,7 +73,12 @@ function parseVersionFloor(contents: string): string | undefined {
 export function createDesktopUpdateVersionFloor(input: {
   readonly root: string;
   readonly log?: (message: string) => void;
+  readonly platform?: NodeJS.Platform;
+  readonly openFile?: typeof open;
+  readonly syncDirectory?: (root: string) => Promise<void>;
 }): DesktopUpdateVersionFloor {
+  const platform = input.platform ?? process.platform;
+  const synchronizeDirectory = input.syncDirectory ?? syncDirectory;
   const target = join(input.root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
   const log = createSafeLog(input.log);
   let pending: Promise<void> = Promise.resolve();
@@ -78,7 +92,17 @@ export function createDesktopUpdateVersionFloor(input: {
     return result;
   };
 
-  const prepareRoot = async (): Promise<void> => {
+  const synchronizeDirectoryIfSupported = async (root: string): Promise<void> => {
+    if (
+      platform === "win32" &&
+      classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable"
+    ) {
+      return;
+    }
+    await synchronizeDirectory(root);
+  };
+
+  const prepareRoot = async (): Promise<WindowsPrivateDirectoryBinding | undefined> => {
     let created = false;
     let metadata: Stats;
     try {
@@ -93,8 +117,14 @@ export function createDesktopUpdateVersionFloor(input: {
       metadata = await lstat(input.root);
     }
     if (!metadata.isDirectory()) throw new TypeError("invalid update version floor root");
-    assertOwner(metadata, DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE);
-    if (created) await syncDirectory(dirname(input.root));
+    const windowsDirectory =
+      platform === "win32"
+        ? bindWindowsPrivateDirectory(dirname(input.root), input.root)
+        : undefined;
+    if (platform !== "win32") {
+      assertOwner(metadata, DESKTOP_UPDATE_VERSION_FLOOR_DIRECTORY_MODE);
+    }
+    if (created) await synchronizeDirectoryIfSupported(dirname(input.root));
     const prefix = `.${DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME}.`;
     let removed = false;
     for (const entry of await readdir(input.root)) {
@@ -107,10 +137,34 @@ export function createDesktopUpdateVersionFloor(input: {
         removed = true;
       }
     }
-    if (removed) await syncDirectory(input.root);
+    if (removed) await synchronizeDirectoryIfSupported(input.root);
+    return windowsDirectory;
   };
 
-  const readFloor = async (): Promise<StoredVersionFloor> => {
+  const readFloor = async (
+    windowsDirectory: WindowsPrivateDirectoryBinding | undefined,
+  ): Promise<StoredVersionFloor> => {
+    if (platform === "win32") {
+      let snapshot;
+      try {
+        snapshot = await readWindowsPrivateFile({
+          directory: windowsDirectory!,
+          path: target,
+          maximumBytes: MAX_VERSION_FLOOR_FILE_BYTES,
+          openFile: input.openFile,
+        });
+      } catch (error) {
+        if (error instanceof WindowsPrivateFileMaximumBytesExceededError) {
+          return { status: "corrupt" };
+        }
+        throw error;
+      }
+      if (snapshot === undefined) return { status: "missing" };
+      const version = parseVersionFloor(snapshot.contents.toString("utf8"));
+      return version === undefined
+        ? { status: "corrupt" }
+        : { status: "ready", version };
+    }
     let before: Stats;
     try {
       before = await lstat(target);
@@ -121,7 +175,10 @@ export function createDesktopUpdateVersionFloor(input: {
     if (!before.isFile()) throw new TypeError("invalid update version floor file");
     assertOwner(before, DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE);
     if (before.size > MAX_VERSION_FLOOR_FILE_BYTES) return { status: "corrupt" };
-    const handle = await open(target, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    const handle = await (input.openFile ?? open)(
+      target,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    );
     try {
       const opened = await handle.stat();
       if (
@@ -149,6 +206,9 @@ export function createDesktopUpdateVersionFloor(input: {
       fileName: DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME,
       contents: `${JSON.stringify({ schemaVersion: 1, version })}\n`,
       mode: DESKTOP_UPDATE_VERSION_FLOOR_FILE_MODE,
+      platform,
+      openFile: input.openFile,
+      syncDirectory: synchronizeDirectory,
     });
 
   return {
@@ -156,8 +216,8 @@ export function createDesktopUpdateVersionFloor(input: {
       return serialize(async () => {
         if (!isStableDesktopVersion(version)) return { status: "unavailable" };
         try {
-          await prepareRoot();
-          const existing = await readFloor();
+          const windowsDirectory = await prepareRoot();
+          const existing = await readFloor(windowsDirectory);
           if (existing.status === "ready") {
             const comparison = compareDesktopVersions(existing.version, version);
             if (comparison === null) return { status: "unavailable" };

--- a/apps/desktop/src/main/windows-private-file.ts
+++ b/apps/desktop/src/main/windows-private-file.ts
@@ -7,6 +7,7 @@ import {
   assertWindowsPrivatePathRead,
   classifyWindowsPrivatePathFailure,
   sameWindowsPrivatePathIdentity,
+  WindowsPrivatePathPolicyError,
   windowsPrivatePathIdentity,
   type WindowsPrivateDirectoryBinding,
 } from "@enduragent/core";
@@ -16,6 +17,12 @@ export const MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES = 262_144;
 export interface WindowsPrivateFileSnapshot {
   readonly contents: Buffer;
   readonly modifiedAt: number;
+}
+
+export class WindowsPrivateFileMaximumBytesExceededError extends WindowsPrivatePathPolicyError {
+  constructor() {
+    super("read-check", "corruption");
+  }
 }
 
 export interface ReadWindowsPrivateFileInput {
@@ -32,6 +39,9 @@ function isMissing(error: unknown): boolean {
 }
 
 function assertBounded(metadata: Stats, minimumBytes: number, maximumBytes: number): void {
+  if (Number.isSafeInteger(metadata.size) && metadata.size > maximumBytes) {
+    throw new WindowsPrivateFileMaximumBytesExceededError();
+  }
   assertWindowsPrivatePathRead({
     bounded:
       Number.isSafeInteger(metadata.size) &&
@@ -52,13 +62,13 @@ export function assertWindowsPrivateFileAtPath(
   allowedLinks: 1 | 2 = 1,
 ): void {
   assertWindowsPrivateFileMetadata(metadata, allowedLinks);
-  assertBounded(metadata, minimumBytes, maximumBytes);
   assertWindowsPrivateFileBinding(
     directory,
     path,
     windowsPrivatePathIdentity(metadata),
     allowedLinks,
   );
+  assertBounded(metadata, minimumBytes, maximumBytes);
 }
 
 export async function readWindowsPrivateFile(
@@ -91,7 +101,6 @@ export async function readWindowsPrivateFile(
     try {
       const opened = await handle.stat();
       assertWindowsPrivateFileMetadata(opened, allowedLinks);
-      assertBounded(opened, minimumBytes, input.maximumBytes);
       assertWindowsPrivatePathRead({
         bounded: true,
         identityStable: sameWindowsPrivatePathIdentity(
@@ -107,6 +116,7 @@ export async function readWindowsPrivateFile(
         windowsPrivatePathIdentity(opened),
         allowedLinks,
       );
+      assertBounded(opened, minimumBytes, input.maximumBytes);
       contents = Buffer.allocUnsafe(opened.size);
       let offset = 0;
       while (offset < contents.length) {

--- a/apps/desktop/tests/update-version-floor.test.ts
+++ b/apps/desktop/tests/update-version-floor.test.ts
@@ -1,4 +1,13 @@
-import { chmod, lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -112,5 +121,145 @@ describe("desktop update version floor", () => {
       version: "1.2.3",
     });
     expect(log).toHaveBeenCalledWith("desktop-update-version-floor-recovered");
+  });
+});
+
+describe("desktop update version floor on Windows", () => {
+  const createWindowsFloor = (root: string, log?: (message: string) => void) =>
+    createDesktopUpdateVersionFloor({
+      root,
+      log,
+      platform: "win32",
+      syncDirectory: async () => {
+        throw new TypeError("Windows directory sync must stay unavailable");
+      },
+    });
+
+  it("records the running version and survives a restart", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-update-version-floor-win32-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = join(temporaryRoot, "desktop-preferences-v1");
+    const target = join(root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
+
+    await expect(createWindowsFloor(root).recordRunningVersion("2.3.4")).resolves.toEqual({
+      status: "ready",
+      version: "2.3.4",
+    });
+    await chmod(root, 0o777);
+    await chmod(target, 0o666);
+
+    await expect(createWindowsFloor(root).recordRunningVersion("2.3.4")).resolves.toEqual({
+      status: "ready",
+      version: "2.3.4",
+    });
+    await expect(readFile(target, "utf8")).resolves.toBe(
+      `${JSON.stringify({ schemaVersion: 1, version: "2.3.4" })}\n`,
+    );
+  });
+
+  it("never falls below the highest version after a restart", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-update-version-floor-win32-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = join(temporaryRoot, "desktop-preferences-v1");
+    const target = join(root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
+
+    await expect(createWindowsFloor(root).recordRunningVersion("2.3.4")).resolves.toEqual({
+      status: "ready",
+      version: "2.3.4",
+    });
+    await chmod(root, 0o777);
+    await chmod(target, 0o666);
+
+    await expect(createWindowsFloor(root).recordRunningVersion("1.9.9")).resolves.toEqual({
+      status: "ready",
+      version: "2.3.4",
+    });
+  });
+
+  it("rejects invalid versions without changing the recorded floor", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-update-version-floor-win32-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = join(temporaryRoot, "desktop-preferences-v1");
+    const target = join(root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
+    const floor = createWindowsFloor(root);
+
+    await expect(floor.recordRunningVersion("2.3.4")).resolves.toEqual({
+      status: "ready",
+      version: "2.3.4",
+    });
+    await expect(floor.recordRunningVersion("invalid-feed-version")).resolves.toEqual({
+      status: "unavailable",
+    });
+    await expect(readFile(target, "utf8")).resolves.toBe(
+      `${JSON.stringify({ schemaVersion: 1, version: "2.3.4" })}\n`,
+    );
+  });
+
+  it("recovers a corrupt file and preserves the recovered floor after restart", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-update-version-floor-win32-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = join(temporaryRoot, "desktop-preferences-v1");
+    const target = join(root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
+    await createWindowsFloor(root).recordRunningVersion("2.3.4");
+    await chmod(root, 0o777);
+    await writeFile(target, "not-json\n");
+    await chmod(target, 0o666);
+    const log = vi.fn();
+
+    await expect(createWindowsFloor(root, log).recordRunningVersion("1.2.3")).resolves.toEqual({
+      status: "ready",
+      version: "1.2.3",
+    });
+    expect(log).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith("desktop-update-version-floor-recovered");
+    await chmod(root, 0o777);
+    await chmod(target, 0o666);
+
+    await expect(createWindowsFloor(root).recordRunningVersion("1.0.0")).resolves.toEqual({
+      status: "ready",
+      version: "1.2.3",
+    });
+  });
+
+  it("recovers an oversize file and logs the recovery", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-update-version-floor-win32-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = join(temporaryRoot, "desktop-preferences-v1");
+    const target = join(root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
+    await createWindowsFloor(root).recordRunningVersion("2.3.4");
+    await chmod(root, 0o777);
+    await writeFile(target, "x".repeat(257));
+    await chmod(target, 0o666);
+    const log = vi.fn();
+
+    await expect(createWindowsFloor(root, log).recordRunningVersion("1.2.3")).resolves.toEqual({
+      status: "ready",
+      version: "1.2.3",
+    });
+    expect(log).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith("desktop-update-version-floor-recovered");
+    await expect(readFile(target, "utf8")).resolves.toBe(
+      `${JSON.stringify({ schemaVersion: 1, version: "1.2.3" })}\n`,
+    );
+  });
+
+  it("keeps non-size policy violations unavailable", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-update-version-floor-win32-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = join(temporaryRoot, "desktop-preferences-v1");
+    const target = join(root, DESKTOP_UPDATE_VERSION_FLOOR_FILE_NAME);
+    const linkedTarget = join(root, "linked-highest-desktop-version.json");
+    const contents = `${JSON.stringify({ schemaVersion: 1, version: "2.3.4" })}\n`;
+    await createWindowsFloor(root).recordRunningVersion("2.3.4");
+    await link(target, linkedTarget);
+    await chmod(root, 0o777);
+    await chmod(target, 0o666);
+    const log = vi.fn();
+
+    await expect(createWindowsFloor(root, log).recordRunningVersion("1.2.3")).resolves.toEqual({
+      status: "unavailable",
+    });
+    expect(log).not.toHaveBeenCalled();
+    await expect(readFile(target, "utf8")).resolves.toBe(contents);
   });
 });


### PR DESCRIPTION
Child C6 of the epic/windows win32 test-lane fix wave. Real product bug found during the first real-win32 suite run: the update version floor (downgrade protection, shipped in #577) was silently inert on every Windows install.

## Mechanism

`update-version-floor.ts` guarded every read/write with `assertOwner`, which requires exact POSIX permissions (`0o700`/`0o600`). Windows stats report `0o777`/`0o666`, so every operation threw, and the catch-all collapsed everything to `{ status: "unavailable" }` — the floor never recorded, never enforced.

## Fix

A win32 lane mirroring the sibling modules: directory binding via `bindWindowsPrivateDirectory`, bounded reads through `readWindowsPrivateFile` (policy metadata/binding asserts + dev/ino identity stability), writes through `durableAtomicReplace`'s existing win32 branch. POSIX behavior byte-identical; `platform` and fs seams are injectable so the win32 lane is tested from macOS.

Round 2 (audit finding): an oversize floor file self-healed on POSIX (`corrupt` → recovery) but wedged as `unavailable` forever on win32. Oversize now throws a dedicated `WindowsPrivateFileMaximumBytesExceededError` subclass mapped to `corrupt`, feeding the same recovery path; all other policy violations still yield `unavailable`. Both behaviors pinned by tests (26 total in the floor/eligibility suites).

One orchestrator type fix on top: the subclass no longer overrides `name` (the base declares it as a literal type; nothing discriminates by name — the catch uses `instanceof`).

## Verification

- `vitest run` update-version-floor + update-eligibility: 26 tests green; desktop build green; root `pnpm check` clean (re-run after the type fix).
- Read-only audits round 1 and round 2; remaining finding is one LOW (files >2^53 bytes classify differently across lanes — unreachable in practice, accepted).
- Windows proof comes with the wave-final VM suite run.

Changeset: `@enduragent/desktop` patch, user-facing (Windows downgrade protection now active). Limits: none added or changed (`MAX_VERSION_FLOOR_FILE_BYTES` stays 256).