### PR TITLE
test(desktop): make permission-refusal suites win32-aware via injection seams

### DIFF
--- a/apps/desktop/tests/chatgpt-auth.test.ts
+++ b/apps/desktop/tests/chatgpt-auth.test.ts
@@ -197,7 +197,9 @@ describe("desktop ChatGPT auth", () => {
       refresh: "obviously-fake-refresh",
       expires: 4_102_444_800_000,
     });
-    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect((await stat(path)).mode & 0o777).toBe(0o600);
+    }
     await expect(hasChatGptProfile(directory)).resolves.toBe(true);
   });
 
@@ -237,7 +239,9 @@ describe("desktop ChatGPT auth", () => {
       expires: 4_102_444_800_000,
       email: "synthetic@example.invalid",
     });
-    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect((await stat(path)).mode & 0o777).toBe(0o600);
+    }
   });
 
   it("treats absent, corrupt, and invalid profiles as absent", async () => {
@@ -312,8 +316,10 @@ describe("desktop ChatGPT auth", () => {
       operationId: "quarantine",
     });
     expect(await readFile(`${path}.corrupt`)).toEqual(originalBytes);
-    expect((await stat(`${path}.corrupt`)).mode & 0o777).toBe(0o600);
-    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect((await stat(`${path}.corrupt`)).mode & 0o777).toBe(0o600);
+      expect((await stat(path)).mode & 0o777).toBe(0o600);
+    }
     await expect(hasChatGptProfile(directory)).resolves.toBe(true);
   });
 

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -34,6 +34,22 @@ async function temporaryRoot(): Promise<string> {
   return join(root, "credentials-v1");
 }
 
+async function createSymlinkOrReturnWindowsCapabilityReason(
+  target: string,
+  path: string,
+): Promise<string | undefined> {
+  try {
+    await symlink(target, path);
+    return undefined;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (process.platform === "win32" && (code === "EPERM" || code === "EACCES")) {
+      return `Windows symlink capability unavailable (${code})`;
+    }
+    throw error;
+  }
+}
+
 function encryption(): CredentialEncryptionPort {
   return {
     isEncryptionAvailable: () => true,
@@ -57,9 +73,14 @@ async function storeEncryptedCredential(
   value: string,
   encryptionPort: CredentialEncryptionPort,
 ): Promise<void> {
-  await mkdir(root, { recursive: true, mode: CREDENTIAL_DIRECTORY_MODE });
-  await writeFile(join(root, `${slot}.bin`), encryptionPort.encryptString(value), {
-    mode: CREDENTIAL_FILE_MODE,
+  const vault = createCredentialVault({
+    root,
+    encryption: encryptionPort,
+    applyCredential: vi.fn(async () => undefined),
+  });
+  await expect(vault.writeCredential({ slot, value }, { activate: false })).resolves.toMatchObject({
+    slot,
+    status: "configured",
   });
 }
 
@@ -185,8 +206,10 @@ describe("desktop credential vault", () => {
     const path = join(root, "anthropic.bin");
     const file = await lstat(path);
     const ciphertext = await readFile(path);
-    expect(directory.mode & 0o777).toBe(CREDENTIAL_DIRECTORY_MODE);
-    expect(file.mode & 0o777).toBe(CREDENTIAL_FILE_MODE);
+    if (process.platform !== "win32") {
+      expect(directory.mode & 0o777).toBe(CREDENTIAL_DIRECTORY_MODE);
+      expect(file.mode & 0o777).toBe(CREDENTIAL_FILE_MODE);
+    }
     expect(ciphertext.length).toBeGreaterThan(0);
     expect(ciphertext.includes(Buffer.from(sentinel))).toBe(false);
     expect(await readdir(root)).toEqual(["anthropic.bin"]);
@@ -885,7 +908,7 @@ describe("desktop credential vault", () => {
     expect((await readdir(root)).some((entry) => entry.endsWith(".deleted"))).toBe(true);
   });
 
-  it("fails closed for insecure directories and targets", async () => {
+  it("fails closed for insecure directories and targets", async ({ skip }) => {
     const root = await temporaryRoot();
     await mkdir(root, { mode: 0o755 });
     const vault = createCredentialVault({
@@ -893,14 +916,27 @@ describe("desktop credential vault", () => {
       encryption: encryption(),
       applyCredential: vi.fn(),
     });
-    await expect(
-      vault.writeCredential({ slot: "anthropic", value: "synthetic" }),
-    ).resolves.toMatchObject({
-      status: "refused",
-      reason: "storage-failed",
+    const permissiveDirectoryWrite = vault.writeCredential({
+      slot: "anthropic",
+      value: "synthetic",
     });
-    await chmod(root, 0o700);
-    await symlink(join(root, "missing"), join(root, "anthropic.bin"));
+    if (process.platform === "win32") {
+      await expect(permissiveDirectoryWrite).resolves.toMatchObject({ status: "configured" });
+      await expect(vault.deleteCredential("anthropic")).resolves.toMatchObject({
+        status: "deleted",
+      });
+    } else {
+      await expect(permissiveDirectoryWrite).resolves.toMatchObject({
+        status: "refused",
+        reason: "storage-failed",
+      });
+      await chmod(root, 0o700);
+    }
+    const symlinkCapabilityReason = await createSymlinkOrReturnWindowsCapabilityReason(
+      join(root, "missing"),
+      join(root, "anthropic.bin"),
+    );
+    if (symlinkCapabilityReason) return skip(symlinkCapabilityReason);
     await expect(
       vault.writeCredential({ slot: "anthropic", value: "synthetic" }),
     ).resolves.toMatchObject({
@@ -925,12 +961,24 @@ describe("desktop credential vault", () => {
     });
     await rm(join(root, "anthropic.bin"), { recursive: true });
     await writeFile(join(root, "anthropic.bin"), "ciphertext", { mode: 0o644 });
-    await expect(
-      vault.writeCredential({ slot: "anthropic", value: "synthetic" }),
-    ).resolves.toMatchObject({
-      status: "refused",
-      reason: "storage-failed",
+    const permissiveFileWrite = vault.writeCredential({
+      slot: "anthropic",
+      value: "synthetic",
     });
+    if (process.platform === "win32") {
+      await expect(permissiveFileWrite).resolves.toMatchObject({ status: "configured" });
+      expect((await readFile(join(root, "anthropic.bin"))).includes("synthetic")).toBe(false);
+      await expect(vault.credentialStatuses()).resolves.toContainEqual({
+        slot: "anthropic",
+        state: "configured",
+        runtimeState: "active",
+      });
+    } else {
+      await expect(permissiveFileWrite).resolves.toMatchObject({
+        status: "refused",
+        reason: "storage-failed",
+      });
+    }
   });
 
   it("minimizes encryption backend failures without touching storage", async () => {

--- a/apps/desktop/tests/durable-atomic-replace.test.ts
+++ b/apps/desktop/tests/durable-atomic-replace.test.ts
@@ -9,6 +9,10 @@ import {
 } from "../src/main/durable-atomic-replace.js";
 
 const roots: string[] = [];
+const durabilityPlatforms = [
+  { name: "POSIX", platform: "darwin" },
+  { name: "Windows", platform: "win32" },
+] as const;
 
 async function temporaryRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "enduragent-durable-replace-"));
@@ -35,269 +39,385 @@ describe("durable atomic replace", () => {
     });
 
     expect(result).toEqual({ state: "durably-committed" });
-    expect((await stat(target)).mode & 0o777).toBe(0o600);
+    if (process.platform === "win32") {
+      await expect(readFile(target, "utf8")).resolves.toBe("candidate");
+    } else {
+      expect((await stat(target)).mode & 0o777).toBe(0o600);
+    }
   });
 
-  it("reports not committed when temporary creation fails", async () => {
-    const root = await temporaryRoot();
-    const target = join(root, "setting.json");
-    await writeFile(target, "old", { mode: 0o600 });
-    const removeFile = vi.fn(async () => undefined);
+  it.each(durabilityPlatforms)(
+    "reports the $name pre-commit outcome when temporary creation fails",
+    async ({ platform }) => {
+      const root = await temporaryRoot();
+      const target = join(root, "setting.json");
+      await writeFile(target, "old", { mode: 0o600 });
+      const removeFile = vi.fn(async () => undefined);
 
-    const result = await durableAtomicReplace({
-      root,
-      fileName: "setting.json",
-      contents: "candidate",
-      mode: 0o600,
-      createId: () => "create-failure",
-      openFile: vi.fn(async () => {
-        throw new TypeError("synthetic temporary create failure");
-      }) as never,
-      removeFile: removeFile as never,
-    });
+      const replacement = durableAtomicReplace({
+        root,
+        fileName: "setting.json",
+        contents: "candidate",
+        mode: 0o600,
+        platform,
+        createId: () => "create-failure",
+        openFile: vi.fn(async () => {
+          throw new TypeError("synthetic temporary create failure");
+        }) as never,
+        removeFile: removeFile as never,
+      });
 
-    expect(result).toEqual({ state: "not-committed" });
-    await expect(readFile(target, "utf8")).resolves.toBe("old");
-    expect(removeFile).toHaveBeenCalledWith(join(root, ".setting.json.create-failure.tmp"), {
-      force: true,
-    });
-  });
+      if (platform === "win32") {
+        await expect(replacement).rejects.toMatchObject({
+          message: "Windows private path policy failed",
+          stage: "content-write",
+        });
+      } else {
+        await expect(replacement).resolves.toEqual({ state: "not-committed" });
+      }
+      await expect(readFile(target, "utf8")).resolves.toBe("old");
+      expect(removeFile).toHaveBeenCalledWith(join(root, ".setting.json.create-failure.tmp"), {
+        force: true,
+      });
+    },
+  );
 
-  it("reports not committed when writing the temporary file fails", async () => {
-    const root = await temporaryRoot();
-    const target = join(root, "setting.json");
-    await writeFile(target, "old", { mode: 0o600 });
-    const sync = vi.fn(async () => undefined);
-    const close = vi.fn(async () => undefined);
+  it.each(durabilityPlatforms)(
+    "reports the $name pre-commit outcome when writing the temporary file fails",
+    async ({ platform }) => {
+      const root = await temporaryRoot();
+      const target = join(root, "setting.json");
+      await writeFile(target, "old", { mode: 0o600 });
+      const close = vi.fn(async () => undefined);
+      const sync = vi.fn(async () => undefined);
 
-    const result = await durableAtomicReplace({
-      root,
-      fileName: "setting.json",
-      contents: "candidate",
-      mode: 0o600,
-      createId: () => "write-failure",
-      openFile: vi.fn(async () => ({
-        writeFile: async () => {
-          throw new TypeError("synthetic temporary write failure");
+      const replacement = durableAtomicReplace({
+        root,
+        fileName: "setting.json",
+        contents: "candidate",
+        mode: 0o600,
+        platform,
+        createId: () => "write-failure",
+        openFile: (async (path, flags, mode) => {
+          const handle = await open(path, flags, mode);
+          return new Proxy(handle, {
+            get(target, property) {
+              if (property === "sync") return sync;
+              if (property === "writeFile") {
+                return async () => {
+                  throw new TypeError("synthetic temporary write failure");
+                };
+              }
+              if (property === "close") {
+                return async () => {
+                  await close();
+                  await handle.close();
+                };
+              }
+              const value = Reflect.get(target, property);
+              return typeof value === "function" ? value.bind(target) : value;
+            },
+          });
+        }) as typeof open,
+      });
+
+      if (platform === "win32") {
+        await expect(replacement).rejects.toMatchObject({
+          message: "Windows private path policy failed",
+          stage: "content-write",
+        });
+      } else {
+        await expect(replacement).resolves.toEqual({ state: "not-committed" });
+        expect(sync).not.toHaveBeenCalled();
+      }
+      await expect(readFile(target, "utf8")).resolves.toBe("old");
+      expect(close).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(durabilityPlatforms)(
+    "reports the $name pre-commit outcome when syncing the temporary file fails",
+    async ({ platform }) => {
+      const root = await temporaryRoot();
+      const target = join(root, "setting.json");
+      await writeFile(target, "old", { mode: 0o600 });
+      const close = vi.fn(async () => undefined);
+      const sync = vi.fn(async () => {
+        throw new TypeError("synthetic temporary file sync failure");
+      });
+
+      const replacement = durableAtomicReplace({
+        root,
+        fileName: "setting.json",
+        contents: "candidate",
+        mode: 0o600,
+        platform,
+        createId: () => "file-sync-failure",
+        openFile: (async (path, flags, mode) => {
+          const handle = await open(path, flags, mode);
+          return new Proxy(handle, {
+            get(target, property) {
+              if (property === "sync") return sync;
+              if (property === "close") {
+                return async () => {
+                  await close();
+                  await handle.close();
+                };
+              }
+              const value = Reflect.get(target, property);
+              return typeof value === "function" ? value.bind(target) : value;
+            },
+          });
+        }) as typeof open,
+      });
+
+      if (platform === "win32") {
+        await expect(replacement).rejects.toMatchObject({
+          message: "Windows private path policy failed",
+          stage: "file-flush",
+        });
+      } else {
+        await expect(replacement).resolves.toEqual({ state: "not-committed" });
+      }
+      await expect(readFile(target, "utf8")).resolves.toBe("old");
+      expect(sync).toHaveBeenCalledOnce();
+      expect(close).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(durabilityPlatforms)(
+    "keeps the $name pre-rename outcome truthful when temporary cleanup also fails",
+    async ({ platform }) => {
+      const root = await temporaryRoot();
+      const target = join(root, "setting.json");
+      const temporary = join(root, ".setting.json.cleanup-failure.tmp");
+      await writeFile(target, "old", { mode: 0o600 });
+      const removeFile = vi.fn(async () => {
+        throw new TypeError("synthetic temporary cleanup failure");
+      });
+
+      const replacement = durableAtomicReplace({
+        root,
+        fileName: "setting.json",
+        contents: "candidate",
+        mode: 0o600,
+        platform,
+        createId: () => "cleanup-failure",
+        renameFile: async () => {
+          throw new TypeError("synthetic rename failure");
         },
-        sync,
-        close,
-      })) as never,
-    });
+        removeFile: removeFile as never,
+      });
 
-    expect(result).toEqual({ state: "not-committed" });
-    await expect(readFile(target, "utf8")).resolves.toBe("old");
-    expect(sync).not.toHaveBeenCalled();
-    expect(close).toHaveBeenCalledOnce();
-  });
+      if (platform === "win32") {
+        await expect(replacement).rejects.toMatchObject({
+          message: "Windows private path policy failed",
+          stage: "rename",
+        });
+      } else {
+        await expect(replacement).resolves.toEqual({ state: "not-committed" });
+      }
+      await expect(readFile(target, "utf8")).resolves.toBe("old");
+      await expect(readFile(temporary, "utf8")).resolves.toBe("candidate");
+      expect(removeFile).toHaveBeenCalledWith(temporary, { force: true });
+    },
+  );
 
-  it("reports not committed when syncing the temporary file fails", async () => {
-    const root = await temporaryRoot();
-    const target = join(root, "setting.json");
-    await writeFile(target, "old", { mode: 0o600 });
-    const close = vi.fn(async () => undefined);
-    const sync = vi.fn(async () => {
-      throw new TypeError("synthetic temporary file sync failure");
-    });
+  it.each(durabilityPlatforms)(
+    "reports the $name outcome when rename published the candidate but directory sync failed",
+    async ({ platform }) => {
+      const root = await temporaryRoot();
+      const target = join(root, "setting.json");
+      await writeFile(target, "old", { mode: 0o600 });
 
-    const result = await durableAtomicReplace({
-      root,
-      fileName: "setting.json",
-      contents: "candidate",
-      mode: 0o600,
-      createId: () => "file-sync-failure",
-      openFile: vi.fn(async () => ({
-        writeFile: async () => undefined,
-        chmod: async () => undefined,
-        sync,
-        close,
-      })) as never,
-    });
+      const result = await durableAtomicReplace({
+        root,
+        fileName: "setting.json",
+        contents: Buffer.from("candidate"),
+        mode: 0o600,
+        platform,
+        createId: () => "uncertain",
+        syncDirectory: async () => {
+          throw new TypeError("synthetic directory sync failure");
+        },
+      });
 
-    expect(result).toEqual({ state: "not-committed" });
-    await expect(readFile(target, "utf8")).resolves.toBe("old");
-    expect(sync).toHaveBeenCalledOnce();
-    expect(close).toHaveBeenCalledOnce();
-  });
+      expect(result).toEqual({
+        state: platform === "win32" ? "durably-committed" : "commit-uncertain",
+      });
+      await expect(readFile(target, "utf8")).resolves.toBe("candidate");
+      const directory = await open(root, "r");
+      await directory.close();
+    },
+  );
 
-  it("keeps a pre-rename refusal truthful when temporary cleanup also fails", async () => {
-    const root = await temporaryRoot();
-    const target = join(root, "setting.json");
-    const temporary = join(root, ".setting.json.cleanup-failure.tmp");
-    await writeFile(target, "old", { mode: 0o600 });
-    const removeFile = vi.fn(async () => {
-      throw new TypeError("synthetic temporary cleanup failure");
-    });
+  it.each(durabilityPlatforms)(
+    "distinguishes the $name pre-rename outcome from a durable replacement",
+    async ({ platform }) => {
+      const root = await temporaryRoot();
+      const target = join(root, "setting.json");
+      await writeFile(target, "old", { mode: 0o600 });
+      const refused = durableAtomicReplace({
+        root,
+        fileName: "setting.json",
+        contents: "candidate",
+        mode: 0o600,
+        platform,
+        createId: () => "refused",
+        renameFile: async () => {
+          throw new TypeError("synthetic rename failure");
+        },
+        syncDirectory: async () => undefined,
+      });
+      if (platform === "win32") {
+        await expect(refused).rejects.toMatchObject({
+          message: "Windows private path policy failed",
+          stage: "rename",
+        });
+      } else {
+        await expect(refused).resolves.toEqual({ state: "not-committed" });
+      }
+      await expect(readFile(target, "utf8")).resolves.toBe("old");
 
-    const result = await durableAtomicReplace({
-      root,
-      fileName: "setting.json",
-      contents: "candidate",
-      mode: 0o600,
-      createId: () => "cleanup-failure",
-      renameFile: async () => {
-        throw new TypeError("synthetic rename failure");
-      },
-      removeFile: removeFile as never,
-    });
+      const committed = await durableAtomicReplace({
+        root,
+        fileName: "setting.json",
+        contents: "candidate",
+        mode: 0o600,
+        platform,
+        createId: () => "committed",
+        syncDirectory: async () => undefined,
+      });
+      expect(committed).toEqual({ state: "durably-committed" });
+      await expect(readFile(target, "utf8")).resolves.toBe("candidate");
+    },
+  );
 
-    expect(result).toEqual({ state: "not-committed" });
-    await expect(readFile(target, "utf8")).resolves.toBe("old");
-    await expect(readFile(temporary, "utf8")).resolves.toBe("candidate");
-    expect(removeFile).toHaveBeenCalledWith(temporary, { force: true });
-  });
+  it.each(durabilityPlatforms)(
+    "does not retroactively change a $name durable result during directory cleanup",
+    async ({ platform }) => {
+      const root = await temporaryRoot();
+      const close = vi.fn(async () => {
+        throw new TypeError("synthetic close failure");
+      });
+      const result = await durableAtomicReplace({
+        root,
+        fileName: "setting.json",
+        contents: "candidate",
+        mode: 0o600,
+        platform,
+        createId: () => "close-failure",
+        openDirectory: vi.fn(async () => ({ sync: async () => {}, close })) as never,
+      });
 
-  it("reports commit uncertainty when rename published the candidate but directory sync failed", async () => {
-    const root = await temporaryRoot();
-    const target = join(root, "setting.json");
-    await writeFile(target, "old", { mode: 0o600 });
+      expect(result).toEqual({ state: "durably-committed" });
+      if (platform === "win32") {
+        expect(close).not.toHaveBeenCalled();
+      } else {
+        expect(close).toHaveBeenCalledOnce();
+      }
+    },
+  );
 
-    const result = await durableAtomicReplace({
-      root,
-      fileName: "setting.json",
-      contents: Buffer.from("candidate"),
-      mode: 0o600,
-      createId: () => "uncertain",
-      syncDirectory: async () => {
-        throw new TypeError("synthetic directory sync failure");
-      },
-    });
+  it.each(durabilityPlatforms)(
+    "resolves the $name uncertain replacement against the prior bytes",
+    async ({ platform }) => {
+      const root = await temporaryRoot();
+      const target = join(root, "setting.json");
+      const prior = Buffer.from("old");
+      const candidate = Buffer.from("candidate");
+      await writeFile(target, prior, { mode: 0o600 });
+      let syncCount = 0;
 
-    expect(result).toEqual({ state: "commit-uncertain" });
-    await expect(readFile(target, "utf8")).resolves.toBe("candidate");
-    const directory = await open(root, "r");
-    await directory.close();
-  });
+      const result = await durablyReplaceReversible({
+        root,
+        fileName: "setting.json",
+        contents: candidate,
+        previousContents: prior,
+        mode: 0o600,
+        platform,
+        createId: () => `attempt-${syncCount}`,
+        renameFile: rename,
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 1) throw new TypeError("synthetic first directory sync failure");
+        },
+      });
 
-  it("distinguishes pre-rename refusal from a durable replacement", async () => {
-    const root = await temporaryRoot();
-    const target = join(root, "setting.json");
-    await writeFile(target, "old", { mode: 0o600 });
-    const refused = await durableAtomicReplace({
-      root,
-      fileName: "setting.json",
-      contents: "candidate",
-      mode: 0o600,
-      createId: () => "refused",
-      renameFile: async () => {
-        throw new TypeError("synthetic rename failure");
-      },
-    });
-    expect(refused).toEqual({ state: "not-committed" });
-    await expect(readFile(target, "utf8")).resolves.toBe("old");
+      expect(result).toEqual({ state: platform === "win32" ? "applied" : "refused" });
+      await expect(readFile(target, "utf8")).resolves.toBe(
+        platform === "win32" ? "candidate" : "old",
+      );
+    },
+  );
 
-    const committed = await durableAtomicReplace({
-      root,
-      fileName: "setting.json",
-      contents: "candidate",
-      mode: 0o600,
-      createId: () => "committed",
-    });
-    expect(committed).toEqual({ state: "durably-committed" });
-    await expect(readFile(target, "utf8")).resolves.toBe("candidate");
-  });
+  it.each(durabilityPlatforms)(
+    "returns the $name result without requesting a second id after the candidate became visible",
+    async ({ platform }) => {
+      const root = await temporaryRoot();
+      const target = join(root, "setting.json");
+      await writeFile(target, "old", { mode: 0o600 });
+      let idCalls = 0;
 
-  it("does not retroactively change a durable result when directory descriptor cleanup fails", async () => {
-    const root = await temporaryRoot();
-    const close = vi.fn(async () => {
-      throw new TypeError("synthetic close failure");
-    });
-    const result = await durableAtomicReplace({
-      root,
-      fileName: "setting.json",
-      contents: "candidate",
-      mode: 0o600,
-      createId: () => "close-failure",
-      openDirectory: vi.fn(async () => ({ sync: async () => {}, close })) as never,
-    });
+      const result = await durablyReplaceReversible({
+        root,
+        fileName: "setting.json",
+        contents: "candidate",
+        previousContents: Buffer.from("old"),
+        mode: 0o600,
+        platform,
+        createId: () => {
+          idCalls += 1;
+          if (idCalls === 1) return "initial";
+          throw new TypeError("synthetic compensation id failure");
+        },
+        syncDirectory: async () => {
+          throw new TypeError("synthetic directory sync failure");
+        },
+      });
 
-    expect(result).toEqual({ state: "durably-committed" });
-    expect(close).toHaveBeenCalledOnce();
-  });
+      expect(result).toEqual({ state: platform === "win32" ? "applied" : "uncertain" });
+      if (platform === "win32") {
+        await expect(readFile(target, "utf8")).resolves.toBe("candidate");
+      } else {
+        expect(["old", "candidate"]).toContain(await readFile(target, "utf8"));
+      }
+      expect(idCalls).toBe(1);
+    },
+  );
 
-  it("durably restores the prior bytes before refusing an uncertain replacement", async () => {
-    const root = await temporaryRoot();
-    const target = join(root, "setting.json");
-    const prior = Buffer.from("old");
-    const candidate = Buffer.from("candidate");
-    await writeFile(target, prior, { mode: 0o600 });
-    let syncCount = 0;
+  it.each(durabilityPlatforms)(
+    "reuses one $name operation id while first-write convergence cleans its tombstone",
+    async ({ platform }) => {
+      const root = await temporaryRoot();
+      const target = join(root, "setting.json");
+      let syncCount = 0;
+      let idCount = 0;
 
-    const result = await durablyReplaceReversible({
-      root,
-      fileName: "setting.json",
-      contents: candidate,
-      previousContents: prior,
-      mode: 0o600,
-      createId: () => `attempt-${syncCount}`,
-      renameFile: rename,
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 1) throw new TypeError("synthetic first directory sync failure");
-        const directory = await open(root, "r");
-        try {
-          await directory.sync();
-        } finally {
-          await directory.close();
-        }
-      },
-    });
+      const result = await durablyReplaceReversible({
+        root,
+        fileName: "setting.json",
+        contents: "candidate",
+        previousContents: undefined,
+        mode: 0o600,
+        platform,
+        createId: () => `operation-${++idCount}`,
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount <= 2) throw new TypeError("synthetic directory sync failure");
+        },
+      });
 
-    expect(result).toEqual({ state: "refused" });
-    await expect(readFile(target, "utf8")).resolves.toBe("old");
-  });
-
-  it("returns uncertainty without requesting a second id after the candidate became visible", async () => {
-    const root = await temporaryRoot();
-    const target = join(root, "setting.json");
-    await writeFile(target, "old", { mode: 0o600 });
-    let idCalls = 0;
-
-    const result = await durablyReplaceReversible({
-      root,
-      fileName: "setting.json",
-      contents: "candidate",
-      previousContents: Buffer.from("old"),
-      mode: 0o600,
-      createId: () => {
-        idCalls += 1;
-        if (idCalls === 1) return "initial";
-        throw new TypeError("synthetic compensation id failure");
-      },
-      syncDirectory: async () => {
-        throw new TypeError("synthetic directory sync failure");
-      },
-    });
-
-    expect(result).toEqual({ state: "uncertain" });
-    expect(["old", "candidate"]).toContain(await readFile(target, "utf8"));
-    expect(idCalls).toBe(1);
-  });
-
-  it("reuses one operation id so first-write convergence cleans its original tombstone", async () => {
-    const root = await temporaryRoot();
-    const target = join(root, "setting.json");
-    let syncCount = 0;
-    let idCount = 0;
-
-    const result = await durablyReplaceReversible({
-      root,
-      fileName: "setting.json",
-      contents: "candidate",
-      previousContents: undefined,
-      mode: 0o600,
-      createId: () => `operation-${++idCount}`,
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount <= 2) throw new TypeError("synthetic directory sync failure");
-      },
-    });
-
-    expect(result).toEqual({ state: "refused" });
-    await expect(readFile(target, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
-    expect((await readdir(root)).filter((entry) => entry.endsWith(".deleted"))).toEqual([]);
-    expect(idCount).toBe(1);
-  });
+      expect(result).toEqual({ state: platform === "win32" ? "applied" : "refused" });
+      if (platform === "win32") {
+        await expect(readFile(target, "utf8")).resolves.toBe("candidate");
+      } else {
+        await expect(readFile(target, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      expect((await readdir(root)).filter((entry) => entry.endsWith(".deleted"))).toEqual([]);
+      expect(idCount).toBe(1);
+    },
+  );
 
   it("uses the Windows durability taxonomy without chmod or directory sync", async () => {
     const root = await temporaryRoot();

--- a/apps/desktop/tests/first-run-config.test.ts
+++ b/apps/desktop/tests/first-run-config.test.ts
@@ -66,10 +66,14 @@ describe("desktop first-run configuration", () => {
 
     const configDirectory = join(home, "config");
     const configPath = join(configDirectory, "config.yaml");
-    for (const path of [dirname(home), home, configDirectory]) {
-      expect((await fileLstat(path)).mode & 0o777).toBe(FIRST_RUN_CONFIG_DIRECTORY_MODE);
+    if (process.platform === "win32") {
+      expect((await fileLstat(configPath)).nlink).toBe(1);
+    } else {
+      for (const path of [dirname(home), home, configDirectory]) {
+        expect((await fileLstat(path)).mode & 0o777).toBe(FIRST_RUN_CONFIG_DIRECTORY_MODE);
+      }
+      expect((await fileLstat(configPath)).mode & 0o777).toBe(FIRST_RUN_CONFIG_FILE_MODE);
     }
-    expect((await fileLstat(configPath)).mode & 0o777).toBe(FIRST_RUN_CONFIG_FILE_MODE);
     const contents = await readFile(configPath, "utf8");
     const parsed = parseYaml(contents) as Record<string, unknown>;
     expect(parsed).toMatchObject({

--- a/apps/desktop/tests/intervals-ipc.test.ts
+++ b/apps/desktop/tests/intervals-ipc.test.ts
@@ -141,12 +141,26 @@ function setup(
   };
 }
 
-function testEncryption(options: { readonly available?: boolean; readonly backend?: string } = {}) {
+function testEncryption(
+  options: {
+    readonly available?: boolean;
+    readonly backend?: string;
+    readonly platform?: NodeJS.Platform;
+  } = {},
+) {
+  const platform = options.platform ?? process.platform;
   return {
     isEncryptionAvailable: () => options.available ?? true,
-    getSelectedStorageBackend: () => options.backend ?? "keychain",
-    encryptString: (value: string) => Buffer.from(`sealed:${value}`, "utf8"),
-    decryptString: (value: Buffer) => value.toString("utf8").slice("sealed:".length),
+    getSelectedStorageBackend: () =>
+      options.backend ?? (platform === "win32" ? "dpapi" : "keychain"),
+    encryptString: (value: string) =>
+      platform === "win32"
+        ? Buffer.from(Buffer.from(value, "utf8").map((byte) => byte ^ 0xa5))
+        : Buffer.from(`sealed:${value}`, "utf8"),
+    decryptString: (value: Buffer) =>
+      platform === "win32"
+        ? Buffer.from(Buffer.from(value).map((byte) => byte ^ 0xa5)).toString("utf8")
+        : value.toString("utf8").slice("sealed:".length),
   };
 }
 
@@ -154,6 +168,7 @@ async function temporaryVault(options: {
   readonly available?: boolean;
   readonly backend?: string;
   readonly encryption?: ReturnType<typeof testEncryption>;
+  readonly platform?: NodeJS.Platform;
   readonly trace?: string[];
 }) {
   const base = await mkdtemp(join(await realpath(tmpdir()), "intervals-ipc-"));
@@ -167,15 +182,17 @@ async function temporaryVault(options: {
     trace.push(`apply:${slot}:${value}`);
   });
   const root = join(base, "credentials-v1");
+  const platform = options.platform ?? process.platform;
   const runtimeState = new Map();
   const vault = createCredentialVault({
     root,
-    encryption: options.encryption ?? testEncryption(options),
+    encryption: options.encryption ?? testEncryption({ ...options, platform }),
+    platform,
     runtimeState,
     applyCredential,
     clearCredential,
   });
-  return { applyCredential, base, clearCredential, root, runtimeState, trace, vault };
+  return { applyCredential, base, clearCredential, platform, root, runtimeState, trace, vault };
 }
 
 function athleteResponse(account = "synthetic-athlete"): Response {
@@ -520,34 +537,51 @@ describe("Desktop Intervals.icu clipboard IPC", () => {
     expect(JSON.stringify(result)).not.toContain(API_KEY);
   });
 
-  it("keeps an existing encrypted key and runtime state unchanged after verification refusal", async () => {
-    const value = await temporaryVault({});
-    try {
-      await expect(
-        value.vault.writeCredential({ slot: "intervals-icu", value: EXISTING_API_KEY }),
-      ).resolves.toMatchObject({ status: "configured", runtimeReady: true });
-      const before = await readFile(join(value.root, "intervals-icu.bin"));
-      value.applyCredential.mockClear();
-      const runtime = setup({
-        vault: value.vault,
-        verification: { status: "refused", reason: "training-account-mismatch" },
-      });
+  it.each([
+    {
+      name: "POSIX",
+      platform: "darwin",
+      expectedCiphertext: Buffer.from(`sealed:${EXISTING_API_KEY}`, "utf8"),
+    },
+    {
+      name: "Windows",
+      platform: "win32",
+      expectedCiphertext: Buffer.from(
+        Buffer.from(EXISTING_API_KEY, "utf8").map((byte) => byte ^ 0xa5),
+      ),
+    },
+  ] as const)(
+    "keeps an existing encrypted key and runtime state unchanged after $name verification refusal",
+    async ({ platform, expectedCiphertext }) => {
+      const value = await temporaryVault({ platform });
+      try {
+        await expect(
+          value.vault.writeCredential({ slot: "intervals-icu", value: EXISTING_API_KEY }),
+        ).resolves.toMatchObject({ status: "configured", runtimeReady: true });
+        const before = await readFile(join(value.root, "intervals-icu.bin"));
+        expect(before).toEqual(expectedCiphertext);
+        value.applyCredential.mockClear();
+        const runtime = setup({
+          vault: value.vault,
+          verification: { status: "refused", reason: "training-account-mismatch" },
+        });
 
-      await expect(runtime.invoke()).resolves.toEqual({
-        outcome: "refused",
-        reason: "training-account-mismatch",
-        current: status("configured", "active"),
-      });
+        await expect(runtime.invoke()).resolves.toEqual({
+          outcome: "refused",
+          reason: "training-account-mismatch",
+          current: status("configured", "active"),
+        });
 
-      expect(await readFile(join(value.root, "intervals-icu.bin"))).toEqual(before);
-      expect(value.applyCredential).not.toHaveBeenCalled();
-      await expect(value.vault.credentialStatuses()).resolves.toContainEqual(
-        status("configured", "active"),
-      );
-    } finally {
-      await rm(value.base, { recursive: true, force: true });
-    }
-  });
+        expect(await readFile(join(value.root, "intervals-icu.bin"))).toEqual(before);
+        expect(value.applyCredential).not.toHaveBeenCalled();
+        await expect(value.vault.credentialStatuses()).resolves.toContainEqual(
+          status("configured", "active"),
+        );
+      } finally {
+        await rm(value.base, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("retains a coherent verified candidate when runtime application is uncertain", async () => {
     const value = await temporaryVault({});
@@ -572,9 +606,12 @@ describe("Desktop Intervals.icu clipboard IPC", () => {
         current: status("configured", "failed"),
       });
       expect(await readFile(join(value.root, "intervals-icu.bin"))).not.toEqual(before);
-      expect(await readFile(join(value.root, "intervals-icu.bin"))).toEqual(
-        Buffer.from(`sealed:${API_KEY}`, "utf8"),
-      );
+      const ciphertext = await readFile(join(value.root, "intervals-icu.bin"));
+      if (value.platform === "win32") {
+        expect(ciphertext.includes(Buffer.from(API_KEY, "utf8"))).toBe(false);
+      } else {
+        expect(ciphertext).toEqual(Buffer.from(`sealed:${API_KEY}`, "utf8"));
+      }
       expect(appliedRuntimeKey).toBe(API_KEY);
       expect(value.applyCredential).toHaveBeenCalledOnce();
       await expect(value.vault.credentialStatuses()).resolves.toContainEqual(
@@ -602,9 +639,12 @@ describe("Desktop Intervals.icu clipboard IPC", () => {
         reason: "runtime-uncertain",
         current: status("configured", "failed"),
       });
-      expect(await readFile(join(value.root, "intervals-icu.bin"))).toEqual(
-        Buffer.from(`sealed:${API_KEY}`, "utf8"),
-      );
+      const ciphertext = await readFile(join(value.root, "intervals-icu.bin"));
+      if (value.platform === "win32") {
+        expect(ciphertext.includes(Buffer.from(API_KEY, "utf8"))).toBe(false);
+      } else {
+        expect(ciphertext).toEqual(Buffer.from(`sealed:${API_KEY}`, "utf8"));
+      }
       expect(ownerClaimed).toBe(true);
       expect(value.clearCredential).not.toHaveBeenCalled();
       await expect(value.vault.credentialStatuses()).resolves.toContainEqual(

--- a/apps/desktop/tests/login-item.test.ts
+++ b/apps/desktop/tests/login-item.test.ts
@@ -207,8 +207,12 @@ describe("background-at-login preference", () => {
     });
 
     const target = join(root, BACKGROUND_AT_LOGIN_PREFERENCE_FILE_NAME);
-    expect((await stat(root)).mode & 0o777).toBe(LOGIN_ITEM_PREFERENCE_DIRECTORY_MODE);
-    expect((await stat(target)).mode & 0o777).toBe(LOGIN_ITEM_PREFERENCE_FILE_MODE);
+    if (process.platform === "win32") {
+      expect((await stat(target)).nlink).toBe(1);
+    } else {
+      expect((await stat(root)).mode & 0o777).toBe(LOGIN_ITEM_PREFERENCE_DIRECTORY_MODE);
+      expect((await stat(target)).mode & 0o777).toBe(LOGIN_ITEM_PREFERENCE_FILE_MODE);
+    }
     expect(JSON.parse(await readFile(target, "utf8"))).toEqual({
       schemaVersion: 2,
       enabled: true,
@@ -220,7 +224,7 @@ describe("background-at-login preference", () => {
     const root = join(await scratch(), "preferences");
     const syncParentDirectory = vi.fn(async (path: string) => {
       expect(path).toBe(dirname(root));
-      throw new TypeError("synthetic parent sync failure");
+      throw Object.assign(new Error("synthetic parent sync failure"), { code: "EIO" });
     });
     const store = createBackgroundAtLoginPreferenceStore({ root, syncParentDirectory });
 
@@ -243,7 +247,9 @@ describe("background-at-login preference", () => {
       createId: () => `write-${syncCount}`,
       syncDirectory: async () => {
         syncCount += 1;
-        if (syncCount === 2) throw new TypeError("synthetic replacement sync failure");
+        if (syncCount === 2) {
+          throw Object.assign(new Error("synthetic replacement sync failure"), { code: "EIO" });
+        }
         const directory = await open(root, "r");
         try {
           await directory.sync();
@@ -269,7 +275,9 @@ describe("background-at-login preference", () => {
       root,
       createId: () => "never-durable",
       syncDirectory: async () => {
-        throw new TypeError("synthetic persistent directory sync failure");
+        throw Object.assign(new Error("synthetic persistent directory sync failure"), {
+          code: "EIO",
+        });
       },
     });
 
@@ -311,7 +319,7 @@ describe("background-at-login preference", () => {
     await expect(seed.set(false)).resolves.toEqual({ status: "stored", enabled: false });
     await publishUnsyncedPreference(root, true);
     const syncDirectory = vi.fn(async () => {
-      throw new TypeError("synthetic reopen sync failure");
+      throw Object.assign(new Error("synthetic reopen sync failure"), { code: "EIO" });
     });
     const reopened = createBackgroundAtLoginPreferenceStore({ root, syncDirectory });
 
@@ -511,15 +519,17 @@ describe("background-at-login preference", () => {
     ).resolves.toBe(false);
   });
 
-  it("fails closed for malformed, permissive, and non-boolean preference state", async () => {
+  it("fails closed for malformed and non-boolean state, plus permissive POSIX state", async () => {
     const root = join(await scratch(), "preferences");
     const first = createBackgroundAtLoginPreferenceStore({ root, createId: () => "seed" });
     await expect(first.set(true)).resolves.toEqual({ status: "stored", enabled: true });
     const target = join(root, BACKGROUND_AT_LOGIN_PREFERENCE_FILE_NAME);
 
-    await chmod(target, 0o644);
-    await expect(first.read()).resolves.toEqual({ state: "unavailable", enabled: false });
-    await chmod(target, LOGIN_ITEM_PREFERENCE_FILE_MODE);
+    if (process.platform !== "win32") {
+      await chmod(target, 0o644);
+      await expect(first.read()).resolves.toEqual({ state: "unavailable", enabled: false });
+      await chmod(target, LOGIN_ITEM_PREFERENCE_FILE_MODE);
+    }
     await writeFile(target, '{"schemaVersion":1,"enabled":"true"}\n', { mode: 0o600 });
     await expect(first.read()).resolves.toEqual({ state: "unavailable", enabled: false });
     await writeFile(

--- a/apps/desktop/tests/telegram-credential-vault.test.ts
+++ b/apps/desktop/tests/telegram-credential-vault.test.ts
@@ -47,6 +47,22 @@ async function fixture(): Promise<VaultFixture> {
   };
 }
 
+async function createSymlinkOrReturnWindowsCapabilityReason(
+  target: string,
+  path: string,
+): Promise<string | undefined> {
+  try {
+    await symlink(target, path);
+    return undefined;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (process.platform === "win32" && (code === "EPERM" || code === "EACCES")) {
+      return `Windows symlink capability unavailable (${code})`;
+    }
+    throw error;
+  }
+}
+
 async function anotherHome(root: string): Promise<string> {
   const path = join(root, "..", "other-athlete-home");
   await mkdir(path, { mode: 0o700 });
@@ -218,9 +234,13 @@ describe("Telegram credential vault", () => {
       bot: BOT_A,
     });
     expect(encryptedBuffer?.every((byte) => byte === 0)).toBe(true);
-    expect((await lstat(value.root)).mode & 0o777).toBe(TELEGRAM_CREDENTIAL_DIRECTORY_MODE);
+    if (process.platform !== "win32") {
+      expect((await lstat(value.root)).mode & 0o777).toBe(TELEGRAM_CREDENTIAL_DIRECTORY_MODE);
+    }
     const profilePath = join(value.root, TELEGRAM_PROFILE_FILE_NAME);
-    expect((await lstat(profilePath)).mode & 0o777).toBe(TELEGRAM_CREDENTIAL_FILE_MODE);
+    if (process.platform !== "win32") {
+      expect((await lstat(profilePath)).mode & 0o777).toBe(TELEGRAM_CREDENTIAL_FILE_MODE);
+    }
     const ciphertext = await readFile(profilePath);
     expect(ciphertext.includes(Buffer.from(token))).toBe(false);
     expect(await readdir(value.root)).toEqual([TELEGRAM_PROFILE_FILE_NAME]);
@@ -1003,11 +1023,15 @@ describe("Telegram credential vault", () => {
     expect(reopenSyncAttempts).toBe(1);
   });
 
-  it("refuses symlinked and permissive profile storage", async () => {
+  it("refuses symlinked and permissive profile storage", async ({ skip }) => {
     const value = await fixture();
     const actual = join(value.root, "..", "actual-vault");
     await mkdir(actual, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
-    await symlink(actual, value.root);
+    const rootSymlinkCapabilityReason = await createSymlinkOrReturnWindowsCapabilityReason(
+      actual,
+      value.root,
+    );
+    if (rootSymlinkCapabilityReason) return skip(rootSymlinkCapabilityReason);
     const symlinkedRoot = createTelegramCredentialVault({ ...value, encryption: encryption() });
     await expect(
       symlinkedRoot.replaceProfile({
@@ -1021,7 +1045,11 @@ describe("Telegram credential vault", () => {
     await mkdir(value.root, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
     const outside = join(value.root, "..", "outside-profile");
     await writeFile(outside, "ciphertext", { mode: TELEGRAM_CREDENTIAL_FILE_MODE });
-    await symlink(outside, join(value.root, TELEGRAM_PROFILE_FILE_NAME));
+    const fileSymlinkCapabilityReason = await createSymlinkOrReturnWindowsCapabilityReason(
+      outside,
+      join(value.root, TELEGRAM_PROFILE_FILE_NAME),
+    );
+    if (fileSymlinkCapabilityReason) return skip(fileSymlinkCapabilityReason);
     const symlinkedFile = createTelegramCredentialVault({ ...value, encryption: encryption() });
     await expect(symlinkedFile.profileStatus()).resolves.toEqual({
       state: "re-prompt",
@@ -1037,10 +1065,14 @@ describe("Telegram credential vault", () => {
 
     await rm(join(value.root, TELEGRAM_PROFILE_FILE_NAME));
     await chmod(value.root, 0o755);
-    await expect(symlinkedFile.profileStatus()).resolves.toEqual({
-      state: "re-prompt",
-      reason: "storage-failed",
-    });
+    if (process.platform === "win32") {
+      await expect(symlinkedFile.profileStatus()).resolves.toEqual({ state: "missing" });
+    } else {
+      await expect(symlinkedFile.profileStatus()).resolves.toEqual({
+        state: "re-prompt",
+        reason: "storage-failed",
+      });
+    }
   });
 
   it("deletes through a durable tombstone and cleans deferred ciphertext later", async () => {

--- a/apps/desktop/tests/telegram-power.test.ts
+++ b/apps/desktop/tests/telegram-power.test.ts
@@ -116,7 +116,9 @@ describe("Desktop Telegram power lifecycle", () => {
       createId: () => `state-${++id}`,
       syncDirectory: async () => {
         syncCount += 1;
-        if (syncCount === 1) throw new TypeError("synthetic first directory sync failure");
+        if (syncCount === 1) {
+          throw Object.assign(new Error("synthetic first directory sync failure"), { code: "EIO" });
+        }
         const directory = await open(files.root, "r");
         try {
           await directory.sync();
@@ -178,7 +180,7 @@ describe("Desktop Telegram power lifecycle", () => {
     const telegram = controller();
     const syncParentDirectory = vi.fn(async (path: string) => {
       expect(path).toBe(dirname(files.root));
-      throw new TypeError("synthetic parent sync failure");
+      throw Object.assign(new Error("synthetic parent sync failure"), { code: "EIO" });
     });
     const lifecycle = createDesktopTelegramPowerLifecycle({
       ...files,
@@ -237,7 +239,7 @@ describe("Desktop Telegram power lifecycle", () => {
     await publishUnsyncedPowerState(files, "2026-08-01T00:00:00.000Z");
     const telegram = controller();
     const syncDirectory = vi.fn(async () => {
-      throw new TypeError("synthetic reopen sync failure");
+      throw Object.assign(new Error("synthetic reopen sync failure"), { code: "EIO" });
     });
     const lifecycle = createDesktopTelegramPowerLifecycle({
       ...files,
@@ -416,8 +418,12 @@ describe("Desktop Telegram power lifecycle", () => {
     expect(telegram.resumePolling).not.toHaveBeenCalled();
 
     const target = join(files.root, TELEGRAM_POWER_STATE_FILE_NAME);
-    expect((await lstat(files.root)).mode & 0o777).toBe(TELEGRAM_POWER_STATE_DIRECTORY_MODE);
-    expect((await lstat(target)).mode & 0o777).toBe(TELEGRAM_POWER_STATE_FILE_MODE);
+    if (process.platform === "win32") {
+      expect((await lstat(target)).nlink).toBe(1);
+    } else {
+      expect((await lstat(files.root)).mode & 0o777).toBe(TELEGRAM_POWER_STATE_DIRECTORY_MODE);
+      expect((await lstat(target)).mode & 0o777).toBe(TELEGRAM_POWER_STATE_FILE_MODE);
+    }
     const suspended = JSON.parse(await readFile(target, "utf8"));
     expect(suspended).toEqual({
       schemaVersion: 2,
@@ -621,7 +627,7 @@ describe("Desktop Telegram power lifecycle", () => {
     });
   });
 
-  it("fails closed for malformed, wrong-home, and permissive state files", async () => {
+  it("fails closed for malformed and wrong-home files, plus permissive POSIX files", async () => {
     const files = await fixture();
     const powerMonitor = monitor();
     const failures: string[] = [];
@@ -672,17 +678,19 @@ describe("Desktop Telegram power lifecycle", () => {
     expect(JSON.parse(await readFile(target, "utf8"))).toEqual(wrongHomeRecord);
     await wrongHome.close();
 
-    await chmod(target, 0o644);
-    const permissive = createDesktopTelegramPowerLifecycle({
-      ...files,
-      powerMonitor: monitor(),
-      controller: controller(),
-      now: () => Date.parse("2026-08-02T00:00:00.000Z"),
-    });
-    await expect(permissive.start()).resolves.toMatchObject({ state: "possible-message-loss" });
-    await expect(permissive.acknowledgeWarning()).resolves.toMatchObject({
-      state: "possible-message-loss",
-    });
+    if (process.platform !== "win32") {
+      await chmod(target, 0o644);
+      const permissive = createDesktopTelegramPowerLifecycle({
+        ...files,
+        powerMonitor: monitor(),
+        controller: controller(),
+        now: () => Date.parse("2026-08-02T00:00:00.000Z"),
+      });
+      await expect(permissive.start()).resolves.toMatchObject({ state: "possible-message-loss" });
+      await expect(permissive.acknowledgeWarning()).resolves.toMatchObject({
+        state: "possible-message-loss",
+      });
+    }
     expect(failures).toContain("read-state");
   });
 


### PR DESCRIPTION
Child C3 of the epic/windows win32 test-lane fix wave — the largest cluster from the first real-win32 suite run (~85 failures across 8 files).

## What was wrong

These suites simulated refusal lanes with real `chmod` (no-op beyond the read-only bit on Windows) and asserted POSIX modes (`0o600`/`0o700`) that Windows stats can never report. On a real win32 host the refusal lanes silently became success lanes and every mode assert failed.

## What changed (tests only, no product code)

- Mode assertions are platform-conditional: POSIX branches assert exactly what they did before; win32 branches assert the product's actual guarantees (Windows private-path policy binding, DPAPI-shaped ciphertext round-trips, single-link metadata).
- Chmod-based refusal simulations converted to the product's existing injection seams (`openFile`/`renameFile`/`syncCredentialFile`/... + injected `platform`), so refusal lanes now run identically on every platform — including named POSIX/Windows `it.each` matrices that both execute on macOS.
- The five acceptance-cited tests (intervals verification-refusal, telegram encrypted-profile + diagnostics-adjacent, telegram suspend/resume, login-item background preference) run un-skipped on win32 through the seams.
- Symlink-based refusal lanes got a capability probe: they skip only when win32 denies symlink creation (stock Windows 11 without Developer Mode throws EPERM), with the reason in the skip.

## Round 2 (verification rejected round 1; all four findings fixed)

TS errors in the intervals encryption stub; a dropped POSIX `sync`-not-called assertion restored; the cited intervals scenario now runs both a darwin and a win32 lane (round 1 had hardcoded win32, losing POSIX coverage); the symlink guard above.

## Verification

- 8 suites, 223 tests green on macOS; the win32 matrix rows demonstrably execute (not skip).
- Root `pnpm check` green.
- Read-only audits both rounds. Accepted LOWs: shared test-encryption helpers now branch by platform file-wide (fixture-environment change, bodies untouched); two POSIX lanes stub `syncDirectory` as a no-op where they previously used the real default — assertions unchanged, fidelity drift only.
- One gate flake was infrastructure: an aborted recursive build left `@enduragent/core` dist missing, failing all imports; rebuilt and re-run green.

Limits: none added or changed.