### PR TITLE
test(desktop): restore exact parity-cited title in intervals refusal matrix

### DIFF
--- a/apps/desktop/tests/intervals-ipc.test.ts
+++ b/apps/desktop/tests/intervals-ipc.test.ts
@@ -551,7 +551,7 @@ describe("Desktop Intervals.icu clipboard IPC", () => {
       ),
     },
   ] as const)(
-    "keeps an existing encrypted key and runtime state unchanged after $name verification refusal",
+    "keeps an existing encrypted key and runtime state unchanged after verification refusal",
     async ({ platform, expectedCiphertext }) => {
       const value = await temporaryVault({ platform });
       try {


### PR DESCRIPTION
Wave repair for epic/windows: the C3 matrix conversion (#618) interpolated the lane name mid-title, so the parity manifest's citation-containment check (windows-parity-scenarios.test.ts) no longer found the frozen cited string for `training.setup.intervals-verification`. Both matrix lanes now carry the exact cited title; lanes are distinguished by their case parameters.

Verification: intervals-ipc + windows-parity-scenarios green (80 tests); full merged-epic desktop suite re-runs after merge (this was its only failure — 1339/1340, renderer 850/850).