### PR TITLE
test(desktop): win32-host lanes for credential vault and telegram suites

### DIFF
--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../src/main/credential-vault.js";
 
 const roots: string[] = [];
+const posixIt = it.skipIf(process.platform === "win32");
 
 async function temporaryRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "desktop-vault-"));
@@ -221,7 +222,7 @@ describe("desktop credential vault", () => {
     });
   });
 
-  it("anchors the credential namespace in its parent before publishing a credential", async () => {
+  posixIt("anchors the credential namespace in its parent before publishing a credential", async () => {
     const root = await temporaryRoot();
     let parentSyncAvailable = false;
     const syncCredentialParentDirectory = vi.fn(async (path: string) => {
@@ -255,7 +256,7 @@ describe("desktop credential vault", () => {
     expect(syncCredentialParentDirectory).toHaveBeenCalledTimes(2);
   });
 
-  it("zeros encryption and rollback buffers after success, refusal, and compensation", async () => {
+  posixIt("zeros encryption and rollback buffers after success, refusal, and compensation", async () => {
     const scenarios = ["success", "pre-rename", "compensation"] as const;
     for (const scenario of scenarios) {
       const root = await temporaryRoot();
@@ -346,13 +347,19 @@ describe("desktop credential vault", () => {
       status: "configured",
       runtimeReady: true,
     });
-    expect(openCredentialDirectory).toHaveBeenCalledWith(root, "r");
-    expect(sync).toHaveBeenCalledOnce();
-    expect(close).toHaveBeenCalledOnce();
+    if (process.platform === "win32") {
+      expect(openCredentialDirectory).not.toHaveBeenCalled();
+      expect(sync).not.toHaveBeenCalled();
+      expect(close).not.toHaveBeenCalled();
+    } else {
+      expect(openCredentialDirectory).toHaveBeenCalledWith(root, "r");
+      expect(sync).toHaveBeenCalledOnce();
+      expect(close).toHaveBeenCalledOnce();
+    }
     expect(applyCredential).toHaveBeenCalledWith("anthropic", "synthetic-candidate");
   });
 
-  it("restores the previous ciphertext before refusing a post-rename durability failure", async () => {
+  posixIt("restores the previous ciphertext before refusing a post-rename durability failure", async () => {
     const root = await temporaryRoot();
     const encryptionPort = encryption();
     const seed = createCredentialVault({
@@ -392,7 +399,7 @@ describe("desktop credential vault", () => {
     expect(applyCredential).not.toHaveBeenCalled();
   });
 
-  it("reports uncertainty and blocks replay when credential convergence cannot be proven", async () => {
+  posixIt("reports uncertainty and blocks replay when credential convergence cannot be proven", async () => {
     const root = await temporaryRoot();
     const encryptionPort = encryption();
     const seed = createCredentialVault({
@@ -442,39 +449,29 @@ describe("desktop credential vault", () => {
     const root = await temporaryRoot();
     const encryptionPort = encryption();
     await storeEncryptedCredential(root, "anthropic", "synthetic-old", encryptionPort);
-    let releaseCandidateSync!: () => void;
-    const candidateSyncBlocked = new Promise<void>((resolve) => {
-      releaseCandidateSync = resolve;
+    let releaseReplacement!: () => void;
+    const replacementBlocked = new Promise<void>((resolve) => {
+      releaseReplacement = resolve;
     });
-    let candidateVisible!: () => void;
-    const candidateWasVisible = new Promise<void>((resolve) => {
-      candidateVisible = resolve;
+    let replacementStarted!: () => void;
+    const replacementWasStarted = new Promise<void>((resolve) => {
+      replacementStarted = resolve;
     });
-    let syncCount = 0;
     const writer = createCredentialVault({
       root,
       encryption: encryptionPort,
       applyCredential: vi.fn(async () => undefined),
-      syncCredentialDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 2) {
-          candidateVisible();
-          await candidateSyncBlocked;
-          throw new TypeError("synthetic candidate directory sync failure");
-        }
-        const directory = await open(root, "r");
-        try {
-          await directory.sync();
-        } finally {
-          await directory.close();
-        }
-      },
+      renameCredentialFile: (async () => {
+        replacementStarted();
+        await replacementBlocked;
+        throw new TypeError("synthetic replacement rename failure");
+      }) as never,
     });
     const write = writer.writeCredential({
       slot: "anthropic",
       value: "synthetic-candidate",
     });
-    await candidateWasVisible;
+    await replacementWasStarted;
 
     const applySuccessorCredential = vi.fn(async () => undefined);
     const successor = createCredentialVault({
@@ -492,7 +489,7 @@ describe("desktop credential vault", () => {
     expect(replaySettled).toBe(false);
     expect(applySuccessorCredential).not.toHaveBeenCalled();
 
-    releaseCandidateSync();
+    releaseReplacement();
     await expect(write).resolves.toEqual({
       slot: "anthropic",
       status: "refused",
@@ -522,7 +519,7 @@ describe("desktop credential vault", () => {
     await expect(lstat(join(root, "anthropic.bin"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("reopens a visible old credential only after cleaning owned transients and syncing", async () => {
+  posixIt("reopens a visible old credential only after cleaning owned transients and syncing", async () => {
     const root = await temporaryRoot();
     const baseEncryption = encryption();
     await leaveAmbiguousCredential(root, "old", baseEncryption);
@@ -562,7 +559,7 @@ describe("desktop credential vault", () => {
     expect(syncCredentialDirectory).toHaveBeenCalledOnce();
   });
 
-  it("reopens a visible candidate only after syncing even when no transient remains", async () => {
+  posixIt("reopens a visible candidate only after syncing even when no transient remains", async () => {
     const root = await temporaryRoot();
     const baseEncryption = encryption();
     await leaveAmbiguousCredential(root, "candidate", baseEncryption);
@@ -592,7 +589,7 @@ describe("desktop credential vault", () => {
     expect(syncCredentialDirectory).toHaveBeenCalledOnce();
   });
 
-  it("keeps a reopened vault indeterminate when its durability barrier fails", async () => {
+  posixIt("keeps a reopened vault indeterminate when its durability barrier fails", async () => {
     const root = await temporaryRoot();
     const baseEncryption = encryption();
     await leaveAmbiguousCredential(root, "candidate", baseEncryption);
@@ -868,7 +865,7 @@ describe("desktop credential vault", () => {
     });
   });
 
-  it("reports deletion uncertainty when neither the visible delete nor restoration is durable", async () => {
+  posixIt("reports deletion uncertainty when neither the visible delete nor restoration is durable", async () => {
     const root = await temporaryRoot();
     const encryptionPort = encryption();
     await storeEncryptedCredential(root, "openrouter", "synthetic-old", encryptionPort);
@@ -915,6 +912,7 @@ describe("desktop credential vault", () => {
       root,
       encryption: encryption(),
       applyCredential: vi.fn(),
+      clearCredential: vi.fn(async () => "cleared" as const),
     });
     const permissiveDirectoryWrite = vault.writeCredential({
       slot: "anthropic",

--- a/apps/desktop/tests/telegram-control.test.ts
+++ b/apps/desktop/tests/telegram-control.test.ts
@@ -582,17 +582,24 @@ describe("Telegram main-process control coordinator", () => {
     expect(runtime.binding.replaceTelegram).not.toHaveBeenCalled();
   });
 
-  it.each([
+  for (const [run, reason, available, selectedBackend, errorCode] of [
     [
+      it,
       "encryption-unavailable" as const,
       false,
       undefined,
       "telegram-credential-encryption-unavailable" as const,
     ],
-    ["unsafe-backend" as const, true, "basic_text", "telegram-credential-unsafe-backend" as const],
-  ])(
-    "preserves a reopened real-vault %s refusal across profile-dependent actions",
-    async (reason, available, selectedBackend, errorCode) => {
+    [
+      it.skipIf(process.platform === "win32"),
+      "unsafe-backend" as const,
+      true,
+      "basic_text",
+      "telegram-credential-unsafe-backend" as const,
+    ],
+  ] as const) {
+    const title = `preserves a reopened real-vault ${reason} refusal across profile-dependent actions`;
+    run(title, async () => {
       const value = await realVaultFixture();
       try {
         const seed = createTelegramCredentialVault({
@@ -686,8 +693,8 @@ describe("Telegram main-process control coordinator", () => {
       } finally {
         await rm(value.base, { recursive: true, force: true });
       }
-    },
-  );
+    });
+  }
 
   it("returns the preserved pre-mutation snapshot when a real vault backend flips during replacement", async () => {
     const value = await realVaultFixture();

--- a/apps/desktop/tests/telegram-credential-vault.test.ts
+++ b/apps/desktop/tests/telegram-credential-vault.test.ts
@@ -30,6 +30,7 @@ const PROFILE_A = "00000000-0000-4000-8000-000000000001";
 const PROFILE_B = "00000000-0000-4000-8000-000000000002";
 const BOT_A = { id: 123456, username: "synthetic_bot_a" } as const;
 const BOT_B = { id: 234567, username: "synthetic_bot_b" } as const;
+const posixIt = it.skipIf(process.platform === "win32");
 
 interface VaultFixture {
   readonly root: string;
@@ -188,6 +189,7 @@ describe("Telegram credential vault", () => {
 
     const unsafe = createTelegramCredentialVault({
       ...value,
+      platform: "darwin",
       encryption: { ...encryption(), getSelectedStorageBackend: () => "basic_text" },
     });
     await expect(
@@ -274,6 +276,15 @@ describe("Telegram credential vault", () => {
       } satisfies CredentialEncryptionPort,
       "encryption-unavailable" as const,
     ],
+  ])("preserves %s as a closed status reason after reopen", async (_label, backend, reason) => {
+    const value = await fixture();
+    await seedProfile(value);
+    const reopened = createTelegramCredentialVault({ ...value, encryption: backend });
+
+    await expect(reopened.profileStatus()).resolves.toEqual({ state: "re-prompt", reason });
+  });
+
+  posixIt.each([
     [
       "an unsafe backend",
       {
@@ -362,7 +373,7 @@ describe("Telegram credential vault", () => {
     );
   });
 
-  it("anchors the profile namespace in its parent before publishing ciphertext", async () => {
+  posixIt("anchors the profile namespace in its parent before publishing ciphertext", async () => {
     const value = await fixture();
     const syncParentDirectory = vi.fn(async (path: string) => {
       expect(path).toBe(dirname(value.root));
@@ -481,7 +492,7 @@ describe("Telegram credential vault", () => {
     }
   });
 
-  it("durably restores the prior ciphertext before refusing post-rename profile uncertainty", async () => {
+  posixIt("durably restores the prior ciphertext before refusing post-rename profile uncertainty", async () => {
     const value = await fixture();
     await seedProfile(value);
     let syncCount = 0;
@@ -518,7 +529,7 @@ describe("Telegram credential vault", () => {
     });
   });
 
-  it("durably removes a first candidate before refusing initial-write uncertainty", async () => {
+  posixIt("durably removes a first candidate before refusing initial-write uncertainty", async () => {
     const value = await fixture();
     let syncCount = 0;
     const vault = createTelegramCredentialVault({
@@ -546,7 +557,7 @@ describe("Telegram credential vault", () => {
     });
   });
 
-  it("blocks replay and reports uncertainty when neither candidate nor prior can converge durably", async () => {
+  posixIt("blocks replay and reports uncertainty when neither candidate nor prior can converge durably", async () => {
     const value = await fixture();
     await seedProfile(value);
     let syncCount = 0;
@@ -581,7 +592,7 @@ describe("Telegram credential vault", () => {
     expect(apply).not.toHaveBeenCalled();
   });
 
-  it("converges a visible prior profile on reopen before accepting or replaying it", async () => {
+  posixIt("converges a visible prior profile on reopen before accepting or replaying it", async () => {
     const value = await fixture();
     await seedProfile(value);
     let syncCount = 0;
@@ -643,7 +654,7 @@ describe("Telegram credential vault", () => {
     expect(events).toEqual(["sync", "decrypt", "decrypt", "apply"]);
   });
 
-  it("converges a visible candidate profile on reopen before accepting or replaying it", async () => {
+  posixIt("converges a visible candidate profile on reopen before accepting or replaying it", async () => {
     const value = await fixture();
     await seedProfile(value);
     let syncCount = 0;
@@ -699,7 +710,7 @@ describe("Telegram credential vault", () => {
     expect(namespaceSync).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps a failed reopen reconciliation uncertain and never replays the visible profile", async () => {
+  posixIt("keeps a failed reopen reconciliation uncertain and never replays the visible profile", async () => {
     const value = await fixture();
     await seedProfile(value);
     let syncAttempts = 0;
@@ -774,10 +785,10 @@ describe("Telegram credential vault", () => {
     const remaining = await readdir(value.root);
     expect(exact.some((entry) => remaining.includes(entry))).toBe(false);
     expect(lookalikes.every((entry) => remaining.includes(entry))).toBe(true);
-    expect(namespaceSync).toHaveBeenCalledTimes(1);
+    expect(namespaceSync).toHaveBeenCalledTimes(process.platform === "win32" ? 0 : 1);
   });
 
-  it("treats an unsynced tombstone cleanup as permanently uncertain", async () => {
+  posixIt("treats an unsynced tombstone cleanup as permanently uncertain", async () => {
     const value = await fixture();
     await seedProfile(value);
     await writeFile(
@@ -838,7 +849,7 @@ describe("Telegram credential vault", () => {
     expect((await readdir(value.root)).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
   });
 
-  it("stores desired state separately without encryption and durably compensates uncertainty", async () => {
+  posixIt("stores desired state separately without encryption and durably compensates uncertainty", async () => {
     const value = await fixture();
     const encryptString = vi.fn();
     const decryptString = vi.fn();
@@ -874,7 +885,7 @@ describe("Telegram credential vault", () => {
     ).toEqual({ schemaVersion: 1, athleteHome: value.athleteHome, enabled: false });
   });
 
-  it("marks desired state uncertain when durable compensation cannot be proven", async () => {
+  posixIt("marks desired state uncertain when durable compensation cannot be proven", async () => {
     const value = await fixture();
     const seed = createTelegramCredentialVault({ ...value, encryption: encryption() });
     await seed.setDesiredState(false);
@@ -929,10 +940,10 @@ describe("Telegram credential vault", () => {
       state: "configured",
       enabled: false,
     });
-    expect(namespaceSync).toHaveBeenCalledTimes(1);
+    expect(namespaceSync).toHaveBeenCalledTimes(process.platform === "win32" ? 0 : 1);
   });
 
-  it("accepts an uncertain visible enable only after a fresh reopen converges it", async () => {
+  posixIt("accepts an uncertain visible enable only after a fresh reopen converges it", async () => {
     const value = await fixture();
     const seed = createTelegramCredentialVault({ ...value, encryption: encryption() });
     await seed.setDesiredState(false);
@@ -977,7 +988,7 @@ describe("Telegram credential vault", () => {
     expect(namespaceSync).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps an uncertain visible enable disabled while reopen convergence is indeterminate", async () => {
+  posixIt("keeps an uncertain visible enable disabled while reopen convergence is indeterminate", async () => {
     const value = await fixture();
     const seed = createTelegramCredentialVault({ ...value, encryption: encryption() });
     await seed.setDesiredState(false);
@@ -1121,7 +1132,7 @@ describe("Telegram credential vault", () => {
     await expect(vault.profileStatus()).resolves.toMatchObject({ state: "configured" });
   });
 
-  it("restores a profile when tombstone durability fails and reports uncertainty if restore fails", async () => {
+  posixIt("restores a profile when tombstone durability fails and reports uncertainty if restore fails", async () => {
     const value = await fixture();
     await seedProfile(value);
     let syncCount = 0;

--- a/apps/desktop/tests/telegram-ipc.test.ts
+++ b/apps/desktop/tests/telegram-ipc.test.ts
@@ -300,12 +300,11 @@ describe("Desktop Telegram IPC", () => {
     expect(runtime.coordinator.replace).toHaveBeenCalledWith(TOKEN);
   });
 
-  it.each([
-    ["encryption-unavailable" as const, false, undefined],
-    ["unsafe-backend" as const, true, "basic_text"],
-  ])(
-    "routes a reopened real-vault %s paste through replacement",
-    async (reason, available, backend) => {
+  for (const [run, reason, available, backend] of [
+    [it, "encryption-unavailable" as const, false, undefined],
+    [it.skipIf(process.platform === "win32"), "unsafe-backend" as const, true, "basic_text"],
+  ] as const) {
+    run(`routes a reopened real-vault ${reason} paste through replacement`, async () => {
       const base = await mkdtemp(join(await realpath(tmpdir()), "telegram-ipc-secure-storage-"));
       try {
         const homePath = join(base, "athlete-home");
@@ -357,8 +356,8 @@ describe("Desktop Telegram IPC", () => {
       } finally {
         await rm(base, { recursive: true, force: true });
       }
-    },
-  );
+    });
+  }
 
   it("passes through refused and uncertain credential outcomes without inferring success from health", async () => {
     const refused = setup({ configured: true });

--- a/apps/desktop/tests/telegram-power.test.ts
+++ b/apps/desktop/tests/telegram-power.test.ts
@@ -101,7 +101,9 @@ function disabledPollingStatus() {
 }
 
 describe("Desktop Telegram power lifecycle", () => {
-  it("keeps the forward gap anchor and warns when its rename is visible but durability is uncertain", async () => {
+  const posixIt = it.skipIf(process.platform === "win32");
+
+  posixIt("keeps the forward gap anchor and warns when its rename is visible but durability is uncertain", async () => {
     const files = await fixture();
     const powerMonitor = monitor();
     const telegram = controller();
@@ -174,7 +176,7 @@ describe("Desktop Telegram power lifecycle", () => {
     });
   });
 
-  it("does not stop polling before the power-state namespace is durably anchored", async () => {
+  posixIt("does not stop polling before the power-state namespace is durably anchored", async () => {
     const files = await fixture();
     const powerMonitor = monitor();
     const telegram = controller();
@@ -208,7 +210,7 @@ describe("Desktop Telegram power lifecycle", () => {
     });
   });
 
-  it("fsyncs and accepts the visible power record after reconstructing the lifecycle", async () => {
+  posixIt("fsyncs and accepts the visible power record after reconstructing the lifecycle", async () => {
     const files = await fixture();
     await publishUnsyncedPowerState(files, "2026-08-01T00:00:00.000Z");
     const syncDirectory = vi.fn(async () => {
@@ -234,7 +236,7 @@ describe("Desktop Telegram power lifecycle", () => {
     expect(syncDirectory).toHaveBeenCalledOnce();
   });
 
-  it("fails closed without power mutations when reopen convergence cannot be proven", async () => {
+  posixIt("fails closed without power mutations when reopen convergence cannot be proven", async () => {
     const files = await fixture();
     await publishUnsyncedPowerState(files, "2026-08-01T00:00:00.000Z");
     const telegram = controller();


### PR DESCRIPTION
W16.6 child C9. Fixes the 34 real-win32 failures across telegram-credential-vault, credential-vault, telegram-power, telegram-ipc, telegram-control: POSIX mode/backend simulations gate to POSIX hosts, seam-expressible cases pin the POSIX lane, win32 branches assert platform-true values. Adjudicated audit patch included: the hostile-directory test is un-gated and its fixture completed with a clearCredential double — the win32 delete path fail-closes with refused/runtime-unavailable when runtime holds a credential and no clear hook exists, so the fixture now provides one and the win32 branch stays live. Test files only. Gate: 6 suites / 286 tests + root pnpm check clean on macOS; win32 proof via VM re-run.