### PR TITLE
fix(desktop): ship the en-US locale pak in the Windows package

### DIFF
--- a/.changeset/windows-locale-paks.md
+++ b/.changeset/windows-locale-paks.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Ship the `en-US` Chromium locale pak in the Windows package. `electronLanguages: [en]` matched nothing under app-builder-lib's inverted prefix filter, so every locale pak was deleted from `win-unpacked/locales/` and Blink null-dereferenced in `Locale::DefaultLocale` the first time a renderer wrote a value into a number input. The Windows package verifier now requires a present, non-empty `locales/en-US.pak` and rejects any other locale entry.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -2,7 +2,7 @@ appId: icu.enduragent.desktop
 productName: Enduragent
 asar: true
 electronLanguages:
-  - en
+  - en-US
 directories:
   output: dist
 files:

--- a/apps/desktop/scripts/package-inventory.mjs
+++ b/apps/desktop/scripts/package-inventory.mjs
@@ -240,7 +240,7 @@ export function validateBuilderInventoryAuthority(config, desktopRoot, options =
     config.asar !== true ||
     !Array.isArray(config.electronLanguages) ||
     config.electronLanguages.length !== 1 ||
-    config.electronLanguages[0] !== "en" ||
+    config.electronLanguages[0] !== "en-US" ||
     !exactObject(config.directories) ||
     config.directories.output !== "dist" ||
     !Array.isArray(config.files) ||

--- a/apps/desktop/scripts/verify-windows-package.mjs
+++ b/apps/desktop/scripts/verify-windows-package.mjs
@@ -62,6 +62,7 @@ const expectedWindowsRuntime = new Set([
   "vk_swiftshader_icd.json",
   "vulkan-1.dll",
 ]);
+const expectedWindowsLocale = "locales/en-US.pak";
 const expectedAsarResourceFiles = new Set([
   "resources/tray.ico",
   "resources/trayTemplate.png",
@@ -212,6 +213,24 @@ function validateRuntimeEntryTypes(tree) {
     if (entry === undefined || entry.type !== expectedType) {
       failWindows("application-inventory", "application entry type is invalid", [name]);
     }
+  }
+}
+
+function validateRuntimeLocales(tree) {
+  const locale = tree.get(expectedWindowsLocale);
+  if (
+    locale === undefined ||
+    locale.type !== "file" ||
+    !Buffer.isBuffer(locale.bytes) ||
+    locale.bytes.length === 0
+  ) {
+    failWindows("application-inventory", "missing locale", [expectedWindowsLocale]);
+  }
+  const undeclared = [...tree.keys()].filter(
+    (path) => path.startsWith("locales/") && path !== expectedWindowsLocale,
+  );
+  if (undeclared.length > 0) {
+    failWindows("application-inventory", "undeclared locale", undeclared);
   }
 }
 
@@ -581,10 +600,7 @@ export async function verifyWindowsPackageLayout(application, options = {}) {
       "application entry",
     );
     validateRuntimeEntryTypes(tree);
-    const locales = [...tree.keys()].filter((path) => path.startsWith("locales/"));
-    if (locales.length > 0) {
-      failWindows("application-inventory", "undeclared locale", locales);
-    }
+    validateRuntimeLocales(tree);
     for (const [path, entry] of tree) {
       if (path === "resources" || path.startsWith("resources/")) continue;
       inspectPath(path, `win-unpacked/${path}`);

--- a/apps/desktop/tests/package-layout.test.ts
+++ b/apps/desktop/tests/package-layout.test.ts
@@ -147,7 +147,7 @@ function builderYaml(
     "productName: Enduragent",
     "asar: true",
     "electronLanguages:",
-    "  - en",
+    "  - en-US",
     "directories:",
     "  output: dist",
     "files:",
@@ -591,7 +591,7 @@ describe("desktop package layout", () => {
 
   it("pins the sole audited Electron locale", async () => {
     const fixture = await syntheticPackage();
-    const yaml = builderYaml().replace("electronLanguages:\n  - en\n", "");
+    const yaml = builderYaml().replace("electronLanguages:\n  - en-US\n", "");
     await writeFile(join(fixture.desktop, "electron-builder.yml"), yaml);
     await expect(
       verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
@@ -599,7 +599,15 @@ describe("desktop package layout", () => {
 
     await writeFile(
       join(fixture.desktop, "electron-builder.yml"),
-      builderYaml().replace("  - en\n", "  - en\n  - fr\n"),
+      builderYaml().replace("  - en-US\n", "  - en-US\n  - fr\n"),
+    );
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("invalid builder packaging authority");
+
+    await writeFile(
+      join(fixture.desktop, "electron-builder.yml"),
+      builderYaml().replace("  - en-US\n", "  - en\n"),
     );
     await expect(
       verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),

--- a/apps/desktop/tests/windows-package-layout.test.ts
+++ b/apps/desktop/tests/windows-package-layout.test.ts
@@ -172,7 +172,7 @@ function builderYaml(): string {
     "productName: Enduragent",
     "asar: true",
     "electronLanguages:",
-    "  - en",
+    "  - en-US",
     "directories:",
     "  output: dist",
     "files:",
@@ -292,6 +292,7 @@ async function syntheticWindowsPackage(): Promise<SyntheticWindowsPackage> {
     writeFile(join(externalSource, "self-test/matrix.json"), matrix),
     writeFile(join(externalSource, "self-test/matrix.sha256"), matrixChecksum),
     writeFile(join(externalSource, "self-test/self-test-runner.cjs"), runner),
+    writeFile(join(application, "locales/en-US.pak"), "synthetic locale\n"),
     writeFile(join(sourceResources, "tray.ico"), "tray ico\n"),
     writeFile(join(sourceResources, "trayTemplate.png"), "tray png\n"),
     writeFile(join(sourceResources, "trayTemplate@2x.png"), "tray 2x png\n"),
@@ -440,6 +441,34 @@ describe("Windows package verification", () => {
       verifyWindowsPackageLayout(fixture.application, { desktopRoot: fixture.desktop }),
     ).rejects.toThrow(
       'windows-package/application-inventory: undeclared application entry: "unexpected.bin"',
+    );
+  });
+
+  it("requires the shipped en-US locale pak", async () => {
+    const missing = await syntheticWindowsPackage();
+    await rm(join(missing.application, "locales/en-US.pak"));
+    await expect(
+      verifyWindowsPackageLayout(missing.application, { desktopRoot: missing.desktop }),
+    ).rejects.toThrow(
+      'windows-package/application-inventory: missing locale: "locales/en-US.pak"',
+    );
+
+    const empty = await syntheticWindowsPackage();
+    await writeFile(join(empty.application, "locales/en-US.pak"), "");
+    await expect(
+      verifyWindowsPackageLayout(empty.application, { desktopRoot: empty.desktop }),
+    ).rejects.toThrow(
+      'windows-package/application-inventory: missing locale: "locales/en-US.pak"',
+    );
+  });
+
+  it("rejects locales beyond the pinned en-US pak", async () => {
+    const fixture = await syntheticWindowsPackage();
+    await writeFile(join(fixture.application, "locales/fr.pak"), "synthetic locale\n");
+    await expect(
+      verifyWindowsPackageLayout(fixture.application, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow(
+      'windows-package/application-inventory: undeclared locale: "locales/fr.pak"',
     );
   });
 


### PR DESCRIPTION
## Why

The packaged Windows app shipped **zero** Chromium locale paks. `apps/desktop/electron-builder.yml` set `electronLanguages: [en]`, and `app-builder-lib@26.15.3` keeps a pak only when the (lowercased) wanted language equals the pak basename or `wantedLanguage.startsWith(basename + "-")` — an inverted prefix test. Electron ships `en-US.pak` and never a bare `en.pak`, so all 55 paks were deleted from `win-unpacked/locales/`. With no locale resource loaded, Blink null-dereferences in `blink::Locale::DefaultLocale` (via `NumberInputType::SetValue → LocalizeValue`) the first time the renderer writes a value into an `<input type="number">` — which is why Settings and the API-key setup card killed the renderer natively and silently while Chat (no number inputs) was fine. Native-hardware probe run `31620078522` proved causality: the identical build with the 55 paks copied back into `locales/` renders Settings (`VERDICT=rendered`).

macOS was never affected: its `en.lproj` survives via the same inverted branch, and it still does under `en-US` (`"en-us".startsWith("en-")`), so mac packaging is byte-identical to before.

## What changed

- `electron-builder.yml`: `electronLanguages: [en-US]`. The upstream filter lowercases wanted languages, so `en-us` exact-matches the `en-US.pak` basename.
- `scripts/package-inventory.mjs`: the builder-authority pin now requires `["en-US"]`.
- `scripts/verify-windows-package.mjs`: the locale invariant is inverted. It previously failed on **any** `locales/*` entry, which locked the bug in. It now requires `locales/en-US.pak` present and non-empty, and rejects every other locale entry. A missing or empty pak is the regression guard that would have caught this.
- Tests assert the new invariant: the synthetic Windows fixture ships a real pak, and three new negative cases cover missing pak, empty pak, and an extra locale — plus a case pinning that the old `- en` value is now rejected by the inventory validator.

## Verification

- `vitest run tests/windows-package-layout.test.ts tests/package-layout.test.ts` — 125 passed.
- Full desktop suite — 1727 passed, 1 pre-existing cwd-sensitive failure in `windows-parity-scenarios.test.ts` that also fails at the epic tip with this branch stashed; it passes when vitest runs from the repo root.
- Root `pnpm check` — exit 0.
- Read-only verification subagent traced the upstream filter, the verifier failure path, and the test diff; no findings.

Confirming the fix on native Windows hardware (probe re-run at the new epic tip) is a follow-up.
