### PR TITLE
feat(desktop): log renderer and child-process crashes from main

### DIFF
--- a/.changeset/crash-telemetry-desktop-main.md
+++ b/.changeset/crash-telemetry-desktop-main.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Log renderer and child-process crashes from the desktop main process and start Electron's crash reporter with local-only minidumps (`uploadToServer: false`). Fields are collapsed to one stderr line, query strings and fragments are dropped from the crashed URL, and oversized values are truncated.

--- a/apps/desktop/src/main/crash-telemetry.ts
+++ b/apps/desktop/src/main/crash-telemetry.ts
@@ -1,0 +1,105 @@
+import type { App, CrashReporter } from "electron";
+import { createSafeLog } from "./safe-log.js";
+
+export const DESKTOP_CRASH_TELEMETRY_FIELD_LIMIT = 120;
+
+export type DesktopCrashReporterPort = Pick<CrashReporter, "start">;
+export type DesktopCrashTelemetryAppPort = Pick<App, "on">;
+
+export type DesktopCrashReporterOutcome = "started" | "unavailable";
+
+export interface DesktopRenderProcessGoneFields {
+  readonly url: string;
+  readonly title: string;
+  readonly reason: string;
+  readonly exitCode: number;
+}
+
+export interface DesktopChildProcessGoneFields {
+  readonly type: string;
+  readonly reason: string;
+  readonly exitCode: number;
+  readonly name?: string;
+}
+
+function telemetryField(value: string | undefined): string {
+  const collapsed = (value ?? "").replaceAll(/[\s\p{C}]+/gu, "_");
+  if (collapsed.length === 0) return "unknown";
+  if (collapsed.length <= DESKTOP_CRASH_TELEMETRY_FIELD_LIMIT) return collapsed;
+  return `${collapsed.slice(0, DESKTOP_CRASH_TELEMETRY_FIELD_LIMIT)}...`;
+}
+
+function telemetryLocation(value: string | undefined): string {
+  return telemetryField((value ?? "").split(/[?#]/u)[0]);
+}
+
+function telemetryExitCode(value: number | undefined): string {
+  return Number.isInteger(value) ? String(value) : "unknown";
+}
+
+export function describeRenderProcessGone(fields: DesktopRenderProcessGoneFields): string {
+  return [
+    "desktop-renderer-process-gone",
+    `reason=${telemetryField(fields.reason)}`,
+    `exitCode=${telemetryExitCode(fields.exitCode)}`,
+    `url=${telemetryLocation(fields.url)}`,
+    `title=${telemetryField(fields.title)}`,
+  ].join(" ");
+}
+
+export function describeChildProcessGone(fields: DesktopChildProcessGoneFields): string {
+  return [
+    "desktop-child-process-gone",
+    `type=${telemetryField(fields.type)}`,
+    `reason=${telemetryField(fields.reason)}`,
+    `exitCode=${telemetryExitCode(fields.exitCode)}`,
+    `name=${telemetryField(fields.name)}`,
+  ].join(" ");
+}
+
+export function startDesktopCrashReporter(input: {
+  readonly crashReporter: DesktopCrashReporterPort;
+  readonly log?: (message: string) => void;
+}): DesktopCrashReporterOutcome {
+  const log = createSafeLog(input.log);
+  try {
+    input.crashReporter.start({ uploadToServer: false });
+    return "started";
+  } catch {
+    log("desktop-crash-reporter-unavailable");
+    return "unavailable";
+  }
+}
+
+export function installDesktopCrashTelemetry(input: {
+  readonly app: DesktopCrashTelemetryAppPort;
+  readonly log?: (message: string) => void;
+}): void {
+  const log = createSafeLog(input.log);
+  input.app.on("render-process-gone", (_event, webContents, details) => {
+    let url = "";
+    let title = "";
+    try {
+      url = webContents.getURL();
+      title = webContents.getTitle();
+    } catch {}
+    log(
+      describeRenderProcessGone({
+        url,
+        title,
+        reason: details.reason,
+        exitCode: details.exitCode,
+      }),
+    );
+  });
+  input.app.on("child-process-gone", (_event, details) => {
+    log(
+      describeChildProcessGone({
+        type: details.type,
+        reason: details.reason,
+        exitCode: details.exitCode,
+        name: details.name,
+      }),
+    );
+  });
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ import {
   app,
   BrowserWindow,
   clipboard,
+  crashReporter,
   dialog,
   ipcMain,
   powerMonitor,
@@ -21,6 +22,7 @@ import {
 import { createChatGptAuth, hasChatGptProfile } from "./chatgpt-auth.js";
 import { createClaudeCliStatus, readClaudeCliSettings } from "./claude-cli-status.js";
 import { installDesktopConnectionIpc } from "./connection-ipc.js";
+import { installDesktopCrashTelemetry, startDesktopCrashReporter } from "./crash-telemetry.js";
 import { bindDesktopAppUserModelId, createDesktopActivationRelay } from "./desktop-lifecycle.js";
 import { installDesktopExternalLinkIpc } from "./external-link-ipc.js";
 import { DESKTOP_LIFECYCLE_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
@@ -117,6 +119,8 @@ import {
 
 bindDesktopAppUserModelId(app);
 bindWindowsUserData(app);
+startDesktopCrashReporter({ crashReporter });
+installDesktopCrashTelemetry({ app });
 registerDesktopScheme();
 
 function disableChromiumMediaSessionIntegration(): void {

--- a/apps/desktop/tests/crash-telemetry.test.ts
+++ b/apps/desktop/tests/crash-telemetry.test.ts
@@ -1,0 +1,177 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DESKTOP_CRASH_TELEMETRY_FIELD_LIMIT,
+  describeChildProcessGone,
+  describeRenderProcessGone,
+  installDesktopCrashTelemetry,
+  startDesktopCrashReporter,
+} from "../src/main/crash-telemetry.js";
+
+type Listener = (...args: any[]) => void;
+
+function appPort() {
+  const listeners = new Map<string, Listener[]>();
+  const on = vi.fn((name: string, listener: Listener) => {
+    listeners.set(name, [...(listeners.get(name) ?? []), listener]);
+    return undefined;
+  });
+  return {
+    port: { on } as never,
+    on,
+    emit(name: string, ...args: unknown[]) {
+      for (const listener of listeners.get(name) ?? []) listener(...args);
+    },
+    names: () => [...listeners.keys()],
+  };
+}
+
+function webContents(url: string, title: string) {
+  return { getURL: () => url, getTitle: () => title };
+}
+
+describe("desktop crash telemetry", () => {
+  it("registers both crash listeners on the supplied app", () => {
+    const app = appPort();
+
+    installDesktopCrashTelemetry({ app: app.port, log: vi.fn() });
+
+    expect(app.names().sort()).toEqual(["child-process-gone", "render-process-gone"]);
+    expect(app.on).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs the renderer crash reason, exit code, url, and title", () => {
+    const app = appPort();
+    const log = vi.fn();
+
+    installDesktopCrashTelemetry({ app: app.port, log });
+    app.emit(
+      "render-process-gone",
+      {},
+      webContents("enduragent://app/index.html", "Enduragent"),
+      { reason: "crashed", exitCode: 133 },
+    );
+
+    expect(log).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith(
+      "desktop-renderer-process-gone reason=crashed exitCode=133 url=enduragent://app/index.html title=Enduragent",
+    );
+  });
+
+  it("logs the child process type, reason, exit code, and name", () => {
+    const app = appPort();
+    const log = vi.fn();
+
+    installDesktopCrashTelemetry({ app: app.port, log });
+    app.emit("child-process-gone", {}, {
+      type: "Utility",
+      reason: "oom",
+      exitCode: 9,
+      name: "enduragent desktop runtime",
+    });
+
+    expect(log).toHaveBeenCalledWith(
+      "desktop-child-process-gone type=Utility reason=oom exitCode=9 name=enduragent_desktop_runtime",
+    );
+  });
+
+  it("keeps the renderer crash line closed over query strings, fragments, and control characters", () => {
+    const line = describeRenderProcessGone({
+      url: "enduragent://app/index.html?token=secret-value#fragment",
+      title: "Enduragent\nsecond line",
+      reason: "abnormal-exit",
+      exitCode: 0,
+    });
+
+    expect(line).toBe(
+      "desktop-renderer-process-gone reason=abnormal-exit exitCode=0 url=enduragent://app/index.html title=Enduragent_second_line",
+    );
+    expect(line).not.toContain("secret");
+    expect(line).not.toContain("fragment");
+    expect(line.split("\n")).toHaveLength(1);
+  });
+
+  it("truncates oversized fields and marks missing ones", () => {
+    const line = describeChildProcessGone({
+      type: "Utility",
+      reason: "x".repeat(DESKTOP_CRASH_TELEMETRY_FIELD_LIMIT + 40),
+      exitCode: Number.NaN,
+    });
+
+    expect(line).toBe(
+      `desktop-child-process-gone type=Utility reason=${"x".repeat(DESKTOP_CRASH_TELEMETRY_FIELD_LIMIT)}... exitCode=unknown name=unknown`,
+    );
+  });
+
+  it("survives a webContents that refuses to describe itself", () => {
+    const app = appPort();
+    const log = vi.fn();
+
+    installDesktopCrashTelemetry({ app: app.port, log });
+    app.emit(
+      "render-process-gone",
+      {},
+      {
+        getURL() {
+          throw new TypeError("destroyed");
+        },
+        getTitle() {
+          throw new TypeError("destroyed");
+        },
+      },
+      { reason: "killed", exitCode: 1 },
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      "desktop-renderer-process-gone reason=killed exitCode=1 url=unknown title=unknown",
+    );
+  });
+
+  it("swallows a failing log sink instead of breaking the crash path", () => {
+    const app = appPort();
+    const log = vi.fn(() => {
+      throw new TypeError("stderr closed");
+    });
+
+    installDesktopCrashTelemetry({ app: app.port, log });
+
+    expect(() => {
+      app.emit("child-process-gone", {}, { type: "GPU", reason: "crashed", exitCode: 5 });
+    }).not.toThrow();
+    expect(log).toHaveBeenCalledOnce();
+  });
+
+  it("collects local minidumps without uploading them anywhere", () => {
+    const start = vi.fn();
+
+    expect(startDesktopCrashReporter({ crashReporter: { start }, log: vi.fn() })).toBe("started");
+    expect(start).toHaveBeenCalledOnce();
+    expect(start).toHaveBeenCalledWith({ uploadToServer: false });
+  });
+
+  it("reports an unavailable crash reporter without failing startup", () => {
+    const log = vi.fn();
+    const start = vi.fn(() => {
+      throw new TypeError("crashpad unavailable");
+    });
+
+    expect(startDesktopCrashReporter({ crashReporter: { start }, log })).toBe("unavailable");
+    expect(log).toHaveBeenCalledWith("desktop-crash-reporter-unavailable");
+    expect(JSON.stringify(log.mock.calls)).not.toContain("crashpad unavailable");
+  });
+
+  it("starts the crash reporter and the listeners before any window in the production entry", async () => {
+    const source = await readFile(new URL("../src/main/index.ts", import.meta.url), "utf8");
+    const userData = source.indexOf("bindWindowsUserData(app);");
+    const reporter = source.indexOf("startDesktopCrashReporter({ crashReporter });");
+    const telemetry = source.indexOf("installDesktopCrashTelemetry({ app });");
+
+    expect(userData).toBeGreaterThanOrEqual(0);
+    expect(reporter).toBeGreaterThan(userData);
+    expect(telemetry).toBeGreaterThan(reporter);
+    expect(telemetry).toBeLessThan(source.indexOf("registerDesktopScheme();"));
+    expect(telemetry).toBeLessThan(source.indexOf("app.requestSingleInstanceLock();"));
+    expect(telemetry).toBeLessThan(source.indexOf("await app.whenReady();"));
+    expect(telemetry).toBeLessThan(source.indexOf("new BrowserWindow("));
+  });
+});

--- a/apps/desktop/tests/residency.test.ts
+++ b/apps/desktop/tests/residency.test.ts
@@ -75,11 +75,13 @@ const mocks = vi.hoisted(() => {
     BrowserWindow: vi.fn(),
     supervisor: vi.fn(),
     registerDesktopScheme: vi.fn(),
+    crashReporter: { start: vi.fn() },
   };
 });
 
 vi.mock("electron", () => ({
   app: mocks.app,
+  crashReporter: mocks.crashReporter,
   BrowserWindow: mocks.BrowserWindow,
   Menu: { buildFromTemplate: mocks.buildFromTemplate },
   Tray: mocks.FakeTray,
@@ -688,6 +690,9 @@ describe("desktop residency", () => {
     expect(source).toContain("if (!primaryInstance) {\n  app.exit(0);");
     mocks.app.requestSingleInstanceLock.mockReturnValueOnce(false);
     await import("../src/main/index.js");
+    expect(mocks.crashReporter.start).toHaveBeenCalledWith({ uploadToServer: false });
+    expect(mocks.app.listenerCount("render-process-gone")).toBe(1);
+    expect(mocks.app.listenerCount("child-process-gone")).toBe(1);
     expect(mocks.app.exit).toHaveBeenCalledWith(0);
     expect(mocks.app.whenReady).not.toHaveBeenCalled();
     expect(mocks.app.commandLine.appendSwitch).not.toHaveBeenCalled();


### PR DESCRIPTION
## Why

Issue 282's Settings-blanking crash shipped invisible: the app had no `render-process-gone` handler, no `child-process-gone` handler, and no crashpad handler, so the renderer self-terminated with `kTerminationCodeNotConnectedToHandler` and left nothing behind — no WER event, no stderr line, no dump. Diagnosis needed a debugger attached to a CI runner. This PR closes that hole so the next crash of this class leaves evidence.

## What

- New `apps/desktop/src/main/crash-telemetry.ts`:
  - `installDesktopCrashTelemetry({ app, log })` registers `render-process-gone` (logs reason, exit code, crashed page URL and title) and `child-process-gone` (logs type, reason, exit code, name).
  - `startDesktopCrashReporter({ crashReporter, log })` starts Electron's crash reporter with `uploadToServer: false` — minidumps land in `app.getPath("crashDumps")`, nothing is uploaded, no `submitURL`, no PII leaves the machine. A throw returns `"unavailable"` and logs `desktop-crash-reporter-unavailable` instead of killing startup.
  - Both use the existing `createSafeLog` seam, so the production sink is the same one-line-per-event `desktop-*` stderr idiom as `desktop-update-version-floor-unavailable` and `desktop-residency-failure`.
- `apps/desktop/src/main/index.ts` wires both at module top level, immediately after `bindWindowsUserData(app)` and before `registerDesktopScheme()`, the single-instance lock, `app.whenReady()`, and any `BrowserWindow`.

## Ordering rationale

`bindWindowsUserData` rebinds `userData` on Windows, and `crashDumps` derives from `userData`; starting the reporter after that binding keeps dumps under `%LOCALAPPDATA%\Enduragent` instead of the pre-rebind default. Lines above that binding remain uncovered — a deliberate trade, pinned by an ordering test.

## Log shape and privacy

Renderer- and page-controlled strings are sanitized before they reach stderr: whitespace and control characters collapse to `_` (a title cannot forge a field or break the one-line shape), and the URL is cut at the first `?` or `#` so query strings and fragments never land in a log.

`desktop-renderer-process-gone reason=crashed exitCode=133 url=enduragent://app/index.html title=Enduragent`
`desktop-child-process-gone type=Utility reason=oom exitCode=9 name=Network_Service`

## Limits

- `DESKTOP_CRASH_TELEMETRY_FIELD_LIMIT = 120` — per-field character cap before truncation, so a hostile or pathological title cannot write an unbounded line to stderr.

## Tests

- New `apps/desktop/tests/crash-telemetry.test.ts` (10 cases): both listeners registered, both log lines byte-exact, query/fragment/control-character sanitization, truncation and missing-field markers, a `webContents` that throws on `getURL`/`getTitle`, a throwing log sink, `crashReporter.start` called with exactly `{ uploadToServer: false }`, reporter failure reported without startup failure, and a source-order assertion that the reporter and listeners precede scheme registration, the instance lock, `whenReady`, and window creation.
- `apps/desktop/tests/residency.test.ts` gains the `crashReporter` electron mock plus three assertions on the real entry module (`start` called with `uploadToServer: false`, one listener registered per crash event) — additive, nothing removed or relaxed.

## Verification

`pnpm -r build`; `pnpm --filter @enduragent/desktop test` → 1737 passed, 1 failure in `windows-parity-scenarios.test.ts` from the known cwd-sensitivity under `--filter`, re-run green from the repo root (30/30); root `pnpm check` green; `oxlint apps/desktop` clean apart from a pre-existing warning in `scripts/electron-smoke.mjs`.

## Residual

The stderr sink is only readable when the launch is redirected; a packaged Windows GUI launch has no console. The durable field artifact from this PR is the minidump, not the log line. A durable log file remains unbuilt.
