### PR TITLE
fix(core): stop gating ChatGPT tokens on the local clock

### DIFF
--- a/.changeset/chatgpt-clock-skew-tolerance.md
+++ b/.changeset/chatgpt-clock-skew-tolerance.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: ChatGPT sign-in now keeps working on machines with a wrong clock, and sign-in problems show up as authentication errors instead of a generic failure.
+
+Token validity no longer depends on the local wall clock: the ChatGPT-lane token readers return the stored access token as-is and treat a server 401 as the only invalid signal, with one bounded refresh-and-retry per generation (MAX_AUTH_REFRESH_ATTEMPTS = 1). HTTP 401/403 from the provider is classified as error_class "auth" in turn_outcome. Coaching dates and daily resets intentionally stay on the local clock.

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -606,10 +606,7 @@ function credential(value: unknown): OAuthCredential {
   return candidate as unknown as OAuthCredential;
 }
 
-function createAccessTokenReader(
-  configDir: string,
-  now: () => number,
-): EngineHostPorts["getAccessToken"] {
+function createAccessTokenReader(configDir: string): EngineHostPorts["getAccessToken"] {
   const path = join(configDir, "auth-profiles.json");
   const queues = new Map<string, Promise<string>>();
   const delay = (milliseconds: number, signal?: AbortSignal): Promise<void> => {
@@ -663,11 +660,15 @@ function createAccessTokenReader(
       }
     }
   };
-  const exclusive = async (profileName: string, signal?: AbortSignal): Promise<string> => {
+  const exclusive = async (
+    profileName: string,
+    signal?: AbortSignal,
+    rejectedAccessToken?: string,
+  ): Promise<string> => {
     const snapshot = loadStoredProfileSnapshot(path, profileName);
     if (snapshot === null) throw new TypeError("OAuth profile is invalid.");
     const current = credential(snapshot.profile);
-    if (Number.isFinite(current.expires) && now() <= current.expires - 300_000) {
+    if (rejectedAccessToken === undefined || current.access !== rejectedAccessToken) {
       return current.access;
     }
     const { refreshed, requestSnapshot, requestProfile } = await refresh(
@@ -689,11 +690,11 @@ function createAccessTokenReader(
     if (saved.status === "missing") throw new TypeError("OAuth profile is invalid.");
     return credential(saved.profile).access;
   };
-  return async (profileName, signal) => {
+  return async (profileName, signal, rejectedAccessToken) => {
     const previous = queues.get(profileName) ?? Promise.resolve("");
     const current = previous.then(
-      () => exclusive(profileName, signal),
-      () => exclusive(profileName, signal),
+      () => exclusive(profileName, signal, rejectedAccessToken),
+      () => exclusive(profileName, signal, rejectedAccessToken),
     );
     queues.set(profileName, current);
     try {
@@ -805,7 +806,7 @@ export async function createLocalCoachComposition(
     await runtime.runWindow();
     runtime.startScheduler();
     const logger = createSubsystemLogger("agent", input.home.root);
-    const getAccessToken = createAccessTokenReader(input.home.configDir, now);
+    const getAccessToken = createAccessTokenReader(input.home.configDir);
     const repository = (dependencies.createRepository ?? createAnchorRepository)(
       input.context.store,
     );

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -331,6 +331,27 @@ function tokenResponse(access: string, refresh = "synthetic-rotated-refresh"): R
   );
 }
 
+function codexTextResponse(text: string): Response {
+  const events = [
+    {
+      type: "response.output_item.done",
+      item: { type: "message", content: [{ type: "output_text", text }] },
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "synthetic-response",
+        status: "completed",
+        usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+      },
+    },
+  ];
+  return new Response(
+    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") + "data: [DONE]\n\n",
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  );
+}
+
 async function writeExpiredOAuthProfile(home: AthleteHome): Promise<void> {
   await writeFile(
     join(home.configDir, "auth-profiles.json"),
@@ -579,6 +600,95 @@ describe("local coach composition", () => {
     await lifecycle.close();
   });
 
+  it.each([
+    { skewHours: -2, expiresFromServerNowMs: -60 * 60_000, rejectedByServer: true },
+    { skewHours: 2, expiresFromServerNowMs: 60 * 60_000, rejectedByServer: false },
+  ])(
+    "completes a ChatGPT-lane turn with a $skewHours-hour local clock skew",
+    async ({ skewHours, expiresFromServerNowMs, rejectedByServer }) => {
+      const home = await freshHome();
+      const serverNow = Date.parse("1998-07-18T12:00:00.000Z");
+      const storedAccess = codexAccessToken("synthetic-stored-account");
+      const refreshedAccess = codexAccessToken("synthetic-refreshed-account");
+      const profilesPath = join(home.configDir, "auth-profiles.json");
+      await writeFile(
+        profilesPath,
+        JSON.stringify({
+          "openai-codex": {
+            type: "oauth",
+            access: storedAccess,
+            refresh: "synthetic-refresh",
+            expires: serverNow + expiresFromServerNowMs,
+            accountId: "synthetic-stored-account",
+          },
+        }),
+        { mode: 0o600 },
+      );
+      let tokenRequests = 0;
+      const authorizations: string[] = [];
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "https://auth.openai.com/oauth/token") {
+          tokenRequests++;
+          return tokenResponse(refreshedAccess);
+        }
+        if (url === "https://chatgpt.com/backend-api/codex/responses") {
+          const authorization = new Headers(init?.headers).get("authorization") ?? "";
+          authorizations.push(authorization);
+          if (rejectedByServer && authorization === `Bearer ${storedAccess}`) {
+            return new Response(
+              JSON.stringify({ error: { code: "invalid_token", message: "expired" } }),
+              { status: 401 },
+            );
+          }
+          return codexTextResponse("clock-safe reply");
+        }
+        throw new Error(`Unexpected request: ${url}`);
+      });
+      const base = config(home);
+      const lifecycle = await compose(
+        home,
+        {
+          bootstrap: async () => reference(),
+          createRuntime: () => runtime(),
+          createRepository: () => ({
+            insertIfAbsent: async () => false,
+            readCurrent: async () => undefined,
+          }),
+          createResolver: () => missingResolver(),
+          now: () => serverNow + skewHours * 60 * 60_000,
+          randomId: () => `synthetic-skew-${skewHours}`,
+        },
+        fakeContext(home),
+        undefined,
+        {
+          ...base,
+          llm: {
+            provider: "openai-codex",
+            model: "gpt-5.4",
+            apiKey: "",
+            authProfile: "openai-codex",
+          },
+        },
+      );
+
+      try {
+        await expect(
+          lifecycle.engine.chat({ chatId: "desktop", message: "hello" }),
+        ).resolves.toEqual({ text: "clock-safe reply" });
+        expect(tokenRequests).toBe(rejectedByServer ? 1 : 0);
+        expect(authorizations[0]).toBe(`Bearer ${storedAccess}`);
+        expect(authorizations.length).toBeGreaterThan(0);
+        const acceptedAccess = rejectedByServer ? refreshedAccess : storedAccess;
+        expect(authorizations.slice(1).every((value) => value === `Bearer ${acceptedAccess}`)).toBe(
+          true,
+        );
+      } finally {
+        await lifecycle.close();
+      }
+    },
+  );
+
   it("carries an explicit refresh rejection through the composed desktop ports", async () => {
     const home = await freshHome();
     await writeExpiredOAuthProfile(home);
@@ -604,10 +714,12 @@ describe("local coach composition", () => {
     });
 
     vi.useFakeTimers();
-    const settled = received!.ports.getAccessToken("openai-codex").then(
-      () => null,
-      (error: unknown) => error,
-    );
+    const settled = received!.ports
+      .getAccessToken("openai-codex", undefined, "synthetic-expired-access")
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
     await vi.advanceTimersByTimeAsync(2_000);
     const failure = await settled;
 
@@ -640,7 +752,9 @@ describe("local coach composition", () => {
       now: () => 1_000,
     });
 
-    const failure = await received!.ports.getAccessToken("openai-codex").catch((error) => error);
+    const failure = await received!.ports
+      .getAccessToken("openai-codex", undefined, "synthetic-expired-access")
+      .catch((error) => error);
 
     expect(received!.ports.classifyFailure(failure)).toBe("server_error");
     expect(failure).toMatchObject({ refreshFailureReason: "server_error" });
@@ -679,8 +793,8 @@ describe("local coach composition", () => {
 
     await expect(
       Promise.all([
-        engineInput.ports.getAccessToken("openai-codex"),
-        engineInput.ports.getAccessToken("openai-codex"),
+        engineInput.ports.getAccessToken("openai-codex", undefined, "synthetic-expired-access"),
+        engineInput.ports.getAccessToken("openai-codex", undefined, "synthetic-expired-access"),
       ]),
     ).resolves.toEqual([refreshedAccess, refreshedAccess]);
 
@@ -724,7 +838,11 @@ describe("local coach composition", () => {
     const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
 
     vi.useFakeTimers();
-    const pending = engineInput.ports.getAccessToken("openai-codex");
+    const pending = engineInput.ports.getAccessToken(
+      "openai-codex",
+      undefined,
+      "synthetic-expired-access",
+    );
     await vi.advanceTimersByTimeAsync(2_000);
     await expect(pending).resolves.toBe(refreshedAccess);
 
@@ -752,10 +870,12 @@ describe("local coach composition", () => {
     const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
 
     vi.useFakeTimers();
-    const settled = engineInput.ports.getAccessToken("openai-codex").then(
-      () => null,
-      (error: unknown) => error,
-    );
+    const settled = engineInput.ports
+      .getAccessToken("openai-codex", undefined, "synthetic-expired-access")
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
     await vi.advanceTimersByTimeAsync(2_000);
     await expect(settled).resolves.toMatchObject({ message: "OAuth profile is invalid." });
 
@@ -780,10 +900,12 @@ describe("local coach composition", () => {
     const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
 
     vi.useFakeTimers();
-    const settled = engineInput.ports.getAccessToken("openai-codex").then(
-      () => null,
-      (error: unknown) => error,
-    );
+    const settled = engineInput.ports
+      .getAccessToken("openai-codex", undefined, "synthetic-expired-access")
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
     await vi.advanceTimersByTimeAsync(2_000);
     await expect(settled).resolves.toMatchObject({ message: "OAuth profile is invalid." });
 
@@ -805,10 +927,12 @@ describe("local coach composition", () => {
     const abortReason = new Error("synthetic caller abort");
 
     vi.useFakeTimers();
-    const settled = engineInput.ports.getAccessToken("openai-codex", controller.signal).then(
-      () => null,
-      (error: unknown) => error,
-    );
+    const settled = engineInput.ports
+      .getAccessToken("openai-codex", controller.signal, "synthetic-expired-access")
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
     await vi.advanceTimersByTimeAsync(0);
     expect(fetchStub).toHaveBeenCalledTimes(1);
     controller.abort(abortReason);
@@ -837,9 +961,13 @@ describe("local coach composition", () => {
     const fetchStub = vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
     const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
 
-    await expect(engineInput.ports.getAccessToken("openai-codex", controller.signal)).resolves.toBe(
-      refreshedAccess,
-    );
+    await expect(
+      engineInput.ports.getAccessToken(
+        "openai-codex",
+        controller.signal,
+        "synthetic-expired-access",
+      ),
+    ).resolves.toBe(refreshedAccess);
 
     expect(controller.signal.reason).toBe(abortReason);
     expect(fetchStub).toHaveBeenCalledTimes(1);
@@ -868,9 +996,9 @@ describe("local coach composition", () => {
     });
     const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
 
-    await expect(engineInput.ports.getAccessToken("openai-codex")).resolves.toBe(
-      "synthetic-concurrent-access",
-    );
+    await expect(
+      engineInput.ports.getAccessToken("openai-codex", undefined, "synthetic-expired-access"),
+    ).resolves.toBe("synthetic-concurrent-access");
 
     expect(fetchStub).toHaveBeenCalledTimes(1);
     expect(JSON.parse(await readFile(profilesPath, "utf8"))["openai-codex"]).toEqual({
@@ -894,9 +1022,9 @@ describe("local coach composition", () => {
     });
     const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
 
-    await expect(engineInput.ports.getAccessToken("openai-codex")).rejects.toThrow(
-      "OAuth profile is invalid.",
-    );
+    await expect(
+      engineInput.ports.getAccessToken("openai-codex", undefined, "synthetic-expired-access"),
+    ).rejects.toThrow("OAuth profile is invalid.");
 
     expect(fetchStub).toHaveBeenCalledTimes(1);
     await expect(readFile(profilesPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });

--- a/packages/core/src/auth/profiles.ts
+++ b/packages/core/src/auth/profiles.ts
@@ -32,7 +32,6 @@ export interface OAuthCredential extends StoredProfile {
 // ============================================================================
 
 const PROFILES_FILE = join(CONFIG_DIR, "auth-profiles.json");
-const REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
 
 interface OAuthProfileSnapshot {
   readonly profile: OAuthCredential;
@@ -83,11 +82,6 @@ export function loadProfile(name: string): OAuthCredential | null {
 
 export function saveProfile(name: string, cred: OAuthCredential): void {
   recoverAndSaveStoredProfile(PROFILES_FILE, name, cred);
-}
-
-function isExpiredOrUnusable(cred: OAuthCredential): boolean {
-  if (!Number.isFinite(cred.expires)) return true;
-  return Date.now() > cred.expires - REFRESH_THRESHOLD_MS;
 }
 
 // ============================================================================
@@ -145,11 +139,15 @@ async function refreshWithReauthConfirmation(
 
 const refreshQueues = new Map<string, Promise<unknown>>();
 
-export async function getFreshToken(name: string, signal?: AbortSignal): Promise<string> {
+export async function getFreshToken(
+  name: string,
+  signal?: AbortSignal,
+  rejectedAccessToken?: string,
+): Promise<string> {
   const prev = refreshQueues.get(name) ?? Promise.resolve();
   const run = prev.then(
-    () => getFreshTokenExclusive(name, signal),
-    () => getFreshTokenExclusive(name, signal),
+    () => getFreshTokenExclusive(name, signal, rejectedAccessToken),
+    () => getFreshTokenExclusive(name, signal, rejectedAccessToken),
   );
   refreshQueues.set(name, run);
   try {
@@ -161,12 +159,16 @@ export async function getFreshToken(name: string, signal?: AbortSignal): Promise
   }
 }
 
-async function getFreshTokenExclusive(name: string, signal?: AbortSignal): Promise<string> {
+async function getFreshTokenExclusive(
+  name: string,
+  signal?: AbortSignal,
+  rejectedAccessToken?: string,
+): Promise<string> {
   const initial = loadOAuthProfileSnapshot(name);
   if (initial === null) throw missingProfile(name);
   const cred = initial.profile;
 
-  if (!isExpiredOrUnusable(cred)) {
+  if (rejectedAccessToken === undefined || cred.access !== rejectedAccessToken) {
     return cred.access;
   }
 

--- a/packages/core/tests/auth-profiles.test.ts
+++ b/packages/core/tests/auth-profiles.test.ts
@@ -131,7 +131,7 @@ describe("auth/profiles", () => {
     expect(token).toBe("cached-access");
   });
 
-  it("getFreshToken refreshes when expires is non-finite", async () => {
+  it("getFreshToken returns stored access when expires is non-finite", async () => {
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
 
@@ -153,14 +153,14 @@ describe("auth/profiles", () => {
       expires: Number.NaN,
     });
     const token = await getFreshToken("openai-codex");
-    expect(token).toBe("new-access");
+    expect(token).toBe("old");
 
     const saved = JSON.parse(readFileSync(profilesPath(), "utf-8"));
-    expect(saved["openai-codex"].access).toBe("new-access");
-    expect(saved["openai-codex"].refresh).toBe("new-refresh");
+    expect(saved["openai-codex"].access).toBe("old");
+    expect(saved["openai-codex"].refresh).toBe("old-refresh");
   });
 
-  it("getFreshToken refreshes when within 5-min threshold", async () => {
+  it("getFreshToken returns stored access when within the former 5-min threshold", async () => {
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
 
@@ -179,13 +179,41 @@ describe("auth/profiles", () => {
       type: "oauth",
       access: "old",
       refresh: "old-refresh",
-      expires: Date.now() + 2 * 60_000, // 2 min from now — inside threshold
+      expires: Date.now() + 2 * 60_000,
     });
     const token = await getFreshToken("openai-codex");
-    expect(token).toBe("rotated");
+    expect(token).toBe("old");
   });
 
-  it("getFreshToken preserves a newer profile when an ordinary refresh resolves stale", async () => {
+  it.each([-2, 2])(
+    "getFreshToken returns stored access with a %i-hour local clock skew",
+    async (skewHours) => {
+      const { mkdirSync } = await import("node:fs");
+      mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+      const serverNow = Date.parse("1998-07-18T12:00:00.000Z");
+      vi.useFakeTimers();
+      vi.setSystemTime(serverNow + skewHours * 60 * 60_000);
+      const refreshMock = vi.fn();
+      vi.doMock("../src/agent/codex/oauth.js", () => ({
+        refreshCodexToken: refreshMock,
+        loginCodex: vi.fn(),
+      }));
+
+      const { saveProfile, getFreshToken } = await loadModule();
+      saveProfile("openai-codex", {
+        type: "oauth",
+        access: "stored-access",
+        refresh: "refresh",
+        expires: serverNow + 60 * 60_000,
+      });
+
+      await expect(getFreshToken("openai-codex")).resolves.toBe("stored-access");
+      expect(refreshMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("getFreshToken preserves a newer profile when a rejection refresh resolves stale", async () => {
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
 
@@ -221,7 +249,7 @@ describe("auth/profiles", () => {
     };
     saveProfile("openai-codex", original);
 
-    const settled = getFreshToken("openai-codex");
+    const settled = getFreshToken("openai-codex", undefined, "original-access");
     await vi.waitFor(() => expect(refreshMock).toHaveBeenCalledTimes(1));
     saveProfile("openai-codex", newer);
     const newerBytes = readFileSync(profilesPath(), "utf-8");
@@ -233,7 +261,7 @@ describe("auth/profiles", () => {
     expect(refreshMock).toHaveBeenCalledWith("original-refresh", undefined);
   });
 
-  it("getFreshToken does not resurrect a profile deleted during an ordinary refresh", async () => {
+  it("getFreshToken does not resurrect a profile deleted during a rejection refresh", async () => {
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
 
@@ -260,7 +288,7 @@ describe("auth/profiles", () => {
       email: "original@example.test",
     });
 
-    const settled = getFreshToken("openai-codex");
+    const settled = getFreshToken("openai-codex", undefined, "original-access");
     await vi.waitFor(() => expect(refreshMock).toHaveBeenCalledTimes(1));
     unlinkSync(profilesPath());
     pendingRefresh.resolve(staleRefresh);
@@ -293,7 +321,7 @@ describe("auth/profiles", () => {
     });
 
     vi.useFakeTimers();
-    const settled = getFreshToken("openai-codex").then(
+    const settled = getFreshToken("openai-codex", undefined, "original-access").then(
       () => null,
       (error: unknown) => error,
     );
@@ -326,7 +354,7 @@ describe("auth/profiles", () => {
     });
 
     vi.useFakeTimers();
-    const settled = getFreshToken("openai-codex").then(
+    const settled = getFreshToken("openai-codex", undefined, "old").then(
       () => null,
       (err: unknown) => err,
     );
@@ -359,7 +387,7 @@ describe("auth/profiles", () => {
       });
 
       vi.useFakeTimers();
-      const error = await getFreshToken("openai-codex").then(
+      const error = await getFreshToken("openai-codex", undefined, "old").then(
         () => null,
         (failure: unknown) => failure,
       );
@@ -396,7 +424,7 @@ describe("auth/profiles", () => {
       });
 
       vi.useFakeTimers();
-      const settled = getFreshToken("openai-codex").then(
+      const settled = getFreshToken("openai-codex", undefined, "synthetic-access").then(
         () => null,
         (error: unknown) => error,
       );
@@ -455,7 +483,7 @@ describe("auth/profiles", () => {
     });
 
     vi.useFakeTimers();
-    const settled = getFreshToken("openai-codex");
+    const settled = getFreshToken("openai-codex", undefined, "old");
     await vi.advanceTimersByTimeAsync(2_000);
     expect(await settled).toBe("confirmed-access");
     expect(refreshMock).toHaveBeenCalledTimes(2);
@@ -515,7 +543,7 @@ describe("auth/profiles", () => {
     saveProfile("openai-codex", original);
 
     vi.useFakeTimers();
-    const settled = getFreshToken("openai-codex");
+    const settled = getFreshToken("openai-codex", undefined, "original-access");
     await vi.advanceTimersByTimeAsync(2_000);
     expect(refreshMock).toHaveBeenCalledTimes(2);
     saveProfile("openai-codex", newer);
@@ -559,7 +587,7 @@ describe("auth/profiles", () => {
     });
 
     vi.useFakeTimers();
-    const settled = getFreshToken("openai-codex").then(
+    const settled = getFreshToken("openai-codex", undefined, "original-access").then(
       () => null,
       (error: unknown) => error,
     );
@@ -606,7 +634,7 @@ describe("auth/profiles", () => {
       expires: Date.now() - 1_000,
     });
 
-    await expect(getFreshToken("openai-codex", controller.signal)).resolves.toBe(
+    await expect(getFreshToken("openai-codex", controller.signal, "original-access")).resolves.toBe(
       "committed-access",
     );
     expect(controller.signal.reason).toBe(lateAbort);
@@ -636,7 +664,7 @@ describe("auth/profiles", () => {
     });
 
     vi.useFakeTimers();
-    const error = await getFreshToken("openai-codex").then(
+    const error = await getFreshToken("openai-codex", undefined, "old").then(
       () => null,
       (failure: unknown) => failure,
     );
@@ -667,7 +695,7 @@ describe("auth/profiles", () => {
     vi.useFakeTimers();
     const controller = new AbortController();
     const abortError = new DOMException("Cancelled before wait", "AbortError");
-    const settled = getFreshToken("openai-codex", controller.signal);
+    const settled = getFreshToken("openai-codex", controller.signal, "old");
     for (let turn = 0; turn < 10 && refreshMock.mock.calls.length === 0; turn += 1) {
       await Promise.resolve();
     }
@@ -703,7 +731,7 @@ describe("auth/profiles", () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const controller = new AbortController();
     const abortError = new DOMException("Cancelled during wait", "AbortError");
-    const settled = getFreshToken("openai-codex", controller.signal);
+    const settled = getFreshToken("openai-codex", controller.signal, "old");
     for (let turn = 0; turn < 10 && vi.getTimerCount() !== 1; turn += 1) {
       await Promise.resolve();
     }
@@ -742,9 +770,9 @@ describe("auth/profiles", () => {
     });
 
     const [a, b, c] = await Promise.all([
-      getFreshToken("openai-codex"),
-      getFreshToken("openai-codex"),
-      getFreshToken("openai-codex"),
+      getFreshToken("openai-codex", undefined, "old"),
+      getFreshToken("openai-codex", undefined, "old"),
+      getFreshToken("openai-codex", undefined, "old"),
     ]);
     expect(a).toBe("fresh");
     expect(b).toBe("fresh");

--- a/packages/engine/src/agent/codex-bridge.ts
+++ b/packages/engine/src/agent/codex-bridge.ts
@@ -3,6 +3,7 @@ import type { FinishReason, LanguageModelUsage, ModelMessage, ToolSet } from "ai
 
 import type { FailureReason } from "../host-ports.js";
 import type { GenerateOpts, GenerateResult } from "../llm-types.js";
+import { markProviderAuthFailure } from "../provider-auth-failure.js";
 import { codexResponses } from "./codex/responses.js";
 import type {
   CodexResponsesResult,
@@ -13,6 +14,7 @@ import type {
 import { PRICE_TABLE, priceUsage } from "./codex/cost.js";
 
 const DEFAULT_STEP_LIMIT = 10;
+const MAX_AUTH_REFRESH_ATTEMPTS = 1;
 
 const SERVER_ERROR_HTTP_STATUSES = new Set([500, 502, 503, 504]);
 
@@ -50,6 +52,9 @@ export function normalizeError(
   // A transient 5xx must take the short server-error backoff, not the rate-limit
   // ramp — split it out before the rate-limit pattern.
   const status = carried.httpStatus;
+  if (status === 401 || status === 403) {
+    return markProviderAuthFailure(err);
+  }
   if (status !== undefined && SERVER_ERROR_HTTP_STATUSES.has(status)) {
     const out = new Error(`Server error: ${msg}`) as Error & { retryAfterMs?: number };
     out.name = "ServerError";
@@ -241,7 +246,11 @@ export async function codexGenerateText(
     stepLimit?: number;
   },
   ports: {
-    getAccessToken: (profileName: string, signal?: AbortSignal) => Promise<string>;
+    getAccessToken: (
+      profileName: string,
+      signal?: AbortSignal,
+      rejectedAccessToken?: string,
+    ) => Promise<string>;
     classifyFailure: (error: unknown) => FailureReason;
   },
 ): Promise<GenerateResult> {
@@ -265,11 +274,8 @@ export async function codexGenerateText(
 
   const limit = stepLimit ?? DEFAULT_STEP_LIMIT;
 
-  // Fetch the token once per request. The step loop runs well within the
-  // 5-minute refresh threshold, so a refresh mid-loop is not a concern.
-  // Thread the per-call signal so a stalled token endpoint is bounded by the
-  // same deadline as the request rather than hanging the turn.
-  const accessToken = await getAccessToken(profileName, signal);
+  let accessToken = await getAccessToken(profileName, signal);
+  let authRefreshAttempts = 0;
 
   const toToolCallPart = (tc: CodexToolCall) => ({
     type: "tool-call" as const,
@@ -285,18 +291,27 @@ export async function codexGenerateText(
 
   for (let step = 0; step < limit; step++) {
     let result: CodexResponsesResult;
-    try {
-      result = await codexResponses({
-        modelId,
-        system,
-        messages: convo,
-        tools,
-        accessToken,
-        sessionId: cacheKey,
-        signal,
-      });
-    } catch (err) {
-      throw normalizeError(err, classifyFailure);
+    while (true) {
+      try {
+        result = await codexResponses({
+          modelId,
+          system,
+          messages: convo,
+          tools,
+          accessToken,
+          sessionId: cacheKey,
+          signal,
+        });
+        break;
+      } catch (err) {
+        const status = (err as { httpStatus?: unknown } | null)?.httpStatus;
+        if (status === 401 && authRefreshAttempts < MAX_AUTH_REFRESH_ATTEMPTS) {
+          authRefreshAttempts++;
+          accessToken = await getAccessToken(profileName, signal, accessToken);
+          continue;
+        }
+        throw normalizeError(err, classifyFailure);
+      }
     }
 
     if (result.stopReason === "error") {

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -329,7 +329,11 @@ export interface EngineHostPorts {
   readonly usage: UsagePort;
   readonly stateReader: AthleteStateReaderPort;
   readonly readReferenceState: () => ReferenceStateSnapshot;
-  readonly getAccessToken: (profileName: string, signal?: AbortSignal) => Promise<string>;
+  readonly getAccessToken: (
+    profileName: string,
+    signal?: AbortSignal,
+    rejectedAccessToken?: string,
+  ) => Promise<string>;
   readonly classifyFailure: (error: unknown) => FailureReason;
   readonly extractRetryAfterMs: (error: unknown) => number | null;
   readonly now: () => number;

--- a/packages/engine/tests/coach-agent-turn-outcome.test.ts
+++ b/packages/engine/tests/coach-agent-turn-outcome.test.ts
@@ -160,6 +160,31 @@ describe("per-turn outcome line", () => {
     expect(lines[0].rateLimitAttempts).toBe(MAX_RATE_LIMIT_ATTEMPTS);
   });
 
+  it("a server token rejection emits exactly one auth failure outcome", async () => {
+    const complete = vi.fn(async () => {
+      throw Object.assign(new Error("unauthorized"), { httpStatus: 401 });
+    });
+    const agent = await setupAgent(complete);
+
+    const outcome = await agent.chat("auth-fail-chat", "hello").then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+
+    expect(outcome.ok).toBe(false);
+    expect(complete).toHaveBeenCalledTimes(2);
+    const lines = readOutcomeLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      chatId: "auth-fail-chat",
+      ok: false,
+      error_class: "auth",
+      overflowAttempts: 0,
+      timeoutAttempts: 0,
+      rateLimitAttempts: 0,
+    });
+  });
+
   it("a retried-then-succeeded turn emits one ok:true line with the recovery counters", async () => {
     let mainCalls = 0;
     const complete = vi.fn(async (params: { system?: string }) => {
@@ -298,4 +323,3 @@ describe("per-turn outcome line", () => {
     await expect(agent.chat("sink-chat", "hello")).resolves.toBe("all good");
   });
 });
-

--- a/packages/engine/tests/codex-bridge.test.ts
+++ b/packages/engine/tests/codex-bridge.test.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import type { EngineHostPorts } from "../src/host-ports.js";
 import { normalizeError } from "../src/agent/codex-bridge.js";
 import { usageFieldsFromResult } from "../src/llm-types.js";
+import { isProviderAuthFailure } from "../src/provider-auth-failure.js";
 import {
   classifyFailure,
   isContextOverflowError,
@@ -487,6 +488,43 @@ describe("codex-bridge", () => {
     expect(complete).toHaveBeenCalledWith(expect.objectContaining({ signal }));
   });
 
+  it("refreshes a server-rejected token once without poisoning the next turn", async () => {
+    let storedAccess = "stale-access";
+    const complete = vi.fn(async ({ accessToken }: { accessToken: string }) => {
+      if (accessToken === "stale-access") {
+        throw Object.assign(new Error("unauthorized"), { httpStatus: 401 });
+      }
+      return asstMsg({ text: "accepted" });
+    });
+    const readStoredValue = vi.fn(
+      async (_profileName: string, _signal?: AbortSignal, rejectedAccessToken?: string) => {
+        if (rejectedAccessToken === "stale-access") storedAccess = "fresh-access";
+        return storedAccess;
+      },
+    );
+    const freshToken = readStoredValue;
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete, freshToken });
+    const input = {
+      messages: [{ role: "user" as const, content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+    };
+
+    await expect(codexGenerateText(input)).resolves.toMatchObject({ text: "accepted" });
+    await expect(codexGenerateText(input)).resolves.toMatchObject({ text: "accepted" });
+
+    expect(readStoredValue.mock.calls).toEqual([
+      ["openai-codex", undefined],
+      ["openai-codex", undefined, "stale-access"],
+      ["openai-codex", undefined],
+    ]);
+    expect(complete.mock.calls.map(([call]) => call.accessToken)).toEqual([
+      "stale-access",
+      "fresh-access",
+      "fresh-access",
+    ]);
+  });
+
   it("surfaces finishReason=length so isContextOverflowError can catch it upstream via retry", async () => {
     const complete = vi.fn(async () => asstMsg({ stopReason: "length", text: "truncated" }));
     const { codexGenerateText } = await loadBridgeWithMocks({ complete });
@@ -680,6 +718,12 @@ describe("codex-bridge normalizeError", () => {
       expect(isServerError(normalized)).toBe(true);
       expect(isRateLimitError(normalized)).toBe(false);
     }
+  });
+
+  it.each([401, 403])("classifies a %i as provider auth", (status) => {
+    const normalized = normalizeError(httpError(status, "unauthorized"), classifyFailure);
+    expect(isProviderAuthFailure(normalized)).toBe(true);
+    expect(classifyFailure(normalized)).toBe("auth");
   });
 
   it("keeps a 429 as rate limit, not server error", () => {

--- a/packages/engine/tests/codex/responses.test.ts
+++ b/packages/engine/tests/codex/responses.test.ts
@@ -183,6 +183,22 @@ describe("codexResponses SSE accumulation", () => {
 });
 
 describe("codexResponses error surface (single attempt, no retry loop)", () => {
+  it("throws an auth-classified httpStatus carrier on a 401 and fetches once", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: "invalid_token", message: "expired" } }), {
+        status: 401,
+      }),
+    );
+
+    const err = (await codexResponses(baseParams()).catch((e) => e)) as Error & {
+      httpStatus?: number;
+    };
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(err.httpStatus).toBe(401);
+    expect(classifyFailure(normalizeError(err, classifyFailure))).toBe("auth");
+  });
+
   it("throws an httpStatus-carrying RateLimit error on a 429 and fetches once", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ error: { code: "rate_limit_exceeded", message: "slow down" } }), {


### PR DESCRIPTION
Fixes the ChatGPT-subscription lane failing every turn on machines whose clock is wrong (observed on a resumed VM 74 minutes behind: every turn failed with a generic error and error_class:"unknown").

## Root cause

The token readers compared the stored access token's expiry against the LOCAL clock (packages/coach/src/composition.ts token reader, duplicated in packages/core/src/auth/profiles.ts). On a clock-behind machine a server-expired token still looked fresh locally, so it was sent without refresh and the server rejected every request. There was no future-issued-token validation and no sticky cache — earlier framings of this bug were wrong; the code path above is the confirmed mechanism.

## Changes

- Remove wall-clock expiry gating from both token readers. The stored access token is returned as-is; a server 401 is the only token-invalid signal.
- Add one bounded refresh-and-retry per ChatGPT generation on a response 401. The refresh is keyed on the exact rejected token, so concurrent callers reuse an already-rotated token instead of burning refresh tokens.
- Classify provider HTTP 401/403 as error_class "auth" in turn_outcome (was "unknown").
- Coaching/domain time ("tomorrow", daily reset, power progress) intentionally stays on the local clock; nothing is server-corrected.

## Limits

- Removed: the 300000 ms (5 min) local token refresh threshold — token validity must not depend on the machine wall clock.
- Added: MAX_AUTH_REFRESH_ATTEMPTS = 1 per generation — allows one server-directed rotation while preventing an unbounded 401/refresh loop.

## Verification

- New tests: injected clocks at -2h and +2h against a mocked Responses endpoint (turns succeed both ways; the -2h case proves 401 → refresh → retry), concurrent rejected-token behavior, recovery on a later turn, 401/403 classification, and a turn_outcome log assertion of error_class "auth".
- Full engine suite green; full root pnpm check green (Node 24).
- Coach suite: 4 failures in backfill-sigkill/backfill/reference-capture-gate reproduce identically on the clean epic tip without this diff (environment-dependent, pre-existing).
- Four independent read-only reviewers verified mechanism, tolerance, no-sticky-cache, and telemetry/tests against the diff.