### PR TITLE
fix(desktop): keep startup alive when Telegram reconciliation is uncertain

### DIFF
--- a/.changeset/telegram-startup-degrade.md
+++ b/.changeset/telegram-startup-degrade.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Enduragent now opens normally when Telegram setup is left in an uncertain state after a crash or forced quit; the Telegram section shows a repair prompt instead of the whole app refusing to start.
+
+Startup no longer throws when the initial Telegram reconciliation returns a non-applied outcome. The channel is latched into its existing failed/repair status until a successful reconcile or a daemon rebind clears it, and unexpected startup failures are now written to log.jsonl as a classified startup_failed record before any dialog.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -83,6 +83,7 @@ import {
   resolveDesktopRendererSource,
 } from "./security.js";
 import { DesktopDaemonSupervisor, isUtilityTerminalFrame } from "./supervisor.js";
+import { logDesktopStartupFailure } from "./startup-failure.js";
 import {
   createDesktopQuitCoordinator,
   installDesktopTerminationSignalHandler,
@@ -106,6 +107,7 @@ import {
   createDesktopTelegramPowerLifecycle,
   type DesktopTelegramPowerLifecycle,
 } from "./telegram-power.js";
+import { startDesktopTelegram } from "./telegram-startup.js";
 import {
   createConnectionTranscriptReader,
   installDesktopTranscriptIpc,
@@ -743,22 +745,11 @@ async function runDesktop(): Promise<void> {
       initialTelegramConnection,
       selectedAthleteHome,
     );
-    if (initialTelegramConnection.supervision === "app-supervised") {
-      const reconciliation = await telegramCoordinator.reconcile();
-      const desiredState = await telegramVault.desiredState();
-      const expectedEnabled = desiredState.state === "configured" && desiredState.enabled;
-      const prepared =
-        reconciliation.outcome === "applied" &&
-        (expectedEnabled
-          ? reconciliation.current.credentialConfigured &&
-            reconciliation.current.channel.desiredState === "enabled" &&
-            (reconciliation.current.channel.state === "starting" ||
-              reconciliation.current.channel.state === "online" ||
-              reconciliation.current.channel.state === "offline-retrying")
-          : reconciliation.current.channel.state === "disabled");
-      if (!prepared) throw new TypeError("Telegram startup reconciliation failed");
-    }
-    await telegramPower.start();
+    await startDesktopTelegram({
+      supervision: initialTelegramConnection.supervision,
+      coordinator: telegramCoordinator,
+      power: telegramPower,
+    });
     await installDesktopProtocol({
       session: session.defaultSession,
       currentDaemonPort: () => daemonLifecycle!.currentPort(),
@@ -1044,6 +1035,7 @@ if (!primaryInstance) {
     ? runRuntimeSmoke
     : runDesktop;
   void runPrimaryDesktop().catch((error: unknown) => {
+    logDesktopStartupFailure(error);
     console.error("desktop startup failed", error);
     if (!desktopIsClosing && !desktopStartedInBackground && !desktopAcceptanceHidden) {
       dialog.showErrorBox(unexpectedStartupCopy.title, unexpectedStartupCopy.content);

--- a/apps/desktop/src/main/startup-failure.ts
+++ b/apps/desktop/src/main/startup-failure.ts
@@ -1,0 +1,9 @@
+import { createSubsystemLogger } from "@enduragent/core";
+import { resolveDesktopAthleteHome } from "./first-run-config.js";
+
+export function logDesktopStartupFailure(
+  error: unknown,
+  dataDir = resolveDesktopAthleteHome(),
+): void {
+  createSubsystemLogger("desktop", dataDir).error("startup_failed", error);
+}

--- a/apps/desktop/src/main/telegram-control.ts
+++ b/apps/desktop/src/main/telegram-control.ts
@@ -308,6 +308,36 @@ function matchesDesired(snapshot: TelegramControlSnapshot, enabled: boolean): bo
   return (snapshot.channel.desiredState === "enabled") === enabled;
 }
 
+function reconciliationFailureSnapshot(
+  result: Exclude<DesktopTelegramMutationResult, { readonly outcome: "applied" }>,
+): DesktopTelegramSnapshot {
+  const current = result.current;
+  if (
+    current.channel.state === "failed" ||
+    current.channel.state === "conflict" ||
+    current.channel.state === "invalid-token" ||
+    current.channel.state === "transfer-required" ||
+    (result.outcome === "refused" &&
+      result.reason === "invalid-state" &&
+      current.channel.state === "waiting-for-credential")
+  ) {
+    return current;
+  }
+  const errorCode =
+    result.outcome === "refused" && isSecureStorageRefusal(result.reason)
+      ? profileStatusErrorCode(result.reason)
+      : result.outcome === "uncertain" && result.reason === "storage-uncertain"
+        ? "telegram-settings-storage-uncertain"
+        : "telegram-control-failed";
+  return failure(
+    current.channel.desiredState,
+    errorCode,
+    current.credentialConfigured,
+    current.bot,
+    current.pairing,
+  );
+}
+
 export function createTelegramControlCoordinator(
   input: CreateTelegramControlCoordinatorInput,
 ): TelegramControlCoordinator {
@@ -315,6 +345,12 @@ export function createTelegramControlCoordinator(
   let accepting = true;
   let closePromise: Promise<void> | undefined;
   let transientSuspension: TelegramDaemonBinding | undefined;
+  let reconciliationFailure:
+    | {
+        readonly binding: TelegramDaemonBinding | undefined;
+        readonly current: DesktopTelegramSnapshot;
+      }
+    | undefined;
   const leaseClock =
     input.pairingLease ??
     ({
@@ -529,11 +565,29 @@ export function createTelegramControlCoordinator(
   ): Promise<DesktopTelegramMutationResult> =>
     serialize(async () => {
       try {
-        return await operation();
+        const result = await operation();
+        if (result.outcome === "applied") reconciliationFailure = undefined;
+        return result;
       } catch {
         return uncertain("control-uncertain");
       }
     });
+
+  const rememberReconciliation = (
+    result: DesktopTelegramMutationResult,
+  ): DesktopTelegramMutationResult => {
+    if (result.outcome === "applied") {
+      reconciliationFailure = undefined;
+      return result;
+    }
+    const current = reconciliationFailureSnapshot(result);
+    reconciliationFailure = { binding: binding(), current };
+    return { ...result, current };
+  };
+
+  const reconcileMutation = (
+    operation: () => Promise<DesktopTelegramMutationResult>,
+  ): Promise<DesktopTelegramMutationResult> => runMutation(operation).then(rememberReconciliation);
 
   const checkedBinding = async (): Promise<
     | { readonly active: TelegramDaemonBinding; readonly desiredState: "disabled" | "enabled" }
@@ -1685,6 +1739,10 @@ export function createTelegramControlCoordinator(
     status: () =>
       runSnapshot(async () => {
         const active = binding();
+        if (reconciliationFailure !== undefined) {
+          if (reconciliationFailure.binding === active) return reconciliationFailure.current;
+          reconciliationFailure = undefined;
+        }
         if (active === undefined) return project();
         const daemonStatus = await guardedSnapshotCall(active, () => active.getTelegramStatus({}));
         if (daemonStatus === undefined) {
@@ -1730,7 +1788,7 @@ export function createTelegramControlCoordinator(
       }),
 
     reconcile() {
-      return runMutation(async () => {
+      return reconcileMutation(async () => {
         const checked = await checkedBinding();
         if ("result" in checked) return checked.result;
         const daemonStatus = await guardedSnapshotCall(checked.active, () =>

--- a/apps/desktop/src/main/telegram-startup.ts
+++ b/apps/desktop/src/main/telegram-startup.ts
@@ -1,0 +1,18 @@
+import type {
+  DesktopTelegramMutationResult,
+  TelegramControlCoordinator,
+} from "./telegram-control.js";
+import type { DesktopTelegramPowerLifecycle } from "./telegram-power.js";
+
+export async function startDesktopTelegram(input: {
+  readonly supervision: "app-supervised" | "attached";
+  readonly coordinator: Pick<TelegramControlCoordinator, "reconcile">;
+  readonly power: Pick<DesktopTelegramPowerLifecycle, "start">;
+}): Promise<DesktopTelegramMutationResult | undefined> {
+  let reconciliation: DesktopTelegramMutationResult | undefined;
+  if (input.supervision === "app-supervised") {
+    reconciliation = await input.coordinator.reconcile();
+  }
+  await input.power.start();
+  return reconciliation;
+}

--- a/apps/desktop/tests/residency.test.ts
+++ b/apps/desktop/tests/residency.test.ts
@@ -642,25 +642,28 @@ describe("desktop residency", () => {
     expect(initialShow).toBeGreaterThan(residencyStart);
   });
 
-  it("reads repaired Telegram intent after startup and successor reconciliation", async () => {
+  it("reads repaired Telegram intent after successor reconciliation", async () => {
     const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
-    const blocks = [
-      source.slice(
-        source.indexOf("const successorTelegramCoordinator"),
-        source.indexOf('throw new TypeError("Telegram successor preparation failed")'),
-      ),
-      source.slice(
-        source.indexOf('if (initialTelegramConnection.supervision === "app-supervised")'),
-        source.indexOf('throw new TypeError("Telegram startup reconciliation failed")'),
-      ),
-    ];
+    const block = source.slice(
+      source.indexOf("const successorTelegramCoordinator"),
+      source.indexOf('throw new TypeError("Telegram successor preparation failed")'),
+    );
+    const reconcile = block.indexOf(".reconcile();");
+    const desiredRead = block.indexOf("telegramVault.desiredState();");
 
-    for (const block of blocks) {
-      const reconcile = block.indexOf(".reconcile();");
-      const desiredRead = block.indexOf("telegramVault.desiredState();");
-      expect(reconcile).toBeGreaterThanOrEqual(0);
-      expect(desiredRead).toBeGreaterThan(reconcile);
-    }
+    expect(reconcile).toBeGreaterThanOrEqual(0);
+    expect(desiredRead).toBeGreaterThan(reconcile);
+  });
+
+  it("continues initial startup through Telegram startup preparation", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+    const startup = source.indexOf("await startDesktopTelegram({");
+    const protocolStart = source.indexOf("await installDesktopProtocol({", startup);
+
+    expect(startup).toBeGreaterThanOrEqual(0);
+    expect(protocolStart).toBeGreaterThan(startup);
+    expect(source.slice(startup, protocolStart)).not.toMatch(/\bthrow\b/u);
+    expect(source).not.toContain("Telegram startup reconciliation failed");
   });
 
   it("reports tray-start and keeps running when the tray icon cannot load", async () => {

--- a/apps/desktop/tests/startup-catch.test.ts
+++ b/apps/desktop/tests/startup-catch.test.ts
@@ -1,0 +1,111 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class Emitter {
+    private readonly listeners = new Map<string, Set<(...args: any[]) => void>>();
+    on(name: string, listener: (...args: any[]) => void) {
+      const listeners = this.listeners.get(name) ?? new Set();
+      listeners.add(listener);
+      this.listeners.set(name, listeners);
+      return this;
+    }
+  }
+  const startupError = new TypeError("synthetic startup rejection");
+  startupError.stack = "TypeError: synthetic startup rejection\n    at synthetic-startup.ts:1:1";
+  const app = Object.assign(new Emitter(), {
+    commandLine: { getSwitchValue: vi.fn(() => ""), appendSwitch: vi.fn() },
+    dock: { hide: vi.fn() },
+    exit: vi.fn(),
+    requestSingleInstanceLock: vi.fn(() => true),
+    setAppUserModelId: vi.fn(),
+    setPath: vi.fn(),
+    whenReady: vi.fn(() => Promise.reject(startupError)),
+  });
+  return {
+    app,
+    startupError,
+    dialog: { showErrorBox: vi.fn() },
+    crashReporter: { start: vi.fn() },
+  };
+});
+
+vi.mock("electron", () => ({
+  app: mocks.app,
+  BrowserWindow: vi.fn(),
+  clipboard: {},
+  crashReporter: mocks.crashReporter,
+  dialog: mocks.dialog,
+  ipcMain: {},
+  Menu: {},
+  nativeImage: {},
+  net: {},
+  powerMonitor: {},
+  protocol: {},
+  safeStorage: {},
+  screen: {},
+  session: {},
+  shell: {},
+  Tray: vi.fn(),
+  utilityProcess: {},
+}));
+
+vi.mock("../src/main/security.js", () => ({
+  createDesktopRendererConsoleCapture: vi.fn(() => ({
+    attach: vi.fn(),
+    hasMessageContaining: vi.fn(() => false),
+  })),
+  desktopWindowOptions: vi.fn(),
+  hardenDesktopWindow: vi.fn(),
+  installDesktopProtocol: vi.fn(),
+  isTrustedConnectionRequest: vi.fn(),
+  registerDesktopScheme: vi.fn(),
+  rendererOutputRoot: vi.fn(),
+  resolveDesktopRendererSource: vi.fn(),
+}));
+
+const scratchDirectories: string[] = [];
+const originalAthleteHome = process.env.ENDURAGENT_HOME;
+const originalAcceptanceHidden = process.env.ENDURAGENT_ACCEPTANCE_HIDDEN;
+
+afterEach(async () => {
+  if (originalAthleteHome === undefined) delete process.env.ENDURAGENT_HOME;
+  else process.env.ENDURAGENT_HOME = originalAthleteHome;
+  if (originalAcceptanceHidden === undefined) delete process.env.ENDURAGENT_ACCEPTANCE_HIDDEN;
+  else process.env.ENDURAGENT_ACCEPTANCE_HIDDEN = originalAcceptanceHidden;
+  vi.restoreAllMocks();
+  vi.resetModules();
+  await Promise.all(
+    scratchDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("desktop startup catch", () => {
+  it("logs a classified failure even when the dialog is gated off", async () => {
+    const root = await mkdtemp(join(tmpdir(), "enduragent-desktop-startup-catch-"));
+    scratchDirectories.push(root);
+    process.env.ENDURAGENT_HOME = root;
+    process.env.ENDURAGENT_ACCEPTANCE_HIDDEN = "1";
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await import("../src/main/index.js");
+
+    await vi.waitFor(() => expect(mocks.app.exit).toHaveBeenCalledWith(1), { timeout: 20_000 });
+    expect(mocks.dialog.showErrorBox).not.toHaveBeenCalled();
+    const record = JSON.parse(
+      (await readFile(join(root, "logs", "log.jsonl"), "utf8")).trim(),
+    ) as Record<string, unknown>;
+    expect(record).toMatchObject({
+      level: "error",
+      component: "desktop",
+      event: "startup_failed",
+      err: {
+        name: "TypeError",
+        message: mocks.startupError.message,
+        stack: mocks.startupError.stack,
+      },
+    });
+  }, 30_000);
+});

--- a/apps/desktop/tests/startup-failure.test.ts
+++ b/apps/desktop/tests/startup-failure.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logDesktopStartupFailure } from "../src/main/startup-failure.js";
+
+const scratchDirectories: string[] = [];
+
+async function scratch(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "enduragent-desktop-startup-failure-"));
+  scratchDirectories.push(path);
+  return path;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    scratchDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("desktop startup failure", () => {
+  it("writes the classified error to the durable app log", async () => {
+    const root = await scratch();
+    const error = new TypeError("synthetic startup failure");
+    error.stack = "TypeError: synthetic startup failure\n    at synthetic-startup.ts:1:1";
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    logDesktopStartupFailure(error, root);
+
+    const lines = (await readFile(join(root, "logs", "log.jsonl"), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      level: "error",
+      component: "desktop",
+      event: "startup_failed",
+      err: {
+        name: "TypeError",
+        message: "synthetic startup failure",
+        stack: error.stack,
+      },
+    });
+  });
+
+  it("logs before the startup dialog gate without changing its flags", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+    const catchStart = source.indexOf("void runPrimaryDesktop().catch");
+    const classifiedLog = source.indexOf("logDesktopStartupFailure(error);", catchStart);
+    const dialogGate = source.indexOf(
+      "if (!desktopIsClosing && !desktopStartedInBackground && !desktopAcceptanceHidden)",
+      catchStart,
+    );
+    const dialog = source.indexOf("dialog.showErrorBox(unexpectedStartupCopy.title", dialogGate);
+
+    expect(catchStart).toBeGreaterThanOrEqual(0);
+    expect(classifiedLog).toBeGreaterThan(catchStart);
+    expect(dialogGate).toBeGreaterThan(classifiedLog);
+    expect(dialog).toBeGreaterThan(dialogGate);
+  });
+});

--- a/apps/desktop/tests/telegram-control.test.ts
+++ b/apps/desktop/tests/telegram-control.test.ts
@@ -24,6 +24,7 @@ import type {
   TelegramProfileRecord,
 } from "../src/main/telegram-credential-vault.js";
 import { createTelegramCredentialVault } from "../src/main/telegram-credential-vault.js";
+import { startDesktopTelegram } from "../src/main/telegram-startup.js";
 
 const HOME = "/synthetic/athlete" as AthleteHomeIdentity;
 const OTHER_HOME = "/synthetic/other" as AthleteHomeIdentity;
@@ -825,6 +826,121 @@ describe("Telegram main-process control coordinator", () => {
     expect(JSON.stringify(observeSecureStorageFailure.mock.calls)).not.toMatch(
       /private daemon|private observer|synthetic-token/u,
     );
+  });
+
+  it.each([true, false])(
+    "keeps configured desired=%s reconciliation uncertainty visible until repair succeeds",
+    async (enabled) => {
+      const runtime = harness({
+        configured: true,
+        enabled,
+        daemonSnapshot: {
+          channel: enabled
+            ? { desiredState: "enabled", state: "waiting-for-credential" }
+            : { desiredState: "disabled", state: "disabled" },
+          bot: { state: "unconfigured" },
+          pairing: { state: "unpaired" },
+        },
+      });
+      vi.mocked(runtime.binding.configureTelegram).mockRejectedValueOnce(
+        new TypeError("synthetic lost response"),
+      );
+      const desiredState = enabled ? "enabled" : "disabled";
+      const repairChannel = {
+        desiredState,
+        state: "failed" as const,
+        errorCode: "telegram-control-failed" as const,
+      };
+      const powerStart = vi.fn(async () => ({ state: "clear" as const }));
+
+      const reconciliation = await startDesktopTelegram({
+        supervision: "app-supervised",
+        coordinator: runtime.coordinator,
+        power: { start: powerStart },
+      });
+      expect(powerStart).toHaveBeenCalledOnce();
+      expect(reconciliation).toMatchObject({
+        outcome: "uncertain",
+        reason: "control-uncertain",
+        current: { channel: repairChannel, credentialConfigured: true },
+      });
+      await expect(runtime.coordinator.status()).resolves.toMatchObject({
+        channel: repairChannel,
+        credentialConfigured: true,
+      });
+
+      runtime.setSnapshot(
+        snapshot(
+          enabled
+            ? { desiredState: "enabled", state: "online" }
+            : { desiredState: "disabled", state: "disabled" },
+        ),
+      );
+      await expect(runtime.coordinator.reconcile()).resolves.toMatchObject({
+        outcome: "applied",
+        current: {
+          channel: enabled
+            ? { desiredState: "enabled", state: "online" }
+            : { desiredState: "disabled", state: "disabled" },
+        },
+      });
+      await expect(runtime.coordinator.status()).resolves.toMatchObject({
+        channel: enabled
+          ? { desiredState: "enabled", state: "online" }
+          : { desiredState: "disabled", state: "disabled" },
+      });
+    },
+  );
+
+  it.each([true, false])(
+    "keeps configured desired=%s reconciliation refusal visible when its fallback looks healthy",
+    async (enabled) => {
+      const runtime = harness({ configured: true, enabled });
+      vi.mocked(runtime.binding.getTelegramStatus).mockRejectedValueOnce(
+        new TypeError("synthetic status refusal"),
+      );
+      const repairChannel = {
+        desiredState: enabled ? ("enabled" as const) : ("disabled" as const),
+        state: "failed" as const,
+        errorCode: "telegram-control-failed" as const,
+      };
+
+      await expect(runtime.coordinator.reconcile()).resolves.toMatchObject({
+        outcome: "refused",
+        reason: "stale-operation",
+        current: { channel: repairChannel, credentialConfigured: true },
+      });
+      await expect(runtime.coordinator.status()).resolves.toMatchObject({
+        channel: repairChannel,
+        credentialConfigured: true,
+      });
+    },
+  );
+
+  it("keeps an unexpected reconciliation throw visible as a repair state", async () => {
+    const runtime = harness({ configured: true, enabled: false });
+    vi.mocked(runtime.vault.desiredState)
+      .mockRejectedValueOnce(new TypeError("synthetic desired-state read failure"))
+      .mockRejectedValueOnce(new TypeError("synthetic fallback read failure"));
+
+    await expect(runtime.coordinator.reconcile()).resolves.toMatchObject({
+      outcome: "uncertain",
+      reason: "control-uncertain",
+      current: {
+        channel: {
+          desiredState: "disabled",
+          state: "failed",
+          errorCode: "telegram-control-failed",
+        },
+      },
+    });
+    await expect(runtime.coordinator.status()).resolves.toMatchObject({
+      channel: {
+        desiredState: "disabled",
+        state: "failed",
+        errorCode: "telegram-control-failed",
+      },
+    });
   });
 
   it("converges to A when daemon replacement throws after B storage", async () => {
@@ -2321,7 +2437,11 @@ describe("Telegram main-process control coordinator", () => {
       outcome: "refused",
       reason: "encryption-unavailable",
       current: {
-        channel: { desiredState: "enabled", state: "online" },
+        channel: {
+          desiredState: "enabled",
+          state: "failed",
+          errorCode: "telegram-credential-encryption-unavailable",
+        },
         bot: { state: "ready", username: USERNAME },
         pairing: { state: "paired" },
         credentialConfigured: true,


### PR DESCRIPTION
Fixes issue 285, found on the Windows installed build: after a forced kill with a Telegram bot token seeded, the app showed "Enduragent couldn't open" on EVERY subsequent launch, forever, with the real error going only to stderr (invisible to a packaged GUI launch).

## Root cause

`apps/desktop/src/main/index.ts` threw `TypeError("Telegram startup reconciliation failed")` when the initial reconcile returned anything other than `applied`. After a hard kill the saved channel state reconciles to `control-uncertain` on every launch, so a CHANNEL failure permanently aborted the APP — violating the promise that Telegram is optional and never blocks Chat, and the uninstall/transient-residue invariant.

## Changes

- New `telegram-startup.ts` boundary: startup awaits app-supervised reconciliation, always continues to Telegram power startup, and never throws on a non-applied result. Startup proceeds to protocol install and window show unconditionally.
- `telegram-control.ts` latches a non-applied reconcile into the EXISTING failed/repair channel shape (no new state, no new error codes, no renderer changes — the Settings section already renders these states with a "Check again" affordance). Actionable states (failed/conflict/invalid-token/transfer-required, and first-run waiting-for-credential) pass through untouched; the latch clears on a successful reconcile/mutation or when the daemon binding changes.
- New `startup-failure.ts`: the `runDesktop` catch path now writes a classified `startup_failed` record (error name, message, stack) to `log.jsonl` through the existing durable logger BEFORE the dialog, and does so regardless of the dialog gating flags. The gating flags themselves are unchanged.

## Verification

- New tests: configured Telegram state in both `enabled:true` and `enabled:false` variants with reconcile reporting uncertainty → startup completes and Telegram power start is still reached (previously unreachable); repair-state persistence and clearing; healthy-looking refusals; unexpected reconcile throw; behavioral catch-path test proving the classified log record is written when the dialog is suppressed; durable log-record field test.
- Desktop suite (Node 24): 1746/1747 passing. The single failure, `windows-parity-scenarios.test.ts`, is the known repo-root-cwd-sensitive test and fails identically on the clean epic tip without this diff.
- Root `pnpm check` green.
- Four independent read-only reviewers verified degrade-not-abort, logging placement/gating, test quality, and regressions.

## Residual (follow-up, not a regression)

The repair latch is sticky by design: a transient startup RPC hiccup can hold the channel in the repair state against the same daemon binding until the user presses "Check again" or the daemon rebinds. That is a visible, actionable state rather than the previous fatal abort, but self-healing on a later successful poll would be an improvement worth a separate ticket.