### PR TITLE
fix(desktop): accept Windows paths for training export and import

### DIFF
--- a/.changeset/windows-path-gates.md
+++ b/.changeset/windows-path-gates.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Exporting a ride and importing ride files now work on Windows. Both used to fail with "The export could not be saved to that location" because every Windows path was rejected before anything was read or written.
+
+Export destinations and import paths now share one platform-absolute path validator that accepts POSIX, drive-letter and UNC paths; the preload and renderer import gates parse extensions across both separators; the export writer joins its temporary path with the platform separator and skips the post-rename directory fsync on Windows, where directory handles cannot be synced; and desktop export IPC now logs the caught error before reporting a write failure.

--- a/apps/desktop-renderer/src/onboarding/bridge.ts
+++ b/apps/desktop-renderer/src/onboarding/bridge.ts
@@ -2,6 +2,7 @@ import type { CoachClient } from "@enduragent/coach-client";
 import { CoachClientDisconnectedError, connectCoachClient } from "@enduragent/coach-client";
 import {
   ImportFilesRpcParamsSchema,
+  PlatformAbsolutePathSchema,
   SaveIntakeRpcParamsSchema,
   type GetSetupStatusRpcResult,
   type CoachOperationProgressNotificationEnvelope,
@@ -205,7 +206,7 @@ export interface DesktopOnboardingAuth {
 }
 
 function extension(path: string): string {
-  const slash = path.lastIndexOf("/");
+  const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
   const dot = path.lastIndexOf(".");
   return dot > slash ? path.slice(dot).toLowerCase() : "";
 }
@@ -216,8 +217,7 @@ export function validateImportPaths(paths: readonly string[]): readonly string[]
     normalized.some(
       (path) =>
         typeof path !== "string" ||
-        !path.startsWith("/") ||
-        path.includes("\0") ||
+        !PlatformAbsolutePathSchema.safeParse(path).success ||
         !(SUPPORTED_IMPORT_EXTENSIONS as readonly string[]).includes(extension(path)),
     )
   ) {

--- a/apps/desktop-renderer/tests/onboarding-wizard.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-wizard.test.ts
@@ -59,6 +59,11 @@ describe("desktop onboarding wizard", () => {
     expect(
       validateImportPaths(["/synthetic/a.FIT", "/synthetic/b.tcx", "/synthetic/c.GpX"]),
     ).toEqual(["/synthetic/a.FIT", "/synthetic/b.tcx", "/synthetic/c.GpX"]);
+    expect(
+      validateImportPaths(["C:\\synthetic\\a.FIT", "\\\\server\\share\\b.gpx"]),
+    ).toEqual(["C:\\synthetic\\a.FIT", "\\\\server\\share\\b.gpx"]);
+    expect(() => validateImportPaths(["C:\\synthetic\\photos.fit\\ride"])).toThrow(TypeError);
+    expect(() => validateImportPaths(["C:relative\\a.fit"])).toThrow(TypeError);
     expect(() => validateImportPaths(["relative.fit"])).toThrow(TypeError);
     expect(() => validateImportPaths(["/synthetic/a.zip"])).toThrow(TypeError);
     expect(() => validateImportPaths(["/synthetic/a.fit", "/synthetic/a.fit"])).toThrow();

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -30,7 +30,7 @@ export function createDesktopViteConfig(
       },
     },
     preload: {
-      plugins: [externalizeDepsPlugin()],
+      plugins: [externalizeDepsPlugin({ exclude: ["@enduragent/coach-contract"] })],
       build: {
         outDir: resolve(outputRoot, "preload"),
         rollupOptions: {

--- a/apps/desktop/src/main/training-export-ipc.ts
+++ b/apps/desktop/src/main/training-export-ipc.ts
@@ -11,6 +11,7 @@ import {
 } from "@enduragent/coach-contract";
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent, SaveDialogOptions } from "electron";
 import { DESKTOP_TRAINING_EXPORT_CHANNEL } from "./constants.js";
+import { createSafeLog } from "./safe-log.js";
 import { isTrustedConnectionRequest } from "./security.js";
 
 export interface DesktopTrainingExporter {
@@ -98,12 +99,20 @@ function refusedWrite(): DesktopTrainingExportResult {
   return { status: "refused", reason: "write-failed" };
 }
 
+function describeWriteFailure(error: unknown): string {
+  const name = error instanceof Error ? error.name : "NonError";
+  const message = error instanceof Error ? error.message : String(error);
+  return `desktop-training-export-write-failed name=${JSON.stringify(name)} message=${JSON.stringify(message)}`;
+}
+
 export function installDesktopTrainingExportIpc(input: {
   readonly ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
   readonly currentWindow: () => BrowserWindow | undefined;
   readonly dialog: TrainingExportDialogPort;
   readonly exporter: () => DesktopTrainingExporter | undefined;
+  readonly log?: (message: string) => void;
 }): () => void {
+  const log = createSafeLog(input.log);
   input.ipcMain.handle(
     DESKTOP_TRAINING_EXPORT_CHANNEL,
     async (event: IpcMainInvokeEvent, ...args: unknown[]): Promise<DesktopTrainingExportResult> => {
@@ -119,7 +128,8 @@ export function installDesktopTrainingExportIpc(input: {
       let selection: Awaited<ReturnType<TrainingExportDialogPort["showSaveDialog"]>>;
       try {
         selection = await input.dialog.showSaveDialog(window, saveDialogOptions(parsed.data));
-      } catch {
+      } catch (error) {
+        log(describeWriteFailure(error));
         return refusedWrite();
       }
       if (selection.canceled || selection.filePath === undefined) return { status: "cancelled" };
@@ -135,7 +145,8 @@ export function installDesktopTrainingExportIpc(input: {
             ? { status: "saved", byteLength: result.byteLength }
             : result,
         );
-      } catch {
+      } catch (error) {
+        log(describeWriteFailure(error));
         return refusedWrite();
       }
     },

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
+import { PlatformAbsolutePathSchema } from "@enduragent/coach-contract";
 import { desktopPlatformProjection } from "../main/platform-copy.js";
 import {
   DESKTOP_CONNECTION_CHANNEL,
@@ -1013,16 +1014,10 @@ function parsePaths(value: unknown): readonly string[] {
     throw new TypeError();
   }
   const paths = value.map((path) => {
-    if (
-      typeof path !== "string" ||
-      path.length === 0 ||
-      path.length > 4_096 ||
-      !path.startsWith("/") ||
-      path.includes("\0")
-    ) {
+    if (!PlatformAbsolutePathSchema.safeParse(path).success) {
       throw new TypeError();
     }
-    const slash = path.lastIndexOf("/");
+    const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
     const dot = path.lastIndexOf(".");
     if (dot <= slash || !IMPORT_EXTENSIONS.has(path.slice(dot).toLowerCase())) {
       throw new TypeError();

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -73,6 +73,7 @@ interface AuthBridge {
   addTelegramAllowedSender(input: unknown): Promise<unknown>;
   removeTelegramAllowedSender(input: unknown): Promise<unknown>;
   acknowledgeTelegramGapWarning(): Promise<unknown>;
+  chooseImportFiles(): Promise<readonly string[]>;
   exportTrainingFile(input: unknown): Promise<unknown>;
   getUpdateState(): Promise<unknown>;
   checkForUpdates(): Promise<unknown>;
@@ -306,6 +307,24 @@ describe("desktop preload ChatGPT auth", () => {
     await expect(bridge.exportTrainingFile(request)).rejects.toBeInstanceOf(TypeError);
     mocks.invoke.mockResolvedValue({ status: "refused", reason: "private-provider-detail" });
     await expect(bridge.exportTrainingFile(request)).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("accepts platform-absolute import paths and validates uppercase extensions", async () => {
+    const paths = ["C:\\x\\ride.FIT", "\\\\server\\share\\ride.gpx", "/home/x/ride.tcx"] as const;
+    mocks.invoke.mockResolvedValue(paths);
+
+    await expect(bridge.chooseImportFiles()).resolves.toEqual(paths);
+    expect(mocks.invoke).toHaveBeenCalledWith("enduragent:onboarding:choose-import-files");
+  });
+
+  it.each([
+    ["a bad extension", ["/home/x/ride.txt"]],
+    ["duplicate paths", ["/home/x/ride.fit", "/home/x/ride.fit"]],
+    ["more than 256 paths", Array.from({ length: 257 }, (_, index) => `/home/x/ride-${index}.fit`)],
+  ])("rejects import results with %s", async (_case, paths) => {
+    mocks.invoke.mockResolvedValue(paths);
+
+    await expect(bridge.chooseImportFiles()).rejects.toBeInstanceOf(TypeError);
   });
 
   it("accepts closed workout archive ranges and rejects inverted ranges", async () => {

--- a/apps/desktop/tests/training-export-ipc.test.ts
+++ b/apps/desktop/tests/training-export-ipc.test.ts
@@ -39,17 +39,20 @@ function setup(result: unknown = EXPORTED) {
     ),
   };
   const exporter = { export: vi.fn(async () => result) };
+  const log = vi.fn();
   const dispose = installDesktopTrainingExportIpc({
     ipcMain: ipcMain as never,
     currentWindow: () => window as never,
     dialog,
     exporter: () => exporter as never,
+    log,
   });
   return {
     handlers,
     ipcMain,
     dialog,
     exporter,
+    log,
     dispose,
     trusted: { sender: webContents, senderFrame: mainFrame },
   };
@@ -88,6 +91,28 @@ describe("desktop training export IPC", () => {
     });
     expect(result).not.toHaveProperty("suggestedFilename");
     expect(result).not.toHaveProperty("contentType");
+  });
+
+  it("passes a Windows save-dialog destination to the exporter", async () => {
+    const subject = setup();
+    const destinationPath = "C:\\Users\\x\\Documents\\ride.fit";
+    subject.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePath: destinationPath,
+    });
+
+    await expect(
+      subject.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(subject.trusted, {
+        kind: "activity",
+        canonicalActivityId: "a".repeat(64),
+        localDate: "1998-07-19",
+        format: "fit",
+      }),
+    ).resolves.toEqual({ status: "saved", byteLength: 4_096 });
+    expect(subject.exporter.export).toHaveBeenCalledWith(
+      expect.objectContaining({ destinationPath }),
+    );
+    expect(subject.log).not.toHaveBeenCalled();
   });
 
   it("routes a closed workout archive request and handles cancellation without daemon work", async () => {
@@ -182,17 +207,24 @@ describe("desktop training export IPC", () => {
     await expect(
       malformed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(malformed.trusted, request),
     ).resolves.toEqual({ status: "refused", reason: "write-failed" });
+    expect(malformed.log).toHaveBeenCalledWith(expect.stringContaining('name="ZodError"'));
 
     const failed = setup();
     failed.exporter.export.mockRejectedValueOnce(new Error("private provider response"));
     await expect(
       failed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(failed.trusted, request),
     ).resolves.toEqual({ status: "refused", reason: "write-failed" });
+    expect(failed.log).toHaveBeenLastCalledWith(
+      'desktop-training-export-write-failed name="Error" message="private provider response"',
+    );
 
     failed.dialog.showSaveDialog.mockRejectedValueOnce(new Error("private filesystem path"));
     await expect(
       failed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(failed.trusted, request),
     ).resolves.toEqual({ status: "refused", reason: "write-failed" });
+    expect(failed.log).toHaveBeenLastCalledWith(
+      'desktop-training-export-write-failed name="Error" message="private filesystem path"',
+    );
 
     failed.dialog.showSaveDialog.mockResolvedValueOnce({
       canceled: false,
@@ -201,6 +233,8 @@ describe("desktop training export IPC", () => {
     await expect(
       failed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(failed.trusted, request),
     ).resolves.toEqual({ status: "refused", reason: "write-failed" });
+    expect(failed.log).toHaveBeenLastCalledWith(expect.stringContaining('name="ZodError"'));
+    expect(failed.log).toHaveBeenCalledTimes(3);
   });
 
   it("uses one privileged client and closes it after the export", async () => {

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -10,3 +10,4 @@ export * from "./handshake.js";
 export * from "./telegram-control.js";
 export * from "./activity-analysis.js";
 export * from "./training-export.js";
+export * from "./platform-path.js";

--- a/packages/coach-contract/src/platform-path.ts
+++ b/packages/coach-contract/src/platform-path.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export function isPlatformAbsolutePath(value: string): boolean {
+  if (value.includes("\0")) return false;
+  if (value.startsWith("/")) return true;
+  if (/^[A-Za-z]:\\/.test(value)) return true;
+  if (!value.startsWith("\\\\")) return false;
+  const [server, share] = value.slice(2).split("\\");
+  return server !== "" && share !== undefined && share !== "";
+}
+
+export const PlatformAbsolutePathSchema = z
+  .string()
+  .min(1)
+  .max(4_096)
+  .refine(isPlatformAbsolutePath, "path must be absolute");

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -10,6 +10,7 @@ import {
   type CoachEngine,
 } from "./engine.js";
 import { TurnEventSchema } from "./turn-event.js";
+import { PlatformAbsolutePathSchema } from "./platform-path.js";
 import {
   GetSpendSummaryRpcParamsSchema,
   SetDailySpendCapRpcParamsSchema,
@@ -409,13 +410,7 @@ export type ListArchivedConversationsRpcResult = z.infer<
   typeof ListArchivedConversationsRpcResultSchema
 >;
 
-export const AbsoluteImportPathSchema = z
-  .string()
-  .min(1)
-  .max(4_096)
-  .refine((value) => value.startsWith("/") && !value.includes("\0"), {
-    message: "import paths must be absolute",
-  });
+export const AbsoluteImportPathSchema = PlatformAbsolutePathSchema;
 
 export const ImportFilesRpcParamsSchema = z
   .object({
@@ -853,9 +848,7 @@ export interface CoachOperations {
     request: SyncRpcParams,
     onEvent?: (event: OperationProgressEvent) => void,
   ): Promise<SyncRpcResult>;
-  getSetupStatus?(
-    request: GetSetupStatusRpcParams,
-  ): Promise<GetSetupStatusRpcResult>;
+  getSetupStatus?(request: GetSetupStatusRpcParams): Promise<GetSetupStatusRpcResult>;
   saveIntake(request: SaveIntakeRpcParams): Promise<SaveIntakeRpcResult>;
   getTranscriptPage(request: GetTranscriptPageRpcParams): Promise<GetTranscriptPageRpcResult>;
   listArchivedConversations(

--- a/packages/coach-contract/src/training-export.ts
+++ b/packages/coach-contract/src/training-export.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { CanonicalActivityIdSchema } from "./activity-analysis.js";
+import { PlatformAbsolutePathSchema } from "./platform-path.js";
 
 export const ACTIVITY_EXPORT_FORMATS = ["fit", "gpx"] as const;
 export const WORKOUT_ARCHIVE_FORMATS = ["zwo", "mrc", "erg", "fit"] as const;
@@ -45,13 +46,7 @@ export const DesktopTrainingExportRequestSchema = z.discriminatedUnion("kind", [
     }),
 ]);
 
-export const TrainingExportDestinationPathSchema = z
-  .string()
-  .min(1)
-  .max(4_096)
-  .refine((value) => value.startsWith("/") && !value.includes("\0"), {
-    message: "training export destination must be absolute",
-  });
+export const TrainingExportDestinationPathSchema = PlatformAbsolutePathSchema;
 
 export const ExportTrainingFileRpcParamsSchema = z.discriminatedUnion("kind", [
   z

--- a/packages/coach-contract/tests/platform-path.test.ts
+++ b/packages/coach-contract/tests/platform-path.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { AbsoluteImportPathSchema, TrainingExportDestinationPathSchema } from "../src/index.js";
+
+describe.each([
+  ["training export", TrainingExportDestinationPathSchema],
+  ["training import", AbsoluteImportPathSchema],
+])("%s absolute path contract", (_name, schema) => {
+  it.each(["/home/x/ride.fit", "C:\\Users\\x\\Documents\\ride.fit", "\\\\server\\share\\ride.fit"])(
+    "accepts %s",
+    (path) => {
+      expect(schema.parse(path)).toBe(path);
+    },
+  );
+
+  it.each([
+    ["empty", ""],
+    ["filename", "ride.fit"],
+    ["dot-relative", "./x"],
+    ["backslash-relative", "x\\y"],
+    ["NUL", "/home/x/ride\0.fit"],
+    ["over-length", `/${"x".repeat(4_096)}`],
+  ])("rejects %s paths", (_case, path) => {
+    expect(schema.safeParse(path).success).toBe(false);
+  });
+});

--- a/packages/coach/src/training-export.ts
+++ b/packages/coach/src/training-export.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { open, rename, rm } from "node:fs/promises";
-import { basename, dirname, isAbsolute, normalize } from "node:path";
+import { basename, dirname, isAbsolute, join, normalize } from "node:path";
 import { makeAbortableClient } from "@enduragent/core";
 import {
   ExportTrainingFileRpcResultSchema,
@@ -175,12 +175,14 @@ async function syncDirectory(path: string): Promise<void> {
 }
 
 export function createDurableTrainingExportWriter(input?: {
+  readonly platform?: NodeJS.Platform;
   readonly createTemporaryId?: () => string;
   readonly openFile?: typeof open;
   readonly renameFile?: typeof rename;
   readonly removeFile?: typeof rm;
   readonly syncDirectory?: (path: string) => Promise<void>;
 }): TrainingExportWriter {
+  const platform = input?.platform ?? process.platform;
   const createTemporaryId = input?.createTemporaryId ?? (() => randomBytes(12).toString("hex"));
   const openFile = input?.openFile ?? open;
   const renameFile = input?.renameFile ?? rename;
@@ -207,7 +209,7 @@ export function createDurableTrainingExportWriter(input?: {
       const root = dirname(destination);
       const id = createTemporaryId();
       if (!/^[A-Za-z0-9-]{1,128}$/.test(id)) return "failed";
-      const temporary = `${root}/.enduragent-export-${id}.tmp`;
+      const temporary = join(root, `.enduragent-export-${id}.tmp`);
       let handle: Awaited<ReturnType<typeof open>> | undefined;
       let renamed = false;
       try {
@@ -227,7 +229,7 @@ export function createDurableTrainingExportWriter(input?: {
         request.signal?.throwIfAborted();
         await renameFile(temporary, destination);
         renamed = true;
-        await sync(root);
+        if (platform !== "win32") await sync(root);
         return "committed";
       } catch {
         return renamed ? "uncertain" : "failed";

--- a/packages/coach/tests/training-export.test.ts
+++ b/packages/coach/tests/training-export.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rename, rm, stat } from "node:fs/promises";
+import { mkdtemp, open, readFile, readdir, rename, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -555,17 +555,22 @@ describe("durable training export writer", () => {
     const root = await mkdtemp(join(tmpdir(), "enduragent-export-"));
     roots.push(root);
     const destinationPath = join(root, "ride.fit");
-    const writer = createDurableTrainingExportWriter({ createTemporaryId: () => "fixed" });
+    const openFile = vi.fn(open);
+    const writer = createDurableTrainingExportWriter({
+      createTemporaryId: () => "fixed",
+      openFile,
+    });
 
     await expect(
       writer.write({ destinationPath, bytes: Uint8Array.from([1, 2, 3]) }),
     ).resolves.toBe("committed");
+    expect(openFile).toHaveBeenCalledWith(join(root, ".enduragent-export-fixed.tmp"), "wx", 0o600);
     expect(await readFile(destinationPath)).toEqual(Buffer.from([1, 2, 3]));
     expect((await stat(destinationPath)).mode & 0o777).toBe(0o600);
     expect(await readdir(root)).toEqual(["ride.fit"]);
   });
 
-  it("distinguishes pre-commit failure from post-rename commit uncertainty", async () => {
+  it("reports a pre-commit failure when temporary creation fails", async () => {
     const root = await mkdtemp(join(tmpdir(), "enduragent-export-state-"));
     roots.push(root);
     const destinationPath = join(root, "workouts.zip");
@@ -578,19 +583,34 @@ describe("durable training export writer", () => {
     await expect(failed.write({ destinationPath, bytes: Uint8Array.from([1]) })).resolves.toBe(
       "failed",
     );
-
-    const uncertain = createDurableTrainingExportWriter({
-      createTemporaryId: () => "uncertain",
-      renameFile: rename,
-      syncDirectory: vi.fn(async () => {
-        throw new Error("directory sync failed");
-      }),
-    });
-    await expect(uncertain.write({ destinationPath, bytes: Uint8Array.from([2]) })).resolves.toBe(
-      "uncertain",
-    );
-    expect(await readFile(destinationPath)).toEqual(Buffer.from([2]));
   });
+
+  it.each([
+    { name: "POSIX", platform: "linux", expected: "uncertain", syncCount: 1 },
+    { name: "Windows", platform: "win32", expected: "committed", syncCount: 0 },
+  ] as const)(
+    "reports the $name outcome when rename commits but directory sync fails",
+    async ({ platform, expected, syncCount }) => {
+      const root = await mkdtemp(join(tmpdir(), "enduragent-export-state-"));
+      roots.push(root);
+      const destinationPath = join(root, `workouts-${platform}.zip`);
+      const syncDirectory = vi.fn(async () => {
+        throw new Error("directory sync failed");
+      });
+
+      const writer = createDurableTrainingExportWriter({
+        platform,
+        createTemporaryId: () => `committed-${platform}`,
+        renameFile: rename,
+        syncDirectory,
+      });
+      await expect(writer.write({ destinationPath, bytes: Uint8Array.from([2]) })).resolves.toBe(
+        expected,
+      );
+      expect(syncDirectory).toHaveBeenCalledTimes(syncCount);
+      expect(await readFile(destinationPath)).toEqual(Buffer.from([2]));
+    },
+  );
 
   it("does not rename when cancellation is observed before the commit point", async () => {
     const controller = new AbortController();


### PR DESCRIPTION
Fixes issue 286, reproduced in the Windows VM on the installed build: every ride export failed instantly with "The export could not be saved to that location", for both FIT and GPX, into a folder that PowerShell could write to.

## Root cause

Four separate POSIX-only `startsWith("/")` gates rejected every `C:\...` path before any download or write:

1. `packages/coach-contract/src/training-export.ts` — export destinations.
2. `packages/coach-contract/src/rpc.ts` — `importFiles` paths.
3. `apps/desktop/src/preload/index.ts` — preload `parsePaths` (gate plus a `/`-only extension parse).
4. `apps/desktop-renderer/src/onboarding/bridge.ts` — `validateImportPaths`, on the path of every import entry point.

In the export case the schema throw was caught by the desktop IPC handler and collapsed into `write-failed`, which the renderer renders as the location error — so a validation rejection was indistinguishable from a filesystem failure.

## Changes

- New shared `PlatformAbsolutePathSchema` in coach-contract accepting POSIX, drive-letter and UNC absolute paths, rejecting NUL and keeping the existing length cap. Both contract gates are now aliases of it; the preload and the renderer bridge use it too, so there is one predicate rather than four.
- Extension parsing in the preload and the renderer bridge splits on the last `/` or `\`, so a dot in a directory name is still not mistaken for an extension.
- Export writer: temporary path joined with the platform separator; the post-rename directory fsync is skipped on win32, where directory handles cannot be synced and the throw would have turned a successful export into `commit-uncertain`.
- Desktop export IPC logs the caught error's name and message before returning `write-failed`.
- `keychain.ts` and the Telegram `startsWith("/")` uses are untouched — those are secret refs and bot commands, not paths.

## Verification

- New tests: contract accept/reject matrices (drive-letter, UNC, POSIX accepted; relative, `C:relative\x`, bare `\\`, NUL, empty, over-length rejected), preload and renderer Windows-path extension detection including a dot-in-directory case, win32-lane writer commit without directory sync, and the new IPC error logging.
- Node 24: contract 464/464, renderer 850/850, coach suite at parity with the clean epic tip, desktop 1742/1743 — the single failure is the known repo-root-cwd-sensitive `windows-parity-scenarios.test.ts`, which fails identically on the clean tip without this diff. Root `pnpm check` green.
- Four independent read-only reviewers verified the shared predicate (including a hand-traced adversarial string list), the preload/writer behavior, preload isolation after the vite config change, and tests/regressions. The renderer gate above was found by that review and fixed before merge.

## Residual

`C:/Users/x/ride.fit` (drive letter with forward slashes) is still rejected, though `path.win32.isAbsolute` accepts it. Unreachable from current callers — the CLI resolves paths first and Electron dialogs return backslash paths — but a latent trap for a future caller that forwards an unresolved path.