### PR TITLE
fix(desktop): stack the settings coach provider label

### DIFF
--- a/.changeset/settings-coach-label-layout.md
+++ b/.changeset/settings-coach-label-layout.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Settings now shows the coach Provider row's title and its active-route detail on separate lines instead of running them together.

--- a/apps/desktop-renderer/src/ui/settings/SettingsView.module.css
+++ b/apps/desktop-renderer/src/ui/settings/SettingsView.module.css
@@ -34,7 +34,10 @@
 }
 
 .label {
+  display: flex;
   flex: 1;
+  flex-direction: column;
+  align-items: stretch;
   min-width: 0;
 }
 

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import type { CoachClient } from "@enduragent/coach-client";
 import type { RuntimeConfigSnapshot, SpendSummary } from "@enduragent/coach-contract";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
@@ -50,6 +52,7 @@ import type { DesktopUpdateState } from "../src/update/controller.js";
 import { createDesktopUpdateController } from "../src/update/controller.js";
 import { CONVERSATION_FIELDS } from "../src/ui/settings/copy.js";
 import { SettingsView } from "../src/ui/settings/SettingsView.js";
+import settingsStyles from "../src/ui/settings/SettingsView.module.css";
 import { testBridge } from "./onboarding-harness.js";
 
 interface Deferred<T> {
@@ -1599,6 +1602,29 @@ describe("coach route", () => {
     expect(
       coach.getByText("Active coach settings are unavailable or not configured."),
     ).toBeInTheDocument();
+  });
+
+  it("stacks the provider label title above its active-route detail", async () => {
+    await renderSettings();
+
+    const provider = screen.getByRole("combobox", { name: /Provider/u });
+    const label = document.querySelector<HTMLLabelElement>(`label[for="${provider.id}"]`);
+    expect(label).not.toBeNull();
+    expect(label?.querySelector(`.${settingsStyles.rowTitle}`)?.textContent).toBe("Provider");
+    expect(label?.querySelector(`.${settingsStyles.rowDetail}`)?.textContent).toMatch(
+      /^Currently active: /u,
+    );
+
+    const stylesheet = await readFile(
+      resolve(import.meta.dirname, "..", "src", "ui", "settings", "SettingsView.module.css"),
+      "utf8",
+    );
+    const rule = /^\.label\s*\{([^}]*)\}/mu.exec(stylesheet)?.[1] ?? "";
+    expect(rule).toMatch(/display:\s*flex;/u);
+    expect(rule).toMatch(/flex-direction:\s*column;/u);
+    expect(rule).toMatch(/align-items:\s*stretch;/u);
+    expect(rule).toMatch(/flex:\s*1;/u);
+    expect(rule).toMatch(/min-width:\s*0;/u);
   });
 });
 


### PR DESCRIPTION
The Settings coach Provider row rendered its title and detail jammed into one line: "ProviderCurrently active: ChatGPT subscription · gpt-5.6-sol".

`.label` in `SettingsView.module.css` set only `flex: 1; min-width: 0;` with no `display`. Most settings rows wrap `<div>` children, which stack anyway because divs are block-level. The Provider and Model rows use a `<label>` element with `<span>` children — both inline — so they ran together.

Verified every other consumer of `.label` renders unchanged, including rows whose label wraps divs and the Model row whose label holds a single span.

Test is red against the old CSS: it asserts on the old rule body `flex: 1; min-width: 0;` and fails before the fix.
