### PR TITLE
fix(desktop): retry setup status on cold start instead of latching unavailable

### DIFF
--- a/.changeset/onboarding-status-cold-start.md
+++ b/.changeset/onboarding-status-cold-start.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: The first launch after installing no longer reports a fully-configured install as unconfigured — setup status now retries while the coach is still starting, shows a neutral "Checking setup…" state until it is known, and the Training page keeps reporting ride imports once setup is complete.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -30,7 +30,7 @@ import { createUpdateSettingsAdapter } from "./state/adapters/update.js";
 import { credentialDrafts } from "./state/credential-drafts.js";
 import { restoreManualSyncFocus } from "./state/manual-sync-focus.js";
 import { useEnduragentStore, type EnduragentState } from "./state/store.js";
-import { setupReady, setupRequired } from "./state/onboarding-slice.js";
+import { setupReady, setupSurfaceOnScreen } from "./state/onboarding-slice.js";
 import { nonTelegramSettingsMutationActive } from "./state/settings-slice.js";
 import { validateImportPaths, type OnboardingBridge } from "./onboarding/bridge.js";
 import { createOnboardingCompletionController } from "./onboarding/completion.js";
@@ -299,12 +299,7 @@ export function bootRenderer(): Disposer {
       store.getState().setRideImportSuppressed(presenting),
     focusOpener: () => {},
     onComplete: (completion) => onboardingCompletion.complete(completion),
-    ownsDroppedImportFiles: () => {
-      const state = store.getState();
-      return (
-        state.activeView === "settings" || (state.activeView === "chat" && setupRequired(state))
-      );
-    },
+    ownsDroppedImportFiles: () => setupSurfaceOnScreen(store.getState()),
     credentialMutationsBlocked: () => onboardingCredentialMutationsBlocked(store.getState()),
     codexAgentSupported: platform.capabilities.codexAgent,
   });

--- a/apps/desktop-renderer/src/onboarding/controller.ts
+++ b/apps/desktop-renderer/src/onboarding/controller.ts
@@ -164,6 +164,23 @@ export const CHATGPT_PROGRESS_DETAIL_DELAY_MS = 3_000;
 // had time to report its authoritative result.
 export const CHATGPT_ACTIVATION_TRANSPORT_TIMEOUT_MS = 12_000;
 export const ONBOARDING_STATUS_REFRESH_TIMEOUT_MS = 3_000;
+export const ONBOARDING_STATUS_COLD_START_TIMEOUT_MS = 8_000;
+export const ONBOARDING_STATUS_LOAD_ATTEMPTS = 4;
+export const ONBOARDING_STATUS_RETRY_BASE_DELAY_MS = 500;
+export const ONBOARDING_STATUS_RETRY_MAX_DELAY_MS = 2_000;
+
+export function onboardingStatusRetryDelayMs(attempt: number): number {
+  const delay = ONBOARDING_STATUS_RETRY_BASE_DELAY_MS * 2 ** attempt;
+  return delay > ONBOARDING_STATUS_RETRY_MAX_DELAY_MS
+    ? ONBOARDING_STATUS_RETRY_MAX_DELAY_MS
+    : delay;
+}
+
+export function setupStatusKnown(
+  surface: Pick<OnboardingSurfaceState, "initialized" | "loadUnavailable">,
+): boolean {
+  return surface.initialized && !surface.loadUnavailable;
+}
 
 type BoundedResult<T> =
   | { readonly status: "fulfilled"; readonly value: T }
@@ -933,7 +950,7 @@ export function createOnboardingController(
     publish();
   });
 
-  const load = async (hydrateIntake: boolean): Promise<void> => {
+  const load = async (hydrateIntake: boolean, retryWhileStarting: boolean): Promise<void> => {
     if (disposed || opening) return;
     const currentIntake = state.intake;
     const currentAutoPersistIntakeDraft = autoPersistIntakeDraft;
@@ -954,16 +971,42 @@ export function createOnboardingController(
     completed = false;
     lastCommit = null;
     actionStatus = null;
-    const [statusesResult, chatGptResult, configurationResult, setupResult] = await Promise.all([
-      settleWithin(options.bridge.credentialStatuses(), ONBOARDING_STATUS_REFRESH_TIMEOUT_MS),
-      settleWithin(options.bridge.chatGptStatus(), ONBOARDING_STATUS_REFRESH_TIMEOUT_MS),
-      settleWithin(options.bridge.llmConfiguration(), ONBOARDING_STATUS_REFRESH_TIMEOUT_MS),
-      settleWithin(
-        options.bridge.getSetupStatus?.() ??
-          Promise.resolve({ schemaVersion: 1 as const, intake: null, durableTrainingData: false }),
-        ONBOARDING_STATUS_REFRESH_TIMEOUT_MS,
-      ),
-    ]);
+    const coldStart = retryWhileStarting && !hasSuccessfulLoad;
+    const attemptTimeoutMs = coldStart
+      ? ONBOARDING_STATUS_COLD_START_TIMEOUT_MS
+      : ONBOARDING_STATUS_REFRESH_TIMEOUT_MS;
+    const maxAttempts = coldStart ? ONBOARDING_STATUS_LOAD_ATTEMPTS : 1;
+    const readAuthoritativeStatus = () =>
+      Promise.all([
+        settleWithin(options.bridge.credentialStatuses(), attemptTimeoutMs),
+        settleWithin(options.bridge.chatGptStatus(), attemptTimeoutMs),
+        settleWithin(options.bridge.llmConfiguration(), attemptTimeoutMs),
+        settleWithin(
+          options.bridge.getSetupStatus?.() ??
+            Promise.resolve({
+              schemaVersion: 1 as const,
+              intake: null,
+              durableTrainingData: false,
+            }),
+          attemptTimeoutMs,
+        ),
+      ]);
+    let read = await readAuthoritativeStatus();
+    let attempt = 0;
+    while (
+      read.some((entry) => entry.status !== "fulfilled") &&
+      attempt + 1 < maxAttempts &&
+      !disposed &&
+      visit === openVisit
+    ) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, onboardingStatusRetryDelayMs(attempt));
+      });
+      if (disposed || visit !== openVisit) break;
+      attempt += 1;
+      read = await readAuthoritativeStatus();
+    }
+    const [statusesResult, chatGptResult, configurationResult, setupResult] = read;
     if (disposed || visit !== openVisit) {
       opening = false;
       return;
@@ -1056,11 +1099,11 @@ export function createOnboardingController(
   return {
     open(): Promise<void> {
       if (disposed || presenting || opening) return Promise.resolve();
-      return load(true);
+      return load(true, true);
     },
     refresh(): Promise<void> {
       if (disposed || opening) return Promise.resolve();
-      return load(false);
+      return load(false, false);
     },
     close,
     dispose(): void {

--- a/apps/desktop-renderer/src/state/onboarding-slice.ts
+++ b/apps/desktop-renderer/src/state/onboarding-slice.ts
@@ -54,6 +54,18 @@ export function setupRequired(state: Pick<EnduragentState, "onboarding" | "setti
   return !setupReady(state);
 }
 
+export function setupSurfaceOnScreen(
+  state: Pick<EnduragentState, "activeView" | "onboarding" | "settings">,
+): boolean {
+  return state.activeView === "settings" || (state.activeView === "chat" && setupRequired(state));
+}
+
+export function rideImportStatusSuppressed(
+  state: Pick<EnduragentState, "activeView" | "onboarding" | "rideImportSuppressed" | "settings">,
+): boolean {
+  return state.rideImportSuppressed && setupSurfaceOnScreen(state);
+}
+
 export const createOnboardingSlice: StateCreator<EnduragentState, [], [], OnboardingSlice> = (
   set,
 ) => ({

--- a/apps/desktop-renderer/src/ui/onboarding/AiRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/AiRow.tsx
@@ -7,7 +7,11 @@ import {
   DESKTOP_CREDENTIAL_SLOTS,
   ONBOARDING_LLM_PROVIDER_LABELS,
 } from "../../onboarding/constants.js";
-import type { OnboardingActions, OnboardingSurfaceState } from "../../onboarding/controller.js";
+import {
+  setupStatusKnown,
+  type OnboardingActions,
+  type OnboardingSurfaceState,
+} from "../../onboarding/controller.js";
 import { chatGptReady, chatGptSignedIn, chatGptUiPhase } from "../../onboarding/machine.js";
 import {
   aiRowCopy,
@@ -32,6 +36,7 @@ import {
   AI_CANCEL_LABEL,
   AI_PANEL_ANNOUNCEMENTS,
   AI_ROW_TOOLTIP,
+  AI_ROW_UNSET,
   AI_SAVE_LABEL,
   AI_TRIGGER_LABELS,
   API_KEY_PANEL_HINT,
@@ -48,6 +53,7 @@ import {
   SETUP_LANE_LABELS,
   SETUP_LANE_MENU_HINTS,
   SETUP_MENU_LABEL,
+  SETUP_ROW_CHECKING_SUBTITLE,
 } from "./copy.js";
 import { CredentialField } from "./CredentialField.js";
 import { InfoTip } from "./InfoTip.js";
@@ -208,12 +214,15 @@ export function AiRow(props: {
         : null;
   const lanes = offeredLanes(configuration, wizard, lane);
   const note = claudeCliNote(configuration, wizard);
-  const copy = showsActiveProviderOutsideCatalogue
-    ? {
-        title: ONBOARDING_LLM_PROVIDER_LABELS[configuration.active!.provider],
-        subtitle: "Connected · powers your coach",
-      }
-    : aiRowCopy(lane, wizard, ready);
+  const statusKnown = setupStatusKnown(surface);
+  const copy = !statusKnown
+    ? { title: AI_ROW_UNSET.title, subtitle: SETUP_ROW_CHECKING_SUBTITLE }
+    : showsActiveProviderOutsideCatalogue
+      ? {
+          title: ONBOARDING_LLM_PROVIDER_LABELS[configuration.active!.provider],
+          subtitle: "Connected · powers your coach",
+        }
+      : aiRowCopy(lane, wizard, ready);
   const hasDisplayedProvider = lane !== null || showsActiveProviderOutsideCatalogue;
   const keyProviders = apiKeyProviders(configuration);
   const keySlot = DESKTOP_CREDENTIAL_SLOTS.find((slot) => slot === draft?.provider.provider);
@@ -319,7 +328,7 @@ export function AiRow(props: {
     <>
       <SetupRow
         id="ai"
-        status={ready ? "ready" : "pending"}
+        status={!statusKnown ? "none" : ready ? "ready" : "pending"}
         title={copy.title}
         subtitle={copy.subtitle}
         announce={panel === null ? "" : AI_PANEL_ANNOUNCEMENTS[panel]}
@@ -331,82 +340,86 @@ export function AiRow(props: {
           />
         }
         trailing={
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            <Menu.Root>
-              <Menu.Trigger
-                ref={triggerRef}
-                data-setup-trigger="ai"
-                disabled={controlsDisabled || chatGptActivating}
-                aria-label={hasDisplayedProvider ? AI_TRIGGER_LABELS.set : AI_TRIGGER_LABELS.unset}
-                className={!hasDisplayedProvider ? BUTTON_OUTLINE_SM : BUTTON_QUIET_SM}
-              >
-                {hasDisplayedProvider ? "Change" : "Choose"}
-              </Menu.Trigger>
-              <Menu.Portal>
-                <Menu.Positioner side="bottom" align="end" sideOffset={6}>
-                  <Menu.Popup
-                    data-setup-menu="ai"
-                    className="w-[262px] rounded-md border border-line-2 bg-surface p-[5px] shadow-elev-3"
-                  >
-                    <Menu.RadioGroup value={lane}>
-                      <Menu.GroupLabel className="px-[9px] pt-1.5 pb-1 text-[11px] font-semibold tracking-wider text-ink-2 uppercase">
-                        {SETUP_MENU_LABEL}
-                      </Menu.GroupLabel>
-                      {lanes.map((entry) => (
-                        <Menu.RadioItem
-                          key={entry}
-                          value={entry}
-                          data-lane={entry}
-                          closeOnClick
-                          disabled={controlsDisabled}
-                          className={MENU_ITEM_CLASS}
-                          onClick={() => {
-                            choose(entry);
-                          }}
-                        >
-                          <span className="mt-px grid size-[15px] shrink-0 place-items-center text-ok">
-                            <Menu.RadioItemIndicator>
-                              <Check size={11} strokeWidth={3.2} aria-hidden="true" />
-                            </Menu.RadioItemIndicator>
-                          </span>
-                          <span className="min-w-0 flex-1">
-                            <b className="block text-[13.5px] font-medium">
-                              {SETUP_LANE_LABELS[entry]}
-                            </b>
-                            <i className="mt-px block text-xs text-ink-2 not-italic">
-                              {SETUP_LANE_MENU_HINTS[entry]}
-                            </i>
-                          </span>
-                        </Menu.RadioItem>
-                      ))}
-                    </Menu.RadioGroup>
-                    {note === null ? null : (
-                      <div className="mt-1 border-t border-line px-[9px] pt-2 pb-1">
-                        <p
-                          data-setup-note="claude-cli"
-                          className="text-[11.5px] leading-normal text-ink-2"
-                        >
-                          {note}
-                        </p>
-                        <Menu.Item
-                          disabled={controlsDisabled}
-                          className={MENU_ACTION_CLASS}
-                          onClick={() => {
-                            actions?.recheckClaudeCli();
-                          }}
-                        >
-                          {CLAUDE_CLI_RECHECK_LABEL}
-                        </Menu.Item>
-                      </div>
-                    )}
-                  </Menu.Popup>
-                </Menu.Positioner>
-              </Menu.Portal>
-            </Menu.Root>
-            {props.placement === "settings" && primaryCredential !== null ? (
-              <CredentialDeleteButton credential={primaryCredential} />
-            ) : null}
-          </div>
+          !statusKnown ? null : (
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <Menu.Root>
+                <Menu.Trigger
+                  ref={triggerRef}
+                  data-setup-trigger="ai"
+                  disabled={controlsDisabled || chatGptActivating}
+                  aria-label={
+                    hasDisplayedProvider ? AI_TRIGGER_LABELS.set : AI_TRIGGER_LABELS.unset
+                  }
+                  className={!hasDisplayedProvider ? BUTTON_OUTLINE_SM : BUTTON_QUIET_SM}
+                >
+                  {hasDisplayedProvider ? "Change" : "Choose"}
+                </Menu.Trigger>
+                <Menu.Portal>
+                  <Menu.Positioner side="bottom" align="end" sideOffset={6}>
+                    <Menu.Popup
+                      data-setup-menu="ai"
+                      className="w-[262px] rounded-md border border-line-2 bg-surface p-[5px] shadow-elev-3"
+                    >
+                      <Menu.RadioGroup value={lane}>
+                        <Menu.GroupLabel className="px-[9px] pt-1.5 pb-1 text-[11px] font-semibold tracking-wider text-ink-2 uppercase">
+                          {SETUP_MENU_LABEL}
+                        </Menu.GroupLabel>
+                        {lanes.map((entry) => (
+                          <Menu.RadioItem
+                            key={entry}
+                            value={entry}
+                            data-lane={entry}
+                            closeOnClick
+                            disabled={controlsDisabled}
+                            className={MENU_ITEM_CLASS}
+                            onClick={() => {
+                              choose(entry);
+                            }}
+                          >
+                            <span className="mt-px grid size-[15px] shrink-0 place-items-center text-ok">
+                              <Menu.RadioItemIndicator>
+                                <Check size={11} strokeWidth={3.2} aria-hidden="true" />
+                              </Menu.RadioItemIndicator>
+                            </span>
+                            <span className="min-w-0 flex-1">
+                              <b className="block text-[13.5px] font-medium">
+                                {SETUP_LANE_LABELS[entry]}
+                              </b>
+                              <i className="mt-px block text-xs text-ink-2 not-italic">
+                                {SETUP_LANE_MENU_HINTS[entry]}
+                              </i>
+                            </span>
+                          </Menu.RadioItem>
+                        ))}
+                      </Menu.RadioGroup>
+                      {note === null ? null : (
+                        <div className="mt-1 border-t border-line px-[9px] pt-2 pb-1">
+                          <p
+                            data-setup-note="claude-cli"
+                            className="text-[11.5px] leading-normal text-ink-2"
+                          >
+                            {note}
+                          </p>
+                          <Menu.Item
+                            disabled={controlsDisabled}
+                            className={MENU_ACTION_CLASS}
+                            onClick={() => {
+                              actions?.recheckClaudeCli();
+                            }}
+                          >
+                            {CLAUDE_CLI_RECHECK_LABEL}
+                          </Menu.Item>
+                        </div>
+                      )}
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.Root>
+              {props.placement === "settings" && primaryCredential !== null ? (
+                <CredentialDeleteButton credential={primaryCredential} />
+              ) : null}
+            </div>
+          )
         }
       />
       {props.placement === "settings" && primaryCredential !== null ? (

--- a/apps/desktop-renderer/src/ui/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/OnboardingWizard.tsx
@@ -15,11 +15,15 @@ import {
   PRIMARY_LABEL,
   RETRY_SETUP_STATUS_LABEL,
   SETUP_CHAT_SUBTITLE,
+  SETUP_CHECKING_HEADING,
+  SETUP_CHECKING_SUBTITLE,
   SETUP_HEADING,
   SETUP_SETTINGS_HEADING,
+  SETUP_STATUS_CHECKING_COPY,
   SETUP_STATUS_UNAVAILABLE_COPY,
 } from "./copy.js";
 import { IntakeRows } from "./IntakeRows.js";
+import { setupStatusKnown } from "../../onboarding/controller.js";
 import { intakeComplete } from "../../onboarding/machine.js";
 import { credentialChangesBlocked } from "../../settings/credential-controller.js";
 import {
@@ -57,10 +61,12 @@ export function SetupPanel(props: { readonly placement: SetupPlacement }): React
 
   const wizard = surface.wizard;
   const readiness = surface.readiness;
+  const statusKnown = setupStatusKnown(surface);
   const requiredReadyCount = [readiness.provider, readiness.trainingData, readiness.intake].filter(
     Boolean,
   ).length;
   const requiredSetupReady = requiredReadyCount === 3;
+  const readinessState = !statusKnown ? "checking" : requiredSetupReady ? "ready" : "pending";
   const activeCredential = desktopCredentialId(surface.configuration?.active?.provider);
   const primaryAiCredential =
     activeCredential === surface.draft?.provider.provider ? activeCredential : null;
@@ -110,24 +116,26 @@ export function SetupPanel(props: { readonly placement: SetupPlacement }): React
               tabIndex={-1}
               className={`${styles.chatTitle} focus-visible:outline-2 focus-visible:outline-offset-[3px] focus-visible:outline-ink`}
             >
-              {SETUP_HEADING}
+              {statusKnown ? SETUP_HEADING : SETUP_CHECKING_HEADING}
             </h2>
-            <p className={`${styles.chatSubtitle} text-ink-2`}>{SETUP_CHAT_SUBTITLE}</p>
+            <p className={`${styles.chatSubtitle} text-ink-2`}>
+              {statusKnown ? SETUP_CHAT_SUBTITLE : SETUP_CHECKING_SUBTITLE}
+            </p>
           </div>
           <span
-            className={`inline-flex h-ctl-sm flex-none items-center gap-2 rounded-full border px-row text-xs ${requiredSetupReady ? "border-ok/35 bg-ok/10 text-ok" : "border-line-2 bg-surface text-ink-2"}`}
-            data-setup-readiness={requiredReadyCount}
-            data-state={requiredSetupReady ? "ready" : "pending"}
+            className={`inline-flex h-ctl-sm flex-none items-center gap-2 rounded-full border px-row text-xs ${readinessState === "ready" ? "border-ok/35 bg-ok/10 text-ok" : "border-line-2 bg-surface text-ink-2"}`}
+            data-setup-readiness={statusKnown ? requiredReadyCount : "unknown"}
+            data-state={readinessState}
             role="status"
             aria-live="polite"
             aria-atomic="true"
           >
             <span
-              className={`size-2 rounded-full ring-4 ${requiredSetupReady ? "bg-ok ring-ok/10" : "bg-warn ring-warn/10"}`}
-              data-setup-readiness-dot={requiredSetupReady ? "ready" : "pending"}
+              className={`size-2 rounded-full ring-4 ${readinessState === "ready" ? "bg-ok ring-ok/10" : readinessState === "pending" ? "bg-warn ring-warn/10" : "bg-line-2 ring-line-2/20"}`}
+              data-setup-readiness-dot={readinessState}
               aria-hidden="true"
             />
-            {requiredReadyCount} of 3 required ready
+            {statusKnown ? `${requiredReadyCount} of 3 required ready` : SETUP_STATUS_CHECKING_COPY}
           </span>
         </header>
       ) : (

--- a/apps/desktop-renderer/src/ui/onboarding/TrainingRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/TrainingRow.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useLayoutEffect, useRef, useState, type ReactElement } from "react";
-import type { OnboardingActions, OnboardingSurfaceState } from "../../onboarding/controller.js";
+import {
+  setupStatusKnown,
+  type OnboardingActions,
+  type OnboardingSurfaceState,
+} from "../../onboarding/controller.js";
 import { credentialPresentation } from "../../onboarding/credential-presentation.js";
 import { errorSection } from "../../onboarding/lanes.js";
 import {
@@ -15,6 +19,7 @@ import {
   IMPORT_FILES_LABEL,
   INTERVALS_PANEL_HINT,
   RETRY_SAVED_KEYS_LABEL,
+  SETUP_ROW_CHECKING_SUBTITLE,
   TRAINING_CANCEL_LABEL,
   TRAINING_CONNECT_TITLE,
   TRAINING_ROW_SUBTITLES,
@@ -116,7 +121,12 @@ export function TrainingRow(props: {
     }
   }, [credentialFocus, props.placement, repairCredential]);
 
-  const subtitle = connected ? TRAINING_ROW_SUBTITLES.connected : TRAINING_ROW_SUBTITLES.missing;
+  const statusKnown = setupStatusKnown(surface);
+  const subtitle = !statusKnown
+    ? SETUP_ROW_CHECKING_SUBTITLE
+    : connected
+      ? TRAINING_ROW_SUBTITLES.connected
+      : TRAINING_ROW_SUBTITLES.missing;
 
   const connect = (): void => {
     if (actions === null || controlsDisabled || importing) return;
@@ -128,7 +138,7 @@ export function TrainingRow(props: {
     <>
       <SetupRow
         id="training"
-        status={connected ? "ready" : "pending"}
+        status={!statusKnown ? "none" : connected ? "ready" : "pending"}
         title={TRAINING_ROW_TITLE}
         subtitle={subtitle}
         info={
@@ -139,7 +149,7 @@ export function TrainingRow(props: {
           />
         }
         trailing={
-          connected ? (
+          !statusKnown ? null : connected ? (
             <CredentialDeleteButton credential="intervals-icu" buttonRef={deleteRef} />
           ) : (
             <button

--- a/apps/desktop-renderer/src/ui/onboarding/copy.ts
+++ b/apps/desktop-renderer/src/ui/onboarding/copy.ts
@@ -67,6 +67,15 @@ export const SETUP_SETTINGS_HEADING = "Setup";
 export const SETUP_CHAT_SUBTITLE =
   "Connect what your coach needs. Telegram is optional and never blocks Chat.";
 
+export const SETUP_CHECKING_HEADING = "Checking your setup";
+
+export const SETUP_CHECKING_SUBTITLE =
+  "Reading the connections already saved on this computer. This can take a moment right after launch.";
+
+export const SETUP_STATUS_CHECKING_COPY = "Checking setup…";
+
+export const SETUP_ROW_CHECKING_SUBTITLE = "Checking what is already connected…";
+
 export const SETUP_STATUS_UNAVAILABLE_COPY =
   "Setup status couldn’t be loaded. Check that Enduragent is running, then try again.";
 

--- a/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef, type ReactElement } from "react";
 import { VIEWS } from "../../app/views.js";
 import { registerNewConversationOpener } from "../../state/new-conversation-opener.js";
 import { settingsMutationActive } from "../../state/settings-slice.js";
+import { setupStatusKnown } from "../../onboarding/controller.js";
+import { SETUP_STATUS_CHECKING_COPY } from "../onboarding/copy.js";
 import { setupReady } from "../../state/onboarding-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
 import styles from "./Sidebar.module.css";
@@ -16,6 +18,8 @@ export function Sidebar(): ReactElement {
   const resetPhase = useEnduragentStore((state) => state.chat.resetPhase);
   const actions = useEnduragentStore((state) => state.chatActions);
   const canChat = useEnduragentStore(setupReady);
+  const statusKnown = useEnduragentStore((state) => setupStatusKnown(state.onboarding));
+  const setupState = canChat ? "ready" : statusKnown ? "waiting" : "checking";
   const settingsBusy = useEnduragentStore((state) => settingsMutationActive(state.settings));
   const opener = useRef<HTMLButtonElement>(null);
   const navigationLocked = activeView === "settings" && settingsBusy;
@@ -76,14 +80,20 @@ export function Sidebar(): ReactElement {
         <SyncChip />
         <div
           className="flex min-h-ctl items-center gap-2 px-row text-xs text-ink-2"
-          data-sidebar-setup-readiness={canChat ? "ready" : "waiting"}
+          data-sidebar-setup-readiness={setupState}
         >
           <span
-            className={`size-2 rounded-full ${canChat ? "bg-ok" : "bg-warn"}`}
-            data-sidebar-setup-dot={canChat ? "ready" : "waiting"}
+            className={`size-2 rounded-full ${setupState === "ready" ? "bg-ok" : setupState === "waiting" ? "bg-warn" : "bg-line-2"}`}
+            data-sidebar-setup-dot={setupState}
             aria-hidden="true"
           />
-          <span>{canChat ? "Ready" : "Waiting for setup"}</span>
+          <span>
+            {setupState === "ready"
+              ? "Ready"
+              : setupState === "waiting"
+                ? "Waiting for setup"
+                : SETUP_STATUS_CHECKING_COPY}
+          </span>
         </div>
       </div>
     </aside>

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@enduragent/coach-contract";
 import { useEffect, useLayoutEffect, useRef, type ReactElement, type ReactNode } from "react";
 import { rideImportStatusCopy } from "../../ride-import.js";
+import { rideImportStatusSuppressed } from "../../state/onboarding-slice.js";
 import {
   setManualSyncFocusFallback,
   setManualSyncFocusTarget,
@@ -278,7 +279,7 @@ function WellnessPanel(props: { readonly panel: WellnessTrendPanel }): ReactElem
 
 function RideImportPanel(): ReactElement {
   const state = useEnduragentStore((store) => store.rideImport);
-  const suppressed = useEnduragentStore((store) => store.rideImportSuppressed);
+  const suppressed = useEnduragentStore(rideImportStatusSuppressed);
   const actions = useEnduragentStore((store) => store.rideImportActions);
   const copy = suppressed ? "" : rideImportStatusCopy(state);
   const progress = state.status === "running" ? state.progress : null;

--- a/apps/desktop-renderer/tests/onboarding-chatgpt-lifecycle.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-chatgpt-lifecycle.test.tsx
@@ -1,6 +1,10 @@
 import { act, fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ONBOARDING_STATUS_COLD_START_TIMEOUT_MS,
+  ONBOARDING_STATUS_RETRY_BASE_DELAY_MS,
+} from "../src/onboarding/controller.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import {
   chooseLane,
@@ -292,13 +296,13 @@ describe("ChatGPT onboarding lifecycle", () => {
     await act(async () => {
       const opening = wizard.controller.open();
       await Promise.resolve();
-      await vi.advanceTimersByTimeAsync(3_000);
+      await vi.advanceTimersByTimeAsync(
+        ONBOARDING_STATUS_COLD_START_TIMEOUT_MS + ONBOARDING_STATUS_RETRY_BASE_DELAY_MS,
+      );
       await opening;
     });
     expect(wizard.controller.state().chatGptCredentialState).toBe("absent");
-    expect(useEnduragentStore.getState().onboarding.loadUnavailable).toBe(true);
-
-    await act(async () => wizard.controller.refresh());
+    expect(bridge.chatGptStatus).toHaveBeenCalledTimes(2);
     expect(useEnduragentStore.getState().onboarding.loadUnavailable).toBe(false);
 
     await act(async () => {

--- a/apps/desktop-renderer/tests/onboarding-completion.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-completion.test.ts
@@ -10,11 +10,19 @@ import {
 } from "../src/onboarding/completion.js";
 import {
   createOnboardingController,
-  ONBOARDING_STATUS_REFRESH_TIMEOUT_MS,
+  onboardingStatusRetryDelayMs,
+  ONBOARDING_STATUS_COLD_START_TIMEOUT_MS,
+  ONBOARDING_STATUS_LOAD_ATTEMPTS,
   type OnboardingSurfaceState,
 } from "../src/onboarding/controller.js";
 import type { CredentialDraftPort } from "../src/onboarding/credentials.js";
 import type { OnboardingCompletion } from "../src/onboarding/machine.js";
+
+const COLD_START_WINDOW_MS =
+  ONBOARDING_STATUS_COLD_START_TIMEOUT_MS * ONBOARDING_STATUS_LOAD_ATTEMPTS +
+  Array.from({ length: ONBOARDING_STATUS_LOAD_ATTEMPTS }, (_unused, attempt) =>
+    onboardingStatusRetryDelayMs(attempt),
+  ).reduce((total, delay) => total + delay, 0);
 
 const completion = {
   providerConfigured: true,
@@ -615,8 +623,12 @@ describe("onboarding runtime completion gate", () => {
         status: "configured",
         runtimeReady: true,
       }));
-      baseBridge.credentialStatuses.mockImplementationOnce(
-        async () => await new Promise<never>(() => undefined),
+      let credentialStatusesHang = true;
+      const readyStatuses = baseBridge.credentialStatuses.getMockImplementation();
+      baseBridge.credentialStatuses.mockImplementation(async () =>
+        credentialStatusesHang
+          ? await new Promise<never>(() => undefined)
+          : ((await readyStatuses?.()) ?? []),
       );
       const bridge = {
         ...baseBridge,
@@ -636,10 +648,11 @@ describe("onboarding runtime completion gate", () => {
       const harness = onboardingHarness(bridge);
 
       const opening = harness.controller.open();
-      await vi.advanceTimersByTimeAsync(ONBOARDING_STATUS_REFRESH_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(COLD_START_WINDOW_MS);
       await opening;
 
       expect(harness.surface().loadUnavailable).toBe(true);
+      expect(bridge.credentialStatuses).toHaveBeenCalledTimes(ONBOARDING_STATUS_LOAD_ATTEMPTS);
       const stateBeforeMutations = harness.controller.state();
       harness.controller.selectProvider("anthropic");
       harness.controller.selectModel("claude-sonnet-4-6");
@@ -670,6 +683,7 @@ describe("onboarding runtime completion gate", () => {
       expect(bridge.saveIntake).not.toHaveBeenCalled();
       expect(harness.controller.ownsDroppedImportFiles()).toBe(false);
 
+      credentialStatusesHang = false;
       await harness.controller.refresh();
 
       expect(harness.surface().loadUnavailable).toBe(false);

--- a/apps/desktop-renderer/tests/setup-readiness.test.tsx
+++ b/apps/desktop-renderer/tests/setup-readiness.test.tsx
@@ -1,6 +1,11 @@
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { act, fireEvent, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  onboardingStatusRetryDelayMs,
+  ONBOARDING_STATUS_COLD_START_TIMEOUT_MS,
+  ONBOARDING_STATUS_LOAD_ATTEMPTS,
+  ONBOARDING_STATUS_RETRY_BASE_DELAY_MS,
+} from "../src/onboarding/controller.js";
 import { setupReady } from "../src/state/onboarding-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { SetupPanel } from "../src/ui/onboarding/OnboardingWizard.js";
@@ -21,6 +26,12 @@ const savedIntake = {
   clinician_cleared: false,
   injury_status: "managing",
 } as const;
+
+const COLD_START_WINDOW_MS =
+  ONBOARDING_STATUS_COLD_START_TIMEOUT_MS * ONBOARDING_STATUS_LOAD_ATTEMPTS +
+  Array.from({ length: ONBOARDING_STATUS_LOAD_ATTEMPTS }, (_unused, attempt) =>
+    onboardingStatusRetryDelayMs(attempt),
+  ).reduce((total, delay) => total + delay, 0);
 
 function readinessBadge(): HTMLElement {
   const badge = document.querySelector<HTMLElement>("[data-setup-readiness]");
@@ -349,48 +360,102 @@ describe("authoritative setup readiness", () => {
     wizard.controller.dispose();
   });
 
-  it("shows unavailable setup status, disables controls, and recovers through Retry", async () => {
-    const user = userEvent.setup();
-    const bridge = testBridge(async () => ({ status: "refused", reason: "cancelled" }));
-    bridge.getSetupStatus = vi
-      .fn()
-      .mockRejectedValueOnce(new TypeError("synthetic setup read failure"))
-      .mockResolvedValueOnce({
-        schemaVersion: 1 as const,
-        intake: savedIntake,
-        durableTrainingData: true,
+  it("retries a cold start before it calls setup status unavailable, and recovers through Retry", async () => {
+    vi.useFakeTimers();
+    try {
+      const bridge = testBridge(async () => ({ status: "refused", reason: "cancelled" }));
+      let setupReadFails = true;
+      bridge.getSetupStatus = vi.fn(async () => {
+        if (setupReadFails) throw new TypeError("synthetic setup read failure");
+        return { schemaVersion: 1 as const, intake: savedIntake, durableTrainingData: true };
       });
-    const wizard = mountWizard({ bridge });
-    await wizard.open();
+      const wizard = mountWizard({ bridge });
 
-    expect(useEnduragentStore.getState().onboarding.loadUnavailable).toBe(true);
-    expect(setupReady(useEnduragentStore.getState())).toBe(false);
-    expect(
-      screen.getByText(
-        "Setup status couldn’t be loaded. Check that Enduragent is running, then try again.",
-      ),
-    ).toBeInTheDocument();
-    expect(document.querySelector<HTMLButtonElement>('[data-setup-trigger="ai"]')).toBeDisabled();
-    expect(
-      document.querySelector<HTMLButtonElement>('[data-setup-trigger="training"]'),
-    ).toBeDisabled();
-    expect(control<HTMLSelectElement>("onboarding-injury-status")).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Start coaching" })).toBeDisabled();
+      await act(async () => {
+        const opening = wizard.controller.open();
+        await vi.advanceTimersByTimeAsync(COLD_START_WINDOW_MS);
+        await opening;
+      });
 
-    await user.click(screen.getByRole("button", { name: "Retry setup status" }));
+      expect(bridge.getSetupStatus).toHaveBeenCalledTimes(ONBOARDING_STATUS_LOAD_ATTEMPTS);
+      expect(useEnduragentStore.getState().onboarding.loadUnavailable).toBe(true);
+      expect(setupReady(useEnduragentStore.getState())).toBe(false);
+      expect(
+        screen.getByText(
+          "Setup status couldn’t be loaded. Check that Enduragent is running, then try again.",
+        ),
+      ).toBeInTheDocument();
+      expect(document.querySelector('[data-setup-trigger="ai"]')).toBeNull();
+      expect(document.querySelector('[data-setup-trigger="training"]')).toBeNull();
+      expect(control<HTMLSelectElement>("onboarding-injury-status")).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Start coaching" })).toBeDisabled();
 
-    await waitFor(() => {
+      setupReadFails = false;
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Retry setup status" }));
+        await vi.advanceTimersByTimeAsync(COLD_START_WINDOW_MS);
+      });
+
       expect(useEnduragentStore.getState().onboarding.loadUnavailable).toBe(false);
       expect(setupReady(useEnduragentStore.getState())).toBe(true);
-    });
-    expect(bridge.getSetupStatus).toHaveBeenCalledTimes(2);
-    expect(screen.queryByRole("button", { name: "Retry setup status" })).toBeNull();
-    expect(document.querySelector<HTMLButtonElement>('[data-setup-trigger="ai"]')).toBeEnabled();
-    expect(
-      document.querySelector<HTMLButtonElement>('[data-setup-trigger="training"]'),
-    ).toBeEnabled();
-    expect(control<HTMLSelectElement>("onboarding-injury-status")).toBeEnabled();
-    wizard.controller.dispose();
+      expect(bridge.getSetupStatus).toHaveBeenCalledTimes(ONBOARDING_STATUS_LOAD_ATTEMPTS + 1);
+      expect(screen.queryByRole("button", { name: "Retry setup status" })).toBeNull();
+      expect(document.querySelector<HTMLButtonElement>('[data-setup-trigger="ai"]')).toBeEnabled();
+      expect(
+        document.querySelector<HTMLButtonElement>('[data-setup-trigger="training"]'),
+      ).toBeEnabled();
+      expect(control<HTMLSelectElement>("onboarding-injury-status")).toBeEnabled();
+      wizard.controller.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reaches the configured state with no user input when the daemon answers late", async () => {
+    vi.useFakeTimers();
+    try {
+      const bridge = testBridge(async () => ({ status: "refused", reason: "cancelled" }));
+      let daemonStarting = true;
+      const getSetupStatus = vi.fn(async () => {
+        if (daemonStarting) throw new TypeError("coach daemon is still starting");
+        return { schemaVersion: 1 as const, intake: savedIntake, durableTrainingData: true };
+      });
+      bridge.getSetupStatus = getSetupStatus;
+      const wizard = mountWizard({ bridge });
+
+      const opening = act(async () => {
+        await wizard.controller.open();
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ONBOARDING_STATUS_RETRY_BASE_DELAY_MS);
+      });
+
+      expect(useEnduragentStore.getState().onboarding.loadUnavailable).toBe(false);
+      expect(document.querySelector('[data-setup-row="ai"]')).toHaveAttribute("data-state", "none");
+      expect(document.querySelector('[data-setup-row="training"]')).toHaveAttribute(
+        "data-state",
+        "none",
+      );
+      expect(document.body.textContent).not.toContain("Required · where your rides come from");
+      expect(document.body.textContent).not.toContain("Required — Enduragent doesn't include one");
+      expect(readinessBadge()).toHaveTextContent("Checking setup…");
+      expect(readinessBadge()).not.toHaveTextContent("0 of 3 required ready");
+
+      daemonStarting = false;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(COLD_START_WINDOW_MS);
+      });
+      await opening;
+
+      expect(useEnduragentStore.getState().onboarding.loadUnavailable).toBe(false);
+      expect(setupReady(useEnduragentStore.getState())).toBe(true);
+      expect(readinessBadge()).toHaveTextContent("3 of 3 required ready");
+      expect(screen.queryByRole("button", { name: "Retry setup status" })).toBeNull();
+      expect(getSetupStatus.mock.calls.length).toBeGreaterThan(1);
+      wizard.controller.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("retains unsaved provider and intake drafts across an unavailable refresh and retry", async () => {

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -146,7 +146,7 @@ describe("shell", () => {
   it("keeps the selected destination active while setup is required", async () => {
     useEnduragentStore.setState({
       activeView: "training",
-      onboarding: { ...CLOSED_ONBOARDING, open: true },
+      onboarding: { ...CLOSED_ONBOARDING, open: true, initialized: true, loading: false },
     });
     render(<Shell onReady={() => {}} />);
 

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -313,7 +313,7 @@ describe("sidebar setup gating", () => {
     );
     expect(setupReadiness().querySelector("[data-sidebar-setup-dot]")).toHaveClass("bg-ok");
 
-    update({ onboarding: CLOSED_ONBOARDING });
+    update({ onboarding: { ...CLOSED_ONBOARDING, initialized: true, loading: false } });
 
     expect(setupReadiness()).toHaveAttribute("data-sidebar-setup-readiness", "waiting");
     expect(setupReadiness()).toHaveTextContent("Waiting for setup");
@@ -322,6 +322,20 @@ describe("sidebar setup gating", () => {
       "waiting",
     );
     expect(setupReadiness().querySelector("[data-sidebar-setup-dot]")).toHaveClass("bg-warn");
+  });
+
+  it("says setup is being checked instead of waiting while status is unknown", () => {
+    render(<Sidebar />);
+
+    update({ onboarding: CLOSED_ONBOARDING });
+
+    expect(setupReadiness()).toHaveAttribute("data-sidebar-setup-readiness", "checking");
+    expect(setupReadiness()).toHaveTextContent("Checking setup…");
+    expect(setupReadiness()).not.toHaveTextContent("Waiting for setup");
+
+    update({ onboarding: { ...READY_ONBOARDING, loadUnavailable: true } });
+
+    expect(setupReadiness()).toHaveAttribute("data-sidebar-setup-readiness", "checking");
   });
 
   it("waits when initialized setup is only partially ready", () => {

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RideImportState } from "../src/ride-import.js";
 import { EMPTY_RIDE_ANALYSIS } from "../src/activity-analysis/controller.js";
 import { restoreManualSyncFocus } from "../src/state/manual-sync-focus.js";
+import { READY_ONBOARDING } from "../src/state/onboarding-slice.js";
 import { IDLE_RIDE_IMPORT } from "../src/state/ride-import-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
@@ -1247,7 +1248,7 @@ describe("training page ride import", () => {
     expect(status).toHaveAttribute("data-state", "failed");
   });
 
-  it("suppresses the resident status while onboarding owns the import surface", () => {
+  it("suppresses the resident status only while the setup surface is on screen", () => {
     render(<TrainingView />);
     setRideImport({
       status: "running",
@@ -1256,14 +1257,31 @@ describe("training page ride import", () => {
       progress: null,
       result: null,
     });
-    update({ rideImportSuppressed: true });
+    update({ rideImportSuppressed: true, activeView: "settings" });
 
     const status = document.querySelector(".ride-import-status");
     expect(status).toHaveProperty("hidden", true);
     expect(status).toHaveAttribute("data-state", "idle");
 
-    update({ rideImportSuppressed: false });
+    update({ activeView: "training" });
     expect(status).toHaveProperty("hidden", false);
     expect(status).toHaveTextContent("Importing ride files…");
+  });
+
+  it("keeps reporting imports after setup completes and the wizard stops presenting", () => {
+    render(<TrainingView />);
+    update({ rideImportSuppressed: true, onboarding: READY_ONBOARDING });
+    setRideImport({
+      status: "running",
+      owner: "resident",
+      stage: "importing",
+      progress: null,
+      result: null,
+    });
+
+    const status = document.querySelector(".ride-import-status");
+    expect(status).toHaveProperty("hidden", false);
+    expect(status).toHaveTextContent("Importing ride files…");
+    expect(status).toHaveAttribute("data-state", "running");
   });
 });


### PR DESCRIPTION
The first launch after installing told a fully-configured user that nothing was set up: "0 of 3 required ready", with the AI and Intervals rows rendering unconfigured copy and the sidebar showing "Waiting for setup". Waiting did not help; one click of `Retry setup status` fixed it instantly.

The open path raced four bridge calls on a single 3 s budget. Any miss latched `loadUnavailable` until the user acted — no backoff, no re-poll, no wait for the daemon. On a first post-install launch the coach daemon is still starting, so 3 s is easy to miss.

Now the startup path retries with bounded backoff, and while status is unknown the rows render a neutral loading state instead of unconfigured copy. A configured install is never described as empty.

## Limits

- `ONBOARDING_STATUS_COLD_START_TIMEOUT_MS = 8000` — per-attempt budget for the first status read after launch; 3 s is a steady-state number and too tight while the daemon is starting.
- `ONBOARDING_STATUS_LOAD_ATTEMPTS = 4` — total automatic attempts before the surface calls status unavailable.
- `ONBOARDING_STATUS_RETRY_BASE_DELAY_MS = 500` — first backoff pause; doubles per attempt.
- `ONBOARDING_STATUS_RETRY_MAX_DELAY_MS = 2000` — cap on the doubling so late attempts stay responsive.
- `ONBOARDING_STATUS_REFRESH_TIMEOUT_MS` stays `3000`, now applying only to refreshes after a successful load.

Worst-case cold start is roughly 35 s of "Checking setup…" before the surface latches unavailable, against the previous single 3 s budget. That trade is deliberate — the old behaviour failed fast into a false "nothing configured" — but it is the number to challenge if it feels long.

Negative control: with `maxAttempts` forced to 1 the new tests fail, confirming they exercise the retry path rather than passing incidentally.
