### PR TITLE
fix(desktop): make danger a button colour, not a weight, and give every control a pointer cursor

### DIFF
--- a/.changeset/button-primitive-consistency.md
+++ b/.changeset/button-primitive-consistency.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Delete buttons in setup and settings now sit at the same weight as the buttons beside them and differ only in colour, the confirm button in a delete prompt is a filled red so it never reads as the same control as Cancel, and buttons, links and dropdowns across setup and settings show the hand cursor on hover.
+
+Danger is a colour, not a button weight. The renderer now exports exactly two danger constants: `BUTTON_DANGER_QUIET_SM` at the quiet weight (no border, transparent background) for every in-row destructive action, and `BUTTON_DANGER_SOLID_SM` at the solid weight for the confirm button in `InlineConfirmation`, where a fill keeps the destructive action distinguishable from Cancel without relying on colour alone. `surface.module.css` `.dangerous` mirrors the quiet variant so the Reset conversation button matches without migrating that file to Tailwind.

--- a/apps/desktop-renderer/src/theme/surface.module.css
+++ b/apps/desktop-renderer/src/theme/surface.module.css
@@ -106,15 +106,14 @@
   }
 
   .dangerous {
-    border-color: var(--line-2);
+    border-color: transparent;
     color: var(--danger);
-    background-color: var(--surface);
-    box-shadow: var(--edge), var(--elev-1);
+    background-color: transparent;
+    box-shadow: none;
   }
 
   .dangerous:hover:not(:disabled) {
-    border-color: color-mix(in srgb, var(--danger) 32%, var(--line-2));
-    background-color: color-mix(in srgb, var(--danger) 6%, var(--surface));
+    background-color: color-mix(in srgb, var(--danger) 11%, transparent);
   }
 
   .linkish {

--- a/apps/desktop-renderer/src/ui/onboarding/AiRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/AiRow.tsx
@@ -71,6 +71,7 @@ import {
   SETUP_FIELD_CLASS,
   SETUP_HINT_CLASS,
   SETUP_LABEL_CLASS,
+  SETUP_SELECT_CLASS,
 } from "./SetupCard.js";
 import { SetupError, SetupRow, SetupSubPanel } from "./SetupRow.js";
 
@@ -491,7 +492,7 @@ export function AiRow(props: {
               </label>
               <select
                 id="onboarding-llm-provider"
-                className={SETUP_FIELD_CLASS}
+                className={SETUP_SELECT_CLASS}
                 disabled={controlsDisabled}
                 value={draft.provider.provider}
                 onChange={(event) => {
@@ -545,7 +546,7 @@ export function AiRow(props: {
                     </label>
                     <select
                       id="onboarding-llm-model"
-                      className={SETUP_FIELD_CLASS}
+                      className={SETUP_SELECT_CLASS}
                       disabled={controlsDisabled}
                       value={draft.modelChoice}
                       onChange={(event) => {
@@ -590,7 +591,7 @@ export function AiRow(props: {
                         </label>
                         <select
                           id="onboarding-endpoint-mode"
-                          className={SETUP_FIELD_CLASS}
+                          className={SETUP_SELECT_CLASS}
                           disabled={controlsDisabled}
                           value={draft.endpointMode}
                           onChange={(event) => {

--- a/apps/desktop-renderer/src/ui/onboarding/IntakeRows.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/IntakeRows.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import type { OnboardingActions, OnboardingSurfaceState } from "../../onboarding/controller.js";
 import { errorSection } from "../../onboarding/lanes.js";
 import { RETRY_INTAKE_SAVE_LABEL } from "./copy.js";
-import { SETUP_FIELD_CLASS, SETUP_LINK_BUTTON } from "./SetupCard.js";
+import { SETUP_LINK_BUTTON, SETUP_SELECT_CLASS } from "./SetupCard.js";
 import { SetupError, SetupRow, SetupSubPanel } from "./SetupRow.js";
 
 const UNSET = "";
@@ -39,7 +39,7 @@ function IntakeSelect(props: {
   return (
     <select
       id={props.id}
-      className={`${SETUP_FIELD_CLASS} w-[180px]`}
+      className={`${SETUP_SELECT_CLASS} w-[180px]`}
       disabled={props.disabled}
       value={props.value}
       aria-describedby={props.describedBy}

--- a/apps/desktop-renderer/src/ui/onboarding/SetupCard.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/SetupCard.tsx
@@ -4,8 +4,7 @@ export const SETUP_CARD_CLASS =
   "rounded-xl border border-line bg-surface shadow-[var(--edge),var(--elev-1)] [&>*+*]:border-t [&>*+*]:border-line [&>*:first-child]:rounded-t-xl [&>*:last-child]:rounded-b-xl";
 
 export {
-  BUTTON_DANGER_LINK_SM,
-  BUTTON_DANGER_SM,
+  BUTTON_DANGER_QUIET_SM,
   BUTTON_OUTLINE_SM,
   BUTTON_PRIMARY,
   BUTTON_QUIET_SM,
@@ -13,12 +12,14 @@ export {
 } from "../shared/buttons.js";
 
 export const SETUP_LINK_BUTTON =
-  "mt-2 block bg-transparent p-0 text-left text-xs font-medium text-ink-2 underline underline-offset-[3px] transition-colors hover:text-ink disabled:opacity-50 motion-reduce:transition-none";
+  "mt-2 block cursor-pointer bg-transparent p-0 text-left text-xs font-medium text-ink-2 underline underline-offset-[3px] transition-colors hover:text-ink disabled:cursor-default disabled:opacity-64 motion-reduce:transition-none";
 
 export const SETUP_HINT_CLASS = "mt-[7px] block text-[11.5px] leading-normal text-ink-2";
 
 export const SETUP_FIELD_CLASS =
   "h-[30px] w-full max-w-[236px] rounded-ctl border border-ink-2 bg-surface px-[11px] text-sm text-ink shadow-[var(--edge),var(--elev-1)] disabled:opacity-64";
+
+export const SETUP_SELECT_CLASS = `${SETUP_FIELD_CLASS} cursor-pointer appearance-none bg-[image:var(--chevron)] bg-[length:14px_14px] bg-[position:right_10px_center] bg-no-repeat pr-[30px] disabled:cursor-default`;
 
 export const SETUP_LABEL_CLASS = "mb-[5px] block text-xs font-medium text-ink-2";
 

--- a/apps/desktop-renderer/src/ui/onboarding/TelegramRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/TelegramRow.tsx
@@ -17,7 +17,7 @@ import {
   TELEGRAM_ROW_TITLE,
   TELEGRAM_VERIFIED_PREFIX,
 } from "./copy.js";
-import { BUTTON_DANGER_OUTLINE_SM, BUTTON_QUIET_SM, BUTTON_SOLID_SM } from "../shared/buttons.js";
+import { BUTTON_DANGER_QUIET_SM, BUTTON_QUIET_SM, BUTTON_SOLID_SM } from "../shared/buttons.js";
 import { InlineConfirmation, type InlineConfirmationFocus } from "../shared/InlineConfirmation.js";
 import { SetupRow, SetupSubPanel } from "./SetupRow.js";
 
@@ -465,7 +465,7 @@ export function TelegramRow(): ReactElement {
             <button
               ref={trigger}
               type="button"
-              className={BUTTON_DANGER_OUTLINE_SM}
+              className={BUTTON_DANGER_QUIET_SM}
               data-setup-delete="telegram"
               disabled={busy || (authoritativeCheckRequired && attempt?.action === "paste-token")}
               aria-expanded={panel === "delete"}

--- a/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
@@ -15,7 +15,7 @@ import {
 import { settingsMutationActive } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
 import { SetupRow } from "../onboarding/SetupRow.js";
-import { BUTTON_DANGER_LINK_SM, BUTTON_QUIET_SM } from "../onboarding/SetupCard.js";
+import { BUTTON_DANGER_QUIET_SM, BUTTON_QUIET_SM } from "../onboarding/SetupCard.js";
 import { InlineConfirmation } from "../shared/InlineConfirmation.js";
 import { credentialRuntimeLabel } from "./copy.js";
 import styles from "./SettingsView.module.css";
@@ -107,7 +107,7 @@ export function CredentialDeleteButton(props: {
       type="button"
       ref={button}
       data-setup-delete={props.credential}
-      className={props.credential === "intervals-icu" ? BUTTON_DANGER_LINK_SM : styles.danger}
+      className={BUTTON_DANGER_QUIET_SM}
       disabled={
         port === null ||
         state.status === "loading" ||

--- a/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
@@ -15,7 +15,7 @@ import { PLATFORM_COPY } from "../../platform-copy.js";
 import { settingsMutationActive } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
 import {
-  BUTTON_DANGER_OUTLINE_SM,
+  BUTTON_DANGER_QUIET_SM,
   BUTTON_OUTLINE_SM,
   BUTTON_QUIET_SM,
   BUTTON_SOLID_SM,
@@ -377,7 +377,7 @@ export function TelegramSection(): ReactElement {
               <button
                 type="button"
                 ref={deleteTrigger}
-                className={BUTTON_DANGER_OUTLINE_SM}
+                className={BUTTON_DANGER_QUIET_SM}
                 disabled={busy || confirmRemove}
                 onClick={() => {
                   setConfirmRemove(true);

--- a/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
@@ -604,7 +604,7 @@ export function TelegramSection(): ReactElement {
                     {sender.role === "additional" ? (
                       <button
                         type="button"
-                        className={BUTTON_OUTLINE_SM}
+                        className={BUTTON_DANGER_QUIET_SM}
                         disabled={busy}
                         aria-label={"Remove Telegram user " + sender.senderId}
                         onClick={() => {

--- a/apps/desktop-renderer/src/ui/shared/InlineConfirmation.tsx
+++ b/apps/desktop-renderer/src/ui/shared/InlineConfirmation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useRef, type ReactElement } from "react";
-import { BUTTON_COMPACT_QUIET_SM, BUTTON_DANGER_OUTLINE_SM } from "./buttons.js";
+import { BUTTON_COMPACT_QUIET_SM, BUTTON_DANGER_SOLID_SM } from "./buttons.js";
 
 export type InlineConfirmationFocus = "cancel" | "confirm" | null;
 
@@ -90,7 +90,7 @@ export function InlineConfirmation(props: {
           <button
             type="button"
             ref={confirm}
-            className={`${BUTTON_DANGER_OUTLINE_SM} aria-disabled:opacity-50`}
+            className={BUTTON_DANGER_SOLID_SM}
             disabled={props.confirmBusy ? false : props.confirmDisabled}
             aria-disabled={props.confirmBusy ? "true" : undefined}
             aria-label={props.confirmAriaLabel}

--- a/apps/desktop-renderer/src/ui/shared/buttons.ts
+++ b/apps/desktop-renderer/src/ui/shared/buttons.ts
@@ -1,5 +1,5 @@
 const BUTTON_LAYOUT =
-  "inline-flex flex-none items-center justify-center rounded-ctl border whitespace-nowrap font-medium transition-colors cursor-pointer disabled:cursor-default disabled:opacity-64 aria-disabled:cursor-default aria-disabled:opacity-64 motion-reduce:transition-none";
+  "relative inline-flex flex-none items-center justify-center rounded-ctl border whitespace-nowrap py-0 font-medium leading-none transition-[background-color,border-color,box-shadow] duration-[120ms] ease-[ease] cursor-pointer disabled:cursor-default disabled:opacity-64 disabled:pointer-events-none aria-disabled:cursor-default aria-disabled:opacity-64 aria-disabled:pointer-events-none motion-reduce:transition-none";
 
 const BUTTON_BASE = `${BUTTON_LAYOUT} gap-1.5`;
 

--- a/apps/desktop-renderer/src/ui/shared/buttons.ts
+++ b/apps/desktop-renderer/src/ui/shared/buttons.ts
@@ -1,5 +1,5 @@
 const BUTTON_LAYOUT =
-  "inline-flex flex-none items-center justify-center rounded-ctl border whitespace-nowrap font-medium transition-colors disabled:opacity-50 motion-reduce:transition-none";
+  "inline-flex flex-none items-center justify-center rounded-ctl border whitespace-nowrap font-medium transition-colors cursor-pointer disabled:cursor-default disabled:opacity-64 aria-disabled:cursor-default aria-disabled:opacity-64 motion-reduce:transition-none";
 
 const BUTTON_BASE = `${BUTTON_LAYOUT} gap-1.5`;
 
@@ -18,10 +18,11 @@ export const BUTTON_QUIET_SM = `${BUTTON_SM} ${BUTTON_QUIET_STYLE}`;
 
 export const BUTTON_COMPACT_QUIET_SM = `${BUTTON_COMPACT_SM} ${BUTTON_QUIET_STYLE}`;
 
-export const BUTTON_DANGER_SM = `${BUTTON_SM} border-[color-mix(in_srgb,var(--danger)_34%,transparent)] bg-[color-mix(in_srgb,var(--danger)_5%,transparent)] text-danger shadow-none hover:bg-[color-mix(in_srgb,var(--danger)_11%,transparent)]`;
+const BUTTON_DANGER_QUIET_STYLE =
+  "border-transparent bg-transparent text-danger hover:bg-[color-mix(in_srgb,var(--danger)_11%,transparent)]";
 
-export const BUTTON_DANGER_OUTLINE_SM = `${BUTTON_COMPACT_SM} border-[color-mix(in_srgb,var(--danger)_34%,transparent)] bg-transparent text-danger hover:bg-[color-mix(in_srgb,var(--danger)_11%,transparent)]`;
+export const BUTTON_DANGER_QUIET_SM = `${BUTTON_SM} ${BUTTON_DANGER_QUIET_STYLE}`;
 
-export const BUTTON_DANGER_LINK_SM = `${BUTTON_SM} border-transparent bg-transparent text-danger shadow-none hover:bg-[color-mix(in_srgb,var(--danger)_11%,transparent)]`;
+export const BUTTON_DANGER_SOLID_SM = `${BUTTON_SM} border-danger bg-danger text-bg shadow-[var(--sheen),var(--elev-1)] hover:bg-[color-mix(in_srgb,var(--danger)_90%,var(--ink))]`;
 
 export const BUTTON_PRIMARY = `${BUTTON_BASE} h-ctl-lg gap-2 px-[14px] text-sm border-ink bg-ink text-bg shadow-[var(--sheen),var(--elev-1)] hover:bg-[color-mix(in_srgb,var(--ink)_90%,var(--bg))]`;

--- a/apps/desktop-renderer/tests/button-primitives.test.ts
+++ b/apps/desktop-renderer/tests/button-primitives.test.ts
@@ -1,0 +1,200 @@
+import { readdir, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import * as buttons from "../src/ui/shared/buttons.js";
+
+const srcRoot = resolve(import.meta.dirname, "..", "src");
+const themeRoot = resolve(srcRoot, "theme");
+
+const DANGER_TOKEN = "danger";
+
+const WEIGHT_TOKENS = /danger|ink/u;
+
+function constants(): ReadonlyArray<readonly [string, string]> {
+  return Object.entries<string>({ ...buttons }).filter(([, value]) => typeof value === "string");
+}
+
+function classes(value: string): ReadonlyArray<string> {
+  return value.split(" ").filter((entry) => entry.length > 0);
+}
+
+function weightOf(value: string): ReadonlyArray<string> {
+  return classes(value)
+    .filter((entry) => !WEIGHT_TOKENS.test(entry))
+    .sort();
+}
+
+function compact(value: string): string {
+  return value.replaceAll("_", " ").replaceAll(/\s+/gu, "");
+}
+
+function arbitrary(constant: string, prefix: string): string {
+  const start = constant.indexOf(`${prefix}-[`);
+  expect(`${prefix} present=${String(start >= 0)}`).toContain("present=true");
+  const open = start + prefix.length + 1;
+  let depth = 0;
+  for (let index = open; index < constant.length; index += 1) {
+    if (constant[index] === "[") depth += 1;
+    else if (constant[index] === "]") {
+      depth -= 1;
+      if (depth === 0) return constant.slice(open + 1, index);
+    }
+  }
+  throw new Error(`Unterminated arbitrary value for ${prefix}`);
+}
+
+function declarations(source: string, selector: string): string {
+  const start = source.indexOf(selector);
+  expect(`${selector} found=${String(start >= 0)}`).toContain("found=true");
+  const open = source.indexOf("{", start);
+  return source.slice(open + 1, source.indexOf("}", open));
+}
+
+function channel(component: number): number {
+  const ratio = component / 255;
+  return ratio <= 0.03928 ? ratio / 12.92 : ((ratio + 0.055) / 1.055) ** 2.4;
+}
+
+function luminance(hex: string): number {
+  const value = Number.parseInt(hex.slice(1), 16);
+  return (
+    0.2126 * channel((value >> 16) & 0xff) +
+    0.7152 * channel((value >> 8) & 0xff) +
+    0.0722 * channel(value & 0xff)
+  );
+}
+
+function contrast(one: string, two: string): number {
+  const a = luminance(one);
+  const b = luminance(two);
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+function hexValues(source: string, token: string): ReadonlyArray<string> {
+  return [...source.matchAll(new RegExp(`--${token}:\\s*(#[0-9a-f]{6})`, "gu"))].map(
+    (match) => match[1] ?? "",
+  );
+}
+
+async function sourceFiles(directory: string): Promise<ReadonlyArray<string>> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const found: Array<string> = [];
+  for (const entry of entries) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) found.push(...(await sourceFiles(path)));
+    else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) found.push(path);
+  }
+  return found;
+}
+
+describe("button primitives", () => {
+  it("gives every exported button constant a pointer cursor", () => {
+    const exported = constants();
+    expect(exported.length).toBeGreaterThanOrEqual(6);
+    for (const [name, value] of exported) {
+      expect(`${name} ${value}`).toContain("cursor-pointer");
+      expect(`${name} ${value}`).toContain("disabled:cursor-default");
+    }
+  });
+
+  it("exports exactly two danger button constants", () => {
+    const danger = constants().filter(([, value]) => value.includes(DANGER_TOKEN));
+    expect(danger.map(([name]) => name).sort()).toEqual([
+      "BUTTON_DANGER_QUIET_SM",
+      "BUTTON_DANGER_SOLID_SM",
+    ]);
+  });
+
+  it("keeps the in-row danger button at the quiet weight with no border", () => {
+    expect(weightOf(buttons.BUTTON_DANGER_QUIET_SM)).toEqual(weightOf(buttons.BUTTON_QUIET_SM));
+    expect(classes(buttons.BUTTON_DANGER_QUIET_SM)).toContain("border-transparent");
+    expect(classes(buttons.BUTTON_DANGER_QUIET_SM)).toContain("bg-transparent");
+    const bordered = classes(buttons.BUTTON_DANGER_QUIET_SM).filter(
+      (entry) => entry.startsWith("border-") && entry !== "border-transparent",
+    );
+    expect(bordered).toEqual([]);
+    expect(
+      classes(buttons.BUTTON_DANGER_QUIET_SM).filter((entry) => entry.startsWith("shadow-")),
+    ).toEqual([]);
+  });
+
+  it("keeps the confirm danger button at the solid weight with a filled background", () => {
+    expect(weightOf(buttons.BUTTON_DANGER_SOLID_SM)).toEqual(weightOf(buttons.BUTTON_SOLID_SM));
+    expect(classes(buttons.BUTTON_DANGER_SOLID_SM)).toContain("bg-danger");
+    expect(classes(buttons.BUTTON_DANGER_SOLID_SM)).toContain("border-danger");
+    expect(classes(buttons.BUTTON_DANGER_SOLID_SM)).toContain("text-bg");
+    expect(buttons.BUTTON_DANGER_SOLID_SM).not.toBe(buttons.BUTTON_DANGER_QUIET_SM);
+  });
+
+  it("keeps the solid danger fill readable in both themes", async () => {
+    const tokens = await readFile(resolve(themeRoot, "tokens.css"), "utf8");
+    const dangers = hexValues(tokens, "danger");
+    const backgrounds = hexValues(tokens, "bg");
+    expect(dangers.length).toBeGreaterThanOrEqual(2);
+    expect(backgrounds.length).toBeGreaterThanOrEqual(2);
+    const pairs = [
+      [dangers[0] ?? "", backgrounds[0] ?? ""],
+      [dangers.at(-1) ?? "", backgrounds.at(-1) ?? ""],
+    ];
+    expect(pairs[0]).not.toEqual(pairs[1]);
+    for (const [fill, text] of pairs) expect(contrast(fill, text)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("matches the module danger control to the quiet danger constant", async () => {
+    const surface = await readFile(resolve(themeRoot, "surface.module.css"), "utf8");
+    const hover = arbitrary(buttons.BUTTON_DANGER_QUIET_SM, "hover:bg");
+
+    const base = compact(declarations(surface, ".dangerous"));
+    expect(base).toContain("border-color:transparent");
+    expect(base).toContain("background-color:transparent");
+    expect(base).toContain("color:var(--danger)");
+
+    const hovered = compact(declarations(surface, ".dangerous:hover:not(:disabled)"));
+    expect(hovered).toContain(`background-color:${compact(hover)}`);
+    expect(hovered).not.toContain("border-color:");
+  });
+
+  it("keeps every danger button on the shared constants", async () => {
+    const offenders: Array<string> = [];
+    for (const file of await sourceFiles(srcRoot)) {
+      if (file.endsWith("shared/buttons.ts")) continue;
+      const source = await readFile(file, "utf8");
+      for (const literal of source.match(/"[^"\n]*"|`[^`]*`/gu) ?? []) {
+        if (!literal.includes("text-danger")) continue;
+        if (/h-ctl|rounded-ctl|cursor-pointer/u.test(literal)) offenders.push(file);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("disables controls at one opacity across both styling systems", async () => {
+    const surface = await readFile(resolve(themeRoot, "surface.module.css"), "utf8");
+    const match = /disabled:opacity-(\d+)/u.exec(buttons.BUTTON_SOLID_SM);
+    expect(match).not.toBeNull();
+    const opacity = Number(match?.[1] ?? 0) / 100;
+    expect(compact(declarations(surface, ".control:disabled"))).toContain(
+      `opacity:${String(opacity)}`,
+    );
+  });
+
+  it("keeps Tailwind preflight out of the stylesheet entry", async () => {
+    const entry = await readFile(resolve(themeRoot, "tailwind.css"), "utf8");
+    expect(entry).not.toContain("preflight");
+  });
+
+  it("gives the setup select the shared chevron affordances", async () => {
+    const card = await readFile(resolve(srcRoot, "ui", "onboarding", "SetupCard.tsx"), "utf8");
+    const surface = await readFile(resolve(themeRoot, "surface.module.css"), "utf8");
+    const select = /export const SETUP_SELECT_CLASS =([\s\S]*?);\n/u.exec(card)?.[1] ?? "";
+    for (const utility of [
+      "cursor-pointer",
+      "appearance-none",
+      "bg-[image:var(--chevron)]",
+      "bg-no-repeat",
+    ])
+      expect(select).toContain(utility);
+    expect(compact(declarations(surface, "select.field"))).toContain(
+      "background-image:var(--chevron)",
+    );
+  });
+});

--- a/apps/desktop-renderer/tests/button-primitives.test.ts
+++ b/apps/desktop-renderer/tests/button-primitives.test.ts
@@ -92,8 +92,10 @@ describe("button primitives", () => {
     const exported = constants();
     expect(exported.length).toBeGreaterThanOrEqual(6);
     for (const [name, value] of exported) {
-      expect(`${name} ${value}`).toContain("cursor-pointer");
-      expect(`${name} ${value}`).toContain("disabled:cursor-default");
+      expect({ name, utilities: classes(value) }).toEqual({
+        name,
+        utilities: expect.arrayContaining(["cursor-pointer", "disabled:cursor-default"]),
+      });
     }
   });
 
@@ -110,7 +112,7 @@ describe("button primitives", () => {
     expect(classes(buttons.BUTTON_DANGER_QUIET_SM)).toContain("border-transparent");
     expect(classes(buttons.BUTTON_DANGER_QUIET_SM)).toContain("bg-transparent");
     const bordered = classes(buttons.BUTTON_DANGER_QUIET_SM).filter(
-      (entry) => entry.startsWith("border-") && entry !== "border-transparent",
+      (entry) => /(^|:)border-/u.test(entry) && entry !== "border-transparent",
     );
     expect(bordered).toEqual([]);
     expect(
@@ -145,9 +147,17 @@ describe("button primitives", () => {
     const hover = arbitrary(buttons.BUTTON_DANGER_QUIET_SM, "hover:bg");
 
     const base = compact(declarations(surface, ".dangerous"));
-    expect(base).toContain("border-color:transparent");
-    expect(base).toContain("background-color:transparent");
-    expect(base).toContain("color:var(--danger)");
+    expect(
+      base
+        .split(";")
+        .filter((entry) => entry.length > 0)
+        .sort(),
+    ).toEqual([
+      "background-color:transparent",
+      "border-color:transparent",
+      "box-shadow:none",
+      "color:var(--danger)",
+    ]);
 
     const hovered = compact(declarations(surface, ".dangerous:hover:not(:disabled)"));
     expect(hovered).toContain(`background-color:${compact(hover)}`);
@@ -175,6 +185,41 @@ describe("button primitives", () => {
     expect(compact(declarations(surface, ".control:disabled"))).toContain(
       `opacity:${String(opacity)}`,
     );
+  });
+
+  it("takes disabled controls out of hit testing across both styling systems", async () => {
+    const surface = await readFile(resolve(themeRoot, "surface.module.css"), "utf8");
+    for (const [name, value] of constants()) {
+      expect({ name, utilities: classes(value) }).toEqual({
+        name,
+        utilities: expect.arrayContaining([
+          "disabled:pointer-events-none",
+          "aria-disabled:pointer-events-none",
+        ]),
+      });
+    }
+    expect(compact(declarations(surface, ".control:disabled"))).toContain("pointer-events:none");
+  });
+
+  it("animates the same properties over the same timing in both styling systems", async () => {
+    const surface = await readFile(resolve(themeRoot, "surface.module.css"), "utf8");
+    const control = compact(declarations(surface, ".control"));
+    const animated = (/transition:([^;]+)/u.exec(control)?.[1] ?? "")
+      .split(",")
+      .map((entry) => entry.replace("120msease", ""))
+      .filter((entry) => entry.length > 0)
+      .sort();
+    expect(animated).toEqual(["background-color", "border-color", "box-shadow"]);
+    expect(
+      arbitrary(buttons.BUTTON_SOLID_SM, "transition")
+        .split(",")
+        .map((entry) => entry.trim())
+        .sort(),
+    ).toEqual(animated);
+    expect(classes(buttons.BUTTON_SOLID_SM)).toEqual(
+      expect.arrayContaining(["duration-[120ms]", "ease-[ease]", "leading-none", "relative"]),
+    );
+    expect(control).toContain("position:relative");
   });
 
   it("keeps Tailwind preflight out of the stylesheet entry", async () => {

--- a/apps/desktop-renderer/tests/inline-confirmation.test.tsx
+++ b/apps/desktop-renderer/tests/inline-confirmation.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import userEvent from "@testing-library/user-event";
 import { useRef, useState, type ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { BUTTON_COMPACT_QUIET_SM, BUTTON_DANGER_SOLID_SM } from "../src/ui/shared/buttons.js";
 import { InlineConfirmation } from "../src/ui/shared/InlineConfirmation.js";
 
 function ReturnFocusHarness(): ReactElement {
@@ -51,8 +52,8 @@ describe("inline confirmation", () => {
     expect(buttons.map((button) => button.textContent)).toEqual(["Cancel", "Delete connection"]);
     expect(buttons[0]).toHaveFocus();
     expect(group.parentElement).toHaveClass("bg-sunk");
-    expect(buttons[1]).toHaveClass("border-[color-mix(in_srgb,var(--danger)_34%,transparent)]");
-    expect(buttons[1]).toHaveClass("bg-transparent", "text-danger");
+    expect(buttons[0]?.className).toBe(BUTTON_COMPACT_QUIET_SM);
+    expect(buttons[1]?.className).toBe(BUTTON_DANGER_SOLID_SM);
 
     view.rerender(
       <InlineConfirmation

--- a/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
@@ -11,6 +11,7 @@ import {
   RETRY_INTAKE_SAVE_LABEL,
   SETUP_MENU_LABEL,
 } from "../src/ui/onboarding/copy.js";
+import { BUTTON_DANGER_QUIET_SM } from "../src/ui/shared/buttons.js";
 import {
   chooseLane,
   claudeCliNoteText,
@@ -293,7 +294,7 @@ describe("setup card", () => {
     expect(document.querySelector('[data-setup-trigger="training"]')).toBeNull();
     const remove = screen.getByRole("button", { name: "Delete the Intervals.icu connection" });
     expect(remove).toHaveTextContent("Delete");
-    expect(remove.className).toContain("border-transparent");
+    expect(remove.className).toBe(BUTTON_DANGER_QUIET_SM);
     expect(setupRow("training").querySelectorAll("button")).toHaveLength(2);
     wizard.controller.dispose();
   });

--- a/apps/desktop-renderer/tests/onboarding-telegram-row.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-telegram-row.test.tsx
@@ -13,7 +13,7 @@ import {
   TELEGRAM_CREATE_TITLE,
   TELEGRAM_DELETE_COPY,
 } from "../src/ui/onboarding/copy.js";
-import { BUTTON_DANGER_OUTLINE_SM } from "../src/ui/shared/buttons.js";
+import { BUTTON_DANGER_QUIET_SM, BUTTON_DANGER_SOLID_SM } from "../src/ui/shared/buttons.js";
 import {
   mountWizard,
   panel,
@@ -264,7 +264,7 @@ describe("Chat Telegram setup row", () => {
     const deleteButton = within(setupRow("telegram")).getByRole("button", {
       name: "Delete the Telegram connection",
     });
-    expect(deleteButton.className).toBe(BUTTON_DANGER_OUTLINE_SM);
+    expect(deleteButton.className).toBe(BUTTON_DANGER_QUIET_SM);
     expect(deleteButton).toHaveFocus();
     expect(screen.queryByRole("button", { name: "Change Telegram bot" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Use copied token" })).toBeNull();
@@ -383,7 +383,7 @@ describe("Chat Telegram setup row", () => {
     const deleteButton = within(setupRow("telegram")).getByRole("button", {
       name: "Delete the Telegram connection",
     });
-    expect(deleteButton.className).toBe(BUTTON_DANGER_OUTLINE_SM);
+    expect(deleteButton.className).toBe(BUTTON_DANGER_QUIET_SM);
     expect(screen.queryByRole("button", { name: "Change Telegram bot" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Use copied token" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Check again" })).toBeNull();
@@ -397,11 +397,7 @@ describe("Chat Telegram setup row", () => {
       "Delete connection",
     ]);
     expect(confirmationButtons[0]).toHaveFocus();
-    expect(confirmationButtons[1]).toHaveClass(
-      "border-[color-mix(in_srgb,var(--danger)_34%,transparent)]",
-      "bg-transparent",
-      "text-danger",
-    );
+    expect(confirmationButtons[1]?.className).toBe(BUTTON_DANGER_SOLID_SM);
     expect(port.remove).not.toHaveBeenCalled();
 
     await user.click(confirmationButtons[0] as HTMLButtonElement);

--- a/apps/desktop-renderer/tests/onboarding-wizard.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-wizard.test.ts
@@ -334,7 +334,7 @@ describe("desktop onboarding wizard", () => {
       ),
     );
     for (const [index, source] of sources.entries()) {
-      const transitions = source.match(/transition-(?!none)[a-z-]+/gu) ?? [];
+      const transitions = source.match(/transition-(?!none)(?:\[[^\]]*\]|[a-z-]+)/gu) ?? [];
       const escapes = source.match(/motion-reduce:transition-none/gu) ?? [];
       expect({ file: SETUP_SOURCES[index], escapes: escapes.length }).toEqual({
         file: SETUP_SOURCES[index],

--- a/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
@@ -261,7 +261,12 @@ describe("Telegram settings surface", () => {
     expect(within(users).getByText("Primary user · required")).toBeVisible();
     expect(within(users).queryByRole("button", { name: "Remove Telegram user 101" })).toBeNull();
 
-    await user.click(within(users).getByRole("button", { name: "Remove Telegram user 202" }));
+    const removeSender = within(users).getByRole("button", {
+      name: "Remove Telegram user 202",
+    });
+    expect(removeSender.className).toBe(BUTTON_DANGER_QUIET_SM);
+
+    await user.click(removeSender);
     expect(port.removeSender).toHaveBeenCalledWith(202);
 
     const senderId = screen.getByLabelText("Add a Telegram user ID");

--- a/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
@@ -9,6 +9,10 @@ import type {
 import { EMPTY_SETTINGS_SURFACE, type TelegramSettingsPort } from "../src/state/settings-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { TelegramSection } from "../src/ui/settings/TelegramSection.js";
+import {
+  BUTTON_DANGER_QUIET_SM,
+  BUTTON_DANGER_SOLID_SM,
+} from "../src/ui/shared/buttons.js";
 
 function status(overrides: Partial<TelegramControlStatus> = {}): TelegramControlStatus {
   return {
@@ -491,11 +495,7 @@ describe("Telegram settings surface", () => {
     ).toBeVisible();
 
     const deleteTrigger = screen.getByRole("button", { name: "Delete" });
-    expect(deleteTrigger).toHaveClass(
-      "border-[color-mix(in_srgb,var(--danger)_34%,transparent)]",
-      "bg-transparent",
-      "text-danger",
-    );
+    expect(deleteTrigger.className).toBe(BUTTON_DANGER_QUIET_SM);
     expect(screen.queryByRole("button", { name: "Replace token from clipboard" })).toBeNull();
 
     await user.click(deleteTrigger);
@@ -511,11 +511,7 @@ describe("Telegram settings surface", () => {
       "Delete connection",
     ]);
     expect(confirmationButtons[0]).toHaveFocus();
-    expect(confirmationButtons[1]).toHaveClass(
-      "border-[color-mix(in_srgb,var(--danger)_34%,transparent)]",
-      "bg-transparent",
-      "text-danger",
-    );
+    expect(confirmationButtons[1]?.className).toBe(BUTTON_DANGER_SOLID_SM);
     expect(port.remove).not.toHaveBeenCalled();
 
     await user.click(confirmationButtons[0]);


### PR DESCRIPTION
Two defects with one root cause: danger was modelled as a button *weight* instead of a *colour*, and the Tailwind half of the renderer never got the basics the CSS-module half had.

**Danger buttons.** Four danger styles existed, and one was chosen by which credential the row was for — so the Intervals Delete was borderless text while the AI-provider Delete one row above was a bordered box. Collapsing them into a single bordered style would not have fixed it, because `Change` sits in the same action group as `Delete` and is `BUTTON_QUIET_SM`, which has no border at all.

The rule now: a button's weight comes from its role in its action group; danger changes only the colour. That gives two constants:

- `BUTTON_DANGER_QUIET_SM` — the quiet weight in red, for every in-row destructive action. `Change` and `Delete` now differ only in colour.
- `BUTTON_DANGER_SOLID_SM` — the solid weight with a red fill, used only for the confirm button in a delete confirmation, where `Cancel` is quiet and colour alone must not separate "go back" from "destroy this". Contrast measured from the tokens: 5.38:1 light, 6.26:1 dark, both re-derived by a test so a token edit that breaks either theme fails the suite.

The Telegram allowed-user `Remove` was also destructive and styled as a neutral secondary; it now uses the quiet danger variant. Its missing confirmation is a separate behaviour change and is not in this PR.

**Pointer cursor.** Tailwind v4's preflight normally supplies `button { cursor: pointer }`, and preflight is deliberately not imported here — importing it would restyle every un-migrated CSS module at once. Nothing else filled the gap, so 37 buttons across the entire first-run surface showed the arrow while their CSS-module siblings showed the hand. `BUTTON_LAYOUT` now carries the cursor, and the setup selects gained the shared chevron and pointer that `select.field` already had.

**Cross-system parity.** `.dangerous` was rewritten to render identically to the quiet constant. Reaching genuine parity took three rounds of adversarial review, which found: disabled buttons still tinting on hover because only the module set `pointer-events: none`; `transition-colors` animating `outline-color` but not `box-shadow` while the module's list was the exact inverse, making focus rings fade on one button and snap on the other; and a missing `position: relative` and vertical padding.

## Limits

- Disabled opacity is now `0.64` in both styling systems, changed from `0.5` on the Tailwind side. Chosen because three existing CSS-module sites already used `0.64` against one Tailwind site.

## Accepted divergence

Tailwind wraps its `hover:` variant in `@media (hover: hover)`; the CSS module's `:hover` is unwrapped. Inert on a desktop app with no touch input, and the Tailwind behaviour is the better one.

## Guard

`tests/button-primitives.test.ts` fails if a third danger variant appears, if the in-row danger regains a border, if any button constant loses its cursor or disabled behaviour, if the two systems drift on transition properties, timing, shadow, or disabled opacity, or if preflight is ever imported. Every assertion was proven red against unfixed sources — three of them were rewritten during review after being caught passing against reverted code, because `aria-disabled:X` satisfies a substring check for `disabled:X`.
