### PR TITLE
test(desktop): align Windows acceptance contract

### DIFF
--- a/apps/desktop/tests/first-run-config.test.ts
+++ b/apps/desktop/tests/first-run-config.test.ts
@@ -283,14 +283,16 @@ describe("desktop first-run configuration", () => {
     });
   });
 
-  it("prepares the home before seeding and constructing the daemon supervisor", async () => {
+  it("prepares the home, seeds the config, and adopts the device timezone before constructing the daemon supervisor", async () => {
     const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
     const prepareCall = source.indexOf("await prepareDesktopAthleteHome(environment)");
     const seedCall = source.indexOf("await seedFirstRunConfig({ env: environment });");
+    const adoptTimezoneCall = source.indexOf("await adoptDeviceTimezoneAtStart({");
     const supervisorConstruction = source.indexOf("new DesktopDaemonSupervisor(");
     expect(prepareCall).toBeGreaterThan(-1);
     expect(seedCall).toBeGreaterThan(prepareCall);
-    expect(supervisorConstruction).toBeGreaterThan(seedCall);
+    expect(adoptTimezoneCall).toBeGreaterThan(seedCall);
+    expect(supervisorConstruction).toBeGreaterThan(adoptTimezoneCall);
     expect(source).toContain('process.stderr.write("desktop-first-run-config-failure seed\\n");');
   });
 });

--- a/apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json
@@ -249,12 +249,14 @@
     {
       "id": "storage.first-run.configuration",
       "surface": "shell-storage",
-      "expected": "Windows prepares the athlete home, seeds a parseable first-run configuration only when absent, reopens an existing configuration unchanged, and completes this work before constructing the daemon supervisor.",
+      "expected": "Windows prepares the athlete home and seeds a parseable first-run configuration only when absent. The seeder leaves an existing configuration byte-identical; startup then adopts the device timezone into an unpinned configuration before constructing the daemon supervisor.",
       "automation": "deterministic",
       "tests": [
         "apps/desktop/tests/first-run-config.test.ts > leaves an existing arbitrary configuration byte-identical",
         "apps/desktop/tests/first-run-config.test.ts > seeds and reopens a Windows configuration without POSIX mode assertions",
-        "apps/desktop/tests/first-run-config.test.ts > prepares the home before seeding and constructing the daemon supervisor"
+        "apps/desktop/tests/session-timezone.test.ts > rewrites the stored zone to the device zone when nothing is pinned",
+        "apps/desktop/tests/session-timezone.test.ts > never rewrites the stored zone once the athlete pinned one",
+        "apps/desktop/tests/first-run-config.test.ts > prepares the home, seeds the config, and adopts the device timezone before constructing the daemon supervisor"
       ]
     },
     {

--- a/apps/desktop/tests/fixtures/windows-parity/training.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/training.scenarios.json
@@ -52,11 +52,11 @@
     {
       "id": "training.setup.readiness-recovery",
       "surface": "training-setup",
-      "expected": "Setup remains locked while authoritative readiness is loading or unavailable, disables its mutation controls, and restores them only after Retry returns a complete provider, training-data, and intake result.",
+      "expected": "Setup remains locked while authoritative readiness is loading, retries cold-start reads before reporting unavailable, blocks mutation controls when unavailable, and restores them through Retry only after a complete provider, training-data, and intake result.",
       "automation": "deterministic",
       "tests": [
         "apps/desktop-renderer/tests/setup-readiness.test.tsx > fails closed while the durable setup read is still loading",
-        "apps/desktop-renderer/tests/setup-readiness.test.tsx > shows unavailable setup status, disables controls, and recovers through Retry",
+        "apps/desktop-renderer/tests/setup-readiness.test.tsx > retries a cold start before it calls setup status unavailable, and recovers through Retry",
         "apps/desktop-renderer/tests/onboarding-setup-card.test.tsx > keeps Start coaching disabled until every requirement is met"
       ]
     },


### PR DESCRIPTION
Align the first-run and Windows parity fixtures with the current acceptance contract. Keep deterministic and VM-only scenario counts synchronized.