### PR TITLE
fix(core): recover interrupted Windows conversations

### DIFF
--- a/.changeset/windows-conversation-recovery.md
+++ b/.changeset/windows-conversation-recovery.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Enduragent now recovers Windows conversations after a crash interrupts reset-intent or transcript-boundary writes.

--- a/packages/core/src/agent/transcript-store.ts
+++ b/packages/core/src/agent/transcript-store.ts
@@ -80,6 +80,12 @@ interface FileIdentity {
   readonly ino: number | bigint;
 }
 
+interface TranscriptBoundaryRecovery {
+  readonly line: Buffer;
+  readonly resetId: string;
+  readonly tailLength: number;
+}
+
 class IncompleteTranscriptWriteError extends Error {
   constructor(readonly bytesWritten: number) {
     super("Transcript append was incomplete.");
@@ -407,6 +413,30 @@ function serializeTranscriptRecord(record: TranscriptRecord): Buffer {
     throw new TranscriptRecordTooLargeError();
   }
   return bytes;
+}
+
+function canonicalBoundaryLine(record: TranscriptConversationBoundaryRecord): Buffer {
+  const bytes = serializeTranscriptRecord(record);
+  return bytes.subarray(0, bytes.length - 1);
+}
+
+function isCanonicalBoundaryPrefix(prefix: Buffer, complete: Buffer): boolean {
+  return (
+    prefix.length > 0 &&
+    prefix.length <= complete.length &&
+    complete.subarray(0, prefix.length).equals(prefix)
+  );
+}
+
+function sameResetIntent(left: ResetIntentRecord, right: ResetIntentRecord): boolean {
+  return (
+    left.version === right.version &&
+    left.kind === right.kind &&
+    left.resetId === right.resetId &&
+    left.chatId === right.chatId &&
+    left.boundaryAt === right.boundaryAt &&
+    left.reason === right.reason
+  );
 }
 
 function parseCurrentWindow(contents: Buffer, chatId: string): CurrentTranscriptWindow {
@@ -1093,7 +1123,7 @@ export class TranscriptStore implements TranscriptWriterPort {
   ensureConversationBoundary(input: ResetIntentRecord): void {
     const intent = resetIntentRecord(input);
     const bytes = serializeTranscriptRecord(conversationBoundaryRecord(intent));
-    const before = this.boundaryCount(intent.chatId, intent.resetId);
+    const before = this.boundaryCount(intent.chatId, intent.resetId, intent);
     if (before > 1) {
       throw this.unsafeTarget("Transcript contains duplicate reset boundaries.");
     }
@@ -1101,20 +1131,30 @@ export class TranscriptStore implements TranscriptWriterPort {
       this.syncTranscriptFileAndDirectory(intent.chatId);
       return;
     }
-    this.appendRecord(intent.chatId, bytes, true);
+    this.appendRecord(intent.chatId, bytes, true, intent);
     if (this.boundaryCount(intent.chatId, intent.resetId) !== 1) {
       throw this.unsafeTarget("Conversation boundary was not durably persisted exactly once.");
     }
   }
 
-  private boundaryCount(chatId: string, resetId: string): number {
+  private boundaryCount(
+    chatId: string,
+    resetId: string,
+    recoveryIntent?: ResetIntentRecord,
+  ): number {
     return this.withDirectory((directoryDescriptor) => {
       const path = this.transcriptPath(chatId);
       const descriptor = this.openExistingFile(directoryDescriptor, path, constants.O_RDONLY, true);
       if (descriptor === null) return 0;
       try {
         const contents = this.readOpenedFile(directoryDescriptor, descriptor, path);
-        if (this.platform === "win32") this.assertWindowsTranscriptContent(contents, chatId);
+        if (this.platform === "win32") {
+          const recovery =
+            recoveryIntent === undefined
+              ? undefined
+              : this.authorizeBoundaryRecovery(directoryDescriptor, contents, recoveryIntent);
+          this.assertWindowsTranscriptContent(contents, chatId, recovery);
+        }
         let count = 0;
         let lineStart = 0;
         for (let index = 0; index < contents.length; index += 1) {
@@ -1143,25 +1183,35 @@ export class TranscriptStore implements TranscriptWriterPort {
     chatId: string,
     recordBytes: Buffer,
     classifyUnchangedBoundaryFailure = false,
+    recoveryIntent?: ResetIntentRecord,
   ): void {
     this.withDirectory((directoryDescriptor) => {
       const path = this.transcriptPath(chatId);
       const { descriptor, created } = this.openForAppend(directoryDescriptor, path);
       const beforeAppend = fstatSync(descriptor);
       try {
+        let recovery: TranscriptBoundaryRecovery | undefined;
         if (this.platform === "win32") {
           const existing = this.readSnapshot(directoryDescriptor, descriptor, path);
-          this.assertWindowsTranscriptContent(existing, chatId);
+          recovery =
+            recoveryIntent === undefined
+              ? undefined
+              : this.authorizeBoundaryRecovery(directoryDescriptor, existing, recoveryIntent);
+          this.assertWindowsTranscriptContent(existing, chatId, recovery);
         }
         let prefix = "";
-        if (beforeAppend.size > 0) {
+        if (beforeAppend.size > 0 && recovery === undefined) {
           const tail = Buffer.allocUnsafe(1);
           const bytesRead = readSync(descriptor, tail, 0, 1, beforeAppend.size - 1);
           if (bytesRead !== 1) throw new Error("Transcript tail could not be read.");
           if (tail[0] !== 0x0a) prefix = "\n";
         }
         const bytes =
-          prefix === "" ? recordBytes : Buffer.concat([Buffer.from(prefix), recordBytes]);
+          recovery !== undefined
+            ? recordBytes.subarray(recovery.tailLength)
+            : prefix === ""
+              ? recordBytes
+              : Buffer.concat([Buffer.from(prefix), recordBytes]);
         if (this.platform === "win32") {
           this.assertWindowsTranscriptSize(beforeAppend.size + bytes.length);
         }
@@ -1300,8 +1350,12 @@ export class TranscriptStore implements TranscriptWriterPort {
     });
   }
 
-  private assertWindowsTranscriptContent(contents: Buffer, chatId: string): void {
-    let contentValid = contents.length === 0;
+  private assertWindowsTranscriptContent(
+    contents: Buffer,
+    chatId: string,
+    recovery?: TranscriptBoundaryRecovery,
+  ): void {
+    let contentValid = true;
     let lineStart = 0;
     const resetIds = new Set<string>();
     for (let index = 0; index < contents.length; index += 1) {
@@ -1322,13 +1376,37 @@ export class TranscriptStore implements TranscriptWriterPort {
       }
       contentValid = true;
     }
-    if (lineStart !== contents.length) contentValid = false;
+    if (contentValid && lineStart !== contents.length) {
+      const tail = contents.subarray(lineStart);
+      contentValid =
+        recovery !== undefined &&
+        !resetIds.has(recovery.resetId) &&
+        isCanonicalBoundaryPrefix(tail, recovery.line);
+    }
     assertWindowsPrivatePathRead({
       bounded: contents.length <= MAX_TRANSCRIPT_FILE_BYTES,
       identityStable: true,
       contentValid,
       authenticatedHomeBinding: true,
     });
+  }
+
+  private authorizeBoundaryRecovery(
+    directoryDescriptor: DirectoryDescriptor,
+    contents: Buffer,
+    intent: ResetIntentRecord,
+  ): TranscriptBoundaryRecovery | undefined {
+    const line = canonicalBoundaryLine(conversationBoundaryRecord(intent));
+    const lastNewline = contents.lastIndexOf(0x0a);
+    const tail = contents.subarray(lastNewline + 1);
+    if (!isCanonicalBoundaryPrefix(tail, line)) return undefined;
+    const persisted = this.readIntentPath(
+      directoryDescriptor,
+      this.intentPath(intent.chatId),
+      intent.chatId,
+    );
+    if (persisted === null || !sameResetIntent(persisted, intent)) return undefined;
+    return { line, resetId: intent.resetId, tailLength: tail.length };
   }
 
   private readOpenedFile(
@@ -1720,24 +1798,7 @@ export class TranscriptStore implements TranscriptWriterPort {
       );
       if (descriptor === null) throw this.unsafeTarget();
       if (targetStats === null) {
-        if (this.platform === "win32") {
-          try {
-            const intent = parseResetIntent(
-              this.readOpenedFile(directoryDescriptor, descriptor, tempPath, allowedLinks),
-            );
-            if (
-              intent === null ||
-              this.chatDigest(intent.chatId) !== match[1] ||
-              intent.resetId !== match[2]
-            ) {
-              throw this.unsafeTarget();
-            }
-          } finally {
-            closeSync(descriptor);
-          }
-        } else {
-          closeSync(descriptor);
-        }
+        closeSync(descriptor);
         if (allowedLinks !== 1) throw this.unsafeTarget();
         this.unlinkPrivateFileIfPresent(directoryDescriptor, tempPath, 1);
         continue;

--- a/packages/core/tests/conversation-store.test.ts
+++ b/packages/core/tests/conversation-store.test.ts
@@ -71,30 +71,56 @@ function seedSession(store: ChatStore, chatId: string): void {
   store.appendTurn(chatId, "athlete", "coach", LINEAGE);
 }
 
-function resetArchives(dataDir: string, chatId: string): string[] {
+function sessionName(chatId: string, platform = process.platform): string {
+  return platform === "win32" ? createHash("sha256").update(chatId, "utf8").digest("hex") : chatId;
+}
+
+function sessionPath(dataDir: string, chatId: string, platform = process.platform): string {
+  return join(dataDir, "sessions", `${sessionName(chatId, platform)}.jsonl`);
+}
+
+function resetArchives(dataDir: string, chatId: string, platform = process.platform): string[] {
   return readdirSync(join(dataDir, "sessions")).filter((name) =>
-    name.startsWith(`${chatId}.jsonl.reset.`),
+    name.startsWith(`${sessionName(chatId, platform)}.jsonl.reset.`),
   );
 }
 
 function windowsSessionPath(dataDir: string, chatId: string): string {
-  const digest = createHash("sha256").update(chatId, "utf8").digest("hex");
-  return join(dataDir, "sessions", `${digest}.jsonl`);
+  return sessionPath(dataDir, chatId, "win32");
 }
 
 function windowsResetArchives(dataDir: string, chatId: string): string[] {
-  const digest = createHash("sha256").update(chatId, "utf8").digest("hex");
-  return readdirSync(join(dataDir, "sessions")).filter((name) =>
-    name.startsWith(`${digest}.jsonl.reset.`),
-  );
+  return resetArchives(dataDir, chatId, "win32");
 }
 
-function resetArchivePath(dataDir: string, reset: ResetIntentRecord): string {
+function resetArchivePath(
+  dataDir: string,
+  reset: ResetIntentRecord,
+  platform = process.platform,
+): string {
   return join(
     dataDir,
     "sessions",
-    `${reset.chatId}.jsonl.reset.${reset.boundaryAt.replace(/:/g, "-")}.${reset.resetId}`,
+    `${sessionName(reset.chatId, platform)}.jsonl.reset.${reset.boundaryAt.replace(/:/g, "-")}.${reset.resetId}`,
   );
+}
+
+function boundaryLine(reset: ResetIntentRecord): Buffer {
+  return Buffer.from(
+    JSON.stringify({
+      version: 1,
+      kind: "conversation-boundary",
+      resetId: reset.resetId,
+      chatId: reset.chatId,
+      boundaryAt: reset.boundaryAt,
+      reason: reset.reason,
+    }),
+    "utf8",
+  );
+}
+
+function platformError(message: string): string | typeof WindowsPrivatePathPolicyError {
+  return process.platform === "win32" ? WindowsPrivatePathPolicyError : message;
 }
 
 function boundaryCount(dataDir: string, chatId: string, resetId = RESET_ID): number {
@@ -329,7 +355,7 @@ describe("ConversationStore reset transaction recovery", () => {
     seedSession(chat, reset.chatId);
     transcript.createResetIntent(reset);
     transcript.ensureConversationBoundary(reset);
-    const active = join(dataDir, "sessions", `${reset.chatId}.jsonl`);
+    const active = sessionPath(dataDir, reset.chatId);
     const archive = resetArchivePath(dataDir, reset);
     linkSync(active, archive);
     expect(lstatSync(active).nlink).toBe(2);
@@ -431,7 +457,7 @@ describe("ConversationStore reset transaction recovery", () => {
         boundaryAt: "2026-07-22T01:02:03.000Z",
         reason: "explicit-reset",
       }),
-    ).toThrow("Transcript append was incomplete.");
+    ).toThrow(platformError("Transcript append was incomplete."));
     expect(chat.hasSession(chatId)).toBe(true);
     expect(transcript.readResetIntent(chatId)).toBeNull();
     expect(boundaryCount(dataDir, chatId)).toBe(0);
@@ -468,7 +494,7 @@ describe("ConversationStore reset transaction recovery", () => {
         boundaryAt: "2026-07-22T01:02:03.000Z",
         reason: "explicit-reset",
       }),
-    ).toThrow("Transcript append was incomplete.");
+    ).toThrow(platformError("Transcript append was incomplete."));
     expect(chat.hasSession(chatId)).toBe(true);
     expect(transcript.readResetIntent(chatId)).not.toBeNull();
     expect(boundaryCount(dataDir, chatId)).toBe(0);
@@ -514,7 +540,7 @@ describe("ConversationStore reset transaction recovery", () => {
         boundaryAt: "2026-07-22T01:02:03.000Z",
         reason: "explicit-reset",
       }),
-    ).toThrow("Transcript append was incomplete.");
+    ).toThrow(platformError("Transcript append was incomplete."));
     expect(() => store.load(chatId)).toThrow(ConversationRecoveryError);
 
     expect(chat.hasSession(chatId)).toBe(true);
@@ -545,7 +571,7 @@ describe("ConversationStore reset transaction recovery", () => {
         boundaryAt: "2026-07-22T01:02:03.000Z",
         reason: "explicit-reset",
       }),
-    ).toThrow("synthetic archive failure");
+    ).toThrow(platformError("synthetic archive failure"));
     expect(chat.hasSession(chatId)).toBe(true);
     expect(transcript.readResetIntent(chatId)).not.toBeNull();
     expect(boundaryCount(dataDir, chatId)).toBe(1);
@@ -575,7 +601,7 @@ describe("ConversationStore reset transaction recovery", () => {
         boundaryAt: reset.boundaryAt,
         reason: reset.reason,
       }),
-    ).toThrow("Transcript contains duplicate reset boundaries.");
+    ).toThrow(platformError("Transcript contains duplicate reset boundaries."));
     expect(transcript.readResetIntent(chatId)).toEqual(reset);
     expect(chat.hasSession(chatId)).toBe(true);
     expect(() => store.load(chatId)).toThrow(ConversationRecoveryError);
@@ -603,7 +629,7 @@ describe("ConversationStore reset transaction recovery", () => {
         boundaryAt: "2026-07-22T01:02:03.000Z",
         reason: "explicit-reset",
       }),
-    ).toThrow("synthetic boundary fsync failure");
+    ).toThrow(platformError("synthetic boundary fsync failure"));
     expect(chat.hasSession(chatId)).toBe(true);
     expect(transcript.readResetIntent(chatId)).not.toBeNull();
     expect(boundaryCount(dataDir, chatId)).toBe(1);
@@ -614,91 +640,97 @@ describe("ConversationStore reset transaction recovery", () => {
     expect(fileSyncs).toBe(3);
   });
 
-  it("retries boundary directory fsync before removing a retained intent", () => {
-    const dataDir = makeDataDir();
-    new TranscriptStore(dataDir);
-    let directorySyncs = 0;
-    const transcript = new TranscriptStore(dataDir, {
-      syncDirectory: (descriptor) => {
-        directorySyncs += 1;
-        if (directorySyncs === 3) {
-          throw new Error("synthetic boundary directory sync failure");
-        }
-        fsyncSync(descriptor);
-      },
-    });
-    const originalRemove = transcript.removeResetIntent.bind(transcript);
-    let directorySyncsAtRemoval = 0;
-    vi.spyOn(transcript, "removeResetIntent").mockImplementation((reset) => {
-      directorySyncsAtRemoval = directorySyncs;
-      originalRemove(reset);
-    });
-    const chat = new ChatStore(dataDir);
-    const store = new ConversationStore(chat, transcript, () => RESET_ID);
-    const chatId = "boundary-directory-sync-failure";
-    seedSession(chat, chatId);
+  it.skipIf(process.platform === "win32")(
+    "retries boundary directory fsync before removing a retained intent",
+    () => {
+      const dataDir = makeDataDir();
+      new TranscriptStore(dataDir);
+      let directorySyncs = 0;
+      const transcript = new TranscriptStore(dataDir, {
+        syncDirectory: (descriptor) => {
+          directorySyncs += 1;
+          if (directorySyncs === 3) {
+            throw new Error("synthetic boundary directory sync failure");
+          }
+          fsyncSync(descriptor);
+        },
+      });
+      const originalRemove = transcript.removeResetIntent.bind(transcript);
+      let directorySyncsAtRemoval = 0;
+      vi.spyOn(transcript, "removeResetIntent").mockImplementation((reset) => {
+        directorySyncsAtRemoval = directorySyncs;
+        originalRemove(reset);
+      });
+      const chat = new ChatStore(dataDir);
+      const store = new ConversationStore(chat, transcript, () => RESET_ID);
+      const chatId = "boundary-directory-sync-failure";
+      seedSession(chat, chatId);
 
-    expect(() =>
-      store.resetConversation({
-        chatId,
-        boundaryAt: "2026-07-22T01:02:03.000Z",
-        reason: "explicit-reset",
-      }),
-    ).toThrow("synthetic boundary directory sync failure");
-    expect(boundaryCount(dataDir, chatId)).toBe(1);
-    expect(transcript.readResetIntent(chatId)).not.toBeNull();
-    expect(directorySyncs).toBe(3);
+      expect(() =>
+        store.resetConversation({
+          chatId,
+          boundaryAt: "2026-07-22T01:02:03.000Z",
+          reason: "explicit-reset",
+        }),
+      ).toThrow("synthetic boundary directory sync failure");
+      expect(boundaryCount(dataDir, chatId)).toBe(1);
+      expect(transcript.readResetIntent(chatId)).not.toBeNull();
+      expect(directorySyncs).toBe(3);
 
-    expect(store.load(chatId).messages).toEqual([]);
+      expect(store.load(chatId).messages).toEqual([]);
 
-    expect(directorySyncsAtRemoval).toBe(4);
-    expect(directorySyncs).toBe(5);
-    expect(transcript.readResetIntent(chatId)).toBeNull();
-    expect(chat.hasSession(chatId)).toBe(false);
-  });
+      expect(directorySyncsAtRemoval).toBe(4);
+      expect(directorySyncs).toBe(5);
+      expect(transcript.readResetIntent(chatId)).toBeNull();
+      expect(chat.hasSession(chatId)).toBe(false);
+    },
+  );
 
-  it("retries the sessions directory fsync after unlink before removing the intent", () => {
-    const dataDir = makeDataDir();
-    let directorySyncs = 0;
-    const chat = createChatStoreWithHooks(dataDir, 0, {
-      syncDirectory: (descriptor) => {
-        directorySyncs += 1;
-        if (directorySyncs === 2) {
-          throw new Error("synthetic post-unlink directory sync failure");
-        }
-        fsyncSync(descriptor);
-      },
-    });
-    const transcript = new TranscriptStore(dataDir);
-    const originalRemove = transcript.removeResetIntent.bind(transcript);
-    let sessionsSyncsAtRemoval = 0;
-    vi.spyOn(transcript, "removeResetIntent").mockImplementation((reset) => {
-      sessionsSyncsAtRemoval = directorySyncs;
-      originalRemove(reset);
-    });
-    const store = new ConversationStore(chat, transcript, () => RESET_ID);
-    const chatId = "session-directory-retry";
-    seedSession(chat, chatId);
+  it.skipIf(process.platform === "win32")(
+    "retries the sessions directory fsync after unlink before removing the intent",
+    () => {
+      const dataDir = makeDataDir();
+      let directorySyncs = 0;
+      const chat = createChatStoreWithHooks(dataDir, 0, {
+        syncDirectory: (descriptor) => {
+          directorySyncs += 1;
+          if (directorySyncs === 2) {
+            throw new Error("synthetic post-unlink directory sync failure");
+          }
+          fsyncSync(descriptor);
+        },
+      });
+      const transcript = new TranscriptStore(dataDir);
+      const originalRemove = transcript.removeResetIntent.bind(transcript);
+      let sessionsSyncsAtRemoval = 0;
+      vi.spyOn(transcript, "removeResetIntent").mockImplementation((reset) => {
+        sessionsSyncsAtRemoval = directorySyncs;
+        originalRemove(reset);
+      });
+      const store = new ConversationStore(chat, transcript, () => RESET_ID);
+      const chatId = "session-directory-retry";
+      seedSession(chat, chatId);
 
-    expect(() =>
-      store.resetConversation({
-        chatId,
-        boundaryAt: "2026-07-22T01:02:03.000Z",
-        reason: "explicit-reset",
-      }),
-    ).toThrow("synthetic post-unlink directory sync failure");
-    expect(chat.hasSession(chatId)).toBe(false);
-    expect(resetArchives(dataDir, chatId)).toHaveLength(1);
-    expect(transcript.readResetIntent(chatId)).not.toBeNull();
-    expect(directorySyncs).toBe(2);
+      expect(() =>
+        store.resetConversation({
+          chatId,
+          boundaryAt: "2026-07-22T01:02:03.000Z",
+          reason: "explicit-reset",
+        }),
+      ).toThrow("synthetic post-unlink directory sync failure");
+      expect(chat.hasSession(chatId)).toBe(false);
+      expect(resetArchives(dataDir, chatId)).toHaveLength(1);
+      expect(transcript.readResetIntent(chatId)).not.toBeNull();
+      expect(directorySyncs).toBe(2);
 
-    expect(store.load(chatId).messages).toEqual([]);
+      expect(store.load(chatId).messages).toEqual([]);
 
-    expect(sessionsSyncsAtRemoval).toBe(3);
-    expect(directorySyncs).toBe(3);
-    expect(transcript.readResetIntent(chatId)).toBeNull();
-    expect(resetArchives(dataDir, chatId)).toHaveLength(1);
-  });
+      expect(sessionsSyncsAtRemoval).toBe(3);
+      expect(directorySyncs).toBe(3);
+      expect(transcript.readResetIntent(chatId)).toBeNull();
+      expect(resetArchives(dataDir, chatId)).toHaveLength(1);
+    },
+  );
 
   it("keeps completed-turn transcript bytes stable across ChatStore compaction mutations", () => {
     const dataDir = makeDataDir();
@@ -762,6 +794,213 @@ describe("ConversationStore reset transaction recovery", () => {
 });
 
 describe("ConversationStore Windows restart recovery", () => {
+  it("removes an unparseable orphan reset temp on simulated Windows", () => {
+    const dataDir = makeDataDir();
+    const chat = new ChatStore(dataDir, 0, { platform: "win32" });
+    const transcript = new TranscriptStore(dataDir, { platform: "win32" });
+    const reset = resetIntent("telegram:synthetic-orphan-temp");
+    seedSession(chat, reset.chatId);
+    const temp = intentTempPath(dataDir, reset.chatId, reset.resetId);
+    writeFileSync(temp, '{"version":1', { mode: 0o600 });
+
+    const recovered = new ConversationStore(chat, transcript);
+
+    expect(existsSync(temp)).toBe(false);
+    expect(recovered.hasSession(reset.chatId)).toBe(true);
+    expect(windowsResetArchives(dataDir, reset.chatId)).toHaveLength(0);
+  });
+
+  it("rejects a hardlinked orphan reset temp on simulated Windows", () => {
+    const dataDir = makeDataDir();
+    const chat = new ChatStore(dataDir, 0, { platform: "win32" });
+    const transcript = new TranscriptStore(dataDir, { platform: "win32" });
+    const reset = resetIntent("telegram:synthetic-linked-orphan");
+    const temp = intentTempPath(dataDir, reset.chatId, reset.resetId);
+    const alias = join(dataDir, "synthetic-reset-temp-alias");
+    writeFileSync(temp, '{"version":1', { mode: 0o600 });
+    linkSync(temp, alias);
+
+    expect(() => new ConversationStore(chat, transcript)).toThrow(WindowsPrivatePathPolicyError);
+    expect(existsSync(temp)).toBe(true);
+    expect(existsSync(alias)).toBe(true);
+  });
+
+  it("recovers only an exact pending boundary prefix on simulated Windows", () => {
+    const dataDir = makeDataDir();
+    const chat = new ChatStore(dataDir, 0, { platform: "win32" });
+    const transcript = new TranscriptStore(dataDir, { platform: "win32" });
+    const reset = resetIntent("telegram:synthetic-torn-boundary");
+    seedSession(chat, reset.chatId);
+    transcript.createResetIntent(reset);
+    transcript.appendCompletedTurn({
+      chatId: reset.chatId,
+      turnId: "old-turn",
+      completedAt: "2026-07-22T00:00:00.000Z",
+      athleteText: "old athlete",
+      coachText: "old coach",
+    });
+    const canonical = boundaryLine(reset);
+    appendFileSync(
+      transcriptPath(dataDir, reset.chatId),
+      canonical.subarray(0, Math.floor(canonical.length / 2)),
+    );
+
+    const recovered = new ConversationStore(chat, transcript);
+
+    expect(recovered.hasSession(reset.chatId)).toBe(false);
+    expect(transcript.readResetIntent(reset.chatId)).toBeNull();
+    expect(boundaryCount(dataDir, reset.chatId)).toBe(1);
+    expect(transcript.readCurrentConversation(reset.chatId)).toEqual([]);
+    expect(windowsResetArchives(dataDir, reset.chatId)).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "an unfenced canonical prefix",
+      (reset: ResetIntentRecord) => boundaryLine(reset).subarray(0, 7),
+    ],
+    ["an arbitrary malformed tail", () => Buffer.from('{"untrusted":', "utf8")],
+  ])("rejects %s on an ordinary simulated-Windows read", (_name, tail) => {
+    const dataDir = makeDataDir();
+    const transcript = new TranscriptStore(dataDir, { platform: "win32" });
+    const reset = resetIntent("telegram:synthetic-unfenced-tail");
+    writeFileSync(transcriptPath(dataDir, reset.chatId), tail(reset), { mode: 0o600 });
+
+    expect(() => transcript.readCurrentConversation(reset.chatId)).toThrow(
+      WindowsPrivatePathPolicyError,
+    );
+  });
+
+  it.each(["resetId", "chatId"] as const)(
+    "rejects a torn boundary with the wrong %s on simulated Windows",
+    (field) => {
+      const dataDir = makeDataDir();
+      const transcript = new TranscriptStore(dataDir, { platform: "win32" });
+      const pending = resetIntent("telegram:synthetic-wrong-boundary", "a".repeat(64));
+      const wrong = {
+        ...pending,
+        [field]: field === "resetId" ? "b".repeat(64) : "telegram:synthetic-other-chat",
+      };
+      transcript.createResetIntent(pending);
+      const canonical = boundaryLine(wrong);
+      writeFileSync(
+        transcriptPath(dataDir, pending.chatId),
+        canonical.subarray(0, canonical.length - 1),
+        { mode: 0o600 },
+      );
+
+      expect(() => transcript.ensureConversationBoundary(pending)).toThrow(
+        WindowsPrivatePathPolicyError,
+      );
+      expect(transcript.readResetIntent(pending.chatId)).toEqual(pending);
+      expect(boundaryCount(dataDir, pending.chatId)).toBe(0);
+    },
+  );
+
+  it("rejects recovery when the persisted intent does not match on simulated Windows", () => {
+    const dataDir = makeDataDir();
+    const transcript = new TranscriptStore(dataDir, { platform: "win32" });
+    const persisted = resetIntent("telegram:synthetic-intent-mismatch", "a".repeat(64));
+    const requested = resetIntent(persisted.chatId, "b".repeat(64));
+    transcript.createResetIntent(persisted);
+    const canonical = boundaryLine(requested);
+    writeFileSync(
+      transcriptPath(dataDir, requested.chatId),
+      canonical.subarray(0, Math.floor(canonical.length / 2)),
+      { mode: 0o600 },
+    );
+
+    expect(() => transcript.ensureConversationBoundary(requested)).toThrow(
+      WindowsPrivatePathPolicyError,
+    );
+    expect(transcript.readResetIntent(persisted.chatId)).toEqual(persisted);
+  });
+
+  it("finishes a complete unterminated pending boundary on simulated Windows", () => {
+    const dataDir = makeDataDir();
+    const transcript = new TranscriptStore(dataDir, { platform: "win32" });
+    const reset = resetIntent("telegram:synthetic-unclosed-boundary");
+    transcript.createResetIntent(reset);
+    writeFileSync(transcriptPath(dataDir, reset.chatId), boundaryLine(reset), { mode: 0o600 });
+
+    transcript.ensureConversationBoundary(reset);
+
+    expect(readFileSync(transcriptPath(dataDir, reset.chatId))).toEqual(
+      Buffer.concat([boundaryLine(reset), Buffer.from("\n", "utf8")]),
+    );
+    expect(boundaryCount(dataDir, reset.chatId)).toBe(1);
+  });
+
+  it("continues one canonical prefix after a short recovery append on simulated Windows", () => {
+    const dataDir = makeDataDir();
+    const reset = resetIntent("telegram:synthetic-recovery-short-write");
+    const original = new TranscriptStore(dataDir, { platform: "win32" });
+    original.createResetIntent(reset);
+    const canonical = boundaryLine(reset);
+    writeFileSync(
+      transcriptPath(dataDir, reset.chatId),
+      canonical.subarray(0, Math.floor(canonical.length / 3)),
+      { mode: 0o600 },
+    );
+    const interrupted = new TranscriptStore(dataDir, {
+      platform: "win32",
+      write: (descriptor, buffer, offset, length, position) =>
+        writeSync(descriptor, buffer, offset, Math.floor(length / 2), position),
+    });
+
+    expect(() => interrupted.ensureConversationBoundary(reset)).toThrow(
+      WindowsPrivatePathPolicyError,
+    );
+    const afterInterrupted = readFileSync(transcriptPath(dataDir, reset.chatId));
+    expect(afterInterrupted.length).toBeGreaterThan(Math.floor(canonical.length / 3));
+    expect(canonical.subarray(0, afterInterrupted.length).equals(afterInterrupted)).toBe(true);
+
+    const recovered = new TranscriptStore(dataDir, { platform: "win32" });
+    recovered.ensureConversationBoundary(reset);
+    expect(boundaryCount(dataDir, reset.chatId)).toBe(1);
+    expect(readFileSync(transcriptPath(dataDir, reset.chatId))).toEqual(
+      Buffer.concat([canonical, Buffer.from("\n", "utf8")]),
+    );
+  });
+
+  it("rejects a malformed prefix unless the next boundary is exact on simulated Windows", () => {
+    const dataDir = makeDataDir();
+    const transcript = new TranscriptStore(dataDir, { platform: "win32" });
+    const first = resetIntent("telegram:synthetic-prefix-pair", "a".repeat(64));
+    const second = resetIntent(first.chatId, "b".repeat(64));
+    const firstLine = boundaryLine(first);
+    writeFileSync(
+      transcriptPath(dataDir, first.chatId),
+      Buffer.concat([
+        firstLine.subarray(0, Math.floor(firstLine.length / 2)),
+        Buffer.from("\n", "utf8"),
+        boundaryLine(second),
+        Buffer.from("\n", "utf8"),
+      ]),
+      { mode: 0o600 },
+    );
+
+    expect(() => transcript.readCurrentConversation(first.chatId)).toThrow(
+      WindowsPrivatePathPolicyError,
+    );
+  });
+
+  it("rejects duplicate boundaries on simulated Windows", () => {
+    const dataDir = makeDataDir();
+    const transcript = new TranscriptStore(dataDir, { platform: "win32" });
+    const reset = resetIntent("telegram:synthetic-duplicate-boundary");
+    const line = boundaryLine(reset);
+    writeFileSync(
+      transcriptPath(dataDir, reset.chatId),
+      Buffer.concat([line, Buffer.from("\n", "utf8"), line, Buffer.from("\n", "utf8")]),
+      { mode: 0o600 },
+    );
+
+    expect(() => transcript.readCurrentConversation(reset.chatId)).toThrow(
+      WindowsPrivatePathPolicyError,
+    );
+  });
+
   it("reopens completed archives without changing the recovered conversation", () => {
     const dataDir = makeDataDir();
     const chatId = "telegram:synthetic-windows-restart";

--- a/packages/core/tests/transcript-store.test.ts
+++ b/packages/core/tests/transcript-store.test.ts
@@ -1334,7 +1334,7 @@ describe("TranscriptStore Windows private paths", () => {
     expect(readFileSync(path, "utf8")).toBe("{not-valid-json}\n");
   });
 
-  it("rejects a malformed orphan reset temp without deleting it during recovery", () => {
+  it("removes a malformed single-link orphan reset temp during recovery", () => {
     const dataDir = makeDataDir();
     const reset = intent("corrupt-orphan-temp");
     const digest = createHash("sha256").update(reset.chatId, "utf8").digest("hex");
@@ -1342,20 +1342,8 @@ describe("TranscriptStore Windows private paths", () => {
     const store = new TranscriptStore(dataDir, { platform: "win32" });
     writeFileSync(path, "{not-valid-json}\n", { mode: 0o600 });
 
-    let failure: unknown;
-    try {
-      store.readResetIntent(reset.chatId);
-    } catch (error) {
-      failure = error;
-    }
-
-    expect(failure).toBeInstanceOf(WindowsPrivatePathPolicyError);
-    expect(failure).toMatchObject({ stage: "read-check", category: "corruption" });
-    expect(failure).not.toHaveProperty("path");
-    expect(failure).not.toHaveProperty("cause");
-    expect(String(failure)).not.toContain(path);
-    expect(JSON.stringify(failure)).not.toContain(path);
-    expect(readFileSync(path, "utf8")).toBe("{not-valid-json}\n");
+    expect(store.readResetIntent(reset.chatId)).toBeNull();
+    expect(existsSync(path)).toBe(false);
   });
 
   it("does not swallow a Windows sharing violation during file flush", () => {


### PR DESCRIPTION
Recover interrupted reset writes safely on Windows. Focused regression tests, package typecheck, and the full repository gates pass.