### PR TITLE
fix(desktop): confirm Telegram user removal

### DIFF
--- a/.changeset/telegram-user-removal-confirmation.md
+++ b/.changeset/telegram-user-removal-confirmation.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Removing an additional Telegram user now asks for confirmation and explains that the user loses access until re-added by sender ID.

--- a/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
@@ -145,8 +145,10 @@ export function TelegramSection(): ReactElement {
   const [senderDraft, setSenderDraft] = useState("");
   const [senderError, setSenderError] = useState<string | null>(null);
   const [confirmRemove, setConfirmRemove] = useState(false);
+  const [confirmRemoveSenderId, setConfirmRemoveSenderId] = useState<number | null>(null);
   const [firstTimeOpen, setFirstTimeOpen] = useState(() => telegram?.credentialConfigured !== true);
   const deleteTrigger = useRef<HTMLButtonElement>(null);
+  const removeSenderTrigger = useRef<HTMLButtonElement>(null);
   const firstTimeTrigger = useRef<HTMLButtonElement>(null);
   const firstTimeHeading = useRef<HTMLHeadingElement>(null);
   const focusFirstTimeHeading = useRef(false);
@@ -165,6 +167,7 @@ export function TelegramSection(): ReactElement {
   const working = state.status === "working";
   const busy = mutating || loading || working;
   const removing = state.status === "working" && state.operation === "remove";
+  const removingSender = state.status === "working" && state.operation === "remove-sender";
   const botUsername =
     telegram === null || telegram.bot.state === "unconfigured" ? null : telegram.bot.username;
   const credentialIdentityMissing =
@@ -200,6 +203,16 @@ export function TelegramSection(): ReactElement {
       setConfirmRemove(false);
     }
   }, [telegram]);
+
+  useEffect(() => {
+    if (
+      confirmRemoveSenderId !== null &&
+      allowedSenders !== null &&
+      !allowedSenders.senders.some((sender) => sender.senderId === confirmRemoveSenderId)
+    ) {
+      setConfirmRemoveSenderId(null);
+    }
+  }, [allowedSenders, confirmRemoveSenderId]);
 
   useEffect(() => {
     if (!credentialIdentityMissing) return;
@@ -602,17 +615,39 @@ export function TelegramSection(): ReactElement {
                       </div>
                     </div>
                     {sender.role === "additional" ? (
-                      <button
-                        type="button"
-                        className={BUTTON_DANGER_QUIET_SM}
-                        disabled={busy}
-                        aria-label={"Remove Telegram user " + sender.senderId}
-                        onClick={() => {
-                          port?.removeSender(sender.senderId);
-                        }}
-                      >
-                        Remove
-                      </button>
+                      <>
+                        <button
+                          type="button"
+                          className={BUTTON_DANGER_QUIET_SM}
+                          disabled={busy || confirmRemoveSenderId !== null}
+                          aria-label={"Remove Telegram user " + sender.senderId}
+                          onClick={(event) => {
+                            removeSenderTrigger.current = event.currentTarget;
+                            setConfirmRemoveSenderId(sender.senderId);
+                          }}
+                        >
+                          Remove
+                        </button>
+                        {confirmRemoveSenderId === sender.senderId ? (
+                          <InlineConfirmation
+                            name="remove-telegram-user"
+                            title={`Remove Telegram user ${sender.senderId}?`}
+                            copy={`This user will lose access to your coach and shared athlete data until you re-add them by sender ID ${sender.senderId}.`}
+                            confirmLabel="Remove user"
+                            focusTarget={null}
+                            cancelDisabled={busy}
+                            confirmDisabled={busy}
+                            confirmBusy={removingSender}
+                            onCancel={() => {
+                              setConfirmRemoveSenderId(null);
+                              queueMicrotask(() => removeSenderTrigger.current?.focus());
+                            }}
+                            onConfirm={() => {
+                              port?.removeSender(sender.senderId);
+                            }}
+                          />
+                        ) : null}
+                      </>
                     ) : null}
                   </li>
                 ))}

--- a/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
@@ -231,25 +231,24 @@ describe("Telegram settings surface", () => {
 
   it("manages paired users without offering removal for the primary user", async () => {
     const user = userEvent.setup();
+    const connected = status({
+      channel: { desiredState: "enabled", state: "online" },
+      bot: { state: "ready", username: "desktop_coach_bot" },
+      pairing: { state: "paired" },
+      credentialConfigured: true,
+      gapWarning: {
+        state: "possible-message-loss",
+        detectedAt: "1998-07-06T12:00:00.000Z",
+      },
+    });
+    const allowedSenders: TelegramAllowedSenders = {
+      senders: [
+        { senderId: 101, role: "primary" },
+        { senderId: 202, role: "additional" },
+      ],
+    };
     const port = setup(
-      readyState(
-        status({
-          channel: { desiredState: "enabled", state: "online" },
-          bot: { state: "ready", username: "desktop_coach_bot" },
-          pairing: { state: "paired" },
-          credentialConfigured: true,
-          gapWarning: {
-            state: "possible-message-loss",
-            detectedAt: "1998-07-06T12:00:00.000Z",
-          },
-        }),
-        {
-          senders: [
-            { senderId: 101, role: "primary" },
-            { senderId: 202, role: "additional" },
-          ],
-        },
-      ),
+      readyState(connected, allowedSenders),
     );
 
     expect(screen.getByText("@desktop_coach_bot")).toBeVisible();
@@ -267,7 +266,66 @@ describe("Telegram settings surface", () => {
     expect(removeSender.className).toBe(BUTTON_DANGER_QUIET_SM);
 
     await user.click(removeSender);
+    let confirmation = within(users).getByRole("group", {
+      name: "Remove Telegram user 202?",
+    });
+    expect(confirmation).toHaveAccessibleDescription(
+      /lose access to your coach and shared athlete data until you re-add them by sender ID 202/iu,
+    );
+    let confirmationButtons = within(confirmation).getAllByRole("button");
+    expect(confirmationButtons.map((button) => button.textContent)).toEqual([
+      "Cancel",
+      "Remove user",
+    ]);
+    expect(confirmationButtons[0]).toHaveFocus();
+    expect(port.removeSender).not.toHaveBeenCalled();
+
+    await user.click(confirmationButtons[0]);
+    await waitFor(() => expect(removeSender).toHaveFocus());
+    expect(port.removeSender).not.toHaveBeenCalled();
+
+    await user.click(removeSender);
+    confirmation = within(users).getByRole("group", {
+      name: "Remove Telegram user 202?",
+    });
+    confirmationButtons = within(confirmation).getAllByRole("button");
+    await user.click(confirmationButtons[1]);
+    expect(port.removeSender).toHaveBeenCalledTimes(1);
     expect(port.removeSender).toHaveBeenCalledWith(202);
+
+    act(() => {
+      useEnduragentStore.setState((current) => ({
+        settings: {
+          ...current.settings,
+          telegram: {
+            ...readyState(connected, allowedSenders),
+            status: "working",
+            operation: "remove-sender",
+          },
+        },
+      }));
+    });
+    const busyRemove = within(confirmation).getByRole("button", { name: "Remove user" });
+    expect(busyRemove).toHaveAttribute("aria-disabled", "true");
+    expect(busyRemove).not.toBeDisabled();
+    await user.click(busyRemove);
+    expect(port.removeSender).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useEnduragentStore.setState((current) => ({
+        settings: {
+          ...current.settings,
+          telegram: readyState(connected, {
+            senders: [{ senderId: 101, role: "primary" }],
+          }),
+        },
+      }));
+    });
+    await waitFor(() =>
+      expect(
+        within(users).queryByRole("group", { name: "Remove Telegram user 202?" }),
+      ).toBeNull(),
+    );
 
     const senderId = screen.getByLabelText("Add a Telegram user ID");
     await user.type(senderId, "9");


### PR DESCRIPTION
Require explicit confirmation before deleting the connected Telegram user. Focused renderer tests and full repository gates pass.