### PR TITLE
fix(desktop): verify Windows package without 7-Zip

### DIFF
--- a/.changeset/windows-native-package-verification.md
+++ b/.changeset/windows-native-package-verification.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Verify the Windows installer envelope and retained application tree with native Node.js tooling, and emit immutable SHA-256 package evidence without relying on a machine-installed archive utility.

--- a/apps/desktop/scripts/verify-windows-package.d.mts
+++ b/apps/desktop/scripts/verify-windows-package.d.mts
@@ -2,13 +2,11 @@ import type { Stats } from "node:fs";
 
 export type WindowsPackageVerificationStage =
   | "artifact"
-  | "installer-inventory"
   | "installer-contract"
   | "application-inventory"
   | "resource-inventory"
   | "asar-inventory"
-  | "binary-platform"
-  | "cleanup";
+  | "binary-platform";
 
 export interface WindowsBuilderAuthority {
   readonly asarSourceRoot: string;
@@ -22,20 +20,27 @@ export interface WindowsPackageLayoutOptions {
 }
 
 export interface WindowsPackageVerificationOverrides {
-  readonly executeFile?: (
-    executable: string,
-    arguments_: readonly string[],
-  ) => Promise<{ readonly stdout: string | Buffer }>;
-  readonly extractInstaller?: (artifact: string, destination: string) => Promise<void>;
-  readonly extractApplication?: (archive: string, destination: string) => Promise<void>;
   readonly lstat?: (path: string) => Promise<Stats>;
-  readonly mkdtemp?: (prefix: string) => Promise<string>;
   readonly readFile?: (path: string) => Promise<Buffer>;
   readonly readVersionFile?: (path: string, encoding: "utf8") => Promise<string>;
-  readonly rm?: (
-    path: string,
-    options: { readonly recursive: true; readonly force: true },
-  ) => Promise<void>;
+}
+
+export interface WindowsApplicationEvidence {
+  readonly fileCount: number;
+  readonly directoryCount: number;
+  readonly manifestSha256: string;
+  readonly peMachine: 0x8664;
+}
+
+export interface WindowsPackageEvidence {
+  readonly artifact: {
+    readonly name: string;
+    readonly size: number;
+    readonly sha256: string;
+    readonly peMachine: 0x014c | 0x8664;
+    readonly nsisEnvelope: true;
+  };
+  readonly application: WindowsApplicationEvidence;
 }
 
 export class WindowsPackageVerificationError extends Error {
@@ -52,10 +57,11 @@ export function readWindowsBuilderAuthority(desktopRoot?: string): Promise<Windo
 export function verifyWindowsPackageLayout(
   application: string,
   options?: WindowsPackageLayoutOptions,
-): Promise<void>;
+): Promise<WindowsApplicationEvidence>;
 
 export function verifyWindowsPackage(
   artifact: string,
+  application: string,
   options?: WindowsPackageLayoutOptions,
   overrides?: WindowsPackageVerificationOverrides,
-): Promise<void>;
+): Promise<WindowsPackageEvidence>;

--- a/apps/desktop/scripts/verify-windows-package.mjs
+++ b/apps/desktop/scripts/verify-windows-package.mjs
@@ -176,7 +176,7 @@ export async function readWindowsBuilderAuthority(desktopRoot = canonicalDesktop
     }
     throw error;
   }
-  if (hook.toString("utf8") !== canonicalInstallerHook) {
+  if (hook.toString("utf8").replaceAll("\r\n", "\n") !== canonicalInstallerHook) {
     failWindows("installer-contract", "uninstall hook is invalid", ["build/installer.nsh"]);
   }
   return Object.freeze({

--- a/apps/desktop/scripts/verify-windows-package.mjs
+++ b/apps/desktop/scripts/verify-windows-package.mjs
@@ -1,7 +1,7 @@
-import { execFile } from "node:child_process";
-import { lstat, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { lstat, readFile } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
-import { promisify, isDeepStrictEqual } from "node:util";
+import { isDeepStrictEqual } from "node:util";
 import { fileURLToPath } from "node:url";
 import {
   PackageLayoutError,
@@ -18,7 +18,6 @@ import {
   validateBuilderInventoryAuthority,
   validateRequiredAsarFiles,
 } from "./package-inventory.mjs";
-import { contained } from "./package-plan.mjs";
 import {
   WINDOWS_PACKAGE_APP_ID,
   WINDOWS_PACKAGE_ARCH,
@@ -31,7 +30,6 @@ import {
   windowsPackageArtifactName,
 } from "./windows-package-plan.mjs";
 
-const executeSystemFile = promisify(execFile);
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const canonicalDesktopRoot = resolve(scriptDirectory, "..");
 const canonicalInstallerHook = [
@@ -69,34 +67,20 @@ const expectedAsarResourceFiles = new Set([
   "resources/trayTemplate@2x.png",
 ]);
 const forbiddenNativeExtensions = new Set([".dylib", ".node", ".so"]);
-const installerApplicationArchive = "$PLUGINSDIR/app-64.7z";
-const installerBinaryEntries = new Set([
-  "$PLUGINSDIR/System.dll",
-  "$PLUGINSDIR/StdUtils.dll",
-  "$PLUGINSDIR/SpiderBanner.dll",
-  "$PLUGINSDIR/nsExec.dll",
-  "$PLUGINSDIR/nsis7z.dll",
-  "$PLUGINSDIR/WinShell.dll",
-  `$R0/Uninstall ${WINDOWS_PACKAGE_PRODUCT_NAME}.exe`,
-]);
-const expectedInstallerEntries = new Map([
-  ["$PLUGINSDIR", "directory"],
-  ...[...installerBinaryEntries].map((path) => [path, "file"]),
-  [installerApplicationArchive, "file"],
-  ["$R0", "directory"],
-]);
 const x64PeMachine = 0x8664;
 const x86PeMachine = 0x014c;
+const nsisOverlaySignature = Buffer.concat([
+  Buffer.from([0xef, 0xbe, 0xad, 0xde]),
+  Buffer.from("NullsoftInst", "latin1"),
+]);
 
 export const WINDOWS_PACKAGE_VERIFICATION_STAGES = Object.freeze([
   "artifact",
-  "installer-inventory",
   "installer-contract",
   "application-inventory",
   "resource-inventory",
   "asar-inventory",
   "binary-platform",
-  "cleanup",
 ]);
 
 export class WindowsPackageVerificationError extends Error {
@@ -454,6 +438,36 @@ function validateApplicationBinaries(tree) {
       `${WINDOWS_PACKAGE_PRODUCT_NAME}.exe`,
     ]);
   }
+  return x64PeMachine;
+}
+
+function applicationEvidence(tree, peMachine) {
+  const manifest = createHash("sha256");
+  let fileCount = 0;
+  let directoryCount = 0;
+  for (const path of [...tree.keys()].sort()) {
+    const entry = tree.get(path);
+    if (entry.type === "directory") {
+      directoryCount += 1;
+      manifest.update(`${JSON.stringify({ path, type: entry.type })}\n`);
+      continue;
+    }
+    fileCount += 1;
+    manifest.update(
+      `${JSON.stringify({
+        path,
+        type: entry.type,
+        size: entry.bytes.length,
+        sha256: createHash("sha256").update(entry.bytes).digest("hex"),
+      })}\n`,
+    );
+  }
+  return Object.freeze({
+    fileCount,
+    directoryCount,
+    manifestSha256: manifest.digest("hex"),
+    peMachine,
+  });
 }
 
 function asarNativeEntries(asar) {
@@ -608,7 +622,8 @@ export async function verifyWindowsPackageLayout(application, options = {}) {
     }
     const authority = await readWindowsBuilderAuthority(desktopRoot);
     await verifyResources(join(application, "resources"), authority, desktopRoot);
-    validateApplicationBinaries(tree);
+    const peMachine = validateApplicationBinaries(tree);
+    return applicationEvidence(tree, peMachine);
   } catch (error) {
     if (error instanceof WindowsPackageVerificationError) throw error;
     if (error instanceof PackageLayoutError) {
@@ -626,59 +641,18 @@ function validateInstallerArtifact(bytes, path) {
   if (metadata.certificateOffset !== 0 || metadata.certificateSize !== 0) {
     failWindows("artifact", "installer must be unsigned", [path]);
   }
-  if (!bytes.includes(Buffer.from("NullsoftInst", "latin1"))) {
+  if (!bytes.includes(nsisOverlaySignature)) {
     failWindows("artifact", "installer is not an NSIS package", [path]);
   }
+  return metadata;
 }
 
-function validateInstallerListing(result, path) {
-  const stdout = result !== null && typeof result === "object" ? result.stdout : undefined;
-  const listing = Buffer.isBuffer(stdout) ? stdout.toString("utf8") : stdout;
-  if (typeof listing !== "string") {
-    failWindows("artifact", "7-Zip installer listing is invalid", [path]);
-  }
-  const entries = listing.search(/^----------\r?$/mu);
-  const header = entries < 0 ? listing : listing.slice(0, entries);
-  const types = [...header.matchAll(/^Type = ([^\r\n]+)\r?$/gmu)].map((match) => match[1]);
-  if (!isDeepStrictEqual(types, ["Nsis"])) {
-    failWindows("artifact", "7-Zip did not identify installer as NSIS", [path]);
-  }
-}
-
-function validateInstallerInventory(tree) {
-  exactNameSet(
-    new Set(tree.keys()),
-    new Set(expectedInstallerEntries.keys()),
-    "installer-inventory",
-    "installer entry",
-  );
-  for (const [path, expectedType] of expectedInstallerEntries) {
-    const entry = tree.get(path);
-    if (entry.type !== expectedType) {
-      failWindows("installer-inventory", "installer entry type is invalid", [path]);
-    }
-  }
-  for (const path of installerBinaryEntries) {
-    const metadata = peMetadata(tree.get(path).bytes, path, "binary-platform");
-    if (![x86PeMachine, x64PeMachine].includes(metadata.machine)) {
-      failWindows("binary-platform", "wrong-platform binary", [path]);
-    }
-  }
-  return installerApplicationArchive;
-}
-
-async function extractWithSevenZip(source, destination, executeFile_) {
-  await mkdir(destination, { recursive: true });
-  await executeFile_("7zz", ["x", "-bd", "-bb0", "-y", `-o${destination}`, source]);
-}
-
-function missingPath(error) {
-  return error !== null && typeof error === "object" && error.code === "ENOENT";
-}
-
-export async function verifyWindowsPackage(artifact, options = {}, overrides = {}) {
+export async function verifyWindowsPackage(artifact, application, options = {}, overrides = {}) {
   if (!isAbsolute(artifact) || extname(artifact).toLowerCase() !== ".exe") {
     failWindows("artifact", "artifact path must be one absolute .exe path");
+  }
+  if (!isAbsolute(application)) {
+    failWindows("application-inventory", "application path must be absolute");
   }
   const desktopRoot = options.desktopRoot ?? canonicalDesktopRoot;
   if (!isAbsolute(desktopRoot)) failWindows("installer-contract", "desktop root must be absolute");
@@ -710,76 +684,41 @@ export async function verifyWindowsPackage(artifact, options = {}, overrides = {
     }
     throw error;
   }
-  validateInstallerArtifact(artifactBytes, expectedName);
-
-  const executeFile_ = overrides.executeFile ?? executeSystemFile;
-  const makeTemporaryDirectory = overrides.mkdtemp ?? mkdtemp;
-  const remove = overrides.rm ?? rm;
-  const extractionPrefix = join(dirname(artifact), ".windows-package-verification-");
-  let temporaryDirectory;
-  let failure;
-  try {
-    const extractionParent = dirname(artifact);
-    const candidate = await makeTemporaryDirectory(extractionPrefix);
-    if (candidate === extractionParent || !contained(extractionParent, candidate)) {
-      failWindows("installer-inventory", "temporary extraction directory is invalid");
-    }
-    temporaryDirectory = candidate;
-    const installerRoot = join(temporaryDirectory, "installer");
-    const applicationRoot = join(temporaryDirectory, "application");
-    const extractInstaller =
-      overrides.extractInstaller ??
-      ((source, destination) => extractWithSevenZip(source, destination, executeFile_));
-    const extractApplication =
-      overrides.extractApplication ??
-      ((source, destination) => extractWithSevenZip(source, destination, executeFile_));
-    validateInstallerListing(
-      await executeFile_("7zz", ["l", "-slt", "-bd", artifact]),
-      expectedName,
-    );
-    await extractInstaller(artifact, installerRoot);
-    const installerTree = await collectTree(installerRoot, "installer", false);
-    const archivePath = validateInstallerInventory(installerTree);
-    await extractApplication(join(installerRoot, archivePath), applicationRoot);
-    await verifyWindowsPackageLayout(applicationRoot, { desktopRoot });
-  } catch (error) {
-    failure =
-      error instanceof WindowsPackageVerificationError
-        ? error
-        : new WindowsPackageVerificationError(
-            "installer-inventory",
-            "installer extraction or verification failed",
-          );
-  }
-  if (temporaryDirectory !== undefined) {
-    try {
-      await remove(temporaryDirectory, { recursive: true, force: true });
-      try {
-        await (overrides.lstat ?? lstat)(temporaryDirectory);
-        failWindows("cleanup", "temporary extraction cleanup failed");
-      } catch (error) {
-        if (!missingPath(error)) throw error;
-      }
-    } catch (error) {
-      if (error instanceof WindowsPackageVerificationError) throw error;
-      failWindows("cleanup", "temporary extraction cleanup failed");
-    }
-  }
-  if (failure !== undefined) throw failure;
+  const metadata = validateInstallerArtifact(artifactBytes, expectedName);
+  const applicationResult = await verifyWindowsPackageLayout(application, { desktopRoot });
+  return Object.freeze({
+    artifact: Object.freeze({
+      name: expectedName,
+      size: artifactBytes.length,
+      sha256: createHash("sha256").update(artifactBytes).digest("hex"),
+      peMachine: metadata.machine,
+      nsisEnvelope: true,
+    }),
+    application: applicationResult,
+  });
 }
 
-async function artifactArgument(args) {
-  if (args.length === 0) return (await createWindowsPackagePlan()).artifactPath;
-  if (args.length !== 1 || !isAbsolute(args[0]) || extname(args[0]).toLowerCase() !== ".exe") {
-    failWindows("artifact", "expected zero arguments or one absolute .exe path");
+async function packageArguments(args) {
+  if (args.length === 0) {
+    const plan = await createWindowsPackagePlan();
+    return { artifact: plan.artifactPath, application: plan.applicationPath };
   }
-  return args[0];
+  if (
+    args.length !== 2 ||
+    !isAbsolute(args[0]) ||
+    extname(args[0]).toLowerCase() !== ".exe" ||
+    !isAbsolute(args[1])
+  ) {
+    failWindows("artifact", "expected zero arguments or absolute artifact and application paths");
+  }
+  return { artifact: args[0], application: args[1] };
 }
 
 async function main() {
   try {
-    await verifyWindowsPackage(await artifactArgument(process.argv.slice(2)));
-    process.stdout.write("Windows package verified\n");
+    const input = await packageArguments(process.argv.slice(2));
+    const evidence = await verifyWindowsPackage(input.artifact, input.application);
+    process.stdout.write(`${JSON.stringify(evidence)}\n`);
   } catch (error) {
     process.stderr.write(
       `${safeWindowsPackageVerificationMessage(error) ?? "Windows package verification failed"}\n`,

--- a/apps/desktop/scripts/windows-package-plan.d.mts
+++ b/apps/desktop/scripts/windows-package-plan.d.mts
@@ -1,3 +1,5 @@
+import type { WindowsPackageEvidence } from "./verify-windows-package.mjs";
+
 export interface WindowsPackageInput {
   readonly desktopRoot?: string;
 }
@@ -73,8 +75,9 @@ export interface WindowsPackageDependencies {
   readonly build?: (options: WindowsPackageBuilderOptions) => Promise<readonly string[]>;
   readonly verifyWindowsPackage?: (
     artifactPath: string,
+    applicationPath: string,
     options: { readonly desktopRoot: string },
-  ) => Promise<void>;
+  ) => Promise<WindowsPackageEvidence>;
   readonly reportStage?: (stage: WindowsPackageStage) => void;
 }
 
@@ -114,5 +117,6 @@ export function runWindowsPackage(
   dependencies?: WindowsPackageDependencies,
 ): Promise<{
   readonly artifacts: readonly string[];
+  readonly evidence: WindowsPackageEvidence;
   readonly plan: WindowsPackagePlan;
 }>;

--- a/apps/desktop/scripts/windows-package-plan.mjs
+++ b/apps/desktop/scripts/windows-package-plan.mjs
@@ -145,8 +145,10 @@ export async function runWindowsPackage(input = {}, dependencies = {}) {
     dependencies.verifyWindowsPackage ??
     (await import("./verify-windows-package.mjs")).verifyWindowsPackage;
   dependencies.reportStage?.("package-verification");
-  await verifyWindowsPackage(plan.artifactPath, { desktopRoot: plan.builderOptions.projectDir });
-  return Object.freeze({ artifacts, plan });
+  const evidence = await verifyWindowsPackage(plan.artifactPath, plan.applicationPath, {
+    desktopRoot: plan.builderOptions.projectDir,
+  });
+  return Object.freeze({ artifacts: Object.freeze([...artifacts]), evidence, plan });
 }
 
 async function main() {

--- a/apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json
@@ -215,12 +215,12 @@
     {
       "id": "package.nsis.verification",
       "surface": "windows-package",
-      "expected": "Packaging cleans output, builds one exact versioned installer, and verifies it before release; signed, renamed, non-NSIS, missing, or undeclared installer contents fail closed.",
+      "expected": "Packaging cleans output, builds one exact versioned installer, and verifies its PE/NSIS envelope plus retained application before release; signed, renamed, non-NSIS, missing, or changed retained contents fail closed.",
       "automation": "deterministic",
       "tests": [
         "apps/desktop/tests/windows-package-plan.test.ts > cleans, builds, checks the singleton artifact, and verifies in order",
         "apps/desktop/tests/windows-package-layout.test.ts > rejects signed, renamed, and non-NSIS installer artifacts",
-        "apps/desktop/tests/windows-package-layout.test.ts > rejects undeclared and missing entries inside the installer"
+        "apps/desktop/tests/windows-package-layout.test.ts > changes artifact and retained-tree digests when one byte changes"
       ]
     },
     {

--- a/apps/desktop/tests/windows-package-layout.test.ts
+++ b/apps/desktop/tests/windows-package-layout.test.ts
@@ -426,6 +426,21 @@ describe("Windows package verification", () => {
     expect(hook).not.toMatch(/RMDir|USERPROFILE|LOCALAPPDATA/u);
   });
 
+  it("accepts CRLF in the exact uninstall hook and rejects content drift", async () => {
+    const fixture = await syntheticWindowsPackage();
+    const hookPath = join(fixture.desktop, "build/installer.nsh");
+    const hook = await readFile(hookPath, "utf8");
+    await writeFile(hookPath, hook.replaceAll("\n", "\r\n"));
+    await expect(readWindowsBuilderAuthority(fixture.desktop)).resolves.toMatchObject({
+      installerHookPath: hookPath,
+    });
+
+    await writeFile(hookPath, hook.replace("DeleteRegValue", "DeleteRegKey"));
+    await expect(readWindowsBuilderAuthority(fixture.desktop)).rejects.toThrow(
+      'windows-package/installer-contract: uninstall hook is invalid: "build/installer.nsh"',
+    );
+  });
+
   it("fails closed with a stage code and the exact undeclared layout path", async () => {
     const fixture = await syntheticWindowsPackage();
     await writeFile(join(fixture.application, "unexpected.bin"), "unexpected\n");

--- a/apps/desktop/tests/windows-package-layout.test.ts
+++ b/apps/desktop/tests/windows-package-layout.test.ts
@@ -5,12 +5,13 @@ import { dirname, join, resolve } from "node:path";
 import { finished } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import { createPackage } from "@electron/asar";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   WINDOWS_PACKAGE_GUID,
   windowsPackageArtifactName,
 } from "../scripts/windows-package-plan.mjs";
 import {
+  type WindowsPackageEvidence,
   WindowsPackageVerificationError,
   readWindowsBuilderAuthority,
   verifyWindowsPackage,
@@ -143,8 +144,6 @@ const telegramRuntimePackages = [
   },
 ] as const;
 
-type InstallerMutation = (installerRoot: string) => Promise<void>;
-
 type SyntheticWindowsPackage = {
   application: string;
   archiveSource: string;
@@ -152,7 +151,7 @@ type SyntheticWindowsPackage = {
   desktop: string;
   externalPackaged: string;
   rebuild: () => Promise<void>;
-  verifyArtifact: (mutation?: InstallerMutation, installerType?: string) => Promise<void>;
+  verifyArtifact: () => Promise<WindowsPackageEvidence>;
   writeArchive: (path: string, bytes?: string | Buffer) => Promise<void>;
 };
 
@@ -224,7 +223,12 @@ function builderYaml(): string {
   ].join("\n");
 }
 
-function windowsExecutable(machine = 0x8664, marker = ""): Buffer {
+const nsisOverlaySignature = Buffer.concat([
+  Buffer.from([0xef, 0xbe, 0xad, 0xde]),
+  Buffer.from("NullsoftInst", "latin1"),
+]);
+
+function windowsExecutable(machine = 0x8664, marker: string | Buffer = ""): Buffer {
   const header = 0x80;
   const optionalSize = machine === 0x014c ? 224 : 240;
   const bytes = Buffer.alloc(header + 24 + optionalSize);
@@ -235,19 +239,6 @@ function windowsExecutable(machine = 0x8664, marker = ""): Buffer {
   bytes.writeUInt16LE(optionalSize, header + 20);
   bytes.writeUInt16LE(machine === 0x014c ? 0x010b : 0x020b, header + 24);
   return Buffer.concat([bytes, Buffer.from(marker)]);
-}
-
-function sevenZipInstallerListing(type: string): string {
-  return [
-    "--",
-    "Path = Enduragent.exe",
-    `Type = ${type}`,
-    "SubType = NSIS-3 Unicode",
-    "",
-    "----------",
-    "Path = $PLUGINSDIR/app-64.7z",
-    "",
-  ].join("\n");
 }
 
 async function syntheticWindowsPackage(): Promise<SyntheticWindowsPackage> {
@@ -358,45 +349,10 @@ async function syntheticWindowsPackage(): Promise<SyntheticWindowsPackage> {
   };
   await rebuild();
   await cp(join(externalSource, "self-test"), externalPackaged, { recursive: true });
-  await writeFile(artifact, windowsExecutable(0x014c, "NullsoftInst"));
+  await writeFile(artifact, windowsExecutable(0x014c, nsisOverlaySignature));
 
-  const verifyArtifact = async (
-    mutation?: InstallerMutation,
-    installerType = "Nsis",
-  ): Promise<void> => {
-    await verifyWindowsPackage(
-      artifact,
-      { desktopRoot: desktop },
-      {
-        executeFile: async () => ({ stdout: sevenZipInstallerListing(installerType) }),
-        extractInstaller: async (_source, destination) => {
-          const pluginDirectory = join(destination, "$PLUGINSDIR");
-          const uninstallerDirectory = join(destination, "$R0");
-          await Promise.all([
-            mkdir(pluginDirectory, { recursive: true }),
-            mkdir(uninstallerDirectory, { recursive: true }),
-          ]);
-          await Promise.all([
-            writeFile(join(pluginDirectory, "System.dll"), windowsExecutable(0x014c)),
-            writeFile(join(pluginDirectory, "StdUtils.dll"), windowsExecutable(0x014c)),
-            writeFile(join(pluginDirectory, "SpiderBanner.dll"), windowsExecutable(0x014c)),
-            writeFile(join(pluginDirectory, "nsExec.dll"), windowsExecutable(0x014c)),
-            writeFile(join(pluginDirectory, "app-64.7z"), "synthetic archive\n"),
-            writeFile(join(pluginDirectory, "nsis7z.dll"), windowsExecutable(0x014c)),
-            writeFile(join(pluginDirectory, "WinShell.dll"), windowsExecutable(0x014c)),
-            writeFile(
-              join(uninstallerDirectory, "Uninstall Enduragent.exe"),
-              windowsExecutable(0x014c, "NullsoftInst"),
-            ),
-          ]);
-          await mutation?.(destination);
-        },
-        extractApplication: async (_source, destination) => {
-          await cp(application, destination, { recursive: true });
-        },
-      },
-    );
-  };
+  const verifyArtifact = async (): Promise<WindowsPackageEvidence> =>
+    verifyWindowsPackage(artifact, application, { desktopRoot: desktop });
 
   return {
     application,
@@ -413,11 +369,47 @@ async function syntheticWindowsPackage(): Promise<SyntheticWindowsPackage> {
 describe("Windows package verification", () => {
   it("accepts the exact x64 application and unsigned NSIS package", async () => {
     const fixture = await syntheticWindowsPackage();
-    await expect(
-      verifyWindowsPackageLayout(fixture.application, { desktopRoot: fixture.desktop }),
-    ).resolves.toBeUndefined();
-    await expect(fixture.verifyArtifact()).resolves.toBeUndefined();
-    await expect(fixture.verifyArtifact()).resolves.toBeUndefined();
+    const layout = await verifyWindowsPackageLayout(fixture.application, {
+      desktopRoot: fixture.desktop,
+    });
+    const evidence = await fixture.verifyArtifact();
+    const repeated = await fixture.verifyArtifact();
+    expect(layout).toEqual(evidence.application);
+    expect(evidence).toEqual(repeated);
+    expect(evidence).toMatchObject({
+      artifact: {
+        name: windowsPackageArtifactName(version),
+        peMachine: 0x014c,
+        nsisEnvelope: true,
+      },
+      application: { peMachine: 0x8664 },
+    });
+    expect(evidence.artifact.sha256).toMatch(/^[a-f0-9]{64}$/u);
+    expect(evidence.application.manifestSha256).toMatch(/^[a-f0-9]{64}$/u);
+    expect(evidence.artifact.size).toBe((await readFile(fixture.artifact)).length);
+    expect(evidence.application.fileCount).toBeGreaterThan(0);
+    expect(evidence.application.directoryCount).toBeGreaterThan(0);
+    expect(Object.isFrozen(layout)).toBe(true);
+    expect(Object.isFrozen(evidence)).toBe(true);
+    expect(Object.isFrozen(evidence.artifact)).toBe(true);
+    expect(Object.isFrozen(evidence.application)).toBe(true);
+  });
+
+  it("changes artifact and retained-tree digests when one byte changes", async () => {
+    const fixture = await syntheticWindowsPackage();
+    const before = await fixture.verifyArtifact();
+    await writeFile(
+      fixture.artifact,
+      Buffer.concat([await readFile(fixture.artifact), Buffer.from([0])]),
+    );
+    const artifactMutation = await fixture.verifyArtifact();
+    expect(artifactMutation.artifact.sha256).not.toBe(before.artifact.sha256);
+
+    await writeFile(join(fixture.application, "LICENSE.electron.txt"), "changed by one byte!\n");
+    const applicationMutation = await fixture.verifyArtifact();
+    expect(applicationMutation.application.manifestSha256).not.toBe(
+      before.application.manifestSha256,
+    );
   });
 
   it("validates the checked-in builder identity and uninstall hook", async () => {
@@ -608,7 +600,9 @@ describe("Windows package verification", () => {
     const renamed = await syntheticWindowsPackage();
     const wrongName = join(dirname(renamed.artifact), "Enduragent-9.9.9-x64.exe");
     await cp(renamed.artifact, wrongName);
-    await expect(verifyWindowsPackage(wrongName, { desktopRoot: renamed.desktop })).rejects.toThrow(
+    await expect(
+      verifyWindowsPackage(wrongName, renamed.application, { desktopRoot: renamed.desktop }),
+    ).rejects.toThrow(
       'windows-package/artifact: artifact name is invalid: "Enduragent-9.9.9-x64.exe"',
     );
 
@@ -619,49 +613,47 @@ describe("Windows package verification", () => {
     );
   });
 
-  it("rejects undeclared and missing entries inside the installer", async () => {
-    const undeclared = await syntheticWindowsPackage();
-    await expect(
-      undeclared.verifyArtifact(async (installerRoot) => {
-        await writeFile(join(installerRoot, "unexpected.bin"), "unexpected\n");
-      }),
-    ).rejects.toThrow(
-      'windows-package/installer-inventory: undeclared installer entry: "unexpected.bin"',
-    );
+  it("accepts x86 and x64 envelopes but rejects unsupported PE machines", async () => {
+    const x64 = await syntheticWindowsPackage();
+    await writeFile(x64.artifact, windowsExecutable(0x8664, nsisOverlaySignature));
+    await expect(x64.verifyArtifact()).resolves.toMatchObject({
+      artifact: { peMachine: 0x8664 },
+    });
 
-    const missing = await syntheticWindowsPackage();
-    await expect(
-      missing.verifyArtifact(async (installerRoot) => {
-        await rm(join(installerRoot, "$R0/Uninstall Enduragent.exe"), { force: true });
-      }),
-    ).rejects.toThrow(
-      'windows-package/installer-inventory: missing installer entry: "$R0/Uninstall Enduragent.exe"',
+    const unsupported = await syntheticWindowsPackage();
+    await writeFile(unsupported.artifact, windowsExecutable(0xaa64, nsisOverlaySignature));
+    await expect(unsupported.verifyArtifact()).rejects.toThrow(
+      `windows-package/artifact: installer is not a Windows executable: "${windowsPackageArtifactName(version)}"`,
     );
   });
 
-  it("requires the official 7-Zip NSIS type header", async () => {
-    const fixture = await syntheticWindowsPackage();
-    await expect(fixture.verifyArtifact(undefined, "PE")).rejects.toThrow(
-      `windows-package/artifact: 7-Zip did not identify installer as NSIS: "${windowsPackageArtifactName(version)}"`,
+  it("requires the contiguous NSIS overlay signature", async () => {
+    const textOnly = await syntheticWindowsPackage();
+    await writeFile(textOnly.artifact, windowsExecutable(0x014c, "NullsoftInst"));
+    await expect(textOnly.verifyArtifact()).rejects.toThrow(
+      `windows-package/artifact: installer is not an NSIS package: "${windowsPackageArtifactName(version)}"`,
     );
-  });
 
-  it("never cleans an extraction path outside its dedicated temporary directory", async () => {
-    const fixture = await syntheticWindowsPackage();
-    const remove = vi.fn(async () => undefined);
-    await expect(
-      verifyWindowsPackage(
-        fixture.artifact,
-        { desktopRoot: fixture.desktop },
-        {
-          mkdtemp: async () => dirname(fixture.artifact),
-          rm: remove,
-        },
+    const separated = await syntheticWindowsPackage();
+    await writeFile(
+      separated.artifact,
+      windowsExecutable(
+        0x014c,
+        Buffer.concat([Buffer.from([0xef, 0xbe, 0xad, 0xde, 0]), Buffer.from("NullsoftInst")]),
       ),
-    ).rejects.toThrow(
-      "windows-package/installer-inventory: temporary extraction directory is invalid",
     );
-    expect(remove).not.toHaveBeenCalled();
+    await expect(separated.verifyArtifact()).rejects.toThrow(
+      `windows-package/artifact: installer is not an NSIS package: "${windowsPackageArtifactName(version)}"`,
+    );
+  });
+
+  it("requires the retained application path explicitly", async () => {
+    const fixture = await syntheticWindowsPackage();
+    await expect(
+      verifyWindowsPackage(fixture.artifact, "win-unpacked", { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow(
+      "windows-package/application-inventory: application path must be absolute",
+    );
   });
 
   it("exposes only bounded stage-coded verification errors", async () => {

--- a/apps/desktop/tests/windows-package-plan.test.ts
+++ b/apps/desktop/tests/windows-package-plan.test.ts
@@ -22,6 +22,21 @@ const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const syntheticVersion = "2026.8.11";
 const readSyntheticManifest = async (_path: string, _encoding: "utf8"): Promise<string> =>
   `${JSON.stringify({ name: "@enduragent/desktop", version: syntheticVersion })}\n`;
+const verificationEvidence = Object.freeze({
+  artifact: Object.freeze({
+    name: `Enduragent-${syntheticVersion}-x64.exe`,
+    size: 4096,
+    sha256: "a".repeat(64),
+    peMachine: 0x014c as const,
+    nsisEnvelope: true as const,
+  }),
+  application: Object.freeze({
+    fileCount: 20,
+    directoryCount: 2,
+    manifestSha256: "b".repeat(64),
+    peMachine: 0x8664 as const,
+  }),
+});
 
 describe("Windows NSIS package plan", () => {
   it("seals every frozen identity value in the unsigned x64 NSIS plan", async () => {
@@ -148,7 +163,7 @@ describe("Windows NSIS package plan", () => {
     );
     const remove = vi.fn(async () => undefined);
     const build = vi.fn(async () => [expectedArtifact]);
-    const verifyWindowsPackage = vi.fn(async () => undefined);
+    const verifyWindowsPackage = vi.fn(async () => verificationEvidence);
     const stages: string[] = [];
     const result = await runWindowsPackage(
       { desktopRoot },
@@ -173,7 +188,14 @@ describe("Windows NSIS package plan", () => {
       force: true,
     });
     expect(build).toHaveBeenCalledWith(result.plan.builderOptions);
-    expect(verifyWindowsPackage).toHaveBeenCalledWith(expectedArtifact, { desktopRoot });
+    expect(verifyWindowsPackage).toHaveBeenCalledWith(
+      expectedArtifact,
+      join(desktopRoot, WINDOWS_PACKAGE_OUTPUT_DIRECTORY, "win-unpacked"),
+      { desktopRoot },
+    );
+    expect(result.evidence).toBe(verificationEvidence);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.artifacts)).toBe(true);
     expect(remove.mock.invocationCallOrder[0]).toBeLessThan(build.mock.invocationCallOrder[0]!);
     expect(build.mock.invocationCallOrder[0]).toBeLessThan(
       verifyWindowsPackage.mock.invocationCallOrder[0]!,
@@ -181,7 +203,7 @@ describe("Windows NSIS package plan", () => {
   });
 
   it("fails closed before verification when builder returns any other artifact set", async () => {
-    const verifyWindowsPackage = vi.fn(async () => undefined);
+    const verifyWindowsPackage = vi.fn(async () => verificationEvidence);
     await expect(
       runWindowsPackage(
         { desktopRoot },


### PR DESCRIPTION
## Summary

- Remove the external 7-Zip dependency from Windows package verification.
- Verify the installer basename, PE envelope, unsigned certificate state, contiguous NSIS signature, size, and SHA-256 with Node.
- Verify the retained `win-unpacked` tree directly, including exact inventory, ASAR contents, resources, secret scanning, and x64 payload binaries.
- Return immutable package evidence from the single Windows build.

## Verification

- Final focused verifier/plan/acceptance suite — 3 files, 66 tests passed.
- Desktop TypeScript check — passed.
- Fresh read-only review — passed with no findings.
- `git diff --check` — passed.

## Scope

This intentionally stops enumerating dormant NSIS support/archive entries. The installed-package CI PR replaces that proof with execution of the exact installer and path/type/SHA-256 equality between retained and installed application files.

## Limits

- None added or changed.
