### PR TITLE
fix(desktop): clear startup approval on uninstall

### DIFF
--- a/.changeset/windows-startup-registration-cleanup.md
+++ b/.changeset/windows-startup-registration-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Uninstalling Enduragent on Windows now removes both owned login-start registry values while preserving athlete data and desktop settings.

--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -1,3 +1,4 @@
 !macro customUnInstall
   DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "icu.enduragent.desktop"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" "icu.enduragent.desktop"
 !macroend

--- a/apps/desktop/scripts/verify-windows-package.mjs
+++ b/apps/desktop/scripts/verify-windows-package.mjs
@@ -35,6 +35,7 @@ const canonicalDesktopRoot = resolve(scriptDirectory, "..");
 const canonicalInstallerHook = [
   "!macro customUnInstall",
   '  DeleteRegValue HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Run" "icu.enduragent.desktop"',
+  '  DeleteRegValue HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run" "icu.enduragent.desktop"',
   "!macroend",
   "",
 ].join("\n");

--- a/apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/shell-lifecycle.scenarios.json
@@ -58,12 +58,12 @@
     {
       "id": "shell.login.registration",
       "surface": "shell-login",
-      "expected": "Login start reads, writes, and verifies the named per-user Windows registration for the installed executable and background argument, and uninstall deletes the matching HKCU Run value.",
+      "expected": "Login start reads, writes, and verifies the named per-user Windows registration for the installed executable and background argument, and uninstall deletes the matching HKCU Run and StartupApproved Run values.",
       "automation": "deterministic",
       "tests": [
         "apps/desktop/tests/login-item.test.ts > reads the exact argument-marked Windows registration",
         "apps/desktop/tests/login-item.test.ts > writes and verifies the named per-user Windows registration when enabled=%s",
-        "apps/desktop/tests/windows-icons.test.ts > keeps the runtime login value name aligned with the uninstall hook"
+        "apps/desktop/tests/windows-icons.test.ts > keeps the runtime login value names aligned with the uninstall hook"
       ]
     },
     {
@@ -304,7 +304,7 @@
     {
       "id": "uninstall.windows.integration-cleanup",
       "surface": "windows-uninstall",
-      "expected": "After seeded use, uninstall removes the program directory, Start menu shortcut, Apps list entry, uninstaller, tray process, and owned HKCU Run value without deleting athlete or user-data roots. This remains VM-only because it requires executing the real NSIS uninstaller and inspecting Windows shell and registry state.",
+      "expected": "After seeded use, uninstall removes the program directory, Start menu shortcut, Apps list entry, uninstaller, tray process, and owned HKCU Run and StartupApproved Run values while preserving %USERPROFILE%\\.enduragent and %LOCALAPPDATA%\\Enduragent. This remains VM-only because it requires executing the real NSIS uninstaller and inspecting Windows shell and registry state.",
       "automation": "vm-only"
     },
     {

--- a/apps/desktop/tests/windows-icons.test.ts
+++ b/apps/desktop/tests/windows-icons.test.ts
@@ -68,11 +68,14 @@ describe("Windows icon generation", () => {
     });
   });
 
-  it("keeps the runtime login value name aligned with the uninstall hook", async () => {
+  it("keeps the runtime login value names aligned with the uninstall hook", async () => {
     const installer = await readFile(join(desktopRoot, "build", "installer.nsh"), "utf8");
 
     expect(installer).toContain(
       `DeleteRegValue HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Run" "${DESKTOP_APP_USER_MODEL_ID}"`,
+    );
+    expect(installer).toContain(
+      `DeleteRegValue HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run" "${DESKTOP_APP_USER_MODEL_ID}"`,
     );
   });
 

--- a/apps/desktop/tests/windows-package-layout.test.ts
+++ b/apps/desktop/tests/windows-package-layout.test.ts
@@ -260,6 +260,7 @@ async function syntheticWindowsPackage(): Promise<SyntheticWindowsPackage> {
   const hook = [
     "!macro customUnInstall",
     '  DeleteRegValue HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Run" "icu.enduragent.desktop"',
+    '  DeleteRegValue HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run" "icu.enduragent.desktop"',
     "!macroend",
     "",
   ].join("\n");
@@ -422,6 +423,9 @@ describe("Windows package verification", () => {
     });
     expect(hook).toContain(
       'DeleteRegValue HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Run" "icu.enduragent.desktop"',
+    );
+    expect(hook).toContain(
+      'DeleteRegValue HKCU "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run" "icu.enduragent.desktop"',
     );
     expect(hook).not.toMatch(/RMDir|USERPROFILE|LOCALAPPDATA/u);
   });


### PR DESCRIPTION
Remove both Windows login registration and StartupApproved state during uninstall. Focused installer-layout tests and full repository gates pass. Operator review required because this changes installer tooling.