### PR TITLE
chore(desktop): correct 0.1.4 release notes

### DIFF
--- a/.changeset/brisk-lanterns-rest.md
+++ b/.changeset/brisk-lanterns-rest.md
@@ -1,5 +1,6 @@
 ---
 "cycling-coach": patch
+"@enduragent/desktop": patch
 ---
 
 User-facing: Deleting the Telegram connection now completes while offline and cancels any pending pairing.

--- a/.changeset/updater-downgrade-floor.md
+++ b/.changeset/updater-downgrade-floor.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: The desktop app now refuses update feeds that would downgrade it below the highest version it has ever run, protecting against replaced release assets.


### PR DESCRIPTION
## Summary

- Include the offline Telegram deletion fix in the Desktop `0.1.4` release notes.
- Remove the downgrade-floor changeset because its code is already present in Desktop `0.1.3`.

## Verification

- `git diff --check`
- Exact `changeset version` plus binary CalVer post-step dry run
- Fresh read-only verification of package selection and generated Desktop `0.1.4` changelog

This PR only corrects pending release metadata. It does not publish a release.
