### PR TITLE
fix: bound S8A scenario children

### DIFF
--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   aggregateExitCode,
@@ -12,6 +12,9 @@ import {
   parseRunFlags,
   resolveRecordLane,
   runDirName,
+  runSelfTestDeterminism,
+  spawnScenarioChild,
+  type ScenarioChildSpawn,
   usage,
 } from "./run.js";
 import { AUTH_PROFILES_SOURCE_ENV } from "./lib/codex-auth.js";
@@ -175,6 +178,141 @@ describe("child spawn env", () => {
     expect(env[AUTH_PROFILES_SOURCE_ENV]).toBe("/operator/config/auth-profiles.json");
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(env.HISTORY_TOKEN_BUDGET_RATIO).toBe("0.05");
+  });
+});
+
+describe("scenario child process", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const params = {
+    scenarioId: "turn-basic-wellness",
+    stage: "replay" as const,
+    mode: "replay" as const,
+    runDir: "/fixed/run",
+    provider: "openai-codex" as const,
+    llmModel: "gpt-5.6-sol",
+  };
+
+  function removeTempHome(options: Parameters<ScenarioChildSpawn>[2]): void {
+    const home = options.env.CYCLING_COACH_HOME;
+    if (home !== undefined) rmSync(home, { recursive: true, force: true });
+  }
+
+  it("applies the fixed deadline and preserves a normal verdict", () => {
+    const verdict: ScenarioVerdict = {
+      scenario: "turn-basic-wellness",
+      pass: false,
+      failures: [{ assertId: "A1", scenario: "turn-basic-wellness", detail: "drift" }],
+    };
+    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+      removeTempHome(options);
+      return { stdout: `${JSON.stringify(verdict)}\n`, stderr: "fixed stderr", status: 1 };
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const outcome = spawnScenarioChild(params, spawnProcess);
+
+    expect(outcome).toEqual({ verdict, exitCode: 1, stderr: "fixed stderr" });
+    expect(spawnProcess).toHaveBeenCalledOnce();
+    expect(spawnProcess.mock.calls[0]?.[2]).toMatchObject({
+      timeout: 120_000,
+      killSignal: "SIGKILL",
+    });
+    expect(log.mock.calls.map(([line]) => line)).toEqual([
+      "S8A_CHILD START scenario=turn-basic-wellness stage=replay",
+      "S8A_CHILD DONE scenario=turn-basic-wellness stage=replay outcome=exit-1",
+    ]);
+  });
+
+  it("maps ETIMEDOUT to a stable path-free harness error", () => {
+    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+      removeTempHome(options);
+      return {
+        stdout: null,
+        stderr: "/private/athlete-home/token",
+        status: null,
+        error: Object.assign(new Error("/private/athlete-home/token"), { code: "ETIMEDOUT" }),
+      };
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const outcome = spawnScenarioChild(
+      { ...params, scenarioId: "../../private/athlete-home" },
+      spawnProcess,
+    );
+
+    expect(outcome).toEqual({
+      verdict: null,
+      exitCode: 2,
+      stderr: "scenario child timed out: scenario=unknown stage=replay",
+    });
+    expect(JSON.stringify(outcome)).not.toContain("private/athlete-home");
+    expect(log.mock.calls.map(([line]) => line)).toEqual([
+      "S8A_CHILD START scenario=unknown stage=replay",
+      "S8A_CHILD DONE scenario=unknown stage=replay outcome=timeout",
+    ]);
+  });
+
+  it("stops determinism before the second child and diff after a timeout", () => {
+    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+      removeTempHome(options);
+      return {
+        stdout: null,
+        stderr: null,
+        status: null,
+        error: Object.assign(new Error("timed out"), { code: "ETIMEDOUT" }),
+      };
+    });
+    const diffProcess = vi.fn(() => ({ status: 0, stdout: "" }));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const outcome = runSelfTestDeterminism(
+      {
+        probeDirs: ["/fixed/probe-1", "/fixed/probe-2"],
+        provider: "openai-codex",
+        llmModel: "gpt-5.6-sol",
+      },
+      spawnProcess,
+      diffProcess,
+    );
+
+    expect(outcome).toMatchObject({ kind: "harness-error", outcome: { exitCode: 2 } });
+    expect(spawnProcess).toHaveBeenCalledOnce();
+    expect(diffProcess).not.toHaveBeenCalled();
+  });
+
+  it("runs both determinism children before the diff", () => {
+    const verdict: ScenarioVerdict = {
+      scenario: "turn-basic-wellness",
+      pass: true,
+      failures: [],
+    };
+    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+      removeTempHome(options);
+      return { stdout: `${JSON.stringify(verdict)}\n`, stderr: "", status: 0 };
+    });
+    const diffProcess = vi.fn(() => ({ status: 0, stdout: "" }));
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const outcome = runSelfTestDeterminism(
+      {
+        probeDirs: ["/fixed/probe-1", "/fixed/probe-2"],
+        provider: "openai-codex",
+        llmModel: "gpt-5.6-sol",
+      },
+      spawnProcess,
+      diffProcess,
+    );
+
+    expect(outcome).toEqual({ kind: "complete", deterministic: true, diffOutput: "" });
+    expect(spawnProcess).toHaveBeenCalledTimes(2);
+    expect(diffProcess).toHaveBeenCalledOnce();
+    expect(log.mock.calls.map(([line]) => line)).toEqual([
+      "S8A_CHILD START scenario=turn-basic-wellness stage=self-test-determinism-1",
+      "S8A_CHILD DONE scenario=turn-basic-wellness stage=self-test-determinism-1 outcome=exit-0",
+      "S8A_CHILD START scenario=turn-basic-wellness stage=self-test-determinism-2",
+      "S8A_CHILD DONE scenario=turn-basic-wellness stage=self-test-determinism-2 outcome=exit-0",
+    ]);
   });
 });
 

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -146,6 +146,33 @@ interface ChildOutcome {
   stderr: string;
 }
 
+export type ScenarioChildStage =
+  | "record"
+  | "replay"
+  | "self-test-drift"
+  | "self-test-determinism-1"
+  | "self-test-determinism-2";
+
+export interface ScenarioChildSpawnResult {
+  stdout: string | null;
+  stderr: string | null;
+  status: number | null;
+  error?: Error & { code?: string };
+}
+
+export type ScenarioChildSpawn = (
+  command: string,
+  args: readonly string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    encoding: "utf-8";
+    maxBuffer: number;
+    timeout: number;
+    killSignal: "SIGKILL";
+  },
+) => ScenarioChildSpawnResult;
+
 export interface ChildEnvParams {
   base: Record<string, string | undefined>;
   tempHome: string;
@@ -181,18 +208,26 @@ export function buildChildEnv(params: ChildEnvParams): Record<string, string | u
   return env;
 }
 
-function spawnScenarioChild(params: {
-  scenarioId: string;
-  mode: "replay" | "record";
-  runDir: string;
-  fixtureDir?: string;
-  noSupersessions?: boolean;
-  scenarioEnv?: Record<string, string>;
-  provider: S8aProvider;
-  llmModel: string;
-  anthropicKey?: string;
-  authProfilesSource?: string;
-}): ChildOutcome {
+export function spawnScenarioChild(
+  params: {
+    scenarioId: string;
+    stage: ScenarioChildStage;
+    mode: "replay" | "record";
+    runDir: string;
+    fixtureDir?: string;
+    noSupersessions?: boolean;
+    scenarioEnv?: Record<string, string>;
+    provider: S8aProvider;
+    llmModel: string;
+    anthropicKey?: string;
+    authProfilesSource?: string;
+  },
+  spawnProcess: ScenarioChildSpawn = (command, args, options) => spawnSync(command, args, options),
+): ChildOutcome {
+  const safeScenarioId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(params.scenarioId)
+    ? params.scenarioId
+    : "unknown";
+  console.log(`S8A_CHILD START scenario=${safeScenarioId} stage=${params.stage}`);
   const tempHome = mkdtempSync(join(tmpdir(), "s8a-home-"));
   const childArgs = [
     join(HERE, "run-scenario.ts"),
@@ -212,12 +247,22 @@ function spawnScenarioChild(params: {
     scenarioEnv: params.scenarioEnv,
   });
 
-  const result = spawnSync(process.execPath, ["--import", "tsx", ...childArgs], {
+  const result = spawnProcess(process.execPath, ["--import", "tsx", ...childArgs], {
     cwd: REPO_ROOT,
     env,
     encoding: "utf-8",
     maxBuffer: 64 * 1024 * 1024,
+    timeout: 120_000,
+    killSignal: "SIGKILL",
   });
+  if (result.error?.code === "ETIMEDOUT") {
+    console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=timeout`);
+    return {
+      verdict: null,
+      exitCode: 2,
+      stderr: `scenario child timed out: scenario=${safeScenarioId} stage=${params.stage}`,
+    };
+  }
   const stdoutLines = (result.stdout ?? "").split("\n").filter((l) => l.trim() !== "");
   let verdict: ScenarioVerdict | null = null;
   for (let i = stdoutLines.length - 1; i >= 0; i--) {
@@ -231,7 +276,61 @@ function spawnScenarioChild(params: {
       // Not the verdict line; keep scanning upward.
     }
   }
-  return { verdict, exitCode: result.status ?? 2, stderr: result.stderr ?? "" };
+  const exitCode = result.status ?? 2;
+  console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=exit-${exitCode}`);
+  return { verdict, exitCode, stderr: result.stderr ?? "" };
+}
+
+export type SelfTestDiffSpawn = (
+  command: string,
+  args: readonly string[],
+  options: { encoding: "utf-8" },
+) => { status: number | null; stdout: string | null };
+
+export function runSelfTestDeterminism(
+  params: {
+    probeDirs: readonly [string, string];
+    provider: S8aProvider;
+    llmModel: string;
+    anthropicKey?: string;
+  },
+  spawnProcess: ScenarioChildSpawn = (command, args, options) => spawnSync(command, args, options),
+  diffProcess: SelfTestDiffSpawn = (command, args, options) => spawnSync(command, args, options),
+):
+  | { kind: "harness-error"; outcome: ChildOutcome }
+  | { kind: "complete"; deterministic: boolean; diffOutput: string } {
+  const probes = [
+    { dir: params.probeDirs[0], stage: "self-test-determinism-1" },
+    { dir: params.probeDirs[1], stage: "self-test-determinism-2" },
+  ] as const;
+  for (const probe of probes) {
+    const outcome = spawnScenarioChild(
+      {
+        scenarioId: "turn-basic-wellness",
+        stage: probe.stage,
+        mode: "replay",
+        runDir: probe.dir,
+        noSupersessions: true,
+        provider: params.provider,
+        llmModel: params.llmModel,
+        anthropicKey: params.anthropicKey,
+      },
+      spawnProcess,
+    );
+    if (outcome.verdict === null || outcome.exitCode === 2) {
+      return { kind: "harness-error", outcome };
+    }
+  }
+  const diff = diffProcess(
+    "diff",
+    ["-r", join(params.probeDirs[0], "home"), join(params.probeDirs[1], "home")],
+    { encoding: "utf-8" },
+  );
+  return {
+    kind: "complete",
+    deterministic: diff.status === 0,
+    diffOutput: diff.stdout ?? "",
+  };
 }
 
 function gitSha(): string {
@@ -314,6 +413,7 @@ async function replayScenarios(params: {
     const lane = readRecordingLane(fixtureDir);
     const outcome = spawnScenarioChild({
       scenarioId: entry.id,
+      stage: "replay",
       mode: "replay",
       runDir: join(params.runDir, entry.id),
       noSupersessions: params.noSupersessions,
@@ -409,6 +509,7 @@ async function main(): Promise<void> {
     console.log(`recording lane: ${lane.provider} / ${lane.model}`);
     const outcome = spawnScenarioChild({
       scenarioId: entry.id,
+      stage: "record",
       mode: "record",
       runDir: join(runDir, entry.id),
       scenarioEnv: await loadScenarioEnv(entry),
@@ -433,6 +534,7 @@ async function main(): Promise<void> {
     const driftLane = readRecordingLane(join(HERE, "fixtures", "drift-must-fail"));
     const driftOutcome = spawnScenarioChild({
       scenarioId: "turn-basic-wellness",
+      stage: "self-test-drift",
       mode: "replay",
       runDir: join(runDir, "drift-must-fail"),
       fixtureDir: join(HERE, "fixtures", "drift-must-fail"),
@@ -455,30 +557,30 @@ async function main(): Promise<void> {
 
     // Probe (b): determinism — two fresh children, byte-compare the snapshotted
     // home trees. The byte-compare is the pass criterion, NOT the exit codes.
-    const probeDirs = ["turn-basic-wellness-probe1", "turn-basic-wellness-probe2"].map((d) => join(runDir, d));
+    const probeDirs = [
+      join(runDir, "turn-basic-wellness-probe1"),
+      join(runDir, "turn-basic-wellness-probe2"),
+    ] as const;
     const probeLane = readRecordingLane(join(HERE, "fixtures", "turn-basic-wellness"));
-    for (const dir of probeDirs) {
-      spawnScenarioChild({
-        scenarioId: "turn-basic-wellness",
-        mode: "replay",
-        runDir: dir,
-        noSupersessions: true,
-        provider: probeLane.provider,
-        llmModel: probeLane.model,
-        anthropicKey: probeLane.provider === "anthropic" ? REPLAY_DUMMY_KEY : undefined,
-      });
-    }
-    const diff = spawnSync("diff", ["-r", join(probeDirs[0], "home"), join(probeDirs[1], "home")], {
-      encoding: "utf-8",
+    const determinism = runSelfTestDeterminism({
+      probeDirs,
+      provider: probeLane.provider,
+      llmModel: probeLane.model,
+      anthropicKey: probeLane.provider === "anthropic" ? REPLAY_DUMMY_KEY : undefined,
     });
-    const deterministic = diff.status === 0;
+    if (determinism.kind === "harness-error") {
+      console.error(
+        `determinism probe harness error (exit ${determinism.outcome.exitCode}):\n${determinism.outcome.stderr}`,
+      );
+      process.exit(2);
+    }
     console.log(
-      deterministic
+      determinism.deterministic
         ? "determinism probe: PASS — two replay home trees byte-identical"
-        : `determinism probe: FAIL — trees differ:\n${diff.stdout}`,
+        : `determinism probe: FAIL — trees differ:\n${determinism.diffOutput}`,
     );
 
-    process.exit(driftPass && deterministic ? 0 : 1);
+    process.exit(driftPass && determinism.deterministic ? 0 : 1);
   }
 
   if (flags.kind === "rebaseline") {


### PR DESCRIPTION
## Summary
- bound every S8A scenario child and terminate a hung child
- emit fixed start/end markers that identify the scenario stage
- stop determinism after a timed-out probe without running the tree diff

## Verification
- pnpm exec vitest run tools/s8a/run.test.ts --maxWorkers=1 (19 passed)
- git diff --check
- fresh read-only review: PASS

## Limit
- S8A child timeout: 120000 ms; SIGKILL terminates a child that exceeds the bound

## Note
- Root typecheck was not usable in the isolated uninstalled worktree; hosted CI is the authoritative full gate.