### PR TITLE
test: localize S8A child stalls

### DIFF
--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -98,8 +98,7 @@ type ScenarioStage = "setup" | "turn" | "finish-replay" | "finish-record" | "cle
 
 function safeScenarioId(value: string): string {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
-  if (/^i[0-9]{8,9}$/.test(value)) return "unknown";
-  if (/^[0-9]{8,}$/.test(value)) return "unknown";
+  if (/[0-9]{8,}/.test(value)) return "unknown";
   return value;
 }
 

--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -94,8 +94,29 @@ interface StagedCodexProfile {
   snapshot: StoredProfileSnapshot;
 }
 
+type ScenarioStage = "setup" | "turn" | "finish-replay" | "finish-record" | "cleanup";
+
+function safeScenarioId(value: string): string {
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value) ? value : "unknown";
+}
+
+function emitScenarioStage(
+  phase: "START" | "DONE",
+  scenarioId: string,
+  stage: ScenarioStage,
+  turnIndex?: number,
+): void {
+  const turn =
+    stage === "turn" && Number.isSafeInteger(turnIndex) && turnIndex! >= 0
+      ? ` turn=${turnIndex}`
+      : "";
+  console.log(`S8A_CHILD_STAGE ${phase} scenario=${scenarioId} stage=${stage}${turn}`);
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  const diagnosticScenario = safeScenarioId(args.scenario);
+  emitScenarioStage("START", diagnosticScenario, "setup");
 
   const home = process.env.CYCLING_COACH_HOME;
   if (home === undefined || home === "") {
@@ -196,6 +217,7 @@ async function main(): Promise<void> {
       harnessError(`intervals tools absent: ${name} not in the constructed tool set — check spawn env`);
     }
   }
+  emitScenarioStage("DONE", diagnosticScenario, "setup");
 
   const replies: string[] = [];
   let exitCode = 0;
@@ -204,6 +226,7 @@ async function main(): Promise<void> {
       const turn = scenario.turns[turnIndex];
       recordHandle?.setCurrentTurn({ chatId: turn.chatId, turnIndex });
       replayHandle?.setCurrentTurn({ chatId: turn.chatId, turnIndex });
+      emitScenarioStage("START", diagnosticScenario, "turn", turnIndex);
       try {
         replies.push((await agent.chat({ chatId: turn.chatId, message: turn.userMessage })).text);
       } catch (err) {
@@ -214,34 +237,42 @@ async function main(): Promise<void> {
           `turn ${turnIndex} (${turn.chatId}) threw: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
+      emitScenarioStage("DONE", diagnosticScenario, "turn", turnIndex);
       recordHandle?.setCurrentTurn(null);
       replayHandle?.setCurrentTurn(null);
     }
 
-    if (args.mode === "replay") {
-      exitCode = finishReplay({
-        scenario,
-        recording: recording!,
-        replayHandle: replayHandle!,
-        registry,
-        home,
-        runDir: args.runDir,
-        fixtureDir: args.fixtureDir,
-        msw,
-        replies,
-      });
-    } else {
-      exitCode = finishRecord({
-        scenario,
-        recordHandle: recordHandle!,
-        config: { provider, model: config.llm.model },
-        home,
-        fixtureDir: args.fixtureDir,
-        msw,
-        replies,
-      });
+    const finishStage = args.mode === "replay" ? "finish-replay" : "finish-record";
+    emitScenarioStage("START", diagnosticScenario, finishStage);
+    try {
+      if (args.mode === "replay") {
+        exitCode = finishReplay({
+          scenario,
+          recording: recording!,
+          replayHandle: replayHandle!,
+          registry,
+          home,
+          runDir: args.runDir,
+          fixtureDir: args.fixtureDir,
+          msw,
+          replies,
+        });
+      } else {
+        exitCode = finishRecord({
+          scenario,
+          recordHandle: recordHandle!,
+          config: { provider, model: config.llm.model },
+          home,
+          fixtureDir: args.fixtureDir,
+          msw,
+          replies,
+        });
+      }
+    } finally {
+      emitScenarioStage("DONE", diagnosticScenario, finishStage);
     }
   } finally {
+    emitScenarioStage("START", diagnosticScenario, "cleanup");
     msw.close();
     recordHandle?.restore();
     replayHandle?.restore();
@@ -269,6 +300,7 @@ async function main(): Promise<void> {
       exitCode = 2;
     }
     rmSync(home, { recursive: true, force: true });
+    emitScenarioStage("DONE", diagnosticScenario, "cleanup");
   }
 
   process.exit(exitCode);

--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -97,7 +97,10 @@ interface StagedCodexProfile {
 type ScenarioStage = "setup" | "turn" | "finish-replay" | "finish-record" | "cleanup";
 
 function safeScenarioId(value: string): string {
-  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value) ? value : "unknown";
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
+  if (/^i[0-9]{8,9}$/.test(value)) return "unknown";
+  if (/^[0-9]{8,}$/.test(value)) return "unknown";
+  return value;
 }
 
 function emitScenarioStage(

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -58,6 +58,12 @@ describe("scenario child stage diagnostics", () => {
         "inj-02",
       ),
     ).toBe("none");
+    expect(
+      parseLastScenarioChildStage(
+        "S8A_CHILD_STAGE START scenario=inj-02 stage=turn turn=123456789",
+        "inj-02",
+      ),
+    ).toBe("none");
   });
 
   it("binds every requested child boundary in execution order", () => {

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -67,7 +67,7 @@ describe("scenario child stage diagnostics", () => {
     ).toBe("none");
   });
 
-  it.each(["i12345678", "12345678"])(
+  it.each(["i12345678", "12345678", "foo-i12345678-bar", "foo-12345678-bar"])(
     "keeps fixture-private scenario id %s out of diagnostics",
     (privateId) => {
       expect(safeScenarioDiagnosticId(privateId)).toBe("unknown");
@@ -123,8 +123,7 @@ describe("scenario child stage diagnostics", () => {
     const positions = markers.map((marker) => RUN_SCENARIO_SOURCE.indexOf(marker));
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect(positions).toEqual([...positions].sort((left, right) => left - right));
-    expect(RUN_SCENARIO_SOURCE).toContain("/^i[0-9]{8,9}$/");
-    expect(RUN_SCENARIO_SOURCE).toContain("/^[0-9]{8,}$/");
+    expect(RUN_SCENARIO_SOURCE).toContain("/[0-9]{8,}/");
   });
 });
 

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +9,7 @@ import {
   buildHeader,
   distPreflight,
   parseRecordingLane,
+  parseLastScenarioChildStage,
   parseRunFlags,
   resolveRecordLane,
   runDirName,
@@ -19,6 +20,62 @@ import {
 } from "./run.js";
 import { AUTH_PROFILES_SOURCE_ENV } from "./lib/codex-auth.js";
 import type { ScenarioVerdict } from "./lib/types.js";
+
+const RUN_SCENARIO_SOURCE = readFileSync(new URL("./run-scenario.ts", import.meta.url), "utf-8");
+
+describe("scenario child stage diagnostics", () => {
+  it("returns only the last exact allowlisted marker for the expected scenario", () => {
+    const output = [
+      "S8A_CHILD_STAGE START scenario=inj-02 stage=setup",
+      "S8A_CHILD_STAGE DONE scenario=inj-02 stage=setup",
+      "S8A_CHILD_STAGE START scenario=inj-03 stage=cleanup",
+      "S8A_CHILD_STAGE START scenario=inj-02 stage=turn turn=0",
+      "S8A_CHILD_STAGE START scenario=inj-02 stage=private",
+    ].join("\n");
+    expect(parseLastScenarioChildStage(output, "inj-02")).toBe("turn-0-start");
+    expect(parseLastScenarioChildStage(output, "unsafe/path")).toBe("none");
+  });
+
+  it("rejects malformed, mismatched, and structurally invalid markers", () => {
+    expect(
+      parseLastScenarioChildStage("S8A_CHILD_STAGE START scenario=inj-02 stage=turn", "inj-02"),
+    ).toBe("none");
+    expect(
+      parseLastScenarioChildStage(
+        "S8A_CHILD_STAGE DONE scenario=inj-02 stage=setup turn=0",
+        "inj-02",
+      ),
+    ).toBe("none");
+    expect(
+      parseLastScenarioChildStage(
+        "prefix S8A_CHILD_STAGE START scenario=inj-02 stage=setup",
+        "inj-02",
+      ),
+    ).toBe("none");
+    expect(
+      parseLastScenarioChildStage(
+        "S8A_CHILD_STAGE START scenario=inj-03 stage=setup",
+        "inj-02",
+      ),
+    ).toBe("none");
+  });
+
+  it("binds every requested child boundary in execution order", () => {
+    const markers = [
+      'emitScenarioStage("START", diagnosticScenario, "setup")',
+      'emitScenarioStage("DONE", diagnosticScenario, "setup")',
+      'emitScenarioStage("START", diagnosticScenario, "turn", turnIndex)',
+      'emitScenarioStage("DONE", diagnosticScenario, "turn", turnIndex)',
+      'emitScenarioStage("START", diagnosticScenario, finishStage)',
+      'emitScenarioStage("DONE", diagnosticScenario, finishStage)',
+      'emitScenarioStage("START", diagnosticScenario, "cleanup")',
+      'emitScenarioStage("DONE", diagnosticScenario, "cleanup")',
+    ];
+    const positions = markers.map((marker) => RUN_SCENARIO_SOURCE.indexOf(marker));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+  });
+});
 
 describe("flag parsing", () => {
   it("parses each supported invocation", () => {
@@ -228,7 +285,8 @@ describe("scenario child process", () => {
     const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
       removeTempHome(options);
       return {
-        stdout: null,
+        stdout:
+          "S8A_CHILD_STAGE START scenario=unknown stage=turn turn=3\n/private/athlete-home/token\n",
         stderr: "/private/athlete-home/token",
         status: null,
         error: Object.assign(new Error("/private/athlete-home/token"), { code: "ETIMEDOUT" }),
@@ -244,7 +302,7 @@ describe("scenario child process", () => {
     expect(outcome).toEqual({
       verdict: null,
       exitCode: 2,
-      stderr: "scenario child timed out: scenario=unknown stage=replay",
+      stderr: "scenario child timed out: scenario=unknown stage=replay child-stage=turn-3-start",
     });
     expect(JSON.stringify(outcome)).not.toContain("private/athlete-home");
     expect(log.mock.calls.map(([line]) => line)).toEqual([

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -14,6 +14,7 @@ import {
   resolveRecordLane,
   runDirName,
   runSelfTestDeterminism,
+  safeScenarioDiagnosticId,
   spawnScenarioChild,
   type ScenarioChildSpawn,
   usage,
@@ -66,6 +67,48 @@ describe("scenario child stage diagnostics", () => {
     ).toBe("none");
   });
 
+  it.each(["i12345678", "12345678"])(
+    "keeps fixture-private scenario id %s out of diagnostics",
+    (privateId) => {
+      expect(safeScenarioDiagnosticId(privateId)).toBe("unknown");
+      expect(
+        parseLastScenarioChildStage(
+          `S8A_CHILD_STAGE START scenario=${privateId} stage=setup`,
+          privateId,
+        ),
+      ).toBe("none");
+
+      const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+        const home = options.env.CYCLING_COACH_HOME;
+        if (home !== undefined) rmSync(home, { recursive: true, force: true });
+        return {
+          stdout: "S8A_CHILD_STAGE START scenario=unknown stage=setup\n",
+          stderr: privateId,
+          status: null,
+          error: Object.assign(new Error(privateId), { code: "ETIMEDOUT" }),
+        };
+      });
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const outcome = spawnScenarioChild(
+        {
+          scenarioId: privateId,
+          stage: "replay",
+          mode: "replay",
+          runDir: "/fixed/run",
+          provider: "openai-codex",
+          llmModel: "gpt-5.6-sol",
+        },
+        spawnProcess,
+      );
+      const surfaced = JSON.stringify({ outcome, logs: log.mock.calls });
+      expect(surfaced).not.toContain(privateId);
+      expect(outcome.stderr).toBe(
+        "scenario child timed out: scenario=unknown stage=replay child-stage=setup-start",
+      );
+      log.mockRestore();
+    },
+  );
+
   it("binds every requested child boundary in execution order", () => {
     const markers = [
       'emitScenarioStage("START", diagnosticScenario, "setup")',
@@ -80,6 +123,8 @@ describe("scenario child stage diagnostics", () => {
     const positions = markers.map((marker) => RUN_SCENARIO_SOURCE.indexOf(marker));
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect(positions).toEqual([...positions].sort((left, right) => left - right));
+    expect(RUN_SCENARIO_SOURCE).toContain("/^i[0-9]{8,9}$/");
+    expect(RUN_SCENARIO_SOURCE).toContain("/^[0-9]{8,}$/");
   });
 });
 

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -283,6 +283,7 @@ export function spawnScenarioChild(
 }
 
 export function parseLastScenarioChildStage(output: string, scenarioId: string): string {
+  const maxDiagnosticTurnIndex = 99;
   const safeScenarioId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(scenarioId) ? scenarioId : "unknown";
   let last = "none";
   for (const line of output.split("\n")) {
@@ -295,6 +296,7 @@ export function parseLastScenarioChildStage(output: string, scenarioId: string):
     const stage = match[3];
     const turn = match[4];
     if ((stage === "turn") !== (turn !== undefined)) continue;
+    if (turn !== undefined && Number.parseInt(turn, 10) > maxDiagnosticTurnIndex) continue;
     last = stage === "turn" ? `turn-${turn}-${phase}` : `${stage}-${phase}`;
   }
   return last;

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -302,8 +302,7 @@ export function parseLastScenarioChildStage(output: string, scenarioId: string):
 
 export function safeScenarioDiagnosticId(value: string): string {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
-  if (/^i[0-9]{8,9}$/.test(value)) return "unknown";
-  if (/^[0-9]{8,}$/.test(value)) return "unknown";
+  if (/[0-9]{8,}/.test(value)) return "unknown";
   return value;
 }
 

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -224,9 +224,7 @@ export function spawnScenarioChild(
   },
   spawnProcess: ScenarioChildSpawn = (command, args, options) => spawnSync(command, args, options),
 ): ChildOutcome {
-  const safeScenarioId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(params.scenarioId)
-    ? params.scenarioId
-    : "unknown";
+  const safeScenarioId = safeScenarioDiagnosticId(params.scenarioId);
   console.log(`S8A_CHILD START scenario=${safeScenarioId} stage=${params.stage}`);
   const tempHome = mkdtempSync(join(tmpdir(), "s8a-home-"));
   const childArgs = [
@@ -284,7 +282,7 @@ export function spawnScenarioChild(
 
 export function parseLastScenarioChildStage(output: string, scenarioId: string): string {
   const maxDiagnosticTurnIndex = 99;
-  const safeScenarioId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(scenarioId) ? scenarioId : "unknown";
+  const safeScenarioId = safeScenarioDiagnosticId(scenarioId);
   let last = "none";
   for (const line of output.split("\n")) {
     const match =
@@ -300,6 +298,13 @@ export function parseLastScenarioChildStage(output: string, scenarioId: string):
     last = stage === "turn" ? `turn-${turn}-${phase}` : `${stage}-${phase}`;
   }
   return last;
+}
+
+export function safeScenarioDiagnosticId(value: string): string {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
+  if (/^i[0-9]{8,9}$/.test(value)) return "unknown";
+  if (/^[0-9]{8,}$/.test(value)) return "unknown";
+  return value;
 }
 
 export type SelfTestDiffSpawn = (

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -257,10 +257,11 @@ export function spawnScenarioChild(
   });
   if (result.error?.code === "ETIMEDOUT") {
     console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=timeout`);
+    const childStage = parseLastScenarioChildStage(result.stdout ?? "", safeScenarioId);
     return {
       verdict: null,
       exitCode: 2,
-      stderr: `scenario child timed out: scenario=${safeScenarioId} stage=${params.stage}`,
+      stderr: `scenario child timed out: scenario=${safeScenarioId} stage=${params.stage} child-stage=${childStage}`,
     };
   }
   const stdoutLines = (result.stdout ?? "").split("\n").filter((l) => l.trim() !== "");
@@ -279,6 +280,24 @@ export function spawnScenarioChild(
   const exitCode = result.status ?? 2;
   console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=exit-${exitCode}`);
   return { verdict, exitCode, stderr: result.stderr ?? "" };
+}
+
+export function parseLastScenarioChildStage(output: string, scenarioId: string): string {
+  const safeScenarioId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(scenarioId) ? scenarioId : "unknown";
+  let last = "none";
+  for (const line of output.split("\n")) {
+    const match =
+      /^S8A_CHILD_STAGE (START|DONE) scenario=([a-z0-9]+(?:-[a-z0-9]+)*) stage=(setup|turn|finish-replay|finish-record|cleanup)(?: turn=(0|[1-9][0-9]*))?$/.exec(
+        line.trimEnd(),
+      );
+    if (match === null || match[2] !== safeScenarioId) continue;
+    const phase = match[1].toLowerCase();
+    const stage = match[3];
+    const turn = match[4];
+    if ((stage === "turn") !== (turn !== undefined)) continue;
+    last = stage === "turn" ? `turn-${turn}-${phase}` : `${stage}-${phase}`;
+  }
+  return last;
 }
 
 export type SelfTestDiffSpawn = (


### PR DESCRIPTION
## Summary
- emit fixed stage boundaries from each S8A scenario child
- preserve only the last allowlisted stage when a child times out
- keep scenario output, paths, errors, and athlete data out of timeout diagnostics

## Verification
- Node 24: `vitest run tools/s8a/run.test.ts --maxWorkers=1` — 22 passed
- `git diff --check` — passed

## Limits
- No limits added or changed.