### PR TITLE
fix: contain S8A child stalls

### DIFF
--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -98,8 +98,7 @@ type ScenarioStage = "setup" | "turn" | "finish-replay" | "finish-record" | "cle
 
 function safeScenarioId(value: string): string {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
-  if (/^i[0-9]{8,9}$/.test(value)) return "unknown";
-  if (/^[0-9]{8,}$/.test(value)) return "unknown";
+  if (/[0-9]{8,}/.test(value)) return "unknown";
   return value;
 }
 

--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -94,8 +94,29 @@ interface StagedCodexProfile {
   snapshot: StoredProfileSnapshot;
 }
 
+type ScenarioStage = "setup" | "turn" | "finish-replay" | "finish-record" | "cleanup";
+
+function safeScenarioId(value: string): string {
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value) ? value : "unknown";
+}
+
+function emitScenarioStage(
+  phase: "START" | "DONE",
+  scenarioId: string,
+  stage: ScenarioStage,
+  turnIndex?: number,
+): void {
+  const turn =
+    stage === "turn" && Number.isSafeInteger(turnIndex) && turnIndex! >= 0
+      ? ` turn=${turnIndex}`
+      : "";
+  console.log(`S8A_CHILD_STAGE ${phase} scenario=${scenarioId} stage=${stage}${turn}`);
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  const diagnosticScenario = safeScenarioId(args.scenario);
+  emitScenarioStage("START", diagnosticScenario, "setup");
 
   const home = process.env.CYCLING_COACH_HOME;
   if (home === undefined || home === "") {
@@ -196,6 +217,7 @@ async function main(): Promise<void> {
       harnessError(`intervals tools absent: ${name} not in the constructed tool set — check spawn env`);
     }
   }
+  emitScenarioStage("DONE", diagnosticScenario, "setup");
 
   const replies: string[] = [];
   let exitCode = 0;
@@ -204,6 +226,7 @@ async function main(): Promise<void> {
       const turn = scenario.turns[turnIndex];
       recordHandle?.setCurrentTurn({ chatId: turn.chatId, turnIndex });
       replayHandle?.setCurrentTurn({ chatId: turn.chatId, turnIndex });
+      emitScenarioStage("START", diagnosticScenario, "turn", turnIndex);
       try {
         replies.push((await agent.chat({ chatId: turn.chatId, message: turn.userMessage })).text);
       } catch (err) {
@@ -214,34 +237,42 @@ async function main(): Promise<void> {
           `turn ${turnIndex} (${turn.chatId}) threw: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
+      emitScenarioStage("DONE", diagnosticScenario, "turn", turnIndex);
       recordHandle?.setCurrentTurn(null);
       replayHandle?.setCurrentTurn(null);
     }
 
-    if (args.mode === "replay") {
-      exitCode = finishReplay({
-        scenario,
-        recording: recording!,
-        replayHandle: replayHandle!,
-        registry,
-        home,
-        runDir: args.runDir,
-        fixtureDir: args.fixtureDir,
-        msw,
-        replies,
-      });
-    } else {
-      exitCode = finishRecord({
-        scenario,
-        recordHandle: recordHandle!,
-        config: { provider, model: config.llm.model },
-        home,
-        fixtureDir: args.fixtureDir,
-        msw,
-        replies,
-      });
+    const finishStage = args.mode === "replay" ? "finish-replay" : "finish-record";
+    emitScenarioStage("START", diagnosticScenario, finishStage);
+    try {
+      if (args.mode === "replay") {
+        exitCode = finishReplay({
+          scenario,
+          recording: recording!,
+          replayHandle: replayHandle!,
+          registry,
+          home,
+          runDir: args.runDir,
+          fixtureDir: args.fixtureDir,
+          msw,
+          replies,
+        });
+      } else {
+        exitCode = finishRecord({
+          scenario,
+          recordHandle: recordHandle!,
+          config: { provider, model: config.llm.model },
+          home,
+          fixtureDir: args.fixtureDir,
+          msw,
+          replies,
+        });
+      }
+    } finally {
+      emitScenarioStage("DONE", diagnosticScenario, finishStage);
     }
   } finally {
+    emitScenarioStage("START", diagnosticScenario, "cleanup");
     msw.close();
     recordHandle?.restore();
     replayHandle?.restore();
@@ -269,6 +300,7 @@ async function main(): Promise<void> {
       exitCode = 2;
     }
     rmSync(home, { recursive: true, force: true });
+    emitScenarioStage("DONE", diagnosticScenario, "cleanup");
   }
 
   process.exit(exitCode);

--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -97,7 +97,10 @@ interface StagedCodexProfile {
 type ScenarioStage = "setup" | "turn" | "finish-replay" | "finish-record" | "cleanup";
 
 function safeScenarioId(value: string): string {
-  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value) ? value : "unknown";
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
+  if (/^i[0-9]{8,9}$/.test(value)) return "unknown";
+  if (/^[0-9]{8,}$/.test(value)) return "unknown";
+  return value;
 }
 
 function emitScenarioStage(

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   aggregateExitCode,
@@ -12,6 +12,9 @@ import {
   parseRunFlags,
   resolveRecordLane,
   runDirName,
+  runSelfTestDeterminism,
+  spawnScenarioChild,
+  type ScenarioChildSpawn,
   usage,
 } from "./run.js";
 import { AUTH_PROFILES_SOURCE_ENV } from "./lib/codex-auth.js";
@@ -175,6 +178,141 @@ describe("child spawn env", () => {
     expect(env[AUTH_PROFILES_SOURCE_ENV]).toBe("/operator/config/auth-profiles.json");
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(env.HISTORY_TOKEN_BUDGET_RATIO).toBe("0.05");
+  });
+});
+
+describe("scenario child process", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const params = {
+    scenarioId: "turn-basic-wellness",
+    stage: "replay" as const,
+    mode: "replay" as const,
+    runDir: "/fixed/run",
+    provider: "openai-codex" as const,
+    llmModel: "gpt-5.6-sol",
+  };
+
+  function removeTempHome(options: Parameters<ScenarioChildSpawn>[2]): void {
+    const home = options.env.CYCLING_COACH_HOME;
+    if (home !== undefined) rmSync(home, { recursive: true, force: true });
+  }
+
+  it("applies the fixed deadline and preserves a normal verdict", () => {
+    const verdict: ScenarioVerdict = {
+      scenario: "turn-basic-wellness",
+      pass: false,
+      failures: [{ assertId: "A1", scenario: "turn-basic-wellness", detail: "drift" }],
+    };
+    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+      removeTempHome(options);
+      return { stdout: `${JSON.stringify(verdict)}\n`, stderr: "fixed stderr", status: 1 };
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const outcome = spawnScenarioChild(params, spawnProcess);
+
+    expect(outcome).toEqual({ verdict, exitCode: 1, stderr: "fixed stderr" });
+    expect(spawnProcess).toHaveBeenCalledOnce();
+    expect(spawnProcess.mock.calls[0]?.[2]).toMatchObject({
+      timeout: 120_000,
+      killSignal: "SIGKILL",
+    });
+    expect(log.mock.calls.map(([line]) => line)).toEqual([
+      "S8A_CHILD START scenario=turn-basic-wellness stage=replay",
+      "S8A_CHILD DONE scenario=turn-basic-wellness stage=replay outcome=exit-1",
+    ]);
+  });
+
+  it("maps ETIMEDOUT to a stable path-free harness error", () => {
+    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+      removeTempHome(options);
+      return {
+        stdout: null,
+        stderr: "/private/athlete-home/token",
+        status: null,
+        error: Object.assign(new Error("/private/athlete-home/token"), { code: "ETIMEDOUT" }),
+      };
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const outcome = spawnScenarioChild(
+      { ...params, scenarioId: "../../private/athlete-home" },
+      spawnProcess,
+    );
+
+    expect(outcome).toEqual({
+      verdict: null,
+      exitCode: 2,
+      stderr: "scenario child timed out: scenario=unknown stage=replay",
+    });
+    expect(JSON.stringify(outcome)).not.toContain("private/athlete-home");
+    expect(log.mock.calls.map(([line]) => line)).toEqual([
+      "S8A_CHILD START scenario=unknown stage=replay",
+      "S8A_CHILD DONE scenario=unknown stage=replay outcome=timeout",
+    ]);
+  });
+
+  it("stops determinism before the second child and diff after a timeout", () => {
+    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+      removeTempHome(options);
+      return {
+        stdout: null,
+        stderr: null,
+        status: null,
+        error: Object.assign(new Error("timed out"), { code: "ETIMEDOUT" }),
+      };
+    });
+    const diffProcess = vi.fn(() => ({ status: 0, stdout: "" }));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const outcome = runSelfTestDeterminism(
+      {
+        probeDirs: ["/fixed/probe-1", "/fixed/probe-2"],
+        provider: "openai-codex",
+        llmModel: "gpt-5.6-sol",
+      },
+      spawnProcess,
+      diffProcess,
+    );
+
+    expect(outcome).toMatchObject({ kind: "harness-error", outcome: { exitCode: 2 } });
+    expect(spawnProcess).toHaveBeenCalledOnce();
+    expect(diffProcess).not.toHaveBeenCalled();
+  });
+
+  it("runs both determinism children before the diff", () => {
+    const verdict: ScenarioVerdict = {
+      scenario: "turn-basic-wellness",
+      pass: true,
+      failures: [],
+    };
+    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+      removeTempHome(options);
+      return { stdout: `${JSON.stringify(verdict)}\n`, stderr: "", status: 0 };
+    });
+    const diffProcess = vi.fn(() => ({ status: 0, stdout: "" }));
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const outcome = runSelfTestDeterminism(
+      {
+        probeDirs: ["/fixed/probe-1", "/fixed/probe-2"],
+        provider: "openai-codex",
+        llmModel: "gpt-5.6-sol",
+      },
+      spawnProcess,
+      diffProcess,
+    );
+
+    expect(outcome).toEqual({ kind: "complete", deterministic: true, diffOutput: "" });
+    expect(spawnProcess).toHaveBeenCalledTimes(2);
+    expect(diffProcess).toHaveBeenCalledOnce();
+    expect(log.mock.calls.map(([line]) => line)).toEqual([
+      "S8A_CHILD START scenario=turn-basic-wellness stage=self-test-determinism-1",
+      "S8A_CHILD DONE scenario=turn-basic-wellness stage=self-test-determinism-1 outcome=exit-0",
+      "S8A_CHILD START scenario=turn-basic-wellness stage=self-test-determinism-2",
+      "S8A_CHILD DONE scenario=turn-basic-wellness stage=self-test-determinism-2 outcome=exit-0",
+    ]);
   });
 });
 

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -58,6 +58,12 @@ describe("scenario child stage diagnostics", () => {
         "inj-02",
       ),
     ).toBe("none");
+    expect(
+      parseLastScenarioChildStage(
+        "S8A_CHILD_STAGE START scenario=inj-02 stage=turn turn=123456789",
+        "inj-02",
+      ),
+    ).toBe("none");
   });
 
   it("binds every requested child boundary in execution order", () => {

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -67,7 +67,7 @@ describe("scenario child stage diagnostics", () => {
     ).toBe("none");
   });
 
-  it.each(["i12345678", "12345678"])(
+  it.each(["i12345678", "12345678", "foo-i12345678-bar", "foo-12345678-bar"])(
     "keeps fixture-private scenario id %s out of diagnostics",
     (privateId) => {
       expect(safeScenarioDiagnosticId(privateId)).toBe("unknown");
@@ -123,8 +123,7 @@ describe("scenario child stage diagnostics", () => {
     const positions = markers.map((marker) => RUN_SCENARIO_SOURCE.indexOf(marker));
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect(positions).toEqual([...positions].sort((left, right) => left - right));
-    expect(RUN_SCENARIO_SOURCE).toContain("/^i[0-9]{8,9}$/");
-    expect(RUN_SCENARIO_SOURCE).toContain("/^[0-9]{8,}$/");
+    expect(RUN_SCENARIO_SOURCE).toContain("/[0-9]{8,}/");
   });
 });
 

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +9,7 @@ import {
   buildHeader,
   distPreflight,
   parseRecordingLane,
+  parseLastScenarioChildStage,
   parseRunFlags,
   resolveRecordLane,
   runDirName,
@@ -19,6 +20,62 @@ import {
 } from "./run.js";
 import { AUTH_PROFILES_SOURCE_ENV } from "./lib/codex-auth.js";
 import type { ScenarioVerdict } from "./lib/types.js";
+
+const RUN_SCENARIO_SOURCE = readFileSync(new URL("./run-scenario.ts", import.meta.url), "utf-8");
+
+describe("scenario child stage diagnostics", () => {
+  it("returns only the last exact allowlisted marker for the expected scenario", () => {
+    const output = [
+      "S8A_CHILD_STAGE START scenario=inj-02 stage=setup",
+      "S8A_CHILD_STAGE DONE scenario=inj-02 stage=setup",
+      "S8A_CHILD_STAGE START scenario=inj-03 stage=cleanup",
+      "S8A_CHILD_STAGE START scenario=inj-02 stage=turn turn=0",
+      "S8A_CHILD_STAGE START scenario=inj-02 stage=private",
+    ].join("\n");
+    expect(parseLastScenarioChildStage(output, "inj-02")).toBe("turn-0-start");
+    expect(parseLastScenarioChildStage(output, "unsafe/path")).toBe("none");
+  });
+
+  it("rejects malformed, mismatched, and structurally invalid markers", () => {
+    expect(
+      parseLastScenarioChildStage("S8A_CHILD_STAGE START scenario=inj-02 stage=turn", "inj-02"),
+    ).toBe("none");
+    expect(
+      parseLastScenarioChildStage(
+        "S8A_CHILD_STAGE DONE scenario=inj-02 stage=setup turn=0",
+        "inj-02",
+      ),
+    ).toBe("none");
+    expect(
+      parseLastScenarioChildStage(
+        "prefix S8A_CHILD_STAGE START scenario=inj-02 stage=setup",
+        "inj-02",
+      ),
+    ).toBe("none");
+    expect(
+      parseLastScenarioChildStage(
+        "S8A_CHILD_STAGE START scenario=inj-03 stage=setup",
+        "inj-02",
+      ),
+    ).toBe("none");
+  });
+
+  it("binds every requested child boundary in execution order", () => {
+    const markers = [
+      'emitScenarioStage("START", diagnosticScenario, "setup")',
+      'emitScenarioStage("DONE", diagnosticScenario, "setup")',
+      'emitScenarioStage("START", diagnosticScenario, "turn", turnIndex)',
+      'emitScenarioStage("DONE", diagnosticScenario, "turn", turnIndex)',
+      'emitScenarioStage("START", diagnosticScenario, finishStage)',
+      'emitScenarioStage("DONE", diagnosticScenario, finishStage)',
+      'emitScenarioStage("START", diagnosticScenario, "cleanup")',
+      'emitScenarioStage("DONE", diagnosticScenario, "cleanup")',
+    ];
+    const positions = markers.map((marker) => RUN_SCENARIO_SOURCE.indexOf(marker));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+  });
+});
 
 describe("flag parsing", () => {
   it("parses each supported invocation", () => {
@@ -228,7 +285,8 @@ describe("scenario child process", () => {
     const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
       removeTempHome(options);
       return {
-        stdout: null,
+        stdout:
+          "S8A_CHILD_STAGE START scenario=unknown stage=turn turn=3\n/private/athlete-home/token\n",
         stderr: "/private/athlete-home/token",
         status: null,
         error: Object.assign(new Error("/private/athlete-home/token"), { code: "ETIMEDOUT" }),
@@ -244,7 +302,7 @@ describe("scenario child process", () => {
     expect(outcome).toEqual({
       verdict: null,
       exitCode: 2,
-      stderr: "scenario child timed out: scenario=unknown stage=replay",
+      stderr: "scenario child timed out: scenario=unknown stage=replay child-stage=turn-3-start",
     });
     expect(JSON.stringify(outcome)).not.toContain("private/athlete-home");
     expect(log.mock.calls.map(([line]) => line)).toEqual([

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -14,6 +14,7 @@ import {
   resolveRecordLane,
   runDirName,
   runSelfTestDeterminism,
+  safeScenarioDiagnosticId,
   spawnScenarioChild,
   type ScenarioChildSpawn,
   usage,
@@ -66,6 +67,48 @@ describe("scenario child stage diagnostics", () => {
     ).toBe("none");
   });
 
+  it.each(["i12345678", "12345678"])(
+    "keeps fixture-private scenario id %s out of diagnostics",
+    (privateId) => {
+      expect(safeScenarioDiagnosticId(privateId)).toBe("unknown");
+      expect(
+        parseLastScenarioChildStage(
+          `S8A_CHILD_STAGE START scenario=${privateId} stage=setup`,
+          privateId,
+        ),
+      ).toBe("none");
+
+      const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+        const home = options.env.CYCLING_COACH_HOME;
+        if (home !== undefined) rmSync(home, { recursive: true, force: true });
+        return {
+          stdout: "S8A_CHILD_STAGE START scenario=unknown stage=setup\n",
+          stderr: privateId,
+          status: null,
+          error: Object.assign(new Error(privateId), { code: "ETIMEDOUT" }),
+        };
+      });
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const outcome = spawnScenarioChild(
+        {
+          scenarioId: privateId,
+          stage: "replay",
+          mode: "replay",
+          runDir: "/fixed/run",
+          provider: "openai-codex",
+          llmModel: "gpt-5.6-sol",
+        },
+        spawnProcess,
+      );
+      const surfaced = JSON.stringify({ outcome, logs: log.mock.calls });
+      expect(surfaced).not.toContain(privateId);
+      expect(outcome.stderr).toBe(
+        "scenario child timed out: scenario=unknown stage=replay child-stage=setup-start",
+      );
+      log.mockRestore();
+    },
+  );
+
   it("binds every requested child boundary in execution order", () => {
     const markers = [
       'emitScenarioStage("START", diagnosticScenario, "setup")',
@@ -80,6 +123,8 @@ describe("scenario child stage diagnostics", () => {
     const positions = markers.map((marker) => RUN_SCENARIO_SOURCE.indexOf(marker));
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect(positions).toEqual([...positions].sort((left, right) => left - right));
+    expect(RUN_SCENARIO_SOURCE).toContain("/^i[0-9]{8,9}$/");
+    expect(RUN_SCENARIO_SOURCE).toContain("/^[0-9]{8,}$/");
   });
 });
 

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -7,6 +7,7 @@ import {
   aggregateExitCode,
   buildChildEnv,
   buildHeader,
+  classifyReplayOutcome,
   distPreflight,
   parseRecordingLane,
   parseLastScenarioChildStage,
@@ -421,6 +422,42 @@ describe("scenario child process", () => {
       "S8A_CHILD START scenario=turn-basic-wellness stage=self-test-determinism-2",
       "S8A_CHILD DONE scenario=turn-basic-wellness stage=self-test-determinism-2 outcome=exit-0",
     ]);
+  });
+});
+
+describe("replay harness errors", () => {
+  it("stops after a missing verdict or harness exit", () => {
+    expect(classifyReplayOutcome({ verdict: null, exitCode: 2, stderr: "timeout" })).toEqual({
+      kind: "harness-error",
+      verdict: null,
+    });
+    expect(
+      classifyReplayOutcome({
+        verdict: { scenario: "a", pass: false, failures: [] },
+        exitCode: 2,
+        stderr: "harness error",
+      }),
+    ).toEqual({
+      kind: "harness-error",
+      verdict: { scenario: "a", pass: false, failures: [] },
+    });
+  });
+
+  it("continues after a normal pass or assertion failure", () => {
+    expect(
+      classifyReplayOutcome({
+        verdict: { scenario: "a", pass: true, failures: [] },
+        exitCode: 0,
+        stderr: "",
+      }),
+    ).toEqual({ kind: "verdict", verdict: { scenario: "a", pass: true, failures: [] } });
+    expect(
+      classifyReplayOutcome({
+        verdict: { scenario: "a", pass: false, failures: [] },
+        exitCode: 1,
+        stderr: "",
+      }),
+    ).toEqual({ kind: "verdict", verdict: { scenario: "a", pass: false, failures: [] } });
   });
 });
 

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -283,6 +283,7 @@ export function spawnScenarioChild(
 }
 
 export function parseLastScenarioChildStage(output: string, scenarioId: string): string {
+  const maxDiagnosticTurnIndex = 99;
   const safeScenarioId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(scenarioId) ? scenarioId : "unknown";
   let last = "none";
   for (const line of output.split("\n")) {
@@ -295,6 +296,7 @@ export function parseLastScenarioChildStage(output: string, scenarioId: string):
     const stage = match[3];
     const turn = match[4];
     if ((stage === "turn") !== (turn !== undefined)) continue;
+    if (turn !== undefined && Number.parseInt(turn, 10) > maxDiagnosticTurnIndex) continue;
     last = stage === "turn" ? `turn-${turn}-${phase}` : `${stage}-${phase}`;
   }
   return last;

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -302,8 +302,7 @@ export function parseLastScenarioChildStage(output: string, scenarioId: string):
 
 export function safeScenarioDiagnosticId(value: string): string {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
-  if (/^i[0-9]{8,9}$/.test(value)) return "unknown";
-  if (/^[0-9]{8,}$/.test(value)) return "unknown";
+  if (/[0-9]{8,}/.test(value)) return "unknown";
   return value;
 }
 

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -224,9 +224,7 @@ export function spawnScenarioChild(
   },
   spawnProcess: ScenarioChildSpawn = (command, args, options) => spawnSync(command, args, options),
 ): ChildOutcome {
-  const safeScenarioId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(params.scenarioId)
-    ? params.scenarioId
-    : "unknown";
+  const safeScenarioId = safeScenarioDiagnosticId(params.scenarioId);
   console.log(`S8A_CHILD START scenario=${safeScenarioId} stage=${params.stage}`);
   const tempHome = mkdtempSync(join(tmpdir(), "s8a-home-"));
   const childArgs = [
@@ -284,7 +282,7 @@ export function spawnScenarioChild(
 
 export function parseLastScenarioChildStage(output: string, scenarioId: string): string {
   const maxDiagnosticTurnIndex = 99;
-  const safeScenarioId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(scenarioId) ? scenarioId : "unknown";
+  const safeScenarioId = safeScenarioDiagnosticId(scenarioId);
   let last = "none";
   for (const line of output.split("\n")) {
     const match =
@@ -300,6 +298,13 @@ export function parseLastScenarioChildStage(output: string, scenarioId: string):
     last = stage === "turn" ? `turn-${turn}-${phase}` : `${stage}-${phase}`;
   }
   return last;
+}
+
+export function safeScenarioDiagnosticId(value: string): string {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
+  if (/^i[0-9]{8,9}$/.test(value)) return "unknown";
+  if (/^[0-9]{8,}$/.test(value)) return "unknown";
+  return value;
 }
 
 export type SelfTestDiffSpawn = (

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -140,10 +140,21 @@ export function aggregateExitCode(verdicts: ScenarioVerdict[]): 0 | 1 {
   return verdicts.every((v) => v.pass) ? 0 : 1;
 }
 
-interface ChildOutcome {
+export interface ChildOutcome {
   verdict: ScenarioVerdict | null;
   exitCode: number;
   stderr: string;
+}
+
+export function classifyReplayOutcome(
+  outcome: ChildOutcome,
+):
+  | { kind: "harness-error"; verdict: ScenarioVerdict | null }
+  | { kind: "verdict"; verdict: ScenarioVerdict } {
+  if (outcome.verdict === null || outcome.exitCode === 2) {
+    return { kind: "harness-error", verdict: outcome.verdict };
+  }
+  return { kind: "verdict", verdict: outcome.verdict };
 }
 
 export type ScenarioChildStage =
@@ -447,13 +458,14 @@ async function replayScenarios(params: {
       llmModel: lane.model,
       anthropicKey: lane.provider === "anthropic" ? REPLAY_DUMMY_KEY : undefined,
     });
-    if (outcome.verdict === null || outcome.exitCode === 2) {
+    const classified = classifyReplayOutcome(outcome);
+    if (classified.kind === "harness-error") {
       console.error(`harness error in scenario ${entry.id} (exit ${outcome.exitCode}):\n${outcome.stderr}`);
       harnessError = true;
-      if (outcome.verdict !== null) verdicts.push(outcome.verdict);
-      continue;
+      if (classified.verdict !== null) verdicts.push(classified.verdict);
+      break;
     }
-    verdicts.push(outcome.verdict);
+    verdicts.push(classified.verdict);
   }
   return { verdicts, harnessError };
 }

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -146,6 +146,33 @@ interface ChildOutcome {
   stderr: string;
 }
 
+export type ScenarioChildStage =
+  | "record"
+  | "replay"
+  | "self-test-drift"
+  | "self-test-determinism-1"
+  | "self-test-determinism-2";
+
+export interface ScenarioChildSpawnResult {
+  stdout: string | null;
+  stderr: string | null;
+  status: number | null;
+  error?: Error & { code?: string };
+}
+
+export type ScenarioChildSpawn = (
+  command: string,
+  args: readonly string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    encoding: "utf-8";
+    maxBuffer: number;
+    timeout: number;
+    killSignal: "SIGKILL";
+  },
+) => ScenarioChildSpawnResult;
+
 export interface ChildEnvParams {
   base: Record<string, string | undefined>;
   tempHome: string;
@@ -181,18 +208,26 @@ export function buildChildEnv(params: ChildEnvParams): Record<string, string | u
   return env;
 }
 
-function spawnScenarioChild(params: {
-  scenarioId: string;
-  mode: "replay" | "record";
-  runDir: string;
-  fixtureDir?: string;
-  noSupersessions?: boolean;
-  scenarioEnv?: Record<string, string>;
-  provider: S8aProvider;
-  llmModel: string;
-  anthropicKey?: string;
-  authProfilesSource?: string;
-}): ChildOutcome {
+export function spawnScenarioChild(
+  params: {
+    scenarioId: string;
+    stage: ScenarioChildStage;
+    mode: "replay" | "record";
+    runDir: string;
+    fixtureDir?: string;
+    noSupersessions?: boolean;
+    scenarioEnv?: Record<string, string>;
+    provider: S8aProvider;
+    llmModel: string;
+    anthropicKey?: string;
+    authProfilesSource?: string;
+  },
+  spawnProcess: ScenarioChildSpawn = (command, args, options) => spawnSync(command, args, options),
+): ChildOutcome {
+  const safeScenarioId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(params.scenarioId)
+    ? params.scenarioId
+    : "unknown";
+  console.log(`S8A_CHILD START scenario=${safeScenarioId} stage=${params.stage}`);
   const tempHome = mkdtempSync(join(tmpdir(), "s8a-home-"));
   const childArgs = [
     join(HERE, "run-scenario.ts"),
@@ -212,12 +247,22 @@ function spawnScenarioChild(params: {
     scenarioEnv: params.scenarioEnv,
   });
 
-  const result = spawnSync(process.execPath, ["--import", "tsx", ...childArgs], {
+  const result = spawnProcess(process.execPath, ["--import", "tsx", ...childArgs], {
     cwd: REPO_ROOT,
     env,
     encoding: "utf-8",
     maxBuffer: 64 * 1024 * 1024,
+    timeout: 120_000,
+    killSignal: "SIGKILL",
   });
+  if (result.error?.code === "ETIMEDOUT") {
+    console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=timeout`);
+    return {
+      verdict: null,
+      exitCode: 2,
+      stderr: `scenario child timed out: scenario=${safeScenarioId} stage=${params.stage}`,
+    };
+  }
   const stdoutLines = (result.stdout ?? "").split("\n").filter((l) => l.trim() !== "");
   let verdict: ScenarioVerdict | null = null;
   for (let i = stdoutLines.length - 1; i >= 0; i--) {
@@ -231,7 +276,61 @@ function spawnScenarioChild(params: {
       // Not the verdict line; keep scanning upward.
     }
   }
-  return { verdict, exitCode: result.status ?? 2, stderr: result.stderr ?? "" };
+  const exitCode = result.status ?? 2;
+  console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=exit-${exitCode}`);
+  return { verdict, exitCode, stderr: result.stderr ?? "" };
+}
+
+export type SelfTestDiffSpawn = (
+  command: string,
+  args: readonly string[],
+  options: { encoding: "utf-8" },
+) => { status: number | null; stdout: string | null };
+
+export function runSelfTestDeterminism(
+  params: {
+    probeDirs: readonly [string, string];
+    provider: S8aProvider;
+    llmModel: string;
+    anthropicKey?: string;
+  },
+  spawnProcess: ScenarioChildSpawn = (command, args, options) => spawnSync(command, args, options),
+  diffProcess: SelfTestDiffSpawn = (command, args, options) => spawnSync(command, args, options),
+):
+  | { kind: "harness-error"; outcome: ChildOutcome }
+  | { kind: "complete"; deterministic: boolean; diffOutput: string } {
+  const probes = [
+    { dir: params.probeDirs[0], stage: "self-test-determinism-1" },
+    { dir: params.probeDirs[1], stage: "self-test-determinism-2" },
+  ] as const;
+  for (const probe of probes) {
+    const outcome = spawnScenarioChild(
+      {
+        scenarioId: "turn-basic-wellness",
+        stage: probe.stage,
+        mode: "replay",
+        runDir: probe.dir,
+        noSupersessions: true,
+        provider: params.provider,
+        llmModel: params.llmModel,
+        anthropicKey: params.anthropicKey,
+      },
+      spawnProcess,
+    );
+    if (outcome.verdict === null || outcome.exitCode === 2) {
+      return { kind: "harness-error", outcome };
+    }
+  }
+  const diff = diffProcess(
+    "diff",
+    ["-r", join(params.probeDirs[0], "home"), join(params.probeDirs[1], "home")],
+    { encoding: "utf-8" },
+  );
+  return {
+    kind: "complete",
+    deterministic: diff.status === 0,
+    diffOutput: diff.stdout ?? "",
+  };
 }
 
 function gitSha(): string {
@@ -314,6 +413,7 @@ async function replayScenarios(params: {
     const lane = readRecordingLane(fixtureDir);
     const outcome = spawnScenarioChild({
       scenarioId: entry.id,
+      stage: "replay",
       mode: "replay",
       runDir: join(params.runDir, entry.id),
       noSupersessions: params.noSupersessions,
@@ -409,6 +509,7 @@ async function main(): Promise<void> {
     console.log(`recording lane: ${lane.provider} / ${lane.model}`);
     const outcome = spawnScenarioChild({
       scenarioId: entry.id,
+      stage: "record",
       mode: "record",
       runDir: join(runDir, entry.id),
       scenarioEnv: await loadScenarioEnv(entry),
@@ -433,6 +534,7 @@ async function main(): Promise<void> {
     const driftLane = readRecordingLane(join(HERE, "fixtures", "drift-must-fail"));
     const driftOutcome = spawnScenarioChild({
       scenarioId: "turn-basic-wellness",
+      stage: "self-test-drift",
       mode: "replay",
       runDir: join(runDir, "drift-must-fail"),
       fixtureDir: join(HERE, "fixtures", "drift-must-fail"),
@@ -455,30 +557,30 @@ async function main(): Promise<void> {
 
     // Probe (b): determinism — two fresh children, byte-compare the snapshotted
     // home trees. The byte-compare is the pass criterion, NOT the exit codes.
-    const probeDirs = ["turn-basic-wellness-probe1", "turn-basic-wellness-probe2"].map((d) => join(runDir, d));
+    const probeDirs = [
+      join(runDir, "turn-basic-wellness-probe1"),
+      join(runDir, "turn-basic-wellness-probe2"),
+    ] as const;
     const probeLane = readRecordingLane(join(HERE, "fixtures", "turn-basic-wellness"));
-    for (const dir of probeDirs) {
-      spawnScenarioChild({
-        scenarioId: "turn-basic-wellness",
-        mode: "replay",
-        runDir: dir,
-        noSupersessions: true,
-        provider: probeLane.provider,
-        llmModel: probeLane.model,
-        anthropicKey: probeLane.provider === "anthropic" ? REPLAY_DUMMY_KEY : undefined,
-      });
-    }
-    const diff = spawnSync("diff", ["-r", join(probeDirs[0], "home"), join(probeDirs[1], "home")], {
-      encoding: "utf-8",
+    const determinism = runSelfTestDeterminism({
+      probeDirs,
+      provider: probeLane.provider,
+      llmModel: probeLane.model,
+      anthropicKey: probeLane.provider === "anthropic" ? REPLAY_DUMMY_KEY : undefined,
     });
-    const deterministic = diff.status === 0;
+    if (determinism.kind === "harness-error") {
+      console.error(
+        `determinism probe harness error (exit ${determinism.outcome.exitCode}):\n${determinism.outcome.stderr}`,
+      );
+      process.exit(2);
+    }
     console.log(
-      deterministic
+      determinism.deterministic
         ? "determinism probe: PASS — two replay home trees byte-identical"
-        : `determinism probe: FAIL — trees differ:\n${diff.stdout}`,
+        : `determinism probe: FAIL — trees differ:\n${determinism.diffOutput}`,
     );
 
-    process.exit(driftPass && deterministic ? 0 : 1);
+    process.exit(driftPass && determinism.deterministic ? 0 : 1);
   }
 
   if (flags.kind === "rebaseline") {

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -257,10 +257,11 @@ export function spawnScenarioChild(
   });
   if (result.error?.code === "ETIMEDOUT") {
     console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=timeout`);
+    const childStage = parseLastScenarioChildStage(result.stdout ?? "", safeScenarioId);
     return {
       verdict: null,
       exitCode: 2,
-      stderr: `scenario child timed out: scenario=${safeScenarioId} stage=${params.stage}`,
+      stderr: `scenario child timed out: scenario=${safeScenarioId} stage=${params.stage} child-stage=${childStage}`,
     };
   }
   const stdoutLines = (result.stdout ?? "").split("\n").filter((l) => l.trim() !== "");
@@ -279,6 +280,24 @@ export function spawnScenarioChild(
   const exitCode = result.status ?? 2;
   console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=exit-${exitCode}`);
   return { verdict, exitCode, stderr: result.stderr ?? "" };
+}
+
+export function parseLastScenarioChildStage(output: string, scenarioId: string): string {
+  const safeScenarioId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(scenarioId) ? scenarioId : "unknown";
+  let last = "none";
+  for (const line of output.split("\n")) {
+    const match =
+      /^S8A_CHILD_STAGE (START|DONE) scenario=([a-z0-9]+(?:-[a-z0-9]+)*) stage=(setup|turn|finish-replay|finish-record|cleanup)(?: turn=(0|[1-9][0-9]*))?$/.exec(
+        line.trimEnd(),
+      );
+    if (match === null || match[2] !== safeScenarioId) continue;
+    const phase = match[1].toLowerCase();
+    const stage = match[3];
+    const turn = match[4];
+    if ((stage === "turn") !== (turn !== undefined)) continue;
+    last = stage === "turn" ? `turn-${turn}-${phase}` : `${stage}-${phase}`;
+  }
+  return last;
 }
 
 export type SelfTestDiffSpawn = (


### PR DESCRIPTION
## Summary
- terminate any S8A scenario child that exceeds its bounded runtime
- emit fixed scenario and stage markers so the next stall is localizable
- stop replay and self-test determinism after the first harness failure

## Verification
- reviewed S8A timeout and diagnostics ported from #651 and #652
- Node 24: `vitest run tools/s8a/run.test.ts --maxWorkers=1` — 28 passed
- `pnpm check` — passed
- `git diff --check` — passed

## Limit
- `S8A scenario child timeout = 120000 ms` — prevents one replay child from consuming the entire CI job budget

## Release context
This ports only the S8A hardening from `epic/windows`; no Windows product changes are included.
