### PR TITLE
fix: isolate S8A child output

### DIFF
--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -1,7 +1,15 @@
 // Per-scenario child entry. One fresh process per scenario: the coach home env
 // var must be set BEFORE this process imports core, because the config dir is a
 // module-level constant resolved at import time.
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -305,6 +313,7 @@ async function main(): Promise<void> {
     emitScenarioStage("DONE", diagnosticScenario, "cleanup");
   }
 
+  writeSync(process.stdout.fd, `S8A_CHILD_EXIT code=${exitCode}\n`);
   process.exit(exitCode);
 }
 

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -10,6 +10,7 @@ import {
   classifyReplayOutcome,
   distPreflight,
   parseRecordingLane,
+  parseScenarioChildExit,
   parseLastScenarioChildStage,
   parseRunFlags,
   resolveRecordLane,
@@ -17,6 +18,7 @@ import {
   runSelfTestDeterminism,
   safeScenarioDiagnosticId,
   spawnScenarioChild,
+  spawnScenarioChildCaptured,
   type ScenarioChildSpawn,
   usage,
 } from "./run.js";
@@ -125,6 +127,12 @@ describe("scenario child stage diagnostics", () => {
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect(positions).toEqual([...positions].sort((left, right) => left - right));
     expect(RUN_SCENARIO_SOURCE).toContain("/[0-9]{8,}/");
+    expect(RUN_SCENARIO_SOURCE).toContain("S8A_CHILD_EXIT code=${exitCode}");
+  });
+
+  it("accepts only the last exact logical-exit sentinel", () => {
+    expect(parseScenarioChildExit("S8A_CHILD_EXIT code=0\nnoise\nS8A_CHILD_EXIT code=1\n")).toBe(1);
+    expect(parseScenarioChildExit("prefix S8A_CHILD_EXIT code=0\nS8A_CHILD_EXIT code=3\n")).toBeNull();
   });
 });
 
@@ -306,6 +314,31 @@ describe("scenario child process", () => {
     if (home !== undefined) rmSync(home, { recursive: true, force: true });
   }
 
+  it("does not wait for a descendant that inherited output", () => {
+    const script = [
+      'const { spawn } = require("node:child_process")',
+      'const child = spawn(process.execPath, ["-e", "process.stdin.resume()"], { detached: true, stdio: ["ignore", 1, 2] })',
+      "child.unref()",
+      "console.log(child.pid)",
+    ].join(";");
+    const result = spawnScenarioChildCaptured(process.execPath, ["-e", script], {
+      cwd: process.cwd(),
+      env: process.env,
+      encoding: "utf-8",
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 1_000,
+      killSignal: "SIGKILL",
+    });
+    const descendantPid = Number.parseInt(result.stdout?.trim() ?? "", 10);
+    try {
+      expect(result.status).toBe(0);
+      expect(result.error).toBeUndefined();
+      expect(Number.isSafeInteger(descendantPid)).toBe(true);
+    } finally {
+      if (Number.isSafeInteger(descendantPid)) process.kill(descendantPid, "SIGKILL");
+    }
+  });
+
   it("applies the fixed deadline and preserves a normal verdict", () => {
     const verdict: ScenarioVerdict = {
       scenario: "turn-basic-wellness",
@@ -323,7 +356,7 @@ describe("scenario child process", () => {
     expect(outcome).toEqual({ verdict, exitCode: 1, stderr: "fixed stderr" });
     expect(spawnProcess).toHaveBeenCalledOnce();
     expect(spawnProcess.mock.calls[0]?.[2]).toMatchObject({
-      timeout: 120_000,
+      timeout: 15_000,
       killSignal: "SIGKILL",
     });
     expect(log.mock.calls.map(([line]) => line)).toEqual([
@@ -360,6 +393,36 @@ describe("scenario child process", () => {
       "S8A_CHILD START scenario=unknown stage=replay",
       "S8A_CHILD DONE scenario=unknown stage=replay outcome=timeout",
     ]);
+  });
+
+  it("recovers a completed replay from an exit stall", () => {
+    const verdict: ScenarioVerdict = {
+      scenario: "turn-basic-wellness",
+      pass: true,
+      failures: [],
+    };
+    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+      removeTempHome(options);
+      return {
+        stdout: [
+          JSON.stringify(verdict),
+          "S8A_CHILD_STAGE DONE scenario=turn-basic-wellness stage=cleanup",
+          "S8A_CHILD_EXIT code=0",
+          "",
+        ].join("\n"),
+        stderr: "",
+        status: null,
+        error: Object.assign(new Error("timed out"), { code: "ETIMEDOUT" }),
+      };
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const outcome = spawnScenarioChild(params, spawnProcess);
+
+    expect(outcome).toEqual({ verdict, exitCode: 0, stderr: "" });
+    expect(log.mock.calls.at(-1)?.[0]).toBe(
+      "S8A_CHILD DONE scenario=turn-basic-wellness stage=replay outcome=recovered-exit-0",
+    );
   });
 
   it("stops determinism before the second child and diff after a timeout", () => {

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -339,6 +339,24 @@ describe("scenario child process", () => {
     }
   });
 
+  it("rejects captured output larger than maxBuffer", () => {
+    const result = spawnScenarioChildCaptured(
+      process.execPath,
+      ["-e", 'process.stdout.write("123456789")'],
+      {
+        cwd: process.cwd(),
+        env: process.env,
+        encoding: "utf-8",
+        maxBuffer: 8,
+        timeout: 1_000,
+        killSignal: "SIGKILL",
+      },
+    );
+
+    expect(result).toMatchObject({ stdout: null, stderr: "", status: null });
+    expect(result.error?.code).toBe("ENOBUFS");
+  });
+
   it("applies the fixed deadline and preserves a normal verdict", () => {
     const verdict: ScenarioVerdict = {
       scenario: "turn-basic-wellness",

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -4,7 +4,16 @@
 // The parent's clock is never frozen: two consecutive runs always land in
 // distinct run dirs.
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -184,6 +193,55 @@ export type ScenarioChildSpawn = (
   },
 ) => ScenarioChildSpawnResult;
 
+export const spawnScenarioChildCaptured: ScenarioChildSpawn = (command, args, options) => {
+  const ioDir = mkdtempSync(join(tmpdir(), "s8a-child-io-"));
+  const stdoutPath = join(ioDir, "stdout");
+  const stderrPath = join(ioDir, "stderr");
+  let stdoutFd: number | undefined;
+  let stderrFd: number | undefined;
+  try {
+    stdoutFd = openSync(stdoutPath, "w");
+    stderrFd = openSync(stderrPath, "w");
+    const result = spawnSync(command, [...args], {
+      cwd: options.cwd,
+      env: options.env,
+      timeout: options.timeout,
+      killSignal: options.killSignal,
+      stdio: ["ignore", stdoutFd, stderrFd],
+    });
+    return {
+      stdout: readFileSync(stdoutPath, options.encoding),
+      stderr: readFileSync(stderrPath, options.encoding),
+      status: result.status,
+      error: result.error,
+    };
+  } finally {
+    if (stdoutFd !== undefined) closeSync(stdoutFd);
+    if (stderrFd !== undefined) closeSync(stderrFd);
+    rmSync(ioDir, { recursive: true, force: true });
+  }
+};
+
+export function parseScenarioChildExit(output: string): 0 | 1 | 2 | null {
+  let exitCode: 0 | 1 | 2 | null = null;
+  for (const line of output.split("\n")) {
+    const match = /^S8A_CHILD_EXIT code=([012])$/.exec(line.trimEnd());
+    if (match !== null) exitCode = Number.parseInt(match[1], 10) as 0 | 1 | 2;
+  }
+  return exitCode;
+}
+
+function parseScenarioVerdict(output: string): ScenarioVerdict | null {
+  const stdoutLines = output.split("\n").filter((line) => line.trim() !== "");
+  for (let i = stdoutLines.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(stdoutLines[i]) as ScenarioVerdict;
+      if (typeof parsed.scenario === "string" && typeof parsed.pass === "boolean") return parsed;
+    } catch {}
+  }
+  return null;
+}
+
 export interface ChildEnvParams {
   base: Record<string, string | undefined>;
   tempHome: string;
@@ -233,7 +291,7 @@ export function spawnScenarioChild(
     anthropicKey?: string;
     authProfilesSource?: string;
   },
-  spawnProcess: ScenarioChildSpawn = (command, args, options) => spawnSync(command, args, options),
+  spawnProcess: ScenarioChildSpawn = spawnScenarioChildCaptured,
 ): ChildOutcome {
   const safeScenarioId = safeScenarioDiagnosticId(params.scenarioId);
   console.log(`S8A_CHILD START scenario=${safeScenarioId} stage=${params.stage}`);
@@ -261,30 +319,30 @@ export function spawnScenarioChild(
     env,
     encoding: "utf-8",
     maxBuffer: 64 * 1024 * 1024,
-    timeout: 120_000,
+    timeout: params.mode === "replay" ? 15_000 : 120_000,
     killSignal: "SIGKILL",
   });
+  const stdout = result.stdout ?? "";
+  const verdict = parseScenarioVerdict(stdout);
   if (result.error?.code === "ETIMEDOUT") {
+    const childStage = parseLastScenarioChildStage(stdout, safeScenarioId);
+    const logicalExitCode = parseScenarioChildExit(stdout);
+    if (
+      childStage === "cleanup-done" &&
+      logicalExitCode !== null &&
+      (logicalExitCode === 2 || verdict !== null)
+    ) {
+      console.log(
+        `S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=recovered-exit-${logicalExitCode}`,
+      );
+      return { verdict, exitCode: logicalExitCode, stderr: result.stderr ?? "" };
+    }
     console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=timeout`);
-    const childStage = parseLastScenarioChildStage(result.stdout ?? "", safeScenarioId);
     return {
       verdict: null,
       exitCode: 2,
       stderr: `scenario child timed out: scenario=${safeScenarioId} stage=${params.stage} child-stage=${childStage}`,
     };
-  }
-  const stdoutLines = (result.stdout ?? "").split("\n").filter((l) => l.trim() !== "");
-  let verdict: ScenarioVerdict | null = null;
-  for (let i = stdoutLines.length - 1; i >= 0; i--) {
-    try {
-      const parsed = JSON.parse(stdoutLines[i]) as ScenarioVerdict;
-      if (typeof parsed.scenario === "string" && typeof parsed.pass === "boolean") {
-        verdict = parsed;
-        break;
-      }
-    } catch {
-      // Not the verdict line; keep scanning upward.
-    }
   }
   const exitCode = result.status ?? 2;
   console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=exit-${exitCode}`);

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -12,6 +12,7 @@ import {
   openSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -209,6 +210,16 @@ export const spawnScenarioChildCaptured: ScenarioChildSpawn = (command, args, op
       killSignal: options.killSignal,
       stdio: ["ignore", stdoutFd, stderrFd],
     });
+    const stdoutSize = statSync(stdoutPath).size;
+    const stderrSize = statSync(stderrPath).size;
+    if (stdoutSize > options.maxBuffer || stderrSize > options.maxBuffer) {
+      return {
+        stdout: stdoutSize <= options.maxBuffer ? readFileSync(stdoutPath, options.encoding) : null,
+        stderr: stderrSize <= options.maxBuffer ? readFileSync(stderrPath, options.encoding) : null,
+        status: null,
+        error: Object.assign(new Error(`spawnSync ${command} ENOBUFS`), { code: "ENOBUFS" }),
+      };
+    }
     return {
       stdout: readFileSync(stdoutPath, options.encoding),
       stderr: readFileSync(stderrPath, options.encoding),
@@ -388,7 +399,7 @@ export function runSelfTestDeterminism(
     llmModel: string;
     anthropicKey?: string;
   },
-  spawnProcess: ScenarioChildSpawn = (command, args, options) => spawnSync(command, args, options),
+  spawnProcess: ScenarioChildSpawn = spawnScenarioChildCaptured,
   diffProcess: SelfTestDiffSpawn = (command, args, options) => spawnSync(command, args, options),
 ):
   | { kind: "harness-error"; outcome: ChildOutcome }


### PR DESCRIPTION
## Summary
- capture each S8A child’s stdout and stderr in temporary files
- prevent inherited output handles from keeping `spawnSync` open after a scenario exits
- emit a logical exit sentinel and recover completed replay scenarios if the OS process stalls after `cleanup-done`
- keep genuine pre-cleanup stalls as stage-specific harness failures

## Evidence
- PR #650 localized one stall to `session-stale-reset-flush` after `cleanup-done`
- PR #654 localized a second stall to `inj-01` after `cleanup-done`
- both scenarios completed their verdict and cleanup before the process-level stall

## Verification
- `vitest run tools/s8a/run.test.ts --maxWorkers=1` — 31 passed
- `pnpm s8a --scenario=session-stale-reset-flush` — 5 consecutive passes
- `pnpm s8a` — all 11 replay scenarios passed after each implementation revision
- `pnpm check` — passed after each implementation revision
- `git diff --check` — passed

## Limits
- `S8A replay child timeout = 15000 ms` — replay normally finishes in about two seconds and can recover a completed cleanup stall quickly
- `S8A record child timeout = 120000 ms` — retained for real model calls

## Release context
This is S8A test infrastructure only; no Windows or desktop product code is included.
