### PR TITLE
fix: contain S8A child execution

### DIFF
--- a/tools/s8a/capture-native-exit.mjs
+++ b/tools/s8a/capture-native-exit.mjs
@@ -1,0 +1,22 @@
+import { writeSync } from "node:fs";
+
+const key = Symbol.for("enduragent.s8a.nativeReallyExit");
+const nativeReallyExit = process.reallyExit;
+
+const invalidCapture =
+  typeof nativeReallyExit !== "function" || Object.prototype.hasOwnProperty.call(globalThis, key);
+
+if (invalidCapture) {
+  try {
+    writeSync(process.stderr.fd, "s8a native exit capture failed\n");
+  } catch {}
+  process.exitCode = 2;
+  if (typeof nativeReallyExit === "function") nativeReallyExit.call(process, 2);
+} else {
+  Object.defineProperty(globalThis, key, {
+    value: nativeReallyExit.bind(process),
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+}

--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -1,7 +1,15 @@
 // Per-scenario child entry. One fresh process per scenario: the coach home env
 // var must be set BEFORE this process imports core, because the config dir is a
 // module-level constant resolved at import time.
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -47,6 +55,7 @@ import type {
 } from "./lib/types.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+const SCENARIO_STAGE_EPOCH = process.hrtime.bigint();
 
 function parseArgs(argv: string[]): {
   scenario: string;
@@ -94,12 +103,32 @@ interface StagedCodexProfile {
   snapshot: StoredProfileSnapshot;
 }
 
-type ScenarioStage = "setup" | "turn" | "finish-replay" | "finish-record" | "cleanup";
+type ScenarioStage =
+  | "setup"
+  | "turn"
+  | "finish-replay"
+  | "finish-record"
+  | "cleanup"
+  | "exit-intent";
 
 function safeScenarioId(value: string): string {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
   if (/[0-9]{8,}/.test(value)) return "unknown";
   return value;
+}
+
+function formatScenarioStage(
+  phase: "START" | "DONE",
+  scenarioId: string,
+  stage: ScenarioStage,
+  turnIndex?: number,
+): string {
+  const turn =
+    stage === "turn" && Number.isSafeInteger(turnIndex) && turnIndex! >= 0
+      ? ` turn=${turnIndex}`
+      : "";
+  const elapsedMs = Number((process.hrtime.bigint() - SCENARIO_STAGE_EPOCH) / 1_000_000n);
+  return `S8A_CHILD_STAGE ${phase} scenario=${scenarioId} stage=${stage}${turn} elapsed-ms=${elapsedMs}`;
 }
 
 function emitScenarioStage(
@@ -108,11 +137,13 @@ function emitScenarioStage(
   stage: ScenarioStage,
   turnIndex?: number,
 ): void {
-  const turn =
-    stage === "turn" && Number.isSafeInteger(turnIndex) && turnIndex! >= 0
-      ? ` turn=${turnIndex}`
-      : "";
-  console.log(`S8A_CHILD_STAGE ${phase} scenario=${scenarioId} stage=${stage}${turn}`);
+  console.log(formatScenarioStage(phase, scenarioId, stage, turnIndex));
+}
+
+function emitExitIntent(scenarioId: string): void {
+  try {
+    writeSync(process.stdout.fd, `${formatScenarioStage("DONE", scenarioId, "exit-intent")}\n`);
+  } catch {}
 }
 
 async function main(): Promise<void> {
@@ -305,6 +336,7 @@ async function main(): Promise<void> {
     emitScenarioStage("DONE", diagnosticScenario, "cleanup");
   }
 
+  emitExitIntent(diagnosticScenario);
   process.exit(exitCode);
 }
 

--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -56,6 +56,11 @@ import type {
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCENARIO_STAGE_EPOCH = process.hrtime.bigint();
+const NATIVE_REALLY_EXIT_KEY = Symbol.for("enduragent.s8a.nativeReallyExit");
+
+type ProcessWithReallyExit = NodeJS.Process & {
+  reallyExit: (code?: number) => never;
+};
 
 function parseArgs(argv: string[]): {
   scenario: string;
@@ -96,6 +101,20 @@ function parseArgs(argv: string[]): {
 function harnessError(message: string): never {
   console.error(`s8a harness error: ${message}`);
   process.exit(2);
+}
+
+function restoreCapturedNativeExit(): void {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, NATIVE_REALLY_EXIT_KEY);
+  if (
+    descriptor === undefined ||
+    typeof descriptor.value !== "function" ||
+    descriptor.enumerable ||
+    descriptor.writable ||
+    descriptor.configurable
+  ) {
+    harnessError("native exit capture is unavailable");
+  }
+  (process as ProcessWithReallyExit).reallyExit = descriptor.value as (code?: number) => never;
 }
 
 interface StagedCodexProfile {
@@ -337,6 +356,7 @@ async function main(): Promise<void> {
   }
 
   emitSynchronousScenarioStage(diagnosticScenario, "exit-intent");
+  restoreCapturedNativeExit();
   process.exit(exitCode);
 }
 

--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -109,7 +109,15 @@ type ScenarioStage =
   | "finish-replay"
   | "finish-record"
   | "cleanup"
-  | "exit-intent";
+  | "exit-intent"
+  | "exit-listeners"
+  | "really-exit";
+
+type ProcessReallyExit = (code?: number) => never;
+
+interface ProcessWithReallyExit extends NodeJS.Process {
+  reallyExit: ProcessReallyExit;
+}
 
 function safeScenarioId(value: string): string {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
@@ -140,10 +148,25 @@ function emitScenarioStage(
   console.log(formatScenarioStage(phase, scenarioId, stage, turnIndex));
 }
 
-function emitExitIntent(scenarioId: string): void {
+function emitSynchronousScenarioStage(scenarioId: string, stage: ScenarioStage): void {
   try {
-    writeSync(process.stdout.fd, `${formatScenarioStage("DONE", scenarioId, "exit-intent")}\n`);
+    writeSync(process.stdout.fd, `${formatScenarioStage("DONE", scenarioId, stage)}\n`);
   } catch {}
+}
+
+function installExitPathProbes(scenarioId: string): void {
+  const processWithReallyExit = process as ProcessWithReallyExit;
+  const currentReallyExit = processWithReallyExit.reallyExit;
+  process.on("exit", () => {
+    emitSynchronousScenarioStage(scenarioId, "exit-listeners");
+  });
+  processWithReallyExit.reallyExit = function (
+    this: NodeJS.Process,
+    ...args: Parameters<ProcessReallyExit>
+  ): never {
+    emitSynchronousScenarioStage(scenarioId, "really-exit");
+    return Reflect.apply(currentReallyExit, this, args) as never;
+  };
 }
 
 async function main(): Promise<void> {
@@ -336,7 +359,8 @@ async function main(): Promise<void> {
     emitScenarioStage("DONE", diagnosticScenario, "cleanup");
   }
 
-  emitExitIntent(diagnosticScenario);
+  installExitPathProbes(diagnosticScenario);
+  emitSynchronousScenarioStage(diagnosticScenario, "exit-intent");
   process.exit(exitCode);
 }
 

--- a/tools/s8a/run-scenario.ts
+++ b/tools/s8a/run-scenario.ts
@@ -109,15 +109,7 @@ type ScenarioStage =
   | "finish-replay"
   | "finish-record"
   | "cleanup"
-  | "exit-intent"
-  | "exit-listeners"
-  | "really-exit";
-
-type ProcessReallyExit = (code?: number) => never;
-
-interface ProcessWithReallyExit extends NodeJS.Process {
-  reallyExit: ProcessReallyExit;
-}
+  | "exit-intent";
 
 function safeScenarioId(value: string): string {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) return "unknown";
@@ -152,21 +144,6 @@ function emitSynchronousScenarioStage(scenarioId: string, stage: ScenarioStage):
   try {
     writeSync(process.stdout.fd, `${formatScenarioStage("DONE", scenarioId, stage)}\n`);
   } catch {}
-}
-
-function installExitPathProbes(scenarioId: string): void {
-  const processWithReallyExit = process as ProcessWithReallyExit;
-  const currentReallyExit = processWithReallyExit.reallyExit;
-  process.on("exit", () => {
-    emitSynchronousScenarioStage(scenarioId, "exit-listeners");
-  });
-  processWithReallyExit.reallyExit = function (
-    this: NodeJS.Process,
-    ...args: Parameters<ProcessReallyExit>
-  ): never {
-    emitSynchronousScenarioStage(scenarioId, "really-exit");
-    return Reflect.apply(currentReallyExit, this, args) as never;
-  };
 }
 
 async function main(): Promise<void> {
@@ -359,7 +336,6 @@ async function main(): Promise<void> {
     emitScenarioStage("DONE", diagnosticScenario, "cleanup");
   }
 
-  installExitPathProbes(diagnosticScenario);
   emitSynchronousScenarioStage(diagnosticScenario, "exit-intent");
   process.exit(exitCode);
 }

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -1,7 +1,9 @@
+import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -30,6 +32,7 @@ import type { ScenarioVerdict } from "./lib/types.js";
 
 const RUN_SCENARIO_SOURCE = readFileSync(new URL("./run-scenario.ts", import.meta.url), "utf-8");
 const RUN_SOURCE = readFileSync(new URL("./run.ts", import.meta.url), "utf-8");
+const CAPTURE_NATIVE_EXIT_URL = new URL("./capture-native-exit.mjs", import.meta.url).href;
 
 describe("scenario child stage diagnostics", () => {
   it("returns only the last exact allowlisted marker for the expected scenario", () => {
@@ -160,6 +163,7 @@ describe("scenario child stage diagnostics", () => {
       'emitScenarioStage("START", diagnosticScenario, "cleanup")',
       'emitScenarioStage("DONE", diagnosticScenario, "cleanup")',
       'emitSynchronousScenarioStage(diagnosticScenario, "exit-intent")',
+      "  restoreCapturedNativeExit();",
       "process.exit(exitCode)",
     ];
     const positions = markers.map((marker) => RUN_SCENARIO_SOURCE.indexOf(marker));
@@ -171,7 +175,15 @@ describe("scenario child stage diagnostics", () => {
       'writeSync(process.stdout.fd, `${formatScenarioStage("DONE", scenarioId, stage)}\\n`)',
     );
     expect(RUN_SCENARIO_SOURCE).not.toContain("installExitPathProbes");
-    expect(RUN_SCENARIO_SOURCE).not.toContain("reallyExit");
+    expect(RUN_SCENARIO_SOURCE).toContain(
+      'Symbol.for("enduragent.s8a.nativeReallyExit")',
+    );
+    expect(RUN_SCENARIO_SOURCE).toContain(
+      'harnessError("native exit capture is unavailable")',
+    );
+    expect(RUN_SCENARIO_SOURCE).toContain(
+      "Object.getOwnPropertyDescriptor(globalThis, NATIVE_REALLY_EXIT_KEY)",
+    );
     expect(RUN_SCENARIO_SOURCE).not.toContain("rawListeners");
     expect(RUN_SCENARIO_SOURCE).not.toContain("getEventListeners");
     expect(RUN_SCENARIO_SOURCE).not.toContain(".listeners(");
@@ -307,6 +319,7 @@ describe("child spawn env", () => {
     [AUTH_PROFILES_SOURCE_ENV]: "/operator/auth-profiles.json",
     LLM_BASE_URL: "https://stray.example",
     HISTORY_TOKEN_BUDGET_RATIO: "0.9",
+    NODE_OPTIONS: "--import=/private/operator-hook.mjs",
   };
 
   it("carries zero credentials into a codex-lane replay child", () => {
@@ -324,6 +337,7 @@ describe("child spawn env", () => {
     expect(env.LLM_API_KEY).toBeUndefined();
     expect(env.LLM_BASE_URL).toBeUndefined();
     expect(env.HISTORY_TOKEN_BUDGET_RATIO).toBeUndefined();
+    expect(env.NODE_OPTIONS).toBeUndefined();
   });
 
   it("scrubs the operator's real key on an anthropic-lane replay child", () => {
@@ -386,6 +400,16 @@ describe("scenario child process", () => {
 
     expect(outcome).toEqual({ verdict, exitCode: 1, stderr: "fixed stderr" });
     expect(spawnProcess).toHaveBeenCalledOnce();
+    expect(spawnProcess.mock.calls[0]?.[1]).toEqual([
+      "--import",
+      CAPTURE_NATIVE_EXIT_URL,
+      "--import",
+      "tsx",
+      fileURLToPath(new URL("./run-scenario.ts", import.meta.url)),
+      "--scenario=turn-basic-wellness",
+      "--mode=replay",
+      "--run-dir=/fixed/run",
+    ]);
     expect(spawnProcess.mock.calls[0]?.[2]).toMatchObject({
       timeout: 120_000,
       killSignal: "SIGKILL",
@@ -487,6 +511,71 @@ describe("scenario child process", () => {
       "S8A_CHILD START scenario=turn-basic-wellness stage=self-test-determinism-2",
       "S8A_CHILD DONE scenario=turn-basic-wellness stage=self-test-determinism-2 outcome=exit-0",
     ]);
+  });
+});
+
+describe("native exit capture", () => {
+  let fixtureDir: string;
+
+  afterEach(() => rmSync(fixtureDir, { recursive: true, force: true }));
+
+  it("runs ordinary and signal-exit hooks while bypassing a late reallyExit wrapper", () => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "s8a-native-exit-test-"));
+    const fixturePath = join(fixtureDir, "fixture.mjs");
+    const signalExitUrl = pathToFileURL(
+      fileURLToPath(
+        new URL(
+          "../../node_modules/.pnpm/signal-exit@4.1.0/node_modules/signal-exit/dist/mjs/index.js",
+          import.meta.url,
+        ),
+      ),
+    ).href;
+    writeFileSync(
+      fixturePath,
+      [
+        'import { writeSync } from "node:fs";',
+        `import { onExit } from ${JSON.stringify(signalExitUrl)};`,
+        'const key = Symbol.for("enduragent.s8a.nativeReallyExit");',
+        'process.on("exit", (code) => writeSync(process.stdout.fd, `ordinary:${code}\\n`));',
+        'onExit((code) => writeSync(process.stdout.fd, `signal-exit:${code}\\n`));',
+        'process.reallyExit = () => writeSync(process.stdout.fd, "late-wrapper\\n");',
+        'const captured = globalThis[key];',
+        'if (typeof captured !== "function") process.exit(2);',
+        'process.reallyExit = captured;',
+        'process.exit(7);',
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = spawnSync(process.execPath, ["--import", CAPTURE_NATIVE_EXIT_URL, fixturePath], {
+      encoding: "utf-8",
+    });
+
+    expect(result.status).toBe(7);
+    expect(result.stdout).toBe("ordinary:7\nsignal-exit:7\n");
+    expect(result.stdout).not.toContain("late-wrapper");
+    expect(result.stderr).toBe("");
+  });
+
+  it.each([
+    ["missing native exit", 'process.reallyExit = undefined;'],
+    [
+      "duplicate capture",
+      'Object.defineProperty(globalThis, Symbol.for("enduragent.s8a.nativeReallyExit"), { value: () => {}, configurable: false });',
+    ],
+  ])("fails path-free when capture starts with %s", (_label, setup) => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "s8a-native-exit-test-"));
+    const setupUrl = `data:text/javascript,${encodeURIComponent(setup)}`;
+    const result = spawnSync(
+      process.execPath,
+      ["--import", setupUrl, "--import", CAPTURE_NATIVE_EXIT_URL, "--eval", ""],
+      { encoding: "utf-8" },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("s8a native exit capture failed\n");
+    expect(`${result.stdout}${result.stderr}`).not.toContain(fixtureDir);
   });
 });
 

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -19,6 +20,7 @@ import {
   spawnScenarioChild,
   spawnScenarioProcess,
   type ScenarioChildCaptureDependencies,
+  type ScenarioChildProcess,
   type ScenarioChildSpawn,
   type ScenarioChildSpawnOptions,
   usage,
@@ -27,6 +29,7 @@ import { AUTH_PROFILES_SOURCE_ENV } from "./lib/codex-auth.js";
 import type { ScenarioVerdict } from "./lib/types.js";
 
 const RUN_SCENARIO_SOURCE = readFileSync(new URL("./run-scenario.ts", import.meta.url), "utf-8");
+const RUN_SOURCE = readFileSync(new URL("./run.ts", import.meta.url), "utf-8");
 
 describe("scenario child stage diagnostics", () => {
   it("returns only the last exact allowlisted marker for the expected scenario", () => {
@@ -89,30 +92,24 @@ describe("scenario child stage diagnostics", () => {
     },
   );
 
-  it("distinguishes each synchronous exit-path boundary", () => {
+  it("keeps the synchronous exit-intent boundary", () => {
     const output = [
       "S8A_CHILD_STAGE DONE scenario=inj-02 stage=cleanup elapsed-ms=119001",
       "S8A_CHILD_STAGE DONE scenario=inj-02 stage=exit-intent elapsed-ms=119002",
-      "S8A_CHILD_STAGE DONE scenario=inj-02 stage=exit-listeners elapsed-ms=119003",
-      "S8A_CHILD_STAGE DONE scenario=inj-02 stage=really-exit elapsed-ms=119004",
     ].join("\n");
     expect(parseLastScenarioChildStage(output.split("\n")[0], "inj-02")).toEqual({
       stage: "cleanup-done",
       elapsedMs: 119001,
     });
     expect(parseLastScenarioChildStage(output, "inj-02")).toEqual({
-      stage: "really-exit-done",
-      elapsedMs: 119004,
-    });
-    expect(parseLastScenarioChildStage(output.split("\n").slice(0, 3).join("\n"), "inj-02")).toEqual({
-      stage: "exit-listeners-done",
-      elapsedMs: 119003,
+      stage: "exit-intent-done",
+      elapsedMs: 119002,
     });
   });
 
   it.each(["i12345678", "12345678", "foo-i12345678-bar", "foo-12345678-bar"])(
     "keeps fixture-private scenario id %s out of diagnostics",
-    (privateId) => {
+    async (privateId) => {
       expect(safeScenarioDiagnosticId(privateId)).toBe("unknown");
       expect(
         parseLastScenarioChildStage(
@@ -121,7 +118,7 @@ describe("scenario child stage diagnostics", () => {
         ),
       ).toEqual({ stage: "none", elapsedMs: null });
 
-      const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+      const spawnProcess = vi.fn<ScenarioChildSpawn>(async (_command, _args, options) => {
         const home = options.env.CYCLING_COACH_HOME;
         if (home !== undefined) rmSync(home, { recursive: true, force: true });
         return {
@@ -132,7 +129,7 @@ describe("scenario child stage diagnostics", () => {
         };
       });
       const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-      const outcome = spawnScenarioChild(
+      const outcome = await spawnScenarioChild(
         {
           scenarioId: privateId,
           stage: "replay",
@@ -162,7 +159,6 @@ describe("scenario child stage diagnostics", () => {
       'emitScenarioStage("DONE", diagnosticScenario, finishStage)',
       'emitScenarioStage("START", diagnosticScenario, "cleanup")',
       'emitScenarioStage("DONE", diagnosticScenario, "cleanup")',
-      "installExitPathProbes(diagnosticScenario)",
       'emitSynchronousScenarioStage(diagnosticScenario, "exit-intent")',
       "process.exit(exitCode)",
     ];
@@ -174,21 +170,25 @@ describe("scenario child stage diagnostics", () => {
     expect(RUN_SCENARIO_SOURCE).toContain(
       'writeSync(process.stdout.fd, `${formatScenarioStage("DONE", scenarioId, stage)}\\n`)',
     );
-    expect(RUN_SCENARIO_SOURCE).toContain('process.on("exit", () => {');
-    expect(RUN_SCENARIO_SOURCE).toContain(
-      'emitSynchronousScenarioStage(scenarioId, "exit-listeners")',
-    );
-    expect(RUN_SCENARIO_SOURCE).toContain("const currentReallyExit = processWithReallyExit.reallyExit");
-    expect(RUN_SCENARIO_SOURCE).toContain(
-      'emitSynchronousScenarioStage(scenarioId, "really-exit")',
-    );
-    expect(RUN_SCENARIO_SOURCE).toContain(
-      "return Reflect.apply(currentReallyExit, this, args) as never",
-    );
+    expect(RUN_SCENARIO_SOURCE).not.toContain("installExitPathProbes");
+    expect(RUN_SCENARIO_SOURCE).not.toContain("reallyExit");
     expect(RUN_SCENARIO_SOURCE).not.toContain("rawListeners");
     expect(RUN_SCENARIO_SOURCE).not.toContain("getEventListeners");
     expect(RUN_SCENARIO_SOURCE).not.toContain(".listeners(");
     expect(RUN_SCENARIO_SOURCE).not.toContain(".toString(");
+  });
+
+  it("awaits every real scenario-child lane without synchronous scenario spawning", () => {
+    const spawnProcessSource = RUN_SOURCE.slice(
+      RUN_SOURCE.indexOf("export async function spawnScenarioProcess("),
+      RUN_SOURCE.indexOf("export interface ChildEnvParams"),
+    );
+    expect(spawnProcessSource).not.toContain("spawnSync");
+    expect(RUN_SOURCE).toContain("export async function spawnScenarioProcess(");
+    expect(RUN_SOURCE).toContain("export async function spawnScenarioChild(");
+    expect(RUN_SOURCE).toContain("export async function runSelfTestDeterminism(");
+    expect(RUN_SOURCE.match(/await spawnScenarioChild\(/g)).toHaveLength(4);
+    expect(RUN_SOURCE).toContain("const determinism = await runSelfTestDeterminism({");
   });
 });
 
@@ -370,19 +370,19 @@ describe("scenario child process", () => {
     if (home !== undefined) rmSync(home, { recursive: true, force: true });
   }
 
-  it("applies the fixed deadline and preserves a normal verdict", () => {
+  it("applies the fixed deadline and preserves a normal verdict", async () => {
     const verdict: ScenarioVerdict = {
       scenario: "turn-basic-wellness",
       pass: false,
       failures: [{ assertId: "A1", scenario: "turn-basic-wellness", detail: "drift" }],
     };
-    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+    const spawnProcess = vi.fn<ScenarioChildSpawn>(async (_command, _args, options) => {
       removeTempHome(options);
       return { stdout: `${JSON.stringify(verdict)}\n`, stderr: "fixed stderr", status: 1 };
     });
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
-    const outcome = spawnScenarioChild(params, spawnProcess);
+    const outcome = await spawnScenarioChild(params, spawnProcess);
 
     expect(outcome).toEqual({ verdict, exitCode: 1, stderr: "fixed stderr" });
     expect(spawnProcess).toHaveBeenCalledOnce();
@@ -396,8 +396,8 @@ describe("scenario child process", () => {
     ]);
   });
 
-  it("maps ETIMEDOUT to a stable path-free harness error", () => {
-    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+  it("maps ETIMEDOUT to a stable path-free harness error", async () => {
+    const spawnProcess = vi.fn<ScenarioChildSpawn>(async (_command, _args, options) => {
       removeTempHome(options);
       return {
         stdout:
@@ -409,7 +409,7 @@ describe("scenario child process", () => {
     });
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
-    const outcome = spawnScenarioChild(
+    const outcome = await spawnScenarioChild(
       { ...params, scenarioId: "../../private/athlete-home" },
       spawnProcess,
     );
@@ -427,8 +427,8 @@ describe("scenario child process", () => {
     ]);
   });
 
-  it("stops determinism before the second child and diff after a timeout", () => {
-    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+  it("stops determinism before the second child and diff after a timeout", async () => {
+    const spawnProcess = vi.fn<ScenarioChildSpawn>(async (_command, _args, options) => {
       removeTempHome(options);
       return {
         stdout: null,
@@ -440,7 +440,7 @@ describe("scenario child process", () => {
     const diffProcess = vi.fn(() => ({ status: 0, stdout: "" }));
     vi.spyOn(console, "log").mockImplementation(() => undefined);
 
-    const outcome = runSelfTestDeterminism(
+    const outcome = await runSelfTestDeterminism(
       {
         probeDirs: ["/fixed/probe-1", "/fixed/probe-2"],
         provider: "openai-codex",
@@ -455,20 +455,20 @@ describe("scenario child process", () => {
     expect(diffProcess).not.toHaveBeenCalled();
   });
 
-  it("runs both determinism children before the diff", () => {
+  it("runs both determinism children before the diff", async () => {
     const verdict: ScenarioVerdict = {
       scenario: "turn-basic-wellness",
       pass: true,
       failures: [],
     };
-    const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
+    const spawnProcess = vi.fn<ScenarioChildSpawn>(async (_command, _args, options) => {
       removeTempHome(options);
       return { stdout: `${JSON.stringify(verdict)}\n`, stderr: "", status: 0 };
     });
     const diffProcess = vi.fn(() => ({ status: 0, stdout: "" }));
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
-    const outcome = runSelfTestDeterminism(
+    const outcome = await runSelfTestDeterminism(
       {
         probeDirs: ["/fixed/probe-1", "/fixed/probe-2"],
         provider: "openai-codex",
@@ -509,60 +509,111 @@ describe("scenario child file capture", () => {
     captureParent = mkdtempSync(join(tmpdir(), "s8a-capture-test-"));
   }
 
-  it("passes file descriptors to the child, reads both streams, and removes the files", () => {
-    makeCaptureParent();
-    const spawnProcess = vi.fn<CaptureSpawn>((_command, _args, spawnOptions) => {
-      expect(spawnOptions.stdio[0]).toBe("ignore");
-      expect(spawnOptions.stdio[1]).toEqual(expect.any(Number));
-      expect(spawnOptions.stdio[2]).toEqual(expect.any(Number));
-      writeFileSync(spawnOptions.stdio[1], "fixed stdout", "utf-8");
-      writeFileSync(spawnOptions.stdio[2], "fixed stderr", "utf-8");
-      return { status: 0 };
+  function emittedChild(
+    outcome: { status: number | null } | { error: Error & { code?: string } },
+    kill = vi.fn(() => true),
+  ): ScenarioChildProcess {
+    const events = new EventEmitter();
+    const child = Object.assign(events, { kill }) as unknown as ScenarioChildProcess;
+    queueMicrotask(() => {
+      if ("error" in outcome) events.emit("error", outcome.error);
+      else events.emit("exit", outcome.status);
     });
+    return child;
+  }
 
-    const result = spawnScenarioProcess("node", ["child.js"], options, {
-      captureParent,
-      spawnProcess,
-    });
-
-    expect(result).toEqual({ stdout: "fixed stdout", stderr: "fixed stderr", status: 0 });
-    expect(spawnProcess).toHaveBeenCalledOnce();
-    expect(readdirSync(captureParent)).toEqual([]);
-  });
-
-  it.each(["ETIMEDOUT", "ENOENT"])(
-    "preserves the %s code with path-free output and removes the files",
-    (code) => {
+  it.each([0, 1] as const)(
+    "passes file descriptors through direct exit %i and removes the files",
+    async (status) => {
       makeCaptureParent();
-      const result = spawnScenarioProcess("node", ["child.js"], options, {
-        captureParent,
-        spawnProcess: (_command, _args, spawnOptions) => {
-          writeFileSync(spawnOptions.stdio[1], "fixed stage", "utf-8");
-          return {
-            status: null,
-            error: Object.assign(new Error("/private/athlete-home/token"), { code }),
-          };
-        },
+      const spawnProcess = vi.fn<CaptureSpawn>((_command, _args, spawnOptions) => {
+        expect(spawnOptions.stdio[0]).toBe("ignore");
+        expect(spawnOptions.stdio[1]).toEqual(expect.any(Number));
+        expect(spawnOptions.stdio[2]).toEqual(expect.any(Number));
+        writeFileSync(spawnOptions.stdio[1], "fixed stdout", "utf-8");
+        writeFileSync(spawnOptions.stdio[2], "fixed stderr", "utf-8");
+        return emittedChild({ status });
       });
 
-      expect(result).toMatchObject({
-        stdout: "fixed stage",
-        stderr: "",
-        status: null,
-        error: { message: "scenario child process failed", code },
+      const result = await spawnScenarioProcess("node", ["child.js"], options, {
+        captureParent,
+        spawnProcess,
       });
-      expect(JSON.stringify(result)).not.toContain("private/athlete-home");
+
+      expect(result).toEqual({ stdout: "fixed stdout", stderr: "fixed stderr", status });
+      expect(spawnProcess).toHaveBeenCalledOnce();
       expect(readdirSync(captureParent)).toEqual([]);
     },
   );
 
-  it("rejects oversized output without reading or retaining it", () => {
+  it("preserves a spawn failure code with path-free output and removes the files", async () => {
     makeCaptureParent();
-    const result = spawnScenarioProcess("node", ["child.js"], { ...options, maxBuffer: 4 }, {
+    const result = await spawnScenarioProcess("node", ["child.js"], options, {
+      captureParent,
+      spawnProcess: (_command, _args, spawnOptions) => {
+        writeFileSync(spawnOptions.stdio[1], "fixed stage", "utf-8");
+        return emittedChild({
+          error: Object.assign(new Error("/private/athlete-home/token"), { code: "ENOENT" }),
+        });
+      },
+    });
+
+    expect(result).toMatchObject({
+      stdout: "fixed stage",
+      stderr: "",
+      status: null,
+      error: { message: "scenario child process failed", code: "ENOENT" },
+    });
+    expect(JSON.stringify(result)).not.toContain("private/athlete-home");
+    expect(readdirSync(captureParent)).toEqual([]);
+  });
+
+  it("kills once and returns ETIMEDOUT at the fixed deadline", async () => {
+    makeCaptureParent();
+    vi.useFakeTimers();
+    const events = new EventEmitter();
+    const kill = vi.fn(() => true);
+    const child = Object.assign(events, { kill }) as unknown as ScenarioChildProcess;
+    try {
+      const resultPromise = spawnScenarioProcess("node", ["child.js"], options, {
+        captureParent,
+        spawnProcess: () => child,
+      });
+      let settled = false;
+      void resultPromise.then(() => {
+        settled = true;
+      });
+      await vi.advanceTimersByTimeAsync(120_000);
+      events.emit(
+        "error",
+        Object.assign(new Error("/private/athlete-home/token"), { code: "EIO" }),
+      );
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      expect(readdirSync(captureParent)).toHaveLength(1);
+      events.emit("exit", null);
+      const result = await resultPromise;
+
+      expect(kill).toHaveBeenCalledOnce();
+      expect(kill).toHaveBeenCalledWith("SIGKILL");
+      expect(result).toMatchObject({
+        status: null,
+        error: { message: "scenario child process failed", code: "ETIMEDOUT" },
+      });
+      expect(JSON.stringify(result)).not.toContain("private/athlete-home");
+      expect(readdirSync(captureParent)).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects oversized output without reading or retaining it", async () => {
+    makeCaptureParent();
+    const result = await spawnScenarioProcess("node", ["child.js"], { ...options, maxBuffer: 4 }, {
       captureParent,
       spawnProcess: (_command, _args, spawnOptions) => {
         writeFileSync(spawnOptions.stdio[1], "12345", "utf-8");
-        return { status: 0 };
+        return emittedChild({ status: 0 });
       },
     });
 
@@ -575,7 +626,7 @@ describe("scenario child file capture", () => {
     expect(readdirSync(captureParent)).toEqual([]);
   });
 
-  it("returns after the direct child exits while its descendant still holds stdio", () => {
+  it("returns after the direct child exits while its descendant still holds stdio", async () => {
     makeCaptureParent();
     let descendantPid: number | undefined;
     const descendantScript =
@@ -588,7 +639,7 @@ describe("scenario child file capture", () => {
     ].join(";");
 
     try {
-      const result = spawnScenarioProcess(
+      const result = await spawnScenarioProcess(
         process.execPath,
         ["-e", script],
         { ...options, cwd: captureParent, env: process.env },

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -31,44 +31,77 @@ const RUN_SCENARIO_SOURCE = readFileSync(new URL("./run-scenario.ts", import.met
 describe("scenario child stage diagnostics", () => {
   it("returns only the last exact allowlisted marker for the expected scenario", () => {
     const output = [
-      "S8A_CHILD_STAGE START scenario=inj-02 stage=setup",
-      "S8A_CHILD_STAGE DONE scenario=inj-02 stage=setup",
-      "S8A_CHILD_STAGE START scenario=inj-03 stage=cleanup",
-      "S8A_CHILD_STAGE START scenario=inj-02 stage=turn turn=0",
-      "S8A_CHILD_STAGE START scenario=inj-02 stage=private",
+      "S8A_CHILD_STAGE START scenario=inj-02 stage=setup elapsed-ms=0",
+      "S8A_CHILD_STAGE DONE scenario=inj-02 stage=setup elapsed-ms=7",
+      "S8A_CHILD_STAGE START scenario=inj-03 stage=cleanup elapsed-ms=8",
+      "S8A_CHILD_STAGE START scenario=inj-02 stage=turn turn=0 elapsed-ms=11",
+      "S8A_CHILD_STAGE START scenario=inj-02 stage=private elapsed-ms=12",
     ].join("\n");
-    expect(parseLastScenarioChildStage(output, "inj-02")).toBe("turn-0-start");
-    expect(parseLastScenarioChildStage(output, "unsafe/path")).toBe("none");
+    expect(parseLastScenarioChildStage(output, "inj-02")).toEqual({
+      stage: "turn-0-start",
+      elapsedMs: 11,
+    });
+    expect(parseLastScenarioChildStage(output, "unsafe/path")).toEqual({
+      stage: "none",
+      elapsedMs: null,
+    });
   });
 
   it("rejects malformed, mismatched, and structurally invalid markers", () => {
     expect(
       parseLastScenarioChildStage("S8A_CHILD_STAGE START scenario=inj-02 stage=turn", "inj-02"),
-    ).toBe("none");
+    ).toEqual({ stage: "none", elapsedMs: null });
     expect(
       parseLastScenarioChildStage(
-        "S8A_CHILD_STAGE DONE scenario=inj-02 stage=setup turn=0",
+        "S8A_CHILD_STAGE DONE scenario=inj-02 stage=setup turn=0 elapsed-ms=2",
         "inj-02",
       ),
-    ).toBe("none");
+    ).toEqual({ stage: "none", elapsedMs: null });
     expect(
       parseLastScenarioChildStage(
-        "prefix S8A_CHILD_STAGE START scenario=inj-02 stage=setup",
+        "prefix S8A_CHILD_STAGE START scenario=inj-02 stage=setup elapsed-ms=2",
         "inj-02",
       ),
-    ).toBe("none");
+    ).toEqual({ stage: "none", elapsedMs: null });
     expect(
       parseLastScenarioChildStage(
-        "S8A_CHILD_STAGE START scenario=inj-03 stage=setup",
+        "S8A_CHILD_STAGE START scenario=inj-03 stage=setup elapsed-ms=2",
         "inj-02",
       ),
-    ).toBe("none");
+    ).toEqual({ stage: "none", elapsedMs: null });
     expect(
       parseLastScenarioChildStage(
-        "S8A_CHILD_STAGE START scenario=inj-02 stage=turn turn=123456789",
+        "S8A_CHILD_STAGE START scenario=inj-02 stage=turn turn=123456789 elapsed-ms=2",
         "inj-02",
       ),
-    ).toBe("none");
+    ).toEqual({ stage: "none", elapsedMs: null });
+  });
+
+  it.each(["-1", "1.5", "0000001", "12345678"])(
+    "rejects unsafe elapsed value %s",
+    (elapsedMs) => {
+      expect(
+        parseLastScenarioChildStage(
+          `S8A_CHILD_STAGE DONE scenario=inj-02 stage=cleanup elapsed-ms=${elapsedMs}`,
+          "inj-02",
+        ),
+      ).toEqual({ stage: "none", elapsedMs: null });
+    },
+  );
+
+  it("distinguishes cleanup completion from synchronous exit intent", () => {
+    const output = [
+      "S8A_CHILD_STAGE DONE scenario=inj-02 stage=cleanup elapsed-ms=119001",
+      "S8A_CHILD_STAGE DONE scenario=inj-02 stage=exit-intent elapsed-ms=119002",
+    ].join("\n");
+    expect(parseLastScenarioChildStage(output.split("\n")[0], "inj-02")).toEqual({
+      stage: "cleanup-done",
+      elapsedMs: 119001,
+    });
+    expect(parseLastScenarioChildStage(output, "inj-02")).toEqual({
+      stage: "exit-intent-done",
+      elapsedMs: 119002,
+    });
   });
 
   it.each(["i12345678", "12345678", "foo-i12345678-bar", "foo-12345678-bar"])(
@@ -77,16 +110,16 @@ describe("scenario child stage diagnostics", () => {
       expect(safeScenarioDiagnosticId(privateId)).toBe("unknown");
       expect(
         parseLastScenarioChildStage(
-          `S8A_CHILD_STAGE START scenario=${privateId} stage=setup`,
+          `S8A_CHILD_STAGE START scenario=${privateId} stage=setup elapsed-ms=1`,
           privateId,
         ),
-      ).toBe("none");
+      ).toEqual({ stage: "none", elapsedMs: null });
 
       const spawnProcess = vi.fn<ScenarioChildSpawn>((_command, _args, options) => {
         const home = options.env.CYCLING_COACH_HOME;
         if (home !== undefined) rmSync(home, { recursive: true, force: true });
         return {
-          stdout: "S8A_CHILD_STAGE START scenario=unknown stage=setup\n",
+          stdout: "S8A_CHILD_STAGE START scenario=unknown stage=setup elapsed-ms=1\n",
           stderr: privateId,
           status: null,
           error: Object.assign(new Error(privateId), { code: "ETIMEDOUT" }),
@@ -107,7 +140,7 @@ describe("scenario child stage diagnostics", () => {
       const surfaced = JSON.stringify({ outcome, logs: log.mock.calls });
       expect(surfaced).not.toContain(privateId);
       expect(outcome.stderr).toBe(
-        "scenario child timed out: scenario=unknown stage=replay child-stage=setup-start",
+        "scenario child timed out: scenario=unknown stage=replay child-stage=setup-start child-elapsed-ms=1",
       );
       log.mockRestore();
     },
@@ -123,11 +156,16 @@ describe("scenario child stage diagnostics", () => {
       'emitScenarioStage("DONE", diagnosticScenario, finishStage)',
       'emitScenarioStage("START", diagnosticScenario, "cleanup")',
       'emitScenarioStage("DONE", diagnosticScenario, "cleanup")',
+      "emitExitIntent(diagnosticScenario)",
     ];
     const positions = markers.map((marker) => RUN_SCENARIO_SOURCE.indexOf(marker));
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect(positions).toEqual([...positions].sort((left, right) => left - right));
     expect(RUN_SCENARIO_SOURCE).toContain("/[0-9]{8,}/");
+    expect(RUN_SCENARIO_SOURCE).toContain("process.hrtime.bigint()");
+    expect(RUN_SCENARIO_SOURCE).toContain(
+      'writeSync(process.stdout.fd, `${formatScenarioStage("DONE", scenarioId, "exit-intent")}\\n`)',
+    );
   });
 });
 
@@ -340,7 +378,7 @@ describe("scenario child process", () => {
       removeTempHome(options);
       return {
         stdout:
-          "S8A_CHILD_STAGE START scenario=unknown stage=turn turn=3\n/private/athlete-home/token\n",
+          "S8A_CHILD_STAGE START scenario=unknown stage=turn turn=3 elapsed-ms=119000\n/private/athlete-home/token\n",
         stderr: "/private/athlete-home/token",
         status: null,
         error: Object.assign(new Error("/private/athlete-home/token"), { code: "ETIMEDOUT" }),
@@ -356,7 +394,8 @@ describe("scenario child process", () => {
     expect(outcome).toEqual({
       verdict: null,
       exitCode: 2,
-      stderr: "scenario child timed out: scenario=unknown stage=replay child-stage=turn-3-start",
+      stderr:
+        "scenario child timed out: scenario=unknown stage=replay child-stage=turn-3-start child-elapsed-ms=119000",
     });
     expect(JSON.stringify(outcome)).not.toContain("private/athlete-home");
     expect(log.mock.calls.map(([line]) => line)).toEqual([

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -17,7 +17,10 @@ import {
   runSelfTestDeterminism,
   safeScenarioDiagnosticId,
   spawnScenarioChild,
+  spawnScenarioProcess,
+  type ScenarioChildCaptureDependencies,
   type ScenarioChildSpawn,
+  type ScenarioChildSpawnOptions,
   usage,
 } from "./run.js";
 import { AUTH_PROFILES_SOURCE_ENV } from "./lib/codex-auth.js";
@@ -422,6 +425,128 @@ describe("scenario child process", () => {
       "S8A_CHILD START scenario=turn-basic-wellness stage=self-test-determinism-2",
       "S8A_CHILD DONE scenario=turn-basic-wellness stage=self-test-determinism-2 outcome=exit-0",
     ]);
+  });
+});
+
+describe("scenario child file capture", () => {
+  let captureParent: string;
+  type CaptureSpawn = NonNullable<ScenarioChildCaptureDependencies["spawnProcess"]>;
+
+  afterEach(() => rmSync(captureParent, { recursive: true, force: true }));
+
+  const options: ScenarioChildSpawnOptions = {
+    cwd: "/fixed/repo",
+    env: { FIXED: "value" },
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 120_000,
+    killSignal: "SIGKILL",
+  };
+
+  function makeCaptureParent(): void {
+    captureParent = mkdtempSync(join(tmpdir(), "s8a-capture-test-"));
+  }
+
+  it("passes file descriptors to the child, reads both streams, and removes the files", () => {
+    makeCaptureParent();
+    const spawnProcess = vi.fn<CaptureSpawn>((_command, _args, spawnOptions) => {
+      expect(spawnOptions.stdio[0]).toBe("ignore");
+      expect(spawnOptions.stdio[1]).toEqual(expect.any(Number));
+      expect(spawnOptions.stdio[2]).toEqual(expect.any(Number));
+      writeFileSync(spawnOptions.stdio[1], "fixed stdout", "utf-8");
+      writeFileSync(spawnOptions.stdio[2], "fixed stderr", "utf-8");
+      return { status: 0 };
+    });
+
+    const result = spawnScenarioProcess("node", ["child.js"], options, {
+      captureParent,
+      spawnProcess,
+    });
+
+    expect(result).toEqual({ stdout: "fixed stdout", stderr: "fixed stderr", status: 0 });
+    expect(spawnProcess).toHaveBeenCalledOnce();
+    expect(readdirSync(captureParent)).toEqual([]);
+  });
+
+  it.each(["ETIMEDOUT", "ENOENT"])(
+    "preserves the %s code with path-free output and removes the files",
+    (code) => {
+      makeCaptureParent();
+      const result = spawnScenarioProcess("node", ["child.js"], options, {
+        captureParent,
+        spawnProcess: (_command, _args, spawnOptions) => {
+          writeFileSync(spawnOptions.stdio[1], "fixed stage", "utf-8");
+          return {
+            status: null,
+            error: Object.assign(new Error("/private/athlete-home/token"), { code }),
+          };
+        },
+      });
+
+      expect(result).toMatchObject({
+        stdout: "fixed stage",
+        stderr: "",
+        status: null,
+        error: { message: "scenario child process failed", code },
+      });
+      expect(JSON.stringify(result)).not.toContain("private/athlete-home");
+      expect(readdirSync(captureParent)).toEqual([]);
+    },
+  );
+
+  it("rejects oversized output without reading or retaining it", () => {
+    makeCaptureParent();
+    const result = spawnScenarioProcess("node", ["child.js"], { ...options, maxBuffer: 4 }, {
+      captureParent,
+      spawnProcess: (_command, _args, spawnOptions) => {
+        writeFileSync(spawnOptions.stdio[1], "12345", "utf-8");
+        return { status: 0 };
+      },
+    });
+
+    expect(result).toMatchObject({
+      stdout: null,
+      stderr: null,
+      status: null,
+      error: { message: "scenario child output exceeded limit", code: "ENOBUFS" },
+    });
+    expect(readdirSync(captureParent)).toEqual([]);
+  });
+
+  it("returns after the direct child exits while its descendant still holds stdio", () => {
+    makeCaptureParent();
+    let descendantPid: number | undefined;
+    const descendantScript =
+      'setTimeout(() => process.stdout.write("descendant-finished"), 30000)';
+    const script = [
+      'const { spawn } = require("node:child_process")',
+      `const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}], { stdio: ["ignore", 1, 2] })`,
+      'process.stdout.write(`direct-complete:${child.pid}\\n`)',
+      "process.exit(0)",
+    ].join(";");
+
+    try {
+      const result = spawnScenarioProcess(
+        process.execPath,
+        ["-e", script],
+        { ...options, cwd: captureParent, env: process.env },
+        { captureParent },
+      );
+      const pidMatch = /^direct-complete:([0-9]+)\n$/.exec(result.stdout ?? "");
+      descendantPid = pidMatch === null ? undefined : Number.parseInt(pidMatch[1], 10);
+
+      expect(result.status).toBe(0);
+      expect(result.error).toBeUndefined();
+      expect(Number.isSafeInteger(descendantPid)).toBe(true);
+      expect(result.stdout).not.toContain("descendant-finished");
+      expect(readdirSync(captureParent)).toEqual([]);
+    } finally {
+      if (descendantPid !== undefined) {
+        try {
+          process.kill(descendantPid, "SIGKILL");
+        } catch {}
+      }
+    }
   });
 });
 

--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -89,18 +89,24 @@ describe("scenario child stage diagnostics", () => {
     },
   );
 
-  it("distinguishes cleanup completion from synchronous exit intent", () => {
+  it("distinguishes each synchronous exit-path boundary", () => {
     const output = [
       "S8A_CHILD_STAGE DONE scenario=inj-02 stage=cleanup elapsed-ms=119001",
       "S8A_CHILD_STAGE DONE scenario=inj-02 stage=exit-intent elapsed-ms=119002",
+      "S8A_CHILD_STAGE DONE scenario=inj-02 stage=exit-listeners elapsed-ms=119003",
+      "S8A_CHILD_STAGE DONE scenario=inj-02 stage=really-exit elapsed-ms=119004",
     ].join("\n");
     expect(parseLastScenarioChildStage(output.split("\n")[0], "inj-02")).toEqual({
       stage: "cleanup-done",
       elapsedMs: 119001,
     });
     expect(parseLastScenarioChildStage(output, "inj-02")).toEqual({
-      stage: "exit-intent-done",
-      elapsedMs: 119002,
+      stage: "really-exit-done",
+      elapsedMs: 119004,
+    });
+    expect(parseLastScenarioChildStage(output.split("\n").slice(0, 3).join("\n"), "inj-02")).toEqual({
+      stage: "exit-listeners-done",
+      elapsedMs: 119003,
     });
   });
 
@@ -156,7 +162,9 @@ describe("scenario child stage diagnostics", () => {
       'emitScenarioStage("DONE", diagnosticScenario, finishStage)',
       'emitScenarioStage("START", diagnosticScenario, "cleanup")',
       'emitScenarioStage("DONE", diagnosticScenario, "cleanup")',
-      "emitExitIntent(diagnosticScenario)",
+      "installExitPathProbes(diagnosticScenario)",
+      'emitSynchronousScenarioStage(diagnosticScenario, "exit-intent")',
+      "process.exit(exitCode)",
     ];
     const positions = markers.map((marker) => RUN_SCENARIO_SOURCE.indexOf(marker));
     expect(positions.every((position) => position >= 0)).toBe(true);
@@ -164,8 +172,23 @@ describe("scenario child stage diagnostics", () => {
     expect(RUN_SCENARIO_SOURCE).toContain("/[0-9]{8,}/");
     expect(RUN_SCENARIO_SOURCE).toContain("process.hrtime.bigint()");
     expect(RUN_SCENARIO_SOURCE).toContain(
-      'writeSync(process.stdout.fd, `${formatScenarioStage("DONE", scenarioId, "exit-intent")}\\n`)',
+      'writeSync(process.stdout.fd, `${formatScenarioStage("DONE", scenarioId, stage)}\\n`)',
     );
+    expect(RUN_SCENARIO_SOURCE).toContain('process.on("exit", () => {');
+    expect(RUN_SCENARIO_SOURCE).toContain(
+      'emitSynchronousScenarioStage(scenarioId, "exit-listeners")',
+    );
+    expect(RUN_SCENARIO_SOURCE).toContain("const currentReallyExit = processWithReallyExit.reallyExit");
+    expect(RUN_SCENARIO_SOURCE).toContain(
+      'emitSynchronousScenarioStage(scenarioId, "really-exit")',
+    );
+    expect(RUN_SCENARIO_SOURCE).toContain(
+      "return Reflect.apply(currentReallyExit, this, args) as never",
+    );
+    expect(RUN_SCENARIO_SOURCE).not.toContain("rawListeners");
+    expect(RUN_SCENARIO_SOURCE).not.toContain("getEventListeners");
+    expect(RUN_SCENARIO_SOURCE).not.toContain(".listeners(");
+    expect(RUN_SCENARIO_SOURCE).not.toContain(".toString(");
   });
 });
 

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -437,11 +437,11 @@ export function spawnScenarioChild(
   });
   if (result.error?.code === "ETIMEDOUT") {
     console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=timeout`);
-    const childStage = parseLastScenarioChildStage(result.stdout ?? "", safeScenarioId);
+    const childDiagnostic = parseLastScenarioChildStage(result.stdout ?? "", safeScenarioId);
     return {
       verdict: null,
       exitCode: 2,
-      stderr: `scenario child timed out: scenario=${safeScenarioId} stage=${params.stage} child-stage=${childStage}`,
+      stderr: `scenario child timed out: scenario=${safeScenarioId} stage=${params.stage} child-stage=${childDiagnostic.stage} child-elapsed-ms=${childDiagnostic.elapsedMs ?? "none"}`,
     };
   }
   const stdoutLines = (result.stdout ?? "").split("\n").filter((l) => l.trim() !== "");
@@ -462,22 +462,34 @@ export function spawnScenarioChild(
   return { verdict, exitCode, stderr: result.stderr ?? "" };
 }
 
-export function parseLastScenarioChildStage(output: string, scenarioId: string): string {
+export interface ScenarioChildDiagnostic {
+  stage: string;
+  elapsedMs: number | null;
+}
+
+export function parseLastScenarioChildStage(
+  output: string,
+  scenarioId: string,
+): ScenarioChildDiagnostic {
   const maxDiagnosticTurnIndex = 99;
   const safeScenarioId = safeScenarioDiagnosticId(scenarioId);
-  let last = "none";
+  let last: ScenarioChildDiagnostic = { stage: "none", elapsedMs: null };
   for (const line of output.split("\n")) {
     const match =
-      /^S8A_CHILD_STAGE (START|DONE) scenario=([a-z0-9]+(?:-[a-z0-9]+)*) stage=(setup|turn|finish-replay|finish-record|cleanup)(?: turn=(0|[1-9][0-9]*))?$/.exec(
+      /^S8A_CHILD_STAGE (START|DONE) scenario=([a-z0-9]+(?:-[a-z0-9]+)*) stage=(setup|turn|finish-replay|finish-record|cleanup|exit-intent)(?: turn=(0|[1-9][0-9]*))? elapsed-ms=(0|[1-9][0-9]{0,6})$/.exec(
         line.trimEnd(),
       );
     if (match === null || match[2] !== safeScenarioId) continue;
     const phase = match[1].toLowerCase();
     const stage = match[3];
     const turn = match[4];
+    const elapsedMs = Number.parseInt(match[5], 10);
     if ((stage === "turn") !== (turn !== undefined)) continue;
     if (turn !== undefined && Number.parseInt(turn, 10) > maxDiagnosticTurnIndex) continue;
-    last = stage === "turn" ? `turn-${turn}-${phase}` : `${stage}-${phase}`;
+    last = {
+      stage: stage === "turn" ? `turn-${turn}-${phase}` : `${stage}-${phase}`,
+      elapsedMs,
+    };
   }
   return last;
 }

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -3,7 +3,7 @@
 // config dir is resolved at import time) and never constructs the agent itself.
 // The parent's clock is never frozen: two consecutive runs always land in
 // distinct run dirs.
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import {
   closeSync,
   existsSync,
@@ -195,7 +195,13 @@ export type ScenarioChildSpawn = (
   command: string,
   args: readonly string[],
   options: ScenarioChildSpawnOptions,
-) => ScenarioChildSpawnResult;
+) => Promise<ScenarioChildSpawnResult>;
+
+export interface ScenarioChildProcess {
+  once(event: "error", listener: (error: Error & { code?: string }) => void): ScenarioChildProcess;
+  once(event: "exit", listener: (code: number | null) => void): ScenarioChildProcess;
+  kill(signal: "SIGKILL"): boolean;
+}
 
 export interface ScenarioChildCaptureDependencies {
   captureParent?: string;
@@ -205,11 +211,9 @@ export interface ScenarioChildCaptureDependencies {
     options: {
       cwd: string;
       env: NodeJS.ProcessEnv;
-      timeout: number;
-      killSignal: "SIGKILL";
       stdio: ["ignore", number, number];
     },
-  ) => { status: number | null; error?: Error & { code?: string } };
+  ) => ScenarioChildProcess;
 }
 
 function readCapturedOutput(
@@ -234,12 +238,12 @@ function readCapturedOutput(
   }
 }
 
-export function spawnScenarioProcess(
+export async function spawnScenarioProcess(
   command: string,
   args: readonly string[],
   options: ScenarioChildSpawnOptions,
   dependencies: ScenarioChildCaptureDependencies = {},
-): ScenarioChildSpawnResult {
+): Promise<ScenarioChildSpawnResult> {
   let captureDir: string;
   try {
     captureDir = mkdtempSync(join(dependencies.captureParent ?? tmpdir(), "s8a-child-capture-"));
@@ -267,14 +271,45 @@ export function spawnScenarioProcess(
     const spawnOptions = {
       cwd: options.cwd,
       env: options.env,
-      timeout: options.timeout,
-      killSignal: options.killSignal,
       stdio: ["ignore", stdoutFd, stderrFd] as ["ignore", number, number],
     };
-    const spawned =
+    const spawned: ScenarioChildProcess =
       dependencies.spawnProcess === undefined
-        ? spawnSync(command, [...args], spawnOptions)
+        ? (spawn(command, [...args], spawnOptions) as ScenarioChildProcess)
         : dependencies.spawnProcess(command, args, spawnOptions);
+    const processOutcome = await new Promise<{
+      status: number | null;
+      error?: Error & { code?: string };
+    }>((resolveProcess) => {
+      let settled = false;
+      let timedOut = false;
+      const finish = (result: { status: number | null; error?: Error & { code?: string } }) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolveProcess(result);
+      };
+      const timer = setTimeout(() => {
+        timedOut = true;
+        spawned.kill(options.killSignal);
+      }, options.timeout);
+      spawned.once("error", (error) => {
+        if (timedOut) return;
+        finish({ status: null, error });
+      });
+      spawned.once("exit", (status) =>
+        finish(
+          timedOut
+            ? {
+                status: null,
+                error: Object.assign(new Error("scenario child timed out"), {
+                  code: "ETIMEDOUT",
+                }),
+              }
+            : { status },
+        ),
+      );
+    });
     closeSync(stdoutFd);
     stdoutFd = undefined;
     closeSync(stderrFd);
@@ -292,16 +327,16 @@ export function spawnScenarioProcess(
       };
     } else {
       const processErrorCode =
-        spawned.error !== undefined &&
-        "code" in spawned.error &&
-        typeof spawned.error.code === "string"
-          ? spawned.error.code
+        processOutcome.error !== undefined &&
+        "code" in processOutcome.error &&
+        typeof processOutcome.error.code === "string"
+          ? processOutcome.error.code
           : undefined;
       outcome = {
         stdout: capturedStdout.output,
         stderr: capturedStderr.output,
-        status: spawned.status,
-        ...(spawned.error === undefined
+        status: processOutcome.status,
+        ...(processOutcome.error === undefined
           ? {}
           : {
               error: Object.assign(new Error("scenario child process failed"), {
@@ -390,7 +425,7 @@ export function buildChildEnv(params: ChildEnvParams): Record<string, string | u
   return env;
 }
 
-export function spawnScenarioChild(
+export async function spawnScenarioChild(
   params: {
     scenarioId: string;
     stage: ScenarioChildStage;
@@ -405,7 +440,7 @@ export function spawnScenarioChild(
     authProfilesSource?: string;
   },
   spawnProcess: ScenarioChildSpawn = spawnScenarioProcess,
-): ChildOutcome {
+): Promise<ChildOutcome> {
   const safeScenarioId = safeScenarioDiagnosticId(params.scenarioId);
   console.log(`S8A_CHILD START scenario=${safeScenarioId} stage=${params.stage}`);
   const tempHome = mkdtempSync(join(tmpdir(), "s8a-home-"));
@@ -427,7 +462,7 @@ export function spawnScenarioChild(
     scenarioEnv: params.scenarioEnv,
   });
 
-  const result = spawnProcess(process.execPath, ["--import", "tsx", ...childArgs], {
+  const result = await spawnProcess(process.execPath, ["--import", "tsx", ...childArgs], {
     cwd: REPO_ROOT,
     env,
     encoding: "utf-8",
@@ -476,7 +511,7 @@ export function parseLastScenarioChildStage(
   let last: ScenarioChildDiagnostic = { stage: "none", elapsedMs: null };
   for (const line of output.split("\n")) {
     const match =
-      /^S8A_CHILD_STAGE (START|DONE) scenario=([a-z0-9]+(?:-[a-z0-9]+)*) stage=(setup|turn|finish-replay|finish-record|cleanup|exit-intent|exit-listeners|really-exit)(?: turn=(0|[1-9][0-9]*))? elapsed-ms=(0|[1-9][0-9]{0,6})$/.exec(
+      /^S8A_CHILD_STAGE (START|DONE) scenario=([a-z0-9]+(?:-[a-z0-9]+)*) stage=(setup|turn|finish-replay|finish-record|cleanup|exit-intent)(?: turn=(0|[1-9][0-9]*))? elapsed-ms=(0|[1-9][0-9]{0,6})$/.exec(
         line.trimEnd(),
       );
     if (match === null || match[2] !== safeScenarioId) continue;
@@ -506,7 +541,7 @@ export type SelfTestDiffSpawn = (
   options: { encoding: "utf-8" },
 ) => { status: number | null; stdout: string | null };
 
-export function runSelfTestDeterminism(
+export async function runSelfTestDeterminism(
   params: {
     probeDirs: readonly [string, string];
     provider: S8aProvider;
@@ -515,15 +550,16 @@ export function runSelfTestDeterminism(
   },
   spawnProcess: ScenarioChildSpawn = spawnScenarioProcess,
   diffProcess: SelfTestDiffSpawn = (command, args, options) => spawnSync(command, args, options),
-):
+): Promise<
   | { kind: "harness-error"; outcome: ChildOutcome }
-  | { kind: "complete"; deterministic: boolean; diffOutput: string } {
+  | { kind: "complete"; deterministic: boolean; diffOutput: string }
+> {
   const probes = [
     { dir: params.probeDirs[0], stage: "self-test-determinism-1" },
     { dir: params.probeDirs[1], stage: "self-test-determinism-2" },
   ] as const;
   for (const probe of probes) {
-    const outcome = spawnScenarioChild(
+    const outcome = await spawnScenarioChild(
       {
         scenarioId: "turn-basic-wellness",
         stage: probe.stage,
@@ -630,7 +666,7 @@ async function replayScenarios(params: {
   for (const entry of params.entries) {
     const fixtureDir = join(HERE, "fixtures", entry.id);
     const lane = readRecordingLane(fixtureDir);
-    const outcome = spawnScenarioChild({
+    const outcome = await spawnScenarioChild({
       scenarioId: entry.id,
       stage: "replay",
       mode: "replay",
@@ -727,7 +763,7 @@ async function main(): Promise<void> {
       process.exit(2);
     }
     console.log(`recording lane: ${lane.provider} / ${lane.model}`);
-    const outcome = spawnScenarioChild({
+    const outcome = await spawnScenarioChild({
       scenarioId: entry.id,
       stage: "record",
       mode: "record",
@@ -752,7 +788,7 @@ async function main(): Promise<void> {
     // Probe (a): drift inversion. Every self-test child runs --no-supersessions
     // so no registry entry can ever downgrade a seeded failure to WARN.
     const driftLane = readRecordingLane(join(HERE, "fixtures", "drift-must-fail"));
-    const driftOutcome = spawnScenarioChild({
+    const driftOutcome = await spawnScenarioChild({
       scenarioId: "turn-basic-wellness",
       stage: "self-test-drift",
       mode: "replay",
@@ -782,7 +818,7 @@ async function main(): Promise<void> {
       join(runDir, "turn-basic-wellness-probe2"),
     ] as const;
     const probeLane = readRecordingLane(join(HERE, "fixtures", "turn-basic-wellness"));
-    const determinism = runSelfTestDeterminism({
+    const determinism = await runSelfTestDeterminism({
       probeDirs,
       provider: probeLane.provider,
       llmModel: probeLane.model,

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -476,7 +476,7 @@ export function parseLastScenarioChildStage(
   let last: ScenarioChildDiagnostic = { stage: "none", elapsedMs: null };
   for (const line of output.split("\n")) {
     const match =
-      /^S8A_CHILD_STAGE (START|DONE) scenario=([a-z0-9]+(?:-[a-z0-9]+)*) stage=(setup|turn|finish-replay|finish-record|cleanup|exit-intent)(?: turn=(0|[1-9][0-9]*))? elapsed-ms=(0|[1-9][0-9]{0,6})$/.exec(
+      /^S8A_CHILD_STAGE (START|DONE) scenario=([a-z0-9]+(?:-[a-z0-9]+)*) stage=(setup|turn|finish-replay|finish-record|cleanup|exit-intent|exit-listeners|really-exit)(?: turn=(0|[1-9][0-9]*))? elapsed-ms=(0|[1-9][0-9]{0,6})$/.exec(
         line.trimEnd(),
       );
     if (match === null || match[2] !== safeScenarioId) continue;

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -415,6 +415,7 @@ export function buildChildEnv(params: ChildEnvParams): Record<string, string | u
   for (const key of SCRUBBED_ENV_KNOBS) {
     delete env[key];
   }
+  delete env.NODE_OPTIONS;
   if (params.scenarioEnv?.HISTORY_TOKEN_BUDGET_RATIO === undefined) {
     delete env.HISTORY_TOKEN_BUDGET_RATIO;
   }
@@ -462,14 +463,19 @@ export async function spawnScenarioChild(
     scenarioEnv: params.scenarioEnv,
   });
 
-  const result = await spawnProcess(process.execPath, ["--import", "tsx", ...childArgs], {
-    cwd: REPO_ROOT,
-    env,
-    encoding: "utf-8",
-    maxBuffer: 64 * 1024 * 1024,
-    timeout: 120_000,
-    killSignal: "SIGKILL",
-  });
+  const captureNativeExitUrl = pathToFileURL(join(HERE, "capture-native-exit.mjs")).href;
+  const result = await spawnProcess(
+    process.execPath,
+    ["--import", captureNativeExitUrl, "--import", "tsx", ...childArgs],
+    {
+      cwd: REPO_ROOT,
+      env,
+      encoding: "utf-8",
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 120_000,
+      killSignal: "SIGKILL",
+    },
+  );
   if (result.error?.code === "ETIMEDOUT") {
     console.log(`S8A_CHILD DONE scenario=${safeScenarioId} stage=${params.stage} outcome=timeout`);
     const childDiagnostic = parseLastScenarioChildStage(result.stdout ?? "", safeScenarioId);

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -4,7 +4,18 @@
 // The parent's clock is never frozen: two consecutive runs always land in
 // distinct run dirs.
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -171,18 +182,178 @@ export interface ScenarioChildSpawnResult {
   error?: Error & { code?: string };
 }
 
+export interface ScenarioChildSpawnOptions {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  encoding: "utf-8";
+  maxBuffer: number;
+  timeout: number;
+  killSignal: "SIGKILL";
+}
+
 export type ScenarioChildSpawn = (
   command: string,
   args: readonly string[],
-  options: {
-    cwd: string;
-    env: NodeJS.ProcessEnv;
-    encoding: "utf-8";
-    maxBuffer: number;
-    timeout: number;
-    killSignal: "SIGKILL";
-  },
+  options: ScenarioChildSpawnOptions,
 ) => ScenarioChildSpawnResult;
+
+export interface ScenarioChildCaptureDependencies {
+  captureParent?: string;
+  spawnProcess?: (
+    command: string,
+    args: readonly string[],
+    options: {
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+      timeout: number;
+      killSignal: "SIGKILL";
+      stdio: ["ignore", number, number];
+    },
+  ) => { status: number | null; error?: Error & { code?: string } };
+}
+
+function readCapturedOutput(
+  path: string,
+  encoding: "utf-8",
+  maxBuffer: number,
+): { output: string | null; overflow: boolean } {
+  const fd = openSync(path, "r");
+  try {
+    const length = fstatSync(fd).size;
+    if (length > maxBuffer) return { output: null, overflow: true };
+    const buffer = Buffer.alloc(length);
+    let offset = 0;
+    while (offset < length) {
+      const bytesRead = readSync(fd, buffer, offset, length - offset, offset);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    return { output: buffer.subarray(0, offset).toString(encoding), overflow: false };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export function spawnScenarioProcess(
+  command: string,
+  args: readonly string[],
+  options: ScenarioChildSpawnOptions,
+  dependencies: ScenarioChildCaptureDependencies = {},
+): ScenarioChildSpawnResult {
+  let captureDir: string;
+  try {
+    captureDir = mkdtempSync(join(dependencies.captureParent ?? tmpdir(), "s8a-child-capture-"));
+  } catch {
+    return {
+      stdout: null,
+      stderr: null,
+      status: null,
+      error: Object.assign(new Error("scenario child capture failed"), { code: "EIO" }),
+    };
+  }
+  const stdoutPath = join(captureDir, "stdout");
+  const stderrPath = join(captureDir, "stderr");
+  let stdoutFd: number | undefined;
+  let stderrFd: number | undefined;
+  let outcome: ScenarioChildSpawnResult = {
+    stdout: null,
+    stderr: null,
+    status: null,
+    error: Object.assign(new Error("scenario child capture failed"), { code: "EIO" }),
+  };
+  try {
+    stdoutFd = openSync(stdoutPath, "w");
+    stderrFd = openSync(stderrPath, "w");
+    const spawnOptions = {
+      cwd: options.cwd,
+      env: options.env,
+      timeout: options.timeout,
+      killSignal: options.killSignal,
+      stdio: ["ignore", stdoutFd, stderrFd] as ["ignore", number, number],
+    };
+    const spawned =
+      dependencies.spawnProcess === undefined
+        ? spawnSync(command, [...args], spawnOptions)
+        : dependencies.spawnProcess(command, args, spawnOptions);
+    closeSync(stdoutFd);
+    stdoutFd = undefined;
+    closeSync(stderrFd);
+    stderrFd = undefined;
+    const capturedStdout = readCapturedOutput(stdoutPath, options.encoding, options.maxBuffer);
+    const capturedStderr = readCapturedOutput(stderrPath, options.encoding, options.maxBuffer);
+    if (capturedStdout.overflow || capturedStderr.overflow) {
+      outcome = {
+        stdout: null,
+        stderr: null,
+        status: null,
+        error: Object.assign(new Error("scenario child output exceeded limit"), {
+          code: "ENOBUFS",
+        }),
+      };
+    } else {
+      const processErrorCode =
+        spawned.error !== undefined &&
+        "code" in spawned.error &&
+        typeof spawned.error.code === "string"
+          ? spawned.error.code
+          : undefined;
+      outcome = {
+        stdout: capturedStdout.output,
+        stderr: capturedStderr.output,
+        status: spawned.status,
+        ...(spawned.error === undefined
+          ? {}
+          : {
+              error: Object.assign(new Error("scenario child process failed"), {
+                code: processErrorCode,
+              }),
+            }),
+      };
+    }
+  } catch {
+    outcome = {
+      stdout: null,
+      stderr: null,
+      status: null,
+      error: Object.assign(new Error("scenario child capture failed"), { code: "EIO" }),
+    };
+  } finally {
+    let closeFailed = false;
+    if (stdoutFd !== undefined) {
+      try {
+        closeSync(stdoutFd);
+      } catch {
+        closeFailed = true;
+      }
+    }
+    if (stderrFd !== undefined) {
+      try {
+        closeSync(stderrFd);
+      } catch {
+        closeFailed = true;
+      }
+    }
+    if (closeFailed) {
+      outcome = {
+        stdout: null,
+        stderr: null,
+        status: null,
+        error: Object.assign(new Error("scenario child capture cleanup failed"), { code: "EIO" }),
+      };
+    }
+    try {
+      rmSync(captureDir, { recursive: true, force: true });
+    } catch {
+      outcome = {
+        stdout: null,
+        stderr: null,
+        status: null,
+        error: Object.assign(new Error("scenario child capture cleanup failed"), { code: "EIO" }),
+      };
+    }
+  }
+  return outcome;
+}
 
 export interface ChildEnvParams {
   base: Record<string, string | undefined>;
@@ -233,7 +404,7 @@ export function spawnScenarioChild(
     anthropicKey?: string;
     authProfilesSource?: string;
   },
-  spawnProcess: ScenarioChildSpawn = (command, args, options) => spawnSync(command, args, options),
+  spawnProcess: ScenarioChildSpawn = spawnScenarioProcess,
 ): ChildOutcome {
   const safeScenarioId = safeScenarioDiagnosticId(params.scenarioId);
   console.log(`S8A_CHILD START scenario=${safeScenarioId} stage=${params.stage}`);
@@ -330,7 +501,7 @@ export function runSelfTestDeterminism(
     llmModel: string;
     anthropicKey?: string;
   },
-  spawnProcess: ScenarioChildSpawn = (command, args, options) => spawnSync(command, args, options),
+  spawnProcess: ScenarioChildSpawn = spawnScenarioProcess,
   diffProcess: SelfTestDiffSpawn = (command, args, options) => spawnSync(command, args, options),
 ):
   | { kind: "harness-error"; outcome: ChildOutcome }


### PR DESCRIPTION
## Summary

- Capture S8A scenario-child stdout and stderr in private regular files.
- Observe the direct child asynchronously through its `exit` event instead of waiting for inherited process resources to close.
- Capture Node’s native `process.reallyExit` before `tsx` and application imports, then restore it at the final child boundary before normal `process.exit`.
- Scrub inherited `NODE_OPTIONS` so operator preloads cannot run before the native-exit capture.
- Keep scenarios sequential and preserve exact status, timeout, privacy, output-size, cleanup, and ordinary exit-hook contracts.

## Verification

- `pnpm exec vitest run tools/s8a/run.test.ts --maxWorkers=1` — 43 passed on Node 24.
- `pnpm check:types` — passed on Node 24.
- `pnpm check` — passed with 19 existing warnings.
- `pnpm s8a --scenario=turn-basic-wellness` — passed with the documented supersession warning.
- Fresh read-only review — PASS.

## Limits

- `timeout = 120000 ms` and `killSignal = SIGKILL` are unchanged.
- `maxBuffer = 64 MiB` keeps the same value; file-backed capture applies it as a post-exit per-stream acceptance and memory-read bound.
- Diagnostic elapsed values are limited to `0–9999999 ms` so fixture-shaped long numeric identifiers cannot enter timeout output.
