### PR TITLE
fix: enforce S8A capture limit live

### DIFF
--- a/tools/s8a/run.test.ts
+++ b/tools/s8a/run.test.ts
@@ -342,7 +342,7 @@ describe("scenario child process", () => {
   it("rejects captured output larger than maxBuffer", () => {
     const result = spawnScenarioChildCaptured(
       process.execPath,
-      ["-e", 'process.stdout.write("123456789")'],
+      ["-e", 'process.stdout.write("123456789"); setInterval(() => {}, 1_000)'],
       {
         cwd: process.cwd(),
         env: process.env,

--- a/tools/s8a/run.ts
+++ b/tools/s8a/run.ts
@@ -4,17 +4,7 @@
 // The parent's clock is never frozen: two consecutive runs always land in
 // distinct run dirs.
 import { spawnSync } from "node:child_process";
-import {
-  closeSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  openSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -38,6 +28,7 @@ const REPO_ROOT = resolve(HERE, "..", "..");
 const RECORD_PROVIDER_DEFAULT: S8aProvider = "openai-codex";
 const LEGACY_HEADER_PROVIDER: S8aProvider = "anthropic";
 const REPLAY_DUMMY_KEY = "s8a-replay-dummy";
+const CAPTURE_HELPER_SHUTDOWN_GRACE_MS = 5_000;
 
 // Stray operator knobs would silently change the child's model lane, budgets,
 // or session policy and break replay determinism. Source of truth for what
@@ -196,39 +187,64 @@ export type ScenarioChildSpawn = (
 
 export const spawnScenarioChildCaptured: ScenarioChildSpawn = (command, args, options) => {
   const ioDir = mkdtempSync(join(tmpdir(), "s8a-child-io-"));
+  const requestPath = join(ioDir, "request.json");
+  const resultPath = join(ioDir, "result.json");
   const stdoutPath = join(ioDir, "stdout");
   const stderrPath = join(ioDir, "stderr");
-  let stdoutFd: number | undefined;
-  let stderrFd: number | undefined;
   try {
-    stdoutFd = openSync(stdoutPath, "w");
-    stderrFd = openSync(stderrPath, "w");
-    const result = spawnSync(command, [...args], {
-      cwd: options.cwd,
-      env: options.env,
-      timeout: options.timeout,
-      killSignal: options.killSignal,
-      stdio: ["ignore", stdoutFd, stderrFd],
-    });
-    const stdoutSize = statSync(stdoutPath).size;
-    const stderrSize = statSync(stderrPath).size;
-    if (stdoutSize > options.maxBuffer || stderrSize > options.maxBuffer) {
+    writeFileSync(
+      requestPath,
+      JSON.stringify({
+        command,
+        args,
+        cwd: options.cwd,
+        maxBuffer: options.maxBuffer,
+        timeout: options.timeout,
+        killSignal: options.killSignal,
+      }),
+      { encoding: "utf-8", mode: 0o600 },
+    );
+    const helper = spawnSync(
+      process.execPath,
+      [join(HERE, "spawn-captured.mjs"), requestPath, resultPath, stdoutPath, stderrPath],
+      {
+        cwd: options.cwd,
+        env: options.env,
+        timeout: options.timeout + CAPTURE_HELPER_SHUTDOWN_GRACE_MS,
+        killSignal: options.killSignal,
+        stdio: "ignore",
+      },
+    );
+    if (!existsSync(resultPath)) {
       return {
-        stdout: stdoutSize <= options.maxBuffer ? readFileSync(stdoutPath, options.encoding) : null,
-        stderr: stderrSize <= options.maxBuffer ? readFileSync(stderrPath, options.encoding) : null,
+        stdout: null,
+        stderr: null,
         status: null,
-        error: Object.assign(new Error(`spawnSync ${command} ENOBUFS`), { code: "ENOBUFS" }),
+        error:
+          helper.error ??
+          Object.assign(new Error(`spawnSync ${command} EHELPER`), { code: "EHELPER" }),
       };
     }
+    const metadata = JSON.parse(readFileSync(resultPath, "utf-8")) as {
+      status: number | null;
+      errorCode?: string;
+      overflowStream?: "stdout" | "stderr";
+    };
+    const error =
+      metadata.errorCode === undefined
+        ? undefined
+        : Object.assign(new Error(`spawnSync ${command} ${metadata.errorCode}`), {
+            code: metadata.errorCode,
+          });
     return {
-      stdout: readFileSync(stdoutPath, options.encoding),
-      stderr: readFileSync(stderrPath, options.encoding),
-      status: result.status,
-      error: result.error,
+      stdout:
+        metadata.overflowStream === "stdout" ? null : readFileSync(stdoutPath, options.encoding),
+      stderr:
+        metadata.overflowStream === "stderr" ? null : readFileSync(stderrPath, options.encoding),
+      status: metadata.status,
+      error,
     };
   } finally {
-    if (stdoutFd !== undefined) closeSync(stdoutFd);
-    if (stderrFd !== undefined) closeSync(stderrFd);
     rmSync(ioDir, { recursive: true, force: true });
   }
 };

--- a/tools/s8a/spawn-captured.mjs
+++ b/tools/s8a/spawn-captured.mjs
@@ -1,0 +1,72 @@
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [requestPath, resultPath, stdoutPath, stderrPath] = process.argv.slice(2);
+const request = JSON.parse(readFileSync(requestPath, "utf-8"));
+const stdoutChunks = [];
+const stderrChunks = [];
+let stdoutBytes = 0;
+let stderrBytes = 0;
+let status = null;
+let errorCode;
+let overflowStream;
+let finished = false;
+let timer;
+
+const child = spawn(request.command, request.args, {
+  cwd: request.cwd,
+  env: process.env,
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+function finish() {
+  if (finished) return;
+  finished = true;
+  clearTimeout(timer);
+  child.stdout.destroy();
+  child.stderr.destroy();
+  writeFileSync(stdoutPath, Buffer.concat(stdoutChunks), { mode: 0o600 });
+  writeFileSync(stderrPath, Buffer.concat(stderrChunks), { mode: 0o600 });
+  writeFileSync(
+    resultPath,
+    JSON.stringify({ status: errorCode === undefined ? status : null, errorCode, overflowStream }),
+    { mode: 0o600 },
+  );
+}
+
+function stop(code, stream) {
+  if (finished || errorCode !== undefined) return;
+  errorCode = code;
+  overflowStream = stream;
+  child.stdout.destroy();
+  child.stderr.destroy();
+  if (!child.kill(request.killSignal)) setImmediate(finish);
+}
+
+function collect(chunk, chunks, bytes, stream) {
+  if (finished || errorCode !== undefined) return bytes;
+  const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+  if (bytes + buffer.byteLength > request.maxBuffer) {
+    stop("ENOBUFS", stream);
+    return bytes;
+  }
+  chunks.push(buffer);
+  return bytes + buffer.byteLength;
+}
+
+child.stdout.on("data", (chunk) => {
+  stdoutBytes = collect(chunk, stdoutChunks, stdoutBytes, "stdout");
+});
+child.stderr.on("data", (chunk) => {
+  stderrBytes = collect(chunk, stderrChunks, stderrBytes, "stderr");
+});
+child.once("error", (error) => {
+  errorCode = typeof error.code === "string" ? error.code : "EHELPER";
+  setImmediate(finish);
+});
+child.once("exit", (code) => {
+  status = code;
+  setImmediate(finish);
+});
+
+timer = setTimeout(() => stop("ETIMEDOUT"), request.timeout);


### PR DESCRIPTION
## Summary

- Enforce the existing S8A stdout and stderr limit while each child is running.
- Isolate child pipes in a helper process so inherited descendant handles cannot stall the parent.
- Preserve bounded diagnostics through temporary files with owner-only permissions.
- Use the same capture path for replay and determinism probes.

## Evidence

- PR #650 exposed a replay child stall after `cleanup-done`.
- Review of PR #654 found that its file-backed capture checked `maxBuffer` only after exit.
- The overflow test now keeps the child alive after exceeding the limit and receives `ENOBUFS` before timeout.

## Verification

- `vitest run tools/s8a/run.test.ts --maxWorkers=1` — 32 passed.
- `pnpm s8a` — all 11 replay scenarios passed.
- `pnpm s8a --self-test` — drift and both determinism probes passed.
- `pnpm check` — passed under Node 24.
- `node --check tools/s8a/spawn-captured.mjs` — passed.
- Fresh read-only verification — both prior findings resolved; zero new P1/P2 findings.

## Limits

- `S8A child output = 64 MiB per stream` — enforce the existing bound before buffering or writing temporary files.
- `CAPTURE_HELPER_SHUTDOWN_GRACE_MS = 5000` — let the helper kill the child and serialize its bounded result after the child deadline.

This changes S8A test infrastructure only. It does not change athlete-facing behavior.
