### PR TITLE
fix(core): link update notice to desktop app

### DIFF
--- a/.changeset/green-bikes-update.md
+++ b/.changeset/green-bikes-update.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Update alerts now link to the Enduragent desktop app for macOS.

--- a/packages/core/src/channels/npm-telegram-host.ts
+++ b/packages/core/src/channels/npm-telegram-host.ts
@@ -145,7 +145,7 @@ export async function notifyNpmTelegramUpdate(
     const updateInstruction = isManagedDeploy(binary.binaryName)
       ? `Send /whatsnew to see what changed. ${MANAGED_DEPLOY_UPDATE_NOTICE}`
       : "Send /whatsnew to see what changed, /update to install.";
-    const message = `Update available: ${info.current} → ${info.latest}\n${updateInstruction}\n\nHelp shape what Cycling Coach builds next: please take 3 minutes to answer this short survey so the mobile app, 24/7 bot, Railway template, and setup/payment options are prioritized around what would actually help you: https://tally.so/r/b5Dv4g\n\nWant the bot running 24/7 without keeping your computer on? Deploy the Railway template: https://railway.com/deploy/cycling-coach`;
+    const message = `Update available: ${info.current} → ${info.latest}\n${updateInstruction}\n\nDesktop app for macOS is available: https://enduragent.icu\n\nWant the bot running 24/7 without keeping your computer on? Deploy the Railway template: https://railway.com/deploy/cycling-coach`;
 
     let delivered = false;
     for (const chatId of chatIds) {

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -550,10 +550,11 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
     expect(message).toContain(
       "Want the bot running 24/7 without keeping your computer on? Deploy the Railway template: https://railway.com/deploy/cycling-coach",
     );
-    expect(message).toContain("https://tally.so/r/b5Dv4g");
-    expect(message).toContain("Help shape what Cycling Coach builds next");
+    expect(message).toContain("Desktop app for macOS is available: https://enduragent.icu");
+    expect(message).not.toContain("https://tally.so/r/b5Dv4g");
+    expect(message).not.toContain("Help shape what Cycling Coach builds next");
     expect(message).not.toContain("x.com/yerzhansa");
-    expect(message.indexOf("https://tally.so/r/b5Dv4g")).toBeLessThan(
+    expect(message.indexOf("https://enduragent.icu")).toBeLessThan(
       message.indexOf("railway.com/deploy/cycling-coach"),
     );
   });


### PR DESCRIPTION
## Summary

- Replace the survey call-to-action in npm Telegram update alerts with the Enduragent macOS desktop app link.
- Keep the update instructions and Railway deployment call-to-action unchanged.
- Assert the new copy and the removal of the old survey copy.
- Add an athlete-facing changeset.

## Verification

- `vitest run packages/core/tests/telegram-bot.test.ts` — 12 tests passed.
- `oxfmt --check packages/core/src/channels/npm-telegram-host.ts packages/core/tests/telegram-bot.test.ts` — passed.
- `check-changeset-userfacing` — 9 changesets clean.
- `git diff --check` — passed.
