### PR TITLE
fix(desktop): wait for uninstall cleanup

### DIFF
--- a/apps/desktop/scripts/windows-installed-package.d.mts
+++ b/apps/desktop/scripts/windows-installed-package.d.mts
@@ -90,6 +90,7 @@ export interface WindowsInstalledPackageDependencies extends CanonicalTreeDepend
     readonly stderr: string;
   }>;
   readonly delay?: (milliseconds: number) => Promise<void>;
+  readonly now?: () => number;
 }
 
 export const WINDOWS_INSTALLED_LIMITS: {
@@ -148,6 +149,11 @@ export function executeWithGuaranteedUninstall(
   primary: () => Promise<void>,
   uninstall: () => Promise<void>,
 ): Promise<void>;
+
+export function waitForCleanupEvidence(
+  readEvidence: () => Promise<NativeInstalledEvidence>,
+  dependencies?: Pick<WindowsInstalledPackageDependencies, "delay" | "now">,
+): Promise<NativeInstalledEvidence>;
 
 export function parseNativeEvidenceResult(
   result: {

--- a/apps/desktop/scripts/windows-installed-package.d.mts
+++ b/apps/desktop/scripts/windows-installed-package.d.mts
@@ -90,7 +90,6 @@ export interface WindowsInstalledPackageDependencies extends CanonicalTreeDepend
     readonly stderr: string;
   }>;
   readonly delay?: (milliseconds: number) => Promise<void>;
-  readonly now?: () => number;
 }
 
 export const WINDOWS_INSTALLED_LIMITS: {
@@ -149,11 +148,6 @@ export function executeWithGuaranteedUninstall(
   primary: () => Promise<void>,
   uninstall: () => Promise<void>,
 ): Promise<void>;
-
-export function waitForCleanupEvidence(
-  readEvidence: () => Promise<NativeInstalledEvidence>,
-  dependencies?: Pick<WindowsInstalledPackageDependencies, "delay" | "now">,
-): Promise<NativeInstalledEvidence>;
 
 export function parseNativeEvidenceResult(
   result: {

--- a/apps/desktop/scripts/windows-installed-package.mjs
+++ b/apps/desktop/scripts/windows-installed-package.mjs
@@ -585,6 +585,24 @@ function assertCleanupEvidence(evidence) {
   checked(Array.isArray(evidence.processes) && evidence.processes.length === 0, "installed process remains");
 }
 
+export async function waitForCleanupEvidence(readEvidence, dependencies = {}) {
+  const delay =
+    dependencies.delay ??
+    ((milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)));
+  const now = dependencies.now ?? (() => performance.now());
+  const deadline = now() + WINDOWS_INSTALLED_LIMITS.filesystemMs;
+  while (true) {
+    const evidence = await readEvidence();
+    try {
+      assertCleanupEvidence(evidence);
+      return evidence;
+    } catch (error) {
+      if (now() >= deadline) throw error;
+    }
+    await delay(WINDOWS_INSTALLED_LIMITS.listenerMs);
+  }
+}
+
 export async function runWindowsInstalledPackage(input = {}, dependencies = {}) {
   const args = input.args ?? process.argv.slice(2);
   const options = parseDriverArguments(args);
@@ -752,20 +770,23 @@ export async function runWindowsInstalledPackage(input = {}, dependencies = {}) 
           ),
         );
         await attempt(() => waitForPathState(installed.installRoot, false, dependencies));
-        await attempt(async () => {
-          const cleanup = await runNative(
-            {
-              ...common,
-              action: "evidence",
-              installRoot: installed.installRoot,
-              treeRoots: [],
-              signaturePaths: [],
-            },
-            scratch,
+        await attempt(() =>
+          waitForCleanupEvidence(
+            () =>
+              runNative(
+                {
+                  ...common,
+                  action: "evidence",
+                  installRoot: installed.installRoot,
+                  treeRoots: [],
+                  signaturePaths: [],
+                },
+                scratch,
+                dependencies,
+              ),
             dependencies,
-          );
-          assertCleanupEvidence(cleanup);
-        });
+          ),
+        );
         if (sentinels !== undefined) await attempt(() => verifyDurableRoots(sentinels));
         await attempt(async () => {
           const finalInstallerDigest = await streamSha256(installer, dependencies);

--- a/apps/desktop/scripts/windows-installed-package.mjs
+++ b/apps/desktop/scripts/windows-installed-package.mjs
@@ -80,11 +80,12 @@ export async function collectCanonicalTree(root, dependencies = {}) {
       folded.set(foldedPath, manifestPath);
       const absolutePath = join(directory, name);
       const metadata = await inspect(absolutePath);
-      checked(!metadata.isSymbolicLink(), `manifest reparse point: ${manifestPath}`);
+      checked(
+        !metadata.isSymbolicLink(),
+        `manifest reparse point: ${manifestPath}`,
+      );
       if (metadata.isDirectory()) {
-        entries.push(
-          Object.freeze({ path: manifestPath, type: "directory", size: 0, sha256: null }),
-        );
+        entries.push(Object.freeze({ path: manifestPath, type: "directory", size: 0, sha256: null }));
         await visit(absolutePath, childSegments);
       } else if (metadata.isFile()) {
         entries.push(
@@ -157,10 +158,7 @@ export function compareInstalledTree(retainedEntries, installedEntries, uninstal
   );
   const uninstaller = installed.get(uninstallerKey);
   checked(uninstaller?.type === "file", "installed uninstaller is not a regular file");
-  checked(
-    uninstaller.size > 0 && typeof uninstaller.sha256 === "string",
-    "installed uninstaller is invalid",
-  );
+  checked(uninstaller.size > 0 && typeof uninstaller.sha256 === "string", "installed uninstaller is invalid");
   return Object.freeze({ uninstaller: Object.freeze({ ...uninstaller }) });
 }
 
@@ -256,10 +254,7 @@ export function validateSignaturePolicy(evidence, policy, ownedPaths, expectedPa
     checked(!seen.has(path), `duplicate signature evidence: ${signature.path}`);
     seen.add(path);
     if (owned.has(path)) {
-      checked(
-        signature.status === "NotSigned",
-        `Enduragent-owned binary signature is ${signature.status}`,
-      );
+      checked(signature.status === "NotSigned", `Enduragent-owned binary signature is ${signature.status}`);
     } else {
       checked(
         signature.status === "Valid" || signature.status === "NotSigned",
@@ -269,7 +264,10 @@ export function validateSignaturePolicy(evidence, policy, ownedPaths, expectedPa
   }
   for (const path of owned) checked(seen.has(path), `signature evidence is missing: ${path}`);
   for (const path of expected) {
-    checked(seen.has(path), `signature evidence is missing: ${path}`);
+    checked(
+      seen.has(path),
+      `signature evidence is missing: ${path}`,
+    );
   }
   return true;
 }
@@ -299,14 +297,9 @@ function parseDriverArguments(args) {
     throw new Error(`unsupported argument: ${argument}`);
   }
   checked(result.githubHosted === true, "--github-hosted is required");
-  checked(
-    result.signaturePolicy === "unsigned-private",
-    "--signature-policy unsigned-private is required",
-  );
-  if (result.installer !== undefined)
-    checked(isAbsolute(result.installer), "installer path must be absolute");
-  if (result.application !== undefined)
-    checked(isAbsolute(result.application), "application path must be absolute");
+  checked(result.signaturePolicy === "unsigned-private", "--signature-policy unsigned-private is required");
+  if (result.installer !== undefined) checked(isAbsolute(result.installer), "installer path must be absolute");
+  if (result.application !== undefined) checked(isAbsolute(result.application), "application path must be absolute");
   return result;
 }
 
@@ -395,9 +388,7 @@ export function parseNativeEvidenceResult(result, label) {
 
 async function runNativeEvidence(request, scratch, dependencies = {}) {
   const requestPath = join(scratch, `native-${randomUUID()}.json`);
-  await (dependencies.writeFile ?? writeFile)(requestPath, JSON.stringify(request), {
-    mode: 0o600,
-  });
+  await (dependencies.writeFile ?? writeFile)(requestPath, JSON.stringify(request), { mode: 0o600 });
   const run = dependencies.capture ?? capture;
   const result = await run(
     "pwsh.exe",
@@ -445,10 +436,7 @@ function validateHostedEnvironment(environment, platform, arch) {
   checked(platform === "win32", "installed Windows package test requires Windows");
   checked(arch === "x64", "installed Windows package test requires x64 Node");
   checked(environment.GITHUB_ACTIONS === "true", "GITHUB_ACTIONS=true is required");
-  checked(
-    environment.RUNNER_ENVIRONMENT === "github-hosted",
-    "RUNNER_ENVIRONMENT=github-hosted is required",
-  );
+  checked(environment.RUNNER_ENVIRONMENT === "github-hosted", "RUNNER_ENVIRONMENT=github-hosted is required");
   const roots = {
     userProfile: environment.USERPROFILE,
     localAppData: environment.LOCALAPPDATA,
@@ -461,24 +449,12 @@ function validateHostedEnvironment(environment, platform, arch) {
 }
 
 function assertCleanPreflight(evidence) {
-  checked(
-    Array.isArray(evidence.registrations) && evidence.registrations.length === 0,
-    "pre-existing app registration",
-  );
-  checked(
-    Array.isArray(evidence.programResidues) && evidence.programResidues.length === 0,
-    "pre-existing app install",
-  );
-  checked(
-    Array.isArray(evidence.processes) && evidence.processes.length === 0,
-    "pre-existing app process",
-  );
+  checked(Array.isArray(evidence.registrations) && evidence.registrations.length === 0, "pre-existing app registration");
+  checked(Array.isArray(evidence.programResidues) && evidence.programResidues.length === 0, "pre-existing app install");
+  checked(Array.isArray(evidence.processes) && evidence.processes.length === 0, "pre-existing app process");
   checked(evidence.shortcut?.exists === false, "pre-existing app shortcut");
   checked(evidence.run?.exists === false, "pre-existing app Run registration");
-  checked(
-    evidence.startupApproved?.exists === false,
-    "pre-existing app StartupApproved registration",
-  );
+  checked(evidence.startupApproved?.exists === false, "pre-existing app StartupApproved registration");
 }
 
 async function assertSafeInstallRoot(programsRoot, installRoot, dependencies = {}) {
@@ -501,19 +477,13 @@ async function assertSafeInstallRoot(programsRoot, installRoot, dependencies = {
   for (const segment of remainder.split(win32.sep)) {
     current = win32.join(current, segment);
     const metadata = await inspect(current);
-    checked(
-      metadata.isDirectory() && !metadata.isSymbolicLink(),
-      `install ancestor is a reparse point: ${current}`,
-    );
+    checked(metadata.isDirectory() && !metadata.isSymbolicLink(), `install ancestor is a reparse point: ${current}`);
   }
 }
 
 function assertNoReparsePoints(evidence) {
   checked(Array.isArray(evidence.reparsePaths), "reparse evidence is malformed");
-  checked(
-    evidence.reparsePaths.length === 0,
-    `package contains reparse points: ${evidence.reparsePaths.join(", ")}`,
-  );
+  checked(evidence.reparsePaths.length === 0, `package contains reparse points: ${evidence.reparsePaths.join(", ")}`);
 }
 
 function signatureInventory(installedEntries, installRoot) {
@@ -527,9 +497,7 @@ function signatureInventory(installedEntries, installRoot) {
 
 async function waitForPathState(path, expected, dependencies = {}) {
   const inspect = dependencies.lstat ?? lstat;
-  const delay =
-    dependencies.delay ??
-    ((milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)));
+  const delay = dependencies.delay ?? ((milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)));
   const deadline = performance.now() + WINDOWS_INSTALLED_LIMITS.filesystemMs;
   while (performance.now() < deadline) {
     let exists = true;
@@ -559,10 +527,7 @@ export async function executeWithGuaranteedUninstall(primary, uninstall) {
     cleanupError = error;
   }
   if (primaryError !== undefined && cleanupError !== undefined) {
-    throw new AggregateError(
-      [primaryError, cleanupError],
-      "installed package test and uninstall both failed",
-    );
+    throw new AggregateError([primaryError, cleanupError], "installed package test and uninstall both failed");
   }
   if (primaryError !== undefined) throw primaryError;
   if (cleanupError !== undefined) throw cleanupError;
@@ -597,10 +562,7 @@ async function verifyDurableRoots(sentinels) {
 }
 
 function assertSeededStartup(evidence, expected) {
-  checked(
-    evidence.run?.exists === true && evidence.run.value === expected.runValue,
-    "Run sentinel was not seeded exactly",
-  );
+  checked(evidence.run?.exists === true && evidence.run.value === expected.runValue, "Run sentinel was not seeded exactly");
   checked(
     evidence.startupApproved?.exists === true &&
       evidence.startupApproved.valueBase64 === expected.startupApprovedValueBase64,
@@ -620,28 +582,7 @@ function assertCleanupEvidence(evidence) {
   );
   checked(evidence.run?.exists === false, "Run registration remains");
   checked(evidence.startupApproved?.exists === false, "StartupApproved registration remains");
-  checked(
-    Array.isArray(evidence.processes) && evidence.processes.length === 0,
-    "installed process remains",
-  );
-}
-
-export async function waitForCleanupEvidence(readEvidence, dependencies = {}) {
-  const delay =
-    dependencies.delay ??
-    ((milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)));
-  const now = dependencies.now ?? (() => performance.now());
-  const deadline = now() + WINDOWS_INSTALLED_LIMITS.filesystemMs;
-  while (true) {
-    const evidence = await readEvidence();
-    try {
-      assertCleanupEvidence(evidence);
-      return evidence;
-    } catch (error) {
-      if (now() >= deadline) throw error;
-    }
-    await delay(WINDOWS_INSTALLED_LIMITS.listenerMs);
-  }
+  checked(Array.isArray(evidence.processes) && evidence.processes.length === 0, "installed process remains");
 }
 
 export async function runWindowsInstalledPackage(input = {}, dependencies = {}) {
@@ -653,21 +594,11 @@ export async function runWindowsInstalledPackage(input = {}, dependencies = {}) 
     input.arch ?? process.arch,
   );
   const desktopRoot = input.desktopRoot ?? canonicalDesktopRoot;
-  const plan = await (dependencies.createWindowsPackagePlan ?? createWindowsPackagePlan)({
-    desktopRoot,
-  });
-  const installer =
-    options.installer === undefined ? plan.artifactPath : resolve(options.installer);
-  const application =
-    options.application === undefined ? plan.applicationPath : resolve(options.application);
-  checked(
-    basename(installer) === plan.artifactName,
-    "installer does not match the frozen package plan",
-  );
-  checked(
-    application === plan.applicationPath,
-    "retained win-unpacked does not match the frozen package plan",
-  );
+  const plan = await (dependencies.createWindowsPackagePlan ?? createWindowsPackagePlan)({ desktopRoot });
+  const installer = options.installer === undefined ? plan.artifactPath : resolve(options.installer);
+  const application = options.application === undefined ? plan.applicationPath : resolve(options.application);
+  checked(basename(installer) === plan.artifactName, "installer does not match the frozen package plan");
+  checked(application === plan.applicationPath, "retained win-unpacked does not match the frozen package plan");
   const scratchBase = await realpath(tmpdir());
   const scratch = await mkdtemp(join(scratchBase, "enduragent-w17-"));
   const expected = {
@@ -686,11 +617,7 @@ export async function runWindowsInstalledPackage(input = {}, dependencies = {}) 
   let installerDigest;
   let uninstallerDigest;
   try {
-    const preflight = await runNative(
-      { ...common, action: "evidence", treeRoots: [], signaturePaths: [] },
-      scratch,
-      dependencies,
-    );
+    const preflight = await runNative({ ...common, action: "evidence", treeRoots: [], signaturePaths: [] }, scratch, dependencies);
     assertCleanPreflight(preflight);
     const packageEvidence = await (dependencies.verifyWindowsPackage ?? verifyWindowsPackage)(
       installer,
@@ -825,34 +752,27 @@ export async function runWindowsInstalledPackage(input = {}, dependencies = {}) 
           ),
         );
         await attempt(() => waitForPathState(installed.installRoot, false, dependencies));
-        await attempt(() =>
-          waitForCleanupEvidence(
-            () =>
-              runNative(
-                {
-                  ...common,
-                  action: "evidence",
-                  installRoot: installed.installRoot,
-                  treeRoots: [],
-                  signaturePaths: [],
-                },
-                scratch,
-                dependencies,
-              ),
+        await attempt(async () => {
+          const cleanup = await runNative(
+            {
+              ...common,
+              action: "evidence",
+              installRoot: installed.installRoot,
+              treeRoots: [],
+              signaturePaths: [],
+            },
+            scratch,
             dependencies,
-          ),
-        );
+          );
+          assertCleanupEvidence(cleanup);
+        });
         if (sentinels !== undefined) await attempt(() => verifyDurableRoots(sentinels));
         await attempt(async () => {
           const finalInstallerDigest = await streamSha256(installer, dependencies);
-          checked(
-            finalInstallerDigest === installerDigest,
-            "installer changed during installed test",
-          );
+          checked(finalInstallerDigest === installerDigest, "installer changed during installed test");
         });
         if (failures.length === 1) throw failures[0];
-        if (failures.length > 1)
-          throw new AggregateError(failures, "installed package cleanup failed");
+        if (failures.length > 1) throw new AggregateError(failures, "installed package cleanup failed");
       },
     );
     return Object.freeze({
@@ -873,9 +793,7 @@ export async function main() {
     process.stdout.write(`${JSON.stringify(result)}\n`);
   } catch (error) {
     const errors = error instanceof AggregateError ? error.errors : [error];
-    process.stderr.write(
-      `${errors.map((entry) => (entry instanceof Error ? entry.message : String(entry))).join("; ")}\n`,
-    );
+    process.stderr.write(`${errors.map((entry) => entry instanceof Error ? entry.message : String(entry)).join("; ")}\n`);
     process.exitCode = 1;
   }
 }

--- a/apps/desktop/scripts/windows-installed-package.mjs
+++ b/apps/desktop/scripts/windows-installed-package.mjs
@@ -80,12 +80,11 @@ export async function collectCanonicalTree(root, dependencies = {}) {
       folded.set(foldedPath, manifestPath);
       const absolutePath = join(directory, name);
       const metadata = await inspect(absolutePath);
-      checked(
-        !metadata.isSymbolicLink(),
-        `manifest reparse point: ${manifestPath}`,
-      );
+      checked(!metadata.isSymbolicLink(), `manifest reparse point: ${manifestPath}`);
       if (metadata.isDirectory()) {
-        entries.push(Object.freeze({ path: manifestPath, type: "directory", size: 0, sha256: null }));
+        entries.push(
+          Object.freeze({ path: manifestPath, type: "directory", size: 0, sha256: null }),
+        );
         await visit(absolutePath, childSegments);
       } else if (metadata.isFile()) {
         entries.push(
@@ -158,7 +157,10 @@ export function compareInstalledTree(retainedEntries, installedEntries, uninstal
   );
   const uninstaller = installed.get(uninstallerKey);
   checked(uninstaller?.type === "file", "installed uninstaller is not a regular file");
-  checked(uninstaller.size > 0 && typeof uninstaller.sha256 === "string", "installed uninstaller is invalid");
+  checked(
+    uninstaller.size > 0 && typeof uninstaller.sha256 === "string",
+    "installed uninstaller is invalid",
+  );
   return Object.freeze({ uninstaller: Object.freeze({ ...uninstaller }) });
 }
 
@@ -254,7 +256,10 @@ export function validateSignaturePolicy(evidence, policy, ownedPaths, expectedPa
     checked(!seen.has(path), `duplicate signature evidence: ${signature.path}`);
     seen.add(path);
     if (owned.has(path)) {
-      checked(signature.status === "NotSigned", `Enduragent-owned binary signature is ${signature.status}`);
+      checked(
+        signature.status === "NotSigned",
+        `Enduragent-owned binary signature is ${signature.status}`,
+      );
     } else {
       checked(
         signature.status === "Valid" || signature.status === "NotSigned",
@@ -264,10 +269,7 @@ export function validateSignaturePolicy(evidence, policy, ownedPaths, expectedPa
   }
   for (const path of owned) checked(seen.has(path), `signature evidence is missing: ${path}`);
   for (const path of expected) {
-    checked(
-      seen.has(path),
-      `signature evidence is missing: ${path}`,
-    );
+    checked(seen.has(path), `signature evidence is missing: ${path}`);
   }
   return true;
 }
@@ -297,9 +299,14 @@ function parseDriverArguments(args) {
     throw new Error(`unsupported argument: ${argument}`);
   }
   checked(result.githubHosted === true, "--github-hosted is required");
-  checked(result.signaturePolicy === "unsigned-private", "--signature-policy unsigned-private is required");
-  if (result.installer !== undefined) checked(isAbsolute(result.installer), "installer path must be absolute");
-  if (result.application !== undefined) checked(isAbsolute(result.application), "application path must be absolute");
+  checked(
+    result.signaturePolicy === "unsigned-private",
+    "--signature-policy unsigned-private is required",
+  );
+  if (result.installer !== undefined)
+    checked(isAbsolute(result.installer), "installer path must be absolute");
+  if (result.application !== undefined)
+    checked(isAbsolute(result.application), "application path must be absolute");
   return result;
 }
 
@@ -388,7 +395,9 @@ export function parseNativeEvidenceResult(result, label) {
 
 async function runNativeEvidence(request, scratch, dependencies = {}) {
   const requestPath = join(scratch, `native-${randomUUID()}.json`);
-  await (dependencies.writeFile ?? writeFile)(requestPath, JSON.stringify(request), { mode: 0o600 });
+  await (dependencies.writeFile ?? writeFile)(requestPath, JSON.stringify(request), {
+    mode: 0o600,
+  });
   const run = dependencies.capture ?? capture;
   const result = await run(
     "pwsh.exe",
@@ -436,7 +445,10 @@ function validateHostedEnvironment(environment, platform, arch) {
   checked(platform === "win32", "installed Windows package test requires Windows");
   checked(arch === "x64", "installed Windows package test requires x64 Node");
   checked(environment.GITHUB_ACTIONS === "true", "GITHUB_ACTIONS=true is required");
-  checked(environment.RUNNER_ENVIRONMENT === "github-hosted", "RUNNER_ENVIRONMENT=github-hosted is required");
+  checked(
+    environment.RUNNER_ENVIRONMENT === "github-hosted",
+    "RUNNER_ENVIRONMENT=github-hosted is required",
+  );
   const roots = {
     userProfile: environment.USERPROFILE,
     localAppData: environment.LOCALAPPDATA,
@@ -449,12 +461,24 @@ function validateHostedEnvironment(environment, platform, arch) {
 }
 
 function assertCleanPreflight(evidence) {
-  checked(Array.isArray(evidence.registrations) && evidence.registrations.length === 0, "pre-existing app registration");
-  checked(Array.isArray(evidence.programResidues) && evidence.programResidues.length === 0, "pre-existing app install");
-  checked(Array.isArray(evidence.processes) && evidence.processes.length === 0, "pre-existing app process");
+  checked(
+    Array.isArray(evidence.registrations) && evidence.registrations.length === 0,
+    "pre-existing app registration",
+  );
+  checked(
+    Array.isArray(evidence.programResidues) && evidence.programResidues.length === 0,
+    "pre-existing app install",
+  );
+  checked(
+    Array.isArray(evidence.processes) && evidence.processes.length === 0,
+    "pre-existing app process",
+  );
   checked(evidence.shortcut?.exists === false, "pre-existing app shortcut");
   checked(evidence.run?.exists === false, "pre-existing app Run registration");
-  checked(evidence.startupApproved?.exists === false, "pre-existing app StartupApproved registration");
+  checked(
+    evidence.startupApproved?.exists === false,
+    "pre-existing app StartupApproved registration",
+  );
 }
 
 async function assertSafeInstallRoot(programsRoot, installRoot, dependencies = {}) {
@@ -477,13 +501,19 @@ async function assertSafeInstallRoot(programsRoot, installRoot, dependencies = {
   for (const segment of remainder.split(win32.sep)) {
     current = win32.join(current, segment);
     const metadata = await inspect(current);
-    checked(metadata.isDirectory() && !metadata.isSymbolicLink(), `install ancestor is a reparse point: ${current}`);
+    checked(
+      metadata.isDirectory() && !metadata.isSymbolicLink(),
+      `install ancestor is a reparse point: ${current}`,
+    );
   }
 }
 
 function assertNoReparsePoints(evidence) {
   checked(Array.isArray(evidence.reparsePaths), "reparse evidence is malformed");
-  checked(evidence.reparsePaths.length === 0, `package contains reparse points: ${evidence.reparsePaths.join(", ")}`);
+  checked(
+    evidence.reparsePaths.length === 0,
+    `package contains reparse points: ${evidence.reparsePaths.join(", ")}`,
+  );
 }
 
 function signatureInventory(installedEntries, installRoot) {
@@ -497,7 +527,9 @@ function signatureInventory(installedEntries, installRoot) {
 
 async function waitForPathState(path, expected, dependencies = {}) {
   const inspect = dependencies.lstat ?? lstat;
-  const delay = dependencies.delay ?? ((milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)));
+  const delay =
+    dependencies.delay ??
+    ((milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)));
   const deadline = performance.now() + WINDOWS_INSTALLED_LIMITS.filesystemMs;
   while (performance.now() < deadline) {
     let exists = true;
@@ -527,7 +559,10 @@ export async function executeWithGuaranteedUninstall(primary, uninstall) {
     cleanupError = error;
   }
   if (primaryError !== undefined && cleanupError !== undefined) {
-    throw new AggregateError([primaryError, cleanupError], "installed package test and uninstall both failed");
+    throw new AggregateError(
+      [primaryError, cleanupError],
+      "installed package test and uninstall both failed",
+    );
   }
   if (primaryError !== undefined) throw primaryError;
   if (cleanupError !== undefined) throw cleanupError;
@@ -562,7 +597,10 @@ async function verifyDurableRoots(sentinels) {
 }
 
 function assertSeededStartup(evidence, expected) {
-  checked(evidence.run?.exists === true && evidence.run.value === expected.runValue, "Run sentinel was not seeded exactly");
+  checked(
+    evidence.run?.exists === true && evidence.run.value === expected.runValue,
+    "Run sentinel was not seeded exactly",
+  );
   checked(
     evidence.startupApproved?.exists === true &&
       evidence.startupApproved.valueBase64 === expected.startupApprovedValueBase64,
@@ -582,7 +620,28 @@ function assertCleanupEvidence(evidence) {
   );
   checked(evidence.run?.exists === false, "Run registration remains");
   checked(evidence.startupApproved?.exists === false, "StartupApproved registration remains");
-  checked(Array.isArray(evidence.processes) && evidence.processes.length === 0, "installed process remains");
+  checked(
+    Array.isArray(evidence.processes) && evidence.processes.length === 0,
+    "installed process remains",
+  );
+}
+
+export async function waitForCleanupEvidence(readEvidence, dependencies = {}) {
+  const delay =
+    dependencies.delay ??
+    ((milliseconds) => new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds)));
+  const now = dependencies.now ?? (() => performance.now());
+  const deadline = now() + WINDOWS_INSTALLED_LIMITS.filesystemMs;
+  while (true) {
+    const evidence = await readEvidence();
+    try {
+      assertCleanupEvidence(evidence);
+      return evidence;
+    } catch (error) {
+      if (now() >= deadline) throw error;
+    }
+    await delay(WINDOWS_INSTALLED_LIMITS.listenerMs);
+  }
 }
 
 export async function runWindowsInstalledPackage(input = {}, dependencies = {}) {
@@ -594,11 +653,21 @@ export async function runWindowsInstalledPackage(input = {}, dependencies = {}) 
     input.arch ?? process.arch,
   );
   const desktopRoot = input.desktopRoot ?? canonicalDesktopRoot;
-  const plan = await (dependencies.createWindowsPackagePlan ?? createWindowsPackagePlan)({ desktopRoot });
-  const installer = options.installer === undefined ? plan.artifactPath : resolve(options.installer);
-  const application = options.application === undefined ? plan.applicationPath : resolve(options.application);
-  checked(basename(installer) === plan.artifactName, "installer does not match the frozen package plan");
-  checked(application === plan.applicationPath, "retained win-unpacked does not match the frozen package plan");
+  const plan = await (dependencies.createWindowsPackagePlan ?? createWindowsPackagePlan)({
+    desktopRoot,
+  });
+  const installer =
+    options.installer === undefined ? plan.artifactPath : resolve(options.installer);
+  const application =
+    options.application === undefined ? plan.applicationPath : resolve(options.application);
+  checked(
+    basename(installer) === plan.artifactName,
+    "installer does not match the frozen package plan",
+  );
+  checked(
+    application === plan.applicationPath,
+    "retained win-unpacked does not match the frozen package plan",
+  );
   const scratchBase = await realpath(tmpdir());
   const scratch = await mkdtemp(join(scratchBase, "enduragent-w17-"));
   const expected = {
@@ -617,7 +686,11 @@ export async function runWindowsInstalledPackage(input = {}, dependencies = {}) 
   let installerDigest;
   let uninstallerDigest;
   try {
-    const preflight = await runNative({ ...common, action: "evidence", treeRoots: [], signaturePaths: [] }, scratch, dependencies);
+    const preflight = await runNative(
+      { ...common, action: "evidence", treeRoots: [], signaturePaths: [] },
+      scratch,
+      dependencies,
+    );
     assertCleanPreflight(preflight);
     const packageEvidence = await (dependencies.verifyWindowsPackage ?? verifyWindowsPackage)(
       installer,
@@ -752,27 +825,34 @@ export async function runWindowsInstalledPackage(input = {}, dependencies = {}) 
           ),
         );
         await attempt(() => waitForPathState(installed.installRoot, false, dependencies));
-        await attempt(async () => {
-          const cleanup = await runNative(
-            {
-              ...common,
-              action: "evidence",
-              installRoot: installed.installRoot,
-              treeRoots: [],
-              signaturePaths: [],
-            },
-            scratch,
+        await attempt(() =>
+          waitForCleanupEvidence(
+            () =>
+              runNative(
+                {
+                  ...common,
+                  action: "evidence",
+                  installRoot: installed.installRoot,
+                  treeRoots: [],
+                  signaturePaths: [],
+                },
+                scratch,
+                dependencies,
+              ),
             dependencies,
-          );
-          assertCleanupEvidence(cleanup);
-        });
+          ),
+        );
         if (sentinels !== undefined) await attempt(() => verifyDurableRoots(sentinels));
         await attempt(async () => {
           const finalInstallerDigest = await streamSha256(installer, dependencies);
-          checked(finalInstallerDigest === installerDigest, "installer changed during installed test");
+          checked(
+            finalInstallerDigest === installerDigest,
+            "installer changed during installed test",
+          );
         });
         if (failures.length === 1) throw failures[0];
-        if (failures.length > 1) throw new AggregateError(failures, "installed package cleanup failed");
+        if (failures.length > 1)
+          throw new AggregateError(failures, "installed package cleanup failed");
       },
     );
     return Object.freeze({
@@ -793,7 +873,9 @@ export async function main() {
     process.stdout.write(`${JSON.stringify(result)}\n`);
   } catch (error) {
     const errors = error instanceof AggregateError ? error.errors : [error];
-    process.stderr.write(`${errors.map((entry) => entry instanceof Error ? entry.message : String(entry)).join("; ")}\n`);
+    process.stderr.write(
+      `${errors.map((entry) => (entry instanceof Error ? entry.message : String(entry))).join("; ")}\n`,
+    );
     process.exitCode = 1;
   }
 }

--- a/apps/desktop/tests/windows-installed-package.test.ts
+++ b/apps/desktop/tests/windows-installed-package.test.ts
@@ -15,6 +15,7 @@ import {
   parseRegisteredUninstallCommands,
   runWindowsInstalledPackage,
   validateSignaturePolicy,
+  waitForCleanupEvidence,
 } from "../scripts/windows-installed-package.mjs";
 import {
   createPrimaryAcknowledgmentFailureObserver,
@@ -70,6 +71,21 @@ function registration(overrides: Record<string, unknown> = {}) {
       '"C:\\Users\\runner\\AppData\\Local\\Programs\\Enduragent\\Uninstall Enduragent.exe" /currentuser',
     quietUninstallString:
       '"C:\\Users\\runner\\AppData\\Local\\Programs\\Enduragent\\Uninstall Enduragent.exe" /currentuser /S',
+    ...overrides,
+  };
+}
+
+function cleanCleanupEvidence(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true as const,
+    registrations: [],
+    programResidues: [],
+    processes: [],
+    shortcut: { path: "shortcut", exists: false, targetPath: null, arguments: null, workingDirectory: null },
+    run: { exists: false, value: null },
+    startupApproved: { exists: false, valueBase64: null },
+    reparsePaths: [],
+    signatures: [],
     ...overrides,
   };
 }
@@ -308,6 +324,42 @@ describe("guaranteed uninstall", () => {
     );
     await expect(failure).rejects.toBeInstanceOf(AggregateError);
     await expect(failure).rejects.toMatchObject({ errors: [new Error("runtime failed"), new Error("uninstall failed")] });
+  });
+});
+
+describe("uninstall cleanup convergence", () => {
+  it("polls the complete native cleanup evidence until it converges", async () => {
+    const clean = cleanCleanupEvidence();
+    const readEvidence = vi
+      .fn()
+      .mockResolvedValueOnce(
+        cleanCleanupEvidence({
+          registrations: [registration()],
+          run: { exists: true, value: "Enduragent.exe" },
+        }),
+      )
+      .mockResolvedValueOnce(clean);
+    const delay = vi.fn(async () => {});
+
+    await expect(
+      waitForCleanupEvidence(readEvidence, { delay, now: vi.fn(() => 0) }),
+    ).resolves.toEqual(clean);
+    expect(readEvidence).toHaveBeenCalledTimes(2);
+    expect(delay).toHaveBeenCalledOnce();
+    expect(delay).toHaveBeenCalledWith(500);
+  });
+
+  it("fails with the fixed cleanup diagnostic at the existing deadline", async () => {
+    const dirty = cleanCleanupEvidence({ registrations: [registration()] });
+    const readEvidence = vi.fn(async () => dirty);
+    const delay = vi.fn(async () => {});
+    const now = vi.fn().mockReturnValueOnce(0).mockReturnValue(30_000);
+
+    await expect(waitForCleanupEvidence(readEvidence, { delay, now })).rejects.toThrow(
+      /^uninstall registration remains$/u,
+    );
+    expect(readEvidence).toHaveBeenCalledOnce();
+    expect(delay).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/tests/windows-installed-package.test.ts
+++ b/apps/desktop/tests/windows-installed-package.test.ts
@@ -15,7 +15,6 @@ import {
   parseRegisteredUninstallCommands,
   runWindowsInstalledPackage,
   validateSignaturePolicy,
-  waitForCleanupEvidence,
 } from "../scripts/windows-installed-package.mjs";
 import {
   createPrimaryAcknowledgmentFailureObserver,
@@ -75,27 +74,6 @@ function registration(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function cleanCleanupEvidence(overrides: Record<string, unknown> = {}) {
-  return {
-    ok: true as const,
-    registrations: [],
-    programResidues: [],
-    processes: [],
-    shortcut: {
-      path: "shortcut",
-      exists: false,
-      targetPath: null,
-      arguments: null,
-      workingDirectory: null,
-    },
-    run: { exists: false, value: null },
-    startupApproved: { exists: false, valueBase64: null },
-    reparsePaths: [],
-    signatures: [],
-    ...overrides,
-  };
-}
-
 describe("canonical installed package manifests", () => {
   it("streams regular files into ordinal normalized manifests", async () => {
     const root = await mkdtemp(join(tmpdir(), "w17-manifest-"));
@@ -104,9 +82,7 @@ describe("canonical installed package manifests", () => {
     await writeFile(join(root, "a.bin"), "alpha");
     const manifest = await collectCanonicalTree(root, { createReadStream });
     expect(manifest.map((entry) => entry.path)).toEqual(["a.bin", "b.bin"]);
-    expect(manifest.every((entry) => entry.type === "file" && entry.sha256?.length === 64)).toBe(
-      true,
-    );
+    expect(manifest.every((entry) => entry.type === "file" && entry.sha256?.length === 64)).toBe(true);
   });
 
   it("rejects case-fold collisions", async () => {
@@ -121,11 +97,10 @@ describe("canonical installed package manifests", () => {
   it("rejects reparse points", async () => {
     await expect(
       collectCanonicalTree("/synthetic", {
-        lstat: vi.fn(
-          async (path: string) =>
-            directoryStat(
-              path === join("/synthetic", "link") ? { isSymbolicLink: () => true } : {},
-            ) as never,
+        lstat: vi.fn(async (path: string) =>
+          directoryStat(
+            path === join("/synthetic", "link") ? { isSymbolicLink: () => true } : {},
+          ) as never,
         ),
         readdir: vi.fn(async (path: string) => (path === "/synthetic" ? ["link"] : [])),
       }),
@@ -135,9 +110,9 @@ describe("canonical installed package manifests", () => {
   it("accepts an exact installed tree with one exact uninstaller", () => {
     const retained = [directory("resources"), file("resources/app.asar", "one", 3)];
     const installed = [...retained, file("Uninstall Enduragent.exe", "two", 7)];
-    expect(
-      compareInstalledTree(retained, installed, "Uninstall Enduragent.exe").uninstaller,
-    ).toEqual(file("Uninstall Enduragent.exe", "two", 7));
+    expect(compareInstalledTree(retained, installed, "Uninstall Enduragent.exe").uninstaller).toEqual(
+      file("Uninstall Enduragent.exe", "two", 7),
+    );
   });
 
   it("compares paths case-insensitively while preserving collision rejection", () => {
@@ -146,9 +121,9 @@ describe("canonical installed package manifests", () => {
       file("resources/app.asar", "one", 3),
       file("uninstall enduragent.exe", "two", 7),
     ];
-    expect(
-      compareInstalledTree(retained, installed, "Uninstall Enduragent.exe").uninstaller.path,
-    ).toBe("uninstall enduragent.exe");
+    expect(compareInstalledTree(retained, installed, "Uninstall Enduragent.exe").uninstaller.path).toBe(
+      "uninstall enduragent.exe",
+    );
     expect(() =>
       compareInstalledTree(
         [file("A", "one"), file("a", "one")],
@@ -160,11 +135,7 @@ describe("canonical installed package manifests", () => {
 
   it.each([
     ["missing", [file("a", "one")], [file("Uninstall Enduragent.exe", "u")]],
-    [
-      "extra",
-      [file("a", "one")],
-      [file("a", "one"), file("extra", "x"), file("Uninstall Enduragent.exe", "u")],
-    ],
+    ["extra", [file("a", "one")], [file("a", "one"), file("extra", "x"), file("Uninstall Enduragent.exe", "u")]],
     ["hash", [file("a", "one")], [file("a", "two"), file("Uninstall Enduragent.exe", "u")]],
     ["type", [file("a", "one")], [directory("a"), file("Uninstall Enduragent.exe", "u")]],
   ])("rejects a %s tree mismatch", (_label, retained, installed) => {
@@ -194,15 +165,7 @@ describe("installed registration discovery", () => {
     ["zero", []],
     ["duplicate", [registration(), registration({ keyPath: "second" })]],
     ["identity-alias", [registration(), registration({ keyName: "icu.enduragent.desktop" })]],
-    [
-      "outside",
-      [
-        registration({
-          installLocation: "C:\\Outside",
-          uninstallString: '"C:\\Outside\\uninstall.exe"',
-        }),
-      ],
-    ],
+    ["outside", [registration({ installLocation: "C:\\Outside", uninstallString: '"C:\\Outside\\uninstall.exe"' })]],
     ["malformed", [registration({ uninstallString: "cmd.exe /c destructive" })]],
     [
       "different-quiet-path",
@@ -216,8 +179,7 @@ describe("installed registration discovery", () => {
       [
         registration({
           installLocation: "c:\\users\\runner\\appdata\\local\\programs",
-          uninstallString:
-            '"c:\\users\\runner\\appdata\\local\\programs\\uninstall.exe" /currentuser',
+          uninstallString: '"c:\\users\\runner\\appdata\\local\\programs\\uninstall.exe" /currentuser',
           quietUninstallString:
             '"c:\\users\\runner\\appdata\\local\\programs\\uninstall.exe" /currentuser /S',
         }),
@@ -293,10 +255,7 @@ describe("unsigned private signature policy", () => {
   it.each(["HashMismatch", "NotTrusted", "UnknownError"])("rejects vendor %s", (status) => {
     expect(() =>
       validateSignaturePolicy(
-        [
-          ...owned.map((path) => ({ path, status: "NotSigned" })),
-          { path: "C:\\installed\\vendor.dll", status },
-        ],
+        [...owned.map((path) => ({ path, status: "NotSigned" })), { path: "C:\\installed\\vendor.dll", status }],
         "unsigned-private",
         owned,
         [...owned, "C:\\installed\\vendor.dll"],
@@ -318,10 +277,7 @@ describe("unsigned private signature policy", () => {
   it("rejects extra signature evidence", () => {
     expect(() =>
       validateSignaturePolicy(
-        [
-          ...owned.map((path) => ({ path, status: "NotSigned" })),
-          { path: "C:\\extra.dll", status: "Valid" },
-        ],
+        [...owned.map((path) => ({ path, status: "NotSigned" })), { path: "C:\\extra.dll", status: "Valid" }],
         "unsigned-private",
         owned,
         owned,
@@ -351,45 +307,7 @@ describe("guaranteed uninstall", () => {
       },
     );
     await expect(failure).rejects.toBeInstanceOf(AggregateError);
-    await expect(failure).rejects.toMatchObject({
-      errors: [new Error("runtime failed"), new Error("uninstall failed")],
-    });
-  });
-});
-
-describe("uninstall cleanup convergence", () => {
-  it("polls the complete native cleanup evidence until it converges", async () => {
-    const clean = cleanCleanupEvidence();
-    const readEvidence = vi
-      .fn()
-      .mockResolvedValueOnce(
-        cleanCleanupEvidence({
-          registrations: [registration()],
-          run: { exists: true, value: "Enduragent.exe" },
-        }),
-      )
-      .mockResolvedValueOnce(clean);
-    const delay = vi.fn(async () => {});
-
-    await expect(
-      waitForCleanupEvidence(readEvidence, { delay, now: vi.fn(() => 0) }),
-    ).resolves.toEqual(clean);
-    expect(readEvidence).toHaveBeenCalledTimes(2);
-    expect(delay).toHaveBeenCalledOnce();
-    expect(delay).toHaveBeenCalledWith(500);
-  });
-
-  it("fails with the fixed cleanup diagnostic at the existing deadline", async () => {
-    const dirty = cleanCleanupEvidence({ registrations: [registration()] });
-    const readEvidence = vi.fn(async () => dirty);
-    const delay = vi.fn(async () => {});
-    const now = vi.fn().mockReturnValueOnce(0).mockReturnValue(30_000);
-
-    await expect(waitForCleanupEvidence(readEvidence, { delay, now })).rejects.toThrow(
-      /^uninstall registration remains$/u,
-    );
-    expect(readEvidence).toHaveBeenCalledOnce();
-    expect(delay).not.toHaveBeenCalled();
+    await expect(failure).rejects.toMatchObject({ errors: [new Error("runtime failed"), new Error("uninstall failed")] });
   });
 });
 
@@ -628,9 +546,7 @@ describe("packaged primary identity", () => {
       { ...ready, rendererSurface: "unknown" },
       missingRendererSurface,
     ]) {
-      expect(() => validateReadyFrame(candidate)).toThrow(
-        /^packaged renderer surface was invalid$/u,
-      );
+      expect(() => validateReadyFrame(candidate)).toThrow(/^packaged renderer surface was invalid$/u);
     }
   });
 
@@ -767,7 +683,9 @@ describe("packaged primary second-instance evidence", () => {
         primaryExited: new Promise(() => {}),
         deadline: performance.now(),
       }),
-    ).rejects.toThrow(/^packaged Windows primary second-instance acknowledgment timed out$/u);
+    ).rejects.toThrow(
+      /^packaged Windows primary second-instance acknowledgment timed out$/u,
+    );
   });
 
   it("observes only the exact fixed primary acknowledgment write failure frame", async () => {
@@ -785,7 +703,9 @@ describe("packaged primary second-instance evidence", () => {
         second: new Promise(() => {}),
         primaryAcknowledgment: new Promise(() => {}),
         primaryAcknowledgmentEvidenceFailure: new Promise(() => {}),
-        primaryAcknowledgmentWriteFailure: Promise.resolve(new Error("C:\\private\\ack-write")),
+        primaryAcknowledgmentWriteFailure: Promise.resolve(
+          new Error("C:\\private\\ack-write"),
+        ),
         primaryAcknowledged: () => false,
         primaryExited: new Promise(() => {}),
         deadline: performance.now() + 10_000,
@@ -837,7 +757,9 @@ describe("packaged application process exit", () => {
 describe("packaged Windows shutdown diagnostics", () => {
   const completeStages = (stages: ReturnType<typeof createSecuritySmokeStageObserver>) => {
     stages.write(
-      SECURITY_SMOKE_SHUTDOWN_STAGES.map((stage) => `DESKTOP_SECURITY_STAGE ${stage}\n`).join(""),
+      SECURITY_SMOKE_SHUTDOWN_STAGES.map(
+        (stage) => `DESKTOP_SECURITY_STAGE ${stage}\n`,
+      ).join(""),
     );
   };
 
@@ -1140,13 +1062,7 @@ describe("installed driver binding", () => {
       registrations: [],
       programResidues: [],
       processes: [],
-      shortcut: {
-        path: "shortcut",
-        exists: false,
-        targetPath: null,
-        arguments: null,
-        workingDirectory: null,
-      },
+      shortcut: { path: "shortcut", exists: false, targetPath: null, arguments: null, workingDirectory: null },
       run: { exists: false, value: null },
       startupApproved: { exists: false, valueBase64: null },
       reparsePaths: [],
@@ -1180,12 +1096,7 @@ describe("installed driver binding", () => {
         peMachine: 0x8664 as const,
         nsisEnvelope: true as const,
       },
-      application: {
-        fileCount: 0,
-        directoryCount: 0,
-        manifestSha256: "x",
-        peMachine: 0x8664 as const,
-      },
+      application: { fileCount: 0, directoryCount: 0, manifestSha256: "x", peMachine: 0x8664 as const },
     }));
     await expect(
       runWindowsInstalledPackage(

--- a/apps/desktop/tests/windows-installed-package.test.ts
+++ b/apps/desktop/tests/windows-installed-package.test.ts
@@ -15,6 +15,7 @@ import {
   parseRegisteredUninstallCommands,
   runWindowsInstalledPackage,
   validateSignaturePolicy,
+  waitForCleanupEvidence,
 } from "../scripts/windows-installed-package.mjs";
 import {
   createPrimaryAcknowledgmentFailureObserver,
@@ -74,6 +75,27 @@ function registration(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function cleanCleanupEvidence(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true as const,
+    registrations: [],
+    programResidues: [],
+    processes: [],
+    shortcut: {
+      path: "shortcut",
+      exists: false,
+      targetPath: null,
+      arguments: null,
+      workingDirectory: null,
+    },
+    run: { exists: false, value: null },
+    startupApproved: { exists: false, valueBase64: null },
+    reparsePaths: [],
+    signatures: [],
+    ...overrides,
+  };
+}
+
 describe("canonical installed package manifests", () => {
   it("streams regular files into ordinal normalized manifests", async () => {
     const root = await mkdtemp(join(tmpdir(), "w17-manifest-"));
@@ -82,7 +104,9 @@ describe("canonical installed package manifests", () => {
     await writeFile(join(root, "a.bin"), "alpha");
     const manifest = await collectCanonicalTree(root, { createReadStream });
     expect(manifest.map((entry) => entry.path)).toEqual(["a.bin", "b.bin"]);
-    expect(manifest.every((entry) => entry.type === "file" && entry.sha256?.length === 64)).toBe(true);
+    expect(manifest.every((entry) => entry.type === "file" && entry.sha256?.length === 64)).toBe(
+      true,
+    );
   });
 
   it("rejects case-fold collisions", async () => {
@@ -97,10 +121,11 @@ describe("canonical installed package manifests", () => {
   it("rejects reparse points", async () => {
     await expect(
       collectCanonicalTree("/synthetic", {
-        lstat: vi.fn(async (path: string) =>
-          directoryStat(
-            path === join("/synthetic", "link") ? { isSymbolicLink: () => true } : {},
-          ) as never,
+        lstat: vi.fn(
+          async (path: string) =>
+            directoryStat(
+              path === join("/synthetic", "link") ? { isSymbolicLink: () => true } : {},
+            ) as never,
         ),
         readdir: vi.fn(async (path: string) => (path === "/synthetic" ? ["link"] : [])),
       }),
@@ -110,9 +135,9 @@ describe("canonical installed package manifests", () => {
   it("accepts an exact installed tree with one exact uninstaller", () => {
     const retained = [directory("resources"), file("resources/app.asar", "one", 3)];
     const installed = [...retained, file("Uninstall Enduragent.exe", "two", 7)];
-    expect(compareInstalledTree(retained, installed, "Uninstall Enduragent.exe").uninstaller).toEqual(
-      file("Uninstall Enduragent.exe", "two", 7),
-    );
+    expect(
+      compareInstalledTree(retained, installed, "Uninstall Enduragent.exe").uninstaller,
+    ).toEqual(file("Uninstall Enduragent.exe", "two", 7));
   });
 
   it("compares paths case-insensitively while preserving collision rejection", () => {
@@ -121,9 +146,9 @@ describe("canonical installed package manifests", () => {
       file("resources/app.asar", "one", 3),
       file("uninstall enduragent.exe", "two", 7),
     ];
-    expect(compareInstalledTree(retained, installed, "Uninstall Enduragent.exe").uninstaller.path).toBe(
-      "uninstall enduragent.exe",
-    );
+    expect(
+      compareInstalledTree(retained, installed, "Uninstall Enduragent.exe").uninstaller.path,
+    ).toBe("uninstall enduragent.exe");
     expect(() =>
       compareInstalledTree(
         [file("A", "one"), file("a", "one")],
@@ -135,7 +160,11 @@ describe("canonical installed package manifests", () => {
 
   it.each([
     ["missing", [file("a", "one")], [file("Uninstall Enduragent.exe", "u")]],
-    ["extra", [file("a", "one")], [file("a", "one"), file("extra", "x"), file("Uninstall Enduragent.exe", "u")]],
+    [
+      "extra",
+      [file("a", "one")],
+      [file("a", "one"), file("extra", "x"), file("Uninstall Enduragent.exe", "u")],
+    ],
     ["hash", [file("a", "one")], [file("a", "two"), file("Uninstall Enduragent.exe", "u")]],
     ["type", [file("a", "one")], [directory("a"), file("Uninstall Enduragent.exe", "u")]],
   ])("rejects a %s tree mismatch", (_label, retained, installed) => {
@@ -165,7 +194,15 @@ describe("installed registration discovery", () => {
     ["zero", []],
     ["duplicate", [registration(), registration({ keyPath: "second" })]],
     ["identity-alias", [registration(), registration({ keyName: "icu.enduragent.desktop" })]],
-    ["outside", [registration({ installLocation: "C:\\Outside", uninstallString: '"C:\\Outside\\uninstall.exe"' })]],
+    [
+      "outside",
+      [
+        registration({
+          installLocation: "C:\\Outside",
+          uninstallString: '"C:\\Outside\\uninstall.exe"',
+        }),
+      ],
+    ],
     ["malformed", [registration({ uninstallString: "cmd.exe /c destructive" })]],
     [
       "different-quiet-path",
@@ -179,7 +216,8 @@ describe("installed registration discovery", () => {
       [
         registration({
           installLocation: "c:\\users\\runner\\appdata\\local\\programs",
-          uninstallString: '"c:\\users\\runner\\appdata\\local\\programs\\uninstall.exe" /currentuser',
+          uninstallString:
+            '"c:\\users\\runner\\appdata\\local\\programs\\uninstall.exe" /currentuser',
           quietUninstallString:
             '"c:\\users\\runner\\appdata\\local\\programs\\uninstall.exe" /currentuser /S',
         }),
@@ -255,7 +293,10 @@ describe("unsigned private signature policy", () => {
   it.each(["HashMismatch", "NotTrusted", "UnknownError"])("rejects vendor %s", (status) => {
     expect(() =>
       validateSignaturePolicy(
-        [...owned.map((path) => ({ path, status: "NotSigned" })), { path: "C:\\installed\\vendor.dll", status }],
+        [
+          ...owned.map((path) => ({ path, status: "NotSigned" })),
+          { path: "C:\\installed\\vendor.dll", status },
+        ],
         "unsigned-private",
         owned,
         [...owned, "C:\\installed\\vendor.dll"],
@@ -277,7 +318,10 @@ describe("unsigned private signature policy", () => {
   it("rejects extra signature evidence", () => {
     expect(() =>
       validateSignaturePolicy(
-        [...owned.map((path) => ({ path, status: "NotSigned" })), { path: "C:\\extra.dll", status: "Valid" }],
+        [
+          ...owned.map((path) => ({ path, status: "NotSigned" })),
+          { path: "C:\\extra.dll", status: "Valid" },
+        ],
         "unsigned-private",
         owned,
         owned,
@@ -307,7 +351,45 @@ describe("guaranteed uninstall", () => {
       },
     );
     await expect(failure).rejects.toBeInstanceOf(AggregateError);
-    await expect(failure).rejects.toMatchObject({ errors: [new Error("runtime failed"), new Error("uninstall failed")] });
+    await expect(failure).rejects.toMatchObject({
+      errors: [new Error("runtime failed"), new Error("uninstall failed")],
+    });
+  });
+});
+
+describe("uninstall cleanup convergence", () => {
+  it("polls the complete native cleanup evidence until it converges", async () => {
+    const clean = cleanCleanupEvidence();
+    const readEvidence = vi
+      .fn()
+      .mockResolvedValueOnce(
+        cleanCleanupEvidence({
+          registrations: [registration()],
+          run: { exists: true, value: "Enduragent.exe" },
+        }),
+      )
+      .mockResolvedValueOnce(clean);
+    const delay = vi.fn(async () => {});
+
+    await expect(
+      waitForCleanupEvidence(readEvidence, { delay, now: vi.fn(() => 0) }),
+    ).resolves.toEqual(clean);
+    expect(readEvidence).toHaveBeenCalledTimes(2);
+    expect(delay).toHaveBeenCalledOnce();
+    expect(delay).toHaveBeenCalledWith(500);
+  });
+
+  it("fails with the fixed cleanup diagnostic at the existing deadline", async () => {
+    const dirty = cleanCleanupEvidence({ registrations: [registration()] });
+    const readEvidence = vi.fn(async () => dirty);
+    const delay = vi.fn(async () => {});
+    const now = vi.fn().mockReturnValueOnce(0).mockReturnValue(30_000);
+
+    await expect(waitForCleanupEvidence(readEvidence, { delay, now })).rejects.toThrow(
+      /^uninstall registration remains$/u,
+    );
+    expect(readEvidence).toHaveBeenCalledOnce();
+    expect(delay).not.toHaveBeenCalled();
   });
 });
 
@@ -546,7 +628,9 @@ describe("packaged primary identity", () => {
       { ...ready, rendererSurface: "unknown" },
       missingRendererSurface,
     ]) {
-      expect(() => validateReadyFrame(candidate)).toThrow(/^packaged renderer surface was invalid$/u);
+      expect(() => validateReadyFrame(candidate)).toThrow(
+        /^packaged renderer surface was invalid$/u,
+      );
     }
   });
 
@@ -683,9 +767,7 @@ describe("packaged primary second-instance evidence", () => {
         primaryExited: new Promise(() => {}),
         deadline: performance.now(),
       }),
-    ).rejects.toThrow(
-      /^packaged Windows primary second-instance acknowledgment timed out$/u,
-    );
+    ).rejects.toThrow(/^packaged Windows primary second-instance acknowledgment timed out$/u);
   });
 
   it("observes only the exact fixed primary acknowledgment write failure frame", async () => {
@@ -703,9 +785,7 @@ describe("packaged primary second-instance evidence", () => {
         second: new Promise(() => {}),
         primaryAcknowledgment: new Promise(() => {}),
         primaryAcknowledgmentEvidenceFailure: new Promise(() => {}),
-        primaryAcknowledgmentWriteFailure: Promise.resolve(
-          new Error("C:\\private\\ack-write"),
-        ),
+        primaryAcknowledgmentWriteFailure: Promise.resolve(new Error("C:\\private\\ack-write")),
         primaryAcknowledged: () => false,
         primaryExited: new Promise(() => {}),
         deadline: performance.now() + 10_000,
@@ -757,9 +837,7 @@ describe("packaged application process exit", () => {
 describe("packaged Windows shutdown diagnostics", () => {
   const completeStages = (stages: ReturnType<typeof createSecuritySmokeStageObserver>) => {
     stages.write(
-      SECURITY_SMOKE_SHUTDOWN_STAGES.map(
-        (stage) => `DESKTOP_SECURITY_STAGE ${stage}\n`,
-      ).join(""),
+      SECURITY_SMOKE_SHUTDOWN_STAGES.map((stage) => `DESKTOP_SECURITY_STAGE ${stage}\n`).join(""),
     );
   };
 
@@ -1062,7 +1140,13 @@ describe("installed driver binding", () => {
       registrations: [],
       programResidues: [],
       processes: [],
-      shortcut: { path: "shortcut", exists: false, targetPath: null, arguments: null, workingDirectory: null },
+      shortcut: {
+        path: "shortcut",
+        exists: false,
+        targetPath: null,
+        arguments: null,
+        workingDirectory: null,
+      },
       run: { exists: false, value: null },
       startupApproved: { exists: false, valueBase64: null },
       reparsePaths: [],
@@ -1096,7 +1180,12 @@ describe("installed driver binding", () => {
         peMachine: 0x8664 as const,
         nsisEnvelope: true as const,
       },
-      application: { fileCount: 0, directoryCount: 0, manifestSha256: "x", peMachine: 0x8664 as const },
+      application: {
+        fileCount: 0,
+        directoryCount: 0,
+        manifestSha256: "x",
+        peMachine: 0x8664 as const,
+      },
     }));
     await expect(
       runWindowsInstalledPackage(


### PR DESCRIPTION
## Summary

- Poll complete native Windows cleanup evidence after the NSIS uninstaller exits.
- Accept cleanup only when registrations, shortcuts, program residues, startup entries, and processes are all gone.
- Preserve the existing fixed, path-free failure diagnostics at the existing deadline.

## Verification

- `pnpm exec vitest run apps/desktop/tests/windows-installed-package.test.ts --maxWorkers=1` — 101 passed.
- `pnpm check:types` — passed.
- `git diff --check` — passed.
- Structured autoreview — clean, no actionable findings.

## Limits

- No new limit.
- Reuses `filesystemMs = 30000` and `listenerMs = 500` for cleanup convergence.
