### PR TITLE
fix(desktop): tolerate disappearing uninstall keys

### DIFF
--- a/apps/desktop/scripts/windows-installed-evidence.ps1
+++ b/apps/desktop/scripts/windows-installed-evidence.ps1
@@ -36,16 +36,21 @@ function Get-UninstallRegistrations {
   $root = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall"
   $installLocation = Get-InstallLocation -Request $Request
   if (-not (Test-Path -LiteralPath $root)) { return @() }
-  $items = @(Get-ChildItem -LiteralPath $root | ForEach-Object {
-    $value = Get-ItemProperty -LiteralPath $_.PSPath
+  $items = @()
+  foreach ($item in @(Get-ChildItem -LiteralPath $root)) {
+    try {
+      $value = Get-ItemProperty -LiteralPath $item.PSPath
+    } catch [System.Management.Automation.ItemNotFoundException] {
+      continue
+    }
     $matchesIdentity =
       $value.DisplayName -eq "$($Request.productName) $($Request.version)" -or
-      $_.PSChildName -eq $Request.guid -or
-      $_.PSChildName -eq $Request.appId
+      $item.PSChildName -eq $Request.guid -or
+      $item.PSChildName -eq $Request.appId
     if ($matchesIdentity) {
-      [ordered]@{
-        keyPath = $_.Name
-        keyName = $_.PSChildName
+      $items += [ordered]@{
+        keyPath = $item.Name
+        keyName = $item.PSChildName
         displayName = $value.DisplayName
         displayVersion = $value.DisplayVersion
         installLocation = $installLocation
@@ -53,7 +58,7 @@ function Get-UninstallRegistrations {
         quietUninstallString = $value.QuietUninstallString
       }
     }
-  })
+  }
   return $items
 }
 

--- a/apps/desktop/tests/windows-parity-contract.test.ts
+++ b/apps/desktop/tests/windows-parity-contract.test.ts
@@ -120,6 +120,9 @@ describe("Windows parity automation contract", () => {
       /if \(\(\$child\.Attributes -band \[IO\.FileAttributes\]::ReparsePoint\) -ne 0\) \{\s+\$paths \+= \$child\.FullName\s+\} elseif \(\$child\.PSIsContainer\) \{\s+\$pending\.Push\(\$child\.FullName\)\s+\}/u,
     );
     expect(nativeEvidence).toContain("installLocation = $installLocation");
+    expect(nativeEvidence).toMatch(
+      /catch \[System\.Management\.Automation\.ItemNotFoundException\] \{\s+continue\s+\}/u,
+    );
     expect(nativeEvidence).toContain("WScript.Shell");
     expect(nativeEvidence).toContain("Get-CimInstance Win32_Process -Filter");
     expect(nativeEvidence).not.toContain("[IO.Path]::GetFileName");


### PR DESCRIPTION
Fix the hosted Windows uninstall evidence race where an NSIS key can disappear between registry enumeration and property lookup.

The evidence collector skips only the typed missing-item exception. Other registry and evidence failures remain fail-closed.

Verification:
- Node 24 + pnpm 10 focused Windows tests: 104 passed
- pnpm check:types
- git diff --check
- fresh read-only review: PASS

Limits: none added or changed.