### PR TITLE
fix: capture desktop draft id atomically

### DIFF
--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -160,14 +160,15 @@ jobs:
             test "$EXISTING_BODY_SHA256" = "$RELEASE_BODY_SHA256"
             echo "::notice::Reusing desktop draft release $DRAFT_ID for $DESKTOP_TAG"
           else
-            gh release create "$DESKTOP_TAG" \
-              --draft \
-              --latest=false \
-              --target "$RELEASE_COMMIT" \
-              --title "Enduragent Desktop $DESKTOP_VERSION" \
-              --notes "$RELEASE_BODY"
-            DRAFT_ID=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
-              --jq "[.[] | select(.tag_name == \"$DESKTOP_TAG\")] | first | .id | tostring")
+            CREATED_RELEASE=$(gh api --method POST "repos/$GITHUB_REPOSITORY/releases" \
+              -f tag_name="$DESKTOP_TAG" \
+              -f target_commitish="$RELEASE_COMMIT" \
+              -f name="Enduragent Desktop $DESKTOP_VERSION" \
+              -f body="$RELEASE_BODY" \
+              -F draft=true \
+              -F prerelease=false \
+              -f make_latest=false)
+            DRAFT_ID=$(printf '%s' "$CREATED_RELEASE" | jq -er '.id | tostring')
             printf '%s' "$DRAFT_ID" | grep -Eq '^[1-9][0-9]*$'
             echo "::notice::Created desktop draft release $DRAFT_ID for $DESKTOP_TAG"
           fi

--- a/apps/desktop/tests/acceptance-support-boundary.test.ts
+++ b/apps/desktop/tests/acceptance-support-boundary.test.ts
@@ -88,4 +88,21 @@ describe("Desktop acceptance support boundary", () => {
 
     expect(violations).toEqual([]);
   });
+
+  it("captures a new desktop release id from the creation response", () => {
+    const workflow = readFileSync(
+      resolve(repositoryRoot, ".github/workflows/version-pr.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain(
+      'CREATED_RELEASE=$(gh api --method POST "repos/$GITHUB_REPOSITORY/releases"',
+    );
+    expect(workflow).toContain(
+      'DRAFT_ID=$(printf \'%s\' "$CREATED_RELEASE" | jq -er \'.id | tostring\')',
+    );
+    expect(workflow).not.toContain(
+      'DRAFT_ID=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100"',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- create the desktop draft through the Releases API
- capture its ID from the same response, eliminating the read-after-write race
- add a regression guard for the release workflow

## Root cause
Version PR run 31878168777 created the 0.1.4 draft, then immediately queried the releases list. The new draft was not indexed yet, so the lookup returned null and desktop-release was never dispatched.

## Verification
- pnpm exec vitest run apps/desktop/tests/acceptance-support-boundary.test.ts
- pnpm check
- workflow YAML parse
- git diff --check

No changeset: release infrastructure only.

Limits: none.