### PR TITLE
fix: publish stable desktop download alias

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -586,13 +586,36 @@ jobs:
           test "$ACTUAL_FILES" = "$EXPECTED_FILES"
           test "$(grep -c '^version:' "$PUBLIC_ENVELOPE/latest-mac.yml")" = '1'
           grep -q "^version: $DESKTOP_VERSION\$" "$PUBLIC_ENVELOPE/latest-mac.yml"
+          STABLE_DMG="$RUNNER_TEMP/Enduragent-arm64.dmg"
+          cp "$PUBLIC_ENVELOPE/Enduragent-$DESKTOP_VERSION-arm64.dmg" "$STABLE_DMG"
+          cmp -s "$PUBLIC_ENVELOPE/Enduragent-$DESKTOP_VERSION-arm64.dmg" "$STABLE_DMG"
           gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --clobber \
             "$PUBLIC_ENVELOPE/Enduragent-$DESKTOP_VERSION-arm64.dmg" \
             "$PUBLIC_ENVELOPE/Enduragent-$DESKTOP_VERSION-arm64.zip" \
             "$PUBLIC_ENVELOPE/Enduragent-$DESKTOP_VERSION-arm64.zip.blockmap" \
-            "$PUBLIC_ENVELOPE/latest-mac.yml"
-          ASSET_COUNT=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID" --jq '.assets | length')
-          test "$ASSET_COUNT" = '4'
+            "$PUBLIC_ENVELOPE/latest-mac.yml" \
+            "$STABLE_DMG"
+          EXPECTED_ASSETS=$(printf '%s\n' \
+            "Enduragent-$DESKTOP_VERSION-arm64.dmg" \
+            "Enduragent-$DESKTOP_VERSION-arm64.zip" \
+            "Enduragent-$DESKTOP_VERSION-arm64.zip.blockmap" \
+            Enduragent-arm64.dmg \
+            latest-mac.yml | LC_ALL=C sort)
+          RELEASE_ASSETS=$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID")
+          ACTUAL_ASSETS=$(printf '%s' "$RELEASE_ASSETS" | jq -r '.assets[].name' | LC_ALL=C sort)
+          test "$ACTUAL_ASSETS" = "$EXPECTED_ASSETS"
+          VERSIONED_DMG_ASSET=$(printf '%s' "$RELEASE_ASSETS" | jq -er \
+            --arg name "Enduragent-$DESKTOP_VERSION-arm64.dmg" \
+            '.assets[] | select(.name == $name)')
+          STABLE_DMG_ASSET=$(printf '%s' "$RELEASE_ASSETS" | jq -er \
+            --arg name Enduragent-arm64.dmg \
+            '.assets[] | select(.name == $name)')
+          VERSIONED_DMG_DIGEST=$(printf '%s' "$VERSIONED_DMG_ASSET" | jq -er '.digest')
+          STABLE_DMG_DIGEST=$(printf '%s' "$STABLE_DMG_ASSET" | jq -er '.digest')
+          printf '%s' "$VERSIONED_DMG_DIGEST" | grep -Eq '^sha256:[0-9a-f]{64}$'
+          test "$STABLE_DMG_DIGEST" = "$VERSIONED_DMG_DIGEST"
+          test "$(printf '%s' "$STABLE_DMG_ASSET" | jq -er '.size')" = \
+            "$(printf '%s' "$VERSIONED_DMG_ASSET" | jq -er '.size')"
           gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID" \
             -F draft=false --jq '.draft' | grep -q '^false$'
           gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_DRAFT_ID" \
@@ -607,8 +630,9 @@ jobs:
           set -euo pipefail
           for attempt in 1 2 3 4 5 6 7 8 9 10; do
             SERVED=$(curl -fsSL "https://github.com/$GITHUB_REPOSITORY/releases/latest/download/latest-mac.yml" | sed -n 's/^version: //p' | head -1) || SERVED=''
-            if [ "$SERVED" = "$DESKTOP_VERSION" ]; then
-              echo "Production feed serves $SERVED"
+            if [ "$SERVED" = "$DESKTOP_VERSION" ] && \
+              curl -fsSIL "https://github.com/$GITHUB_REPOSITORY/releases/latest/download/Enduragent-arm64.dmg" >/dev/null; then
+              echo "Production feed and stable DMG serve $SERVED"
               exit 0
             fi
             sleep 30

--- a/apps/desktop/tests/acceptance-support-boundary.test.ts
+++ b/apps/desktop/tests/acceptance-support-boundary.test.ts
@@ -99,10 +99,24 @@ describe("Desktop acceptance support boundary", () => {
       'CREATED_RELEASE=$(gh api --method POST "repos/$GITHUB_REPOSITORY/releases"',
     );
     expect(workflow).toContain(
-      'DRAFT_ID=$(printf \'%s\' "$CREATED_RELEASE" | jq -er \'.id | tostring\')',
+      "DRAFT_ID=$(printf '%s' \"$CREATED_RELEASE\" | jq -er '.id | tostring')",
     );
     expect(workflow).not.toContain(
       'DRAFT_ID=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100"',
     );
+  });
+
+  it("publishes and verifies a stable latest-release DMG alias", () => {
+    const workflow = readFileSync(
+      resolve(repositoryRoot, ".github/workflows/desktop-release.yml"),
+      "utf8",
+    );
+
+    expect(workflow).toContain('STABLE_DMG="$RUNNER_TEMP/Enduragent-arm64.dmg"');
+    const uploadStart = workflow.indexOf('gh release upload "$RELEASE_TAG"');
+    const assetCheck = workflow.indexOf("EXPECTED_ASSETS=", uploadStart);
+    expect(workflow.slice(uploadStart, assetCheck)).toContain('"$STABLE_DMG"');
+    expect(workflow).toContain('test "$STABLE_DMG_DIGEST" = "$VERSIONED_DMG_DIGEST"');
+    expect(workflow).toContain("releases/latest/download/Enduragent-arm64.dmg");
   });
 });

--- a/tools/desktop-release-github.test.ts
+++ b/tools/desktop-release-github.test.ts
@@ -9,6 +9,7 @@ import {
   DESKTOP_FEED_URL,
   DESKTOP_MANIFEST,
   DESKTOP_PROVISIONAL_RELEASE_BODY,
+  DESKTOP_STABLE_DMG_NAME,
   GithubClient,
   activateDesktopRelease,
   compensateDesktopRelease,
@@ -1396,6 +1397,59 @@ describe("GitHub desktop release transaction", () => {
     expect(readFileSync(output, "utf8")).toContain("baseline_tag=cycling-coach@2026.8.8");
     expect(readFileSync(output, "utf8")).toContain("baseline_version=0.1.0");
     expect(readdirSync(target).sort()).toEqual([...releaseFileNames("0.1.0")].sort());
+  });
+
+  it("accepts a stable DMG alias only when it matches the versioned release asset", async () => {
+    const accepted = new FakeGithub();
+    const acceptedCandidate = await steadyCandidate(accepted);
+    const acceptedDmg = acceptedCandidate.baseline.assets.find((asset) =>
+      asset.name.endsWith("-arm64.dmg"),
+    )!;
+    accepted.addAsset(
+      acceptedCandidate.baseline,
+      DESKTOP_STABLE_DMG_NAME,
+      accepted.bytes.get(acceptedDmg.url)!,
+    );
+    const acceptedOutputDirectory = mkdtempSync(join(tmpdir(), "desktop-baseline-output-"));
+    const acceptedTarget = mkdtempSync(join(tmpdir(), "desktop-baseline-target-"));
+    directories.push(acceptedOutputDirectory, acceptedTarget);
+    const acceptedOutput = join(acceptedOutputDirectory, "output");
+    writeFileSync(acceptedOutput, "");
+
+    await prepareDesktopBaseline(
+      acceptedTarget,
+      accepted.client(),
+      "steady",
+      candidateTag,
+      candidateVersion,
+      acceptedCandidate.baseline.tag_name,
+      acceptedOutput,
+    );
+
+    const rejected = new FakeGithub();
+    const rejectedCandidate = await steadyCandidate(rejected);
+    rejected.addAsset(
+      rejectedCandidate.baseline,
+      DESKTOP_STABLE_DMG_NAME,
+      Buffer.from("wrong-dmg"),
+    );
+    const rejectedOutputDirectory = mkdtempSync(join(tmpdir(), "desktop-baseline-output-"));
+    const rejectedTarget = mkdtempSync(join(tmpdir(), "desktop-baseline-target-"));
+    directories.push(rejectedOutputDirectory, rejectedTarget);
+    const rejectedOutput = join(rejectedOutputDirectory, "output");
+    writeFileSync(rejectedOutput, "");
+
+    await expect(
+      prepareDesktopBaseline(
+        rejectedTarget,
+        rejected.client(),
+        "steady",
+        candidateTag,
+        candidateVersion,
+        rejectedCandidate.baseline.tag_name,
+        rejectedOutput,
+      ),
+    ).rejects.toThrow("desktop baseline");
   });
 
   it.each([

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -134,6 +134,7 @@ export type NpmProvenanceBundleVerifier = (
 const desktopVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/u;
 const npmVersionPattern = /^([1-9]\d{3})\.([1-9]|1[0-2])\.(0|[1-9]\d*)$/u;
 const desktopTagPrefix = "enduragent-desktop@";
+export const DESKTOP_STABLE_DMG_NAME = "Enduragent-arm64.dmg";
 const legacyDesktopBaselineTag = "cycling-coach@2026.8.8";
 const legacyDesktopBaselineVersion = "0.1.0";
 const commitPattern = /^[0-9a-f]{40}$/u;
@@ -1256,9 +1257,21 @@ function desktopReleaseVersion(release: GithubRelease, excludingTag?: string): s
   if (versions.length !== 1 || versions[0] !== tagVersion) return null;
   const version = versions[0];
   const expected = [...releaseFileNames(version)].sort();
-  const actual = release.assets.map((asset) => asset.name).sort();
-  return actual.length === expected.length &&
-    actual.every((name, index) => name === expected[index])
+  const actual = release.assets
+    .filter((asset) => asset.name !== DESKTOP_STABLE_DMG_NAME)
+    .map((asset) => asset.name)
+    .sort();
+  if (actual.length !== expected.length || actual.some((name, index) => name !== expected[index])) {
+    return null;
+  }
+  const stableDmg = release.assets.find((asset) => asset.name === DESKTOP_STABLE_DMG_NAME);
+  if (!stableDmg) return version;
+  const versionedDmg = release.assets.find((asset) => asset.name === releaseFileNames(version)[0]);
+  return versionedDmg &&
+    stableDmg.state === "uploaded" &&
+    stableDmg.size === versionedDmg.size &&
+    stableDmg.digest !== null &&
+    stableDmg.digest === versionedDmg.digest
     ? version
     : null;
 }


### PR DESCRIPTION
## Summary

- Publish `Enduragent-arm64.dmg` from the verified signed desktop DMG during every desktop release.
- Require the versioned and stable DMG assets to have identical GitHub digests and sizes.
- Verify the stable `releases/latest/download` URL before the release job succeeds.
- Accept the stable alias in rollback baselines only when it matches the versioned DMG.

## Rollout

1. Merge this release-tooling PR.
2. Backfill `Enduragent-arm64.dmg` onto the existing desktop `0.1.4` release.
3. Verify the stable download URL.
4. Merge the dependent website PR.

## Verification

- `pnpm check` passed.
- 76 focused desktop-release tests passed.
- `desktop-release.yml` parsed successfully.
- Formatting and `git diff --check` passed.
- TruffleHog found no secrets.
- Full local `pnpm test` passed all changed suites; 14 unrelated tests failed under local Node 22 while hosted CI uses Node 24.

No changeset: this is release infrastructure only.

## Review note

Automated model review could not run because approval to transmit this private-repository diff to the external review service was denied. Direct diff review and repository gates completed.
