### PR TITLE
fix(desktop): accept slash-form Windows paths

### DIFF
--- a/apps/desktop-renderer/tests/onboarding-wizard.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-wizard.test.ts
@@ -61,8 +61,12 @@ describe("desktop onboarding wizard", () => {
       validateImportPaths(["/synthetic/a.FIT", "/synthetic/b.tcx", "/synthetic/c.GpX"]),
     ).toEqual(["/synthetic/a.FIT", "/synthetic/b.tcx", "/synthetic/c.GpX"]);
     expect(
-      validateImportPaths(["C:\\synthetic\\a.FIT", "\\\\server\\share\\b.gpx"]),
-    ).toEqual(["C:\\synthetic\\a.FIT", "\\\\server\\share\\b.gpx"]);
+      validateImportPaths([
+        "C:\\synthetic\\a.FIT",
+        "C:/synthetic/b.tcx",
+        "\\\\server\\share\\c.gpx",
+      ]),
+    ).toEqual(["C:\\synthetic\\a.FIT", "C:/synthetic/b.tcx", "\\\\server\\share\\c.gpx"]);
     expect(() => validateImportPaths(["C:\\synthetic\\photos.fit\\ride"])).toThrow(TypeError);
     expect(() => validateImportPaths(["C:relative\\a.fit"])).toThrow(TypeError);
     expect(() => validateImportPaths(["relative.fit"])).toThrow(TypeError);

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -335,7 +335,12 @@ describe("desktop preload ChatGPT auth", () => {
   });
 
   it("accepts platform-absolute import paths and validates uppercase extensions", async () => {
-    const paths = ["C:\\x\\ride.FIT", "\\\\server\\share\\ride.gpx", "/home/x/ride.tcx"] as const;
+    const paths = [
+      "C:\\x\\ride.FIT",
+      "C:/x/second-ride.gpx",
+      "\\\\server\\share\\ride.gpx",
+      "/home/x/ride.tcx",
+    ] as const;
     mocks.invoke.mockResolvedValue(paths);
 
     await expect(bridge.chooseImportFiles()).resolves.toEqual(paths);

--- a/apps/desktop/tests/training-export-ipc.test.ts
+++ b/apps/desktop/tests/training-export-ipc.test.ts
@@ -93,27 +93,29 @@ describe("desktop training export IPC", () => {
     expect(result).not.toHaveProperty("contentType");
   });
 
-  it("passes a Windows save-dialog destination to the exporter", async () => {
-    const subject = setup();
-    const destinationPath = "C:\\Users\\x\\Documents\\ride.fit";
-    subject.dialog.showSaveDialog.mockResolvedValueOnce({
-      canceled: false,
-      filePath: destinationPath,
-    });
+  it.each(["C:\\Users\\x\\Documents\\ride.fit", "C:/Users/x/Documents/ride.fit"])(
+    "passes the Windows save-dialog destination %s to the exporter",
+    async (destinationPath) => {
+      const subject = setup();
+      subject.dialog.showSaveDialog.mockResolvedValueOnce({
+        canceled: false,
+        filePath: destinationPath,
+      });
 
-    await expect(
-      subject.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(subject.trusted, {
-        kind: "activity",
-        canonicalActivityId: "a".repeat(64),
-        localDate: "1998-07-19",
-        format: "fit",
-      }),
-    ).resolves.toEqual({ status: "saved", byteLength: 4_096 });
-    expect(subject.exporter.export).toHaveBeenCalledWith(
-      expect.objectContaining({ destinationPath }),
-    );
-    expect(subject.log).not.toHaveBeenCalled();
-  });
+      await expect(
+        subject.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(subject.trusted, {
+          kind: "activity",
+          canonicalActivityId: "a".repeat(64),
+          localDate: "1998-07-19",
+          format: "fit",
+        }),
+      ).resolves.toEqual({ status: "saved", byteLength: 4_096 });
+      expect(subject.exporter.export).toHaveBeenCalledWith(
+        expect.objectContaining({ destinationPath }),
+      );
+      expect(subject.log).not.toHaveBeenCalled();
+    },
+  );
 
   it("routes a closed workout archive request and handles cancellation without daemon work", async () => {
     const subject = setup();

--- a/packages/coach-contract/src/platform-path.ts
+++ b/packages/coach-contract/src/platform-path.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export function isPlatformAbsolutePath(value: string): boolean {
   if (value.includes("\0")) return false;
   if (value.startsWith("/")) return true;
-  if (/^[A-Za-z]:\\/.test(value)) return true;
+  if (/^[A-Za-z]:[\\/]/.test(value)) return true;
   if (!value.startsWith("\\\\")) return false;
   const [server, share] = value.slice(2).split("\\");
   return server !== "" && share !== undefined && share !== "";

--- a/packages/coach-contract/tests/platform-path.test.ts
+++ b/packages/coach-contract/tests/platform-path.test.ts
@@ -6,18 +6,21 @@ describe.each([
   ["training export", TrainingExportDestinationPathSchema],
   ["training import", AbsoluteImportPathSchema],
 ])("%s absolute path contract", (_name, schema) => {
-  it.each(["/home/x/ride.fit", "C:\\Users\\x\\Documents\\ride.fit", "\\\\server\\share\\ride.fit"])(
-    "accepts %s",
-    (path) => {
-      expect(schema.parse(path)).toBe(path);
-    },
-  );
+  it.each([
+    "/home/x/ride.fit",
+    "C:\\Users\\x\\Documents\\ride.fit",
+    "C:/Users/x/Documents/ride.fit",
+    "\\\\server\\share\\ride.fit",
+  ])("accepts %s", (path) => {
+    expect(schema.parse(path)).toBe(path);
+  });
 
   it.each([
     ["empty", ""],
     ["filename", "ride.fit"],
     ["dot-relative", "./x"],
     ["backslash-relative", "x\\y"],
+    ["drive-relative", "C:relative\\ride.fit"],
     ["NUL", "/home/x/ride\0.fit"],
     ["over-length", `/${"x".repeat(4_096)}`],
   ])("rejects %s paths", (_case, path) => {

--- a/packages/coach/src/training-export.ts
+++ b/packages/coach/src/training-export.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { open, rename, rm } from "node:fs/promises";
-import { basename, dirname, isAbsolute, join, normalize } from "node:path";
+import { posix, win32 } from "node:path";
 import { makeAbortableClient } from "@enduragent/core";
 import {
   ExportTrainingFileRpcResultSchema,
@@ -176,6 +176,10 @@ async function syncDirectory(path: string): Promise<void> {
 
 export function createDurableTrainingExportWriter(input?: {
   readonly platform?: NodeJS.Platform;
+  readonly pathApi?: Pick<
+    typeof posix,
+    "basename" | "dirname" | "isAbsolute" | "join" | "normalize"
+  >;
   readonly createTemporaryId?: () => string;
   readonly openFile?: typeof open;
   readonly renameFile?: typeof rename;
@@ -183,6 +187,7 @@ export function createDurableTrainingExportWriter(input?: {
   readonly syncDirectory?: (path: string) => Promise<void>;
 }): TrainingExportWriter {
   const platform = input?.platform ?? process.platform;
+  const pathApi = input?.pathApi ?? (platform === "win32" ? win32 : posix);
   const createTemporaryId = input?.createTemporaryId ?? (() => randomBytes(12).toString("hex"));
   const openFile = input?.openFile ?? open;
   const renameFile = input?.renameFile ?? rename;
@@ -194,11 +199,14 @@ export function createDurableTrainingExportWriter(input?: {
       readonly bytes: Uint8Array;
       readonly signal?: AbortSignal;
     }): Promise<TrainingExportWriteOutcome> {
-      const destination = request.destinationPath;
-      const fileName = basename(destination);
+      const destination =
+        platform === "win32" && /^[A-Za-z]:[\\/]/.test(request.destinationPath)
+          ? request.destinationPath.replaceAll("/", "\\")
+          : request.destinationPath;
+      const fileName = pathApi.basename(destination);
       if (
-        !isAbsolute(destination) ||
-        normalize(destination) !== destination ||
+        !pathApi.isAbsolute(destination) ||
+        pathApi.normalize(destination) !== destination ||
         fileName.length === 0 ||
         fileName === "/" ||
         fileName === "." ||
@@ -206,10 +214,10 @@ export function createDurableTrainingExportWriter(input?: {
       ) {
         return "failed";
       }
-      const root = dirname(destination);
+      const root = pathApi.dirname(destination);
       const id = createTemporaryId();
       if (!/^[A-Za-z0-9-]{1,128}$/.test(id)) return "failed";
-      const temporary = join(root, `.enduragent-export-${id}.tmp`);
+      const temporary = pathApi.join(root, `.enduragent-export-${id}.tmp`);
       let handle: Awaited<ReturnType<typeof open>> | undefined;
       let renamed = false;
       try {

--- a/packages/coach/tests/training-export.test.ts
+++ b/packages/coach/tests/training-export.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, open, readFile, readdir, rename, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TrustedActivitySourceResolver } from "@enduragent/kernel/store";
 import {
@@ -600,6 +600,7 @@ describe("durable training export writer", () => {
 
       const writer = createDurableTrainingExportWriter({
         platform,
+        pathApi: posix,
         createTemporaryId: () => `committed-${platform}`,
         renameFile: rename,
         syncDirectory,
@@ -611,6 +612,57 @@ describe("durable training export writer", () => {
       expect(await readFile(destinationPath)).toEqual(Buffer.from([2]));
     },
   );
+
+  it("normalizes slash-form Windows drive paths before atomic commit", async () => {
+    const handle = {
+      writeFile: vi.fn(async () => {}),
+      chmod: vi.fn(async () => {}),
+      sync: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+    };
+    const openFile = vi.fn(async () => handle);
+    const renameFile = vi.fn(async () => {});
+    const removeFile = vi.fn(async () => {}) as never;
+    const writer = createDurableTrainingExportWriter({
+      platform: "win32",
+      createTemporaryId: () => "slash-form",
+      openFile: openFile as never,
+      renameFile,
+      removeFile,
+    });
+    const temporary = "C:\\Users\\x\\Documents\\.enduragent-export-slash-form.tmp";
+    const destination = "C:\\Users\\x\\Documents\\ride.fit";
+
+    await expect(
+      writer.write({
+        destinationPath: "C:/Users/x/Documents/ride.fit",
+        bytes: Uint8Array.from([1, 2, 3]),
+      }),
+    ).resolves.toBe("committed");
+    expect(openFile).toHaveBeenCalledWith(temporary, "wx", 0o600);
+    expect(renameFile).toHaveBeenCalledWith(temporary, destination);
+    expect(removeFile).toHaveBeenCalledWith(temporary, { force: true });
+
+  });
+
+  it.each([
+    "C:relative/ride.fit",
+    "C:/Users//x/ride.fit",
+    "C:/Users/x/./ride.fit",
+    "C:/Users/x/../ride.fit",
+  ])("rejects the noncanonical Windows path %s", async (destinationPath) => {
+    const openFile = vi.fn();
+    const writer = createDurableTrainingExportWriter({
+      platform: "win32",
+      createTemporaryId: () => "invalid-path",
+      openFile: openFile as never,
+    });
+
+    await expect(
+      writer.write({ destinationPath, bytes: Uint8Array.from([1]) }),
+    ).resolves.toBe("failed");
+    expect(openFile).not.toHaveBeenCalled();
+  });
 
   it("does not rename when cancellation is observed before the commit point", async () => {
     const controller = new AbortController();


### PR DESCRIPTION
Summary:
- accept slash-form Windows drive paths in the shared import/export contract
- normalize qualified Windows drive paths before durable filesystem writes
- preserve canonical-path rejection and cover contract, preload, renderer, IPC, and writer boundaries

Verification:
- 145 focused tests passed
- pnpm check passed
- fresh read-only verification passed with no findings

Limits: none.