### PR TITLE
fix(desktop): classify export failures safely

### DIFF
--- a/.changeset/windows-path-gates.md
+++ b/.changeset/windows-path-gates.md
@@ -4,4 +4,4 @@
 
 User-facing: Exporting a ride and importing ride files now work on Windows. Both used to fail with "The export could not be saved to that location" because every Windows path was rejected before anything was read or written.
 
-Export destinations and import paths now share one platform-absolute path validator that accepts POSIX, drive-letter and UNC paths; the preload and renderer import gates parse extensions across both separators; the export writer joins its temporary path with the platform separator and skips the post-rename directory fsync on Windows, where directory handles cannot be synced; and desktop export IPC now logs the caught error before reporting a write failure.
+Export destinations and import paths now share one platform-absolute path validator that accepts POSIX, drive-letter and UNC paths; the preload and renderer import gates parse extensions across both separators; the export writer joins its temporary path with the platform separator and skips the post-rename directory fsync on Windows, where directory handles cannot be synced; and desktop export IPC now logs a fixed failure-stage classification before reporting a write failure.

--- a/apps/desktop/src/main/training-export-ipc.ts
+++ b/apps/desktop/src/main/training-export-ipc.ts
@@ -99,12 +99,6 @@ function refusedWrite(): DesktopTrainingExportResult {
   return { status: "refused", reason: "write-failed" };
 }
 
-function describeWriteFailure(error: unknown): string {
-  const name = error instanceof Error ? error.name : "NonError";
-  const message = error instanceof Error ? error.message : String(error);
-  return `desktop-training-export-write-failed name=${JSON.stringify(name)} message=${JSON.stringify(message)}`;
-}
-
 export function installDesktopTrainingExportIpc(input: {
   readonly ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
   readonly currentWindow: () => BrowserWindow | undefined;
@@ -128,8 +122,8 @@ export function installDesktopTrainingExportIpc(input: {
       let selection: Awaited<ReturnType<TrainingExportDialogPort["showSaveDialog"]>>;
       try {
         selection = await input.dialog.showSaveDialog(window, saveDialogOptions(parsed.data));
-      } catch (error) {
-        log(describeWriteFailure(error));
+      } catch {
+        log("desktop-training-export-failed stage=dialog");
         return refusedWrite();
       }
       if (selection.canceled || selection.filePath === undefined) return { status: "cancelled" };
@@ -145,8 +139,8 @@ export function installDesktopTrainingExportIpc(input: {
             ? { status: "saved", byteLength: result.byteLength }
             : result,
         );
-      } catch (error) {
-        log(describeWriteFailure(error));
+      } catch {
+        log("desktop-training-export-failed stage=operation");
         return refusedWrite();
       }
     },

--- a/apps/desktop/tests/training-export-ipc.test.ts
+++ b/apps/desktop/tests/training-export-ipc.test.ts
@@ -198,7 +198,7 @@ describe("desktop training export IPC", () => {
     expect(subject.exporter.export).not.toHaveBeenCalled();
   });
 
-  it("redacts dialog, daemon, and malformed-result failures", async () => {
+  it("logs stable failure stages without exposing exception details", async () => {
     const request = {
       kind: "activity",
       canonicalActivityId: "a".repeat(64),
@@ -209,24 +209,20 @@ describe("desktop training export IPC", () => {
     await expect(
       malformed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(malformed.trusted, request),
     ).resolves.toEqual({ status: "refused", reason: "write-failed" });
-    expect(malformed.log).toHaveBeenCalledWith(expect.stringContaining('name="ZodError"'));
+    expect(malformed.log).toHaveBeenCalledWith("desktop-training-export-failed stage=operation");
 
     const failed = setup();
     failed.exporter.export.mockRejectedValueOnce(new Error("private provider response"));
     await expect(
       failed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(failed.trusted, request),
     ).resolves.toEqual({ status: "refused", reason: "write-failed" });
-    expect(failed.log).toHaveBeenLastCalledWith(
-      'desktop-training-export-write-failed name="Error" message="private provider response"',
-    );
+    expect(failed.log).toHaveBeenLastCalledWith("desktop-training-export-failed stage=operation");
 
     failed.dialog.showSaveDialog.mockRejectedValueOnce(new Error("private filesystem path"));
     await expect(
       failed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(failed.trusted, request),
     ).resolves.toEqual({ status: "refused", reason: "write-failed" });
-    expect(failed.log).toHaveBeenLastCalledWith(
-      'desktop-training-export-write-failed name="Error" message="private filesystem path"',
-    );
+    expect(failed.log).toHaveBeenLastCalledWith("desktop-training-export-failed stage=dialog");
 
     failed.dialog.showSaveDialog.mockResolvedValueOnce({
       canceled: false,
@@ -235,8 +231,51 @@ describe("desktop training export IPC", () => {
     await expect(
       failed.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(failed.trusted, request),
     ).resolves.toEqual({ status: "refused", reason: "write-failed" });
-    expect(failed.log).toHaveBeenLastCalledWith(expect.stringContaining('name="ZodError"'));
+    expect(failed.log).toHaveBeenLastCalledWith("desktop-training-export-failed stage=operation");
     expect(failed.log).toHaveBeenCalledTimes(3);
+    expect(JSON.stringify([...malformed.log.mock.calls, ...failed.log.mock.calls])).not.toContain(
+      "private",
+    );
+  });
+
+  it("does not inspect rejected values or let logging failures escape", async () => {
+    const request = {
+      kind: "activity",
+      canonicalActivityId: "a".repeat(64),
+      localDate: "1998-07-19",
+      format: "fit",
+    } as const;
+    const subject = setup();
+    const hostileError = new Error();
+    Object.defineProperty(hostileError, "message", {
+      get() {
+        throw new Error("message getter was inspected");
+      },
+    });
+    subject.exporter.export.mockRejectedValueOnce(hostileError);
+
+    await expect(
+      subject.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(subject.trusted, request),
+    ).resolves.toEqual({ status: "refused", reason: "write-failed" });
+    expect(subject.log).toHaveBeenLastCalledWith("desktop-training-export-failed stage=operation");
+
+    subject.dialog.showSaveDialog.mockRejectedValueOnce({
+      toString() {
+        throw new Error("string conversion was attempted");
+      },
+    });
+    await expect(
+      subject.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(subject.trusted, request),
+    ).resolves.toEqual({ status: "refused", reason: "write-failed" });
+    expect(subject.log).toHaveBeenLastCalledWith("desktop-training-export-failed stage=dialog");
+
+    subject.log.mockImplementationOnce(() => {
+      throw new Error("logger unavailable");
+    });
+    subject.dialog.showSaveDialog.mockRejectedValueOnce(new Error("dialog unavailable"));
+    await expect(
+      subject.handlers.get(DESKTOP_TRAINING_EXPORT_CHANNEL)!(subject.trusted, request),
+    ).resolves.toEqual({ status: "refused", reason: "write-failed" });
   });
 
   it("uses one privileged client and closes it after the export", async () => {

--- a/apps/desktop/tests/training-export-ipc.test.ts
+++ b/apps/desktop/tests/training-export-ipc.test.ts
@@ -198,7 +198,7 @@ describe("desktop training export IPC", () => {
     expect(subject.exporter.export).not.toHaveBeenCalled();
   });
 
-  it("logs stable failure stages without exposing exception details", async () => {
+  it("redacts dialog, daemon, and malformed-result failures", async () => {
     const request = {
       kind: "activity",
       canonicalActivityId: "a".repeat(64),


### PR DESCRIPTION
Summary:
- replace exception-derived export logs with fixed dialog and operation classifications
- avoid reading exception names, messages, or string conversions
- preserve failure responses even when the injected logger throws
- update the existing Windows export changeset wording

Verification:
- 9 focused tests passed
- pnpm check passed
- fresh read-only verification passed with no findings

Stacking: this PR will be retargeted to epic/windows after #666 merges.

Limits: none.