### PR TITLE
Version Packages

### DIFF
--- a/.changeset/atomic-session-timezone-pin.md
+++ b/.changeset/atomic-session-timezone-pin.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: Saving a timezone now keeps the timezone and its pin together, so Enduragent cannot lose the saved choice between two separate writes.

--- a/.changeset/button-primitive-consistency.md
+++ b/.changeset/button-primitive-consistency.md
@@ -1,7 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: Delete buttons in setup and settings now sit at the same weight as the buttons beside them and differ only in colour, the confirm button in a delete prompt is a filled red so it never reads as the same control as Cancel, and buttons, links and dropdowns across setup and settings show the hand cursor on hover.
-
-Danger is a colour, not a button weight. The renderer now exports exactly two danger constants: `BUTTON_DANGER_QUIET_SM` at the quiet weight (no border, transparent background) for every in-row destructive action, and `BUTTON_DANGER_SOLID_SM` at the solid weight for the confirm button in `InlineConfirmation`, where a fill keeps the destructive action distinguishable from Cancel without relying on colour alone. `surface.module.css` `.dangerous` mirrors the quiet variant so the Reset conversation button matches without migrating that file to Tailwind.

--- a/.changeset/calm-services-start.md
+++ b/.changeset/calm-services-start.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: Fixed Desktop startup when an existing Intervals refresh cannot be saved.

--- a/.changeset/chatgpt-clock-skew-tolerance.md
+++ b/.changeset/chatgpt-clock-skew-tolerance.md
@@ -1,7 +1,0 @@
----
-"cycling-coach": patch
----
-
-User-facing: ChatGPT sign-in now keeps working on machines with a wrong clock, and sign-in problems show up as authentication errors instead of a generic failure.
-
-Token validity no longer depends on the local wall clock: the ChatGPT-lane token readers return the stored access token as-is and treat a server 401 as the only invalid signal, with one bounded refresh-and-retry per generation (MAX_AUTH_REFRESH_ATTEMPTS = 1). HTTP 401/403 from the provider is classified as error_class "auth" in turn_outcome. Coaching dates and daily resets intentionally stay on the local clock.

--- a/.changeset/crash-telemetry-desktop-main.md
+++ b/.changeset/crash-telemetry-desktop-main.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-Log renderer and child-process crashes from the desktop main process and start Electron's crash reporter with local-only minidumps (`uploadToServer: false`). Fields are collapsed to one stderr line, query strings and fragments are dropped from the crashed URL, and oversized values are truncated.

--- a/.changeset/native-theme-title-bar.md
+++ b/.changeset/native-theme-title-bar.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: The native window title bar now follows the appearance you pick in Preferences, so a dark app no longer sits under light window chrome.

--- a/.changeset/onboarding-status-cold-start.md
+++ b/.changeset/onboarding-status-cold-start.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: The first launch after installing no longer reports a fully-configured install as unconfigured — setup status now retries while the coach is still starting, shows a neutral "Checking setup…" state until it is known, and the Training page keeps reporting ride imports once setup is complete.

--- a/.changeset/session-timezone-follows-host.md
+++ b/.changeset/session-timezone-follows-host.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: Enduragent now uses this computer's timezone by default and refreshes it every time it starts, so a machine that moves zones no longer coaches on the old one. Save a timezone yourself in Settings → Conversation & time and Enduragent keeps that one from then on. COACH_TZ still owns the timezone when it is set.

--- a/.changeset/settings-coach-label-layout.md
+++ b/.changeset/settings-coach-label-layout.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: Settings now shows the coach Provider row's title and its active-route detail on separate lines instead of running them together.

--- a/.changeset/telegram-startup-degrade.md
+++ b/.changeset/telegram-startup-degrade.md
@@ -1,7 +1,0 @@
----
-"cycling-coach": patch
----
-
-User-facing: Enduragent now opens normally when Telegram setup is left in an uncertain state after a crash or forced quit; the Telegram section shows a repair prompt instead of the whole app refusing to start.
-
-Startup no longer throws when the initial Telegram reconciliation returns a non-applied outcome. The channel is latched into its existing failed/repair status until a successful reconcile or a daemon rebind clears it, and unexpected startup failures are now written to log.jsonl as a classified startup_failed record before any dialog.

--- a/.changeset/telegram-user-removal-confirmation.md
+++ b/.changeset/telegram-user-removal-confirmation.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: Removing an additional Telegram user now asks for confirmation and explains that the user loses access until re-added by sender ID.

--- a/.changeset/windows-conversation-recovery.md
+++ b/.changeset/windows-conversation-recovery.md
@@ -1,5 +1,0 @@
----
-"cycling-coach": patch
----
-
-User-facing: Enduragent now recovers Windows conversations after a crash interrupts reset-intent or transcript-boundary writes.

--- a/.changeset/windows-locale-paks.md
+++ b/.changeset/windows-locale-paks.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-Ship the `en-US` Chromium locale pak in the Windows package. `electronLanguages: [en]` matched nothing under app-builder-lib's inverted prefix filter, so every locale pak was deleted from `win-unpacked/locales/` and Blink null-dereferenced in `Locale::DefaultLocale` the first time a renderer wrote a value into a number input. The Windows package verifier now requires a present, non-empty `locales/en-US.pak` and rejects any other locale entry.

--- a/.changeset/windows-native-package-verification.md
+++ b/.changeset/windows-native-package-verification.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-Verify the Windows installer envelope and retained application tree with native Node.js tooling, and emit immutable SHA-256 package evidence without relying on a machine-installed archive utility.

--- a/.changeset/windows-parity-ci.md
+++ b/.changeset/windows-parity-ci.md
@@ -1,5 +1,0 @@
----
-"cycling-coach": patch
----
-
-Internal: Add hosted Windows verification for the installed unsigned NSIS package and its cleanup contract.

--- a/.changeset/windows-path-gates.md
+++ b/.changeset/windows-path-gates.md
@@ -1,7 +1,0 @@
----
-"cycling-coach": patch
----
-
-User-facing: Exporting a ride and importing ride files now work on Windows. Both used to fail with "The export could not be saved to that location" because every Windows path was rejected before anything was read or written.
-
-Export destinations and import paths now share one platform-absolute path validator that accepts POSIX, drive-letter and UNC paths; the preload and renderer import gates parse extensions across both separators; the export writer joins its temporary path with the platform separator and skips the post-rename directory fsync on Windows, where directory handles cannot be synced; and desktop export IPC now logs a fixed failure-stage classification before reporting a write failure.

--- a/.changeset/windows-sport-skill-codegen.md
+++ b/.changeset/windows-sport-skill-codegen.md
@@ -1,5 +1,0 @@
----
-"cycling-coach": patch
----
-
-Internal: Stage generated sport-skill modules beside their destination so atomic replacement also works when Windows temp and workspace directories are on different drives.

--- a/.changeset/windows-startup-registration-cleanup.md
+++ b/.changeset/windows-startup-registration-cleanup.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: Uninstalling Enduragent on Windows now removes both owned login-start registry values while preserving athlete data and desktop settings.

--- a/.changeset/windows-update-floor.md
+++ b/.changeset/windows-update-floor.md
@@ -1,5 +1,0 @@
----
-"@enduragent/desktop": patch
----
-
-User-facing: The Windows app now enforces the update downgrade floor; previously it was silently inactive on Windows.

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @enduragent/desktop
 
+## 0.1.5
+
+### Patch Changes
+
+- fb370fb: User-facing: Saving a timezone now keeps the timezone and its pin together, so Enduragent cannot lose the saved choice between two separate writes.
+- 10678ab: User-facing: Delete buttons in setup and settings now sit at the same weight as the buttons beside them and differ only in colour, the confirm button in a delete prompt is a filled red so it never reads as the same control as Cancel, and buttons, links and dropdowns across setup and settings show the hand cursor on hover.
+
+  Danger is a colour, not a button weight. The renderer now exports exactly two danger constants: `BUTTON_DANGER_QUIET_SM` at the quiet weight (no border, transparent background) for every in-row destructive action, and `BUTTON_DANGER_SOLID_SM` at the solid weight for the confirm button in `InlineConfirmation`, where a fill keeps the destructive action distinguishable from Cancel without relying on colour alone. `surface.module.css` `.dangerous` mirrors the quiet variant so the Reset conversation button matches without migrating that file to Tailwind.
+
+- 85fd087: User-facing: Fixed Desktop startup when an existing Intervals refresh cannot be saved.
+- be36645: Log renderer and child-process crashes from the desktop main process and start Electron's crash reporter with local-only minidumps (`uploadToServer: false`). Fields are collapsed to one stderr line, query strings and fragments are dropped from the crashed URL, and oversized values are truncated.
+- 63637ca: User-facing: The native window title bar now follows the appearance you pick in Preferences, so a dark app no longer sits under light window chrome.
+- 7438087: User-facing: The first launch after installing no longer reports a fully-configured install as unconfigured — setup status now retries while the coach is still starting, shows a neutral "Checking setup…" state until it is known, and the Training page keeps reporting ride imports once setup is complete.
+- d7dc601: User-facing: Enduragent now uses this computer's timezone by default and refreshes it every time it starts, so a machine that moves zones no longer coaches on the old one. Save a timezone yourself in Settings → Conversation & time and Enduragent keeps that one from then on. COACH_TZ still owns the timezone when it is set.
+- 73269ae: User-facing: Settings now shows the coach Provider row's title and its active-route detail on separate lines instead of running them together.
+- 381ea8a: User-facing: Removing an additional Telegram user now asks for confirmation and explains that the user loses access until re-added by sender ID.
+- 479180d: Ship the `en-US` Chromium locale pak in the Windows package. `electronLanguages: [en]` matched nothing under app-builder-lib's inverted prefix filter, so every locale pak was deleted from `win-unpacked/locales/` and Blink null-dereferenced in `Locale::DefaultLocale` the first time a renderer wrote a value into a number input. The Windows package verifier now requires a present, non-empty `locales/en-US.pak` and rejects any other locale entry.
+- a0571e3: Verify the Windows installer envelope and retained application tree with native Node.js tooling, and emit immutable SHA-256 package evidence without relying on a machine-installed archive utility.
+- a0571e3: User-facing: Uninstalling Enduragent on Windows now removes both owned login-start registry values while preserving athlete data and desktop settings.
+- b4c0197: User-facing: The Windows app now enforces the update downgrade floor; previously it was silently inactive on Windows.
+
 ## 0.1.4
 
 ### Patch Changes

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enduragent/desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "main": "out/main/index.js",

--- a/packages/cycling-coach/CHANGELOG.md
+++ b/packages/cycling-coach/CHANGELOG.md
@@ -1,5 +1,25 @@
 # cycling-coach
 
+## 2026.8.18
+
+### Patch Changes
+
+- df20eb1: User-facing: ChatGPT sign-in now keeps working on machines with a wrong clock, and sign-in problems show up as authentication errors instead of a generic failure.
+
+  Token validity no longer depends on the local wall clock: the ChatGPT-lane token readers return the stored access token as-is and treat a server 401 as the only invalid signal, with one bounded refresh-and-retry per generation (MAX_AUTH_REFRESH_ATTEMPTS = 1). HTTP 401/403 from the provider is classified as error_class "auth" in turn_outcome. Coaching dates and daily resets intentionally stay on the local clock.
+
+- d141441: User-facing: Enduragent now opens normally when Telegram setup is left in an uncertain state after a crash or forced quit; the Telegram section shows a repair prompt instead of the whole app refusing to start.
+
+  Startup no longer throws when the initial Telegram reconciliation returns a non-applied outcome. The channel is latched into its existing failed/repair status until a successful reconcile or a daemon rebind clears it, and unexpected startup failures are now written to log.jsonl as a classified startup_failed record before any dialog.
+
+- 5eecfd8: User-facing: Enduragent now recovers Windows conversations after a crash interrupts reset-intent or transcript-boundary writes.
+- a0571e3: Internal: Add hosted Windows verification for the installed unsigned NSIS package and its cleanup contract.
+- 8b8991a: User-facing: Exporting a ride and importing ride files now work on Windows. Both used to fail with "The export could not be saved to that location" because every Windows path was rejected before anything was read or written.
+
+  Export destinations and import paths now share one platform-absolute path validator that accepts POSIX, drive-letter and UNC paths; the preload and renderer import gates parse extensions across both separators; the export writer joins its temporary path with the platform separator and skips the post-rename directory fsync on Windows, where directory handles cannot be synced; and desktop export IPC now logs a fixed failure-stage classification before reporting a write failure.
+
+- 40c9230: Internal: Stage generated sport-skill modules beside their destination so atomic replacement also works when Windows temp and workspace directories are on different drives.
+
 ## 2026.8.15
 
 ### Patch Changes

--- a/packages/cycling-coach/package.json
+++ b/packages/cycling-coach/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cycling-coach",
-  "version": "2026.8.15",
+  "version": "2026.8.18",
   "description": "AI cycling coaching agent — BYOK + intervals.icu + Telegram",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
This PR was prepared by the Version PR workflow (Changesets). Merging it versions the packages, publishes `cycling-coach@2026.8.18` to npm, and dispatches the Enduragent Desktop `0.1.5` release pipeline.

The workflow versioned and pushed this branch but could not open the PR itself ("GitHub Actions is not permitted to create or approve pull requests"), so this PR was opened manually from the untouched `changeset-release/main` branch.

# Releases

## @enduragent/desktop

### 0.1.5

#### Patch Changes

- fb370fb: User-facing: Saving a timezone now keeps the timezone and its pin together, so Enduragent cannot lose the saved choice between two separate writes.
- 10678ab: User-facing: Delete buttons in setup and settings now sit at the same weight as the buttons beside them and differ only in colour, the confirm button in a delete prompt is a filled red so it never reads as the same control as Cancel, and buttons, links and dropdowns across setup and settings show the hand cursor on hover.

  Danger is a colour, not a button weight. The renderer now exports exactly two danger constants: `BUTTON_DANGER_QUIET_SM` at the quiet weight (no border, transparent background) for every in-row destructive action, and `BUTTON_DANGER_SOLID_SM` at the solid weight for the confirm button in `InlineConfirmation`, where a fill keeps the destructive action distinguishable from Cancel without relying on colour alone. `surface.module.css` `.dangerous` mirrors the quiet variant so the Reset conversation button matches without migrating that file to Tailwind.

- 85fd087: User-facing: Fixed Desktop startup when an existing Intervals refresh cannot be saved.
- be36645: Log renderer and child-process crashes from the desktop main process and start Electron's crash reporter with local-only minidumps (`uploadToServer: false`). Fields are collapsed to one stderr line, query strings and fragments are dropped from the crashed URL, and oversized values are truncated.
- 63637ca: User-facing: The native window title bar now follows the appearance you pick in Preferences, so a dark app no longer sits under light window chrome.
- 7438087: User-facing: The first launch after installing no longer reports a fully-configured install as unconfigured — setup status now retries while the coach is still starting, shows a neutral "Checking setup…" state until it is known, and the Training page keeps reporting ride imports once setup is complete.
- d7dc601: User-facing: Enduragent now uses this computer's timezone by default and refreshes it every time it starts, so a machine that moves zones no longer coaches on the old one. Save a timezone yourself in Settings → Conversation & time and Enduragent keeps that one from then on. COACH_TZ still owns the timezone when it is set.
- 73269ae: User-facing: Settings now shows the coach Provider row's title and its active-route detail on separate lines instead of running them together.
- 381ea8a: User-facing: Removing an additional Telegram user now asks for confirmation and explains that the user loses access until re-added by sender ID.
- 479180d: Ship the `en-US` Chromium locale pak in the Windows package. `electronLanguages: [en]` matched nothing under app-builder-lib's inverted prefix filter, so every locale pak was deleted from `win-unpacked/locales/` and Blink null-dereferenced in `Locale::DefaultLocale` the first time a renderer wrote a value into a number input. The Windows package verifier now requires a present, non-empty `locales/en-US.pak` and rejects any other locale entry.
- a0571e3: Verify the Windows installer envelope and retained application tree with native Node.js tooling, and emit immutable SHA-256 package evidence without relying on a machine-installed archive utility.
- a0571e3: User-facing: Uninstalling Enduragent on Windows now removes both owned login-start registry values while preserving athlete data and desktop settings.
- b4c0197: User-facing: The Windows app now enforces the update downgrade floor; previously it was silently inactive on Windows.


## cycling-coach

### 2026.8.18

#### Patch Changes

- df20eb1: User-facing: ChatGPT sign-in now keeps working on machines with a wrong clock, and sign-in problems show up as authentication errors instead of a generic failure.

  Token validity no longer depends on the local wall clock: the ChatGPT-lane token readers return the stored access token as-is and treat a server 401 as the only invalid signal, with one bounded refresh-and-retry per generation (MAX_AUTH_REFRESH_ATTEMPTS = 1). HTTP 401/403 from the provider is classified as error_class "auth" in turn_outcome. Coaching dates and daily resets intentionally stay on the local clock.

- d141441: User-facing: Enduragent now opens normally when Telegram setup is left in an uncertain state after a crash or forced quit; the Telegram section shows a repair prompt instead of the whole app refusing to start.

  Startup no longer throws when the initial Telegram reconciliation returns a non-applied outcome. The channel is latched into its existing failed/repair status until a successful reconcile or a daemon rebind clears it, and unexpected startup failures are now written to log.jsonl as a classified startup_failed record before any dialog.

- 5eecfd8: User-facing: Enduragent now recovers Windows conversations after a crash interrupts reset-intent or transcript-boundary writes.
- a0571e3: Internal: Add hosted Windows verification for the installed unsigned NSIS package and its cleanup contract.
- 8b8991a: User-facing: Exporting a ride and importing ride files now work on Windows. Both used to fail with "The export could not be saved to that location" because every Windows path was rejected before anything was read or written.

  Export destinations and import paths now share one platform-absolute path validator that accepts POSIX, drive-letter and UNC paths; the preload and renderer import gates parse extensions across both separators; the export writer joins its temporary path with the platform separator and skips the post-rename directory fsync on Windows, where directory handles cannot be synced; and desktop export IPC now logs a fixed failure-stage classification before reporting a write failure.

- 40c9230: Internal: Stage generated sport-skill modules beside their destination so atomic replacement also works when Windows temp and workspace directories are on different drives.

