### PR TITLE
feat(desktop): add team-signed keychain helper and partition backend

### DIFF
--- a/apps/desktop/CONTEXT.md
+++ b/apps/desktop/CONTEXT.md
@@ -1,0 +1,50 @@
+# Desktop
+
+The Electron desktop application. Hosts the coaching daemon, the renderer, and the credential storage the athlete configures during onboarding. This file is the shared vocabulary for that credential storage; it defines terms, not mechanisms.
+
+## Language
+
+**Vault**:
+A store of encrypted credential records owned by the desktop app. Two exist: the per-slot LLM and intervals.icu store (`credentials-v1`) and the single-record Telegram profile store (`telegram-channel-v1`). A vault owns durability, refusal, and uncertainty; it never owns encryption.
+_Avoid_: Keystore, secret store, credential manager
+
+**Slot**:
+One named credential position inside a vault — one AI provider or intervals.icu. A slot holds at most one credential and carries its own state (`missing`, `configured`, `re-prompt`) independently of every other slot.
+_Avoid_: Key, entry, provider (a provider is the upstream service; a slot is where its credential lives)
+
+**Envelope**:
+The on-disk form of one credential: a self-describing byte blob that a vault writes and reads whole. An envelope declares which key protects it, so a directory holding envelopes from two eras is still readable rather than ambiguous.
+_Avoid_: Blob, ciphertext, encrypted file
+
+**Backend**:
+The named implementation that turns a credential into an envelope and back. Each backend reports its own name, so a vault can recognise an unsafe one and refuse to write rather than store a credential the athlete believes is protected. `basic_text` is the name that means unprotected.
+_Avoid_: Cipher, provider, encryptor
+
+**Helper**:
+A separate signed executable the desktop app runs to reach a platform facility Electron cannot reach itself. It answers one request and exits. A helper never receives or returns a credential value — only the key material a backend needs.
+_Avoid_: Daemon, service, agent (the daemon is the long-lived coaching process; a helper is short-lived and answers one question)
+
+**Key-id**:
+The single number inside an envelope naming the key that protects it. `0` names the platform-secure-storage era. Any other value names a later key. Without a key-id an envelope from one era is indistinguishable from another, and a half-migrated vault cannot be repaired.
+_Avoid_: Version, key version, generation
+
+**Poisoned item**:
+A stored key that exists but cannot be read by the app entitled to it. It is a recoverable state, not a fatal one: the app destroys it and creates a fresh key, accepting that every envelope under the old key must be re-entered. Distinct from a missing key, which is simply the first-run case.
+_Avoid_: Corrupt key, broken keychain, orphaned item
+
+## Relationships
+
+- A **Vault** holds **Slot**s; each configured slot has exactly one **Envelope**.
+- A **Vault** delegates every encryption and decryption to one **Backend** and never inspects an **Envelope** itself.
+- A **Backend** may need a **Helper** to obtain its key; a backend that needs no helper has none.
+- Every **Envelope** carries the **Key-id** of the key that sealed it.
+- A **Poisoned item** is a **Backend** concern; a **Vault** only ever sees the refusal that follows.
+
+## Example dialogue
+
+> **Dev:** "The athlete removed their Telegram integration. Do we destroy the key too?"
+> **Domain expert:** "No. One key seals every **Envelope** in both **Vault**s. Removing one integration deletes that **Slot**'s envelope and nothing else — destroying the key would take every remaining credential with it."
+
+## Flagged ambiguities
+
+- "Key" was used for both a credential the athlete pastes in (an API key) and the secret that encrypts it. Resolved: an athlete-supplied secret lives in a **Slot**; the secret that seals envelopes is the encryption key, named only as such.

--- a/apps/desktop/native/keychain-helper/main.swift
+++ b/apps/desktop/native/keychain-helper/main.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Security
+
+let requiredTeamIdentifier = "FA494ACVTF"
+let keyAccount = "credential-encryption-key-v1"
+let allowedServices: Set<String> = ["icu.enduragent.desktop", "icu.enduragent.desktop.dev"]
+let keyByteCount = 32
+let accessLabel = "Enduragent credential encryption key"
+let partitionMarker = "teamid:FA494ACVTF"
+let partitionPlist = """
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>Partitions</key><array><string>teamid:FA494ACVTF</string></array></dict></plist>
+"""
+
+SecKeychainSetUserInteractionAllowed(false)
+
+func emit(_ payload: [String: Any]) {
+  guard let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
+        let line = String(data: data, encoding: .utf8)
+  else {
+    print("{\"ok\":false,\"code\":\"unknown\"}")
+    return
+  }
+  print(line)
+}
+
+func succeed(_ payload: [String: Any]) -> Never {
+  emit(payload)
+  exit(0)
+}
+
+func fail(_ code: String) -> Never {
+  emit(["ok": false, "code": code])
+  exit(0)
+}
+
+func mapStatus(_ status: OSStatus) -> String {
+  switch status {
+  case errSecItemNotFound:
+    return "item-not-found"
+  case errSecDuplicateItem:
+    return "duplicate-item"
+  case errSecInteractionNotAllowed, errSecInteractionRequired, errSecNotAvailable:
+    return "keychain-locked"
+  case errSecAuthFailed:
+    return "unreadable-item"
+  default:
+    return "unknown"
+  }
+}
+
+func signedTeamIdentifier() -> String? {
+  var code: SecCode?
+  guard SecCodeCopySelf(SecCSFlags(rawValue: 0), &code) == errSecSuccess, let code else { return nil }
+  var staticCode: SecStaticCode?
+  guard SecCodeCopyStaticCode(code, SecCSFlags(rawValue: 0), &staticCode) == errSecSuccess,
+        let staticCode
+  else { return nil }
+  var information: CFDictionary?
+  guard SecCodeCopySigningInformation(
+    staticCode,
+    SecCSFlags(rawValue: kSecCSSigningInformation),
+    &information
+  ) == errSecSuccess,
+    let attributes = information as? [String: Any]
+  else { return nil }
+  return attributes[kSecCodeInfoTeamIdentifier as String] as? String
+}
+
+func baseQuery(_ service: String) -> [String: Any] {
+  return [
+    kSecClass as String: kSecClassGenericPassword,
+    kSecAttrService as String: service,
+    kSecAttrAccount as String: keyAccount,
+  ]
+}
+
+func makeAccess() -> SecAccess? {
+  var access: SecAccess?
+  guard SecAccessCreate(accessLabel as CFString, nil, &access) == errSecSuccess, let access else {
+    return nil
+  }
+  var aclList: CFArray?
+  guard SecAccessCopyACLList(access, &aclList) == errSecSuccess else { return nil }
+  for acl in (aclList as? [SecACL]) ?? [] {
+    var applications: CFArray?
+    var description: CFString?
+    var prompt = SecKeychainPromptSelector()
+    guard SecACLCopyContents(acl, &applications, &description, &prompt) == errSecSuccess else {
+      continue
+    }
+    guard SecACLSetContents(acl, nil, description ?? "" as CFString, prompt) == errSecSuccess else {
+      return nil
+    }
+  }
+  var partitionACL: SecACL?
+  guard SecACLCreateWithSimpleContents(
+    access,
+    nil,
+    partitionPlist as CFString,
+    SecKeychainPromptSelector(rawValue: 0),
+    &partitionACL
+  ) == errSecSuccess,
+    let partitionACL
+  else { return nil }
+  guard SecACLUpdateAuthorizations(
+    partitionACL,
+    [kSecACLAuthorizationPartitionID] as CFArray
+  ) == errSecSuccess else { return nil }
+  return access
+}
+
+func carriesPartitionEntry(_ item: SecKeychainItem) -> Bool {
+  var access: SecAccess?
+  guard SecKeychainItemCopyAccess(item, &access) == errSecSuccess, let access else { return false }
+  var aclList: CFArray?
+  guard SecAccessCopyACLList(access, &aclList) == errSecSuccess else { return false }
+  for acl in (aclList as? [SecACL]) ?? [] {
+    let authorizations = SecACLCopyAuthorizations(acl) as? [String] ?? []
+    guard authorizations.contains(kSecACLAuthorizationPartitionID as String) else { continue }
+    var applications: CFArray?
+    var description: CFString?
+    var prompt = SecKeychainPromptSelector()
+    guard SecACLCopyContents(acl, &applications, &description, &prompt) == errSecSuccess else {
+      continue
+    }
+    if let text = description as String?, text.contains(partitionMarker) { return true }
+  }
+  return false
+}
+
+func readKey(_ service: String) -> Never {
+  var query = baseQuery(service)
+  query[kSecReturnData as String] = true
+  query[kSecReturnRef as String] = true
+  query[kSecMatchLimit as String] = kSecMatchLimitOne
+  var result: CFTypeRef?
+  let status = SecItemCopyMatching(query as CFDictionary, &result)
+  guard status == errSecSuccess else { fail(mapStatus(status)) }
+  guard let attributes = result as? [String: Any],
+        let data = attributes[kSecValueData as String] as? Data,
+        data.count == keyByteCount,
+        let reference = attributes[kSecValueRef as String]
+  else { fail("unreadable-item") }
+  let candidate = reference as CFTypeRef
+  guard CFGetTypeID(candidate) == SecKeychainItemGetTypeID() else { fail("unreadable-item") }
+  let item = unsafeBitCast(candidate, to: SecKeychainItem.self)
+  guard carriesPartitionEntry(item) else { fail("unreadable-item") }
+  succeed(["ok": true, "op": "read-key", "key": data.base64EncodedString()])
+}
+
+func createKey(_ service: String) -> Never {
+  var material = [UInt8](repeating: 0, count: keyByteCount)
+  guard SecRandomCopyBytes(kSecRandomDefault, keyByteCount, &material) == errSecSuccess else {
+    fail("unknown")
+  }
+  guard let access = makeAccess() else { fail("unknown") }
+  let data = Data(material)
+  var attributes = baseQuery(service)
+  attributes[kSecValueData as String] = data
+  attributes[kSecAttrAccess as String] = access
+  let status = SecItemAdd(attributes as CFDictionary, nil)
+  guard status == errSecSuccess else { fail(mapStatus(status)) }
+  succeed(["ok": true, "op": "create-key", "key": data.base64EncodedString()])
+}
+
+func deleteKey(_ service: String) -> Never {
+  let status = SecItemDelete(baseQuery(service) as CFDictionary)
+  if status == errSecSuccess { succeed(["ok": true, "op": "delete-key", "deleted": true]) }
+  if status == errSecItemNotFound { succeed(["ok": true, "op": "delete-key", "deleted": false]) }
+  fail(mapStatus(status))
+}
+
+guard let line = readLine(strippingNewline: true),
+      let payload = line.data(using: .utf8),
+      let request = (try? JSONSerialization.jsonObject(with: payload)) as? [String: Any],
+      let operation = request["op"] as? String
+else { fail("unknown") }
+
+guard signedTeamIdentifier() == requiredTeamIdentifier else { fail("not-team-signed") }
+
+if operation == "probe" {
+  succeed(["ok": true, "op": "probe", "teamIdentifier": requiredTeamIdentifier])
+}
+
+guard let service = request["service"] as? String, allowedServices.contains(service) else {
+  fail("unknown")
+}
+
+switch operation {
+case "read-key":
+  readKey(service)
+case "create-key":
+  createKey(service)
+case "delete-key":
+  deleteKey(service)
+default:
+  fail("unknown")
+}

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -1,0 +1,150 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import type { CredentialEncryptionPort } from "./credential-vault.js";
+import {
+  KEYCHAIN_KEY_BYTES,
+  KEYCHAIN_TEAM_IDENTIFIER,
+  type KeychainHelperErrorCode,
+  type KeychainHelperTransport,
+} from "./keychain-helper.js";
+
+export const KEYCHAIN_PARTITION_STORAGE_BACKEND = "keychain_partition_v1" as const;
+export const CREDENTIAL_ENVELOPE_MAGIC = "ENDURAGENT1" as const;
+export const SAFE_STORAGE_ENVELOPE_KEY_ID = 0;
+export const KEYCHAIN_ENVELOPE_KEY_ID = 1;
+export const CREDENTIAL_ENVELOPE_IV_BYTES = 12;
+export const CREDENTIAL_ENVELOPE_TAG_BYTES = 16;
+
+const MAGIC = Buffer.from(CREDENTIAL_ENVELOPE_MAGIC, "ascii");
+const HEADER_BYTES = MAGIC.length + 1;
+const MINIMUM_ENVELOPE_BYTES =
+  HEADER_BYTES + CREDENTIAL_ENVELOPE_IV_BYTES + CREDENTIAL_ENVELOPE_TAG_BYTES;
+
+export class KeychainEncryptionError extends Error {
+  constructor(readonly code: KeychainHelperErrorCode) {
+    super();
+  }
+}
+
+export class CredentialEnvelopeError extends Error {}
+
+export function readCredentialEnvelopeKeyId(envelope: Buffer): number | undefined {
+  if (envelope.length < MINIMUM_ENVELOPE_BYTES) return undefined;
+  if (!envelope.subarray(0, MAGIC.length).equals(MAGIC)) return undefined;
+  return envelope[MAGIC.length];
+}
+
+export function sealCredentialEnvelope(key: Buffer, value: string): Buffer {
+  const iv = randomBytes(CREDENTIAL_ENVELOPE_IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
+  const header = Buffer.concat([MAGIC, Buffer.of(KEYCHAIN_ENVELOPE_KEY_ID)]);
+  return Buffer.concat([header, iv, ciphertext, cipher.getAuthTag()]);
+}
+
+export function openCredentialEnvelope(key: Buffer, envelope: Buffer): string {
+  if (readCredentialEnvelopeKeyId(envelope) !== KEYCHAIN_ENVELOPE_KEY_ID) {
+    throw new CredentialEnvelopeError();
+  }
+  const iv = envelope.subarray(HEADER_BYTES, HEADER_BYTES + CREDENTIAL_ENVELOPE_IV_BYTES);
+  const tag = envelope.subarray(envelope.length - CREDENTIAL_ENVELOPE_TAG_BYTES);
+  const ciphertext = envelope.subarray(
+    HEADER_BYTES + CREDENTIAL_ENVELOPE_IV_BYTES,
+    envelope.length - CREDENTIAL_ENVELOPE_TAG_BYTES,
+  );
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+}
+
+export type KeychainPartitionEncryptionResult =
+  | {
+      readonly status: "ready";
+      readonly encryption: CredentialEncryptionPort;
+      readonly createdKey: boolean;
+    }
+  | {
+      readonly status: "unavailable";
+      readonly code: KeychainHelperErrorCode;
+      readonly encryption: CredentialEncryptionPort;
+    }
+  | {
+      readonly status: "storage-failed";
+      readonly code: KeychainHelperErrorCode;
+      readonly encryption: CredentialEncryptionPort;
+    }
+  | {
+      readonly status: "unsupported";
+      readonly code: "not-team-signed";
+    };
+
+export interface CreateKeychainPartitionEncryptionOptions {
+  readonly transport: KeychainHelperTransport;
+  readonly service: string;
+}
+
+function refusingPort(code: KeychainHelperErrorCode, available: boolean): CredentialEncryptionPort {
+  const refuse = (): never => {
+    throw new KeychainEncryptionError(code);
+  };
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: refuse,
+    decryptString: refuse,
+    getSelectedStorageBackend: () => KEYCHAIN_PARTITION_STORAGE_BACKEND,
+  };
+}
+
+function readyPort(key: Buffer): CredentialEncryptionPort {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) => sealCredentialEnvelope(key, value),
+    decryptString: (envelope: Buffer) => openCredentialEnvelope(key, envelope),
+    getSelectedStorageBackend: () => KEYCHAIN_PARTITION_STORAGE_BACKEND,
+  };
+}
+
+function refused(code: KeychainHelperErrorCode): KeychainPartitionEncryptionResult {
+  if (code === "keychain-locked") {
+    return { status: "unavailable", code, encryption: refusingPort(code, false) };
+  }
+  return { status: "storage-failed", code, encryption: refusingPort(code, true) };
+}
+
+export async function createKeychainPartitionEncryption(
+  options: CreateKeychainPartitionEncryptionOptions,
+): Promise<KeychainPartitionEncryptionResult> {
+  const { transport, service } = options;
+  const probe = await transport.send({ op: "probe", service });
+  if (!probe.ok) {
+    return probe.code === "not-team-signed"
+      ? { status: "unsupported", code: "not-team-signed" }
+      : refused(probe.code);
+  }
+  if (probe.op !== "probe" || probe.teamIdentifier !== KEYCHAIN_TEAM_IDENTIFIER) {
+    return refused("unknown");
+  }
+
+  const create = async (): Promise<KeychainPartitionEncryptionResult> => {
+    const created = await transport.send({ op: "create-key", service });
+    if (!created.ok) return refused(created.code);
+    if (created.op !== "create-key") return refused("unknown");
+    const key = Buffer.from(created.key, "base64");
+    if (key.length !== KEYCHAIN_KEY_BYTES) return refused("unknown");
+    return { status: "ready", encryption: readyPort(key), createdKey: true };
+  };
+
+  const read = await transport.send({ op: "read-key", service });
+  if (read.ok) {
+    if (read.op !== "read-key") return refused("unknown");
+    const key = Buffer.from(read.key, "base64");
+    if (key.length !== KEYCHAIN_KEY_BYTES) return refused("unknown");
+    return { status: "ready", encryption: readyPort(key), createdKey: false };
+  }
+  if (read.code === "item-not-found") return create();
+  if (read.code !== "unreadable-item") return refused(read.code);
+
+  const deleted = await transport.send({ op: "delete-key", service });
+  if (!deleted.ok) return refused(deleted.code);
+  if (deleted.op !== "delete-key") return refused("unknown");
+  return create();
+}

--- a/apps/desktop/src/main/keychain-helper.ts
+++ b/apps/desktop/src/main/keychain-helper.ts
@@ -1,0 +1,170 @@
+import { spawn, type ChildProcess } from "node:child_process";
+
+export const KEYCHAIN_HELPER_OPERATIONS = [
+  "probe",
+  "read-key",
+  "create-key",
+  "delete-key",
+] as const;
+
+export const KEYCHAIN_HELPER_ERROR_CODES = [
+  "not-team-signed",
+  "item-not-found",
+  "keychain-locked",
+  "duplicate-item",
+  "unreadable-item",
+  "unknown",
+] as const;
+
+export type KeychainHelperOperation = (typeof KEYCHAIN_HELPER_OPERATIONS)[number];
+export type KeychainHelperErrorCode = (typeof KEYCHAIN_HELPER_ERROR_CODES)[number];
+
+export const KEYCHAIN_CREDENTIAL_SERVICE = "icu.enduragent.desktop" as const;
+export const KEYCHAIN_CREDENTIAL_SERVICE_DEV = "icu.enduragent.desktop.dev" as const;
+export const KEYCHAIN_CREDENTIAL_ACCOUNT = "credential-encryption-key-v1" as const;
+export const KEYCHAIN_TEAM_IDENTIFIER = "FA494ACVTF" as const;
+export const KEYCHAIN_KEY_BYTES = 32;
+
+export const KEYCHAIN_HELPER_DEADLINE_MS = 5_000;
+export const KEYCHAIN_HELPER_MAX_RESPONSE_BYTES = 8_192;
+
+export interface KeychainHelperRequest {
+  readonly op: KeychainHelperOperation;
+  readonly service: string;
+}
+
+export type KeychainHelperResponse =
+  | {
+      readonly ok: true;
+      readonly op: "probe";
+      readonly teamIdentifier: string;
+    }
+  | {
+      readonly ok: true;
+      readonly op: "read-key" | "create-key";
+      readonly key: string;
+    }
+  | {
+      readonly ok: true;
+      readonly op: "delete-key";
+      readonly deleted: boolean;
+    }
+  | {
+      readonly ok: false;
+      readonly code: KeychainHelperErrorCode;
+    };
+
+export interface KeychainHelperTransport {
+  send(request: KeychainHelperRequest): Promise<KeychainHelperResponse>;
+}
+
+export type KeychainHelperSpawn = (command: string, args: readonly string[]) => ChildProcess;
+
+export interface KeychainHelperTransportOptions {
+  readonly helperPath: string;
+  readonly deadlineMs?: number;
+  readonly maxResponseBytes?: number;
+  readonly spawnHelper?: KeychainHelperSpawn;
+}
+
+const UNKNOWN_RESPONSE: KeychainHelperResponse = { ok: false, code: "unknown" };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isErrorCode(value: unknown): value is KeychainHelperErrorCode {
+  return (
+    typeof value === "string" && (KEYCHAIN_HELPER_ERROR_CODES as readonly string[]).includes(value)
+  );
+}
+
+function decodedKeyBytes(value: unknown): number {
+  if (typeof value !== "string" || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return -1;
+  const decoded = Buffer.from(value, "base64");
+  return decoded.toString("base64") === value ? decoded.length : -1;
+}
+
+export function parseKeychainHelperResponse(line: string): KeychainHelperResponse {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return UNKNOWN_RESPONSE;
+  }
+  if (!isRecord(parsed)) return UNKNOWN_RESPONSE;
+  if (parsed.ok === false) {
+    return isErrorCode(parsed.code) ? { ok: false, code: parsed.code } : UNKNOWN_RESPONSE;
+  }
+  if (parsed.ok !== true) return UNKNOWN_RESPONSE;
+  if (parsed.op === "probe") {
+    return typeof parsed.teamIdentifier === "string"
+      ? { ok: true, op: "probe", teamIdentifier: parsed.teamIdentifier }
+      : UNKNOWN_RESPONSE;
+  }
+  if (parsed.op === "read-key" || parsed.op === "create-key") {
+    return decodedKeyBytes(parsed.key) === KEYCHAIN_KEY_BYTES
+      ? { ok: true, op: parsed.op, key: parsed.key as string }
+      : UNKNOWN_RESPONSE;
+  }
+  if (parsed.op === "delete-key") {
+    return typeof parsed.deleted === "boolean"
+      ? { ok: true, op: "delete-key", deleted: parsed.deleted }
+      : UNKNOWN_RESPONSE;
+  }
+  return UNKNOWN_RESPONSE;
+}
+
+export function createKeychainHelperTransport(
+  options: KeychainHelperTransportOptions,
+): KeychainHelperTransport {
+  const deadlineMs = options.deadlineMs ?? KEYCHAIN_HELPER_DEADLINE_MS;
+  const maxResponseBytes = options.maxResponseBytes ?? KEYCHAIN_HELPER_MAX_RESPONSE_BYTES;
+  const spawnHelper =
+    options.spawnHelper ??
+    ((command, args) => spawn(command, [...args], { stdio: ["pipe", "pipe", "ignore"] }));
+  return {
+    send(request: KeychainHelperRequest): Promise<KeychainHelperResponse> {
+      return new Promise<KeychainHelperResponse>((resolve) => {
+        let child: ChildProcess;
+        try {
+          child = spawnHelper(options.helperPath, []);
+        } catch {
+          resolve(UNKNOWN_RESPONSE);
+          return;
+        }
+        let settled = false;
+        let received = "";
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const finish = (response: KeychainHelperResponse): void => {
+          if (settled) return;
+          settled = true;
+          if (timer !== undefined) clearTimeout(timer);
+          try {
+            child.kill("SIGKILL");
+          } catch {}
+          resolve(response);
+        };
+        timer = setTimeout(() => finish(UNKNOWN_RESPONSE), deadlineMs);
+        timer.unref?.();
+        child.once("error", () => finish(UNKNOWN_RESPONSE));
+        child.once("close", () => {
+          const newline = received.indexOf("\n");
+          finish(parseKeychainHelperResponse(newline < 0 ? received : received.slice(0, newline)));
+        });
+        child.stdout?.setEncoding("utf8");
+        child.stdout?.on("data", (chunk: string) => {
+          received += chunk;
+          if (Buffer.byteLength(received, "utf8") > maxResponseBytes) {
+            finish(UNKNOWN_RESPONSE);
+            return;
+          }
+          const newline = received.indexOf("\n");
+          if (newline >= 0) finish(parseKeychainHelperResponse(received.slice(0, newline)));
+        });
+        child.stdin?.on("error", () => {});
+        child.stdin?.end(`${JSON.stringify(request)}\n`);
+      });
+    },
+  };
+}

--- a/apps/desktop/tests/keychain-credential-encryption.test.ts
+++ b/apps/desktop/tests/keychain-credential-encryption.test.ts
@@ -1,0 +1,249 @@
+import { randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  CREDENTIAL_ENVELOPE_IV_BYTES,
+  CREDENTIAL_ENVELOPE_MAGIC,
+  CREDENTIAL_ENVELOPE_TAG_BYTES,
+  CredentialEnvelopeError,
+  KEYCHAIN_ENVELOPE_KEY_ID,
+  KEYCHAIN_PARTITION_STORAGE_BACKEND,
+  KeychainEncryptionError,
+  SAFE_STORAGE_ENVELOPE_KEY_ID,
+  createKeychainPartitionEncryption,
+  openCredentialEnvelope,
+  readCredentialEnvelopeKeyId,
+  sealCredentialEnvelope,
+} from "../src/main/keychain-credential-encryption.js";
+import {
+  KEYCHAIN_CREDENTIAL_SERVICE,
+  KEYCHAIN_CREDENTIAL_SERVICE_DEV,
+  KEYCHAIN_KEY_BYTES,
+  KEYCHAIN_TEAM_IDENTIFIER,
+  type KeychainHelperRequest,
+  type KeychainHelperResponse,
+  type KeychainHelperTransport,
+} from "../src/main/keychain-helper.js";
+
+const PROBE_OK: KeychainHelperResponse = {
+  ok: true,
+  op: "probe",
+  teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER,
+};
+
+interface RecordingTransport extends KeychainHelperTransport {
+  readonly requests: KeychainHelperRequest[];
+}
+
+function transportOf(...responses: readonly KeychainHelperResponse[]): RecordingTransport {
+  const remaining = [...responses];
+  const requests: KeychainHelperRequest[] = [];
+  return {
+    requests,
+    send(request) {
+      requests.push(request);
+      const next = remaining.shift();
+      if (next === undefined) throw new Error("unexpected helper request");
+      return Promise.resolve(next);
+    },
+  };
+}
+
+function storedKey(): { readonly key: Buffer; readonly encoded: string } {
+  const key = randomBytes(KEYCHAIN_KEY_BYTES);
+  return { key, encoded: key.toString("base64") };
+}
+
+describe("credential envelope", () => {
+  it("seals a value under the keychain key-id and reads it back", () => {
+    const { key } = storedKey();
+    const envelope = sealCredentialEnvelope(key, "sk-secret-value");
+    expect(envelope.subarray(0, CREDENTIAL_ENVELOPE_MAGIC.length).toString("ascii")).toBe(
+      CREDENTIAL_ENVELOPE_MAGIC,
+    );
+    expect(readCredentialEnvelopeKeyId(envelope)).toBe(KEYCHAIN_ENVELOPE_KEY_ID);
+    expect(readCredentialEnvelopeKeyId(envelope)).not.toBe(SAFE_STORAGE_ENVELOPE_KEY_ID);
+    expect(envelope.includes(Buffer.from("sk-secret-value", "utf8"))).toBe(false);
+    expect(openCredentialEnvelope(key, envelope)).toBe("sk-secret-value");
+  });
+
+  it("lays the envelope out as magic, key-id, iv, ciphertext, tag", () => {
+    const { key } = storedKey();
+    const envelope = sealCredentialEnvelope(key, "abcd");
+    const overhead =
+      CREDENTIAL_ENVELOPE_MAGIC.length +
+      1 +
+      CREDENTIAL_ENVELOPE_IV_BYTES +
+      CREDENTIAL_ENVELOPE_TAG_BYTES;
+    expect(envelope.length).toBe(overhead + Buffer.byteLength("abcd", "utf8"));
+  });
+
+  it("uses a fresh iv for every seal", () => {
+    const { key } = storedKey();
+    const first = sealCredentialEnvelope(key, "same");
+    const second = sealCredentialEnvelope(key, "same");
+    expect(first.equals(second)).toBe(false);
+  });
+
+  it("refuses a tampered ciphertext", () => {
+    const { key } = storedKey();
+    const envelope = sealCredentialEnvelope(key, "sk-secret-value");
+    const target = CREDENTIAL_ENVELOPE_MAGIC.length + 1 + CREDENTIAL_ENVELOPE_IV_BYTES;
+    envelope[target] ^= 0xff;
+    expect(() => openCredentialEnvelope(key, envelope)).toThrow();
+  });
+
+  it("refuses another key", () => {
+    const envelope = sealCredentialEnvelope(storedKey().key, "sk-secret-value");
+    expect(() => openCredentialEnvelope(storedKey().key, envelope)).toThrow();
+  });
+
+  it("refuses a safeStorage-era envelope and foreign bytes", () => {
+    const { key } = storedKey();
+    const envelope = sealCredentialEnvelope(key, "sk-secret-value");
+    const legacy = Buffer.from(envelope);
+    legacy[CREDENTIAL_ENVELOPE_MAGIC.length] = SAFE_STORAGE_ENVELOPE_KEY_ID;
+    expect(() => openCredentialEnvelope(key, legacy)).toThrow(CredentialEnvelopeError);
+    expect(
+      readCredentialEnvelopeKeyId(Buffer.from("v10 opaque safeStorage bytes")),
+    ).toBeUndefined();
+    expect(readCredentialEnvelopeKeyId(Buffer.alloc(4))).toBeUndefined();
+    expect(() => openCredentialEnvelope(key, Buffer.alloc(4))).toThrow(CredentialEnvelopeError);
+  });
+});
+
+describe("keychain partition backend", () => {
+  it("adopts an existing key and reports its backend id", async () => {
+    const { encoded } = storedKey();
+    const transport = transportOf(PROBE_OK, { ok: true, op: "read-key", key: encoded });
+    const result = await createKeychainPartitionEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+    expect(result.createdKey).toBe(false);
+    expect(result.encryption.isEncryptionAvailable()).toBe(true);
+    expect(result.encryption.getSelectedStorageBackend?.()).toBe(
+      KEYCHAIN_PARTITION_STORAGE_BACKEND,
+    );
+    const sealed = result.encryption.encryptString("token-value");
+    expect(result.encryption.decryptString(sealed)).toBe("token-value");
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
+    expect(
+      transport.requests.every((request) => request.service === KEYCHAIN_CREDENTIAL_SERVICE),
+    ).toBe(true);
+    expect(JSON.stringify(transport.requests)).not.toContain(encoded);
+  });
+
+  it("creates a key when the item is absent", async () => {
+    const { encoded } = storedKey();
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: false, code: "item-not-found" },
+      { ok: true, op: "create-key", key: encoded },
+    );
+    const result = await createKeychainPartitionEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE_DEV,
+    });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+    expect(result.createdKey).toBe(true);
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "create-key",
+    ]);
+    expect(
+      transport.requests.every((request) => request.service === KEYCHAIN_CREDENTIAL_SERVICE_DEV),
+    ).toBe(true);
+  });
+
+  it("deletes and recreates a poisoned item", async () => {
+    const { encoded } = storedKey();
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: false, code: "unreadable-item" },
+      { ok: true, op: "delete-key", deleted: true },
+      { ok: true, op: "create-key", key: encoded },
+    );
+    const result = await createKeychainPartitionEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("ready");
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "delete-key",
+      "create-key",
+    ]);
+  });
+
+  it("reports encryption as unavailable when the keychain is locked", async () => {
+    const transport = transportOf(PROBE_OK, { ok: false, code: "keychain-locked" });
+    const result = await createKeychainPartitionEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("unavailable");
+    if (result.status !== "unavailable") return;
+    expect(result.code).toBe("keychain-locked");
+    expect(result.encryption.isEncryptionAvailable()).toBe(false);
+    expect(result.encryption.getSelectedStorageBackend?.()).toBe(
+      KEYCHAIN_PARTITION_STORAGE_BACKEND,
+    );
+    expect(() => result.encryption.encryptString("token-value")).toThrow(KeychainEncryptionError);
+  });
+
+  it("keeps encryption available but refuses writes when a create duplicates", async () => {
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: false, code: "item-not-found" },
+      { ok: false, code: "duplicate-item" },
+    );
+    const result = await createKeychainPartitionEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("storage-failed");
+    if (result.status !== "storage-failed") return;
+    expect(result.code).toBe("duplicate-item");
+    expect(result.encryption.isEncryptionAvailable()).toBe(true);
+    expect(() => result.encryption.encryptString("token-value")).toThrow(KeychainEncryptionError);
+    expect(() => result.encryption.decryptString(Buffer.alloc(0))).toThrow(KeychainEncryptionError);
+  });
+
+  it("stops at the probe and touches no keychain op when the build is not team signed", async () => {
+    const transport = transportOf({ ok: false, code: "not-team-signed" });
+    const result = await createKeychainPartitionEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result).toEqual({ status: "unsupported", code: "not-team-signed" });
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe"]);
+  });
+
+  it("refuses a probe answered by a foreign team", async () => {
+    const transport = transportOf({ ok: true, op: "probe", teamIdentifier: "ZZZZZZZZZZ" });
+    const result = await createKeychainPartitionEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("storage-failed");
+    expect(transport.requests).toHaveLength(1);
+  });
+
+  it("refuses a helper key of the wrong size", async () => {
+    const transport = transportOf(PROBE_OK, {
+      ok: true,
+      op: "read-key",
+      key: randomBytes(16).toString("base64"),
+    });
+    const result = await createKeychainPartitionEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("storage-failed");
+  });
+});

--- a/apps/desktop/tests/keychain-helper-swift.integration.test.ts
+++ b/apps/desktop/tests/keychain-helper-swift.integration.test.ts
@@ -1,0 +1,57 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  KEYCHAIN_CREDENTIAL_SERVICE_DEV,
+  createKeychainHelperTransport,
+} from "../src/main/keychain-helper.js";
+
+const SWIFT_COMPILE_TIMEOUT_MS = 180_000;
+
+function swiftcAvailable(): boolean {
+  if (process.platform !== "darwin") return false;
+  const probe = spawnSync("swiftc", ["-version"], { stdio: "ignore" });
+  return probe.error === undefined && probe.status === 0;
+}
+
+const source = fileURLToPath(new URL("../native/keychain-helper/main.swift", import.meta.url));
+let root = "";
+let helperPath = "";
+
+describe.skipIf(!swiftcAvailable())("keychain helper binary", () => {
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "enduragent-keychain-helper-"));
+    helperPath = join(root, "keychain-helper");
+    const build = spawnSync("swiftc", [source, "-o", helperPath], { encoding: "utf8" });
+    expect(build.status, build.stderr ?? "").toBe(0);
+  }, SWIFT_COMPILE_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (root !== "") await rm(root, { recursive: true, force: true });
+  });
+
+  it("refuses every operation from a build without the team identity", async () => {
+    const transport = createKeychainHelperTransport({ helperPath });
+    await expect(
+      transport.send({ op: "probe", service: KEYCHAIN_CREDENTIAL_SERVICE_DEV }),
+    ).resolves.toEqual({ ok: false, code: "not-team-signed" });
+    await expect(
+      transport.send({ op: "read-key", service: KEYCHAIN_CREDENTIAL_SERVICE_DEV }),
+    ).resolves.toEqual({ ok: false, code: "not-team-signed" });
+    await expect(
+      transport.send({ op: "create-key", service: KEYCHAIN_CREDENTIAL_SERVICE_DEV }),
+    ).resolves.toEqual({ ok: false, code: "not-team-signed" });
+    await expect(
+      transport.send({ op: "delete-key", service: KEYCHAIN_CREDENTIAL_SERVICE_DEV }),
+    ).resolves.toEqual({ ok: false, code: "not-team-signed" });
+  });
+
+  it("answers a malformed request line with unknown", async () => {
+    const helper = spawnSync(helperPath, { input: "not a request\n", encoding: "utf8" });
+    expect(helper.status).toBe(0);
+    expect(JSON.parse(helper.stdout.trim())).toEqual({ ok: false, code: "unknown" });
+  });
+});

--- a/apps/desktop/tests/keychain-helper.test.ts
+++ b/apps/desktop/tests/keychain-helper.test.ts
@@ -1,0 +1,171 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  KEYCHAIN_CREDENTIAL_SERVICE,
+  KEYCHAIN_HELPER_DEADLINE_MS,
+  KEYCHAIN_HELPER_MAX_RESPONSE_BYTES,
+  KEYCHAIN_KEY_BYTES,
+  createKeychainHelperTransport,
+  parseKeychainHelperResponse,
+  type KeychainHelperSpawn,
+} from "../src/main/keychain-helper.js";
+
+const ENCODED_KEY = randomBytes(KEYCHAIN_KEY_BYTES).toString("base64");
+
+const RESPONDER = `
+let data = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { data += chunk; });
+process.stdin.on("end", () => {
+  let request = null;
+  try { request = JSON.parse(data.trim()); } catch {}
+  const matched =
+    request !== null &&
+    request.op === "delete-key" &&
+    request.service === ${JSON.stringify(KEYCHAIN_CREDENTIAL_SERVICE)};
+  const response = matched
+    ? { ok: true, op: "delete-key", deleted: true }
+    : { ok: false, code: "unknown" };
+  process.stdout.write(JSON.stringify(response) + "\\n");
+});
+`;
+
+const TRAILING_NOISE = `
+process.stdout.write(JSON.stringify({ ok: true, op: "create-key", key: ${JSON.stringify(ENCODED_KEY)} }) + "\\n");
+process.stdout.write("diagnostic noise the transport must ignore\\n");
+`;
+
+const SILENT = `process.exit(0);`;
+const SLEEPER = `setTimeout(() => {}, 30000);`;
+const FLOOD = `process.stdout.write("x".repeat(64 * 1024));`;
+
+function nodeSpawn(script: string): KeychainHelperSpawn {
+  return () => spawn(process.execPath, ["-e", script], { stdio: ["pipe", "pipe", "ignore"] });
+}
+
+describe("parseKeychainHelperResponse", () => {
+  it("accepts each success shape", () => {
+    expect(
+      parseKeychainHelperResponse('{"ok":true,"op":"probe","teamIdentifier":"FA494ACVTF"}'),
+    ).toEqual({ ok: true, op: "probe", teamIdentifier: "FA494ACVTF" });
+    expect(
+      parseKeychainHelperResponse(`{"ok":true,"op":"read-key","key":"${ENCODED_KEY}"}`),
+    ).toEqual({
+      ok: true,
+      op: "read-key",
+      key: ENCODED_KEY,
+    });
+    expect(parseKeychainHelperResponse('{"ok":true,"op":"delete-key","deleted":false}')).toEqual({
+      ok: true,
+      op: "delete-key",
+      deleted: false,
+    });
+  });
+
+  it("accepts every documented error code", () => {
+    expect(parseKeychainHelperResponse('{"ok":false,"code":"not-team-signed"}')).toEqual({
+      ok: false,
+      code: "not-team-signed",
+    });
+    expect(parseKeychainHelperResponse('{"code":"keychain-locked","ok":false}')).toEqual({
+      ok: false,
+      code: "keychain-locked",
+    });
+  });
+
+  it("rejects malformed, unknown-coded, and wrong-sized payloads", () => {
+    const unknown = { ok: false, code: "unknown" };
+    expect(parseKeychainHelperResponse("")).toEqual(unknown);
+    expect(parseKeychainHelperResponse("not json")).toEqual(unknown);
+    expect(parseKeychainHelperResponse("[]")).toEqual(unknown);
+    expect(parseKeychainHelperResponse('{"ok":false,"code":"teapot"}')).toEqual(unknown);
+    expect(parseKeychainHelperResponse('{"ok":true,"op":"probe"}')).toEqual(unknown);
+    expect(parseKeychainHelperResponse('{"ok":true,"op":"read-key","key":"short"}')).toEqual(
+      unknown,
+    );
+    expect(parseKeychainHelperResponse('{"ok":true,"op":"unheard-of"}')).toEqual(unknown);
+  });
+});
+
+describe("createKeychainHelperTransport", () => {
+  it("delivers the request line and returns the parsed response", async () => {
+    const transport = createKeychainHelperTransport({
+      helperPath: join("unused", "keychain-helper"),
+      spawnHelper: nodeSpawn(RESPONDER),
+    });
+    await expect(
+      transport.send({ op: "delete-key", service: KEYCHAIN_CREDENTIAL_SERVICE }),
+    ).resolves.toEqual({ ok: true, op: "delete-key", deleted: true });
+  });
+
+  it("takes the first line and ignores trailing output", async () => {
+    const transport = createKeychainHelperTransport({
+      helperPath: join("unused", "keychain-helper"),
+      spawnHelper: nodeSpawn(TRAILING_NOISE),
+    });
+    await expect(
+      transport.send({ op: "create-key", service: KEYCHAIN_CREDENTIAL_SERVICE }),
+    ).resolves.toEqual({ ok: true, op: "create-key", key: ENCODED_KEY });
+  });
+
+  it("reports unknown when the helper exits silently", async () => {
+    const transport = createKeychainHelperTransport({
+      helperPath: join("unused", "keychain-helper"),
+      spawnHelper: nodeSpawn(SILENT),
+    });
+    await expect(
+      transport.send({ op: "probe", service: KEYCHAIN_CREDENTIAL_SERVICE }),
+    ).resolves.toEqual({
+      ok: false,
+      code: "unknown",
+    });
+  });
+
+  it("reports unknown when the helper misses the deadline", async () => {
+    const transport = createKeychainHelperTransport({
+      helperPath: join("unused", "keychain-helper"),
+      deadlineMs: 50,
+      spawnHelper: nodeSpawn(SLEEPER),
+    });
+    await expect(
+      transport.send({ op: "probe", service: KEYCHAIN_CREDENTIAL_SERVICE }),
+    ).resolves.toEqual({
+      ok: false,
+      code: "unknown",
+    });
+  });
+
+  it("reports unknown when the helper floods stdout", async () => {
+    const transport = createKeychainHelperTransport({
+      helperPath: join("unused", "keychain-helper"),
+      maxResponseBytes: 128,
+      spawnHelper: nodeSpawn(FLOOD),
+    });
+    await expect(
+      transport.send({ op: "probe", service: KEYCHAIN_CREDENTIAL_SERVICE }),
+    ).resolves.toEqual({
+      ok: false,
+      code: "unknown",
+    });
+  });
+
+  it("reports unknown when the helper binary is absent", async () => {
+    const transport = createKeychainHelperTransport({
+      helperPath: join("no", "such", "keychain-helper"),
+      deadlineMs: 2_000,
+    });
+    await expect(
+      transport.send({ op: "probe", service: KEYCHAIN_CREDENTIAL_SERVICE }),
+    ).resolves.toEqual({
+      ok: false,
+      code: "unknown",
+    });
+  });
+
+  it("keeps its default bounds", () => {
+    expect(KEYCHAIN_HELPER_DEADLINE_MS).toBe(5_000);
+    expect(KEYCHAIN_HELPER_MAX_RESPONSE_BYTES).toBe(8_192);
+  });
+});


### PR DESCRIPTION
Child PR 1 of epic #672. Ships dark: no production code path selects the new backend; `safeStorage` remains the injected `CredentialEncryptionPort` at all three sites in `apps/desktop/src/main/index.ts`.

## What

- `apps/desktop/native/keychain-helper/main.swift` — single-file helper, plain `swiftc`, no Xcode project. Disables keychain user interaction before any Security call, refuses every op unless its own `SecCode` team identifier is `FA494ACVTF` (never probes by writing), and serves `probe` / `read-key` / `create-key` / `delete-key` as one JSON line in, one JSON line out. Creates the key item on the legacy file keychain with a partition-list ACL (`teamid:FA494ACVTF`) set at creation; 32-byte key from `SecRandomCopyBytes`, base64 over stdout, never argv/env. Accepts only services `icu.enduragent.desktop` and `icu.enduragent.desktop.dev`.
- `apps/desktop/src/main/keychain-helper.ts` — protocol constants, `KeychainHelperTransport` interface, defensive response parser, spawn-backed transport (deadline, response cap, SIGKILL on settle).
- `apps/desktop/src/main/keychain-credential-encryption.ts` — `keychain_partition_v1` backend: envelope codec (`ENDURAGENT1` magic + key-id byte + 12-byte IV + AES-256-GCM ciphertext + 16-byte tag; key-id 1) and `createKeychainPartitionEncryption`, which obtains the key once and returns the existing synchronous `CredentialEncryptionPort`. Unreadable/poisoned items are deleted and recreated; a locked keychain maps to the vault's encryption-unavailable state.
- `apps/desktop/CONTEXT.md` — credential-storage glossary (vault, slot, envelope, backend, helper, key-id, poisoned item).
- 26 tests: envelope tamper/wrong-key/key-id matrix, transport robustness (deadline, stdout flood, silent exit, absent binary), and a darwin-only integration test that compiles the helper with `swiftc` (skips cleanly elsewhere) and asserts an ad-hoc binary is refused before touching any keychain.

## New limits

- `KEYCHAIN_HELPER_DEADLINE_MS = 5000` — a helper with no response by then is SIGKILLed and reported as an error, so a hung helper cannot stall startup.
- `KEYCHAIN_HELPER_MAX_RESPONSE_BYTES = 8192` — caps buffered helper stdout so a runaway helper cannot grow Electron main's heap.
- `KEYCHAIN_KEY_BYTES = 32`, IV 12 bytes, GCM tag 16 bytes, key-ids 0 (safeStorage era) / 1 (keychain) — envelope contract.
- `SWIFT_COMPILE_TIMEOUT_MS = 180000` (test-only) — compile budget for the darwin integration test.

## Verification

- Root `pnpm check` green in the epic worktree.
- `vitest run` on the three new test files: 26/26 pass, including the real `swiftc` compile + ad-hoc refusal matrix on this mac.
- Full desktop suite: 1621/1623 pass; the 2 failures are pre-existing load-induced flakes in untouched files (`spend-meter.integration`, `windows-package-layout`), both pass in isolation.
- Adversarial verify: 4 read-only lenses (spec conformance, crypto/protocol correctness, darkness/regression, house rules), all pass, plus independent orchestrator spot-checks of the Security call order, probe mechanism, and dark wiring.

No changeset: nothing here ships in a release — the backend is unwired and `native/` is outside the packaged file set. Packaging lands in child PR 2.