### PR TITLE
feat(desktop): compile and package the macOS keychain helper

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
     "package:win": "pnpm build:self-test-resources && electron-vite build && node scripts/windows-package-plan.mjs",
     "package:mac": "pnpm build:self-test-resources && electron-vite build && node scripts/macos-release-plan.mjs",
     "package:telegram-acceptance": "pnpm --filter '@enduragent/desktop^...' build && pnpm build:self-test-resources && electron-vite build --config electron.telegram-acceptance.vite.config.ts && node scripts/package-telegram-acceptance.mjs",
+    "build:keychain-helper": "node scripts/build-keychain-helper.mjs",
     "build:self-test-resources": "tsx scripts/build-self-test-resources.ts",
     "stage:extra-resources": "node scripts/stage-extra-resources.mjs",
     "test:self-test-resources": "vitest run tests/self-test-resources.test.ts",

--- a/apps/desktop/scripts/build-keychain-helper.d.mts
+++ b/apps/desktop/scripts/build-keychain-helper.d.mts
@@ -1,0 +1,11 @@
+export const KEYCHAIN_HELPER_FILE: "keychain-helper";
+export const KEYCHAIN_HELPER_BUILD_DIRECTORY: "dist/keychain-helper";
+export const KEYCHAIN_HELPER_SOURCE: "native/keychain-helper/main.swift";
+export const KEYCHAIN_HELPER_SWIFT_TARGET: "arm64-apple-macos12.0";
+export const KEYCHAIN_HELPER_COMPILE_TIMEOUT_MS: number;
+
+export function keychainHelperBuildPath(desktopRoot?: string): string;
+
+export function keychainHelperCompilerAvailable(): boolean;
+
+export function buildKeychainHelper(desktopRoot?: string): Promise<string | undefined>;

--- a/apps/desktop/scripts/build-keychain-helper.mjs
+++ b/apps/desktop/scripts/build-keychain-helper.mjs
@@ -1,0 +1,76 @@
+import { spawnSync } from "node:child_process";
+import { chmod, mkdir, readFile, rename, rm } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { machoExecutableIdentity } from "./package-inventory.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const canonicalDesktopRoot = resolve(scriptDirectory, "..");
+
+export const KEYCHAIN_HELPER_FILE = "keychain-helper";
+export const KEYCHAIN_HELPER_BUILD_DIRECTORY = "dist/keychain-helper";
+export const KEYCHAIN_HELPER_SOURCE = "native/keychain-helper/main.swift";
+export const KEYCHAIN_HELPER_SWIFT_TARGET = "arm64-apple-macos12.0";
+export const KEYCHAIN_HELPER_COMPILE_TIMEOUT_MS = 300_000;
+
+export function keychainHelperBuildPath(desktopRoot = canonicalDesktopRoot) {
+  return join(desktopRoot, KEYCHAIN_HELPER_BUILD_DIRECTORY, KEYCHAIN_HELPER_FILE);
+}
+
+export function keychainHelperCompilerAvailable() {
+  const probe = spawnSync("swiftc", ["-version"], { stdio: "ignore" });
+  return probe.error === undefined && probe.status === 0;
+}
+
+export async function buildKeychainHelper(desktopRoot = canonicalDesktopRoot) {
+  if (process.platform !== "darwin") return undefined;
+  if (!keychainHelperCompilerAvailable()) {
+    throw new Error("swiftc is required to build the macOS keychain helper");
+  }
+  const buildRoot = join(desktopRoot, KEYCHAIN_HELPER_BUILD_DIRECTORY);
+  const temporaryRoot = join(desktopRoot, "dist", `.keychain-helper-${process.pid}`);
+  await rm(temporaryRoot, { recursive: true, force: true });
+  await mkdir(temporaryRoot, { recursive: true });
+  try {
+    const temporaryBinary = join(temporaryRoot, KEYCHAIN_HELPER_FILE);
+    const compile = spawnSync(
+      "swiftc",
+      [
+        join(desktopRoot, KEYCHAIN_HELPER_SOURCE),
+        "-O",
+        "-target",
+        KEYCHAIN_HELPER_SWIFT_TARGET,
+        "-o",
+        temporaryBinary,
+      ],
+      { cwd: temporaryRoot, encoding: "utf8", timeout: KEYCHAIN_HELPER_COMPILE_TIMEOUT_MS },
+    );
+    if (compile.error !== undefined || compile.status !== 0 || compile.signal !== null) {
+      if (typeof compile.stderr === "string" && compile.stderr.length > 0) {
+        process.stderr.write(compile.stderr);
+      }
+      throw new Error("keychain helper compilation failed");
+    }
+    machoExecutableIdentity(await readFile(temporaryBinary), KEYCHAIN_HELPER_BUILD_DIRECTORY);
+    await chmod(temporaryBinary, 0o755);
+    await rm(buildRoot, { recursive: true, force: true });
+    await rename(temporaryRoot, buildRoot);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+  return keychainHelperBuildPath(desktopRoot);
+}
+
+async function main() {
+  if (process.argv.length !== 2) throw new Error("arguments are not supported");
+  const built = await buildKeychainHelper();
+  process.stdout.write(
+    built === undefined
+      ? "keychain helper build skipped on this platform\n"
+      : `keychain helper: ${KEYCHAIN_HELPER_BUILD_DIRECTORY}/${KEYCHAIN_HELPER_FILE}\n`,
+  );
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/apps/desktop/scripts/build-self-test-resources.ts
+++ b/apps/desktop/scripts/build-self-test-resources.ts
@@ -8,6 +8,7 @@ import { METRIC_REGISTRY } from "@enduragent/kernel/reference/registry";
 import { FixtureSchema } from "@enduragent/kernel/reference/schemas";
 import * as statistics from "@enduragent/kernel/reference/metrics";
 import { deviationMap } from "./self-test-deviations.js";
+import { buildKeychainHelper } from "./build-keychain-helper.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = resolve(scriptDirectory, "../../..");
@@ -245,6 +246,7 @@ async function main(): Promise<void> {
   ]);
   await Promise.all([rename(temporaryAsar, asarOutput), rename(temporaryRunner, runnerOutput)]);
   try {
+    await buildKeychainHelper(desktopRoot);
     await runStage();
   } catch (error) {
     await Promise.all([

--- a/apps/desktop/scripts/macos-release-plan.d.mts
+++ b/apps/desktop/scripts/macos-release-plan.d.mts
@@ -104,6 +104,7 @@ export type MacosReleaseStage =
   | "baseline-verification"
   | "electron-builder"
   | "package-layout"
+  | "keychain-helper"
   | "candidate-verification"
   | "identity-continuity"
   | "dmg-notarization"
@@ -133,6 +134,7 @@ export interface MacosReleaseDependencies {
     baselineApplication: string,
     options: { readonly candidateVersion: string },
   ) => Promise<VerifiedMacosBaselineApplication>;
+  readonly verifyKeychainHelper?: (candidateApplication: string) => Promise<unknown>;
   readonly verifyIdentityContinuity?: (
     baselineApplication: string,
     candidateApplication: string,

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -755,6 +755,14 @@ export async function runMacosRelease(input, dependencies = {}) {
       feedUrl: plan.feedUrl,
     },
   });
+  const verifyKeychainHelper =
+    dependencies.verifyKeychainHelper ??
+    ((candidate) =>
+      verification.verifyMacosKeychainHelper(candidate, {
+        executeFile: dependencies.executeFile,
+      }));
+  dependencies.reportStage?.("keychain-helper");
+  await verifyKeychainHelper(application);
   const verifyIdentityContinuity =
     dependencies.verifyIdentityContinuity ??
     ((baseline, candidate, options) =>

--- a/apps/desktop/scripts/package-inventory.d.mts
+++ b/apps/desktop/scripts/package-inventory.d.mts
@@ -2,6 +2,8 @@ import type { Stats } from "node:fs";
 
 export { contained } from "./package-plan.mjs";
 
+export const KEYCHAIN_HELPER_RESOURCE_PATH: "keychain/keychain-helper";
+
 export interface BuilderAuthority {
   readonly asarSourceRoot: string;
   readonly externalSourceRoot: string;
@@ -54,6 +56,18 @@ export interface ManifestValidationOptions {
   readonly release?: {
     readonly version: string;
   };
+}
+
+export interface MachoExecutableIdentity {
+  readonly cpuType: number;
+  readonly cpuSubtype: number;
+  readonly fileType: number;
+  readonly uuid: string;
+  readonly contentSha256: string;
+}
+
+export interface StagedTreeComparisonOptions {
+  readonly signedExecutables?: readonly string[];
 }
 
 export class PackageLayoutError extends Error {}
@@ -110,10 +124,13 @@ export function validateUnpackedTree(
   labels: UnpackedTreeLabels,
 ): Promise<void>;
 
+export function machoExecutableIdentity(bytes: Buffer, label: string): MachoExecutableIdentity;
+
 export function compareStagedTree(
   expected: ReadonlyMap<string, PackageTreeEntry>,
   actual: ReadonlyMap<string, PackageTreeEntry>,
   actualRoot: string,
+  options?: StagedTreeComparisonOptions,
 ): void;
 
 export function compareAsarStaging(

--- a/apps/desktop/scripts/package-inventory.mjs
+++ b/apps/desktop/scripts/package-inventory.mjs
@@ -8,6 +8,8 @@ import { contained } from "./package-plan.mjs";
 
 export { contained } from "./package-plan.mjs";
 
+export const KEYCHAIN_HELPER_RESOURCE_PATH = "keychain/keychain-helper";
+
 const requiredAsarFiles = [
   "out/main/index.js",
   "out/main/daemon-utility.js",
@@ -74,6 +76,20 @@ const acceptanceOnlyMarkers = [
   "enduragent-desktop-telegram-acceptance",
   "enduragentdesktoptelegramacceptance",
 ];
+const MACH_O_HEADER_BYTES = 32;
+const MACH_O_64_LITTLE_ENDIAN_MAGIC = 0xfeed_facf;
+const MACH_O_ARM64_CPU_TYPE = 0x0100_000c;
+const MACH_O_EXECUTE_FILE_TYPE = 0x2;
+const MACH_O_UUID_COMMAND = 0x1b;
+const MACH_O_UUID_COMMAND_BYTES = 24;
+const MACH_O_SEGMENT_64_COMMAND = 0x19;
+const MACH_O_SEGMENT_64_COMMAND_BYTES = 72;
+const MACH_O_CODE_SIGNATURE_COMMAND = 0x1d;
+const MACH_O_CODE_SIGNATURE_COMMAND_BYTES = 16;
+const MACH_O_LINK_EDIT_SEGMENT = "__LINKEDIT";
+const MACH_O_MAXIMUM_LOAD_COMMANDS = 1_024;
+const MINIMUM_MACH_O_EXECUTABLE_BYTES = 4_096;
+const MAXIMUM_MACH_O_EXECUTABLE_BYTES = 8_388_608;
 const removedMainManifestKeys = new Set([
   "dist",
   "gitHead",
@@ -201,6 +217,93 @@ export function inspectContents(bytes, label) {
   ) {
     fail("known plaintext secret marker", label);
   }
+}
+
+export function machoExecutableIdentity(bytes, label) {
+  if (
+    !Buffer.isBuffer(bytes) ||
+    bytes.length < MINIMUM_MACH_O_EXECUTABLE_BYTES ||
+    bytes.length > MAXIMUM_MACH_O_EXECUTABLE_BYTES ||
+    bytes.readUInt32LE(0) !== MACH_O_64_LITTLE_ENDIAN_MAGIC
+  ) {
+    fail("expected a 64-bit little-endian Mach-O executable", label);
+  }
+  const cpuType = bytes.readUInt32LE(4);
+  const cpuSubtype = bytes.readUInt32LE(8);
+  const fileType = bytes.readUInt32LE(12);
+  const commandCount = bytes.readUInt32LE(16);
+  const commandBytes = bytes.readUInt32LE(20);
+  const commandEnd = MACH_O_HEADER_BYTES + commandBytes;
+  if (cpuType !== MACH_O_ARM64_CPU_TYPE || fileType !== MACH_O_EXECUTE_FILE_TYPE) {
+    fail("unsupported Mach-O executable architecture", label);
+  }
+  if (
+    commandCount === 0 ||
+    commandCount > MACH_O_MAXIMUM_LOAD_COMMANDS ||
+    commandBytes < 8 ||
+    commandEnd > bytes.length
+  ) {
+    fail("invalid Mach-O load commands", label);
+  }
+  let offset = MACH_O_HEADER_BYTES;
+  let uuid;
+  let linkEditCommand;
+  let signatureCommand;
+  for (let index = 0; index < commandCount; index += 1) {
+    if (offset + 8 > commandEnd) fail("invalid Mach-O load commands", label);
+    const command = bytes.readUInt32LE(offset);
+    const size = bytes.readUInt32LE(offset + 4);
+    if (size < 8 || size % 8 !== 0 || offset + size > commandEnd) {
+      fail("invalid Mach-O load commands", label);
+    }
+    if (command === MACH_O_UUID_COMMAND) {
+      if (size !== MACH_O_UUID_COMMAND_BYTES || uuid !== undefined) {
+        fail("invalid Mach-O image identifier", label);
+      }
+      uuid = bytes.subarray(offset + 8, offset + MACH_O_UUID_COMMAND_BYTES).toString("hex");
+    }
+    if (
+      command === MACH_O_SEGMENT_64_COMMAND &&
+      size === MACH_O_SEGMENT_64_COMMAND_BYTES &&
+      bytes.subarray(offset + 8, offset + 24).toString("latin1").replace(/\0+$/u, "") ===
+        MACH_O_LINK_EDIT_SEGMENT
+    ) {
+      if (linkEditCommand !== undefined) fail("invalid Mach-O link edit segment", label);
+      linkEditCommand = offset;
+    }
+    if (command === MACH_O_CODE_SIGNATURE_COMMAND) {
+      if (size !== MACH_O_CODE_SIGNATURE_COMMAND_BYTES || signatureCommand !== undefined) {
+        fail("invalid Mach-O code signature", label);
+      }
+      signatureCommand = offset;
+    }
+    offset += size;
+  }
+  if (offset !== commandEnd || uuid === undefined) {
+    fail("invalid Mach-O image identifier", label);
+  }
+  if (linkEditCommand === undefined) fail("invalid Mach-O link edit segment", label);
+  if (signatureCommand === undefined) fail("invalid Mach-O code signature", label);
+  const signatureOffset = bytes.readUInt32LE(signatureCommand + 8);
+  const signatureBytes = bytes.readUInt32LE(signatureCommand + 12);
+  if (
+    signatureOffset < commandEnd ||
+    signatureBytes === 0 ||
+    signatureOffset + signatureBytes !== bytes.length
+  ) {
+    fail("invalid Mach-O code signature", label);
+  }
+  const content = Buffer.from(bytes.subarray(0, signatureOffset));
+  content.fill(0, linkEditCommand + 32, linkEditCommand + 40);
+  content.fill(0, linkEditCommand + 48, linkEditCommand + 56);
+  content.fill(0, signatureCommand + 8, signatureCommand + MACH_O_CODE_SIGNATURE_COMMAND_BYTES);
+  return {
+    cpuType,
+    cpuSubtype,
+    fileType,
+    uuid,
+    contentSha256: createHash("sha256").update(content).digest("hex"),
+  };
 }
 
 function fileSet(value) {
@@ -431,7 +534,8 @@ export async function validateUnpackedTree(unpackedRoot, asar, present, labels) 
   }
 }
 
-export function compareStagedTree(expected, actual, actualRoot) {
+export function compareStagedTree(expected, actual, actualRoot, options = {}) {
+  const signedExecutables = new Set(options.signedExecutables ?? []);
   const expectedPaths = [...expected.keys()].sort();
   const actualPaths = [...actual.keys()].sort();
   if (
@@ -446,7 +550,22 @@ export function compareStagedTree(expected, actual, actualRoot) {
     if (expectedEntry.type !== actualEntry.type) {
       fail("packaged external resource type differs from staging", `${actualRoot}/${path}`);
     }
-    if (expectedEntry.type === "file" && !expectedEntry.bytes.equals(actualEntry.bytes)) {
+    if (expectedEntry.type !== "file") continue;
+    if (signedExecutables.has(path)) {
+      const staged = machoExecutableIdentity(expectedEntry.bytes, `${actualRoot}/${path}`);
+      const packaged = machoExecutableIdentity(actualEntry.bytes, `${actualRoot}/${path}`);
+      if (
+        staged.uuid !== packaged.uuid ||
+        staged.contentSha256 !== packaged.contentSha256 ||
+        staged.cpuType !== packaged.cpuType ||
+        staged.cpuSubtype !== packaged.cpuSubtype ||
+        staged.fileType !== packaged.fileType
+      ) {
+        fail("packaged external executable differs from staging", `${actualRoot}/${path}`);
+      }
+      continue;
+    }
+    if (!expectedEntry.bytes.equals(actualEntry.bytes)) {
       fail("packaged external resource bytes differ from staging", `${actualRoot}/${path}`);
     }
   }

--- a/apps/desktop/scripts/stage-extra-resources.mjs
+++ b/apps/desktop/scripts/stage-extra-resources.mjs
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
-import { copyFile, lstat, mkdir, readFile, rename, rm } from "node:fs/promises";
+import { chmod, copyFile, lstat, mkdir, readFile, rename, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { keychainHelperBuildPath } from "./build-keychain-helper.mjs";
+import { KEYCHAIN_HELPER_RESOURCE_PATH, machoExecutableIdentity } from "./package-inventory.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(scriptDirectory, "..");
@@ -48,6 +50,18 @@ if (
   canonicalChecksum.toString("utf8") !== `${digest(canonicalMatrix)}  matrix.json\n`
 ) {
   throw new Error("staged resource mismatch");
+}
+if (process.platform === "darwin") {
+  const source = keychainHelperBuildPath(desktopRoot);
+  const sourceStat = await lstat(source);
+  if (!sourceStat.isFile() || sourceStat.isSymbolicLink()) throw new Error("invalid staged source");
+  const target = join(temporaryRoot, KEYCHAIN_HELPER_RESOURCE_PATH);
+  await mkdir(dirname(target), { recursive: true });
+  await copyFile(source, target);
+  await chmod(target, 0o755);
+  const staged = await lstat(target);
+  if (!staged.isFile() || staged.isSymbolicLink()) throw new Error("invalid staged resource");
+  machoExecutableIdentity(await readFile(target), KEYCHAIN_HELPER_RESOURCE_PATH);
 }
 await rm(targetRoot, { recursive: true, force: true });
 await rename(temporaryRoot, targetRoot);

--- a/apps/desktop/scripts/verify-macos-release.d.mts
+++ b/apps/desktop/scripts/verify-macos-release.d.mts
@@ -128,6 +128,15 @@ export interface VerifiedMacosReleaseEnvelope {
 
 export function safeMacosReleaseVerificationMessage(error: unknown): string | undefined;
 
+export interface VerifiedMacosKeychainHelper {
+  readonly teamIdentifier: string;
+  readonly designatedRequirement: string;
+}
+
+export function verifyMacosKeychainHelper(
+  application: string,
+  dependencies?: Pick<VerifyMacosReleaseDependencies, "executeFile">,
+): Promise<VerifiedMacosKeychainHelper>;
 export function verifyMacosApplication(
   application: string,
   dependencies?: Pick<VerifyMacosReleaseDependencies, "executeFile">,

--- a/apps/desktop/scripts/verify-macos-release.mjs
+++ b/apps/desktop/scripts/verify-macos-release.mjs
@@ -25,6 +25,7 @@ import {
   releaseArtifactNames,
   requireStableSemVer,
 } from "./macos-release-plan.mjs";
+import { KEYCHAIN_HELPER_RESOURCE_PATH } from "./package-inventory.mjs";
 
 const localRequire = createRequire(import.meta.url);
 const supportedElectronBuilderVersion = "26.15.3";
@@ -42,6 +43,8 @@ const canonicalDesignatedRequirementSha256 = createHash("sha256")
   .digest("hex");
 const canonicalDesignatedRequirementPattern =
   /^identifier "icu\.enduragent\.desktop" and anchor apple generic and certificate 1\[field\.1\.2\.840\.113635\.100\.6\.2\.6\] (?:exists|\/\* exists \*\/) and certificate leaf\[field\.1\.2\.840\.113635\.100\.6\.1\.13\] (?:exists|\/\* exists \*\/) and certificate leaf\[subject\.OU\] = (?:FA494ACVTF|"FA494ACVTF")$/u;
+const canonicalHelperDesignatedRequirementPattern =
+  /^identifier "keychain-helper(?:-[0-9a-f]{1,64})?" and anchor apple generic and certificate 1\[field\.1\.2\.840\.113635\.100\.6\.2\.6\] (?:exists|\/\* exists \*\/) and certificate leaf\[field\.1\.2\.840\.113635\.100\.6\.1\.13\] (?:exists|\/\* exists \*\/) and certificate leaf\[subject\.OU\] = (?:FA494ACVTF|"FA494ACVTF")$/u;
 
 class MacosReleaseVerificationError extends Error {
   constructor(message) {
@@ -1498,6 +1501,54 @@ async function verifyMacosDmgNotarization(dmgPath, executeFile) {
     ],
     "macOS DMG Gatekeeper verification failed",
   );
+}
+
+export async function verifyMacosKeychainHelper(application, overrides = {}) {
+  if (!isAbsolute(application)) fail("application path must be absolute");
+  const executeFile = overrides.executeFile ?? executeSystemFile;
+  const helper = join(application, "Contents/Resources", KEYCHAIN_HELPER_RESOURCE_PATH);
+  await runSystemVerification(
+    executeFile,
+    "/usr/bin/codesign",
+    ["--verify", "--strict", "--verbose=2", helper],
+    "macOS keychain helper signature verification failed",
+  );
+  let signatureResult;
+  let requirementResult;
+  try {
+    [signatureResult, requirementResult] = await Promise.all([
+      executeFile("/usr/bin/codesign", ["--display", "--verbose=4", helper]),
+      executeFile("/usr/bin/codesign", ["--display", "--requirements", "-", helper]),
+    ]);
+  } catch {
+    fail("macOS keychain helper identity inspection failed");
+  }
+  const output = allCommandOutput(signatureResult);
+  const teamIdentifier = exactLine(output, /^TeamIdentifier=([^\r\n]+)$/gmu);
+  const authorities = Array.from(output.matchAll(/^Authority=([^\r\n]+)$/gmu), (match) => match[1]);
+  const flags = exactLine(output, /^CodeDirectory [^\r\n]* flags=0x[0-9a-f]+\(([^\r\n)]*)\)/gimu);
+  if (
+    !hasCanonicalDeveloperIdApplicationIdentity(teamIdentifier, authorities) ||
+    flags === undefined ||
+    !flags
+      .split(",")
+      .map((flag) => flag.trim())
+      .includes("runtime")
+  ) {
+    fail("macOS keychain helper signing identity is invalid");
+  }
+  const requirement = exactLine(allCommandOutput(requirementResult), /^designated => ([^\r\n]+)$/gmu)
+    ?.replaceAll(/\s+/gu, " ")
+    .trim();
+  if (
+    requirement === undefined ||
+    requirement.length === 0 ||
+    requirement.length > 16_384 ||
+    !canonicalHelperDesignatedRequirementPattern.test(requirement)
+  ) {
+    fail("macOS keychain helper designated requirement is invalid");
+  }
+  return Object.freeze({ teamIdentifier, designatedRequirement: requirement });
 }
 
 export async function verifyMacosApplication(application, overrides = {}) {

--- a/apps/desktop/scripts/verify-package-layout.mjs
+++ b/apps/desktop/scripts/verify-package-layout.mjs
@@ -10,6 +10,7 @@ import {
   createDevelopmentPackagePlan,
 } from "./development-package-plan.mjs";
 import {
+  KEYCHAIN_HELPER_RESOURCE_PATH,
   PackageLayoutError,
   assertDirectory,
   assertExactResourceNames,
@@ -43,6 +44,7 @@ const reservedResourceNames = new Set([
   "icon.icns",
   "en.lproj",
 ]);
+const signedExternalExecutables = [KEYCHAIN_HELPER_RESOURCE_PATH];
 
 export async function readBuilderAuthority(desktopRoot = canonicalDesktopRoot) {
   const config = await readBuilderConfiguration(desktopRoot);
@@ -167,12 +169,21 @@ export async function verifyPackageLayout(application, options = {}) {
         externalPackaged.set(`${topLevel}/${path}`, entry);
       }
     }
-    compareStagedTree(externalSource, externalPackaged, "Contents/Resources");
+    compareStagedTree(externalSource, externalPackaged, "Contents/Resources", {
+      signedExecutables: signedExternalExecutables,
+    });
     const runner = externalPackaged.get("self-test/self-test-runner.cjs");
     if (runner === undefined || runner.type !== "file") {
       fail(
         "external self-test runner is missing",
         "Contents/Resources/self-test/self-test-runner.cjs",
+      );
+    }
+    const helper = externalPackaged.get(KEYCHAIN_HELPER_RESOURCE_PATH);
+    if (helper === undefined || helper.type !== "file") {
+      fail(
+        "external keychain helper is missing",
+        `Contents/Resources/${KEYCHAIN_HELPER_RESOURCE_PATH}`,
       );
     }
 

--- a/apps/desktop/scripts/verify-packaged-self-test.mjs
+++ b/apps/desktop/scripts/verify-packaged-self-test.mjs
@@ -7,6 +7,7 @@ import {
   DEVELOPMENT_PRODUCT_NAME,
   createDevelopmentPackagePlan,
 } from "./development-package-plan.mjs";
+import { KEYCHAIN_HELPER_RESOURCE_PATH } from "./package-inventory.mjs";
 
 const APP_READY_TIMEOUT_MS = 30_000;
 const SELF_TEST_TIMEOUT_MS = 120_000;
@@ -309,6 +310,12 @@ async function main() {
     const matrix = await readFile(matrixPath);
     matrix[0] = matrix[0] === 97 ? 98 : 97;
     await writeFile(matrixPath, matrix);
+    await runChecked("codesign", [
+      "--force",
+      "--sign",
+      "-",
+      join(copiedApplication, "Contents/Resources", KEYCHAIN_HELPER_RESOURCE_PATH),
+    ]);
     const frameworksDirectory = join(copiedApplication, "Contents/Frameworks");
     for (const entry of (await readdir(frameworksDirectory)).sort()) {
       const componentPath = entry.endsWith(".framework")

--- a/apps/desktop/src/main/keychain-helper-path.ts
+++ b/apps/desktop/src/main/keychain-helper-path.ts
@@ -1,0 +1,21 @@
+import { isAbsolute, join } from "node:path";
+
+export const KEYCHAIN_HELPER_EXECUTABLE_NAME = "keychain-helper" as const;
+export const KEYCHAIN_HELPER_RESOURCE_DIRECTORY = "keychain" as const;
+export const KEYCHAIN_HELPER_DEVELOPMENT_DIRECTORY = "dist/keychain-helper" as const;
+
+export interface KeychainHelperLocation {
+  readonly platform: NodeJS.Platform;
+  readonly packaged: boolean;
+  readonly resourcesPath: string;
+  readonly applicationPath: string;
+}
+
+export function resolveKeychainHelperPath(location: KeychainHelperLocation): string | undefined {
+  if (location.platform !== "darwin") return undefined;
+  const root = location.packaged
+    ? join(location.resourcesPath, KEYCHAIN_HELPER_RESOURCE_DIRECTORY)
+    : join(location.applicationPath, KEYCHAIN_HELPER_DEVELOPMENT_DIRECTORY);
+  if (!isAbsolute(root)) return undefined;
+  return join(root, KEYCHAIN_HELPER_EXECUTABLE_NAME);
+}

--- a/apps/desktop/tests/keychain-helper-path.test.ts
+++ b/apps/desktop/tests/keychain-helper-path.test.ts
@@ -1,4 +1,7 @@
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { KEYCHAIN_HELPER_BUILD_DIRECTORY } from "../scripts/build-keychain-helper.mjs";
+import { KEYCHAIN_HELPER_RESOURCE_PATH } from "../scripts/package-inventory.mjs";
 import {
   KEYCHAIN_HELPER_DEVELOPMENT_DIRECTORY,
   KEYCHAIN_HELPER_EXECUTABLE_NAME,
@@ -21,6 +24,16 @@ const development = {
 };
 
 describe("keychain helper path", () => {
+  it("agrees with the packaging constants on the packaged resource path", () => {
+    expect(join(KEYCHAIN_HELPER_RESOURCE_DIRECTORY, KEYCHAIN_HELPER_EXECUTABLE_NAME)).toBe(
+      KEYCHAIN_HELPER_RESOURCE_PATH,
+    );
+  });
+
+  it("agrees with the build script on the development directory", () => {
+    expect(KEYCHAIN_HELPER_DEVELOPMENT_DIRECTORY).toBe(KEYCHAIN_HELPER_BUILD_DIRECTORY);
+  });
+
   it("resolves the packaged helper under the external resource directory", () => {
     expect(resolveKeychainHelperPath(packaged)).toBe(
       `/Applications/Enduragent.app/Contents/Resources/${KEYCHAIN_HELPER_RESOURCE_DIRECTORY}/${KEYCHAIN_HELPER_EXECUTABLE_NAME}`,

--- a/apps/desktop/tests/keychain-helper-path.test.ts
+++ b/apps/desktop/tests/keychain-helper-path.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  KEYCHAIN_HELPER_DEVELOPMENT_DIRECTORY,
+  KEYCHAIN_HELPER_EXECUTABLE_NAME,
+  KEYCHAIN_HELPER_RESOURCE_DIRECTORY,
+  resolveKeychainHelperPath,
+} from "../src/main/keychain-helper-path.js";
+
+const packaged = {
+  platform: "darwin" as NodeJS.Platform,
+  packaged: true,
+  resourcesPath: "/Applications/Enduragent.app/Contents/Resources",
+  applicationPath: "/Applications/Enduragent.app/Contents/Resources/app.asar",
+};
+
+const development = {
+  platform: "darwin" as NodeJS.Platform,
+  packaged: false,
+  resourcesPath: "/opt/electron/resources",
+  applicationPath: "/repository/apps/desktop",
+};
+
+describe("keychain helper path", () => {
+  it("resolves the packaged helper under the external resource directory", () => {
+    expect(resolveKeychainHelperPath(packaged)).toBe(
+      `/Applications/Enduragent.app/Contents/Resources/${KEYCHAIN_HELPER_RESOURCE_DIRECTORY}/${KEYCHAIN_HELPER_EXECUTABLE_NAME}`,
+    );
+  });
+
+  it("resolves the locally compiled helper in development", () => {
+    expect(resolveKeychainHelperPath(development)).toBe(
+      `/repository/apps/desktop/${KEYCHAIN_HELPER_DEVELOPMENT_DIRECTORY}/${KEYCHAIN_HELPER_EXECUTABLE_NAME}`,
+    );
+  });
+
+  it.each(["win32", "linux"] as const)("returns nothing on %s", (platform) => {
+    expect(resolveKeychainHelperPath({ ...packaged, platform })).toBeUndefined();
+    expect(resolveKeychainHelperPath({ ...development, platform })).toBeUndefined();
+  });
+
+  it("returns nothing when the resolved root is not absolute", () => {
+    expect(resolveKeychainHelperPath({ ...packaged, resourcesPath: "Resources" })).toBeUndefined();
+    expect(
+      resolveKeychainHelperPath({ ...development, applicationPath: "apps/desktop" }),
+    ).toBeUndefined();
+  });
+
+  it("ignores the unused sibling root for each mode", () => {
+    expect(resolveKeychainHelperPath({ ...packaged, applicationPath: "relative" })).toBe(
+      `/Applications/Enduragent.app/Contents/Resources/${KEYCHAIN_HELPER_RESOURCE_DIRECTORY}/${KEYCHAIN_HELPER_EXECUTABLE_NAME}`,
+    );
+    expect(resolveKeychainHelperPath({ ...development, resourcesPath: "relative" })).toBe(
+      `/repository/apps/desktop/${KEYCHAIN_HELPER_DEVELOPMENT_DIRECTORY}/${KEYCHAIN_HELPER_EXECUTABLE_NAME}`,
+    );
+  });
+});

--- a/apps/desktop/tests/macos-release-artifacts.test.ts
+++ b/apps/desktop/tests/macos-release-artifacts.test.ts
@@ -27,6 +27,7 @@ import {
   verifyMacosApplication,
   verifyMacosBaselineApplication,
   verifyMacosIdentityContinuity,
+  verifyMacosKeychainHelper,
   verifyMacosReleaseApplicationContents,
   verifyMacosReleaseArtifacts,
   verifyMacosReleaseEnvelope,
@@ -61,6 +62,33 @@ function dmgSigningIdentityResult(
       "Authority=Apple Root CA",
       `TeamIdentifier=${teamIdentifier}`,
     ].join("\n"),
+  };
+}
+
+const keychainHelperDesignatedRequirement = [
+  'identifier "keychain-helper-a1b2c3" and anchor apple generic and certificate',
+  "1[field.1.2.840.113635.100.6.2.6] exists and certificate",
+  "leaf[field.1.2.840.113635.100.6.1.13] exists and certificate leaf[subject.OU] = FA494ACVTF",
+].join(" ");
+
+function keychainHelperIdentityResult(teamIdentifier = "FA494ACVTF", flags = "runtime") {
+  return {
+    stdout: "",
+    stderr: [
+      "Identifier=keychain-helper-a1b2c3",
+      `CodeDirectory v=20500 size=402 flags=0x10000(${flags}) hashes=6+2 location=embedded`,
+      `Authority=Developer ID Application: Enduragent Test (${teamIdentifier})`,
+      "Authority=Developer ID Certification Authority",
+      "Authority=Apple Root CA",
+      `TeamIdentifier=${teamIdentifier}`,
+    ].join("\n"),
+  };
+}
+
+function keychainHelperRequirementResult(teamIdentifier = "FA494ACVTF") {
+  return {
+    stdout: `designated => ${keychainHelperDesignatedRequirement.replace("FA494ACVTF", teamIdentifier)}\n`,
+    stderr: "",
   };
 }
 
@@ -2060,6 +2088,72 @@ describe.skipIf(process.platform === "win32")("macOS release artifact envelope",
       ["/usr/bin/xcrun", ["stapler", "validate", "-v", application]],
       ["/usr/sbin/spctl", ["--assess", "--type", "execute", "--verbose=4", application]],
     ]);
+  });
+
+  it("verifies the packaged keychain helper identity and designated requirement", async () => {
+    const application = "/synthetic/Enduragent.app";
+    const helper = `${application}/Contents/Resources/keychain/keychain-helper`;
+    const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+      if (arguments_.includes("--requirements")) return keychainHelperRequirementResult();
+      if (arguments_.includes("--verbose=4")) return keychainHelperIdentityResult();
+      return { stdout: "", stderr: "" };
+    });
+
+    await expect(verifyMacosKeychainHelper(application, { executeFile })).resolves.toEqual({
+      teamIdentifier: "FA494ACVTF",
+      designatedRequirement: keychainHelperDesignatedRequirement,
+    });
+    expect(executeFile.mock.calls).toEqual([
+      ["/usr/bin/codesign", ["--verify", "--strict", "--verbose=2", helper]],
+      ["/usr/bin/codesign", ["--display", "--verbose=4", helper]],
+      ["/usr/bin/codesign", ["--display", "--requirements", "-", helper]],
+    ]);
+  });
+
+  it.each([
+    [
+      "an unverifiable signature",
+      () => ({ verifies: false }),
+      "macOS keychain helper signature verification failed",
+    ],
+    [
+      "a foreign team identifier",
+      () => ({ teamIdentifier: "ZZZZZZZZZZ" }),
+      "macOS keychain helper signing identity is invalid",
+    ],
+    [
+      "a helper without the hardened runtime",
+      () => ({ flags: "adhoc" }),
+      "macOS keychain helper signing identity is invalid",
+    ],
+    [
+      "a designated requirement naming another team",
+      () => ({ requirementTeamIdentifier: "ZZZZZZZZZZ" }),
+      "macOS keychain helper designated requirement is invalid",
+    ],
+  ])("rejects %s", async (_label, overrides, message) => {
+    const options = overrides() as {
+      verifies?: boolean;
+      teamIdentifier?: string;
+      flags?: string;
+      requirementTeamIdentifier?: string;
+    };
+    const executeFile = vi.fn(async (_executable: string, arguments_: readonly string[]) => {
+      if (arguments_.includes("--verify") && options.verifies === false) {
+        throw new Error("synthetic native verification failure");
+      }
+      if (arguments_.includes("--requirements")) {
+        return keychainHelperRequirementResult(options.requirementTeamIdentifier);
+      }
+      if (arguments_.includes("--verbose=4")) {
+        return keychainHelperIdentityResult(options.teamIdentifier, options.flags);
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    await expect(
+      verifyMacosKeychainHelper("/synthetic/Enduragent.app", { executeFile }),
+    ).rejects.toThrow(message);
   });
 
   it("fails closed without invoking later application verification commands", async () => {

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -61,6 +61,10 @@ const verifiedBaselineApplication = Object.freeze({
   baselineVersion: "2026.7.1",
   teamIdentifier: "FA494ACVTF",
 });
+const verifiedKeychainHelper = Object.freeze({
+  teamIdentifier: "FA494ACVTF",
+  designatedRequirement: 'identifier "keychain-helper" and anchor apple generic',
+});
 const temporaryRoots: string[] = [];
 
 afterEach(async () => {
@@ -87,6 +91,10 @@ function canonicalDmgSigningIdentityResult() {
 
 function baselineVerifier() {
   return vi.fn(async () => verifiedBaselineApplication);
+}
+
+function keychainHelperVerifier() {
+  return vi.fn(async () => verifiedKeychainHelper);
 }
 
 function verifiedReleaseArtifactsAt(artifactDirectory: string) {
@@ -470,6 +478,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
     ]);
     const sealReleaseMetadata = vi.fn(async () => {});
     const verifyPackageLayout = vi.fn(async () => {});
+    const verifyKeychainHelper = keychainHelperVerifier();
     const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
       if (executable === "/usr/bin/codesign" && arguments_.includes("--display")) {
         return canonicalDmgSigningIdentityResult();
@@ -516,6 +525,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
         sealReleaseMetadata,
         verifyBaselineApplication,
         verifyPackageLayout,
+        verifyKeychainHelper,
         verifyIdentityContinuity,
         verifyReleaseApplicationContents,
         promoteReleaseEnvelope,
@@ -600,7 +610,12 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
     expect(build.mock.invocationCallOrder[0]).toBeLessThan(
       verifyPackageLayout.mock.invocationCallOrder[0]!,
     );
+    expect(verifyKeychainHelper).toHaveBeenCalledOnce();
+    expect(verifyKeychainHelper).toHaveBeenCalledWith(application);
     expect(verifyPackageLayout.mock.invocationCallOrder[0]).toBeLessThan(
+      verifyKeychainHelper.mock.invocationCallOrder[0]!,
+    );
+    expect(verifyKeychainHelper.mock.invocationCallOrder[0]).toBeLessThan(
       verifyIdentityContinuity.mock.invocationCallOrder[0]!,
     );
     expect(verifyIdentityContinuity.mock.invocationCallOrder[0]).toBeLessThan(
@@ -630,6 +645,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
       "baseline-verification",
       "electron-builder",
       "package-layout",
+      "keychain-helper",
       "identity-continuity",
       "dmg-notarization",
       "dmg-verification",
@@ -660,6 +676,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
           build,
           sealReleaseMetadata,
           verifyBaselineApplication: baselineVerifier(),
+          verifyKeychainHelper: keychainHelperVerifier(),
           verifyPackageLayout,
         },
       ),
@@ -702,6 +719,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
           notarize,
           sealReleaseMetadata,
           verifyBaselineApplication: baselineVerifier(),
+          verifyKeychainHelper: keychainHelperVerifier(),
           verifyPackageLayout,
           verifyIdentityContinuity,
           promoteReleaseEnvelope,
@@ -911,6 +929,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
           build,
           sealReleaseMetadata,
           verifyBaselineApplication: baselineVerifier(),
+          verifyKeychainHelper: keychainHelperVerifier(),
           verifyPackageLayout,
           verifyIdentityContinuity,
           notarize,
@@ -951,6 +970,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
           environment: notarizationEnvironment,
           build,
           verifyBaselineApplication: baselineVerifier(),
+          verifyKeychainHelper: keychainHelperVerifier(),
           verifyPackageLayout,
           verifyIdentityContinuity,
           executeFile,
@@ -1026,6 +1046,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
         environment: notarizationEnvironment,
         build: vi.fn(async () => []),
         verifyBaselineApplication: baselineVerifier(),
+        verifyKeychainHelper: keychainHelperVerifier(),
         verifyPackageLayout: vi.fn(async () => {}),
         verifyIdentityContinuity,
         verifyReleaseApplicationContents,
@@ -1088,6 +1109,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
           environment: notarizationEnvironment,
           build: vi.fn(async () => []),
           verifyBaselineApplication: baselineVerifier(),
+          verifyKeychainHelper: keychainHelperVerifier(),
           verifyPackageLayout: vi.fn(async () => {}),
           verifyIdentityContinuity: vi.fn(async () => verifiedLooseIdentity),
           notarize: vi.fn(async () => {}),

--- a/apps/desktop/tests/package-contract.test.ts
+++ b/apps/desktop/tests/package-contract.test.ts
@@ -15,6 +15,7 @@ import {
   forbiddenPathReason,
   inspectContents,
   inspectPath,
+  machoExecutableIdentity,
   outputChild,
   parseManifest,
   validateManifest,
@@ -63,6 +64,42 @@ async function makeAsar(
 
 function packageFile(bytes: string): PackageTreeEntry {
   return { type: "file", bytes: Buffer.from(bytes) };
+}
+
+const syntheticUuid = "0123456789abcdeffedcba9876543210";
+
+function machoExecutable(
+  options: {
+    readonly uuid?: string;
+    readonly signatureBytes?: number;
+    readonly payload?: string;
+  } = {},
+): Buffer {
+  const signature = options.signatureBytes ?? 512;
+  const signatureOffset = 8_192;
+  const bytes = Buffer.alloc(signatureOffset + signature);
+  bytes.writeUInt32LE(0xfeed_facf, 0);
+  bytes.writeUInt32LE(0x0100_000c, 4);
+  bytes.writeUInt32LE(0, 8);
+  bytes.writeUInt32LE(2, 12);
+  bytes.writeUInt32LE(3, 16);
+  bytes.writeUInt32LE(112, 20);
+  bytes.writeUInt32LE(0x1b, 32);
+  bytes.writeUInt32LE(24, 36);
+  Buffer.from(options.uuid ?? syntheticUuid, "hex").copy(bytes, 40);
+  bytes.writeUInt32LE(0x19, 56);
+  bytes.writeUInt32LE(72, 60);
+  bytes.write("__LINKEDIT", 64, "latin1");
+  bytes.writeBigUInt64LE(BigInt(4_096 + signature), 88);
+  bytes.writeBigUInt64LE(BigInt(4_096), 96);
+  bytes.writeBigUInt64LE(BigInt(4_096 + signature), 104);
+  bytes.writeUInt32LE(0x1d, 128);
+  bytes.writeUInt32LE(16, 132);
+  bytes.writeUInt32LE(signatureOffset, 136);
+  bytes.writeUInt32LE(signature, 140);
+  bytes.write(options.payload ?? "synthetic image", 1_024, "latin1");
+  bytes.fill(0x5a, signatureOffset);
+  return bytes;
 }
 
 function asarFile(bytes: string, unpacked = false): AsarTreeEntry {
@@ -300,6 +337,132 @@ describe("shared package trees", () => {
     wrongBytes.set("assets/runtime.bin", packageFile("different"));
     expect(() => compareStagedTree(expected, wrongBytes, "packaged-tree")).toThrow(
       "packaged external resource bytes differ from staging: packaged-tree/assets/runtime.bin",
+    );
+  });
+
+  it("compares a declared signed executable by image identifier instead of bytes", () => {
+    const staged = new Map<string, PackageTreeEntry>([
+      ["keychain", { type: "directory" }],
+      ["keychain/keychain-helper", { type: "file", bytes: machoExecutable() }],
+    ]);
+    const options = { signedExecutables: ["keychain/keychain-helper"] };
+    const resigned = new Map<string, PackageTreeEntry>([
+      ["keychain", { type: "directory" }],
+      ["keychain/keychain-helper", { type: "file", bytes: machoExecutable({ signatureBytes: 4_096 }) }],
+    ]);
+    expect(() => compareStagedTree(staged, resigned, "packaged-tree", options)).not.toThrow();
+    expect(() => compareStagedTree(staged, resigned, "packaged-tree")).toThrow(
+      "packaged external resource bytes differ from staging: packaged-tree/keychain/keychain-helper",
+    );
+
+    const rebuilt = new Map<string, PackageTreeEntry>([
+      ["keychain", { type: "directory" }],
+      [
+        "keychain/keychain-helper",
+        { type: "file", bytes: machoExecutable({ uuid: "ffffffffffffffffffffffffffffffff" }) },
+      ],
+    ]);
+    expect(() => compareStagedTree(staged, rebuilt, "packaged-tree", options)).toThrow(
+      "packaged external executable differs from staging: packaged-tree/keychain/keychain-helper",
+    );
+
+    const foreign = new Map<string, PackageTreeEntry>([
+      ["keychain", { type: "directory" }],
+      ["keychain/keychain-helper", { type: "file", bytes: Buffer.alloc(8_192, 0x61) }],
+    ]);
+    expect(() => compareStagedTree(staged, foreign, "packaged-tree", options)).toThrow(
+      "expected a 64-bit little-endian Mach-O executable: packaged-tree/keychain/keychain-helper",
+    );
+  });
+});
+
+describe("shared Mach-O executable identity", () => {
+  it("reads the architecture and image identifier of a 64-bit executable", () => {
+    expect(machoExecutableIdentity(machoExecutable(), "helper")).toEqual({
+      cpuType: 0x0100_000c,
+      cpuSubtype: 0,
+      fileType: 2,
+      uuid: syntheticUuid,
+      contentSha256: expect.stringMatching(/^[0-9a-f]{64}$/u),
+    });
+  });
+
+  it("digests the same content across a replaced code signature", () => {
+    const staged = machoExecutableIdentity(machoExecutable(), "helper");
+    const resigned = machoExecutableIdentity(machoExecutable({ signatureBytes: 4_096 }), "helper");
+    expect(resigned.contentSha256).toBe(staged.contentSha256);
+    expect(resigned.uuid).toBe(staged.uuid);
+  });
+
+  it("digests a changed image differently", () => {
+    const staged = machoExecutableIdentity(machoExecutable(), "helper");
+    const tampered = machoExecutableIdentity(
+      machoExecutable({ signatureBytes: 4_096, payload: "tampered image" }),
+      "helper",
+    );
+    expect(tampered.uuid).toBe(staged.uuid);
+    expect(tampered.contentSha256).not.toBe(staged.contentSha256);
+  });
+
+  it.each([
+    ["a short file", () => machoExecutable().subarray(0, 2_048)],
+    [
+      "a foreign magic",
+      () => {
+        const bytes = machoExecutable();
+        bytes.writeUInt32LE(0xfeed_face, 0);
+        return bytes;
+      },
+    ],
+  ])("rejects %s", (_label, build) => {
+    expect(() => machoExecutableIdentity(build(), "helper")).toThrow(
+      "expected a 64-bit little-endian Mach-O executable: helper",
+    );
+  });
+
+  it.each([
+    ["a foreign architecture", 4, 0x0100_0007],
+    ["a non-executable file type", 12, 6],
+  ])("rejects %s", (_label, offset, value) => {
+    const bytes = machoExecutable();
+    bytes.writeUInt32LE(value, offset);
+    expect(() => machoExecutableIdentity(bytes, "helper")).toThrow(
+      "unsupported Mach-O executable architecture: helper",
+    );
+  });
+
+  it("rejects load commands that overflow the declared region", () => {
+    const bytes = machoExecutable();
+    bytes.writeUInt32LE(40, 132);
+    expect(() => machoExecutableIdentity(bytes, "helper")).toThrow(
+      "invalid Mach-O load commands: helper",
+    );
+  });
+
+  it("rejects an executable that declares no image identifier", () => {
+    const bytes = machoExecutable();
+    bytes.writeUInt32LE(0x19, 32);
+    expect(() => machoExecutableIdentity(bytes, "helper")).toThrow(
+      "invalid Mach-O image identifier: helper",
+    );
+  });
+
+  it("rejects an executable without a link edit segment", () => {
+    const bytes = machoExecutable();
+    bytes.write("__TEXTPAD\0", 64, "latin1");
+    expect(() => machoExecutableIdentity(bytes, "helper")).toThrow(
+      "invalid Mach-O link edit segment: helper",
+    );
+  });
+
+  it.each([
+    ["declares no code signature", 128, 0x1c],
+    ["places its code signature inside the load commands", 136, 64],
+  ])("rejects an executable that %s", (_label, offset, value) => {
+    const bytes = machoExecutable();
+    bytes.writeUInt32LE(value, offset);
+    expect(() => machoExecutableIdentity(bytes, "helper")).toThrow(
+      "invalid Mach-O code signature: helper",
     );
   });
 });

--- a/apps/desktop/tests/package-layout.test.ts
+++ b/apps/desktop/tests/package-layout.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { createPackage, createPackageWithOptions } from "@electron/asar";
 import { afterEach, describe, expect, it } from "vitest";
 import { DEVELOPMENT_PACKAGE_NAME } from "../scripts/development-package-plan.mjs";
+import { KEYCHAIN_HELPER_RESOURCE_PATH } from "../scripts/package-inventory.mjs";
 import { readBuilderAuthority, verifyPackageLayout } from "../scripts/verify-package-layout.mjs";
 
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -138,6 +139,35 @@ function checksum(bytes: Buffer): Buffer {
   return Buffer.from(`${createHash("sha256").update(bytes).digest("hex")}  matrix.json\n`);
 }
 
+const stagedHelperUuid = "00112233445566778899aabbccddeeff";
+
+function machoExecutable(uuid: string, signatureBytes = 512, payload = "synthetic helper"): Buffer {
+  const signatureOffset = 8_192;
+  const bytes = Buffer.alloc(signatureOffset + signatureBytes);
+  bytes.writeUInt32LE(0xfeed_facf, 0);
+  bytes.writeUInt32LE(0x0100_000c, 4);
+  bytes.writeUInt32LE(0, 8);
+  bytes.writeUInt32LE(2, 12);
+  bytes.writeUInt32LE(3, 16);
+  bytes.writeUInt32LE(112, 20);
+  bytes.writeUInt32LE(0x1b, 32);
+  bytes.writeUInt32LE(24, 36);
+  Buffer.from(uuid, "hex").copy(bytes, 40);
+  bytes.writeUInt32LE(0x19, 56);
+  bytes.writeUInt32LE(72, 60);
+  bytes.write("__LINKEDIT", 64, "latin1");
+  bytes.writeBigUInt64LE(BigInt(4_096 + signatureBytes), 88);
+  bytes.writeBigUInt64LE(BigInt(4_096), 96);
+  bytes.writeBigUInt64LE(BigInt(4_096 + signatureBytes), 104);
+  bytes.writeUInt32LE(0x1d, 128);
+  bytes.writeUInt32LE(16, 132);
+  bytes.writeUInt32LE(signatureOffset, 136);
+  bytes.writeUInt32LE(signatureBytes, 140);
+  bytes.write(payload, 1_024, "latin1");
+  bytes.fill(0x5a, signatureOffset);
+  return bytes;
+}
+
 function builderYaml(
   asarSource = "dist/self-test-asar",
   externalSource = "dist/extra-resources",
@@ -176,6 +206,8 @@ type SyntheticPackage = {
   desktop: string;
   externalPackaged: string;
   externalSource: string;
+  helperPackaged: string;
+  helperSource: string;
   resources: string;
   rebuild: () => Promise<void>;
   writeArchive: (path: string, bytes?: string | Buffer) => Promise<void>;
@@ -191,6 +223,8 @@ async function syntheticPackage(): Promise<SyntheticPackage> {
   const asarSource = join(desktop, "dist/self-test-asar");
   const externalSource = join(desktop, "dist/extra-resources");
   const externalPackaged = join(resources, "self-test");
+  const helperSource = join(externalSource, KEYCHAIN_HELPER_RESOURCE_PATH);
+  const helperPackaged = join(resources, KEYCHAIN_HELPER_RESOURCE_PATH);
   const matrix = Buffer.from('{"schemaVersion":1}\n');
   const matrixChecksum = checksum(matrix);
 
@@ -200,9 +234,13 @@ async function syntheticPackage(): Promise<SyntheticPackage> {
     mkdir(archiveSource, { recursive: true }),
     mkdir(join(asarSource, "resources/self-test"), { recursive: true }),
     mkdir(join(externalSource, "self-test"), { recursive: true }),
+    mkdir(dirname(helperSource), { recursive: true }),
+    mkdir(dirname(helperPackaged), { recursive: true }),
     mkdir(desktop, { recursive: true }),
   ]);
   await Promise.all([
+    writeFile(helperSource, machoExecutable(stagedHelperUuid)),
+    writeFile(helperPackaged, machoExecutable(stagedHelperUuid)),
     writeFile(join(desktop, "electron-builder.yml"), builderYaml()),
     writeFile(join(desktop, "package.json"), sourceManifestBytes),
     writeFile(join(resources, "icon.icns"), "synthetic icon"),
@@ -263,6 +301,8 @@ async function syntheticPackage(): Promise<SyntheticPackage> {
     desktop,
     externalPackaged,
     externalSource,
+    helperPackaged,
+    helperSource,
     resources,
     rebuild,
     writeArchive,
@@ -954,6 +994,44 @@ describe("desktop package layout", () => {
     await expect(
       verifyPackageLayout(unpacked.app, { desktopRoot: unpacked.desktop }),
     ).rejects.toThrow("symbolic links are forbidden");
+  });
+
+  it("accepts a packaged keychain helper re-signed after staging", async () => {
+    const fixture = await syntheticPackage();
+    await writeFile(fixture.helperPackaged, machoExecutable(stagedHelperUuid, 4_096));
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ["built from a different image", machoExecutable("ffeeddccbbaa99887766554433221100")],
+    ["patched outside its code signature", machoExecutable(stagedHelperUuid, 4_096, "patched")],
+  ])("rejects a packaged keychain helper %s", async (_label, replacement) => {
+    const fixture = await syntheticPackage();
+    await writeFile(fixture.helperPackaged, replacement);
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("packaged external executable differs from staging");
+  });
+
+  it("rejects a packaged keychain helper that is not a Mach-O executable", async () => {
+    const fixture = await syntheticPackage();
+    await writeFile(fixture.helperPackaged, Buffer.alloc(8_192, 0x61));
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("expected a 64-bit little-endian Mach-O executable");
+  });
+
+  it("rejects a package that stages no keychain helper at all", async () => {
+    const fixture = await syntheticPackage();
+    await Promise.all([
+      rm(dirname(fixture.helperSource), { recursive: true }),
+      rm(dirname(fixture.helperPackaged), { recursive: true }),
+    ]);
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("external keychain helper is missing");
   });
 
   it("keeps the external runner out of app.asar", async () => {


### PR DESCRIPTION
Child PR 2 of epic #672. The helper built in PR 1 now ships inside the macOS bundle at `Contents/Resources/keychain/keychain-helper`. Still dark: nothing spawns it in production; the path resolver is unused by any production path.

## What

- `scripts/build-keychain-helper.mjs` — compiles `native/keychain-helper/main.swift` with `swiftc` on darwin; fails loudly if `swiftc` is absent on darwin; no-op on every other platform. Invoked from `build-self-test-resources.ts`, which owns `dist/extra-resources`.
- `scripts/stage-extra-resources.mjs` — stages the compiled helper (mode `0755`, symlink-rejected, validated as Mach-O). The existing text content scan still runs over text resources only — no regex touches binary bytes.
- `scripts/package-inventory.mjs` — new `machoExecutableIdentity()` and a `signedExecutables` option on `compareStagedTree`.
- `scripts/verify-package-layout.mjs` — the helper is a REQUIRED row (`external keychain helper is missing`), compared by image identity.
- `scripts/verify-macos-release.mjs` — new `verifyMacosKeychainHelper()`: `codesign --verify --strict`, Team ID `FA494ACVTF`, canonical authorities, hardened-runtime flag, designated requirement pinning `subject.OU = FA494ACVTF`.
- `scripts/macos-release-plan.mjs` — new `keychain-helper` stage between `package-layout` and `identity-continuity`, candidate app only (the signed baseline predates the helper).
- `scripts/verify-packaged-self-test.mjs` — re-signs the helper in the corruption copy before the Frameworks loop.
- `src/main/keychain-helper-path.ts` — packaged/dev path resolver, cross-asserted against the packaging constants so the two sides cannot drift silently.
- 20+ new tests across the packaging suites plus synthetic Mach-O fixtures.

## Why image identity instead of byte equality

`@electron/osx-sign` walks and signs every binary under `Contents`, including `Resources` (verified in `@electron/osx-sign@1.3.3` `util.js:150-181`). After release signing the helper's bytes legitimately differ from staging. Measured on the real binary: signing mutates exactly the `__LINKEDIT` vmsize/filesize, `LC_CODE_SIGNATURE.datasize`, and the signature blob; `LC_UUID` and all code bytes are untouched. The identity check hashes everything outside the signature with those four mutable fields zeroed — tamper-tested: one flipped byte in the code region fails `verify:package-layout`.

## New limits

- `KEYCHAIN_HELPER_COMPILE_TIMEOUT_MS = 300000` — bounds the `swiftc` compile so a hung compiler fails packaging instead of stalling it.
- `MACH_O_MAXIMUM_LOAD_COMMANDS = 1024` — parser bound while computing image identity; malformed headers fail closed.
- `MINIMUM_MACH_O_EXECUTABLE_BYTES = 4096` / `MAXIMUM_MACH_O_EXECUTABLE_BYTES = 8388608` — size window for the staged helper; anything outside is rejected as not-our-binary.
- Requirement-string cap `16384` in `verifyMacosKeychainHelper` — mirrors the pre-existing cap for the app's own requirement parsing.

## Verification

- `package:dir` → `verify:package-layout` green; after an in-place ad-hoc re-sign of the packaged helper (release-lane simulation) still green; after flipping one code byte → fails with `packaged external executable differs from staging`.
- `test:packaged-self-test` green (602 parity + 84 differential cases; corruption exit 7 as required).
- Root `pnpm check` green. Full desktop suite: 2067/2068; the single failure (`windows-parity-scenarios.test.ts`) is pre-existing — proved by stashing the whole change and reproducing it on clean epic.
- Windows packaging untouched: `windows-package-layout` and `package-inventory-win32` suites green; the compile step no-ops off darwin.
- Adversarial verify: 3 read-only lenses, all pass; 3 mechanical findings (two undeclared limits — now declared above — and a path-constant drift risk, closed by cross-assertion tests in the final commit).

Known residuals, deferred to later children: the real Developer ID lane (`package:mac`) was simulated with an ad-hoc identity, not run — the notarized-artifact assertion is PR 4 (`verify-macos-backend-selection.mjs`); helper is arm64-only, matching the current release target; standalone `pnpm stage:extra-resources` on darwin needs a pre-built helper first.

No changeset: nothing user-visible ships; the helper is inert cargo until the backend flip.