### PR TITLE
feat(desktop): migrate credential envelopes onto the keychain key

### DIFF
--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -1,0 +1,112 @@
+import type { rename, rm } from "node:fs/promises";
+import type { CredentialEncryptionPort } from "./credential-vault.js";
+import {
+  scanCredentialEnvelopes,
+  type CredentialEnvelopeRoots,
+} from "./credential-envelope-inventory.js";
+import {
+  createKeychainPartitionEncryption,
+  createRefusingKeychainEncryption,
+} from "./keychain-credential-encryption.js";
+import type { KeychainHelperErrorCode, KeychainHelperTransport } from "./keychain-helper.js";
+import {
+  createLegacyReadFallbackEncryption,
+  migrateCredentialEnvelopes,
+  type CredentialMigrationOutcome,
+} from "./credential-key-migration.js";
+
+export type DesktopCredentialBackendRefusal = "encryption-unavailable" | "storage-failed";
+
+export type DesktopCredentialBackendSelection =
+  | Readonly<{
+      status: "keychain";
+      encryption: CredentialEncryptionPort;
+      migration: CredentialMigrationOutcome;
+      createdKey: boolean;
+    }>
+  | Readonly<{ status: "safe-storage"; encryption: CredentialEncryptionPort }>
+  | Readonly<{
+      status: "refused";
+      encryption: CredentialEncryptionPort;
+      reason: DesktopCredentialBackendRefusal;
+      code: KeychainHelperErrorCode;
+    }>;
+
+export interface SelectDesktopCredentialBackendOptions extends CredentialEnvelopeRoots {
+  readonly transport: KeychainHelperTransport;
+  readonly service: string;
+  readonly safeStorage: CredentialEncryptionPort;
+  readonly platform?: NodeJS.Platform;
+  readonly createId?: () => string;
+  readonly renameFile?: typeof rename;
+  readonly removeFile?: typeof rm;
+  readonly syncDirectory?: (root: string) => Promise<void>;
+}
+
+export function keychainFailureRefusal(
+  code: KeychainHelperErrorCode,
+): DesktopCredentialBackendRefusal {
+  return code === "keychain-locked" || code === "not-team-signed"
+    ? "encryption-unavailable"
+    : "storage-failed";
+}
+
+export async function selectDesktopCredentialBackend(
+  options: SelectDesktopCredentialBackendOptions,
+): Promise<DesktopCredentialBackendSelection> {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "darwin") {
+    return { status: "safe-storage", encryption: options.safeStorage };
+  }
+  const inventory = await scanCredentialEnvelopes(options);
+  const keychain = await createKeychainPartitionEncryption({
+    transport: options.transport,
+    service: options.service,
+  });
+  if (keychain.status === "unsupported") {
+    if (!inventory.keychainRequired) {
+      return { status: "safe-storage", encryption: options.safeStorage };
+    }
+    return {
+      status: "refused",
+      encryption: createRefusingKeychainEncryption(keychain.code, false),
+      reason: keychainFailureRefusal(keychain.code),
+      code: keychain.code,
+    };
+  }
+  if (keychain.status !== "ready") {
+    return {
+      status: "refused",
+      encryption: keychain.encryption,
+      reason: keychainFailureRefusal(keychain.code),
+      code: keychain.code,
+    };
+  }
+  const migration =
+    inventory.legacy.length === 0 && inventory.unreadable === 0
+      ? ({
+          status: "complete",
+          migrated: 0,
+          alreadyMigrated: inventory.migrated,
+          failed: 0,
+          uncertain: 0,
+        } as const)
+      : await migrateCredentialEnvelopes({
+          ...options,
+          platform,
+          legacy: options.safeStorage,
+          keychain: keychain.encryption,
+        });
+  return {
+    status: "keychain",
+    encryption:
+      migration.status === "complete"
+        ? keychain.encryption
+        : createLegacyReadFallbackEncryption({
+            keychain: keychain.encryption,
+            legacy: options.safeStorage,
+          }),
+    migration,
+    createdKey: keychain.createdKey,
+  };
+}

--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -45,10 +45,15 @@ export interface SelectDesktopCredentialBackendOptions extends CredentialEnvelop
 
 export function keychainFailureRefusal(
   code: KeychainHelperErrorCode,
+  keychainRequired: boolean,
 ): DesktopCredentialBackendRefusal {
-  return code === "keychain-locked" || code === "not-team-signed"
-    ? "encryption-unavailable"
-    : "storage-failed";
+  if (code === "keychain-locked" || code === "not-team-signed") {
+    return "encryption-unavailable";
+  }
+  if (keychainRequired && code === "unknown") {
+    return "encryption-unavailable";
+  }
+  return "storage-failed";
 }
 
 export async function selectDesktopCredentialBackend(
@@ -70,15 +75,19 @@ export async function selectDesktopCredentialBackend(
     return {
       status: "refused",
       encryption: createRefusingKeychainEncryption(keychain.code, false),
-      reason: keychainFailureRefusal(keychain.code),
+      reason: keychainFailureRefusal(keychain.code, inventory.keychainRequired),
       code: keychain.code,
     };
   }
   if (keychain.status !== "ready") {
+    const reason = keychainFailureRefusal(keychain.code, inventory.keychainRequired);
     return {
       status: "refused",
-      encryption: keychain.encryption,
-      reason: keychainFailureRefusal(keychain.code),
+      encryption: createRefusingKeychainEncryption(
+        keychain.code,
+        reason !== "encryption-unavailable",
+      ),
+      reason,
       code: keychain.code,
     };
   }

--- a/apps/desktop/src/main/credential-envelope-inventory.ts
+++ b/apps/desktop/src/main/credential-envelope-inventory.ts
@@ -1,0 +1,93 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { CREDENTIAL_FILE_MODE, DESKTOP_CREDENTIAL_SLOTS } from "./credential-vault.js";
+import {
+  SAFE_STORAGE_ENVELOPE_KEY_ID,
+  readCredentialEnvelopeKeyId,
+} from "./keychain-credential-encryption.js";
+import {
+  TELEGRAM_CREDENTIAL_FILE_MODE,
+  TELEGRAM_PROFILE_FILE_NAME,
+} from "./telegram-credential-vault.js";
+
+export type CredentialEnvelopeVault = "credentials" | "telegram";
+
+export interface CredentialEnvelopeTarget {
+  readonly vault: CredentialEnvelopeVault;
+  readonly root: string;
+  readonly fileName: string;
+  readonly mode: number;
+}
+
+export interface CredentialEnvelopeRef extends CredentialEnvelopeTarget {
+  readonly keyId: number | undefined;
+}
+
+export interface CredentialEnvelopeInventory {
+  readonly envelopes: readonly CredentialEnvelopeRef[];
+  readonly legacy: readonly CredentialEnvelopeRef[];
+  readonly migrated: number;
+  readonly unreadable: number;
+  readonly keychainRequired: boolean;
+}
+
+export interface CredentialEnvelopeRoots {
+  readonly credentialRoot: string;
+  readonly telegramRoot: string;
+  readonly readEnvelopeFile?: typeof readFile;
+}
+
+export function credentialEnvelopeTargets(
+  roots: CredentialEnvelopeRoots,
+): readonly CredentialEnvelopeTarget[] {
+  return [
+    ...DESKTOP_CREDENTIAL_SLOTS.map((slot) => ({
+      vault: "credentials" as const,
+      root: roots.credentialRoot,
+      fileName: `${slot}.bin`,
+      mode: CREDENTIAL_FILE_MODE,
+    })),
+    {
+      vault: "telegram" as const,
+      root: roots.telegramRoot,
+      fileName: TELEGRAM_PROFILE_FILE_NAME,
+      mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+    },
+  ];
+}
+
+export function credentialEnvelopeKeyId(envelope: Buffer): number {
+  return readCredentialEnvelopeKeyId(envelope) ?? SAFE_STORAGE_ENVELOPE_KEY_ID;
+}
+
+export async function scanCredentialEnvelopes(
+  roots: CredentialEnvelopeRoots,
+): Promise<CredentialEnvelopeInventory> {
+  const read = roots.readEnvelopeFile ?? readFile;
+  const envelopes: CredentialEnvelopeRef[] = [];
+  for (const target of credentialEnvelopeTargets(roots)) {
+    let contents: Buffer | undefined;
+    try {
+      contents = await read(join(target.root, target.fileName));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      envelopes.push({ ...target, keyId: undefined });
+      continue;
+    }
+    try {
+      envelopes.push({ ...target, keyId: credentialEnvelopeKeyId(contents) });
+    } finally {
+      contents.fill(0);
+    }
+  }
+  const legacy = envelopes.filter((envelope) => envelope.keyId === SAFE_STORAGE_ENVELOPE_KEY_ID);
+  const unreadable = envelopes.filter((envelope) => envelope.keyId === undefined).length;
+  const migrated = envelopes.length - legacy.length - unreadable;
+  return {
+    envelopes,
+    legacy,
+    migrated,
+    unreadable,
+    keychainRequired: migrated > 0 || unreadable > 0,
+  };
+}

--- a/apps/desktop/src/main/credential-key-migration.ts
+++ b/apps/desktop/src/main/credential-key-migration.ts
@@ -1,0 +1,155 @@
+import type { rename, rm } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { CredentialEncryptionPort } from "./credential-vault.js";
+import {
+  credentialEnvelopeKeyId,
+  scanCredentialEnvelopes,
+  type CredentialEnvelopeRef,
+  type CredentialEnvelopeRoots,
+} from "./credential-envelope-inventory.js";
+import { durablyReplaceReversible } from "./durable-atomic-replace.js";
+import {
+  KEYCHAIN_ENVELOPE_KEY_ID,
+  KEYCHAIN_PARTITION_STORAGE_BACKEND,
+  SAFE_STORAGE_ENVELOPE_KEY_ID,
+  readCredentialEnvelopeKeyId,
+} from "./keychain-credential-encryption.js";
+
+export type CredentialEnvelopeMigrationState =
+  | "migrated"
+  | "already-migrated"
+  | "absent"
+  | "failed"
+  | "uncertain";
+
+export interface CredentialMigrationOutcome {
+  readonly status: "complete" | "incomplete";
+  readonly migrated: number;
+  readonly alreadyMigrated: number;
+  readonly failed: number;
+  readonly uncertain: number;
+}
+
+export interface MigrateCredentialEnvelopesOptions extends CredentialEnvelopeRoots {
+  readonly legacy: CredentialEncryptionPort;
+  readonly keychain: CredentialEncryptionPort;
+  readonly platform?: NodeJS.Platform;
+  readonly createId?: () => string;
+  readonly renameFile?: typeof rename;
+  readonly removeFile?: typeof rm;
+  readonly syncDirectory?: (root: string) => Promise<void>;
+}
+
+export function createLegacyReadFallbackEncryption(options: {
+  readonly keychain: CredentialEncryptionPort;
+  readonly legacy: CredentialEncryptionPort;
+}): CredentialEncryptionPort {
+  return {
+    isEncryptionAvailable: () => options.keychain.isEncryptionAvailable(),
+    encryptString: (value: string) => options.keychain.encryptString(value),
+    decryptString: (envelope: Buffer) =>
+      readCredentialEnvelopeKeyId(envelope) === KEYCHAIN_ENVELOPE_KEY_ID
+        ? options.keychain.decryptString(envelope)
+        : options.legacy.decryptString(envelope),
+    getSelectedStorageBackend: () => KEYCHAIN_PARTITION_STORAGE_BACKEND,
+  };
+}
+
+async function migrateEnvelope(
+  envelope: CredentialEnvelopeRef,
+  options: MigrateCredentialEnvelopesOptions,
+): Promise<CredentialEnvelopeMigrationState> {
+  const read = options.readEnvelopeFile ?? readFile;
+  const path = join(envelope.root, envelope.fileName);
+  let previous: Buffer | undefined;
+  let sealed: Buffer | undefined;
+  try {
+    try {
+      previous = await read(path);
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code === "ENOENT" ? "absent" : "failed";
+    }
+    const keyId = credentialEnvelopeKeyId(previous);
+    if (keyId === KEYCHAIN_ENVELOPE_KEY_ID) return "already-migrated";
+    if (keyId !== SAFE_STORAGE_ENVELOPE_KEY_ID) return "failed";
+    let value: string;
+    try {
+      value = options.legacy.decryptString(previous);
+    } catch {
+      return "failed";
+    }
+    if (value.length === 0) return "failed";
+    try {
+      sealed = options.keychain.encryptString(value);
+      if (!Buffer.isBuffer(sealed) || sealed.length === 0) return "failed";
+      if (readCredentialEnvelopeKeyId(sealed) !== KEYCHAIN_ENVELOPE_KEY_ID) return "failed";
+      if (options.keychain.decryptString(sealed) !== value) return "failed";
+    } catch {
+      return "failed";
+    }
+    const replacement = {
+      root: envelope.root,
+      fileName: envelope.fileName,
+      mode: envelope.mode,
+      platform: options.platform,
+      createId: options.createId,
+      renameFile: options.renameFile,
+      removeFile: options.removeFile,
+      syncDirectory: options.syncDirectory,
+    };
+    const stored = await durablyReplaceReversible({
+      ...replacement,
+      contents: sealed,
+      previousContents: previous,
+    });
+    if (stored.state === "refused") return "failed";
+    if (stored.state === "uncertain") return "uncertain";
+    let written: Buffer | undefined;
+    try {
+      written = await read(path);
+      if (options.keychain.decryptString(written) !== value) throw new TypeError();
+      return "migrated";
+    } catch {
+      const restored = await durablyReplaceReversible({
+        ...replacement,
+        contents: previous,
+        previousContents: sealed,
+      });
+      return restored.state === "applied" ? "failed" : "uncertain";
+    } finally {
+      written?.fill(0);
+    }
+  } finally {
+    previous?.fill(0);
+    sealed?.fill(0);
+  }
+}
+
+export async function migrateCredentialEnvelopes(
+  options: MigrateCredentialEnvelopesOptions,
+): Promise<CredentialMigrationOutcome> {
+  const inventory = await scanCredentialEnvelopes(options);
+  let migrated = 0;
+  let alreadyMigrated = 0;
+  let failed = 0;
+  let uncertain = 0;
+  for (const envelope of inventory.envelopes) {
+    if (envelope.keyId === KEYCHAIN_ENVELOPE_KEY_ID) {
+      alreadyMigrated += 1;
+      continue;
+    }
+    const state = await migrateEnvelope(envelope, options);
+    if (state === "migrated") migrated += 1;
+    else if (state === "already-migrated") alreadyMigrated += 1;
+    else if (state === "failed") failed += 1;
+    else if (state === "uncertain") uncertain += 1;
+  }
+  return {
+    status: failed === 0 && uncertain === 0 ? "complete" : "incomplete",
+    migrated,
+    alreadyMigrated,
+    failed,
+    uncertain,
+  };
+}

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -82,7 +82,10 @@ export interface CreateKeychainPartitionEncryptionOptions {
   readonly service: string;
 }
 
-function refusingPort(code: KeychainHelperErrorCode, available: boolean): CredentialEncryptionPort {
+export function createRefusingKeychainEncryption(
+  code: KeychainHelperErrorCode,
+  available: boolean,
+): CredentialEncryptionPort {
   const refuse = (): never => {
     throw new KeychainEncryptionError(code);
   };
@@ -105,9 +108,17 @@ function readyPort(key: Buffer): CredentialEncryptionPort {
 
 function refused(code: KeychainHelperErrorCode): KeychainPartitionEncryptionResult {
   if (code === "keychain-locked") {
-    return { status: "unavailable", code, encryption: refusingPort(code, false) };
+    return {
+      status: "unavailable",
+      code,
+      encryption: createRefusingKeychainEncryption(code, false),
+    };
   }
-  return { status: "storage-failed", code, encryption: refusingPort(code, true) };
+  return {
+    status: "storage-failed",
+    code,
+    encryption: createRefusingKeychainEncryption(code, true),
+  };
 }
 
 export async function createKeychainPartitionEncryption(

--- a/apps/desktop/src/main/keychain-key-lifetime.ts
+++ b/apps/desktop/src/main/keychain-key-lifetime.ts
@@ -1,0 +1,29 @@
+import {
+  scanCredentialEnvelopes,
+  type CredentialEnvelopeRoots,
+} from "./credential-envelope-inventory.js";
+import type { KeychainHelperErrorCode, KeychainHelperTransport } from "./keychain-helper.js";
+
+export type KeychainKeyRetirement =
+  | Readonly<{ status: "retained"; envelopes: number }>
+  | Readonly<{ status: "deleted" }>
+  | Readonly<{ status: "already-absent" }>
+  | Readonly<{ status: "failed"; code: KeychainHelperErrorCode }>;
+
+export interface RetireKeychainKeyOptions extends CredentialEnvelopeRoots {
+  readonly transport: KeychainHelperTransport;
+  readonly service: string;
+}
+
+export async function retireKeychainKeyWhenLastEnvelopeGone(
+  options: RetireKeychainKeyOptions,
+): Promise<KeychainKeyRetirement> {
+  const inventory = await scanCredentialEnvelopes(options);
+  if (inventory.envelopes.length > 0) {
+    return { status: "retained", envelopes: inventory.envelopes.length };
+  }
+  const deleted = await options.transport.send({ op: "delete-key", service: options.service });
+  if (!deleted.ok) return { status: "failed", code: deleted.code };
+  if (deleted.op !== "delete-key") return { status: "failed", code: "unknown" };
+  return deleted.deleted ? { status: "deleted" } : { status: "already-absent" };
+}

--- a/apps/desktop/tests/credential-backend-selection.test.ts
+++ b/apps/desktop/tests/credential-backend-selection.test.ts
@@ -1,0 +1,509 @@
+import { randomBytes } from "node:crypto";
+import { mkdir, mkdtemp, readFile, realpath, rename, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  keychainFailureRefusal,
+  selectDesktopCredentialBackend,
+  type SelectDesktopCredentialBackendOptions,
+} from "../src/main/credential-backend-selection.js";
+import {
+  createCredentialVault,
+  type CredentialEncryptionPort,
+  type DesktopCredentialSlot,
+} from "../src/main/credential-vault.js";
+import { credentialEnvelopeKeyId } from "../src/main/credential-envelope-inventory.js";
+import {
+  KEYCHAIN_ENVELOPE_KEY_ID,
+  KEYCHAIN_PARTITION_STORAGE_BACKEND,
+  SAFE_STORAGE_ENVELOPE_KEY_ID,
+  createKeychainPartitionEncryption,
+} from "../src/main/keychain-credential-encryption.js";
+import {
+  KEYCHAIN_CREDENTIAL_SERVICE,
+  KEYCHAIN_KEY_BYTES,
+  KEYCHAIN_TEAM_IDENTIFIER,
+  type KeychainHelperRequest,
+  type KeychainHelperResponse,
+  type KeychainHelperTransport,
+} from "../src/main/keychain-helper.js";
+import {
+  TELEGRAM_PROFILE_FILE_NAME,
+  createTelegramCredentialVault,
+} from "../src/main/telegram-credential-vault.js";
+
+const fixtureRoots: string[] = [];
+const posixIt = it.skipIf(process.platform === "win32");
+const BOT = { id: 123456, username: "synthetic_bot" } as const;
+const PROBE_OK: KeychainHelperResponse = {
+  ok: true,
+  op: "probe",
+  teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER,
+};
+
+interface Fixture {
+  readonly credentialRoot: string;
+  readonly telegramRoot: string;
+  readonly athleteHome: string;
+}
+
+async function fixture(): Promise<Fixture> {
+  const base = await mkdtemp(join(await realpath(tmpdir()), "desktop-backend-selection-"));
+  fixtureRoots.push(base);
+  const home = join(base, "athlete-home");
+  await mkdir(home, { mode: 0o700 });
+  return {
+    credentialRoot: join(base, "credentials-v1"),
+    telegramRoot: join(base, "telegram-channel-v1"),
+    athleteHome: await realpath(home),
+  };
+}
+
+function safeStorage(): CredentialEncryptionPort {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) =>
+      Buffer.concat([Buffer.from("SAFE:"), Buffer.from(value, "utf8").reverse()]),
+    decryptString(value) {
+      if (!value.subarray(0, 5).equals(Buffer.from("SAFE:"))) throw new TypeError();
+      return Buffer.from(value.subarray(5)).reverse().toString("utf8");
+    },
+  };
+}
+
+interface RecordingTransport extends KeychainHelperTransport {
+  readonly requests: KeychainHelperRequest[];
+}
+
+function transportOf(...responses: readonly KeychainHelperResponse[]): RecordingTransport {
+  const remaining = [...responses];
+  const requests: KeychainHelperRequest[] = [];
+  return {
+    requests,
+    send(request) {
+      requests.push(request);
+      const next = remaining.shift();
+      if (next === undefined) throw new Error("unexpected helper request");
+      return Promise.resolve(next);
+    },
+  };
+}
+
+function readKey(key: Buffer): KeychainHelperResponse {
+  return { ok: true, op: "read-key", key: key.toString("base64") };
+}
+
+async function keychainEncryption(key: Buffer): Promise<CredentialEncryptionPort> {
+  const result = await createKeychainPartitionEncryption({
+    transport: transportOf(PROBE_OK, readKey(key)),
+    service: KEYCHAIN_CREDENTIAL_SERVICE,
+  });
+  if (result.status !== "ready") throw new TypeError();
+  return result.encryption;
+}
+
+function selection(
+  roots: Fixture,
+  transport: KeychainHelperTransport,
+): SelectDesktopCredentialBackendOptions {
+  return {
+    credentialRoot: roots.credentialRoot,
+    telegramRoot: roots.telegramRoot,
+    transport,
+    service: KEYCHAIN_CREDENTIAL_SERVICE,
+    safeStorage: safeStorage(),
+    platform: "darwin",
+  };
+}
+
+async function seedCredential(
+  root: string,
+  slot: DesktopCredentialSlot,
+  value: string,
+  encryption: CredentialEncryptionPort,
+): Promise<void> {
+  const vault = createCredentialVault({
+    root,
+    encryption,
+    applyCredential: vi.fn(async () => undefined),
+  });
+  await expect(vault.writeCredential({ slot, value }, { activate: false })).resolves.toMatchObject({
+    status: "configured",
+  });
+}
+
+async function seedProfile(
+  roots: Fixture,
+  token: string,
+  encryption: CredentialEncryptionPort,
+): Promise<void> {
+  const vault = createTelegramCredentialVault({
+    root: roots.telegramRoot,
+    athleteHome: roots.athleteHome,
+    encryption,
+  });
+  await expect(
+    vault.replaceProfile({ token, bot: BOT, authenticatedAthleteHome: roots.athleteHome }),
+  ).resolves.toMatchObject({ outcome: "applied" });
+}
+
+function credentialVault(roots: Fixture, encryption: CredentialEncryptionPort) {
+  return createCredentialVault({
+    root: roots.credentialRoot,
+    encryption,
+    applyCredential: vi.fn(async () => undefined),
+  });
+}
+
+function telegramVault(roots: Fixture, encryption: CredentialEncryptionPort) {
+  return createTelegramCredentialVault({
+    root: roots.telegramRoot,
+    athleteHome: roots.athleteHome,
+    encryption,
+  });
+}
+
+afterEach(async () => {
+  for (const root of fixtureRoots.splice(0)) {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+describe("backend selection", () => {
+  posixIt("selects the keychain backend on a team-signed darwin build", async () => {
+    const roots = await fixture();
+    const transport = transportOf(PROBE_OK, readKey(randomBytes(KEYCHAIN_KEY_BYTES)));
+
+    const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+    expect(selected.status).toBe("keychain");
+    if (selected.status !== "keychain") return;
+    expect(selected.encryption.getSelectedStorageBackend?.()).toBe(
+      KEYCHAIN_PARTITION_STORAGE_BACKEND,
+    );
+    expect(selected.migration).toEqual({
+      status: "complete",
+      migrated: 0,
+      alreadyMigrated: 0,
+      failed: 0,
+      uncertain: 0,
+    });
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
+  });
+
+  posixIt("keeps safeStorage on a build that carries no team identity", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
+    const transport = transportOf({ ok: false, code: "not-team-signed" });
+    const options = { ...selection(roots, transport), safeStorage: legacy };
+
+    const selected = await selectDesktopCredentialBackend(options);
+
+    expect(selected.status).toBe("safe-storage");
+    expect(selected.encryption).toBe(legacy);
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe"]);
+  });
+
+  posixIt("keeps safeStorage off darwin without probing the helper", async () => {
+    const roots = await fixture();
+    const transport = transportOf();
+
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transport),
+      platform: "win32",
+    });
+
+    expect(selected.status).toBe("safe-storage");
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  posixIt("migrates eagerly at the first startup on the keychain backend", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
+    await seedProfile(roots, "synthetic-token", legacy);
+    const options = {
+      ...selection(roots, transportOf(PROBE_OK, readKey(randomBytes(KEYCHAIN_KEY_BYTES)))),
+      safeStorage: legacy,
+    };
+
+    const selected = await selectDesktopCredentialBackend(options);
+
+    expect(selected.status).toBe("keychain");
+    if (selected.status !== "keychain") return;
+    expect(selected.migration).toMatchObject({ status: "complete", migrated: 2 });
+    for (const path of [
+      join(roots.credentialRoot, "anthropic.bin"),
+      join(roots.telegramRoot, TELEGRAM_PROFILE_FILE_NAME),
+    ]) {
+      expect(credentialEnvelopeKeyId(await readFile(path))).toBe(KEYCHAIN_ENVELOPE_KEY_ID);
+    }
+    await expect(credentialVault(roots, selected.encryption).credentialStatuses()).resolves.toEqual(
+      expect.arrayContaining([
+        { slot: "anthropic", state: "configured", runtimeState: "stored-inactive" },
+      ]),
+    );
+    await expect(telegramVault(roots, selected.encryption).profileStatus()).resolves.toMatchObject({
+      state: "configured",
+    });
+  });
+});
+
+describe("unreadable envelopes", () => {
+  posixIt("reports the pass incomplete when an envelope cannot be read", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
+
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transportOf(PROBE_OK, readKey(randomBytes(KEYCHAIN_KEY_BYTES)))),
+      safeStorage: legacy,
+      readEnvelopeFile: (async (path: string) => {
+        if (path.endsWith("anthropic.bin")) {
+          throw Object.assign(new Error("synthetic read failure"), { code: "EACCES" });
+        }
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }) as never,
+    });
+
+    expect(selected.status).toBe("keychain");
+    if (selected.status !== "keychain") return;
+    expect(selected.migration).toEqual({
+      status: "incomplete",
+      migrated: 0,
+      alreadyMigrated: 0,
+      failed: 1,
+      uncertain: 0,
+    });
+    expect(
+      credentialEnvelopeKeyId(await readFile(join(roots.credentialRoot, "anthropic.bin"))),
+    ).toBe(SAFE_STORAGE_ENVELOPE_KEY_ID);
+    expect(selected.encryption.decryptString(legacy.encryptString("sk-old"))).toBe("sk-old");
+  });
+});
+
+describe("mandatory keychain rule", () => {
+  posixIt("refuses to fall back to safeStorage once an envelope is migrated", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    const key = randomBytes(KEYCHAIN_KEY_BYTES);
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
+    await seedProfile(roots, "synthetic-token", legacy);
+    await selectDesktopCredentialBackend({
+      ...selection(roots, transportOf(PROBE_OK, readKey(key))),
+      safeStorage: legacy,
+    });
+    const migrated = await readFile(join(roots.credentialRoot, "anthropic.bin"));
+
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transportOf({ ok: false, code: "not-team-signed" })),
+      safeStorage: legacy,
+    });
+
+    expect(selected.status).toBe("refused");
+    if (selected.status !== "refused") return;
+    expect(selected.reason).toBe("encryption-unavailable");
+    expect(selected.code).toBe("not-team-signed");
+    expect(selected.encryption.isEncryptionAvailable()).toBe(false);
+    expect(selected.encryption.getSelectedStorageBackend?.()).toBe(
+      KEYCHAIN_PARTITION_STORAGE_BACKEND,
+    );
+    await expect(readFile(join(roots.credentialRoot, "anthropic.bin"))).resolves.toEqual(migrated);
+  });
+
+  posixIt("refuses when an existing envelope cannot be read", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
+
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transportOf({ ok: false, code: "not-team-signed" })),
+      safeStorage: legacy,
+      readEnvelopeFile: (async () => {
+        throw Object.assign(new Error("synthetic read failure"), { code: "EACCES" });
+      }) as never,
+    });
+
+    expect(selected.status).toBe("refused");
+  });
+
+  posixIt("leaves every credential untouched when the probe fails after migration", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    const key = randomBytes(KEYCHAIN_KEY_BYTES);
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
+    await seedProfile(roots, "synthetic-token", legacy);
+    await selectDesktopCredentialBackend({
+      ...selection(roots, transportOf(PROBE_OK, readKey(key))),
+      safeStorage: legacy,
+    });
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transportOf({ ok: false, code: "not-team-signed" })),
+      safeStorage: legacy,
+    });
+    if (selected.status !== "refused") throw new TypeError();
+
+    await expect(
+      credentialVault(roots, selected.encryption).writeCredential({
+        slot: "anthropic",
+        value: "sk-replacement",
+      }),
+    ).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "encryption-unavailable",
+    });
+    await expect(telegramVault(roots, selected.encryption).profileStatus()).resolves.toEqual({
+      state: "re-prompt",
+      reason: "encryption-unavailable",
+    });
+    expect(
+      credentialEnvelopeKeyId(await readFile(join(roots.credentialRoot, "anthropic.bin"))),
+    ).toBe(KEYCHAIN_ENVELOPE_KEY_ID);
+  });
+});
+
+describe("keychain failure mapping", () => {
+  it("maps every helper error code onto the existing taxonomy", () => {
+    expect(keychainFailureRefusal("keychain-locked")).toBe("encryption-unavailable");
+    expect(keychainFailureRefusal("not-team-signed")).toBe("encryption-unavailable");
+    expect(keychainFailureRefusal("duplicate-item")).toBe("storage-failed");
+    expect(keychainFailureRefusal("unreadable-item")).toBe("storage-failed");
+    expect(keychainFailureRefusal("item-not-found")).toBe("storage-failed");
+    expect(keychainFailureRefusal("unknown")).toBe("storage-failed");
+  });
+
+  posixIt("maps a locked keychain onto encryption-unavailable in both vaults", async () => {
+    const roots = await fixture();
+    const transport = transportOf(PROBE_OK, { ok: false, code: "keychain-locked" });
+
+    const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+    expect(selected).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "keychain-locked",
+    });
+    if (selected.status !== "refused") return;
+    await expect(
+      credentialVault(roots, selected.encryption).writeCredential({
+        slot: "anthropic",
+        value: "sk-anthropic",
+      }),
+    ).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "encryption-unavailable",
+    });
+    await expect(
+      telegramVault(roots, selected.encryption).replaceProfile({
+        token: "synthetic-token",
+        bot: BOT,
+        authenticatedAthleteHome: roots.athleteHome,
+      }),
+    ).resolves.toEqual({ outcome: "refused", reason: "encryption-unavailable" });
+  });
+
+  posixIt("maps a duplicate item on create onto storage-failed in both vaults", async () => {
+    const roots = await fixture();
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: false, code: "item-not-found" },
+      { ok: false, code: "duplicate-item" },
+    );
+
+    const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+    expect(selected).toMatchObject({
+      status: "refused",
+      reason: "storage-failed",
+      code: "duplicate-item",
+    });
+    if (selected.status !== "refused") return;
+    expect(selected.encryption.isEncryptionAvailable()).toBe(true);
+    await expect(
+      credentialVault(roots, selected.encryption).writeCredential({
+        slot: "anthropic",
+        value: "sk-anthropic",
+      }),
+    ).resolves.toEqual({ slot: "anthropic", status: "refused", reason: "storage-failed" });
+    await expect(
+      telegramVault(roots, selected.encryption).replaceProfile({
+        token: "synthetic-token",
+        bot: BOT,
+        authenticatedAthleteHome: roots.athleteHome,
+      }),
+    ).resolves.toEqual({ outcome: "refused", reason: "storage-failed" });
+  });
+
+  posixIt("recreates a poisoned item and re-prompts the envelopes under the old key", async () => {
+    const roots = await fixture();
+    const retired = await keychainEncryption(randomBytes(KEYCHAIN_KEY_BYTES));
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", retired);
+    await seedProfile(roots, "synthetic-token", retired);
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: false, code: "unreadable-item" },
+      { ok: true, op: "delete-key", deleted: true },
+      { ok: true, op: "create-key", key: randomBytes(KEYCHAIN_KEY_BYTES).toString("base64") },
+    );
+
+    const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+    expect(selected.status).toBe("keychain");
+    if (selected.status !== "keychain") return;
+    expect(selected.createdKey).toBe(true);
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "delete-key",
+      "create-key",
+    ]);
+    await expect(credentialVault(roots, selected.encryption).credentialStatuses()).resolves.toEqual(
+      expect.arrayContaining([{ slot: "anthropic", state: "re-prompt", runtimeState: null }]),
+    );
+    await expect(telegramVault(roots, selected.encryption).profileStatus()).resolves.toEqual({
+      state: "re-prompt",
+      reason: "storage-failed",
+    });
+  });
+
+  posixIt("keeps a partly migrated vault readable and writes only keychain envelopes", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
+    await seedCredential(roots.credentialRoot, "openrouter", "sk-openrouter", legacy);
+    let renames = 0;
+
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transportOf(PROBE_OK, readKey(randomBytes(KEYCHAIN_KEY_BYTES)))),
+      safeStorage: legacy,
+      renameFile: (async (from: string, to: string) => {
+        renames += 1;
+        if (renames > 1) throw new TypeError("synthetic rename failure");
+        await rename(from, to);
+      }) as never,
+    });
+
+    expect(selected.status).toBe("keychain");
+    if (selected.status !== "keychain") return;
+    expect(selected.migration).toMatchObject({ status: "incomplete", migrated: 1, failed: 1 });
+    expect(
+      credentialEnvelopeKeyId(await readFile(join(roots.credentialRoot, "anthropic.bin"))),
+    ).toBe(KEYCHAIN_ENVELOPE_KEY_ID);
+    expect(
+      credentialEnvelopeKeyId(await readFile(join(roots.credentialRoot, "openrouter.bin"))),
+    ).toBe(SAFE_STORAGE_ENVELOPE_KEY_ID);
+    await expect(credentialVault(roots, selected.encryption).credentialStatuses()).resolves.toEqual(
+      expect.arrayContaining([
+        { slot: "anthropic", state: "configured", runtimeState: "stored-inactive" },
+        { slot: "openrouter", state: "configured", runtimeState: "stored-inactive" },
+      ]),
+    );
+    expect(credentialEnvelopeKeyId(selected.encryption.encryptString("sk-new"))).toBe(
+      KEYCHAIN_ENVELOPE_KEY_ID,
+    );
+  });
+});

--- a/apps/desktop/tests/credential-backend-selection.test.ts
+++ b/apps/desktop/tests/credential-backend-selection.test.ts
@@ -313,6 +313,44 @@ describe("mandatory keychain rule", () => {
     await expect(readFile(join(roots.credentialRoot, "anthropic.bin"))).resolves.toEqual(migrated);
   });
 
+  posixIt("reports a broken helper as encryption-unavailable once an envelope is migrated", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    const key = randomBytes(KEYCHAIN_KEY_BYTES);
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
+    await selectDesktopCredentialBackend({
+      ...selection(roots, transportOf(PROBE_OK, readKey(key))),
+      safeStorage: legacy,
+    });
+
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transportOf({ ok: false, code: "unknown" })),
+      safeStorage: legacy,
+    });
+
+    expect(selected.status).toBe("refused");
+    if (selected.status !== "refused") return;
+    expect(selected.reason).toBe("encryption-unavailable");
+    expect(selected.code).toBe("unknown");
+    expect(selected.encryption.isEncryptionAvailable()).toBe(false);
+  });
+
+  posixIt("keeps a broken helper as storage-failed before any envelope is migrated", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
+
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transportOf({ ok: false, code: "unknown" })),
+      safeStorage: legacy,
+    });
+
+    expect(selected.status).toBe("refused");
+    if (selected.status !== "refused") return;
+    expect(selected.reason).toBe("storage-failed");
+    expect(selected.encryption.isEncryptionAvailable()).toBe(true);
+  });
+
   posixIt("refuses when an existing envelope cannot be read", async () => {
     const roots = await fixture();
     const legacy = safeStorage();
@@ -367,12 +405,18 @@ describe("mandatory keychain rule", () => {
 
 describe("keychain failure mapping", () => {
   it("maps every helper error code onto the existing taxonomy", () => {
-    expect(keychainFailureRefusal("keychain-locked")).toBe("encryption-unavailable");
-    expect(keychainFailureRefusal("not-team-signed")).toBe("encryption-unavailable");
-    expect(keychainFailureRefusal("duplicate-item")).toBe("storage-failed");
-    expect(keychainFailureRefusal("unreadable-item")).toBe("storage-failed");
-    expect(keychainFailureRefusal("item-not-found")).toBe("storage-failed");
-    expect(keychainFailureRefusal("unknown")).toBe("storage-failed");
+    expect(keychainFailureRefusal("keychain-locked", false)).toBe("encryption-unavailable");
+    expect(keychainFailureRefusal("not-team-signed", false)).toBe("encryption-unavailable");
+    expect(keychainFailureRefusal("duplicate-item", false)).toBe("storage-failed");
+    expect(keychainFailureRefusal("unreadable-item", false)).toBe("storage-failed");
+    expect(keychainFailureRefusal("item-not-found", false)).toBe("storage-failed");
+    expect(keychainFailureRefusal("unknown", false)).toBe("storage-failed");
+    expect(keychainFailureRefusal("keychain-locked", true)).toBe("encryption-unavailable");
+    expect(keychainFailureRefusal("not-team-signed", true)).toBe("encryption-unavailable");
+    expect(keychainFailureRefusal("unknown", true)).toBe("encryption-unavailable");
+    expect(keychainFailureRefusal("duplicate-item", true)).toBe("storage-failed");
+    expect(keychainFailureRefusal("unreadable-item", true)).toBe("storage-failed");
+    expect(keychainFailureRefusal("item-not-found", true)).toBe("storage-failed");
   });
 
   posixIt("maps a locked keychain onto encryption-unavailable in both vaults", async () => {

--- a/apps/desktop/tests/credential-key-migration.test.ts
+++ b/apps/desktop/tests/credential-key-migration.test.ts
@@ -1,0 +1,518 @@
+import { randomBytes } from "node:crypto";
+import { lstat, mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createCredentialVault,
+  type CredentialEncryptionPort,
+  type DesktopCredentialSlot,
+} from "../src/main/credential-vault.js";
+import {
+  credentialEnvelopeKeyId,
+  scanCredentialEnvelopes,
+} from "../src/main/credential-envelope-inventory.js";
+import {
+  createLegacyReadFallbackEncryption,
+  migrateCredentialEnvelopes,
+} from "../src/main/credential-key-migration.js";
+import {
+  KEYCHAIN_ENVELOPE_KEY_ID,
+  KEYCHAIN_PARTITION_STORAGE_BACKEND,
+  SAFE_STORAGE_ENVELOPE_KEY_ID,
+  createKeychainPartitionEncryption,
+} from "../src/main/keychain-credential-encryption.js";
+import {
+  KEYCHAIN_CREDENTIAL_SERVICE,
+  KEYCHAIN_KEY_BYTES,
+  KEYCHAIN_TEAM_IDENTIFIER,
+  type KeychainHelperResponse,
+  type KeychainHelperTransport,
+} from "../src/main/keychain-helper.js";
+import {
+  TELEGRAM_PROFILE_FILE_NAME,
+  createTelegramCredentialVault,
+} from "../src/main/telegram-credential-vault.js";
+
+const fixtureRoots: string[] = [];
+const posixIt = it.skipIf(process.platform === "win32");
+const BOT = { id: 123456, username: "synthetic_bot" } as const;
+
+interface Fixture {
+  readonly credentialRoot: string;
+  readonly telegramRoot: string;
+  readonly athleteHome: string;
+}
+
+async function fixture(): Promise<Fixture> {
+  const base = await mkdtemp(join(await realpath(tmpdir()), "desktop-credential-migration-"));
+  fixtureRoots.push(base);
+  const home = join(base, "athlete-home");
+  await mkdir(home, { mode: 0o700 });
+  return {
+    credentialRoot: join(base, "credentials-v1"),
+    telegramRoot: join(base, "telegram-channel-v1"),
+    athleteHome: await realpath(home),
+  };
+}
+
+interface SafeStorageSpy {
+  readonly port: CredentialEncryptionPort;
+  decryptCalls: number;
+}
+
+function safeStorage(): SafeStorageSpy {
+  const spy: SafeStorageSpy = {
+    decryptCalls: 0,
+    port: {
+      isEncryptionAvailable: () => true,
+      encryptString: (value) =>
+        Buffer.concat([Buffer.from("SAFE:"), Buffer.from(value, "utf8").reverse()]),
+      decryptString(value) {
+        spy.decryptCalls += 1;
+        if (!value.subarray(0, 5).equals(Buffer.from("SAFE:"))) throw new TypeError();
+        return Buffer.from(value.subarray(5)).reverse().toString("utf8");
+      },
+    },
+  };
+  return spy;
+}
+
+function transportOf(...responses: readonly KeychainHelperResponse[]): KeychainHelperTransport {
+  const remaining = [...responses];
+  return {
+    send() {
+      const next = remaining.shift();
+      if (next === undefined) throw new Error("unexpected helper request");
+      return Promise.resolve(next);
+    },
+  };
+}
+
+async function keychainEncryption(
+  key: Buffer = randomBytes(KEYCHAIN_KEY_BYTES),
+): Promise<CredentialEncryptionPort> {
+  const result = await createKeychainPartitionEncryption({
+    transport: transportOf(
+      { ok: true, op: "probe", teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER },
+      { ok: true, op: "read-key", key: key.toString("base64") },
+    ),
+    service: KEYCHAIN_CREDENTIAL_SERVICE,
+  });
+  if (result.status !== "ready") throw new TypeError();
+  return result.encryption;
+}
+
+function refuseValue(port: CredentialEncryptionPort, refused: string): CredentialEncryptionPort {
+  return {
+    ...port,
+    encryptString(value) {
+      if (value === refused) throw new TypeError("synthetic seal failure");
+      return port.encryptString(value);
+    },
+  };
+}
+
+async function seedCredential(
+  root: string,
+  slot: DesktopCredentialSlot,
+  value: string,
+  encryption: CredentialEncryptionPort,
+): Promise<void> {
+  const vault = createCredentialVault({
+    root,
+    encryption,
+    applyCredential: vi.fn(async () => undefined),
+  });
+  await expect(vault.writeCredential({ slot, value }, { activate: false })).resolves.toMatchObject({
+    slot,
+    status: "configured",
+  });
+}
+
+async function seedProfile(
+  fixtureRoot: Fixture,
+  token: string,
+  encryption: CredentialEncryptionPort,
+): Promise<void> {
+  const vault = createTelegramCredentialVault({
+    root: fixtureRoot.telegramRoot,
+    athleteHome: fixtureRoot.athleteHome,
+    encryption,
+  });
+  await expect(
+    vault.replaceProfile({
+      token,
+      bot: BOT,
+      authenticatedAthleteHome: fixtureRoot.athleteHome,
+    }),
+  ).resolves.toMatchObject({ outcome: "applied" });
+}
+
+async function keyIdOf(path: string): Promise<number> {
+  return credentialEnvelopeKeyId(await readFile(path));
+}
+
+afterEach(async () => {
+  for (const root of fixtureRoots.splice(0)) {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+describe("credential envelope inventory", () => {
+  posixIt("reports every seeded envelope with its key-id", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    const keychain = await keychainEncryption();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-legacy", legacy.port);
+    await seedCredential(roots.credentialRoot, "openrouter", "sk-migrated", keychain);
+    await seedProfile(roots, "synthetic-token", legacy.port);
+
+    const inventory = await scanCredentialEnvelopes(roots);
+
+    expect(inventory.envelopes.map((envelope) => envelope.fileName)).toEqual([
+      "anthropic.bin",
+      "openrouter.bin",
+      TELEGRAM_PROFILE_FILE_NAME,
+    ]);
+    expect(inventory.envelopes.map((envelope) => envelope.keyId)).toEqual([
+      SAFE_STORAGE_ENVELOPE_KEY_ID,
+      KEYCHAIN_ENVELOPE_KEY_ID,
+      SAFE_STORAGE_ENVELOPE_KEY_ID,
+    ]);
+    expect(inventory.legacy).toHaveLength(2);
+    expect(inventory.migrated).toBe(1);
+    expect(inventory.unreadable).toBe(0);
+  });
+
+  posixIt("does not require the keychain while every envelope is safeStorage-era", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-legacy", legacy.port);
+    await seedProfile(roots, "synthetic-token", legacy.port);
+
+    await expect(scanCredentialEnvelopes(roots)).resolves.toMatchObject({
+      keychainRequired: false,
+      migrated: 0,
+    });
+    await expect(scanCredentialEnvelopes(await fixture())).resolves.toMatchObject({
+      keychainRequired: false,
+      envelopes: [],
+    });
+  });
+
+  posixIt("requires the keychain once any envelope carries a non-zero key-id", async () => {
+    const roots = await fixture();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-legacy", safeStorage().port);
+    await seedProfile(roots, "synthetic-token", await keychainEncryption());
+
+    await expect(scanCredentialEnvelopes(roots)).resolves.toMatchObject({
+      keychainRequired: true,
+      migrated: 1,
+    });
+  });
+
+  posixIt("requires the keychain when an existing envelope cannot be read", async () => {
+    const roots = await fixture();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-legacy", safeStorage().port);
+
+    const inventory = await scanCredentialEnvelopes({
+      ...roots,
+      readEnvelopeFile: (async (path: string) => {
+        if (typeof path === "string" && path.endsWith("anthropic.bin")) {
+          throw Object.assign(new Error("synthetic read failure"), { code: "EACCES" });
+        }
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }) as never,
+    });
+
+    expect(inventory).toMatchObject({ keychainRequired: true, unreadable: 1, migrated: 0 });
+    expect(inventory.legacy).toHaveLength(0);
+  });
+});
+
+describe("eager credential migration", () => {
+  posixIt("migrates nothing on a fresh vault", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+
+    await expect(
+      migrateCredentialEnvelopes({
+        ...roots,
+        legacy: legacy.port,
+        keychain: await keychainEncryption(),
+      }),
+    ).resolves.toEqual({
+      status: "complete",
+      migrated: 0,
+      alreadyMigrated: 0,
+      failed: 0,
+      uncertain: 0,
+    });
+    expect(legacy.decryptCalls).toBe(0);
+  });
+
+  posixIt("migrates every legacy envelope and reads it back under the keychain key", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    const keychain = await keychainEncryption();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy.port);
+    await seedCredential(roots.credentialRoot, "openrouter", "sk-openrouter", legacy.port);
+    await seedProfile(roots, "synthetic-token", legacy.port);
+
+    await expect(
+      migrateCredentialEnvelopes({ ...roots, legacy: legacy.port, keychain }),
+    ).resolves.toEqual({
+      status: "complete",
+      migrated: 3,
+      alreadyMigrated: 0,
+      failed: 0,
+      uncertain: 0,
+    });
+
+    await expect(scanCredentialEnvelopes(roots)).resolves.toMatchObject({
+      migrated: 3,
+      legacy: [],
+      keychainRequired: true,
+    });
+    const vault = createCredentialVault({
+      root: roots.credentialRoot,
+      encryption: keychain,
+      applyCredential: vi.fn(async () => undefined),
+    });
+    await expect(vault.credentialStatuses()).resolves.toEqual(
+      expect.arrayContaining([
+        { slot: "anthropic", state: "configured", runtimeState: "stored-inactive" },
+        { slot: "openrouter", state: "configured", runtimeState: "stored-inactive" },
+      ]),
+    );
+    const telegram = createTelegramCredentialVault({
+      root: roots.telegramRoot,
+      athleteHome: roots.athleteHome,
+      encryption: keychain,
+    });
+    await expect(telegram.profileStatus()).resolves.toMatchObject({
+      state: "configured",
+      bot: BOT,
+    });
+  });
+
+  posixIt("skips envelopes already at the keychain key-id on the next run", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    const keychain = await keychainEncryption();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy.port);
+    await seedProfile(roots, "synthetic-token", legacy.port);
+    await migrateCredentialEnvelopes({ ...roots, legacy: legacy.port, keychain });
+    const consulted = legacy.decryptCalls;
+
+    await expect(
+      migrateCredentialEnvelopes({ ...roots, legacy: legacy.port, keychain }),
+    ).resolves.toEqual({
+      status: "complete",
+      migrated: 0,
+      alreadyMigrated: 2,
+      failed: 0,
+      uncertain: 0,
+    });
+    expect(legacy.decryptCalls).toBe(consulted);
+  });
+
+  posixIt("resumes the unmigrated envelopes after a failed one", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    const keychain = await keychainEncryption();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy.port);
+    await seedCredential(roots.credentialRoot, "openrouter", "sk-openrouter", legacy.port);
+    await seedProfile(roots, "synthetic-token", legacy.port);
+
+    await expect(
+      migrateCredentialEnvelopes({
+        ...roots,
+        legacy: legacy.port,
+        keychain: refuseValue(keychain, "sk-openrouter"),
+      }),
+    ).resolves.toEqual({
+      status: "incomplete",
+      migrated: 2,
+      alreadyMigrated: 0,
+      failed: 1,
+      uncertain: 0,
+    });
+    await expect(keyIdOf(join(roots.credentialRoot, "anthropic.bin"))).resolves.toBe(
+      KEYCHAIN_ENVELOPE_KEY_ID,
+    );
+    await expect(keyIdOf(join(roots.credentialRoot, "openrouter.bin"))).resolves.toBe(
+      SAFE_STORAGE_ENVELOPE_KEY_ID,
+    );
+
+    await expect(
+      migrateCredentialEnvelopes({ ...roots, legacy: legacy.port, keychain }),
+    ).resolves.toEqual({
+      status: "complete",
+      migrated: 1,
+      alreadyMigrated: 2,
+      failed: 0,
+      uncertain: 0,
+    });
+    await expect(keyIdOf(join(roots.credentialRoot, "openrouter.bin"))).resolves.toBe(
+      KEYCHAIN_ENVELOPE_KEY_ID,
+    );
+  });
+
+  posixIt("keeps a failed envelope readable while the pass is incomplete", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    const keychain = await keychainEncryption();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy.port);
+    await seedCredential(roots.credentialRoot, "openrouter", "sk-openrouter", legacy.port);
+
+    const outcome = await migrateCredentialEnvelopes({
+      ...roots,
+      legacy: legacy.port,
+      keychain: refuseValue(keychain, "sk-openrouter"),
+    });
+    expect(outcome.status).toBe("incomplete");
+
+    const vault = createCredentialVault({
+      root: roots.credentialRoot,
+      encryption: createLegacyReadFallbackEncryption({ keychain, legacy: legacy.port }),
+      applyCredential: vi.fn(async () => undefined),
+    });
+    await expect(vault.credentialStatuses()).resolves.toEqual(
+      expect.arrayContaining([
+        { slot: "anthropic", state: "configured", runtimeState: "stored-inactive" },
+        { slot: "openrouter", state: "configured", runtimeState: "stored-inactive" },
+      ]),
+    );
+  });
+
+  posixIt("leaves the envelope untouched when the durable replace refuses", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy.port);
+    const before = await readFile(join(roots.credentialRoot, "anthropic.bin"));
+
+    await expect(
+      migrateCredentialEnvelopes({
+        ...roots,
+        legacy: legacy.port,
+        keychain: await keychainEncryption(),
+        renameFile: (async () => {
+          throw new TypeError("synthetic rename failure");
+        }) as never,
+      }),
+    ).resolves.toEqual({
+      status: "incomplete",
+      migrated: 0,
+      alreadyMigrated: 0,
+      failed: 1,
+      uncertain: 0,
+    });
+    await expect(readFile(join(roots.credentialRoot, "anthropic.bin"))).resolves.toEqual(before);
+  });
+
+  posixIt("refuses an envelope the safeStorage backend cannot decrypt", async () => {
+    const roots = await fixture();
+    const keychain = await keychainEncryption();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", safeStorage().port);
+    const foreign: CredentialEncryptionPort = {
+      isEncryptionAvailable: () => true,
+      encryptString: () => Buffer.alloc(0),
+      decryptString: () => {
+        throw new TypeError("synthetic decrypt failure");
+      },
+    };
+
+    await expect(
+      migrateCredentialEnvelopes({ ...roots, legacy: foreign, keychain }),
+    ).resolves.toMatchObject({ status: "incomplete", failed: 1, migrated: 0 });
+    await expect(keyIdOf(join(roots.credentialRoot, "anthropic.bin"))).resolves.toBe(
+      SAFE_STORAGE_ENVELOPE_KEY_ID,
+    );
+  });
+
+  posixIt("skips an envelope that disappeared before its turn", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy.port);
+    let reads = 0;
+
+    await expect(
+      migrateCredentialEnvelopes({
+        ...roots,
+        legacy: legacy.port,
+        keychain: await keychainEncryption(),
+        readEnvelopeFile: (async (path: string) => {
+          reads += 1;
+          if (reads > 1) throw Object.assign(new Error("missing"), { code: "ENOENT" });
+          return await readFile(path);
+        }) as never,
+      }),
+    ).resolves.toEqual({
+      status: "complete",
+      migrated: 0,
+      alreadyMigrated: 0,
+      failed: 0,
+      uncertain: 0,
+    });
+  });
+});
+
+describe("legacy read fallback", () => {
+  posixIt("reads both key-ids, writes only the keychain key-id", async () => {
+    const legacy = safeStorage();
+    const keychain = await keychainEncryption();
+    const fallback = createLegacyReadFallbackEncryption({ keychain, legacy: legacy.port });
+
+    const sealed = fallback.encryptString("sk-value");
+    expect(credentialEnvelopeKeyId(sealed)).toBe(KEYCHAIN_ENVELOPE_KEY_ID);
+    expect(fallback.decryptString(sealed)).toBe("sk-value");
+    expect(fallback.decryptString(legacy.port.encryptString("sk-old"))).toBe("sk-old");
+    expect(fallback.getSelectedStorageBackend?.()).toBe(KEYCHAIN_PARTITION_STORAGE_BACKEND);
+    expect(fallback.isEncryptionAvailable()).toBe(true);
+  });
+
+  posixIt("stops reading through safeStorage once the pass is complete", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    const keychain = await keychainEncryption();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy.port);
+    await migrateCredentialEnvelopes({ ...roots, legacy: legacy.port, keychain });
+    const consulted = legacy.decryptCalls;
+
+    const vault = createCredentialVault({
+      root: roots.credentialRoot,
+      encryption: createLegacyReadFallbackEncryption({ keychain, legacy: legacy.port }),
+      applyCredential: vi.fn(async () => undefined),
+    });
+    await expect(vault.credentialStatuses()).resolves.toEqual(
+      expect.arrayContaining([
+        { slot: "anthropic", state: "configured", runtimeState: "stored-inactive" },
+      ]),
+    );
+    expect(legacy.decryptCalls).toBe(consulted);
+  });
+});
+
+describe("migrated envelope permissions", () => {
+  posixIt("keeps both vault file modes after migration", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy.port);
+    await seedProfile(roots, "synthetic-token", legacy.port);
+
+    await migrateCredentialEnvelopes({
+      ...roots,
+      legacy: legacy.port,
+      keychain: await keychainEncryption(),
+    });
+
+    for (const path of [
+      join(roots.credentialRoot, "anthropic.bin"),
+      join(roots.telegramRoot, TELEGRAM_PROFILE_FILE_NAME),
+    ]) {
+      expect((await lstat(path)).mode & 0o777).toBe(0o600);
+    }
+  });
+});

--- a/apps/desktop/tests/keychain-key-lifetime.test.ts
+++ b/apps/desktop/tests/keychain-key-lifetime.test.ts
@@ -1,0 +1,220 @@
+import { randomBytes } from "node:crypto";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createCredentialVault,
+  type CredentialEncryptionPort,
+  type DesktopCredentialSlot,
+} from "../src/main/credential-vault.js";
+import { createKeychainPartitionEncryption } from "../src/main/keychain-credential-encryption.js";
+import {
+  KEYCHAIN_CREDENTIAL_SERVICE,
+  KEYCHAIN_KEY_BYTES,
+  KEYCHAIN_TEAM_IDENTIFIER,
+  type KeychainHelperRequest,
+  type KeychainHelperResponse,
+  type KeychainHelperTransport,
+} from "../src/main/keychain-helper.js";
+import { retireKeychainKeyWhenLastEnvelopeGone } from "../src/main/keychain-key-lifetime.js";
+import { createTelegramCredentialVault } from "../src/main/telegram-credential-vault.js";
+
+const fixtureRoots: string[] = [];
+const posixIt = it.skipIf(process.platform === "win32");
+const BOT = { id: 123456, username: "synthetic_bot" } as const;
+const PROBE_OK: KeychainHelperResponse = {
+  ok: true,
+  op: "probe",
+  teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER,
+};
+
+interface Fixture {
+  readonly credentialRoot: string;
+  readonly telegramRoot: string;
+  readonly athleteHome: string;
+}
+
+async function fixture(): Promise<Fixture> {
+  const base = await mkdtemp(join(await realpath(tmpdir()), "desktop-key-lifetime-"));
+  fixtureRoots.push(base);
+  const home = join(base, "athlete-home");
+  await mkdir(home, { mode: 0o700 });
+  return {
+    credentialRoot: join(base, "credentials-v1"),
+    telegramRoot: join(base, "telegram-channel-v1"),
+    athleteHome: await realpath(home),
+  };
+}
+
+interface RecordingTransport extends KeychainHelperTransport {
+  readonly requests: KeychainHelperRequest[];
+}
+
+function transportOf(...responses: readonly KeychainHelperResponse[]): RecordingTransport {
+  const remaining = [...responses];
+  const requests: KeychainHelperRequest[] = [];
+  return {
+    requests,
+    send(request) {
+      requests.push(request);
+      const next = remaining.shift();
+      if (next === undefined) throw new Error("unexpected helper request");
+      return Promise.resolve(next);
+    },
+  };
+}
+
+async function keychainEncryption(): Promise<CredentialEncryptionPort> {
+  const result = await createKeychainPartitionEncryption({
+    transport: transportOf(PROBE_OK, {
+      ok: true,
+      op: "read-key",
+      key: randomBytes(KEYCHAIN_KEY_BYTES).toString("base64"),
+    }),
+    service: KEYCHAIN_CREDENTIAL_SERVICE,
+  });
+  if (result.status !== "ready") throw new TypeError();
+  return result.encryption;
+}
+
+function credentialVault(roots: Fixture, encryption: CredentialEncryptionPort) {
+  return createCredentialVault({
+    root: roots.credentialRoot,
+    encryption,
+    applyCredential: vi.fn(async () => undefined),
+    clearCredential: vi.fn(async () => "not-active" as const),
+  });
+}
+
+function telegramVault(roots: Fixture, encryption: CredentialEncryptionPort) {
+  return createTelegramCredentialVault({
+    root: roots.telegramRoot,
+    athleteHome: roots.athleteHome,
+    encryption,
+  });
+}
+
+async function seedCredential(
+  roots: Fixture,
+  slot: DesktopCredentialSlot,
+  value: string,
+  encryption: CredentialEncryptionPort,
+): Promise<void> {
+  await expect(
+    credentialVault(roots, encryption).writeCredential({ slot, value }, { activate: false }),
+  ).resolves.toMatchObject({ status: "configured" });
+}
+
+async function seedProfile(roots: Fixture, encryption: CredentialEncryptionPort): Promise<void> {
+  await expect(
+    telegramVault(roots, encryption).replaceProfile({
+      token: "synthetic-token",
+      bot: BOT,
+      authenticatedAthleteHome: roots.athleteHome,
+    }),
+  ).resolves.toMatchObject({ outcome: "applied" });
+}
+
+afterEach(async () => {
+  for (const root of fixtureRoots.splice(0)) {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+describe("keychain key retirement", () => {
+  posixIt("keeps the key while any envelope survives in either vault", async () => {
+    const roots = await fixture();
+    const encryption = await keychainEncryption();
+    await seedCredential(roots, "anthropic", "sk-anthropic", encryption);
+    await seedProfile(roots, encryption);
+    const transport = transportOf();
+
+    await expect(
+      credentialVault(roots, encryption).deleteCredential("anthropic"),
+    ).resolves.toMatchObject({ slot: "anthropic", status: "deleted" });
+
+    await expect(
+      retireKeychainKeyWhenLastEnvelopeGone({
+        ...roots,
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+      }),
+    ).resolves.toEqual({ status: "retained", envelopes: 1 });
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  posixIt("deletes the key when the last envelope across both vaults is gone", async () => {
+    const roots = await fixture();
+    const encryption = await keychainEncryption();
+    await seedCredential(roots, "anthropic", "sk-anthropic", encryption);
+    await seedCredential(roots, "openrouter", "sk-openrouter", encryption);
+    await seedProfile(roots, encryption);
+    const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
+
+    for (const slot of ["anthropic", "openrouter"] as const) {
+      await expect(
+        credentialVault(roots, encryption).deleteCredential(slot),
+      ).resolves.toMatchObject({ status: "deleted" });
+    }
+    await expect(
+      retireKeychainKeyWhenLastEnvelopeGone({
+        ...roots,
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+      }),
+    ).resolves.toMatchObject({ status: "retained" });
+
+    await expect(telegramVault(roots, encryption).deleteProfile()).resolves.toMatchObject({
+      outcome: "applied",
+    });
+
+    await expect(
+      retireKeychainKeyWhenLastEnvelopeGone({
+        ...roots,
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+      }),
+    ).resolves.toEqual({ status: "deleted" });
+    expect(transport.requests).toEqual([
+      { op: "delete-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
+    ]);
+  });
+
+  posixIt("keeps the key while an envelope exists but cannot be read", async () => {
+    const roots = await fixture();
+    const transport = transportOf();
+
+    await expect(
+      retireKeychainKeyWhenLastEnvelopeGone({
+        ...roots,
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+        readEnvelopeFile: (async () => {
+          throw Object.assign(new Error("synthetic read failure"), { code: "EACCES" });
+        }) as never,
+      }),
+    ).resolves.toMatchObject({ status: "retained" });
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  posixIt("reports an absent item and a refused delete apart", async () => {
+    const roots = await fixture();
+
+    await expect(
+      retireKeychainKeyWhenLastEnvelopeGone({
+        ...roots,
+        transport: transportOf({ ok: true, op: "delete-key", deleted: false }),
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+      }),
+    ).resolves.toEqual({ status: "already-absent" });
+
+    await expect(
+      retireKeychainKeyWhenLastEnvelopeGone({
+        ...roots,
+        transport: transportOf({ ok: false, code: "keychain-locked" }),
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+      }),
+    ).resolves.toEqual({ status: "failed", code: "keychain-locked" });
+  });
+});


### PR DESCRIPTION
Child PR 3 of epic #672. Backend selection, eager crash-resumable migration, and key-retirement ordering. Still dark: `apps/desktop/src/main/index.ts` is untouched — all three `encryption: safeStorage` injection sites stand, and nothing in production calls the new selection seam. The flip is PR 4.

## What

- `credential-envelope-inventory.ts` — enumerates the fixed envelope set across both vaults (`credentials-v1` slots + `telegram-channel-v1` profile) and reads each envelope's key-id; derives `keychainRequired` (any key-id ≠ 0). An envelope that exists but cannot be read counts as `keychainRequired` — failing closed costs a re-entry prompt; failing open would re-encrypt under a retired key.
- `credential-key-migration.ts` — eager per-envelope re-key through the vaults' existing `durablyReplaceReversible`; crash between envelopes leaves a resumable state (key-id-1 skipped, key-id-0 resumed next startup); a failed envelope never blocks the others; `createLegacyReadFallbackEncryption` reads key-id-0 via safeStorage during an incomplete pass but seals every write at key-id 1.
- `credential-backend-selection.ts` — the single selection seam: darwin-only, helper own-signature probe (never write-then-read), then migrate, then compose the port. Mandatory-keychain rule: once any envelope carries key-id ≠ 0, a probe failure (`keychain-locked`, `not-team-signed`, `unknown`) refuses with `encryption-unavailable` and an unavailable port — there is no path back to safeStorage. Pre-migration, unsigned builds fall back to safeStorage unchanged.
- `keychain-key-lifetime.ts` — `retireKeychainKeyWhenLastEnvelopeGone`: `delete-key` fires only when zero envelopes remain across BOTH vaults.
- 34 tests: migration resume matrix (fresh/partial/crash-between/already-migrated), the mandatory rule driven through real vault instances, failure mapping for every helper code in both migration states, deletion ordering.

## Adversarial verify

Four read-only lenses. Migration-safety, darkness/regression, and house-rules passed clean. The selection lens found one structural defect: post-migration, helper code `unknown` (helper missing/crashed/timed out) mapped to `storage-failed` with an available-looking port, so the vaults could never surface the mandated `encryption-unavailable`. Fixed in the second commit (`keychainFailureRefusal` is now migration-aware; refused-lane port availability follows the computed reason), pinned by 12 mapping assertions plus two end-to-end refusal tests, and re-verified by a fresh read-only agent that confirmed the invariant holds in every refusal path.

## Verification

- Full desktop suite: 86 files, 1688/1688 pass.
- `pnpm --filter @enduragent/desktop check` and root `pnpm check:types` green.
- No new numeric limits: migration deliberately has no retry counter — a failed envelope retries at the next startup.

Residuals handed to PR 4: wire `selectDesktopCredentialBackend` at the three injection sites (it must run before the vaults are constructed for those roots), pick prod vs `.dev` service, call `retireKeychainKeyWhenLastEnvelopeGone` after envelope deletions, and surface the refusal reason to the athlete.

No changeset: still dark, nothing user-visible.