### PR TITLE
feat(desktop): select the keychain credential backend at startup

### DIFF
--- a/.changeset/calm-keys-stay-safe.md
+++ b/.changeset/calm-keys-stay-safe.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Prevented locked or inaccessible macOS Keychain items from deleting stored credential keys.

--- a/apps/desktop-renderer/src/platform-copy.ts
+++ b/apps/desktop-renderer/src/platform-copy.ts
@@ -21,7 +21,7 @@ const DARWIN_FALLBACK: DesktopPlatformProjection = Object.freeze({
     operatingSystem: "macOS",
     credentialEncryptionUnavailable:
       "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
-    credentialRecoveryAction: "unlock or approve Keychain access",
+    credentialRecoveryAction: "unlock your login keychain",
     restartComputer: "restart your Mac",
     rideImportDescription:
       "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.",

--- a/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
@@ -383,7 +383,7 @@ describe("Telegram settings surface", () => {
   it.each([
     [
       "telegram-credential-encryption-unavailable" as const,
-      /quit and reopen Enduragent, unlock or approve Keychain access, then choose Check again/iu,
+      /quit and reopen Enduragent, unlock your login keychain, then choose Check again/iu,
       /without encryption/iu,
     ],
     [
@@ -515,7 +515,7 @@ describe("Telegram settings surface", () => {
   it.each([
     [
       "telegram-credential-encryption-unavailable" as const,
-      /quit and reopen Enduragent, unlock or approve Keychain access, then choose Check again/iu,
+      /quit and reopen Enduragent, unlock your login keychain, then choose Check again/iu,
     ],
     [
       "telegram-credential-unsafe-backend" as const,

--- a/apps/desktop-renderer/tests/telegram-settings.test.ts
+++ b/apps/desktop-renderer/tests/telegram-settings.test.ts
@@ -313,7 +313,7 @@ describe("Telegram settings controller", () => {
         feedback: {
           tone: "error",
           message:
-            "Secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, copy the bot token again, then retry.",
+            "Secure token storage is unavailable. Quit and reopen Enduragent, unlock your login keychain, copy the bot token again, then retry.",
         },
       }),
     );
@@ -611,7 +611,7 @@ describe("Telegram settings controller", () => {
     ],
     [
       "encryption-unavailable",
-      "The current Telegram bot is unchanged because secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, copy the bot token again, then retry.",
+      "The current Telegram bot is unchanged because secure token storage is unavailable. Quit and reopen Enduragent, unlock your login keychain, copy the bot token again, then retry.",
     ],
     [
       "unsafe-backend",
@@ -671,7 +671,7 @@ describe("Telegram settings controller", () => {
     [
       "reconcile" as const,
       "encryption-unavailable" as const,
-      "Secure token storage is unavailable. Quit and reopen Enduragent, unlock or approve Keychain access, then choose Check again.",
+      "Secure token storage is unavailable. Quit and reopen Enduragent, unlock your login keychain, then choose Check again.",
     ],
     [
       "remove-webhook" as const,

--- a/apps/desktop/CONTEXT.md
+++ b/apps/desktop/CONTEXT.md
@@ -28,9 +28,13 @@ _Avoid_: Daemon, service, agent (the daemon is the long-lived coaching process; 
 The single number inside an envelope naming the key that protects it. `0` names the platform-secure-storage era. Any other value names a later key. Without a key-id an envelope from one era is indistinguishable from another, and a half-migrated vault cannot be repaired.
 _Avoid_: Version, key version, generation
 
-**Poisoned item**:
-A stored key that exists but cannot be read by the app entitled to it. It is a recoverable state, not a fatal one: the app destroys it and creates a fresh key, accepting that every envelope under the old key must be re-entered. Distinct from a missing key, which is simply the first-run case.
-_Avoid_: Corrupt key, broken keychain, orphaned item
+**Uninspectable item**:
+An existing keychain item whose contents or access rules cannot be positively verified. This state does not prove corruption and never authorises destroying the encryption key.
+_Avoid_: Poisoned item, corrupt key, broken keychain
+
+**Missing encryption key**:
+An absent encryption key. It is a first-run state only when no envelope depends on it; otherwise it is a recovery state and the envelopes remain preserved.
+_Avoid_: Unconfigured credential, empty vault
 
 ## Relationships
 
@@ -38,7 +42,7 @@ _Avoid_: Corrupt key, broken keychain, orphaned item
 - A **Vault** delegates every encryption and decryption to one **Backend** and never inspects an **Envelope** itself.
 - A **Backend** may need a **Helper** to obtain its key; a backend that needs no helper has none.
 - Every **Envelope** carries the **Key-id** of the key that sealed it.
-- A **Poisoned item** is a **Backend** concern; a **Vault** only ever sees the refusal that follows.
+- An **Uninspectable item** is a **Backend** concern; a **Vault** only ever sees the refusal that follows.
 
 ## Example dialogue
 

--- a/apps/desktop/native/keychain-helper/main.swift
+++ b/apps/desktop/native/keychain-helper/main.swift
@@ -44,7 +44,7 @@ func mapStatus(_ status: OSStatus) -> String {
   case errSecInteractionNotAllowed, errSecInteractionRequired, errSecNotAvailable:
     return "keychain-locked"
   case errSecAuthFailed:
-    return "unreadable-item"
+    return "uninspectable-item"
   default:
     return "unknown"
   }
@@ -111,23 +111,35 @@ func makeAccess() -> SecAccess? {
   return access
 }
 
-func carriesPartitionEntry(_ item: SecKeychainItem) -> Bool {
+enum PartitionInspection {
+  case present
+  case absent
+  case uninspectable
+}
+
+func inspectPartitionEntry(_ item: SecKeychainItem) -> PartitionInspection {
   var access: SecAccess?
-  guard SecKeychainItemCopyAccess(item, &access) == errSecSuccess, let access else { return false }
+  guard SecKeychainItemCopyAccess(item, &access) == errSecSuccess, let access else {
+    return .uninspectable
+  }
   var aclList: CFArray?
-  guard SecAccessCopyACLList(access, &aclList) == errSecSuccess else { return false }
-  for acl in (aclList as? [SecACL]) ?? [] {
-    let authorizations = SecACLCopyAuthorizations(acl) as? [String] ?? []
+  guard SecAccessCopyACLList(access, &aclList) == errSecSuccess,
+        let acls = aclList as? [SecACL]
+  else { return .uninspectable }
+  for acl in acls {
+    guard let authorizations = SecACLCopyAuthorizations(acl) as? [String] else {
+      return .uninspectable
+    }
     guard authorizations.contains(kSecACLAuthorizationPartitionID as String) else { continue }
     var applications: CFArray?
     var description: CFString?
     var prompt = SecKeychainPromptSelector()
     guard SecACLCopyContents(acl, &applications, &description, &prompt) == errSecSuccess else {
-      continue
+      return .uninspectable
     }
-    if let text = description as String?, text.contains(partitionMarker) { return true }
+    if let text = description as String?, text.contains(partitionMarker) { return .present }
   }
-  return false
+  return .absent
 }
 
 func readKey(_ service: String) -> Never {
@@ -144,9 +156,18 @@ func readKey(_ service: String) -> Never {
         let reference = attributes[kSecValueRef as String]
   else { fail("unreadable-item") }
   let candidate = reference as CFTypeRef
-  guard CFGetTypeID(candidate) == SecKeychainItemGetTypeID() else { fail("unreadable-item") }
+  guard CFGetTypeID(candidate) == SecKeychainItemGetTypeID() else {
+    fail("uninspectable-item")
+  }
   let item = unsafeBitCast(candidate, to: SecKeychainItem.self)
-  guard carriesPartitionEntry(item) else { fail("unreadable-item") }
+  switch inspectPartitionEntry(item) {
+  case .present:
+    break
+  case .absent:
+    fail("unreadable-item")
+  case .uninspectable:
+    fail("uninspectable-item")
+  }
   succeed(["ok": true, "op": "read-key", "key": data.base64EncodedString()])
 }
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,7 @@
     "verify:package-layout": "node scripts/verify-package-layout.mjs",
     "verify:win-package": "node scripts/verify-windows-package.mjs",
     "verify:mac-release": "node scripts/verify-macos-release.mjs",
+    "verify:mac-backend-selection": "node scripts/verify-macos-backend-selection.mjs",
     "smoke:runtime": "node scripts/electron-smoke.mjs runtime",
     "smoke:security": "node scripts/electron-smoke.mjs security",
     "accept:residency": "node ./scripts/accept-residency.mjs",

--- a/apps/desktop/scripts/macos-release-plan.d.mts
+++ b/apps/desktop/scripts/macos-release-plan.d.mts
@@ -105,6 +105,7 @@ export type MacosReleaseStage =
   | "electron-builder"
   | "package-layout"
   | "keychain-helper"
+  | "backend-selection"
   | "candidate-verification"
   | "identity-continuity"
   | "dmg-notarization"
@@ -135,6 +136,7 @@ export interface MacosReleaseDependencies {
     options: { readonly candidateVersion: string },
   ) => Promise<VerifiedMacosBaselineApplication>;
   readonly verifyKeychainHelper?: (candidateApplication: string) => Promise<unknown>;
+  readonly verifyBackendSelection?: (candidateApplication: string) => Promise<unknown>;
   readonly verifyIdentityContinuity?: (
     baselineApplication: string,
     candidateApplication: string,

--- a/apps/desktop/scripts/macos-release-plan.mjs
+++ b/apps/desktop/scripts/macos-release-plan.mjs
@@ -763,6 +763,14 @@ export async function runMacosRelease(input, dependencies = {}) {
       }));
   dependencies.reportStage?.("keychain-helper");
   await verifyKeychainHelper(application);
+  const verifyBackendSelection =
+    dependencies.verifyBackendSelection ??
+    (async (candidate) =>
+      (await import("./verify-macos-backend-selection.mjs")).verifyMacosBackendSelection(candidate, {
+        executeFile: dependencies.executeFile,
+      }));
+  dependencies.reportStage?.("backend-selection");
+  await verifyBackendSelection(application);
   const verifyIdentityContinuity =
     dependencies.verifyIdentityContinuity ??
     ((baseline, candidate, options) =>

--- a/apps/desktop/scripts/verify-macos-backend-selection.d.mts
+++ b/apps/desktop/scripts/verify-macos-backend-selection.d.mts
@@ -1,0 +1,27 @@
+export declare const BACKEND_SELECTION_SERVICE: "icu.enduragent.desktop";
+export declare const BACKEND_SELECTION_TEAM_IDENTIFIER: "FA494ACVTF";
+export declare const BACKEND_SELECTION_PROBE_TIMEOUT_MS: number;
+export declare const BACKEND_SELECTION_MAX_RESPONSE_BYTES: number;
+
+export interface VerifiedMacosBackendSelection {
+  readonly helper: string;
+  readonly service: string;
+  readonly teamIdentifier: string;
+  readonly designatedRequirement: string;
+}
+
+export interface VerifyMacosBackendSelectionOverrides {
+  readonly executeFile?: (executable: string, arguments_: readonly string[]) => Promise<unknown>;
+  readonly requireHelper?: (helperPath: string) => Promise<void>;
+  readonly verifyKeychainHelper?: (application: string) => Promise<unknown>;
+  readonly runHelper?: (helperPath: string, request: string) => Promise<string | undefined>;
+}
+
+export declare function safeMacosBackendSelectionMessage(error: unknown): string | undefined;
+
+export declare function backendSelectionProbeRequest(): string;
+
+export declare function verifyMacosBackendSelection(
+  application: string,
+  overrides?: VerifyMacosBackendSelectionOverrides,
+): Promise<VerifiedMacosBackendSelection>;

--- a/apps/desktop/scripts/verify-macos-backend-selection.mjs
+++ b/apps/desktop/scripts/verify-macos-backend-selection.mjs
@@ -1,0 +1,163 @@
+import { spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access, lstat } from "node:fs/promises";
+import { isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { KEYCHAIN_HELPER_RESOURCE_PATH } from "./package-inventory.mjs";
+import { verifyMacosKeychainHelper } from "./verify-macos-release.mjs";
+
+export const BACKEND_SELECTION_SERVICE = "icu.enduragent.desktop";
+export const BACKEND_SELECTION_TEAM_IDENTIFIER = "FA494ACVTF";
+export const BACKEND_SELECTION_PROBE_TIMEOUT_MS = 15_000;
+export const BACKEND_SELECTION_MAX_RESPONSE_BYTES = 8_192;
+
+class MacosBackendSelectionError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "MacosBackendSelectionError";
+  }
+}
+
+function fail(message) {
+  throw new MacosBackendSelectionError(message);
+}
+
+export function safeMacosBackendSelectionMessage(error) {
+  return error instanceof MacosBackendSelectionError ? error.message : undefined;
+}
+
+export function backendSelectionProbeRequest() {
+  return `${JSON.stringify({ op: "probe", service: BACKEND_SELECTION_SERVICE })}\n`;
+}
+
+async function requireExecutableHelper(helper) {
+  let entry;
+  try {
+    entry = await lstat(helper);
+  } catch {
+    fail("bundled keychain helper is missing");
+  }
+  if (!entry.isFile()) fail("bundled keychain helper is not a regular file");
+  try {
+    await access(helper, constants.X_OK);
+  } catch {
+    fail("bundled keychain helper is not executable");
+  }
+}
+
+function runBundledHelper(helper, request) {
+  return new Promise((resolveLine, rejectLine) => {
+    let child;
+    try {
+      child = spawn(helper, [], { stdio: ["pipe", "pipe", "ignore"] });
+    } catch {
+      rejectLine(new MacosBackendSelectionError("bundled keychain helper could not be launched"));
+      return;
+    }
+    let settled = false;
+    let received = "";
+    const finish = (line, message) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        child.kill("SIGKILL");
+      } catch {}
+      if (message === undefined) resolveLine(line);
+      else rejectLine(new MacosBackendSelectionError(message));
+    };
+    const timer = setTimeout(
+      () => finish(undefined, "bundled keychain helper probe timed out"),
+      BACKEND_SELECTION_PROBE_TIMEOUT_MS,
+    );
+    child.once("error", () => finish(undefined, "bundled keychain helper could not be launched"));
+    child.once("close", () => {
+      const newline = received.indexOf("\n");
+      finish(newline < 0 ? received : received.slice(0, newline));
+    });
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      received += chunk;
+      if (Buffer.byteLength(received, "utf8") > BACKEND_SELECTION_MAX_RESPONSE_BYTES) {
+        finish(undefined, "bundled keychain helper answered too much output");
+        return;
+      }
+      const newline = received.indexOf("\n");
+      if (newline >= 0) finish(received.slice(0, newline));
+    });
+    child.stdin?.on("error", () => {});
+    child.stdin?.end(request);
+  });
+}
+
+function parseProbeAnswer(line) {
+  if (typeof line !== "string" || line.length === 0) {
+    fail("bundled keychain helper answered nothing");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    fail("bundled keychain helper answered malformed JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    fail("bundled keychain helper answered malformed JSON");
+  }
+  if (parsed.ok !== true || parsed.op !== "probe") {
+    fail("bundled keychain helper refused the capability probe");
+  }
+  if (parsed.teamIdentifier !== BACKEND_SELECTION_TEAM_IDENTIFIER) {
+    fail("bundled keychain helper reported an unexpected team identifier");
+  }
+  return parsed.teamIdentifier;
+}
+
+export async function verifyMacosBackendSelection(application, overrides = {}) {
+  if (typeof application !== "string" || !isAbsolute(application)) {
+    fail("application path must be absolute");
+  }
+  const helper = join(application, "Contents/Resources", KEYCHAIN_HELPER_RESOURCE_PATH);
+  await (overrides.requireHelper ?? requireExecutableHelper)(helper);
+  const verifyHelperSignature =
+    overrides.verifyKeychainHelper ??
+    ((candidate) => verifyMacosKeychainHelper(candidate, { executeFile: overrides.executeFile }));
+  let signature;
+  try {
+    signature = await verifyHelperSignature(application);
+  } catch (error) {
+    fail(
+      typeof error?.message === "string" && error.message.length > 0
+        ? error.message
+        : "bundled keychain helper signature verification failed",
+    );
+  }
+  if (
+    typeof signature !== "object" ||
+    signature === null ||
+    signature.teamIdentifier !== BACKEND_SELECTION_TEAM_IDENTIFIER
+  ) {
+    fail("bundled keychain helper signing identity is invalid");
+  }
+  const runHelper = overrides.runHelper ?? runBundledHelper;
+  const teamIdentifier = parseProbeAnswer(await runHelper(helper, backendSelectionProbeRequest()));
+  return Object.freeze({
+    helper,
+    service: BACKEND_SELECTION_SERVICE,
+    teamIdentifier,
+    designatedRequirement: signature.designatedRequirement,
+  });
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const [application] = process.argv.slice(2);
+    if (application === undefined) fail("expected an absolute application path");
+    await verifyMacosBackendSelection(application);
+    process.stdout.write("macOS keychain backend selection verified\n");
+  } catch (error) {
+    process.stderr.write(
+      `${safeMacosBackendSelectionMessage(error) ?? "macOS keychain backend selection verification failed"}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -7,6 +7,7 @@ import {
 import {
   createKeychainPartitionEncryption,
   createRefusingKeychainEncryption,
+  type KeychainKeyRotation,
 } from "./keychain-credential-encryption.js";
 import type { KeychainHelperErrorCode, KeychainHelperTransport } from "./keychain-helper.js";
 import {
@@ -23,6 +24,7 @@ export type DesktopCredentialBackendSelection =
       encryption: CredentialEncryptionPort;
       migration: CredentialMigrationOutcome;
       createdKey: boolean;
+      rotateKey: () => Promise<KeychainKeyRotation>;
     }>
   | Readonly<{ status: "safe-storage"; encryption: CredentialEncryptionPort }>
   | Readonly<{
@@ -117,5 +119,6 @@ export async function selectDesktopCredentialBackend(
           }),
     migration,
     createdKey: keychain.createdKey,
+    rotateKey: keychain.rotateKey,
   };
 }

--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -89,7 +89,7 @@ async function selectMacCredentialBackend(
   const keychain = await createKeychainPartitionEncryption({
     transport: options.transport,
     service: options.service,
-    dependentEnvelopes: inventory.envelopes.length,
+    dependentEnvelopes: inventory.migrated + inventory.unreadable,
     lockProof: proof,
   });
   if (keychain.status === "unsupported") {

--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -1,4 +1,8 @@
 import type { rename, rm } from "node:fs/promises";
+import type {
+  CredentialEnvelopeLockProof,
+  SerializeCredentialEnvelopeMutation,
+} from "./credential-envelope-lock.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
 import {
   scanCredentialEnvelopes,
@@ -7,7 +11,8 @@ import {
 import {
   createKeychainPartitionEncryption,
   createRefusingKeychainEncryption,
-  type KeychainKeyRotation,
+  type KeychainKeyDeletion,
+  type KeychainKeyPreparation,
 } from "./keychain-credential-encryption.js";
 import type { KeychainHelperErrorCode, KeychainHelperTransport } from "./keychain-helper.js";
 import {
@@ -24,7 +29,8 @@ export type DesktopCredentialBackendSelection =
       encryption: CredentialEncryptionPort;
       migration: CredentialMigrationOutcome;
       createdKey: boolean;
-      rotateKey: () => Promise<KeychainKeyRotation>;
+      prepareKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyPreparation>;
+      deleteKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyDeletion>;
     }>
   | Readonly<{ status: "safe-storage"; encryption: CredentialEncryptionPort }>
   | Readonly<{
@@ -43,16 +49,20 @@ export interface SelectDesktopCredentialBackendOptions extends CredentialEnvelop
   readonly renameFile?: typeof rename;
   readonly removeFile?: typeof rm;
   readonly syncDirectory?: (root: string) => Promise<void>;
+  readonly serializeEnvelopeMutation: SerializeCredentialEnvelopeMutation;
 }
 
 export function keychainFailureRefusal(
   code: KeychainHelperErrorCode,
   keychainRequired: boolean,
 ): DesktopCredentialBackendRefusal {
-  if (code === "keychain-locked" || code === "not-team-signed") {
+  if (code === "keychain-locked" || code === "uninspectable-item" || code === "not-team-signed") {
     return "encryption-unavailable";
   }
-  if (keychainRequired && code === "unknown") {
+  if (
+    keychainRequired &&
+    (code === "unknown" || code === "item-not-found" || code === "unreadable-item")
+  ) {
     return "encryption-unavailable";
   }
   return "storage-failed";
@@ -65,10 +75,22 @@ export async function selectDesktopCredentialBackend(
   if (platform !== "darwin") {
     return { status: "safe-storage", encryption: options.safeStorage };
   }
+  return await options.serializeEnvelopeMutation((proof) =>
+    selectMacCredentialBackend(options, platform, proof),
+  );
+}
+
+async function selectMacCredentialBackend(
+  options: SelectDesktopCredentialBackendOptions,
+  platform: NodeJS.Platform,
+  proof: CredentialEnvelopeLockProof,
+): Promise<DesktopCredentialBackendSelection> {
   const inventory = await scanCredentialEnvelopes(options);
   const keychain = await createKeychainPartitionEncryption({
     transport: options.transport,
     service: options.service,
+    dependentEnvelopes: inventory.envelopes.length,
+    lockProof: proof,
   });
   if (keychain.status === "unsupported") {
     if (!inventory.keychainRequired) {
@@ -119,6 +141,7 @@ export async function selectDesktopCredentialBackend(
           }),
     migration,
     createdKey: keychain.createdKey,
-    rotateKey: keychain.rotateKey,
+    prepareKey: keychain.prepareKey,
+    deleteKey: keychain.deleteKey,
   };
 }

--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -85,7 +85,16 @@ async function selectMacCredentialBackend(
   platform: NodeJS.Platform,
   proof: CredentialEnvelopeLockProof,
 ): Promise<DesktopCredentialBackendSelection> {
-  const inventory = await scanCredentialEnvelopes(options);
+  const inventory = await scanCredentialEnvelopes({
+    ...options,
+    classifyLegacyEnvelope(envelope) {
+      try {
+        return options.safeStorage.decryptString(envelope).length > 0;
+      } catch {
+        return false;
+      }
+    },
+  });
   const keychain = await createKeychainPartitionEncryption({
     transport: options.transport,
     service: options.service,

--- a/apps/desktop/src/main/credential-envelope-inventory.ts
+++ b/apps/desktop/src/main/credential-envelope-inventory.ts
@@ -35,6 +35,10 @@ export interface CredentialEnvelopeRoots {
   readonly credentialRoot: string;
   readonly telegramRoot: string;
   readonly readEnvelopeFile?: typeof readFile;
+  readonly classifyLegacyEnvelope?: (
+    envelope: Buffer,
+    target: CredentialEnvelopeTarget,
+  ) => boolean | Promise<boolean>;
 }
 
 export function credentialEnvelopeTargets(
@@ -75,7 +79,16 @@ export async function scanCredentialEnvelopes(
       continue;
     }
     try {
-      envelopes.push({ ...target, keyId: credentialEnvelopeKeyId(contents) });
+      let keyId = readCredentialEnvelopeKeyId(contents);
+      if (keyId === undefined || keyId === SAFE_STORAGE_ENVELOPE_KEY_ID) {
+        keyId = undefined;
+        try {
+          if (await roots.classifyLegacyEnvelope?.(contents, target)) {
+            keyId = SAFE_STORAGE_ENVELOPE_KEY_ID;
+          }
+        } catch {}
+      }
+      envelopes.push({ ...target, keyId });
     } finally {
       contents.fill(0);
     }

--- a/apps/desktop/src/main/credential-envelope-lock.ts
+++ b/apps/desktop/src/main/credential-envelope-lock.ts
@@ -1,0 +1,27 @@
+const credentialEnvelopeLockProof = Symbol("credential-envelope-lock-proof");
+
+export interface CredentialEnvelopeLockProof {
+  readonly [credentialEnvelopeLockProof]: true;
+}
+
+export type SerializeCredentialEnvelopeMutation = <T>(
+  operation: (proof: CredentialEnvelopeLockProof) => Promise<T>,
+) => Promise<T>;
+
+export function createCredentialEnvelopeMutationLock(): SerializeCredentialEnvelopeMutation {
+  let queue = Promise.resolve();
+  const proof = Object.freeze({
+    [credentialEnvelopeLockProof]: true as const,
+  });
+  return <T>(operation: (current: CredentialEnvelopeLockProof) => Promise<T>): Promise<T> => {
+    const result = queue.then(
+      () => operation(proof),
+      () => operation(proof),
+    );
+    queue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -19,6 +19,10 @@ import {
   type OnboardingLlmSelectionResult,
 } from "./llm-selection.js";
 import { durablyReplaceReversible } from "./durable-atomic-replace.js";
+import type {
+  CredentialEnvelopeLockProof,
+  SerializeCredentialEnvelopeMutation,
+} from "./credential-envelope-lock.js";
 import {
   assertWindowsPrivateFileAtPath,
   MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
@@ -165,7 +169,9 @@ interface CredentialVaultOptions {
   readonly clearCredential?: (
     slot: DesktopCredentialSlot,
   ) => Promise<"cleared" | "not-active" | "managed-by-environment">;
-  readonly observeEnvelopeRemoved?: () => Promise<void>;
+  readonly serializeEnvelopeMutation?: SerializeCredentialEnvelopeMutation;
+  readonly prepareEnvelopeWrite?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
+  readonly observeEnvelopeRemoved?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
   readonly renameCredentialFile?: typeof rename;
   readonly removeCredentialFile?: typeof rm;
   readonly readCredentialFile?: typeof readFile;
@@ -330,6 +336,12 @@ async function validTarget(
 }
 
 export function createCredentialVault(options: CredentialVaultOptions): CredentialVault {
+  if (
+    options.serializeEnvelopeMutation === undefined &&
+    (options.prepareEnvelopeWrite !== undefined || options.observeEnvelopeRemoved !== undefined)
+  ) {
+    throw new TypeError();
+  }
   const platform = options.platform ?? process.platform;
   const runtimeState =
     options.runtimeState ?? new Map<DesktopCredentialSlot, CredentialRuntimeState>();
@@ -407,6 +419,12 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
 
   const exclusive = <T>(operation: () => Promise<T>): Promise<T> =>
     serializeCredentialRoot(options.root, operation);
+  const envelopeExclusive = <T>(
+    operation: (proof: CredentialEnvelopeLockProof | undefined) => Promise<T>,
+  ): Promise<T> =>
+    options.serializeEnvelopeMutation === undefined
+      ? exclusive(() => operation(undefined))
+      : options.serializeEnvelopeMutation((proof) => exclusive(() => operation(proof)));
 
   const reconcileDurability = (): Promise<CredentialVaultDurabilityState> => {
     if (durabilityState !== "pending") return Promise.resolve(durabilityState);
@@ -819,13 +837,17 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
 
   return {
     writeCredential(input, behavior): Promise<CredentialWriteResult> {
-      return exclusive(() => writeCredential(input, behavior));
+      return envelopeExclusive(async (proof) => {
+        if (proof !== undefined) await options.prepareEnvelopeWrite?.(proof);
+        return await writeCredential(input, behavior);
+      });
     },
 
     runExclusiveMutation<T>(
       operation: (current: CredentialVaultMutation) => Promise<T>,
     ): Promise<T> {
-      return exclusive(async () => {
+      return envelopeExclusive(async (proof) => {
+        if (proof !== undefined) await options.prepareEnvelopeWrite?.(proof);
         let active = true;
         const mutation = Object.freeze({
           writeCredential(
@@ -883,7 +905,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     },
 
     deleteCredential(slot): Promise<CredentialDeleteResult> {
-      return exclusive(async () => {
+      return envelopeExclusive(async (proof) => {
         if (!isCredentialSlot(slot)) {
           return { slot: "anthropic", status: "refused", reason: "not-found" };
         }
@@ -921,9 +943,11 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
         }
         if (removed === "deleted" || removed === "cleanup-pending") {
           clearRuntimeState(slot);
-          try {
-            await options.observeEnvelopeRemoved?.();
-          } catch {}
+          if (proof !== undefined) {
+            try {
+              await options.observeEnvelopeRemoved?.(proof);
+            } catch {}
+          }
           return {
             slot,
             status: "deleted",

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -165,6 +165,7 @@ interface CredentialVaultOptions {
   readonly clearCredential?: (
     slot: DesktopCredentialSlot,
   ) => Promise<"cleared" | "not-active" | "managed-by-environment">;
+  readonly observeEnvelopeRemoved?: () => Promise<void>;
   readonly renameCredentialFile?: typeof rename;
   readonly removeCredentialFile?: typeof rm;
   readonly readCredentialFile?: typeof readFile;
@@ -920,6 +921,9 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
         }
         if (removed === "deleted" || removed === "cleanup-pending") {
           clearRuntimeState(slot);
+          try {
+            await options.observeEnvelopeRemoved?.();
+          } catch {}
           return {
             slot,
             status: "deleted",

--- a/apps/desktop/src/main/desktop-credential-encryption.ts
+++ b/apps/desktop/src/main/desktop-credential-encryption.ts
@@ -93,7 +93,12 @@ export async function prepareDesktopCredentialEncryption(
     service,
     async retireKeychainKey(): Promise<KeychainKeyRetirement | undefined> {
       if (selection.status !== "keychain") return undefined;
-      return await retireKeychainKeyWhenLastEnvelopeGone({ ...roots, transport, service });
+      return await retireKeychainKeyWhenLastEnvelopeGone({
+        ...roots,
+        transport,
+        service,
+        rotate: selection.rotateKey,
+      });
     },
   };
 }

--- a/apps/desktop/src/main/desktop-credential-encryption.ts
+++ b/apps/desktop/src/main/desktop-credential-encryption.ts
@@ -4,6 +4,10 @@ import {
   selectDesktopCredentialBackend,
   type DesktopCredentialBackendSelection,
 } from "./credential-backend-selection.js";
+import type {
+  CredentialEnvelopeLockProof,
+  SerializeCredentialEnvelopeMutation,
+} from "./credential-envelope-lock.js";
 import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
 import { createRefusingKeychainEncryption } from "./keychain-credential-encryption.js";
@@ -33,7 +37,8 @@ export interface DesktopCredentialEncryption {
   readonly encryption: CredentialEncryptionPort;
   readonly selection: DesktopCredentialBackendSelection;
   readonly service: string;
-  retireKeychainKey(): Promise<KeychainKeyRetirement | undefined>;
+  prepareEnvelopeWrite(proof: CredentialEnvelopeLockProof): Promise<void>;
+  retireKeychainKey(proof: CredentialEnvelopeLockProof): Promise<KeychainKeyRetirement | undefined>;
 }
 
 export interface PrepareDesktopCredentialEncryptionOptions extends CredentialEnvelopeRoots {
@@ -41,6 +46,7 @@ export interface PrepareDesktopCredentialEncryptionOptions extends CredentialEnv
   readonly safeStorage: CredentialEncryptionPort;
   readonly createTransport?: (helperPath: string) => KeychainHelperTransport;
   readonly helperIsExecutable?: (helperPath: string) => Promise<boolean>;
+  readonly serializeEnvelopeMutation: SerializeCredentialEnvelopeMutation;
 }
 
 async function helperIsExecutableFile(helperPath: string): Promise<boolean> {
@@ -69,8 +75,10 @@ export async function prepareDesktopCredentialEncryption(
       helperPath !== undefined &&
       (await (options.helperIsExecutable ?? helperIsExecutableFile)(helperPath));
     if (usableHelper && helperPath !== undefined) {
-      transport = (options.createTransport ??
-        ((path: string) => createKeychainHelperTransport({ helperPath: path })))(helperPath);
+      transport = (
+        options.createTransport ??
+        ((path: string) => createKeychainHelperTransport({ helperPath: path }))
+      )(helperPath);
     }
     selection = await selectDesktopCredentialBackend({
       ...roots,
@@ -78,6 +86,7 @@ export async function prepareDesktopCredentialEncryption(
       service,
       safeStorage: options.safeStorage,
       platform: options.location.platform,
+      serializeEnvelopeMutation: options.serializeEnvelopeMutation,
     });
   } catch {
     selection = {
@@ -91,13 +100,18 @@ export async function prepareDesktopCredentialEncryption(
     encryption: selection.encryption,
     selection,
     service,
-    async retireKeychainKey(): Promise<KeychainKeyRetirement | undefined> {
+    async prepareEnvelopeWrite(proof: CredentialEnvelopeLockProof): Promise<void> {
+      if (selection.status !== "keychain") return;
+      await selection.prepareKey(proof);
+    },
+    async retireKeychainKey(
+      proof: CredentialEnvelopeLockProof,
+    ): Promise<KeychainKeyRetirement | undefined> {
       if (selection.status !== "keychain") return undefined;
       return await retireKeychainKeyWhenLastEnvelopeGone({
         ...roots,
-        transport,
-        service,
-        rotate: selection.rotateKey,
+        lockProof: proof,
+        deleteKey: selection.deleteKey,
       });
     },
   };

--- a/apps/desktop/src/main/desktop-credential-encryption.ts
+++ b/apps/desktop/src/main/desktop-credential-encryption.ts
@@ -1,0 +1,99 @@
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
+import {
+  selectDesktopCredentialBackend,
+  type DesktopCredentialBackendSelection,
+} from "./credential-backend-selection.js";
+import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
+import type { CredentialEncryptionPort } from "./credential-vault.js";
+import { createRefusingKeychainEncryption } from "./keychain-credential-encryption.js";
+import {
+  KEYCHAIN_CREDENTIAL_SERVICE,
+  KEYCHAIN_CREDENTIAL_SERVICE_DEV,
+  createKeychainHelperTransport,
+  type KeychainHelperResponse,
+  type KeychainHelperTransport,
+} from "./keychain-helper.js";
+import { resolveKeychainHelperPath, type KeychainHelperLocation } from "./keychain-helper-path.js";
+import {
+  retireKeychainKeyWhenLastEnvelopeGone,
+  type KeychainKeyRetirement,
+} from "./keychain-key-lifetime.js";
+
+const UNAVAILABLE_HELPER_RESPONSE: KeychainHelperResponse = Object.freeze({
+  ok: false,
+  code: "not-team-signed",
+});
+
+export function desktopKeychainCredentialService(packaged: boolean): string {
+  return packaged ? KEYCHAIN_CREDENTIAL_SERVICE : KEYCHAIN_CREDENTIAL_SERVICE_DEV;
+}
+
+export interface DesktopCredentialEncryption {
+  readonly encryption: CredentialEncryptionPort;
+  readonly selection: DesktopCredentialBackendSelection;
+  readonly service: string;
+  retireKeychainKey(): Promise<KeychainKeyRetirement | undefined>;
+}
+
+export interface PrepareDesktopCredentialEncryptionOptions extends CredentialEnvelopeRoots {
+  readonly location: KeychainHelperLocation;
+  readonly safeStorage: CredentialEncryptionPort;
+  readonly createTransport?: (helperPath: string) => KeychainHelperTransport;
+  readonly helperIsExecutable?: (helperPath: string) => Promise<boolean>;
+}
+
+async function helperIsExecutableFile(helperPath: string): Promise<boolean> {
+  try {
+    await access(helperPath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function prepareDesktopCredentialEncryption(
+  options: PrepareDesktopCredentialEncryptionOptions,
+): Promise<DesktopCredentialEncryption> {
+  const service = desktopKeychainCredentialService(options.location.packaged);
+  const helperPath = resolveKeychainHelperPath(options.location);
+  const roots = {
+    credentialRoot: options.credentialRoot,
+    telegramRoot: options.telegramRoot,
+    readEnvelopeFile: options.readEnvelopeFile,
+  };
+  let transport: KeychainHelperTransport = { send: async () => UNAVAILABLE_HELPER_RESPONSE };
+  let selection: DesktopCredentialBackendSelection;
+  try {
+    const usableHelper =
+      helperPath !== undefined &&
+      (await (options.helperIsExecutable ?? helperIsExecutableFile)(helperPath));
+    if (usableHelper && helperPath !== undefined) {
+      transport = (options.createTransport ??
+        ((path: string) => createKeychainHelperTransport({ helperPath: path })))(helperPath);
+    }
+    selection = await selectDesktopCredentialBackend({
+      ...roots,
+      transport,
+      service,
+      safeStorage: options.safeStorage,
+      platform: options.location.platform,
+    });
+  } catch {
+    selection = {
+      status: "refused",
+      encryption: createRefusingKeychainEncryption("unknown", true),
+      reason: "storage-failed",
+      code: "unknown",
+    };
+  }
+  return {
+    encryption: selection.encryption,
+    selection,
+    service,
+    async retireKeychainKey(): Promise<KeychainKeyRetirement | undefined> {
+      if (selection.status !== "keychain") return undefined;
+      return await retireKeychainKeyWhenLastEnvelopeGone({ ...roots, transport, service });
+    },
+  };
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -69,6 +69,7 @@ import {
   type CredentialSlotStatus,
   type DesktopCredentialSlot,
 } from "./credential-vault.js";
+import { prepareDesktopCredentialEncryption } from "./desktop-credential-encryption.js";
 import {
   DesktopDaemonLifecycle,
   type DesktopDaemonConnection,
@@ -408,12 +409,40 @@ async function runDesktop(): Promise<void> {
     );
     const intervalsStorePath = join(selectedAthleteHome, "store", "store.db");
     requireDesktopDaemonHome(selectedAthleteHome, resolution.athleteHome);
+    const credentialRoot = join(app.getPath("userData"), CREDENTIAL_DIRECTORY_NAME);
+    const telegramCredentialRoot = join(
+      app.getPath("userData"),
+      TELEGRAM_CREDENTIAL_DIRECTORY_NAME,
+    );
+    const credentialEncryption = await prepareDesktopCredentialEncryption({
+      credentialRoot,
+      telegramRoot: telegramCredentialRoot,
+      location: {
+        platform: process.platform,
+        packaged: app.isPackaged,
+        resourcesPath: process.resourcesPath,
+        applicationPath: app.getAppPath(),
+      },
+      safeStorage,
+    });
+    const retireCredentialEncryptionKey = async (): Promise<void> => {
+      await credentialEncryption.retireKeychainKey();
+    };
+    if (process.platform === "darwin") {
+      const selected = credentialEncryption.selection;
+      process.stderr.write(
+        selected.status === "refused"
+          ? `desktop-credential-backend refused ${selected.reason} ${selected.code}\n`
+          : `desktop-credential-backend ${selected.status}\n`,
+      );
+    }
     const telegramSecureStorageDiagnostics = createTelegramSecureStorageDiagnostics();
     const telegramVault = createTelegramCredentialVault({
-      root: join(app.getPath("userData"), TELEGRAM_CREDENTIAL_DIRECTORY_NAME),
+      root: telegramCredentialRoot,
       athleteHome: selectedAthleteHome,
-      encryption: safeStorage,
+      encryption: credentialEncryption.encryption,
       observeSecureStorageFailure: telegramSecureStorageDiagnostics,
+      observeEnvelopeRemoved: retireCredentialEncryptionKey,
     });
     let activeTelegramBinding: TelegramDaemonBinding | undefined;
     const preparedTelegramBindings = new Map<number, TelegramDaemonBinding>();
@@ -433,7 +462,7 @@ async function runDesktop(): Promise<void> {
     });
     closeTelegramCoordinator = () => telegramCoordinator.close();
     telegramPower = createDesktopTelegramPowerLifecycle({
-      root: join(app.getPath("userData"), TELEGRAM_CREDENTIAL_DIRECTORY_NAME),
+      root: telegramCredentialRoot,
       athleteHome: selectedAthleteHome,
       powerMonitor,
       controller: telegramCoordinator,
@@ -674,10 +703,10 @@ async function runDesktop(): Promise<void> {
       }
       return page;
     };
-    const credentialRoot = join(app.getPath("userData"), CREDENTIAL_DIRECTORY_NAME);
     const vault = createCredentialVault({
       root: credentialRoot,
-      encryption: safeStorage,
+      encryption: credentialEncryption.encryption,
+      observeEnvelopeRemoved: retireCredentialEncryptionKey,
       runtimeState: credentialRuntimeState,
       onRuntimeStateChange: markCredentialRuntimeChange,
       createRuntimePublicationGuard(slot) {
@@ -754,7 +783,7 @@ async function runDesktop(): Promise<void> {
       const successor = createRuntimeBinding(connection);
       const successorVault = createCredentialVault({
         root: credentialRoot,
-        encryption: safeStorage,
+        encryption: credentialEncryption.encryption,
         async applyCredential(slot, value) {
           await successor.credentials.applyExplicit(runtimeConfigurationForCredential(slot, value));
         },

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -69,6 +69,10 @@ import {
   type CredentialSlotStatus,
   type DesktopCredentialSlot,
 } from "./credential-vault.js";
+import {
+  createCredentialEnvelopeMutationLock,
+  type CredentialEnvelopeLockProof,
+} from "./credential-envelope-lock.js";
 import { prepareDesktopCredentialEncryption } from "./desktop-credential-encryption.js";
 import {
   DesktopDaemonLifecycle,
@@ -414,6 +418,7 @@ async function runDesktop(): Promise<void> {
       app.getPath("userData"),
       TELEGRAM_CREDENTIAL_DIRECTORY_NAME,
     );
+    const serializeCredentialEnvelopeMutation = createCredentialEnvelopeMutationLock();
     const credentialEncryption = await prepareDesktopCredentialEncryption({
       credentialRoot,
       telegramRoot: telegramCredentialRoot,
@@ -424,9 +429,17 @@ async function runDesktop(): Promise<void> {
         applicationPath: app.getAppPath(),
       },
       safeStorage,
+      serializeEnvelopeMutation: serializeCredentialEnvelopeMutation,
     });
-    const retireCredentialEncryptionKey = async (): Promise<void> => {
-      await credentialEncryption.retireKeychainKey();
+    const prepareCredentialEnvelopeWrite = async (
+      proof: CredentialEnvelopeLockProof,
+    ): Promise<void> => {
+      await credentialEncryption.prepareEnvelopeWrite(proof);
+    };
+    const retireCredentialEncryptionKey = async (
+      proof: CredentialEnvelopeLockProof,
+    ): Promise<void> => {
+      await credentialEncryption.retireKeychainKey(proof);
     };
     if (process.platform === "darwin") {
       const selected = credentialEncryption.selection;
@@ -442,6 +455,8 @@ async function runDesktop(): Promise<void> {
       athleteHome: selectedAthleteHome,
       encryption: credentialEncryption.encryption,
       observeSecureStorageFailure: telegramSecureStorageDiagnostics,
+      serializeEnvelopeMutation: serializeCredentialEnvelopeMutation,
+      prepareEnvelopeWrite: prepareCredentialEnvelopeWrite,
       observeEnvelopeRemoved: retireCredentialEncryptionKey,
     });
     let activeTelegramBinding: TelegramDaemonBinding | undefined;
@@ -474,9 +489,7 @@ async function runDesktop(): Promise<void> {
     let windowCreation: Promise<BrowserWindow> | undefined;
     const rendererNavigationTracker = createDesktopRendererNavigationTracker<BrowserWindow>();
     const currentWindow = (): BrowserWindow | null =>
-      window !== null && !window.isDestroyed() && !window.webContents.isDestroyed()
-        ? window
-        : null;
+      window !== null && !window.isDestroyed() && !window.webContents.isDestroyed() ? window : null;
     const startRendererNavigation = (
       target: BrowserWindow,
       navigationUrl: string,
@@ -706,6 +719,8 @@ async function runDesktop(): Promise<void> {
     const vault = createCredentialVault({
       root: credentialRoot,
       encryption: credentialEncryption.encryption,
+      serializeEnvelopeMutation: serializeCredentialEnvelopeMutation,
+      prepareEnvelopeWrite: prepareCredentialEnvelopeWrite,
       observeEnvelopeRemoved: retireCredentialEncryptionKey,
       runtimeState: credentialRuntimeState,
       onRuntimeStateChange: markCredentialRuntimeChange,
@@ -1014,10 +1029,8 @@ async function runDesktop(): Promise<void> {
               shouldReleaseInitialRefreshForWindowEvent(
                 currentWindow(),
                 created,
-                connectionIpc?.isCurrentDocumentNavigation(
-                  created,
-                  created.webContents.getURL(),
-                ) ?? false,
+                connectionIpc?.isCurrentDocumentNavigation(created, created.webContents.getURL()) ??
+                  false,
               )
             ) {
               void initialRefreshCoordinator.releaseCurrent();

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -170,10 +170,38 @@ export async function createKeychainPartitionEncryption(
       : { status: "failed", code: "unknown" };
   };
 
+  const readMaterial = async (): Promise<
+    | Readonly<{ status: "ready"; key: Buffer }>
+    | Readonly<{ status: "missing" }>
+    | Readonly<{ status: "failed"; code: KeychainHelperErrorCode }>
+  > => {
+    const read = await transport.send({ op: "read-key", service });
+    if (!read.ok) {
+      return read.code === "item-not-found"
+        ? { status: "missing" }
+        : { status: "failed", code: read.code };
+    }
+    if (read.op !== "read-key") return { status: "failed", code: "unknown" };
+    const key = Buffer.from(read.key, "base64");
+    return key.length === KEYCHAIN_KEY_BYTES
+      ? { status: "ready", key }
+      : { status: "failed", code: "unknown" };
+  };
+
   const ready = (key: Buffer, createdKey: boolean): KeychainPartitionEncryptionResult => {
     const holder: KeyHolder = { key, failure: "item-not-found" };
     const prepareKey = async (): Promise<KeychainKeyPreparation> => {
       if (holder.key !== null) return { status: "ready" };
+      const existing = await readMaterial();
+      if (existing.status === "ready") {
+        holder.key = existing.key;
+        holder.failure = "item-not-found";
+        return { status: "ready" };
+      }
+      if (existing.status === "failed") {
+        holder.failure = existing.code;
+        return existing;
+      }
       const created = await createMaterial();
       if (created.status === "failed") {
         holder.failure = created.code;
@@ -189,7 +217,7 @@ export async function createKeychainPartitionEncryption(
       const deleted = await transport.send({ op: "delete-key", service });
       if (!deleted.ok || deleted.op !== "delete-key") {
         const code = deleted.ok ? "unknown" : deleted.code;
-        holder.key = previous;
+        previous?.fill(0);
         holder.failure = code;
         return { status: "failed", code };
       }
@@ -205,15 +233,10 @@ export async function createKeychainPartitionEncryption(
     return created.status === "ready" ? ready(created.key, true) : refused(created.code);
   };
 
-  const read = await transport.send({ op: "read-key", service });
-  if (read.ok) {
-    if (read.op !== "read-key") return refused("unknown");
-    const key = Buffer.from(read.key, "base64");
-    if (key.length !== KEYCHAIN_KEY_BYTES) return refused("unknown");
-    return ready(key, false);
-  }
-  if (read.code === "item-not-found") {
-    return options.dependentEnvelopes === 0 ? create() : refused(read.code);
+  const read = await readMaterial();
+  if (read.status === "ready") return ready(read.key, false);
+  if (read.status === "missing") {
+    return options.dependentEnvelopes === 0 ? create() : refused("item-not-found");
   }
   if (read.code !== "unreadable-item") return refused(read.code);
   if (options.dependentEnvelopes > 0) return refused(read.code);

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -1,4 +1,5 @@
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import type { CredentialEnvelopeLockProof } from "./credential-envelope-lock.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
 import {
   KEYCHAIN_KEY_BYTES,
@@ -61,7 +62,8 @@ export type KeychainPartitionEncryptionResult =
       readonly status: "ready";
       readonly encryption: CredentialEncryptionPort;
       readonly createdKey: boolean;
-      readonly rotateKey: () => Promise<KeychainKeyRotation>;
+      readonly prepareKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyPreparation>;
+      readonly deleteKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyDeletion>;
     }
   | {
       readonly status: "unavailable";
@@ -81,6 +83,8 @@ export type KeychainPartitionEncryptionResult =
 export interface CreateKeychainPartitionEncryptionOptions {
   readonly transport: KeychainHelperTransport;
   readonly service: string;
+  readonly dependentEnvelopes: number;
+  readonly lockProof: CredentialEnvelopeLockProof;
 }
 
 export function createRefusingKeychainEncryption(
@@ -98,8 +102,12 @@ export function createRefusingKeychainEncryption(
   };
 }
 
-export type KeychainKeyRotation =
-  | Readonly<{ status: "rotated" }>
+export type KeychainKeyPreparation =
+  | Readonly<{ status: "ready" }>
+  | Readonly<{ status: "failed"; code: KeychainHelperErrorCode }>;
+
+export type KeychainKeyDeletion =
+  | Readonly<{ status: "deleted" | "already-absent" }>
   | Readonly<{ status: "failed"; code: KeychainHelperErrorCode }>;
 
 interface KeyHolder {
@@ -121,7 +129,7 @@ function readyPort(holder: KeyHolder): CredentialEncryptionPort {
 }
 
 function refused(code: KeychainHelperErrorCode): KeychainPartitionEncryptionResult {
-  if (code === "keychain-locked") {
+  if (code === "keychain-locked" || code === "uninspectable-item" || code === "item-not-found") {
     return {
       status: "unavailable",
       code,
@@ -149,38 +157,52 @@ export async function createKeychainPartitionEncryption(
     return refused("unknown");
   }
 
+  const createMaterial = async (): Promise<
+    | Readonly<{ status: "ready"; key: Buffer }>
+    | Readonly<{ status: "failed"; code: KeychainHelperErrorCode }>
+  > => {
+    const created = await transport.send({ op: "create-key", service });
+    if (!created.ok) return { status: "failed", code: created.code };
+    if (created.op !== "create-key") return { status: "failed", code: "unknown" };
+    const key = Buffer.from(created.key, "base64");
+    return key.length === KEYCHAIN_KEY_BYTES
+      ? { status: "ready", key }
+      : { status: "failed", code: "unknown" };
+  };
+
   const ready = (key: Buffer, createdKey: boolean): KeychainPartitionEncryptionResult => {
-    const holder: KeyHolder = { key, failure: "unknown" };
-    const rotateKey = async (): Promise<KeychainKeyRotation> => {
-      const deleted = await transport.send({ op: "delete-key", service });
-      if (!deleted.ok) return { status: "failed", code: deleted.code };
-      if (deleted.op !== "delete-key") return { status: "failed", code: "unknown" };
-      const created = await transport.send({ op: "create-key", service });
-      const failure = created.ok ? "unknown" : created.code;
-      if (!created.ok || created.op !== "create-key") {
-        holder.key = null;
-        holder.failure = failure;
-        return { status: "failed", code: failure };
+    const holder: KeyHolder = { key, failure: "item-not-found" };
+    const prepareKey = async (): Promise<KeychainKeyPreparation> => {
+      if (holder.key !== null) return { status: "ready" };
+      const created = await createMaterial();
+      if (created.status === "failed") {
+        holder.failure = created.code;
+        return created;
       }
-      const next = Buffer.from(created.key, "base64");
-      if (next.length !== KEYCHAIN_KEY_BYTES) {
-        holder.key = null;
-        holder.failure = "unknown";
-        return { status: "failed", code: "unknown" };
-      }
-      holder.key = next;
-      return { status: "rotated" };
+      holder.key = created.key;
+      holder.failure = "item-not-found";
+      return { status: "ready" };
     };
-    return { status: "ready", encryption: readyPort(holder), createdKey, rotateKey };
+    const deleteKey = async (): Promise<KeychainKeyDeletion> => {
+      const previous = holder.key;
+      holder.key = null;
+      const deleted = await transport.send({ op: "delete-key", service });
+      if (!deleted.ok || deleted.op !== "delete-key") {
+        const code = deleted.ok ? "unknown" : deleted.code;
+        holder.key = previous;
+        holder.failure = code;
+        return { status: "failed", code };
+      }
+      previous?.fill(0);
+      holder.failure = "item-not-found";
+      return { status: deleted.deleted ? "deleted" : "already-absent" };
+    };
+    return { status: "ready", encryption: readyPort(holder), createdKey, prepareKey, deleteKey };
   };
 
   const create = async (): Promise<KeychainPartitionEncryptionResult> => {
-    const created = await transport.send({ op: "create-key", service });
-    if (!created.ok) return refused(created.code);
-    if (created.op !== "create-key") return refused("unknown");
-    const key = Buffer.from(created.key, "base64");
-    if (key.length !== KEYCHAIN_KEY_BYTES) return refused("unknown");
-    return ready(key, true);
+    const created = await createMaterial();
+    return created.status === "ready" ? ready(created.key, true) : refused(created.code);
   };
 
   const read = await transport.send({ op: "read-key", service });
@@ -190,8 +212,11 @@ export async function createKeychainPartitionEncryption(
     if (key.length !== KEYCHAIN_KEY_BYTES) return refused("unknown");
     return ready(key, false);
   }
-  if (read.code === "item-not-found") return create();
+  if (read.code === "item-not-found") {
+    return options.dependentEnvelopes === 0 ? create() : refused(read.code);
+  }
   if (read.code !== "unreadable-item") return refused(read.code);
+  if (options.dependentEnvelopes > 0) return refused(read.code);
 
   const deleted = await transport.send({ op: "delete-key", service });
   if (!deleted.ok) return refused(deleted.code);

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -61,6 +61,7 @@ export type KeychainPartitionEncryptionResult =
       readonly status: "ready";
       readonly encryption: CredentialEncryptionPort;
       readonly createdKey: boolean;
+      readonly rotateKey: () => Promise<KeychainKeyRotation>;
     }
   | {
       readonly status: "unavailable";
@@ -97,11 +98,24 @@ export function createRefusingKeychainEncryption(
   };
 }
 
-function readyPort(key: Buffer): CredentialEncryptionPort {
+export type KeychainKeyRotation =
+  | Readonly<{ status: "rotated" }>
+  | Readonly<{ status: "failed"; code: KeychainHelperErrorCode }>;
+
+interface KeyHolder {
+  key: Buffer | null;
+  failure: KeychainHelperErrorCode;
+}
+
+function readyPort(holder: KeyHolder): CredentialEncryptionPort {
+  const currentKey = (): Buffer => {
+    if (holder.key === null) throw new KeychainEncryptionError(holder.failure);
+    return holder.key;
+  };
   return {
-    isEncryptionAvailable: () => true,
-    encryptString: (value: string) => sealCredentialEnvelope(key, value),
-    decryptString: (envelope: Buffer) => openCredentialEnvelope(key, envelope),
+    isEncryptionAvailable: () => holder.key !== null,
+    encryptString: (value: string) => sealCredentialEnvelope(currentKey(), value),
+    decryptString: (envelope: Buffer) => openCredentialEnvelope(currentKey(), envelope),
     getSelectedStorageBackend: () => KEYCHAIN_PARTITION_STORAGE_BACKEND,
   };
 }
@@ -135,13 +149,38 @@ export async function createKeychainPartitionEncryption(
     return refused("unknown");
   }
 
+  const ready = (key: Buffer, createdKey: boolean): KeychainPartitionEncryptionResult => {
+    const holder: KeyHolder = { key, failure: "unknown" };
+    const rotateKey = async (): Promise<KeychainKeyRotation> => {
+      const deleted = await transport.send({ op: "delete-key", service });
+      if (!deleted.ok) return { status: "failed", code: deleted.code };
+      if (deleted.op !== "delete-key") return { status: "failed", code: "unknown" };
+      const created = await transport.send({ op: "create-key", service });
+      const failure = created.ok ? "unknown" : created.code;
+      if (!created.ok || created.op !== "create-key") {
+        holder.key = null;
+        holder.failure = failure;
+        return { status: "failed", code: failure };
+      }
+      const next = Buffer.from(created.key, "base64");
+      if (next.length !== KEYCHAIN_KEY_BYTES) {
+        holder.key = null;
+        holder.failure = "unknown";
+        return { status: "failed", code: "unknown" };
+      }
+      holder.key = next;
+      return { status: "rotated" };
+    };
+    return { status: "ready", encryption: readyPort(holder), createdKey, rotateKey };
+  };
+
   const create = async (): Promise<KeychainPartitionEncryptionResult> => {
     const created = await transport.send({ op: "create-key", service });
     if (!created.ok) return refused(created.code);
     if (created.op !== "create-key") return refused("unknown");
     const key = Buffer.from(created.key, "base64");
     if (key.length !== KEYCHAIN_KEY_BYTES) return refused("unknown");
-    return { status: "ready", encryption: readyPort(key), createdKey: true };
+    return ready(key, true);
   };
 
   const read = await transport.send({ op: "read-key", service });
@@ -149,7 +188,7 @@ export async function createKeychainPartitionEncryption(
     if (read.op !== "read-key") return refused("unknown");
     const key = Buffer.from(read.key, "base64");
     if (key.length !== KEYCHAIN_KEY_BYTES) return refused("unknown");
-    return { status: "ready", encryption: readyPort(key), createdKey: false };
+    return ready(key, false);
   }
   if (read.code === "item-not-found") return create();
   if (read.code !== "unreadable-item") return refused(read.code);

--- a/apps/desktop/src/main/keychain-helper.ts
+++ b/apps/desktop/src/main/keychain-helper.ts
@@ -13,6 +13,7 @@ export const KEYCHAIN_HELPER_ERROR_CODES = [
   "keychain-locked",
   "duplicate-item",
   "unreadable-item",
+  "uninspectable-item",
   "unknown",
 ] as const;
 

--- a/apps/desktop/src/main/keychain-key-lifetime.ts
+++ b/apps/desktop/src/main/keychain-key-lifetime.ts
@@ -2,20 +2,19 @@ import {
   scanCredentialEnvelopes,
   type CredentialEnvelopeRoots,
 } from "./credential-envelope-inventory.js";
-import type { KeychainHelperErrorCode, KeychainHelperTransport } from "./keychain-helper.js";
-import type { KeychainKeyRotation } from "./keychain-credential-encryption.js";
+import type { CredentialEnvelopeLockProof } from "./credential-envelope-lock.js";
+import type { KeychainKeyDeletion } from "./keychain-credential-encryption.js";
+import type { KeychainHelperErrorCode } from "./keychain-helper.js";
 
 export type KeychainKeyRetirement =
   | Readonly<{ status: "retained"; envelopes: number }>
   | Readonly<{ status: "deleted" }>
-  | Readonly<{ status: "rotated" }>
   | Readonly<{ status: "already-absent" }>
   | Readonly<{ status: "failed"; code: KeychainHelperErrorCode }>;
 
 export interface RetireKeychainKeyOptions extends CredentialEnvelopeRoots {
-  readonly transport: KeychainHelperTransport;
-  readonly service: string;
-  readonly rotate?: () => Promise<KeychainKeyRotation>;
+  readonly lockProof: CredentialEnvelopeLockProof;
+  readonly deleteKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyDeletion>;
 }
 
 export async function retireKeychainKeyWhenLastEnvelopeGone(
@@ -25,14 +24,5 @@ export async function retireKeychainKeyWhenLastEnvelopeGone(
   if (inventory.envelopes.length > 0) {
     return { status: "retained", envelopes: inventory.envelopes.length };
   }
-  if (options.rotate !== undefined) {
-    const rotated = await options.rotate();
-    return rotated.status === "rotated"
-      ? { status: "rotated" }
-      : { status: "failed", code: rotated.code };
-  }
-  const deleted = await options.transport.send({ op: "delete-key", service: options.service });
-  if (!deleted.ok) return { status: "failed", code: deleted.code };
-  if (deleted.op !== "delete-key") return { status: "failed", code: "unknown" };
-  return deleted.deleted ? { status: "deleted" } : { status: "already-absent" };
+  return await options.deleteKey(options.lockProof);
 }

--- a/apps/desktop/src/main/keychain-key-lifetime.ts
+++ b/apps/desktop/src/main/keychain-key-lifetime.ts
@@ -3,16 +3,19 @@ import {
   type CredentialEnvelopeRoots,
 } from "./credential-envelope-inventory.js";
 import type { KeychainHelperErrorCode, KeychainHelperTransport } from "./keychain-helper.js";
+import type { KeychainKeyRotation } from "./keychain-credential-encryption.js";
 
 export type KeychainKeyRetirement =
   | Readonly<{ status: "retained"; envelopes: number }>
   | Readonly<{ status: "deleted" }>
+  | Readonly<{ status: "rotated" }>
   | Readonly<{ status: "already-absent" }>
   | Readonly<{ status: "failed"; code: KeychainHelperErrorCode }>;
 
 export interface RetireKeychainKeyOptions extends CredentialEnvelopeRoots {
   readonly transport: KeychainHelperTransport;
   readonly service: string;
+  readonly rotate?: () => Promise<KeychainKeyRotation>;
 }
 
 export async function retireKeychainKeyWhenLastEnvelopeGone(
@@ -21,6 +24,12 @@ export async function retireKeychainKeyWhenLastEnvelopeGone(
   const inventory = await scanCredentialEnvelopes(options);
   if (inventory.envelopes.length > 0) {
     return { status: "retained", envelopes: inventory.envelopes.length };
+  }
+  if (options.rotate !== undefined) {
+    const rotated = await options.rotate();
+    return rotated.status === "rotated"
+      ? { status: "rotated" }
+      : { status: "failed", code: rotated.code };
   }
   const deleted = await options.transport.send({ op: "delete-key", service: options.service });
   if (!deleted.ok) return { status: "failed", code: deleted.code };

--- a/apps/desktop/src/main/platform-copy.ts
+++ b/apps/desktop/src/main/platform-copy.ts
@@ -21,7 +21,7 @@ const DARWIN_PLATFORM_PROJECTION: DesktopPlatformProjection = Object.freeze({
     operatingSystem: "macOS",
     credentialEncryptionUnavailable:
       "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
-    credentialRecoveryAction: "unlock or approve Keychain access",
+    credentialRecoveryAction: "unlock your login keychain",
     restartComputer: "restart your Mac",
     rideImportDescription:
       "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.",

--- a/apps/desktop/src/main/telegram-credential-vault.ts
+++ b/apps/desktop/src/main/telegram-credential-vault.ts
@@ -19,6 +19,10 @@ import {
   type WindowsPrivateDirectoryBinding,
 } from "@enduragent/core";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
+import type {
+  CredentialEnvelopeLockProof,
+  SerializeCredentialEnvelopeMutation,
+} from "./credential-envelope-lock.js";
 import {
   durablyReplaceReversible,
   type ReversibleDurableReplaceOutcome,
@@ -148,7 +152,9 @@ export interface TelegramCredentialVaultOptions {
   readonly syncDirectory?: (root: string) => Promise<void>;
   readonly syncParentDirectory?: (root: string) => Promise<void>;
   readonly observeSecureStorageFailure?: TelegramSecureStorageObserver;
-  readonly observeEnvelopeRemoved?: () => Promise<void>;
+  readonly serializeEnvelopeMutation?: SerializeCredentialEnvelopeMutation;
+  readonly prepareEnvelopeWrite?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
+  readonly observeEnvelopeRemoved?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
   readonly platform?: NodeJS.Platform;
   readonly openFile?: typeof open;
 }
@@ -372,6 +378,12 @@ async function syncDirectory(root: string): Promise<void> {
 export function createTelegramCredentialVault(
   options: TelegramCredentialVaultOptions,
 ): TelegramCredentialVault {
+  if (
+    options.serializeEnvelopeMutation === undefined &&
+    (options.prepareEnvelopeWrite !== undefined || options.observeEnvelopeRemoved !== undefined)
+  ) {
+    throw new TypeError();
+  }
   if (typeof options.root !== "string" || options.root.length === 0) {
     throw new TypeError("invalid Telegram credential vault root");
   }
@@ -439,6 +451,12 @@ export function createTelegramCredentialVault(
     );
     return result;
   };
+  const envelopeExclusive = <T>(
+    operation: (proof: CredentialEnvelopeLockProof | undefined) => Promise<T>,
+  ): Promise<T> =>
+    options.serializeEnvelopeMutation === undefined
+      ? exclusive(() => operation(undefined))
+      : options.serializeEnvelopeMutation((proof) => exclusive(() => operation(proof)));
 
   const reconcileOwnedTransients = async (forceSync: boolean): Promise<boolean> => {
     const directory = await secureDirectoryState(options.root, platform, bindCredentialDirectory);
@@ -749,7 +767,8 @@ export function createTelegramCredentialVault(
     },
 
     replaceProfile(input): Promise<TelegramProfileReplaceResult> {
-      return exclusive(async () => {
+      return envelopeExclusive(async (proof) => {
+        if (proof !== undefined) await options.prepareEnvelopeWrite?.(proof);
         const authenticatedAthleteHome = parseAthleteHome(input?.authenticatedAthleteHome);
         if (authenticatedAthleteHome === undefined || authenticatedAthleteHome !== athleteHome) {
           return { outcome: "refused", reason: "wrong-home" };
@@ -875,7 +894,7 @@ export function createTelegramCredentialVault(
     },
 
     deleteProfile(): Promise<TelegramProfileDeleteResult> {
-      return exclusive(async () => {
+      return envelopeExclusive(async (proof) => {
         if (!(await prepareNamespace())) {
           return { outcome: "uncertain", reason: "storage-uncertain" };
         }
@@ -893,9 +912,11 @@ export function createTelegramCredentialVault(
         }
         const removed = await removeStoredProfile();
         if (removed === "deleted" || removed === "cleanup-pending") {
-          try {
-            await options.observeEnvelopeRemoved?.();
-          } catch {}
+          if (proof !== undefined) {
+            try {
+              await options.observeEnvelopeRemoved?.(proof);
+            } catch {}
+          }
           return { outcome: "applied", cleanupPending: removed === "cleanup-pending" };
         }
         if (removed === "uncertain") profileUncertain = true;

--- a/apps/desktop/src/main/telegram-credential-vault.ts
+++ b/apps/desktop/src/main/telegram-credential-vault.ts
@@ -148,6 +148,7 @@ export interface TelegramCredentialVaultOptions {
   readonly syncDirectory?: (root: string) => Promise<void>;
   readonly syncParentDirectory?: (root: string) => Promise<void>;
   readonly observeSecureStorageFailure?: TelegramSecureStorageObserver;
+  readonly observeEnvelopeRemoved?: () => Promise<void>;
   readonly platform?: NodeJS.Platform;
   readonly openFile?: typeof open;
 }
@@ -892,6 +893,9 @@ export function createTelegramCredentialVault(
         }
         const removed = await removeStoredProfile();
         if (removed === "deleted" || removed === "cleanup-pending") {
+          try {
+            await options.observeEnvelopeRemoved?.();
+          } catch {}
           return { outcome: "applied", cleanupPending: removed === "cleanup-pending" };
         }
         if (removed === "uncertain") profileUncertain = true;

--- a/apps/desktop/tests/credential-backend-selection.test.ts
+++ b/apps/desktop/tests/credential-backend-selection.test.ts
@@ -8,6 +8,7 @@ import {
   selectDesktopCredentialBackend,
   type SelectDesktopCredentialBackendOptions,
 } from "../src/main/credential-backend-selection.js";
+import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import {
   createCredentialVault,
   type CredentialEncryptionPort,
@@ -95,10 +96,15 @@ function readKey(key: Buffer): KeychainHelperResponse {
 }
 
 async function keychainEncryption(key: Buffer): Promise<CredentialEncryptionPort> {
-  const result = await createKeychainPartitionEncryption({
-    transport: transportOf(PROBE_OK, readKey(key)),
-    service: KEYCHAIN_CREDENTIAL_SERVICE,
-  });
+  const serialize = createCredentialEnvelopeMutationLock();
+  const result = await serialize((lockProof) =>
+    createKeychainPartitionEncryption({
+      transport: transportOf(PROBE_OK, readKey(key)),
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+      dependentEnvelopes: 0,
+      lockProof,
+    }),
+  );
   if (result.status !== "ready") throw new TypeError();
   return result.encryption;
 }
@@ -114,6 +120,7 @@ function selection(
     service: KEYCHAIN_CREDENTIAL_SERVICE,
     safeStorage: safeStorage(),
     platform: "darwin",
+    serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
   };
 }
 
@@ -313,27 +320,30 @@ describe("mandatory keychain rule", () => {
     await expect(readFile(join(roots.credentialRoot, "anthropic.bin"))).resolves.toEqual(migrated);
   });
 
-  posixIt("reports a broken helper as encryption-unavailable once an envelope is migrated", async () => {
-    const roots = await fixture();
-    const legacy = safeStorage();
-    const key = randomBytes(KEYCHAIN_KEY_BYTES);
-    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
-    await selectDesktopCredentialBackend({
-      ...selection(roots, transportOf(PROBE_OK, readKey(key))),
-      safeStorage: legacy,
-    });
+  posixIt(
+    "reports a broken helper as encryption-unavailable once an envelope is migrated",
+    async () => {
+      const roots = await fixture();
+      const legacy = safeStorage();
+      const key = randomBytes(KEYCHAIN_KEY_BYTES);
+      await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
+      await selectDesktopCredentialBackend({
+        ...selection(roots, transportOf(PROBE_OK, readKey(key))),
+        safeStorage: legacy,
+      });
 
-    const selected = await selectDesktopCredentialBackend({
-      ...selection(roots, transportOf({ ok: false, code: "unknown" })),
-      safeStorage: legacy,
-    });
+      const selected = await selectDesktopCredentialBackend({
+        ...selection(roots, transportOf({ ok: false, code: "unknown" })),
+        safeStorage: legacy,
+      });
 
-    expect(selected.status).toBe("refused");
-    if (selected.status !== "refused") return;
-    expect(selected.reason).toBe("encryption-unavailable");
-    expect(selected.code).toBe("unknown");
-    expect(selected.encryption.isEncryptionAvailable()).toBe(false);
-  });
+      expect(selected.status).toBe("refused");
+      if (selected.status !== "refused") return;
+      expect(selected.reason).toBe("encryption-unavailable");
+      expect(selected.code).toBe("unknown");
+      expect(selected.encryption.isEncryptionAvailable()).toBe(false);
+    },
+  );
 
   posixIt("keeps a broken helper as storage-failed before any envelope is migrated", async () => {
     const roots = await fixture();
@@ -410,13 +420,15 @@ describe("keychain failure mapping", () => {
     expect(keychainFailureRefusal("duplicate-item", false)).toBe("storage-failed");
     expect(keychainFailureRefusal("unreadable-item", false)).toBe("storage-failed");
     expect(keychainFailureRefusal("item-not-found", false)).toBe("storage-failed");
+    expect(keychainFailureRefusal("uninspectable-item", false)).toBe("encryption-unavailable");
     expect(keychainFailureRefusal("unknown", false)).toBe("storage-failed");
     expect(keychainFailureRefusal("keychain-locked", true)).toBe("encryption-unavailable");
     expect(keychainFailureRefusal("not-team-signed", true)).toBe("encryption-unavailable");
     expect(keychainFailureRefusal("unknown", true)).toBe("encryption-unavailable");
     expect(keychainFailureRefusal("duplicate-item", true)).toBe("storage-failed");
-    expect(keychainFailureRefusal("unreadable-item", true)).toBe("storage-failed");
-    expect(keychainFailureRefusal("item-not-found", true)).toBe("storage-failed");
+    expect(keychainFailureRefusal("unreadable-item", true)).toBe("encryption-unavailable");
+    expect(keychainFailureRefusal("item-not-found", true)).toBe("encryption-unavailable");
+    expect(keychainFailureRefusal("uninspectable-item", true)).toBe("encryption-unavailable");
   });
 
   posixIt("maps a locked keychain onto encryption-unavailable in both vaults", async () => {
@@ -482,36 +494,37 @@ describe("keychain failure mapping", () => {
     ).resolves.toEqual({ outcome: "refused", reason: "storage-failed" });
   });
 
-  posixIt("recreates a poisoned item and re-prompts the envelopes under the old key", async () => {
+  posixIt("preserves an invalid item while dependent envelopes need recovery", async () => {
     const roots = await fixture();
     const retired = await keychainEncryption(randomBytes(KEYCHAIN_KEY_BYTES));
     await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", retired);
     await seedProfile(roots, "synthetic-token", retired);
-    const transport = transportOf(
-      PROBE_OK,
-      { ok: false, code: "unreadable-item" },
-      { ok: true, op: "delete-key", deleted: true },
-      { ok: true, op: "create-key", key: randomBytes(KEYCHAIN_KEY_BYTES).toString("base64") },
-    );
+    const transport = transportOf(PROBE_OK, { ok: false, code: "unreadable-item" });
 
     const selected = await selectDesktopCredentialBackend(selection(roots, transport));
 
-    expect(selected.status).toBe("keychain");
-    if (selected.status !== "keychain") return;
-    expect(selected.createdKey).toBe(true);
-    expect(transport.requests.map((request) => request.op)).toEqual([
-      "probe",
-      "read-key",
-      "delete-key",
-      "create-key",
-    ]);
-    await expect(credentialVault(roots, selected.encryption).credentialStatuses()).resolves.toEqual(
-      expect.arrayContaining([{ slot: "anthropic", state: "re-prompt", runtimeState: null }]),
-    );
-    await expect(telegramVault(roots, selected.encryption).profileStatus()).resolves.toEqual({
-      state: "re-prompt",
-      reason: "storage-failed",
+    expect(selected).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "unreadable-item",
     });
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
+  });
+
+  posixIt("preserves missing-key envelopes for explicit recovery", async () => {
+    const roots = await fixture();
+    const retired = await keychainEncryption(randomBytes(KEYCHAIN_KEY_BYTES));
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", retired);
+    const transport = transportOf(PROBE_OK, { ok: false, code: "item-not-found" });
+
+    const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+    expect(selected).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "item-not-found",
+    });
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
   });
 
   posixIt("keeps a partly migrated vault readable and writes only keychain envelopes", async () => {

--- a/apps/desktop/tests/credential-backend-selection.test.ts
+++ b/apps/desktop/tests/credential-backend-selection.test.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { mkdir, mkdtemp, readFile, realpath, rename, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -16,6 +16,7 @@ import {
 } from "../src/main/credential-vault.js";
 import { credentialEnvelopeKeyId } from "../src/main/credential-envelope-inventory.js";
 import {
+  CREDENTIAL_ENVELOPE_MAGIC,
   KEYCHAIN_ENVELOPE_KEY_ID,
   KEYCHAIN_PARTITION_STORAGE_BACKEND,
   SAFE_STORAGE_ENVELOPE_KEY_ID,
@@ -537,6 +538,54 @@ describe("keychain failure mapping", () => {
     });
     expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
   });
+
+  posixIt(
+    "preserves an unrecognized envelope when legacy decryption cannot prove ownership",
+    async () => {
+      const roots = await fixture();
+      const retired = await keychainEncryption(randomBytes(KEYCHAIN_KEY_BYTES));
+      await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", retired);
+      const path = join(roots.credentialRoot, "anthropic.bin");
+      const damaged = await readFile(path);
+      damaged[0] ^= 0xff;
+      await writeFile(path, damaged);
+      damaged.fill(0);
+      const transport = transportOf(PROBE_OK, { ok: false, code: "unreadable-item" });
+
+      const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+      expect(selected).toMatchObject({
+        status: "refused",
+        reason: "encryption-unavailable",
+        code: "unreadable-item",
+      });
+      expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
+    },
+  );
+
+  posixIt(
+    "preserves a key-id zero envelope when legacy decryption cannot prove ownership",
+    async () => {
+      const roots = await fixture();
+      const retired = await keychainEncryption(randomBytes(KEYCHAIN_KEY_BYTES));
+      await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", retired);
+      const path = join(roots.credentialRoot, "anthropic.bin");
+      const damaged = await readFile(path);
+      damaged[CREDENTIAL_ENVELOPE_MAGIC.length] = SAFE_STORAGE_ENVELOPE_KEY_ID;
+      await writeFile(path, damaged);
+      damaged.fill(0);
+      const transport = transportOf(PROBE_OK, { ok: false, code: "unreadable-item" });
+
+      const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+      expect(selected).toMatchObject({
+        status: "refused",
+        reason: "encryption-unavailable",
+        code: "unreadable-item",
+      });
+      expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
+    },
+  );
 
   posixIt("keeps a partly migrated vault readable and writes only keychain envelopes", async () => {
     const roots = await fixture();

--- a/apps/desktop/tests/credential-backend-selection.test.ts
+++ b/apps/desktop/tests/credential-backend-selection.test.ts
@@ -229,10 +229,16 @@ describe("backend selection", () => {
   posixIt("migrates eagerly at the first startup on the keychain backend", async () => {
     const roots = await fixture();
     const legacy = safeStorage();
+    const key = randomBytes(KEYCHAIN_KEY_BYTES);
     await seedCredential(roots.credentialRoot, "anthropic", "sk-anthropic", legacy);
     await seedProfile(roots, "synthetic-token", legacy);
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: false, code: "item-not-found" },
+      { ok: true, op: "create-key", key: key.toString("base64") },
+    );
     const options = {
-      ...selection(roots, transportOf(PROBE_OK, readKey(randomBytes(KEYCHAIN_KEY_BYTES)))),
+      ...selection(roots, transport),
       safeStorage: legacy,
     };
 
@@ -255,6 +261,11 @@ describe("backend selection", () => {
     await expect(telegramVault(roots, selected.encryption).profileStatus()).resolves.toMatchObject({
       state: "configured",
     });
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "create-key",
+    ]);
   });
 });
 

--- a/apps/desktop/tests/credential-key-migration.test.ts
+++ b/apps/desktop/tests/credential-key-migration.test.ts
@@ -174,7 +174,16 @@ describe("credential envelope inventory", () => {
     await seedCredential(roots.credentialRoot, "openrouter", "sk-migrated", keychain);
     await seedProfile(roots, "synthetic-token", legacy.port);
 
-    const inventory = await scanCredentialEnvelopes(roots);
+    const inventory = await scanCredentialEnvelopes({
+      ...roots,
+      classifyLegacyEnvelope(envelope) {
+        try {
+          return legacy.port.decryptString(envelope).length > 0;
+        } catch {
+          return false;
+        }
+      },
+    });
 
     expect(inventory.envelopes.map((envelope) => envelope.fileName)).toEqual([
       "anthropic.bin",
@@ -197,13 +206,45 @@ describe("credential envelope inventory", () => {
     await seedCredential(roots.credentialRoot, "anthropic", "sk-legacy", legacy.port);
     await seedProfile(roots, "synthetic-token", legacy.port);
 
-    await expect(scanCredentialEnvelopes(roots)).resolves.toMatchObject({
+    await expect(
+      scanCredentialEnvelopes({
+        ...roots,
+        classifyLegacyEnvelope(envelope) {
+          try {
+            return legacy.port.decryptString(envelope).length > 0;
+          } catch {
+            return false;
+          }
+        },
+      }),
+    ).resolves.toMatchObject({
       keychainRequired: false,
       migrated: 0,
     });
     await expect(scanCredentialEnvelopes(await fixture())).resolves.toMatchObject({
       keychainRequired: false,
       envelopes: [],
+    });
+  });
+
+  posixIt("requires positive legacy decryption before excluding an unknown envelope", async () => {
+    const roots = await fixture();
+    const legacy = safeStorage();
+    await seedCredential(roots.credentialRoot, "anthropic", "sk-legacy", legacy.port);
+
+    await expect(scanCredentialEnvelopes(roots)).resolves.toMatchObject({
+      keychainRequired: true,
+      legacy: [],
+      unreadable: 1,
+    });
+    await expect(
+      scanCredentialEnvelopes({
+        ...roots,
+        classifyLegacyEnvelope: (envelope) => legacy.port.decryptString(envelope).length > 0,
+      }),
+    ).resolves.toMatchObject({
+      keychainRequired: false,
+      unreadable: 0,
     });
   });
 

--- a/apps/desktop/tests/credential-key-migration.test.ts
+++ b/apps/desktop/tests/credential-key-migration.test.ts
@@ -12,6 +12,7 @@ import {
   credentialEnvelopeKeyId,
   scanCredentialEnvelopes,
 } from "../src/main/credential-envelope-inventory.js";
+import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import {
   createLegacyReadFallbackEncryption,
   migrateCredentialEnvelopes,
@@ -92,13 +93,18 @@ function transportOf(...responses: readonly KeychainHelperResponse[]): KeychainH
 async function keychainEncryption(
   key: Buffer = randomBytes(KEYCHAIN_KEY_BYTES),
 ): Promise<CredentialEncryptionPort> {
-  const result = await createKeychainPartitionEncryption({
-    transport: transportOf(
-      { ok: true, op: "probe", teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER },
-      { ok: true, op: "read-key", key: key.toString("base64") },
-    ),
-    service: KEYCHAIN_CREDENTIAL_SERVICE,
-  });
+  const serialize = createCredentialEnvelopeMutationLock();
+  const result = await serialize((lockProof) =>
+    createKeychainPartitionEncryption({
+      transport: transportOf(
+        { ok: true, op: "probe", teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER },
+        { ok: true, op: "read-key", key: key.toString("base64") },
+      ),
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+      dependentEnvelopes: 0,
+      lockProof,
+    }),
+  );
   if (result.status !== "ready") throw new TypeError();
   return result.encryption;
 }

--- a/apps/desktop/tests/credential-key-retirement.test.ts
+++ b/apps/desktop/tests/credential-key-retirement.test.ts
@@ -8,6 +8,10 @@ import {
   type CredentialEncryptionPort,
 } from "../src/main/credential-vault.js";
 import {
+  createCredentialEnvelopeMutationLock,
+  type CredentialEnvelopeLockProof,
+} from "../src/main/credential-envelope-lock.js";
+import {
   openCredentialEnvelope,
   sealCredentialEnvelope,
 } from "../src/main/keychain-credential-encryption.js";
@@ -69,21 +73,39 @@ function transportOf(...responses: readonly KeychainHelperResponse[]) {
   };
 }
 
+async function retireKey(
+  roots: Fixture,
+  transport: ReturnType<typeof transportOf>,
+  lockProof: CredentialEnvelopeLockProof,
+) {
+  return await retireKeychainKeyWhenLastEnvelopeGone({
+    ...roots,
+    lockProof,
+    deleteKey: async () => {
+      const deleted = await transport.send({
+        op: "delete-key",
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+      });
+      if (!deleted.ok) return { status: "failed", code: deleted.code };
+      if (deleted.op !== "delete-key") return { status: "failed", code: "unknown" };
+      return { status: deleted.deleted ? "deleted" : "already-absent" };
+    },
+  });
+}
+
 describe("keychain key retirement call sites", () => {
   posixIt("retires the key when deleting the last credential envelope", async () => {
     const roots = await fixture();
     const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
     const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
-    const observeEnvelopeRemoved = vi.fn(async () => {
-      await retireKeychainKeyWhenLastEnvelopeGone({
-        ...roots,
-        transport,
-        service: KEYCHAIN_CREDENTIAL_SERVICE,
-      });
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    const observeEnvelopeRemoved = vi.fn(async (proof: CredentialEnvelopeLockProof) => {
+      await retireKey(roots, transport, proof);
     });
     const vault = createCredentialVault({
       root: roots.credentialRoot,
       encryption,
+      serializeEnvelopeMutation,
       observeEnvelopeRemoved,
       applyCredential: vi.fn(async () => undefined),
       clearCredential: vi.fn(async () => "cleared" as const),
@@ -106,15 +128,13 @@ describe("keychain key retirement call sites", () => {
     const roots = await fixture();
     const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
     const transport = transportOf();
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     const vault = createCredentialVault({
       root: roots.credentialRoot,
       encryption,
-      observeEnvelopeRemoved: async () => {
-        await retireKeychainKeyWhenLastEnvelopeGone({
-          ...roots,
-          transport,
-          service: KEYCHAIN_CREDENTIAL_SERVICE,
-        });
+      serializeEnvelopeMutation,
+      observeEnvelopeRemoved: async (proof) => {
+        await retireKey(roots, transport, proof);
       },
       applyCredential: vi.fn(async () => undefined),
       clearCredential: vi.fn(async () => "cleared" as const),
@@ -136,17 +156,15 @@ describe("keychain key retirement call sites", () => {
     const roots = await fixture();
     const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
     const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
-    const observeEnvelopeRemoved = vi.fn(async () => {
-      await retireKeychainKeyWhenLastEnvelopeGone({
-        ...roots,
-        transport,
-        service: KEYCHAIN_CREDENTIAL_SERVICE,
-      });
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    const observeEnvelopeRemoved = vi.fn(async (proof: CredentialEnvelopeLockProof) => {
+      await retireKey(roots, transport, proof);
     });
     const vault = createTelegramCredentialVault({
       root: roots.telegramRoot,
       athleteHome: roots.athleteHome,
       encryption,
+      serializeEnvelopeMutation,
       observeEnvelopeRemoved,
     });
     await expect(
@@ -169,24 +187,26 @@ describe("keychain key retirement call sites", () => {
     const roots = await fixture();
     const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
     const transport = transportOf();
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     const credentials = createCredentialVault({
       root: roots.credentialRoot,
       encryption,
+      serializeEnvelopeMutation,
       applyCredential: vi.fn(async () => undefined),
     });
     await expect(
-      credentials.writeCredential({ slot: "anthropic", value: "sk-anthropic" }, { activate: false }),
+      credentials.writeCredential(
+        { slot: "anthropic", value: "sk-anthropic" },
+        { activate: false },
+      ),
     ).resolves.toMatchObject({ status: "configured" });
     const vault = createTelegramCredentialVault({
       root: roots.telegramRoot,
       athleteHome: roots.athleteHome,
       encryption,
-      observeEnvelopeRemoved: async () => {
-        await retireKeychainKeyWhenLastEnvelopeGone({
-          ...roots,
-          transport,
-          service: KEYCHAIN_CREDENTIAL_SERVICE,
-        });
+      serializeEnvelopeMutation,
+      observeEnvelopeRemoved: async (proof) => {
+        await retireKey(roots, transport, proof);
       },
     });
     await expect(
@@ -205,9 +225,11 @@ describe("keychain key retirement call sites", () => {
   posixIt("never fails a deletion because retirement threw", async () => {
     const roots = await fixture();
     const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     const vault = createCredentialVault({
       root: roots.credentialRoot,
       encryption,
+      serializeEnvelopeMutation,
       observeEnvelopeRemoved: async () => {
         throw new Error("synthetic retirement failure");
       },
@@ -221,5 +243,68 @@ describe("keychain key retirement call sites", () => {
     await expect(vault.deleteCredential("anthropic")).resolves.toMatchObject({
       status: "deleted",
     });
+  });
+
+  posixIt("blocks a write in the other vault through the zero-envelope census", async () => {
+    const roots = await fixture();
+    const key = randomBytes(KEYCHAIN_KEY_BYTES);
+    const baseEncryption = keychainPort(key);
+    let seals = 0;
+    const encryption: CredentialEncryptionPort = {
+      ...baseEncryption,
+      encryptString(value) {
+        seals += 1;
+        return baseEncryption.encryptString(value);
+      },
+    };
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
+    let releaseRetirement: (() => void) | undefined;
+    let markRetirementStarted: (() => void) | undefined;
+    const retirementBlocked = new Promise<void>((resolve) => {
+      releaseRetirement = resolve;
+    });
+    const retirementStarted = new Promise<void>((resolve) => {
+      markRetirementStarted = resolve;
+    });
+    const credentials = createCredentialVault({
+      root: roots.credentialRoot,
+      encryption,
+      serializeEnvelopeMutation,
+      observeEnvelopeRemoved: async (proof) => {
+        markRetirementStarted?.();
+        await retirementBlocked;
+        await retireKey(roots, transport, proof);
+      },
+      applyCredential: vi.fn(async () => undefined),
+      clearCredential: vi.fn(async () => "cleared" as const),
+    });
+    const telegram = createTelegramCredentialVault({
+      root: roots.telegramRoot,
+      athleteHome: roots.athleteHome,
+      encryption,
+      serializeEnvelopeMutation,
+    });
+    await credentials.writeCredential(
+      { slot: "anthropic", value: "sk-anthropic" },
+      { activate: false },
+    );
+    seals = 0;
+
+    const deletion = credentials.deleteCredential("anthropic");
+    await retirementStarted;
+    const write = telegram.replaceProfile({
+      token: "123:synthetic",
+      bot: BOT,
+      authenticatedAthleteHome: roots.athleteHome,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(seals).toBe(0);
+    releaseRetirement?.();
+    await expect(deletion).resolves.toMatchObject({ status: "deleted" });
+    await expect(write).resolves.toMatchObject({ outcome: "applied" });
+    expect(seals).toBe(1);
   });
 });

--- a/apps/desktop/tests/credential-key-retirement.test.ts
+++ b/apps/desktop/tests/credential-key-retirement.test.ts
@@ -1,0 +1,225 @@
+import { randomBytes } from "node:crypto";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createCredentialVault,
+  type CredentialEncryptionPort,
+} from "../src/main/credential-vault.js";
+import {
+  openCredentialEnvelope,
+  sealCredentialEnvelope,
+} from "../src/main/keychain-credential-encryption.js";
+import { retireKeychainKeyWhenLastEnvelopeGone } from "../src/main/keychain-key-lifetime.js";
+import {
+  KEYCHAIN_CREDENTIAL_SERVICE,
+  KEYCHAIN_KEY_BYTES,
+  type KeychainHelperRequest,
+  type KeychainHelperResponse,
+} from "../src/main/keychain-helper.js";
+import { createTelegramCredentialVault } from "../src/main/telegram-credential-vault.js";
+
+const posixIt = it.skipIf(process.platform === "win32");
+const BOT = { id: 987654, username: "synthetic_bot" } as const;
+const fixtureRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+interface Fixture {
+  readonly credentialRoot: string;
+  readonly telegramRoot: string;
+  readonly athleteHome: string;
+}
+
+async function fixture(): Promise<Fixture> {
+  const base = await mkdtemp(join(await realpath(tmpdir()), "desktop-key-retirement-"));
+  fixtureRoots.push(base);
+  const home = join(base, "athlete-home");
+  await mkdir(home, { mode: 0o700 });
+  return {
+    credentialRoot: join(base, "credentials-v1"),
+    telegramRoot: join(base, "telegram-channel-v1"),
+    athleteHome: await realpath(home),
+  };
+}
+
+function keychainPort(key: Buffer): CredentialEncryptionPort {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) => sealCredentialEnvelope(key, value),
+    decryptString: (envelope: Buffer) => openCredentialEnvelope(key, envelope),
+    getSelectedStorageBackend: () => "keychain_partition_v1",
+  };
+}
+
+function transportOf(...responses: readonly KeychainHelperResponse[]) {
+  const remaining = [...responses];
+  const requests: KeychainHelperRequest[] = [];
+  return {
+    requests,
+    send(request: KeychainHelperRequest): Promise<KeychainHelperResponse> {
+      requests.push(request);
+      return Promise.resolve(remaining.shift() ?? { ok: false, code: "unknown" });
+    },
+  };
+}
+
+describe("keychain key retirement call sites", () => {
+  posixIt("retires the key when deleting the last credential envelope", async () => {
+    const roots = await fixture();
+    const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
+    const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
+    const observeEnvelopeRemoved = vi.fn(async () => {
+      await retireKeychainKeyWhenLastEnvelopeGone({
+        ...roots,
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+      });
+    });
+    const vault = createCredentialVault({
+      root: roots.credentialRoot,
+      encryption,
+      observeEnvelopeRemoved,
+      applyCredential: vi.fn(async () => undefined),
+      clearCredential: vi.fn(async () => "cleared" as const),
+    });
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: "sk-anthropic" }, { activate: false }),
+    ).resolves.toMatchObject({ status: "configured" });
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toMatchObject({
+      status: "deleted",
+    });
+
+    expect(observeEnvelopeRemoved).toHaveBeenCalledOnce();
+    expect(transport.requests).toEqual([
+      { op: "delete-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
+    ]);
+  });
+
+  posixIt("keeps the key while another credential envelope survives", async () => {
+    const roots = await fixture();
+    const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
+    const transport = transportOf();
+    const vault = createCredentialVault({
+      root: roots.credentialRoot,
+      encryption,
+      observeEnvelopeRemoved: async () => {
+        await retireKeychainKeyWhenLastEnvelopeGone({
+          ...roots,
+          transport,
+          service: KEYCHAIN_CREDENTIAL_SERVICE,
+        });
+      },
+      applyCredential: vi.fn(async () => undefined),
+      clearCredential: vi.fn(async () => "cleared" as const),
+    });
+    for (const slot of ["anthropic", "openai"] as const) {
+      await expect(
+        vault.writeCredential({ slot, value: `sk-${slot}` }, { activate: false }),
+      ).resolves.toMatchObject({ status: "configured" });
+    }
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toMatchObject({
+      status: "deleted",
+    });
+
+    expect(transport.requests).toEqual([]);
+  });
+
+  posixIt("retires the key when removing the Telegram profile envelope", async () => {
+    const roots = await fixture();
+    const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
+    const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
+    const observeEnvelopeRemoved = vi.fn(async () => {
+      await retireKeychainKeyWhenLastEnvelopeGone({
+        ...roots,
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+      });
+    });
+    const vault = createTelegramCredentialVault({
+      root: roots.telegramRoot,
+      athleteHome: roots.athleteHome,
+      encryption,
+      observeEnvelopeRemoved,
+    });
+    await expect(
+      vault.replaceProfile({
+        token: "123:synthetic",
+        bot: BOT,
+        authenticatedAthleteHome: roots.athleteHome,
+      }),
+    ).resolves.toMatchObject({ outcome: "applied" });
+
+    await expect(vault.deleteProfile()).resolves.toMatchObject({ outcome: "applied" });
+
+    expect(observeEnvelopeRemoved).toHaveBeenCalledOnce();
+    expect(transport.requests).toEqual([
+      { op: "delete-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
+    ]);
+  });
+
+  posixIt("keeps the key when a credential envelope outlives the Telegram profile", async () => {
+    const roots = await fixture();
+    const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
+    const transport = transportOf();
+    const credentials = createCredentialVault({
+      root: roots.credentialRoot,
+      encryption,
+      applyCredential: vi.fn(async () => undefined),
+    });
+    await expect(
+      credentials.writeCredential({ slot: "anthropic", value: "sk-anthropic" }, { activate: false }),
+    ).resolves.toMatchObject({ status: "configured" });
+    const vault = createTelegramCredentialVault({
+      root: roots.telegramRoot,
+      athleteHome: roots.athleteHome,
+      encryption,
+      observeEnvelopeRemoved: async () => {
+        await retireKeychainKeyWhenLastEnvelopeGone({
+          ...roots,
+          transport,
+          service: KEYCHAIN_CREDENTIAL_SERVICE,
+        });
+      },
+    });
+    await expect(
+      vault.replaceProfile({
+        token: "123:synthetic",
+        bot: BOT,
+        authenticatedAthleteHome: roots.athleteHome,
+      }),
+    ).resolves.toMatchObject({ outcome: "applied" });
+
+    await expect(vault.deleteProfile()).resolves.toMatchObject({ outcome: "applied" });
+
+    expect(transport.requests).toEqual([]);
+  });
+
+  posixIt("never fails a deletion because retirement threw", async () => {
+    const roots = await fixture();
+    const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
+    const vault = createCredentialVault({
+      root: roots.credentialRoot,
+      encryption,
+      observeEnvelopeRemoved: async () => {
+        throw new Error("synthetic retirement failure");
+      },
+      applyCredential: vi.fn(async () => undefined),
+      clearCredential: vi.fn(async () => "cleared" as const),
+    });
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: "sk-anthropic" }, { activate: false }),
+    ).resolves.toMatchObject({ status: "configured" });
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toMatchObject({
+      status: "deleted",
+    });
+  });
+});

--- a/apps/desktop/tests/desktop-credential-encryption.test.ts
+++ b/apps/desktop/tests/desktop-credential-encryption.test.ts
@@ -1,0 +1,324 @@
+import { randomBytes } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { CredentialEncryptionPort } from "../src/main/credential-vault.js";
+import {
+  desktopKeychainCredentialService,
+  prepareDesktopCredentialEncryption,
+  type PrepareDesktopCredentialEncryptionOptions,
+} from "../src/main/desktop-credential-encryption.js";
+import {
+  KEYCHAIN_PARTITION_STORAGE_BACKEND,
+  sealCredentialEnvelope,
+} from "../src/main/keychain-credential-encryption.js";
+import {
+  KEYCHAIN_CREDENTIAL_SERVICE,
+  KEYCHAIN_CREDENTIAL_SERVICE_DEV,
+  KEYCHAIN_KEY_BYTES,
+  KEYCHAIN_TEAM_IDENTIFIER,
+  type KeychainHelperRequest,
+  type KeychainHelperResponse,
+} from "../src/main/keychain-helper.js";
+
+const CREDENTIAL_ROOT = "/synthetic/userData/credentials-v1";
+const TELEGRAM_ROOT = "/synthetic/userData/telegram-channel-v1";
+const KEY = randomBytes(KEYCHAIN_KEY_BYTES);
+const PROBE_OK: KeychainHelperResponse = {
+  ok: true,
+  op: "probe",
+  teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER,
+};
+
+function safeStoragePort(): CredentialEncryptionPort {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) =>
+      Buffer.concat([Buffer.from("SAFE:"), Buffer.from(value, "utf8")]),
+    decryptString: (value: Buffer) => value.subarray(5).toString("utf8"),
+    getSelectedStorageBackend: () => "basic_text",
+  };
+}
+
+function transportOf(...answers: readonly KeychainHelperResponse[]) {
+  const requests: KeychainHelperRequest[] = [];
+  const queue = [...answers];
+  return {
+    requests,
+    send: vi.fn(async (request: KeychainHelperRequest) => {
+      requests.push(request);
+      return queue.shift() ?? ({ ok: false, code: "unknown" } as KeychainHelperResponse);
+    }),
+  };
+}
+
+function noEnvelopes() {
+  return (async () => {
+    throw Object.assign(new Error("missing"), { code: "ENOENT" });
+  }) as never;
+}
+
+function migratedTelegramEnvelope() {
+  const sealed = sealCredentialEnvelope(KEY, "bot-token");
+  return (async (path: string) => {
+    if (path.startsWith(TELEGRAM_ROOT)) return sealed;
+    throw Object.assign(new Error("missing"), { code: "ENOENT" });
+  }) as never;
+}
+
+function options(
+  overrides: Partial<PrepareDesktopCredentialEncryptionOptions> = {},
+): PrepareDesktopCredentialEncryptionOptions {
+  return {
+    credentialRoot: CREDENTIAL_ROOT,
+    telegramRoot: TELEGRAM_ROOT,
+    safeStorage: safeStoragePort(),
+    readEnvelopeFile: noEnvelopes(),
+    location: {
+      platform: "darwin",
+      packaged: true,
+      resourcesPath: "/Applications/Enduragent.app/Contents/Resources",
+      applicationPath: "/Applications/Enduragent.app/Contents/Resources/app.asar",
+    },
+    helperIsExecutable: async () => true,
+    ...overrides,
+  };
+}
+
+describe("desktop credential encryption startup", () => {
+  it("separates the signed-release service from the development service", () => {
+    expect(desktopKeychainCredentialService(true)).toBe(KEYCHAIN_CREDENTIAL_SERVICE);
+    expect(desktopKeychainCredentialService(false)).toBe(KEYCHAIN_CREDENTIAL_SERVICE_DEV);
+    expect(KEYCHAIN_CREDENTIAL_SERVICE_DEV).not.toBe(KEYCHAIN_CREDENTIAL_SERVICE);
+  });
+
+  it("asks the packaged lane for the signed-release service exactly once per key acquisition", async () => {
+    const transport = transportOf(PROBE_OK, { ok: true, op: "read-key", key: KEY.toString("base64") });
+
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({ createTransport: () => transport }),
+    );
+
+    expect(prepared.service).toBe(KEYCHAIN_CREDENTIAL_SERVICE);
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
+    expect(
+      transport.requests.every((request) => request.service === KEYCHAIN_CREDENTIAL_SERVICE),
+    ).toBe(true);
+    expect(prepared.selection.status).toBe("keychain");
+    expect(prepared.encryption.getSelectedStorageBackend?.()).toBe(
+      KEYCHAIN_PARTITION_STORAGE_BACKEND,
+    );
+  });
+
+  it("never lets an unpackaged run touch the signed-release service", async () => {
+    const transport = transportOf(PROBE_OK, { ok: true, op: "read-key", key: KEY.toString("base64") });
+
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({
+        createTransport: () => transport,
+        location: {
+          platform: "darwin",
+          packaged: false,
+          resourcesPath: "/opt/electron/resources",
+          applicationPath: "/repository/apps/desktop",
+        },
+      }),
+    );
+
+    expect(prepared.service).toBe(KEYCHAIN_CREDENTIAL_SERVICE_DEV);
+    expect(transport.requests).not.toHaveLength(0);
+    for (const request of transport.requests) {
+      expect(request.service).toBe(KEYCHAIN_CREDENTIAL_SERVICE_DEV);
+      expect(request.service).not.toBe(KEYCHAIN_CREDENTIAL_SERVICE);
+    }
+  });
+
+  it("resolves the development helper from the application path", async () => {
+    const createTransport = vi.fn(() =>
+      transportOf(PROBE_OK, { ok: true, op: "read-key", key: KEY.toString("base64") }),
+    );
+
+    await prepareDesktopCredentialEncryption(
+      options({
+        createTransport,
+        location: {
+          platform: "darwin",
+          packaged: false,
+          resourcesPath: "/opt/electron/resources",
+          applicationPath: "/repository/apps/desktop",
+        },
+      }),
+    );
+
+    expect(createTransport).toHaveBeenCalledWith(
+      "/repository/apps/desktop/dist/keychain-helper/keychain-helper",
+    );
+  });
+
+  it("keeps Windows on the injected safeStorage port without resolving a helper", async () => {
+    const safeStorage = safeStoragePort();
+    const createTransport = vi.fn(() => transportOf());
+    const helperIsExecutable = vi.fn(async () => true);
+
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({
+        safeStorage,
+        createTransport,
+        helperIsExecutable,
+        location: {
+          platform: "win32",
+          packaged: true,
+          resourcesPath: "C:/Program Files/Enduragent/resources",
+          applicationPath: "C:/Program Files/Enduragent/resources/app.asar",
+        },
+      }),
+    );
+
+    expect(prepared.encryption).toBe(safeStorage);
+    expect(prepared.selection.status).toBe("safe-storage");
+    expect(createTransport).not.toHaveBeenCalled();
+    expect(helperIsExecutable).not.toHaveBeenCalled();
+    await expect(prepared.retireKeychainKey()).resolves.toBeUndefined();
+  });
+
+  it("falls back to safeStorage when the bundled helper cannot run and nothing is migrated", async () => {
+    const safeStorage = safeStoragePort();
+    const createTransport = vi.fn(() => transportOf());
+
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({ safeStorage, createTransport, helperIsExecutable: async () => false }),
+    );
+
+    expect(prepared.encryption).toBe(safeStorage);
+    expect(prepared.selection.status).toBe("safe-storage");
+    expect(createTransport).not.toHaveBeenCalled();
+  });
+
+  it("refuses instead of downgrading when a migrated envelope outlives the helper", async () => {
+    const safeStorage = safeStoragePort();
+
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({
+        safeStorage,
+        helperIsExecutable: async () => false,
+        readEnvelopeFile: migratedTelegramEnvelope(),
+      }),
+    );
+
+    expect(prepared.selection.status).toBe("refused");
+    if (prepared.selection.status !== "refused") return;
+    expect(prepared.selection.reason).toBe("encryption-unavailable");
+    expect(prepared.encryption).not.toBe(safeStorage);
+    expect(prepared.encryption.isEncryptionAvailable()).toBe(false);
+    expect(() => prepared.encryption.encryptString("sk-anthropic")).toThrow();
+  });
+
+  it("refuses without a safeStorage downgrade when selection itself throws", async () => {
+    const safeStorage = safeStoragePort();
+    const createTransport = vi.fn(() => {
+      throw new Error("synthetic transport failure");
+    });
+
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({ safeStorage, createTransport }),
+    );
+
+    expect(prepared.selection.status).toBe("refused");
+    if (prepared.selection.status !== "refused") return;
+    expect(prepared.selection.reason).toBe("storage-failed");
+    expect(prepared.encryption).not.toBe(safeStorage);
+    expect(prepared.encryption.getSelectedStorageBackend?.()).toBe(
+      KEYCHAIN_PARTITION_STORAGE_BACKEND,
+    );
+  });
+
+  it("retires the key only when the keychain backend is live and every envelope is gone", async () => {
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: KEY.toString("base64") },
+      { ok: true, op: "delete-key", deleted: true },
+    );
+
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({ createTransport: () => transport }),
+    );
+
+    await expect(prepared.retireKeychainKey()).resolves.toEqual({ status: "deleted" });
+    expect(transport.requests.at(-1)).toEqual({
+      op: "delete-key",
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+  });
+
+  it("keeps the key while any envelope survives in either vault", async () => {
+    const transport = transportOf(PROBE_OK, { ok: true, op: "read-key", key: KEY.toString("base64") });
+
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({
+        createTransport: () => transport,
+        readEnvelopeFile: migratedTelegramEnvelope(),
+      }),
+    );
+
+    await expect(prepared.retireKeychainKey()).resolves.toEqual({
+      status: "retained",
+      envelopes: 1,
+    });
+    expect(transport.requests.some((request) => request.op === "delete-key")).toBe(false);
+  });
+
+  it("never deletes a keychain item from a refusing or safeStorage lane", async () => {
+    const transport = transportOf({ ok: false, code: "keychain-locked" });
+
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({
+        createTransport: () => transport,
+        readEnvelopeFile: migratedTelegramEnvelope(),
+      }),
+    );
+
+    expect(prepared.selection.status).toBe("refused");
+    await expect(prepared.retireKeychainKey()).resolves.toBeUndefined();
+    expect(transport.requests.some((request) => request.op === "delete-key")).toBe(false);
+  });
+});
+
+describe("desktop startup wiring", () => {
+  it("selects the credential backend once, before either vault is constructed", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+
+    const selection = source.indexOf("await prepareDesktopCredentialEncryption({");
+    const telegramVault = source.indexOf("createTelegramCredentialVault({");
+    const credentialVault = source.indexOf("createCredentialVault({");
+
+    expect(selection).toBeGreaterThan(0);
+    expect(source.split("prepareDesktopCredentialEncryption(")).toHaveLength(2);
+    expect(selection).toBeLessThan(telegramVault);
+    expect(selection).toBeLessThan(credentialVault);
+  });
+
+  it("injects the selected port into every vault and keeps safeStorage out of the vaults", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+
+    expect(source).not.toMatch(/encryption: safeStorage/u);
+    expect(source.split("encryption: credentialEncryption.encryption")).toHaveLength(4);
+    expect(source).toMatch(/safeStorage,\n/u);
+  });
+
+  it("reports the selected backend on darwin only", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+    const report = source.indexOf("desktop-credential-backend ");
+
+    expect(report).toBeGreaterThan(0);
+    expect(source.slice(report - 400, report)).toMatch(/process\.platform === "darwin"/u);
+  });
+
+  it("retires the keychain key from both envelope-deletion paths", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+
+    expect(source).toMatch(/credentialEncryption\.retireKeychainKey\(\)/u);
+    expect(
+      source.split("observeEnvelopeRemoved: retireCredentialEncryptionKey"),
+    ).toHaveLength(3);
+  });
+});

--- a/apps/desktop/tests/desktop-credential-encryption.test.ts
+++ b/apps/desktop/tests/desktop-credential-encryption.test.ts
@@ -233,21 +233,45 @@ describe("desktop credential encryption startup", () => {
   });
 
   it("retires the key only when the keychain backend is live and every envelope is gone", async () => {
+    const replacement = randomBytes(KEY.length);
     const transport = transportOf(
       PROBE_OK,
       { ok: true, op: "read-key", key: KEY.toString("base64") },
       { ok: true, op: "delete-key", deleted: true },
+      { ok: true, op: "create-key", key: replacement.toString("base64") },
     );
 
     const prepared = await prepareDesktopCredentialEncryption(
       options({ createTransport: () => transport }),
     );
 
-    await expect(prepared.retireKeychainKey()).resolves.toEqual({ status: "deleted" });
-    expect(transport.requests.at(-1)).toEqual({
-      op: "delete-key",
-      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    await expect(prepared.retireKeychainKey()).resolves.toEqual({ status: "rotated" });
+    expect(transport.requests.slice(-2)).toEqual([
+      { op: "delete-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
+      { op: "create-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
+    ]);
+    const sealed = prepared.encryption.encryptString("post-retirement-secret");
+    expect(prepared.encryption.decryptString(sealed)).toBe("post-retirement-secret");
+  });
+
+  it("refuses to seal under the old key when rotation cannot mint a replacement", async () => {
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: KEY.toString("base64") },
+      { ok: true, op: "delete-key", deleted: true },
+      { ok: false, code: "keychain-locked" },
+    );
+
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({ createTransport: () => transport }),
+    );
+
+    await expect(prepared.retireKeychainKey()).resolves.toEqual({
+      status: "failed",
+      code: "keychain-locked",
     });
+    expect(prepared.encryption.isEncryptionAvailable()).toBe(false);
+    expect(() => prepared.encryption.encryptString("orphan-candidate")).toThrow();
   });
 
   it("keeps the key while any envelope survives in either vault", async () => {

--- a/apps/desktop/tests/desktop-credential-encryption.test.ts
+++ b/apps/desktop/tests/desktop-credential-encryption.test.ts
@@ -252,6 +252,7 @@ describe("desktop credential encryption startup", () => {
       PROBE_OK,
       { ok: true, op: "read-key", key: KEY.toString("base64") },
       { ok: true, op: "delete-key", deleted: true },
+      { ok: false, code: "item-not-found" },
       { ok: true, op: "create-key", key: replacement.toString("base64") },
     );
 
@@ -269,7 +270,8 @@ describe("desktop credential encryption startup", () => {
     ]);
 
     await serializeEnvelopeMutation((proof) => prepared.prepareEnvelopeWrite(proof));
-    expect(transport.requests.slice(-1)).toEqual([
+    expect(transport.requests.slice(-2)).toEqual([
+      { op: "read-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
       { op: "create-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
     ]);
     const sealed = prepared.encryption.encryptString("post-retirement-secret");
@@ -281,6 +283,7 @@ describe("desktop credential encryption startup", () => {
       PROBE_OK,
       { ok: true, op: "read-key", key: KEY.toString("base64") },
       { ok: true, op: "delete-key", deleted: true },
+      { ok: false, code: "item-not-found" },
       { ok: false, code: "keychain-locked" },
     );
 

--- a/apps/desktop/tests/desktop-credential-encryption.test.ts
+++ b/apps/desktop/tests/desktop-credential-encryption.test.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import type { CredentialEncryptionPort } from "../src/main/credential-vault.js";
 import {
   desktopKeychainCredentialService,
@@ -81,6 +82,7 @@ function options(
       applicationPath: "/Applications/Enduragent.app/Contents/Resources/app.asar",
     },
     helperIsExecutable: async () => true,
+    serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
     ...overrides,
   };
 }
@@ -93,7 +95,11 @@ describe("desktop credential encryption startup", () => {
   });
 
   it("asks the packaged lane for the signed-release service exactly once per key acquisition", async () => {
-    const transport = transportOf(PROBE_OK, { ok: true, op: "read-key", key: KEY.toString("base64") });
+    const transport = transportOf(PROBE_OK, {
+      ok: true,
+      op: "read-key",
+      key: KEY.toString("base64"),
+    });
 
     const prepared = await prepareDesktopCredentialEncryption(
       options({ createTransport: () => transport }),
@@ -111,7 +117,11 @@ describe("desktop credential encryption startup", () => {
   });
 
   it("never lets an unpackaged run touch the signed-release service", async () => {
-    const transport = transportOf(PROBE_OK, { ok: true, op: "read-key", key: KEY.toString("base64") });
+    const transport = transportOf(PROBE_OK, {
+      ok: true,
+      op: "read-key",
+      key: KEY.toString("base64"),
+    });
 
     const prepared = await prepareDesktopCredentialEncryption(
       options({
@@ -160,11 +170,13 @@ describe("desktop credential encryption startup", () => {
     const createTransport = vi.fn(() => transportOf());
     const helperIsExecutable = vi.fn(async () => true);
 
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     const prepared = await prepareDesktopCredentialEncryption(
       options({
         safeStorage,
         createTransport,
         helperIsExecutable,
+        serializeEnvelopeMutation,
         location: {
           platform: "win32",
           packaged: true,
@@ -178,7 +190,9 @@ describe("desktop credential encryption startup", () => {
     expect(prepared.selection.status).toBe("safe-storage");
     expect(createTransport).not.toHaveBeenCalled();
     expect(helperIsExecutable).not.toHaveBeenCalled();
-    await expect(prepared.retireKeychainKey()).resolves.toBeUndefined();
+    await expect(
+      serializeEnvelopeMutation((proof) => prepared.retireKeychainKey(proof)),
+    ).resolves.toBeUndefined();
   });
 
   it("falls back to safeStorage when the bundled helper cannot run and nothing is migrated", async () => {
@@ -232,7 +246,7 @@ describe("desktop credential encryption startup", () => {
     );
   });
 
-  it("retires the key only when the keychain backend is live and every envelope is gone", async () => {
+  it("deletes after a zero-envelope census and recreates before a later write", async () => {
     const replacement = randomBytes(KEY.length);
     const transport = transportOf(
       PROBE_OK,
@@ -241,20 +255,28 @@ describe("desktop credential encryption startup", () => {
       { ok: true, op: "create-key", key: replacement.toString("base64") },
     );
 
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     const prepared = await prepareDesktopCredentialEncryption(
-      options({ createTransport: () => transport }),
+      options({ createTransport: () => transport, serializeEnvelopeMutation }),
     );
 
-    await expect(prepared.retireKeychainKey()).resolves.toEqual({ status: "rotated" });
-    expect(transport.requests.slice(-2)).toEqual([
+    await expect(
+      serializeEnvelopeMutation((proof) => prepared.retireKeychainKey(proof)),
+    ).resolves.toEqual({ status: "deleted" });
+    expect(prepared.encryption.isEncryptionAvailable()).toBe(false);
+    expect(transport.requests.slice(-1)).toEqual([
       { op: "delete-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
+    ]);
+
+    await serializeEnvelopeMutation((proof) => prepared.prepareEnvelopeWrite(proof));
+    expect(transport.requests.slice(-1)).toEqual([
       { op: "create-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
     ]);
     const sealed = prepared.encryption.encryptString("post-retirement-secret");
     expect(prepared.encryption.decryptString(sealed)).toBe("post-retirement-secret");
   });
 
-  it("refuses to seal under the old key when rotation cannot mint a replacement", async () => {
+  it("refuses to seal when a later write cannot recreate the retired key", async () => {
     const transport = transportOf(
       PROBE_OK,
       { ok: true, op: "read-key", key: KEY.toString("base64") },
@@ -262,47 +284,57 @@ describe("desktop credential encryption startup", () => {
       { ok: false, code: "keychain-locked" },
     );
 
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     const prepared = await prepareDesktopCredentialEncryption(
-      options({ createTransport: () => transport }),
+      options({ createTransport: () => transport, serializeEnvelopeMutation }),
     );
 
-    await expect(prepared.retireKeychainKey()).resolves.toEqual({
-      status: "failed",
-      code: "keychain-locked",
-    });
+    await expect(
+      serializeEnvelopeMutation((proof) => prepared.retireKeychainKey(proof)),
+    ).resolves.toEqual({ status: "deleted" });
+    await serializeEnvelopeMutation((proof) => prepared.prepareEnvelopeWrite(proof));
     expect(prepared.encryption.isEncryptionAvailable()).toBe(false);
     expect(() => prepared.encryption.encryptString("orphan-candidate")).toThrow();
   });
 
   it("keeps the key while any envelope survives in either vault", async () => {
-    const transport = transportOf(PROBE_OK, { ok: true, op: "read-key", key: KEY.toString("base64") });
+    const transport = transportOf(PROBE_OK, {
+      ok: true,
+      op: "read-key",
+      key: KEY.toString("base64"),
+    });
 
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     const prepared = await prepareDesktopCredentialEncryption(
       options({
         createTransport: () => transport,
         readEnvelopeFile: migratedTelegramEnvelope(),
+        serializeEnvelopeMutation,
       }),
     );
 
-    await expect(prepared.retireKeychainKey()).resolves.toEqual({
-      status: "retained",
-      envelopes: 1,
-    });
+    await expect(
+      serializeEnvelopeMutation((proof) => prepared.retireKeychainKey(proof)),
+    ).resolves.toEqual({ status: "retained", envelopes: 1 });
     expect(transport.requests.some((request) => request.op === "delete-key")).toBe(false);
   });
 
   it("never deletes a keychain item from a refusing or safeStorage lane", async () => {
     const transport = transportOf({ ok: false, code: "keychain-locked" });
 
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     const prepared = await prepareDesktopCredentialEncryption(
       options({
         createTransport: () => transport,
         readEnvelopeFile: migratedTelegramEnvelope(),
+        serializeEnvelopeMutation,
       }),
     );
 
     expect(prepared.selection.status).toBe("refused");
-    await expect(prepared.retireKeychainKey()).resolves.toBeUndefined();
+    await expect(
+      serializeEnvelopeMutation((proof) => prepared.retireKeychainKey(proof)),
+    ).resolves.toBeUndefined();
     expect(transport.requests.some((request) => request.op === "delete-key")).toBe(false);
   });
 });
@@ -337,12 +369,11 @@ describe("desktop startup wiring", () => {
     expect(source.slice(report - 400, report)).toMatch(/process\.platform === "darwin"/u);
   });
 
-  it("retires the keychain key from both envelope-deletion paths", async () => {
+  it("uses one shared lock for both envelope-deletion paths", async () => {
     const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
 
-    expect(source).toMatch(/credentialEncryption\.retireKeychainKey\(\)/u);
-    expect(
-      source.split("observeEnvelopeRemoved: retireCredentialEncryptionKey"),
-    ).toHaveLength(3);
+    expect(source).toMatch(/credentialEncryption\.retireKeychainKey\(proof\)/u);
+    expect(source.split("createCredentialEnvelopeMutationLock()")).toHaveLength(2);
+    expect(source.split("observeEnvelopeRemoved: retireCredentialEncryptionKey")).toHaveLength(3);
   });
 });

--- a/apps/desktop/tests/keychain-credential-encryption.test.ts
+++ b/apps/desktop/tests/keychain-credential-encryption.test.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { describe, expect, it } from "vitest";
+import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import {
   CREDENTIAL_ENVELOPE_IV_BYTES,
   CREDENTIAL_ENVELOPE_MAGIC,
@@ -10,6 +11,7 @@ import {
   KeychainEncryptionError,
   SAFE_STORAGE_ENVELOPE_KEY_ID,
   createKeychainPartitionEncryption,
+  type CreateKeychainPartitionEncryptionOptions,
   openCredentialEnvelope,
   readCredentialEnvelopeKeyId,
   sealCredentialEnvelope,
@@ -51,6 +53,22 @@ function transportOf(...responses: readonly KeychainHelperResponse[]): Recording
 function storedKey(): { readonly key: Buffer; readonly encoded: string } {
   const key = randomBytes(KEYCHAIN_KEY_BYTES);
   return { key, encoded: key.toString("base64") };
+}
+
+async function createEncryption(
+  options: Omit<CreateKeychainPartitionEncryptionOptions, "dependentEnvelopes" | "lockProof"> & {
+    readonly dependentEnvelopes?: number;
+  },
+) {
+  const { dependentEnvelopes = 0, ...keychainOptions } = options;
+  const serialize = createCredentialEnvelopeMutationLock();
+  return await serialize((lockProof) =>
+    createKeychainPartitionEncryption({
+      ...keychainOptions,
+      dependentEnvelopes,
+      lockProof,
+    }),
+  );
 }
 
 describe("credential envelope", () => {
@@ -115,7 +133,7 @@ describe("keychain partition backend", () => {
   it("adopts an existing key and reports its backend id", async () => {
     const { encoded } = storedKey();
     const transport = transportOf(PROBE_OK, { ok: true, op: "read-key", key: encoded });
-    const result = await createKeychainPartitionEncryption({
+    const result = await createEncryption({
       transport,
       service: KEYCHAIN_CREDENTIAL_SERVICE,
     });
@@ -142,7 +160,7 @@ describe("keychain partition backend", () => {
       { ok: false, code: "item-not-found" },
       { ok: true, op: "create-key", key: encoded },
     );
-    const result = await createKeychainPartitionEncryption({
+    const result = await createEncryption({
       transport,
       service: KEYCHAIN_CREDENTIAL_SERVICE_DEV,
     });
@@ -159,7 +177,7 @@ describe("keychain partition backend", () => {
     ).toBe(true);
   });
 
-  it("deletes and recreates a poisoned item", async () => {
+  it("deletes and recreates a positively unreadable item with no dependent envelopes", async () => {
     const { encoded } = storedKey();
     const transport = transportOf(
       PROBE_OK,
@@ -167,7 +185,7 @@ describe("keychain partition backend", () => {
       { ok: true, op: "delete-key", deleted: true },
       { ok: true, op: "create-key", key: encoded },
     );
-    const result = await createKeychainPartitionEncryption({
+    const result = await createEncryption({
       transport,
       service: KEYCHAIN_CREDENTIAL_SERVICE,
     });
@@ -182,7 +200,7 @@ describe("keychain partition backend", () => {
 
   it("reports encryption as unavailable when the keychain is locked", async () => {
     const transport = transportOf(PROBE_OK, { ok: false, code: "keychain-locked" });
-    const result = await createKeychainPartitionEncryption({
+    const result = await createEncryption({
       transport,
       service: KEYCHAIN_CREDENTIAL_SERVICE,
     });
@@ -202,7 +220,7 @@ describe("keychain partition backend", () => {
       { ok: false, code: "item-not-found" },
       { ok: false, code: "duplicate-item" },
     );
-    const result = await createKeychainPartitionEncryption({
+    const result = await createEncryption({
       transport,
       service: KEYCHAIN_CREDENTIAL_SERVICE,
     });
@@ -216,7 +234,7 @@ describe("keychain partition backend", () => {
 
   it("stops at the probe and touches no keychain op when the build is not team signed", async () => {
     const transport = transportOf({ ok: false, code: "not-team-signed" });
-    const result = await createKeychainPartitionEncryption({
+    const result = await createEncryption({
       transport,
       service: KEYCHAIN_CREDENTIAL_SERVICE,
     });
@@ -226,7 +244,7 @@ describe("keychain partition backend", () => {
 
   it("refuses a probe answered by a foreign team", async () => {
     const transport = transportOf({ ok: true, op: "probe", teamIdentifier: "ZZZZZZZZZZ" });
-    const result = await createKeychainPartitionEncryption({
+    const result = await createEncryption({
       transport,
       service: KEYCHAIN_CREDENTIAL_SERVICE,
     });
@@ -240,10 +258,49 @@ describe("keychain partition backend", () => {
       op: "read-key",
       key: randomBytes(16).toString("base64"),
     });
-    const result = await createKeychainPartitionEncryption({
+    const result = await createEncryption({
       transport,
       service: KEYCHAIN_CREDENTIAL_SERVICE,
     });
     expect(result.status).toBe("storage-failed");
+  });
+
+  it("preserves an uninspectable item and reports encryption unavailable", async () => {
+    const transport = transportOf(PROBE_OK, { ok: false, code: "uninspectable-item" });
+
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+      dependentEnvelopes: 2,
+    });
+
+    expect(result.status).toBe("unavailable");
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
+  });
+
+  it("preserves a missing key when dependent envelopes need recovery", async () => {
+    const transport = transportOf(PROBE_OK, { ok: false, code: "item-not-found" });
+
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+      dependentEnvelopes: 1,
+    });
+
+    expect(result.status).toBe("unavailable");
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
+  });
+
+  it("preserves a positively invalid item while dependent envelopes survive", async () => {
+    const transport = transportOf(PROBE_OK, { ok: false, code: "unreadable-item" });
+
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+      dependentEnvelopes: 1,
+    });
+
+    expect(result.status).toBe("storage-failed");
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
   });
 });

--- a/apps/desktop/tests/keychain-credential-encryption.test.ts
+++ b/apps/desktop/tests/keychain-credential-encryption.test.ts
@@ -303,4 +303,82 @@ describe("keychain partition backend", () => {
     expect(result.status).toBe("storage-failed");
     expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
   });
+
+  it("keeps an ambiguous deletion unavailable until the surviving key is read again", async () => {
+    const { encoded } = storedKey();
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: encoded },
+      { ok: false, code: "unknown" },
+      { ok: true, op: "read-key", key: encoded },
+    );
+    const serialize = createCredentialEnvelopeMutationLock();
+    const result = await serialize((lockProof) =>
+      createKeychainPartitionEncryption({
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+        dependentEnvelopes: 0,
+        lockProof,
+      }),
+    );
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await expect(serialize((proof) => result.deleteKey(proof))).resolves.toEqual({
+      status: "failed",
+      code: "unknown",
+    });
+    expect(result.encryption.isEncryptionAvailable()).toBe(false);
+    expect(() => result.encryption.encryptString("orphan-candidate")).toThrow(
+      KeychainEncryptionError,
+    );
+
+    await expect(serialize((proof) => result.prepareKey(proof))).resolves.toEqual({
+      status: "ready",
+    });
+    expect(result.encryption.isEncryptionAvailable()).toBe(true);
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "delete-key",
+      "read-key",
+    ]);
+  });
+
+  it("re-reads an ambiguously deleted key before replacing a confirmed absence", async () => {
+    const original = storedKey();
+    const replacement = storedKey();
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: original.encoded },
+      { ok: false, code: "unknown" },
+      { ok: false, code: "item-not-found" },
+      { ok: true, op: "create-key", key: replacement.encoded },
+    );
+    const serialize = createCredentialEnvelopeMutationLock();
+    const result = await serialize((lockProof) =>
+      createKeychainPartitionEncryption({
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+        dependentEnvelopes: 0,
+        lockProof,
+      }),
+    );
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await serialize((proof) => result.deleteKey(proof));
+    await expect(serialize((proof) => result.prepareKey(proof))).resolves.toEqual({
+      status: "ready",
+    });
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "delete-key",
+      "read-key",
+      "create-key",
+    ]);
+    const sealed = result.encryption.encryptString("post-reconciliation-secret");
+    expect(openCredentialEnvelope(replacement.key, sealed)).toBe("post-reconciliation-secret");
+  });
 });

--- a/apps/desktop/tests/keychain-key-lifetime.test.ts
+++ b/apps/desktop/tests/keychain-key-lifetime.test.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -8,6 +8,7 @@ import {
   type CredentialEncryptionPort,
   type DesktopCredentialSlot,
 } from "../src/main/credential-vault.js";
+import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import { createKeychainPartitionEncryption } from "../src/main/keychain-credential-encryption.js";
 import {
   KEYCHAIN_CREDENTIAL_SERVICE,
@@ -66,16 +67,45 @@ function transportOf(...responses: readonly KeychainHelperResponse[]): Recording
 }
 
 async function keychainEncryption(): Promise<CredentialEncryptionPort> {
-  const result = await createKeychainPartitionEncryption({
-    transport: transportOf(PROBE_OK, {
-      ok: true,
-      op: "read-key",
-      key: randomBytes(KEYCHAIN_KEY_BYTES).toString("base64"),
+  const serialize = createCredentialEnvelopeMutationLock();
+  const result = await serialize((lockProof) =>
+    createKeychainPartitionEncryption({
+      transport: transportOf(PROBE_OK, {
+        ok: true,
+        op: "read-key",
+        key: randomBytes(KEYCHAIN_KEY_BYTES).toString("base64"),
+      }),
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+      dependentEnvelopes: 0,
+      lockProof,
     }),
-    service: KEYCHAIN_CREDENTIAL_SERVICE,
-  });
+  );
   if (result.status !== "ready") throw new TypeError();
   return result.encryption;
+}
+
+async function retireKey(
+  roots: Fixture,
+  transport: RecordingTransport,
+  readEnvelopeFile?: typeof readFile,
+) {
+  const serialize = createCredentialEnvelopeMutationLock();
+  return await serialize((lockProof) =>
+    retireKeychainKeyWhenLastEnvelopeGone({
+      ...roots,
+      readEnvelopeFile,
+      lockProof,
+      deleteKey: async () => {
+        const deleted = await transport.send({
+          op: "delete-key",
+          service: KEYCHAIN_CREDENTIAL_SERVICE,
+        });
+        if (!deleted.ok) return { status: "failed", code: deleted.code };
+        if (deleted.op !== "delete-key") return { status: "failed", code: "unknown" };
+        return { status: deleted.deleted ? "deleted" : "already-absent" };
+      },
+    }),
+  );
 }
 
 function credentialVault(roots: Fixture, encryption: CredentialEncryptionPort) {
@@ -134,13 +164,10 @@ describe("keychain key retirement", () => {
       credentialVault(roots, encryption).deleteCredential("anthropic"),
     ).resolves.toMatchObject({ slot: "anthropic", status: "deleted" });
 
-    await expect(
-      retireKeychainKeyWhenLastEnvelopeGone({
-        ...roots,
-        transport,
-        service: KEYCHAIN_CREDENTIAL_SERVICE,
-      }),
-    ).resolves.toEqual({ status: "retained", envelopes: 1 });
+    await expect(retireKey(roots, transport)).resolves.toEqual({
+      status: "retained",
+      envelopes: 1,
+    });
     expect(transport.requests).toHaveLength(0);
   });
 
@@ -157,25 +184,13 @@ describe("keychain key retirement", () => {
         credentialVault(roots, encryption).deleteCredential(slot),
       ).resolves.toMatchObject({ status: "deleted" });
     }
-    await expect(
-      retireKeychainKeyWhenLastEnvelopeGone({
-        ...roots,
-        transport,
-        service: KEYCHAIN_CREDENTIAL_SERVICE,
-      }),
-    ).resolves.toMatchObject({ status: "retained" });
+    await expect(retireKey(roots, transport)).resolves.toMatchObject({ status: "retained" });
 
     await expect(telegramVault(roots, encryption).deleteProfile()).resolves.toMatchObject({
       outcome: "applied",
     });
 
-    await expect(
-      retireKeychainKeyWhenLastEnvelopeGone({
-        ...roots,
-        transport,
-        service: KEYCHAIN_CREDENTIAL_SERVICE,
-      }),
-    ).resolves.toEqual({ status: "deleted" });
+    await expect(retireKey(roots, transport)).resolves.toEqual({ status: "deleted" });
     expect(transport.requests).toEqual([
       { op: "delete-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
     ]);
@@ -186,14 +201,9 @@ describe("keychain key retirement", () => {
     const transport = transportOf();
 
     await expect(
-      retireKeychainKeyWhenLastEnvelopeGone({
-        ...roots,
-        transport,
-        service: KEYCHAIN_CREDENTIAL_SERVICE,
-        readEnvelopeFile: (async () => {
-          throw Object.assign(new Error("synthetic read failure"), { code: "EACCES" });
-        }) as never,
-      }),
+      retireKey(roots, transport, (async () => {
+        throw Object.assign(new Error("synthetic read failure"), { code: "EACCES" });
+      }) as never),
     ).resolves.toMatchObject({ status: "retained" });
     expect(transport.requests).toHaveLength(0);
   });
@@ -202,19 +212,11 @@ describe("keychain key retirement", () => {
     const roots = await fixture();
 
     await expect(
-      retireKeychainKeyWhenLastEnvelopeGone({
-        ...roots,
-        transport: transportOf({ ok: true, op: "delete-key", deleted: false }),
-        service: KEYCHAIN_CREDENTIAL_SERVICE,
-      }),
+      retireKey(roots, transportOf({ ok: true, op: "delete-key", deleted: false })),
     ).resolves.toEqual({ status: "already-absent" });
 
     await expect(
-      retireKeychainKeyWhenLastEnvelopeGone({
-        ...roots,
-        transport: transportOf({ ok: false, code: "keychain-locked" }),
-        service: KEYCHAIN_CREDENTIAL_SERVICE,
-      }),
+      retireKey(roots, transportOf({ ok: false, code: "keychain-locked" })),
     ).resolves.toEqual({ status: "failed", code: "keychain-locked" });
   });
 });

--- a/apps/desktop/tests/macos-release-plan.test.ts
+++ b/apps/desktop/tests/macos-release-plan.test.ts
@@ -65,6 +65,12 @@ const verifiedKeychainHelper = Object.freeze({
   teamIdentifier: "FA494ACVTF",
   designatedRequirement: 'identifier "keychain-helper" and anchor apple generic',
 });
+const verifiedBackendSelection = Object.freeze({
+  helper: "/synthetic/Enduragent.app/Contents/Resources/keychain/keychain-helper",
+  service: "icu.enduragent.desktop",
+  teamIdentifier: "FA494ACVTF",
+  designatedRequirement: 'identifier "keychain-helper" and anchor apple generic',
+});
 const temporaryRoots: string[] = [];
 
 afterEach(async () => {
@@ -95,6 +101,10 @@ function baselineVerifier() {
 
 function keychainHelperVerifier() {
   return vi.fn(async () => verifiedKeychainHelper);
+}
+
+function backendSelectionVerifier() {
+  return vi.fn(async () => verifiedBackendSelection);
 }
 
 function verifiedReleaseArtifactsAt(artifactDirectory: string) {
@@ -479,6 +489,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
     const sealReleaseMetadata = vi.fn(async () => {});
     const verifyPackageLayout = vi.fn(async () => {});
     const verifyKeychainHelper = keychainHelperVerifier();
+    const verifyBackendSelection = backendSelectionVerifier();
     const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
       if (executable === "/usr/bin/codesign" && arguments_.includes("--display")) {
         return canonicalDmgSigningIdentityResult();
@@ -526,6 +537,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
         verifyBaselineApplication,
         verifyPackageLayout,
         verifyKeychainHelper,
+        verifyBackendSelection,
         verifyIdentityContinuity,
         verifyReleaseApplicationContents,
         promoteReleaseEnvelope,
@@ -615,7 +627,12 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
     expect(verifyPackageLayout.mock.invocationCallOrder[0]).toBeLessThan(
       verifyKeychainHelper.mock.invocationCallOrder[0]!,
     );
+    expect(verifyBackendSelection).toHaveBeenCalledOnce();
+    expect(verifyBackendSelection).toHaveBeenCalledWith(application);
     expect(verifyKeychainHelper.mock.invocationCallOrder[0]).toBeLessThan(
+      verifyBackendSelection.mock.invocationCallOrder[0]!,
+    );
+    expect(verifyBackendSelection.mock.invocationCallOrder[0]).toBeLessThan(
       verifyIdentityContinuity.mock.invocationCallOrder[0]!,
     );
     expect(verifyIdentityContinuity.mock.invocationCallOrder[0]).toBeLessThan(
@@ -646,6 +663,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
       "electron-builder",
       "package-layout",
       "keychain-helper",
+      "backend-selection",
       "identity-continuity",
       "dmg-notarization",
       "dmg-verification",
@@ -677,12 +695,51 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
           sealReleaseMetadata,
           verifyBaselineApplication: baselineVerifier(),
           verifyKeychainHelper: keychainHelperVerifier(),
+          verifyBackendSelection: backendSelectionVerifier(),
           verifyPackageLayout,
         },
       ),
     ).rejects.toBe(failure);
     expect(build).toHaveBeenCalledOnce();
     expect(verifyPackageLayout).toHaveBeenCalledOnce();
+    expect(sealReleaseMetadata).not.toHaveBeenCalled();
+  });
+
+  it("fails the release before notarization when backend selection is rejected", async () => {
+    const build = vi.fn(async (_options: MacosReleaseBuilderOptions) => []);
+    const sealReleaseMetadata = vi.fn(async () => {});
+    const notarize = vi.fn(async () => {});
+    const verifyIdentityContinuity = vi.fn(async () => verifiedLooseIdentity);
+    const failure = new Error("bundled keychain helper refused the capability probe");
+    const verifyBackendSelection = vi.fn(async () => {
+      throw failure;
+    });
+    await expect(
+      runMacosRelease(
+        {
+          repositoryRoot: "/synthetic/repository",
+          desktopRoot: "/synthetic/repository/apps/desktop",
+          feedUrl,
+          identity,
+          baselineApplication,
+        },
+        {
+          readFile: versionReader(),
+          environment: notarizationEnvironment,
+          build,
+          sealReleaseMetadata,
+          notarize,
+          verifyBaselineApplication: baselineVerifier(),
+          verifyPackageLayout: vi.fn(async () => {}),
+          verifyKeychainHelper: keychainHelperVerifier(),
+          verifyBackendSelection,
+          verifyIdentityContinuity,
+        },
+      ),
+    ).rejects.toBe(failure);
+    expect(verifyBackendSelection).toHaveBeenCalledOnce();
+    expect(verifyIdentityContinuity).not.toHaveBeenCalled();
+    expect(notarize).not.toHaveBeenCalled();
     expect(sealReleaseMetadata).not.toHaveBeenCalled();
   });
 
@@ -720,6 +777,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
           sealReleaseMetadata,
           verifyBaselineApplication: baselineVerifier(),
           verifyKeychainHelper: keychainHelperVerifier(),
+          verifyBackendSelection: backendSelectionVerifier(),
           verifyPackageLayout,
           verifyIdentityContinuity,
           promoteReleaseEnvelope,
@@ -930,6 +988,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
           sealReleaseMetadata,
           verifyBaselineApplication: baselineVerifier(),
           verifyKeychainHelper: keychainHelperVerifier(),
+          verifyBackendSelection: backendSelectionVerifier(),
           verifyPackageLayout,
           verifyIdentityContinuity,
           notarize,
@@ -971,6 +1030,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
           build,
           verifyBaselineApplication: baselineVerifier(),
           verifyKeychainHelper: keychainHelperVerifier(),
+          verifyBackendSelection: backendSelectionVerifier(),
           verifyPackageLayout,
           verifyIdentityContinuity,
           executeFile,
@@ -1047,6 +1107,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
         build: vi.fn(async () => []),
         verifyBaselineApplication: baselineVerifier(),
         verifyKeychainHelper: keychainHelperVerifier(),
+        verifyBackendSelection: backendSelectionVerifier(),
         verifyPackageLayout: vi.fn(async () => {}),
         verifyIdentityContinuity,
         verifyReleaseApplicationContents,
@@ -1110,6 +1171,7 @@ describe.skipIf(process.platform === "win32")("macOS release plan", () => {
           build: vi.fn(async () => []),
           verifyBaselineApplication: baselineVerifier(),
           verifyKeychainHelper: keychainHelperVerifier(),
+          verifyBackendSelection: backendSelectionVerifier(),
           verifyPackageLayout: vi.fn(async () => {}),
           verifyIdentityContinuity: vi.fn(async () => verifiedLooseIdentity),
           notarize: vi.fn(async () => {}),

--- a/apps/desktop/tests/platform-copy.test.ts
+++ b/apps/desktop/tests/platform-copy.test.ts
@@ -12,7 +12,7 @@ describe("desktop platform projection", () => {
         operatingSystem: "macOS",
         credentialEncryptionUnavailable:
           "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
-        credentialRecoveryAction: "unlock or approve Keychain access",
+        credentialRecoveryAction: "unlock your login keychain",
         restartComputer: "restart your Mac",
         rideImportDescription:
           "Add FIT, TCX or GPX files from this Mac. You can also drop them onto the window.",

--- a/apps/desktop/tests/verify-macos-backend-selection.test.ts
+++ b/apps/desktop/tests/verify-macos-backend-selection.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi, type Mock } from "vitest";
+import { KEYCHAIN_HELPER_RESOURCE_PATH } from "../scripts/package-inventory.mjs";
+import {
+  BACKEND_SELECTION_SERVICE,
+  BACKEND_SELECTION_TEAM_IDENTIFIER,
+  backendSelectionProbeRequest,
+  safeMacosBackendSelectionMessage,
+  verifyMacosBackendSelection,
+} from "../scripts/verify-macos-backend-selection.mjs";
+
+const application = "/synthetic/dist/mac-arm64/Enduragent.app";
+const helper = `${application}/Contents/Resources/${KEYCHAIN_HELPER_RESOURCE_PATH}`;
+const signedHelper = Object.freeze({
+  teamIdentifier: "FA494ACVTF",
+  designatedRequirement: 'identifier "keychain-helper" and anchor apple generic',
+});
+
+function probeAnswer(payload: unknown) {
+  return vi.fn(async () => `${JSON.stringify(payload)}\n`);
+}
+
+interface HelperOverrides {
+  readonly requireHelper: Mock;
+  readonly verifyKeychainHelper: Mock;
+  readonly runHelper: Mock;
+}
+
+function overrides(extra: Partial<HelperOverrides> = {}): HelperOverrides {
+  return {
+    requireHelper: vi.fn(async () => {}),
+    verifyKeychainHelper: vi.fn(async () => signedHelper),
+    runHelper: probeAnswer({
+      ok: true,
+      op: "probe",
+      teamIdentifier: BACKEND_SELECTION_TEAM_IDENTIFIER,
+    }),
+    ...extra,
+  };
+}
+
+describe("macOS backend selection verification", () => {
+  it("probes the bundled helper only after its signature is verified", async () => {
+    const dependencies = overrides();
+
+    const verified = await verifyMacosBackendSelection(application, dependencies);
+
+    expect(verified).toEqual({
+      helper,
+      service: BACKEND_SELECTION_SERVICE,
+      teamIdentifier: BACKEND_SELECTION_TEAM_IDENTIFIER,
+      designatedRequirement: signedHelper.designatedRequirement,
+    });
+    expect(Object.isFrozen(verified)).toBe(true);
+    expect(dependencies.requireHelper).toHaveBeenCalledWith(helper);
+    expect(dependencies.verifyKeychainHelper).toHaveBeenCalledWith(application);
+    expect(dependencies.runHelper).toHaveBeenCalledWith(helper, backendSelectionProbeRequest());
+    expect(dependencies.requireHelper.mock.invocationCallOrder[0]).toBeLessThan(
+      dependencies.verifyKeychainHelper.mock.invocationCallOrder[0]!,
+    );
+    expect(dependencies.verifyKeychainHelper.mock.invocationCallOrder[0]).toBeLessThan(
+      dependencies.runHelper.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("asks the helper for a read-only probe of the signed-release service", () => {
+    expect(JSON.parse(backendSelectionProbeRequest())).toEqual({
+      op: "probe",
+      service: "icu.enduragent.desktop",
+    });
+    expect(backendSelectionProbeRequest().endsWith("\n")).toBe(true);
+  });
+
+  it("refuses a relative application path before touching the bundle", async () => {
+    const dependencies = overrides();
+
+    await expect(
+      verifyMacosBackendSelection("dist/mac-arm64/Enduragent.app", dependencies),
+    ).rejects.toThrow("application path must be absolute");
+    expect(dependencies.requireHelper).not.toHaveBeenCalled();
+  });
+
+  it("stops when the bundled helper is absent", async () => {
+    const dependencies = overrides({
+      requireHelper: vi.fn(async () => {
+        throw new Error("bundled keychain helper is missing");
+      }),
+    });
+
+    await expect(verifyMacosBackendSelection(application, dependencies)).rejects.toThrow(
+      "bundled keychain helper is missing",
+    );
+    expect(dependencies.verifyKeychainHelper).not.toHaveBeenCalled();
+    expect(dependencies.runHelper).not.toHaveBeenCalled();
+  });
+
+  it("never probes a helper whose signature verification fails", async () => {
+    const dependencies = overrides({
+      verifyKeychainHelper: vi.fn(async () => {
+        throw new Error("macOS keychain helper signing identity is invalid");
+      }),
+    });
+
+    await expect(verifyMacosBackendSelection(application, dependencies)).rejects.toThrow(
+      "macOS keychain helper signing identity is invalid",
+    );
+    expect(dependencies.runHelper).not.toHaveBeenCalled();
+  });
+
+  it("rejects a helper signed by another team", async () => {
+    const dependencies = overrides({
+      verifyKeychainHelper: vi.fn(async () => ({ ...signedHelper, teamIdentifier: "ZZZZZZZZZZ" })),
+    });
+
+    await expect(verifyMacosBackendSelection(application, dependencies)).rejects.toThrow(
+      "bundled keychain helper signing identity is invalid",
+    );
+    expect(dependencies.runHelper).not.toHaveBeenCalled();
+  });
+
+  it("rejects a refused capability probe", async () => {
+    const dependencies = overrides({
+      runHelper: probeAnswer({ ok: false, code: "not-team-signed" }),
+    });
+
+    await expect(verifyMacosBackendSelection(application, dependencies)).rejects.toThrow(
+      "bundled keychain helper refused the capability probe",
+    );
+  });
+
+  it("rejects a probe answering another team identifier", async () => {
+    const dependencies = overrides({
+      runHelper: probeAnswer({ ok: true, op: "probe", teamIdentifier: "ZZZZZZZZZZ" }),
+    });
+
+    await expect(verifyMacosBackendSelection(application, dependencies)).rejects.toThrow(
+      "bundled keychain helper reported an unexpected team identifier",
+    );
+  });
+
+  it.each([
+    ["", "bundled keychain helper answered nothing"],
+    ["not json", "bundled keychain helper answered malformed JSON"],
+    ["[]", "bundled keychain helper answered malformed JSON"],
+    ['{"ok":true,"op":"read-key","key":"AA=="}', "bundled keychain helper refused the capability"],
+  ])("rejects the probe answer %j", async (line, message) => {
+    const dependencies = overrides({ runHelper: vi.fn(async () => line) });
+
+    await expect(verifyMacosBackendSelection(application, dependencies)).rejects.toThrow(message);
+  });
+
+  it("names its own failures and stays silent about foreign errors", async () => {
+    const dependencies = overrides({
+      runHelper: probeAnswer({ ok: false, code: "keychain-locked" }),
+    });
+    const failure = await verifyMacosBackendSelection(application, dependencies).catch(
+      (error: unknown) => error,
+    );
+
+    expect(safeMacosBackendSelectionMessage(failure)).toBe(
+      "bundled keychain helper refused the capability probe",
+    );
+    expect(safeMacosBackendSelectionMessage(new Error("something else"))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Child PR 4 of epic #672 — the flip and the release assertion. **Operator review required; do not self-merge.** Per the epic's decision record this merges only after `verify:mac-backend-selection` has passed against a real notarized artifact.

## What

- `src/main/desktop-credential-encryption.ts` — the startup seam: service per lane (`icu.enduragent.desktop` packaged, `icu.enduragent.desktop.dev` dev/unpackaged, using the existing packaged discriminator), helper path resolution, ONE `selectDesktopCredentialBackend` call, and a retirement function bound to the same transport/service/roots. A thrown selection maps to a refusal — never a safeStorage downgrade.
- `src/main/index.ts` — selection runs once after the daemon home is resolved, before both vaults; all three `encryption:` sites consume the selection result; both vaults get `observeEnvelopeRemoved` wired to key retirement; a darwin-only stderr line names the selected backend so the operator's notarized-build run can read it without new UI.
- Key retirement **rotates** rather than deleting bare: at last-envelope-gone, `delete-key` → `create-key` → the session's key holder swaps, so the old key is crypto-shredded while later writes in the same session stay readable. On a failed create the holder is nulled — the port refuses (`encryption-unavailable`) instead of ever sealing under a dead key.
- `scripts/verify-macos-backend-selection.mjs` + `macos-release-plan.mjs` `backend-selection` stage (candidate app only): helper present at `Contents/Resources/keychain/keychain-helper`, signature via `verifyMacosKeychainHelper`, and the BUNDLED helper answering the probe with team `FA494ACVTF`. The probe never touches keychain items. Available standalone: `pnpm --filter @enduragent/desktop verify:mac-backend-selection <abs-app-path>`.
- `credentialRecoveryAction` copy updated to "unlock your login keychain" in both `platform-copy.ts` mirrors, with their pinning tests.

## Adversarial verify

Four read-only lenses. Flip-correctness and release-assertion passed clean (startup ordering, single selection call, candidate-only stage). Service-lane-safety found one structural defect — retiring the key while the session cached it would orphan credentials written later that session. Fixed by the rotation design above (second commit), pinned by round-trip-after-retirement and refuse-on-failed-rotation tests, and re-verified by a fresh read-only agent (CONFIRMED-FIXED). Its one residual — a cross-vault write race two helper round-trips wide, detected as re-prompt, pre-dating the fix — is filed as ticket 299. The rollback-on-runtime-refusal path deliberately does not retire (it undoes a just-refused write, and a zero-envelope key item is recreated at next startup regardless).

## New limits

- `BACKEND_SELECTION_PROBE_TIMEOUT_MS = 15000` (release script) — bounds a hung bundled-helper spawn; larger than the runtime 5000ms because a freshly notarized binary's first launch pays Gatekeeper assessment.
- `BACKEND_SELECTION_MAX_RESPONSE_BYTES = 8192` (release script) — caps helper stdout before parsing; mirrors the runtime cap.
- No limits added to shipped app code; migration deliberately has no retry counter.

## Verification

- Full workspace: 615 files, 9627 tests pass (twice). Desktop + renderer: 145 files, 2634 tests.
- `tsc --noEmit`, `tsc -p tsconfig.check.json`, oxlint (0 new), oxfmt clean on touched files.
- No `.github/workflows/` change needed: the stage runs inside `runMacosRelease`.

## What only a signed/notarized artifact can prove (operator's evidence lane)

The bundled helper answering the probe from inside a signed bundle; `verifyMacosKeychainHelper` against a real signature; a packaged signed startup actually selecting `keychain_partition_v1`; prompt-free item creation and migration off real safeStorage envelopes; prod/dev service disjointness; the 15s probe timeout under first-launch Gatekeeper assessment; `delete-key` against a real keychain. Plus the operator acceptance test: notarized build, launched from a different path than the one that stored the credentials, decrypts silently.

No changeset: desktop-only; the npm package is untouched.