### PR TITLE
fix(sync): keep syncing when intervals.icu returns Strava stubs

### DIFF
--- a/.changeset/strava-sourced-activities-no-longer-break-sync.md
+++ b/.changeset/strava-sourced-activities-no-longer-break-sync.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Your training history now syncs even when most of your rides came from Strava — the sessions intervals.icu can share are saved instead of the whole sync failing with no data at all.
+
+intervals.icu cannot expose activity detail for Strava-sourced rows under the Strava API Agreement, so it returns a five-key placeholder with no `type`, `moving_time`, `elapsed_time` or streams. The activity index treated a missing `type` as a fatal transport error and aborted the entire pull, so a single placeholder wiped out every other activity in the same window. Placeholder rows are now dropped from the index; rows that do carry a `type` keep the identical strict validation. The `intervals-icu-api` bump to 0.4.0 makes `Activity.type` nullish so the response array parses at all, and the reference sport-adapter dispatcher guards `null` as well as `undefined`.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vitest/coverage-v8": "^4.1.4",
     "@xmldom/xmldom": "0.9.10",
     "ai": "^6.0.158",
-    "intervals-icu-api": "0.3.1",
+    "intervals-icu-api": "0.4.0",
     "msw": "^2.13.3",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",

--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -47,7 +47,7 @@
     "@enduragent/kernel-node": "workspace:*",
     "@enduragent/sync-intervals-icu": "workspace:*",
     "@enduragent/sport-cycling": "workspace:*",
-    "intervals-icu-api": "0.3.1",
+    "intervals-icu-api": "0.4.0",
     "ws": "^8.21.3",
     "yaml": "^2.8.3"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "@grammyjs/auto-retry": "^2.0.2",
     "ai": "^6.0.158",
     "grammy": "^1.42.0",
-    "intervals-icu-api": "^0.3.1",
+    "intervals-icu-api": "^0.4.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/reference/sport-adapter-dispatcher.ts
+++ b/packages/core/src/reference/sport-adapter-dispatcher.ts
@@ -39,10 +39,10 @@ export function findAdapterForActivity(
   activity: Activity,
 ): ReferenceSportAdapter | null {
   const type = activity.type;
-  // `Activity.type` is typed as a required string, but a malformed upstream row
-  // can still arrive without it at runtime — so this guard is load-bearing, not
-  // dead code; don't strip it. A gap here is silent (never a warn).
-  if (type === undefined) return null;
+  // `Activity.type` is typed as nullish, and an upstream row can arrive without
+  // it at runtime — so this guard is load-bearing, not dead code; don't strip
+  // it. A gap here is silent (never a warn).
+  if (type == null) return null;
   return adapters.find((a) => adapterCoversType(a, type)) ?? null;
 }
 
@@ -73,7 +73,7 @@ export function runAdaptersForActivities(
   const sportFamilies = new Set(sportTypes.map((t) => familyOf(t, t)));
   for (const activity of activities) {
     const type = activity.type;
-    if (type === undefined) continue;
+    if (type == null) continue;
     const family = familyOf(type, type);
     const adapter = findAdapterForActivity(adapters, activity);
     if (adapter) {

--- a/packages/core/tests/reference-sport-adapter-dispatcher.test.ts
+++ b/packages/core/tests/reference-sport-adapter-dispatcher.test.ts
@@ -80,6 +80,13 @@ describe("findAdapterForActivity", () => {
     expect(findAdapterForActivity([cyclingAdapter, runningAdapter], activity("Skydive"))).toBeNull();
   });
 
+  it("returns null without warning for a Strava stub whose type is null", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stub = { id: "12345", startDateLocal: "1998-08-20T14:08:41", type: null } as unknown as Activity;
+    expect(findAdapterForActivity([cyclingAdapter], stub)).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("returns null without warning for a malformed row whose type is missing", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const malformed = { id: "12345", startDateLocal: "1998-06-04T12:00:00" } as unknown as Activity;
@@ -143,6 +150,14 @@ describe("runAdaptersForActivities", () => {
   it("silently skips an out-of-sport type without warning", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const runs = runAdaptersForActivities([cyclingAdapter], cyclingTypes, [activity("Swim")]);
+    expect(runs).toHaveLength(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("silently skips a Strava stub whose type is null", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stub = { id: "12345", startDateLocal: "1998-08-20T14:08:41", type: null } as unknown as Activity;
+    const runs = runAdaptersForActivities([cyclingAdapter], cyclingTypes, [stub]);
     expect(runs).toHaveLength(0);
     expect(warn).not.toHaveBeenCalled();
   });

--- a/packages/cycling-coach/package.json
+++ b/packages/cycling-coach/package.json
@@ -37,7 +37,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "ai": "^6.0.158",
     "grammy": "^1.42.0",
-    "intervals-icu-api": "^0.3.1",
+    "intervals-icu-api": "^0.4.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -36,7 +36,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "@openrouter/ai-sdk-provider": "^2.9.1",
     "ai": "^6.0.158",
-    "intervals-icu-api": "^0.3.1",
+    "intervals-icu-api": "^0.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/sport-cycling/package.json
+++ b/packages/sport-cycling/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@enduragent/engine": "workspace:*",
     "@enduragent/kernel": "workspace:*",
-    "intervals-icu-api": "^0.3.1",
+    "intervals-icu-api": "^0.4.0",
     "ai": "^6.0.158",
     "zod": "^4.3.6"
   },

--- a/packages/sport-running/package.json
+++ b/packages/sport-running/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@enduragent/engine": "workspace:*",
     "@enduragent/kernel": "workspace:*",
-    "intervals-icu-api": "^0.3.1",
+    "intervals-icu-api": "^0.4.0",
     "ai": "^6.0.158",
     "zod": "^4.3.6"
   },

--- a/packages/sync-intervals-icu/package.json
+++ b/packages/sync-intervals-icu/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@enduragent/kernel": "workspace:*",
     "fflate": "0.8.3",
-    "intervals-icu-api": "^0.3.1"
+    "intervals-icu-api": "^0.4.0"
   },
   "devDependencies": {
     "tsup": "^8.4.0",

--- a/packages/sync-intervals-icu/src/source.ts
+++ b/packages/sync-intervals-icu/src/source.ts
@@ -71,15 +71,17 @@ interface ActivityIndexEntry extends ReturnType<typeof activityIdentity> {
 
 function activityIndex(value: unknown): readonly ActivityIndexEntry[] {
   if (!Array.isArray(value)) throw new TypeError("activities response is invalid");
-  const rows = value.map((entry) => {
+  const rows: ActivityIndexEntry[] = [];
+  for (const entry of value) {
     const row = objectRow(entry, "activity row");
-    nonempty(row.type, "activity type");
+    const type = row.type;
+    if (typeof type !== "string" || type.length === 0) continue;
     for (const [field, label] of [["moving_time", "moving time"], ["elapsed_time", "elapsed time"]] as const) {
       const item = row[field];
       if (typeof item !== "number" || !Number.isSafeInteger(item) || item < 0) throw new TypeError(`activity ${label} is invalid`);
     }
-    return { ...activityIdentity(row), row };
-  });
+    rows.push({ ...activityIdentity(row), row });
+  }
   rows.sort((a, b) => compareBinary(a.key, b.key));
   return rows;
 }

--- a/packages/sync-intervals-icu/tests/source.test.ts
+++ b/packages/sync-intervals-icu/tests/source.test.ts
@@ -206,6 +206,38 @@ describe("intervals.icu full-history source", () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("stores every visible activity when Strava stubs dominate the page", async () => {
+    const stub = (index: number) => ({ id: `strava-${String(index).padStart(2, "0")}`, icu_athlete_id: "i12345",
+      start_date_local: "1998-08-20T14:08:41", source: "STRAVA", _note: "STRAVA activities are not available via the API" });
+    const visible = Array.from({ length: 7 }, (_, index) => activity(`visible-${index}`, `1998-03-0${index + 1}`));
+    const page = [...Array.from({ length: 60 }, (_, index) => stub(index)), ...visible];
+
+    const result = await collect(source({ fetch: async () => json(page) }).pull(watermark("activities"), budget()));
+
+    const snapshots = result.filter((entry) => (entry as { kind: string }).kind === "snapshot");
+    expect(snapshots).toHaveLength(7);
+    expect(snapshots.map((entry) => (entry as { externalId: string }).externalId).sort())
+      .toEqual(visible.map((entry) => entry.id).sort());
+    expect(result.at(-1)).toMatchObject({ kind: "checkpoint" });
+  });
+
+  it("stores all 67 rows when the page carries no Strava stubs", async () => {
+    const page = Array.from({ length: 67 }, (_, index) => activity(
+      `full-${String(index).padStart(2, "0")}`,
+      `1998-0${Math.floor(index / 28) + 1}-${String((index % 28) + 1).padStart(2, "0")}`,
+    ));
+
+    const result = await collect(source({ fetch: async () => json(page) }).pull(watermark("activities"), budget()));
+
+    expect(result.filter((entry) => (entry as { kind: string }).kind === "snapshot")).toHaveLength(67);
+  });
+
+  it("still rejects a typed activity row with an invalid elapsed time", async () => {
+    const broken = { ...activity("broken"), elapsed_time: -1 };
+    await expect(collect(source({ fetch: async () => json([broken]) }).pull(watermark("activities"), budget())))
+      .rejects.toThrow("activity elapsed time is invalid");
+  });
+
   it("charges the injected physical-attempt ledger at the actual source request", async () => {
     const attemptLedger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
     await collect(source({ fetch: async () => json([]) }, { attemptLedger })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: 0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: 0.4.0
+        version: 0.4.0(typescript@6.0.3)
       msw:
         specifier: ^2.13.3
         version: 2.14.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -247,8 +247,8 @@ importers:
         specifier: workspace:*
         version: link:../sync-intervals-icu
       intervals-icu-api:
-        specifier: 0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: 0.4.0
+        version: 0.4.0(typescript@6.0.3)
       ws:
         specifier: ^8.21.3
         version: 8.21.3
@@ -368,8 +368,8 @@ importers:
         specifier: ^1.42.0
         version: 1.42.0
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -426,8 +426,8 @@ importers:
         specifier: ^1.42.0
         version: 1.42.0
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -512,8 +512,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -621,8 +621,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -671,8 +671,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -721,8 +721,8 @@ importers:
         specifier: 0.8.3
         version: 0.8.3
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
     devDependencies:
       tsup:
         specifier: ^8.4.0
@@ -3245,8 +3245,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  intervals-icu-api@0.3.1:
-    resolution: {integrity: sha512-W1zKgPpPTbT3TtqF/PGSaarcMxpKBC6SQnFOvRsJ5Te9Hp7LPav5pLi5lWY8lqXtXrSt2Ab74ZFHICiBOZuEqA==}
+  intervals-icu-api@0.4.0:
+    resolution: {integrity: sha512-N0GdEhFu/dCPjLQrezkydObmzKabQfALU/3fIMREfKKoFDP78PepnRj1VRzfplhI/iFeVDTAlkoxbTDfQXIncQ==}
     engines: {node: '>=18'}
 
   ip-address@10.4.0:
@@ -7336,7 +7336,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  intervals-icu-api@0.3.1(typescript@6.0.3):
+  intervals-icu-api@0.4.0(typescript@6.0.3):
     dependencies:
       openapi-fetch: 0.17.0
       valibot: 1.3.1(typescript@6.0.3)


### PR DESCRIPTION
## The bug

An athlete synced 67 activities and got "Training data unavailable" with no training data at all. 60 of the 67 were Strava-sourced.

Under the Strava API Agreement, intervals.icu may not hand Strava-sourced activity data to a third-party application. For those rows its API returns a five-key placeholder instead of an activity:

```json
{
  "id": "12345678",
  "icu_athlete_id": "i12345",
  "start_date_local": "1998-08-20T14:08:41",
  "source": "STRAVA",
  "_note": "STRAVA activities are not available via the API"
}
```

No `type`, no `moving_time`, no `elapsed_time`, no `name`, no streams.

`activityIndex` in `packages/sync-intervals-icu/src/source.ts` treated a missing `type` as a fatal transport error and threw outside any try/catch. One placeholder anywhere in the page aborted the whole pull, so the 7 activities intervals.icu *could* share were lost along with the 60 it could not.

## The fix

- `activityIndex` now DROPS a row with no usable `type` instead of throwing. A row that does carry a `type` keeps the identical strict validation, including the `moving_time` and `elapsed_time` safe-integer checks — those checks are simply not reached for a placeholder, which has none of the three fields.
- `intervals-icu-api` 0.3.1 -> 0.4.0. 0.4.0 makes `ActivitySchema.type` nullish, so the response array parses at all instead of the library rejecting the whole page.
- `findAdapterForActivity` and `runAdaptersForActivities` in `packages/core/src/reference/sport-adapter-dispatcher.ts` now guard `type == null` rather than `type === undefined`. `v.nullish()` admits `null`, which strict equality against `undefined` misses.
- The stale comment above that guard claimed `Activity.type` is "typed as a required string". 0.4.0 makes that false, so the clause is corrected. The guard stays.

## Behaviour after this PR

A sync of 67 activities where 60 are Strava placeholders completes and stores the 7 visible ones.

## Deliberately unchanged

- `packages/kernel/src/reference/schemas/inputs.ts` stays strict. Placeholders die at the sync boundary; the kernel contract does not loosen.
- `packages/core/src/reference/sync/fetch-live-bundle.ts` needs nothing: its per-row `safeParse` already drops type-less rows now that the library stops rejecting the whole array.
- `packages/sync-intervals-icu/src/landing.ts` needs nothing: its `nonempty(activity.type, ...)` is unreachable with a placeholder once the index drops it. Every `mapActivityLanding` call site is fed either by the dropped-clean index or from inside an existing try/catch.
- No counting, no athlete-facing copy, no message changes. Those are separate.

## Tests

`packages/sync-intervals-icu/tests/source.test.ts`

- 60 placeholders + 7 real rows in one page -> the pull completes, yields exactly the 7 real `externalId`s, and checkpoints. Verified red before the fix: `TypeError: activity type is invalid`.
- 67 real rows, no placeholders -> 67 snapshots, so the drop path cannot silently eat good rows.
- A typed row with `elapsed_time: -1` still rejects, so the strict path is unchanged.

`packages/core/tests/reference-sport-adapter-dispatcher.test.ts`

- Both dispatcher entry points skip a `type: null` row silently, with no warn.

## Limits

None added or changed.

## Gates

- `pnpm check` — pass (exit 0).
- `pnpm test` (full suite) — 9493 passed, 14 failed in 2 files. All 14 are pre-existing and fail identically on the clean epic branch with these changes stashed: `packages/coach-client/tests/client.test.ts` (13x `ReferenceError: CloseEvent is not defined`) and `packages/coach/tests/upgrade-fence.test.ts` (`reports an unusably long socket path`). Neither file is touched by this PR.
