### PR TITLE
fix(sync): survive and explain Strava-restricted activities

### DIFF
--- a/.changeset/count-source-restricted-activity-drops.md
+++ b/.changeset/count-source-restricted-activity-drops.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+Carry balanced activity visibility summaries from the current intervals.icu reference fetch to sync consumers.
+
+`SyncRpcResult` now reports `overall` and `recent7Days` windows. Each window includes its raw total, visible count, other malformed rows, and sorted per-source restrictions with the `source-restricted` reason. Both windows must balance, and recent counts cannot exceed their overall counterparts. Detection still uses exact `source === "STRAVA"`; the contract supports additional providers without collapsing them into one source. Counts stay in memory, come from the same fetch that supplies training context, and no longer come from historical backfill. Mid-page capture resumes report a page's dropped rows once. `PROTOCOL_VERSION` moves from 18 to 19. No athlete-facing copy changes.

--- a/.changeset/explain-strava-restricted-activities.md
+++ b/.changeset/explain-strava-restricted-activities.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Explained when Strava API restrictions hide activities, with separate recovery steps for future and past rides.
+
+Show the restricted count after sync on the Training page, in the sidebar, and in Telegram. Direct athletes to connect their recording source to intervals.icu for future rides or use Import All Strava Data with an intervals.icu supporter subscription for history.

--- a/.changeset/refuse-source-restricted-coaching.md
+++ b/.changeset/refuse-source-restricted-coaching.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Coaching panels now say when hidden source data makes an answer unreliable.
+
+Refuse adherence after any restricted recent activity, and refuse load, performance, and recent-ride panels when half their activity window is restricted.

--- a/.changeset/strava-sourced-activities-no-longer-break-sync.md
+++ b/.changeset/strava-sourced-activities-no-longer-break-sync.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Your training history now syncs even when most of your rides came from Strava — the sessions intervals.icu can share are saved instead of the whole sync failing with no data at all.
+
+intervals.icu cannot expose activity detail for Strava-sourced rows under the Strava API Agreement, so it returns a five-key placeholder with no `type`, `moving_time`, `elapsed_time` or streams. The activity index treated a missing `type` as a fatal transport error and aborted the entire pull, so a single placeholder wiped out every other activity in the same window. Placeholder rows are now dropped from the index; rows that do carry a `type` keep the identical strict validation. The `intervals-icu-api` bump to 0.4.0 makes `Activity.type` nullish so the response array parses at all, and the reference sport-adapter dispatcher guards `null` as well as `undefined`.

--- a/apps/desktop-renderer/src/training-context/manual-sync.ts
+++ b/apps/desktop-renderer/src/training-context/manual-sync.ts
@@ -1,4 +1,8 @@
-import type { TrainingSyncCoordinator, TrainingSyncState } from "../training-sync.js";
+import type {
+  TrainingSyncCoordinator,
+  TrainingSyncDroppedActivities,
+  TrainingSyncState,
+} from "../training-sync.js";
 
 export const SYNC_QUEUED_COPY = "Sync queued.";
 export const SYNC_RUNNING_COPY = "Syncing training data…";
@@ -13,12 +17,41 @@ export const SYNC_INDETERMINATE_COPY =
 export const SYNC_PROTOCOL_COPY =
   "Enduragent couldn’t verify the sync result. Quit and reopen Enduragent.";
 
+export const STRAVA_RESTRICTION_DESKTOP_COPY = Object.freeze({
+  syncMessage(count: number): string {
+    return count === 1
+      ? "A Strava API restriction prevents intervals.icu from sharing one activity, so it isn’t included."
+      : `A Strava API restriction prevents intervals.icu from sharing ${count} activities, so they aren’t included.`;
+  },
+  tooltipLead(count: number): string {
+    return count === 1 ? "1 activity hidden by Strava" : `${count} activities hidden by Strava`;
+  },
+  tooltipBody:
+    "A Strava API restriction prevents intervals.icu from sharing these activities with Enduragent.",
+  cardTitle(count: number, total: number): string {
+    return count === 1 && total === 1
+      ? "1 of 1 activity is hidden by Strava"
+      : `${count} of ${total} activities are hidden by Strava`;
+  },
+  cause:
+    "A Strava API restriction prevents intervals.icu from sharing activities that came from Strava with Enduragent. Your API key is fine.",
+  future:
+    "Connect your recording source directly to intervals.icu and keep Strava connected. This is free and covers future rides.",
+  past: "Use Import All Strava Data in intervals.icu settings. This covers past rides and requires an intervals.icu supporter subscription.",
+});
+
+export interface SourceRestrictionSummary {
+  readonly count: number;
+  readonly total: number;
+}
+
 export interface ManualSyncViewState {
   readonly label: "Sync now" | "Sync again" | "Try again" | "Sync unavailable";
   readonly message: string;
   readonly disabled: boolean;
   readonly busy: boolean;
   readonly tone: "idle" | "active" | "success" | "partial" | "failure";
+  readonly droppedActivities?: TrainingSyncDroppedActivities;
 }
 
 export interface ManualSyncView {
@@ -29,6 +62,19 @@ export interface ManualSyncView {
 export interface ManualSyncController {
   activate(kind: "keyboard" | "pointer"): Promise<void>;
   dispose(): void;
+}
+
+export function sourceRestrictionSummary(
+  droppedActivities: TrainingSyncDroppedActivities | undefined,
+  source: string,
+): SourceRestrictionSummary | null {
+  if (droppedActivities === undefined) return null;
+  const restriction = droppedActivities.overall.restrictions.find(
+    (entry) => entry.reason === "source-restricted" && entry.source === source,
+  );
+  return restriction === undefined
+    ? null
+    : { count: restriction.count, total: droppedActivities.overall.total };
 }
 
 export function toManualSyncViewState(state: TrainingSyncState): ManualSyncViewState {
@@ -51,14 +97,21 @@ export function toManualSyncViewState(state: TrainingSyncState): ManualSyncViewS
         busy: true,
         tone: "active",
       };
-    case "succeeded":
+    case "succeeded": {
+      const message = state.kind === "published" ? SYNC_PUBLISHED_COPY : SYNC_NO_CHANGE_COPY;
+      const restriction = sourceRestrictionSummary(state.droppedActivities, "STRAVA");
       return {
         label: "Sync again",
-        message: state.kind === "published" ? SYNC_PUBLISHED_COPY : SYNC_NO_CHANGE_COPY,
+        message:
+          restriction === null
+            ? message
+            : `${message} ${STRAVA_RESTRICTION_DESKTOP_COPY.syncMessage(restriction.count)}`,
         disabled: false,
         busy: false,
         tone: "success",
+        droppedActivities: state.droppedActivities,
       };
+    }
     case "failed":
       if (state.kind === "protocol") {
         return {
@@ -91,8 +144,16 @@ export function createManualSyncController(input: {
   let disposed = false;
   let activation = 0;
   let activationTask: Promise<void> | undefined;
+  let droppedActivities: TrainingSyncDroppedActivities | undefined;
   const unsubscribe = input.coordinator.subscribe((state) => {
-    if (!disposed) input.view.render(toManualSyncViewState(state));
+    if (disposed) return;
+    const next = toManualSyncViewState(state);
+    if (next.droppedActivities !== undefined) droppedActivities = next.droppedActivities;
+    input.view.render(
+      droppedActivities === undefined || next.droppedActivities !== undefined
+        ? next
+        : { ...next, droppedActivities },
+    );
   });
 
   return {

--- a/apps/desktop-renderer/src/training-sync.ts
+++ b/apps/desktop-renderer/src/training-sync.ts
@@ -10,10 +10,23 @@ import {
   type CoachClientTerminalEnvelope,
 } from "@enduragent/coach-client";
 import type {
+  ActivityRestriction,
   CoachOperationProgressNotificationEnvelope,
   SyncRpcResult,
 } from "@enduragent/coach-contract";
 import type { DesktopCoachClientProvider } from "./coach-client.js";
+
+interface TrainingSyncRestrictionWindow {
+  readonly total: number;
+  readonly visible: number;
+  readonly restrictions: readonly ActivityRestriction[];
+  readonly other: number;
+}
+
+export interface TrainingSyncDroppedActivities {
+  readonly overall: TrainingSyncRestrictionWindow;
+  readonly recent7Days: TrainingSyncRestrictionWindow;
+}
 
 export type TrainingSyncState =
   | { readonly status: "idle" }
@@ -23,6 +36,7 @@ export type TrainingSyncState =
       readonly status: "succeeded";
       readonly operation: number;
       readonly kind: "published" | "no-change";
+      readonly droppedActivities: TrainingSyncDroppedActivities;
     }
   | {
       readonly status: "failed";
@@ -50,6 +64,27 @@ function isIndeterminateFailure(error: unknown): boolean {
   );
 }
 
+function isSameRestrictionWindow(
+  left: TrainingSyncRestrictionWindow,
+  right: TrainingSyncRestrictionWindow,
+): boolean {
+  return (
+    left.total === right.total &&
+    left.visible === right.visible &&
+    left.other === right.other &&
+    left.restrictions.length === right.restrictions.length &&
+    left.restrictions.every((entry, index) => {
+      const other = right.restrictions[index];
+      return (
+        other !== undefined &&
+        entry.reason === other.reason &&
+        entry.source === other.source &&
+        entry.count === other.count
+      );
+    })
+  );
+}
+
 function isSameTrainingSyncState(left: TrainingSyncState, right: TrainingSyncState): boolean {
   switch (left.status) {
     case "idle":
@@ -61,7 +96,15 @@ function isSameTrainingSyncState(left: TrainingSyncState, right: TrainingSyncSta
       return (
         right.status === "succeeded" &&
         right.operation === left.operation &&
-        right.kind === left.kind
+        right.kind === left.kind &&
+        isSameRestrictionWindow(
+          right.droppedActivities.overall,
+          left.droppedActivities.overall,
+        ) &&
+        isSameRestrictionWindow(
+          right.droppedActivities.recent7Days,
+          left.droppedActivities.recent7Days,
+        )
       );
     case "failed":
       return (
@@ -289,9 +332,19 @@ export function createTrainingSyncCoordinator(input: {
           retryable: true,
         });
       } else if (result.published && result.referenceSucceeded) {
-        publish({ status: "succeeded", operation: selectedOperation, kind: "published" });
+        publish({
+          status: "succeeded",
+          operation: selectedOperation,
+          kind: "published",
+          droppedActivities: result.droppedActivities,
+        });
       } else if (!result.published && result.referenceSucceeded) {
-        publish({ status: "succeeded", operation: selectedOperation, kind: "no-change" });
+        publish({
+          status: "succeeded",
+          operation: selectedOperation,
+          kind: "no-change",
+          droppedActivities: result.droppedActivities,
+        });
       } else if (result.published) {
         publish({
           status: "failed",

--- a/apps/desktop-renderer/src/ui/onboarding/InfoTip.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/InfoTip.tsx
@@ -7,23 +7,30 @@ export function InfoTip(props: {
   readonly lead: string;
   readonly body: ReactNode;
   readonly trigger?: ReactElement;
+  readonly triggerContent?: ReactNode;
 }): ReactElement {
+  const customTrigger = props.trigger !== undefined;
+
   return (
     <Tooltip.Root>
       <Tooltip.Trigger
         render={props.trigger}
         data-info-tip=""
-        aria-label={props.label}
-        className="grid size-[15px] shrink-0 appearance-none place-items-center bg-transparent p-0 text-ink-2 transition-colors hover:text-ink focus-visible:text-ink motion-reduce:transition-none"
+        aria-label={customTrigger ? undefined : props.label}
+        className={
+          customTrigger
+            ? undefined
+            : "grid size-[15px] shrink-0 appearance-none place-items-center bg-transparent p-0 text-ink-2 transition-colors hover:text-ink focus-visible:text-ink motion-reduce:transition-none"
+        }
       >
-        <Info size={14} strokeWidth={2.25} aria-hidden="true" />
+        {props.triggerContent}
+        <Info className="flex-none" size={14} strokeWidth={2.25} aria-hidden="true" />
       </Tooltip.Trigger>
       <Tooltip.Portal>
-        <Tooltip.Positioner side="top" sideOffset={8} style={{ pointerEvents: "auto" }}>
+        <Tooltip.Positioner side="top" sideOffset={8}>
           <Tooltip.Popup
             data-info-tip-popup=""
-            style={{ pointerEvents: "auto" }}
-            className="pointer-events-auto w-[252px] rounded-md border border-line-2 bg-surface px-3 py-2.5 text-xs leading-relaxed text-ink-2 shadow-elev-3"
+            className="w-[252px] rounded-md border border-line-2 bg-surface px-3 py-2.5 text-xs leading-relaxed text-ink-2 shadow-elev-3"
           >
             <b className="mb-1 block font-medium text-ink">{props.lead}</b>
             {props.body}

--- a/apps/desktop-renderer/src/ui/onboarding/InfoTip.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/InfoTip.tsx
@@ -1,15 +1,17 @@
 import { Tooltip } from "@base-ui/react/tooltip";
 import { Info } from "lucide-react";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 export function InfoTip(props: {
   readonly label: string;
   readonly lead: string;
-  readonly body: string;
+  readonly body: ReactNode;
+  readonly trigger?: ReactElement;
 }): ReactElement {
   return (
     <Tooltip.Root>
       <Tooltip.Trigger
+        render={props.trigger}
         data-info-tip=""
         aria-label={props.label}
         className="grid size-[15px] shrink-0 appearance-none place-items-center bg-transparent p-0 text-ink-2 transition-colors hover:text-ink focus-visible:text-ink motion-reduce:transition-none"
@@ -17,10 +19,11 @@ export function InfoTip(props: {
         <Info size={14} strokeWidth={2.25} aria-hidden="true" />
       </Tooltip.Trigger>
       <Tooltip.Portal>
-        <Tooltip.Positioner side="top" sideOffset={8}>
+        <Tooltip.Positioner side="top" sideOffset={8} style={{ pointerEvents: "auto" }}>
           <Tooltip.Popup
             data-info-tip-popup=""
-            className="w-[252px] rounded-md border border-line-2 bg-surface px-3 py-2.5 text-xs leading-relaxed text-ink-2 shadow-elev-3"
+            style={{ pointerEvents: "auto" }}
+            className="pointer-events-auto w-[252px] rounded-md border border-line-2 bg-surface px-3 py-2.5 text-xs leading-relaxed text-ink-2 shadow-elev-3"
           >
             <b className="mb-1 block font-medium text-ink">{props.lead}</b>
             {props.body}

--- a/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
@@ -9,6 +9,11 @@ import {
 } from "../../training-context/manual-sync.js";
 import { formatUtcTimestamp } from "../../training-context/format.js";
 import { InfoTip } from "../onboarding/InfoTip.js";
+import {
+  focusTrainingRestrictionIfPresent,
+  requestTrainingRestrictionFocus,
+  STRAVA_RESTRICTION_CARD_ID,
+} from "../training/restriction-focus.js";
 import styles from "./Sidebar.module.css";
 
 type SyncChipStatus = "loading" | "syncing" | "attention" | "synced" | "never" | "unavailable";
@@ -37,6 +42,7 @@ export function SyncChip(): ReactElement {
   const training = useEnduragentStore((store) => store.training);
   const sync = useEnduragentStore((store) => store.sync);
   const actions = useEnduragentStore((store) => store.syncActions);
+  const closeRide = useEnduragentStore((store) => store.closeRide);
   const setActiveView = useEnduragentStore((store) => store.setActiveView);
   const chip = useRef<HTMLButtonElement>(null);
   const status = syncChipStatus(training, sync);
@@ -51,70 +57,79 @@ export function SyncChip(): ReactElement {
         : `${restriction.count} hidden by Strava`;
 
   return (
-    <button
-      type="button"
-      ref={chip}
-      className={`${styles.sync} sync-chip`}
-      data-status={status}
-      title={restriction === null || detail === null ? undefined : detail}
-      disabled={sync.disabled || actions === null}
-      aria-label={[sync.label, HEADLINE[status], restrictionLabel, detail]
-        .filter(Boolean)
-        .join(" · ")}
-      onClick={(event) => {
-        const keyboard = event.detail === 0;
-        setManualSyncFocusTarget(keyboard ? chip.current : null);
-        actions?.request(keyboard ? "keyboard" : "pointer");
-      }}
-    >
-      <span className={styles.dot} data-status={status} aria-hidden="true" />
-      <span className={styles.syncCopy}>
-        <span className={styles.syncHeadline}>{HEADLINE[status]}</span>
+    <div className={`${styles.sync} relative`} data-sync-chip="" data-status={status}>
+      <button
+        type="button"
+        ref={chip}
+        className="sync-chip absolute inset-0 z-0 m-0 appearance-none rounded-ctl border-0 bg-transparent p-0 disabled:cursor-default"
+        data-status={status}
+        title={restriction === null || detail === null ? undefined : detail}
+        disabled={sync.disabled || actions === null}
+        aria-label={[sync.label, HEADLINE[status], detail].filter(Boolean).join(" · ")}
+        onClick={(event) => {
+          const keyboard = event.detail === 0;
+          setManualSyncFocusTarget(keyboard ? chip.current : null);
+          actions?.request(keyboard ? "keyboard" : "pointer");
+        }}
+      />
+      <span
+        className={`${styles.dot} pointer-events-none relative z-[1]`}
+        data-status={status}
+        aria-hidden="true"
+      />
+      <span className={`${styles.syncCopy} pointer-events-none relative z-[1]`}>
+        <span className={styles.syncHeadline} aria-hidden="true">
+          {HEADLINE[status]}
+        </span>
         {restriction === null ? (
           detail === null ? null : (
-            <span className={styles.syncWhen}>{detail}</span>
+            <span className={styles.syncWhen} aria-hidden="true">
+              {detail}
+            </span>
           )
         ) : (
-          <span className="mt-px flex min-w-0 items-center gap-1 font-mono text-[11px] text-warn">
-            <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
-              {restrictionLabel}
-            </span>
-            <InfoTip
-              label="Why are activities hidden?"
-              lead={STRAVA_RESTRICTION_DESKTOP_COPY.tooltipLead(restriction.count)}
-              trigger={
-                <span
-                  role="button"
-                  tabIndex={0}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                  }}
-                />
-              }
-              body={
-                <>
-                  {STRAVA_RESTRICTION_DESKTOP_COPY.tooltipBody}{" "}
-                  <a
-                    href="#strava-restricted-activities"
-                    className="text-brand underline-offset-2 hover:underline"
-                    onPointerDown={() => {
-                      setActiveView("training");
-                    }}
-                    onClick={() => {
-                      setActiveView("training");
-                    }}
-                  >
-                    How to fix this
-                  </a>
-                </>
-              }
-            />
-          </span>
+          <InfoTip
+            label="Why are activities hidden?"
+            lead={STRAVA_RESTRICTION_DESKTOP_COPY.tooltipLead(restriction.count)}
+            trigger={
+              <a
+                href={`#${STRAVA_RESTRICTION_CARD_ID}`}
+                aria-label={`${restrictionLabel}. How to fix this`}
+                className="pointer-events-auto mt-px flex w-full min-w-0 items-center gap-1 font-mono text-[11px] no-underline"
+                onClick={(event) => {
+                  setActiveView("training");
+                  if (useEnduragentStore.getState().activeView !== "training") {
+                    event.preventDefault();
+                    return;
+                  }
+                  requestTrainingRestrictionFocus();
+                  closeRide();
+                  focusTrainingRestrictionIfPresent(
+                    document.getElementById(STRAVA_RESTRICTION_CARD_ID),
+                  );
+                }}
+              />
+            }
+            triggerContent={
+              <>
+                <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-warn">
+                  {restrictionLabel}
+                </span>
+                <span className="flex-none font-sans text-brand underline-offset-2 hover:underline">
+                  · How to fix this
+                </span>
+              </>
+            }
+            body={STRAVA_RESTRICTION_DESKTOP_COPY.tooltipBody}
+          />
         )}
       </span>
-      <span className={styles.syncAction} aria-hidden="true">
+      <span
+        className={`${styles.syncAction} pointer-events-none relative z-[1]`}
+        aria-hidden="true"
+      >
         {sync.label}
       </span>
-    </button>
+    </div>
   );
 }

--- a/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
@@ -2,8 +2,13 @@ import { useRef, type ReactElement } from "react";
 import { setManualSyncFocusTarget } from "../../state/manual-sync-focus.js";
 import { useEnduragentStore } from "../../state/store.js";
 import type { TrainingContextViewState } from "../../training-context/controller.js";
-import type { ManualSyncViewState } from "../../training-context/manual-sync.js";
+import {
+  sourceRestrictionSummary,
+  STRAVA_RESTRICTION_DESKTOP_COPY,
+  type ManualSyncViewState,
+} from "../../training-context/manual-sync.js";
 import { formatUtcTimestamp } from "../../training-context/format.js";
+import { InfoTip } from "../onboarding/InfoTip.js";
 import styles from "./Sidebar.module.css";
 
 type SyncChipStatus = "loading" | "syncing" | "attention" | "synced" | "never" | "unavailable";
@@ -32,10 +37,18 @@ export function SyncChip(): ReactElement {
   const training = useEnduragentStore((store) => store.training);
   const sync = useEnduragentStore((store) => store.sync);
   const actions = useEnduragentStore((store) => store.syncActions);
+  const setActiveView = useEnduragentStore((store) => store.setActiveView);
   const chip = useRef<HTMLButtonElement>(null);
   const status = syncChipStatus(training, sync);
   const synced = training.metadata?.lastSynced ?? null;
   const detail = status === "synced" && synced !== null ? formatUtcTimestamp(synced) : null;
+  const restriction = sourceRestrictionSummary(sync.droppedActivities, "STRAVA");
+  const restrictionLabel =
+    restriction === null
+      ? null
+      : restriction.count === 1
+        ? "1 hidden by Strava"
+        : `${restriction.count} hidden by Strava`;
 
   return (
     <button
@@ -43,8 +56,11 @@ export function SyncChip(): ReactElement {
       ref={chip}
       className={`${styles.sync} sync-chip`}
       data-status={status}
+      title={restriction === null || detail === null ? undefined : detail}
       disabled={sync.disabled || actions === null}
-      aria-label={[sync.label, HEADLINE[status], detail].filter(Boolean).join(" · ")}
+      aria-label={[sync.label, HEADLINE[status], restrictionLabel, detail]
+        .filter(Boolean)
+        .join(" · ")}
       onClick={(event) => {
         const keyboard = event.detail === 0;
         setManualSyncFocusTarget(keyboard ? chip.current : null);
@@ -54,7 +70,47 @@ export function SyncChip(): ReactElement {
       <span className={styles.dot} data-status={status} aria-hidden="true" />
       <span className={styles.syncCopy}>
         <span className={styles.syncHeadline}>{HEADLINE[status]}</span>
-        {detail === null ? null : <span className={styles.syncWhen}>{detail}</span>}
+        {restriction === null ? (
+          detail === null ? null : (
+            <span className={styles.syncWhen}>{detail}</span>
+          )
+        ) : (
+          <span className="mt-px flex min-w-0 items-center gap-1 font-mono text-[11px] text-warn">
+            <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+              {restrictionLabel}
+            </span>
+            <InfoTip
+              label="Why are activities hidden?"
+              lead={STRAVA_RESTRICTION_DESKTOP_COPY.tooltipLead(restriction.count)}
+              trigger={
+                <span
+                  role="button"
+                  tabIndex={0}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                  }}
+                />
+              }
+              body={
+                <>
+                  {STRAVA_RESTRICTION_DESKTOP_COPY.tooltipBody}{" "}
+                  <a
+                    href="#strava-restricted-activities"
+                    className="text-brand underline-offset-2 hover:underline"
+                    onPointerDown={() => {
+                      setActiveView("training");
+                    }}
+                    onClick={() => {
+                      setActiveView("training");
+                    }}
+                  >
+                    How to fix this
+                  </a>
+                </>
+              }
+            />
+          </span>
+        )}
       </span>
       <span className={styles.syncAction} aria-hidden="true">
         {sync.label}

--- a/apps/desktop-renderer/src/ui/training/RideReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideReview.tsx
@@ -32,6 +32,7 @@ const EMPTY_COPY: Readonly<
   "not-synced": "Sync or import a cycling ride to review it here.",
   "no-recent-rides": "No cycling rides are available from the last 28 days.",
   "temporary-failure": "Recent rides could not be refreshed. Try syncing again.",
+  "source-restricted": "Too many activities are hidden to show a trustworthy ride list.",
 };
 
 function rideKind(ride: RecentRide): string {

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -8,7 +8,14 @@ import type {
   WellnessTrendPanel,
 } from "@enduragent/coach-contract";
 import { TriangleAlert } from "lucide-react";
-import { useEffect, useLayoutEffect, useRef, type ReactElement, type ReactNode } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type ReactElement,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import { rideImportStatusCopy } from "../../ride-import.js";
 import { rideImportStatusSuppressed } from "../../state/onboarding-slice.js";
 import {
@@ -41,6 +48,10 @@ import { PowerProgressContent } from "./PowerProgressPanel.js";
 import { RecentRidesStatePanel, RideDetailView } from "./RideReview.js";
 import { WellnessSparkline } from "./WellnessSparkline.js";
 import { WorkoutArchiveExportControl } from "./TrainingExportControls.js";
+import {
+  STRAVA_RESTRICTION_CARD_ID,
+  takeTrainingRestrictionFocusRequest,
+} from "./restriction-focus.js";
 
 function Panel(props: {
   readonly name: string;
@@ -67,7 +78,9 @@ function PowerProgressStatePanel(props: { readonly panel: PowerProgressPanel }):
   );
 }
 
-function SyncPanel(): ReactElement {
+function SyncPanel(props: {
+  readonly restrictionCard: RefObject<HTMLDivElement | null>;
+}): ReactElement {
   const metadata = useEnduragentStore((store) => store.training.metadata);
   const sync = useEnduragentStore((store) => store.sync);
   const actions = useEnduragentStore((store) => store.syncActions);
@@ -139,7 +152,8 @@ function SyncPanel(): ReactElement {
       </div>
       {restriction === null ? null : (
         <div
-          id="strava-restricted-activities"
+          ref={props.restrictionCard}
+          id={STRAVA_RESTRICTION_CARD_ID}
           tabIndex={-1}
           className="mt-4 rounded-xl border border-line bg-surface p-4 shadow-[var(--edge),var(--elev-1)]"
         >
@@ -377,24 +391,28 @@ export function TrainingView(): ReactElement {
   const rideAnalysisActions = useEnduragentStore((store) => store.rideAnalysisActions);
   const rideButtons = useRef(new Map<string, HTMLButtonElement>());
   const previousRideId = useRef<string | null>(null);
+  const restrictionCard = useRef<HTMLDivElement>(null);
   const title = useRef<HTMLHeadingElement>(null);
   const status = trainingStatusCopy(training.status);
 
   useLayoutEffect(() => {
-    const element = title.current;
-    if (element === null) return;
-    const owner = element.ownerDocument;
-    const active = owner.activeElement;
-    if (active !== null && active !== owner.body && active !== owner.documentElement) return;
-    element.focus();
-  }, []);
-
-  useLayoutEffect(() => {
     const currentRideId = selectedRide?.id ?? null;
-    if (currentRideId !== null && previousRideId.current !== currentRideId) {
+    const restrictionFocusRequested = takeTrainingRestrictionFocusRequest();
+    if (restrictionFocusRequested) {
+      (restrictionCard.current ?? title.current)?.focus();
+    } else if (currentRideId !== null && previousRideId.current !== currentRideId) {
       title.current?.focus();
     } else if (currentRideId === null && previousRideId.current !== null) {
       (rideButtons.current.get(previousRideId.current) ?? title.current)?.focus();
+    } else {
+      const element = title.current;
+      if (element !== null) {
+        const owner = element.ownerDocument;
+        const active = owner.activeElement;
+        if (active === null || active === owner.body || active === owner.documentElement) {
+          element.focus();
+        }
+      }
     }
     previousRideId.current = currentRideId;
   }, [selectedRide?.id]);
@@ -419,7 +437,7 @@ export function TrainingView(): ReactElement {
       <p className={`${styles.status} training-status`} hidden={training.status === "ready"}>
         {status}
       </p>
-      <SyncPanel />
+      <SyncPanel restrictionCard={restrictionCard} />
       <PowerProgressStatePanel panel={training.trainingContext.performanceProgress} />
       <RecentRidesStatePanel
         panel={training.trainingContext.recentRides}

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -7,6 +7,7 @@ import type {
   RecentRide,
   WellnessTrendPanel,
 } from "@enduragent/coach-contract";
+import { TriangleAlert } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, type ReactElement, type ReactNode } from "react";
 import { rideImportStatusCopy } from "../../ride-import.js";
 import { rideImportStatusSuppressed } from "../../state/onboarding-slice.js";
@@ -15,6 +16,10 @@ import {
   setManualSyncFocusTarget,
 } from "../../state/manual-sync-focus.js";
 import { useEnduragentStore } from "../../state/store.js";
+import {
+  sourceRestrictionSummary,
+  STRAVA_RESTRICTION_DESKTOP_COPY,
+} from "../../training-context/manual-sync.js";
 import {
   formatDateLabel,
   formatPercentage,
@@ -72,6 +77,7 @@ function SyncPanel(): ReactElement {
   const syncedCopy = synced === null ? null : formatUtcTimestamp(synced);
   const syncedInstant =
     synced === null || syncedCopy === "Unknown sync time" ? null : new Date(synced).toISOString();
+  const restriction = sourceRestrictionSummary(sync.droppedActivities, "STRAVA");
 
   useEffect(() => {
     setManualSyncFocusFallback(message.current);
@@ -131,6 +137,50 @@ function SyncPanel(): ReactElement {
           {sync.message}
         </p>
       </div>
+      {restriction === null ? null : (
+        <div
+          id="strava-restricted-activities"
+          tabIndex={-1}
+          className="mt-4 rounded-xl border border-line bg-surface p-4 shadow-[var(--edge),var(--elev-1)]"
+        >
+          <div className="flex items-start gap-2.5">
+            <TriangleAlert
+              size={17}
+              strokeWidth={1.8}
+              className="mt-px flex-none text-warn"
+              aria-hidden="true"
+            />
+            <div className="min-w-0">
+              <p className="m-0 text-sm font-semibold text-ink">
+                {STRAVA_RESTRICTION_DESKTOP_COPY.cardTitle(restriction.count, restriction.total)}
+              </p>
+              <p className="mt-1 text-[12.5px] leading-relaxed text-ink-2">
+                {STRAVA_RESTRICTION_DESKTOP_COPY.cause}
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 grid gap-2.5 border-t border-line pt-3">
+            <div className="flex items-start gap-2.5">
+              <span className="flex size-[18px] flex-none items-center justify-center rounded-full bg-brand/15 text-[10px] font-semibold text-brand">
+                1
+              </span>
+              <p className="m-0 text-[12.5px] leading-relaxed text-ink-2">
+                <strong className="font-semibold text-ink">For future rides — </strong>
+                {STRAVA_RESTRICTION_DESKTOP_COPY.future}
+              </p>
+            </div>
+            <div className="flex items-start gap-2.5">
+              <span className="flex size-[18px] flex-none items-center justify-center rounded-full bg-brand/15 text-[10px] font-semibold text-brand">
+                2
+              </span>
+              <p className="m-0 text-[12.5px] leading-relaxed text-ink-2">
+                <strong className="font-semibold text-ink">For past rides — </strong>
+                {STRAVA_RESTRICTION_DESKTOP_COPY.past}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
     </Panel>
   );
 }

--- a/apps/desktop-renderer/src/ui/training/copy.ts
+++ b/apps/desktop-renderer/src/ui/training/copy.ts
@@ -19,6 +19,7 @@ export const TRAINING_UNKNOWN_COPY: Readonly<Record<TrainingContextUnknownReason
   "no-plan": "No planned cycling workouts are available",
   "insufficient-data": "Not enough persisted data to show this yet",
   "no-wellness": "No wellness readings are available",
+  "source-restricted": "Not enough activity data is visible to calculate this safely",
 };
 
 export const WELLNESS_LABELS: readonly string[] = ["HRV", "Sleep", "Resting HR"];
@@ -31,6 +32,7 @@ export const POWER_PROGRESS_UNAVAILABLE_COPY: Readonly<
   "invalid-data": "Power progress data could not be verified. Sync again.",
   "refresh-failed": "Power progress has not refreshed yet. Try syncing again.",
   "temporary-failure": "Power progress is temporarily unavailable. Try again.",
+  "source-restricted": "Too much activity data is hidden to compare power safely.",
 };
 
 export const POWER_PROGRESS_REFRESH_FAILURE_COPY: Readonly<

--- a/apps/desktop-renderer/src/ui/training/restriction-focus.ts
+++ b/apps/desktop-renderer/src/ui/training/restriction-focus.ts
@@ -1,0 +1,23 @@
+export const STRAVA_RESTRICTION_CARD_ID = "strava-restricted-activities";
+
+let focusRequested = false;
+
+export function requestTrainingRestrictionFocus(): void {
+  focusRequested = true;
+}
+
+export function focusTrainingRestrictionIfPresent(element: HTMLElement | null): void {
+  if (!focusRequested || element === null || !element.isConnected || element.hidden) return;
+  focusRequested = false;
+  element.focus();
+}
+
+export function takeTrainingRestrictionFocusRequest(): boolean {
+  const requested = focusRequested;
+  focusRequested = false;
+  return requested;
+}
+
+export function clearTrainingRestrictionFocusRequest(): void {
+  focusRequested = false;
+}

--- a/apps/desktop-renderer/tests/first-sync.test.ts
+++ b/apps/desktop-renderer/tests/first-sync.test.ts
@@ -36,6 +36,7 @@ const success: SyncRpcResult = {
   published: true,
   referenceSucceeded: true,
   requests: { store: 1, reference: 1, total: 2 },
+  droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
 };
 
 function deferred<T>(): {
@@ -144,7 +145,7 @@ describe("first sync controller", () => {
     expect(ports.states).toEqual([{ status: "syncing" }]);
     coordinator.publish({ status: "running", operation: 1 });
     expect(ports.states).toEqual([{ status: "syncing" }]);
-    coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await first;
     expect(ports.states.at(-1)).toEqual({ status: "ready" });
     expect(ports.focusComposer).toHaveBeenCalledTimes(1);
@@ -200,7 +201,7 @@ describe("first sync controller", () => {
     expect(coordinator.requestCalls).toEqual([1]);
     expect(ports.states).toEqual([]);
     expect(ports.focusComposer).toHaveBeenCalledTimes(1);
-    coordinator.finish({ status: "succeeded", operation: 1, kind: "no-change" });
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "no-change", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await manualTask;
     expect(ports.states).toEqual([]);
 
@@ -210,7 +211,7 @@ describe("first sync controller", () => {
 
   it.each([
     [
-      { status: "succeeded", operation: 1, kind: "no-change" },
+      { status: "succeeded", operation: 1, kind: "no-change", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } },
       { status: "failed", kind: "operation", retryable: true },
     ],
     [
@@ -256,7 +257,7 @@ describe("first sync controller", () => {
     expect(coordinator.requestCalls).toEqual([1]);
     const retry = controller.retry();
     expect(coordinator.requestCalls).toEqual([1, 2]);
-    coordinator.finish({ status: "succeeded", operation: 2, kind: "published" });
+    coordinator.finish({ status: "succeeded", operation: 2, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await retry;
     expect(coordinator.requestCalls).toEqual([1, 2]);
     expect(ports.focusComposer).toHaveBeenCalledTimes(1);
@@ -276,14 +277,14 @@ describe("first sync controller", () => {
       const joinedTask = admission === "joined" ? manual.activate("pointer") : undefined;
       const firstTask = first.start(completion);
       if (joinedTask !== undefined) expect(firstTask).toBe(joinedTask);
-      coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+      coordinator.finish({ status: "succeeded", operation: 1, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
       await firstTask;
       await Promise.resolve();
       const renderedAtReady = [...ports.states];
       const focusCallsAtReady = ports.focusComposer.mock.calls.length;
 
       const laterManual = manual.activate("pointer");
-      coordinator.finish({ status: "succeeded", operation: 2, kind: "no-change" });
+      coordinator.finish({ status: "succeeded", operation: 2, kind: "no-change", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
       await laterManual;
 
       expect(coordinator.requestCalls).toEqual([1, 2]);
@@ -305,13 +306,13 @@ describe("first sync controller", () => {
     });
 
     const initialSetup = first.start(completion);
-    coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await initialSetup;
     expect(ports.states).toEqual([{ status: "syncing" }, { status: "ready" }]);
     const renderedAtReady = [...ports.states];
 
     const laterManual = manual.activate("pointer");
-    coordinator.finish({ status: "succeeded", operation: 2, kind: "no-change" });
+    coordinator.finish({ status: "succeeded", operation: 2, kind: "no-change", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await laterManual;
     expect(ports.states).toEqual(renderedAtReady);
     expect(ports.focusComposer).toHaveBeenCalledTimes(1);
@@ -319,7 +320,7 @@ describe("first sync controller", () => {
     const laterSetup = first.start(completion);
     expect(coordinator.requestCalls).toEqual([1, 2, 3]);
     expect(ports.states).toEqual([...renderedAtReady, { status: "syncing" }]);
-    coordinator.finish({ status: "succeeded", operation: 3, kind: "published" });
+    coordinator.finish({ status: "succeeded", operation: 3, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await laterSetup;
     expect(ports.states).toEqual([...renderedAtReady, { status: "syncing" }, { status: "ready" }]);
     expect(ports.focusComposer).toHaveBeenCalledTimes(1);
@@ -333,7 +334,7 @@ describe("first sync controller", () => {
     const controller = createFirstSyncController(ports);
     const task = controller.start(completion);
     controller.dispose();
-    coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await task;
     await controller.retry();
     await controller.start(completion);
@@ -361,7 +362,7 @@ describe("first sync controller", () => {
         tone: "active",
       },
     ]);
-    coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await firstTask;
     expect(manualStates.at(-1)?.message).toBe("Training-data check completed.");
   });
@@ -375,20 +376,20 @@ describe("first sync controller", () => {
     });
     const keyboard = manual.activate("keyboard");
     expect(manual.activate("pointer")).toBe(keyboard);
-    coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await keyboard;
     await Promise.resolve();
     expect(restoreKeyboardFocus).toHaveBeenCalledTimes(1);
 
     const pointer = manual.activate("pointer");
-    coordinator.finish({ status: "succeeded", operation: 2, kind: "published" });
+    coordinator.finish({ status: "succeeded", operation: 2, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await pointer;
     await Promise.resolve();
     expect(restoreKeyboardFocus).toHaveBeenCalledTimes(1);
 
     const staleKeyboard = manual.activate("keyboard");
     manual.dispose();
-    coordinator.finish({ status: "succeeded", operation: 3, kind: "published" });
+    coordinator.finish({ status: "succeeded", operation: 3, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } });
     await staleKeyboard;
     expect(restoreKeyboardFocus).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop-renderer/tests/first-sync.test.ts
+++ b/apps/desktop-renderer/tests/first-sync.test.ts
@@ -367,6 +367,53 @@ describe("first sync controller", () => {
     expect(manualStates.at(-1)?.message).toBe("Training-data check completed.");
   });
 
+  it("keeps the last successful restriction summary through a failed refresh", async () => {
+    const coordinator = new FakeCoordinator();
+    const states: ManualSyncViewState[] = [];
+    const manual = createManualSyncController({
+      coordinator,
+      view: { render: (state) => states.push(state), restoreKeyboardFocus: vi.fn() },
+    });
+
+    const first = manual.activate("pointer");
+    coordinator.finish({
+      status: "succeeded",
+      operation: 1,
+      kind: "published",
+      droppedActivities: {
+        overall: {
+          total: 67,
+          visible: 5,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+          other: 2,
+        },
+        recent7Days: {
+          total: 5,
+          visible: 1,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+          other: 0,
+        },
+      },
+    });
+    await first;
+    await Promise.resolve();
+
+    const second = manual.activate("pointer");
+    expect(states.at(-1)?.tone).toBe("active");
+    expect(states.at(-1)?.droppedActivities?.overall.restrictions[0]?.count).toBe(60);
+    coordinator.finish({
+      status: "failed",
+      operation: 2,
+      kind: "operation",
+      retryable: true,
+    });
+    await second;
+
+    expect(states.at(-1)?.tone).toBe("failure");
+    expect(states.at(-1)?.droppedActivities?.overall.restrictions[0]?.count).toBe(60);
+    manual.dispose();
+  });
+
   it("restores focus only for the accepted keyboard activation", async () => {
     const coordinator = new FakeCoordinator();
     const restoreKeyboardFocus = vi.fn();

--- a/apps/desktop-renderer/tests/restriction-focus.test.tsx
+++ b/apps/desktop-renderer/tests/restriction-focus.test.tsx
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearTrainingRestrictionFocusRequest,
+  focusTrainingRestrictionIfPresent,
+  requestTrainingRestrictionFocus,
+  takeTrainingRestrictionFocusRequest,
+} from "../src/ui/training/restriction-focus.js";
+
+afterEach(() => {
+  clearTrainingRestrictionFocusRequest();
+});
+
+describe("training restriction focus", () => {
+  it("focuses a present destination and consumes the request", () => {
+    const card = document.createElement("div");
+    card.tabIndex = -1;
+    document.body.append(card);
+
+    requestTrainingRestrictionFocus();
+    focusTrainingRestrictionIfPresent(card);
+
+    expect(card).toHaveFocus();
+    expect(takeTrainingRestrictionFocusRequest()).toBe(false);
+    card.remove();
+  });
+
+  it("leaves an absent destination pending for the coordinator", () => {
+    requestTrainingRestrictionFocus();
+    focusTrainingRestrictionIfPresent(null);
+
+    expect(takeTrainingRestrictionFocusRequest()).toBe(true);
+    expect(takeTrainingRestrictionFocusRequest()).toBe(false);
+  });
+});

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -14,6 +14,13 @@ import {
   setupSurfaceOnScreen,
 } from "../src/state/onboarding-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
+import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
+import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
+import { toManualSyncViewState } from "../src/training-context/manual-sync.js";
+import {
+  clearTrainingRestrictionFocusRequest,
+  takeTrainingRestrictionFocusRequest,
+} from "../src/ui/training/restriction-focus.js";
 
 const REPAIR_REQUIRED_CREDENTIALS: CredentialSettingsState = {
   status: "ready",
@@ -34,6 +41,17 @@ const REQUIRED_ONBOARDING = Object.freeze({
   completionRequired: true,
 });
 
+const SELECTED_RIDE = Object.freeze({
+  id: "a".repeat(64),
+  subSport: "road",
+  startEpochSeconds: 900_000_000,
+  timezoneOffsetSeconds: 0,
+  localDate: "1998-07-09",
+  elapsedSeconds: 3_600,
+  movingSeconds: 3_500,
+  distanceMeters: 32_000,
+});
+
 function stubActions(): ChatActions {
   return {
     submit: vi.fn(),
@@ -45,6 +63,23 @@ function stubActions(): ChatActions {
     cancelNewConversation: vi.fn(),
     confirmNewConversation: vi.fn(),
     retryFirstSync: vi.fn(),
+  };
+}
+
+function stravaDroppedActivities() {
+  return {
+    overall: {
+      total: 67,
+      visible: 5,
+      restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 60 }],
+      other: 2,
+    },
+    recent7Days: {
+      total: 5,
+      visible: 1,
+      restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 4 }],
+      other: 0,
+    },
   };
 }
 
@@ -65,9 +100,17 @@ describe("shell", () => {
       runtimeReady: true,
       chat: { ...EMPTY_CHAT_SURFACE, newConversationUnavailable: false },
       chatActions: stubActions(),
+      training: EMPTY_TRAINING_SURFACE,
+      selectedRide: null,
+      sync: IDLE_MANUAL_SYNC,
+      syncActions: null,
       onboarding: READY_ONBOARDING,
       onboardingActions: null,
       onboardingStartupSettled: true,
+      settings: {
+        ...useEnduragentStore.getState().settings,
+        savingOwners: [],
+      },
     });
   });
 
@@ -75,14 +118,20 @@ describe("shell", () => {
     useEnduragentStore.setState({
       chat: EMPTY_CHAT_SURFACE,
       chatActions: null,
+      training: EMPTY_TRAINING_SURFACE,
+      selectedRide: null,
+      sync: IDLE_MANUAL_SYNC,
+      syncActions: null,
       onboarding: CLOSED_ONBOARDING,
       onboardingActions: null,
       onboardingStartupSettled: false,
       settings: {
         ...useEnduragentStore.getState().settings,
         credentials: { status: "closed" },
+        savingOwners: [],
       },
     });
+    clearTrainingRestrictionFocusRequest();
     resetChatStream();
   });
 
@@ -154,6 +203,80 @@ describe("shell", () => {
     await screen.findByRole("region", { name: "Training" });
 
     expect(trainingButton).toHaveFocus();
+  });
+
+  it("moves focus from a mounted ride review to the Training action card", async () => {
+    const user = userEvent.setup();
+    const request = vi.fn();
+    useEnduragentStore.setState({
+      activeView: "training",
+      training: {
+        ...EMPTY_TRAINING_SURFACE,
+        status: "ready",
+        metadata: {
+          lastUpdated: "1998-07-19T08:00:00.000Z",
+          lastSynced: "1998-07-19T07:55:00.000Z",
+          freshness: "fresh",
+          degraded: false,
+        },
+      },
+      selectedRide: SELECTED_RIDE,
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 1,
+        kind: "published",
+        droppedActivities: stravaDroppedActivities(),
+      }),
+      syncActions: { request },
+    });
+    render(<Shell onReady={() => {}} />);
+    expect(screen.getByRole("region", { name: "Ride review" })).toBeInTheDocument();
+
+    const remedy = screen.getByRole("link", {
+      name: "60 hidden by Strava. How to fix this",
+    });
+    remedy.focus();
+    await user.keyboard("{Enter}");
+
+    const card = await waitFor(() => {
+      const element = document.querySelector<HTMLElement>("#strava-restricted-activities");
+      expect(element).not.toBeNull();
+      return element as HTMLElement;
+    });
+    await waitFor(() => {
+      expect(card).toHaveFocus();
+    });
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(useEnduragentStore.getState().selectedRide).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("preserves a selected ride and does not arm focus when navigation is blocked", async () => {
+    const user = userEvent.setup();
+    const request = vi.fn();
+    useEnduragentStore.setState({
+      activeView: "settings",
+      selectedRide: SELECTED_RIDE,
+      settings: {
+        ...useEnduragentStore.getState().settings,
+        savingOwners: ["session"],
+      },
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 1,
+        kind: "published",
+        droppedActivities: stravaDroppedActivities(),
+      }),
+      syncActions: { request },
+    });
+    render(<Shell onReady={() => {}} />);
+
+    await user.click(screen.getByRole("link", { name: "60 hidden by Strava. How to fix this" }));
+
+    expect(useEnduragentStore.getState().activeView).toBe("settings");
+    expect(useEnduragentStore.getState().selectedRide).toEqual(SELECTED_RIDE);
+    expect(takeTrainingRestrictionFocusRequest()).toBe(false);
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("keeps the chat surface mounted while another view is shown", async () => {

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -13,6 +13,7 @@ import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
 import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
 import { toManualSyncViewState } from "../src/training-context/manual-sync.js";
 import { Sidebar } from "../src/ui/sidebar/Sidebar.js";
+import { clearTrainingRestrictionFocusRequest } from "../src/ui/training/restriction-focus.js";
 
 function stubActions(): ChatActions {
   return {
@@ -40,6 +41,29 @@ function chip(): HTMLElement {
   return element;
 }
 
+function chipSurface(): HTMLElement {
+  const element = document.querySelector<HTMLElement>("[data-sync-chip]");
+  if (element === null) throw new TypeError("sync chip surface missing");
+  return element;
+}
+
+function stravaDroppedActivities() {
+  return {
+    overall: {
+      total: 67,
+      visible: 5,
+      restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 60 }],
+      other: 2,
+    },
+    recent7Days: {
+      total: 5,
+      visible: 1,
+      restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 4 }],
+      other: 0,
+    },
+  };
+}
+
 function setupReadiness(): HTMLElement {
   const element = document.querySelector<HTMLElement>("[data-sidebar-setup-readiness]");
   if (element === null) throw new TypeError("sidebar setup readiness missing");
@@ -63,6 +87,7 @@ beforeEach(() => {
 
 afterEach(() => {
   setManualSyncFocusTarget(null);
+  clearTrainingRestrictionFocusRequest();
   useEnduragentStore.setState({
     chat: EMPTY_CHAT_SURFACE,
     chatActions: null,
@@ -225,7 +250,7 @@ describe("sidebar sync chip", () => {
     render(<Sidebar />);
 
     expect(chip()).toHaveAttribute("data-status", "loading");
-    expect(chip()).toHaveTextContent("Loading training data");
+    expect(chipSurface()).toHaveTextContent("Loading training data");
 
     update({
       training: {
@@ -240,8 +265,8 @@ describe("sidebar sync chip", () => {
       },
     });
     expect(chip()).toHaveAttribute("data-status", "synced");
-    expect(chip()).toHaveTextContent("Training data synced");
-    expect(chip()).toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chipSurface()).toHaveTextContent("Training data synced");
+    expect(chipSurface()).toHaveTextContent("1998-07-19 07:55:00 UTC");
     expect(chip()).toHaveAccessibleName(
       "Sync now · Training data synced · 1998-07-19 07:55:00 UTC",
     );
@@ -259,12 +284,13 @@ describe("sidebar sync chip", () => {
       }),
     });
     expect(chip()).toHaveAttribute("data-status", "attention");
-    expect(chip()).toHaveTextContent("Try again");
+    expect(chipSurface()).toHaveTextContent("Try again");
   });
 
-  it("shows a successful Strava restriction without nesting buttons", async () => {
+  it("keeps Strava remedy navigation independent from syncing", async () => {
     const user = userEvent.setup();
-    useEnduragentStore.setState({ syncActions: { request: vi.fn() } });
+    const request = vi.fn();
+    useEnduragentStore.setState({ syncActions: { request } });
     render(<Sidebar />);
 
     update({
@@ -282,41 +308,70 @@ describe("sidebar sync chip", () => {
         status: "succeeded",
         operation: 1,
         kind: "published",
-        droppedActivities: {
-          overall: {
-            total: 67,
-            visible: 5,
-            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
-            other: 2,
-          },
-          recent7Days: {
-            total: 5,
-            visible: 1,
-            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
-            other: 0,
-          },
-        },
+        droppedActivities: stravaDroppedActivities(),
       }),
     });
 
     expect(chip()).toHaveAttribute("data-status", "synced");
-    expect(chip()).toHaveTextContent("60 hidden by Strava");
-    expect(chip()).not.toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chipSurface()).toHaveTextContent("60 hidden by Strava");
+    expect(chipSurface()).toHaveTextContent("How to fix this");
+    expect(chipSurface()).not.toHaveTextContent("1998-07-19 07:55:00 UTC");
     expect(chip()).toHaveAttribute("title", "1998-07-19 07:55:00 UTC");
-    expect(chip().querySelector("button")).toBeNull();
+    expect(chip()).toHaveAccessibleName(
+      "Sync again · Training data synced · 1998-07-19 07:55:00 UTC",
+    );
+    expect(
+      chip().querySelector("a, button, input, select, textarea, [role='button'], [tabindex]"),
+    ).toBeNull();
 
-    const trigger = chip().querySelector<HTMLElement>("[data-info-tip]");
-    expect(trigger?.tagName).toBe("SPAN");
-    await user.hover(trigger as HTMLElement);
+    const link = screen.getByRole("link", {
+      name: "60 hidden by Strava. How to fix this",
+    });
+    expect(link).toHaveAttribute("href", "#strava-restricted-activities");
+    expect(link).toHaveAttribute("data-info-tip");
+    await user.hover(link);
     await waitFor(() => {
       expect(document.querySelector("[data-info-tip-popup]")).not.toBeNull();
     });
     expect(screen.getByText("60 activities hidden by Strava")).toBeInTheDocument();
-    const link = screen.getByRole("link", { name: "How to fix this" });
-    expect(link).toHaveAttribute("href", "#strava-restricted-activities");
+    const popup = document.querySelector<HTMLElement>("[data-info-tip-popup]");
+    expect(
+      popup?.querySelector("a, button, input, select, textarea, [role='button'], [tabindex]"),
+    ).toBeNull();
 
-    fireEvent.click(link);
+    await user.click(link);
     expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(request).not.toHaveBeenCalled();
+
+    clearTrainingRestrictionFocusRequest();
+    update({ activeView: "chat" });
+    chip().focus();
+    await user.tab();
+    expect(link).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(request).not.toHaveBeenCalled();
+
+    clearTrainingRestrictionFocusRequest();
+    update({ activeView: "chat" });
+    fireEvent.pointerDown(link, { pointerType: "touch" });
+    fireEvent.click(link, { detail: 1 });
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(request).not.toHaveBeenCalled();
+
+    clearTrainingRestrictionFocusRequest();
+    update({
+      activeView: "chat",
+      sync: {
+        ...toManualSyncViewState({ status: "running", operation: 2 }),
+        droppedActivities: stravaDroppedActivities(),
+      },
+    });
+    expect(chip()).toBeDisabled();
+    expect(link).toBeEnabled();
+    await user.click(link);
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(request).not.toHaveBeenCalled();
 
     update({
       sync: toManualSyncViewState({
@@ -329,9 +384,9 @@ describe("sidebar sync chip", () => {
         },
       }),
     });
-    expect(chip()).toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chipSurface()).toHaveTextContent("1998-07-19 07:55:00 UTC");
     expect(chip()).not.toHaveAttribute("title");
-    expect(chip().querySelector("[data-info-tip]")).toBeNull();
+    expect(chipSurface().querySelector("[data-info-tip]")).toBeNull();
   });
 
   it("reports never-synced and unavailable training data honestly", () => {
@@ -339,11 +394,11 @@ describe("sidebar sync chip", () => {
 
     update({ training: { ...EMPTY_TRAINING_SURFACE, status: "ready" } });
     expect(chip()).toHaveAttribute("data-status", "never");
-    expect(chip()).toHaveTextContent("Not synced yet");
+    expect(chipSurface()).toHaveTextContent("Not synced yet");
 
     update({ training: { ...EMPTY_TRAINING_SURFACE, status: "unavailable" } });
     expect(chip()).toHaveAttribute("data-status", "unavailable");
-    expect(chip()).toHaveTextContent("Training data unavailable");
+    expect(chipSurface()).toHaveTextContent("Training data unavailable");
   });
 
   it("requests a manual sync and restores keyboard focus to the activator", async () => {

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_CHAT_SURFACE, type ChatActions } from "../src/state/chat-slice.js";
@@ -260,6 +260,78 @@ describe("sidebar sync chip", () => {
     });
     expect(chip()).toHaveAttribute("data-status", "attention");
     expect(chip()).toHaveTextContent("Try again");
+  });
+
+  it("shows a successful Strava restriction without nesting buttons", async () => {
+    const user = userEvent.setup();
+    useEnduragentStore.setState({ syncActions: { request: vi.fn() } });
+    render(<Sidebar />);
+
+    update({
+      training: {
+        ...EMPTY_TRAINING_SURFACE,
+        status: "ready",
+        metadata: {
+          lastUpdated: "1998-07-19T08:00:00.000Z",
+          lastSynced: "1998-07-19T07:55:00.000Z",
+          freshness: "fresh",
+          degraded: false,
+        },
+      },
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 1,
+        kind: "published",
+        droppedActivities: {
+          overall: {
+            total: 67,
+            visible: 5,
+            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+            other: 2,
+          },
+          recent7Days: {
+            total: 5,
+            visible: 1,
+            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+            other: 0,
+          },
+        },
+      }),
+    });
+
+    expect(chip()).toHaveAttribute("data-status", "synced");
+    expect(chip()).toHaveTextContent("60 hidden by Strava");
+    expect(chip()).not.toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chip()).toHaveAttribute("title", "1998-07-19 07:55:00 UTC");
+    expect(chip().querySelector("button")).toBeNull();
+
+    const trigger = chip().querySelector<HTMLElement>("[data-info-tip]");
+    expect(trigger?.tagName).toBe("SPAN");
+    await user.hover(trigger as HTMLElement);
+    await waitFor(() => {
+      expect(document.querySelector("[data-info-tip-popup]")).not.toBeNull();
+    });
+    expect(screen.getByText("60 activities hidden by Strava")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "How to fix this" });
+    expect(link).toHaveAttribute("href", "#strava-restricted-activities");
+
+    fireEvent.click(link);
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+
+    update({
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 2,
+        kind: "no-change",
+        droppedActivities: {
+          overall: { total: 5, visible: 5, restrictions: [], other: 0 },
+          recent7Days: { total: 5, visible: 5, restrictions: [], other: 0 },
+        },
+      }),
+    });
+    expect(chip()).toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chip()).not.toHaveAttribute("title");
+    expect(chip().querySelector("[data-info-tip]")).toBeNull();
   });
 
   it("reports never-synced and unavailable training data honestly", () => {

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -1042,7 +1042,7 @@ describe("training page sync", () => {
     expect(message).toHaveTextContent("Syncing training data…");
 
     update({
-      sync: toManualSyncViewState({ status: "succeeded", operation: 1, kind: "no-change" }),
+      sync: toManualSyncViewState({ status: "succeeded", operation: 1, kind: "no-change", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } }),
     });
     const settled = screen.getByRole("button", { name: "Sync again" });
     expect(settled).toBeEnabled();

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -1042,7 +1042,15 @@ describe("training page sync", () => {
     expect(message).toHaveTextContent("Syncing training data…");
 
     update({
-      sync: toManualSyncViewState({ status: "succeeded", operation: 1, kind: "no-change", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } }),
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 1,
+        kind: "no-change",
+        droppedActivities: {
+          overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+          recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+        },
+      }),
     });
     const settled = screen.getByRole("button", { name: "Sync again" });
     expect(settled).toBeEnabled();
@@ -1085,6 +1093,57 @@ describe("training page sync", () => {
     });
     expect(screen.getByRole("button", { name: "Sync unavailable" })).toBeDisabled();
     expect(message).toHaveTextContent("Enduragent couldn’t verify the sync result.");
+  });
+
+  it("shows the Strava action card only when restricted activities exist", () => {
+    useEnduragentStore.setState({ syncActions: { request: vi.fn() } });
+    render(<TrainingView />);
+
+    update({
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 1,
+        kind: "published",
+        droppedActivities: {
+          overall: {
+            total: 67,
+            visible: 5,
+            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+            other: 2,
+          },
+          recent7Days: {
+            total: 5,
+            visible: 1,
+            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+            other: 0,
+          },
+        },
+      }),
+    });
+
+    const notice = document.querySelector("#strava-restricted-activities");
+    expect(notice).not.toBeNull();
+    expect(notice).toHaveTextContent("60 of 67 activities are hidden by Strava");
+    expect(notice).toHaveTextContent("recording source directly to intervals.icu");
+    expect(notice).toHaveTextContent("Import All Strava Data");
+    expect(notice).toHaveTextContent("intervals.icu supporter subscription");
+    expect(document.querySelector(".training-sync-message")).toHaveTextContent(
+      "A Strava API restriction prevents intervals.icu from sharing 60 activities",
+    );
+
+    update({
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 2,
+        kind: "no-change",
+        droppedActivities: {
+          overall: { total: 5, visible: 5, restrictions: [], other: 0 },
+          recent7Days: { total: 5, visible: 5, restrictions: [], other: 0 },
+        },
+      }),
+    });
+
+    expect(document.querySelector("#strava-restricted-activities")).toBeNull();
   });
 
   it("disables the sync action until the controller is bound", () => {

--- a/apps/desktop-renderer/tests/training-sync.test.ts
+++ b/apps/desktop-renderer/tests/training-sync.test.ts
@@ -25,6 +25,7 @@ const published: SyncRpcResult = {
   published: true,
   referenceSucceeded: true,
   requests: { store: 1, reference: 1, total: 2 },
+  droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
 };
 
 function deferred<T>(): {
@@ -148,12 +149,13 @@ describe("training sync coordinator", () => {
       status: "succeeded",
       operation: 1,
       kind: "published",
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     });
   });
 
   it.each([
-    [true, true, { status: "succeeded", operation: 1, kind: "published" }],
-    [false, true, { status: "succeeded", operation: 1, kind: "no-change" }],
+    [true, true, { status: "succeeded", operation: 1, kind: "published", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } }],
+    [false, true, { status: "succeeded", operation: 1, kind: "no-change", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } }],
     [true, false, { status: "failed", operation: 1, kind: "partial", retryable: true }],
     [false, false, { status: "failed", operation: 1, kind: "operation", retryable: true }],
   ] as const)(
@@ -171,6 +173,40 @@ describe("training sync coordinator", () => {
       expect(refreshTrainingContext).toHaveBeenCalledTimes(1);
     },
   );
+
+  it("carries the dropped-activity split onto the succeeded state", async () => {
+    const result: SyncRpcResult = {
+      ...published,
+      droppedActivities: {
+        overall: {
+          total: 67,
+          visible: 5,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+          other: 2,
+        },
+        recent7Days: {
+          total: 5,
+          visible: 1,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+          other: 0,
+        },
+      },
+    };
+    const client = clientWith((options) => exactCall(options, result));
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(client),
+      refreshTrainingContext: vi.fn(async () => {}),
+    });
+
+    await coordinator.request();
+
+    expect(coordinator.getState()).toEqual({
+      status: "succeeded",
+      operation: 1,
+      kind: "published",
+      droppedActivities: result.droppedActivities,
+    });
+  });
 
   it("maps a pending-verification backfill to a retryable operation failure", async () => {
     const result: SyncRpcResult = { ...published, backfill: "pending-verification" };
@@ -330,6 +366,7 @@ describe("training sync coordinator", () => {
       status: "succeeded",
       operation: 2,
       kind: "published",
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     });
   });
 
@@ -361,6 +398,7 @@ describe("training sync coordinator", () => {
       status: "succeeded",
       operation: 2,
       kind: "published",
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     });
   });
 
@@ -544,6 +582,7 @@ describe("training sync coordinator", () => {
       status: "succeeded",
       operation: 1,
       kind: "published",
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     });
   });
 
@@ -579,6 +618,7 @@ describe("training sync coordinator", () => {
       status: "succeeded",
       operation: 2,
       kind: "published",
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     });
   });
 

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -452,6 +452,7 @@ ${"nonwrapping".repeat(36)}
             published: partial,
             referenceSucceeded: !partial,
             requests: { store: 1, reference: 1, total: 2 },
+            droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
           }),
         ];
       }

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -977,7 +977,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       controlObserver.disconnect();
       const coach = document.querySelector(".chat-message--coach");
       const link = coach?.querySelector("a");
-      const syncChip = document.querySelector(".sync-chip");
+      const syncChip = document.querySelector("[data-sync-chip]");
       return {
         location: location.href,
         bridgeKeys,

--- a/apps/desktop/tests/desktop-telegram-release-chain.integration.test.ts
+++ b/apps/desktop/tests/desktop-telegram-release-chain.integration.test.ts
@@ -456,6 +456,7 @@ async function createFixture(): Promise<ReleaseChainFixture> {
       published: false,
       referenceSucceeded: true,
       requests: { store: 0, reference: 0, total: 0 },
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     }),
   } as unknown as CoachOperations;
   const confirmations = {

--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -100,6 +100,7 @@ function makeScript(): DesktopFixtureScript {
           published: true,
           referenceSucceeded: true,
           requests: { store: 1, reference: 1, total: 2 },
+          droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
         });
       }
       if (request.method === "getAthleteState") {

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -165,6 +165,7 @@ function script(calls: ScriptRequest[], initial: "reached" | "complete") {
           published: false,
           referenceSucceeded: true,
           requests: { store: 0, reference: 0, total: 0 },
+          droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
         });
       }
       if (request.method === "hasSession") return response({ hasSession: false });

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@vitest/coverage-v8": "^4.1.4",
     "@xmldom/xmldom": "0.9.10",
     "ai": "^6.0.158",
-    "intervals-icu-api": "0.3.1",
+    "intervals-icu-api": "0.4.0",
     "msw": "^2.13.3",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",

--- a/packages/coach-cli/tests/verbs-rpc.test.ts
+++ b/packages/coach-cli/tests/verbs-rpc.test.ts
@@ -55,6 +55,7 @@ describe("bounded remote connection", () => {
         published: true,
         referenceSucceeded: true,
         requests: { store: 1, reference: 0, total: 1 },
+        droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
       },
     });
     const call = vi.fn(

--- a/packages/coach-cli/tests/verbs.test.ts
+++ b/packages/coach-cli/tests/verbs.test.ts
@@ -329,6 +329,7 @@ describe("verb rendering", () => {
               published,
               referenceSucceeded: true,
               requests: { store: 0, reference: 0, total: 0 },
+              droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
             }),
           }),
         }),

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -830,6 +830,7 @@ describe("RPC receive and observers", () => {
           published: true,
           referenceSucceeded: true,
           requests: { store: 1, reference: 1, total: 2 },
+          droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
         },
         getSetupStatus: {
           schemaVersion: 1,
@@ -1343,6 +1344,7 @@ describe("RPC receive and observers", () => {
           published: false,
           referenceSucceeded: true,
           requests: { store: 0, reference: 0, total: 0 },
+          droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
         },
       }),
     );

--- a/packages/coach-contract/src/athlete-state.ts
+++ b/packages/coach-contract/src/athlete-state.ts
@@ -182,6 +182,7 @@ export const PowerProgressUnavailableReasonSchema = z.enum([
   "invalid-data",
   "refresh-failed",
   "temporary-failure",
+  "source-restricted",
 ]);
 
 export const PowerProgressComputedSchema = z
@@ -256,6 +257,7 @@ export const TrainingContextUnknownReasonSchema = z.enum([
   "no-plan",
   "insufficient-data",
   "no-wellness",
+  "source-restricted",
 ]);
 
 export const CyclingAnchorSchema = z
@@ -310,7 +312,7 @@ export const CyclingLoadPanelSchema = z.discriminatedUnion("kind", [
   z
     .object({
       kind: z.literal("unknown"),
-      reason: z.enum(["not-synced", "no-platform-load"]),
+      reason: z.enum(["not-synced", "no-platform-load", "source-restricted"]),
     })
     .strict(),
 ]);
@@ -350,7 +352,7 @@ export const AdherencePanelSchema = z.discriminatedUnion("kind", [
   z
     .object({
       kind: z.literal("unknown"),
-      reason: z.enum(["not-synced", "no-plan", "insufficient-data"]),
+      reason: z.enum(["not-synced", "no-plan", "insufficient-data", "source-restricted"]),
     })
     .strict(),
 ]);
@@ -409,7 +411,7 @@ export const RecentRidesPanelSchema = z.discriminatedUnion("kind", [
   z
     .object({
       kind: z.literal("unknown"),
-      reason: z.enum(["not-synced", "no-recent-rides", "temporary-failure"]),
+      reason: z.enum(["not-synced", "no-recent-rides", "temporary-failure", "source-restricted"]),
     })
     .strict(),
 ]);

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -468,6 +468,80 @@ export const SyncBackfillOutcomeSchema = z.enum([
 ]);
 export type SyncBackfillOutcome = z.infer<typeof SyncBackfillOutcomeSchema>;
 
+export const ActivityRestrictionSchema = z
+  .object({
+    reason: z.literal("source-restricted"),
+    source: z.string().min(1),
+    count: z.number().int().positive(),
+  })
+  .strict();
+export type ActivityRestriction = z.infer<typeof ActivityRestrictionSchema>;
+
+export const ActivityRestrictionWindowSchema = z
+  .object({
+    total: z.number().int().nonnegative(),
+    visible: z.number().int().nonnegative(),
+    restrictions: z.array(ActivityRestrictionSchema),
+    other: z.number().int().nonnegative(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const restricted = value.restrictions.reduce((sum, entry) => sum + entry.count, 0);
+    if (value.visible + restricted + value.other !== value.total) {
+      context.addIssue({
+        code: "custom",
+        path: [],
+        message: "activity counts must balance",
+      });
+    }
+    for (let index = 1; index < value.restrictions.length; index += 1) {
+      if (value.restrictions[index - 1]!.source >= value.restrictions[index]!.source) {
+        context.addIssue({
+          code: "custom",
+          path: ["restrictions", index, "source"],
+          message: "activity restriction sources must be unique and sorted",
+        });
+      }
+    }
+  });
+export type ActivityRestrictionWindow = z.infer<typeof ActivityRestrictionWindowSchema>;
+
+export const DroppedActivitiesSchema = z
+  .object({
+    overall: ActivityRestrictionWindowSchema,
+    recent7Days: ActivityRestrictionWindowSchema,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    for (const field of ["total", "visible", "other"] as const) {
+      if (value.recent7Days[field] > value.overall[field]) {
+        context.addIssue({
+          code: "custom",
+          path: ["recent7Days", field],
+          message: "recent activity count cannot exceed overall activity count",
+        });
+      }
+    }
+    const overallBySource = new Map(
+      value.overall.restrictions.map((entry) => [entry.source, entry.count]),
+    );
+    for (const entry of value.recent7Days.restrictions) {
+      if (entry.count > (overallBySource.get(entry.source) ?? 0)) {
+        context.addIssue({
+          code: "custom",
+          path: ["recent7Days", "restrictions"],
+          message: "recent source restriction count cannot exceed its overall count",
+        });
+      }
+    }
+  });
+export type DroppedActivities = z.infer<typeof DroppedActivitiesSchema>;
+
+export const EMPTY_DROPPED_ACTIVITIES: DroppedActivities = Object.freeze({
+  overall: Object.freeze({ total: 0, visible: 0, restrictions: [], other: 0 }),
+  recent7Days: Object.freeze({ total: 0, visible: 0, restrictions: [], other: 0 }),
+});
+
 export const SyncRpcResultSchema = z
   .object({
     schemaVersion: z.literal(1),
@@ -481,6 +555,7 @@ export const SyncRpcResultSchema = z
         total: z.number().int().nonnegative(),
       })
       .strict(),
+    droppedActivities: DroppedActivitiesSchema,
   })
   .strict()
   .superRefine((value, context) => {

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 18;
+export const PROTOCOL_VERSION = 19;

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -112,7 +112,7 @@ describe("exit codes", () => {
 
 describe("protocol version", () => {
   it("is 18", () => {
-    expect(PROTOCOL_VERSION).toBe(18);
+    expect(PROTOCOL_VERSION).toBe(19);
   });
 });
 

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -11,6 +11,8 @@ import {
   PROTOCOL_VERSION,
   TurnEventSchema,
   AthleteStateSchema,
+  AdherencePanelSchema,
+  CyclingLoadPanelSchema,
   CyclingTrainingContextSchema,
   PowerProgressPanelSchema,
   RecentRidesPanelSchema,
@@ -396,6 +398,9 @@ describe("AthleteState", () => {
       reason: "not-synced",
     });
     expect(
+      PowerProgressPanelSchema.parse({ kind: "unavailable", reason: "source-restricted" }),
+    ).toEqual({ kind: "unavailable", reason: "source-restricted" });
+    expect(
       PowerProgressPanelSchema.safeParse({
         ...computedPowerProgress,
         anchors: [...computedPowerProgress.anchors].reverse(),
@@ -421,6 +426,17 @@ describe("AthleteState", () => {
     ).toBe(false);
   });
 
+  it("accepts source-restricted as a refusal reason for load and adherence", () => {
+    expect(CyclingLoadPanelSchema.parse({ kind: "unknown", reason: "source-restricted" })).toEqual({
+      kind: "unknown",
+      reason: "source-restricted",
+    });
+    expect(AdherencePanelSchema.parse({ kind: "unknown", reason: "source-restricted" })).toEqual({
+      kind: "unknown",
+      reason: "source-restricted",
+    });
+  });
+
   it("bounds recent rides and rejects provider-only or malformed fields", () => {
     const ride = {
       id: "a".repeat(64),
@@ -442,6 +458,10 @@ describe("AthleteState", () => {
       })),
     } as const;
     expect(RecentRidesPanelSchema.parse(panel)).toEqual(panel);
+    expect(RecentRidesPanelSchema.parse({ kind: "unknown", reason: "source-restricted" })).toEqual({
+      kind: "unknown",
+      reason: "source-restricted",
+    });
     expect(
       RecentRidesPanelSchema.safeParse({ ...panel, items: [...panel.items, ride] }).success,
     ).toBe(false);

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -113,7 +113,7 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 18", () => {
+  it("is 19", () => {
     expect(PROTOCOL_VERSION).toBe(19);
   });
 });

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -80,6 +80,7 @@ import {
   compareProtocolVersions,
   createAcceptedServerHandshakeFrame,
   createClientHandshakeFrame,
+  EXIT_VERSION_MISMATCH,
   createVersionMismatchServerHandshakeFrame,
   parseCoachRpcEnvelope,
   serializeCoachRpcEnvelope,
@@ -617,6 +618,7 @@ describe("coach request and event projection", () => {
       published: true,
       referenceSucceeded: true,
       requests: { store: 2, reference: 1, total: 3 },
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     } as const;
     expect(SyncRpcResultSchema.parse(syncResult)).toEqual(syncResult);
     for (const backfill of [
@@ -638,6 +640,77 @@ describe("coach request and event projection", () => {
         requests: { ...syncResult.requests, total: 4 },
       }).success,
     ).toBe(false);
+    const restricted = {
+      overall: {
+        total: 67,
+        visible: 5,
+        restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+        other: 2,
+      },
+      recent7Days: {
+        total: 5,
+        visible: 1,
+        restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+        other: 0,
+      },
+    } as const;
+    expect(
+      SyncRpcResultSchema.parse({ ...syncResult, droppedActivities: restricted })
+        .droppedActivities,
+    ).toEqual(restricted);
+    expect(
+      SyncRpcResultSchema.safeParse({
+        ...syncResult,
+        droppedActivities: {
+          overall: {
+            total: 67,
+            visible: 5,
+            restrictions: [
+              { reason: "source-restricted", source: "GARMIN_CONNECT", count: 10 },
+              { reason: "source-restricted", source: "STRAVA", count: 50 },
+            ],
+            other: 2,
+          },
+          recent7Days: {
+            total: 5,
+            visible: 1,
+            restrictions: [
+              { reason: "source-restricted", source: "GARMIN_CONNECT", count: 1 },
+              { reason: "source-restricted", source: "STRAVA", count: 3 },
+            ],
+            other: 0,
+          },
+        },
+      }).success,
+    ).toBe(true);
+    for (const droppedActivities of [
+      { ...restricted, overall: { ...restricted.overall, total: 68 } },
+      {
+        ...restricted,
+        recent7Days: {
+          total: 62,
+          visible: 1,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 61 }],
+          other: 0,
+        },
+      },
+      {
+        ...restricted,
+        overall: {
+          total: 67,
+          visible: 5,
+          restrictions: [
+            { reason: "source-restricted", source: "STRAVA", count: 30 },
+            { reason: "source-restricted", source: "STRAVA", count: 30 },
+          ],
+          other: 2,
+        },
+      },
+    ]) {
+      expect(
+        SyncRpcResultSchema.safeParse({ ...syncResult, droppedActivities }).success,
+      ).toBe(false);
+    }
     expect(
       OperationProgressEventSchema.parse({ phase: "started", completed: 0, total: 1 }),
     ).toEqual({ phase: "started", completed: 0, total: 1 });
@@ -1063,6 +1136,7 @@ describe("coach request and event projection", () => {
         published: false,
         referenceSucceeded: true,
         requests: { store: 0, reference: 0, total: 0 },
+        droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
       }),
       getSetupStatus: async () => ({
         schemaVersion: 1,
@@ -1624,7 +1698,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-18 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-19 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1632,12 +1706,39 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 18,
-      serverProtocolVersion: 18,
+      clientProtocolVersion: 19,
+      serverProtocolVersion: 19,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
     });
+  });
+
+  it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
+    const previous = PROTOCOL_VERSION - 1;
+    expect(previous).toBe(18);
+    expect(() =>
+      createAcceptedServerHandshakeFrame("service-managed", previous, {
+        ...acceptedHandshakeBinding,
+      }),
+    ).toThrow();
+    expect(createVersionMismatchServerHandshakeFrame("service-managed", previous)).toEqual({
+      type: "handshake",
+      status: "version-mismatch",
+      clientProtocolVersion: previous,
+      serverProtocolVersion: PROTOCOL_VERSION,
+      direction: "client-older",
+      owner: "service-managed",
+    });
+    expect(EXIT_VERSION_MISMATCH).toBe(5);
+    expect(
+      SyncRpcResultSchema.safeParse({
+        schemaVersion: 1,
+        published: true,
+        referenceSucceeded: true,
+        requests: { store: 1, reference: 1, total: 2 },
+      }).success,
+    ).toBe(false);
   });
 
   it("keeps protocol-11 acceptance available only through the upgrade-control schema", () => {
@@ -1688,9 +1789,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 18 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 19 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(18);
+    expect(client.clientProtocolVersion).toBe(19);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -1816,7 +1917,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version eighteen", () => {
-    expect(PROTOCOL_VERSION).toBe(18);
+  it("uses protocol version nineteen", () => {
+    expect(PROTOCOL_VERSION).toBe(19);
   });
 });

--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -47,7 +47,7 @@
     "@enduragent/kernel-node": "workspace:*",
     "@enduragent/sync-intervals-icu": "workspace:*",
     "@enduragent/sport-cycling": "workspace:*",
-    "intervals-icu-api": "0.3.1",
+    "intervals-icu-api": "0.4.0",
     "ws": "^8.21.3",
     "yaml": "^2.8.3"
   },

--- a/packages/coach/src/athlete-state-reader.ts
+++ b/packages/coach/src/athlete-state-reader.ts
@@ -2,9 +2,11 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   AthleteStateSchema,
+  EMPTY_DROPPED_ACTIVITIES,
   PowerProgressPanelSchema,
   RecentRidesPanelSchema,
   type AthleteState,
+  type DroppedActivities,
   type PowerProgressPanel,
   type RecentRidesPanel,
 } from "@enduragent/coach-contract";
@@ -63,6 +65,7 @@ export interface CreatePersistedAthleteStateSourceOptions {
       readonly asOfEpochSeconds: number;
     }): Promise<RecentRidesPanel>;
   };
+  readonly droppedActivitiesSource?: () => DroppedActivities;
 }
 
 export function createPersistedAthleteStateSource(
@@ -165,6 +168,8 @@ export function createPersistedAthleteStateSource(
         wellness: latest.wellness_data,
         performanceProgress,
         recentRides,
+        droppedActivities:
+          input.droppedActivitiesSource?.() ?? EMPTY_DROPPED_ACTIVITIES,
       });
       const mapped = {
         schemaVersion: latest.metadata.schema_version,

--- a/packages/coach/src/backfill.ts
+++ b/packages/coach/src/backfill.ts
@@ -5,6 +5,8 @@ import { createNodeImportRuntime, type NodeImportRuntime } from "@enduragent/ker
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import {
   REQUEST_ATTEMPTS,
+  ZERO_DROPPED_ACTIVITY_ROWS,
+  type DroppedActivityRowCounts,
   type IntervalsIcuArtifact,
   type IntervalsIcuSource,
 } from "@enduragent/sync-intervals-icu";
@@ -91,13 +93,20 @@ export interface RunBackfillPagesOptions {
   readonly onPageCommitted?: (input: { readonly pages: number; readonly artifacts: number; readonly report: ImportReport | null }) => void;
 }
 
-export interface BackfillRunResult { readonly pages: number; readonly artifacts: number; readonly reports: readonly ImportReport[]; }
+export interface BackfillRunResult { readonly pages: number; readonly artifacts: number; readonly reports: readonly ImportReport[];
+  readonly droppedActivityRows: DroppedActivityRowCounts; }
+
+function addDropped(total: DroppedActivityRowCounts, page: DroppedActivityRowCounts | undefined): DroppedActivityRowCounts {
+  if (page === undefined) return total;
+  return { sourceRestricted: total.sourceRestricted + page.sourceRestricted, other: total.other + page.other };
+}
 
 export async function runActivityAuditPages(options: RunBackfillPagesOptions): Promise<BackfillRunResult> {
   const batchSize = configured(options.batchSize, DEFAULT_BACKFILL_BATCH_SIZE, 1, 1_000, "batch size");
   const perRequestTimeoutMs = configured(options.perRequestTimeoutMs, DEFAULT_PER_REQUEST_TIMEOUT_MS, 1_000, 300_000, "request timeout");
   const pageDeadlineMs = configured(options.backfillPageDeadlineMs, DEFAULT_BACKFILL_PAGE_DEADLINE_MS, 60_000, 86_400_000, "page deadline");
   let pages = 0, artifacts = 0;
+  let droppedActivityRows: DroppedActivityRowCounts = ZERO_DROPPED_ACTIVITY_ROWS;
   const reports: ImportReport[] = [];
   for (;;) {
     const before = await createSyncStateRepository(options.store).readWatermark("intervals-icu", "activities");
@@ -129,6 +138,7 @@ export async function runActivityAuditPages(options: RunBackfillPagesOptions): P
     if (checkpoint === null || checkpoint.watermark.source !== "intervals-icu" || checkpoint.watermark.lane !== "activities") {
       throw new Error("invalid source checkpoint");
     }
+    droppedActivityRows = addDropped(droppedActivityRows, checkpoint.droppedActivityRows);
     const checkpointValue = checkpoint.watermark.value;
     const parsed = cursor(checkpointValue);
     let report: ImportReport | null = null;
@@ -153,7 +163,8 @@ export async function runActivityAuditPages(options: RunBackfillPagesOptions): P
     options.onPageCommitted?.({ pages, artifacts, report });
     if (parsed.complete) break;
   }
-  return Object.freeze({ pages, artifacts, reports: Object.freeze(reports) });
+  return Object.freeze({ pages, artifacts, reports: Object.freeze(reports),
+    droppedActivityRows: Object.freeze(droppedActivityRows) });
 }
 
 export async function runBackfillPages(options: RunBackfillPagesOptions): Promise<BackfillRunResult> {
@@ -161,6 +172,7 @@ export async function runBackfillPages(options: RunBackfillPagesOptions): Promis
   const perRequestTimeoutMs = configured(options.perRequestTimeoutMs, DEFAULT_PER_REQUEST_TIMEOUT_MS, 1_000, 300_000, "request timeout");
   const pageDeadlineMs = configured(options.backfillPageDeadlineMs, DEFAULT_BACKFILL_PAGE_DEADLINE_MS, 60_000, 86_400_000, "page deadline");
   let pages = 0, artifacts = 0, terminalCursor: string | null = null;
+  let droppedActivityRows: DroppedActivityRowCounts = ZERO_DROPPED_ACTIVITY_ROWS;
   const reports: ImportReport[] = [];
   for (;;) {
     const before = await createSyncStateRepository(options.store).readWatermark("intervals-icu", "bulk-fit");
@@ -194,6 +206,7 @@ export async function runBackfillPages(options: RunBackfillPagesOptions): Promis
     if (checkpoint === null || checkpoint.watermark.source !== "intervals-icu" || checkpoint.watermark.lane !== "bulk-fit") {
       throw new Error("invalid source checkpoint");
     }
+    if (terminalCursor === null) droppedActivityRows = addDropped(droppedActivityRows, checkpoint.droppedActivityRows);
     const checkpointValue = checkpoint.watermark.value;
     const parsed = cursor(checkpointValue);
     let report: ImportReport | null = null;
@@ -222,7 +235,8 @@ export async function runBackfillPages(options: RunBackfillPagesOptions): Promis
     }
     if (parsed.complete) terminalCursor = checkpointValue;
   }
-  return Object.freeze({ pages, artifacts, reports: Object.freeze(reports) });
+  return Object.freeze({ pages, artifacts, reports: Object.freeze(reports),
+    droppedActivityRows: Object.freeze(droppedActivityRows) });
 }
 
 export interface RunIntervalsBackfillOptions {

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -202,6 +202,7 @@ export interface LocalReferenceRuntime {
 
 export interface LocalStoreRuntime {
   readonly athleteData: StoreRuntime["athleteData"];
+  currentDroppedActivities(): ReturnType<StoreRuntime["currentDroppedActivities"]>;
   attemptLedgerForRun(): ReturnType<StoreRuntime["attemptLedgerForRun"]>;
   runWindow(): ReturnType<StoreRuntime["runWindow"]>;
   runWindowAfter(
@@ -942,6 +943,7 @@ export async function createLocalCoachComposition(
       cyclingFtpAnchorResolver,
       powerProgressSource: powerProgress,
       recentRidesSource: createRecentRidesSource(canonicalActivities),
+      droppedActivitiesSource: () => runtime!.currentDroppedActivities(),
     });
     const buildBundle = (config: Config): RuntimeBundle => {
       const timezone = resolveUserTimezone(config.session.timezone);

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -249,6 +249,7 @@ export function createCoachOperations(
               reference: window.counts.legacyRequests,
               total: window.counts.totalRequests,
             },
+            droppedActivities: window.droppedActivities,
           });
           deliver(onEvent, { phase: "completed", completed: 1, total: 1 });
           return result;

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -19,6 +19,10 @@ import type { ReferenceCaptureManifest } from "@enduragent/kernel/reference/capt
 import type { ProducedLocalBundle } from "@enduragent/kernel/reference/local-bundle";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { openReadonlySqliteStorage } from "@enduragent/kernel-node/sqlite";
+import {
+  EMPTY_DROPPED_ACTIVITIES,
+  type DroppedActivities,
+} from "@enduragent/coach-contract";
 import { join } from "node:path";
 import { runAnalyticsCurveRefresh } from "./analytics-curves.js";
 import { runReferenceCapture } from "./capture.js";
@@ -45,6 +49,7 @@ export interface StoreWindowResult {
   readonly published: boolean;
   readonly counts: PhysicalRequestCounts;
   readonly legacySucceeded: boolean;
+  readonly droppedActivities: DroppedActivities;
 }
 
 export interface StoreWriteResult<T> {
@@ -98,6 +103,7 @@ export class StoreRuntime {
   private activeController: AbortController | undefined;
   private activeBeforeWindowController: AbortController | undefined;
   private activeWindow: Promise<StoreWindowResult> | undefined;
+  private droppedActivitiesValue = EMPTY_DROPPED_ACTIVITIES;
   private admissionActive = false;
   private readonly admissionQueue: Array<() => void> = [];
   private readonly admissionDrainWaiters = new Set<() => void>();
@@ -198,6 +204,10 @@ export class StoreRuntime {
     });
     this.installActiveWindow(task);
     return task;
+  }
+
+  currentDroppedActivities(): DroppedActivities {
+    return this.droppedActivitiesValue;
   }
 
   runExclusive<T>(work: (signal: AbortSignal) => Promise<T>): Promise<T> {
@@ -442,11 +452,19 @@ LIMIT 1`,
       }
       const counts = ledger.snapshot();
       if (captureResult.status === "rejected") throw captureResult.reason;
+      const droppedActivities =
+        legacyResult.status === "fulfilled" && legacyResult.value.kind === "ran"
+          ? legacyResult.value.droppedActivities
+          : this.droppedActivitiesValue;
+      if (legacyResult.status === "fulfilled" && legacyResult.value.kind === "ran") {
+        this.droppedActivitiesValue = droppedActivities;
+      }
       return Object.freeze({
         published,
         counts,
         legacySucceeded:
           legacyResult.status === "fulfilled" && legacyResult.value.kind !== "failed",
+        droppedActivities,
       });
     } finally {
       admissionSignal.removeEventListener("abort", abortWindow);

--- a/packages/coach/src/training-context.ts
+++ b/packages/coach/src/training-context.ts
@@ -26,7 +26,21 @@ export interface ProjectCyclingTrainingContextInput {
   readonly droppedActivities?: DroppedActivities;
 }
 
+export const ADHERENCE_MAX_RESTRICTED_ACTIVITIES = 0;
+export const LOAD_MAX_RESTRICTED_SHARE = 0.5;
+
 const cyclingTypes = new Set<string>(cyclingSport.intervalsActivityTypes);
+
+type DroppedActivitiesWindow = DroppedActivities["overall"];
+
+function restrictedActivityCount(window: DroppedActivitiesWindow | undefined): number {
+  return window?.restrictions.reduce((sum, entry) => sum + entry.count, 0) ?? 0;
+}
+
+function restrictedActivityShare(window: DroppedActivitiesWindow | undefined): number {
+  if (window === undefined || window.total === 0) return 0;
+  return restrictedActivityCount(window) / window.total;
+}
 
 function projectAnchorZones(
   input: ProjectCyclingTrainingContextInput,
@@ -58,6 +72,9 @@ function projectAnchorZones(
 function projectCyclingLoad(
   input: ProjectCyclingTrainingContextInput,
 ): CyclingTrainingContext["cyclingLoad"] {
+  if (restrictedActivityShare(input.droppedActivities?.recent7Days) >= LOAD_MAX_RESTRICTED_SHARE) {
+    return { kind: "unknown", reason: "source-restricted" };
+  }
   const activities = input.recentActivities.flatMap((row) => {
     const parsed = ActivitySchema.safeParse(row);
     return parsed.success && cyclingTypes.has(parsed.data.type) ? [parsed.data] : [];
@@ -112,6 +129,12 @@ function nonnegativeInteger(value: unknown): value is number {
 function projectAdherence(
   input: ProjectCyclingTrainingContextInput,
 ): CyclingTrainingContext["adherence"] {
+  if (
+    restrictedActivityCount(input.droppedActivities?.recent7Days) >
+    ADHERENCE_MAX_RESTRICTED_ACTIVITIES
+  ) {
+    return { kind: "unknown", reason: "source-restricted" };
+  }
   const ratio = input.derivedMetrics.consistency_index;
   const details = input.derivedMetrics.consistency_details;
   if (
@@ -192,12 +215,18 @@ function projectWellness(
 export function projectCyclingTrainingContext(
   input: ProjectCyclingTrainingContextInput,
 ): CyclingTrainingContext {
+  const overallRestricted =
+    restrictedActivityShare(input.droppedActivities?.overall) >= LOAD_MAX_RESTRICTED_SHARE;
   return {
-    performanceProgress: input.performanceProgress ?? {
-      kind: "unavailable",
-      reason: "not-synced",
-    },
-    recentRides: input.recentRides ?? { kind: "unknown", reason: "not-synced" },
+    performanceProgress: overallRestricted
+      ? { kind: "unavailable", reason: "source-restricted" }
+      : (input.performanceProgress ?? {
+          kind: "unavailable",
+          reason: "not-synced",
+        }),
+    recentRides: overallRestricted
+      ? { kind: "unknown", reason: "source-restricted" }
+      : (input.recentRides ?? { kind: "unknown", reason: "not-synced" }),
     anchorZones: projectAnchorZones(input),
     cyclingLoad: projectCyclingLoad(input),
     plan: projectPlan(input),

--- a/packages/coach/src/training-context.ts
+++ b/packages/coach/src/training-context.ts
@@ -1,6 +1,7 @@
 import type {
   CyclingTrainingContext,
   CyclingZoneRow,
+  DroppedActivities,
   PowerProgressPanel,
   RecentRidesPanel,
   WellnessSeries,
@@ -22,6 +23,7 @@ export interface ProjectCyclingTrainingContextInput {
   readonly wellness: unknown;
   readonly performanceProgress?: PowerProgressPanel;
   readonly recentRides?: RecentRidesPanel;
+  readonly droppedActivities?: DroppedActivities;
 }
 
 const cyclingTypes = new Set<string>(cyclingSport.intervalsActivityTypes);

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -12,6 +12,7 @@ import { createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import type { IntervalsIcuSource } from "@enduragent/sync-intervals-icu";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { EMPTY_DROPPED_ACTIVITIES } from "@enduragent/coach-contract";
 import {
   createIntervalsBackfillSource,
   runBackfillPages,
@@ -125,6 +126,39 @@ describe("incremental backfill pages", () => {
       configDir: join(root, "config"),
     };
   }
+
+  it("sums dropped activity rows across pages and never counts the terminal replay twice", async () => {
+    const value = await fresh();
+    try {
+      const midway = JSON.stringify({
+        v: 1,
+        cycle: 0,
+        window_start: "2010-11-05",
+        window_end: "2010-11-30",
+        last_key: null,
+        complete: false,
+      });
+      const fake = source((_watermark, call) =>
+        (async function* () {
+          yield {
+            kind: "checkpoint",
+            watermark: { source: "intervals-icu", lane: "bulk-fit", value: call === 0 ? midway : complete },
+            droppedActivityRows: { sourceRestricted: call === 0 ? 60 : 3, other: call === 0 ? 0 : 2 },
+          };
+        })(),
+      );
+      const result = await runBackfillPages({
+        store: value.store,
+        node: value.node,
+        source: fake,
+        clock,
+      });
+      expect(result).toMatchObject({ pages: 3 });
+      expect(result.droppedActivityRows).toEqual({ sourceRestricted: 63, other: 2 });
+    } finally {
+      await value.store.close();
+    }
+  });
 
   it("commits each page checkpoint atomically and finishes with one terminal no-op", async () => {
     const value = await fresh();
@@ -328,6 +362,7 @@ describe("incremental backfill pages", () => {
                   "legacy:reference": 0,
                 },
               },
+              droppedActivities: EMPTY_DROPPED_ACTIVITIES,
             };
           },
         },

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -78,6 +78,7 @@ const operations: CoachOperations = {
     published: true,
     referenceSucceeded: true,
     requests: { store: 1, reference: 1, total: 2 },
+    droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
   getTranscriptPage: async () => ({

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -5,7 +5,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse as parseYaml, stringify as toYaml } from "yaml";
-import type { AthleteState, CoachEngine } from "@enduragent/coach-contract";
+import {
+  EMPTY_DROPPED_ACTIVITIES,
+  type AthleteState,
+  type CoachEngine,
+} from "@enduragent/coach-contract";
 import {
   RefreshTokenReusedError,
   engineConfigFromConfig,
@@ -197,6 +201,7 @@ function runtime(
       published: boolean;
       counts: ReturnType<ReturnType<typeof createPhysicalRequestLedger>["snapshot"]>;
       legacySucceeded: boolean;
+      droppedActivities?: typeof EMPTY_DROPPED_ACTIVITIES;
     }>;
     close?: () => Promise<void>;
   } = {},
@@ -220,11 +225,12 @@ function runtime(
   };
   return {
     athleteData: athleteData(),
+    currentDroppedActivities: () => EMPTY_DROPPED_ACTIVITIES,
     attemptLedgerForRun: () => ledger,
-    runWindow,
+    runWindow: async () => ({ ...(await runWindow()), droppedActivities: EMPTY_DROPPED_ACTIVITIES }),
     async runWindowAfter(work) {
       await work(new AbortController().signal);
-      return runWindow();
+      return { ...(await runWindow()), droppedActivities: EMPTY_DROPPED_ACTIVITIES };
     },
     runExclusive,
     async runActivityWrite(work) {
@@ -1380,7 +1386,7 @@ describe("local coach composition", () => {
       const current = runtimeOptions?.readConfig?.();
       if (current === undefined) throw new Error("Expected live runtime configuration.");
       windows.push({ ...current.intervals });
-      return { published: true, counts, legacySucceeded: true };
+      return { published: true, counts, legacySucceeded: true, droppedActivities: EMPTY_DROPPED_ACTIVITIES };
     });
     const lifecycle = await compose(
       home,
@@ -1578,7 +1584,7 @@ describe("local coach composition", () => {
   it("keeps manual sync keyless before deferred owner approval", async () => {
     const home = await freshHome();
     const context = fakeContext(home);
-    const backfill = vi.fn(async () => ({ pages: 1, artifacts: 0, reports: [] }));
+    const backfill = vi.fn(async () => ({ pages: 1, artifacts: 0, reports: [], droppedActivityRows: { sourceRestricted: 0, other: 0 } }));
     let runtimeOptions: LocalStoreRuntimeOptions | undefined;
     let readReferenceIntervals:
       | (() => { readonly apiKey: string; readonly athleteId?: string })
@@ -1665,7 +1671,7 @@ describe("local coach composition", () => {
         const current = runtimeOptions?.readConfig?.();
         if (current === undefined) throw new Error("Expected live runtime configuration.");
         windows.push({ ...current.intervals });
-        return { published: true, counts, legacySucceeded: true };
+        return { published: true, counts, legacySucceeded: true, droppedActivities: EMPTY_DROPPED_ACTIVITIES };
       }),
     );
     let holdTurn = true;
@@ -1735,13 +1741,7 @@ describe("local coach composition", () => {
     const home = await freshHome();
     const shutdownFailure = new Error("synthetic lifecycle close");
     let windowController: AbortController | undefined;
-    let activeWindow:
-      | Promise<{
-          published: boolean;
-          counts: ReturnType<ReturnType<typeof createPhysicalRequestLedger>["snapshot"]>;
-          legacySucceeded: boolean;
-        }>
-      | undefined;
+    let activeWindow: ReturnType<LocalStoreRuntime["runWindow"]> | undefined;
     let markOwnerEntered!: () => void;
     const ownerEntered = new Promise<void>((resolve) => {
       markOwnerEntered = resolve;
@@ -1757,7 +1757,7 @@ describe("local coach composition", () => {
       windowController = new AbortController();
       activeWindow = (async () => {
         await work(windowController!.signal);
-        return { published: true, counts, legacySucceeded: true };
+        return { published: true, counts, legacySucceeded: true, droppedActivities: EMPTY_DROPPED_ACTIVITIES };
       })();
       return activeWindow;
     });
@@ -2809,7 +2809,7 @@ describe("local coach composition", () => {
               const current = options.readConfig?.();
               if (current === undefined) throw new Error("Expected live runtime configuration.");
               windows.push({ ...current.intervals });
-              return { published: true, counts, legacySucceeded: true };
+              return { published: true, counts, legacySucceeded: true, droppedActivities: EMPTY_DROPPED_ACTIVITIES };
             },
           });
         },
@@ -3910,7 +3910,7 @@ describe("local coach composition", () => {
       legacyLimit: 15,
       totalLimit: 79,
     }).snapshot();
-    const result = { published: true, counts, legacySucceeded: true };
+    const result = { published: true, counts, legacySucceeded: true, droppedActivities: EMPTY_DROPPED_ACTIVITIES };
     let active: ReturnType<LocalStoreRuntime["runWindow"]> | undefined;
     let windowCount = 0;
     const launchWindow = (): ReturnType<LocalStoreRuntime["runWindow"]> => {
@@ -4949,7 +4949,7 @@ describe("local coach composition", () => {
     const home = await freshHome();
     const context = fakeContext(home);
     const selectedRuntime = runtime();
-    const backfill = vi.fn(async () => ({ pages: 1, artifacts: 0, reports: [] }));
+    const backfill = vi.fn(async () => ({ pages: 1, artifacts: 0, reports: [], droppedActivityRows: { sourceRestricted: 0, other: 0 } }));
     const lifecycle = await compose(
       home,
       {

--- a/packages/coach/tests/daemon-handshake.test.ts
+++ b/packages/coach/tests/daemon-handshake.test.ts
@@ -293,6 +293,7 @@ describe.skipIf(!hasLoopback)("production peer observations", () => {
           published: false,
           referenceSucceeded: true,
           requests: { store: 0, reference: 0, total: 0 },
+          droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
         }),
         saveIntake: async () => ({ schemaVersion: 1, saved: true }),
         getTranscriptPage: async () => ({

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -111,6 +111,7 @@ const operations: CoachOperations = {
     published: true,
     referenceSucceeded: true,
     requests: { store: 1, reference: 1, total: 2 },
+    droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
   getTranscriptPage: async () => ({

--- a/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
+++ b/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
@@ -198,6 +198,7 @@ async function startRpc(coachEngine: CoachEngine): Promise<RunningRpc> {
         published: false,
         referenceSucceeded: true,
         requests: { store: 0, reference: 0, total: 0 },
+        droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
       }),
       saveIntake: async () => ({ schemaVersion: 1, saved: true }),
       getTranscriptPage: async () => ({

--- a/packages/coach/tests/desktop-telegram-runtime.test.ts
+++ b/packages/coach/tests/desktop-telegram-runtime.test.ts
@@ -51,6 +51,7 @@ describe("Desktop Telegram runtime projection", () => {
       published: true,
       referenceSucceeded: true,
       requests: { store: 1, reference: 1, total: 2 },
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     }));
     const lifecycle = {
       home: { root: "/synthetic/home" },

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 18 as const,
-      serverProtocolVersion: 18 as const,
+      clientProtocolVersion: 19 as const,
+      serverProtocolVersion: 19 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -76,6 +76,7 @@ const operations: CoachOperations = {
     published: false,
     referenceSucceeded: true,
     requests: { store: 0, reference: 0, total: 0 },
+    droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
   getTranscriptPage: async () => ({
@@ -282,7 +283,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(18);
+    expect(PROTOCOL_VERSION).toBe(19);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/coach/tests/enduragent-redaction.test.ts
+++ b/packages/coach/tests/enduragent-redaction.test.ts
@@ -157,6 +157,7 @@ describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
               published: false,
               referenceSucceeded: true,
               requests: { store: 0, reference: 0, total: 0 },
+              droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
             }),
             saveIntake: async () => ({ schemaVersion: 1, saved: true }),
             getTranscriptPage: async () => ({

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -68,6 +68,7 @@ const operations: CoachOperations = {
     published: true,
     referenceSucceeded: true,
     requests: { store: 0, reference: 0, total: 0 },
+    droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
   getTranscriptPage: async () => ({

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -7,6 +7,7 @@ import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import { runMigrations } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import type { LocalStoreRuntime } from "../src/composition.js";
+import { EMPTY_DROPPED_ACTIVITIES, type DroppedActivities } from "@enduragent/coach-contract";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
 import { createCoachOperations } from "../src/operations.js";
 
@@ -56,7 +57,13 @@ function promiseGate(): { readonly promise: Promise<void>; release(): void } {
 }
 
 function operationRuntime(
-  runWindowAfter: LocalStoreRuntime["runWindowAfter"] = async (work) => {
+  runWindowAfter: (
+    work: (signal: AbortSignal) => Promise<void>,
+  ) => Promise<
+    Omit<Awaited<ReturnType<LocalStoreRuntime["runWindowAfter"]>>, "droppedActivities"> & {
+      readonly droppedActivities?: DroppedActivities;
+    }
+  > = async (work) => {
     await work(new AbortController().signal);
     return {
       published: false,
@@ -81,7 +88,14 @@ function operationRuntime(
       value: await runExclusive(work),
       activityReadAvailable: true,
     }),
-    runWindowAfter: (work) => runExclusive(() => runWindowAfter(work)),
+    runWindowAfter: (work) =>
+      runExclusive(async () => {
+        const result = await runWindowAfter(work);
+        return {
+          ...result,
+          droppedActivities: result.droppedActivities ?? EMPTY_DROPPED_ACTIVITIES,
+        };
+      }),
   };
 }
 
@@ -513,6 +527,7 @@ describe("coach operations", () => {
       published: true,
       referenceSucceeded: false,
       requests: { store: 2, reference: 1, total: 3 },
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     });
     expect(importFiles).toHaveBeenCalledTimes(1);
     expect(runWindowAfter).toHaveBeenCalledTimes(1);
@@ -608,7 +623,7 @@ describe("coach operations", () => {
   });
 
   it("reports pending verification instead of a completed keyless sync", async () => {
-    const backfill = vi.fn(async () => ({ pages: 0, artifacts: 0, reports: [] }));
+    const backfill = vi.fn(async () => ({ pages: 0, artifacts: 0, reports: [], droppedActivityRows: { sourceRestricted: 0, other: 0 } }));
     const pending = { value: true };
     const operations = createCoachOperations(
       {
@@ -648,7 +663,7 @@ describe("coach operations", () => {
     };
     const backfill = vi.fn(async () => {
       trace.push("backfill");
-      return { pages: 1, artifacts: 1, reports: [] };
+      return { pages: 1, artifacts: 1, reports: [], droppedActivityRows: { sourceRestricted: 60, other: 2 } };
     });
     const runWindowAfter = vi.fn(async (work: (signal: AbortSignal) => Promise<void>) => {
       trace.push("admitted");
@@ -658,6 +673,20 @@ describe("coach operations", () => {
         published: true,
         legacySucceeded: true,
         counts: requestCounts(3, 2),
+        droppedActivities: {
+          overall: {
+            total: 67,
+            visible: 5,
+            restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 60 }],
+            other: 2,
+          },
+          recent7Days: {
+            total: 5,
+            visible: 1,
+            restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 4 }],
+            other: 0,
+          },
+        },
       };
     });
     const operations = createCoachOperations(
@@ -697,6 +726,20 @@ describe("coach operations", () => {
       published: true,
       referenceSucceeded: true,
       requests: { store: 3, reference: 2, total: 5 },
+      droppedActivities: {
+        overall: {
+          total: 67,
+          visible: 5,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+          other: 2,
+        },
+        recent7Days: {
+          total: 5,
+          visible: 1,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+          other: 0,
+        },
+      },
     });
     const terminal = JSON.stringify(result);
     for (const privateValue of [
@@ -727,7 +770,7 @@ describe("coach operations", () => {
     ] as const;
     for (const options of pairs) {
       const events: unknown[] = [];
-      const backfill = vi.fn(async () => ({ pages: 1, artifacts: 0, reports: [] }));
+      const backfill = vi.fn(async () => ({ pages: 1, artifacts: 0, reports: [], droppedActivityRows: { sourceRestricted: 0, other: 0 } }));
       const refresh = vi.fn();
       const runtime = {
         credentials: intervalsCredentials(options.apiKey, options.athleteId),
@@ -778,7 +821,7 @@ describe("coach operations", () => {
       const refresh = vi.fn();
       const backfill = vi.fn(async () => {
         if (failurePoint === "backfill") throw new Error("synthetic backfill failure");
-        return { pages: 1, artifacts: 1, reports: [] };
+        return { pages: 1, artifacts: 1, reports: [], droppedActivityRows: { sourceRestricted: 60, other: 2 } };
       });
       const runtime = {
         intervals: intervalsCredentials(
@@ -834,7 +877,7 @@ describe("coach operations", () => {
         ]);
         attempt += 1;
         if (attempt === 1) throw new Error("synthetic interruption");
-        return { pages: 1, artifacts: 0, reports: [] };
+        return { pages: 1, artifacts: 0, reports: [], droppedActivityRows: { sourceRestricted: 0, other: 0 } };
       });
       const runtime = {
         intervals: intervalsCredentials(

--- a/packages/coach/tests/serve.test.ts
+++ b/packages/coach/tests/serve.test.ts
@@ -72,6 +72,7 @@ const operations: CoachOperations = {
     published: false,
     referenceSucceeded: true,
     requests: { store: 0, reference: 0, total: 0 },
+    droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
   getTranscriptPage: async () => ({

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -77,7 +77,7 @@ async function makeRuntime(
     services: {},
     runScheduledOnce: vi.fn(async () => {
       runtime.attemptLedgerForRun().charge("legacy", "legacy:reference");
-      return { kind: "ran", lastSyncAt: "1998-07-18T12:00:00.000Z", refreshed: [] } as const;
+      return { kind: "ran", lastSyncAt: "1998-07-18T12:00:00.000Z", refreshed: [], droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } } as const;
     }),
   } as unknown as ReferenceRuntime;
   const capture = vi.fn(
@@ -166,6 +166,48 @@ describe("StoreRuntime", () => {
     await runtime.close();
   });
 
+  it("surfaces the current Reference restriction summary without persisting it", async () => {
+    const { runtime, reference } = await makeRuntime();
+    const droppedActivities = {
+      overall: {
+        total: 67,
+        visible: 5,
+        restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 60 }],
+        other: 2,
+      },
+      recent7Days: {
+        total: 5,
+        visible: 1,
+        restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 4 }],
+        other: 0,
+      },
+    };
+    vi.mocked(reference.runScheduledOnce).mockImplementationOnce(async () => {
+      runtime.attemptLedgerForRun().charge("legacy", "legacy:reference");
+      return {
+        kind: "ran",
+        lastSyncAt: "1998-07-18T12:00:00.000Z",
+        refreshed: [],
+        droppedActivities,
+      };
+    });
+
+    const result = await runtime.runWindow();
+
+    expect(result.droppedActivities).toEqual(droppedActivities);
+    expect(runtime.currentDroppedActivities()).toEqual(droppedActivities);
+    vi.mocked(reference.runScheduledOnce).mockImplementationOnce(async () => {
+      runtime.attemptLedgerForRun().charge("legacy", "legacy:reference");
+      return { kind: "failed", reason: "fetch_failed", failures: [] };
+    });
+
+    const failedRefresh = await runtime.runWindow();
+
+    expect(failedRefresh).toMatchObject({ legacySucceeded: false, droppedActivities });
+    expect(runtime.currentDroppedActivities()).toEqual(droppedActivities);
+    await runtime.close();
+  });
+
   it("waits for both base lanes before reserving optional curve capacity", async () => {
     const { runtime, refreshCurves, reference } = await makeRuntime();
     let releaseLegacy!: () => void;
@@ -179,7 +221,7 @@ describe("StoreRuntime", () => {
       await new Promise<void>((resolve) => {
         releaseLegacy = resolve;
       });
-      return { kind: "ran", lastSyncAt: "1998-07-18T12:00:00.000Z", refreshed: [] };
+      return { kind: "ran", lastSyncAt: "1998-07-18T12:00:00.000Z", refreshed: [], droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } };
     });
 
     const window = runtime.runWindow();
@@ -283,7 +325,7 @@ describe("StoreRuntime", () => {
     const reference = {
       scheduler: { stop: vi.fn() },
       services: {},
-      runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [] })),
+      runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [], droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } })),
     } as unknown as ReferenceRuntime;
     const capture = vi
       .fn<() => Promise<ReferenceCaptureManifest>>()
@@ -358,7 +400,7 @@ describe("StoreRuntime", () => {
     const reference = {
       scheduler: { stop: vi.fn() },
       services: {},
-      runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [] })),
+      runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [], droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } })),
     } as unknown as ReferenceRuntime;
     const runtime = createStoreRuntime({
       env: {},

--- a/packages/coach/tests/training-context.test.ts
+++ b/packages/coach/tests/training-context.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
+import type {
+  DroppedActivities,
+  PowerProgressPanel,
+  RecentRidesPanel,
+} from "@enduragent/coach-contract";
 import type { CyclingFtpAnchorResult } from "@enduragent/kernel/anchors";
-import { projectCyclingTrainingContext } from "../src/training-context.js";
+import {
+  ADHERENCE_MAX_RESTRICTED_ACTIVITIES,
+  LOAD_MAX_RESTRICTED_SHARE,
+  projectCyclingTrainingContext,
+} from "../src/training-context.js";
 
 const anchor: CyclingFtpAnchorResult = {
   kind: "ftp",
@@ -11,6 +20,46 @@ const anchor: CyclingFtpAnchorResult = {
   ageDays: 48,
   stalenessBand: "aging",
   stale: true,
+};
+
+const performanceProgress: PowerProgressPanel = {
+  kind: "computed",
+  currentWindow: { start: "1998-06-09", end: "1998-07-06" },
+  previousWindow: { start: "1998-05-12", end: "1998-06-08" },
+  anchors: ([5, 60, 300, 1_200, 3_600] as const).map((durationSeconds) => ({
+    durationSeconds,
+    current: { kind: "computed", watts: 300 },
+    previous: { kind: "computed", watts: 280 },
+    change: { kind: "computed", percent: 7.1 },
+  })),
+  rotation: "balanced",
+  heartRateContext: { kind: "unavailable", reason: "insufficient-data" },
+  sustainabilityContext: {
+    kind: "computed",
+    window: { start: "1998-05-26", end: "1998-07-06" },
+    coverageRatio: 0.8,
+    sourceContext: "mixed",
+  },
+  freshness: "fresh",
+  asOf: "1998-07-06T09:00:00.000Z",
+};
+
+const recentRides: RecentRidesPanel = {
+  kind: "computed",
+  asOf: "1998-07-06T09:00:00.000Z",
+  windowDays: 28,
+  items: [
+    {
+      id: "a".repeat(64),
+      subSport: "road",
+      startEpochSeconds: 899_712_000,
+      timezoneOffsetSeconds: 21_600,
+      localDate: "1998-07-06",
+      elapsedSeconds: 3_700,
+      movingSeconds: 3_600,
+      distanceMeters: 40_000,
+    },
+  ],
 };
 
 function activity(overrides: Record<string, unknown> = {}) {
@@ -37,6 +86,27 @@ function wellness(id: string, overrides: Record<string, unknown> = {}) {
   };
 }
 
+function droppedActivities(
+  overallRestricted: number,
+  overallTotal: number,
+  recentRestricted: number,
+  recentTotal: number,
+): DroppedActivities {
+  const window = (restricted: number, total: number) => ({
+    total,
+    visible: total - restricted,
+    restrictions:
+      restricted === 0
+        ? []
+        : [{ reason: "source-restricted" as const, source: "STRAVA", count: restricted }],
+    other: 0,
+  });
+  return {
+    overall: window(overallRestricted, overallTotal),
+    recent7Days: window(recentRestricted, recentTotal),
+  };
+}
+
 function project(overrides: Partial<Parameters<typeof projectCyclingTrainingContext>[0]> = {}) {
   return projectCyclingTrainingContext({
     asOf: "2026-07-18T00:00:00.000Z",
@@ -56,6 +126,8 @@ function project(overrides: Partial<Parameters<typeof projectCyclingTrainingCont
       },
     ],
     wellness: [wellness("2026-07-17")],
+    performanceProgress,
+    recentRides,
     ...overrides,
   });
 }
@@ -123,6 +195,84 @@ describe("cycling training context projection", () => {
       kind: "unknown",
       reason: "no-platform-load",
     });
+  });
+
+  it("preserves every computed panel when no activities are restricted", () => {
+    const baseline = project();
+    const result = project({ droppedActivities: droppedActivities(0, 100, 0, 7) });
+    expect(result).toEqual(baseline);
+    expect({
+      performanceProgress: result.performanceProgress.kind,
+      recentRides: result.recentRides.kind,
+      cyclingLoad: result.cyclingLoad.kind,
+      adherence: result.adherence.kind,
+    }).toMatchInlineSnapshot(`
+      {
+        "adherence": "computed",
+        "cyclingLoad": "computed",
+        "performanceProgress": "computed",
+        "recentRides": "computed",
+      }
+    `);
+  });
+
+  it("refuses adherence after one restricted activity without hiding the other panels", () => {
+    const result = project({ droppedActivities: droppedActivities(1, 100, 1, 100) });
+    expect(result.adherence).toEqual({ kind: "unknown", reason: "source-restricted" });
+    expect(result.cyclingLoad.kind).toBe("computed");
+    expect(result.performanceProgress.kind).toBe("computed");
+    expect(result.recentRides.kind).toBe("computed");
+  });
+
+  it("keeps broad panels computed below the restricted-share boundary", () => {
+    const result = project({ droppedActivities: droppedActivities(49, 100, 49, 100) });
+    expect(result.cyclingLoad.kind).toBe("computed");
+    expect(result.performanceProgress.kind).toBe("computed");
+    expect(result.recentRides.kind).toBe("computed");
+  });
+
+  it("refuses broad panels at the restricted-share boundary", () => {
+    const result = project({ droppedActivities: droppedActivities(50, 100, 50, 100) });
+    expect(result.cyclingLoad).toEqual({ kind: "unknown", reason: "source-restricted" });
+    expect(result.performanceProgress).toEqual({
+      kind: "unavailable",
+      reason: "source-restricted",
+    });
+    expect(result.recentRides).toEqual({ kind: "unknown", reason: "source-restricted" });
+    expect(result.adherence).toEqual({ kind: "unknown", reason: "source-restricted" });
+  });
+
+  it("combines restricted sources without treating other dropped rows as restrictions", () => {
+    const restrictedWindow = {
+      total: 100,
+      visible: 49,
+      restrictions: [
+        { reason: "source-restricted" as const, source: "GARMIN_CONNECT", count: 25 },
+        { reason: "source-restricted" as const, source: "STRAVA", count: 25 },
+      ],
+      other: 1,
+    };
+    const restricted = project({
+      droppedActivities: { overall: restrictedWindow, recent7Days: restrictedWindow },
+    });
+    expect(restricted.cyclingLoad).toEqual({ kind: "unknown", reason: "source-restricted" });
+
+    const otherOnlyWindow = {
+      total: 100,
+      visible: 49,
+      restrictions: [],
+      other: 51,
+    };
+    const otherOnly = project({
+      droppedActivities: { overall: otherOnlyWindow, recent7Days: otherOnlyWindow },
+    });
+    expect(otherOnly.cyclingLoad.kind).toBe("computed");
+    expect(otherOnly.adherence.kind).toBe("computed");
+  });
+
+  it("exports the refusal boundaries", () => {
+    expect(ADHERENCE_MAX_RESTRICTED_ACTIVITIES).toBe(0);
+    expect(LOAD_MAX_RESTRICTED_SHARE).toBe(0.5);
   });
 
   it("filters, sorts, and caps cycling plan rows", () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "@grammyjs/auto-retry": "^2.0.2",
     "ai": "^6.0.158",
     "grammy": "^1.42.0",
-    "intervals-icu-api": "^0.3.1",
+    "intervals-icu-api": "^0.4.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/reference/sport-adapter-dispatcher.ts
+++ b/packages/core/src/reference/sport-adapter-dispatcher.ts
@@ -39,10 +39,10 @@ export function findAdapterForActivity(
   activity: Activity,
 ): ReferenceSportAdapter | null {
   const type = activity.type;
-  // `Activity.type` is typed as a required string, but a malformed upstream row
-  // can still arrive without it at runtime — so this guard is load-bearing, not
-  // dead code; don't strip it. A gap here is silent (never a warn).
-  if (type === undefined) return null;
+  // `Activity.type` is typed as nullish, and an upstream row can arrive without
+  // it at runtime — so this guard is load-bearing, not dead code; don't strip
+  // it. A gap here is silent (never a warn).
+  if (type == null) return null;
   return adapters.find((a) => adapterCoversType(a, type)) ?? null;
 }
 
@@ -73,7 +73,7 @@ export function runAdaptersForActivities(
   const sportFamilies = new Set(sportTypes.map((t) => familyOf(t, t)));
   for (const activity of activities) {
     const type = activity.type;
-    if (type === undefined) continue;
+    if (type == null) continue;
     const family = familyOf(type, type);
     const adapter = findAdapterForActivity(adapters, activity);
     if (adapter) {

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -16,6 +16,11 @@
 // `SYNC_OPERATION_TIMEOUT_MS` budget.
 
 import { snakeCaseKeys, type Activity as ManagedActivity } from "intervals-icu-api";
+import {
+  DroppedActivitiesSchema,
+  type ActivityRestriction,
+  type DroppedActivities,
+} from "@enduragent/coach-contract";
 import { serializeError } from "../../logging/serialize-error.js";
 import {
   REFERENCE_CAPTURE_STREAM_LIMIT,
@@ -106,6 +111,8 @@ export interface FetchEndpointError {
   readonly detail: string;
 }
 
+export const SOURCE_RESTRICTED_PROVIDER = "STRAVA";
+
 export interface LiveFetchResult {
   /** Raw athlete object — cached verbatim as `latest.athlete_profile`. */
   readonly athleteProfile: unknown;
@@ -122,6 +129,7 @@ export interface LiveFetchResult {
   readonly adapterActivities: readonly ManagedActivity[];
   /** Sync wall-clock as an ISO string — the metric date-window anchor. */
   readonly frozenNow: string;
+  readonly droppedActivities: DroppedActivities;
   /** Endpoints that returned an error (athlete-profile, wellness) and were
    *  filled with empty fallbacks to keep the bundle well-typed. The gate turns
    *  a non-empty list into a hard-fail so a swallowed failure can no longer
@@ -292,16 +300,57 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
   const actSummary: RenameSummary = { skippedNonNumeric: {} };
   const wellSummary: RenameSummary = { skippedNonNumeric: {} };
 
+  const retentionCutoffMs = now.getTime() - LATEST_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  const isRecent = (row: { readonly start_date_local?: unknown }): boolean => {
+    if (typeof row.start_date_local !== "string") return false;
+    const milliseconds = Date.parse(row.start_date_local);
+    return Number.isFinite(milliseconds) && milliseconds >= retentionCutoffMs;
+  };
   const activities: Activity[] = [];
+  const droppedRows: Array<Record<string, unknown>> = [];
   for (const row of rawActivities) {
     try {
       activities.push(parseRenamedActivity(renameTpFieldsOnActivity(row, actSummary)));
     } catch (err) {
+      droppedRows.push(row);
       log(
         `Reference: skipped malformed activity row: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }
+  const restrictionsFor = (
+    rows: readonly Record<string, unknown>[],
+  ): ActivityRestriction[] => {
+    const counts = new Map<string, number>();
+    for (const row of rows) {
+      if (row.source !== SOURCE_RESTRICTED_PROVIDER) continue;
+      counts.set(row.source, (counts.get(row.source) ?? 0) + 1);
+    }
+    return [...counts]
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([source, count]) => ({ reason: "source-restricted", source, count }));
+  };
+  const recentRawActivities = rawActivities.filter(isRecent);
+  const recentActivities = activities.filter(isRecent);
+  const recentDroppedRows = droppedRows.filter(isRecent);
+  const restrictions = restrictionsFor(droppedRows);
+  const recentRestrictions = restrictionsFor(recentDroppedRows);
+  const restrictedCount = restrictions.reduce((sum, entry) => sum + entry.count, 0);
+  const recentRestrictedCount = recentRestrictions.reduce((sum, entry) => sum + entry.count, 0);
+  const droppedActivities = DroppedActivitiesSchema.parse({
+    overall: {
+      total: rawActivities.length,
+      visible: activities.length,
+      restrictions,
+      other: droppedRows.length - restrictedCount,
+    },
+    recent7Days: {
+      total: recentRawActivities.length,
+      visible: recentActivities.length,
+      restrictions: recentRestrictions,
+      other: recentDroppedRows.length - recentRestrictedCount,
+    },
+  });
   const wellness: WellnessDay[] = [];
   for (const row of rawWellness) {
     try {
@@ -330,13 +379,6 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
     ...(athlete !== undefined ? { athlete } : {}),
   };
 
-  const retentionCutoffMs = now.getTime() - LATEST_RETENTION_DAYS * 24 * 60 * 60 * 1000;
-  const recentActivities = activities.filter((a) => {
-    if (typeof a.start_date_local !== "string") return false;
-    const ms = Date.parse(a.start_date_local);
-    return Number.isFinite(ms) && ms >= retentionCutoffMs;
-  });
-
   return {
     athleteProfile,
     recentActivities,
@@ -345,6 +387,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
     bundle,
     adapterActivities,
     frozenNow,
+    droppedActivities,
     ...(fetchErrors.length > 0 ? { fetchErrors } : {}),
   };
 }

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -157,6 +157,7 @@ async function fetchOnce(
     intervals: { by_activity: {} },
     routes: { routes: [] },
     ftp_history: { entries: [] },
+    dropped_activities: live.droppedActivities,
     ...(live.fetchErrors && live.fetchErrors.length > 0 ? { fetch_errors: live.fetchErrors } : {}),
   };
 }

--- a/packages/core/src/reference/sync/format-sync-reply.ts
+++ b/packages/core/src/reference/sync/format-sync-reply.ts
@@ -1,5 +1,11 @@
 import type { SyncResult } from "./run-sync.js";
 
+export const STRAVA_RESTRICTION_TELEGRAM_COPY = Object.freeze({
+  notice(count: number, total: number): string {
+    return `${count} of ${total} activities are hidden by Strava, so they aren’t included. A Strava API restriction prevents intervals.icu from sharing activities that came from Strava. For future rides, connect your recording source directly to intervals.icu and keep Strava connected. For past rides, use Import All Strava Data in intervals.icu settings; it requires an intervals.icu supporter subscription.`;
+  },
+});
+
 /**
  * Render a `SyncResult` as athlete-facing prose for the `/sync` Telegram
  * reply. Spec shape:
@@ -49,7 +55,26 @@ export function formatSyncReply(result: SyncResult, now: Date = new Date()): str
         result.refreshed.length === 0
           ? "Already up to date — nothing changed since the last sync."
           : `Refreshed: ${result.refreshed.join(", ")}`;
-      return `Sync ✅\n${lastLine}\n${detailLine}`;
+      const stravaRestriction = result.droppedActivities.overall.restrictions.find((entry) => {
+        switch (entry.reason) {
+          case "source-restricted":
+            return entry.source === "STRAVA";
+          default: {
+            const _exhaustive: never = entry.reason;
+            throw new Error(
+              `formatSyncReply: unhandled activity restriction ${String(_exhaustive)}`,
+            );
+          }
+        }
+      });
+      const restrictionLine =
+        stravaRestriction === undefined
+          ? null
+          : STRAVA_RESTRICTION_TELEGRAM_COPY.notice(
+              stravaRestriction.count,
+              result.droppedActivities.overall.total,
+            );
+      return ["Sync ✅", lastLine, detailLine, restrictionLine].filter(Boolean).join("\n");
     }
     default: {
       const _exhaustive: never = result;

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -27,6 +27,10 @@ import type { AsyncMutex } from "../../concurrency/mutex.js";
 import type { Cooldown } from "../../concurrency/cooldown.js";
 import type { Clock } from "../../concurrency/clock.js";
 import type { LatestSourceProvenance } from "../source-provenance.js";
+import {
+  EMPTY_DROPPED_ACTIVITIES,
+  type DroppedActivities,
+} from "@enduragent/coach-contract";
 
 /**
  * Re-exported from `error-state.ts` so the runtime opt and the on-disk
@@ -68,6 +72,7 @@ export type SyncResult =
       readonly kind: "ran";
       readonly lastSyncAt: string;
       readonly refreshed: readonly CacheFile[];
+      readonly droppedActivities: DroppedActivities;
     }
   | {
       readonly kind: "skipped";
@@ -111,6 +116,7 @@ export interface FetchedReference {
    *  behind a fresh stamp. Omitted when every endpoint was reachable, so a
    *  fully-successful fetch is shape-identical to a genuinely-empty account. */
   readonly fetch_errors?: readonly { readonly endpoint: string; readonly detail: string }[];
+  readonly dropped_activities?: DroppedActivities;
 }
 
 export interface RunSyncDeps {
@@ -487,6 +493,7 @@ export function createRunSync(
             kind: "ran",
             lastSyncAt: lastUpdated,
             refreshed,
+            droppedActivities: fetched.dropped_activities ?? EMPTY_DROPPED_ACTIVITIES,
           };
         };
 

--- a/packages/core/tests/reference-fetch-live-bundle.test.ts
+++ b/packages/core/tests/reference-fetch-live-bundle.test.ts
@@ -566,6 +566,61 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
     expect(res.fetchErrors).toBeUndefined();
   });
 
+  it("splits dropped activity rows into source-restricted and other", async () => {
+    const stub = (index: number) => ({
+      id: 9000 + index,
+      icuAthleteId: "i12345",
+      startDateLocal: daysAgo(index < 4 ? 2 : 20),
+      source: "STRAVA",
+    });
+    const foreign = { id: 8001, icuAthleteId: "i12345", startDateLocal: daysAgo(20), source: "GARMIN_CONNECT" };
+    const visible = Array.from({ length: 6 }, (_, index) =>
+      camelActivity({ id: index + 1, startDateLocal: daysAgo(index === 0 ? 2 : 20) }),
+    );
+    const activities = [...Array.from({ length: 60 }, (_, index) => stub(index)), foreign, ...visible];
+    const { client } = fakeClient({ activities });
+
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+      log: () => {},
+    });
+
+    expect(activities).toHaveLength(67);
+    expect(res.droppedActivities).toEqual({
+      overall: {
+        total: 67,
+        visible: 6,
+        restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+        other: 1,
+      },
+      recent7Days: {
+        total: 5,
+        visible: 1,
+        restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+        other: 0,
+      },
+    });
+  });
+
+  it("reports no dropped activity rows when every row lands", async () => {
+    const { client } = fakeClient({ activities: [camelActivity({ id: 1 })] });
+
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
+
+    expect(res.droppedActivities).toEqual({
+      overall: { total: 1, visible: 1, restrictions: [], other: 0 },
+      recent7Days: { total: 1, visible: 1, restrictions: [], other: 0 },
+    });
+  });
+
   it("treats a non-array activities body as empty (ok:true, malformed) without crashing", async () => {
     const logs: string[] = [];
     const client: BundleFetchClient = {

--- a/packages/core/tests/reference-format-sync-reply.test.ts
+++ b/packages/core/tests/reference-format-sync-reply.test.ts
@@ -10,6 +10,7 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
       refreshed: ["latest", "history", "intervals", "routes", "ftp_history"],
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).toContain("Sync");
@@ -19,11 +20,46 @@ describe("formatSyncReply", () => {
     expect(text).toContain("history");
   });
 
+  it("carries the dropped-activity split to the Telegram surface without changing the reply", () => {
+    const base = {
+      kind: "ran",
+      lastSyncAt: "2026-05-09T14:23:00Z",
+      refreshed: ["latest"],
+    } as const;
+    const clean: SyncResult = {
+      ...base,
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+    };
+    const restricted: SyncResult = {
+      ...base,
+      droppedActivities: {
+        overall: {
+          total: 67,
+          visible: 5,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+          other: 2,
+        },
+        recent7Days: {
+          total: 5,
+          visible: 1,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+          other: 0,
+        },
+      },
+    };
+
+    expect(restricted.droppedActivities.recent7Days.restrictions).toEqual([
+      { reason: "source-restricted", source: "STRAVA", count: 4 },
+    ]);
+    expect(formatSyncReply(restricted, fixedNow)).toBe(formatSyncReply(clean, fixedNow));
+  });
+
   it("renders a no-op ran result (empty refreshed) without a dangling 'Refreshed:' line", () => {
     const r: SyncResult = {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
       refreshed: [],
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).toContain("Sync");
@@ -37,6 +73,7 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: new Date(fixedNow.getTime() + 10 * 60 * 1000).toISOString(),
       refreshed: ["latest"],
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).not.toContain("0s ago");
@@ -48,6 +85,7 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
       refreshed: ["latest"],
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).toContain("32s ago");

--- a/packages/core/tests/reference-format-sync-reply.test.ts
+++ b/packages/core/tests/reference-format-sync-reply.test.ts
@@ -10,7 +10,10 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
       refreshed: ["latest", "history", "intervals", "routes", "ftp_history"],
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).toContain("Sync");
@@ -20,7 +23,7 @@ describe("formatSyncReply", () => {
     expect(text).toContain("history");
   });
 
-  it("carries the dropped-activity split to the Telegram surface without changing the reply", () => {
+  it("explains Strava-restricted activities with both recovery paths", () => {
     const base = {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
@@ -28,7 +31,10 @@ describe("formatSyncReply", () => {
     } as const;
     const clean: SyncResult = {
       ...base,
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     };
     const restricted: SyncResult = {
       ...base,
@@ -48,10 +54,15 @@ describe("formatSyncReply", () => {
       },
     };
 
-    expect(restricted.droppedActivities.recent7Days.restrictions).toEqual([
-      { reason: "source-restricted", source: "STRAVA", count: 4 },
-    ]);
-    expect(formatSyncReply(restricted, fixedNow)).toBe(formatSyncReply(clean, fixedNow));
+    const cleanText = formatSyncReply(clean, fixedNow);
+    const restrictedText = formatSyncReply(restricted, fixedNow);
+
+    expect(cleanText).not.toContain("hidden by Strava");
+    expect(restrictedText).toContain("60 of 67 activities are hidden by Strava");
+    expect(restrictedText).toContain("Strava API restriction");
+    expect(restrictedText).toContain("recording source directly to intervals.icu");
+    expect(restrictedText).toContain("Import All Strava Data");
+    expect(restrictedText).toContain("intervals.icu supporter subscription");
   });
 
   it("renders a no-op ran result (empty refreshed) without a dangling 'Refreshed:' line", () => {
@@ -59,7 +70,10 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
       refreshed: [],
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).toContain("Sync");
@@ -73,7 +87,10 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: new Date(fixedNow.getTime() + 10 * 60 * 1000).toISOString(),
       refreshed: ["latest"],
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).not.toContain("0s ago");
@@ -85,7 +102,10 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
       refreshed: ["latest"],
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).toContain("32s ago");

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -344,6 +344,7 @@ describe("createRunSync", () => {
       kind: "ran",
       lastSyncAt: now.toISOString(),
       refreshed: ["latest", "history", "intervals", "routes", "ftp_history"],
+      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
     });
 
     const latest = JSON.parse(readFileSync(join(dir, "latest.json"), "utf-8"));

--- a/packages/core/tests/reference-scheduler.test.ts
+++ b/packages/core/tests/reference-scheduler.test.ts
@@ -9,6 +9,7 @@ const okResult = (lastSyncAt: string): SyncResult => ({
   kind: "ran",
   lastSyncAt,
   refreshed: ["latest", "history", "intervals", "routes", "ftp_history"],
+  droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
 });
 
 describe("Scheduler", () => {

--- a/packages/core/tests/reference-sport-adapter-dispatcher.test.ts
+++ b/packages/core/tests/reference-sport-adapter-dispatcher.test.ts
@@ -80,6 +80,13 @@ describe("findAdapterForActivity", () => {
     expect(findAdapterForActivity([cyclingAdapter, runningAdapter], activity("Skydive"))).toBeNull();
   });
 
+  it("returns null without warning for a Strava stub whose type is null", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stub = { id: "12345", startDateLocal: "1998-08-20T14:08:41", type: null } as unknown as Activity;
+    expect(findAdapterForActivity([cyclingAdapter], stub)).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("returns null without warning for a malformed row whose type is missing", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const malformed = { id: "12345", startDateLocal: "1998-06-04T12:00:00" } as unknown as Activity;
@@ -143,6 +150,14 @@ describe("runAdaptersForActivities", () => {
   it("silently skips an out-of-sport type without warning", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const runs = runAdaptersForActivities([cyclingAdapter], cyclingTypes, [activity("Swim")]);
+    expect(runs).toHaveLength(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("silently skips a Strava stub whose type is null", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stub = { id: "12345", startDateLocal: "1998-08-20T14:08:41", type: null } as unknown as Activity;
+    const runs = runAdaptersForActivities([cyclingAdapter], cyclingTypes, [stub]);
     expect(runs).toHaveLength(0);
     expect(warn).not.toHaveBeenCalled();
   });

--- a/packages/cycling-coach/package.json
+++ b/packages/cycling-coach/package.json
@@ -37,7 +37,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "ai": "^6.0.158",
     "grammy": "^1.42.0",
-    "intervals-icu-api": "^0.3.1",
+    "intervals-icu-api": "^0.4.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -36,7 +36,7 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "@openrouter/ai-sdk-provider": "^2.9.1",
     "ai": "^6.0.158",
-    "intervals-icu-api": "^0.3.1",
+    "intervals-icu-api": "^0.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/sport-cycling/package.json
+++ b/packages/sport-cycling/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@enduragent/engine": "workspace:*",
     "@enduragent/kernel": "workspace:*",
-    "intervals-icu-api": "^0.3.1",
+    "intervals-icu-api": "^0.4.0",
     "ai": "^6.0.158",
     "zod": "^4.3.6"
   },

--- a/packages/sport-running/package.json
+++ b/packages/sport-running/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@enduragent/engine": "workspace:*",
     "@enduragent/kernel": "workspace:*",
-    "intervals-icu-api": "^0.3.1",
+    "intervals-icu-api": "^0.4.0",
     "ai": "^6.0.158",
     "zod": "^4.3.6"
   },

--- a/packages/sync-intervals-icu/package.json
+++ b/packages/sync-intervals-icu/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@enduragent/kernel": "workspace:*",
     "fflate": "0.8.3",
-    "intervals-icu-api": "^0.3.1"
+    "intervals-icu-api": "^0.4.0"
   },
   "devDependencies": {
     "tsup": "^8.4.0",

--- a/packages/sync-intervals-icu/src/source.ts
+++ b/packages/sync-intervals-icu/src/source.ts
@@ -14,12 +14,12 @@ import {
   assertProjectionEvidenceEqual,
   parseCanonicalProjectionValue,
 } from "@enduragent/kernel/reference/local-bundle";
-import type { SourceCheckpoint, SourceLane, SourceWatermark, SyncBudget } from "@enduragent/kernel/store";
+import type { SourceLane, SourceWatermark, SyncBudget } from "@enduragent/kernel/store";
 import { activityIdentity, mapActivityLanding, mapSettingsLanding, mapWellnessLanding, normalizeStreamLanding } from "./landing.js";
 import { advanceWindow, compactCursor, compareBinary, parseCivilDate, parseCursor, type CursorRange, type RangeCursor } from "./cursor.js";
 import { createRequester, IntervalsHttpError, MIN_CONFIGURED_INTERVAL_MS, SyncBudgetExceededError, type IntervalsRequester } from "./http.js";
 import { BULK_FIT_BATCH_SIZE, BULK_SAFE_ACTIVITY_ID, IncompleteBulkFitBatchError, MAX_FIT_BYTES, MAX_ZIP_BYTES, extractBulkFitZip } from "./zip.js";
-import { INTERVALS_ICU_CAPABILITIES, INTERVALS_ICU_SOURCE_ID, MAX_JSON_BYTES, type IntervalsIcuArtifact, type IntervalsIcuCaptureSource, type IntervalsIcuSourceOptions, type ReferenceCaptureActivityRecord, type ReferenceCaptureBatch, type ReferenceCaptureEndpoint, type ReferenceCaptureSettingsRecord, type ReferenceCaptureStreamRecord, type ReferenceCaptureWellnessRecord } from "./types.js";
+import { INTERVALS_ICU_CAPABILITIES, INTERVALS_ICU_SOURCE_ID, MAX_JSON_BYTES, ZERO_DROPPED_ACTIVITY_ROWS, type DroppedActivityRowCounts, type IntervalsIcuArtifact, type IntervalsIcuCaptureSource, type IntervalsIcuCheckpoint, type IntervalsIcuSourceOptions, type ReferenceCaptureActivityRecord, type ReferenceCaptureBatch, type ReferenceCaptureEndpoint, type ReferenceCaptureSettingsRecord, type ReferenceCaptureStreamRecord, type ReferenceCaptureWellnessRecord } from "./types.js";
 
 const BASE_URL = "https://intervals.icu";
 const JSON_TYPE = "application/json";
@@ -69,13 +69,38 @@ interface ActivityIndexEntry extends ReturnType<typeof activityIdentity> {
   readonly row: Record<string, unknown>;
 }
 
-function activityIndex(value: unknown): readonly ActivityIndexEntry[] {
+const SOURCE_RESTRICTED_PROVIDER = "STRAVA";
+
+function isSourceRestrictedRow(entry: unknown): boolean {
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) return false;
+  return (entry as Record<string, unknown>).source === SOURCE_RESTRICTED_PROVIDER;
+}
+
+class DropTally {
+  private restricted = 0;
+  private rest = 0;
+  record(entry: unknown): void {
+    if (isSourceRestrictedRow(entry)) this.restricted += 1;
+    else this.rest += 1;
+  }
+  counts(): DroppedActivityRowCounts {
+    return Object.freeze({ sourceRestricted: this.restricted, other: this.rest });
+  }
+}
+
+interface ActivityScan {
+  readonly rows: readonly ActivityIndexEntry[];
+  readonly dropped: DroppedActivityRowCounts;
+}
+
+function activityIndex(value: unknown): ActivityScan {
   if (!Array.isArray(value)) throw new TypeError("activities response is invalid");
   const rows: ActivityIndexEntry[] = [];
+  const tally = new DropTally();
   for (const entry of value) {
     const row = objectRow(entry, "activity row");
     const type = row.type;
-    if (typeof type !== "string" || type.length === 0) continue;
+    if (typeof type !== "string" || type.length === 0) { tally.record(row); continue; }
     for (const [field, label] of [["moving_time", "moving time"], ["elapsed_time", "elapsed time"]] as const) {
       const item = row[field];
       if (typeof item !== "number" || !Number.isSafeInteger(item) || item < 0) throw new TypeError(`activity ${label} is invalid`);
@@ -83,11 +108,11 @@ function activityIndex(value: unknown): readonly ActivityIndexEntry[] {
     rows.push({ ...activityIdentity(row), row });
   }
   rows.sort((a, b) => compareBinary(a.key, b.key));
-  return rows;
+  return { rows, dropped: tally.counts() };
 }
 
-function checkpoint(lane: SourceLane, cursor: RangeCursor): SourceCheckpoint {
-  return { kind: "checkpoint", watermark: { source: "intervals-icu", lane, value: compactCursor(cursor) } };
+function checkpoint(lane: SourceLane, cursor: RangeCursor, droppedActivityRows: DroppedActivityRowCounts): IntervalsIcuCheckpoint {
+  return { kind: "checkpoint", watermark: { source: "intervals-icu", lane, value: compactCursor(cursor) }, droppedActivityRows };
 }
 
 function nextCursor(cursor: RangeCursor, range: CursorRange, remaining: number, processedKey: string | null): RangeCursor {
@@ -178,9 +203,10 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
       if (yielded >= budget.maxArtifacts) throw new Error("artifact yield exceeds validated budget");
       yielded += 1;
     };
-    const yieldCheckpoint = async function* (value: RangeCursor): AsyncGenerator<IntervalsIcuArtifact> {
+    const yieldCheckpoint = async function* (value: RangeCursor,
+      dropped: DroppedActivityRowCounts = ZERO_DROPPED_ACTIVITY_ROWS): AsyncGenerator<IntervalsIcuArtifact> {
       requester.assertActive();
-      yield checkpoint(lane, value);
+      yield checkpoint(lane, value, dropped);
     };
 
     if (lane === "bulk-fit" && cursor.complete) {
@@ -196,10 +222,13 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
       const transport = await fetchJson(requester, lane, { method: "GET", url: rangeUrl(athleteId, lane, cursor) });
       await options.archive.writeSnapshot(transport, rowInstant(epochForDate(cursor.requestStart ?? cursor.window_start)));
       if (!Array.isArray(transport)) throw new TypeError(`${lane} response is invalid`);
-      const indexed = lane === "activities" ? [...activityIndex(transport)] : transport.map((entry) => {
+      const scan = lane === "activities" ? activityIndex(transport) : null;
+      const indexed = scan !== null ? [...scan.rows] : transport.map((entry) => {
         const row = objectRow(entry, "wellness row"), identity = wellnessIdentity(row);
         return { externalId: identity.id, startUtc: identity.instant.epochSeconds, localDate: identity.id, key: identity.key, row };
       }).sort((a, b) => compareBinary(a.key, b.key));
+      const droppedRows =
+        scan === null || cursor.last_key !== null ? ZERO_DROPPED_ACTIVITY_ROWS : scan.dropped;
       const remaining = indexed.filter((entry) => cursor.last_key === null || compareBinary(entry.key, cursor.last_key) > 0);
       let processedKey = cursor.last_key;
       let processed = 0;
@@ -227,7 +256,7 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
         processed += 1;
         processedKey = entry.key;
       }
-      yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey));
+      yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey), droppedRows);
       return;
     }
 
@@ -272,8 +301,10 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
 
     const activityTransport = await fetchJson(requester, "activities", { method: "GET", url: rangeUrl(athleteId, "activities", cursor) });
     await options.archive.writeSnapshot(activityTransport, rowInstant(epochForDate(cursor.requestStart ?? cursor.window_start)));
-    const allActivities = activityIndex(activityTransport);
-    const remaining = allActivities.filter((entry) => cursor.last_key === null || compareBinary(entry.key, cursor.last_key) > 0);
+    const activityScan = activityIndex(activityTransport);
+    const droppedRows =
+      cursor.last_key === null ? activityScan.dropped : ZERO_DROPPED_ACTIVITY_ROWS;
+    const remaining = activityScan.rows.filter((entry) => cursor.last_key === null || compareBinary(entry.key, cursor.last_key) > 0);
     let processedKey = cursor.last_key, processed = 0;
 
     if (lane === "streams") {
@@ -307,7 +338,7 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
             normalizedPayloadJson } };
         processed += 1; processedKey = activity.key;
       }
-      yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey));
+      yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey), droppedRows);
       return;
     }
 
@@ -384,8 +415,10 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
       processedKey = group[group.length - 1]!.key;
       offset += group.length;
     }
-    yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey));
+    yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey), droppedRows);
   }
+
+  let capturedActivityDrops: DroppedActivityRowCounts = ZERO_DROPPED_ACTIVITY_ROWS;
 
   const placeholderArchive: ArchiveWriteResult = Object.freeze({
     address: "0".repeat(64),
@@ -440,6 +473,7 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
 
     const activities: DerivedCaptureMember[] = [];
     const activityPayload = endpointPayloads[1]!.payload as unknown[];
+    const activityDrops = new DropTally();
     for (let index = 0; index < activityPayload.length; index += 1) {
       try {
         const row = objectRow(activityPayload[index], "activity row");
@@ -453,8 +487,9 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
         options.acl.assertClean(normalized);
         await mapActivityLanding({ normalized, archiveInstant: rowInstant(identity.startUtc), archive: placeholderArchive });
         activities.push({ endpoint_ordinal: 1, payload_index: index, external_id: identity.externalId, payload: row });
-      } catch {}
+      } catch { activityDrops.record(activityPayload[index]); }
     }
+    capturedActivityDrops = activityDrops.counts();
 
     const wellness: DerivedCaptureMember[] = [];
     const wellnessPayload = endpointPayloads[2]!.payload as unknown[];
@@ -613,7 +648,8 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
       settings: Object.freeze(settings), activities: Object.freeze(activities),
       wellness: Object.freeze(wellness), streams: Object.freeze(streams),
     }), selected_stream_ids: Object.freeze(selectedIds),
-    captured_stream_ids: Object.freeze(successfulStreams.map((endpoint) => endpoint.request.activity_id!)) });
+    captured_stream_ids: Object.freeze(successfulStreams.map((endpoint) => endpoint.request.activity_id!)),
+    dropped_activity_rows: capturedActivityDrops });
   }
 
   return Object.freeze({ id: INTERVALS_ICU_SOURCE_ID, capabilities: INTERVALS_ICU_CAPABILITIES,

--- a/packages/sync-intervals-icu/src/source.ts
+++ b/packages/sync-intervals-icu/src/source.ts
@@ -71,15 +71,17 @@ interface ActivityIndexEntry extends ReturnType<typeof activityIdentity> {
 
 function activityIndex(value: unknown): readonly ActivityIndexEntry[] {
   if (!Array.isArray(value)) throw new TypeError("activities response is invalid");
-  const rows = value.map((entry) => {
+  const rows: ActivityIndexEntry[] = [];
+  for (const entry of value) {
     const row = objectRow(entry, "activity row");
-    nonempty(row.type, "activity type");
+    const type = row.type;
+    if (typeof type !== "string" || type.length === 0) continue;
     for (const [field, label] of [["moving_time", "moving time"], ["elapsed_time", "elapsed time"]] as const) {
       const item = row[field];
       if (typeof item !== "number" || !Number.isSafeInteger(item) || item < 0) throw new TypeError(`activity ${label} is invalid`);
     }
-    return { ...activityIdentity(row), row };
-  });
+    rows.push({ ...activityIdentity(row), row });
+  }
   rows.sort((a, b) => compareBinary(a.key, b.key));
   return rows;
 }

--- a/packages/sync-intervals-icu/src/types.ts
+++ b/packages/sync-intervals-icu/src/types.ts
@@ -33,6 +33,16 @@ export const INTERVALS_ICU_CAPABILITIES = Object.freeze({
 
 export const MAX_JSON_BYTES = 67_108_864;
 
+export interface DroppedActivityRowCounts {
+  readonly sourceRestricted: number;
+  readonly other: number;
+}
+
+export const ZERO_DROPPED_ACTIVITY_ROWS: DroppedActivityRowCounts = Object.freeze({
+  sourceRestricted: 0,
+  other: 0,
+});
+
 export type IntervalsHttpFactory = (args: {
   readonly outer: AbortSignal;
   readonly perRequestTimeoutMs: number;
@@ -78,7 +88,11 @@ export type IntervalsIcuArtifact =
         readonly archive: { readonly address: string; readonly relPath: string; readonly deduped: boolean };
       } | null;
     })
-  | SourceCheckpoint;
+  | IntervalsIcuCheckpoint;
+
+export type IntervalsIcuCheckpoint = SourceCheckpoint & {
+  readonly droppedActivityRows?: DroppedActivityRowCounts;
+};
 
 export interface IntervalsIcuSource extends SyncSource {
   readonly id: "intervals-icu";
@@ -135,4 +149,5 @@ export interface ReferenceCaptureBatch {
   };
   readonly selected_stream_ids: readonly string[];
   readonly captured_stream_ids: readonly string[];
+  readonly dropped_activity_rows: DroppedActivityRowCounts;
 }

--- a/packages/sync-intervals-icu/tests/capture.test.ts
+++ b/packages/sync-intervals-icu/tests/capture.test.ts
@@ -19,9 +19,9 @@ function budget(maxArtifacts = 20): SyncBudget {
     perRequestTimeoutMs: 1_000, maxRequests: 20, maxArtifacts };
 }
 
-function fixture(stream: unknown = { time: [0, 1], watts: [200, 210] }) {
+function fixture(stream: unknown = { time: [0, 1], watts: [200, 210] }, activities: readonly unknown[] = [ACTIVITY]) {
   const requests: string[] = [], writes: { payload: unknown; epoch: number }[] = [];
-  const queue = [response(PROFILE), response([ACTIVITY]), response([WELLNESS]), response(stream)];
+  const queue = [response(PROFILE), response(activities), response([WELLNESS]), response(stream)];
   const source = createIntervalsIcuSource({ athleteId: "synthetic-athlete", historyNewestDate: "1998-07-18",
     minRequestIntervalMs: 250, wallClock: { now: () => NOW.getTime() }, sleep: async () => {},
     httpFactory: () => ({ fetch: async (request) => { requests.push(request.url); return queue.shift()!; } }),
@@ -55,6 +55,22 @@ describe("captureReference", () => {
     expect(batch.records.streams[0]?.externalId).toBe("streams:42");
     expect(batch.records.streams[0]?.archive).toBe(batch.endpoints[3]?.archive);
     expect(value.writes).toHaveLength(7);
+  });
+
+  it("splits the activity rows the capture drops into source-restricted and other", async () => {
+    const stub = { id: "9001", icu_athlete_id: "i12345", start_date_local: "1998-07-17T14:08:41", source: "STRAVA" };
+    const foreign = { id: "9002", icu_athlete_id: "i12345", start_date_local: "1998-07-17T14:09:41", source: "GARMIN_CONNECT" };
+    const value = fixture({ time: [0, 1], watts: [200, 210] }, [ACTIVITY, stub, foreign]);
+
+    const batch = await value.source.captureReference(NOW, budget());
+
+    expect(batch.records.activities).toHaveLength(1);
+    expect(batch.dropped_activity_rows).toEqual({ sourceRestricted: 1, other: 1 });
+  });
+
+  it("reports no dropped activity rows for a clean capture", async () => {
+    const batch = await fixture().source.captureReference(NOW, budget());
+    expect(batch.dropped_activity_rows).toEqual({ sourceRestricted: 0, other: 0 });
   });
 
   it("omits malformed stream responses without omitting required lanes", async () => {

--- a/packages/sync-intervals-icu/tests/source.test.ts
+++ b/packages/sync-intervals-icu/tests/source.test.ts
@@ -206,6 +206,38 @@ describe("intervals.icu full-history source", () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("stores every visible activity when Strava stubs dominate the page", async () => {
+    const stub = (index: number) => ({ id: `strava-${String(index).padStart(2, "0")}`, icu_athlete_id: "i12345",
+      start_date_local: "1998-08-20T14:08:41", source: "STRAVA", _note: "STRAVA activities are not available via the API" });
+    const visible = Array.from({ length: 7 }, (_, index) => activity(`visible-${index}`, `1998-03-0${index + 1}`));
+    const page = [...Array.from({ length: 60 }, (_, index) => stub(index)), ...visible];
+
+    const result = await collect(source({ fetch: async () => json(page) }).pull(watermark("activities"), budget()));
+
+    const snapshots = result.filter((entry) => (entry as { kind: string }).kind === "snapshot");
+    expect(snapshots).toHaveLength(7);
+    expect(snapshots.map((entry) => (entry as { externalId: string }).externalId).sort())
+      .toEqual(visible.map((entry) => entry.id).sort());
+    expect(result.at(-1)).toMatchObject({ kind: "checkpoint" });
+  });
+
+  it("stores all 67 rows when the page carries no Strava stubs", async () => {
+    const page = Array.from({ length: 67 }, (_, index) => activity(
+      `full-${String(index).padStart(2, "0")}`,
+      `1998-0${Math.floor(index / 28) + 1}-${String((index % 28) + 1).padStart(2, "0")}`,
+    ));
+
+    const result = await collect(source({ fetch: async () => json(page) }).pull(watermark("activities"), budget()));
+
+    expect(result.filter((entry) => (entry as { kind: string }).kind === "snapshot")).toHaveLength(67);
+  });
+
+  it("still rejects a typed activity row with an invalid elapsed time", async () => {
+    const broken = { ...activity("broken"), elapsed_time: -1 };
+    await expect(collect(source({ fetch: async () => json([broken]) }).pull(watermark("activities"), budget())))
+      .rejects.toThrow("activity elapsed time is invalid");
+  });
+
   it("charges the injected physical-attempt ledger at the actual source request", async () => {
     const attemptLedger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
     await collect(source({ fetch: async () => json([]) }, { attemptLedger })

--- a/packages/sync-intervals-icu/tests/source.test.ts
+++ b/packages/sync-intervals-icu/tests/source.test.ts
@@ -91,6 +91,24 @@ describe("intervals.icu full-history source", () => {
     expect(JSON.parse((refreshed.at(-1) as { watermark: { value: string } }).watermark.value).cycle).toBe(4);
   });
 
+  it("reports dropped rows once when resuming the same activity page", async () => {
+    const page = [
+      { id: "strava-stub", icu_athlete_id: "i12345", start_date_local: "1998-01-04T08:00:00", source: "STRAVA" },
+      activity("a"),
+      activity("b", "1998-01-06"),
+    ];
+    const value = source({ fetch: async () => json(page) });
+    const first = await collect(value.pull(watermark("activities"), budget(1)));
+    expect(first.at(-1)).toMatchObject({ kind: "checkpoint",
+      droppedActivityRows: { sourceRestricted: 1, other: 0 } });
+    const cursor = (first.at(-1) as { watermark: { value: string } }).watermark.value;
+
+    const resumed = await collect(value.pull(watermark("activities", cursor), budget(1)));
+
+    expect(resumed.at(-1)).toMatchObject({ kind: "checkpoint",
+      droppedActivityRows: { sourceRestricted: 0, other: 0 } });
+  });
+
   it.each([
     ["the next day", "1998-07-19", "1998-07-19"],
     ["five days later", "1998-07-23", "1998-07-23"],
@@ -230,6 +248,54 @@ describe("intervals.icu full-history source", () => {
     const result = await collect(source({ fetch: async () => json(page) }).pull(watermark("activities"), budget()));
 
     expect(result.filter((entry) => (entry as { kind: string }).kind === "snapshot")).toHaveLength(67);
+  });
+
+  it("counts 60 source-restricted drops and no other drops across a 67-row page", async () => {
+    const stub = (index: number) => ({ id: `strava-${String(index).padStart(2, "0")}`, icu_athlete_id: "i12345",
+      start_date_local: "1998-08-20T14:08:41", source: "STRAVA", _note: "STRAVA activities are not available via the API" });
+    const visible = Array.from({ length: 7 }, (_, index) => activity(`visible-${index}`, `1998-03-0${index + 1}`));
+    const page = [...Array.from({ length: 60 }, (_, index) => stub(index)), ...visible];
+
+    const result = await collect(source({ fetch: async () => json(page) }).pull(watermark("activities"), budget()));
+
+    expect(page).toHaveLength(67);
+    expect(result.at(-1)).toMatchObject({ kind: "checkpoint",
+      droppedActivityRows: { sourceRestricted: 60, other: 0 } });
+  });
+
+  it("counts a type-less row from another provider as an other drop", async () => {
+    const page = [
+      { id: "garmin-01", icu_athlete_id: "i12345", start_date_local: "1998-08-20T14:08:41", source: "GARMIN_CONNECT" },
+      { id: "strava-01", icu_athlete_id: "i12345", start_date_local: "1998-08-20T14:08:41", source: "STRAVA" },
+      activity("visible-0"),
+    ];
+
+    const result = await collect(source({ fetch: async () => json(page) }).pull(watermark("activities"), budget()));
+
+    expect(result.at(-1)).toMatchObject({ kind: "checkpoint",
+      droppedActivityRows: { sourceRestricted: 1, other: 1 } });
+  });
+
+  it("reports zero drops when the page carries no unusable rows", async () => {
+    const page = Array.from({ length: 67 }, (_, index) => activity(
+      `full-${String(index).padStart(2, "0")}`,
+      `1998-0${Math.floor(index / 28) + 1}-${String((index % 28) + 1).padStart(2, "0")}`,
+    ));
+
+    const result = await collect(source({ fetch: async () => json(page) }).pull(watermark("activities"), budget()));
+
+    expect(result.at(-1)).toMatchObject({ kind: "checkpoint",
+      droppedActivityRows: { sourceRestricted: 0, other: 0 } });
+  });
+
+  it("carries the drop split on the bulk-fit checkpoint", async () => {
+    const page = Array.from({ length: 60 }, (_, index) => ({ id: `strava-${String(index).padStart(2, "0")}`,
+      icu_athlete_id: "i12345", start_date_local: "1998-08-20T14:08:41", source: "STRAVA" }));
+
+    const result = await collect(source({ fetch: async () => json(page) }).pull(watermark("bulk-fit"), budget()));
+
+    expect(result.at(-1)).toMatchObject({ kind: "checkpoint",
+      droppedActivityRows: { sourceRestricted: 60, other: 0 } });
   });
 
   it("still rejects a typed activity row with an invalid elapsed time", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: 0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: 0.4.0
+        version: 0.4.0(typescript@6.0.3)
       msw:
         specifier: ^2.13.3
         version: 2.14.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -247,8 +247,8 @@ importers:
         specifier: workspace:*
         version: link:../sync-intervals-icu
       intervals-icu-api:
-        specifier: 0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: 0.4.0
+        version: 0.4.0(typescript@6.0.3)
       ws:
         specifier: ^8.21.3
         version: 8.21.3
@@ -368,8 +368,8 @@ importers:
         specifier: ^1.42.0
         version: 1.42.0
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -426,8 +426,8 @@ importers:
         specifier: ^1.42.0
         version: 1.42.0
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -512,8 +512,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -621,8 +621,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -671,8 +671,8 @@ importers:
         specifier: ^6.0.158
         version: 6.0.170(zod@4.4.1)
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -721,8 +721,8 @@ importers:
         specifier: 0.8.3
         version: 0.8.3
       intervals-icu-api:
-        specifier: ^0.3.1
-        version: 0.3.1(typescript@6.0.3)
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@6.0.3)
     devDependencies:
       tsup:
         specifier: ^8.4.0
@@ -3245,8 +3245,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  intervals-icu-api@0.3.1:
-    resolution: {integrity: sha512-W1zKgPpPTbT3TtqF/PGSaarcMxpKBC6SQnFOvRsJ5Te9Hp7LPav5pLi5lWY8lqXtXrSt2Ab74ZFHICiBOZuEqA==}
+  intervals-icu-api@0.4.0:
+    resolution: {integrity: sha512-N0GdEhFu/dCPjLQrezkydObmzKabQfALU/3fIMREfKKoFDP78PepnRj1VRzfplhI/iFeVDTAlkoxbTDfQXIncQ==}
     engines: {node: '>=18'}
 
   ip-address@10.4.0:
@@ -7336,7 +7336,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  intervals-icu-api@0.3.1(typescript@6.0.3):
+  intervals-icu-api@0.4.0(typescript@6.0.3):
     dependencies:
       openapi-fetch: 0.17.0
       valibot: 1.3.1(typescript@6.0.3)


### PR DESCRIPTION
Addresses #656.

## Outcome

- Keep syncing when intervals.icu returns Strava-restricted placeholder activities.
- Store and coach from the visible activities instead of failing the entire sync.
- Carry balanced overall and seven-day dropped-activity counts, grouped by source.
- Explain the Strava API restriction and both remedies in Desktop and Telegram.
- Refuse coaching panels when the visible remainder is not trustworthy.

## Cause

intervals.icu may show Strava-sourced data in its own product but cannot forward that data through its API. It returns a five-field placeholder with `source: "STRAVA"` and no activity type, duration, or sport data. The old strict activity parser rejected the whole response when one placeholder was present.

The placeholders are now detected by source, counted, and dropped before the strict kernel boundary. They are never stored and never rendered as invented dated rides.

## Athlete guidance

1. Connect the recording source directly to intervals.icu and keep Strava connected. This is free and covers future activities.
2. Use intervals.icu's `Import All Strava Data` with the Strava archive. This requires an intervals.icu supporter subscription and covers past activities.

Athletes who record in the Strava phone app may have no separate recording source, so only the archive route is available to them.

## Trust rules

- `ADHERENCE_MAX_RESTRICTED_ACTIVITIES = 0` — one hidden recent activity can make a completed workout look missed.
- `LOAD_MAX_RESTRICTED_SHARE = 0.5` — at half hidden, the visible remainder is not trustworthy for load, performance, or recent rides.

The seven-day count governs adherence and cycling load. The overall Reference count governs performance progress and recent rides. Restrictions from every source are summed; unrelated dropped rows are excluded.

## Children

- [x] #677 — keep syncing and persist the visible remainder.
- [x] #679 — count and transport grouped restrictions; bump protocol 18 to 19.
- [x] #682 — Desktop and Telegram guidance plus `source-restricted` panel contracts.
- [x] #683 — apply the two coaching refusal rules.
- [x] #684 — correct the stale protocol-version test title.

The wire-type dependency is published as `intervals-icu-api@0.4.0`.

## Verification

- Every feature child passed all six CI checks.
- Combined epic: `pnpm check` passed, including builds, types, and all policy gates.
- Combined epic: `pnpm test` passed 605 files and 9,531 tests; 5 files and 15 tests skipped.
