### PR TITLE
feat(core): explain Strava-restricted activities

### DIFF
--- a/.changeset/explain-strava-restricted-activities.md
+++ b/.changeset/explain-strava-restricted-activities.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Explained when Strava API restrictions hide activities, with separate recovery steps for future and past rides.
+
+Show the restricted count after sync on the Training page, in the sidebar, and in Telegram. Direct athletes to connect their recording source to intervals.icu for future rides or use Import All Strava Data with an intervals.icu supporter subscription for history.

--- a/apps/desktop-renderer/src/training-context/manual-sync.ts
+++ b/apps/desktop-renderer/src/training-context/manual-sync.ts
@@ -1,4 +1,8 @@
-import type { TrainingSyncCoordinator, TrainingSyncState } from "../training-sync.js";
+import type {
+  TrainingSyncCoordinator,
+  TrainingSyncDroppedActivities,
+  TrainingSyncState,
+} from "../training-sync.js";
 
 export const SYNC_QUEUED_COPY = "Sync queued.";
 export const SYNC_RUNNING_COPY = "Syncing training data…";
@@ -13,12 +17,41 @@ export const SYNC_INDETERMINATE_COPY =
 export const SYNC_PROTOCOL_COPY =
   "Enduragent couldn’t verify the sync result. Quit and reopen Enduragent.";
 
+export const STRAVA_RESTRICTION_DESKTOP_COPY = Object.freeze({
+  syncMessage(count: number): string {
+    return count === 1
+      ? "A Strava API restriction prevents intervals.icu from sharing one activity, so it isn’t included."
+      : `A Strava API restriction prevents intervals.icu from sharing ${count} activities, so they aren’t included.`;
+  },
+  tooltipLead(count: number): string {
+    return count === 1 ? "1 activity hidden by Strava" : `${count} activities hidden by Strava`;
+  },
+  tooltipBody:
+    "A Strava API restriction prevents intervals.icu from sharing these activities with Enduragent.",
+  cardTitle(count: number, total: number): string {
+    return count === 1 && total === 1
+      ? "1 of 1 activity is hidden by Strava"
+      : `${count} of ${total} activities are hidden by Strava`;
+  },
+  cause:
+    "A Strava API restriction prevents intervals.icu from sharing activities that came from Strava with Enduragent. Your API key is fine.",
+  future:
+    "Connect your recording source directly to intervals.icu and keep Strava connected. This is free and covers future rides.",
+  past: "Use Import All Strava Data in intervals.icu settings. This covers past rides and requires an intervals.icu supporter subscription.",
+});
+
+export interface SourceRestrictionSummary {
+  readonly count: number;
+  readonly total: number;
+}
+
 export interface ManualSyncViewState {
   readonly label: "Sync now" | "Sync again" | "Try again" | "Sync unavailable";
   readonly message: string;
   readonly disabled: boolean;
   readonly busy: boolean;
   readonly tone: "idle" | "active" | "success" | "partial" | "failure";
+  readonly droppedActivities?: TrainingSyncDroppedActivities;
 }
 
 export interface ManualSyncView {
@@ -29,6 +62,19 @@ export interface ManualSyncView {
 export interface ManualSyncController {
   activate(kind: "keyboard" | "pointer"): Promise<void>;
   dispose(): void;
+}
+
+export function sourceRestrictionSummary(
+  droppedActivities: TrainingSyncDroppedActivities | undefined,
+  source: string,
+): SourceRestrictionSummary | null {
+  if (droppedActivities === undefined) return null;
+  const restriction = droppedActivities.overall.restrictions.find(
+    (entry) => entry.reason === "source-restricted" && entry.source === source,
+  );
+  return restriction === undefined
+    ? null
+    : { count: restriction.count, total: droppedActivities.overall.total };
 }
 
 export function toManualSyncViewState(state: TrainingSyncState): ManualSyncViewState {
@@ -51,14 +97,21 @@ export function toManualSyncViewState(state: TrainingSyncState): ManualSyncViewS
         busy: true,
         tone: "active",
       };
-    case "succeeded":
+    case "succeeded": {
+      const message = state.kind === "published" ? SYNC_PUBLISHED_COPY : SYNC_NO_CHANGE_COPY;
+      const restriction = sourceRestrictionSummary(state.droppedActivities, "STRAVA");
       return {
         label: "Sync again",
-        message: state.kind === "published" ? SYNC_PUBLISHED_COPY : SYNC_NO_CHANGE_COPY,
+        message:
+          restriction === null
+            ? message
+            : `${message} ${STRAVA_RESTRICTION_DESKTOP_COPY.syncMessage(restriction.count)}`,
         disabled: false,
         busy: false,
         tone: "success",
+        droppedActivities: state.droppedActivities,
       };
+    }
     case "failed":
       if (state.kind === "protocol") {
         return {
@@ -91,8 +144,16 @@ export function createManualSyncController(input: {
   let disposed = false;
   let activation = 0;
   let activationTask: Promise<void> | undefined;
+  let droppedActivities: TrainingSyncDroppedActivities | undefined;
   const unsubscribe = input.coordinator.subscribe((state) => {
-    if (!disposed) input.view.render(toManualSyncViewState(state));
+    if (disposed) return;
+    const next = toManualSyncViewState(state);
+    if (next.droppedActivities !== undefined) droppedActivities = next.droppedActivities;
+    input.view.render(
+      droppedActivities === undefined || next.droppedActivities !== undefined
+        ? next
+        : { ...next, droppedActivities },
+    );
   });
 
   return {

--- a/apps/desktop-renderer/src/ui/onboarding/InfoTip.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/InfoTip.tsx
@@ -1,15 +1,17 @@
 import { Tooltip } from "@base-ui/react/tooltip";
 import { Info } from "lucide-react";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 export function InfoTip(props: {
   readonly label: string;
   readonly lead: string;
-  readonly body: string;
+  readonly body: ReactNode;
+  readonly trigger?: ReactElement;
 }): ReactElement {
   return (
     <Tooltip.Root>
       <Tooltip.Trigger
+        render={props.trigger}
         data-info-tip=""
         aria-label={props.label}
         className="grid size-[15px] shrink-0 appearance-none place-items-center bg-transparent p-0 text-ink-2 transition-colors hover:text-ink focus-visible:text-ink motion-reduce:transition-none"
@@ -17,10 +19,11 @@ export function InfoTip(props: {
         <Info size={14} strokeWidth={2.25} aria-hidden="true" />
       </Tooltip.Trigger>
       <Tooltip.Portal>
-        <Tooltip.Positioner side="top" sideOffset={8}>
+        <Tooltip.Positioner side="top" sideOffset={8} style={{ pointerEvents: "auto" }}>
           <Tooltip.Popup
             data-info-tip-popup=""
-            className="w-[252px] rounded-md border border-line-2 bg-surface px-3 py-2.5 text-xs leading-relaxed text-ink-2 shadow-elev-3"
+            style={{ pointerEvents: "auto" }}
+            className="pointer-events-auto w-[252px] rounded-md border border-line-2 bg-surface px-3 py-2.5 text-xs leading-relaxed text-ink-2 shadow-elev-3"
           >
             <b className="mb-1 block font-medium text-ink">{props.lead}</b>
             {props.body}

--- a/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
@@ -2,8 +2,13 @@ import { useRef, type ReactElement } from "react";
 import { setManualSyncFocusTarget } from "../../state/manual-sync-focus.js";
 import { useEnduragentStore } from "../../state/store.js";
 import type { TrainingContextViewState } from "../../training-context/controller.js";
-import type { ManualSyncViewState } from "../../training-context/manual-sync.js";
+import {
+  sourceRestrictionSummary,
+  STRAVA_RESTRICTION_DESKTOP_COPY,
+  type ManualSyncViewState,
+} from "../../training-context/manual-sync.js";
 import { formatUtcTimestamp } from "../../training-context/format.js";
+import { InfoTip } from "../onboarding/InfoTip.js";
 import styles from "./Sidebar.module.css";
 
 type SyncChipStatus = "loading" | "syncing" | "attention" | "synced" | "never" | "unavailable";
@@ -32,10 +37,18 @@ export function SyncChip(): ReactElement {
   const training = useEnduragentStore((store) => store.training);
   const sync = useEnduragentStore((store) => store.sync);
   const actions = useEnduragentStore((store) => store.syncActions);
+  const setActiveView = useEnduragentStore((store) => store.setActiveView);
   const chip = useRef<HTMLButtonElement>(null);
   const status = syncChipStatus(training, sync);
   const synced = training.metadata?.lastSynced ?? null;
   const detail = status === "synced" && synced !== null ? formatUtcTimestamp(synced) : null;
+  const restriction = sourceRestrictionSummary(sync.droppedActivities, "STRAVA");
+  const restrictionLabel =
+    restriction === null
+      ? null
+      : restriction.count === 1
+        ? "1 hidden by Strava"
+        : `${restriction.count} hidden by Strava`;
 
   return (
     <button
@@ -43,8 +56,11 @@ export function SyncChip(): ReactElement {
       ref={chip}
       className={`${styles.sync} sync-chip`}
       data-status={status}
+      title={restriction === null || detail === null ? undefined : detail}
       disabled={sync.disabled || actions === null}
-      aria-label={[sync.label, HEADLINE[status], detail].filter(Boolean).join(" · ")}
+      aria-label={[sync.label, HEADLINE[status], restrictionLabel, detail]
+        .filter(Boolean)
+        .join(" · ")}
       onClick={(event) => {
         const keyboard = event.detail === 0;
         setManualSyncFocusTarget(keyboard ? chip.current : null);
@@ -54,7 +70,47 @@ export function SyncChip(): ReactElement {
       <span className={styles.dot} data-status={status} aria-hidden="true" />
       <span className={styles.syncCopy}>
         <span className={styles.syncHeadline}>{HEADLINE[status]}</span>
-        {detail === null ? null : <span className={styles.syncWhen}>{detail}</span>}
+        {restriction === null ? (
+          detail === null ? null : (
+            <span className={styles.syncWhen}>{detail}</span>
+          )
+        ) : (
+          <span className="mt-px flex min-w-0 items-center gap-1 font-mono text-[11px] text-warn">
+            <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+              {restrictionLabel}
+            </span>
+            <InfoTip
+              label="Why are activities hidden?"
+              lead={STRAVA_RESTRICTION_DESKTOP_COPY.tooltipLead(restriction.count)}
+              trigger={
+                <span
+                  role="button"
+                  tabIndex={0}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                  }}
+                />
+              }
+              body={
+                <>
+                  {STRAVA_RESTRICTION_DESKTOP_COPY.tooltipBody}{" "}
+                  <a
+                    href="#strava-restricted-activities"
+                    className="text-brand underline-offset-2 hover:underline"
+                    onPointerDown={() => {
+                      setActiveView("training");
+                    }}
+                    onClick={() => {
+                      setActiveView("training");
+                    }}
+                  >
+                    How to fix this
+                  </a>
+                </>
+              }
+            />
+          </span>
+        )}
       </span>
       <span className={styles.syncAction} aria-hidden="true">
         {sync.label}

--- a/apps/desktop-renderer/src/ui/training/RideReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideReview.tsx
@@ -32,6 +32,7 @@ const EMPTY_COPY: Readonly<
   "not-synced": "Sync or import a cycling ride to review it here.",
   "no-recent-rides": "No cycling rides are available from the last 28 days.",
   "temporary-failure": "Recent rides could not be refreshed. Try syncing again.",
+  "source-restricted": "Too many activities are hidden to show a trustworthy ride list.",
 };
 
 function rideKind(ride: RecentRide): string {

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -7,6 +7,7 @@ import type {
   RecentRide,
   WellnessTrendPanel,
 } from "@enduragent/coach-contract";
+import { TriangleAlert } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, type ReactElement, type ReactNode } from "react";
 import { rideImportStatusCopy } from "../../ride-import.js";
 import { rideImportStatusSuppressed } from "../../state/onboarding-slice.js";
@@ -15,6 +16,10 @@ import {
   setManualSyncFocusTarget,
 } from "../../state/manual-sync-focus.js";
 import { useEnduragentStore } from "../../state/store.js";
+import {
+  sourceRestrictionSummary,
+  STRAVA_RESTRICTION_DESKTOP_COPY,
+} from "../../training-context/manual-sync.js";
 import {
   formatDateLabel,
   formatPercentage,
@@ -72,6 +77,7 @@ function SyncPanel(): ReactElement {
   const syncedCopy = synced === null ? null : formatUtcTimestamp(synced);
   const syncedInstant =
     synced === null || syncedCopy === "Unknown sync time" ? null : new Date(synced).toISOString();
+  const restriction = sourceRestrictionSummary(sync.droppedActivities, "STRAVA");
 
   useEffect(() => {
     setManualSyncFocusFallback(message.current);
@@ -131,6 +137,50 @@ function SyncPanel(): ReactElement {
           {sync.message}
         </p>
       </div>
+      {restriction === null ? null : (
+        <div
+          id="strava-restricted-activities"
+          tabIndex={-1}
+          className="mt-4 rounded-xl border border-line bg-surface p-4 shadow-[var(--edge),var(--elev-1)]"
+        >
+          <div className="flex items-start gap-2.5">
+            <TriangleAlert
+              size={17}
+              strokeWidth={1.8}
+              className="mt-px flex-none text-warn"
+              aria-hidden="true"
+            />
+            <div className="min-w-0">
+              <p className="m-0 text-sm font-semibold text-ink">
+                {STRAVA_RESTRICTION_DESKTOP_COPY.cardTitle(restriction.count, restriction.total)}
+              </p>
+              <p className="mt-1 text-[12.5px] leading-relaxed text-ink-2">
+                {STRAVA_RESTRICTION_DESKTOP_COPY.cause}
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 grid gap-2.5 border-t border-line pt-3">
+            <div className="flex items-start gap-2.5">
+              <span className="flex size-[18px] flex-none items-center justify-center rounded-full bg-brand/15 text-[10px] font-semibold text-brand">
+                1
+              </span>
+              <p className="m-0 text-[12.5px] leading-relaxed text-ink-2">
+                <strong className="font-semibold text-ink">For future rides — </strong>
+                {STRAVA_RESTRICTION_DESKTOP_COPY.future}
+              </p>
+            </div>
+            <div className="flex items-start gap-2.5">
+              <span className="flex size-[18px] flex-none items-center justify-center rounded-full bg-brand/15 text-[10px] font-semibold text-brand">
+                2
+              </span>
+              <p className="m-0 text-[12.5px] leading-relaxed text-ink-2">
+                <strong className="font-semibold text-ink">For past rides — </strong>
+                {STRAVA_RESTRICTION_DESKTOP_COPY.past}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
     </Panel>
   );
 }

--- a/apps/desktop-renderer/src/ui/training/copy.ts
+++ b/apps/desktop-renderer/src/ui/training/copy.ts
@@ -19,6 +19,7 @@ export const TRAINING_UNKNOWN_COPY: Readonly<Record<TrainingContextUnknownReason
   "no-plan": "No planned cycling workouts are available",
   "insufficient-data": "Not enough persisted data to show this yet",
   "no-wellness": "No wellness readings are available",
+  "source-restricted": "Not enough activity data is visible to calculate this safely",
 };
 
 export const WELLNESS_LABELS: readonly string[] = ["HRV", "Sleep", "Resting HR"];
@@ -31,6 +32,7 @@ export const POWER_PROGRESS_UNAVAILABLE_COPY: Readonly<
   "invalid-data": "Power progress data could not be verified. Sync again.",
   "refresh-failed": "Power progress has not refreshed yet. Try syncing again.",
   "temporary-failure": "Power progress is temporarily unavailable. Try again.",
+  "source-restricted": "Too much activity data is hidden to compare power safely.",
 };
 
 export const POWER_PROGRESS_REFRESH_FAILURE_COPY: Readonly<

--- a/apps/desktop-renderer/tests/first-sync.test.ts
+++ b/apps/desktop-renderer/tests/first-sync.test.ts
@@ -367,6 +367,53 @@ describe("first sync controller", () => {
     expect(manualStates.at(-1)?.message).toBe("Training-data check completed.");
   });
 
+  it("keeps the last successful restriction summary through a failed refresh", async () => {
+    const coordinator = new FakeCoordinator();
+    const states: ManualSyncViewState[] = [];
+    const manual = createManualSyncController({
+      coordinator,
+      view: { render: (state) => states.push(state), restoreKeyboardFocus: vi.fn() },
+    });
+
+    const first = manual.activate("pointer");
+    coordinator.finish({
+      status: "succeeded",
+      operation: 1,
+      kind: "published",
+      droppedActivities: {
+        overall: {
+          total: 67,
+          visible: 5,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+          other: 2,
+        },
+        recent7Days: {
+          total: 5,
+          visible: 1,
+          restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+          other: 0,
+        },
+      },
+    });
+    await first;
+    await Promise.resolve();
+
+    const second = manual.activate("pointer");
+    expect(states.at(-1)?.tone).toBe("active");
+    expect(states.at(-1)?.droppedActivities?.overall.restrictions[0]?.count).toBe(60);
+    coordinator.finish({
+      status: "failed",
+      operation: 2,
+      kind: "operation",
+      retryable: true,
+    });
+    await second;
+
+    expect(states.at(-1)?.tone).toBe("failure");
+    expect(states.at(-1)?.droppedActivities?.overall.restrictions[0]?.count).toBe(60);
+    manual.dispose();
+  });
+
   it("restores focus only for the accepted keyboard activation", async () => {
     const coordinator = new FakeCoordinator();
     const restoreKeyboardFocus = vi.fn();

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_CHAT_SURFACE, type ChatActions } from "../src/state/chat-slice.js";
@@ -260,6 +260,78 @@ describe("sidebar sync chip", () => {
     });
     expect(chip()).toHaveAttribute("data-status", "attention");
     expect(chip()).toHaveTextContent("Try again");
+  });
+
+  it("shows a successful Strava restriction without nesting buttons", async () => {
+    const user = userEvent.setup();
+    useEnduragentStore.setState({ syncActions: { request: vi.fn() } });
+    render(<Sidebar />);
+
+    update({
+      training: {
+        ...EMPTY_TRAINING_SURFACE,
+        status: "ready",
+        metadata: {
+          lastUpdated: "1998-07-19T08:00:00.000Z",
+          lastSynced: "1998-07-19T07:55:00.000Z",
+          freshness: "fresh",
+          degraded: false,
+        },
+      },
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 1,
+        kind: "published",
+        droppedActivities: {
+          overall: {
+            total: 67,
+            visible: 5,
+            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+            other: 2,
+          },
+          recent7Days: {
+            total: 5,
+            visible: 1,
+            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+            other: 0,
+          },
+        },
+      }),
+    });
+
+    expect(chip()).toHaveAttribute("data-status", "synced");
+    expect(chip()).toHaveTextContent("60 hidden by Strava");
+    expect(chip()).not.toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chip()).toHaveAttribute("title", "1998-07-19 07:55:00 UTC");
+    expect(chip().querySelector("button")).toBeNull();
+
+    const trigger = chip().querySelector<HTMLElement>("[data-info-tip]");
+    expect(trigger?.tagName).toBe("SPAN");
+    await user.hover(trigger as HTMLElement);
+    await waitFor(() => {
+      expect(document.querySelector("[data-info-tip-popup]")).not.toBeNull();
+    });
+    expect(screen.getByText("60 activities hidden by Strava")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "How to fix this" });
+    expect(link).toHaveAttribute("href", "#strava-restricted-activities");
+
+    fireEvent.click(link);
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+
+    update({
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 2,
+        kind: "no-change",
+        droppedActivities: {
+          overall: { total: 5, visible: 5, restrictions: [], other: 0 },
+          recent7Days: { total: 5, visible: 5, restrictions: [], other: 0 },
+        },
+      }),
+    });
+    expect(chip()).toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chip()).not.toHaveAttribute("title");
+    expect(chip().querySelector("[data-info-tip]")).toBeNull();
   });
 
   it("reports never-synced and unavailable training data honestly", () => {

--- a/apps/desktop-renderer/tests/training-surface.test.tsx
+++ b/apps/desktop-renderer/tests/training-surface.test.tsx
@@ -1042,7 +1042,15 @@ describe("training page sync", () => {
     expect(message).toHaveTextContent("Syncing training data…");
 
     update({
-      sync: toManualSyncViewState({ status: "succeeded", operation: 1, kind: "no-change", droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } } }),
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 1,
+        kind: "no-change",
+        droppedActivities: {
+          overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+          recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+        },
+      }),
     });
     const settled = screen.getByRole("button", { name: "Sync again" });
     expect(settled).toBeEnabled();
@@ -1085,6 +1093,57 @@ describe("training page sync", () => {
     });
     expect(screen.getByRole("button", { name: "Sync unavailable" })).toBeDisabled();
     expect(message).toHaveTextContent("Enduragent couldn’t verify the sync result.");
+  });
+
+  it("shows the Strava action card only when restricted activities exist", () => {
+    useEnduragentStore.setState({ syncActions: { request: vi.fn() } });
+    render(<TrainingView />);
+
+    update({
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 1,
+        kind: "published",
+        droppedActivities: {
+          overall: {
+            total: 67,
+            visible: 5,
+            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
+            other: 2,
+          },
+          recent7Days: {
+            total: 5,
+            visible: 1,
+            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
+            other: 0,
+          },
+        },
+      }),
+    });
+
+    const notice = document.querySelector("#strava-restricted-activities");
+    expect(notice).not.toBeNull();
+    expect(notice).toHaveTextContent("60 of 67 activities are hidden by Strava");
+    expect(notice).toHaveTextContent("recording source directly to intervals.icu");
+    expect(notice).toHaveTextContent("Import All Strava Data");
+    expect(notice).toHaveTextContent("intervals.icu supporter subscription");
+    expect(document.querySelector(".training-sync-message")).toHaveTextContent(
+      "A Strava API restriction prevents intervals.icu from sharing 60 activities",
+    );
+
+    update({
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 2,
+        kind: "no-change",
+        droppedActivities: {
+          overall: { total: 5, visible: 5, restrictions: [], other: 0 },
+          recent7Days: { total: 5, visible: 5, restrictions: [], other: 0 },
+        },
+      }),
+    });
+
+    expect(document.querySelector("#strava-restricted-activities")).toBeNull();
   });
 
   it("disables the sync action until the controller is bound", () => {

--- a/packages/coach-contract/src/athlete-state.ts
+++ b/packages/coach-contract/src/athlete-state.ts
@@ -182,6 +182,7 @@ export const PowerProgressUnavailableReasonSchema = z.enum([
   "invalid-data",
   "refresh-failed",
   "temporary-failure",
+  "source-restricted",
 ]);
 
 export const PowerProgressComputedSchema = z
@@ -256,6 +257,7 @@ export const TrainingContextUnknownReasonSchema = z.enum([
   "no-plan",
   "insufficient-data",
   "no-wellness",
+  "source-restricted",
 ]);
 
 export const CyclingAnchorSchema = z
@@ -310,7 +312,7 @@ export const CyclingLoadPanelSchema = z.discriminatedUnion("kind", [
   z
     .object({
       kind: z.literal("unknown"),
-      reason: z.enum(["not-synced", "no-platform-load"]),
+      reason: z.enum(["not-synced", "no-platform-load", "source-restricted"]),
     })
     .strict(),
 ]);
@@ -350,7 +352,7 @@ export const AdherencePanelSchema = z.discriminatedUnion("kind", [
   z
     .object({
       kind: z.literal("unknown"),
-      reason: z.enum(["not-synced", "no-plan", "insufficient-data"]),
+      reason: z.enum(["not-synced", "no-plan", "insufficient-data", "source-restricted"]),
     })
     .strict(),
 ]);
@@ -409,7 +411,7 @@ export const RecentRidesPanelSchema = z.discriminatedUnion("kind", [
   z
     .object({
       kind: z.literal("unknown"),
-      reason: z.enum(["not-synced", "no-recent-rides", "temporary-failure"]),
+      reason: z.enum(["not-synced", "no-recent-rides", "temporary-failure", "source-restricted"]),
     })
     .strict(),
 ]);

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -11,6 +11,8 @@ import {
   PROTOCOL_VERSION,
   TurnEventSchema,
   AthleteStateSchema,
+  AdherencePanelSchema,
+  CyclingLoadPanelSchema,
   CyclingTrainingContextSchema,
   PowerProgressPanelSchema,
   RecentRidesPanelSchema,
@@ -396,6 +398,9 @@ describe("AthleteState", () => {
       reason: "not-synced",
     });
     expect(
+      PowerProgressPanelSchema.parse({ kind: "unavailable", reason: "source-restricted" }),
+    ).toEqual({ kind: "unavailable", reason: "source-restricted" });
+    expect(
       PowerProgressPanelSchema.safeParse({
         ...computedPowerProgress,
         anchors: [...computedPowerProgress.anchors].reverse(),
@@ -421,6 +426,17 @@ describe("AthleteState", () => {
     ).toBe(false);
   });
 
+  it("accepts source-restricted as a refusal reason for load and adherence", () => {
+    expect(CyclingLoadPanelSchema.parse({ kind: "unknown", reason: "source-restricted" })).toEqual({
+      kind: "unknown",
+      reason: "source-restricted",
+    });
+    expect(AdherencePanelSchema.parse({ kind: "unknown", reason: "source-restricted" })).toEqual({
+      kind: "unknown",
+      reason: "source-restricted",
+    });
+  });
+
   it("bounds recent rides and rejects provider-only or malformed fields", () => {
     const ride = {
       id: "a".repeat(64),
@@ -442,6 +458,10 @@ describe("AthleteState", () => {
       })),
     } as const;
     expect(RecentRidesPanelSchema.parse(panel)).toEqual(panel);
+    expect(RecentRidesPanelSchema.parse({ kind: "unknown", reason: "source-restricted" })).toEqual({
+      kind: "unknown",
+      reason: "source-restricted",
+    });
     expect(
       RecentRidesPanelSchema.safeParse({ ...panel, items: [...panel.items, ride] }).success,
     ).toBe(false);

--- a/packages/core/src/reference/sync/format-sync-reply.ts
+++ b/packages/core/src/reference/sync/format-sync-reply.ts
@@ -1,5 +1,11 @@
 import type { SyncResult } from "./run-sync.js";
 
+export const STRAVA_RESTRICTION_TELEGRAM_COPY = Object.freeze({
+  notice(count: number, total: number): string {
+    return `${count} of ${total} activities are hidden by Strava, so they aren’t included. A Strava API restriction prevents intervals.icu from sharing activities that came from Strava. For future rides, connect your recording source directly to intervals.icu and keep Strava connected. For past rides, use Import All Strava Data in intervals.icu settings; it requires an intervals.icu supporter subscription.`;
+  },
+});
+
 /**
  * Render a `SyncResult` as athlete-facing prose for the `/sync` Telegram
  * reply. Spec shape:
@@ -49,7 +55,26 @@ export function formatSyncReply(result: SyncResult, now: Date = new Date()): str
         result.refreshed.length === 0
           ? "Already up to date — nothing changed since the last sync."
           : `Refreshed: ${result.refreshed.join(", ")}`;
-      return `Sync ✅\n${lastLine}\n${detailLine}`;
+      const stravaRestriction = result.droppedActivities.overall.restrictions.find((entry) => {
+        switch (entry.reason) {
+          case "source-restricted":
+            return entry.source === "STRAVA";
+          default: {
+            const _exhaustive: never = entry.reason;
+            throw new Error(
+              `formatSyncReply: unhandled activity restriction ${String(_exhaustive)}`,
+            );
+          }
+        }
+      });
+      const restrictionLine =
+        stravaRestriction === undefined
+          ? null
+          : STRAVA_RESTRICTION_TELEGRAM_COPY.notice(
+              stravaRestriction.count,
+              result.droppedActivities.overall.total,
+            );
+      return ["Sync ✅", lastLine, detailLine, restrictionLine].filter(Boolean).join("\n");
     }
     default: {
       const _exhaustive: never = result;

--- a/packages/core/tests/reference-format-sync-reply.test.ts
+++ b/packages/core/tests/reference-format-sync-reply.test.ts
@@ -10,7 +10,10 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
       refreshed: ["latest", "history", "intervals", "routes", "ftp_history"],
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).toContain("Sync");
@@ -20,7 +23,7 @@ describe("formatSyncReply", () => {
     expect(text).toContain("history");
   });
 
-  it("carries the dropped-activity split to the Telegram surface without changing the reply", () => {
+  it("explains Strava-restricted activities with both recovery paths", () => {
     const base = {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
@@ -28,7 +31,10 @@ describe("formatSyncReply", () => {
     } as const;
     const clean: SyncResult = {
       ...base,
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     };
     const restricted: SyncResult = {
       ...base,
@@ -48,10 +54,15 @@ describe("formatSyncReply", () => {
       },
     };
 
-    expect(restricted.droppedActivities.recent7Days.restrictions).toEqual([
-      { reason: "source-restricted", source: "STRAVA", count: 4 },
-    ]);
-    expect(formatSyncReply(restricted, fixedNow)).toBe(formatSyncReply(clean, fixedNow));
+    const cleanText = formatSyncReply(clean, fixedNow);
+    const restrictedText = formatSyncReply(restricted, fixedNow);
+
+    expect(cleanText).not.toContain("hidden by Strava");
+    expect(restrictedText).toContain("60 of 67 activities are hidden by Strava");
+    expect(restrictedText).toContain("Strava API restriction");
+    expect(restrictedText).toContain("recording source directly to intervals.icu");
+    expect(restrictedText).toContain("Import All Strava Data");
+    expect(restrictedText).toContain("intervals.icu supporter subscription");
   });
 
   it("renders a no-op ran result (empty refreshed) without a dangling 'Refreshed:' line", () => {
@@ -59,7 +70,10 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
       refreshed: [],
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).toContain("Sync");
@@ -73,7 +87,10 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: new Date(fixedNow.getTime() + 10 * 60 * 1000).toISOString(),
       refreshed: ["latest"],
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).not.toContain("0s ago");
@@ -85,7 +102,10 @@ describe("formatSyncReply", () => {
       kind: "ran",
       lastSyncAt: "2026-05-09T14:23:00Z",
       refreshed: ["latest"],
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     };
     const text = formatSyncReply(r, fixedNow);
     expect(text).toContain("32s ago");


### PR DESCRIPTION
PR2 made Strava-restricted activities measurable. This PR explains the missing data and gives athletes both recovery paths on desktop and Telegram.

## Desktop

- With zero hidden activities, the warning stays absent and the sidebar keeps its sync timestamp.
- With Strava-restricted activities, the Training page shows an action card with the overall count, the Strava API cause, and separate future/history remedies.
- The sidebar shows the restricted count in amber while its successful-sync dot stays green.
- The timestamp moves to the chip title only while the count occupies the second row.
- The existing InfoTip now accepts linked content and renders its trigger as a focusable span, so the sync button never contains another button.
- A failed refresh retains the last successful restriction summary. A later successful zero count clears it.

The future remedy says “recording source,” not “device,” because a Strava-phone recording may have no upstream device to connect.

## Telegram

A successful sync with Strava-restricted rows now names the Strava API restriction and both remedies:

1. Connect the recording source directly to intervals.icu for future rides.
2. Use Import All Strava Data for history; this requires an intervals.icu supporter subscription.

The formatter selects the Strava restriction entry from the grouped contract. It does not collapse multiple providers into one source.

## Contract

`source-restricted` is now an accepted refusal reason for cycling load, adherence, performance progress, and recent rides. Renderer copy maps remain exhaustive. PR4 will produce this already-supported reason when visibility crosses its refusal rules.

## Verification

- 229 focused tests passed across contract, sync state, Training, sidebar, onboarding InfoTip callers, and Telegram
- coach-contract, core, and desktop-renderer package checks passed
- root type graph and all policy gates passed
- Node 24 production renderer build passed
- aggregate sandbox run: 9,371 passed; 55 unrelated loopback/IPC/writer-lock tests failed under `EPERM`
- the added failed-refresh retention regression passed after that aggregate run

## Limits

None added or changed.