### PR TITLE
test(core): correct protocol version title

### DIFF
--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -113,7 +113,7 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 18", () => {
+  it("is 19", () => {
     expect(PROTOCOL_VERSION).toBe(19);
   });
 });


### PR DESCRIPTION
## Summary

- Correct the protocol-version test title from 18 to 19.
- Keep the assertion unchanged at the actual protocol version.

## Verification

- `pnpm --filter @enduragent/coach-contract exec vitest run tests/contract.test.ts` — 25 tests passed.
