### PR TITLE
fix: coordinate sync chip remedy navigation

### DIFF
--- a/apps/desktop-renderer/src/ui/onboarding/InfoTip.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/InfoTip.tsx
@@ -7,23 +7,30 @@ export function InfoTip(props: {
   readonly lead: string;
   readonly body: ReactNode;
   readonly trigger?: ReactElement;
+  readonly triggerContent?: ReactNode;
 }): ReactElement {
+  const customTrigger = props.trigger !== undefined;
+
   return (
     <Tooltip.Root>
       <Tooltip.Trigger
         render={props.trigger}
         data-info-tip=""
-        aria-label={props.label}
-        className="grid size-[15px] shrink-0 appearance-none place-items-center bg-transparent p-0 text-ink-2 transition-colors hover:text-ink focus-visible:text-ink motion-reduce:transition-none"
+        aria-label={customTrigger ? undefined : props.label}
+        className={
+          customTrigger
+            ? undefined
+            : "grid size-[15px] shrink-0 appearance-none place-items-center bg-transparent p-0 text-ink-2 transition-colors hover:text-ink focus-visible:text-ink motion-reduce:transition-none"
+        }
       >
-        <Info size={14} strokeWidth={2.25} aria-hidden="true" />
+        {props.triggerContent}
+        <Info className="flex-none" size={14} strokeWidth={2.25} aria-hidden="true" />
       </Tooltip.Trigger>
       <Tooltip.Portal>
-        <Tooltip.Positioner side="top" sideOffset={8} style={{ pointerEvents: "auto" }}>
+        <Tooltip.Positioner side="top" sideOffset={8}>
           <Tooltip.Popup
             data-info-tip-popup=""
-            style={{ pointerEvents: "auto" }}
-            className="pointer-events-auto w-[252px] rounded-md border border-line-2 bg-surface px-3 py-2.5 text-xs leading-relaxed text-ink-2 shadow-elev-3"
+            className="w-[252px] rounded-md border border-line-2 bg-surface px-3 py-2.5 text-xs leading-relaxed text-ink-2 shadow-elev-3"
           >
             <b className="mb-1 block font-medium text-ink">{props.lead}</b>
             {props.body}

--- a/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
@@ -9,6 +9,11 @@ import {
 } from "../../training-context/manual-sync.js";
 import { formatUtcTimestamp } from "../../training-context/format.js";
 import { InfoTip } from "../onboarding/InfoTip.js";
+import {
+  focusTrainingRestrictionIfPresent,
+  requestTrainingRestrictionFocus,
+  STRAVA_RESTRICTION_CARD_ID,
+} from "../training/restriction-focus.js";
 import styles from "./Sidebar.module.css";
 
 type SyncChipStatus = "loading" | "syncing" | "attention" | "synced" | "never" | "unavailable";
@@ -37,6 +42,7 @@ export function SyncChip(): ReactElement {
   const training = useEnduragentStore((store) => store.training);
   const sync = useEnduragentStore((store) => store.sync);
   const actions = useEnduragentStore((store) => store.syncActions);
+  const closeRide = useEnduragentStore((store) => store.closeRide);
   const setActiveView = useEnduragentStore((store) => store.setActiveView);
   const chip = useRef<HTMLButtonElement>(null);
   const status = syncChipStatus(training, sync);
@@ -51,70 +57,79 @@ export function SyncChip(): ReactElement {
         : `${restriction.count} hidden by Strava`;
 
   return (
-    <button
-      type="button"
-      ref={chip}
-      className={`${styles.sync} sync-chip`}
-      data-status={status}
-      title={restriction === null || detail === null ? undefined : detail}
-      disabled={sync.disabled || actions === null}
-      aria-label={[sync.label, HEADLINE[status], restrictionLabel, detail]
-        .filter(Boolean)
-        .join(" · ")}
-      onClick={(event) => {
-        const keyboard = event.detail === 0;
-        setManualSyncFocusTarget(keyboard ? chip.current : null);
-        actions?.request(keyboard ? "keyboard" : "pointer");
-      }}
-    >
-      <span className={styles.dot} data-status={status} aria-hidden="true" />
-      <span className={styles.syncCopy}>
-        <span className={styles.syncHeadline}>{HEADLINE[status]}</span>
+    <div className={`${styles.sync} relative`} data-sync-chip="" data-status={status}>
+      <button
+        type="button"
+        ref={chip}
+        className="sync-chip absolute inset-0 z-0 m-0 appearance-none rounded-ctl border-0 bg-transparent p-0 disabled:cursor-default"
+        data-status={status}
+        title={restriction === null || detail === null ? undefined : detail}
+        disabled={sync.disabled || actions === null}
+        aria-label={[sync.label, HEADLINE[status], detail].filter(Boolean).join(" · ")}
+        onClick={(event) => {
+          const keyboard = event.detail === 0;
+          setManualSyncFocusTarget(keyboard ? chip.current : null);
+          actions?.request(keyboard ? "keyboard" : "pointer");
+        }}
+      />
+      <span
+        className={`${styles.dot} pointer-events-none relative z-[1]`}
+        data-status={status}
+        aria-hidden="true"
+      />
+      <span className={`${styles.syncCopy} pointer-events-none relative z-[1]`}>
+        <span className={styles.syncHeadline} aria-hidden="true">
+          {HEADLINE[status]}
+        </span>
         {restriction === null ? (
           detail === null ? null : (
-            <span className={styles.syncWhen}>{detail}</span>
+            <span className={styles.syncWhen} aria-hidden="true">
+              {detail}
+            </span>
           )
         ) : (
-          <span className="mt-px flex min-w-0 items-center gap-1 font-mono text-[11px] text-warn">
-            <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
-              {restrictionLabel}
-            </span>
-            <InfoTip
-              label="Why are activities hidden?"
-              lead={STRAVA_RESTRICTION_DESKTOP_COPY.tooltipLead(restriction.count)}
-              trigger={
-                <span
-                  role="button"
-                  tabIndex={0}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                  }}
-                />
-              }
-              body={
-                <>
-                  {STRAVA_RESTRICTION_DESKTOP_COPY.tooltipBody}{" "}
-                  <a
-                    href="#strava-restricted-activities"
-                    className="text-brand underline-offset-2 hover:underline"
-                    onPointerDown={() => {
-                      setActiveView("training");
-                    }}
-                    onClick={() => {
-                      setActiveView("training");
-                    }}
-                  >
-                    How to fix this
-                  </a>
-                </>
-              }
-            />
-          </span>
+          <InfoTip
+            label="Why are activities hidden?"
+            lead={STRAVA_RESTRICTION_DESKTOP_COPY.tooltipLead(restriction.count)}
+            trigger={
+              <a
+                href={`#${STRAVA_RESTRICTION_CARD_ID}`}
+                aria-label={`${restrictionLabel}. How to fix this`}
+                className="pointer-events-auto mt-px flex w-full min-w-0 items-center gap-1 font-mono text-[11px] no-underline"
+                onClick={(event) => {
+                  setActiveView("training");
+                  if (useEnduragentStore.getState().activeView !== "training") {
+                    event.preventDefault();
+                    return;
+                  }
+                  requestTrainingRestrictionFocus();
+                  closeRide();
+                  focusTrainingRestrictionIfPresent(
+                    document.getElementById(STRAVA_RESTRICTION_CARD_ID),
+                  );
+                }}
+              />
+            }
+            triggerContent={
+              <>
+                <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-warn">
+                  {restrictionLabel}
+                </span>
+                <span className="flex-none font-sans text-brand underline-offset-2 hover:underline">
+                  · How to fix this
+                </span>
+              </>
+            }
+            body={STRAVA_RESTRICTION_DESKTOP_COPY.tooltipBody}
+          />
         )}
       </span>
-      <span className={styles.syncAction} aria-hidden="true">
+      <span
+        className={`${styles.syncAction} pointer-events-none relative z-[1]`}
+        aria-hidden="true"
+      >
         {sync.label}
       </span>
-    </button>
+    </div>
   );
 }

--- a/apps/desktop-renderer/src/ui/training/TrainingView.tsx
+++ b/apps/desktop-renderer/src/ui/training/TrainingView.tsx
@@ -8,7 +8,14 @@ import type {
   WellnessTrendPanel,
 } from "@enduragent/coach-contract";
 import { TriangleAlert } from "lucide-react";
-import { useEffect, useLayoutEffect, useRef, type ReactElement, type ReactNode } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type ReactElement,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import { rideImportStatusCopy } from "../../ride-import.js";
 import { rideImportStatusSuppressed } from "../../state/onboarding-slice.js";
 import {
@@ -41,6 +48,10 @@ import { PowerProgressContent } from "./PowerProgressPanel.js";
 import { RecentRidesStatePanel, RideDetailView } from "./RideReview.js";
 import { WellnessSparkline } from "./WellnessSparkline.js";
 import { WorkoutArchiveExportControl } from "./TrainingExportControls.js";
+import {
+  STRAVA_RESTRICTION_CARD_ID,
+  takeTrainingRestrictionFocusRequest,
+} from "./restriction-focus.js";
 
 function Panel(props: {
   readonly name: string;
@@ -67,7 +78,9 @@ function PowerProgressStatePanel(props: { readonly panel: PowerProgressPanel }):
   );
 }
 
-function SyncPanel(): ReactElement {
+function SyncPanel(props: {
+  readonly restrictionCard: RefObject<HTMLDivElement | null>;
+}): ReactElement {
   const metadata = useEnduragentStore((store) => store.training.metadata);
   const sync = useEnduragentStore((store) => store.sync);
   const actions = useEnduragentStore((store) => store.syncActions);
@@ -139,7 +152,8 @@ function SyncPanel(): ReactElement {
       </div>
       {restriction === null ? null : (
         <div
-          id="strava-restricted-activities"
+          ref={props.restrictionCard}
+          id={STRAVA_RESTRICTION_CARD_ID}
           tabIndex={-1}
           className="mt-4 rounded-xl border border-line bg-surface p-4 shadow-[var(--edge),var(--elev-1)]"
         >
@@ -377,24 +391,28 @@ export function TrainingView(): ReactElement {
   const rideAnalysisActions = useEnduragentStore((store) => store.rideAnalysisActions);
   const rideButtons = useRef(new Map<string, HTMLButtonElement>());
   const previousRideId = useRef<string | null>(null);
+  const restrictionCard = useRef<HTMLDivElement>(null);
   const title = useRef<HTMLHeadingElement>(null);
   const status = trainingStatusCopy(training.status);
 
   useLayoutEffect(() => {
-    const element = title.current;
-    if (element === null) return;
-    const owner = element.ownerDocument;
-    const active = owner.activeElement;
-    if (active !== null && active !== owner.body && active !== owner.documentElement) return;
-    element.focus();
-  }, []);
-
-  useLayoutEffect(() => {
     const currentRideId = selectedRide?.id ?? null;
-    if (currentRideId !== null && previousRideId.current !== currentRideId) {
+    const restrictionFocusRequested = takeTrainingRestrictionFocusRequest();
+    if (restrictionFocusRequested) {
+      (restrictionCard.current ?? title.current)?.focus();
+    } else if (currentRideId !== null && previousRideId.current !== currentRideId) {
       title.current?.focus();
     } else if (currentRideId === null && previousRideId.current !== null) {
       (rideButtons.current.get(previousRideId.current) ?? title.current)?.focus();
+    } else {
+      const element = title.current;
+      if (element !== null) {
+        const owner = element.ownerDocument;
+        const active = owner.activeElement;
+        if (active === null || active === owner.body || active === owner.documentElement) {
+          element.focus();
+        }
+      }
     }
     previousRideId.current = currentRideId;
   }, [selectedRide?.id]);
@@ -419,7 +437,7 @@ export function TrainingView(): ReactElement {
       <p className={`${styles.status} training-status`} hidden={training.status === "ready"}>
         {status}
       </p>
-      <SyncPanel />
+      <SyncPanel restrictionCard={restrictionCard} />
       <PowerProgressStatePanel panel={training.trainingContext.performanceProgress} />
       <RecentRidesStatePanel
         panel={training.trainingContext.recentRides}

--- a/apps/desktop-renderer/src/ui/training/restriction-focus.ts
+++ b/apps/desktop-renderer/src/ui/training/restriction-focus.ts
@@ -1,0 +1,23 @@
+export const STRAVA_RESTRICTION_CARD_ID = "strava-restricted-activities";
+
+let focusRequested = false;
+
+export function requestTrainingRestrictionFocus(): void {
+  focusRequested = true;
+}
+
+export function focusTrainingRestrictionIfPresent(element: HTMLElement | null): void {
+  if (!focusRequested || element === null || !element.isConnected || element.hidden) return;
+  focusRequested = false;
+  element.focus();
+}
+
+export function takeTrainingRestrictionFocusRequest(): boolean {
+  const requested = focusRequested;
+  focusRequested = false;
+  return requested;
+}
+
+export function clearTrainingRestrictionFocusRequest(): void {
+  focusRequested = false;
+}

--- a/apps/desktop-renderer/tests/restriction-focus.test.tsx
+++ b/apps/desktop-renderer/tests/restriction-focus.test.tsx
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearTrainingRestrictionFocusRequest,
+  focusTrainingRestrictionIfPresent,
+  requestTrainingRestrictionFocus,
+  takeTrainingRestrictionFocusRequest,
+} from "../src/ui/training/restriction-focus.js";
+
+afterEach(() => {
+  clearTrainingRestrictionFocusRequest();
+});
+
+describe("training restriction focus", () => {
+  it("focuses a present destination and consumes the request", () => {
+    const card = document.createElement("div");
+    card.tabIndex = -1;
+    document.body.append(card);
+
+    requestTrainingRestrictionFocus();
+    focusTrainingRestrictionIfPresent(card);
+
+    expect(card).toHaveFocus();
+    expect(takeTrainingRestrictionFocusRequest()).toBe(false);
+    card.remove();
+  });
+
+  it("leaves an absent destination pending for the coordinator", () => {
+    requestTrainingRestrictionFocus();
+    focusTrainingRestrictionIfPresent(null);
+
+    expect(takeTrainingRestrictionFocusRequest()).toBe(true);
+    expect(takeTrainingRestrictionFocusRequest()).toBe(false);
+  });
+});

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -14,6 +14,13 @@ import {
   setupSurfaceOnScreen,
 } from "../src/state/onboarding-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
+import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
+import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
+import { toManualSyncViewState } from "../src/training-context/manual-sync.js";
+import {
+  clearTrainingRestrictionFocusRequest,
+  takeTrainingRestrictionFocusRequest,
+} from "../src/ui/training/restriction-focus.js";
 
 const REPAIR_REQUIRED_CREDENTIALS: CredentialSettingsState = {
   status: "ready",
@@ -34,6 +41,17 @@ const REQUIRED_ONBOARDING = Object.freeze({
   completionRequired: true,
 });
 
+const SELECTED_RIDE = Object.freeze({
+  id: "a".repeat(64),
+  subSport: "road",
+  startEpochSeconds: 900_000_000,
+  timezoneOffsetSeconds: 0,
+  localDate: "1998-07-09",
+  elapsedSeconds: 3_600,
+  movingSeconds: 3_500,
+  distanceMeters: 32_000,
+});
+
 function stubActions(): ChatActions {
   return {
     submit: vi.fn(),
@@ -45,6 +63,23 @@ function stubActions(): ChatActions {
     cancelNewConversation: vi.fn(),
     confirmNewConversation: vi.fn(),
     retryFirstSync: vi.fn(),
+  };
+}
+
+function stravaDroppedActivities() {
+  return {
+    overall: {
+      total: 67,
+      visible: 5,
+      restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 60 }],
+      other: 2,
+    },
+    recent7Days: {
+      total: 5,
+      visible: 1,
+      restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 4 }],
+      other: 0,
+    },
   };
 }
 
@@ -65,9 +100,17 @@ describe("shell", () => {
       runtimeReady: true,
       chat: { ...EMPTY_CHAT_SURFACE, newConversationUnavailable: false },
       chatActions: stubActions(),
+      training: EMPTY_TRAINING_SURFACE,
+      selectedRide: null,
+      sync: IDLE_MANUAL_SYNC,
+      syncActions: null,
       onboarding: READY_ONBOARDING,
       onboardingActions: null,
       onboardingStartupSettled: true,
+      settings: {
+        ...useEnduragentStore.getState().settings,
+        savingOwners: [],
+      },
     });
   });
 
@@ -75,14 +118,20 @@ describe("shell", () => {
     useEnduragentStore.setState({
       chat: EMPTY_CHAT_SURFACE,
       chatActions: null,
+      training: EMPTY_TRAINING_SURFACE,
+      selectedRide: null,
+      sync: IDLE_MANUAL_SYNC,
+      syncActions: null,
       onboarding: CLOSED_ONBOARDING,
       onboardingActions: null,
       onboardingStartupSettled: false,
       settings: {
         ...useEnduragentStore.getState().settings,
         credentials: { status: "closed" },
+        savingOwners: [],
       },
     });
+    clearTrainingRestrictionFocusRequest();
     resetChatStream();
   });
 
@@ -154,6 +203,80 @@ describe("shell", () => {
     await screen.findByRole("region", { name: "Training" });
 
     expect(trainingButton).toHaveFocus();
+  });
+
+  it("moves focus from a mounted ride review to the Training action card", async () => {
+    const user = userEvent.setup();
+    const request = vi.fn();
+    useEnduragentStore.setState({
+      activeView: "training",
+      training: {
+        ...EMPTY_TRAINING_SURFACE,
+        status: "ready",
+        metadata: {
+          lastUpdated: "1998-07-19T08:00:00.000Z",
+          lastSynced: "1998-07-19T07:55:00.000Z",
+          freshness: "fresh",
+          degraded: false,
+        },
+      },
+      selectedRide: SELECTED_RIDE,
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 1,
+        kind: "published",
+        droppedActivities: stravaDroppedActivities(),
+      }),
+      syncActions: { request },
+    });
+    render(<Shell onReady={() => {}} />);
+    expect(screen.getByRole("region", { name: "Ride review" })).toBeInTheDocument();
+
+    const remedy = screen.getByRole("link", {
+      name: "60 hidden by Strava. How to fix this",
+    });
+    remedy.focus();
+    await user.keyboard("{Enter}");
+
+    const card = await waitFor(() => {
+      const element = document.querySelector<HTMLElement>("#strava-restricted-activities");
+      expect(element).not.toBeNull();
+      return element as HTMLElement;
+    });
+    await waitFor(() => {
+      expect(card).toHaveFocus();
+    });
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(useEnduragentStore.getState().selectedRide).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("preserves a selected ride and does not arm focus when navigation is blocked", async () => {
+    const user = userEvent.setup();
+    const request = vi.fn();
+    useEnduragentStore.setState({
+      activeView: "settings",
+      selectedRide: SELECTED_RIDE,
+      settings: {
+        ...useEnduragentStore.getState().settings,
+        savingOwners: ["session"],
+      },
+      sync: toManualSyncViewState({
+        status: "succeeded",
+        operation: 1,
+        kind: "published",
+        droppedActivities: stravaDroppedActivities(),
+      }),
+      syncActions: { request },
+    });
+    render(<Shell onReady={() => {}} />);
+
+    await user.click(screen.getByRole("link", { name: "60 hidden by Strava. How to fix this" }));
+
+    expect(useEnduragentStore.getState().activeView).toBe("settings");
+    expect(useEnduragentStore.getState().selectedRide).toEqual(SELECTED_RIDE);
+    expect(takeTrainingRestrictionFocusRequest()).toBe(false);
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("keeps the chat surface mounted while another view is shown", async () => {

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -13,6 +13,7 @@ import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
 import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
 import { toManualSyncViewState } from "../src/training-context/manual-sync.js";
 import { Sidebar } from "../src/ui/sidebar/Sidebar.js";
+import { clearTrainingRestrictionFocusRequest } from "../src/ui/training/restriction-focus.js";
 
 function stubActions(): ChatActions {
   return {
@@ -40,6 +41,29 @@ function chip(): HTMLElement {
   return element;
 }
 
+function chipSurface(): HTMLElement {
+  const element = document.querySelector<HTMLElement>("[data-sync-chip]");
+  if (element === null) throw new TypeError("sync chip surface missing");
+  return element;
+}
+
+function stravaDroppedActivities() {
+  return {
+    overall: {
+      total: 67,
+      visible: 5,
+      restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 60 }],
+      other: 2,
+    },
+    recent7Days: {
+      total: 5,
+      visible: 1,
+      restrictions: [{ reason: "source-restricted" as const, source: "STRAVA", count: 4 }],
+      other: 0,
+    },
+  };
+}
+
 function setupReadiness(): HTMLElement {
   const element = document.querySelector<HTMLElement>("[data-sidebar-setup-readiness]");
   if (element === null) throw new TypeError("sidebar setup readiness missing");
@@ -63,6 +87,7 @@ beforeEach(() => {
 
 afterEach(() => {
   setManualSyncFocusTarget(null);
+  clearTrainingRestrictionFocusRequest();
   useEnduragentStore.setState({
     chat: EMPTY_CHAT_SURFACE,
     chatActions: null,
@@ -225,7 +250,7 @@ describe("sidebar sync chip", () => {
     render(<Sidebar />);
 
     expect(chip()).toHaveAttribute("data-status", "loading");
-    expect(chip()).toHaveTextContent("Loading training data");
+    expect(chipSurface()).toHaveTextContent("Loading training data");
 
     update({
       training: {
@@ -240,8 +265,8 @@ describe("sidebar sync chip", () => {
       },
     });
     expect(chip()).toHaveAttribute("data-status", "synced");
-    expect(chip()).toHaveTextContent("Training data synced");
-    expect(chip()).toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chipSurface()).toHaveTextContent("Training data synced");
+    expect(chipSurface()).toHaveTextContent("1998-07-19 07:55:00 UTC");
     expect(chip()).toHaveAccessibleName(
       "Sync now · Training data synced · 1998-07-19 07:55:00 UTC",
     );
@@ -259,12 +284,13 @@ describe("sidebar sync chip", () => {
       }),
     });
     expect(chip()).toHaveAttribute("data-status", "attention");
-    expect(chip()).toHaveTextContent("Try again");
+    expect(chipSurface()).toHaveTextContent("Try again");
   });
 
-  it("shows a successful Strava restriction without nesting buttons", async () => {
+  it("keeps Strava remedy navigation independent from syncing", async () => {
     const user = userEvent.setup();
-    useEnduragentStore.setState({ syncActions: { request: vi.fn() } });
+    const request = vi.fn();
+    useEnduragentStore.setState({ syncActions: { request } });
     render(<Sidebar />);
 
     update({
@@ -282,41 +308,70 @@ describe("sidebar sync chip", () => {
         status: "succeeded",
         operation: 1,
         kind: "published",
-        droppedActivities: {
-          overall: {
-            total: 67,
-            visible: 5,
-            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 60 }],
-            other: 2,
-          },
-          recent7Days: {
-            total: 5,
-            visible: 1,
-            restrictions: [{ reason: "source-restricted", source: "STRAVA", count: 4 }],
-            other: 0,
-          },
-        },
+        droppedActivities: stravaDroppedActivities(),
       }),
     });
 
     expect(chip()).toHaveAttribute("data-status", "synced");
-    expect(chip()).toHaveTextContent("60 hidden by Strava");
-    expect(chip()).not.toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chipSurface()).toHaveTextContent("60 hidden by Strava");
+    expect(chipSurface()).toHaveTextContent("How to fix this");
+    expect(chipSurface()).not.toHaveTextContent("1998-07-19 07:55:00 UTC");
     expect(chip()).toHaveAttribute("title", "1998-07-19 07:55:00 UTC");
-    expect(chip().querySelector("button")).toBeNull();
+    expect(chip()).toHaveAccessibleName(
+      "Sync again · Training data synced · 1998-07-19 07:55:00 UTC",
+    );
+    expect(
+      chip().querySelector("a, button, input, select, textarea, [role='button'], [tabindex]"),
+    ).toBeNull();
 
-    const trigger = chip().querySelector<HTMLElement>("[data-info-tip]");
-    expect(trigger?.tagName).toBe("SPAN");
-    await user.hover(trigger as HTMLElement);
+    const link = screen.getByRole("link", {
+      name: "60 hidden by Strava. How to fix this",
+    });
+    expect(link).toHaveAttribute("href", "#strava-restricted-activities");
+    expect(link).toHaveAttribute("data-info-tip");
+    await user.hover(link);
     await waitFor(() => {
       expect(document.querySelector("[data-info-tip-popup]")).not.toBeNull();
     });
     expect(screen.getByText("60 activities hidden by Strava")).toBeInTheDocument();
-    const link = screen.getByRole("link", { name: "How to fix this" });
-    expect(link).toHaveAttribute("href", "#strava-restricted-activities");
+    const popup = document.querySelector<HTMLElement>("[data-info-tip-popup]");
+    expect(
+      popup?.querySelector("a, button, input, select, textarea, [role='button'], [tabindex]"),
+    ).toBeNull();
 
-    fireEvent.click(link);
+    await user.click(link);
     expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(request).not.toHaveBeenCalled();
+
+    clearTrainingRestrictionFocusRequest();
+    update({ activeView: "chat" });
+    chip().focus();
+    await user.tab();
+    expect(link).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(request).not.toHaveBeenCalled();
+
+    clearTrainingRestrictionFocusRequest();
+    update({ activeView: "chat" });
+    fireEvent.pointerDown(link, { pointerType: "touch" });
+    fireEvent.click(link, { detail: 1 });
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(request).not.toHaveBeenCalled();
+
+    clearTrainingRestrictionFocusRequest();
+    update({
+      activeView: "chat",
+      sync: {
+        ...toManualSyncViewState({ status: "running", operation: 2 }),
+        droppedActivities: stravaDroppedActivities(),
+      },
+    });
+    expect(chip()).toBeDisabled();
+    expect(link).toBeEnabled();
+    await user.click(link);
+    expect(useEnduragentStore.getState().activeView).toBe("training");
+    expect(request).not.toHaveBeenCalled();
 
     update({
       sync: toManualSyncViewState({
@@ -329,9 +384,9 @@ describe("sidebar sync chip", () => {
         },
       }),
     });
-    expect(chip()).toHaveTextContent("1998-07-19 07:55:00 UTC");
+    expect(chipSurface()).toHaveTextContent("1998-07-19 07:55:00 UTC");
     expect(chip()).not.toHaveAttribute("title");
-    expect(chip().querySelector("[data-info-tip]")).toBeNull();
+    expect(chipSurface().querySelector("[data-info-tip]")).toBeNull();
   });
 
   it("reports never-synced and unavailable training data honestly", () => {
@@ -339,11 +394,11 @@ describe("sidebar sync chip", () => {
 
     update({ training: { ...EMPTY_TRAINING_SURFACE, status: "ready" } });
     expect(chip()).toHaveAttribute("data-status", "never");
-    expect(chip()).toHaveTextContent("Not synced yet");
+    expect(chipSurface()).toHaveTextContent("Not synced yet");
 
     update({ training: { ...EMPTY_TRAINING_SURFACE, status: "unavailable" } });
     expect(chip()).toHaveAttribute("data-status", "unavailable");
-    expect(chip()).toHaveTextContent("Training data unavailable");
+    expect(chipSurface()).toHaveTextContent("Training data unavailable");
   });
 
   it("requests a manual sync and restores keyboard focus to the activator", async () => {

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -977,7 +977,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       controlObserver.disconnect();
       const coach = document.querySelector(".chat-message--coach");
       const link = coach?.querySelector("a");
-      const syncChip = document.querySelector(".sync-chip");
+      const syncChip = document.querySelector("[data-sync-chip]");
       return {
         location: location.href,
         bridgeKeys,


### PR DESCRIPTION
## Summary

- split the sync action and Strava remedy into valid sibling controls
- keep the remedy directly navigable while the supplementary tooltip stays noninteractive
- centralize Training focus priority so the Action card wins after closing an already-mounted ride
- preserve the current ride and focus state when navigation is blocked
- cover pointer, keyboard, touch, disabled-sync, mounted-ride, and blocked-navigation paths

The existing epic changeset already covers this unshipped user-visible behavior, so this child does not add a duplicate changeset.

## Verification

- focused renderer tests: 5 files, 127 tests passed
- `pnpm --filter @enduragent/desktop-renderer check`
- `pnpm check` (19 pre-existing warnings, 0 errors)
- `pnpm test` (606 files passed, 5 skipped; 9,535 tests passed, 15 skipped)
- fresh read-only verifier: 8/8 acceptance criteria passed with no P1–P3 findings

## Limits

- none
