### PR TITLE
feat(desktop): adopt Primer UI tokens

### DIFF
--- a/.changeset/ui-primer-token-values.md
+++ b/.changeset/ui-primer-token-values.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: The desktop interface now uses a consistent Primer-based type, spacing, control, radius, and contrast system.

--- a/apps/desktop-renderer/src/theme/applyPalette.ts
+++ b/apps/desktop-renderer/src/theme/applyPalette.ts
@@ -22,7 +22,6 @@ export function paletteCustomProperties(
 ): ReadonlyMap<string, string> {
   const ramp = theme === "dark" ? palette.d : palette.l;
   const fixed = theme === "dark" ? FIXED.d : FIXED.l;
-  const controlEdge = theme === "dark" ? "93%" : "85%";
   return new Map([
     ["--bg", ramp.bg],
     ["--rail", ramp.rail],
@@ -31,9 +30,9 @@ export function paletteCustomProperties(
     ["--sunk", `color-mix(in srgb, ${ramp.rail} 55%, ${ramp.bg})`],
     ["--ink", ramp.ink],
     ["--ink-2", ramp.ink2],
-    ["--ink-3", `color-mix(in srgb, ${ramp.ink2} 62%, ${ramp.bg})`],
+    ["--ink-3", `color-mix(in srgb, ${ramp.ink2} 78%, ${ramp.sf})`],
     ["--line", ramp.line],
-    ["--line-2", `color-mix(in srgb, ${ramp.line} ${controlEdge}, ${ramp.ink2})`],
+    ["--line-2", `color-mix(in srgb, ${ramp.line} 25%, ${ramp.ink2})`],
     ["--brand", ramp.br],
     ["--brand-ink", ramp.bri],
     ["--brand-soft", ramp.soft],

--- a/apps/desktop-renderer/src/theme/surface.module.css
+++ b/apps/desktop-renderer/src/theme/surface.module.css
@@ -1,7 +1,7 @@
 @layer surface {
   .raised {
     border: 1px solid var(--line);
-    border-radius: var(--r-xl);
+    border-radius: var(--r-card);
     background-color: var(--surface);
     box-shadow: var(--edge), var(--elev-1);
   }
@@ -13,7 +13,7 @@
 
   .overlay {
     border: 1px solid var(--line-2);
-    border-radius: var(--r-xl);
+    border-radius: var(--r-card);
     background-color: var(--surface);
     box-shadow: var(--edge), var(--elev-3);
   }
@@ -57,12 +57,12 @@
     height: var(--ctl-h-sm);
     padding: 0 var(--ctl-px-sm);
     gap: 6px;
-    font-size: 13px;
+    font-size: var(--font-size-xs);
   }
 
   .lg {
     height: var(--ctl-h-lg);
-    padding: 0 13px;
+    padding: 0 var(--ctl-px-lg);
   }
 
   .solid {
@@ -128,8 +128,8 @@
   .field {
     width: 100%;
     min-width: 0;
-    height: 30px;
-    padding: 0 11px;
+    height: var(--ctl-h);
+    padding: 0 var(--ctl-px);
     border: 1px solid var(--line-2);
     border-radius: var(--r-ctl);
     color: var(--ink);
@@ -158,7 +158,9 @@
   .field:focus-visible {
     outline: 0;
     border-color: var(--ink);
-    box-shadow: var(--edge), 0 0 0 3px color-mix(in srgb, var(--ink) 12%, transparent);
+    box-shadow:
+      var(--edge),
+      0 0 0 3px color-mix(in srgb, var(--ink) 12%, transparent);
   }
 
   .field:disabled {
@@ -178,10 +180,10 @@
     gap: 4px;
     align-items: center;
     justify-content: center;
-    height: 18px;
-    padding: 0 5px;
+    height: 20px;
+    padding: 0 6px;
     border: 1px solid transparent;
-    border-radius: 4px;
+    border-radius: var(--r-chip);
     color: var(--ink-2);
     background-color: var(--surface-2);
     font: 500 12px/1 var(--f-ui);

--- a/apps/desktop-renderer/src/theme/tailwind.css
+++ b/apps/desktop-renderer/src/theme/tailwind.css
@@ -58,17 +58,38 @@
   --color-ring: var(--ring);
   --color-sidebar: var(--sidebar);
 
+  --radius-chip: var(--r-chip);
   --radius-ctl: var(--r-ctl);
-  --radius-md: var(--r);
-  --radius-lg: var(--r-lg);
-  --radius-xl: var(--r-xl);
+  --radius-card: var(--r-card);
+  --radius-sm: var(--r-chip);
+  --radius-md: var(--r-ctl);
+  --radius-lg: var(--r-card);
+  --radius-xl: var(--r-card);
+  --radius-full: var(--r-pill);
 
   --font-sans: var(--f-ui);
   --font-mono: var(--f-mono);
+  --text-xs: var(--font-size-xs);
+  --text-xs--line-height: var(--line-height-xs);
+  --text-sm: var(--font-size-sm);
+  --text-sm--line-height: var(--line-height-sm);
+  --text-base: var(--font-size-prose);
+  --text-base--line-height: var(--line-height-prose);
+  --text-lg: var(--font-size-lg);
+  --text-lg--line-height: var(--line-height-lg);
+  --text-xl: var(--font-size-xl);
+  --text-xl--line-height: var(--line-height-xl);
+  --font-weight-normal: var(--weight-regular);
+  --font-weight-medium: var(--weight-medium);
+  --font-weight-semibold: var(--weight-semibold);
+  --tracking-normal: var(--tracking-ui);
 
   --spacing-ctl: var(--ctl-h);
   --spacing-ctl-sm: var(--ctl-h-sm);
   --spacing-ctl-lg: var(--ctl-h-lg);
+  --spacing-ctl-px: var(--ctl-px);
+  --spacing-ctl-px-sm: var(--ctl-px-sm);
+  --spacing-ctl-px-lg: var(--ctl-px-lg);
   --spacing-inset: var(--inset);
   --spacing-row: var(--row-inset);
 

--- a/apps/desktop-renderer/src/theme/tokens.css
+++ b/apps/desktop-renderer/src/theme/tokens.css
@@ -7,9 +7,9 @@
   --sunk: color-mix(in srgb, #e8edf2 55%, #f2f5f8);
   --ink: #16202b;
   --ink-2: #57636e;
-  --ink-3: color-mix(in srgb, #57636e 62%, #f2f5f8);
+  --ink-3: color-mix(in srgb, #57636e 78%, #ffffff);
   --line: #dfe5eb;
-  --line-2: color-mix(in srgb, #dfe5eb 85%, #57636e);
+  --line-2: color-mix(in srgb, #dfe5eb 25%, #57636e);
   --brand: #38658e;
   --brand-ink: #ffffff;
   --brand-soft: #e0eaf3;
@@ -40,10 +40,10 @@
   --sidebar: var(--rail);
   --radius: var(--r);
 
-  --edge: inset 0 -1px 0 rgb(0 0 0 / 4%);
-  --sheen: inset 0 1px 0 rgb(255 255 255 / 16%);
-  --press: inset 0 1px 0 rgb(0 0 0 / 8%);
-  --elev-1: 0 1px 2px rgb(0 0 0 / 5%);
+  --edge: 0 0 #0000;
+  --sheen: 0 0 #0000;
+  --press: 0 0 #0000;
+  --elev-1: 0 0 #0000;
   --elev-2: 0 2px 8px -2px rgb(0 0 0 / 8%);
   --elev-3: 0 16px 48px -12px rgb(0 0 0 / 22%);
   --elev-4: 0 32px 80px -16px rgb(0 0 0 / 28%);
@@ -52,18 +52,37 @@
   --scrollbar-thumb: rgb(217 217 217);
   --scrollbar-thumb-hover: rgb(191 191 191);
 
-  --r-ctl: 8px;
-  --r: 10px;
-  --r-lg: 12px;
-  --r-xl: 16px;
+  --r-chip: 3px;
+  --r-ctl: 6px;
+  --r-card: 12px;
+  --r-pill: 9999px;
+  --r: var(--r-card);
+  --r-lg: var(--r-card);
+  --r-xl: var(--r-card);
   --scrollbar-w: 6px;
   --ctl-h: 32px;
   --ctl-h-sm: 28px;
-  --ctl-h-lg: 36px;
-  --ctl-px: 11px;
-  --ctl-px-sm: 9px;
+  --ctl-h-lg: 40px;
+  --ctl-px: 12px;
+  --ctl-px-sm: 10px;
+  --ctl-px-lg: 14px;
   --inset: 8px;
   --row-inset: 10px;
+
+  --font-size-xs: 12px;
+  --line-height-xs: 16px;
+  --font-size-sm: 14px;
+  --line-height-sm: 20px;
+  --font-size-prose: 16px;
+  --line-height-prose: 24px;
+  --font-size-lg: 20px;
+  --line-height-lg: 28px;
+  --font-size-xl: 24px;
+  --line-height-xl: 32px;
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --tracking-ui: 0;
 
   --f-ui:
     "Inter Variable", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
@@ -72,7 +91,7 @@
   --f-mono:
     "Geist Mono Variable", "Geist Mono", "SF Mono", "SFMono-Regular", Consolas, Menlo, monospace;
 
-  --grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
+  --grain: 0 0 #0000;
   --chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2357636e' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
 }
 
@@ -85,9 +104,9 @@
     --sunk: color-mix(in srgb, #0b101a 55%, #0f1520);
     --ink: #e6ebf2;
     --ink-2: #93a0af;
-    --ink-3: color-mix(in srgb, #93a0af 62%, #0f1520);
+    --ink-3: color-mix(in srgb, #93a0af 78%, #161e2b);
     --line: #24303f;
-    --line-2: color-mix(in srgb, #24303f 93%, #93a0af);
+    --line-2: color-mix(in srgb, #24303f 25%, #93a0af);
     --brand: #82aed6;
     --brand-ink: #0a1826;
     --brand-soft: #1c2c3f;
@@ -97,9 +116,6 @@
     --warn: #d9a441;
     --danger: #e07a70;
 
-    --edge: inset 0 1px 0 rgb(255 255 255 / 6%);
-    --sheen: inset 0 1px 0 rgb(255 255 255 / 10%);
-    --elev-1: 0 1px 2px rgb(0 0 0 / 24%);
     --elev-2: 0 2px 8px -2px rgb(0 0 0 / 40%);
     --elev-3: 0 16px 48px -12px rgb(0 0 0 / 64%);
     --elev-4: 0 32px 80px -16px rgb(0 0 0 / 72%);
@@ -124,9 +140,9 @@
   --sunk: color-mix(in srgb, #0b101a 55%, #0f1520);
   --ink: #e6ebf2;
   --ink-2: #93a0af;
-  --ink-3: color-mix(in srgb, #93a0af 62%, #0f1520);
+  --ink-3: color-mix(in srgb, #93a0af 78%, #161e2b);
   --line: #24303f;
-  --line-2: color-mix(in srgb, #24303f 93%, #93a0af);
+  --line-2: color-mix(in srgb, #24303f 25%, #93a0af);
   --brand: #82aed6;
   --brand-ink: #0a1826;
   --brand-soft: #1c2c3f;
@@ -136,9 +152,6 @@
   --warn: #d9a441;
   --danger: #e07a70;
 
-  --edge: inset 0 1px 0 rgb(255 255 255 / 6%);
-  --sheen: inset 0 1px 0 rgb(255 255 255 / 10%);
-  --elev-1: 0 1px 2px rgb(0 0 0 / 24%);
   --elev-2: 0 2px 8px -2px rgb(0 0 0 / 40%);
   --elev-3: 0 16px 48px -12px rgb(0 0 0 / 64%);
   --elev-4: 0 32px 80px -16px rgb(0 0 0 / 72%);
@@ -168,7 +181,7 @@
     background-repeat: repeat;
     background-size: 256px 256px;
     color: var(--ink);
-    font: 400 14px/1.5 var(--f-ui);
+    font: var(--weight-regular) var(--font-size-sm) / var(--line-height-sm) var(--f-ui);
     font-optical-sizing: auto;
     font-feature-settings: "cv01", "ss02";
     -webkit-font-smoothing: antialiased;

--- a/apps/desktop-renderer/tests/theme-palette.test.tsx
+++ b/apps/desktop-renderer/tests/theme-palette.test.tsx
@@ -20,7 +20,10 @@ import { setPrefersDark } from "./matchmedia.js";
 
 const NON_PALETTE_TOKENS = new Set([
   "--r",
+  "--r-chip",
   "--r-ctl",
+  "--r-card",
+  "--r-pill",
   "--r-lg",
   "--r-xl",
   "--ctl-h",
@@ -28,8 +31,23 @@ const NON_PALETTE_TOKENS = new Set([
   "--ctl-h-lg",
   "--ctl-px",
   "--ctl-px-sm",
+  "--ctl-px-lg",
   "--inset",
   "--row-inset",
+  "--font-size-xs",
+  "--line-height-xs",
+  "--font-size-sm",
+  "--line-height-sm",
+  "--font-size-prose",
+  "--line-height-prose",
+  "--font-size-lg",
+  "--line-height-lg",
+  "--font-size-xl",
+  "--line-height-xl",
+  "--weight-regular",
+  "--weight-medium",
+  "--weight-semibold",
+  "--tracking-ui",
   "--scrollbar-w",
   "--scrollbar-thumb",
   "--scrollbar-thumb-hover",
@@ -95,12 +113,9 @@ function expectedProperties(paletteId: string, theme: ResolvedTheme): Map<string
     ["--sunk", `color-mix(in srgb, ${ramp.rail} 55%, ${ramp.bg})`],
     ["--ink", ramp.ink],
     ["--ink-2", ramp.ink2],
-    ["--ink-3", `color-mix(in srgb, ${ramp.ink2} 62%, ${ramp.bg})`],
+    ["--ink-3", `color-mix(in srgb, ${ramp.ink2} 78%, ${ramp.sf})`],
     ["--line", ramp.line],
-    [
-      "--line-2",
-      `color-mix(in srgb, ${ramp.line} ${theme === "dark" ? "93%" : "85%"}, ${ramp.ink2})`,
-    ],
+    ["--line-2", `color-mix(in srgb, ${ramp.line} 25%, ${ramp.ink2})`],
     ["--brand", ramp.br],
     ["--brand-ink", ramp.bri],
     ["--brand-soft", ramp.soft],
@@ -162,13 +177,17 @@ describe("palette engine", () => {
     }
   });
 
-  it("keeps compact Setup copy and control edges readable in every appearance", () => {
+  it("keeps compact copy and control edges readable in every appearance", () => {
     for (const palette of PALETTES) {
       for (const ramp of [palette.l, palette.d]) {
         const setupBackgrounds = [ramp.bg, ramp.sf, mixHex(ramp.rail, 0.55, ramp.bg)];
         for (const background of setupBackgrounds) {
           expect(contrastRatio(ramp.ink2, background)).toBeGreaterThanOrEqual(4.5);
         }
+        expect(contrastRatio(mixHex(ramp.ink2, 0.78, ramp.sf), ramp.sf)).toBeGreaterThanOrEqual(3);
+        expect(contrastRatio(mixHex(ramp.line, 0.25, ramp.ink2), ramp.sf)).toBeGreaterThanOrEqual(
+          3,
+        );
       }
     }
   });
@@ -232,6 +251,69 @@ describe("palette engine", () => {
           `${selector} ${property}: ${declared.get(property)?.toLowerCase() ?? "absent"}`,
         ).toBe(`${selector} ${property}: ${value.toLowerCase()}`);
     }
+  });
+
+  it("declares the Primer type, radius, control, and resting-surface values", async () => {
+    const declared = blockDeclarations(await readTokenSheet(), ":root");
+    expect(
+      Object.fromEntries(
+        [
+          "--font-size-xs",
+          "--line-height-xs",
+          "--font-size-sm",
+          "--line-height-sm",
+          "--font-size-prose",
+          "--line-height-prose",
+          "--font-size-lg",
+          "--line-height-lg",
+          "--font-size-xl",
+          "--line-height-xl",
+          "--weight-regular",
+          "--weight-medium",
+          "--weight-semibold",
+          "--tracking-ui",
+          "--r-chip",
+          "--r-ctl",
+          "--r-card",
+          "--r-pill",
+          "--ctl-h-sm",
+          "--ctl-h",
+          "--ctl-h-lg",
+          "--edge",
+          "--sheen",
+          "--press",
+          "--elev-1",
+          "--grain",
+        ].map((property) => [property, declared.get(property)]),
+      ),
+    ).toEqual({
+      "--font-size-xs": "12px",
+      "--line-height-xs": "16px",
+      "--font-size-sm": "14px",
+      "--line-height-sm": "20px",
+      "--font-size-prose": "16px",
+      "--line-height-prose": "24px",
+      "--font-size-lg": "20px",
+      "--line-height-lg": "28px",
+      "--font-size-xl": "24px",
+      "--line-height-xl": "32px",
+      "--weight-regular": "400",
+      "--weight-medium": "500",
+      "--weight-semibold": "600",
+      "--tracking-ui": "0",
+      "--r-chip": "3px",
+      "--r-ctl": "6px",
+      "--r-card": "12px",
+      "--r-pill": "9999px",
+      "--ctl-h-sm": "28px",
+      "--ctl-h": "32px",
+      "--ctl-h-lg": "40px",
+      "--edge": "0 0 #0000",
+      "--sheen": "0 0 #0000",
+      "--press": "0 0 #0000",
+      "--elev-1": "0 0 #0000",
+      "--grain": "0 0 #0000",
+    });
   });
 
   it("covers the whole colour vocabulary declared in the token sheet", async () => {


### PR DESCRIPTION
## Summary
- standardize the renderer type ramp, weights, radii, control sizes, and Tailwind mappings
- strengthen secondary text and control-edge contrast across every runtime palette
- remove resting surface shadows and grain while retaining overlay elevation

## Design values
- type: 12/16, 14/20, 16/24, 20/28, and 24/32
- radii: 3px chips, 6px controls, 12px cards, and full pills
- controls: 28px small, 32px default, and 40px large
- control-edge mix: 25% line and 75% secondary ink; the planned 55% mix did not meet 3:1 contrast across all palettes

## Verification
- `pnpm check`
- `pnpm --filter @enduragent/desktop-renderer exec vitest run --maxWorkers=2` — 56 files, 912 tests
- focused theme tests — 2 files, 21 tests
- `pnpm exec oxfmt --check` on changed files
- autoreview: clean, no accepted or actionable findings; TruffleHog clean