### PR TITLE
refactor: replace onboarding selects

### DIFF
--- a/.changeset/ui-onboarding-selects.md
+++ b/.changeset/ui-onboarding-selects.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Updated setup menus, labels, and status controls to the new interface system.

--- a/apps/desktop-renderer/src/ui/onboarding/AiRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/AiRow.tsx
@@ -24,6 +24,13 @@ import {
 } from "../../onboarding/lanes.js";
 import { llmSelectionFromDraft, type LlmSelectionDraft } from "../../onboarding/selection.js";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../components/ui/select.js";
+import {
   credentialChangesBlocked,
   repairRequiredCredential,
 } from "../../settings/credential-controller.js";
@@ -364,7 +371,7 @@ export function AiRow(props: {
                       className="w-[262px] rounded-md border border-line-2 bg-surface p-[5px] shadow-elev-3"
                     >
                       <Menu.RadioGroup value={lane}>
-                        <Menu.GroupLabel className="px-[9px] pt-1.5 pb-1 text-[11px] font-semibold tracking-wider text-ink-2 uppercase">
+                        <Menu.GroupLabel className="px-[9px] pt-1.5 pb-1 text-xs font-medium text-ink-2">
                           {SETUP_MENU_LABEL}
                         </Menu.GroupLabel>
                         {lanes.map((entry) => (
@@ -385,7 +392,7 @@ export function AiRow(props: {
                               </Menu.RadioItemIndicator>
                             </span>
                             <span className="min-w-0 flex-1">
-                              <b className="block text-[13.5px] font-medium">
+                              <b className="block text-sm font-medium">
                                 {SETUP_LANE_LABELS[entry]}
                               </b>
                               <i className="mt-px block text-xs text-ink-2 not-italic">
@@ -399,7 +406,7 @@ export function AiRow(props: {
                         <div className="mt-1 border-t border-line px-[9px] pt-2 pb-1">
                           <p
                             data-setup-note="claude-cli"
-                            className="text-[11.5px] leading-normal text-ink-2"
+                            className="text-xs leading-normal text-ink-2"
                           >
                             {note}
                           </p>
@@ -431,7 +438,7 @@ export function AiRow(props: {
       {panel === "chatgpt" ? (
         <SetupSubPanel name="chatgpt">
           <div className="flex min-w-0 flex-wrap items-center gap-x-7 gap-y-3">
-            <span className="min-w-52 flex-1 text-[11.5px] leading-normal text-ink-2">
+            <span className="min-w-52 flex-1 text-xs leading-normal text-ink-2">
               {CHATGPT_PANEL_HINT}
             </span>
             <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
@@ -468,7 +475,7 @@ export function AiRow(props: {
           </div>
           {chatGptStatusCopy === null ? null : (
             <p
-              className={`mt-[7px] text-[11.5px] ${chatGptPhase === "activation-failed" ? "text-danger" : "text-ink-2"}`}
+              className={`mt-[7px] text-xs ${chatGptPhase === "activation-failed" ? "text-danger" : "text-ink-2"}`}
               role="status"
               aria-live="polite"
               aria-atomic="true"
@@ -478,7 +485,7 @@ export function AiRow(props: {
             </p>
           )}
           {wizard.chatGptRefusal !== null ? (
-            <p className="mt-[7px] text-[11.5px] text-danger" aria-live="polite">
+            <p className="mt-[7px] text-xs text-danger" aria-live="polite">
               {CHATGPT_REFUSAL_COPY[wizard.chatGptRefusal]}
             </p>
           ) : null}
@@ -488,27 +495,34 @@ export function AiRow(props: {
       {panel === "api-key" ? (
         <SetupSubPanel name="api-key">
           {configuration === null || draft === null ? (
-            <p className="text-[13px] text-ink-2">{ERROR_COPY["configuration-unavailable"]}</p>
+            <p className="text-sm text-ink-2">{ERROR_COPY["configuration-unavailable"]}</p>
           ) : (
             <>
               <label className={SETUP_LABEL_CLASS} htmlFor="onboarding-llm-provider">
                 Provider
               </label>
-              <select
-                id="onboarding-llm-provider"
-                className={SETUP_SELECT_CLASS}
+              <Select
                 disabled={controlsDisabled}
+                items={keyProviders.map((entry) => ({
+                  value: entry.provider,
+                  label: ONBOARDING_LLM_PROVIDER_LABELS[entry.provider],
+                }))}
                 value={draft.provider.provider}
-                onChange={(event) => {
-                  actions?.selectProvider(event.target.value);
+                onValueChange={(value) => {
+                  if (value !== null) actions?.selectProvider(value);
                 }}
               >
-                {keyProviders.map((entry) => (
-                  <option key={entry.provider} value={entry.provider}>
-                    {ONBOARDING_LLM_PROVIDER_LABELS[entry.provider]}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger id="onboarding-llm-provider" className={SETUP_SELECT_CLASS}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="start">
+                  {keyProviders.map((entry) => (
+                    <SelectItem key={entry.provider} value={entry.provider}>
+                      {ONBOARDING_LLM_PROVIDER_LABELS[entry.provider]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               {keySlot === undefined ? null : (
                 <div className="mt-[11px]">
                   <CredentialField
@@ -548,24 +562,36 @@ export function AiRow(props: {
                     <label className={SETUP_LABEL_CLASS} htmlFor="onboarding-llm-model">
                       Model
                     </label>
-                    <select
-                      id="onboarding-llm-model"
-                      className={SETUP_SELECT_CLASS}
+                    <Select
                       disabled={controlsDisabled}
+                      items={draft.provider.models
+                        .map((model) => ({
+                          value: model.value,
+                          label:
+                            model.hint === undefined
+                              ? model.label
+                              : `${model.label} · ${model.hint}`,
+                        }))
+                        .concat({ value: CUSTOM_MODEL_SELECTION, label: "Other model…" })}
                       value={draft.modelChoice}
-                      onChange={(event) => {
-                        actions?.selectModel(event.target.value);
+                      onValueChange={(value) => {
+                        if (value !== null) actions?.selectModel(value);
                       }}
                     >
-                      {draft.provider.models.map((model) => (
-                        <option key={model.value} value={model.value}>
-                          {model.hint === undefined
-                            ? model.label
-                            : `${model.label} · ${model.hint}`}
-                        </option>
-                      ))}
-                      <option value={CUSTOM_MODEL_SELECTION}>Other model…</option>
-                    </select>
+                      <SelectTrigger id="onboarding-llm-model" className={SETUP_SELECT_CLASS}>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent align="start">
+                        {draft.provider.models.map((model) => (
+                          <SelectItem key={model.value} value={model.value}>
+                            {model.hint === undefined
+                              ? model.label
+                              : `${model.label} · ${model.hint}`}
+                          </SelectItem>
+                        ))}
+                        <SelectItem value={CUSTOM_MODEL_SELECTION}>Other model…</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
                   {draft.modelChoice === CUSTOM_MODEL_SELECTION ? (
                     <div>
@@ -593,21 +619,28 @@ export function AiRow(props: {
                         <label className={SETUP_LABEL_CLASS} htmlFor="onboarding-endpoint-mode">
                           Endpoint
                         </label>
-                        <select
-                          id="onboarding-endpoint-mode"
-                          className={SETUP_SELECT_CLASS}
+                        <Select
                           disabled={controlsDisabled}
+                          items={ENDPOINT_MODE_COPY.map(([value, label]) => ({ value, label }))}
                           value={draft.endpointMode}
-                          onChange={(event) => {
-                            actions?.setEndpointMode(event.target.value);
+                          onValueChange={(value) => {
+                            if (value !== null) actions?.setEndpointMode(value);
                           }}
                         >
-                          {ENDPOINT_MODE_COPY.map(([value, entry]) => (
-                            <option key={value} value={value}>
-                              {entry}
-                            </option>
-                          ))}
-                        </select>
+                          <SelectTrigger
+                            id="onboarding-endpoint-mode"
+                            className={SETUP_SELECT_CLASS}
+                          >
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent align="start">
+                            {ENDPOINT_MODE_COPY.map(([value, entry]) => (
+                              <SelectItem key={value} value={value}>
+                                {entry}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </div>
                       {draft.endpointMode === "custom" ? (
                         <div>

--- a/apps/desktop-renderer/src/ui/onboarding/IntakeRows.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/IntakeRows.tsx
@@ -1,4 +1,11 @@
 import type { ReactElement } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../components/ui/select.js";
 import type { OnboardingActions, OnboardingSurfaceState } from "../../onboarding/controller.js";
 import { errorSection } from "../../onboarding/lanes.js";
 import { RETRY_INTAKE_SAVE_LABEL } from "./copy.js";
@@ -24,22 +31,29 @@ function IntakeSelect(props: {
   readonly onSelect: (value: string) => void;
 }): ReactElement {
   return (
-    <select
-      id={props.id}
-      className={`${SETUP_SELECT_CLASS} w-[180px]`}
+    <Select
       disabled={props.disabled}
+      items={props.options.map(([value, label]) => ({ value, label }))}
       value={props.value}
-      aria-describedby={props.describedBy}
-      onChange={(event) => {
-        props.onSelect(event.target.value);
+      onValueChange={(value) => {
+        if (value !== null) props.onSelect(value);
       }}
     >
-      {props.options.map(([value, label]) => (
-        <option key={value} value={value}>
-          {label}
-        </option>
-      ))}
-    </select>
+      <SelectTrigger
+        id={props.id}
+        className={`${SETUP_SELECT_CLASS} w-[180px]`}
+        aria-describedby={props.describedBy}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align="end">
+        {props.options.map(([value, label]) => (
+          <SelectItem key={value} value={value}>
+            {label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }
 

--- a/apps/desktop-renderer/src/ui/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/OnboardingWizard.tsx
@@ -101,7 +101,7 @@ export function SetupPanel(props: { readonly placement: SetupPlacement }): React
             <h1
               id="setup-panel-title"
               tabIndex={-1}
-              className="text-[27px] leading-[1.16] font-[590] tracking-[-0.035em] outline-none"
+              className="text-2xl leading-8 font-semibold tracking-[-0.02em] outline-none"
             >
               {gateUnavailable || statusKnown ? SETUP_HEADING : SETUP_CHECKING_HEADING}
             </h1>
@@ -138,7 +138,7 @@ export function SetupPanel(props: { readonly placement: SetupPlacement }): React
           role="status"
           aria-live="polite"
         >
-          <span className="text-[13px] text-ink-2">{SETUP_STATUS_UNAVAILABLE_COPY}</span>
+          <span className="text-sm text-ink-2">{SETUP_STATUS_UNAVAILABLE_COPY}</span>
           <button
             type="button"
             className={BUTTON_PRIMARY}

--- a/apps/desktop-renderer/src/ui/onboarding/SetupCard.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/SetupCard.tsx
@@ -14,12 +14,12 @@ export {
 export const SETUP_LINK_BUTTON =
   "mt-2 block cursor-pointer bg-transparent p-0 text-left text-xs font-medium text-ink-2 underline underline-offset-[3px] transition-colors hover:text-ink disabled:cursor-default disabled:opacity-64 motion-reduce:transition-none";
 
-export const SETUP_HINT_CLASS = "mt-[7px] block text-[11.5px] leading-normal text-ink-2";
+export const SETUP_HINT_CLASS = "mt-[7px] block text-xs leading-normal text-ink-2";
 
 export const SETUP_FIELD_CLASS =
   "h-[30px] w-full max-w-[236px] rounded-ctl border border-ink-2 bg-surface px-[11px] text-sm text-ink shadow-[var(--edge),var(--elev-1)] disabled:opacity-64";
 
-export const SETUP_SELECT_CLASS = `${SETUP_FIELD_CLASS} cursor-pointer appearance-none bg-[image:var(--chevron)] bg-[length:14px_14px] bg-[position:right_10px_center] bg-no-repeat pr-[30px] disabled:cursor-default`;
+export const SETUP_SELECT_CLASS = "w-full max-w-[236px]";
 
 export const SETUP_LABEL_CLASS = "mb-[5px] block text-xs font-medium text-ink-2";
 

--- a/apps/desktop-renderer/src/ui/onboarding/SetupRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/SetupRow.tsx
@@ -6,7 +6,7 @@ import { ERROR_COPY } from "./copy.js";
 
 export type SetupRowStatus = "ready" | "pending" | "none";
 
-const TITLE_CLASS = "flex items-center gap-1.5 text-[13.5px] font-medium";
+const TITLE_CLASS = "flex items-center gap-1.5 text-sm font-medium";
 
 function StatusDisc(props: { readonly status: SetupRowStatus }): ReactElement | null {
   if (props.status === "none") return null;
@@ -98,7 +98,7 @@ export function SetupError(props: {
   const wizard = props.surface.wizard;
   if (errorSection(wizard.fixedError, props.surface.lastCommit) !== props.section) return null;
   return (
-    <p id="onboarding-error" className="mt-2 text-[13px] text-danger">
+    <p id="onboarding-error" className="mt-2 text-sm text-danger">
       {wizard.fixedError === null ? "" : ERROR_COPY[wizard.fixedError]}
     </p>
   );

--- a/apps/desktop-renderer/src/ui/onboarding/TelegramRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/TelegramRow.tsx
@@ -420,7 +420,7 @@ export function TelegramRow(): ReactElement {
   const feedbackNode =
     panelFeedback === null ? null : (
       <p
-        className={`mt-2 mb-0 text-[12.5px] ${panelFeedback.tone === "error" || panelFeedback.tone === "warning" ? "text-danger" : "text-ink-2"}`}
+        className={`mt-2 mb-0 text-xs ${panelFeedback.tone === "error" || panelFeedback.tone === "warning" ? "text-danger" : "text-ink-2"}`}
         role={panelFeedback.tone === "error" ? "alert" : "status"}
         aria-live={panelFeedback.tone === "error" ? undefined : "polite"}
         data-telegram-feedback={panelFeedback.tone}
@@ -447,7 +447,7 @@ export function TelegramRow(): ReactElement {
         }
         info={
           <span
-            className="rounded-full bg-[color-mix(in_srgb,var(--brand)_10%,transparent)] px-[7px] py-0.5 text-[10px] font-semibold uppercase tracking-[0.055em] text-brand"
+            className="rounded-full bg-[color-mix(in_srgb,var(--brand)_10%,transparent)] px-[7px] py-0.5 text-xs font-semibold text-brand"
             data-telegram-optional=""
           >
             {TELEGRAM_OPTIONAL_LABEL}
@@ -508,11 +508,11 @@ export function TelegramRow(): ReactElement {
                 ref={heading}
                 id="onboarding-telegram-create-title"
                 tabIndex={-1}
-                className="m-0 text-[13.5px] font-medium text-ink focus-visible:outline-2 focus-visible:outline-offset-[3px] focus-visible:outline-ink"
+                className="m-0 text-sm font-medium text-ink focus-visible:outline-2 focus-visible:outline-offset-[3px] focus-visible:outline-ink"
               >
                 {TELEGRAM_CREATE_TITLE}
               </h3>
-              <p className="mt-1 mb-0 max-w-[525px] text-[12.5px] text-ink-2">
+              <p className="mt-1 mb-0 max-w-[525px] text-xs text-ink-2">
                 Ask{" "}
                 <a
                   className="font-medium underline underline-offset-[3px] hover:text-ink"

--- a/apps/desktop-renderer/src/ui/onboarding/TrainingRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/TrainingRow.tsx
@@ -172,7 +172,7 @@ export function TrainingRow(props: {
               <h3
                 ref={headingRef}
                 tabIndex={-1}
-                className="m-0 text-[13.5px] font-medium text-ink focus-visible:outline-2 focus-visible:outline-offset-[3px] focus-visible:outline-ink"
+                className="m-0 text-sm font-medium text-ink focus-visible:outline-2 focus-visible:outline-offset-[3px] focus-visible:outline-ink"
               >
                 {TRAINING_CONNECT_TITLE}
               </h3>

--- a/apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx
@@ -300,8 +300,8 @@ describe("claude-cli onboarding lane", () => {
     const wizard = await openLane(bridge);
     await openApiKeyPanel(user);
 
-    expect(control<HTMLSelectElement>("onboarding-llm-provider").value).toBe("anthropic");
-    expect(control<HTMLSelectElement>("onboarding-llm-model").value).toBe("claude-sonnet-4-6");
+    expect(control("onboarding-llm-provider")).toHaveTextContent("Anthropic");
+    expect(control("onboarding-llm-model")).toHaveTextContent("Claude Sonnet 4.6");
     expect(bridge.claudeCliStatus).not.toHaveBeenCalled();
     expect(bridge.claudeCliRecheck).not.toHaveBeenCalled();
     wizard.controller.dispose();

--- a/apps/desktop-renderer/tests/onboarding-harness.tsx
+++ b/apps/desktop-renderer/tests/onboarding-harness.tsx
@@ -147,6 +147,34 @@ export function control<T extends HTMLElement>(id: string): T {
   return element;
 }
 
+const SETUP_OPTION_LABELS: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  "onboarding-injury-status": {
+    none: "No current injury",
+    returning: "Returning after an injury",
+  },
+  "onboarding-llm-provider": {
+    anthropic: "Anthropic",
+    openrouter: "OpenRouter",
+  },
+  "onboarding-llm-model": {
+    __custom__: "Other model…",
+    "deepseek/deepseek-v4-flash": "DeepSeek V4 Flash",
+  },
+  "onboarding-endpoint-mode": {
+    custom: "Use a custom endpoint",
+  },
+};
+
+export async function selectSetupOption(
+  user: UserEvent,
+  id: string,
+  value: string,
+): Promise<void> {
+  const label = SETUP_OPTION_LABELS[id]?.[value] ?? value;
+  await user.click(control(id));
+  await user.click(await screen.findByRole("option", { name: label }));
+}
+
 export function errorText(): string {
   return document.querySelector("#onboarding-error")?.textContent ?? "";
 }

--- a/apps/desktop-renderer/tests/onboarding-provider-status.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-provider-status.test.tsx
@@ -5,13 +5,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OnboardingBridge } from "../src/onboarding/bridge.js";
 import {
   chooseLane,
-  control,
   mountWizard,
   openApiKeyPanel,
   panel,
   resetOnboardingStore,
   rowState,
   rowSubtitle,
+  selectSetupOption,
   seedSecret,
   setupCard,
   testBridge,
@@ -123,7 +123,7 @@ describe("onboarding provider status", () => {
     const wizard = mountWizard({ bridge });
     await wizard.open();
     await openApiKeyPanel(user);
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "anthropic");
+    await selectSetupOption(user, "onboarding-llm-provider", "anthropic");
     seedSecret("anthropic", randomUUID());
 
     const host = panel("api-key");
@@ -162,7 +162,7 @@ describe("onboarding provider status", () => {
     const wizard = mountWizard({ bridge });
     await wizard.open();
     await openApiKeyPanel(user);
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "anthropic");
+    await selectSetupOption(user, "onboarding-llm-provider", "anthropic");
 
     const host = panel("api-key");
     await user.click(within(host as HTMLElement).getByRole("button", { name: "Save API key" }));
@@ -200,7 +200,7 @@ describe("onboarding provider status", () => {
     const wizard = mountWizard({ bridge });
     await wizard.open();
     await openApiKeyPanel(user);
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "anthropic");
+    await selectSetupOption(user, "onboarding-llm-provider", "anthropic");
 
     const host = panel("api-key");
     await user.click(within(host as HTMLElement).getByRole("button", { name: "Save API key" }));

--- a/apps/desktop-renderer/tests/onboarding-secret-boundary.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-secret-boundary.test.tsx
@@ -9,7 +9,6 @@ import type {
 } from "../src/onboarding/bridge.js";
 import { handoffCredential } from "../src/onboarding/credentials.js";
 import {
-  control,
   mountWizard,
   openApiKeyPanel,
   openTrainingPanel,
@@ -19,6 +18,7 @@ import {
   resetOnboardingStore,
   rowState,
   saveModelKey,
+  selectSetupOption,
   seedSecret,
   testBridge,
 } from "./onboarding-harness.js";
@@ -248,7 +248,7 @@ describe("mounted onboarding secret boundary", () => {
     const wizard = mountWizard({ bridge });
     await wizard.open();
     await openApiKeyPanel(user);
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "openrouter");
+    await selectSetupOption(user, "onboarding-llm-provider", "openrouter");
 
     await user.type(passwordInput("openrouter"), sentinel);
     await saveModelKey(user);
@@ -271,7 +271,7 @@ describe("mounted onboarding secret boundary", () => {
     await openApiKeyPanel(user);
 
     await user.type(passwordInput("anthropic"), sentinel);
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "openrouter");
+    await selectSetupOption(user, "onboarding-llm-provider", "openrouter");
 
     expect(document.querySelector('input[data-slot="anthropic"]')).toBeNull();
     expect(passwordInput("openrouter").getAttribute("value")).toBeNull();

--- a/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
@@ -31,6 +31,7 @@ import {
   rowState,
   rowSubtitle,
   seedSecret,
+  selectSetupOption,
   setTelegramSettings,
   setupCard,
   setupRow,
@@ -98,7 +99,10 @@ function trigger(id: string): HTMLElement {
 }
 
 function buttonNames(host: HTMLElement | null): readonly string[] {
-  return Array.from(host?.querySelectorAll("button") ?? [], (entry) => entry.textContent ?? "");
+  return Array.from(
+    host?.querySelectorAll('button:not([role="combobox"])') ?? [],
+    (entry) => entry.textContent ?? "",
+  );
 }
 
 function bindCredentialPort(): CredentialSettingsPort {
@@ -117,7 +121,7 @@ function bindCredentialPort(): CredentialSettingsPort {
 }
 
 async function completeIntake(user: ReturnType<typeof userEvent.setup>): Promise<void> {
-  await user.selectOptions(control<HTMLSelectElement>("onboarding-injury-status"), "none");
+  await selectSetupOption(user, "onboarding-injury-status", "none");
 }
 
 describe("setup card", () => {
@@ -279,12 +283,9 @@ describe("setup card", () => {
       expect(panel("api-key")).not.toBeNull();
     });
     expect(rowState("ai")).toBe("pending");
-    expect(
-      Array.from(
-        control<HTMLSelectElement>("onboarding-llm-provider").options,
-        (option) => option.value,
-      ),
-    ).not.toContain("codex-agent");
+    await user.click(control("onboarding-llm-provider"));
+    expect(screen.queryByRole("option", { name: "Codex agent (experimental)" })).toBeNull();
+    await user.keyboard("{Escape}");
     wizard.controller.dispose();
   });
 
@@ -344,7 +345,7 @@ describe("setup card", () => {
     await wizard.open();
 
     expect(screen.queryByRole("button", { name: RETRY_INTAKE_SAVE_LABEL })).toBeNull();
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-injury-status"), "none");
+    await selectSetupOption(user, "onboarding-injury-status", "none");
 
     const retry = await screen.findByRole("button", { name: RETRY_INTAKE_SAVE_LABEL });
     expect(retry.className).toContain("underline");
@@ -602,11 +603,11 @@ describe("setup card", () => {
     const advanced = control("onboarding-llm-model").closest("details");
     expect(advanced).not.toBeNull();
     expect(advanced?.hasAttribute("open")).toBe(false);
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "openrouter");
+    await selectSetupOption(user, "onboarding-llm-provider", "openrouter");
     expect(control("onboarding-endpoint-mode").closest("details")).toBe(
       control("onboarding-llm-model").closest("details"),
     );
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "anthropic");
+    await selectSetupOption(user, "onboarding-llm-provider", "anthropic");
 
     seedSecret("anthropic", randomUUID());
     await user.click(screen.getByRole("button", { name: "Save API key" }));
@@ -669,12 +670,12 @@ describe("setup card", () => {
     await wizard.open();
     await openApiKeyPanel(user);
     await openTrainingPanel(user);
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-injury-status"), "returning");
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-model"), "__custom__");
+    await selectSetupOption(user, "onboarding-injury-status", "returning");
+    await selectSetupOption(user, "onboarding-llm-model", "__custom__");
 
     const controls = Array.from(
       document.querySelectorAll<HTMLElement>(
-        ".setup-panel input, .setup-panel select, .setup-panel textarea",
+        '.setup-panel input:not([aria-hidden="true"]), .setup-panel select, .setup-panel textarea, .setup-panel [role="combobox"]',
       ),
     );
     expect(controls.length).toBeGreaterThan(4);
@@ -719,7 +720,7 @@ describe("setup card", () => {
       "2 of 3 required ready",
     );
 
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-injury-status"), "none");
+    await selectSetupOption(user, "onboarding-injury-status", "none");
 
     await waitFor(() => {
       expect(rowState("injury-status")).toBe("ready");
@@ -781,13 +782,13 @@ describe("setup card", () => {
 
     expect(rowIds()).toEqual(["ai", "training", "telegram", "injury-status"]);
 
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-injury-status"), "returning");
+    await selectSetupOption(user, "onboarding-injury-status", "returning");
 
     expect(rowIds()).toEqual(["ai", "training", "telegram", "injury-status"]);
     expect(setupRow("injury-status").parentElement).toBe(setupCard());
     expect(document.querySelector('[data-setup-row="clinician-cleared"]')).toBeNull();
 
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-injury-status"), "none");
+    await selectSetupOption(user, "onboarding-injury-status", "none");
 
     expect(rowIds()).toEqual(["ai", "training", "telegram", "injury-status"]);
     wizard.controller.dispose();
@@ -966,21 +967,20 @@ describe("setup card", () => {
     });
     await openApiKeyPanel(user);
 
-    expect(control<HTMLSelectElement>("onboarding-llm-provider").value).toBe("openrouter");
-    expect(control<HTMLSelectElement>("onboarding-llm-model").value).toBe("__custom__");
+    expect(control("onboarding-llm-provider")).toHaveTextContent("OpenRouter");
+    expect(control("onboarding-llm-model")).toHaveTextContent("Other model…");
     expect(control<HTMLInputElement>("onboarding-custom-model").value).toBe("saved/custom-model");
-    expect(control<HTMLSelectElement>("onboarding-endpoint-mode").value).toBe("automatic");
-
-    await user.selectOptions(
-      control<HTMLSelectElement>("onboarding-llm-model"),
-      "deepseek/deepseek-v4-flash",
+    expect(control("onboarding-endpoint-mode")).toHaveTextContent(
+      "Keep current, or use provider default",
     );
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-endpoint-mode"), "custom");
+
+    await selectSetupOption(user, "onboarding-llm-model", "deepseek/deepseek-v4-flash");
+    await selectSetupOption(user, "onboarding-endpoint-mode", "custom");
     await user.type(
       control<HTMLInputElement>("onboarding-custom-endpoint"),
       "https://changed.example.test/v1",
     );
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "anthropic");
+    await selectSetupOption(user, "onboarding-llm-provider", "anthropic");
 
     await user.click(
       within(panel("api-key") as HTMLElement).getByRole("button", { name: "Cancel API key setup" }),
@@ -990,10 +990,12 @@ describe("setup card", () => {
     });
     await openApiKeyPanel(user);
 
-    expect(control<HTMLSelectElement>("onboarding-llm-provider").value).toBe("openrouter");
-    expect(control<HTMLSelectElement>("onboarding-llm-model").value).toBe("__custom__");
+    expect(control("onboarding-llm-provider")).toHaveTextContent("OpenRouter");
+    expect(control("onboarding-llm-model")).toHaveTextContent("Other model…");
     expect(control<HTMLInputElement>("onboarding-custom-model").value).toBe("saved/custom-model");
-    expect(control<HTMLSelectElement>("onboarding-endpoint-mode").value).toBe("automatic");
+    expect(control("onboarding-endpoint-mode")).toHaveTextContent(
+      "Keep current, or use provider default",
+    );
     expect(document.querySelector("#onboarding-custom-endpoint")).toBeNull();
     wizard.controller.dispose();
   });
@@ -1028,7 +1030,7 @@ describe("setup card", () => {
     });
     await openApiKeyPanel(user);
 
-    expect(control<HTMLSelectElement>("onboarding-llm-provider").value).toBe("anthropic");
+    expect(control("onboarding-llm-provider")).toHaveTextContent("Anthropic");
     wizard.controller.dispose();
   });
 
@@ -1205,7 +1207,7 @@ describe("setup card", () => {
     expect(screen.getByText(FOOTER_NOTE).className).toContain("ml-auto");
     expect(document.querySelector("[data-setup-outstanding]")).toBeNull();
 
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-injury-status"), "returning");
+    await selectSetupOption(user, "onboarding-injury-status", "returning");
 
     await waitFor(() => {
       expect(primaryButton()).toBeEnabled();
@@ -1274,9 +1276,9 @@ describe("setup card", () => {
     const wizard = mountWizard({ bridge: coldBridge() });
     await wizard.open();
     await openApiKeyPanel(user);
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-provider"), "openrouter");
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-llm-model"), "__custom__");
-    await user.selectOptions(control<HTMLSelectElement>("onboarding-endpoint-mode"), "custom");
+    await selectSetupOption(user, "onboarding-llm-provider", "openrouter");
+    await selectSetupOption(user, "onboarding-llm-model", "__custom__");
+    await selectSetupOption(user, "onboarding-endpoint-mode", "custom");
 
     expect(screen.getByLabelText("Custom model name")).toBe(control("onboarding-custom-model"));
     expect(screen.getByLabelText("Endpoint")).toBe(control("onboarding-endpoint-mode"));
@@ -1532,7 +1534,7 @@ describe("setup card accessibility", () => {
       expect(element.className).toContain("border-input");
       expect(element.className).not.toContain("border-line-2");
     }
-    expect(control("onboarding-injury-status").className).toContain("border-ink-2");
+    expect(control("onboarding-injury-status").className).toContain("border-input");
     expect(control("onboarding-injury-status").className).not.toContain("border-line-2");
 
     await openLaneMenu(user);
@@ -1547,7 +1549,7 @@ describe("setup card accessibility", () => {
       expect(panel("api-key")).not.toBeNull();
     });
     expect(screen.getByText(API_KEY_PANEL_HINT).className).toContain("text-ink-2");
-    expect(control("onboarding-llm-provider").className).toContain("border-ink-2");
+    expect(control("onboarding-llm-provider").className).toContain("border-input");
     wizard.controller.dispose();
   });
 });

--- a/apps/desktop-renderer/tests/onboarding-surface.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-surface.test.tsx
@@ -26,6 +26,7 @@ import {
   rowState,
   saveModelKey,
   seedSecret,
+  selectSetupOption,
   testBridge,
   TEST_LLM_CONFIGURATION,
   type UserEvent,
@@ -47,7 +48,7 @@ function button(name: string): HTMLButtonElement {
 }
 
 async function chooseOption(user: UserEvent, id: string, value: string) {
-  await user.selectOptions(control<HTMLSelectElement>(id), value);
+  await selectSetupOption(user, id, value);
 }
 
 async function typeInto(user: UserEvent, id: string, value: string) {
@@ -667,7 +668,7 @@ describe("mounted onboarding", () => {
     const wizard = mountWizard({ bridge });
     await wizard.open();
     await openApiKeyPanel(user);
-    const provider = control<HTMLSelectElement>("onboarding-llm-provider");
+    const provider = control<HTMLButtonElement>("onboarding-llm-provider");
 
     expect(fireEvent.keyDown(provider, { key: "Enter" })).toBe(true);
 
@@ -763,9 +764,9 @@ describe("mounted onboarding", () => {
     await chooseOption(user, "onboarding-llm-provider", "anthropic");
     await chooseOption(user, "onboarding-llm-provider", "openrouter");
 
-    expect(control<HTMLSelectElement>("onboarding-llm-model").value).toBe("__custom__");
+    expect(control("onboarding-llm-model")).toHaveTextContent("Other model…");
     expect(control<HTMLInputElement>("onboarding-custom-model").value).toBe(selection.model);
-    expect(control<HTMLSelectElement>("onboarding-endpoint-mode").value).toBe("custom");
+    expect(control("onboarding-endpoint-mode")).toHaveTextContent("Use a custom endpoint");
     expect(control<HTMLInputElement>("onboarding-custom-endpoint").value).toBe(
       selection.endpoint.value,
     );

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -662,7 +662,7 @@ describe("settings setup inventory", () => {
       expect(document.querySelector('[data-setup-panel="api-key"]')).not.toBeNull(),
     );
     expect(document.querySelector('[data-setup-menu="ai"]')).toBeNull();
-    expect(screen.getByLabelText("Provider")).toHaveValue("openrouter");
+    expect(screen.getByLabelText("Provider")).toHaveTextContent("OpenRouter");
     expect(useEnduragentStore.getState().onboarding.configuration?.active).toEqual({
       provider: "anthropic",
       model: "synthetic-model",

--- a/apps/desktop-renderer/tests/setup-readiness.test.tsx
+++ b/apps/desktop-renderer/tests/setup-readiness.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   onboardingStatusRetryDelayMs,
@@ -14,6 +15,7 @@ import {
   mountWizard,
   readyTelegramSettings,
   resetOnboardingStore,
+  selectSetupOption,
   setTelegramSettings,
   testBridge,
 } from "./onboarding-harness.js";
@@ -60,7 +62,7 @@ describe("authoritative setup readiness", () => {
     await wizard.open();
 
     expect(wizard.controller.state().intake).toEqual({ injuryStatus: "managing" });
-    expect(control<HTMLSelectElement>("onboarding-injury-status")).toHaveValue("managing");
+    expect(control("onboarding-injury-status")).toHaveTextContent("Managing an injury");
     expect(document.querySelector("#onboarding-clinician-cleared")).toBeNull();
     expect(useEnduragentStore.getState().onboarding.readiness).toEqual({
       provider: true,
@@ -251,7 +253,7 @@ describe("authoritative setup readiness", () => {
     expect(screen.getByRole("button", { name: "Start coaching" })).toBeEnabled();
     expect(document.querySelector('[data-setup-trigger="ai"]')).toBeEnabled();
     expect(document.querySelector('[data-setup-trigger="training"]')).toBeEnabled();
-    expect(control<HTMLSelectElement>("onboarding-injury-status")).toBeEnabled();
+    expect(control<HTMLButtonElement>("onboarding-injury-status")).toBeEnabled();
     expect(document.querySelector("#onboarding-clinician-cleared")).toBeNull();
     expect(document.querySelector("[data-setup-readiness]")).toHaveTextContent(
       "3 of 3 required ready",
@@ -331,7 +333,7 @@ describe("authoritative setup readiness", () => {
     expect(setupReady(useEnduragentStore.getState())).toBe(true);
     expect(readinessBadge()).toHaveTextContent("3 of 3 required ready");
     expect(readinessBadge()).toHaveAttribute("data-state", "ready");
-    const injury = control<HTMLSelectElement>("onboarding-injury-status");
+    const injury = control<HTMLButtonElement>("onboarding-injury-status");
     expect(injury).toBeDisabled();
     expect(control<HTMLButtonElement>("setup-panel-title").closest("section")).toHaveAttribute(
       "aria-busy",
@@ -407,7 +409,7 @@ describe("authoritative setup readiness", () => {
       expect(document.querySelector("[data-setup-card]")).not.toBeNull();
       expect(document.querySelector('[data-setup-trigger="ai"]')).toBeNull();
       expect(document.querySelector('[data-setup-trigger="training"]')).toBeNull();
-      expect(control<HTMLSelectElement>("onboarding-injury-status")).toBeDisabled();
+      expect(control<HTMLButtonElement>("onboarding-injury-status")).toBeDisabled();
       expect(screen.queryByRole("button", { name: "Start coaching" })).toBeNull();
 
       setupReadFails = false;
@@ -424,7 +426,7 @@ describe("authoritative setup readiness", () => {
       expect(
         document.querySelector<HTMLButtonElement>('[data-setup-trigger="training"]'),
       ).toBeEnabled();
-      expect(control<HTMLSelectElement>("onboarding-injury-status")).toBeEnabled();
+      expect(control<HTMLButtonElement>("onboarding-injury-status")).toBeEnabled();
       wizard.controller.dispose();
     } finally {
       vi.useRealTimers();
@@ -580,6 +582,7 @@ describe("authoritative setup readiness", () => {
   );
 
   it("counts an answered injury status before it is persisted, so the badge agrees with the primary action", async () => {
+    const user = userEvent.setup();
     const bridge = testBridge(async () => ({ status: "refused", reason: "cancelled" }));
     bridge.chatGptStatus.mockResolvedValue({ state: "configured", runtimeReady: true });
     bridge.getSetupStatus = vi.fn(async () => ({
@@ -593,9 +596,7 @@ describe("authoritative setup readiness", () => {
     expect(readinessBadge()).toHaveTextContent("2 of 3 required ready");
     expect(screen.getByRole("button", { name: "Start coaching" })).toBeDisabled();
 
-    fireEvent.change(control<HTMLSelectElement>("onboarding-injury-status"), {
-      target: { value: "none" },
-    });
+    await selectSetupOption(user, "onboarding-injury-status", "none");
 
     expect(useEnduragentStore.getState().onboarding.readiness.intake).toBe(false);
     expect(readinessBadge()).toHaveTextContent("3 of 3 required ready");

--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -215,15 +215,26 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
         setter?.call(input, value);
         input.dispatchEvent(new Event("input", { bubbles: true }));
       };
-      const pick = (id, value) => {
-        const select = document.querySelector("#" + id);
-        if (!select) return;
-        const setter = Object.getOwnPropertyDescriptor(
-          HTMLSelectElement.prototype,
-          "value",
-        )?.set;
-        setter?.call(select, value);
-        select.dispatchEvent(new Event("change", { bubbles: true }));
+      const pick = async (id, label) => {
+        const trigger = document.querySelector("#" + id);
+        if (!(trigger instanceof HTMLButtonElement)) {
+          throw new Error("missing select trigger " + id);
+        }
+        trigger.click();
+        const optionsDeadline = Date.now() + 10000;
+        let option;
+        while (option === undefined && Date.now() < optionsDeadline) {
+          option = Array.from(document.querySelectorAll('[role="option"]')).find(
+            (entry) => entry.textContent?.trim() === label,
+          );
+          if (option === undefined) {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+          }
+        }
+        if (!(option instanceof HTMLElement)) {
+          throw new Error("missing select option " + label);
+        }
+        option.click();
       };
       document.querySelector('[data-setup-trigger="ai"]')?.click();
       await waitFor('[data-lane="api-key"]');
@@ -241,7 +252,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
         throw new Error("unexpected Intervals.icu credential input");
       }
       await waitFor('[data-setup-readiness="2"]');
-      pick("onboarding-injury-status", "none");
+      await pick("onboarding-injury-status", "No current injury");
       await new Promise((resolve) => setTimeout(resolve, 60));
       button("Start coaching")?.click();
       const chatDeadline = Date.now() + 10000;


### PR DESCRIPTION
## Summary
- replace the four onboarding native selects with the shared shadcn/Base UI select
- preserve provider, model, endpoint, and injury-state behavior
- normalize onboarding typography to the new UI scale

## Verification
- `pnpm --filter @enduragent/desktop-renderer check`
- `pnpm --filter @enduragent/desktop-renderer test` — 57 files, 915 tests passed
- `pnpm --filter @enduragent/desktop-renderer build`
- `pnpm check` — passed with 19 existing warnings
- autoreview — clean

## Limits
- none