### PR TITLE
refactor: migrate ride reviews to Tailwind

### DIFF
--- a/.changeset/ui-training-ride-tailwind.md
+++ b/.changeset/ui-training-ride-tailwind.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Updated ride lists, ride summaries, intervals, and best-effort analysis to the new interface system.

--- a/apps/desktop-renderer/src/ui/training/RideReview.tsx
+++ b/apps/desktop-renderer/src/ui/training/RideReview.tsx
@@ -8,11 +8,12 @@ import type {
 } from "@enduragent/coach-contract";
 import type { ReactElement, ReactNode, Ref } from "react";
 import type { RideAnalysisViewState } from "../../activity-analysis/controller.js";
+import { Button } from "../../components/ui/button.js";
 import { formatDateLabel } from "../../training-context/format.js";
 import { Page } from "../shared/Page.js";
 import { analysisRefreshFailureCopy, analysisUnavailableCopy } from "./copy.js";
 import { RideResponseReview } from "./RideResponseReview.js";
-import styles from "./TrainingView.module.css";
+import { rideStyles as styles } from "./rideStyles.js";
 import { ActivityExportControl } from "./TrainingExportControls.js";
 
 const RIDE_KIND: Readonly<Record<string, string>> = {
@@ -248,9 +249,9 @@ function AerobicDriftPanel(props: {
       <div className={styles.analysisUnavailable}>
         <p>{analysisUnavailableCopy(section.reason)}</p>
         {props.onRefresh !== null && shouldOfferRetry(section.reason) ? (
-          <button type="button" className={styles.action} onClick={props.onRefresh}>
+          <Button type="button" variant="outline" onClick={props.onRefresh}>
             Try again
-          </button>
+          </Button>
         ) : null}
       </div>
     );
@@ -259,9 +260,9 @@ function AerobicDriftPanel(props: {
       <div className={styles.analysisUnavailable}>
         <p>The ride could not be analyzed right now.</p>
         {props.onRefresh === null ? null : (
-          <button type="button" className={styles.action} onClick={props.onRefresh}>
+          <Button type="button" variant="outline" onClick={props.onRefresh}>
             Try again
-          </button>
+          </Button>
         )}
       </div>
     );
@@ -444,9 +445,9 @@ function AnalysisRetry(props: {
           : analysisUnavailableCopy(props.reason)}
       </p>
       {props.onRefresh !== null && retry ? (
-        <button type="button" className={styles.action} onClick={props.onRefresh}>
+        <Button type="button" variant="outline" onClick={props.onRefresh}>
           Try again
-        </button>
+        </Button>
       ) : null}
     </div>
   );
@@ -724,11 +725,12 @@ export function RecentRidesStatePanel(props: {
               const distance = rideDistance(ride, props.units);
               return (
                 <li key={ride.id} className={styles.rideListItem}>
-                  <button
+                  <Button
                     ref={(node) => {
                       props.registerButton(ride.id, node);
                     }}
                     type="button"
+                    variant="ghost"
                     className={styles.rideButton}
                     aria-label={`Review ${rideKind(ride).toLowerCase()} from ${dateTime}, ${duration}, ${distance}`}
                     onClick={() => {
@@ -747,7 +749,7 @@ export function RecentRidesStatePanel(props: {
                     <span className={styles.rideArrow} aria-hidden="true">
                       →
                     </span>
-                  </button>
+                  </Button>
                 </li>
               );
             })}
@@ -772,9 +774,9 @@ export function RideDetailView(props: {
       subtitle={formatDateLabel(props.ride.localDate)}
       titleRef={props.titleRef}
       action={
-        <button type="button" className={styles.detailBack} onClick={props.onBack}>
+        <Button type="button" variant="outline" onClick={props.onBack}>
           Back to training
-        </button>
+        </Button>
       }
     >
       <section className={styles.rideOverview} aria-labelledby="ride-overview-title">

--- a/apps/desktop-renderer/src/ui/training/rideStyles.ts
+++ b/apps/desktop-renderer/src/ui/training/rideStyles.ts
@@ -1,0 +1,80 @@
+import { overviewStyles } from "./overviewStyles.js";
+
+export const rideStyles = {
+  ...overviewStyles,
+  ridePanelHeading:
+    "flex items-baseline justify-between gap-3 [&>span]:text-xs [&>span]:font-medium [&>span]:text-ink-3",
+  rideList: "m-0 list-none p-0",
+  rideListItem: "border-line [&+&]:border-t",
+  rideButton:
+    "group/ride grid h-auto w-full min-w-0 grid-cols-[12px_minmax(0,1fr)_auto_18px] gap-2.5 rounded-ctl px-2 py-3 text-left hover:bg-[color-mix(in_srgb,var(--ink)_5%,transparent)] max-[760px]:grid-cols-[12px_minmax(0,1fr)_18px]",
+  rideRail:
+    "relative h-[38px] w-0.5 justify-self-center bg-line before:absolute before:top-[3px] before:left-1/2 before:size-1.5 before:-translate-x-1/2 before:rounded-full before:bg-ink before:content-['']",
+  ridePrimary:
+    "grid min-w-0 gap-1 [&_strong]:[overflow-wrap:anywhere] [&_strong]:text-sm [&_strong]:font-semibold [&_time]:text-xs [&_time]:text-ink-3",
+  rideStats:
+    "grid grid-cols-[minmax(58px,auto)_minmax(68px,auto)] gap-3 text-right text-xs text-ink-2 tabular-nums max-[760px]:col-start-2 max-[760px]:grid-cols-[auto_auto] max-[760px]:justify-start max-[760px]:text-left",
+  rideArrow:
+    "text-sm text-ink-3 transition-transform group-hover/ride:translate-x-0.5 motion-reduce:transition-none max-[760px]:col-start-3 max-[760px]:row-span-2 max-[760px]:row-start-1",
+  rideOverview:
+    "rounded-card border border-line bg-surface p-5 shadow-elev-1 [&_h2]:m-0 [&_h2]:text-2xl [&_h2]:leading-7 [&_h2]:font-semibold [&_h2]:tracking-normal",
+  analysisPanel: overviewStyles.analysisPanel,
+  analysisHeading:
+    "flex items-start justify-between gap-4 [&_h2]:m-0 [&_h2]:text-xl [&_h2]:leading-6 [&_h2]:font-semibold [&_h2]:tracking-normal",
+  analysisTitle: overviewStyles.analysisTitle,
+  analysisIntro: overviewStyles.analysisIntro,
+  analysisLoading:
+    "mt-5 text-sm leading-[1.5] text-ink-2",
+  analysisUnavailable:
+    "[&_p]:mt-5 [&_p]:text-sm [&_p]:leading-[1.5] [&_p]:text-ink-2 [&_[data-slot=button]]:mt-3",
+  analysisNotice:
+    "mt-[18px] border-l-[3px] border-warn bg-[color-mix(in_srgb,var(--warn)_var(--tint),transparent)] px-[11px] py-[9px] text-xs leading-[1.5] text-ink-2",
+  analysisRefresh: "mt-4 text-xs leading-[1.5] text-ink-2",
+  driftReading:
+    "mt-[22px] flex min-w-0 items-end justify-between gap-[22px] border-l-2 border-ink pl-[13px] max-[520px]:grid max-[520px]:items-start",
+  driftValue: "m-0 text-2xl leading-8 font-semibold tracking-normal tabular-nums",
+  driftContext:
+    "grid min-w-0 justify-items-end gap-1.5 text-right max-[520px]:justify-items-start max-[520px]:text-left [&_p]:m-0 [&_p]:text-xs [&_p]:text-ink-3",
+  driftEvidenceBadge:
+    "inline-flex h-5 shrink-0 items-center justify-center gap-1 rounded-chip bg-surface-2 px-1.5 text-xs font-medium text-ink-2 data-[evidence=limited]:bg-[color-mix(in_srgb,var(--warn)_var(--tint),transparent)] data-[evidence=limited]:text-warn",
+  driftTrace:
+    "mt-[18px] grid grid-cols-[minmax(0,1fr)_28px_minmax(0,1fr)] items-stretch gap-2 max-[520px]:grid-cols-1",
+  driftHalf:
+    "min-w-0 rounded-card bg-sunk px-3.5 py-[13px] [&_h3]:m-0 [&_h3]:text-xs [&_h3]:font-semibold [&_h3]:text-ink-3",
+  driftEf: "mt-2.5 text-lg leading-5 font-semibold tabular-nums",
+  driftHalfStats: "mt-[7px] text-xs leading-[1.4] text-ink-2 tabular-nums",
+  driftHalfMeta:
+    "mt-1 [overflow-wrap:anywhere] text-xs leading-[1.4] text-ink-3 tabular-nums",
+  driftConnector:
+    "relative isolate grid place-items-center text-sm text-ink-3 before:absolute before:right-0 before:left-0 before:-z-10 before:h-px before:bg-line before:content-[''] max-[520px]:h-[18px] max-[520px]:rotate-90",
+  driftCoverage:
+    "mt-[13px] [overflow-wrap:anywhere] text-xs leading-[1.5] text-ink-3 tabular-nums",
+  driftLimitations:
+    "mt-[13px] grid gap-[5px] pl-[18px] text-xs leading-[1.45] text-ink-2",
+  analysisSource: "mt-[17px] text-xs leading-[1.5] text-ink-3",
+  analysisEmpty: "mt-4 text-sm leading-[1.5] text-ink-2",
+  intervalList: "mt-3.5 grid list-none gap-[9px] p-0",
+  intervalGroups:
+    "mt-4 [&>h3]:m-0 [&>h3]:text-sm [&>h3]:font-semibold [&>p]:mt-1 [&>p]:text-xs [&>p]:leading-[1.45] [&>p]:text-ink-3",
+  intervalGroupList: "mt-2.5 grid list-none gap-[9px] p-0",
+  intervalGroupItem: "grid min-w-0 gap-3 rounded-card bg-sunk px-3.5 py-3",
+  intervalGroupIdentity:
+    "flex min-w-0 items-end justify-between gap-3 max-[520px]:flex-col max-[520px]:items-start [&>div]:grid [&>div]:min-w-0 [&>div]:gap-[3px] [&_span]:text-xs [&_span]:text-ink-3 [&_strong]:text-sm [&_strong]:font-semibold [&_p]:m-0 [&_p]:[overflow-wrap:anywhere] [&_p]:text-right [&_p]:text-xs [&_p]:leading-[1.3] [&_p]:text-ink-3 max-[520px]:[&_p]:text-left",
+  intervalItem:
+    "grid min-w-0 grid-cols-[minmax(155px,0.72fr)_minmax(0,1.6fr)] items-center gap-4 rounded-card border-l-[3px] border-line-2 bg-sunk px-3.5 py-[13px] data-[kind=recovery]:border-l-ink-3 data-[kind=work]:border-l-brand max-[760px]:grid-cols-1",
+  intervalIdentity:
+    "grid min-w-0 grid-cols-[27px_minmax(0,1fr)] items-start gap-2.5 [&_h3]:mt-1 [&_h3]:[overflow-wrap:anywhere] [&_h3]:text-sm [&_h3]:font-semibold [&_p]:mt-1 [&_p]:text-xs [&_p]:leading-[1.3] [&_p]:text-ink-3",
+  intervalOrdinal:
+    "grid size-[25px] place-items-center rounded-full border border-line-2 text-xs text-ink-2 tabular-nums",
+  intervalKind: "text-xs text-ink-3",
+  intervalMetrics:
+    "m-0 grid min-w-0 grid-cols-4 gap-2.5 max-[760px]:grid-cols-2 max-[520px]:grid-cols-1 [&>div]:min-w-0 [&_dt]:text-xs [&_dt]:text-ink-3 [&_dd]:mt-[5px] [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-xs [&_dd]:leading-[1.4] [&_dd]:text-ink-2 [&_dd]:tabular-nums",
+  effortList:
+    "mt-3.5 grid list-none grid-cols-3 gap-[9px] p-0 max-[760px]:grid-cols-2 max-[520px]:grid-cols-1 [&_strong]:text-xl [&_strong]:leading-[1.1] [&_strong]:font-semibold [&_strong]:tabular-nums",
+  effortItem:
+    "grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-2.5 gap-y-[5px] rounded-card bg-sunk px-3.5 py-[13px] [&>span:last-child]:[overflow-wrap:anywhere] [&>span:last-child]:text-xs [&>span:last-child]:leading-[1.4] [&>span:last-child]:text-ink-3",
+  effortRank: "row-span-2 row-start-1 text-xs text-ink-3",
+  rideEyebrow: "mb-2 text-xs font-medium text-ink-3",
+  rideSummary:
+    "mt-[22px] grid grid-cols-3 border-t border-line max-[520px]:grid-cols-1 [&>div]:min-w-0 [&>div]:pt-3.5 [&>div]:pr-3.5 [&_dt]:mb-[5px] [&_dt]:text-xs [&_dt]:font-medium [&_dt]:text-ink-3 [&_dd]:m-0 [&_dd]:[overflow-wrap:anywhere] [&_dd]:text-xs [&_dd]:leading-[1.45] [&_dd]:text-ink [&_dd]:tabular-nums",
+} as const;


### PR DESCRIPTION
## Summary

- migrate ride review cards and related training panels to Tailwind utilities
- reuse the shared Button primitive for ride-review actions
- remove the migrated ride styling from the legacy module

## Verification

- desktop renderer TypeScript check
- 28 focused training tests
- full renderer suite: 57 files passed
- desktop renderer production build
- root pnpm check
- autoreview clean