### PR TITLE
fix: repair desktop UI layout regressions

### DIFF
--- a/.changeset/ui-layout-regressions.md
+++ b/.changeset/ui-layout-regressions.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Fixed overlapping and clipped desktop controls in compact layouts.
+
+Restored palette swatch sizing, archive row flow, release-note centering, and opaque chat controls.

--- a/apps/desktop-renderer/src/lib/utils.ts
+++ b/apps/desktop-renderer/src/lib/utils.ts
@@ -1,6 +1,16 @@
 import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+const mergeTailwindClasses = extendTailwindMerge({
+  extend: {
+    theme: {
+      radius: ["chip", "ctl", "card"],
+      shadow: ["elev-1", "elev-2", "elev-3", "elev-4"],
+      spacing: ["ctl", "ctl-sm", "ctl-lg", "ctl-px", "ctl-px-sm", "ctl-px-lg", "inset", "row"],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]): string {
-  return twMerge(clsx(inputs));
+  return mergeTailwindClasses(clsx(inputs));
 }

--- a/apps/desktop-renderer/src/ui/archive/ArchiveView.tsx
+++ b/apps/desktop-renderer/src/ui/archive/ArchiveView.tsx
@@ -92,7 +92,8 @@ function ArchiveList(): ReactElement {
             key={entry.boundaryRef}
             type="button"
             variant="outline"
-            className="archive-entry grid h-auto w-full justify-items-start gap-1 rounded-card border-line bg-surface px-3.5 py-3 text-left shadow-elev-1 transition-colors hover:border-line-2 hover:bg-surface-2 active:shadow-none"
+            className="archive-entry grid h-auto w-full grid-cols-1 items-start justify-start justify-items-start gap-1 whitespace-normal rounded-card border-line bg-surface px-3.5 py-3 text-left font-normal shadow-elev-1 transition-colors hover:border-line-2 hover:bg-surface-2 active:shadow-none"
+            aria-label={`${archiveTimestampCopy(entry.boundaryAt)} · ${archiveTurnCountCopy(entry.turnCount)} · ${archiveReasonCopy(entry.reason)}`}
             disabled={actions === null}
             onClick={() => {
               actions?.open(entry.boundaryRef);
@@ -188,11 +189,7 @@ function ArchiveReader(props: { readonly reading: ArchiveReadingState }): ReactE
       >
         {ARCHIVE_EMPTY_CONVERSATION_COPY}
       </p>
-      <section
-        className="archive-thread grid gap-6"
-        aria-label="Past conversation"
-        aria-live="off"
-      >
+      <section className="archive-thread grid gap-6" aria-label="Past conversation" aria-live="off">
         {reading.turns.map((turn) => (
           <TurnRows key={turn.turnId} turn={turn} />
         ))}

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -110,7 +110,7 @@ export function ChatView(): ReactElement {
         </div>
       </main>
       <div
-        className="composer-wrap sticky bottom-0 z-2 col-start-1 row-start-2 self-end bg-[linear-gradient(transparent,var(--bg)_28%)] px-[max(24px,calc((100%-48px-840px)/2))] pt-3 pb-[18px] max-[760px]:px-4"
+        className="composer-wrap sticky bottom-0 z-2 col-start-1 row-start-2 self-end bg-bg bg-[linear-gradient(transparent,var(--bg)_28%)] px-[max(24px,calc((100%-48px-840px)/2))] pt-3 pb-[18px] max-[760px]:px-4"
         ref={composerWrap}
       >
         <div className="chat-notice-host empty:hidden">

--- a/apps/desktop-renderer/src/ui/settings/PalettePicker.tsx
+++ b/apps/desktop-renderer/src/ui/settings/PalettePicker.tsx
@@ -19,7 +19,7 @@ export function PalettePicker(): ReactElement {
           key={palette.id}
           type="button"
           variant="ghost"
-          className="flex h-auto cursor-pointer flex-col gap-1.5 rounded-ctl border-0 bg-transparent p-0 font-inherit"
+          className="flex h-auto cursor-pointer flex-col items-stretch gap-1.5 rounded-ctl border-0 bg-transparent p-0 font-inherit"
           aria-pressed={palette.id === paletteId}
           aria-label={`Use the ${palette.name} palette`}
           onClick={() => {

--- a/apps/desktop-renderer/src/ui/settings/styles.ts
+++ b/apps/desktop-renderer/src/ui/settings/styles.ts
@@ -33,7 +33,7 @@ export const settingsStyles = {
   capLabel: "min-w-0 flex-1 text-sm font-semibold",
   srOnly: "sr-only",
   dialog:
-    "new-settings-dialog w-[min(520px,calc(100vw-48px))] max-w-none max-h-[min(70vh,620px)] rounded-card border border-line-2 bg-surface p-5 text-ink shadow-elev-4 backdrop:bg-[var(--scrim)]",
+    "new-settings-dialog m-auto w-[min(520px,calc(100vw-48px))] max-w-none max-h-[min(70vh,620px)] rounded-card border border-line-2 bg-surface p-5 text-ink shadow-elev-4 backdrop:bg-[var(--scrim)]",
   dialogHeader: "flex items-baseline justify-between gap-3 [&_h2]:m-0 [&_h2]:text-[15px]",
   dialogContent: "mt-3 text-[13.5px] text-ink-2 [&_ol]:m-0 [&_ol]:pl-5 [&_li]:mb-1.5",
   dialogActions:

--- a/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/SyncChip.tsx
@@ -59,7 +59,7 @@ export function SyncChip(): ReactElement {
 
   return (
     <div
-      className="relative flex min-h-ctl w-full items-center gap-2 px-row py-1.5 text-left text-xs font-normal text-ink-2"
+      className="relative flex min-h-ctl min-w-0 w-full items-center gap-2 px-row py-1.5 text-left text-xs font-normal text-ink-2"
       data-sync-chip=""
       data-status={status}
     >
@@ -136,7 +136,10 @@ export function SyncChip(): ReactElement {
           />
         )}
       </span>
-      <span className="pointer-events-none relative z-[1] flex-none text-xs text-ink-3" aria-hidden="true">
+      <span
+        className="pointer-events-none relative z-[1] flex-none text-xs text-ink-3 max-[860px]:hidden"
+        aria-hidden="true"
+      >
         {sync.label}
       </span>
     </div>

--- a/apps/desktop-renderer/tests/archive-surface.test.tsx
+++ b/apps/desktop-renderer/tests/archive-surface.test.tsx
@@ -122,6 +122,18 @@ describe("past chats list", () => {
     const region = screen.getByRole("region", { name: "Past chats" });
     const entries = region.querySelectorAll("button.archive-entry");
     expect(entries).toHaveLength(2);
+    expect(entries[0]).toHaveClass(
+      "h-auto",
+      "grid-cols-1",
+      "items-start",
+      "justify-start",
+      "whitespace-normal",
+      "font-normal",
+    );
+    expect(entries[0]).not.toHaveClass("h-ctl", "justify-center", "whitespace-nowrap");
+    expect(entries[0]).toHaveAccessibleName(
+      "1998-07-19 08:15 UTC · 3 messages · You started a new conversation",
+    );
     expect(entries[0]).toHaveTextContent("1998-07-19 08:15 UTC");
     expect(entries[0]).toHaveTextContent("3 messages");
     expect(entries[1]).toHaveTextContent("1 message");

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -161,6 +161,7 @@ describe("chat surface", () => {
 
       expect(form?.nextElementSibling).toBe(disclaimer);
       expect(disclaimer.parentElement).toHaveClass("composer-wrap");
+      expect(disclaimer.parentElement).toHaveClass("bg-bg");
     });
 
     it("focuses the enabled composer when Chat mounts after required setup", () => {

--- a/apps/desktop-renderer/tests/lib-utils.test.ts
+++ b/apps/desktop-renderer/tests/lib-utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "../src/lib/utils.js";
+
+describe("Tailwind class merging", () => {
+  it("lets later utilities override app theme tokens", () => {
+    expect(cn("h-ctl", "h-auto")).toBe("h-auto");
+    expect(cn("px-ctl-px", "p-0")).toBe("p-0");
+    expect(cn("rounded-ctl", "rounded-none")).toBe("rounded-none");
+    expect(cn("shadow-elev-1", "shadow-none")).toBe("shadow-none");
+  });
+
+  it("keeps the last app token from each theme group", () => {
+    expect(cn("gap-inset", "gap-row")).toBe("gap-row");
+    expect(cn("rounded-chip", "rounded-card")).toBe("rounded-card");
+    expect(cn("shadow-elev-1", "shadow-elev-4")).toBe("shadow-elev-4");
+  });
+});

--- a/apps/desktop-renderer/tests/settings-preferences.test.tsx
+++ b/apps/desktop-renderer/tests/settings-preferences.test.tsx
@@ -21,6 +21,11 @@ describe("settings preferences", () => {
 
     const swatches = screen.getAllByRole("button", { name: /^Use the .+ palette$/u });
     expect(swatches).toHaveLength(PALETTES.length);
+    for (const swatch of swatches) {
+      expect(swatch).toHaveClass("h-auto", "items-stretch");
+      expect(swatch).not.toHaveClass("h-ctl");
+      expect(swatch.firstElementChild).toHaveClass("h-10");
+    }
     expect(screen.getByRole("button", { name: "Use the Patrol palette" })).toHaveAttribute(
       "aria-pressed",
       "true",

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -1652,7 +1652,9 @@ describe("coach route", () => {
     expect(label).not.toBeNull();
     expect(label).toHaveClass("settings-label", "flex", "min-w-0", "flex-1", "flex-col");
     expect(label?.querySelector(".settings-row-title")?.textContent).toBe("Provider");
-    expect(label?.querySelector(".settings-row-detail")?.textContent).toMatch(/^Currently active: /u);
+    expect(label?.querySelector(".settings-row-detail")?.textContent).toMatch(
+      /^Currently active: /u,
+    );
   });
 });
 
@@ -1716,6 +1718,7 @@ describe("application section", () => {
 
     await user.click(screen.getByRole("button", { name: "What’s new" }));
     const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveClass("m-auto");
     expect(
       await within(dialog).findByText(
         "Release notes aren’t available right now. Check your connection and try again.",

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -265,7 +265,9 @@ describe("sidebar sync chip", () => {
     render(<Sidebar />);
 
     expect(chip()).toHaveAttribute("data-status", "loading");
+    expect(chipSurface()).toHaveClass("min-w-0");
     expect(chipSurface()).toHaveTextContent("Loading training data");
+    expect(screen.getByText("Sync now")).toHaveClass("max-[860px]:hidden");
 
     update({
       training: {

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -452,7 +452,10 @@ ${"nonwrapping".repeat(36)}
             published: partial,
             referenceSucceeded: !partial,
             requests: { store: 1, reference: 1, total: 2 },
-            droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+            droppedActivities: {
+              overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+              recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+            },
           }),
         ];
       }
@@ -1122,6 +1125,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly draft: string;
       readonly documentOverflow: boolean;
       readonly composerHeight: number;
+      readonly composerOpaque: boolean;
       readonly composerClearanceTracksHeight: boolean;
       readonly finalTranscriptClearsComposer: boolean;
     }>(`
@@ -1181,6 +1185,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         draft: textarea.value,
         documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
         composerHeight: composerRect.height,
+        composerOpaque: getComputedStyle(composer).backgroundColor !== "rgba(0, 0, 0, 0)",
         composerClearanceTracksHeight: Math.abs(reservedBottom - composerRect.height) < 1,
         finalTranscriptClearsComposer:
           finalTranscriptItem.getBoundingClientRect().bottom <= composerRect.top + 1,
@@ -1197,6 +1202,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       draft: "  keep draft\n",
       documentOverflow: false,
       composerHeight: expect.any(Number),
+      composerOpaque: true,
       composerClearanceTracksHeight: true,
       finalTranscriptClearsComposer: true,
     });
@@ -1207,6 +1213,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly tableScrollsLocally: boolean;
       readonly codeScrollsLocally: boolean;
       readonly shortcutsWrapped: boolean;
+      readonly composerOpaque: boolean;
       readonly composerHeight: number;
       readonly composerClearanceTracksHeight: boolean;
       readonly finalTranscriptClearsComposer: boolean;
@@ -1229,6 +1236,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
           tableScrollsLocally: tableScroll.scrollWidth > tableScroll.clientWidth && getComputedStyle(tableScroll).overflowX === "auto",
           codeScrollsLocally: codeBlock.scrollWidth > codeBlock.clientWidth && getComputedStyle(codeBlock).overflowX === "auto",
           shortcutsWrapped: shortcutGroup.getBoundingClientRect().height > firstShortcut.getBoundingClientRect().height,
+          composerOpaque: getComputedStyle(composer).backgroundColor !== "rgba(0, 0, 0, 0)",
           composerHeight: composerRect.height,
           composerClearanceTracksHeight: Math.abs(reservedBottom - composerRect.height) < 1,
           finalTranscriptClearsComposer:
@@ -1240,6 +1248,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       tableScrollsLocally: true,
       codeScrollsLocally: true,
       shortcutsWrapped: true,
+      composerOpaque: true,
       composerHeight: expect.any(Number),
       composerClearanceTracksHeight: true,
       finalTranscriptClearsComposer: true,
@@ -1672,6 +1681,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly settingsReachable: boolean;
       readonly settingsAccessibleLabel: string;
       readonly chipReachable: boolean;
+      readonly syncFitsRail: boolean;
+      readonly syncHasNoOverflow: boolean;
+      readonly syncActionHidden: boolean;
       readonly trainingOpen: boolean;
       readonly buttonResident: boolean;
       readonly buttonReachable: boolean;
@@ -1695,11 +1707,16 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       const compactButton = page.querySelector(".training-sync-action");
       const compactStatus = page.querySelector(".training-sync-message");
       const chip = document.querySelector(".sync-chip");
+      const syncSurface = document.querySelector("[data-sync-chip]");
+      const sidebar = syncSurface.closest("aside");
+      const syncAction = syncSurface.lastElementChild;
       const pageRect = page.getBoundingClientRect();
       const buttonRect = compactButton.getBoundingClientRect();
       const railRect = rail.getBoundingClientRect();
       const settingsRect = settings.getBoundingClientRect();
       const chipRect = chip.getBoundingClientRect();
+      const syncRect = syncSurface.getBoundingClientRect();
+      const sidebarRect = sidebar.getBoundingClientRect();
       compactButton.scrollIntoView({ block: "nearest" });
       return {
         documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
@@ -1714,6 +1731,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
           chipRect.left >= 0 &&
           chipRect.right <= window.innerWidth &&
           chipRect.bottom <= window.innerHeight,
+        syncFitsRail:
+          syncRect.left >= sidebarRect.left && syncRect.right <= sidebarRect.right,
+        syncHasNoOverflow: syncSurface.scrollWidth <= syncSurface.clientWidth,
+        syncActionHidden: getComputedStyle(syncAction).display === "none",
         trainingOpen: page.getAttribute("aria-hidden") === null,
         buttonResident: page.querySelectorAll(".training-sync-action").length === 1,
         buttonReachable:
@@ -1734,6 +1755,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       settingsReachable: true,
       settingsAccessibleLabel: "Settings",
       chipReachable: true,
+      syncFitsRail: true,
+      syncHasNoOverflow: true,
+      syncActionHidden: true,
       trainingOpen: true,
       buttonResident: true,
       buttonReachable: true,
@@ -1754,6 +1778,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly scrolled: boolean;
       readonly resetWarningVisible: boolean;
       readonly retentionWarningVisible: boolean;
+      readonly paletteSwatchesFillButtons: boolean;
     }>(`
       const settings = Array.from(
         document.querySelectorAll('nav[aria-label="Main navigation"] button'),
@@ -1789,6 +1814,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       const scrollRect = scroll.getBoundingClientRect();
       const subpixelTolerance = 1;
       const copy = page.textContent;
+      const paletteButtons = Array.from(
+        page.querySelectorAll('button[aria-label^="Use the "][aria-label$=" palette"]'),
+      );
       return {
         open: page.getAttribute("aria-hidden") === null,
         onePage: document.querySelectorAll('section[aria-label="Settings"]').length === 1,
@@ -1819,6 +1847,15 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
           "may make your next message start a fresh conversation",
         ),
         retentionWarningVisible: copy.includes("changes apply only to future pruning"),
+        paletteSwatchesFillButtons:
+          paletteButtons.length > 0 &&
+          paletteButtons.every((button) => {
+            const swatch = button.firstElementChild;
+            return (
+              swatch !== null &&
+              Math.abs(swatch.getBoundingClientRect().width - button.getBoundingClientRect().width) < 1
+            );
+          }),
       };
     `);
     expect(compactSettingsGeometry).toEqual({
@@ -1831,7 +1868,29 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       scrolled: true,
       resetWarningVisible: true,
       retentionWarningVisible: true,
+      paletteSwatchesFillButtons: true,
     });
+    const releaseDialogCentered = await fixture.evaluate<boolean>(`
+      const settingsPage = document.querySelector('section[aria-label="Settings"]');
+      const releaseNotesButton = Array.from(settingsPage.querySelectorAll("button")).find(
+        (entry) => entry.textContent.trim() === "What’s new",
+      );
+      releaseNotesButton.click();
+      const deadline = Date.now() + 2000;
+      let dialog = document.querySelector("dialog.new-settings-dialog[open]");
+      while (dialog === null && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        dialog = document.querySelector("dialog.new-settings-dialog[open]");
+      }
+      if (dialog === null) throw new Error("release notes dialog did not open");
+      const rect = dialog.getBoundingClientRect();
+      const centered =
+        Math.abs(rect.left + rect.width / 2 - window.innerWidth / 2) <= 1 &&
+        Math.abs(rect.top + rect.height / 2 - window.innerHeight / 2) <= 1;
+      dialog.querySelector('button[aria-label="Close release notes"]').click();
+      return centered;
+    `);
+    expect(releaseDialogCentered).toBe(true);
     const runtimeReads = calls.filter((call) => call.method === "getRuntimeConfig");
     expect(runtimeReads.length).toBeGreaterThan(runtimeReadsBeforeSettings);
     expect(runtimeReads).toEqual(


### PR DESCRIPTION
## Summary

- Restore full-width palette swatches and contained, left-aligned archive rows.
- Center the release-notes dialog and keep the chat footer opaque.
- Keep the sidebar sync status inside the rail at minimum window width.
- Teach the shared Tailwind class merger about app theme tokens.

## Verification

- `pnpm check`
- Renderer tests: 59 files, 924 tests passed.
- Desktop tests: 104 files and 2,028 tests passed; the repository-root Windows parity suite passed 30 tests.
- Focused real Electron geometry scenario passed.
- Manual Electron QA passed at normal and minimum window widths.
- Three fresh read-only reviews and autoreview returned no findings.

## Limits

None.