### PR TITLE
fix(desktop): allow full reset during repair

### DIFF
--- a/.changeset/repair-safe-credential-reset.md
+++ b/.changeset/repair-safe-credential-reset.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Fixed “Remove all credentials” after an uncertain credential deletion.
+
+The explicit full reset now bypasses the per-credential repair lock while other destructive actions remain blocked.

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -637,10 +637,11 @@ export function createCredentialSettingsController(input: {
       return operation ?? Promise.resolve();
     }
     const content = contentState();
-    if (content === null || content.repairCredential !== null || content.confirmation === null) {
+    if (content === null || content.confirmation === null) {
       return Promise.resolve();
     }
     if (content.confirmation === "all") return confirmReset();
+    if (content.repairCredential !== null) return Promise.resolve();
     const target = content.entries.find((entry) => entry.credential === content.confirmation);
     if (target === undefined) return Promise.resolve();
     const releaseMutation = input.beginMutation();

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -632,6 +632,43 @@ describe("credential settings controller", () => {
     expect(content(controller.state()).repairCredential).toBeNull();
   });
 
+  it("allows confirmed removal of all credentials while a per-slot deletion needs repair", async () => {
+    const { controller, subject, resetAllCredentials } = createSubject({
+      deletion: {
+        slot: "anthropic",
+        status: "uncertain",
+        reason: "storage-uncertain",
+      },
+    });
+    await controller.activate();
+
+    subject.requestDelete("anthropic");
+    subject.confirmDelete();
+    await vi.waitFor(() =>
+      expect(controller.state()).toMatchObject({
+        status: "error",
+        repairCredential: "anthropic",
+      }),
+    );
+
+    subject.requestReset();
+    expect(controller.state()).toMatchObject({
+      status: "confirming",
+      confirmation: "all",
+      repairCredential: "anthropic",
+    });
+    subject.confirmDelete();
+
+    await vi.waitFor(() => expect(controller.state().status).toBe("deleted"));
+    expect(resetAllCredentials).toHaveBeenCalledOnce();
+    expect(controller.state()).toMatchObject({
+      status: "deleted",
+      entries: [],
+      confirmation: null,
+      repairCredential: null,
+    });
+  });
+
   it("treats a rejected delete request as an unknown outcome that requires repair", async () => {
     const { controller, subject, deleteCredential } = createSubject({
       deleteCredential: async () => {


### PR DESCRIPTION
## Summary

- Allow the explicit `Remove all credentials` confirmation to proceed while a per-credential repair lock is active.
- Keep the repair lock blocking every per-slot destructive action.
- Add regression coverage for uncertain deletion followed by full credential reset.

## Verification

- `pnpm --filter @enduragent/desktop-renderer test -- credential-settings.test.ts` — 56 files, 922 tests passed
- `pnpm --filter @enduragent/desktop-renderer check`
- `pnpm exec oxfmt --check apps/desktop-renderer/src/settings/credential-controller.ts apps/desktop-renderer/tests/credential-settings.test.ts`
- `pnpm check:changeset-userfacing`

## Limits

- none
