### PR TITLE
fix(desktop): improve popup accessibility

### DIFF
--- a/.changeset/ui-popup-accessibility.md
+++ b/.changeset/ui-popup-accessibility.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Improved keyboard, touch, and screen-reader access for desktop help and slash-command popups.

--- a/apps/desktop-renderer/src/ui/chat/Composer.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Composer.tsx
@@ -1,5 +1,6 @@
 import {
   useImperativeHandle,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -26,6 +27,7 @@ export function Composer(props: {
   const [draft, setDraft] = useState("");
   const [selected, setSelected] = useState(0);
   const [dismissed, setDismissed] = useState(false);
+  const listboxId = useId();
   const sendDisabled = useEnduragentStore((state) => state.chat.sendDisabled);
   const inputDisabled = useEnduragentStore((state) => state.chat.inputDisabled);
   const actions = useEnduragentStore((state) => state.chatActions);
@@ -118,6 +120,7 @@ export function Composer(props: {
       <SlashPopup
         open={open}
         anchor={form}
+        listboxId={listboxId}
         matches={matches}
         selected={active}
         onHighlight={setSelected}
@@ -139,6 +142,11 @@ export function Composer(props: {
           className="min-h-10 max-h-[140px] resize-none border-0 bg-transparent py-2 text-ink outline-0 placeholder:text-[color-mix(in_srgb,var(--ink-2)_72%,transparent)] focus-visible:outline-0"
           rows={2}
           disabled={inputDisabled || !canChat}
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={open}
+          aria-controls={open ? listboxId : undefined}
+          aria-activedescendant={open ? `${listboxId}-option-${active}` : undefined}
           onChange={(event) => {
             setDraft(event.currentTarget.value);
             setSelected(0);

--- a/apps/desktop-renderer/src/ui/chat/SlashPopup.tsx
+++ b/apps/desktop-renderer/src/ui/chat/SlashPopup.tsx
@@ -6,6 +6,7 @@ import { cn } from "../../lib/utils.js";
 export function SlashPopup(props: {
   readonly open: boolean;
   readonly anchor: RefObject<Element | null>;
+  readonly listboxId: string;
   readonly matches: readonly SlashCommand[];
   readonly selected: number;
   readonly onHighlight: (index: number) => void;
@@ -18,7 +19,6 @@ export function SlashPopup(props: {
     <Popover
       open={props.open}
       modal={false}
-      triggerId="message"
       onOpenChange={(open) => {
         if (!open) props.onDismiss();
       }}
@@ -29,6 +29,7 @@ export function SlashPopup(props: {
         sideOffset={8}
         align="start"
         className="block w-(--anchor-width) overflow-hidden p-0"
+        id={props.listboxId}
         role="listbox"
         aria-label="Commands"
         initialFocus={false}
@@ -41,6 +42,7 @@ export function SlashPopup(props: {
           {props.matches.map((match, index) => (
             <li
               key={match.command}
+              id={`${props.listboxId}-option-${index}`}
               role="option"
               aria-selected={index === props.selected}
               className={cn(

--- a/apps/desktop-renderer/src/ui/onboarding/InfoTip.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/InfoTip.tsx
@@ -1,42 +1,50 @@
-import { Tooltip } from "@base-ui/react/tooltip";
+import { Popover } from "@base-ui/react/popover";
 import { Info } from "lucide-react";
-import type { ReactElement, ReactNode } from "react";
+import { cloneElement, type AnchorHTMLAttributes, type ReactElement, type ReactNode } from "react";
 
 export function InfoTip(props: {
   readonly label: string;
   readonly lead: string;
   readonly body: ReactNode;
-  readonly trigger?: ReactElement;
+  readonly trigger?: ReactElement<AnchorHTMLAttributes<HTMLAnchorElement>>;
   readonly triggerContent?: ReactNode;
 }): ReactElement {
   const customTrigger = props.trigger !== undefined;
+  const trigger =
+    props.trigger === undefined ? undefined : cloneElement(props.trigger, { role: "link" });
 
   return (
-    <Tooltip.Root>
-      <Tooltip.Trigger
-        render={props.trigger}
+    <Popover.Root>
+      <Popover.Trigger
+        render={trigger}
+        nativeButton={!customTrigger}
+        openOnHover
         data-info-tip=""
         aria-label={customTrigger ? undefined : props.label}
         className={
           customTrigger
             ? undefined
-            : "grid size-[15px] shrink-0 appearance-none place-items-center bg-transparent p-0 text-ink-2 transition-colors hover:text-ink focus-visible:text-ink motion-reduce:transition-none"
+            : "grid size-6 shrink-0 appearance-none place-items-center bg-transparent p-0 text-ink-2 transition-colors hover:text-ink focus-visible:text-ink motion-reduce:transition-none"
         }
       >
         {props.triggerContent}
         <Info className="flex-none" size={14} strokeWidth={2.25} aria-hidden="true" />
-      </Tooltip.Trigger>
-      <Tooltip.Portal>
-        <Tooltip.Positioner side="top" sideOffset={8}>
-          <Tooltip.Popup
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner side="top" sideOffset={8}>
+          <Popover.Popup
             data-info-tip-popup=""
             className="w-[252px] rounded-md border border-line-2 bg-surface px-3 py-2.5 text-xs leading-relaxed text-ink-2 shadow-elev-3"
+            initialFocus={false}
+            finalFocus={false}
           >
-            <b className="mb-1 block font-medium text-ink">{props.lead}</b>
-            {props.body}
-          </Tooltip.Popup>
-        </Tooltip.Positioner>
-      </Tooltip.Portal>
-    </Tooltip.Root>
+            <Popover.Title render={<b />} className="mb-1 block font-medium text-ink">
+              {props.lead}
+            </Popover.Title>
+            <Popover.Description render={<div />}>{props.body}</Popover.Description>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -103,6 +103,41 @@ describe("chat surface", () => {
       expect(screen.queryByRole("listbox")).toBeNull();
     });
 
+    it("exposes the command list as the composer's active suggestion list", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+      const input = composer();
+
+      expect(input).toHaveAttribute("role", "combobox");
+      expect(input).toHaveAttribute("aria-autocomplete", "list");
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      expect(input).not.toHaveAttribute("aria-controls");
+      expect(input).not.toHaveAttribute("aria-activedescendant");
+
+      await user.click(input);
+      await user.keyboard("/st");
+
+      const listbox = screen.getByRole("listbox", { name: "Commands" });
+      const options = screen.getAllByRole("option");
+      const first = options.at(0);
+      const second = options.at(1);
+      if (first === undefined || second === undefined) {
+        throw new TypeError("command options missing");
+      }
+      expect(input).toHaveAttribute("aria-expanded", "true");
+      expect(input).toHaveAttribute("aria-controls", listbox.id);
+      expect(input).toHaveAttribute("aria-activedescendant", first.id);
+
+      await user.keyboard("{ArrowDown}");
+      expect(input).toHaveAttribute("aria-activedescendant", second.id);
+
+      await user.keyboard("{Escape}");
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      expect(input).not.toHaveAttribute("aria-controls");
+      expect(input).not.toHaveAttribute("aria-activedescendant");
+      expect(document.activeElement).toBe(input);
+    });
+
     it("moves the selection with the arrow keys and accepts with Enter", async () => {
       const user = userEvent.setup();
       render(<Harness />);

--- a/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-setup-card.test.tsx
@@ -695,6 +695,7 @@ describe("setup card", () => {
     const title = setupRow("ai").querySelector("[data-setup-row-title]");
     const trigger = title?.querySelector<HTMLElement>("[data-info-tip]");
     expect(trigger).not.toBeNull();
+    expect(trigger).toHaveClass("size-6");
 
     await user.hover(trigger as HTMLElement);
 
@@ -703,6 +704,27 @@ describe("setup card", () => {
     });
     const popup = document.querySelector("[data-info-tip-popup]") as HTMLElement;
     expect(setupCard().contains(popup)).toBe(false);
+    wizard.controller.dispose();
+  });
+
+  it("opens info details from the keyboard without moving focus", async () => {
+    const user = userEvent.setup();
+    const wizard = mountWizard({ bridge: coldBridge() });
+    await wizard.open();
+    const trigger = setupRow("ai").querySelector<HTMLElement>("[data-info-tip]");
+    if (trigger === null) throw new TypeError("info trigger missing");
+
+    trigger.focus();
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(document.querySelector("[data-info-tip-popup]")).not.toBeNull();
+    });
+    const popup = document.querySelector<HTMLElement>("[data-info-tip-popup]");
+    if (popup === null) throw new TypeError("info popup missing");
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(trigger).toHaveAttribute("aria-controls", popup.id);
+    expect(document.activeElement).toBe(trigger);
     wizard.controller.dispose();
   });
 


### PR DESCRIPTION
## Summary

- make InfoTip available by hover and press with a 24px target while preserving custom link semantics
- expose SlashPopup as the textarea's active listbox with stable combobox ARIA relationships
- keep textarea focus and existing keyboard/pointer behavior unchanged

## Limits

- `InfoTip target = 24px` — minimum accessible target size.

## Verification

- focused onboarding/sidebar/chat tests — 109/109 passed
- renderer TypeScript check — passed
- root `pnpm check` — passed
- formatting — passed
- fresh read-only verification — 6/6 acceptance checks passed