### PR TITLE
fix(desktop): expose reset during credential repair

### DIFF
--- a/.changeset/repair-safe-credential-reset.md
+++ b/.changeset/repair-safe-credential-reset.md
@@ -4,4 +4,4 @@
 
 User-facing: Fixed “Remove all credentials” after an uncertain credential deletion.
 
-The explicit full reset now bypasses the per-credential repair lock while other destructive actions remain blocked.
+The explicit full reset remains visible and bypasses the per-credential repair lock while other destructive actions remain blocked.

--- a/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
@@ -268,7 +268,8 @@ export function CredentialSettingsFeedback(): ReactElement | null {
   const resetConfirmation = current?.confirmation === "all";
   const canRetryRecovery = recovery?.state === "locked" || recovery?.state === "unavailable";
   const canReset =
-    recovery !== undefined && (recovery.state !== "ready" || recovery.unverifiedEnvelopes > 0);
+    recovery !== undefined &&
+    (repairRequired !== null || recovery.state !== "ready" || recovery.unverifiedEnvelopes > 0);
   const announcement =
     "announcement" in state && state.announcement.length > 0
       ? state.announcement

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -930,6 +930,12 @@ describe("settings lifecycle", () => {
 });
 
 describe("credential deletion", () => {
+  it("does not offer full reset for verified credentials without repair", async () => {
+    await renderSettings();
+
+    expect(screen.queryByRole("button", { name: "Remove all credentials" })).toBeNull();
+  });
+
   it("offers inline removal when saved credentials are unverified", async () => {
     const user = userEvent.setup();
     const subject = await renderSettings({
@@ -944,9 +950,43 @@ describe("credential deletion", () => {
     );
     expect(subject.resetAllCredentials).not.toHaveBeenCalled();
 
+    await user.click(within(confirmation).getByRole("button", { name: "Remove all credentials" }));
+    await waitFor(() => expect(subject.resetAllCredentials).toHaveBeenCalledOnce());
+  });
+
+  it("offers explicit full reset after an uncertain per-slot deletion", async () => {
+    const user = userEvent.setup();
+    const subject = await renderSettings({
+      deleteCredential: async () => ({
+        slot: "openrouter",
+        status: "uncertain",
+        reason: "storage-uncertain",
+      }),
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete the OpenRouter credential" }));
     await user.click(
-      within(confirmation).getByRole("button", { name: "Remove all credentials" }),
+      screen.getByRole("button", { name: "Confirm deletion of the OpenRouter credential" }),
     );
+    await screen.findByText(
+      "Credential deletion could not be confirmed because secure storage could not be verified. Restart Enduragent and reload before trying again.",
+    );
+
+    expect(screen.getByRole("button", { name: "Delete the Anthropic credential" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Delete the OpenRouter credential" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Delete the Intervals.icu connection" }),
+    ).toBeDisabled();
+    const reset = screen.getByRole("button", { name: "Remove all credentials" });
+    expect(reset).toBeEnabled();
+
+    await user.click(reset);
+    const confirmation = screen.getByRole("group", { name: "Remove all credentials?" });
+    await waitFor(() =>
+      expect(within(confirmation).getByRole("button", { name: "Cancel" })).toHaveFocus(),
+    );
+    await user.click(within(confirmation).getByRole("button", { name: "Remove all credentials" }));
+
     await waitFor(() => expect(subject.resetAllCredentials).toHaveBeenCalledOnce());
   });
 


### PR DESCRIPTION
## Summary

- keep explicit full reset visible after an uncertain per-slot deletion
- keep every per-slot delete disabled during repair
- cover ready, repair, confirmation, and reset bridge behavior

## Verification

- pnpm --filter @enduragent/desktop-renderer check
- pnpm --filter @enduragent/desktop-renderer test -- settings-surface.test.tsx: 58 files, 929 tests passed
- pnpm check:changeset-userfacing
- git diff --check