### PR TITLE
fix(desktop): protect keychain owner acl

### DIFF
--- a/.changeset/protect-keychain-owner-acl.md
+++ b/.changeset/protect-keychain-owner-acl.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Hardened the macOS credential key against access-control changes by other local applications.
+
+The native Keychain backend now preserves and validates the protected owner ACL while retaining prompt-free Team-ID access.

--- a/apps/desktop/native/keychain-binding/keychain-binding.mm
+++ b/apps/desktop/native/keychain-binding/keychain-binding.mm
@@ -145,6 +145,10 @@ CFMutableDictionaryRef Query(const std::string &service) {
   return query;
 }
 
+enum class PartitionInspection { kPresent, kAbsent, kUninspectable };
+
+PartitionInspection InspectAccess(SecAccessRef access);
+
 SecAccessRef MakeAccess() {
   SecAccessRef access = nullptr;
   CFStringRef label = String("Enduragent credential encryption key");
@@ -161,31 +165,64 @@ SecAccessRef MakeAccess() {
     return nullptr;
   }
   const CFIndex count = CFArrayGetCount(aclList);
+  CFIndex ownerCount = 0;
   for (CFIndex index = 0; index < count; index += 1) {
     SecACLRef acl = static_cast<SecACLRef>(
         const_cast<void *>(CFArrayGetValueAtIndex(aclList, index)));
+    CFArrayRef authorizations = SecACLCopyAuthorizations(acl);
+    if (authorizations == nullptr) {
+      CFRelease(aclList);
+      CFRelease(access);
+      return nullptr;
+    }
+    const KeychainAclRole role = ClassifyKeychainAcl(authorizations);
+    if (role == KeychainAclRole::kPartition ||
+        role == KeychainAclRole::kUnsafe) {
+      CFRelease(authorizations);
+      CFRelease(aclList);
+      CFRelease(access);
+      return nullptr;
+    }
     CFArrayRef applications = nullptr;
     CFStringRef description = nullptr;
     SecKeychainPromptSelector prompt{};
     if (SecACLCopyContents(acl, &applications, &description, &prompt) !=
-            errSecSuccess ||
-        SecACLSetContents(acl, nullptr,
-                          description == nullptr ? CFSTR("") : description,
-                          prompt) != errSecSuccess) {
+        errSecSuccess) {
       if (applications != nullptr)
         CFRelease(applications);
       if (description != nullptr)
         CFRelease(description);
+      CFRelease(authorizations);
       CFRelease(aclList);
       CFRelease(access);
       return nullptr;
+    }
+    bool acceptable = true;
+    if (role == KeychainAclRole::kOwner) {
+      ownerCount += 1;
+      acceptable = IsExpectedOwnerAcl(authorizations, applications);
+    } else {
+      acceptable = SecACLSetContents(
+                       acl, nullptr,
+                       description == nullptr ? CFSTR("") : description,
+                       prompt) == errSecSuccess;
     }
     if (applications != nullptr)
       CFRelease(applications);
     if (description != nullptr)
       CFRelease(description);
+    CFRelease(authorizations);
+    if (!acceptable) {
+      CFRelease(aclList);
+      CFRelease(access);
+      return nullptr;
+    }
   }
   CFRelease(aclList);
+  if (ownerCount != 1) {
+    CFRelease(access);
+    return nullptr;
+  }
   CFStringRef partition =
       String("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
              "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" "
@@ -211,32 +248,21 @@ SecAccessRef MakeAccess() {
     CFRelease(access);
     return nullptr;
   }
+  if (InspectAccess(access) != PartitionInspection::kPresent) {
+    CFRelease(access);
+    return nullptr;
+  }
   return access;
 }
 
-enum class PartitionInspection { kPresent, kAbsent, kUninspectable };
-
-PartitionInspection InspectPartition(SecKeychainItemRef item) {
-  SecAccessRef access = nullptr;
-  if (SecKeychainItemCopyAccess(item, &access) != errSecSuccess ||
-      access == nullptr) {
-    return PartitionInspection::kUninspectable;
-  }
+PartitionInspection InspectAccess(SecAccessRef access) {
   CFArrayRef aclList = nullptr;
   if (SecAccessCopyACLList(access, &aclList) != errSecSuccess ||
       aclList == nullptr) {
-    CFRelease(access);
-    return PartitionInspection::kUninspectable;
-  }
-  CFMutableArrayRef partitionDescriptions = CFArrayCreateMutable(
-      kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
-  if (partitionDescriptions == nullptr) {
-    CFRelease(aclList);
-    CFRelease(access);
     return PartitionInspection::kUninspectable;
   }
   PartitionInspection result = PartitionInspection::kAbsent;
-  bool exactPartitionSemantics = true;
+  KeychainAccessAclInspection inspection{0, 0, true};
   const CFIndex count = CFArrayGetCount(aclList);
   for (CFIndex index = 0; index < count; index += 1) {
     SecACLRef acl = static_cast<SecACLRef>(
@@ -246,10 +272,14 @@ PartitionInspection InspectPartition(SecKeychainItemRef item) {
       result = PartitionInspection::kUninspectable;
       break;
     }
-    const bool partition = CFArrayContainsValue(
-        authorizations, CFRangeMake(0, CFArrayGetCount(authorizations)),
-        kSecACLAuthorizationPartitionID);
-    if (!partition) {
+    const KeychainAclRole role = ClassifyKeychainAcl(authorizations);
+    if (role == KeychainAclRole::kUnrelated) {
+      CFRelease(authorizations);
+      continue;
+    }
+    if (role == KeychainAclRole::kUnsafe) {
+      IncludeKeychainAcl(inspection, role, authorizations, nullptr, nullptr,
+                         SecKeychainPromptSelector{});
       CFRelease(authorizations);
       continue;
     }
@@ -257,8 +287,7 @@ PartitionInspection InspectPartition(SecKeychainItemRef item) {
     CFStringRef description = nullptr;
     SecKeychainPromptSelector prompt{};
     if (SecACLCopyContents(acl, &applications, &description, &prompt) !=
-            errSecSuccess ||
-        description == nullptr) {
+        errSecSuccess) {
       if (applications != nullptr)
         CFRelease(applications);
       if (description != nullptr)
@@ -267,22 +296,28 @@ PartitionInspection InspectPartition(SecKeychainItemRef item) {
       result = PartitionInspection::kUninspectable;
       break;
     }
-    exactPartitionSemantics =
-        exactPartitionSemantics &&
-        IsExpectedPartitionAcl(authorizations, applications, description,
-                               prompt);
-    CFArrayAppendValue(partitionDescriptions, description);
+    IncludeKeychainAcl(inspection, role, authorizations, applications,
+                       description, prompt);
     CFRelease(authorizations);
     if (applications != nullptr)
       CFRelease(applications);
-    CFRelease(description);
+    if (description != nullptr)
+      CFRelease(description);
   }
   if (result != PartitionInspection::kUninspectable &&
-      exactPartitionSemantics &&
-      AreExpectedPartitionDescriptions(partitionDescriptions))
+      IsExpectedKeychainAccess(inspection))
     result = PartitionInspection::kPresent;
-  CFRelease(partitionDescriptions);
   CFRelease(aclList);
+  return result;
+}
+
+PartitionInspection InspectPartition(SecKeychainItemRef item) {
+  SecAccessRef access = nullptr;
+  if (SecKeychainItemCopyAccess(item, &access) != errSecSuccess ||
+      access == nullptr) {
+    return PartitionInspection::kUninspectable;
+  }
+  const PartitionInspection result = InspectAccess(access);
   CFRelease(access);
   return result;
 }

--- a/apps/desktop/native/keychain-binding/partition-description-harness.mm
+++ b/apps/desktop/native/keychain-binding/partition-description-harness.mm
@@ -88,6 +88,127 @@ int AclStatus(int argumentCount, char **arguments) {
   return acceptable ? 0 : 1;
 }
 
+int CopyCount(const char *value) {
+  if (Equal(value, "missing"))
+    return 0;
+  if (Equal(value, "single"))
+    return 1;
+  if (Equal(value, "duplicate"))
+    return 2;
+  return -1;
+}
+
+int AccessStatus(int argumentCount, char **arguments) {
+  if (argumentCount != 8)
+    return 2;
+  const int ownerCopies = CopyCount(arguments[4]);
+  const int partitionCopies = CopyCount(arguments[5]);
+  if (ownerCopies < 0 || partitionCopies < 0)
+    return 2;
+
+  CFMutableArrayRef ownerAuthorizations = CFArrayCreateMutable(
+      kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+  if (ownerAuthorizations == nullptr)
+    return 2;
+  if (Equal(arguments[2], "exact") || Equal(arguments[2], "extra"))
+    CFArrayAppendValue(ownerAuthorizations, kSecACLAuthorizationChangeACL);
+  if (Equal(arguments[2], "extra"))
+    CFArrayAppendValue(ownerAuthorizations, kSecACLAuthorizationDecrypt);
+  if (!Equal(arguments[2], "exact") && !Equal(arguments[2], "extra")) {
+    CFRelease(ownerAuthorizations);
+    return 2;
+  }
+
+  CFMutableArrayRef ownerApplications = nullptr;
+  if (Equal(arguments[3], "empty") || Equal(arguments[3], "populated")) {
+    ownerApplications = CFArrayCreateMutable(kCFAllocatorDefault, 0,
+                                             &kCFTypeArrayCallBacks);
+    if (ownerApplications == nullptr) {
+      CFRelease(ownerAuthorizations);
+      return 2;
+    }
+    if (Equal(arguments[3], "populated"))
+      CFArrayAppendValue(ownerApplications, CFSTR("application"));
+  } else if (!Equal(arguments[3], "null")) {
+    CFRelease(ownerAuthorizations);
+    return 2;
+  }
+
+  CFMutableArrayRef partitionAuthorizations = CFArrayCreateMutable(
+      kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+  CFStringRef partitionDescription = String(arguments[7]);
+  if (partitionAuthorizations == nullptr || partitionDescription == nullptr) {
+    if (partitionAuthorizations != nullptr)
+      CFRelease(partitionAuthorizations);
+    if (partitionDescription != nullptr)
+      CFRelease(partitionDescription);
+    if (ownerApplications != nullptr)
+      CFRelease(ownerApplications);
+    CFRelease(ownerAuthorizations);
+    return 2;
+  }
+  CFArrayAppendValue(partitionAuthorizations,
+                     kSecACLAuthorizationPartitionID);
+
+  KeychainAccessAclInspection inspection{0, 0, true};
+  for (int index = 0; index < ownerCopies; index += 1) {
+    IncludeKeychainAcl(inspection, ClassifyKeychainAcl(ownerAuthorizations),
+                       ownerAuthorizations, ownerApplications, CFSTR("owner"),
+                       SecKeychainPromptSelector{});
+  }
+  for (int index = 0; index < partitionCopies; index += 1) {
+    IncludeKeychainAcl(
+        inspection, ClassifyKeychainAcl(partitionAuthorizations),
+        partitionAuthorizations, nullptr, partitionDescription,
+        SecKeychainPromptSelector{});
+  }
+
+  CFMutableArrayRef unrelatedAuthorizations = nullptr;
+  if (!Equal(arguments[6], "none")) {
+    unrelatedAuthorizations = CFArrayCreateMutable(
+        kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+    if (unrelatedAuthorizations == nullptr) {
+      CFRelease(partitionDescription);
+      CFRelease(partitionAuthorizations);
+      if (ownerApplications != nullptr)
+        CFRelease(ownerApplications);
+      CFRelease(ownerAuthorizations);
+      return 2;
+    }
+    if (Equal(arguments[6], "default"))
+      CFArrayAppendValue(unrelatedAuthorizations,
+                         kSecACLAuthorizationEncrypt);
+    else if (Equal(arguments[6], "any"))
+      CFArrayAppendValue(unrelatedAuthorizations, kSecACLAuthorizationAny);
+    else if (Equal(arguments[6], "change-owner"))
+      CFArrayAppendValue(unrelatedAuthorizations,
+                         kSecACLAuthorizationChangeOwner);
+    else {
+      CFRelease(unrelatedAuthorizations);
+      CFRelease(partitionDescription);
+      CFRelease(partitionAuthorizations);
+      if (ownerApplications != nullptr)
+        CFRelease(ownerApplications);
+      CFRelease(ownerAuthorizations);
+      return 2;
+    }
+    IncludeKeychainAcl(
+        inspection, ClassifyKeychainAcl(unrelatedAuthorizations),
+        unrelatedAuthorizations, nullptr, CFSTR("unrelated"),
+        SecKeychainPromptSelector{});
+  }
+
+  const bool acceptable = IsExpectedKeychainAccess(inspection);
+  if (unrelatedAuthorizations != nullptr)
+    CFRelease(unrelatedAuthorizations);
+  CFRelease(partitionDescription);
+  CFRelease(partitionAuthorizations);
+  if (ownerApplications != nullptr)
+    CFRelease(ownerApplications);
+  CFRelease(ownerAuthorizations);
+  return acceptable ? 0 : 1;
+}
+
 }
 
 int main(int argumentCount, char **arguments) {
@@ -97,5 +218,7 @@ int main(int argumentCount, char **arguments) {
     return DescriptionStatus(argumentCount, arguments);
   if (Equal(arguments[1], "acl"))
     return AclStatus(argumentCount, arguments);
+  if (Equal(arguments[1], "access"))
+    return AccessStatus(argumentCount, arguments);
   return 2;
 }

--- a/apps/desktop/native/keychain-binding/partition-description.h
+++ b/apps/desktop/native/keychain-binding/partition-description.h
@@ -3,8 +3,24 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/SecACL.h>
 
+enum class KeychainAclRole { kOwner, kPartition, kUnrelated, kUnsafe };
+
+struct KeychainAccessAclInspection {
+  CFIndex ownerCount;
+  CFIndex partitionCount;
+  bool exact;
+};
+
 bool IsExpectedPartitionDescription(CFStringRef description);
 bool AreExpectedPartitionDescriptions(CFArrayRef descriptions);
 bool IsExpectedPartitionAcl(CFArrayRef authorizations, CFArrayRef applications,
                             CFStringRef description,
                             SecKeychainPromptSelector prompt);
+KeychainAclRole ClassifyKeychainAcl(CFArrayRef authorizations);
+bool IsExpectedOwnerAcl(CFArrayRef authorizations, CFArrayRef applications);
+void IncludeKeychainAcl(KeychainAccessAclInspection &inspection,
+                        KeychainAclRole role, CFArrayRef authorizations,
+                        CFArrayRef applications, CFStringRef description,
+                        SecKeychainPromptSelector prompt);
+bool IsExpectedKeychainAccess(
+    const KeychainAccessAclInspection &inspection);

--- a/apps/desktop/native/keychain-binding/partition-description.mm
+++ b/apps/desktop/native/keychain-binding/partition-description.mm
@@ -23,6 +23,11 @@ bool HasUnambiguousPartitionKey(CFStringRef description) {
          OccurrenceCount(description, CFSTR("<!ENTITY")) == 0;
 }
 
+bool IsAuthorization(CFTypeRef value, CFStringRef expected) {
+  return value != nullptr && CFGetTypeID(value) == CFStringGetTypeID() &&
+         CFEqual(value, expected);
+}
+
 }
 
 bool IsExpectedPartitionDescription(CFStringRef description) {
@@ -98,4 +103,81 @@ bool IsExpectedPartitionAcl(CFArrayRef authorizations, CFArrayRef applications,
          CFEqual(authorization, kSecACLAuthorizationPartitionID) &&
          applications == nullptr && prompt == 0 &&
          IsExpectedPartitionDescription(description);
+}
+
+KeychainAclRole ClassifyKeychainAcl(CFArrayRef authorizations) {
+  if (authorizations == nullptr ||
+      CFGetTypeID(authorizations) != CFArrayGetTypeID() ||
+      CFArrayGetCount(authorizations) == 0) {
+    return KeychainAclRole::kUnsafe;
+  }
+  bool owner = false;
+  bool partition = false;
+  const CFIndex count = CFArrayGetCount(authorizations);
+  for (CFIndex index = 0; index < count; index += 1) {
+    CFTypeRef authorization = CFArrayGetValueAtIndex(authorizations, index);
+    if (authorization == nullptr ||
+        CFGetTypeID(authorization) != CFStringGetTypeID()) {
+      return KeychainAclRole::kUnsafe;
+    }
+    owner = owner ||
+            IsAuthorization(authorization, kSecACLAuthorizationChangeACL);
+    partition =
+        partition ||
+        IsAuthorization(authorization, kSecACLAuthorizationPartitionID);
+    if (IsAuthorization(authorization, kSecACLAuthorizationAny) ||
+        IsAuthorization(authorization, kSecACLAuthorizationChangeOwner)) {
+      return KeychainAclRole::kUnsafe;
+    }
+  }
+  if (owner && partition)
+    return KeychainAclRole::kUnsafe;
+  if (owner)
+    return KeychainAclRole::kOwner;
+  if (partition)
+    return KeychainAclRole::kPartition;
+  return KeychainAclRole::kUnrelated;
+}
+
+bool IsExpectedOwnerAcl(CFArrayRef authorizations, CFArrayRef applications) {
+  if (authorizations == nullptr ||
+      CFGetTypeID(authorizations) != CFArrayGetTypeID() ||
+      CFArrayGetCount(authorizations) != 1 || applications == nullptr ||
+      CFGetTypeID(applications) != CFArrayGetTypeID() ||
+      CFArrayGetCount(applications) != 0) {
+    return false;
+  }
+  return IsAuthorization(CFArrayGetValueAtIndex(authorizations, 0),
+                         kSecACLAuthorizationChangeACL);
+}
+
+void IncludeKeychainAcl(KeychainAccessAclInspection &inspection,
+                        KeychainAclRole role, CFArrayRef authorizations,
+                        CFArrayRef applications, CFStringRef description,
+                        SecKeychainPromptSelector prompt) {
+  switch (role) {
+  case KeychainAclRole::kOwner:
+    inspection.ownerCount += 1;
+    inspection.exact = inspection.exact &&
+                       IsExpectedOwnerAcl(authorizations, applications);
+    return;
+  case KeychainAclRole::kPartition:
+    inspection.partitionCount += 1;
+    inspection.exact =
+        inspection.exact &&
+        IsExpectedPartitionAcl(authorizations, applications, description,
+                               prompt);
+    return;
+  case KeychainAclRole::kUnrelated:
+    return;
+  case KeychainAclRole::kUnsafe:
+    inspection.exact = false;
+    return;
+  }
+}
+
+bool IsExpectedKeychainAccess(
+    const KeychainAccessAclInspection &inspection) {
+  return inspection.exact && inspection.ownerCount == 1 &&
+         inspection.partitionCount == 1;
 }

--- a/apps/desktop/tests/keychain-binding-native.integration.test.ts
+++ b/apps/desktop/tests/keychain-binding-native.integration.test.ts
@@ -61,11 +61,23 @@ function partitionAclStatus(
   applications: "null" | "empty" | "populated",
   prompt: "zero" | "nonzero",
 ) {
+  return harnessStatus("acl", authorization, applications, prompt, canonicalPartitionDescription);
+}
+
+function accessAclStatus(
+  ownerAuthorization: "exact" | "extra",
+  ownerApplications: "null" | "empty" | "populated",
+  ownerCount: "missing" | "single" | "duplicate",
+  partitionCount: "missing" | "single" | "duplicate",
+  unrelated: "none" | "default" | "any" | "change-owner",
+) {
   return harnessStatus(
-    "acl",
-    authorization,
-    applications,
-    prompt,
+    "access",
+    ownerAuthorization,
+    ownerApplications,
+    ownerCount,
+    partitionCount,
+    unrelated,
     canonicalPartitionDescription,
   );
 }
@@ -132,8 +144,22 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
         source.indexOf("napi_value CreateKey"),
         source.indexOf("napi_value DeleteKey"),
       );
+      const accessConstructionStart = source.indexOf("SecAccessRef MakeAccess");
+      const accessConstruction = source.slice(
+        accessConstructionStart,
+        source.indexOf("PartitionInspection InspectAccess", accessConstructionStart),
+      );
       expect(readiness.indexOf("InteractionDisabled()")).toBeLessThan(
         readiness.indexOf("TrustedHost()"),
+      );
+      expect(accessConstruction).toContain(
+        "acceptable = IsExpectedOwnerAcl(authorizations, applications)",
+      );
+      expect(accessConstruction.indexOf("IsExpectedOwnerAcl")).toBeLessThan(
+        accessConstruction.indexOf("SecACLSetContents"),
+      );
+      expect(accessConstruction).toContain(
+        "InspectAccess(access) != PartitionInspection::kPresent",
       );
       expect(creation.indexOf("InspectPartition(")).toBeLessThan(
         creation.indexOf("SecKeychainItemCopyContent"),
@@ -144,9 +170,7 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       expect(creation.indexOf("SecKeychainItemFreeContent")).toBeLessThan(
         creation.indexOf("napi_create_buffer_copy"),
       );
-      expect(creation).toContain(
-        "persistedLength == static_cast<UInt32>(material.size())",
-      );
+      expect(creation).toContain("persistedLength == static_cast<UInt32>(material.size())");
       expect(creation).toContain("timingsafe_bcmp");
       expect(creation).not.toContain("SecItemDelete");
       expect(source).toContain("#define __STDC_WANT_LIB_EXT1__ 1");
@@ -169,6 +193,26 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       expect(partitionAclStatus("exact", "null", "nonzero")).toBe(1);
     });
 
+    it("accepts one protected owner with one exact partition ACL", () => {
+      expect(accessAclStatus("exact", "empty", "single", "single", "none")).toBe(0);
+      expect(accessAclStatus("exact", "empty", "single", "single", "default")).toBe(0);
+    });
+
+    it("rejects an unsafe or ambiguous owner ACL", () => {
+      expect(accessAclStatus("exact", "empty", "missing", "single", "none")).toBe(1);
+      expect(accessAclStatus("exact", "empty", "duplicate", "single", "none")).toBe(1);
+      expect(accessAclStatus("exact", "null", "single", "single", "none")).toBe(1);
+      expect(accessAclStatus("exact", "populated", "single", "single", "none")).toBe(1);
+      expect(accessAclStatus("extra", "empty", "single", "single", "none")).toBe(1);
+    });
+
+    it("rejects ambiguous partitions and unrestricted mutation authority", () => {
+      expect(accessAclStatus("exact", "empty", "single", "missing", "none")).toBe(1);
+      expect(accessAclStatus("exact", "empty", "single", "duplicate", "none")).toBe(1);
+      expect(accessAclStatus("exact", "empty", "single", "single", "any")).toBe(1);
+      expect(accessAclStatus("exact", "empty", "single", "single", "change-owner")).toBe(1);
+    });
+
     it("rejects malformed and structurally invalid property lists", () => {
       const rejected = [
         "teamid:FA494ACVTF",
@@ -177,9 +221,7 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
         plistDictionary(""),
         plistDictionary("<key>Partitions</key><string>teamid:FA494ACVTF</string>"),
         plistDictionary("<key>Partitions</key><array></array>"),
-        plistDictionary(
-          "<key>Partitions</key><array><integer>1</integer></array>",
-        ),
+        plistDictionary("<key>Partitions</key><array><integer>1</integer></array>"),
       ];
       for (const description of rejected) {
         expect(partitionDescriptionStatus(description)).toBe(1);
@@ -192,9 +234,7 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
           "<key>Partitions</key><array><string>teamid:FA494ACVTF</string></array>" +
             "<key>Extra</key><string>teamid:FA494ACVTF</string>",
         ),
-        plistDictionary(
-          "<key>Partitions</key><array><string>teamid:OTHER</string></array>",
-        ),
+        plistDictionary("<key>Partitions</key><array><string>teamid:OTHER</string></array>"),
         plistDictionary(
           "<key>Partitions</key><array><string>teamid:FA494ACVTF</string>" +
             "<string>teamid:OTHER</string></array>",
@@ -206,25 +246,16 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
     });
 
     it("rejects duplicate partition dictionary keys", () => {
-      const expected =
-        "<key>Partitions</key><array><string>teamid:FA494ACVTF</string></array>";
-      const wrong =
-        "<key>Partitions</key><array><string>teamid:OTHER</string></array>";
-      expect(
-        partitionDescriptionStatus(plistDictionary(expected + expected)),
-      ).toBe(1);
-      expect(partitionDescriptionStatus(plistDictionary(expected + wrong))).toBe(
-        1,
-      );
+      const expected = "<key>Partitions</key><array><string>teamid:FA494ACVTF</string></array>";
+      const wrong = "<key>Partitions</key><array><string>teamid:OTHER</string></array>";
+      expect(partitionDescriptionStatus(plistDictionary(expected + expected))).toBe(1);
+      expect(partitionDescriptionStatus(plistDictionary(expected + wrong))).toBe(1);
     });
 
     it("rejects zero or multiple partition-authorized ACL descriptions", () => {
       expect(partitionDescriptionStatus()).toBe(1);
       expect(
-        partitionDescriptionStatus(
-          canonicalPartitionDescription,
-          alternatePartitionDescription,
-        ),
+        partitionDescriptionStatus(canonicalPartitionDescription, alternatePartitionDescription),
       ).toBe(1);
     });
   },


### PR DESCRIPTION
Preserves the protected Keychain owner ACL instead of converting it to an any-application ACL. Creation and adoption now fail closed unless the access object contains exactly one protected owner ACL and one exact Team-ID partition ACL.\n\nVerification:\n- Native ACL harness: 11/11 tests passed\n- Desktop TypeScript check passed\n- Native binding build passed\n- Changeset validation passed\n- Fresh read-only security review: no P0-P3 findings\n\nLimits: none.