### PR TITLE
refactor(desktop): group UI primitive recipes

### DIFF
--- a/apps/desktop-renderer/src/components/ui/button.tsx
+++ b/apps/desktop-renderer/src/components/ui/button.tsx
@@ -3,8 +3,27 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "../../lib/utils.js";
 
+const buttonBaseClasses =
+  "group/button inline-flex shrink-0 items-center justify-center rounded-ctl border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-colors outline-none select-none";
+const buttonFocusClasses =
+  "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20";
+const buttonDisabledClasses =
+  "disabled:pointer-events-none disabled:opacity-64 aria-disabled:pointer-events-none aria-disabled:cursor-default aria-disabled:opacity-64";
+const buttonInvalidClasses =
+  "aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20";
+const buttonMotionClasses = "motion-reduce:transition-none";
+const buttonIconClasses =
+  "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4";
+
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-ctl border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 disabled:pointer-events-none disabled:opacity-64 aria-disabled:pointer-events-none aria-disabled:cursor-default aria-disabled:opacity-64 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  cn(
+    buttonBaseClasses,
+    buttonFocusClasses,
+    buttonDisabledClasses,
+    buttonInvalidClasses,
+    buttonMotionClasses,
+    buttonIconClasses,
+  ),
   {
     variants: {
       variant: {

--- a/apps/desktop-renderer/src/components/ui/card.tsx
+++ b/apps/desktop-renderer/src/components/ui/card.tsx
@@ -2,6 +2,16 @@ import * as React from "react";
 
 import { cn } from "../../lib/utils.js";
 
+const cardBaseClasses =
+  "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-card border border-border bg-card py-(--card-spacing) text-sm text-card-foreground [--card-spacing:--spacing(4)]";
+const cardStateClasses =
+  "has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0";
+const cardMediaClasses = "*:[img:first-child]:rounded-t-card *:[img:last-child]:rounded-b-card";
+const cardHeaderBaseClasses =
+  "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-card px-(--card-spacing)";
+const cardHeaderStateClasses =
+  "has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)";
+
 function Card({
   className,
   size = "default",
@@ -11,10 +21,7 @@ function Card({
     <div
       data-slot="card"
       data-size={size}
-      className={cn(
-        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-card border border-border bg-card py-(--card-spacing) text-sm text-card-foreground [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-card *:[img:last-child]:rounded-b-card",
-        className,
-      )}
+      className={cn(cardBaseClasses, cardStateClasses, cardMediaClasses, className)}
       {...props}
     />
   );
@@ -24,10 +31,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-header"
-      className={cn(
-        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-card px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
-        className,
-      )}
+      className={cn(cardHeaderBaseClasses, cardHeaderStateClasses, className)}
       {...props}
     />
   );

--- a/apps/desktop-renderer/src/components/ui/dialog.tsx
+++ b/apps/desktop-renderer/src/components/ui/dialog.tsx
@@ -5,6 +5,14 @@ import { cn } from "../../lib/utils.js";
 import { Button } from "./button.js";
 import { XIcon } from "lucide-react";
 
+const dialogOverlayBaseClasses = "fixed inset-0 isolate z-50 bg-[var(--scrim)] duration-100";
+const dialogOverlayMotionClasses =
+  "data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0";
+const dialogContentBaseClasses =
+  "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-card border border-line-2 bg-popover p-4 text-sm text-popover-foreground shadow-elev-3 duration-100 outline-none sm:max-w-sm";
+const dialogContentMotionClasses =
+  "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95";
+
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
@@ -25,10 +33,7 @@ function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) 
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
-      className={cn(
-        "fixed inset-0 isolate z-50 bg-[var(--scrim)] duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className,
-      )}
+      className={cn(dialogOverlayBaseClasses, dialogOverlayMotionClasses, className)}
       {...props}
     />
   );
@@ -47,10 +52,7 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
-        className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-card border border-line-2 bg-popover p-4 text-sm text-popover-foreground shadow-elev-3 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className,
-        )}
+        className={cn(dialogContentBaseClasses, dialogContentMotionClasses, className)}
         {...props}
       >
         {children}

--- a/apps/desktop-renderer/src/components/ui/popover.tsx
+++ b/apps/desktop-renderer/src/components/ui/popover.tsx
@@ -5,6 +5,13 @@ import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 
 import { cn } from "../../lib/utils.js";
 
+const popoverContentBaseClasses =
+  "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-card border border-line-2 bg-popover p-row text-sm text-popover-foreground shadow-elev-3 outline-hidden duration-100";
+const popoverContentPlacementClasses =
+  "data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2";
+const popoverContentMotionClasses =
+  "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95";
+
 function Popover({ ...props }: PopoverPrimitive.Root.Props) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
@@ -39,7 +46,9 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-card border border-line-2 bg-popover p-row text-sm text-popover-foreground shadow-elev-3 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            popoverContentBaseClasses,
+            popoverContentPlacementClasses,
+            popoverContentMotionClasses,
             className,
           )}
           {...props}

--- a/apps/desktop-renderer/src/components/ui/select.tsx
+++ b/apps/desktop-renderer/src/components/ui/select.tsx
@@ -4,6 +4,33 @@ import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { cn } from "../../lib/utils.js";
 import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
 
+const selectTriggerBaseClasses =
+  "flex w-fit items-center justify-between gap-1.5 rounded-ctl border border-input bg-background px-ctl-px text-sm whitespace-nowrap transition-colors outline-none select-none";
+const selectTriggerStateClasses =
+  "focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-64 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground";
+const selectTriggerSizeClasses =
+  "data-[size=default]:h-ctl data-[size=sm]:h-ctl-sm data-[size=sm]:px-ctl-px-sm";
+const selectTriggerValueClasses =
+  "*:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5";
+const selectTriggerMotionClasses = "motion-reduce:transition-none";
+const selectTriggerIconClasses =
+  "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4";
+const selectContentBaseClasses =
+  "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-card border border-line-2 bg-popover p-1 text-popover-foreground shadow-elev-3 duration-100";
+const selectContentStateClasses = "data-[align-trigger=true]:animate-none";
+const selectContentPlacementClasses =
+  "data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2";
+const selectContentMotionClasses =
+  "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95";
+const selectItemBaseClasses =
+  "relative flex min-h-ctl-sm w-full cursor-default items-center gap-1.5 rounded-ctl py-1 pr-8 pl-inset text-sm outline-hidden select-none";
+const selectItemStateClasses =
+  "focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-64";
+const selectItemIconClasses =
+  "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4";
+const selectItemContentClasses =
+  "*:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2";
+
 const Select = SelectPrimitive.Root;
 
 function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
@@ -39,7 +66,12 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "flex w-fit items-center justify-between gap-1.5 rounded-ctl border border-input bg-background px-ctl-px text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-64 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-ctl data-[size=sm]:h-ctl-sm data-[size=sm]:px-ctl-px-sm *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 motion-reduce:transition-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        selectTriggerBaseClasses,
+        selectTriggerStateClasses,
+        selectTriggerSizeClasses,
+        selectTriggerValueClasses,
+        selectTriggerMotionClasses,
+        selectTriggerIconClasses,
         className,
       )}
       {...props}
@@ -80,7 +112,10 @@ function SelectContent({
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
           className={cn(
-            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-card border border-line-2 bg-popover p-1 text-popover-foreground shadow-elev-3 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            selectContentBaseClasses,
+            selectContentStateClasses,
+            selectContentPlacementClasses,
+            selectContentMotionClasses,
             className,
           )}
           {...props}
@@ -109,7 +144,10 @@ function SelectItem({ className, children, ...props }: SelectPrimitive.Item.Prop
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex min-h-ctl-sm w-full cursor-default items-center gap-1.5 rounded-ctl py-1 pr-8 pl-inset text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-64 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        selectItemBaseClasses,
+        selectItemStateClasses,
+        selectItemIconClasses,
+        selectItemContentClasses,
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

- split exceptionally long active primitive recipes into private named static groups
- keep ordinary short Tailwind classes inline
- preserve every class token, its order, caller overrides, and component behavior

## Verification

- before/after rendered recipe hash — identical across every primitive slot and all 56 Button variant/size combinations
- focused primitive tests — 11/11 passed
- root `pnpm check` — passed
- formatting and `git diff --check` — passed
- fresh read-only verification — 6/6 acceptance checks passed

No changeset: this is a behavior-neutral source refactor.