### PR TITLE
fix(desktop): bind credential reset vault roots

### DIFF
--- a/.changeset/refuse-redirected-credential-reset.md
+++ b/.changeset/refuse-redirected-credential-reset.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Prevented “Remove all credentials” from following redirected credential folders.
+
+The full reset now validates both credential vault roots before removing any encrypted credential or shared Keychain key.

--- a/apps/desktop/src/main/credential-envelope-inventory.ts
+++ b/apps/desktop/src/main/credential-envelope-inventory.ts
@@ -32,7 +32,7 @@ export interface CredentialEnvelopeInventory {
 export interface CredentialEnvelopeRoots {
   readonly credentialRoot: string;
   readonly telegramRoot: string;
-  readonly readEnvelopeFile?: typeof readFile;
+  readonly readEnvelopeFile?: (path: string) => Promise<Buffer>;
   readonly readEnvelopeDirectory?: (path: string) => Promise<string[]>;
 }
 
@@ -104,7 +104,7 @@ function transientCredentialEnvelopeTarget(
 
 async function inspectEnvelopeTarget(
   target: CredentialEnvelopeTarget,
-  read: typeof readFile,
+  read: (path: string) => Promise<Buffer>,
 ): Promise<CredentialEnvelopeRef | undefined> {
   let contents: Buffer | undefined;
   try {
@@ -123,7 +123,7 @@ async function inspectEnvelopeTarget(
 export async function scanCredentialEnvelopes(
   roots: CredentialEnvelopeRoots,
 ): Promise<CredentialEnvelopeInventory> {
-  const read = roots.readEnvelopeFile ?? readFile;
+  const read = roots.readEnvelopeFile ?? ((path: string) => readFile(path));
   const readDirectory = roots.readEnvelopeDirectory ?? readdir;
   const deletionBlockers: CredentialEnvelopeRef[] = [];
   const canonicalEnvelopes: CredentialEnvelopeRef[] = [];

--- a/apps/desktop/src/main/credential-reset.ts
+++ b/apps/desktop/src/main/credential-reset.ts
@@ -1,5 +1,11 @@
-import { rm } from "node:fs/promises";
-import { join } from "node:path";
+import type { Stats } from "node:fs";
+import { lstat, readFile, readdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  assertWindowsPrivateDirectoryStable,
+  bindWindowsPrivateDirectory,
+  type WindowsPrivateDirectoryBinding,
+} from "@enduragent/core";
 import type {
   CredentialEnvelopeLockProof,
   SerializeCredentialEnvelopeMutation,
@@ -9,8 +15,10 @@ import {
   scanCredentialEnvelopes,
   type CredentialEnvelopeRoots,
 } from "./credential-envelope-inventory.js";
+import { CREDENTIAL_DIRECTORY_MODE } from "./credential-vault.js";
 import { syncDirectory } from "./durable-atomic-replace.js";
 import type { KeychainKeyDeletion } from "./keychain-credential-encryption.js";
+import { TELEGRAM_CREDENTIAL_DIRECTORY_MODE } from "./telegram-credential-vault.js";
 
 export type EncryptedCredentialResetResult =
   | Readonly<{ status: "reset"; keyCleanupPending: boolean }>
@@ -21,6 +29,116 @@ export interface ResetEncryptedCredentialStorageOptions extends CredentialEnvelo
   readonly deleteKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyDeletion>;
   readonly removeFile?: typeof rm;
   readonly syncCredentialDirectory?: (root: string) => Promise<void>;
+  readonly platform?: NodeJS.Platform;
+}
+
+interface CredentialRootIdentity {
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+}
+
+type CredentialRootBinding =
+  | Readonly<{
+      state: "missing";
+      root: string;
+      expectedMode: number;
+    }>
+  | Readonly<{
+      state: "bound";
+      root: string;
+      expectedMode: number;
+      identity: CredentialRootIdentity;
+      windowsDirectory?: WindowsPrivateDirectoryBinding;
+    }>;
+
+function permissions(mode: number): number {
+  return mode & 0o777;
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function missingPath(path: string): NodeJS.ErrnoException {
+  return Object.assign(new Error("credential root is missing"), { code: "ENOENT", path });
+}
+
+function assertPosixCredentialRoot(metadata: Stats, expectedMode: number): void {
+  if (
+    !metadata.isDirectory() ||
+    metadata.isSymbolicLink() ||
+    permissions(metadata.mode) !== expectedMode ||
+    (typeof process.getuid === "function" && metadata.uid !== process.getuid())
+  ) {
+    throw new TypeError("unsafe credential root");
+  }
+}
+
+async function bindCredentialRoot(
+  root: string,
+  expectedMode: number,
+  platform: NodeJS.Platform,
+): Promise<CredentialRootBinding> {
+  let metadata: Stats;
+  try {
+    metadata = await lstat(root);
+  } catch (error) {
+    if (isMissing(error)) return { state: "missing", root, expectedMode };
+    throw error;
+  }
+  if (platform === "win32") {
+    const windowsDirectory = bindWindowsPrivateDirectory(dirname(root), root);
+    return {
+      state: "bound",
+      root,
+      expectedMode,
+      identity: windowsDirectory.identity,
+      windowsDirectory,
+    };
+  }
+  assertPosixCredentialRoot(metadata, expectedMode);
+  return {
+    state: "bound",
+    root,
+    expectedMode,
+    identity: { dev: metadata.dev, ino: metadata.ino },
+  };
+}
+
+async function assertCredentialRootStable(
+  binding: CredentialRootBinding,
+  platform: NodeJS.Platform,
+): Promise<void> {
+  if (binding.state === "missing") {
+    try {
+      await lstat(binding.root);
+    } catch (error) {
+      if (isMissing(error)) return;
+      throw error;
+    }
+    throw new TypeError("missing credential root appeared during reset");
+  }
+  if (platform === "win32") {
+    assertWindowsPrivateDirectoryStable(binding.windowsDirectory!);
+    return;
+  }
+  const metadata = await lstat(binding.root);
+  assertPosixCredentialRoot(metadata, binding.expectedMode);
+  if (metadata.dev !== binding.identity.dev || metadata.ino !== binding.identity.ino) {
+    throw new TypeError("credential root changed during reset");
+  }
+}
+
+async function useBoundCredentialRoot<T>(
+  binding: CredentialRootBinding,
+  platform: NodeJS.Platform,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (binding.state === "missing") throw missingPath(binding.root);
+  await assertCredentialRootStable(binding, platform);
+  const result = await operation();
+  await assertCredentialRootStable(binding, platform);
+  return result;
 }
 
 export function resetEncryptedCredentialStorage(
@@ -29,27 +147,74 @@ export function resetEncryptedCredentialStorage(
   return options.serializeEnvelopeMutation(async (proof) => {
     const removeFile = options.removeFile ?? rm;
     const syncCredentialDirectory = options.syncCredentialDirectory ?? syncDirectory;
-    const roots = new Set<string>();
+    const platform = options.platform ?? process.platform;
     try {
+      const credentialBinding = await bindCredentialRoot(
+        options.credentialRoot,
+        CREDENTIAL_DIRECTORY_MODE,
+        platform,
+      );
+      const telegramBinding = await bindCredentialRoot(
+        options.telegramRoot,
+        TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
+        platform,
+      );
+      const bindingByVault = {
+        credentials: credentialBinding,
+        telegram: telegramBinding,
+      } as const;
+      const bindingByRoot = new Map<string, CredentialRootBinding>([
+        [credentialBinding.root, credentialBinding],
+        [telegramBinding.root, telegramBinding],
+      ]);
+      const guardedRoots: CredentialEnvelopeRoots = {
+        credentialRoot: options.credentialRoot,
+        telegramRoot: options.telegramRoot,
+        readEnvelopeFile: async (path) => {
+          const binding = bindingByRoot.get(dirname(path));
+          if (binding === undefined) throw new TypeError("unexpected credential root");
+          return useBoundCredentialRoot(binding, platform, () =>
+            (options.readEnvelopeFile ?? readFile)(path),
+          );
+        },
+        readEnvelopeDirectory: async (root) => {
+          const binding = bindingByRoot.get(root);
+          if (binding === undefined) throw new TypeError("unexpected credential root");
+          return useBoundCredentialRoot(binding, platform, () =>
+            (options.readEnvelopeDirectory ?? readdir)(root),
+          );
+        },
+      };
       for (const target of credentialEnvelopeTargets(options)) {
-        roots.add(target.root);
-        await removeFile(join(target.root, target.fileName), { force: true });
+        const binding = bindingByVault[target.vault];
+        if (binding.state === "missing") continue;
+        await useBoundCredentialRoot(binding, platform, () =>
+          removeFile(join(target.root, target.fileName), { force: true }),
+        );
       }
-      const remaining = await scanCredentialEnvelopes(options);
+      const remaining = await scanCredentialEnvelopes(guardedRoots);
       for (const blocker of remaining.deletionBlockers) {
-        roots.add(blocker.root);
-        await removeFile(join(blocker.root, blocker.fileName), { force: true });
+        const binding = bindingByVault[blocker.vault];
+        if (binding.state === "missing") throw new TypeError("missing credential root was scanned");
+        await useBoundCredentialRoot(binding, platform, () =>
+          removeFile(join(blocker.root, blocker.fileName), { force: true }),
+        );
       }
-      for (const root of roots) {
+      for (const binding of [credentialBinding, telegramBinding]) {
+        if (binding.state === "missing") continue;
         try {
-          await syncCredentialDirectory(root);
+          await useBoundCredentialRoot(binding, platform, () =>
+            syncCredentialDirectory(binding.root),
+          );
         } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+          if (!isMissing(error)) throw error;
         }
       }
-      if ((await scanCredentialEnvelopes(options)).deletionBlockers.length !== 0) {
+      if ((await scanCredentialEnvelopes(guardedRoots)).deletionBlockers.length !== 0) {
         return { status: "failed" };
       }
+      await assertCredentialRootStable(credentialBinding, platform);
+      await assertCredentialRootStable(telegramBinding, platform);
       const key = await options.deleteKey(proof);
       return { status: "reset", keyCleanupPending: key.status === "failed" };
     } catch {

--- a/apps/desktop/tests/credential-reset.test.ts
+++ b/apps/desktop/tests/credential-reset.test.ts
@@ -1,11 +1,19 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import { credentialEnvelopeTargets } from "../src/main/credential-envelope-inventory.js";
 import { resetEncryptedCredentialStorage } from "../src/main/credential-reset.js";
-import { TELEGRAM_PROFILE_FILE_NAME } from "../src/main/telegram-credential-vault.js";
+import {
+  CREDENTIAL_DIRECTORY_MODE,
+  CREDENTIAL_FILE_MODE,
+} from "../src/main/credential-vault.js";
+import {
+  TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
+  TELEGRAM_CREDENTIAL_FILE_MODE,
+  TELEGRAM_PROFILE_FILE_NAME,
+} from "../src/main/telegram-credential-vault.js";
 
 const roots: string[] = [];
 
@@ -14,9 +22,25 @@ async function fixture() {
   roots.push(root);
   const credentialRoot = join(root, "credentials-v1");
   const telegramRoot = join(root, "telegram-channel-v1");
-  await mkdir(credentialRoot, { recursive: true });
-  await mkdir(telegramRoot, { recursive: true });
+  await mkdir(credentialRoot, { recursive: true, mode: CREDENTIAL_DIRECTORY_MODE });
+  await mkdir(telegramRoot, { recursive: true, mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
   return { credentialRoot, telegramRoot };
+}
+
+async function createDirectoryLinkOrReturnWindowsCapabilityReason(
+  target: string,
+  path: string,
+): Promise<string | undefined> {
+  try {
+    await symlink(target, path, process.platform === "win32" ? "junction" : "dir");
+    return undefined;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (process.platform === "win32" && (code === "EPERM" || code === "EACCES")) {
+      return `Windows symlink capability unavailable (${code})`;
+    }
+    throw error;
+  }
 }
 
 afterEach(async () => {
@@ -78,6 +102,61 @@ describe("encrypted credential reset", () => {
 
     expect(result).toEqual({ status: "failed" });
     expect(deleteKey).not.toHaveBeenCalled();
+  });
+
+  it("accepts missing roots without following or inspecting them", async () => {
+    const storage = await fixture();
+    await rm(storage.credentialRoot, { recursive: true });
+    await rm(storage.telegramRoot, { recursive: true });
+    const readEnvelopeFile = vi.fn(async () => Buffer.from("must not be read"));
+    const readEnvelopeDirectory = vi.fn(async () => ["must-not-be-read.bin"]);
+    const deleteKey = vi.fn(async () => ({ status: "deleted" as const }));
+
+    const result = await resetEncryptedCredentialStorage({
+      ...storage,
+      readEnvelopeFile,
+      readEnvelopeDirectory,
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      deleteKey,
+    });
+
+    expect(result).toEqual({ status: "reset", keyCleanupPending: false });
+    expect(readEnvelopeFile).not.toHaveBeenCalled();
+    expect(readEnvelopeDirectory).not.toHaveBeenCalled();
+    expect(deleteKey).toHaveBeenCalledOnce();
+  });
+
+  it("refuses both roots atomically when one root redirects outside its vault", async ({ skip }) => {
+    const storage = await fixture();
+    const credentialPath = join(storage.credentialRoot, "anthropic.bin");
+    const externalRoot = join(storage.telegramRoot, "..", "external-telegram-vault");
+    const externalProfile = join(externalRoot, TELEGRAM_PROFILE_FILE_NAME);
+    const externalUnrelated = join(externalRoot, "keep.txt");
+    await writeFile(credentialPath, "credential-envelope", { mode: CREDENTIAL_FILE_MODE });
+    await mkdir(externalRoot, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    await writeFile(externalProfile, "telegram-envelope", {
+      mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+    });
+    await writeFile(externalUnrelated, "keep", { mode: TELEGRAM_CREDENTIAL_FILE_MODE });
+    await rm(storage.telegramRoot, { recursive: true });
+    const capabilityReason = await createDirectoryLinkOrReturnWindowsCapabilityReason(
+      externalRoot,
+      storage.telegramRoot,
+    );
+    if (capabilityReason) return skip(capabilityReason);
+    const deleteKey = vi.fn(async () => ({ status: "deleted" as const }));
+
+    const result = await resetEncryptedCredentialStorage({
+      ...storage,
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      deleteKey,
+    });
+
+    expect(result).toEqual({ status: "failed" });
+    expect(deleteKey).not.toHaveBeenCalled();
+    await expect(readFile(credentialPath, "utf8")).resolves.toBe("credential-envelope");
+    await expect(readFile(externalProfile, "utf8")).resolves.toBe("telegram-envelope");
+    await expect(readFile(externalUnrelated, "utf8")).resolves.toBe("keep");
   });
 
   it("reports deferred key cleanup after every envelope is gone", async () => {


### PR DESCRIPTION
## Summary

- Validate and bind both credential vault roots before deleting any envelope.
- Reject POSIX symlink, ownership, mode, or identity drift and Windows junction or reparse drift.
- Keep missing roots untouched and preserve the Keychain key after any unsafe or changed root.
- Add redirected-root and missing-root regression coverage plus a user-facing changeset.

## Verification

- `pnpm check` passed with 0 errors and the existing 20 warnings.
- `vitest run apps/desktop/tests/credential-reset.test.ts` passed: 5/5.
- Desktop and root TypeScript checks passed.
- Fresh architecture adjudication approved the accepted same-user threat boundary.

## Security boundary

The fix blocks persistent root redirection and detects identity changes around every path operation. Hostile code already executing as the same signed-in user remains outside the accepted Desktop threat model.
