### PR TITLE
fix(desktop): bind automatic key retirement roots

### DIFF
--- a/.changeset/bind-automatic-key-retirement-roots.md
+++ b/.changeset/bind-automatic-key-retirement-roots.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Prevented Enduragent from deleting its encryption key when credential storage cannot be safely inspected.
+
+Credential envelope scans now bind both vault roots before automatic Keychain key retirement and
+fail closed when either root is unsafe or changes during the scan.

--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -3,10 +3,8 @@ import type {
   SerializeCredentialEnvelopeMutation,
 } from "./credential-envelope-lock.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
-import {
-  scanCredentialEnvelopes,
-  type CredentialEnvelopeRoots,
-} from "./credential-envelope-inventory.js";
+import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
+import { scanBoundCredentialEnvelopes } from "./credential-envelope-root-binding.js";
 import {
   createKeychainPartitionEncryption,
   createRefusingKeychainEncryption,
@@ -89,7 +87,10 @@ async function selectMacCredentialBackend(
     service: options.service,
     keyCleanupPending: options.keyCleanupPending,
     envelopeCensus: async () => {
-      const inventory = await scanCredentialEnvelopes(options);
+      const { inventory } = await scanBoundCredentialEnvelopes(
+        options,
+        options.platform ?? process.platform,
+      );
       deletionBlockers = inventory.deletionBlockers.length;
       unverifiedEnvelopes = inventory.unverified;
       return {

--- a/apps/desktop/src/main/credential-envelope-root-binding.ts
+++ b/apps/desktop/src/main/credential-envelope-root-binding.ts
@@ -1,0 +1,210 @@
+import type { Stats } from "node:fs";
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import {
+  assertWindowsPrivateDirectoryStable,
+  bindWindowsPrivateDirectory,
+  type WindowsPrivateDirectoryBinding,
+} from "@enduragent/core";
+import {
+  scanCredentialEnvelopes,
+  type CredentialEnvelopeInventory,
+  type CredentialEnvelopeRoots,
+  type CredentialEnvelopeVault,
+} from "./credential-envelope-inventory.js";
+import { CREDENTIAL_DIRECTORY_MODE } from "./credential-vault.js";
+import { TELEGRAM_CREDENTIAL_DIRECTORY_MODE } from "./telegram-credential-vault.js";
+
+interface CredentialRootIdentity {
+  readonly dev: number | bigint;
+  readonly ino: number | bigint;
+}
+
+export type CredentialEnvelopeRootBinding =
+  | Readonly<{
+      state: "missing";
+      root: string;
+      expectedMode: number;
+    }>
+  | Readonly<{
+      state: "bound";
+      root: string;
+      expectedMode: number;
+      identity: CredentialRootIdentity;
+      windowsDirectory?: WindowsPrivateDirectoryBinding;
+    }>;
+
+export interface CredentialEnvelopeRootBindings {
+  readonly platform: NodeJS.Platform;
+  readonly credentials: CredentialEnvelopeRootBinding;
+  readonly telegram: CredentialEnvelopeRootBinding;
+}
+
+export interface BoundCredentialEnvelopeScan {
+  readonly bindings: CredentialEnvelopeRootBindings;
+  readonly inventory: CredentialEnvelopeInventory;
+}
+
+function permissions(mode: number): number {
+  return mode & 0o777;
+}
+
+export function isMissingCredentialRootError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function missingPath(path: string): NodeJS.ErrnoException {
+  return Object.assign(new Error("credential root is missing"), { code: "ENOENT", path });
+}
+
+export function assertPosixCredentialRoot(metadata: Stats, expectedMode: number): void {
+  if (
+    !metadata.isDirectory() ||
+    metadata.isSymbolicLink() ||
+    permissions(metadata.mode) !== expectedMode ||
+    (typeof process.getuid === "function" && metadata.uid !== process.getuid())
+  ) {
+    throw new TypeError("unsafe credential root");
+  }
+}
+
+async function bindCredentialRoot(
+  root: string,
+  expectedMode: number,
+  platform: NodeJS.Platform,
+): Promise<CredentialEnvelopeRootBinding> {
+  let metadata: Stats;
+  try {
+    metadata = await lstat(root);
+  } catch (error) {
+    if (isMissingCredentialRootError(error)) return { state: "missing", root, expectedMode };
+    throw error;
+  }
+  if (platform === "win32") {
+    const windowsDirectory = bindWindowsPrivateDirectory(dirname(root), root);
+    return {
+      state: "bound",
+      root,
+      expectedMode,
+      identity: windowsDirectory.identity,
+      windowsDirectory,
+    };
+  }
+  assertPosixCredentialRoot(metadata, expectedMode);
+  return {
+    state: "bound",
+    root,
+    expectedMode,
+    identity: { dev: metadata.dev, ino: metadata.ino },
+  };
+}
+
+export async function bindCredentialEnvelopeRoots(
+  roots: CredentialEnvelopeRoots,
+  platform: NodeJS.Platform = process.platform,
+): Promise<CredentialEnvelopeRootBindings> {
+  const credentials = await bindCredentialRoot(
+    roots.credentialRoot,
+    CREDENTIAL_DIRECTORY_MODE,
+    platform,
+  );
+  const telegram = await bindCredentialRoot(
+    roots.telegramRoot,
+    TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
+    platform,
+  );
+  return { platform, credentials, telegram };
+}
+
+export function credentialRootBindingForVault(
+  bindings: CredentialEnvelopeRootBindings,
+  vault: CredentialEnvelopeVault,
+): CredentialEnvelopeRootBinding {
+  return bindings[vault];
+}
+
+export async function assertCredentialEnvelopeRootStable(
+  binding: CredentialEnvelopeRootBinding,
+  platform: NodeJS.Platform,
+): Promise<void> {
+  if (binding.state === "missing") {
+    try {
+      await lstat(binding.root);
+    } catch (error) {
+      if (isMissingCredentialRootError(error)) return;
+      throw error;
+    }
+    throw new TypeError("missing credential root appeared");
+  }
+  if (platform === "win32") {
+    assertWindowsPrivateDirectoryStable(binding.windowsDirectory!);
+    return;
+  }
+  const metadata = await lstat(binding.root);
+  assertPosixCredentialRoot(metadata, binding.expectedMode);
+  if (metadata.dev !== binding.identity.dev || metadata.ino !== binding.identity.ino) {
+    throw new TypeError("credential root changed");
+  }
+}
+
+export async function assertCredentialEnvelopeRootsStable(
+  bindings: CredentialEnvelopeRootBindings,
+): Promise<void> {
+  await assertCredentialEnvelopeRootStable(bindings.credentials, bindings.platform);
+  await assertCredentialEnvelopeRootStable(bindings.telegram, bindings.platform);
+}
+
+export async function useBoundCredentialRoot<T>(
+  binding: CredentialEnvelopeRootBinding,
+  platform: NodeJS.Platform,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (binding.state === "missing") throw missingPath(binding.root);
+  await assertCredentialEnvelopeRootStable(binding, platform);
+  try {
+    return await operation();
+  } finally {
+    await assertCredentialEnvelopeRootStable(binding, platform);
+  }
+}
+
+function bindingForRoot(
+  bindings: CredentialEnvelopeRootBindings,
+  root: string,
+): CredentialEnvelopeRootBinding {
+  if (bindings.credentials.root === root) return bindings.credentials;
+  if (bindings.telegram.root === root) return bindings.telegram;
+  throw new TypeError("unexpected credential root");
+}
+
+export function guardedCredentialEnvelopeRoots(
+  roots: CredentialEnvelopeRoots,
+  bindings: CredentialEnvelopeRootBindings,
+): CredentialEnvelopeRoots {
+  return {
+    credentialRoot: roots.credentialRoot,
+    telegramRoot: roots.telegramRoot,
+    readEnvelopeFile: async (path) => {
+      const binding = bindingForRoot(bindings, dirname(path));
+      const read = roots.readEnvelopeFile ?? ((target: string) => readFile(target));
+      return useBoundCredentialRoot(binding, bindings.platform, () => read(path));
+    },
+    readEnvelopeDirectory: async (root) => {
+      const binding = bindingForRoot(bindings, root);
+      const readDirectory = roots.readEnvelopeDirectory ?? ((target: string) => readdir(target));
+      return useBoundCredentialRoot(binding, bindings.platform, () => readDirectory(root));
+    },
+  };
+}
+
+export async function scanBoundCredentialEnvelopes(
+  roots: CredentialEnvelopeRoots,
+  platform: NodeJS.Platform = process.platform,
+): Promise<BoundCredentialEnvelopeScan> {
+  const bindings = await bindCredentialEnvelopeRoots(roots, platform);
+  const inventory = await scanCredentialEnvelopes(
+    guardedCredentialEnvelopeRoots(roots, bindings),
+  );
+  await assertCredentialEnvelopeRootsStable(bindings);
+  return { bindings, inventory };
+}

--- a/apps/desktop/src/main/credential-reset.ts
+++ b/apps/desktop/src/main/credential-reset.ts
@@ -1,11 +1,5 @@
-import type { Stats } from "node:fs";
-import { lstat, readFile, readdir, rm } from "node:fs/promises";
-import { dirname, join } from "node:path";
-import {
-  assertWindowsPrivateDirectoryStable,
-  bindWindowsPrivateDirectory,
-  type WindowsPrivateDirectoryBinding,
-} from "@enduragent/core";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
 import type {
   CredentialEnvelopeLockProof,
   SerializeCredentialEnvelopeMutation,
@@ -15,10 +9,16 @@ import {
   scanCredentialEnvelopes,
   type CredentialEnvelopeRoots,
 } from "./credential-envelope-inventory.js";
-import { CREDENTIAL_DIRECTORY_MODE } from "./credential-vault.js";
+import {
+  assertCredentialEnvelopeRootsStable,
+  bindCredentialEnvelopeRoots,
+  credentialRootBindingForVault,
+  guardedCredentialEnvelopeRoots,
+  isMissingCredentialRootError,
+  useBoundCredentialRoot,
+} from "./credential-envelope-root-binding.js";
 import { syncDirectory } from "./durable-atomic-replace.js";
 import type { KeychainKeyDeletion } from "./keychain-credential-encryption.js";
-import { TELEGRAM_CREDENTIAL_DIRECTORY_MODE } from "./telegram-credential-vault.js";
 
 export type EncryptedCredentialResetResult =
   | Readonly<{ status: "reset"; keyCleanupPending: boolean }>
@@ -32,115 +32,6 @@ export interface ResetEncryptedCredentialStorageOptions extends CredentialEnvelo
   readonly platform?: NodeJS.Platform;
 }
 
-interface CredentialRootIdentity {
-  readonly dev: number | bigint;
-  readonly ino: number | bigint;
-}
-
-type CredentialRootBinding =
-  | Readonly<{
-      state: "missing";
-      root: string;
-      expectedMode: number;
-    }>
-  | Readonly<{
-      state: "bound";
-      root: string;
-      expectedMode: number;
-      identity: CredentialRootIdentity;
-      windowsDirectory?: WindowsPrivateDirectoryBinding;
-    }>;
-
-function permissions(mode: number): number {
-  return mode & 0o777;
-}
-
-function isMissing(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException).code === "ENOENT";
-}
-
-function missingPath(path: string): NodeJS.ErrnoException {
-  return Object.assign(new Error("credential root is missing"), { code: "ENOENT", path });
-}
-
-function assertPosixCredentialRoot(metadata: Stats, expectedMode: number): void {
-  if (
-    !metadata.isDirectory() ||
-    metadata.isSymbolicLink() ||
-    permissions(metadata.mode) !== expectedMode ||
-    (typeof process.getuid === "function" && metadata.uid !== process.getuid())
-  ) {
-    throw new TypeError("unsafe credential root");
-  }
-}
-
-async function bindCredentialRoot(
-  root: string,
-  expectedMode: number,
-  platform: NodeJS.Platform,
-): Promise<CredentialRootBinding> {
-  let metadata: Stats;
-  try {
-    metadata = await lstat(root);
-  } catch (error) {
-    if (isMissing(error)) return { state: "missing", root, expectedMode };
-    throw error;
-  }
-  if (platform === "win32") {
-    const windowsDirectory = bindWindowsPrivateDirectory(dirname(root), root);
-    return {
-      state: "bound",
-      root,
-      expectedMode,
-      identity: windowsDirectory.identity,
-      windowsDirectory,
-    };
-  }
-  assertPosixCredentialRoot(metadata, expectedMode);
-  return {
-    state: "bound",
-    root,
-    expectedMode,
-    identity: { dev: metadata.dev, ino: metadata.ino },
-  };
-}
-
-async function assertCredentialRootStable(
-  binding: CredentialRootBinding,
-  platform: NodeJS.Platform,
-): Promise<void> {
-  if (binding.state === "missing") {
-    try {
-      await lstat(binding.root);
-    } catch (error) {
-      if (isMissing(error)) return;
-      throw error;
-    }
-    throw new TypeError("missing credential root appeared during reset");
-  }
-  if (platform === "win32") {
-    assertWindowsPrivateDirectoryStable(binding.windowsDirectory!);
-    return;
-  }
-  const metadata = await lstat(binding.root);
-  assertPosixCredentialRoot(metadata, binding.expectedMode);
-  if (metadata.dev !== binding.identity.dev || metadata.ino !== binding.identity.ino) {
-    throw new TypeError("credential root changed during reset");
-  }
-}
-
-async function useBoundCredentialRoot<T>(
-  binding: CredentialRootBinding,
-  platform: NodeJS.Platform,
-  operation: () => Promise<T>,
-): Promise<T> {
-  if (binding.state === "missing") throw missingPath(binding.root);
-  await assertCredentialRootStable(binding, platform);
-  const result = await operation();
-  await assertCredentialRootStable(binding, platform);
-  return result;
-}
-
 export function resetEncryptedCredentialStorage(
   options: ResetEncryptedCredentialStorageOptions,
 ): Promise<EncryptedCredentialResetResult> {
@@ -149,44 +40,10 @@ export function resetEncryptedCredentialStorage(
     const syncCredentialDirectory = options.syncCredentialDirectory ?? syncDirectory;
     const platform = options.platform ?? process.platform;
     try {
-      const credentialBinding = await bindCredentialRoot(
-        options.credentialRoot,
-        CREDENTIAL_DIRECTORY_MODE,
-        platform,
-      );
-      const telegramBinding = await bindCredentialRoot(
-        options.telegramRoot,
-        TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
-        platform,
-      );
-      const bindingByVault = {
-        credentials: credentialBinding,
-        telegram: telegramBinding,
-      } as const;
-      const bindingByRoot = new Map<string, CredentialRootBinding>([
-        [credentialBinding.root, credentialBinding],
-        [telegramBinding.root, telegramBinding],
-      ]);
-      const guardedRoots: CredentialEnvelopeRoots = {
-        credentialRoot: options.credentialRoot,
-        telegramRoot: options.telegramRoot,
-        readEnvelopeFile: async (path) => {
-          const binding = bindingByRoot.get(dirname(path));
-          if (binding === undefined) throw new TypeError("unexpected credential root");
-          return useBoundCredentialRoot(binding, platform, () =>
-            (options.readEnvelopeFile ?? readFile)(path),
-          );
-        },
-        readEnvelopeDirectory: async (root) => {
-          const binding = bindingByRoot.get(root);
-          if (binding === undefined) throw new TypeError("unexpected credential root");
-          return useBoundCredentialRoot(binding, platform, () =>
-            (options.readEnvelopeDirectory ?? readdir)(root),
-          );
-        },
-      };
+      const bindings = await bindCredentialEnvelopeRoots(options, platform);
+      const guardedRoots = guardedCredentialEnvelopeRoots(options, bindings);
       for (const target of credentialEnvelopeTargets(options)) {
-        const binding = bindingByVault[target.vault];
+        const binding = credentialRootBindingForVault(bindings, target.vault);
         if (binding.state === "missing") continue;
         await useBoundCredentialRoot(binding, platform, () =>
           removeFile(join(target.root, target.fileName), { force: true }),
@@ -194,27 +51,26 @@ export function resetEncryptedCredentialStorage(
       }
       const remaining = await scanCredentialEnvelopes(guardedRoots);
       for (const blocker of remaining.deletionBlockers) {
-        const binding = bindingByVault[blocker.vault];
+        const binding = credentialRootBindingForVault(bindings, blocker.vault);
         if (binding.state === "missing") throw new TypeError("missing credential root was scanned");
         await useBoundCredentialRoot(binding, platform, () =>
           removeFile(join(blocker.root, blocker.fileName), { force: true }),
         );
       }
-      for (const binding of [credentialBinding, telegramBinding]) {
+      for (const binding of [bindings.credentials, bindings.telegram]) {
         if (binding.state === "missing") continue;
         try {
           await useBoundCredentialRoot(binding, platform, () =>
             syncCredentialDirectory(binding.root),
           );
         } catch (error) {
-          if (!isMissing(error)) throw error;
+          if (!isMissingCredentialRootError(error)) throw error;
         }
       }
       if ((await scanCredentialEnvelopes(guardedRoots)).deletionBlockers.length !== 0) {
         return { status: "failed" };
       }
-      await assertCredentialRootStable(credentialBinding, platform);
-      await assertCredentialRootStable(telegramBinding, platform);
+      await assertCredentialEnvelopeRootsStable(bindings);
       const key = await options.deleteKey(proof);
       return { status: "reset", keyCleanupPending: key.status === "failed" };
     } catch {

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -172,11 +172,17 @@ export async function createKeychainPartitionEncryption(
   if (probe.op !== "probe" || probe.teamIdentifier !== KEYCHAIN_TEAM_IDENTIFIER) {
     return refused("unknown");
   }
-  const envelopeCensus = async (): Promise<KeychainEnvelopeCensus> =>
-    typeof options.envelopeCensus === "function"
-      ? await options.envelopeCensus()
-      : options.envelopeCensus;
+  const envelopeCensus = async (): Promise<KeychainEnvelopeCensus | undefined> => {
+    try {
+      return typeof options.envelopeCensus === "function"
+        ? await options.envelopeCensus()
+        : options.envelopeCensus;
+    } catch {
+      return undefined;
+    }
+  };
   const initialCensus = await envelopeCensus();
+  if (initialCensus === undefined) return refused("unknown", options.keyCleanupPending ?? false);
 
   const createMaterial = async (): Promise<
     | Readonly<{ status: "ready"; key: Buffer }>
@@ -223,7 +229,7 @@ export async function createKeychainPartitionEncryption(
       if (holder.key !== null) return { status: "ready" };
       if (holder.cleanupPending) {
         const census = await envelopeCensus();
-        if (census.deletionBlockers > 0) {
+        if (census === undefined || census.deletionBlockers > 0) {
           holder.failure = "unknown";
           return { status: "failed", code: holder.failure };
         }
@@ -245,6 +251,10 @@ export async function createKeychainPartitionEncryption(
         return existing;
       }
       const census = await envelopeCensus();
+      if (census === undefined) {
+        holder.failure = "unknown";
+        return { status: "failed", code: holder.failure };
+      }
       if (census.keychainDependents > 0) {
         holder.failure = "item-not-found";
         return { status: "failed", code: holder.failure };
@@ -260,7 +270,7 @@ export async function createKeychainPartitionEncryption(
     };
     const deleteKey = async (): Promise<KeychainKeyDeletion> => {
       const census = await envelopeCensus();
-      if (census.deletionBlockers > 0) {
+      if (census === undefined || census.deletionBlockers > 0) {
         holder.failure = "unknown";
         return { status: "failed", code: holder.failure };
       }

--- a/apps/desktop/src/main/keychain-key-lifetime.ts
+++ b/apps/desktop/src/main/keychain-key-lifetime.ts
@@ -1,7 +1,8 @@
+import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
 import {
-  scanCredentialEnvelopes,
-  type CredentialEnvelopeRoots,
-} from "./credential-envelope-inventory.js";
+  assertCredentialEnvelopeRootsStable,
+  scanBoundCredentialEnvelopes,
+} from "./credential-envelope-root-binding.js";
 import type { CredentialEnvelopeLockProof } from "./credential-envelope-lock.js";
 import type { KeychainKeyDeletion } from "./keychain-credential-encryption.js";
 import type { KeychainBindingErrorCode } from "./keychain-binding.js";
@@ -15,14 +16,23 @@ export type KeychainKeyRetirement =
 export interface RetireKeychainKeyOptions extends CredentialEnvelopeRoots {
   readonly lockProof: CredentialEnvelopeLockProof;
   readonly deleteKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyDeletion>;
+  readonly platform?: NodeJS.Platform;
 }
 
 export async function retireKeychainKeyWhenLastEnvelopeGone(
   options: RetireKeychainKeyOptions,
 ): Promise<KeychainKeyRetirement> {
-  const inventory = await scanCredentialEnvelopes(options);
-  if (inventory.deletionBlockers.length > 0) {
-    return { status: "retained", envelopes: inventory.deletionBlockers.length };
+  try {
+    const { bindings, inventory } = await scanBoundCredentialEnvelopes(
+      options,
+      options.platform ?? process.platform,
+    );
+    if (inventory.deletionBlockers.length > 0) {
+      return { status: "retained", envelopes: inventory.deletionBlockers.length };
+    }
+    await assertCredentialEnvelopeRootsStable(bindings);
+    return await options.deleteKey(options.lockProof);
+  } catch {
+    return { status: "failed", code: "unknown" };
   }
-  return await options.deleteKey(options.lockProof);
 }

--- a/apps/desktop/tests/credential-backend-selection.test.ts
+++ b/apps/desktop/tests/credential-backend-selection.test.ts
@@ -1,5 +1,15 @@
 import { randomBytes } from "node:crypto";
-import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,8 +19,10 @@ import {
   type SelectDesktopCredentialBackendOptions,
 } from "../src/main/credential-backend-selection.js";
 import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
+import { assertPosixCredentialRoot } from "../src/main/credential-envelope-root-binding.js";
 import {
   createCredentialVault,
+  CREDENTIAL_DIRECTORY_MODE,
   type CredentialEncryptionPort,
   type DesktopCredentialSlot,
 } from "../src/main/credential-vault.js";
@@ -32,6 +44,7 @@ import {
   type KeychainBindingTransport,
 } from "../src/main/keychain-binding.js";
 import {
+  TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
   TELEGRAM_PROFILE_FILE_NAME,
   createTelegramCredentialVault,
 } from "../src/main/telegram-credential-vault.js";
@@ -180,6 +193,139 @@ afterEach(async () => {
 });
 
 describe("backend selection", () => {
+  posixIt("rejects a private credential root owned by another uid", () => {
+    if (typeof process.getuid !== "function") throw new TypeError("uid unavailable");
+    const currentUid = process.getuid();
+    const metadata = {
+      isDirectory: () => true,
+      isSymbolicLink: () => false,
+      mode: CREDENTIAL_DIRECTORY_MODE,
+      uid: currentUid + 1,
+    } as Parameters<typeof assertPosixCredentialRoot>[0];
+
+    expect(() => assertPosixCredentialRoot(metadata, CREDENTIAL_DIRECTORY_MODE)).toThrow(TypeError);
+  });
+
+  posixIt("refuses startup key retirement when a credential root redirects", async () => {
+    const roots = await fixture();
+    const hiddenRoot = `${roots.credentialRoot}-hidden`;
+    const redirectedRoot = `${roots.credentialRoot}-redirected`;
+    const hiddenEnvelope = join(hiddenRoot, "anthropic.bin");
+    await mkdir(hiddenRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(redirectedRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await writeFile(hiddenEnvelope, "hidden-envelope");
+    await symlink(redirectedRoot, roots.credentialRoot, "dir");
+    const transport = transportOf(
+      PROBE_OK,
+      readKey(randomBytes(KEYCHAIN_KEY_BYTES)),
+      { ok: true, op: "delete-key", deleted: true },
+    );
+
+    const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+    expect(selected).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "unknown",
+    });
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe"]);
+    await expect(readFile(hiddenEnvelope, "utf8")).resolves.toBe("hidden-envelope");
+  });
+
+  posixIt("refuses startup key retirement when a credential root is a dangling link", async () => {
+    const roots = await fixture();
+    await symlink(`${roots.credentialRoot}-missing`, roots.credentialRoot, "dir");
+    const transport = transportOf(
+      PROBE_OK,
+      readKey(randomBytes(KEYCHAIN_KEY_BYTES)),
+      { ok: true, op: "delete-key", deleted: true },
+    );
+
+    const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+    expect(selected).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "unknown",
+    });
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe"]);
+  });
+
+  posixIt("refuses startup key retirement when a credential root has unsafe mode", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await chmod(roots.credentialRoot, 0o755);
+    const transport = transportOf(
+      PROBE_OK,
+      readKey(randomBytes(KEYCHAIN_KEY_BYTES)),
+      { ok: true, op: "delete-key", deleted: true },
+    );
+
+    const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+    expect(selected).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "unknown",
+    });
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe"]);
+  });
+
+  posixIt(
+    "refuses startup key retirement when a credential root changes during census",
+    async () => {
+      const roots = await fixture();
+      await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+      const readEnvelopeDirectory = vi.fn(async (root: string) => {
+        if (root === roots.credentialRoot) {
+          await rename(root, `${root}-displaced`);
+          await mkdir(root, { mode: CREDENTIAL_DIRECTORY_MODE });
+        }
+        return [];
+      });
+      const transport = transportOf(
+        PROBE_OK,
+        readKey(randomBytes(KEYCHAIN_KEY_BYTES)),
+        { ok: true, op: "delete-key", deleted: true },
+      );
+
+      const selected = await selectDesktopCredentialBackend({
+        ...selection(roots, transport),
+        readEnvelopeDirectory,
+      });
+
+      expect(selected).toMatchObject({
+        status: "refused",
+        reason: "encryption-unavailable",
+        code: "unknown",
+      });
+      expect(readEnvelopeDirectory).toHaveBeenCalledOnce();
+      expect(transport.requests.map((request) => request.op)).toEqual(["probe"]);
+    },
+  );
+
+  posixIt("retires an orphan key when both bound roots are stably empty", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(roots.telegramRoot, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    const transport = transportOf(
+      PROBE_OK,
+      readKey(randomBytes(KEYCHAIN_KEY_BYTES)),
+      { ok: true, op: "delete-key", deleted: true },
+    );
+
+    const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+
+    expect(selected).toMatchObject({ status: "keychain", createdKey: false });
+    if (selected.status !== "keychain") return;
+    expect(selected.encryption.isEncryptionAvailable()).toBe(false);
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "delete-key",
+    ]);
+  });
+
   posixIt("selects the keychain backend on a team-signed darwin build", async () => {
     const roots = await fixture();
     const key = randomBytes(KEYCHAIN_KEY_BYTES);
@@ -582,7 +728,7 @@ describe("keychain failure mapping", () => {
 
   posixIt("lets a recognised transient key-id one envelope block key creation", async () => {
     const roots = await fixture();
-    await mkdir(roots.credentialRoot, { recursive: true });
+    await mkdir(roots.credentialRoot, { recursive: true, mode: CREDENTIAL_DIRECTORY_MODE });
     const transient = sealCredentialEnvelope(
       randomBytes(KEYCHAIN_KEY_BYTES),
       "transient-secret",

--- a/apps/desktop/tests/desktop-credential-encryption.test.ts
+++ b/apps/desktop/tests/desktop-credential-encryption.test.ts
@@ -1,9 +1,13 @@
 import { randomBytes } from "node:crypto";
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
-import type { CredentialEncryptionPort } from "../src/main/credential-vault.js";
+import {
+  CREDENTIAL_DIRECTORY_MODE,
+  type CredentialEncryptionPort,
+} from "../src/main/credential-vault.js";
 import {
   desktopKeychainCredentialService,
   prepareDesktopCredentialEncryption,
@@ -21,9 +25,12 @@ import {
   type KeychainBindingRequest,
   type KeychainBindingResponse,
 } from "../src/main/keychain-binding.js";
+import { TELEGRAM_CREDENTIAL_DIRECTORY_MODE } from "../src/main/telegram-credential-vault.js";
 
-const CREDENTIAL_ROOT = "/synthetic/userData/credentials-v1";
-const TELEGRAM_ROOT = "/synthetic/userData/telegram-channel-v1";
+let fixtureRoot = "";
+let credentialRoot = "";
+let telegramRoot = "";
+const posixIt = it.skipIf(process.platform === "win32");
 const KEY = randomBytes(KEYCHAIN_KEY_BYTES);
 const PROBE_OK: KeychainBindingResponse = {
   ok: true,
@@ -62,7 +69,7 @@ function noEnvelopes() {
 function migratedTelegramEnvelope() {
   const sealed = sealCredentialEnvelope(KEY, "bot-token");
   return (async (path: string) => {
-    if (path.startsWith(TELEGRAM_ROOT)) return Buffer.from(sealed);
+    if (path.startsWith(telegramRoot)) return Buffer.from(sealed);
     throw Object.assign(new Error("missing"), { code: "ENOENT" });
   }) as never;
 }
@@ -72,7 +79,7 @@ function removableTelegramEnvelope() {
   let present = true;
   return {
     read: (async (path: string) => {
-      if (present && path.startsWith(TELEGRAM_ROOT)) return Buffer.from(sealed);
+      if (present && path.startsWith(telegramRoot)) return Buffer.from(sealed);
       throw Object.assign(new Error("missing"), { code: "ENOENT" });
     }) as never,
     remove() {
@@ -85,8 +92,8 @@ function options(
   overrides: Partial<PrepareDesktopCredentialEncryptionOptions> = {},
 ): PrepareDesktopCredentialEncryptionOptions {
   return {
-    credentialRoot: CREDENTIAL_ROOT,
-    telegramRoot: TELEGRAM_ROOT,
+    credentialRoot,
+    telegramRoot,
     safeStorage: safeStoragePort(),
     readEnvelopeFile: noEnvelopes(),
     location: {
@@ -99,6 +106,18 @@ function options(
     ...overrides,
   };
 }
+
+beforeAll(async () => {
+  fixtureRoot = await mkdtemp(join(await realpath(tmpdir()), "desktop-credential-encryption-"));
+  credentialRoot = join(fixtureRoot, "credentials-v1");
+  telegramRoot = join(fixtureRoot, "telegram-channel-v1");
+  await mkdir(credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+  await mkdir(telegramRoot, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+});
+
+afterAll(async () => {
+  await rm(fixtureRoot, { recursive: true, force: true });
+});
 
 describe("desktop credential encryption startup", () => {
   it("separates the signed-release service from the development service", () => {
@@ -287,6 +306,48 @@ describe("desktop credential encryption startup", () => {
     expect(stablePort.decryptString(stablePort.encryptString("synthetic-secret"))).toBe(
       "synthetic-secret",
     );
+  });
+
+  posixIt("refuses Retry when a previously safe credential root redirects", async () => {
+    const retryRoot = await mkdtemp(join(fixtureRoot, "retry-redirect-"));
+    const retryCredentialRoot = join(retryRoot, "credentials-v1");
+    const retryTelegramRoot = join(retryRoot, "telegram-channel-v1");
+    const redirectedRoot = join(retryRoot, "redirected-credentials");
+    await mkdir(retryCredentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(retryTelegramRoot, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(redirectedRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: false, code: "keychain-locked" },
+      PROBE_OK,
+      { ok: true, op: "read-key", key: KEY },
+      { ok: true, op: "delete-key", deleted: true },
+    );
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({
+        credentialRoot: retryCredentialRoot,
+        telegramRoot: retryTelegramRoot,
+        createTransport: () => transport,
+      }),
+    );
+    expect(prepared.selection).toMatchObject({
+      status: "refused",
+      code: "keychain-locked",
+    });
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
+    await rm(retryCredentialRoot, { recursive: true });
+    await symlink(redirectedRoot, retryCredentialRoot, "dir");
+
+    await expect(prepared.retryKeychain()).resolves.toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "unknown",
+    });
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "probe",
+    ]);
   });
 
   it("leaves the custom key absent after reset and recreates it only before a later write", async () => {

--- a/apps/desktop/tests/keychain-key-lifetime.test.ts
+++ b/apps/desktop/tests/keychain-key-lifetime.test.ts
@@ -1,10 +1,19 @@
 import { randomBytes } from "node:crypto";
-import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createCredentialVault,
+  CREDENTIAL_DIRECTORY_MODE,
   type CredentialEncryptionPort,
   type DesktopCredentialSlot,
 } from "../src/main/credential-vault.js";
@@ -24,6 +33,7 @@ import {
 } from "../src/main/keychain-binding.js";
 import { retireKeychainKeyWhenLastEnvelopeGone } from "../src/main/keychain-key-lifetime.js";
 import {
+  TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
   TELEGRAM_PROFILE_FILE_NAME,
   createTelegramCredentialVault,
 } from "../src/main/telegram-credential-vault.js";
@@ -94,13 +104,15 @@ async function keychainEncryption(): Promise<CredentialEncryptionPort> {
 async function retireKey(
   roots: Fixture,
   transport: RecordingTransport,
-  readEnvelopeFile?: typeof readFile,
+  readEnvelopeFile?: (path: string) => Promise<Buffer>,
+  readEnvelopeDirectory?: (path: string) => Promise<string[]>,
 ) {
   const serialize = createCredentialEnvelopeMutationLock();
   return await serialize((lockProof) =>
     retireKeychainKeyWhenLastEnvelopeGone({
       ...roots,
       readEnvelopeFile,
+      readEnvelopeDirectory,
       lockProof,
       deleteKey: async () => {
         const deleted = await transport.send({
@@ -160,6 +172,38 @@ afterEach(async () => {
 });
 
 describe("keychain key retirement", () => {
+  posixIt("refuses key retirement when a credential root redirects", async () => {
+    const roots = await fixture();
+    const hiddenRoot = `${roots.credentialRoot}-hidden`;
+    const redirectedRoot = `${roots.credentialRoot}-redirected`;
+    const hiddenEnvelope = join(hiddenRoot, "anthropic.bin");
+    await mkdir(hiddenRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(redirectedRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await writeFile(hiddenEnvelope, "hidden-envelope");
+    await symlink(redirectedRoot, roots.credentialRoot, "dir");
+    const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
+
+    await expect(retireKey(roots, transport)).resolves.toEqual({
+      status: "failed",
+      code: "unknown",
+    });
+    expect(transport.requests).toHaveLength(0);
+    await expect(readFile(hiddenEnvelope, "utf8")).resolves.toBe("hidden-envelope");
+  });
+
+  posixIt("retires the key when both credential roots remain missing", async () => {
+    const roots = await fixture();
+    const readEnvelopeFile = vi.fn(async () => Buffer.from("must-not-be-read"));
+    const readEnvelopeDirectory = vi.fn(async () => ["must-not-be-read.bin"]);
+    const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
+
+    await expect(
+      retireKey(roots, transport, readEnvelopeFile as never, readEnvelopeDirectory),
+    ).resolves.toEqual({ status: "deleted" });
+    expect(readEnvelopeFile).not.toHaveBeenCalled();
+    expect(readEnvelopeDirectory).not.toHaveBeenCalled();
+  });
+
   posixIt("keeps the key while any envelope survives in either vault", async () => {
     const roots = await fixture();
     const encryption = await keychainEncryption();
@@ -205,6 +249,7 @@ describe("keychain key retirement", () => {
 
   posixIt("keeps the key while an envelope exists but cannot be read", async () => {
     const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
     const transport = transportOf();
 
     await expect(
@@ -217,8 +262,11 @@ describe("keychain key retirement", () => {
 
   posixIt("keeps the key while recognised transient envelope artifacts survive", async () => {
     const roots = await fixture();
-    await mkdir(roots.credentialRoot, { recursive: true });
-    await mkdir(roots.telegramRoot, { recursive: true });
+    await mkdir(roots.credentialRoot, { recursive: true, mode: CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(roots.telegramRoot, {
+      recursive: true,
+      mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
+    });
     await writeFile(join(roots.credentialRoot, ".anthropic.bin.write-1.tmp"), "credential");
     await writeFile(
       join(roots.telegramRoot, `.${TELEGRAM_PROFILE_FILE_NAME}.delete-1.deleted`),
@@ -236,7 +284,7 @@ describe("keychain key retirement", () => {
 
   posixIt("counts only canonical legacy envelopes as user-facing recovery", async () => {
     const roots = await fixture();
-    await mkdir(roots.credentialRoot, { recursive: true });
+    await mkdir(roots.credentialRoot, { recursive: true, mode: CREDENTIAL_DIRECTORY_MODE });
     await writeFile(join(roots.credentialRoot, "anthropic.bin"), "legacy-canonical");
     await writeFile(join(roots.credentialRoot, ".openrouter.bin.write-1.tmp"), "legacy-transient");
 
@@ -249,7 +297,7 @@ describe("keychain key retirement", () => {
 
   posixIt("keeps transient-only recovery out of the user-facing count", async () => {
     const roots = await fixture();
-    await mkdir(roots.credentialRoot, { recursive: true });
+    await mkdir(roots.credentialRoot, { recursive: true, mode: CREDENTIAL_DIRECTORY_MODE });
     await writeFile(join(roots.credentialRoot, ".anthropic.bin.write-1.tmp"), "transient");
     const transport = transportOf();
 
@@ -266,7 +314,10 @@ describe("keychain key retirement", () => {
 
   posixIt("counts a transient key-id one envelope as a keychain dependent", async () => {
     const roots = await fixture();
-    await mkdir(roots.telegramRoot, { recursive: true });
+    await mkdir(roots.telegramRoot, {
+      recursive: true,
+      mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
+    });
     const envelope = sealCredentialEnvelope(randomBytes(KEYCHAIN_KEY_BYTES), "transient-token");
     await writeFile(
       join(roots.telegramRoot, `.${TELEGRAM_PROFILE_FILE_NAME}.write-1.tmp`),
@@ -283,8 +334,8 @@ describe("keychain key retirement", () => {
 
   posixIt("ignores files outside the credential transient namespaces", async () => {
     const roots = await fixture();
-    await mkdir(roots.credentialRoot, { recursive: true });
-    await mkdir(roots.telegramRoot, { recursive: true });
+    await mkdir(roots.credentialRoot, { recursive: true, mode: CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(roots.telegramRoot, { recursive: true, mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
     await writeFile(join(roots.credentialRoot, ".unknown.bin.cleanup.tmp"), "unrelated");
     await writeFile(
       join(roots.telegramRoot, ".telegram-desired-state.json.cleanup.deleted"),


### PR DESCRIPTION
## Summary

- Bind both credential vault roots before automatic Keychain envelope scans.
- Refuse key creation or deletion when a root is redirected, unsafe, or changes during inspection.
- Preserve legitimate retirement when both roots are stably empty or missing.
- Reuse the same root guard for explicit credential reset.
- Add coverage for symlinks, dangling links, unsafe permissions, foreign ownership, root replacement, Retry, and safe empty or missing roots.
- Add a desktop patch changeset.

## Verification

- `pnpm check` — passed with 0 errors and 20 existing warnings.
- `pnpm test` — 618 files passed, 5 skipped; 9,707 tests passed, 15 skipped.
- Focused desktop credential suite — 87 tests passed.
- `git diff --check` — passed.

## Limits

No numeric limits added or changed.