### PR TITLE
fix(desktop): harden credential key retirement

### DIFF
--- a/.changeset/bounded-credential-key-retirement.md
+++ b/.changeset/bounded-credential-key-retirement.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Prevented unsafe credential files or a changed macOS Keychain key from making saved credentials unreadable.
+
+Automatic key retirement now requires a bounded, stable cross-vault census, and every credential write revalidates the persisted key without user interaction.

--- a/apps/desktop/src/main/automatic-key-retirement.ts
+++ b/apps/desktop/src/main/automatic-key-retirement.ts
@@ -1,0 +1,65 @@
+import type { CredentialEnvelopeLockProof } from "./credential-envelope-lock.js";
+import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
+import { scanBoundCredentialEnvelopes } from "./credential-envelope-root-binding.js";
+import type { KeychainBindingErrorCode } from "./keychain-binding.js";
+
+const zeroDeletionBlockerCensusProof = Symbol("zero-deletion-blocker-census-proof");
+
+export interface ZeroDeletionBlockerCensusProof {
+  readonly [zeroDeletionBlockerCensusProof]: true;
+  readonly lockProof: CredentialEnvelopeLockProof;
+}
+
+export type AutomaticKeyRetirementInspection =
+  | Readonly<{
+      status: "inspected";
+      deletionBlockers: number;
+      keychainDependents: number;
+      unverified: number;
+      zeroProof: ZeroDeletionBlockerCensusProof | null;
+    }>
+  | Readonly<{ status: "failed" }>;
+
+export type InspectAutomaticKeyRetirement = (
+  proof: CredentialEnvelopeLockProof,
+) => Promise<AutomaticKeyRetirementInspection>;
+
+export type KeychainKeyRetirement =
+  | Readonly<{ status: "retained"; envelopes: number }>
+  | Readonly<{ status: "deleted" }>
+  | Readonly<{ status: "already-absent" }>
+  | Readonly<{ status: "failed"; code: KeychainBindingErrorCode }>;
+
+export function createAutomaticKeyRetirementInspector(
+  roots: CredentialEnvelopeRoots,
+  platform: NodeJS.Platform = process.platform,
+): InspectAutomaticKeyRetirement {
+  return async (lockProof) => {
+    try {
+      const { inventory } = await scanBoundCredentialEnvelopes(roots, platform);
+      const deletionBlockers = inventory.deletionBlockers.length;
+      return {
+        status: "inspected",
+        deletionBlockers,
+        keychainDependents: inventory.keychainDependents,
+        unverified: inventory.unverified,
+        zeroProof:
+          deletionBlockers === 0
+            ? Object.freeze({
+                [zeroDeletionBlockerCensusProof]: true as const,
+                lockProof,
+              })
+            : null,
+      };
+    } catch {
+      return { status: "failed" };
+    }
+  };
+}
+
+export function isZeroDeletionBlockerCensusProof(
+  proof: ZeroDeletionBlockerCensusProof,
+  lockProof: CredentialEnvelopeLockProof,
+): boolean {
+  return proof[zeroDeletionBlockerCensusProof] === true && proof.lockProof === lockProof;
+}

--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -2,9 +2,12 @@ import type {
   CredentialEnvelopeLockProof,
   SerializeCredentialEnvelopeMutation,
 } from "./credential-envelope-lock.js";
+import {
+  createAutomaticKeyRetirementInspector,
+  type KeychainKeyRetirement,
+} from "./automatic-key-retirement.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
 import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
-import { scanBoundCredentialEnvelopes } from "./credential-envelope-root-binding.js";
 import {
   createKeychainPartitionEncryption,
   createRefusingKeychainEncryption,
@@ -22,7 +25,10 @@ export type DesktopCredentialBackendSelection =
       unverifiedEnvelopes: number;
       createdKey: boolean;
       prepareKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyPreparation>;
-      deleteKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyDeletion>;
+      retireKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyRetirement>;
+      deleteKeyForReset: (
+        proof: CredentialEnvelopeLockProof,
+      ) => Promise<KeychainKeyDeletion>;
     }>
   | Readonly<{ status: "safe-storage"; encryption: CredentialEncryptionPort }>
   | Readonly<{
@@ -82,21 +88,21 @@ async function selectMacCredentialBackend(
 ): Promise<DesktopCredentialBackendSelection> {
   let deletionBlockers = 0;
   let unverifiedEnvelopes = 0;
+  const inspect = createAutomaticKeyRetirementInspector(
+    options,
+    options.platform ?? process.platform,
+  );
   const keychain = await createKeychainPartitionEncryption({
     transport: options.transport,
     service: options.service,
     keyCleanupPending: options.keyCleanupPending,
-    envelopeCensus: async () => {
-      const { inventory } = await scanBoundCredentialEnvelopes(
-        options,
-        options.platform ?? process.platform,
-      );
-      deletionBlockers = inventory.deletionBlockers.length;
-      unverifiedEnvelopes = inventory.unverified;
-      return {
-        deletionBlockers,
-        keychainDependents: inventory.keychainDependents,
-      };
+    inspectAutomaticRetirement: async (currentProof) => {
+      const inspection = await inspect(currentProof);
+      if (inspection.status === "inspected") {
+        deletionBlockers = inspection.deletionBlockers;
+        unverifiedEnvelopes = inspection.unverified;
+      }
+      return inspection;
     },
     lockProof: proof,
   });
@@ -128,6 +134,7 @@ async function selectMacCredentialBackend(
     unverifiedEnvelopes,
     createdKey: keychain.createdKey,
     prepareKey: keychain.prepareKey,
-    deleteKey: keychain.deleteKey,
+    retireKey: keychain.retireKey,
+    deleteKeyForReset: keychain.deleteKeyForReset,
   };
 }

--- a/apps/desktop/src/main/credential-envelope-inventory.ts
+++ b/apps/desktop/src/main/credential-envelope-inventory.ts
@@ -1,7 +1,10 @@
-import { readdir, readFile } from "node:fs/promises";
+import { constants, type Stats } from "node:fs";
+import { lstat, open, readdir } from "node:fs/promises";
 import { join } from "node:path";
+import type { WindowsPrivateDirectoryBinding } from "@enduragent/core";
 import { CREDENTIAL_FILE_MODE, DESKTOP_CREDENTIAL_SLOTS } from "./credential-vault.js";
 import {
+  CREDENTIAL_ENVELOPE_INSPECTION_BYTES,
   KEYCHAIN_ENVELOPE_KEY_ID,
   readCredentialEnvelopeKeyId,
 } from "./keychain-credential-encryption.js";
@@ -9,6 +12,7 @@ import {
   TELEGRAM_CREDENTIAL_FILE_MODE,
   TELEGRAM_PROFILE_FILE_NAME,
 } from "./telegram-credential-vault.js";
+import { readWindowsPrivateFilePrefix } from "./windows-private-file.js";
 
 export type CredentialEnvelopeVault = "credentials" | "telegram";
 
@@ -33,7 +37,21 @@ export interface CredentialEnvelopeRoots {
   readonly credentialRoot: string;
   readonly telegramRoot: string;
   readonly readEnvelopeFile?: (path: string) => Promise<Buffer>;
+  readonly inspectEnvelopeTarget?: (
+    target: CredentialEnvelopeTarget,
+  ) => Promise<CredentialEnvelopeInspection>;
   readonly readEnvelopeDirectory?: (path: string) => Promise<string[]>;
+}
+
+export type CredentialEnvelopeInspection =
+  | Readonly<{ status: "missing" }>
+  | Readonly<{ status: "readable"; contents: Buffer }>
+  | Readonly<{ status: "blocked" }>;
+
+export interface InspectCredentialEnvelopeTargetOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly windowsDirectory?: WindowsPrivateDirectoryBinding;
+  readonly openFile?: typeof open;
 }
 
 export function credentialEnvelopeTargets(
@@ -104,34 +122,174 @@ function transientCredentialEnvelopeTarget(
 
 async function inspectEnvelopeTarget(
   target: CredentialEnvelopeTarget,
-  read: (path: string) => Promise<Buffer>,
+  inspect: (target: CredentialEnvelopeTarget) => Promise<CredentialEnvelopeInspection>,
 ): Promise<CredentialEnvelopeRef | undefined> {
-  let contents: Buffer | undefined;
+  let inspected: CredentialEnvelopeInspection;
   try {
-    contents = await read(join(target.root, target.fileName));
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    inspected = await inspect(target);
+  } catch {
     return { ...target, keyId: undefined };
   }
+  if (inspected.status === "missing") return undefined;
+  if (inspected.status === "blocked") return { ...target, keyId: undefined };
   try {
-    return { ...target, keyId: readCredentialEnvelopeKeyId(contents) };
+    return { ...target, keyId: readCredentialEnvelopeKeyId(inspected.contents) };
   } finally {
-    contents.fill(0);
+    inspected.contents.fill(0);
   }
+}
+
+function permissions(mode: number): number {
+  return mode & 0o777;
+}
+
+function safePosixEnvelopeMetadata(metadata: Stats, expectedMode: number): boolean {
+  return (
+    metadata.isFile() &&
+    !metadata.isSymbolicLink() &&
+    permissions(metadata.mode) === expectedMode &&
+    (typeof process.getuid !== "function" || metadata.uid === process.getuid())
+  );
+}
+
+function samePosixEnvelopeMetadata(first: Stats, second: Stats): boolean {
+  return (
+    first.dev === second.dev &&
+    first.ino === second.ino &&
+    first.mode === second.mode &&
+    first.uid === second.uid &&
+    first.size === second.size &&
+    first.mtimeMs === second.mtimeMs &&
+    first.ctimeMs === second.ctimeMs &&
+    first.isFile() === second.isFile() &&
+    first.isSymbolicLink() === second.isSymbolicLink()
+  );
+}
+
+async function inspectPosixCredentialEnvelopeTarget(
+  target: CredentialEnvelopeTarget,
+  openFile: typeof open = open,
+): Promise<CredentialEnvelopeInspection> {
+  const path = join(target.root, target.fileName);
+  let beforeOpen: Stats;
+  try {
+    beforeOpen = await lstat(path);
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT"
+      ? { status: "missing" }
+      : { status: "blocked" };
+  }
+  if (!safePosixEnvelopeMetadata(beforeOpen, target.mode)) return { status: "blocked" };
+  const flags = constants.O_RDONLY | constants.O_NONBLOCK | (constants.O_NOFOLLOW ?? 0);
+  let handle;
+  try {
+    handle = await openFile(path, flags);
+  } catch {
+    return { status: "blocked" };
+  }
+  let contents: Buffer | undefined;
+  try {
+    const opened = await handle.stat();
+    if (
+      !safePosixEnvelopeMetadata(opened, target.mode) ||
+      !samePosixEnvelopeMetadata(beforeOpen, opened) ||
+      !Number.isSafeInteger(opened.size) ||
+      opened.size < 0
+    ) {
+      return { status: "blocked" };
+    }
+    const prefixBytes = Math.min(opened.size, CREDENTIAL_ENVELOPE_INSPECTION_BYTES);
+    contents = Buffer.allocUnsafe(prefixBytes);
+    let offset = 0;
+    while (offset < contents.length) {
+      const read = await handle.read(contents, offset, contents.length - offset, offset);
+      if (read.bytesRead <= 0) return { status: "blocked" };
+      offset += read.bytesRead;
+    }
+    const afterRead = await handle.stat();
+    let current: Stats;
+    try {
+      current = await lstat(path);
+    } catch {
+      return { status: "blocked" };
+    }
+    if (
+      !safePosixEnvelopeMetadata(afterRead, target.mode) ||
+      !safePosixEnvelopeMetadata(current, target.mode) ||
+      !samePosixEnvelopeMetadata(beforeOpen, afterRead) ||
+      !samePosixEnvelopeMetadata(afterRead, current)
+    ) {
+      return { status: "blocked" };
+    }
+    await handle.close();
+    handle = undefined;
+    return { status: "readable", contents };
+  } catch {
+    return { status: "blocked" };
+  } finally {
+    if (handle !== undefined) {
+      contents?.fill(0);
+      await handle.close().catch(() => undefined);
+    }
+  }
+}
+
+export async function inspectCredentialEnvelopeTarget(
+  target: CredentialEnvelopeTarget,
+  options: InspectCredentialEnvelopeTargetOptions = {},
+): Promise<CredentialEnvelopeInspection> {
+  if ((options.platform ?? process.platform) !== "win32") {
+    return await inspectPosixCredentialEnvelopeTarget(target, options.openFile);
+  }
+  if (options.windowsDirectory === undefined) return { status: "blocked" };
+  try {
+    const snapshot = await readWindowsPrivateFilePrefix({
+      directory: options.windowsDirectory,
+      path: join(target.root, target.fileName),
+      maximumReadBytes: CREDENTIAL_ENVELOPE_INSPECTION_BYTES,
+      openFile: options.openFile,
+    });
+    return snapshot === undefined
+      ? { status: "missing" }
+      : { status: "readable", contents: snapshot.contents };
+  } catch {
+    return { status: "blocked" };
+  }
+}
+
+function injectedEnvelopeInspector(
+  read: (path: string) => Promise<Buffer>,
+): (target: CredentialEnvelopeTarget) => Promise<CredentialEnvelopeInspection> {
+  return async (target) => {
+    try {
+      return { status: "readable", contents: await read(join(target.root, target.fileName)) };
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code === "ENOENT"
+        ? { status: "missing" }
+        : { status: "blocked" };
+    }
+  };
 }
 
 export async function scanCredentialEnvelopes(
   roots: CredentialEnvelopeRoots,
 ): Promise<CredentialEnvelopeInventory> {
-  const read = roots.readEnvelopeFile ?? ((path: string) => readFile(path));
+  const inspect =
+    roots.inspectEnvelopeTarget ??
+    (roots.readEnvelopeFile === undefined
+      ? inspectCredentialEnvelopeTarget
+      : injectedEnvelopeInspector(roots.readEnvelopeFile));
   const readDirectory = roots.readEnvelopeDirectory ?? readdir;
   const deletionBlockers: CredentialEnvelopeRef[] = [];
   const canonicalEnvelopes: CredentialEnvelopeRef[] = [];
+  const missingCanonicalTargets: CredentialEnvelopeTarget[] = [];
   for (const target of credentialEnvelopeTargets(roots)) {
-    const inspected = await inspectEnvelopeTarget(target, read);
+    const inspected = await inspectEnvelopeTarget(target, inspect);
     if (inspected !== undefined) {
       deletionBlockers.push(inspected);
       canonicalEnvelopes.push(inspected);
+    } else {
+      missingCanonicalTargets.push(target);
     }
   }
   for (const root of new Set([roots.credentialRoot, roots.telegramRoot])) {
@@ -145,8 +303,15 @@ export async function scanCredentialEnvelopes(
     for (const entry of entries) {
       const target = transientCredentialEnvelopeTarget(roots, root, entry);
       if (target === undefined) continue;
-      const inspected = await inspectEnvelopeTarget(target, read);
+      const inspected = await inspectEnvelopeTarget(target, inspect);
       if (inspected !== undefined) deletionBlockers.push(inspected);
+    }
+  }
+  for (const target of missingCanonicalTargets) {
+    const inspected = await inspectEnvelopeTarget(target, inspect);
+    if (inspected !== undefined) {
+      deletionBlockers.push(inspected);
+      canonicalEnvelopes.push(inspected);
     }
   }
   const keychainDependents = deletionBlockers.filter(

--- a/apps/desktop/src/main/credential-envelope-root-binding.ts
+++ b/apps/desktop/src/main/credential-envelope-root-binding.ts
@@ -1,12 +1,13 @@
 import type { Stats } from "node:fs";
-import { lstat, readFile, readdir } from "node:fs/promises";
-import { dirname } from "node:path";
+import { lstat, readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import {
   assertWindowsPrivateDirectoryStable,
   bindWindowsPrivateDirectory,
   type WindowsPrivateDirectoryBinding,
 } from "@enduragent/core";
 import {
+  inspectCredentialEnvelopeTarget,
   scanCredentialEnvelopes,
   type CredentialEnvelopeInventory,
   type CredentialEnvelopeRoots,
@@ -184,10 +185,33 @@ export function guardedCredentialEnvelopeRoots(
   return {
     credentialRoot: roots.credentialRoot,
     telegramRoot: roots.telegramRoot,
-    readEnvelopeFile: async (path) => {
-      const binding = bindingForRoot(bindings, dirname(path));
-      const read = roots.readEnvelopeFile ?? ((target: string) => readFile(target));
-      return useBoundCredentialRoot(binding, bindings.platform, () => read(path));
+    inspectEnvelopeTarget: async (target) => {
+      const binding = bindingForRoot(bindings, target.root);
+      if (binding.state === "missing") {
+        await assertCredentialEnvelopeRootStable(binding, bindings.platform);
+        return { status: "missing" as const };
+      }
+      return useBoundCredentialRoot(binding, bindings.platform, async () => {
+        if (roots.inspectEnvelopeTarget !== undefined) {
+          return await roots.inspectEnvelopeTarget(target);
+        }
+        if (roots.readEnvelopeFile !== undefined) {
+          try {
+            return {
+              status: "readable" as const,
+              contents: await roots.readEnvelopeFile(join(target.root, target.fileName)),
+            };
+          } catch (error) {
+            return (error as NodeJS.ErrnoException).code === "ENOENT"
+              ? { status: "missing" as const }
+              : { status: "blocked" as const };
+          }
+        }
+        return await inspectCredentialEnvelopeTarget(target, {
+          platform: bindings.platform,
+          windowsDirectory: binding.state === "bound" ? binding.windowsDirectory : undefined,
+        });
+      });
     },
     readEnvelopeDirectory: async (root) => {
       const binding = bindingForRoot(bindings, root);

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -638,6 +638,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
   const writeCredential = async (
     input: CredentialWriteInput,
     behavior?: CredentialWriteBehavior,
+    proof?: CredentialEnvelopeLockProof,
   ): Promise<CredentialWriteResult> => {
     if (!isCredentialSlot(input?.slot) || typeof input.value !== "string") {
       return {
@@ -669,9 +670,19 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     ) {
       return { slot: input.slot, status: "refused", reason: "invalid-input" };
     }
-    const encryptionFailure = encryptionRefusal(options.encryption, platform);
-    if (encryptionFailure !== undefined) {
-      return { slot: input.slot, status: "refused", reason: encryptionFailure };
+    let initialEncryptionFailure = encryptionRefusal(options.encryption, platform);
+    if (
+      initialEncryptionFailure === "encryption-unavailable" &&
+      proof !== undefined &&
+      options.prepareEnvelopeWrite !== undefined
+    ) {
+      try {
+        await options.prepareEnvelopeWrite(proof);
+      } catch {}
+      initialEncryptionFailure = encryptionRefusal(options.encryption, platform);
+    }
+    if (initialEncryptionFailure !== undefined) {
+      return { slot: input.slot, status: "refused", reason: initialEncryptionFailure };
     }
     const durability = await reconcileDurability();
     if (durability === "uncertain") {
@@ -716,6 +727,11 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
         }
+      }
+      if (proof !== undefined) await options.prepareEnvelopeWrite?.(proof);
+      const encryptionFailure = encryptionRefusal(options.encryption, platform);
+      if (encryptionFailure !== undefined) {
+        return { slot: input.slot, status: "refused", reason: encryptionFailure };
       }
       encrypted = options.encryption.encryptString(value);
       if (!Buffer.isBuffer(encrypted) || encrypted.length === 0) throw new TypeError();
@@ -843,8 +859,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     writeCredential(input, behavior): Promise<CredentialWriteResult> {
       return serializeCredentialMutation(() =>
         envelopeExclusive(async (proof) => {
-          if (proof !== undefined) await options.prepareEnvelopeWrite?.(proof);
-          return await writeCredential(input, behavior);
+          return await writeCredential(input, behavior, proof);
         }),
       );
     },
@@ -854,7 +869,6 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     ): Promise<T> {
       return serializeCredentialMutation(() =>
         envelopeExclusive(async (proof) => {
-          if (proof !== undefined) await options.prepareEnvelopeWrite?.(proof);
           let active = true;
           const mutation = Object.freeze({
             writeCredential(
@@ -862,7 +876,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
               behavior?: CredentialWriteBehavior,
             ): Promise<CredentialWriteResult> {
               if (!active) throw new TypeError();
-              return writeCredential(input, behavior);
+              return writeCredential(input, behavior, proof);
             },
             credentialStatuses(): Promise<readonly CredentialSlotStatus[]> {
               if (!active) throw new TypeError();

--- a/apps/desktop/src/main/desktop-credential-encryption.ts
+++ b/apps/desktop/src/main/desktop-credential-encryption.ts
@@ -7,10 +7,9 @@ import type {
   CredentialEnvelopeLockProof,
   SerializeCredentialEnvelopeMutation,
 } from "./credential-envelope-lock.js";
-import {
-  scanCredentialEnvelopes,
-  type CredentialEnvelopeRoots,
-} from "./credential-envelope-inventory.js";
+import type { KeychainKeyRetirement } from "./automatic-key-retirement.js";
+import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
+import { scanBoundCredentialEnvelopes } from "./credential-envelope-root-binding.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
 import {
   createRefusingKeychainEncryption,
@@ -25,10 +24,6 @@ import {
   type KeychainBindingTransport,
 } from "./keychain-binding.js";
 import { resolveKeychainBindingPath, type KeychainBindingLocation } from "./keychain-binding-path.js";
-import {
-  retireKeychainKeyWhenLastEnvelopeGone,
-  type KeychainKeyRetirement,
-} from "./keychain-key-lifetime.js";
 
 const UNAVAILABLE_BINDING_RESPONSE: KeychainBindingResponse = Object.freeze({
   ok: false,
@@ -176,11 +171,7 @@ export async function prepareDesktopCredentialEncryption(
       proof: CredentialEnvelopeLockProof,
     ): Promise<KeychainKeyRetirement | undefined> {
       if (selection.status !== "keychain") return undefined;
-      const retired = await retireKeychainKeyWhenLastEnvelopeGone({
-        ...roots,
-        lockProof: proof,
-        deleteKey: selection.deleteKey,
-      });
+      const retired = await selection.retireKey(proof);
       if (retired.status === "failed") transitionToUnavailable(retired.code, true);
       return retired;
     },
@@ -196,7 +187,10 @@ export async function prepareDesktopCredentialEncryption(
         if (current.status !== "keychain") {
           return { selection: current, unverifiedEnvelopes: 0 };
         }
-        const inventory = await scanCredentialEnvelopes(roots);
+        const { inventory } = await scanBoundCredentialEnvelopes(
+          roots,
+          options.location.platform,
+        );
         return { selection: current, unverifiedEnvelopes: inventory.unverified };
       });
     },
@@ -206,7 +200,7 @@ export async function prepareDesktopCredentialEncryption(
       if (options.location.platform !== "darwin") return { status: "already-absent" };
       const deleted =
         selection.status === "keychain"
-          ? await selection.deleteKey(proof)
+          ? await selection.deleteKeyForReset(proof)
           : await transport.send({ op: "delete-key", service }).then((response) => {
               if (!response.ok) return { status: "failed" as const, code: response.code };
               if (response.op !== "delete-key") {

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -1,4 +1,10 @@
-import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { createCipheriv, createDecipheriv, randomBytes, timingSafeEqual } from "node:crypto";
+import {
+  isZeroDeletionBlockerCensusProof,
+  type InspectAutomaticKeyRetirement,
+  type KeychainKeyRetirement,
+  type ZeroDeletionBlockerCensusProof,
+} from "./automatic-key-retirement.js";
 import type { CredentialEnvelopeLockProof } from "./credential-envelope-lock.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
 import {
@@ -19,6 +25,7 @@ const MAGIC = Buffer.from(CREDENTIAL_ENVELOPE_MAGIC, "ascii");
 const HEADER_BYTES = MAGIC.length + 1;
 const MINIMUM_ENVELOPE_BYTES =
   HEADER_BYTES + CREDENTIAL_ENVELOPE_IV_BYTES + CREDENTIAL_ENVELOPE_TAG_BYTES;
+export const CREDENTIAL_ENVELOPE_INSPECTION_BYTES = MINIMUM_ENVELOPE_BYTES;
 
 export class KeychainEncryptionError extends Error {
   constructor(readonly code: KeychainBindingErrorCode) {
@@ -63,7 +70,10 @@ export type KeychainPartitionEncryptionResult =
       readonly encryption: CredentialEncryptionPort;
       readonly createdKey: boolean;
       readonly prepareKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyPreparation>;
-      readonly deleteKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyDeletion>;
+      readonly retireKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyRetirement>;
+      readonly deleteKeyForReset: (
+        proof: CredentialEnvelopeLockProof,
+      ) => Promise<KeychainKeyDeletion>;
     }
   | {
       readonly status: "unavailable";
@@ -85,16 +95,9 @@ export type KeychainPartitionEncryptionResult =
 export interface CreateKeychainPartitionEncryptionOptions {
   readonly transport: KeychainBindingTransport;
   readonly service: string;
-  readonly envelopeCensus:
-    | KeychainEnvelopeCensus
-    | (() => Promise<KeychainEnvelopeCensus>);
+  readonly inspectAutomaticRetirement: InspectAutomaticKeyRetirement;
   readonly keyCleanupPending?: boolean;
   readonly lockProof: CredentialEnvelopeLockProof;
-}
-
-export interface KeychainEnvelopeCensus {
-  readonly deletionBlockers: number;
-  readonly keychainDependents: number;
 }
 
 export function createRefusingKeychainEncryption(
@@ -172,17 +175,18 @@ export async function createKeychainPartitionEncryption(
   if (probe.op !== "probe" || probe.teamIdentifier !== KEYCHAIN_TEAM_IDENTIFIER) {
     return refused("unknown");
   }
-  const envelopeCensus = async (): Promise<KeychainEnvelopeCensus | undefined> => {
+  const inspectAutomaticRetirement = async (proof: CredentialEnvelopeLockProof) => {
+    if (proof !== options.lockProof) return { status: "failed" as const };
     try {
-      return typeof options.envelopeCensus === "function"
-        ? await options.envelopeCensus()
-        : options.envelopeCensus;
+      return await options.inspectAutomaticRetirement(proof);
     } catch {
-      return undefined;
+      return { status: "failed" as const };
     }
   };
-  const initialCensus = await envelopeCensus();
-  if (initialCensus === undefined) return refused("unknown", options.keyCleanupPending ?? false);
+  const initialInspection = await inspectAutomaticRetirement(options.lockProof);
+  if (initialInspection.status === "failed") {
+    return refused("unknown", options.keyCleanupPending ?? false);
+  }
 
   const createMaterial = async (): Promise<
     | Readonly<{ status: "ready"; key: Buffer }>
@@ -192,9 +196,9 @@ export async function createKeychainPartitionEncryption(
     if (!created.ok) return { status: "failed", code: created.code };
     if (created.op !== "create-key") return { status: "failed", code: "unknown" };
     const key = Buffer.from(created.key);
-    return key.length === KEYCHAIN_KEY_BYTES
-      ? { status: "ready", key }
-      : { status: "failed", code: "unknown" };
+    if (key.length === KEYCHAIN_KEY_BYTES) return { status: "ready", key };
+    key.fill(0);
+    return { status: "failed", code: "unknown" };
   };
 
   const readMaterial = async (): Promise<
@@ -210,12 +214,12 @@ export async function createKeychainPartitionEncryption(
     }
     if (read.op !== "read-key") return { status: "failed", code: "unknown" };
     const key = Buffer.from(read.key);
-    return key.length === KEYCHAIN_KEY_BYTES
-      ? { status: "ready", key }
-      : { status: "failed", code: "unknown" };
+    if (key.length === KEYCHAIN_KEY_BYTES) return { status: "ready", key };
+    key.fill(0);
+    return { status: "failed", code: "unknown" };
   };
 
-  const deleteMaterial = async (): Promise<KeychainKeyDeletion> => {
+  const deleteMaterialForReset = async (): Promise<KeychainKeyDeletion> => {
     const deleted = await transport.send({ op: "delete-key", service });
     if (!deleted.ok || deleted.op !== "delete-key") {
       return { status: "failed", code: deleted.ok ? "unknown" : deleted.code };
@@ -223,20 +227,49 @@ export async function createKeychainPartitionEncryption(
     return { status: deleted.deleted ? "deleted" : "already-absent" };
   };
 
+  const deleteMaterial = async (
+    zeroProof: ZeroDeletionBlockerCensusProof,
+  ): Promise<KeychainKeyDeletion> => {
+    if (!isZeroDeletionBlockerCensusProof(zeroProof, options.lockProof)) {
+      return { status: "failed", code: "unknown" };
+    }
+    return await deleteMaterialForReset();
+  };
+
   const ready = (key: Buffer | null, createdKey: boolean): KeychainPartitionEncryptionResult => {
     const holder: KeyHolder = { key, failure: "item-not-found", cleanupPending: false };
-    const prepareKey = async (): Promise<KeychainKeyPreparation> => {
-      if (holder.key !== null) return { status: "ready" };
-      if (holder.cleanupPending) {
-        const census = await envelopeCensus();
-        if (census === undefined || census.deletionBlockers > 0) {
-          holder.failure = "unknown";
-          return { status: "failed", code: holder.failure };
+    const fail = (code: KeychainBindingErrorCode): KeychainKeyPreparation => {
+      holder.failure = code;
+      return { status: "failed", code };
+    };
+    const clearKey = (): void => {
+      holder.key?.fill(0);
+      holder.key = null;
+    };
+    const prepareKey = async (
+      proof: CredentialEnvelopeLockProof,
+    ): Promise<KeychainKeyPreparation> => {
+      if (proof !== options.lockProof) return fail("unknown");
+      if (holder.key !== null) {
+        const persisted = await readMaterial();
+        if (persisted.status === "ready") {
+          const matches = timingSafeEqual(holder.key, persisted.key);
+          persisted.key.fill(0);
+          if (matches) return { status: "ready" };
+          clearKey();
+          return fail("unknown");
         }
-        const deleted = await deleteMaterial();
+        clearKey();
+        return fail(persisted.status === "missing" ? "item-not-found" : persisted.code);
+      }
+      if (holder.cleanupPending) {
+        const inspection = await inspectAutomaticRetirement(proof);
+        if (inspection.status === "failed" || inspection.zeroProof === null) {
+          return fail("unknown");
+        }
+        const deleted = await deleteMaterial(inspection.zeroProof);
         if (deleted.status === "failed") {
-          holder.failure = deleted.code;
-          return deleted;
+          return fail(deleted.code);
         }
         holder.cleanupPending = false;
       }
@@ -247,36 +280,32 @@ export async function createKeychainPartitionEncryption(
         return { status: "ready" };
       }
       if (existing.status === "failed") {
-        holder.failure = existing.code;
-        return existing;
+        return fail(existing.code);
       }
-      const census = await envelopeCensus();
-      if (census === undefined) {
-        holder.failure = "unknown";
-        return { status: "failed", code: holder.failure };
-      }
-      if (census.keychainDependents > 0) {
-        holder.failure = "item-not-found";
-        return { status: "failed", code: holder.failure };
+      const inspection = await inspectAutomaticRetirement(proof);
+      if (inspection.status === "failed") return fail("unknown");
+      if (inspection.keychainDependents > 0) {
+        return fail("item-not-found");
       }
       const created = await createMaterial();
       if (created.status === "failed") {
-        holder.failure = created.code;
-        return created;
+        return fail(created.code);
       }
       holder.key = created.key;
       holder.failure = "item-not-found";
       return { status: "ready" };
     };
-    const deleteKey = async (): Promise<KeychainKeyDeletion> => {
-      const census = await envelopeCensus();
-      if (census === undefined || census.deletionBlockers > 0) {
-        holder.failure = "unknown";
-        return { status: "failed", code: holder.failure };
+    const retireKey = async (
+      proof: CredentialEnvelopeLockProof,
+    ): Promise<KeychainKeyRetirement> => {
+      const inspection = await inspectAutomaticRetirement(proof);
+      if (inspection.status === "failed") return { status: "failed", code: "unknown" };
+      if (inspection.zeroProof === null) {
+        return { status: "retained", envelopes: inspection.deletionBlockers };
       }
       const previous = holder.key;
       holder.key = null;
-      const deleted = await deleteMaterial();
+      const deleted = await deleteMaterial(inspection.zeroProof);
       if (deleted.status === "failed") {
         previous?.fill(0);
         holder.failure = deleted.code;
@@ -288,26 +317,48 @@ export async function createKeychainPartitionEncryption(
       holder.cleanupPending = false;
       return deleted;
     };
-    return { status: "ready", encryption: readyPort(holder), createdKey, prepareKey, deleteKey };
+    const deleteKeyForReset = async (
+      proof: CredentialEnvelopeLockProof,
+    ): Promise<KeychainKeyDeletion> => {
+      if (proof !== options.lockProof) return { status: "failed", code: "unknown" };
+      const previous = holder.key;
+      holder.key = null;
+      const deleted = await deleteMaterialForReset();
+      previous?.fill(0);
+      if (deleted.status === "failed") {
+        holder.failure = deleted.code;
+        holder.cleanupPending = true;
+        return deleted;
+      }
+      holder.failure = "item-not-found";
+      holder.cleanupPending = false;
+      return deleted;
+    };
+    return {
+      status: "ready",
+      encryption: readyPort(holder),
+      createdKey,
+      prepareKey,
+      retireKey,
+      deleteKeyForReset,
+    };
   };
 
   if (options.keyCleanupPending) {
-    if (initialCensus.deletionBlockers > 0) return refused("unknown", true);
-    const deleted = await deleteMaterial();
+    if (initialInspection.zeroProof === null) return refused("unknown", true);
+    const deleted = await deleteMaterial(initialInspection.zeroProof);
     return deleted.status === "failed" ? refused(deleted.code, true) : ready(null, false);
   }
 
   const read = await readMaterial();
   if (read.status === "ready") {
-    if (initialCensus.deletionBlockers > 0) return ready(read.key, false);
-    const deleted = await deleteMaterial();
+    if (initialInspection.zeroProof === null) return ready(read.key, false);
+    const deleted = await deleteMaterial(initialInspection.zeroProof);
     read.key.fill(0);
     return deleted.status === "failed" ? refused(deleted.code, true) : ready(null, false);
   }
   if (read.status === "missing") {
-    return initialCensus.keychainDependents === 0
-      ? ready(null, false)
-      : refused("item-not-found");
+    return initialInspection.keychainDependents > 0 ? refused("item-not-found") : ready(null, false);
   }
   return refused(read.code);
 }

--- a/apps/desktop/src/main/keychain-key-lifetime.ts
+++ b/apps/desktop/src/main/keychain-key-lifetime.ts
@@ -1,37 +1,18 @@
-import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
-import {
-  assertCredentialEnvelopeRootsStable,
-  scanBoundCredentialEnvelopes,
-} from "./credential-envelope-root-binding.js";
 import type { CredentialEnvelopeLockProof } from "./credential-envelope-lock.js";
-import type { KeychainKeyDeletion } from "./keychain-credential-encryption.js";
-import type { KeychainBindingErrorCode } from "./keychain-binding.js";
+import type { KeychainKeyRetirement } from "./automatic-key-retirement.js";
 
-export type KeychainKeyRetirement =
-  | Readonly<{ status: "retained"; envelopes: number }>
-  | Readonly<{ status: "deleted" }>
-  | Readonly<{ status: "already-absent" }>
-  | Readonly<{ status: "failed"; code: KeychainBindingErrorCode }>;
+export type { KeychainKeyRetirement } from "./automatic-key-retirement.js";
 
-export interface RetireKeychainKeyOptions extends CredentialEnvelopeRoots {
+export interface RetireKeychainKeyOptions {
   readonly lockProof: CredentialEnvelopeLockProof;
-  readonly deleteKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyDeletion>;
-  readonly platform?: NodeJS.Platform;
+  readonly retireKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyRetirement>;
 }
 
 export async function retireKeychainKeyWhenLastEnvelopeGone(
   options: RetireKeychainKeyOptions,
 ): Promise<KeychainKeyRetirement> {
   try {
-    const { bindings, inventory } = await scanBoundCredentialEnvelopes(
-      options,
-      options.platform ?? process.platform,
-    );
-    if (inventory.deletionBlockers.length > 0) {
-      return { status: "retained", envelopes: inventory.deletionBlockers.length };
-    }
-    await assertCredentialEnvelopeRootsStable(bindings);
-    return await options.deleteKey(options.lockProof);
+    return await options.retireKey(options.lockProof);
   } catch {
     return { status: "failed", code: "unknown" };
   }

--- a/apps/desktop/src/main/telegram-credential-vault.ts
+++ b/apps/desktop/src/main/telegram-credential-vault.ts
@@ -768,7 +768,6 @@ export function createTelegramCredentialVault(
 
     replaceProfile(input): Promise<TelegramProfileReplaceResult> {
       return envelopeExclusive(async (proof) => {
-        if (proof !== undefined) await options.prepareEnvelopeWrite?.(proof);
         const authenticatedAthleteHome = parseAthleteHome(input?.authenticatedAthleteHome);
         if (authenticatedAthleteHome === undefined || authenticatedAthleteHome !== athleteHome) {
           return { outcome: "refused", reason: "wrong-home" };
@@ -779,9 +778,19 @@ export function createTelegramCredentialVault(
         if (token === undefined || id === undefined || username === undefined) {
           return { outcome: "refused", reason: "invalid-input" };
         }
-        const encryptionFailure = observedEncryptionRefusal();
-        if (encryptionFailure !== undefined) {
-          return { outcome: "refused", reason: encryptionFailure };
+        let initialEncryptionFailure = observedEncryptionRefusal();
+        if (
+          initialEncryptionFailure === "encryption-unavailable" &&
+          proof !== undefined &&
+          options.prepareEnvelopeWrite !== undefined
+        ) {
+          try {
+            await options.prepareEnvelopeWrite(proof);
+          } catch {}
+          initialEncryptionFailure = observedEncryptionRefusal();
+        }
+        if (initialEncryptionFailure !== undefined) {
+          return { outcome: "refused", reason: initialEncryptionFailure };
         }
         if (!(await prepareNamespace())) {
           profileUncertain = true;
@@ -806,6 +815,11 @@ export function createTelegramCredentialVault(
         let plaintext: Buffer | undefined;
         let tokenPlaintext: Buffer | undefined;
         try {
+          if (proof !== undefined) await options.prepareEnvelopeWrite?.(proof);
+          const encryptionFailure = observedEncryptionRefusal();
+          if (encryptionFailure !== undefined) {
+            return { outcome: "refused", reason: encryptionFailure };
+          }
           const serialized = JSON.stringify(profile);
           encrypted = options.encryption.encryptString(serialized);
           if (!Buffer.isBuffer(encrypted) || encrypted.length === 0) throw new TypeError();

--- a/apps/desktop/src/main/windows-private-file.ts
+++ b/apps/desktop/src/main/windows-private-file.ts
@@ -19,6 +19,10 @@ export interface WindowsPrivateFileSnapshot {
   readonly modifiedAt: number;
 }
 
+export interface WindowsPrivateFilePrefixSnapshot {
+  readonly contents: Buffer;
+}
+
 export class WindowsPrivateFileMaximumBytesExceededError extends WindowsPrivatePathPolicyError {
   constructor() {
     super("read-check", "corruption");
@@ -30,6 +34,14 @@ export interface ReadWindowsPrivateFileInput {
   readonly path: string;
   readonly minimumBytes?: number;
   readonly maximumBytes: number;
+  readonly allowedLinks?: 1 | 2;
+  readonly openFile?: typeof open;
+}
+
+export interface ReadWindowsPrivateFilePrefixInput {
+  readonly directory: WindowsPrivateDirectoryBinding;
+  readonly path: string;
+  readonly maximumReadBytes: number;
   readonly allowedLinks?: 1 | 2;
   readonly openFile?: typeof open;
 }
@@ -165,6 +177,110 @@ export async function readWindowsPrivateFile(
       assertWindowsPrivateDirectoryStable(input.directory);
       await handle.close();
       return { contents, modifiedAt: afterRead.mtimeMs };
+    } catch (error) {
+      contents?.fill(0);
+      await handle.close().catch(() => undefined);
+      throw error;
+    }
+  } catch (error) {
+    throw classifyWindowsPrivatePathFailure("read-check", error);
+  }
+}
+
+export async function readWindowsPrivateFilePrefix(
+  input: ReadWindowsPrivateFilePrefixInput,
+): Promise<WindowsPrivateFilePrefixSnapshot | undefined> {
+  const allowedLinks = input.allowedLinks ?? 1;
+  try {
+    assertWindowsPrivateDirectoryStable(input.directory);
+    let beforeOpen: Stats;
+    try {
+      beforeOpen = await lstat(input.path);
+    } catch (error) {
+      if (isMissing(error)) {
+        assertWindowsPrivateDirectoryStable(input.directory);
+        return undefined;
+      }
+      throw error;
+    }
+    assertWindowsPrivateFileMetadata(beforeOpen, allowedLinks);
+    assertWindowsPrivateFileBinding(
+      input.directory,
+      input.path,
+      windowsPrivatePathIdentity(beforeOpen),
+      allowedLinks,
+    );
+    const handle = await (input.openFile ?? open)(input.path, constants.O_RDONLY);
+    let contents: Buffer | undefined;
+    try {
+      const opened = await handle.stat();
+      assertWindowsPrivateFileMetadata(opened, allowedLinks);
+      assertWindowsPrivateFileBinding(
+        input.directory,
+        input.path,
+        windowsPrivatePathIdentity(opened),
+        allowedLinks,
+      );
+      const bounded =
+        Number.isSafeInteger(opened.size) &&
+        opened.size >= 0 &&
+        Number.isSafeInteger(input.maximumReadBytes) &&
+        input.maximumReadBytes > 0;
+      assertWindowsPrivatePathRead({
+        bounded,
+        identityStable: sameWindowsPrivatePathIdentity(
+          windowsPrivatePathIdentity(beforeOpen),
+          windowsPrivatePathIdentity(opened),
+        ),
+        contentValid: true,
+        authenticatedHomeBinding: true,
+      });
+      const prefixBytes = Math.min(opened.size, input.maximumReadBytes);
+      contents = Buffer.allocUnsafe(prefixBytes);
+      let offset = 0;
+      while (offset < contents.length) {
+        const read = await handle.read(contents, offset, contents.length - offset, offset);
+        if (read.bytesRead <= 0) {
+          assertWindowsPrivatePathRead({
+            bounded: true,
+            identityStable: true,
+            contentValid: false,
+            authenticatedHomeBinding: true,
+          });
+        }
+        offset += read.bytesRead;
+      }
+      const afterRead = await handle.stat();
+      assertWindowsPrivateFileMetadata(afterRead, allowedLinks);
+      const current = assertWindowsPrivateFileBinding(
+        input.directory,
+        input.path,
+        windowsPrivatePathIdentity(afterRead),
+        allowedLinks,
+      );
+      assertWindowsPrivatePathRead({
+        bounded: true,
+        identityStable:
+          sameWindowsPrivatePathIdentity(
+            windowsPrivatePathIdentity(beforeOpen),
+            windowsPrivatePathIdentity(opened),
+          ) &&
+          sameWindowsPrivatePathIdentity(
+            windowsPrivatePathIdentity(opened),
+            windowsPrivatePathIdentity(afterRead),
+          ) &&
+          opened.size === afterRead.size &&
+          opened.size === current.size &&
+          opened.mtimeMs === afterRead.mtimeMs &&
+          opened.mtimeMs === current.mtimeMs &&
+          opened.ctimeMs === afterRead.ctimeMs &&
+          opened.ctimeMs === current.ctimeMs,
+        contentValid: offset === prefixBytes,
+        authenticatedHomeBinding: true,
+      });
+      assertWindowsPrivateDirectoryStable(input.directory);
+      await handle.close();
+      return { contents };
     } catch (error) {
       contents?.fill(0);
       await handle.close().catch(() => undefined);

--- a/apps/desktop/tests/credential-backend-selection.test.ts
+++ b/apps/desktop/tests/credential-backend-selection.test.ts
@@ -23,6 +23,7 @@ import { assertPosixCredentialRoot } from "../src/main/credential-envelope-root-
 import {
   createCredentialVault,
   CREDENTIAL_DIRECTORY_MODE,
+  CREDENTIAL_FILE_MODE,
   type CredentialEncryptionPort,
   type DesktopCredentialSlot,
 } from "../src/main/credential-vault.js";
@@ -116,7 +117,13 @@ async function keychainEncryption(key: Buffer): Promise<CredentialEncryptionPort
     createKeychainPartitionEncryption({
       transport: transportOf(PROBE_OK, readKey(key)),
       service: KEYCHAIN_CREDENTIAL_SERVICE,
-      envelopeCensus: { deletionBlockers: 1, keychainDependents: 1 },
+      inspectAutomaticRetirement: async () => ({
+        status: "inspected",
+        deletionBlockers: 1,
+        keychainDependents: 1,
+        unverified: 0,
+        zeroProof: null,
+      }),
       lockProof,
     }),
   );
@@ -673,7 +680,11 @@ describe("keychain failure mapping", () => {
       { ok: false, code: "duplicate-item" },
     );
 
-    const selected = await selectDesktopCredentialBackend(selection(roots, transport));
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transport),
+      serializeEnvelopeMutation,
+    });
 
     expect(selected.status).toBe("keychain");
     if (selected.status !== "keychain") return;
@@ -681,7 +692,6 @@ describe("keychain failure mapping", () => {
     expect(selected.encryption.isEncryptionAvailable()).toBe(false);
     expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
 
-    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     await expect(
       serializeEnvelopeMutation((proof) => selected.prepareKey(proof)),
     ).resolves.toEqual({ status: "failed", code: "duplicate-item" });
@@ -733,7 +743,9 @@ describe("keychain failure mapping", () => {
       randomBytes(KEYCHAIN_KEY_BYTES),
       "transient-secret",
     );
-    await writeFile(join(roots.credentialRoot, ".anthropic.bin.pending-1.tmp"), transient);
+    await writeFile(join(roots.credentialRoot, ".anthropic.bin.pending-1.tmp"), transient, {
+      mode: CREDENTIAL_FILE_MODE,
+    });
     transient.fill(0);
     const transport = transportOf(PROBE_OK, { ok: false, code: "item-not-found" });
 

--- a/apps/desktop/tests/credential-key-retirement.test.ts
+++ b/apps/desktop/tests/credential-key-retirement.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAutomaticKeyRetirementInspector } from "../src/main/automatic-key-retirement.js";
 import {
   createCredentialVault,
   type CredentialEncryptionPort,
@@ -78,10 +79,15 @@ async function retireKey(
   transport: ReturnType<typeof transportOf>,
   lockProof: CredentialEnvelopeLockProof,
 ) {
+  const inspect = createAutomaticKeyRetirementInspector(roots);
   return await retireKeychainKeyWhenLastEnvelopeGone({
-    ...roots,
     lockProof,
-    deleteKey: async () => {
+    retireKey: async (proof) => {
+      const inspection = await inspect(proof);
+      if (inspection.status === "failed") return { status: "failed", code: "unknown" };
+      if (inspection.zeroProof === null) {
+        return { status: "retained", envelopes: inspection.deletionBlockers };
+      }
       const deleted = await transport.send({
         op: "delete-key",
         service: KEYCHAIN_CREDENTIAL_SERVICE,

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -15,7 +15,10 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createCredentialMutationLock } from "../src/main/credential-envelope-lock.js";
+import {
+  createCredentialEnvelopeMutationLock,
+  createCredentialMutationLock,
+} from "../src/main/credential-envelope-lock.js";
 import {
   CREDENTIAL_DIRECTORY_MODE,
   CREDENTIAL_FILE_MODE,
@@ -556,6 +559,46 @@ describe("desktop credential vault", () => {
     expect(() =>
       escaped!.writeCredential({ slot: "anthropic", value: "synthetic-secret" }),
     ).toThrow(TypeError);
+    await expect(lstat(join(root, "anthropic.bin"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("revalidates encryption at the delayed exclusive mutation write boundary", async () => {
+    const root = await temporaryRoot();
+    let persistedKey = "key-a";
+    const cachedKey = "key-a";
+    let available = true;
+    const encryptString = vi.fn((value: string) => Buffer.from(value));
+    const prepareEnvelopeWrite = vi.fn(async () => {
+      if (persistedKey !== cachedKey) available = false;
+    });
+    const vault = createCredentialVault({
+      root,
+      encryption: {
+        isEncryptionAvailable: () => available,
+        encryptString,
+        decryptString: vi.fn(),
+      },
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      prepareEnvelopeWrite,
+      applyCredential: vi.fn(async () => undefined),
+    });
+
+    const result = await vault.runExclusiveMutation(async (mutation) => {
+      expect(prepareEnvelopeWrite).not.toHaveBeenCalled();
+      persistedKey = "key-b";
+      return await mutation.writeCredential(
+        { slot: "anthropic", value: "synthetic-secret" },
+        { activate: false },
+      );
+    });
+
+    expect(result).toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "encryption-unavailable",
+    });
+    expect(prepareEnvelopeWrite).toHaveBeenCalledOnce();
+    expect(encryptString).not.toHaveBeenCalled();
     await expect(lstat(join(root, "anthropic.bin"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 

--- a/apps/desktop/tests/desktop-credential-encryption.test.ts
+++ b/apps/desktop/tests/desktop-credential-encryption.test.ts
@@ -148,6 +148,37 @@ describe("desktop credential encryption startup", () => {
     );
   });
 
+  it("publishes encryption unavailable when the persisted key changes before a write", async () => {
+    const replacement = randomBytes(KEYCHAIN_KEY_BYTES);
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: KEY },
+      { ok: true, op: "read-key", key: replacement },
+    );
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({
+        createTransport: () => transport,
+        readEnvelopeFile: migratedTelegramEnvelope(),
+        serializeEnvelopeMutation,
+      }),
+    );
+
+    await serializeEnvelopeMutation((proof) => prepared.prepareEnvelopeWrite(proof));
+
+    expect(prepared.selection).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "unknown",
+    });
+    expect(prepared.encryption.isEncryptionAvailable()).toBe(false);
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "read-key",
+    ]);
+  });
+
   it("never lets an unpackaged run touch the signed-release service", async () => {
     const transport = transportOf(PROBE_OK, {
       ok: true,

--- a/apps/desktop/tests/keychain-credential-encryption.test.ts
+++ b/apps/desktop/tests/keychain-credential-encryption.test.ts
@@ -1,5 +1,11 @@
 import { randomBytes } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  createAutomaticKeyRetirementInspector,
+  type InspectAutomaticKeyRetirement,
+} from "../src/main/automatic-key-retirement.js";
 import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import {
   CREDENTIAL_ENVELOPE_IV_BYTES,
@@ -31,6 +37,7 @@ const PROBE_OK: KeychainBindingResponse = {
   op: "probe",
   teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER,
 };
+const serializePreparedEncryption = createCredentialEnvelopeMutationLock();
 
 interface RecordingTransport extends KeychainBindingTransport {
   readonly requests: KeychainBindingRequest[];
@@ -56,22 +63,50 @@ function storedKey(): { readonly key: Buffer; readonly encoded: Buffer } {
 }
 
 async function createEncryption(
-  options: Omit<CreateKeychainPartitionEncryptionOptions, "envelopeCensus" | "lockProof"> & {
-    readonly envelopeCensus?: CreateKeychainPartitionEncryptionOptions["envelopeCensus"];
+  options: Omit<
+    CreateKeychainPartitionEncryptionOptions,
+    "inspectAutomaticRetirement" | "lockProof"
+  > & {
+    readonly envelopeCensus?: TestEnvelopeCensus | (() => Promise<TestEnvelopeCensus>);
   },
 ) {
   const {
     envelopeCensus = { deletionBlockers: 1, keychainDependents: 1 },
     ...keychainOptions
   } = options;
-  const serialize = createCredentialEnvelopeMutationLock();
-  return await serialize((lockProof) =>
+  return await serializePreparedEncryption((lockProof) =>
     createKeychainPartitionEncryption({
       ...keychainOptions,
-      envelopeCensus,
+      inspectAutomaticRetirement: automaticRetirementInspector(envelopeCensus),
       lockProof,
     }),
   );
+}
+
+interface TestEnvelopeCensus {
+  readonly deletionBlockers: number;
+  readonly keychainDependents: number;
+}
+
+function automaticRetirementInspector(
+  census: TestEnvelopeCensus | (() => Promise<TestEnvelopeCensus>),
+): InspectAutomaticKeyRetirement {
+  const nonce = randomBytes(12).toString("hex");
+  const zeroInspector = createAutomaticKeyRetirementInspector({
+    credentialRoot: join(tmpdir(), `missing-credential-${nonce}`),
+    telegramRoot: join(tmpdir(), `missing-telegram-${nonce}`),
+  });
+  return async (proof) => {
+    const current = typeof census === "function" ? await census() : census;
+    if (current.deletionBlockers === 0) return await zeroInspector(proof);
+    return {
+      status: "inspected",
+      deletionBlockers: current.deletionBlockers,
+      keychainDependents: current.keychainDependents,
+      unverified: 0,
+      zeroProof: null,
+    };
+  };
 }
 
 describe("credential envelope", () => {
@@ -156,6 +191,110 @@ describe("keychain partition backend", () => {
     expect(JSON.stringify(transport.requests)).not.toContain(encoded);
   });
 
+  it("revalidates the same persisted key before a later write", async () => {
+    const { encoded } = storedKey();
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: encoded },
+      { ok: true, op: "read-key", key: Buffer.from(encoded) },
+    );
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await expect(
+      serializePreparedEncryption((proof) => result.prepareKey(proof)),
+    ).resolves.toEqual({ status: "ready" });
+    expect(result.encryption.isEncryptionAvailable()).toBe(true);
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "read-key",
+    ]);
+  });
+
+  it("refuses a write when the persisted key was replaced", async () => {
+    const original = storedKey();
+    const replacement = storedKey();
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: original.encoded },
+      { ok: true, op: "read-key", key: replacement.encoded },
+    );
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await expect(
+      serializePreparedEncryption((proof) => result.prepareKey(proof)),
+    ).resolves.toEqual({ status: "failed", code: "unknown" });
+    expect(result.encryption.isEncryptionAvailable()).toBe(false);
+    expect(() => result.encryption.encryptString("must-not-seal")).toThrow(
+      KeychainEncryptionError,
+    );
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "read-key",
+    ]);
+  });
+
+  it("refuses a write when the persisted key disappeared", async () => {
+    const original = storedKey();
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: original.encoded },
+      { ok: false, code: "item-not-found" },
+    );
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await expect(
+      serializePreparedEncryption((proof) => result.prepareKey(proof)),
+    ).resolves.toEqual({ status: "failed", code: "item-not-found" });
+    expect(result.encryption.isEncryptionAvailable()).toBe(false);
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "read-key",
+    ]);
+  });
+
+  it("refuses a write when no-interaction key revalidation is locked", async () => {
+    const original = storedKey();
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: original.encoded },
+      { ok: false, code: "keychain-locked" },
+    );
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await expect(
+      serializePreparedEncryption((proof) => result.prepareKey(proof)),
+    ).resolves.toEqual({ status: "failed", code: "keychain-locked" });
+    expect(result.encryption.isEncryptionAvailable()).toBe(false);
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "read-key",
+    ]);
+  });
+
   it("keeps an absent key missing until an explicit credential write", async () => {
     const { encoded } = storedKey();
     const transport = transportOf(
@@ -175,8 +314,9 @@ describe("keychain partition backend", () => {
     expect(result.encryption.isEncryptionAvailable()).toBe(false);
     expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
 
-    const serialize = createCredentialEnvelopeMutationLock();
-    await expect(serialize((proof) => result.prepareKey(proof))).resolves.toEqual({
+    await expect(
+      serializePreparedEncryption((proof) => result.prepareKey(proof)),
+    ).resolves.toEqual({
       status: "ready",
     });
     expect(result.encryption.isEncryptionAvailable()).toBe(true);
@@ -214,8 +354,9 @@ describe("keychain partition backend", () => {
       "delete-key",
     ]);
 
-    const serialize = createCredentialEnvelopeMutationLock();
-    await expect(serialize((proof) => result.prepareKey(proof))).resolves.toEqual({
+    await expect(
+      serializePreparedEncryption((proof) => result.prepareKey(proof)),
+    ).resolves.toEqual({
       status: "ready",
     });
     expect(transport.requests.map((request) => request.op)).toEqual([
@@ -260,8 +401,9 @@ describe("keychain partition backend", () => {
     if (result.status !== "ready") return;
     expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
 
-    const serialize = createCredentialEnvelopeMutationLock();
-    await expect(serialize((proof) => result.prepareKey(proof))).resolves.toEqual({
+    await expect(
+      serializePreparedEncryption((proof) => result.prepareKey(proof)),
+    ).resolves.toEqual({
       status: "failed",
       code: "duplicate-item",
     });
@@ -372,7 +514,7 @@ describe("keychain partition backend", () => {
       createKeychainPartitionEncryption({
         transport,
         service: KEYCHAIN_CREDENTIAL_SERVICE,
-        envelopeCensus: async () => census,
+        inspectAutomaticRetirement: automaticRetirementInspector(async () => census),
         lockProof,
       }),
     );
@@ -380,7 +522,7 @@ describe("keychain partition backend", () => {
     if (result.status !== "ready") return;
 
     census = { deletionBlockers: 0, keychainDependents: 0 };
-    await expect(serialize((proof) => result.deleteKey(proof))).resolves.toEqual({
+    await expect(serialize((proof) => result.retireKey(proof))).resolves.toEqual({
       status: "failed",
       code: "unknown",
     });
@@ -418,7 +560,7 @@ describe("keychain partition backend", () => {
       createKeychainPartitionEncryption({
         transport,
         service: KEYCHAIN_CREDENTIAL_SERVICE,
-        envelopeCensus: async () => census,
+        inspectAutomaticRetirement: automaticRetirementInspector(async () => census),
         lockProof,
       }),
     );
@@ -426,7 +568,7 @@ describe("keychain partition backend", () => {
     if (result.status !== "ready") return;
 
     census = { deletionBlockers: 0, keychainDependents: 0 };
-    await expect(serialize((proof) => result.deleteKey(proof))).resolves.toEqual({
+    await expect(serialize((proof) => result.retireKey(proof))).resolves.toEqual({
       status: "failed",
       code: "unknown",
     });

--- a/apps/desktop/tests/keychain-key-lifetime.test.ts
+++ b/apps/desktop/tests/keychain-key-lifetime.test.ts
@@ -1,16 +1,23 @@
 import { randomBytes } from "node:crypto";
+import { execFile } from "node:child_process";
 import {
+  chmod,
   mkdir,
   mkdtemp,
+  open,
   readFile,
   realpath,
+  rename,
   rm,
   symlink,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { bindWindowsPrivateDirectory } from "@enduragent/core";
+import { createAutomaticKeyRetirementInspector } from "../src/main/automatic-key-retirement.js";
 import {
   createCredentialVault,
   CREDENTIAL_DIRECTORY_MODE,
@@ -18,7 +25,11 @@ import {
   type DesktopCredentialSlot,
 } from "../src/main/credential-vault.js";
 import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
-import { scanCredentialEnvelopes } from "../src/main/credential-envelope-inventory.js";
+import {
+  credentialEnvelopeTargets,
+  inspectCredentialEnvelopeTarget,
+  scanCredentialEnvelopes,
+} from "../src/main/credential-envelope-inventory.js";
 import {
   createKeychainPartitionEncryption,
   sealCredentialEnvelope,
@@ -34,6 +45,7 @@ import {
 import { retireKeychainKeyWhenLastEnvelopeGone } from "../src/main/keychain-key-lifetime.js";
 import {
   TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
+  TELEGRAM_CREDENTIAL_FILE_MODE,
   TELEGRAM_PROFILE_FILE_NAME,
   createTelegramCredentialVault,
 } from "../src/main/telegram-credential-vault.js";
@@ -46,6 +58,7 @@ const PROBE_OK: KeychainBindingResponse = {
   op: "probe",
   teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER,
 };
+const execFileAsync = promisify(execFile);
 
 interface Fixture {
   readonly credentialRoot: string;
@@ -93,7 +106,13 @@ async function keychainEncryption(): Promise<CredentialEncryptionPort> {
         key: randomBytes(KEYCHAIN_KEY_BYTES),
       }),
       service: KEYCHAIN_CREDENTIAL_SERVICE,
-      envelopeCensus: { deletionBlockers: 1, keychainDependents: 1 },
+      inspectAutomaticRetirement: async () => ({
+        status: "inspected",
+        deletionBlockers: 1,
+        keychainDependents: 1,
+        unverified: 0,
+        zeroProof: null,
+      }),
       lockProof,
     }),
   );
@@ -108,13 +127,20 @@ async function retireKey(
   readEnvelopeDirectory?: (path: string) => Promise<string[]>,
 ) {
   const serialize = createCredentialEnvelopeMutationLock();
+  const inspect = createAutomaticKeyRetirementInspector({
+    ...roots,
+    readEnvelopeFile,
+    readEnvelopeDirectory,
+  });
   return await serialize((lockProof) =>
     retireKeychainKeyWhenLastEnvelopeGone({
-      ...roots,
-      readEnvelopeFile,
-      readEnvelopeDirectory,
       lockProof,
-      deleteKey: async () => {
+      retireKey: async (proof) => {
+        const inspection = await inspect(proof);
+        if (inspection.status === "failed") return { status: "failed", code: "unknown" };
+        if (inspection.zeroProof === null) {
+          return { status: "retained", envelopes: inspection.deletionBlockers };
+        }
         const deleted = await transport.send({
           op: "delete-key",
           service: KEYCHAIN_CREDENTIAL_SERVICE,
@@ -202,6 +228,145 @@ describe("keychain key retirement", () => {
     ).resolves.toEqual({ status: "deleted" });
     expect(readEnvelopeFile).not.toHaveBeenCalled();
     expect(readEnvelopeDirectory).not.toHaveBeenCalled();
+  });
+
+  posixIt("keeps the key for a dangling canonical envelope symlink", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await symlink(
+      join(roots.credentialRoot, "missing-envelope"),
+      join(roots.credentialRoot, "anthropic.bin"),
+    );
+    const transport = transportOf();
+
+    await expect(retireKey(roots, transport)).resolves.toEqual({
+      status: "retained",
+      envelopes: 1,
+    });
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  posixIt("keeps the key for a canonical envelope symlink to a readable file", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    const source = join(roots.credentialRoot, "source-envelope");
+    await writeFile(source, Buffer.alloc(64), { mode: 0o600 });
+    await symlink(source, join(roots.credentialRoot, "anthropic.bin"));
+    const transport = transportOf();
+
+    await expect(retireKey(roots, transport)).resolves.toEqual({
+      status: "retained",
+      envelopes: 1,
+    });
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  posixIt("inspects a canonical FIFO without opening or waiting on it", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    const fifo = join(roots.credentialRoot, "anthropic.bin");
+    await execFileAsync("mkfifo", [fifo]);
+    await chmod(fifo, 0o600);
+    const transport = transportOf();
+
+    await expect(
+      Promise.race([
+        retireKey(roots, transport),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("FIFO read waited")), 1_000)),
+      ]),
+    ).resolves.toEqual({ status: "retained", envelopes: 1 });
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  posixIt("keeps the key for a canonical envelope with unsafe permissions", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await writeFile(join(roots.credentialRoot, "anthropic.bin"), Buffer.alloc(64), {
+      mode: 0o644,
+    });
+
+    await expect(retireKey(roots, transportOf())).resolves.toEqual({
+      status: "retained",
+      envelopes: 1,
+    });
+  });
+
+  posixIt("reads only the classification prefix from a huge sparse envelope", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    const path = join(roots.credentialRoot, "anthropic.bin");
+    const envelope = sealCredentialEnvelope(randomBytes(KEYCHAIN_KEY_BYTES), "bounded-prefix");
+    const handle = await open(path, "w", 0o600);
+    await handle.write(envelope, 0, envelope.length, 0);
+    await handle.truncate(128 * 1024 * 1024);
+    await handle.close();
+    const target = credentialEnvelopeTargets(roots).find(
+      (candidate) => candidate.fileName === "anthropic.bin",
+    )!;
+
+    const inspected = await inspectCredentialEnvelopeTarget(target);
+
+    expect(inspected.status).toBe("readable");
+    if (inspected.status === "readable") {
+      expect(inspected.contents).toHaveLength(40);
+      inspected.contents.fill(0);
+    }
+    const windowsInspection = await inspectCredentialEnvelopeTarget(target, {
+      platform: "win32",
+      windowsDirectory: bindWindowsPrivateDirectory(
+        dirname(roots.credentialRoot),
+        roots.credentialRoot,
+      ),
+    });
+    expect(windowsInspection.status).toBe("readable");
+    if (windowsInspection.status === "readable") {
+      expect(windowsInspection.contents).toHaveLength(40);
+      windowsInspection.contents.fill(0);
+    }
+    envelope.fill(0);
+  });
+
+  posixIt("blocks deletion when a canonical envelope is replaced during inspection", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    const path = join(roots.credentialRoot, "anthropic.bin");
+    const displaced = `${path}.old`;
+    await writeFile(path, Buffer.alloc(64), { mode: 0o600 });
+    const target = credentialEnvelopeTargets(roots).find(
+      (candidate) => candidate.fileName === "anthropic.bin",
+    )!;
+    const openAndReplace: typeof open = async (...arguments_) => {
+      const handle = await open(...arguments_);
+      await rename(path, displaced);
+      await writeFile(path, Buffer.alloc(64, 1), { mode: 0o600 });
+      return handle;
+    };
+
+    await expect(
+      inspectCredentialEnvelopeTarget(target, { openFile: openAndReplace }),
+    ).resolves.toEqual({ status: "blocked" });
+  });
+
+  posixIt("blocks deletion when a canonical envelope appears after the first check", async () => {
+    const roots = await fixture();
+    const envelope = sealCredentialEnvelope(randomBytes(KEYCHAIN_KEY_BYTES), "appeared");
+    let anthropicInspections = 0;
+
+    const inventory = await scanCredentialEnvelopes({
+      ...roots,
+      inspectEnvelopeTarget: async (target) => {
+        if (target.fileName !== "anthropic.bin") return { status: "missing" };
+        anthropicInspections += 1;
+        return anthropicInspections === 1
+          ? { status: "missing" }
+          : { status: "readable", contents: Buffer.from(envelope) };
+      },
+      readEnvelopeDirectory: async () => [],
+    });
+
+    expect(inventory.deletionBlockers).toHaveLength(1);
+    expect(inventory.keychainDependents).toBe(1);
+    envelope.fill(0);
   });
 
   posixIt("keeps the key while any envelope survives in either vault", async () => {
@@ -322,6 +487,7 @@ describe("keychain key retirement", () => {
     await writeFile(
       join(roots.telegramRoot, `.${TELEGRAM_PROFILE_FILE_NAME}.write-1.tmp`),
       envelope,
+      { mode: TELEGRAM_CREDENTIAL_FILE_MODE },
     );
     envelope.fill(0);
 

--- a/apps/desktop/tests/telegram-credential-vault.test.ts
+++ b/apps/desktop/tests/telegram-credential-vault.test.ts
@@ -15,6 +15,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import type { CredentialEncryptionPort } from "../src/main/credential-vault.js";
 import {
   TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
@@ -397,6 +398,45 @@ describe("Telegram credential vault", () => {
       code: "ENOENT",
     });
     expect(syncParentDirectory).toHaveBeenCalledOnce();
+  });
+
+  it("revalidates encryption after preparing the profile namespace and before encrypting", async () => {
+    const value = await fixture();
+    await mkdir(value.root, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    let persistedKey = "key-a";
+    const cachedKey = "key-a";
+    let available = true;
+    const encryptString = vi.fn(() => Buffer.from("unused"));
+    const prepareEnvelopeWrite = vi.fn(async () => {
+      if (persistedKey !== cachedKey) available = false;
+    });
+    const vault = createTelegramCredentialVault({
+      ...value,
+      encryption: {
+        isEncryptionAvailable: () => available,
+        encryptString,
+        decryptString: vi.fn(),
+      },
+      createProfileId: () => PROFILE_A,
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      prepareEnvelopeWrite,
+      syncDirectory: vi.fn(async () => {
+        persistedKey = "key-b";
+      }),
+    });
+
+    await expect(
+      vault.replaceProfile({
+        token: "synthetic-token-a",
+        bot: BOT_A,
+        authenticatedAthleteHome: value.athleteHome,
+      }),
+    ).resolves.toEqual({ outcome: "refused", reason: "encryption-unavailable" });
+    expect(prepareEnvelopeWrite).toHaveBeenCalledOnce();
+    expect(encryptString).not.toHaveBeenCalled();
+    await expect(lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("creates token-independent random profile IDs for successive coherent profiles", async () => {


### PR DESCRIPTION
## Summary

- Inspect credential envelopes through bounded, identity-stable POSIX and Windows readers; every unsafe, linked, special, changed, or uninspectable target blocks automatic key deletion.
- Authorize automatic Keychain deletion only with a private zero-blocker proof minted under the shared cross-vault lock; keep explicit full reset separate.
- Revalidate resident Keychain bytes immediately before every Intervals and Telegram encryption while preserving explicit inline missing-key re-entry.
- Add the desktop patch changeset and regression coverage for filesystem races, delayed writes, Keychain divergence, and onboarding.

## Verification

- Focused credential suite: 239 passed.
- `pnpm check`: passed with 20 existing warnings and 0 errors.
- `pnpm test`: 9,721 passed, 15 skipped.
- Packaged layout, runtime smoke, security smoke, self-test/corruption matrix, and Telegram packaged acceptance: passed.
- Two fresh read-only safety reviews: 3/3 and 4/4 criteria passed with no findings.
- Isolated xhigh P0-P3 autoreview: one proposed root-stability finding rejected because the bound scanner already performs the aggregate post-scan assertion before synchronous proof creation; no accepted findings remain.

## Limits

- `CREDENTIAL_ENVELOPE_INSPECTION_BYTES = 40` — read only the minimum authenticated-envelope classification prefix.

## Release evidence

The development package is ad-hoc signed and passed packaged QA. A Developer ID release build could not be produced on this Mac because `security find-identity -v -p codesigning` reports zero valid identities.