### PR TITLE
fix(desktop): show file-only training data

### DIFF
--- a/.changeset/calm-rides-train.md
+++ b/.changeset/calm-rides-train.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Training now shows recently imported ride files immediately without requiring an Intervals.icu sync.
+
+Credential-free setups no longer run Intervals.icu refreshes or surface their failures.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -273,6 +273,7 @@ export function bootRenderer(): Disposer {
   const rideImportAdapter = createRideImportAdapter({
     imports: rideImports,
     publish: (next) => store.getState().setRideImport(next),
+    onSucceeded: () => void trainingContextController.refresh(),
   });
   store.getState().bindRideImportActions(rideImportAdapter.port);
   const onboardingCompletion = createOnboardingCompletionController({

--- a/apps/desktop-renderer/src/state/adapters/ride-import.ts
+++ b/apps/desktop-renderer/src/state/adapters/ride-import.ts
@@ -9,10 +9,13 @@ export interface RideImportAdapter {
 export function createRideImportAdapter(input: {
   readonly imports: RideImportController;
   readonly publish: (next: RideImportState) => void;
+  readonly onSucceeded?: () => void;
 }): RideImportAdapter {
   let disposed = false;
   const unsubscribe = input.imports.subscribe((state) => {
-    if (!disposed) input.publish(state);
+    if (disposed) return;
+    input.publish(state);
+    if (state.status === "succeeded") input.onSucceeded?.();
   });
 
   return {

--- a/apps/desktop-renderer/tests/ride-import-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/ride-import-adapter.test.tsx
@@ -31,7 +31,12 @@ function importResult(imported: number, quarantined = 0): ImportFilesRpcResult {
   };
 }
 
-function harness(options: { readonly importFiles?: RideImportTransport["importFiles"] } = {}) {
+function harness(
+  options: {
+    readonly importFiles?: RideImportTransport["importFiles"];
+    readonly onSucceeded?: () => void;
+  } = {},
+) {
   const chooseImportFiles = vi.fn<RideImportTransport["chooseImportFiles"]>(async () => [...PATHS]);
   const importFiles = vi.fn<RideImportTransport["importFiles"]>(
     options.importFiles ?? (async () => importResult(1)),
@@ -41,6 +46,7 @@ function harness(options: { readonly importFiles?: RideImportTransport["importFi
   const published: RideImportState[] = [];
   const adapter = createRideImportAdapter({
     imports: controller,
+    ...(options.onSucceeded === undefined ? {} : { onSucceeded: options.onSucceeded }),
     publish: (next) => {
       published.push(next);
       owners.push(next.owner);
@@ -79,6 +85,65 @@ afterEach(() => {
 });
 
 describe("resident ride import glue", () => {
+  it("refreshes Training after a file-only onboarding import succeeds", async () => {
+    const onSucceeded = vi.fn(() => {
+      useEnduragentStore.getState().setTraining({
+        ...EMPTY_TRAINING_SURFACE,
+        status: "ready",
+        metadata: {
+          lastUpdated: "1998-07-18T12:00:00.000Z",
+          lastSynced: null,
+          freshness: "fresh",
+          degraded: false,
+        },
+        trainingContext: {
+          performanceProgress: { kind: "unavailable", reason: "not-synced" },
+          recentRides: {
+            kind: "computed",
+            asOf: "1998-07-18T12:00:00.000Z",
+            windowDays: 28,
+            items: [
+              {
+                id: "a".repeat(64),
+                subSport: "road",
+                startEpochSeconds: 900_000_000,
+                timezoneOffsetSeconds: 0,
+                localDate: "1998-07-09",
+                elapsedSeconds: 3_700,
+                movingSeconds: 3_600,
+                distanceMeters: 40_000,
+              },
+            ],
+          },
+          anchorZones: { kind: "unknown", reason: "not-synced" },
+          cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
+          plan: { kind: "unknown", reason: "no-plan" },
+          adherence: { kind: "unknown", reason: "insufficient-data" },
+          wellnessTrend: { kind: "unknown", reason: "no-wellness" },
+        },
+      });
+    });
+    const subject = harness({ onSucceeded });
+    useEnduragentStore.getState().setTraining({
+      ...EMPTY_TRAINING_SURFACE,
+      status: "unavailable",
+    });
+    render(<TrainingView />);
+
+    expect(screen.getByText("Training data unavailable")).toBeInTheDocument();
+    await act(async () => {
+      await subject.controller.importPaths("onboarding", [...PATHS]);
+    });
+
+    expect(onSucceeded).toHaveBeenCalledOnce();
+    expect(screen.queryByText("Training data unavailable")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Review road ride from 1998-07-09 · 16:00, 1h 2m, 40.0 km",
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("publishes the controller state into the store from the first subscription", () => {
     const subject = harness();
 

--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -116,6 +116,31 @@ function makeScript(): DesktopFixtureScript {
           recentActivities: [],
           plannedWorkouts: [],
           wellness: {},
+          trainingContext: {
+            performanceProgress: { kind: "unavailable", reason: "not-synced" },
+            recentRides: {
+              kind: "computed",
+              asOf: "1998-07-19T08:00:00.000Z",
+              windowDays: 28,
+              items: [
+                {
+                  id: "a".repeat(64),
+                  subSport: "road",
+                  startEpochSeconds: 900_000_000,
+                  timezoneOffsetSeconds: 0,
+                  localDate: "1998-07-09",
+                  elapsedSeconds: 3_700,
+                  movingSeconds: 3_600,
+                  distanceMeters: 40_000,
+                },
+              ],
+            },
+            anchorZones: { kind: "unknown", reason: "not-synced" },
+            cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
+            plan: { kind: "unknown", reason: "no-plan" },
+            adherence: { kind: "unknown", reason: "insufficient-data" },
+            wellnessTrend: { kind: "unknown", reason: "no-wellness" },
+          },
         });
       }
       if (request.method === "getTranscriptPage") {
@@ -137,7 +162,7 @@ afterEach(async () => {
 });
 
 describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live", () => {
-  it("embeds first-run Setup in Chat and finishes into a working chat", async () => {
+  it("finishes file-only onboarding into working Chat and Training pages", async () => {
     const fixture = await launchDesktopFixture({
       script: makeScript(),
       token,
@@ -158,6 +183,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
       readonly finished: boolean;
       readonly shellRestored: boolean;
       readonly chatWorking: boolean;
+      readonly trainingReady: boolean;
+      readonly recentRideVisible: boolean;
+      readonly syncNeedsAttention: boolean;
     }>(`
       const deadline = Date.now() + 10000;
       const setupSelector =
@@ -273,6 +301,20 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
       const composer = document.querySelector(
         '[data-view="chat"][data-onboarding="settled"] textarea#message',
       );
+      const trainingNav = Array.from(
+        document.querySelectorAll('nav[aria-label="Main navigation"] button'),
+      ).find((entry) => entry.textContent?.includes("Training"));
+      trainingNav?.click();
+      const trainingDeadline = Date.now() + 10000;
+      while (
+        document.querySelector('section[aria-label="Training"]') === null &&
+        Date.now() < trainingDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      const training = document.querySelector('section[aria-label="Training"]');
+      const recentRides = training?.querySelector('[data-panel="recent-rides"]');
+      const syncChip = document.querySelector(".sync-chip");
       return {
         present,
         chatSetup,
@@ -284,6 +326,12 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
         finished: document.querySelector("[data-setup-host]") === null,
         shellRestored: document.querySelector('nav[aria-label="Main navigation"]') !== null,
         chatWorking: composer !== null && composer.disabled === false,
+        trainingReady:
+          training !== null &&
+          training.querySelector(".training-status")?.hasAttribute("hidden") === true,
+        recentRideVisible:
+          recentRides?.querySelector('button[aria-label^="Review road ride"]') !== null,
+        syncNeedsAttention: syncChip?.getAttribute("data-status") === "attention",
       };
     `);
     expect(observed).toEqual({
@@ -297,6 +345,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("onboarding live"
       finished: true,
       shellRestored: true,
       chatWorking: true,
+      trainingReady: true,
+      recentRideVisible: true,
+      syncNeedsAttention: false,
     });
   }, 90_000);
 });

--- a/packages/coach/src/athlete-state-reader.ts
+++ b/packages/coach/src/athlete-state-reader.ts
@@ -5,6 +5,7 @@ import {
   EMPTY_DROPPED_ACTIVITIES,
   PowerProgressPanelSchema,
   RecentRidesPanelSchema,
+  UNKNOWN_CYCLING_TRAINING_CONTEXT,
   type AthleteState,
   type DroppedActivities,
   type PowerProgressPanel,
@@ -56,6 +57,7 @@ function isFiniteInstant(value: string): boolean {
 export interface CreatePersistedAthleteStateSourceOptions {
   readonly dataDir: string;
   readonly cyclingFtpAnchorResolver: CyclingFtpAnchorResolver;
+  readonly now?: () => Date;
   readonly powerProgressSource?: {
     readPowerProgress(): Promise<PowerProgressPanel>;
   };
@@ -66,6 +68,34 @@ export interface CreatePersistedAthleteStateSourceOptions {
     }): Promise<RecentRidesPanel>;
   };
   readonly droppedActivitiesSource?: () => DroppedActivities;
+}
+
+function isMissingFile(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+async function readRecentRides(
+  source: CreatePersistedAthleteStateSourceOptions["recentRidesSource"],
+  asOf: string,
+  asOfEpochSeconds: number,
+): Promise<RecentRidesPanel> {
+  if (source === undefined) return { kind: "unknown", reason: "not-synced" };
+  return source
+    .readRecentRides({ asOf, asOfEpochSeconds })
+    .then((value): RecentRidesPanel => {
+      const parsed = RecentRidesPanelSchema.safeParse(value);
+      return parsed.success ? parsed.data : { kind: "unknown", reason: "temporary-failure" };
+    })
+    .catch(
+      (): RecentRidesPanel => ({
+        kind: "unknown",
+        reason: "temporary-failure",
+      }),
+    );
 }
 
 export function createPersistedAthleteStateSource(
@@ -82,6 +112,32 @@ export function createPersistedAthleteStateSource(
         readJson(errorPath),
       ]);
       if (latestResult.status === "rejected") {
+        if (input.recentRidesSource !== undefined && isMissingFile(latestResult.reason)) {
+          const now = input.now?.() ?? new Date();
+          const asOf = now.toISOString();
+          const recentRides = await readRecentRides(
+            input.recentRidesSource,
+            asOf,
+            Math.floor(now.getTime() / 1_000),
+          );
+          return AthleteStateSchema.parse({
+            schemaVersion: LATEST_SCHEMA_VERSION,
+            lastUpdated: asOf,
+            freshness: "fresh",
+            degraded: false,
+            lastSynced: null,
+            athleteProfile: null,
+            currentStatus: null,
+            derivedMetrics: {},
+            recentActivities: [],
+            plannedWorkouts: [],
+            wellness: null,
+            trainingContext: {
+              ...UNKNOWN_CYCLING_TRAINING_CONTEXT,
+              recentRides,
+            },
+          });
+        }
         throw new AthleteStateUnavailableError("No validated athlete state is available.");
       }
       const latestParsed = LatestJsonSchema.safeParse(latestResult.value);
@@ -139,25 +195,13 @@ export function createPersistedAthleteStateSource(
                   reason: "temporary-failure",
                 }),
               ),
-        asOfEpochS === null || input.recentRidesSource === undefined
+        asOfEpochS === null
           ? Promise.resolve({ kind: "unknown", reason: "not-synced" } as const)
-          : input.recentRidesSource
-              .readRecentRides({
-                asOf: latest.metadata.last_updated,
-                asOfEpochSeconds: asOfEpochS,
-              })
-              .then((value): RecentRidesPanel => {
-                const parsed = RecentRidesPanelSchema.safeParse(value);
-                return parsed.success
-                  ? parsed.data
-                  : { kind: "unknown", reason: "temporary-failure" };
-              })
-              .catch(
-                (): RecentRidesPanel => ({
-                  kind: "unknown",
-                  reason: "temporary-failure",
-                }),
-              ),
+          : readRecentRides(
+              input.recentRidesSource,
+              latest.metadata.last_updated,
+              asOfEpochS,
+            ),
       ]);
       const trainingContext = projectCyclingTrainingContext({
         asOf: latest.metadata.last_updated,

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -921,8 +921,10 @@ export async function createLocalCoachComposition(
         : dependencies.createRuntime(runtimeOptions);
     if (!input.deferInitialRefresh) {
       await runtime.runWindow();
-      runtime.startScheduler();
-      schedulerStarted = true;
+      if (unapprovedConfig.intervals.apiKey.length > 0) {
+        runtime.startScheduler();
+        schedulerStarted = true;
+      }
     }
     const logger = createSubsystemLogger("agent", input.home.root);
     const getAccessToken = createAccessTokenReader(input.home.configDir);
@@ -941,6 +943,7 @@ export async function createLocalCoachComposition(
     const stateReader = createPersistedAthleteStateSource({
       dataDir: input.home.root,
       cyclingFtpAnchorResolver,
+      now: () => new Date(now()),
       powerProgressSource: powerProgress,
       recentRidesSource: createRecentRidesSource(canonicalActivities),
       droppedActivitiesSource: () => runtime!.currentDroppedActivities(),
@@ -1251,8 +1254,6 @@ export async function createLocalCoachComposition(
               }),
             );
         }
-      } else if (request.intervals !== undefined && initialRefreshStarted && intervalsOwnerReady) {
-        ensureSchedulerStarted();
       }
     };
     const scheduleInitialRefreshRetry = (): void => {
@@ -1314,7 +1315,9 @@ export async function createLocalCoachComposition(
         })
         .then(() => undefined)
         .finally(() => {
-          if (ownerSucceeded) ensureSchedulerStarted();
+          if (ownerSucceeded && unapprovedConfig.intervals.apiKey.length > 0) {
+            ensureSchedulerStarted();
+          }
         })
         .catch((error) => {
           if (!closing) {

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -380,6 +380,20 @@ LIMIT 1`,
   }
 
   private async runWindowInternal(admissionSignal: AbortSignal): Promise<StoreWindowResult> {
+    admissionSignal.throwIfAborted();
+    const config = this.options.readConfig?.() ?? this.options.config;
+    if (config.intervals.apiKey.length === 0) {
+      return Object.freeze({
+        published: false,
+        counts: createPhysicalRequestLedger({
+          storeLimit: STORE_REQUEST_LIMIT,
+          legacyLimit: LEGACY_REQUEST_LIMIT,
+          totalLimit: TOTAL_REQUEST_LIMIT,
+        }).snapshot(),
+        legacySucceeded: true,
+        droppedActivities: this.droppedActivitiesValue,
+      });
+    }
     const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
     const controller = new AbortController();
     const abortWindow = (): void => controller.abort(admissionSignal.reason);
@@ -399,28 +413,22 @@ LIMIT 1`,
     };
     try {
       controller.signal.throwIfAborted();
-      const config = this.options.readConfig?.() ?? this.options.config;
-      const capturePromise =
-        config.intervals.apiKey.length === 0
-          ? Promise.resolve(undefined)
-          : this.dependencies.capture({
-              env: this.options.env,
-              ...(this.options.writerContext === undefined
-                ? {}
-                : { writerContext: this.options.writerContext }),
-              apiKey: config.intervals.apiKey,
-              athleteId: config.intervals.athleteId,
-              reviewedOn: now.toISOString().slice(0, 10),
-              reason: this.snapshotValue === undefined ? "initial" : "provider-refresh",
-              ...(this.snapshotValue === undefined
-                ? {}
-                : { replacesCaptureId: this.snapshotValue.captureId }),
-              budget,
-              attemptLedger: ledger,
-              ...(this.options.platform === undefined
-                ? {}
-                : { platform: this.options.platform }),
-            });
+      const capturePromise = this.dependencies.capture({
+        env: this.options.env,
+        ...(this.options.writerContext === undefined
+          ? {}
+          : { writerContext: this.options.writerContext }),
+        apiKey: config.intervals.apiKey,
+        athleteId: config.intervals.athleteId,
+        reviewedOn: now.toISOString().slice(0, 10),
+        reason: this.snapshotValue === undefined ? "initial" : "provider-refresh",
+        ...(this.snapshotValue === undefined
+          ? {}
+          : { replacesCaptureId: this.snapshotValue.captureId }),
+        budget,
+        attemptLedger: ledger,
+        ...(this.options.platform === undefined ? {} : { platform: this.options.platform }),
+      });
       const legacyPromise = this.options.reference.runScheduledOnce(controller.signal);
       const [captureResult, legacyResult] = await Promise.allSettled([
         capturePromise,

--- a/packages/coach/tests/athlete-state-reader.test.ts
+++ b/packages/coach/tests/athlete-state-reader.test.ts
@@ -104,6 +104,56 @@ afterEach(async () => {
 });
 
 describe("persisted athlete state source", () => {
+  it("returns canonical recent rides without a Reference snapshot", async () => {
+    const root = await home();
+    const now = new Date("1998-07-18T12:00:00.000Z");
+    const recentRide = {
+      id: "a".repeat(64),
+      subSport: "road",
+      startEpochSeconds: 900_000_000,
+      timezoneOffsetSeconds: 0,
+      localDate: "1998-07-09",
+      elapsedSeconds: 3_700,
+      movingSeconds: 3_600,
+      distanceMeters: 40_000,
+    } as const;
+    const readRecentRides = vi.fn(async () => ({
+      kind: "computed" as const,
+      asOf: now.toISOString(),
+      windowDays: 28 as const,
+      items: [recentRide],
+    }));
+
+    const state = await createPersistedAthleteStateSource({
+      dataDir: root,
+      cyclingFtpAnchorResolver: resolver,
+      now: () => now,
+      recentRidesSource: { readRecentRides },
+    }).getAthleteState();
+
+    expect(AthleteStateSchema.parse(state)).toEqual(state);
+    expect(readRecentRides).toHaveBeenCalledWith({
+      asOf: now.toISOString(),
+      asOfEpochSeconds: now.getTime() / 1_000,
+    });
+    expect(state).toMatchObject({
+      lastUpdated: now.toISOString(),
+      freshness: "fresh",
+      degraded: false,
+      lastSynced: null,
+      athleteProfile: null,
+      currentStatus: null,
+      derivedMetrics: {},
+      recentActivities: [],
+      plannedWorkouts: [],
+      wellness: null,
+      trainingContext: {
+        recentRides: { kind: "computed", items: [recentRide] },
+        anchorZones: { kind: "unknown", reason: "not-synced" },
+      },
+    });
+  });
+
   it("maps every persisted field into a contract-valid state", async () => {
     const root = await home();
     await writeJson(root, "latest.json", latest("fresh", T1));

--- a/packages/coach/tests/canonical-activity-coaching.test.ts
+++ b/packages/coach/tests/canonical-activity-coaching.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Config, ReferenceRuntime } from "@enduragent/core";
-import { runMigrations } from "@enduragent/kernel/store";
+import { createCanonicalActivityReader, runMigrations } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { createNodeImportRuntime, importFilesWithReport } from "@enduragent/kernel-node/ingest";
@@ -10,6 +10,8 @@ import { openReadonlySqliteStorage, openSqliteStorage } from "@enduragent/kernel
 import { mapActivityLanding } from "@enduragent/sync-intervals-icu";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCoachOperations } from "../src/operations.js";
+import { createPersistedAthleteStateSource } from "../src/athlete-state-reader.js";
+import { createRecentRidesSource } from "../src/recent-rides.js";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
 import { createStoreRuntime, type StoreRuntimeDependencies } from "../src/store-runtime.js";
 
@@ -141,6 +143,48 @@ async function coachingSnapshot(
 }
 
 describe("canonical activity coaching cutover", () => {
+  it("returns partial Training state from a file-only canonical import", async () => {
+    const selected = await fixture();
+    try {
+      await expect(
+        selected.operations.importFiles({ paths: [mixedImportPath] }),
+      ).resolves.toMatchObject({
+        files: { imported: 1, quarantined: 0 },
+        publication: { scope: "activities-and-streams", status: "available" },
+      });
+
+      const state = await createPersistedAthleteStateSource({
+        dataDir: selected.home.root,
+        cyclingFtpAnchorResolver: {
+          resolve: async () => ({ kind: "missing", refusal: "missing-cycling-ftp-anchor" }),
+        },
+        now: () => new Date("1998-07-18T12:00:00.000Z"),
+        recentRidesSource: createRecentRidesSource(
+          createCanonicalActivityReader(selected.context.store),
+        ),
+      }).getAthleteState();
+
+      expect(state.trainingContext?.recentRides).toMatchObject({
+        kind: "computed",
+        windowDays: 28,
+        items: [
+          {
+            id: expect.stringMatching(/^[0-9a-f]{64}$/u),
+            localDate: "1998-07-04",
+          },
+        ],
+      });
+      expect(state.trainingContext?.performanceProgress).toEqual({
+        kind: "unavailable",
+        reason: "not-synced",
+      });
+      expect(state.lastSynced).toBeNull();
+    } finally {
+      await selected.runtime.close();
+      await selected.context.store.close();
+    }
+  });
+
   it("reads an import immediately and identically after a credential-free restart", async () => {
     const first = await fixture();
     let firstWriterOpen = true;

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -1169,6 +1169,33 @@ describe("local coach composition", () => {
     expect(trace).toEqual(["run-window", "reference-stop", "runtime-close"]);
   });
 
+  it("does not start the scheduler after a credential-free deferred refresh", async () => {
+    const home = await freshHome();
+    const trace: string[] = [];
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(trace),
+        createRuntime: () => runtime(trace),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      { apiKey: "", athleteId: "" },
+      undefined,
+      { ENDURAGENT_HOME: home.root },
+      true,
+    );
+
+    await expect(lifecycle.startInitialRefresh()).resolves.toBeUndefined();
+    expect(trace).toEqual(["run-window"]);
+    await lifecycle.close();
+  });
+
   it("defers the daemon refresh, tracks one start, and schedules retries after capture failure", async () => {
     const home = await freshHome();
     const failure = new Error("synthetic persistence failure");

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -234,7 +234,7 @@ describe("StoreRuntime", () => {
     await runtime.close();
   });
 
-  it("runs the legacy lane without capture when the intervals.icu API key is empty", async () => {
+  it("skips both provider lanes when the intervals.icu API key is empty", async () => {
     const { runtime, capture, refreshCurves, produce, reference } = await makeRuntime({
       ...config,
       intervals: { ...config.intervals, apiKey: "" },
@@ -242,13 +242,13 @@ describe("StoreRuntime", () => {
     const result = await runtime.runWindow();
     expect(result).toMatchObject({
       published: false,
-      counts: { storeRequests: 0, legacyRequests: 1, totalRequests: 1 },
+      counts: { storeRequests: 0, legacyRequests: 0, totalRequests: 0 },
       legacySucceeded: true,
     });
     expect(capture).not.toHaveBeenCalled();
     expect(refreshCurves).not.toHaveBeenCalled();
     expect(produce).not.toHaveBeenCalled();
-    expect(reference.runScheduledOnce).toHaveBeenCalledTimes(1);
+    expect(reference.runScheduledOnce).not.toHaveBeenCalled();
     expect(runtime.currentSnapshot()).toBeUndefined();
     await runtime.close();
   });


### PR DESCRIPTION
## Summary

- return a schema-valid partial Training state from canonical recent rides when latest.json does not exist
- refresh Training after successful ride-file imports
- skip Intervals capture, legacy sync, and scheduling when no Intervals credential exists
- cover file-only onboarding through the live Training page

## Verification

- pnpm check
- pnpm test (9,524 passed; one unrelated process-cleanup flake passed on focused rerun)
- pnpm exec vitest run packages/coach/tests/athlete-state-reader.test.ts packages/coach/tests/store-runtime.test.ts packages/coach/tests/composition.test.ts packages/coach/tests/canonical-activity-coaching.test.ts apps/desktop-renderer/tests/ride-import-adapter.test.tsx
- pnpm exec vitest run apps/desktop/tests/onboarding-first-run.integration.test.ts
- full-severity autoreview completed; one scheduler finding rejected by the passing credential-free-to-credential-added composition test

## Limits

No numeric limits were added or changed.