### PR TITLE
fix: preserve credential recovery states

### DIFF
--- a/.changeset/calm-keychain-recovery-state.md
+++ b/.changeset/calm-keychain-recovery-state.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Kept credential recovery available when secure storage or its local inventory cannot be inspected safely.

--- a/apps/desktop/src/main/desktop-credential-encryption.ts
+++ b/apps/desktop/src/main/desktop-credential-encryption.ts
@@ -34,6 +34,14 @@ export function desktopKeychainCredentialService(packaged: boolean): string {
   return packaged ? KEYCHAIN_CREDENTIAL_SERVICE : KEYCHAIN_CREDENTIAL_SERVICE_DEV;
 }
 
+export function desktopCredentialRecoveryFailureState(
+  code: KeychainBindingErrorCode,
+): "locked" | "missing" | "unavailable" {
+  if (code === "keychain-locked") return "locked";
+  if (code === "item-not-found") return "missing";
+  return "unavailable";
+}
+
 export interface DesktopCredentialEncryption {
   readonly encryption: CredentialEncryptionPort;
   readonly selection: DesktopCredentialBackendSelection;
@@ -187,11 +195,16 @@ export async function prepareDesktopCredentialEncryption(
         if (current.status !== "keychain") {
           return { selection: current, unverifiedEnvelopes: 0 };
         }
-        const { inventory } = await scanBoundCredentialEnvelopes(
-          roots,
-          options.location.platform,
-        );
-        return { selection: current, unverifiedEnvelopes: inventory.unverified };
+        try {
+          const { inventory } = await scanBoundCredentialEnvelopes(
+            roots,
+            options.location.platform,
+          );
+          return { selection: current, unverifiedEnvelopes: inventory.unverified };
+        } catch {
+          transitionToUnavailable("unknown", false);
+          return { selection, unverifiedEnvelopes: 0 };
+        }
       });
     },
     async deleteKeyForCredentialReset(

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -84,7 +84,10 @@ import {
   createCredentialMutationLock,
   type CredentialEnvelopeLockProof,
 } from "./credential-envelope-lock.js";
-import { prepareDesktopCredentialEncryption } from "./desktop-credential-encryption.js";
+import {
+  desktopCredentialRecoveryFailureState,
+  prepareDesktopCredentialEncryption,
+} from "./desktop-credential-encryption.js";
 import { resetEncryptedCredentialStorage } from "./credential-reset.js";
 import { probePackagedKeychainBackendSelection } from "./keychain-backend-selection-probe.js";
 import {
@@ -507,15 +510,7 @@ async function runDesktop(): Promise<void> {
       if (selected.status === "safe-storage") {
         return { state: "ready", unverifiedEnvelopes: 0 };
       }
-      if (selected.code === "item-not-found") return { state: "missing" };
-      if (
-        selected.code === "keychain-locked" ||
-        selected.code === "uninspectable-item" ||
-        selected.code === "unreadable-item"
-      ) {
-        return { state: "locked" };
-      }
-      return { state: "unavailable" };
+      return { state: desktopCredentialRecoveryFailureState(selected.code) };
     };
     if (process.platform === "darwin") {
       const selected = credentialEncryption.selection;

--- a/apps/desktop/tests/desktop-credential-encryption.test.ts
+++ b/apps/desktop/tests/desktop-credential-encryption.test.ts
@@ -9,6 +9,7 @@ import {
   type CredentialEncryptionPort,
 } from "../src/main/credential-vault.js";
 import {
+  desktopCredentialRecoveryFailureState,
   desktopKeychainCredentialService,
   prepareDesktopCredentialEncryption,
   type PrepareDesktopCredentialEncryptionOptions,
@@ -120,6 +121,17 @@ afterAll(async () => {
 });
 
 describe("desktop credential encryption startup", () => {
+  it.each([
+    ["keychain-locked", "locked"],
+    ["item-not-found", "missing"],
+    ["uninspectable-item", "unavailable"],
+    ["unreadable-item", "unavailable"],
+    ["not-team-signed", "unavailable"],
+    ["unknown", "unavailable"],
+  ] as const)("maps %s onto the %s recovery state", (code, expected) => {
+    expect(desktopCredentialRecoveryFailureState(code)).toBe(expected);
+  });
+
   it("separates the signed-release service from the development service", () => {
     expect(desktopKeychainCredentialService(true)).toBe(KEYCHAIN_CREDENTIAL_SERVICE);
     expect(desktopKeychainCredentialService(false)).toBe(KEYCHAIN_CREDENTIAL_SERVICE_DEV);
@@ -549,6 +561,37 @@ describe("desktop credential encryption startup", () => {
       "probe",
       "read-key",
     ]);
+  });
+
+  it("publishes encryption unavailable when a recovery inventory scan fails", async () => {
+    const transport = transportOf(PROBE_OK, { ok: true, op: "read-key", key: KEY });
+    let inventoryAvailable = true;
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({
+        createTransport: () => transport,
+        readEnvelopeFile: migratedTelegramEnvelope(),
+        readEnvelopeDirectory: async () => {
+          if (!inventoryAvailable) {
+            throw Object.assign(new Error("inventory unavailable"), { code: "EACCES" });
+          }
+          return [];
+        },
+      }),
+    );
+    expect(prepared.selection.status).toBe("keychain");
+
+    inventoryAvailable = false;
+
+    await expect(prepared.credentialRecoverySnapshot()).resolves.toMatchObject({
+      selection: {
+        status: "refused",
+        reason: "encryption-unavailable",
+        code: "unknown",
+        keyCleanupPending: false,
+      },
+      unverifiedEnvelopes: 0,
+    });
+    expect(prepared.encryption.isEncryptionAvailable()).toBe(false);
   });
 
   it("deletes a readable zero-envelope key during startup without replacing it", async () => {


### PR DESCRIPTION
## Summary

- Convert unsafe or failed cross-vault recovery scans into a typed non-destructive `encryption-unavailable` snapshot.
- Map only `keychain-locked` to the inline locked state; map missing to missing and malformed or uninspectable items to unavailable.
- Add regression coverage and a user-facing desktop changeset.

## Review adjudication

- Rejected the claimed partition-description encoding defect after a disposable Security.framework probe showed the exact 252-byte XML unchanged before and after `SecItemAdd`.
- Accepted and fixed the recovery-scan P2 and recovery-copy P3.

## Verification

- `pnpm exec vitest run apps/desktop/tests/desktop-credential-encryption.test.ts` — 34 passed.
- `pnpm --filter @enduragent/desktop check` — passed.
- `pnpm check` under Node 24 — passed with 20 existing warnings and 0 errors.
- `pnpm test` under Node 24 — 618 files passed, 5 skipped; 9,728 tests passed, 15 skipped.
- Fresh read-only skeptic — 3/3 criteria passed, no P0–P3 findings.

## Limits

- None.