### PR TITLE
fix: harden keychain census stability

### DIFF
--- a/.changeset/quiet-keychain-census.md
+++ b/.changeset/quiet-keychain-census.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Prevented unsafe credential-key replacement when local credential files cannot be inspected consistently.
+
+The macOS binding now scopes every key operation to the default Keychain and deletes only the exact validated Enduragent item. A failed envelope inspection no longer masquerades as a pending key deletion during recovery. Automatic key retirement now syncs both vault directories before proving that no dependent envelope survives. Ordinary credential removal revalidates the exact Keychain key without creating a replacement, a missing-key recovery state now offers a non-creating Retry action, and an explicitly removed legacy Telegram envelope no longer requires a missing custom key.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -380,6 +380,8 @@ export function bootRenderer(): Disposer {
         window.enduragentAuth.removeTelegramAllowedSender({ senderId }),
     },
     beginMutation: () => store.getState().beginSettingsMutation("telegram"),
+    credentialMutationsBlocked: () =>
+      credentialChangesBlocked(store.getState().settings.credentials, false),
     view: telegramAdapter.view,
   });
   store.getState().bindSettingsPorts({

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -188,7 +188,7 @@ function recoveryCopy(recovery: CredentialRecoveryStatus): string {
     return "Unlock your login Keychain outside Enduragent, then Retry.";
   }
   if (recovery.state === "missing") {
-    return "These credentials cannot be recovered. Remove all credentials and start again.";
+    return "The credential encryption key is missing. Restore it if possible, then Retry, or remove all credentials and start again.";
   }
   if (recovery.state === "unavailable") {
     return "Secure credential storage is unavailable. Retry, or remove all credentials and start again.";
@@ -479,7 +479,7 @@ export function createCredentialSettingsController(input: {
       disposed ||
       operation !== undefined ||
       input.credentialMutationsBlocked?.() ||
-      repairRequiredCredential(currentState) !== null
+      credentialChangesBlocked(currentState, false)
     ) {
       return;
     }
@@ -493,7 +493,7 @@ export function createCredentialSettingsController(input: {
         disposed ||
         operation !== undefined ||
         input.credentialMutationsBlocked?.() ||
-        repairRequiredCredential(currentState) !== null
+        credentialChangesBlocked(currentState, false)
       ) {
         return;
       }
@@ -641,7 +641,9 @@ export function createCredentialSettingsController(input: {
       return Promise.resolve();
     }
     if (content.confirmation === "all") return confirmReset();
-    if (content.repairCredential !== null) return Promise.resolve();
+    if (content.repairCredential !== null || content.recovery.state !== "ready") {
+      return Promise.resolve();
+    }
     const target = content.entries.find((entry) => entry.credential === content.confirmation);
     if (target === undefined) return Promise.resolve();
     const releaseMutation = input.beginMutation();
@@ -810,7 +812,11 @@ export function createCredentialSettingsController(input: {
   input.view.bind({
     onRetry: () => {
       const recovery = contentState()?.recovery;
-      void startLoad(recovery?.state === "locked" || recovery?.state === "unavailable");
+      void startLoad(
+        recovery?.state === "locked" ||
+          recovery?.state === "missing" ||
+          recovery?.state === "unavailable",
+      );
     },
     onRequestDelete: requestDelete,
     onRequestReset: requestReset,

--- a/apps/desktop-renderer/src/settings/telegram-controller.ts
+++ b/apps/desktop-renderer/src/settings/telegram-controller.ts
@@ -502,6 +502,7 @@ async function loadSenders(
 export function createTelegramSettingsController(input: {
   readonly bridge: TelegramSettingsBridge;
   readonly beginMutation: () => (() => void) | null;
+  readonly credentialMutationsBlocked?: () => boolean;
   readonly view: TelegramSettingsView;
   readonly pollIntervalMs?: number;
   readonly setInterval?: typeof globalThis.setInterval;
@@ -651,7 +652,14 @@ export function createTelegramSettingsController(input: {
     action: TelegramSettingsAction,
     invoke: () => Promise<TelegramMutationResult>,
   ): void => {
-    if (disposed || operation !== undefined) return;
+    if (
+      disposed ||
+      operation !== undefined ||
+      ((action === "paste-token" || action === "remove") &&
+        input.credentialMutationsBlocked?.())
+    ) {
+      return;
+    }
     const release = input.beginMutation();
     if (release === null) return;
     const previous = readCurrentContent();

--- a/apps/desktop-renderer/src/ui/onboarding/TelegramRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/TelegramRow.tsx
@@ -5,6 +5,7 @@ import type {
   TelegramSettingsFeedback,
   TelegramSettingsState,
 } from "../../settings/telegram-controller.js";
+import { credentialChangesBlocked } from "../../settings/credential-controller.js";
 import { PLATFORM_COPY } from "../../platform-copy.js";
 import { settingsMutationActive, type TelegramSettingsPort } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
@@ -190,6 +191,7 @@ export function TelegramRow(): ReactElement {
   const identityUnknown = currentIdentity.kind === "unknown";
   const loading = state.status === "closed" || state.status === "loading";
   const busy = loading || settingsMutationActive(settings) || state.status === "working";
+  const credentialMutationBlocked = credentialChangesBlocked(settings.credentials, false);
   const activeAttempt = attempt !== null && attempt.phase !== "settled";
   const connecting = activeAttempt && attempt.action === "paste-token";
   const removing = activeAttempt && attempt.action === "remove";
@@ -325,7 +327,9 @@ export function TelegramRow(): ReactElement {
   }, [attempt, currentIdentity.kind, feedback, panel, port, state]);
 
   const begin = (action: TelegramAction): void => {
-    if (port === null || busy || activeAttempt || mutationUnsafe) return;
+    if (port === null || busy || credentialMutationBlocked || activeAttempt || mutationUnsafe) {
+      return;
+    }
     setPanelFeedback(null);
     const nextAttempt = persistAttempt(port, {
       action,
@@ -469,7 +473,11 @@ export function TelegramRow(): ReactElement {
               variant="destructive"
               size="sm"
               data-setup-delete="telegram"
-              disabled={busy || (authoritativeCheckRequired && attempt?.action === "paste-token")}
+              disabled={
+                busy ||
+                credentialMutationBlocked ||
+                (authoritativeCheckRequired && attempt?.action === "paste-token")
+              }
               aria-expanded={panel === "delete"}
               aria-label="Delete the Telegram connection"
               onClick={openDeletePanel}
@@ -483,7 +491,7 @@ export function TelegramRow(): ReactElement {
               variant="outline"
               size="sm"
               data-setup-trigger="telegram"
-              disabled={busy}
+              disabled={busy || credentialMutationBlocked}
               aria-expanded={panel === "token"}
               aria-label="Create Telegram bot"
               {...(panel === "closed" ? {} : { "aria-controls": panelId })}
@@ -553,7 +561,7 @@ export function TelegramRow(): ReactElement {
                 variant="default"
                 size="sm"
                 data-telegram-action="use-token"
-                disabled={busy || mutationUnsafe}
+                disabled={busy || credentialMutationBlocked || mutationUnsafe}
                 onClick={() => begin("paste-token")}
               >
                 {connecting ? "Connecting…" : "Use copied token"}
@@ -596,7 +604,7 @@ export function TelegramRow(): ReactElement {
             confirmLabel="Delete connection"
             focusTarget={confirmationFocus}
             cancelDisabled={busy}
-            confirmDisabled={busy || mutationUnsafe}
+            confirmDisabled={busy || credentialMutationBlocked || mutationUnsafe}
             confirmBusy={removing}
             onCancel={cancelDeletePanel}
             onConfirm={() => begin("remove")}

--- a/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/CredentialsSection.tsx
@@ -89,8 +89,7 @@ export function CredentialDeleteButton(props: {
     (store) => store.onboarding.wizard.credentialStatus["intervals-icu"] === "configured",
   );
   const target = "focus" in state ? state.focus : null;
-  const confirmation = content(state)?.confirmation ?? null;
-  const repairRequired = repairRequiredCredential(state) !== null;
+  const changesBlocked = credentialChangesBlocked(state, mutating);
   const intervalsFallback = props.credential === "intervals-icu" && intervalsConnected;
 
   useEffect(() => {
@@ -111,11 +110,9 @@ export function CredentialDeleteButton(props: {
       disabled={
         port === null ||
         state.status === "loading" ||
-        mutating ||
         setupLoading ||
         onboardingMutating ||
-        confirmation !== null ||
-        repairRequired
+        changesBlocked
       }
       aria-label={
         props.credential === "intervals-icu"
@@ -266,7 +263,10 @@ export function CredentialSettingsFeedback(): ReactElement | null {
   const current = content(state);
   const recovery = current?.recovery;
   const resetConfirmation = current?.confirmation === "all";
-  const canRetryRecovery = recovery?.state === "locked" || recovery?.state === "unavailable";
+  const canRetryRecovery =
+    recovery?.state === "locked" ||
+    recovery?.state === "missing" ||
+    recovery?.state === "unavailable";
   const canReset =
     recovery !== undefined &&
     (repairRequired !== null || recovery.state !== "ready" || recovery.unverifiedEnvelopes > 0);

--- a/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
@@ -12,6 +12,7 @@ import {
   type TelegramControlStatus,
   type TelegramSettingsState,
 } from "../../settings/telegram-controller.js";
+import { credentialChangesBlocked } from "../../settings/credential-controller.js";
 import { PLATFORM_COPY } from "../../platform-copy.js";
 import { settingsMutationActive } from "../../state/settings-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
@@ -133,6 +134,7 @@ function parseSenderId(value: string): number | null {
 
 export function TelegramSection(): ReactElement {
   const state = useEnduragentStore((store) => store.settings.telegram);
+  const credentialState = useEnduragentStore((store) => store.settings.credentials);
   const mutating = useEnduragentStore((store) => settingsMutationActive(store.settings));
   const port = useEnduragentStore((store) => store.settingsPorts?.telegram ?? null);
   const current = content(state);
@@ -161,6 +163,7 @@ export function TelegramSection(): ReactElement {
   const loading = state.status === "closed" || state.status === "loading";
   const working = state.status === "working";
   const busy = mutating || loading || working;
+  const credentialMutationBlocked = credentialChangesBlocked(credentialState, false);
   const removing = state.status === "working" && state.operation === "remove";
   const removingSender = state.status === "working" && state.operation === "remove-sender";
   const botUsername =
@@ -392,7 +395,7 @@ export function TelegramSection(): ReactElement {
                 ref={deleteTrigger}
                 variant="destructive"
                 size="sm"
-                disabled={busy || confirmRemove}
+                disabled={busy || credentialMutationBlocked || confirmRemove}
                 onClick={() => {
                   setConfirmRemove(true);
                 }}
@@ -459,7 +462,7 @@ export function TelegramSection(): ReactElement {
                 type="button"
                 variant="default"
                 size="sm"
-                disabled={busy}
+                disabled={busy || credentialMutationBlocked}
                 onClick={() => {
                   port?.pasteToken();
                 }}
@@ -500,7 +503,7 @@ export function TelegramSection(): ReactElement {
             confirmLabel="Delete connection"
             focusTarget={null}
             cancelDisabled={busy}
-            confirmDisabled={busy}
+            confirmDisabled={busy || credentialMutationBlocked}
             confirmBusy={removing}
             onCancel={() => {
               setConfirmRemove(false);

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -267,6 +267,39 @@ describe("credential settings controller", () => {
     );
   });
 
+  it("retries a missing Keychain item from the inline recovery message", async () => {
+    const retryRecovery = vi.fn(async () => ({ state: "ready", unverifiedEnvelopes: 0 }) as const);
+    const { controller, subject } = createSubject({
+      recovery: { state: "missing" },
+      retryRecovery,
+    });
+    await controller.activate();
+
+    subject.retry();
+    await vi.waitFor(() => expect(retryRecovery).toHaveBeenCalledOnce());
+    await vi.waitFor(() =>
+      expect(content(controller.state()).recovery).toEqual({
+        state: "ready",
+        unverifiedEnvelopes: 0,
+      }),
+    );
+  });
+
+  it.each([
+    { state: "locked" },
+    { state: "missing" },
+    { state: "unavailable" },
+  ] as const)("blocks individual deletion during $state recovery but keeps full reset available", async (recovery) => {
+    const { controller, subject } = createSubject({ recovery });
+    await controller.activate();
+
+    subject.requestDelete("anthropic");
+    expect(controller.state()).toMatchObject({ status: "ready", confirmation: null });
+
+    subject.requestReset();
+    expect(controller.state()).toMatchObject({ status: "confirming", confirmation: "all" });
+  });
+
   it("confirmation-gates the inline missing-key reset and focuses Cancel first", async () => {
     const { controller, subject, resetAllCredentials } = createSubject({
       recovery: { state: "missing" },
@@ -274,7 +307,7 @@ describe("credential settings controller", () => {
     await controller.activate();
 
     expect(content(controller.state()).announcement).toBe(
-      "These credentials cannot be recovered. Remove all credentials and start again.",
+      "The credential encryption key is missing. Restore it if possible, then Retry, or remove all credentials and start again.",
     );
     subject.requestReset();
     expect(controller.state()).toMatchObject({

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -175,6 +175,7 @@ interface HarnessOptions {
   readonly claudeCliStatus?: () => Promise<ClaudeCliStatus>;
   readonly deleteCredential?: () => Promise<CredentialDeleteResult>;
   readonly credentialRecoveryStatus?: () => Promise<CredentialRecoveryStatus>;
+  readonly retryCredentialRecovery?: () => Promise<CredentialRecoveryStatus>;
   readonly resetAllCredentials?: () => Promise<CredentialResetResult>;
   readonly onDeleted?: () => Promise<void> | void;
   readonly onReconciled?: () => Promise<void> | void;
@@ -243,6 +244,13 @@ function createHarness(options: HarnessOptions = {}) {
         keyCleanupPending: false,
       })),
   );
+  const retryCredentialRecovery = vi.fn(
+    options.retryCredentialRecovery ??
+      (async (): Promise<CredentialRecoveryStatus> => ({
+        state: "ready",
+        unverifiedEnvelopes: 0,
+      })),
+  );
   const openSetup = vi.fn();
   const onDeleted = vi.fn(options.onDeleted ?? (async () => {}));
   const onReconciled = vi.fn(options.onReconciled ?? (async () => {}));
@@ -292,6 +300,7 @@ function createHarness(options: HarnessOptions = {}) {
         state: "ready",
         unverifiedEnvelopes: 0,
       })),
+    retryCredentialRecovery,
     resetAllCredentials,
     ...(options.claudeCliStatus === undefined
       ? {}
@@ -410,6 +419,7 @@ function createHarness(options: HarnessOptions = {}) {
     applyLlmSelection,
     deleteCredential,
     resetAllCredentials,
+    retryCredentialRecovery,
     restartToUpdate,
     checkForUpdates,
     openSetup,
@@ -952,6 +962,23 @@ describe("credential deletion", () => {
 
     await user.click(within(confirmation).getByRole("button", { name: "Remove all credentials" }));
     await waitFor(() => expect(subject.resetAllCredentials).toHaveBeenCalledOnce());
+  });
+
+  it("offers Retry when a missing Keychain item may have been restored", async () => {
+    const user = userEvent.setup();
+    let recovery: CredentialRecoveryStatus = { state: "missing" };
+    const subject = await renderSettings({
+      credentialRecoveryStatus: async () => recovery,
+      retryCredentialRecovery: async () => {
+        recovery = { state: "ready", unverifiedEnvelopes: 0 };
+        return recovery;
+      },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(subject.retryCredentialRecovery).toHaveBeenCalledOnce());
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Retry" })).toBeNull());
   });
 
   it("offers explicit full reset after an uncertain per-slot deletion", async () => {

--- a/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
@@ -8,6 +8,7 @@ import type {
   TelegramControlStatus,
   TelegramSettingsState,
 } from "../src/settings/telegram-controller.js";
+import type { CredentialSettingsState } from "../src/settings/credential-controller.js";
 import { EMPTY_SETTINGS_SURFACE, type TelegramSettingsPort } from "../src/state/settings-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { TelegramSection } from "../src/ui/settings/TelegramSection.js";
@@ -38,7 +39,10 @@ function readyState(
   };
 }
 
-function setup(next: TelegramSettingsState) {
+function setup(
+  next: TelegramSettingsState,
+  credentials: CredentialSettingsState = EMPTY_SETTINGS_SURFACE.credentials,
+) {
   const port = {
     retry: vi.fn(),
     pasteToken: vi.fn(),
@@ -54,7 +58,7 @@ function setup(next: TelegramSettingsState) {
     removeSender: vi.fn(),
   } satisfies TelegramSettingsPort;
   useEnduragentStore.setState({
-    settings: { ...EMPTY_SETTINGS_SURFACE, telegram: next },
+    settings: { ...EMPTY_SETTINGS_SURFACE, credentials, telegram: next },
     settingsPorts: { telegram: port } as never,
   });
   render(<TelegramSection />);
@@ -76,6 +80,85 @@ afterEach(() => {
 });
 
 describe("Telegram settings surface", () => {
+  it("disables token storage and connection deletion during credential recovery", async () => {
+    const user = userEvent.setup();
+    const recovery = {
+      status: "ready",
+      entries: [],
+      providerStatuses: [],
+      confirmation: null,
+      announcement: "Unlock your login Keychain outside Enduragent, then Retry.",
+      recovery: { state: "locked" },
+      repairCredential: null,
+      recoveryAvailable: false,
+      focus: null,
+    } as const satisfies CredentialSettingsState;
+    const port = setup(readyState(status()), recovery);
+
+    const paste = screen.getByRole("button", { name: "Paste token from clipboard" });
+    expect(paste).toBeDisabled();
+    await user.click(paste);
+    expect(port.pasteToken).not.toHaveBeenCalled();
+
+    act(() => {
+      useEnduragentStore.setState({
+        settings: {
+          ...useEnduragentStore.getState().settings,
+          telegram: readyState(
+            status({
+              bot: { state: "ready", username: "desktop_coach_bot" },
+              credentialConfigured: true,
+            }),
+          ),
+        },
+      });
+    });
+
+    const remove = screen.getByRole("button", { name: "Delete" });
+    expect(remove).toBeDisabled();
+    await user.click(remove);
+    expect(port.remove).not.toHaveBeenCalled();
+  });
+
+  it("disables an open Telegram deletion confirmation when recovery becomes blocked", async () => {
+    const user = userEvent.setup();
+    const port = setup(
+      readyState(
+        status({
+          bot: { state: "ready", username: "desktop_coach_bot" },
+          credentialConfigured: true,
+        }),
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    const confirm = screen.getByRole("button", { name: "Delete connection" });
+    expect(confirm).toBeEnabled();
+
+    act(() => {
+      useEnduragentStore.setState({
+        settings: {
+          ...useEnduragentStore.getState().settings,
+          credentials: {
+            status: "ready",
+            entries: [],
+            providerStatuses: [],
+            confirmation: null,
+            announcement: "Secure credential storage is unavailable.",
+            recovery: { state: "unavailable" },
+            repairCredential: null,
+            recoveryAvailable: false,
+            focus: null,
+          },
+        },
+      });
+    });
+
+    expect(confirm).toBeDisabled();
+    await user.click(confirm);
+    expect(port.remove).not.toHaveBeenCalled();
+  });
+
   it("explains the dedicated-bot boundary and accepts a token only from the clipboard", async () => {
     const user = userEvent.setup();
     const port = setup(readyState(status()));

--- a/apps/desktop-renderer/tests/telegram-settings.test.ts
+++ b/apps/desktop-renderer/tests/telegram-settings.test.ts
@@ -45,7 +45,7 @@ const SENDERS = Object.freeze({
   senders: Object.freeze([{ senderId: 101, role: "primary" as const }]),
 }) satisfies TelegramAllowedSenders;
 
-function setup() {
+function setup(options: { readonly credentialMutationsBlocked?: () => boolean } = {}) {
   const states: TelegramSettingsState[] = [];
   let handlers!: Parameters<TelegramSettingsView["bind"]>[0];
   let poll: (() => void) | undefined;
@@ -137,6 +137,9 @@ function setup() {
   const controller = createTelegramSettingsController({
     bridge,
     beginMutation: () => release,
+    ...(options.credentialMutationsBlocked === undefined
+      ? {}
+      : { credentialMutationsBlocked: options.credentialMutationsBlocked }),
     view,
     pollIntervalMs: 10,
     setInterval: ((callback: () => void) => {
@@ -247,6 +250,20 @@ describe("Telegram settings controller", () => {
       status: "ready",
       telegram: { credentialConfigured: true, bot: { username: "synthetic_bot" } },
     });
+  });
+
+  it("blocks credential-changing Telegram actions while allowing recovery checks", async () => {
+    const runtime = setup({ credentialMutationsBlocked: () => true });
+    await runtime.controller.activate();
+
+    runtime.handlers.onPasteToken();
+    runtime.handlers.onRemove();
+
+    expect(runtime.bridge.pasteTokenFromClipboard).not.toHaveBeenCalled();
+    expect(runtime.bridge.remove).not.toHaveBeenCalled();
+
+    runtime.handlers.onReconcile();
+    await vi.waitFor(() => expect(runtime.bridge.reconcile).toHaveBeenCalledOnce());
   });
 
   it("announces a fresh clipboard connection with the connected bot", async () => {

--- a/apps/desktop/native/keychain-binding/keychain-binding.mm
+++ b/apps/desktop/native/keychain-binding/keychain-binding.mm
@@ -56,6 +56,12 @@ napi_value Success(napi_env env) {
   return result;
 }
 
+bool DefaultKeychainLocked() {
+  SecKeychainStatus status = 0;
+  return SecKeychainGetStatus(nullptr, &status) == errSecSuccess &&
+         (status & kSecUnlockStateStatus) == 0;
+}
+
 const char *StatusCode(OSStatus status) {
   switch (status) {
   case errSecItemNotFound:
@@ -64,8 +70,10 @@ const char *StatusCode(OSStatus status) {
     return "duplicate-item";
   case errSecInteractionNotAllowed:
   case errSecInteractionRequired:
+    return DefaultKeychainLocked() ? "keychain-locked" : "uninspectable-item";
   case errSecNotAvailable:
-    return "keychain-locked";
+  case errSecNoDefaultKeychain:
+    return "uninspectable-item";
   case errSecAuthFailed:
     return "uninspectable-item";
   default:
@@ -97,8 +105,8 @@ bool TrustedHost() {
   return trusted;
 }
 
-bool InteractionDisabled() {
-  return SecKeychainSetUserInteractionAllowed(false) == errSecSuccess;
+OSStatus InteractionDisabled() {
+  return SecKeychainSetUserInteractionAllowed(false);
 }
 
 bool AllowedService(const std::string &service) {
@@ -131,17 +139,53 @@ bool ReadService(napi_env env, napi_callback_info info, std::string &service) {
   return AllowedService(service);
 }
 
-CFMutableDictionaryRef Query(const std::string &service) {
+OSStatus CopyDefaultKeychain(SecKeychainRef &keychain) {
+  keychain = nullptr;
+  const OSStatus status = SecKeychainCopyDefault(&keychain);
+  if (status != errSecSuccess) {
+    if (keychain != nullptr)
+      CFRelease(keychain);
+    keychain = nullptr;
+    return status;
+  }
+  return keychain == nullptr ? errSecNoDefaultKeychain : errSecSuccess;
+}
+
+CFMutableDictionaryRef Query(const std::string &service,
+                             SecKeychainRef keychain, bool adding) {
   CFMutableDictionaryRef query = CFDictionaryCreateMutable(
       kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks,
       &kCFTypeDictionaryValueCallBacks);
+  if (query == nullptr)
+    return nullptr;
   CFStringRef serviceValue = String(service.c_str());
   CFStringRef accountValue = String(kAccount);
+  if (serviceValue == nullptr || accountValue == nullptr) {
+    if (serviceValue != nullptr)
+      CFRelease(serviceValue);
+    if (accountValue != nullptr)
+      CFRelease(accountValue);
+    CFRelease(query);
+    return nullptr;
+  }
   CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
   CFDictionarySetValue(query, kSecAttrService, serviceValue);
   CFDictionarySetValue(query, kSecAttrAccount, accountValue);
   CFRelease(serviceValue);
   CFRelease(accountValue);
+  if (adding) {
+    CFDictionarySetValue(query, kSecUseKeychain, keychain);
+  } else {
+    const void *values[] = {keychain};
+    CFArrayRef searchList = CFArrayCreate(
+        kCFAllocatorDefault, values, 1, &kCFTypeArrayCallBacks);
+    if (searchList == nullptr) {
+      CFRelease(query);
+      return nullptr;
+    }
+    CFDictionarySetValue(query, kSecMatchSearchList, searchList);
+    CFRelease(searchList);
+  }
   return query;
 }
 
@@ -323,8 +367,9 @@ PartitionInspection InspectPartition(SecKeychainItemRef item) {
 }
 
 bool ReadyForKeychain(napi_env env, napi_value &refusal) {
-  if (!InteractionDisabled()) {
-    refusal = Failure(env, "keychain-locked");
+  const OSStatus interactionStatus = InteractionDisabled();
+  if (interactionStatus != errSecSuccess) {
+    refusal = Failure(env, StatusCode(interactionStatus));
     return false;
   }
   static const bool trusted = TrustedHost();
@@ -351,7 +396,14 @@ napi_value ReadKey(napi_env env, napi_callback_info info) {
   napi_value refusal;
   if (!ReadyForKeychain(env, refusal))
     return refusal;
-  CFMutableDictionaryRef query = Query(service);
+  SecKeychainRef keychain = nullptr;
+  const OSStatus defaultStatus = CopyDefaultKeychain(keychain);
+  if (defaultStatus != errSecSuccess)
+    return Failure(env, StatusCode(defaultStatus));
+  CFMutableDictionaryRef query = Query(service, keychain, false);
+  CFRelease(keychain);
+  if (query == nullptr)
+    return Failure(env, "unknown");
   CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
   CFDictionarySetValue(query, kSecReturnRef, kCFBooleanTrue);
   CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
@@ -404,18 +456,30 @@ napi_value CreateKey(napi_env env, napi_callback_info info) {
   napi_value refusal;
   if (!ReadyForKeychain(env, refusal))
     return refusal;
+  SecKeychainRef keychain = nullptr;
+  const OSStatus defaultStatus = CopyDefaultKeychain(keychain);
+  if (defaultStatus != errSecSuccess)
+    return Failure(env, StatusCode(defaultStatus));
   std::array<unsigned char, kKeyBytes> material{};
   if (SecRandomCopyBytes(kSecRandomDefault, material.size(), material.data()) !=
       errSecSuccess) {
+    CFRelease(keychain);
     EraseKey(material);
     return Failure(env, "unknown");
   }
   SecAccessRef access = MakeAccess();
   if (access == nullptr) {
+    CFRelease(keychain);
     EraseKey(material);
     return Failure(env, "unknown");
   }
-  CFMutableDictionaryRef attributes = Query(service);
+  CFMutableDictionaryRef attributes = Query(service, keychain, true);
+  CFRelease(keychain);
+  if (attributes == nullptr) {
+    CFRelease(access);
+    EraseKey(material);
+    return Failure(env, "unknown");
+  }
   CFDataRef data =
       CFDataCreate(kCFAllocatorDefault, material.data(), material.size());
   if (data == nullptr) {
@@ -494,11 +558,42 @@ napi_value DeleteKey(napi_env env, napi_callback_info info) {
   napi_value refusal;
   if (!ReadyForKeychain(env, refusal))
     return refusal;
-  CFMutableDictionaryRef query = Query(service);
-  const OSStatus status = SecItemDelete(query);
+  SecKeychainRef keychain = nullptr;
+  const OSStatus defaultStatus = CopyDefaultKeychain(keychain);
+  if (defaultStatus != errSecSuccess)
+    return Failure(env, StatusCode(defaultStatus));
+  CFMutableDictionaryRef query = Query(service, keychain, false);
+  CFRelease(keychain);
+  if (query == nullptr)
+    return Failure(env, "unknown");
+  CFDictionarySetValue(query, kSecReturnRef, kCFBooleanTrue);
+  CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
+  CFTypeRef itemValue = nullptr;
+  OSStatus status = SecItemCopyMatching(query, &itemValue);
   CFRelease(query);
-  if (status != errSecSuccess && status != errSecItemNotFound) {
+  if (status != errSecSuccess && status != errSecItemNotFound)
     return Failure(env, StatusCode(status));
+  if (status == errSecSuccess &&
+      (itemValue == nullptr ||
+       CFGetTypeID(itemValue) != SecKeychainItemGetTypeID())) {
+    if (itemValue != nullptr)
+      CFRelease(itemValue);
+    return Failure(env, "unreadable-item");
+  }
+  if (status == errSecSuccess) {
+    SecKeychainItemRef item =
+        static_cast<SecKeychainItemRef>(const_cast<void *>(itemValue));
+    const PartitionInspection partition = InspectPartition(item);
+    if (partition != PartitionInspection::kPresent) {
+      CFRelease(itemValue);
+      return Failure(env, partition == PartitionInspection::kAbsent
+                              ? "unreadable-item"
+                              : "uninspectable-item");
+    }
+    status = SecKeychainItemDelete(item);
+    CFRelease(itemValue);
+    if (status != errSecSuccess)
+      return Failure(env, StatusCode(status));
   }
   napi_value response = Success(env);
   napi_value deleted;

--- a/apps/desktop/src/main/automatic-key-retirement.ts
+++ b/apps/desktop/src/main/automatic-key-retirement.ts
@@ -1,6 +1,15 @@
 import type { CredentialEnvelopeLockProof } from "./credential-envelope-lock.js";
-import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
-import { scanBoundCredentialEnvelopes } from "./credential-envelope-root-binding.js";
+import {
+  scanCredentialEnvelopes,
+  type CredentialEnvelopeRoots,
+} from "./credential-envelope-inventory.js";
+import {
+  assertCredentialEnvelopeRootsStable,
+  bindCredentialEnvelopeRoots,
+  guardedCredentialEnvelopeRoots,
+  useBoundCredentialRoot,
+} from "./credential-envelope-root-binding.js";
+import { syncDirectory } from "./durable-atomic-replace.js";
 import type { KeychainBindingErrorCode } from "./keychain-binding.js";
 
 const zeroDeletionBlockerCensusProof = Symbol("zero-deletion-blocker-census-proof");
@@ -28,15 +37,36 @@ export type KeychainKeyRetirement =
   | Readonly<{ status: "retained"; envelopes: number }>
   | Readonly<{ status: "deleted" }>
   | Readonly<{ status: "already-absent" }>
-  | Readonly<{ status: "failed"; code: KeychainBindingErrorCode }>;
+  | Readonly<{
+      status: "failed";
+      code: KeychainBindingErrorCode;
+      keyCleanupPending: boolean;
+    }>;
+
+export interface AutomaticKeyRetirementInspectorOptions {
+  readonly syncDirectory?: (root: string) => Promise<void>;
+}
 
 export function createAutomaticKeyRetirementInspector(
   roots: CredentialEnvelopeRoots,
   platform: NodeJS.Platform = process.platform,
+  options: AutomaticKeyRetirementInspectorOptions = {},
 ): InspectAutomaticKeyRetirement {
+  const synchronizeDirectory =
+    options.syncDirectory ?? (platform === "win32" ? async () => undefined : syncDirectory);
   return async (lockProof) => {
     try {
-      const { inventory } = await scanBoundCredentialEnvelopes(roots, platform);
+      const bindings = await bindCredentialEnvelopeRoots(roots, platform);
+      for (const binding of [bindings.credentials, bindings.telegram]) {
+        if (binding.state === "missing") continue;
+        await useBoundCredentialRoot(binding, platform, () =>
+          synchronizeDirectory(binding.root),
+        );
+      }
+      const inventory = await scanCredentialEnvelopes(
+        guardedCredentialEnvelopeRoots(roots, bindings),
+      );
+      await assertCredentialEnvelopeRootsStable(bindings);
       const deletionBlockers = inventory.deletionBlockers.length;
       return {
         status: "inspected",

--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -25,6 +25,7 @@ export type DesktopCredentialBackendSelection =
       unverifiedEnvelopes: number;
       createdKey: boolean;
       prepareKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyPreparation>;
+      validateKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyPreparation>;
       retireKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyRetirement>;
       deleteKeyForReset: (
         proof: CredentialEnvelopeLockProof,
@@ -134,6 +135,7 @@ async function selectMacCredentialBackend(
     unverifiedEnvelopes,
     createdKey: keychain.createdKey,
     prepareKey: keychain.prepareKey,
+    validateKey: keychain.validateKey,
     retireKey: keychain.retireKey,
     deleteKeyForReset: keychain.deleteKeyForReset,
   };

--- a/apps/desktop/src/main/credential-envelope-inventory.ts
+++ b/apps/desktop/src/main/credential-envelope-inventory.ts
@@ -1,5 +1,5 @@
 import { constants, type Stats } from "node:fs";
-import { lstat, open, readdir } from "node:fs/promises";
+import { lstat, open, opendir } from "node:fs/promises";
 import { join } from "node:path";
 import type { WindowsPrivateDirectoryBinding } from "@enduragent/core";
 import { CREDENTIAL_FILE_MODE, DESKTOP_CREDENTIAL_SLOTS } from "./credential-vault.js";
@@ -15,6 +15,8 @@ import {
 import { readWindowsPrivateFilePrefix } from "./windows-private-file.js";
 
 export type CredentialEnvelopeVault = "credentials" | "telegram";
+
+export const CREDENTIAL_ENVELOPE_DIRECTORY_ENTRY_LIMIT = 256;
 
 export interface CredentialEnvelopeTarget {
   readonly vault: CredentialEnvelopeVault;
@@ -41,6 +43,22 @@ export interface CredentialEnvelopeRoots {
     target: CredentialEnvelopeTarget,
   ) => Promise<CredentialEnvelopeInspection>;
   readonly readEnvelopeDirectory?: (path: string) => Promise<string[]>;
+}
+
+export async function readCredentialEnvelopeDirectory(root: string): Promise<string[]> {
+  const directory = await opendir(root);
+  const entries: string[] = [];
+  try {
+    for await (const entry of directory) {
+      if (entries.length >= CREDENTIAL_ENVELOPE_DIRECTORY_ENTRY_LIMIT) {
+        throw new RangeError("credential envelope directory entry limit exceeded");
+      }
+      entries.push(entry.name);
+    }
+  } finally {
+    await directory.close().catch(() => undefined);
+  }
+  return entries.sort();
 }
 
 export type CredentialEnvelopeInspection =
@@ -279,7 +297,7 @@ export async function scanCredentialEnvelopes(
     (roots.readEnvelopeFile === undefined
       ? inspectCredentialEnvelopeTarget
       : injectedEnvelopeInspector(roots.readEnvelopeFile));
-  const readDirectory = roots.readEnvelopeDirectory ?? readdir;
+  const readDirectory = roots.readEnvelopeDirectory ?? readCredentialEnvelopeDirectory;
   const deletionBlockers: CredentialEnvelopeRef[] = [];
   const canonicalEnvelopes: CredentialEnvelopeRef[] = [];
   const missingCanonicalTargets: CredentialEnvelopeTarget[] = [];
@@ -299,6 +317,9 @@ export async function scanCredentialEnvelopes(
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
       throw error;
+    }
+    if (entries.length > CREDENTIAL_ENVELOPE_DIRECTORY_ENTRY_LIMIT) {
+      throw new RangeError("credential envelope directory entry limit exceeded");
     }
     for (const entry of entries) {
       const target = transientCredentialEnvelopeTarget(roots, root, entry);

--- a/apps/desktop/src/main/credential-envelope-root-binding.ts
+++ b/apps/desktop/src/main/credential-envelope-root-binding.ts
@@ -1,5 +1,5 @@
-import type { Stats } from "node:fs";
-import { lstat, readdir } from "node:fs/promises";
+import type { BigIntStats, Stats } from "node:fs";
+import { lstat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import {
   assertWindowsPrivateDirectoryStable,
@@ -8,6 +8,7 @@ import {
 } from "@enduragent/core";
 import {
   inspectCredentialEnvelopeTarget,
+  readCredentialEnvelopeDirectory,
   scanCredentialEnvelopes,
   type CredentialEnvelopeInventory,
   type CredentialEnvelopeRoots,
@@ -21,6 +22,28 @@ interface CredentialRootIdentity {
   readonly ino: number | bigint;
 }
 
+interface CredentialRootEntryIdentity {
+  readonly name: string;
+  readonly dev: bigint;
+  readonly ino: bigint;
+  readonly mode: bigint;
+  readonly uid: bigint;
+  readonly size: bigint;
+  readonly mtimeNs: bigint;
+  readonly ctimeNs: bigint;
+  readonly birthtimeNs: bigint;
+}
+
+interface CredentialRootContents {
+  readonly dev: bigint;
+  readonly ino: bigint;
+  readonly mode: bigint;
+  readonly uid: bigint;
+  readonly mtimeNs: bigint;
+  readonly ctimeNs: bigint;
+  readonly entries: readonly CredentialRootEntryIdentity[];
+}
+
 export type CredentialEnvelopeRootBinding =
   | Readonly<{
       state: "missing";
@@ -32,6 +55,7 @@ export type CredentialEnvelopeRootBinding =
       root: string;
       expectedMode: number;
       identity: CredentialRootIdentity;
+      contents: CredentialRootContents;
       windowsDirectory?: WindowsPrivateDirectoryBinding;
     }>;
 
@@ -56,6 +80,81 @@ export function isMissingCredentialRootError(error: unknown): boolean {
 
 function missingPath(path: string): NodeJS.ErrnoException {
   return Object.assign(new Error("credential root is missing"), { code: "ENOENT", path });
+}
+
+function entryIdentity(name: string, metadata: BigIntStats): CredentialRootEntryIdentity {
+  return Object.freeze({
+    name,
+    dev: metadata.dev,
+    ino: metadata.ino,
+    mode: metadata.mode,
+    uid: metadata.uid,
+    size: metadata.size,
+    mtimeNs: metadata.mtimeNs,
+    ctimeNs: metadata.ctimeNs,
+    birthtimeNs: metadata.birthtimeNs,
+  });
+}
+
+function sameEntry(
+  first: CredentialRootEntryIdentity,
+  second: CredentialRootEntryIdentity,
+): boolean {
+  return (
+    first.name === second.name &&
+    first.dev === second.dev &&
+    first.ino === second.ino &&
+    first.mode === second.mode &&
+    first.uid === second.uid &&
+    first.size === second.size &&
+    first.mtimeNs === second.mtimeNs &&
+    first.ctimeNs === second.ctimeNs &&
+    first.birthtimeNs === second.birthtimeNs
+  );
+}
+
+function sameContents(first: CredentialRootContents, second: CredentialRootContents): boolean {
+  return (
+    first.dev === second.dev &&
+    first.ino === second.ino &&
+    first.mode === second.mode &&
+    first.uid === second.uid &&
+    first.mtimeNs === second.mtimeNs &&
+    first.ctimeNs === second.ctimeNs &&
+    first.entries.length === second.entries.length &&
+    first.entries.every((entry, index) => sameEntry(entry, second.entries[index]!))
+  );
+}
+
+function sameRootMetadata(first: BigIntStats, second: BigIntStats): boolean {
+  return (
+    first.dev === second.dev &&
+    first.ino === second.ino &&
+    first.mode === second.mode &&
+    first.uid === second.uid &&
+    first.mtimeNs === second.mtimeNs &&
+    first.ctimeNs === second.ctimeNs
+  );
+}
+
+async function readCredentialRootContents(root: string): Promise<CredentialRootContents> {
+  const before = await lstat(root, { bigint: true });
+  const names = await readCredentialEnvelopeDirectory(root);
+  const entries: CredentialRootEntryIdentity[] = [];
+  for (const name of names) {
+    entries.push(entryIdentity(name, await lstat(join(root, name), { bigint: true })));
+  }
+  const after = await lstat(root, { bigint: true });
+  if (!sameRootMetadata(before, after)) throw new TypeError("credential root changed");
+  return Object.freeze({
+    dev: after.dev,
+    ino: after.ino,
+    mode: after.mode,
+    uid: after.uid,
+    mtimeNs: after.mtimeNs,
+    ctimeNs: after.ctimeNs,
+    entries: Object.freeze(entries),
+  });
 }
 
 export function assertPosixCredentialRoot(metadata: Stats, expectedMode: number): void {
@@ -83,20 +182,30 @@ async function bindCredentialRoot(
   }
   if (platform === "win32") {
     const windowsDirectory = bindWindowsPrivateDirectory(dirname(root), root);
+    const contents = await readCredentialRootContents(root);
+    assertWindowsPrivateDirectoryStable(windowsDirectory);
     return {
       state: "bound",
       root,
       expectedMode,
       identity: windowsDirectory.identity,
+      contents,
       windowsDirectory,
     };
   }
   assertPosixCredentialRoot(metadata, expectedMode);
+  const contents = await readCredentialRootContents(root);
+  const confirmedMetadata = await lstat(root);
+  assertPosixCredentialRoot(confirmedMetadata, expectedMode);
+  if (confirmedMetadata.dev !== metadata.dev || confirmedMetadata.ino !== metadata.ino) {
+    throw new TypeError("credential root changed");
+  }
   return {
     state: "bound",
     root,
     expectedMode,
     identity: { dev: metadata.dev, ino: metadata.ino },
+    contents,
   };
 }
 
@@ -124,7 +233,7 @@ export function credentialRootBindingForVault(
   return bindings[vault];
 }
 
-export async function assertCredentialEnvelopeRootStable(
+export async function assertCredentialEnvelopeRootIdentityStable(
   binding: CredentialEnvelopeRootBinding,
   platform: NodeJS.Platform,
 ): Promise<void> {
@@ -139,13 +248,44 @@ export async function assertCredentialEnvelopeRootStable(
   }
   if (platform === "win32") {
     assertWindowsPrivateDirectoryStable(binding.windowsDirectory!);
-    return;
+  } else {
+    const metadata = await lstat(binding.root);
+    assertPosixCredentialRoot(metadata, binding.expectedMode);
+    if (metadata.dev !== binding.identity.dev || metadata.ino !== binding.identity.ino) {
+      throw new TypeError("credential root changed");
+    }
   }
-  const metadata = await lstat(binding.root);
-  assertPosixCredentialRoot(metadata, binding.expectedMode);
-  if (metadata.dev !== binding.identity.dev || metadata.ino !== binding.identity.ino) {
+}
+
+export async function assertCredentialEnvelopeRootStable(
+  binding: CredentialEnvelopeRootBinding,
+  platform: NodeJS.Platform,
+): Promise<void> {
+  await assertCredentialEnvelopeRootIdentityStable(binding, platform);
+  if (binding.state === "missing") return;
+  const contents = await readCredentialRootContents(binding.root);
+  if (!sameContents(binding.contents, contents)) {
     throw new TypeError("credential root changed");
   }
+}
+
+export async function refreshCredentialEnvelopeRootBindings(
+  bindings: CredentialEnvelopeRootBindings,
+): Promise<CredentialEnvelopeRootBindings> {
+  const refresh = async (
+    binding: CredentialEnvelopeRootBinding,
+  ): Promise<CredentialEnvelopeRootBinding> => {
+    await assertCredentialEnvelopeRootIdentityStable(binding, bindings.platform);
+    if (binding.state === "missing") return binding;
+    const contents = await readCredentialRootContents(binding.root);
+    await assertCredentialEnvelopeRootIdentityStable(binding, bindings.platform);
+    return { ...binding, contents };
+  };
+  return {
+    platform: bindings.platform,
+    credentials: await refresh(bindings.credentials),
+    telegram: await refresh(bindings.telegram),
+  };
 }
 
 export async function assertCredentialEnvelopeRootsStable(
@@ -166,6 +306,20 @@ export async function useBoundCredentialRoot<T>(
     return await operation();
   } finally {
     await assertCredentialEnvelopeRootStable(binding, platform);
+  }
+}
+
+export async function useBoundCredentialRootMutation<T>(
+  binding: CredentialEnvelopeRootBinding,
+  platform: NodeJS.Platform,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (binding.state === "missing") throw missingPath(binding.root);
+  await assertCredentialEnvelopeRootIdentityStable(binding, platform);
+  try {
+    return await operation();
+  } finally {
+    await assertCredentialEnvelopeRootIdentityStable(binding, platform);
   }
 }
 
@@ -215,7 +369,7 @@ export function guardedCredentialEnvelopeRoots(
     },
     readEnvelopeDirectory: async (root) => {
       const binding = bindingForRoot(bindings, root);
-      const readDirectory = roots.readEnvelopeDirectory ?? ((target: string) => readdir(target));
+      const readDirectory = roots.readEnvelopeDirectory ?? readCredentialEnvelopeDirectory;
       return useBoundCredentialRoot(binding, bindings.platform, () => readDirectory(root));
     },
   };

--- a/apps/desktop/src/main/credential-reset.ts
+++ b/apps/desktop/src/main/credential-reset.ts
@@ -15,7 +15,9 @@ import {
   credentialRootBindingForVault,
   guardedCredentialEnvelopeRoots,
   isMissingCredentialRootError,
+  refreshCredentialEnvelopeRootBindings,
   useBoundCredentialRoot,
+  useBoundCredentialRootMutation,
 } from "./credential-envelope-root-binding.js";
 import { syncDirectory } from "./durable-atomic-replace.js";
 import type { KeychainKeyDeletion } from "./keychain-credential-encryption.js";
@@ -40,23 +42,26 @@ export function resetEncryptedCredentialStorage(
     const syncCredentialDirectory = options.syncCredentialDirectory ?? syncDirectory;
     const platform = options.platform ?? process.platform;
     try {
-      const bindings = await bindCredentialEnvelopeRoots(options, platform);
-      const guardedRoots = guardedCredentialEnvelopeRoots(options, bindings);
+      let bindings = await bindCredentialEnvelopeRoots(options, platform);
       for (const target of credentialEnvelopeTargets(options)) {
         const binding = credentialRootBindingForVault(bindings, target.vault);
         if (binding.state === "missing") continue;
-        await useBoundCredentialRoot(binding, platform, () =>
+        await useBoundCredentialRootMutation(binding, platform, () =>
           removeFile(join(target.root, target.fileName), { force: true }),
         );
       }
+      bindings = await refreshCredentialEnvelopeRootBindings(bindings);
+      let guardedRoots = guardedCredentialEnvelopeRoots(options, bindings);
       const remaining = await scanCredentialEnvelopes(guardedRoots);
       for (const blocker of remaining.deletionBlockers) {
         const binding = credentialRootBindingForVault(bindings, blocker.vault);
         if (binding.state === "missing") throw new TypeError("missing credential root was scanned");
-        await useBoundCredentialRoot(binding, platform, () =>
+        await useBoundCredentialRootMutation(binding, platform, () =>
           removeFile(join(blocker.root, blocker.fileName), { force: true }),
         );
       }
+      bindings = await refreshCredentialEnvelopeRootBindings(bindings);
+      guardedRoots = guardedCredentialEnvelopeRoots(options, bindings);
       for (const binding of [bindings.credentials, bindings.telegram]) {
         if (binding.state === "missing") continue;
         try {

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -173,6 +173,9 @@ interface CredentialVaultOptions {
   readonly serializeCredentialMutation?: SerializeCredentialMutation;
   readonly serializeEnvelopeMutation?: SerializeCredentialEnvelopeMutation;
   readonly prepareEnvelopeWrite?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
+  readonly revalidateEnvelopeRemoval?: (
+    proof: CredentialEnvelopeLockProof,
+  ) => Promise<boolean>;
   readonly observeEnvelopeRemoved?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
   readonly renameCredentialFile?: typeof rename;
   readonly removeCredentialFile?: typeof rm;
@@ -340,7 +343,9 @@ async function validTarget(
 export function createCredentialVault(options: CredentialVaultOptions): CredentialVault {
   if (
     options.serializeEnvelopeMutation === undefined &&
-    (options.prepareEnvelopeWrite !== undefined || options.observeEnvelopeRemoved !== undefined)
+    (options.prepareEnvelopeWrite !== undefined ||
+      options.revalidateEnvelopeRemoval !== undefined ||
+      options.observeEnvelopeRemoved !== undefined)
   ) {
     throw new TypeError();
   }
@@ -957,7 +962,19 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
               return { slot, status: "refused", reason: "runtime-state-diverged" };
             }
           }
-          const removed = await removeStoredCredential(slot);
+          let removalReady = true;
+          if (
+            credential.state === "configured" &&
+            proof !== undefined &&
+            options.revalidateEnvelopeRemoval !== undefined
+          ) {
+            try {
+              removalReady = await options.revalidateEnvelopeRemoval(proof);
+            } catch {
+              removalReady = false;
+            }
+          }
+          const removed = removalReady ? await removeStoredCredential(slot) : "retained";
           if (removed === "uncertain") {
             uncertainSlots.add(slot);
             setRuntimeState(slot, "failed");

--- a/apps/desktop/src/main/desktop-credential-encryption.ts
+++ b/apps/desktop/src/main/desktop-credential-encryption.ts
@@ -47,6 +47,7 @@ export interface DesktopCredentialEncryption {
   readonly selection: DesktopCredentialBackendSelection;
   readonly service: string;
   prepareEnvelopeWrite(proof: CredentialEnvelopeLockProof): Promise<void>;
+  revalidateEnvelopeRemoval(proof: CredentialEnvelopeLockProof): Promise<boolean>;
   retireKeychainKey(proof: CredentialEnvelopeLockProof): Promise<KeychainKeyRetirement | undefined>;
   retryKeychain(): Promise<DesktopCredentialBackendSelection>;
   deleteKeyForCredentialReset(proof: CredentialEnvelopeLockProof): Promise<KeychainKeyDeletion>;
@@ -175,12 +176,22 @@ export async function prepareDesktopCredentialEncryption(
       const prepared = await selection.prepareKey(proof);
       if (prepared.status === "failed") transitionToUnavailable(prepared.code, false);
     },
+    async revalidateEnvelopeRemoval(proof: CredentialEnvelopeLockProof): Promise<boolean> {
+      if (options.location.platform !== "darwin") return true;
+      if (selection.status !== "keychain") return false;
+      const validated = await selection.validateKey(proof);
+      if (validated.status === "ready") return true;
+      transitionToUnavailable(validated.code, false);
+      return false;
+    },
     async retireKeychainKey(
       proof: CredentialEnvelopeLockProof,
     ): Promise<KeychainKeyRetirement | undefined> {
       if (selection.status !== "keychain") return undefined;
       const retired = await selection.retireKey(proof);
-      if (retired.status === "failed") transitionToUnavailable(retired.code, true);
+      if (retired.status === "failed") {
+        transitionToUnavailable(retired.code, retired.keyCleanupPending);
+      }
       return retired;
     },
     retryKeychain(): Promise<DesktopCredentialBackendSelection> {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -493,6 +493,9 @@ async function runDesktop(): Promise<void> {
     ): Promise<void> => {
       await credentialEncryption.prepareEnvelopeWrite(proof);
     };
+    const revalidateCredentialEnvelopeRemoval = async (
+      proof: CredentialEnvelopeLockProof,
+    ): Promise<boolean> => await credentialEncryption.revalidateEnvelopeRemoval(proof);
     const retireCredentialEncryptionKey = async (
       proof: CredentialEnvelopeLockProof,
     ): Promise<void> => {
@@ -528,6 +531,7 @@ async function runDesktop(): Promise<void> {
       observeSecureStorageFailure: telegramSecureStorageDiagnostics,
       serializeEnvelopeMutation: serializeCredentialEnvelopeMutation,
       prepareEnvelopeWrite: prepareCredentialEnvelopeWrite,
+      revalidateEnvelopeRemoval: revalidateCredentialEnvelopeRemoval,
       observeEnvelopeRemoved: retireCredentialEncryptionKey,
     });
     let activeTelegramBinding: TelegramDaemonBinding | undefined;
@@ -793,6 +797,7 @@ async function runDesktop(): Promise<void> {
       encryption: credentialEncryption.encryption,
       serializeEnvelopeMutation: serializeCredentialEnvelopeMutation,
       prepareEnvelopeWrite: prepareCredentialEnvelopeWrite,
+      revalidateEnvelopeRemoval: revalidateCredentialEnvelopeRemoval,
       observeEnvelopeRemoved: retireCredentialEncryptionKey,
       runtimeState: credentialRuntimeState,
       serializeCredentialMutation,

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -70,6 +70,7 @@ export type KeychainPartitionEncryptionResult =
       readonly encryption: CredentialEncryptionPort;
       readonly createdKey: boolean;
       readonly prepareKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyPreparation>;
+      readonly validateKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyPreparation>;
       readonly retireKey: (proof: CredentialEnvelopeLockProof) => Promise<KeychainKeyRetirement>;
       readonly deleteKeyForReset: (
         proof: CredentialEnvelopeLockProof,
@@ -246,7 +247,7 @@ export async function createKeychainPartitionEncryption(
       holder.key?.fill(0);
       holder.key = null;
     };
-    const prepareKey = async (
+    const validateKey = async (
       proof: CredentialEnvelopeLockProof,
     ): Promise<KeychainKeyPreparation> => {
       if (proof !== options.lockProof) return fail("unknown");
@@ -262,6 +263,13 @@ export async function createKeychainPartitionEncryption(
         clearKey();
         return fail(persisted.status === "missing" ? "item-not-found" : persisted.code);
       }
+      return fail(holder.failure);
+    };
+    const prepareKey = async (
+      proof: CredentialEnvelopeLockProof,
+    ): Promise<KeychainKeyPreparation> => {
+      if (proof !== options.lockProof) return fail("unknown");
+      if (holder.key !== null) return await validateKey(proof);
       if (holder.cleanupPending) {
         const inspection = await inspectAutomaticRetirement(proof);
         if (inspection.status === "failed" || inspection.zeroProof === null) {
@@ -299,7 +307,11 @@ export async function createKeychainPartitionEncryption(
       proof: CredentialEnvelopeLockProof,
     ): Promise<KeychainKeyRetirement> => {
       const inspection = await inspectAutomaticRetirement(proof);
-      if (inspection.status === "failed") return { status: "failed", code: "unknown" };
+      if (inspection.status === "failed") {
+        clearKey();
+        holder.failure = "unknown";
+        return { status: "failed", code: "unknown", keyCleanupPending: false };
+      }
       if (inspection.zeroProof === null) {
         return { status: "retained", envelopes: inspection.deletionBlockers };
       }
@@ -310,7 +322,7 @@ export async function createKeychainPartitionEncryption(
         previous?.fill(0);
         holder.failure = deleted.code;
         holder.cleanupPending = true;
-        return deleted;
+        return { ...deleted, keyCleanupPending: true };
       }
       previous?.fill(0);
       holder.failure = "item-not-found";
@@ -339,6 +351,7 @@ export async function createKeychainPartitionEncryption(
       encryption: readyPort(holder),
       createdKey,
       prepareKey,
+      validateKey,
       retireKey,
       deleteKeyForReset,
     };

--- a/apps/desktop/src/main/keychain-key-lifetime.ts
+++ b/apps/desktop/src/main/keychain-key-lifetime.ts
@@ -14,6 +14,6 @@ export async function retireKeychainKeyWhenLastEnvelopeGone(
   try {
     return await options.retireKey(options.lockProof);
   } catch {
-    return { status: "failed", code: "unknown" };
+    return { status: "failed", code: "unknown", keyCleanupPending: false };
   }
 }

--- a/apps/desktop/src/main/telegram-credential-vault.ts
+++ b/apps/desktop/src/main/telegram-credential-vault.ts
@@ -23,10 +23,15 @@ import type {
   CredentialEnvelopeLockProof,
   SerializeCredentialEnvelopeMutation,
 } from "./credential-envelope-lock.js";
+import { inspectCredentialEnvelopeTarget } from "./credential-envelope-inventory.js";
 import {
   durablyReplaceReversible,
   type ReversibleDurableReplaceOutcome,
 } from "./durable-atomic-replace.js";
+import {
+  KEYCHAIN_ENVELOPE_KEY_ID,
+  readCredentialEnvelopeKeyId,
+} from "./keychain-credential-encryption.js";
 import {
   emitTelegramSecureStorageFailure,
   type TelegramSecureStorageObserver,
@@ -154,6 +159,9 @@ export interface TelegramCredentialVaultOptions {
   readonly observeSecureStorageFailure?: TelegramSecureStorageObserver;
   readonly serializeEnvelopeMutation?: SerializeCredentialEnvelopeMutation;
   readonly prepareEnvelopeWrite?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
+  readonly revalidateEnvelopeRemoval?: (
+    proof: CredentialEnvelopeLockProof,
+  ) => Promise<boolean>;
   readonly observeEnvelopeRemoved?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
   readonly platform?: NodeJS.Platform;
   readonly openFile?: typeof open;
@@ -380,7 +388,9 @@ export function createTelegramCredentialVault(
 ): TelegramCredentialVault {
   if (
     options.serializeEnvelopeMutation === undefined &&
-    (options.prepareEnvelopeWrite !== undefined || options.observeEnvelopeRemoved !== undefined)
+    (options.prepareEnvelopeWrite !== undefined ||
+      options.revalidateEnvelopeRemoval !== undefined ||
+      options.observeEnvelopeRemoved !== undefined)
   ) {
     throw new TypeError();
   }
@@ -740,6 +750,32 @@ export function createTelegramCredentialVault(
     }
   };
 
+  const profileEnvelopeRemovalState = async (): Promise<
+    "missing" | "blocked" | "keychain-dependent" | "unverified"
+  > => {
+    const inspected = await inspectCredentialEnvelopeTarget(
+      {
+        vault: "telegram",
+        root: options.root,
+        fileName: TELEGRAM_PROFILE_FILE_NAME,
+        mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+      },
+      {
+        platform,
+        windowsDirectory,
+        openFile: options.openFile,
+      },
+    );
+    if (inspected.status !== "readable") return inspected.status;
+    try {
+      return readCredentialEnvelopeKeyId(inspected.contents) === KEYCHAIN_ENVELOPE_KEY_ID
+        ? "keychain-dependent"
+        : "unverified";
+    } finally {
+      inspected.contents.fill(0);
+    }
+  };
+
   return {
     profileStatus(): Promise<TelegramProfileStatus> {
       return exclusive(async () => {
@@ -913,16 +949,35 @@ export function createTelegramCredentialVault(
           return { outcome: "uncertain", reason: "storage-uncertain" };
         }
         if (profileUncertain) return { outcome: "uncertain", reason: "storage-uncertain" };
-        const profile = await readProfile();
-        if (profile.state === "missing") return { outcome: "refused", reason: "not-found" };
-        if (profile.state === "wrong-home") {
-          return { outcome: "refused", reason: "wrong-home" };
-        }
-        if (profile.state === "re-prompt") {
-          if (profile.reason === "encryption-unavailable" || profile.reason === "unsafe-backend") {
-            return { outcome: "refused", reason: profile.reason };
-          }
+        const removalState = await profileEnvelopeRemovalState();
+        if (removalState === "missing") return { outcome: "refused", reason: "not-found" };
+        if (removalState === "blocked") {
           return { outcome: "refused", reason: "storage-failed" };
+        }
+        if (removalState === "keychain-dependent") {
+          const profile = await readProfile();
+          if (profile.state === "missing") return { outcome: "refused", reason: "not-found" };
+          if (profile.state === "wrong-home") {
+            return { outcome: "refused", reason: "wrong-home" };
+          }
+          if (profile.state === "re-prompt") {
+            if (
+              profile.reason === "encryption-unavailable" ||
+              profile.reason === "unsafe-backend"
+            ) {
+              return { outcome: "refused", reason: profile.reason };
+            }
+            return { outcome: "refused", reason: "storage-failed" };
+          }
+          if (proof !== undefined && options.revalidateEnvelopeRemoval !== undefined) {
+            let removalReady = false;
+            try {
+              removalReady = await options.revalidateEnvelopeRemoval(proof);
+            } catch {}
+            if (!removalReady) {
+              return { outcome: "refused", reason: "encryption-unavailable" };
+            }
+          }
         }
         const removed = await removeStoredProfile();
         if (removed === "deleted" || removed === "cleanup-pending") {

--- a/apps/desktop/tests/credential-backend-selection.test.ts
+++ b/apps/desktop/tests/credential-backend-selection.test.ts
@@ -311,6 +311,69 @@ describe("backend selection", () => {
     },
   );
 
+  posixIt("refuses startup key retirement when vault contents change during census", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(roots.telegramRoot, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    const readEnvelopeDirectory = vi.fn(async (root: string) => {
+      if (root === roots.credentialRoot) {
+        await writeFile(join(root, "anthropic.bin"), Buffer.alloc(64), {
+          mode: CREDENTIAL_FILE_MODE,
+        });
+      }
+      return [];
+    });
+    const transport = transportOf(
+      PROBE_OK,
+      readKey(randomBytes(KEYCHAIN_KEY_BYTES)),
+      { ok: true, op: "delete-key", deleted: true },
+    );
+
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transport),
+      readEnvelopeDirectory,
+    });
+
+    expect(selected).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "unknown",
+    });
+    expect(readEnvelopeDirectory).toHaveBeenCalledOnce();
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe"]);
+  });
+
+  posixIt("refuses retirement when a transient is replaced under the same name", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(roots.telegramRoot, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    const transientName = ".anthropic.bin.write-1.tmp";
+    const transientPath = join(roots.credentialRoot, transientName);
+    await writeFile(transientPath, Buffer.alloc(64), { mode: CREDENTIAL_FILE_MODE });
+    const transport = transportOf(
+      PROBE_OK,
+      readKey(randomBytes(KEYCHAIN_KEY_BYTES)),
+      { ok: true, op: "delete-key", deleted: true },
+    );
+
+    const selected = await selectDesktopCredentialBackend({
+      ...selection(roots, transport),
+      inspectEnvelopeTarget: async (target) => {
+        if (target.fileName !== transientName) return { status: "missing" };
+        await rm(transientPath);
+        await writeFile(transientPath, Buffer.alloc(64, 1), { mode: CREDENTIAL_FILE_MODE });
+        return { status: "missing" };
+      },
+    });
+
+    expect(selected).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "unknown",
+    });
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe"]);
+  });
+
   posixIt("retires an orphan key when both bound roots are stably empty", async () => {
     const roots = await fixture();
     await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });

--- a/apps/desktop/tests/credential-key-retirement.test.ts
+++ b/apps/desktop/tests/credential-key-retirement.test.ts
@@ -1,10 +1,11 @@
 import { randomBytes } from "node:crypto";
-import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAutomaticKeyRetirementInspector } from "../src/main/automatic-key-retirement.js";
 import {
+  CREDENTIAL_DIRECTORY_MODE,
   createCredentialVault,
   type CredentialEncryptionPort,
 } from "../src/main/credential-vault.js";
@@ -17,13 +18,17 @@ import {
   sealCredentialEnvelope,
 } from "../src/main/keychain-credential-encryption.js";
 import { retireKeychainKeyWhenLastEnvelopeGone } from "../src/main/keychain-key-lifetime.js";
+import { syncDirectory } from "../src/main/durable-atomic-replace.js";
 import {
   KEYCHAIN_CREDENTIAL_SERVICE,
   KEYCHAIN_KEY_BYTES,
   type KeychainBindingRequest,
   type KeychainBindingResponse,
 } from "../src/main/keychain-binding.js";
-import { createTelegramCredentialVault } from "../src/main/telegram-credential-vault.js";
+import {
+  createTelegramCredentialVault,
+  TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
+} from "../src/main/telegram-credential-vault.js";
 
 const posixIt = it.skipIf(process.platform === "win32");
 const BOT = { id: 987654, username: "synthetic_bot" } as const;
@@ -78,13 +83,18 @@ async function retireKey(
   roots: Fixture,
   transport: ReturnType<typeof transportOf>,
   lockProof: CredentialEnvelopeLockProof,
+  synchronizeDirectory?: (root: string) => Promise<void>,
 ) {
-  const inspect = createAutomaticKeyRetirementInspector(roots);
+  const inspect = createAutomaticKeyRetirementInspector(roots, process.platform, {
+    syncDirectory: synchronizeDirectory,
+  });
   return await retireKeychainKeyWhenLastEnvelopeGone({
     lockProof,
     retireKey: async (proof) => {
       const inspection = await inspect(proof);
-      if (inspection.status === "failed") return { status: "failed", code: "unknown" };
+      if (inspection.status === "failed") {
+        return { status: "failed", code: "unknown", keyCleanupPending: false };
+      }
       if (inspection.zeroProof === null) {
         return { status: "retained", envelopes: inspection.deletionBlockers };
       }
@@ -92,8 +102,12 @@ async function retireKey(
         op: "delete-key",
         service: KEYCHAIN_CREDENTIAL_SERVICE,
       });
-      if (!deleted.ok) return { status: "failed", code: deleted.code };
-      if (deleted.op !== "delete-key") return { status: "failed", code: "unknown" };
+      if (!deleted.ok) {
+        return { status: "failed", code: deleted.code, keyCleanupPending: true };
+      }
+      if (deleted.op !== "delete-key") {
+        return { status: "failed", code: "unknown", keyCleanupPending: true };
+      }
       return { status: deleted.deleted ? "deleted" : "already-absent" };
     },
   });
@@ -128,6 +142,52 @@ describe("keychain key retirement call sites", () => {
     expect(transport.requests).toEqual([
       { op: "delete-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
     ]);
+  });
+
+  posixIt("keeps the key when credential tombstone cleanup is not durable", async () => {
+    const roots = await fixture();
+    await mkdir(roots.telegramRoot, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
+    const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    let deleting = false;
+    let deletionSyncs = 0;
+    const vault = createCredentialVault({
+      root: roots.credentialRoot,
+      encryption,
+      serializeEnvelopeMutation,
+      observeEnvelopeRemoved: async (proof) => {
+        await retireKey(roots, transport, proof, async () => {
+          expect(
+            (await readdir(roots.credentialRoot)).some((entry) => entry.endsWith(".deleted")),
+          ).toBe(false);
+          throw new TypeError("synthetic retirement durability failure");
+        });
+      },
+      syncCredentialDirectory: async (root) => {
+        if (deleting) {
+          deletionSyncs += 1;
+          if (deletionSyncs === 2) throw new TypeError("synthetic final sync failure");
+        }
+        await syncDirectory(root);
+      },
+      applyCredential: vi.fn(async () => undefined),
+      clearCredential: vi.fn(async () => "cleared" as const),
+    });
+    await vault.writeCredential(
+      { slot: "anthropic", value: "sk-anthropic" },
+      { activate: false },
+    );
+
+    deleting = true;
+    await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+      slot: "anthropic",
+      status: "deleted",
+      cleanupPending: true,
+    });
+
+    expect(deletionSyncs).toBe(2);
+    expect(transport.requests).toEqual([]);
   });
 
   posixIt("keeps the key while another credential envelope survives", async () => {
@@ -186,6 +246,90 @@ describe("keychain key retirement call sites", () => {
     expect(observeEnvelopeRemoved).toHaveBeenCalledOnce();
     expect(transport.requests).toEqual([
       { op: "delete-key", service: KEYCHAIN_CREDENTIAL_SERVICE },
+    ]);
+  });
+
+  posixIt("keeps the key when Telegram tombstone cleanup is not durable", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    const encryption = keychainPort(randomBytes(KEYCHAIN_KEY_BYTES));
+    const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    let deleting = false;
+    let deletionSyncs = 0;
+    const vault = createTelegramCredentialVault({
+      root: roots.telegramRoot,
+      athleteHome: roots.athleteHome,
+      encryption,
+      serializeEnvelopeMutation,
+      revalidateEnvelopeRemoval: async () => true,
+      observeEnvelopeRemoved: async (proof) => {
+        await retireKey(roots, transport, proof, async () => {
+          expect(
+            (await readdir(roots.telegramRoot)).some((entry) => entry.endsWith(".deleted")),
+          ).toBe(false);
+          throw new TypeError("synthetic retirement durability failure");
+        });
+      },
+      syncDirectory: async (root) => {
+        if (deleting) {
+          deletionSyncs += 1;
+          if (deletionSyncs === 2) throw new TypeError("synthetic final sync failure");
+        }
+        await syncDirectory(root);
+      },
+    });
+    await vault.replaceProfile({
+      token: "123:synthetic",
+      bot: BOT,
+      authenticatedAthleteHome: roots.athleteHome,
+    });
+
+    deleting = true;
+    await expect(vault.deleteProfile()).resolves.toEqual({
+      outcome: "applied",
+      cleanupPending: true,
+    });
+
+    expect(deletionSyncs).toBe(2);
+    expect(transport.requests).toEqual([]);
+  });
+
+  posixIt("creates a zero proof only after syncing both existing vault roots", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(roots.telegramRoot, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    const events: string[] = [];
+    const inspector = createAutomaticKeyRetirementInspector(
+      {
+        ...roots,
+        readEnvelopeDirectory: async (root) => {
+          events.push(`scan:${root}`);
+          return [];
+        },
+      },
+      process.platform,
+      {
+        syncDirectory: async (root) => {
+          events.push(`sync:${root}`);
+          await syncDirectory(root);
+        },
+      },
+    );
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+
+    const result = await serializeEnvelopeMutation((proof) => inspector(proof));
+
+    expect(result.status).toBe("inspected");
+    if (result.status !== "inspected") throw new TypeError();
+    expect(result.zeroProof).not.toBeNull();
+    expect(events.slice(0, 2)).toEqual([
+      `sync:${roots.credentialRoot}`,
+      `sync:${roots.telegramRoot}`,
+    ]);
+    expect(events.slice(2)).toEqual([
+      `scan:${roots.credentialRoot}`,
+      `scan:${roots.telegramRoot}`,
     ]);
   });
 

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -809,6 +809,38 @@ describe("desktop credential vault", () => {
     });
   });
 
+  it("retains a configured envelope when removal key revalidation fails", async () => {
+    const root = await temporaryRoot();
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    const applyCredential = vi.fn(async () => undefined);
+    const clearCredential = vi.fn(async () => "cleared" as const);
+    const revalidateEnvelopeRemoval = vi.fn(async () => false);
+    const removeCredentialFile = vi.fn(rm);
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential,
+      clearCredential,
+      serializeEnvelopeMutation,
+      revalidateEnvelopeRemoval,
+      removeCredentialFile,
+    });
+    await vault.writeCredential({ slot: "anthropic", value: randomUUID() });
+    removeCredentialFile.mockClear();
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "storage-failed",
+    });
+
+    expect(clearCredential).toHaveBeenCalledOnce();
+    expect(revalidateEnvelopeRemoval).toHaveBeenCalledOnce();
+    expect(removeCredentialFile).not.toHaveBeenCalled();
+    expect(applyCredential).toHaveBeenCalledTimes(2);
+    expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
+  });
+
   posixIt("deletes an unverified envelope only after the athlete requests that slot", async () => {
     const root = await temporaryRoot();
     await mkdir(root, { mode: CREDENTIAL_DIRECTORY_MODE });

--- a/apps/desktop/tests/desktop-credential-encryption.test.ts
+++ b/apps/desktop/tests/desktop-credential-encryption.test.ts
@@ -191,6 +191,38 @@ describe("desktop credential encryption startup", () => {
     ]);
   });
 
+  it("publishes encryption unavailable when removal revalidation sees a replaced key", async () => {
+    const replacement = randomBytes(KEYCHAIN_KEY_BYTES);
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: KEY },
+      { ok: true, op: "read-key", key: replacement },
+    );
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({
+        createTransport: () => transport,
+        readEnvelopeFile: migratedTelegramEnvelope(),
+        serializeEnvelopeMutation,
+      }),
+    );
+
+    await expect(
+      serializeEnvelopeMutation((proof) => prepared.revalidateEnvelopeRemoval(proof)),
+    ).resolves.toBe(false);
+
+    expect(prepared.selection).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "unknown",
+    });
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "read-key",
+    ]);
+  });
+
   it("never lets an unpackaged run touch the signed-release service", async () => {
     const transport = transportOf(PROBE_OK, {
       ok: true,
@@ -739,7 +771,11 @@ describe("desktop credential encryption startup", () => {
     envelope.remove();
     await expect(
       serializeEnvelopeMutation((proof) => prepared.retireKeychainKey(proof)),
-    ).resolves.toEqual({ status: "failed", code: "keychain-locked" });
+    ).resolves.toEqual({
+      status: "failed",
+      code: "keychain-locked",
+      keyCleanupPending: true,
+    });
     expect(prepared.selection).toMatchObject({
       status: "refused",
       code: "keychain-locked",
@@ -820,6 +856,53 @@ describe("desktop credential encryption startup", () => {
     expect(transport.requests.some((request) => request.op === "delete-key")).toBe(false);
   });
 
+  it("recovers a surviving credential after a retirement inventory failure", async () => {
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: KEY },
+      PROBE_OK,
+      { ok: true, op: "read-key", key: KEY },
+    );
+    let inventoryAvailable = true;
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({
+        createTransport: () => transport,
+        readEnvelopeFile: migratedTelegramEnvelope(),
+        readEnvelopeDirectory: async () => {
+          if (!inventoryAvailable) {
+            throw Object.assign(new Error("inventory unavailable"), { code: "EACCES" });
+          }
+          return [];
+        },
+        serializeEnvelopeMutation,
+      }),
+    );
+
+    inventoryAvailable = false;
+    await expect(
+      serializeEnvelopeMutation((proof) => prepared.retireKeychainKey(proof)),
+    ).resolves.toEqual({
+      status: "failed",
+      code: "unknown",
+      keyCleanupPending: false,
+    });
+    expect(prepared.selection).toMatchObject({
+      status: "refused",
+      keyCleanupPending: false,
+    });
+
+    inventoryAvailable = true;
+    await expect(prepared.retryKeychain()).resolves.toMatchObject({ status: "keychain" });
+    expect(prepared.encryption.isEncryptionAvailable()).toBe(true);
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "probe",
+      "read-key",
+    ]);
+  });
+
   it("never deletes a keychain item from a refusing or safeStorage lane", async () => {
     const transport = transportOf({ ok: false, code: "keychain-locked" });
 
@@ -875,6 +958,9 @@ describe("desktop startup wiring", () => {
 
     expect(source).toMatch(/credentialEncryption\.retireKeychainKey\(proof\)/u);
     expect(source.split("createCredentialEnvelopeMutationLock()")).toHaveLength(2);
+    expect(
+      source.split("revalidateEnvelopeRemoval: revalidateCredentialEnvelopeRemoval"),
+    ).toHaveLength(3);
     expect(source.split("observeEnvelopeRemoved: retireCredentialEncryptionKey")).toHaveLength(3);
   });
 });

--- a/apps/desktop/tests/keychain-binding-native.integration.test.ts
+++ b/apps/desktop/tests/keychain-binding-native.integration.test.ts
@@ -140,9 +140,17 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
         source.indexOf("bool ReadyForKeychain"),
         source.indexOf("napi_value Probe"),
       );
+      const statusMapping = source.slice(
+        source.indexOf("const char *StatusCode"),
+        source.indexOf("bool TrustedHost"),
+      );
       const creation = source.slice(
         source.indexOf("napi_value CreateKey"),
         source.indexOf("napi_value DeleteKey"),
+      );
+      const deletion = source.slice(
+        source.indexOf("napi_value DeleteKey"),
+        source.indexOf("NAPI_MODULE_INIT"),
       );
       const accessConstructionStart = source.indexOf("SecAccessRef MakeAccess");
       const accessConstruction = source.slice(
@@ -152,6 +160,16 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       expect(readiness.indexOf("InteractionDisabled()")).toBeLessThan(
         readiness.indexOf("TrustedHost()"),
       );
+      expect(readiness).toContain("StatusCode(interactionStatus)");
+      expect(readiness).not.toContain('Failure(env, "keychain-locked")');
+      expect(statusMapping).toContain(
+        'DefaultKeychainLocked() ? "keychain-locked" : "uninspectable-item"',
+      );
+      expect(statusMapping).toMatch(
+        /case errSecNotAvailable:\s+case errSecNoDefaultKeychain:\s+return "uninspectable-item";/u,
+      );
+      expect(source).toContain("kSecMatchSearchList");
+      expect(source).toContain("kSecUseKeychain");
       expect(accessConstruction).toContain(
         "acceptable = IsExpectedOwnerAcl(authorizations, applications)",
       );
@@ -173,6 +191,10 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       expect(creation).toContain("persistedLength == static_cast<UInt32>(material.size())");
       expect(creation).toContain("timingsafe_bcmp");
       expect(creation).not.toContain("SecItemDelete");
+      expect(deletion).toContain("SecItemCopyMatching");
+      expect(deletion).toContain("InspectPartition(item)");
+      expect(deletion).toContain("SecKeychainItemDelete(item)");
+      expect(deletion).not.toContain("SecItemDelete");
       expect(source).toContain("#define __STDC_WANT_LIB_EXT1__ 1");
       expect(source).toContain("memset_s(material.data(), material.size(), 0, material.size())");
       expect(source).not.toContain("explicit_bzero");

--- a/apps/desktop/tests/keychain-credential-encryption.test.ts
+++ b/apps/desktop/tests/keychain-credential-encryption.test.ts
@@ -245,6 +245,32 @@ describe("keychain partition backend", () => {
     ]);
   });
 
+  it("revalidates a removal without creating or deleting key material", async () => {
+    const original = storedKey();
+    const replacement = storedKey();
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: original.encoded },
+      { ok: true, op: "read-key", key: replacement.encoded },
+    );
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await expect(
+      serializePreparedEncryption((proof) => result.validateKey(proof)),
+    ).resolves.toEqual({ status: "failed", code: "unknown" });
+    expect(result.encryption.isEncryptionAvailable()).toBe(false);
+    expect(transport.requests.map((request) => request.op)).toEqual([
+      "probe",
+      "read-key",
+      "read-key",
+    ]);
+  });
+
   it("refuses a write when the persisted key disappeared", async () => {
     const original = storedKey();
     const transport = transportOf(
@@ -525,6 +551,7 @@ describe("keychain partition backend", () => {
     await expect(serialize((proof) => result.retireKey(proof))).resolves.toEqual({
       status: "failed",
       code: "unknown",
+      keyCleanupPending: true,
     });
     expect(result.encryption.isEncryptionAvailable()).toBe(false);
     expect(() => result.encryption.encryptString("orphan-candidate")).toThrow(
@@ -545,6 +572,45 @@ describe("keychain partition backend", () => {
     ]);
     const sealed = result.encryption.encryptString("post-cleanup-secret");
     expect(openCredentialEnvelope(replacement.key, sealed)).toBe("post-cleanup-secret");
+  });
+
+  it("does not record cleanup debt when retirement inspection fails before deletion", async () => {
+    const original = storedKey();
+    let inspectionFails = false;
+    const transport = transportOf(PROBE_OK, {
+      ok: true,
+      op: "read-key",
+      key: original.encoded,
+    });
+    const serialize = createCredentialEnvelopeMutationLock();
+    const result = await serialize((lockProof) =>
+      createKeychainPartitionEncryption({
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+        inspectAutomaticRetirement: async () =>
+          inspectionFails
+            ? { status: "failed" }
+            : {
+                status: "inspected",
+                deletionBlockers: 1,
+                keychainDependents: 1,
+                unverified: 0,
+                zeroProof: null,
+              },
+        lockProof,
+      }),
+    );
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    inspectionFails = true;
+    await expect(serialize((proof) => result.retireKey(proof))).resolves.toEqual({
+      status: "failed",
+      code: "unknown",
+      keyCleanupPending: false,
+    });
+    expect(result.encryption.isEncryptionAvailable()).toBe(false);
+    expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
   });
 
   it("refuses pending cleanup when a blocker appears", async () => {
@@ -571,6 +637,7 @@ describe("keychain partition backend", () => {
     await expect(serialize((proof) => result.retireKey(proof))).resolves.toEqual({
       status: "failed",
       code: "unknown",
+      keyCleanupPending: true,
     });
     census = { deletionBlockers: 1, keychainDependents: 0 };
     await expect(serialize((proof) => result.prepareKey(proof))).resolves.toEqual({

--- a/apps/desktop/tests/keychain-key-lifetime.test.ts
+++ b/apps/desktop/tests/keychain-key-lifetime.test.ts
@@ -21,13 +21,16 @@ import { createAutomaticKeyRetirementInspector } from "../src/main/automatic-key
 import {
   createCredentialVault,
   CREDENTIAL_DIRECTORY_MODE,
+  CREDENTIAL_FILE_MODE,
   type CredentialEncryptionPort,
   type DesktopCredentialSlot,
 } from "../src/main/credential-vault.js";
 import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import {
+  CREDENTIAL_ENVELOPE_DIRECTORY_ENTRY_LIMIT,
   credentialEnvelopeTargets,
   inspectCredentialEnvelopeTarget,
+  readCredentialEnvelopeDirectory,
   scanCredentialEnvelopes,
 } from "../src/main/credential-envelope-inventory.js";
 import {
@@ -137,7 +140,9 @@ async function retireKey(
       lockProof,
       retireKey: async (proof) => {
         const inspection = await inspect(proof);
-        if (inspection.status === "failed") return { status: "failed", code: "unknown" };
+        if (inspection.status === "failed") {
+          return { status: "failed", code: "unknown", keyCleanupPending: false };
+        }
         if (inspection.zeroProof === null) {
           return { status: "retained", envelopes: inspection.deletionBlockers };
         }
@@ -145,8 +150,12 @@ async function retireKey(
           op: "delete-key",
           service: KEYCHAIN_CREDENTIAL_SERVICE,
         });
-        if (!deleted.ok) return { status: "failed", code: deleted.code };
-        if (deleted.op !== "delete-key") return { status: "failed", code: "unknown" };
+        if (!deleted.ok) {
+          return { status: "failed", code: deleted.code, keyCleanupPending: true };
+        }
+        if (deleted.op !== "delete-key") {
+          return { status: "failed", code: "unknown", keyCleanupPending: true };
+        }
         return { status: deleted.deleted ? "deleted" : "already-absent" };
       },
     }),
@@ -212,6 +221,7 @@ describe("keychain key retirement", () => {
     await expect(retireKey(roots, transport)).resolves.toEqual({
       status: "failed",
       code: "unknown",
+      keyCleanupPending: false,
     });
     expect(transport.requests).toHaveLength(0);
     await expect(readFile(hiddenEnvelope, "utf8")).resolves.toBe("hidden-envelope");
@@ -415,13 +425,20 @@ describe("keychain key retirement", () => {
   posixIt("keeps the key while an envelope exists but cannot be read", async () => {
     const roots = await fixture();
     await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    const envelopePath = join(roots.credentialRoot, "anthropic.bin");
+    await writeFile(envelopePath, "unreadable-envelope", { mode: CREDENTIAL_FILE_MODE });
+    const readEnvelopeFile = vi.fn(async (path: string) => {
+      if (path === envelopePath) {
+        throw Object.assign(new Error("synthetic read failure"), { code: "EACCES" });
+      }
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
     const transport = transportOf();
 
-    await expect(
-      retireKey(roots, transport, (async () => {
-        throw Object.assign(new Error("synthetic read failure"), { code: "EACCES" });
-      }) as never),
-    ).resolves.toMatchObject({ status: "retained" });
+    await expect(retireKey(roots, transport, readEnvelopeFile)).resolves.toMatchObject({
+      status: "retained",
+    });
+    expect(readEnvelopeFile).toHaveBeenCalledWith(envelopePath);
     expect(transport.requests).toHaveLength(0);
   });
 
@@ -477,6 +494,30 @@ describe("keychain key retirement", () => {
     expect(transport.requests).toHaveLength(0);
   });
 
+  posixIt("fails closed when a credential directory exceeds the census limit", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await Promise.all(
+      Array.from({ length: CREDENTIAL_ENVELOPE_DIRECTORY_ENTRY_LIMIT + 1 }, (_, index) =>
+        writeFile(join(roots.credentialRoot, `entry-${index}`), "ignored"),
+      ),
+    );
+
+    await expect(readCredentialEnvelopeDirectory(roots.credentialRoot)).rejects.toThrow(
+      "credential envelope directory entry limit exceeded",
+    );
+    await expect(
+      scanCredentialEnvelopes({
+        ...roots,
+        readEnvelopeDirectory: async () =>
+          Array.from(
+            { length: CREDENTIAL_ENVELOPE_DIRECTORY_ENTRY_LIMIT + 1 },
+            (_, index) => `entry-${index}`,
+          ),
+      }),
+    ).rejects.toThrow("credential envelope directory entry limit exceeded");
+  });
+
   posixIt("counts a transient key-id one envelope as a keychain dependent", async () => {
     const roots = await fixture();
     await mkdir(roots.telegramRoot, {
@@ -521,6 +562,10 @@ describe("keychain key retirement", () => {
 
     await expect(
       retireKey(roots, transportOf({ ok: false, code: "keychain-locked" })),
-    ).resolves.toEqual({ status: "failed", code: "keychain-locked" });
+    ).resolves.toEqual({
+      status: "failed",
+      code: "keychain-locked",
+      keyCleanupPending: true,
+    });
   });
 });

--- a/apps/desktop/tests/telegram-credential-vault.test.ts
+++ b/apps/desktop/tests/telegram-credential-vault.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import {
   chmod,
   lstat,
@@ -17,6 +18,11 @@ import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import type { CredentialEncryptionPort } from "../src/main/credential-vault.js";
+import {
+  openCredentialEnvelope,
+  sealCredentialEnvelope,
+} from "../src/main/keychain-credential-encryption.js";
+import { KEYCHAIN_KEY_BYTES } from "../src/main/keychain-binding.js";
 import {
   TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
   TELEGRAM_CREDENTIAL_FILE_MODE,
@@ -90,6 +96,15 @@ function encryption(): CredentialEncryptionPort {
       }
       return Buffer.from(value.subarray(5, -4)).reverse().toString("utf8");
     },
+  };
+}
+
+function keychainEncryption(): CredentialEncryptionPort {
+  const key = randomBytes(KEYCHAIN_KEY_BYTES);
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => sealCredentialEnvelope(key, value),
+    decryptString: (value) => openCredentialEnvelope(key, value),
   };
 }
 
@@ -1152,6 +1167,71 @@ describe("Telegram credential vault", () => {
     const reopened = createTelegramCredentialVault({ ...value, encryption: encryption() });
     await expect(reopened.profileStatus()).resolves.toEqual({ state: "missing" });
     expect((await readdir(value.root)).some((entry) => entry.endsWith(".deleted"))).toBe(false);
+  });
+
+  it("retains a configured profile when removal key revalidation fails", async () => {
+    const value = await fixture();
+    const encryptionPort = keychainEncryption();
+    const seed = createTelegramCredentialVault({
+      ...value,
+      encryption: encryptionPort,
+      createProfileId: () => PROFILE_A,
+    });
+    await expect(
+      seed.replaceProfile({
+        token: "synthetic-token-a",
+        bot: BOT_A,
+        authenticatedAthleteHome: value.athleteHome,
+      }),
+    ).resolves.toMatchObject({ outcome: "applied", profileId: PROFILE_A });
+    const revalidateEnvelopeRemoval = vi.fn(async () => false);
+    const removeFile = vi.fn(rm);
+    const vault = createTelegramCredentialVault({
+      ...value,
+      encryption: encryptionPort,
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      revalidateEnvelopeRemoval,
+      removeFile,
+    });
+    removeFile.mockClear();
+
+    await expect(vault.deleteProfile()).resolves.toEqual({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+    });
+
+    expect(revalidateEnvelopeRemoval).toHaveBeenCalledOnce();
+    expect(removeFile).not.toHaveBeenCalled();
+    await expect(vault.profileStatus()).resolves.toMatchObject({
+      state: "configured",
+      profileId: PROFILE_A,
+    });
+  });
+
+  it("deletes an unverified profile without requiring a Keychain key", async () => {
+    const value = await fixture();
+    await seedProfile(value);
+    const revalidateEnvelopeRemoval = vi.fn(async () => false);
+    const vault = createTelegramCredentialVault({
+      ...value,
+      encryption: {
+        isEncryptionAvailable: () => false,
+        encryptString: vi.fn(),
+        decryptString: vi.fn(),
+      },
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      revalidateEnvelopeRemoval,
+    });
+
+    await expect(vault.deleteProfile()).resolves.toEqual({
+      outcome: "applied",
+      cleanupPending: false,
+    });
+
+    expect(revalidateEnvelopeRemoval).not.toHaveBeenCalled();
+    await expect(lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("refuses deletion when the tombstone id is invalid instead of rejecting", async () => {


### PR DESCRIPTION
## Summary

- bind vault contents by entry identity and nanosecond metadata so same-name replacement cannot authorize key deletion
- stream and cap each vault census at 256 directory entries, failing closed above the limit
- distinguish a proven locked default Keychain from unavailable or generic interaction failures
- scope every native read, add, and delete to the current default Keychain; delete only the exact partition-validated item
- distinguish a failed envelope census from a failed key deletion so Retry can recover surviving credentials safely
- block per-credential and Telegram credential mutations during unavailable recovery while keeping Retry and full reset available
- preserve explicit inline credential re-entry and proof-gated orphan retirement

## Verification

- focused final UI, controller, and backend safety suite: 217 passed
- full `pnpm check`: passed with 20 pre-existing warnings and 0 errors
- full `pnpm test`: 9,739 passed and 15 skipped
- disposable two-Keychain probe: deleted the exact item from one Keychain while preserving the same service/account item in the other
- fresh read-only skeptic: 5/5 criteria passed with no P0-P3 findings

## Limits

- `CREDENTIAL_ENVELOPE_DIRECTORY_ENTRY_LIMIT = 256`: bounds each vault census before it can create deletion authority
