### PR TITLE
fix: protect credential deletion authorization

### DIFF
--- a/.changeset/retain-keychain-dependent-credentials.md
+++ b/.changeset/retain-keychain-dependent-credentials.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Saved credentials are no longer deleted when the macOS Keychain cannot confirm their encryption key.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -436,6 +436,7 @@ type CredentialDeleteResult =
       readonly reason:
         | "not-found"
         | "managed-by-environment"
+        | "encryption-unavailable"
         | "storage-failed"
         | "runtime-unavailable"
         | "runtime-state-diverged";

--- a/apps/desktop-renderer/src/onboarding/bridge.ts
+++ b/apps/desktop-renderer/src/onboarding/bridge.ts
@@ -68,6 +68,7 @@ export type CredentialDeleteResult =
       readonly reason:
         | "not-found"
         | "managed-by-environment"
+        | "encryption-unavailable"
         | "storage-failed"
         | "runtime-unavailable"
         | "runtime-state-diverged";

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -297,6 +297,9 @@ function refusalCopy(
   if (reason === "not-found") {
     return "That credential is no longer stored. Reload to refresh the list.";
   }
+  if (reason === "encryption-unavailable") {
+    return "The credential was retained because secure storage could not confirm its encryption key.";
+  }
   if (reason === "storage-failed") {
     return "The credential remains stored. No deletion was completed. Try again.";
   }

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -593,6 +593,37 @@ describe("credential settings controller", () => {
     });
   });
 
+  it("retains the credential and recovery state when its encryption key cannot be confirmed", async () => {
+    let recovery: CredentialRecoveryStatus = { state: "ready", unverifiedEnvelopes: 0 };
+    const { controller, subject } = createSubject({
+      loadRecoveryStatus: async () => recovery,
+      deleteCredential: async () => {
+        recovery = { state: "unavailable" };
+        return {
+          credential: "anthropic",
+          status: "refused",
+          reason: "encryption-unavailable",
+        };
+      },
+    });
+    await controller.activate();
+
+    subject.requestDelete("anthropic");
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(controller.state().status).toBe("error"));
+
+    expect(controller.state()).toMatchObject({
+      status: "error",
+      kind: "delete",
+      reason: "encryption-unavailable",
+      entries: expect.arrayContaining([expect.objectContaining({ credential: "anthropic" })]),
+      announcement:
+        "The credential was retained because secure storage could not confirm its encryption key.",
+      recovery: { state: "unavailable" },
+      repairCredential: null,
+    });
+  });
+
   it("requires authoritative repair when saved and active runtime state diverge", async () => {
     const onReconciled = vi.fn(async () => {});
     const { controller, subject } = createSubject({

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -1017,6 +1017,43 @@ describe("credential deletion", () => {
     await waitFor(() => expect(subject.resetAllCredentials).toHaveBeenCalledOnce());
   });
 
+  it("shows an inline recovery path when secure storage refuses credential deletion", async () => {
+    const user = userEvent.setup();
+    let recovery: CredentialRecoveryStatus = { state: "ready", unverifiedEnvelopes: 0 };
+    await renderSettings({
+      credentialRecoveryStatus: async () => recovery,
+      deleteCredential: async () => {
+        recovery = { state: "unavailable" };
+        return {
+          credential: "openrouter",
+          status: "refused",
+          reason: "encryption-unavailable",
+        };
+      },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete the OpenRouter credential" }));
+    await user.click(
+      screen.getByRole("button", { name: "Confirm deletion of the OpenRouter credential" }),
+    );
+
+    const feedback = await screen.findByText(
+      "The credential was retained because secure storage could not confirm its encryption key.",
+    );
+    expect(feedback).toHaveAttribute("role", "status");
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Remove all credentials" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Delete the OpenRouter credential" })).toBeDisabled();
+    expect(useEnduragentStore.getState().settings.credentials).toMatchObject({
+      status: "error",
+      kind: "delete",
+      reason: "encryption-unavailable",
+      recovery: { state: "unavailable" },
+      repairCredential: null,
+    });
+  });
+
   it("cross-locks setup changes while deletion is confirmed and pending", async () => {
     const user = userEvent.setup();
     const deletion = deferred<CredentialDeleteResult>();

--- a/apps/desktop/src/main/credential-envelope-format.ts
+++ b/apps/desktop/src/main/credential-envelope-format.ts
@@ -1,0 +1,16 @@
+export const CREDENTIAL_ENVELOPE_MAGIC = "ENDURAGENT1" as const;
+export const SAFE_STORAGE_ENVELOPE_KEY_ID = 0;
+export const KEYCHAIN_ENVELOPE_KEY_ID = 1;
+export const CREDENTIAL_ENVELOPE_IV_BYTES = 12;
+export const CREDENTIAL_ENVELOPE_TAG_BYTES = 16;
+
+const MAGIC = Buffer.from(CREDENTIAL_ENVELOPE_MAGIC, "ascii");
+export const CREDENTIAL_ENVELOPE_HEADER_BYTES = MAGIC.length + 1;
+export const CREDENTIAL_ENVELOPE_INSPECTION_BYTES =
+  CREDENTIAL_ENVELOPE_HEADER_BYTES + CREDENTIAL_ENVELOPE_IV_BYTES + CREDENTIAL_ENVELOPE_TAG_BYTES;
+
+export function readCredentialEnvelopeKeyId(envelope: Buffer): number | undefined {
+  if (envelope.length < CREDENTIAL_ENVELOPE_INSPECTION_BYTES) return undefined;
+  if (!envelope.subarray(0, MAGIC.length).equals(MAGIC)) return undefined;
+  return envelope[MAGIC.length];
+}

--- a/apps/desktop/src/main/credential-envelope-inspection.ts
+++ b/apps/desktop/src/main/credential-envelope-inspection.ts
@@ -1,0 +1,179 @@
+import { constants, type Stats } from "node:fs";
+import { lstat, open } from "node:fs/promises";
+import { join } from "node:path";
+import type { WindowsPrivateDirectoryBinding } from "@enduragent/core";
+import {
+  CREDENTIAL_ENVELOPE_INSPECTION_BYTES,
+  KEYCHAIN_ENVELOPE_KEY_ID,
+  readCredentialEnvelopeKeyId,
+} from "./credential-envelope-format.js";
+import { readWindowsPrivateFilePrefix } from "./windows-private-file.js";
+
+export type CredentialEnvelopeVault = "credentials" | "telegram";
+
+export interface CredentialEnvelopeTarget {
+  readonly vault: CredentialEnvelopeVault;
+  readonly root: string;
+  readonly fileName: string;
+  readonly mode: number;
+}
+
+export type CredentialEnvelopeInspection =
+  | Readonly<{ status: "missing" }>
+  | Readonly<{ status: "readable"; contents: Buffer }>
+  | Readonly<{ status: "blocked" }>;
+
+export type CredentialEnvelopeRemovalState =
+  | "missing"
+  | "blocked"
+  | "keychain-dependent"
+  | "unverified";
+
+export interface InspectCredentialEnvelopeTargetOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly windowsDirectory?: WindowsPrivateDirectoryBinding;
+  readonly openFile?: typeof open;
+}
+
+function permissions(mode: number): number {
+  return mode & 0o777;
+}
+
+function safePosixEnvelopeMetadata(metadata: Stats, expectedMode: number): boolean {
+  return (
+    metadata.isFile() &&
+    !metadata.isSymbolicLink() &&
+    permissions(metadata.mode) === expectedMode &&
+    (typeof process.getuid !== "function" || metadata.uid === process.getuid())
+  );
+}
+
+function samePosixEnvelopeMetadata(first: Stats, second: Stats): boolean {
+  return (
+    first.dev === second.dev &&
+    first.ino === second.ino &&
+    first.mode === second.mode &&
+    first.uid === second.uid &&
+    first.size === second.size &&
+    first.mtimeMs === second.mtimeMs &&
+    first.ctimeMs === second.ctimeMs &&
+    first.isFile() === second.isFile() &&
+    first.isSymbolicLink() === second.isSymbolicLink()
+  );
+}
+
+async function inspectPosixCredentialEnvelopeTarget(
+  target: CredentialEnvelopeTarget,
+  openFile: typeof open = open,
+): Promise<CredentialEnvelopeInspection> {
+  const path = join(target.root, target.fileName);
+  let beforeOpen: Stats;
+  try {
+    beforeOpen = await lstat(path);
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT"
+      ? { status: "missing" }
+      : { status: "blocked" };
+  }
+  if (!safePosixEnvelopeMetadata(beforeOpen, target.mode)) return { status: "blocked" };
+  const flags = constants.O_RDONLY | constants.O_NONBLOCK | (constants.O_NOFOLLOW ?? 0);
+  let handle;
+  try {
+    handle = await openFile(path, flags);
+  } catch {
+    return { status: "blocked" };
+  }
+  let prefix: Buffer | undefined;
+  try {
+    const opened = await handle.stat();
+    if (
+      !safePosixEnvelopeMetadata(opened, target.mode) ||
+      !samePosixEnvelopeMetadata(beforeOpen, opened) ||
+      !Number.isSafeInteger(opened.size) ||
+      opened.size < 0
+    ) {
+      return { status: "blocked" };
+    }
+    const prefixBytes = Math.min(opened.size, CREDENTIAL_ENVELOPE_INSPECTION_BYTES);
+    prefix = Buffer.allocUnsafe(prefixBytes);
+    let offset = 0;
+    while (offset < prefix.length) {
+      const read = await handle.read(prefix, offset, prefix.length - offset, offset);
+      if (read.bytesRead <= 0) return { status: "blocked" };
+      offset += read.bytesRead;
+    }
+    const afterRead = await handle.stat();
+    let current: Stats;
+    try {
+      current = await lstat(path);
+    } catch {
+      return { status: "blocked" };
+    }
+    if (
+      !safePosixEnvelopeMetadata(afterRead, target.mode) ||
+      !safePosixEnvelopeMetadata(current, target.mode) ||
+      !samePosixEnvelopeMetadata(beforeOpen, afterRead) ||
+      !samePosixEnvelopeMetadata(afterRead, current)
+    ) {
+      return { status: "blocked" };
+    }
+    await handle.close();
+    handle = undefined;
+    return { status: "readable", contents: Buffer.from(prefix) };
+  } catch {
+    return { status: "blocked" };
+  } finally {
+    prefix?.fill(0);
+    if (handle !== undefined) await handle.close().catch(() => undefined);
+  }
+}
+
+export async function inspectCredentialEnvelopeTarget(
+  target: CredentialEnvelopeTarget,
+  options: InspectCredentialEnvelopeTargetOptions = {},
+): Promise<CredentialEnvelopeInspection> {
+  if ((options.platform ?? process.platform) !== "win32") {
+    return await inspectPosixCredentialEnvelopeTarget(target, options.openFile);
+  }
+  if (options.windowsDirectory === undefined) {
+    try {
+      await lstat(join(target.root, target.fileName));
+      return { status: "blocked" };
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code === "ENOENT"
+        ? { status: "missing" }
+        : { status: "blocked" };
+    }
+  }
+  let prefix: Buffer | undefined;
+  try {
+    const snapshot = await readWindowsPrivateFilePrefix({
+      directory: options.windowsDirectory,
+      path: join(target.root, target.fileName),
+      maximumReadBytes: CREDENTIAL_ENVELOPE_INSPECTION_BYTES,
+      openFile: options.openFile,
+    });
+    if (snapshot === undefined) return { status: "missing" };
+    prefix = snapshot.contents;
+    return { status: "readable", contents: Buffer.from(prefix) };
+  } catch {
+    return { status: "blocked" };
+  } finally {
+    prefix?.fill(0);
+  }
+}
+
+export async function classifyCredentialEnvelopeRemoval(
+  target: CredentialEnvelopeTarget,
+  options: InspectCredentialEnvelopeTargetOptions = {},
+): Promise<CredentialEnvelopeRemovalState> {
+  const inspected = await inspectCredentialEnvelopeTarget(target, options);
+  if (inspected.status !== "readable") return inspected.status;
+  try {
+    return readCredentialEnvelopeKeyId(inspected.contents) === KEYCHAIN_ENVELOPE_KEY_ID
+      ? "keychain-dependent"
+      : "unverified";
+  } finally {
+    inspected.contents.fill(0);
+  }
+}

--- a/apps/desktop/src/main/credential-envelope-inventory.ts
+++ b/apps/desktop/src/main/credential-envelope-inventory.ts
@@ -1,29 +1,33 @@
-import { constants, type Stats } from "node:fs";
-import { lstat, open, opendir } from "node:fs/promises";
+import { opendir } from "node:fs/promises";
 import { join } from "node:path";
-import type { WindowsPrivateDirectoryBinding } from "@enduragent/core";
 import { CREDENTIAL_FILE_MODE, DESKTOP_CREDENTIAL_SLOTS } from "./credential-vault.js";
 import {
-  CREDENTIAL_ENVELOPE_INSPECTION_BYTES,
   KEYCHAIN_ENVELOPE_KEY_ID,
   readCredentialEnvelopeKeyId,
-} from "./keychain-credential-encryption.js";
+} from "./credential-envelope-format.js";
+import {
+  inspectCredentialEnvelopeTarget,
+  type CredentialEnvelopeInspection,
+  type CredentialEnvelopeTarget,
+  type CredentialEnvelopeVault,
+} from "./credential-envelope-inspection.js";
 import {
   TELEGRAM_CREDENTIAL_FILE_MODE,
   TELEGRAM_PROFILE_FILE_NAME,
 } from "./telegram-credential-vault.js";
-import { readWindowsPrivateFilePrefix } from "./windows-private-file.js";
-
-export type CredentialEnvelopeVault = "credentials" | "telegram";
+export {
+  classifyCredentialEnvelopeRemoval,
+  inspectCredentialEnvelopeTarget,
+} from "./credential-envelope-inspection.js";
+export type {
+  CredentialEnvelopeInspection,
+  CredentialEnvelopeRemovalState,
+  CredentialEnvelopeTarget,
+  CredentialEnvelopeVault,
+  InspectCredentialEnvelopeTargetOptions,
+} from "./credential-envelope-inspection.js";
 
 export const CREDENTIAL_ENVELOPE_DIRECTORY_ENTRY_LIMIT = 256;
-
-export interface CredentialEnvelopeTarget {
-  readonly vault: CredentialEnvelopeVault;
-  readonly root: string;
-  readonly fileName: string;
-  readonly mode: number;
-}
 
 export interface CredentialEnvelopeRef extends CredentialEnvelopeTarget {
   readonly keyId: number | undefined;
@@ -59,17 +63,6 @@ export async function readCredentialEnvelopeDirectory(root: string): Promise<str
     await directory.close().catch(() => undefined);
   }
   return entries.sort();
-}
-
-export type CredentialEnvelopeInspection =
-  | Readonly<{ status: "missing" }>
-  | Readonly<{ status: "readable"; contents: Buffer }>
-  | Readonly<{ status: "blocked" }>;
-
-export interface InspectCredentialEnvelopeTargetOptions {
-  readonly platform?: NodeJS.Platform;
-  readonly windowsDirectory?: WindowsPrivateDirectoryBinding;
-  readonly openFile?: typeof open;
 }
 
 export function credentialEnvelopeTargets(
@@ -154,124 +147,6 @@ async function inspectEnvelopeTarget(
     return { ...target, keyId: readCredentialEnvelopeKeyId(inspected.contents) };
   } finally {
     inspected.contents.fill(0);
-  }
-}
-
-function permissions(mode: number): number {
-  return mode & 0o777;
-}
-
-function safePosixEnvelopeMetadata(metadata: Stats, expectedMode: number): boolean {
-  return (
-    metadata.isFile() &&
-    !metadata.isSymbolicLink() &&
-    permissions(metadata.mode) === expectedMode &&
-    (typeof process.getuid !== "function" || metadata.uid === process.getuid())
-  );
-}
-
-function samePosixEnvelopeMetadata(first: Stats, second: Stats): boolean {
-  return (
-    first.dev === second.dev &&
-    first.ino === second.ino &&
-    first.mode === second.mode &&
-    first.uid === second.uid &&
-    first.size === second.size &&
-    first.mtimeMs === second.mtimeMs &&
-    first.ctimeMs === second.ctimeMs &&
-    first.isFile() === second.isFile() &&
-    first.isSymbolicLink() === second.isSymbolicLink()
-  );
-}
-
-async function inspectPosixCredentialEnvelopeTarget(
-  target: CredentialEnvelopeTarget,
-  openFile: typeof open = open,
-): Promise<CredentialEnvelopeInspection> {
-  const path = join(target.root, target.fileName);
-  let beforeOpen: Stats;
-  try {
-    beforeOpen = await lstat(path);
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "ENOENT"
-      ? { status: "missing" }
-      : { status: "blocked" };
-  }
-  if (!safePosixEnvelopeMetadata(beforeOpen, target.mode)) return { status: "blocked" };
-  const flags = constants.O_RDONLY | constants.O_NONBLOCK | (constants.O_NOFOLLOW ?? 0);
-  let handle;
-  try {
-    handle = await openFile(path, flags);
-  } catch {
-    return { status: "blocked" };
-  }
-  let contents: Buffer | undefined;
-  try {
-    const opened = await handle.stat();
-    if (
-      !safePosixEnvelopeMetadata(opened, target.mode) ||
-      !samePosixEnvelopeMetadata(beforeOpen, opened) ||
-      !Number.isSafeInteger(opened.size) ||
-      opened.size < 0
-    ) {
-      return { status: "blocked" };
-    }
-    const prefixBytes = Math.min(opened.size, CREDENTIAL_ENVELOPE_INSPECTION_BYTES);
-    contents = Buffer.allocUnsafe(prefixBytes);
-    let offset = 0;
-    while (offset < contents.length) {
-      const read = await handle.read(contents, offset, contents.length - offset, offset);
-      if (read.bytesRead <= 0) return { status: "blocked" };
-      offset += read.bytesRead;
-    }
-    const afterRead = await handle.stat();
-    let current: Stats;
-    try {
-      current = await lstat(path);
-    } catch {
-      return { status: "blocked" };
-    }
-    if (
-      !safePosixEnvelopeMetadata(afterRead, target.mode) ||
-      !safePosixEnvelopeMetadata(current, target.mode) ||
-      !samePosixEnvelopeMetadata(beforeOpen, afterRead) ||
-      !samePosixEnvelopeMetadata(afterRead, current)
-    ) {
-      return { status: "blocked" };
-    }
-    await handle.close();
-    handle = undefined;
-    return { status: "readable", contents };
-  } catch {
-    return { status: "blocked" };
-  } finally {
-    if (handle !== undefined) {
-      contents?.fill(0);
-      await handle.close().catch(() => undefined);
-    }
-  }
-}
-
-export async function inspectCredentialEnvelopeTarget(
-  target: CredentialEnvelopeTarget,
-  options: InspectCredentialEnvelopeTargetOptions = {},
-): Promise<CredentialEnvelopeInspection> {
-  if ((options.platform ?? process.platform) !== "win32") {
-    return await inspectPosixCredentialEnvelopeTarget(target, options.openFile);
-  }
-  if (options.windowsDirectory === undefined) return { status: "blocked" };
-  try {
-    const snapshot = await readWindowsPrivateFilePrefix({
-      directory: options.windowsDirectory,
-      path: join(target.root, target.fileName),
-      maximumReadBytes: CREDENTIAL_ENVELOPE_INSPECTION_BYTES,
-      openFile: options.openFile,
-    });
-    return snapshot === undefined
-      ? { status: "missing" }
-      : { status: "readable", contents: snapshot.contents };
-  } catch {
-    return { status: "blocked" };
   }
 }
 

--- a/apps/desktop/src/main/credential-envelope-root-binding.ts
+++ b/apps/desktop/src/main/credential-envelope-root-binding.ts
@@ -7,13 +7,15 @@ import {
   type WindowsPrivateDirectoryBinding,
 } from "@enduragent/core";
 import {
-  inspectCredentialEnvelopeTarget,
   readCredentialEnvelopeDirectory,
   scanCredentialEnvelopes,
   type CredentialEnvelopeInventory,
   type CredentialEnvelopeRoots,
-  type CredentialEnvelopeVault,
 } from "./credential-envelope-inventory.js";
+import {
+  inspectCredentialEnvelopeTarget,
+  type CredentialEnvelopeVault,
+} from "./credential-envelope-inspection.js";
 import { CREDENTIAL_DIRECTORY_MODE } from "./credential-vault.js";
 import { TELEGRAM_CREDENTIAL_DIRECTORY_MODE } from "./telegram-credential-vault.js";
 

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -24,6 +24,7 @@ import type {
   SerializeCredentialEnvelopeMutation,
   SerializeCredentialMutation,
 } from "./credential-envelope-lock.js";
+import { classifyCredentialEnvelopeRemoval } from "./credential-envelope-inspection.js";
 import {
   assertWindowsPrivateFileAtPath,
   MAX_WINDOWS_DESKTOP_VAULT_FILE_BYTES,
@@ -89,6 +90,7 @@ export type CredentialDeleteResult =
       readonly reason:
         | "not-found"
         | "managed-by-environment"
+        | "encryption-unavailable"
         | "storage-failed"
         | "runtime-unavailable"
         | "runtime-state-diverged";
@@ -483,7 +485,10 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
 
   const removeStoredCredential = async (
     slot: DesktopCredentialSlot,
-  ): Promise<"deleted" | "cleanup-pending" | "retained" | "uncertain"> => {
+    authorizeRename?: () => Promise<boolean>,
+  ): Promise<
+    "deleted" | "cleanup-pending" | "authorization-refused" | "retained" | "uncertain"
+  > => {
     const target = join(options.root, `${slot}.bin`);
     let id: string;
     try {
@@ -493,6 +498,9 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     }
     if (!/^[A-Za-z0-9-]{1,128}$/.test(id)) return "retained";
     const tombstone = join(options.root, `.${slot}.${id}.deleted`);
+    if (authorizeRename !== undefined && !(await authorizeRename())) {
+      return "authorization-refused";
+    }
     try {
       await renameCredentialFile(target, tombstone);
     } catch {
@@ -939,9 +947,61 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
           if (!isCredentialSlot(slot)) {
             return { slot: "anthropic", status: "refused", reason: "not-found" };
           }
-          const credential = await readSlot(slot);
-          if (credential.state === "missing") {
+          const durability = await reconcileDurability();
+          if (durability === "uncertain") {
+            return { slot, status: "uncertain", reason: "storage-uncertain" };
+          }
+          if (durability !== "verified") {
+            return { slot, status: "refused", reason: "storage-failed" };
+          }
+          const removalState = await classifyCredentialEnvelopeRemoval(
+            {
+              vault: "credentials",
+              root: options.root,
+              fileName: `${slot}.bin`,
+              mode: CREDENTIAL_FILE_MODE,
+            },
+            {
+              platform,
+              windowsDirectory,
+              openFile: options.openCredentialFile,
+            },
+          );
+          if (removalState === "missing") {
             return { slot, status: "refused", reason: "not-found" };
+          }
+          if (removalState === "blocked") {
+            return { slot, status: "refused", reason: "storage-failed" };
+          }
+          let credential: ReadCredential | undefined;
+          if (removalState === "keychain-dependent") {
+            if (encryptionRefusal(options.encryption, platform) !== undefined) {
+              return { slot, status: "refused", reason: "encryption-unavailable" };
+            }
+            credential = await readSlot(slot);
+            if (credential.state === "missing") {
+              return { slot, status: "refused", reason: "not-found" };
+            }
+            if (credential.state !== "configured" || credential.value === undefined) {
+              return {
+                slot,
+                status: "refused",
+                reason:
+                  encryptionRefusal(options.encryption, platform) === undefined
+                    ? "storage-failed"
+                    : "encryption-unavailable",
+              };
+            }
+            if (proof === undefined || options.revalidateEnvelopeRemoval === undefined) {
+              return { slot, status: "refused", reason: "encryption-unavailable" };
+            }
+            let removalReady = false;
+            try {
+              removalReady = await options.revalidateEnvelopeRemoval(proof);
+            } catch {}
+            if (!removalReady) {
+              return { slot, status: "refused", reason: "encryption-unavailable" };
+            }
           }
           const runtimeStatus = runtimeState.get(slot);
           const shouldClearRuntime = runtimeStatus === "active" || runtimeStatus === "failed";
@@ -962,19 +1022,18 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
               return { slot, status: "refused", reason: "runtime-state-diverged" };
             }
           }
-          let removalReady = true;
-          if (
-            credential.state === "configured" &&
-            proof !== undefined &&
-            options.revalidateEnvelopeRemoval !== undefined
-          ) {
-            try {
-              removalReady = await options.revalidateEnvelopeRemoval(proof);
-            } catch {
-              removalReady = false;
-            }
-          }
-          const removed = removalReady ? await removeStoredCredential(slot) : "retained";
+          const removed = await removeStoredCredential(
+            slot,
+            removalState === "keychain-dependent"
+              ? async () => {
+                  try {
+                    return await options.revalidateEnvelopeRemoval!(proof!);
+                  } catch {
+                    return false;
+                  }
+                }
+              : undefined,
+          );
           if (removed === "uncertain") {
             uncertainSlots.add(slot);
             setRuntimeState(slot, "failed");
@@ -993,11 +1052,20 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
               cleanupPending: removed === "cleanup-pending",
             };
           }
-          if (runtimeCleared && credential.value !== undefined && removed === "retained") {
+          if (
+            runtimeCleared &&
+            credential?.value !== undefined &&
+            (removed === "retained" || removed === "authorization-refused")
+          ) {
             try {
               await options.applyCredential(slot, credential.value);
               setRuntimeState(slot, "active");
-              return { slot, status: "refused", reason: "storage-failed" };
+              return {
+                slot,
+                status: "refused",
+                reason:
+                  removed === "authorization-refused" ? "encryption-unavailable" : "storage-failed",
+              };
             } catch {
               setRuntimeState(slot, "failed");
               return { slot, status: "refused", reason: "runtime-state-diverged" };
@@ -1007,7 +1075,12 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
             setRuntimeState(slot, "failed");
             return { slot, status: "refused", reason: "runtime-state-diverged" };
           }
-          return { slot, status: "refused", reason: "storage-failed" };
+          return {
+            slot,
+            status: "refused",
+            reason:
+              removed === "authorization-refused" ? "encryption-unavailable" : "storage-failed",
+          };
         }),
       );
     },

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -8,6 +8,14 @@ import {
 import type { CredentialEnvelopeLockProof } from "./credential-envelope-lock.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
 import {
+  CREDENTIAL_ENVELOPE_HEADER_BYTES,
+  CREDENTIAL_ENVELOPE_IV_BYTES,
+  CREDENTIAL_ENVELOPE_MAGIC,
+  CREDENTIAL_ENVELOPE_TAG_BYTES,
+  KEYCHAIN_ENVELOPE_KEY_ID,
+  readCredentialEnvelopeKeyId,
+} from "./credential-envelope-format.js";
+import {
   KEYCHAIN_KEY_BYTES,
   KEYCHAIN_TEAM_IDENTIFIER,
   type KeychainBindingErrorCode,
@@ -15,17 +23,18 @@ import {
 } from "./keychain-binding.js";
 
 export const KEYCHAIN_PARTITION_STORAGE_BACKEND = "keychain_partition_v1" as const;
-export const CREDENTIAL_ENVELOPE_MAGIC = "ENDURAGENT1" as const;
-export const SAFE_STORAGE_ENVELOPE_KEY_ID = 0;
-export const KEYCHAIN_ENVELOPE_KEY_ID = 1;
-export const CREDENTIAL_ENVELOPE_IV_BYTES = 12;
-export const CREDENTIAL_ENVELOPE_TAG_BYTES = 16;
+export {
+  CREDENTIAL_ENVELOPE_HEADER_BYTES,
+  CREDENTIAL_ENVELOPE_INSPECTION_BYTES,
+  CREDENTIAL_ENVELOPE_IV_BYTES,
+  CREDENTIAL_ENVELOPE_MAGIC,
+  CREDENTIAL_ENVELOPE_TAG_BYTES,
+  KEYCHAIN_ENVELOPE_KEY_ID,
+  SAFE_STORAGE_ENVELOPE_KEY_ID,
+  readCredentialEnvelopeKeyId,
+} from "./credential-envelope-format.js";
 
 const MAGIC = Buffer.from(CREDENTIAL_ENVELOPE_MAGIC, "ascii");
-const HEADER_BYTES = MAGIC.length + 1;
-const MINIMUM_ENVELOPE_BYTES =
-  HEADER_BYTES + CREDENTIAL_ENVELOPE_IV_BYTES + CREDENTIAL_ENVELOPE_TAG_BYTES;
-export const CREDENTIAL_ENVELOPE_INSPECTION_BYTES = MINIMUM_ENVELOPE_BYTES;
 
 export class KeychainEncryptionError extends Error {
   constructor(readonly code: KeychainBindingErrorCode) {
@@ -34,12 +43,6 @@ export class KeychainEncryptionError extends Error {
 }
 
 export class CredentialEnvelopeError extends Error {}
-
-export function readCredentialEnvelopeKeyId(envelope: Buffer): number | undefined {
-  if (envelope.length < MINIMUM_ENVELOPE_BYTES) return undefined;
-  if (!envelope.subarray(0, MAGIC.length).equals(MAGIC)) return undefined;
-  return envelope[MAGIC.length];
-}
 
 export function sealCredentialEnvelope(key: Buffer, value: string): Buffer {
   const iv = randomBytes(CREDENTIAL_ENVELOPE_IV_BYTES);
@@ -53,10 +56,13 @@ export function openCredentialEnvelope(key: Buffer, envelope: Buffer): string {
   if (readCredentialEnvelopeKeyId(envelope) !== KEYCHAIN_ENVELOPE_KEY_ID) {
     throw new CredentialEnvelopeError();
   }
-  const iv = envelope.subarray(HEADER_BYTES, HEADER_BYTES + CREDENTIAL_ENVELOPE_IV_BYTES);
+  const iv = envelope.subarray(
+    CREDENTIAL_ENVELOPE_HEADER_BYTES,
+    CREDENTIAL_ENVELOPE_HEADER_BYTES + CREDENTIAL_ENVELOPE_IV_BYTES,
+  );
   const tag = envelope.subarray(envelope.length - CREDENTIAL_ENVELOPE_TAG_BYTES);
   const ciphertext = envelope.subarray(
-    HEADER_BYTES + CREDENTIAL_ENVELOPE_IV_BYTES,
+    CREDENTIAL_ENVELOPE_HEADER_BYTES + CREDENTIAL_ENVELOPE_IV_BYTES,
     envelope.length - CREDENTIAL_ENVELOPE_TAG_BYTES,
   );
   const decipher = createDecipheriv("aes-256-gcm", key, iv);

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -208,6 +208,7 @@ export type DesktopCredentialDeleteResult =
       readonly reason:
         | "not-found"
         | "managed-by-environment"
+        | "encryption-unavailable"
         | "storage-failed"
         | "runtime-unavailable"
         | "runtime-state-diverged";

--- a/apps/desktop/src/main/telegram-control.ts
+++ b/apps/desktop/src/main/telegram-control.ts
@@ -160,6 +160,7 @@ export interface CreateTelegramControlCoordinatorInput {
     | "profileStatus"
     | "replaceProfile"
     | "applyStoredProfile"
+    | "preauthorizeProfileRemoval"
     | "deleteProfile"
     | "desiredState"
     | "setDesiredState"
@@ -1280,6 +1281,29 @@ export function createTelegramControlCoordinator(
     return (restored.channel.desiredState === "enabled") === enabled ? restored : undefined;
   };
 
+  const compensateFailedRemoval = async (
+    active: TelegramDaemonBinding,
+    priorProfile: TelegramProfileRecord | undefined,
+    priorDesired: boolean,
+  ): Promise<boolean> => {
+    let credentialRestored = false;
+    if (priorProfile !== undefined && isCurrent(active)) {
+      try {
+        const configured = parseMutation(
+          await active.configureTelegram({ token: priorProfile.token }),
+        );
+        credentialRestored =
+          isCurrent(active) &&
+          configured?.outcome === "applied" &&
+          isReadyForProfile(configured.current, priorProfile);
+      } catch {}
+    }
+    const desiredRestored = (await restoreDesired(priorDesired)) === "restored";
+    const runtimeRestored =
+      (await restoreDaemonDesired(active, priorDesired)) !== undefined;
+    return credentialRestored && desiredRestored && runtimeRestored;
+  };
+
   const clearPairingLease = (): void => {
     if (pairingLease === undefined) return;
     if (pairingLease.handle !== undefined) leaseClock.cancel(pairingLease.handle);
@@ -1639,8 +1663,18 @@ export function createTelegramControlCoordinator(
         if ("result" in checked) return checked.result;
         const prior = await captureProfile(checked.active);
         if (prior.state === "uncertain") return uncertain();
-        if (prior.state === "refused") return refused(prior.reason);
-        if (prior.state !== "configured") return refused("invalid-state");
+        const authorization = await input.vault.preauthorizeProfileRemoval();
+        if (authorization.outcome === "uncertain") return uncertain();
+        if (authorization.outcome === "refused") {
+          return refused(
+            authorization.reason === "not-found"
+              ? "invalid-state"
+              : isSecureStorageRefusal(authorization.reason)
+              ? authorization.reason
+              : "storage-failed",
+          );
+        }
+        const priorProfile = prior.state === "configured" ? prior.profile : undefined;
         const previousDesired = checked.desiredState === "enabled";
         const disabled = await guardedSnapshotCall(checked.active, () =>
           checked.active.disableTelegram({}),
@@ -1670,8 +1704,8 @@ export function createTelegramControlCoordinator(
         }
         const deleted = await input.vault.deleteProfile();
         if (deleted.outcome !== "applied") {
-          await restoreDesired(previousDesired);
-          return uncertain();
+          await compensateFailedRemoval(checked.active, priorProfile, previousDesired);
+          return uncertain("control-uncertain");
         }
         return applied(await project(forgotten, checked.active));
       });

--- a/apps/desktop/src/main/telegram-credential-vault.ts
+++ b/apps/desktop/src/main/telegram-credential-vault.ts
@@ -23,15 +23,11 @@ import type {
   CredentialEnvelopeLockProof,
   SerializeCredentialEnvelopeMutation,
 } from "./credential-envelope-lock.js";
-import { inspectCredentialEnvelopeTarget } from "./credential-envelope-inventory.js";
+import { classifyCredentialEnvelopeRemoval } from "./credential-envelope-inspection.js";
 import {
   durablyReplaceReversible,
   type ReversibleDurableReplaceOutcome,
 } from "./durable-atomic-replace.js";
-import {
-  KEYCHAIN_ENVELOPE_KEY_ID,
-  readCredentialEnvelopeKeyId,
-} from "./keychain-credential-encryption.js";
 import {
   emitTelegramSecureStorageFailure,
   type TelegramSecureStorageObserver,
@@ -121,6 +117,19 @@ export type TelegramProfileDeleteResult =
     }>
   | Readonly<{ outcome: "uncertain"; reason: "storage-uncertain" }>;
 
+export type TelegramProfileRemovalAuthorizationResult =
+  | Readonly<{ outcome: "authorized" }>
+  | Readonly<{
+      outcome: "refused";
+      reason:
+        | "not-found"
+        | "wrong-home"
+        | "encryption-unavailable"
+        | "unsafe-backend"
+        | "storage-failed";
+    }>
+  | Readonly<{ outcome: "uncertain"; reason: "storage-uncertain" }>;
+
 export type TelegramDesiredState =
   | Readonly<{ state: "configured"; enabled: boolean }>
   | Readonly<{ state: "missing" | "re-prompt" | "wrong-home" | "uncertain"; enabled: false }>;
@@ -141,6 +150,7 @@ export interface TelegramCredentialVault {
     authenticatedAthleteHome: AthleteHomeIdentity,
     applyProfile: (profile: TelegramProfileRecord) => Promise<void>,
   ): Promise<TelegramProfileApplyResult>;
+  preauthorizeProfileRemoval(): Promise<TelegramProfileRemovalAuthorizationResult>;
   deleteProfile(): Promise<TelegramProfileDeleteResult>;
   desiredState(): Promise<TelegramDesiredState>;
   setDesiredState(enabled: boolean): Promise<TelegramDesiredStateWriteResult>;
@@ -706,8 +716,10 @@ export function createTelegramCredentialVault(
     }
   };
 
-  const removeStoredProfile = async (): Promise<
-    "deleted" | "cleanup-pending" | "retained" | "uncertain"
+  const removeStoredProfile = async (
+    authorizeRename?: () => Promise<boolean>,
+  ): Promise<
+    "deleted" | "cleanup-pending" | "authorization-refused" | "retained" | "uncertain"
   > => {
     if (
       (await secureDirectoryState(options.root, platform, bindCredentialDirectory)) !== "secure"
@@ -724,6 +736,9 @@ export function createTelegramCredentialVault(
     }
     if (!/^[A-Za-z0-9-]{1,128}$/.test(id)) return "retained";
     const tombstone = join(options.root, `.${TELEGRAM_PROFILE_FILE_NAME}.${id}.deleted`);
+    if (authorizeRename !== undefined && !(await authorizeRename())) {
+      return "authorization-refused";
+    }
     try {
       await renameFile(target, tombstone);
       transientArtifactsMayExist = true;
@@ -750,10 +765,18 @@ export function createTelegramCredentialVault(
     }
   };
 
-  const profileEnvelopeRemovalState = async (): Promise<
-    "missing" | "blocked" | "keychain-dependent" | "unverified"
+  const authorizeProfileRemoval = async (
+    proof: CredentialEnvelopeLockProof | undefined,
+    validateImmediately: boolean,
+  ): Promise<
+    | Readonly<{ outcome: "authorized"; keychainDependent: boolean }>
+    | Exclude<TelegramProfileRemovalAuthorizationResult, { outcome: "authorized" }>
   > => {
-    const inspected = await inspectCredentialEnvelopeTarget(
+    if (!(await prepareNamespace())) {
+      return { outcome: "uncertain", reason: "storage-uncertain" };
+    }
+    if (profileUncertain) return { outcome: "uncertain", reason: "storage-uncertain" };
+    const removalState = await classifyCredentialEnvelopeRemoval(
       {
         vault: "telegram",
         root: options.root,
@@ -766,14 +789,37 @@ export function createTelegramCredentialVault(
         openFile: options.openFile,
       },
     );
-    if (inspected.status !== "readable") return inspected.status;
-    try {
-      return readCredentialEnvelopeKeyId(inspected.contents) === KEYCHAIN_ENVELOPE_KEY_ID
-        ? "keychain-dependent"
-        : "unverified";
-    } finally {
-      inspected.contents.fill(0);
+    if (removalState === "missing") return { outcome: "refused", reason: "not-found" };
+    if (removalState === "blocked") {
+      return { outcome: "refused", reason: "storage-failed" };
     }
+    if (removalState !== "keychain-dependent") {
+      return { outcome: "authorized", keychainDependent: false };
+    }
+    const profile = await readProfile();
+    if (profile.state === "missing") return { outcome: "refused", reason: "not-found" };
+    if (profile.state === "wrong-home") {
+      return { outcome: "refused", reason: "wrong-home" };
+    }
+    if (profile.state === "re-prompt") {
+      if (profile.reason === "encryption-unavailable" || profile.reason === "unsafe-backend") {
+        return { outcome: "refused", reason: profile.reason };
+      }
+      return { outcome: "refused", reason: "storage-failed" };
+    }
+    if (proof === undefined || options.revalidateEnvelopeRemoval === undefined) {
+      return { outcome: "refused", reason: "encryption-unavailable" };
+    }
+    if (validateImmediately) {
+      let removalReady = false;
+      try {
+        removalReady = await options.revalidateEnvelopeRemoval(proof);
+      } catch {}
+      if (!removalReady) {
+        return { outcome: "refused", reason: "encryption-unavailable" };
+      }
+    }
+    return { outcome: "authorized", keychainDependent: true };
   };
 
   return {
@@ -943,43 +989,30 @@ export function createTelegramCredentialVault(
       });
     },
 
+    preauthorizeProfileRemoval(): Promise<TelegramProfileRemovalAuthorizationResult> {
+      return envelopeExclusive(async (proof) => {
+        const authorization = await authorizeProfileRemoval(proof, true);
+        return authorization.outcome === "authorized"
+          ? { outcome: "authorized" }
+          : authorization;
+      });
+    },
+
     deleteProfile(): Promise<TelegramProfileDeleteResult> {
       return envelopeExclusive(async (proof) => {
-        if (!(await prepareNamespace())) {
-          return { outcome: "uncertain", reason: "storage-uncertain" };
-        }
-        if (profileUncertain) return { outcome: "uncertain", reason: "storage-uncertain" };
-        const removalState = await profileEnvelopeRemovalState();
-        if (removalState === "missing") return { outcome: "refused", reason: "not-found" };
-        if (removalState === "blocked") {
-          return { outcome: "refused", reason: "storage-failed" };
-        }
-        if (removalState === "keychain-dependent") {
-          const profile = await readProfile();
-          if (profile.state === "missing") return { outcome: "refused", reason: "not-found" };
-          if (profile.state === "wrong-home") {
-            return { outcome: "refused", reason: "wrong-home" };
-          }
-          if (profile.state === "re-prompt") {
-            if (
-              profile.reason === "encryption-unavailable" ||
-              profile.reason === "unsafe-backend"
-            ) {
-              return { outcome: "refused", reason: profile.reason };
-            }
-            return { outcome: "refused", reason: "storage-failed" };
-          }
-          if (proof !== undefined && options.revalidateEnvelopeRemoval !== undefined) {
-            let removalReady = false;
-            try {
-              removalReady = await options.revalidateEnvelopeRemoval(proof);
-            } catch {}
-            if (!removalReady) {
-              return { outcome: "refused", reason: "encryption-unavailable" };
-            }
-          }
-        }
-        const removed = await removeStoredProfile();
+        const authorization = await authorizeProfileRemoval(proof, false);
+        if (authorization.outcome !== "authorized") return authorization;
+        const removed = await removeStoredProfile(
+          authorization.keychainDependent
+            ? async () => {
+                try {
+                  return await options.revalidateEnvelopeRemoval!(proof!);
+                } catch {
+                  return false;
+                }
+              }
+            : undefined,
+        );
         if (removed === "deleted" || removed === "cleanup-pending") {
           if (proof !== undefined) {
             try {
@@ -987,6 +1020,9 @@ export function createTelegramCredentialVault(
             } catch {}
           }
           return { outcome: "applied", cleanupPending: removed === "cleanup-pending" };
+        }
+        if (removed === "authorization-refused") {
+          return { outcome: "refused", reason: "encryption-unavailable" };
         }
         if (removed === "uncertain") profileUncertain = true;
         observeFailure(

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -104,6 +104,7 @@ const REASONS = new Set([
 const DELETE_REASONS = new Set([
   "not-found",
   "managed-by-environment",
+  "encryption-unavailable",
   "storage-failed",
   "runtime-unavailable",
   "runtime-state-diverged",

--- a/apps/desktop/tests/credential-key-retirement.test.ts
+++ b/apps/desktop/tests/credential-key-retirement.test.ts
@@ -126,6 +126,7 @@ describe("keychain key retirement call sites", () => {
       root: roots.credentialRoot,
       encryption,
       serializeEnvelopeMutation,
+      revalidateEnvelopeRemoval: async () => true,
       observeEnvelopeRemoved,
       applyCredential: vi.fn(async () => undefined),
       clearCredential: vi.fn(async () => "cleared" as const),
@@ -156,6 +157,7 @@ describe("keychain key retirement call sites", () => {
       root: roots.credentialRoot,
       encryption,
       serializeEnvelopeMutation,
+      revalidateEnvelopeRemoval: async () => true,
       observeEnvelopeRemoved: async (proof) => {
         await retireKey(roots, transport, proof, async () => {
           expect(
@@ -199,6 +201,7 @@ describe("keychain key retirement call sites", () => {
       root: roots.credentialRoot,
       encryption,
       serializeEnvelopeMutation,
+      revalidateEnvelopeRemoval: async () => true,
       observeEnvelopeRemoved: async (proof) => {
         await retireKey(roots, transport, proof);
       },
@@ -231,6 +234,7 @@ describe("keychain key retirement call sites", () => {
       athleteHome: roots.athleteHome,
       encryption,
       serializeEnvelopeMutation,
+      revalidateEnvelopeRemoval: async () => true,
       observeEnvelopeRemoved,
     });
     await expect(
@@ -355,6 +359,7 @@ describe("keychain key retirement call sites", () => {
       athleteHome: roots.athleteHome,
       encryption,
       serializeEnvelopeMutation,
+      revalidateEnvelopeRemoval: async () => true,
       observeEnvelopeRemoved: async (proof) => {
         await retireKey(roots, transport, proof);
       },
@@ -380,6 +385,7 @@ describe("keychain key retirement call sites", () => {
       root: roots.credentialRoot,
       encryption,
       serializeEnvelopeMutation,
+      revalidateEnvelopeRemoval: async () => true,
       observeEnvelopeRemoved: async () => {
         throw new Error("synthetic retirement failure");
       },
@@ -421,6 +427,7 @@ describe("keychain key retirement call sites", () => {
       root: roots.credentialRoot,
       encryption,
       serializeEnvelopeMutation,
+      revalidateEnvelopeRemoval: async () => true,
       observeEnvelopeRemoved: async (proof) => {
         markRetirementStarted?.();
         await retirementBlocked;

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import {
   chmod,
   lstat,
@@ -29,6 +29,13 @@ import {
   type CredentialEncryptionPort,
   type CredentialVaultMutation,
 } from "../src/main/credential-vault.js";
+import {
+  CREDENTIAL_ENVELOPE_MAGIC,
+  SAFE_STORAGE_ENVELOPE_KEY_ID,
+  openCredentialEnvelope,
+  sealCredentialEnvelope,
+} from "../src/main/keychain-credential-encryption.js";
+import { KEYCHAIN_KEY_BYTES } from "../src/main/keychain-binding.js";
 
 const roots: string[] = [];
 const posixIt = it.skipIf(process.platform === "win32");
@@ -70,6 +77,14 @@ function encryption(): CredentialEncryptionPort {
       }
       return value.subarray(5, -4).reverse().toString();
     },
+  };
+}
+
+function keychainEncryption(key = randomBytes(KEYCHAIN_KEY_BYTES)): CredentialEncryptionPort {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => sealCredentialEnvelope(key, value),
+    decryptString: (value) => openCredentialEnvelope(key, value),
   };
 }
 
@@ -811,6 +826,7 @@ describe("desktop credential vault", () => {
 
   it("retains a configured envelope when removal key revalidation fails", async () => {
     const root = await temporaryRoot();
+    const encryptionPort = keychainEncryption();
     const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     const applyCredential = vi.fn(async () => undefined);
     const clearCredential = vi.fn(async () => "cleared" as const);
@@ -818,7 +834,7 @@ describe("desktop credential vault", () => {
     const removeCredentialFile = vi.fn(rm);
     const vault = createCredentialVault({
       root,
-      encryption: encryption(),
+      encryption: encryptionPort,
       applyCredential,
       clearCredential,
       serializeEnvelopeMutation,
@@ -831,15 +847,171 @@ describe("desktop credential vault", () => {
     await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
       slot: "anthropic",
       status: "refused",
+      reason: "encryption-unavailable",
+    });
+
+    expect(clearCredential).not.toHaveBeenCalled();
+    expect(revalidateEnvelopeRemoval).toHaveBeenCalledOnce();
+    expect(removeCredentialFile).not.toHaveBeenCalled();
+    expect(applyCredential).toHaveBeenCalledOnce();
+    expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
+  });
+
+  it("retains a keychain envelope when encryption is unavailable", async () => {
+    const root = await temporaryRoot();
+    const encryptionPort = keychainEncryption();
+    await storeEncryptedCredential(root, "anthropic", "synthetic-secret", encryptionPort);
+    const decryptString = vi.fn(() => {
+      throw new TypeError();
+    });
+    const clearCredential = vi.fn(async () => "cleared" as const);
+    const revalidateEnvelopeRemoval = vi.fn(async () => true);
+    const vault = createCredentialVault({
+      root,
+      encryption: {
+        isEncryptionAvailable: () => false,
+        encryptString: vi.fn(),
+        decryptString,
+      },
+      applyCredential: vi.fn(async () => undefined),
+      clearCredential,
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      revalidateEnvelopeRemoval,
+    });
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "encryption-unavailable",
+    });
+
+    expect(decryptString).not.toHaveBeenCalled();
+    expect(clearCredential).not.toHaveBeenCalled();
+    expect(revalidateEnvelopeRemoval).not.toHaveBeenCalled();
+    expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
+  });
+
+  it("maps a corrupt keychain envelope to storage failure", async () => {
+    const root = await temporaryRoot();
+    await storeEncryptedCredential(root, "anthropic", "synthetic-secret", keychainEncryption());
+    const clearCredential = vi.fn(async () => "cleared" as const);
+    const revalidateEnvelopeRemoval = vi.fn(async () => true);
+    const vault = createCredentialVault({
+      root,
+      encryption: keychainEncryption(),
+      applyCredential: vi.fn(async () => undefined),
+      clearCredential,
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      revalidateEnvelopeRemoval,
+    });
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
       reason: "storage-failed",
     });
 
-    expect(clearCredential).toHaveBeenCalledOnce();
-    expect(revalidateEnvelopeRemoval).toHaveBeenCalledOnce();
-    expect(removeCredentialFile).not.toHaveBeenCalled();
-    expect(applyCredential).toHaveBeenCalledTimes(2);
+    expect(clearCredential).not.toHaveBeenCalled();
+    expect(revalidateEnvelopeRemoval).not.toHaveBeenCalled();
     expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
   });
+
+  it.each(["missing-proof", "missing-hook"] as const)(
+    "retains a keychain envelope with %s",
+    async (missing) => {
+      const root = await temporaryRoot();
+      const encryptionPort = keychainEncryption();
+      await storeEncryptedCredential(root, "anthropic", "synthetic-secret", encryptionPort);
+      const vault = createCredentialVault({
+        root,
+        encryption: encryptionPort,
+        applyCredential: vi.fn(async () => undefined),
+        serializeEnvelopeMutation:
+          missing === "missing-proof"
+            ? async (operation) => await operation(undefined as never)
+            : createCredentialEnvelopeMutationLock(),
+        revalidateEnvelopeRemoval:
+          missing === "missing-hook" ? undefined : vi.fn(async () => true),
+      });
+
+      await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+        slot: "anthropic",
+        status: "refused",
+        reason: "encryption-unavailable",
+      });
+      expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
+    },
+  );
+
+  it.each(["false", "throws"] as const)(
+    "does not clear runtime when first key validation %s",
+    async (failure) => {
+      const root = await temporaryRoot();
+      const encryptionPort = keychainEncryption();
+      const clearCredential = vi.fn(async () => "cleared" as const);
+      const revalidateEnvelopeRemoval = vi.fn(async () => {
+        if (failure === "throws") throw new TypeError();
+        return false;
+      });
+      const vault = createCredentialVault({
+        root,
+        encryption: encryptionPort,
+        applyCredential: vi.fn(async () => undefined),
+        clearCredential,
+        serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+        revalidateEnvelopeRemoval,
+      });
+      await vault.writeCredential({ slot: "anthropic", value: "synthetic-secret" });
+
+      await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+        slot: "anthropic",
+        status: "refused",
+        reason: "encryption-unavailable",
+      });
+
+      expect(clearCredential).not.toHaveBeenCalled();
+      expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
+    },
+  );
+
+  it.each(["restored", "diverged"] as const)(
+    "retains storage and reports runtime %s after late key replacement",
+    async (compensation) => {
+      const root = await temporaryRoot();
+      const encryptionPort = keychainEncryption();
+      let applyCount = 0;
+      const applyCredential = vi.fn(async () => {
+        applyCount += 1;
+        if (compensation === "diverged" && applyCount > 1) throw new TypeError();
+      });
+      const clearCredential = vi.fn(async () => "cleared" as const);
+      const revalidateEnvelopeRemoval = vi
+        .fn<() => Promise<boolean>>()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      const vault = createCredentialVault({
+        root,
+        encryption: encryptionPort,
+        applyCredential,
+        clearCredential,
+        serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+        revalidateEnvelopeRemoval,
+      });
+      await vault.writeCredential({ slot: "anthropic", value: "synthetic-secret" });
+
+      await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+        slot: "anthropic",
+        status: "refused",
+        reason:
+          compensation === "restored" ? "encryption-unavailable" : "runtime-state-diverged",
+      });
+
+      expect(clearCredential).toHaveBeenCalledOnce();
+      expect(revalidateEnvelopeRemoval).toHaveBeenCalledTimes(2);
+      expect(applyCredential).toHaveBeenCalledTimes(2);
+      expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
+    },
+  );
 
   posixIt("deletes an unverified envelope only after the athlete requests that slot", async () => {
     const root = await temporaryRoot();
@@ -863,6 +1035,60 @@ describe("desktop credential vault", () => {
       cleanupPending: false,
     });
     await expect(lstat(path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  posixIt("deletes an explicit key-id zero envelope without Keychain access", async () => {
+    const root = await temporaryRoot();
+    await mkdir(root, { mode: CREDENTIAL_DIRECTORY_MODE });
+    const path = join(root, "anthropic.bin");
+    const envelope = sealCredentialEnvelope(
+      randomBytes(KEYCHAIN_KEY_BYTES),
+      "synthetic-legacy-secret",
+    );
+    envelope[CREDENTIAL_ENVELOPE_MAGIC.length] = SAFE_STORAGE_ENVELOPE_KEY_ID;
+    await writeFile(path, envelope, { mode: CREDENTIAL_FILE_MODE });
+    envelope.fill(0);
+    const decryptString = vi.fn();
+    const vault = createCredentialVault({
+      root,
+      encryption: {
+        isEncryptionAvailable: () => false,
+        encryptString: vi.fn(),
+        decryptString,
+      },
+      applyCredential: vi.fn(async () => undefined),
+    });
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+      slot: "anthropic",
+      status: "deleted",
+      cleanupPending: false,
+    });
+
+    expect(decryptString).not.toHaveBeenCalled();
+    await expect(lstat(path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("does not clear stale runtime state when the envelope is missing", async () => {
+    const root = await temporaryRoot();
+    const runtimeState = new Map([["anthropic", "active"]] as const);
+    const clearCredential = vi.fn(async () => "cleared" as const);
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      runtimeState,
+      applyCredential: vi.fn(async () => undefined),
+      clearCredential,
+    });
+
+    await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "not-found",
+    });
+
+    expect(clearCredential).not.toHaveBeenCalled();
+    expect(runtimeState.get("anthropic")).toBe("active");
   });
 
   it("deletes a stored-inactive credential without replacing the active runtime", async () => {
@@ -936,6 +1162,7 @@ describe("desktop credential vault", () => {
 
   it("restores runtime after a retained vault delete failure and surfaces failed reconciliation", async () => {
     const root = await temporaryRoot();
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
     let applyCount = 0;
     let restoreFails = false;
     const applyCredential = vi.fn(async () => {
@@ -944,9 +1171,11 @@ describe("desktop credential vault", () => {
     });
     const vault = createCredentialVault({
       root,
-      encryption: encryption(),
+      encryption: keychainEncryption(),
       applyCredential,
       clearCredential: vi.fn(async () => "cleared" as const),
+      serializeEnvelopeMutation,
+      revalidateEnvelopeRemoval: vi.fn(async () => true),
       renameCredentialFile: vi.fn(async (from: string, to: string) => {
         if (to.endsWith(".deleted")) throw new TypeError();
         await rename(from, to);

--- a/apps/desktop/tests/keychain-key-lifetime.test.ts
+++ b/apps/desktop/tests/keychain-key-lifetime.test.ts
@@ -26,6 +26,7 @@ import {
   type DesktopCredentialSlot,
 } from "../src/main/credential-vault.js";
 import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
+import { classifyCredentialEnvelopeRemoval } from "../src/main/credential-envelope-inspection.js";
 import {
   CREDENTIAL_ENVELOPE_DIRECTORY_ENTRY_LIMIT,
   credentialEnvelopeTargets,
@@ -163,19 +164,25 @@ async function retireKey(
 }
 
 function credentialVault(roots: Fixture, encryption: CredentialEncryptionPort) {
+  const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
   return createCredentialVault({
     root: roots.credentialRoot,
     encryption,
     applyCredential: vi.fn(async () => undefined),
     clearCredential: vi.fn(async () => "not-active" as const),
+    serializeEnvelopeMutation,
+    revalidateEnvelopeRemoval: vi.fn(async () => true),
   });
 }
 
 function telegramVault(roots: Fixture, encryption: CredentialEncryptionPort) {
+  const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
   return createTelegramCredentialVault({
     root: roots.telegramRoot,
     athleteHome: roots.athleteHome,
     encryption,
+    serializeEnvelopeMutation,
+    revalidateEnvelopeRemoval: vi.fn(async () => true),
   });
 }
 
@@ -333,6 +340,30 @@ describe("keychain key retirement", () => {
       expect(windowsInspection.contents).toHaveLength(40);
       windowsInspection.contents.fill(0);
     }
+    envelope.fill(0);
+  });
+
+  posixIt("classifies equivalent envelopes identically in both vaults", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(roots.telegramRoot, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    const envelope = sealCredentialEnvelope(
+      randomBytes(KEYCHAIN_KEY_BYTES),
+      "classifier-parity",
+    );
+    await writeFile(join(roots.credentialRoot, "anthropic.bin"), envelope, { mode: 0o600 });
+    await writeFile(join(roots.telegramRoot, TELEGRAM_PROFILE_FILE_NAME), envelope, {
+      mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+    });
+    const targets = credentialEnvelopeTargets(roots).filter(
+      (target) =>
+        target.fileName === "anthropic.bin" || target.fileName === TELEGRAM_PROFILE_FILE_NAME,
+    );
+
+    await expect(
+      Promise.all(targets.map((target) => classifyCredentialEnvelopeRemoval(target))),
+    ).resolves.toEqual(["keychain-dependent", "keychain-dependent"]);
+
     envelope.fill(0);
   });
 

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -475,6 +475,26 @@ describe("desktop onboarding IPC", () => {
     expect(subject.getRuntimeConfig).not.toHaveBeenCalled();
   });
 
+  it("projects Keychain deletion refusal without exposing private storage details", async () => {
+    const subject = harness();
+    vi.mocked(subject.vault.deleteCredential).mockResolvedValueOnce({
+      slot: "anthropic",
+      status: "refused",
+      reason: "encryption-unavailable",
+    });
+
+    const result = await subject.invoke(DESKTOP_CREDENTIAL_DELETE_CHANNEL, subject.trustedEvent, {
+      credential: "anthropic",
+    });
+
+    expect(result).toEqual({
+      credential: "anthropic",
+      status: "refused",
+      reason: "encryption-unavailable",
+    });
+    expect(Object.keys(result as object)).toEqual(["credential", "status", "reason"]);
+  });
+
   it("projects credential deletion uncertainty as its exact slot envelope", async () => {
     const subject = harness();
     vi.mocked(subject.vault.deleteCredential).mockResolvedValueOnce({

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -1340,6 +1340,32 @@ describe("desktop preload ChatGPT auth", () => {
     });
   });
 
+  it("accepts only the exact Keychain deletion refusal envelope", async () => {
+    const result = {
+      credential: "anthropic",
+      status: "refused",
+      reason: "encryption-unavailable",
+    };
+    mocks.invoke.mockResolvedValueOnce(result);
+
+    const copied = await bridge.deleteCredential({ credential: "anthropic" });
+
+    expect(copied).toEqual(result);
+    expect(copied).not.toBe(result);
+
+    for (const malformed of [
+      { ...result, extra: true },
+      { ...result, credential: "unknown" },
+      { ...result, reason: "keychain-unavailable" },
+      { slot: "anthropic", status: "refused", reason: "encryption-unavailable" },
+    ]) {
+      mocks.invoke.mockResolvedValueOnce(malformed);
+      await expect(bridge.deleteCredential({ credential: "anthropic" })).rejects.toBeInstanceOf(
+        TypeError,
+      );
+    }
+  });
+
   it("accepts only the exact credential deletion uncertainty envelope", async () => {
     const result = {
       slot: "anthropic",

--- a/apps/desktop/tests/telegram-control.test.ts
+++ b/apps/desktop/tests/telegram-control.test.ts
@@ -9,11 +9,20 @@ import {
   type TelegramControlSnapshot,
   type TelegramCredentialInspection,
 } from "@enduragent/coach-contract";
-import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import {
+  createCredentialEnvelopeMutationLock,
+  type CredentialEnvelopeLockProof,
+} from "../src/main/credential-envelope-lock.js";
 import type { CredentialEncryptionPort } from "../src/main/credential-vault.js";
+import {
+  openCredentialEnvelope,
+  sealCredentialEnvelope,
+} from "../src/main/keychain-credential-encryption.js";
+import { KEYCHAIN_KEY_BYTES } from "../src/main/keychain-binding.js";
 import {
   createTelegramControlCoordinator,
   type CreateTelegramControlCoordinatorInput,
@@ -23,7 +32,12 @@ import type {
   TelegramCredentialVault,
   TelegramProfileRecord,
 } from "../src/main/telegram-credential-vault.js";
-import { createTelegramCredentialVault } from "../src/main/telegram-credential-vault.js";
+import {
+  TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
+  TELEGRAM_CREDENTIAL_FILE_MODE,
+  TELEGRAM_PROFILE_FILE_NAME,
+  createTelegramCredentialVault,
+} from "../src/main/telegram-credential-vault.js";
 import { startDesktopTelegram } from "../src/main/telegram-startup.js";
 
 const HOME = "/synthetic/athlete" as AthleteHomeIdentity;
@@ -45,6 +59,15 @@ function realVaultEncryption(): CredentialEncryptionPort {
   };
 }
 
+function keychainVaultEncryption(): CredentialEncryptionPort {
+  const key = Buffer.alloc(KEYCHAIN_KEY_BYTES, 0x2a);
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => sealCredentialEnvelope(key, value),
+    decryptString: (value) => openCredentialEnvelope(key, value),
+  };
+}
+
 async function realVaultFixture() {
   const base = await mkdtemp(join(await realpath(tmpdir()), "telegram-control-secure-storage-"));
   const homePath = join(base, "athlete-home");
@@ -54,6 +77,36 @@ async function realVaultFixture() {
     root: join(base, "telegram-channel-v1"),
     athleteHome: AthleteHomeIdentitySchema.parse(await realpath(homePath)),
   };
+}
+
+async function keychainControlFixture(
+  revalidateEnvelopeRemoval: (proof: CredentialEnvelopeLockProof) => Promise<boolean>,
+) {
+  const value = await realVaultFixture();
+  const vault = createTelegramCredentialVault({
+    root: value.root,
+    athleteHome: value.athleteHome,
+    encryption: keychainVaultEncryption(),
+    createProfileId: () => PROFILE_ID,
+    serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+    revalidateEnvelopeRemoval,
+  });
+  const replaced = await vault.replaceProfile({
+    token: TOKEN,
+    bot: { id: BOT_ID, username: USERNAME },
+    authenticatedAthleteHome: value.athleteHome,
+  });
+  if (replaced.outcome !== "applied") throw new TypeError();
+  const desired = await vault.setDesiredState(true);
+  if (desired.status !== "stored") throw new TypeError();
+  const runtime = harness();
+  const binding = { ...runtime.binding, athleteHome: value.athleteHome };
+  const coordinator = createTelegramControlCoordinator({
+    selectedAthleteHome: () => value.athleteHome,
+    vault,
+    daemon: { current: () => binding },
+  });
+  return { binding, coordinator, runtime, value, vault };
 }
 
 interface Deferred<T> {
@@ -192,6 +245,10 @@ function harness(
       } catch {
         return { outcome: "refused", reason: "runtime-unavailable" } as const;
       }
+    }),
+    preauthorizeProfileRemoval: vi.fn(async () => {
+      trace.push("vault:preauthorize");
+      return { outcome: "authorized" } as const;
     }),
     deleteProfile: vi.fn(async () => {
       trace.push("vault:delete");
@@ -345,6 +402,7 @@ function expectNoTelegramMutation(runtime: ReturnType<typeof harness>): void {
     runtime.vault.setDesiredState,
     runtime.vault.replaceProfile,
     runtime.vault.applyStoredProfile,
+    runtime.vault.preauthorizeProfileRemoval,
     runtime.vault.deleteProfile,
     runtime.binding.configureTelegram,
     runtime.binding.replaceTelegram,
@@ -599,7 +657,7 @@ describe("Telegram main-process control coordinator", () => {
       "telegram-credential-unsafe-backend" as const,
     ],
   ] as const) {
-    const title = `preserves a reopened real-vault ${reason} refusal across profile-dependent actions`;
+    const title = `preserves a reopened real-vault ${reason} refusal across non-delete actions and explicitly removes it`;
     run(title, async () => {
       const value = await realVaultFixture();
       try {
@@ -620,11 +678,14 @@ describe("Telegram main-process control coordinator", () => {
           enabled: true,
         });
         const observeSecureStorageFailure = vi.fn();
+        const reopenedEncryption = realVaultEncryption();
+        const decryptString = vi.fn(reopenedEncryption.decryptString);
         const reopened = createTelegramCredentialVault({
           ...value,
           ...(selectedBackend === undefined ? {} : { platform: "linux" as const }),
           encryption: {
-            ...realVaultEncryption(),
+            ...reopenedEncryption,
+            decryptString,
             isEncryptionAvailable: () => available,
             ...(selectedBackend === undefined
               ? {}
@@ -653,7 +714,6 @@ describe("Telegram main-process control coordinator", () => {
           () => coordinator.replace(REPLACEMENT_TOKEN),
           () => coordinator.enable(),
           () => coordinator.reconcile(),
-          () => coordinator.remove(),
           () => coordinator.removeWebhook(),
           () => coordinator.beginPairing(),
         ]) {
@@ -664,6 +724,20 @@ describe("Telegram main-process control coordinator", () => {
           });
         }
 
+        await expect(coordinator.remove()).resolves.toEqual({
+          outcome: "applied",
+          current: {
+            channel: { desiredState: "disabled", state: "disabled" },
+            bot: { state: "unconfigured" },
+            pairing: { state: "unpaired" },
+            credentialConfigured: false,
+          },
+        });
+        expect(decryptString).not.toHaveBeenCalled();
+        await expect(lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+
         expect(observeSecureStorageFailure).toHaveBeenCalledWith({
           stage: "encryption-availability",
           reason,
@@ -672,7 +746,9 @@ describe("Telegram main-process control coordinator", () => {
         expect(runtime.binding.inspectTelegramCredential).not.toHaveBeenCalled();
         expect(runtime.binding.replaceTelegram).not.toHaveBeenCalled();
         expect(runtime.binding.enableTelegram).not.toHaveBeenCalled();
-        expect(runtime.binding.disableTelegram).not.toHaveBeenCalled();
+        expect(runtime.binding.disableTelegram).toHaveBeenCalledOnce();
+        expect(runtime.binding.resetTelegramAccess).toHaveBeenCalledOnce();
+        expect(runtime.binding.forgetTelegramCredential).toHaveBeenCalledOnce();
         expect(runtime.binding.deleteTelegramWebhook).not.toHaveBeenCalled();
         expect(runtime.binding.beginTelegramPairing).not.toHaveBeenCalled();
 
@@ -683,13 +759,11 @@ describe("Telegram main-process control coordinator", () => {
         const appliedProfile = vi.fn();
         await expect(
           verified.applyStoredProfile(value.athleteHome, appliedProfile),
-        ).resolves.toMatchObject({ outcome: "applied" });
-        expect(appliedProfile).toHaveBeenCalledWith(
-          expect.objectContaining({ token: TOKEN, bot: { id: BOT_ID, username: USERNAME } }),
-        );
+        ).resolves.toEqual({ outcome: "refused", reason: "missing" });
+        expect(appliedProfile).not.toHaveBeenCalled();
         await expect(verified.desiredState()).resolves.toEqual({
           state: "configured",
-          enabled: true,
+          enabled: false,
         });
       } finally {
         await rm(value.base, { recursive: true, force: true });
@@ -1105,6 +1179,7 @@ describe("Telegram main-process control coordinator", () => {
     await expect(runtime.coordinator.remove()).resolves.toMatchObject({ outcome: "applied" });
     expect(runtime.trace).toEqual([
       "vault:apply",
+      "vault:preauthorize",
       "daemon:disable",
       "daemon:reset-access",
       "daemon:forget",
@@ -1112,6 +1187,276 @@ describe("Telegram main-process control coordinator", () => {
       "vault:delete",
     ]);
     expect(runtime.profile()).toBeUndefined();
+  });
+
+  it("refuses removal authorization before changing daemon, desired, or profile state", async () => {
+    const runtime = harness();
+    const before = runtime.profile();
+    runtime.trace.length = 0;
+    vi.mocked(runtime.vault.preauthorizeProfileRemoval).mockResolvedValueOnce({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+    });
+
+    await expect(runtime.coordinator.remove()).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+    });
+
+    expect(runtime.trace).toEqual(["vault:apply"]);
+    expect(runtime.profile()).toEqual(before);
+    expect(runtime.desired()).toBe(true);
+    expect(runtime.binding.disableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.resetTelegramAccess).not.toHaveBeenCalled();
+    expect(runtime.binding.forgetTelegramCredential).not.toHaveBeenCalled();
+    expect(runtime.vault.setDesiredState).not.toHaveBeenCalled();
+    expect(runtime.vault.deleteProfile).not.toHaveBeenCalled();
+  });
+
+  it("maps a missing profile during removal authorization to invalid state", async () => {
+    const runtime = harness();
+    const before = runtime.profile();
+    vi.mocked(runtime.vault.preauthorizeProfileRemoval).mockResolvedValueOnce({
+      outcome: "refused",
+      reason: "not-found",
+    });
+
+    await expect(runtime.coordinator.remove()).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "invalid-state",
+    });
+
+    expect(runtime.profile()).toEqual(before);
+    expect(runtime.desired()).toBe(true);
+    expect(runtime.binding.disableTelegram).not.toHaveBeenCalled();
+    expect(runtime.binding.resetTelegramAccess).not.toHaveBeenCalled();
+    expect(runtime.binding.forgetTelegramCredential).not.toHaveBeenCalled();
+    expect(runtime.vault.setDesiredState).not.toHaveBeenCalled();
+    expect(runtime.vault.deleteProfile).not.toHaveBeenCalled();
+  });
+
+  it("leaves a real keychain profile and daemon unchanged when initial removal validation fails", async () => {
+    const revalidateEnvelopeRemoval = vi.fn(
+      async (_proof: CredentialEnvelopeLockProof) => false,
+    );
+    const fixture = await keychainControlFixture(revalidateEnvelopeRemoval);
+    revalidateEnvelopeRemoval.mockClear();
+
+    try {
+      await expect(fixture.coordinator.remove()).resolves.toMatchObject({
+        outcome: "refused",
+        reason: "encryption-unavailable",
+      });
+
+      expect(revalidateEnvelopeRemoval).toHaveBeenCalledOnce();
+      expect(fixture.runtime.binding.disableTelegram).not.toHaveBeenCalled();
+      expect(fixture.runtime.binding.resetTelegramAccess).not.toHaveBeenCalled();
+      expect(fixture.runtime.binding.forgetTelegramCredential).not.toHaveBeenCalled();
+      expect(
+        (await lstat(join(fixture.value.root, TELEGRAM_PROFILE_FILE_NAME))).isFile(),
+      ).toBe(true);
+      await expect(fixture.vault.desiredState()).resolves.toEqual({
+        state: "configured",
+        enabled: true,
+      });
+    } finally {
+      await fixture.coordinator.close();
+      await rm(fixture.value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("retains a real keychain profile and compensates after final removal validation fails", async () => {
+    const revalidateEnvelopeRemoval = vi
+      .fn(async (_proof: CredentialEnvelopeLockProof) => true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const fixture = await keychainControlFixture(revalidateEnvelopeRemoval);
+    revalidateEnvelopeRemoval.mockClear();
+    revalidateEnvelopeRemoval.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    vi.mocked(fixture.runtime.binding.configureTelegram).mockImplementationOnce(
+      async () => {
+        const configured = snapshot(
+          { desiredState: "disabled", state: "disabled" },
+          { pairing: { state: "unpaired" } },
+        );
+        fixture.runtime.setSnapshot(configured);
+        return { outcome: "applied", current: configured };
+      },
+    );
+    vi.mocked(fixture.runtime.binding.enableTelegram).mockImplementationOnce(async () => {
+      const enabled = snapshot(undefined, { pairing: { state: "unpaired" } });
+      fixture.runtime.setSnapshot(enabled);
+      return enabled;
+    });
+
+    try {
+      await expect(fixture.coordinator.remove()).resolves.toMatchObject({
+        outcome: "uncertain",
+        reason: "control-uncertain",
+        current: {
+          channel: { desiredState: "enabled", state: "online" },
+          pairing: { state: "unpaired" },
+          credentialConfigured: true,
+        },
+      });
+
+      expect(revalidateEnvelopeRemoval).toHaveBeenCalledTimes(2);
+      expect(revalidateEnvelopeRemoval.mock.calls[0]?.[0]).toBe(
+        revalidateEnvelopeRemoval.mock.calls[1]?.[0],
+      );
+      expect(fixture.runtime.binding.disableTelegram).toHaveBeenCalledOnce();
+      expect(fixture.runtime.binding.resetTelegramAccess).toHaveBeenCalledOnce();
+      expect(fixture.runtime.binding.forgetTelegramCredential).toHaveBeenCalledOnce();
+      expect(fixture.runtime.binding.configureTelegram).toHaveBeenCalledWith({ token: TOKEN });
+      expect(fixture.runtime.binding.enableTelegram).toHaveBeenCalledOnce();
+      expect(
+        (await lstat(join(fixture.value.root, TELEGRAM_PROFILE_FILE_NAME))).isFile(),
+      ).toBe(true);
+      await expect(fixture.vault.desiredState()).resolves.toEqual({
+        state: "configured",
+        enabled: true,
+      });
+    } finally {
+      await fixture.coordinator.close();
+      await rm(fixture.value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("removes a real keychain profile only after both validations succeed", async () => {
+    const revalidateEnvelopeRemoval = vi.fn(
+      async (_proof: CredentialEnvelopeLockProof) => true,
+    );
+    const fixture = await keychainControlFixture(revalidateEnvelopeRemoval);
+    revalidateEnvelopeRemoval.mockClear();
+
+    try {
+      await expect(fixture.coordinator.remove()).resolves.toMatchObject({ outcome: "applied" });
+
+      expect(revalidateEnvelopeRemoval).toHaveBeenCalledTimes(2);
+      expect(revalidateEnvelopeRemoval.mock.calls[0]?.[0]).toBe(
+        revalidateEnvelopeRemoval.mock.calls[1]?.[0],
+      );
+      await expect(
+        lstat(join(fixture.value.root, TELEGRAM_PROFILE_FILE_NAME)),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fixture.vault.desiredState()).resolves.toEqual({
+        state: "configured",
+        enabled: false,
+      });
+    } finally {
+      await fixture.coordinator.close();
+      await rm(fixture.value.base, { recursive: true, force: true });
+    }
+  });
+
+  it("restores daemon credential and desired state after late removal refusal", async () => {
+    const runtime = harness();
+    runtime.trace.length = 0;
+    vi.mocked(runtime.vault.deleteProfile).mockImplementationOnce(async () => {
+      runtime.trace.push("vault:delete-refused");
+      return { outcome: "refused", reason: "encryption-unavailable" };
+    });
+    vi.mocked(runtime.binding.configureTelegram).mockImplementationOnce(async ({ token }) => {
+      runtime.trace.push(`daemon:configure:${token}`);
+      const configured = snapshot(
+        { desiredState: "disabled", state: "disabled" },
+        { pairing: { state: "unpaired" } },
+      );
+      runtime.setSnapshot(configured);
+      return { outcome: "applied", current: configured };
+    });
+    vi.mocked(runtime.binding.enableTelegram).mockImplementationOnce(async () => {
+      runtime.trace.push("daemon:enable");
+      const enabled = snapshot(undefined, { pairing: { state: "unpaired" } });
+      runtime.setSnapshot(enabled);
+      return enabled;
+    });
+
+    await expect(runtime.coordinator.remove()).resolves.toMatchObject({
+      outcome: "uncertain",
+      reason: "control-uncertain",
+      current: {
+        channel: { desiredState: "enabled", state: "online" },
+        pairing: { state: "unpaired" },
+        credentialConfigured: true,
+      },
+    });
+
+    expect(runtime.profile()).toMatchObject({ token: TOKEN });
+    expect(runtime.desired()).toBe(true);
+    expect(runtime.binding.configureTelegram).toHaveBeenCalledWith({ token: TOKEN });
+    expect(runtime.binding.enableTelegram).toHaveBeenCalledOnce();
+    expect(runtime.trace).toEqual([
+      "vault:apply",
+      "vault:preauthorize",
+      "daemon:disable",
+      "daemon:reset-access",
+      "daemon:forget",
+      "vault:desired:false",
+      "vault:delete-refused",
+      `daemon:configure:${TOKEN}`,
+      "vault:desired:true",
+      "daemon:enable",
+    ]);
+  });
+
+  it("reports uncertainty when late removal compensation cannot restore the credential", async () => {
+    const runtime = harness();
+    const before = runtime.profile();
+    vi.mocked(runtime.vault.deleteProfile).mockResolvedValueOnce({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+    });
+    vi.mocked(runtime.binding.configureTelegram).mockRejectedValueOnce(
+      new Error("credential restore failed"),
+    );
+
+    await expect(runtime.coordinator.remove()).resolves.toMatchObject({
+      outcome: "uncertain",
+      reason: "control-uncertain",
+    });
+
+    expect(runtime.profile()).toEqual(before);
+    expect(runtime.binding.configureTelegram).toHaveBeenCalledWith({ token: TOKEN });
+    expect(runtime.binding.resetTelegramAccess).toHaveBeenCalledOnce();
+  });
+
+  it("explicitly removes an unreadable unverified envelope without decrypting it", async () => {
+    const value = await realVaultFixture();
+    const decryptString = vi.fn(() => {
+      throw new TypeError();
+    });
+    const vault = createTelegramCredentialVault({
+      root: value.root,
+      athleteHome: value.athleteHome,
+      encryption: {
+        isEncryptionAvailable: () => false,
+        encryptString: vi.fn(),
+        decryptString,
+      },
+    });
+    await vault.setDesiredState(true);
+    await mkdir(value.root, { recursive: true, mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    const profilePath = join(value.root, TELEGRAM_PROFILE_FILE_NAME);
+    await writeFile(profilePath, Buffer.from("unverified-envelope"), {
+      mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+    });
+    const runtime = harness();
+    const binding = { ...runtime.binding, athleteHome: value.athleteHome };
+    const coordinator = createTelegramControlCoordinator({
+      selectedAthleteHome: () => value.athleteHome,
+      vault,
+      daemon: { current: () => binding },
+    });
+
+    try {
+      await expect(coordinator.remove()).resolves.toMatchObject({ outcome: "applied" });
+      expect(decryptString).not.toHaveBeenCalled();
+      await expect(lstat(profilePath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await coordinator.close();
+      await rm(value.base, { recursive: true, force: true });
+    }
   });
 
   it("stops Telegram for a global reset without decrypting or deleting the profile itself", async () => {

--- a/apps/desktop/tests/telegram-credential-vault.test.ts
+++ b/apps/desktop/tests/telegram-credential-vault.test.ts
@@ -1208,6 +1208,77 @@ describe("Telegram credential vault", () => {
     });
   });
 
+  it.each(["missing-proof", "missing-hook"] as const)(
+    "retains a keychain profile with %s",
+    async (missing) => {
+      const value = await fixture();
+      const encryptionPort = keychainEncryption();
+      const seed = createTelegramCredentialVault({
+        ...value,
+        encryption: encryptionPort,
+        createProfileId: () => PROFILE_A,
+      });
+      await seed.replaceProfile({
+        token: "synthetic-token-a",
+        bot: BOT_A,
+        authenticatedAthleteHome: value.athleteHome,
+      });
+      const vault = createTelegramCredentialVault({
+        ...value,
+        encryption: encryptionPort,
+        serializeEnvelopeMutation:
+          missing === "missing-proof"
+            ? async (operation) => await operation(undefined as never)
+            : createCredentialEnvelopeMutationLock(),
+        revalidateEnvelopeRemoval:
+          missing === "missing-hook" ? undefined : vi.fn(async () => true),
+      });
+
+      await expect(vault.deleteProfile()).resolves.toEqual({
+        outcome: "refused",
+        reason: "encryption-unavailable",
+      });
+      expect((await lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).isFile()).toBe(true);
+    },
+  );
+
+  it("retains a keychain profile without decrypting when encryption is unavailable", async () => {
+    const value = await fixture();
+    const encryptionPort = keychainEncryption();
+    const seed = createTelegramCredentialVault({
+      ...value,
+      encryption: encryptionPort,
+      createProfileId: () => PROFILE_A,
+    });
+    await seed.replaceProfile({
+      token: "synthetic-token-a",
+      bot: BOT_A,
+      authenticatedAthleteHome: value.athleteHome,
+    });
+    const decryptString = vi.fn(() => {
+      throw new TypeError();
+    });
+    const revalidateEnvelopeRemoval = vi.fn(async () => true);
+    const vault = createTelegramCredentialVault({
+      ...value,
+      encryption: {
+        isEncryptionAvailable: () => false,
+        encryptString: vi.fn(),
+        decryptString,
+      },
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      revalidateEnvelopeRemoval,
+    });
+
+    await expect(vault.deleteProfile()).resolves.toEqual({
+      outcome: "refused",
+      reason: "encryption-unavailable",
+    });
+    expect(decryptString).not.toHaveBeenCalled();
+    expect(revalidateEnvelopeRemoval).not.toHaveBeenCalled();
+    expect((await lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).isFile()).toBe(true);
+  });
+
   it("deletes an unverified profile without requiring a Keychain key", async () => {
     const value = await fixture();
     await seedProfile(value);


### PR DESCRIPTION
## Summary

- classify each credential envelope before destructive work
- require full decryption and exact-key validation for key-ID 1
- preauthorize Telegram removal and compensate late refusal truthfully
- propagate encryption-unavailable to the inline recovery UI

## Verification

- 12 focused test files: 575 tests passed
- Telegram focused tests: 186 tests passed
- desktop and renderer type checks passed
- changeset validation passed
- full pnpm check passed
- fresh read-only safety review: 11/11 criteria passed, no P0-P3 findings

## Limits

- none