### PR TITLE
fix: roll back failed keychain creation

### DIFF
--- a/.changeset/clean-keychain-creation-rollback.md
+++ b/.changeset/clean-keychain-creation-rollback.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Failed macOS secure-storage setup no longer leaves an unusable encryption key behind.

--- a/apps/desktop/native/keychain-binding/creation-rollback-harness.cc
+++ b/apps/desktop/native/keychain-binding/creation-rollback-harness.cc
@@ -1,0 +1,495 @@
+#include "creation-rollback.h"
+
+#include <array>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+using enduragent::keychain::CreationRollbackAddResult;
+using enduragent::keychain::CreationRollbackBufferResult;
+using enduragent::keychain::CreationRollbackContentResult;
+using enduragent::keychain::CreationRollbackDebt;
+using enduragent::keychain::CreationRollbackDependencies;
+using enduragent::keychain::CreationRollbackResult;
+using enduragent::keychain::ReleaseCreationRollbackDebt;
+using enduragent::keychain::RetryCreationRollback;
+using enduragent::keychain::RunCreationRollbackTransaction;
+
+constexpr size_t kLength = 32;
+constexpr char kService[] = "icu.enduragent.desktop.dev";
+constexpr char kOtherService[] = "icu.enduragent.desktop";
+constexpr char kPrepareFailure[] = "prepare-failure";
+constexpr char kAddFailure[] = "add-failure";
+constexpr char kInspectFailure[] = "inspect-failure";
+constexpr char kCopyFailure[] = "copy-failure";
+constexpr char kFreeFailure[] = "free-failure";
+constexpr char kBufferFailure[] = "buffer-failure";
+constexpr char kPublishFailure[] = "publish-failure";
+constexpr char kDeleteFailure[] = "delete-failure";
+
+int exactToken = 0;
+int wrongToken = 0;
+
+struct Fake {
+  const char *prepareCode = nullptr;
+  const char *addCode = nullptr;
+  void *addRef = &exactToken;
+  bool addExact = true;
+  const char *inspectCode = nullptr;
+  const char *copyCode = nullptr;
+  bool copyNull = false;
+  size_t copyLength = kLength;
+  const char *freeCode = nullptr;
+  const char *bufferCode = nullptr;
+  bool bufferNull = false;
+  bool bufferBytesOnFailure = false;
+  bool bufferValueNull = false;
+  bool bufferBytesNull = false;
+  size_t bufferLength = kLength;
+  const char *publishCode = nullptr;
+  const char *deleteCode = nullptr;
+  std::array<unsigned char, kLength> persisted{};
+  std::array<unsigned char, kLength> buffer{};
+  int prepareCalls = 0;
+  int addCalls = 0;
+  int inspectCalls = 0;
+  int copyCalls = 0;
+  int freeCalls = 0;
+  int bufferCalls = 0;
+  int publishCalls = 0;
+  int wipeCalls = 0;
+  int deleteCalls = 0;
+  int releaseCalls = 0;
+  int eraseCalls = 0;
+  void *releasedRef = nullptr;
+};
+
+void Require(bool condition) {
+  if (!condition)
+    std::abort();
+}
+
+const char *Prepare(void *context) {
+  auto &fake = *static_cast<Fake *>(context);
+  fake.prepareCalls += 1;
+  return fake.prepareCode;
+}
+
+CreationRollbackAddResult Add(void *context) {
+  auto &fake = *static_cast<Fake *>(context);
+  fake.addCalls += 1;
+  return {fake.addCode, fake.addRef, fake.addExact};
+}
+
+const char *Inspect(void *context, void *exactRef) {
+  auto &fake = *static_cast<Fake *>(context);
+  Require(exactRef == &exactToken);
+  fake.inspectCalls += 1;
+  return fake.inspectCode;
+}
+
+CreationRollbackContentResult CopyContent(void *context, void *exactRef) {
+  auto &fake = *static_cast<Fake *>(context);
+  Require(exactRef == &exactToken);
+  fake.copyCalls += 1;
+  return {fake.copyCode, fake.copyNull ? nullptr : fake.persisted.data(),
+          fake.copyLength};
+}
+
+const char *FreeContent(void *context, void *bytes, size_t length) {
+  auto &fake = *static_cast<Fake *>(context);
+  Require(bytes == fake.persisted.data());
+  Require(length == fake.copyLength);
+  fake.freeCalls += 1;
+  std::memset(bytes, 0, length);
+  return fake.freeCode;
+}
+
+CreationRollbackBufferResult CreateBuffer(void *context,
+                                          const unsigned char *material,
+                                          size_t length) {
+  auto &fake = *static_cast<Fake *>(context);
+  fake.bufferCalls += 1;
+  Require(length == kLength);
+  std::memcpy(fake.buffer.data(), material, length);
+  if (fake.bufferCode != nullptr && !fake.bufferBytesOnFailure)
+    return {fake.bufferCode, nullptr, nullptr, 0};
+  if (fake.bufferNull)
+    return {fake.bufferCode, nullptr, nullptr, 0};
+  return {fake.bufferCode, fake.bufferValueNull ? nullptr : &fake,
+          fake.bufferBytesNull ? nullptr : fake.buffer.data(),
+          fake.bufferLength};
+}
+
+const char *PublishBuffer(void *context, void *value) {
+  auto &fake = *static_cast<Fake *>(context);
+  Require(value == &fake);
+  fake.publishCalls += 1;
+  return fake.publishCode;
+}
+
+void WipeBuffer(void *context, unsigned char *bytes, size_t length) {
+  auto &fake = *static_cast<Fake *>(context);
+  Require(bytes == fake.buffer.data());
+  fake.wipeCalls += 1;
+  std::memset(bytes, 0, length);
+}
+
+const char *DeleteExact(void *context, void *exactRef) {
+  auto &fake = *static_cast<Fake *>(context);
+  Require(exactRef == &exactToken);
+  fake.deleteCalls += 1;
+  return fake.deleteCode;
+}
+
+void ReleaseRef(void *context, void *ref) {
+  auto &fake = *static_cast<Fake *>(context);
+  fake.releaseCalls += 1;
+  fake.releasedRef = ref;
+}
+
+void EraseMaterial(void *context, unsigned char *material, size_t length) {
+  auto &fake = *static_cast<Fake *>(context);
+  fake.eraseCalls += 1;
+  std::memset(material, 0, length);
+}
+
+CreationRollbackDependencies Dependencies(Fake &fake) {
+  return {&fake,       Prepare,      Add,          Inspect,
+          CopyContent, FreeContent,  CreateBuffer, PublishBuffer,
+          WipeBuffer, DeleteExact,   ReleaseRef,   EraseMaterial};
+}
+
+std::array<unsigned char, kLength> Material() {
+  std::array<unsigned char, kLength> material{};
+  for (size_t index = 0; index < material.size(); index += 1)
+    material[index] = static_cast<unsigned char>(index + 1);
+  return material;
+}
+
+void PreparePersisted(Fake &fake,
+                      const std::array<unsigned char, kLength> &material) {
+  fake.persisted = material;
+}
+
+void RequireErased(const std::array<unsigned char, kLength> &material) {
+  for (const unsigned char byte : material)
+    Require(byte == 0);
+}
+
+CreationRollbackResult Run(Fake &fake, CreationRollbackDebt &debt,
+                           std::array<unsigned char, kLength> &material) {
+  PreparePersisted(fake, material);
+  return RunCreationRollbackTransaction(kService, material.data(),
+                                        material.size(), debt,
+                                        Dependencies(fake));
+}
+
+void RequireFailure(const CreationRollbackResult &result, const char *code,
+                    bool pending) {
+  Require(!result.ok);
+  Require(std::strcmp(result.code, code) == 0);
+  Require(result.creationRollbackPending == pending);
+}
+
+void TestPreAddFailures() {
+  {
+    Fake fake;
+    CreationRollbackDebt debt{true, &exactToken, kService};
+    auto material = Material();
+    const CreationRollbackResult result = Run(fake, debt, material);
+    RequireFailure(result, "uninspectable-item", true);
+    Require(fake.prepareCalls == 0);
+    Require(fake.addCalls == 0);
+    Require(fake.deleteCalls == 0);
+    Require(fake.releaseCalls == 0);
+    Require(fake.eraseCalls == 1);
+    RequireErased(material);
+  }
+  {
+    Fake fake;
+    fake.prepareCode = kPrepareFailure;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    const CreationRollbackResult result = Run(fake, debt, material);
+    RequireFailure(result, kPrepareFailure, false);
+    Require(fake.addCalls == 0);
+    Require(fake.deleteCalls == 0);
+    Require(fake.releaseCalls == 0);
+    Require(fake.eraseCalls == 1);
+    RequireErased(material);
+  }
+  {
+    Fake fake;
+    fake.addCode = kAddFailure;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    const CreationRollbackResult result = Run(fake, debt, material);
+    RequireFailure(result, kAddFailure, false);
+    Require(fake.addCalls == 1);
+    Require(fake.deleteCalls == 0);
+    Require(fake.releaseCalls == 1);
+    Require(fake.releasedRef == &exactToken);
+    Require(fake.eraseCalls == 1);
+    RequireErased(material);
+  }
+}
+
+void TestUnknownReferences() {
+  {
+    Fake fake;
+    fake.addRef = nullptr;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    const CreationRollbackResult result = Run(fake, debt, material);
+    RequireFailure(result, "unreadable-item", true);
+    Require(debt.pending);
+    Require(debt.exactRef == nullptr);
+    Require(debt.service == kService);
+    Require(fake.deleteCalls == 0);
+    Require(fake.releaseCalls == 0);
+    const CreationRollbackResult retry =
+        RetryCreationRollback(kService, debt, Dependencies(fake));
+    RequireFailure(retry, "uninspectable-item", true);
+    Require(debt.pending);
+    Require(fake.deleteCalls == 0);
+    ReleaseCreationRollbackDebt(debt, Dependencies(fake));
+    Require(fake.releaseCalls == 0);
+  }
+  {
+    Fake fake;
+    fake.addRef = &wrongToken;
+    fake.addExact = false;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    const CreationRollbackResult result = Run(fake, debt, material);
+    RequireFailure(result, "unreadable-item", true);
+    Require(debt.pending);
+    Require(debt.exactRef == nullptr);
+    Require(fake.deleteCalls == 0);
+    Require(fake.releaseCalls == 1);
+    Require(fake.releasedRef == &wrongToken);
+  }
+}
+
+void RequireRolledBack(Fake &fake, CreationRollbackDebt &debt,
+                       std::array<unsigned char, kLength> &material,
+                       const char *code) {
+  const CreationRollbackResult result = Run(fake, debt, material);
+  RequireFailure(result, code, false);
+  Require(!debt.pending);
+  Require(fake.deleteCalls == 1);
+  Require(fake.releaseCalls == 1);
+  Require(fake.releasedRef == &exactToken);
+  Require(fake.eraseCalls == 1);
+  RequireErased(material);
+}
+
+void TestEveryPostAddFailure() {
+  {
+    Fake fake;
+    fake.inspectCode = kInspectFailure;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, kInspectFailure);
+    Require(fake.copyCalls == 0);
+  }
+  {
+    Fake fake;
+    fake.copyCode = kCopyFailure;
+    fake.freeCode = kFreeFailure;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, kCopyFailure);
+    Require(fake.freeCalls == 1);
+  }
+  {
+    Fake fake;
+    fake.copyNull = true;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, "unreadable-item");
+    Require(fake.freeCalls == 0);
+  }
+  {
+    Fake fake;
+    fake.copyLength = kLength - 1;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, "unreadable-item");
+    Require(fake.freeCalls == 1);
+  }
+  {
+    Fake fake;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    PreparePersisted(fake, material);
+    fake.persisted[0] ^= 1;
+    const CreationRollbackResult result = RunCreationRollbackTransaction(
+        kService, material.data(), material.size(), debt, Dependencies(fake));
+    RequireFailure(result, "unreadable-item", false);
+    Require(fake.freeCalls == 1);
+    Require(fake.deleteCalls == 1);
+    Require(fake.releaseCalls == 1);
+    RequireErased(material);
+  }
+  {
+    Fake fake;
+    fake.freeCode = kFreeFailure;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, kFreeFailure);
+    Require(fake.freeCalls == 1);
+  }
+  {
+    Fake fake;
+    fake.bufferCode = kBufferFailure;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, kBufferFailure);
+    Require(fake.wipeCalls == 0);
+  }
+  {
+    Fake fake;
+    fake.bufferCode = kBufferFailure;
+    fake.bufferBytesOnFailure = true;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, kBufferFailure);
+    Require(fake.wipeCalls == 1);
+    RequireErased(fake.buffer);
+  }
+  {
+    Fake fake;
+    fake.bufferNull = true;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, "unknown");
+    Require(fake.wipeCalls == 0);
+  }
+  {
+    Fake fake;
+    fake.bufferValueNull = true;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, "unknown");
+    Require(fake.wipeCalls == 1);
+    RequireErased(fake.buffer);
+  }
+  {
+    Fake fake;
+    fake.bufferBytesNull = true;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, "unknown");
+    Require(fake.wipeCalls == 0);
+  }
+  {
+    Fake fake;
+    fake.bufferLength = kLength - 1;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, "unknown");
+    Require(fake.wipeCalls == 1);
+    for (size_t index = 0; index < fake.bufferLength; index += 1)
+      Require(fake.buffer[index] == 0);
+    Require(fake.buffer.back() != 0);
+  }
+  {
+    Fake fake;
+    fake.publishCode = kPublishFailure;
+    CreationRollbackDebt debt;
+    auto material = Material();
+    RequireRolledBack(fake, debt, material, kPublishFailure);
+    Require(fake.publishCalls == 1);
+    Require(fake.wipeCalls == 1);
+    RequireErased(fake.buffer);
+  }
+}
+
+void TestRollbackDebtRetryAndCleanup() {
+  Fake fake;
+  fake.inspectCode = kInspectFailure;
+  fake.deleteCode = kDeleteFailure;
+  CreationRollbackDebt debt;
+  auto material = Material();
+  const CreationRollbackResult result = Run(fake, debt, material);
+  RequireFailure(result, kInspectFailure, true);
+  Require(debt.pending);
+  Require(debt.exactRef == &exactToken);
+  Require(fake.deleteCalls == 1);
+  Require(fake.releaseCalls == 0);
+
+  const CreationRollbackResult mismatch =
+      RetryCreationRollback(kOtherService, debt, Dependencies(fake));
+  RequireFailure(mismatch, "uninspectable-item", true);
+  Require(fake.deleteCalls == 1);
+
+  const CreationRollbackResult failedRetry =
+      RetryCreationRollback(kService, debt, Dependencies(fake));
+  RequireFailure(failedRetry, kDeleteFailure, true);
+  Require(fake.deleteCalls == 2);
+  Require(fake.releaseCalls == 0);
+
+  fake.deleteCode = nullptr;
+  const CreationRollbackResult successfulRetry =
+      RetryCreationRollback(kService, debt, Dependencies(fake));
+  Require(successfulRetry.ok);
+  Require(!debt.pending);
+  Require(fake.deleteCalls == 3);
+  Require(fake.releaseCalls == 1);
+
+  const CreationRollbackResult noDebt =
+      RetryCreationRollback(kService, debt, Dependencies(fake));
+  Require(noDebt.ok);
+  Require(fake.deleteCalls == 3);
+
+  Fake cleanupFake;
+  cleanupFake.inspectCode = kInspectFailure;
+  cleanupFake.deleteCode = kDeleteFailure;
+  CreationRollbackDebt cleanupDebt;
+  auto cleanupMaterial = Material();
+  Run(cleanupFake, cleanupDebt, cleanupMaterial);
+  Require(cleanupFake.releaseCalls == 0);
+  const int deletesBeforeCleanup = cleanupFake.deleteCalls;
+  ReleaseCreationRollbackDebt(cleanupDebt, Dependencies(cleanupFake));
+  Require(cleanupFake.releaseCalls == 1);
+  Require(cleanupFake.deleteCalls == deletesBeforeCleanup);
+}
+
+void TestSuccess() {
+  Fake fake;
+  CreationRollbackDebt debt;
+  auto material = Material();
+  const auto expected = material;
+  const CreationRollbackResult result = Run(fake, debt, material);
+  Require(result.ok);
+  Require(result.code == nullptr);
+  Require(!result.creationRollbackPending);
+  Require(fake.prepareCalls == 1);
+  Require(fake.addCalls == 1);
+  Require(fake.inspectCalls == 1);
+  Require(fake.copyCalls == 1);
+  Require(fake.freeCalls == 1);
+  Require(fake.bufferCalls == 1);
+  Require(fake.publishCalls == 1);
+  Require(fake.wipeCalls == 0);
+  Require(fake.deleteCalls == 0);
+  Require(fake.releaseCalls == 1);
+  Require(fake.eraseCalls == 1);
+  RequireErased(fake.persisted);
+  Require(fake.buffer == expected);
+  RequireErased(material);
+}
+
+}
+
+int main() {
+  TestPreAddFailures();
+  TestUnknownReferences();
+  TestEveryPostAddFailure();
+  TestRollbackDebtRetryAndCleanup();
+  TestSuccess();
+  return 0;
+}

--- a/apps/desktop/native/keychain-binding/creation-rollback.cc
+++ b/apps/desktop/native/keychain-binding/creation-rollback.cc
@@ -1,0 +1,168 @@
+#include "creation-rollback.h"
+
+namespace enduragent::keychain {
+
+namespace {
+
+constexpr char kUnknown[] = "unknown";
+constexpr char kUnreadableItem[] = "unreadable-item";
+constexpr char kUninspectableItem[] = "uninspectable-item";
+
+void ClearDebt(CreationRollbackDebt &debt) {
+  debt.pending = false;
+  debt.exactRef = nullptr;
+  debt.service.clear();
+}
+
+bool BytesMatch(const void *persisted, size_t persistedLength,
+                const unsigned char *material, size_t materialLength) {
+  if (persisted == nullptr || persistedLength != materialLength)
+    return false;
+  const auto *persistedBytes = static_cast<const unsigned char *>(persisted);
+  unsigned char difference = 0;
+  for (size_t index = 0; index < materialLength; index += 1)
+    difference |= persistedBytes[index] ^ material[index];
+  return difference == 0;
+}
+
+CreationRollbackResult PreAddFailure(
+    const char *code, unsigned char *material, size_t length,
+    const CreationRollbackDependencies &dependencies) {
+  dependencies.eraseMaterial(dependencies.context, material, length);
+  return {false, code == nullptr ? kUnknown : code, false};
+}
+
+CreationRollbackResult UnknownReferenceFailure(
+    const std::string &service, void *ref, unsigned char *material,
+    size_t length, CreationRollbackDebt &debt,
+    const CreationRollbackDependencies &dependencies) {
+  if (ref != nullptr)
+    dependencies.releaseRef(dependencies.context, ref);
+  debt.pending = true;
+  debt.exactRef = nullptr;
+  debt.service = service;
+  dependencies.eraseMaterial(dependencies.context, material, length);
+  return {false, kUnreadableItem, true};
+}
+
+CreationRollbackResult PostAddFailure(
+    const std::string &service, const char *primaryCode, void *exactRef,
+    unsigned char *material, size_t materialLength,
+    CreationRollbackDebt &debt,
+    const CreationRollbackDependencies &dependencies,
+    const CreationRollbackBufferResult *buffer) {
+  if (buffer != nullptr && buffer->bytes != nullptr)
+    dependencies.wipeBuffer(dependencies.context, buffer->bytes,
+                            buffer->length);
+  const char *rollbackCode =
+      dependencies.deleteExact(dependencies.context, exactRef);
+  if (rollbackCode == nullptr) {
+    dependencies.releaseRef(dependencies.context, exactRef);
+    ClearDebt(debt);
+  } else {
+    debt.pending = true;
+    debt.exactRef = exactRef;
+    debt.service = service;
+  }
+  dependencies.eraseMaterial(dependencies.context, material, materialLength);
+  return {false, primaryCode == nullptr ? kUnknown : primaryCode,
+          rollbackCode != nullptr};
+}
+
+}
+
+CreationRollbackResult RunCreationRollbackTransaction(
+    const std::string &service, unsigned char *material, size_t length,
+    CreationRollbackDebt &debt,
+    const CreationRollbackDependencies &dependencies) {
+  if (debt.pending) {
+    dependencies.eraseMaterial(dependencies.context, material, length);
+    return {false, kUninspectableItem, true};
+  }
+
+  const char *primaryCode =
+      dependencies.prepareResponse(dependencies.context);
+  if (primaryCode != nullptr)
+    return PreAddFailure(primaryCode, material, length, dependencies);
+
+  const CreationRollbackAddResult added =
+      dependencies.add(dependencies.context);
+  if (added.code != nullptr) {
+    if (added.ref != nullptr)
+      dependencies.releaseRef(dependencies.context, added.ref);
+    return PreAddFailure(added.code, material, length, dependencies);
+  }
+  if (added.ref == nullptr || !added.exactRef)
+    return UnknownReferenceFailure(service, added.ref, material, length, debt,
+                                   dependencies);
+
+  primaryCode = dependencies.inspect(dependencies.context, added.ref);
+  if (primaryCode != nullptr)
+    return PostAddFailure(service, primaryCode, added.ref, material, length,
+                          debt, dependencies, nullptr);
+
+  const CreationRollbackContentResult content =
+      dependencies.copyContent(dependencies.context, added.ref);
+  primaryCode = content.code;
+  if (primaryCode == nullptr &&
+      !BytesMatch(content.bytes, content.length, material, length))
+    primaryCode = kUnreadableItem;
+  if (content.bytes != nullptr) {
+    const char *freeCode =
+        dependencies.freeContent(dependencies.context, content.bytes,
+                                 content.length);
+    if (primaryCode == nullptr && freeCode != nullptr)
+      primaryCode = freeCode;
+  }
+  if (primaryCode != nullptr)
+    return PostAddFailure(service, primaryCode, added.ref, material, length,
+                          debt, dependencies, nullptr);
+
+  const CreationRollbackBufferResult buffer =
+      dependencies.createBuffer(dependencies.context, material, length);
+  primaryCode = buffer.code;
+  if (primaryCode == nullptr &&
+      (buffer.value == nullptr || buffer.bytes == nullptr ||
+       buffer.length != length))
+    primaryCode = kUnknown;
+  if (primaryCode != nullptr)
+    return PostAddFailure(service, primaryCode, added.ref, material, length,
+                          debt, dependencies, &buffer);
+
+  primaryCode =
+      dependencies.publishBuffer(dependencies.context, buffer.value);
+  if (primaryCode != nullptr)
+    return PostAddFailure(service, primaryCode, added.ref, material, length,
+                          debt, dependencies, &buffer);
+
+  dependencies.releaseRef(dependencies.context, added.ref);
+  dependencies.eraseMaterial(dependencies.context, material, length);
+  ClearDebt(debt);
+  return {true, nullptr, false};
+}
+
+CreationRollbackResult RetryCreationRollback(
+    const std::string &service, CreationRollbackDebt &debt,
+    const CreationRollbackDependencies &dependencies) {
+  if (!debt.pending)
+    return {true, nullptr, false};
+  if (debt.exactRef == nullptr || debt.service != service)
+    return {false, kUninspectableItem, true};
+  const char *code =
+      dependencies.deleteExact(dependencies.context, debt.exactRef);
+  if (code != nullptr)
+    return {false, code, true};
+  dependencies.releaseRef(dependencies.context, debt.exactRef);
+  ClearDebt(debt);
+  return {true, nullptr, false};
+}
+
+void ReleaseCreationRollbackDebt(
+    CreationRollbackDebt &debt,
+    const CreationRollbackDependencies &dependencies) {
+  if (debt.exactRef != nullptr)
+    dependencies.releaseRef(dependencies.context, debt.exactRef);
+  ClearDebt(debt);
+}
+
+}

--- a/apps/desktop/native/keychain-binding/creation-rollback.h
+++ b/apps/desktop/native/keychain-binding/creation-rollback.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace enduragent::keychain {
+
+struct CreationRollbackDebt {
+  bool pending = false;
+  void *exactRef = nullptr;
+  std::string service;
+};
+
+struct CreationRollbackResult {
+  bool ok;
+  const char *code;
+  bool creationRollbackPending;
+};
+
+struct CreationRollbackAddResult {
+  const char *code;
+  void *ref;
+  bool exactRef;
+};
+
+struct CreationRollbackContentResult {
+  const char *code;
+  void *bytes;
+  size_t length;
+};
+
+struct CreationRollbackBufferResult {
+  const char *code;
+  void *value;
+  unsigned char *bytes;
+  size_t length;
+};
+
+struct CreationRollbackDependencies {
+  void *context;
+  const char *(*prepareResponse)(void *context);
+  CreationRollbackAddResult (*add)(void *context);
+  const char *(*inspect)(void *context, void *exactRef);
+  CreationRollbackContentResult (*copyContent)(void *context, void *exactRef);
+  const char *(*freeContent)(void *context, void *bytes, size_t length);
+  CreationRollbackBufferResult (*createBuffer)(void *context,
+                                               const unsigned char *material,
+                                               size_t length);
+  const char *(*publishBuffer)(void *context, void *value);
+  void (*wipeBuffer)(void *context, unsigned char *bytes, size_t length);
+  const char *(*deleteExact)(void *context, void *exactRef);
+  void (*releaseRef)(void *context, void *ref);
+  void (*eraseMaterial)(void *context, unsigned char *material, size_t length);
+};
+
+CreationRollbackResult RunCreationRollbackTransaction(
+    const std::string &service, unsigned char *material, size_t length,
+    CreationRollbackDebt &debt,
+    const CreationRollbackDependencies &dependencies);
+
+CreationRollbackResult RetryCreationRollback(
+    const std::string &service, CreationRollbackDebt &debt,
+    const CreationRollbackDependencies &dependencies);
+
+void ReleaseCreationRollbackDebt(
+    CreationRollbackDebt &debt,
+    const CreationRollbackDependencies &dependencies);
+
+}

--- a/apps/desktop/native/keychain-binding/keychain-binding.mm
+++ b/apps/desktop/native/keychain-binding/keychain-binding.mm
@@ -6,8 +6,10 @@
 #include <string.h>
 
 #include <array>
+#include <new>
 #include <string>
 
+#include "creation-rollback.h"
 #include "partition-description.h"
 
 namespace {
@@ -18,8 +20,27 @@ constexpr char kDevelopmentService[] = "icu.enduragent.desktop.dev";
 constexpr char kAccount[] = "credential-encryption-key-v1";
 constexpr size_t kKeyBytes = 32;
 
+using enduragent::keychain::CreationRollbackAddResult;
+using enduragent::keychain::CreationRollbackBufferResult;
+using enduragent::keychain::CreationRollbackContentResult;
+using enduragent::keychain::CreationRollbackDebt;
+using enduragent::keychain::CreationRollbackDependencies;
+using enduragent::keychain::CreationRollbackResult;
+using enduragent::keychain::ReleaseCreationRollbackDebt;
+using enduragent::keychain::RetryCreationRollback;
+using enduragent::keychain::RunCreationRollbackTransaction;
+
+struct BindingState {
+  CreationRollbackDebt creationDebt;
+};
+
+void EraseBytes(void *bytes, size_t length) {
+  if (bytes != nullptr && length > 0)
+    memset_s(bytes, length, 0, length);
+}
+
 void EraseKey(std::array<unsigned char, kKeyBytes> &material) {
-  memset_s(material.data(), material.size(), 0, material.size());
+  EraseBytes(material.data(), material.size());
 }
 
 CFStringRef String(const char *value) {
@@ -27,32 +48,54 @@ CFStringRef String(const char *value) {
                                    kCFStringEncodingUTF8);
 }
 
-napi_value Text(napi_env env, const char *value) {
-  napi_value result;
-  napi_create_string_utf8(env, value, NAPI_AUTO_LENGTH, &result);
-  return result;
+bool Text(napi_env env, const char *value, napi_value &result) {
+  return napi_create_string_utf8(env, value, NAPI_AUTO_LENGTH, &result) ==
+         napi_ok;
 }
 
-void Set(napi_env env, napi_value object, const char *key, napi_value value) {
-  napi_set_named_property(env, object, key, value);
+bool Set(napi_env env, napi_value object, const char *key, napi_value value) {
+  return napi_set_named_property(env, object, key, value) == napi_ok;
+}
+
+napi_value NapiError(napi_env env) {
+  if (napi_throw_error(env, nullptr, "keychain binding response failed") !=
+      napi_ok)
+    return nullptr;
+  return nullptr;
+}
+
+bool ResultShell(napi_env env, bool succeeded, napi_value &result) {
+  napi_value ok = nullptr;
+  return napi_create_object(env, &result) == napi_ok &&
+         napi_get_boolean(env, succeeded, &ok) == napi_ok &&
+         Set(env, result, "ok", ok);
 }
 
 napi_value Failure(napi_env env, const char *code) {
-  napi_value result;
-  napi_create_object(env, &result);
-  napi_value ok;
-  napi_get_boolean(env, false, &ok);
-  Set(env, result, "ok", ok);
-  Set(env, result, "code", Text(env, code));
+  napi_value result = nullptr;
+  napi_value codeValue = nullptr;
+  if (!ResultShell(env, false, result) || !Text(env, code, codeValue) ||
+      !Set(env, result, "code", codeValue))
+    return NapiError(env);
+  return result;
+}
+
+napi_value CreationFailure(napi_env env, const char *code, bool pending) {
+  napi_value result = nullptr;
+  napi_value codeValue = nullptr;
+  napi_value pendingValue = nullptr;
+  if (!ResultShell(env, false, result) || !Text(env, code, codeValue) ||
+      !Set(env, result, "code", codeValue) ||
+      napi_get_boolean(env, pending, &pendingValue) != napi_ok ||
+      !Set(env, result, "creationRollbackPending", pendingValue))
+    return NapiError(env);
   return result;
 }
 
 napi_value Success(napi_env env) {
-  napi_value result;
-  napi_create_object(env, &result);
-  napi_value ok;
-  napi_get_boolean(env, true, &ok);
-  Set(env, result, "ok", ok);
+  napi_value result = nullptr;
+  if (!ResultShell(env, true, result))
+    return NapiError(env);
   return result;
 }
 
@@ -366,26 +409,152 @@ PartitionInspection InspectPartition(SecKeychainItemRef item) {
   return result;
 }
 
-bool ReadyForKeychain(napi_env env, napi_value &refusal) {
-  const OSStatus interactionStatus = InteractionDisabled();
-  if (interactionStatus != errSecSuccess) {
-    refusal = Failure(env, StatusCode(interactionStatus));
-    return false;
+struct NativeCreationContext {
+  napi_env env;
+  CFMutableDictionaryRef attributes;
+  napi_value response = nullptr;
+  bool napiFailure = false;
+};
+
+const char *PrepareCreationResponse(void *value) {
+  auto &context = *static_cast<NativeCreationContext *>(value);
+  if (!ResultShell(context.env, true, context.response)) {
+    context.napiFailure = true;
+    return "unknown";
   }
-  static const bool trusted = TrustedHost();
-  if (!trusted) {
-    refusal = Failure(env, "not-team-signed");
-    return false;
+  return nullptr;
+}
+
+CreationRollbackAddResult AddCreatedItem(void *value) {
+  auto &context = *static_cast<NativeCreationContext *>(value);
+  CFTypeRef itemValue = nullptr;
+  const OSStatus status = SecItemAdd(context.attributes, &itemValue);
+  if (status != errSecSuccess)
+    return {StatusCode(status), const_cast<void *>(itemValue), false};
+  const bool exact = itemValue != nullptr &&
+                     CFGetTypeID(itemValue) == SecKeychainItemGetTypeID();
+  return {nullptr, const_cast<void *>(itemValue), exact};
+}
+
+const char *InspectCreatedItem(void *, void *value) {
+  const PartitionInspection partition = InspectPartition(
+      static_cast<SecKeychainItemRef>(value));
+  if (partition == PartitionInspection::kPresent)
+    return nullptr;
+  return partition == PartitionInspection::kAbsent ? "unreadable-item"
+                                                    : "uninspectable-item";
+}
+
+CreationRollbackContentResult CopyCreatedContent(void *, void *value) {
+  UInt32 length = 0;
+  void *bytes = nullptr;
+  const OSStatus status = SecKeychainItemCopyContent(
+      static_cast<SecKeychainItemRef>(value), nullptr, nullptr, &length,
+      &bytes);
+  return {status == errSecSuccess ? nullptr : StatusCode(status), bytes,
+          static_cast<size_t>(length)};
+}
+
+const char *FreeCreatedContent(void *, void *bytes, size_t length) {
+  EraseBytes(bytes, length);
+  return SecKeychainItemFreeContent(nullptr, bytes) == errSecSuccess
+             ? nullptr
+             : "uninspectable-item";
+}
+
+CreationRollbackBufferResult CreateKeyBuffer(void *value,
+                                             const unsigned char *material,
+                                             size_t length) {
+  auto &context = *static_cast<NativeCreationContext *>(value);
+  napi_value key = nullptr;
+  void *bytes = nullptr;
+  if (napi_create_buffer_copy(context.env, length, material, &bytes, &key) !=
+      napi_ok) {
+    context.napiFailure = true;
+    return {"unknown", key, static_cast<unsigned char *>(bytes),
+            bytes == nullptr ? 0 : length};
   }
+  return {nullptr, key, static_cast<unsigned char *>(bytes), length};
+}
+
+const char *PublishKeyBuffer(void *value, void *key) {
+  auto &context = *static_cast<NativeCreationContext *>(value);
+  if (!Set(context.env, context.response, "key",
+           static_cast<napi_value>(key))) {
+    context.napiFailure = true;
+    return "unknown";
+  }
+  return nullptr;
+}
+
+void WipeKeyBuffer(void *, unsigned char *bytes, size_t length) {
+  EraseBytes(bytes, length);
+}
+
+const char *DeleteCreatedItem(void *, void *value) {
+  const OSStatus status =
+      SecKeychainItemDelete(static_cast<SecKeychainItemRef>(value));
+  return status == errSecSuccess ? nullptr : StatusCode(status);
+}
+
+void ReleaseCreatedRef(void *, void *value) {
+  CFRelease(static_cast<CFTypeRef>(value));
+}
+
+void EraseCreatedMaterial(void *, unsigned char *material, size_t length) {
+  EraseBytes(material, length);
+}
+
+CreationRollbackDependencies NativeCreationDependencies(void *context) {
+  return {context,
+          PrepareCreationResponse,
+          AddCreatedItem,
+          InspectCreatedItem,
+          CopyCreatedContent,
+          FreeCreatedContent,
+          CreateKeyBuffer,
+          PublishKeyBuffer,
+          WipeKeyBuffer,
+          DeleteCreatedItem,
+          ReleaseCreatedRef,
+          EraseCreatedMaterial};
+}
+
+bool GetBindingState(napi_env env, BindingState *&state) {
+  void *value = nullptr;
+  if (napi_get_instance_data(env, &value) != napi_ok || value == nullptr)
+    return false;
+  state = static_cast<BindingState *>(value);
   return true;
 }
 
+void FinalizeBindingState(napi_env, void *value, void *) {
+  auto *state = static_cast<BindingState *>(value);
+  if (state == nullptr)
+    return;
+  const CreationRollbackDependencies dependencies =
+      NativeCreationDependencies(nullptr);
+  ReleaseCreationRollbackDebt(state->creationDebt, dependencies);
+  delete state;
+}
+
+const char *ReadinessFailure() {
+  const OSStatus interactionStatus = InteractionDisabled();
+  if (interactionStatus != errSecSuccess)
+    return StatusCode(interactionStatus);
+  static const bool trusted = TrustedHost();
+  return trusted ? nullptr : "not-team-signed";
+}
+
 napi_value Probe(napi_env env, napi_callback_info) {
-  napi_value refusal;
-  if (!ReadyForKeychain(env, refusal))
-    return refusal;
+  const char *refusal = ReadinessFailure();
+  if (refusal != nullptr)
+    return Failure(env, refusal);
   napi_value result = Success(env);
-  Set(env, result, "teamIdentifier", Text(env, kTeamIdentifier));
+  napi_value identifier = nullptr;
+  if (result == nullptr || !Text(env, kTeamIdentifier, identifier) ||
+      !Set(env, result, "teamIdentifier", identifier))
+    return NapiError(env);
   return result;
 }
 
@@ -393,9 +562,16 @@ napi_value ReadKey(napi_env env, napi_callback_info info) {
   std::string service;
   if (!ReadService(env, info, service))
     return Failure(env, "unknown");
-  napi_value refusal;
-  if (!ReadyForKeychain(env, refusal))
-    return refusal;
+  const char *refusal = ReadinessFailure();
+  if (refusal != nullptr)
+    return Failure(env, refusal);
+  BindingState *state = nullptr;
+  if (!GetBindingState(env, state))
+    return Failure(env, "unknown");
+  const CreationRollbackResult retry = RetryCreationRollback(
+      service, state->creationDebt, NativeCreationDependencies(nullptr));
+  if (!retry.ok)
+    return Failure(env, retry.code);
   SecKeychainRef keychain = nullptr;
   const OSStatus defaultStatus = CopyDefaultKeychain(keychain);
   if (defaultStatus != errSecSuccess)
@@ -440,124 +616,112 @@ napi_value ReadKey(napi_env env, napi_callback_info info) {
                             ? "unreadable-item"
                             : "uninspectable-item");
   }
-  napi_value key;
-  napi_create_buffer_copy(env, kKeyBytes, CFDataGetBytePtr(data), nullptr,
-                          &key);
+  napi_value key = nullptr;
+  void *keyBytes = nullptr;
+  const napi_status bufferStatus = napi_create_buffer_copy(
+      env, kKeyBytes, CFDataGetBytePtr(data), &keyBytes, &key);
   CFRelease(resultValue);
+  if (bufferStatus != napi_ok) {
+    EraseBytes(keyBytes, keyBytes == nullptr ? 0 : kKeyBytes);
+    return NapiError(env);
+  }
   napi_value response = Success(env);
-  Set(env, response, "key", key);
+  if (response == nullptr || !Set(env, response, "key", key)) {
+    EraseBytes(keyBytes, kKeyBytes);
+    return NapiError(env);
+  }
   return response;
 }
 
 napi_value CreateKey(napi_env env, napi_callback_info info) {
   std::string service;
   if (!ReadService(env, info, service))
-    return Failure(env, "unknown");
-  napi_value refusal;
-  if (!ReadyForKeychain(env, refusal))
-    return refusal;
+    return CreationFailure(env, "unknown", false);
+  const char *refusal = ReadinessFailure();
+  if (refusal != nullptr)
+    return CreationFailure(env, refusal, false);
+  BindingState *state = nullptr;
+  if (!GetBindingState(env, state))
+    return CreationFailure(env, "unknown", false);
+  const CreationRollbackResult retry = RetryCreationRollback(
+      service, state->creationDebt, NativeCreationDependencies(nullptr));
+  if (!retry.ok)
+    return CreationFailure(env, retry.code,
+                           retry.creationRollbackPending);
   SecKeychainRef keychain = nullptr;
   const OSStatus defaultStatus = CopyDefaultKeychain(keychain);
   if (defaultStatus != errSecSuccess)
-    return Failure(env, StatusCode(defaultStatus));
+    return CreationFailure(env, StatusCode(defaultStatus), false);
   std::array<unsigned char, kKeyBytes> material{};
   if (SecRandomCopyBytes(kSecRandomDefault, material.size(), material.data()) !=
       errSecSuccess) {
     CFRelease(keychain);
     EraseKey(material);
-    return Failure(env, "unknown");
+    return CreationFailure(env, "unknown", false);
   }
   SecAccessRef access = MakeAccess();
   if (access == nullptr) {
     CFRelease(keychain);
     EraseKey(material);
-    return Failure(env, "unknown");
+    return CreationFailure(env, "unknown", false);
   }
   CFMutableDictionaryRef attributes = Query(service, keychain, true);
   CFRelease(keychain);
   if (attributes == nullptr) {
     CFRelease(access);
     EraseKey(material);
-    return Failure(env, "unknown");
+    return CreationFailure(env, "unknown", false);
   }
-  CFDataRef data =
-      CFDataCreate(kCFAllocatorDefault, material.data(), material.size());
+  CFDataRef data = CFDataCreateWithBytesNoCopy(
+      kCFAllocatorDefault, material.data(), material.size(), kCFAllocatorNull);
   if (data == nullptr) {
     CFRelease(attributes);
     CFRelease(access);
     EraseKey(material);
-    return Failure(env, "unknown");
+    return CreationFailure(env, "unknown", false);
   }
   CFDictionarySetValue(attributes, kSecValueData, data);
   CFDictionarySetValue(attributes, kSecAttrAccess, access);
   CFDictionarySetValue(attributes, kSecReturnRef, kCFBooleanTrue);
-  CFTypeRef itemValue = nullptr;
-  const OSStatus status = SecItemAdd(attributes, &itemValue);
+  NativeCreationContext context{env, attributes};
+  const CreationRollbackResult result = RunCreationRollbackTransaction(
+      service, material.data(), material.size(), state->creationDebt,
+      NativeCreationDependencies(&context));
   CFRelease(attributes);
   CFRelease(data);
   CFRelease(access);
-  if (status != errSecSuccess) {
-    if (itemValue != nullptr)
-      CFRelease(itemValue);
-    EraseKey(material);
-    return Failure(env, StatusCode(status));
-  }
-  if (itemValue == nullptr ||
-      CFGetTypeID(itemValue) != SecKeychainItemGetTypeID()) {
-    if (itemValue != nullptr)
-      CFRelease(itemValue);
-    EraseKey(material);
-    return Failure(env, "unreadable-item");
-  }
-  const PartitionInspection partition = InspectPartition(
-      static_cast<SecKeychainItemRef>(const_cast<void *>(itemValue)));
-  if (partition != PartitionInspection::kPresent) {
-    CFRelease(itemValue);
-    EraseKey(material);
-    return Failure(env, partition == PartitionInspection::kAbsent
-                            ? "unreadable-item"
-                            : "uninspectable-item");
-  }
-  UInt32 persistedLength = 0;
-  void *persistedData = nullptr;
-  const OSStatus persistedStatus = SecKeychainItemCopyContent(
-      static_cast<SecKeychainItemRef>(const_cast<void *>(itemValue)), nullptr,
-      nullptr, &persistedLength, &persistedData);
-  const bool persistedMatches =
-      persistedStatus == errSecSuccess && persistedData != nullptr &&
-      persistedLength == static_cast<UInt32>(material.size()) &&
-      timingsafe_bcmp(persistedData, material.data(), material.size()) == 0;
-  OSStatus freeStatus = errSecSuccess;
-  if (persistedData != nullptr)
-    freeStatus = SecKeychainItemFreeContent(nullptr, persistedData);
-  CFRelease(itemValue);
-  if (persistedStatus != errSecSuccess) {
-    EraseKey(material);
-    return Failure(env, StatusCode(persistedStatus));
-  }
-  if (freeStatus != errSecSuccess) {
-    EraseKey(material);
-    return Failure(env, "uninspectable-item");
-  }
-  if (!persistedMatches) {
-    EraseKey(material);
-    return Failure(env, "unreadable-item");
-  }
-  napi_value key;
-  napi_create_buffer_copy(env, material.size(), material.data(), nullptr, &key);
-  EraseKey(material);
-  napi_value response = Success(env);
-  Set(env, response, "key", key);
-  return response;
+  if (result.ok)
+    return context.response;
+  return CreationFailure(env, result.code, result.creationRollbackPending);
+}
+
+napi_value RetryCreatedKeyRollback(napi_env env, napi_callback_info info) {
+  std::string service;
+  if (!ReadService(env, info, service))
+    return Failure(env, "unknown");
+  const char *refusal = ReadinessFailure();
+  if (refusal != nullptr)
+    return Failure(env, refusal);
+  BindingState *state = nullptr;
+  if (!GetBindingState(env, state))
+    return Failure(env, "unknown");
+  const CreationRollbackResult retry = RetryCreationRollback(
+      service, state->creationDebt, NativeCreationDependencies(nullptr));
+  return retry.ok ? Success(env) : Failure(env, retry.code);
 }
 
 napi_value DeleteKey(napi_env env, napi_callback_info info) {
   std::string service;
   if (!ReadService(env, info, service))
     return Failure(env, "unknown");
-  napi_value refusal;
-  if (!ReadyForKeychain(env, refusal))
-    return refusal;
+  const char *refusal = ReadinessFailure();
+  if (refusal != nullptr)
+    return Failure(env, refusal);
+  BindingState *state = nullptr;
+  if (!GetBindingState(env, state))
+    return Failure(env, "unknown");
+  if (state->creationDebt.pending)
+    return Failure(env, "uninspectable-item");
   SecKeychainRef keychain = nullptr;
   const OSStatus defaultStatus = CopyDefaultKeychain(keychain);
   if (defaultStatus != errSecSuccess)
@@ -596,15 +760,25 @@ napi_value DeleteKey(napi_env env, napi_callback_info info) {
       return Failure(env, StatusCode(status));
   }
   napi_value response = Success(env);
-  napi_value deleted;
-  napi_get_boolean(env, status == errSecSuccess, &deleted);
-  Set(env, response, "deleted", deleted);
+  napi_value deleted = nullptr;
+  if (response == nullptr ||
+      napi_get_boolean(env, status == errSecSuccess, &deleted) != napi_ok ||
+      !Set(env, response, "deleted", deleted))
+    return NapiError(env);
   return response;
 }
 
 }
 
 NAPI_MODULE_INIT() {
+  auto *state = new (std::nothrow) BindingState();
+  if (state == nullptr)
+    return NapiError(env);
+  if (napi_set_instance_data(env, state, FinalizeBindingState, nullptr) !=
+      napi_ok) {
+    delete state;
+    return NapiError(env);
+  }
   const napi_property_descriptor properties[] = {
       {"probe", nullptr, Probe, nullptr, nullptr, nullptr, napi_default,
        nullptr},
@@ -612,10 +786,14 @@ NAPI_MODULE_INIT() {
        nullptr},
       {"createKey", nullptr, CreateKey, nullptr, nullptr, nullptr, napi_default,
        nullptr},
+      {"retryCreatedKeyRollback", nullptr, RetryCreatedKeyRollback, nullptr,
+       nullptr, nullptr, napi_default, nullptr},
       {"deleteKey", nullptr, DeleteKey, nullptr, nullptr, nullptr, napi_default,
        nullptr},
   };
-  napi_define_properties(
-      env, exports, sizeof(properties) / sizeof(properties[0]), properties);
+  if (napi_define_properties(
+          env, exports, sizeof(properties) / sizeof(properties[0]),
+          properties) != napi_ok)
+    return NapiError(env);
   return exports;
 }

--- a/apps/desktop/scripts/build-keychain-binding.d.mts
+++ b/apps/desktop/scripts/build-keychain-binding.d.mts
@@ -1,6 +1,7 @@
 export const KEYCHAIN_BINDING_FILE: "keychain-binding.node";
 export const KEYCHAIN_BINDING_BUILD_DIRECTORY: "dist/keychain-binding";
 export const KEYCHAIN_BINDING_SOURCE: "native/keychain-binding/keychain-binding.mm";
+export const KEYCHAIN_BINDING_CREATION_ROLLBACK_SOURCE: "native/keychain-binding/creation-rollback.cc";
 export const KEYCHAIN_BINDING_PARTITION_DESCRIPTION_SOURCE: "native/keychain-binding/partition-description.mm";
 export const KEYCHAIN_BINDING_MINIMUM_MACOS: "12.0";
 export const KEYCHAIN_BINDING_NAPI_VERSION: "9";

--- a/apps/desktop/scripts/build-keychain-binding.mjs
+++ b/apps/desktop/scripts/build-keychain-binding.mjs
@@ -10,6 +10,8 @@ const canonicalDesktopRoot = resolve(scriptDirectory, "..");
 export const KEYCHAIN_BINDING_FILE = "keychain-binding.node";
 export const KEYCHAIN_BINDING_BUILD_DIRECTORY = "dist/keychain-binding";
 export const KEYCHAIN_BINDING_SOURCE = "native/keychain-binding/keychain-binding.mm";
+export const KEYCHAIN_BINDING_CREATION_ROLLBACK_SOURCE =
+  "native/keychain-binding/creation-rollback.cc";
 export const KEYCHAIN_BINDING_PARTITION_DESCRIPTION_SOURCE =
   "native/keychain-binding/partition-description.mm";
 export const KEYCHAIN_BINDING_MINIMUM_MACOS = "12.0";
@@ -61,6 +63,7 @@ export async function buildKeychainBinding(desktopRoot = canonicalDesktopRoot) {
       [
         "clang++",
         join(desktopRoot, KEYCHAIN_BINDING_SOURCE),
+        join(desktopRoot, KEYCHAIN_BINDING_CREATION_ROLLBACK_SOURCE),
         join(desktopRoot, KEYCHAIN_BINDING_PARTITION_DESCRIPTION_SOURCE),
         "-std=c++20",
         "-O2",

--- a/apps/desktop/src/main/acceptance-credential-backend.ts
+++ b/apps/desktop/src/main/acceptance-credential-backend.ts
@@ -96,6 +96,9 @@ function memoryTransport(initialKey: Buffer): KeychainBindingTransport {
         key ??= randomBytes(KEYCHAIN_KEY_BYTES);
         return { ok: true, op: "create-key", key: Buffer.from(key) };
       }
+      if (request.op === "retry-created-key-rollback") {
+        return { ok: true, op: "retry-created-key-rollback" };
+      }
       const deleted = key !== undefined;
       key?.fill(0);
       key = undefined;
@@ -134,7 +137,9 @@ function fileTransport(keyPath: string): KeychainBindingTransport {
       if (request.op === "create-key") {
         const existing = await readFileKey(keyPath);
         if (existing.ok) return { ...existing, op: "create-key" };
-        if (existing.code !== "item-not-found") return existing;
+        if (existing.code !== "item-not-found") {
+          return { ...existing, creationRollbackPending: false };
+        }
         const key = randomBytes(KEYCHAIN_KEY_BYTES);
         try {
           await writeFile(keyPath, key, { flag: "wx", mode: 0o600 });
@@ -142,12 +147,17 @@ function fileTransport(keyPath: string): KeychainBindingTransport {
         } catch (error) {
           return (error as NodeJS.ErrnoException).code === "EEXIST"
             ? await readFileKey(keyPath).then((response) =>
-                response.ok ? { ...response, op: "create-key" } : response,
+                response.ok
+                  ? { ...response, op: "create-key" }
+                  : { ...response, creationRollbackPending: false },
               )
-            : { ok: false, code: "unknown" };
+            : { ok: false, code: "unknown", creationRollbackPending: false };
         } finally {
           key.fill(0);
         }
+      }
+      if (request.op === "retry-created-key-rollback") {
+        return { ok: true, op: "retry-created-key-rollback" };
       }
       try {
         await unlink(keyPath);

--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -8,6 +8,7 @@ import {
 } from "./automatic-key-retirement.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
 import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
+import type { KeyCleanupDebt } from "./key-cleanup-debt.js";
 import {
   createKeychainPartitionEncryption,
   createRefusingKeychainEncryption,
@@ -37,6 +38,7 @@ export type DesktopCredentialBackendSelection =
       encryption: CredentialEncryptionPort;
       reason: DesktopCredentialBackendRefusal;
       code: KeychainBindingErrorCode;
+      keyCleanupDebt: KeyCleanupDebt;
       keyCleanupPending: boolean;
     }>;
 
@@ -45,7 +47,7 @@ export interface SelectDesktopCredentialBackendOptions extends CredentialEnvelop
   readonly service: string;
   readonly safeStorage: CredentialEncryptionPort;
   readonly platform?: NodeJS.Platform;
-  readonly keyCleanupPending?: boolean;
+  readonly keyCleanupDebt?: KeyCleanupDebt;
   readonly serializeEnvelopeMutation: SerializeCredentialEnvelopeMutation;
 }
 
@@ -96,7 +98,7 @@ async function selectMacCredentialBackend(
   const keychain = await createKeychainPartitionEncryption({
     transport: options.transport,
     service: options.service,
-    keyCleanupPending: options.keyCleanupPending,
+    keyCleanupDebt: options.keyCleanupDebt,
     inspectAutomaticRetirement: async (currentProof) => {
       const inspection = await inspect(currentProof);
       if (inspection.status === "inspected") {
@@ -113,7 +115,8 @@ async function selectMacCredentialBackend(
       encryption: createRefusingKeychainEncryption(keychain.code, false),
       reason: "encryption-unavailable",
       code: keychain.code,
-      keyCleanupPending: false,
+      keyCleanupDebt: keychain.keyCleanupDebt,
+      keyCleanupPending: keychain.keyCleanupDebt !== "none",
     };
   }
   if (keychain.status !== "ready") {
@@ -126,7 +129,8 @@ async function selectMacCredentialBackend(
       ),
       reason,
       code: keychain.code,
-      keyCleanupPending: keychain.keyCleanupPending,
+      keyCleanupDebt: keychain.keyCleanupDebt,
+      keyCleanupPending: keychain.keyCleanupDebt !== "none",
     };
   }
   return {

--- a/apps/desktop/src/main/desktop-credential-encryption.ts
+++ b/apps/desktop/src/main/desktop-credential-encryption.ts
@@ -11,6 +11,7 @@ import type { KeychainKeyRetirement } from "./automatic-key-retirement.js";
 import type { CredentialEnvelopeRoots } from "./credential-envelope-inventory.js";
 import { scanBoundCredentialEnvelopes } from "./credential-envelope-root-binding.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
+import type { KeyCleanupDebt } from "./key-cleanup-debt.js";
 import {
   createRefusingKeychainEncryption,
   type KeychainKeyDeletion,
@@ -94,17 +95,20 @@ export async function prepareDesktopCredentialEncryption(
     });
   } catch {
     const unavailable = options.location.platform === "darwin";
+    const keyCleanupDebt: KeyCleanupDebt = "none";
     selection = {
       status: "refused",
       encryption: createRefusingKeychainEncryption("unknown", !unavailable),
       reason: unavailable ? "encryption-unavailable" : "storage-failed",
       code: "unknown",
-      keyCleanupPending: false,
+      keyCleanupDebt,
+      keyCleanupPending: keyCleanupDebt !== "none",
     };
   }
   let currentEncryption = selection.encryption;
-  let keyCleanupPending = selection.status === "refused" && selection.keyCleanupPending;
-  let refreshBeforeWrite = keyCleanupPending;
+  let keyCleanupDebt: KeyCleanupDebt =
+    selection.status === "refused" ? selection.keyCleanupDebt : "none";
+  let refreshBeforeWrite = keyCleanupDebt !== "none";
   const encryption: CredentialEncryptionPort = {
     isEncryptionAvailable: () => currentEncryption.isEncryptionAvailable(),
     encryptString: (value) => currentEncryption.encryptString(value),
@@ -113,52 +117,51 @@ export async function prepareDesktopCredentialEncryption(
   };
   const transitionToUnavailable = (
     code: KeychainBindingErrorCode,
-    cleanupPending: boolean,
+    cleanupDebt: KeyCleanupDebt,
   ): void => {
     selection = {
       status: "refused",
       encryption: createRefusingKeychainEncryption(code, false),
       reason: "encryption-unavailable",
       code,
-      keyCleanupPending: cleanupPending,
+      keyCleanupDebt: cleanupDebt,
+      keyCleanupPending: cleanupDebt !== "none",
     };
     currentEncryption = selection.encryption;
-    keyCleanupPending = cleanupPending;
-    refreshBeforeWrite = cleanupPending;
+    keyCleanupDebt = cleanupDebt;
+    refreshBeforeWrite = cleanupDebt !== "none";
   };
   const refreshSelection = async (
     proof: CredentialEnvelopeLockProof,
   ): Promise<DesktopCredentialBackendSelection> => {
-    const pendingBeforeRefresh = keyCleanupPending;
     try {
-      let next = await selectDesktopCredentialBackendLocked(
+      const next = await selectDesktopCredentialBackendLocked(
         {
           ...roots,
           transport,
           service,
           safeStorage: options.safeStorage,
           platform: options.location.platform,
-          keyCleanupPending,
+          keyCleanupDebt,
           serializeEnvelopeMutation: options.serializeEnvelopeMutation,
         },
         proof,
       );
-      if (next.status === "refused" && pendingBeforeRefresh && !next.keyCleanupPending) {
-        next = { ...next, keyCleanupPending: true };
-      }
       selection = next;
       currentEncryption = next.encryption;
-      keyCleanupPending = next.status === "refused" && next.keyCleanupPending;
-      refreshBeforeWrite = keyCleanupPending;
+      keyCleanupDebt = next.status === "refused" ? next.keyCleanupDebt : "none";
+      refreshBeforeWrite = keyCleanupDebt !== "none";
     } catch {
       selection = {
         status: "refused",
         encryption: createRefusingKeychainEncryption("unknown", false),
         reason: "encryption-unavailable",
         code: "unknown",
-        keyCleanupPending,
+        keyCleanupDebt,
+        keyCleanupPending: keyCleanupDebt !== "none",
       };
       currentEncryption = selection.encryption;
+      refreshBeforeWrite = keyCleanupDebt !== "none";
     }
     return selection;
   };
@@ -174,14 +177,16 @@ export async function prepareDesktopCredentialEncryption(
       }
       if (selection.status !== "keychain") return;
       const prepared = await selection.prepareKey(proof);
-      if (prepared.status === "failed") transitionToUnavailable(prepared.code, false);
+      if (prepared.status === "failed") {
+        transitionToUnavailable(prepared.code, prepared.keyCleanupDebt ?? "none");
+      }
     },
     async revalidateEnvelopeRemoval(proof: CredentialEnvelopeLockProof): Promise<boolean> {
       if (options.location.platform !== "darwin") return true;
       if (selection.status !== "keychain") return false;
       const validated = await selection.validateKey(proof);
       if (validated.status === "ready") return true;
-      transitionToUnavailable(validated.code, false);
+      transitionToUnavailable(validated.code, validated.keyCleanupDebt ?? "none");
       return false;
     },
     async retireKeychainKey(
@@ -190,7 +195,10 @@ export async function prepareDesktopCredentialEncryption(
       if (selection.status !== "keychain") return undefined;
       const retired = await selection.retireKey(proof);
       if (retired.status === "failed") {
-        transitionToUnavailable(retired.code, retired.keyCleanupPending);
+        transitionToUnavailable(
+          retired.code,
+          retired.keyCleanupPending ? "retirement" : "none",
+        );
       }
       return retired;
     },
@@ -213,7 +221,7 @@ export async function prepareDesktopCredentialEncryption(
           );
           return { selection: current, unverifiedEnvelopes: inventory.unverified };
         } catch {
-          transitionToUnavailable("unknown", false);
+          transitionToUnavailable("unknown", keyCleanupDebt);
           return { selection, unverifiedEnvelopes: 0 };
         }
       });
@@ -235,10 +243,10 @@ export async function prepareDesktopCredentialEncryption(
               };
             });
       if (deleted.status === "failed") {
-        transitionToUnavailable(deleted.code, true);
+        transitionToUnavailable(deleted.code, "retirement");
         return deleted;
       }
-      keyCleanupPending = false;
+      keyCleanupDebt = "none";
       refreshBeforeWrite = false;
       await refreshSelection(proof);
       return deleted;

--- a/apps/desktop/src/main/key-cleanup-debt.ts
+++ b/apps/desktop/src/main/key-cleanup-debt.ts
@@ -1,0 +1,1 @@
+export type KeyCleanupDebt = "none" | "retirement" | "creation-rollback";

--- a/apps/desktop/src/main/keychain-backend-selection-probe.ts
+++ b/apps/desktop/src/main/keychain-backend-selection-probe.ts
@@ -35,6 +35,9 @@ export function createKeychainBackendSelectionProbeTransport(
   return {
     async send(request): Promise<KeychainBindingResponse> {
       if (request.op === "read-key") return SYNTHETIC_MISSING_KEY;
+      if (request.op === "retry-created-key-rollback") {
+        return { ok: true, op: "retry-created-key-rollback" };
+      }
       if (request.op === "create-key" || request.op === "delete-key") {
         throw new Error("release backend selection probe refused key mutation");
       }

--- a/apps/desktop/src/main/keychain-binding.ts
+++ b/apps/desktop/src/main/keychain-binding.ts
@@ -4,6 +4,7 @@ export const KEYCHAIN_BINDING_OPERATIONS = [
   "probe",
   "read-key",
   "create-key",
+  "retry-created-key-rollback",
   "delete-key",
 ] as const;
 
@@ -48,8 +49,13 @@ export type KeychainBindingResponse =
       readonly deleted: boolean;
     }
   | {
+      readonly ok: true;
+      readonly op: "retry-created-key-rollback";
+    }
+  | {
       readonly ok: false;
       readonly code: KeychainBindingErrorCode;
+      readonly creationRollbackPending?: boolean;
     };
 
 export interface KeychainBindingTransport {
@@ -60,6 +66,7 @@ interface NativeKeychainBinding {
   probe(): unknown;
   readKey(service: string): unknown;
   createKey(service: string): unknown;
+  retryCreatedKeyRollback(service: string): unknown;
   deleteKey(service: string): unknown;
 }
 
@@ -71,6 +78,15 @@ export interface KeychainBindingTransportOptions {
 }
 
 const UNKNOWN_RESPONSE: KeychainBindingResponse = Object.freeze({ ok: false, code: "unknown" });
+const CREATION_ROLLBACK_UNKNOWN_RESPONSE: KeychainBindingResponse = Object.freeze({
+  ok: false,
+  code: "unknown",
+  creationRollbackPending: true,
+});
+
+function unknownResponse(operation: KeychainBindingOperation): KeychainBindingResponse {
+  return operation === "create-key" ? CREATION_ROLLBACK_UNKNOWN_RESPONSE : UNKNOWN_RESPONSE;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -88,6 +104,7 @@ function nativeBinding(value: unknown): NativeKeychainBinding | undefined {
     typeof value.probe !== "function" ||
     typeof value.readKey !== "function" ||
     typeof value.createKey !== "function" ||
+    typeof value.retryCreatedKeyRollback !== "function" ||
     typeof value.deleteKey !== "function"
   ) {
     return undefined;
@@ -99,24 +116,36 @@ export function parseKeychainBindingResponse(
   operation: KeychainBindingOperation,
   value: unknown,
 ): KeychainBindingResponse {
-  if (!isRecord(value)) return UNKNOWN_RESPONSE;
+  if (!isRecord(value)) return unknownResponse(operation);
   if (value.ok === false) {
+    if (operation === "create-key") {
+      return isErrorCode(value.code) && typeof value.creationRollbackPending === "boolean"
+        ? {
+            ok: false,
+            code: value.code,
+            creationRollbackPending: value.creationRollbackPending,
+          }
+        : CREATION_ROLLBACK_UNKNOWN_RESPONSE;
+    }
     return isErrorCode(value.code) ? { ok: false, code: value.code } : UNKNOWN_RESPONSE;
   }
-  if (value.ok !== true) return UNKNOWN_RESPONSE;
+  if (value.ok !== true) return unknownResponse(operation);
   if (operation === "probe") {
     return value.teamIdentifier === KEYCHAIN_TEAM_IDENTIFIER
       ? { ok: true, op: "probe", teamIdentifier: value.teamIdentifier }
-      : UNKNOWN_RESPONSE;
+      : unknownResponse(operation);
   }
   if (operation === "read-key" || operation === "create-key") {
     return Buffer.isBuffer(value.key) && value.key.length === KEYCHAIN_KEY_BYTES
       ? { ok: true, op: operation, key: Buffer.from(value.key) }
-      : UNKNOWN_RESPONSE;
+      : unknownResponse(operation);
+  }
+  if (operation === "retry-created-key-rollback") {
+    return { ok: true, op: "retry-created-key-rollback" };
   }
   return typeof value.deleted === "boolean"
     ? { ok: true, op: "delete-key", deleted: value.deleted }
-    : UNKNOWN_RESPONSE;
+    : unknownResponse(operation);
 }
 
 export function createKeychainBindingTransport(
@@ -131,7 +160,7 @@ export function createKeychainBindingTransport(
   } catch {}
   return {
     async send(request: KeychainBindingRequest): Promise<KeychainBindingResponse> {
-      if (binding === undefined) return UNKNOWN_RESPONSE;
+      if (binding === undefined) return unknownResponse(request.op);
       try {
         const response =
           request.op === "probe"
@@ -140,10 +169,12 @@ export function createKeychainBindingTransport(
               ? binding.readKey(request.service)
               : request.op === "create-key"
                 ? binding.createKey(request.service)
-                : binding.deleteKey(request.service);
+                : request.op === "retry-created-key-rollback"
+                  ? binding.retryCreatedKeyRollback(request.service)
+                  : binding.deleteKey(request.service);
         return parseKeychainBindingResponse(request.op, response);
       } catch {
-        return UNKNOWN_RESPONSE;
+        return unknownResponse(request.op);
       }
     },
   };

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -7,6 +7,7 @@ import {
 } from "./automatic-key-retirement.js";
 import type { CredentialEnvelopeLockProof } from "./credential-envelope-lock.js";
 import type { CredentialEncryptionPort } from "./credential-vault.js";
+import type { KeyCleanupDebt } from "./key-cleanup-debt.js";
 import {
   CREDENTIAL_ENVELOPE_HEADER_BYTES,
   CREDENTIAL_ENVELOPE_IV_BYTES,
@@ -19,6 +20,7 @@ import {
   KEYCHAIN_KEY_BYTES,
   KEYCHAIN_TEAM_IDENTIFIER,
   type KeychainBindingErrorCode,
+  type KeychainBindingResponse,
   type KeychainBindingTransport,
 } from "./keychain-binding.js";
 
@@ -85,25 +87,26 @@ export type KeychainPartitionEncryptionResult =
   | {
       readonly status: "unavailable";
       readonly code: KeychainBindingErrorCode;
-      readonly keyCleanupPending: boolean;
+      readonly keyCleanupDebt: KeyCleanupDebt;
       readonly encryption: CredentialEncryptionPort;
     }
   | {
       readonly status: "storage-failed";
       readonly code: KeychainBindingErrorCode;
-      readonly keyCleanupPending: boolean;
+      readonly keyCleanupDebt: KeyCleanupDebt;
       readonly encryption: CredentialEncryptionPort;
     }
   | {
       readonly status: "unsupported";
       readonly code: "not-team-signed";
+      readonly keyCleanupDebt: KeyCleanupDebt;
     };
 
 export interface CreateKeychainPartitionEncryptionOptions {
   readonly transport: KeychainBindingTransport;
   readonly service: string;
   readonly inspectAutomaticRetirement: InspectAutomaticKeyRetirement;
-  readonly keyCleanupPending?: boolean;
+  readonly keyCleanupDebt?: KeyCleanupDebt;
   readonly lockProof: CredentialEnvelopeLockProof;
 }
 
@@ -124,7 +127,16 @@ export function createRefusingKeychainEncryption(
 
 export type KeychainKeyPreparation =
   | Readonly<{ status: "ready" }>
-  | Readonly<{ status: "failed"; code: KeychainBindingErrorCode }>;
+  | Readonly<{
+      status: "failed";
+      code: KeychainBindingErrorCode;
+      keyCleanupDebt: Exclude<KeyCleanupDebt, "none">;
+    }>
+  | Readonly<{
+      status: "failed";
+      code: KeychainBindingErrorCode;
+      keyCleanupDebt?: "none";
+    }>;
 
 export type KeychainKeyDeletion =
   | Readonly<{ status: "deleted" | "already-absent" }>
@@ -133,7 +145,7 @@ export type KeychainKeyDeletion =
 interface KeyHolder {
   key: Buffer | null;
   failure: KeychainBindingErrorCode;
-  cleanupPending: boolean;
+  cleanupDebt: KeyCleanupDebt;
 }
 
 function readyPort(holder: KeyHolder): CredentialEncryptionPort {
@@ -151,20 +163,20 @@ function readyPort(holder: KeyHolder): CredentialEncryptionPort {
 
 function refused(
   code: KeychainBindingErrorCode,
-  keyCleanupPending = false,
+  keyCleanupDebt: KeyCleanupDebt = "none",
 ): KeychainPartitionEncryptionResult {
   if (code === "keychain-locked" || code === "uninspectable-item" || code === "item-not-found") {
     return {
       status: "unavailable",
       code,
-      keyCleanupPending,
+      keyCleanupDebt,
       encryption: createRefusingKeychainEncryption(code, false),
     };
   }
   return {
     status: "storage-failed",
     code,
-    keyCleanupPending,
+    keyCleanupDebt,
     encryption: createRefusingKeychainEncryption(code, true),
   };
 }
@@ -173,15 +185,33 @@ export async function createKeychainPartitionEncryption(
   options: CreateKeychainPartitionEncryptionOptions,
 ): Promise<KeychainPartitionEncryptionResult> {
   const { transport, service } = options;
+  const retryCreationRollback = async (): Promise<
+    | Readonly<{ status: "ready" }>
+    | Readonly<{ status: "failed"; code: KeychainBindingErrorCode }>
+  > => {
+    try {
+      const retried = await transport.send({ op: "retry-created-key-rollback", service });
+      if (!retried.ok) return { status: "failed", code: retried.code };
+      return retried.op === "retry-created-key-rollback"
+        ? { status: "ready" }
+        : { status: "failed", code: "unknown" };
+    } catch {
+      return { status: "failed", code: "unknown" };
+    }
+  };
+  let initialCleanupDebt = options.keyCleanupDebt ?? "none";
   const probe = await transport.send({ op: "probe", service });
   if (!probe.ok) {
     return probe.code === "not-team-signed"
-      ? { status: "unsupported", code: "not-team-signed" }
-      : refused(probe.code);
+      ? { status: "unsupported", code: "not-team-signed", keyCleanupDebt: initialCleanupDebt }
+      : refused(probe.code, initialCleanupDebt);
   }
   if (probe.op !== "probe" || probe.teamIdentifier !== KEYCHAIN_TEAM_IDENTIFIER) {
-    return refused("unknown");
+    return refused("unknown", initialCleanupDebt);
   }
+  const retried = await retryCreationRollback();
+  if (retried.status === "failed") return refused(retried.code, "creation-rollback");
+  if (initialCleanupDebt === "creation-rollback") initialCleanupDebt = "none";
   const inspectAutomaticRetirement = async (proof: CredentialEnvelopeLockProof) => {
     if (proof !== options.lockProof) return { status: "failed" as const };
     try {
@@ -192,20 +222,38 @@ export async function createKeychainPartitionEncryption(
   };
   const initialInspection = await inspectAutomaticRetirement(options.lockProof);
   if (initialInspection.status === "failed") {
-    return refused("unknown", options.keyCleanupPending ?? false);
+    return refused("unknown", initialCleanupDebt);
   }
 
   const createMaterial = async (): Promise<
     | Readonly<{ status: "ready"; key: Buffer }>
-    | Readonly<{ status: "failed"; code: KeychainBindingErrorCode }>
+    | Readonly<{
+        status: "failed";
+        code: KeychainBindingErrorCode;
+        keyCleanupDebt: KeyCleanupDebt;
+      }>
   > => {
-    const created = await transport.send({ op: "create-key", service });
-    if (!created.ok) return { status: "failed", code: created.code };
-    if (created.op !== "create-key") return { status: "failed", code: "unknown" };
+    let created: KeychainBindingResponse;
+    try {
+      created = await transport.send({ op: "create-key", service });
+    } catch {
+      return { status: "failed", code: "unknown", keyCleanupDebt: "creation-rollback" };
+    }
+    if (!created.ok) {
+      return {
+        status: "failed",
+        code: created.code,
+        keyCleanupDebt:
+          created.creationRollbackPending === false ? "none" : "creation-rollback",
+      };
+    }
+    if (created.op !== "create-key") {
+      return { status: "failed", code: "unknown", keyCleanupDebt: "creation-rollback" };
+    }
     const key = Buffer.from(created.key);
     if (key.length === KEYCHAIN_KEY_BYTES) return { status: "ready", key };
     key.fill(0);
-    return { status: "failed", code: "unknown" };
+    return { status: "failed", code: "unknown", keyCleanupDebt: "creation-rollback" };
   };
 
   const readMaterial = async (): Promise<
@@ -244,10 +292,16 @@ export async function createKeychainPartitionEncryption(
   };
 
   const ready = (key: Buffer | null, createdKey: boolean): KeychainPartitionEncryptionResult => {
-    const holder: KeyHolder = { key, failure: "item-not-found", cleanupPending: false };
-    const fail = (code: KeychainBindingErrorCode): KeychainKeyPreparation => {
+    const holder: KeyHolder = { key, failure: "item-not-found", cleanupDebt: "none" };
+    const fail = (
+      code: KeychainBindingErrorCode,
+      keyCleanupDebt: KeyCleanupDebt = holder.cleanupDebt,
+    ): KeychainKeyPreparation => {
       holder.failure = code;
-      return { status: "failed", code };
+      holder.cleanupDebt = keyCleanupDebt;
+      return keyCleanupDebt === "none"
+        ? { status: "failed", code }
+        : { status: "failed", code, keyCleanupDebt };
     };
     const clearKey = (): void => {
       holder.key?.fill(0);
@@ -276,16 +330,21 @@ export async function createKeychainPartitionEncryption(
     ): Promise<KeychainKeyPreparation> => {
       if (proof !== options.lockProof) return fail("unknown");
       if (holder.key !== null) return await validateKey(proof);
-      if (holder.cleanupPending) {
+      if (holder.cleanupDebt === "creation-rollback") {
+        const retried = await retryCreationRollback();
+        if (retried.status === "failed") return fail(retried.code, "creation-rollback");
+        holder.cleanupDebt = "none";
+      }
+      if (holder.cleanupDebt === "retirement") {
         const inspection = await inspectAutomaticRetirement(proof);
         if (inspection.status === "failed" || inspection.zeroProof === null) {
-          return fail("unknown");
+          return fail("unknown", "retirement");
         }
         const deleted = await deleteMaterial(inspection.zeroProof);
         if (deleted.status === "failed") {
-          return fail(deleted.code);
+          return fail(deleted.code, "retirement");
         }
-        holder.cleanupPending = false;
+        holder.cleanupDebt = "none";
       }
       const existing = await readMaterial();
       if (existing.status === "ready") {
@@ -303,7 +362,7 @@ export async function createKeychainPartitionEncryption(
       }
       const created = await createMaterial();
       if (created.status === "failed") {
-        return fail(created.code);
+        return fail(created.code, created.keyCleanupDebt);
       }
       holder.key = created.key;
       holder.failure = "item-not-found";
@@ -316,6 +375,7 @@ export async function createKeychainPartitionEncryption(
       if (inspection.status === "failed") {
         clearKey();
         holder.failure = "unknown";
+        holder.cleanupDebt = "none";
         return { status: "failed", code: "unknown", keyCleanupPending: false };
       }
       if (inspection.zeroProof === null) {
@@ -327,12 +387,12 @@ export async function createKeychainPartitionEncryption(
       if (deleted.status === "failed") {
         previous?.fill(0);
         holder.failure = deleted.code;
-        holder.cleanupPending = true;
+        holder.cleanupDebt = "retirement";
         return { ...deleted, keyCleanupPending: true };
       }
       previous?.fill(0);
       holder.failure = "item-not-found";
-      holder.cleanupPending = false;
+      holder.cleanupDebt = "none";
       return deleted;
     };
     const deleteKeyForReset = async (
@@ -345,11 +405,11 @@ export async function createKeychainPartitionEncryption(
       previous?.fill(0);
       if (deleted.status === "failed") {
         holder.failure = deleted.code;
-        holder.cleanupPending = true;
+        holder.cleanupDebt = "retirement";
         return deleted;
       }
       holder.failure = "item-not-found";
-      holder.cleanupPending = false;
+      holder.cleanupDebt = "none";
       return deleted;
     };
     return {
@@ -363,10 +423,12 @@ export async function createKeychainPartitionEncryption(
     };
   };
 
-  if (options.keyCleanupPending) {
-    if (initialInspection.zeroProof === null) return refused("unknown", true);
+  if (initialCleanupDebt === "retirement") {
+    if (initialInspection.zeroProof === null) return refused("unknown", "retirement");
     const deleted = await deleteMaterial(initialInspection.zeroProof);
-    return deleted.status === "failed" ? refused(deleted.code, true) : ready(null, false);
+    return deleted.status === "failed"
+      ? refused(deleted.code, "retirement")
+      : ready(null, false);
   }
 
   const read = await readMaterial();
@@ -374,7 +436,9 @@ export async function createKeychainPartitionEncryption(
     if (initialInspection.zeroProof === null) return ready(read.key, false);
     const deleted = await deleteMaterial(initialInspection.zeroProof);
     read.key.fill(0);
-    return deleted.status === "failed" ? refused(deleted.code, true) : ready(null, false);
+    return deleted.status === "failed"
+      ? refused(deleted.code, "retirement")
+      : ready(null, false);
   }
   if (read.status === "missing") {
     return initialInspection.keychainDependents > 0 ? refused("item-not-found") : ready(null, false);

--- a/apps/desktop/tests/credential-backend-selection.test.ts
+++ b/apps/desktop/tests/credential-backend-selection.test.ts
@@ -91,14 +91,21 @@ function safeStorage(): CredentialEncryptionPort {
 
 interface RecordingTransport extends KeychainBindingTransport {
   readonly requests: KeychainBindingRequest[];
+  readonly allRequests: KeychainBindingRequest[];
 }
 
 function transportOf(...responses: readonly KeychainBindingResponse[]): RecordingTransport {
   const remaining = [...responses];
   const requests: KeychainBindingRequest[] = [];
+  const allRequests: KeychainBindingRequest[] = [];
   return {
     requests,
+    allRequests,
     send(request) {
+      allRequests.push(request);
+      if (request.op === "retry-created-key-rollback") {
+        return Promise.resolve({ ok: true, op: "retry-created-key-rollback" });
+      }
       requests.push(request);
       const next = remaining.shift();
       if (next === undefined) throw new Error("unexpected helper request");
@@ -740,7 +747,7 @@ describe("keychain failure mapping", () => {
       PROBE_OK,
       { ok: false, code: "item-not-found" },
       { ok: false, code: "item-not-found" },
-      { ok: false, code: "duplicate-item" },
+      { ok: false, code: "duplicate-item", creationRollbackPending: false },
     );
 
     const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();

--- a/apps/desktop/tests/desktop-credential-encryption.test.ts
+++ b/apps/desktop/tests/desktop-credential-encryption.test.ts
@@ -50,11 +50,30 @@ function safeStoragePort(): CredentialEncryptionPort {
 }
 
 function transportOf(...answers: readonly KeychainBindingResponse[]) {
+  return transportWithRollbackRetries(answers, []);
+}
+
+function transportWithRollbackRetries(
+  answers: readonly KeychainBindingResponse[],
+  rollbackAnswers: readonly KeychainBindingResponse[],
+) {
   const requests: KeychainBindingRequest[] = [];
+  const allRequests: KeychainBindingRequest[] = [];
   const queue = [...answers];
+  const rollbackQueue = [...rollbackAnswers];
   return {
     requests,
-    send: vi.fn(async (request: KeychainBindingRequest) => {
+    allRequests,
+    send: vi.fn(async (request: KeychainBindingRequest): Promise<KeychainBindingResponse> => {
+      allRequests.push(request);
+      if (request.op === "retry-created-key-rollback") {
+        return (
+          rollbackQueue.shift() ?? {
+            ok: true,
+            op: "retry-created-key-rollback",
+          }
+        );
+      }
       requests.push(request);
       return queue.shift() ?? ({ ok: false, code: "unknown" } as KeychainBindingResponse);
     }),
@@ -593,6 +612,74 @@ describe("desktop credential encryption startup", () => {
       "probe",
       "read-key",
     ]);
+  });
+
+  it("keeps failed creation unavailable until exact rollback succeeds", async () => {
+    const replacement = randomBytes(KEY.length);
+    const transport = transportWithRollbackRetries(
+      [
+        PROBE_OK,
+        { ok: false, code: "item-not-found" },
+        { ok: false, code: "item-not-found" },
+        {
+          ok: false,
+          code: "unreadable-item",
+          creationRollbackPending: true,
+        },
+        PROBE_OK,
+        PROBE_OK,
+        { ok: false, code: "item-not-found" },
+        { ok: false, code: "item-not-found" },
+        { ok: true, op: "create-key", key: replacement },
+      ],
+      [
+        { ok: true, op: "retry-created-key-rollback" },
+        { ok: false, code: "keychain-locked" },
+        { ok: true, op: "retry-created-key-rollback" },
+        { ok: true, op: "retry-created-key-rollback" },
+      ],
+    );
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({ createTransport: () => transport, serializeEnvelopeMutation }),
+    );
+
+    await serializeEnvelopeMutation((proof) => prepared.prepareEnvelopeWrite(proof));
+    expect(prepared.selection).toMatchObject({
+      status: "refused",
+      code: "unreadable-item",
+      keyCleanupDebt: "creation-rollback",
+      keyCleanupPending: true,
+    });
+    expect(prepared.encryption.isEncryptionAvailable()).toBe(false);
+    expect(() => prepared.encryption.encryptString("must-not-seal")).toThrow();
+
+    await expect(prepared.retryKeychain()).resolves.toMatchObject({
+      status: "refused",
+      keyCleanupDebt: "creation-rollback",
+      keyCleanupPending: true,
+    });
+    expect(transport.allRequests.at(-1)?.op).toBe("retry-created-key-rollback");
+    await expect(prepared.retryKeychain()).resolves.toMatchObject({ status: "keychain" });
+
+    await serializeEnvelopeMutation((proof) => prepared.prepareEnvelopeWrite(proof));
+    const sealed = prepared.encryption.encryptString("post-rollback-secret");
+    expect(prepared.encryption.decryptString(sealed)).toBe("post-rollback-secret");
+    expect(transport.allRequests.map((request) => request.op)).toEqual([
+      "probe",
+      "retry-created-key-rollback",
+      "read-key",
+      "read-key",
+      "create-key",
+      "probe",
+      "retry-created-key-rollback",
+      "probe",
+      "retry-created-key-rollback",
+      "read-key",
+      "read-key",
+      "create-key",
+    ]);
+    expect(transport.allRequests.some((request) => request.op === "delete-key")).toBe(false);
   });
 
   it("publishes encryption unavailable when a recovery inventory scan fails", async () => {

--- a/apps/desktop/tests/keychain-binding-native.integration.test.ts
+++ b/apps/desktop/tests/keychain-binding-native.integration.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   buildKeychainBinding,
+  KEYCHAIN_BINDING_CREATION_ROLLBACK_SOURCE,
   KEYCHAIN_BINDING_MINIMUM_MACOS,
   keychainBindingBuildPath,
   keychainBindingCompilerAvailable,
@@ -35,6 +36,7 @@ const alternatePartitionDescription = `<?xml version="1.0" encoding="UTF-8"?>
 </plist>`;
 let root = "";
 let parserHarness = "";
+let creationRollbackHarness = "";
 
 function plistDictionary(contents: string) {
   return `<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict>${contents}</dict></plist>`;
@@ -114,6 +116,29 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       if (compile.status !== 0 || compile.signal !== null) {
         throw new Error(compile.stderr || "partition description harness compilation failed");
       }
+      creationRollbackHarness = join(root, "creation-rollback-harness");
+      const creationRollbackCompile = spawnSync(
+        "xcrun",
+        [
+          "clang++",
+          join(root, "native/keychain-binding/creation-rollback-harness.cc"),
+          join(root, KEYCHAIN_BINDING_CREATION_ROLLBACK_SOURCE),
+          "-std=c++20",
+          "-O2",
+          "-arch",
+          "arm64",
+          `-mmacosx-version-min=${KEYCHAIN_BINDING_MINIMUM_MACOS}`,
+          "-o",
+          creationRollbackHarness,
+        ],
+        { encoding: "utf8", timeout: COMPILE_TIMEOUT_MS },
+      );
+      if (creationRollbackCompile.error !== undefined) throw creationRollbackCompile.error;
+      if (creationRollbackCompile.status !== 0 || creationRollbackCompile.signal !== null) {
+        throw new Error(
+          creationRollbackCompile.stderr || "creation rollback harness compilation failed",
+        );
+      }
     }, COMPILE_TIMEOUT_MS);
 
     afterAll(async () => {
@@ -124,20 +149,45 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       const transport = createKeychainBindingTransport({
         bindingPath: keychainBindingBuildPath(root),
       });
-      for (const op of ["probe", "read-key", "create-key", "delete-key"] as const) {
+      for (const op of [
+        "probe",
+        "read-key",
+        "create-key",
+        "retry-created-key-rollback",
+        "delete-key",
+      ] as const) {
         await expect(
           transport.send({ op, service: KEYCHAIN_CREDENTIAL_SERVICE_DEV }),
-        ).resolves.toEqual({ ok: false, code: "not-team-signed" });
+        ).resolves.toEqual(
+          op === "create-key"
+            ? { ok: false, code: "not-team-signed", creationRollbackPending: false }
+            : { ok: false, code: "not-team-signed" },
+        );
       }
     });
 
-    it("pins promptless persisted-key validation and secure erasure", async () => {
+    it("passes the deterministic creation rollback transaction harness", () => {
+      const result = spawnSync(creationRollbackHarness, [], {
+        encoding: "utf8",
+        timeout: COMPILE_TIMEOUT_MS,
+      });
+      if (result.error !== undefined) throw result.error;
+      expect(result.signal).toBeNull();
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+    });
+
+    it("pins promptless validation and exact-reference creation rollback", async () => {
       const source = await readFile(
         join(desktopRoot, "native/keychain-binding/keychain-binding.mm"),
         "utf8",
       );
+      const transactionSource = await readFile(
+        join(desktopRoot, KEYCHAIN_BINDING_CREATION_ROLLBACK_SOURCE),
+        "utf8",
+      );
       const readiness = source.slice(
-        source.indexOf("bool ReadyForKeychain"),
+        source.indexOf("const char *ReadinessFailure"),
         source.indexOf("napi_value Probe"),
       );
       const statusMapping = source.slice(
@@ -146,11 +196,23 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       );
       const creation = source.slice(
         source.indexOf("napi_value CreateKey"),
-        source.indexOf("napi_value DeleteKey"),
+        source.indexOf("napi_value RetryCreatedKeyRollback"),
+      );
+      const reading = source.slice(
+        source.indexOf("napi_value ReadKey"),
+        source.indexOf("napi_value CreateKey"),
       );
       const deletion = source.slice(
         source.indexOf("napi_value DeleteKey"),
         source.indexOf("NAPI_MODULE_INIT"),
+      );
+      const rollbackDeletion = source.slice(
+        source.indexOf("const char *DeleteCreatedItem"),
+        source.indexOf("void ReleaseCreatedRef"),
+      );
+      const finalizer = source.slice(
+        source.indexOf("void FinalizeBindingState"),
+        source.indexOf("const char *ReadinessFailure"),
       );
       const accessConstructionStart = source.indexOf("SecAccessRef MakeAccess");
       const accessConstruction = source.slice(
@@ -179,24 +241,47 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       expect(accessConstruction).toContain(
         "InspectAccess(access) != PartitionInspection::kPresent",
       );
-      expect(creation.indexOf("InspectPartition(")).toBeLessThan(
-        creation.indexOf("SecKeychainItemCopyContent"),
+      expect(reading.indexOf("RetryCreationRollback(")).toBeLessThan(
+        reading.indexOf("CopyDefaultKeychain"),
       );
-      expect(creation.indexOf("SecKeychainItemCopyContent")).toBeLessThan(
-        creation.indexOf("SecKeychainItemFreeContent"),
+      expect(creation.indexOf("RetryCreationRollback(")).toBeLessThan(
+        creation.indexOf("CopyDefaultKeychain"),
       );
-      expect(creation.indexOf("SecKeychainItemFreeContent")).toBeLessThan(
-        creation.indexOf("napi_create_buffer_copy"),
+      expect(creation).toContain("RunCreationRollbackTransaction(");
+      expect(creation).toContain("CreationFailure(env, result.code");
+      expect(source).toContain('"creationRollbackPending"');
+      expect(source).toContain('"retryCreatedKeyRollback"');
+      expect(transactionSource.indexOf("dependencies.inspect(")).toBeLessThan(
+        transactionSource.indexOf("dependencies.copyContent("),
       );
-      expect(creation).toContain("persistedLength == static_cast<UInt32>(material.size())");
-      expect(creation).toContain("timingsafe_bcmp");
-      expect(creation).not.toContain("SecItemDelete");
+      expect(transactionSource.indexOf("dependencies.freeContent(")).toBeLessThan(
+        transactionSource.indexOf("dependencies.createBuffer("),
+      );
+      expect(transactionSource.indexOf("dependencies.createBuffer(")).toBeLessThan(
+        transactionSource.indexOf("dependencies.publishBuffer("),
+      );
+      expect(transactionSource).toContain("dependencies.wipeBuffer(");
+      expect(transactionSource).toContain("dependencies.deleteExact(");
+      expect(transactionSource).not.toContain("SecItemDelete");
+      expect(transactionSource).not.toContain("SecItemCopyMatching");
+      expect(rollbackDeletion).toContain("SecKeychainItemDelete(");
+      expect(rollbackDeletion).not.toContain("SecItemDelete");
+      expect(finalizer).toContain("ReleaseCreationRollbackDebt(");
+      expect(finalizer).not.toContain("DeleteCreatedItem");
       expect(deletion).toContain("SecItemCopyMatching");
       expect(deletion).toContain("InspectPartition(item)");
       expect(deletion).toContain("SecKeychainItemDelete(item)");
+      expect(deletion).not.toContain("RetryCreationRollback");
+      expect(deletion.indexOf("state->creationDebt.pending")).toBeLessThan(
+        deletion.indexOf("CopyDefaultKeychain"),
+      );
       expect(deletion).not.toContain("SecItemDelete");
       expect(source).toContain("#define __STDC_WANT_LIB_EXT1__ 1");
-      expect(source).toContain("memset_s(material.data(), material.size(), 0, material.size())");
+      expect(source).toContain("memset_s(bytes, length, 0, length)");
+      expect(source).toContain("CFDataCreateWithBytesNoCopy(");
+      expect(source).toContain("kCFAllocatorNull");
+      expect(source).toContain("napi_set_instance_data(");
+      expect(source).toMatch(/napi_define_properties\([\s\S]*?\) != napi_ok/u);
       expect(source).not.toContain("explicit_bzero");
       expect(source).not.toContain("material.fill");
     });

--- a/apps/desktop/tests/keychain-binding.test.ts
+++ b/apps/desktop/tests/keychain-binding.test.ts
@@ -25,6 +25,43 @@ describe("keychain binding adapter", () => {
     expect(parseKeychainBindingResponse("create-key", { ok: true, key: randomBytes(16) })).toEqual({
       ok: false,
       code: "unknown",
+      creationRollbackPending: true,
+    });
+    expect(
+      parseKeychainBindingResponse("create-key", {
+        ok: false,
+        code: "unreadable-item",
+        creationRollbackPending: false,
+      }),
+    ).toEqual({
+      ok: false,
+      code: "unreadable-item",
+      creationRollbackPending: false,
+    });
+    expect(
+      parseKeychainBindingResponse("create-key", {
+        ok: false,
+        code: "unreadable-item",
+        creationRollbackPending: true,
+      }),
+    ).toEqual({
+      ok: false,
+      code: "unreadable-item",
+      creationRollbackPending: true,
+    });
+    for (const malformed of [
+      { ok: false, code: "unreadable-item" },
+      { ok: false, code: "unreadable-item", creationRollbackPending: "true" },
+    ]) {
+      expect(parseKeychainBindingResponse("create-key", malformed)).toEqual({
+        ok: false,
+        code: "unknown",
+        creationRollbackPending: true,
+      });
+    }
+    expect(parseKeychainBindingResponse("retry-created-key-rollback", { ok: true })).toEqual({
+      ok: true,
+      op: "retry-created-key-rollback",
     });
     expect(parseKeychainBindingResponse("delete-key", { ok: true, deleted: false })).toEqual({
       ok: true,
@@ -43,6 +80,7 @@ describe("keychain binding adapter", () => {
       probe: vi.fn(() => ({ ok: true, teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER })),
       readKey: vi.fn(() => ({ ok: true, key })),
       createKey: vi.fn(() => ({ ok: true, key })),
+      retryCreatedKeyRollback: vi.fn(() => ({ ok: true })),
       deleteKey: vi.fn(() => ({ ok: true, deleted: true })),
     };
     const loadBinding = vi.fn(() => binding);
@@ -57,8 +95,39 @@ describe("keychain binding adapter", () => {
     await expect(
       transport.send({ op: "read-key", service: KEYCHAIN_CREDENTIAL_SERVICE }),
     ).resolves.toEqual({ ok: true, op: "read-key", key });
+    await expect(
+      transport.send({
+        op: "retry-created-key-rollback",
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+      }),
+    ).resolves.toEqual({ ok: true, op: "retry-created-key-rollback" });
     expect(loadBinding).toHaveBeenCalledOnce();
     expect(binding.readKey).toHaveBeenCalledWith(KEYCHAIN_CREDENTIAL_SERVICE);
+    expect(binding.retryCreatedKeyRollback).toHaveBeenCalledWith(KEYCHAIN_CREDENTIAL_SERVICE);
+  });
+
+  it("fails closed when native creation throws", async () => {
+    const binding = {
+      probe: vi.fn(() => ({ ok: true, teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER })),
+      readKey: vi.fn(() => ({ ok: false, code: "item-not-found" })),
+      createKey: vi.fn(() => {
+        throw new Error("synthetic creation failure");
+      }),
+      retryCreatedKeyRollback: vi.fn(() => ({ ok: true })),
+      deleteKey: vi.fn(() => ({ ok: true, deleted: true })),
+    };
+    const transport = createKeychainBindingTransport({
+      bindingPath: "/synthetic/keychain-binding.node",
+      loadBinding: () => binding,
+    });
+
+    await expect(
+      transport.send({ op: "create-key", service: KEYCHAIN_CREDENTIAL_SERVICE }),
+    ).resolves.toEqual({
+      ok: false,
+      code: "unknown",
+      creationRollbackPending: true,
+    });
   });
 
   it("maps missing, replaced, and wrong-shape native modules to unknown", async () => {
@@ -71,6 +140,7 @@ describe("keychain binding adapter", () => {
         probe: () => ({ ok: true, teamIdentifier: "OTHERTEAM" }),
         readKey: () => ({ ok: true, key: Buffer.alloc(KEYCHAIN_KEY_BYTES) }),
         createKey: () => ({ ok: true, key: Buffer.alloc(KEYCHAIN_KEY_BYTES) }),
+        retryCreatedKeyRollback: () => ({ ok: true }),
         deleteKey: () => ({ ok: true, deleted: true }),
       }),
     ]) {

--- a/apps/desktop/tests/keychain-credential-encryption.test.ts
+++ b/apps/desktop/tests/keychain-credential-encryption.test.ts
@@ -41,14 +41,31 @@ const serializePreparedEncryption = createCredentialEnvelopeMutationLock();
 
 interface RecordingTransport extends KeychainBindingTransport {
   readonly requests: KeychainBindingRequest[];
+  readonly allRequests: KeychainBindingRequest[];
 }
 
 function transportOf(...responses: readonly KeychainBindingResponse[]): RecordingTransport {
+  return transportWithRollbackRetries(responses, []);
+}
+
+function transportWithRollbackRetries(
+  responses: readonly KeychainBindingResponse[],
+  rollbackResponses: readonly KeychainBindingResponse[],
+): RecordingTransport {
   const remaining = [...responses];
+  const remainingRollback = [...rollbackResponses];
   const requests: KeychainBindingRequest[] = [];
+  const allRequests: KeychainBindingRequest[] = [];
   return {
     requests,
+    allRequests,
     send(request) {
+      allRequests.push(request);
+      if (request.op === "retry-created-key-rollback") {
+        return Promise.resolve(
+          remainingRollback.shift() ?? { ok: true, op: "retry-created-key-rollback" },
+        );
+      }
       requests.push(request);
       const next = remaining.shift();
       if (next === undefined) throw new Error("unexpected helper request");
@@ -357,6 +374,113 @@ describe("keychain partition backend", () => {
     ).toBe(true);
   });
 
+  it("retries failed creation through exact rollback before another census or read", async () => {
+    const replacement = storedKey();
+    const transport = transportWithRollbackRetries(
+      [
+        PROBE_OK,
+        { ok: false, code: "item-not-found" },
+        { ok: false, code: "item-not-found" },
+        {
+          ok: false,
+          code: "unreadable-item",
+          creationRollbackPending: true,
+        },
+        { ok: false, code: "item-not-found" },
+        { ok: true, op: "create-key", key: replacement.encoded },
+      ],
+      [
+        { ok: true, op: "retry-created-key-rollback" },
+        { ok: false, code: "keychain-locked" },
+        { ok: true, op: "retry-created-key-rollback" },
+      ],
+    );
+    const inspect = automaticRetirementInspector({
+      deletionBlockers: 0,
+      keychainDependents: 0,
+    });
+    let inspections = 0;
+    const serialize = createCredentialEnvelopeMutationLock();
+    const result = await serialize((lockProof) =>
+      createKeychainPartitionEncryption({
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+        inspectAutomaticRetirement: async (proof) => {
+          inspections += 1;
+          return await inspect(proof);
+        },
+        lockProof,
+      }),
+    );
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await expect(serialize((proof) => result.prepareKey(proof))).resolves.toEqual({
+      status: "failed",
+      code: "unreadable-item",
+      keyCleanupDebt: "creation-rollback",
+    });
+    expect(result.encryption.isEncryptionAvailable()).toBe(false);
+    expect(() => result.encryption.encryptString("must-not-seal")).toThrow(
+      KeychainEncryptionError,
+    );
+    const inspectionsBeforeRetry = inspections;
+    await expect(serialize((proof) => result.prepareKey(proof))).resolves.toEqual({
+      status: "failed",
+      code: "keychain-locked",
+      keyCleanupDebt: "creation-rollback",
+    });
+    expect(inspections).toBe(inspectionsBeforeRetry);
+    expect(transport.allRequests.at(-1)?.op).toBe("retry-created-key-rollback");
+
+    await expect(serialize((proof) => result.prepareKey(proof))).resolves.toEqual({
+      status: "ready",
+    });
+    expect(transport.allRequests.map((request) => request.op)).toEqual([
+      "probe",
+      "retry-created-key-rollback",
+      "read-key",
+      "read-key",
+      "create-key",
+      "retry-created-key-rollback",
+      "retry-created-key-rollback",
+      "read-key",
+      "create-key",
+    ]);
+    expect(transport.allRequests.some((request) => request.op === "delete-key")).toBe(false);
+    expect(result.encryption.isEncryptionAvailable()).toBe(true);
+  });
+
+  it("does not record creation rollback debt after confirmed cleanup", async () => {
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: false, code: "item-not-found" },
+      { ok: false, code: "item-not-found" },
+      {
+        ok: false,
+        code: "unreadable-item",
+        creationRollbackPending: false,
+      },
+    );
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+      envelopeCensus: { deletionBlockers: 0, keychainDependents: 0 },
+    });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await expect(
+      serializePreparedEncryption((proof) => result.prepareKey(proof)),
+    ).resolves.toEqual({
+      status: "failed",
+      code: "unreadable-item",
+    });
+    expect(transport.requests.some((request) => request.op === "retry-created-key-rollback")).toBe(
+      false,
+    );
+  });
+
   it("deletes a readable orphan but defers replacement until a write", async () => {
     const { encoded } = storedKey();
     const transport = transportOf(
@@ -416,7 +540,7 @@ describe("keychain partition backend", () => {
       PROBE_OK,
       { ok: false, code: "item-not-found" },
       { ok: false, code: "item-not-found" },
-      { ok: false, code: "duplicate-item" },
+      { ok: false, code: "duplicate-item", creationRollbackPending: false },
     );
     const result = await createEncryption({
       transport,
@@ -444,7 +568,11 @@ describe("keychain partition backend", () => {
       transport,
       service: KEYCHAIN_CREDENTIAL_SERVICE,
     });
-    expect(result).toEqual({ status: "unsupported", code: "not-team-signed" });
+    expect(result).toEqual({
+      status: "unsupported",
+      code: "not-team-signed",
+      keyCleanupDebt: "none",
+    });
     expect(transport.requests.map((request) => request.op)).toEqual(["probe"]);
   });
 
@@ -643,6 +771,7 @@ describe("keychain partition backend", () => {
     await expect(serialize((proof) => result.prepareKey(proof))).resolves.toEqual({
       status: "failed",
       code: "unknown",
+      keyCleanupDebt: "retirement",
     });
     expect(transport.requests.map((request) => request.op)).toEqual([
       "probe",

--- a/apps/desktop/tests/keychain-key-lifetime.test.ts
+++ b/apps/desktop/tests/keychain-key-lifetime.test.ts
@@ -104,11 +104,15 @@ async function keychainEncryption(): Promise<CredentialEncryptionPort> {
   const serialize = createCredentialEnvelopeMutationLock();
   const result = await serialize((lockProof) =>
     createKeychainPartitionEncryption({
-      transport: transportOf(PROBE_OK, {
-        ok: true,
-        op: "read-key",
-        key: randomBytes(KEYCHAIN_KEY_BYTES),
-      }),
+      transport: transportOf(
+        PROBE_OK,
+        { ok: true, op: "retry-created-key-rollback" },
+        {
+          ok: true,
+          op: "read-key",
+          key: randomBytes(KEYCHAIN_KEY_BYTES),
+        },
+      ),
       service: KEYCHAIN_CREDENTIAL_SERVICE,
       inspectAutomaticRetirement: async () => ({
         status: "inspected",


### PR DESCRIPTION
## Summary

- Roll back only the exact Keychain item returned by the current successful `SecItemAdd` when later validation or response construction fails.
- Retain failed exact rollback as typed `creation-rollback` debt and retry it before any read, create, census, or retirement work.
- Keep encryption unavailable while creation debt survives.
- Compile one shared native transaction core into production and a deterministic failure harness.
- Add the desktop patch changeset.

## Safety

- Creation rollback never performs a service/account query.
- Existing automatic retirement remains gated by the shared-lock durable cross-vault zero proof.
- Process-exit rollback debt remains an explicit external-recovery residual; it does not authorize broad deletion.
- Generated material, copied Keychain content, and failed JavaScript buffers are erased.

## Verification

- Native binding build passed.
- Focused rollback and lifetime suites passed: 6 files, 128 tests.
- `pnpm check` passed with 20 existing warnings and zero errors.
- `pnpm test` passed: 618 files and 9,780 tests; 5 files and 15 tests skipped.
- Changeset status reports `@enduragent/desktop` patch.
- Fresh read-only skeptics passed 10 of 10 native criteria and 11 of 11 TypeScript lifecycle criteria with no actionable P0-P3 findings.

## Limits

- No numeric limits were added or changed.
