### PR TITLE
fix: preserve keychain cleanup debt

### DIFF
--- a/apps/desktop/src/main/credential-backend-selection.ts
+++ b/apps/desktop/src/main/credential-backend-selection.ts
@@ -120,7 +120,10 @@ async function selectMacCredentialBackend(
     };
   }
   if (keychain.status !== "ready") {
-    const reason = keychainFailureRefusal(keychain.code, deletionBlockers > 0);
+    const reason =
+      keychain.keyCleanupDebt === "none"
+        ? keychainFailureRefusal(keychain.code, deletionBlockers > 0)
+        : "encryption-unavailable";
     return {
       status: "refused",
       encryption: createRefusingKeychainEncryption(

--- a/apps/desktop/src/main/desktop-credential-encryption.ts
+++ b/apps/desktop/src/main/desktop-credential-encryption.ts
@@ -230,6 +230,15 @@ export async function prepareDesktopCredentialEncryption(
       proof: CredentialEnvelopeLockProof,
     ): Promise<KeychainKeyDeletion> {
       if (options.location.platform !== "darwin") return { status: "already-absent" };
+      if (keyCleanupDebt === "creation-rollback") {
+        const reconciled = await refreshSelection(proof);
+        if (reconciled.status !== "keychain") {
+          return {
+            status: "failed",
+            code: reconciled.status === "refused" ? reconciled.code : "unknown",
+          };
+        }
+      }
       const deleted =
         selection.status === "keychain"
           ? await selection.deleteKeyForReset(proof)
@@ -243,7 +252,10 @@ export async function prepareDesktopCredentialEncryption(
               };
             });
       if (deleted.status === "failed") {
-        transitionToUnavailable(deleted.code, "retirement");
+        transitionToUnavailable(
+          deleted.code,
+          keyCleanupDebt === "creation-rollback" ? "creation-rollback" : "retirement",
+        );
         return deleted;
       }
       keyCleanupDebt = "none";

--- a/apps/desktop/tests/desktop-credential-encryption.test.ts
+++ b/apps/desktop/tests/desktop-credential-encryption.test.ts
@@ -634,8 +634,7 @@ describe("desktop credential encryption startup", () => {
       ],
       [
         { ok: true, op: "retry-created-key-rollback" },
-        { ok: false, code: "keychain-locked" },
-        { ok: true, op: "retry-created-key-rollback" },
+        { ok: false, code: "item-not-found" },
         { ok: true, op: "retry-created-key-rollback" },
       ],
     );
@@ -656,9 +655,12 @@ describe("desktop credential encryption startup", () => {
 
     await expect(prepared.retryKeychain()).resolves.toMatchObject({
       status: "refused",
+      reason: "encryption-unavailable",
+      code: "item-not-found",
       keyCleanupDebt: "creation-rollback",
       keyCleanupPending: true,
     });
+    expect(prepared.encryption.isEncryptionAvailable()).toBe(false);
     expect(transport.allRequests.at(-1)?.op).toBe("retry-created-key-rollback");
     await expect(prepared.retryKeychain()).resolves.toMatchObject({ status: "keychain" });
 
@@ -678,6 +680,54 @@ describe("desktop credential encryption startup", () => {
       "read-key",
       "read-key",
       "create-key",
+    ]);
+    expect(transport.allRequests.some((request) => request.op === "delete-key")).toBe(false);
+  });
+
+  it("preserves exact creation rollback debt when explicit reset cannot reconcile it", async () => {
+    const transport = transportWithRollbackRetries(
+      [
+        PROBE_OK,
+        { ok: false, code: "item-not-found" },
+        { ok: false, code: "item-not-found" },
+        {
+          ok: false,
+          code: "unreadable-item",
+          creationRollbackPending: true,
+        },
+        PROBE_OK,
+      ],
+      [
+        { ok: true, op: "retry-created-key-rollback" },
+        { ok: false, code: "item-not-found" },
+      ],
+    );
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+    const prepared = await prepareDesktopCredentialEncryption(
+      options({ createTransport: () => transport, serializeEnvelopeMutation }),
+    );
+
+    await serializeEnvelopeMutation((proof) => prepared.prepareEnvelopeWrite(proof));
+    await expect(
+      serializeEnvelopeMutation((proof) => prepared.deleteKeyForCredentialReset(proof)),
+    ).resolves.toEqual({ status: "failed", code: "item-not-found" });
+
+    expect(prepared.selection).toMatchObject({
+      status: "refused",
+      reason: "encryption-unavailable",
+      code: "item-not-found",
+      keyCleanupDebt: "creation-rollback",
+      keyCleanupPending: true,
+    });
+    expect(prepared.encryption.isEncryptionAvailable()).toBe(false);
+    expect(transport.allRequests.map((request) => request.op)).toEqual([
+      "probe",
+      "retry-created-key-rollback",
+      "read-key",
+      "read-key",
+      "create-key",
+      "probe",
+      "retry-created-key-rollback",
     ]);
     expect(transport.allRequests.some((request) => request.op === "delete-key")).toBe(false);
   });


### PR DESCRIPTION
## Summary
- keep any pending Keychain cleanup debt non-writable
- resolve exact creation rollback before reset can use generic deletion
- preserve creation-debt provenance when reconciliation fails

## Verification
- focused desktop encryption tests: 93 passed
- final changed suite: 38 passed
- root pnpm check: passed with 20 existing warnings and zero errors
- three fresh read-only state-machine reviews: no P0-P3 findings

No numeric limits changed.