### PR TITLE
test(desktop): cover credential reset orchestration

### DIFF
--- a/apps/desktop/src/main/credential-reset-orchestration.ts
+++ b/apps/desktop/src/main/credential-reset-orchestration.ts
@@ -1,0 +1,108 @@
+import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
+import {
+  resetEncryptedCredentialStorage,
+  type EncryptedCredentialResetResult,
+  type ResetEncryptedCredentialStorageOptions,
+} from "./credential-reset.js";
+import type {
+  CredentialEnvelopeLockProof,
+  SerializeCredentialEnvelopeMutation,
+  SerializeCredentialMutation,
+} from "./credential-envelope-lock.js";
+import type { DesktopManagedCredential } from "./credential-runtime.js";
+import type { CredentialRuntimeState, DesktopCredentialSlot } from "./credential-vault.js";
+import type { KeychainKeyDeletion } from "./keychain-credential-encryption.js";
+import type { DesktopCredentialResetResult } from "./onboarding-ipc.js";
+
+export interface DesktopCredentialResetRuntimeBinding {
+  readonly authority: {
+    getRuntimeConfig(): Promise<RuntimeConfigSnapshot>;
+  };
+  readonly credentials: {
+    clearCredential(credential: DesktopManagedCredential): Promise<unknown>;
+  };
+}
+
+export interface DesktopCredentialResetLifecycleSnapshot {
+  readonly status: string;
+  readonly generation?: number;
+}
+
+type ResetEncryptedCredentialStorage = (
+  options: ResetEncryptedCredentialStorageOptions,
+) => Promise<EncryptedCredentialResetResult>;
+
+export interface CreateDesktopCredentialResetOptions {
+  readonly serializeCredentialMutation: SerializeCredentialMutation;
+  readonly currentRuntimeBinding: () => DesktopCredentialResetRuntimeBinding | undefined;
+  readonly lifecycleSnapshot: () => DesktopCredentialResetLifecycleSnapshot | undefined;
+  readonly managedModelCredentials: ReadonlySet<string>;
+  readonly resetTelegramRuntime: () => Promise<boolean>;
+  readonly configDir: string;
+  readonly deleteChatGptProfile: (configDir: string) => void;
+  readonly credentialRoot: string;
+  readonly telegramRoot: string;
+  readonly serializeEnvelopeMutation: SerializeCredentialEnvelopeMutation;
+  readonly deleteKeyForCredentialReset: (
+    proof: CredentialEnvelopeLockProof,
+  ) => Promise<KeychainKeyDeletion>;
+  readonly credentialRuntimeState: Map<DesktopCredentialSlot, CredentialRuntimeState>;
+  readonly resetEncryptedCredentialStorage?: ResetEncryptedCredentialStorage;
+}
+
+export function createDesktopCredentialReset(
+  options: CreateDesktopCredentialResetOptions,
+): () => Promise<DesktopCredentialResetResult> {
+  const resetStorage = options.resetEncryptedCredentialStorage ?? resetEncryptedCredentialStorage;
+  return (): Promise<DesktopCredentialResetResult> =>
+    options.serializeCredentialMutation(async (): Promise<DesktopCredentialResetResult> => {
+      const binding = options.currentRuntimeBinding();
+      const lifecycleState = options.lifecycleSnapshot();
+      if (binding === undefined || lifecycleState?.status !== "ready") {
+        return { status: "refused", reason: "runtime-unavailable" };
+      }
+      try {
+        const snapshot = await binding.authority.getRuntimeConfig();
+        const activeCredentials: DesktopManagedCredential[] = [];
+        if (
+          snapshot.llm.credential_configured &&
+          options.managedModelCredentials.has(snapshot.llm.provider)
+        ) {
+          activeCredentials.push(snapshot.llm.provider as DesktopManagedCredential);
+        }
+        if (snapshot.intervals.credential_configured) activeCredentials.push("intervals-icu");
+        for (const credential of activeCredentials) {
+          await binding.credentials.clearCredential(credential);
+        }
+        if (!(await options.resetTelegramRuntime())) {
+          return { status: "refused", reason: "runtime-unavailable" };
+        }
+        const currentLifecycleState = options.lifecycleSnapshot();
+        if (
+          options.currentRuntimeBinding() !== binding ||
+          currentLifecycleState?.status !== "ready" ||
+          currentLifecycleState.generation !== lifecycleState.generation
+        ) {
+          return { status: "refused", reason: "runtime-unavailable" };
+        }
+      } catch {
+        return { status: "refused", reason: "runtime-unavailable" };
+      }
+      try {
+        options.deleteChatGptProfile(options.configDir);
+        const reset = await resetStorage({
+          credentialRoot: options.credentialRoot,
+          telegramRoot: options.telegramRoot,
+          serializeEnvelopeMutation: options.serializeEnvelopeMutation,
+          deleteKey: options.deleteKeyForCredentialReset,
+        });
+        if (reset.status !== "reset") {
+          return { status: "refused", reason: "storage-failed" };
+        }
+        options.credentialRuntimeState.clear();
+        return reset;
+      } catch {
+        return { status: "refused", reason: "storage-failed" };
+      }
+    });
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -65,7 +65,6 @@ import {
   createCredentialRuntimeApplication,
   intervalsAthleteIdForOwnership,
   readSelectedLlmProvider,
-  type DesktopManagedCredential,
   type CredentialRuntimeApplication,
   type RuntimeConfigurationAuthority,
 } from "./credential-runtime.js";
@@ -88,7 +87,7 @@ import {
   desktopCredentialRecoveryFailureState,
   prepareDesktopCredentialEncryption,
 } from "./desktop-credential-encryption.js";
-import { resetEncryptedCredentialStorage } from "./credential-reset.js";
+import { createDesktopCredentialReset } from "./credential-reset-orchestration.js";
 import { probePackagedKeychainBackendSelection } from "./keychain-backend-selection-probe.js";
 import {
   DesktopDaemonLifecycle,
@@ -977,56 +976,21 @@ async function runDesktop(): Promise<void> {
       ...DESKTOP_CREDENTIAL_SLOTS.filter((slot) => slot !== "intervals-icu"),
       CHATGPT_PROFILE_NAME,
     ]);
-    const resetAllCredentials = (): Promise<DesktopCredentialResetResult> =>
-      serializeCredentialMutation(async () => {
-        const binding = activeRuntimeBinding;
-        const lifecycleState = daemonLifecycle?.snapshot();
-        if (binding === undefined || lifecycleState?.status !== "ready") {
-          return { status: "refused", reason: "runtime-unavailable" };
-        }
-        try {
-          const snapshot = await binding.authority.getRuntimeConfig();
-          const activeCredentials: DesktopManagedCredential[] = [];
-          if (
-            snapshot.llm.credential_configured &&
-            managedModelCredentials.has(snapshot.llm.provider)
-          ) {
-            activeCredentials.push(snapshot.llm.provider as DesktopManagedCredential);
-          }
-          if (snapshot.intervals.credential_configured) activeCredentials.push("intervals-icu");
-          for (const credential of activeCredentials) {
-            await binding.credentials.clearCredential(credential);
-          }
-          if (!(await telegramCoordinator.resetRuntimeForCredentialReset())) {
-            return { status: "refused", reason: "runtime-unavailable" };
-          }
-          const currentLifecycleState = daemonLifecycle?.snapshot();
-          if (
-            activeRuntimeBinding !== binding ||
-            currentLifecycleState?.status !== "ready" ||
-            currentLifecycleState.generation !== lifecycleState.generation
-          ) {
-            return { status: "refused", reason: "runtime-unavailable" };
-          }
-        } catch {
-          return { status: "refused", reason: "runtime-unavailable" };
-        }
-        try {
-          deleteChatGptProfile(configDir);
-          const reset = await resetEncryptedCredentialStorage({
-            credentialRoot,
-            telegramRoot: telegramCredentialRoot,
-            serializeEnvelopeMutation: serializeCredentialEnvelopeMutation,
-            deleteKey: (proof) => credentialEncryption.deleteKeyForCredentialReset(proof),
-          });
-          if (reset.status !== "reset") {
-            return { status: "refused", reason: "storage-failed" };
-          }
-          credentialRuntimeState.clear();
-          return reset;
-        } catch {
-          return { status: "refused", reason: "storage-failed" };
-        }
+    const resetAllCredentials: () => Promise<DesktopCredentialResetResult> =
+      createDesktopCredentialReset({
+        serializeCredentialMutation,
+        currentRuntimeBinding: () => activeRuntimeBinding,
+        lifecycleSnapshot: () => daemonLifecycle?.snapshot(),
+        managedModelCredentials,
+        resetTelegramRuntime: () => telegramCoordinator.resetRuntimeForCredentialReset(),
+        configDir,
+        deleteChatGptProfile,
+        credentialRoot,
+        telegramRoot: telegramCredentialRoot,
+        serializeEnvelopeMutation: serializeCredentialEnvelopeMutation,
+        deleteKeyForCredentialReset: (proof) =>
+          credentialEncryption.deleteKeyForCredentialReset(proof),
+        credentialRuntimeState,
       });
     const claudeCli = createClaudeCliStatus({
       settings: () => readClaudeCliSettings({ configPath: join(configDir, "config.yaml") }),

--- a/apps/desktop/tests/credential-reset-orchestration.test.ts
+++ b/apps/desktop/tests/credential-reset-orchestration.test.ts
@@ -1,0 +1,322 @@
+import { readFile } from "node:fs/promises";
+import type { RuntimeConfigSnapshot } from "@enduragent/coach-contract";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  CredentialEnvelopeLockProof,
+  SerializeCredentialEnvelopeMutation,
+  SerializeCredentialMutation,
+} from "../src/main/credential-envelope-lock.js";
+import {
+  createDesktopCredentialReset,
+  type DesktopCredentialResetLifecycleSnapshot,
+  type DesktopCredentialResetRuntimeBinding,
+} from "../src/main/credential-reset-orchestration.js";
+import type {
+  EncryptedCredentialResetResult,
+  ResetEncryptedCredentialStorageOptions,
+} from "../src/main/credential-reset.js";
+import type { DesktopManagedCredential } from "../src/main/credential-runtime.js";
+import type {
+  CredentialRuntimeState,
+  DesktopCredentialSlot,
+} from "../src/main/credential-vault.js";
+import type { KeychainKeyDeletion } from "../src/main/keychain-credential-encryption.js";
+
+function runtimeSnapshot(): RuntimeConfigSnapshot {
+  return {
+    schemaVersion: 3,
+    llm: {
+      provider: "anthropic",
+      model: "synthetic-model",
+      credential_configured: true,
+    },
+    intervals: {
+      athlete_id: "synthetic-athlete",
+      credential_configured: true,
+      managedByEnvironment: { athleteId: false },
+    },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+      managedByEnvironment: {
+        historyTokenBudgetRatio: false,
+        idleMinutes: false,
+        dailyResetHour: false,
+        resetArchiveRetentionDays: false,
+        timezone: false,
+      },
+    },
+  };
+}
+
+function harness(
+  options: {
+    readonly serializeCredentialMutation?: SerializeCredentialMutation;
+  } = {},
+) {
+  const events: string[] = [];
+  const proof = {} as CredentialEnvelopeLockProof;
+  const getRuntimeConfig = vi.fn(async () => runtimeSnapshot());
+  const clearCredential = vi.fn(async (credential: DesktopManagedCredential) => {
+    events.push(`clear:${credential}`);
+    return "cleared" as const;
+  });
+  const initialBinding: DesktopCredentialResetRuntimeBinding = {
+    authority: { getRuntimeConfig },
+    credentials: { clearCredential },
+  };
+  let binding: DesktopCredentialResetRuntimeBinding | undefined = initialBinding;
+  let lifecycle: DesktopCredentialResetLifecycleSnapshot | undefined = {
+    status: "ready",
+    generation: 1,
+  };
+  const resetTelegramRuntime = vi.fn(async () => {
+    events.push("telegram-reset");
+    return true;
+  });
+  const deleteChatGptProfile = vi.fn(() => {
+    events.push("chatgpt-profile-delete");
+  });
+  const deleteKeyForCredentialReset = vi.fn(async (): Promise<KeychainKeyDeletion> => {
+    events.push("key-delete");
+    return { status: "deleted" };
+  });
+  const serializeEnvelopeMutation: SerializeCredentialEnvelopeMutation = (operation) => {
+    events.push("envelope-mutation");
+    return operation(proof);
+  };
+  const resetEncryptedCredentialStorage = vi.fn(
+    async (
+      options: ResetEncryptedCredentialStorageOptions,
+    ): Promise<EncryptedCredentialResetResult> => {
+      events.push("storage-reset");
+      return await options.serializeEnvelopeMutation(async (currentProof) => {
+        const deletion = await options.deleteKey(currentProof);
+        return { status: "reset", keyCleanupPending: deletion.status === "failed" };
+      });
+    },
+  );
+  const credentialRuntimeState = new Map<DesktopCredentialSlot, CredentialRuntimeState>([
+    ["anthropic", "active"],
+  ]);
+  const reset = createDesktopCredentialReset({
+    serializeCredentialMutation:
+      options.serializeCredentialMutation ?? ((operation) => operation()),
+    currentRuntimeBinding: () => binding,
+    lifecycleSnapshot: () => lifecycle,
+    managedModelCredentials: new Set(["anthropic", "openai"]),
+    resetTelegramRuntime,
+    configDir: "/synthetic/config",
+    deleteChatGptProfile,
+    credentialRoot: "/synthetic/credentials",
+    telegramRoot: "/synthetic/telegram",
+    serializeEnvelopeMutation,
+    deleteKeyForCredentialReset,
+    credentialRuntimeState,
+    resetEncryptedCredentialStorage,
+  });
+  return {
+    events,
+    proof,
+    initialBinding,
+    getRuntimeConfig,
+    clearCredential,
+    resetTelegramRuntime,
+    deleteChatGptProfile,
+    deleteKeyForCredentialReset,
+    serializeEnvelopeMutation,
+    resetEncryptedCredentialStorage,
+    credentialRuntimeState,
+    reset,
+    setBinding(next: DesktopCredentialResetRuntimeBinding | undefined) {
+      binding = next;
+    },
+    setLifecycle(next: DesktopCredentialResetLifecycleSnapshot | undefined) {
+      lifecycle = next;
+    },
+  };
+}
+
+describe("desktop credential reset orchestration", () => {
+  it("refuses an unavailable runtime binding without mutating credentials", async () => {
+    const subject = harness();
+    subject.setBinding(undefined);
+
+    await expect(subject.reset()).resolves.toEqual({
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+
+    expect(subject.getRuntimeConfig).not.toHaveBeenCalled();
+    expect(subject.clearCredential).not.toHaveBeenCalled();
+    expect(subject.resetTelegramRuntime).not.toHaveBeenCalled();
+    expect(subject.deleteChatGptProfile).not.toHaveBeenCalled();
+    expect(subject.resetEncryptedCredentialStorage).not.toHaveBeenCalled();
+    expect(subject.deleteKeyForCredentialReset).not.toHaveBeenCalled();
+    expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+  });
+
+  it("clears active model and Intervals credentials before resetting Telegram", async () => {
+    const subject = harness();
+
+    await expect(subject.reset()).resolves.toEqual({
+      status: "reset",
+      keyCleanupPending: false,
+    });
+
+    expect(subject.events).toEqual([
+      "clear:anthropic",
+      "clear:intervals-icu",
+      "telegram-reset",
+      "chatgpt-profile-delete",
+      "storage-reset",
+      "envelope-mutation",
+      "key-delete",
+    ]);
+  });
+
+  it("runs the reset only through the credential mutation serializer", async () => {
+    const serializerFailure = new Error("synthetic serializer refusal");
+    const serializeCredentialMutation: SerializeCredentialMutation = async () => {
+      throw serializerFailure;
+    };
+    const subject = harness({ serializeCredentialMutation });
+
+    await expect(subject.reset()).rejects.toBe(serializerFailure);
+
+    expect(subject.getRuntimeConfig).not.toHaveBeenCalled();
+    expect(subject.clearCredential).not.toHaveBeenCalled();
+    expect(subject.resetTelegramRuntime).not.toHaveBeenCalled();
+    expect(subject.resetEncryptedCredentialStorage).not.toHaveBeenCalled();
+  });
+
+  it.each(["false", "throw"] as const)(
+    "stops before local deletion when Telegram reset returns %s",
+    async (outcome) => {
+      const subject = harness();
+      subject.resetTelegramRuntime.mockImplementationOnce(async () => {
+        subject.events.push("telegram-reset");
+        if (outcome === "throw") throw new Error("synthetic Telegram failure");
+        return false;
+      });
+
+      await expect(subject.reset()).resolves.toEqual({
+        status: "refused",
+        reason: "runtime-unavailable",
+      });
+
+      expect(subject.deleteChatGptProfile).not.toHaveBeenCalled();
+      expect(subject.resetEncryptedCredentialStorage).not.toHaveBeenCalled();
+      expect(subject.deleteKeyForCredentialReset).not.toHaveBeenCalled();
+      expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+    },
+  );
+
+  it.each(["binding", "generation"] as const)(
+    "stops before durable deletion when the runtime %s changes after Telegram reset",
+    async (change) => {
+      const subject = harness();
+      subject.resetTelegramRuntime.mockImplementationOnce(async () => {
+        subject.events.push("telegram-reset");
+        if (change === "binding") {
+          subject.setBinding({ ...subject.initialBinding });
+        } else {
+          subject.setLifecycle({ status: "ready", generation: 2 });
+        }
+        return true;
+      });
+
+      await expect(subject.reset()).resolves.toEqual({
+        status: "refused",
+        reason: "runtime-unavailable",
+      });
+
+      expect(subject.deleteChatGptProfile).not.toHaveBeenCalled();
+      expect(subject.resetEncryptedCredentialStorage).not.toHaveBeenCalled();
+      expect(subject.deleteKeyForCredentialReset).not.toHaveBeenCalled();
+      expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+    },
+  );
+
+  it("maps durable storage reset failure to storage-failed", async () => {
+    const subject = harness();
+    subject.resetEncryptedCredentialStorage.mockResolvedValueOnce({ status: "failed" });
+
+    await expect(subject.reset()).resolves.toEqual({
+      status: "refused",
+      reason: "storage-failed",
+    });
+
+    expect(subject.deleteChatGptProfile).toHaveBeenCalledOnce();
+    expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+  });
+
+  it("returns reset with pending cleanup when Keychain deletion fails", async () => {
+    const subject = harness();
+    subject.deleteKeyForCredentialReset.mockResolvedValueOnce({
+      status: "failed",
+      code: "keychain-locked",
+    });
+
+    await expect(subject.reset()).resolves.toEqual({
+      status: "reset",
+      keyCleanupPending: true,
+    });
+
+    expect(subject.resetEncryptedCredentialStorage).toHaveBeenCalledOnce();
+    expect(subject.resetEncryptedCredentialStorage.mock.calls[0]![0].deleteKey).toBe(
+      subject.deleteKeyForCredentialReset,
+    );
+    expect(
+      subject.resetEncryptedCredentialStorage.mock.calls[0]![0].serializeEnvelopeMutation,
+    ).toBe(subject.serializeEnvelopeMutation);
+    expect(subject.deleteKeyForCredentialReset).toHaveBeenCalledWith(subject.proof);
+  });
+
+  it("clears runtime state only after durable storage reset succeeds", async () => {
+    const subject = harness();
+    let resolveStorage!: (result: { status: "reset"; keyCleanupPending: false }) => void;
+    let markStorageStarted!: () => void;
+    const storageStarted = new Promise<void>((resolve) => {
+      markStorageStarted = resolve;
+    });
+    const storageFinished = new Promise<{
+      status: "reset";
+      keyCleanupPending: false;
+    }>((resolve) => {
+      resolveStorage = resolve;
+    });
+    subject.resetEncryptedCredentialStorage.mockImplementationOnce(async () => {
+      markStorageStarted();
+      return await storageFinished;
+    });
+
+    const reset = subject.reset();
+    await storageStarted;
+    expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+
+    resolveStorage({ status: "reset", keyCleanupPending: false });
+    await expect(reset).resolves.toEqual({ status: "reset", keyCleanupPending: false });
+    expect(subject.credentialRuntimeState.size).toBe(0);
+  });
+
+  it("wires the shared envelope lock and reset-only Keychain deletion in production", async () => {
+    const source = await readFile(new URL("../src/main/index.ts", import.meta.url), "utf8");
+    const start = source.indexOf("createDesktopCredentialReset({");
+    const end = source.indexOf("const claudeCli =", start);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const composition = source.slice(start, end);
+    expect(composition).toContain("serializeCredentialMutation,");
+    expect(composition).toContain(
+      "serializeEnvelopeMutation: serializeCredentialEnvelopeMutation,",
+    );
+    expect(composition).toMatch(
+      /deleteKeyForCredentialReset: \(proof\) =>\s+credentialEncryption\.deleteKeyForCredentialReset\(proof\)/u,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extract the global credential-reset orchestration into a directly testable dependency leaf.
- Pin Telegram refusal, runtime replacement, storage failure, cleanup-pending, and runtime-state ordering.
- Guard production wiring to the shared mutation locks and reset-only Keychain deletion path.

## Verification

- `pnpm exec vitest run apps/desktop/tests/credential-reset-orchestration.test.ts apps/desktop/tests/credential-reset.test.ts apps/desktop/tests/desktop-credential-encryption.test.ts` — 54 passed.
- `pnpm --filter @enduragent/desktop check` — passed.
- `pnpm check` — passed with 20 existing warnings and 0 errors.
- Fresh read-only verification — 7/7 criteria passed with no P0–P3 findings.

## Limits

- None.
