### PR TITLE
fix(desktop): complete credential reset on Windows

### DIFF
--- a/.changeset/reliable-windows-credential-reset.md
+++ b/.changeset/reliable-windows-credential-reset.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: “Remove all credentials” now completes reliably on Windows.

--- a/apps/desktop/src/main/credential-reset.ts
+++ b/apps/desktop/src/main/credential-reset.ts
@@ -39,8 +39,9 @@ export function resetEncryptedCredentialStorage(
 ): Promise<EncryptedCredentialResetResult> {
   return options.serializeEnvelopeMutation(async (proof) => {
     const removeFile = options.removeFile ?? rm;
-    const syncCredentialDirectory = options.syncCredentialDirectory ?? syncDirectory;
     const platform = options.platform ?? process.platform;
+    const syncCredentialDirectory =
+      platform === "win32" ? undefined : (options.syncCredentialDirectory ?? syncDirectory);
     try {
       let bindings = await bindCredentialEnvelopeRoots(options, platform);
       for (const target of credentialEnvelopeTargets(options)) {
@@ -62,14 +63,16 @@ export function resetEncryptedCredentialStorage(
       }
       bindings = await refreshCredentialEnvelopeRootBindings(bindings);
       guardedRoots = guardedCredentialEnvelopeRoots(options, bindings);
-      for (const binding of [bindings.credentials, bindings.telegram]) {
-        if (binding.state === "missing") continue;
-        try {
-          await useBoundCredentialRoot(binding, platform, () =>
-            syncCredentialDirectory(binding.root),
-          );
-        } catch (error) {
-          if (!isMissingCredentialRootError(error)) throw error;
+      if (syncCredentialDirectory !== undefined) {
+        for (const binding of [bindings.credentials, bindings.telegram]) {
+          if (binding.state === "missing") continue;
+          try {
+            await useBoundCredentialRoot(binding, platform, () =>
+              syncCredentialDirectory(binding.root),
+            );
+          } catch (error) {
+            if (!isMissingCredentialRootError(error)) throw error;
+          }
         }
       }
       if ((await scanCredentialEnvelopes(guardedRoots)).deletionBlockers.length !== 0) {

--- a/apps/desktop/tests/credential-reset.test.ts
+++ b/apps/desktop/tests/credential-reset.test.ts
@@ -5,10 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCredentialEnvelopeMutationLock } from "../src/main/credential-envelope-lock.js";
 import { credentialEnvelopeTargets } from "../src/main/credential-envelope-inventory.js";
 import { resetEncryptedCredentialStorage } from "../src/main/credential-reset.js";
-import {
-  CREDENTIAL_DIRECTORY_MODE,
-  CREDENTIAL_FILE_MODE,
-} from "../src/main/credential-vault.js";
+import { CREDENTIAL_DIRECTORY_MODE, CREDENTIAL_FILE_MODE } from "../src/main/credential-vault.js";
 import {
   TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
   TELEGRAM_CREDENTIAL_FILE_MODE,
@@ -85,6 +82,37 @@ describe("encrypted credential reset", () => {
     }
   });
 
+  it("completes Windows reset without invoking POSIX directory sync", async () => {
+    const storage = await fixture();
+    const targets = credentialEnvelopeTargets(storage);
+    const credentialTarget = targets.find((target) => target.vault === "credentials")!;
+    const telegramTarget = targets.find((target) => target.vault === "telegram")!;
+    for (const target of [credentialTarget, telegramTarget]) {
+      await writeFile(join(target.root, target.fileName), Buffer.from("synthetic-envelope"));
+    }
+    const syncCredentialDirectory = vi.fn(async () => {
+      throw new Error("POSIX directory sync must not run on Windows");
+    });
+    const deleteKey = vi.fn(async () => ({ status: "deleted" as const }));
+
+    const result = await resetEncryptedCredentialStorage({
+      ...storage,
+      platform: "win32",
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      deleteKey,
+      syncCredentialDirectory,
+    });
+
+    expect(result).toEqual({ status: "reset", keyCleanupPending: false });
+    expect(syncCredentialDirectory).not.toHaveBeenCalled();
+    expect(deleteKey).toHaveBeenCalledOnce();
+    for (const target of [credentialTarget, telegramTarget]) {
+      await expect(readFile(join(target.root, target.fileName))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    }
+  });
+
   it("does not delete the shared key while any envelope survives", async () => {
     const storage = await fixture();
     const target = credentialEnvelopeTargets(storage)[0]!;
@@ -126,7 +154,9 @@ describe("encrypted credential reset", () => {
     expect(deleteKey).toHaveBeenCalledOnce();
   });
 
-  it("refuses both roots atomically when one root redirects outside its vault", async ({ skip }) => {
+  it("refuses both roots atomically when one root redirects outside its vault", async ({
+    skip,
+  }) => {
     const storage = await fixture();
     const credentialPath = join(storage.credentialRoot, "anthropic.bin");
     const externalRoot = join(storage.telegramRoot, "..", "external-telegram-vault");


### PR DESCRIPTION
## Summary

- skip POSIX directory durability calls during explicit credential reset on Windows
- keep both credential-vault files and the Keychain key in the same reset sequence
- cover the Windows reset path with a regression test

## Why

Windows does not support the POSIX directory `fsync` operation used after file deletion. Calling it made the explicit “Remove all credentials” flow fail after files were already removed.

## Verification

- `pnpm --filter @cycling-coach/desktop exec vitest run tests/credential-reset.test.ts` — 6 tests passed
- `pnpm --filter @cycling-coach/desktop check` — passed
- independent verification — 6/6 acceptance criteria, no P0–P3 findings
