### PR TITLE
fix(desktop): preserve safeStorage deletion state

### DIFF
--- a/.changeset/guard-cross-platform-credential-deletion.md
+++ b/.changeset/guard-cross-platform-credential-deletion.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Credential deletion on Windows and Linux now protects another athlete’s Telegram profile and keeps credentials that cannot be restored.

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -175,9 +175,7 @@ interface CredentialVaultOptions {
   readonly serializeCredentialMutation?: SerializeCredentialMutation;
   readonly serializeEnvelopeMutation?: SerializeCredentialEnvelopeMutation;
   readonly prepareEnvelopeWrite?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
-  readonly revalidateEnvelopeRemoval?: (
-    proof: CredentialEnvelopeLockProof,
-  ) => Promise<boolean>;
+  readonly revalidateEnvelopeRemoval?: (proof: CredentialEnvelopeLockProof) => Promise<boolean>;
   readonly observeEnvelopeRemoved?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
   readonly renameCredentialFile?: typeof rename;
   readonly removeCredentialFile?: typeof rm;
@@ -973,6 +971,8 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
           if (removalState === "blocked") {
             return { slot, status: "refused", reason: "storage-failed" };
           }
+          const runtimeStatus = runtimeState.get(slot);
+          const shouldClearRuntime = runtimeStatus === "active" || runtimeStatus === "failed";
           let credential: ReadCredential | undefined;
           if (removalState === "keychain-dependent") {
             if (encryptionRefusal(options.encryption, platform) !== undefined) {
@@ -1003,8 +1003,22 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
               return { slot, status: "refused", reason: "encryption-unavailable" };
             }
           }
-          const runtimeStatus = runtimeState.get(slot);
-          const shouldClearRuntime = runtimeStatus === "active" || runtimeStatus === "failed";
+          if (removalState === "unverified" && platform !== "darwin" && shouldClearRuntime) {
+            credential = await readSlot(slot);
+            if (credential.state === "missing") {
+              return { slot, status: "refused", reason: "not-found" };
+            }
+            if (credential.state !== "configured" || credential.value === undefined) {
+              return {
+                slot,
+                status: "refused",
+                reason:
+                  encryptionRefusal(options.encryption, platform) === undefined
+                    ? "storage-failed"
+                    : "encryption-unavailable",
+              };
+            }
+          }
           let runtimeCleared = false;
           if (shouldClearRuntime) {
             if (options.clearCredential === undefined) {

--- a/apps/desktop/src/main/telegram-credential-vault.ts
+++ b/apps/desktop/src/main/telegram-credential-vault.ts
@@ -169,9 +169,7 @@ export interface TelegramCredentialVaultOptions {
   readonly observeSecureStorageFailure?: TelegramSecureStorageObserver;
   readonly serializeEnvelopeMutation?: SerializeCredentialEnvelopeMutation;
   readonly prepareEnvelopeWrite?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
-  readonly revalidateEnvelopeRemoval?: (
-    proof: CredentialEnvelopeLockProof,
-  ) => Promise<boolean>;
+  readonly revalidateEnvelopeRemoval?: (proof: CredentialEnvelopeLockProof) => Promise<boolean>;
   readonly observeEnvelopeRemoved?: (proof: CredentialEnvelopeLockProof) => Promise<void>;
   readonly platform?: NodeJS.Platform;
   readonly openFile?: typeof open;
@@ -793,13 +791,16 @@ export function createTelegramCredentialVault(
     if (removalState === "blocked") {
       return { outcome: "refused", reason: "storage-failed" };
     }
-    if (removalState !== "keychain-dependent") {
+    if (removalState === "unverified" && platform === "darwin") {
       return { outcome: "authorized", keychainDependent: false };
     }
     const profile = await readProfile();
     if (profile.state === "missing") return { outcome: "refused", reason: "not-found" };
     if (profile.state === "wrong-home") {
       return { outcome: "refused", reason: "wrong-home" };
+    }
+    if (removalState === "unverified") {
+      return { outcome: "authorized", keychainDependent: false };
     }
     if (profile.state === "re-prompt") {
       if (profile.reason === "encryption-unavailable" || profile.reason === "unsafe-backend") {
@@ -992,9 +993,7 @@ export function createTelegramCredentialVault(
     preauthorizeProfileRemoval(): Promise<TelegramProfileRemovalAuthorizationResult> {
       return envelopeExclusive(async (proof) => {
         const authorization = await authorizeProfileRemoval(proof, true);
-        return authorization.outcome === "authorized"
-          ? { outcome: "authorized" }
-          : authorization;
+        return authorization.outcome === "authorized" ? { outcome: "authorized" } : authorization;
       });
     },
 

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -280,106 +280,112 @@ describe("desktop credential vault", () => {
     });
   });
 
-  posixIt("anchors the credential namespace in its parent before publishing a credential", async () => {
-    const root = await temporaryRoot();
-    let parentSyncAvailable = false;
-    const syncCredentialParentDirectory = vi.fn(async (path: string) => {
-      expect(path).toBe(dirname(root));
-      if (!parentSyncAvailable) throw new TypeError("synthetic parent sync failure");
-      const directory = await open(path, "r");
-      try {
-        await directory.sync();
-      } finally {
-        await directory.close();
-      }
-    });
-    const applyCredential = vi.fn(async () => undefined);
-    const vault = createCredentialVault({
-      root,
-      encryption: encryption(),
-      applyCredential,
-      syncCredentialParentDirectory,
-    });
-
-    await expect(
-      vault.writeCredential({ slot: "anthropic", value: "synthetic-candidate" }),
-    ).resolves.toEqual({ slot: "anthropic", status: "refused", reason: "storage-failed" });
-    await expect(lstat(join(root, "anthropic.bin"))).rejects.toMatchObject({ code: "ENOENT" });
-    expect(applyCredential).not.toHaveBeenCalled();
-
-    parentSyncAvailable = true;
-    await expect(
-      vault.writeCredential({ slot: "anthropic", value: "synthetic-candidate" }),
-    ).resolves.toEqual({ slot: "anthropic", status: "configured", runtimeReady: true });
-    expect(syncCredentialParentDirectory).toHaveBeenCalledTimes(2);
-  });
-
-  posixIt("zeros encryption and rollback buffers after success, refusal, and compensation", async () => {
-    const scenarios = ["success", "pre-rename", "compensation"] as const;
-    for (const scenario of scenarios) {
+  posixIt(
+    "anchors the credential namespace in its parent before publishing a credential",
+    async () => {
       const root = await temporaryRoot();
-      const baseEncryption = encryption();
-      if (scenario === "compensation") {
-        await storeEncryptedCredential(root, "anthropic", "synthetic-old", baseEncryption);
-      }
-      const ciphertexts: Buffer[] = [];
-      const rollbackBuffers: Buffer[] = [];
-      let syncCount = 0;
+      let parentSyncAvailable = false;
+      const syncCredentialParentDirectory = vi.fn(async (path: string) => {
+        expect(path).toBe(dirname(root));
+        if (!parentSyncAvailable) throw new TypeError("synthetic parent sync failure");
+        const directory = await open(path, "r");
+        try {
+          await directory.sync();
+        } finally {
+          await directory.close();
+        }
+      });
+      const applyCredential = vi.fn(async () => undefined);
       const vault = createCredentialVault({
         root,
-        encryption: {
-          ...baseEncryption,
-          encryptString(value) {
-            const ciphertext = baseEncryption.encryptString(value);
-            ciphertexts.push(ciphertext);
-            return ciphertext;
+        encryption: encryption(),
+        applyCredential,
+        syncCredentialParentDirectory,
+      });
+
+      await expect(
+        vault.writeCredential({ slot: "anthropic", value: "synthetic-candidate" }),
+      ).resolves.toEqual({ slot: "anthropic", status: "refused", reason: "storage-failed" });
+      await expect(lstat(join(root, "anthropic.bin"))).rejects.toMatchObject({ code: "ENOENT" });
+      expect(applyCredential).not.toHaveBeenCalled();
+
+      parentSyncAvailable = true;
+      await expect(
+        vault.writeCredential({ slot: "anthropic", value: "synthetic-candidate" }),
+      ).resolves.toEqual({ slot: "anthropic", status: "configured", runtimeReady: true });
+      expect(syncCredentialParentDirectory).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  posixIt(
+    "zeros encryption and rollback buffers after success, refusal, and compensation",
+    async () => {
+      const scenarios = ["success", "pre-rename", "compensation"] as const;
+      for (const scenario of scenarios) {
+        const root = await temporaryRoot();
+        const baseEncryption = encryption();
+        if (scenario === "compensation") {
+          await storeEncryptedCredential(root, "anthropic", "synthetic-old", baseEncryption);
+        }
+        const ciphertexts: Buffer[] = [];
+        const rollbackBuffers: Buffer[] = [];
+        let syncCount = 0;
+        const vault = createCredentialVault({
+          root,
+          encryption: {
+            ...baseEncryption,
+            encryptString(value) {
+              const ciphertext = baseEncryption.encryptString(value);
+              ciphertexts.push(ciphertext);
+              return ciphertext;
+            },
           },
-        },
-        applyCredential: vi.fn(async () => undefined),
-        readCredentialFile:
-          scenario === "compensation"
-            ? ((async (path: string) => {
-                const contents = await readFile(path);
-                rollbackBuffers.push(contents);
-                return contents;
-              }) as typeof readFile)
-            : undefined,
-        renameCredentialFile:
-          scenario === "pre-rename"
-            ? (vi.fn(async () => {
-                throw new TypeError("synthetic rename failure");
-              }) as never)
-            : undefined,
-        syncCredentialDirectory:
-          scenario === "compensation"
-            ? async () => {
-                syncCount += 1;
-                if (syncCount === 2) {
-                  throw new TypeError("synthetic candidate directory sync failure");
+          applyCredential: vi.fn(async () => undefined),
+          readCredentialFile:
+            scenario === "compensation"
+              ? ((async (path: string) => {
+                  const contents = await readFile(path);
+                  rollbackBuffers.push(contents);
+                  return contents;
+                }) as typeof readFile)
+              : undefined,
+          renameCredentialFile:
+            scenario === "pre-rename"
+              ? (vi.fn(async () => {
+                  throw new TypeError("synthetic rename failure");
+                }) as never)
+              : undefined,
+          syncCredentialDirectory:
+            scenario === "compensation"
+              ? async () => {
+                  syncCount += 1;
+                  if (syncCount === 2) {
+                    throw new TypeError("synthetic candidate directory sync failure");
+                  }
+                  const directory = await open(root, "r");
+                  try {
+                    await directory.sync();
+                  } finally {
+                    await directory.close();
+                  }
                 }
-                const directory = await open(root, "r");
-                try {
-                  await directory.sync();
-                } finally {
-                  await directory.close();
-                }
-              }
-            : undefined,
-      });
+              : undefined,
+        });
 
-      const result = await vault.writeCredential({
-        slot: "anthropic",
-        value: `synthetic-${scenario}`,
-      });
+        const result = await vault.writeCredential({
+          slot: "anthropic",
+          value: `synthetic-${scenario}`,
+        });
 
-      expect(result.status).toBe(scenario === "success" ? "configured" : "refused");
-      expect(ciphertexts).toHaveLength(1);
-      for (const buffer of [...ciphertexts, ...rollbackBuffers]) {
-        expect(buffer.every((byte) => byte === 0)).toBe(true);
+        expect(result.status).toBe(scenario === "success" ? "configured" : "refused");
+        expect(ciphertexts).toHaveLength(1);
+        for (const buffer of [...ciphertexts, ...rollbackBuffers]) {
+          expect(buffer.every((byte) => byte === 0)).toBe(true);
+        }
+        if (scenario === "compensation") expect(rollbackBuffers).toHaveLength(1);
       }
-      if (scenario === "compensation") expect(rollbackBuffers).toHaveLength(1);
-    }
-  });
+    },
+  );
 
   it("keeps a write committed when directory cleanup fails after a successful fsync", async () => {
     const root = await temporaryRoot();
@@ -417,91 +423,103 @@ describe("desktop credential vault", () => {
     expect(applyCredential).toHaveBeenCalledWith("anthropic", "synthetic-candidate");
   });
 
-  posixIt("restores the previous ciphertext before refusing a post-rename durability failure", async () => {
-    const root = await temporaryRoot();
-    const encryptionPort = encryption();
-    const seed = createCredentialVault({
-      root,
-      encryption: encryptionPort,
-      applyCredential: vi.fn(),
-    });
-    await seed.writeCredential({ slot: "anthropic", value: "synthetic-old" }, { activate: false });
-    let syncCount = 0;
-    const applyCredential = vi.fn();
-    const vault = createCredentialVault({
-      root,
-      encryption: encryptionPort,
-      applyCredential,
-      createId: () => `write-${syncCount}`,
-      syncCredentialDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 2) throw new TypeError("synthetic replacement directory sync failure");
-        const directory = await open(root, "r");
-        try {
-          await directory.sync();
-        } finally {
-          await directory.close();
-        }
-      },
-    });
-
-    await expect(
-      vault.writeCredential({ slot: "anthropic", value: "synthetic-candidate" }),
-    ).resolves.toEqual({
-      slot: "anthropic",
-      status: "refused",
-      reason: "storage-failed",
-    });
-    const stored = await readFile(join(root, "anthropic.bin"));
-    expect(encryptionPort.decryptString(stored)).toBe("synthetic-old");
-    expect(applyCredential).not.toHaveBeenCalled();
-  });
-
-  posixIt("reports uncertainty and blocks replay when credential convergence cannot be proven", async () => {
-    const root = await temporaryRoot();
-    const encryptionPort = encryption();
-    const seed = createCredentialVault({
-      root,
-      encryption: encryptionPort,
-      applyCredential: vi.fn(),
-    });
-    await seed.writeCredential({ slot: "anthropic", value: "synthetic-old" }, { activate: false });
-    const applyCredential = vi.fn();
-    let syncCount = 0;
-    const vault = createCredentialVault({
-      root,
-      encryption: encryptionPort,
-      applyCredential,
-      createId: () => "never-durable",
-      syncCredentialDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 1) {
+  posixIt(
+    "restores the previous ciphertext before refusing a post-rename durability failure",
+    async () => {
+      const root = await temporaryRoot();
+      const encryptionPort = encryption();
+      const seed = createCredentialVault({
+        root,
+        encryption: encryptionPort,
+        applyCredential: vi.fn(),
+      });
+      await seed.writeCredential(
+        { slot: "anthropic", value: "synthetic-old" },
+        { activate: false },
+      );
+      let syncCount = 0;
+      const applyCredential = vi.fn();
+      const vault = createCredentialVault({
+        root,
+        encryption: encryptionPort,
+        applyCredential,
+        createId: () => `write-${syncCount}`,
+        syncCredentialDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 2) throw new TypeError("synthetic replacement directory sync failure");
           const directory = await open(root, "r");
           try {
             await directory.sync();
           } finally {
             await directory.close();
           }
-          return;
-        }
-        throw new TypeError("synthetic persistent directory sync failure");
-      },
-    });
+        },
+      });
 
-    await expect(
-      vault.writeCredential({ slot: "anthropic", value: "synthetic-candidate" }),
-    ).resolves.toEqual({
-      slot: "anthropic",
-      status: "uncertain",
-      reason: "storage-uncertain",
-    });
-    await expect(vault.credentialStatuses()).resolves.toContainEqual({
-      slot: "anthropic",
-      state: "re-prompt",
-      runtimeState: null,
-    });
-    expect(applyCredential).not.toHaveBeenCalled();
-  });
+      await expect(
+        vault.writeCredential({ slot: "anthropic", value: "synthetic-candidate" }),
+      ).resolves.toEqual({
+        slot: "anthropic",
+        status: "refused",
+        reason: "storage-failed",
+      });
+      const stored = await readFile(join(root, "anthropic.bin"));
+      expect(encryptionPort.decryptString(stored)).toBe("synthetic-old");
+      expect(applyCredential).not.toHaveBeenCalled();
+    },
+  );
+
+  posixIt(
+    "reports uncertainty and blocks replay when credential convergence cannot be proven",
+    async () => {
+      const root = await temporaryRoot();
+      const encryptionPort = encryption();
+      const seed = createCredentialVault({
+        root,
+        encryption: encryptionPort,
+        applyCredential: vi.fn(),
+      });
+      await seed.writeCredential(
+        { slot: "anthropic", value: "synthetic-old" },
+        { activate: false },
+      );
+      const applyCredential = vi.fn();
+      let syncCount = 0;
+      const vault = createCredentialVault({
+        root,
+        encryption: encryptionPort,
+        applyCredential,
+        createId: () => "never-durable",
+        syncCredentialDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 1) {
+            const directory = await open(root, "r");
+            try {
+              await directory.sync();
+            } finally {
+              await directory.close();
+            }
+            return;
+          }
+          throw new TypeError("synthetic persistent directory sync failure");
+        },
+      });
+
+      await expect(
+        vault.writeCredential({ slot: "anthropic", value: "synthetic-candidate" }),
+      ).resolves.toEqual({
+        slot: "anthropic",
+        status: "uncertain",
+        reason: "storage-uncertain",
+      });
+      await expect(vault.credentialStatuses()).resolves.toContainEqual({
+        slot: "anthropic",
+        state: "re-prompt",
+        runtimeState: null,
+      });
+      expect(applyCredential).not.toHaveBeenCalled();
+    },
+  );
 
   it("serializes successor replay behind an in-flight replacement until storage converges", async () => {
     const root = await temporaryRoot();
@@ -617,75 +635,81 @@ describe("desktop credential vault", () => {
     await expect(lstat(join(root, "anthropic.bin"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  posixIt("reopens a visible old credential only after cleaning owned transients and syncing", async () => {
-    const root = await temporaryRoot();
-    const baseEncryption = encryption();
-    await leaveAmbiguousCredential(root, "old", baseEncryption);
-    const ownedTemporary = join(root, ".anthropic.bin.reopen-old.tmp");
-    await writeFile(ownedTemporary, Buffer.from("synthetic abandoned ciphertext"), {
-      mode: CREDENTIAL_FILE_MODE,
-    });
-    const syncCredentialDirectory = vi.fn(async () => {
-      await expect(lstat(ownedTemporary)).rejects.toMatchObject({ code: "ENOENT" });
-      const directory = await open(root, "r");
-      try {
-        await directory.sync();
-      } finally {
-        await directory.close();
-      }
-    });
-    const decryptString = vi.fn((value: Buffer) => {
+  posixIt(
+    "reopens a visible old credential only after cleaning owned transients and syncing",
+    async () => {
+      const root = await temporaryRoot();
+      const baseEncryption = encryption();
+      await leaveAmbiguousCredential(root, "old", baseEncryption);
+      const ownedTemporary = join(root, ".anthropic.bin.reopen-old.tmp");
+      await writeFile(ownedTemporary, Buffer.from("synthetic abandoned ciphertext"), {
+        mode: CREDENTIAL_FILE_MODE,
+      });
+      const syncCredentialDirectory = vi.fn(async () => {
+        await expect(lstat(ownedTemporary)).rejects.toMatchObject({ code: "ENOENT" });
+        const directory = await open(root, "r");
+        try {
+          await directory.sync();
+        } finally {
+          await directory.close();
+        }
+      });
+      const decryptString = vi.fn((value: Buffer) => {
+        expect(syncCredentialDirectory).toHaveBeenCalledOnce();
+        return baseEncryption.decryptString(value);
+      });
+      const applyCredential = vi.fn(async () => undefined);
+      const reopened = createCredentialVault({
+        root,
+        encryption: { ...baseEncryption, decryptString },
+        applyCredential,
+        syncCredentialDirectory,
+      });
+
+      await reopened.reapplyConfigured();
+
+      expect(applyCredential).toHaveBeenCalledWith("anthropic", "synthetic-old");
+      await expect(reopened.credentialStatuses()).resolves.toContainEqual({
+        slot: "anthropic",
+        state: "configured",
+        runtimeState: "active",
+      });
       expect(syncCredentialDirectory).toHaveBeenCalledOnce();
-      return baseEncryption.decryptString(value);
-    });
-    const applyCredential = vi.fn(async () => undefined);
-    const reopened = createCredentialVault({
-      root,
-      encryption: { ...baseEncryption, decryptString },
-      applyCredential,
-      syncCredentialDirectory,
-    });
+    },
+  );
 
-    await reopened.reapplyConfigured();
+  posixIt(
+    "reopens a visible candidate only after syncing even when no transient remains",
+    async () => {
+      const root = await temporaryRoot();
+      const baseEncryption = encryption();
+      await leaveAmbiguousCredential(root, "candidate", baseEncryption);
+      const syncCredentialDirectory = vi.fn(async () => {
+        const directory = await open(root, "r");
+        try {
+          await directory.sync();
+        } finally {
+          await directory.close();
+        }
+      });
+      const decryptString = vi.fn((value: Buffer) => {
+        expect(syncCredentialDirectory).toHaveBeenCalledOnce();
+        return baseEncryption.decryptString(value);
+      });
+      const applyCredential = vi.fn(async () => undefined);
+      const reopened = createCredentialVault({
+        root,
+        encryption: { ...baseEncryption, decryptString },
+        applyCredential,
+        syncCredentialDirectory,
+      });
 
-    expect(applyCredential).toHaveBeenCalledWith("anthropic", "synthetic-old");
-    await expect(reopened.credentialStatuses()).resolves.toContainEqual({
-      slot: "anthropic",
-      state: "configured",
-      runtimeState: "active",
-    });
-    expect(syncCredentialDirectory).toHaveBeenCalledOnce();
-  });
+      await reopened.reapplyConfigured();
 
-  posixIt("reopens a visible candidate only after syncing even when no transient remains", async () => {
-    const root = await temporaryRoot();
-    const baseEncryption = encryption();
-    await leaveAmbiguousCredential(root, "candidate", baseEncryption);
-    const syncCredentialDirectory = vi.fn(async () => {
-      const directory = await open(root, "r");
-      try {
-        await directory.sync();
-      } finally {
-        await directory.close();
-      }
-    });
-    const decryptString = vi.fn((value: Buffer) => {
+      expect(applyCredential).toHaveBeenCalledWith("anthropic", "synthetic-candidate");
       expect(syncCredentialDirectory).toHaveBeenCalledOnce();
-      return baseEncryption.decryptString(value);
-    });
-    const applyCredential = vi.fn(async () => undefined);
-    const reopened = createCredentialVault({
-      root,
-      encryption: { ...baseEncryption, decryptString },
-      applyCredential,
-      syncCredentialDirectory,
-    });
-
-    await reopened.reapplyConfigured();
-
-    expect(applyCredential).toHaveBeenCalledWith("anthropic", "synthetic-candidate");
-    expect(syncCredentialDirectory).toHaveBeenCalledOnce();
-  });
+    },
+  );
 
   posixIt("keeps a reopened vault indeterminate when its durability barrier fails", async () => {
     const root = await temporaryRoot();
@@ -930,8 +954,7 @@ describe("desktop credential vault", () => {
           missing === "missing-proof"
             ? async (operation) => await operation(undefined as never)
             : createCredentialEnvelopeMutationLock(),
-        revalidateEnvelopeRemoval:
-          missing === "missing-hook" ? undefined : vi.fn(async () => true),
+        revalidateEnvelopeRemoval: missing === "missing-hook" ? undefined : vi.fn(async () => true),
       });
 
       await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
@@ -1002,8 +1025,7 @@ describe("desktop credential vault", () => {
       await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
         slot: "anthropic",
         status: "refused",
-        reason:
-          compensation === "restored" ? "encryption-unavailable" : "runtime-state-diverged",
+        reason: compensation === "restored" ? "encryption-unavailable" : "runtime-state-diverged",
       });
 
       expect(clearCredential).toHaveBeenCalledOnce();
@@ -1013,14 +1035,17 @@ describe("desktop credential vault", () => {
     },
   );
 
-  posixIt("deletes an unverified envelope only after the athlete requests that slot", async () => {
+  posixIt("deletes an unknown Darwin envelope without decrypting during deletion", async () => {
     const root = await temporaryRoot();
     await mkdir(root, { mode: CREDENTIAL_DIRECTORY_MODE });
     const path = join(root, "anthropic.bin");
     await writeFile(path, Buffer.from("unverified-envelope"), { mode: CREDENTIAL_FILE_MODE });
+    const baseEncryption = encryption();
+    const decryptString = vi.fn(baseEncryption.decryptString);
     const vault = createCredentialVault({
       root,
-      encryption: encryption(),
+      platform: "darwin",
+      encryption: { ...baseEncryption, decryptString },
       applyCredential: vi.fn(async () => undefined),
     });
 
@@ -1029,15 +1054,17 @@ describe("desktop credential vault", () => {
       state: "re-prompt",
       runtimeState: null,
     });
+    decryptString.mockClear();
     await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
       slot: "anthropic",
       status: "deleted",
       cleanupPending: false,
     });
+    expect(decryptString).not.toHaveBeenCalled();
     await expect(lstat(path)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  posixIt("deletes an explicit key-id zero envelope without Keychain access", async () => {
+  posixIt("deletes an explicit Darwin key-id zero envelope without Keychain access", async () => {
     const root = await temporaryRoot();
     await mkdir(root, { mode: CREDENTIAL_DIRECTORY_MODE });
     const path = join(root, "anthropic.bin");
@@ -1051,6 +1078,7 @@ describe("desktop credential vault", () => {
     const decryptString = vi.fn();
     const vault = createCredentialVault({
       root,
+      platform: "darwin",
       encryption: {
         isEncryptionAvailable: () => false,
         encryptString: vi.fn(),
@@ -1068,6 +1096,78 @@ describe("desktop credential vault", () => {
     expect(decryptString).not.toHaveBeenCalled();
     await expect(lstat(path)).rejects.toMatchObject({ code: "ENOENT" });
   });
+
+  it.each(["linux", "win32"] as const)(
+    "restores an active %s credential when its unverified envelope cannot be renamed",
+    async (platform) => {
+      const root = await temporaryRoot();
+      await storeEncryptedCredential(root, "anthropic", "synthetic-secret", encryption());
+      const runtimeState = new Map([["anthropic", "active"]] as const);
+      const applyCredential = vi.fn(async () => undefined);
+      const clearCredential = vi.fn(async () => "cleared" as const);
+      const vault = createCredentialVault({
+        root,
+        platform,
+        runtimeState,
+        encryption: encryption(),
+        applyCredential,
+        clearCredential,
+        renameCredentialFile: vi.fn(async () => {
+          throw new TypeError("synthetic rename failure");
+        }),
+      });
+
+      await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+        slot: "anthropic",
+        status: "refused",
+        reason: "storage-failed",
+      });
+
+      expect(clearCredential).toHaveBeenCalledOnce();
+      expect(applyCredential).toHaveBeenCalledWith("anthropic", "synthetic-secret");
+      expect(runtimeState.get("anthropic")).toBe("active");
+      expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
+    },
+  );
+
+  it.each(["linux", "win32"] as const)(
+    "refuses to clear a failed %s runtime when its unverified credential cannot be backed up",
+    async (platform) => {
+      const root = await temporaryRoot();
+      await mkdir(root, { mode: CREDENTIAL_DIRECTORY_MODE });
+      await writeFile(join(root, "anthropic.bin"), "unreadable-ciphertext", {
+        mode: CREDENTIAL_FILE_MODE,
+      });
+      const runtimeState = new Map([["anthropic", "failed"]] as const);
+      const decryptString = vi.fn(() => {
+        throw new TypeError("synthetic decrypt failure");
+      });
+      const clearCredential = vi.fn(async () => "cleared" as const);
+      const vault = createCredentialVault({
+        root,
+        platform,
+        runtimeState,
+        encryption: {
+          isEncryptionAvailable: () => true,
+          encryptString: vi.fn(),
+          decryptString,
+        },
+        applyCredential: vi.fn(async () => undefined),
+        clearCredential,
+      });
+
+      await expect(vault.deleteCredential("anthropic")).resolves.toEqual({
+        slot: "anthropic",
+        status: "refused",
+        reason: "storage-failed",
+      });
+
+      expect(decryptString).toHaveBeenCalledOnce();
+      expect(clearCredential).not.toHaveBeenCalled();
+      expect(runtimeState.get("anthropic")).toBe("failed");
+      expect((await lstat(join(root, "anthropic.bin"))).isFile()).toBe(true);
+    },
+  );
 
   it("does not clear stale runtime state when the envelope is missing", async () => {
     const root = await temporaryRoot();
@@ -1233,45 +1333,48 @@ describe("desktop credential vault", () => {
     });
   });
 
-  posixIt("reports deletion uncertainty when neither the visible delete nor restoration is durable", async () => {
-    const root = await temporaryRoot();
-    const encryptionPort = encryption();
-    await storeEncryptedCredential(root, "openrouter", "synthetic-old", encryptionPort);
-    let renameCount = 0;
-    let syncCount = 0;
-    const vault = createCredentialVault({
-      root,
-      encryption: encryptionPort,
-      applyCredential: vi.fn(async () => undefined),
-      renameCredentialFile: (async (from: string, to: string) => {
-        renameCount += 1;
-        if (renameCount === 2) throw new TypeError("synthetic restoration rename failure");
-        await rename(from, to);
-      }) as never,
-      syncCredentialDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 2) throw new TypeError("synthetic deletion directory sync failure");
-        const directory = await open(root, "r");
-        try {
-          await directory.sync();
-        } finally {
-          await directory.close();
-        }
-      },
-    });
+  posixIt(
+    "reports deletion uncertainty when neither the visible delete nor restoration is durable",
+    async () => {
+      const root = await temporaryRoot();
+      const encryptionPort = encryption();
+      await storeEncryptedCredential(root, "openrouter", "synthetic-old", encryptionPort);
+      let renameCount = 0;
+      let syncCount = 0;
+      const vault = createCredentialVault({
+        root,
+        encryption: encryptionPort,
+        applyCredential: vi.fn(async () => undefined),
+        renameCredentialFile: (async (from: string, to: string) => {
+          renameCount += 1;
+          if (renameCount === 2) throw new TypeError("synthetic restoration rename failure");
+          await rename(from, to);
+        }) as never,
+        syncCredentialDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 2) throw new TypeError("synthetic deletion directory sync failure");
+          const directory = await open(root, "r");
+          try {
+            await directory.sync();
+          } finally {
+            await directory.close();
+          }
+        },
+      });
 
-    await expect(vault.deleteCredential("openrouter")).resolves.toEqual({
-      slot: "openrouter",
-      status: "uncertain",
-      reason: "storage-uncertain",
-    });
-    await expect(vault.credentialStatuses()).resolves.toContainEqual({
-      slot: "openrouter",
-      state: "re-prompt",
-      runtimeState: null,
-    });
-    expect((await readdir(root)).some((entry) => entry.endsWith(".deleted"))).toBe(true);
-  });
+      await expect(vault.deleteCredential("openrouter")).resolves.toEqual({
+        slot: "openrouter",
+        status: "uncertain",
+        reason: "storage-uncertain",
+      });
+      await expect(vault.credentialStatuses()).resolves.toContainEqual({
+        slot: "openrouter",
+        state: "re-prompt",
+        runtimeState: null,
+      });
+      expect((await readdir(root)).some((entry) => entry.endsWith(".deleted"))).toBe(true);
+    },
+  );
 
   it("fails closed for insecure directories and targets", async ({ skip }) => {
     const root = await temporaryRoot();
@@ -1485,11 +1588,9 @@ describe("desktop credential vault", () => {
     await vault.reapplyConfigured();
 
     expect(applyCredential).not.toHaveBeenCalled();
-    expect(reapplyCredential).toHaveBeenCalledWith(
+    expect(reapplyCredential).toHaveBeenCalledWith("intervals-icu", "synthetic-intervals-key", [
       "intervals-icu",
-      "synthetic-intervals-key",
-      ["intervals-icu"],
-    );
+    ]);
     expect(JSON.stringify(reapplyCredential.mock.calls)).not.toContain(VERIFICATION_APPROVAL);
   });
 
@@ -1508,9 +1609,7 @@ describe("desktop credential vault", () => {
       status: "configured",
       runtimeReady: true,
     });
-    expect(applyCredential.mock.calls).toEqual([
-      ["intervals-icu", "synthetic-intervals-key"],
-    ]);
+    expect(applyCredential.mock.calls).toEqual([["intervals-icu", "synthetic-intervals-key"]]);
   });
 
   it("refuses approval data outside an explicit Intervals activation", async () => {

--- a/apps/desktop/tests/telegram-credential-vault.test.ts
+++ b/apps/desktop/tests/telegram-credential-vault.test.ts
@@ -547,255 +547,273 @@ describe("Telegram credential vault", () => {
     }
   });
 
-  posixIt("durably restores the prior ciphertext before refusing post-rename profile uncertainty", async () => {
-    const value = await fixture();
-    await seedProfile(value);
-    let syncCount = 0;
-    const vault = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      createProfileId: () => PROFILE_B,
-      createId: () => `replace-${syncCount}`,
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 2) throw new TypeError("synthetic replacement sync failure");
-        await syncDirectory(value.root);
-      },
-    });
+  posixIt(
+    "durably restores the prior ciphertext before refusing post-rename profile uncertainty",
+    async () => {
+      const value = await fixture();
+      await seedProfile(value);
+      let syncCount = 0;
+      const vault = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        createProfileId: () => PROFILE_B,
+        createId: () => `replace-${syncCount}`,
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 2) throw new TypeError("synthetic replacement sync failure");
+          await syncDirectory(value.root);
+        },
+      });
 
-    await expect(
-      vault.replaceProfile({
-        token: "synthetic-token-b",
-        bot: BOT_B,
-        authenticatedAthleteHome: value.athleteHome,
-      }),
-    ).resolves.toEqual({ outcome: "refused", reason: "storage-failed" });
-    await expect(vault.profileStatus()).resolves.toEqual({
-      state: "configured",
-      profileId: PROFILE_A,
-      bot: BOT_A,
-    });
-    const apply = vi.fn();
-    await vault.applyStoredProfile(value.athleteHome, apply);
-    expect(apply.mock.calls[0]?.[0]).toMatchObject({
-      profileId: PROFILE_A,
-      token: "synthetic-token-a",
-      bot: BOT_A,
-    });
-  });
-
-  posixIt("durably removes a first candidate before refusing initial-write uncertainty", async () => {
-    const value = await fixture();
-    let syncCount = 0;
-    const vault = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      createProfileId: () => PROFILE_A,
-      createId: () => `initial-${syncCount}`,
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 1) throw new TypeError("synthetic first directory sync failure");
-        await syncDirectory(value.root);
-      },
-    });
-
-    await expect(
-      vault.replaceProfile({
+      await expect(
+        vault.replaceProfile({
+          token: "synthetic-token-b",
+          bot: BOT_B,
+          authenticatedAthleteHome: value.athleteHome,
+        }),
+      ).resolves.toEqual({ outcome: "refused", reason: "storage-failed" });
+      await expect(vault.profileStatus()).resolves.toEqual({
+        state: "configured",
+        profileId: PROFILE_A,
+        bot: BOT_A,
+      });
+      const apply = vi.fn();
+      await vault.applyStoredProfile(value.athleteHome, apply);
+      expect(apply.mock.calls[0]?.[0]).toMatchObject({
+        profileId: PROFILE_A,
         token: "synthetic-token-a",
         bot: BOT_A,
-        authenticatedAthleteHome: value.athleteHome,
-      }),
-    ).resolves.toEqual({ outcome: "refused", reason: "storage-failed" });
-    await expect(vault.profileStatus()).resolves.toEqual({ state: "missing" });
-    await expect(lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-  });
+      });
+    },
+  );
 
-  posixIt("blocks replay and reports uncertainty when neither candidate nor prior can converge durably", async () => {
-    const value = await fixture();
-    await seedProfile(value);
-    let syncCount = 0;
-    const vault = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      createProfileId: () => PROFILE_B,
-      createId: () => "never-durable",
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 1) {
+  posixIt(
+    "durably removes a first candidate before refusing initial-write uncertainty",
+    async () => {
+      const value = await fixture();
+      let syncCount = 0;
+      const vault = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        createProfileId: () => PROFILE_A,
+        createId: () => `initial-${syncCount}`,
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 1) throw new TypeError("synthetic first directory sync failure");
           await syncDirectory(value.root);
-          return;
-        }
-        throw new TypeError("synthetic persistent directory sync failure");
-      },
-    });
-
-    await expect(
-      vault.replaceProfile({
-        token: "synthetic-token-b",
-        bot: BOT_B,
-        authenticatedAthleteHome: value.athleteHome,
-      }),
-    ).resolves.toEqual({ outcome: "uncertain", reason: "storage-uncertain" });
-    await expect(vault.profileStatus()).resolves.toEqual({ state: "uncertain" });
-    const apply = vi.fn();
-    await expect(vault.applyStoredProfile(value.athleteHome, apply)).resolves.toEqual({
-      outcome: "uncertain",
-      reason: "storage-uncertain",
-    });
-    expect(apply).not.toHaveBeenCalled();
-  });
-
-  posixIt("converges a visible prior profile on reopen before accepting or replaying it", async () => {
-    const value = await fixture();
-    await seedProfile(value);
-    let syncCount = 0;
-    const uncertain = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      createProfileId: () => PROFILE_B,
-      createId: () => "reopen-old",
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 1) {
-          await syncDirectory(value.root);
-          return;
-        }
-        throw new TypeError("synthetic indeterminate directory sync");
-      },
-    });
-    await expect(
-      uncertain.replaceProfile({
-        token: "synthetic-token-b",
-        bot: BOT_B,
-        authenticatedAthleteHome: value.athleteHome,
-      }),
-    ).resolves.toEqual({ outcome: "uncertain", reason: "storage-uncertain" });
-
-    const events: string[] = [];
-    const baseEncryption = encryption();
-    const reopened = createTelegramCredentialVault({
-      ...value,
-      encryption: {
-        ...baseEncryption,
-        decryptString(ciphertext) {
-          events.push("decrypt");
-          return baseEncryption.decryptString(ciphertext);
         },
-      },
-      syncDirectory: async () => {
-        events.push("sync");
-        await syncDirectory(value.root);
-      },
-    });
-    await expect(reopened.profileStatus()).resolves.toEqual({
-      state: "configured",
-      profileId: PROFILE_A,
-      bot: BOT_A,
-    });
-    const apply = vi.fn(async (_profile: TelegramProfileRecord) => {
-      events.push("apply");
-    });
-    await expect(reopened.applyStoredProfile(value.athleteHome, apply)).resolves.toMatchObject({
-      outcome: "applied",
-      profileId: PROFILE_A,
-    });
-    expect(apply.mock.calls[0]?.[0]).toMatchObject({
-      profileId: PROFILE_A,
-      token: "synthetic-token-a",
-      bot: BOT_A,
-    });
-    expect(events).toEqual(["sync", "decrypt", "decrypt", "apply"]);
-  });
+      });
 
-  posixIt("converges a visible candidate profile on reopen before accepting or replaying it", async () => {
-    const value = await fixture();
-    await seedProfile(value);
-    let syncCount = 0;
-    let renameCount = 0;
-    const uncertain = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      createProfileId: () => PROFILE_B,
-      createId: () => "reopen-candidate",
-      renameFile: (async (from: string, to: string) => {
-        renameCount += 1;
-        if (renameCount === 2) throw new TypeError("synthetic compensation rename failure");
-        await rename(from, to);
-      }) as never,
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 1) {
+      await expect(
+        vault.replaceProfile({
+          token: "synthetic-token-a",
+          bot: BOT_A,
+          authenticatedAthleteHome: value.athleteHome,
+        }),
+      ).resolves.toEqual({ outcome: "refused", reason: "storage-failed" });
+      await expect(vault.profileStatus()).resolves.toEqual({ state: "missing" });
+      await expect(lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
+
+  posixIt(
+    "blocks replay and reports uncertainty when neither candidate nor prior can converge durably",
+    async () => {
+      const value = await fixture();
+      await seedProfile(value);
+      let syncCount = 0;
+      const vault = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        createProfileId: () => PROFILE_B,
+        createId: () => "never-durable",
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 1) {
+            await syncDirectory(value.root);
+            return;
+          }
+          throw new TypeError("synthetic persistent directory sync failure");
+        },
+      });
+
+      await expect(
+        vault.replaceProfile({
+          token: "synthetic-token-b",
+          bot: BOT_B,
+          authenticatedAthleteHome: value.athleteHome,
+        }),
+      ).resolves.toEqual({ outcome: "uncertain", reason: "storage-uncertain" });
+      await expect(vault.profileStatus()).resolves.toEqual({ state: "uncertain" });
+      const apply = vi.fn();
+      await expect(vault.applyStoredProfile(value.athleteHome, apply)).resolves.toEqual({
+        outcome: "uncertain",
+        reason: "storage-uncertain",
+      });
+      expect(apply).not.toHaveBeenCalled();
+    },
+  );
+
+  posixIt(
+    "converges a visible prior profile on reopen before accepting or replaying it",
+    async () => {
+      const value = await fixture();
+      await seedProfile(value);
+      let syncCount = 0;
+      const uncertain = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        createProfileId: () => PROFILE_B,
+        createId: () => "reopen-old",
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 1) {
+            await syncDirectory(value.root);
+            return;
+          }
+          throw new TypeError("synthetic indeterminate directory sync");
+        },
+      });
+      await expect(
+        uncertain.replaceProfile({
+          token: "synthetic-token-b",
+          bot: BOT_B,
+          authenticatedAthleteHome: value.athleteHome,
+        }),
+      ).resolves.toEqual({ outcome: "uncertain", reason: "storage-uncertain" });
+
+      const events: string[] = [];
+      const baseEncryption = encryption();
+      const reopened = createTelegramCredentialVault({
+        ...value,
+        encryption: {
+          ...baseEncryption,
+          decryptString(ciphertext) {
+            events.push("decrypt");
+            return baseEncryption.decryptString(ciphertext);
+          },
+        },
+        syncDirectory: async () => {
+          events.push("sync");
           await syncDirectory(value.root);
-          return;
-        }
-        throw new TypeError("synthetic indeterminate directory sync");
-      },
-    });
-    await expect(
-      uncertain.replaceProfile({
+        },
+      });
+      await expect(reopened.profileStatus()).resolves.toEqual({
+        state: "configured",
+        profileId: PROFILE_A,
+        bot: BOT_A,
+      });
+      const apply = vi.fn(async (_profile: TelegramProfileRecord) => {
+        events.push("apply");
+      });
+      await expect(reopened.applyStoredProfile(value.athleteHome, apply)).resolves.toMatchObject({
+        outcome: "applied",
+        profileId: PROFILE_A,
+      });
+      expect(apply.mock.calls[0]?.[0]).toMatchObject({
+        profileId: PROFILE_A,
+        token: "synthetic-token-a",
+        bot: BOT_A,
+      });
+      expect(events).toEqual(["sync", "decrypt", "decrypt", "apply"]);
+    },
+  );
+
+  posixIt(
+    "converges a visible candidate profile on reopen before accepting or replaying it",
+    async () => {
+      const value = await fixture();
+      await seedProfile(value);
+      let syncCount = 0;
+      let renameCount = 0;
+      const uncertain = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        createProfileId: () => PROFILE_B,
+        createId: () => "reopen-candidate",
+        renameFile: (async (from: string, to: string) => {
+          renameCount += 1;
+          if (renameCount === 2) throw new TypeError("synthetic compensation rename failure");
+          await rename(from, to);
+        }) as never,
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 1) {
+            await syncDirectory(value.root);
+            return;
+          }
+          throw new TypeError("synthetic indeterminate directory sync");
+        },
+      });
+      await expect(
+        uncertain.replaceProfile({
+          token: "synthetic-token-b",
+          bot: BOT_B,
+          authenticatedAthleteHome: value.athleteHome,
+        }),
+      ).resolves.toEqual({ outcome: "uncertain", reason: "storage-uncertain" });
+
+      const namespaceSync = vi.fn(async () => syncDirectory(value.root));
+      const reopened = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        syncDirectory: namespaceSync,
+      });
+      await expect(reopened.profileStatus()).resolves.toEqual({
+        state: "configured",
+        profileId: PROFILE_B,
+        bot: BOT_B,
+      });
+      const apply = vi.fn(async (_profile: TelegramProfileRecord) => {});
+      await expect(reopened.applyStoredProfile(value.athleteHome, apply)).resolves.toMatchObject({
+        outcome: "applied",
+        profileId: PROFILE_B,
+      });
+      expect(apply.mock.calls[0]?.[0]).toMatchObject({
+        profileId: PROFILE_B,
         token: "synthetic-token-b",
         bot: BOT_B,
-        authenticatedAthleteHome: value.athleteHome,
-      }),
-    ).resolves.toEqual({ outcome: "uncertain", reason: "storage-uncertain" });
+      });
+      expect(namespaceSync).toHaveBeenCalledTimes(1);
+    },
+  );
 
-    const namespaceSync = vi.fn(async () => syncDirectory(value.root));
-    const reopened = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      syncDirectory: namespaceSync,
-    });
-    await expect(reopened.profileStatus()).resolves.toEqual({
-      state: "configured",
-      profileId: PROFILE_B,
-      bot: BOT_B,
-    });
-    const apply = vi.fn(async (_profile: TelegramProfileRecord) => {});
-    await expect(reopened.applyStoredProfile(value.athleteHome, apply)).resolves.toMatchObject({
-      outcome: "applied",
-      profileId: PROFILE_B,
-    });
-    expect(apply.mock.calls[0]?.[0]).toMatchObject({
-      profileId: PROFILE_B,
-      token: "synthetic-token-b",
-      bot: BOT_B,
-    });
-    expect(namespaceSync).toHaveBeenCalledTimes(1);
-  });
+  posixIt(
+    "keeps a failed reopen reconciliation uncertain and never replays the visible profile",
+    async () => {
+      const value = await fixture();
+      await seedProfile(value);
+      let syncAttempts = 0;
+      const decryptString = vi.fn(encryption().decryptString);
+      const reopened = createTelegramCredentialVault({
+        ...value,
+        encryption: { ...encryption(), decryptString },
+        syncDirectory: async () => {
+          syncAttempts += 1;
+          if (syncAttempts === 1) throw new TypeError("synthetic reopen sync failure");
+          await syncDirectory(value.root);
+        },
+      });
 
-  posixIt("keeps a failed reopen reconciliation uncertain and never replays the visible profile", async () => {
-    const value = await fixture();
-    await seedProfile(value);
-    let syncAttempts = 0;
-    const decryptString = vi.fn(encryption().decryptString);
-    const reopened = createTelegramCredentialVault({
-      ...value,
-      encryption: { ...encryption(), decryptString },
-      syncDirectory: async () => {
-        syncAttempts += 1;
-        if (syncAttempts === 1) throw new TypeError("synthetic reopen sync failure");
-        await syncDirectory(value.root);
-      },
-    });
-
-    await expect(reopened.profileStatus()).resolves.toEqual({ state: "uncertain" });
-    await expect(reopened.profileStatus()).resolves.toEqual({ state: "uncertain" });
-    const apply = vi.fn();
-    await expect(reopened.applyStoredProfile(value.athleteHome, apply)).resolves.toEqual({
-      outcome: "uncertain",
-      reason: "storage-uncertain",
-    });
-    await expect(reopened.deleteProfile()).resolves.toEqual({
-      outcome: "uncertain",
-      reason: "storage-uncertain",
-    });
-    expect(syncAttempts).toBe(1);
-    expect(decryptString).not.toHaveBeenCalled();
-    expect(apply).not.toHaveBeenCalled();
-    expect((await lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).isFile()).toBe(true);
-  });
+      await expect(reopened.profileStatus()).resolves.toEqual({ state: "uncertain" });
+      await expect(reopened.profileStatus()).resolves.toEqual({ state: "uncertain" });
+      const apply = vi.fn();
+      await expect(reopened.applyStoredProfile(value.athleteHome, apply)).resolves.toEqual({
+        outcome: "uncertain",
+        reason: "storage-uncertain",
+      });
+      await expect(reopened.deleteProfile()).resolves.toEqual({
+        outcome: "uncertain",
+        reason: "storage-uncertain",
+      });
+      expect(syncAttempts).toBe(1);
+      expect(decryptString).not.toHaveBeenCalled();
+      expect(apply).not.toHaveBeenCalled();
+      expect((await lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).isFile()).toBe(true);
+    },
+  );
 
   it("reconciles only exact vault-owned transient artifacts before reading a profile", async () => {
     const value = await fixture();
@@ -904,41 +922,44 @@ describe("Telegram credential vault", () => {
     expect((await readdir(value.root)).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
   });
 
-  posixIt("stores desired state separately without encryption and durably compensates uncertainty", async () => {
-    const value = await fixture();
-    const encryptString = vi.fn();
-    const decryptString = vi.fn();
-    const seed = createTelegramCredentialVault({
-      ...value,
-      encryption: { isEncryptionAvailable: () => false, encryptString, decryptString },
-    });
-    await expect(seed.setDesiredState(false)).resolves.toEqual({
-      status: "stored",
-      enabled: false,
-    });
-    let syncCount = 0;
-    const vault = createTelegramCredentialVault({
-      ...value,
-      encryption: { isEncryptionAvailable: () => false, encryptString, decryptString },
-      createId: () => `desired-${syncCount}`,
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 2) throw new TypeError("synthetic replacement sync failure");
-        await syncDirectory(value.root);
-      },
-    });
+  posixIt(
+    "stores desired state separately without encryption and durably compensates uncertainty",
+    async () => {
+      const value = await fixture();
+      const encryptString = vi.fn();
+      const decryptString = vi.fn();
+      const seed = createTelegramCredentialVault({
+        ...value,
+        encryption: { isEncryptionAvailable: () => false, encryptString, decryptString },
+      });
+      await expect(seed.setDesiredState(false)).resolves.toEqual({
+        status: "stored",
+        enabled: false,
+      });
+      let syncCount = 0;
+      const vault = createTelegramCredentialVault({
+        ...value,
+        encryption: { isEncryptionAvailable: () => false, encryptString, decryptString },
+        createId: () => `desired-${syncCount}`,
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 2) throw new TypeError("synthetic replacement sync failure");
+          await syncDirectory(value.root);
+        },
+      });
 
-    await expect(vault.setDesiredState(true)).resolves.toEqual({
-      status: "refused",
-      reason: "storage-failed",
-    });
-    await expect(vault.desiredState()).resolves.toEqual({ state: "configured", enabled: false });
-    expect(encryptString).not.toHaveBeenCalled();
-    expect(decryptString).not.toHaveBeenCalled();
-    expect(
-      JSON.parse(await readFile(join(value.root, TELEGRAM_DESIRED_STATE_FILE_NAME), "utf8")),
-    ).toEqual({ schemaVersion: 1, athleteHome: value.athleteHome, enabled: false });
-  });
+      await expect(vault.setDesiredState(true)).resolves.toEqual({
+        status: "refused",
+        reason: "storage-failed",
+      });
+      await expect(vault.desiredState()).resolves.toEqual({ state: "configured", enabled: false });
+      expect(encryptString).not.toHaveBeenCalled();
+      expect(decryptString).not.toHaveBeenCalled();
+      expect(
+        JSON.parse(await readFile(join(value.root, TELEGRAM_DESIRED_STATE_FILE_NAME), "utf8")),
+      ).toEqual({ schemaVersion: 1, athleteHome: value.athleteHome, enabled: false });
+    },
+  );
 
   posixIt("marks desired state uncertain when durable compensation cannot be proven", async () => {
     const value = await fixture();
@@ -998,97 +1019,103 @@ describe("Telegram credential vault", () => {
     expect(namespaceSync).toHaveBeenCalledTimes(process.platform === "win32" ? 0 : 1);
   });
 
-  posixIt("accepts an uncertain visible enable only after a fresh reopen converges it", async () => {
-    const value = await fixture();
-    const seed = createTelegramCredentialVault({ ...value, encryption: encryption() });
-    await seed.setDesiredState(false);
-    let syncCount = 0;
-    let renameCount = 0;
-    const uncertain = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      createId: () => "uncertain-enable-candidate",
-      renameFile: (async (from: string, to: string) => {
-        renameCount += 1;
-        if (renameCount === 2) throw new TypeError("synthetic compensation rename failure");
-        await rename(from, to);
-      }) as never,
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 1) {
+  posixIt(
+    "accepts an uncertain visible enable only after a fresh reopen converges it",
+    async () => {
+      const value = await fixture();
+      const seed = createTelegramCredentialVault({ ...value, encryption: encryption() });
+      await seed.setDesiredState(false);
+      let syncCount = 0;
+      let renameCount = 0;
+      const uncertain = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        createId: () => "uncertain-enable-candidate",
+        renameFile: (async (from: string, to: string) => {
+          renameCount += 1;
+          if (renameCount === 2) throw new TypeError("synthetic compensation rename failure");
+          await rename(from, to);
+        }) as never,
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 1) {
+            await syncDirectory(value.root);
+            return;
+          }
+          throw new TypeError("synthetic indeterminate directory sync");
+        },
+      });
+      await expect(uncertain.setDesiredState(true)).resolves.toEqual({
+        status: "uncertain",
+        reason: "storage-uncertain",
+      });
+      expect(
+        JSON.parse(await readFile(join(value.root, TELEGRAM_DESIRED_STATE_FILE_NAME), "utf8")),
+      ).toMatchObject({ enabled: true });
+
+      const namespaceSync = vi.fn(async () => syncDirectory(value.root));
+      const reopened = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        syncDirectory: namespaceSync,
+      });
+      await expect(reopened.desiredState()).resolves.toEqual({
+        state: "configured",
+        enabled: true,
+      });
+      expect(namespaceSync).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  posixIt(
+    "keeps an uncertain visible enable disabled while reopen convergence is indeterminate",
+    async () => {
+      const value = await fixture();
+      const seed = createTelegramCredentialVault({ ...value, encryption: encryption() });
+      await seed.setDesiredState(false);
+      let syncCount = 0;
+      let renameCount = 0;
+      const uncertain = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        createId: () => "indeterminate-enable-candidate",
+        renameFile: (async (from: string, to: string) => {
+          renameCount += 1;
+          if (renameCount === 2) throw new TypeError("synthetic compensation rename failure");
+          await rename(from, to);
+        }) as never,
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 1) {
+            await syncDirectory(value.root);
+            return;
+          }
+          throw new TypeError("synthetic indeterminate directory sync");
+        },
+      });
+      await expect(uncertain.setDesiredState(true)).resolves.toMatchObject({ status: "uncertain" });
+
+      let reopenSyncAttempts = 0;
+      const reopened = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        syncDirectory: async () => {
+          reopenSyncAttempts += 1;
+          if (reopenSyncAttempts === 1) throw new TypeError("synthetic reopen sync failure");
           await syncDirectory(value.root);
-          return;
-        }
-        throw new TypeError("synthetic indeterminate directory sync");
-      },
-    });
-    await expect(uncertain.setDesiredState(true)).resolves.toEqual({
-      status: "uncertain",
-      reason: "storage-uncertain",
-    });
-    expect(
-      JSON.parse(await readFile(join(value.root, TELEGRAM_DESIRED_STATE_FILE_NAME), "utf8")),
-    ).toMatchObject({ enabled: true });
-
-    const namespaceSync = vi.fn(async () => syncDirectory(value.root));
-    const reopened = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      syncDirectory: namespaceSync,
-    });
-    await expect(reopened.desiredState()).resolves.toEqual({
-      state: "configured",
-      enabled: true,
-    });
-    expect(namespaceSync).toHaveBeenCalledTimes(1);
-  });
-
-  posixIt("keeps an uncertain visible enable disabled while reopen convergence is indeterminate", async () => {
-    const value = await fixture();
-    const seed = createTelegramCredentialVault({ ...value, encryption: encryption() });
-    await seed.setDesiredState(false);
-    let syncCount = 0;
-    let renameCount = 0;
-    const uncertain = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      createId: () => "indeterminate-enable-candidate",
-      renameFile: (async (from: string, to: string) => {
-        renameCount += 1;
-        if (renameCount === 2) throw new TypeError("synthetic compensation rename failure");
-        await rename(from, to);
-      }) as never,
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 1) {
-          await syncDirectory(value.root);
-          return;
-        }
-        throw new TypeError("synthetic indeterminate directory sync");
-      },
-    });
-    await expect(uncertain.setDesiredState(true)).resolves.toMatchObject({ status: "uncertain" });
-
-    let reopenSyncAttempts = 0;
-    const reopened = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      syncDirectory: async () => {
-        reopenSyncAttempts += 1;
-        if (reopenSyncAttempts === 1) throw new TypeError("synthetic reopen sync failure");
-        await syncDirectory(value.root);
-      },
-    });
-    await expect(reopened.desiredState()).resolves.toEqual({
-      state: "uncertain",
-      enabled: false,
-    });
-    await expect(reopened.desiredState()).resolves.toEqual({
-      state: "uncertain",
-      enabled: false,
-    });
-    expect(reopenSyncAttempts).toBe(1);
-  });
+        },
+      });
+      await expect(reopened.desiredState()).resolves.toEqual({
+        state: "uncertain",
+        enabled: false,
+      });
+      await expect(reopened.desiredState()).resolves.toEqual({
+        state: "uncertain",
+        enabled: false,
+      });
+      expect(reopenSyncAttempts).toBe(1);
+    },
+  );
 
   it("refuses symlinked and permissive profile storage", async ({ skip }) => {
     const value = await fixture();
@@ -1230,8 +1257,7 @@ describe("Telegram credential vault", () => {
           missing === "missing-proof"
             ? async (operation) => await operation(undefined as never)
             : createCredentialEnvelopeMutationLock(),
-        revalidateEnvelopeRemoval:
-          missing === "missing-hook" ? undefined : vi.fn(async () => true),
+        revalidateEnvelopeRemoval: missing === "missing-hook" ? undefined : vi.fn(async () => true),
       });
 
       await expect(vault.deleteProfile()).resolves.toEqual({
@@ -1279,16 +1305,18 @@ describe("Telegram credential vault", () => {
     expect((await lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).isFile()).toBe(true);
   });
 
-  it("deletes an unverified profile without requiring a Keychain key", async () => {
+  posixIt("deletes an unverified Darwin profile without decrypting it", async () => {
     const value = await fixture();
     await seedProfile(value);
     const revalidateEnvelopeRemoval = vi.fn(async () => false);
+    const decryptString = vi.fn();
     const vault = createTelegramCredentialVault({
       ...value,
+      platform: "darwin",
       encryption: {
         isEncryptionAvailable: () => false,
         encryptString: vi.fn(),
-        decryptString: vi.fn(),
+        decryptString,
       },
       serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
       revalidateEnvelopeRemoval,
@@ -1299,11 +1327,61 @@ describe("Telegram credential vault", () => {
       cleanupPending: false,
     });
 
+    expect(decryptString).not.toHaveBeenCalled();
     expect(revalidateEnvelopeRemoval).not.toHaveBeenCalled();
     await expect(lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).rejects.toMatchObject({
       code: "ENOENT",
     });
   });
+
+  it.each(["linux", "win32"] as const)(
+    "refuses an unverified %s profile owned by another athlete home",
+    async (platform) => {
+      const value = await fixture();
+      const foreignHome = await anotherHome(value.root);
+      await seedProfile({ ...value, athleteHome: foreignHome });
+      const baseEncryption = encryption();
+      const decryptString = vi.fn(baseEncryption.decryptString);
+      const vault = createTelegramCredentialVault({
+        ...value,
+        platform,
+        encryption: { ...baseEncryption, decryptString },
+      });
+
+      await expect(vault.deleteProfile()).resolves.toEqual({
+        outcome: "refused",
+        reason: "wrong-home",
+      });
+
+      expect(decryptString).toHaveBeenCalledOnce();
+      expect((await lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).isFile()).toBe(true);
+    },
+  );
+
+  it.each(["linux", "win32"] as const)(
+    "deletes an unverified %s profile after confirming its athlete home",
+    async (platform) => {
+      const value = await fixture();
+      await seedProfile(value);
+      const baseEncryption = encryption();
+      const decryptString = vi.fn(baseEncryption.decryptString);
+      const vault = createTelegramCredentialVault({
+        ...value,
+        platform,
+        encryption: { ...baseEncryption, decryptString },
+      });
+
+      await expect(vault.deleteProfile()).resolves.toEqual({
+        outcome: "applied",
+        cleanupPending: false,
+      });
+
+      expect(decryptString).toHaveBeenCalledOnce();
+      await expect(lstat(join(value.root, TELEGRAM_PROFILE_FILE_NAME))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
 
   it("refuses deletion when the tombstone id is invalid instead of rejecting", async () => {
     const value = await fixture();
@@ -1323,61 +1401,64 @@ describe("Telegram credential vault", () => {
     await expect(vault.profileStatus()).resolves.toMatchObject({ state: "configured" });
   });
 
-  posixIt("restores a profile when tombstone durability fails and reports uncertainty if restore fails", async () => {
-    const value = await fixture();
-    await seedProfile(value);
-    let syncCount = 0;
-    const restored = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      createId: () => "restore-profile",
-      syncDirectory: async () => {
-        syncCount += 1;
-        if (syncCount === 2) throw new TypeError("synthetic tombstone sync failure");
-        await syncDirectory(value.root);
-      },
-    });
-    await expect(restored.deleteProfile()).resolves.toEqual({
-      outcome: "refused",
-      reason: "storage-failed",
-    });
-    await expect(restored.profileStatus()).resolves.toMatchObject({
-      state: "configured",
-      profileId: PROFILE_A,
-    });
-
-    let renameCount = 0;
-    let uncertainSyncCount = 0;
-    const uncertain = createTelegramCredentialVault({
-      ...value,
-      encryption: encryption(),
-      createId: () => "uncertain-delete",
-      renameFile: (async (from: string, to: string) => {
-        renameCount += 1;
-        if (renameCount === 2) throw new TypeError("synthetic restore failure");
-        await rename(from, to);
-      }) as never,
-      syncDirectory: async () => {
-        uncertainSyncCount += 1;
-        if (uncertainSyncCount === 1) {
+  posixIt(
+    "restores a profile when tombstone durability fails and reports uncertainty if restore fails",
+    async () => {
+      const value = await fixture();
+      await seedProfile(value);
+      let syncCount = 0;
+      const restored = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        createId: () => "restore-profile",
+        syncDirectory: async () => {
+          syncCount += 1;
+          if (syncCount === 2) throw new TypeError("synthetic tombstone sync failure");
           await syncDirectory(value.root);
-          return;
-        }
-        throw new TypeError("synthetic tombstone sync failure");
-      },
-    });
-    await expect(uncertain.deleteProfile()).resolves.toEqual({
-      outcome: "uncertain",
-      reason: "storage-uncertain",
-    });
-    await expect(uncertain.profileStatus()).resolves.toEqual({ state: "uncertain" });
-    const apply = vi.fn();
-    await expect(uncertain.applyStoredProfile(value.athleteHome, apply)).resolves.toEqual({
-      outcome: "uncertain",
-      reason: "storage-uncertain",
-    });
-    expect(apply).not.toHaveBeenCalled();
-  });
+        },
+      });
+      await expect(restored.deleteProfile()).resolves.toEqual({
+        outcome: "refused",
+        reason: "storage-failed",
+      });
+      await expect(restored.profileStatus()).resolves.toMatchObject({
+        state: "configured",
+        profileId: PROFILE_A,
+      });
+
+      let renameCount = 0;
+      let uncertainSyncCount = 0;
+      const uncertain = createTelegramCredentialVault({
+        ...value,
+        encryption: encryption(),
+        createId: () => "uncertain-delete",
+        renameFile: (async (from: string, to: string) => {
+          renameCount += 1;
+          if (renameCount === 2) throw new TypeError("synthetic restore failure");
+          await rename(from, to);
+        }) as never,
+        syncDirectory: async () => {
+          uncertainSyncCount += 1;
+          if (uncertainSyncCount === 1) {
+            await syncDirectory(value.root);
+            return;
+          }
+          throw new TypeError("synthetic tombstone sync failure");
+        },
+      });
+      await expect(uncertain.deleteProfile()).resolves.toEqual({
+        outcome: "uncertain",
+        reason: "storage-uncertain",
+      });
+      await expect(uncertain.profileStatus()).resolves.toEqual({ state: "uncertain" });
+      const apply = vi.fn();
+      await expect(uncertain.applyStoredProfile(value.athleteHome, apply)).resolves.toEqual({
+        outcome: "uncertain",
+        reason: "storage-uncertain",
+      });
+      expect(apply).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps Windows DPAPI ciphertext isolated from a corrupt profile and desired state", async () => {
     const value = await fixture();


### PR DESCRIPTION
## Summary

- cache non-Darwin safeStorage credentials before clearing runtime state so failed deletion can restore them
- verify Telegram profile ownership before deleting unverified non-Darwin envelopes
- keep the existing no-dialog macOS deletion path unchanged
- add Linux, Windows, and macOS regression coverage

## Why

Credential deletion could lose restorable safeStorage credentials after encryption became unavailable, and Telegram deletion could bypass the wrong-home guard on Windows and Linux.

## Verification

- focused credential and Telegram vault tests — 102 tests passed
- `pnpm --filter @cycling-coach/desktop check` — passed
- independent verification — 7/7 acceptance criteria, no P0–P3 findings
