### PR TITLE
test(desktop): use POSIX ASAR paths

### DIFF
--- a/apps/desktop/tests/keychain-binding-path.test.ts
+++ b/apps/desktop/tests/keychain-binding-path.test.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { posix, win32 } from "node:path";
 import { describe, expect, it } from "vitest";
 import { KEYCHAIN_BINDING_BUILD_DIRECTORY } from "../scripts/build-keychain-binding.mjs";
 import { KEYCHAIN_BINDING_ASAR_PATH } from "../scripts/package-inventory.mjs";
@@ -25,7 +25,10 @@ const development = {
 
 describe("keychain binding path", () => {
   it("agrees with the package and build authorities", () => {
-    expect(join(KEYCHAIN_BINDING_ASAR_DIRECTORY, KEYCHAIN_BINDING_FILE_NAME)).toBe(
+    expect(posix.join(KEYCHAIN_BINDING_ASAR_DIRECTORY, KEYCHAIN_BINDING_FILE_NAME)).toBe(
+      KEYCHAIN_BINDING_ASAR_PATH,
+    );
+    expect(win32.join(KEYCHAIN_BINDING_ASAR_DIRECTORY, KEYCHAIN_BINDING_FILE_NAME)).not.toBe(
       KEYCHAIN_BINDING_ASAR_PATH,
     );
     expect(KEYCHAIN_BINDING_DEVELOPMENT_DIRECTORY).toBe(KEYCHAIN_BINDING_BUILD_DIRECTORY);


### PR DESCRIPTION
## Summary

- compare ASAR inventory paths with `path.posix.join`
- pin the Windows separator mismatch with a regression assertion

## Why

ASAR inventory paths always use forward slashes, while `node:path.join` uses backslashes on Windows.

## Verification

- focused keychain binding path test — 5 tests passed
- desktop TypeScript check — passed
- independent verification — 4/4 criteria, no P0–P3 findings
