### PR TITLE
fix(desktop): erase superseded key buffers

### DIFF
--- a/apps/desktop/native/keychain-binding/keychain-binding.mm
+++ b/apps/desktop/native/keychain-binding/keychain-binding.mm
@@ -580,50 +580,58 @@ napi_value ReadKey(napi_env env, napi_callback_info info) {
   CFRelease(keychain);
   if (query == nullptr)
     return Failure(env, "unknown");
-  CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
   CFDictionarySetValue(query, kSecReturnRef, kCFBooleanTrue);
   CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
-  CFTypeRef resultValue = nullptr;
-  const OSStatus status = SecItemCopyMatching(query, &resultValue);
+  CFTypeRef itemValue = nullptr;
+  const OSStatus status = SecItemCopyMatching(query, &itemValue);
   CFRelease(query);
   if (status != errSecSuccess)
     return Failure(env, StatusCode(status));
-  if (resultValue == nullptr ||
-      CFGetTypeID(resultValue) != CFDictionaryGetTypeID()) {
-    if (resultValue != nullptr)
-      CFRelease(resultValue);
-    return Failure(env, "unreadable-item");
-  }
-  CFDictionaryRef result = static_cast<CFDictionaryRef>(resultValue);
-  CFTypeRef dataValue = CFDictionaryGetValue(result, kSecValueData);
-  CFTypeRef itemValue = CFDictionaryGetValue(result, kSecValueRef);
-  if (dataValue == nullptr || CFGetTypeID(dataValue) != CFDataGetTypeID() ||
-      itemValue == nullptr ||
+  if (itemValue == nullptr ||
       CFGetTypeID(itemValue) != SecKeychainItemGetTypeID()) {
-    CFRelease(resultValue);
+    if (itemValue != nullptr)
+      CFRelease(itemValue);
     return Failure(env, "unreadable-item");
   }
-  CFDataRef data = static_cast<CFDataRef>(dataValue);
-  if (CFDataGetLength(data) != static_cast<CFIndex>(kKeyBytes)) {
-    CFRelease(resultValue);
-    return Failure(env, "unreadable-item");
-  }
-  const PartitionInspection partition = InspectPartition(
-      static_cast<SecKeychainItemRef>(const_cast<void *>(itemValue)));
+  SecKeychainItemRef item =
+      static_cast<SecKeychainItemRef>(const_cast<void *>(itemValue));
+  const PartitionInspection partition = InspectPartition(item);
   if (partition != PartitionInspection::kPresent) {
-    CFRelease(resultValue);
+    CFRelease(itemValue);
     return Failure(env, partition == PartitionInspection::kAbsent
                             ? "unreadable-item"
                             : "uninspectable-item");
   }
+  UInt32 contentLength = 0;
+  void *contentBytes = nullptr;
+  const OSStatus contentStatus = SecKeychainItemCopyContent(
+      item, nullptr, nullptr, &contentLength, &contentBytes);
+  CFRelease(itemValue);
+  if (contentStatus != errSecSuccess) {
+    EraseBytes(contentBytes, static_cast<size_t>(contentLength));
+    if (contentBytes != nullptr)
+      SecKeychainItemFreeContent(nullptr, contentBytes);
+    return Failure(env, StatusCode(contentStatus));
+  }
+  if (contentBytes == nullptr || contentLength != kKeyBytes) {
+    EraseBytes(contentBytes, static_cast<size_t>(contentLength));
+    OSStatus freeStatus = errSecSuccess;
+    if (contentBytes != nullptr)
+      freeStatus = SecKeychainItemFreeContent(nullptr, contentBytes);
+    return Failure(env, freeStatus == errSecSuccess ? "unreadable-item"
+                                                    : "uninspectable-item");
+  }
   napi_value key = nullptr;
   void *keyBytes = nullptr;
   const napi_status bufferStatus = napi_create_buffer_copy(
-      env, kKeyBytes, CFDataGetBytePtr(data), &keyBytes, &key);
-  CFRelease(resultValue);
-  if (bufferStatus != napi_ok) {
+      env, kKeyBytes, contentBytes, &keyBytes, &key);
+  EraseBytes(contentBytes, static_cast<size_t>(contentLength));
+  const OSStatus freeStatus =
+      SecKeychainItemFreeContent(nullptr, contentBytes);
+  if (bufferStatus != napi_ok || freeStatus != errSecSuccess) {
     EraseBytes(keyBytes, keyBytes == nullptr ? 0 : kKeyBytes);
-    return NapiError(env);
+    return bufferStatus != napi_ok ? NapiError(env)
+                                   : Failure(env, "uninspectable-item");
   }
   napi_value response = Success(env);
   if (response == nullptr || !Set(env, response, "key", key)) {

--- a/apps/desktop/src/main/keychain-binding.ts
+++ b/apps/desktop/src/main/keychain-binding.ts
@@ -117,6 +117,15 @@ export function parseKeychainBindingResponse(
   value: unknown,
 ): KeychainBindingResponse {
   if (!isRecord(value)) return unknownResponse(operation);
+  const key = Buffer.isBuffer(value.key) ? value.key : undefined;
+  if (
+    value.ok === true &&
+    (operation === "read-key" || operation === "create-key") &&
+    key?.length === KEYCHAIN_KEY_BYTES
+  ) {
+    return { ok: true, op: operation, key };
+  }
+  key?.fill(0);
   if (value.ok === false) {
     if (operation === "create-key") {
       return isErrorCode(value.code) && typeof value.creationRollbackPending === "boolean"
@@ -135,11 +144,7 @@ export function parseKeychainBindingResponse(
       ? { ok: true, op: "probe", teamIdentifier: value.teamIdentifier }
       : unknownResponse(operation);
   }
-  if (operation === "read-key" || operation === "create-key") {
-    return Buffer.isBuffer(value.key) && value.key.length === KEYCHAIN_KEY_BYTES
-      ? { ok: true, op: operation, key: Buffer.from(value.key) }
-      : unknownResponse(operation);
-  }
+  if (operation === "read-key" || operation === "create-key") return unknownResponse(operation);
   if (operation === "retry-created-key-rollback") {
     return { ok: true, op: "retry-created-key-rollback" };
   }

--- a/apps/desktop/src/main/keychain-credential-encryption.ts
+++ b/apps/desktop/src/main/keychain-credential-encryption.ts
@@ -148,6 +148,15 @@ interface KeyHolder {
   cleanupDebt: KeyCleanupDebt;
 }
 
+function responseKey(response: KeychainBindingResponse): Buffer | undefined {
+  const key = (response as { readonly key?: unknown }).key;
+  return Buffer.isBuffer(key) ? key : undefined;
+}
+
+function wipeResponseKey(response: KeychainBindingResponse): void {
+  responseKey(response)?.fill(0);
+}
+
 function readyPort(holder: KeyHolder): CredentialEncryptionPort {
   const currentKey = (): Buffer => {
     if (holder.key === null) throw new KeychainEncryptionError(holder.failure);
@@ -191,6 +200,7 @@ export async function createKeychainPartitionEncryption(
   > => {
     try {
       const retried = await transport.send({ op: "retry-created-key-rollback", service });
+      wipeResponseKey(retried);
       if (!retried.ok) return { status: "failed", code: retried.code };
       return retried.op === "retry-created-key-rollback"
         ? { status: "ready" }
@@ -201,6 +211,7 @@ export async function createKeychainPartitionEncryption(
   };
   let initialCleanupDebt = options.keyCleanupDebt ?? "none";
   const probe = await transport.send({ op: "probe", service });
+  wipeResponseKey(probe);
   if (!probe.ok) {
     return probe.code === "not-team-signed"
       ? { status: "unsupported", code: "not-team-signed", keyCleanupDebt: initialCleanupDebt }
@@ -240,6 +251,7 @@ export async function createKeychainPartitionEncryption(
       return { status: "failed", code: "unknown", keyCleanupDebt: "creation-rollback" };
     }
     if (!created.ok) {
+      wipeResponseKey(created);
       return {
         status: "failed",
         code: created.code,
@@ -248,9 +260,13 @@ export async function createKeychainPartitionEncryption(
       };
     }
     if (created.op !== "create-key") {
+      wipeResponseKey(created);
       return { status: "failed", code: "unknown", keyCleanupDebt: "creation-rollback" };
     }
-    const key = Buffer.from(created.key);
+    const key = responseKey(created);
+    if (key === undefined) {
+      return { status: "failed", code: "unknown", keyCleanupDebt: "creation-rollback" };
+    }
     if (key.length === KEYCHAIN_KEY_BYTES) return { status: "ready", key };
     key.fill(0);
     return { status: "failed", code: "unknown", keyCleanupDebt: "creation-rollback" };
@@ -263,12 +279,17 @@ export async function createKeychainPartitionEncryption(
   > => {
     const read = await transport.send({ op: "read-key", service });
     if (!read.ok) {
+      wipeResponseKey(read);
       return read.code === "item-not-found"
         ? { status: "missing" }
         : { status: "failed", code: read.code };
     }
-    if (read.op !== "read-key") return { status: "failed", code: "unknown" };
-    const key = Buffer.from(read.key);
+    if (read.op !== "read-key") {
+      wipeResponseKey(read);
+      return { status: "failed", code: "unknown" };
+    }
+    const key = responseKey(read);
+    if (key === undefined) return { status: "failed", code: "unknown" };
     if (key.length === KEYCHAIN_KEY_BYTES) return { status: "ready", key };
     key.fill(0);
     return { status: "failed", code: "unknown" };
@@ -276,6 +297,7 @@ export async function createKeychainPartitionEncryption(
 
   const deleteMaterialForReset = async (): Promise<KeychainKeyDeletion> => {
     const deleted = await transport.send({ op: "delete-key", service });
+    wipeResponseKey(deleted);
     if (!deleted.ok || deleted.op !== "delete-key") {
       return { status: "failed", code: deleted.ok ? "unknown" : deleted.code };
     }
@@ -315,7 +337,7 @@ export async function createKeychainPartitionEncryption(
         const persisted = await readMaterial();
         if (persisted.status === "ready") {
           const matches = timingSafeEqual(holder.key, persisted.key);
-          persisted.key.fill(0);
+          if (persisted.key !== holder.key) persisted.key.fill(0);
           if (matches) return { status: "ready" };
           clearKey();
           return fail("unknown");

--- a/apps/desktop/tests/keychain-binding-native.integration.test.ts
+++ b/apps/desktop/tests/keychain-binding-native.integration.test.ts
@@ -244,6 +244,40 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       expect(reading.indexOf("RetryCreationRollback(")).toBeLessThan(
         reading.indexOf("CopyDefaultKeychain"),
       );
+      expect(reading).not.toContain("kSecReturnData");
+      expect(reading.match(/SecKeychainItemCopyContent\(/gu)).toHaveLength(1);
+      const contentCleanup = reading.slice(reading.indexOf("SecKeychainItemCopyContent("));
+      const eraseOffsets = [...contentCleanup.matchAll(/EraseBytes\(contentBytes/gu)].map(
+        (match) => match.index,
+      );
+      const freeOffsets = [
+        ...contentCleanup.matchAll(/SecKeychainItemFreeContent\(nullptr, contentBytes\)/gu),
+      ].map((match) => match.index);
+      expect(eraseOffsets).toHaveLength(3);
+      expect(freeOffsets).toHaveLength(3);
+      for (const [index, eraseOffset] of eraseOffsets.entries()) {
+        const freeOffset = freeOffsets[index]!;
+        expect(eraseOffset).toBeLessThan(freeOffset);
+        if (index + 1 < eraseOffsets.length) {
+          expect(freeOffset).toBeLessThan(eraseOffsets[index + 1]!);
+        }
+      }
+      const bufferFailure = reading.slice(
+        reading.indexOf("if (bufferStatus != napi_ok || freeStatus != errSecSuccess)"),
+        reading.indexOf("napi_value response"),
+      );
+      const publicationFailure = reading.slice(
+        reading.indexOf('if (response == nullptr || !Set(env, response, "key", key))'),
+        reading.indexOf("return response;"),
+      );
+      expect(bufferFailure.match(/EraseBytes\(keyBytes/gu)).toHaveLength(1);
+      expect(bufferFailure.indexOf("EraseBytes(keyBytes")).toBeLessThan(
+        bufferFailure.indexOf("return bufferStatus"),
+      );
+      expect(publicationFailure.match(/EraseBytes\(keyBytes/gu)).toHaveLength(1);
+      expect(publicationFailure.indexOf("EraseBytes(keyBytes")).toBeLessThan(
+        publicationFailure.indexOf("return NapiError(env)"),
+      );
       expect(creation.indexOf("RetryCreationRollback(")).toBeLessThan(
         creation.indexOf("CopyDefaultKeychain"),
       );

--- a/apps/desktop/tests/keychain-binding.test.ts
+++ b/apps/desktop/tests/keychain-binding.test.ts
@@ -17,16 +17,20 @@ describe("keychain binding adapter", () => {
         teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER,
       }),
     ).toEqual({ ok: true, op: "probe", teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER });
-    expect(parseKeychainBindingResponse("read-key", { ok: true, key })).toEqual({
+    const read = parseKeychainBindingResponse("read-key", { ok: true, key });
+    expect(read).toEqual({
       ok: true,
       op: "read-key",
       key,
     });
-    expect(parseKeychainBindingResponse("create-key", { ok: true, key: randomBytes(16) })).toEqual({
+    expect(read.ok && read.op === "read-key" ? read.key : undefined).toBe(key);
+    const wrongLength = randomBytes(16);
+    expect(parseKeychainBindingResponse("create-key", { ok: true, key: wrongLength })).toEqual({
       ok: false,
       code: "unknown",
       creationRollbackPending: true,
     });
+    expect(wrongLength).toEqual(Buffer.alloc(16));
     expect(
       parseKeychainBindingResponse("create-key", {
         ok: false,
@@ -74,6 +78,27 @@ describe("keychain binding adapter", () => {
     });
   });
 
+  it("wipes key buffers discarded from malformed and unrelated responses", () => {
+    const failed = randomBytes(KEYCHAIN_KEY_BYTES);
+    const unrelated = randomBytes(KEYCHAIN_KEY_BYTES);
+    expect(
+      parseKeychainBindingResponse("read-key", {
+        ok: false,
+        code: "unreadable-item",
+        key: failed,
+      }),
+    ).toEqual({ ok: false, code: "unreadable-item" });
+    expect(
+      parseKeychainBindingResponse("probe", {
+        ok: true,
+        teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER,
+        key: unrelated,
+      }),
+    ).toEqual({ ok: true, op: "probe", teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER });
+    expect(failed).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
+    expect(unrelated).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
+  });
+
   it("keeps the lifecycle seam asynchronous around an injected native fake", async () => {
     const key = randomBytes(KEYCHAIN_KEY_BYTES);
     const binding = {
@@ -92,9 +117,9 @@ describe("keychain binding adapter", () => {
     await expect(
       transport.send({ op: "probe", service: KEYCHAIN_CREDENTIAL_SERVICE }),
     ).resolves.toEqual({ ok: true, op: "probe", teamIdentifier: KEYCHAIN_TEAM_IDENTIFIER });
-    await expect(
-      transport.send({ op: "read-key", service: KEYCHAIN_CREDENTIAL_SERVICE }),
-    ).resolves.toEqual({ ok: true, op: "read-key", key });
+    const read = await transport.send({ op: "read-key", service: KEYCHAIN_CREDENTIAL_SERVICE });
+    expect(read).toEqual({ ok: true, op: "read-key", key });
+    expect(read.ok && read.op === "read-key" ? read.key : undefined).toBe(key);
     await expect(
       transport.send({
         op: "retry-created-key-rollback",

--- a/apps/desktop/tests/keychain-credential-encryption.test.ts
+++ b/apps/desktop/tests/keychain-credential-encryption.test.ts
@@ -209,11 +209,13 @@ describe("keychain partition backend", () => {
   });
 
   it("revalidates the same persisted key before a later write", async () => {
-    const { encoded } = storedKey();
+    const material = randomBytes(KEYCHAIN_KEY_BYTES);
+    const resident = Buffer.from(material);
+    const temporary = Buffer.from(material);
     const transport = transportOf(
       PROBE_OK,
-      { ok: true, op: "read-key", key: encoded },
-      { ok: true, op: "read-key", key: Buffer.from(encoded) },
+      { ok: true, op: "read-key", key: resident },
+      { ok: true, op: "read-key", key: temporary },
     );
     const result = await createEncryption({
       transport,
@@ -222,10 +224,14 @@ describe("keychain partition backend", () => {
     expect(result.status).toBe("ready");
     if (result.status !== "ready") return;
 
-    await expect(
-      serializePreparedEncryption((proof) => result.prepareKey(proof)),
-    ).resolves.toEqual({ status: "ready" });
+    await expect(serializePreparedEncryption((proof) => result.prepareKey(proof))).resolves.toEqual(
+      { status: "ready" },
+    );
     expect(result.encryption.isEncryptionAvailable()).toBe(true);
+    expect(temporary).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
+    expect(resident).toEqual(material);
+    const sealed = result.encryption.encryptString("still-usable");
+    expect(result.encryption.decryptString(sealed)).toBe("still-usable");
     expect(transport.requests.map((request) => request.op)).toEqual([
       "probe",
       "read-key",
@@ -251,6 +257,8 @@ describe("keychain partition backend", () => {
     await expect(
       serializePreparedEncryption((proof) => result.prepareKey(proof)),
     ).resolves.toEqual({ status: "failed", code: "unknown" });
+    expect(original.encoded).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
+    expect(replacement.encoded).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
     expect(result.encryption.isEncryptionAvailable()).toBe(false);
     expect(() => result.encryption.encryptString("must-not-seal")).toThrow(
       KeychainEncryptionError,
@@ -280,6 +288,8 @@ describe("keychain partition backend", () => {
     await expect(
       serializePreparedEncryption((proof) => result.validateKey(proof)),
     ).resolves.toEqual({ status: "failed", code: "unknown" });
+    expect(original.encoded).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
+    expect(replacement.encoded).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
     expect(result.encryption.isEncryptionAvailable()).toBe(false);
     expect(transport.requests.map((request) => request.op)).toEqual([
       "probe",
@@ -372,6 +382,57 @@ describe("keychain partition backend", () => {
     expect(
       transport.requests.every((request) => request.service === KEYCHAIN_CREDENTIAL_SERVICE_DEV),
     ).toBe(true);
+  });
+
+  it("publishes created material by identity until reset wipes it", async () => {
+    const created = randomBytes(KEYCHAIN_KEY_BYTES);
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: false, code: "item-not-found" },
+      { ok: false, code: "item-not-found" },
+      { ok: true, op: "create-key", key: created },
+      { ok: true, op: "delete-key", deleted: true },
+    );
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+      envelopeCensus: { deletionBlockers: 0, keychainDependents: 0 },
+    });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await expect(serializePreparedEncryption((proof) => result.prepareKey(proof))).resolves.toEqual(
+      { status: "ready" },
+    );
+    const sealed = result.encryption.encryptString("created-key-secret");
+    expect(result.encryption.decryptString(sealed)).toBe("created-key-secret");
+    expect(created).not.toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
+
+    await expect(
+      serializePreparedEncryption((proof) => result.deleteKeyForReset(proof)),
+    ).resolves.toEqual({ status: "deleted" });
+    expect(created).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
+  });
+
+  it("wipes resident material when reset deletion fails", async () => {
+    const resident = randomBytes(KEYCHAIN_KEY_BYTES);
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: resident },
+      { ok: false, code: "keychain-locked" },
+    );
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    await expect(
+      serializePreparedEncryption((proof) => result.deleteKeyForReset(proof)),
+    ).resolves.toEqual({ status: "failed", code: "keychain-locked" });
+    expect(resident).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
+    expect(result.encryption.isEncryptionAvailable()).toBe(false);
   });
 
   it("retries failed creation through exact rollback before another census or read", async () => {
@@ -587,16 +648,33 @@ describe("keychain partition backend", () => {
   });
 
   it("refuses a helper key of the wrong size", async () => {
+    const discarded = randomBytes(16);
     const transport = transportOf(PROBE_OK, {
       ok: true,
       op: "read-key",
-      key: randomBytes(16),
+      key: discarded,
     });
     const result = await createEncryption({
       transport,
       service: KEYCHAIN_CREDENTIAL_SERVICE,
     });
     expect(result.status).toBe("storage-failed");
+    expect(discarded).toEqual(Buffer.alloc(16));
+  });
+
+  it("wipes key material returned for the wrong operation", async () => {
+    const discarded = randomBytes(KEYCHAIN_KEY_BYTES);
+    const transport = transportOf(PROBE_OK, {
+      ok: true,
+      op: "create-key",
+      key: discarded,
+    });
+    const result = await createEncryption({
+      transport,
+      service: KEYCHAIN_CREDENTIAL_SERVICE,
+    });
+    expect(result.status).toBe("storage-failed");
+    expect(discarded).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
   });
 
   it("preserves an uninspectable item and reports encryption unavailable", async () => {
@@ -681,6 +759,7 @@ describe("keychain partition backend", () => {
       code: "unknown",
       keyCleanupPending: true,
     });
+    expect(original.encoded).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
     expect(result.encryption.isEncryptionAvailable()).toBe(false);
     expect(() => result.encryption.encryptString("orphan-candidate")).toThrow(
       KeychainEncryptionError,
@@ -700,6 +779,34 @@ describe("keychain partition backend", () => {
     ]);
     const sealed = result.encryption.encryptString("post-cleanup-secret");
     expect(openCredentialEnvelope(replacement.key, sealed)).toBe("post-cleanup-secret");
+  });
+
+  it("wipes resident material after successful retirement", async () => {
+    const original = storedKey();
+    let census = { deletionBlockers: 1, keychainDependents: 1 };
+    const transport = transportOf(
+      PROBE_OK,
+      { ok: true, op: "read-key", key: original.encoded },
+      { ok: true, op: "delete-key", deleted: true },
+    );
+    const serialize = createCredentialEnvelopeMutationLock();
+    const result = await serialize((lockProof) =>
+      createKeychainPartitionEncryption({
+        transport,
+        service: KEYCHAIN_CREDENTIAL_SERVICE,
+        inspectAutomaticRetirement: automaticRetirementInspector(async () => census),
+        lockProof,
+      }),
+    );
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+
+    census = { deletionBlockers: 0, keychainDependents: 0 };
+    await expect(serialize((proof) => result.retireKey(proof))).resolves.toEqual({
+      status: "deleted",
+    });
+    expect(original.encoded).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
+    expect(result.encryption.isEncryptionAvailable()).toBe(false);
   });
 
   it("does not record cleanup debt when retirement inspection fails before deletion", async () => {
@@ -737,6 +844,7 @@ describe("keychain partition backend", () => {
       code: "unknown",
       keyCleanupPending: false,
     });
+    expect(original.encoded).toEqual(Buffer.alloc(KEYCHAIN_KEY_BYTES));
     expect(result.encryption.isEncryptionAvailable()).toBe(false);
     expect(transport.requests.map((request) => request.op)).toEqual(["probe", "read-key"]);
   });


### PR DESCRIPTION
## Summary

- Read the exact Keychain item content and erase it before native release.
- Transfer one valid key Buffer through TypeScript without duplicate copies.
- Erase malformed, discarded, temporary, reset, and retirement key Buffers.

## Verification

- Focused native and TypeScript tests: 49 passed.
- Desktop type check passed.
- Fresh read-only skeptic passed all 10 security criteria with no P0–P3 findings.

## Changeset

- Reuses the epic's existing secure-storage changeset.
