### PR TITLE
fix(desktop): block retirement on unknown vault entries

### DIFF
--- a/apps/desktop/src/main/automatic-key-retirement.ts
+++ b/apps/desktop/src/main/automatic-key-retirement.ts
@@ -67,7 +67,8 @@ export function createAutomaticKeyRetirementInspector(
         guardedCredentialEnvelopeRoots(roots, bindings),
       );
       await assertCredentialEnvelopeRootsStable(bindings);
-      const deletionBlockers = inventory.deletionBlockers.length;
+      const deletionBlockers =
+        inventory.deletionBlockers.length + inventory.unexplainedDeletionBlockers.length;
       return {
         status: "inspected",
         deletionBlockers,

--- a/apps/desktop/src/main/credential-envelope-inventory.ts
+++ b/apps/desktop/src/main/credential-envelope-inventory.ts
@@ -13,8 +13,10 @@ import {
 } from "./credential-envelope-inspection.js";
 import {
   TELEGRAM_CREDENTIAL_FILE_MODE,
+  TELEGRAM_DESIRED_STATE_FILE_NAME,
   TELEGRAM_PROFILE_FILE_NAME,
 } from "./telegram-credential-vault.js";
+import { TELEGRAM_POWER_STATE_FILE_NAME } from "./telegram-power.js";
 export {
   classifyCredentialEnvelopeRemoval,
   inspectCredentialEnvelopeTarget,
@@ -33,8 +35,15 @@ export interface CredentialEnvelopeRef extends CredentialEnvelopeTarget {
   readonly keyId: number | undefined;
 }
 
+export interface UnexplainedCredentialVaultEntry {
+  readonly vault: CredentialEnvelopeVault;
+  readonly root: string;
+  readonly fileName: string;
+}
+
 export interface CredentialEnvelopeInventory {
   readonly deletionBlockers: readonly CredentialEnvelopeRef[];
+  readonly unexplainedDeletionBlockers: readonly UnexplainedCredentialVaultEntry[];
   readonly keychainDependents: number;
   readonly unverified: number;
 }
@@ -131,6 +140,64 @@ function transientCredentialEnvelopeTarget(
   return undefined;
 }
 
+function knownNonEnvelopeTelegramEntryName(entry: string): boolean {
+  for (const [fileName, suffixes] of [
+    [TELEGRAM_DESIRED_STATE_FILE_NAME, [".tmp", ".deleted"]],
+    [TELEGRAM_POWER_STATE_FILE_NAME, [".tmp"]],
+  ] as const) {
+    if (entry === fileName) return true;
+    const prefix = `.${fileName}.`;
+    if (!entry.startsWith(prefix)) continue;
+    for (const suffix of suffixes) {
+      if (!entry.endsWith(suffix)) continue;
+      const id = entry.slice(prefix.length, -suffix.length);
+      if (/^[A-Za-z0-9-]{1,128}$/.test(id)) return true;
+    }
+  }
+  return false;
+}
+
+async function isVerifiedNonEnvelopeTelegramEntry(
+  root: string,
+  entry: string,
+  inspect: (target: CredentialEnvelopeTarget) => Promise<CredentialEnvelopeInspection>,
+): Promise<boolean> {
+  let inspected: CredentialEnvelopeInspection;
+  try {
+    inspected = await inspect({
+      vault: "telegram",
+      root,
+      fileName: entry,
+      mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+    });
+  } catch {
+    return false;
+  }
+  if (inspected.status !== "readable") return false;
+  try {
+    return readCredentialEnvelopeKeyId(inspected.contents) !== KEYCHAIN_ENVELOPE_KEY_ID;
+  } finally {
+    inspected.contents.fill(0);
+  }
+}
+
+function canonicalEnvelopeEntry(
+  roots: CredentialEnvelopeRoots,
+  root: string,
+  entry: string,
+): boolean {
+  return credentialEnvelopeTargets(roots).some(
+    (target) => target.root === root && target.fileName === entry,
+  );
+}
+
+function credentialEnvelopeVaultForRoot(
+  roots: CredentialEnvelopeRoots,
+  root: string,
+): CredentialEnvelopeVault {
+  return root === roots.credentialRoot ? "credentials" : "telegram";
+}
+
 async function inspectEnvelopeTarget(
   target: CredentialEnvelopeTarget,
   inspect: (target: CredentialEnvelopeTarget) => Promise<CredentialEnvelopeInspection>,
@@ -174,6 +241,7 @@ export async function scanCredentialEnvelopes(
       : injectedEnvelopeInspector(roots.readEnvelopeFile));
   const readDirectory = roots.readEnvelopeDirectory ?? readCredentialEnvelopeDirectory;
   const deletionBlockers: CredentialEnvelopeRef[] = [];
+  const unexplainedDeletionBlockers: UnexplainedCredentialVaultEntry[] = [];
   const canonicalEnvelopes: CredentialEnvelopeRef[] = [];
   const missingCanonicalTargets: CredentialEnvelopeTarget[] = [];
   for (const target of credentialEnvelopeTargets(roots)) {
@@ -197,10 +265,25 @@ export async function scanCredentialEnvelopes(
       throw new RangeError("credential envelope directory entry limit exceeded");
     }
     for (const entry of entries) {
+      if (canonicalEnvelopeEntry(roots, root, entry)) continue;
       const target = transientCredentialEnvelopeTarget(roots, root, entry);
-      if (target === undefined) continue;
-      const inspected = await inspectEnvelopeTarget(target, inspect);
-      if (inspected !== undefined) deletionBlockers.push(inspected);
+      if (target !== undefined) {
+        const inspected = await inspectEnvelopeTarget(target, inspect);
+        if (inspected !== undefined) deletionBlockers.push(inspected);
+        continue;
+      }
+      if (
+        root === roots.telegramRoot &&
+        knownNonEnvelopeTelegramEntryName(entry) &&
+        (await isVerifiedNonEnvelopeTelegramEntry(root, entry, inspect))
+      ) {
+        continue;
+      }
+      unexplainedDeletionBlockers.push({
+        vault: credentialEnvelopeVaultForRoot(roots, root),
+        root,
+        fileName: entry,
+      });
     }
   }
   for (const target of missingCanonicalTargets) {
@@ -215,9 +298,9 @@ export async function scanCredentialEnvelopes(
   ).length;
   return {
     deletionBlockers,
+    unexplainedDeletionBlockers,
     keychainDependents,
-    unverified: canonicalEnvelopes.filter(
-      (envelope) => envelope.keyId !== KEYCHAIN_ENVELOPE_KEY_ID,
-    ).length,
+    unverified: canonicalEnvelopes.filter((envelope) => envelope.keyId !== KEYCHAIN_ENVELOPE_KEY_ID)
+      .length,
   };
 }

--- a/apps/desktop/src/main/credential-reset.ts
+++ b/apps/desktop/src/main/credential-reset.ts
@@ -75,7 +75,11 @@ export function resetEncryptedCredentialStorage(
           }
         }
       }
-      if ((await scanCredentialEnvelopes(guardedRoots)).deletionBlockers.length !== 0) {
+      const finalInventory = await scanCredentialEnvelopes(guardedRoots);
+      if (
+        finalInventory.deletionBlockers.length !== 0 ||
+        finalInventory.unexplainedDeletionBlockers.length !== 0
+      ) {
         return { status: "failed" };
       }
       await assertCredentialEnvelopeRootsStable(bindings);

--- a/apps/desktop/tests/credential-key-retirement.test.ts
+++ b/apps/desktop/tests/credential-key-retirement.test.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { mkdir, mkdtemp, readdir, realpath, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -335,6 +335,21 @@ describe("keychain key retirement call sites", () => {
       `scan:${roots.credentialRoot}`,
       `scan:${roots.telegramRoot}`,
     ]);
+  });
+
+  posixIt("never creates a zero proof while an unexplained vault entry remains", async () => {
+    const roots = await fixture();
+    await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
+    await writeFile(join(roots.credentialRoot, "future-entry"), "unexplained");
+    const transport = transportOf();
+    const serializeEnvelopeMutation = createCredentialEnvelopeMutationLock();
+
+    const result = await serializeEnvelopeMutation((proof) =>
+      retireKey(roots, transport, proof),
+    );
+
+    expect(result).toEqual({ status: "retained", envelopes: 1 });
+    expect(transport.requests).toEqual([]);
   });
 
   posixIt("keeps the key when a credential envelope outlives the Telegram profile", async () => {

--- a/apps/desktop/tests/credential-reset.test.ts
+++ b/apps/desktop/tests/credential-reset.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +9,7 @@ import { CREDENTIAL_DIRECTORY_MODE, CREDENTIAL_FILE_MODE } from "../src/main/cre
 import {
   TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
   TELEGRAM_CREDENTIAL_FILE_MODE,
+  TELEGRAM_DESIRED_STATE_FILE_NAME,
   TELEGRAM_PROFILE_FILE_NAME,
 } from "../src/main/telegram-credential-vault.js";
 
@@ -45,22 +46,27 @@ afterEach(async () => {
 });
 
 describe("encrypted credential reset", () => {
-  it("removes every envelope under one shared lock and preserves unrelated files", async () => {
+  it("removes every envelope under one shared lock and preserves known Telegram state", async () => {
     const storage = await fixture();
     for (const target of credentialEnvelopeTargets(storage)) {
       await writeFile(join(target.root, target.fileName), Buffer.from("synthetic-envelope"));
     }
-    const unrelated = join(storage.credentialRoot, "keep.txt");
+    const desiredState = join(storage.telegramRoot, TELEGRAM_DESIRED_STATE_FILE_NAME);
+    const desiredStateTemporary = join(
+      storage.telegramRoot,
+      `.${TELEGRAM_DESIRED_STATE_FILE_NAME}.reset-3.tmp`,
+    );
     const credentialTemporary = join(storage.credentialRoot, ".anthropic.bin.reset-1.tmp");
     const telegramTombstone = join(
       storage.telegramRoot,
       `.${TELEGRAM_PROFILE_FILE_NAME}.reset-2.deleted`,
     );
-    const unrelatedTemporary = join(storage.credentialRoot, ".unknown.bin.reset-3.tmp");
-    await writeFile(unrelated, "keep");
+    await writeFile(desiredState, "desired-state", { mode: TELEGRAM_CREDENTIAL_FILE_MODE });
+    await writeFile(desiredStateTemporary, "desired-state-transient", {
+      mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+    });
     await writeFile(credentialTemporary, "credential-transient");
     await writeFile(telegramTombstone, "telegram-transient");
-    await writeFile(unrelatedTemporary, "unrelated-transient");
     const deleteKey = vi.fn(async () => ({ status: "deleted" as const }));
 
     const result = await resetEncryptedCredentialStorage({
@@ -71,8 +77,10 @@ describe("encrypted credential reset", () => {
 
     expect(result).toEqual({ status: "reset", keyCleanupPending: false });
     expect(deleteKey).toHaveBeenCalledOnce();
-    await expect(readFile(unrelated, "utf8")).resolves.toBe("keep");
-    await expect(readFile(unrelatedTemporary, "utf8")).resolves.toBe("unrelated-transient");
+    await expect(readFile(desiredState, "utf8")).resolves.toBe("desired-state");
+    await expect(readFile(desiredStateTemporary, "utf8")).resolves.toBe(
+      "desired-state-transient",
+    );
     await expect(readFile(credentialTemporary)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(telegramTombstone)).rejects.toMatchObject({ code: "ENOENT" });
     for (const target of credentialEnvelopeTargets(storage)) {
@@ -130,6 +138,31 @@ describe("encrypted credential reset", () => {
 
     expect(result).toEqual({ status: "failed" });
     expect(deleteKey).not.toHaveBeenCalled();
+  });
+
+  it("preserves unexplained entries and retains the shared key", async () => {
+    const storage = await fixture();
+    const target = credentialEnvelopeTargets(storage)[0]!;
+    const unknownCredential = join(storage.credentialRoot, "future-credential-state");
+    const unknownTelegram = join(storage.telegramRoot, "future-telegram-state");
+    await writeFile(join(target.root, target.fileName), "synthetic-envelope");
+    await writeFile(unknownCredential, "credential-state");
+    await mkdir(unknownTelegram);
+    const deleteKey = vi.fn(async () => ({ status: "deleted" as const }));
+
+    const result = await resetEncryptedCredentialStorage({
+      ...storage,
+      serializeEnvelopeMutation: createCredentialEnvelopeMutationLock(),
+      deleteKey,
+    });
+
+    expect(result).toEqual({ status: "failed" });
+    expect(deleteKey).not.toHaveBeenCalled();
+    await expect(readFile(unknownCredential, "utf8")).resolves.toBe("credential-state");
+    await expect(readFile(join(target.root, target.fileName))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect((await lstat(unknownTelegram)).isDirectory()).toBe(true);
   });
 
   it("accepts missing roots without following or inspecting them", async () => {

--- a/apps/desktop/tests/keychain-key-lifetime.test.ts
+++ b/apps/desktop/tests/keychain-key-lifetime.test.ts
@@ -50,9 +50,11 @@ import { retireKeychainKeyWhenLastEnvelopeGone } from "../src/main/keychain-key-
 import {
   TELEGRAM_CREDENTIAL_DIRECTORY_MODE,
   TELEGRAM_CREDENTIAL_FILE_MODE,
+  TELEGRAM_DESIRED_STATE_FILE_NAME,
   TELEGRAM_PROFILE_FILE_NAME,
   createTelegramCredentialVault,
 } from "../src/main/telegram-credential-vault.js";
+import { TELEGRAM_POWER_STATE_FILE_NAME } from "../src/main/telegram-power.js";
 
 const fixtureRoots: string[] = [];
 const posixIt = it.skipIf(process.platform === "win32");
@@ -277,7 +279,7 @@ describe("keychain key retirement", () => {
 
     await expect(retireKey(roots, transport)).resolves.toEqual({
       status: "retained",
-      envelopes: 1,
+      envelopes: 2,
     });
     expect(transport.requests).toHaveLength(0);
   });
@@ -351,10 +353,7 @@ describe("keychain key retirement", () => {
     const roots = await fixture();
     await mkdir(roots.credentialRoot, { mode: CREDENTIAL_DIRECTORY_MODE });
     await mkdir(roots.telegramRoot, { mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
-    const envelope = sealCredentialEnvelope(
-      randomBytes(KEYCHAIN_KEY_BYTES),
-      "classifier-parity",
-    );
+    const envelope = sealCredentialEnvelope(randomBytes(KEYCHAIN_KEY_BYTES), "classifier-parity");
     await writeFile(join(roots.credentialRoot, "anthropic.bin"), envelope, { mode: 0o600 });
     await writeFile(join(roots.telegramRoot, TELEGRAM_PROFILE_FILE_NAME), envelope, {
       mode: TELEGRAM_CREDENTIAL_FILE_MODE,
@@ -494,7 +493,7 @@ describe("keychain key retirement", () => {
 
     await expect(retireKey(roots, transport)).resolves.toEqual({
       status: "retained",
-      envelopes: 2,
+      envelopes: 3,
     });
     expect(transport.requests).toHaveLength(0);
   });
@@ -574,18 +573,105 @@ describe("keychain key retirement", () => {
     expect(inventory.unverified).toBe(0);
   });
 
-  posixIt("ignores files outside the credential transient namespaces", async () => {
+  posixIt("keeps unexplained entries separate from envelope recovery counts", async () => {
     const roots = await fixture();
     await mkdir(roots.credentialRoot, { recursive: true, mode: CREDENTIAL_DIRECTORY_MODE });
     await mkdir(roots.telegramRoot, { recursive: true, mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
-    await writeFile(join(roots.credentialRoot, ".unknown.bin.cleanup.tmp"), "unrelated");
+    await writeFile(join(roots.credentialRoot, "future-credential-state"), "unexplained");
+    await mkdir(join(roots.telegramRoot, "future-telegram-state"));
+    const transport = transportOf();
+
+    const inventory = await scanCredentialEnvelopes(roots);
+
+    expect(inventory.deletionBlockers).toEqual([]);
+    expect(inventory.unexplainedDeletionBlockers).toEqual([
+      {
+        vault: "credentials",
+        root: roots.credentialRoot,
+        fileName: "future-credential-state",
+      },
+      {
+        vault: "telegram",
+        root: roots.telegramRoot,
+        fileName: "future-telegram-state",
+      },
+    ]);
+    expect(inventory.keychainDependents).toBe(0);
+    expect(inventory.unverified).toBe(0);
+    await expect(retireKey(roots, transport)).resolves.toEqual({
+      status: "retained",
+      envelopes: 2,
+    });
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  posixIt("exempts only exact bounded Telegram non-envelope vault state", async () => {
+    const roots = await fixture();
+    await mkdir(roots.telegramRoot, { recursive: true, mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    await writeFile(join(roots.telegramRoot, TELEGRAM_DESIRED_STATE_FILE_NAME), "known-state", {
+      mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+    });
     await writeFile(
-      join(roots.telegramRoot, ".telegram-desired-state.json.cleanup.deleted"),
-      "unrelated",
+      join(roots.telegramRoot, `.${TELEGRAM_DESIRED_STATE_FILE_NAME}.cleanup-1.deleted`),
+      "known-transient",
+      { mode: TELEGRAM_CREDENTIAL_FILE_MODE },
+    );
+    await writeFile(join(roots.telegramRoot, TELEGRAM_POWER_STATE_FILE_NAME), "known-power-state", {
+      mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+    });
+    await writeFile(
+      join(roots.telegramRoot, `.${TELEGRAM_POWER_STATE_FILE_NAME}.cleanup-1.tmp`),
+      "known-power-transient",
+      { mode: TELEGRAM_CREDENTIAL_FILE_MODE },
     );
     const transport = transportOf({ ok: true, op: "delete-key", deleted: true });
 
     await expect(retireKey(roots, transport)).resolves.toEqual({ status: "deleted" });
+  });
+
+  posixIt("blocks unsafe and keychain-backed Telegram state lookalikes", async () => {
+    const roots = await fixture();
+    await mkdir(roots.telegramRoot, { recursive: true, mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    await mkdir(join(roots.telegramRoot, TELEGRAM_DESIRED_STATE_FILE_NAME));
+    const keychainEnvelope = sealCredentialEnvelope(
+      randomBytes(KEYCHAIN_KEY_BYTES),
+      "not-desired-state",
+    );
+    const transient = `.${TELEGRAM_DESIRED_STATE_FILE_NAME}.cleanup-1.tmp`;
+    await writeFile(join(roots.telegramRoot, transient), keychainEnvelope, {
+      mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+    });
+    keychainEnvelope.fill(0);
+
+    const inventory = await scanCredentialEnvelopes(roots);
+
+    expect(inventory.deletionBlockers).toEqual([]);
+    expect(inventory.unexplainedDeletionBlockers.map((entry) => entry.fileName)).toEqual([
+      transient,
+      TELEGRAM_DESIRED_STATE_FILE_NAME,
+    ]);
+    expect(inventory.keychainDependents).toBe(0);
+    expect(inventory.unverified).toBe(0);
+  });
+
+  posixIt("blocks a keychain-backed Telegram power-state lookalike", async () => {
+    const roots = await fixture();
+    await mkdir(roots.telegramRoot, { recursive: true, mode: TELEGRAM_CREDENTIAL_DIRECTORY_MODE });
+    const keychainEnvelope = sealCredentialEnvelope(
+      randomBytes(KEYCHAIN_KEY_BYTES),
+      "not-power-state",
+    );
+    await writeFile(join(roots.telegramRoot, TELEGRAM_POWER_STATE_FILE_NAME), keychainEnvelope, {
+      mode: TELEGRAM_CREDENTIAL_FILE_MODE,
+    });
+    keychainEnvelope.fill(0);
+
+    const inventory = await scanCredentialEnvelopes(roots);
+
+    expect(inventory.deletionBlockers).toEqual([]);
+    expect(inventory.unexplainedDeletionBlockers.map((entry) => entry.fileName)).toEqual([
+      TELEGRAM_POWER_STATE_FILE_NAME,
+    ]);
   });
 
   posixIt("reports an absent item and a refused delete apart", async () => {


### PR DESCRIPTION
Summary:
- track unexplained vault entries separately from known credential envelopes
- block automatic key retirement and final reset proof while any unexplained entry remains
- inspect known Telegram state files before exempting them

Verification:
- desktop focused tests: 39 passed
- desktop TypeScript check: passed
- fresh read-only invariant review: 10 of 10 passed

Changeset:
- covered by the existing epic credential-retirement changesets