### PR TITLE
fix(desktop): retain global reset uncertainty

### DIFF
--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -79,7 +79,9 @@ interface CredentialSettingsContent {
   readonly focus: CredentialSettingsFocus;
 }
 
-export type CredentialSettingsState =
+export type CredentialSettingsState = {
+  readonly resetUncertain?: boolean;
+} & (
   | {
       readonly status: "closed";
       readonly repairCredential?: DesktopCredentialId | null;
@@ -106,7 +108,8 @@ export type CredentialSettingsState =
       readonly repairCredential: DesktopCredentialId | null;
       readonly recoveryAvailable: boolean;
       readonly focus: CredentialSettingsFocus;
-    };
+    }
+);
 
 export function repairRequiredCredential(
   state: CredentialSettingsState,
@@ -118,7 +121,13 @@ export function credentialChangesBlocked(
   state: CredentialSettingsState,
   settingsMutationActive: boolean,
 ): boolean {
-  if (settingsMutationActive || repairRequiredCredential(state) !== null) return true;
+  if (
+    settingsMutationActive ||
+    state.resetUncertain === true ||
+    repairRequiredCredential(state) !== null
+  ) {
+    return true;
+  }
   if (
     state.status === "ready" ||
     state.status === "confirming" ||
@@ -387,9 +396,12 @@ export function createCredentialSettingsController(input: {
   const startLoad = (retryRecovery = false): Promise<void> => {
     if (disposed || operation !== undefined) return operation ?? Promise.resolve();
     const repairCredential = repairRequiredCredential(currentState);
+    const resetUncertain = currentState.resetUncertain === true;
     const repairAnnouncement =
       repairCredential === null
-        ? ""
+        ? resetUncertain && "announcement" in currentState
+          ? currentState.announcement
+          : ""
         : "announcement" in currentState && currentState.announcement.length > 0
           ? currentState.announcement
           : UNCERTAIN_DELETE_ANNOUNCEMENT;
@@ -398,15 +410,16 @@ export function createCredentialSettingsController(input: {
       status: "loading",
       announcement: repairAnnouncement,
       repairCredential,
+      ...(resetUncertain ? { resetUncertain: true } : {}),
       recoveryAvailable: false,
-      focus: repairCredential === null ? null : { target: "feedback" },
+      focus: repairCredential === null && !resetUncertain ? null : { target: "feedback" },
     });
     const pending = (async () => {
       try {
         if (retryRecovery) await input.retryCredentialRecovery?.();
         const loaded = await loadEntries();
         if (disposed || generation !== operationGeneration) return;
-        if (repairCredential !== null) await input.onReconciled?.();
+        if (repairCredential !== null || resetUncertain) await input.onReconciled?.();
         if (disposed || generation !== operationGeneration) return;
         render({
           status: "ready",
@@ -430,8 +443,9 @@ export function createCredentialSettingsController(input: {
               ? "Saved credentials aren’t available. Reconnect and reload."
               : repairAnnouncement,
           repairCredential,
+          ...(resetUncertain ? { resetUncertain: true } : {}),
           recoveryAvailable: false,
-          focus: repairCredential === null ? null : { target: "feedback" },
+          focus: repairCredential === null && !resetUncertain ? null : { target: "feedback" },
         });
       }
     })().finally(() => {
@@ -505,7 +519,14 @@ export function createCredentialSettingsController(input: {
   };
 
   const requestReset = (): void => {
-    if (disposed || operation !== undefined || input.credentialMutationsBlocked?.()) return;
+    if (
+      disposed ||
+      operation !== undefined ||
+      currentState.resetUncertain === true ||
+      input.credentialMutationsBlocked?.()
+    ) {
+      return;
+    }
     const content = contentState();
     if (
       content === null ||
@@ -595,6 +616,7 @@ export function createCredentialSettingsController(input: {
               ? "Credential removal could not be verified because Settings could not reload. Reconnect and reload."
               : "Credentials were removed, but Settings could not reload. Reconnect and reload.",
           repairCredential: result.status === "refused" ? content.repairCredential : null,
+          resetUncertain: true,
           recoveryAvailable: true,
           focus: { target: "feedback" },
         });
@@ -641,7 +663,12 @@ export function createCredentialSettingsController(input: {
   };
 
   const confirmDelete = (): Promise<void> => {
-    if (disposed || operation !== undefined || input.credentialMutationsBlocked?.()) {
+    if (
+      disposed ||
+      operation !== undefined ||
+      currentState.resetUncertain === true ||
+      input.credentialMutationsBlocked?.()
+    ) {
       return operation ?? Promise.resolve();
     }
     const content = contentState();
@@ -795,7 +822,14 @@ export function createCredentialSettingsController(input: {
 
   const openSetup = (): void => {
     const content = contentState();
-    if (disposed || operation !== undefined || content?.recoveryAvailable !== true) return;
+    if (
+      disposed ||
+      operation !== undefined ||
+      currentState.resetUncertain === true ||
+      content?.recoveryAvailable !== true
+    ) {
+      return;
+    }
     currentState = { status: "closed" };
     input.openSetup();
   };
@@ -811,9 +845,11 @@ export function createCredentialSettingsController(input: {
     ++generation;
     operation = undefined;
     const repairCredential = repairRequiredCredential(currentState);
+    const resetUncertain = currentState.resetUncertain === true;
     currentState = {
       status: "closed",
       ...(repairCredential === null ? {} : { repairCredential }),
+      ...(resetUncertain ? { resetUncertain: true } : {}),
     };
   };
 

--- a/apps/desktop-renderer/src/state/settings-slice.ts
+++ b/apps/desktop-renderer/src/state/settings-slice.ts
@@ -207,14 +207,22 @@ export const createSettingsSlice: StateCreator<EnduragentState, [], [], Settings
   },
   closeSettingsPanes() {
     get().settingsPorts?.panes.close();
-    const repairCredential = repairRequiredCredential(get().settings.credentials);
+    const credentials = get().settings.credentials;
+    const repairCredential = repairRequiredCredential(credentials);
+    const resetUncertain = credentials.resetUncertain === true;
     if (repairCredential !== null) get().onboardingActions?.requireCompletion();
     set({
       settings: {
         ...get().settings,
         coach: CLOSED_PANE,
         credentials:
-          repairCredential === null ? CLOSED_PANE : { status: "closed", repairCredential },
+          repairCredential === null && !resetUncertain
+            ? CLOSED_PANE
+            : {
+                status: "closed",
+                ...(repairCredential === null ? {} : { repairCredential }),
+                ...(resetUncertain ? { resetUncertain: true } : {}),
+              },
         athlete: CLOSED_PANE,
         conversation: CLOSED_PANE,
       },

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -13,6 +13,7 @@ import type {
   CredentialSlotStatus,
 } from "../src/onboarding/machine.js";
 import {
+  credentialChangesBlocked,
   createCredentialSettingsController,
   type CredentialSettingsState,
   type CredentialSettingsView,
@@ -336,6 +337,55 @@ describe("credential settings controller", () => {
     });
   });
 
+  it.each(
+    (["reset", "refused"] as const).flatMap((resultStatus) =>
+      [true, false].flatMap((reloadSucceeds) =>
+        [true, false].map((callbackSucceeds) => ({
+          resultStatus,
+          reloadSucceeds,
+          callbackSucceeds,
+        })),
+      ),
+    ),
+  )(
+    "tracks reset uncertainty for $resultStatus with reload=$reloadSucceeds and callback=$callbackSucceeds",
+    async ({ resultStatus, reloadSucceeds, callbackSucceeds }) => {
+      let loadCount = 0;
+      const loadStatuses = vi.fn(async () => {
+        loadCount += 1;
+        if (loadCount === 2 && !reloadSucceeds) {
+          throw new Error("synthetic reset reload failure");
+        }
+        return [{ slot: "anthropic", state: "configured", runtimeState: "active" }] as const;
+      });
+      const callback = vi.fn(async () => {
+        if (!callbackSucceeds) throw new Error("synthetic reset callback failure");
+      });
+      const { controller, subject } = createSubject({
+        loadStatuses,
+        ...(resultStatus === "reset" ? { onDeleted: callback } : { onReconciled: callback }),
+        reset: async () =>
+          resultStatus === "reset"
+            ? { status: "reset", keyCleanupPending: false }
+            : { status: "refused", reason: "storage-failed" },
+      });
+      await controller.activate();
+
+      subject.requestReset();
+      subject.confirmDelete();
+      const uncertain = !reloadSucceeds || !callbackSucceeds;
+      await vi.waitFor(() =>
+        expect(controller.state().status).toBe(
+          uncertain ? "error" : resultStatus === "reset" ? "deleted" : "ready",
+        ),
+      );
+
+      expect(callback).toHaveBeenCalledTimes(reloadSucceeds ? 1 : 0);
+      expect(controller.state().resetUncertain).toBe(uncertain ? true : undefined);
+      expect(credentialChangesBlocked(controller.state(), false)).toBe(uncertain);
+    },
+  );
+
   it("reloads authoritative credential state when reset refuses after a partial mutation", async () => {
     let backingStatuses: readonly CredentialSlotStatus[] = [
       { slot: "anthropic", state: "configured", runtimeState: "active" },
@@ -438,6 +488,7 @@ describe("credential settings controller", () => {
       announcement:
         "Credential removal could not be verified because Settings could not reload. Reconnect and reload.",
       repairCredential: null,
+      resetUncertain: true,
       recoveryAvailable: true,
       focus: { target: "feedback" },
     });
@@ -478,10 +529,113 @@ describe("credential settings controller", () => {
       announcement:
         "Credential removal could not be verified because Settings could not reload. Reconnect and reload.",
       repairCredential: "anthropic",
+      resetUncertain: true,
       recoveryAvailable: true,
       focus: { target: "feedback" },
     });
     expect(releaseMutation).toHaveBeenCalled();
+  });
+
+  it("retains reset uncertainty across failed reload, failed reconciliation, and a successful retry", async () => {
+    let loadCount = 0;
+    const loadStatuses = vi.fn(async () => {
+      loadCount += 1;
+      if (loadCount === 2 || loadCount === 3) {
+        throw new Error("synthetic authoritative reload failure");
+      }
+      return [{ slot: "anthropic", state: "configured", runtimeState: "active" }] as const;
+    });
+    const onReconciled = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("synthetic reconciliation failure"))
+      .mockResolvedValueOnce();
+    const { controller, subject, resetAllCredentials } = createSubject({
+      loadStatuses,
+      onReconciled,
+      reset: async () => ({ status: "reset", keyCleanupPending: false }),
+    });
+    await controller.activate();
+    subject.requestReset();
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(controller.state().resetUncertain).toBe(true));
+
+    subject.requestDelete("anthropic");
+    subject.requestReset();
+    subject.confirmDelete();
+    expect(resetAllCredentials).toHaveBeenCalledOnce();
+
+    subject.retry();
+    await vi.waitFor(() => expect(loadStatuses).toHaveBeenCalledTimes(3));
+    expect(controller.state()).toMatchObject({
+      status: "error",
+      kind: "load",
+      resetUncertain: true,
+    });
+    expect(onReconciled).not.toHaveBeenCalled();
+
+    subject.retry();
+    await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledOnce());
+    expect(controller.state()).toMatchObject({
+      status: "error",
+      kind: "load",
+      resetUncertain: true,
+    });
+
+    subject.retry();
+    await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(controller.state().status).toBe("ready"));
+    expect(controller.state().resetUncertain).toBeUndefined();
+    expect(credentialChangesBlocked(controller.state(), false)).toBe(false);
+  });
+
+  it("preserves reset uncertainty through close and reopen until reconciliation succeeds", async () => {
+    let loadCount = 0;
+    const loadStatuses = vi.fn(async () => {
+      loadCount += 1;
+      if (loadCount === 2) throw new Error("synthetic reset reload failure");
+      return [{ slot: "anthropic", state: "configured", runtimeState: "active" }] as const;
+    });
+    const onReconciled = vi.fn(async () => {});
+    const { controller, subject } = createSubject({
+      loadStatuses,
+      onReconciled,
+      reset: async () => ({ status: "refused", reason: "storage-failed" }),
+    });
+    await controller.activate();
+    subject.requestReset();
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(controller.state().resetUncertain).toBe(true));
+
+    controller.close();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
+
+    await controller.activate();
+    expect(onReconciled).toHaveBeenCalledOnce();
+    expect(controller.state().status).toBe("ready");
+    expect(controller.state().resetUncertain).toBeUndefined();
+  });
+
+  it("keeps ordinary load errors mutable when no reset was attempted", async () => {
+    const onReconciled = vi.fn(async () => {});
+    const { controller } = createSubject({
+      loadStatuses: async () => {
+        throw new Error("synthetic initial load failure");
+      },
+      onReconciled,
+    });
+
+    await controller.activate();
+
+    expect(controller.state()).toEqual({
+      status: "error",
+      kind: "load",
+      announcement: "Saved credentials aren’t available. Reconnect and reload.",
+      repairCredential: null,
+      recoveryAvailable: false,
+      focus: null,
+    });
+    expect(onReconciled).not.toHaveBeenCalled();
+    expect(credentialChangesBlocked(controller.state(), false)).toBe(false);
   });
 
   it("builds a provider, kind, and coarse-state-only list for every stored credential kind", async () => {

--- a/apps/desktop-renderer/tests/onboarding-settings-mutation-gate.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-settings-mutation-gate.test.tsx
@@ -87,6 +87,23 @@ describe("onboarding settings mutation gate", () => {
     wizard.controller.dispose();
   });
 
+  it("blocks onboarding credential mutations while a global reset is uncertain", async () => {
+    useEnduragentStore.setState((state) => ({
+      settings: {
+        ...state.settings,
+        credentials: { status: "closed", resetUncertain: true },
+      },
+    }));
+
+    expect(onboardingCredentialMutationsBlocked(useEnduragentStore.getState())).toBe(true);
+    const wizard = mountWizard({ bridge: readyBridge() });
+    await wizard.open();
+
+    expect(setupTrigger("ai")).toBeDisabled();
+    expect(setupTrigger("training")).toBeDisabled();
+    wizard.controller.dispose();
+  });
+
   it("still blocks setup completion when another settings mutation is active", async () => {
     const bridge = readyBridge();
     const onComplete = vi.fn();

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -531,6 +531,19 @@ describe("shell", () => {
     expect(screen.queryByRole("navigation", { name: "Main navigation" })).toBeNull();
   });
 
+  it("preserves global reset uncertainty when settings panes close", () => {
+    useEnduragentStore.getState().patchSettings({
+      credentials: { status: "closed", resetUncertain: true },
+    });
+
+    useEnduragentStore.getState().closeSettingsPanes();
+
+    expect(useEnduragentStore.getState().settings.credentials).toEqual({
+      status: "closed",
+      resetUncertain: true,
+    });
+  });
+
   it("holds a repair-triggered gate after reconciliation until Start coaching", () => {
     const requireCompletion = vi.fn(() => {
       useEnduragentStore.setState((state) => ({


### PR DESCRIPTION
Summary:
- represent reset uncertainty independently from per-credential repair debt
- block every credential mutation lane until authoritative reload and reconciliation succeed
- preserve the latch through retry, pane close, and reopen

Verification:
- renderer focused tests: 75 passed
- renderer source and test TypeScript checks: passed
- fresh read-only invariant review: 10 of 10 passed

Changeset:
- covered by the existing epic credential-reset changeset