### PR TITLE
fix(desktop): complete reset uncertainty gate

### DIFF
--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -583,6 +583,7 @@ export function createCredentialSettingsController(input: {
       announcement: "Removing all credentials…",
       recovery: content.recovery,
       repairCredential: content.repairCredential,
+      resetUncertain: true,
       recoveryAvailable: content.recoveryAvailable,
       focus: { target: "confirmation-delete" },
     });
@@ -600,6 +601,7 @@ export function createCredentialSettingsController(input: {
       let loaded: Awaited<ReturnType<typeof loadEntries>>;
       try {
         loaded = await loadEntries();
+        if (disposed || generation !== operationGeneration) return;
         if (result.status === "refused") {
           await input.onReconciled?.();
         } else {

--- a/apps/desktop-renderer/src/settings/telegram-controller.ts
+++ b/apps/desktop-renderer/src/settings/telegram-controller.ts
@@ -655,8 +655,7 @@ export function createTelegramSettingsController(input: {
     if (
       disposed ||
       operation !== undefined ||
-      ((action === "paste-token" || action === "remove") &&
-        input.credentialMutationsBlocked?.())
+      ((action === "paste-token" || action === "remove") && input.credentialMutationsBlocked?.())
     ) {
       return;
     }
@@ -737,7 +736,7 @@ export function createTelegramSettingsController(input: {
     action: "add-sender" | "remove-sender",
     invoke: () => Promise<TelegramAllowedSendersMutationResult>,
   ): void => {
-    if (disposed || operation !== undefined) return;
+    if (disposed || operation !== undefined || input.credentialMutationsBlocked?.()) return;
     const release = input.beginMutation();
     if (release === null) return;
     const previous = readCurrentContent();

--- a/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
+++ b/apps/desktop-renderer/src/ui/settings/TelegramSection.tsx
@@ -238,6 +238,7 @@ export function TelegramSection(): ReactElement {
 
   const submitSender = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
+    if (credentialMutationBlocked) return;
     const senderId = parseSenderId(senderDraft);
     if (senderId === null) {
       setSenderError("Enter a numeric Telegram user ID with at least two digits.");
@@ -632,7 +633,9 @@ export function TelegramSection(): ReactElement {
                           type="button"
                           variant="destructive"
                           size="sm"
-                          disabled={busy || confirmRemoveSenderId !== null}
+                          disabled={
+                            busy || credentialMutationBlocked || confirmRemoveSenderId !== null
+                          }
                           aria-label={"Remove Telegram user " + sender.senderId}
                           onClick={(event) => {
                             removeSenderTrigger.current = event.currentTarget;
@@ -649,13 +652,14 @@ export function TelegramSection(): ReactElement {
                             confirmLabel="Remove user"
                             focusTarget={null}
                             cancelDisabled={busy}
-                            confirmDisabled={busy}
+                            confirmDisabled={busy || credentialMutationBlocked}
                             confirmBusy={removingSender}
                             onCancel={() => {
                               setConfirmRemoveSenderId(null);
                               queueMicrotask(() => removeSenderTrigger.current?.focus());
                             }}
                             onConfirm={() => {
+                              if (credentialMutationBlocked) return;
                               port?.removeSender(sender.senderId);
                             }}
                           />
@@ -679,7 +683,7 @@ export function TelegramSection(): ReactElement {
                   spellCheck={false}
                   className={FIELD_CLASS}
                   value={senderDraft}
-                  disabled={busy}
+                  disabled={busy || credentialMutationBlocked}
                   aria-invalid={senderError === null ? undefined : "true"}
                   aria-describedby="telegram-sender-help telegram-sender-error"
                   onChange={(event) => {
@@ -687,7 +691,12 @@ export function TelegramSection(): ReactElement {
                     setSenderError(null);
                   }}
                 />
-                <Button type="submit" variant="outline" size="sm" disabled={busy}>
+                <Button
+                  type="submit"
+                  variant="outline"
+                  size="sm"
+                  disabled={busy || credentialMutationBlocked}
+                >
                   Add user
                 </Button>
               </div>

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -557,7 +557,7 @@ describe("credential settings controller", () => {
     await controller.activate();
     subject.requestReset();
     subject.confirmDelete();
-    await vi.waitFor(() => expect(controller.state().resetUncertain).toBe(true));
+    await vi.waitFor(() => expect(controller.state().status).toBe("error"));
 
     subject.requestDelete("anthropic");
     subject.requestReset();
@@ -604,7 +604,7 @@ describe("credential settings controller", () => {
     await controller.activate();
     subject.requestReset();
     subject.confirmDelete();
-    await vi.waitFor(() => expect(controller.state().resetUncertain).toBe(true));
+    await vi.waitFor(() => expect(controller.state().status).toBe("error"));
 
     controller.close();
     expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
@@ -612,6 +612,118 @@ describe("credential settings controller", () => {
     await controller.activate();
     expect(onReconciled).toHaveBeenCalledOnce();
     expect(controller.state().status).toBe("ready");
+    expect(controller.state().resetUncertain).toBeUndefined();
+  });
+
+  it("preserves reset uncertainty when closed while the reset is pending", async () => {
+    let resolveReset!: (result: CredentialResetResult) => void;
+    const reset = new Promise<CredentialResetResult>((resolve) => {
+      resolveReset = resolve;
+    });
+    let resolveReconciliation!: () => void;
+    const reconciliation = new Promise<void>((resolve) => {
+      resolveReconciliation = resolve;
+    });
+    const onReconciled = vi.fn(() => reconciliation);
+    const { controller, subject, resetAllCredentials, releaseMutation } = createSubject({
+      onReconciled,
+      reset: () => reset,
+    });
+    await controller.activate();
+    subject.requestReset();
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(resetAllCredentials).toHaveBeenCalledOnce());
+
+    expect(controller.state()).toMatchObject({ status: "deleting", resetUncertain: true });
+    controller.close();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
+    resolveReset({ status: "refused", reason: "storage-failed" });
+    await vi.waitFor(() => expect(releaseMutation).toHaveBeenCalled());
+
+    void controller.activate();
+    await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledOnce());
+    expect(controller.state()).toMatchObject({ status: "loading", resetUncertain: true });
+    resolveReconciliation();
+    await vi.waitFor(() => expect(controller.state().status).toBe("ready"));
+    expect(controller.state().resetUncertain).toBeUndefined();
+  });
+
+  it("preserves reset uncertainty when closed while the authoritative reload is pending", async () => {
+    let resolveReload!: (statuses: readonly CredentialSlotStatus[]) => void;
+    const reload = new Promise<readonly CredentialSlotStatus[]>((resolve) => {
+      resolveReload = resolve;
+    });
+    let loadCount = 0;
+    const loadStatuses = vi.fn(() => {
+      loadCount += 1;
+      return loadCount === 2
+        ? reload
+        : Promise.resolve([
+            { slot: "anthropic", state: "configured", runtimeState: "active" },
+          ] as const);
+    });
+    let resolveReconciliation!: () => void;
+    const reconciliation = new Promise<void>((resolve) => {
+      resolveReconciliation = resolve;
+    });
+    const onReconciled = vi.fn(() => reconciliation);
+    const { controller, subject, releaseMutation } = createSubject({
+      loadStatuses,
+      onReconciled,
+      reset: async () => ({ status: "refused", reason: "storage-failed" }),
+    });
+    await controller.activate();
+    subject.requestReset();
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(loadStatuses).toHaveBeenCalledTimes(2));
+
+    expect(controller.state()).toMatchObject({ status: "deleting", resetUncertain: true });
+    controller.close();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
+    resolveReload([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
+    await vi.waitFor(() => expect(releaseMutation).toHaveBeenCalled());
+
+    void controller.activate();
+    await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledOnce());
+    expect(controller.state()).toMatchObject({ status: "loading", resetUncertain: true });
+    resolveReconciliation();
+    await vi.waitFor(() => expect(controller.state().status).toBe("ready"));
+    expect(controller.state().resetUncertain).toBeUndefined();
+  });
+
+  it("preserves reset uncertainty when closed while reconciliation is pending", async () => {
+    let resolveFirstReconciliation!: () => void;
+    const firstReconciliation = new Promise<void>((resolve) => {
+      resolveFirstReconciliation = resolve;
+    });
+    let resolveSecondReconciliation!: () => void;
+    const secondReconciliation = new Promise<void>((resolve) => {
+      resolveSecondReconciliation = resolve;
+    });
+    const onReconciled = vi
+      .fn<() => Promise<void>>()
+      .mockReturnValueOnce(firstReconciliation)
+      .mockReturnValueOnce(secondReconciliation);
+    const { controller, subject, releaseMutation } = createSubject({
+      onReconciled,
+      reset: async () => ({ status: "refused", reason: "storage-failed" }),
+    });
+    await controller.activate();
+    subject.requestReset();
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledOnce());
+
+    expect(controller.state()).toMatchObject({ status: "deleting", resetUncertain: true });
+    controller.close();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
+    resolveFirstReconciliation();
+    await vi.waitFor(() => expect(releaseMutation).toHaveBeenCalled());
+
+    void controller.activate();
+    await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledTimes(2));
+    expect(controller.state()).toMatchObject({ status: "loading", resetUncertain: true });
+    resolveSecondReconciliation();
+    await vi.waitFor(() => expect(controller.state().status).toBe("ready"));
     expect(controller.state().resetUncertain).toBeUndefined();
   });
 

--- a/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/telegram-settings-surface.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buttonVariants } from "../src/components/ui/button.js";
@@ -414,6 +414,58 @@ describe("Telegram settings surface", () => {
     await user.type(senderId, "303");
     await user.click(screen.getByRole("button", { name: "Add user" }));
     expect(port.addSender).toHaveBeenCalledWith(303);
+  });
+
+  it("blocks allowed-user changes while credential reset is uncertain", async () => {
+    const user = userEvent.setup();
+    const connected = status({
+      channel: { desiredState: "enabled", state: "online" },
+      bot: { state: "ready", username: "desktop_coach_bot" },
+      pairing: { state: "paired" },
+      credentialConfigured: true,
+    });
+    const port = setup(
+      readyState(connected, {
+        senders: [
+          { senderId: 101, role: "primary" },
+          { senderId: 202, role: "additional" },
+        ],
+      }),
+    );
+
+    await user.click(screen.getByText("Advanced · allowed users"));
+    const senderId = screen.getByLabelText("Add a Telegram user ID");
+    await user.type(senderId, "303");
+    const removeSender = screen.getByRole("button", { name: "Remove Telegram user 202" });
+    await user.click(removeSender);
+    const confirmation = screen.getByRole("group", { name: "Remove Telegram user 202?" });
+
+    act(() => {
+      useEnduragentStore.setState((current) => ({
+        settings: {
+          ...current.settings,
+          credentials: {
+            status: "error",
+            kind: "load",
+            announcement: "Credential removal could not be verified.",
+            repairCredential: null,
+            resetUncertain: true,
+            recoveryAvailable: true,
+            focus: { target: "feedback" },
+          },
+        },
+      }));
+    });
+
+    expect(senderId).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add user" })).toBeDisabled();
+    expect(removeSender).toBeDisabled();
+    const confirm = within(confirmation).getByRole("button", { name: "Remove user" });
+    expect(confirm).toBeDisabled();
+    fireEvent.submit(senderId.closest("form")!);
+    await user.click(confirm);
+    expect(port.addSender).not.toHaveBeenCalled();
+    expect(port.removeSender).not.toHaveBeenCalled();
   });
 
   it("truthfully explains automatic recovery when paired-user loading fails", async () => {

--- a/apps/desktop-renderer/tests/telegram-settings.test.ts
+++ b/apps/desktop-renderer/tests/telegram-settings.test.ts
@@ -258,9 +258,13 @@ describe("Telegram settings controller", () => {
 
     runtime.handlers.onPasteToken();
     runtime.handlers.onRemove();
+    runtime.handlers.onAddSender(202);
+    runtime.handlers.onRemoveSender(202);
 
     expect(runtime.bridge.pasteTokenFromClipboard).not.toHaveBeenCalled();
     expect(runtime.bridge.remove).not.toHaveBeenCalled();
+    expect(runtime.bridge.addAllowedSender).not.toHaveBeenCalled();
+    expect(runtime.bridge.removeAllowedSender).not.toHaveBeenCalled();
 
     runtime.handlers.onReconcile();
     await vi.waitFor(() => expect(runtime.bridge.reconcile).toHaveBeenCalledOnce());


### PR DESCRIPTION
## Summary
- latch global reset uncertainty before destructive reset begins
- stop stale reload work before reconciliation and preserve the latch across Settings close/reopen
- block Telegram allowed-user mutations while credential changes are unsafe

## Verification
- focused renderer tests: 134 passed
- renderer source and test typechecks passed
- formatting and diff checks passed
- fresh read-only skeptic passed all reset, close/reopen, and Telegram mutation criteria

The existing reset-safety changeset on the epic covers this completion fix.