### PR TITLE
fix(desktop): serialize reset reopen

### DIFF
--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -845,9 +845,9 @@ export function createCredentialSettingsController(input: {
   const close = (): void => {
     if (disposed) return;
     ++generation;
-    operation = undefined;
     const repairCredential = repairRequiredCredential(currentState);
     const resetUncertain = currentState.resetUncertain === true;
+    if (!resetUncertain) operation = undefined;
     currentState = {
       status: "closed",
       ...(repairCredential === null ? {} : { repairCredential }),
@@ -873,10 +873,16 @@ export function createCredentialSettingsController(input: {
   });
 
   return {
-    activate() {
-      if (disposed) return Promise.resolve();
-      if (currentState.status !== "closed") return operation ?? Promise.resolve();
-      return startLoad();
+    async activate() {
+      if (disposed) return;
+      if (currentState.status !== "closed") {
+        await operation;
+        return;
+      }
+      const reopenBarrier = currentState.resetUncertain === true ? operation : undefined;
+      if (reopenBarrier !== undefined) await reopenBarrier;
+      if (disposed || currentState.status !== "closed") return;
+      await startLoad();
     },
     close,
     state: () => currentState,

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -637,14 +637,17 @@ describe("credential settings controller", () => {
     expect(controller.state()).toMatchObject({ status: "deleting", resetUncertain: true });
     controller.close();
     expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
-    resolveReset({ status: "refused", reason: "storage-failed" });
-    await vi.waitFor(() => expect(releaseMutation).toHaveBeenCalled());
+    const reopening = controller.activate();
+    expect(onReconciled).not.toHaveBeenCalled();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
 
-    void controller.activate();
+    resolveReset({ status: "refused", reason: "storage-failed" });
     await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledOnce());
     expect(controller.state()).toMatchObject({ status: "loading", resetUncertain: true });
     resolveReconciliation();
-    await vi.waitFor(() => expect(controller.state().status).toBe("ready"));
+    await reopening;
+    expect(releaseMutation).toHaveBeenCalled();
+    expect(controller.state().status).toBe("ready");
     expect(controller.state().resetUncertain).toBeUndefined();
   });
 
@@ -680,14 +683,17 @@ describe("credential settings controller", () => {
     expect(controller.state()).toMatchObject({ status: "deleting", resetUncertain: true });
     controller.close();
     expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
-    resolveReload([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
-    await vi.waitFor(() => expect(releaseMutation).toHaveBeenCalled());
+    const reopening = controller.activate();
+    expect(onReconciled).not.toHaveBeenCalled();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
 
-    void controller.activate();
+    resolveReload([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
     await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledOnce());
     expect(controller.state()).toMatchObject({ status: "loading", resetUncertain: true });
     resolveReconciliation();
-    await vi.waitFor(() => expect(controller.state().status).toBe("ready"));
+    await reopening;
+    expect(releaseMutation).toHaveBeenCalled();
+    expect(controller.state().status).toBe("ready");
     expect(controller.state().resetUncertain).toBeUndefined();
   });
 
@@ -716,14 +722,17 @@ describe("credential settings controller", () => {
     expect(controller.state()).toMatchObject({ status: "deleting", resetUncertain: true });
     controller.close();
     expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
-    resolveFirstReconciliation();
-    await vi.waitFor(() => expect(releaseMutation).toHaveBeenCalled());
+    const reopening = controller.activate();
+    expect(onReconciled).toHaveBeenCalledOnce();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
 
-    void controller.activate();
+    resolveFirstReconciliation();
     await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledTimes(2));
     expect(controller.state()).toMatchObject({ status: "loading", resetUncertain: true });
     resolveSecondReconciliation();
-    await vi.waitFor(() => expect(controller.state().status).toBe("ready"));
+    await reopening;
+    expect(releaseMutation).toHaveBeenCalled();
+    expect(controller.state().status).toBe("ready");
     expect(controller.state().resetUncertain).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- retain an uncertain reset operation as a close/reopen barrier
- wait for that stale operation before authoritative reload and reconciliation
- prevent a pre-reset snapshot from clearing global reset uncertainty

## Verification
- credential controller tests: 46 passed
- renderer source and test typechecks passed
- formatting and diff checks passed
- fresh read-only skeptic passed the reset RPC, reload, reconciliation, lock-release, and ordinary reopen criteria

The existing reset-safety changeset on the epic covers this completion fix.