### PR TITLE
feat(kernel): add durable Plan store

### DIFF
--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -51,7 +51,7 @@ import {
   type ModelTransportDecorator,
   type ReferenceStateSnapshot,
 } from "@enduragent/engine";
-import { resolveUserTimezone } from "@enduragent/engine/sport";
+import { resolveUserTimezone, todayInTZ } from "@enduragent/engine/sport";
 import {
   createCyclingFtpAnchorResolver,
   type CyclingFtpAnchorResolver,
@@ -65,8 +65,13 @@ import {
   type AnchorRepository,
 } from "@enduragent/kernel/store";
 import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
-import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { createAuthoredIdentity, type AthleteHome } from "@enduragent/kernel-node/home";
 import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
+import {
+  createLegacyPlanRepository,
+  createLegacyPlanRowWriter,
+  importLegacyCurrentPlan,
+} from "@enduragent/kernel-node/planning";
 import type { CoachStoreWriterContext } from "./runtime.js";
 import {
   type CoachEngine,
@@ -765,6 +770,25 @@ export async function createLocalCoachComposition(
     throw new TypeError("Ready engine configuration does not match the selected athlete home.");
   }
   const now = dependencies.now ?? Date.now;
+  const logger = createSubsystemLogger("agent", input.home.root);
+  const planningIdentity = createAuthoredIdentity(input.home.configDir, { now });
+  const planningRepository = createLegacyPlanRepository(input.context.store);
+  const planningTimezone = resolveUserTimezone(input.config.session.timezone);
+  const planningDateKey = (): number => Number(todayInTZ(planningTimezone).replaceAll("-", ""));
+  await importLegacyCurrentPlan({
+    home: input.home,
+    store: input.context.store,
+    identity: planningIdentity,
+    importDateKey: planningDateKey(),
+    importTimestampMs: now(),
+    logger: { warn: () => logger.warn("legacy_plan_import_skipped") },
+  });
+  const persistPlan = await createLegacyPlanRowWriter({
+    repository: planningRepository,
+    identity: planningIdentity,
+    fallbackDateKey: planningDateKey,
+    now,
+  });
   const ownerClock = { now, monotonicNow: () => performance.now() };
   const intervalsCredentialApprovals = createIntervalsCredentialApprovalStore({ now });
   let intervalsConfigRevision = 0;
@@ -926,7 +950,6 @@ export async function createLocalCoachComposition(
         schedulerStarted = true;
       }
     }
-    const logger = createSubsystemLogger("agent", input.home.root);
     const getAccessToken = createAccessTokenReader(input.home.configDir);
     const repository = (dependencies.createRepository ?? createAnchorRepository)(
       input.context.store,
@@ -957,7 +980,10 @@ export async function createLocalCoachComposition(
               ...config,
               session: { ...config.session, timezone },
             };
-      const memory = new Memory(input.home.root, timezone, { platform: dependencies.platform });
+      const memory = new Memory(input.home.root, timezone, {
+        platform: dependencies.platform,
+        persistPlan,
+      });
       const conversationStore = createConversationStore(
         input.home.root,
         config.session.resetArchiveRetentionDays,

--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -588,7 +588,7 @@ describe("account identity", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 12 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(
         beforeWorkouts,

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -582,7 +582,7 @@ describe("coach sync composition", () => {
           return store.get("PRAGMA user_version");
         },
       );
-      expect(value).toEqual({ user_version: 11 });
+      expect(value).toEqual({ user_version: 12 });
       expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
       expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
       expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -590,7 +590,7 @@ describe("coach sync composition", () => {
       const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
       try {
         await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-          user_version: 11,
+          user_version: 12,
         });
       } finally {
         await reopened.close();

--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -62,6 +62,18 @@ A delivery surface (currently only Telegram); sport-agnostic.
 **Static Prefix**:
 The turn-invariant head of the system prompt — SOUL, the joined skill prompts, the rule blocks (untrusted-data, recall, workout-review, data-grounding) — that forms one frozen cache prefix; only the Athlete Context block is volatile and renders last. **Boundary policy:** SOUL and always-needed rules stay preloaded in this prefix. Future skill growth that is not needed every turn (e.g., nutrition depth, race-prep depth) ships tool-retrievable rather than preloaded — but never via per-turn conditional injection, which would reshape the prefix and defeat the cache. A guardrail test fails if the prefix's estimated token count exceeds its ceiling, forcing a conscious preload-vs-retrieve decision instead of silent bloat.
 
+**Plan**:
+The locally authoritative training block with exactly one lifecycle state: `draft`, `active`, or `ended`.
+_Avoid_: Training program, calendar plan
+
+**Plan Workout**:
+A Workout that belongs to one Plan and carries its planned date, origin, and sport-owned prescription.
+_Avoid_: Session, `planned_workout`, `planned_workouts`
+
+**Training Week**:
+A seven-day span counted from a Plan's athlete-selected start date; week 1 begins on that date.
+_Avoid_: Calendar week, partial week
+
 ## Relationships
 
 - A **Binary** wraps exactly one **Sport** plus deployment config.

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -97,6 +97,7 @@ type RenameOutcome = "renamed" | "noop" | "merged";
 
 export interface MemoryOptions {
   readonly platform?: NodeJS.Platform;
+  readonly persistPlan?: (plan: unknown) => Promise<void>;
 }
 
 /**
@@ -129,6 +130,7 @@ export class Memory implements MemoryStore {
   private tz: string;
   private provenance: ProvenanceMetadata;
   private readonly platform: NodeJS.Platform;
+  private readonly persistPlan: ((plan: unknown) => Promise<void>) | undefined;
   private readonly writeProvenance = new AsyncLocalStorage<SourceProvenance>();
 
   constructor(dataDir: string, tz: string = "UTC", options: MemoryOptions = {}) {
@@ -136,6 +138,7 @@ export class Memory implements MemoryStore {
     this.plansDir = join(dataDir, "plans");
     this.tz = tz;
     this.platform = options.platform ?? process.platform;
+    this.persistPlan = options.persistPlan;
     mkdirSync(this.memoryDir, { recursive: true, mode: 0o700 });
     mkdirSync(this.plansDir, { recursive: true, mode: 0o700 });
     this.provenance = new ProvenanceMetadata(this.memoryDir, { platform: this.platform });
@@ -456,7 +459,7 @@ export class Memory implements MemoryStore {
     plan: unknown,
     source: MemoryWriteSource = "unattributed",
     provenance?: SourceProvenance,
-  ): void {
+  ): void | Promise<void> {
     const path = join(this.plansDir, "current-plan.json");
     const newBody = JSON.stringify(plan, null, 2);
     this.provenance.write("plan", newBody, this.resolvedWriteProvenance(provenance));
@@ -469,6 +472,7 @@ export class Memory implements MemoryStore {
       source,
     });
     atomicWriteFileSync(path, newBody, { platform: this.platform });
+    return this.persistPlan?.(plan);
   }
 
   loadPlan(): unknown | null {

--- a/packages/core/tests/plan-dual-write.test.ts
+++ b/packages/core/tests/plan-dual-write.test.ts
@@ -1,0 +1,49 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryTools } from "../../engine/src/sport/memory-tools.js";
+import { Memory } from "../src/memory/store.js";
+
+describe("plan_save compatibility dual-write", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("keeps the legacy file byte-identical while awaiting the Plan row write", async () => {
+    const root = mkdtempSync(join(tmpdir(), "plan-dual-write-"));
+    roots.push(root);
+    const persistPlan = vi.fn(async () => {});
+    const memory = new Memory(root, "UTC", { persistPlan });
+    const tool = createMemoryTools(memory, [{ name: "goals", description: "Goals" }]).plan_save;
+    const plan = {
+      id: "32cc7944-facd-4b56-b1a1-7dfe43e4bfe7",
+      name: "Base Plan",
+      primaryGoal: "Gran Fondo",
+      totalWeeks: 8,
+      status: "draft",
+    };
+
+    await expect(tool.execute!({ plan }, {} as never)).resolves.toEqual({ saved: true });
+    expect(readFileSync(join(root, "plans", "current-plan.json"), "utf8"))
+      .toBe(JSON.stringify(plan, null, 2));
+    expect(persistPlan).toHaveBeenCalledWith(plan);
+  });
+
+  it("surfaces a Plan row failure after preserving the legacy file", async () => {
+    const root = mkdtempSync(join(tmpdir(), "plan-dual-write-failure-"));
+    roots.push(root);
+    const failure = new Error("row write failed");
+    const memory = new Memory(root, "UTC", {
+      persistPlan: async () => Promise.reject(failure),
+    });
+    const tool = createMemoryTools(memory, [{ name: "goals", description: "Goals" }]).plan_save;
+    const plan = { name: "Fallback Plan" };
+
+    await expect(tool.execute!({ plan }, {} as never)).rejects.toBe(failure);
+    expect(readFileSync(join(root, "plans", "current-plan.json"), "utf8"))
+      .toBe(JSON.stringify(plan, null, 2));
+  });
+});

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -83,7 +83,11 @@ export interface MemoryStorePort {
   readDailyNotesInRange(from: string, to: string): Array<{ date: string; text: string }>;
   readEventsRaw(): string;
   appendEvent(event: LedgerEventInput, provenance?: SourceProvenance): void;
-  savePlan(plan: unknown, source?: MemoryWriteSource, provenance?: SourceProvenance): void;
+  savePlan(
+    plan: unknown,
+    source?: MemoryWriteSource,
+    provenance?: SourceProvenance,
+  ): void | Promise<void>;
   loadPlan(): unknown | null;
   /** Source labels bound to the exact visible result of a synchronous tool read. */
   provenanceForToolRead?(

--- a/packages/engine/src/sport/memory-tools.ts
+++ b/packages/engine/src/sport/memory-tools.ts
@@ -212,7 +212,7 @@ export function createMemoryTools(
         }),
       ),
       execute: async (input: { plan: Record<string, unknown> }) => {
-        memory.savePlan(input.plan, "chat-tool");
+        await memory.savePlan(input.plan, "chat-tool");
         return { saved: true };
       },
     }),

--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -17,7 +17,8 @@
     "./ingest": "./dist/ingest/index.js",
     "./capture-manifest": "./dist/capture-manifest/index.js",
     "./service": "./dist/service/index.js",
-    "./coach-dev": "./dist/coach-dev.js"
+    "./coach-dev": "./dist/coach-dev.js",
+    "./planning": "./dist/planning/index.js"
   },
   "engines": {
     "node": ">=24"
@@ -25,7 +26,7 @@
   "scripts": {
     "build": "tsup",
     "check": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "pnpm --dir ../.. exec vitest run --project workspace packages/kernel-node/tests"
   },
   "dependencies": {
     "@enduragent/kernel": "workspace:*",

--- a/packages/kernel-node/src/planning/index.ts
+++ b/packages/kernel-node/src/planning/index.ts
@@ -1,0 +1,1 @@
+export * from "./legacy-plan-store.js";

--- a/packages/kernel-node/src/planning/legacy-plan-store.ts
+++ b/packages/kernel-node/src/planning/legacy-plan-store.ts
@@ -1,0 +1,151 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  createPlanRepository,
+  legacyPlanRows,
+  type PlanRepository,
+  type PlanningIdentity,
+} from "@enduragent/kernel/planning";
+import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
+import type { AthleteHome } from "../home/resolve-athlete-home.js";
+import type { AuthoredIdentity } from "../store/authored-identity.js";
+
+export const LEGACY_PLAN_IMPORT_MARKER = "planning-current-plan-import-v1" as const;
+
+export interface LegacyPlanImportLogger {
+  warn(message: string): void;
+}
+
+export type LegacyPlanImportResult =
+  | { readonly status: "imported"; readonly planId: string }
+  | { readonly status: "already-completed" | "no-source" | "malformed" };
+
+type PlanningStore = SqlStore & Pick<MigratorStore, "transaction">;
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null
+    ? (error as { readonly code?: string }).code
+    : undefined;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await readFile(path);
+    return true;
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function markCompleted(path: string): Promise<void> {
+  try {
+    await writeFile(path, "completed\n", { flag: "wx", mode: 0o600 });
+  } catch (error) {
+    if (errorCode(error) !== "EEXIST") throw error;
+  }
+}
+
+async function planningIdentity(identity: AuthoredIdentity): Promise<PlanningIdentity> {
+  const deviceId = await identity.deviceId();
+  return Object.freeze({
+    deviceId,
+    newId: () => identity.newUlid(),
+    stamp: () => identity.hlcStamp(),
+  });
+}
+
+export async function importLegacyCurrentPlan(input: {
+  readonly home: AthleteHome;
+  readonly store: PlanningStore;
+  readonly identity: AuthoredIdentity;
+  readonly importDateKey: number;
+  readonly importTimestampMs: number;
+  readonly logger: LegacyPlanImportLogger;
+}): Promise<LegacyPlanImportResult> {
+  const markerPath = join(input.home.configDir, LEGACY_PLAN_IMPORT_MARKER);
+  if (await exists(markerPath)) return { status: "already-completed" };
+  const sourcePath = join(input.home.root, "plans", "current-plan.json");
+  let sourceBytes: Buffer;
+  try {
+    sourceBytes = await readFile(sourcePath);
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") throw error;
+    await mkdir(input.home.configDir, { recursive: true, mode: 0o700 });
+    await markCompleted(markerPath);
+    return { status: "no-source" };
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(sourceBytes.toString("utf8"));
+  } catch {
+    input.logger.warn("Legacy Plan import skipped because the source is malformed.");
+    return { status: "malformed" };
+  }
+  const repository = createPlanRepository(input.store);
+  let rows;
+  try {
+    const originId = typeof value === "object"
+      && value !== null
+      && !Array.isArray(value)
+      && typeof (value as { readonly id?: unknown }).id === "string"
+      ? (value as { readonly id: string }).id
+      : undefined;
+    const existing = originId === undefined ? undefined : await repository.readByOriginId(originId);
+    rows = legacyPlanRows({
+      value,
+      identity: await planningIdentity(input.identity),
+      fallbackDateKey: input.importDateKey,
+      fallbackTimestampMs: input.importTimestampMs,
+      ...(existing === undefined ? {} : { existingPlanId: existing.id }),
+    });
+    await repository.replace(rows.plan, rows.workouts);
+  } catch {
+    input.logger.warn("Legacy Plan import skipped because the source is malformed.");
+    return { status: "malformed" };
+  }
+  await mkdir(input.home.configDir, { recursive: true, mode: 0o700 });
+  await markCompleted(markerPath);
+  return { status: "imported", planId: rows.plan.id };
+}
+
+export async function createLegacyPlanRowWriter(input: {
+  readonly repository: PlanRepository;
+  readonly identity: AuthoredIdentity;
+  readonly fallbackDateKey: () => number;
+  readonly now: () => number;
+}): Promise<(value: unknown) => Promise<void>> {
+  const identity = await planningIdentity(input.identity);
+  let currentPlanId: string | undefined;
+  return async (value: unknown): Promise<void> => {
+    const todayDateKey = input.fallbackDateKey();
+    const originId = typeof value === "object"
+      && value !== null
+      && !Array.isArray(value)
+      && typeof (value as { readonly id?: unknown }).id === "string"
+      ? (value as { readonly id: string }).id
+      : undefined;
+    const existing = originId === undefined
+      ? currentPlanId === undefined
+        ? await input.repository.readLatest()
+        : await input.repository.read(currentPlanId)
+      : await input.repository.readByOriginId(originId);
+    const rows = legacyPlanRows({
+      value,
+      identity,
+      fallbackDateKey: todayDateKey,
+      fallbackTimestampMs: input.now(),
+      ...(existing === undefined ? {} : { existingPlanId: existing.id }),
+    });
+    if (existing === undefined) {
+      await input.repository.replaceNew(rows.plan, rows.workouts, todayDateKey);
+    } else {
+      await input.repository.replace(rows.plan, rows.workouts);
+    }
+    currentPlanId = rows.plan.id;
+  };
+}
+
+export function createLegacyPlanRepository(store: PlanningStore): PlanRepository {
+  return createPlanRepository(store);
+}

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -592,7 +592,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/legacy-plan-store.test.ts
+++ b/packages/kernel-node/tests/legacy-plan-store.test.ts
@@ -1,0 +1,209 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PlanningDateError, createPlanRepository } from "@enduragent/kernel/planning";
+import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createAuthoredIdentity, type AthleteHome } from "../src/home/index.js";
+import {
+  LEGACY_PLAN_IMPORT_MARKER,
+  createLegacyPlanRowWriter,
+  importLegacyCurrentPlan,
+} from "../src/planning/index.js";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+function legacyPlan(): Record<string, unknown> {
+  return {
+    id: "32cc7944-facd-4b56-b1a1-7dfe43e4bfe7",
+    name: "8-Week Plan",
+    primaryGoal: "Gran Fondo",
+    targetDate: "1998-08-30T00:00:00.000Z",
+    totalWeeks: 8,
+    cycleLength: 7,
+    phases: [],
+    createdAt: "1998-07-06T12:00:00.000Z",
+    status: "draft",
+  };
+}
+
+describe("legacy current Plan import and dual-write adapter", () => {
+  let root: string;
+  let home: AthleteHome;
+  let store: SqlStore & MigratorStore;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), "plan-import-"));
+    home = {
+      root,
+      storeDir: join(root, "store"),
+      archiveDir: join(root, "archive"),
+      configDir: join(root, "config"),
+    };
+    await Promise.all([
+      mkdir(join(root, "plans"), { recursive: true }),
+      mkdir(home.storeDir, { recursive: true }),
+      mkdir(home.archiveDir, { recursive: true }),
+      mkdir(home.configDir, { recursive: true }),
+    ]);
+    store = openSqliteStorage(join(home.storeDir, "store.db"));
+    await runMigrations(store, MIGRATIONS);
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("imports the real Draft shape once without modifying its source", async () => {
+    const sourcePath = join(root, "plans", "current-plan.json");
+    const sourceBytes = Buffer.from(JSON.stringify(legacyPlan(), null, 2));
+    await writeFile(sourcePath, sourceBytes);
+    const before = await stat(sourcePath);
+    const logger = { warn: vi.fn() };
+    const identity = createAuthoredIdentity(home.configDir, {
+      now: () => 900,
+      randomBytes: () => new Uint8Array(10).fill(1),
+    });
+
+    const first = await importLegacyCurrentPlan({
+      home,
+      store,
+      identity,
+      importDateKey: 19980707,
+      importTimestampMs: 900,
+      logger,
+    });
+    const second = await importLegacyCurrentPlan({
+      home,
+      store,
+      identity,
+      importDateKey: 19980707,
+      importTimestampMs: 900,
+      logger,
+    });
+
+    expect(first).toEqual({
+      status: "imported",
+      planId: expect.stringMatching(/^[0-9A-HJKMNP-TV-Z]{26}$/),
+    });
+    expect(second).toEqual({ status: "already-completed" });
+    const repository = createPlanRepository(store);
+    expect(await repository.count()).toBe(1);
+    expect(await repository.readByOriginId("32cc7944-facd-4b56-b1a1-7dfe43e4bfe7"))
+      .toMatchObject({
+        startDateKey: 19980706,
+        status: "draft",
+        kind: "short_race_preparation",
+        totalWeeks: 8,
+      });
+    expect(await readFile(sourcePath)).toEqual(sourceBytes);
+    expect((await stat(sourcePath)).mtimeMs).toBe(before.mtimeMs);
+    expect(logger.warn).not.toHaveBeenCalled();
+    await expect(readFile(join(home.configDir, LEGACY_PLAN_IMPORT_MARKER), "utf8"))
+      .resolves.toBe("completed\n");
+  });
+
+  it("logs and skips malformed input without a partial Plan or completion marker", async () => {
+    const sourcePath = join(root, "plans", "current-plan.json");
+    await writeFile(sourcePath, '{"name":');
+    const logger = { warn: vi.fn() };
+    const identity = createAuthoredIdentity(home.configDir, {
+      now: () => 900,
+      randomBytes: () => new Uint8Array(10).fill(2),
+    });
+
+    await expect(importLegacyCurrentPlan({
+      home,
+      store,
+      identity,
+      importDateKey: 19980707,
+      importTimestampMs: 900,
+      logger,
+    })).resolves.toEqual({ status: "malformed" });
+    expect(await createPlanRepository(store).count()).toBe(0);
+    expect(logger.warn).toHaveBeenCalledOnce();
+    await expect(readFile(join(home.configDir, LEGACY_PLAN_IMPORT_MARKER)))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("falls back to the import date when createdAt is absent or unparseable", async () => {
+    const sourcePath = join(root, "plans", "current-plan.json");
+    await writeFile(sourcePath, JSON.stringify({
+      ...legacyPlan(),
+      id: "0a8c6007-d36e-4d44-82d7-5df9fa2db200",
+      createdAt: "not-an-instant",
+      targetDate: undefined,
+    }));
+    const identity = createAuthoredIdentity(home.configDir, {
+      now: () => 900,
+      randomBytes: () => new Uint8Array(10).fill(3),
+    });
+    await importLegacyCurrentPlan({
+      home,
+      store,
+      identity,
+      importDateKey: 19980707,
+      importTimestampMs: 900,
+      logger: { warn: vi.fn() },
+    });
+    expect(await createPlanRepository(store).readByOriginId(
+      "0a8c6007-d36e-4d44-82d7-5df9fa2db200",
+    )).toMatchObject({ startDateKey: 19980707, createdAtMs: 900 });
+  });
+
+  it("upserts the same row through repeated compatibility writes", async () => {
+    const identity = createAuthoredIdentity(home.configDir, {
+      now: () => 900,
+      randomBytes: () => new Uint8Array(10).fill(4),
+    });
+    const repository = createPlanRepository(store);
+    const writeRows = await createLegacyPlanRowWriter({
+      repository,
+      identity,
+      fallbackDateKey: () => 19980706,
+      now: () => 900,
+    });
+    await writeRows(legacyPlan());
+    await writeRows({ ...legacyPlan(), name: "Updated Plan" });
+    expect(await repository.count()).toBe(1);
+    expect(await repository.readByOriginId("32cc7944-facd-4b56-b1a1-7dfe43e4bfe7"))
+      .toMatchObject({ name: "Updated Plan" });
+  });
+
+  it.each([
+    [
+      "before today",
+      "1998-07-05T00:00:00.000Z",
+      "1998-08-30T00:00:00.000Z",
+      new PlanningDateError("start-before-today"),
+    ],
+    [
+      "after the target",
+      "1998-08-31T00:00:00.000Z",
+      "1998-08-30T00:00:00.000Z",
+      new PlanningDateError("start-after-target"),
+    ],
+  ])("rejects a new compatibility Plan starting %s", async (_label, startDate, targetDate, error) => {
+    const identity = createAuthoredIdentity(home.configDir, {
+      now: () => 900,
+      randomBytes: () => new Uint8Array(10).fill(5),
+    });
+    const repository = createPlanRepository(store);
+    const writeRows = await createLegacyPlanRowWriter({
+      repository,
+      identity,
+      fallbackDateKey: () => 19980706,
+      now: () => 900,
+    });
+
+    await expect(writeRows({
+      ...legacyPlan(),
+      id: undefined,
+      startDate,
+      targetDate,
+    })).rejects.toEqual(error);
+    await expect(repository.count()).resolves.toBe(0);
+  });
+});

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -31,9 +31,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 11", async () => {
+  it("applies the full migration list and advances user_version to 12", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -53,7 +53,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -82,11 +82,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 11", async () => {
+  it("upgrades a version-1-on-disk store to version 12", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -106,8 +106,8 @@ describe("migrator end-to-end over node:sqlite", () => {
     );
 
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 4, toVersion: 11, applied: [5, 6, 7, 8, 9, 10, 11] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(result).toEqual({ fromVersion: 4, toVersion: 12, applied: [5, 6, 7, 8, 9, 10, 11, 12] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -158,16 +158,59 @@ describe("migrator end-to-end over node:sqlite", () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 6, toVersion: 11, applied: [7, 8, 9, 10, 11] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(result).toEqual({ fromVersion: 6, toVersion: 12, applied: [7, 8, 9, 10, 11, 12] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 11,
-      toVersion: 11,
+      fromVersion: 12,
+      toVersion: 12,
       applied: [],
     });
+  });
+
+  it("upgrades version 11 to 12 while preserving existing rows", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 11));
+    await store.run(
+      "INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,?)",
+      ["chronoBridge", 1],
+    );
+
+    await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
+      fromVersion: 11,
+      toVersion: 12,
+      applied: [12],
+    });
+    await expect(store.get("SELECT fixer,enabled FROM repair_fixer_settings"))
+      .resolves.toEqual({ fixer: "chronoBridge", enabled: 1 });
+    await expect(store.get("SELECT count(*) AS count FROM repair_fixer_settings"))
+      .resolves.toEqual({ count: 1 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 12 });
+  });
+
+  it("rolls back a failed migration 12 without partial Planning tables", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 11));
+    await store.run(
+      "INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,?)",
+      ["pulseWeave", 1],
+    );
+    const tablesBefore = await store.all(
+      "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+    );
+    const broken = {
+      ...MIGRATIONS[11]!,
+      sql: `${MIGRATIONS[11]!.sql}\nINSERT INTO missing_table VALUES (1);`,
+    };
+    await expect(runMigrations(store, [...MIGRATIONS.slice(0, 11), broken])).rejects.toThrow();
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 11 });
+    await expect(store.all(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('plan','plan_workout')",
+    )).resolves.toEqual([]);
+    await expect(store.all("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"))
+      .resolves.toEqual(tablesBefore);
+    await expect(store.get("SELECT fixer,enabled FROM repair_fixer_settings"))
+      .resolves.toEqual({ fixer: "pulseWeave", enabled: 1 });
   });
 
   it("preserves an existing cursor and leaves its store owner unset", async () => {

--- a/packages/kernel-node/tests/plan-repository.test.ts
+++ b/packages/kernel-node/tests/plan-repository.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  PlanValidationError,
+  PlanningDateError,
+  createPlanRepository,
+  type PlanRecord,
+  type PlanWorkoutRecord,
+} from "@enduragent/kernel/planning";
+import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const PLAN_ID = `${"0".repeat(25)}1`;
+const OTHER_PLAN_ID = `${"0".repeat(25)}2`;
+const WORKOUT_ID = `${"0".repeat(25)}3`;
+
+function plan(overrides: Partial<PlanRecord> = {}): PlanRecord {
+  return {
+    id: PLAN_ID,
+    originId: "32cc7944-facd-4b56-b1a1-7dfe43e4bfe7",
+    name: "Gran Fondo Plan",
+    primaryGoal: "Finish in the front half",
+    startDateKey: 20260709,
+    targetDateKey: 20260930,
+    status: "draft",
+    kind: "full_plan",
+    totalWeeks: 12,
+    weekStartDay: 4,
+    structureJson: '{"phases":[]}',
+    createdAtMs: 1,
+    updatedAtMs: 2,
+    deviceId: "device-1",
+    hlcPhysicalMs: 2,
+    hlcCounter: 0,
+    ...overrides,
+  };
+}
+
+function workout(overrides: Partial<PlanWorkoutRecord> = {}): PlanWorkoutRecord {
+  return {
+    id: WORKOUT_ID,
+    planId: PLAN_ID,
+    dateKey: 20260710,
+    sport: "cycling",
+    name: "Endurance",
+    durationS: 5_400,
+    structureJson: '{"sport":"cycling"}',
+    origin: "coach",
+    deviceId: "device-1",
+    hlcPhysicalMs: 3,
+    hlcCounter: 0,
+    ...overrides,
+  };
+}
+
+describe("Plan repository", () => {
+  let store: SqlStore & MigratorStore;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("replaces and reads a Plan with ordered Plan Workouts", async () => {
+    const repository = createPlanRepository(store);
+    await repository.replace(plan(), [
+      workout({ id: `${"0".repeat(25)}4`, dateKey: 20260711, name: "Tempo" }),
+      workout(),
+    ]);
+    await expect(repository.read(PLAN_ID)).resolves.toEqual(plan());
+    await expect(repository.readByOriginId("32cc7944-facd-4b56-b1a1-7dfe43e4bfe7"))
+      .resolves.toEqual(plan());
+    await expect(repository.readWorkouts(PLAN_ID)).resolves.toEqual([
+      workout(),
+      workout({ id: `${"0".repeat(25)}4`, dateKey: 20260711, name: "Tempo" }),
+    ]);
+    await expect(repository.count()).resolves.toBe(1);
+  });
+
+  it("rejects every persisted Plan invariant with a typed error", async () => {
+    const repository = createPlanRepository(store);
+    const cases: Array<[PlanRecord, PlanValidationError | PlanningDateError]> = [
+      [plan({ id: "uuid" }), new PlanValidationError("invalid-id")],
+      [plan({ status: "paused" as PlanRecord["status"] }), new PlanValidationError("invalid-status")],
+      [plan({ kind: "other" as PlanRecord["kind"] }), new PlanValidationError("invalid-kind")],
+      [plan({ kind: "short_race_preparation" }), new PlanValidationError("inconsistent-kind")],
+      [plan({ totalWeeks: 0 }), new PlanValidationError("invalid-total-weeks")],
+      [plan({ weekStartDay: 7 }), new PlanValidationError("invalid-week-start-day")],
+      [plan({ weekStartDay: 1 }), new PlanValidationError("inconsistent-week-start-day")],
+      [plan({ totalWeeks: 11 }), new PlanValidationError("target-outside-plan")],
+    ];
+    for (const [candidate, error] of cases) {
+      await expect(repository.replace(candidate, [])).rejects.toEqual(error);
+    }
+    await expect(repository.replaceNew(plan({ startDateKey: 20260708, weekStartDay: 3 }), [], 20260709))
+      .rejects.toEqual(new PlanningDateError("start-before-today"));
+    await expect(repository.replaceNew(plan({
+      startDateKey: 20261005,
+      targetDateKey: 20261004,
+      weekStartDay: 1,
+      kind: "short_race_preparation",
+    }), [], 20260709)).rejects.toEqual(new PlanningDateError("start-after-target"));
+  });
+
+  it("accepts a valid short block even when race day lands in display week 12", async () => {
+    const repository = createPlanRepository(store);
+    const short = plan({
+      targetDateKey: 20260929,
+      kind: "short_race_preparation",
+    });
+    await expect(repository.replaceNew(short, [], 20260709)).resolves.toBeUndefined();
+    await expect(repository.read(PLAN_ID)).resolves.toEqual(short);
+  });
+
+  it("enforces Plan Workout ownership and cascades deletion", async () => {
+    const repository = createPlanRepository(store);
+    await expect(store.run(`INSERT INTO plan_workout (
+  id, plan_id, date_key, sport, name, duration_s, structure_json, origin,
+  device_id, hlc_physical_ms, hlc_counter
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, [
+      WORKOUT_ID,
+      OTHER_PLAN_ID,
+      20260710,
+      "cycling",
+      "Endurance",
+      5_400,
+      "{}",
+      "coach",
+      "device-1",
+      1,
+      0,
+    ])).rejects.toThrow();
+    await repository.replace(plan(), [workout()]);
+    await repository.delete(PLAN_ID);
+    await expect(repository.readWorkouts(PLAN_ID)).resolves.toEqual([]);
+  });
+
+  it("rejects invalid Plan Workout values before SQL", async () => {
+    const repository = createPlanRepository(store);
+    await expect(repository.replace(plan(), [workout({ durationS: 0 })]))
+      .rejects.toEqual(new PlanValidationError("invalid-workout"));
+    await expect(repository.replace(plan(), [workout({ dateKey: 20260708 })]))
+      .rejects.toEqual(new PlanValidationError("workout-outside-plan"));
+  });
+});

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -236,8 +236,8 @@ describe("sync failure repository", () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     await runMigrations(store, MIGRATIONS);
     expect(await dumpStore(store)).not.toContain("# sync_failure");
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
-    expect(DUMP_TABLES).toHaveLength(37);
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
+    expect(DUMP_TABLES).toHaveLength(39);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");
     expect(DERIVED_TABLES).not.toContain("sync_failure");

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "filesystem/index": "src/filesystem/index.ts", "ingest/index": "src/ingest/index.ts", "capture-manifest/index": "src/capture-manifest/index.ts", "service/index": "src/service/index.ts", "coach-dev": "src/cli/coach-dev.ts" },
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "filesystem/index": "src/filesystem/index.ts", "ingest/index": "src/ingest/index.ts", "capture-manifest/index": "src/capture-manifest/index.ts", "service/index": "src/service/index.ts", "planning/index": "src/planning/index.ts", "coach-dev": "src/cli/coach-dev.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -12,6 +12,7 @@
     "./ports": "./dist/ports.js",
     "./store/migrations": "./dist/store/migrations.js",
     "./store": "./dist/store.js",
+    "./planning": "./dist/planning.js",
     "./archive": "./dist/archive/index.js",
     "./store/export": "./dist/store/export/index.js",
     "./ingest": "./dist/ingest/index.js",
@@ -32,7 +33,7 @@
   "scripts": {
     "build": "tsup",
     "check": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "pnpm --dir ../.. exec vitest run --project workspace packages/kernel/tests"
   },
   "dependencies": {
     "@xmldom/xmldom": "0.9.10",

--- a/packages/kernel/src/planning/date-keys.ts
+++ b/packages/kernel/src/planning/date-keys.ts
@@ -1,0 +1,128 @@
+export const MIN_FULL_PLAN_WEEKS = 12 as const;
+export const MIN_FULL_PLAN_DAYS = 84 as const;
+
+export class PlanningDateError extends Error {
+  readonly code:
+    | "invalid-date-key"
+    | "invalid-week-index"
+    | "start-before-today"
+    | "start-after-target";
+
+  constructor(code: PlanningDateError["code"]) {
+    super(`planning date rejected: ${code}`);
+    this.name = "PlanningDateError";
+    this.code = code;
+  }
+}
+
+const MS_PER_DAY = 86_400_000;
+
+function parts(dateKey: number): { readonly year: number; readonly month: number; readonly day: number } {
+  if (!Number.isSafeInteger(dateKey) || dateKey < 10_101 || dateKey > 99_991_231) {
+    throw new PlanningDateError("invalid-date-key");
+  }
+  const year = Math.floor(dateKey / 10_000);
+  const month = Math.floor((dateKey % 10_000) / 100);
+  const day = dateKey % 100;
+  const date = new Date(0);
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCFullYear(year, month - 1, day);
+  if (
+    date.getUTCFullYear() !== year
+    || date.getUTCMonth() !== month - 1
+    || date.getUTCDate() !== day
+  ) {
+    throw new PlanningDateError("invalid-date-key");
+  }
+  return { year, month, day };
+}
+
+function epochDay(dateKey: number): number {
+  const { year, month, day } = parts(dateKey);
+  const date = new Date(0);
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCFullYear(year, month - 1, day);
+  return Math.floor(date.getTime() / MS_PER_DAY);
+}
+
+function fromEpochDay(value: number): number {
+  const date = new Date(value * MS_PER_DAY);
+  return date.getUTCFullYear() * 10_000 + (date.getUTCMonth() + 1) * 100 + date.getUTCDate();
+}
+
+export function dateKeyFromText(value: string): number {
+  if (!/^\d{4}-\d{2}-\d{2}(?:$|T)/.test(value)) {
+    throw new PlanningDateError("invalid-date-key");
+  }
+  const dateKey = Number(value.slice(0, 10).replaceAll("-", ""));
+  parts(dateKey);
+  return dateKey;
+}
+
+export function addCivilDays(dateKey: number, days: number): number {
+  if (!Number.isSafeInteger(days)) throw new PlanningDateError("invalid-date-key");
+  return fromEpochDay(epochDay(dateKey) + days);
+}
+
+export function inclusiveCivilDays(startDateKey: number, endDateKey: number): number {
+  return epochDay(endDateKey) - epochDay(startDateKey) + 1;
+}
+
+export function weekdayForDateKey(dateKey: number): number {
+  const { year, month, day } = parts(dateKey);
+  const date = new Date(0);
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCFullYear(year, month - 1, day);
+  return date.getUTCDay();
+}
+
+export type PlanWeekIndexResult =
+  | { readonly kind: "inside"; readonly weekIndex: number }
+  | { readonly kind: "outside-plan"; readonly side: "before" | "after" };
+
+export interface PlanWeekSource {
+  readonly startDateKey: number;
+  readonly totalWeeks: number;
+}
+
+export function planWeekIndex(
+  plan: PlanWeekSource,
+  dateKey: number,
+): PlanWeekIndexResult {
+  const offset = inclusiveCivilDays(plan.startDateKey, dateKey) - 1;
+  if (offset < 0) return { kind: "outside-plan", side: "before" };
+  const weekIndex = Math.floor(offset / 7) + 1;
+  if (weekIndex > plan.totalWeeks) return { kind: "outside-plan", side: "after" };
+  return { kind: "inside", weekIndex };
+}
+
+export function planWeekRange(
+  plan: PlanWeekSource,
+  weekIndex: number,
+): { readonly startDateKey: number; readonly endDateKey: number } {
+  if (
+    !Number.isSafeInteger(weekIndex)
+    || weekIndex < 1
+    || !Number.isSafeInteger(plan.totalWeeks)
+    || weekIndex > plan.totalWeeks
+  ) {
+    throw new PlanningDateError("invalid-week-index");
+  }
+  const startDateKey = addCivilDays(plan.startDateKey, (weekIndex - 1) * 7);
+  return { startDateKey, endDateKey: addCivilDays(startDateKey, 6) };
+}
+
+export function validateNewPlanStartDate(
+  plan: { readonly startDateKey: number; readonly targetDateKey: number | null },
+  todayDateKey: number,
+): void {
+  parts(plan.startDateKey);
+  parts(todayDateKey);
+  if (plan.startDateKey < todayDateKey) throw new PlanningDateError("start-before-today");
+  if (plan.targetDateKey !== null) {
+    parts(plan.targetDateKey);
+    if (plan.startDateKey > plan.targetDateKey) {
+      throw new PlanningDateError("start-after-target");
+    }
+  }
+}

--- a/packages/kernel/src/planning/index.ts
+++ b/packages/kernel/src/planning/index.ts
@@ -1,0 +1,3 @@
+export * from "./date-keys.js";
+export * from "./repository.js";
+export * from "./legacy-plan.js";

--- a/packages/kernel/src/planning/legacy-plan.ts
+++ b/packages/kernel/src/planning/legacy-plan.ts
@@ -1,0 +1,179 @@
+import type { PlanKind, PlanRecord, PlanStatus, PlanWorkoutRecord } from "./repository.js";
+import {
+  MIN_FULL_PLAN_DAYS,
+  MIN_FULL_PLAN_WEEKS,
+  dateKeyFromText,
+  inclusiveCivilDays,
+  weekdayForDateKey,
+} from "./date-keys.js";
+
+export interface PlanningIdentity {
+  readonly deviceId: string;
+  newId(): string;
+  stamp(): { readonly physicalMs: number; readonly counter: number };
+}
+
+export interface LegacyPlanRows {
+  readonly plan: PlanRecord;
+  readonly workouts: readonly PlanWorkoutRecord[];
+}
+
+export class LegacyPlanError extends Error {
+  readonly code: "invalid-plan" | "invalid-workout";
+
+  constructor(code: LegacyPlanError["code"]) {
+    super(`legacy plan rejected: ${code}`);
+    this.name = "LegacyPlanError";
+    this.code = code;
+  }
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new LegacyPlanError("invalid-plan");
+  }
+  return value as Record<string, unknown>;
+}
+
+function optionalDate(value: unknown): number | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") throw new LegacyPlanError("invalid-plan");
+  return dateKeyFromText(value);
+}
+
+function dateOrFallback(value: unknown, fallback: number): number {
+  if (typeof value !== "string") return fallback;
+  try {
+    return dateKeyFromText(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function integer(value: unknown, fallback?: number): number {
+  if (value === undefined && fallback !== undefined) return fallback;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new LegacyPlanError("invalid-plan");
+  }
+  return value;
+}
+
+function instant(value: unknown, fallback: number): number {
+  if (typeof value !== "string") return fallback;
+  const parsed = Date.parse(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function status(value: unknown): PlanStatus {
+  if (value === undefined) return "draft";
+  if (value === "draft" || value === "active" || value === "ended") return value;
+  throw new LegacyPlanError("invalid-plan");
+}
+
+function kind(startDateKey: number, targetDateKey: number | null, totalWeeks: number): PlanKind {
+  if (targetDateKey === null) {
+    return totalWeeks >= MIN_FULL_PLAN_WEEKS ? "full_plan" : "short_race_preparation";
+  }
+  return inclusiveCivilDays(startDateKey, targetDateKey) >= MIN_FULL_PLAN_DAYS
+    ? "full_plan"
+    : "short_race_preparation";
+}
+
+function workoutRows(
+  planId: string,
+  value: unknown,
+  identity: PlanningIdentity,
+): readonly PlanWorkoutRecord[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new LegacyPlanError("invalid-workout");
+  return value.map((item) => {
+    const source = record(item);
+    const dateValue = source.dateKey ?? source.date;
+    const dateKey = typeof dateValue === "number"
+      ? dateValue
+      : typeof dateValue === "string"
+        ? dateKeyFromText(dateValue)
+        : undefined;
+    if (
+      dateKey === undefined
+      || typeof source.sport !== "string"
+      || source.sport.length === 0
+      || typeof source.name !== "string"
+      || source.name.length === 0
+    ) {
+      throw new LegacyPlanError("invalid-workout");
+    }
+    const duration = source.durationS ?? source.totalDuration;
+    if (
+      duration !== undefined
+      && (typeof duration !== "number" || !Number.isSafeInteger(duration) || duration <= 0)
+    ) {
+      throw new LegacyPlanError("invalid-workout");
+    }
+    const origin = source.origin === undefined ? "coach" : source.origin;
+    if (origin !== "coach" && origin !== "athlete") {
+      throw new LegacyPlanError("invalid-workout");
+    }
+    const stamp = identity.stamp();
+    return Object.freeze({
+      id: identity.newId(),
+      planId,
+      dateKey,
+      sport: source.sport,
+      name: source.name,
+      durationS: duration ?? null,
+      structureJson: JSON.stringify(source),
+      origin,
+      deviceId: identity.deviceId,
+      hlcPhysicalMs: stamp.physicalMs,
+      hlcCounter: stamp.counter,
+    });
+  });
+}
+
+export function legacyPlanRows(input: {
+  readonly value: unknown;
+  readonly identity: PlanningIdentity;
+  readonly fallbackDateKey: number;
+  readonly fallbackTimestampMs: number;
+  readonly existingPlanId?: string;
+}): LegacyPlanRows {
+  const source = record(input.value);
+  if (typeof source.name !== "string") throw new LegacyPlanError("invalid-plan");
+  const primaryGoal = source.primaryGoal === undefined ? "" : source.primaryGoal;
+  if (typeof primaryGoal !== "string") throw new LegacyPlanError("invalid-plan");
+  const totalWeeks = integer(source.totalWeeks, 1);
+  const createdAtMs = instant(source.createdAt, input.fallbackTimestampMs);
+  const updatedAtMs = Math.max(createdAtMs, instant(source.updatedAt, createdAtMs));
+  const startDateKey = optionalDate(source.startDate)
+    ?? dateOrFallback(source.createdAt, input.fallbackDateKey);
+  const targetDateKey = optionalDate(source.targetDate);
+  const originId = source.id === undefined ? null : source.id;
+  if (originId !== null && (typeof originId !== "string" || originId.length === 0)) {
+    throw new LegacyPlanError("invalid-plan");
+  }
+  const stamp = input.identity.stamp();
+  const planId = input.existingPlanId ?? input.identity.newId();
+  const plan: PlanRecord = Object.freeze({
+    id: planId,
+    originId,
+    name: source.name,
+    primaryGoal,
+    startDateKey,
+    targetDateKey,
+    status: status(source.status),
+    kind: kind(startDateKey, targetDateKey, totalWeeks),
+    totalWeeks,
+    weekStartDay: weekdayForDateKey(startDateKey),
+    structureJson: JSON.stringify(source),
+    createdAtMs,
+    updatedAtMs,
+    deviceId: input.identity.deviceId,
+    hlcPhysicalMs: stamp.physicalMs,
+    hlcCounter: stamp.counter,
+  });
+  return Object.freeze({
+    plan,
+    workouts: workoutRows(planId, source.workouts, input.identity),
+  });
+}

--- a/packages/kernel/src/planning/repository.ts
+++ b/packages/kernel/src/planning/repository.ts
@@ -1,0 +1,365 @@
+import type { MigratorStore } from "../store/migrator.js";
+import type { Row, SqlStore } from "../store/ports.js";
+import {
+  MIN_FULL_PLAN_DAYS,
+  MIN_FULL_PLAN_WEEKS,
+  inclusiveCivilDays,
+  planWeekIndex,
+  validateNewPlanStartDate,
+  weekdayForDateKey,
+} from "./date-keys.js";
+
+export type PlanStatus = "draft" | "active" | "ended";
+export type PlanKind = "full_plan" | "short_race_preparation";
+export type PlanWorkoutOrigin = "coach" | "athlete";
+
+export interface PlanRecord {
+  readonly id: string;
+  readonly originId: string | null;
+  readonly name: string;
+  readonly primaryGoal: string;
+  readonly startDateKey: number;
+  readonly targetDateKey: number | null;
+  readonly status: PlanStatus;
+  readonly kind: PlanKind;
+  readonly totalWeeks: number;
+  readonly weekStartDay: number;
+  readonly structureJson: string;
+  readonly createdAtMs: number;
+  readonly updatedAtMs: number;
+  readonly deviceId: string;
+  readonly hlcPhysicalMs: number;
+  readonly hlcCounter: number;
+}
+
+export interface PlanWorkoutRecord {
+  readonly id: string;
+  readonly planId: string;
+  readonly dateKey: number;
+  readonly sport: string;
+  readonly name: string;
+  readonly durationS: number | null;
+  readonly structureJson: string;
+  readonly origin: PlanWorkoutOrigin;
+  readonly deviceId: string;
+  readonly hlcPhysicalMs: number;
+  readonly hlcCounter: number;
+}
+
+export type PlanValidationErrorCode =
+  | "invalid-id"
+  | "invalid-origin-id"
+  | "invalid-name"
+  | "invalid-primary-goal"
+  | "invalid-status"
+  | "invalid-kind"
+  | "inconsistent-kind"
+  | "invalid-total-weeks"
+  | "invalid-week-start-day"
+  | "inconsistent-week-start-day"
+  | "invalid-target-date"
+  | "target-outside-plan"
+  | "invalid-json"
+  | "invalid-timestamp"
+  | "invalid-device-id"
+  | "invalid-hlc"
+  | "invalid-workout"
+  | "workout-outside-plan";
+
+export class PlanValidationError extends Error {
+  readonly code: PlanValidationErrorCode;
+
+  constructor(code: PlanValidationErrorCode) {
+    super(`plan rejected: ${code}`);
+    this.name = "PlanValidationError";
+    this.code = code;
+  }
+}
+
+export interface PlanRepository {
+  replace(plan: PlanRecord, workouts: readonly PlanWorkoutRecord[]): Promise<void>;
+  replaceNew(
+    plan: PlanRecord,
+    workouts: readonly PlanWorkoutRecord[],
+    todayDateKey: number,
+  ): Promise<void>;
+  read(id: string): Promise<PlanRecord | undefined>;
+  readByOriginId(originId: string): Promise<PlanRecord | undefined>;
+  readLatest(): Promise<PlanRecord | undefined>;
+  readWorkouts(planId: string): Promise<readonly PlanWorkoutRecord[]>;
+  count(): Promise<number>;
+  delete(id: string): Promise<void>;
+}
+
+type PlanningStore = SqlStore & Pick<MigratorStore, "transaction">;
+
+const ULID = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const STATUS = new Set<unknown>(["draft", "active", "ended"]);
+const KIND = new Set<unknown>(["full_plan", "short_race_preparation"]);
+const ORIGIN = new Set<unknown>(["coach", "athlete"]);
+const DEVICE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+function validJson(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function expectedKind(plan: Pick<PlanRecord, "startDateKey" | "targetDateKey" | "totalWeeks">): PlanKind {
+  if (plan.targetDateKey !== null) {
+    const days = inclusiveCivilDays(plan.startDateKey, plan.targetDateKey);
+    if (days <= 0) throw new PlanValidationError("invalid-target-date");
+    return days >= MIN_FULL_PLAN_DAYS ? "full_plan" : "short_race_preparation";
+  }
+  return plan.totalWeeks >= MIN_FULL_PLAN_WEEKS ? "full_plan" : "short_race_preparation";
+}
+
+function validatePlan(plan: PlanRecord): void {
+  if (!ULID.test(plan.id)) throw new PlanValidationError("invalid-id");
+  if (plan.originId !== null && (typeof plan.originId !== "string" || plan.originId.length === 0)) {
+    throw new PlanValidationError("invalid-origin-id");
+  }
+  if (typeof plan.name !== "string") throw new PlanValidationError("invalid-name");
+  if (typeof plan.primaryGoal !== "string") throw new PlanValidationError("invalid-primary-goal");
+  if (!STATUS.has(plan.status)) throw new PlanValidationError("invalid-status");
+  if (!KIND.has(plan.kind)) throw new PlanValidationError("invalid-kind");
+  if (!Number.isSafeInteger(plan.totalWeeks) || plan.totalWeeks <= 0) {
+    throw new PlanValidationError("invalid-total-weeks");
+  }
+  if (!Number.isSafeInteger(plan.weekStartDay) || plan.weekStartDay < 0 || plan.weekStartDay > 6) {
+    throw new PlanValidationError("invalid-week-start-day");
+  }
+  const actualWeekStartDay = weekdayForDateKey(plan.startDateKey);
+  if (plan.weekStartDay !== actualWeekStartDay) {
+    throw new PlanValidationError("inconsistent-week-start-day");
+  }
+  if (plan.targetDateKey !== null) {
+    const targetWeek = planWeekIndex(plan, plan.targetDateKey);
+    if (targetWeek.kind !== "inside") throw new PlanValidationError("target-outside-plan");
+  }
+  if (plan.kind !== expectedKind(plan)) throw new PlanValidationError("inconsistent-kind");
+  if (!validJson(plan.structureJson)) throw new PlanValidationError("invalid-json");
+  if (
+    !Number.isSafeInteger(plan.createdAtMs)
+    || plan.createdAtMs < 0
+    || !Number.isSafeInteger(plan.updatedAtMs)
+    || plan.updatedAtMs < plan.createdAtMs
+  ) {
+    throw new PlanValidationError("invalid-timestamp");
+  }
+  if (!DEVICE_ID.test(plan.deviceId)) throw new PlanValidationError("invalid-device-id");
+  if (
+    !Number.isSafeInteger(plan.hlcPhysicalMs)
+    || plan.hlcPhysicalMs < 0
+    || !Number.isSafeInteger(plan.hlcCounter)
+    || plan.hlcCounter < 0
+  ) {
+    throw new PlanValidationError("invalid-hlc");
+  }
+}
+
+function validateWorkout(plan: PlanRecord, workout: PlanWorkoutRecord): void {
+  if (
+    !ULID.test(workout.id)
+    || workout.planId !== plan.id
+    || typeof workout.sport !== "string"
+    || workout.sport.length === 0
+    || typeof workout.name !== "string"
+    || workout.name.length === 0
+    || (workout.durationS !== null
+      && (!Number.isSafeInteger(workout.durationS) || workout.durationS <= 0))
+    || !validJson(workout.structureJson)
+    || !ORIGIN.has(workout.origin)
+    || !DEVICE_ID.test(workout.deviceId)
+    || !Number.isSafeInteger(workout.hlcPhysicalMs)
+    || workout.hlcPhysicalMs < 0
+    || !Number.isSafeInteger(workout.hlcCounter)
+    || workout.hlcCounter < 0
+  ) {
+    throw new PlanValidationError("invalid-workout");
+  }
+  if (planWeekIndex(plan, workout.dateKey).kind !== "inside") {
+    throw new PlanValidationError("workout-outside-plan");
+  }
+}
+
+function text(row: Row, key: string): string {
+  const value = row[key];
+  if (typeof value !== "string") throw new PlanValidationError("invalid-json");
+  return value;
+}
+
+function integer(row: Row, key: string): number {
+  const value = row[key];
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    throw new PlanValidationError("invalid-json");
+  }
+  return value;
+}
+
+function nullableText(row: Row, key: string): string | null {
+  const value = row[key];
+  if (value !== null && typeof value !== "string") throw new PlanValidationError("invalid-json");
+  return value;
+}
+
+function nullableInteger(row: Row, key: string): number | null {
+  const value = row[key];
+  if (value !== null && (typeof value !== "number" || !Number.isSafeInteger(value))) {
+    throw new PlanValidationError("invalid-json");
+  }
+  return value;
+}
+
+function planFromRow(row: Row): PlanRecord {
+  const plan: PlanRecord = Object.freeze({
+    id: text(row, "id"),
+    originId: nullableText(row, "origin_id"),
+    name: text(row, "name"),
+    primaryGoal: text(row, "primary_goal"),
+    startDateKey: integer(row, "start_date_key"),
+    targetDateKey: nullableInteger(row, "target_date_key"),
+    status: text(row, "status") as PlanStatus,
+    kind: text(row, "kind") as PlanKind,
+    totalWeeks: integer(row, "total_weeks"),
+    weekStartDay: integer(row, "week_start_day"),
+    structureJson: text(row, "structure_json"),
+    createdAtMs: integer(row, "created_at_ms"),
+    updatedAtMs: integer(row, "updated_at_ms"),
+    deviceId: text(row, "device_id"),
+    hlcPhysicalMs: integer(row, "hlc_physical_ms"),
+    hlcCounter: integer(row, "hlc_counter"),
+  });
+  validatePlan(plan);
+  return plan;
+}
+
+function workoutFromRow(row: Row): PlanWorkoutRecord {
+  return Object.freeze({
+    id: text(row, "id"),
+    planId: text(row, "plan_id"),
+    dateKey: integer(row, "date_key"),
+    sport: text(row, "sport"),
+    name: text(row, "name"),
+    durationS: nullableInteger(row, "duration_s"),
+    structureJson: text(row, "structure_json"),
+    origin: text(row, "origin") as PlanWorkoutOrigin,
+    deviceId: text(row, "device_id"),
+    hlcPhysicalMs: integer(row, "hlc_physical_ms"),
+    hlcCounter: integer(row, "hlc_counter"),
+  });
+}
+
+export function createPlanRepository(store: PlanningStore): PlanRepository {
+  const replace = async (plan: PlanRecord, workouts: readonly PlanWorkoutRecord[]): Promise<void> => {
+    validatePlan(plan);
+    for (const workout of workouts) validateWorkout(plan, workout);
+    await store.transaction(async () => {
+      await store.run(`INSERT INTO plan (
+  id, origin_id, name, primary_goal, start_date_key, target_date_key, status, kind,
+  total_weeks, week_start_day, structure_json, created_at_ms, updated_at_ms,
+  device_id, hlc_physical_ms, hlc_counter
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (id) DO UPDATE SET
+  origin_id = excluded.origin_id,
+  name = excluded.name,
+  primary_goal = excluded.primary_goal,
+  start_date_key = excluded.start_date_key,
+  target_date_key = excluded.target_date_key,
+  status = excluded.status,
+  kind = excluded.kind,
+  total_weeks = excluded.total_weeks,
+  week_start_day = excluded.week_start_day,
+  structure_json = excluded.structure_json,
+  updated_at_ms = excluded.updated_at_ms,
+  device_id = excluded.device_id,
+  hlc_physical_ms = excluded.hlc_physical_ms,
+  hlc_counter = excluded.hlc_counter`, [
+        plan.id,
+        plan.originId,
+        plan.name,
+        plan.primaryGoal,
+        plan.startDateKey,
+        plan.targetDateKey,
+        plan.status,
+        plan.kind,
+        plan.totalWeeks,
+        plan.weekStartDay,
+        plan.structureJson,
+        plan.createdAtMs,
+        plan.updatedAtMs,
+        plan.deviceId,
+        plan.hlcPhysicalMs,
+        plan.hlcCounter,
+      ]);
+      await store.run("DELETE FROM plan_workout WHERE plan_id = ?", [plan.id]);
+      for (const workout of workouts) {
+        await store.run(`INSERT INTO plan_workout (
+  id, plan_id, date_key, sport, name, duration_s, structure_json, origin,
+  device_id, hlc_physical_ms, hlc_counter
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, [
+          workout.id,
+          workout.planId,
+          workout.dateKey,
+          workout.sport,
+          workout.name,
+          workout.durationS,
+          workout.structureJson,
+          workout.origin,
+          workout.deviceId,
+          workout.hlcPhysicalMs,
+          workout.hlcCounter,
+        ]);
+      }
+    });
+  };
+
+  return Object.freeze({
+    replace,
+    async replaceNew(
+      plan: PlanRecord,
+      workouts: readonly PlanWorkoutRecord[],
+      todayDateKey: number,
+    ) {
+      validateNewPlanStartDate(plan, todayDateKey);
+      await replace(plan, workouts);
+    },
+    async read(id: string) {
+      if (!ULID.test(id)) throw new PlanValidationError("invalid-id");
+      const row = await store.get("SELECT * FROM plan WHERE id = ?", [id]);
+      return row === undefined ? undefined : planFromRow(row);
+    },
+    async readByOriginId(originId: string) {
+      if (typeof originId !== "string" || originId.length === 0) {
+        throw new PlanValidationError("invalid-origin-id");
+      }
+      const row = await store.get("SELECT * FROM plan WHERE origin_id = ?", [originId]);
+      return row === undefined ? undefined : planFromRow(row);
+    },
+    async readLatest() {
+      const row = await store.get(
+        "SELECT * FROM plan ORDER BY updated_at_ms DESC, hlc_physical_ms DESC, hlc_counter DESC, id DESC LIMIT 1",
+      );
+      return row === undefined ? undefined : planFromRow(row);
+    },
+    async readWorkouts(planId: string) {
+      if (!ULID.test(planId)) throw new PlanValidationError("invalid-id");
+      return (await store.all(
+        "SELECT * FROM plan_workout WHERE plan_id = ? ORDER BY date_key, id",
+        [planId],
+      )).map(workoutFromRow);
+    },
+    async count() {
+      const row = await store.get("SELECT count(*) AS count FROM plan");
+      return row === undefined ? 0 : integer(row, "count");
+    },
+    async delete(id: string) {
+      if (!ULID.test(id)) throw new PlanValidationError("invalid-id");
+      await store.run("DELETE FROM plan WHERE id = ?", [id]);
+    },
+  });
+}

--- a/packages/kernel/src/store/dump.ts
+++ b/packages/kernel/src/store/dump.ts
@@ -40,6 +40,8 @@ export const DUMP_TABLES = [
   { table: "lap", orderBy: "lap_key" },
   { table: "mean_max_cache", orderBy: "mmax_key" },
   { table: "metric_snapshot", orderBy: "snapshot_key" },
+  { table: "plan", orderBy: "id" },
+  { table: "plan_workout", orderBy: "plan_id, date_key, id" },
   { table: "planned_workout", orderBy: "id" },
   { table: "pool_size_correction_overlay", orderBy: "id" },
   { table: "race_goal", orderBy: "id" },

--- a/packages/kernel/src/store/export/ports.ts
+++ b/packages/kernel/src/store/export/ports.ts
@@ -82,6 +82,8 @@ export const PURE_AUTHORED_TABLES = [
   "field_merge_override_overlay",
   "pool_size_correction_overlay",
   "dedup_confirmation",
+  "plan",
+  "plan_workout",
 ] as const;
 
 /** Mixed source|authored tables — ONLY provenance='manual' rows are authored. */

--- a/packages/kernel/src/store/migrations/012_planning.sql
+++ b/packages/kernel/src/store/migrations/012_planning.sql
@@ -1,0 +1,57 @@
+CREATE TABLE plan (
+  id TEXT PRIMARY KEY
+    CHECK (
+      length(id) = 26
+      AND id NOT GLOB '*[^0123456789ABCDEFGHJKMNPQRSTVWXYZ]*'
+    ),
+  origin_id TEXT,
+  name TEXT NOT NULL,
+  primary_goal TEXT NOT NULL,
+  start_date_key INTEGER NOT NULL,
+  target_date_key INTEGER,
+  status TEXT NOT NULL CHECK (status IN ('draft','active','ended')),
+  kind TEXT NOT NULL CHECK (kind IN ('full_plan','short_race_preparation')),
+  total_weeks INTEGER NOT NULL CHECK (total_weeks > 0),
+  week_start_day INTEGER NOT NULL CHECK (week_start_day BETWEEN 0 AND 6),
+  structure_json TEXT NOT NULL CHECK (json_valid(structure_json)),
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+  device_id TEXT NOT NULL
+    CHECK (
+      length(device_id) BETWEEN 1 AND 128
+      AND substr(device_id, 1, 1) GLOB '[A-Za-z0-9]'
+      AND device_id NOT GLOB '*[^A-Za-z0-9._:-]*'
+    ),
+  hlc_physical_ms INTEGER NOT NULL CHECK (hlc_physical_ms >= 0),
+  hlc_counter INTEGER NOT NULL CHECK (hlc_counter >= 0)
+) STRICT;
+
+CREATE UNIQUE INDEX idx_plan_origin_id
+  ON plan (origin_id)
+  WHERE origin_id IS NOT NULL;
+
+CREATE TABLE plan_workout (
+  id TEXT PRIMARY KEY
+    CHECK (
+      length(id) = 26
+      AND id NOT GLOB '*[^0123456789ABCDEFGHJKMNPQRSTVWXYZ]*'
+    ),
+  plan_id TEXT NOT NULL REFERENCES plan(id) ON DELETE CASCADE,
+  date_key INTEGER NOT NULL,
+  sport TEXT NOT NULL,
+  name TEXT NOT NULL,
+  duration_s INTEGER CHECK (duration_s IS NULL OR duration_s > 0),
+  structure_json TEXT NOT NULL CHECK (json_valid(structure_json)),
+  origin TEXT NOT NULL CHECK (origin IN ('coach','athlete')),
+  device_id TEXT NOT NULL
+    CHECK (
+      length(device_id) BETWEEN 1 AND 128
+      AND substr(device_id, 1, 1) GLOB '[A-Za-z0-9]'
+      AND device_id NOT GLOB '*[^A-Za-z0-9._:-]*'
+    ),
+  hlc_physical_ms INTEGER NOT NULL CHECK (hlc_physical_ms >= 0),
+  hlc_counter INTEGER NOT NULL CHECK (hlc_counter >= 0)
+) STRICT;
+
+CREATE INDEX idx_plan_workout_plan_date
+  ON plan_workout (plan_id, date_key);

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -9,6 +9,7 @@ import storeOwner008 from "./008_store_owner.sql";
 import activitySourceResolver009 from "./009_activity_source_resolver.sql";
 import analyticsCurves010 from "./010_analytics_curves.sql";
 import activityAnalysisProjection011 from "./011_activity_analysis_projection.sql";
+import planning012 from "./012_planning.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -35,4 +36,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 9, name: "009_activity_source_resolver", sql: activitySourceResolver009 },
   { version: 10, name: "010_analytics_curves", sql: analyticsCurves010 },
   { version: 11, name: "011_activity_analysis_projection", sql: activityAnalysisProjection011 },
+  { version: 12, name: "012_planning", sql: planning012 },
 ];

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -29,6 +29,8 @@ const EXPECTED_TABLES = [
 ];
 const EXPECTED_FULL_TABLES = [
   ...EXPECTED_TABLES,
+  "plan",
+  "plan_workout",
   "ingest_metadata",
   "repair_log",
   "dedup_confirmation",
@@ -171,6 +173,7 @@ describe("001_init migration", () => {
       { version: 9, name: "009_activity_source_resolver" },
       { version: 10, name: "010_analytics_curves" },
       { version: 11, name: "011_activity_analysis_projection" },
+      { version: 12, name: "012_planning" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -262,7 +265,7 @@ describe("001_init migration", () => {
     expect(MIGRATIONS[2]!.sql).toBe(MIGRATION_003);
   });
 
-  it("applies 001 through 010 with exactly forty-one tables and no foreign-key violations", () => {
+  it("applies all migrations with exactly forty-four tables and no foreign-key violations", () => {
     db = openFull();
     const names = (
       db
@@ -272,7 +275,7 @@ describe("001_init migration", () => {
       .map((row) => row.name)
       .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
-    expect(names).toHaveLength(42);
+    expect(names).toHaveLength(44);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
@@ -758,6 +761,8 @@ describe("001_init migration", () => {
       { table: "lap", orderBy: "lap_key" },
       { table: "mean_max_cache", orderBy: "mmax_key" },
       { table: "metric_snapshot", orderBy: "snapshot_key" },
+      { table: "plan", orderBy: "id" },
+      { table: "plan_workout", orderBy: "plan_id, date_key, id" },
       { table: "planned_workout", orderBy: "id" },
       { table: "pool_size_correction_overlay", orderBy: "id" },
       { table: "race_goal", orderBy: "id" },
@@ -777,7 +782,7 @@ describe("001_init migration", () => {
       { table: "workout", orderBy: "workout_key" },
       { table: "zone_set_history", orderBy: "id" },
     ]);
-    expect(DUMP_TABLES).toHaveLength(37);
+    expect(DUMP_TABLES).toHaveLength(39);
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("source_watermark");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_failure");
@@ -833,7 +838,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     }>;
     expect(tables.find((row) => row.name === "sync_failure")?.strict).toBe(1);
     expect(db.prepare("PRAGMA foreign_key_list(sync_failure)").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(37);
+    expect(DUMP_TABLES).toHaveLength(39);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(PURE_AUTHORED_TABLES).not.toContain("sync_failure");
     expect(MIXED_AUTHORED_TABLES).not.toContain("sync_failure");
@@ -890,7 +895,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       expect(tables.find((row) => row.name === name)?.strict).toBe(1);
     }
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(37);
+    expect(DUMP_TABLES).toHaveLength(39);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("analytics_curve_refresh_failure");
     expect(DERIVED_TABLES).not.toContain("analytics_curve_generation");
   });
@@ -918,6 +923,25 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       "activity_analysis_projection",
     );
     expect(DERIVED_TABLES).not.toContain("activity_analysis_projection");
+  });
+
+  it("adds strict authored Plan and Plan Workout tables without changing planned_workout", () => {
+    db = openFull();
+    const tables = db.prepare("PRAGMA table_list").all() as Array<{
+      name: string;
+      strict: number;
+    }>;
+    expect(tables.find((row) => row.name === "plan")?.strict).toBe(1);
+    expect(tables.find((row) => row.name === "plan_workout")?.strict).toBe(1);
+    expect(db.prepare("PRAGMA foreign_key_list(plan_workout)").all())
+      .toContainEqual(expect.objectContaining({ table: "plan", on_delete: "CASCADE" }));
+    expect(db.prepare("PRAGMA index_info(idx_plan_workout_plan_date)").all()).toEqual([
+      expect.objectContaining({ seqno: 0, name: "plan_id" }),
+      expect.objectContaining({ seqno: 1, name: "date_key" }),
+    ]);
+    expect(PURE_AUTHORED_TABLES).toEqual(expect.arrayContaining(["plan", "plan_workout"]));
+    expect(MIXED_AUTHORED_TABLES).toContain("planned_workout");
+    expect(db.prepare("PRAGMA table_info(planned_workout)").all()).not.toEqual([]);
   });
 
   it("omits the unreleased prior bone-stress column from the baseline schema", () => {

--- a/packages/kernel/tests/planning-date-keys.test.ts
+++ b/packages/kernel/tests/planning-date-keys.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  PlanningDateError,
+  addCivilDays,
+  dateKeyFromText,
+  inclusiveCivilDays,
+  planWeekIndex,
+  planWeekRange,
+  validateNewPlanStartDate,
+  weekdayForDateKey,
+} from "../src/planning/index.js";
+
+describe("Planning civil dates and Training weeks", () => {
+  it.each([
+    [20260709, 12, 20260708, { kind: "outside-plan", side: "before" }],
+    [20260709, 12, 20260709, { kind: "inside", weekIndex: 1 }],
+    [20260709, 12, 20260715, { kind: "inside", weekIndex: 1 }],
+    [20260709, 12, 20260716, { kind: "inside", weekIndex: 2 }],
+    [20260730, 2, 20260806, { kind: "inside", weekIndex: 2 }],
+    [20261229, 2, 20270105, { kind: "inside", weekIndex: 2 }],
+    [20260709, 12, 20260930, { kind: "inside", weekIndex: 12 }],
+    [20260709, 12, 20261001, { kind: "outside-plan", side: "after" }],
+  ] as const)(
+    "maps Plan %i/%i and date %i to its Training week",
+    (startDateKey, totalWeeks, dateKey, expected) => {
+      expect(planWeekIndex({ startDateKey, totalWeeks }, dateKey)).toEqual(expected);
+    },
+  );
+
+  it("derives the stored weekday from the athlete-selected start date", () => {
+    expect(weekdayForDateKey(20260709)).toBe(4);
+  });
+
+  it("crosses month and year boundaries without resolving a timezone", () => {
+    expect(planWeekRange({ startDateKey: 20261229, totalWeeks: 2 }, 1)).toEqual({
+      startDateKey: 20261229,
+      endDateKey: 20270104,
+    });
+    expect(planWeekRange({ startDateKey: 20261229, totalWeeks: 2 }, 2)).toEqual({
+      startDateKey: 20270105,
+      endDateKey: 20270111,
+    });
+    expect(addCivilDays(20240228, 1)).toBe(20240229);
+    expect(inclusiveCivilDays(20260709, 20260930)).toBe(84);
+  });
+
+  it("rejects impossible dates, invalid week indexes, and invalid new starts", () => {
+    expect(() => dateKeyFromText("2026-02-30")).toThrow(new PlanningDateError("invalid-date-key"));
+    expect(() => planWeekRange({ startDateKey: 20260709, totalWeeks: 2 }, 0))
+      .toThrow(new PlanningDateError("invalid-week-index"));
+    expect(() => validateNewPlanStartDate(
+      { startDateKey: 20260708, targetDateKey: 20261004 },
+      20260709,
+    )).toThrow(new PlanningDateError("start-before-today"));
+    expect(() => validateNewPlanStartDate(
+      { startDateKey: 20261005, targetDateKey: 20261004 },
+      20260709,
+    )).toThrow(new PlanningDateError("start-after-target"));
+  });
+});

--- a/packages/kernel/tests/store-export.test.ts
+++ b/packages/kernel/tests/store-export.test.ts
@@ -216,7 +216,7 @@ describe("store export op", () => {
     }
   });
 
-  it("(roundtrip-plain) plaintext round-trip restores all 12 tables", async () => {
+  it("(roundtrip-plain) plaintext round-trip restores every authored table", async () => {
     const data = populated();
     const { source } = makeSource(data);
     const crypto = new FakeCrypto();
@@ -229,7 +229,9 @@ describe("store export op", () => {
       { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
       { container: built.container },
     );
-    expect(imported.restored).toHaveLength(12);
+    expect(imported.restored).toHaveLength(
+      PURE_AUTHORED_TABLES.length + MIXED_AUTHORED_TABLES.length,
+    );
     expect(imported.restored.find((row) => row.table === "dedup_confirmation")?.inserted).toBe(2);
     for (const t of PURE_AUTHORED_TABLES) {
       expect(imported.restored.find((r) => r.table === t)?.inserted).toBe(2);
@@ -263,7 +265,9 @@ describe("store export op", () => {
       { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
       { container: built.container, passphrase: "correct horse" },
     );
-    expect(imported.restored).toHaveLength(12);
+    expect(imported.restored).toHaveLength(
+      PURE_AUTHORED_TABLES.length + MIXED_AUTHORED_TABLES.length,
+    );
     expect(imported.restored.find((row) => row.table === "dedup_confirmation")?.inserted).toBe(2);
   });
 
@@ -339,7 +343,9 @@ describe("store export op", () => {
         { sink: makeSink(), presence: makePresence(), crypto, codec, targetUserVersion: 5 },
         { container: built.container },
       );
-      expect(imported.restored).toHaveLength(12);
+      expect(imported.restored).toHaveLength(
+        PURE_AUTHORED_TABLES.length + MIXED_AUTHORED_TABLES.length,
+      );
     }
   });
 

--- a/packages/kernel/tsup.config.ts
+++ b/packages/kernel/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     ports: "src/ports/index.ts",
     "store/migrations": "src/store/migrations/index.ts",
     store: "src/store/index.ts",
+    planning: "src/planning/index.ts",
     "archive/index": "src/archive/index.ts",
     "store/export/index": "src/store/export/index.ts",
     "ingest/index": "src/ingest/index.ts",


### PR DESCRIPTION
## Summary

- add migration 012 with durable Plan and Plan Workout rows
- add typed repositories, civil-date Training Week helpers, and lifecycle invariants
- import the legacy current Plan once without modifying its source
- dual-write `plan_save` to the legacy file and new rows until the later read migration
- include Plan rows in deterministic dumps and authored backup/restore

## Verification

- `pnpm --filter @enduragent/kernel test` — 697 passed
- `pnpm --filter @enduragent/kernel-node test` — 286 passed, 1 skipped
- `pnpm check` — passed
- fresh read-only acceptance review — SHIP, 18/18

## Limits

- `MIN_FULL_PLAN_WEEKS = 12` — classifies a targetless block as a full Plan at twelve complete Training Weeks.
- `MIN_FULL_PLAN_DAYS = 84` — classifies a dated block as a full Plan at eighty-four inclusive civil days; shorter valid blocks remain Short race-preparation blocks.

## Changeset

Not added. This is internal persistence and compatibility wiring with no athlete-visible behavior change.
