### PR TITLE
fix(desktop): keep backend-selection probe stderr clean

### DIFF
--- a/.changeset/clean-backend-selection-probe.md
+++ b/.changeset/clean-backend-selection-probe.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Keep the signed macOS backend-selection probe free of dependency deprecation output.

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -5,6 +5,10 @@ import { defineConfig, externalizeDepsPlugin, type UserConfig } from "electron-v
 import { appVersionDefine } from "../desktop-renderer/app-version.mjs";
 
 const desktopRoot = import.meta.dirname;
+const keychainBindingProbeDeprecationEntry = resolve(
+  desktopRoot,
+  "src/main/keychain-binding-probe-deprecation.ts",
+);
 
 export function createDesktopViteConfig(
   options: {
@@ -25,6 +29,11 @@ export function createDesktopViteConfig(
           input: {
             index: resolve(desktopRoot, "src/main/index.ts"),
             "daemon-utility": daemonUtilityEntry,
+          },
+          output: {
+            manualChunks: {
+              "keychain-binding-probe-deprecation": [keychainBindingProbeDeprecationEntry],
+            },
           },
         },
       },

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,3 +1,4 @@
+import "./keychain-binding-probe-deprecation.js";
 import { bindWindowsUserData } from "./windows-user-data.js";
 import {
   createAcceptanceKeychainTransport,

--- a/apps/desktop/src/main/keychain-binding-probe-deprecation.ts
+++ b/apps/desktop/src/main/keychain-binding-probe-deprecation.ts
@@ -1,0 +1,3 @@
+if (process.argv.includes("--desktop-keychain-binding-probe")) {
+  process.noDeprecation = true;
+}

--- a/apps/desktop/src/main/keychain-binding-probe-deprecation.ts
+++ b/apps/desktop/src/main/keychain-binding-probe-deprecation.ts
@@ -1,3 +1,5 @@
 if (process.argv.includes("--desktop-keychain-binding-probe")) {
   process.noDeprecation = true;
 }
+
+export {};

--- a/apps/desktop/tests/keychain-binding-probe-deprecation.test.ts
+++ b/apps/desktop/tests/keychain-binding-probe-deprecation.test.ts
@@ -1,0 +1,46 @@
+import { readFile } from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const probeFlag = "--desktop-keychain-binding-probe";
+const originalArgv = process.argv;
+const originalNoDeprecation = process.noDeprecation;
+
+async function loadProbeDeprecationPolicy(commandLine: readonly string[]): Promise<boolean> {
+  process.argv = [...commandLine];
+  process.noDeprecation = false;
+  vi.resetModules();
+  await import("../src/main/keychain-binding-probe-deprecation.js");
+  return process.noDeprecation;
+}
+
+afterEach(() => {
+  process.argv = originalArgv;
+  if (originalNoDeprecation === undefined) delete process.noDeprecation;
+  else process.noDeprecation = originalNoDeprecation;
+  vi.resetModules();
+});
+
+describe("keychain binding probe deprecation policy", () => {
+  it("disables deprecation output for the backend-selection probe", async () => {
+    await expect(loadProbeDeprecationPolicy(["electron", "index.js", probeFlag])).resolves.toBe(
+      true,
+    );
+  });
+
+  it.each([{ arguments_: [] }, { arguments_: [`${probeFlag}-other`] }])(
+    "leaves deprecation output enabled without the exact probe flag",
+    async ({ arguments_ }) => {
+      await expect(
+        loadProbeDeprecationPolicy(["electron", "index.js", ...arguments_]),
+      ).resolves.toBe(false);
+    },
+  );
+
+  it("loads the policy before every other main-process import", async () => {
+    const source = await readFile(new URL("../src/main/index.ts", import.meta.url), "utf8");
+
+    expect(source.split("\n", 1)).toEqual([
+      'import "./keychain-binding-probe-deprecation.js";',
+    ]);
+  });
+});

--- a/apps/desktop/tests/keychain-binding-probe-deprecation.test.ts
+++ b/apps/desktop/tests/keychain-binding-probe-deprecation.test.ts
@@ -1,9 +1,13 @@
-import { readFile } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDesktopViteConfig } from "../electron.vite.config.js";
 
+const desktopRoot = resolve(import.meta.dirname, "..");
 const probeFlag = "--desktop-keychain-binding-probe";
 const originalArgv = process.argv;
 const originalNoDeprecation = process.noDeprecation;
+const builtMainEntry = resolve(desktopRoot, "out/main/index.js");
 
 async function loadProbeDeprecationPolicy(commandLine: readonly string[]): Promise<boolean> {
   process.argv = [...commandLine];
@@ -36,11 +40,38 @@ describe("keychain binding probe deprecation policy", () => {
     },
   );
 
-  it("loads the policy before every other main-process import", async () => {
-    const source = await readFile(new URL("../src/main/index.ts", import.meta.url), "utf8");
+  it("configures the policy as a dedicated main-process chunk", () => {
+    const config = createDesktopViteConfig();
+    const output = config.main?.build?.rollupOptions?.output;
 
-    expect(source.split("\n", 1)).toEqual([
-      'import "./keychain-binding-probe-deprecation.js";',
-    ]);
+    expect(config.main?.build?.rollupOptions?.input).toMatchObject({
+      index: resolve(desktopRoot, "src/main/index.ts"),
+    });
+    expect(output).not.toBeInstanceOf(Array);
+    expect(output).toMatchObject({
+      manualChunks: {
+        "keychain-binding-probe-deprecation": [
+          resolve(desktopRoot, "src/main/keychain-binding-probe-deprecation.ts"),
+        ],
+      },
+    });
   });
+
+  it.skipIf(!existsSync(builtMainEntry))(
+    "evaluates the policy chunk before the built main-process imports",
+    () => {
+      const firstLine = readFileSync(builtMainEntry, "utf8").split("\n", 1)[0];
+      const guardImport = firstLine.match(
+        /^import "(\.\/chunks\/keychain-binding-probe-deprecation-[^"]+\.js)";$/u,
+      );
+
+      expect(guardImport).not.toBeNull();
+      if (guardImport === null) return;
+
+      const guardChunk = readFileSync(resolve(desktopRoot, "out/main", guardImport[1]), "utf8");
+      expect(guardChunk).toContain(`process.argv.includes("${probeFlag}")`);
+      expect(guardChunk).toContain("process.noDeprecation = true;");
+      expect(guardChunk).not.toMatch(/^\s*import\b/mu);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

`verify-macos-backend-selection.mjs` requires the signed `Enduragent --desktop-keychain-binding-probe` run to leave stderr empty. On a signed build the probe emitted Node's `DEP0040` punycode deprecation (grammy → node-fetch 2.x → whatwg-url → tr46), so the release-lane `sign-macos` assertion would fail regardless of environment.

- Set `process.noDeprecation = true` when argv contains `--desktop-keychain-binding-probe`, in a dedicated Rollup chunk that the main bundle imports before any hoisted external import (a plain first-import module was inlined after the externals and never ran early enough).
- Tests: config mapping test (always on) + built-output regression test (skips when `out/` is absent).

## Verification

- `pnpm exec electron-vite build` → guard chunk import is line 1 of `out/main/index.js`
- `vitest run tests/keychain-binding-probe-deprecation.test.ts` → 5/5
- `pnpm --filter @enduragent/desktop check` → pass
- Fable 5 read-only skeptic on built output → PASS

Limits: none.