### PR TITLE
fix(desktop): keep setup reachable after a successful credential reset

### DIFF
--- a/.changeset/unstrand-credential-reset.md
+++ b/.changeset/unstrand-credential-reset.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Removing all credentials no longer leaves the setup screen locked until restart.

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -340,6 +340,7 @@ export function createCredentialSettingsController(input: {
   let generation = 0;
   let disposed = false;
   let operation: Promise<void> | undefined;
+  let activeResetOperation: symbol | undefined;
   let reconnectRequired = false;
   let failedClient: CoachClient | undefined;
 
@@ -574,6 +575,8 @@ export function createCredentialSettingsController(input: {
     if (content === null || content.confirmation !== "all") return Promise.resolve();
     const releaseMutation = input.beginMutation();
     if (releaseMutation === null) return Promise.resolve();
+    const resetOperation = Symbol();
+    activeResetOperation = resetOperation;
     const operationGeneration = ++generation;
     render({
       status: "deleting",
@@ -624,7 +627,7 @@ export function createCredentialSettingsController(input: {
         });
         return;
       }
-      if (disposed || generation !== operationGeneration) return;
+      if (disposed || activeResetOperation !== resetOperation) return;
       releaseMutation();
       if (result.status === "refused") {
         render({
@@ -658,6 +661,7 @@ export function createCredentialSettingsController(input: {
       });
     })().finally(() => {
       releaseMutation();
+      if (activeResetOperation === resetOperation) activeResetOperation = undefined;
       if (operation === pending) operation = undefined;
     });
     operation = pending;
@@ -891,6 +895,7 @@ export function createCredentialSettingsController(input: {
       disposed = true;
       ++generation;
       operation = undefined;
+      activeResetOperation = undefined;
       currentState = { status: "closed" };
       input.view.dispose();
     },

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -150,7 +150,7 @@ export interface CredentialSettingsView {
     readonly onSetupOpened: () => void;
     readonly onOpenSetup: () => void;
   }): void;
-  render(state: Exclude<CredentialSettingsState, { readonly status: "closed" }>): void;
+  render(state: CredentialSettingsState): void;
   dispose(): void;
 }
 
@@ -344,7 +344,7 @@ export function createCredentialSettingsController(input: {
   let reconnectRequired = false;
   let failedClient: CoachClient | undefined;
 
-  const render = (state: Exclude<CredentialSettingsState, { readonly status: "closed" }>): void => {
+  const render = (state: CredentialSettingsState): void => {
     currentState = state;
     input.view.render(state);
   };
@@ -644,6 +644,10 @@ export function createCredentialSettingsController(input: {
           recoveryAvailable: false,
           focus: { target: "feedback" },
         });
+        return;
+      }
+      if (generation !== operationGeneration) {
+        render({ status: "closed" });
         return;
       }
       render({

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -702,14 +702,7 @@ describe("credential settings controller", () => {
     const firstReconciliation = new Promise<void>((resolve) => {
       resolveFirstReconciliation = resolve;
     });
-    let resolveSecondReconciliation!: () => void;
-    const secondReconciliation = new Promise<void>((resolve) => {
-      resolveSecondReconciliation = resolve;
-    });
-    const onReconciled = vi
-      .fn<() => Promise<void>>()
-      .mockReturnValueOnce(firstReconciliation)
-      .mockReturnValueOnce(secondReconciliation);
+    const onReconciled = vi.fn<() => Promise<void>>(() => firstReconciliation);
     const { controller, subject, releaseMutation } = createSubject({
       onReconciled,
       reset: async () => ({ status: "refused", reason: "storage-failed" }),
@@ -723,14 +716,19 @@ describe("credential settings controller", () => {
     controller.close();
     expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
     const reopening = controller.activate();
+    let reopened = false;
+    void reopening.then(() => {
+      reopened = true;
+    });
+    await Promise.resolve();
     expect(onReconciled).toHaveBeenCalledOnce();
+    expect(reopened).toBe(false);
     expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
 
     resolveFirstReconciliation();
-    await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledTimes(2));
-    expect(controller.state()).toMatchObject({ status: "loading", resetUncertain: true });
-    resolveSecondReconciliation();
     await reopening;
+    expect(reopened).toBe(true);
+    expect(onReconciled).toHaveBeenCalledOnce();
     expect(releaseMutation).toHaveBeenCalled();
     expect(controller.state().status).toBe("ready");
     expect(controller.state().resetUncertain).toBeUndefined();

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -3,6 +3,7 @@ import type { RuntimeConfigSnapshot, SpendSummary } from "@enduragent/coach-cont
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Shell } from "../src/app/Shell.js";
 import type { DesktopCoachClientProvider } from "../src/coach-client.js";
 import type {
   CredentialDeleteResult,
@@ -24,7 +25,10 @@ import {
   type OnboardingController,
 } from "../src/onboarding/controller.js";
 import { createAthleteSettingsController } from "../src/settings/athlete-controller.js";
-import { createCredentialSettingsController } from "../src/settings/credential-controller.js";
+import {
+  credentialChangesBlocked,
+  createCredentialSettingsController,
+} from "../src/settings/credential-controller.js";
 import { createProviderModelSettingsController } from "../src/settings/provider-model-controller.js";
 import { createSessionSettingsController } from "../src/settings/session-controller.js";
 import {
@@ -429,6 +433,7 @@ function createHarness(options: HarnessOptions = {}) {
     loadTelegramStatus,
     scheduleTelegramPoll,
     cancelTelegramPoll,
+    credentialController,
     telegramController,
     spendController,
     startUpdate: () => updateController.start(),
@@ -893,6 +898,120 @@ describe("conversation settings", () => {
 });
 
 describe("settings lifecycle", () => {
+  it("unlocks fresh credential setup after a successful reset unmounts Settings", async () => {
+    const user = userEvent.setup();
+    const resetContinuation = deferred<void>();
+    const configuredStatuses = [
+      { slot: "anthropic", state: "configured", runtimeState: "active" },
+      { slot: "intervals-icu", state: "configured", runtimeState: "active" },
+    ] as const;
+    let resetCompleted = false;
+    const loadCredentialStatuses = vi.fn(async () => (resetCompleted ? [] : configuredStatuses));
+    const bridge = testBridge(async () => ({ status: "configured", runtimeReady: true }));
+    bridge.credentialStatuses.mockImplementation(loadCredentialStatuses);
+    bridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    bridge.llmConfiguration.mockImplementation(async () => llmConfiguration());
+    bridge.getSetupStatus = vi.fn(async () => ({
+      schemaVersion: 1 as const,
+      intake: {
+        swim_skill_floor: null,
+        continuous_distance_capable: null,
+        open_water_comfort: null,
+        prior_bsi: false,
+        clinician_cleared: null,
+        injury_status: "none" as const,
+      },
+      durableTrainingData: true,
+    }));
+    const onboardingView = createOnboardingViewAdapter({
+      publish: (next) => useEnduragentStore.getState().setOnboarding(next),
+    });
+    const onboarding = createOnboardingController({
+      bridge,
+      credentials: credentialDrafts,
+      view: onboardingView.view,
+      focusOpener: vi.fn(),
+      onComplete: vi.fn(),
+      credentialMutationsBlocked: () =>
+        credentialChangesBlocked(useEnduragentStore.getState().settings.credentials, false),
+    });
+    useEnduragentStore.getState().bindOnboardingActions(onboarding);
+
+    try {
+      await act(async () => onboarding.open());
+      expect(setupReady(useEnduragentStore.getState())).toBe(true);
+      harness = createHarness({
+        runtime: () =>
+          snapshot({
+            llm: {
+              provider: "anthropic",
+              model: "synthetic-model",
+              credential_configured: !resetCompleted,
+            },
+            intervals: {
+              athlete_id: "i1",
+              credential_configured: !resetCompleted,
+              managedByEnvironment: { athleteId: false },
+            },
+          }),
+        loadCredentialStatuses,
+        credentialRecoveryStatus: async () => ({
+          state: "ready",
+          unverifiedEnvelopes: resetCompleted ? 0 : 1,
+        }),
+        resetAllCredentials: async () => {
+          resetCompleted = true;
+          return { status: "reset", keyCleanupPending: false };
+        },
+        onDeleted: async () => {
+          await onboarding.refresh();
+          await resetContinuation.promise;
+        },
+      });
+      render(<Shell onReady={() => {}} />);
+      await screen.findByRole("button", { name: "Save coach route" });
+
+      await user.click(screen.getByRole("button", { name: "Remove all credentials" }));
+      const confirmation = screen.getByRole("group", { name: "Remove all credentials?" });
+      await user.click(
+        within(confirmation).getByRole("button", { name: "Remove all credentials" }),
+      );
+
+      await waitFor(() => {
+        expect(document.querySelector('[data-setup-host="gate"]')).not.toBeNull();
+        expect(useEnduragentStore.getState().onboarding.completionRequired).toBe(true);
+        expect(harness?.credentialController.state()).toEqual({
+          status: "closed",
+          resetUncertain: true,
+        });
+      });
+      expect(
+        credentialChangesBlocked(useEnduragentStore.getState().settings.credentials, false),
+      ).toBe(true);
+      const aiSetup = document.querySelector<HTMLButtonElement>('[data-setup-trigger="ai"]');
+      expect(aiSetup).toBeDisabled();
+
+      act(() => resetContinuation.resolve(undefined));
+
+      await waitFor(() => {
+        expect(
+          credentialChangesBlocked(useEnduragentStore.getState().settings.credentials, false),
+        ).toBe(false);
+        expect(harness?.credentialController.state()).toMatchObject({ status: "deleted" });
+        expect(harness?.credentialController.state().resetUncertain).toBeUndefined();
+        expect(aiSetup).toBeEnabled();
+      });
+      expect(document.querySelector('[data-setup-host="gate"]')).not.toBeNull();
+      await user.click(aiSetup!);
+      await waitFor(() => expect(document.querySelector('[data-setup-menu="ai"]')).not.toBeNull());
+    } finally {
+      resetContinuation.resolve(undefined);
+      onboarding.dispose();
+      onboardingView.dispose();
+      useEnduragentStore.getState().bindOnboardingActions(null);
+    }
+  });
+
   it("keeps the resident Telegram controller active when Settings unmounts and remounts", async () => {
     harness = createHarness();
     const view = render(<SettingsView />);

--- a/apps/desktop-renderer/tests/settings-surface.test.tsx
+++ b/apps/desktop-renderer/tests/settings-surface.test.tsx
@@ -901,12 +901,20 @@ describe("settings lifecycle", () => {
   it("unlocks fresh credential setup after a successful reset unmounts Settings", async () => {
     const user = userEvent.setup();
     const resetContinuation = deferred<void>();
+    const refreshedStatuses = deferred<readonly CredentialSlotStatus[]>();
     const configuredStatuses = [
       { slot: "anthropic", state: "configured", runtimeState: "active" },
       { slot: "intervals-icu", state: "configured", runtimeState: "active" },
     ] as const;
+    const reconfiguredStatuses = [
+      { slot: "openrouter", state: "configured", runtimeState: "stored-inactive" },
+    ] as const;
     let resetCompleted = false;
-    const loadCredentialStatuses = vi.fn(async () => (resetCompleted ? [] : configuredStatuses));
+    let setupCompleted = false;
+    const loadCredentialStatuses = vi.fn(() => {
+      if (!resetCompleted) return Promise.resolve(configuredStatuses);
+      return setupCompleted ? refreshedStatuses.promise : Promise.resolve([]);
+    });
     const bridge = testBridge(async () => ({ status: "configured", runtimeReady: true }));
     bridge.credentialStatuses.mockImplementation(loadCredentialStatuses);
     bridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
@@ -997,15 +1005,50 @@ describe("settings lifecycle", () => {
         expect(
           credentialChangesBlocked(useEnduragentStore.getState().settings.credentials, false),
         ).toBe(false);
-        expect(harness?.credentialController.state()).toMatchObject({ status: "deleted" });
-        expect(harness?.credentialController.state().resetUncertain).toBeUndefined();
+        expect(harness?.credentialController.state()).toEqual({ status: "closed" });
+        expect(useEnduragentStore.getState().settings.credentials).toEqual({ status: "closed" });
         expect(aiSetup).toBeEnabled();
       });
       expect(document.querySelector('[data-setup-host="gate"]')).not.toBeNull();
       await user.click(aiSetup!);
       await waitFor(() => expect(document.querySelector('[data-setup-menu="ai"]')).not.toBeNull());
+
+      const loadsBeforeSettingsReopens = loadCredentialStatuses.mock.calls.length;
+      act(() => {
+        setupCompleted = true;
+        useEnduragentStore.setState((state) => ({
+          onboarding: { ...state.onboarding, completionRequired: false },
+        }));
+      });
+
+      await waitFor(() => {
+        expect(loadCredentialStatuses).toHaveBeenCalledTimes(loadsBeforeSettingsReopens + 1);
+        expect(harness?.credentialController.state()).toMatchObject({
+          status: "loading",
+          announcement: "",
+        });
+        expect(useEnduragentStore.getState().settings.credentials).toMatchObject({
+          status: "loading",
+          announcement: "",
+        });
+      });
+      expect(screen.queryByText(/All credentials were removed/u)).not.toBeInTheDocument();
+
+      act(() => refreshedStatuses.resolve(reconfiguredStatuses));
+      await waitFor(() => {
+        expect(harness?.credentialController.state()).toMatchObject({
+          status: "ready",
+          entries: [expect.objectContaining({ credential: "openrouter" })],
+        });
+        expect(useEnduragentStore.getState().settings.credentials).toMatchObject({
+          status: "ready",
+          entries: [expect.objectContaining({ credential: "openrouter" })],
+        });
+      });
+      expect(screen.queryByText(/All credentials were removed/u)).not.toBeInTheDocument();
     } finally {
       resetContinuation.resolve(undefined);
+      refreshedStatuses.resolve(reconfiguredStatuses);
       onboarding.dispose();
       onboardingView.dispose();
       useEnduragentStore.getState().bindOnboardingActions(null);


### PR DESCRIPTION
## Summary

A successful full credential reset left the Settings credential pane stranded: the global `resetUncertain` flag survived the completed reset, so re-entering setup stayed blocked (audit item C9). Second commit covers the follow-up: when the reset finishes after Settings was unmounted, the controller now publishes a clean `closed` state so the next activation starts a fresh load instead of reusing a stale `deleted` snapshot.

- Reset operations are token-scoped (`activeResetOperation`); only the owning operation clears uncertainty.
- Uncertainty is still set before the RPC and retained on reload/reconcile failure.

## Verification

- `vitest run` desktop-renderer: 58 files, 963 tests pass
- `pnpm --filter @enduragent/desktop-renderer check` pass
- Fable 5 read-only skeptics on both commits → PASS

Limits: none.

Design note (pre-existing, unchanged): a *refused* reset that completes while Settings is unmounted publishes `ready` into the closed pane; the existing reopen test encodes that as intended.