### PR TITLE
fix(desktop): accept macOS-managed partition ACL on the keychain key

### DIFF
--- a/.changeset/fresh-keys-save.md
+++ b/.changeset/fresh-keys-save.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Fixed saving credentials failing with "encryption unavailable" on macOS.

--- a/apps/desktop/native/keychain-binding/keychain-binding.mm
+++ b/apps/desktop/native/keychain-binding/keychain-binding.mm
@@ -234,8 +234,6 @@ CFMutableDictionaryRef Query(const std::string &service,
 
 enum class PartitionInspection { kPresent, kAbsent, kUninspectable };
 
-PartitionInspection InspectAccess(SecAccessRef access);
-
 SecAccessRef MakeAccess() {
   SecAccessRef access = nullptr;
   CFStringRef label = String("Enduragent credential encryption key");
@@ -253,6 +251,9 @@ SecAccessRef MakeAccess() {
   }
   const CFIndex count = CFArrayGetCount(aclList);
   CFIndex ownerCount = 0;
+  CFIndex partitionCount = 0;
+  bool ownerExact = true;
+  bool hasUnsafe = false;
   for (CFIndex index = 0; index < count; index += 1) {
     SecACLRef acl = static_cast<SecACLRef>(
         const_cast<void *>(CFArrayGetValueAtIndex(aclList, index)));
@@ -263,12 +264,15 @@ SecAccessRef MakeAccess() {
       return nullptr;
     }
     const KeychainAclRole role = ClassifyKeychainAcl(authorizations);
-    if (role == KeychainAclRole::kPartition ||
-        role == KeychainAclRole::kUnsafe) {
+    if (role == KeychainAclRole::kPartition) {
+      partitionCount += 1;
       CFRelease(authorizations);
-      CFRelease(aclList);
-      CFRelease(access);
-      return nullptr;
+      continue;
+    }
+    if (role == KeychainAclRole::kUnsafe) {
+      hasUnsafe = true;
+      CFRelease(authorizations);
+      continue;
     }
     CFArrayRef applications = nullptr;
     CFStringRef description = nullptr;
@@ -287,12 +291,13 @@ SecAccessRef MakeAccess() {
     bool acceptable = true;
     if (role == KeychainAclRole::kOwner) {
       ownerCount += 1;
-      acceptable = IsExpectedOwnerAcl(authorizations, applications);
+      ownerExact = ownerExact &&
+                   IsExpectedOwnerAcl(authorizations, applications);
     } else {
       acceptable = SecACLSetContents(
                        acl, nullptr,
                        description == nullptr ? CFSTR("") : description,
-                       prompt) == errSecSuccess;
+                       SecKeychainPromptSelector{}) == errSecSuccess;
     }
     if (applications != nullptr)
       CFRelease(applications);
@@ -306,36 +311,7 @@ SecAccessRef MakeAccess() {
     }
   }
   CFRelease(aclList);
-  if (ownerCount != 1) {
-    CFRelease(access);
-    return nullptr;
-  }
-  CFStringRef partition =
-      String("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-             "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" "
-             "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">"
-             "<plist version=\"1.0\"><dict><key>Partitions</key><array>"
-             "<string>teamid:FA494ACVTF</string></array></dict></plist>");
-  SecACLRef partitionAcl = nullptr;
-  const OSStatus createStatus = SecACLCreateWithSimpleContents(
-      access, nullptr, partition, SecKeychainPromptSelector{}, &partitionAcl);
-  CFRelease(partition);
-  if (createStatus != errSecSuccess || partitionAcl == nullptr) {
-    CFRelease(access);
-    return nullptr;
-  }
-  const void *authorization = kSecACLAuthorizationPartitionID;
-  CFArrayRef authorizations = CFArrayCreate(kCFAllocatorDefault, &authorization,
-                                            1, &kCFTypeArrayCallBacks);
-  const OSStatus updateStatus =
-      SecACLUpdateAuthorizations(partitionAcl, authorizations);
-  CFRelease(authorizations);
-  CFRelease(partitionAcl);
-  if (updateStatus != errSecSuccess) {
-    CFRelease(access);
-    return nullptr;
-  }
-  if (InspectAccess(access) != PartitionInspection::kPresent) {
+  if (ownerCount != 1 || !ownerExact || partitionCount != 0 || hasUnsafe) {
     CFRelease(access);
     return nullptr;
   }

--- a/apps/desktop/native/keychain-binding/partition-description.mm
+++ b/apps/desktop/native/keychain-binding/partition-description.mm
@@ -1,5 +1,7 @@
 #include "partition-description.h"
 
+#include <vector>
+
 namespace {
 
 CFStringRef ExpectedPartition() {
@@ -23,6 +25,42 @@ bool HasUnambiguousPartitionKey(CFStringRef description) {
          OccurrenceCount(description, CFSTR("<!ENTITY")) == 0;
 }
 
+int HexValue(UniChar value) {
+  if (value >= '0' && value <= '9')
+    return value - '0';
+  if (value >= 'a' && value <= 'f')
+    return value - 'a' + 10;
+  if (value >= 'A' && value <= 'F')
+    return value - 'A' + 10;
+  return -1;
+}
+
+CFStringRef CopyDecodedPartitionDescription(CFStringRef description) {
+  const CFIndex length = CFStringGetLength(description);
+  bool hexadecimal = length > 0 && length % 2 == 0;
+  std::vector<UInt8> bytes;
+  if (hexadecimal) {
+    bytes.reserve(static_cast<size_t>(length / 2));
+    for (CFIndex index = 0; index < length; index += 2) {
+      const int high = HexValue(CFStringGetCharacterAtIndex(description, index));
+      const int low =
+          HexValue(CFStringGetCharacterAtIndex(description, index + 1));
+      if (high < 0 || low < 0) {
+        hexadecimal = false;
+        break;
+      }
+      bytes.push_back(static_cast<UInt8>((high << 4) | low));
+    }
+  }
+  if (!hexadecimal) {
+    CFRetain(description);
+    return description;
+  }
+  return CFStringCreateWithBytes(kCFAllocatorDefault, bytes.data(),
+                                 static_cast<CFIndex>(bytes.size()),
+                                 kCFStringEncodingUTF8, false);
+}
+
 bool IsAuthorization(CFTypeRef value, CFStringRef expected) {
   return value != nullptr && CFGetTypeID(value) == CFStringGetTypeID() &&
          CFEqual(value, expected);
@@ -35,10 +73,16 @@ bool IsExpectedPartitionDescription(CFStringRef description) {
       CFGetTypeID(description) != CFStringGetTypeID()) {
     return false;
   }
-  if (!HasUnambiguousPartitionKey(description))
+  CFStringRef decoded = CopyDecodedPartitionDescription(description);
+  if (decoded == nullptr)
     return false;
+  if (!HasUnambiguousPartitionKey(decoded)) {
+    CFRelease(decoded);
+    return false;
+  }
   CFDataRef serialized = CFStringCreateExternalRepresentation(
-      kCFAllocatorDefault, description, kCFStringEncodingUTF8, 0);
+      kCFAllocatorDefault, decoded, kCFStringEncodingUTF8, 0);
+  CFRelease(decoded);
   if (serialized == nullptr)
     return false;
   CFErrorRef error = nullptr;
@@ -80,13 +124,20 @@ bool IsExpectedPartitionDescription(CFStringRef description) {
 bool AreExpectedPartitionDescriptions(CFArrayRef descriptions) {
   if (descriptions == nullptr ||
       CFGetTypeID(descriptions) != CFArrayGetTypeID() ||
-      CFArrayGetCount(descriptions) != 1) {
+      CFArrayGetCount(descriptions) == 0) {
     return false;
   }
-  CFTypeRef description = CFArrayGetValueAtIndex(descriptions, 0);
-  return description != nullptr &&
-         CFGetTypeID(description) == CFStringGetTypeID() &&
-         IsExpectedPartitionDescription(static_cast<CFStringRef>(description));
+  const CFIndex count = CFArrayGetCount(descriptions);
+  for (CFIndex index = 0; index < count; index += 1) {
+    CFTypeRef description = CFArrayGetValueAtIndex(descriptions, index);
+    if (description == nullptr ||
+        CFGetTypeID(description) != CFStringGetTypeID() ||
+        !IsExpectedPartitionDescription(
+            static_cast<CFStringRef>(description))) {
+      return false;
+    }
+  }
+  return true;
 }
 
 bool IsExpectedPartitionAcl(CFArrayRef authorizations, CFArrayRef applications,
@@ -179,5 +230,5 @@ void IncludeKeychainAcl(KeychainAccessAclInspection &inspection,
 bool IsExpectedKeychainAccess(
     const KeychainAccessAclInspection &inspection) {
   return inspection.exact && inspection.ownerCount == 1 &&
-         inspection.partitionCount == 1;
+         inspection.partitionCount >= 1;
 }

--- a/apps/desktop/tests/keychain-binding-native.integration.test.ts
+++ b/apps/desktop/tests/keychain-binding-native.integration.test.ts
@@ -34,12 +34,20 @@ const alternatePartitionDescription = `<?xml version="1.0" encoding="UTF-8"?>
     </array>
   </dict>
 </plist>`;
+const wrongTeamPartitionDescription = alternatePartitionDescription.replace(
+  "teamid:FA494ACVTF",
+  "teamid:OTHER",
+);
 let root = "";
 let parserHarness = "";
 let creationRollbackHarness = "";
 
 function plistDictionary(contents: string) {
   return `<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict>${contents}</dict></plist>`;
+}
+
+function hexDescription(description: string) {
+  return Buffer.from(description, "utf8").toString("hex");
 }
 
 function harnessStatus(...arguments_: string[]) {
@@ -232,15 +240,16 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       );
       expect(source).toContain("kSecMatchSearchList");
       expect(source).toContain("kSecUseKeychain");
-      expect(accessConstruction).toContain(
-        "acceptable = IsExpectedOwnerAcl(authorizations, applications)",
-      );
+      expect(accessConstruction).toContain("IsExpectedOwnerAcl(authorizations, applications)");
       expect(accessConstruction.indexOf("IsExpectedOwnerAcl")).toBeLessThan(
         accessConstruction.indexOf("SecACLSetContents"),
       );
-      expect(accessConstruction).toContain(
-        "InspectAccess(access) != PartitionInspection::kPresent",
+      expect(accessConstruction).toContain("SecKeychainPromptSelector{}");
+      expect(accessConstruction).toMatch(
+        /ownerCount != 1 \|\| !ownerExact \|\| partitionCount != 0 \|\| hasUnsafe/u,
       );
+      expect(accessConstruction).not.toContain("SecACLCreateWithSimpleContents");
+      expect(accessConstruction).not.toContain("InspectAccess(access)");
       expect(reading.indexOf("RetryCreationRollback(")).toBeLessThan(
         reading.indexOf("CopyDefaultKeychain"),
       );
@@ -325,6 +334,12 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       expect(partitionDescriptionStatus(alternatePartitionDescription)).toBe(0);
     });
 
+    it("accepts hex-encoded pretty-printed partition property lists", () => {
+      const hexadecimal = hexDescription(alternatePartitionDescription);
+      expect(partitionDescriptionStatus(hexadecimal)).toBe(0);
+      expect(partitionDescriptionStatus(hexadecimal.toUpperCase())).toBe(0);
+    });
+
     it("accepts only exact persisted partition ACL fields", () => {
       expect(partitionAclStatus("exact", "null", "zero")).toBe(0);
       expect(partitionAclStatus("extra", "null", "zero")).toBe(1);
@@ -334,9 +349,10 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       expect(partitionAclStatus("exact", "null", "nonzero")).toBe(1);
     });
 
-    it("accepts one protected owner with one exact partition ACL", () => {
+    it("accepts one protected owner with one or more exact partition ACLs", () => {
       expect(accessAclStatus("exact", "empty", "single", "single", "none")).toBe(0);
       expect(accessAclStatus("exact", "empty", "single", "single", "default")).toBe(0);
+      expect(accessAclStatus("exact", "empty", "single", "duplicate", "none")).toBe(0);
     });
 
     it("rejects an unsafe or ambiguous owner ACL", () => {
@@ -349,7 +365,6 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
 
     it("rejects ambiguous partitions and unrestricted mutation authority", () => {
       expect(accessAclStatus("exact", "empty", "single", "missing", "none")).toBe(1);
-      expect(accessAclStatus("exact", "empty", "single", "duplicate", "none")).toBe(1);
       expect(accessAclStatus("exact", "empty", "single", "single", "any")).toBe(1);
       expect(accessAclStatus("exact", "empty", "single", "single", "change-owner")).toBe(1);
     });
@@ -386,6 +401,21 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       }
     });
 
+    it("rejects hex-encoded wrong teams and malformed hex", () => {
+      expect(partitionDescriptionStatus(hexDescription(wrongTeamPartitionDescription))).toBe(1);
+      expect(partitionDescriptionStatus("abc")).toBe(1);
+      expect(partitionDescriptionStatus("gg")).toBe(1);
+    });
+
+    it("rejects entities after decoding a hex description", () => {
+      const withEntity =
+        '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<!DOCTYPE plist [<!ENTITY team "teamid:FA494ACVTF">]>' +
+        '<plist version="1.0"><dict><key>Partitions</key><array>' +
+        "<string>&team;</string></array></dict></plist>";
+      expect(partitionDescriptionStatus(hexDescription(withEntity))).toBe(1);
+    });
+
     it("rejects duplicate partition dictionary keys", () => {
       const expected = "<key>Partitions</key><array><string>teamid:FA494ACVTF</string></array>";
       const wrong = "<key>Partitions</key><array><string>teamid:OTHER</string></array>";
@@ -393,10 +423,13 @@ describe.skipIf(process.platform !== "darwin" || !keychainBindingCompilerAvailab
       expect(partitionDescriptionStatus(plistDictionary(expected + wrong))).toBe(1);
     });
 
-    it("rejects zero or multiple partition-authorized ACL descriptions", () => {
+    it("accepts multiple expected descriptions and rejects zero or mixed descriptions", () => {
       expect(partitionDescriptionStatus()).toBe(1);
       expect(
         partitionDescriptionStatus(canonicalPartitionDescription, alternatePartitionDescription),
+      ).toBe(0);
+      expect(
+        partitionDescriptionStatus(canonicalPartitionDescription, wrongTeamPartitionDescription),
       ).toBe(1);
     });
   },


### PR DESCRIPTION
## Summary

On a signed build (macOS 26.2) every credential save failed with `encryption-unavailable` and reads with `unreadable-item`. Root cause, measured with a signed diagnostic against a disposable keychain: macOS adds a `PartitionID` ACL for the creating process's team id on its own, with a **hex-encoded** pretty-printed plist description, plus an `Integrity` ACL. The binding also wrote its own raw-XML partition ACL, then demanded exactly one raw-XML description → `kAbsent` → creation rollback deleted the key.

- `MakeAccess` no longer writes a partition ACL. Pre-persist gate: exactly one exact owner ACL, zero partition ACLs, nothing unsafe.
- `partition-description.mm` decodes hex or raw descriptions, then applies the existing entity/key guards and strict plist check. Post-persist validation accepts ≥1 partition ACLs when every one is expected (prompt 0, applications null).
- Creation rollback on `kAbsent` / `kUninspectable` is unchanged. `SecKeychainSetUserInteractionAllowed(false)` and the trusted-host gate are unchanged.

## Verification

- `pnpm --filter @enduragent/desktop check` pass
- `vitest run tests/keychain-binding-native.integration.test.ts` → 15/15 (new harness cases: hex accept upper/lower, wrong-team hex, odd-length/non-hex, entity-after-decode, duplicate expected, mixed, missing)
- Three Fable 5 read-only skeptics (decode/validation, create/rollback, tests/hygiene) → PASS
- Signed local QA on a disposable keychain: see follow-up comment.

Limits: none.