### PR TITLE
feat(core): persist chat queue recovery

### DIFF
--- a/.changeset/durable-chat-queue.md
+++ b/.changeset/durable-chat-queue.md
@@ -1,0 +1,6 @@
+---
+"cycling-coach": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Saved queued Chat messages across app restarts, added explicit recovery actions, and now keeps a queued message visible with an error when removal cannot be saved.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -195,9 +195,11 @@ export function bootRenderer(): Disposer {
     }).render,
   });
   store.getState().bindChatActions({
-    submit: (message) => void chatController.submit(message),
+    submit: (message) => chatController.submit(message),
     stop: () => chatController.stop(),
     removeQueued: (id) => chatController.removeQueued(id),
+    runQueuedCommand: (id) => void chatController.runQueuedCommand(id),
+    retryQueuedTurn: (claimId) => void chatController.retryQueuedTurn(claimId),
     retry: () => void chatController.retryInterrupted(),
     loadEarlier: () => void chatController.loadEarlier(),
     retryHydration: () => void chatController.retryHydration(),

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -12,6 +12,7 @@ import {
 import type {
   CoachDecisionAnswer,
   CoachDecisionReadModel,
+  ChatQueueSnapshot,
   CoachTurnEventNotificationEnvelope,
   TranscriptPageEntry,
   TurnEvent,
@@ -47,6 +48,9 @@ export const CHAT_DECISION_FAILURE_COPY =
 export const CHAT_DECISION_SKIP_FAILURE_COPY = "We couldn’t skip this question. Please try again.";
 export const CHAT_DECISION_LOAD_FAILURE_COPY =
   "We couldn’t check for a saved Coach question. Reconnect and try again.";
+export const CHAT_QUEUE_LOAD_FAILURE_COPY =
+  "We couldn’t check your saved messages. Reconnect and try again.";
+export const CHAT_QUEUE_REMOVE_FAILURE_COPY = "We couldn’t remove that saved message. Try again.";
 export const NEW_CONVERSATION_SUCCESS_COPY = "New conversation started.";
 export const NEW_CONVERSATION_MEMORY_WARNING_COPY =
   "New conversation started. Some recent details may not have been saved to coach memory.";
@@ -65,6 +69,8 @@ export interface ChatViewControls {
   readonly workBlocked: boolean;
   readonly decisionLoading?: boolean;
   readonly decisionLoadError?: string | null;
+  readonly queueLoadError?: string | null;
+  readonly queueMutationError?: string | null;
   readonly appendDelta?: ChatAppendDelta;
   readonly hydration?: {
     readonly status: TranscriptHydrationStatus;
@@ -88,9 +94,11 @@ export interface ChatView {
 export interface ChatController {
   start(): Promise<void>;
   resume(): Promise<void>;
-  submit(message: string): Promise<void>;
+  submit(message: string): Promise<boolean>;
   stop(): void;
   removeQueued(id: string): void;
+  runQueuedCommand(id: string): Promise<void>;
+  retryQueuedTurn(claimId: string): Promise<void>;
   retryInterrupted(): Promise<void>;
   loadEarlier(): Promise<void>;
   retryHydration(): Promise<void>;
@@ -129,8 +137,15 @@ export function createChatController(input: {
     readonly limit: number;
   }) => Promise<TranscriptPage>;
   readonly canChat?: () => boolean;
+  readonly initialQueueSnapshot?: ChatQueueSnapshot;
 }): ChatController {
-  let state = EMPTY_CHAT_STATE;
+  let state =
+    input.initialQueueSnapshot === undefined
+      ? EMPTY_CHAT_STATE
+      : reduceChatState(EMPTY_CHAT_STATE, {
+          type: "queue-snapshot",
+          snapshot: input.initialQueueSnapshot,
+        });
   let hydration = emptyTranscriptHydration();
   let sequence = 0;
   let disposed = false;
@@ -150,11 +165,14 @@ export function createChatController(input: {
   let decisionLoaded = true;
   let decisionLoadError: string | null = null;
   let decisionLoadTask: Promise<void> | undefined;
+  let queueLoaded = input.initialQueueSnapshot !== undefined;
+  let queueLoadError: string | null = null;
+  let queueMutationError: string | null = null;
   let decisionContinuationTask: Promise<void> | undefined;
   let epoch = 0;
   const canChat = input.canChat ?? (() => true);
 
-  const nextId = (prefix: "request" | "message" | "queued"): string => `${prefix}-${++sequence}`;
+  const nextId = (prefix: "request" | "message"): string => `${prefix}-${++sequence}`;
   const resetBlocksWork = (): boolean =>
     state.session.resetPhase === "confirming" || state.session.resetPhase === "resetting";
   const decisionBlocksWork = (): boolean =>
@@ -163,6 +181,7 @@ export function createChatController(input: {
     (decision?.status === "answered" && decision.continuation.status === "pending");
   const canOpenNewConversation = (): boolean =>
     canChat() &&
+    queueLoaded &&
     !disposed &&
     (hasClearableConversation(state) ||
       hydration.turns.length > 0 ||
@@ -187,9 +206,11 @@ export function createChatController(input: {
             },
         {
           newConversationDisabled: !canOpenNewConversation(),
-          workBlocked: resetBlocksWork(),
+          workBlocked: resetBlocksWork() || !queueLoaded,
           decisionLoading: !decisionLoaded,
           decisionLoadError,
+          queueLoadError,
+          queueMutationError,
           ...(appendDelta === undefined ? {} : { appendDelta }),
           hydration: {
             status: hydration.status,
@@ -214,6 +235,9 @@ export function createChatController(input: {
   ): void => {
     state = reduceChatState(state, action);
     render(appendDelta);
+  };
+  const applyQueueSnapshot = (snapshot: ChatQueueSnapshot): void => {
+    reduce({ type: "queue-snapshot", snapshot });
   };
   const hydrator = createTranscriptHydrator({
     readPage:
@@ -243,7 +267,23 @@ export function createChatController(input: {
     render();
   };
 
-  const run = (userMessage: string, includeUser: boolean, reconnect: boolean): ChatRun => {
+  const run = (
+    userMessage: string,
+    includeUser: boolean,
+    reconnect: boolean,
+    queueCall?:
+      | {
+          readonly method: "runQueuedCommand";
+          readonly queuedMessageId: string;
+          readonly queuedMessageIds: readonly string[];
+        }
+      | {
+          readonly method: "retryQueuedTurn";
+          readonly claimId: string;
+          readonly queuedMessageIds: readonly string[];
+        }
+      | { readonly method: "resumeChatQueue"; readonly queuedMessageIds: readonly string[] },
+  ): ChatRun => {
     epoch += 1;
     const requestKey = Number(nextId("request").slice("request-".length));
     const userMessageId = nextId("message");
@@ -284,7 +324,7 @@ export function createChatController(input: {
         stopRequested = true;
         if (client === undefined || boundTurnId === undefined || stopTask !== undefined) return;
         stopTask = client
-          .call("stopChat", { chatId: DESKTOP_CHAT_ID })
+          .call("stopChat", { chatId: DESKTOP_CHAT_ID, turnId: boundTurnId })
           .then(() => undefined)
           .catch(() => undefined);
       };
@@ -305,120 +345,152 @@ export function createChatController(input: {
         }
         if (!current()) return;
         callStarted = true;
-        const result = await client.call(
-          "chat",
-          { chatId: DESKTOP_CHAT_ID, message: userMessage },
-          {
-            signal: callAbortController.signal,
-            onNotificationEnvelope(envelope) {
-              if (!current() || protocolFault) return;
-              if (
-                envelope.method !== "coach.turnEvent" ||
-                envelope.params.requestMethod !== "chat" ||
-                envelope.params.turnId.length === 0
-              ) {
-                failProtocol();
-                return;
-              }
-              if (boundRequestId === undefined) {
-                boundRequestId = envelope.params.requestId;
-                boundTurnId = envelope.params.turnId;
-                reduce({ type: "bind-turn", requestKey, turnId: boundTurnId });
-                if (stopRequested) requestStop();
-              } else if (
-                envelope.params.requestId !== boundRequestId ||
-                envelope.params.turnId !== boundTurnId
-              ) {
-                failProtocol();
-                return;
-              }
-              pendingEnvelope = envelope;
-            },
-            onEvent(event: TurnEvent) {
-              if (!current() || protocolFault) return;
-              const envelope = pendingEnvelope;
-              pendingEnvelope = undefined;
-              if (
-                envelope === undefined ||
-                boundTurnId === undefined ||
-                event.turnId !== boundTurnId ||
-                envelope.params.event.turnId !== boundTurnId
-              ) {
-                failProtocol();
-                return;
-              }
-              if (eventCount >= COACH_TURN_EVENT_LIMIT) {
-                failProtocol();
-                return;
-              }
-              eventCount += 1;
-              if (requestedDecision !== undefined) {
-                failProtocol();
-                return;
-              }
-              if (event.type === "turn-start") {
-                if (eventCount !== 1 || startSeen || event.chatId !== DESKTOP_CHAT_ID) {
-                  failProtocol();
-                  return;
-                }
-                startSeen = true;
-              }
-              let appendDelta: ChatAppendDelta | undefined;
-              if (event.type === "text_delta") {
-                const activeTurn = state.activeTurn;
-                if (activeTurn === null || activeTurn.requestKey !== requestKey) return;
-                const previousTextLength = activeTurn.draft.length;
-                if (event.delta.length > COACH_RESPONSE_CODE_UNIT_LIMIT - previousTextLength) {
-                  failProtocol();
-                  return;
-                }
-                appendDelta = {
-                  messageId: activeTurn.assistantMessageId,
-                  previousTextLength,
-                  nextTextLength: previousTextLength + event.delta.length,
-                  delta: event.delta,
-                };
-              } else if (
-                (event.type === "final-text" || event.type === "interrupted") &&
-                event.text.length > COACH_RESPONSE_CODE_UNIT_LIMIT
-              ) {
-                failProtocol();
-                return;
-              }
-              if (event.type === "final-text") finalText = event.text;
-              if (event.type === "interrupted") interruptedText = event.text;
-              if (event.type === "decision-requested") {
-                if (
-                  !startSeen ||
-                  event.chatId !== DESKTOP_CHAT_ID ||
-                  event.decision.status !== "unanswered"
-                ) {
-                  failProtocol();
-                  return;
-                }
-                requestedDecision = event.decision;
-                reduce({
-                  type: "bind-decision",
-                  requestKey,
-                  decisionId: event.decision.decisionId,
-                });
-                decision = event.decision;
-                decisionPhase = "idle";
-                decisionAnswerLabel = null;
-                decisionError = null;
-                render();
-                return;
-              }
-              reduce({ type: "event", requestKey, event }, appendDelta);
-            },
-            onTerminalEnvelope(envelope) {
-              if (!current()) return;
-              terminal = envelope;
-              terminalHadFinal = finalText !== undefined;
-            },
+        const callOptions = {
+          signal: callAbortController.signal,
+          onNotificationEnvelope(envelope) {
+            if (!current() || protocolFault) return;
+            if (
+              envelope.method !== "coach.turnEvent" ||
+              envelope.params.requestMethod !== (queueCall?.method ?? "chat") ||
+              envelope.params.turnId.length === 0
+            ) {
+              failProtocol();
+              return;
+            }
+            if (boundRequestId === undefined) {
+              boundRequestId = envelope.params.requestId;
+              boundTurnId = envelope.params.turnId;
+              reduce({ type: "bind-turn", requestKey, turnId: boundTurnId });
+              if (stopRequested) requestStop();
+            } else if (
+              envelope.params.requestId !== boundRequestId ||
+              envelope.params.turnId !== boundTurnId
+            ) {
+              failProtocol();
+              return;
+            }
+            pendingEnvelope = envelope;
           },
-        );
+          onEvent(event: TurnEvent) {
+            if (!current() || protocolFault) return;
+            const envelope = pendingEnvelope;
+            pendingEnvelope = undefined;
+            if (
+              envelope === undefined ||
+              boundTurnId === undefined ||
+              event.turnId !== boundTurnId ||
+              envelope.params.event.turnId !== boundTurnId
+            ) {
+              failProtocol();
+              return;
+            }
+            if (eventCount >= COACH_TURN_EVENT_LIMIT) {
+              failProtocol();
+              return;
+            }
+            eventCount += 1;
+            if (requestedDecision !== undefined) {
+              failProtocol();
+              return;
+            }
+            if (event.type === "turn-start") {
+              if (eventCount !== 1 || startSeen || event.chatId !== DESKTOP_CHAT_ID) {
+                failProtocol();
+                return;
+              }
+              startSeen = true;
+              if (queueCall !== undefined) {
+                reduce({ type: "queue-claimed", ids: queueCall.queuedMessageIds });
+              }
+            }
+            let appendDelta: ChatAppendDelta | undefined;
+            if (event.type === "text_delta") {
+              const activeTurn = state.activeTurn;
+              if (activeTurn === null || activeTurn.requestKey !== requestKey) return;
+              const previousTextLength = activeTurn.draft.length;
+              if (event.delta.length > COACH_RESPONSE_CODE_UNIT_LIMIT - previousTextLength) {
+                failProtocol();
+                return;
+              }
+              appendDelta = {
+                messageId: activeTurn.assistantMessageId,
+                previousTextLength,
+                nextTextLength: previousTextLength + event.delta.length,
+                delta: event.delta,
+              };
+            } else if (
+              (event.type === "final-text" || event.type === "interrupted") &&
+              event.text.length > COACH_RESPONSE_CODE_UNIT_LIMIT
+            ) {
+              failProtocol();
+              return;
+            }
+            if (event.type === "final-text") finalText = event.text;
+            if (event.type === "interrupted") interruptedText = event.text;
+            if (event.type === "decision-requested") {
+              if (
+                !startSeen ||
+                event.chatId !== DESKTOP_CHAT_ID ||
+                event.decision.status !== "unanswered"
+              ) {
+                failProtocol();
+                return;
+              }
+              requestedDecision = event.decision;
+              reduce({
+                type: "bind-decision",
+                requestKey,
+                decisionId: event.decision.decisionId,
+              });
+              decision = event.decision;
+              decisionPhase = "idle";
+              decisionAnswerLabel = null;
+              decisionError = null;
+              render();
+              return;
+            }
+            reduce({ type: "event", requestKey, event }, appendDelta);
+          },
+          onTerminalEnvelope(envelope) {
+            if (!current()) return;
+            terminal = envelope;
+            terminalHadFinal = finalText !== undefined;
+          },
+        } satisfies CoachClientCallOptions<"chat">;
+        const queuedResult =
+          queueCall?.method === "resumeChatQueue"
+            ? await client.call("resumeChatQueue", { chatId: DESKTOP_CHAT_ID }, callOptions)
+            : queueCall?.method === "runQueuedCommand"
+              ? await client.call(
+                  "runQueuedCommand",
+                  { chatId: DESKTOP_CHAT_ID, queuedMessageId: queueCall.queuedMessageId },
+                  callOptions,
+                )
+              : queueCall?.method === "retryQueuedTurn"
+                ? await client.call(
+                    "retryQueuedTurn",
+                    { chatId: DESKTOP_CHAT_ID, claimId: queueCall.claimId },
+                    callOptions,
+                  )
+                : undefined;
+        const result =
+          queuedResult === undefined
+            ? await client.call(
+                "chat",
+                { chatId: DESKTOP_CHAT_ID, message: userMessage },
+                callOptions,
+              )
+            : (queuedResult.response ?? { text: "" });
         if (!current()) return;
+        if (queuedResult !== undefined) applyQueueSnapshot(queuedResult.snapshot);
+        if (
+          queuedResult !== undefined &&
+          queuedResult.response === undefined &&
+          boundTurnId === undefined
+        ) {
+          reduce({ type: "discard-submission", requestKey });
+          return;
+        }
         if (interruptedText !== undefined) {
           if (
             protocolFault ||
@@ -477,6 +549,11 @@ export function createChatController(input: {
         completed = state.status === "idle" && state.activeTurn?.requestKey === requestKey;
       } catch (error) {
         if (!current()) return;
+        if (queueCall !== undefined && client !== undefined) {
+          try {
+            applyQueueSnapshot(await client.call("getChatQueue", { chatId: DESKTOP_CHAT_ID }));
+          } catch {}
+        }
         if (protocolFault || error instanceof CoachClientProtocolError) {
           retryClient = client;
           retryReconnect = true;
@@ -526,6 +603,26 @@ export function createChatController(input: {
     return chatRun.task.then(() => (chatRun.completed() ? drain() : undefined));
   };
 
+  const dispatchQueue = (
+    userMessage: string,
+    queueCall:
+      | {
+          readonly method: "runQueuedCommand";
+          readonly queuedMessageId: string;
+          readonly queuedMessageIds: readonly string[];
+        }
+      | {
+          readonly method: "retryQueuedTurn";
+          readonly claimId: string;
+          readonly queuedMessageIds: readonly string[];
+        }
+      | { readonly method: "resumeChatQueue"; readonly queuedMessageIds: readonly string[] },
+    includeUser = true,
+  ): Promise<void> => {
+    const chatRun = run(userMessage, includeUser, false, queueCall);
+    return chatRun.task.then(() => (chatRun.completed() ? drain() : undefined));
+  };
+
   const answerLabel = (
     currentDecision: CoachDecisionReadModel,
     answer: CoachDecisionAnswer,
@@ -552,6 +649,16 @@ export function createChatController(input: {
     decisionLoadError = null;
     render();
     return decision;
+  };
+
+  const refreshQueue = async (client?: CoachClient): Promise<void> => {
+    const activeClient = client ?? (await input.clients.getClient());
+    const snapshot = await activeClient.call("getChatQueue", { chatId: DESKTOP_CHAT_ID });
+    if (disposed) return;
+    applyQueueSnapshot(snapshot);
+    queueLoaded = true;
+    queueLoadError = null;
+    render();
   };
 
   const continueDecision = (
@@ -645,7 +752,7 @@ export function createChatController(input: {
         stopRequested = true;
         if (client === undefined || boundTurnId === undefined || stopTask !== undefined) return;
         stopTask = client
-          .call("stopChat", { chatId: DESKTOP_CHAT_ID })
+          .call("stopChat", { chatId: DESKTOP_CHAT_ID, turnId: boundTurnId })
           .then(() => undefined)
           .catch(() => undefined);
       };
@@ -836,6 +943,7 @@ export function createChatController(input: {
   const drain = (): Promise<void> => {
     if (
       !canChat() ||
+      !queueLoaded ||
       disposed ||
       resetBlocksWork() ||
       decisionBlocksWork() ||
@@ -845,14 +953,21 @@ export function createChatController(input: {
     }
     const group = nextDrainGroup(state);
     if (group === null) return Promise.resolve();
-    reduce({ type: "dequeue-group" });
-    return dispatch(group.text, true, false);
+    if (
+      state.retryRequired != null ||
+      (state.queued[0]?.command === true && state.queued[0]?.restored === true)
+    )
+      return Promise.resolve();
+    return dispatchQueue(group.text, {
+      method: "resumeChatQueue",
+      queuedMessageIds: state.queued.slice(0, group.size).map((item) => item.id),
+    });
   };
 
   const start = (): Promise<void> => {
     if (!canChat() || disposed) return Promise.resolve();
-    void hydrator.start();
     if (probeTask !== undefined) return probeTask;
+    const transcriptLoadTask = hydrator.start();
     decisionLoaded = false;
     decisionLoadError = null;
     render();
@@ -890,7 +1005,20 @@ export function createChatController(input: {
         reduce({ type: "session-probe", hasSession: result.hasSession });
       } catch {}
     })();
-    const task = Promise.all([sessionProbeTask, loadTask]).then(() => {});
+    const queueLoadTask = (async () => {
+      try {
+        await refreshQueue();
+      } catch {
+        queueLoaded = false;
+        queueLoadError = CHAT_QUEUE_LOAD_FAILURE_COPY;
+        render();
+      }
+    })();
+    const task = Promise.all([transcriptLoadTask, sessionProbeTask, loadTask, queueLoadTask]).then(
+      async () => {
+        if (!decisionBlocksWork()) await drain();
+      },
+    );
     probeTask = task;
     return task;
   };
@@ -906,22 +1034,26 @@ export function createChatController(input: {
     submit(message) {
       if (
         !canChat() ||
+        !queueLoaded ||
         !/\S/u.test(message) ||
         disposed ||
         resetBlocksWork() ||
         decisionBlocksWork()
       ) {
-        return activeTask ?? Promise.resolve();
+        return Promise.resolve(false);
       }
-      if (state.status === "streaming") {
-        reduce({ type: "enqueue", id: nextId("queued"), text: message });
-        return Promise.resolve();
-      }
-      if (state.queued.length > 0) {
-        reduce({ type: "enqueue", id: nextId("queued"), text: message });
-        return drain();
-      }
-      return dispatch(message, true, false);
+      const submissionId = globalThis.crypto.randomUUID();
+      return input.clients.getClient().then(async (client) => {
+        const acknowledged = await client.call("enqueueChatMessage", {
+          chatId: DESKTOP_CHAT_ID,
+          submissionId,
+          text: message,
+        });
+        if (disposed) return false;
+        applyQueueSnapshot(acknowledged);
+        void drain();
+        return true;
+      });
     },
     stop() {
       if (disposed || state.status !== "streaming" || state.activeTurn === null) return;
@@ -929,13 +1061,81 @@ export function createChatController(input: {
     },
     removeQueued(id) {
       if (disposed || resetBlocksWork()) return;
-      reduce({ type: "remove-queued", id });
+      queueMutationError = null;
+      render();
+      void input.clients.getClient().then(
+        async (client) => {
+          try {
+            const acknowledged = await client.call("removeQueuedChatMessage", {
+              chatId: DESKTOP_CHAT_ID,
+              queuedMessageId: id,
+            });
+            if (!disposed) {
+              queueMutationError = null;
+              applyQueueSnapshot(acknowledged);
+            }
+          } catch {
+            if (!disposed) {
+              queueMutationError = CHAT_QUEUE_REMOVE_FAILURE_COPY;
+              render();
+            }
+          }
+        },
+        () => {
+          if (!disposed) {
+            queueMutationError = CHAT_QUEUE_REMOVE_FAILURE_COPY;
+            render();
+          }
+        },
+      );
+    },
+    runQueuedCommand(id) {
+      if (
+        disposed ||
+        !queueLoaded ||
+        resetBlocksWork() ||
+        decisionBlocksWork() ||
+        state.status !== "idle"
+      ) {
+        return activeTask ?? Promise.resolve();
+      }
+      const head = state.queued[0];
+      if (head?.id !== id || !head.command) return Promise.resolve();
+      return dispatchQueue(head.text, {
+        method: "runQueuedCommand",
+        queuedMessageId: id,
+        queuedMessageIds: [id],
+      });
+    },
+    retryQueuedTurn(claimId) {
+      if (
+        disposed ||
+        !queueLoaded ||
+        resetBlocksWork() ||
+        decisionBlocksWork() ||
+        (state.status !== "idle" && state.status !== "interrupted")
+      ) {
+        return activeTask ?? Promise.resolve();
+      }
+      if (state.retryRequired?.claimId !== claimId) return Promise.resolve();
+      const ids = new Set(state.retryRequired.queuedMessageIds);
+      const text = state.queued
+        .filter((item) => ids.has(item.id))
+        .map((item) => item.text)
+        .join("\n\n");
+      return dispatchQueue(
+        text,
+        { method: "retryQueuedTurn", claimId, queuedMessageIds: [...ids] },
+        false,
+      );
     },
     retryInterrupted() {
       if (
         !canChat() ||
+        !queueLoaded ||
         disposed ||
         state.status !== "interrupted" ||
+        state.retryRequired != null ||
         state.activeTurn === null ||
         resetBlocksWork()
       ) {
@@ -978,11 +1178,12 @@ export function createChatController(input: {
       if (disposed || decisionLoadTask !== undefined) return decisionLoadTask;
       decisionLoaded = false;
       decisionLoadError = null;
+      queueLoadError = null;
       render();
       const task = (async () => {
         try {
           const client = await input.clients.reconnect();
-          const loaded = await refreshDecision(client);
+          const [loaded] = await Promise.all([refreshDecision(client), refreshQueue(client)]);
           if (
             loaded?.status === "answered" &&
             loaded.continuation.status === "pending" &&
@@ -992,7 +1193,8 @@ export function createChatController(input: {
           }
         } catch {
           decisionLoaded = false;
-          decisionLoadError = CHAT_DECISION_LOAD_FAILURE_COPY;
+          if (!queueLoaded) queueLoadError = CHAT_QUEUE_LOAD_FAILURE_COPY;
+          else decisionLoadError = CHAT_DECISION_LOAD_FAILURE_COPY;
           decisionPhase = "idle";
           render();
         }

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -199,6 +199,7 @@ export function createChatViewAdapter(input: {
       id: message.id,
       text: message.text,
       command: message.command,
+      restored: message.restored === true,
     }));
     const liveDecisionIds = new Set(
       messages.flatMap((message) => (message.decisionId === undefined ? [] : [message.decisionId])),
@@ -240,16 +241,18 @@ export function createChatViewAdapter(input: {
       decision?.value?.status === "unanswered" ||
       (decision?.value?.status === "answered" && decision.value.continuation.status === "pending");
     const decisionLoading = controls?.decisionLoading === true;
-    const decisionLoadError = controls?.decisionLoadError ?? null;
+    const decisionLoadError = controls?.queueLoadError ?? controls?.decisionLoadError ?? null;
     const decisionUnavailable = decisionLoading || decisionLoadError !== null;
     return {
       messages: sameChatMessages(published.messages, messages) ? published.messages : messages,
       queued: sameChatQueued(published.queued, queued) ? published.queued : queued,
+      retryRequired: state.retryRequired ?? null,
       decision: decision?.value ?? null,
       decisionPhase: decision?.phase ?? "idle",
       decisionAnswerLabel: decision?.answerLabel ?? null,
       decisionError: decision?.error ?? null,
       decisionLoadError,
+      queueMutationError: controls?.queueMutationError ?? null,
       timeline: sameChatTimeline(published.timeline, timeline) ? published.timeline : timeline,
       status: state.status,
       notice:

--- a/apps/desktop-renderer/src/state/chat-slice.ts
+++ b/apps/desktop-renderer/src/state/chat-slice.ts
@@ -1,4 +1,8 @@
-import type { CoachDecisionAnswer, CoachDecisionReadModel } from "@enduragent/coach-contract";
+import type {
+  ChatQueueRecoveryClaim,
+  CoachDecisionAnswer,
+  CoachDecisionReadModel,
+} from "@enduragent/coach-contract";
 import type { StateCreator } from "zustand";
 import type { TranscriptHydrationChange, TranscriptHydrationStatus } from "../chat/hydration.js";
 import type { FirstSyncState } from "../first-sync.js";
@@ -19,6 +23,7 @@ export interface ChatQueuedView {
   readonly id: string;
   readonly text: string;
   readonly command: boolean;
+  readonly restored: boolean;
 }
 
 export interface ChatChoiceView {
@@ -38,11 +43,13 @@ export type ChatDecisionPhase = "idle" | "continuing" | "recovering";
 export interface ChatSurfaceState {
   readonly messages: readonly ChatMessageView[];
   readonly queued: readonly ChatQueuedView[];
+  readonly retryRequired: ChatQueueRecoveryClaim | null;
   readonly decision: CoachDecisionReadModel | null;
   readonly decisionPhase: ChatDecisionPhase;
   readonly decisionAnswerLabel: string | null;
   readonly decisionError: string | null;
   readonly decisionLoadError: string | null;
+  readonly queueMutationError?: string | null;
   readonly timeline: readonly ChatTranscriptItemView[];
   readonly status: ChatStatus;
   readonly notice: string | null;
@@ -63,9 +70,11 @@ export interface ChatSurfaceState {
 }
 
 export interface ChatActions {
-  submit(message: string): void;
+  submit(message: string): Promise<boolean>;
   stop(): void;
   removeQueued(id: string): void;
+  runQueuedCommand(id: string): void;
+  retryQueuedTurn(claimId: string): void;
   retry(): void;
   loadEarlier(): void;
   retryHydration(): void;
@@ -81,11 +90,13 @@ export interface ChatActions {
 export const EMPTY_CHAT_SURFACE: ChatSurfaceState = Object.freeze({
   messages: Object.freeze([]),
   queued: Object.freeze([]),
+  retryRequired: null,
   decision: null,
   decisionPhase: "idle",
   decisionAnswerLabel: null,
   decisionError: null,
   decisionLoadError: null,
+  queueMutationError: null,
   timeline: Object.freeze([]),
   status: "idle",
   notice: null,
@@ -149,7 +160,8 @@ export function sameChatQueued(
       other !== undefined &&
       message.id === other.id &&
       message.text === other.text &&
-      message.command === other.command
+      message.command === other.command &&
+      message.restored === other.restored
     );
   });
 }
@@ -185,11 +197,13 @@ export function sameChatSurface(left: ChatSurfaceState, right: ChatSurfaceState)
     left.notice === right.notice &&
     left.coachProgress === right.coachProgress &&
     left.interrupted === right.interrupted &&
+    left.retryRequired === right.retryRequired &&
     left.decision === right.decision &&
     left.decisionPhase === right.decisionPhase &&
     left.decisionAnswerLabel === right.decisionAnswerLabel &&
     left.decisionError === right.decisionError &&
     left.decisionLoadError === right.decisionLoadError &&
+    left.queueMutationError === right.queueMutationError &&
     left.workBlocked === right.workBlocked &&
     left.sendDisabled === right.sendDisabled &&
     left.inputDisabled === right.inputDisabled &&

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -1,4 +1,8 @@
-import type { TurnEvent } from "@enduragent/coach-contract";
+import type {
+  ChatQueueRecoveryClaim,
+  ChatQueueSnapshot,
+  TurnEvent,
+} from "@enduragent/coach-contract";
 import { isSlashCommandText } from "./chat/commands.js";
 
 export const DESKTOP_CHAT_ID = "desktop" as const;
@@ -47,6 +51,7 @@ export interface QueuedMessage {
   readonly id: string;
   readonly text: string;
   readonly command: boolean;
+  readonly restored?: boolean;
 }
 
 export interface ChatDrainGroup {
@@ -60,6 +65,9 @@ export interface ChatState {
   readonly activeTurn: ActiveTurn | null;
   readonly progress: string | null;
   readonly queued: readonly QueuedMessage[];
+  readonly queueRevision?: number;
+  readonly activeQueueClaimIds?: readonly string[];
+  readonly retryRequired?: ChatQueueRecoveryClaim | null;
   readonly session: ChatSessionState;
 }
 
@@ -91,9 +99,12 @@ export type ChatAction =
   | { readonly type: "event"; readonly requestKey: number; readonly event: TurnEvent }
   | { readonly type: "complete"; readonly requestKey: number }
   | { readonly type: "discard"; readonly requestKey: number }
+  | { readonly type: "discard-submission"; readonly requestKey: number }
   | { readonly type: "interrupt"; readonly requestKey: number; readonly copy: string }
   | { readonly type: "retry-pending"; readonly requestKey: number }
   | { readonly type: "fail"; readonly requestKey: number; readonly copy: string }
+  | { readonly type: "queue-snapshot"; readonly snapshot: ChatQueueSnapshot }
+  | { readonly type: "queue-claimed"; readonly ids: readonly string[] }
   | { readonly type: "enqueue"; readonly id: string; readonly text: string }
   | { readonly type: "remove-queued"; readonly id: string }
   | { readonly type: "dequeue-group" }
@@ -181,6 +192,8 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
         messages,
         progress: CHAT_WORKING_COPY,
         queued: state.queued,
+        ...(state.queueRevision === undefined ? {} : { queueRevision: state.queueRevision }),
+        ...(state.retryRequired === undefined ? {} : { retryRequired: state.retryRequired }),
         session: { ...state.session, announcement: null },
         activeTurn: {
           requestKey: action.requestKey,
@@ -306,6 +319,20 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
         messages: state.messages.filter((message) => message.id !== active.assistantMessageId),
       };
     }
+    case "discard-submission": {
+      const active = current(state, action.requestKey);
+      if (active === null) return state;
+      return {
+        ...state,
+        status: "idle",
+        progress: null,
+        activeTurn: null,
+        messages: state.messages.filter(
+          (message) =>
+            message.id !== active.assistantMessageId && message.id !== active.userMessageId,
+        ),
+      };
+    }
     case "interrupt": {
       const active = current(state, action.requestKey);
       if (active === null) return state;
@@ -336,10 +363,41 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
         messages: updateAssistant(state, active, visibleDraft(active.draft), "interrupted"),
       };
     }
+    case "queue-snapshot": {
+      if (action.snapshot.revision <= (state.queueRevision ?? 0)) return state;
+      const activeQueueClaimIds =
+        action.snapshot.retryRequired === undefined
+          ? (state.activeQueueClaimIds ?? []).filter((id) =>
+              action.snapshot.items.some((item) => item.queuedMessageId === id),
+            )
+          : [];
+      const activeClaims = new Set(activeQueueClaimIds);
+      return {
+        ...state,
+        queueRevision: action.snapshot.revision,
+        activeQueueClaimIds,
+        queued: action.snapshot.items
+          .filter((item) => !activeClaims.has(item.queuedMessageId))
+          .map((item) => ({
+            id: item.queuedMessageId,
+            text: item.text,
+            command: item.kind === "slash-command",
+            restored: item.restored,
+          })),
+        retryRequired: action.snapshot.retryRequired ?? null,
+      };
+    }
+    case "queue-claimed": {
+      const claimed = new Set(action.ids);
+      return {
+        ...state,
+        activeQueueClaimIds: action.ids,
+        queued: state.queued.filter((message) => !claimed.has(message.id)),
+      };
+    }
     case "enqueue": {
-      if (!/\S/u.test(action.text) || state.queued.some((message) => message.id === action.id)) {
+      if (!/\S/u.test(action.text) || state.queued.some((message) => message.id === action.id))
         return state;
-      }
       return {
         ...state,
         queued: [
@@ -402,6 +460,9 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
             activeTurn: null,
             progress: null,
             queued: [],
+            ...(state.queueRevision === undefined ? {} : { queueRevision: state.queueRevision }),
+            ...(state.activeQueueClaimIds === undefined ? {} : { activeQueueClaimIds: [] }),
+            ...(state.retryRequired === undefined ? {} : { retryRequired: null }),
             session: {
               presence: "absent",
               resetPhase: "idle",

--- a/apps/desktop-renderer/src/ui/chat/Composer.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Composer.tsx
@@ -29,6 +29,7 @@ export function Composer(props: {
   const [draft, setDraft] = useState("");
   const [selected, setSelected] = useState(0);
   const [dismissed, setDismissed] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const listboxId = useId();
   const sendDisabled = useEnduragentStore((state) => state.chat.sendDisabled);
   const inputDisabled = useEnduragentStore((state) => state.chat.inputDisabled);
@@ -60,16 +61,26 @@ export function Composer(props: {
     [],
   );
 
-  const submit = (): void => {
+  const submit = async (): Promise<void> => {
     const input = textarea.current;
-    if (input === null || sendDisabled || !canChat) return;
+    if (input === null || sendDisabled || submitting || !canChat || actions === null) return;
     const value = input.value;
     if (!/\S/u.test(value)) return;
-    input.value = "";
-    setDraft("");
-    setSelected(0);
-    setDismissed(false);
-    actions?.submit(value);
+    setSubmitting(true);
+    try {
+      const acknowledged = await actions.submit(value);
+      if (!acknowledged) return;
+      if (input.value === value) {
+        input.value = "";
+        setDraft("");
+        setSelected(0);
+        setDismissed(false);
+      }
+    } catch {
+      input.focus();
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const accept = (index: number): void => {
@@ -107,7 +118,7 @@ export function Composer(props: {
     }
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
-      submit();
+      void submit();
     }
   };
 
@@ -118,7 +129,7 @@ export function Composer(props: {
       hidden={props.hidden}
       onSubmit={(event) => {
         event.preventDefault();
-        submit();
+        void submit();
       }}
     >
       <SlashPopup
@@ -179,7 +190,7 @@ export function Composer(props: {
               variant="default"
               size="icon-lg"
               aria-label="Send message"
-              disabled={sendDisabled || !canChat}
+              disabled={sendDisabled || submitting || !canChat}
             >
               <ArrowUp aria-hidden="true" />
             </Button>

--- a/apps/desktop-renderer/src/ui/chat/Notice.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Notice.tsx
@@ -33,6 +33,7 @@ export function CoachProgress(): ReactElement | null {
 
 export function RetryBar(): ReactElement {
   const interrupted = useEnduragentStore((state) => state.chat.interrupted);
+  const retryRequired = useEnduragentStore((state) => state.chat.retryRequired);
   const workBlocked = useEnduragentStore((state) => state.chat.workBlocked);
   const actions = useEnduragentStore((state) => state.chatActions);
 
@@ -42,10 +43,10 @@ export function RetryBar(): ReactElement {
       className="chat-retry justify-self-start"
       variant="outline"
       size="sm"
-      hidden={!interrupted}
+      hidden={!interrupted || retryRequired !== null}
       disabled={workBlocked}
       onClick={() => {
-        if (!interrupted || workBlocked) return;
+        if (!interrupted || retryRequired !== null || workBlocked) return;
         actions?.retry();
       }}
     >

--- a/apps/desktop-renderer/src/ui/chat/QueuedMessages.tsx
+++ b/apps/desktop-renderer/src/ui/chat/QueuedMessages.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react";
-import { XIcon } from "lucide-react";
 import { Button } from "../../components/ui/button.js";
 import { cn } from "../../lib/utils.js";
 import { useEnduragentStore } from "../../state/store.js";
@@ -8,42 +7,89 @@ import { setupReady } from "../../state/onboarding-slice.js";
 export function QueuedMessages(): ReactElement | null {
   const queued = useEnduragentStore((state) => state.chat.queued);
   const workBlocked = useEnduragentStore((state) => state.chat.workBlocked);
+  const retryRequired = useEnduragentStore((state) => state.chat.retryRequired);
+  const queueMutationError = useEnduragentStore((state) => state.chat.queueMutationError) ?? null;
   const actions = useEnduragentStore((state) => state.chatActions);
   const canChat = useEnduragentStore(setupReady);
 
   if (queued.length === 0) return null;
+  const queueLabel = `${queued.length} queued ${queued.length === 1 ? "message" : "messages"}`;
 
   return (
-    <section className="chat-queue mb-2.5 min-w-0" aria-label="Queued messages">
-      <p className="chat-queue__caption m-0 mb-1.5 ml-3.5 text-xs font-medium text-ink-2">
-        Queued to send next
-      </p>
-      <ul className="m-0 flex list-none flex-col gap-1.5 p-0" role="list">
+    <section
+      className="chat-queue mb-[var(--inset)] min-w-0 overflow-hidden rounded-card border border-line bg-surface shadow-elev-2"
+      aria-label={`Queued messages, ${queueLabel}`}
+    >
+      <div className="flex min-h-ctl items-center justify-between gap-inset px-ctl-px">
+        <h2 className="m-0 text-xs font-semibold text-ink">Queued messages</h2>
+        <span className="rounded-chip bg-sunk px-inset text-xs text-ink-2" aria-hidden="true">
+          {queued.length}
+        </span>
+        <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+          {queueLabel}
+        </span>
+      </div>
+      {retryRequired !== null ? (
+        <div className="border-t border-line px-[var(--ctl-px)] py-[var(--inset)]">
+          <Button
+            variant="secondary"
+            size="xs"
+            disabled={!canChat || workBlocked || actions === null}
+            onClick={() => actions?.retryQueuedTurn(retryRequired.claimId)}
+          >
+            Retry interrupted message
+          </Button>
+        </div>
+      ) : null}
+      {queueMutationError !== null ? (
+        <p
+          className="m-0 border-t border-line px-ctl-px py-inset text-xs text-danger"
+          role="status"
+        >
+          {queueMutationError}
+        </p>
+      ) : null}
+      <ul className="m-0 flex list-none flex-col border-t border-line p-0" role="list">
         {queued.map((message, index) => (
           <li
             key={message.id}
-            className="chat-queue__item flex min-w-0 items-center gap-2 rounded-ctl border border-line bg-sunk py-[5px] pr-[5px] pl-3.5"
+            className="chat-queue__item flex min-h-ctl min-w-0 flex-wrap items-center gap-inset border-b border-line px-ctl-px py-inset last:border-b-0"
           >
             <span
               className={cn(
-                "chat-queue__text min-w-0 flex-1 truncate text-sm text-ink-2",
+                "chat-queue__text min-w-0 flex-[1_1_12rem] whitespace-pre-wrap break-words text-sm text-ink-2",
                 message.command && "chat-queue__command font-medium",
               )}
             >
               {message.text}
             </span>
-            <Button
-              className="chat-queue__remove text-ink-2 hover:text-ink"
-              variant="ghost"
-              size="icon-sm"
-              aria-label={`Remove queued message ${index + 1}`}
-              disabled={!canChat || workBlocked || actions === null}
-              onClick={() => {
-                actions?.removeQueued(message.id);
-              }}
-            >
-              <XIcon />
-            </Button>
+            <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-inset">
+              {message.command && message.restored ? (
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  disabled={!canChat || workBlocked || actions === null || retryRequired !== null}
+                  onClick={() => actions?.runQueuedCommand(message.id)}
+                >
+                  Run command
+                </Button>
+              ) : null}
+              <Button
+                className="chat-queue__remove text-ink-2 hover:text-ink"
+                variant="ghost"
+                size="xs"
+                aria-label={`Remove queued message ${index + 1}`}
+                disabled={
+                  !canChat ||
+                  workBlocked ||
+                  actions === null ||
+                  retryRequired?.queuedMessageIds.includes(message.id) === true
+                }
+                onClick={() => actions?.removeQueued(message.id)}
+              >
+                Remove
+              </Button>
+            </div>
           </li>
         ))}
       </ul>

--- a/apps/desktop-renderer/tests/archive-surface.test.tsx
+++ b/apps/desktop-renderer/tests/archive-surface.test.tsx
@@ -32,6 +32,8 @@ function chatActions(): ChatActions {
     stop: vi.fn(),
     retry: vi.fn(),
     removeQueued: vi.fn(),
+    runQueuedCommand: vi.fn(),
+    retryQueuedTurn: vi.fn(),
     loadEarlier: vi.fn(),
     retryHydration: vi.fn(),
     openNewConversation: vi.fn(),

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -88,11 +88,13 @@ describe("chat view adapter", () => {
         },
       ],
       queued: [],
+      retryRequired: null,
       decision: null,
       decisionPhase: "idle",
       decisionAnswerLabel: null,
       decisionError: null,
       decisionLoadError: null,
+      queueMutationError: null,
       timeline: [
         {
           kind: "message",

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -7,11 +7,15 @@ import {
   type CoachClient,
   type CoachClientCallOptions,
 } from "@enduragent/coach-client";
-import type { CoachTurnEventNotificationEnvelope, TurnEvent } from "@enduragent/coach-contract";
+import type {
+  ChatQueueSnapshot,
+  CoachTurnEventNotificationEnvelope,
+  QueuedChatMessage,
+  TurnEvent,
+} from "@enduragent/coach-contract";
 import {
   CHAT_CONNECTION_INTERRUPTED_COPY,
   CHAT_EMPTY_RESPONSE_COPY,
-  CHAT_FAILURE_COPY,
   CHAT_PROTOCOL_FAILURE_COPY,
   CHAT_RESPONSE_STOPPED_COPY,
   NEW_CONVERSATION_MEMORY_WARNING_COPY,
@@ -24,13 +28,17 @@ import { COACH_RESPONSE_CODE_UNIT_LIMIT, COACH_TURN_EVENT_LIMIT } from "../src/c
 import type { DesktopCoachClientProvider } from "../src/coach-client.js";
 import { CHAT_WORKING_COPY, EMPTY_CHAT_STATE, type ChatState } from "../src/turn-state.js";
 
-function envelope(event: TurnEvent, requestId = 1): CoachTurnEventNotificationEnvelope {
+function envelope(
+  event: TurnEvent,
+  requestId = 1,
+  requestMethod: CoachTurnEventNotificationEnvelope["params"]["requestMethod"] = "chat",
+): CoachTurnEventNotificationEnvelope {
   return {
     jsonrpc: "2.0",
     method: "coach.turnEvent",
     params: {
       requestId,
-      requestMethod: "chat",
+      requestMethod,
       turnId: event.turnId,
       event,
     },
@@ -54,7 +62,14 @@ function errorEvent(message = "Safe athlete message"): Extract<TurnEvent, { type
 }
 
 function deliver(options: CoachClientCallOptions<"chat"> | undefined, event: TurnEvent): void {
-  options?.onNotificationEnvelope?.(envelope(event));
+  const requestMethod = (
+    options as
+      | (CoachClientCallOptions<"chat"> & {
+          requestMethod?: CoachTurnEventNotificationEnvelope["params"]["requestMethod"];
+        })
+      | undefined
+  )?.requestMethod;
+  options?.onNotificationEnvelope?.(envelope(event, 1, requestMethod));
   options?.onEvent?.(event);
 }
 
@@ -79,34 +94,110 @@ function client(
   sessions: {
     readonly hasSession?: (request: { chatId: string }) => Promise<{ hasSession: boolean }>;
     readonly resetSession?: (request: { chatId: string }) => Promise<{ memoryFlushed: boolean }>;
-    readonly stopChat?: (request: { chatId: string }) => Promise<{ stopped: boolean }>;
+    readonly stopChat?: (request: {
+      chatId: string;
+      turnId: string;
+    }) => Promise<{ stopped: boolean }>;
   } = {},
 ): CoachClient {
+  let queueRevision = 0;
+  const queued: QueuedChatMessage[] = [];
+  const snapshot = (): ChatQueueSnapshot => ({
+    schemaVersion: 1,
+    revision: queueRevision,
+    items: queued.map((item, position) => ({ ...item, position })),
+  });
+  const acknowledge = (items: readonly QueuedChatMessage[]): void => {
+    const ids = new Set(items.map((item) => item.queuedMessageId));
+    for (let index = queued.length - 1; index >= 0; index -= 1) {
+      if (ids.has(queued[index]!.queuedMessageId)) queued.splice(index, 1);
+    }
+    queueRevision += 1;
+  };
+  const call = vi.fn((method, request, options) => {
+    const hideQueueCall = (): void => {
+      call.mock.calls.pop();
+    };
+    if (method === "getChatQueue") {
+      hideQueueCall();
+      return Promise.resolve(snapshot()) as never;
+    }
+    if (method === "enqueueChatMessage") {
+      hideQueueCall();
+      const value = request as { submissionId: string; text: string };
+      if (!queued.some((item) => item.submissionId === value.submissionId)) {
+        queued.push({
+          queuedMessageId: `queued-${value.submissionId}`,
+          submissionId: value.submissionId,
+          text: value.text,
+          kind: value.text.trimStart().startsWith("/") ? "slash-command" : "ordinary",
+          position: queued.length,
+          restored: false,
+        });
+        queueRevision += 1;
+      }
+      return Promise.resolve(snapshot()) as never;
+    }
+    if (method === "removeQueuedChatMessage") {
+      hideQueueCall();
+      const value = request as { queuedMessageId: string };
+      acknowledge(queued.filter((item) => item.queuedMessageId === value.queuedMessageId));
+      return Promise.resolve(snapshot()) as never;
+    }
+    if (method === "resumeChatQueue" || method === "runQueuedCommand") {
+      hideQueueCall();
+      const head = queued[0];
+      if (head === undefined) return Promise.resolve({ snapshot: snapshot() }) as never;
+      const commandIndex = queued.findIndex((item) => item.kind === "slash-command");
+      const group =
+        head.kind === "slash-command"
+          ? [head]
+          : queued.slice(0, commandIndex === -1 ? queued.length : commandIndex);
+      const queueOptions = {
+        ...(options as CoachClientCallOptions<"chat">),
+        requestMethod: method,
+      };
+      const response = call(
+        "chat",
+        { chatId: "desktop", message: group.map((item) => item.text).join("\n\n") },
+        queueOptions,
+      ) as Promise<{ text: string }>;
+      return response.then(
+        (value) => {
+          acknowledge(group);
+          return { snapshot: snapshot(), response: value };
+        },
+        (error: unknown) => {
+          acknowledge(group);
+          throw error;
+        },
+      ) as never;
+    }
+    if (method === "hasSession") {
+      return (sessions.hasSession ?? (async () => ({ hasSession: false })))(
+        request as { chatId: string },
+      ) as never;
+    }
+    if (method === "resetSession") {
+      return (sessions.resetSession ?? (async () => ({ memoryFlushed: true })))(
+        request as { chatId: string },
+      ) as never;
+    }
+    if (method === "stopChat") {
+      return (sessions.stopChat ?? (async () => ({ stopped: false })))(
+        request as { chatId: string; turnId: string },
+      ) as never;
+    }
+    if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+    if (method !== "chat") throw new TypeError();
+    return implementation(
+      request as { chatId: string; message: string },
+      options as CoachClientCallOptions<"chat">,
+    ) as never;
+  });
   return {
     handshake: {} as CoachClient["handshake"],
-    call: vi.fn((method, request, options) => {
-      if (method === "hasSession") {
-        return (sessions.hasSession ?? (async () => ({ hasSession: false })))(
-          request as { chatId: string },
-        ) as never;
-      }
-      if (method === "resetSession") {
-        return (sessions.resetSession ?? (async () => ({ memoryFlushed: true })))(
-          request as { chatId: string },
-        ) as never;
-      }
-      if (method === "stopChat") {
-        return (sessions.stopChat ?? (async () => ({ stopped: false })))(
-          request as { chatId: string },
-        ) as never;
-      }
-      if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
-      if (method !== "chat") throw new TypeError();
-      return implementation(
-        request as { chatId: string; message: string },
-        options as CoachClientCallOptions<"chat">,
-      ) as never;
-    }),
+    call,
     close: vi.fn(async () => {}),
   };
 }
@@ -141,9 +232,11 @@ function subject(
   refreshImplementation: () => Promise<void> = async () => {},
   spendRefreshImplementation: () => Promise<void> = async () => {},
   canChat: () => boolean = () => true,
+  settleSubmissions = true,
 ) {
   const states: ChatState[] = [];
   const controls: ChatViewControls[] = [];
+  const settlements = new Set<{ remaining: number; resolve: () => void }>();
   const refresh = vi.fn(refreshImplementation);
   const refreshSpend = vi.fn(spendRefreshImplementation);
   const provider: DesktopCoachClientProvider = {
@@ -157,13 +250,47 @@ function subject(
       render: (state, nextControls) => {
         states.push(structuredClone(state));
         if (nextControls !== undefined) controls.push(structuredClone(nextControls));
+        if (state.status !== "streaming") {
+          for (const settlement of settlements) {
+            settlement.remaining -= 1;
+            if (settlement.remaining === 0) {
+              settlements.delete(settlement);
+              settlement.resolve();
+            }
+          }
+        }
       },
     },
     refreshTrainingContext: refresh,
     refreshSpend,
     canChat,
+    initialQueueSnapshot: { schemaVersion: 1, revision: 0, items: [] },
   });
-  return { controller, provider, states, controls, refresh, refreshSpend };
+  const submittedController = {
+    ...controller,
+    async submit(message: string): Promise<boolean> {
+      const alreadyStreaming = states.at(-1)?.status === "streaming";
+      const acknowledged = await controller.submit(message);
+      if (
+        !settleSubmissions ||
+        !acknowledged ||
+        alreadyStreaming ||
+        states.at(-1)?.status !== "streaming"
+      ) {
+        return acknowledged;
+      }
+      await new Promise<void>((resolve) => settlements.add({ remaining: 2, resolve }));
+      return acknowledged;
+    },
+  };
+  return {
+    controller: submittedController,
+    provider,
+    states,
+    controls,
+    refresh,
+    refreshSpend,
+  };
 }
 
 describe("chat controller", () => {
@@ -180,6 +307,7 @@ describe("chat controller", () => {
       async () => {},
       async () => {},
       () => ready,
+      false,
     );
 
     await controller.submit("Blocked");
@@ -194,8 +322,9 @@ describe("chat controller", () => {
     release();
     await first;
 
-    expect(chatMessages(fake)).toEqual(["Allowed"]);
-    expect(states.at(-1)?.queued).toMatchObject([{ text: "Queued" }]);
+    expect(chatMessages(fake)).toEqual(["Allowed\n\nQueued"]);
+    await vi.waitFor(() => expect(states.at(-1)?.queued).toEqual([]));
+    expect(states.at(-1)?.queued).toEqual([]);
     expect(controller.openNewConversation()).toBe(false);
   });
 
@@ -212,6 +341,7 @@ describe("chat controller", () => {
       async () => {},
       async () => {},
       () => ready,
+      false,
     );
 
     const first = controller.submit("Allowed");
@@ -221,13 +351,14 @@ describe("chat controller", () => {
     release();
     await first;
 
-    expect(chatMessages(fake)).toEqual(["Allowed"]);
-    expect(states.at(-1)?.queued).toMatchObject([{ text: "Queued" }]);
+    expect(chatMessages(fake)).toEqual(["Allowed\n\nQueued"]);
+    await vi.waitFor(() => expect(states.at(-1)?.queued).toEqual([]));
+    expect(states.at(-1)?.queued).toEqual([]);
 
     ready = true;
     await Promise.all([controller.resume(), controller.resume(), controller.resume()]);
 
-    expect(chatMessages(fake)).toEqual(["Allowed", "Queued"]);
+    expect(chatMessages(fake)).toEqual(["Allowed\n\nQueued"]);
     expect(states.at(-1)?.queued).toEqual([]);
   });
 
@@ -289,7 +420,7 @@ describe("chat controller", () => {
       async () => {},
       () => gate,
     );
-    await expect(controller.submit("Continue")).resolves.toBeUndefined();
+    await expect(controller.submit("Continue")).resolves.toBe(true);
     expect(refreshSpend).toHaveBeenCalledTimes(1);
   });
 
@@ -308,14 +439,16 @@ describe("chat controller", () => {
 
     const submission = controller.submit("Continue");
 
-    expect(states.at(-1)).toMatchObject({
-      status: "streaming",
-      progress: CHAT_WORKING_COPY,
-      messages: [
-        { role: "athlete", text: "Continue" },
-        { role: "coach", text: "", delivery: "streaming" },
-      ],
-    });
+    await vi.waitFor(() =>
+      expect(states.at(-1)).toMatchObject({
+        status: "streaming",
+        progress: CHAT_WORKING_COPY,
+        messages: [
+          { role: "athlete", text: "Continue" },
+          { role: "coach", text: "", delivery: "streaming" },
+        ],
+      }),
+    );
 
     release();
     await submission;
@@ -371,6 +504,10 @@ describe("chat controller", () => {
     await submission;
 
     expect(vi.mocked(fake.call).mock.calls.map(([method]) => method)).toEqual(["chat", "stopChat"]);
+    expect(vi.mocked(fake.call).mock.calls[1]?.[1]).toEqual({
+      chatId: "desktop",
+      turnId: "turn-1",
+    });
     expect(states.at(-1)).toMatchObject({
       status: "interrupted",
       progress: CHAT_RESPONSE_STOPPED_COPY,
@@ -601,7 +738,7 @@ describe("chat controller", () => {
     await controller.submit("Help");
     expect(states.at(-1)?.messages.at(-1)?.text).toBe("Partial");
     expect(states.at(-1)?.activeTurn?.error?.athleteMessage).toBe("Safe athlete message");
-    expect(fake.call).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(fake.call).toHaveBeenCalledTimes(1));
   });
 
   it("reconciles a safe final after an error while retaining the subdued notice", async () => {
@@ -781,8 +918,10 @@ describe("chat controller", () => {
       view: { render: (state) => states.push(structuredClone(state)) },
       refreshTrainingContext: vi.fn(async () => {}),
       refreshSpend: vi.fn(async () => {}),
+      initialQueueSnapshot: { schemaVersion: 1, revision: 0, items: [] },
     });
     await controller.submit("Same message");
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("interrupted"));
     await controller.retryInterrupted();
     expect(provider.reconnect).not.toHaveBeenCalled();
     expect(recovered.call).toHaveBeenCalledTimes(1);
@@ -827,6 +966,7 @@ describe("chat controller", () => {
         if (refreshCalls === 1) await refreshGate;
       }),
       refreshSpend: vi.fn(async () => {}),
+      initialQueueSnapshot: { schemaVersion: 1, revision: 0, items: [] },
     });
     const submission = controller.submit("Same message");
     await interruptedState;
@@ -841,112 +981,6 @@ describe("chat controller", () => {
     expect(second.call).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps queued retries owned by the interrupted request when a newer pre-call disconnects", async () => {
-    let releaseFirstRefresh!: () => void;
-    const firstRefreshGate = new Promise<void>((resolve) => {
-      releaseFirstRefresh = resolve;
-    });
-    let resolveReconnect!: (value: CoachClient) => void;
-    const reconnectGate = new Promise<CoachClient>((resolve) => {
-      resolveReconnect = resolve;
-    });
-    const first = client(async (_request, options) => {
-      deliver(options, { type: "text_delta", turnId: "turn-a", delta: "Partial A" });
-      throw new CoachClientDisconnectedError(1006, "chat-a-disconnected");
-    });
-    const recovered = client(async (_request, options) => {
-      deliver(options, { type: "final-text", turnId: "turn-b-retry", text: "Recovered B" });
-      options?.onTerminalEnvelope?.({
-        jsonrpc: "2.0",
-        id: 3,
-        result: { text: "Recovered B" },
-      });
-      return { text: "Recovered B" };
-    });
-    let clientAcquisitions = 0;
-    const provider: DesktopCoachClientProvider = {
-      getClient: vi.fn(async () => {
-        clientAcquisitions += 1;
-        if (clientAcquisitions === 1) return first;
-        throw new CoachClientDisconnectedError(1006, "chat-b-pre-call-disconnected");
-      }),
-      reconnect: vi.fn(() => reconnectGate),
-      close: vi.fn(async () => {}),
-    };
-    const states: ChatState[] = [];
-    let renderCount = 0;
-    let releasedFirstRefresh = false;
-    let showSecondInterruption!: () => void;
-    const secondInterruption = new Promise<void>((resolve) => {
-      showSecondInterruption = resolve;
-    });
-    const refreshTrainingContext = vi.fn(async () => {
-      if (refreshTrainingContext.mock.calls.length === 1) await firstRefreshGate;
-    });
-    const refreshSpend = vi.fn(async () => {});
-    const controller = createChatController({
-      clients: provider,
-      view: {
-        render(state) {
-          states.push(structuredClone(state));
-          renderCount += 1;
-          if (
-            !releasedFirstRefresh &&
-            state.status === "interrupted" &&
-            state.activeTurn?.userMessage === "Chat B"
-          ) {
-            releasedFirstRefresh = true;
-            releaseFirstRefresh();
-            showSecondInterruption();
-          }
-        },
-      },
-      refreshTrainingContext,
-      refreshSpend,
-    });
-
-    const chatA = controller.submit("Chat A");
-    while (states.at(-1)?.status !== "interrupted") await Promise.resolve();
-    const retryA = controller.retryInterrupted();
-    const chatB = controller.submit("Chat B");
-    await secondInterruption;
-    const rendersAtSecondInterruption = renderCount;
-    const retryB = controller.retryInterrupted();
-    const duplicateB = controller.retryInterrupted();
-
-    expect(retryB).not.toBe(retryA);
-    expect(duplicateB).toBe(retryB);
-    await Promise.all([chatA, chatB, retryA]);
-    expect(provider.getClient).toHaveBeenCalledTimes(2);
-    expect(provider.reconnect).toHaveBeenCalledTimes(1);
-    expect(renderCount).toBe(rendersAtSecondInterruption + 5);
-    expect(first.call).toHaveBeenCalledTimes(1);
-    expect(recovered.call).not.toHaveBeenCalled();
-
-    resolveReconnect(recovered);
-    await Promise.all([retryB, duplicateB]);
-
-    expect(provider.getClient).toHaveBeenCalledTimes(2);
-    expect(provider.reconnect).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(first.call).mock.calls.map(([, request]) => request)).toEqual([
-      { chatId: "desktop", message: "Chat A" },
-    ]);
-    expect(vi.mocked(recovered.call).mock.calls.map(([, request]) => request)).toEqual([
-      { chatId: "desktop", message: "Chat B" },
-    ]);
-    expect(refreshTrainingContext).toHaveBeenCalledTimes(2);
-    expect(refreshSpend).toHaveBeenCalledTimes(2);
-    expect(
-      states.at(-1)?.messages.map(({ role, text, delivery }) => ({ role, text, delivery })),
-    ).toEqual([
-      { role: "athlete", text: "Chat A", delivery: "complete" },
-      { role: "coach", text: "Partial A", delivery: "interrupted" },
-      { role: "athlete", text: "Chat B", delivery: "complete" },
-      { role: "coach", text: "", delivery: "interrupted" },
-      { role: "coach", text: "Recovered B", delivery: "complete" },
-    ]);
-  });
-
   it("allows one in-flight call and treats client protocol rejection as explicit-retry state", async () => {
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {
@@ -959,8 +993,7 @@ describe("chat controller", () => {
     const { controller, states } = subject(fake);
     const first = controller.submit("One");
     const second = controller.submit("Two");
-    await Promise.resolve();
-    expect(fake.call).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(fake.call).toHaveBeenCalledTimes(1));
     release();
     await Promise.all([first, second]);
     expect(states.at(-1)?.progress).toBe(CHAT_PROTOCOL_FAILURE_COPY);
@@ -1015,7 +1048,7 @@ describe("chat controller", () => {
     ).toEqual([]);
   });
 
-  it("uses visible local content without promoting an absent session after pre-client failure", async () => {
+  it("does not project local content before durable admission succeeds", async () => {
     const fake = client(async () => ({ text: "unused" }));
     const { controller, provider, states, controls } = subject(fake);
     await controller.start();
@@ -1028,39 +1061,21 @@ describe("chat controller", () => {
 
     const submission = controller.submit("Keep this visible");
     expect(states.at(-1)?.session.presence).toBe("absent");
-    expect(states.at(-1)?.messages).toMatchObject([
-      { role: "athlete", text: "Keep this visible" },
-      { role: "coach", text: "" },
-    ]);
+    expect(states.at(-1)?.messages).toEqual([]);
     expect(controls.at(-1)?.newConversationDisabled).toBe(true);
     expect(controller.openNewConversation()).toBe(false);
 
     rejectClient(new Error("synthetic pre-client failure"));
-    await submission;
+    await expect(submission).rejects.toThrow("synthetic pre-client failure");
 
     expect(states.at(-1)?.session.presence).toBe("absent");
-    expect(states.at(-1)?.messages).toMatchObject([
-      { role: "athlete", text: "Keep this visible", delivery: "complete" },
-      { role: "coach", text: "", delivery: "interrupted" },
-    ]);
-    expect(
-      controls.slice(-2).map(({ newConversationDisabled }) => newConversationDisabled),
-    ).toEqual([true, false]);
-    expect(controller.openNewConversation()).toBe(true);
-    expect(states.at(-1)?.session).toMatchObject({
-      presence: "absent",
-      resetPhase: "confirming",
-    });
-    expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "chat")).toEqual([]);
-
-    await controller.confirmNewConversation();
     expect(states.at(-1)?.messages).toEqual([]);
-    expect(states.at(-1)?.session).toMatchObject({
-      presence: "absent",
-      resetPhase: "idle",
-    });
+    expect(controls.at(-1)?.newConversationDisabled).toBe(true);
+    expect(controller.openNewConversation()).toBe(false);
+    expect(states.at(-1)?.session).toMatchObject({ presence: "absent", resetPhase: "idle" });
+    expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "chat")).toEqual([]);
     expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession")).toEqual(
-      [["resetSession", { chatId: "desktop" }]],
+      [],
     );
   });
 
@@ -1170,7 +1185,7 @@ describe("chat controller", () => {
 
     vi.mocked(provider.getClient).mockRejectedValueOnce(new Error("synthetic admission failure"));
     const chatB = controller.submit("Chat B");
-    await chatB;
+    await expect(chatB).rejects.toThrow("synthetic admission failure");
 
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(controls.at(-1)?.newConversationDisabled).toBe(true);
@@ -1360,317 +1375,6 @@ describe("chat controller", () => {
     settleReset({ memoryFlushed: true });
     await reset;
     expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "chat")).toEqual([]);
-  });
-
-  it("queues a message sent while the coach streams and dispatches it once the turn settles", async () => {
-    let release!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const fake = client(replies(() => gate));
-    const { controller, states } = subject(fake);
-
-    const submission = controller.submit("First question");
-    await expect(controller.submit("Second question")).resolves.toBeUndefined();
-
-    expect(chatMessages(fake)).toEqual(["First question"]);
-    expect(states.at(-1)?.queued).toMatchObject([{ text: "Second question", command: false }]);
-    expect(states.at(-1)?.status).toBe("streaming");
-
-    release();
-    await submission;
-
-    expect(chatMessages(fake)).toEqual(["First question", "Second question"]);
-    expect(states.at(-1)?.queued).toEqual([]);
-    expect(states.at(-1)?.status).toBe("idle");
-    expect(states.at(-1)?.messages.map((message) => message.text)).toEqual([
-      "First question",
-      "Reply 1",
-      "Second question",
-      "Reply 2",
-    ]);
-  });
-
-  it("drains queued messages after the athlete stops the active response", async () => {
-    let turn = 0;
-    let firstOptions: CoachClientCallOptions<"chat"> | undefined;
-    let finishFirst!: (value: { text: string }) => void;
-    const firstResult = new Promise<{ text: string }>((resolve) => {
-      finishFirst = resolve;
-    });
-    const fake = client(
-      async (_request, options) => {
-        turn += 1;
-        if (turn === 1) {
-          firstOptions = options;
-          deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
-          return firstResult;
-        }
-        deliver(options, { type: "final-text", turnId: "turn-2", text: "Queued reply" });
-        options?.onTerminalEnvelope?.({
-          jsonrpc: "2.0",
-          id: 2,
-          result: { text: "Queued reply" },
-        });
-        return { text: "Queued reply" };
-      },
-      {
-        stopChat: async () => {
-          deliver(firstOptions, {
-            type: "interrupted",
-            turnId: "turn-1",
-            chatId: "desktop",
-            text: "Partial",
-          });
-          firstOptions?.onTerminalEnvelope?.({
-            jsonrpc: "2.0",
-            id: 1,
-            result: { text: "Partial" },
-          });
-          finishFirst({ text: "Partial" });
-          return { stopped: true };
-        },
-      },
-    );
-    const { controller, states } = subject(fake);
-
-    const submission = controller.submit("Opening question");
-    await controller.submit("Queued question");
-    controller.stop();
-    await submission;
-
-    expect(chatMessages(fake)).toEqual(["Opening question", "Queued question"]);
-    expect(states.at(-1)?.queued).toEqual([]);
-    expect(states.at(-1)?.messages.map((message) => message.text)).toEqual([
-      "Opening question",
-      "Partial",
-      "Queued question",
-      "Queued reply",
-    ]);
-  });
-
-  it("coalesces queued free text into one turn and keeps each command on its own turn", async () => {
-    let release!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const fake = client(replies(() => gate));
-    const { controller } = subject(fake);
-
-    const submission = controller.submit("Opening");
-    await Promise.all([
-      controller.submit("One more thought"),
-      controller.submit("And another"),
-      controller.submit("/plan"),
-      controller.submit("Back to prose"),
-    ]);
-
-    release();
-    await submission;
-
-    expect(chatMessages(fake)).toEqual([
-      "Opening",
-      "One more thought\n\nAnd another",
-      "/plan",
-      "Back to prose",
-    ]);
-  });
-
-  it("holds the queue when the streaming turn is interrupted and drains after a successful retry", async () => {
-    const recovered = client(replies());
-    let current: CoachClient;
-    let release!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const failing = client(async (_request, options) => {
-      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
-      await gate;
-      throw new CoachClientDisconnectedError(1006, "synthetic");
-    });
-    current = failing;
-    const provider: DesktopCoachClientProvider = {
-      getClient: vi.fn(async () => current),
-      reconnect: vi.fn(async () => {
-        current = recovered;
-        return recovered;
-      }),
-      close: vi.fn(async () => {}),
-    };
-    const states: ChatState[] = [];
-    const controller = createChatController({
-      clients: provider,
-      view: { render: (state) => states.push(structuredClone(state)) },
-      refreshTrainingContext: vi.fn(async () => {}),
-      refreshSpend: vi.fn(async () => {}),
-    });
-
-    const submission = controller.submit("Original");
-    await controller.submit("Queued behind it");
-    release();
-    await submission;
-
-    expect(states.at(-1)?.status).toBe("interrupted");
-    expect(states.at(-1)?.queued).toMatchObject([{ text: "Queued behind it" }]);
-    expect(chatMessages(recovered)).toEqual([]);
-    expect(controller.openNewConversation()).toBe(false);
-
-    await controller.retryInterrupted();
-
-    expect(chatMessages(recovered)).toEqual(["Original", "Queued behind it"]);
-    expect(states.at(-1)?.queued).toEqual([]);
-  });
-
-  it("keeps a queued message un-drained after a failed turn and removes it on request", async () => {
-    let release!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const fake = client(async () => {
-      await gate;
-      throw new Error("private failure detail");
-    });
-    const { controller, states } = subject(fake);
-
-    const submission = controller.submit("Original");
-    await controller.submit("Queued behind it");
-    release();
-    await submission;
-
-    expect(states.at(-1)).toMatchObject({ status: "idle", progress: CHAT_FAILURE_COPY });
-    expect(chatMessages(fake)).toEqual(["Original"]);
-    const held = states.at(-1)?.queued.at(0)?.id;
-    expect(held).toBeDefined();
-    expect(controller.openNewConversation()).toBe(false);
-
-    controller.removeQueued(held ?? "");
-
-    expect(states.at(-1)?.queued).toEqual([]);
-    expect(chatMessages(fake)).toEqual(["Original"]);
-    expect(controller.openNewConversation()).toBe(true);
-  });
-
-  it("drains a queue left over from a paused turn when the athlete sends again", async () => {
-    let release!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    let calls = 0;
-    const fake = client(async (request, options) => {
-      calls += 1;
-      if (calls === 1) {
-        await gate;
-        throw new Error("private failure detail");
-      }
-      return replies()(request, options);
-    });
-    const { controller, states } = subject(fake);
-
-    const submission = controller.submit("Original");
-    await controller.submit("Queued behind it");
-    release();
-    await submission;
-    expect(chatMessages(fake)).toEqual(["Original"]);
-
-    await controller.submit("Sent after the failure");
-
-    expect(chatMessages(fake)).toEqual(["Original", "Queued behind it\n\nSent after the failure"]);
-    expect(states.at(-1)?.queued).toEqual([]);
-  });
-
-  it("holds the queue when a drain lands while a newer turn is already streaming", async () => {
-    const releaseCall: Record<number, () => void> = {};
-    const callGates: Record<number, Promise<void>> = {};
-    for (const turnNumber of [1, 2]) {
-      callGates[turnNumber] = new Promise<void>((resolve) => {
-        releaseCall[turnNumber] = resolve;
-      });
-    }
-    let releaseRefresh!: () => void;
-    const refreshGate = new Promise<void>((resolve) => {
-      releaseRefresh = resolve;
-    });
-    let refreshes = 0;
-    let turn = 0;
-    const fake = client(async (_request, options) => {
-      turn += 1;
-      const gate = callGates[turn];
-      if (gate !== undefined) await gate;
-      const text = `Reply ${turn}`;
-      deliver(options, { type: "final-text", turnId: `turn-${turn}`, text });
-      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: turn, result: { text } });
-      return { text };
-    });
-    const { controller, states } = subject(fake, fake, () => {
-      refreshes += 1;
-      return refreshes === 1 ? refreshGate : Promise.resolve();
-    });
-
-    const submission = controller.submit("Original");
-    await controller.submit("Queued prose");
-    await controller.submit("/plan");
-
-    releaseCall[1]?.();
-    while (states.at(-1)?.status !== "idle") await Promise.resolve();
-
-    const late = controller.submit("Sent in the refresh window");
-    while (chatMessages(fake).length < 2) await Promise.resolve();
-
-    expect(states.at(-1)?.status).toBe("streaming");
-    expect(chatMessages(fake)).toEqual(["Original", "Queued prose"]);
-    expect(states.at(-1)?.queued).toMatchObject([
-      { text: "/plan" },
-      { text: "Sent in the refresh window" },
-    ]);
-
-    releaseRefresh();
-    await submission;
-
-    expect(chatMessages(fake)).toEqual(["Original", "Queued prose"]);
-    expect(states.at(-1)?.queued).toMatchObject([
-      { text: "/plan" },
-      { text: "Sent in the refresh window" },
-    ]);
-
-    releaseCall[2]?.();
-    await late;
-
-    expect(chatMessages(fake)).toEqual([
-      "Original",
-      "Queued prose",
-      "/plan",
-      "Sent in the refresh window",
-    ]);
-    expect(states.at(-1)?.queued).toEqual([]);
-    expect(states.at(-1)?.status).toBe("idle");
-    expect(
-      states
-        .at(-1)
-        ?.messages.filter((message) => message.role === "athlete")
-        .map((message) => message.text),
-    ).toEqual(["Original", "Queued prose", "/plan", "Sent in the refresh window"]);
-  });
-
-  it("never drains a queued message after dispose", async () => {
-    let release!: () => void;
-    const refreshGate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const fake = client(replies());
-    const { controller, provider, states } = subject(fake, fake, () => refreshGate);
-
-    const submission = controller.submit("Original");
-    await controller.submit("Queued behind it");
-    while (states.at(-1)?.status !== "idle") await Promise.resolve();
-    const renderCount = states.length;
-    controller.dispose();
-    release();
-    await submission;
-
-    expect(states).toHaveLength(renderCount);
-    expect(states.at(-1)?.queued).toMatchObject([{ text: "Queued behind it" }]);
-    expect(chatMessages(fake)).toEqual(["Original"]);
-    expect(provider.getClient).toHaveBeenCalledTimes(1);
   });
 
   it("fences late probe and reset settlements after dispose without refreshing spend", async () => {

--- a/apps/desktop-renderer/tests/chat-decision-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-decision-controller.test.ts
@@ -52,7 +52,7 @@ function completed(): Extract<CoachDecisionReadModel, { status: "answered" }> {
 
 function emit(
   options: TestCallOptions | undefined,
-  requestMethod: "chat" | "answerCoachDecision" | "resumeCoachDecision",
+  requestMethod: "chat" | "resumeChatQueue" | "answerCoachDecision" | "resumeCoachDecision",
   event: TurnEvent,
   requestId: number,
 ): void {
@@ -90,12 +90,44 @@ function subject(
 ) {
   const states: ChatState[] = [];
   const controls: ChatViewControls[] = [];
-  const call = vi.fn(async (method: string, _request: unknown, options?: TestCallOptions) => {
-    if (method === "chat") {
-      emit(options, "chat", { type: "turn-start", turnId: "turn-1", chatId: "desktop" }, 1);
+  let queueRevision = 0;
+  let queued:
+    | {
+        queuedMessageId: string;
+        submissionId: string;
+        text: string;
+        kind: "ordinary";
+        position: number;
+        restored: boolean;
+      }
+    | undefined;
+  const call = vi.fn(async (method: string, request: unknown, options?: TestCallOptions) => {
+    if (method === "enqueueChatMessage") {
+      const input = request as { submissionId: string; text: string };
+      queueRevision += 1;
+      queued = {
+        queuedMessageId: `queued-${queueRevision}`,
+        submissionId: input.submissionId,
+        text: input.text,
+        kind: "ordinary",
+        position: 0,
+        restored: false,
+      };
+      return { schemaVersion: 1, revision: queueRevision, items: [queued] };
+    }
+    if (method === "getChatQueue") {
+      return {
+        schemaVersion: 1,
+        revision: queueRevision,
+        items: queued === undefined ? [] : [queued],
+      };
+    }
+    if (method === "chat" || method === "resumeChatQueue") {
+      const requestMethod = method;
+      emit(options, requestMethod, { type: "turn-start", turnId: "turn-1", chatId: "desktop" }, 1);
       emit(
         options,
-        "chat",
+        requestMethod,
         { type: "decision-requested", turnId: "turn-1", chatId: "desktop", decision: unanswered() },
         1,
       );
@@ -104,7 +136,14 @@ function subject(
         id: 1,
         result: { status: "decision-required", decision: unanswered() },
       });
-      return { status: "decision-required", decision: unanswered() };
+      const response = { status: "decision-required" as const, decision: unanswered() };
+      if (method === "chat") return response;
+      queueRevision += 1;
+      queued = undefined;
+      return {
+        snapshot: { schemaVersion: 1, revision: queueRevision, items: [] },
+        response,
+      };
     }
     if (method === "answerCoachDecision" || method === "resumeCoachDecision") {
       if (continuationOverride !== undefined) return continuationOverride(method, options);
@@ -154,8 +193,19 @@ function subject(
     },
     refreshTrainingContext: async () => {},
     refreshSpend: async () => {},
+    initialQueueSnapshot: { schemaVersion: 1, revision: 0, items: [] },
   });
-  return { controller, call, states, controls };
+  const submittedController = {
+    ...controller,
+    async submit(message: string): Promise<boolean> {
+      const acknowledged = await controller.submit(message);
+      if (acknowledged) {
+        await vi.waitFor(() => expect(states.at(-1)?.status).not.toBe("streaming"));
+      }
+      return acknowledged;
+    },
+  };
+  return { controller: submittedController, call, states, controls };
 }
 
 describe("Coach decision controller", () => {
@@ -244,12 +294,7 @@ describe("Coach decision controller", () => {
         10 + attempt,
       );
       if (attempt === 1) {
-        emit(
-          options,
-          method,
-          { type: "text_delta", turnId: "turn-2", delta: "Partial" },
-          11,
-        );
+        emit(options, method, { type: "text_delta", turnId: "turn-2", delta: "Partial" }, 11);
         await stopped.promise;
         emit(
           options,
@@ -272,8 +317,7 @@ describe("Coach decision controller", () => {
         {
           type: "final-text",
           turnId: "turn-3",
-          text:
-            resumed.continuation.status === "completed" ? resumed.continuation.coachText : "",
+          text: resumed.continuation.status === "completed" ? resumed.continuation.coachText : "",
         },
         12,
       );
@@ -281,12 +325,19 @@ describe("Coach decision controller", () => {
       return { decision: resumed };
     });
     await controller.submit("What should I do tomorrow?");
-    const answer = controller.answerDecision("decision-1", { kind: "option", optionId: "recovery" });
+    const answer = controller.answerDecision("decision-1", {
+      kind: "option",
+      optionId: "recovery",
+    });
     await vi.waitFor(() => expect(states.at(-1)?.status).toBe("streaming"));
     controller.stop();
     await vi.waitFor(() =>
       expect(call.mock.calls.some(([method]) => method === "stopChat")).toBe(true),
     );
+    expect(call.mock.calls.find(([method]) => method === "stopChat")?.[1]).toEqual({
+      chatId: "desktop",
+      turnId: "turn-2",
+    });
     stopped.resolve();
     await answer;
 
@@ -297,20 +348,21 @@ describe("Coach decision controller", () => {
   });
 
   it("keeps Chat blocked after decision hydration fails and recovers through reconnect", async () => {
-    const decisionRead = vi.fn<() => Promise<CoachDecisionReadModel | null>>()
+    const decisionRead = vi
+      .fn<() => Promise<CoachDecisionReadModel | null>>()
       .mockRejectedValueOnce(new Error("offline"))
       .mockResolvedValueOnce(null);
     const { controller, call, controls } = subject(null, undefined, decisionRead);
     await controller.start();
     expect(controls.at(-1)?.decisionLoadError).toContain("saved Coach question");
     await controller.submit("Blocked while unknown");
-    expect(call.mock.calls.filter(([method]) => method === "chat")).toHaveLength(0);
+    expect(call.mock.calls.filter(([method]) => method === "resumeChatQueue")).toHaveLength(0);
 
     await controller.retryDecision();
     expect(controls.at(-1)?.decisionLoading).toBe(false);
     expect(controls.at(-1)?.decisionLoadError).toBeNull();
     await controller.submit("Now available");
-    expect(call.mock.calls.filter(([method]) => method === "chat")).toHaveLength(1);
+    expect(call.mock.calls.filter(([method]) => method === "resumeChatQueue")).toHaveLength(1);
   });
 
   it("restores a committed continuation after the transport fails before its terminal result", async () => {
@@ -351,11 +403,11 @@ describe("Coach decision controller", () => {
     void controller.start();
     await vi.waitFor(() => expect(controls.at(-1)?.decisionLoading).toBe(true));
     await controller.submit("Send too early");
-    expect(call.mock.calls.filter(([method]) => method === "chat")).toHaveLength(0);
+    expect(call.mock.calls.filter(([method]) => method === "resumeChatQueue")).toHaveLength(0);
 
     decisionRead.resolve(null);
     await vi.waitFor(() => expect(controls.at(-1)?.decisionLoading).toBe(false));
     await controller.submit("Send after recovery check");
-    expect(call.mock.calls.filter(([method]) => method === "chat")).toHaveLength(1);
+    expect(call.mock.calls.filter(([method]) => method === "resumeChatQueue")).toHaveLength(1);
   });
 });

--- a/apps/desktop-renderer/tests/chat-hydration-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-hydration-controller.test.ts
@@ -36,9 +36,20 @@ function coachClient(input: {
     options: CoachClientCallOptions<"chat"> | undefined,
   ) => Promise<{ text: string }>;
 }): CoachClient {
+  let revision = 0;
+  let queued:
+    | {
+        queuedMessageId: string;
+        submissionId: string;
+        text: string;
+        kind: "ordinary";
+        position: number;
+        restored: boolean;
+      }
+    | undefined;
   return {
     handshake: {} as CoachClient["handshake"],
-    call: vi.fn((method, _request, options) => {
+    call: vi.fn((method, request, options) => {
       if (method === "hasSession") {
         return Promise.resolve({ hasSession: input.hasSession ?? false }) as never;
       }
@@ -47,6 +58,37 @@ function coachClient(input: {
       }
       if (method === "getCoachDecision") {
         return Promise.resolve({ decision: null }) as never;
+      }
+      if (method === "getChatQueue") {
+        return Promise.resolve({
+          schemaVersion: 1,
+          revision,
+          items: queued === undefined ? [] : [queued],
+        }) as never;
+      }
+      if (method === "enqueueChatMessage") {
+        const value = request as { submissionId: string; text: string };
+        revision += 1;
+        queued = {
+          queuedMessageId: `queued-${revision}`,
+          submissionId: value.submissionId,
+          text: value.text,
+          kind: "ordinary",
+          position: 0,
+          restored: false,
+        };
+        return Promise.resolve({ schemaVersion: 1, revision, items: [queued] }) as never;
+      }
+      if (method === "resumeChatQueue" && input.chat !== undefined) {
+        const queueOptions = {
+          ...(options as CoachClientCallOptions<"chat">),
+          requestMethod: "resumeChatQueue" as const,
+        };
+        return input.chat(queueOptions).then((response) => {
+          revision += 1;
+          queued = undefined;
+          return { snapshot: { schemaVersion: 1, revision, items: [] }, response };
+        }) as never;
       }
       if (method === "chat" && input.chat !== undefined) {
         return input.chat(options as CoachClientCallOptions<"chat">) as never;
@@ -58,12 +100,15 @@ function coachClient(input: {
 }
 
 function deliver(options: CoachClientCallOptions<"chat"> | undefined, event: TurnEvent): void {
+  const requestMethod = (
+    options as (CoachClientCallOptions<"chat"> & { requestMethod?: "resumeChatQueue" }) | undefined
+  )?.requestMethod;
   options?.onNotificationEnvelope?.({
     jsonrpc: "2.0",
     method: "coach.turnEvent",
     params: {
       requestId: 1,
-      requestMethod: "chat",
+      requestMethod: requestMethod ?? "chat",
       turnId: event.turnId,
       event,
     },
@@ -127,7 +172,7 @@ describe("chat controller transcript hydration", () => {
       expect(readTranscriptPage).toHaveBeenCalledTimes(1);
       expect(states.at(-1)?.messages).toHaveLength(2);
     });
-    expect(client.call).toHaveBeenCalledTimes(2);
+    expect(client.call).toHaveBeenCalledTimes(3);
     expect(client.call).toHaveBeenCalledWith("hasSession", { chatId: "desktop" });
     expect(client.call).toHaveBeenCalledWith("getCoachDecision", { chatId: "desktop" });
   });
@@ -137,6 +182,9 @@ describe("chat controller transcript hydration", () => {
     const client = coachClient({});
     vi.mocked(client.call).mockImplementation((method) => {
       if (method === "hasSession") return session.promise as never;
+      if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+      if (method === "getChatQueue")
+        return Promise.resolve({ schemaVersion: 1, revision: 0, items: [] }) as never;
       throw new TypeError();
     });
     const { controller, states } = subject({
@@ -168,16 +216,18 @@ describe("chat controller transcript hydration", () => {
         return { text: "Live coach" };
       },
     });
-    const { controller, states } = subject({
+    const { controller, states, controls } = subject({
       client,
       readTranscriptPage: () => hydration.promise,
     });
-    await controller.start();
+    const starting = controller.start();
+    await vi.waitFor(() => expect(controls.at(-1)?.decisionLoading).toBe(false));
 
-    await expect(controller.submit("Live athlete")).resolves.toBeUndefined();
-    expect(states.at(-1)?.messages).toHaveLength(2);
+    await expect(controller.submit("Live athlete")).resolves.toBe(true);
+    await vi.waitFor(() => expect(states.at(-1)?.messages).toHaveLength(2));
 
     hydration.resolve(transcriptPage("turn-live"));
+    await starting;
     await vi.waitFor(() => {
       expect(states.at(-1)?.messages).toHaveLength(2);
       expect(states.at(-1)?.messages.every((message) => message.historical !== true)).toBe(true);
@@ -248,7 +298,8 @@ describe("chat controller transcript hydration", () => {
       client,
       readTranscriptPage: () => stale.promise,
     });
-    await controller.start();
+    const starting = controller.start();
+    await vi.waitFor(() => expect(states.at(-1)?.session.presence).toBe("present"));
 
     expect(controller.openNewConversation()).toBe(true);
     const resetting = controller.confirmNewConversation();
@@ -257,6 +308,7 @@ describe("chat controller transcript hydration", () => {
     expect(states.at(-1)?.messages).toEqual([]);
 
     stale.resolve(transcriptPage("turn-stale"));
+    await starting;
     await vi.waitFor(() => expect(states.at(-1)?.messages).toEqual([]));
   });
 

--- a/apps/desktop-renderer/tests/chat-queue-recovery.test.ts
+++ b/apps/desktop-renderer/tests/chat-queue-recovery.test.ts
@@ -1,0 +1,706 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ChatQueueRunResult,
+  ChatQueueSnapshot,
+  CoachTurnEventNotificationEnvelope,
+  TurnEvent,
+} from "@enduragent/coach-contract";
+import type { CoachClient, CoachClientCallOptions } from "@enduragent/coach-client";
+import {
+  CHAT_QUEUE_REMOVE_FAILURE_COPY,
+  createChatController,
+  type ChatViewControls,
+} from "../src/chat/controller.js";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
+import type { ChatState } from "../src/turn-state.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function notification(
+  method: "resumeChatQueue" | "runQueuedCommand" | "retryQueuedTurn",
+  event: TurnEvent,
+): CoachTurnEventNotificationEnvelope {
+  return {
+    jsonrpc: "2.0",
+    method: "coach.turnEvent",
+    params: { requestId: 1, requestMethod: method, turnId: event.turnId, event },
+  };
+}
+
+function deliver(
+  method: "resumeChatQueue" | "runQueuedCommand" | "retryQueuedTurn",
+  options: CoachClientCallOptions<"chat">,
+  event: TurnEvent,
+): void {
+  options.onNotificationEnvelope?.(notification(method, event));
+  options.onEvent?.(event);
+}
+
+function harness(client: CoachClient, canChat: () => boolean = () => true) {
+  const states: ChatState[] = [];
+  const controls: ChatViewControls[] = [];
+  const provider: DesktopCoachClientProvider = {
+    getClient: vi.fn(async () => client),
+    reconnect: vi.fn(async () => client),
+    close: vi.fn(async () => {}),
+  };
+  const controller = createChatController({
+    clients: provider,
+    view: {
+      render: (state, nextControls) => {
+        states.push(structuredClone(state));
+        if (nextControls !== undefined) controls.push(structuredClone(nextControls));
+      },
+    },
+    refreshTrainingContext: async () => {},
+    refreshSpend: async () => {},
+    canChat,
+  });
+  return { controller, states, controls };
+}
+
+describe("durable chat queue controller", () => {
+  it("projects neither a queue row nor athlete text before durable enqueue acknowledgment", async () => {
+    const enqueue = deferred<ChatQueueSnapshot>();
+    const run = deferred<ChatQueueRunResult>();
+    let runOptions: CoachClientCallOptions<"chat"> | undefined;
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method, _request, options) => {
+        if (method === "enqueueChatMessage") return enqueue.promise as never;
+        if (method === "resumeChatQueue") {
+          runOptions = options as CoachClientCallOptions<"chat">;
+          return run.promise as never;
+        }
+        if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+        if (method === "hasSession") return Promise.resolve({ hasSession: false }) as never;
+        if (method === "getChatQueue")
+          return Promise.resolve({ schemaVersion: 1, revision: 0, items: [] }) as never;
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(client);
+    await controller.start();
+    const submission = controller.submit("Hello");
+    await Promise.resolve();
+    expect(states.at(-1)?.queued).toEqual([]);
+    expect(states.at(-1)?.messages).toEqual([]);
+
+    enqueue.resolve({
+      schemaVersion: 1,
+      revision: 1,
+      items: [
+        {
+          queuedMessageId: "queued-1",
+          submissionId: "submission-1",
+          text: "Hello",
+          kind: "ordinary",
+          position: 0,
+          restored: false,
+        },
+      ],
+    });
+    await vi.waitFor(() => expect(runOptions).toBeDefined());
+    expect(states.at(-1)?.messages).toMatchObject([
+      { role: "athlete", text: "Hello" },
+      { role: "coach" },
+    ]);
+    expect(states.at(-1)?.queued).toHaveLength(1);
+
+    const start = { type: "turn-start", turnId: "turn-1", chatId: "desktop" } as const;
+    const final = { type: "final-text", turnId: "turn-1", text: "Hi" } as const;
+    deliver("resumeChatQueue", runOptions!, start);
+    expect(states.at(-1)?.queued).toEqual([]);
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+    deliver("resumeChatQueue", runOptions!, final);
+    runOptions!.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: {} });
+    run.resolve({
+      snapshot: { schemaVersion: 1, revision: 2, items: [] },
+      response: { text: "Hi" },
+    });
+    await submission;
+    await vi.waitFor(() => expect(states.at(-1)?.queued).toEqual([]));
+    expect(states.at(-1)?.queued).toEqual([]);
+    expect(states.at(-1)?.messages).toMatchObject([
+      { role: "athlete", text: "Hello" },
+      { role: "coach", text: "Hi", delivery: "complete" },
+    ]);
+  });
+
+  it("uses collision-resistant submission ids across renderer relaunches", async () => {
+    const submissionIds: string[] = [];
+    let revision = 0;
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn(async (method, request, options) => {
+        if (method === "enqueueChatMessage") {
+          const input = request as { submissionId: string; text: string };
+          submissionIds.push(input.submissionId);
+          revision += 1;
+          return {
+            schemaVersion: 1,
+            revision,
+            items: [
+              {
+                queuedMessageId: `queued-${revision}`,
+                submissionId: input.submissionId,
+                text: input.text,
+                kind: "ordinary",
+                position: 0,
+                restored: false,
+              },
+            ],
+          } as never;
+        }
+        if (method === "resumeChatQueue") {
+          (options as CoachClientCallOptions<"chat">).onTerminalEnvelope?.({
+            jsonrpc: "2.0",
+            id: revision,
+            result: {},
+          });
+          return {
+            snapshot: { schemaVersion: 1, revision, items: [] },
+          } as never;
+        }
+        if (method === "getCoachDecision") return { decision: null } as never;
+        if (method === "hasSession") return { hasSession: false } as never;
+        if (method === "getChatQueue") return { schemaVersion: 1, revision, items: [] } as never;
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const first = harness(client).controller;
+    await first.start();
+    await first.submit("First launch");
+    const second = harness(client).controller;
+    await second.start();
+    await second.submit("Second launch");
+    expect(submissionIds).toHaveLength(2);
+    expect(submissionIds[0]).not.toBe(submissionIds[1]);
+    expect(submissionIds.every((id) => /^[0-9a-f-]{36}$/u.test(id))).toBe(true);
+  });
+
+  it("holds restored commands for Run command and ignores stale snapshots", async () => {
+    const restored: ChatQueueSnapshot = {
+      schemaVersion: 1,
+      revision: 4,
+      items: [
+        {
+          queuedMessageId: "command-1",
+          submissionId: "submission-1",
+          text: "/review",
+          kind: "slash-command",
+          position: 0,
+          restored: true,
+        },
+      ],
+    };
+    const calls: string[] = [];
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn(async (method, _request, options) => {
+        calls.push(method);
+        if (method === "getCoachDecision") return { decision: null } as never;
+        if (method === "hasSession") return { hasSession: false } as never;
+        if (method === "getChatQueue") return restored as never;
+        if (method === "runQueuedCommand") {
+          const stream = options as CoachClientCallOptions<"chat">;
+          deliver("runQueuedCommand", stream, {
+            type: "turn-start",
+            turnId: "turn-2",
+            chatId: "desktop",
+          });
+          deliver("runQueuedCommand", stream, {
+            type: "final-text",
+            turnId: "turn-2",
+            text: "Review",
+          });
+          stream.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: {} });
+          return {
+            snapshot: { schemaVersion: 1, revision: 5, items: [] },
+            response: { text: "Review" },
+          } as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(client);
+    await controller.resume();
+    expect(calls).not.toContain("resumeChatQueue");
+    expect(states.at(-1)?.queued).toMatchObject([{ id: "command-1", restored: true }]);
+
+    await controller.runQueuedCommand("command-1");
+    expect(calls).toContain("runQueuedCommand");
+    expect(states.at(-1)?.queued).toEqual([]);
+  });
+
+  it("auto-resumes restored ordinary work and discards a blocked no-response run", async () => {
+    const queued: ChatQueueSnapshot = {
+      schemaVersion: 1,
+      revision: 1,
+      items: [
+        {
+          queuedMessageId: "queued-1",
+          submissionId: "submission-1",
+          text: "Restored",
+          kind: "ordinary",
+          position: 0,
+          restored: true,
+        },
+      ],
+    };
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn(async (method, _request, options) => {
+        if (method === "getCoachDecision") return { decision: null } as never;
+        if (method === "hasSession") return { hasSession: true } as never;
+        if (method === "getChatQueue") return queued as never;
+        if (method === "resumeChatQueue") {
+          (options as CoachClientCallOptions<"chat">).onTerminalEnvelope?.({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {},
+          });
+          return { snapshot: queued } as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(client);
+    await controller.start();
+    expect(vi.mocked(client.call).mock.calls.some(([method]) => method === "resumeChatQueue")).toBe(
+      true,
+    );
+    expect(states.at(-1)?.status).toBe("idle");
+    expect(states.at(-1)?.messages).toEqual([]);
+    expect(states.at(-1)?.queued).toMatchObject([{ text: "Restored" }]);
+  });
+
+  it("blocks Send after queue hydration fails and recovers through reconnect retry", async () => {
+    let queueReads = 0;
+    let enqueueCalls = 0;
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn(async (method, request, options) => {
+        if (method === "getCoachDecision") return { decision: null } as never;
+        if (method === "hasSession") return { hasSession: false } as never;
+        if (method === "getChatQueue") {
+          queueReads += 1;
+          if (queueReads === 1) throw new Error("transient queue read failure");
+          return { schemaVersion: 1, revision: 0, items: [] } as never;
+        }
+        if (method === "enqueueChatMessage") {
+          enqueueCalls += 1;
+          const input = request as { submissionId: string; text: string };
+          return {
+            schemaVersion: 1,
+            revision: 1,
+            items: [
+              {
+                queuedMessageId: "queued-1",
+                submissionId: input.submissionId,
+                text: input.text,
+                kind: "ordinary",
+                position: 0,
+                restored: false,
+              },
+            ],
+          } as never;
+        }
+        if (method === "resumeChatQueue") {
+          (options as CoachClientCallOptions<"chat">).onTerminalEnvelope?.({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {},
+          });
+          return { snapshot: { schemaVersion: 1, revision: 1, items: [] } } as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller } = harness(client);
+    await controller.start();
+    await expect(controller.submit("Blocked")).resolves.toBe(false);
+    expect(enqueueCalls).toBe(0);
+    await controller.retryDecision();
+    await expect(controller.submit("Allowed")).resolves.toBe(true);
+    expect(enqueueCalls).toBe(1);
+  });
+
+  it("keeps a queued row visible until durable removal is acknowledged", async () => {
+    const removal = deferred<ChatQueueSnapshot>();
+    const queued: ChatQueueSnapshot = {
+      schemaVersion: 1,
+      revision: 1,
+      items: [
+        {
+          queuedMessageId: "command-1",
+          submissionId: "submission-1",
+          text: "/review",
+          kind: "slash-command",
+          position: 0,
+          restored: true,
+        },
+      ],
+    };
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method) => {
+        if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+        if (method === "hasSession") return Promise.resolve({ hasSession: true }) as never;
+        if (method === "getChatQueue") return Promise.resolve(queued) as never;
+        if (method === "removeQueuedChatMessage") return removal.promise as never;
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(client);
+    await controller.start();
+
+    controller.removeQueued("command-1");
+    expect(states.at(-1)?.queued).toMatchObject([{ id: "command-1" }]);
+
+    removal.resolve({ schemaVersion: 1, revision: 2, items: [] });
+    await vi.waitFor(() => expect(states.at(-1)?.queued).toEqual([]));
+  });
+
+  it("keeps a queued row and reports visible feedback when durable removal fails", async () => {
+    const queued: ChatQueueSnapshot = {
+      schemaVersion: 1,
+      revision: 1,
+      items: [
+        {
+          queuedMessageId: "command-1",
+          submissionId: "submission-1",
+          text: "/review",
+          kind: "slash-command",
+          position: 0,
+          restored: true,
+        },
+      ],
+    };
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn(async (method) => {
+        if (method === "getCoachDecision") return { decision: null } as never;
+        if (method === "hasSession") return { hasSession: true } as never;
+        if (method === "getChatQueue") return queued as never;
+        if (method === "removeQueuedChatMessage") throw new Error("storage unavailable");
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states, controls } = harness(client);
+    await controller.start();
+
+    controller.removeQueued("command-1");
+    await vi.waitFor(() =>
+      expect(controls.at(-1)?.queueMutationError).toBe(CHAT_QUEUE_REMOVE_FAILURE_COPY),
+    );
+    expect(states.at(-1)?.queued).toMatchObject([{ id: "command-1" }]);
+  });
+
+  it("shows a message queued during streaming and dispatches it exactly once after success", async () => {
+    const firstRun = deferred<ChatQueueRunResult>();
+    const secondRun = deferred<ChatQueueRunResult>();
+    let firstOptions: CoachClientCallOptions<"chat"> | undefined;
+    let secondOptions: CoachClientCallOptions<"chat"> | undefined;
+    const first = {
+      queuedMessageId: "queued-1",
+      submissionId: "submission-1",
+      text: "First",
+      kind: "ordinary" as const,
+      position: 0,
+      restored: false,
+    };
+    const later = {
+      queuedMessageId: "queued-2",
+      submissionId: "submission-2",
+      text: "Later",
+      kind: "ordinary" as const,
+      position: 1,
+      restored: false,
+    };
+    let enqueueCount = 0;
+    let runCount = 0;
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method, _request, options) => {
+        if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+        if (method === "hasSession") return Promise.resolve({ hasSession: false }) as never;
+        if (method === "getChatQueue")
+          return Promise.resolve({ schemaVersion: 1, revision: 0, items: [] }) as never;
+        if (method === "enqueueChatMessage") {
+          enqueueCount += 1;
+          return Promise.resolve(
+            enqueueCount === 1
+              ? { schemaVersion: 1, revision: 1, items: [first] }
+              : { schemaVersion: 1, revision: 2, items: [first, later] },
+          ) as never;
+        }
+        if (method === "resumeChatQueue") {
+          runCount += 1;
+          if (runCount === 1) {
+            firstOptions = options as CoachClientCallOptions<"chat">;
+            return firstRun.promise as never;
+          }
+          secondOptions = options as CoachClientCallOptions<"chat">;
+          return secondRun.promise as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(client);
+    await controller.start();
+
+    await expect(controller.submit("First")).resolves.toBe(true);
+    await vi.waitFor(() => expect(firstOptions).toBeDefined());
+    deliver("resumeChatQueue", firstOptions!, {
+      type: "turn-start",
+      turnId: "turn-1",
+      chatId: "desktop",
+    });
+
+    await expect(controller.submit("Later")).resolves.toBe(true);
+    expect(states.at(-1)?.queued.map((item) => item.text)).toEqual(["Later"]);
+    expect(runCount).toBe(1);
+
+    deliver("resumeChatQueue", firstOptions!, {
+      type: "final-text",
+      turnId: "turn-1",
+      text: "First reply",
+    });
+    firstOptions!.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: {} });
+    firstRun.resolve({
+      snapshot: { schemaVersion: 1, revision: 3, items: [later] },
+      response: { text: "First reply" },
+    });
+
+    await vi.waitFor(() => expect(secondOptions).toBeDefined());
+    expect(runCount).toBe(2);
+    deliver("resumeChatQueue", secondOptions!, {
+      type: "turn-start",
+      turnId: "turn-2",
+      chatId: "desktop",
+    });
+    deliver("resumeChatQueue", secondOptions!, {
+      type: "final-text",
+      turnId: "turn-2",
+      text: "Later reply",
+    });
+    secondOptions!.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: {} });
+    secondRun.resolve({
+      snapshot: { schemaVersion: 1, revision: 4, items: [] },
+      response: { text: "Later reply" },
+    });
+
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("idle"));
+    expect(states.at(-1)?.queued).toEqual([]);
+    expect(states.at(-1)?.messages.map((message) => [message.role, message.text])).toEqual([
+      ["athlete", "First"],
+      ["coach", "First reply"],
+      ["athlete", "Later"],
+      ["coach", "Later reply"],
+    ]);
+    expect(
+      vi.mocked(client.call).mock.calls.filter(([method]) => method === "resumeChatQueue"),
+    ).toHaveLength(2);
+  });
+
+  it("keeps a claimed head hidden when enqueue acknowledges a full durable snapshot", async () => {
+    const run = deferred<ChatQueueRunResult>();
+    let options: CoachClientCallOptions<"chat"> | undefined;
+    const head = {
+      queuedMessageId: "queued-1",
+      submissionId: "submission-1",
+      text: "First",
+      kind: "ordinary" as const,
+      position: 0,
+      restored: true,
+    };
+    const later = {
+      queuedMessageId: "queued-2",
+      submissionId: "submission-2",
+      text: "Later",
+      kind: "ordinary" as const,
+      position: 1,
+      restored: false,
+    };
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method, _request, callOptions) => {
+        if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+        if (method === "hasSession") return Promise.resolve({ hasSession: true }) as never;
+        if (method === "getChatQueue")
+          return Promise.resolve({ schemaVersion: 1, revision: 1, items: [head] }) as never;
+        if (method === "resumeChatQueue") {
+          options = callOptions as CoachClientCallOptions<"chat">;
+          return run.promise as never;
+        }
+        if (method === "enqueueChatMessage")
+          return Promise.resolve({
+            schemaVersion: 1,
+            revision: 2,
+            items: [head, later],
+          }) as never;
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(client);
+    const active = controller.resume();
+    await vi.waitFor(() => expect(options).toBeDefined());
+    deliver("resumeChatQueue", options!, {
+      type: "turn-start",
+      turnId: "turn-1",
+      chatId: "desktop",
+    });
+    expect(states.at(-1)?.queued).toEqual([]);
+
+    await expect(controller.submit("Later")).resolves.toBe(true);
+    expect(states.at(-1)?.queued.map((item) => item.id)).toEqual(["queued-2"]);
+    expect(states.at(-1)?.activeQueueClaimIds).toEqual(["queued-1"]);
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+
+    deliver("resumeChatQueue", options!, {
+      type: "interrupted",
+      turnId: "turn-1",
+      chatId: "desktop",
+      text: "Partial",
+    });
+    options!.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: {} });
+    run.resolve({
+      snapshot: {
+        schemaVersion: 1,
+        revision: 3,
+        items: [head, later],
+        retryRequired: {
+          claimId: "claim-1",
+          queuedMessageIds: ["queued-1"],
+          turnId: "turn-1",
+          status: "retry-required",
+        },
+      },
+      response: { text: "Partial" },
+    });
+    await active;
+    expect(states.at(-1)?.queued.map((item) => item.id)).toEqual(["queued-1", "queued-2"]);
+    expect(states.at(-1)?.activeQueueClaimIds).toEqual([]);
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+  });
+
+  it("keeps later messages queued when Stop creates retry-required recovery", async () => {
+    const run = deferred<ChatQueueRunResult>();
+    let options: CoachClientCallOptions<"chat"> | undefined;
+    const items = [
+      {
+        queuedMessageId: "queued-1",
+        submissionId: "submission-1",
+        text: "First",
+        kind: "ordinary" as const,
+        position: 0,
+        restored: false,
+      },
+      {
+        queuedMessageId: "queued-2",
+        submissionId: "submission-2",
+        text: "/later",
+        kind: "slash-command" as const,
+        position: 1,
+        restored: true,
+      },
+    ];
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method, _request, callOptions) => {
+        if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+        if (method === "hasSession") return Promise.resolve({ hasSession: false }) as never;
+        if (method === "getChatQueue")
+          return Promise.resolve({ schemaVersion: 1, revision: 2, items }) as never;
+        if (method === "resumeChatQueue") {
+          options = callOptions as CoachClientCallOptions<"chat">;
+          deliver("resumeChatQueue", options, {
+            type: "turn-start",
+            turnId: "turn-3",
+            chatId: "desktop",
+          });
+          return run.promise as never;
+        }
+        if (method === "retryQueuedTurn") {
+          const retryOptions = callOptions as CoachClientCallOptions<"chat">;
+          deliver("retryQueuedTurn", retryOptions, {
+            type: "turn-start",
+            turnId: "turn-4",
+            chatId: "desktop",
+          });
+          deliver("retryQueuedTurn", retryOptions, {
+            type: "final-text",
+            turnId: "turn-4",
+            text: "Recovered",
+          });
+          retryOptions.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 4, result: {} });
+          return Promise.resolve({
+            snapshot: { schemaVersion: 1, revision: 6, items: [items[1]!] },
+            response: { text: "Recovered" },
+          }) as never;
+        }
+        if (method === "stopChat") {
+          const interrupted = {
+            type: "interrupted",
+            turnId: "turn-3",
+            chatId: "desktop",
+            text: "Partial",
+          } as const;
+          deliver("resumeChatQueue", options!, interrupted);
+          options!.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 3, result: {} });
+          run.resolve({
+            snapshot: {
+              schemaVersion: 1,
+              revision: 4,
+              items,
+              retryRequired: {
+                claimId: "claim-1",
+                queuedMessageIds: ["queued-1"],
+                turnId: "turn-3",
+                status: "retry-required",
+              },
+            },
+            response: { text: "Partial" },
+          });
+          return Promise.resolve({ stopped: true }) as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(client);
+    const active = controller.resume();
+    await vi.waitFor(() => expect(options).toBeDefined());
+    controller.stop();
+    await active;
+    expect(states.at(-1)?.status).toBe("interrupted");
+    expect(states.at(-1)?.queued.map((item) => item.text)).toEqual(["First", "/later"]);
+    expect(states.at(-1)?.retryRequired).toMatchObject({ claimId: "claim-1" });
+    expect(
+      vi.mocked(client.call).mock.calls.filter(([method]) => method === "resumeChatQueue"),
+    ).toHaveLength(1);
+
+    await controller.retryQueuedTurn("claim-1");
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")[0]?.text).toBe(
+      "First",
+    );
+    expect(states.at(-1)?.queued.map((item) => item.text)).toEqual(["/later"]);
+  });
+});

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -21,9 +21,11 @@ import { ChatView } from "../src/ui/chat/ChatView.js";
 
 function stubActions(): ChatActions {
   return {
-    submit: vi.fn(),
+    submit: vi.fn(async () => true),
     stop: vi.fn(),
     removeQueued: vi.fn(),
+    runQueuedCommand: vi.fn(),
+    retryQueuedTurn: vi.fn(),
     retry: vi.fn(),
     loadEarlier: vi.fn(),
     retryHydration: vi.fn(),
@@ -104,6 +106,26 @@ describe("chat surface", () => {
       onboarding: CLOSED_ONBOARDING,
     });
     resetChatStream();
+  });
+
+  it("preserves and focuses the draft after enqueue failure and clears only after acknowledgment", async () => {
+    const user = userEvent.setup();
+    let reject!: (error: Error) => void;
+    const failed = new Promise<boolean>((_resolve, fail) => {
+      reject = fail;
+    });
+    vi.mocked(actions.submit).mockReturnValueOnce(failed).mockResolvedValueOnce(true);
+    render(<Harness />);
+    const input = composer();
+    await user.type(input, "Keep this draft");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(input).toHaveValue("Keep this draft");
+    reject(new Error("durable enqueue failed"));
+    await waitFor(() => expect(input).toHaveFocus());
+    expect(input).toHaveValue("Keep this draft");
+
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => expect(input).toHaveValue(""));
   });
 
   describe("Coach decision", () => {
@@ -554,7 +576,7 @@ describe("chat surface", () => {
 
       expect(committed.defaultPrevented).toBe(true);
       expect(actions.submit).toHaveBeenCalledWith(draft);
-      expect(textarea).toHaveValue("");
+      await waitFor(() => expect(textarea).toHaveValue(""));
     });
 
     it("keeps Shift+Enter as a newline and ignores blank drafts", async () => {
@@ -630,7 +652,7 @@ describe("chat surface", () => {
       expect(strip()).toBeNull();
 
       setChat({
-        queued: [{ id: "queued-1", text: "And my long ride?", command: false }],
+        queued: [{ id: "queued-1", text: "And my long ride?", command: false, restored: false }],
       });
 
       expect(strip()).not.toBeNull();
@@ -643,8 +665,8 @@ describe("chat surface", () => {
       render(<Harness />);
       setChat({
         queued: [
-          { id: "queued-1", text: "And my long ride?", command: false },
-          { id: "queued-2", text: "/status", command: true },
+          { id: "queued-1", text: "And my long ride?", command: false, restored: false },
+          { id: "queued-2", text: "/status", command: true, restored: false },
         ],
       });
 
@@ -656,12 +678,80 @@ describe("chat surface", () => {
       expect(actions.removeQueued).toHaveBeenNthCalledWith(2, "queued-1");
     });
 
+    it("runs only restored commands and offers durable recovery without a second retry", async () => {
+      const user = userEvent.setup();
+      render(<Harness />);
+      setChat({
+        interrupted: true,
+        queued: [
+          { id: "queued-1", text: "Try this again", command: false, restored: true },
+          { id: "queued-2", text: "/status", command: true, restored: true },
+        ],
+        retryRequired: {
+          claimId: "claim-1",
+          queuedMessageIds: ["queued-1"],
+          turnId: "turn-1",
+          status: "retry-required",
+        },
+      });
+
+      expect(screen.getByRole("button", { name: "Retry interrupted message" })).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Remove queued message 1" })).toBeDisabled();
+      const ordinaryRetry = document.querySelector(".chat-retry");
+      expect(ordinaryRetry).toBeInstanceOf(HTMLButtonElement);
+      expect((ordinaryRetry as HTMLButtonElement).hidden).toBe(true);
+      await user.click(screen.getByRole("button", { name: "Retry interrupted message" }));
+      expect(actions.retryQueuedTurn).toHaveBeenCalledWith("claim-1");
+
+      setChat({ interrupted: false, retryRequired: null });
+      await user.click(screen.getByRole("button", { name: "Run command" }));
+      expect(actions.runQueuedCommand).toHaveBeenCalledWith("queued-2");
+    });
+
+    it("wraps long rows, announces queue changes, and shows removal feedback", () => {
+      render(<Harness />);
+      setChat({
+        queued: [
+          {
+            id: "queued-1",
+            text: "This is a very long queued question that must wrap on compact and wide layouts without hiding its actions",
+            command: false,
+            restored: false,
+          },
+          { id: "queued-2", text: "/status", command: true, restored: true },
+        ],
+        queueMutationError: "We couldn’t remove that saved message. Try again.",
+      });
+
+      expect(
+        screen.getByRole("region", { name: "Queued messages, 2 queued messages" }),
+      ).toBeVisible();
+      const live = strip()?.querySelector('[role="status"][aria-live="polite"]');
+      expect(live).toHaveTextContent("2 queued messages");
+      expect(document.querySelector(".chat-queue__text")).toHaveClass(
+        "whitespace-pre-wrap",
+        "break-words",
+      );
+      expect(document.querySelector(".chat-queue__text")).not.toHaveClass("truncate");
+      expect(strip()).toHaveClass("rounded-card", "shadow-elev-2");
+      expect(screen.getByRole("heading", { name: "Queued messages" })).toHaveClass(
+        "text-xs",
+        "font-semibold",
+      );
+      expect(document.querySelector(".chat-queue__item")).toHaveClass("flex-wrap", "items-center");
+      expect(screen.getByRole("button", { name: "Run command" })).toHaveClass("text-xs");
+      expect(screen.getByRole("button", { name: "Remove queued message 1" })).toHaveClass(
+        "text-xs",
+      );
+      expect(screen.getByText("We couldn’t remove that saved message. Try again.")).toBeVisible();
+    });
+
     it("marks queued commands without restoring the legacy monospace face", () => {
       render(<Harness />);
       setChat({
         queued: [
-          { id: "queued-1", text: "And my long ride?", command: false },
-          { id: "queued-2", text: "/status", command: true },
+          { id: "queued-1", text: "And my long ride?", command: false, restored: false },
+          { id: "queued-2", text: "/status", command: true, restored: false },
         ],
       });
 
@@ -677,7 +767,7 @@ describe("chat surface", () => {
       const user = userEvent.setup();
       render(<Harness />);
       setChat({
-        queued: [{ id: "queued-1", text: "And my long ride?", command: false }],
+        queued: [{ id: "queued-1", text: "And my long ride?", command: false, restored: false }],
         workBlocked: true,
       });
 
@@ -692,7 +782,9 @@ describe("chat surface", () => {
         useEnduragentStore.setState({ chatActions: null });
       });
       render(<Harness />);
-      setChat({ queued: [{ id: "queued-1", text: "And my long ride?", command: false }] });
+      setChat({
+        queued: [{ id: "queued-1", text: "And my long ride?", command: false, restored: false }],
+      });
 
       const remove = screen.getByRole("button", { name: "Remove queued message 1" });
       expect(remove).toBeDisabled();

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -57,6 +57,8 @@ function stubActions(): ChatActions {
     submit: vi.fn(),
     stop: vi.fn(),
     removeQueued: vi.fn(),
+    runQueuedCommand: vi.fn(),
+    retryQueuedTurn: vi.fn(),
     retry: vi.fn(),
     loadEarlier: vi.fn(),
     retryHydration: vi.fn(),

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -22,6 +22,8 @@ function stubActions(): ChatActions {
     submit: vi.fn(),
     stop: vi.fn(),
     removeQueued: vi.fn(),
+    runQueuedCommand: vi.fn(),
+    retryQueuedTurn: vi.fn(),
     retry: vi.fn(),
     loadEarlier: vi.fn(),
     retryHydration: vi.fn(),

--- a/apps/desktop-renderer/tests/turn-state.test.ts
+++ b/apps/desktop-renderer/tests/turn-state.test.ts
@@ -30,6 +30,75 @@ function queued(state: ChatState, ...texts: readonly string[]): ChatState {
 }
 
 describe("desktop turn state", () => {
+  it("keeps an active durable claim hidden across newer queue snapshots", () => {
+    const item = (id: string, position: number) => ({
+      queuedMessageId: id,
+      submissionId: `submission-${id}`,
+      text: id,
+      kind: "ordinary" as const,
+      position,
+      restored: false,
+    });
+    let state = reduceChatState(EMPTY_CHAT_STATE, {
+      type: "queue-snapshot",
+      snapshot: { schemaVersion: 1, revision: 1, items: [item("head", 0)] },
+    });
+    state = reduceChatState(state, { type: "queue-claimed", ids: ["head"] });
+    state = reduceChatState(state, {
+      type: "queue-snapshot",
+      snapshot: { schemaVersion: 1, revision: 2, items: [item("head", 0), item("later", 1)] },
+    });
+    expect(state.queued.map(({ id }) => id)).toEqual(["later"]);
+    expect(state.activeQueueClaimIds).toEqual(["head"]);
+
+    state = reduceChatState(state, {
+      type: "queue-snapshot",
+      snapshot: {
+        schemaVersion: 1,
+        revision: 3,
+        items: [item("head", 0), item("later", 1)],
+        retryRequired: {
+          claimId: "claim-1",
+          queuedMessageIds: ["head"],
+          turnId: "turn-1",
+          status: "retry-required",
+        },
+      },
+    });
+    expect(state.queued.map(({ id }) => id)).toEqual(["head", "later"]);
+    expect(state.activeQueueClaimIds).toEqual([]);
+  });
+
+  it("ignores an equal queue revision after successful reset", () => {
+    const snapshot = {
+      schemaVersion: 1 as const,
+      revision: 2,
+      items: [
+        {
+          queuedMessageId: "queued-1",
+          submissionId: "submission-1",
+          text: "Later",
+          kind: "ordinary" as const,
+          position: 0,
+          restored: false,
+        },
+      ],
+    };
+    const queuedState = reduceChatState(EMPTY_CHAT_STATE, { type: "queue-snapshot", snapshot });
+    const resetting = {
+      ...queuedState,
+      session: {
+        ...queuedState.session,
+        presence: "present" as const,
+        resetPhase: "resetting" as const,
+      },
+    };
+    const reset = reduceChatState(resetting, {
+      type: "reset-succeeded",
+      announcement: "Done",
+    });
+    expect(reduceChatState(reset, { type: "queue-snapshot", snapshot }).queued).toEqual([]);
+  });
   it("owns the one desktop conversation identity", () => {
     expect(DESKTOP_CHAT_ID).toBe("desktop");
   });

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -162,6 +162,20 @@ function makeScript(
   let units: "metric" | "imperial" = "metric";
   let hasSession = false;
   let lastSynced: string = athleteState.lastSynced;
+  let queueRevision = 0;
+  let queueItems: Array<{
+    queuedMessageId: string;
+    submissionId: string;
+    text: string;
+    kind: "ordinary" | "slash-command";
+    position: number;
+    restored: boolean;
+  }> = [];
+  const queueSnapshot = () => ({
+    schemaVersion: 1 as const,
+    revision: queueRevision,
+    items: queueItems,
+  });
   return {
     onRequest(value) {
       const request = value as ScriptRequest;
@@ -359,7 +373,31 @@ function makeScript(
         units = (request.params as { readonly value: "metric" | "imperial" }).value;
         return response({ value: units, source: "cycling" });
       }
-      if (request.method === "chat") {
+      if (request.method === "getChatQueue") return response(queueSnapshot());
+      if (request.method === "enqueueChatMessage") {
+        const params = request.params as { readonly submissionId: string; readonly text: string };
+        if (!queueItems.some((item) => item.submissionId === params.submissionId)) {
+          queueRevision += 1;
+          queueItems.push({
+            queuedMessageId: `queued-${queueRevision}`,
+            submissionId: params.submissionId,
+            text: params.text,
+            kind: params.text.trimStart().startsWith("/") ? "slash-command" : "ordinary",
+            position: queueItems.length,
+            restored: false,
+          });
+        }
+        return response(queueSnapshot());
+      }
+      if (request.method === "removeQueuedChatMessage") {
+        const id = (request.params as { readonly queuedMessageId: string }).queuedMessageId;
+        queueItems = queueItems
+          .filter((item) => item.queuedMessageId !== id)
+          .map((item, position) => ({ ...item, position }));
+        queueRevision += 1;
+        return response(queueSnapshot());
+      }
+      if (request.method === "resumeChatQueue") {
         hasSession = true;
         const firstDelta = "## Today’s ride\n\nHold   **ste";
         const finalText = `${firstDelta}ady**.
@@ -376,6 +414,7 @@ ${"nonwrapping".repeat(36)}
 
 [Guide](https://example.test/guide)`;
         return [
+          JSON.stringify({ type: "turn-start", turnId: "turn-fixture", chatId: "desktop" }),
           JSON.stringify({
             type: "text_delta",
             turnId: "turn-fixture",
@@ -387,7 +426,13 @@ ${"nonwrapping".repeat(36)}
             delta: finalText.slice(firstDelta.length),
           }),
           JSON.stringify({ type: "final-text", turnId: "turn-fixture", text: finalText }),
-          JSON.stringify({ text: finalText }),
+          JSON.stringify(
+            (() => {
+              queueItems = [];
+              queueRevision += 1;
+              return { snapshot: queueSnapshot(), response: { text: finalText } };
+            })(),
+          ),
         ];
       }
       if (request.method === "hasSession") return response({ hasSession });
@@ -440,6 +485,8 @@ ${"nonwrapping".repeat(36)}
       }
       if (request.method === "resetSession") {
         hasSession = false;
+        queueItems = [];
+        queueRevision += 1;
         return response({ memoryFlushed: true });
       }
       if (request.method === "sync") {
@@ -745,7 +792,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       athleteRows: 0,
       quickActionClicks: 0,
     });
-    expect(calls.filter((call) => call.method === "chat")).toHaveLength(0);
+    expect(calls.filter((call) => call.method === "enqueueChatMessage")).toHaveLength(0);
 
     const committedMessage = "回復走を30分します。";
     const committedEnter = await fixture.evaluate<{
@@ -765,7 +812,6 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         quickAction.addEventListener("click", recordQuickActionClick);
       }
       textarea.value = ${JSON.stringify(committedMessage)};
-      const conversation = document.querySelector(".conversation");
       const event = new KeyboardEvent("keydown", {
         key: "Enter",
         bubbles: true,
@@ -773,7 +819,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       });
       const dispatchResult = textarea.dispatchEvent(event);
       const deadline = Date.now() + 5000;
-      while (conversation.dataset.chatStatus === "streaming" && Date.now() < deadline) {
+      while (
+        document.querySelectorAll(".chat-message--athlete").length === 0 &&
+        Date.now() < deadline
+      ) {
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
       for (const quickAction of quickActions) {
@@ -796,12 +845,19 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       athleteMessages: [committedMessage],
       quickActionClicks: 0,
     });
-    expect(calls.filter((call) => call.method === "chat")).toEqual([
+    expect(calls.filter((call) => call.method === "enqueueChatMessage")).toEqual([
       {
         jsonrpc: "2.0",
-        method: "chat",
-        params: { chatId: "desktop", message: committedMessage },
+        method: "enqueueChatMessage",
+        params: {
+          chatId: "desktop",
+          submissionId: expect.stringMatching(/^[0-9a-f-]{36}$/u),
+          text: committedMessage,
+        },
       },
+    ]);
+    expect(calls.filter((call) => call.method === "resumeChatQueue")).toEqual([
+      { jsonrpc: "2.0", method: "resumeChatQueue", params: { chatId: "desktop" } },
     ]);
   }, 90_000);
 
@@ -922,14 +978,24 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       });
       textarea.dispatchEvent(streamingEnter);
       const streamingEnterHandled = streamingEnter.defaultPrevented;
-      const streamingDraftCleared = textarea.value === "";
       const streamingFocusPreserved = document.activeElement === textarea;
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      const queueDeadline = Date.now() + 5000;
+      while (
+        (textarea.value !== "" ||
+          document.querySelector(".chat-queue__text")?.textContent !== "How should I recover?") &&
+        Date.now() < queueDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const streamingDraftCleared = textarea.value === "";
       const streamingQueued = [...document.querySelectorAll(".chat-queue__text")].map(
         (node) => node.textContent,
       );
       document.querySelector(".chat-queue__remove")?.click();
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      const removalDeadline = Date.now() + 5000;
+      while (document.querySelector(".chat-queue") && Date.now() < removalDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
       const streamingQueueCleared = document.querySelector(".chat-queue") === null;
       textarea.value = "How should I recover?";
       textarea.dispatchEvent(new Event("input", { bubbles: true }));
@@ -1583,12 +1649,28 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     expect(
       calls.slice(syncCallIndex + 1).filter((call) => call.method === "getAthleteState"),
     ).toHaveLength(1);
-    expect(calls.filter((call) => call.method === "chat")).toEqual([
+    expect(calls.filter((call) => call.method === "enqueueChatMessage")).toEqual([
       {
         jsonrpc: "2.0",
-        method: "chat",
-        params: { chatId: "desktop", message: "What should I ride?" },
+        method: "enqueueChatMessage",
+        params: {
+          chatId: "desktop",
+          submissionId: expect.stringMatching(/^[0-9a-f-]{36}$/u),
+          text: "What should I ride?",
+        },
       },
+      {
+        jsonrpc: "2.0",
+        method: "enqueueChatMessage",
+        params: {
+          chatId: "desktop",
+          submissionId: expect.stringMatching(/^[0-9a-f-]{36}$/u),
+          text: "How should I recover?",
+        },
+      },
+    ]);
+    expect(calls.filter((call) => call.method === "resumeChatQueue")).toEqual([
+      { jsonrpc: "2.0", method: "resumeChatQueue", params: { chatId: "desktop" } },
     ]);
     expect(calls.filter((call) => call.method === "setUnitsPreference")).toEqual([
       { jsonrpc: "2.0", method: "setUnitsPreference", params: { value: "imperial" } },

--- a/apps/desktop/tests/fixtures/windows-parity/chat-settings.scenarios.json
+++ b/apps/desktop/tests/fixtures/windows-parity/chat-settings.scenarios.json
@@ -41,21 +41,24 @@
       "surface": "chat",
       "expected": "A message sent during streaming is shown as queued and dispatches exactly once after the active turn succeeds.",
       "automation": "deterministic",
-      "test": "apps/desktop-renderer/tests/chat-controller.test.ts > queues a message sent while the coach streams and dispatches it once the turn settles"
+      "test": "apps/desktop-renderer/tests/chat-queue-recovery.test.ts > shows a message queued during streaming and dispatches it exactly once after success"
     },
     {
       "id": "chat.queue.coalescing",
       "surface": "chat",
       "expected": "Queued free text coalesces into one next turn while each queued slash command remains its own turn.",
       "automation": "deterministic",
-      "test": "apps/desktop-renderer/tests/chat-controller.test.ts > coalesces queued free text into one turn and keeps each command on its own turn"
+      "test": "packages/engine/tests/chat-queue.test.ts > groups consecutive ordinary messages and stops at a command barrier"
     },
     {
       "id": "chat.queue.hold-and-remove",
       "surface": "chat",
       "expected": "Queued messages remain held after a failed or interrupted turn and each queued item can be removed before dispatch.",
       "automation": "deterministic",
-      "test": "apps/desktop-renderer/tests/chat-controller.test.ts > keeps a queued message un-drained after a failed turn and removes it on request"
+      "tests": [
+        "packages/engine/tests/chat-queue.test.ts > Stop marks only the active claim retry-required and never drains the command behind it",
+        "packages/core/tests/chat-queue-store.test.ts > removes every unclaimed item by stable identity before dispatch"
+      ]
     },
     {
       "id": "chat.commands.slash-picker",

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -237,6 +237,46 @@ export async function launchDesktopFixture(input: {
       }
       return finalFrame(frames) as Awaited<ReturnType<CoachEngine["chat"]>>;
     },
+    async stopChat(request) {
+      return finalFrame(await invoke("stopChat", request)) as Awaited<
+        ReturnType<NonNullable<CoachEngine["stopChat"]>>
+      >;
+    },
+    async enqueueChatMessage(request) {
+      return finalFrame(await invoke("enqueueChatMessage", request)) as Awaited<
+        ReturnType<NonNullable<CoachEngine["enqueueChatMessage"]>>
+      >;
+    },
+    async getChatQueue(request) {
+      return finalFrame(await invoke("getChatQueue", request)) as Awaited<
+        ReturnType<NonNullable<CoachEngine["getChatQueue"]>>
+      >;
+    },
+    async removeQueuedChatMessage(request) {
+      return finalFrame(await invoke("removeQueuedChatMessage", request)) as Awaited<
+        ReturnType<NonNullable<CoachEngine["removeQueuedChatMessage"]>>
+      >;
+    },
+    async resumeChatQueue(request, onEvent) {
+      const frames = await invoke("resumeChatQueue", request);
+      for (const event of eventFrames(frames)) {
+        onEvent?.(event as TurnEvent);
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 40));
+      }
+      return finalFrame(frames) as Awaited<ReturnType<NonNullable<CoachEngine["resumeChatQueue"]>>>;
+    },
+    async runQueuedCommand(request, onEvent) {
+      const frames = await invoke("runQueuedCommand", request);
+      for (const event of eventFrames(frames)) onEvent?.(event as TurnEvent);
+      return finalFrame(frames) as Awaited<
+        ReturnType<NonNullable<CoachEngine["runQueuedCommand"]>>
+      >;
+    },
+    async retryQueuedTurn(request, onEvent) {
+      const frames = await invoke("retryQueuedTurn", request);
+      for (const event of eventFrames(frames)) onEvent?.(event as TurnEvent);
+      return finalFrame(frames) as Awaited<ReturnType<NonNullable<CoachEngine["retryQueuedTurn"]>>>;
+    },
     async getCoachDecision(request) {
       return finalFrame(await invoke("getCoachDecision", request)) as Awaited<
         ReturnType<CoachEngine["getCoachDecision"]>

--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -38,6 +38,20 @@ interface FixtureIntake {
 function makeScript(): DesktopFixtureScript {
   let savedIntake: FixtureIntake | null = null;
   let durableTrainingData = true;
+  let queueRevision = 0;
+  let queueItems: Array<{
+    queuedMessageId: string;
+    submissionId: string;
+    text: string;
+    kind: "ordinary" | "slash-command";
+    position: number;
+    restored: boolean;
+  }> = [];
+  const queueSnapshot = () => ({
+    schemaVersion: 1 as const,
+    revision: queueRevision,
+    items: queueItems,
+  });
   return {
     onRequest(value) {
       const request = value as ScriptRequest;
@@ -100,7 +114,10 @@ function makeScript(): DesktopFixtureScript {
           published: true,
           referenceSucceeded: true,
           requests: { store: 1, reference: 1, total: 2 },
-          droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+          droppedActivities: {
+            overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+            recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+          },
         });
       }
       if (request.method === "getAthleteState") {
@@ -151,6 +168,36 @@ function makeScript(): DesktopFixtureScript {
       }
       if (request.method === "hasSession") {
         return response({ hasSession: false });
+      }
+      if (request.method === "getCoachDecision") return response({ decision: null });
+      if (request.method === "getChatQueue") return response(queueSnapshot());
+      if (request.method === "enqueueChatMessage") {
+        const params = request.params as { readonly submissionId: string; readonly text: string };
+        if (!queueItems.some((item) => item.submissionId === params.submissionId)) {
+          queueRevision += 1;
+          queueItems.push({
+            queuedMessageId: `queued-${queueRevision}`,
+            submissionId: params.submissionId,
+            text: params.text,
+            kind: params.text.trimStart().startsWith("/") ? "slash-command" : "ordinary",
+            position: queueItems.length,
+            restored: false,
+          });
+        }
+        return response(queueSnapshot());
+      }
+      if (request.method === "removeQueuedChatMessage") {
+        const id = (request.params as { readonly queuedMessageId: string }).queuedMessageId;
+        queueItems = queueItems
+          .filter((item) => item.queuedMessageId !== id)
+          .map((item, position) => ({ ...item, position }));
+        queueRevision += 1;
+        return response(queueSnapshot());
+      }
+      if (request.method === "resumeChatQueue") {
+        queueItems = [];
+        queueRevision += 1;
+        return response({ snapshot: queueSnapshot() });
       }
       throw new TypeError(`unexpected fixture request: ${request.method}`);
     },

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -115,6 +115,20 @@ function script(calls: ScriptRequest[], initial: "reached" | "complete") {
   let cap = 0.5;
   let complete = initial === "complete";
   let spendAvailable = true;
+  let queueRevision = 0;
+  let queueItems: Array<{
+    queuedMessageId: string;
+    submissionId: string;
+    text: string;
+    kind: "ordinary" | "slash-command";
+    position: number;
+    restored: boolean;
+  }> = [];
+  const queueSnapshot = () => ({
+    schemaVersion: 1 as const,
+    revision: queueRevision,
+    items: queueItems,
+  });
   const fixture: DesktopFixtureScript = {
     onRequest(value) {
       const request = value as ScriptRequest;
@@ -152,11 +166,38 @@ function script(calls: ScriptRequest[], initial: "reached" | "complete") {
       if (request.method === "setUnitsPreference") {
         return response({ value: "metric", source: "cycling" });
       }
-      if (request.method === "chat") {
+      if (request.method === "getChatQueue") return response(queueSnapshot());
+      if (request.method === "enqueueChatMessage") {
+        const params = request.params as { readonly submissionId: string; readonly text: string };
+        if (!queueItems.some((item) => item.submissionId === params.submissionId)) {
+          queueRevision += 1;
+          queueItems.push({
+            queuedMessageId: `queued-${queueRevision}`,
+            submissionId: params.submissionId,
+            text: params.text,
+            kind: params.text.trimStart().startsWith("/") ? "slash-command" : "ordinary",
+            position: queueItems.length,
+            restored: false,
+          });
+        }
+        return response(queueSnapshot());
+      }
+      if (request.method === "removeQueuedChatMessage") {
+        const id = (request.params as { readonly queuedMessageId: string }).queuedMessageId;
+        queueItems = queueItems
+          .filter((item) => item.queuedMessageId !== id)
+          .map((item, position) => ({ ...item, position }));
+        queueRevision += 1;
+        return response(queueSnapshot());
+      }
+      if (request.method === "resumeChatQueue") {
+        queueItems = [];
+        queueRevision += 1;
         return [
+          JSON.stringify({ type: "turn-start", turnId: "turn-spend", chatId: "desktop" }),
           JSON.stringify({ type: "text_delta", turnId: "turn-spend", delta: "Keep " }),
           JSON.stringify({ type: "final-text", turnId: "turn-spend", text: "Keep riding." }),
-          JSON.stringify({ text: "Keep riding." }),
+          JSON.stringify({ snapshot: queueSnapshot(), response: { text: "Keep riding." } }),
         ];
       }
       if (request.method === "sync") {
@@ -355,7 +396,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
     expect(desktop.composerInputDisabled).toBe(false);
     expect(desktop.submitDisabled).toBe(false);
     expect(desktop.final).toBe("Keep riding.");
-    expect(calls.filter((call) => call.method === "chat")).toHaveLength(1);
+    expect(calls.filter((call) => call.method === "enqueueChatMessage")).toHaveLength(1);
+    expect(calls.filter((call) => call.method === "resumeChatQueue")).toHaveLength(1);
     await vi.waitFor(() =>
       expect(calls.filter((call) => call.method === "getSpendSummary").length).toBeGreaterThan(1),
     );
@@ -529,6 +571,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       return document.querySelector("[data-spend-meter]").textContent;
     `);
     expect(stale).toContain("Spend data may be out of date.");
-    expect(calls.filter((call) => call.method === "chat")).toHaveLength(1);
+    expect(calls.filter((call) => call.method === "enqueueChatMessage")).toHaveLength(1);
+    expect(calls.filter((call) => call.method === "resumeChatQueue")).toHaveLength(1);
   }, 60_000);
 });

--- a/apps/desktop/tests/windows-parity-scenarios.test.ts
+++ b/apps/desktop/tests/windows-parity-scenarios.test.ts
@@ -100,6 +100,7 @@ describe("Windows parity scenario manifests", () => {
         scenario.automation === "deterministic" && "tests" in scenario ? [scenario.id] : [],
       ),
     ).toEqual([
+      "chat.queue.hold-and-remove",
       "settings.providers.chatgpt-sign-in",
       "settings.providers.chatgpt-refusals",
       "settings.providers.claude-readiness",

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -112,6 +112,12 @@ interface OutboundFrame {
 const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   chat: 11 * 60_000,
   stopChat: 10_000,
+  enqueueChatMessage: 30_000,
+  getChatQueue: 30_000,
+  removeQueuedChatMessage: 30_000,
+  resumeChatQueue: 11 * 60_000,
+  runQueuedCommand: 11 * 60_000,
+  retryQueuedTurn: 11 * 60_000,
   getCoachDecision: 30_000,
   answerCoachDecision: 11 * 60_000,
   skipCoachDecision: 30_000,

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -44,7 +44,13 @@ const telegramControlSnapshot = {
 
 const rpcDeadlineCases = [
   ["chat", { chatId: "chat-1", message: "deadline" }, 660_000],
-  ["stopChat", { chatId: "chat-1" }, 10_000],
+  ["stopChat", { chatId: "chat-1", turnId: "turn-1" }, 10_000],
+  ["enqueueChatMessage", { chatId: "chat-1", submissionId: "submission-1", text: "Hello" }, 30_000],
+  ["getChatQueue", { chatId: "chat-1" }, 30_000],
+  ["removeQueuedChatMessage", { chatId: "chat-1", queuedMessageId: "queued-1" }, 30_000],
+  ["resumeChatQueue", { chatId: "chat-1" }, 660_000],
+  ["runQueuedCommand", { chatId: "chat-1", queuedMessageId: "queued-1" }, 660_000],
+  ["retryQueuedTurn", { chatId: "chat-1", claimId: "claim-1" }, 660_000],
   ["getCoachDecision", { chatId: "chat-1" }, 30_000],
   [
     "answerCoachDecision",
@@ -805,6 +811,12 @@ describe("RPC receive and observers", () => {
       const results = {
         chat: { text: "answer" },
         stopChat: { stopped: true },
+        enqueueChatMessage: { schemaVersion: 1, revision: 1, items: [] },
+        getChatQueue: { schemaVersion: 1, revision: 1, items: [] },
+        removeQueuedChatMessage: { schemaVersion: 1, revision: 2, items: [] },
+        resumeChatQueue: { snapshot: { schemaVersion: 1, revision: 2, items: [] } },
+        runQueuedCommand: { snapshot: { schemaVersion: 1, revision: 2, items: [] } },
+        retryQueuedTurn: { snapshot: { schemaVersion: 1, revision: 2, items: [] } },
         getCoachDecision: { decision: { ...decision, status: "unanswered" } },
         answerCoachDecision: { decision: completedDecision },
         skipCoachDecision: { decision: { ...decision, status: "skipped" } },
@@ -1018,7 +1030,9 @@ describe("RPC receive and observers", () => {
     await expect(client.call("chat", { chatId: "chat-1", message: "hello" })).resolves.toEqual({
       text: "answer",
     });
-    await expect(client.call("stopChat", { chatId: "chat-1" })).resolves.toEqual({
+    await expect(
+      client.call("stopChat", { chatId: "chat-1", turnId: "turn-1" }),
+    ).resolves.toEqual({
       stopped: true,
     });
     await expect(client.call("resetSession", { chatId: "chat-1" })).resolves.toEqual({

--- a/packages/coach-contract/src/chat-queue.ts
+++ b/packages/coach-contract/src/chat-queue.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import { ChatResponseSchema } from "./engine.js";
+
+export const QueuedChatMessageSchema = z
+  .object({
+    queuedMessageId: z.string().min(1),
+    submissionId: z.string().min(1),
+    text: z.string().refine((value) => /\S/u.test(value)),
+    kind: z.enum(["ordinary", "slash-command"]),
+    position: z.number().int().nonnegative(),
+    restored: z.boolean(),
+  })
+  .strict();
+export type QueuedChatMessage = z.infer<typeof QueuedChatMessageSchema>;
+
+export const ChatQueueRecoveryClaimSchema = z
+  .object({
+    claimId: z.string().min(1),
+    queuedMessageIds: z.array(z.string().min(1)).min(1),
+    turnId: z.string().min(1),
+    status: z.literal("retry-required"),
+  })
+  .strict();
+export type ChatQueueRecoveryClaim = z.infer<typeof ChatQueueRecoveryClaimSchema>;
+
+export const ChatQueueSnapshotSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    revision: z.number().int().nonnegative(),
+    items: z.array(QueuedChatMessageSchema),
+    retryRequired: ChatQueueRecoveryClaimSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const ids = new Set<string>();
+    const submissions = new Set<string>();
+    value.items.forEach((item, index) => {
+      if (item.position !== index) {
+        context.addIssue({
+          code: "custom",
+          path: ["items", index, "position"],
+          message: "queue position must match FIFO order",
+        });
+      }
+      if (ids.has(item.queuedMessageId)) {
+        context.addIssue({
+          code: "custom",
+          path: ["items", index, "queuedMessageId"],
+          message: "queued message ids must be unique",
+        });
+      }
+      if (submissions.has(item.submissionId)) {
+        context.addIssue({
+          code: "custom",
+          path: ["items", index, "submissionId"],
+          message: "submission ids must be unique",
+        });
+      }
+      ids.add(item.queuedMessageId);
+      submissions.add(item.submissionId);
+    });
+    if (value.retryRequired !== undefined) {
+      const expected = value.items
+        .slice(0, value.retryRequired.queuedMessageIds.length)
+        .map((item) => item.queuedMessageId);
+      if (
+        expected.length !== value.retryRequired.queuedMessageIds.length ||
+        expected.some((id, index) => id !== value.retryRequired?.queuedMessageIds[index])
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["retryRequired", "queuedMessageIds"],
+          message: "retry claim must own an exact queue-head prefix",
+        });
+      }
+    }
+  });
+export type ChatQueueSnapshot = z.infer<typeof ChatQueueSnapshotSchema>;
+
+export const EnqueueChatMessageRequestSchema = z
+  .object({
+    chatId: z.string().min(1),
+    submissionId: z.string().min(1),
+    text: z.string().refine((value) => /\S/u.test(value)),
+  })
+  .strict();
+export type EnqueueChatMessageRequest = z.infer<typeof EnqueueChatMessageRequestSchema>;
+
+export const GetChatQueueRequestSchema = z.object({ chatId: z.string().min(1) }).strict();
+export type GetChatQueueRequest = z.infer<typeof GetChatQueueRequestSchema>;
+
+export const RemoveQueuedChatMessageRequestSchema = z
+  .object({ chatId: z.string().min(1), queuedMessageId: z.string().min(1) })
+  .strict();
+export type RemoveQueuedChatMessageRequest = z.infer<typeof RemoveQueuedChatMessageRequestSchema>;
+
+export const ResumeChatQueueRequestSchema = GetChatQueueRequestSchema;
+export type ResumeChatQueueRequest = z.infer<typeof ResumeChatQueueRequestSchema>;
+
+export const RunQueuedCommandRequestSchema = z
+  .object({ chatId: z.string().min(1), queuedMessageId: z.string().min(1) })
+  .strict();
+export type RunQueuedCommandRequest = z.infer<typeof RunQueuedCommandRequestSchema>;
+
+export const RetryQueuedTurnRequestSchema = z
+  .object({ chatId: z.string().min(1), claimId: z.string().min(1) })
+  .strict();
+export type RetryQueuedTurnRequest = z.infer<typeof RetryQueuedTurnRequestSchema>;
+
+export const ChatQueueRunResultSchema = z
+  .object({ snapshot: ChatQueueSnapshotSchema, response: ChatResponseSchema.optional() })
+  .strict();
+export type ChatQueueRunResult = z.infer<typeof ChatQueueRunResultSchema>;

--- a/packages/coach-contract/src/engine.ts
+++ b/packages/coach-contract/src/engine.ts
@@ -12,6 +12,16 @@ import {
   type SkipCoachDecisionRpcParams,
   type SkipCoachDecisionRpcResult,
 } from "./coach-decision.js";
+import type {
+  ChatQueueRunResult,
+  ChatQueueSnapshot,
+  EnqueueChatMessageRequest,
+  GetChatQueueRequest,
+  RemoveQueuedChatMessageRequest,
+  ResumeChatQueueRequest,
+  RetryQueuedTurnRequest,
+  RunQueuedCommandRequest,
+} from "./chat-queue.js";
 
 export const ChatRequestSchema = z
   .object({
@@ -51,7 +61,9 @@ export const ChatResponseSchema = z
   });
 export type ChatResponse = z.infer<typeof ChatResponseSchema>;
 
-export const StopChatRequestSchema = z.object({ chatId: z.string() }).strict();
+export const StopChatRequestSchema = z
+  .object({ chatId: z.string(), turnId: z.string().min(1) })
+  .strict();
 export type StopChatRequest = z.infer<typeof StopChatRequestSchema>;
 
 export const StopChatResponseSchema = z.object({ stopped: z.boolean() }).strict();
@@ -84,6 +96,21 @@ export type HasSessionResponse = z.infer<typeof HasSessionResponseSchema>;
 export interface CoachEngine {
   chat(request: ChatRequest, onEvent?: (event: TurnEvent) => void): Promise<ChatResponse>;
   stopChat?(request: StopChatRequest): Promise<StopChatResponse>;
+  enqueueChatMessage?(request: EnqueueChatMessageRequest): Promise<ChatQueueSnapshot>;
+  getChatQueue?(request: GetChatQueueRequest): Promise<ChatQueueSnapshot>;
+  removeQueuedChatMessage?(request: RemoveQueuedChatMessageRequest): Promise<ChatQueueSnapshot>;
+  resumeChatQueue?(
+    request: ResumeChatQueueRequest,
+    onEvent?: (event: TurnEvent) => void,
+  ): Promise<ChatQueueRunResult>;
+  runQueuedCommand?(
+    request: RunQueuedCommandRequest,
+    onEvent?: (event: TurnEvent) => void,
+  ): Promise<ChatQueueRunResult>;
+  retryQueuedTurn?(
+    request: RetryQueuedTurnRequest,
+    onEvent?: (event: TurnEvent) => void,
+  ): Promise<ChatQueueRunResult>;
   getCoachDecision(request: GetCoachDecisionRpcParams): Promise<GetCoachDecisionRpcResult>;
   answerCoachDecision(
     request: AnswerCoachDecisionRpcParams,

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -12,3 +12,4 @@ export * from "./activity-analysis.js";
 export * from "./training-export.js";
 export * from "./platform-path.js";
 export * from "./coach-decision.js";
+export * from "./chat-queue.js";

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -79,6 +79,16 @@ import {
   type TelegramControlSnapshot,
   type TelegramCredentialInspection,
 } from "./telegram-control.js";
+import {
+  ChatQueueRunResultSchema,
+  ChatQueueSnapshotSchema,
+  EnqueueChatMessageRequestSchema,
+  GetChatQueueRequestSchema,
+  RemoveQueuedChatMessageRequestSchema,
+  ResumeChatQueueRequestSchema,
+  RetryQueuedTurnRequestSchema,
+  RunQueuedCommandRequestSchema,
+} from "./chat-queue.js";
 
 export const JsonValueSchema = z.json();
 export type JsonValue = z.infer<typeof JsonValueSchema>;
@@ -173,6 +183,12 @@ export type JsonRpcNotificationEnvelope = z.infer<typeof JsonRpcNotificationEnve
 export const COACH_RPC_METHOD_NAMES = [
   "chat",
   "stopChat",
+  "enqueueChatMessage",
+  "getChatQueue",
+  "removeQueuedChatMessage",
+  "resumeChatQueue",
+  "runQueuedCommand",
+  "retryQueuedTurn",
   "resetSession",
   "hasSession",
   "getCoachDecision",
@@ -1198,6 +1214,54 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
     .object({
       jsonrpc: z.literal("2.0"),
       id: JsonRpcIdSchema,
+      method: z.literal("enqueueChatMessage"),
+      params: EnqueueChatMessageRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("getChatQueue"),
+      params: GetChatQueueRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("removeQueuedChatMessage"),
+      params: RemoveQueuedChatMessageRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("resumeChatQueue"),
+      params: ResumeChatQueueRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("runQueuedCommand"),
+      params: RunQueuedCommandRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("retryQueuedTurn"),
+      params: RetryQueuedTurnRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
       method: z.literal("resetSession"),
       params: ResetSessionRequestSchema,
     })
@@ -1540,7 +1604,14 @@ export const CoachTurnEventNotificationEnvelopeSchema = z
     params: z
       .object({
         requestId: JsonRpcIdSchema,
-        requestMethod: z.enum(["chat", "answerCoachDecision", "resumeCoachDecision"]),
+        requestMethod: z.enum([
+          "chat",
+          "resumeChatQueue",
+          "runQueuedCommand",
+          "retryQueuedTurn",
+          "answerCoachDecision",
+          "resumeCoachDecision",
+        ]),
         turnId: z.string().min(1),
         event: TurnEventSchema,
       })
@@ -1626,6 +1697,42 @@ export const COACH_RPC_METHOD_REGISTRY = {
     requestSchema: StopChatRequestSchema,
     responseSchema: StopChatResponseSchema,
     eventSchema: NoRpcEventSchema,
+  },
+  enqueueChatMessage: {
+    wireName: "enqueueChatMessage",
+    requestSchema: EnqueueChatMessageRequestSchema,
+    responseSchema: ChatQueueSnapshotSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  getChatQueue: {
+    wireName: "getChatQueue",
+    requestSchema: GetChatQueueRequestSchema,
+    responseSchema: ChatQueueSnapshotSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  removeQueuedChatMessage: {
+    wireName: "removeQueuedChatMessage",
+    requestSchema: RemoveQueuedChatMessageRequestSchema,
+    responseSchema: ChatQueueSnapshotSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  resumeChatQueue: {
+    wireName: "resumeChatQueue",
+    requestSchema: ResumeChatQueueRequestSchema,
+    responseSchema: ChatQueueRunResultSchema,
+    eventSchema: TurnEventSchema,
+  },
+  runQueuedCommand: {
+    wireName: "runQueuedCommand",
+    requestSchema: RunQueuedCommandRequestSchema,
+    responseSchema: ChatQueueRunResultSchema,
+    eventSchema: TurnEventSchema,
+  },
+  retryQueuedTurn: {
+    wireName: "retryQueuedTurn",
+    requestSchema: RetryQueuedTurnRequestSchema,
+    responseSchema: ChatQueueRunResultSchema,
+    eventSchema: TurnEventSchema,
   },
   resetSession: {
     wireName: "resetSession",

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 21;
+export const PROTOCOL_VERSION = 23;

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  ChatQueueSnapshotSchema,
+  EnqueueChatMessageRequestSchema,
+  PROTOCOL_VERSION,
+  RunQueuedCommandRequestSchema,
+} from "../src/index.js";
+
+describe("chat queue contract", () => {
+  it("ships protocol 23 and rejects blank enqueue text", () => {
+    expect(PROTOCOL_VERSION).toBe(23);
+    expect(() =>
+      EnqueueChatMessageRequestSchema.parse({
+        chatId: "desktop",
+        submissionId: "submission-1",
+        text: "  ",
+      }),
+    ).toThrow();
+  });
+
+  it("requires exact FIFO positions, unique submission ids, and a head-owned recovery claim", () => {
+    const item = {
+      queuedMessageId: "queued-1",
+      submissionId: "submission-1",
+      text: "Hello",
+      kind: "ordinary" as const,
+      position: 0,
+      restored: true,
+    };
+    expect(
+      ChatQueueSnapshotSchema.parse({ schemaVersion: 1, revision: 3, items: [item] }),
+    ).toMatchObject({ revision: 3, items: [{ restored: true }] });
+    expect(() =>
+      ChatQueueSnapshotSchema.parse({
+        schemaVersion: 1,
+        revision: 3,
+        items: [item, { ...item, queuedMessageId: "queued-2", position: 2 }],
+      }),
+    ).toThrow();
+    expect(() =>
+      ChatQueueSnapshotSchema.parse({
+        schemaVersion: 1,
+        revision: 3,
+        items: [item],
+        retryRequired: {
+          claimId: "claim-1",
+          queuedMessageIds: ["other"],
+          turnId: "turn-1",
+          status: "retry-required",
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects extra command identity fields", () => {
+    expect(() =>
+      RunQueuedCommandRequestSchema.parse({
+        chatId: "desktop",
+        queuedMessageId: "queued-1",
+        text: "/review",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -152,7 +152,7 @@ describe("coach decision wire contract", () => {
   });
 
   it("projects resume completion explicitly at protocol 20", () => {
-    expect(PROTOCOL_VERSION).toBe(21);
+    expect(PROTOCOL_VERSION).toBe(23);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -19,6 +19,7 @@ import {
   UNKNOWN_CYCLING_TRAINING_CONTEXT,
   ChatRequestSchema,
   ChatResponseSchema,
+  StopChatRequestSchema,
   ResetSessionResponseSchema,
   HasSessionResponseSchema,
   type CoachEngine,
@@ -113,8 +114,19 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 19", () => {
-    expect(PROTOCOL_VERSION).toBe(21);
+  it("is 23", () => {
+    expect(PROTOCOL_VERSION).toBe(23);
+  });
+
+  it("requires Stop to name the exact active turn", () => {
+    expect(StopChatRequestSchema.parse({ chatId: "desktop", turnId: TURN_ID })).toEqual({
+      chatId: "desktop",
+      turnId: TURN_ID,
+    });
+    expect(() => StopChatRequestSchema.parse({ chatId: "desktop" })).toThrow();
+    expect(() =>
+      StopChatRequestSchema.parse({ chatId: "desktop", turnId: TURN_ID, extra: true }),
+    ).toThrow();
   });
 });
 

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1083,6 +1083,18 @@ describe("coach request and event projection", () => {
     const fake: CoachRpcService = {
       chat: async () => ({ text: "ok" }),
       stopChat: async () => ({ stopped: true }),
+      enqueueChatMessage: async () => ({ schemaVersion: 1, revision: 1, items: [] }),
+      getChatQueue: async () => ({ schemaVersion: 1, revision: 1, items: [] }),
+      removeQueuedChatMessage: async () => ({ schemaVersion: 1, revision: 2, items: [] }),
+      resumeChatQueue: async () => ({
+        snapshot: { schemaVersion: 1, revision: 2, items: [] },
+      }),
+      runQueuedCommand: async () => ({
+        snapshot: { schemaVersion: 1, revision: 2, items: [] },
+      }),
+      retryQueuedTurn: async () => ({
+        snapshot: { schemaVersion: 1, revision: 2, items: [] },
+      }),
       resetSession: async () => ({ memoryFlushed: true }),
       hasSession: async () => ({ hasSession: false }),
       getCoachDecision: async () => ({ decision: null }),
@@ -1792,7 +1804,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-21 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-23 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1800,8 +1812,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 21,
-      serverProtocolVersion: 21,
+      clientProtocolVersion: 23,
+      serverProtocolVersion: 23,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1810,7 +1822,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(20);
+    expect(previous).toBe(22);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -1883,9 +1895,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 19 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 23 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(21);
+    expect(client.clientProtocolVersion).toBe(23);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2011,7 +2023,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version nineteen", () => {
-    expect(PROTOCOL_VERSION).toBe(21);
+  it("uses protocol version 23", () => {
+    expect(PROTOCOL_VERSION).toBe(23);
   });
 });

--- a/packages/coach/src/coach-engine-adapter.ts
+++ b/packages/coach/src/coach-engine-adapter.ts
@@ -3,6 +3,10 @@ import {
   AnswerCoachDecisionRpcResultSchema,
   AthleteStateSchema,
   ChatRequestSchema,
+  ChatQueueRunResultSchema,
+  ChatQueueSnapshotSchema,
+  EnqueueChatMessageRequestSchema,
+  GetChatQueueRequestSchema,
   ChatResponseSchema,
   GetCoachDecisionRpcParamsSchema,
   GetCoachDecisionRpcResultSchema,
@@ -12,13 +16,19 @@ import {
   ResetSessionResponseSchema,
   ResumeCoachDecisionRpcParamsSchema,
   ResumeCoachDecisionRpcResultSchema,
+  RemoveQueuedChatMessageRequestSchema,
+  ResumeChatQueueRequestSchema,
+  RetryQueuedTurnRequestSchema,
+  RunQueuedCommandRequestSchema,
   SkipCoachDecisionRpcParamsSchema,
   SkipCoachDecisionRpcResultSchema,
   StopChatRequestSchema,
   StopChatResponseSchema,
   TurnEventSchema,
   type AthleteState,
+  type ChatQueueRunResult,
   type CoachEngine,
+  type TurnEvent,
 } from "@enduragent/coach-contract";
 import type { CyclingFtpAnchorResolver } from "@enduragent/kernel/anchors";
 
@@ -30,6 +40,25 @@ export interface CoachEngineAdapterInput {
 }
 
 export function createCoachEngineAdapter(input: CoachEngineAdapterInput): CoachEngine {
+  const queueStream = async (
+    operation: (onEvent: (event: TurnEvent) => void) => Promise<ChatQueueRunResult>,
+    onEvent?: (event: TurnEvent) => void,
+  ): Promise<ChatQueueRunResult> => {
+    let firstEventValidationError: unknown | undefined;
+    const response = await operation((event) => {
+      if (firstEventValidationError !== undefined) return;
+      const result = TurnEventSchema.safeParse(event);
+      if (!result.success) {
+        firstEventValidationError = result.error;
+        return;
+      }
+      try {
+        onEvent?.(result.data);
+      } catch {}
+    });
+    if (firstEventValidationError !== undefined) throw firstEventValidationError;
+    return ChatQueueRunResultSchema.parse(response);
+  };
   return {
     async chat(request, onEvent) {
       const parsed = ChatRequestSchema.parse(request);
@@ -65,6 +94,42 @@ export function createCoachEngineAdapter(input: CoachEngineAdapterInput): CoachE
       return StopChatResponseSchema.parse(
         await input.backend.stopChat?.(parsed).then((value) => value ?? { stopped: false }),
       );
+    },
+    async enqueueChatMessage(request) {
+      const parsed = EnqueueChatMessageRequestSchema.parse(request);
+      if (input.backend.enqueueChatMessage === undefined)
+        throw new Error("Durable chat queue is unavailable.");
+      return ChatQueueSnapshotSchema.parse(await input.backend.enqueueChatMessage(parsed));
+    },
+    async getChatQueue(request) {
+      const parsed = GetChatQueueRequestSchema.parse(request);
+      if (input.backend.getChatQueue === undefined)
+        throw new Error("Durable chat queue is unavailable.");
+      return ChatQueueSnapshotSchema.parse(await input.backend.getChatQueue(parsed));
+    },
+    async removeQueuedChatMessage(request) {
+      const parsed = RemoveQueuedChatMessageRequestSchema.parse(request);
+      if (input.backend.removeQueuedChatMessage === undefined)
+        throw new Error("Durable chat queue is unavailable.");
+      return ChatQueueSnapshotSchema.parse(await input.backend.removeQueuedChatMessage(parsed));
+    },
+    async resumeChatQueue(request, onEvent) {
+      const parsed = ResumeChatQueueRequestSchema.parse(request);
+      if (input.backend.resumeChatQueue === undefined)
+        throw new Error("Durable chat queue is unavailable.");
+      return queueStream((emit) => input.backend.resumeChatQueue!(parsed, emit), onEvent);
+    },
+    async runQueuedCommand(request, onEvent) {
+      const parsed = RunQueuedCommandRequestSchema.parse(request);
+      if (input.backend.runQueuedCommand === undefined)
+        throw new Error("Durable chat queue is unavailable.");
+      return queueStream((emit) => input.backend.runQueuedCommand!(parsed, emit), onEvent);
+    },
+    async retryQueuedTurn(request, onEvent) {
+      const parsed = RetryQueuedTurnRequestSchema.parse(request);
+      if (input.backend.retryQueuedTurn === undefined)
+        throw new Error("Durable chat queue is unavailable.");
+      return queueStream((emit) => input.backend.retryQueuedTurn!(parsed, emit), onEvent);
     },
     async resetSession(request) {
       const parsed = ResetSessionRequestSchema.parse(request);

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -556,6 +556,16 @@ function createReconfigurableRuntimeBundle(initial: RuntimeBundle): {
       chat: (request, onEvent) => run((bundle) => bundle.engine.chat(request, onEvent)),
       stopChat: (request) =>
         run(async (bundle) => bundle.engine.stopChat?.(request) ?? { stopped: false }),
+      enqueueChatMessage: (request) => run((bundle) => bundle.engine.enqueueChatMessage!(request)),
+      getChatQueue: (request) => run((bundle) => bundle.engine.getChatQueue!(request)),
+      removeQueuedChatMessage: (request) =>
+        run((bundle) => bundle.engine.removeQueuedChatMessage!(request)),
+      resumeChatQueue: (request, onEvent) =>
+        run((bundle) => bundle.engine.resumeChatQueue!(request, onEvent)),
+      runQueuedCommand: (request, onEvent) =>
+        run((bundle) => bundle.engine.runQueuedCommand!(request, onEvent)),
+      retryQueuedTurn: (request, onEvent) =>
+        run((bundle) => bundle.engine.retryQueuedTurn!(request, onEvent)),
       getCoachDecision: (request) => run((bundle) => bundle.engine.getCoachDecision(request)),
       answerCoachDecision: (request, onEvent) =>
         run((bundle) => bundle.engine.answerCoachDecision(request, onEvent)),
@@ -985,6 +995,7 @@ export async function createLocalCoachComposition(
         memory,
         chatStore: conversationStore,
         transcriptWriter: conversationStore,
+        coachDecisions: conversationStore,
         secrets: { resolve: resolveSecretRef },
         platform: {
           legacyClient,

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -493,6 +493,12 @@ function sameToken(received: string, expected: string): boolean {
 const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "chat",
   "stopChat",
+  "enqueueChatMessage",
+  "getChatQueue",
+  "removeQueuedChatMessage",
+  "resumeChatQueue",
+  "runQueuedCommand",
+  "retryQueuedTurn",
   "getCoachDecision",
   "answerCoachDecision",
   "skipCoachDecision",
@@ -860,6 +866,12 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
     if (
       generic.data.method === "chat" ||
       generic.data.method === "stopChat" ||
+      generic.data.method === "enqueueChatMessage" ||
+      generic.data.method === "getChatQueue" ||
+      generic.data.method === "removeQueuedChatMessage" ||
+      generic.data.method === "resumeChatQueue" ||
+      generic.data.method === "runQueuedCommand" ||
+      generic.data.method === "retryQueuedTurn" ||
       generic.data.method === "getCoachDecision" ||
       generic.data.method === "answerCoachDecision" ||
       generic.data.method === "skipCoachDecision" ||
@@ -935,6 +947,68 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                 input.engine.stopChat === undefined
                   ? { stopped: false }
                   : await input.engine.stopChat(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "enqueueChatMessage":
+            try {
+              result = await input.engine.enqueueChatMessage!(
+                COACH_RPC_METHOD_REGISTRY.enqueueChatMessage.requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "getChatQueue":
+            try {
+              result = await input.engine.getChatQueue!(
+                COACH_RPC_METHOD_REGISTRY.getChatQueue.requestSchema.parse(generic.data.params),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "removeQueuedChatMessage":
+            try {
+              result = await input.engine.removeQueuedChatMessage!(
+                COACH_RPC_METHOD_REGISTRY.removeQueuedChatMessage.requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "resumeChatQueue":
+          case "runQueuedCommand":
+          case "retryQueuedTurn":
+            try {
+              const method = registry.wireName;
+              const request = COACH_RPC_METHOD_REGISTRY[method].requestSchema.parse(
+                generic.data.params,
+              ) as never;
+              result = await input.engine[method]!(request, (event) => {
+                if (eventFailure !== undefined) return;
+                try {
+                  const parsedEvent = COACH_RPC_METHOD_REGISTRY[method].eventSchema.parse(event);
+                  const notification = CoachTurnEventNotificationEnvelopeSchema.parse({
+                    jsonrpc: "2.0",
+                    method: "coach.turnEvent",
+                    params: {
+                      requestId: generic.data.id,
+                      requestMethod: method,
+                      turnId: parsedEvent.turnId,
+                      event: parsedEvent,
+                    },
+                  });
+                  void enqueueSerialized(state, serializeCoachRpcEnvelope(notification));
+                } catch (error) {
+                  eventFailure = { error };
+                }
+              });
             } catch (error) {
               invocationFailure = { error };
             }

--- a/packages/coach/tests/coach-engine-adapter.test.ts
+++ b/packages/coach/tests/coach-engine-adapter.test.ts
@@ -359,11 +359,17 @@ describe("coach engine adapter", () => {
     expect(Object.keys(engine).sort()).toEqual([
       "answerCoachDecision",
       "chat",
+      "enqueueChatMessage",
       "getAthleteState",
+      "getChatQueue",
       "getCoachDecision",
       "hasSession",
+      "removeQueuedChatMessage",
       "resetSession",
+      "resumeChatQueue",
       "resumeCoachDecision",
+      "retryQueuedTurn",
+      "runQueuedCommand",
       "skipCoachDecision",
       "stopChat",
     ]);

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -629,6 +629,7 @@ describe("local coach composition", () => {
     expect(Object.keys(received!.ports).sort()).toEqual([
       "chatStore",
       "classifyFailure",
+      "coachDecisions",
       "config",
       "extractRetryAfterMs",
       "getAccessToken",
@@ -2823,10 +2824,12 @@ describe("local coach composition", () => {
       createResolver: () => missingResolver(),
     });
 
-    await expect(lifecycle.engine.stopChat?.({ chatId: "desktop" })).resolves.toEqual({
+    await expect(
+      lifecycle.engine.stopChat?.({ chatId: "desktop", turnId: "turn-1" }),
+    ).resolves.toEqual({
       stopped: true,
     });
-    expect(stopChat).toHaveBeenCalledWith({ chatId: "desktop" });
+    expect(stopChat).toHaveBeenCalledWith({ chatId: "desktop", turnId: "turn-1" });
     await lifecycle.close();
   });
 

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -775,6 +775,30 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
           calls.push(`resumeCoachDecision:${chatId}`);
           return { decision: { ...completedDecision, chatId }, resumed: true };
         },
+        enqueueChatMessage: async ({ chatId }) => {
+          calls.push(`enqueueChatMessage:${chatId}`);
+          return { schemaVersion: 1, revision: 1, items: [] };
+        },
+        getChatQueue: async ({ chatId }) => {
+          calls.push(`getChatQueue:${chatId}`);
+          return { schemaVersion: 1, revision: 1, items: [] };
+        },
+        removeQueuedChatMessage: async ({ chatId }) => {
+          calls.push(`removeQueuedChatMessage:${chatId}`);
+          return { schemaVersion: 1, revision: 2, items: [] };
+        },
+        resumeChatQueue: async ({ chatId }) => {
+          calls.push(`resumeChatQueue:${chatId}`);
+          return { snapshot: { schemaVersion: 1, revision: 2, items: [] } };
+        },
+        runQueuedCommand: async ({ chatId }) => {
+          calls.push(`runQueuedCommand:${chatId}`);
+          return { snapshot: { schemaVersion: 1, revision: 2, items: [] } };
+        },
+        retryQueuedTurn: async ({ chatId }) => {
+          calls.push(`retryQueuedTurn:${chatId}`);
+          return { snapshot: { schemaVersion: 1, revision: 2, items: [] } };
+        },
         getAthleteState: async () => {
           calls.push("getAthleteState");
           return state;
@@ -848,6 +872,24 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         method: "resumeCoachDecision",
         params: { chatId: "chat", decisionId: "decision-1" },
       },
+      {
+        id: 35,
+        method: "enqueueChatMessage",
+        params: { chatId: "chat", submissionId: "submission-1", text: "Hello" },
+      },
+      { id: 36, method: "getChatQueue", params: { chatId: "chat" } },
+      {
+        id: 37,
+        method: "removeQueuedChatMessage",
+        params: { chatId: "chat", queuedMessageId: "queued-1" },
+      },
+      { id: 38, method: "resumeChatQueue", params: { chatId: "chat" } },
+      {
+        id: 39,
+        method: "runQueuedCommand",
+        params: { chatId: "chat", queuedMessageId: "queued-1" },
+      },
+      { id: 40, method: "retryQueuedTurn", params: { chatId: "chat", claimId: "claim-1" } },
       { id: 4, method: "getAthleteState", params: {} },
       {
         id: 5,
@@ -878,6 +920,12 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       "answerCoachDecision:chat",
       "skipCoachDecision:chat",
       "resumeCoachDecision:chat",
+      "enqueueChatMessage:chat",
+      "getChatQueue:chat",
+      "removeQueuedChatMessage:chat",
+      "resumeChatQueue:chat",
+      "runQueuedCommand:chat",
+      "retryQueuedTurn:chat",
       "getAthleteState",
       "getActivityAnalysis",
       "exportTrainingFile",
@@ -1013,7 +1061,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         jsonrpc: "2.0",
         id: "stop",
         method: "stopChat",
-        params: { chatId: "desktop" },
+        params: { chatId: "desktop", turnId: "turn-1" },
       }),
     );
 
@@ -1022,7 +1070,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       id: "stop",
       result: { stopped: true },
     });
-    expect(stopChat).toHaveBeenCalledWith({ chatId: "desktop" });
+    expect(stopChat).toHaveBeenCalledWith({ chatId: "desktop", turnId: "turn-1" });
 
     chatResult.resolve({ text: "partial" });
     expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
@@ -1064,7 +1112,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
         jsonrpc: "2.0",
         id: "stop-decision",
         method: "stopChat",
-        params: { chatId: "desktop" },
+        params: { chatId: "desktop", turnId: "turn-2" },
       }),
     );
 
@@ -1073,7 +1121,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       id: "stop-decision",
       result: { stopped: true },
     });
-    expect(stopChat).toHaveBeenCalledWith({ chatId: "desktop" });
+    expect(stopChat).toHaveBeenCalledWith({ chatId: "desktop", turnId: "turn-2" });
 
     answerResult.resolve({ decision: completedDecision });
     expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 21 as const,
-      serverProtocolVersion: 21 as const,
+      clientProtocolVersion: 23 as const,
+      serverProtocolVersion: 23 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -304,7 +304,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(21);
+    expect(PROTOCOL_VERSION).toBe(23);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/core/src/agent/chat-queue-store.ts
+++ b/packages/core/src/agent/chat-queue-store.ts
@@ -1,0 +1,394 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fsyncSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  ChatQueueSnapshotSchema,
+  type ChatQueueSnapshot,
+  type QueuedChatMessage,
+} from "@enduragent/coach-contract";
+import { z } from "zod";
+import {
+  assertWindowsPrivateDirectoryStable,
+  assertWindowsPrivateFileBinding,
+  assertWindowsPrivateFileMetadata,
+  assertWindowsPrivatePathRead,
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathFailure,
+  sameWindowsPrivatePathIdentity,
+  windowsPrivatePathIdentity,
+  type WindowsPrivateDirectoryBinding,
+} from "../io/windows-private-path-policy.js";
+
+const StoredItemSchema = z
+  .object({
+    queuedMessageId: z.string().min(1),
+    submissionId: z.string().min(1),
+    text: z.string().refine((value) => /\S/u.test(value)),
+    kind: z.enum(["ordinary", "slash-command"]),
+  })
+  .strict();
+
+const StoredClaimSchema = z
+  .object({
+    claimId: z.string().min(1),
+    queuedMessageIds: z.array(z.string().min(1)).min(1),
+    turnId: z.string().min(1),
+    status: z.enum(["claimed", "retry-required"]),
+  })
+  .strict();
+
+const StoredQueueSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    revision: z.number().int().nonnegative(),
+    items: z.array(StoredItemSchema),
+    claim: StoredClaimSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const ids = value.items.map((item) => item.queuedMessageId);
+    const submissions = value.items.map((item) => item.submissionId);
+    if (new Set(ids).size !== ids.length) {
+      context.addIssue({ code: "custom", path: ["items"], message: "duplicate queue ids" });
+    }
+    if (new Set(submissions).size !== submissions.length) {
+      context.addIssue({ code: "custom", path: ["items"], message: "duplicate submissions" });
+    }
+    if (
+      value.claim !== undefined &&
+      (value.claim.queuedMessageIds.length > ids.length ||
+        value.claim.queuedMessageIds.some((id, index) => id !== ids[index]))
+    ) {
+      context.addIssue({ code: "custom", path: ["claim"], message: "claim is not queue head" });
+    }
+  });
+
+type StoredQueue = z.infer<typeof StoredQueueSchema>;
+type StoredClaim = z.infer<typeof StoredClaimSchema>;
+
+export interface ChatQueueStoreHooks {
+  readonly afterFileOpen?: (path: string, descriptor: number) => void;
+  readonly afterFileRead?: (path: string, descriptor: number) => void;
+}
+
+function emptyQueue(): StoredQueue {
+  return { schemaVersion: 1, revision: 0, items: [] };
+}
+
+function safeName(chatId: string): string {
+  return `${createHash("sha256").update(chatId).digest("hex")}.json`;
+}
+
+export class ChatQueueStore {
+  private readonly directory: string;
+  private readonly windowsDirectoryBinding: WindowsPrivateDirectoryBinding | undefined;
+  private readonly freshIds = new Set<string>();
+
+  constructor(
+    dataDir: string,
+    private readonly platform: NodeJS.Platform = process.platform,
+    private readonly hooks: ChatQueueStoreHooks = {},
+  ) {
+    this.directory = join(dataDir, "chat-queues");
+    try {
+      mkdirSync(this.directory, { recursive: true, mode: 0o700 });
+    } catch (error) {
+      throw this.platform === "win32"
+        ? classifyWindowsPrivatePathFailure("entry-check", error)
+        : error;
+    }
+    if (this.platform === "win32") {
+      this.windowsDirectoryBinding = bindWindowsPrivateDirectory(dataDir, this.directory);
+      return;
+    }
+    this.windowsDirectoryBinding = undefined;
+    const stats = lstatSync(this.directory);
+    if (!stats.isDirectory() || stats.isSymbolicLink())
+      throw new Error("Chat queue directory is unsafe.");
+    if ((stats.mode & 0o7777) !== 0o700) {
+      const descriptor = openSync(
+        this.directory,
+        constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+      );
+      try {
+        fchmodSync(descriptor, 0o700);
+        fsyncSync(descriptor);
+      } finally {
+        closeSync(descriptor);
+      }
+    }
+  }
+
+  get(chatId: string): ChatQueueSnapshot {
+    return this.snapshot(this.read(chatId));
+  }
+
+  enqueue(
+    chatId: string,
+    submissionId: string,
+    text: string,
+    queuedMessageId: string,
+  ): ChatQueueSnapshot {
+    const state = this.read(chatId);
+    const duplicate = state.items.find((item) => item.submissionId === submissionId);
+    if (duplicate !== undefined) return this.snapshot(state);
+    const item = {
+      queuedMessageId,
+      submissionId,
+      text,
+      kind: /^\s*\//u.test(text) ? ("slash-command" as const) : ("ordinary" as const),
+    };
+    this.freshIds.add(queuedMessageId);
+    return this.commit(chatId, {
+      ...state,
+      revision: state.revision + 1,
+      items: [...state.items, item],
+    });
+  }
+
+  remove(chatId: string, queuedMessageId: string): ChatQueueSnapshot {
+    const state = this.read(chatId);
+    if (state.claim?.queuedMessageIds.includes(queuedMessageId) === true) {
+      throw new Error("A claimed queued message cannot be removed.");
+    }
+    const items = state.items.filter((item) => item.queuedMessageId !== queuedMessageId);
+    if (items.length === state.items.length) return this.snapshot(state);
+    this.freshIds.delete(queuedMessageId);
+    return this.commit(chatId, { ...state, revision: state.revision + 1, items });
+  }
+
+  claim(chatId: string, claim: Omit<StoredClaim, "status">): ChatQueueSnapshot {
+    const state = this.read(chatId);
+    if (state.claim !== undefined) throw new Error("The chat queue already has a claim.");
+    const actual = state.items
+      .slice(0, claim.queuedMessageIds.length)
+      .map((item) => item.queuedMessageId);
+    if (actual.join("\u0000") !== claim.queuedMessageIds.join("\u0000")) {
+      throw new Error("The queue head changed before it could be claimed.");
+    }
+    return this.commit(chatId, {
+      ...state,
+      revision: state.revision + 1,
+      claim: { ...claim, status: "claimed" },
+    });
+  }
+
+  complete(chatId: string, claimId: string): ChatQueueSnapshot {
+    const state = this.read(chatId);
+    if (state.claim?.claimId !== claimId)
+      throw new Error("The queue claim changed before completion.");
+    const claimed = new Set(state.claim.queuedMessageIds);
+    const items = state.items.filter((item) => !claimed.has(item.queuedMessageId));
+    state.claim.queuedMessageIds.forEach((id) => this.freshIds.delete(id));
+    return this.commit(chatId, { schemaVersion: 1, revision: state.revision + 1, items });
+  }
+
+  requireRetry(chatId: string, claimId: string): ChatQueueSnapshot {
+    const state = this.read(chatId);
+    if (state.claim?.claimId !== claimId)
+      throw new Error("The queue claim changed before recovery.");
+    if (state.claim.status === "retry-required") return this.snapshot(state);
+    return this.commit(chatId, {
+      ...state,
+      revision: state.revision + 1,
+      claim: { ...state.claim, status: "retry-required" },
+    });
+  }
+
+  retry(chatId: string, claimId: string, turnId: string): ChatQueueSnapshot {
+    const state = this.read(chatId);
+    if (state.claim?.claimId !== claimId || state.claim.status !== "retry-required") {
+      throw new Error("The recovery claim changed before retry.");
+    }
+    return this.commit(chatId, {
+      ...state,
+      revision: state.revision + 1,
+      claim: { ...state.claim, turnId, status: "claimed" },
+    });
+  }
+
+  clear(chatId: string): ChatQueueSnapshot {
+    const state = this.read(chatId);
+    if (state.items.length === 0 && state.claim === undefined) return this.snapshot(state);
+    state.items.forEach((item) => this.freshIds.delete(item.queuedMessageId));
+    return this.commit(chatId, { schemaVersion: 1, revision: state.revision + 1, items: [] });
+  }
+
+  reconcile(chatId: string, completedTurnIds: ReadonlySet<string>): ChatQueueSnapshot {
+    const state = this.read(chatId);
+    if (state.claim?.status !== "claimed") return this.snapshot(state);
+    return completedTurnIds.has(state.claim.turnId)
+      ? this.complete(chatId, state.claim.claimId)
+      : this.requireRetry(chatId, state.claim.claimId);
+  }
+
+  private snapshot(state: StoredQueue): ChatQueueSnapshot {
+    const items: QueuedChatMessage[] = state.items.map((item, position) => ({
+      ...item,
+      position,
+      restored: !this.freshIds.has(item.queuedMessageId),
+    }));
+    return ChatQueueSnapshotSchema.parse({
+      schemaVersion: 1,
+      revision: state.revision,
+      items,
+      ...(state.claim?.status === "retry-required" ? { retryRequired: state.claim } : {}),
+    });
+  }
+
+  private read(chatId: string): StoredQueue {
+    const path = join(this.directory, safeName(chatId));
+    if (this.platform === "win32") {
+      assertWindowsPrivateDirectoryStable(this.windowsDirectoryBinding!);
+    }
+    let descriptor: number;
+    try {
+      descriptor = openSync(
+        path,
+        constants.O_RDONLY | (this.platform === "win32" ? 0 : constants.O_NOFOLLOW),
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        if (this.platform === "win32") {
+          assertWindowsPrivateDirectoryStable(this.windowsDirectoryBinding!);
+        }
+        return emptyQueue();
+      }
+      throw error;
+    }
+    try {
+      this.hooks.afterFileOpen?.(path, descriptor);
+      const before = fstatSync(descriptor);
+      if (
+        !before.isFile() ||
+        (this.platform !== "win32" && ((before.mode & 0o7777) !== 0o600 || before.nlink !== 1))
+      ) {
+        throw new Error("Chat queue file is unsafe.");
+      }
+      if (this.platform === "win32") {
+        assertWindowsPrivateFileMetadata(before);
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          path,
+          windowsPrivatePathIdentity(before),
+        );
+      }
+      const contents = readFileSync(descriptor, "utf8");
+      this.hooks.afterFileRead?.(path, descriptor);
+      let parsed: StoredQueue;
+      try {
+        parsed = StoredQueueSchema.parse(JSON.parse(contents));
+      } catch (error) {
+        if (this.platform === "win32") {
+          assertWindowsPrivatePathRead({
+            bounded: true,
+            identityStable: true,
+            contentValid: false,
+            authenticatedHomeBinding: true,
+          });
+        }
+        throw error;
+      }
+      if (this.platform === "win32") {
+        const after = fstatSync(descriptor);
+        assertWindowsPrivateFileMetadata(after);
+        const current = assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          path,
+          windowsPrivatePathIdentity(after),
+        );
+        assertWindowsPrivatePathRead({
+          bounded: Number.isSafeInteger(before.size) && before.size >= 0,
+          identityStable:
+            sameWindowsPrivatePathIdentity(
+              windowsPrivatePathIdentity(before),
+              windowsPrivatePathIdentity(after),
+            ) &&
+            before.size === after.size &&
+            before.size === current.size &&
+            before.mtimeMs === after.mtimeMs &&
+            before.mtimeMs === current.mtimeMs &&
+            before.ctimeMs === after.ctimeMs &&
+            before.ctimeMs === current.ctimeMs,
+          contentValid: true,
+          authenticatedHomeBinding: true,
+        });
+        assertWindowsPrivateDirectoryStable(this.windowsDirectoryBinding!);
+      }
+      return parsed;
+    } finally {
+      closeSync(descriptor);
+    }
+  }
+
+  private commit(chatId: string, state: StoredQueue): ChatQueueSnapshot {
+    const parsed = StoredQueueSchema.parse(state);
+    const path = join(this.directory, safeName(chatId));
+    const temporary = `${path}.${randomBytes(16).toString("hex")}.tmp`;
+    let descriptor: number | undefined;
+    try {
+      if (this.platform === "win32") {
+        assertWindowsPrivateDirectoryStable(this.windowsDirectoryBinding!);
+      }
+      descriptor = openSync(
+        temporary,
+        constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+        0o600,
+      );
+      writeFileSync(descriptor, `${JSON.stringify(parsed)}\n`, "utf8");
+      fsyncSync(descriptor);
+      closeSync(descriptor);
+      descriptor = undefined;
+      if (this.platform === "win32") {
+        const temporaryMetadata = lstatSync(temporary);
+        assertWindowsPrivateFileMetadata(temporaryMetadata);
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          temporary,
+          windowsPrivatePathIdentity(temporaryMetadata),
+        );
+      }
+      renameSync(temporary, path);
+      if (this.platform === "win32") {
+        const targetMetadata = lstatSync(path);
+        assertWindowsPrivateFileMetadata(targetMetadata);
+        assertWindowsPrivateFileBinding(
+          this.windowsDirectoryBinding!,
+          path,
+          windowsPrivatePathIdentity(targetMetadata),
+        );
+        assertWindowsPrivateDirectoryStable(this.windowsDirectoryBinding!);
+      } else {
+        const directoryDescriptor = openSync(
+          this.directory,
+          constants.O_RDONLY | constants.O_DIRECTORY,
+        );
+        try {
+          fsyncSync(directoryDescriptor);
+        } finally {
+          closeSync(directoryDescriptor);
+        }
+      }
+      return this.snapshot(parsed);
+    } catch (error) {
+      if (descriptor !== undefined) closeSync(descriptor);
+      try {
+        unlinkSync(temporary);
+      } catch {}
+      throw error;
+    }
+  }
+}

--- a/packages/core/src/agent/conversation-store.ts
+++ b/packages/core/src/agent/conversation-store.ts
@@ -23,9 +23,29 @@ import {
   type TranscriptPageResult,
 } from "./transcript-store.js";
 import type { CoachDecisionReadModel } from "@enduragent/coach-contract";
+import type { ChatQueueSnapshot } from "@enduragent/coach-contract";
 import { WindowsPrivatePathPolicyError } from "../io/windows-private-path-policy.js";
+import { ChatQueueStore, type ChatQueueStoreHooks } from "./chat-queue-store.js";
 
 export interface ConversationStorePort extends ChatStorePort, TranscriptWriterPort {
+  getChatQueue(chatId: string): ChatQueueSnapshot;
+  enqueueChatMessage(
+    chatId: string,
+    submissionId: string,
+    text: string,
+    queuedMessageId: string,
+  ): ChatQueueSnapshot;
+  removeQueuedChatMessage(chatId: string, queuedMessageId: string): ChatQueueSnapshot;
+  claimChatQueue(
+    chatId: string,
+    claimId: string,
+    turnId: string,
+    queuedMessageIds: readonly string[],
+  ): ChatQueueSnapshot;
+  completeChatQueueClaim(chatId: string, claimId: string): ChatQueueSnapshot;
+  requireChatQueueRetry(chatId: string, claimId: string): ChatQueueSnapshot;
+  retryChatQueueClaim(chatId: string, claimId: string, turnId: string): ChatQueueSnapshot;
+  clearChatQueue(chatId: string): ChatQueueSnapshot;
   appendDecisionRequested(input: TranscriptDecisionRequestedInput): CoachDecisionReadModel;
   answerDecision(input: TranscriptDecisionAnsweredInput): CoachDecisionReadModel;
   skipDecision(input: TranscriptDecisionSkippedInput): CoachDecisionReadModel;
@@ -42,10 +62,12 @@ export interface ConversationStorePort extends ChatStorePort, TranscriptWriterPo
     boundaryRef: string,
     request: TranscriptPageRequest,
   ): TranscriptPageResult;
+  reconcileChatQueue(chatId: string): ChatQueueSnapshot;
 }
 
 export interface ConversationStoreOptions {
   readonly platform?: NodeJS.Platform;
+  readonly chatQueueHooks?: ChatQueueStoreHooks;
 }
 
 export function createConversationStore(
@@ -76,6 +98,8 @@ export class ConversationStore implements ConversationStorePort {
     return new ConversationStore(
       new ChatStore(dataDir, resetArchiveRetentionDays, options),
       new TranscriptStore(dataDir, { platform: options.platform }),
+      undefined,
+      new ChatQueueStore(dataDir, options.platform, options.chatQueueHooks),
     );
   }
 
@@ -83,6 +107,7 @@ export class ConversationStore implements ConversationStorePort {
     private readonly chatStore: ChatStore,
     private readonly transcriptStore: TranscriptStore,
     private readonly createResetId: () => string = () => randomBytes(32).toString("hex"),
+    private readonly chatQueueStore?: ChatQueueStore,
   ) {
     for (const intent of this.transcriptStore.listResetIntents()) {
       try {
@@ -191,6 +216,69 @@ export class ConversationStore implements ConversationStorePort {
     return this.transcriptStore.readArchivedConversationPage(chatId, boundaryRef, request);
   }
 
+  getChatQueue(chatId: string): ChatQueueSnapshot {
+    this.recoverBeforeAccess(chatId);
+    return this.reconcileChatQueue(chatId);
+  }
+
+  enqueueChatMessage(
+    chatId: string,
+    submissionId: string,
+    text: string,
+    queuedMessageId: string,
+  ): ChatQueueSnapshot {
+    this.recoverBeforeAccess(chatId);
+    return this.queueStore().enqueue(chatId, submissionId, text, queuedMessageId);
+  }
+
+  removeQueuedChatMessage(chatId: string, queuedMessageId: string): ChatQueueSnapshot {
+    this.recoverBeforeAccess(chatId);
+    return this.queueStore().remove(chatId, queuedMessageId);
+  }
+
+  claimChatQueue(
+    chatId: string,
+    claimId: string,
+    turnId: string,
+    queuedMessageIds: readonly string[],
+  ): ChatQueueSnapshot {
+    this.recoverBeforeAccess(chatId);
+    return this.queueStore().claim(chatId, {
+      claimId,
+      turnId,
+      queuedMessageIds: [...queuedMessageIds],
+    });
+  }
+
+  completeChatQueueClaim(chatId: string, claimId: string): ChatQueueSnapshot {
+    this.recoverBeforeAccess(chatId);
+    return this.queueStore().complete(chatId, claimId);
+  }
+
+  requireChatQueueRetry(chatId: string, claimId: string): ChatQueueSnapshot {
+    this.recoverBeforeAccess(chatId);
+    return this.queueStore().requireRetry(chatId, claimId);
+  }
+
+  retryChatQueueClaim(chatId: string, claimId: string, turnId: string): ChatQueueSnapshot {
+    this.recoverBeforeAccess(chatId);
+    return this.queueStore().retry(chatId, claimId, turnId);
+  }
+
+  clearChatQueue(chatId: string): ChatQueueSnapshot {
+    this.recoverBeforeAccess(chatId);
+    return this.queueStore().clear(chatId);
+  }
+
+  reconcileChatQueue(chatId: string): ChatQueueSnapshot {
+    return this.queueStore().reconcile(chatId, this.transcriptStore.getTerminalTurnIds(chatId));
+  }
+
+  private queueStore(): ChatQueueStore {
+    if (this.chatQueueStore === undefined) throw new Error("Chat queue storage is unavailable.");
+    return this.chatQueueStore;
+  }
+
   resetConversation(input: ConversationResetInput): void {
     this.recoverBeforeAccess(input.chatId);
     const intent: ResetIntentRecord = {
@@ -234,6 +322,7 @@ export class ConversationStore implements ConversationStorePort {
         resetId: intent.resetId,
         boundaryAt: intent.boundaryAt,
       });
+      this.chatQueueStore?.clear(intent.chatId);
       this.transcriptStore.removeResetIntent(intent);
       this.blockedChats.delete(intent.chatId);
     } catch (error) {
@@ -280,6 +369,7 @@ export class ConversationStore implements ConversationStorePort {
         resetId: intent.resetId,
         boundaryAt: intent.boundaryAt,
       });
+      this.chatQueueStore?.clear(intent.chatId);
       this.transcriptStore.removeResetIntent(intent);
       return;
     }
@@ -288,6 +378,7 @@ export class ConversationStore implements ConversationStorePort {
       resetId: intent.resetId,
       boundaryAt: intent.boundaryAt,
     });
+    this.chatQueueStore?.clear(intent.chatId);
     this.transcriptStore.removeResetIntent(intent);
   }
 }

--- a/packages/core/src/agent/transcript-store.ts
+++ b/packages/core/src/agent/transcript-store.ts
@@ -131,6 +131,7 @@ export interface TranscriptDecisionRequestedRecord {
   readonly version: typeof TRANSCRIPT_SCHEMA_VERSION;
   readonly kind: "decision-requested";
   readonly chatId: string;
+  readonly turnId?: string;
   readonly decisionId: string;
   readonly toolCallId: string;
   readonly messageId: string;
@@ -202,6 +203,7 @@ export type TranscriptRecord =
 
 export interface TranscriptDecisionRequestedInput {
   readonly decision: CoachDecisionReadModel;
+  readonly turnId: string;
   readonly toolCallId: string;
   readonly athleteText: string;
   readonly requestedAt: string;
@@ -379,9 +381,7 @@ function isIsoTimestamp(value: string): boolean {
   }
 }
 
-function isDecisionContinuationLineage(
-  value: unknown,
-): value is CoachDecisionContinuationLineage {
+function isDecisionContinuationLineage(value: unknown): value is CoachDecisionContinuationLineage {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const record = value as Record<string, unknown>;
   return (
@@ -490,7 +490,7 @@ function parseRecordBytes(bytes: Buffer): TranscriptRecord | null {
 
   if (value.kind === "decision-requested") {
     if (
-      !hasExactKeys(value, [
+      (!hasExactKeys(value, [
         "version",
         "kind",
         "chatId",
@@ -501,8 +501,23 @@ function parseRecordBytes(bytes: Buffer): TranscriptRecord | null {
         "question",
         "options",
         "requestedAt",
-      ]) ||
+      ]) &&
+        !hasExactKeys(value, [
+          "version",
+          "kind",
+          "chatId",
+          "turnId",
+          "decisionId",
+          "toolCallId",
+          "messageId",
+          "athleteText",
+          "question",
+          "options",
+          "requestedAt",
+        ])) ||
       typeof value.chatId !== "string" ||
+      (value.turnId !== undefined &&
+        (typeof value.turnId !== "string" || value.turnId.length === 0)) ||
       typeof value.decisionId !== "string" ||
       value.decisionId.length === 0 ||
       typeof value.toolCallId !== "string" ||
@@ -604,8 +619,7 @@ function parseRecordBytes(bytes: Buffer): TranscriptRecord | null {
       typeof value.turnId !== "string" ||
       value.turnId.length === 0 ||
       typeof value.coachText !== "string" ||
-      (Object.hasOwn(value, "lineage") &&
-        !isDecisionContinuationLineage(value.lineage)) ||
+      (Object.hasOwn(value, "lineage") && !isDecisionContinuationLineage(value.lineage)) ||
       typeof value.completedAt !== "string" ||
       !isIsoTimestamp(value.completedAt)
     )
@@ -1231,6 +1245,7 @@ export class TranscriptStore implements TranscriptWriterPort {
     const parsed = CoachDecisionReadModelSchema.parse(input.decision);
     if (
       parsed.status !== "unanswered" ||
+      input.turnId.length === 0 ||
       input.toolCallId.length === 0 ||
       typeof input.athleteText !== "string" ||
       !isIsoTimestamp(input.requestedAt)
@@ -1246,6 +1261,7 @@ export class TranscriptStore implements TranscriptWriterPort {
       const requestedOptions = parsed.options.map(({ id: _id, ...option }) => option);
       const sameRequest =
         matchingToolCall.athleteText === input.athleteText &&
+        (matchingToolCall.turnId === undefined || matchingToolCall.turnId === input.turnId) &&
         matchingToolCall.question === parsed.question &&
         JSON.stringify(matchingOptions) === JSON.stringify(requestedOptions);
       if (sameRequest && existing !== null) return existing;
@@ -1264,6 +1280,7 @@ export class TranscriptStore implements TranscriptWriterPort {
       version: TRANSCRIPT_SCHEMA_VERSION,
       kind: "decision-requested",
       chatId: parsed.chatId,
+      turnId: input.turnId,
       decisionId: parsed.decisionId,
       toolCallId: input.toolCallId,
       messageId: parsed.messageId,
@@ -1409,6 +1426,18 @@ export class TranscriptStore implements TranscriptWriterPort {
       (record) => record.kind === "decision-requested" && record.decisionId === decisionId,
     );
     return request?.kind === "decision-requested" ? request.athleteText : null;
+  }
+
+  getTerminalTurnIds(chatId: string): ReadonlySet<string> {
+    return new Set(
+      this.readCurrentRecords(chatId).flatMap<string>((record) => {
+        if (record.kind === "turn-completed") return [record.turnId];
+        if (record.kind === "decision-requested" && record.turnId !== undefined) {
+          return [record.turnId];
+        }
+        return [];
+      }),
+    );
   }
 
   private readCurrentRecords(

--- a/packages/core/tests/chat-queue-store.test.ts
+++ b/packages/core/tests/chat-queue-store.test.ts
@@ -1,0 +1,300 @@
+import { createHash } from "node:crypto";
+import {
+  appendFileSync,
+  chmodSync,
+  copyFileSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ChatQueueStore } from "../src/agent/chat-queue-store.js";
+import { ChatStore } from "../src/agent/chat-store.js";
+import { ConversationStore, createConversationStore } from "../src/agent/conversation-store.js";
+import { TranscriptStore } from "../src/agent/transcript-store.js";
+import { WindowsPrivatePathPolicyError } from "../src/io/windows-private-path-policy.js";
+
+describe("ChatQueueStore", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    roots.splice(0).forEach((root) => rmSync(root, { recursive: true, force: true }));
+  });
+
+  function store(): { root: string; value: ChatQueueStore } {
+    const root = mkdtempSync(join(tmpdir(), "chat-queue-"));
+    roots.push(root);
+    return { root, value: new ChatQueueStore(root) };
+  }
+
+  it("durably enqueues idempotently and restores FIFO state with a monotonic revision", () => {
+    const { root, value } = store();
+    const first = value.enqueue("desktop", "submission-1", "First", "message-1");
+    const duplicate = value.enqueue("desktop", "submission-1", "Changed", "message-2");
+    const second = value.enqueue("desktop", "submission-2", "/review", "message-3");
+
+    expect(first).toMatchObject({ revision: 1, items: [{ text: "First", restored: false }] });
+    expect(duplicate).toEqual(first);
+    expect(second.items.map((item) => [item.text, item.position])).toEqual([
+      ["First", 0],
+      ["/review", 1],
+    ]);
+
+    const restored = new ChatQueueStore(root).get("desktop");
+    expect(restored.revision).toBe(2);
+    expect(restored.items.map((item) => item.restored)).toEqual([true, true]);
+  });
+
+  it("removes every unclaimed item by stable identity before dispatch", () => {
+    const { value } = store();
+    value.enqueue("desktop", "submission-1", "First", "message-1");
+    value.enqueue("desktop", "submission-2", "Second", "message-2");
+    value.enqueue("desktop", "submission-3", "Third", "message-3");
+
+    expect(value.remove("desktop", "message-2").items.map((item) => item.queuedMessageId)).toEqual([
+      "message-1",
+      "message-3",
+    ]);
+    expect(value.remove("desktop", "message-1").items.map((item) => item.queuedMessageId)).toEqual([
+      "message-3",
+    ]);
+    expect(value.remove("desktop", "message-3").items).toEqual([]);
+  });
+
+  it("claims the exact head, preserves later messages on interruption, and removes only on completion", () => {
+    const { value } = store();
+    value.enqueue("desktop", "submission-1", "First", "message-1");
+    value.enqueue("desktop", "submission-2", "Second", "message-2");
+    value.claim("desktop", {
+      claimId: "claim-1",
+      turnId: "turn-1",
+      queuedMessageIds: ["message-1"],
+    });
+
+    expect(() => value.remove("desktop", "message-1")).toThrow(/claimed/u);
+    const recovery = value.requireRetry("desktop", "claim-1");
+    expect(recovery.retryRequired).toMatchObject({ claimId: "claim-1", turnId: "turn-1" });
+    expect(recovery.items.map((item) => item.text)).toEqual(["First", "Second"]);
+
+    value.retry("desktop", "claim-1", "turn-2");
+    const completed = value.complete("desktop", "claim-1");
+    expect(completed.items.map((item) => item.text)).toEqual(["Second"]);
+    expect(completed.retryRequired).toBeUndefined();
+  });
+
+  it("reconciles a completed claimed turn without rerun and fences an incomplete claim", () => {
+    const complete = store();
+    complete.value.enqueue("desktop", "submission-1", "First", "message-1");
+    complete.value.claim("desktop", {
+      claimId: "claim-1",
+      turnId: "turn-1",
+      queuedMessageIds: ["message-1"],
+    });
+    expect(
+      new ChatQueueStore(complete.root).reconcile("desktop", new Set(["turn-1"])).items,
+    ).toEqual([]);
+
+    const incomplete = store();
+    incomplete.value.enqueue("desktop", "submission-2", "First", "message-2");
+    incomplete.value.claim("desktop", {
+      claimId: "claim-2",
+      turnId: "turn-2",
+      queuedMessageIds: ["message-2"],
+    });
+    expect(
+      new ChatQueueStore(incomplete.root).reconcile("desktop", new Set()).retryRequired,
+    ).toMatchObject({
+      claimId: "claim-2",
+    });
+  });
+
+  it("fails closed on corrupt or non-private queue snapshots", () => {
+    const { root, value } = store();
+    value.enqueue("desktop", "submission-1", "First", "message-1");
+    const queues = join(root, "chat-queues");
+    const path = join(queues, `${createHash("sha256").update("desktop").digest("hex")}.json`);
+    writeFileSync(path, "{}\n", { mode: 0o600 });
+    chmodSync(path, 0o644);
+    expect(() => value.get("desktop")).toThrow();
+  });
+
+  it("does not require a directory descriptor flush on Windows", () => {
+    const root = mkdtempSync(join(tmpdir(), "chat-queue-win-"));
+    roots.push(root);
+    const value = new ChatQueueStore(root, "win32");
+    expect(value.enqueue("desktop", "submission-1", "First", "message-1")).toMatchObject({
+      revision: 1,
+      items: [{ text: "First" }],
+    });
+  });
+
+  it("binds Windows queue paths to the private conversation directory", () => {
+    const symlinkRoot = mkdtempSync(join(tmpdir(), "chat-queue-win-link-"));
+    roots.push(symlinkRoot);
+    const outside = join(symlinkRoot, "outside");
+    mkdirSync(outside);
+    symlinkSync(outside, join(symlinkRoot, "chat-queues"));
+    expect(() => createConversationStore(symlinkRoot, 0, { platform: "win32" })).toThrow(
+      WindowsPrivatePathPolicyError,
+    );
+
+    const hardlinkRoot = mkdtempSync(join(tmpdir(), "chat-queue-win-hardlink-"));
+    roots.push(hardlinkRoot);
+    const conversations = createConversationStore(hardlinkRoot, 0, { platform: "win32" });
+    conversations.enqueueChatMessage("desktop", "submission-1", "First", "message-1");
+    const queuePath = join(
+      hardlinkRoot,
+      "chat-queues",
+      `${createHash("sha256").update("desktop").digest("hex")}.json`,
+    );
+    linkSync(queuePath, join(hardlinkRoot, "shared-queue.json"));
+    expect(() => conversations.getChatQueue("desktop")).toThrow(WindowsPrivatePathPolicyError);
+  });
+
+  it("rejects Windows queue identity changes and unstable reads through ConversationStore", () => {
+    const identityRoot = mkdtempSync(join(tmpdir(), "chat-queue-win-identity-"));
+    roots.push(identityRoot);
+    const seedIdentity = createConversationStore(identityRoot, 0, { platform: "win32" });
+    seedIdentity.enqueueChatMessage("desktop", "submission-1", "First", "message-1");
+    let replaced = false;
+    const identityStore = createConversationStore(identityRoot, 0, {
+      platform: "win32",
+      chatQueueHooks: {
+        afterFileOpen(path) {
+          if (replaced) return;
+          replaced = true;
+          const moved = `${path}.moved`;
+          renameSync(path, moved);
+          copyFileSync(moved, path);
+        },
+      },
+    });
+    expect(() => identityStore.getChatQueue("desktop")).toThrow(WindowsPrivatePathPolicyError);
+
+    const stableRoot = mkdtempSync(join(tmpdir(), "chat-queue-win-stable-"));
+    roots.push(stableRoot);
+    const seedStable = createConversationStore(stableRoot, 0, { platform: "win32" });
+    seedStable.enqueueChatMessage("desktop", "submission-1", "First", "message-1");
+    expect(seedStable.getChatQueue("desktop").items).toHaveLength(1);
+    let changed = false;
+    const unstableStore = createConversationStore(stableRoot, 0, {
+      platform: "win32",
+      chatQueueHooks: {
+        afterFileRead(path) {
+          if (changed) return;
+          changed = true;
+          appendFileSync(path, " ");
+        },
+      },
+    });
+    expect(() => unstableStore.getChatQueue("desktop")).toThrow(WindowsPrivatePathPolicyError);
+  });
+
+  it("reconciles a decision-requested crash window without resending the queued prompt", () => {
+    const root = mkdtempSync(join(tmpdir(), "chat-queue-decision-recovery-"));
+    roots.push(root);
+    const conversations = createConversationStore(root);
+    const queued = conversations.enqueueChatMessage(
+      "desktop",
+      "submission-1",
+      "Should I race tomorrow?",
+      "message-1",
+    );
+    conversations.claimChatQueue("desktop", "claim-1", "turn-1", [
+      queued.items[0]!.queuedMessageId,
+    ]);
+    conversations.appendDecisionRequested({
+      turnId: "turn-1",
+      decision: {
+        status: "unanswered",
+        decisionId: "decision-1",
+        chatId: "desktop",
+        messageId: "decision-message-1",
+        question: "Choose tomorrow's priority.",
+        options: [
+          {
+            id: "recover",
+            label: "Recover",
+            description: "Protect recovery.",
+            recommended: true,
+            consequence: "Tomorrow stays easy.",
+          },
+          {
+            id: "race",
+            label: "Race",
+            description: "Keep the race.",
+            recommended: false,
+            consequence: "Tomorrow is a race day.",
+          },
+        ],
+      },
+      toolCallId: "tool-1",
+      athleteText: "Should I race tomorrow?",
+      requestedAt: "2026-08-25T00:00:00.000Z",
+    });
+
+    const recovered = createConversationStore(root);
+    expect(recovered.getChatQueue("desktop")).toMatchObject({ items: [] });
+    expect(recovered.getDecision("desktop")).toMatchObject({
+      decisionId: "decision-1",
+      status: "unanswered",
+    });
+  });
+
+  it("clears the durable queue only after a successful conversation reset", () => {
+    const root = mkdtempSync(join(tmpdir(), "chat-queue-reset-"));
+    roots.push(root);
+    const conversations = createConversationStore(root);
+    conversations.enqueueChatMessage!("desktop", "submission-1", "First", "message-1");
+    conversations.resetConversation({
+      chatId: "desktop",
+      boundaryAt: "2026-08-25T00:00:00.000Z",
+      reason: "explicit-reset",
+    });
+    expect(conversations.getChatQueue!("desktop").items).toEqual([]);
+  });
+
+  it("keeps the reset intent until queue clearing succeeds and recovers the exact crash window", () => {
+    const root = mkdtempSync(join(tmpdir(), "chat-queue-reset-recovery-"));
+    roots.push(root);
+    class FailingClearQueueStore extends ChatQueueStore {
+      override clear(_chatId: string): never {
+        throw new Error("synthetic queue clear failure");
+      }
+    }
+    const queue = new FailingClearQueueStore(root);
+    const transcript = new TranscriptStore(root);
+    const conversations = new ConversationStore(
+      new ChatStore(root),
+      transcript,
+      () => "a".repeat(64),
+      queue,
+    );
+    queue.enqueue("desktop", "submission-1", "First", "message-1");
+    expect(() =>
+      conversations.resetConversation({
+        chatId: "desktop",
+        boundaryAt: "2026-08-25T00:00:00.000Z",
+        reason: "explicit-reset",
+      }),
+    ).toThrow("synthetic queue clear failure");
+    expect(transcript.readResetIntent("desktop")).not.toBeNull();
+
+    const recoveredQueue = new ChatQueueStore(root);
+    const recoveredTranscript = new TranscriptStore(root);
+    const recovered = new ConversationStore(
+      new ChatStore(root),
+      recoveredTranscript,
+      () => "b".repeat(64),
+      recoveredQueue,
+    );
+    expect(recovered.getChatQueue("desktop").items).toEqual([]);
+    expect(recoveredTranscript.readResetIntent("desktop")).toBeNull();
+  });
+});

--- a/packages/core/tests/coach-decision-transcript.test.ts
+++ b/packages/core/tests/coach-decision-transcript.test.ts
@@ -51,6 +51,7 @@ describe("TranscriptStore coach decisions", () => {
     const store = new TranscriptStore(makeDataDir());
     const requested = {
       decision: unanswered(),
+      turnId: "turn-decision",
       toolCallId: "tool-1",
       athleteText: "Should I keep tomorrow's tempo session?",
       requestedAt: "2026-08-24T00:00:00.000Z",
@@ -92,6 +93,7 @@ describe("TranscriptStore coach decisions", () => {
     expect(answered).toMatchObject({ status: "answered", continuation: { status: "pending" } });
     expect(() =>
       store.appendDecisionRequested({
+        turnId: "turn-decision",
         decision: unanswered("decision-2"),
         toolCallId: "tool-2",
         athleteText: "One more question.",
@@ -207,6 +209,7 @@ describe("TranscriptStore coach decisions", () => {
       () => RESET_ID,
     );
     store.appendDecisionRequested({
+      turnId: "turn-decision",
       decision: unanswered(),
       toolCallId: "tool-1",
       athleteText: "Should I keep tomorrow's tempo session?",
@@ -250,6 +253,7 @@ describe("TranscriptStore coach decisions", () => {
     });
     const store = new ConversationStore(new ChatStore(dataDir), transcript, () => RESET_ID);
     store.appendDecisionRequested({
+      turnId: "turn-decision",
       decision: unanswered(),
       toolCallId: "tool-1",
       athleteText: "Should I keep tomorrow's tempo session?",

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -336,7 +336,10 @@ export class CoachAgent {
   // skills, tool schemas, model, and the compile-time rule-block set), so it is
   // computed once on first use and reused for every turn of the process.
   private templateHash?: string;
-  private readonly activeChatTurns = new Map<string, AbortController>();
+  private readonly activeChatTurns = new Map<
+    string,
+    { readonly turnId: string; readonly controller: AbortController }
+  >();
 
   constructor(sport: Sport, ports: EngineHostPorts) {
     const config = ports.config;
@@ -684,21 +687,25 @@ export class CoachAgent {
     turn?: { resolvedCs?: ResolvedCs | null; referenceProvenance?: SourceProvenance },
     onEvent?: TurnEventHandler,
     onDecision?: (decision: CoachDecisionReadModel) => void,
+    requestedTurnId?: string,
   ): Promise<string> {
     // One explicit context per turn, created synchronously before the session
     // lock is queued so rapid same-chat sends can never share turn state. Tool
     // wrappers and sport tools reach it through the tool-execution options, so
     // the tool set and cached template hash never rebuild. resolvedCs is null
     // when the channel supplies nothing (CLI path, no sync data).
+    const turnId = requestedTurnId ?? this.ports.randomId();
     const ctx = createTurnContext(
       turn?.resolvedCs ?? null,
       chatId,
       turn?.referenceProvenance ?? EMPTY_PROVENANCE,
       userMessage,
+      turnId,
     );
     return withSessionLock(chatId, async () => {
       const abortController = new AbortController();
-      this.activeChatTurns.set(chatId, abortController);
+      const activeTurn = { turnId, controller: abortController };
+      this.activeChatTurns.set(chatId, activeTurn);
       try {
         const existingDecision = this.ports.coachDecisions?.getDecision(chatId);
         if (existingDecision?.status === "unanswered") {
@@ -720,7 +727,6 @@ export class CoachAgent {
           this.repairCoachDecisionSession(existingDecision);
         }
         const turnStart = this.ports.now();
-        const turnId = this.ports.randomId();
         const emitEvent = (event: TurnEvent): void => {
           try {
             onEvent?.(event);
@@ -1402,17 +1408,22 @@ export class CoachAgent {
           throw terminalErr;
         }
       } finally {
-        if (this.activeChatTurns.get(chatId) === abortController) {
+        if (this.activeChatTurns.get(chatId) === activeTurn) {
           this.activeChatTurns.delete(chatId);
         }
       }
     });
   }
 
-  stopChat(chatId: string): boolean {
-    const controller = this.activeChatTurns.get(chatId);
-    if (controller === undefined || controller.signal.aborted) return false;
-    controller.abort();
+  stopChat(chatId: string, turnId: string): boolean {
+    const activeTurn = this.activeChatTurns.get(chatId);
+    if (
+      activeTurn === undefined ||
+      activeTurn.turnId !== turnId ||
+      activeTurn.controller.signal.aborted
+    )
+      return false;
+    activeTurn.controller.abort();
     return true;
   }
 
@@ -1641,7 +1652,7 @@ export class CoachAgent {
     try {
       onEvent?.({ type: "turn-start", turnId, chatId: decision.chatId });
     } catch {}
-    const context = createTurnContext(null, decision.chatId, EMPTY_PROVENANCE, "");
+    const context = createTurnContext(null, decision.chatId, EMPTY_PROVENANCE, "", turnId);
     const system =
       buildSystemPrompt(this.sport, this.memory, this.tz, this.buildDegradeBlock(), {
         excludeSections: this.excludedSectionNames,
@@ -1705,7 +1716,8 @@ export class CoachAgent {
     ] as ModelMessage[];
     const abortController = new AbortController();
     let streamedText = "";
-    this.activeChatTurns.set(decision.chatId, abortController);
+    const activeTurn = { turnId, controller: abortController };
+    this.activeChatTurns.set(decision.chatId, activeTurn);
     try {
       const result = await this.llm.generate({
         system,
@@ -1745,12 +1757,9 @@ export class CoachAgent {
       try {
         onEvent?.({ type: "interrupted", turnId, chatId: decision.chatId, text: streamedText });
       } catch {}
-      return this.requireCoachDecisionStore().getDecision(
-        decision.chatId,
-        decision.decisionId,
-      )!;
+      return this.requireCoachDecisionStore().getDecision(decision.chatId, decision.decisionId)!;
     } finally {
-      if (this.activeChatTurns.get(decision.chatId) === abortController) {
+      if (this.activeChatTurns.get(decision.chatId) === activeTurn) {
         this.activeChatTurns.delete(decision.chatId);
       }
     }

--- a/packages/engine/src/agent/coach-decision-tool.ts
+++ b/packages/engine/src/agent/coach-decision-tool.ts
@@ -57,6 +57,7 @@ export function createCoachDecisionTool(input: {
       try {
         persisted = input.store.appendDecisionRequested({
           decision,
+          turnId: context.turnId,
           toolCallId: execution.toolCallId,
           athleteText: context.athleteText,
           requestedAt: new Date(input.now()).toISOString(),

--- a/packages/engine/src/agent/turn-context.ts
+++ b/packages/engine/src/agent/turn-context.ts
@@ -30,6 +30,7 @@ export interface TurnContext {
   readonly resolvedCs: ResolvedCs | null;
   /** Chat this turn belongs to; the key a host confirmation surface resolves a proposal against. */
   readonly chatId: string;
+  readonly turnId: string;
   readonly athleteText: string;
   /** Per-turn read-tool memoizer cache. */
   readonly readToolCache: Map<string, unknown>;
@@ -53,11 +54,13 @@ export function createTurnContext(
   chatId: string = "",
   referenceProvenance: SourceProvenance = EMPTY_PROVENANCE,
   athleteText: string = "",
+  turnId: string = "",
 ): TurnContext {
   const ctx: BrandedTurnContext = {
     [TURN_CONTEXT_BRAND]: true,
     resolvedCs,
     chatId,
+    turnId,
     athleteText,
     readToolCache: new Map<string, unknown>(),
     turnWrites: { writesCommitted: 0 },

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -1,5 +1,6 @@
 import type {
   AthleteState,
+  ChatQueueSnapshot,
   CoachDecisionAnswer,
   CoachDecisionContinuationLineage,
   CoachDecisionReadModel,
@@ -149,6 +150,24 @@ export interface ChatStorePort {
   overwriteHistory(chatId: string, messages: ModelMessage[]): void;
   resetConversation(input: ConversationResetInput): void;
   archivePreCompact(chatId: string): void;
+  getChatQueue?(chatId: string): ChatQueueSnapshot;
+  enqueueChatMessage?(
+    chatId: string,
+    submissionId: string,
+    text: string,
+    queuedMessageId: string,
+  ): ChatQueueSnapshot;
+  removeQueuedChatMessage?(chatId: string, queuedMessageId: string): ChatQueueSnapshot;
+  claimChatQueue?(
+    chatId: string,
+    claimId: string,
+    turnId: string,
+    queuedMessageIds: readonly string[],
+  ): ChatQueueSnapshot;
+  completeChatQueueClaim?(chatId: string, claimId: string): ChatQueueSnapshot;
+  requireChatQueueRetry?(chatId: string, claimId: string): ChatQueueSnapshot;
+  retryChatQueueClaim?(chatId: string, claimId: string, turnId: string): ChatQueueSnapshot;
+  clearChatQueue?(chatId: string): ChatQueueSnapshot;
 }
 
 export type TranscriptConversationBoundaryReason = "explicit-reset" | "stale-reset";
@@ -177,6 +196,7 @@ export interface TranscriptWriterPort {
 export interface CoachDecisionStorePort {
   appendDecisionRequested(input: {
     readonly decision: CoachDecisionReadModel;
+    readonly turnId: string;
     readonly toolCallId: string;
     readonly athleteText: string;
     readonly requestedAt: string;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,4 +1,10 @@
-import type { CoachEngine } from "@enduragent/coach-contract";
+import type {
+  ChatQueueRunResult,
+  ChatQueueSnapshot,
+  CoachEngine,
+  QueuedChatMessage,
+  TurnEvent,
+} from "@enduragent/coach-contract";
 import { CoachAgent } from "./agent/coach-agent.js";
 import { extractAccountId } from "./agent/codex/jwt.js";
 import type { EngineHostPorts } from "./host-ports.js";
@@ -57,6 +63,137 @@ export interface CreateCoachEngineInput {
 
 export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
   const agent = new CoachAgent(input.sport, input.ports);
+  const queueRuns = new Map<string, Promise<ChatQueueRunResult>>();
+  const queueAuthorities = new Map<string, Promise<void>>();
+  const withQueueAuthority = async <T>(chatId: string, work: () => Promise<T>): Promise<T> => {
+    const previous = queueAuthorities.get(chatId) ?? Promise.resolve();
+    let release = (): void => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.catch(() => {}).then(() => gate);
+    queueAuthorities.set(chatId, tail);
+    await previous.catch(() => {});
+    try {
+      return await work();
+    } finally {
+      release();
+      if (queueAuthorities.get(chatId) === tail) queueAuthorities.delete(chatId);
+    }
+  };
+  const queuePort = <K extends keyof EngineHostPorts["chatStore"]>(
+    name: K,
+  ): NonNullable<EngineHostPorts["chatStore"][K]> => {
+    const operation = input.ports.chatStore[name];
+    if (typeof operation !== "function")
+      throw new Error("Durable chat queue storage is unavailable.");
+    return operation as NonNullable<EngineHostPorts["chatStore"][K]>;
+  };
+  const snapshot = (chatId: string): ChatQueueSnapshot =>
+    queuePort("getChatQueue").call(input.ports.chatStore, chatId);
+  const queueText = (items: readonly QueuedChatMessage[]): string =>
+    items.map((item) => item.text).join("\n\n");
+  const runQueue = (
+    chatId: string,
+    mode: "resume" | "command" | "retry",
+    exactId: string | undefined,
+    onEvent: ((event: TurnEvent) => void) | undefined,
+  ): Promise<ChatQueueRunResult> => {
+    const active = queueRuns.get(chatId);
+    if (active !== undefined) return active;
+    const task = withQueueAuthority(chatId, async (): Promise<ChatQueueRunResult> => {
+      const before = snapshot(chatId);
+      const pendingDecision = input.ports.coachDecisions?.getDecision(chatId);
+      if (
+        pendingDecision?.status === "unanswered" ||
+        (pendingDecision?.status === "answered" &&
+          pendingDecision.continuation.status === "pending")
+      ) {
+        return { snapshot: before };
+      }
+      let claimId: string;
+      let turnId: string;
+      let selected: readonly QueuedChatMessage[];
+      if (mode === "retry") {
+        const recovery = before.retryRequired;
+        if (recovery === undefined || recovery.claimId !== exactId) return { snapshot: before };
+        claimId = recovery.claimId;
+        turnId = input.ports.randomId();
+        selected = before.items.slice(0, recovery.queuedMessageIds.length);
+        queuePort("retryChatQueueClaim").call(input.ports.chatStore, chatId, claimId, turnId);
+      } else {
+        const head = before.items[0];
+        if (head === undefined || before.retryRequired !== undefined) return { snapshot: before };
+        if (mode === "command") {
+          if (head.kind !== "slash-command" || head.queuedMessageId !== exactId)
+            return { snapshot: before };
+          selected = [head];
+        } else {
+          if (head.kind === "slash-command") {
+            if (head.restored) return { snapshot: before };
+            selected = [head];
+          } else {
+            let size = 1;
+            while (before.items[size]?.kind === "ordinary") size += 1;
+            selected = before.items.slice(0, size);
+          }
+        }
+        claimId = input.ports.randomId();
+        turnId = input.ports.randomId();
+        queuePort("claimChatQueue").call(
+          input.ports.chatStore,
+          chatId,
+          claimId,
+          turnId,
+          selected.map((item) => item.queuedMessageId),
+        );
+      }
+      let interrupted = false;
+      try {
+        let decision;
+        const text = await agent.chat(
+          chatId,
+          queueText(selected),
+          undefined,
+          (event) => {
+            if (event.type === "interrupted") interrupted = true;
+            onEvent?.(event);
+          },
+          (requested) => {
+            decision = requested;
+          },
+          turnId,
+        );
+        if (interrupted) {
+          return {
+            snapshot: queuePort("requireChatQueueRetry").call(
+              input.ports.chatStore,
+              chatId,
+              claimId,
+            ),
+            response: decision === undefined ? { text } : { text, decision },
+          };
+        }
+        return {
+          snapshot: queuePort("completeChatQueueClaim").call(
+            input.ports.chatStore,
+            chatId,
+            claimId,
+          ),
+          response: decision === undefined ? { text } : { text, decision },
+        };
+      } catch (error) {
+        queuePort("requireChatQueueRetry").call(input.ports.chatStore, chatId, claimId);
+        throw error;
+      }
+    });
+    queueRuns.set(chatId, task);
+    const release = (): void => {
+      if (queueRuns.get(chatId) === task) queueRuns.delete(chatId);
+    };
+    void task.then(release, release);
+    return task;
+  };
   return {
     chat: async (request, onEvent) => {
       let decision;
@@ -73,12 +210,33 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
       );
       return decision === undefined ? { text } : { text, decision };
     },
-    stopChat: async (request) => ({ stopped: agent.stopChat(request.chatId) }),
+    stopChat: async (request) => ({ stopped: agent.stopChat(request.chatId, request.turnId) }),
+    enqueueChatMessage: async (request) =>
+      queuePort("enqueueChatMessage").call(
+        input.ports.chatStore,
+        request.chatId,
+        request.submissionId,
+        request.text,
+        input.ports.randomId(),
+      ),
+    getChatQueue: async (request) => snapshot(request.chatId),
+    removeQueuedChatMessage: async (request) =>
+      queuePort("removeQueuedChatMessage").call(
+        input.ports.chatStore,
+        request.chatId,
+        request.queuedMessageId,
+      ),
+    resumeChatQueue: (request, onEvent) => runQueue(request.chatId, "resume", undefined, onEvent),
+    runQueuedCommand: (request, onEvent) =>
+      runQueue(request.chatId, "command", request.queuedMessageId, onEvent),
+    retryQueuedTurn: (request, onEvent) =>
+      runQueue(request.chatId, "retry", request.claimId, onEvent),
     getCoachDecision: (request) => agent.getCoachDecision(request),
     answerCoachDecision: (request, onEvent) => agent.answerCoachDecision(request, onEvent),
     skipCoachDecision: (request) => agent.skipCoachDecision(request),
     resumeCoachDecision: (request, onEvent) => agent.resumeCoachDecision(request, onEvent),
-    resetSession: (request) => agent.resetSession(request.chatId),
+    resetSession: (request) =>
+      withQueueAuthority(request.chatId, () => agent.resetSession(request.chatId)),
     hasSession: async (request) => ({ hasSession: agent.hasSession(request.chatId) }),
     getAthleteState: () => agent.getAthleteState(),
   };

--- a/packages/engine/tests/chat-queue.test.ts
+++ b/packages/engine/tests/chat-queue.test.ts
@@ -1,0 +1,216 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import { createCoachEngine } from "../src/index.js";
+import type { EngineHostPorts, ModelTransportRequest } from "../src/host-ports.js";
+import type { GenerateResult, Sport } from "../src/sport.js";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  roots.splice(0).forEach((root) => rmSync(root, { recursive: true, force: true }));
+});
+
+function generated(text: string): GenerateResult {
+  const usage = {
+    inputTokens: 1,
+    outputTokens: 1,
+    totalTokens: 2,
+    inputTokenDetails: { noCacheTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    outputTokenDetails: { textTokens: 1, reasoningTokens: 0 },
+  };
+  return { text, toolCalls: [], finishReason: "stop", usage, totalUsage: usage, steps: 1 };
+}
+
+function setup(
+  root = mkdtempSync(join(tmpdir(), "engine-chat-queue-")),
+  generate: (request: ModelTransportRequest) => Promise<GenerateResult> = async () =>
+    generated("Done"),
+) {
+  if (!roots.includes(root)) roots.push(root);
+  const base = baseAgentConfig(root);
+  let sequence = 0;
+  const ports: EngineHostPorts = {
+    ...base,
+    transcriptWriter: base.chatStore as unknown as EngineHostPorts["transcriptWriter"],
+    randomId: () => `id-${++sequence}`,
+    modelTransportDecorator: () => ({ generate }),
+  };
+  return {
+    root,
+    ports,
+    engine: createCoachEngine({ sport: cyclingSport as unknown as Sport, ports }),
+  };
+}
+
+describe("engine durable chat queue", () => {
+  it("groups consecutive ordinary messages and stops at a command barrier", async () => {
+    const requests: ModelTransportRequest[] = [];
+    const { engine } = setup(undefined, async (request) => {
+      requests.push(request);
+      return generated(`Reply ${requests.length}`);
+    });
+    await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s1", text: "First" });
+    await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s2", text: "Second" });
+    await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s3", text: "/review" });
+    await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s4", text: "Later" });
+
+    const first = await engine.resumeChatQueue!({ chatId: "desktop" });
+    expect(first.response?.text).toBe("Reply 1");
+    expect(first.snapshot.items.map((item) => item.text)).toEqual(["/review", "Later"]);
+    expect(JSON.stringify(requests[0]?.options.messages)).toContain("First\\n\\nSecond");
+
+    const command = await engine.resumeChatQueue!({ chatId: "desktop" });
+    expect(command.response?.text).toBe("Reply 2");
+    expect(command.snapshot.items.map((item) => item.text)).toEqual(["Later"]);
+  });
+
+  it("requires Run command only after a slash command is restored", async () => {
+    const first = setup();
+    const queued = await first.engine.enqueueChatMessage!({
+      chatId: "desktop",
+      submissionId: "s1",
+      text: "/review",
+    });
+    const id = queued.items[0]!.queuedMessageId;
+    const restored = setup(first.root);
+
+    const held = await restored.engine.resumeChatQueue!({ chatId: "desktop" });
+    expect(held.response).toBeUndefined();
+    expect(held.snapshot.items[0]).toMatchObject({ restored: true, queuedMessageId: id });
+    await expect(
+      restored.engine.runQueuedCommand!({ chatId: "desktop", queuedMessageId: id }),
+    ).resolves.toMatchObject({ response: { text: "Done" }, snapshot: { items: [] } });
+  });
+
+  it("does not claim or run while an unanswered coach decision owns the chat", async () => {
+    const generate = vi.fn(async () => generated("Unexpected"));
+    const { engine, ports } = setup(undefined, generate);
+    await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s1", text: "Later" });
+    ports.coachDecisions!.appendDecisionRequested({
+      turnId: "turn-decision",
+      decision: {
+        status: "unanswered",
+        decisionId: "decision-1",
+        chatId: "desktop",
+        messageId: "message-1",
+        question: "Choose.",
+        options: [
+          { id: "a", label: "A", description: "A", recommended: true, consequence: "A" },
+          { id: "b", label: "B", description: "B", recommended: false, consequence: "B" },
+        ],
+      },
+      toolCallId: "tool-1",
+      athleteText: "Question",
+      requestedAt: "2026-08-25T00:00:00.000Z",
+    });
+
+    const blocked = await engine.resumeChatQueue!({ chatId: "desktop" });
+    expect(blocked.response).toBeUndefined();
+    expect(blocked.snapshot.items.map((item) => item.text)).toEqual(["Later"]);
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("fences queue execution behind a paused reset for the same chat", async () => {
+    let releaseFlush!: () => void;
+    const flushStarted = new Promise<void>((resolve) => {
+      releaseFlush = resolve;
+    });
+    let allowFlush!: () => void;
+    const flushGate = new Promise<void>((resolve) => {
+      allowFlush = resolve;
+    });
+    const generate = vi.fn(async (request: ModelTransportRequest) => {
+      if (request.options.caller === "flush") {
+        releaseFlush();
+        await flushGate;
+        return generated("Flush complete");
+      }
+      return generated("Unexpected queue response");
+    });
+    const { engine, ports } = setup(undefined, generate);
+    ports.chatStore.overwriteHistory("desktop", [{ role: "user", content: "Earlier message" }]);
+    await engine.enqueueChatMessage!({
+      chatId: "desktop",
+      submissionId: "submission-1",
+      text: "Queued during reset race",
+    });
+
+    const reset = engine.resetSession({ chatId: "desktop" });
+    await flushStarted;
+    const resume = engine.resumeChatQueue!({ chatId: "desktop" });
+    await Promise.resolve();
+    expect(generate).toHaveBeenCalledTimes(1);
+    allowFlush();
+
+    await expect(reset).resolves.toMatchObject({ memoryFlushed: true });
+    await expect(resume).resolves.toMatchObject({ snapshot: { items: [] } });
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles a durably projected claimed turn without rerunning it", async () => {
+    const generate = vi.fn(async () => generated("Unexpected"));
+    const { engine, ports } = setup(undefined, generate);
+    const queued = await engine.enqueueChatMessage!({
+      chatId: "desktop",
+      submissionId: "s1",
+      text: "First",
+    });
+    const id = queued.items[0]!.queuedMessageId;
+    ports.chatStore.claimChatQueue!("desktop", "claim-1", "turn-1", [id]);
+    ports.transcriptWriter.appendCompletedTurn({
+      chatId: "desktop",
+      turnId: "turn-1",
+      completedAt: "2026-08-25T00:00:00.000Z",
+      athleteText: "First",
+      coachText: "Done",
+    });
+
+    expect(await engine.getChatQueue!({ chatId: "desktop" })).toMatchObject({ items: [] });
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("Stop marks only the active claim retry-required and never drains the command behind it", async () => {
+    let started!: () => void;
+    const active = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    let attempts = 0;
+    const generate = vi.fn((request: ModelTransportRequest) => {
+      attempts += 1;
+      if (attempts === 2) return Promise.resolve(generated("Recovered"));
+      return new Promise<GenerateResult>((_resolve, reject) => {
+        started();
+        request.options.signal?.addEventListener("abort", () => reject(new Error("stopped")), {
+          once: true,
+        });
+      });
+    });
+    const { engine } = setup(undefined, generate);
+    await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s1", text: "First" });
+    await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s2", text: "/review" });
+    const running = engine.resumeChatQueue!({ chatId: "desktop" }).catch(() => undefined);
+    await active;
+    await engine.stopChat!({ chatId: "desktop", turnId: "id-4" });
+    await running;
+
+    const snapshot = await engine.getChatQueue!({ chatId: "desktop" });
+    expect(snapshot.retryRequired).toMatchObject({
+      queuedMessageIds: [snapshot.items[0]!.queuedMessageId],
+    });
+    expect(snapshot.items.map((item) => item.text)).toEqual(["First", "/review"]);
+    expect(generate).toHaveBeenCalledTimes(1);
+
+    const retried = await engine.retryQueuedTurn!({
+      chatId: "desktop",
+      claimId: snapshot.retryRequired!.claimId,
+    });
+    expect(retried.response?.text).toBe("Recovered");
+    expect(retried.snapshot.retryRequired).toBeUndefined();
+    expect(retried.snapshot.items.map((item) => item.text)).toEqual(["/review"]);
+    expect(generate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/engine/tests/coach-agent-transcript.test.ts
+++ b/packages/engine/tests/coach-agent-transcript.test.ts
@@ -52,6 +52,7 @@ function harness(input: {
   appendCompletedTurn?: (turn: TranscriptCompletedTurnInput) => void;
   appendInterruptedTurn?: (turn: TranscriptInterruptedTurnInput) => void;
   config?: Partial<EngineHostPorts["config"]["session"]>;
+  randomId?: () => string;
 }) {
   const dataDir = makeDataDir();
   const base = baseAgentConfig(dataDir);
@@ -69,7 +70,7 @@ function harness(input: {
       session: { ...base.config.session, timezone: "UTC", ...input.config },
     },
     now: () => Date.parse("2026-07-22T12:34:56.789Z"),
-    randomId: () => "turn-transcript-1",
+    randomId: input.randomId ?? (() => "turn-transcript-1"),
     classifyFailure: input.classifyFailure ?? base.classifyFailure,
     logger: {
       ...base.logger,
@@ -279,9 +280,9 @@ describe("CoachAgent transcript recording", () => {
     );
 
     await vi.waitFor(() => expect(releaseFirst).toBeTypeOf("function"));
-    expect(setup.agent.stopChat("chat-stop")).toBe(true);
+    expect(setup.agent.stopChat("chat-stop", "turn-transcript-1")).toBe(true);
     await expect(first).resolves.toBe("Partial response");
-    expect(setup.agent.stopChat("chat-stop")).toBe(false);
+    expect(setup.agent.stopChat("chat-stop", "turn-transcript-1")).toBe(false);
     expect(setup.completed).toEqual([]);
     expect(setup.interrupted).toEqual([
       {
@@ -306,6 +307,39 @@ describe("CoachAgent transcript recording", () => {
 
     await expect(setup.agent.chat("chat-stop", "continue")).resolves.toBe("next response");
     releaseFirst?.();
+  });
+
+  it("ignores a delayed Stop for a completed turn after its successor starts", async () => {
+    const ids = ["turn-a", "turn-b"];
+    let secondStarted!: () => void;
+    const activeSecond = new Promise<void>((resolve) => {
+      secondStarted = resolve;
+    });
+    let secondSignal: AbortSignal | undefined;
+    let attempt = 0;
+    const setup = harness({
+      randomId: () => ids.shift() ?? "unexpected-turn",
+      generate: async (request) => {
+        attempt += 1;
+        if (attempt === 1) return result("First response");
+        secondSignal = request.options.signal;
+        secondStarted();
+        await new Promise<void>((_resolve, reject) => {
+          request.options.signal?.addEventListener("abort", () => reject(new Error("stopped")), {
+            once: true,
+          });
+        });
+        return result("unreachable");
+      },
+    });
+
+    await setup.agent.chat("chat-stop-scope", "first");
+    const second = setup.agent.chat("chat-stop-scope", "second");
+    await activeSecond;
+    expect(setup.agent.stopChat("chat-stop-scope", "turn-a")).toBe(false);
+    expect(secondSignal?.aborted).toBe(false);
+    expect(setup.agent.stopChat("chat-stop-scope", "turn-b")).toBe(true);
+    await expect(second).resolves.toBe("");
   });
 
   it.each([

--- a/packages/engine/tests/coach-decision-lifecycle.test.ts
+++ b/packages/engine/tests/coach-decision-lifecycle.test.ts
@@ -100,6 +100,7 @@ describe("coach decision lifecycle", () => {
     const { engine, generate, store } = setup();
     const events: TurnEvent[] = [];
     store.appendDecisionRequested({
+      turnId: "turn-decision",
       decision: makeDecision("chat-1"),
       toolCallId: "tool-1",
       athleteText: "What should I do tomorrow?",
@@ -150,6 +151,7 @@ describe("coach decision lifecycle", () => {
   it("skips without calling the model", async () => {
     const { engine, generate, store } = setup();
     store.appendDecisionRequested({
+      turnId: "turn-decision",
       decision: makeDecision("chat-2"),
       toolCallId: "tool-2",
       athleteText: "What should I do tomorrow?",
@@ -168,6 +170,7 @@ describe("coach decision lifecycle", () => {
   it("returns durable Skip when structured session repair fails", async () => {
     const { engine, generate, store, chatStore } = setup();
     store.appendDecisionRequested({
+      turnId: "turn-decision",
       decision: makeDecision("chat-skip-failure"),
       toolCallId: "tool-skip-failure",
       athleteText: "What should I do tomorrow?",
@@ -189,6 +192,7 @@ describe("coach decision lifecycle", () => {
   it("repairs structured session context on resume without another provider call", async () => {
     const { engine, generate, store, chatStore } = setup();
     store.appendDecisionRequested({
+      turnId: "turn-decision",
       decision: makeDecision("chat-3"),
       toolCallId: "tool-3",
       athleteText: "What should I do tomorrow?",
@@ -220,6 +224,7 @@ describe("coach decision lifecycle", () => {
   it("emits turn-start before stored final text when resuming a completed continuation", async () => {
     const { engine, generate, store } = setup();
     store.appendDecisionRequested({
+      turnId: "turn-decision",
       decision: makeDecision("chat-5"),
       toolCallId: "tool-5",
       athleteText: "What should I do tomorrow?",
@@ -250,6 +255,7 @@ describe("coach decision lifecycle", () => {
   it("rejects ordinary chat while a decision is unanswered", async () => {
     const { engine, generate, store } = setup();
     store.appendDecisionRequested({
+      turnId: "turn-decision",
       decision: makeDecision("chat-4"),
       toolCallId: "tool-4",
       athleteText: "What should I do tomorrow?",
@@ -267,12 +273,14 @@ describe("coach decision lifecycle", () => {
     let firstStarted = false;
     generate
       .mockImplementationOnce(async (request: unknown) => {
-        const options = (request as {
-          options: {
-            signal?: AbortSignal;
-            onTextDelta?: (delta: string) => void;
-          };
-        }).options;
+        const options = (
+          request as {
+            options: {
+              signal?: AbortSignal;
+              onTextDelta?: (delta: string) => void;
+            };
+          }
+        ).options;
         firstStarted = true;
         options.onTextDelta?.("Partial decision response");
         await new Promise<void>((_resolve, reject) => {
@@ -309,6 +317,7 @@ describe("coach decision lifecycle", () => {
         },
       });
     store.appendDecisionRequested({
+      turnId: "turn-decision",
       decision: makeDecision("chat-stop-decision"),
       toolCallId: "tool-stop-decision",
       athleteText: "What should I do tomorrow?",
@@ -327,8 +336,10 @@ describe("coach decision lifecycle", () => {
     await vi.waitFor(() => expect(firstStarted).toBe(true));
     expect(engine.stopChat).toBeDefined();
     const stopChat = engine.stopChat!;
-    await expect(stopChat({ chatId: "another-chat" })).resolves.toEqual({ stopped: false });
-    await expect(stopChat({ chatId: "chat-stop-decision" })).resolves.toEqual({
+    await expect(stopChat({ chatId: "another-chat", turnId: "turn-1" })).resolves.toEqual({
+      stopped: false,
+    });
+    await expect(stopChat({ chatId: "chat-stop-decision", turnId: "turn-1" })).resolves.toEqual({
       stopped: true,
     });
     await expect(answer).resolves.toMatchObject({
@@ -346,7 +357,7 @@ describe("coach decision lifecycle", () => {
         coachText: "Partial decision response",
       }),
     );
-    await expect(stopChat({ chatId: "chat-stop-decision" })).resolves.toEqual({
+    await expect(stopChat({ chatId: "chat-stop-decision", turnId: "turn-1" })).resolves.toEqual({
       stopped: false,
     });
 
@@ -366,6 +377,7 @@ describe("coach decision lifecycle", () => {
   it("rejects a Conversation reset while an answer continuation is pending", async () => {
     const { engine, store } = setup();
     store.appendDecisionRequested({
+      turnId: "turn-decision",
       decision: makeDecision("chat-reset"),
       toolCallId: "tool-reset",
       athleteText: "What should I do tomorrow?",

--- a/packages/engine/tests/engine-contract.test.ts
+++ b/packages/engine/tests/engine-contract.test.ts
@@ -69,11 +69,17 @@ describe("createCoachEngine", () => {
     expect(Object.keys(engine).sort()).toEqual([
       "answerCoachDecision",
       "chat",
+      "enqueueChatMessage",
       "getAthleteState",
+      "getChatQueue",
       "getCoachDecision",
       "hasSession",
+      "removeQueuedChatMessage",
       "resetSession",
+      "resumeChatQueue",
       "resumeCoachDecision",
+      "retryQueuedTurn",
+      "runQueuedCommand",
       "skipCoachDecision",
       "stopChat",
     ]);


### PR DESCRIPTION
## Summary
- persist queued Chat messages per conversation and restore them after relaunch
- process ordinary messages in FIFO order while keeping slash commands explicit
- preserve failed queue operations with recovery actions instead of losing athlete input
- carry scoped turn IDs through Stop so cancellation affects only the active response

## Verification
- root `pnpm check` passed with 18 existing warnings and 0 errors
- 13 queue/recovery integration files passed: 165 tests
- coach-client RPC suite passed in isolation: 127 tests
- `git diff --check` passed

## Limits
- queue RPC calls time out after 30 seconds
- queue execution and recovery calls time out after 11 minutes
- scoped Stop times out after 10 seconds
- queue and recovery identifiers must contain at least one character
- retry claims must contain at least one queued message
- no queue item-count or byte cap is introduced in this slice