### PR TITLE
fix(desktop): reconcile a credential reset that finishes after Settings closes

### DIFF
--- a/.changeset/reconcile-closed-credential-reset.md
+++ b/.changeset/reconcile-closed-credential-reset.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Closing Settings while credentials are being removed no longer blocks setup until Settings is reopened.

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -600,18 +600,28 @@ export function createCredentialSettingsController(input: {
       } catch {
         result = { status: "refused", reason: "storage-failed" };
       }
-      if (disposed || generation !== operationGeneration) return;
+      if (disposed) return;
       let loaded: Awaited<ReturnType<typeof loadEntries>>;
       try {
         loaded = await loadEntries();
-        if (disposed || generation !== operationGeneration) return;
+        if (disposed) return;
         if (result.status === "refused") {
           await input.onReconciled?.();
         } else {
           await input.onDeleted?.();
         }
       } catch {
-        if (disposed || generation !== operationGeneration) return;
+        if (disposed) return;
+        if (generation !== operationGeneration) {
+          const repairCredential =
+            result.status === "refused" ? repairRequiredCredential(currentState) : null;
+          render({
+            status: "closed",
+            ...(repairCredential === null ? {} : { repairCredential }),
+            resetUncertain: true,
+          });
+          return;
+        }
         releaseMutation();
         render({
           status: "error",
@@ -628,6 +638,15 @@ export function createCredentialSettingsController(input: {
         return;
       }
       if (disposed || activeResetOperation !== resetOperation) return;
+      if (generation !== operationGeneration) {
+        const repairCredential =
+          result.status === "refused" ? repairRequiredCredential(currentState) : null;
+        render({
+          status: "closed",
+          ...(repairCredential === null ? {} : { repairCredential }),
+        });
+        return;
+      }
       releaseMutation();
       if (result.status === "refused") {
         render({
@@ -644,10 +663,6 @@ export function createCredentialSettingsController(input: {
           recoveryAvailable: false,
           focus: { target: "feedback" },
         });
-        return;
-      }
-      if (generation !== operationGeneration) {
-        render({ status: "closed" });
         return;
       }
       render({

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -615,6 +615,126 @@ describe("credential settings controller", () => {
     expect(controller.state().resetUncertain).toBeUndefined();
   });
 
+  it("reconciles a successful reset after closing while the reset RPC is pending", async () => {
+    let resolveReset!: (result: CredentialResetResult) => void;
+    const reset = new Promise<CredentialResetResult>((resolve) => {
+      resolveReset = resolve;
+    });
+    const loadStatuses = vi.fn(async () => {
+      return [{ slot: "anthropic", state: "configured", runtimeState: "active" }] as const;
+    });
+    const onDeleted = vi.fn(async () => {});
+    const openSetup = vi.fn();
+    const { controller, subject, resetAllCredentials, releaseMutation } = createSubject({
+      loadStatuses,
+      loadRuntime: async () => runtime(),
+      onDeleted,
+      openSetup,
+      reset: () => reset,
+    });
+    await controller.activate();
+    subject.requestReset();
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(resetAllCredentials).toHaveBeenCalledOnce());
+
+    controller.close();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
+    resolveReset({ status: "reset", keyCleanupPending: false });
+
+    await vi.waitFor(() => {
+      expect(loadStatuses).toHaveBeenCalledTimes(2);
+      expect(onDeleted).toHaveBeenCalledOnce();
+      expect(releaseMutation).toHaveBeenCalledOnce();
+      expect(controller.state()).toEqual({ status: "closed" });
+    });
+
+    await controller.activate();
+    expect(loadStatuses).toHaveBeenCalledTimes(3);
+    expect(onDeleted).toHaveBeenCalledOnce();
+    expect(controller.state().status).toBe("ready");
+    expect(credentialChangesBlocked(controller.state(), false)).toBe(false);
+
+    subject.requestDelete("anthropic");
+    expect(controller.state()).toMatchObject({ status: "confirming", confirmation: "anthropic" });
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(controller.state().status).toBe("deleted"));
+    await Promise.resolve();
+    subject.openSetup();
+    expect(openSetup).toHaveBeenCalledOnce();
+  });
+
+  it("reconciles a refused reset after closing while the reset RPC is pending", async () => {
+    let resolveReset!: (result: CredentialResetResult) => void;
+    const reset = new Promise<CredentialResetResult>((resolve) => {
+      resolveReset = resolve;
+    });
+    const loadStatuses = vi.fn(async () => {
+      return [{ slot: "anthropic", state: "configured", runtimeState: "active" }] as const;
+    });
+    const onReconciled = vi.fn(async () => {});
+    const { controller, subject, resetAllCredentials, releaseMutation } = createSubject({
+      loadStatuses,
+      onReconciled,
+      reset: () => reset,
+    });
+    await controller.activate();
+    subject.requestReset();
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(resetAllCredentials).toHaveBeenCalledOnce());
+
+    controller.close();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
+    resolveReset({ status: "refused", reason: "storage-failed" });
+
+    await vi.waitFor(() => {
+      expect(loadStatuses).toHaveBeenCalledTimes(2);
+      expect(onReconciled).toHaveBeenCalledOnce();
+      expect(releaseMutation).toHaveBeenCalledOnce();
+      expect(controller.state()).toEqual({ status: "closed" });
+    });
+
+    await controller.activate();
+    expect(loadStatuses).toHaveBeenCalledTimes(3);
+    expect(onReconciled).toHaveBeenCalledOnce();
+    expect(controller.state().status).toBe("ready");
+    expect(credentialChangesBlocked(controller.state(), false)).toBe(false);
+  });
+
+  it("keeps reset uncertainty when a closed reset cannot reload authoritative state", async () => {
+    let resolveReset!: (result: CredentialResetResult) => void;
+    const reset = new Promise<CredentialResetResult>((resolve) => {
+      resolveReset = resolve;
+    });
+    let loadCount = 0;
+    const loadStatuses = vi.fn(async () => {
+      loadCount += 1;
+      if (loadCount === 2) throw new Error("synthetic authoritative reload failure");
+      return [{ slot: "anthropic", state: "configured", runtimeState: "active" }] as const;
+    });
+    const onDeleted = vi.fn(async () => {});
+    const { controller, subject, resetAllCredentials, releaseMutation } = createSubject({
+      loadStatuses,
+      onDeleted,
+      reset: () => reset,
+    });
+    await controller.activate();
+    subject.requestReset();
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(resetAllCredentials).toHaveBeenCalledOnce());
+
+    controller.close();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
+    resolveReset({ status: "reset", keyCleanupPending: false });
+
+    await vi.waitFor(() => {
+      expect(loadStatuses).toHaveBeenCalledTimes(2);
+      expect(releaseMutation).toHaveBeenCalledOnce();
+    });
+    expect(onDeleted).not.toHaveBeenCalled();
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
+    expect(credentialChangesBlocked(controller.state(), false)).toBe(true);
+  });
+
   it("preserves reset uncertainty when closed while the reset is pending", async () => {
     let resolveReset!: (result: CredentialResetResult) => void;
     const reset = new Promise<CredentialResetResult>((resolve) => {
@@ -643,7 +763,7 @@ describe("credential settings controller", () => {
 
     resolveReset({ status: "refused", reason: "storage-failed" });
     await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledOnce());
-    expect(controller.state()).toMatchObject({ status: "loading", resetUncertain: true });
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
     resolveReconciliation();
     await reopening;
     expect(releaseMutation).toHaveBeenCalled();
@@ -689,7 +809,7 @@ describe("credential settings controller", () => {
 
     resolveReload([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
     await vi.waitFor(() => expect(onReconciled).toHaveBeenCalledOnce());
-    expect(controller.state()).toMatchObject({ status: "loading", resetUncertain: true });
+    expect(controller.state()).toEqual({ status: "closed", resetUncertain: true });
     resolveReconciliation();
     await reopening;
     expect(releaseMutation).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Closing Settings while a reset-all RPC was in flight bumped the controller `generation`, so the reset exited before the authoritative reload and `onDeleted`/`onReconciled`. The closed state kept `resetUncertain: true`, which blocked setup and credential mutations until Settings was reopened.

Now only disposal aborts reconciliation. A closed controller still reloads and fires the callback; on success the closed state drops `resetUncertain`, on reload/callback failure it keeps it so the next `activate()` reconciles. Open-Settings behavior is unchanged.

Two existing tests asserted the intermediate `{ status: "loading", resetUncertain: true }` while closed; they now assert `{ status: "closed", resetUncertain: true }` because reconciliation belongs to the in-flight operation and nothing renders while closed. Three regression tests added (success, refused, failed reload after close).

## Verification

- `pnpm --filter @enduragent/desktop-renderer exec vitest run tests/credential-settings.test.ts tests/onboarding-settings-mutation-gate.test.tsx tests/settings-surface.test.tsx` → 100 passed
- `pnpm --filter @enduragent/desktop-renderer exec vitest run` → 966 passed
- `pnpm --filter @enduragent/desktop-renderer check` → clean
- Built by codex gpt-5.6-sol (xhigh); 4 read-only skeptics, one per acceptance criterion, all PASS.

## Limits

none.