### PR TITLE
fix(desktop): mark cleared credentials failed when a reset is refused

### DIFF
--- a/.changeset/truthful-runtime-state-after-failed-reset.md
+++ b/.changeset/truthful-runtime-state-after-failed-reset.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: A credential removal that fails partway no longer shows providers as active when the daemon has already dropped them.

--- a/apps/desktop/src/main/credential-reset-orchestration.ts
+++ b/apps/desktop/src/main/credential-reset-orchestration.ts
@@ -10,7 +10,11 @@ import type {
   SerializeCredentialMutation,
 } from "./credential-envelope-lock.js";
 import type { DesktopManagedCredential } from "./credential-runtime.js";
-import type { CredentialRuntimeState, DesktopCredentialSlot } from "./credential-vault.js";
+import {
+  DESKTOP_CREDENTIAL_SLOTS,
+  type CredentialRuntimeState,
+  type DesktopCredentialSlot,
+} from "./credential-vault.js";
 import type { KeychainKeyDeletion } from "./keychain-credential-encryption.js";
 import type { DesktopCredentialResetResult } from "./onboarding-ipc.js";
 
@@ -47,6 +51,7 @@ export interface CreateDesktopCredentialResetOptions {
     proof: CredentialEnvelopeLockProof,
   ) => Promise<KeychainKeyDeletion>;
   readonly credentialRuntimeState: Map<DesktopCredentialSlot, CredentialRuntimeState>;
+  readonly onRuntimeStateChange: (slot: DesktopCredentialSlot) => void;
   readonly resetEncryptedCredentialStorage?: ResetEncryptedCredentialStorage;
 }
 
@@ -73,6 +78,11 @@ export function createDesktopCredentialReset(
         if (snapshot.intervals.credential_configured) activeCredentials.push("intervals-icu");
         for (const credential of activeCredentials) {
           await binding.credentials.clearCredential(credential);
+          const slot = DESKTOP_CREDENTIAL_SLOTS.find((candidate) => candidate === credential);
+          if (slot !== undefined) {
+            options.credentialRuntimeState.set(slot, "failed");
+            options.onRuntimeStateChange(slot);
+          }
         }
         if (!(await options.resetTelegramRuntime())) {
           return { status: "refused", reason: "runtime-unavailable" };

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -992,6 +992,7 @@ async function runDesktop(): Promise<void> {
         deleteKeyForCredentialReset: (proof) =>
           credentialEncryption.deleteKeyForCredentialReset(proof),
         credentialRuntimeState,
+        onRuntimeStateChange: markCredentialRuntimeChange,
       });
     const claudeCli = createClaudeCliStatus({
       settings: () => readClaudeCliSettings({ configPath: join(configDir, "config.yaml") }),

--- a/apps/desktop/tests/credential-reset-orchestration.test.ts
+++ b/apps/desktop/tests/credential-reset-orchestration.test.ts
@@ -101,7 +101,9 @@ function harness(
   );
   const credentialRuntimeState = new Map<DesktopCredentialSlot, CredentialRuntimeState>([
     ["anthropic", "active"],
+    ["intervals-icu", "active"],
   ]);
+  const onRuntimeStateChange = vi.fn<(slot: DesktopCredentialSlot) => void>();
   const reset = createDesktopCredentialReset({
     serializeCredentialMutation:
       options.serializeCredentialMutation ?? ((operation) => operation()),
@@ -116,6 +118,7 @@ function harness(
     serializeEnvelopeMutation,
     deleteKeyForCredentialReset,
     credentialRuntimeState,
+    onRuntimeStateChange,
     resetEncryptedCredentialStorage,
   });
   return {
@@ -130,6 +133,7 @@ function harness(
     serializeEnvelopeMutation,
     resetEncryptedCredentialStorage,
     credentialRuntimeState,
+    onRuntimeStateChange,
     reset,
     setBinding(next: DesktopCredentialResetRuntimeBinding | undefined) {
       binding = next;
@@ -211,7 +215,12 @@ describe("desktop credential reset orchestration", () => {
       expect(subject.deleteChatGptProfile).not.toHaveBeenCalled();
       expect(subject.resetEncryptedCredentialStorage).not.toHaveBeenCalled();
       expect(subject.deleteKeyForCredentialReset).not.toHaveBeenCalled();
-      expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+      expect(subject.credentialRuntimeState.get("anthropic")).toBe("failed");
+      expect(subject.credentialRuntimeState.get("intervals-icu")).toBe("failed");
+      expect(subject.onRuntimeStateChange.mock.calls).toEqual([
+        ["anthropic"],
+        ["intervals-icu"],
+      ]);
     },
   );
 
@@ -237,9 +246,36 @@ describe("desktop credential reset orchestration", () => {
       expect(subject.deleteChatGptProfile).not.toHaveBeenCalled();
       expect(subject.resetEncryptedCredentialStorage).not.toHaveBeenCalled();
       expect(subject.deleteKeyForCredentialReset).not.toHaveBeenCalled();
-      expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+      expect(subject.credentialRuntimeState.get("anthropic")).toBe("failed");
+      expect(subject.credentialRuntimeState.get("intervals-icu")).toBe("failed");
     },
   );
+
+  it("updates only credentials cleared before a later daemon clear fails", async () => {
+    const subject = harness();
+    subject.clearCredential
+      .mockImplementationOnce(async (credential) => {
+        subject.events.push(`clear:${credential}`);
+        return "cleared" as const;
+      })
+      .mockImplementationOnce(async (credential) => {
+        subject.events.push(`clear:${credential}`);
+        throw new Error("synthetic credential clear failure");
+      });
+
+    await expect(subject.reset()).resolves.toEqual({
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+
+    expect(subject.credentialRuntimeState.get("anthropic")).toBe("failed");
+    expect(subject.credentialRuntimeState.get("intervals-icu")).toBe("active");
+    expect(subject.onRuntimeStateChange).toHaveBeenCalledOnce();
+    expect(subject.onRuntimeStateChange).toHaveBeenCalledWith("anthropic");
+    expect(subject.resetTelegramRuntime).not.toHaveBeenCalled();
+    expect(subject.deleteChatGptProfile).not.toHaveBeenCalled();
+    expect(subject.resetEncryptedCredentialStorage).not.toHaveBeenCalled();
+  });
 
   it("maps durable storage reset failure to storage-failed", async () => {
     const subject = harness();
@@ -251,7 +287,8 @@ describe("desktop credential reset orchestration", () => {
     });
 
     expect(subject.deleteChatGptProfile).toHaveBeenCalledOnce();
-    expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+    expect(subject.credentialRuntimeState.get("anthropic")).toBe("failed");
+    expect(subject.credentialRuntimeState.get("intervals-icu")).toBe("failed");
   });
 
   it("returns reset with pending cleanup when Keychain deletion fails", async () => {
@@ -276,7 +313,7 @@ describe("desktop credential reset orchestration", () => {
     expect(subject.deleteKeyForCredentialReset).toHaveBeenCalledWith(subject.proof);
   });
 
-  it("clears runtime state only after durable storage reset succeeds", async () => {
+  it("marks cleared runtime slots failed until durable storage reset succeeds", async () => {
     const subject = harness();
     let resolveStorage!: (result: { status: "reset"; keyCleanupPending: false }) => void;
     let markStorageStarted!: () => void;
@@ -296,7 +333,8 @@ describe("desktop credential reset orchestration", () => {
 
     const reset = subject.reset();
     await storageStarted;
-    expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+    expect(subject.credentialRuntimeState.get("anthropic")).toBe("failed");
+    expect(subject.credentialRuntimeState.get("intervals-icu")).toBe("failed");
 
     resolveStorage({ status: "reset", keyCleanupPending: false });
     await expect(reset).resolves.toEqual({ status: "reset", keyCleanupPending: false });
@@ -318,5 +356,6 @@ describe("desktop credential reset orchestration", () => {
     expect(composition).toMatch(
       /deleteKeyForCredentialReset: \(proof\) =>\s+credentialEncryption\.deleteKeyForCredentialReset\(proof\)/u,
     );
+    expect(composition).toContain("onRuntimeStateChange: markCredentialRuntimeChange,");
   });
 });


### PR DESCRIPTION
## Summary

`createDesktopCredentialReset` clears the daemon's model and Intervals credentials before the Telegram reset, lifecycle re-check, and storage reset, but only cleared `credentialRuntimeState` after total success. A later refusal left cleared slots marked `active`, so the vault published configured envelopes as runtime-active and onboarding reported a provider the daemon no longer had.

Each successful `clearCredential` now sets the slot to `failed` and bumps its revision through `onRuntimeStateChange` (wired to `markCredentialRuntimeChange` in `index.ts`). `failed` rather than delete because a configured envelope with no map entry publishes as `stored-inactive` (`credentialStatuses`), hiding the divergence, and only `failed` enters the repair lane (`retryFailed`). The revision bump keeps the recovering→ready restore in `publishLifecycle` from resurrecting `active`. Full success still clears the map.

The test that pinned the old in-flight `active` state now asserts `failed`; four regression tests cover Telegram refusal, lifecycle re-check refusal, storage refusal, and `clearCredential` throwing on the second slot.

## Verification

- `pnpm --filter @enduragent/desktop exec vitest run tests/credential-reset-orchestration.test.ts tests/credential-vault.test.ts tests/credential-reset.test.ts` → 80 passed
- `pnpm --filter @enduragent/desktop check` → clean
- Built by codex gpt-5.6-sol (xhigh); 4 read-only skeptics, one per acceptance criterion, all PASS.

## Limits

none.

## Residual

`clearCredential` can return `managed-by-environment` (daemon still holds an env-sourced credential); that slot is still marked `failed`. Pre-existing edge, unchanged in effect from before this PR (it was left `active` before, now `failed`).