### PR TITLE
fix(desktop): keep environment-managed credentials active through a reset

### DIFF
--- a/.changeset/keep-environment-managed-credentials-active.md
+++ b/.changeset/keep-environment-managed-credentials-active.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Removing credentials no longer marks an environment-managed provider as needing repair.

--- a/apps/desktop/src/main/credential-reset-orchestration.ts
+++ b/apps/desktop/src/main/credential-reset-orchestration.ts
@@ -9,7 +9,10 @@ import type {
   SerializeCredentialEnvelopeMutation,
   SerializeCredentialMutation,
 } from "./credential-envelope-lock.js";
-import type { DesktopManagedCredential } from "./credential-runtime.js";
+import type {
+  CredentialRuntimeApplication,
+  DesktopManagedCredential,
+} from "./credential-runtime.js";
 import {
   DESKTOP_CREDENTIAL_SLOTS,
   type CredentialRuntimeState,
@@ -22,9 +25,7 @@ export interface DesktopCredentialResetRuntimeBinding {
   readonly authority: {
     getRuntimeConfig(): Promise<RuntimeConfigSnapshot>;
   };
-  readonly credentials: {
-    clearCredential(credential: DesktopManagedCredential): Promise<unknown>;
-  };
+  readonly credentials: Pick<CredentialRuntimeApplication, "clearCredential">;
 }
 
 export interface DesktopCredentialResetLifecycleSnapshot {
@@ -77,7 +78,8 @@ export function createDesktopCredentialReset(
         }
         if (snapshot.intervals.credential_configured) activeCredentials.push("intervals-icu");
         for (const credential of activeCredentials) {
-          await binding.credentials.clearCredential(credential);
+          const cleared = await binding.credentials.clearCredential(credential);
+          if (cleared !== "cleared") continue;
           const slot = DESKTOP_CREDENTIAL_SLOTS.find((candidate) => candidate === credential);
           if (slot !== undefined) {
             options.credentialRuntimeState.set(slot, "failed");

--- a/apps/desktop/tests/credential-reset-orchestration.test.ts
+++ b/apps/desktop/tests/credential-reset-orchestration.test.ts
@@ -60,9 +60,11 @@ function harness(
   const events: string[] = [];
   const proof = {} as CredentialEnvelopeLockProof;
   const getRuntimeConfig = vi.fn(async () => runtimeSnapshot());
-  const clearCredential = vi.fn(async (credential: DesktopManagedCredential) => {
+  const clearCredential = vi.fn<
+    DesktopCredentialResetRuntimeBinding["credentials"]["clearCredential"]
+  >(async (credential: DesktopManagedCredential) => {
     events.push(`clear:${credential}`);
-    return "cleared" as const;
+    return "cleared";
   });
   const initialBinding: DesktopCredentialResetRuntimeBinding = {
     authority: { getRuntimeConfig },
@@ -273,6 +275,63 @@ describe("desktop credential reset orchestration", () => {
     expect(subject.onRuntimeStateChange).toHaveBeenCalledOnce();
     expect(subject.onRuntimeStateChange).toHaveBeenCalledWith("anthropic");
     expect(subject.resetTelegramRuntime).not.toHaveBeenCalled();
+    expect(subject.deleteChatGptProfile).not.toHaveBeenCalled();
+    expect(subject.resetEncryptedCredentialStorage).not.toHaveBeenCalled();
+  });
+
+  it("keeps environment-managed runtime state through a later reset refusal", async () => {
+    const subject = harness();
+    subject.clearCredential
+      .mockImplementationOnce(async (credential) => {
+        subject.events.push(`clear:${credential}`);
+        return "managed-by-environment";
+      })
+      .mockImplementationOnce(async (credential) => {
+        subject.events.push(`clear:${credential}`);
+        return "cleared";
+      });
+    subject.resetTelegramRuntime.mockImplementationOnce(async () => {
+      subject.events.push("telegram-reset");
+      return false;
+    });
+
+    await expect(subject.reset()).resolves.toEqual({
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+
+    expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+    expect(subject.credentialRuntimeState.get("intervals-icu")).toBe("failed");
+    expect(subject.onRuntimeStateChange.mock.calls).toEqual([["intervals-icu"]]);
+    expect(subject.deleteChatGptProfile).not.toHaveBeenCalled();
+    expect(subject.resetEncryptedCredentialStorage).not.toHaveBeenCalled();
+  });
+
+  it("keeps runtime state unchanged when the daemon credential is not active", async () => {
+    const subject = harness();
+    const snapshot = runtimeSnapshot();
+    subject.getRuntimeConfig.mockResolvedValueOnce({
+      ...snapshot,
+      intervals: { ...snapshot.intervals, credential_configured: false },
+    });
+    subject.clearCredential.mockImplementationOnce(async (credential) => {
+      subject.events.push(`clear:${credential}`);
+      return "not-active";
+    });
+    subject.resetTelegramRuntime.mockImplementationOnce(async () => {
+      subject.events.push("telegram-reset");
+      return false;
+    });
+
+    await expect(subject.reset()).resolves.toEqual({
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+
+    expect(subject.credentialRuntimeState.get("anthropic")).toBe("active");
+    expect(subject.clearCredential).toHaveBeenCalledOnce();
+    expect(subject.clearCredential).toHaveBeenCalledWith("anthropic");
+    expect(subject.onRuntimeStateChange).not.toHaveBeenCalled();
     expect(subject.deleteChatGptProfile).not.toHaveBeenCalled();
     expect(subject.resetEncryptedCredentialStorage).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Follow-up to #749. `clearCredential` returns `"cleared" | "not-active" | "managed-by-environment"`; the reset marked the slot `failed` regardless. For `managed-by-environment` the daemon still holds the credential, so the slot was wrongly reported as needing repair.

The reset now reads the result and only marks the slot `failed` (with a revision bump) on `"cleared"`. `not-active` and `managed-by-environment` leave runtime state untouched, matching how the vault treats those results. The binding type is narrowed from `Promise<unknown>` to `Pick<CredentialRuntimeApplication, "clearCredential">`.

Two regression tests added; no existing assertion changed.

## Verification

- `pnpm --filter @enduragent/desktop exec vitest run tests/credential-reset-orchestration.test.ts tests/credential-runtime.test.ts tests/credential-vault.test.ts` → 107 passed
- `pnpm --filter @enduragent/desktop check` → clean
- Built by codex gpt-5.6-sol (xhigh); 3 read-only skeptics, one per criterion, all PASS, no findings.

## Limits

none.