### PR TITLE
fix(desktop): drop stale repair state after a closed credential reset reconciles

### DIFF
--- a/.changeset/clear-stale-repair-after-closed-reset.md
+++ b/.changeset/clear-stale-repair-after-closed-reset.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: A credential reset finished while Settings is closed no longer keeps a stale repair prompt for the next open.

--- a/apps/desktop-renderer/src/settings/credential-controller.ts
+++ b/apps/desktop-renderer/src/settings/credential-controller.ts
@@ -639,12 +639,7 @@ export function createCredentialSettingsController(input: {
       }
       if (disposed || activeResetOperation !== resetOperation) return;
       if (generation !== operationGeneration) {
-        const repairCredential =
-          result.status === "refused" ? repairRequiredCredential(currentState) : null;
-        render({
-          status: "closed",
-          ...(repairCredential === null ? {} : { repairCredential }),
-        });
+        render({ status: "closed" });
         return;
       }
       releaseMutation();

--- a/apps/desktop-renderer/tests/credential-settings.test.ts
+++ b/apps/desktop-renderer/tests/credential-settings.test.ts
@@ -700,6 +700,53 @@ describe("credential settings controller", () => {
     expect(credentialChangesBlocked(controller.state(), false)).toBe(false);
   });
 
+  it("clears existing repair debt after a closed refused reset reconciles", async () => {
+    let resolveReset!: (result: CredentialResetResult) => void;
+    const reset = new Promise<CredentialResetResult>((resolve) => {
+      resolveReset = resolve;
+    });
+    const onReconciled = vi.fn(async () => {});
+    const { controller, subject, resetAllCredentials } = createSubject({
+      deletion: {
+        slot: "anthropic",
+        status: "uncertain",
+        reason: "storage-uncertain",
+      },
+      onReconciled,
+      reset: () => reset,
+    });
+    await controller.activate();
+    subject.requestDelete("anthropic");
+    subject.confirmDelete();
+    await vi.waitFor(() =>
+      expect(controller.state()).toMatchObject({
+        status: "error",
+        repairCredential: "anthropic",
+      }),
+    );
+
+    subject.requestReset();
+    subject.confirmDelete();
+    await vi.waitFor(() => expect(resetAllCredentials).toHaveBeenCalledOnce());
+
+    controller.close();
+    expect(controller.state()).toEqual({
+      status: "closed",
+      repairCredential: "anthropic",
+      resetUncertain: true,
+    });
+    resolveReset({ status: "refused", reason: "storage-failed" });
+
+    await vi.waitFor(() => {
+      expect(onReconciled).toHaveBeenCalledOnce();
+      expect(controller.state()).toEqual({ status: "closed" });
+    });
+
+    await controller.activate();
+    expect(controller.state().status).toBe("ready");
+    expect(onReconciled).toHaveBeenCalledOnce();
+  });
+
   it("keeps reset uncertainty when a closed reset cannot reload authoritative state", async () => {
     let resolveReset!: (result: CredentialResetResult) => void;
     const reset = new Promise<CredentialResetResult>((resolve) => {


### PR DESCRIPTION
## Summary

Follow-up to #748. After a reset finished while Settings was closed, the closed path re-rendered the pre-reset `repairCredential` on a refused result, while the open path (same reload + `onReconciled` already run) sets it to null. Both paths now render exactly `{ status: "closed" }` once reconciliation succeeds. The catch branch (reload or callback threw) is unchanged and still preserves `repairCredential` + `resetUncertain`.

One regression test added (pre-existing repair debt, close during pending RPC, refused → `{ status: "closed" }`, `onReconciled` called once across reset + reopen). No existing assertion changed.

## Verification

- `pnpm --filter @enduragent/desktop-renderer exec vitest run tests/credential-settings.test.ts tests/onboarding-settings-mutation-gate.test.tsx` → 54 passed
- `pnpm --filter @enduragent/desktop-renderer check` → clean
- Built by codex gpt-5.6-sol (xhigh); 3 read-only skeptics, one per criterion, all PASS, no findings.

## Limits

none.