### PR TITLE
feat: add Plan workspace shell

### DIFF
--- a/.changeset/plan-shell.md
+++ b/.changeset/plan-shell.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Added a Plan workspace that starts planning with the coach and highlights decisions that need attention.

--- a/apps/desktop-renderer/src/app/views.ts
+++ b/apps/desktop-renderer/src/app/views.ts
@@ -1,5 +1,6 @@
 import {
   Activity,
+  CalendarDays,
   History,
   MessageSquare,
   Settings,
@@ -7,7 +8,7 @@ import {
 } from "lucide-react";
 import { lazy, type ComponentType, type LazyExoticComponent } from "react";
 
-export type ViewId = "chat" | "archive" | "training" | "settings";
+export type ViewId = "chat" | "archive" | "training" | "plan" | "settings";
 export type StoredViewId = ViewId;
 
 export const REACT_CHAT_REGION = "react-chat-region";
@@ -44,6 +45,15 @@ export const VIEWS: readonly ViewDefinition[] = Object.freeze([
     title: "Training",
     page: lazy(async () => ({
       default: (await import("../ui/training/TrainingView.js")).TrainingView,
+    })),
+  },
+  {
+    id: "plan",
+    label: "Plan",
+    icon: CalendarDays,
+    title: "Plan",
+    page: lazy(async () => ({
+      default: (await import("../ui/plan/PlanView.js")).PlanView,
     })),
   },
   {

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -14,6 +14,7 @@ import { createArchiveViewAdapter } from "./state/adapters/archive.js";
 import { createChatViewAdapter } from "./state/adapters/chat.js";
 import { createFirstSyncViewAdapter } from "./state/adapters/first-sync.js";
 import { createOnboardingViewAdapter } from "./state/adapters/onboarding.js";
+import { createPlanViewAdapter } from "./state/adapters/plan.js";
 import { createRideImportAdapter } from "./state/adapters/ride-import.js";
 import {
   createAthleteSettingsAdapter,
@@ -170,6 +171,19 @@ export function bootRenderer(): Disposer {
   const disposeSetupReadiness = store.subscribe((state, previousState) => {
     if (!setupReady(previousState) && setupReady(state)) void chatController.resume();
   });
+
+  const planAdapter = createPlanViewAdapter({
+    bridge: window.enduragentAuth,
+    read: () => store.getState().plan,
+    publishHydration: (next) => store.getState().setPlanHydration(next),
+    publishTransition: (next) => store.getState().setPlanTransition(next),
+  });
+  store.getState().bindPlanActions({
+    open: () => planAdapter.open(),
+    startPlan: () => planAdapter.startPlan(),
+    retry: () => planAdapter.retry(),
+  });
+  planAdapter.start();
 
   const archiveAdapter = createArchiveViewAdapter({
     publish: (next) => store.getState().setArchive(next),
@@ -449,6 +463,7 @@ export function bootRenderer(): Disposer {
     store.getState().bindRideAnalysisActions(null);
     store.getState().bindTrainingExportActions(null);
     store.getState().bindOnboardingActions(null);
+    store.getState().bindPlanActions(null);
     disposeRideAnalysisSelection();
     disposeSetupReadiness();
     window.removeEventListener("enduragent-lifecycle", onLifecycle);
@@ -468,6 +483,7 @@ export function bootRenderer(): Disposer {
     trainingSyncCoordinator.dispose();
     chatController.dispose();
     archiveController.dispose();
+    planAdapter.dispose();
     spendController.dispose();
     trainingContextController.dispose();
     rideAnalysisController.dispose();

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -1,0 +1,230 @@
+import type {
+  ExecutePlanTransitionRpcParams,
+  ExecutePlanTransitionRpcResult,
+  GetPlanStateRpcResult,
+  PlanError,
+  PlanHydrationState,
+  PlanProgressEvent,
+  PlanReadModel,
+  PlanTransitionId,
+} from "@enduragent/coach-contract";
+import type { PlanSurfaceState, PlanTransitionState } from "../plan-slice.js";
+import { planReadModel } from "../plan-slice.js";
+
+export interface PlanBridge {
+  getPlanState(): Promise<GetPlanStateRpcResult>;
+  executePlanTransition(
+    input: ExecutePlanTransitionRpcParams,
+  ): Promise<ExecutePlanTransitionRpcResult>;
+  onPlanProgress(listener: (progress: PlanProgressEvent) => void): () => void;
+}
+
+export interface PlanViewAdapter {
+  start(): void;
+  open(): void;
+  startPlan(): void;
+  retry(): void;
+  dispose(): void;
+}
+
+const UNAVAILABLE_ERROR: PlanError = Object.freeze({
+  code: "unavailable",
+  message: "Plan could not connect. Try again.",
+  retryable: true,
+});
+
+function hydrationFromResult(result: GetPlanStateRpcResult): PlanHydrationState {
+  return result;
+}
+
+function hydrationFromTransition(result: ExecutePlanTransitionRpcResult): PlanHydrationState {
+  if (result.status === "unsupported-capability") return result;
+  return { status: "ready", state: result.state };
+}
+
+export function createPlanViewAdapter(input: {
+  readonly bridge: PlanBridge;
+  readonly read: () => PlanSurfaceState;
+  readonly publishHydration: (next: PlanHydrationState) => void;
+  readonly publishTransition: (next: PlanTransitionState) => void;
+  readonly createCommandId?: () => string;
+}): PlanViewAdapter {
+  const createCommandId = input.createCommandId ?? (() => globalThis.crypto.randomUUID());
+  let disposed = false;
+  let started = false;
+  let disposeProgress: (() => void) | null = null;
+  let hydrationGeneration = 0;
+  let lastRetry: "hydrate" | "start" | "attention" = "hydrate";
+  let active:
+    | {
+        readonly commandId: string;
+        readonly transitionId: PlanTransitionId;
+        operationId: string | null;
+      }
+    | null = null;
+
+  const refresh = async (showLoading: boolean): Promise<void> => {
+    const generation = ++hydrationGeneration;
+    if (showLoading && input.read().lastReady === null) {
+      input.publishHydration({ status: "loading" });
+    }
+    try {
+      const result = await input.bridge.getPlanState();
+      if (disposed || generation !== hydrationGeneration) return;
+      input.publishHydration(hydrationFromResult(result));
+    } catch {
+      if (disposed || generation !== hydrationGeneration) return;
+      input.publishHydration({ status: "failed", error: UNAVAILABLE_ERROR });
+    }
+  };
+
+  const execute = async (
+    command: ExecutePlanTransitionRpcParams,
+    retry: "start" | "attention",
+  ): Promise<void> => {
+    active = {
+      commandId: command.commandId,
+      transitionId: command.transitionId,
+      operationId: null,
+    };
+    lastRetry = retry;
+    input.publishTransition({
+      status: "submitting",
+      commandId: command.commandId,
+      transitionId: command.transitionId,
+    });
+    try {
+      const result = await input.bridge.executePlanTransition(command);
+      if (
+        disposed ||
+        active?.commandId !== command.commandId ||
+        active.transitionId !== command.transitionId
+      ) {
+        return;
+      }
+      input.publishHydration(hydrationFromTransition(result));
+      if (result.status === "unsupported-capability") {
+        active = null;
+        input.publishTransition({ status: "idle" });
+        return;
+      }
+      if (result.status === "rejected") {
+        active = null;
+        input.publishTransition({
+          status: "failed",
+          commandId: command.commandId,
+          transitionId: command.transitionId,
+          error: result.error,
+        });
+        return;
+      }
+      if (result.status === "accepted") {
+        active.operationId = result.operationId;
+        input.publishTransition({
+          status: "running",
+          commandId: command.commandId,
+          transitionId: command.transitionId,
+          operationId: result.operationId,
+          progress: result.state.activeOperation,
+        });
+        return;
+      }
+      active = null;
+      input.publishTransition({ status: "idle" });
+    } catch {
+      if (
+        disposed ||
+        active?.commandId !== command.commandId ||
+        active.transitionId !== command.transitionId
+      ) {
+        return;
+      }
+      active = null;
+      input.publishTransition({
+        status: "failed",
+        commandId: command.commandId,
+        transitionId: command.transitionId,
+        error: UNAVAILABLE_ERROR,
+      });
+    }
+  };
+
+  const startPlan = (): void => {
+    if (active !== null) return;
+    const commandId = createCommandId();
+    void execute(
+      { transitionId: "PL-T01", commandId, sourceConversationId: null },
+      "start",
+    );
+  };
+
+  const open = (): void => {
+    if (active !== null) return;
+    const model: PlanReadModel | null = planReadModel(input.read());
+    if (model === null) return;
+    if (model.attention.destination === "none") {
+      lastRetry = "hydrate";
+      void refresh(false);
+      return;
+    }
+    if (model.planId === null) {
+      lastRetry = "hydrate";
+      void refresh(false);
+      return;
+    }
+    const commandId = createCommandId();
+    void execute(
+      { transitionId: "PL-T33", commandId, planId: model.planId },
+      "attention",
+    );
+  };
+
+  const onProgress = (progress: PlanProgressEvent): void => {
+    if (
+      disposed ||
+      active === null ||
+      active.operationId === null ||
+      progress.commandId !== active.commandId ||
+      progress.transitionId !== active.transitionId ||
+      progress.operationId !== active.operationId
+    ) {
+      return;
+    }
+    input.publishTransition({
+      status: "running",
+      commandId: active.commandId,
+      transitionId: active.transitionId,
+      operationId: active.operationId,
+      progress,
+    });
+    if (progress.phase === "completed" || progress.phase === "failed") {
+      active = null;
+      input.publishTransition({ status: "idle" });
+      void refresh(false);
+    }
+  };
+
+  return {
+    start() {
+      if (started || disposed) return;
+      started = true;
+      disposeProgress = input.bridge.onPlanProgress(onProgress);
+      void refresh(true);
+    },
+    open,
+    startPlan,
+    retry() {
+      if (lastRetry === "start") startPlan();
+      else if (lastRetry === "attention") open();
+      else void refresh(input.read().lastReady === null);
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      hydrationGeneration += 1;
+      active = null;
+      disposeProgress?.();
+      disposeProgress = null;
+    },
+  };
+}

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -1,0 +1,89 @@
+import type {
+  PlanError,
+  PlanHydrationState,
+  PlanProgressEvent,
+  PlanReadModel,
+  PlanTransitionId,
+} from "@enduragent/coach-contract";
+import type { StateCreator } from "zustand";
+import type { EnduragentState } from "./store.js";
+
+export type PlanTransitionState =
+  | { readonly status: "idle" }
+  | {
+      readonly status: "submitting";
+      readonly commandId: string;
+      readonly transitionId: PlanTransitionId;
+    }
+  | {
+      readonly status: "running";
+      readonly commandId: string;
+      readonly transitionId: PlanTransitionId;
+      readonly operationId: string;
+      readonly progress: PlanProgressEvent | null;
+    }
+  | {
+      readonly status: "failed";
+      readonly commandId: string | null;
+      readonly transitionId: PlanTransitionId | null;
+      readonly error: PlanError;
+    };
+
+export interface PlanSurfaceState {
+  readonly hydration: PlanHydrationState;
+  readonly lastReady: PlanReadModel | null;
+  readonly transition: PlanTransitionState;
+}
+
+export interface PlanActions {
+  open(): void;
+  startPlan(): void;
+  retry(): void;
+}
+
+export interface PlanSlice {
+  readonly plan: PlanSurfaceState;
+  readonly planActions: PlanActions | null;
+  setPlanHydration: (next: PlanHydrationState) => void;
+  setPlanTransition: (next: PlanTransitionState) => void;
+  bindPlanActions: (actions: PlanActions | null) => void;
+}
+
+export const EMPTY_PLAN_SURFACE: PlanSurfaceState = Object.freeze({
+  hydration: Object.freeze({ status: "loading" }),
+  lastReady: null,
+  transition: Object.freeze({ status: "idle" }),
+});
+
+export function planReadModel(plan: PlanSurfaceState): PlanReadModel | null {
+  if (plan.hydration.status === "ready" || plan.hydration.status === "stale") {
+    return plan.hydration.state;
+  }
+  return plan.lastReady;
+}
+
+export function planAttentionCount(plan: PlanSurfaceState): number {
+  return planReadModel(plan)?.attention.count ?? 0;
+}
+
+export const createPlanSlice: StateCreator<EnduragentState, [], [], PlanSlice> = (set) => ({
+  plan: EMPTY_PLAN_SURFACE,
+  planActions: null,
+  setPlanHydration(next) {
+    set((current) => {
+      const lastReady =
+        next.status === "ready" || next.status === "stale" ? next.state : current.plan.lastReady;
+      const hydration =
+        next.status === "failed" && lastReady !== null
+          ? ({ status: "stale", state: lastReady, error: next.error } as const)
+          : next;
+      return { plan: { ...current.plan, hydration, lastReady } };
+    });
+  },
+  setPlanTransition(next) {
+    set((current) => ({ plan: { ...current.plan, transition: next } }));
+  },
+  bindPlanActions(actions) {
+    set({ planActions: actions });
+  },
+});

--- a/apps/desktop-renderer/src/state/store.ts
+++ b/apps/desktop-renderer/src/state/store.ts
@@ -21,6 +21,7 @@ import {
 } from "./activity-analysis-slice.js";
 import { createChatSlice, type ChatSlice } from "./chat-slice.js";
 import { createOnboardingSlice, type OnboardingSlice } from "./onboarding-slice.js";
+import { createPlanSlice, type PlanSlice } from "./plan-slice.js";
 import { createRideImportSlice, type RideImportSlice } from "./ride-import-slice.js";
 import {
   createSettingsSlice,
@@ -41,7 +42,8 @@ export interface EnduragentState
     ActivityAnalysisSlice,
     SyncSlice,
     RideImportSlice,
-    OnboardingSlice {
+    OnboardingSlice,
+    PlanSlice {
   readonly activeView: StoredViewId;
   readonly paletteId: string;
   readonly appearance: Appearance;
@@ -73,6 +75,7 @@ export const useEnduragentStore = create<EnduragentState>((set, get, api) => ({
   ...createSyncSlice(set, get, api),
   ...createRideImportSlice(set, get, api),
   ...createOnboardingSlice(set, get, api),
+  ...createPlanSlice(set, get, api),
   activeView: "chat",
   paletteId: readStoredPaletteId(),
   appearance: readStoredAppearance(),

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -1,0 +1,190 @@
+import { TriangleAlert } from "lucide-react";
+import type { ReactElement } from "react";
+import { Button } from "../../components/ui/button.js";
+import { planReadModel } from "../../state/plan-slice.js";
+import { useEnduragentStore } from "../../state/store.js";
+import { Page } from "../shared/Page.js";
+
+const SUPPORT_PAIR = "grid gap-[calc(var(--inset)/2)]";
+
+function RetryButton(): ReactElement | null {
+  const actions = useEnduragentStore((state) => state.planActions);
+  if (actions === null) return null;
+  return (
+    <Button type="button" variant="outline" onClick={() => actions.retry()}>
+      Retry
+    </Button>
+  );
+}
+
+function StatusCard(props: {
+  readonly title: string;
+  readonly support: string;
+  readonly retry?: boolean;
+}): ReactElement {
+  return (
+    <section className="grid gap-row rounded-card bg-surface p-5 shadow-elev-1">
+      <div className={SUPPORT_PAIR}>
+        <h2 className="m-0 text-base font-medium">{props.title}</h2>
+        <p className="m-0 text-ink-2">{props.support}</p>
+      </div>
+      {props.retry === true ? <div className="pt-row"><RetryButton /></div> : null}
+    </section>
+  );
+}
+
+function StaleNotice(props: { readonly message: string }): ReactElement {
+  return (
+    <div
+      className="flex items-start gap-row rounded-ctl bg-[color-mix(in_srgb,var(--warn)_10%,var(--surface))] p-3 text-warn"
+      role="status"
+    >
+      <TriangleAlert className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+      <p className="m-0 text-ink-2">{props.message}</p>
+    </div>
+  );
+}
+
+function NoPlan(): ReactElement {
+  const actions = useEnduragentStore((state) => state.planActions);
+  const transition = useEnduragentStore((state) => state.plan.transition);
+  const model = useEnduragentStore((state) => planReadModel(state.plan));
+  const startGuard = model?.transitions.find((guard) => guard.transitionId === "PL-T01");
+  const startBlocked = startGuard?.status === "blocked";
+  const busy = transition.status === "submitting" || transition.status === "running";
+  const failed = transition.status === "failed";
+
+  return (
+    <div className="grid gap-6" data-plan-scenario="PL-S001">
+      <section className={SUPPORT_PAIR}>
+        <h2 className="m-0 text-lg font-semibold">Train toward one clear goal</h2>
+        <p className="m-0 text-ink-2">
+          Your coach will ask here for your Goal Event, optional GPX/FIT Race Course, weekly
+          availability, and FTP. Nothing writes until you approve.
+        </p>
+      </section>
+      <section className="grid gap-inset">
+        <h2 className="m-0 text-sm font-medium">What the draft needs</h2>
+        <div className="overflow-hidden rounded-card bg-surface px-5 shadow-elev-1">
+          <div className={`${SUPPORT_PAIR} py-3.5`}>
+            <h3 className="m-0 text-sm font-medium">Goal event + Race Course</h3>
+            <p className="m-0 text-ink-2">Race date, priority, and optional GPX/FIT file</p>
+          </div>
+          <div className="h-px bg-line" />
+          <div className={`${SUPPORT_PAIR} py-3.5`}>
+            <h3 className="m-0 text-sm font-medium">Current training</h3>
+            <p className="m-0 text-ink-2">
+              Recent workouts, recovery, and weekly availability
+            </p>
+          </div>
+          <div className="h-px bg-line" />
+          <div className={`${SUPPORT_PAIR} py-3.5`}>
+            <h3 className="m-0 text-sm font-medium">FTP</h3>
+            <p className="m-0 text-ink-2">
+              Athlete-entered FTP, Intervals FTP, or Intervals eFTP
+            </p>
+          </div>
+        </div>
+      </section>
+      {failed ? (
+        <StaleNotice message={transition.error.message} />
+      ) : null}
+      {startBlocked && startGuard.reason !== null ? (
+        <StaleNotice message={startGuard.reason} />
+      ) : null}
+      <div>
+        <Button
+          type="button"
+          disabled={actions === null || busy || startBlocked}
+          aria-busy={busy ? "true" : undefined}
+          onClick={() => actions?.startPlan()}
+        >
+          {busy ? "Opening coach…" : "Build a plan with coach"}
+        </Button>
+        {failed ? (
+          <Button type="button" variant="outline" className="ml-inset" onClick={() => actions?.retry()}>
+            Retry
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function AttentionProjection(): ReactElement {
+  const model = useEnduragentStore((state) => planReadModel(state.plan));
+  if (model === null) return <StatusCard title="Plan attention" support="Refreshing your Plan…" />;
+  return (
+    <section className="grid gap-row rounded-card bg-surface p-5 shadow-elev-1">
+      <div className={SUPPORT_PAIR}>
+        <h2 className="m-0 text-base font-medium">Plan attention</h2>
+        <p className="m-0 text-ink-2">
+          {model.attention.count} {model.attention.count === 1 ? "item needs" : "items need"} your
+          decision.
+        </p>
+      </div>
+      <div className="grid divide-y divide-line">
+        {model.attention.items.map((item) => (
+          <p key={item.id} className="m-0 py-3 text-sm">
+            {item.title}
+          </p>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ReadyProjection(): ReactElement {
+  const model = useEnduragentStore((state) => planReadModel(state.plan));
+  if (model === null) return <StatusCard title="Plan" support="Refreshing your Plan…" />;
+  if (model.lifecycle === "none" || model.projection === "no-plan") return <NoPlan />;
+  if (model.projection === "attention") return <AttentionProjection />;
+  return (
+    <StatusCard
+      title={model.title.length > 0 ? model.title : "Your Plan"}
+      support={model.summary.length > 0 ? model.summary : "Your Plan is available."}
+    />
+  );
+}
+
+export function PlanView(): ReactElement {
+  const plan = useEnduragentStore((state) => state.plan);
+  const model = planReadModel(plan);
+  const loading = plan.hydration.status === "loading";
+  const subtitle =
+    loading
+      ? "Loading…"
+      : model?.lifecycle === "none"
+        ? "No active plan"
+        : plan.transition.status === "running" || plan.transition.status === "submitting"
+          ? "Working…"
+          : undefined;
+
+  return (
+    <Page title="Plan" subtitle={subtitle} busy={loading} className="plan-view">
+      <div className="grid gap-6">
+        {plan.hydration.status === "stale" ? (
+          <StaleNotice message={plan.hydration.error.message} />
+        ) : null}
+        {plan.hydration.status === "loading" ? (
+          <p className="m-0 text-ink-2" role="status" aria-live="polite">
+            Loading your Plan…
+          </p>
+        ) : plan.hydration.status === "failed" ? (
+          <StatusCard
+            title="Plan could not load"
+            support={plan.hydration.error.message}
+            retry={plan.hydration.error.retryable}
+          />
+        ) : plan.hydration.status === "unsupported-capability" ? (
+          <StatusCard
+            title="Plan is not available yet"
+            support="Update Enduragent and its local service to use Plan."
+          />
+        ) : (
+          <ReadyProjection />
+        )}
+      </div>
+    </Page>
+  );
+}

--- a/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
+++ b/apps/desktop-renderer/src/ui/sidebar/Sidebar.tsx
@@ -5,6 +5,7 @@ import { cn } from "../../lib/utils.js";
 import { VIEWS } from "../../app/views.js";
 import { registerNewConversationOpener } from "../../state/new-conversation-opener.js";
 import { settingsMutationActive } from "../../state/settings-slice.js";
+import { planAttentionCount } from "../../state/plan-slice.js";
 import { setupReady } from "../../state/onboarding-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
 import { SyncChip } from "./SyncChip.js";
@@ -18,6 +19,8 @@ export function Sidebar(): ReactElement {
   const actions = useEnduragentStore((state) => state.chatActions);
   const canChat = useEnduragentStore(setupReady);
   const settingsBusy = useEnduragentStore((state) => settingsMutationActive(state.settings));
+  const planActions = useEnduragentStore((state) => state.planActions);
+  const attentionCount = useEnduragentStore((state) => planAttentionCount(state.plan));
   const opener = useRef<HTMLButtonElement>(null);
   const navigationLocked = activeView === "settings" && settingsBusy;
 
@@ -57,6 +60,10 @@ export function Sidebar(): ReactElement {
       <nav className="flex flex-col gap-0.5 px-inset pt-3" aria-label="Main navigation">
         {VIEWS.map((view) => {
           const active = view.id === activeView;
+          const planAttentionLabel =
+            view.id === "plan" && attentionCount > 0
+              ? `Plan, ${attentionCount} ${attentionCount === 1 ? "item needs" : "items need"} attention`
+              : undefined;
           return (
             <Button
               key={view.id}
@@ -68,9 +75,11 @@ export function Sidebar(): ReactElement {
                 active && "bg-surface font-medium text-ink hover:bg-surface",
               )}
               aria-current={active ? "page" : undefined}
+              aria-label={planAttentionLabel}
               disabled={navigationLocked && view.id !== activeView}
               onClick={() => {
                 setActiveView(view.id);
+                if (view.id === "plan") planActions?.open();
               }}
             >
               <view.icon
@@ -79,6 +88,14 @@ export function Sidebar(): ReactElement {
                 aria-hidden="true"
               />
               {view.label}
+              {view.id === "plan" && attentionCount > 0 ? (
+                <span
+                  className="ml-auto grid size-[18px] place-items-center rounded-full bg-warn text-xs leading-none font-semibold text-surface"
+                  aria-hidden="true"
+                >
+                  {attentionCount}
+                </span>
+              ) : null}
             </Button>
           );
         })}

--- a/apps/desktop-renderer/tests/plan-adapter.test.ts
+++ b/apps/desktop-renderer/tests/plan-adapter.test.ts
@@ -1,0 +1,268 @@
+import type {
+  ExecutePlanTransitionRpcResult,
+  GetPlanStateRpcResult,
+  PlanHydrationState,
+  PlanProgressEvent,
+} from "@enduragent/coach-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createPlanViewAdapter,
+  type PlanBridge,
+} from "../src/state/adapters/plan.js";
+import {
+  EMPTY_PLAN_SURFACE,
+  type PlanSurfaceState,
+  type PlanTransitionState,
+} from "../src/state/plan-slice.js";
+import { PLAN_ERROR, planReadModel } from "./plan-fixtures.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((accept, decline) => {
+    resolve = accept;
+    reject = decline;
+  });
+  return { promise, resolve, reject };
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function harness(input: {
+  readonly getPlanState?: () => Promise<GetPlanStateRpcResult>;
+  readonly executePlanTransition?: PlanBridge["executePlanTransition"];
+  readonly ids?: readonly string[];
+} = {}) {
+  let surface: PlanSurfaceState = EMPTY_PLAN_SURFACE;
+  let progressListener: ((progress: PlanProgressEvent) => void) | null = null;
+  const disposeProgress = vi.fn();
+  const defaultGetPlanState: PlanBridge["getPlanState"] = async () => ({
+    status: "ready",
+    state: planReadModel(),
+  });
+  const defaultExecute: PlanBridge["executePlanTransition"] = async () => ({
+    status: "completed",
+    state: planReadModel(),
+  });
+  const getPlanState = vi.fn<PlanBridge["getPlanState"]>(
+    input.getPlanState ?? defaultGetPlanState,
+  );
+  const executePlanTransition = vi.fn<PlanBridge["executePlanTransition"]>(
+    input.executePlanTransition ?? defaultExecute,
+  );
+  const ids = [...(input.ids ?? ["command-1", "command-2", "command-3"])];
+  const adapter = createPlanViewAdapter({
+    bridge: {
+      getPlanState,
+      executePlanTransition,
+      onPlanProgress(listener) {
+        progressListener = listener;
+        return disposeProgress;
+      },
+    },
+    read: () => surface,
+    publishHydration(next: PlanHydrationState) {
+      const lastReady =
+        next.status === "ready" || next.status === "stale" ? next.state : surface.lastReady;
+      surface = { ...surface, hydration: next, lastReady };
+    },
+    publishTransition(next: PlanTransitionState) {
+      surface = { ...surface, transition: next };
+    },
+    createCommandId: () => ids.shift() ?? "unexpected-command",
+  });
+  return {
+    adapter,
+    get surface() {
+      return surface;
+    },
+    getPlanState,
+    executePlanTransition,
+    disposeProgress,
+    progress(value: PlanProgressEvent) {
+      progressListener?.(value);
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Plan view adapter", () => {
+  it("subscribes and hydrates once", async () => {
+    const subject = harness();
+
+    subject.adapter.start();
+    subject.adapter.start();
+    await settle();
+
+    expect(subject.getPlanState).toHaveBeenCalledOnce();
+    expect(subject.surface.hydration).toEqual({ status: "ready", state: planReadModel() });
+  });
+
+  it("keeps hydration failure retryable", async () => {
+    const first = deferred<GetPlanStateRpcResult>();
+    const getPlanState = vi
+      .fn<() => Promise<GetPlanStateRpcResult>>()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValueOnce({ status: "ready", state: planReadModel() });
+    const subject = harness({ getPlanState });
+
+    subject.adapter.start();
+    first.reject(new TypeError());
+    await settle();
+    expect(subject.surface.hydration).toEqual({ status: "failed", error: expect.any(Object) });
+
+    subject.adapter.retry();
+    await settle();
+    expect(subject.surface.hydration.status).toBe("ready");
+    expect(getPlanState).toHaveBeenCalledTimes(2);
+  });
+
+  it("dispatches PL-T01 with one stable command identifier", async () => {
+    const execute = deferred<ExecutePlanTransitionRpcResult>();
+    const subject = harness({
+      ids: ["create-draft-command"],
+      executePlanTransition: () => execute.promise,
+    });
+
+    subject.adapter.startPlan();
+    expect(subject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T01",
+      commandId: "create-draft-command",
+      sourceConversationId: null,
+    });
+    expect(subject.surface.transition).toEqual({
+      status: "submitting",
+      transitionId: "PL-T01",
+      commandId: "create-draft-command",
+    });
+
+    execute.resolve({ status: "completed", state: planReadModel({ lifecycle: "intake", projection: "coach" }) });
+    await settle();
+    expect(subject.surface.transition).toEqual({ status: "idle" });
+    expect(subject.surface.hydration.status).toBe("ready");
+  });
+
+  it("keeps a rejected transition inside Plan and retries it with a new command", async () => {
+    const subject = harness({
+      ids: ["rejected-command", "retry-command"],
+      executePlanTransition: async () => ({
+        status: "rejected",
+        error: PLAN_ERROR,
+        state: planReadModel(),
+      }),
+    });
+
+    subject.adapter.startPlan();
+    await settle();
+    expect(subject.surface.transition).toEqual({
+      status: "failed",
+      commandId: "rejected-command",
+      transitionId: "PL-T01",
+      error: PLAN_ERROR,
+    });
+
+    subject.adapter.retry();
+    await settle();
+    expect(subject.executePlanTransition).toHaveBeenLastCalledWith({
+      transitionId: "PL-T01",
+      commandId: "retry-command",
+      sourceConversationId: null,
+    });
+  });
+
+  it.each([
+    { count: 1, projection: "workout" as const },
+    { count: 2, projection: "attention" as const },
+  ])("routes $count unresolved item(s) through PL-T33", async ({ count, projection }) => {
+    const model = planReadModel({ attentionCount: count, planId: "plan-1" });
+    const subject = harness({
+      ids: ["attention-command"],
+      getPlanState: async () => ({ status: "ready", state: model }),
+      executePlanTransition: async () => ({
+        status: "completed",
+        state: planReadModel({
+          attentionCount: count,
+          lifecycle: "active",
+          planId: "plan-1",
+          projection,
+        }),
+      }),
+    });
+    subject.adapter.start();
+    await settle();
+
+    subject.adapter.open();
+    await settle();
+
+    expect(subject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T33",
+      commandId: "attention-command",
+      planId: "plan-1",
+    });
+    expect(subject.surface.hydration.status).toBe("ready");
+    if (subject.surface.hydration.status === "ready") {
+      expect(subject.surface.hydration.state.projection).toBe(projection);
+    }
+  });
+
+  it("opens ordinary Plan without dispatching when attention is empty", async () => {
+    const subject = harness();
+    subject.adapter.start();
+    await settle();
+
+    subject.adapter.open();
+    await settle();
+
+    expect(subject.executePlanTransition).not.toHaveBeenCalled();
+    expect(subject.getPlanState).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts progress only for the current command, transition, and operation", async () => {
+    const state = planReadModel({ lifecycle: "intake", projection: "coach" });
+    const subject = harness({
+      ids: ["command-1"],
+      executePlanTransition: async () => ({ status: "accepted", operationId: "operation-1", state }),
+    });
+    subject.adapter.start();
+    await settle();
+    subject.adapter.startPlan();
+    await settle();
+
+    const matching: PlanProgressEvent = {
+      commandId: "command-1",
+      transitionId: "PL-T01",
+      operationId: "operation-1",
+      phase: "running",
+      completed: 1,
+      total: 2,
+    };
+    subject.progress({ ...matching, operationId: "other-operation" });
+    expect(subject.surface.transition).toMatchObject({ progress: null });
+
+    subject.progress(matching);
+    expect(subject.surface.transition).toMatchObject({ progress: matching });
+
+    subject.progress({ ...matching, phase: "completed", completed: 2 });
+    await settle();
+    expect(subject.getPlanState).toHaveBeenCalledTimes(2);
+  });
+
+  it("disposes the progress subscription and ignores pending hydration", async () => {
+    const load = deferred<GetPlanStateRpcResult>();
+    const subject = harness({ getPlanState: () => load.promise });
+    subject.adapter.start();
+
+    subject.adapter.dispose();
+    load.resolve({ status: "ready", state: planReadModel() });
+    await settle();
+
+    expect(subject.disposeProgress).toHaveBeenCalledOnce();
+    expect(subject.surface.hydration).toEqual({ status: "loading" });
+  });
+});

--- a/apps/desktop-renderer/tests/plan-fixtures.ts
+++ b/apps/desktop-renderer/tests/plan-fixtures.ts
@@ -1,0 +1,61 @@
+import type {
+  PlanAttention,
+  PlanError,
+  PlanProjectionKind,
+  PlanReadModel,
+} from "@enduragent/coach-contract";
+
+export const PLAN_ERROR: PlanError = Object.freeze({
+  code: "unavailable",
+  message: "Plan is temporarily unavailable.",
+  retryable: true,
+});
+
+export function planAttention(count = 0): PlanAttention {
+  const items = Array.from({ length: count }, (_, index) => ({
+    id: `attention-${index + 1}`,
+    title: `Decision ${index + 1}`,
+    scenarioId: "PL-S021" as const,
+    priority: index === 0 ? ("blocker" as const) : ("recent" as const),
+    affectedDate: null,
+  }));
+  return {
+    count,
+    destination: count === 0 ? "none" : count === 1 ? "direct" : "list",
+    items,
+  };
+}
+
+export function planReadModel(input: {
+  readonly attentionCount?: number;
+  readonly projection?: PlanProjectionKind;
+  readonly lifecycle?: PlanReadModel["lifecycle"];
+  readonly scenarioId?: PlanReadModel["scenarioId"];
+  readonly planId?: string | null;
+  readonly title?: string;
+  readonly summary?: string;
+} = {}): PlanReadModel {
+  return {
+    schemaVersion: 1,
+    scenarioId: input.scenarioId ?? "PL-S001",
+    lifecycle: input.lifecycle ?? "none",
+    planId: input.planId === undefined ? null : input.planId,
+    revision: 0,
+    title: input.title ?? "",
+    summary: input.summary ?? "",
+    projection: input.projection ?? "no-plan",
+    transitions: [{ transitionId: "PL-T01", status: "available", reason: null }],
+    reconciliation: {
+      status: "not-applicable",
+      created: 0,
+      pending: 0,
+      failed: 0,
+      total: 0,
+      currentThrough: null,
+      error: null,
+    },
+    attention: planAttention(input.attentionCount),
+    activeOperation: null,
+    data: {},
+  };
+}

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -1,0 +1,126 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_PLAN_SURFACE, type PlanActions } from "../src/state/plan-slice.js";
+import { useEnduragentStore } from "../src/state/store.js";
+import { PlanView } from "../src/ui/plan/PlanView.js";
+import { PLAN_ERROR, planReadModel } from "./plan-fixtures.js";
+
+function actions(): PlanActions {
+  return { open: vi.fn(), startPlan: vi.fn(), retry: vi.fn() };
+}
+
+beforeEach(() => {
+  useEnduragentStore.setState({ plan: EMPTY_PLAN_SURFACE, planActions: actions() });
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute("data-theme");
+  useEnduragentStore.setState({ plan: EMPTY_PLAN_SURFACE, planActions: null });
+});
+
+describe("Plan surface", () => {
+  it("renders explicit loading, failed, and compatibility states", async () => {
+    const user = userEvent.setup();
+    render(<PlanView />);
+    expect(screen.getByRole("status")).toHaveTextContent("Loading your Plan");
+
+    act(() => {
+      useEnduragentStore.getState().setPlanHydration({ status: "failed", error: PLAN_ERROR });
+    });
+    expect(screen.getByRole("heading", { name: "Plan could not load" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(useEnduragentStore.getState().planActions?.retry).toHaveBeenCalledOnce();
+
+    act(() => {
+      useEnduragentStore.getState().setPlanHydration({
+        status: "unsupported-capability",
+        capability: "planning",
+      });
+    });
+    expect(screen.getByRole("heading", { name: "Plan is not available yet" })).toBeInTheDocument();
+    expect(screen.getByText(/Update Enduragent/u)).toBeInTheDocument();
+  });
+
+  it("renders the accepted no-Plan hierarchy and starts PL-T01 from the keyboard", async () => {
+    const user = userEvent.setup();
+    const planActions = actions();
+    useEnduragentStore.setState({
+      plan: {
+        ...EMPTY_PLAN_SURFACE,
+        hydration: { status: "ready", state: planReadModel() },
+        lastReady: planReadModel(),
+      },
+      planActions,
+    });
+    render(<PlanView />);
+
+    expect(screen.getByRole("heading", { name: "Train toward one clear goal" })).toBeInTheDocument();
+    expect(screen.getByText("What the draft needs")).toBeInTheDocument();
+    expect(screen.getByText("Goal event + Race Course")).toBeInTheDocument();
+    expect(screen.getByText("Current training")).toBeInTheDocument();
+    expect(screen.getByText("FTP")).toBeInTheDocument();
+    expect(screen.getAllByText(/GPX\/FIT/u)).toHaveLength(2);
+
+    const start = screen.getByRole("button", { name: "Build a plan with coach" });
+    start.focus();
+    await user.keyboard("{Enter}");
+    expect(planActions.startPlan).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the last ready no-Plan screen visible when hydration becomes stale", () => {
+    const state = planReadModel();
+    useEnduragentStore.setState({
+      plan: {
+        ...EMPTY_PLAN_SURFACE,
+        hydration: { status: "ready", state },
+        lastReady: state,
+      },
+    });
+    act(() => {
+      useEnduragentStore.getState().setPlanHydration({ status: "failed", error: PLAN_ERROR });
+    });
+    render(<PlanView />);
+
+    expect(screen.getByText(PLAN_ERROR.message)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Train toward one clear goal" })).toBeInTheDocument();
+  });
+
+  it("renders the server attention projection without deriving a count", () => {
+    const state = planReadModel({
+      attentionCount: 2,
+      lifecycle: "active",
+      planId: "plan-1",
+      projection: "attention",
+    });
+    useEnduragentStore.setState({
+      plan: {
+        ...EMPTY_PLAN_SURFACE,
+        hydration: { status: "ready", state },
+        lastReady: state,
+      },
+    });
+    render(<PlanView />);
+
+    expect(screen.getByText("2 items need your decision.")).toBeInTheDocument();
+    expect(screen.getByText("Decision 1")).toBeInTheDocument();
+    expect(screen.getByText("Decision 2")).toBeInTheDocument();
+  });
+
+  it("uses production token classes for wide, compact, Light, and Dark layouts", async () => {
+    const [view, page, tokens] = await Promise.all([
+      readFile(resolve(import.meta.dirname, "..", "src", "ui", "plan", "PlanView.tsx"), "utf8"),
+      readFile(resolve(import.meta.dirname, "..", "src", "ui", "shared", "Page.tsx"), "utf8"),
+      readFile(resolve(import.meta.dirname, "..", "src", "theme", "tokens.css"), "utf8"),
+    ]);
+
+    expect(view).toContain("rounded-card bg-surface");
+    expect(view).toContain("text-ink-2");
+    expect(view).not.toMatch(/#[\da-f]{3,8}/iu);
+    expect(page).toContain("w-[min(680px,calc(100%-64px))]");
+    expect(tokens).toContain(':root[data-theme="dark"]');
+    expect(tokens).toContain(':root[data-theme="light"]');
+  });
+});

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -13,6 +13,7 @@ import {
   setupRequired,
   setupSurfaceOnScreen,
 } from "../src/state/onboarding-slice.js";
+import { EMPTY_PLAN_SURFACE, type PlanActions } from "../src/state/plan-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
 import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
@@ -21,6 +22,7 @@ import {
   clearTrainingRestrictionFocusRequest,
   takeTrainingRestrictionFocusRequest,
 } from "../src/ui/training/restriction-focus.js";
+import { planReadModel } from "./plan-fixtures.js";
 
 const REPAIR_REQUIRED_CREDENTIALS: CredentialSettingsState = {
   status: "ready",
@@ -72,6 +74,10 @@ function stubActions(): ChatActions {
   };
 }
 
+function stubPlanActions(): PlanActions {
+  return { open: vi.fn(), startPlan: vi.fn(), retry: vi.fn() };
+}
+
 function stravaDroppedActivities() {
   return {
     overall: {
@@ -93,6 +99,7 @@ async function preloadLazyViews(): Promise<void> {
   await Promise.all([
     import("../src/ui/archive/ArchiveView.js"),
     import("../src/ui/training/TrainingView.js"),
+    import("../src/ui/plan/PlanView.js"),
     import("../src/ui/settings/SettingsView.js"),
   ]);
 }
@@ -113,6 +120,8 @@ describe("shell", () => {
       onboarding: READY_ONBOARDING,
       onboardingActions: null,
       onboardingStartupSettled: true,
+      plan: EMPTY_PLAN_SURFACE,
+      planActions: stubPlanActions(),
       settings: {
         ...useEnduragentStore.getState().settings,
         savingOwners: [],
@@ -131,6 +140,8 @@ describe("shell", () => {
       onboarding: CLOSED_ONBOARDING,
       onboardingActions: null,
       onboardingStartupSettled: false,
+      plan: EMPTY_PLAN_SURFACE,
+      planActions: null,
       settings: {
         ...useEnduragentStore.getState().settings,
         credentials: { status: "closed" },
@@ -188,6 +199,24 @@ describe("shell", () => {
 
     await user.click(screen.getByRole("button", { name: "Training" }));
     expect(await screen.findByRole("region", { name: "Training" })).toBeInTheDocument();
+
+    const planState = planReadModel();
+    act(() => {
+      useEnduragentStore.setState({
+        plan: {
+          ...EMPTY_PLAN_SURFACE,
+          hydration: { status: "ready", state: planState },
+          lastReady: planState,
+        },
+      });
+    });
+    await user.click(screen.getByRole("button", { name: "Plan" }));
+    expect(await screen.findByRole("region", { name: "Plan" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Train toward one clear goal" })).toBeInTheDocument();
+    expect(document.querySelector("div.thread")).not.toBeNull();
+    const conversation = screen.getByLabelText("Coaching conversation");
+    expect(conversation.closest(".hidden")).not.toBeNull();
+    expect(screen.getByRole("region", { name: "Plan" }).querySelector("div.thread")).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "Settings" }));
     expect(await screen.findByRole("region", { name: "Settings" })).toBeInTheDocument();

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -9,6 +9,7 @@ import {
   setManualSyncFocusTarget,
 } from "../src/state/manual-sync-focus.js";
 import { CLOSED_ONBOARDING, READY_ONBOARDING } from "../src/state/onboarding-slice.js";
+import { EMPTY_PLAN_SURFACE, type PlanActions } from "../src/state/plan-slice.js";
 import { EMPTY_SETTINGS_SURFACE } from "../src/state/settings-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { IDLE_MANUAL_SYNC } from "../src/state/sync-slice.js";
@@ -16,6 +17,7 @@ import { EMPTY_TRAINING_SURFACE } from "../src/state/training-slice.js";
 import { toManualSyncViewState } from "../src/training-context/manual-sync.js";
 import { Sidebar } from "../src/ui/sidebar/Sidebar.js";
 import { clearTrainingRestrictionFocusRequest } from "../src/ui/training/restriction-focus.js";
+import { planReadModel } from "./plan-fixtures.js";
 
 function stubActions(): ChatActions {
   return {
@@ -35,6 +37,10 @@ function stubActions(): ChatActions {
     skipDecision: vi.fn(),
     retryDecision: vi.fn(),
   };
+}
+
+function stubPlanActions(): PlanActions {
+  return { open: vi.fn(), startPlan: vi.fn(), retry: vi.fn() };
 }
 
 function update(patch: Partial<Parameters<typeof useEnduragentStore.setState>[0]>): void {
@@ -84,6 +90,8 @@ beforeEach(() => {
     onboardingActions: null,
     settings: EMPTY_SETTINGS_SURFACE,
     settingsPorts: null,
+    plan: EMPTY_PLAN_SURFACE,
+    planActions: stubPlanActions(),
   });
 });
 
@@ -100,6 +108,49 @@ afterEach(() => {
     onboardingActions: null,
     settings: EMPTY_SETTINGS_SURFACE,
     settingsPorts: null,
+    plan: EMPTY_PLAN_SURFACE,
+    planActions: null,
+  });
+});
+
+describe("Plan navigation attention", () => {
+  it("shows no badge when Plan has no athlete action", () => {
+    render(<Sidebar />);
+
+    expect(screen.getByRole("button", { name: "Plan" })).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    { count: 1, name: "Plan, 1 item needs attention" },
+    { count: 3, name: "Plan, 3 items need attention" },
+  ])("shows the exact count for $count unresolved item(s)", ({ count, name }) => {
+    const readModel = planReadModel({ attentionCount: count, lifecycle: "active", planId: "plan-1" });
+    update({
+      plan: {
+        ...EMPTY_PLAN_SURFACE,
+        hydration: { status: "ready", state: readModel },
+        lastReady: readModel,
+      },
+    });
+    render(<Sidebar />);
+
+    expect(screen.getByRole("button", { name })).toHaveTextContent(String(count));
+  });
+
+  it("keeps Plan selected and asks the adapter to resolve its destination", async () => {
+    const user = userEvent.setup();
+    const planActions = stubPlanActions();
+    update({ planActions });
+    render(<Sidebar />);
+
+    const plan = screen.getByRole("button", { name: "Plan" });
+    plan.focus();
+    await user.keyboard("{Enter}");
+
+    expect(useEnduragentStore.getState().activeView).toBe("plan");
+    expect(planActions.open).toHaveBeenCalledOnce();
+    expect(plan).toHaveFocus();
   });
 });
 


### PR DESCRIPTION
## Summary
- add Plan as a top-level desktop destination
- hydrate the server-authoritative Plan read model and route attention state
- render the no-Plan starting surface from the frozen HTML behavior
- show an exact unresolved-attention badge in the sidebar

## Verification
- 58 focused Plan and shell tests passed
- 974 desktop renderer tests passed
- desktop renderer typecheck passed
- desktop renderer production build passed
- root `pnpm check` passed
- isolated Codex autoreview passed with no actionable findings

## Limits
- none