### PR TITLE
feat(desktop): add Windows release envelope and verify workflow

### DIFF
--- a/.changeset/windows-release-envelope.md
+++ b/.changeset/windows-release-envelope.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Add the Windows release envelope: release planner, asset verifier, operator upload script, Windows-aware desktop release transaction, and the dispatch-only Windows verification workflow. Authenticode verification is a pending W19 hook.

--- a/.github/workflows/desktop-windows-release.yml
+++ b/.github/workflows/desktop-windows-release.yml
@@ -1,0 +1,123 @@
+name: Desktop Windows release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Frozen desktop SemVer already published for macOS
+        required: true
+        type: string
+      dry_run:
+        description: Verify only; never edit the release
+        type: boolean
+        default: true
+
+permissions: { contents: read }
+
+concurrency:
+  group: desktop-windows-release
+  cancel-in-progress: false
+
+jobs:
+  verify-windows-envelope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions: { contents: write }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile
+      - name: Resolve release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          trap 'echo "::error::Failed to resolve Windows release"' ERR
+          if ! printf '%s' "$VERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo '::error::Desktop version must be stable SemVer'
+            exit 1
+          fi
+          if ! RELEASE=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/enduragent-desktop@$VERSION"); then
+            echo '::error::Desktop release does not exist'
+            exit 1
+          fi
+          if [ "$(printf '%s' "$RELEASE" | jq -r '.draft')" != 'false' ] || \
+             [ "$(printf '%s' "$RELEASE" | jq -r '.prerelease')" != 'false' ]; then
+            echo '::error::Desktop release must be published and not prerelease'
+            exit 1
+          fi
+          EXPECTED=$(printf '%s\n' \
+            "Enduragent-$VERSION-x64.exe" \
+            "Enduragent-$VERSION-x64.exe.blockmap" \
+            latest.yml | LC_ALL=C sort)
+          ACTUAL=$(printf '%s' "$RELEASE" | jq -r --arg version "$VERSION" \
+            '.assets[].name | select(. == "Enduragent-\($version)-x64.exe" or . == "Enduragent-\($version)-x64.exe.blockmap" or . == "latest.yml")' | LC_ALL=C sort)
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo '::error::Windows release assets are incomplete'
+            exit 1
+          fi
+          RELEASE_ID=$(printf '%s' "$RELEASE" | jq -er '.id')
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+      - name: Download Windows assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/windows-release"
+          gh release download "enduragent-desktop@$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir "$RUNNER_TEMP/windows-release" \
+            --pattern "Enduragent-$VERSION-x64.exe" \
+            --pattern "Enduragent-$VERSION-x64.exe.blockmap" \
+            --pattern latest.yml
+          test "$(ls -1 "$RUNNER_TEMP/windows-release" | LC_ALL=C sort)" = "$(printf '%s\n' "Enduragent-$VERSION-x64.exe" "Enduragent-$VERSION-x64.exe.blockmap" latest.yml | LC_ALL=C sort)"
+      - name: Verify Windows release envelope
+        id: verify
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          node apps/desktop/scripts/verify-windows-release.mjs "$RUNNER_TEMP/windows-release" --version "$VERSION" --authenticode pending-w19 | tee "$RUNNER_TEMP/verify.out"
+          INSTALLER_SHA256=$(awk '/^Windows release envelope verified [0-9a-f]{64}$/{sha=$NF} END{if (sha == "") exit 1; print sha}' "$RUNNER_TEMP/verify.out")
+          echo "installer_sha256=$INSTALLER_SHA256" >> "$GITHUB_OUTPUT"
+      - name: Verify Authenticode (pending W19)
+        run: |
+          set -euo pipefail
+          echo "::notice::Authenticode verification pending W19 (apps/desktop/scripts/verify-windows-authenticode.ps1 does not exist yet); the installer signature was NOT verified"
+      - name: Mark Windows assets verified
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.release.outputs.release_id }}
+          INSTALLER_SHA256: ${{ steps.verify.outputs.installer_sha256 }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$RUNNER_TEMP/release.json"
+          jq -j '.body // ""' "$RUNNER_TEMP/release.json" > "$RUNNER_TEMP/release-body.txt"
+          MARKER="Windows assets verified: $INSTALLER_SHA256 (Authenticode verification pending W19)"
+          if grep -Fxq "$MARKER" "$RUNNER_TEMP/release-body.txt"; then
+            exit 0
+          fi
+          printf '\n\n%s' "$MARKER" >> "$RUNNER_TEMP/release-body.txt"
+          jq -n --rawfile body "$RUNNER_TEMP/release-body.txt" '{body: $body}' > "$RUNNER_TEMP/release-patch.json"
+          gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            --input "$RUNNER_TEMP/release-patch.json" >/dev/null
+      - name: Dry run summary
+        if: ${{ inputs.dry_run == true }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          echo "::notice::dry_run=true; release enduragent-desktop@$VERSION was verified but not marked"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,8 @@
     "test:windows-parity-contract": "vitest run tests/windows-parity-contract.test.ts",
     "verify:package-layout": "node scripts/verify-package-layout.mjs",
     "verify:win-package": "node scripts/verify-windows-package.mjs",
+    "verify:win-release": "node scripts/verify-windows-release.mjs",
+    "upload:win-release": "node scripts/upload-windows-release.mjs",
     "verify:mac-release": "node scripts/verify-macos-release.mjs",
     "verify:mac-backend-selection": "node scripts/verify-macos-backend-selection.mjs",
     "smoke:runtime": "node scripts/electron-smoke.mjs runtime",

--- a/apps/desktop/scripts/upload-windows-release.d.mts
+++ b/apps/desktop/scripts/upload-windows-release.d.mts
@@ -1,0 +1,49 @@
+import type { ObjectEncodingOptions, OpenMode } from "node:fs";
+import type { VerifiedWindowsReleaseAssets } from "./verify-windows-release.mjs";
+import type { VerifyWindowsReleaseOptions } from "./verify-windows-release.mjs";
+
+export interface WindowsReleaseUploadInput {
+  readonly version: string;
+  readonly directory: string;
+  readonly commit: string;
+  readonly authenticode: "pending-w19";
+  readonly repo?: string;
+  readonly record?: string;
+}
+
+export interface WindowsReleaseUploadRecord {
+  readonly schemaVersion: 1;
+  readonly tag: string;
+  readonly version: string;
+  readonly commit: string;
+  readonly arch: "x64";
+  readonly authenticode: "pending-w19" | "verified";
+  readonly files: readonly {
+    readonly name: string;
+    readonly size: number;
+    readonly sha256: string;
+  }[];
+}
+
+export interface WindowsReleaseUploadDependencies {
+  readonly executeFile?: (
+    executable: string,
+    arguments_: readonly string[],
+  ) => Promise<{ readonly stdout: string }>;
+  readonly verifyAssets?: (
+    artifactDirectory: string,
+    options: VerifyWindowsReleaseOptions,
+  ) => Promise<VerifiedWindowsReleaseAssets>;
+  readonly readFile?: (path: string) => Promise<Buffer>;
+  readonly writeFile?: (
+    path: string,
+    data: string,
+    options: ObjectEncodingOptions & { readonly mode?: OpenMode; readonly flag?: OpenMode },
+  ) => Promise<void>;
+}
+
+export function safeWindowsReleaseUploadMessage(error: unknown): string | undefined;
+export function runWindowsReleaseUpload(
+  input: WindowsReleaseUploadInput,
+  dependencies?: WindowsReleaseUploadDependencies,
+): Promise<WindowsReleaseUploadRecord>;

--- a/apps/desktop/scripts/upload-windows-release.mjs
+++ b/apps/desktop/scripts/upload-windows-release.mjs
@@ -1,0 +1,220 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import {
+  WINDOWS_AUTHENTICODE_PENDING,
+  requireReleaseCommit,
+  windowsReleaseArtifactNames,
+} from "./windows-release-plan.mjs";
+import {
+  safeWindowsReleaseVerificationMessage,
+  verifyWindowsReleaseAssets,
+} from "./verify-windows-release.mjs";
+import { requireStableSemVer } from "./macos-release-plan.mjs";
+
+const execFileAsync = promisify(execFile);
+const defaultRepository = "yerzhansa/enduragent";
+const safeWindowsReleaseUploadMessages = new Set([
+  "release tag mismatch",
+  "Windows release upload is incomplete",
+  "Authenticode verification mode is required",
+  "upload record path must be absolute",
+  "release repository is invalid",
+]);
+const safeReleaseStateMessagePattern =
+  /^(?:release does not exist|release is still a draft): enduragent-desktop@[-A-Za-z0-9@._]+$/u;
+const safeExistingAssetMessagePattern = /^Windows release asset already exists: [-A-Za-z0-9@._]+$/u;
+
+async function executeSystemFile(executable, arguments_) {
+  const result = await execFileAsync(executable, [...arguments_], { encoding: "utf8" });
+  return { stdout: result.stdout };
+}
+
+export function safeWindowsReleaseUploadMessage(error) {
+  return error instanceof TypeError &&
+    (safeWindowsReleaseUploadMessages.has(error.message) ||
+      safeReleaseStateMessagePattern.test(error.message) ||
+      safeExistingAssetMessagePattern.test(error.message))
+    ? error.message
+    : undefined;
+}
+
+function requireRepository(value) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(value)) {
+    throw new TypeError("release repository is invalid");
+  }
+  return value;
+}
+
+function parseRelease(stdout, tag) {
+  let release;
+  try {
+    release = JSON.parse(stdout);
+  } catch {
+    throw new TypeError(`release does not exist: ${tag}`);
+  }
+  if (
+    release === null ||
+    typeof release !== "object" ||
+    Array.isArray(release) ||
+    typeof release.tagName !== "string" ||
+    typeof release.isDraft !== "boolean" ||
+    !Array.isArray(release.assets)
+  ) {
+    throw new TypeError(`release does not exist: ${tag}`);
+  }
+  if (release.isDraft) throw new TypeError(`release is still a draft: ${tag}`);
+  if (release.tagName !== tag) throw new TypeError("release tag mismatch");
+  return release;
+}
+
+async function viewRelease(executeFile, tag, repository) {
+  let result;
+  try {
+    result = await executeFile("gh-personal", [
+      "release",
+      "view",
+      tag,
+      "--repo",
+      repository,
+      "--json",
+      "id,tagName,isDraft,isPrerelease,assets",
+    ]);
+  } catch {
+    throw new TypeError(`release does not exist: ${tag}`);
+  }
+  return parseRelease(result.stdout, tag);
+}
+
+function releaseAssetNames(release) {
+  return release.assets.flatMap((asset) =>
+    asset !== null && typeof asset === "object" && typeof asset.name === "string"
+      ? [asset.name]
+      : [],
+  );
+}
+
+async function releaseFileRecords(verified, dependencies) {
+  const entries = [
+    [verified.names.installer, verified.paths.installer, verified.sizes.installer],
+    [verified.names.blockmap, verified.paths.blockmap, verified.sizes.blockmap],
+    [verified.names.metadata, verified.paths.metadata, verified.sizes.metadata],
+  ];
+  return Promise.all(
+    entries.map(async ([name, path, size]) => {
+      const bytes = await dependencies.readFile(path);
+      if (bytes.length !== size) throw new TypeError("Windows release upload is incomplete");
+      return Object.freeze({
+        name,
+        size,
+        sha256: createHash("sha256").update(bytes).digest("hex"),
+      });
+    }),
+  );
+}
+
+export async function runWindowsReleaseUpload(input, dependencies = {}) {
+  const version = requireStableSemVer(input.version);
+  const commit = requireReleaseCommit(input.commit);
+  if (!isAbsolute(input.directory)) throw new TypeError("artifact directory must be absolute");
+  if (input.authenticode !== WINDOWS_AUTHENTICODE_PENDING) {
+    throw new TypeError("Authenticode verification mode is required");
+  }
+  const repository = requireRepository(input.repo ?? defaultRepository);
+  if (input.record !== undefined && !isAbsolute(input.record)) {
+    throw new TypeError("upload record path must be absolute");
+  }
+  const executeFile = dependencies.executeFile ?? executeSystemFile;
+  const verifyAssets = dependencies.verifyAssets ?? verifyWindowsReleaseAssets;
+  const fileDependencies = {
+    readFile: dependencies.readFile ?? readFile,
+    writeFile: dependencies.writeFile ?? writeFile,
+  };
+  const verified = await verifyAssets(input.directory, {
+    version,
+    commit,
+    authenticode: input.authenticode,
+  });
+  const tag = `enduragent-desktop@${version}`;
+  const expectedNames = Object.values(windowsReleaseArtifactNames(version));
+  const release = await viewRelease(executeFile, tag, repository);
+  const existingNames = new Set(releaseAssetNames(release));
+  for (const name of expectedNames) {
+    if (existingNames.has(name)) {
+      throw new TypeError(`Windows release asset already exists: ${name}`);
+    }
+  }
+  await executeFile("gh-personal", [
+    "release",
+    "upload",
+    tag,
+    "--repo",
+    repository,
+    verified.paths.installer,
+    verified.paths.blockmap,
+    verified.paths.metadata,
+  ]);
+  const uploadedRelease = await viewRelease(executeFile, tag, repository);
+  const uploadedNames = new Set(releaseAssetNames(uploadedRelease));
+  if (expectedNames.some((name) => !uploadedNames.has(name))) {
+    throw new TypeError("Windows release upload is incomplete");
+  }
+  const files = Object.freeze(await releaseFileRecords(verified, fileDependencies));
+  const record = Object.freeze({
+    schemaVersion: 1,
+    tag,
+    version,
+    commit,
+    arch: "x64",
+    authenticode: verified.authenticode,
+    files,
+  });
+  if (input.record !== undefined) {
+    await fileDependencies.writeFile(input.record, `${JSON.stringify(record, null, 2)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+  }
+  return record;
+}
+
+function parseArguments(arguments_) {
+  const parsed = { repo: defaultRepository };
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const name = arguments_[index];
+    const value = arguments_[index + 1];
+    if (value === undefined || !name.startsWith("--") || value.startsWith("--")) {
+      throw new TypeError("Windows release upload failed");
+    }
+    const key = name.slice(2);
+    if (!["version", "directory", "commit", "authenticode", "repo", "record"].includes(key)) {
+      throw new TypeError("Windows release upload failed");
+    }
+    if (Object.hasOwn(parsed, key) && key !== "repo") {
+      throw new TypeError("Windows release upload failed");
+    }
+    parsed[key] = value;
+  }
+  return parsed;
+}
+
+async function main() {
+  const result = await runWindowsReleaseUpload(parseArguments(process.argv.slice(2)));
+  process.stdout.write(`Windows release uploaded ${result.tag}\n`);
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    const message =
+      safeWindowsReleaseUploadMessage(error) ??
+      safeWindowsReleaseVerificationMessage(error) ??
+      "Windows release upload failed";
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/apps/desktop/scripts/verify-windows-release.d.mts
+++ b/apps/desktop/scripts/verify-windows-release.d.mts
@@ -1,0 +1,52 @@
+import type { Stats } from "node:fs";
+import type { WindowsReleaseArtifactNames } from "./windows-release-plan.mjs";
+
+export type WindowsAuthenticodeMode =
+  | "pending-w19"
+  | {
+      readonly verify: (
+        installerPath: string,
+        context: { readonly version: string; readonly publisherName?: string },
+      ) => Promise<void>;
+    };
+
+export interface VerifyWindowsReleaseOptions {
+  readonly version: string;
+  readonly commit?: string;
+  readonly expectedPublisherName?: string;
+  readonly appUpdateMetadata?: string | Uint8Array;
+  readonly authenticode: WindowsAuthenticodeMode;
+}
+
+export interface VerifyWindowsReleaseDependencies {
+  readonly lstat?: (path: string) => Promise<Stats>;
+  readonly readdir?: (path: string) => Promise<string[]>;
+  readonly readFile?: (path: string) => Promise<Buffer>;
+  readonly notice?: (message: string) => void;
+}
+
+export interface VerifiedWindowsReleaseAssets {
+  readonly version: string;
+  readonly commit: string | null;
+  readonly names: WindowsReleaseArtifactNames;
+  readonly paths: {
+    readonly installer: string;
+    readonly blockmap: string;
+    readonly metadata: string;
+  };
+  readonly sizes: {
+    readonly installer: number;
+    readonly blockmap: number;
+    readonly metadata: number;
+  };
+  readonly installerSha512: string;
+  readonly installerSha256: string;
+  readonly authenticode: "pending-w19" | "verified";
+}
+
+export function safeWindowsReleaseVerificationMessage(error: unknown): string | undefined;
+export function verifyWindowsReleaseAssets(
+  artifactDirectory: string,
+  options: VerifyWindowsReleaseOptions,
+  overrides?: VerifyWindowsReleaseDependencies,
+): Promise<VerifiedWindowsReleaseAssets>;

--- a/apps/desktop/scripts/verify-windows-release.mjs
+++ b/apps/desktop/scripts/verify-windows-release.mjs
@@ -1,0 +1,310 @@
+import { createHash } from "node:crypto";
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gunzipSync } from "node:zlib";
+import { parse } from "yaml";
+import {
+  WINDOWS_AUTHENTICODE_PENDING,
+  parseWindowsReleaseUpdaterMetadata,
+  requireReleaseCommit,
+  windowsReleaseArtifactNames,
+} from "./windows-release-plan.mjs";
+import { requireStableSemVer } from "./macos-release-plan.mjs";
+
+const maximumUpdaterMetadataBytes = 16_384;
+
+class WindowsReleaseVerificationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "WindowsReleaseVerificationError";
+  }
+}
+
+function fail(message) {
+  throw new WindowsReleaseVerificationError(message);
+}
+
+export function safeWindowsReleaseVerificationMessage(error) {
+  return error instanceof WindowsReleaseVerificationError ? error.message : undefined;
+}
+
+function exactObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value, keys) {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+async function readRegularFile(path, label, dependencies, maximumBytes) {
+  let stat;
+  try {
+    stat = await dependencies.lstat(path);
+  } catch {
+    fail(`missing ${label}`);
+  }
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isFile() ||
+    !Number.isSafeInteger(stat.size) ||
+    stat.size <= 0
+  ) {
+    fail(`invalid ${label}`);
+  }
+  if (maximumBytes !== undefined && stat.size > maximumBytes) fail("latest.yml is invalid");
+  let bytes;
+  try {
+    bytes = await dependencies.readFile(path);
+  } catch {
+    fail(`unreadable ${label}`);
+  }
+  if (!Buffer.isBuffer(bytes)) bytes = Buffer.from(bytes);
+  let after;
+  try {
+    after = await dependencies.lstat(path);
+  } catch {
+    fail(`unreadable ${label}`);
+  }
+  if (
+    after.isSymbolicLink() ||
+    !after.isFile() ||
+    bytes.length !== stat.size ||
+    after.dev !== stat.dev ||
+    after.ino !== stat.ino ||
+    after.mode !== stat.mode ||
+    after.size !== stat.size ||
+    after.mtimeMs !== stat.mtimeMs ||
+    after.ctimeMs !== stat.ctimeMs
+  ) {
+    fail(`invalid ${label}`);
+  }
+  return bytes;
+}
+
+function parseUpdaterMetadata(bytes) {
+  let metadata;
+  try {
+    metadata = parse(bytes.toString("utf8"));
+  } catch {
+    fail("latest.yml is invalid");
+  }
+  if (
+    !exactObject(metadata) ||
+    !hasExactKeys(metadata, ["version", "files", "path", "sha512", "releaseDate"]) ||
+    !Array.isArray(metadata.files) ||
+    metadata.files.length !== 1 ||
+    !exactObject(metadata.files[0]) ||
+    !hasExactKeys(metadata.files[0], ["url", "sha512", "size"])
+  ) {
+    fail("latest.yml is invalid");
+  }
+  return metadata;
+}
+
+function canonicalReleaseDate(value) {
+  if (typeof value !== "string") return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function installerMetadataMatches(metadata, version, installerName, sha512, size) {
+  const file = metadata.files[0];
+  return (
+    metadata.version === version &&
+    metadata.path === installerName &&
+    metadata.sha512 === sha512 &&
+    canonicalReleaseDate(metadata.releaseDate) &&
+    file.url === installerName &&
+    file.sha512 === sha512 &&
+    file.size === size &&
+    Number.isSafeInteger(file.size) &&
+    file.size > 0
+  );
+}
+
+function verifyBlockmap(bytes) {
+  if (bytes.length < 2 || bytes[0] !== 0x1f || bytes[1] !== 0x8b) {
+    fail("installer blockmap is invalid");
+  }
+  let blockmap;
+  try {
+    blockmap = JSON.parse(gunzipSync(bytes).toString("utf8"));
+  } catch {
+    fail("installer blockmap is invalid");
+  }
+  if (!exactObject(blockmap) || !Array.isArray(blockmap.files) || blockmap.files.length === 0) {
+    fail("installer blockmap is invalid");
+  }
+}
+
+function requireVersion(value) {
+  try {
+    return requireStableSemVer(value);
+  } catch {
+    fail("desktop release version must be stable SemVer");
+  }
+}
+
+function requireCommit(value) {
+  try {
+    return requireReleaseCommit(value);
+  } catch {
+    fail("release commit must be a full lowercase SHA-1");
+  }
+}
+
+function requireAuthenticodeMode(value) {
+  if (value === WINDOWS_AUTHENTICODE_PENDING) return value;
+  if (exactObject(value) && typeof value.verify === "function") return value;
+  fail("Authenticode verification mode is required");
+}
+
+export async function verifyWindowsReleaseAssets(artifactDirectory, options, overrides = {}) {
+  if (!isAbsolute(artifactDirectory)) fail("artifact directory must be absolute");
+  const version = requireVersion(options?.version);
+  const commit = options?.commit === undefined ? null : requireCommit(options.commit);
+  const authenticodeMode = requireAuthenticodeMode(options?.authenticode);
+  const dependencies = {
+    lstat: overrides.lstat ?? lstat,
+    readdir: overrides.readdir ?? readdir,
+    readFile: overrides.readFile ?? readFile,
+    notice: overrides.notice,
+  };
+  let directoryStat;
+  try {
+    directoryStat = await dependencies.lstat(artifactDirectory);
+  } catch {
+    fail("release artifact envelope differs");
+  }
+  if (directoryStat.isSymbolicLink() || !directoryStat.isDirectory()) {
+    fail("release artifact envelope differs");
+  }
+  let entries;
+  try {
+    entries = await dependencies.readdir(artifactDirectory);
+  } catch {
+    fail("release artifact envelope differs");
+  }
+  const names = windowsReleaseArtifactNames(version);
+  const expectedNames = Object.values(names).sort();
+  const actualNames = [...entries].sort();
+  if (
+    actualNames.length !== expectedNames.length ||
+    actualNames.some((name, index) => name !== expectedNames[index])
+  ) {
+    fail("release artifact envelope differs");
+  }
+  const paths = Object.freeze({
+    installer: join(artifactDirectory, names.installer),
+    blockmap: join(artifactDirectory, names.blockmap),
+    metadata: join(artifactDirectory, names.metadata),
+  });
+  const [installer, blockmap, metadataBytes] = await Promise.all([
+    readRegularFile(paths.installer, "Windows installer", dependencies),
+    readRegularFile(paths.blockmap, "installer blockmap", dependencies),
+    readRegularFile(paths.metadata, "latest.yml", dependencies, maximumUpdaterMetadataBytes),
+  ]);
+  const metadata = parseUpdaterMetadata(metadataBytes);
+  const installerSha512 = createHash("sha512").update(installer).digest("base64");
+  const installerSha256 = createHash("sha256").update(installer).digest("hex");
+  if (
+    !installerMetadataMatches(metadata, version, names.installer, installerSha512, installer.length)
+  ) {
+    fail("latest.yml does not match the Windows installer");
+  }
+  verifyBlockmap(blockmap);
+  if (options.appUpdateMetadata !== undefined) {
+    try {
+      parseWindowsReleaseUpdaterMetadata(
+        options.appUpdateMetadata,
+        options.expectedPublisherName === undefined
+          ? {}
+          : { expectedPublisherName: options.expectedPublisherName },
+      );
+    } catch (error) {
+      fail(error instanceof TypeError ? error.message : "release updater metadata is invalid");
+    }
+  }
+  let authenticode;
+  if (authenticodeMode === WINDOWS_AUTHENTICODE_PENDING) {
+    dependencies.notice?.("Authenticode verification is pending W19; signature not verified");
+    authenticode = WINDOWS_AUTHENTICODE_PENDING;
+  } else {
+    try {
+      await authenticodeMode.verify(paths.installer, {
+        version,
+        publisherName: options.expectedPublisherName,
+      });
+    } catch {
+      fail("Windows installer Authenticode verification failed");
+    }
+    authenticode = "verified";
+  }
+  return Object.freeze({
+    version,
+    commit,
+    names,
+    paths,
+    sizes: Object.freeze({
+      installer: installer.length,
+      blockmap: blockmap.length,
+      metadata: metadataBytes.length,
+    }),
+    installerSha512,
+    installerSha256,
+    authenticode,
+  });
+}
+
+function parseArguments(arguments_) {
+  let directory;
+  let version;
+  let commit;
+  let authenticode;
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (!argument.startsWith("--") && directory === undefined) {
+      directory = argument;
+      continue;
+    }
+    const value = arguments_[index + 1];
+    if (value === undefined || value.startsWith("--")) fail("Windows release verification failed");
+    index += 1;
+    if (argument === "--version" && version === undefined) version = value;
+    else if (argument === "--commit" && commit === undefined) commit = value;
+    else if (argument === "--authenticode" && authenticode === undefined) authenticode = value;
+    else fail("Windows release verification failed");
+  }
+  return { directory, version, commit, authenticode };
+}
+
+async function main() {
+  const arguments_ = parseArguments(process.argv.slice(2));
+  if (arguments_.authenticode !== WINDOWS_AUTHENTICODE_PENDING) {
+    fail("Authenticode verification mode is required");
+  }
+  const result = await verifyWindowsReleaseAssets(
+    arguments_.directory,
+    {
+      version: arguments_.version,
+      commit: arguments_.commit,
+      authenticode: arguments_.authenticode,
+    },
+    { notice: (message) => process.stderr.write(`${message}\n`) },
+  );
+  process.stdout.write(`Windows release envelope verified ${result.installerSha256}\n`);
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(
+      `${safeWindowsReleaseVerificationMessage(error) ?? "Windows release verification failed"}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/apps/desktop/scripts/windows-release-plan.d.mts
+++ b/apps/desktop/scripts/windows-release-plan.d.mts
@@ -1,0 +1,91 @@
+export type WindowsReleaseMode = "genesis" | "steady";
+
+export interface WindowsReleaseArtifactNames {
+  readonly installer: string;
+  readonly blockmap: string;
+  readonly metadata: "latest.yml";
+}
+
+export interface WindowsReleaseUpdaterMetadata {
+  readonly provider: "generic";
+  readonly url: string;
+  readonly channel: "latest";
+  readonly updaterCacheDirName: "@enduragentdesktop-updater";
+  readonly publisherName?: string;
+}
+
+export interface WindowsReleaseInput {
+  readonly version: string;
+  readonly commit: string;
+  readonly feedUrl: string;
+  readonly mode: WindowsReleaseMode;
+  readonly baselineVersion?: string;
+  readonly repositoryRoot?: string;
+  readonly desktopRoot?: string;
+}
+
+export interface WindowsReleaseBuilderOptions {
+  readonly projectDir: string;
+  readonly publish: "never";
+  readonly win: readonly ["nsis:x64"];
+  readonly config: {
+    readonly extends: string;
+    readonly artifactName: string;
+    readonly forceCodeSigning: true;
+    readonly extraMetadata: {
+      readonly version: string;
+      readonly enduragentDesktopRelease: true;
+    };
+    readonly publish: readonly [
+      { readonly provider: "generic"; readonly url: string; readonly channel: "latest" },
+    ];
+    readonly win: {
+      readonly verifyUpdateCodeSignature: true;
+      readonly target: readonly [{ readonly target: "nsis"; readonly arch: readonly ["x64"] }];
+    };
+    readonly nsis: {
+      readonly artifactName: string;
+      readonly differentialPackage: true;
+    };
+  };
+}
+
+export interface WindowsReleasePlan {
+  readonly version: string;
+  readonly commit: string;
+  readonly tag: string;
+  readonly platform: "win32";
+  readonly arch: "x64";
+  readonly mode: WindowsReleaseMode;
+  readonly baselineVersion: string | null;
+  readonly feedUrl: string;
+  readonly artifactNames: WindowsReleaseArtifactNames;
+  readonly assetNames: readonly string[];
+  readonly updaterMetadata: WindowsReleaseUpdaterMetadata;
+  readonly authenticode: "pending-w19";
+  readonly builderOptions: WindowsReleaseBuilderOptions;
+}
+
+export const WINDOWS_RELEASE_ARCH: "x64";
+export const WINDOWS_RELEASE_PLATFORM: "win32";
+export const WINDOWS_RELEASE_METADATA_NAME: "latest.yml";
+export const WINDOWS_AUTHENTICODE_PENDING: "pending-w19";
+export function safeWindowsReleasePlanMessage(error: unknown): string | undefined;
+export function requireReleaseCommit(value: unknown): string;
+export function windowsReleaseArtifactNames(version: string): WindowsReleaseArtifactNames;
+export function windowsReleaseAssetNames(version: string): readonly string[];
+export function assertKnownWindowsReleaseAssets(
+  names: readonly string[],
+  version: string,
+): readonly string[];
+export function parseWindowsReleaseUpdaterMetadata(
+  bytes: string | Uint8Array,
+  options?: { readonly expectedPublisherName?: string },
+): WindowsReleaseUpdaterMetadata;
+export function readWindowsReleaseVersion(
+  options?: { readonly repositoryRoot?: string; readonly desktopRoot?: string },
+  dependencies?: {
+    readonly readFile?: (path: string, encoding: "utf8") => Promise<string>;
+  },
+): Promise<string>;
+export function createWindowsReleasePlan(input: WindowsReleaseInput): WindowsReleasePlan;

--- a/apps/desktop/scripts/windows-release-plan.mjs
+++ b/apps/desktop/scripts/windows-release-plan.mjs
@@ -1,0 +1,240 @@
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+import {
+  DESKTOP_UPDATER_CACHE_DIRECTORY,
+  requireGenericFeedUrl,
+  requireStableSemVer,
+} from "./macos-release-plan.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const canonicalRepositoryRoot = resolve(scriptDirectory, "../../..");
+const safeWindowsReleaseAssetMessagePattern =
+  /^(?:duplicate|unknown|missing) Windows release asset: [-A-Za-z0-9@._]+$/u;
+const safeWindowsReleasePlanMessages = new Set([
+  "desktop release version must be stable SemVer",
+  "release feed URL is invalid",
+  "release commit must be a full lowercase SHA-1",
+  "Windows release mode must be genesis or steady",
+  "genesis Windows release must not name a baseline",
+  "steady Windows release requires a lower stable baseline version",
+  "release updater metadata is invalid",
+  "release updater publisher name mismatch",
+]);
+
+export const WINDOWS_RELEASE_ARCH = "x64";
+export const WINDOWS_RELEASE_PLATFORM = "win32";
+export const WINDOWS_RELEASE_METADATA_NAME = "latest.yml";
+export const WINDOWS_AUTHENTICODE_PENDING = "pending-w19";
+
+function exactObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value, keys) {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function compareStableVersions(left, right) {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) return leftParts[index] - rightParts[index];
+  }
+  return 0;
+}
+
+function freezeBuilderOptions(desktopRoot, version, feedUrl) {
+  const publish = Object.freeze([
+    Object.freeze({ provider: "generic", url: feedUrl, channel: "latest" }),
+  ]);
+  const target = Object.freeze([
+    Object.freeze({ target: "nsis", arch: Object.freeze([WINDOWS_RELEASE_ARCH]) }),
+  ]);
+  const config = Object.freeze({
+    extends: join(desktopRoot, "electron-builder.yml"),
+    artifactName: `Enduragent-${version}-x64.\${ext}`,
+    forceCodeSigning: true,
+    extraMetadata: Object.freeze({ version, enduragentDesktopRelease: true }),
+    publish,
+    win: Object.freeze({ verifyUpdateCodeSignature: true, target }),
+    nsis: Object.freeze({
+      artifactName: `Enduragent-${version}-x64.\${ext}`,
+      differentialPackage: true,
+    }),
+  });
+  return Object.freeze({
+    projectDir: desktopRoot,
+    publish: "never",
+    win: Object.freeze([`nsis:${WINDOWS_RELEASE_ARCH}`]),
+    config,
+  });
+}
+
+export function safeWindowsReleasePlanMessage(error) {
+  return error instanceof TypeError &&
+    (safeWindowsReleasePlanMessages.has(error.message) ||
+      safeWindowsReleaseAssetMessagePattern.test(error.message))
+    ? error.message
+    : undefined;
+}
+
+export function requireReleaseCommit(value) {
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/u.test(value)) {
+    throw new TypeError("release commit must be a full lowercase SHA-1");
+  }
+  return value;
+}
+
+export function windowsReleaseArtifactNames(version) {
+  const stableVersion = requireStableSemVer(version);
+  const installer = `Enduragent-${stableVersion}-${WINDOWS_RELEASE_ARCH}.exe`;
+  return Object.freeze({
+    installer,
+    blockmap: `${installer}.blockmap`,
+    metadata: WINDOWS_RELEASE_METADATA_NAME,
+  });
+}
+
+export function windowsReleaseAssetNames(version) {
+  return Object.freeze(Object.values(windowsReleaseArtifactNames(version)).sort());
+}
+
+export function assertKnownWindowsReleaseAssets(names, version) {
+  if (!Array.isArray(names)) throw new TypeError("unknown Windows release asset: latest.yml");
+  const expected = windowsReleaseAssetNames(version);
+  const duplicate = names.find((name, index) => names.indexOf(name) !== index);
+  if (duplicate !== undefined) throw new TypeError(`duplicate Windows release asset: ${duplicate}`);
+  const seen = new Set();
+  for (const name of names) {
+    seen.add(name);
+    if (!expected.includes(name)) throw new TypeError(`unknown Windows release asset: ${name}`);
+  }
+  for (const name of expected) {
+    if (!seen.has(name)) throw new TypeError(`missing Windows release asset: ${name}`);
+  }
+  return expected;
+}
+
+export function parseWindowsReleaseUpdaterMetadata(bytes, options = {}) {
+  let metadata;
+  try {
+    const source =
+      typeof bytes === "string"
+        ? bytes
+        : bytes instanceof Uint8Array
+          ? Buffer.from(bytes).toString("utf8")
+          : undefined;
+    if (source === undefined) throw new TypeError();
+    metadata = parse(source);
+  } catch {
+    throw new TypeError("release updater metadata is invalid");
+  }
+  const keys = ["provider", "url", "channel", "updaterCacheDirName"];
+  if (exactObject(metadata) && Object.hasOwn(metadata, "publisherName")) keys.push("publisherName");
+  if (
+    !exactObject(metadata) ||
+    !hasExactKeys(metadata, keys) ||
+    metadata.provider !== "generic" ||
+    metadata.channel !== "latest" ||
+    metadata.updaterCacheDirName !== DESKTOP_UPDATER_CACHE_DIRECTORY ||
+    (Object.hasOwn(metadata, "publisherName") &&
+      (typeof metadata.publisherName !== "string" ||
+        metadata.publisherName.length === 0 ||
+        metadata.publisherName !== metadata.publisherName.trim()))
+  ) {
+    throw new TypeError("release updater metadata is invalid");
+  }
+  let url;
+  try {
+    url = requireGenericFeedUrl(metadata.url);
+  } catch {
+    throw new TypeError("release updater metadata is invalid");
+  }
+  if (
+    Object.hasOwn(options, "expectedPublisherName") &&
+    options.expectedPublisherName !== metadata.publisherName
+  ) {
+    throw new TypeError("release updater publisher name mismatch");
+  }
+  const result = {
+    provider: "generic",
+    url,
+    channel: "latest",
+    updaterCacheDirName: DESKTOP_UPDATER_CACHE_DIRECTORY,
+  };
+  if (Object.hasOwn(metadata, "publisherName")) result.publisherName = metadata.publisherName;
+  return Object.freeze(result);
+}
+
+export async function readWindowsReleaseVersion(options = {}, dependencies = {}) {
+  const repositoryRoot = options.repositoryRoot ?? canonicalRepositoryRoot;
+  if (!isAbsolute(repositoryRoot)) throw new TypeError("repository root must be absolute");
+  const desktopRoot = options.desktopRoot ?? join(repositoryRoot, "apps/desktop");
+  if (!isAbsolute(desktopRoot)) throw new TypeError("desktop root must be absolute");
+  const read = dependencies.readFile ?? readFile;
+  let manifest;
+  try {
+    manifest = JSON.parse(await read(join(desktopRoot, "package.json"), "utf8"));
+  } catch {
+    throw new TypeError("desktop release manifest is invalid");
+  }
+  if (!exactObject(manifest) || !Object.hasOwn(manifest, "version")) {
+    throw new TypeError("desktop release manifest is invalid");
+  }
+  return requireStableSemVer(manifest.version);
+}
+
+export function createWindowsReleasePlan(input) {
+  const version = requireStableSemVer(input.version);
+  const commit = requireReleaseCommit(input.commit);
+  const feedUrl = requireGenericFeedUrl(input.feedUrl);
+  if (input.mode !== "genesis" && input.mode !== "steady") {
+    throw new TypeError("Windows release mode must be genesis or steady");
+  }
+  let baselineVersion = null;
+  if (input.mode === "genesis") {
+    if (input.baselineVersion !== undefined) {
+      throw new TypeError("genesis Windows release must not name a baseline");
+    }
+  } else {
+    try {
+      baselineVersion = requireStableSemVer(input.baselineVersion);
+    } catch {
+      throw new TypeError("steady Windows release requires a lower stable baseline version");
+    }
+    if (compareStableVersions(baselineVersion, version) >= 0) {
+      throw new TypeError("steady Windows release requires a lower stable baseline version");
+    }
+  }
+  const repositoryRoot = input.repositoryRoot ?? canonicalRepositoryRoot;
+  if (!isAbsolute(repositoryRoot)) throw new TypeError("repository root must be absolute");
+  const desktopRoot = input.desktopRoot ?? join(repositoryRoot, "apps/desktop");
+  if (!isAbsolute(desktopRoot)) throw new TypeError("desktop root must be absolute");
+  const artifactNames = windowsReleaseArtifactNames(version);
+  const assetNames = windowsReleaseAssetNames(version);
+  const updaterMetadata = Object.freeze({
+    provider: "generic",
+    url: feedUrl,
+    channel: "latest",
+    updaterCacheDirName: DESKTOP_UPDATER_CACHE_DIRECTORY,
+  });
+  return Object.freeze({
+    version,
+    commit,
+    tag: `enduragent-desktop@${version}`,
+    platform: WINDOWS_RELEASE_PLATFORM,
+    arch: WINDOWS_RELEASE_ARCH,
+    mode: input.mode,
+    baselineVersion,
+    feedUrl,
+    artifactNames,
+    assetNames,
+    updaterMetadata,
+    authenticode: WINDOWS_AUTHENTICODE_PENDING,
+    builderOptions: freezeBuilderOptions(desktopRoot, version, feedUrl),
+  });
+}

--- a/apps/desktop/tests/upload-windows-release.test.ts
+++ b/apps/desktop/tests/upload-windows-release.test.ts
@@ -1,0 +1,229 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VerifiedWindowsReleaseAssets } from "../scripts/verify-windows-release.mjs";
+import { runWindowsReleaseUpload } from "../scripts/upload-windows-release.mjs";
+import { windowsReleaseArtifactNames } from "../scripts/windows-release-plan.mjs";
+
+const version = "0.1.5";
+const commit = "a".repeat(40);
+const tag = `enduragent-desktop@${version}`;
+const repository = "yerzhansa/enduragent";
+const script = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../scripts/upload-windows-release.mjs",
+);
+const temporaryRoots: string[] = [];
+let directory: string;
+let verified: VerifiedWindowsReleaseAssets;
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), "windows-release-upload-"));
+  temporaryRoots.push(directory);
+  const names = windowsReleaseArtifactNames(version);
+  const contents = {
+    installer: Buffer.from("signed installer"),
+    blockmap: Buffer.from("blockmap"),
+    metadata: Buffer.from("metadata"),
+  };
+  const paths = {
+    installer: join(directory, names.installer),
+    blockmap: join(directory, names.blockmap),
+    metadata: join(directory, names.metadata),
+  };
+  await Promise.all([
+    writeFile(paths.installer, contents.installer),
+    writeFile(paths.blockmap, contents.blockmap),
+    writeFile(paths.metadata, contents.metadata),
+  ]);
+  verified = {
+    version,
+    commit,
+    names,
+    paths,
+    sizes: {
+      installer: contents.installer.length,
+      blockmap: contents.blockmap.length,
+      metadata: contents.metadata.length,
+    },
+    installerSha512: createHash("sha512").update(contents.installer).digest("base64"),
+    installerSha256: createHash("sha256").update(contents.installer).digest("hex"),
+    authenticode: "pending-w19",
+  };
+});
+
+function release(assets: readonly string[] = [], overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    id: "123",
+    tagName: tag,
+    isDraft: false,
+    isPrerelease: false,
+    assets: assets.map((name) => ({ name })),
+    ...overrides,
+  });
+}
+
+function successfulExecutor() {
+  let views = 0;
+  return vi.fn(async (_executable: string, arguments_: readonly string[]) => {
+    if (arguments_[0] === "release" && arguments_[1] === "view") {
+      views += 1;
+      return {
+        stdout:
+          views === 1
+            ? release([`Enduragent-${version}-arm64.dmg`])
+            : release(Object.values(verified.names)),
+      };
+    }
+    return { stdout: "" };
+  });
+}
+
+function input(overrides: Record<string, unknown> = {}) {
+  return {
+    version,
+    directory,
+    commit,
+    authenticode: "pending-w19" as const,
+    ...overrides,
+  };
+}
+
+describe("Windows release upload", () => {
+  it("verifies locally, views the release, and uploads installer, blockmap, then metadata", async () => {
+    const executeFile = successfulExecutor();
+    const verifyAssets = vi.fn(async () => verified);
+    await runWindowsReleaseUpload(input(), { executeFile, verifyAssets });
+    expect(verifyAssets).toHaveBeenCalledWith(directory, {
+      version,
+      commit,
+      authenticode: "pending-w19",
+    });
+    const viewArguments = [
+      "release",
+      "view",
+      tag,
+      "--repo",
+      repository,
+      "--json",
+      "id,tagName,isDraft,isPrerelease,assets",
+    ];
+    expect(executeFile.mock.calls[0]).toEqual(["gh-personal", viewArguments]);
+    expect(executeFile.mock.calls[1]).toEqual([
+      "gh-personal",
+      [
+        "release",
+        "upload",
+        tag,
+        "--repo",
+        repository,
+        verified.paths.installer,
+        verified.paths.blockmap,
+        verified.paths.metadata,
+      ],
+    ]);
+    expect(executeFile.mock.calls[2]).toEqual(["gh-personal", viewArguments]);
+    expect(executeFile.mock.calls.flat(2)).not.toContain("--clobber");
+  });
+
+  it("refuses a missing or unparsable release", async () => {
+    const executeFile = vi.fn(async () => Promise.reject(new Error("not found")));
+    await expect(
+      runWindowsReleaseUpload(input(), {
+        executeFile,
+        verifyAssets: vi.fn(async () => verified),
+      }),
+    ).rejects.toThrow(`release does not exist: ${tag}`);
+  });
+
+  it("refuses a draft release", async () => {
+    const executeFile = vi.fn(async () => ({ stdout: release([], { isDraft: true }) }));
+    await expect(
+      runWindowsReleaseUpload(input(), {
+        executeFile,
+        verifyAssets: vi.fn(async () => verified),
+      }),
+    ).rejects.toThrow(`release is still a draft: ${tag}`);
+  });
+
+  it("refuses pre-existing Windows assets", async () => {
+    const existing = verified.names.blockmap;
+    const executeFile = vi.fn(async () => ({ stdout: release([existing]) }));
+    await expect(
+      runWindowsReleaseUpload(input(), {
+        executeFile,
+        verifyAssets: vi.fn(async () => verified),
+      }),
+    ).rejects.toThrow(`Windows release asset already exists: ${existing}`);
+  });
+
+  it("refuses unsupported Authenticode modes before verification or upload", async () => {
+    const executeFile = vi.fn(async () => ({ stdout: "" }));
+    const verifyAssets = vi.fn(async () => verified);
+    await expect(
+      runWindowsReleaseUpload(input({ authenticode: "verified" }) as never, {
+        executeFile,
+        verifyAssets,
+      }),
+    ).rejects.toThrow("Authenticode verification mode is required");
+    expect(verifyAssets).not.toHaveBeenCalled();
+    expect(executeFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported Authenticode CLI value before invoking GitHub", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        "--version",
+        version,
+        "--directory",
+        directory,
+        "--commit",
+        commit,
+        "--authenticode",
+        "verified",
+      ],
+      { encoding: "utf8" },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("Authenticode verification mode is required\n");
+  });
+
+  it("writes an owner-only immutable upload record with all file hashes", async () => {
+    const recordPath = join(directory, "upload-record.json");
+    const result = await runWindowsReleaseUpload(input({ record: recordPath }), {
+      executeFile: successfulExecutor(),
+      verifyAssets: vi.fn(async () => verified),
+    });
+    const recorded = JSON.parse(await readFile(recordPath, "utf8"));
+    expect((await stat(recordPath)).mode & 0o777).toBe(0o600);
+    expect(recorded).toEqual(result);
+    expect(recorded).toMatchObject({
+      schemaVersion: 1,
+      tag,
+      version,
+      commit,
+      arch: "x64",
+      authenticode: "pending-w19",
+    });
+    expect(recorded.files.map((file: { name: string }) => file.name)).toEqual([
+      verified.names.installer,
+      verified.names.blockmap,
+      verified.names.metadata,
+    ]);
+    expect(
+      recorded.files.every((file: { sha256: string }) => /^[0-9a-f]{64}$/u.test(file.sha256)),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/tests/windows-release-artifacts.test.ts
+++ b/apps/desktop/tests/windows-release-artifacts.test.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stringify } from "yaml";
+import type { VerifyWindowsReleaseOptions } from "../scripts/verify-windows-release.mjs";
+import { verifyWindowsReleaseAssets } from "../scripts/verify-windows-release.mjs";
+import { windowsReleaseArtifactNames } from "../scripts/windows-release-plan.mjs";
+
+const version = "0.1.5";
+const commit = "a".repeat(40);
+const releaseDate = "2026-08-25T00:00:00.000Z";
+const script = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../scripts/verify-windows-release.mjs",
+);
+const temporaryRoots: string[] = [];
+let directory: string;
+let installer: Buffer;
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+function metadata(overrides: Record<string, unknown> = {}) {
+  const names = windowsReleaseArtifactNames(version);
+  const sha512 = createHash("sha512").update(installer).digest("base64");
+  return {
+    version,
+    files: [{ url: names.installer, sha512, size: installer.length }],
+    path: names.installer,
+    sha512,
+    releaseDate,
+    ...overrides,
+  };
+}
+
+async function writeMetadata(value = metadata()) {
+  await writeFile(join(directory, "latest.yml"), stringify(value));
+}
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), "windows-release-envelope-"));
+  temporaryRoots.push(directory);
+  installer = Buffer.from("synthetic signed Windows installer\n");
+  const names = windowsReleaseArtifactNames(version);
+  await Promise.all([
+    writeFile(join(directory, names.installer), installer),
+    writeFile(
+      join(directory, names.blockmap),
+      gzipSync(
+        JSON.stringify({
+          version: "2",
+          files: [{ name: "file", offset: 0, checksums: ["x"], sizes: [1] }],
+        }),
+      ),
+    ),
+  ]);
+  await writeMetadata();
+});
+
+describe("Windows release artifact verification", () => {
+  it("verifies the exact envelope and records the pending Authenticode notice", async () => {
+    const notice = vi.fn();
+    const result = await verifyWindowsReleaseAssets(
+      directory,
+      { version, commit, authenticode: "pending-w19" },
+      { notice },
+    );
+    expect(result.commit).toBe(commit);
+    expect(result.authenticode).toBe("pending-w19");
+    expect(result.installerSha256).toBe(createHash("sha256").update(installer).digest("hex"));
+    expect(notice).toHaveBeenCalledWith(
+      "Authenticode verification is pending W19; signature not verified",
+    );
+  });
+
+  it("requires an explicit Authenticode mode", async () => {
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version } as unknown as VerifyWindowsReleaseOptions),
+    ).rejects.toThrow("Authenticode verification mode is required");
+  });
+
+  it("calls an injected Authenticode verifier and fails closed on rejection", async () => {
+    const verify = vi.fn(async () => {});
+    const result = await verifyWindowsReleaseAssets(directory, {
+      version,
+      expectedPublisherName: "CN=Enduragent Test",
+      authenticode: { verify },
+    });
+    expect(verify).toHaveBeenCalledWith(join(directory, `Enduragent-${version}-x64.exe`), {
+      version,
+      publisherName: "CN=Enduragent Test",
+    });
+    expect(result.authenticode).toBe("verified");
+    await expect(
+      verifyWindowsReleaseAssets(directory, {
+        version,
+        authenticode: { verify: vi.fn(async () => Promise.reject(new Error("signature"))) },
+      }),
+    ).rejects.toThrow("Windows installer Authenticode verification failed");
+  });
+
+  it("rejects extra files and symlinked installers", async () => {
+    await writeFile(join(directory, "extra.txt"), "extra");
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("release artifact envelope differs");
+    await unlink(join(directory, "extra.txt"));
+    const names = windowsReleaseArtifactNames(version);
+    await unlink(join(directory, names.installer));
+    await symlink(join(directory, names.blockmap), join(directory, names.installer));
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("invalid Windows installer");
+  });
+
+  it.each(["wrong sha512", "wrong size", "non-canonical releaseDate"])(
+    "rejects %s metadata that does not bind the installer",
+    async (failure) => {
+      const value = metadata();
+      if (failure === "wrong sha512") value.sha512 = "wrong";
+      if (failure === "wrong size") value.files[0]!.size = 1;
+      if (failure === "non-canonical releaseDate") value.releaseDate = "2026-08-25T00:00:00Z";
+      await writeMetadata(value);
+      await expect(
+        verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+      ).rejects.toThrow("latest.yml does not match the Windows installer");
+    },
+  );
+
+  it("rejects a mismatched file digest", async () => {
+    const value = metadata();
+    value.files[0]!.sha512 = "wrong";
+    await writeMetadata(value);
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("latest.yml does not match the Windows installer");
+  });
+
+  it("rejects extra latest.yml keys as invalid", async () => {
+    await writeMetadata(metadata({ unexpected: true }));
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("latest.yml is invalid");
+  });
+
+  it("rejects a non-gzip installer blockmap", async () => {
+    const names = windowsReleaseArtifactNames(version);
+    await writeFile(join(directory, names.blockmap), "not gzip");
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("installer blockmap is invalid");
+  });
+
+  it("runs the pending CLI and rejects unsupported Authenticode modes", async () => {
+    const { spawnSync } = await import("node:child_process");
+    const success = spawnSync(
+      process.execPath,
+      [script, directory, "--version", version, "--authenticode", "pending-w19"],
+      { encoding: "utf8" },
+    );
+    expect(success.status).toBe(0);
+    expect(success.stdout).toMatch(/^Windows release envelope verified [0-9a-f]{64}\n$/u);
+    const failure = spawnSync(
+      process.execPath,
+      [script, directory, "--version", version, "--authenticode", "verified"],
+      { encoding: "utf8" },
+    );
+    expect(failure.status).toBe(1);
+    expect(failure.stderr).toContain("Authenticode verification mode is required");
+  });
+});

--- a/apps/desktop/tests/windows-release-plan.test.ts
+++ b/apps/desktop/tests/windows-release-plan.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { stringify } from "yaml";
+import {
+  WINDOWS_AUTHENTICODE_PENDING,
+  assertKnownWindowsReleaseAssets,
+  createWindowsReleasePlan,
+  parseWindowsReleaseUpdaterMetadata,
+  safeWindowsReleasePlanMessage,
+  windowsReleaseArtifactNames,
+  windowsReleaseAssetNames,
+} from "../scripts/windows-release-plan.mjs";
+
+const feedUrl = "https://github.com/yerzhansa/enduragent/releases/latest/download/";
+const commit = "a".repeat(40);
+
+function planInput(overrides: Record<string, unknown> = {}) {
+  return {
+    version: "0.1.5",
+    commit,
+    feedUrl,
+    mode: "steady" as const,
+    baselineVersion: "0.1.2",
+    repositoryRoot: "/synthetic/repository",
+    desktopRoot: "/synthetic/repository/apps/desktop",
+    ...overrides,
+  };
+}
+
+describe("Windows release plan", () => {
+  it("freezes the exact Windows asset names", () => {
+    const names = windowsReleaseArtifactNames("0.1.5");
+    expect(names).toEqual({
+      installer: "Enduragent-0.1.5-x64.exe",
+      blockmap: "Enduragent-0.1.5-x64.exe.blockmap",
+      metadata: "latest.yml",
+    });
+    expect(windowsReleaseAssetNames("0.1.5")).toEqual([
+      "Enduragent-0.1.5-x64.exe",
+      "Enduragent-0.1.5-x64.exe.blockmap",
+      "latest.yml",
+    ]);
+    expect(Object.isFrozen(names)).toBe(true);
+  });
+
+  it("rejects duplicate, unknown, and missing Windows release assets", () => {
+    const names = windowsReleaseAssetNames("0.1.5");
+    expect(() => assertKnownWindowsReleaseAssets([...names, names[0]!], "0.1.5")).toThrow(
+      `duplicate Windows release asset: ${names[0]}`,
+    );
+    expect(() => assertKnownWindowsReleaseAssets([...names, "old.zip"], "0.1.5")).toThrow(
+      "unknown Windows release asset: old.zip",
+    );
+    expect(() => assertKnownWindowsReleaseAssets(names.slice(1), "0.1.5")).toThrow(
+      `missing Windows release asset: ${names[0]}`,
+    );
+  });
+
+  it("enforces genesis and steady baseline rules while allowing lag", () => {
+    expect(() =>
+      createWindowsReleasePlan(planInput({ mode: "genesis", baselineVersion: "0.1.2" })),
+    ).toThrow("genesis Windows release must not name a baseline");
+    expect(() => createWindowsReleasePlan(planInput({ baselineVersion: undefined }))).toThrow(
+      "steady Windows release requires a lower stable baseline version",
+    );
+    expect(() => createWindowsReleasePlan(planInput({ baselineVersion: "0.1.5" }))).toThrow(
+      "steady Windows release requires a lower stable baseline version",
+    );
+    expect(() => createWindowsReleasePlan(planInput({ baselineVersion: "0.1.6" }))).toThrow(
+      "steady Windows release requires a lower stable baseline version",
+    );
+    expect(createWindowsReleasePlan(planInput()).baselineVersion).toBe("0.1.2");
+  });
+
+  it("parses exact updater identity with an optional publisher", () => {
+    const base = {
+      provider: "generic",
+      url: feedUrl,
+      channel: "latest",
+      updaterCacheDirName: "@enduragentdesktop-updater",
+    };
+    expect(parseWindowsReleaseUpdaterMetadata(stringify(base))).toEqual(base);
+    const publisherName = "CN=Enduragent Test";
+    expect(
+      parseWindowsReleaseUpdaterMetadata(stringify({ ...base, publisherName }), {
+        expectedPublisherName: publisherName,
+      }),
+    ).toEqual({ ...base, publisherName });
+    expect(() =>
+      parseWindowsReleaseUpdaterMetadata(stringify({ ...base, publisherName }), {
+        expectedPublisherName: "CN=Different Publisher",
+      }),
+    ).toThrow("release updater publisher name mismatch");
+    expect(() =>
+      parseWindowsReleaseUpdaterMetadata(stringify({ ...base, unexpected: true })),
+    ).toThrow("release updater metadata is invalid");
+  });
+
+  it("creates the signed NSIS builder contract with differential packaging", () => {
+    const plan = createWindowsReleasePlan(planInput());
+    expect(plan).toMatchObject({
+      version: "0.1.5",
+      commit,
+      tag: "enduragent-desktop@0.1.5",
+      platform: "win32",
+      arch: "x64",
+      mode: "steady",
+      authenticode: WINDOWS_AUTHENTICODE_PENDING,
+    });
+    expect(plan.builderOptions.config.forceCodeSigning).toBe(true);
+    expect(plan.builderOptions.config.nsis.differentialPackage).toBe(true);
+    expect(plan.builderOptions.config.win).toEqual({
+      verifyUpdateCodeSignature: true,
+      target: [{ target: "nsis", arch: ["x64"] }],
+    });
+    expect(Object.isFrozen(plan)).toBe(true);
+  });
+
+  it("exposes only safe planner failures", () => {
+    expect(
+      safeWindowsReleasePlanMessage(
+        new TypeError("steady Windows release requires a lower stable baseline version"),
+      ),
+    ).toBe("steady Windows release requires a lower stable baseline version");
+    expect(safeWindowsReleasePlanMessage(new Error("foreign"))).toBeUndefined();
+  });
+});

--- a/tools/desktop-release-transaction.test.ts
+++ b/tools/desktop-release-transaction.test.ts
@@ -22,12 +22,15 @@ import {
   assertPublishableAssets,
   assertRemoteAsset,
   inspectNpmAttestationClaims,
+  macosOwnedAssets,
   materializeDesktopPublicEnvelope,
   releaseFileNames,
+  resolveDesktopReleaseVersion,
   runDesktopLatestPromotionWithOutput,
   sealDesktopRelease,
   verifyNpmProvenanceBundle,
   verifyDesktopRelease,
+  windowsReleaseFileNames,
 } from "./desktop-release-transaction.js";
 
 const npmVersion = "2026.8.7";
@@ -530,5 +533,84 @@ describe("desktop release publication guards", () => {
       ),
     ).toThrow("changed");
     expect(() => assertLatestCas(desktopVersion, observed, observed, "0.1.8")).toThrow("monotonic");
+  });
+});
+
+describe("windows release assets", () => {
+  function asset(name: string) {
+    return {
+      id: 1,
+      name,
+      size: 1,
+      digest: "sha256:synthetic",
+      state: "uploaded" as const,
+      url: `https://api.example.test/assets/${name}`,
+      browser_download_url: `https://downloads.example.test/${name}`,
+    };
+  }
+
+  function release(assets: readonly ReturnType<typeof asset>[]) {
+    return {
+      id: 123,
+      tag_name: `enduragent-desktop@${desktopVersion}`,
+      draft: false,
+      prerelease: false,
+      assets,
+      upload_url: "https://uploads.example.test/release",
+      body: "synthetic release",
+    };
+  }
+
+  it("returns the exact Windows release triple", () => {
+    expect(windowsReleaseFileNames("0.1.7")).toEqual([
+      "Enduragent-0.1.7-x64.exe",
+      "Enduragent-0.1.7-x64.exe.blockmap",
+      "latest.yml",
+    ]);
+  });
+
+  it("allows the exact same-version Windows triple and still rejects stale assets", async () => {
+    writeEnvelope();
+    const manifest = await sealDesktopRelease(directory, binding);
+    const macos = manifest.files.map((file) => ({ name: file.name }));
+    const windows = windowsReleaseFileNames(desktopVersion).map((name) => ({ name }));
+    expect(() => assertPublishableAssets([...macos, ...windows], manifest)).not.toThrow();
+    expect(() => assertPublishableAssets([...macos, { name: "old.zip" }], manifest)).toThrow(
+      "stale",
+    );
+    expect(() =>
+      assertPublishableAssets(
+        [...macos, ...windowsReleaseFileNames("0.1.6").map((name) => ({ name }))],
+        manifest,
+      ),
+    ).toThrow("stale");
+  });
+
+  it("strips exactly the same-version Windows triple from macOS-owned assets", () => {
+    const macos = releaseFileNames(desktopVersion).map(asset);
+    const windows = windowsReleaseFileNames(desktopVersion).map(asset);
+    const otherWindows = windowsReleaseFileNames("0.1.6").map(asset);
+    expect(macosOwnedAssets([...macos, ...windows, ...otherWindows], desktopVersion)).toEqual([
+      ...macos,
+      ...otherWindows.slice(0, 2),
+    ]);
+  });
+
+  it.each([
+    ["no", 0],
+    ["a partial set of", 1],
+    ["a complete set of", 3],
+  ] as const)("resolves a complete macOS release with %s Windows assets", (_label, count) => {
+    const macos = releaseFileNames(desktopVersion).map(asset);
+    const windows = windowsReleaseFileNames(desktopVersion).map(asset);
+    expect(resolveDesktopReleaseVersion(release([...macos, ...windows.slice(0, count)]))).toBe(
+      desktopVersion,
+    );
+  });
+
+  it("rejects a foreign Windows triple", () => {
+    const macos = releaseFileNames(desktopVersion).map(asset);
+    const otherWindows = windowsReleaseFileNames("0.1.6").map(asset);
+    expect(resolveDesktopReleaseVersion(release([...macos, ...otherWindows]))).toBeNull();
   });
 });

--- a/tools/desktop-release-transaction.ts
+++ b/tools/desktop-release-transaction.ts
@@ -11,6 +11,7 @@ export const DESKTOP_MANIFEST = "desktop-release-manifest.json";
 export const DESKTOP_RELEASE_SCHEMA_VERSION = 3 as const;
 export const DESKTOP_PROVISIONAL_RELEASE_BODY =
   "Desktop update validation is in progress. This release is not yet generally available.";
+export const WINDOWS_DESKTOP_METADATA_NAME = "latest.yml";
 
 type RetainedDesktopReleaseMode = "steady" | "genesis";
 
@@ -238,6 +239,20 @@ export function releaseFileNames(version: string): readonly [string, string, str
   const stableVersion = requireDesktopVersion(version);
   const base = `Enduragent-${stableVersion}-arm64`;
   return [`${base}.dmg`, `${base}.zip`, `${base}.zip.blockmap`, "latest-mac.yml"];
+}
+
+export function windowsReleaseFileNames(version: string): readonly [string, string, string] {
+  const stableVersion = requireDesktopVersion(version);
+  const installer = `Enduragent-${stableVersion}-x64.exe`;
+  return [installer, `${installer}.blockmap`, WINDOWS_DESKTOP_METADATA_NAME];
+}
+
+export function macosOwnedAssets<T extends Pick<GithubAsset, "name">>(
+  assets: readonly T[],
+  version: string,
+): readonly T[] {
+  const windowsNames = new Set(windowsReleaseFileNames(version));
+  return assets.filter((asset) => !windowsNames.has(asset.name));
 }
 
 function requireBinding(input: {
@@ -739,7 +754,10 @@ export function assertPublishableAssets(
   existing: readonly Pick<GithubAsset, "name">[],
   manifest: DesktopReleaseManifest,
 ): void {
-  const allowed = new Set(manifest.files.map((file) => file.name));
+  const allowed = new Set([
+    ...manifest.files.map((file) => file.name),
+    ...windowsReleaseFileNames(manifest.desktopVersion),
+  ]);
   const duplicate = existing.find(
     (asset, index) => existing.findIndex((other) => other.name === asset.name) !== index,
   );
@@ -1243,7 +1261,10 @@ export class GithubClient {
   }
 }
 
-function desktopReleaseVersion(release: GithubRelease, excludingTag?: string): string | null {
+export function resolveDesktopReleaseVersion(
+  release: GithubRelease,
+  excludingTag?: string,
+): string | null {
   if (release.draft || release.prerelease || release.tag_name === excludingTag) return null;
   const tagVersion =
     release.tag_name === legacyDesktopBaselineTag
@@ -1256,8 +1277,9 @@ function desktopReleaseVersion(release: GithubRelease, excludingTag?: string): s
   });
   if (versions.length !== 1 || versions[0] !== tagVersion) return null;
   const version = versions[0];
+  const macosAssets = macosOwnedAssets(release.assets, version);
   const expected = [...releaseFileNames(version)].sort();
-  const actual = release.assets
+  const actual = macosAssets
     .filter((asset) => asset.name !== DESKTOP_STABLE_DMG_NAME)
     .map((asset) => asset.name)
     .sort();
@@ -1284,7 +1306,7 @@ async function newestDesktopRelease(
 ): Promise<{ release: GithubRelease; version: string; commit: string } | null> {
   let selected: { release: GithubRelease; version: string; commit: string } | null = null;
   for (const release of releases) {
-    const version = desktopReleaseVersion(release, excludingTag);
+    const version = resolveDesktopReleaseVersion(release, excludingTag);
     if (!version) continue;
     const commit = await client.tagCommit(release.tag_name, deadlineAt);
     if (!selected || compareVersions(version, selected.version) > 0) {
@@ -1300,7 +1322,7 @@ async function exactDesktopRelease(
   tag: string,
 ): Promise<{ release: GithubRelease; version: string; commit: string } | null> {
   if (!release || release.tag_name !== tag) return null;
-  const version = desktopReleaseVersion(release);
+  const version = resolveDesktopReleaseVersion(release);
   if (!version) return null;
   return { release, version, commit: await client.tagCommit(tag) };
 }
@@ -1473,7 +1495,7 @@ async function stageExactAssets(
   }
   const staged = await verifyReleaseBinding(client, manifest);
   assertPublishableAssets(staged.assets, manifest);
-  if (staged.assets.length !== manifest.files.length)
+  if (macosOwnedAssets(staged.assets, manifest.desktopVersion).length !== manifest.files.length)
     throw new TypeError("staged release asset set is incomplete");
   for (const file of manifest.files) {
     const asset = staged.assets.find((candidate) => candidate.name === file.name);
@@ -1492,7 +1514,7 @@ async function assertCompleteReleaseAssets(
   deadlineAt?: number,
 ): Promise<void> {
   assertPublishableAssets(release.assets, manifest);
-  if (release.assets.length !== manifest.files.length) {
+  if (macosOwnedAssets(release.assets, manifest.desktopVersion).length !== manifest.files.length) {
     throw new TypeError(`${label} asset set is incomplete`);
   }
   for (const file of manifest.files) {
@@ -1656,7 +1678,9 @@ export async function promoteDesktopLatest(
     );
     assertPromotionLatestCas(manifest.desktopVersion, observed, current, previous?.version ?? null);
     assertPublishableAssets(candidate.assets, manifest);
-    if (candidate.assets.length !== manifest.files.length) {
+    if (
+      macosOwnedAssets(candidate.assets, manifest.desktopVersion).length !== manifest.files.length
+    ) {
       throw new TypeError("promotion candidate asset set is incomplete");
     }
     const releasePropagationDeadline = preflightDeadlineAt;
@@ -1772,7 +1796,9 @@ export async function reconcileDesktopLatest(
     throw new TypeError("desktop latest reconciliation candidate binding mismatch");
   }
   assertPublishableAssets(candidate.assets, manifest);
-  if (candidate.assets.length !== manifest.files.length) {
+  if (
+    macosOwnedAssets(candidate.assets, manifest.desktopVersion).length !== manifest.files.length
+  ) {
     throw new TypeError("desktop latest reconciliation asset set is incomplete");
   }
   const metadata = manifest.files.find((file) => file.name === "latest-mac.yml");
@@ -2006,7 +2032,9 @@ export async function activateDesktopRelease(
     throw new TypeError("desktop activation candidate binding mismatch");
   }
   assertPublishableAssets(candidate.assets, manifest);
-  if (candidate.assets.length !== manifest.files.length) {
+  if (
+    macosOwnedAssets(candidate.assets, manifest.desktopVersion).length !== manifest.files.length
+  ) {
     throw new TypeError("desktop activation asset set is incomplete");
   }
   for (const file of manifest.files) {
@@ -2050,7 +2078,8 @@ export async function activateDesktopRelease(
   }
   assertPublishableAssets(mutationCandidate.assets, manifest);
   if (
-    mutationCandidate.assets.length !== manifest.files.length ||
+    macosOwnedAssets(mutationCandidate.assets, manifest.desktopVersion).length !==
+      manifest.files.length ||
     !sameLatest(expectedLatest, await client.latest())
   ) {
     throw new TypeError("desktop activation candidate changed at the mutation boundary");
@@ -2166,7 +2195,9 @@ export async function compensateDesktopRelease(
     throw new TypeError("desktop compensation candidate changed at the mutation boundary");
   }
   assertPublishableAssets(candidate.assets, manifest);
-  if (candidate.assets.length !== manifest.files.length) {
+  if (
+    macosOwnedAssets(candidate.assets, manifest.desktopVersion).length !== manifest.files.length
+  ) {
     throw new TypeError("desktop compensation candidate changed at the mutation boundary");
   }
   if (!sameLatest(candidateLatest, await client.latest())) {
@@ -2196,7 +2227,9 @@ export async function compensateDesktopRelease(
     throw new TypeError("desktop compensation candidate changed before withdrawal");
   }
   assertPublishableAssets(candidate.assets, manifest);
-  if (candidate.assets.length !== manifest.files.length) {
+  if (
+    macosOwnedAssets(candidate.assets, manifest.desktopVersion).length !== manifest.files.length
+  ) {
     throw new TypeError("desktop compensation candidate changed before withdrawal");
   }
   await client.request(`/repos/${client.repository()}/releases/${candidate.id}`, {


### PR DESCRIPTION
## Summary

- Adds a separate `workflow_dispatch` workflow `.github/workflows/desktop-windows-release.yml` that verifies operator-uploaded Windows assets and stamps a body marker on the release; Authenticode verification is pending W19.
- Adds `apps/desktop/scripts/windows-release-plan.mjs`, `verify-windows-release.mjs`, and `upload-windows-release.mjs` with matching `.d.mts` declarations.
- `tools/desktop-release-transaction.ts` now tolerates Windows assets appended to a release and never blocks the macOS lane.
- Tests for the plan, verify, upload, and transaction paths.
- Changeset `.changeset/windows-release-envelope.md`.

## Release model

Manual operator signing on a Windows VM with a Certum SimplySign certificate. CI verifies and publishes only. The macOS `desktop-release.yml` workflow is untouched.

## Limits

- `desktop-windows-release.yml timeout-minutes = 30` — bound the verify job.
- `maximumUpdaterMetadataBytes = 16384` — cap `latest.yml` size, mirrors macOS.

## Verification

- Root `pnpm check`: exit code 0 (build, per-package check, types, oxlint 0 errors, trademarks, fixture-privacy, registry-isolation, changeset-userfacing, contract-deps, package-deps, kernel-discipline, codex-schema all clean).
- `vitest run` tools project: 47 files, 898 tests passed.
- `vitest run` desktop project: 120/121 files, 2335/2336 tests passed. The one failure is `tests/windows-parity-scenarios.test.ts` (ENOENT on a repo-relative path when run from `apps/desktop` cwd); it is pre-existing and unrelated to this diff.
- 26-criterion adversarial verify: 24 pass, 2 adjudicated; fix round re-verified.

## Workflow-file changes (operator review)

- `.github/workflows/desktop-windows-release.yml` — NEW.

## Residuals

- NSIS blockmap regeneration not implemented.
- Authenticode signing and verification: W19.
- D8 updater plumbing: W20.
- `desktop-release.yml` exact-asset-set check on rerun after Windows assets are appended — follow-up.
