### PR TITLE
Chat Gate 3: establish ATT-01 attachment contracts

### DIFF
--- a/.changeset/chat-attachment-contract.md
+++ b/.changeset/chat-attachment-contract.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/coach-contract": patch
+"@enduragent/coach-client": patch
+"@enduragent/engine": patch
+"@enduragent/core": patch
+"@enduragent/coach": patch
+---
+
+Add the privileged Chat attachment-admission contract and durable queued-Message attachment identities.

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -128,9 +128,11 @@ function client(
       if (!queued.some((item) => item.submissionId === value.submissionId)) {
         queued.push({
           queuedMessageId: `queued-${value.submissionId}`,
+          messageId: `message-${value.submissionId}`,
           submissionId: value.submissionId,
           text: value.text,
           kind: value.text.trimStart().startsWith("/") ? "slash-command" : "ordinary",
+          attachmentIds: [],
           position: queued.length,
           restored: false,
         });

--- a/apps/desktop-renderer/tests/chat-queue-recovery.test.ts
+++ b/apps/desktop-renderer/tests/chat-queue-recovery.test.ts
@@ -99,9 +99,11 @@ describe("durable chat queue controller", () => {
       items: [
         {
           queuedMessageId: "queued-1",
+          messageId: "message-1",
           submissionId: "submission-1",
           text: "Hello",
           kind: "ordinary",
+          attachmentIds: [],
           position: 0,
           restored: false,
         },
@@ -150,9 +152,11 @@ describe("durable chat queue controller", () => {
             items: [
               {
                 queuedMessageId: `queued-${revision}`,
+                messageId: `message-${revision}`,
                 submissionId: input.submissionId,
                 text: input.text,
                 kind: "ordinary",
+                attachmentIds: [],
                 position: 0,
                 restored: false,
               },
@@ -194,9 +198,11 @@ describe("durable chat queue controller", () => {
       items: [
         {
           queuedMessageId: "command-1",
+          messageId: "message-command-1",
           submissionId: "submission-1",
           text: "/review",
           kind: "slash-command",
+          attachmentIds: [],
           position: 0,
           restored: true,
         },
@@ -249,9 +255,11 @@ describe("durable chat queue controller", () => {
       items: [
         {
           queuedMessageId: "queued-1",
+          messageId: "message-1",
           submissionId: "submission-1",
           text: "Restored",
           kind: "ordinary",
+          attachmentIds: [],
           position: 0,
           restored: true,
         },
@@ -307,9 +315,11 @@ describe("durable chat queue controller", () => {
             items: [
               {
                 queuedMessageId: "queued-1",
+                messageId: "message-1",
                 submissionId: input.submissionId,
                 text: input.text,
                 kind: "ordinary",
+                attachmentIds: [],
                 position: 0,
                 restored: false,
               },
@@ -345,9 +355,11 @@ describe("durable chat queue controller", () => {
       items: [
         {
           queuedMessageId: "command-1",
+          messageId: "message-command-1",
           submissionId: "submission-1",
           text: "/review",
           kind: "slash-command",
+          attachmentIds: [],
           position: 0,
           restored: true,
         },
@@ -381,9 +393,11 @@ describe("durable chat queue controller", () => {
       items: [
         {
           queuedMessageId: "command-1",
+          messageId: "message-command-1",
           submissionId: "submission-1",
           text: "/review",
           kind: "slash-command",
+          attachmentIds: [],
           position: 0,
           restored: true,
         },
@@ -417,17 +431,21 @@ describe("durable chat queue controller", () => {
     let secondOptions: CoachClientCallOptions<"chat"> | undefined;
     const first = {
       queuedMessageId: "queued-1",
+      messageId: "message-1",
       submissionId: "submission-1",
       text: "First",
       kind: "ordinary" as const,
+      attachmentIds: [],
       position: 0,
       restored: false,
     };
     const later = {
       queuedMessageId: "queued-2",
+      messageId: "message-2",
       submissionId: "submission-2",
       text: "Later",
       kind: "ordinary" as const,
+      attachmentIds: [],
       position: 1,
       restored: false,
     };
@@ -523,17 +541,21 @@ describe("durable chat queue controller", () => {
     let options: CoachClientCallOptions<"chat"> | undefined;
     const head = {
       queuedMessageId: "queued-1",
+      messageId: "message-1",
       submissionId: "submission-1",
       text: "First",
       kind: "ordinary" as const,
+      attachmentIds: [],
       position: 0,
       restored: true,
     };
     const later = {
       queuedMessageId: "queued-2",
+      messageId: "message-2",
       submissionId: "submission-2",
       text: "Later",
       kind: "ordinary" as const,
+      attachmentIds: [],
       position: 1,
       restored: false,
     };
@@ -606,17 +628,21 @@ describe("durable chat queue controller", () => {
     const items = [
       {
         queuedMessageId: "queued-1",
+        messageId: "message-1",
         submissionId: "submission-1",
         text: "First",
         kind: "ordinary" as const,
+        attachmentIds: [],
         position: 0,
         restored: false,
       },
       {
         queuedMessageId: "queued-2",
+        messageId: "message-2",
         submissionId: "submission-2",
         text: "/later",
         kind: "slash-command" as const,
+        attachmentIds: [],
         position: 1,
         restored: true,
       },

--- a/apps/desktop-renderer/tests/turn-state.test.ts
+++ b/apps/desktop-renderer/tests/turn-state.test.ts
@@ -33,9 +33,11 @@ describe("desktop turn state", () => {
   it("keeps an active durable claim hidden across newer queue snapshots", () => {
     const item = (id: string, position: number) => ({
       queuedMessageId: id,
+      messageId: `message-${id}`,
       submissionId: `submission-${id}`,
       text: id,
       kind: "ordinary" as const,
+      attachmentIds: [],
       position,
       restored: false,
     });
@@ -76,9 +78,11 @@ describe("desktop turn state", () => {
       items: [
         {
           queuedMessageId: "queued-1",
+          messageId: "message-1",
           submissionId: "submission-1",
           text: "Later",
           kind: "ordinary" as const,
+          attachmentIds: [],
           position: 0,
           restored: false,
         },

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -165,7 +165,9 @@ function makeScript(
   let queueRevision = 0;
   let queueItems: Array<{
     queuedMessageId: string;
+    messageId: string;
     submissionId: string;
+    attachmentIds: string[];
     text: string;
     kind: "ordinary" | "slash-command";
     position: number;
@@ -380,7 +382,9 @@ function makeScript(
           queueRevision += 1;
           queueItems.push({
             queuedMessageId: `queued-${queueRevision}`,
+            messageId: `message-${queueRevision}`,
             submissionId: params.submissionId,
+            attachmentIds: [],
             text: params.text,
             kind: params.text.trimStart().startsWith("/") ? "slash-command" : "ordinary",
             position: queueItems.length,

--- a/apps/desktop/tests/onboarding-first-run.integration.test.ts
+++ b/apps/desktop/tests/onboarding-first-run.integration.test.ts
@@ -41,7 +41,9 @@ function makeScript(): DesktopFixtureScript {
   let queueRevision = 0;
   let queueItems: Array<{
     queuedMessageId: string;
+    messageId: string;
     submissionId: string;
+    attachmentIds: string[];
     text: string;
     kind: "ordinary" | "slash-command";
     position: number;
@@ -177,7 +179,9 @@ function makeScript(): DesktopFixtureScript {
           queueRevision += 1;
           queueItems.push({
             queuedMessageId: `queued-${queueRevision}`,
+            messageId: `message-${queueRevision}`,
             submissionId: params.submissionId,
+            attachmentIds: [],
             text: params.text,
             kind: params.text.trimStart().startsWith("/") ? "slash-command" : "ordinary",
             position: queueItems.length,

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -118,7 +118,9 @@ function script(calls: ScriptRequest[], initial: "reached" | "complete") {
   let queueRevision = 0;
   let queueItems: Array<{
     queuedMessageId: string;
+    messageId: string;
     submissionId: string;
+    attachmentIds: string[];
     text: string;
     kind: "ordinary" | "slash-command";
     position: number;
@@ -173,7 +175,9 @@ function script(calls: ScriptRequest[], initial: "reached" | "complete") {
           queueRevision += 1;
           queueItems.push({
             queuedMessageId: `queued-${queueRevision}`,
+            messageId: `message-${queueRevision}`,
             submissionId: params.submissionId,
+            attachmentIds: [],
             text: params.text,
             kind: params.text.trimStart().startsWith("/") ? "slash-command" : "ordinary",
             position: queueItems.length,

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -112,6 +112,7 @@ interface OutboundFrame {
 const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   chat: 11 * 60_000,
   stopChat: 10_000,
+  admitChatAttachment: 120_000,
   enqueueChatMessage: 30_000,
   getChatQueue: 30_000,
   removeQueuedChatMessage: 30_000,

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -45,6 +45,16 @@ const telegramControlSnapshot = {
 const rpcDeadlineCases = [
   ["chat", { chatId: "chat-1", message: "deadline" }, 660_000],
   ["stopChat", { chatId: "chat-1", turnId: "turn-1" }, 10_000],
+  [
+    "admitChatAttachment",
+    {
+      chatId: "desktop",
+      selectionId: "selection-1",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath: "/tmp/activity.fit" },
+    },
+    120_000,
+  ],
   ["enqueueChatMessage", { chatId: "chat-1", submissionId: "submission-1", text: "Hello" }, 30_000],
   ["getChatQueue", { chatId: "chat-1" }, 30_000],
   ["removeQueuedChatMessage", { chatId: "chat-1", queuedMessageId: "queued-1" }, 30_000],
@@ -811,6 +821,13 @@ describe("RPC receive and observers", () => {
       const results = {
         chat: { text: "answer" },
         stopChat: { stopped: true },
+        admitChatAttachment: {
+          selectionId: "selection-1",
+          displayName: "activity.fit",
+          status: "storage_failed",
+          failureCode: "admission_unavailable",
+          retryable: false,
+        },
         enqueueChatMessage: { schemaVersion: 1, revision: 1, items: [] },
         getChatQueue: { schemaVersion: 1, revision: 1, items: [] },
         removeQueuedChatMessage: { schemaVersion: 1, revision: 2, items: [] },
@@ -1030,9 +1047,7 @@ describe("RPC receive and observers", () => {
     await expect(client.call("chat", { chatId: "chat-1", message: "hello" })).resolves.toEqual({
       text: "answer",
     });
-    await expect(
-      client.call("stopChat", { chatId: "chat-1", turnId: "turn-1" }),
-    ).resolves.toEqual({
+    await expect(client.call("stopChat", { chatId: "chat-1", turnId: "turn-1" })).resolves.toEqual({
       stopped: true,
     });
     await expect(client.call("resetSession", { chatId: "chat-1" })).resolves.toEqual({

--- a/packages/coach-contract/src/chat-attachment.ts
+++ b/packages/coach-contract/src/chat-attachment.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import { PlatformAbsolutePathSchema } from "./platform-path.js";
+
+export const CHAT_ATTACHMENT_LIMITS = Object.freeze({
+  attachmentsPerMessage: 5,
+  messageBytes: 104_857_600,
+  conversationBytes: 1_073_741_824,
+  athleteBytes: 10_737_418_240,
+  documentBytes: 26_214_400,
+  activityBytes: 104_857_600,
+  workoutBytes: 5_242_880,
+  imageBytes: 20_971_520,
+  extractedTextChars: 200_000,
+  pdfPages: 100,
+  pdfVisualPages: 10,
+  pdfUsefulTextCharsPerPage: 32,
+  pdfVisualPixels: 16_000_000,
+  pdfPageDimension: 4_096,
+  docxEntries: 2_048,
+  docxExpandedBytes: 67_108_864,
+  docxCompressionRatio: 100,
+  csvRows: 50_000,
+  csvColumns: 512,
+  csvRecordChars: 32_768,
+  imageDimension: 8_192,
+  imagePixels: 40_000_000,
+  workoutCandidates: 50,
+  workoutSegments: 5_000,
+  workoutDurationSeconds: 86_400,
+  parserMs: 30_000,
+  parserOldGenerationMiB: 256,
+  capabilityMetadataMaxAgeMs: 86_400_000,
+  orphanGraceMs: 86_400_000,
+});
+
+export const DocumentAttachmentExtensionSchema = z.enum(["pdf", "txt", "csv", "docx"]);
+export const ActivityAttachmentExtensionSchema = z.enum(["fit", "tcx", "gpx"]);
+export const WorkoutAttachmentExtensionSchema = z.enum(["zwo", "mrc", "erg"]);
+export const ImageAttachmentExtensionSchema = z.enum(["png", "jpg", "jpeg", "webp"]);
+export const ChatAttachmentKindSchema = z.enum(["document", "activity", "workout", "image"]);
+
+export const NativeChatAttachmentCandidateSchema = z
+  .object({
+    kind: z.literal("native-path"),
+    sourcePath: PlatformAbsolutePathSchema,
+  })
+  .strict();
+export type NativeChatAttachmentCandidate = z.infer<typeof NativeChatAttachmentCandidateSchema>;
+
+export const AdmitChatAttachmentRequestSchema = z
+  .object({
+    chatId: z.string().min(1),
+    selectionId: z.string().min(1),
+    source: z.enum(["picker", "drop"]),
+    candidate: NativeChatAttachmentCandidateSchema,
+  })
+  .strict();
+export type AdmitChatAttachmentRequest = z.infer<typeof AdmitChatAttachmentRequestSchema>;
+
+const AttachmentAdmissionBaseSchema = z
+  .object({
+    selectionId: z.string().min(1),
+    displayName: z.string().min(1),
+  })
+  .strict();
+
+export const AttachmentAdmissionReadModelSchema = z.discriminatedUnion("status", [
+  AttachmentAdmissionBaseSchema.extend({ status: z.literal("selected") }).strict(),
+  AttachmentAdmissionBaseSchema.extend({ status: z.literal("admitting") }).strict(),
+  AttachmentAdmissionBaseSchema.extend({
+    status: z.literal("rejected"),
+    reason: z.enum([
+      "empty_file",
+      "file_too_large",
+      "format_unsupported",
+      "signature_mismatch",
+      "unsafe_source",
+      "validation_failed",
+      "message_limit",
+      "storage_full",
+    ]),
+  }).strict(),
+  AttachmentAdmissionBaseSchema.extend({
+    status: z.literal("storage_failed"),
+    failureCode: z.enum(["admission_unavailable", "storage_failed"]),
+    retryable: z.boolean(),
+  }).strict(),
+  AttachmentAdmissionBaseSchema.extend({
+    status: z.literal("accepted"),
+    attachmentId: z.string().min(1),
+  }).strict(),
+  AttachmentAdmissionBaseSchema.extend({ status: z.literal("removed") }).strict(),
+]);
+export type AttachmentAdmissionReadModel = z.infer<typeof AttachmentAdmissionReadModelSchema>;

--- a/packages/coach-contract/src/chat-queue.ts
+++ b/packages/coach-contract/src/chat-queue.ts
@@ -1,16 +1,33 @@
 import { z } from "zod";
 import { ChatResponseSchema } from "./engine.js";
+import { CHAT_ATTACHMENT_LIMITS } from "./chat-attachment.js";
+
+const AttachmentIdsSchema = z
+  .array(z.string().min(1))
+  .max(CHAT_ATTACHMENT_LIMITS.attachmentsPerMessage)
+  .refine((value) => new Set(value).size === value.length, "attachment ids must be unique");
 
 export const QueuedChatMessageSchema = z
   .object({
     queuedMessageId: z.string().min(1),
+    messageId: z.string().min(1),
     submissionId: z.string().min(1),
     text: z.string().refine((value) => /\S/u.test(value)),
     kind: z.enum(["ordinary", "slash-command"]),
+    attachmentIds: AttachmentIdsSchema,
     position: z.number().int().nonnegative(),
     restored: z.boolean(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, context) => {
+    if (value.kind === "slash-command" && value.attachmentIds.length !== 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["attachmentIds"],
+        message: "slash commands are text-only",
+      });
+    }
+  });
 export type QueuedChatMessage = z.infer<typeof QueuedChatMessageSchema>;
 
 export const ChatQueueRecoveryClaimSchema = z
@@ -33,6 +50,7 @@ export const ChatQueueSnapshotSchema = z
   .strict()
   .superRefine((value, context) => {
     const ids = new Set<string>();
+    const messageIds = new Set<string>();
     const submissions = new Set<string>();
     value.items.forEach((item, index) => {
       if (item.position !== index) {
@@ -56,7 +74,15 @@ export const ChatQueueSnapshotSchema = z
           message: "submission ids must be unique",
         });
       }
+      if (messageIds.has(item.messageId)) {
+        context.addIssue({
+          code: "custom",
+          path: ["items", index, "messageId"],
+          message: "message ids must be unique",
+        });
+      }
       ids.add(item.queuedMessageId);
+      messageIds.add(item.messageId);
       submissions.add(item.submissionId);
     });
     if (value.retryRequired !== undefined) {
@@ -82,8 +108,18 @@ export const EnqueueChatMessageRequestSchema = z
     chatId: z.string().min(1),
     submissionId: z.string().min(1),
     text: z.string().refine((value) => /\S/u.test(value)),
+    attachmentIds: AttachmentIdsSchema.optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, context) => {
+    if (/^\s*\//u.test(value.text) && (value.attachmentIds?.length ?? 0) !== 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["attachmentIds"],
+        message: "slash commands are text-only",
+      });
+    }
+  });
 export type EnqueueChatMessageRequest = z.infer<typeof EnqueueChatMessageRequestSchema>;
 
 export const GetChatQueueRequestSchema = z.object({ chatId: z.string().min(1) }).strict();

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -13,3 +13,4 @@ export * from "./training-export.js";
 export * from "./platform-path.js";
 export * from "./coach-decision.js";
 export * from "./chat-queue.js";
+export * from "./chat-attachment.js";

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -14,6 +14,12 @@ import {
 import { TurnEventSchema, type TurnEvent } from "./turn-event.js";
 import { PlatformAbsolutePathSchema } from "./platform-path.js";
 import {
+  AdmitChatAttachmentRequestSchema,
+  AttachmentAdmissionReadModelSchema,
+  type AdmitChatAttachmentRequest,
+  type AttachmentAdmissionReadModel,
+} from "./chat-attachment.js";
+import {
   AnswerCoachDecisionRpcParamsSchema,
   AnswerCoachDecisionRpcResultSchema,
   GetCoachDecisionRpcParamsSchema,
@@ -183,6 +189,7 @@ export type JsonRpcNotificationEnvelope = z.infer<typeof JsonRpcNotificationEnve
 export const COACH_RPC_METHOD_NAMES = [
   "chat",
   "stopChat",
+  "admitChatAttachment",
   "enqueueChatMessage",
   "getChatQueue",
   "removeQueuedChatMessage",
@@ -1106,6 +1113,7 @@ export const OperationProgressEventSchema = z
 export type OperationProgressEvent = z.infer<typeof OperationProgressEventSchema>;
 
 export interface CoachOperations {
+  admitChatAttachment?(request: AdmitChatAttachmentRequest): Promise<AttachmentAdmissionReadModel>;
   getActivityAnalysis?(
     request: ActivityAnalysisRequest,
     signal?: AbortSignal,
@@ -1208,6 +1216,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("stopChat"),
       params: StopChatRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("admitChatAttachment"),
+      params: AdmitChatAttachmentRequestSchema,
     })
     .strict(),
   z
@@ -1696,6 +1712,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "stopChat",
     requestSchema: StopChatRequestSchema,
     responseSchema: StopChatResponseSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  admitChatAttachment: {
+    wireName: "admitChatAttachment",
+    requestSchema: AdmitChatAttachmentRequestSchema,
+    responseSchema: AttachmentAdmissionReadModelSchema,
     eventSchema: NoRpcEventSchema,
   },
   enqueueChatMessage: {

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 23;
+export const PROTOCOL_VERSION = 24;

--- a/packages/coach-contract/tests/chat-attachment-contract.test.ts
+++ b/packages/coach-contract/tests/chat-attachment-contract.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  AdmitChatAttachmentRequestSchema,
+  AttachmentAdmissionReadModelSchema,
+  CHAT_ATTACHMENT_LIMITS,
+} from "../src/index.js";
+
+describe("chat attachment contract", () => {
+  it("keeps all approved attachment limits in one immutable contract", () => {
+    expect(CHAT_ATTACHMENT_LIMITS).toMatchObject({
+      attachmentsPerMessage: 5,
+      messageBytes: 104_857_600,
+      conversationBytes: 1_073_741_824,
+      athleteBytes: 10_737_418_240,
+      parserMs: 30_000,
+    });
+    expect(Object.isFrozen(CHAT_ATTACHMENT_LIMITS)).toBe(true);
+  });
+
+  it("accepts only privileged native paths from picker or drop", () => {
+    const request = {
+      chatId: "desktop",
+      selectionId: "selection-1",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath: "/tmp/activity.fit" },
+    } as const;
+    expect(AdmitChatAttachmentRequestSchema.parse(request)).toEqual(request);
+    expect(() =>
+      AdmitChatAttachmentRequestSchema.parse({
+        ...request,
+        candidate: { kind: "native-path", sourcePath: "relative/activity.fit" },
+      }),
+    ).toThrow(/absolute/u);
+    expect(() =>
+      AdmitChatAttachmentRequestSchema.parse({
+        ...request,
+        source: "paste",
+      }),
+    ).toThrow();
+  });
+
+  it("models fail-closed admission without issuing a stable attachment id", () => {
+    const result = AttachmentAdmissionReadModelSchema.parse({
+      selectionId: "selection-1",
+      displayName: "activity.fit",
+      status: "storage_failed",
+      failureCode: "admission_unavailable",
+      retryable: false,
+    });
+    expect(result).not.toHaveProperty("attachmentId");
+  });
+});

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../src/index.js";
 
 describe("chat queue contract", () => {
-  it("ships protocol 23 and rejects blank enqueue text", () => {
-    expect(PROTOCOL_VERSION).toBe(23);
+  it("ships protocol 24 and rejects blank enqueue text", () => {
+    expect(PROTOCOL_VERSION).toBe(24);
     expect(() =>
       EnqueueChatMessageRequestSchema.parse({
         chatId: "desktop",
@@ -21,9 +21,11 @@ describe("chat queue contract", () => {
   it("requires exact FIFO positions, unique submission ids, and a head-owned recovery claim", () => {
     const item = {
       queuedMessageId: "queued-1",
+      messageId: "message-1",
       submissionId: "submission-1",
       text: "Hello",
       kind: "ordinary" as const,
+      attachmentIds: ["attachment-1"],
       position: 0,
       restored: true,
     };
@@ -37,6 +39,21 @@ describe("chat queue contract", () => {
         items: [item, { ...item, queuedMessageId: "queued-2", position: 2 }],
       }),
     ).toThrow();
+    expect(() =>
+      ChatQueueSnapshotSchema.parse({
+        schemaVersion: 1,
+        revision: 3,
+        items: [
+          item,
+          {
+            ...item,
+            queuedMessageId: "queued-2",
+            submissionId: "submission-2",
+            position: 1,
+          },
+        ],
+      }),
+    ).toThrow(/message ids must be unique/u);
     expect(() =>
       ChatQueueSnapshotSchema.parse({
         schemaVersion: 1,
@@ -60,5 +77,24 @@ describe("chat queue contract", () => {
         text: "/review",
       }),
     ).toThrow();
+  });
+
+  it("keeps slash commands text-only and ordinary attachment ids unique", () => {
+    expect(() =>
+      EnqueueChatMessageRequestSchema.parse({
+        chatId: "desktop",
+        submissionId: "submission-1",
+        text: "/review",
+        attachmentIds: ["attachment-1"],
+      }),
+    ).toThrow(/text-only/u);
+    expect(() =>
+      EnqueueChatMessageRequestSchema.parse({
+        chatId: "desktop",
+        submissionId: "submission-1",
+        text: "Review these",
+        attachmentIds: ["attachment-1", "attachment-1"],
+      }),
+    ).toThrow(/unique/u);
   });
 });

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -152,7 +152,7 @@ describe("coach decision wire contract", () => {
   });
 
   it("projects resume completion explicitly at protocol 20", () => {
-    expect(PROTOCOL_VERSION).toBe(23);
+    expect(PROTOCOL_VERSION).toBe(24);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -114,8 +114,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 23", () => {
-    expect(PROTOCOL_VERSION).toBe(23);
+  it("is 24", () => {
+    expect(PROTOCOL_VERSION).toBe(24);
   });
 
   it("requires Stop to name the exact active turn", () => {

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1083,6 +1083,13 @@ describe("coach request and event projection", () => {
     const fake: CoachRpcService = {
       chat: async () => ({ text: "ok" }),
       stopChat: async () => ({ stopped: true }),
+      admitChatAttachment: async ({ selectionId }) => ({
+        selectionId,
+        displayName: "activity.fit",
+        status: "storage_failed",
+        failureCode: "admission_unavailable",
+        retryable: false,
+      }),
       enqueueChatMessage: async () => ({ schemaVersion: 1, revision: 1, items: [] }),
       getChatQueue: async () => ({ schemaVersion: 1, revision: 1, items: [] }),
       removeQueuedChatMessage: async () => ({ schemaVersion: 1, revision: 2, items: [] }),
@@ -1804,7 +1811,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-23 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-24 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1812,8 +1819,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 23,
-      serverProtocolVersion: 23,
+      clientProtocolVersion: 24,
+      serverProtocolVersion: 24,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1822,7 +1829,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(22);
+    expect(previous).toBe(23);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -1895,9 +1902,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 23 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 24 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(23);
+    expect(client.clientProtocolVersion).toBe(24);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2023,7 +2030,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version 23", () => {
-    expect(PROTOCOL_VERSION).toBe(23);
+  it("uses protocol version 24", () => {
+    expect(PROTOCOL_VERSION).toBe(24);
   });
 });

--- a/packages/coach/src/attachment-operations.ts
+++ b/packages/coach/src/attachment-operations.ts
@@ -1,0 +1,22 @@
+import {
+  AttachmentAdmissionReadModelSchema,
+  type AdmitChatAttachmentRequest,
+  type AttachmentAdmissionReadModel,
+} from "@enduragent/coach-contract";
+
+function displayNameFromPath(sourcePath: string): string {
+  const segments = sourcePath.split(/[\\/]/u);
+  return segments.at(-1) || "Attachment";
+}
+
+export function unavailableChatAttachmentAdmission(
+  request: AdmitChatAttachmentRequest,
+): AttachmentAdmissionReadModel {
+  return AttachmentAdmissionReadModelSchema.parse({
+    selectionId: request.selectionId,
+    displayName: displayNameFromPath(request.candidate.sourcePath),
+    status: "storage_failed",
+    failureCode: "admission_unavailable",
+    retryable: false,
+  });
+}

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -42,6 +42,7 @@ import {
   type SetDailySpendCapRpcParams,
   type SpendSummary,
 } from "@enduragent/coach-contract";
+import { unavailableChatAttachmentAdmission } from "../attachment-operations.js";
 import type { WriterProtocolHandlers } from "@enduragent/kernel-node/lock";
 import WebSocket, { WebSocketServer, type RawData } from "ws";
 import type { DaemonHealthState } from "./healthz-server.js";
@@ -866,6 +867,7 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
     if (
       generic.data.method === "chat" ||
       generic.data.method === "stopChat" ||
+      generic.data.method === "admitChatAttachment" ||
       generic.data.method === "enqueueChatMessage" ||
       generic.data.method === "getChatQueue" ||
       generic.data.method === "removeQueuedChatMessage" ||
@@ -882,6 +884,7 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
       const chatId = (params.data as { readonly chatId: string }).chatId;
       if (
         chatId.startsWith("telegram:") ||
+        (generic.data.method === "admitChatAttachment" && chatId !== "desktop") ||
         (state.authority === "renderer" && chatId !== "desktop")
       ) {
         void enqueueSerialized(state, ordinaryError(generic.data.id, -32602, "Invalid params"));
@@ -947,6 +950,19 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                 input.engine.stopChat === undefined
                   ? { stopped: false }
                   : await input.engine.stopChat(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "admitChatAttachment":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.admitChatAttachment.requestSchema.parse(
+                generic.data.params,
+              );
+              result =
+                input.operations.admitChatAttachment === undefined
+                  ? unavailableChatAttachmentAdmission(request)
+                  : await input.operations.admitChatAttachment(request);
             } catch (error) {
               invocationFailure = { error };
             }

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -2014,6 +2014,128 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
 });
 
 describe.skipIf(!hasLoopback)("RPC authority boundaries", () => {
+  it("admits native paths only for privileged Desktop-main callers and fails closed before storage", async () => {
+    const token = "x".repeat(43);
+    const admitChatAttachment = vi.fn(async (request) => ({
+      selectionId: request.selectionId,
+      displayName: "activity.fit",
+      status: "storage_failed" as const,
+      failureCode: "admission_unavailable" as const,
+      retryable: false,
+    }));
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: { ...operations, admitChatAttachment },
+      token,
+      owner: "app-supervised",
+    });
+    const privileged = await openSocket(rpc);
+    privileged.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await privileged.frames.next();
+
+    const request = {
+      chatId: "desktop",
+      selectionId: "selection-1",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath: "/tmp/activity.fit" },
+    } as const;
+    privileged.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "privileged-admission",
+        method: "admitChatAttachment",
+        params: request,
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await privileged.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "privileged-admission",
+      result: {
+        selectionId: "selection-1",
+        displayName: "activity.fit",
+        status: "storage_failed",
+        failureCode: "admission_unavailable",
+        retryable: false,
+      },
+    });
+    expect(admitChatAttachment).toHaveBeenCalledWith(request);
+
+    privileged.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "foreign-admission",
+        method: "admitChatAttachment",
+        params: { ...request, chatId: "other" },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await privileged.frames.next())).toMatchObject({
+      id: "foreign-admission",
+      error: { code: -32602, message: "Invalid params" },
+    });
+
+    const renderer = await openSocket(rpc);
+    renderer.ws.send(
+      JSON.stringify(
+        createClientHandshakeFrame(TEST_RENDERER_CAPABILITY_BYTES.toString("base64url")),
+      ),
+    );
+    await renderer.frames.next();
+    renderer.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "renderer-admission",
+        method: "admitChatAttachment",
+        params: request,
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await renderer.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "renderer-admission",
+      error: { code: -32601, message: "Method not found" },
+    });
+    expect(admitChatAttachment).toHaveBeenCalledOnce();
+
+    await renderer.close();
+    await privileged.close();
+  });
+
+  it("returns a typed unavailable result when durable admission is not installed", async () => {
+    const token = "x".repeat(43);
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations,
+      token,
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "unavailable",
+        method: "admitChatAttachment",
+        params: {
+          chatId: "desktop",
+          selectionId: "selection-1",
+          source: "drop",
+          candidate: { kind: "native-path", sourcePath: "C:\\rides\\activity.fit" },
+        },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+      id: "unavailable",
+      result: {
+        selectionId: "selection-1",
+        displayName: "activity.fit",
+        status: "storage_failed",
+        failureCode: "admission_unavailable",
+        retryable: false,
+      },
+    });
+    await client.close();
+  });
+
   it("binds renderer capabilities to the exact Desktop session namespace", async () => {
     const token = "x".repeat(43);
     const chat = vi.fn(async () => ({ text: "ok" }));

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 23 as const,
-      serverProtocolVersion: 23 as const,
+      clientProtocolVersion: 24 as const,
+      serverProtocolVersion: 24 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -304,7 +304,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(23);
+    expect(PROTOCOL_VERSION).toBe(24);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/core/src/agent/chat-queue-store.ts
+++ b/packages/core/src/agent/chat-queue-store.ts
@@ -15,6 +15,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import {
+  CHAT_ATTACHMENT_LIMITS,
   ChatQueueSnapshotSchema,
   type ChatQueueSnapshot,
   type QueuedChatMessage,
@@ -32,7 +33,7 @@ import {
   type WindowsPrivateDirectoryBinding,
 } from "../io/windows-private-path-policy.js";
 
-const StoredItemSchema = z
+const LegacyStoredItemSchema = z
   .object({
     queuedMessageId: z.string().min(1),
     submissionId: z.string().min(1),
@@ -40,6 +41,28 @@ const StoredItemSchema = z
     kind: z.enum(["ordinary", "slash-command"]),
   })
   .strict();
+
+const StoredItemSchema = LegacyStoredItemSchema.extend({
+  messageId: z.string().min(1),
+  attachmentIds: z.array(z.string().min(1)).max(CHAT_ATTACHMENT_LIMITS.attachmentsPerMessage),
+})
+  .strict()
+  .superRefine((value, context) => {
+    if (new Set(value.attachmentIds).size !== value.attachmentIds.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["attachmentIds"],
+        message: "attachment ids must be unique",
+      });
+    }
+    if (value.kind === "slash-command" && value.attachmentIds.length !== 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["attachmentIds"],
+        message: "slash commands are text-only",
+      });
+    }
+  });
 
 const StoredClaimSchema = z
   .object({
@@ -50,29 +73,53 @@ const StoredClaimSchema = z
   })
   .strict();
 
-const StoredQueueSchema = z
+function validateQueueHead(
+  value: {
+    readonly items: readonly { readonly queuedMessageId: string; readonly submissionId: string }[];
+    readonly claim?: z.infer<typeof StoredClaimSchema>;
+  },
+  context: z.RefinementCtx,
+): void {
+  const ids = value.items.map((item) => item.queuedMessageId);
+  const submissions = value.items.map((item) => item.submissionId);
+  if (new Set(ids).size !== ids.length) {
+    context.addIssue({ code: "custom", path: ["items"], message: "duplicate queue ids" });
+  }
+  if (new Set(submissions).size !== submissions.length) {
+    context.addIssue({ code: "custom", path: ["items"], message: "duplicate submissions" });
+  }
+  if (
+    value.claim !== undefined &&
+    (value.claim.queuedMessageIds.length > ids.length ||
+      value.claim.queuedMessageIds.some((id, index) => id !== ids[index]))
+  ) {
+    context.addIssue({ code: "custom", path: ["claim"], message: "claim is not queue head" });
+  }
+}
+
+const LegacyStoredQueueSchema = z
   .object({
     schemaVersion: z.literal(1),
+    revision: z.number().int().nonnegative(),
+    items: z.array(LegacyStoredItemSchema),
+    claim: StoredClaimSchema.optional(),
+  })
+  .strict()
+  .superRefine(validateQueueHead);
+
+const StoredQueueSchema = z
+  .object({
+    schemaVersion: z.literal(2),
     revision: z.number().int().nonnegative(),
     items: z.array(StoredItemSchema),
     claim: StoredClaimSchema.optional(),
   })
   .strict()
   .superRefine((value, context) => {
-    const ids = value.items.map((item) => item.queuedMessageId);
-    const submissions = value.items.map((item) => item.submissionId);
-    if (new Set(ids).size !== ids.length) {
-      context.addIssue({ code: "custom", path: ["items"], message: "duplicate queue ids" });
-    }
-    if (new Set(submissions).size !== submissions.length) {
-      context.addIssue({ code: "custom", path: ["items"], message: "duplicate submissions" });
-    }
-    if (
-      value.claim !== undefined &&
-      (value.claim.queuedMessageIds.length > ids.length ||
-        value.claim.queuedMessageIds.some((id, index) => id !== ids[index]))
-    ) {
-      context.addIssue({ code: "custom", path: ["claim"], message: "claim is not queue head" });
+    validateQueueHead(value, context);
+    const messageIds = value.items.map((item) => item.messageId);
+    if (new Set(messageIds).size !== messageIds.length) {
+      context.addIssue({ code: "custom", path: ["items"], message: "duplicate message ids" });
     }
   });
 
@@ -85,7 +132,23 @@ export interface ChatQueueStoreHooks {
 }
 
 function emptyQueue(): StoredQueue {
-  return { schemaVersion: 1, revision: 0, items: [] };
+  return { schemaVersion: 2, revision: 0, items: [] };
+}
+
+function parseStoredQueue(value: unknown): StoredQueue {
+  const current = StoredQueueSchema.safeParse(value);
+  if (current.success) return current.data;
+  const legacy = LegacyStoredQueueSchema.parse(value);
+  return StoredQueueSchema.parse({
+    schemaVersion: 2,
+    revision: legacy.revision,
+    items: legacy.items.map((item) => ({
+      ...item,
+      messageId: item.queuedMessageId,
+      attachmentIds: [],
+    })),
+    ...(legacy.claim === undefined ? {} : { claim: legacy.claim }),
+  });
 }
 
 function safeName(chatId: string): string {
@@ -141,16 +204,20 @@ export class ChatQueueStore {
     submissionId: string,
     text: string,
     queuedMessageId: string,
+    messageId = queuedMessageId,
+    attachmentIds: readonly string[] = [],
   ): ChatQueueSnapshot {
     const state = this.read(chatId);
     const duplicate = state.items.find((item) => item.submissionId === submissionId);
     if (duplicate !== undefined) return this.snapshot(state);
-    const item = {
+    const item = StoredItemSchema.parse({
       queuedMessageId,
+      messageId,
       submissionId,
       text,
       kind: /^\s*\//u.test(text) ? ("slash-command" as const) : ("ordinary" as const),
-    };
+      attachmentIds: [...attachmentIds],
+    });
     this.freshIds.add(queuedMessageId);
     return this.commit(chatId, {
       ...state,
@@ -193,7 +260,7 @@ export class ChatQueueStore {
     const claimed = new Set(state.claim.queuedMessageIds);
     const items = state.items.filter((item) => !claimed.has(item.queuedMessageId));
     state.claim.queuedMessageIds.forEach((id) => this.freshIds.delete(id));
-    return this.commit(chatId, { schemaVersion: 1, revision: state.revision + 1, items });
+    return this.commit(chatId, { schemaVersion: 2, revision: state.revision + 1, items });
   }
 
   requireRetry(chatId: string, claimId: string): ChatQueueSnapshot {
@@ -224,7 +291,7 @@ export class ChatQueueStore {
     const state = this.read(chatId);
     if (state.items.length === 0 && state.claim === undefined) return this.snapshot(state);
     state.items.forEach((item) => this.freshIds.delete(item.queuedMessageId));
-    return this.commit(chatId, { schemaVersion: 1, revision: state.revision + 1, items: [] });
+    return this.commit(chatId, { schemaVersion: 2, revision: state.revision + 1, items: [] });
   }
 
   reconcile(chatId: string, completedTurnIds: ReadonlySet<string>): ChatQueueSnapshot {
@@ -290,7 +357,7 @@ export class ChatQueueStore {
       this.hooks.afterFileRead?.(path, descriptor);
       let parsed: StoredQueue;
       try {
-        parsed = StoredQueueSchema.parse(JSON.parse(contents));
+        parsed = parseStoredQueue(JSON.parse(contents));
       } catch (error) {
         if (this.platform === "win32") {
           assertWindowsPrivatePathRead({

--- a/packages/core/src/agent/conversation-store.ts
+++ b/packages/core/src/agent/conversation-store.ts
@@ -34,6 +34,8 @@ export interface ConversationStorePort extends ChatStorePort, TranscriptWriterPo
     submissionId: string,
     text: string,
     queuedMessageId: string,
+    messageId?: string,
+    attachmentIds?: readonly string[],
   ): ChatQueueSnapshot;
   removeQueuedChatMessage(chatId: string, queuedMessageId: string): ChatQueueSnapshot;
   claimChatQueue(
@@ -226,9 +228,18 @@ export class ConversationStore implements ConversationStorePort {
     submissionId: string,
     text: string,
     queuedMessageId: string,
+    messageId = queuedMessageId,
+    attachmentIds: readonly string[] = [],
   ): ChatQueueSnapshot {
     this.recoverBeforeAccess(chatId);
-    return this.queueStore().enqueue(chatId, submissionId, text, queuedMessageId);
+    return this.queueStore().enqueue(
+      chatId,
+      submissionId,
+      text,
+      queuedMessageId,
+      messageId,
+      attachmentIds,
+    );
   }
 
   removeQueuedChatMessage(chatId: string, queuedMessageId: string): ChatQueueSnapshot {

--- a/packages/core/tests/chat-queue-store.test.ts
+++ b/packages/core/tests/chat-queue-store.test.ts
@@ -7,6 +7,7 @@ import {
   mkdirSync,
   mkdtempSync,
   renameSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -49,6 +50,68 @@ describe("ChatQueueStore", () => {
     const restored = new ChatQueueStore(root).get("desktop");
     expect(restored.revision).toBe(2);
     expect(restored.items.map((item) => item.restored)).toEqual([true, true]);
+  });
+
+  it("stores one stable Message identity and attachment list per ordinary queue item", () => {
+    const { value } = store();
+    const queued = value.enqueue(
+      "desktop",
+      "submission-1",
+      "Review this",
+      "queued-1",
+      "message-1",
+      ["attachment-1"],
+    );
+    expect(queued.items[0]).toMatchObject({
+      queuedMessageId: "queued-1",
+      messageId: "message-1",
+      attachmentIds: ["attachment-1"],
+    });
+    expect(() =>
+      value.enqueue("desktop", "submission-2", "/review", "queued-2", "message-2", [
+        "attachment-2",
+      ]),
+    ).toThrow(/text-only/u);
+  });
+
+  it("restores legacy queues with deterministic Message identities and upgrades on mutation", () => {
+    const { root, value } = store();
+    const path = join(
+      root,
+      "chat-queues",
+      `${createHash("sha256").update("desktop").digest("hex")}.json`,
+    );
+    writeFileSync(
+      path,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        revision: 1,
+        items: [
+          {
+            queuedMessageId: "legacy-queued-1",
+            submissionId: "legacy-submission-1",
+            text: "Legacy message",
+            kind: "ordinary",
+          },
+        ],
+      })}\n`,
+      { mode: 0o600 },
+    );
+
+    expect(value.get("desktop").items[0]).toMatchObject({
+      queuedMessageId: "legacy-queued-1",
+      messageId: "legacy-queued-1",
+      attachmentIds: [],
+      restored: true,
+    });
+    value.enqueue("desktop", "submission-2", "New", "queued-2", "message-2", []);
+    expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
+      schemaVersion: 2,
+      items: [
+        { messageId: "legacy-queued-1", attachmentIds: [] },
+        { messageId: "message-2", attachmentIds: [] },
+      ],
+    });
   });
 
   it("removes every unclaimed item by stable identity before dispatch", () => {

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -156,6 +156,8 @@ export interface ChatStorePort {
     submissionId: string,
     text: string,
     queuedMessageId: string,
+    messageId?: string,
+    attachmentIds?: readonly string[],
   ): ChatQueueSnapshot;
   removeQueuedChatMessage?(chatId: string, queuedMessageId: string): ChatQueueSnapshot;
   claimChatQueue?(

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -218,6 +218,8 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
         request.submissionId,
         request.text,
         input.ports.randomId(),
+        input.ports.randomId(),
+        request.attachmentIds,
       ),
     getChatQueue: async (request) => snapshot(request.chatId),
     removeQueuedChatMessage: async (request) =>

--- a/packages/engine/tests/chat-queue.test.ts
+++ b/packages/engine/tests/chat-queue.test.ts
@@ -47,6 +47,29 @@ function setup(
 }
 
 describe("engine durable chat queue", () => {
+  it("assigns host-owned Message identities and preserves ordinary attachment references", async () => {
+    const { engine } = setup();
+    const queued = await engine.enqueueChatMessage!({
+      chatId: "desktop",
+      submissionId: "submission-1",
+      text: "Review this activity",
+      attachmentIds: ["attachment-1"],
+    });
+    expect(queued.items[0]).toMatchObject({
+      queuedMessageId: "id-1",
+      messageId: "id-2",
+      attachmentIds: ["attachment-1"],
+    });
+    await expect(
+      engine.enqueueChatMessage!({
+        chatId: "desktop",
+        submissionId: "submission-2",
+        text: "/review",
+        attachmentIds: ["attachment-2"],
+      }),
+    ).rejects.toThrow(/text-only/u);
+  });
+
   it("groups consecutive ordinary messages and stops at a command barrier", async () => {
     const requests: ModelTransportRequest[] = [];
     const { engine } = setup(undefined, async (request) => {
@@ -192,9 +215,13 @@ describe("engine durable chat queue", () => {
     const { engine } = setup(undefined, generate);
     await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s1", text: "First" });
     await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s2", text: "/review" });
-    const running = engine.resumeChatQueue!({ chatId: "desktop" }).catch(() => undefined);
+    let activeTurnId: string | undefined;
+    const running = engine.resumeChatQueue!({ chatId: "desktop" }, (event) => {
+      if (event.type === "turn-start") activeTurnId = event.turnId;
+    }).catch(() => undefined);
     await active;
-    await engine.stopChat!({ chatId: "desktop", turnId: "id-4" });
+    if (activeTurnId === undefined) throw new Error("active turn was not announced");
+    await engine.stopChat!({ chatId: "desktop", turnId: activeTurnId });
     await running;
 
     const snapshot = await engine.getChatQueue!({ chatId: "desktop" });


### PR DESCRIPTION
## Summary

- define fail-closed attachment admission limits, kinds, and read models
- add a privileged Desktop-main native-path RPC while keeping renderer access denied
- persist stable message and attachment references in the chat queue with safe v1-to-v2 migration
- keep slash commands text-only

## Approved sequencing

- durable successful admission and stable attachment creation move to ATT-02
- Desktop picker/drop wiring remains a later UI slice

## Verification

- pnpm check
- pnpm test: 618 files passed, 9,632 tests passed, 15 skipped
- focused Desktop integrations: 9 passed
- autoreview: clean; TruffleHog clean