### PR TITLE
feat: add Plan-native Coach and Draft flow

### DIFF
--- a/.changeset/plan-native-coach-draft.md
+++ b/.changeset/plan-native-coach-draft.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Added a dedicated coach conversation inside Plan, including streamed replies, queued follow-ups, Stop and retry recovery, and reviewable Draft creation and revision.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -174,13 +174,31 @@ export function bootRenderer(): Disposer {
 
   const planAdapter = createPlanViewAdapter({
     bridge: window.enduragentAuth,
+    clients,
     read: () => store.getState().plan,
     publishHydration: (next) => store.getState().setPlanHydration(next),
     publishTransition: (next) => store.getState().setPlanTransition(next),
+    publishCoach: (next) => store.getState().setPlanCoach(next),
+    publishDiscardConfirmation: (open) => store.getState().setPlanDiscardConfirmation(open),
+    publishRevisionComposer: (open) => store.getState().setPlanRevisionComposer(open),
   });
   store.getState().bindPlanActions({
     open: () => planAdapter.open(),
     startPlan: () => planAdapter.startPlan(),
+    submitCoach: (message) => planAdapter.submitCoach(message),
+    stopCoach: () => planAdapter.stopCoach(),
+    removeQueuedCoachMessage: (id) => planAdapter.removeQueuedCoachMessage(id),
+    retryQueuedCoachTurn: (claimId) => planAdapter.retryQueuedCoachTurn(claimId),
+    answerCoachDecision: (decisionId, answer) =>
+      planAdapter.answerCoachDecision(decisionId, answer),
+    skipCoachDecision: (decisionId) => planAdapter.skipCoachDecision(decisionId),
+    createDraft: () => planAdapter.createDraft(),
+    updateDraft: (message) => planAdapter.updateDraft(message),
+    openDiscardConfirmation: () => planAdapter.openDiscardConfirmation(),
+    closeDiscardConfirmation: () => planAdapter.closeDiscardConfirmation(),
+    discardDraft: () => planAdapter.discardDraft(),
+    openRevisionComposer: () => planAdapter.openRevisionComposer(),
+    closeRevisionComposer: () => planAdapter.closeRevisionComposer(),
     retry: () => planAdapter.retry(),
   });
   planAdapter.start();

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -167,6 +167,7 @@ export function createChatViewAdapter(input: {
   readonly publish: (next: ChatSurfaceState) => void;
   readonly buffer?: ChatStreamBuffer;
   readonly anchor?: ChatScrollAnchor;
+  readonly bufferStreaming?: boolean;
 }): ChatViewAdapter {
   const buffer = input.buffer ?? chatStreamBuffer;
   const anchor = input.anchor ?? chatScrollAnchor;
@@ -183,7 +184,7 @@ export function createChatViewAdapter(input: {
       role: message.role,
       delivery: message.delivery,
       historical: message.historical === true,
-      text: isStreamingCoach(message) ? "" : message.text,
+      text: input.bufferStreaming !== false && isStreamingCoach(message) ? "" : message.text,
     }));
     const workBlocked =
       controls?.workBlocked ??
@@ -280,6 +281,7 @@ export function createChatViewAdapter(input: {
     state: ChatState,
     controls: ChatViewControls | undefined,
   ): { readonly action: StreamAction | null; readonly streaming: ReadonlySet<string> } => {
+    if (input.bufferStreaming === false) return { action: null, streaming: new Set() };
     const streaming = new Set<string>();
     let action: StreamAction | null = null;
     for (const message of state.messages) {

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -1,15 +1,27 @@
-import type {
-  ExecutePlanTransitionRpcParams,
-  ExecutePlanTransitionRpcResult,
-  GetPlanStateRpcResult,
-  PlanError,
-  PlanHydrationState,
-  PlanProgressEvent,
-  PlanReadModel,
-  PlanTransitionId,
+import {
+  PlanCoachProjectionDataSchema,
+  type CoachDecisionAnswer,
+  type CoachDecisionReadModel,
+  type ExecutePlanTransitionRpcParams,
+  type ExecutePlanTransitionRpcResult,
+  type GetPlanStateRpcResult,
+  type PlanError,
+  type PlanHydrationState,
+  type PlanProgressEvent,
+  type PlanReadModel,
+  type PlanTransitionId,
 } from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../../coach-client.js";
+import {
+  EMPTY_CHAT_STATE,
+  nextDrainGroup,
+  reduceChatState,
+  type ChatState,
+} from "../../turn-state.js";
+import type { ChatSurfaceState } from "../chat-slice.js";
 import type { PlanSurfaceState, PlanTransitionState } from "../plan-slice.js";
 import { planReadModel } from "../plan-slice.js";
+import { createChatViewAdapter } from "./chat.js";
 
 export interface PlanBridge {
   getPlanState(): Promise<GetPlanStateRpcResult>;
@@ -23,6 +35,19 @@ export interface PlanViewAdapter {
   start(): void;
   open(): void;
   startPlan(): void;
+  submitCoach(message: string): Promise<boolean>;
+  stopCoach(): void;
+  removeQueuedCoachMessage(id: string): void;
+  retryQueuedCoachTurn(claimId: string): void;
+  answerCoachDecision(decisionId: string, answer: CoachDecisionAnswer): void;
+  skipCoachDecision(decisionId: string): void;
+  createDraft(): void;
+  updateDraft(message: string): void;
+  openDiscardConfirmation(): void;
+  closeDiscardConfirmation(): void;
+  discardDraft(): void;
+  openRevisionComposer(): void;
+  closeRevisionComposer(): void;
   retry(): void;
   dispose(): void;
 }
@@ -42,26 +67,122 @@ function hydrationFromTransition(result: ExecutePlanTransitionRpcResult): PlanHy
   return { status: "ready", state: result.state };
 }
 
+function hydratedCoachState(model: PlanReadModel): ChatState | null {
+  const parsed = PlanCoachProjectionDataSchema.safeParse(model.data);
+  if (!parsed.success) return null;
+  return reduceChatState(
+    {
+      ...EMPTY_CHAT_STATE,
+      messages: parsed.data.messages.map((message) => ({
+        id: message.id,
+        ...(message.turnId === null ? {} : { turnId: message.turnId }),
+        role: message.role,
+        text: message.text,
+        delivery: "complete",
+      })),
+      session: {
+        ...EMPTY_CHAT_STATE.session,
+        presence: parsed.data.messages.length > 1 ? "present" : "absent",
+      },
+    },
+    { type: "queue-snapshot", snapshot: parsed.data.queue },
+  );
+}
+
 export function createPlanViewAdapter(input: {
   readonly bridge: PlanBridge;
+  readonly clients?: DesktopCoachClientProvider;
   readonly read: () => PlanSurfaceState;
   readonly publishHydration: (next: PlanHydrationState) => void;
   readonly publishTransition: (next: PlanTransitionState) => void;
+  readonly publishCoach: (next: ChatSurfaceState) => void;
+  readonly publishDiscardConfirmation: (open: boolean) => void;
+  readonly publishRevisionComposer: (open: boolean) => void;
   readonly createCommandId?: () => string;
+  readonly createMessageId?: () => string;
 }): PlanViewAdapter {
   const createCommandId = input.createCommandId ?? (() => globalThis.crypto.randomUUID());
+  const createMessageId = input.createMessageId ?? (() => globalThis.crypto.randomUUID());
   let disposed = false;
   let started = false;
   let disposeProgress: (() => void) | null = null;
   let hydrationGeneration = 0;
-  let lastRetry: "hydrate" | "start" | "attention" = "hydrate";
-  let active:
-    | {
-        readonly commandId: string;
-        readonly transitionId: PlanTransitionId;
-        operationId: string | null;
+  let lastCommand: ExecutePlanTransitionRpcParams | null = null;
+  let coachState = EMPTY_CHAT_STATE;
+  let coachRequestKey = 0;
+  let coachDecision: CoachDecisionReadModel | null = null;
+  let coachDecisionPhase: ChatSurfaceState["decisionPhase"] = "idle";
+  let coachDecisionAnswerLabel: string | null = null;
+  let coachDecisionError: string | null = null;
+  let recoveringDecisionId: string | null = null;
+  let active: {
+    readonly commandId: string;
+    readonly transitionId: PlanTransitionId;
+    operationId: string | null;
+    accepted: boolean;
+  } | null = null;
+
+  const coachView = createChatViewAdapter({
+    publish: input.publishCoach,
+    bufferStreaming: false,
+  }).view;
+
+  const renderCoach = (): void => {
+    coachView.render(coachState, {
+      newConversationDisabled: true,
+      workBlocked: false,
+      decision: {
+        value: coachDecision,
+        phase: coachDecisionPhase,
+        answerLabel: coachDecisionAnswerLabel,
+        error: coachDecisionError,
+      },
+    });
+  };
+
+  const reduceCoach = (action: Parameters<typeof reduceChatState>[1]): void => {
+    coachState = reduceChatState(coachState, action);
+    renderCoach();
+  };
+
+  const decisionLabel = (decision: CoachDecisionReadModel): string | null => {
+    if (decision.status !== "answered") return null;
+    if (decision.answer.kind === "custom") return decision.answer.text;
+    const optionId = decision.answer.optionId;
+    return decision.options.find((option) => option.id === optionId)?.label ?? "Saved choice";
+  };
+
+  const syncCoach = (model: PlanReadModel): void => {
+    const next = hydratedCoachState(model);
+    if (next === null) return;
+    const data = PlanCoachProjectionDataSchema.parse(model.data);
+    coachState = next;
+    coachDecision = data.decision;
+    coachDecisionAnswerLabel = data.decision === null ? null : decisionLabel(data.decision);
+    coachDecisionError = null;
+    if (data.decision?.status === "answered" && data.decision.continuation.status === "pending") {
+      coachDecisionPhase = "recovering";
+      if (recoveringDecisionId !== data.decision.decisionId) {
+        const decisionId = data.decision.decisionId;
+        recoveringDecisionId = decisionId;
+        queueMicrotask(() => {
+          submitCommand(coachDecisionAnswerLabel ?? "Saved choice", {
+            action: "resume",
+            decisionId,
+          });
+        });
       }
-    | null = null;
+    } else {
+      coachDecisionPhase = "idle";
+      recoveringDecisionId = null;
+    }
+    renderCoach();
+  };
+
+  const publishHydration = (next: PlanHydrationState): void => {
+    input.publishHydration(next);
+    if (next.status === "ready" || next.status === "stale") syncCoach(next.state);
+  };
 
   const refresh = async (showLoading: boolean): Promise<void> => {
     const generation = ++hydrationGeneration;
@@ -71,23 +192,22 @@ export function createPlanViewAdapter(input: {
     try {
       const result = await input.bridge.getPlanState();
       if (disposed || generation !== hydrationGeneration) return;
-      input.publishHydration(hydrationFromResult(result));
+      publishHydration(hydrationFromResult(result));
     } catch {
       if (disposed || generation !== hydrationGeneration) return;
       input.publishHydration({ status: "failed", error: UNAVAILABLE_ERROR });
     }
   };
 
-  const execute = async (
-    command: ExecutePlanTransitionRpcParams,
-    retry: "start" | "attention",
-  ): Promise<void> => {
+  const execute = async (command: ExecutePlanTransitionRpcParams): Promise<void> => {
+    if (active !== null) return;
     active = {
       commandId: command.commandId,
       transitionId: command.transitionId,
       operationId: null,
+      accepted: false,
     };
-    lastRetry = retry;
+    lastCommand = command;
     input.publishTransition({
       status: "submitting",
       commandId: command.commandId,
@@ -102,13 +222,17 @@ export function createPlanViewAdapter(input: {
       ) {
         return;
       }
-      input.publishHydration(hydrationFromTransition(result));
+      publishHydration(hydrationFromTransition(result));
       if (result.status === "unsupported-capability") {
         active = null;
         input.publishTransition({ status: "idle" });
         return;
       }
       if (result.status === "rejected") {
+        if (command.transitionId === "PL-T05") {
+          coachDecisionError = result.error.message;
+          reduceCoach({ type: "fail", requestKey: coachRequestKey, copy: result.error.message });
+        }
         active = null;
         input.publishTransition({
           status: "failed",
@@ -120,6 +244,7 @@ export function createPlanViewAdapter(input: {
       }
       if (result.status === "accepted") {
         active.operationId = result.operationId;
+        active.accepted = true;
         input.publishTransition({
           status: "running",
           commandId: command.commandId,
@@ -139,6 +264,10 @@ export function createPlanViewAdapter(input: {
       ) {
         return;
       }
+      if (command.transitionId === "PL-T05") {
+        coachDecisionError = UNAVAILABLE_ERROR.message;
+        reduceCoach({ type: "fail", requestKey: coachRequestKey, copy: UNAVAILABLE_ERROR.message });
+      }
       active = null;
       input.publishTransition({
         status: "failed",
@@ -149,47 +278,78 @@ export function createPlanViewAdapter(input: {
     }
   };
 
-  const startPlan = (): void => {
-    if (active !== null) return;
-    const commandId = createCommandId();
-    void execute(
-      { transitionId: "PL-T01", commandId, sourceConversationId: null },
-      "start",
-    );
+  const currentCoachData = (): ReturnType<typeof PlanCoachProjectionDataSchema.parse> | null => {
+    const model = planReadModel(input.read());
+    if (model === null) return null;
+    const parsed = PlanCoachProjectionDataSchema.safeParse(model.data);
+    return parsed.success ? parsed.data : null;
   };
 
-  const open = (): void => {
-    if (active !== null) return;
-    const model: PlanReadModel | null = planReadModel(input.read());
-    if (model === null) return;
-    if (model.attention.destination === "none") {
-      lastRetry = "hydrate";
-      void refresh(false);
-      return;
+  const beginCoachSubmission = (message: string, includeUser: boolean): void => {
+    coachRequestKey += 1;
+    reduceCoach({
+      type: "submit",
+      requestKey: coachRequestKey,
+      userMessage: message,
+      userMessageId: createMessageId(),
+      assistantMessageId: createMessageId(),
+      includeUser,
+    });
+  };
+
+  const submitCommand = (
+    message: string,
+    decision?: Extract<ExecutePlanTransitionRpcParams, { transitionId: "PL-T05" }>["decision"],
+  ): boolean => {
+    const data = currentCoachData();
+    if (data === null || active !== null || !/\S/u.test(message)) return false;
+    beginCoachSubmission(message, decision === undefined);
+    void execute({
+      transitionId: "PL-T05",
+      commandId: createCommandId(),
+      conversationId: data.conversationId,
+      text: message.trim(),
+      ...(decision === undefined ? {} : { decision }),
+    });
+    return true;
+  };
+
+  const onCoachTurnEvent = (event: NonNullable<PlanProgressEvent["turnEvent"]>): void => {
+    if (event.type === "turn-start") {
+      const current = coachState.activeTurn;
+      if (current?.finalText !== null && current?.finalText !== undefined) {
+        reduceCoach({ type: "complete", requestKey: current.requestKey });
+        const group = nextDrainGroup(coachState);
+        if (group !== null) {
+          reduceCoach({ type: "dequeue-group" });
+          beginCoachSubmission(group.text, true);
+        }
+      }
+      reduceCoach({ type: "bind-turn", requestKey: coachRequestKey, turnId: event.turnId });
     }
-    if (model.planId === null) {
-      lastRetry = "hydrate";
-      void refresh(false);
-      return;
+    if (event.type === "decision-requested") {
+      coachDecision = event.decision;
+      reduceCoach({
+        type: "bind-decision",
+        requestKey: coachRequestKey,
+        decisionId: event.decision.decisionId,
+      });
     }
-    const commandId = createCommandId();
-    void execute(
-      { transitionId: "PL-T33", commandId, planId: model.planId },
-      "attention",
-    );
+    reduceCoach({ type: "event", requestKey: coachRequestKey, event });
   };
 
   const onProgress = (progress: PlanProgressEvent): void => {
     if (
       disposed ||
       active === null ||
-      active.operationId === null ||
       progress.commandId !== active.commandId ||
-      progress.transitionId !== active.transitionId ||
-      progress.operationId !== active.operationId
+      progress.transitionId !== active.transitionId
     ) {
       return;
     }
+    if (active.operationId === null) active.operationId = progress.operationId;
+    if (progress.operationId !== active.operationId) return;
+    if (progress.turnEvent !== undefined) onCoachTurnEvent(progress.turnEvent);
     input.publishTransition({
       status: "running",
       commandId: active.commandId,
@@ -197,11 +357,34 @@ export function createPlanViewAdapter(input: {
       operationId: active.operationId,
       progress,
     });
-    if (progress.phase === "completed" || progress.phase === "failed") {
+    if ((progress.phase === "completed" || progress.phase === "failed") && active.accepted) {
       active = null;
       input.publishTransition({ status: "idle" });
       void refresh(false);
     }
+  };
+
+  const startPlan = (): void => {
+    if (active !== null) return;
+    void execute({
+      transitionId: "PL-T01",
+      commandId: createCommandId(),
+      sourceConversationId: null,
+    });
+  };
+
+  const open = (): void => {
+    if (active !== null) return;
+    const model = planReadModel(input.read());
+    if (model === null || model.attention.destination === "none" || model.planId === null) {
+      void refresh(false);
+      return;
+    }
+    void execute({
+      transitionId: "PL-T33",
+      commandId: createCommandId(),
+      planId: model.planId,
+    });
   };
 
   return {
@@ -213,10 +396,133 @@ export function createPlanViewAdapter(input: {
     },
     open,
     startPlan,
+    async submitCoach(message) {
+      if (coachState.status === "streaming") {
+        const data = currentCoachData();
+        if (data === null || input.clients === undefined || !/\S/u.test(message)) return false;
+        try {
+          const client = await input.clients.getClient();
+          const snapshot = await client.call("enqueueChatMessage", {
+            chatId: data.chatId,
+            submissionId: createMessageId(),
+            text: message.trim(),
+          });
+          reduceCoach({ type: "queue-snapshot", snapshot });
+          return true;
+        } catch {
+          return false;
+        }
+      }
+      return submitCommand(message);
+    },
+    stopCoach() {
+      const data = currentCoachData();
+      const turnId = coachState.activeTurn?.turnId;
+      if (data === null || turnId === null || turnId === undefined || input.clients === undefined) {
+        return;
+      }
+      void input.clients
+        .getClient()
+        .then((client) => client.call("stopChat", { chatId: data.chatId, turnId }))
+        .catch(() => undefined);
+    },
+    removeQueuedCoachMessage(id) {
+      const data = currentCoachData();
+      if (data === null || input.clients === undefined) return;
+      void input.clients
+        .getClient()
+        .then((client) =>
+          client.call("removeQueuedChatMessage", { chatId: data.chatId, queuedMessageId: id }),
+        )
+        .then((snapshot) => reduceCoach({ type: "queue-snapshot", snapshot }))
+        .catch(() => undefined);
+    },
+    retryQueuedCoachTurn(claimId) {
+      const retry = coachState.retryRequired;
+      if (retry?.claimId !== claimId) return;
+      const text = coachState.queued
+        .filter((item) => retry.queuedMessageIds.includes(item.id))
+        .map((item) => item.text)
+        .join("\n\n");
+      submitCommand(text);
+    },
+    answerCoachDecision(decisionId, answer) {
+      const decision = coachDecision;
+      if (decision?.decisionId !== decisionId) return;
+      const label =
+        answer.kind === "custom"
+          ? answer.text
+          : (decision.options.find((option) => option.id === answer.optionId)?.label ??
+            "Saved choice");
+      coachDecisionPhase = "continuing";
+      coachDecisionAnswerLabel = label;
+      coachDecisionError = null;
+      submitCommand(label, { action: "answer", decisionId, answer });
+    },
+    skipCoachDecision(decisionId) {
+      if (coachDecision?.decisionId !== decisionId) return;
+      coachDecisionPhase = "continuing";
+      coachDecisionAnswerLabel = "Question skipped";
+      coachDecisionError = null;
+      submitCommand("Question skipped", { action: "skip", decisionId });
+    },
+    createDraft() {
+      const data = currentCoachData();
+      if (data === null || !data.readyToCreateDraft) return;
+      void execute({
+        transitionId: "PL-T06",
+        commandId: createCommandId(),
+        conversationId: data.conversationId,
+      });
+    },
+    updateDraft(message) {
+      const data = currentCoachData();
+      if (data === null || data.draft === null || !/\S/u.test(message)) return;
+      input.publishRevisionComposer(false);
+      void execute({
+        transitionId: "PL-T07",
+        commandId: createCommandId(),
+        draftId: data.draft.id,
+        text: message.trim(),
+      });
+    },
+    openDiscardConfirmation() {
+      input.publishDiscardConfirmation(true);
+    },
+    closeDiscardConfirmation() {
+      input.publishDiscardConfirmation(false);
+    },
+    discardDraft() {
+      const data = currentCoachData();
+      if (data === null || data.draft === null) return;
+      input.publishDiscardConfirmation(false);
+      void execute({
+        transitionId: "PL-T10",
+        commandId: createCommandId(),
+        draftId: data.draft.id,
+      });
+    },
+    openRevisionComposer() {
+      input.publishRevisionComposer(true);
+    },
+    closeRevisionComposer() {
+      input.publishRevisionComposer(false);
+    },
     retry() {
-      if (lastRetry === "start") startPlan();
-      else if (lastRetry === "attention") open();
-      else void refresh(input.read().lastReady === null);
+      if (lastCommand === null) {
+        void refresh(input.read().lastReady === null);
+        return;
+      }
+      const retry = {
+        ...lastCommand,
+        commandId: createCommandId(),
+      } as ExecutePlanTransitionRpcParams;
+      if (retry.transitionId === "PL-T05") {
+        coachState = { ...coachState, status: "idle", activeTurn: null };
+        submitCommand(retry.text, retry.decision);
+      } else {
+        void execute(retry);
+      }
     },
     dispose() {
       if (disposed) return;

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -1,4 +1,5 @@
 import type {
+  CoachDecisionAnswer,
   PlanError,
   PlanHydrationState,
   PlanProgressEvent,
@@ -7,6 +8,7 @@ import type {
 } from "@enduragent/coach-contract";
 import type { StateCreator } from "zustand";
 import type { EnduragentState } from "./store.js";
+import { EMPTY_CHAT_SURFACE, type ChatSurfaceState } from "./chat-slice.js";
 
 export type PlanTransitionState =
   | { readonly status: "idle" }
@@ -33,11 +35,27 @@ export interface PlanSurfaceState {
   readonly hydration: PlanHydrationState;
   readonly lastReady: PlanReadModel | null;
   readonly transition: PlanTransitionState;
+  readonly coach: ChatSurfaceState;
+  readonly discardConfirmation: boolean;
+  readonly revisionComposer: boolean;
 }
 
 export interface PlanActions {
   open(): void;
   startPlan(): void;
+  submitCoach(message: string): Promise<boolean>;
+  stopCoach(): void;
+  removeQueuedCoachMessage(id: string): void;
+  retryQueuedCoachTurn(claimId: string): void;
+  answerCoachDecision(decisionId: string, answer: CoachDecisionAnswer): void;
+  skipCoachDecision(decisionId: string): void;
+  createDraft(): void;
+  updateDraft(message: string): void;
+  openDiscardConfirmation(): void;
+  closeDiscardConfirmation(): void;
+  discardDraft(): void;
+  openRevisionComposer(): void;
+  closeRevisionComposer(): void;
   retry(): void;
 }
 
@@ -46,6 +64,9 @@ export interface PlanSlice {
   readonly planActions: PlanActions | null;
   setPlanHydration: (next: PlanHydrationState) => void;
   setPlanTransition: (next: PlanTransitionState) => void;
+  setPlanCoach: (next: ChatSurfaceState) => void;
+  setPlanDiscardConfirmation: (open: boolean) => void;
+  setPlanRevisionComposer: (open: boolean) => void;
   bindPlanActions: (actions: PlanActions | null) => void;
 }
 
@@ -53,6 +74,9 @@ export const EMPTY_PLAN_SURFACE: PlanSurfaceState = Object.freeze({
   hydration: Object.freeze({ status: "loading" }),
   lastReady: null,
   transition: Object.freeze({ status: "idle" }),
+  coach: EMPTY_CHAT_SURFACE,
+  discardConfirmation: false,
+  revisionComposer: false,
 });
 
 export function planReadModel(plan: PlanSurfaceState): PlanReadModel | null {
@@ -82,6 +106,15 @@ export const createPlanSlice: StateCreator<EnduragentState, [], [], PlanSlice> =
   },
   setPlanTransition(next) {
     set((current) => ({ plan: { ...current.plan, transition: next } }));
+  },
+  setPlanCoach(next) {
+    set((current) => ({ plan: { ...current.plan, coach: next } }));
+  },
+  setPlanDiscardConfirmation(open) {
+    set((current) => ({ plan: { ...current.plan, discardConfirmation: open } }));
+  },
+  setPlanRevisionComposer(open) {
+    set((current) => ({ plan: { ...current.plan, revisionComposer: open } }));
   },
   bindPlanActions(actions) {
     set({ planActions: actions });

--- a/apps/desktop-renderer/src/ui/chat/CoachDecisionPanel.tsx
+++ b/apps/desktop-renderer/src/ui/chat/CoachDecisionPanel.tsx
@@ -1,5 +1,6 @@
 import { ChevronRight, LoaderCircle, Plus, X } from "lucide-react";
 import {
+  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -10,16 +11,51 @@ import {
 } from "react";
 import { Button } from "../../components/ui/button.js";
 import { useEnduragentStore } from "../../state/store.js";
+import type { CoachDecisionAnswer, CoachDecisionReadModel } from "@enduragent/coach-contract";
 
 export function CoachDecisionPanel(props: {
   readonly onCustomOpenChange: (open: boolean) => void;
+  readonly surface?: {
+    readonly decision: CoachDecisionReadModel | null;
+    readonly phase: "idle" | "continuing" | "recovering";
+    readonly answerLabel: string | null;
+    readonly error: string | null;
+    readonly loadError: string | null;
+    answer(decisionId: string, answer: CoachDecisionAnswer): void;
+    skip(decisionId: string): void;
+    retry(): void;
+  };
 }): ReactElement | null {
-  const decision = useEnduragentStore((state) => state.chat.decision);
-  const phase = useEnduragentStore((state) => state.chat.decisionPhase);
-  const answerLabel = useEnduragentStore((state) => state.chat.decisionAnswerLabel);
-  const error = useEnduragentStore((state) => state.chat.decisionError);
-  const loadError = useEnduragentStore((state) => state.chat.decisionLoadError);
+  const chatDecision = useEnduragentStore((state) => state.chat.decision);
+  const chatPhase = useEnduragentStore((state) => state.chat.decisionPhase);
+  const chatAnswerLabel = useEnduragentStore((state) => state.chat.decisionAnswerLabel);
+  const chatError = useEnduragentStore((state) => state.chat.decisionError);
+  const chatLoadError = useEnduragentStore((state) => state.chat.decisionLoadError);
   const actions = useEnduragentStore((state) => state.chatActions);
+  const decision = props.surface?.decision ?? chatDecision;
+  const phase = props.surface?.phase ?? chatPhase;
+  const answerLabel = props.surface?.answerLabel ?? chatAnswerLabel;
+  const error = props.surface?.error ?? chatError;
+  const loadError = props.surface?.loadError ?? chatLoadError;
+  const available = props.surface !== undefined || actions !== null;
+  const answer = useCallback(
+    (decisionId: string, value: CoachDecisionAnswer): void => {
+      if (props.surface === undefined) actions?.answerDecision(decisionId, value);
+      else props.surface.answer(decisionId, value);
+    },
+    [actions, props.surface],
+  );
+  const skipDecision = useCallback(
+    (decisionId: string): void => {
+      if (props.surface === undefined) actions?.skipDecision(decisionId);
+      else props.surface.skip(decisionId);
+    },
+    [actions, props.surface],
+  );
+  const retryDecision = useCallback((): void => {
+    if (props.surface === undefined) actions?.retryDecision();
+    else props.surface.retry();
+  }, [actions, props.surface]);
   const [customOpen, setCustomOpen] = useState(false);
   const [customText, setCustomText] = useState("");
   const questionId = useId();
@@ -59,7 +95,7 @@ export function CoachDecisionPanel(props: {
       if (event.defaultPrevented) return;
       if (event.key === "Escape") {
         event.preventDefault();
-        actions?.skipDecision(decision.decisionId);
+        skipDecision(decision.decisionId);
         return;
       }
       if (
@@ -74,13 +110,13 @@ export function CoachDecisionPanel(props: {
       const option = displayedOptions[number - 1];
       if (option === undefined) return;
       event.preventDefault();
-      actions?.answerDecision(decision.decisionId, { kind: "option", optionId: option.id });
+      answer(decision.decisionId, { kind: "option", optionId: option.id });
     };
     document.addEventListener("keydown", onShortcut);
     return () => {
       document.removeEventListener("keydown", onShortcut);
     };
-  }, [actions, decision, displayedOptions, phase]);
+  }, [answer, decision, displayedOptions, phase, skipDecision]);
 
   if (decision === null && loadError !== null) {
     return (
@@ -95,9 +131,9 @@ export function CoachDecisionPanel(props: {
           <Button
             type="button"
             variant="outline"
-            disabled={actions === null}
+            disabled={!available}
             onClick={() => {
-              actions?.retryDecision();
+              retryDecision();
             }}
           >
             Reconnect
@@ -141,9 +177,9 @@ export function CoachDecisionPanel(props: {
               <Button
                 type="button"
                 variant="outline"
-                disabled={actions === null}
+                disabled={!available}
                 onClick={() => {
-                  actions?.retryDecision();
+                  retryDecision();
                 }}
               >
                 Try again
@@ -158,10 +194,10 @@ export function CoachDecisionPanel(props: {
   if (decision?.status !== "unanswered") return null;
 
   const skip = (): void => {
-    actions?.skipDecision(decision.decisionId);
+    skipDecision(decision.decisionId);
   };
   const choose = (optionId: string): void => {
-    actions?.answerDecision(decision.decisionId, { kind: "option", optionId });
+    answer(decision.decisionId, { kind: "option", optionId });
   };
   const onKeyDown = (event: ReactKeyboardEvent<HTMLElement>): void => {
     if (event.key === "Escape") {
@@ -209,7 +245,7 @@ export function CoachDecisionPanel(props: {
           variant="ghost"
           size="icon-sm"
           aria-label="Skip question"
-          disabled={actions === null}
+          disabled={!available}
           onClick={skip}
         >
           <X aria-hidden="true" />
@@ -247,9 +283,9 @@ export function CoachDecisionPanel(props: {
             </Button>
             <Button
               type="button"
-              disabled={!/\S/u.test(customText) || actions === null}
+              disabled={!/\S/u.test(customText) || !available}
               onClick={() => {
-                actions?.answerDecision(decision.decisionId, {
+                answer(decision.decisionId, {
                   kind: "custom",
                   text: customText.trim(),
                 });

--- a/apps/desktop-renderer/src/ui/chat/Composer.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Composer.tsx
@@ -23,6 +23,16 @@ export interface ComposerHandle {
 export function Composer(props: {
   readonly handle: RefObject<ComposerHandle | null>;
   readonly hidden?: boolean;
+  readonly surface?: {
+    readonly status: "idle" | "streaming" | "interrupted";
+    readonly sendDisabled: boolean;
+    readonly inputDisabled: boolean;
+    readonly placeholder: string;
+    readonly label: string;
+    readonly allowSlashCommands?: boolean;
+    submit(message: string): Promise<boolean>;
+    stop(): void;
+  };
 }): ReactElement {
   const form = useRef<HTMLFormElement>(null);
   const textarea = useRef<HTMLTextAreaElement>(null);
@@ -31,13 +41,20 @@ export function Composer(props: {
   const [dismissed, setDismissed] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const listboxId = useId();
-  const sendDisabled = useEnduragentStore((state) => state.chat.sendDisabled);
-  const inputDisabled = useEnduragentStore((state) => state.chat.inputDisabled);
-  const status = useEnduragentStore((state) => state.chat.status);
+  const chatSendDisabled = useEnduragentStore((state) => state.chat.sendDisabled);
+  const chatInputDisabled = useEnduragentStore((state) => state.chat.inputDisabled);
+  const chatStatus = useEnduragentStore((state) => state.chat.status);
   const actions = useEnduragentStore((state) => state.chatActions);
-  const canChat = useEnduragentStore(setupReady);
+  const chatReady = useEnduragentStore(setupReady);
+  const sendDisabled = props.surface?.sendDisabled ?? chatSendDisabled;
+  const inputDisabled = props.surface?.inputDisabled ?? chatInputDisabled;
+  const status = props.surface?.status ?? chatStatus;
+  const canChat = props.surface === undefined ? chatReady : true;
 
-  const matches = useMemo(() => filterSlashCommands(draft), [draft]);
+  const matches = useMemo(
+    () => (props.surface?.allowSlashCommands === false ? [] : filterSlashCommands(draft)),
+    [draft, props.surface?.allowSlashCommands],
+  );
   const open = matches.length > 0 && !dismissed;
   const active = selected < matches.length ? selected : 0;
 
@@ -63,12 +80,20 @@ export function Composer(props: {
 
   const submit = async (): Promise<void> => {
     const input = textarea.current;
-    if (input === null || sendDisabled || submitting || !canChat || actions === null) return;
+    if (
+      input === null ||
+      sendDisabled ||
+      submitting ||
+      !canChat ||
+      (props.surface === undefined && actions === null)
+    ) {
+      return;
+    }
     const value = input.value;
     if (!/\S/u.test(value)) return;
     setSubmitting(true);
     try {
-      const acknowledged = await actions.submit(value);
+      const acknowledged = await (props.surface?.submit(value) ?? actions!.submit(value));
       if (!acknowledged) return;
       if (input.value === value) {
         input.value = "";
@@ -145,7 +170,7 @@ export function Composer(props: {
         }}
       />
       <label className="sr-only" htmlFor="message">
-        Message your coach
+        {props.surface?.label ?? "Message your coach"}
       </label>
       <div className="chat-composer__controls grid grid-rows-[minmax(var(--ctl-h-lg),auto)_var(--ctl-h-lg)] gap-[calc(var(--inset)/2)] rounded-card border border-line-2 bg-surface pt-row pr-ctl-px pb-row pl-[calc(var(--inset)*2)] shadow-elev-2 transition-[border-color,box-shadow] duration-120 motion-reduce:transition-none focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/20">
         <textarea
@@ -153,7 +178,11 @@ export function Composer(props: {
           ref={textarea}
           className="min-h-10 max-h-[140px] w-full resize-none border-0 bg-transparent py-[3px] text-sm text-ink outline-0 placeholder:text-ink-3 focus-visible:outline-0"
           rows={2}
-          placeholder={status === "streaming" ? "Coach is responding…" : "Message your coach"}
+          placeholder={
+            status === "streaming"
+              ? "Coach is responding…"
+              : (props.surface?.placeholder ?? "Message your coach")
+          }
           disabled={inputDisabled || !canChat}
           role="combobox"
           aria-autocomplete="list"
@@ -177,9 +206,10 @@ export function Composer(props: {
               variant="default"
               size="icon-lg"
               aria-label="Stop responding"
-              disabled={actions === null}
+              disabled={props.surface === undefined && actions === null}
               onClick={() => {
-                actions?.stop();
+                if (props.surface === undefined) actions?.stop();
+                else props.surface.stop();
               }}
             >
               <Square className="size-2.5 fill-current stroke-none" aria-hidden="true" />

--- a/apps/desktop-renderer/src/ui/chat/Transcript.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Transcript.tsx
@@ -1,6 +1,10 @@
 import { Check, X } from "lucide-react";
 import type { ReactElement } from "react";
-import type { ChatChoiceView, ChatMessageView } from "../../state/chat-slice.js";
+import type {
+  ChatChoiceView,
+  ChatMessageView,
+  ChatTranscriptItemView,
+} from "../../state/chat-slice.js";
 import { cn } from "../../lib/utils.js";
 import { useEnduragentStore } from "../../state/store.js";
 import { AthleteMessage } from "./AthleteMessage.js";
@@ -8,7 +12,10 @@ import { CoachMessage } from "./CoachMessage.js";
 import { HistoryControls } from "./HistoryControls.js";
 import { StreamingMessage } from "./StreamingMessage.js";
 
-function MessageRow(props: { readonly message: ChatMessageView }): ReactElement {
+function MessageRow(props: {
+  readonly message: ChatMessageView;
+  readonly bufferedStreaming: boolean;
+}): ReactElement {
   const message = props.message;
   const streaming = message.role === "coach" && message.delivery === "streaming";
   const silent = message.historical || message.role === "athlete";
@@ -33,7 +40,7 @@ function MessageRow(props: { readonly message: ChatMessageView }): ReactElement 
       </span>
       {message.role === "athlete" ? (
         <AthleteMessage text={message.text} />
-      ) : streaming ? (
+      ) : streaming && props.bufferedStreaming ? (
         <StreamingMessage messageId={message.id} />
       ) : (
         <CoachMessage text={message.text} />
@@ -73,9 +80,14 @@ function ChoiceRow(props: { readonly choice: ChatChoiceView }): ReactElement {
   );
 }
 
-export function Transcript(): ReactElement {
-  const timeline = useEnduragentStore((state) => state.chat.timeline);
-  const messages = useEnduragentStore((state) => state.chat.messages);
+export function ConversationTranscript(props: {
+  readonly messages: readonly ChatMessageView[];
+  readonly timeline?: readonly ChatTranscriptItemView[];
+  readonly historyControls?: boolean;
+  readonly bufferedStreaming?: boolean;
+}): ReactElement {
+  const timeline = props.timeline ?? [];
+  const messages = props.messages;
   const items =
     timeline.length > 0
       ? timeline
@@ -90,13 +102,17 @@ export function Transcript(): ReactElement {
       aria-atomic="false"
       aria-label="Coach conversation"
     >
-      <HistoryControls />
+      {props.historyControls === false ? null : <HistoryControls />}
       <div className="chat-messages grid gap-7">
         {items.length === 0 ? null : (
           <div className="contents">
             {items.map((item) =>
               item.kind === "message" ? (
-                <MessageRow key={`message:${item.message.id}`} message={item.message} />
+                <MessageRow
+                  key={`message:${item.message.id}`}
+                  message={item.message}
+                  bufferedStreaming={props.bufferedStreaming ?? false}
+                />
               ) : (
                 <ChoiceRow key={`choice:${item.choice.id}`} choice={item.choice} />
               ),
@@ -106,4 +122,10 @@ export function Transcript(): ReactElement {
       </div>
     </section>
   );
+}
+
+export function Transcript(): ReactElement {
+  const timeline = useEnduragentStore((state) => state.chat.timeline);
+  const messages = useEnduragentStore((state) => state.chat.messages);
+  return <ConversationTranscript messages={messages} timeline={timeline} bufferedStreaming />;
 }

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -1,8 +1,21 @@
-import { TriangleAlert } from "lucide-react";
-import type { ReactElement } from "react";
+import { CheckCircle2, LoaderCircle, TriangleAlert } from "lucide-react";
+import { useRef, useState, type FormEvent, type ReactElement } from "react";
+import { PlanCoachProjectionDataSchema } from "@enduragent/coach-contract";
 import { Button } from "../../components/ui/button.js";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../components/ui/dialog.js";
 import { planReadModel } from "../../state/plan-slice.js";
 import { useEnduragentStore } from "../../state/store.js";
+import { CoachDecisionPanel } from "../chat/CoachDecisionPanel.js";
+import { Composer, type ComposerHandle } from "../chat/Composer.js";
+import { ConversationTranscript } from "../chat/Transcript.js";
 import { Page } from "../shared/Page.js";
 
 const SUPPORT_PAIR = "grid gap-[calc(var(--inset)/2)]";
@@ -28,7 +41,11 @@ function StatusCard(props: {
         <h2 className="m-0 text-base font-medium">{props.title}</h2>
         <p className="m-0 text-ink-2">{props.support}</p>
       </div>
-      {props.retry === true ? <div className="pt-row"><RetryButton /></div> : null}
+      {props.retry === true ? (
+        <div className="pt-row">
+          <RetryButton />
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -73,26 +90,20 @@ function NoPlan(): ReactElement {
           <div className="h-px bg-line" />
           <div className={`${SUPPORT_PAIR} py-3.5`}>
             <h3 className="m-0 text-sm font-medium">Current training</h3>
-            <p className="m-0 text-ink-2">
-              Recent workouts, recovery, and weekly availability
-            </p>
+            <p className="m-0 text-ink-2">Recent workouts, recovery, and weekly availability</p>
           </div>
           <div className="h-px bg-line" />
           <div className={`${SUPPORT_PAIR} py-3.5`}>
             <h3 className="m-0 text-sm font-medium">FTP</h3>
-            <p className="m-0 text-ink-2">
-              Athlete-entered FTP, Intervals FTP, or Intervals eFTP
-            </p>
+            <p className="m-0 text-ink-2">Athlete-entered FTP, Intervals FTP, or Intervals eFTP</p>
           </div>
         </div>
       </section>
-      {failed ? (
-        <StaleNotice message={transition.error.message} />
-      ) : null}
+      {failed ? <StaleNotice message={transition.error.message} /> : null}
       {startBlocked && startGuard.reason !== null ? (
         <StaleNotice message={startGuard.reason} />
       ) : null}
-      <div>
+      <div className="flex flex-wrap gap-inset">
         <Button
           type="button"
           disabled={actions === null || busy || startBlocked}
@@ -101,12 +112,291 @@ function NoPlan(): ReactElement {
         >
           {busy ? "Opening coach…" : "Build a plan with coach"}
         </Button>
-        {failed ? (
-          <Button type="button" variant="outline" className="ml-inset" onClick={() => actions?.retry()}>
-            Retry
-          </Button>
-        ) : null}
+        {failed ? <RetryButton /> : null}
       </div>
+    </div>
+  );
+}
+
+function PlanQueue(): ReactElement | null {
+  const queue = useEnduragentStore((state) => state.plan.coach.queued);
+  const retry = useEnduragentStore((state) => state.plan.coach.retryRequired);
+  const actions = useEnduragentStore((state) => state.planActions);
+  if (queue.length === 0) return null;
+  return (
+    <section className="overflow-hidden rounded-card bg-sunk" aria-label="Queued coach messages">
+      <div className="flex min-h-ctl items-center justify-between px-ctl-px">
+        <h3 className="m-0 text-xs font-semibold">Queued messages</h3>
+        <span className="rounded-chip bg-surface px-inset text-xs text-ink-2">{queue.length}</span>
+      </div>
+      {retry === null ? null : (
+        <div className="border-t border-line px-ctl-px py-inset">
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            disabled={actions === null}
+            onClick={() => actions?.retryQueuedCoachTurn(retry.claimId)}
+          >
+            Retry interrupted message
+          </Button>
+        </div>
+      )}
+      <ul className="m-0 list-none divide-y divide-line border-t border-line p-0">
+        {queue.map((message, index) => (
+          <li key={message.id} className="flex min-h-ctl items-center gap-inset px-ctl-px py-inset">
+            <span className="min-w-0 flex-1 break-words text-sm text-ink-2">{message.text}</span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              aria-label={`Remove queued message ${index + 1}`}
+              disabled={actions === null || retry?.queuedMessageIds.includes(message.id) === true}
+              onClick={() => actions?.removeQueuedCoachMessage(message.id)}
+            >
+              Remove
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function PlanCoach(): ReactElement {
+  const composer = useRef<ComposerHandle>(null);
+  const actions = useEnduragentStore((state) => state.planActions);
+  const coach = useEnduragentStore((state) => state.plan.coach);
+  const model = useEnduragentStore((state) => planReadModel(state.plan));
+  const transition = useEnduragentStore((state) => state.plan.transition);
+  const [customDecisionOpen, setCustomDecisionOpen] = useState(false);
+  const parsed = model === null ? null : PlanCoachProjectionDataSchema.safeParse(model.data);
+  const data = parsed?.success === true ? parsed.data : null;
+  const busy = transition.status === "submitting" || transition.status === "running";
+  const ready = data?.readyToCreateDraft === true;
+  const messages =
+    coach.messages.length > 0
+      ? coach.messages
+      : (data?.messages.map((message) => ({
+          id: message.id,
+          ...(message.turnId === null ? {} : { turnId: message.turnId }),
+          role: message.role,
+          text: message.text,
+          delivery: "complete" as const,
+          historical: false,
+        })) ?? []);
+  const decision = coach.decision ?? data?.decision ?? null;
+
+  return (
+    <section
+      className="grid gap-6 rounded-card bg-surface p-5 shadow-elev-1"
+      data-plan-scenario={model?.scenarioId}
+    >
+      {model?.scenarioId === "PL-S020" ? (
+        <div className="flex items-start gap-row text-ok" role="status">
+          <CheckCircle2 className="mt-0.5 size-4" aria-hidden="true" />
+          <div className={SUPPORT_PAIR}>
+            <h2 className="m-0 text-base font-medium text-ink">Draft discarded</h2>
+            <p className="m-0 text-ink-2">Your Plan conversation is still here.</p>
+          </div>
+        </div>
+      ) : null}
+      <ConversationTranscript
+        messages={messages}
+        timeline={coach.timeline}
+        historyControls={false}
+      />
+      <CoachDecisionPanel
+        onCustomOpenChange={setCustomDecisionOpen}
+        surface={{
+          decision,
+          phase: coach.decisionPhase,
+          answerLabel: coach.decisionAnswerLabel,
+          error: coach.decisionError,
+          loadError: coach.decisionLoadError,
+          answer: (decisionId, answer) => actions?.answerCoachDecision(decisionId, answer),
+          skip: (decisionId) => actions?.skipCoachDecision(decisionId),
+          retry: () => actions?.retry(),
+        }}
+      />
+      <PlanQueue />
+      {ready ? (
+        <section className="grid gap-row rounded-card bg-sunk p-4">
+          <div className={SUPPORT_PAIR}>
+            <h2 className="m-0 text-sm font-medium">Ready to create Draft</h2>
+            <p className="m-0 text-ink-2">
+              Goal event, availability, FTP, and course choice are ready.
+            </p>
+          </div>
+          <div className="flex flex-wrap justify-end gap-inset pt-inset">
+            <Button type="button" variant="outline" onClick={() => composer.current?.focus()}>
+              Back to coach
+            </Button>
+            <Button
+              type="button"
+              disabled={actions === null || busy}
+              onClick={() => actions?.createDraft()}
+            >
+              {data?.replacement ? "Create replacement draft" : "Create draft"}
+            </Button>
+          </div>
+        </section>
+      ) : null}
+      <Composer
+        handle={composer}
+        hidden={customDecisionOpen}
+        surface={{
+          status: coach.status,
+          sendDisabled: coach.sendDisabled,
+          inputDisabled: coach.inputDisabled || decision?.status === "unanswered",
+          placeholder: "Reply to your coach…",
+          label: "Reply to your Plan coach",
+          allowSlashCommands: false,
+          submit: (message) => actions?.submitCoach(message) ?? Promise.resolve(false),
+          stop: () => actions?.stopCoach(),
+        }}
+      />
+    </section>
+  );
+}
+
+function DraftFormation(): ReactElement {
+  const transition = useEnduragentStore((state) => state.plan.transition);
+  const revision = transition.status === "running" && transition.transitionId === "PL-T07";
+  return (
+    <section
+      className="grid place-items-center gap-row rounded-card bg-surface p-8 text-center shadow-elev-1"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <LoaderCircle
+        className="size-6 animate-spin text-primary motion-reduce:animate-none"
+        aria-hidden="true"
+      />
+      <div className={SUPPORT_PAIR}>
+        <h2 className="m-0 text-lg font-semibold">
+          {revision ? "Updating your Draft" : "Building your Draft"}
+        </h2>
+        <p className="m-0 text-ink-2">
+          {revision
+            ? "Your previous Draft stays available until this update is complete."
+            : "Your Draft opens automatically when it is ready."}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function DiscardDraftDialog(): ReactElement {
+  const open = useEnduragentStore((state) => state.plan.discardConfirmation);
+  const actions = useEnduragentStore((state) => state.planActions);
+  const cancel = useRef<HTMLButtonElement>(null);
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) actions?.closeDiscardConfirmation();
+      }}
+    >
+      <DialogContent
+        className="w-[min(460px,calc(100vw-32px))] max-w-none gap-0 p-6 shadow-elev-4 sm:max-w-none"
+        showCloseButton={false}
+        initialFocus={cancel}
+      >
+        <DialogHeader className="gap-2.5">
+          <DialogTitle className="m-0 text-xl">Discard this Draft?</DialogTitle>
+          <DialogDescription className="m-0 leading-[1.5]">
+            Only this Draft is removed. Your Plan conversation and active Plan stay.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="mx-0 mt-[22px] mb-0 flex-row justify-end border-0 bg-transparent p-0">
+          <DialogClose render={<Button ref={cancel} variant="outline" size="lg" />}>
+            Cancel
+          </DialogClose>
+          <Button
+            type="button"
+            variant="destructive-solid"
+            size="lg"
+            onClick={() => actions?.discardDraft()}
+          >
+            Discard Draft
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DraftProjection(): ReactElement {
+  const actions = useEnduragentStore((state) => state.planActions);
+  const model = useEnduragentStore((state) => planReadModel(state.plan));
+  const revisionComposer = useEnduragentStore((state) => state.plan.revisionComposer);
+  const [instruction, setInstruction] = useState("");
+  const parsed = model === null ? null : PlanCoachProjectionDataSchema.safeParse(model.data);
+  const draft = parsed?.success === true ? parsed.data.draft : null;
+  const submit = (event: FormEvent): void => {
+    event.preventDefault();
+    if (/\S/u.test(instruction)) actions?.updateDraft(instruction);
+  };
+  return (
+    <div className="grid gap-6" data-plan-scenario={model?.scenarioId}>
+      <section className="grid gap-row rounded-card bg-surface p-5 shadow-elev-1">
+        <div className={SUPPORT_PAIR}>
+          <h2 className="m-0 text-lg font-semibold">{model?.title ?? "Draft Plan"}</h2>
+          <p className="m-0 text-ink-2">{model?.summary}</p>
+        </div>
+        <div className="grid grid-cols-2 gap-inset rounded-card bg-sunk p-4">
+          <div className={SUPPORT_PAIR}>
+            <span className="text-xs text-ink-2">Revision</span>
+            <strong>{draft?.revision ?? model?.revision ?? 1}</strong>
+          </div>
+          <div className={SUPPORT_PAIR}>
+            <span className="text-xs text-ink-2">Status</span>
+            <strong>Ready for review</strong>
+          </div>
+        </div>
+        {revisionComposer ? (
+          <form className="grid gap-inset pt-row" onSubmit={submit}>
+            <label className="text-sm font-medium" htmlFor="plan-draft-revision">
+              What should the coach change?
+            </label>
+            <textarea
+              id="plan-draft-revision"
+              autoFocus
+              rows={4}
+              className="resize-y rounded-ctl border border-line-2 bg-sunk px-3 py-2 text-sm outline-none focus:border-ring focus:ring-3 focus:ring-ring/20"
+              value={instruction}
+              onChange={(event) => setInstruction(event.currentTarget.value)}
+            />
+            <div className="flex justify-end gap-inset">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => actions?.closeRevisionComposer()}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!/\S/u.test(instruction)}>
+                Update draft
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <div className="flex flex-wrap justify-end gap-inset pt-row">
+            <Button type="button" variant="outline" onClick={() => actions?.openRevisionComposer()}>
+              Back to coach
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => actions?.openDiscardConfirmation()}
+            >
+              Discard draft
+            </Button>
+          </div>
+        )}
+      </section>
+      <DiscardDraftDialog />
     </div>
   );
 }
@@ -136,8 +426,17 @@ function AttentionProjection(): ReactElement {
 
 function ReadyProjection(): ReactElement {
   const model = useEnduragentStore((state) => planReadModel(state.plan));
+  const transition = useEnduragentStore((state) => state.plan.transition);
+  if (
+    transition.status === "running" &&
+    (transition.transitionId === "PL-T06" || transition.transitionId === "PL-T07")
+  ) {
+    return <DraftFormation />;
+  }
   if (model === null) return <StatusCard title="Plan" support="Refreshing your Plan…" />;
   if (model.lifecycle === "none" || model.projection === "no-plan") return <NoPlan />;
+  if (model.projection === "coach") return <PlanCoach />;
+  if (model.projection === "draft") return <DraftProjection />;
   if (model.projection === "attention") return <AttentionProjection />;
   return (
     <StatusCard
@@ -151,14 +450,11 @@ export function PlanView(): ReactElement {
   const plan = useEnduragentStore((state) => state.plan);
   const model = planReadModel(plan);
   const loading = plan.hydration.status === "loading";
-  const subtitle =
-    loading
-      ? "Loading…"
-      : model?.lifecycle === "none"
-        ? "No active plan"
-        : plan.transition.status === "running" || plan.transition.status === "submitting"
-          ? "Working…"
-          : undefined;
+  const subtitle = loading
+    ? "Loading…"
+    : model?.lifecycle === "none"
+      ? "No active plan"
+      : undefined;
 
   return (
     <Page title="Plan" subtitle={subtitle} busy={loading} className="plan-view">

--- a/apps/desktop-renderer/tests/plan-adapter.test.ts
+++ b/apps/desktop-renderer/tests/plan-adapter.test.ts
@@ -4,17 +4,15 @@ import type {
   PlanHydrationState,
   PlanProgressEvent,
 } from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  createPlanViewAdapter,
-  type PlanBridge,
-} from "../src/state/adapters/plan.js";
+import { createPlanViewAdapter, type PlanBridge } from "../src/state/adapters/plan.js";
 import {
   EMPTY_PLAN_SURFACE,
   type PlanSurfaceState,
   type PlanTransitionState,
 } from "../src/state/plan-slice.js";
-import { PLAN_ERROR, planReadModel } from "./plan-fixtures.js";
+import { PLAN_ERROR, planCoachData, planReadModel } from "./plan-fixtures.js";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -31,11 +29,15 @@ async function settle(): Promise<void> {
   await Promise.resolve();
 }
 
-function harness(input: {
-  readonly getPlanState?: () => Promise<GetPlanStateRpcResult>;
-  readonly executePlanTransition?: PlanBridge["executePlanTransition"];
-  readonly ids?: readonly string[];
-} = {}) {
+function harness(
+  input: {
+    readonly getPlanState?: () => Promise<GetPlanStateRpcResult>;
+    readonly executePlanTransition?: PlanBridge["executePlanTransition"];
+    readonly ids?: readonly string[];
+    readonly clients?: DesktopCoachClientProvider;
+    readonly messageIds?: readonly string[];
+  } = {},
+) {
   let surface: PlanSurfaceState = EMPTY_PLAN_SURFACE;
   let progressListener: ((progress: PlanProgressEvent) => void) | null = null;
   const disposeProgress = vi.fn();
@@ -47,13 +49,12 @@ function harness(input: {
     status: "completed",
     state: planReadModel(),
   });
-  const getPlanState = vi.fn<PlanBridge["getPlanState"]>(
-    input.getPlanState ?? defaultGetPlanState,
-  );
+  const getPlanState = vi.fn<PlanBridge["getPlanState"]>(input.getPlanState ?? defaultGetPlanState);
   const executePlanTransition = vi.fn<PlanBridge["executePlanTransition"]>(
     input.executePlanTransition ?? defaultExecute,
   );
   const ids = [...(input.ids ?? ["command-1", "command-2", "command-3"])];
+  const messageIds = [...(input.messageIds ?? ["message-1", "message-2", "message-3"])];
   const adapter = createPlanViewAdapter({
     bridge: {
       getPlanState,
@@ -63,6 +64,7 @@ function harness(input: {
         return disposeProgress;
       },
     },
+    clients: input.clients,
     read: () => surface,
     publishHydration(next: PlanHydrationState) {
       const lastReady =
@@ -72,7 +74,17 @@ function harness(input: {
     publishTransition(next: PlanTransitionState) {
       surface = { ...surface, transition: next };
     },
+    publishCoach(next) {
+      surface = { ...surface, coach: next };
+    },
+    publishDiscardConfirmation(open) {
+      surface = { ...surface, discardConfirmation: open };
+    },
+    publishRevisionComposer(open) {
+      surface = { ...surface, revisionComposer: open };
+    },
     createCommandId: () => ids.shift() ?? "unexpected-command",
+    createMessageId: () => messageIds.shift() ?? "unexpected-message",
   });
   return {
     adapter,
@@ -142,7 +154,10 @@ describe("Plan view adapter", () => {
       commandId: "create-draft-command",
     });
 
-    execute.resolve({ status: "completed", state: planReadModel({ lifecycle: "intake", projection: "coach" }) });
+    execute.resolve({
+      status: "completed",
+      state: planReadModel({ lifecycle: "intake", projection: "coach" }),
+    });
     await settle();
     expect(subject.surface.transition).toEqual({ status: "idle" });
     expect(subject.surface.hydration.status).toBe("ready");
@@ -173,6 +188,299 @@ describe("Plan view adapter", () => {
       transitionId: "PL-T01",
       commandId: "retry-command",
       sourceConversationId: null,
+    });
+  });
+
+  it("streams PL-T05 inside the dedicated Plan conversation before the RPC completes", async () => {
+    const initial = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S017",
+      projection: "coach",
+      data: planCoachData(),
+    });
+    const completed = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S016",
+      projection: "coach",
+      data: planCoachData({
+        ready: true,
+        messages: [
+          { id: "intro", turnId: null, role: "coach", text: "What is your event?" },
+          { id: "athlete", turnId: "turn-1", role: "athlete", text: "Gran Fondo Almaty." },
+          { id: "coach", turnId: "turn-1", role: "coach", text: "I found your training." },
+        ],
+      }),
+    });
+    const transition = deferred<ExecutePlanTransitionRpcResult>();
+    const subject = harness({
+      ids: ["coach-command"],
+      getPlanState: async () => ({ status: "ready", state: initial }),
+      executePlanTransition: () => transition.promise,
+    });
+    subject.adapter.start();
+    await settle();
+
+    await expect(subject.adapter.submitCoach("Gran Fondo Almaty.")).resolves.toBe(true);
+    expect(subject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T05",
+      commandId: "coach-command",
+      conversationId: "00000000000000000000000001",
+      text: "Gran Fondo Almaty.",
+    });
+    subject.progress({
+      commandId: "coach-command",
+      transitionId: "PL-T05",
+      operationId: "operation-1",
+      phase: "running",
+      completed: 0,
+      total: 1,
+      turnEvent: {
+        type: "turn-start",
+        turnId: "turn-1",
+        chatId: "plan:00000000000000000000000001",
+      },
+    });
+    subject.progress({
+      commandId: "coach-command",
+      transitionId: "PL-T05",
+      operationId: "operation-1",
+      phase: "running",
+      completed: 0,
+      total: 1,
+      turnEvent: { type: "final-text", turnId: "turn-1", text: "I found your training." },
+    });
+    expect(subject.surface.coach.messages.at(-1)).toMatchObject({
+      role: "coach",
+      text: "I found your training.",
+      delivery: "streaming",
+    });
+    transition.resolve({ status: "completed", state: completed });
+    await settle();
+    expect(subject.surface.coach.status).toBe("idle");
+    expect(subject.surface.coach.messages.at(-1)).toMatchObject({
+      role: "coach",
+      text: "I found your training.",
+      delivery: "complete",
+    });
+  });
+
+  it("queues a second Plan coach message and stops only its active Plan turn", async () => {
+    const initial = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S017",
+      projection: "coach",
+      data: planCoachData(),
+    });
+    const transition = deferred<ExecutePlanTransitionRpcResult>();
+    const queue = {
+      schemaVersion: 1 as const,
+      revision: 1,
+      items: [
+        {
+          queuedMessageId: "queued-1",
+          submissionId: "message-3",
+          text: "Sunday must stay free.",
+          kind: "ordinary" as const,
+          position: 0,
+          restored: false,
+        },
+      ],
+    };
+    const call = vi.fn(async (method: string) => {
+      if (method === "enqueueChatMessage") return queue;
+      return { stopped: true };
+    });
+    const clients = {
+      getClient: async () => ({ call }),
+      reconnect: async () => ({ call }),
+      close: async () => undefined,
+    } as unknown as DesktopCoachClientProvider;
+    const subject = harness({
+      clients,
+      ids: ["coach-command"],
+      messageIds: ["message-1", "message-2", "message-3"],
+      getPlanState: async () => ({ status: "ready", state: initial }),
+      executePlanTransition: () => transition.promise,
+    });
+    subject.adapter.start();
+    await settle();
+    await subject.adapter.submitCoach("Gran Fondo Almaty.");
+    subject.progress({
+      commandId: "coach-command",
+      transitionId: "PL-T05",
+      operationId: "operation-1",
+      phase: "running",
+      completed: 0,
+      total: 1,
+      turnEvent: {
+        type: "turn-start",
+        turnId: "turn-1",
+        chatId: "plan:00000000000000000000000001",
+      },
+    });
+
+    await expect(subject.adapter.submitCoach("Sunday must stay free.")).resolves.toBe(true);
+    expect(call).toHaveBeenCalledWith("enqueueChatMessage", {
+      chatId: "plan:00000000000000000000000001",
+      submissionId: "message-3",
+      text: "Sunday must stay free.",
+    });
+    expect(subject.surface.coach.queued).toMatchObject([
+      { id: "queued-1", text: "Sunday must stay free." },
+    ]);
+
+    subject.adapter.stopCoach();
+    await settle();
+    expect(call).toHaveBeenCalledWith("stopChat", {
+      chatId: "plan:00000000000000000000000001",
+      turnId: "turn-1",
+    });
+  });
+
+  it("answers a host-owned Coach decision through the persisted Plan transition", async () => {
+    const decision = {
+      decisionId: "decision-1",
+      chatId: "plan:00000000000000000000000001",
+      messageId: "message-1",
+      question: "Which day must stay free?",
+      options: [
+        {
+          id: "option-1",
+          label: "Sunday",
+          description: "Keep Sunday free.",
+          recommended: true,
+          consequence: "Training moves earlier in the week.",
+        },
+        {
+          id: "option-2",
+          label: "Monday",
+          description: "Keep Monday free.",
+          recommended: false,
+          consequence: "Recovery moves to Monday.",
+        },
+      ],
+      status: "unanswered" as const,
+    };
+    const initial = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S017",
+      projection: "coach",
+      data: planCoachData({ decision }),
+    });
+    const subject = harness({
+      ids: ["decision-command"],
+      getPlanState: async () => ({ status: "ready", state: initial }),
+    });
+    subject.adapter.start();
+    await settle();
+
+    subject.adapter.answerCoachDecision("decision-1", { kind: "option", optionId: "option-1" });
+    await settle();
+    expect(subject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T05",
+      commandId: "decision-command",
+      conversationId: "00000000000000000000000001",
+      text: "Sunday",
+      decision: {
+        action: "answer",
+        decisionId: "decision-1",
+        answer: { kind: "option", optionId: "option-1" },
+      },
+    });
+  });
+
+  it("resumes a saved Coach choice whose continuation was pending at relaunch", async () => {
+    const decision = {
+      decisionId: "decision-1",
+      chatId: "plan:00000000000000000000000001",
+      messageId: "message-1",
+      question: "Which day must stay free?",
+      options: [
+        {
+          id: "option-1",
+          label: "Sunday",
+          description: "Keep Sunday free.",
+          recommended: true,
+          consequence: "Training moves earlier in the week.",
+        },
+        {
+          id: "option-2",
+          label: "Monday",
+          description: "Keep Monday free.",
+          recommended: false,
+          consequence: "Recovery moves to Monday.",
+        },
+      ],
+      status: "answered" as const,
+      answer: { kind: "option" as const, optionId: "option-1" },
+      consequence: "Training moves earlier in the week.",
+      continuation: { continuationId: "continuation-1", status: "pending" as const },
+    };
+    const initial = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S017",
+      projection: "coach",
+      data: planCoachData({ decision }),
+    });
+    const subject = harness({
+      ids: ["resume-command"],
+      getPlanState: async () => ({ status: "ready", state: initial }),
+    });
+
+    subject.adapter.start();
+    await settle();
+    expect(subject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T05",
+      commandId: "resume-command",
+      conversationId: "00000000000000000000000001",
+      text: "Sunday",
+      decision: { action: "resume", decisionId: "decision-1" },
+    });
+    expect(subject.surface.coach.decisionPhase).toBe("recovering");
+    expect(subject.surface.coach.decisionAnswerLabel).toBe("Sunday");
+  });
+
+  it("retries an interrupted queued Plan message through PL-T05", async () => {
+    const queue = {
+      schemaVersion: 1 as const,
+      revision: 2,
+      items: [
+        {
+          queuedMessageId: "queued-1",
+          submissionId: "submission-1",
+          text: "Keep Sunday free.",
+          kind: "ordinary" as const,
+          position: 0,
+          restored: true,
+        },
+      ],
+      retryRequired: {
+        claimId: "claim-1",
+        queuedMessageIds: ["queued-1"],
+        turnId: "turn-1",
+        status: "retry-required" as const,
+      },
+    };
+    const initial = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S017",
+      projection: "coach",
+      data: planCoachData({ queue }),
+    });
+    const subject = harness({
+      ids: ["retry-command"],
+      getPlanState: async () => ({ status: "ready", state: initial }),
+    });
+    subject.adapter.start();
+    await settle();
+
+    subject.adapter.retryQueuedCoachTurn("claim-1");
+    await settle();
+    expect(subject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T05",
+      commandId: "retry-command",
+      conversationId: "00000000000000000000000001",
+      text: "Keep Sunday free.",
     });
   });
 
@@ -227,7 +535,11 @@ describe("Plan view adapter", () => {
     const state = planReadModel({ lifecycle: "intake", projection: "coach" });
     const subject = harness({
       ids: ["command-1"],
-      executePlanTransition: async () => ({ status: "accepted", operationId: "operation-1", state }),
+      executePlanTransition: async () => ({
+        status: "accepted",
+        operationId: "operation-1",
+        state,
+      }),
     });
     subject.adapter.start();
     await settle();

--- a/apps/desktop-renderer/tests/plan-fixtures.ts
+++ b/apps/desktop-renderer/tests/plan-fixtures.ts
@@ -1,5 +1,8 @@
 import type {
+  ChatQueueSnapshot,
+  CoachDecisionReadModel,
   PlanAttention,
+  PlanDraftProjection,
   PlanError,
   PlanProjectionKind,
   PlanReadModel,
@@ -26,21 +29,25 @@ export function planAttention(count = 0): PlanAttention {
   };
 }
 
-export function planReadModel(input: {
-  readonly attentionCount?: number;
-  readonly projection?: PlanProjectionKind;
-  readonly lifecycle?: PlanReadModel["lifecycle"];
-  readonly scenarioId?: PlanReadModel["scenarioId"];
-  readonly planId?: string | null;
-  readonly title?: string;
-  readonly summary?: string;
-} = {}): PlanReadModel {
+export function planReadModel(
+  input: {
+    readonly attentionCount?: number;
+    readonly projection?: PlanProjectionKind;
+    readonly lifecycle?: PlanReadModel["lifecycle"];
+    readonly scenarioId?: PlanReadModel["scenarioId"];
+    readonly planId?: string | null;
+    readonly title?: string;
+    readonly summary?: string;
+    readonly revision?: number;
+    readonly data?: PlanReadModel["data"];
+  } = {},
+): PlanReadModel {
   return {
     schemaVersion: 1,
     scenarioId: input.scenarioId ?? "PL-S001",
     lifecycle: input.lifecycle ?? "none",
     planId: input.planId === undefined ? null : input.planId,
-    revision: 0,
+    revision: input.revision ?? 0,
     title: input.title ?? "",
     summary: input.summary ?? "",
     projection: input.projection ?? "no-plan",
@@ -56,6 +63,40 @@ export function planReadModel(input: {
     },
     attention: planAttention(input.attentionCount),
     activeOperation: null,
-    data: {},
+    data: input.data ?? {},
+  };
+}
+
+export function planCoachData(
+  input: {
+    readonly ready?: boolean;
+    readonly draft?: PlanDraftProjection | null;
+    readonly decision?: CoachDecisionReadModel | null;
+    readonly queue?: ChatQueueSnapshot;
+    readonly messages?: readonly {
+      readonly id: string;
+      readonly turnId: string | null;
+      readonly role: "athlete" | "coach";
+      readonly text: string;
+    }[];
+  } = {},
+): PlanReadModel["data"] {
+  return {
+    conversationId: "00000000000000000000000001",
+    chatId: "plan:00000000000000000000000001",
+    sourceConversationId: null,
+    replacement: false,
+    readyToCreateDraft: input.ready ?? false,
+    messages: input.messages?.map((message) => ({ ...message })) ?? [
+      {
+        id: "plan-intro",
+        turnId: null,
+        role: "coach",
+        text: "Let’s build this here in Plan. What event are you training toward?",
+      },
+    ],
+    queue: input.queue ?? { schemaVersion: 1, revision: 0, items: [] },
+    decision: input.decision ?? null,
+    draft: input.draft ?? null,
   };
 }

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -1,15 +1,32 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_PLAN_SURFACE, type PlanActions } from "../src/state/plan-slice.js";
 import { useEnduragentStore } from "../src/state/store.js";
 import { PlanView } from "../src/ui/plan/PlanView.js";
-import { PLAN_ERROR, planReadModel } from "./plan-fixtures.js";
+import { PLAN_ERROR, planCoachData, planReadModel } from "./plan-fixtures.js";
 
 function actions(): PlanActions {
-  return { open: vi.fn(), startPlan: vi.fn(), retry: vi.fn() };
+  return {
+    open: vi.fn(),
+    startPlan: vi.fn(),
+    submitCoach: vi.fn(async () => true),
+    stopCoach: vi.fn(),
+    removeQueuedCoachMessage: vi.fn(),
+    retryQueuedCoachTurn: vi.fn(),
+    answerCoachDecision: vi.fn(),
+    skipCoachDecision: vi.fn(),
+    createDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    openDiscardConfirmation: vi.fn(),
+    closeDiscardConfirmation: vi.fn(),
+    discardDraft: vi.fn(),
+    openRevisionComposer: vi.fn(),
+    closeRevisionComposer: vi.fn(),
+    retry: vi.fn(),
+  };
 }
 
 beforeEach(() => {
@@ -57,7 +74,9 @@ describe("Plan surface", () => {
     });
     render(<PlanView />);
 
-    expect(screen.getByRole("heading", { name: "Train toward one clear goal" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Train toward one clear goal" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("What the draft needs")).toBeInTheDocument();
     expect(screen.getByText("Goal event + Race Course")).toBeInTheDocument();
     expect(screen.getByText("Current training")).toBeInTheDocument();
@@ -85,7 +104,9 @@ describe("Plan surface", () => {
     render(<PlanView />);
 
     expect(screen.getByText(PLAN_ERROR.message)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Train toward one clear goal" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Train toward one clear goal" }),
+    ).toBeInTheDocument();
   });
 
   it("renders the server attention projection without deriving a count", () => {
@@ -107,6 +128,64 @@ describe("Plan surface", () => {
     expect(screen.getByText("2 items need your decision.")).toBeInTheDocument();
     expect(screen.getByText("Decision 1")).toBeInTheDocument();
     expect(screen.getByText("Decision 2")).toBeInTheDocument();
+  });
+
+  it("keeps the Coach interview inside Plan and offers Draft creation when ready", async () => {
+    const user = userEvent.setup();
+    const planActions = actions();
+    const state = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S016",
+      projection: "coach",
+      data: planCoachData({ ready: true }),
+    });
+    useEnduragentStore.setState({
+      plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state }, lastReady: state },
+      planActions,
+    });
+    render(<PlanView />);
+
+    expect(screen.getByRole("log", { name: "Coach conversation" })).toHaveTextContent(
+      "What event are you training toward",
+    );
+    expect(screen.getByRole("heading", { name: "Ready to create Draft" })).toBeInTheDocument();
+    const composer = screen.getByRole("combobox", { name: "Reply to your Plan coach" });
+    await user.type(composer, "Four days each week.{Enter}");
+    expect(planActions.submitCoach).toHaveBeenCalledWith("Four days each week.");
+    await user.click(screen.getByRole("button", { name: "Create draft" }));
+    expect(planActions.createDraft).toHaveBeenCalledOnce();
+  });
+
+  it("confirms Draft discard with Cancel focused before the destructive action", async () => {
+    const user = userEvent.setup();
+    const planActions = actions();
+    const draft = {
+      id: "00000000000000000000000002",
+      planId: "00000000000000000000000003",
+      revision: 1,
+      status: "ready" as const,
+      snapshot: { completeWeeks: 12 },
+    };
+    const state = planReadModel({
+      lifecycle: "draft",
+      scenarioId: "PL-S002",
+      projection: "draft",
+      planId: draft.planId,
+      revision: 1,
+      data: planCoachData({ draft }),
+    });
+    useEnduragentStore.setState({
+      plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state }, lastReady: state },
+      planActions,
+    });
+    render(<PlanView />);
+    await user.click(screen.getByRole("button", { name: "Discard draft" }));
+    expect(planActions.openDiscardConfirmation).toHaveBeenCalledOnce();
+    act(() => useEnduragentStore.getState().setPlanDiscardConfirmation(true));
+    expect(screen.getByRole("heading", { name: "Discard this Draft?" })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus());
+    await user.click(screen.getByRole("button", { name: "Discard Draft" }));
+    expect(planActions.discardDraft).toHaveBeenCalledOnce();
   });
 
   it("uses production token classes for wide, compact, Light, and Dark layouts", async () => {

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -75,7 +75,24 @@ function stubActions(): ChatActions {
 }
 
 function stubPlanActions(): PlanActions {
-  return { open: vi.fn(), startPlan: vi.fn(), retry: vi.fn() };
+  return {
+    open: vi.fn(),
+    startPlan: vi.fn(),
+    submitCoach: vi.fn(async () => true),
+    stopCoach: vi.fn(),
+    removeQueuedCoachMessage: vi.fn(),
+    retryQueuedCoachTurn: vi.fn(),
+    answerCoachDecision: vi.fn(),
+    skipCoachDecision: vi.fn(),
+    createDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    openDiscardConfirmation: vi.fn(),
+    closeDiscardConfirmation: vi.fn(),
+    discardDraft: vi.fn(),
+    openRevisionComposer: vi.fn(),
+    closeRevisionComposer: vi.fn(),
+    retry: vi.fn(),
+  };
 }
 
 function stravaDroppedActivities() {
@@ -212,7 +229,9 @@ describe("shell", () => {
     });
     await user.click(screen.getByRole("button", { name: "Plan" }));
     expect(await screen.findByRole("region", { name: "Plan" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Train toward one clear goal" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Train toward one clear goal" }),
+    ).toBeInTheDocument();
     expect(document.querySelector("div.thread")).not.toBeNull();
     const conversation = screen.getByLabelText("Coaching conversation");
     expect(conversation.closest(".hidden")).not.toBeNull();

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -40,7 +40,24 @@ function stubActions(): ChatActions {
 }
 
 function stubPlanActions(): PlanActions {
-  return { open: vi.fn(), startPlan: vi.fn(), retry: vi.fn() };
+  return {
+    open: vi.fn(),
+    startPlan: vi.fn(),
+    submitCoach: vi.fn(async () => true),
+    stopCoach: vi.fn(),
+    removeQueuedCoachMessage: vi.fn(),
+    retryQueuedCoachTurn: vi.fn(),
+    answerCoachDecision: vi.fn(),
+    skipCoachDecision: vi.fn(),
+    createDraft: vi.fn(),
+    updateDraft: vi.fn(),
+    openDiscardConfirmation: vi.fn(),
+    closeDiscardConfirmation: vi.fn(),
+    discardDraft: vi.fn(),
+    openRevisionComposer: vi.fn(),
+    closeRevisionComposer: vi.fn(),
+    retry: vi.fn(),
+  };
 }
 
 function update(patch: Partial<Parameters<typeof useEnduragentStore.setState>[0]>): void {
@@ -125,7 +142,11 @@ describe("Plan navigation attention", () => {
     { count: 1, name: "Plan, 1 item needs attention" },
     { count: 3, name: "Plan, 3 items need attention" },
   ])("shows the exact count for $count unresolved item(s)", ({ count, name }) => {
-    const readModel = planReadModel({ attentionCount: count, lifecycle: "active", planId: "plan-1" });
+    const readModel = planReadModel({
+      attentionCount: count,
+      lifecycle: "active",
+      planId: "plan-1",
+    });
     update({
       plan: {
         ...EMPTY_PLAN_SURFACE,

--- a/packages/coach-contract/src/planning.ts
+++ b/packages/coach-contract/src/planning.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
+import { ChatQueueSnapshotSchema } from "./chat-queue.js";
+import { CoachDecisionAnswerSchema, CoachDecisionReadModelSchema } from "./coach-decision.js";
 import { PlatformAbsolutePathSchema } from "./platform-path.js";
 import { TrainingExportCivilDateSchema } from "./training-export.js";
+import { TurnEventSchema } from "./turn-event.js";
 
 export const PLAN_TRANSITION_IDS = [
   "PL-T01",
@@ -47,9 +50,7 @@ export const PLAN_TRANSITION_IDS = [
 export const PlanTransitionIdSchema = z.enum(PLAN_TRANSITION_IDS);
 export type PlanTransitionId = z.infer<typeof PlanTransitionIdSchema>;
 
-export const PlanScenarioIdSchema = z
-  .string()
-  .regex(/^PL-S(?:00[1-9]|0[1-9][0-9]|10[0-5])$/);
+export const PlanScenarioIdSchema = z.string().regex(/^PL-S(?:00[1-9]|0[1-9][0-9]|10[0-5])$/);
 export type PlanScenarioId = z.infer<typeof PlanScenarioIdSchema>;
 
 export const PlanLifecycleSchema = z.enum([
@@ -181,10 +182,7 @@ export const PlanReconciliationSchema = z
         message: "failed reconciliation requires an error and other states forbid one",
       });
     }
-    if (
-      value.status === "not-applicable" &&
-      (value.total !== 0 || value.currentThrough !== null)
-    ) {
+    if (value.status === "not-applicable" && (value.total !== 0 || value.currentThrough !== null)) {
       context.addIssue({
         code: "custom",
         path: ["status"],
@@ -212,6 +210,7 @@ export const PlanProgressEventSchema = z
     phase: z.enum(["queued", "running", "completed", "failed"]),
     completed: z.number().int().nonnegative(),
     total: z.number().int().positive(),
+    turnEvent: TurnEventSchema.optional(),
   })
   .strict()
   .superRefine((value, context) => {
@@ -236,8 +235,51 @@ export const PlanProgressEventSchema = z
         message: "completed progress reaches total",
       });
     }
+    if (value.turnEvent !== undefined && value.phase !== "running") {
+      context.addIssue({
+        code: "custom",
+        path: ["turnEvent"],
+        message: "coach turn events require running progress",
+      });
+    }
   });
 export type PlanProgressEvent = z.infer<typeof PlanProgressEventSchema>;
+
+export const PlanCoachMessageSchema = z
+  .object({
+    id: z.string().min(1),
+    turnId: z.string().min(1).nullable(),
+    role: z.enum(["athlete", "coach"]),
+    text: z.string(),
+  })
+  .strict();
+export type PlanCoachMessage = z.infer<typeof PlanCoachMessageSchema>;
+
+export const PlanDraftProjectionSchema = z
+  .object({
+    id: z.string().min(1),
+    planId: z.string().min(1),
+    revision: z.number().int().positive(),
+    status: z.enum(["forming", "ready", "failed", "discarded", "approved"]),
+    snapshot: z.json(),
+  })
+  .strict();
+export type PlanDraftProjection = z.infer<typeof PlanDraftProjectionSchema>;
+
+export const PlanCoachProjectionDataSchema = z
+  .object({
+    conversationId: z.string().min(1),
+    chatId: z.string().min(1),
+    sourceConversationId: z.string().min(1).nullable(),
+    replacement: z.boolean(),
+    readyToCreateDraft: z.boolean(),
+    messages: z.array(PlanCoachMessageSchema),
+    queue: ChatQueueSnapshotSchema,
+    decision: CoachDecisionReadModelSchema.nullable(),
+    draft: PlanDraftProjectionSchema.nullable(),
+  })
+  .strict();
+export type PlanCoachProjectionData = z.infer<typeof PlanCoachProjectionDataSchema>;
 
 export const PlanReadModelSchema = z
   .object({
@@ -338,6 +380,19 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
       commandId: CommandIdSchema,
       conversationId: EntityIdSchema,
       text: z.string().trim().min(1),
+      decision: z
+        .discriminatedUnion("action", [
+          z
+            .object({
+              action: z.literal("answer"),
+              decisionId: EntityIdSchema,
+              answer: CoachDecisionAnswerSchema,
+            })
+            .strict(),
+          z.object({ action: z.literal("skip"), decisionId: EntityIdSchema }).strict(),
+          z.object({ action: z.literal("resume"), decisionId: EntityIdSchema }).strict(),
+        ])
+        .optional(),
     })
     .strict(),
   z
@@ -375,7 +430,11 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
     })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T10"), commandId: CommandIdSchema, draftId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T10"),
+      commandId: CommandIdSchema,
+      draftId: EntityIdSchema,
+    })
     .strict(),
   z
     .object({
@@ -386,7 +445,11 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
     })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T12"), commandId: CommandIdSchema, planId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T12"),
+      commandId: CommandIdSchema,
+      planId: EntityIdSchema,
+    })
     .strict(),
   z
     .object({
@@ -448,7 +511,11 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
     })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T20"), commandId: CommandIdSchema, proposalId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T20"),
+      commandId: CommandIdSchema,
+      proposalId: EntityIdSchema,
+    })
     .strict(),
   z
     .object({
@@ -468,13 +535,25 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
     })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T23"), commandId: CommandIdSchema, planId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T23"),
+      commandId: CommandIdSchema,
+      planId: EntityIdSchema,
+    })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T24"), commandId: CommandIdSchema, planId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T24"),
+      commandId: CommandIdSchema,
+      planId: EntityIdSchema,
+    })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T25"), commandId: CommandIdSchema, planId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T25"),
+      commandId: CommandIdSchema,
+      planId: EntityIdSchema,
+    })
     .strict(),
   z
     .object({
@@ -494,7 +573,11 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
     })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T28"), commandId: CommandIdSchema, planId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T28"),
+      commandId: CommandIdSchema,
+      planId: EntityIdSchema,
+    })
     .strict(),
   z
     .object({
@@ -513,16 +596,32 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
     })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T31"), commandId: CommandIdSchema, planId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T31"),
+      commandId: CommandIdSchema,
+      planId: EntityIdSchema,
+    })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T32"), commandId: CommandIdSchema, planId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T32"),
+      commandId: CommandIdSchema,
+      planId: EntityIdSchema,
+    })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T33"), commandId: CommandIdSchema, planId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T33"),
+      commandId: CommandIdSchema,
+      planId: EntityIdSchema,
+    })
     .strict(),
   z
-    .object({ transitionId: z.literal("PL-T34"), commandId: CommandIdSchema, attentionId: EntityIdSchema })
+    .object({
+      transitionId: z.literal("PL-T34"),
+      commandId: CommandIdSchema,
+      attentionId: EntityIdSchema,
+    })
     .strict(),
   z
     .object({
@@ -591,9 +690,7 @@ export const GetPlanStateRpcResultSchema = z.discriminatedUnion("status", [
 export type GetPlanStateRpcResult = z.infer<typeof GetPlanStateRpcResultSchema>;
 
 export const ExecutePlanTransitionRpcParamsSchema = PlanTransitionCommandSchema;
-export type ExecutePlanTransitionRpcParams = z.infer<
-  typeof ExecutePlanTransitionRpcParamsSchema
->;
+export type ExecutePlanTransitionRpcParams = z.infer<typeof ExecutePlanTransitionRpcParamsSchema>;
 
 export const ExecutePlanTransitionRpcResultSchema = z.discriminatedUnion("status", [
   z.object({ status: z.literal("completed"), state: PlanReadModelSchema }).strict(),
@@ -613,9 +710,7 @@ export const ExecutePlanTransitionRpcResultSchema = z.discriminatedUnion("status
     .strict(),
   UnsupportedPlanningCapabilitySchema,
 ]);
-export type ExecutePlanTransitionRpcResult = z.infer<
-  typeof ExecutePlanTransitionRpcResultSchema
->;
+export type ExecutePlanTransitionRpcResult = z.infer<typeof ExecutePlanTransitionRpcResultSchema>;
 
 export interface PlanningOperations {
   getPlanState?(request: GetPlanStateRpcParams): Promise<GetPlanStateRpcResult>;

--- a/packages/coach-contract/tests/planning.test.ts
+++ b/packages/coach-contract/tests/planning.test.ts
@@ -124,15 +124,19 @@ describe("planning contract", () => {
   });
 
   it("accepts one strict command for every lifecycle transition", () => {
-    expect(commands.map((command) => PlanTransitionCommandSchema.parse(command).transitionId)).toEqual(
-      PLAN_TRANSITION_IDS,
-    );
+    expect(
+      commands.map((command) => PlanTransitionCommandSchema.parse(command).transitionId),
+    ).toEqual(PLAN_TRANSITION_IDS);
   });
 
   it("rejects missing, extra, and transition-specific command fields", () => {
     expect(
-      PlanTransitionCommandSchema.safeParse({ transitionId: "PL-T12", commandId, planId, extra: true })
-        .success,
+      PlanTransitionCommandSchema.safeParse({
+        transitionId: "PL-T12",
+        commandId,
+        planId,
+        extra: true,
+      }).success,
     ).toBe(false);
     expect(
       PlanTransitionCommandSchema.safeParse({ transitionId: "PL-T08", commandId, draftId }).success,
@@ -178,12 +182,12 @@ describe("planning contract", () => {
       priority: "dated",
       affectedDate: "1998-08-23",
     };
-    expect(PlanAttentionSchema.safeParse({ count: 1, destination: "direct", items: [item] }).success).toBe(
-      true,
-    );
-    expect(PlanAttentionSchema.safeParse({ count: 1, destination: "list", items: [item] }).success).toBe(
-      false,
-    );
+    expect(
+      PlanAttentionSchema.safeParse({ count: 1, destination: "direct", items: [item] }).success,
+    ).toBe(true);
+    expect(
+      PlanAttentionSchema.safeParse({ count: 1, destination: "list", items: [item] }).success,
+    ).toBe(false);
   });
 
   it("keeps loading, stale, failed, and unsupported hydration explicit", () => {
@@ -194,12 +198,11 @@ describe("planning contract", () => {
         capability: "planning",
       }),
     ).toEqual({ status: "unsupported-capability", capability: "planning" });
-    expect(
-      GetPlanStateRpcResultSchema.parse({ status: "ready", state }),
-    ).toEqual({ status: "ready", state });
-    expect(
-      GetPlanStateRpcResultSchema.safeParse({ status: "failed" }).success,
-    ).toBe(false);
+    expect(GetPlanStateRpcResultSchema.parse({ status: "ready", state })).toEqual({
+      status: "ready",
+      state,
+    });
+    expect(GetPlanStateRpcResultSchema.safeParse({ status: "failed" }).success).toBe(false);
   });
 
   it("validates transition progress and terminal results", () => {
@@ -213,8 +216,45 @@ describe("planning contract", () => {
     };
     expect(PlanProgressEventSchema.parse(progress)).toEqual(progress);
     expect(PlanProgressEventSchema.safeParse({ ...progress, completed: 6 }).success).toBe(false);
+    const running = {
+      ...progress,
+      transitionId: "PL-T05" as const,
+      phase: "running" as const,
+      completed: 0,
+      turnEvent: {
+        type: "turn-start" as const,
+        turnId: "turn-1",
+        chatId: "plan:00000000000000000000000001",
+      },
+    };
+    expect(PlanProgressEventSchema.parse(running)).toEqual(running);
     expect(
-      ExecutePlanTransitionRpcResultSchema.parse({ status: "completed", state }),
-    ).toEqual({ status: "completed", state });
+      PlanProgressEventSchema.safeParse({ ...running, phase: "completed", completed: 1 }).success,
+    ).toBe(false);
+    expect(ExecutePlanTransitionRpcResultSchema.parse({ status: "completed", state })).toEqual({
+      status: "completed",
+      state,
+    });
+  });
+
+  it("keeps Plan coach decisions inside PL-T05", () => {
+    const decision = {
+      transitionId: "PL-T05" as const,
+      commandId,
+      conversationId,
+      text: "Keep Saturday available",
+      decision: {
+        action: "answer" as const,
+        decisionId: "decision-1",
+        answer: { kind: "option" as const, optionId: "option-1" },
+      },
+    };
+    expect(PlanTransitionCommandSchema.parse(decision)).toEqual(decision);
+    expect(
+      PlanTransitionCommandSchema.safeParse({
+        ...decision,
+        decision: { action: "answer", decisionId: "decision-1" },
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -149,6 +149,7 @@ import {
   createProviderActivityPowerHeartRateReader,
 } from "./activity-power-heart-rate.js";
 import { createTrainingExportService } from "./training-export.js";
+import { createPlanningOperations } from "./planning-operations.js";
 import { serializeBoundaryError } from "./daemon/error-boundary.js";
 
 interface OAuthCredential extends StoredProfile {
@@ -1454,6 +1455,11 @@ export async function createLocalCoachComposition(
       credentials: options.liveIntervals,
       sources: trustedActivitySources,
     });
+    const planningOperations = createPlanningOperations({
+      context: input.context,
+      engine: reconfigurable.engine,
+      identity: planningIdentity,
+    });
     const operations = {
       ...createCoachOperations(
         {
@@ -1483,6 +1489,7 @@ export async function createLocalCoachComposition(
       getActivityAnalysis: (request, signal) =>
         activityAnalysis.getActivityAnalysis(request, signal),
       exportTrainingFile: (request, signal) => trainingExport.export(request, signal),
+      ...planningOperations,
     } satisfies CoachOperations;
     return {
       engine: reconfigurable.engine,

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -527,6 +527,21 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "executePlanTransition",
 ]);
 
+const PLAN_CHAT_RENDERER_METHODS = new Set<CoachRpcMethodName>([
+  "stopChat",
+  "enqueueChatMessage",
+  "getChatQueue",
+  "removeQueuedChatMessage",
+  "resumeChatQueue",
+  "runQueuedCommand",
+  "retryQueuedTurn",
+]);
+
+function rendererChatIdAllowed(method: CoachRpcMethodName, chatId: string): boolean {
+  if (chatId === "desktop") return true;
+  return PLAN_CHAT_RENDERER_METHODS.has(method) && /^plan:[0-9A-HJKMNP-TV-Z]{26}$/u.test(chatId);
+}
+
 function generateRendererCapability(
   privilegedToken: string,
   generateBytes: (size: number) => Buffer,
@@ -886,7 +901,7 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
       const chatId = (params.data as { readonly chatId: string }).chatId;
       if (
         chatId.startsWith("telegram:") ||
-        (state.authority === "renderer" && chatId !== "desktop")
+        (state.authority === "renderer" && !rendererChatIdAllowed(generic.data.method, chatId))
       ) {
         void enqueueSerialized(state, ordinaryError(generic.data.id, -32602, "Invalid params"));
         return;
@@ -1571,39 +1586,43 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               if (input.operations.executePlanTransition) {
                 let operationResult: unknown;
                 try {
-                  operationResult = await input.operations.executePlanTransition(request, (event) => {
-                    if (!progressOpen || eventFailure !== undefined) return;
-                    try {
-                      const parsedEvent =
-                        COACH_RPC_METHOD_REGISTRY.executePlanTransition.eventSchema.parse(event);
-                      if (
-                        parsedEvent.commandId !== request.commandId ||
-                        parsedEvent.transitionId !== request.transitionId ||
-                        (operationId !== undefined && parsedEvent.operationId !== operationId)
-                      ) {
-                        throw new Error("Planning progress correlation mismatch");
+                  operationResult = await input.operations.executePlanTransition(
+                    request,
+                    (event) => {
+                      if (!progressOpen || eventFailure !== undefined) return;
+                      try {
+                        const parsedEvent =
+                          COACH_RPC_METHOD_REGISTRY.executePlanTransition.eventSchema.parse(event);
+                        if (
+                          parsedEvent.commandId !== request.commandId ||
+                          parsedEvent.transitionId !== request.transitionId ||
+                          (operationId !== undefined && parsedEvent.operationId !== operationId)
+                        ) {
+                          throw new Error("Planning progress correlation mismatch");
+                        }
+                        operationId = parsedEvent.operationId;
+                        const notification = CoachPlanProgressNotificationEnvelopeSchema.parse({
+                          jsonrpc: "2.0",
+                          method: "coach.planProgress",
+                          params: {
+                            requestId: generic.data.id,
+                            requestMethod: "executePlanTransition",
+                            event: parsedEvent,
+                          },
+                        });
+                        void enqueueSerialized(state, serializeCoachRpcEnvelope(notification));
+                      } catch (error) {
+                        eventFailure = { error };
                       }
-                      operationId = parsedEvent.operationId;
-                      const notification = CoachPlanProgressNotificationEnvelopeSchema.parse({
-                        jsonrpc: "2.0",
-                        method: "coach.planProgress",
-                        params: {
-                          requestId: generic.data.id,
-                          requestMethod: "executePlanTransition",
-                          event: parsedEvent,
-                        },
-                      });
-                      void enqueueSerialized(state, serializeCoachRpcEnvelope(notification));
-                    } catch (error) {
-                      eventFailure = { error };
-                    }
-                  });
+                    },
+                  );
                 } finally {
                   progressOpen = false;
                 }
-                const parsedResult = COACH_RPC_METHOD_REGISTRY.executePlanTransition.responseSchema.parse(
-                  operationResult,
-                );
+                const parsedResult =
+                  COACH_RPC_METHOD_REGISTRY.executePlanTransition.responseSchema.parse(
+                    operationResult,
+                  );
                 if (
                   parsedResult.status === "accepted" &&
                   operationId !== undefined &&

--- a/packages/coach/src/planning-lifecycle.ts
+++ b/packages/coach/src/planning-lifecycle.ts
@@ -1,0 +1,218 @@
+import {
+  PlanCoachProjectionDataSchema,
+  PlanReadModelSchema,
+  type ChatQueueSnapshot,
+  type CoachDecisionReadModel,
+  type PlanAttention,
+  type PlanCoachMessage,
+  type PlanDraftProjection,
+  type PlanLifecycle,
+  type PlanProjectionKind,
+  type PlanReadModel,
+  type PlanScenarioId,
+  type PlanTransitionGuard,
+} from "@enduragent/coach-contract";
+
+export interface PlanConversationProjection {
+  readonly id: string;
+  readonly planId: string | null;
+  readonly replacesPlanId: string | null;
+  readonly sourceConversationId: string | null;
+}
+
+export interface PlanConversationTurnProjection {
+  readonly id: string;
+  readonly athleteText: string;
+  readonly coachText: string;
+}
+
+export interface BuildPlanLifecycleReadModelInput {
+  readonly conversation: PlanConversationProjection | null;
+  readonly turns: readonly PlanConversationTurnProjection[];
+  readonly readyToCreateDraft: boolean;
+  readonly queue: ChatQueueSnapshot;
+  readonly decision: CoachDecisionReadModel | null;
+  readonly draft: PlanDraftProjection | null;
+}
+
+const EMPTY_ATTENTION: PlanAttention = Object.freeze({
+  count: 0,
+  destination: "none",
+  items: [],
+});
+
+const EMPTY_RECONCILIATION = Object.freeze({
+  status: "not-applicable" as const,
+  created: 0,
+  pending: 0,
+  failed: 0,
+  total: 0,
+  currentThrough: null,
+  error: null,
+});
+
+function guard(transitionId: PlanTransitionGuard["transitionId"]): PlanTransitionGuard {
+  return { transitionId, status: "available", reason: null };
+}
+
+function messages(
+  conversationId: string,
+  turns: readonly PlanConversationTurnProjection[],
+): readonly PlanCoachMessage[] {
+  return [
+    {
+      id: `plan-intro:${conversationId}`,
+      turnId: null,
+      role: "coach",
+      text: "Let’s build this here in Plan. What event are you training toward?",
+    },
+    ...turns.flatMap((turn) => [
+      {
+        id: `${turn.id}:athlete`,
+        turnId: turn.id,
+        role: "athlete" as const,
+        text: turn.athleteText,
+      },
+      {
+        id: `${turn.id}:coach`,
+        turnId: turn.id,
+        role: "coach" as const,
+        text: turn.coachText,
+      },
+    ]),
+  ];
+}
+
+function stateKind(input: BuildPlanLifecycleReadModelInput): {
+  readonly scenarioId: PlanScenarioId;
+  readonly lifecycle: PlanLifecycle;
+  readonly projection: PlanProjectionKind;
+  readonly title: string;
+  readonly summary: string;
+  readonly transitions: readonly PlanTransitionGuard[];
+} {
+  const conversation = input.conversation;
+  if (conversation === null) {
+    return {
+      scenarioId: "PL-S001",
+      lifecycle: "none",
+      projection: "no-plan",
+      title: "Train toward one clear goal",
+      summary: "Build a Plan with your coach.",
+      transitions: [guard("PL-T01")],
+    };
+  }
+  const replacement = conversation.replacesPlanId !== null;
+  const draft = input.draft;
+  if (draft?.status === "forming") {
+    const revision = draft.revision > 1;
+    return {
+      scenarioId: replacement ? "PL-S105" : revision ? "PL-S030" : "PL-S018",
+      lifecycle: replacement ? "replacement-draft-forming" : "draft-forming",
+      projection: "draft",
+      title: revision
+        ? "Updating your Draft"
+        : replacement
+          ? "Building your replacement Draft"
+          : "Building your Draft",
+      summary: revision
+        ? "The previous Draft stays available until this update is complete."
+        : "Your Draft opens automatically when it is ready.",
+      transitions: [],
+    };
+  }
+  if (draft?.status === "ready" || draft?.status === "failed") {
+    const revision = draft.revision > 1;
+    return {
+      scenarioId: replacement ? "PL-S080" : revision ? "PL-S031" : "PL-S002",
+      lifecycle: replacement ? "replacement-draft" : "draft",
+      projection: "draft",
+      title: replacement ? "Replacement Draft" : revision ? "Draft updated" : "Draft Plan",
+      summary:
+        draft.status === "failed"
+          ? "The previous Draft is still available. Try the update again."
+          : "Review the Draft before anything writes to your calendar.",
+      transitions: [
+        guard("PL-T07"),
+        guard("PL-T08"),
+        guard("PL-T09"),
+        guard("PL-T10"),
+        guard("PL-T11"),
+      ],
+    };
+  }
+  const discarded = draft?.status === "discarded";
+  const ready = input.readyToCreateDraft && !discarded;
+  return {
+    scenarioId: discarded
+      ? "PL-S020"
+      : replacement
+        ? ready
+          ? "PL-S103"
+          : "PL-S079"
+        : ready
+          ? "PL-S016"
+          : "PL-S017",
+    lifecycle: replacement ? "replacement-intake" : "intake",
+    projection: "coach",
+    title: discarded ? "Draft discarded" : ready ? "Ready to create Draft" : "Plan coach",
+    summary: discarded
+      ? "Your Plan conversation is still here."
+      : ready
+        ? "The coach has enough information to build your Draft."
+        : "Tell your coach what you are training toward.",
+    transitions: ready
+      ? [guard("PL-T02"), guard("PL-T03"), guard("PL-T04"), guard("PL-T05"), guard("PL-T06")]
+      : [guard("PL-T02"), guard("PL-T03"), guard("PL-T04"), guard("PL-T05")],
+  };
+}
+
+export function buildPlanLifecycleReadModel(
+  input: BuildPlanLifecycleReadModelInput,
+): PlanReadModel {
+  const kind = stateKind(input);
+  if (input.conversation === null) {
+    return PlanReadModelSchema.parse({
+      schemaVersion: 1,
+      scenarioId: kind.scenarioId,
+      lifecycle: kind.lifecycle,
+      planId: null,
+      revision: 0,
+      title: kind.title,
+      summary: kind.summary,
+      projection: kind.projection,
+      transitions: kind.transitions,
+      reconciliation: EMPTY_RECONCILIATION,
+      attention: EMPTY_ATTENTION,
+      activeOperation: null,
+      data: {},
+    });
+  }
+  const conversation = input.conversation;
+  const data = PlanCoachProjectionDataSchema.parse({
+    conversationId: conversation.id,
+    chatId: `plan:${conversation.id}`,
+    sourceConversationId: conversation.sourceConversationId,
+    replacement: conversation.replacesPlanId !== null,
+    readyToCreateDraft: input.readyToCreateDraft,
+    messages: messages(conversation.id, input.turns),
+    queue: input.queue,
+    decision: input.decision,
+    draft: input.draft,
+  });
+  return PlanReadModelSchema.parse({
+    schemaVersion: 1,
+    scenarioId: kind.scenarioId,
+    lifecycle: kind.lifecycle,
+    planId: input.draft?.planId ?? conversation.planId,
+    revision: input.draft?.revision ?? 0,
+    title: kind.title,
+    summary: kind.summary,
+    projection: kind.projection,
+    transitions: kind.transitions,
+    reconciliation: EMPTY_RECONCILIATION,
+    attention: EMPTY_ATTENTION,
+    activeOperation: null,
+    data,
+  });
+}

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -1,0 +1,524 @@
+import {
+  ExecutePlanTransitionRpcParamsSchema,
+  ExecutePlanTransitionRpcResultSchema,
+  GetPlanStateRpcParamsSchema,
+  GetPlanStateRpcResultSchema,
+  PlanDraftProjectionSchema,
+  PlanProgressEventSchema,
+  type ChatQueueRunResult,
+  type ChatQueueSnapshot,
+  type CoachEngine,
+  type ExecutePlanTransitionRpcParams,
+  type ExecutePlanTransitionRpcResult,
+  type PlanDraftProjection,
+  type PlanError,
+  type PlanProgressEvent,
+  type PlanReadModel,
+  type PlanningOperations,
+  type TurnEvent,
+} from "@enduragent/coach-contract";
+import { buildPlanLifecycleReadModel } from "./planning-lifecycle.js";
+import {
+  createPlanConversationRepository,
+  createPlanRepository,
+  type PlanConversationRecord,
+  type PlanConversationRepository,
+  type PlanConversationTurnRecord,
+  type PlanDraftRevisionRecord,
+  type PlanRecord,
+  type PlanRepository,
+  type PlanWorkoutRecord,
+} from "@enduragent/kernel/planning";
+import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+import type { CoachStoreWriterContext } from "./runtime.js";
+
+const EMPTY_QUEUE: ChatQueueSnapshot = Object.freeze({
+  schemaVersion: 1,
+  revision: 0,
+  items: [],
+});
+
+const UNAVAILABLE: PlanError = Object.freeze({
+  code: "unavailable",
+  message: "This Plan action is not available yet.",
+  retryable: true,
+});
+
+const PROVIDER_FAILED: PlanError = Object.freeze({
+  code: "provider-failed",
+  message: "The coach couldn’t respond. Try again.",
+  retryable: true,
+});
+
+const PERSISTENCE_FAILED: PlanError = Object.freeze({
+  code: "persistence-failed",
+  message: "The Plan couldn’t save that change. Try again.",
+  retryable: true,
+});
+
+export interface PlanDraftBuild {
+  readonly plan: PlanRecord;
+  readonly workouts: readonly PlanWorkoutRecord[];
+  readonly snapshot: unknown;
+}
+
+export interface PlanDraftBuilder {
+  form(input: {
+    readonly conversation: PlanConversationRecord;
+    readonly turns: readonly PlanConversationTurnRecord[];
+  }): Promise<PlanDraftBuild>;
+  revise(input: {
+    readonly conversation: PlanConversationRecord;
+    readonly turns: readonly PlanConversationTurnRecord[];
+    readonly previous: PlanDraftRevisionRecord;
+    readonly instruction: string;
+  }): Promise<PlanDraftBuild>;
+}
+
+export interface PlanReadinessInput {
+  readonly conversation: PlanConversationRecord;
+  readonly turns: readonly PlanConversationTurnRecord[];
+  readonly draft: PlanDraftRevisionRecord | undefined;
+}
+
+export interface CreatePlanningOperationsDependencies {
+  readonly conversations?: PlanConversationRepository;
+  readonly plans?: PlanRepository;
+  readonly draftBuilder?: PlanDraftBuilder;
+  readonly isReady?: (input: PlanReadinessInput) => boolean | Promise<boolean>;
+}
+
+function createSerializedLane(): <T>(operation: () => Promise<T>) => Promise<T> {
+  let tail = Promise.resolve();
+  return <T>(operation: () => Promise<T>): Promise<T> => {
+    const task = tail.then(operation, operation);
+    tail = task.then(
+      () => undefined,
+      () => undefined,
+    );
+    return task;
+  };
+}
+
+function snapshot(value: string): unknown {
+  return JSON.parse(value) as unknown;
+}
+
+function draftProjection(value: PlanDraftRevisionRecord | undefined): PlanDraftProjection | null {
+  if (value === undefined) return null;
+  return PlanDraftProjectionSchema.parse({
+    id: value.id,
+    planId: value.planId,
+    revision: value.revision,
+    status: value.status,
+    snapshot: snapshot(value.snapshotJson),
+  });
+}
+
+function queueText(queue: ChatQueueSnapshot): string {
+  const head = queue.items[0];
+  if (head === undefined) return "";
+  if (queue.retryRequired !== undefined) {
+    return queue.items
+      .slice(0, queue.retryRequired.queuedMessageIds.length)
+      .map((item) => item.text)
+      .join("\n\n");
+  }
+  if (head.kind === "slash-command") return head.text;
+  let size = 1;
+  while (queue.items[size]?.kind === "ordinary") size += 1;
+  return queue.items
+    .slice(0, size)
+    .map((item) => item.text)
+    .join("\n\n");
+}
+
+export function createPlanningOperations(
+  input: {
+    readonly context: CoachStoreWriterContext;
+    readonly engine: CoachEngine;
+    readonly identity: AuthoredIdentity;
+  },
+  dependencies: CreatePlanningOperationsDependencies = {},
+): PlanningOperations {
+  const conversations =
+    dependencies.conversations ?? createPlanConversationRepository(input.context.store);
+  const plans = dependencies.plans ?? createPlanRepository(input.context.store);
+  const enqueue = createSerializedLane();
+
+  const read = async (): Promise<PlanReadModel> => {
+    const conversation = await conversations.readLatestOpenConversation();
+    if (conversation === undefined) {
+      return buildPlanLifecycleReadModel({
+        conversation: null,
+        turns: [],
+        readyToCreateDraft: false,
+        queue: EMPTY_QUEUE,
+        decision: null,
+        draft: null,
+      });
+    }
+    const chatId = `plan:${conversation.id}`;
+    const [turns, draft, queue, decision] = await Promise.all([
+      conversations.readTurns(conversation.id),
+      conversations.readLatestDraftRevision(conversation.id),
+      input.engine.getChatQueue?.({ chatId }).catch(() => EMPTY_QUEUE) ?? EMPTY_QUEUE,
+      input.engine
+        .getCoachDecision({ chatId })
+        .then((result) => result.decision)
+        .catch(() => null),
+    ]);
+    const ready = await (dependencies.isReady?.({ conversation, turns, draft }) ??
+      Promise.resolve(false));
+    return buildPlanLifecycleReadModel({
+      conversation: {
+        id: conversation.id,
+        planId: conversation.planId,
+        replacesPlanId: conversation.replacesPlanId,
+        sourceConversationId: null,
+      },
+      turns,
+      readyToCreateDraft: ready,
+      queue,
+      decision,
+      draft: draftProjection(draft),
+    });
+  };
+
+  const deliver = (
+    onEvent: ((event: PlanProgressEvent) => void) | undefined,
+    event: PlanProgressEvent,
+  ): void => {
+    const parsed = PlanProgressEventSchema.parse(event);
+    try {
+      onEvent?.(parsed);
+    } catch {}
+  };
+
+  const appendTurn = async (
+    conversationId: string,
+    athleteText: string,
+    coachText: string,
+    engineTurnId: string | null,
+  ): Promise<void> => {
+    if (!/\S/u.test(coachText) || engineTurnId === null) return;
+    const existing = await conversations.readTurns(conversationId);
+    if (
+      existing.some((turn) => {
+        const lineage = snapshot(turn.lineageJson) as { readonly engineTurnId?: unknown };
+        return lineage.engineTurnId === engineTurnId;
+      })
+    ) {
+      return;
+    }
+    const stamp = input.identity.hlcStamp();
+    await conversations.appendTurn({
+      id: input.identity.newUlid(),
+      conversationId,
+      sequence: existing.length + 1,
+      athleteText,
+      coachText,
+      lineageJson: JSON.stringify({ engineTurnId }),
+      completedAtMs: stamp.physicalMs,
+      deviceId: await input.identity.deviceId(),
+      hlcPhysicalMs: stamp.physicalMs,
+      hlcCounter: stamp.counter,
+    });
+  };
+
+  const executeCoachCall = async (
+    command: Extract<ExecutePlanTransitionRpcParams, { transitionId: "PL-T05" }>,
+    operationId: string,
+    onEvent: ((event: PlanProgressEvent) => void) | undefined,
+  ): Promise<void> => {
+    const conversation = await conversations.readConversation(command.conversationId);
+    if (conversation === undefined || conversation.status !== "open") throw UNAVAILABLE;
+    const chatId = `plan:${conversation.id}`;
+    const forward = (event: TurnEvent): void => {
+      deliver(onEvent, {
+        commandId: command.commandId,
+        transitionId: command.transitionId,
+        operationId,
+        phase: "running",
+        completed: 0,
+        total: 1,
+        turnEvent: event,
+      });
+    };
+    let pendingText = command.text;
+    let queue = await (input.engine.getChatQueue?.({ chatId }) ?? Promise.resolve(EMPTY_QUEUE));
+    if (command.decision !== undefined) {
+      let turnId: string | null = null;
+      const onTurnEvent = (event: TurnEvent): void => {
+        if (event.type === "turn-start") turnId = event.turnId;
+        forward(event);
+      };
+      if (command.decision.action === "skip") {
+        await input.engine.skipCoachDecision({
+          chatId,
+          decisionId: command.decision.decisionId,
+        });
+        return;
+      }
+      const result =
+        command.decision.action === "answer"
+          ? await input.engine.answerCoachDecision(
+              {
+                chatId,
+                decisionId: command.decision.decisionId,
+                answer: command.decision.answer,
+              },
+              onTurnEvent,
+            )
+          : await input.engine.resumeCoachDecision(
+              { chatId, decisionId: command.decision.decisionId },
+              onTurnEvent,
+            );
+      const continuation =
+        result.decision.status === "answered" ? result.decision.continuation : null;
+      if (continuation?.status === "completed") {
+        await appendTurn(
+          conversation.id,
+          pendingText,
+          continuation.coachText,
+          turnId ?? continuation.turnId,
+        );
+      }
+      return;
+    }
+    let first = true;
+    while (first || queue.items.length > 0) {
+      first = false;
+      let turnId: string | null = null;
+      const onTurnEvent = (event: TurnEvent): void => {
+        if (event.type === "turn-start") turnId = event.turnId;
+        forward(event);
+      };
+      let resultText = "";
+      if (queue.items.length > 0 && queueText(queue) === pendingText) {
+        let result: ChatQueueRunResult;
+        if (queue.retryRequired !== undefined) {
+          if (input.engine.retryQueuedTurn === undefined) throw UNAVAILABLE;
+          result = await input.engine.retryQueuedTurn(
+            { chatId, claimId: queue.retryRequired.claimId },
+            onTurnEvent,
+          );
+        } else if (queue.items[0]?.kind === "slash-command" && queue.items[0]?.restored) {
+          if (input.engine.runQueuedCommand === undefined) throw UNAVAILABLE;
+          result = await input.engine.runQueuedCommand(
+            { chatId, queuedMessageId: queue.items[0].queuedMessageId },
+            onTurnEvent,
+          );
+        } else {
+          if (input.engine.resumeChatQueue === undefined) throw UNAVAILABLE;
+          result = await input.engine.resumeChatQueue({ chatId }, onTurnEvent);
+        }
+        resultText = result.response?.text ?? "";
+        queue = result.snapshot;
+      } else {
+        const result = await input.engine.chat({ chatId, message: pendingText }, onTurnEvent);
+        resultText = result.text;
+        queue = await (input.engine.getChatQueue?.({ chatId }) ?? Promise.resolve(EMPTY_QUEUE));
+      }
+      await appendTurn(conversation.id, pendingText, resultText, turnId);
+      if (queue.retryRequired !== undefined || queue.items.length === 0) break;
+      const nextText = queueText(queue);
+      if (!/\S/u.test(nextText) || (nextText === pendingText && resultText.length === 0)) break;
+      pendingText = nextText;
+    }
+  };
+
+  const saveDraft = async (
+    conversation: PlanConversationRecord,
+    previous: PlanDraftRevisionRecord | undefined,
+    build: PlanDraftBuild,
+  ): Promise<void> => {
+    const timestamp = input.identity.hlcStamp().physicalMs;
+    await plans.replace(build.plan, build.workouts);
+    const conversationStamp = input.identity.hlcStamp();
+    await conversations.saveConversation({
+      ...conversation,
+      planId: build.plan.id,
+      updatedAtMs: timestamp,
+      deviceId: await input.identity.deviceId(),
+      hlcPhysicalMs: conversationStamp.physicalMs,
+      hlcCounter: conversationStamp.counter,
+    });
+    const stamp = input.identity.hlcStamp();
+    await conversations.saveDraftRevision({
+      id: input.identity.newUlid(),
+      conversationId: conversation.id,
+      planId: build.plan.id,
+      revision: (previous?.revision ?? 0) + 1,
+      parentRevisionId: previous?.id ?? null,
+      status: "ready",
+      snapshotJson: JSON.stringify(build.snapshot),
+      createdAtMs: timestamp,
+      updatedAtMs: timestamp,
+      deviceId: await input.identity.deviceId(),
+      hlcPhysicalMs: stamp.physicalMs,
+      hlcCounter: stamp.counter,
+    });
+  };
+
+  const reject = async (error: PlanError): Promise<ExecutePlanTransitionRpcResult> =>
+    ExecutePlanTransitionRpcResultSchema.parse({ status: "rejected", error, state: await read() });
+
+  return {
+    async getPlanState(request) {
+      GetPlanStateRpcParamsSchema.parse(request);
+      return GetPlanStateRpcResultSchema.parse({ status: "ready", state: await read() });
+    },
+    executePlanTransition(request, onEvent) {
+      const command = ExecutePlanTransitionRpcParamsSchema.parse(request);
+      return enqueue(async () => {
+        if (command.transitionId === "PL-T01") {
+          let conversation = await conversations.readLatestOpenConversation();
+          if (conversation === undefined) {
+            const timestamp = input.identity.hlcStamp().physicalMs;
+            const stamp = input.identity.hlcStamp();
+            conversation = {
+              id: input.identity.newUlid(),
+              planId: null,
+              replacesPlanId: null,
+              status: "open",
+              endedAtMs: null,
+              createdAtMs: timestamp,
+              updatedAtMs: timestamp,
+              deviceId: await input.identity.deviceId(),
+              hlcPhysicalMs: stamp.physicalMs,
+              hlcCounter: stamp.counter,
+            };
+            await conversations.saveConversation(conversation);
+          }
+          return ExecutePlanTransitionRpcResultSchema.parse({
+            status: "completed",
+            state: await read(),
+          });
+        }
+        if (command.transitionId === "PL-T05") {
+          const operationId = input.identity.newUlid();
+          deliver(onEvent, {
+            commandId: command.commandId,
+            transitionId: command.transitionId,
+            operationId,
+            phase: "queued",
+            completed: 0,
+            total: 1,
+          });
+          try {
+            await executeCoachCall(command, operationId, onEvent);
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "completed",
+              completed: 1,
+              total: 1,
+            });
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read(),
+            });
+          } catch (error) {
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "failed",
+              completed: 0,
+              total: 1,
+            });
+            return reject(error === UNAVAILABLE ? UNAVAILABLE : PROVIDER_FAILED);
+          }
+        }
+        if (command.transitionId === "PL-T06" || command.transitionId === "PL-T07") {
+          if (dependencies.draftBuilder === undefined) return reject(UNAVAILABLE);
+          const operationId = input.identity.newUlid();
+          deliver(onEvent, {
+            commandId: command.commandId,
+            transitionId: command.transitionId,
+            operationId,
+            phase: "running",
+            completed: 0,
+            total: 1,
+          });
+          try {
+            const selectedDraft =
+              command.transitionId === "PL-T07"
+                ? await conversations.readDraftRevision(command.draftId)
+                : undefined;
+            const conversation =
+              command.transitionId === "PL-T06"
+                ? await conversations.readConversation(command.conversationId)
+                : selectedDraft === undefined
+                  ? undefined
+                  : await conversations.readConversationByPlanId(selectedDraft.planId);
+            if (conversation === undefined || conversation.status !== "open")
+              return reject(UNAVAILABLE);
+            const turns = await conversations.readTurns(conversation.id);
+            const previous = await conversations.readLatestDraftRevision(conversation.id);
+            const build =
+              command.transitionId === "PL-T06"
+                ? await dependencies.draftBuilder.form({ conversation, turns })
+                : previous === undefined
+                  ? null
+                  : await dependencies.draftBuilder.revise({
+                      conversation,
+                      turns,
+                      previous,
+                      instruction: command.text,
+                    });
+            if (build === null) return reject(UNAVAILABLE);
+            await saveDraft(conversation, previous, build);
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "completed",
+              completed: 1,
+              total: 1,
+            });
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read(),
+            });
+          } catch {
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "failed",
+              completed: 0,
+              total: 1,
+            });
+            return reject(PERSISTENCE_FAILED);
+          }
+        }
+        if (command.transitionId === "PL-T10") {
+          try {
+            const current = await conversations.readDraftRevision(command.draftId);
+            if (current === undefined) return reject(UNAVAILABLE);
+            const timestamp = input.identity.hlcStamp().physicalMs;
+            const stamp = input.identity.hlcStamp();
+            await conversations.saveDraftRevision({
+              ...current,
+              status: "discarded",
+              updatedAtMs: timestamp,
+              deviceId: await input.identity.deviceId(),
+              hlcPhysicalMs: stamp.physicalMs,
+              hlcCounter: stamp.counter,
+            });
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read(),
+            });
+          } catch {
+            return reject(PERSISTENCE_FAILED);
+          }
+        }
+        return reject(UNAVAILABLE);
+      });
+    },
+  };
+}

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -2092,49 +2092,52 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       acceptedOperationId: "operation-2",
       validEvents: 1,
     },
-  ])("rejects Planning $name correlation mismatches", async ({ events, acceptedOperationId, validEvents }) => {
-    const token = "x".repeat(43);
-    const rpc = createCoachRpcServer({
-      engine: engine(),
-      operations: {
-        ...operations,
-        executePlanTransition: async (_request, onEvent) => {
-          for (const event of events) onEvent?.(event);
-          return acceptedOperationId === null
-            ? { status: "completed", state: planState }
-            : { status: "accepted", operationId: acceptedOperationId, state: planState };
+  ])(
+    "rejects Planning $name correlation mismatches",
+    async ({ events, acceptedOperationId, validEvents }) => {
+      const token = "x".repeat(43);
+      const rpc = createCoachRpcServer({
+        engine: engine(),
+        operations: {
+          ...operations,
+          executePlanTransition: async (_request, onEvent) => {
+            for (const event of events) onEvent?.(event);
+            return acceptedOperationId === null
+              ? { status: "completed", state: planState }
+              : { status: "accepted", operationId: acceptedOperationId, state: planState };
+          },
         },
-      },
-      token,
-      owner: "app-supervised",
-    });
-    const client = await openSocket(rpc);
-    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
-    await client.frames.next();
-    client.ws.send(
-      JSON.stringify({
+        token,
+        owner: "app-supervised",
+      });
+      const client = await openSocket(rpc);
+      client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+      await client.frames.next();
+      client.ws.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: "plan-write",
+          method: "executePlanTransition",
+          params: {
+            transitionId: "PL-T01",
+            commandId: "command-1",
+            sourceConversationId: null,
+          },
+        }),
+      );
+      for (let index = 0; index < validEvents; index += 1) {
+        expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+          method: "coach.planProgress",
+        });
+      }
+      expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
         jsonrpc: "2.0",
         id: "plan-write",
-        method: "executePlanTransition",
-        params: {
-          transitionId: "PL-T01",
-          commandId: "command-1",
-          sourceConversationId: null,
-        },
-      }),
-    );
-    for (let index = 0; index < validEvents; index += 1) {
-      expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
-        method: "coach.planProgress",
+        error: { code: -32603, message: "Internal error" },
       });
-    }
-    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
-      jsonrpc: "2.0",
-      id: "plan-write",
-      error: { code: -32603, message: "Internal error" },
-    });
-    await client.close();
-  });
+      await client.close();
+    },
+  );
 
   it("ignores Planning progress emitted after the transition result", async () => {
     const token = "x".repeat(43);
@@ -2309,7 +2312,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
 });
 
 describe.skipIf(!hasLoopback)("RPC authority boundaries", () => {
-  it("binds renderer capabilities to the exact Desktop session namespace", async () => {
+  it("binds renderer capabilities to the ordinary Chat and dedicated Plan namespaces", async () => {
     const token = "x".repeat(43);
     const chat = vi.fn(async () => ({ text: "ok" }));
     const resetSession = vi.fn(async () => ({ memoryFlushed: true }));
@@ -2323,6 +2326,7 @@ describe.skipIf(!hasLoopback)("RPC authority boundaries", () => {
       decision: completedDecision,
       resumed: true,
     }));
+    const getChatQueue = vi.fn(async () => ({ schemaVersion: 1 as const, revision: 0, items: [] }));
     const getActivityAnalysis = vi.fn(operations.getActivityAnalysis!);
     const rpc = createCoachRpcServer({
       engine: engine({
@@ -2333,6 +2337,7 @@ describe.skipIf(!hasLoopback)("RPC authority boundaries", () => {
         answerCoachDecision,
         skipCoachDecision,
         resumeCoachDecision,
+        getChatQueue,
       }),
       operations: { ...operations, getActivityAnalysis },
       token,
@@ -2425,6 +2430,36 @@ describe.skipIf(!hasLoopback)("RPC authority boundaries", () => {
     expect(resumeCoachDecision).toHaveBeenCalledOnce();
     expect(resetSession).toHaveBeenCalledOnce();
     expect(hasSession).toHaveBeenCalledOnce();
+
+    const planChatId = `plan:${"0".repeat(25)}1`;
+    id += 1;
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method: "getChatQueue",
+        params: { chatId: planChatId },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+      id,
+      result: { schemaVersion: 1, revision: 0, items: [] },
+    });
+    expect(getChatQueue).toHaveBeenCalledWith({ chatId: planChatId });
+    id += 1;
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method: "chat",
+        params: { chatId: planChatId, message: "bypass" },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+      id,
+      error: { code: -32602, message: "Invalid params" },
+    });
+    expect(chat).toHaveBeenCalledOnce();
 
     id += 1;
     client.ws.send(

--- a/packages/coach/tests/planning-lifecycle.test.ts
+++ b/packages/coach/tests/planning-lifecycle.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { buildPlanLifecycleReadModel } from "../src/planning-lifecycle.js";
+
+const queue = { schemaVersion: 1 as const, revision: 0, items: [] };
+const conversation = {
+  id: "conversation-1",
+  planId: null,
+  replacesPlanId: null,
+  sourceConversationId: null,
+};
+
+function build(input: Partial<Parameters<typeof buildPlanLifecycleReadModel>[0]> = {}) {
+  return buildPlanLifecycleReadModel({
+    conversation,
+    turns: [],
+    readyToCreateDraft: false,
+    queue,
+    decision: null,
+    draft: null,
+    ...input,
+  });
+}
+
+describe("Plan lifecycle projection", () => {
+  it("keeps the dedicated conversation available from intake through readiness", () => {
+    expect(build()).toMatchObject({
+      scenarioId: "PL-S017",
+      lifecycle: "intake",
+      projection: "coach",
+    });
+    const ready = build({ readyToCreateDraft: true });
+    expect(ready).toMatchObject({
+      scenarioId: "PL-S016",
+      lifecycle: "intake",
+      projection: "coach",
+    });
+    expect(ready.transitions.map((transition) => transition.transitionId)).toContain("PL-T06");
+  });
+
+  it("projects forming, revised, and discarded Draft states without losing the conversation", () => {
+    expect(
+      build({
+        draft: { id: "draft-1", planId: "plan-1", revision: 1, status: "forming", snapshot: {} },
+      }),
+    ).toMatchObject({ scenarioId: "PL-S018", lifecycle: "draft-forming", projection: "draft" });
+    expect(
+      build({
+        draft: { id: "draft-1", planId: "plan-1", revision: 2, status: "ready", snapshot: {} },
+      }),
+    ).toMatchObject({ scenarioId: "PL-S031", lifecycle: "draft", title: "Draft updated" });
+    const discarded = build({
+      draft: { id: "draft-1", planId: "plan-1", revision: 2, status: "discarded", snapshot: {} },
+    });
+    expect(discarded).toMatchObject({
+      scenarioId: "PL-S020",
+      lifecycle: "intake",
+      projection: "coach",
+    });
+    expect(discarded.data).toMatchObject({ conversationId: "conversation-1" });
+  });
+
+  it("keeps the active Plan while a replacement Draft is discussed and formed", () => {
+    const replacement = { ...conversation, planId: "plan-1", replacesPlanId: "plan-1" };
+    expect(build({ conversation: replacement })).toMatchObject({
+      scenarioId: "PL-S079",
+      lifecycle: "replacement-intake",
+    });
+    expect(
+      build({
+        conversation: replacement,
+        draft: { id: "draft-2", planId: "plan-2", revision: 1, status: "forming", snapshot: {} },
+      }),
+    ).toMatchObject({ scenarioId: "PL-S105", lifecycle: "replacement-draft-forming" });
+  });
+});

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ChatQueueSnapshot,
+  CoachEngine,
+  PlanProgressEvent,
+  TurnEvent,
+} from "@enduragent/coach-contract";
+import { createPlanConversationRepository, type PlanRecord } from "@enduragent/kernel/planning";
+import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createPlanningOperations, type PlanDraftBuilder } from "../src/planning-operations.js";
+import type { CoachStoreWriterContext } from "../src/runtime.js";
+
+const EMPTY_QUEUE: ChatQueueSnapshot = { schemaVersion: 1, revision: 0, items: [] };
+const ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+function identity(): AuthoredIdentity {
+  let sequence = 0;
+  let clock = 100;
+  return {
+    deviceId: async () => "device-1",
+    newUlid() {
+      sequence += 1;
+      return `${"0".repeat(25)}${ALPHABET[sequence]}`;
+    },
+    hlcStamp() {
+      clock += 1;
+      return { physicalMs: clock, counter: 0 };
+    },
+  };
+}
+
+function engine(): CoachEngine {
+  return {
+    chat: vi.fn(async (request, onEvent) => {
+      onEvent?.({ type: "turn-start", turnId: "engine-turn-1", chatId: request.chatId });
+      onEvent?.({ type: "text_delta", turnId: "engine-turn-1", delta: "I found your rides." });
+      onEvent?.({ type: "final-text", turnId: "engine-turn-1", text: "I found your rides." });
+      return { text: "I found your rides." };
+    }),
+    getChatQueue: async () => EMPTY_QUEUE,
+    getCoachDecision: async () => ({ decision: null }),
+    answerCoachDecision: vi.fn(),
+    skipCoachDecision: vi.fn(),
+    resumeCoachDecision: vi.fn(),
+    resetSession: async () => ({ memoryFlushed: true }),
+    hasSession: async () => ({ hasSession: true }),
+    getAthleteState: vi.fn(),
+  } as unknown as CoachEngine;
+}
+
+function plan(id: string, timestamp: number): PlanRecord {
+  return {
+    id,
+    originId: null,
+    name: "Gran Fondo Plan",
+    primaryGoal: "Finish in the front half",
+    startDateKey: 20260709,
+    targetDateKey: 20260930,
+    status: "draft",
+    kind: "full_plan",
+    totalWeeks: 12,
+    weekStartDay: 4,
+    structureJson: '{"phases":[]}',
+    createdAtMs: timestamp,
+    updatedAtMs: timestamp,
+    deviceId: "device-1",
+    hlcPhysicalMs: timestamp,
+    hlcCounter: 0,
+  };
+}
+
+describe("Plan operations", () => {
+  let store: SqlStore & MigratorStore;
+  let context: CoachStoreWriterContext;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    context = {
+      home: {
+        root: "/synthetic/athlete",
+        storeDir: "/synthetic/athlete/store",
+        archiveDir: "/synthetic/athlete/archive",
+        configDir: "/synthetic/athlete/config",
+      },
+      store,
+      listener: {} as CoachStoreWriterContext["listener"],
+    };
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("persists and relaunches a dedicated streamed Plan conversation", async () => {
+    const coach = engine();
+    const authored = identity();
+    const readiness = {
+      isReady: ({ turns }: { readonly turns: readonly unknown[] }) => turns.length > 0,
+    };
+    const operations = createPlanningOperations(
+      { context, engine: coach, identity: authored },
+      readiness,
+    );
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    expect(started).toMatchObject({
+      status: "completed",
+      state: { scenarioId: "PL-S017", projection: "coach" },
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = started.state.data.conversationId;
+    if (typeof conversationId !== "string") throw new TypeError("Conversation id missing.");
+    const progress: PlanProgressEvent[] = [];
+    const sent = await operations.executePlanTransition?.(
+      {
+        transitionId: "PL-T05",
+        commandId: "command-2",
+        conversationId,
+        text: "Gran Fondo Almaty on 4 October.",
+      },
+      (event) => progress.push(event),
+    );
+    expect(sent).toMatchObject({
+      status: "completed",
+      state: { scenarioId: "PL-S016", projection: "coach" },
+    });
+    expect(progress.map((event) => event.phase)).toEqual([
+      "queued",
+      "running",
+      "running",
+      "running",
+      "completed",
+    ]);
+    expect(coach.chat).toHaveBeenCalledWith(
+      { chatId: `plan:${conversationId}`, message: "Gran Fondo Almaty on 4 October." },
+      expect.any(Function),
+    );
+    const repository = createPlanConversationRepository(store);
+    await expect(repository.readTurns(conversationId)).resolves.toMatchObject([
+      {
+        sequence: 1,
+        athleteText: "Gran Fondo Almaty on 4 October.",
+        coachText: "I found your rides.",
+      },
+    ]);
+    const restored = createPlanningOperations(
+      { context, engine: coach, identity: authored },
+      readiness,
+    );
+    await expect(restored.getPlanState?.({})).resolves.toMatchObject({
+      status: "ready",
+      state: {
+        scenarioId: "PL-S016",
+        data: {
+          conversationId,
+          messages: [
+            { role: "coach" },
+            { role: "athlete", text: "Gran Fondo Almaty on 4 October." },
+            { role: "coach", text: "I found your rides." },
+          ],
+        },
+      },
+    });
+  });
+
+  it("forms, revises, and discards a Draft without deleting the Plan conversation", async () => {
+    const authored = identity();
+    const coach = engine();
+    let revision = 0;
+    const builder: PlanDraftBuilder = {
+      async form() {
+        revision += 1;
+        return {
+          plan: plan(`${"0".repeat(25)}T`, 200),
+          workouts: [],
+          snapshot: { completeWeeks: 12, revision },
+        };
+      },
+      async revise() {
+        revision += 1;
+        return {
+          plan: plan(`${"0".repeat(25)}T`, 201),
+          workouts: [],
+          snapshot: { completeWeeks: 12, revision },
+        };
+      },
+    };
+    const operations = createPlanningOperations(
+      { context, engine: coach, identity: authored },
+      { draftBuilder: builder, isReady: () => true },
+    );
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+    const formed = await operations.executePlanTransition?.({
+      transitionId: "PL-T06",
+      commandId: "command-2",
+      conversationId,
+    });
+    expect(formed).toMatchObject({
+      status: "completed",
+      state: { scenarioId: "PL-S002", revision: 1 },
+    });
+    if (formed?.status !== "completed") throw new TypeError("Draft did not form.");
+    const firstDraft = formed.state.data.draft;
+    if (firstDraft === null || typeof firstDraft !== "object")
+      throw new TypeError("Draft missing.");
+    const draftId = String((firstDraft as { id: unknown }).id);
+    const revised = await operations.executePlanTransition?.({
+      transitionId: "PL-T07",
+      commandId: "command-3",
+      draftId,
+      text: "Move Thursday endurance to Wednesday.",
+    });
+    expect(revised).toMatchObject({
+      status: "completed",
+      state: { scenarioId: "PL-S031", revision: 2 },
+    });
+    if (revised?.status !== "completed") throw new TypeError("Draft did not revise.");
+    const secondDraft = revised.state.data.draft;
+    if (secondDraft === null || typeof secondDraft !== "object")
+      throw new TypeError("Draft missing.");
+    const secondDraftId = String((secondDraft as { id: unknown }).id);
+    const discarded = await operations.executePlanTransition?.({
+      transitionId: "PL-T10",
+      commandId: "command-4",
+      draftId: secondDraftId,
+    });
+    expect(discarded).toMatchObject({
+      status: "completed",
+      state: { scenarioId: "PL-S020", projection: "coach" },
+    });
+    await expect(
+      createPlanConversationRepository(store).readConversation(conversationId),
+    ).resolves.toMatchObject({ status: "open" });
+  });
+
+  it("retries an interrupted Plan queue claim and persists the recovered turn", async () => {
+    const recoveredQueue = {
+      schemaVersion: 1 as const,
+      revision: 2,
+      items: [
+        {
+          queuedMessageId: "queued-1",
+          submissionId: "submission-1",
+          text: "Keep Sunday free.",
+          kind: "ordinary" as const,
+          position: 0,
+          restored: true,
+        },
+      ],
+      retryRequired: {
+        claimId: "claim-1",
+        queuedMessageIds: ["queued-1"],
+        turnId: "turn-1",
+        status: "retry-required" as const,
+      },
+    };
+    const retryQueuedTurn = vi.fn(
+      async (
+        _request: { readonly chatId: string; readonly claimId: string },
+        onEvent?: (event: TurnEvent) => void,
+      ) => {
+        onEvent?.({
+          type: "turn-start",
+          turnId: "turn-recovered",
+          chatId: `plan:${"0".repeat(25)}1`,
+        });
+        onEvent?.({ type: "final-text", turnId: "turn-recovered", text: "Sunday stays free." });
+        return { snapshot: EMPTY_QUEUE, response: { text: "Sunday stays free." } };
+      },
+    );
+    const coach = {
+      ...engine(),
+      getChatQueue: vi
+        .fn()
+        .mockResolvedValueOnce(EMPTY_QUEUE)
+        .mockResolvedValueOnce(recoveredQueue)
+        .mockResolvedValue(EMPTY_QUEUE),
+      retryQueuedTurn,
+    } as unknown as CoachEngine;
+    const operations = createPlanningOperations({ context, engine: coach, identity: identity() });
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T05",
+        commandId: "command-2",
+        conversationId,
+        text: "Keep Sunday free.",
+      }),
+    ).resolves.toMatchObject({ status: "completed" });
+    expect(retryQueuedTurn).toHaveBeenCalledWith(
+      { chatId: `plan:${conversationId}`, claimId: "claim-1" },
+      expect.any(Function),
+    );
+    await expect(
+      createPlanConversationRepository(store).readTurns(conversationId),
+    ).resolves.toMatchObject([
+      { athleteText: "Keep Sunday free.", coachText: "Sunday stays free." },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- add a durable coach conversation owned by Plan, with streaming, queueing, Stop, retry, and decision recovery
- add Coach-owned planning lifecycle projection and operations without widening the Engine public API
- add Draft formation, revision, and safe discard UI while preserving the Plan conversation
- reuse the established Chat transcript, composer, and decision components
- add the required Desktop patch changeset

## Verification

- root `pnpm check`
- Coach Contract: 35 files, 562 tests passed
- Desktop Renderer: 62 files, 979 tests passed; final focused Plan tests passed after decision-recovery coverage
- Coach and Engine repository-root test harness passed after rebuilding the moved Coach lifecycle module
- `git diff --check`
- `oxfmt --check` on every changed source and test file
- isolated autoreview: clean, no accepted/actionable findings