### PR TITLE
feat(desktop): wire Windows updater plumbing with activation off

### DIFF
--- a/.changeset/windows-updater-plumbing.md
+++ b/.changeset/windows-updater-plumbing.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Wire Windows updater plumbing: platform-gated update eligibility with Windows present but inactive, disableWebInstaller on the updater, and a pure N-to-N+1 Windows updater round-trip verifier with a negative-scenario harness. Windows update activation and Authenticode publisher checks stay pending until the first signed release.

--- a/apps/desktop/scripts/verify-windows-release.d.mts
+++ b/apps/desktop/scripts/verify-windows-release.d.mts
@@ -44,6 +44,7 @@ export interface VerifiedWindowsReleaseAssets {
   readonly authenticode: "pending-w19" | "verified";
 }
 
+export const WINDOWS_UPDATER_METADATA_MAX_BYTES: 16_384;
 export function safeWindowsReleaseVerificationMessage(error: unknown): string | undefined;
 export function verifyWindowsReleaseAssets(
   artifactDirectory: string,

--- a/apps/desktop/scripts/verify-windows-release.mjs
+++ b/apps/desktop/scripts/verify-windows-release.mjs
@@ -12,7 +12,7 @@ import {
 } from "./windows-release-plan.mjs";
 import { requireStableSemVer } from "./macos-release-plan.mjs";
 
-const maximumUpdaterMetadataBytes = 16_384;
+export const WINDOWS_UPDATER_METADATA_MAX_BYTES = 16_384;
 
 class WindowsReleaseVerificationError extends Error {
   constructor(message) {
@@ -205,7 +205,7 @@ export async function verifyWindowsReleaseAssets(artifactDirectory, options, ove
   const [installer, blockmap, metadataBytes] = await Promise.all([
     readRegularFile(paths.installer, "Windows installer", dependencies),
     readRegularFile(paths.blockmap, "installer blockmap", dependencies),
-    readRegularFile(paths.metadata, "latest.yml", dependencies, maximumUpdaterMetadataBytes),
+    readRegularFile(paths.metadata, "latest.yml", dependencies, WINDOWS_UPDATER_METADATA_MAX_BYTES),
   ]);
   const metadata = parseUpdaterMetadata(metadataBytes);
   const installerSha512 = createHash("sha512").update(installer).digest("base64");

--- a/apps/desktop/scripts/verify-windows-updater-round-trip.d.mts
+++ b/apps/desktop/scripts/verify-windows-updater-round-trip.d.mts
@@ -1,0 +1,31 @@
+export interface WindowsUpdaterReleaseInput {
+  readonly version: string;
+  readonly installer: Uint8Array | { readonly sha512: string; readonly size: number };
+  readonly blockmap?: Uint8Array;
+  readonly metadata: string | Uint8Array;
+}
+
+export interface WindowsUpdaterPreflight {
+  readonly feedUrl: string;
+  readonly channel: "latest";
+  readonly publisherName: string;
+  readonly disableWebInstaller: true;
+  readonly verifyUpdateCodeSignature: true;
+}
+
+export interface WindowsUpdaterRoundTripResult {
+  readonly baselineVersion: string;
+  readonly candidateVersion: string;
+  readonly candidateInstallerName: string;
+  readonly candidateInstallerSha512: string;
+  readonly candidateInstallerSize: number;
+  readonly preflight: WindowsUpdaterPreflight;
+  readonly authenticode: "pending-w19";
+}
+
+export function verifyWindowsUpdaterRoundTrip(input: {
+  readonly baseline: WindowsUpdaterReleaseInput;
+  readonly candidate: WindowsUpdaterReleaseInput;
+  readonly preflight: WindowsUpdaterPreflight;
+}): WindowsUpdaterRoundTripResult;
+export function safeWindowsUpdaterRoundTripMessage(error: unknown): string | undefined;

--- a/apps/desktop/scripts/verify-windows-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-windows-updater-round-trip.mjs
@@ -1,0 +1,229 @@
+import { createHash } from "node:crypto";
+import { parse } from "yaml";
+import {
+  WINDOWS_RELEASE_METADATA_NAME,
+  windowsReleaseArtifactNames,
+} from "./windows-release-plan.mjs";
+import { requireGenericFeedUrl, requireStableSemVer } from "./macos-release-plan.mjs";
+import { WINDOWS_UPDATER_METADATA_MAX_BYTES } from "./verify-windows-release.mjs";
+
+const maximumPublisherNameCharacters = 512;
+const invalidMetadataMessage = `${WINDOWS_RELEASE_METADATA_NAME} is invalid`;
+
+class WindowsUpdaterRoundTripError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "WindowsUpdaterRoundTripError";
+  }
+}
+
+function fail(message) {
+  throw new WindowsUpdaterRoundTripError(message);
+}
+
+export function safeWindowsUpdaterRoundTripMessage(error) {
+  return error instanceof WindowsUpdaterRoundTripError ? error.message : undefined;
+}
+
+function exactObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value, keys) {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function requireRoundTripVersion(value) {
+  try {
+    return requireStableSemVer(value);
+  } catch {
+    fail("updater round-trip version must be stable SemVer");
+  }
+}
+
+function compareStableVersions(left, right) {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) return leftParts[index] - rightParts[index];
+  }
+  return 0;
+}
+
+function parseUpdaterMetadata(value) {
+  let source;
+  if (typeof value === "string") source = value;
+  else if (value instanceof Uint8Array) source = Buffer.from(value).toString("utf8");
+  else fail(invalidMetadataMessage);
+  if (Buffer.byteLength(source, "utf8") > WINDOWS_UPDATER_METADATA_MAX_BYTES) {
+    fail(invalidMetadataMessage);
+  }
+  let metadata;
+  try {
+    metadata = parse(source);
+  } catch {
+    fail(invalidMetadataMessage);
+  }
+  if (
+    !exactObject(metadata) ||
+    !hasExactKeys(metadata, ["version", "files", "path", "sha512", "releaseDate"]) ||
+    !Array.isArray(metadata.files) ||
+    metadata.files.length !== 1 ||
+    !exactObject(metadata.files[0]) ||
+    !hasExactKeys(metadata.files[0], ["url", "sha512", "size"])
+  ) {
+    fail(invalidMetadataMessage);
+  }
+  return metadata;
+}
+
+function validBase64(value) {
+  if (typeof value !== "string" || value.length === 0 || value.length % 4 !== 0) return false;
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(value)) {
+    return false;
+  }
+  return Buffer.from(value, "base64").toString("base64") === value;
+}
+
+function installerDescriptor(value) {
+  if (value instanceof Uint8Array) {
+    return Object.freeze({
+      sha512: createHash("sha512").update(value).digest("base64"),
+      size: value.byteLength,
+    });
+  }
+  if (
+    !exactObject(value) ||
+    !Number.isSafeInteger(value.size) ||
+    value.size <= 0 ||
+    !validBase64(value.sha512)
+  ) {
+    fail("installer descriptor is invalid");
+  }
+  return Object.freeze({ sha512: value.sha512, size: value.size });
+}
+
+function canonicalReleaseDate(value) {
+  if (typeof value !== "string") return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function verifyMetadata(metadata, version, installer) {
+  const installerName = windowsReleaseArtifactNames(version).installer;
+  const file = metadata.files[0];
+  if (metadata.version !== version) fail(`${WINDOWS_RELEASE_METADATA_NAME} version mismatch`);
+  if (metadata.path !== installerName || file.url !== installerName) {
+    fail(`${WINDOWS_RELEASE_METADATA_NAME} installer name mismatch`);
+  }
+  if (metadata.sha512 !== installer.sha512 || file.sha512 !== installer.sha512) {
+    fail(`${WINDOWS_RELEASE_METADATA_NAME} installer sha512 mismatch`);
+  }
+  if (file.size !== installer.size) {
+    fail(`${WINDOWS_RELEASE_METADATA_NAME} installer size mismatch`);
+  }
+  if (!canonicalReleaseDate(metadata.releaseDate)) fail(invalidMetadataMessage);
+  return installerName;
+}
+
+function verifyBlockmap(value) {
+  if (
+    !(value instanceof Uint8Array) ||
+    value.length < 2 ||
+    value[0] !== 0x1f ||
+    value[1] !== 0x8b
+  ) {
+    fail("installer blockmap is invalid");
+  }
+}
+
+function fullDistinguishedName(value) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximumPublisherNameCharacters ||
+    value !== value.trim()
+  ) {
+    return false;
+  }
+  const rdns = value.split(", ");
+  return (
+    rdns.length >= 2 &&
+    rdns.every((rdn) => {
+      const equals = rdn.indexOf("=");
+      return (
+        equals > 0 &&
+        equals < rdn.length - 1 &&
+        rdn.slice(0, equals) === rdn.slice(0, equals).trim() &&
+        rdn.slice(equals + 1) === rdn.slice(equals + 1).trim()
+      );
+    }) &&
+    rdns.some((rdn) => rdn.startsWith("CN="))
+  );
+}
+
+export function verifyWindowsUpdaterRoundTrip(input) {
+  const baselineVersion = requireRoundTripVersion(input?.baseline?.version);
+  const candidateVersion = requireRoundTripVersion(input?.candidate?.version);
+  if (compareStableVersions(candidateVersion, baselineVersion) <= 0) {
+    fail("updater round-trip candidate must be a higher version than the baseline");
+  }
+
+  const baselineMetadata = parseUpdaterMetadata(input.baseline.metadata);
+  const candidateMetadata = parseUpdaterMetadata(input.candidate.metadata);
+  const baselineInstaller = installerDescriptor(input.baseline.installer);
+  const candidateInstaller = installerDescriptor(input.candidate.installer);
+  verifyMetadata(baselineMetadata, baselineVersion, baselineInstaller);
+  const candidateInstallerName = verifyMetadata(
+    candidateMetadata,
+    candidateVersion,
+    candidateInstaller,
+  );
+
+  if (input.candidate.blockmap === undefined) fail("missing candidate installer blockmap");
+  verifyBlockmap(input.candidate.blockmap);
+  if (input.baseline.blockmap !== undefined) verifyBlockmap(input.baseline.blockmap);
+
+  let feedUrl;
+  try {
+    feedUrl = requireGenericFeedUrl(input.preflight?.feedUrl);
+  } catch {
+    fail("updater preflight feed URL is invalid");
+  }
+  if (
+    !exactObject(input.preflight) ||
+    !hasExactKeys(input.preflight, [
+      "feedUrl",
+      "channel",
+      "publisherName",
+      "disableWebInstaller",
+      "verifyUpdateCodeSignature",
+    ]) ||
+    input.preflight.channel !== "latest" ||
+    input.preflight.disableWebInstaller !== true ||
+    input.preflight.verifyUpdateCodeSignature !== true
+  ) {
+    fail("updater preflight is invalid");
+  }
+  if (!fullDistinguishedName(input.preflight.publisherName)) {
+    fail("updater preflight publisher name must be a full distinguished name");
+  }
+  const preflight = Object.freeze({
+    feedUrl,
+    channel: "latest",
+    publisherName: input.preflight.publisherName,
+    disableWebInstaller: true,
+    verifyUpdateCodeSignature: true,
+  });
+  return Object.freeze({
+    baselineVersion,
+    candidateVersion,
+    candidateInstallerName,
+    candidateInstallerSha512: candidateInstaller.sha512,
+    candidateInstallerSize: candidateInstaller.size,
+    preflight,
+    authenticode: "pending-w19",
+  });
+}

--- a/apps/desktop/src/main/update-controller.ts
+++ b/apps/desktop/src/main/update-controller.ts
@@ -35,6 +35,7 @@ export type DesktopAutoUpdater = Pick<
   | "autoRunAppAfterInstall"
   | "allowPrerelease"
   | "allowDowngrade"
+  | "disableWebInstaller"
   | "on"
   | "off"
   | "checkForUpdates"
@@ -433,6 +434,7 @@ export function createDesktopUpdateController(input: {
         updater.autoRunAppAfterInstall = true;
         updater.allowPrerelease = false;
         updater.allowDowngrade = false;
+        updater.disableWebInstaller = true;
         intervalTimer = scheduleInterval(() => {
           void check();
         }, DESKTOP_UPDATE_INTERVAL_MS);

--- a/apps/desktop/src/main/update-eligibility.ts
+++ b/apps/desktop/src/main/update-eligibility.ts
@@ -4,6 +4,11 @@ import { isStableDesktopVersion } from "./desktop-version.js";
 
 const PACKAGE_JSON_LIMIT = 64 * 1024;
 
+export const DESKTOP_UPDATE_SUPPORTED_PLATFORMS = Object.freeze(["darwin", "win32"] as const);
+export type DesktopUpdatePlatform = (typeof DESKTOP_UPDATE_SUPPORTED_PLATFORMS)[number];
+export const DESKTOP_UPDATE_PLATFORM_ACTIVATION: Readonly<Record<DesktopUpdatePlatform, boolean>> =
+  Object.freeze({ darwin: true, win32: false });
+
 export function isDesktopUpdateReleaseEligible(input: {
   readonly isPackaged: boolean;
   readonly platform: NodeJS.Platform;
@@ -11,10 +16,13 @@ export function isDesktopUpdateReleaseEligible(input: {
   readonly appPath: string;
   readonly currentVersion: string;
   readonly readPackageJson?: (path: string) => string;
+  readonly platformActivation?: Readonly<Record<DesktopUpdatePlatform, boolean>>;
 }): boolean {
+  const platformActivation = input.platformActivation ?? DESKTOP_UPDATE_PLATFORM_ACTIVATION;
   if (
     !input.isPackaged ||
-    input.platform !== "darwin" ||
+    !DESKTOP_UPDATE_SUPPORTED_PLATFORMS.includes(input.platform as DesktopUpdatePlatform) ||
+    platformActivation[input.platform as DesktopUpdatePlatform] !== true ||
     input.securitySmokeMode ||
     !isStableDesktopVersion(input.currentVersion)
   ) {

--- a/apps/desktop/tests/update-controller.test.ts
+++ b/apps/desktop/tests/update-controller.test.ts
@@ -100,6 +100,7 @@ function fakeUpdater() {
     autoRunAppAfterInstall: false,
     allowPrerelease: true,
     allowDowngrade: true,
+    disableWebInstaller: false,
     checkForUpdates: vi.fn<DesktopAutoUpdater["checkForUpdates"]>(),
     downloadUpdate: vi.fn<DesktopAutoUpdater["downloadUpdate"]>(async () => []),
     quitAndInstall: vi.fn(),
@@ -258,6 +259,7 @@ describe("desktop update controller", () => {
       autoRunAppAfterInstall: true,
       allowPrerelease: false,
       allowDowngrade: false,
+      disableWebInstaller: true,
     });
     expect(fake.updater.checkForUpdates).toHaveBeenCalledOnce();
     expect(subject.timer.unref).toHaveBeenCalledOnce();

--- a/apps/desktop/tests/update-eligibility.test.ts
+++ b/apps/desktop/tests/update-eligibility.test.ts
@@ -1,6 +1,11 @@
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { isDesktopUpdateReleaseEligible } from "../src/main/update-eligibility.js";
+import {
+  DESKTOP_UPDATE_PLATFORM_ACTIVATION,
+  DESKTOP_UPDATE_SUPPORTED_PLATFORMS,
+  isDesktopUpdateReleaseEligible,
+  type DesktopUpdatePlatform,
+} from "../src/main/update-eligibility.js";
 
 const appPath = "/Applications/Enduragent.app/Contents/Resources/app.asar";
 
@@ -19,6 +24,39 @@ function eligibility(
 }
 
 describe("desktop update release eligibility", () => {
+  it("keeps Windows supported but inactive by default", () => {
+    expect(DESKTOP_UPDATE_SUPPORTED_PLATFORMS).toEqual(["darwin", "win32"]);
+    expect(DESKTOP_UPDATE_PLATFORM_ACTIVATION.win32).toBe(false);
+    const readPackageJson = vi.fn(() => {
+      throw new Error("must not read");
+    });
+    expect(eligibility({ platform: "win32", readPackageJson })).toBe(false);
+    expect(readPackageJson).not.toHaveBeenCalled();
+  });
+
+  it("uses the Windows activation test seam without bypassing release metadata", () => {
+    const platformActivation = { darwin: true, win32: true };
+    expect(eligibility({ platform: "win32", platformActivation })).toBe(true);
+    expect(
+      eligibility({
+        platform: "win32",
+        platformActivation,
+        readPackageJson: () => JSON.stringify({ version: "0.1.0" }),
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects an unsupported platform even when activation claims it", () => {
+    const platformActivation = { darwin: true, win32: false, linux: true } as unknown as Readonly<
+      Record<DesktopUpdatePlatform, boolean>
+    >;
+    const readPackageJson = vi.fn(() => {
+      throw new Error("must not read");
+    });
+    expect(eligibility({ platform: "linux", platformActivation, readPackageJson })).toBe(false);
+    expect(readPackageJson).not.toHaveBeenCalled();
+  });
+
   it("accepts only the marked packaged mac release with its exact stable version", () => {
     const readPackageJson = vi.fn(() => '{"version":"0.1.0","enduragentDesktopRelease":true}');
     expect(eligibility({ readPackageJson })).toBe(true);

--- a/apps/desktop/tests/windows-release-plan.test.ts
+++ b/apps/desktop/tests/windows-release-plan.test.ts
@@ -108,6 +108,10 @@ describe("Windows release plan", () => {
     });
     expect(plan.builderOptions.config.forceCodeSigning).toBe(true);
     expect(plan.builderOptions.config.nsis.differentialPackage).toBe(true);
+    expect(plan.builderOptions.config.publish).toEqual([
+      { provider: "generic", url: feedUrl, channel: "latest" },
+    ]);
+    expect(plan.builderOptions.publish).toBe("never");
     expect(plan.builderOptions.config.win).toEqual({
       verifyUpdateCodeSignature: true,
       target: [{ target: "nsis", arch: ["x64"] }],

--- a/apps/desktop/tests/windows-updater-round-trip.test.ts
+++ b/apps/desktop/tests/windows-updater-round-trip.test.ts
@@ -1,0 +1,252 @@
+import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { stringify } from "yaml";
+import {
+  safeWindowsUpdaterRoundTripMessage,
+  verifyWindowsUpdaterRoundTrip,
+  type WindowsUpdaterPreflight,
+  type WindowsUpdaterReleaseInput,
+} from "../scripts/verify-windows-updater-round-trip.mjs";
+import { windowsReleaseArtifactNames } from "../scripts/windows-release-plan.mjs";
+
+type RoundTripInput = Parameters<typeof verifyWindowsUpdaterRoundTrip>[0];
+
+const baselineInstaller = Buffer.from("synthetic Windows installer 0.1.5\n");
+const candidateInstaller = Buffer.from("synthetic Windows installer 0.1.6\n");
+const blockmap = gzipSync(JSON.stringify({ version: "2", files: [{ name: "file" }] }));
+const releaseDate = "2026-08-25T00:00:00.000Z";
+const preflight: WindowsUpdaterPreflight = {
+  feedUrl: "https://github.com/yerzhansa/enduragent/releases/latest/download/",
+  channel: "latest",
+  publisherName: "CN=Operator Name, O=Open Source Developer, C=KZ",
+  disableWebInstaller: true,
+  verifyUpdateCodeSignature: true,
+};
+
+function metadata(
+  version: string,
+  installer: Uint8Array,
+  overrides: {
+    readonly version?: string;
+    readonly installerName?: string;
+    readonly sha512?: string;
+    readonly size?: number;
+    readonly extra?: Readonly<Record<string, unknown>>;
+  } = {},
+): string {
+  const installerName = overrides.installerName ?? windowsReleaseArtifactNames(version).installer;
+  const sha512 = overrides.sha512 ?? createHash("sha512").update(installer).digest("base64");
+  const size = overrides.size ?? installer.byteLength;
+  return stringify({
+    version: overrides.version ?? version,
+    files: [{ url: installerName, sha512, size }],
+    path: installerName,
+    sha512,
+    releaseDate,
+    ...overrides.extra,
+  });
+}
+
+function release(
+  version: string,
+  installer: Uint8Array,
+  options: {
+    readonly metadata?: string | Uint8Array;
+    readonly metadataOverrides?: Parameters<typeof metadata>[2];
+    readonly blockmap?: Uint8Array;
+    readonly includeBlockmap?: boolean;
+  } = {},
+): WindowsUpdaterReleaseInput {
+  const result: {
+    version: string;
+    installer: Uint8Array;
+    metadata: string | Uint8Array;
+    blockmap?: Uint8Array;
+  } = {
+    version,
+    installer,
+    metadata: options.metadata ?? metadata(version, installer, options.metadataOverrides),
+  };
+  if (options.includeBlockmap !== false) result.blockmap = options.blockmap ?? blockmap;
+  return result;
+}
+
+function roundTripInput(
+  overrides: {
+    readonly baseline?: WindowsUpdaterReleaseInput;
+    readonly candidate?: WindowsUpdaterReleaseInput;
+    readonly preflight?: WindowsUpdaterPreflight;
+  } = {},
+): RoundTripInput {
+  return {
+    baseline: overrides.baseline ?? release("0.1.5", baselineInstaller),
+    candidate: overrides.candidate ?? release("0.1.6", candidateInstaller),
+    preflight: overrides.preflight ?? preflight,
+  };
+}
+
+const negativeScenarios: readonly {
+  readonly name: string;
+  readonly expected: string;
+  readonly input: () => RoundTripInput;
+}[] = [
+  {
+    name: "wrong-version",
+    expected: "latest.yml version mismatch",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6", candidateInstaller, {
+          metadataOverrides: { version: "0.1.7" },
+        }),
+      }),
+  },
+  {
+    name: "wrong-sha512",
+    expected: "latest.yml installer sha512 mismatch",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6", candidateInstaller, {
+          metadataOverrides: { sha512: "d3Jvbmc=" },
+        }),
+      }),
+  },
+  {
+    name: "wrong-size",
+    expected: "latest.yml installer size mismatch",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6", candidateInstaller, {
+          metadataOverrides: { size: candidateInstaller.byteLength + 1 },
+        }),
+      }),
+  },
+  {
+    name: "missing blockmap",
+    expected: "missing candidate installer blockmap",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6", candidateInstaller, { includeBlockmap: false }),
+      }),
+  },
+  {
+    name: "non-gzip blockmap",
+    expected: "installer blockmap is invalid",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6", candidateInstaller, {
+          blockmap: Buffer.from("not gzip"),
+        }),
+      }),
+  },
+  {
+    name: "downgrade",
+    expected: "updater round-trip candidate must be a higher version than the baseline",
+    input: () => roundTripInput({ candidate: release("0.1.4", candidateInstaller) }),
+  },
+  {
+    name: "equal versions",
+    expected: "updater round-trip candidate must be a higher version than the baseline",
+    input: () => roundTripInput({ candidate: release("0.1.5", candidateInstaller) }),
+  },
+  {
+    name: "wrong installer name",
+    expected: "latest.yml installer name mismatch",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6", candidateInstaller, {
+          metadataOverrides: { installerName: "Enduragent-0.1.6-arm64.exe" },
+        }),
+      }),
+  },
+  {
+    name: "oversized latest.yml",
+    expected: "latest.yml is invalid",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6", candidateInstaller, {
+          metadata: new Uint8Array(16_384 + 1),
+        }),
+      }),
+  },
+  {
+    name: "extra key in latest.yml",
+    expected: "latest.yml is invalid",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6", candidateInstaller, {
+          metadataOverrides: { extra: { unexpected: true } },
+        }),
+      }),
+  },
+  {
+    name: "prerelease version",
+    expected: "updater round-trip version must be stable SemVer",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6-beta.1", candidateInstaller, {
+          metadataOverrides: { installerName: "Enduragent-0.1.6-beta.1-x64.exe" },
+        }),
+      }),
+  },
+  {
+    name: "CN-only publisherName",
+    expected: "updater preflight publisher name must be a full distinguished name",
+    input: () => roundTripInput({ preflight: { ...preflight, publisherName: "CN=Operator Name" } }),
+  },
+  {
+    name: "empty publisherName",
+    expected: "updater preflight publisher name must be a full distinguished name",
+    input: () => roundTripInput({ preflight: { ...preflight, publisherName: "" } }),
+  },
+  {
+    name: "http feed URL",
+    expected: "updater preflight feed URL is invalid",
+    input: () =>
+      roundTripInput({
+        preflight: {
+          ...preflight,
+          feedUrl: "http://github.com/yerzhansa/enduragent/releases/latest/download/",
+        },
+      }),
+  },
+  {
+    name: "disableWebInstaller false",
+    expected: "updater preflight is invalid",
+    input: () =>
+      roundTripInput({
+        preflight: {
+          ...preflight,
+          disableWebInstaller: false,
+        } as unknown as WindowsUpdaterPreflight,
+      }),
+  },
+];
+
+describe("Windows updater N-to-N+1 round trip", () => {
+  it("verifies a complete 0.1.5 to 0.1.6 round trip", () => {
+    const result = verifyWindowsUpdaterRoundTrip(roundTripInput());
+    expect(result).toEqual({
+      baselineVersion: "0.1.5",
+      candidateVersion: "0.1.6",
+      candidateInstallerName: "Enduragent-0.1.6-x64.exe",
+      candidateInstallerSha512: createHash("sha512").update(candidateInstaller).digest("base64"),
+      candidateInstallerSize: candidateInstaller.byteLength,
+      preflight,
+      authenticode: "pending-w19",
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
+  it.each(negativeScenarios)("rejects $name", ({ expected, input }) => {
+    let error: unknown;
+    try {
+      verifyWindowsUpdaterRoundTrip(input());
+    } catch (caught) {
+      error = caught;
+    }
+    expect(safeWindowsUpdaterRoundTripMessage(error)).toBe(expected);
+  });
+
+  it.skip("rejects wrong publisher — Authenticode publisher comparison requires W19 signature verification", () => {});
+});


### PR DESCRIPTION
## Summary

- Supported updater platform set is now `{darwin, win32}` with per-platform activation. `win32` is OFF via `DESKTOP_UPDATE_PLATFORM_ACTIVATION`. There is no env override.
- Adds `apps/desktop/scripts/verify-windows-updater-round-trip.mjs` plus negative-scenario tests (`apps/desktop/tests/windows-updater-round-trip.test.ts`). The wrong-publisher scenario is skipped pending W19 Authenticode.
- The `publish` block stays release-plan-injected so dev builds never emit updater metadata with a hardcoded feed.
- Changeset included.

## Decisions

- The `publish` block is injected by the release plan, not declared in `electron-builder.yml`. Dev builds must not carry a feed.
- `win32` activation is a constant in `DESKTOP_UPDATE_PLATFORM_ACTIVATION`. It flips in the first signed release.

## Limits

- `WINDOWS_UPDATER_METADATA_MAX_BYTES = 16384` — `latest.yml` size cap (renamed export, value unchanged).
- `maximumPublisherNameCharacters = 512` — bound the preflight publisher DN.

## Verification

- Root `pnpm check` exit 0.
- 6 targeted test files: 257 pass, 1 skip.
- Full desktop project: 96 files, 1909 pass, 1 skip.
- 11 acceptance criteria adversarially verified: 10 pass, 1 mechanical partial.

## Workflow-file changes

None.

## Residuals

- The wrong-publisher negative scenario needs W19 Authenticode before it can run.
- Signed N to N+1 update proof lands after the certificate is available.
