### PR TITLE
feat: add Plan FTP resolution flow

### DIFF
--- a/.changeset/plan-ftp-flow.md
+++ b/.changeset/plan-ftp-flow.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Added manual and Intervals FTP resolution to Plan creation, including source precedence, retry recovery, and automatic return to Draft planning.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -192,6 +192,8 @@ export function bootRenderer(): Disposer {
     answerCoachDecision: (decisionId, answer) =>
       planAdapter.answerCoachDecision(decisionId, answer),
     skipCoachDecision: (decisionId) => planAdapter.skipCoachDecision(decisionId),
+    saveFtp: (watts) => planAdapter.saveFtp(watts),
+    refreshFtp: () => planAdapter.refreshFtp(),
     createDraft: () => planAdapter.createDraft(),
     updateDraft: (message) => planAdapter.updateDraft(message),
     openDiscardConfirmation: () => planAdapter.openDiscardConfirmation(),

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -41,6 +41,8 @@ export interface PlanViewAdapter {
   retryQueuedCoachTurn(claimId: string): void;
   answerCoachDecision(decisionId: string, answer: CoachDecisionAnswer): void;
   skipCoachDecision(decisionId: string): void;
+  saveFtp(watts: number): void;
+  refreshFtp(): void;
   createDraft(): void;
   updateDraft(message: string): void;
   openDiscardConfirmation(): void;
@@ -256,6 +258,13 @@ export function createPlanViewAdapter(input: {
       }
       active = null;
       input.publishTransition({ status: "idle" });
+      if (
+        command.transitionId === "PL-T04" &&
+        (result.state.scenarioId === "PL-S060" || result.state.scenarioId === "PL-S062")
+      ) {
+        lastCommand = null;
+        queueMicrotask(() => void refresh(false));
+      }
     } catch {
       if (
         disposed ||
@@ -465,6 +474,28 @@ export function createPlanViewAdapter(input: {
       coachDecisionAnswerLabel = "Question skipped";
       coachDecisionError = null;
       submitCommand("Question skipped", { action: "skip", decisionId });
+    },
+    saveFtp(watts) {
+      const data = currentCoachData();
+      if (data === null) return;
+      void execute({
+        transitionId: "PL-T04",
+        commandId: createCommandId(),
+        conversationId: data.conversationId,
+        source: "manual",
+        watts,
+      });
+    },
+    refreshFtp() {
+      const data = currentCoachData();
+      if (data === null) return;
+      void execute({
+        transitionId: "PL-T04",
+        commandId: createCommandId(),
+        conversationId: data.conversationId,
+        source: "intervals",
+        watts: null,
+      });
     },
     createDraft() {
       const data = currentCoachData();

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -49,6 +49,8 @@ export interface PlanActions {
   retryQueuedCoachTurn(claimId: string): void;
   answerCoachDecision(decisionId: string, answer: CoachDecisionAnswer): void;
   skipCoachDecision(decisionId: string): void;
+  saveFtp(watts: number): void;
+  refreshFtp(): void;
   createDraft(): void;
   updateDraft(message: string): void;
   openDiscardConfirmation(): void;

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -1,6 +1,10 @@
-import { CheckCircle2, LoaderCircle, TriangleAlert } from "lucide-react";
+import { CheckCircle2, LoaderCircle, RefreshCw, TriangleAlert } from "lucide-react";
 import { useRef, useState, type FormEvent, type ReactElement } from "react";
-import { PlanCoachProjectionDataSchema } from "@enduragent/coach-contract";
+import {
+  PlanCoachProjectionDataSchema,
+  type PlanFtpProjection,
+  type PlanFtpSourceValue,
+} from "@enduragent/coach-contract";
 import { Button } from "../../components/ui/button.js";
 import {
   Dialog,
@@ -163,6 +167,184 @@ function PlanQueue(): ReactElement | null {
   );
 }
 
+const FTP_SCENARIOS = new Set([
+  "PL-S003",
+  "PL-S057",
+  "PL-S058",
+  "PL-S059",
+  "PL-S060",
+  "PL-S061",
+  "PL-S062",
+]);
+
+function ftpSourceCopy(value: PlanFtpSourceValue | null, empty: string): string {
+  if (value === null) return empty;
+  const refreshed = new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(value.refreshedAtMs);
+  return `${value.watts} W · ${refreshed}`;
+}
+
+function FtpSourceRow(props: {
+  readonly label: string;
+  readonly value: PlanFtpSourceValue | null;
+  readonly empty: string;
+  readonly selected: boolean;
+}): ReactElement {
+  return (
+    <div className="grid gap-1 py-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-inset">
+      <span className="text-sm font-medium">{props.label}</span>
+      <span className={props.selected ? "text-sm text-primary" : "text-sm text-ink-2"}>
+        {ftpSourceCopy(props.value, props.empty)}
+        {props.selected ? " · Used for this Draft" : ""}
+      </span>
+    </div>
+  );
+}
+
+function FtpResolution(props: { readonly ftp: PlanFtpProjection }): ReactElement {
+  const actions = useEnduragentStore((state) => state.planActions);
+  const model = useEnduragentStore((state) => planReadModel(state.plan));
+  const transition = useEnduragentStore((state) => state.plan.transition);
+  const [watts, setWatts] = useState(
+    props.ftp.manual === null ? "" : String(props.ftp.manual.watts),
+  );
+  const [validation, setValidation] = useState<string | null>(null);
+  const [pending, setPending] = useState<"save" | "refresh" | null>(null);
+  const busy =
+    (transition.status === "submitting" || transition.status === "running") &&
+    transition.transitionId === "PL-T04";
+  const failure =
+    transition.status === "failed" && transition.transitionId === "PL-T04"
+      ? transition.error.message
+      : null;
+  const submit = (event: FormEvent): void => {
+    event.preventDefault();
+    const value = Number(watts);
+    if (!/^\d{1,4}$/u.test(watts) || !Number.isSafeInteger(value) || value < 1) {
+      setValidation("Enter 1–9999 whole watts.");
+      return;
+    }
+    setValidation(null);
+    setPending("save");
+    actions?.saveFtp(value);
+  };
+  const notice =
+    failure ??
+    validation ??
+    (model?.scenarioId === "PL-S058"
+      ? "No FTP was found in Intervals. Enter watts or refresh again."
+      : model?.scenarioId === "PL-S060"
+        ? "Sources differ. The highest-precedence value is selected for this Draft."
+        : model?.scenarioId === "PL-S062"
+          ? "FTP saved. Returning to your Plan coach…"
+          : null);
+  const scenario = busy && pending === "refresh" ? "PL-S057" : model?.scenarioId;
+  const accepted = model?.scenarioId === "PL-S062";
+
+  return (
+    <section
+      className="grid gap-6 rounded-card bg-surface p-5 shadow-elev-1"
+      data-plan-scenario={scenario}
+    >
+      <div className="flex items-start gap-row">
+        {accepted ? (
+          <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-ok" aria-hidden="true" />
+        ) : (
+          <TriangleAlert className="mt-0.5 size-4 shrink-0 text-warn" aria-hidden="true" />
+        )}
+        <div className={SUPPORT_PAIR}>
+          <h2 className="m-0 text-base font-semibold">
+            FTP needed before we build your cycling block
+          </h2>
+          <p className="m-0 text-ink-2">Power targets require an FTP value.</p>
+        </div>
+      </div>
+      <form className="flex flex-wrap items-start gap-inset" onSubmit={submit}>
+        <div className={SUPPORT_PAIR}>
+          <label className="sr-only" htmlFor="plan-ftp-watts">
+            FTP in whole watts
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              id="plan-ftp-watts"
+              className="h-ctl w-28 rounded-ctl border border-line-2 bg-sunk px-3 text-sm outline-none focus:border-ring focus:ring-3 focus:ring-ring/20"
+              inputMode="numeric"
+              maxLength={4}
+              placeholder="e.g. 282"
+              value={watts}
+              disabled={busy}
+              aria-invalid={validation === null ? undefined : "true"}
+              aria-describedby={notice === null ? undefined : "plan-ftp-notice"}
+              onChange={(event) => setWatts(event.currentTarget.value.replace(/\D/gu, ""))}
+            />
+            <span className="text-sm text-ink-2">W</span>
+          </div>
+        </div>
+        <Button type="submit" disabled={actions === null || busy || watts.length === 0}>
+          {busy && pending === "save" ? "Saving…" : "Save"}
+        </Button>
+      </form>
+      {notice === null ? null : (
+        <div
+          id="plan-ftp-notice"
+          className={`rounded-ctl p-3 text-sm ${model?.scenarioId === "PL-S062" ? "bg-[color-mix(in_srgb,var(--ok)_10%,var(--surface))] text-ok" : "bg-[color-mix(in_srgb,var(--warn)_10%,var(--surface))] text-ink"}`}
+          role="status"
+        >
+          {notice}
+        </div>
+      )}
+      <section aria-labelledby="plan-ftp-source-status">
+        <h3 id="plan-ftp-source-status" className="m-0 text-sm font-medium">
+          Source status
+        </h3>
+        <div className="mt-inset divide-y divide-line">
+          <FtpSourceRow
+            label="Athlete-entered FTP"
+            value={props.ftp.manual}
+            empty="Not entered"
+            selected={props.ftp.usedSource === "manual"}
+          />
+          <FtpSourceRow
+            label="Intervals FTP"
+            value={props.ftp.intervalsFtp}
+            empty="Not found"
+            selected={props.ftp.usedSource === "intervals-ftp"}
+          />
+          <FtpSourceRow
+            label="Intervals eFTP"
+            value={props.ftp.intervalsEftp}
+            empty="Not found"
+            selected={props.ftp.usedSource === "intervals-eftp"}
+          />
+        </div>
+      </section>
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={actions === null || busy}
+          onClick={() => {
+            setPending("refresh");
+            actions?.refreshFtp();
+          }}
+        >
+          <RefreshCw
+            className={busy && pending === "refresh" ? "animate-spin" : ""}
+            aria-hidden="true"
+          />
+          {busy && pending === "refresh"
+            ? "Refreshing…"
+            : model?.scenarioId === "PL-S059"
+              ? "Retry"
+              : "Refresh Intervals"}
+        </Button>
+      </div>
+    </section>
+  );
+}
+
 function PlanCoach(): ReactElement {
   const composer = useRef<ComposerHandle>(null);
   const actions = useEnduragentStore((state) => state.planActions);
@@ -187,6 +369,10 @@ function PlanCoach(): ReactElement {
         })) ?? []);
   const decision = coach.decision ?? data?.decision ?? null;
 
+  if (data?.ftp !== undefined && data.ftp !== null && FTP_SCENARIOS.has(model?.scenarioId ?? "")) {
+    return <FtpResolution ftp={data.ftp} />;
+  }
+
   return (
     <section
       className="grid gap-6 rounded-card bg-surface p-5 shadow-elev-1"
@@ -199,6 +385,14 @@ function PlanCoach(): ReactElement {
             <h2 className="m-0 text-base font-medium text-ink">Draft discarded</h2>
             <p className="m-0 text-ink-2">Your Plan conversation is still here.</p>
           </div>
+        </div>
+      ) : null}
+      {data?.ftp?.conflict === true && data.ftp.usedWatts !== null ? (
+        <div
+          className="rounded-ctl bg-[color-mix(in_srgb,var(--warn)_10%,var(--surface))] p-3 text-sm"
+          role="status"
+        >
+          Using {data.ftp.usedWatts} W from the selected FTP source. Other FTP sources differ.
         </div>
       ) : null}
       <ConversationTranscript

--- a/apps/desktop-renderer/tests/plan-adapter.test.ts
+++ b/apps/desktop-renderer/tests/plan-adapter.test.ts
@@ -163,6 +163,108 @@ describe("Plan view adapter", () => {
     expect(subject.surface.hydration.status).toBe("ready");
   });
 
+  it("saves manual FTP and automatically returns to the Plan coach", async () => {
+    const required = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S003",
+      projection: "coach",
+      data: planCoachData({
+        ftp: {
+          status: "required",
+          manual: null,
+          intervalsFtp: null,
+          intervalsEftp: null,
+          usedSource: null,
+          usedWatts: null,
+          conflict: false,
+          error: null,
+        },
+      }),
+    });
+    const accepted = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S062",
+      projection: "coach",
+      data: planCoachData({
+        ftp: {
+          status: "accepted",
+          manual: { watts: 282, refreshedAtMs: 1 },
+          intervalsFtp: null,
+          intervalsEftp: null,
+          usedSource: "manual",
+          usedWatts: 282,
+          conflict: false,
+          error: null,
+        },
+      }),
+    });
+    const resumed = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S016",
+      projection: "coach",
+      data: planCoachData({ ready: true }),
+    });
+    const getPlanState = vi
+      .fn<() => Promise<GetPlanStateRpcResult>>()
+      .mockResolvedValueOnce({ status: "ready", state: required })
+      .mockResolvedValueOnce({ status: "ready", state: resumed });
+    const subject = harness({
+      ids: ["ftp-command"],
+      getPlanState,
+      executePlanTransition: async () => ({ status: "completed", state: accepted }),
+    });
+    subject.adapter.start();
+    await settle();
+
+    subject.adapter.saveFtp(282);
+    await settle();
+    expect(subject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T04",
+      commandId: "ftp-command",
+      conversationId: "00000000000000000000000001",
+      source: "manual",
+      watts: 282,
+    });
+    expect(getPlanState).toHaveBeenCalledTimes(2);
+    expect(subject.surface.hydration).toEqual({ status: "ready", state: resumed });
+  });
+
+  it("refreshes all Intervals FTP sources through the generic PL-T04 command", async () => {
+    const initial = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S003",
+      projection: "coach",
+      data: planCoachData({
+        ftp: {
+          status: "required",
+          manual: null,
+          intervalsFtp: null,
+          intervalsEftp: null,
+          usedSource: null,
+          usedWatts: null,
+          conflict: false,
+          error: null,
+        },
+      }),
+    });
+    const subject = harness({
+      ids: ["refresh-command"],
+      getPlanState: async () => ({ status: "ready", state: initial }),
+    });
+    subject.adapter.start();
+    await settle();
+
+    subject.adapter.refreshFtp();
+    await settle();
+    expect(subject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T04",
+      commandId: "refresh-command",
+      conversationId: "00000000000000000000000001",
+      source: "intervals",
+      watts: null,
+    });
+  });
+
   it("keeps a rejected transition inside Plan and retries it with a new command", async () => {
     const subject = harness({
       ids: ["rejected-command", "retry-command"],

--- a/apps/desktop-renderer/tests/plan-fixtures.ts
+++ b/apps/desktop-renderer/tests/plan-fixtures.ts
@@ -4,6 +4,7 @@ import type {
   PlanAttention,
   PlanDraftProjection,
   PlanError,
+  PlanFtpProjection,
   PlanProjectionKind,
   PlanReadModel,
 } from "@enduragent/coach-contract";
@@ -79,6 +80,7 @@ export function planCoachData(
       readonly role: "athlete" | "coach";
       readonly text: string;
     }[];
+    readonly ftp?: PlanFtpProjection | null;
   } = {},
 ): PlanReadModel["data"] {
   return {
@@ -98,5 +100,6 @@ export function planCoachData(
     queue: input.queue ?? { schemaVersion: 1, revision: 0, items: [] },
     decision: input.decision ?? null,
     draft: input.draft ?? null,
+    ...(input.ftp === undefined ? {} : { ftp: input.ftp }),
   };
 }

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -18,6 +18,8 @@ function actions(): PlanActions {
     retryQueuedCoachTurn: vi.fn(),
     answerCoachDecision: vi.fn(),
     skipCoachDecision: vi.fn(),
+    saveFtp: vi.fn(),
+    refreshFtp: vi.fn(),
     createDraft: vi.fn(),
     updateDraft: vi.fn(),
     openDiscardConfirmation: vi.fn(),
@@ -154,6 +156,117 @@ describe("Plan surface", () => {
     expect(planActions.submitCoach).toHaveBeenCalledWith("Four days each week.");
     await user.click(screen.getByRole("button", { name: "Create draft" }));
     expect(planActions.createDraft).toHaveBeenCalledOnce();
+  });
+
+  it("resolves FTP with one compact whole-watts control and an Intervals refresh", async () => {
+    const user = userEvent.setup();
+    const planActions = actions();
+    const state = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S003",
+      projection: "coach",
+      data: planCoachData({
+        ftp: {
+          status: "required",
+          manual: null,
+          intervalsFtp: null,
+          intervalsEftp: null,
+          usedSource: null,
+          usedWatts: null,
+          conflict: false,
+          error: null,
+        },
+      }),
+    });
+    useEnduragentStore.setState({
+      plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state }, lastReady: state },
+      planActions,
+    });
+    render(<PlanView />);
+
+    expect(
+      screen.getByRole("heading", { name: "FTP needed before we build your cycling block" }),
+    ).toBeInTheDocument();
+    const input = screen.getByRole("textbox", { name: "FTP in whole watts" });
+    expect(input).toHaveAttribute("maxlength", "4");
+    expect(input).toHaveClass("w-28");
+    await user.type(input, "282");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(planActions.saveFtp).toHaveBeenCalledWith(282);
+    await user.click(screen.getByRole("button", { name: "Refresh Intervals" }));
+    expect(planActions.refreshFtp).toHaveBeenCalledOnce();
+  });
+
+  it("shows the selected FTP source and keeps conflicting values visible", () => {
+    const state = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S060",
+      projection: "coach",
+      data: planCoachData({
+        ftp: {
+          status: "conflict",
+          manual: { watts: 282, refreshedAtMs: 1 },
+          intervalsFtp: { watts: 278, refreshedAtMs: 2 },
+          intervalsEftp: { watts: 280, refreshedAtMs: 3 },
+          usedSource: "manual",
+          usedWatts: 282,
+          conflict: true,
+          error: null,
+        },
+      }),
+    });
+    useEnduragentStore.setState({
+      plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state }, lastReady: state },
+    });
+    render(<PlanView />);
+
+    expect(screen.getByText(/282 W.*Used for this Draft/u)).toBeInTheDocument();
+    expect(screen.getByText(/278 W/u)).toBeInTheDocument();
+    expect(screen.getByText(/280 W/u)).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("highest-precedence value");
+  });
+
+  it("keeps a failed Intervals refresh recoverable without hiding manual entry", async () => {
+    const user = userEvent.setup();
+    const planActions = actions();
+    const error = { code: "provider-failed" as const, message: "Refresh failed", retryable: true };
+    const state = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S059",
+      projection: "coach",
+      data: planCoachData({
+        ftp: {
+          status: "refresh-failed",
+          manual: null,
+          intervalsFtp: null,
+          intervalsEftp: null,
+          usedSource: null,
+          usedWatts: null,
+          conflict: false,
+          error,
+        },
+      }),
+    });
+    useEnduragentStore.setState({
+      plan: {
+        ...EMPTY_PLAN_SURFACE,
+        hydration: { status: "ready", state },
+        lastReady: state,
+        transition: {
+          status: "failed",
+          commandId: "command-1",
+          transitionId: "PL-T04",
+          error,
+        },
+      },
+      planActions,
+    });
+    render(<PlanView />);
+
+    expect(screen.getByRole("textbox", { name: "FTP in whole watts" })).toBeEnabled();
+    expect(screen.getByRole("status")).toHaveTextContent("Refresh failed");
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(planActions.refreshFtp).toHaveBeenCalledOnce();
   });
 
   it("confirms Draft discard with Cancel focused before the destructive action", async () => {

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -84,6 +84,8 @@ function stubPlanActions(): PlanActions {
     retryQueuedCoachTurn: vi.fn(),
     answerCoachDecision: vi.fn(),
     skipCoachDecision: vi.fn(),
+    saveFtp: vi.fn(),
+    refreshFtp: vi.fn(),
     createDraft: vi.fn(),
     updateDraft: vi.fn(),
     openDiscardConfirmation: vi.fn(),

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -49,6 +49,8 @@ function stubPlanActions(): PlanActions {
     retryQueuedCoachTurn: vi.fn(),
     answerCoachDecision: vi.fn(),
     skipCoachDecision: vi.fn(),
+    saveFtp: vi.fn(),
+    refreshFtp: vi.fn(),
     createDraft: vi.fn(),
     updateDraft: vi.fn(),
     openDiscardConfirmation: vi.fn(),

--- a/packages/coach-contract/src/planning.ts
+++ b/packages/coach-contract/src/planning.ts
@@ -266,6 +266,78 @@ export const PlanDraftProjectionSchema = z
   .strict();
 export type PlanDraftProjection = z.infer<typeof PlanDraftProjectionSchema>;
 
+export const PlanFtpSourceValueSchema = z
+  .object({
+    watts: z.number().int().min(1).max(9_999),
+    refreshedAtMs: z.number().int().nonnegative(),
+  })
+  .strict();
+export type PlanFtpSourceValue = z.infer<typeof PlanFtpSourceValueSchema>;
+
+export const PlanFtpProjectionSchema = z
+  .object({
+    status: z.enum(["required", "no-source", "refresh-failed", "conflict", "accepted"]),
+    manual: PlanFtpSourceValueSchema.nullable(),
+    intervalsFtp: PlanFtpSourceValueSchema.nullable(),
+    intervalsEftp: PlanFtpSourceValueSchema.nullable(),
+    usedSource: z.enum(["manual", "intervals-ftp", "intervals-eftp"]).nullable(),
+    usedWatts: z.number().int().min(1).max(9_999).nullable(),
+    conflict: z.boolean(),
+    error: PlanErrorSchema.nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if ((value.usedSource === null) !== (value.usedWatts === null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["usedWatts"],
+        message: "used FTP source and watts must appear together",
+      });
+    }
+    const selected =
+      value.usedSource === "manual"
+        ? value.manual
+        : value.usedSource === "intervals-ftp"
+          ? value.intervalsFtp
+          : value.usedSource === "intervals-eftp"
+            ? value.intervalsEftp
+            : null;
+    if (value.usedSource !== null && selected === null) {
+      context.addIssue({
+        code: "custom",
+        path: ["usedSource"],
+        message: "used FTP source must be available",
+      });
+    }
+    if (selected !== null && selected.watts !== value.usedWatts) {
+      context.addIssue({
+        code: "custom",
+        path: ["usedWatts"],
+        message: "used FTP watts must match the selected source",
+      });
+    }
+    if ((value.status === "refresh-failed") !== (value.error !== null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["error"],
+        message: "only a failed FTP refresh carries an error",
+      });
+    }
+    if (
+      ((value.status === "required" || value.status === "no-source") &&
+        value.usedSource !== null) ||
+      (value.status === "accepted" && (value.usedSource === null || value.conflict)) ||
+      (value.status === "conflict" && (value.usedSource === null || !value.conflict))
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["status"],
+        message: "FTP status must match source availability and conflict state",
+      });
+    }
+  });
+export type PlanFtpProjection = z.infer<typeof PlanFtpProjectionSchema>;
+
 export const PlanCoachProjectionDataSchema = z
   .object({
     conversationId: z.string().min(1),
@@ -277,6 +349,7 @@ export const PlanCoachProjectionDataSchema = z
     queue: ChatQueueSnapshotSchema,
     decision: CoachDecisionReadModelSchema.nullable(),
     draft: PlanDraftProjectionSchema.nullable(),
+    ftp: PlanFtpProjectionSchema.nullable().optional(),
   })
   .strict();
 export type PlanCoachProjectionData = z.infer<typeof PlanCoachProjectionDataSchema>;
@@ -361,7 +434,7 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
       transitionId: z.literal("PL-T04"),
       commandId: CommandIdSchema,
       conversationId: EntityIdSchema,
-      source: z.enum(["manual", "intervals-ftp", "intervals-eftp"]),
+      source: z.enum(["manual", "intervals", "intervals-ftp", "intervals-eftp"]),
       watts: z.number().int().min(1).max(9_999).nullable(),
     })
     .strict()

--- a/packages/coach-contract/tests/planning.test.ts
+++ b/packages/coach-contract/tests/planning.test.ts
@@ -4,6 +4,7 @@ import {
   GetPlanStateRpcResultSchema,
   PLAN_TRANSITION_IDS,
   PlanAttentionSchema,
+  PlanFtpProjectionSchema,
   PlanHydrationStateSchema,
   PlanProgressEventSchema,
   PlanScenarioIdSchema,
@@ -166,6 +167,48 @@ describe("planning contract", () => {
         source: "intervals-ftp",
         watts: 282,
       }).success,
+    ).toBe(false);
+    expect(
+      PlanTransitionCommandSchema.safeParse({
+        transitionId: "PL-T04",
+        commandId,
+        conversationId,
+        source: "intervals",
+        watts: null,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("keeps selected FTP source, value, conflicts, and refresh failures coherent", () => {
+    const accepted = {
+      status: "accepted" as const,
+      manual: { watts: 282, refreshedAtMs: 1 },
+      intervalsFtp: { watts: 282, refreshedAtMs: 2 },
+      intervalsEftp: null,
+      usedSource: "manual" as const,
+      usedWatts: 282,
+      conflict: false,
+      error: null,
+    };
+    expect(PlanFtpProjectionSchema.parse(accepted)).toEqual(accepted);
+    expect(PlanFtpProjectionSchema.safeParse({ ...accepted, usedWatts: 278 }).success).toBe(false);
+    expect(
+      PlanFtpProjectionSchema.safeParse({
+        ...accepted,
+        status: "conflict",
+        intervalsFtp: { watts: 278, refreshedAtMs: 2 },
+        conflict: true,
+      }).success,
+    ).toBe(true);
+    expect(
+      PlanFtpProjectionSchema.safeParse({
+        ...accepted,
+        status: "refresh-failed",
+        error: { code: "provider-failed", message: "Refresh failed", retryable: true },
+      }).success,
+    ).toBe(true);
+    expect(
+      PlanFtpProjectionSchema.safeParse({ ...accepted, status: "accepted", error: {} }).success,
     ).toBe(false);
   });
 

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -49,6 +49,7 @@ import {
   type EngineConfig,
   type EngineHostPorts,
   type ModelTransportDecorator,
+  type PlanFtpSourceValue,
   type ReferenceStateSnapshot,
 } from "@enduragent/engine";
 import { resolveUserTimezone, todayInTZ } from "@enduragent/engine/sport";
@@ -85,10 +86,11 @@ import {
   type ListArchivedConversationsRpcParams,
   type ListArchivedConversationsRpcResult,
   type GetRuntimeConfigRpcResult,
+  type PlanningOperations,
   type VerifyIntervalsCredentialRpcParams,
   type VerifyIntervalsCredentialRpcResult,
 } from "@enduragent/coach-contract";
-import { cyclingSport } from "@enduragent/sport-cycling";
+import { createCyclingPlanFtpAdapter, cyclingSport } from "@enduragent/sport-cycling";
 import { createPersistedAthleteStateSource } from "./athlete-state-reader.js";
 import { createPowerProgressStateSource } from "./power-progress.js";
 import { createRecentRidesSource } from "./recent-rides.js";
@@ -163,7 +165,7 @@ interface OAuthCredential extends StoredProfile {
 
 export interface LocalCoachComposition {
   readonly engine: CoachEngine;
-  readonly operations: CoachOperations;
+  readonly operations: CoachOperations & PlanningOperations;
   readonly spendMeter: SpendMeterService;
   readonly confirmations: Pick<ConfirmationGate, "peek" | "confirm" | "cancel">;
   startInitialRefresh(): Promise<void>;
@@ -1455,42 +1457,125 @@ export async function createLocalCoachComposition(
       credentials: options.liveIntervals,
       sources: trustedActivitySources,
     });
-    const planningOperations = createPlanningOperations({
-      context: input.context,
-      engine: reconfigurable.engine,
-      identity: planningIdentity,
+    const coachOperations = createCoachOperations(
+      {
+        home: input.home,
+        context: input.context,
+        runtime,
+        intervalsCredentials: options.liveIntervals,
+        historyNewestDate: () => new Date(now()).toISOString().slice(0, 10),
+        readTranscriptPage: (request) => reconfigurable.getTranscriptPage(request),
+        readArchivedConversations: (request) => reconfigurable.listArchivedConversations(request),
+        readArchivedTranscriptPage: (request) => reconfigurable.getArchivedTranscriptPage(request),
+        applyRuntimeConfig,
+        verifyIntervalsCredential,
+        intervalsVerificationPending,
+        readRuntimeConfig: () =>
+          runtimeConfigSnapshot(
+            input.home.configDir,
+            unapprovedConfig,
+            input.env,
+            activeTimezone,
+            intervalsVerificationPending(),
+          ),
+      },
+      dependencies.operationsDependencies,
+    );
+    const readFtpAnchor = async (
+      confidence: "manual" | "platform",
+    ): Promise<PlanFtpSourceValue | null> => {
+      const row =
+        confidence === "manual"
+          ? await input.context.store.get(
+              "SELECT value, valid_from FROM anchor_history WHERE sport = ? AND anchor_type = ? AND confidence = ? ORDER BY valid_from DESC, id DESC LIMIT 1",
+              ["cycling", "ftp", confidence],
+            )
+          : await input.context.store.get(
+              "SELECT value, valid_from FROM anchor_history WHERE sport = ? AND anchor_type = ? AND confidence = ? AND source = ? ORDER BY valid_from DESC, id DESC LIMIT 1",
+              ["cycling", "ftp", confidence, "intervals-icu"],
+            );
+      if (
+        row === undefined ||
+        typeof row.value !== "number" ||
+        typeof row.valid_from !== "number"
+      ) {
+        return null;
+      }
+      return { watts: row.value, refreshedAtMs: row.valid_from * 1_000 };
+    };
+    const ftp = createCyclingPlanFtpAdapter({
+      readManual: () => readFtpAnchor("manual"),
+      readIntervalsFtp: () => readFtpAnchor("platform"),
+      async readIntervalsEftp() {
+        const latest = readReferenceState(input.home.root).latest;
+        const watts = latest?.derived_metrics?.eftp;
+        const refreshedAtMs = Date.parse(latest?.metadata?.last_updated ?? "");
+        return typeof watts === "number" && Number.isFinite(refreshedAtMs)
+          ? { watts, refreshedAtMs }
+          : null;
+      },
+      async saveManual(watts) {
+        const stamp = planningIdentity.hlcStamp();
+        const validFrom = Math.floor(stamp.physicalMs / 1_000);
+        const deviceId = await planningIdentity.deviceId();
+        const inserted = await repository.insertIfAbsent({
+          id: planningIdentity.newUlid(),
+          sport: "cycling",
+          anchor_type: "ftp",
+          value: watts,
+          unit: "W",
+          valid_from: validFrom,
+          source: "athlete",
+          confidence: "manual",
+          note: null,
+          provenance: "manual",
+          device_id: deviceId,
+          hlc_physical_ms: stamp.physicalMs,
+          hlc_counter: stamp.counter,
+        });
+        if (inserted) return;
+        const existing = await input.context.store.get(
+          "SELECT confidence FROM anchor_history WHERE sport = ? AND anchor_type = ? AND valid_from = ?",
+          ["cycling", "ftp", validFrom],
+        );
+        if (existing?.confidence !== "manual") throw new Error("Manual FTP could not be saved.");
+        await input.context.store.run(
+          "UPDATE anchor_history SET value = ?, unit = ?, source = ?, note = ?, provenance = ?, device_id = ?, hlc_physical_ms = ?, hlc_counter = ? WHERE sport = ? AND anchor_type = ? AND valid_from = ? AND confidence = ?",
+          [
+            watts,
+            "W",
+            "athlete",
+            null,
+            "manual",
+            deviceId,
+            stamp.physicalMs,
+            stamp.counter,
+            "cycling",
+            "ftp",
+            validFrom,
+            "manual",
+          ],
+        );
+      },
+      async refreshIntervals() {
+        await coachOperations.sync({});
+      },
     });
+    const planningOperations = createPlanningOperations(
+      {
+        context: input.context,
+        engine: reconfigurable.engine,
+        identity: planningIdentity,
+      },
+      { ftp },
+    );
     const operations = {
-      ...createCoachOperations(
-        {
-          home: input.home,
-          context: input.context,
-          runtime,
-          intervalsCredentials: options.liveIntervals,
-          historyNewestDate: () => new Date(now()).toISOString().slice(0, 10),
-          readTranscriptPage: (request) => reconfigurable.getTranscriptPage(request),
-          readArchivedConversations: (request) => reconfigurable.listArchivedConversations(request),
-          readArchivedTranscriptPage: (request) =>
-            reconfigurable.getArchivedTranscriptPage(request),
-          applyRuntimeConfig,
-          verifyIntervalsCredential,
-          intervalsVerificationPending,
-          readRuntimeConfig: () =>
-            runtimeConfigSnapshot(
-              input.home.configDir,
-              unapprovedConfig,
-              input.env,
-              activeTimezone,
-              intervalsVerificationPending(),
-            ),
-        },
-        dependencies.operationsDependencies,
-      ),
+      ...coachOperations,
       getActivityAnalysis: (request, signal) =>
         activityAnalysis.getActivityAnalysis(request, signal),
       exportTrainingFile: (request, signal) => trainingExport.export(request, signal),
       ...planningOperations,
-    } satisfies CoachOperations;
+    } satisfies CoachOperations & PlanningOperations;
     return {
       engine: reconfigurable.engine,
       operations,

--- a/packages/coach/src/planning-lifecycle.ts
+++ b/packages/coach/src/planning-lifecycle.ts
@@ -6,6 +6,7 @@ import {
   type PlanAttention,
   type PlanCoachMessage,
   type PlanDraftProjection,
+  type PlanFtpProjection,
   type PlanLifecycle,
   type PlanProjectionKind,
   type PlanReadModel,
@@ -33,6 +34,8 @@ export interface BuildPlanLifecycleReadModelInput {
   readonly queue: ChatQueueSnapshot;
   readonly decision: CoachDecisionReadModel | null;
   readonly draft: PlanDraftProjection | null;
+  readonly ftp?: PlanFtpProjection | null;
+  readonly ftpScenario?: "PL-S057" | "PL-S058" | "PL-S059" | "PL-S060" | "PL-S061" | "PL-S062";
 }
 
 const EMPTY_ATTENTION: PlanAttention = Object.freeze({
@@ -141,8 +144,31 @@ function stateKind(input: BuildPlanLifecycleReadModelInput): {
       ],
     };
   }
+  const ftpScenario =
+    input.ftpScenario ??
+    (input.ftp !== undefined && input.ftp?.usedSource === null ? "PL-S003" : null);
+  if (ftpScenario !== null) {
+    const copy = {
+      "PL-S003": ["FTP required", "Add FTP before the cycling Draft can be built."],
+      "PL-S057": ["Refreshing Intervals", "Checking FTP and eFTP sources."],
+      "PL-S058": ["FTP required", "No FTP source was found in Intervals."],
+      "PL-S059": ["FTP required", "Intervals could not be refreshed."],
+      "PL-S060": ["FTP source selected", "The highest-precedence source controls this Draft."],
+      "PL-S061": ["FTP required", "Enter 1–9999 whole watts."],
+      "PL-S062": ["FTP accepted", "Returning to the Plan coach automatically."],
+    } as const;
+    return {
+      scenarioId: ftpScenario,
+      lifecycle: replacement ? "replacement-intake" : "intake",
+      projection: "coach",
+      title: copy[ftpScenario][0],
+      summary: copy[ftpScenario][1],
+      transitions: [guard("PL-T04")],
+    };
+  }
   const discarded = draft?.status === "discarded";
-  const ready = input.readyToCreateDraft && !discarded;
+  const ftpReady = input.ftp === undefined || input.ftp === null || input.ftp.usedSource !== null;
+  const ready = input.readyToCreateDraft && ftpReady && !discarded;
   return {
     scenarioId: discarded
       ? "PL-S020"
@@ -199,6 +225,7 @@ export function buildPlanLifecycleReadModel(
     queue: input.queue,
     decision: input.decision,
     draft: input.draft,
+    ...(input.ftp === undefined ? {} : { ftp: input.ftp }),
   });
   return PlanReadModelSchema.parse({
     schemaVersion: 1,

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -4,6 +4,7 @@ import {
   GetPlanStateRpcParamsSchema,
   GetPlanStateRpcResultSchema,
   PlanDraftProjectionSchema,
+  PlanFtpProjectionSchema,
   PlanProgressEventSchema,
   type ChatQueueRunResult,
   type ChatQueueSnapshot,
@@ -12,11 +13,17 @@ import {
   type ExecutePlanTransitionRpcResult,
   type PlanDraftProjection,
   type PlanError,
+  type PlanFtpProjection,
   type PlanProgressEvent,
   type PlanReadModel,
   type PlanningOperations,
   type TurnEvent,
 } from "@enduragent/coach-contract";
+import {
+  executePlanFtpTransition,
+  type PlanFtpAdapter,
+  type PlanFtpSnapshot,
+} from "@enduragent/engine";
 import { buildPlanLifecycleReadModel } from "./planning-lifecycle.js";
 import {
   createPlanConversationRepository,
@@ -56,6 +63,18 @@ const PERSISTENCE_FAILED: PlanError = Object.freeze({
   retryable: true,
 });
 
+const FTP_REFRESH_FAILED: PlanError = Object.freeze({
+  code: "provider-failed",
+  message: "Couldn’t refresh Intervals. Try again.",
+  retryable: true,
+});
+
+const FTP_SAVE_FAILED: PlanError = Object.freeze({
+  code: "persistence-failed",
+  message: "FTP couldn’t be saved. Try again.",
+  retryable: true,
+});
+
 export interface PlanDraftBuild {
   readonly plan: PlanRecord;
   readonly workouts: readonly PlanWorkoutRecord[];
@@ -86,6 +105,7 @@ export interface CreatePlanningOperationsDependencies {
   readonly plans?: PlanRepository;
   readonly draftBuilder?: PlanDraftBuilder;
   readonly isReady?: (input: PlanReadinessInput) => boolean | Promise<boolean>;
+  readonly ftp?: PlanFtpAdapter;
 }
 
 function createSerializedLane(): <T>(operation: () => Promise<T>) => Promise<T> {
@@ -112,6 +132,37 @@ function draftProjection(value: PlanDraftRevisionRecord | undefined): PlanDraftP
     revision: value.revision,
     status: value.status,
     snapshot: snapshot(value.snapshotJson),
+  });
+}
+
+type FtpScenario = "PL-S057" | "PL-S058" | "PL-S059" | "PL-S060" | "PL-S061" | "PL-S062";
+
+function ftpProjection(
+  value: PlanFtpSnapshot,
+  scenario: FtpScenario | undefined,
+  error: PlanError | null,
+): PlanFtpProjection {
+  const status =
+    scenario === "PL-S058"
+      ? "no-source"
+      : scenario === "PL-S059"
+        ? "refresh-failed"
+        : scenario === "PL-S060"
+          ? "conflict"
+          : value.usedSource === null
+            ? "required"
+            : value.conflict
+              ? "conflict"
+              : "accepted";
+  return PlanFtpProjectionSchema.parse({
+    status,
+    manual: value.manual,
+    intervalsFtp: value.intervalsFtp,
+    intervalsEftp: value.intervalsEftp,
+    usedSource: value.usedSource,
+    usedWatts: value.usedWatts,
+    conflict: value.conflict,
+    error: status === "refresh-failed" ? error : null,
   });
 }
 
@@ -146,7 +197,10 @@ export function createPlanningOperations(
   const plans = dependencies.plans ?? createPlanRepository(input.context.store);
   const enqueue = createSerializedLane();
 
-  const read = async (): Promise<PlanReadModel> => {
+  const read = async (
+    ftpScenario?: FtpScenario,
+    ftpError: PlanError | null = null,
+  ): Promise<PlanReadModel> => {
     const conversation = await conversations.readLatestOpenConversation();
     if (conversation === undefined) {
       return buildPlanLifecycleReadModel({
@@ -159,7 +213,7 @@ export function createPlanningOperations(
       });
     }
     const chatId = `plan:${conversation.id}`;
-    const [turns, draft, queue, decision] = await Promise.all([
+    const [turns, draft, queue, decision, ftp] = await Promise.all([
       conversations.readTurns(conversation.id),
       conversations.readLatestDraftRevision(conversation.id),
       input.engine.getChatQueue?.({ chatId }).catch(() => EMPTY_QUEUE) ?? EMPTY_QUEUE,
@@ -167,6 +221,7 @@ export function createPlanningOperations(
         .getCoachDecision({ chatId })
         .then((result) => result.decision)
         .catch(() => null),
+      dependencies.ftp?.read(),
     ]);
     const ready = await (dependencies.isReady?.({ conversation, turns, draft }) ??
       Promise.resolve(false));
@@ -182,6 +237,8 @@ export function createPlanningOperations(
       queue,
       decision,
       draft: draftProjection(draft),
+      ...(ftp === undefined ? {} : { ftp: ftpProjection(ftp, ftpScenario, ftpError) }),
+      ...(ftpScenario === undefined ? {} : { ftpScenario }),
     });
   };
 
@@ -361,8 +418,15 @@ export function createPlanningOperations(
     });
   };
 
-  const reject = async (error: PlanError): Promise<ExecutePlanTransitionRpcResult> =>
-    ExecutePlanTransitionRpcResultSchema.parse({ status: "rejected", error, state: await read() });
+  const reject = async (
+    error: PlanError,
+    ftpScenario?: FtpScenario,
+  ): Promise<ExecutePlanTransitionRpcResult> =>
+    ExecutePlanTransitionRpcResultSchema.parse({
+      status: "rejected",
+      error,
+      state: await read(ftpScenario, error),
+    });
 
   return {
     async getPlanState(request) {
@@ -430,6 +494,53 @@ export function createPlanningOperations(
               total: 1,
             });
             return reject(error === UNAVAILABLE ? UNAVAILABLE : PROVIDER_FAILED);
+          }
+        }
+        if (command.transitionId === "PL-T04") {
+          if (dependencies.ftp === undefined) return reject(UNAVAILABLE);
+          const conversation = await conversations.readConversation(command.conversationId);
+          if (conversation === undefined || conversation.status !== "open")
+            return reject(UNAVAILABLE);
+          const operationId = input.identity.newUlid();
+          deliver(onEvent, {
+            commandId: command.commandId,
+            transitionId: command.transitionId,
+            operationId,
+            phase: "running",
+            completed: 0,
+            total: 1,
+          });
+          try {
+            const ftp = await executePlanFtpTransition(dependencies.ftp, {
+              source: command.source,
+              watts: command.watts,
+            });
+            const scenario: FtpScenario =
+              ftp.usedSource === null ? "PL-S058" : ftp.conflict ? "PL-S060" : "PL-S062";
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "completed",
+              completed: 1,
+              total: 1,
+            });
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read(scenario),
+            });
+          } catch {
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "failed",
+              completed: 0,
+              total: 1,
+            });
+            return command.source === "manual"
+              ? reject(FTP_SAVE_FAILED, "PL-S061")
+              : reject(FTP_REFRESH_FAILED, "PL-S059");
           }
         }
         if (command.transitionId === "PL-T06" || command.transitionId === "PL-T07") {

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -519,9 +519,9 @@ describe("local coach composition", () => {
     const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
 
     expect(engineInput.ports.platform.calendarMutations.updateEvent).toBeTypeOf("function");
-    expect(engineInput.ports.toolConfirmations!.gatedToolNames.has("intervals_update_workout")).toBe(
-      true,
-    );
+    expect(
+      engineInput.ports.toolConfirmations!.gatedToolNames.has("intervals_update_workout"),
+    ).toBe(true);
 
     await lifecycle.close();
   });
@@ -1942,6 +1942,96 @@ describe("local coach composition", () => {
       plannedWorkouts: state.plannedWorkouts,
       degraded: true,
     });
+    await lifecycle.close();
+  });
+
+  it("composes Plan FTP precedence from Intervals anchors, eFTP, and athlete input", async () => {
+    const home = await freshHome();
+    await mkdir(home.storeDir, { recursive: true });
+    const store = openSqliteStorage(join(home.storeDir, "store.db"));
+    stores.push(store);
+    await runMigrations(store, MIGRATIONS);
+    await store.run(
+      "INSERT INTO anchor_history (id, sport, anchor_type, value, unit, valid_from, source, confidence, note, provenance, device_id, hlc_physical_ms, hlc_counter) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+      [
+        "intervals-ftp",
+        "cycling",
+        "ftp",
+        275,
+        "W",
+        1_752_796_000,
+        "intervals-icu",
+        "platform",
+        null,
+        "sync",
+        null,
+        null,
+        null,
+      ],
+    );
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        now: () => 1_752_796_800_000,
+      },
+      { home, store, listener: inertWriterProtocolListener },
+    );
+    const started = await lifecycle.operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    expect(started).toMatchObject({
+      status: "completed",
+      state: {
+        data: {
+          ftp: {
+            usedSource: "intervals-ftp",
+            usedWatts: 275,
+            intervalsEftp: { watts: 260 },
+            conflict: true,
+          },
+        },
+      },
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+    await expect(
+      lifecycle.operations.executePlanTransition?.({
+        transitionId: "PL-T04",
+        commandId: "command-2",
+        conversationId,
+        source: "manual",
+        watts: 282,
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S060",
+        data: { ftp: { usedSource: "manual", usedWatts: 282, conflict: true } },
+      },
+    });
+    await expect(
+      lifecycle.operations.executePlanTransition?.({
+        transitionId: "PL-T04",
+        commandId: "command-3",
+        conversationId,
+        source: "manual",
+        watts: 285,
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: { data: { ftp: { usedSource: "manual", usedWatts: 285 } } },
+    });
+    await expect(
+      store.get(
+        "SELECT value, source, confidence FROM anchor_history WHERE sport = ? AND anchor_type = ? AND confidence = ?",
+        ["cycling", "ftp", "manual"],
+      ),
+    ).resolves.toEqual({ value: 285, source: "athlete", confidence: "manual" });
     await lifecycle.close();
   });
 

--- a/packages/coach/tests/planning-lifecycle.test.ts
+++ b/packages/coach/tests/planning-lifecycle.test.ts
@@ -22,6 +22,68 @@ function build(input: Partial<Parameters<typeof buildPlanLifecycleReadModel>[0]>
 }
 
 describe("Plan lifecycle projection", () => {
+  it("blocks Draft creation until an FTP source is available", () => {
+    const ftp = {
+      status: "required" as const,
+      manual: null,
+      intervalsFtp: null,
+      intervalsEftp: null,
+      usedSource: null,
+      usedWatts: null,
+      conflict: false,
+      error: null,
+    };
+    const blocked = build({ readyToCreateDraft: true, ftp });
+    expect(blocked).toMatchObject({ scenarioId: "PL-S003", projection: "coach" });
+    expect(blocked.transitions.map((transition) => transition.transitionId)).not.toContain(
+      "PL-T06",
+    );
+    expect(
+      build({
+        readyToCreateDraft: true,
+        ftp: {
+          ...ftp,
+          status: "accepted",
+          manual: { watts: 282, refreshedAtMs: 1 },
+          usedSource: "manual",
+          usedWatts: 282,
+        },
+      }),
+    ).toMatchObject({ scenarioId: "PL-S016" });
+  });
+
+  it("projects FTP refresh, conflict, failure, and accepted return states", () => {
+    const ftp = {
+      status: "accepted" as const,
+      manual: { watts: 282, refreshedAtMs: 1 },
+      intervalsFtp: { watts: 282, refreshedAtMs: 2 },
+      intervalsEftp: null,
+      usedSource: "manual" as const,
+      usedWatts: 282,
+      conflict: false,
+      error: null,
+    };
+    expect(build({ ftp, ftpScenario: "PL-S057" })).toMatchObject({
+      scenarioId: "PL-S057",
+      title: "Refreshing Intervals",
+    });
+    expect(
+      build({
+        ftp: {
+          ...ftp,
+          status: "conflict",
+          intervalsFtp: { watts: 278, refreshedAtMs: 2 },
+          conflict: true,
+        },
+        ftpScenario: "PL-S060",
+      }),
+    ).toMatchObject({ scenarioId: "PL-S060", title: "FTP source selected" });
+    expect(build({ ftp, ftpScenario: "PL-S062" })).toMatchObject({
+      scenarioId: "PL-S062",
+      title: "FTP accepted",
+    });
+  });
+
   it("keeps the dedicated conversation available from intake through readiness", () => {
     expect(build()).toMatchObject({
       scenarioId: "PL-S017",

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -10,6 +10,7 @@ import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/ke
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import type { PlanFtpAdapter, PlanFtpSnapshot } from "@enduragent/engine";
 import { createPlanningOperations, type PlanDraftBuilder } from "../src/planning-operations.js";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
 
@@ -244,6 +245,131 @@ describe("Plan operations", () => {
     await expect(
       createPlanConversationRepository(store).readConversation(conversationId),
     ).resolves.toMatchObject({ status: "open" });
+  });
+
+  it("resolves manual and Intervals FTP sources before returning to the Plan coach", async () => {
+    let snapshot: PlanFtpSnapshot = {
+      manual: null,
+      intervalsFtp: null,
+      intervalsEftp: null,
+      usedSource: null,
+      usedWatts: null,
+      conflict: false,
+    };
+    const saveManual = vi.fn(async (watts: number) => {
+      snapshot = {
+        ...snapshot,
+        manual: { watts, refreshedAtMs: 10 },
+        usedSource: "manual",
+        usedWatts: watts,
+      };
+      return snapshot;
+    });
+    const refreshIntervals = vi.fn(async () => snapshot);
+    const ftp: PlanFtpAdapter = { read: async () => snapshot, saveManual, refreshIntervals };
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: identity() },
+      { ftp, isReady: () => true },
+    );
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    expect(started).toMatchObject({ status: "completed", state: { scenarioId: "PL-S003" } });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+    const saved = await operations.executePlanTransition?.({
+      transitionId: "PL-T04",
+      commandId: "command-2",
+      conversationId,
+      source: "manual",
+      watts: 282,
+    });
+    expect(saveManual).toHaveBeenCalledWith(282);
+    expect(saved).toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S062",
+        data: { ftp: { usedSource: "manual", usedWatts: 282 } },
+      },
+    });
+    await operations.executePlanTransition?.({
+      transitionId: "PL-T04",
+      commandId: "command-3",
+      conversationId,
+      source: "intervals",
+      watts: null,
+    });
+    expect(refreshIntervals).toHaveBeenCalledOnce();
+  });
+
+  it("keeps FTP refresh failures retryable and exposes source conflicts", async () => {
+    let mode: "failure" | "conflict" = "failure";
+    const empty: PlanFtpSnapshot = {
+      manual: null,
+      intervalsFtp: null,
+      intervalsEftp: null,
+      usedSource: null,
+      usedWatts: null,
+      conflict: false,
+    };
+    const conflict: PlanFtpSnapshot = {
+      manual: { watts: 282, refreshedAtMs: 1 },
+      intervalsFtp: { watts: 278, refreshedAtMs: 2 },
+      intervalsEftp: { watts: 280, refreshedAtMs: 3 },
+      usedSource: "manual",
+      usedWatts: 282,
+      conflict: true,
+    };
+    const ftp: PlanFtpAdapter = {
+      read: async () => (mode === "conflict" ? conflict : empty),
+      saveManual: async () => empty,
+      refreshIntervals: async () => {
+        if (mode === "failure") throw new Error("offline");
+        return conflict;
+      },
+    };
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: identity() },
+      { ftp },
+    );
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T04",
+        commandId: "command-2",
+        conversationId,
+        source: "intervals",
+        watts: null,
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      error: { retryable: true },
+      state: { scenarioId: "PL-S059", data: { ftp: { status: "refresh-failed" } } },
+    });
+    mode = "conflict";
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T04",
+        commandId: "command-3",
+        conversationId,
+        source: "intervals",
+        watts: null,
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S060",
+        data: { ftp: { status: "conflict", usedSource: "manual", usedWatts: 282 } },
+      },
+    });
   });
 
   it("retries an interrupted Plan queue claim and persists the recovered turn", async () => {

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -403,6 +403,7 @@ export interface ReferenceStateSnapshot {
   } | null;
   readonly latest: {
     readonly metadata?: { readonly last_updated?: string };
+    readonly derived_metrics?: { readonly eftp?: number | null };
   } | null;
 }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -281,6 +281,14 @@ export {
   type RaceCourseRecalculatingState,
   type RaceCourseRecalculationFailedState,
 } from "./planning/race-course.js";
+export {
+  executePlanFtpTransition,
+  type PlanFtpAdapter,
+  type PlanFtpSnapshot,
+  type PlanFtpSource,
+  type PlanFtpSourceValue,
+  type PlanFtpTransitionInput,
+} from "./planning/ftp.js";
 export { makeSummaryMessage, splitHistoryByBudget, SUMMARY_PREFIX } from "./agent/history-limit.js";
 export { truncateUtf16Safe } from "./text-truncate.js";
 export { warnOrphanSections, _resetOrphanWarnCacheForTesting } from "./sport/orphan-sections.js";

--- a/packages/engine/src/planning/ftp.ts
+++ b/packages/engine/src/planning/ftp.ts
@@ -1,0 +1,38 @@
+export type PlanFtpSource = "manual" | "intervals-ftp" | "intervals-eftp";
+
+export interface PlanFtpSourceValue {
+  readonly watts: number;
+  readonly refreshedAtMs: number;
+}
+
+export interface PlanFtpSnapshot {
+  readonly manual: PlanFtpSourceValue | null;
+  readonly intervalsFtp: PlanFtpSourceValue | null;
+  readonly intervalsEftp: PlanFtpSourceValue | null;
+  readonly usedSource: PlanFtpSource | null;
+  readonly usedWatts: number | null;
+  readonly conflict: boolean;
+}
+
+export interface PlanFtpAdapter {
+  read(): Promise<PlanFtpSnapshot>;
+  saveManual(watts: number): Promise<PlanFtpSnapshot>;
+  refreshIntervals(): Promise<PlanFtpSnapshot>;
+}
+
+export interface PlanFtpTransitionInput {
+  readonly source: "manual" | "intervals" | "intervals-ftp" | "intervals-eftp";
+  readonly watts: number | null;
+}
+
+export async function executePlanFtpTransition(
+  adapter: PlanFtpAdapter,
+  input: PlanFtpTransitionInput,
+): Promise<PlanFtpSnapshot> {
+  if (input.source === "manual") {
+    if (input.watts === null) throw new TypeError("Manual FTP requires watts.");
+    return adapter.saveManual(input.watts);
+  }
+  if (input.watts !== null) throw new TypeError("Intervals refresh forbids manual watts.");
+  return adapter.refreshIntervals();
+}

--- a/packages/engine/src/sport.ts
+++ b/packages/engine/src/sport.ts
@@ -248,3 +248,9 @@ export {
   createPureCoreIntervalsTools,
 } from "./sport/platform-tools.js";
 export { resolveUserTimezone, todayInTZ } from "./sport/user-time.js";
+export type {
+  PlanFtpAdapter,
+  PlanFtpSnapshot,
+  PlanFtpSource,
+  PlanFtpSourceValue,
+} from "./planning/ftp.js";

--- a/packages/engine/tests/export-map.test.ts
+++ b/packages/engine/tests/export-map.test.ts
@@ -64,6 +64,7 @@ describe("engine public export surface", () => {
       "demoteSummaryHeadings",
       "ensureClaudeCliReady",
       "ensureCodexAgentReady",
+      "executePlanFtpTransition",
       "extractAccountId",
       "failRaceCourseRecalculation",
       "formatCompactionNote",

--- a/packages/engine/tests/plan-ftp.test.ts
+++ b/packages/engine/tests/plan-ftp.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  executePlanFtpTransition,
+  type PlanFtpAdapter,
+  type PlanFtpSnapshot,
+} from "../src/planning/ftp.js";
+
+const snapshot: PlanFtpSnapshot = {
+  manual: null,
+  intervalsFtp: { watts: 282, refreshedAtMs: 1_000 },
+  intervalsEftp: { watts: 289, refreshedAtMs: 1_000 },
+  usedSource: "intervals-ftp",
+  usedWatts: 282,
+  conflict: true,
+};
+
+function adapter(): {
+  readonly value: PlanFtpAdapter;
+  readonly saveManual: ReturnType<typeof vi.fn<PlanFtpAdapter["saveManual"]>>;
+  readonly refreshIntervals: ReturnType<typeof vi.fn<PlanFtpAdapter["refreshIntervals"]>>;
+} {
+  const saveManual = vi.fn<PlanFtpAdapter["saveManual"]>(async () => snapshot);
+  const refreshIntervals = vi.fn<PlanFtpAdapter["refreshIntervals"]>(async () => snapshot);
+  return {
+    value: { read: async () => snapshot, saveManual, refreshIntervals },
+    saveManual,
+    refreshIntervals,
+  };
+}
+
+describe("Plan FTP transition", () => {
+  it("saves a manual source without refreshing Intervals", async () => {
+    const selected = adapter();
+    await expect(
+      executePlanFtpTransition(selected.value, { source: "manual", watts: 282 }),
+    ).resolves.toEqual(snapshot);
+    expect(selected.saveManual).toHaveBeenCalledWith(282);
+    expect(selected.refreshIntervals).not.toHaveBeenCalled();
+  });
+
+  it.each(["intervals", "intervals-ftp", "intervals-eftp"] as const)(
+    "refreshes source %s and lets the adapter choose precedence",
+    async (source) => {
+      const selected = adapter();
+      await expect(
+        executePlanFtpTransition(selected.value, { source, watts: null }),
+      ).resolves.toEqual(snapshot);
+      expect(selected.refreshIntervals).toHaveBeenCalledOnce();
+      expect(selected.saveManual).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects mismatched source payloads", async () => {
+    const selected = adapter();
+    await expect(
+      executePlanFtpTransition(selected.value, { source: "manual", watts: null }),
+    ).rejects.toThrow("Manual FTP requires watts.");
+    await expect(
+      executePlanFtpTransition(selected.value, { source: "intervals", watts: 282 }),
+    ).rejects.toThrow("Intervals refresh forbids manual watts.");
+  });
+});

--- a/packages/engine/tests/scaffold.test.ts
+++ b/packages/engine/tests/scaffold.test.ts
@@ -76,6 +76,7 @@ describe("engine scaffold", () => {
       "demoteSummaryHeadings",
       "ensureClaudeCliReady",
       "ensureCodexAgentReady",
+      "executePlanFtpTransition",
       "extractAccountId",
       "failRaceCourseRecalculation",
       "formatCompactionNote",

--- a/packages/sport-cycling/src/index.ts
+++ b/packages/sport-cycling/src/index.ts
@@ -35,11 +35,13 @@ export { cyclingSport, CYCLING_VOCABULARY } from "./sport.js";
 export { CYCLING_PRESCRIPTION_CAPABILITY } from "./prescription-posture.js";
 export type { PrescriptionCapability } from "./prescription-posture.js";
 export { migrateCyclingLegacySections } from "./migrate.js";
-export {
-  CyclingRaceCourseError,
-  interpretCyclingRaceCourse,
-} from "./race-course.js";
+export { CyclingRaceCourseError, interpretCyclingRaceCourse } from "./race-course.js";
 export type { CyclingRaceCourseInterpretation } from "./race-course.js";
+export {
+  createCyclingPlanFtpAdapter,
+  validateManualPlanFtp,
+  type CyclingPlanFtpSourcePorts,
+} from "./plan-ftp.js";
 
 export {
   cyclingReferenceAdapter,

--- a/packages/sport-cycling/src/plan-ftp.ts
+++ b/packages/sport-cycling/src/plan-ftp.ts
@@ -1,0 +1,86 @@
+import type {
+  PlanFtpAdapter,
+  PlanFtpSnapshot,
+  PlanFtpSource,
+  PlanFtpSourceValue,
+} from "@enduragent/engine/sport";
+
+export interface CyclingPlanFtpSourcePorts {
+  readManual(): Promise<PlanFtpSourceValue | null>;
+  readIntervalsFtp(): Promise<PlanFtpSourceValue | null>;
+  readIntervalsEftp(): Promise<PlanFtpSourceValue | null>;
+  saveManual(watts: number): Promise<void>;
+  refreshIntervals(): Promise<void>;
+}
+
+function validSource(value: PlanFtpSourceValue | null): PlanFtpSourceValue | null {
+  if (value === null) return null;
+  if (
+    !Number.isFinite(value.watts) ||
+    value.watts <= 0 ||
+    value.watts > 9_999 ||
+    !Number.isSafeInteger(value.refreshedAtMs) ||
+    value.refreshedAtMs < 0
+  ) {
+    throw new TypeError("Cycling FTP source is invalid.");
+  }
+  return { watts: Math.round(value.watts), refreshedAtMs: value.refreshedAtMs };
+}
+
+export function validateManualPlanFtp(watts: number): number {
+  if (!Number.isSafeInteger(watts) || watts < 1 || watts > 9_999) {
+    throw new RangeError("Enter 1–9999 whole watts.");
+  }
+  return watts;
+}
+
+function resolveSources(input: {
+  readonly manual: PlanFtpSourceValue | null;
+  readonly intervalsFtp: PlanFtpSourceValue | null;
+  readonly intervalsEftp: PlanFtpSourceValue | null;
+}): PlanFtpSnapshot {
+  const manual = validSource(input.manual);
+  const intervalsFtp = validSource(input.intervalsFtp);
+  const intervalsEftp = validSource(input.intervalsEftp);
+  const selected: readonly [PlanFtpSource, PlanFtpSourceValue] | null =
+    manual !== null
+      ? ["manual", manual]
+      : intervalsFtp !== null
+        ? ["intervals-ftp", intervalsFtp]
+        : intervalsEftp !== null
+          ? ["intervals-eftp", intervalsEftp]
+          : null;
+  const values = [manual, intervalsFtp, intervalsEftp].filter(
+    (value): value is PlanFtpSourceValue => value !== null,
+  );
+  return {
+    manual,
+    intervalsFtp,
+    intervalsEftp,
+    usedSource: selected?.[0] ?? null,
+    usedWatts: selected?.[1].watts ?? null,
+    conflict: new Set(values.map((value) => value.watts)).size > 1,
+  };
+}
+
+export function createCyclingPlanFtpAdapter(ports: CyclingPlanFtpSourcePorts): PlanFtpAdapter {
+  const read = async (): Promise<PlanFtpSnapshot> => {
+    const [manual, intervalsFtp, intervalsEftp] = await Promise.all([
+      ports.readManual(),
+      ports.readIntervalsFtp(),
+      ports.readIntervalsEftp(),
+    ]);
+    return resolveSources({ manual, intervalsFtp, intervalsEftp });
+  };
+  return {
+    read,
+    async saveManual(watts) {
+      await ports.saveManual(validateManualPlanFtp(watts));
+      return read();
+    },
+    async refreshIntervals() {
+      await ports.refreshIntervals();
+      return read();
+    },
+  };
+}

--- a/packages/sport-cycling/tests/plan-ftp.test.ts
+++ b/packages/sport-cycling/tests/plan-ftp.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCyclingPlanFtpAdapter, validateManualPlanFtp } from "../src/plan-ftp.js";
+
+const value = (watts: number) => ({ watts, refreshedAtMs: 1_000 });
+
+describe("cycling Plan FTP adapter", () => {
+  it("uses manual FTP before Intervals FTP and Intervals eFTP", async () => {
+    const adapter = createCyclingPlanFtpAdapter({
+      readManual: async () => value(280),
+      readIntervalsFtp: async () => value(282),
+      readIntervalsEftp: async () => value(289),
+      saveManual: async () => {},
+      refreshIntervals: async () => {},
+    });
+    await expect(adapter.read()).resolves.toMatchObject({
+      usedSource: "manual",
+      usedWatts: 280,
+      conflict: true,
+    });
+  });
+
+  it("falls back from Intervals FTP to Intervals eFTP", async () => {
+    const adapter = createCyclingPlanFtpAdapter({
+      readManual: async () => null,
+      readIntervalsFtp: async () => null,
+      readIntervalsEftp: async () => value(289),
+      saveManual: async () => {},
+      refreshIntervals: async () => {},
+    });
+    await expect(adapter.read()).resolves.toMatchObject({
+      usedSource: "intervals-eftp",
+      usedWatts: 289,
+      conflict: false,
+    });
+  });
+
+  it("uses Intervals FTP before Intervals eFTP", async () => {
+    const adapter = createCyclingPlanFtpAdapter({
+      readManual: async () => null,
+      readIntervalsFtp: async () => value(282),
+      readIntervalsEftp: async () => value(289),
+      saveManual: async () => {},
+      refreshIntervals: async () => {},
+    });
+    await expect(adapter.read()).resolves.toMatchObject({
+      usedSource: "intervals-ftp",
+      usedWatts: 282,
+      conflict: true,
+    });
+  });
+
+  it("saves a whole-watt manual value before resolving sources again", async () => {
+    let manual: ReturnType<typeof value> | null = null;
+    const saveManual = vi.fn(async (watts: number) => {
+      manual = value(watts);
+    });
+    const adapter = createCyclingPlanFtpAdapter({
+      readManual: async () => manual,
+      readIntervalsFtp: async () => value(282),
+      readIntervalsEftp: async () => value(289),
+      saveManual,
+      refreshIntervals: async () => {},
+    });
+    await expect(adapter.saveManual(301)).resolves.toMatchObject({
+      usedSource: "manual",
+      usedWatts: 301,
+    });
+    expect(saveManual).toHaveBeenCalledWith(301);
+  });
+
+  it("refreshes Intervals before resolving the latest source", async () => {
+    let ftp: ReturnType<typeof value> | null = null;
+    const adapter = createCyclingPlanFtpAdapter({
+      readManual: async () => null,
+      readIntervalsFtp: async () => ftp,
+      readIntervalsEftp: async () => null,
+      saveManual: async () => {},
+      refreshIntervals: async () => {
+        ftp = value(282);
+      },
+    });
+    await expect(adapter.refreshIntervals()).resolves.toMatchObject({
+      usedSource: "intervals-ftp",
+      usedWatts: 282,
+    });
+  });
+
+  it.each([1, 999, 1_000, 9_999])("accepts manual FTP %i", (watts) => {
+    expect(validateManualPlanFtp(watts)).toBe(watts);
+  });
+
+  it.each([0, 10_000, 282.5, Number.NaN])("rejects manual FTP %s", (watts) => {
+    expect(() => validateManualPlanFtp(watts)).toThrow("Enter 1–9999 whole watts.");
+  });
+});


### PR DESCRIPTION
## Summary
- add a generic Plan FTP transition and Cycling-specific source precedence
- add manual FTP save, Intervals refresh/retry, conflict, and accepted transitions to Plan Coach
- add the compact FTP resolution UI and return users to Draft planning after resolution

## Verification
- focused tests: 11 files, 229 tests passed
- `pnpm check` passed
- isolated autoreview passed with no actionable findings

## Limit
- manual FTP accepts whole watts from 1 through 9999, matching the approved four-digit input rule
