### PR TITLE
feat(plan): add storage foundation

### DIFF
--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -65,7 +65,7 @@ import {
   type AnchorRepository,
 } from "@enduragent/kernel/store";
 import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
-import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { createAuthoredIdentity, type AthleteHome } from "@enduragent/kernel-node/home";
 import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import type { CoachStoreWriterContext } from "./runtime.js";
 import {
@@ -145,6 +145,7 @@ import {
 } from "./activity-power-heart-rate.js";
 import { createTrainingExportService } from "./training-export.js";
 import { serializeBoundaryError } from "./daemon/error-boundary.js";
+import { createPlanStorageService } from "./plan-storage.js";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -945,6 +946,18 @@ export async function createLocalCoachComposition(
       }
     }
     const logger = createSubsystemLogger("agent", input.home.root);
+    const planIdentity = createAuthoredIdentity(input.home.configDir, { now });
+    const createPlanPersistence = (timezone: string) =>
+      createPlanStorageService({
+        store: input.context.store,
+        identity: planIdentity,
+        timezone,
+        now,
+        logger,
+      });
+    await createPlanPersistence(resolveUserTimezone(approvedConfig().session.timezone)).importLegacyPlan(
+      join(input.home.root, "plans", "current-plan.json"),
+    );
     const getAccessToken = createAccessTokenReader(input.home.configDir);
     const repository = (dependencies.createRepository ?? createAnchorRepository)(
       input.context.store,
@@ -993,6 +1006,7 @@ export async function createLocalCoachComposition(
       const ports: EngineHostPorts = {
         config: projectedConfig,
         memory,
+        planPersistence: createPlanPersistence(timezone),
         chatStore: conversationStore,
         transcriptWriter: conversationStore,
         coachDecisions: conversationStore,

--- a/packages/coach/src/plan-storage.ts
+++ b/packages/coach/src/plan-storage.ts
@@ -1,0 +1,292 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import {
+  createPlanAggregateRepository,
+  createPlanRepository,
+  createPlanWorkoutRepository,
+  derivePlanKind,
+  minimumWeeksToCover,
+  PlanningInvariantError,
+  validateNewPlanStart,
+  weekdayForDateKey,
+  type PlanRow,
+  type PlanStatus,
+  type PlanWorkoutOrigin,
+  type PlanWorkoutRow,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import type { MigratorStore } from "@enduragent/kernel/store";
+import type { PlanPersistencePort } from "@enduragent/engine";
+import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+
+const ULID = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+interface PlanStorageLogger {
+  info(event: string, fields?: Record<string, unknown>): void;
+  warn(event: string, error?: unknown, fields?: Record<string, unknown>): void;
+}
+
+export interface PlanStorageService extends PlanPersistencePort {
+  importLegacyPlan(path: string): Promise<"absent" | "imported" | "already-imported" | "skipped">;
+}
+
+export interface PlanStorageServiceInput {
+  readonly store: SqlStore & MigratorStore;
+  readonly identity: AuthoredIdentity;
+  readonly timezone: string;
+  readonly now?: () => number;
+  readonly logger: PlanStorageLogger;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: Readonly<Record<string, unknown>>, ...keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function integerField(record: Readonly<Record<string, unknown>>, ...keys: readonly string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (Number.isSafeInteger(value)) return value as number;
+  }
+  return undefined;
+}
+
+function dateKeyFromText(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (match === null) return undefined;
+  const result = Number(`${match[1]}${match[2]}${match[3]}`);
+  try {
+    weekdayForDateKey(result);
+    return result;
+  } catch {
+    return undefined;
+  }
+}
+
+function dateKeyField(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+  textKey?: string,
+): number | undefined {
+  if (record[key] !== undefined) {
+    const direct = integerField(record, key);
+    if (direct === undefined) {
+      throw new PlanningInvariantError("invalid_date_key", `${key} must be a civil date key`);
+    }
+    weekdayForDateKey(direct);
+    return direct;
+  }
+  if (textKey !== undefined && record[textKey] !== undefined) {
+    const parsed = dateKeyFromText(stringField(record, textKey));
+    if (parsed === undefined) {
+      throw new PlanningInvariantError("invalid_date_key", `${textKey} must begin with a civil date`);
+    }
+    return parsed;
+  }
+  return undefined;
+}
+
+function todayInTimezone(nowMs: number, timezone: string): number {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const values = Object.fromEntries(
+    formatter.formatToParts(new Date(nowMs)).map((part) => [part.type, part.value]),
+  );
+  return Number(`${values.year}${values.month}${values.day}`);
+}
+
+function timestamp(value: unknown, fallback: number): number {
+  if (typeof value !== "string") return fallback;
+  const parsed = Date.parse(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function requiredPositiveInteger(value: unknown, fallback: number, field: string): number {
+  if (value === undefined) return fallback;
+  if (!Number.isSafeInteger(value) || Number(value) < 1) {
+    throw new PlanningInvariantError("invalid_total_weeks", `${field} must be a positive integer`);
+  }
+  return Number(value);
+}
+
+function statusOf(value: unknown, fallback: PlanStatus): PlanStatus {
+  if (value === undefined) return fallback;
+  if (value === "draft" || value === "active" || value === "ended") return value;
+  throw new PlanningInvariantError("invalid_status", "plan status is invalid");
+}
+
+function workoutKey(row: Pick<PlanWorkoutRow, "date_key" | "sport" | "name">): string {
+  return `${row.date_key}\u0000${row.sport}\u0000${row.name}`;
+}
+
+function normalizedDuration(workout: Readonly<Record<string, unknown>>): number | null {
+  const seconds = integerField(workout, "durationS", "duration_s");
+  if (seconds !== undefined) return seconds;
+  const minutes = integerField(workout, "durationMinutes");
+  return minutes === undefined ? null : minutes * 60;
+}
+
+export function createPlanStorageService(input: PlanStorageServiceInput): PlanStorageService {
+  const now = input.now ?? Date.now;
+  const plans = createPlanRepository(input.store);
+  const planWorkouts = createPlanWorkoutRepository(input.store);
+  const aggregates = createPlanAggregateRepository(input.store);
+
+  const persist = async (
+    rawPlan: Readonly<Record<string, unknown>>,
+    mode: "save" | "import",
+  ): Promise<void> => {
+    const observedAt = Math.floor(now());
+    const todayDateKey = todayInTimezone(observedAt, input.timezone);
+    const sourceId = stringField(rawPlan, "id");
+    const existing =
+      sourceId !== undefined && !ULID.test(sourceId)
+        ? await plans.readByOriginId(sourceId)
+        : sourceId !== undefined && ULID.test(sourceId)
+          ? await plans.read(sourceId)
+          : await plans.readCurrent();
+    const planId = existing?.id ?? (sourceId !== undefined && ULID.test(sourceId) ? sourceId : input.identity.newUlid());
+    const originId = existing?.origin_id ?? (sourceId !== undefined && !ULID.test(sourceId) ? sourceId : null);
+    const createdAtMs = existing?.created_at_ms ?? timestamp(rawPlan.createdAt, observedAt);
+
+    const requestedStart =
+      dateKeyField(rawPlan, "startDateKey", "startDate") ??
+      dateKeyField(rawPlan, "start_date_key") ??
+      dateKeyFromText(stringField(rawPlan, "createdAt"));
+    const startDateKey = existing?.start_date_key ?? requestedStart ?? todayDateKey;
+    const targetDateKey =
+      dateKeyField(rawPlan, "targetDateKey", "targetDate") ?? existing?.target_date_key ?? null;
+    if (mode === "save" && existing === undefined) {
+      validateNewPlanStart(startDateKey, todayDateKey, targetDateKey);
+    } else if (targetDateKey !== null && startDateKey > targetDateKey) {
+      throw new PlanningInvariantError("start_after_target", "plan start cannot be after target");
+    }
+    const fallbackWeeks = targetDateKey === null ? 1 : minimumWeeksToCover(startDateKey, targetDateKey);
+    const totalWeeks = requiredPositiveInteger(
+      rawPlan.totalWeeks,
+      existing?.total_weeks ?? fallbackWeeks,
+      "totalWeeks",
+    );
+    if (targetDateKey !== null && totalWeeks < minimumWeeksToCover(startDateKey, targetDateKey)) {
+      throw new PlanningInvariantError("target_not_covered", "totalWeeks does not cover targetDate");
+    }
+    const deviceId = await input.identity.deviceId();
+    const planStamp = input.identity.hlcStamp();
+    const name = stringField(rawPlan, "name") ?? existing?.name;
+    if (name === undefined) throw new PlanningInvariantError("invalid_name", "plan name is required");
+    const plan: PlanRow = {
+      id: planId,
+      origin_id: originId,
+      name,
+      primary_goal: stringField(rawPlan, "primaryGoal", "primary_goal") ?? existing?.primary_goal ?? "",
+      start_date_key: startDateKey,
+      target_date_key: targetDateKey,
+      status: statusOf(rawPlan.status, existing?.status ?? "draft"),
+      kind: derivePlanKind(startDateKey, targetDateKey, totalWeeks),
+      total_weeks: totalWeeks,
+      week_start_day: weekdayForDateKey(startDateKey),
+      structure_json: JSON.stringify(rawPlan),
+      created_at_ms: createdAtMs,
+      updated_at_ms: Math.max(createdAtMs, timestamp(rawPlan.updatedAt, observedAt)),
+      device_id: deviceId,
+      hlc_physical_ms: planStamp.physicalMs,
+      hlc_counter: planStamp.counter,
+    };
+
+    const priorWorkouts = await planWorkouts.listForPlan(planId);
+    const priorIds = new Map(priorWorkouts.map((workout) => [workoutKey(workout), workout.id]));
+    const rawWorkouts = rawPlan.workouts;
+    if (rawWorkouts !== undefined && !Array.isArray(rawWorkouts)) {
+      throw new PlanningInvariantError("invalid_json", "plan workouts must be an array");
+    }
+    const workouts: PlanWorkoutRow[] = rawWorkouts === undefined ? [...priorWorkouts] : [];
+    for (const candidate of rawWorkouts ?? []) {
+      if (!isRecord(candidate)) throw new PlanningInvariantError("invalid_json", "plan workout is invalid");
+      const dateKey = dateKeyField(candidate, "dateKey", "date");
+      const sport = stringField(candidate, "sport");
+      const workoutName = stringField(candidate, "name");
+      if (dateKey === undefined || sport === undefined || workoutName === undefined) {
+        throw new PlanningInvariantError("invalid_json", "plan workout identity is incomplete");
+      }
+      const key = workoutKey({ date_key: dateKey, sport, name: workoutName });
+      const explicitId = stringField(candidate, "id");
+      const workoutId = explicitId !== undefined && ULID.test(explicitId)
+        ? explicitId
+        : priorIds.get(key) ?? input.identity.newUlid();
+      const originValue = candidate.origin;
+      const origin: PlanWorkoutOrigin = originValue === undefined || originValue === "coach"
+        ? "coach"
+        : originValue === "athlete"
+          ? "athlete"
+          : (() => { throw new PlanningInvariantError("invalid_origin", "plan workout origin is invalid"); })();
+      const stamp = input.identity.hlcStamp();
+      workouts.push({
+        id: workoutId,
+        plan_id: planId,
+        date_key: dateKey,
+        sport,
+        name: workoutName,
+        duration_s: normalizedDuration(candidate),
+        structure_json: JSON.stringify(candidate),
+        origin,
+        device_id: deviceId,
+        hlc_physical_ms: stamp.physicalMs,
+        hlc_counter: stamp.counter,
+      });
+    }
+    await aggregates.save(plan, workouts);
+  };
+
+  return {
+    save(plan) {
+      return persist(plan, "save");
+    },
+    async importLegacyPlan(path) {
+      if (!existsSync(path)) return "absent";
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(readFileSync(path, "utf8"));
+      } catch (error) {
+        input.logger.warn("legacy_plan_import_skipped", error, { path, reason: "invalid-json" });
+        return "skipped";
+      }
+      if (!isRecord(parsed)) {
+        input.logger.warn("legacy_plan_import_skipped", undefined, { path, reason: "invalid-shape" });
+        return "skipped";
+      }
+      const sourceId = stringField(parsed, "id");
+      const alreadyImported = sourceId === undefined
+        ? await plans.readCurrent() !== undefined
+        : ULID.test(sourceId)
+          ? await plans.read(sourceId) !== undefined
+          : await plans.readByOriginId(sourceId) !== undefined;
+      if (alreadyImported) {
+        return "already-imported";
+      }
+      const before = statSync(path);
+      try {
+        await persist(parsed, "import");
+      } catch (error) {
+        input.logger.warn("legacy_plan_import_skipped", error, { path, reason: "invalid-plan" });
+        return "skipped";
+      }
+      const after = statSync(path);
+      if (before.mtimeMs !== after.mtimeMs || before.size !== after.size) {
+        throw new Error("legacy Plan import modified its source file");
+      }
+      input.logger.info("legacy_plan_imported", { path });
+      return "imported";
+    },
+  };
+}

--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -588,7 +588,7 @@ describe("account identity", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 12 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(
         beforeWorkouts,

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -582,7 +582,7 @@ describe("coach sync composition", () => {
           return store.get("PRAGMA user_version");
         },
       );
-      expect(value).toEqual({ user_version: 11 });
+      expect(value).toEqual({ user_version: 12 });
       expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
       expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
       expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -590,7 +590,7 @@ describe("coach sync composition", () => {
       const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
       try {
         await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-          user_version: 11,
+          user_version: 12,
         });
       } finally {
         await reopened.close();

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -638,6 +638,7 @@ describe("local coach composition", () => {
       "modelTransportDecorator",
       "now",
       "onToolsAssembled",
+      "planPersistence",
       "platform",
       "randomId",
       "readReferenceState",

--- a/packages/coach/tests/plan-storage.test.ts
+++ b/packages/coach/tests/plan-storage.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Memory } from "@enduragent/core";
+import { createMemoryTools } from "@enduragent/engine/sport";
+import {
+  createPlanRepository,
+  createPlanWorkoutRepository,
+  runMigrations,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createAuthoredIdentity } from "@enduragent/kernel-node/home";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createPlanStorageService } from "../src/plan-storage.js";
+
+const NOW = Date.parse("2026-08-25T12:00:00.000Z");
+
+describe("legacy Plan import and plan_save dual-write", () => {
+  let root: string;
+  let store: SqlStore & MigratorStore;
+  const logger = { info: vi.fn(), warn: vi.fn() };
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), "plan-storage-"));
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    logger.info.mockClear();
+    logger.warn.mockClear();
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function service() {
+    return createPlanStorageService({
+      store,
+      identity: createAuthoredIdentity(join(root, "config"), {
+        now: () => NOW,
+        randomBytes: () => new Uint8Array(10),
+      }),
+      timezone: "UTC",
+      now: () => NOW,
+      logger,
+    });
+  }
+
+  it("writes the unchanged legacy file and the new Plan row", async () => {
+    const memory = new Memory(root);
+    const plan = {
+      id: "67508c6e-f3bd-4bac-9005-1fbbe8950036",
+      name: "Eight-week base",
+      primaryGoal: "Consistency",
+      totalWeeks: 8,
+      createdAt: "2026-08-25T08:00:00.000Z",
+      status: "draft",
+    };
+    const tools = createMemoryTools(memory, [{ name: "goals", description: "Goals" }], {
+      planPersistence: service(),
+    });
+    await tools.plan_save.execute!({ plan }, {} as never);
+
+    expect(readFileSync(join(root, "plans", "current-plan.json"), "utf8")).toBe(
+      JSON.stringify(plan, null, 2),
+    );
+    const rows = await createPlanRepository(store).list();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      origin_id: plan.id,
+      name: plan.name,
+      kind: "short_race_preparation",
+      start_date_key: 20260825,
+      total_weeks: 8,
+    });
+  });
+
+  it("surfaces a row-write failure after preserving the legacy file", async () => {
+    const memory = new Memory(root);
+    const plan = { name: "Safe draft", status: "paused" };
+    const tools = createMemoryTools(memory, [{ name: "goals", description: "Goals" }], {
+      planPersistence: service(),
+    });
+    await expect(tools.plan_save.execute!({ plan }, {} as never)).rejects.toMatchObject({
+      code: "invalid_status",
+    });
+    expect(readFileSync(join(root, "plans", "current-plan.json"), "utf8")).toBe(
+      JSON.stringify(plan, null, 2),
+    );
+    await expect(createPlanRepository(store).list()).resolves.toEqual([]);
+  });
+
+  it("preserves existing Workout rows when a Plan-only update omits workouts", async () => {
+    const storage = service();
+    const id = "67508c6e-f3bd-4bac-9005-1fbbe8950036";
+    await storage.save({
+      id,
+      name: "Base",
+      totalWeeks: 8,
+      createdAt: "2026-08-25T08:00:00.000Z",
+      workouts: [{ date: "2026-08-26", sport: "cycling", name: "Endurance" }],
+    });
+    await storage.save({ id, name: "Renamed base", totalWeeks: 8 });
+    const plan = (await createPlanRepository(store).list())[0]!;
+    await expect(createPlanWorkoutRepository(store).listForPlan(plan.id)).resolves.toHaveLength(1);
+  });
+
+  it("imports the old UUID draft once without touching its source", async () => {
+    const plansDir = join(root, "plans");
+    mkdirSync(plansDir, { recursive: true });
+    const path = join(plansDir, "current-plan.json");
+    const draft = {
+      id: "67508c6e-f3bd-4bac-9005-1fbbe8950036",
+      name: "Legacy draft",
+      primaryGoal: "Base fitness",
+      totalWeeks: 8,
+      status: "draft",
+      createdAt: "2026-01-07T10:00:00.000Z",
+    };
+    const bytes = JSON.stringify(draft, null, 2);
+    writeFileSync(path, bytes);
+    const storage = service();
+
+    await expect(storage.importLegacyPlan(path)).resolves.toBe("imported");
+    await expect(storage.importLegacyPlan(path)).resolves.toBe("already-imported");
+    expect(readFileSync(path, "utf8")).toBe(bytes);
+    const rows = await createPlanRepository(store).list();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: expect.stringMatching(/^[0-9A-HJKMNP-TV-Z]{26}$/),
+      origin_id: draft.id,
+      start_date_key: 20260107,
+      kind: "short_race_preparation",
+    });
+  });
+
+  it("logs and skips malformed legacy JSON without a partial row", async () => {
+    const plansDir = join(root, "plans");
+    mkdirSync(plansDir, { recursive: true });
+    const path = join(plansDir, "current-plan.json");
+    writeFileSync(path, "{truncated");
+    await expect(service().importLegacyPlan(path)).resolves.toBe("skipped");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "legacy_plan_import_skipped",
+      expect.anything(),
+      expect.objectContaining({ reason: "invalid-json" }),
+    );
+    await expect(createPlanRepository(store).list()).resolves.toEqual([]);
+  });
+});

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -379,6 +379,7 @@ export class CoachAgent {
           ? undefined
           : ports.platform.calendarMutations,
       memory: this.memory,
+      planPersistence: ports.planPersistence,
       secrets: ports.secrets,
       bindMemoryToolProvenance: true,
       tz: this.tz,

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -316,6 +316,11 @@ export interface LoggerPort {
   error(event: string, error?: unknown, fields?: LoggerFields): void;
 }
 
+/** Host-owned durable projection written after the legacy Plan file succeeds. */
+export interface PlanPersistencePort {
+  save(plan: Readonly<Record<string, unknown>>): Promise<void>;
+}
+
 export type CallerRole = "chat" | "flush" | "compact" | "sync-triage" | "dream";
 
 export interface UsageCost {
@@ -397,6 +402,7 @@ export interface ReferenceStateSnapshot {
 export interface EngineHostPorts {
   readonly config: EngineConfig;
   readonly memory: MemoryStorePort;
+  readonly planPersistence?: PlanPersistencePort;
   readonly chatStore: ChatStorePort;
   readonly transcriptWriter: TranscriptWriterPort;
   readonly coachDecisions?: CoachDecisionStorePort;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -41,6 +41,7 @@ export type {
   ModelTransportRequest,
   PlatformCalendarMutationsPort,
   PlatformClientPort,
+  PlanPersistencePort,
   ReferenceStateSnapshot,
   SecretRef,
   SecretsPort,

--- a/packages/engine/src/sport.ts
+++ b/packages/engine/src/sport.ts
@@ -142,6 +142,7 @@ export interface SportRuntimePorts {
   athleteData?: AthleteDataReaderPort;
   calendarMutations?: PlatformCalendarMutationsPort;
   memory: MemoryStorePort;
+  planPersistence?: import("./host-ports.js").PlanPersistencePort;
   secrets: SecretsPort;
   /** Enables host-private provenance binding on memory read results. */
   bindMemoryToolProvenance?: boolean;

--- a/packages/engine/src/sport/memory-tools.ts
+++ b/packages/engine/src/sport/memory-tools.ts
@@ -1,7 +1,7 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { MemorySectionSpec } from "../sport.js";
-import type { MemoryStorePort } from "../host-ports.js";
+import type { MemoryStorePort, PlanPersistencePort } from "../host-ports.js";
 import { isRealDateKey, parseDateKeyMs, MS_PER_DAY } from "./date-keys.js";
 import { truncateUtf16Safe } from "../text-truncate.js";
 import { DATE_KEY_RE } from "./date-schema.js";
@@ -165,7 +165,7 @@ export function createMemoryQueryTool(memory: MemoryStorePort, bindProvenance: b
 export function createMemoryTools(
   memory: MemoryStorePort,
   sections: readonly MemorySectionSpec[],
-  opts?: { bindProvenance?: boolean },
+  opts?: { bindProvenance?: boolean; planPersistence?: PlanPersistencePort },
 ) {
   if (sections.length === 0) {
     throw new Error(
@@ -213,6 +213,7 @@ export function createMemoryTools(
       ),
       execute: async (input: { plan: Record<string, unknown> }) => {
         memory.savePlan(input.plan, "chat-tool");
+        await opts?.planPersistence?.save(input.plan);
         return { saved: true };
       },
     }),

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -592,7 +592,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -31,9 +31,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 11", async () => {
+  it("applies the full migration list and advances user_version to 12", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -53,7 +53,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -82,11 +82,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 11", async () => {
+  it("upgrades a version-1-on-disk store to version 12", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -106,8 +106,8 @@ describe("migrator end-to-end over node:sqlite", () => {
     );
 
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 4, toVersion: 11, applied: [5, 6, 7, 8, 9, 10, 11] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(result).toEqual({ fromVersion: 4, toVersion: 12, applied: [5, 6, 7, 8, 9, 10, 11, 12] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -158,14 +158,14 @@ describe("migrator end-to-end over node:sqlite", () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 6, toVersion: 11, applied: [7, 8, 9, 10, 11] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
+    expect(result).toEqual({ fromVersion: 6, toVersion: 12, applied: [7, 8, 9, 10, 11, 12] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 11,
-      toVersion: 11,
+      fromVersion: 12,
+      toVersion: 12,
       applied: [],
     });
   });

--- a/packages/kernel-node/tests/plan-repository.test.ts
+++ b/packages/kernel-node/tests/plan-repository.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createPlanAggregateRepository,
+  createPlanRepository,
+  createPlanWorkoutRepository,
+  runMigrations,
+  type MigratorStore,
+  type PlanRow,
+  type PlanWorkoutRow,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const PLAN_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+const WORKOUT_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
+const DEVICE_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAX";
+
+function plan(overrides: Partial<PlanRow> = {}): PlanRow {
+  return {
+    id: PLAN_ID,
+    origin_id: null,
+    name: "Eight-week base",
+    primary_goal: "Consistency",
+    start_date_key: 20260709,
+    target_date_key: null,
+    status: "draft",
+    kind: "short_race_preparation",
+    total_weeks: 8,
+    week_start_day: 4,
+    structure_json: "{}",
+    created_at_ms: 1,
+    updated_at_ms: 1,
+    device_id: DEVICE_ID,
+    hlc_physical_ms: 1,
+    hlc_counter: 0,
+    ...overrides,
+  };
+}
+
+function workout(overrides: Partial<PlanWorkoutRow> = {}): PlanWorkoutRow {
+  return {
+    id: WORKOUT_ID,
+    plan_id: PLAN_ID,
+    date_key: 20260710,
+    sport: "cycling",
+    name: "Easy endurance",
+    duration_s: 3600,
+    structure_json: "{}",
+    origin: "coach",
+    device_id: DEVICE_ID,
+    hlc_physical_ms: 2,
+    hlc_counter: 0,
+    ...overrides,
+  };
+}
+
+describe("Plan repositories over node:sqlite", () => {
+  let store: SqlStore & MigratorStore;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("atomically stores and reads a Plan aggregate", async () => {
+    await createPlanAggregateRepository(store).save(plan(), [workout()]);
+    await expect(createPlanRepository(store).read(PLAN_ID)).resolves.toEqual(plan());
+    await expect(createPlanWorkoutRepository(store).listForPlan(PLAN_ID)).resolves.toEqual([workout()]);
+  });
+
+  it("enforces the Workout foreign key and delete cascade", async () => {
+    await expect(createPlanWorkoutRepository(store).upsert(workout())).rejects.toThrow();
+    const plans = createPlanRepository(store);
+    await plans.upsert(plan());
+    await createPlanWorkoutRepository(store).upsert(workout());
+    await plans.delete(PLAN_ID);
+    await expect(createPlanWorkoutRepository(store).listForPlan(PLAN_ID)).resolves.toEqual([]);
+  });
+
+  it.each([
+    ["invalid_id", { id: "not-ulid" }],
+    ["invalid_status", { status: "paused" }],
+    ["invalid_kind", { kind: "block" }],
+    ["invalid_total_weeks", { total_weeks: 0 }],
+    ["invalid_week_start_day", { week_start_day: 7 }],
+    ["inconsistent_week_start_day", { week_start_day: 1 }],
+    ["inconsistent_kind", { kind: "full_plan" }],
+    ["target_not_covered", { target_date_key: 20261231 }],
+  ])("rejects %s with a typed invariant error", async (code, overrides) => {
+    await expect(createPlanRepository(store).upsert(plan(overrides as Partial<PlanRow>))).rejects.toMatchObject({ code });
+  });
+
+  it("migrates a version-11 store without changing existing rows", async () => {
+    const prior = openSqliteStorage(":memory:");
+    try {
+      await runMigrations(prior, MIGRATIONS.slice(0, 11));
+      await prior.run("INSERT INTO raw_file(sha256) VALUES(?)", ["a".repeat(64)]);
+      await runMigrations(prior, MIGRATIONS);
+      await expect(prior.get("PRAGMA user_version")).resolves.toEqual({ user_version: 12 });
+      await expect(prior.get("SELECT sha256 FROM raw_file")).resolves.toEqual({ sha256: "a".repeat(64) });
+    } finally {
+      await prior.close();
+    }
+  });
+});

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -236,8 +236,8 @@ describe("sync failure repository", () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     await runMigrations(store, MIGRATIONS);
     expect(await dumpStore(store)).not.toContain("# sync_failure");
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 11 });
-    expect(DUMP_TABLES).toHaveLength(37);
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
+    expect(DUMP_TABLES).toHaveLength(39);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");
     expect(DERIVED_TABLES).not.toContain("sync_failure");

--- a/packages/kernel/src/planning/date-key.ts
+++ b/packages/kernel/src/planning/date-key.ts
@@ -1,0 +1,117 @@
+import {
+  MIN_FULL_PLAN_DAYS,
+  MIN_FULL_PLAN_WEEKS,
+  PlanningInvariantError,
+  type PlanKind,
+  type PlanRow,
+} from "./types.js";
+
+const MS_PER_DAY = 86_400_000;
+
+function parts(dateKey: number): { year: number; month: number; day: number } {
+  if (!Number.isSafeInteger(dateKey)) {
+    throw new PlanningInvariantError("invalid_date_key", "date key must be an integer");
+  }
+  const year = Math.floor(dateKey / 10_000);
+  const month = Math.floor((dateKey % 10_000) / 100);
+  const day = dateKey % 100;
+  const date = new Date(0);
+  date.setUTCFullYear(year, month - 1, day);
+  date.setUTCHours(0, 0, 0, 0);
+  if (
+    year < 1 ||
+    year > 9999 ||
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw new PlanningInvariantError("invalid_date_key", "date key is not a real civil date");
+  }
+  return { year, month, day };
+}
+
+function epochDay(dateKey: number): number {
+  const { year, month, day } = parts(dateKey);
+  const date = new Date(0);
+  date.setUTCFullYear(year, month - 1, day);
+  date.setUTCHours(0, 0, 0, 0);
+  return Math.floor(date.getTime() / MS_PER_DAY);
+}
+
+function fromEpochDay(value: number): number {
+  const date = new Date(value * MS_PER_DAY);
+  return date.getUTCFullYear() * 10_000 + (date.getUTCMonth() + 1) * 100 + date.getUTCDate();
+}
+
+export function addCivilDays(dateKey: number, days: number): number {
+  if (!Number.isSafeInteger(days)) {
+    throw new PlanningInvariantError("invalid_date_key", "civil-day offset must be an integer");
+  }
+  return fromEpochDay(epochDay(dateKey) + days);
+}
+
+export function civilDaysBetween(startDateKey: number, endDateKey: number): number {
+  return epochDay(endDateKey) - epochDay(startDateKey);
+}
+
+export function weekdayForDateKey(dateKey: number): number {
+  const ordinal = epochDay(dateKey);
+  return new Date(ordinal * MS_PER_DAY).getUTCDay();
+}
+
+export function derivePlanKind(
+  startDateKey: number,
+  targetDateKey: number | null,
+  totalWeeks: number,
+): PlanKind {
+  if (targetDateKey !== null) {
+    const inclusiveDays = civilDaysBetween(startDateKey, targetDateKey) + 1;
+    return inclusiveDays >= MIN_FULL_PLAN_DAYS ? "full_plan" : "short_race_preparation";
+  }
+  return totalWeeks >= MIN_FULL_PLAN_WEEKS ? "full_plan" : "short_race_preparation";
+}
+
+export function minimumWeeksToCover(startDateKey: number, targetDateKey: number): number {
+  const offset = civilDaysBetween(startDateKey, targetDateKey);
+  if (offset < 0) {
+    throw new PlanningInvariantError("start_after_target", "plan start cannot be after target");
+  }
+  return Math.floor(offset / 7) + 1;
+}
+
+export type PlanWeekIndexResult =
+  | { readonly kind: "inside"; readonly weekIndex: number }
+  | { readonly kind: "outside"; readonly side: "before" | "after" };
+
+export function planWeekIndex(plan: Pick<PlanRow, "start_date_key" | "total_weeks">, dateKey: number): PlanWeekIndexResult {
+  const offset = civilDaysBetween(plan.start_date_key, dateKey);
+  if (offset < 0) return { kind: "outside", side: "before" };
+  const weekIndex = Math.floor(offset / 7) + 1;
+  return weekIndex > plan.total_weeks
+    ? { kind: "outside", side: "after" }
+    : { kind: "inside", weekIndex };
+}
+
+export function planWeekRange(
+  plan: Pick<PlanRow, "start_date_key" | "total_weeks">,
+  weekIndex: number,
+): { readonly startDateKey: number; readonly endDateKey: number } {
+  if (!Number.isSafeInteger(weekIndex) || weekIndex < 1 || weekIndex > plan.total_weeks) {
+    throw new PlanningInvariantError("invalid_total_weeks", "week index is outside the plan");
+  }
+  const startDateKey = addCivilDays(plan.start_date_key, 7 * (weekIndex - 1));
+  return { startDateKey, endDateKey: addCivilDays(startDateKey, 6) };
+}
+
+export function validateNewPlanStart(
+  startDateKey: number,
+  todayDateKey: number,
+  targetDateKey: number | null,
+): void {
+  if (civilDaysBetween(todayDateKey, startDateKey) < 0) {
+    throw new PlanningInvariantError("start_before_today", "new plan start cannot be before today");
+  }
+  if (targetDateKey !== null && civilDaysBetween(startDateKey, targetDateKey) < 0) {
+    throw new PlanningInvariantError("start_after_target", "plan start cannot be after target");
+  }
+}

--- a/packages/kernel/src/planning/index.ts
+++ b/packages/kernel/src/planning/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./date-key.js";
+export * from "./repository.js";

--- a/packages/kernel/src/planning/repository.ts
+++ b/packages/kernel/src/planning/repository.ts
@@ -1,0 +1,174 @@
+import type { MigratorStore } from "../store/migrator.js";
+import type { Row, SqlStore } from "../store/ports.js";
+import { derivePlanKind, minimumWeeksToCover, weekdayForDateKey } from "./date-key.js";
+import {
+  PlanningInvariantError,
+  type PlanAggregateRepository,
+  type PlanRepository,
+  type PlanRow,
+  type PlanWorkoutRepository,
+  type PlanWorkoutRow,
+} from "./types.js";
+
+const ULID = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const DEVICE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+function validJson(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function validatePlanRow(row: PlanRow): void {
+  if (!ULID.test(row.id)) throw new PlanningInvariantError("invalid_id", "plan id is invalid");
+  if (row.origin_id !== null && row.origin_id.length === 0) {
+    throw new PlanningInvariantError("invalid_origin_id", "plan origin id is invalid");
+  }
+  if (row.name.trim().length === 0) throw new PlanningInvariantError("invalid_name", "plan name is invalid");
+  if (row.status !== "draft" && row.status !== "active" && row.status !== "ended") {
+    throw new PlanningInvariantError("invalid_status", "plan status is invalid");
+  }
+  if (row.kind !== "full_plan" && row.kind !== "short_race_preparation") {
+    throw new PlanningInvariantError("invalid_kind", "plan kind is invalid");
+  }
+  if (!Number.isSafeInteger(row.total_weeks) || row.total_weeks < 1) {
+    throw new PlanningInvariantError("invalid_total_weeks", "plan total weeks is invalid");
+  }
+  const weekday = weekdayForDateKey(row.start_date_key);
+  if (!Number.isSafeInteger(row.week_start_day) || row.week_start_day < 0 || row.week_start_day > 6) {
+    throw new PlanningInvariantError("invalid_week_start_day", "plan week start day is invalid");
+  }
+  if (row.week_start_day !== weekday) {
+    throw new PlanningInvariantError("inconsistent_week_start_day", "plan week start day disagrees with start date");
+  }
+  if (row.target_date_key !== null) {
+    const requiredWeeks = minimumWeeksToCover(row.start_date_key, row.target_date_key);
+    if (row.total_weeks < requiredWeeks) {
+      throw new PlanningInvariantError("target_not_covered", "plan total weeks do not cover the target");
+    }
+  }
+  if (row.kind !== derivePlanKind(row.start_date_key, row.target_date_key, row.total_weeks)) {
+    throw new PlanningInvariantError("inconsistent_kind", "plan kind disagrees with its duration");
+  }
+  if (!validJson(row.structure_json)) throw new PlanningInvariantError("invalid_json", "plan structure is invalid JSON");
+  if (
+    !Number.isSafeInteger(row.created_at_ms) || row.created_at_ms < 0 ||
+    !Number.isSafeInteger(row.updated_at_ms) || row.updated_at_ms < row.created_at_ms
+  ) {
+    throw new PlanningInvariantError("invalid_timestamp", "plan timestamps are invalid");
+  }
+  if (
+    !DEVICE_ID.test(row.device_id) ||
+    !Number.isSafeInteger(row.hlc_physical_ms) || row.hlc_physical_ms < 0 ||
+    !Number.isSafeInteger(row.hlc_counter) || row.hlc_counter < 0
+  ) {
+    throw new PlanningInvariantError("invalid_authored_stamp", "plan authored stamp is invalid");
+  }
+}
+
+export function validatePlanWorkoutRow(row: PlanWorkoutRow): void {
+  if (!ULID.test(row.id)) throw new PlanningInvariantError("invalid_id", "plan workout id is invalid");
+  if (!ULID.test(row.plan_id)) throw new PlanningInvariantError("invalid_plan_id", "plan workout plan id is invalid");
+  weekdayForDateKey(row.date_key);
+  if (row.sport.trim().length === 0) throw new PlanningInvariantError("invalid_sport", "plan workout sport is invalid");
+  if (row.name.trim().length === 0) throw new PlanningInvariantError("invalid_name", "plan workout name is invalid");
+  if (row.duration_s !== null && (!Number.isSafeInteger(row.duration_s) || row.duration_s < 0)) {
+    throw new PlanningInvariantError("invalid_duration", "plan workout duration is invalid");
+  }
+  if (!validJson(row.structure_json)) throw new PlanningInvariantError("invalid_json", "plan workout structure is invalid JSON");
+  if (row.origin !== "coach" && row.origin !== "athlete") {
+    throw new PlanningInvariantError("invalid_origin", "plan workout origin is invalid");
+  }
+  if (
+    !DEVICE_ID.test(row.device_id) ||
+    !Number.isSafeInteger(row.hlc_physical_ms) || row.hlc_physical_ms < 0 ||
+    !Number.isSafeInteger(row.hlc_counter) || row.hlc_counter < 0
+  ) {
+    throw new PlanningInvariantError("invalid_authored_stamp", "plan workout authored stamp is invalid");
+  }
+}
+
+function mapPlan(row: Row): PlanRow {
+  const value: PlanRow = {
+    id: String(row.id), origin_id: row.origin_id === null ? null : String(row.origin_id),
+    name: String(row.name), primary_goal: String(row.primary_goal),
+    start_date_key: Number(row.start_date_key), target_date_key: row.target_date_key === null ? null : Number(row.target_date_key),
+    status: String(row.status) as PlanRow["status"], kind: String(row.kind) as PlanRow["kind"],
+    total_weeks: Number(row.total_weeks), week_start_day: Number(row.week_start_day),
+    structure_json: String(row.structure_json), created_at_ms: Number(row.created_at_ms), updated_at_ms: Number(row.updated_at_ms),
+    device_id: String(row.device_id), hlc_physical_ms: Number(row.hlc_physical_ms), hlc_counter: Number(row.hlc_counter),
+  };
+  validatePlanRow(value);
+  return value;
+}
+
+function mapWorkout(row: Row): PlanWorkoutRow {
+  const value: PlanWorkoutRow = {
+    id: String(row.id), plan_id: String(row.plan_id), date_key: Number(row.date_key), sport: String(row.sport),
+    name: String(row.name), duration_s: row.duration_s === null ? null : Number(row.duration_s),
+    structure_json: String(row.structure_json), origin: String(row.origin) as PlanWorkoutRow["origin"],
+    device_id: String(row.device_id), hlc_physical_ms: Number(row.hlc_physical_ms), hlc_counter: Number(row.hlc_counter),
+  };
+  validatePlanWorkoutRow(value);
+  return value;
+}
+
+const PLAN_COLUMNS = "id,origin_id,name,primary_goal,start_date_key,target_date_key,status,kind,total_weeks,week_start_day,structure_json,created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter";
+const WORKOUT_COLUMNS = "id,plan_id,date_key,sport,name,duration_s,structure_json,origin,device_id,hlc_physical_ms,hlc_counter";
+
+async function writePlan(store: SqlStore, row: PlanRow): Promise<void> {
+  validatePlanRow(row);
+  await store.run(`INSERT INTO plan (${PLAN_COLUMNS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+ON CONFLICT(id) DO UPDATE SET origin_id=excluded.origin_id,name=excluded.name,primary_goal=excluded.primary_goal,start_date_key=excluded.start_date_key,target_date_key=excluded.target_date_key,status=excluded.status,kind=excluded.kind,total_weeks=excluded.total_weeks,week_start_day=excluded.week_start_day,structure_json=excluded.structure_json,updated_at_ms=excluded.updated_at_ms,device_id=excluded.device_id,hlc_physical_ms=excluded.hlc_physical_ms,hlc_counter=excluded.hlc_counter`,
+  [row.id,row.origin_id,row.name,row.primary_goal,row.start_date_key,row.target_date_key,row.status,row.kind,row.total_weeks,row.week_start_day,row.structure_json,row.created_at_ms,row.updated_at_ms,row.device_id,row.hlc_physical_ms,row.hlc_counter]);
+}
+
+async function writeWorkout(store: SqlStore, row: PlanWorkoutRow): Promise<void> {
+  validatePlanWorkoutRow(row);
+  await store.run(`INSERT INTO plan_workout (${WORKOUT_COLUMNS}) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+ON CONFLICT(id) DO UPDATE SET plan_id=excluded.plan_id,date_key=excluded.date_key,sport=excluded.sport,name=excluded.name,duration_s=excluded.duration_s,structure_json=excluded.structure_json,origin=excluded.origin,device_id=excluded.device_id,hlc_physical_ms=excluded.hlc_physical_ms,hlc_counter=excluded.hlc_counter`,
+  [row.id,row.plan_id,row.date_key,row.sport,row.name,row.duration_s,row.structure_json,row.origin,row.device_id,row.hlc_physical_ms,row.hlc_counter]);
+}
+
+export function createPlanRepository(store: SqlStore): PlanRepository {
+  return {
+    upsert: (row) => writePlan(store, row),
+    async read(id) { const row = await store.get(`SELECT ${PLAN_COLUMNS} FROM plan WHERE id=?`, [id]); return row === undefined ? undefined : mapPlan(row); },
+    async readByOriginId(originId) { const row = await store.get(`SELECT ${PLAN_COLUMNS} FROM plan WHERE origin_id=?`, [originId]); return row === undefined ? undefined : mapPlan(row); },
+    async readCurrent() { const row = await store.get(`SELECT ${PLAN_COLUMNS} FROM plan WHERE status!='ended' ORDER BY updated_at_ms DESC, id DESC LIMIT 1`); return row === undefined ? undefined : mapPlan(row); },
+    async list() { return (await store.all(`SELECT ${PLAN_COLUMNS} FROM plan ORDER BY created_at_ms ASC,id ASC`)).map(mapPlan); },
+    async delete(id) { await store.run("DELETE FROM plan WHERE id=?", [id]); },
+  };
+}
+
+export function createPlanWorkoutRepository(store: SqlStore): PlanWorkoutRepository {
+  return {
+    upsert: (row) => writeWorkout(store, row),
+    async replaceForPlan(planId, rows) {
+      if (!ULID.test(planId)) throw new PlanningInvariantError("invalid_plan_id", "plan id is invalid");
+      for (const row of rows) { if (row.plan_id !== planId) throw new PlanningInvariantError("invalid_plan_id", "workout belongs to another plan"); validatePlanWorkoutRow(row); }
+      await store.run("DELETE FROM plan_workout WHERE plan_id=?", [planId]);
+      for (const row of rows) await writeWorkout(store, row);
+    },
+    async listForPlan(planId) { return (await store.all(`SELECT ${WORKOUT_COLUMNS} FROM plan_workout WHERE plan_id=? ORDER BY date_key ASC,id ASC`, [planId])).map(mapWorkout); },
+  };
+}
+
+export function createPlanAggregateRepository(
+  store: SqlStore & Pick<MigratorStore, "transaction">,
+): PlanAggregateRepository {
+  return {
+    async save(plan, workouts) {
+      validatePlanRow(plan);
+      for (const workout of workouts) { if (workout.plan_id !== plan.id) throw new PlanningInvariantError("invalid_plan_id", "workout belongs to another plan"); validatePlanWorkoutRow(workout); }
+      await store.transaction(async () => {
+        await writePlan(store, plan);
+        await store.run("DELETE FROM plan_workout WHERE plan_id=?", [plan.id]);
+        for (const workout of workouts) await writeWorkout(store, workout);
+      });
+    },
+  };
+}

--- a/packages/kernel/src/planning/types.ts
+++ b/packages/kernel/src/planning/types.ts
@@ -1,0 +1,90 @@
+export const MIN_FULL_PLAN_WEEKS = 12;
+export const MIN_FULL_PLAN_DAYS = 84;
+
+export type PlanStatus = "draft" | "active" | "ended";
+export type PlanKind = "full_plan" | "short_race_preparation";
+export type PlanWorkoutOrigin = "coach" | "athlete";
+
+export interface PlanRow {
+  readonly id: string;
+  readonly origin_id: string | null;
+  readonly name: string;
+  readonly primary_goal: string;
+  readonly start_date_key: number;
+  readonly target_date_key: number | null;
+  readonly status: PlanStatus;
+  readonly kind: PlanKind;
+  readonly total_weeks: number;
+  readonly week_start_day: number;
+  readonly structure_json: string;
+  readonly created_at_ms: number;
+  readonly updated_at_ms: number;
+  readonly device_id: string;
+  readonly hlc_physical_ms: number;
+  readonly hlc_counter: number;
+}
+
+export interface PlanWorkoutRow {
+  readonly id: string;
+  readonly plan_id: string;
+  readonly date_key: number;
+  readonly sport: string;
+  readonly name: string;
+  readonly duration_s: number | null;
+  readonly structure_json: string;
+  readonly origin: PlanWorkoutOrigin;
+  readonly device_id: string;
+  readonly hlc_physical_ms: number;
+  readonly hlc_counter: number;
+}
+
+export type PlanningInvariantCode =
+  | "invalid_id"
+  | "invalid_origin_id"
+  | "invalid_name"
+  | "invalid_date_key"
+  | "invalid_status"
+  | "invalid_kind"
+  | "inconsistent_kind"
+  | "invalid_total_weeks"
+  | "target_not_covered"
+  | "invalid_week_start_day"
+  | "inconsistent_week_start_day"
+  | "invalid_json"
+  | "invalid_timestamp"
+  | "invalid_authored_stamp"
+  | "invalid_plan_id"
+  | "invalid_sport"
+  | "invalid_duration"
+  | "invalid_origin"
+  | "start_before_today"
+  | "start_after_target";
+
+export class PlanningInvariantError extends Error {
+  constructor(
+    readonly code: PlanningInvariantCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "PlanningInvariantError";
+  }
+}
+
+export interface PlanRepository {
+  upsert(row: PlanRow): Promise<void>;
+  read(id: string): Promise<PlanRow | undefined>;
+  readByOriginId(originId: string): Promise<PlanRow | undefined>;
+  readCurrent(): Promise<PlanRow | undefined>;
+  list(): Promise<readonly PlanRow[]>;
+  delete(id: string): Promise<void>;
+}
+
+export interface PlanWorkoutRepository {
+  upsert(row: PlanWorkoutRow): Promise<void>;
+  replaceForPlan(planId: string, rows: readonly PlanWorkoutRow[]): Promise<void>;
+  listForPlan(planId: string): Promise<readonly PlanWorkoutRow[]>;
+}
+
+export interface PlanAggregateRepository {
+  save(plan: PlanRow, workouts: readonly PlanWorkoutRow[]): Promise<void>;
+}

--- a/packages/kernel/src/store/dump.ts
+++ b/packages/kernel/src/store/dump.ts
@@ -40,6 +40,8 @@ export const DUMP_TABLES = [
   { table: "lap", orderBy: "lap_key" },
   { table: "mean_max_cache", orderBy: "mmax_key" },
   { table: "metric_snapshot", orderBy: "snapshot_key" },
+  { table: "plan", orderBy: "id" },
+  { table: "plan_workout", orderBy: "id" },
   { table: "planned_workout", orderBy: "id" },
   { table: "pool_size_correction_overlay", orderBy: "id" },
   { table: "race_goal", orderBy: "id" },

--- a/packages/kernel/src/store/export/ports.ts
+++ b/packages/kernel/src/store/export/ports.ts
@@ -82,6 +82,8 @@ export const PURE_AUTHORED_TABLES = [
   "field_merge_override_overlay",
   "pool_size_correction_overlay",
   "dedup_confirmation",
+  "plan",
+  "plan_workout",
 ] as const;
 
 /** Mixed source|authored tables — ONLY provenance='manual' rows are authored. */

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -17,3 +17,4 @@ export * from "./sync-source.js";
 export * from "./sync-state-repository.js";
 export * from "./sync-failure-repository.js";
 export * from "./units-preference-repository.js";
+export * from "../planning/index.js";

--- a/packages/kernel/src/store/migrations/012_plan.sql
+++ b/packages/kernel/src/store/migrations/012_plan.sql
@@ -1,0 +1,44 @@
+-- INV-1 class: authored Plan aggregate root. PK = ULID.
+CREATE TABLE plan (
+  id                TEXT PRIMARY KEY CHECK (
+    length(id) = 26 AND id NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*'
+  ),
+  origin_id         TEXT,
+  name              TEXT NOT NULL,
+  primary_goal      TEXT NOT NULL,
+  start_date_key    INTEGER NOT NULL CHECK (start_date_key BETWEEN 10000101 AND 99991231),
+  target_date_key   INTEGER CHECK (target_date_key BETWEEN 10000101 AND 99991231),
+  status            TEXT NOT NULL CHECK (status IN ('draft','active','ended')),
+  kind              TEXT NOT NULL CHECK (kind IN ('full_plan','short_race_preparation')),
+  total_weeks       INTEGER NOT NULL CHECK (total_weeks > 0),
+  week_start_day    INTEGER NOT NULL CHECK (week_start_day BETWEEN 0 AND 6),
+  structure_json    TEXT NOT NULL CHECK (json_valid(structure_json)),
+  created_at_ms     INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  updated_at_ms     INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+  device_id         TEXT NOT NULL CHECK (length(device_id) BETWEEN 1 AND 128),
+  hlc_physical_ms   INTEGER NOT NULL CHECK (hlc_physical_ms >= 0),
+  hlc_counter       INTEGER NOT NULL CHECK (hlc_counter >= 0)
+) STRICT, WITHOUT ROWID;
+
+CREATE UNIQUE INDEX idx_plan_origin_id
+  ON plan (origin_id)
+  WHERE origin_id IS NOT NULL;
+
+-- INV-1 class: authored Workout belonging to a Plan. PK = ULID.
+CREATE TABLE plan_workout (
+  id                TEXT PRIMARY KEY CHECK (
+    length(id) = 26 AND id NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*'
+  ),
+  plan_id           TEXT NOT NULL REFERENCES plan(id) ON DELETE CASCADE,
+  date_key          INTEGER NOT NULL CHECK (date_key BETWEEN 10000101 AND 99991231),
+  sport             TEXT NOT NULL CHECK (length(sport) > 0),
+  name              TEXT NOT NULL CHECK (length(name) > 0),
+  duration_s        INTEGER CHECK (duration_s >= 0),
+  structure_json    TEXT NOT NULL CHECK (json_valid(structure_json)),
+  origin            TEXT NOT NULL CHECK (origin IN ('coach','athlete')),
+  device_id         TEXT NOT NULL CHECK (length(device_id) BETWEEN 1 AND 128),
+  hlc_physical_ms   INTEGER NOT NULL CHECK (hlc_physical_ms >= 0),
+  hlc_counter       INTEGER NOT NULL CHECK (hlc_counter >= 0)
+) STRICT, WITHOUT ROWID;
+
+CREATE INDEX idx_plan_workout_plan_date ON plan_workout (plan_id, date_key);

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -9,6 +9,7 @@ import storeOwner008 from "./008_store_owner.sql";
 import activitySourceResolver009 from "./009_activity_source_resolver.sql";
 import analyticsCurves010 from "./010_analytics_curves.sql";
 import activityAnalysisProjection011 from "./011_activity_analysis_projection.sql";
+import plan012 from "./012_plan.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -35,4 +36,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 9, name: "009_activity_source_resolver", sql: activitySourceResolver009 },
   { version: 10, name: "010_analytics_curves", sql: analyticsCurves010 },
   { version: 11, name: "011_activity_analysis_projection", sql: activityAnalysisProjection011 },
+  { version: 12, name: "012_plan", sql: plan012 },
 ];

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -51,6 +51,8 @@ const EXPECTED_FULL_TABLES = [
   "analytics_curve_current",
   "analytics_curve_refresh_failure",
   "activity_analysis_projection",
+  "plan",
+  "plan_workout",
 ];
 const MIGRATION_002 = `ALTER TABLE swim_length ADD COLUMN distance_m REAL;
 
@@ -171,6 +173,7 @@ describe("001_init migration", () => {
       { version: 9, name: "009_activity_source_resolver" },
       { version: 10, name: "010_analytics_curves" },
       { version: 11, name: "011_activity_analysis_projection" },
+      { version: 12, name: "012_plan" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -262,7 +265,7 @@ describe("001_init migration", () => {
     expect(MIGRATIONS[2]!.sql).toBe(MIGRATION_003);
   });
 
-  it("applies 001 through 010 with exactly forty-one tables and no foreign-key violations", () => {
+  it("applies the full migration list with the exact table inventory and no foreign-key violations", () => {
     db = openFull();
     const names = (
       db
@@ -272,7 +275,7 @@ describe("001_init migration", () => {
       .map((row) => row.name)
       .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
-    expect(names).toHaveLength(42);
+    expect(names).toHaveLength(44);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
@@ -758,6 +761,8 @@ describe("001_init migration", () => {
       { table: "lap", orderBy: "lap_key" },
       { table: "mean_max_cache", orderBy: "mmax_key" },
       { table: "metric_snapshot", orderBy: "snapshot_key" },
+      { table: "plan", orderBy: "id" },
+      { table: "plan_workout", orderBy: "id" },
       { table: "planned_workout", orderBy: "id" },
       { table: "pool_size_correction_overlay", orderBy: "id" },
       { table: "race_goal", orderBy: "id" },
@@ -777,7 +782,7 @@ describe("001_init migration", () => {
       { table: "workout", orderBy: "workout_key" },
       { table: "zone_set_history", orderBy: "id" },
     ]);
-    expect(DUMP_TABLES).toHaveLength(37);
+    expect(DUMP_TABLES).toHaveLength(39);
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("source_watermark");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_failure");
@@ -833,7 +838,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     }>;
     expect(tables.find((row) => row.name === "sync_failure")?.strict).toBe(1);
     expect(db.prepare("PRAGMA foreign_key_list(sync_failure)").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(37);
+    expect(DUMP_TABLES).toHaveLength(39);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(PURE_AUTHORED_TABLES).not.toContain("sync_failure");
     expect(MIXED_AUTHORED_TABLES).not.toContain("sync_failure");
@@ -890,7 +895,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       expect(tables.find((row) => row.name === name)?.strict).toBe(1);
     }
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(37);
+    expect(DUMP_TABLES).toHaveLength(39);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("analytics_curve_refresh_failure");
     expect(DERIVED_TABLES).not.toContain("analytics_curve_generation");
   });

--- a/packages/kernel/tests/planning-date-key.test.ts
+++ b/packages/kernel/tests/planning-date-key.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  addCivilDays,
+  derivePlanKind,
+  minimumWeeksToCover,
+  planWeekIndex,
+  planWeekRange,
+  validateNewPlanStart,
+  weekdayForDateKey,
+  PlanningInvariantError,
+} from "../src/planning/index.js";
+
+describe("Plan civil-date and training-week rules", () => {
+  const plan = { start_date_key: 20260709, total_weeks: 30 };
+
+  it.each([
+    [20260708, { kind: "outside", side: "before" }],
+    [20260709, { kind: "inside", weekIndex: 1 }],
+    [20260715, { kind: "inside", weekIndex: 1 }],
+    [20260716, { kind: "inside", weekIndex: 2 }],
+    [20260731, { kind: "inside", weekIndex: 4 }],
+    [20261231, { kind: "inside", weekIndex: 26 }],
+    [20270101, { kind: "inside", weekIndex: 26 }],
+  ])("maps %i to its derived week", (dateKey, expected) => {
+    expect(planWeekIndex(plan, dateKey)).toEqual(expected);
+  });
+
+  it("returns exact seven-day ranges across month and year boundaries", () => {
+    expect(planWeekRange(plan, 1)).toEqual({ startDateKey: 20260709, endDateKey: 20260715 });
+    const yearBoundary = { start_date_key: 20261229, total_weeks: 2 };
+    expect(planWeekRange(yearBoundary, 1)).toEqual({ startDateKey: 20261229, endDateKey: 20270104 });
+    expect(addCivilDays(20260228, 1)).toBe(20260301);
+  });
+
+  it("derives the week-start weekday and validates real civil dates", () => {
+    expect(weekdayForDateKey(20260709)).toBe(4);
+    expect(() => weekdayForDateKey(20260230)).toThrowError(PlanningInvariantError);
+  });
+
+  it("uses inclusive 84-day lead time and target-covering display weeks", () => {
+    expect(derivePlanKind(20260101, 20260324, 12)).toBe("short_race_preparation");
+    expect(derivePlanKind(20260101, 20260325, 12)).toBe("full_plan");
+    expect(minimumWeeksToCover(20260101, 20260324)).toBe(12);
+  });
+
+  it("enforces only the decided bounds for a new start", () => {
+    expect(() => validateNewPlanStart(20260825, 20260825, 20260901)).not.toThrow();
+    expect(() => validateNewPlanStart(20260824, 20260825, 20260901)).toThrowError(
+      expect.objectContaining({ code: "start_before_today" }),
+    );
+    expect(() => validateNewPlanStart(20260902, 20260825, 20260901)).toThrowError(
+      expect.objectContaining({ code: "start_after_target" }),
+    );
+  });
+});

--- a/packages/kernel/tests/store-export.test.ts
+++ b/packages/kernel/tests/store-export.test.ts
@@ -167,7 +167,7 @@ function makePresence(
 }
 
 describe("store export op", () => {
-  it("(enumerate) exports exactly the 12 authored keys with correct manualOnly flags and no source/derived tables", async () => {
+  it("(enumerate) exports every authored key with correct manualOnly flags and no source/derived tables", async () => {
     const data = populated();
     const { source, calls } = makeSource(data);
     const crypto = new FakeCrypto();
@@ -216,7 +216,7 @@ describe("store export op", () => {
     }
   });
 
-  it("(roundtrip-plain) plaintext round-trip restores all 12 tables", async () => {
+  it("(roundtrip-plain) plaintext round-trip restores every authored table", async () => {
     const data = populated();
     const { source } = makeSource(data);
     const crypto = new FakeCrypto();
@@ -229,7 +229,7 @@ describe("store export op", () => {
       { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
       { container: built.container },
     );
-    expect(imported.restored).toHaveLength(12);
+    expect(imported.restored).toHaveLength(14);
     expect(imported.restored.find((row) => row.table === "dedup_confirmation")?.inserted).toBe(2);
     for (const t of PURE_AUTHORED_TABLES) {
       expect(imported.restored.find((r) => r.table === t)?.inserted).toBe(2);
@@ -263,7 +263,7 @@ describe("store export op", () => {
       { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
       { container: built.container, passphrase: "correct horse" },
     );
-    expect(imported.restored).toHaveLength(12);
+    expect(imported.restored).toHaveLength(14);
     expect(imported.restored.find((row) => row.table === "dedup_confirmation")?.inserted).toBe(2);
   });
 
@@ -339,7 +339,7 @@ describe("store export op", () => {
         { sink: makeSink(), presence: makePresence(), crypto, codec, targetUserVersion: 5 },
         { container: built.container },
       );
-      expect(imported.restored).toHaveLength(12);
+      expect(imported.restored).toHaveLength(14);
     }
   });
 

--- a/packages/sport-cycling/src/sport.ts
+++ b/packages/sport-cycling/src/sport.ts
@@ -97,6 +97,7 @@ export const cyclingSport = {
     const toolset = {
       ...createMemoryTools(deps.memory, sections, {
         bindProvenance: deps.bindMemoryToolProvenance,
+        planPersistence: deps.planPersistence,
       }),
       ...createPureCoreIntervalsTools(deps.intervals, deps.tz, deps.athleteData, deps.calendarMutations),
       ...createCoreToolsWithSportConfig(deps.intervals, cyclingSport.intervalsActivityTypes, deps.athleteData),

--- a/packages/sport-running/src/sport.ts
+++ b/packages/sport-running/src/sport.ts
@@ -88,6 +88,7 @@ export const runningSport: Sport = {
     const toolset = {
       ...createMemoryTools(deps.memory, sections, {
         bindProvenance: deps.bindMemoryToolProvenance,
+        planPersistence: deps.planPersistence,
       }),
       ...createPureCoreIntervalsTools(deps.intervals, deps.tz, deps.athleteData, deps.calendarMutations),
       ...createCoreToolsWithSportConfig(deps.intervals, runningSport.intervalsActivityTypes, deps.athleteData),


### PR DESCRIPTION
## Summary
- add migration 012 with authored Plan and Plan Workout tables, repositories, and deterministic store/export ownership
- add civil-date, derived-week, lifecycle, block-kind, and target-coverage invariants
- import the legacy current Plan idempotently and dual-write plan_save file-first through a host-owned persistence port

## Limits
- MIN_FULL_PLAN_WEEKS = 12: full Plans without a target require twelve display weeks
- MIN_FULL_PLAN_DAYS = 84: full Plans with a target require eighty-four inclusive days; shorter valid blocks remain short race-preparation blocks

## Validation
- pnpm check
- focused Kernel, Kernel Node, Coach, composition, migration, repository, import, and dual-write tests
- full monorepo run: 9,653 tests passed; two load-timeout cases passed in isolation; four remaining local child cases selected unsupported system Node 20 and are left to Node 24 CI
- TruffleHog clean
- autoreview clean: no accepted/actionable findings reported

No Plan UI, attachment UI, matcher, materialization, or coach-read switch is included.