### PR TITLE
feat(desktop): add Windows Authenticode verification scaffolding

### DIFF
--- a/.changeset/windows-authenticode-scaffolding.md
+++ b/.changeset/windows-authenticode-scaffolding.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Add certificate-independent Windows release signature verification scaffolding.

--- a/apps/desktop/build/windows-pe-inventory.json
+++ b/apps/desktop/build/windows-pe-inventory.json
@@ -1,0 +1,30 @@
+{
+  "schema": "windows-pe-inventory/1",
+  "signing": {
+    "tool": "electron-builder",
+    "version": "26.15.3",
+    "option": "win.signExts"
+  },
+  "required": [
+    { "path": "Enduragent.exe", "kind": "application" },
+    { "path": "d3dcompiler_47.dll", "kind": "runtime-library" },
+    { "path": "dxcompiler.dll", "kind": "runtime-library" },
+    { "path": "dxil.dll", "kind": "runtime-library" },
+    { "path": "ffmpeg.dll", "kind": "runtime-library" },
+    { "path": "libEGL.dll", "kind": "runtime-library" },
+    { "path": "libGLESv2.dll", "kind": "runtime-library" },
+    { "path": "vk_swiftshader.dll", "kind": "runtime-library" },
+    { "path": "vulkan-1.dll", "kind": "runtime-library" },
+    {
+      "path": "Uninstall Enduragent.exe",
+      "kind": "uninstaller",
+      "location": "installer-payload"
+    },
+    {
+      "path": "Enduragent-${version}-x64.exe",
+      "kind": "installer",
+      "location": "artifact"
+    }
+  ],
+  "thirdPartyExceptions": []
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,8 @@
     "test:windows-parity-contract": "vitest run tests/windows-parity-contract.test.ts",
     "verify:package-layout": "node scripts/verify-package-layout.mjs",
     "verify:win-package": "node scripts/verify-windows-package.mjs",
+    "verify:win-authenticode": "node scripts/verify-windows-authenticode.mjs",
+    "verify:win-pe-inventory": "node scripts/windows-pe-inventory.mjs",
     "verify:win-release": "node scripts/verify-windows-release.mjs",
     "upload:win-release": "node scripts/upload-windows-release.mjs",
     "verify:mac-release": "node scripts/verify-macos-release.mjs",

--- a/apps/desktop/scripts/make-test-signing-cert.ps1
+++ b/apps/desktop/scripts/make-test-signing-cert.ps1
@@ -1,0 +1,73 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$OutputDirectory,
+  [string]$SubjectDn = "CN=Enduragent Self-Signed Test, O=Enduragent Test Fixture",
+  [string]$TimestampServer = "http://timestamp.digicert.com"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $IsWindows) {
+  Write-Output ([ordered]@{ error = "windows-only" } | ConvertTo-Json -Compress)
+  exit 2
+}
+
+$certificate = $null
+try {
+  $scriptDirectory = Split-Path -Parent $PSCommandPath
+  $repositoryRoot = [IO.Path]::GetFullPath((Join-Path $scriptDirectory "..\..\.."))
+  $resolvedOutputDirectory = [IO.Path]::GetFullPath($OutputDirectory)
+  $repositoryPrefix = $repositoryRoot.TrimEnd('\') + '\'
+  if (
+    [string]::Equals($resolvedOutputDirectory, $repositoryRoot, [StringComparison]::OrdinalIgnoreCase) -or
+    $resolvedOutputDirectory.StartsWith($repositoryPrefix, [StringComparison]::OrdinalIgnoreCase)
+  ) {
+    throw "output directory must be outside the repository"
+  }
+  $null = New-Item -ItemType Directory -Path $resolvedOutputDirectory -Force
+  $resolvedOutputDirectory = (Resolve-Path -LiteralPath $resolvedOutputDirectory).ProviderPath
+  if (
+    [string]::Equals($resolvedOutputDirectory, $repositoryRoot, [StringComparison]::OrdinalIgnoreCase) -or
+    $resolvedOutputDirectory.StartsWith($repositoryPrefix, [StringComparison]::OrdinalIgnoreCase)
+  ) {
+    throw "output directory must be outside the repository"
+  }
+  $fixturePath = Join-Path $resolvedOutputDirectory "fixture.exe"
+  Copy-Item -LiteralPath (Join-Path ([System.Environment]::SystemDirectory) "where.exe") -Destination $fixturePath
+  $certificate = New-SelfSignedCertificate `
+    -Type CodeSigningCert `
+    -Subject $SubjectDn `
+    -HashAlgorithm SHA256 `
+    -CertStoreLocation Cert:\CurrentUser\My `
+    -NotAfter ([DateTime]::Now.AddDays(1))
+  try {
+    $signature = Set-AuthenticodeSignature `
+      -LiteralPath $fixturePath `
+      -Certificate $certificate `
+      -HashAlgorithm SHA256 `
+      -TimestampServer $TimestampServer
+  } catch {
+    $signature = Set-AuthenticodeSignature `
+      -LiteralPath $fixturePath `
+      -Certificate $certificate `
+      -HashAlgorithm SHA256
+  }
+  $summary = [ordered]@{
+    fixturePath = $fixturePath
+    subject = $certificate.Subject
+    thumbprint = $certificate.Thumbprint
+    timestamped = $null -ne $signature.TimeStamperCertificate
+  }
+  Write-Output ($summary | ConvertTo-Json -Compress)
+} catch {
+  [Console]::Error.WriteLine($_.Exception.Message)
+  Write-Output ([ordered]@{ error = "fixture-generation-failed" } | ConvertTo-Json -Compress)
+  exit 1
+} finally {
+  if ($null -ne $certificate) {
+    Remove-Item -LiteralPath "Cert:\CurrentUser\My\$($certificate.Thumbprint)" -Force -ErrorAction SilentlyContinue
+  }
+}

--- a/apps/desktop/scripts/verify-windows-authenticode.d.mts
+++ b/apps/desktop/scripts/verify-windows-authenticode.d.mts
@@ -1,0 +1,89 @@
+export interface WindowsAuthenticodeCheck {
+  readonly name: string;
+  readonly ok: boolean;
+  readonly detail: string;
+}
+
+export interface WindowsAuthenticodeSigner {
+  readonly subject: string;
+  readonly thumbprint: string;
+  readonly issuer: string;
+  readonly notAfter: string;
+}
+
+export interface WindowsAuthenticodeSummary {
+  readonly schema: "windows-authenticode-verification/1";
+  readonly installerPath: string;
+  readonly ok: boolean;
+  readonly signer: WindowsAuthenticodeSigner | null;
+  readonly timestamper: { readonly subject: string } | null;
+  readonly status: string | null;
+  readonly statusMessage: string | null;
+  readonly digestAlgorithm: string | null;
+  readonly rfc3161: boolean;
+  readonly signtool: {
+    readonly path: string | null;
+    readonly exitCode: number | null;
+    readonly output: string;
+  };
+  readonly allowSelfSignedTest: boolean;
+  readonly checks: readonly WindowsAuthenticodeCheck[];
+}
+
+export interface WindowsAuthenticodeOptions {
+  readonly installerPath: string;
+  readonly expectedPublisherDn: string;
+  readonly expectedThumbprint?: string;
+  readonly allowSelfSignedTest?: boolean;
+  readonly allowMissingSigntool?: boolean;
+}
+
+export interface WindowsAuthenticodeDependencies {
+  readonly executeFile?: (
+    executable: string,
+    arguments_: readonly string[],
+    options: { readonly encoding: "utf8"; readonly maxBuffer: number },
+  ) => Promise<unknown>;
+  readonly scriptPath?: string;
+}
+
+export interface VerifiedWindowsAuthenticode {
+  readonly ok: true;
+  readonly signer: WindowsAuthenticodeSigner;
+  readonly digestAlgorithm: "sha256";
+  readonly rfc3161: true;
+}
+
+export interface WindowsAuthenticodeVerifyMode {
+  readonly mode: "verify";
+  readonly expectedPublisherDn: string;
+  readonly verify: (
+    installerPath: string,
+    context: { readonly version: string; readonly publisherName?: string },
+  ) => Promise<void>;
+}
+
+export const WINDOWS_AUTHENTICODE_SUMMARY_SCHEMA: "windows-authenticode-verification/1";
+export const WINDOWS_AUTHENTICODE_REQUIRED_CHECKS: readonly [
+  "file",
+  "status",
+  "digest",
+  "timestamp",
+  "subject",
+  "chain",
+  "signtool",
+];
+export function parseWindowsAuthenticodeSummary(stdout: string): WindowsAuthenticodeSummary;
+export function decideWindowsAuthenticode(
+  summary: WindowsAuthenticodeSummary,
+  options: Pick<WindowsAuthenticodeOptions, "expectedPublisherDn" | "expectedThumbprint" | "allowSelfSignedTest">,
+): VerifiedWindowsAuthenticode;
+export function verifyWindowsAuthenticode(
+  options: WindowsAuthenticodeOptions,
+  dependencies?: WindowsAuthenticodeDependencies,
+): Promise<VerifiedWindowsAuthenticode>;
+export function createWindowsAuthenticodeVerifyMode(
+  options: Omit<WindowsAuthenticodeOptions, "installerPath">,
+  dependencies?: WindowsAuthenticodeDependencies,
+): WindowsAuthenticodeVerifyMode;
+export function safeWindowsAuthenticodeMessage(error: unknown): string | undefined;

--- a/apps/desktop/scripts/verify-windows-authenticode.mjs
+++ b/apps/desktop/scripts/verify-windows-authenticode.mjs
@@ -1,0 +1,390 @@
+import { execFile } from "node:child_process";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+export const WINDOWS_AUTHENTICODE_SUMMARY_SCHEMA = "windows-authenticode-verification/1";
+export const WINDOWS_AUTHENTICODE_REQUIRED_CHECKS = Object.freeze([
+  "file",
+  "status",
+  "digest",
+  "timestamp",
+  "subject",
+  "chain",
+  "signtool",
+]);
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const canonicalScriptPath = resolve(scriptDirectory, "verify-windows-authenticode.ps1");
+const executeSystemFile = promisify(execFile);
+const maximumCommandOutputBytes = 4 * 1024 * 1024;
+const safeMessages = new Set([
+  "Authenticode signature is not valid",
+  "Authenticode digest is not SHA-256",
+  "Authenticode timestamp is missing",
+  "Authenticode publisher mismatch",
+  "Authenticode thumbprint mismatch",
+  "Authenticode chain is untrusted",
+  "signtool verification failed",
+  "Authenticode summary is invalid",
+  "PowerShell 7 is required for Authenticode verification",
+]);
+
+class WindowsAuthenticodeError extends TypeError {
+  constructor(message) {
+    super(message);
+    this.name = "WindowsAuthenticodeError";
+  }
+}
+
+function fail(message) {
+  throw new WindowsAuthenticodeError(message);
+}
+
+export function safeWindowsAuthenticodeMessage(error) {
+  return error instanceof WindowsAuthenticodeError && safeMessages.has(error.message)
+    ? error.message
+    : undefined;
+}
+
+function exactObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value, keys) {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function nullableString(value) {
+  return value === null || typeof value === "string";
+}
+
+function validSummary(summary) {
+  if (
+    !exactObject(summary) ||
+    !hasExactKeys(summary, [
+      "schema",
+      "installerPath",
+      "ok",
+      "signer",
+      "timestamper",
+      "status",
+      "statusMessage",
+      "digestAlgorithm",
+      "rfc3161",
+      "signtool",
+      "allowSelfSignedTest",
+      "checks",
+    ]) ||
+    summary.schema !== WINDOWS_AUTHENTICODE_SUMMARY_SCHEMA ||
+    typeof summary.installerPath !== "string" ||
+    typeof summary.ok !== "boolean" ||
+    !nullableString(summary.status) ||
+    !nullableString(summary.statusMessage) ||
+    !nullableString(summary.digestAlgorithm) ||
+    typeof summary.rfc3161 !== "boolean" ||
+    typeof summary.allowSelfSignedTest !== "boolean"
+  ) {
+    return false;
+  }
+  if (
+    summary.signer !== null &&
+    (!exactObject(summary.signer) ||
+      !hasExactKeys(summary.signer, ["subject", "thumbprint", "issuer", "notAfter"]) ||
+      ![summary.signer.subject, summary.signer.thumbprint, summary.signer.issuer, summary.signer.notAfter].every(
+        (value) => typeof value === "string",
+      ))
+  ) {
+    return false;
+  }
+  if (
+    summary.timestamper !== null &&
+    (!exactObject(summary.timestamper) ||
+      !hasExactKeys(summary.timestamper, ["subject"]) ||
+      typeof summary.timestamper.subject !== "string")
+  ) {
+    return false;
+  }
+  if (
+    !exactObject(summary.signtool) ||
+    !hasExactKeys(summary.signtool, ["path", "exitCode", "output"]) ||
+    !nullableString(summary.signtool.path) ||
+    !(summary.signtool.exitCode === null || Number.isSafeInteger(summary.signtool.exitCode)) ||
+    typeof summary.signtool.output !== "string"
+  ) {
+    return false;
+  }
+  if (
+    !Array.isArray(summary.checks) ||
+    !summary.checks.every(
+      (check) =>
+        exactObject(check) &&
+        hasExactKeys(check, ["name", "ok", "detail"]) &&
+        typeof check.name === "string" &&
+        typeof check.ok === "boolean" &&
+        typeof check.detail === "string",
+    ) ||
+    new Set(summary.checks.map((check) => check.name)).size !== summary.checks.length
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function parseWindowsAuthenticodeSummary(stdout) {
+  if (typeof stdout !== "string") fail("Authenticode summary is invalid");
+  let summary;
+  try {
+    summary = JSON.parse(stdout);
+  } catch {
+    fail("Authenticode summary is invalid");
+  }
+  if (!validSummary(summary)) fail("Authenticode summary is invalid");
+  return summary;
+}
+
+function checkMap(summary) {
+  return new Map(summary.checks.map((check) => [check.name, check]));
+}
+
+function validExpectedValues(expectedPublisherDn, expectedThumbprint) {
+  return (
+    typeof expectedPublisherDn === "string" &&
+    expectedPublisherDn.length > 0 &&
+    expectedPublisherDn === expectedPublisherDn.trim() &&
+    (expectedThumbprint === undefined || /^[0-9a-f]{40}$/iu.test(expectedThumbprint))
+  );
+}
+
+export function decideWindowsAuthenticode(
+  summary,
+  { expectedPublisherDn, expectedThumbprint, allowSelfSignedTest = false },
+) {
+  if (
+    !validSummary(summary) ||
+    !validExpectedValues(expectedPublisherDn, expectedThumbprint) ||
+    typeof allowSelfSignedTest !== "boolean" ||
+    summary.allowSelfSignedTest !== allowSelfSignedTest
+  ) {
+    fail("Authenticode summary is invalid");
+  }
+  const checks = checkMap(summary);
+  const required =
+    expectedThumbprint === undefined
+      ? WINDOWS_AUTHENTICODE_REQUIRED_CHECKS
+      : [...WINDOWS_AUTHENTICODE_REQUIRED_CHECKS, "thumbprint"];
+  if (required.some((name) => !checks.has(name))) fail("Authenticode summary is invalid");
+  const untrustedStatus = summary.status === "NotTrusted" || summary.status === "UnknownError";
+  const testTrustAccepted =
+    allowSelfSignedTest &&
+    expectedThumbprint !== undefined &&
+    untrustedStatus &&
+    typeof summary.statusMessage === "string" &&
+    /untrusted root|root certificate which is not trusted|terminated in a root certificate/iu.test(
+      summary.statusMessage,
+    ) &&
+    checks.get("chain").detail === "untrusted-root-accepted-for-test";
+  if (!checks.get("file").ok) fail("Authenticode signature is not valid");
+  if (summary.status !== "Valid" && !untrustedStatus) {
+    fail("Authenticode signature is not valid");
+  }
+  if (!checks.get("digest").ok || summary.digestAlgorithm !== "sha256") {
+    fail("Authenticode digest is not SHA-256");
+  }
+  if (!checks.get("timestamp").ok || !summary.rfc3161 || summary.timestamper === null) {
+    fail("Authenticode timestamp is missing");
+  }
+  if (
+    !checks.get("subject").ok ||
+    summary.signer === null ||
+    summary.signer.subject !== expectedPublisherDn
+  ) {
+    fail("Authenticode publisher mismatch");
+  }
+  if (
+    expectedThumbprint !== undefined &&
+    (!checks.get("thumbprint").ok ||
+      summary.signer.thumbprint.toLowerCase() !== expectedThumbprint.toLowerCase())
+  ) {
+    fail("Authenticode thumbprint mismatch");
+  }
+  if (!checks.get("chain").ok || (untrustedStatus && !testTrustAccepted)) {
+    fail("Authenticode chain is untrusted");
+  }
+  if (!checks.get("signtool").ok) fail("signtool verification failed");
+  if (!checks.get("status").ok || !summary.ok || summary.checks.some((check) => !check.ok)) {
+    fail("Authenticode signature is not valid");
+  }
+  return Object.freeze({
+    ok: true,
+    signer: Object.freeze({ ...summary.signer }),
+    digestAlgorithm: "sha256",
+    rfc3161: true,
+  });
+}
+
+function outputStream(result, name) {
+  if (typeof result === "string" || Buffer.isBuffer(result)) {
+    return name === "stdout" ? String(result) : "";
+  }
+  if (!exactObject(result)) return "";
+  const value = result[name];
+  return typeof value === "string" || Buffer.isBuffer(value) ? String(value) : "";
+}
+
+async function runWindowsAuthenticode(options, dependencies = {}) {
+  if (
+    !exactObject(options) ||
+    !isAbsolute(options.installerPath) ||
+    !validExpectedValues(options.expectedPublisherDn, options.expectedThumbprint)
+  ) {
+    fail("Authenticode summary is invalid");
+  }
+  const scriptPath = dependencies.scriptPath ?? canonicalScriptPath;
+  if (!isAbsolute(scriptPath)) fail("Authenticode summary is invalid");
+  const arguments_ = [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    scriptPath,
+    "-InstallerPath",
+    options.installerPath,
+    "-ExpectedPublisherDn",
+    options.expectedPublisherDn,
+  ];
+  if (options.expectedThumbprint !== undefined) {
+    arguments_.push("-ExpectedThumbprint", options.expectedThumbprint);
+  }
+  if (options.allowSelfSignedTest === true) arguments_.push("-AllowSelfSignedTest");
+  if (options.allowMissingSigntool === true) arguments_.push("-AllowMissingSigntool");
+  const executeFile = dependencies.executeFile ?? executeSystemFile;
+  let result;
+  try {
+    result = await executeFile("pwsh", arguments_, {
+      encoding: "utf8",
+      maxBuffer: maximumCommandOutputBytes,
+    });
+  } catch (error) {
+    if (exactObject(error) && error.code === "ENOENT") {
+      fail("PowerShell 7 is required for Authenticode verification");
+    }
+    if (exactObject(error) && error.code === 1) {
+      result = error;
+    } else {
+      fail("Authenticode summary is invalid");
+    }
+  }
+  if (exactObject(result) && Object.hasOwn(result, "exitCode") && ![0, 1].includes(result.exitCode)) {
+    fail("Authenticode summary is invalid");
+  }
+  return parseWindowsAuthenticodeSummary(outputStream(result, "stdout"));
+}
+
+export async function verifyWindowsAuthenticode(options, dependencies = {}) {
+  const summary = await runWindowsAuthenticode(options, dependencies);
+  return decideWindowsAuthenticode(summary, {
+    expectedPublisherDn: options.expectedPublisherDn,
+    expectedThumbprint: options.expectedThumbprint,
+    allowSelfSignedTest: options.allowSelfSignedTest ?? false,
+  });
+}
+
+export function createWindowsAuthenticodeVerifyMode(options, dependencies = {}) {
+  if (
+    !exactObject(options) ||
+    !validExpectedValues(options.expectedPublisherDn, options.expectedThumbprint)
+  ) {
+    fail("Authenticode summary is invalid");
+  }
+  const expectedPublisherDn = options.expectedPublisherDn;
+  return Object.freeze({
+    mode: "verify",
+    expectedPublisherDn,
+    async verify(installerPath, context) {
+      if (
+        context?.publisherName !== undefined &&
+        context.publisherName !== expectedPublisherDn
+      ) {
+        fail("Authenticode publisher mismatch");
+      }
+      await verifyWindowsAuthenticode(
+        {
+          installerPath,
+          expectedPublisherDn,
+          expectedThumbprint: options.expectedThumbprint,
+          allowSelfSignedTest: options.allowSelfSignedTest,
+          allowMissingSigntool: options.allowMissingSigntool,
+        },
+        dependencies,
+      );
+    },
+  });
+}
+
+function parseArguments(arguments_) {
+  let installerPath;
+  let expectedPublisherDn;
+  let expectedThumbprint;
+  let allowSelfSignedTest = false;
+  let allowMissingSigntool = false;
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (!argument.startsWith("--") && installerPath === undefined) {
+      installerPath = argument;
+      continue;
+    }
+    if (argument === "--allow-self-signed-test" && !allowSelfSignedTest) {
+      allowSelfSignedTest = true;
+      continue;
+    }
+    if (argument === "--allow-missing-signtool" && !allowMissingSigntool) {
+      allowMissingSigntool = true;
+      continue;
+    }
+    const value = arguments_[index + 1];
+    if (value === undefined || value.startsWith("--")) fail("Authenticode summary is invalid");
+    index += 1;
+    if (argument === "--publisher-dn" && expectedPublisherDn === undefined) {
+      expectedPublisherDn = value;
+    } else if (argument === "--thumbprint" && expectedThumbprint === undefined) {
+      expectedThumbprint = value;
+    } else {
+      fail("Authenticode summary is invalid");
+    }
+  }
+  if (installerPath === undefined || expectedPublisherDn === undefined) {
+    fail("Authenticode summary is invalid");
+  }
+  return {
+    installerPath: resolve(installerPath),
+    expectedPublisherDn,
+    expectedThumbprint,
+    allowSelfSignedTest,
+    allowMissingSigntool,
+  };
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const summary = await runWindowsAuthenticode(options);
+  process.stdout.write(`${JSON.stringify(summary)}\n`);
+  try {
+    decideWindowsAuthenticode(summary, options);
+  } catch (error) {
+    process.stderr.write(`${safeWindowsAuthenticodeMessage(error) ?? "Authenticode verification failed"}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(`${safeWindowsAuthenticodeMessage(error) ?? "Authenticode verification failed"}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/apps/desktop/scripts/verify-windows-authenticode.ps1
+++ b/apps/desktop/scripts/verify-windows-authenticode.ps1
@@ -1,0 +1,293 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.0
+
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$InstallerPath,
+  [Parameter(Mandatory = $true)]
+  [string]$ExpectedPublisherDn,
+  [string]$ExpectedThumbprint,
+  [switch]$AllowSelfSignedTest,
+  [switch]$AllowMissingSigntool
+)
+
+$ErrorActionPreference = "Stop"
+$checks = [Collections.Generic.List[object]]::new()
+$resolvedInstallerPath = $InstallerPath
+$signer = $null
+$timestamper = $null
+$status = $null
+$statusMessage = $null
+$digestAlgorithm = $null
+$rfc3161 = $false
+$signtool = [ordered]@{ path = $null; exitCode = $null; output = "" }
+
+function Add-VerificationCheck {
+  param([string]$Name, [bool]$Ok, [string]$Detail)
+  $checks.Add([ordered]@{ name = $Name; ok = $Ok; detail = $Detail })
+}
+
+function Write-VerificationSummary {
+  param([bool]$Ok)
+  $summary = [ordered]@{
+    schema = "windows-authenticode-verification/1"
+    installerPath = $resolvedInstallerPath
+    ok = $Ok
+    signer = $signer
+    timestamper = $timestamper
+    status = $status
+    statusMessage = $statusMessage
+    digestAlgorithm = $digestAlgorithm
+    rfc3161 = $rfc3161
+    signtool = $signtool
+    allowSelfSignedTest = [bool]$AllowSelfSignedTest
+    checks = @($checks)
+  }
+  Write-Output ($summary | ConvertTo-Json -Depth 6 -Compress)
+}
+
+function Get-PrimarySignedCms {
+  param([string]$Path)
+  $bytes = [IO.File]::ReadAllBytes($Path)
+  if ($bytes.Length -lt 64 -or $bytes[0] -ne 0x4d -or $bytes[1] -ne 0x5a) {
+    throw "invalid PE header"
+  }
+  $peOffset = [BitConverter]::ToUInt32($bytes, 60)
+  if ($peOffset -gt $bytes.Length - 28) { throw "invalid PE offset" }
+  if (
+    $bytes[$peOffset] -ne 0x50 -or
+    $bytes[$peOffset + 1] -ne 0x45 -or
+    $bytes[$peOffset + 2] -ne 0 -or
+    $bytes[$peOffset + 3] -ne 0
+  ) {
+    throw "invalid PE signature"
+  }
+  $optionalHeaderOffset = $peOffset + 24
+  $magic = [BitConverter]::ToUInt16($bytes, $optionalHeaderOffset)
+  if ($magic -eq 0x10b) {
+    $dataDirectoryOffset = $optionalHeaderOffset + 96
+    $directoryCountOffset = $optionalHeaderOffset + 92
+  } elseif ($magic -eq 0x20b) {
+    $dataDirectoryOffset = $optionalHeaderOffset + 112
+    $directoryCountOffset = $optionalHeaderOffset + 108
+  } else {
+    throw "invalid PE optional header"
+  }
+  if ($directoryCountOffset -gt $bytes.Length - 4) { throw "invalid PE data directories" }
+  if ([BitConverter]::ToUInt32($bytes, $directoryCountOffset) -le 4) {
+    throw "missing PE security directory"
+  }
+  $securityEntryOffset = $dataDirectoryOffset + 32
+  if ($securityEntryOffset -gt $bytes.Length - 8) { throw "invalid PE security directory" }
+  $certificateOffset = [BitConverter]::ToUInt32($bytes, $securityEntryOffset)
+  $certificateDirectorySize = [BitConverter]::ToUInt32($bytes, $securityEntryOffset + 4)
+  if (
+    $certificateOffset -eq 0 -or
+    $certificateDirectorySize -lt 8 -or
+    $certificateOffset -gt $bytes.Length - 8 -or
+    $certificateDirectorySize -gt $bytes.Length - $certificateOffset
+  ) {
+    throw "invalid PE certificate table"
+  }
+  $certificateLength = [BitConverter]::ToUInt32($bytes, $certificateOffset)
+  if (
+    $certificateLength -lt 8 -or
+    $certificateLength -gt $certificateDirectorySize -or
+    $certificateLength -gt $bytes.Length - $certificateOffset
+  ) {
+    throw "invalid WIN_CERTIFICATE"
+  }
+  $encodedLength = $certificateLength - 8
+  $encoded = [byte[]]::new($encodedLength)
+  [Array]::Copy($bytes, $certificateOffset + 8, $encoded, 0, $encodedLength)
+  $cms = [System.Security.Cryptography.Pkcs.SignedCms]::new()
+  $cms.Decode($encoded)
+  return $cms
+}
+
+function Get-ContentDigestOid {
+  param($Cms)
+  $reader = [System.Formats.Asn1.AsnReader]::new(
+    $Cms.ContentInfo.Content,
+    [System.Formats.Asn1.AsnEncodingRules]::DER
+  )
+  $content = $reader.ReadSequence()
+  $null = $content.ReadEncodedValue()
+  $digestInfo = $content.ReadSequence()
+  $algorithm = $digestInfo.ReadSequence()
+  return $algorithm.ReadObjectIdentifier()
+}
+
+function Find-Signtool {
+  $command = Get-Command signtool.exe -CommandType Application -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+  if ($null -ne $command) { return $command.Source }
+  $kitsRoot = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin"
+  if (-not (Test-Path -LiteralPath $kitsRoot -PathType Container)) { return $null }
+  $versions = @(Get-ChildItem -LiteralPath $kitsRoot -Directory | ForEach-Object {
+    try {
+      [ordered]@{ version = [version]$_.Name; path = $_.FullName }
+    } catch {
+    }
+  } | Sort-Object version -Descending)
+  foreach ($version in $versions) {
+    $candidate = Join-Path $version.path "x64\signtool.exe"
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+  }
+  return $null
+}
+
+function Invoke-Signtool {
+  param([string]$Path, [string]$Target)
+  $startInfo = [Diagnostics.ProcessStartInfo]::new()
+  $startInfo.FileName = $Path
+  $startInfo.UseShellExecute = $false
+  $startInfo.RedirectStandardOutput = $true
+  $startInfo.RedirectStandardError = $true
+  foreach ($argument in @("verify", "/pa", "/all", "/v", $Target)) {
+    $null = $startInfo.ArgumentList.Add($argument)
+  }
+  $process = [Diagnostics.Process]::new()
+  $process.StartInfo = $startInfo
+  $null = $process.Start()
+  $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+  $stderrTask = $process.StandardError.ReadToEndAsync()
+  $process.WaitForExit()
+  $output = "$($stdoutTask.GetAwaiter().GetResult())$($stderrTask.GetAwaiter().GetResult())"
+  return [ordered]@{ exitCode = $process.ExitCode; output = $output }
+}
+
+try {
+  if ($ExpectedPublisherDn -eq "" -or $ExpectedPublisherDn -ne $ExpectedPublisherDn.Trim()) {
+    throw "invalid expected publisher DN"
+  }
+  if (
+    $ExpectedThumbprint -ne "" -and
+    -not [Text.RegularExpressions.Regex]::IsMatch($ExpectedThumbprint, "\A[0-9A-Fa-f]{40}\z")
+  ) {
+    throw "invalid expected thumbprint"
+  }
+  $resolvedInstallerPath = [IO.Path]::GetFullPath($InstallerPath)
+  $item = Get-Item -LiteralPath $resolvedInstallerPath -Force -ErrorAction SilentlyContinue
+  $fileOk =
+    $null -ne $item -and
+    -not $item.PSIsContainer -and
+    ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0 -and
+    [string]::Equals([IO.Path]::GetExtension($resolvedInstallerPath), ".exe", [StringComparison]::OrdinalIgnoreCase)
+  Add-VerificationCheck -Name "file" -Ok $fileOk -Detail $(if ($fileOk) { "regular-executable" } else { "invalid-installer-path" })
+  if (-not $fileOk) {
+    Add-VerificationCheck -Name "status" -Ok $false -Detail "file-unavailable"
+    Add-VerificationCheck -Name "digest" -Ok $false -Detail "file-unavailable"
+    Add-VerificationCheck -Name "timestamp" -Ok $false -Detail "file-unavailable"
+    Add-VerificationCheck -Name "subject" -Ok $false -Detail "file-unavailable"
+    if ($ExpectedThumbprint -ne "") {
+      Add-VerificationCheck -Name "thumbprint" -Ok $false -Detail "file-unavailable"
+    }
+    Add-VerificationCheck -Name "chain" -Ok $false -Detail "file-unavailable"
+    Add-VerificationCheck -Name "signtool" -Ok $false -Detail "file-unavailable"
+    Write-VerificationSummary -Ok $false
+    exit 1
+  }
+
+  $null = Add-Type -AssemblyName System.Security.Cryptography.Pkcs
+  $signature = Get-AuthenticodeSignature -LiteralPath $resolvedInstallerPath
+  $status = [string]$signature.Status
+  $statusMessage = [string]$signature.StatusMessage
+  if ($null -ne $signature.SignerCertificate) {
+    $signer = [ordered]@{
+      subject = $signature.SignerCertificate.Subject
+      thumbprint = $signature.SignerCertificate.Thumbprint
+      issuer = $signature.SignerCertificate.Issuer
+      notAfter = $signature.SignerCertificate.NotAfter.ToUniversalTime().ToString("o")
+    }
+  }
+  if ($null -ne $signature.TimeStamperCertificate) {
+    $timestamper = [ordered]@{ subject = $signature.TimeStamperCertificate.Subject }
+  }
+  $thumbprintMatches =
+    $ExpectedThumbprint -ne "" -and
+    $null -ne $signature.SignerCertificate -and
+    [string]::Equals(
+      $signature.SignerCertificate.Thumbprint,
+      $ExpectedThumbprint,
+      [StringComparison]::OrdinalIgnoreCase
+    )
+  $untrustedRoot =
+    ($status -eq "NotTrusted" -or $status -eq "UnknownError") -and
+    [Text.RegularExpressions.Regex]::IsMatch(
+      $statusMessage,
+      "untrusted root|root certificate which is not trusted|terminated in a root certificate",
+      [Text.RegularExpressions.RegexOptions]::IgnoreCase
+    )
+  $testTrustAccepted =
+    [bool]$AllowSelfSignedTest -and
+    $ExpectedThumbprint -ne "" -and
+    $thumbprintMatches -and
+    $untrustedRoot
+  $statusOk = $status -eq "Valid" -or $testTrustAccepted
+  Add-VerificationCheck -Name "status" -Ok $statusOk -Detail $status
+
+  try {
+    $cms = Get-PrimarySignedCms -Path $resolvedInstallerPath
+    $digestOid = Get-ContentDigestOid -Cms $cms
+    if ($digestOid -eq "2.16.840.1.101.3.4.2.1") {
+      $digestAlgorithm = "sha256"
+    } elseif ($digestOid -eq "1.3.14.3.2.26") {
+      $digestAlgorithm = "sha1"
+    } else {
+      $digestAlgorithm = $digestOid
+    }
+    Add-VerificationCheck -Name "digest" -Ok ($digestOid -eq "2.16.840.1.101.3.4.2.1") -Detail $digestAlgorithm
+    $primarySigner = if ($cms.SignerInfos.Count -gt 0) { $cms.SignerInfos[0] } else { $null }
+    $rfc3161 =
+      $null -ne $primarySigner -and
+      @($primarySigner.UnsignedAttributes | Where-Object {
+        $_.Oid.Value -eq "1.3.6.1.4.1.311.3.3.1"
+      }).Count -gt 0
+  } catch {
+    Add-VerificationCheck -Name "digest" -Ok $false -Detail "unreadable-primary-signature"
+    $rfc3161 = $false
+  }
+  $timestampOk = $rfc3161 -and $null -ne $signature.TimeStamperCertificate
+  Add-VerificationCheck -Name "timestamp" -Ok $timestampOk -Detail $(if ($timestampOk) { "rfc3161" } else { "rfc3161-missing" })
+
+  $subjectOk =
+    $null -ne $signature.SignerCertificate -and
+    [string]::Equals(
+      $signature.SignerCertificate.Subject,
+      $ExpectedPublisherDn,
+      [StringComparison]::Ordinal
+    )
+  Add-VerificationCheck -Name "subject" -Ok $subjectOk -Detail $(if ($null -eq $signer) { "signer-missing" } else { $signer.subject })
+  if ($ExpectedThumbprint -ne "") {
+    Add-VerificationCheck -Name "thumbprint" -Ok $thumbprintMatches -Detail $(if ($null -eq $signer) { "signer-missing" } else { $signer.thumbprint })
+  }
+
+  $chainOk = $status -eq "Valid" -or $testTrustAccepted
+  $chainDetail = if ($testTrustAccepted) { "untrusted-root-accepted-for-test" } elseif ($status -eq "Valid") { "trusted" } else { "untrusted" }
+  Add-VerificationCheck -Name "chain" -Ok $chainOk -Detail $chainDetail
+
+  $signtoolPath = Find-Signtool
+  if ($null -eq $signtoolPath) {
+    $signtoolOk = [bool]$AllowMissingSigntool
+    Add-VerificationCheck -Name "signtool" -Ok $signtoolOk -Detail "signtool-unavailable"
+  } else {
+    $signtool.path = $signtoolPath
+    $signtoolResult = Invoke-Signtool -Path $signtoolPath -Target $resolvedInstallerPath
+    $signtool.exitCode = $signtoolResult.exitCode
+    $signtool.output = $signtoolResult.output
+    $signtoolOk = $signtoolResult.exitCode -eq 0 -or [bool]$AllowSelfSignedTest
+    Add-VerificationCheck -Name "signtool" -Ok $signtoolOk -Detail "exit-code-$($signtoolResult.exitCode)"
+  }
+
+  $ok = @($checks | Where-Object { -not $_.ok }).Count -eq 0
+  Write-VerificationSummary -Ok $ok
+  if ($ok) { exit 0 }
+  exit 1
+} catch {
+  [Console]::Error.WriteLine($_.Exception.Message)
+  $checks.Clear()
+  Add-VerificationCheck -Name "error" -Ok $false -Detail "script-error"
+  Write-VerificationSummary -Ok $false
+  exit 2
+}

--- a/apps/desktop/scripts/verify-windows-release.d.mts
+++ b/apps/desktop/scripts/verify-windows-release.d.mts
@@ -4,6 +4,8 @@ import type { WindowsReleaseArtifactNames } from "./windows-release-plan.mjs";
 export type WindowsAuthenticodeMode =
   | "pending-w19"
   | {
+      readonly mode?: "verify";
+      readonly expectedPublisherDn?: string;
       readonly verify: (
         installerPath: string,
         context: { readonly version: string; readonly publisherName?: string },

--- a/apps/desktop/scripts/verify-windows-release.mjs
+++ b/apps/desktop/scripts/verify-windows-release.mjs
@@ -11,6 +11,7 @@ import {
   windowsReleaseArtifactNames,
 } from "./windows-release-plan.mjs";
 import { requireStableSemVer } from "./macos-release-plan.mjs";
+import { createWindowsAuthenticodeVerifyMode } from "./verify-windows-authenticode.mjs";
 
 export const WINDOWS_UPDATER_METADATA_MAX_BYTES = 16_384;
 
@@ -264,10 +265,17 @@ function parseArguments(arguments_) {
   let version;
   let commit;
   let authenticode;
+  let publisherDn;
+  let thumbprint;
+  let allowSelfSignedTest = false;
   for (let index = 0; index < arguments_.length; index += 1) {
     const argument = arguments_[index];
     if (!argument.startsWith("--") && directory === undefined) {
       directory = argument;
+      continue;
+    }
+    if (argument === "--allow-self-signed-test" && !allowSelfSignedTest) {
+      allowSelfSignedTest = true;
       continue;
     }
     const value = arguments_[index + 1];
@@ -276,14 +284,30 @@ function parseArguments(arguments_) {
     if (argument === "--version" && version === undefined) version = value;
     else if (argument === "--commit" && commit === undefined) commit = value;
     else if (argument === "--authenticode" && authenticode === undefined) authenticode = value;
+    else if (argument === "--publisher-dn" && publisherDn === undefined) publisherDn = value;
+    else if (argument === "--thumbprint" && thumbprint === undefined) thumbprint = value;
     else fail("Windows release verification failed");
   }
-  return { directory, version, commit, authenticode };
+  return { directory, version, commit, authenticode, publisherDn, thumbprint, allowSelfSignedTest };
 }
 
 async function main() {
   const arguments_ = parseArguments(process.argv.slice(2));
-  if (arguments_.authenticode !== WINDOWS_AUTHENTICODE_PENDING) {
+  let authenticodeMode;
+  if (
+    arguments_.authenticode === WINDOWS_AUTHENTICODE_PENDING &&
+    arguments_.publisherDn === undefined &&
+    arguments_.thumbprint === undefined &&
+    !arguments_.allowSelfSignedTest
+  ) {
+    authenticodeMode = WINDOWS_AUTHENTICODE_PENDING;
+  } else if (arguments_.authenticode === "verify" && arguments_.publisherDn !== undefined) {
+    authenticodeMode = createWindowsAuthenticodeVerifyMode({
+      expectedPublisherDn: arguments_.publisherDn,
+      expectedThumbprint: arguments_.thumbprint,
+      allowSelfSignedTest: arguments_.allowSelfSignedTest,
+    });
+  } else {
     fail("Authenticode verification mode is required");
   }
   const result = await verifyWindowsReleaseAssets(
@@ -291,7 +315,8 @@ async function main() {
     {
       version: arguments_.version,
       commit: arguments_.commit,
-      authenticode: arguments_.authenticode,
+      expectedPublisherName: arguments_.publisherDn,
+      authenticode: authenticodeMode,
     },
     { notice: (message) => process.stderr.write(`${message}\n`) },
   );

--- a/apps/desktop/scripts/windows-pe-inventory.d.mts
+++ b/apps/desktop/scripts/windows-pe-inventory.d.mts
@@ -1,0 +1,45 @@
+export type WindowsPeKind = "application" | "runtime-library" | "uninstaller" | "installer";
+export type WindowsPeLocation = "installer-payload" | "artifact";
+
+export interface WindowsPeRequiredEntry {
+  readonly path: string;
+  readonly kind: WindowsPeKind;
+  readonly location?: WindowsPeLocation;
+}
+
+export interface WindowsPeThirdPartyException {
+  readonly path: string;
+  readonly sha256: string;
+  readonly upstreamSigner: string;
+  readonly rationale: string;
+}
+
+export interface WindowsPeInventory {
+  readonly schema: "windows-pe-inventory/1";
+  readonly signing: {
+    readonly tool: "electron-builder";
+    readonly version: "26.15.3";
+    readonly option: "win.signExts";
+  };
+  readonly required: readonly WindowsPeRequiredEntry[];
+  readonly thirdPartyExceptions: readonly WindowsPeThirdPartyException[];
+}
+
+export interface WindowsPeInventoryDiff {
+  readonly ok: boolean;
+  readonly missing: readonly string[];
+  readonly undeclared: readonly string[];
+  readonly symlinks: readonly string[];
+  readonly expected: readonly string[];
+  readonly actual: readonly string[];
+  readonly notInspected: readonly string[];
+}
+
+export function readWindowsPeInventory(path?: string): WindowsPeInventory;
+export function isPortableExecutable(bytes: Uint8Array): boolean;
+export function enumeratePortableExecutables(unpackedRoot: string): Promise<readonly string[]>;
+export function diffWindowsPeInventory(input: {
+  readonly unpackedRoot: string;
+  readonly inventory: WindowsPeInventory;
+  readonly version: string;
+}): Promise<WindowsPeInventoryDiff>;

--- a/apps/desktop/scripts/windows-pe-inventory.mjs
+++ b/apps/desktop/scripts/windows-pe-inventory.mjs
@@ -1,0 +1,259 @@
+import { lstatSync, readFileSync } from "node:fs";
+import { lstat, open, readdir } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const canonicalInventoryPath = resolve(scriptDirectory, "../build/windows-pe-inventory.json");
+const portableExecutableHeaderBytes = 4096;
+const inventoryFailureMessage = "Windows PE inventory is invalid";
+
+function exactObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value, keys) {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function validRelativePath(value) {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value === value.trim() &&
+    !isAbsolute(value) &&
+    !value.includes("\\") &&
+    !value.split("/").includes("..")
+  );
+}
+
+function freezeInventory(value) {
+  return Object.freeze({
+    schema: value.schema,
+    signing: Object.freeze({ ...value.signing }),
+    required: Object.freeze(value.required.map((entry) => Object.freeze({ ...entry }))),
+    thirdPartyExceptions: Object.freeze(
+      value.thirdPartyExceptions.map((entry) => Object.freeze({ ...entry })),
+    ),
+  });
+}
+
+function parseInventory(source) {
+  let inventory;
+  try {
+    inventory = JSON.parse(source);
+  } catch {
+    throw new TypeError(inventoryFailureMessage);
+  }
+  const signingValid =
+    exactObject(inventory?.signing) &&
+    hasExactKeys(inventory.signing, ["tool", "version", "option"]) &&
+    inventory.signing.tool === "electron-builder" &&
+    inventory.signing.version === "26.15.3" &&
+    inventory.signing.option === "win.signExts";
+  const requiredValid =
+    Array.isArray(inventory?.required) &&
+    inventory.required.length > 0 &&
+    inventory.required.every((entry) => {
+      if (!exactObject(entry) || !validRelativePath(entry.path)) return false;
+      const keys = Object.hasOwn(entry, "location")
+        ? ["path", "kind", "location"]
+        : ["path", "kind"];
+      if (!hasExactKeys(entry, keys)) return false;
+      if (![
+        "application",
+        "runtime-library",
+        "uninstaller",
+        "installer",
+      ].includes(entry.kind)) return false;
+      return (
+        !Object.hasOwn(entry, "location") ||
+        entry.location === "installer-payload" ||
+        entry.location === "artifact"
+      );
+    });
+  const exceptionsValid =
+    Array.isArray(inventory?.thirdPartyExceptions) &&
+    inventory.thirdPartyExceptions.every(
+      (entry) =>
+        exactObject(entry) &&
+        hasExactKeys(entry, ["path", "sha256", "upstreamSigner", "rationale"]) &&
+        validRelativePath(entry.path) &&
+        /^[0-9a-f]{64}$/u.test(entry.sha256) &&
+        [entry.upstreamSigner, entry.rationale].every(
+          (field) => typeof field === "string" && field.length > 0 && field === field.trim(),
+        ),
+    );
+  const paths = [
+    ...(Array.isArray(inventory?.required) ? inventory.required.map((entry) => entry?.path) : []),
+    ...(Array.isArray(inventory?.thirdPartyExceptions)
+      ? inventory.thirdPartyExceptions.map((entry) => entry?.path)
+      : []),
+  ];
+  if (
+    !exactObject(inventory) ||
+    !hasExactKeys(inventory, ["schema", "signing", "required", "thirdPartyExceptions"]) ||
+    inventory.schema !== "windows-pe-inventory/1" ||
+    !signingValid ||
+    !requiredValid ||
+    !exceptionsValid ||
+    new Set(paths).size !== paths.length
+  ) {
+    throw new TypeError(inventoryFailureMessage);
+  }
+  return freezeInventory(inventory);
+}
+
+export function readWindowsPeInventory(path = canonicalInventoryPath) {
+  if (typeof path !== "string" || path.length === 0) throw new TypeError(inventoryFailureMessage);
+  try {
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink() || !stat.isFile()) throw new TypeError();
+    return parseInventory(readFileSync(path, "utf8"));
+  } catch (error) {
+    if (error instanceof TypeError && error.message === inventoryFailureMessage) throw error;
+    throw new TypeError(inventoryFailureMessage);
+  }
+}
+
+export function isPortableExecutable(bytes) {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength < 64) return false;
+  if (bytes[0] !== 0x4d || bytes[1] !== 0x5a) return false;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const peOffset = view.getUint32(60, true);
+  return (
+    peOffset <= bytes.byteLength - 4 &&
+    bytes[peOffset] === 0x50 &&
+    bytes[peOffset + 1] === 0x45 &&
+    bytes[peOffset + 2] === 0 &&
+    bytes[peOffset + 3] === 0
+  );
+}
+
+function portablePath(root, path) {
+  return relative(root, path).split(sep).join("/");
+}
+
+async function enumerateTree(unpackedRoot) {
+  const rootStat = await lstat(unpackedRoot);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new TypeError("Windows unpacked root is invalid");
+  }
+  const portableExecutables = [];
+  const symlinks = [];
+  async function visit(directory) {
+    const names = await readdir(directory);
+    for (const name of names) {
+      const path = join(directory, name);
+      const stat = await lstat(path);
+      const relativePath = portablePath(unpackedRoot, path);
+      if (stat.isSymbolicLink()) {
+        symlinks.push(relativePath);
+      } else if (stat.isDirectory()) {
+        await visit(path);
+      } else if (stat.isFile()) {
+        const handle = await open(path, "r");
+        try {
+          const bytes = Buffer.alloc(portableExecutableHeaderBytes);
+          const { bytesRead } = await handle.read(bytes, 0, portableExecutableHeaderBytes, 0);
+          if (isPortableExecutable(bytes.subarray(0, bytesRead))) {
+            portableExecutables.push(relativePath);
+          }
+        } finally {
+          await handle.close();
+        }
+      }
+    }
+  }
+  await visit(unpackedRoot);
+  return {
+    portableExecutables: portableExecutables.sort(),
+    symlinks: symlinks.sort(),
+  };
+}
+
+export async function enumeratePortableExecutables(unpackedRoot) {
+  return Object.freeze((await enumerateTree(unpackedRoot)).portableExecutables);
+}
+
+function applyVersion(path, version) {
+  return path.replaceAll("${version}", version);
+}
+
+export async function diffWindowsPeInventory({ unpackedRoot, inventory, version }) {
+  if (
+    typeof version !== "string" ||
+    !/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u.test(version)
+  ) {
+    throw new TypeError("Windows PE inventory version is invalid");
+  }
+  const inspected = await enumerateTree(unpackedRoot);
+  const expected = inventory.required
+    .filter((entry) => entry.location === undefined)
+    .map((entry) => applyVersion(entry.path, version))
+    .sort();
+  const declared = new Set([
+    ...expected,
+    ...inventory.thirdPartyExceptions.map((entry) => applyVersion(entry.path, version)),
+  ]);
+  const actual = inspected.portableExecutables;
+  const missing = expected.filter((path) => !actual.includes(path));
+  const undeclared = actual.filter((path) => !declared.has(path));
+  const notInspected = inventory.required
+    .filter((entry) => entry.location !== undefined)
+    .map((entry) => applyVersion(entry.path, version))
+    .sort();
+  return Object.freeze({
+    ok: missing.length === 0 && undeclared.length === 0 && inspected.symlinks.length === 0,
+    missing: Object.freeze(missing),
+    undeclared: Object.freeze(undeclared),
+    symlinks: Object.freeze(inspected.symlinks),
+    expected: Object.freeze(expected),
+    actual: Object.freeze(actual),
+    notInspected: Object.freeze(notInspected),
+  });
+}
+
+function parseArguments(arguments_) {
+  let unpackedRoot;
+  let inventoryPath;
+  let version;
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (!argument.startsWith("--") && unpackedRoot === undefined) {
+      unpackedRoot = argument;
+      continue;
+    }
+    const value = arguments_[index + 1];
+    if (value === undefined || value.startsWith("--")) throw new TypeError("Invalid arguments");
+    index += 1;
+    if (argument === "--inventory" && inventoryPath === undefined) inventoryPath = value;
+    else if (argument === "--version" && version === undefined) version = value;
+    else throw new TypeError("Invalid arguments");
+  }
+  if (unpackedRoot === undefined) throw new TypeError("Invalid arguments");
+  return { unpackedRoot: resolve(unpackedRoot), inventoryPath, version: version ?? "0.0.0" };
+}
+
+async function main() {
+  const arguments_ = parseArguments(process.argv.slice(2));
+  const inventory = readWindowsPeInventory(arguments_.inventoryPath);
+  const result = await diffWindowsPeInventory({
+    unpackedRoot: arguments_.unpackedRoot,
+    inventory,
+    version: arguments_.version,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof TypeError ? error.message : "Windows PE inventory failed"}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/apps/desktop/scripts/windows-release-plan.d.mts
+++ b/apps/desktop/scripts/windows-release-plan.d.mts
@@ -22,6 +22,7 @@ export interface WindowsReleaseInput {
   readonly baselineVersion?: string;
   readonly repositoryRoot?: string;
   readonly desktopRoot?: string;
+  readonly publisherDn?: string;
 }
 
 export interface WindowsReleaseBuilderOptions {
@@ -40,6 +41,7 @@ export interface WindowsReleaseBuilderOptions {
       { readonly provider: "generic"; readonly url: string; readonly channel: "latest" },
     ];
     readonly win: {
+      readonly publisherName: readonly [string];
       readonly verifyUpdateCodeSignature: true;
       readonly target: readonly [{ readonly target: "nsis"; readonly arch: readonly ["x64"] }];
     };
@@ -59,6 +61,8 @@ export interface WindowsReleasePlan {
   readonly mode: WindowsReleaseMode;
   readonly baselineVersion: string | null;
   readonly feedUrl: string;
+  readonly publisherDn: string;
+  readonly publisherDnIsPlaceholder: boolean;
   readonly artifactNames: WindowsReleaseArtifactNames;
   readonly assetNames: readonly string[];
   readonly updaterMetadata: WindowsReleaseUpdaterMetadata;
@@ -70,6 +74,7 @@ export const WINDOWS_RELEASE_ARCH: "x64";
 export const WINDOWS_RELEASE_PLATFORM: "win32";
 export const WINDOWS_RELEASE_METADATA_NAME: "latest.yml";
 export const WINDOWS_AUTHENTICODE_PENDING: "pending-w19";
+export const WINDOWS_PUBLISHER_DN_PLACEHOLDER: "CN=ENDURAGENT PUBLISHER DN PLACEHOLDER, O=PLACEHOLDER";
 export function safeWindowsReleasePlanMessage(error: unknown): string | undefined;
 export function requireReleaseCommit(value: unknown): string;
 export function windowsReleaseArtifactNames(version: string): WindowsReleaseArtifactNames;

--- a/apps/desktop/scripts/windows-release-plan.mjs
+++ b/apps/desktop/scripts/windows-release-plan.mjs
@@ -21,12 +21,15 @@ const safeWindowsReleasePlanMessages = new Set([
   "steady Windows release requires a lower stable baseline version",
   "release updater metadata is invalid",
   "release updater publisher name mismatch",
+  "Windows publisher DN is invalid",
 ]);
 
 export const WINDOWS_RELEASE_ARCH = "x64";
 export const WINDOWS_RELEASE_PLATFORM = "win32";
 export const WINDOWS_RELEASE_METADATA_NAME = "latest.yml";
 export const WINDOWS_AUTHENTICODE_PENDING = "pending-w19";
+export const WINDOWS_PUBLISHER_DN_PLACEHOLDER =
+  "CN=ENDURAGENT PUBLISHER DN PLACEHOLDER, O=PLACEHOLDER";
 
 function exactObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -47,7 +50,7 @@ function compareStableVersions(left, right) {
   return 0;
 }
 
-function freezeBuilderOptions(desktopRoot, version, feedUrl) {
+function freezeBuilderOptions(desktopRoot, version, feedUrl, publisherDn) {
   const publish = Object.freeze([
     Object.freeze({ provider: "generic", url: feedUrl, channel: "latest" }),
   ]);
@@ -60,7 +63,11 @@ function freezeBuilderOptions(desktopRoot, version, feedUrl) {
     forceCodeSigning: true,
     extraMetadata: Object.freeze({ version, enduragentDesktopRelease: true }),
     publish,
-    win: Object.freeze({ verifyUpdateCodeSignature: true, target }),
+    win: Object.freeze({
+      publisherName: Object.freeze([publisherDn]),
+      verifyUpdateCodeSignature: true,
+      target,
+    }),
     nsis: Object.freeze({
       artifactName: `Enduragent-${version}-x64.\${ext}`,
       differentialPackage: true,
@@ -192,6 +199,11 @@ export function createWindowsReleasePlan(input) {
   const version = requireStableSemVer(input.version);
   const commit = requireReleaseCommit(input.commit);
   const feedUrl = requireGenericFeedUrl(input.feedUrl);
+  const publisherDn =
+    input.publisherDn === undefined ? WINDOWS_PUBLISHER_DN_PLACEHOLDER : input.publisherDn?.trim();
+  if (typeof publisherDn !== "string" || publisherDn.length === 0) {
+    throw new TypeError("Windows publisher DN is invalid");
+  }
   if (input.mode !== "genesis" && input.mode !== "steady") {
     throw new TypeError("Windows release mode must be genesis or steady");
   }
@@ -221,6 +233,7 @@ export function createWindowsReleasePlan(input) {
     url: feedUrl,
     channel: "latest",
     updaterCacheDirName: DESKTOP_UPDATER_CACHE_DIRECTORY,
+    publisherName: publisherDn,
   });
   return Object.freeze({
     version,
@@ -231,10 +244,12 @@ export function createWindowsReleasePlan(input) {
     mode: input.mode,
     baselineVersion,
     feedUrl,
+    publisherDn,
+    publisherDnIsPlaceholder: publisherDn === WINDOWS_PUBLISHER_DN_PLACEHOLDER,
     artifactNames,
     assetNames,
     updaterMetadata,
     authenticode: WINDOWS_AUTHENTICODE_PENDING,
-    builderOptions: freezeBuilderOptions(desktopRoot, version, feedUrl),
+    builderOptions: freezeBuilderOptions(desktopRoot, version, feedUrl, publisherDn),
   });
 }

--- a/apps/desktop/tests/windows-authenticode-fixture.test.ts
+++ b/apps/desktop/tests/windows-authenticode-fixture.test.ts
@@ -1,0 +1,64 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterAll, describe, expect, it } from "vitest";
+import { verifyWindowsAuthenticode } from "../scripts/verify-windows-authenticode.mjs";
+
+const execFileAsync = promisify(execFile);
+const scriptDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "../scripts");
+let temporaryDirectory: string | undefined;
+let fixture: {
+  readonly fixturePath: string;
+  readonly subject: string;
+  readonly thumbprint: string;
+  readonly timestamped: boolean;
+} | undefined;
+
+if (process.platform === "win32") {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), "windows-authenticode-fixture-"));
+  const result = await execFileAsync("pwsh", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    join(scriptDirectory, "make-test-signing-cert.ps1"),
+    "-OutputDirectory",
+    temporaryDirectory,
+  ]);
+  fixture = JSON.parse(result.stdout);
+}
+
+const fixtureTest = fixture !== undefined && !fixture.timestamped ? it.skip : it;
+
+afterAll(async () => {
+  if (temporaryDirectory !== undefined) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+describe.skipIf(process.platform !== "win32")(
+  "Windows-only: needs pwsh, New-SelfSignedCertificate, and a reachable RFC 3161 TSA",
+  () => {
+    fixtureTest("verifies the generated self-signed and timestamped PE", async () => {
+      if (fixture === undefined) throw new TypeError("Windows fixture is unavailable");
+      const options = {
+        installerPath: fixture.fixturePath,
+        expectedPublisherDn: fixture.subject,
+        expectedThumbprint: fixture.thumbprint,
+        allowSelfSignedTest: true,
+        allowMissingSigntool: true,
+      };
+      await expect(verifyWindowsAuthenticode(options)).resolves.toMatchObject({ ok: true });
+      await expect(
+        verifyWindowsAuthenticode({ ...options, expectedPublisherDn: "CN=Different Test Publisher" }),
+      ).rejects.toThrow("Authenticode publisher mismatch");
+      await expect(
+        verifyWindowsAuthenticode({ ...options, allowSelfSignedTest: false }),
+      ).rejects.toThrow("Authenticode chain is untrusted");
+    });
+  },
+);

--- a/apps/desktop/tests/windows-authenticode.test.ts
+++ b/apps/desktop/tests/windows-authenticode.test.ts
@@ -1,0 +1,242 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stringify } from "yaml";
+import {
+  createWindowsAuthenticodeVerifyMode,
+  decideWindowsAuthenticode,
+  parseWindowsAuthenticodeSummary,
+  verifyWindowsAuthenticode,
+  type WindowsAuthenticodeSummary,
+} from "../scripts/verify-windows-authenticode.mjs";
+import { verifyWindowsReleaseAssets } from "../scripts/verify-windows-release.mjs";
+import { windowsReleaseArtifactNames } from "../scripts/windows-release-plan.mjs";
+
+const version = "0.1.5";
+const publisherDn = "CN=Enduragent Test Publisher, O=Enduragent Test";
+const thumbprint = "a".repeat(40);
+const scriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../scripts/verify-windows-authenticode.ps1",
+);
+const temporaryRoots: string[] = [];
+let directory: string;
+let installerPath: string;
+
+function summary(
+  overrides: Partial<WindowsAuthenticodeSummary> = {},
+): WindowsAuthenticodeSummary {
+  return {
+    schema: "windows-authenticode-verification/1",
+    installerPath: "/synthetic/installer.exe",
+    ok: true,
+    signer: {
+      subject: publisherDn,
+      thumbprint,
+      issuer: publisherDn,
+      notAfter: "2026-08-26T00:00:00.000Z",
+    },
+    timestamper: { subject: "CN=Test Timestamp Authority" },
+    status: "Valid",
+    statusMessage: "Signature verified.",
+    digestAlgorithm: "sha256",
+    rfc3161: true,
+    signtool: { path: "C:\\signtool.exe", exitCode: 0, output: "verified" },
+    allowSelfSignedTest: false,
+    checks: [
+      { name: "file", ok: true, detail: "regular-executable" },
+      { name: "status", ok: true, detail: "Valid" },
+      { name: "digest", ok: true, detail: "sha256" },
+      { name: "timestamp", ok: true, detail: "rfc3161" },
+      { name: "subject", ok: true, detail: publisherDn },
+      { name: "thumbprint", ok: true, detail: thumbprint },
+      { name: "chain", ok: true, detail: "trusted" },
+      { name: "signtool", ok: true, detail: "exit-code-0" },
+    ],
+    ...overrides,
+  };
+}
+
+function decisionOptions(allowSelfSignedTest = false) {
+  return { expectedPublisherDn: publisherDn, expectedThumbprint: thumbprint, allowSelfSignedTest };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), "windows-authenticode-envelope-"));
+  temporaryRoots.push(directory);
+  const installer = Buffer.from("synthetic signed Windows installer\n");
+  const names = windowsReleaseArtifactNames(version);
+  installerPath = join(directory, names.installer);
+  const sha512 = createHash("sha512").update(installer).digest("base64");
+  await Promise.all([
+    writeFile(installerPath, installer),
+    writeFile(
+      join(directory, names.blockmap),
+      gzipSync(
+        JSON.stringify({
+          version: "2",
+          files: [{ name: "file", offset: 0, checksums: ["x"], sizes: [1] }],
+        }),
+      ),
+    ),
+    writeFile(
+      join(directory, names.metadata),
+      stringify({
+        version,
+        files: [{ url: names.installer, sha512, size: installer.length }],
+        path: names.installer,
+        sha512,
+        releaseDate: "2026-08-25T00:00:00.000Z",
+      }),
+    ),
+  ]);
+});
+
+describe("Windows Authenticode decisions", () => {
+  it("accepts an exact SHA-256 signature with an RFC 3161 timestamp", () => {
+    expect(decideWindowsAuthenticode(summary(), decisionOptions())).toMatchObject({
+      ok: true,
+      digestAlgorithm: "sha256",
+      rfc3161: true,
+    });
+  });
+
+  it("re-derives publisher, digest, and timestamp decisions from summary fields", () => {
+    expect(() =>
+      decideWindowsAuthenticode(
+        summary({ signer: { ...summary().signer!, subject: "CN=Wrong Publisher" } }),
+        decisionOptions(),
+      ),
+    ).toThrow("Authenticode publisher mismatch");
+    expect(() =>
+      decideWindowsAuthenticode(summary({ digestAlgorithm: "sha1" }), decisionOptions()),
+    ).toThrow("Authenticode digest is not SHA-256");
+    expect(() =>
+      decideWindowsAuthenticode(summary({ rfc3161: false }), decisionOptions()),
+    ).toThrow("Authenticode timestamp is missing");
+  });
+
+  it("accepts an explicitly requested self-signed test chain and rejects it otherwise", () => {
+    const checks = summary().checks.map((check) =>
+      check.name === "chain"
+        ? { ...check, detail: "untrusted-root-accepted-for-test" }
+        : check.name === "status"
+          ? { ...check, detail: "NotTrusted" }
+          : check,
+    );
+    const testSummary = summary({
+      status: "NotTrusted",
+      statusMessage: "terminated in a root certificate which is not trusted",
+      allowSelfSignedTest: true,
+      checks,
+    });
+    expect(decideWindowsAuthenticode(testSummary, decisionOptions(true)).ok).toBe(true);
+    expect(() => decideWindowsAuthenticode(testSummary, decisionOptions())).toThrow(
+      "Authenticode summary is invalid",
+    );
+    const refusedChecks = checks.map((check) =>
+      check.name === "chain" || check.name === "status" ? { ...check, ok: false } : check,
+    );
+    expect(() =>
+      decideWindowsAuthenticode(
+        summary({
+          ok: false,
+          status: "NotTrusted",
+          statusMessage: "terminated in a root certificate which is not trusted",
+          checks: refusedChecks,
+        }),
+        decisionOptions(),
+      ),
+    ).toThrow("Authenticode chain is untrusted");
+  });
+
+  it("rejects thumbprint and signtool failures", () => {
+    expect(() =>
+      decideWindowsAuthenticode(
+        summary({ signer: { ...summary().signer!, thumbprint: "b".repeat(40) } }),
+        decisionOptions(),
+      ),
+    ).toThrow("Authenticode thumbprint mismatch");
+    expect(() =>
+      decideWindowsAuthenticode(
+        summary({
+          ok: false,
+          signtool: { path: "C:\\signtool.exe", exitCode: 1, output: "failed" },
+          checks: summary().checks.map((check) =>
+            check.name === "signtool" ? { ...check, ok: false, detail: "exit-code-1" } : check,
+          ),
+        }),
+        decisionOptions(),
+      ),
+    ).toThrow("signtool verification failed");
+  });
+
+  it("strictly parses the summary envelope", () => {
+    expect(parseWindowsAuthenticodeSummary(JSON.stringify(summary()))).toEqual(summary());
+    expect(() => parseWindowsAuthenticodeSummary("not json")).toThrow(
+      "Authenticode summary is invalid",
+    );
+    expect(() =>
+      parseWindowsAuthenticodeSummary(JSON.stringify({ ...summary(), unexpected: true })),
+    ).toThrow("Authenticode summary is invalid");
+  });
+
+  it("captures summaries from successful and failed verifier exits", async () => {
+    const executeFile = vi.fn(async () => ({ stdout: JSON.stringify(summary()), exitCode: 0 }));
+    await expect(
+      verifyWindowsAuthenticode(
+        { installerPath, expectedPublisherDn: publisherDn, expectedThumbprint: thumbprint },
+        { executeFile, scriptPath },
+      ),
+    ).resolves.toMatchObject({ ok: true });
+    const wrong = summary({ signer: { ...summary().signer!, subject: "CN=Wrong Publisher" } });
+    await expect(
+      verifyWindowsAuthenticode(
+        { installerPath, expectedPublisherDn: publisherDn, expectedThumbprint: thumbprint },
+        {
+          executeFile: vi.fn(async () => ({ stdout: JSON.stringify(wrong), exitCode: 1 })),
+          scriptPath,
+        },
+      ),
+    ).rejects.toThrow("Authenticode publisher mismatch");
+  });
+
+  it("runs the verify mode through the Windows release envelope", async () => {
+    const executeFile = vi.fn(async () => ({
+      stdout: JSON.stringify(summary({ installerPath })),
+      exitCode: 0,
+    }));
+    const authenticode = createWindowsAuthenticodeVerifyMode(
+      { expectedPublisherDn: publisherDn, expectedThumbprint: thumbprint },
+      { executeFile, scriptPath },
+    );
+    const result = await verifyWindowsReleaseAssets(directory, {
+      version,
+      expectedPublisherName: publisherDn,
+      authenticode,
+    });
+    expect(result.authenticode).toBe("verified");
+    expect(executeFile).toHaveBeenCalledWith(
+      "pwsh",
+      expect.arrayContaining([
+        "-File",
+        scriptPath,
+        "-InstallerPath",
+        installerPath,
+        "-ExpectedPublisherDn",
+        publisherDn,
+      ]),
+      { encoding: "utf8", maxBuffer: 4 * 1024 * 1024 },
+    );
+  });
+});

--- a/apps/desktop/tests/windows-pe-inventory.test.ts
+++ b/apps/desktop/tests/windows-pe-inventory.test.ts
@@ -1,0 +1,129 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  diffWindowsPeInventory,
+  enumeratePortableExecutables,
+  isPortableExecutable,
+  readWindowsPeInventory,
+  type WindowsPeInventory,
+} from "../scripts/windows-pe-inventory.mjs";
+
+const inventoryPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../build/windows-pe-inventory.json",
+);
+const temporaryRoots: string[] = [];
+
+function portableExecutable() {
+  const bytes = Buffer.alloc(68);
+  bytes.write("MZ", 0, "ascii");
+  bytes.writeUInt32LE(64, 60);
+  bytes.write("PE\0\0", 64, "binary");
+  return bytes;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("Windows PE inventory", () => {
+  it("recognizes bounded PE headers", () => {
+    expect(isPortableExecutable(portableExecutable())).toBe(true);
+    expect(isPortableExecutable(Buffer.from("MZ text"))).toBe(false);
+    expect(isPortableExecutable(Buffer.alloc(68))).toBe(false);
+  });
+
+  it("enumerates PEs recursively and reports inventory differences and symlinks", async () => {
+    const root = await mkdtemp(join(tmpdir(), "windows-pe-inventory-"));
+    temporaryRoots.push(root);
+    await mkdir(join(root, "nested"));
+    await Promise.all([
+      writeFile(join(root, "Declared.exe"), portableExecutable()),
+      writeFile(join(root, "text.dll"), "not a portable executable"),
+      writeFile(join(root, "nested", "Extra.dll"), portableExecutable()),
+    ]);
+    await symlink(join(root, "Declared.exe"), join(root, "linked.exe"));
+    expect(await enumeratePortableExecutables(root)).toEqual([
+      "Declared.exe",
+      "nested/Extra.dll",
+    ]);
+    const inventory: WindowsPeInventory = {
+      schema: "windows-pe-inventory/1",
+      signing: { tool: "electron-builder", version: "26.15.3", option: "win.signExts" },
+      required: [
+        { path: "Declared.exe", kind: "application" },
+        { path: "Missing.dll", kind: "runtime-library" },
+        { path: "Uninstall Enduragent.exe", kind: "uninstaller", location: "installer-payload" },
+        {
+          path: "Enduragent-${version}-x64.exe",
+          kind: "installer",
+          location: "artifact",
+        },
+      ],
+      thirdPartyExceptions: [],
+    };
+    const result = await diffWindowsPeInventory({ unpackedRoot: root, inventory, version: "1.2.3" });
+    expect(result).toMatchObject({
+      ok: false,
+      missing: ["Missing.dll"],
+      undeclared: ["nested/Extra.dll"],
+      symlinks: ["linked.exe"],
+      expected: ["Declared.exe", "Missing.dll"],
+      actual: ["Declared.exe", "nested/Extra.dll"],
+      notInspected: ["Enduragent-1.2.3-x64.exe", "Uninstall Enduragent.exe"],
+    });
+  });
+
+  it("strictly parses the committed inventory and freezes the complete PE set", () => {
+    const inventory = readWindowsPeInventory(inventoryPath);
+    expect(inventory.signing).toEqual({
+      tool: "electron-builder",
+      version: "26.15.3",
+      option: "win.signExts",
+    });
+    expect(inventory.required).toEqual([
+      { path: "Enduragent.exe", kind: "application" },
+      { path: "d3dcompiler_47.dll", kind: "runtime-library" },
+      { path: "dxcompiler.dll", kind: "runtime-library" },
+      { path: "dxil.dll", kind: "runtime-library" },
+      { path: "ffmpeg.dll", kind: "runtime-library" },
+      { path: "libEGL.dll", kind: "runtime-library" },
+      { path: "libGLESv2.dll", kind: "runtime-library" },
+      { path: "vk_swiftshader.dll", kind: "runtime-library" },
+      { path: "vulkan-1.dll", kind: "runtime-library" },
+      {
+        path: "Uninstall Enduragent.exe",
+        kind: "uninstaller",
+        location: "installer-payload",
+      },
+      {
+        path: "Enduragent-${version}-x64.exe",
+        kind: "installer",
+        location: "artifact",
+      },
+    ]);
+    expect(inventory.thirdPartyExceptions).toEqual([]);
+    expect(Object.isFrozen(inventory.required)).toBe(true);
+  });
+
+  it("rejects incomplete third-party exception entries", async () => {
+    const root = await mkdtemp(join(tmpdir(), "windows-pe-invalid-inventory-"));
+    temporaryRoots.push(root);
+    const path = join(root, "inventory.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        schema: "windows-pe-inventory/1",
+        signing: { tool: "electron-builder", version: "26.15.3", option: "win.signExts" },
+        required: [{ path: "Enduragent.exe", kind: "application" }],
+        thirdPartyExceptions: [{ path: "vendor.dll" }],
+      }),
+    );
+    expect(() => readWindowsPeInventory(path)).toThrow("Windows PE inventory is invalid");
+  });
+});

--- a/apps/desktop/tests/windows-release-artifacts.test.ts
+++ b/apps/desktop/tests/windows-release-artifacts.test.ts
@@ -167,6 +167,9 @@ describe("Windows release artifact verification", () => {
     );
     expect(success.status).toBe(0);
     expect(success.stdout).toMatch(/^Windows release envelope verified [0-9a-f]{64}\n$/u);
+    expect(success.stderr).toBe(
+      "Authenticode verification is pending W19; signature not verified\n",
+    );
     const failure = spawnSync(
       process.execPath,
       [script, directory, "--version", version, "--authenticode", "verified"],

--- a/apps/desktop/tests/windows-release-plan.test.ts
+++ b/apps/desktop/tests/windows-release-plan.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { stringify } from "yaml";
 import {
   WINDOWS_AUTHENTICODE_PENDING,
+  WINDOWS_PUBLISHER_DN_PLACEHOLDER,
   assertKnownWindowsReleaseAssets,
   createWindowsReleasePlan,
   parseWindowsReleaseUpdaterMetadata,
@@ -105,6 +106,8 @@ describe("Windows release plan", () => {
       arch: "x64",
       mode: "steady",
       authenticode: WINDOWS_AUTHENTICODE_PENDING,
+      publisherDn: WINDOWS_PUBLISHER_DN_PLACEHOLDER,
+      publisherDnIsPlaceholder: true,
     });
     expect(plan.builderOptions.config.forceCodeSigning).toBe(true);
     expect(plan.builderOptions.config.nsis.differentialPackage).toBe(true);
@@ -113,9 +116,20 @@ describe("Windows release plan", () => {
     ]);
     expect(plan.builderOptions.publish).toBe("never");
     expect(plan.builderOptions.config.win).toEqual({
+      publisherName: [WINDOWS_PUBLISHER_DN_PLACEHOLDER],
       verifyUpdateCodeSignature: true,
       target: [{ target: "nsis", arch: ["x64"] }],
     });
+    expect(plan.updaterMetadata.publisherName).toBe(WINDOWS_PUBLISHER_DN_PLACEHOLDER);
+    const customPublisherDn = "CN=Enduragent Test Publisher, O=Enduragent Test";
+    const customPlan = createWindowsReleasePlan(planInput({ publisherDn: customPublisherDn }));
+    expect(customPlan.publisherDn).toBe(customPublisherDn);
+    expect(customPlan.publisherDnIsPlaceholder).toBe(false);
+    expect(customPlan.builderOptions.config.win.publisherName).toEqual([customPublisherDn]);
+    expect(customPlan.updaterMetadata.publisherName).toBe(customPublisherDn);
+    expect(() => createWindowsReleasePlan(planInput({ publisherDn: "  " }))).toThrow(
+      "Windows publisher DN is invalid",
+    );
     expect(Object.isFrozen(plan)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- `apps/desktop/scripts/verify-windows-authenticode.ps1` (pwsh 7): `Get-AuthenticodeSignature` + `signtool verify /pa /all /v`, SHA-256 digest check, RFC 3161 timestamp, chain validation, exact subject DN match, thumbprint match, `--allow-self-signed-test` for fixture runs.
- Node wrapper `verify-windows-authenticode.mjs` wired into `verify-windows-release.mjs` as `--authenticode verify`; default mode stays `pending-w19`.
- `apps/desktop/build/windows-pe-inventory.json` + `windows-pe-inventory.mjs` diff tool to catch new or dropped PE files between builds.
- Release-plan-injected publisher DN placeholder (`windows-release-plan.mjs`); inert for dev builds, `signExecutable` stays `false`.
- `make-test-signing-cert.ps1` fixture generator for the self-signed test path.
- Tests: `windows-authenticode.test.ts`, `windows-pe-inventory.test.ts`, updated release-plan/artifacts tests; Windows-only fixture test is skipped on macOS.
- Changeset.

## Decisions

- The publisher DN placeholder is injected by the release plan, not by `electron-builder.yml`, so dev builds and the config stay free of a fake identity.
- Default verification mode remains `pending-w19` until the first signed release; `verify` is opt-in via the flag.

## Limits

- `apps/desktop/scripts/verify-windows-authenticode.mjs:20` — `maximumCommandOutputBytes = 4 * 1024 * 1024` (4 MiB `maxBuffer` for the pwsh child process, used at :269; mirrored in test `apps/desktop/tests/windows-authenticode.test.ts:239`)
- `apps/desktop/scripts/windows-pe-inventory.mjs:8` — `portableExecutableHeaderBytes = 4096` (bytes read from each PE file's header, used at :159-160)
- `apps/desktop/scripts/make-test-signing-cert.ps1:45` — `-NotAfter ([DateTime]::Now.AddDays(1))` (1-day validity for the self-signed test cert)
- `apps/desktop/scripts/verify-windows-authenticode.ps1:71-72` — PE header offsets `+112` / `+108` (fixed format constants, not tunable bounds)
- No timeouts, retries, intervals, or caps otherwise. Pre-existing `WINDOWS_UPDATER_METADATA_MAX_BYTES = 16_384` is unchanged context, not new.

## Verification

- Root `pnpm check`: exit 0.
- Targeted `vitest run`: 236 pass / 2 skips.
- Full desktop project: 98 files, 1920 pass / 2 skips.
- 16 acceptance criteria adversarially verified: 14 pass first round; AC9 and AC11 pass on re-run.
- The two `.ps1` files are unvalidated on macOS (no `pwsh` on the host) and need a Windows/pwsh run.

## Workflow-file changes

None.

## Residuals

- After the certificate arrives: real DN + thumbprint, flip the default to `verify`, enable the workflow's Authenticode step on `windows-latest`, set `signExecutable: true`.
- Validate both `.ps1` scripts on a Windows host.
