### PR TITLE
feat(chat): add managed attachment storage

### DIFF
--- a/packages/coach/src/attachment-operations.ts
+++ b/packages/coach/src/attachment-operations.ts
@@ -1,8 +1,16 @@
+import { createHash, randomUUID } from "node:crypto";
 import {
   AttachmentAdmissionReadModelSchema,
+  CHAT_ATTACHMENT_LIMITS,
   type AdmitChatAttachmentRequest,
   type AttachmentAdmissionReadModel,
 } from "@enduragent/coach-contract";
+import type { ChatAttachmentRepository } from "@enduragent/kernel/store";
+import {
+  ManagedAttachmentSourceError,
+  chatAttachmentRelativePath,
+  type ManagedChatAttachmentStore,
+} from "@enduragent/kernel-node/chat-attachments";
 
 function displayNameFromPath(sourcePath: string): string {
   const segments = sourcePath.split(/[\\/]/u);
@@ -19,4 +27,207 @@ export function unavailableChatAttachmentAdmission(
     failureCode: "admission_unavailable",
     retryable: false,
   });
+}
+
+export interface ManagedChatAttachmentOperations {
+  admit(request: AdmitChatAttachmentRequest): Promise<AttachmentAdmissionReadModel>;
+  removeDraftAttachment(conversationId: string, attachmentId: string): Promise<void>;
+  cleanupConversation(conversationId: string): Promise<void>;
+  reconcile(): Promise<void>;
+}
+
+export interface ManagedChatAttachmentOperationsInput {
+  readonly repository: ChatAttachmentRepository;
+  readonly objects: ManagedChatAttachmentStore;
+  readonly runExclusive: <T>(work: () => Promise<T>) => Promise<T>;
+  readonly now?: () => number;
+  readonly randomId?: () => string;
+}
+
+const CAPACITY_LIMITS = {
+  attachmentsPerMessage: CHAT_ATTACHMENT_LIMITS.attachmentsPerMessage,
+  messageBytes: CHAT_ATTACHMENT_LIMITS.messageBytes,
+  conversationBytes: CHAT_ATTACHMENT_LIMITS.conversationBytes,
+  athleteBytes: CHAT_ATTACHMENT_LIMITS.athleteBytes,
+} as const;
+
+function conversationKey(conversationId: string): string {
+  return createHash("sha256").update(conversationId, "utf8").digest("hex");
+}
+
+function rejected(
+  request: AdmitChatAttachmentRequest,
+  displayName: string,
+  reason: Extract<AttachmentAdmissionReadModel, { status: "rejected" }>["reason"],
+): AttachmentAdmissionReadModel {
+  return AttachmentAdmissionReadModelSchema.parse({
+    selectionId: request.selectionId,
+    displayName,
+    status: "rejected",
+    reason,
+  });
+}
+
+export function createManagedChatAttachmentOperations(
+  input: ManagedChatAttachmentOperationsInput,
+): ManagedChatAttachmentOperations {
+  const now = input.now ?? Date.now;
+  const randomId = input.randomId ?? randomUUID;
+
+  return {
+    async admit(request) {
+      const fallbackName = displayNameFromPath(request.candidate.sourcePath);
+      let source: Awaited<ReturnType<ManagedChatAttachmentStore["inspectNativeSource"]>>;
+      try {
+        source = await input.objects.inspectNativeSource(request.candidate.sourcePath);
+      } catch (error) {
+        if (error instanceof ManagedAttachmentSourceError) {
+          return rejected(request, fallbackName, error.reason);
+        }
+        return AttachmentAdmissionReadModelSchema.parse({
+          selectionId: request.selectionId,
+          displayName: fallbackName,
+          status: "storage_failed",
+          failureCode: "storage_failed",
+          retryable: true,
+        });
+      }
+
+      return input.runExclusive(async () => {
+        const createdAtMs = now();
+        const key = conversationKey(request.chatId);
+        const objectId = randomId();
+        const attachmentId = randomId();
+        const relativePath = chatAttachmentRelativePath(key, objectId);
+        let reservation: Awaited<ReturnType<ChatAttachmentRepository["reserveObject"]>>;
+        try {
+          reservation = await input.repository.reserveObject({
+            object: {
+              id: objectId,
+              conversation_id: request.chatId,
+              conversation_key: key,
+              sha256: source.sha256,
+              byte_size: source.byteSize,
+              relative_path: relativePath,
+              status: "reserved",
+              failure_code: null,
+              created_at_ms: createdAtMs,
+              updated_at_ms: createdAtMs,
+            },
+            limits: CAPACITY_LIMITS,
+          });
+        } catch {
+          return AttachmentAdmissionReadModelSchema.parse({
+            selectionId: request.selectionId,
+            displayName: source.displayName,
+            status: "storage_failed",
+            failureCode: "storage_failed",
+            retryable: true,
+          });
+        }
+        if (reservation.kind === "message_limit") {
+          return rejected(request, source.displayName, "message_limit");
+        }
+        if (reservation.kind === "storage_full") {
+          return rejected(request, source.displayName, "storage_full");
+        }
+
+        const object = reservation.object;
+        if (reservation.kind === "reserved") {
+          try {
+            await input.objects.copyInspectedSource({ source, relativePath: object.relative_path });
+          } catch (error) {
+            await input.repository
+              .failObject(
+                object.id,
+                error instanceof ManagedAttachmentSourceError
+                  ? "source_changed"
+                  : "storage_write_failed",
+                now(),
+              )
+              .catch(() => {});
+            if (error instanceof ManagedAttachmentSourceError) {
+              return rejected(request, source.displayName, error.reason);
+            }
+            return AttachmentAdmissionReadModelSchema.parse({
+              selectionId: request.selectionId,
+              displayName: source.displayName,
+              status: "storage_failed",
+              failureCode: "storage_failed",
+              retryable: true,
+            });
+          }
+        }
+
+        try {
+          await input.repository.commitAdmission({
+            objectId: object.id,
+            attachment: {
+              id: attachmentId,
+              schema_version: 1,
+              conversation_id: request.chatId,
+              object_id: object.id,
+              kind: source.kind,
+              display_name: source.displayName,
+              media_type: source.mediaType,
+              extension: source.extension,
+              byte_size: source.byteSize,
+              sha256: source.sha256,
+              status: "preprocessing",
+              state_json: null,
+              message_id: null,
+              created_at_ms: createdAtMs,
+              updated_at_ms: now(),
+            },
+            draftUpdatedAtMs: now(),
+          });
+        } catch {
+          if (reservation.kind === "reserved") {
+            await input.repository
+              .failObject(object.id, "metadata_commit_failed", now())
+              .catch(() => {});
+            await input.objects.removeObject(object.relative_path).catch(() => {});
+          }
+          return AttachmentAdmissionReadModelSchema.parse({
+            selectionId: request.selectionId,
+            displayName: source.displayName,
+            status: "storage_failed",
+            failureCode: "storage_failed",
+            retryable: true,
+          });
+        }
+        return AttachmentAdmissionReadModelSchema.parse({
+          selectionId: request.selectionId,
+          displayName: source.displayName,
+          status: "accepted",
+          attachmentId,
+        });
+      });
+    },
+
+    async removeDraftAttachment(conversationId, attachmentId) {
+      await input.runExclusive(async () => {
+        const result = await input.repository.removeDraftAttachment({
+          conversationId,
+          attachmentId,
+        });
+        if (result.unreferencedObject !== undefined) {
+          await input.objects.removeObject(result.unreferencedObject.relative_path);
+        }
+      });
+    },
+
+    async cleanupConversation(conversationId) {
+      await input.runExclusive(async () => {
+        const objects = await input.repository.cleanupConversation(conversationId);
+        for (const object of objects) await input.objects.removeObject(object.relative_path);
+      });
+    },
+
+    async reconcile() {
+      await input.runExclusive(async () => {
+        await input.objects.reconcile(input.repository, CHAT_ATTACHMENT_LIMITS.orphanGraceMs);
+      });
+    },
+  };
 }

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -58,6 +58,7 @@ import {
 } from "@enduragent/kernel/anchors";
 import {
   createAnchorRepository,
+  createChatAttachmentRepository,
   createCanonicalActivityReader,
   createIntervalsSourceRepository,
   createTrustedActivitySourceResolver,
@@ -66,9 +67,11 @@ import {
 } from "@enduragent/kernel/store";
 import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
 import { createAuthoredIdentity, type AthleteHome } from "@enduragent/kernel-node/home";
+import { createManagedChatAttachmentStore } from "@enduragent/kernel-node/chat-attachments";
 import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import type { CoachStoreWriterContext } from "./runtime.js";
 import {
+  CHAT_ATTACHMENT_LIMITS,
   type CoachEngine,
   type CoachOperations,
   type ConfigureRuntimeRpcParams,
@@ -146,6 +149,7 @@ import {
 import { createTrainingExportService } from "./training-export.js";
 import { serializeBoundaryError } from "./daemon/error-boundary.js";
 import { createPlanStorageService } from "./plan-storage.js";
+import { createManagedChatAttachmentOperations } from "./attachment-operations.js";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -946,6 +950,23 @@ export async function createLocalCoachComposition(
       }
     }
     const logger = createSubsystemLogger("agent", input.home.root);
+    const attachmentOperations = createManagedChatAttachmentOperations({
+      repository: createChatAttachmentRepository(input.context.store),
+      objects: createManagedChatAttachmentStore({
+        archiveDir: input.home.archiveDir,
+        kindByteLimits: {
+          document: CHAT_ATTACHMENT_LIMITS.documentBytes,
+          activity: CHAT_ATTACHMENT_LIMITS.activityBytes,
+          workout: CHAT_ATTACHMENT_LIMITS.workoutBytes,
+          image: CHAT_ATTACHMENT_LIMITS.imageBytes,
+        },
+        ...(dependencies.platform === undefined ? {} : { platform: dependencies.platform }),
+        now,
+      }),
+      runExclusive: (work) => runtime!.runExclusive(work),
+      now,
+    });
+    await attachmentOperations.reconcile();
     const planIdentity = createAuthoredIdentity(input.home.configDir, { now });
     const createPlanPersistence = (timezone: string) =>
       createPlanStorageService({
@@ -955,9 +976,9 @@ export async function createLocalCoachComposition(
         now,
         logger,
       });
-    await createPlanPersistence(resolveUserTimezone(approvedConfig().session.timezone)).importLegacyPlan(
-      join(input.home.root, "plans", "current-plan.json"),
-    );
+    await createPlanPersistence(
+      resolveUserTimezone(approvedConfig().session.timezone),
+    ).importLegacyPlan(join(input.home.root, "plans", "current-plan.json"));
     const getAccessToken = createAccessTokenReader(input.home.configDir);
     const repository = (dependencies.createRepository ?? createAnchorRepository)(
       input.context.store,
@@ -1468,6 +1489,7 @@ export async function createLocalCoachComposition(
         },
         dependencies.operationsDependencies,
       ),
+      admitChatAttachment: (request) => attachmentOperations.admit(request),
       getActivityAnalysis: (request, signal) =>
         activityAnalysis.getActivityAnalysis(request, signal),
       exportTrainingFile: (request, signal) => trainingExport.export(request, signal),

--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -588,7 +588,7 @@ describe("account identity", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 12 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 13 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(
         beforeWorkouts,

--- a/packages/coach/tests/attachment-operations.test.ts
+++ b/packages/coach/tests/attachment-operations.test.ts
@@ -1,0 +1,274 @@
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createChatAttachmentRepository, runMigrations } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createManagedChatAttachmentStore } from "@enduragent/kernel-node/chat-attachments";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createManagedChatAttachmentOperations } from "../src/attachment-operations.js";
+
+describe("managed Chat attachment operations", () => {
+  let root: string;
+  let archiveDir: string;
+  let store: ReturnType<typeof openSqliteStorage>;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(await realpath(tmpdir()), "chat-attachment-operations-"));
+    archiveDir = join(root, "archive");
+    await mkdir(archiveDir, { mode: 0o700 });
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+  });
+
+  afterEach(async () => {
+    await store.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  function createOperations(ids: readonly string[]) {
+    let index = 0;
+    const repository = createChatAttachmentRepository(store);
+    const objects = createManagedChatAttachmentStore({
+      archiveDir,
+      kindByteLimits: {
+        document: 26_214_400,
+        activity: 104_857_600,
+        workout: 5_242_880,
+        image: 20_971_520,
+      },
+      now: () => 100,
+    });
+    return {
+      repository,
+      operations: createManagedChatAttachmentOperations({
+        repository,
+        objects,
+        runExclusive: (work) => work(),
+        now: () => 100,
+        randomId: () => ids[index++]!,
+      }),
+    };
+  }
+
+  it("returns a stable identifier only after bytes, metadata, and the draft reference are durable", async () => {
+    const sourcePath = join(root, "training-notes.txt");
+    await writeFile(sourcePath, "Keep Friday easy.");
+    const { operations, repository } = createOperations(["object-1", "attachment-1"]);
+    await expect(
+      operations.admit({
+        chatId: "desktop",
+        selectionId: "selection-1",
+        source: "picker",
+        candidate: { kind: "native-path", sourcePath },
+      }),
+    ).resolves.toEqual({
+      selectionId: "selection-1",
+      displayName: "training-notes.txt",
+      status: "accepted",
+      attachmentId: "attachment-1",
+    });
+    const attachment = await repository.readAttachment("attachment-1");
+    expect(attachment).toMatchObject({
+      conversation_id: "desktop",
+      object_id: "object-1",
+      status: "preprocessing",
+      extension: "txt",
+    });
+    const object = await repository.readObject("object-1");
+    expect(object).toMatchObject({ status: "durable" });
+    await expect(
+      readFile(join(archiveDir, ...object!.relative_path.split("/")), "utf8"),
+    ).resolves.toBe("Keep Friday easy.");
+    await expect(repository.readDraft("desktop")).resolves.toMatchObject({
+      text: "",
+      attachmentIds: ["attachment-1"],
+      state: "active",
+    });
+  });
+
+  it("reuses physical bytes inside one Conversation while returning a distinct attachment identifier", async () => {
+    const sourcePath = join(root, "notes.txt");
+    await writeFile(sourcePath, "same bytes");
+    const { operations, repository } = createOperations([
+      "object-1",
+      "attachment-1",
+      "object-unused",
+      "attachment-2",
+    ]);
+    const request = {
+      chatId: "desktop",
+      selectionId: "selection-1",
+      source: "drop" as const,
+      candidate: { kind: "native-path" as const, sourcePath },
+    };
+    await operations.admit(request);
+    await expect(
+      operations.admit({ ...request, selectionId: "selection-2" }),
+    ).resolves.toMatchObject({
+      status: "accepted",
+      attachmentId: "attachment-2",
+    });
+    await expect(repository.listObjects()).resolves.toHaveLength(1);
+    await expect(repository.readAttachment("attachment-2")).resolves.toMatchObject({
+      object_id: "object-1",
+    });
+  });
+
+  it("rejects unsupported content without persisting an attachment or clearing the draft", async () => {
+    const sourcePath = join(root, "ride.xyz");
+    await writeFile(sourcePath, "unknown");
+    const { operations, repository } = createOperations([]);
+    await repository.saveDraftText({
+      conversationId: "desktop",
+      text: "Keep this draft",
+      state: "active",
+      updatedAtMs: 1,
+    });
+    await expect(
+      operations.admit({
+        chatId: "desktop",
+        selectionId: "selection-1",
+        source: "picker",
+        candidate: { kind: "native-path", sourcePath },
+      }),
+    ).resolves.toEqual({
+      selectionId: "selection-1",
+      displayName: "ride.xyz",
+      status: "rejected",
+      reason: "format_unsupported",
+    });
+    await expect(repository.listObjects()).resolves.toEqual([]);
+    await expect(repository.readDraft("desktop")).resolves.toMatchObject({
+      text: "Keep this draft",
+    });
+  });
+
+  it("maps managed storage failures to a retryable result without exposing a path", async () => {
+    const sourcePath = join(root, "notes.txt");
+    await writeFile(sourcePath, "safe");
+    const repository = createChatAttachmentRepository(store);
+    const copyFailure = new Error("private path must not escape");
+    const inspect = createManagedChatAttachmentStore({
+      archiveDir,
+      kindByteLimits: { document: 100, activity: 100, workout: 100, image: 100 },
+    });
+    const operations = createManagedChatAttachmentOperations({
+      repository,
+      objects: {
+        ...inspect,
+        copyInspectedSource: vi.fn(async () => {
+          throw copyFailure;
+        }),
+      },
+      runExclusive: (work) => work(),
+      randomId: (() => {
+        const ids = ["object-1", "attachment-1"];
+        return () => ids.shift()!;
+      })(),
+    });
+    const result = await operations.admit({
+      chatId: "desktop",
+      selectionId: "selection-1",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath },
+    });
+    expect(result).toEqual({
+      selectionId: "selection-1",
+      displayName: "notes.txt",
+      status: "storage_failed",
+      failureCode: "storage_failed",
+      retryable: true,
+    });
+    expect(JSON.stringify(result)).not.toContain(sourcePath);
+    await expect(repository.readObject("object-1")).resolves.toMatchObject({
+      status: "failed",
+      failure_code: "storage_write_failed",
+    });
+  });
+
+  it("restores the same managed identifiers and draft after a database relaunch", async () => {
+    const sourcePath = join(root, "relaunch.txt");
+    const databasePath = join(root, "attachments.db");
+    await writeFile(sourcePath, "survives relaunch");
+    let persisted = openSqliteStorage(databasePath);
+    await runMigrations(persisted, MIGRATIONS);
+    const objects = createManagedChatAttachmentStore({
+      archiveDir,
+      kindByteLimits: { document: 100, activity: 100, workout: 100, image: 100 },
+    });
+    const firstRepository = createChatAttachmentRepository(persisted);
+    const first = createManagedChatAttachmentOperations({
+      repository: firstRepository,
+      objects,
+      runExclusive: (work) => work(),
+      randomId: (() => {
+        const ids = ["object-relaunch", "attachment-relaunch"];
+        return () => ids.shift()!;
+      })(),
+    });
+    await first.admit({
+      chatId: "desktop",
+      selectionId: "selection-relaunch",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath },
+    });
+    await firstRepository.saveDraftText({
+      conversationId: "desktop",
+      text: "Review after restart",
+      state: "active",
+      updatedAtMs: 10,
+    });
+    await persisted.close();
+
+    persisted = openSqliteStorage(databasePath);
+    await runMigrations(persisted, MIGRATIONS);
+    const restored = createChatAttachmentRepository(persisted);
+    await createManagedChatAttachmentOperations({
+      repository: restored,
+      objects,
+      runExclusive: (work) => work(),
+    }).reconcile();
+    await expect(restored.readDraft("desktop")).resolves.toMatchObject({
+      text: "Review after restart",
+      attachmentIds: ["attachment-relaunch"],
+    });
+    await expect(restored.readObject("object-relaunch")).resolves.toMatchObject({
+      status: "durable",
+    });
+    await persisted.close();
+  });
+
+  it("removes unsent bytes and Conversation-owned bytes through idempotent cleanup", async () => {
+    const firstPath = join(root, "first.txt");
+    const secondPath = join(root, "second.txt");
+    await writeFile(firstPath, "first");
+    await writeFile(secondPath, "second");
+    const { operations, repository } = createOperations([
+      "object-1",
+      "attachment-1",
+      "object-2",
+      "attachment-2",
+    ]);
+    await operations.admit({
+      chatId: "desktop",
+      selectionId: "s1",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath: firstPath },
+    });
+    await operations.admit({
+      chatId: "desktop",
+      selectionId: "s2",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath: secondPath },
+    });
+    const firstObject = (await repository.readObject("object-1"))!;
+    await operations.removeDraftAttachment("desktop", "attachment-1");
+    await expect(
+      readFile(join(archiveDir, ...firstObject.relative_path.split("/"))),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await operations.cleanupConversation("desktop");
+    await operations.cleanupConversation("desktop");
+    await expect(repository.listObjects()).resolves.toEqual([]);
+  });
+});

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -81,13 +81,9 @@ function syntheticHome(root = "synthetic-root"): AthleteHome {
 }
 
 function writerOperation<T>(
-  operationOrPlan:
-    | ((context: CoachStoreWriterContext) => Promise<T>)
-    | CoachStoreWriterPlan<T>,
+  operationOrPlan: ((context: CoachStoreWriterContext) => Promise<T>) | CoachStoreWriterPlan<T>,
 ): (context: CoachStoreWriterContext) => Promise<T> {
-  return typeof operationOrPlan === "function"
-    ? operationOrPlan
-    : operationOrPlan.operation;
+  return typeof operationOrPlan === "function" ? operationOrPlan : operationOrPlan.operation;
 }
 
 function syntheticStore(): CoachStoreWriterContext["store"] {
@@ -320,17 +316,23 @@ describe("coach sync composition", () => {
       await options.beforeStoreOpen?.(context.home);
       return { status: "completed", value: await options.operation(context) };
     };
-    await expect(withCoachStoreWriter({}, {
-      beforeStoreOpen: async (home) => {
-        expect(home).toBe(context.home);
-        trace.push("before");
-      },
-      operation: async (received) => {
-        expect(received).toBe(context);
-        trace.push("operation");
-        return "done";
-      },
-    }, { runWriter })).resolves.toBe("done");
+    await expect(
+      withCoachStoreWriter(
+        {},
+        {
+          beforeStoreOpen: async (home) => {
+            expect(home).toBe(context.home);
+            trace.push("before");
+          },
+          operation: async (received) => {
+            expect(received).toBe(context);
+            trace.push("operation");
+            return "done";
+          },
+        },
+        { runWriter },
+      ),
+    ).resolves.toBe("done");
     expect(trace).toEqual(["before", "operation"]);
     const cause = new Error("private");
     expect(new CoachStoreWriterError("writer-failed", "open store", { cause }).cause).toBe(cause);
@@ -343,9 +345,7 @@ describe("coach sync composition", () => {
     const context = syntheticContext();
     const withWriter: typeof withCoachStoreWriter = async <T>(
       _env: Record<string, string | undefined>,
-      operationOrPlan:
-        | ((value: CoachStoreWriterContext) => Promise<T>)
-        | CoachStoreWriterPlan<T>,
+      operationOrPlan: ((value: CoachStoreWriterContext) => Promise<T>) | CoachStoreWriterPlan<T>,
     ): Promise<T> => {
       writerCalls += 1;
       return writerOperation(operationOrPlan)(context);
@@ -447,9 +447,7 @@ describe("coach sync composition", () => {
     let maximumRunning = 0;
     const withWriter: typeof withCoachStoreWriter = async <T>(
       _env: Record<string, string | undefined>,
-      operationOrPlan:
-        | ((value: CoachStoreWriterContext) => Promise<T>)
-        | CoachStoreWriterPlan<T>,
+      operationOrPlan: ((value: CoachStoreWriterContext) => Promise<T>) | CoachStoreWriterPlan<T>,
     ): Promise<T> => writerOperation(operationOrPlan)(context);
     const importFiles: typeof importFilesWithReport = async () => importReport;
     const binding = (id: SourceId, shouldFail: boolean): CoachSourceBinding => ({
@@ -507,9 +505,7 @@ describe("coach sync composition", () => {
     let importCalls = 0;
     const withWriter: typeof withCoachStoreWriter = async <T>(
       _env: Record<string, string | undefined>,
-      operationOrPlan:
-        | ((value: CoachStoreWriterContext) => Promise<T>)
-        | CoachStoreWriterPlan<T>,
+      operationOrPlan: ((value: CoachStoreWriterContext) => Promise<T>) | CoachStoreWriterPlan<T>,
     ): Promise<T> => writerOperation(operationOrPlan)(context);
     const importFiles: typeof importFilesWithReport = async (options) => {
       importCalls += 1;
@@ -552,9 +548,7 @@ describe("coach sync composition", () => {
     let importCalls = 0;
     const withWriter: typeof withCoachStoreWriter = async <T>(
       _env: Record<string, string | undefined>,
-      operationOrPlan:
-        | ((value: CoachStoreWriterContext) => Promise<T>)
-        | CoachStoreWriterPlan<T>,
+      operationOrPlan: ((value: CoachStoreWriterContext) => Promise<T>) | CoachStoreWriterPlan<T>,
     ): Promise<T> => writerOperation(operationOrPlan)(context);
     const importFiles: typeof importFilesWithReport = async () => {
       importCalls += 1;
@@ -571,34 +565,37 @@ describe("coach sync composition", () => {
     expect(importCalls).toBe(0);
   });
 
-  it.runIf(hasLoopback)("real writer lifecycle migrates closes and releases an isolated store", async () => {
-    const root = await mkdtemp(join(await realpath(tmpdir()), "coach-runtime-"));
-    const home = syntheticHome(root);
-    try {
-      const value = await withCoachStoreWriter(
-        { ENDURAGENT_HOME: root },
-        async ({ home: receivedHome, store }) => {
-          expect(receivedHome).toEqual(home);
-          return store.get("PRAGMA user_version");
-        },
-      );
-      expect(value).toEqual({ user_version: 12 });
-      expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
-      expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
-      expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
-
-      const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
+  it.runIf(hasLoopback)(
+    "real writer lifecycle migrates closes and releases an isolated store",
+    async () => {
+      const root = await mkdtemp(join(await realpath(tmpdir()), "coach-runtime-"));
+      const home = syntheticHome(root);
       try {
-        await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-          user_version: 12,
-        });
+        const value = await withCoachStoreWriter(
+          { ENDURAGENT_HOME: root },
+          async ({ home: receivedHome, store }) => {
+            expect(receivedHome).toEqual(home);
+            return store.get("PRAGMA user_version");
+          },
+        );
+        expect(value).toEqual({ user_version: 13 });
+        expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
+        expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
+        expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
+
+        const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
+        try {
+          await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
+            user_version: 13,
+          });
+        } finally {
+          await reopened.close();
+        }
       } finally {
-        await reopened.close();
+        await rm(root, { recursive: true, force: true });
       }
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
+    },
+  );
 
   it.runIf(hasLoopback)("isolates concurrent writers for two athlete homes", async () => {
     const temporaryRoot = await realpath(tmpdir());

--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -3,13 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "description": "Node host adapter for the pure kernel — node:sqlite / node:fs / WebCrypto drivers behind the kernel's ports (scaffold, no content yet).",
-  "type": "module",
+  "license": "MIT",
   "files": [
     "dist"
   ],
+  "type": "module",
   "exports": {
     "./sqlite": "./dist/sqlite.js",
     "./archive": "./dist/archive/index.js",
+    "./chat-attachments": "./dist/chat-attachments/index.js",
     "./lock": "./dist/lock/index.js",
     "./store-export": "./dist/store-export/index.js",
     "./home": "./dist/home/index.js",
@@ -18,9 +20,6 @@
     "./capture-manifest": "./dist/capture-manifest/index.js",
     "./service": "./dist/service/index.js",
     "./coach-dev": "./dist/coach-dev.js"
-  },
-  "engines": {
-    "node": ">=24"
   },
   "scripts": {
     "build": "tsup",
@@ -38,5 +37,7 @@
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"
   },
-  "license": "MIT"
+  "engines": {
+    "node": ">=24"
+  }
 }

--- a/packages/kernel-node/src/chat-attachments/index.ts
+++ b/packages/kernel-node/src/chat-attachments/index.ts
@@ -1,0 +1,1 @@
+export * from "./managed-store.js";

--- a/packages/kernel-node/src/chat-attachments/managed-store.ts
+++ b/packages/kernel-node/src/chat-attachments/managed-store.ts
@@ -1,0 +1,590 @@
+import { createHash, randomBytes as nodeRandomBytes } from "node:crypto";
+import { constants } from "node:fs";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  realpath,
+  rename,
+  rmdir,
+  unlink,
+  type FileHandle,
+} from "node:fs/promises";
+import { basename, dirname, extname, isAbsolute, join, resolve, sep } from "node:path";
+import type { ChatAttachmentKind, ChatAttachmentRepository } from "@enduragent/kernel/store";
+import { ensureWindowsPrivateDirectory } from "../home/windows-home-policy.js";
+
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+const SIGNATURE_BYTES = 65_536;
+const COPY_BUFFER_BYTES = 1024 * 1024;
+const SAFE_OBJECT_ID = /^[A-Za-z0-9_-]{1,128}$/u;
+const SAFE_CONVERSATION_KEY = /^[0-9a-f]{64}$/u;
+
+export type AttachmentAdmissionRejection =
+  | "empty_file"
+  | "file_too_large"
+  | "format_unsupported"
+  | "signature_mismatch"
+  | "unsafe_source"
+  | "validation_failed";
+
+export class ManagedAttachmentSourceError extends Error {
+  constructor(readonly reason: AttachmentAdmissionRejection) {
+    super("attachment source was rejected");
+    this.name = "ManagedAttachmentSourceError";
+  }
+}
+
+interface SourceIdentity {
+  readonly dev: number;
+  readonly ino: number;
+  readonly size: number;
+  readonly mtimeMs: number;
+  readonly ctimeMs: number;
+  readonly birthtimeMs: number;
+}
+
+export interface InspectedChatAttachmentSource {
+  readonly sourcePath: string;
+  readonly identity: SourceIdentity;
+  readonly displayName: string;
+  readonly extension: string;
+  readonly kind: ChatAttachmentKind;
+  readonly mediaType: string;
+  readonly byteSize: number;
+  readonly sha256: string;
+}
+
+export interface ManagedChatAttachmentStore {
+  inspectNativeSource(sourcePath: string): Promise<InspectedChatAttachmentSource>;
+  copyInspectedSource(input: {
+    readonly source: InspectedChatAttachmentSource;
+    readonly relativePath: string;
+  }): Promise<void>;
+  stagePrivateBytes(input: {
+    readonly displayName: string;
+    readonly bytes: Uint8Array;
+  }): Promise<{ readonly sourcePath: string; readonly displayName: string }>;
+  removeObject(relativePath: string): Promise<void>;
+  reconcile(
+    repository: ChatAttachmentRepository,
+    orphanGraceMs: number,
+  ): Promise<{
+    readonly missing: number;
+    readonly interruptedReservations: number;
+    readonly orphansRemoved: number;
+  }>;
+}
+
+export interface ManagedChatAttachmentStoreOptions {
+  readonly archiveDir: string;
+  readonly kindByteLimits: Readonly<Record<ChatAttachmentKind, number>>;
+  readonly platform?: NodeJS.Platform;
+  readonly now?: () => number;
+  readonly randomBytes?: typeof nodeRandomBytes;
+}
+
+const FORMAT: Readonly<
+  Record<string, { readonly kind: ChatAttachmentKind; readonly mediaType: string }>
+> = {
+  pdf: { kind: "document", mediaType: "application/pdf" },
+  txt: { kind: "document", mediaType: "text/plain" },
+  csv: { kind: "document", mediaType: "text/csv" },
+  docx: {
+    kind: "document",
+    mediaType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  },
+  fit: { kind: "activity", mediaType: "application/vnd.ant.fit" },
+  tcx: { kind: "activity", mediaType: "application/vnd.garmin.tcx+xml" },
+  gpx: { kind: "activity", mediaType: "application/gpx+xml" },
+  zwo: { kind: "workout", mediaType: "application/vnd.zwift.workout+xml" },
+  mrc: { kind: "workout", mediaType: "text/plain" },
+  erg: { kind: "workout", mediaType: "text/plain" },
+  png: { kind: "image", mediaType: "image/png" },
+  jpg: { kind: "image", mediaType: "image/jpeg" },
+  jpeg: { kind: "image", mediaType: "image/jpeg" },
+  webp: { kind: "image", mediaType: "image/webp" },
+};
+
+const UTF8_EXTENSIONS = new Set(["txt", "csv", "tcx", "gpx", "zwo", "mrc", "erg"]);
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String(error.code)
+    : undefined;
+}
+
+function sourceIdentity(metadata: Awaited<ReturnType<typeof lstat>>): SourceIdentity {
+  return {
+    dev: Number(metadata.dev),
+    ino: Number(metadata.ino),
+    size: Number(metadata.size),
+    mtimeMs: Number(metadata.mtimeMs),
+    ctimeMs: Number(metadata.ctimeMs),
+    birthtimeMs: Number(metadata.birthtimeMs),
+  };
+}
+
+function sameIdentity(left: SourceIdentity, right: SourceIdentity): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs &&
+    left.birthtimeMs === right.birthtimeMs
+  );
+}
+
+function assertOrdinaryFile(metadata: Awaited<ReturnType<typeof lstat>>): void {
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
+    throw new ManagedAttachmentSourceError("unsafe_source");
+  }
+}
+
+function signatureMatches(extension: string, head: Uint8Array): boolean {
+  const bytes = Buffer.from(head);
+  if (extension === "pdf") return bytes.subarray(0, 5).equals(Buffer.from("%PDF-"));
+  if (extension === "png") {
+    return bytes
+      .subarray(0, 8)
+      .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  }
+  if (extension === "jpg" || extension === "jpeg") {
+    return bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+  }
+  if (extension === "webp") {
+    return (
+      bytes.length >= 12 &&
+      bytes.subarray(0, 4).toString("ascii") === "RIFF" &&
+      bytes.subarray(8, 12).toString("ascii") === "WEBP"
+    );
+  }
+  if (extension === "fit") {
+    return (
+      bytes.length >= 12 &&
+      (bytes[0] === 12 || bytes[0] === 14) &&
+      bytes.subarray(8, 12).toString("ascii") === ".FIT"
+    );
+  }
+  if (extension === "docx") {
+    return (
+      bytes.length >= 4 &&
+      bytes[0] === 0x50 &&
+      bytes[1] === 0x4b &&
+      ((bytes[2] === 0x03 && bytes[3] === 0x04) ||
+        (bytes[2] === 0x05 && bytes[3] === 0x06) ||
+        (bytes[2] === 0x07 && bytes[3] === 0x08))
+    );
+  }
+  const text = bytes.toString("utf8").replace(/^\uFEFF/u, "");
+  if (extension === "txt" || extension === "csv") return !text.includes("\0");
+  if (extension === "mrc" || extension === "erg") {
+    return /^\s*\[COURSE HEADER\]/imu.test(text) && /\[COURSE DATA\]/iu.test(text);
+  }
+  if (text.includes("<!DOCTYPE") || text.includes("<!ENTITY")) return false;
+  const withoutDeclaration = text.replace(/^\s*<\?xml[^?]*\?>/iu, "").trimStart();
+  if (extension === "tcx")
+    return /^<(?:[A-Za-z_][\w.-]*:)?TrainingCenterDatabase(?:\s|>)/u.test(withoutDeclaration);
+  if (extension === "gpx") return /^<(?:[A-Za-z_][\w.-]*:)?gpx(?:\s|>)/u.test(withoutDeclaration);
+  if (extension === "zwo")
+    return /^<(?:[A-Za-z_][\w.-]*:)?workout_file(?:\s|>)/u.test(withoutDeclaration);
+  return false;
+}
+
+function managedRelativePath(conversationKey: string, objectId: string): string {
+  if (!SAFE_CONVERSATION_KEY.test(conversationKey) || !SAFE_OBJECT_ID.test(objectId)) {
+    throw new TypeError("managed attachment path is invalid");
+  }
+  return `chat-attachments/${conversationKey}/${objectId}`;
+}
+
+function resolveManagedPath(archiveDir: string, relativePath: string): string {
+  const normalized = relativePath.split("/");
+  if (
+    normalized.length !== 3 ||
+    normalized[0] !== "chat-attachments" ||
+    !SAFE_CONVERSATION_KEY.test(normalized[1]!) ||
+    !SAFE_OBJECT_ID.test(normalized[2]!)
+  )
+    throw new TypeError("managed attachment path is invalid");
+  const full = resolve(archiveDir, ...normalized);
+  const root = resolve(archiveDir);
+  if (!full.startsWith(`${root}${sep}`))
+    throw new TypeError("managed attachment path escaped the archive");
+  return full;
+}
+
+async function ensurePosixPrivateDirectory(path: string): Promise<void> {
+  try {
+    await mkdir(path, { mode: PRIVATE_DIRECTORY_MODE });
+  } catch (error) {
+    if (errorCode(error) !== "EEXIST") throw error;
+  }
+  const before = await lstat(path);
+  if (before.isSymbolicLink() || !before.isDirectory())
+    throw new TypeError("managed attachment directory is unsafe");
+  const physical = await realpath(path);
+  if (physical !== resolve(path))
+    throw new TypeError("managed attachment directory escaped its root");
+  const after = await lstat(path);
+  if (
+    after.dev !== before.dev ||
+    after.ino !== before.ino ||
+    after.isSymbolicLink() ||
+    !after.isDirectory()
+  ) {
+    throw new TypeError("managed attachment directory changed identity");
+  }
+  await chmod(path, PRIVATE_DIRECTORY_MODE);
+}
+
+async function syncDirectory(path: string, platform: NodeJS.Platform): Promise<void> {
+  if (platform === "win32") return;
+  const handle = await open(path, constants.O_RDONLY);
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function removeIfPresent(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") throw error;
+  }
+}
+
+export function createManagedChatAttachmentStore(
+  options: ManagedChatAttachmentStoreOptions,
+): ManagedChatAttachmentStore {
+  if (!isAbsolute(options.archiveDir))
+    throw new TypeError("attachment archive path must be absolute");
+  const platform = options.platform ?? process.platform;
+  const now = options.now ?? Date.now;
+  const randomBytes = options.randomBytes ?? nodeRandomBytes;
+  const attachmentRoot = join(options.archiveDir, "chat-attachments");
+  const ingressRoot = join(attachmentRoot, ".ingress");
+
+  const ensureDirectory = async (path: string): Promise<void> => {
+    if (platform === "win32") {
+      await ensureWindowsPrivateDirectory(path);
+      return;
+    }
+    await ensurePosixPrivateDirectory(path);
+  };
+
+  const ensureManagedDirectory = async (conversationKey?: string): Promise<string> => {
+    await ensureDirectory(options.archiveDir);
+    await ensureDirectory(attachmentRoot);
+    if (conversationKey === undefined) return attachmentRoot;
+    if (!SAFE_CONVERSATION_KEY.test(conversationKey))
+      throw new TypeError("conversation key is invalid");
+    const path = join(attachmentRoot, conversationKey);
+    await ensureDirectory(path);
+    return path;
+  };
+
+  const inspectNativeSource = async (
+    sourcePath: string,
+  ): Promise<InspectedChatAttachmentSource> => {
+    if (!isAbsolute(sourcePath)) throw new ManagedAttachmentSourceError("unsafe_source");
+    const displayName = basename(sourcePath);
+    if (displayName.length < 1 || displayName.length > 512) {
+      throw new ManagedAttachmentSourceError("validation_failed");
+    }
+    const extension = extname(displayName).slice(1).toLowerCase();
+    const format = FORMAT[extension];
+    if (format === undefined) throw new ManagedAttachmentSourceError("format_unsupported");
+
+    let before: Awaited<ReturnType<typeof lstat>>;
+    try {
+      before = await lstat(sourcePath);
+    } catch {
+      throw new ManagedAttachmentSourceError("unsafe_source");
+    }
+    assertOrdinaryFile(before);
+    if (before.size === 0) throw new ManagedAttachmentSourceError("empty_file");
+    if (before.size > options.kindByteLimits[format.kind]) {
+      throw new ManagedAttachmentSourceError("file_too_large");
+    }
+    const identity = sourceIdentity(before);
+    let handle: FileHandle | undefined;
+    try {
+      const flags = constants.O_RDONLY | (platform === "win32" ? 0 : constants.O_NOFOLLOW);
+      handle = await open(sourcePath, flags);
+      const opened = await handle.stat();
+      assertOrdinaryFile(opened);
+      if (!sameIdentity(identity, sourceIdentity(opened)))
+        throw new ManagedAttachmentSourceError("unsafe_source");
+      const hash = createHash("sha256");
+      const decoder = UTF8_EXTENSIONS.has(extension)
+        ? new TextDecoder("utf-8", { fatal: true })
+        : undefined;
+      const head = Buffer.allocUnsafe(Math.min(SIGNATURE_BYTES, identity.size));
+      let headBytes = 0;
+      let offset = 0;
+      const buffer = Buffer.allocUnsafe(Math.min(COPY_BUFFER_BYTES, identity.size));
+      while (offset < identity.size) {
+        const result = await handle.read(
+          buffer,
+          0,
+          Math.min(buffer.length, identity.size - offset),
+          offset,
+        );
+        if (result.bytesRead === 0) break;
+        const chunk = buffer.subarray(0, result.bytesRead);
+        hash.update(chunk);
+        if (headBytes < head.length) {
+          const copied = Math.min(head.length - headBytes, chunk.length);
+          chunk.copy(head, headBytes, 0, copied);
+          headBytes += copied;
+        }
+        if (decoder !== undefined) {
+          try {
+            decoder.decode(chunk, { stream: true });
+          } catch {
+            throw new ManagedAttachmentSourceError("validation_failed");
+          }
+        }
+        offset += result.bytesRead;
+      }
+      if (offset !== identity.size) throw new ManagedAttachmentSourceError("unsafe_source");
+      if (decoder !== undefined) {
+        try {
+          decoder.decode();
+        } catch {
+          throw new ManagedAttachmentSourceError("validation_failed");
+        }
+      }
+      const afterRead = await handle.stat();
+      if (!sameIdentity(identity, sourceIdentity(afterRead)))
+        throw new ManagedAttachmentSourceError("unsafe_source");
+      await handle.close();
+      handle = undefined;
+      const afterPath = await lstat(sourcePath);
+      assertOrdinaryFile(afterPath);
+      if (!sameIdentity(identity, sourceIdentity(afterPath)))
+        throw new ManagedAttachmentSourceError("unsafe_source");
+      if (!signatureMatches(extension, head.subarray(0, headBytes))) {
+        throw new ManagedAttachmentSourceError("signature_mismatch");
+      }
+      return {
+        sourcePath,
+        identity,
+        displayName,
+        extension,
+        kind: format.kind,
+        mediaType: format.mediaType,
+        byteSize: identity.size,
+        sha256: hash.digest("hex"),
+      };
+    } catch (error) {
+      if (error instanceof ManagedAttachmentSourceError) throw error;
+      throw new ManagedAttachmentSourceError("unsafe_source");
+    } finally {
+      await handle?.close().catch(() => {});
+    }
+  };
+
+  return {
+    inspectNativeSource,
+
+    async copyInspectedSource({ source, relativePath }) {
+      const finalPath = resolveManagedPath(options.archiveDir, relativePath);
+      const conversationKey = relativePath.split("/")[1]!;
+      const directory = await ensureManagedDirectory(conversationKey);
+      if (dirname(finalPath) !== directory)
+        throw new TypeError("managed attachment target is invalid");
+      const temporaryPath = `${finalPath}.tmp.${randomBytes(8).toString("hex")}`;
+      let sourceHandle: FileHandle | undefined;
+      let targetHandle: FileHandle | undefined;
+      try {
+        const sourceFlags = constants.O_RDONLY | (platform === "win32" ? 0 : constants.O_NOFOLLOW);
+        sourceHandle = await open(source.sourcePath, sourceFlags);
+        const opened = await sourceHandle.stat();
+        assertOrdinaryFile(opened);
+        if (!sameIdentity(source.identity, sourceIdentity(opened))) {
+          throw new ManagedAttachmentSourceError("unsafe_source");
+        }
+        const targetFlags =
+          constants.O_CREAT |
+          constants.O_EXCL |
+          constants.O_WRONLY |
+          (platform === "win32" ? 0 : constants.O_NOFOLLOW);
+        targetHandle = await open(temporaryPath, targetFlags, PRIVATE_FILE_MODE);
+        const hash = createHash("sha256");
+        const buffer = Buffer.allocUnsafe(Math.min(COPY_BUFFER_BYTES, source.byteSize));
+        let offset = 0;
+        while (offset < source.byteSize) {
+          const read = await sourceHandle.read(
+            buffer,
+            0,
+            Math.min(buffer.length, source.byteSize - offset),
+            offset,
+          );
+          if (read.bytesRead === 0) break;
+          const chunk = buffer.subarray(0, read.bytesRead);
+          hash.update(chunk);
+          await targetHandle.write(chunk, 0, chunk.length, offset);
+          offset += read.bytesRead;
+        }
+        const afterRead = await sourceHandle.stat();
+        if (
+          offset !== source.byteSize ||
+          !sameIdentity(source.identity, sourceIdentity(afterRead)) ||
+          hash.digest("hex") !== source.sha256
+        )
+          throw new ManagedAttachmentSourceError("unsafe_source");
+        await targetHandle.sync();
+        await targetHandle.close();
+        targetHandle = undefined;
+        await sourceHandle.close();
+        sourceHandle = undefined;
+        const afterPath = await lstat(source.sourcePath);
+        assertOrdinaryFile(afterPath);
+        if (!sameIdentity(source.identity, sourceIdentity(afterPath))) {
+          throw new ManagedAttachmentSourceError("unsafe_source");
+        }
+        await rename(temporaryPath, finalPath);
+        if (platform !== "win32") await chmod(finalPath, PRIVATE_FILE_MODE);
+        await syncDirectory(directory, platform);
+      } catch (error) {
+        await sourceHandle?.close().catch(() => {});
+        await targetHandle?.close().catch(() => {});
+        await removeIfPresent(temporaryPath).catch(() => {});
+        throw error;
+      }
+    },
+
+    async stagePrivateBytes({ displayName, bytes }) {
+      if (displayName.length < 1 || displayName.length > 512 || bytes.byteLength === 0) {
+        throw new ManagedAttachmentSourceError(
+          bytes.byteLength === 0 ? "empty_file" : "validation_failed",
+        );
+      }
+      await ensureManagedDirectory();
+      await ensureDirectory(ingressRoot);
+      const extension = extname(displayName).toLowerCase();
+      const format = FORMAT[extension.slice(1)];
+      if (format === undefined) throw new ManagedAttachmentSourceError("format_unsupported");
+      if (bytes.byteLength > options.kindByteLimits[format.kind]) {
+        throw new ManagedAttachmentSourceError("file_too_large");
+      }
+      const path = join(ingressRoot, `${randomBytes(16).toString("hex")}${extension}`);
+      const handle = await open(
+        path,
+        constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+        PRIVATE_FILE_MODE,
+      );
+      try {
+        await handle.writeFile(Buffer.from(bytes));
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+      if (platform !== "win32") await chmod(path, PRIVATE_FILE_MODE);
+      await syncDirectory(ingressRoot, platform);
+      return { sourcePath: path, displayName };
+    },
+
+    async removeObject(relativePath) {
+      const path = resolveManagedPath(options.archiveDir, relativePath);
+      await removeIfPresent(path);
+      try {
+        await rmdir(dirname(path));
+      } catch (error) {
+        if (errorCode(error) !== "ENOTEMPTY" && errorCode(error) !== "ENOENT") throw error;
+      }
+    },
+
+    async reconcile(repository, orphanGraceMs) {
+      if (!Number.isSafeInteger(orphanGraceMs) || orphanGraceMs < 0)
+        throw new TypeError("orphan grace is invalid");
+      await ensureManagedDirectory();
+      let missing = 0;
+      let interruptedReservations = 0;
+      let orphansRemoved = 0;
+      for (const object of await repository.listObjects()) {
+        const path = resolveManagedPath(options.archiveDir, object.relative_path);
+        let metadata: Awaited<ReturnType<typeof lstat>> | undefined;
+        try {
+          metadata = await lstat(path);
+        } catch (error) {
+          if (errorCode(error) !== "ENOENT") throw error;
+        }
+        const valid =
+          metadata !== undefined &&
+          metadata.isFile() &&
+          !metadata.isSymbolicLink() &&
+          metadata.size === object.byte_size;
+        if (object.status === "durable" && !valid) {
+          await repository.markObjectMissing(object.id, now());
+          missing += 1;
+        } else if (object.status === "reserved") {
+          await repository.failObject(object.id, "admission_interrupted", now());
+          await repository.deleteFailedObject(object.id);
+          interruptedReservations += 1;
+        } else if (
+          object.status === "failed" &&
+          metadata !== undefined &&
+          valid &&
+          now() - Number(metadata.mtimeMs) >= orphanGraceMs
+        ) {
+          await removeIfPresent(path);
+          await repository.deleteFailedObject(object.id);
+          orphansRemoved += 1;
+        }
+      }
+
+      const visit = async (directory: string, conversationKey?: string): Promise<void> => {
+        let entries: import("node:fs").Dirent<string>[];
+        try {
+          entries = await readdir(directory, { withFileTypes: true });
+        } catch (error) {
+          if (errorCode(error) === "ENOENT") return;
+          throw error;
+        }
+        for (const entry of entries) {
+          const path = join(directory, entry.name);
+          if (entry.isSymbolicLink()) continue;
+          if (conversationKey === undefined && entry.name === ".ingress" && entry.isDirectory()) {
+            await visit(path, ".ingress");
+            continue;
+          }
+          if (
+            conversationKey === undefined &&
+            entry.isDirectory() &&
+            SAFE_CONVERSATION_KEY.test(entry.name)
+          ) {
+            await visit(path, entry.name);
+            continue;
+          }
+          if (!entry.isFile()) continue;
+          const metadata = await lstat(path);
+          const oldEnough = now() - metadata.mtimeMs >= orphanGraceMs;
+          const temporary = entry.name.includes(".tmp.") || conversationKey === ".ingress";
+          const known =
+            !temporary &&
+            SAFE_OBJECT_ID.test(entry.name) &&
+            (await repository.hasObject(entry.name));
+          if (!known && oldEnough) {
+            await removeIfPresent(path);
+            orphansRemoved += 1;
+          }
+        }
+      };
+      await visit(attachmentRoot);
+      return { missing, interruptedReservations, orphansRemoved };
+    },
+  };
+}
+
+export function chatAttachmentRelativePath(conversationKey: string, objectId: string): string {
+  return managedRelativePath(conversationKey, objectId);
+}

--- a/packages/kernel-node/tests/chat-attachment-repository.test.ts
+++ b/packages/kernel-node/tests/chat-attachment-repository.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+import {
+  createChatAttachmentRepository,
+  runMigrations,
+  type ChatAttachmentObjectRow,
+  type ChatAttachmentRow,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const LIMITS = {
+  attachmentsPerMessage: 5,
+  messageBytes: 100,
+  conversationBytes: 200,
+  athleteBytes: 300,
+} as const;
+const KEY = "a".repeat(64);
+
+function objectRow(
+  id: string,
+  conversationId: string,
+  sha256: string,
+  byteSize = 20,
+): ChatAttachmentObjectRow {
+  return {
+    id,
+    conversation_id: conversationId,
+    conversation_key: KEY,
+    sha256,
+    byte_size: byteSize,
+    relative_path: `chat-attachments/${KEY}/${id}`,
+    status: "reserved",
+    failure_code: null,
+    created_at_ms: 1,
+    updated_at_ms: 1,
+  };
+}
+
+function attachmentRow(id: string, object: ChatAttachmentObjectRow): ChatAttachmentRow {
+  return {
+    id,
+    schema_version: 1,
+    conversation_id: object.conversation_id,
+    object_id: object.id,
+    kind: "document",
+    display_name: `${id}.txt`,
+    media_type: "text/plain",
+    extension: "txt",
+    byte_size: object.byte_size,
+    sha256: object.sha256,
+    status: "preprocessing",
+    state_json: null,
+    message_id: null,
+    created_at_ms: 2,
+    updated_at_ms: 2,
+  };
+}
+
+describe("chat attachment repository", () => {
+  let store: ReturnType<typeof openSqliteStorage>;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("reserves capacity and returns a durable duplicate only inside the same Conversation", async () => {
+    const repository = createChatAttachmentRepository(store);
+    const first = objectRow("object-1", "chat-a", "1".repeat(64));
+    await expect(repository.reserveObject({ object: first, limits: LIMITS })).resolves.toEqual({
+      kind: "reserved",
+      object: first,
+    });
+    await repository.commitAdmission({
+      objectId: first.id,
+      attachment: attachmentRow("attachment-1", first),
+      draftUpdatedAtMs: 3,
+    });
+
+    const duplicate = objectRow("object-2", "chat-a", first.sha256);
+    await expect(
+      repository.reserveObject({ object: duplicate, limits: LIMITS }),
+    ).resolves.toMatchObject({
+      kind: "reused",
+      object: { id: first.id, status: "durable" },
+    });
+    const anotherConversation = objectRow("object-3", "chat-b", first.sha256);
+    await expect(
+      repository.reserveObject({ object: anotherConversation, limits: LIMITS }),
+    ).resolves.toMatchObject({
+      kind: "reserved",
+      object: { id: "object-3" },
+    });
+  });
+
+  it("atomically enforces Message, Conversation, and athlete capacity without evicting rows", async () => {
+    const repository = createChatAttachmentRepository(store);
+    const first = objectRow("object-1", "chat-a", "1".repeat(64), 60);
+    await repository.reserveObject({ object: first, limits: LIMITS });
+    await repository.commitAdmission({
+      objectId: first.id,
+      attachment: attachmentRow("attachment-1", first),
+      draftUpdatedAtMs: 3,
+    });
+
+    const messageFull = objectRow("object-2", "chat-a", "2".repeat(64), 50);
+    await expect(
+      repository.reserveObject({ object: messageFull, limits: LIMITS }),
+    ).resolves.toEqual({
+      kind: "message_limit",
+    });
+    expect(await repository.readObject(first.id)).toMatchObject({ status: "durable" });
+
+    await repository.linkMessage({
+      conversationId: "chat-a",
+      messageId: "message-1",
+      attachmentIds: ["attachment-1"],
+      createdAtMs: 4,
+    });
+    await repository.saveDraftText({
+      conversationId: "chat-a",
+      text: "",
+      state: "active",
+      updatedAtMs: 4,
+    });
+    await repository.removeDraftAttachment({
+      conversationId: "chat-a",
+      attachmentId: "attachment-1",
+    });
+    const conversationFull = objectRow("object-3", "chat-a", "3".repeat(64), 150);
+    await expect(
+      repository.reserveObject({
+        object: conversationFull,
+        limits: { ...LIMITS, messageBytes: 200 },
+      }),
+    ).resolves.toEqual({
+      kind: "storage_full",
+      scope: "conversation",
+    });
+
+    const athleteA = objectRow("object-4", "chat-c", "4".repeat(64), 160);
+    await repository.reserveObject({ object: athleteA, limits: { ...LIMITS, messageBytes: 200 } });
+    const athleteFull = objectRow("object-5", "chat-b", "5".repeat(64), 100);
+    await expect(
+      repository.reserveObject({ object: athleteFull, limits: LIMITS }),
+    ).resolves.toEqual({
+      kind: "storage_full",
+      scope: "athlete",
+    });
+  });
+
+  it("restores draft text and attachment identifiers together and links them to one Message", async () => {
+    const repository = createChatAttachmentRepository(store);
+    const object = objectRow("object-1", "chat-a", "1".repeat(64));
+    await repository.reserveObject({ object, limits: LIMITS });
+    const draft = await repository.commitAdmission({
+      objectId: object.id,
+      attachment: attachmentRow("attachment-1", object),
+      draftUpdatedAtMs: 3,
+    });
+    expect(draft).toMatchObject({ text: "", attachmentIds: ["attachment-1"], state: "active" });
+    await repository.saveDraftText({
+      conversationId: "chat-a",
+      text: "Please review this",
+      state: "restored",
+      updatedAtMs: 4,
+    });
+    await expect(repository.readDraft("chat-a")).resolves.toEqual({
+      schemaVersion: 1,
+      conversationId: "chat-a",
+      text: "Please review this",
+      attachmentIds: ["attachment-1"],
+      state: "restored",
+      updatedAtMs: 4,
+    });
+    const secondObject = objectRow("object-2", "chat-a", "2".repeat(64));
+    await repository.reserveObject({ object: secondObject, limits: LIMITS });
+    await expect(
+      repository.commitAdmission({
+        objectId: secondObject.id,
+        attachment: attachmentRow("attachment-2", secondObject),
+        draftUpdatedAtMs: 5,
+      }),
+    ).resolves.toEqual({
+      schemaVersion: 1,
+      conversationId: "chat-a",
+      text: "Please review this",
+      attachmentIds: ["attachment-1", "attachment-2"],
+      state: "active",
+      updatedAtMs: 5,
+    });
+    await repository.linkMessage({
+      conversationId: "chat-a",
+      messageId: "message-1",
+      attachmentIds: ["attachment-1", "attachment-2"],
+      createdAtMs: 6,
+    });
+    await expect(repository.listMessageAttachments("message-1")).resolves.toMatchObject([
+      { id: "attachment-1", object_id: "object-1" },
+      { id: "attachment-2", object_id: "object-2" },
+    ]);
+  });
+
+  it("serializes competing reservations so aggregate capacity cannot be oversubscribed", async () => {
+    const repository = createChatAttachmentRepository(store);
+    const limits = {
+      attachmentsPerMessage: 5,
+      messageBytes: 30,
+      conversationBytes: 30,
+      athleteBytes: 30,
+    } as const;
+    const results = await Promise.all([
+      repository.reserveObject({
+        object: objectRow("object-a", "chat-a", "a".repeat(64), 20),
+        limits,
+      }),
+      repository.reserveObject({
+        object: objectRow("object-b", "chat-b", "b".repeat(64), 20),
+        limits,
+      }),
+    ]);
+    expect(results.filter((result) => result.kind === "reserved")).toHaveLength(1);
+    expect(results.filter((result) => result.kind === "storage_full")).toEqual([
+      { kind: "storage_full", scope: "athlete" },
+    ]);
+  });
+
+  it("reuses the first free draft ordinal after removal", async () => {
+    const repository = createChatAttachmentRepository(store);
+    for (let index = 0; index < 5; index += 1) {
+      const object = objectRow(`object-${index}`, "chat-a", String(index).repeat(64));
+      await repository.reserveObject({ object, limits: { ...LIMITS, messageBytes: 200 } });
+      await repository.commitAdmission({
+        objectId: object.id,
+        attachment: attachmentRow(`attachment-${index}`, object),
+        draftUpdatedAtMs: index + 2,
+      });
+    }
+    await repository.removeDraftAttachment({
+      conversationId: "chat-a",
+      attachmentId: "attachment-2",
+    });
+    const replacement = objectRow("object-new", "chat-a", "f".repeat(64));
+    await repository.reserveObject({
+      object: replacement,
+      limits: { ...LIMITS, messageBytes: 200 },
+    });
+    await expect(
+      repository.commitAdmission({
+        objectId: replacement.id,
+        attachment: attachmentRow("attachment-new", replacement),
+        draftUpdatedAtMs: 10,
+      }),
+    ).resolves.toMatchObject({
+      attachmentIds: [
+        "attachment-0",
+        "attachment-1",
+        "attachment-new",
+        "attachment-3",
+        "attachment-4",
+      ],
+    });
+  });
+
+  it("cleans one Conversation idempotently while leaving other Conversations untouched", async () => {
+    const repository = createChatAttachmentRepository(store);
+    for (const [id, conversationId, digest] of [
+      ["object-a", "chat-a", "a".repeat(64)],
+      ["object-b", "chat-b", "b".repeat(64)],
+    ] as const) {
+      const object = objectRow(id, conversationId, digest);
+      await repository.reserveObject({ object, limits: LIMITS });
+      await repository.commitAdmission({
+        objectId: id,
+        attachment: attachmentRow(`attachment-${id}`, object),
+        draftUpdatedAtMs: 3,
+      });
+    }
+    await expect(repository.cleanupConversation("chat-a")).resolves.toMatchObject([
+      { id: "object-a" },
+    ]);
+    await expect(repository.cleanupConversation("chat-a")).resolves.toEqual([]);
+    await expect(repository.readObject("object-b")).resolves.toMatchObject({
+      conversation_id: "chat-b",
+    });
+  });
+});

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -1,6 +1,15 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { access, copyFile, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import {
+  access,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { createServer as createNetServer } from "node:net";
@@ -8,10 +17,7 @@ import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { ImportReport } from "@enduragent/kernel/ingest";
 import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
-import {
-  inertWriterProtocolListener,
-  type WriteLockHandle,
-} from "@enduragent/kernel-node/lock";
+import { inertWriterProtocolListener, type WriteLockHandle } from "@enduragent/kernel-node/lock";
 
 type RunCoachDev = typeof import("../src/cli/coach-dev.js").runCoachDev;
 type RunCoachDevWriter = typeof import("../src/cli/coach-dev.js").runCoachDevWriter;
@@ -592,7 +598,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 13 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(
@@ -644,51 +650,55 @@ describe("coach-dev import --report", () => {
     await expectLockFilesAbsent(realHome!);
   });
 
-  it.runIf(hasLoopback)("held-lock refuses safely", async () => {
-    const homePath = await freshHome("coach-dev-held-");
-    const home = resolveAthleteHome({ ENDURAGENT_HOME: homePath });
-    const result = await acquireWriteLock({
-      configDir: home.configDir,
-      athleteHome: home.root,
-      version: "test-parent",
-    });
-    expect(result.status).toBe("acquired");
-    if (result.status !== "acquired") throw new Error("expected acquired lock");
-    const foreignServer = createServer((_request, response) => {
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({ service: "foreign", version: "test" }));
-    });
-    await new Promise<void>((resolveListen) => {
-      foreignServer.listen({ host: "127.0.0.1", port: 0 }, resolveListen);
-    });
-    const foreignAddress = foreignServer.address();
-    if (foreignAddress === null || typeof foreignAddress === "string") {
-      throw new Error("foreign holder did not bind a TCP port");
-    }
-    await writeFile(join(home.configDir, PORT_FILE_NAME), `${foreignAddress.port}\n`, {
-      mode: 0o600,
-    });
-    try {
-      const child = await runChild(homePath, [
-        "import",
-        "--report",
-        resolve("packages/kernel-node/tests/fixtures/ingest/triathlon-multisport.fit"),
-      ]);
-      expect(child).toEqual({
-        exitCode: 3,
-        stdout: WRITER_LOCK_STDOUT,
-        stderr: WRITER_LOCK_STDERR,
+  it.runIf(hasLoopback)(
+    "held-lock refuses safely",
+    async () => {
+      const homePath = await freshHome("coach-dev-held-");
+      const home = resolveAthleteHome({ ENDURAGENT_HOME: homePath });
+      const result = await acquireWriteLock({
+        configDir: home.configDir,
+        athleteHome: home.root,
+        version: "test-parent",
       });
-      expect(await exists(home.storeDir)).toBe(true);
-      expect(await exists(join(home.storeDir, "store.db"))).toBe(false);
-    } finally {
-      await new Promise<void>((resolveClose, reject) => {
-        foreignServer.close((error) => (error ? reject(error) : resolveClose()));
+      expect(result.status).toBe("acquired");
+      if (result.status !== "acquired") throw new Error("expected acquired lock");
+      const foreignServer = createServer((_request, response) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ service: "foreign", version: "test" }));
       });
-      await result.release();
-    }
-    await expectLockFilesAbsent(homePath);
-  }, 15_000);
+      await new Promise<void>((resolveListen) => {
+        foreignServer.listen({ host: "127.0.0.1", port: 0 }, resolveListen);
+      });
+      const foreignAddress = foreignServer.address();
+      if (foreignAddress === null || typeof foreignAddress === "string") {
+        throw new Error("foreign holder did not bind a TCP port");
+      }
+      await writeFile(join(home.configDir, PORT_FILE_NAME), `${foreignAddress.port}\n`, {
+        mode: 0o600,
+      });
+      try {
+        const child = await runChild(homePath, [
+          "import",
+          "--report",
+          resolve("packages/kernel-node/tests/fixtures/ingest/triathlon-multisport.fit"),
+        ]);
+        expect(child).toEqual({
+          exitCode: 3,
+          stdout: WRITER_LOCK_STDOUT,
+          stderr: WRITER_LOCK_STDERR,
+        });
+        expect(await exists(home.storeDir)).toBe(true);
+        expect(await exists(join(home.storeDir, "store.db"))).toBe(false);
+      } finally {
+        await new Promise<void>((resolveClose, reject) => {
+          foreignServer.close((error) => (error ? reject(error) : resolveClose()));
+        });
+        await result.release();
+      }
+      await expectLockFilesAbsent(homePath);
+    },
+    15_000,
+  );
 
   it.runIf(hasLoopback)("healthy-peer refuses without ownership", async () => {
     const homePath = await freshHome("coach-dev-peer-");
@@ -850,7 +860,9 @@ describe("coach-dev import --report", () => {
       failed.deps,
     );
     expect(failure).toEqual({ status: "failed", stage: "invoke operation" });
-    expect(failure.status === "failed" && failure.cause instanceof Error && failure.cause.message).toBe(privateValues[0]);
+    expect(
+      failure.status === "failed" && failure.cause instanceof Error && failure.cause.message,
+    ).toBe(privateValues[0]);
     expect(failed.calls).toEqual([
       "resolve",
       "prepare",
@@ -932,18 +944,23 @@ describe("coach-dev import --report", () => {
 
   it("runs the pre-open hook under the writer before store effects and releases on failure", async () => {
     const successful = injected();
-    await expect(runCoachDevWriter({
-      env: {},
-      writerVersion: "generic-operation/1",
-      beforeStoreOpen: async (home) => {
-        expect(home).toBe(successful.home);
-        successful.calls.push("pre-open");
-      },
-      operation: async () => {
-        successful.calls.push("operation");
-        return "done";
-      },
-    }, successful.deps)).resolves.toEqual({ status: "completed", value: "done" });
+    await expect(
+      runCoachDevWriter(
+        {
+          env: {},
+          writerVersion: "generic-operation/1",
+          beforeStoreOpen: async (home) => {
+            expect(home).toBe(successful.home);
+            successful.calls.push("pre-open");
+          },
+          operation: async () => {
+            successful.calls.push("operation");
+            return "done";
+          },
+        },
+        successful.deps,
+      ),
+    ).resolves.toEqual({ status: "completed", value: "done" });
     expect(successful.calls).toEqual([
       "resolve",
       "prepare",
@@ -960,18 +977,21 @@ describe("coach-dev import --report", () => {
 
     const failure = { kind: "pre-open" };
     const failed = injected();
-    const result = await runCoachDevWriter({
-      env: {},
-      writerVersion: "generic-operation/1",
-      beforeStoreOpen: async () => {
-        failed.calls.push("pre-open");
-        throw failure;
+    const result = await runCoachDevWriter(
+      {
+        env: {},
+        writerVersion: "generic-operation/1",
+        beforeStoreOpen: async () => {
+          failed.calls.push("pre-open");
+          throw failure;
+        },
+        operation: async () => {
+          failed.calls.push("operation");
+          return null;
+        },
       },
-      operation: async () => {
-        failed.calls.push("operation");
-        return null;
-      },
-    }, failed.deps);
+      failed.deps,
+    );
     expect(result).toEqual({ status: "failed", stage: "run pre-open operation" });
     expect(result.status === "failed" && result.cause).toBe(failure);
     expect(failed.calls).toEqual(["resolve", "prepare", "acquire", "pre-open", "release"]);
@@ -1006,11 +1026,16 @@ describe("coach-dev import --report", () => {
       portFile: "synthetic/config/store-writer.port",
     };
     const typedScenario = injected({ fail: { acquire: typedForeign } });
-    await expect(runCoachDevWriter({
-      env: {},
-      writerVersion: "generic-operation/1",
-      operation: async () => null,
-    }, typedScenario.deps)).resolves.toEqual({
+    await expect(
+      runCoachDevWriter(
+        {
+          env: {},
+          writerVersion: "generic-operation/1",
+          operation: async () => null,
+        },
+        typedScenario.deps,
+      ),
+    ).resolves.toEqual({
       status: "writer-lock-held",
       contention: typedForeign.contention,
     });
@@ -1032,8 +1057,15 @@ describe("coach-dev import --report", () => {
   });
 
   it("never serializes failure causes carrying enumerable private data", async () => {
-    const privateTexts = ["/private/athlete/home/store.db", "thrown-plain-object-secret", "thrown-string-secret"];
-    const fsLike = Object.assign(new Error("EACCES: permission denied"), { path: privateTexts[0], syscall: "open" });
+    const privateTexts = [
+      "/private/athlete/home/store.db",
+      "thrown-plain-object-secret",
+      "thrown-string-secret",
+    ];
+    const fsLike = Object.assign(new Error("EACCES: permission denied"), {
+      path: privateTexts[0],
+      syscall: "open",
+    });
     for (const thrown of [fsLike, { detail: privateTexts[1] }, privateTexts[2]]) {
       const scenario = injected();
       const failure = await runCoachDevWriter(
@@ -1111,7 +1143,17 @@ describe("coach-dev import --report", () => {
         stage: "migrate",
         error: new Error("private migration failure"),
         diagnostic: "run migrations",
-        calls: ["resolve", "prepare", "acquire", "mkdir", "chmod", "open", "migrate", "close", "release"],
+        calls: [
+          "resolve",
+          "prepare",
+          "acquire",
+          "mkdir",
+          "chmod",
+          "open",
+          "migrate",
+          "close",
+          "release",
+        ],
       },
       {
         stage: "import",

--- a/packages/kernel-node/tests/managed-chat-attachment-store.test.ts
+++ b/packages/kernel-node/tests/managed-chat-attachment-store.test.ts
@@ -1,0 +1,258 @@
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createChatAttachmentRepository,
+  runMigrations,
+  type ChatAttachmentObjectRow,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import {
+  ManagedAttachmentSourceError,
+  chatAttachmentRelativePath,
+  createManagedChatAttachmentStore,
+} from "../src/chat-attachments/index.js";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const LIMITS = { document: 1024, activity: 1024, workout: 1024, image: 1024 } as const;
+const KEY = "a".repeat(64);
+
+describe("managed Chat attachment store", () => {
+  let root: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(await realpath(tmpdir()), "managed-chat-attachments-"));
+    archiveDir = join(root, "archive");
+    await mkdir(archiveDir, { mode: 0o700 });
+  });
+
+  afterEach(async () => {
+    await chmod(root, 0o700).catch(() => {});
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("copies a signature-validated source into a durable private object", async () => {
+    const sourcePath = join(root, "notes.txt");
+    await writeFile(sourcePath, "steady ride\n", { mode: 0o600 });
+    const managed = createManagedChatAttachmentStore({ archiveDir, kindByteLimits: LIMITS });
+    const source = await managed.inspectNativeSource(sourcePath);
+    expect(source).toMatchObject({
+      displayName: "notes.txt",
+      extension: "txt",
+      kind: "document",
+      mediaType: "text/plain",
+      byteSize: 12,
+    });
+    const relativePath = chatAttachmentRelativePath(KEY, "object-1");
+    await managed.copyInspectedSource({ source, relativePath });
+    const target = join(archiveDir, ...relativePath.split("/"));
+    await expect(readFile(target, "utf8")).resolves.toBe("steady ride\n");
+    if (process.platform !== "win32") {
+      expect((await lstat(target)).mode & 0o777).toBe(0o600);
+      expect((await lstat(join(archiveDir, "chat-attachments"))).mode & 0o777).toBe(0o700);
+      expect((await lstat(join(archiveDir, "chat-attachments", KEY))).mode & 0o777).toBe(0o700);
+    }
+  });
+
+  it("rejects unknown extensions, signature mismatches, invalid UTF-8, and links", async () => {
+    const managed = createManagedChatAttachmentStore({ archiveDir, kindByteLimits: LIMITS });
+    const unknown = join(root, "ride.xyz");
+    await writeFile(unknown, "data");
+    await expect(managed.inspectNativeSource(unknown)).rejects.toMatchObject({
+      reason: "format_unsupported",
+    });
+
+    const fakePdf = join(root, "report.pdf");
+    await writeFile(fakePdf, "not a pdf");
+    await expect(managed.inspectNativeSource(fakePdf)).rejects.toMatchObject({
+      reason: "signature_mismatch",
+    });
+
+    const invalidText = join(root, "invalid.txt");
+    await writeFile(invalidText, Buffer.from([0xc3, 0x28]));
+    await expect(managed.inspectNativeSource(invalidText)).rejects.toMatchObject({
+      reason: "validation_failed",
+    });
+
+    const target = join(root, "target.txt");
+    const linked = join(root, "linked.txt");
+    await writeFile(target, "private");
+    await symlink(target, linked);
+    await expect(managed.inspectNativeSource(linked)).rejects.toMatchObject({
+      reason: "unsafe_source",
+    });
+  });
+
+  it("detects a source identity change between inspection and copying", async () => {
+    const sourcePath = join(root, "notes.txt");
+    await writeFile(sourcePath, "first");
+    const managed = createManagedChatAttachmentStore({ archiveDir, kindByteLimits: LIMITS });
+    const source = await managed.inspectNativeSource(sourcePath);
+    await writeFile(sourcePath, "second version");
+    await expect(
+      managed.copyInspectedSource({
+        source,
+        relativePath: chatAttachmentRelativePath(KEY, "object-1"),
+      }),
+    ).rejects.toBeInstanceOf(ManagedAttachmentSourceError);
+  });
+
+  it("rejects a linked managed root and supports the authenticated Windows path policy", async () => {
+    const sourcePath = join(root, "notes.txt");
+    const outside = join(root, "outside");
+    await writeFile(sourcePath, "private");
+    await mkdir(outside);
+    await symlink(outside, join(archiveDir, "chat-attachments"));
+    const posix = createManagedChatAttachmentStore({ archiveDir, kindByteLimits: LIMITS });
+    const source = await posix.inspectNativeSource(sourcePath);
+    await expect(
+      posix.copyInspectedSource({
+        source,
+        relativePath: chatAttachmentRelativePath(KEY, "object-linked"),
+      }),
+    ).rejects.toThrow("managed attachment directory is unsafe");
+    await rm(join(archiveDir, "chat-attachments"));
+
+    const windows = createManagedChatAttachmentStore({
+      archiveDir,
+      kindByteLimits: LIMITS,
+      platform: "win32",
+    });
+    await windows.copyInspectedSource({
+      source,
+      relativePath: chatAttachmentRelativePath(KEY, "object-windows"),
+    });
+    await expect(
+      readFile(join(archiveDir, "chat-attachments", KEY, "object-windows"), "utf8"),
+    ).resolves.toBe("private");
+  });
+
+  it("stages pasted bytes privately and enforces the format byte limit before writing", async () => {
+    const managed = createManagedChatAttachmentStore({
+      archiveDir,
+      kindByteLimits: { ...LIMITS, document: 4 },
+      randomBytes: ((size: number) =>
+        Buffer.alloc(size, 1)) as typeof import("node:crypto").randomBytes,
+    });
+    await expect(
+      managed.stagePrivateBytes({ displayName: "note.txt", bytes: Buffer.from("12345") }),
+    ).rejects.toMatchObject({ reason: "file_too_large" });
+    const staged = await managed.stagePrivateBytes({
+      displayName: "note.txt",
+      bytes: Buffer.from("1234"),
+    });
+    expect(staged.displayName).toBe("note.txt");
+    await expect(readFile(staged.sourcePath, "utf8")).resolves.toBe("1234");
+    if (process.platform !== "win32")
+      expect((await lstat(staged.sourcePath)).mode & 0o777).toBe(0o600);
+  });
+
+  it("reconciles missing metadata bytes, interrupted reservations, and aged orphan bytes", async () => {
+    const store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    const repository = createChatAttachmentRepository(store);
+    const managed = createManagedChatAttachmentStore({
+      archiveDir,
+      kindByteLimits: LIMITS,
+      now: () => 200_000,
+    });
+    const durableSource = join(root, "durable.txt");
+    await writeFile(durableSource, "durable");
+    const inspected = await managed.inspectNativeSource(durableSource);
+    const durable: ChatAttachmentObjectRow = {
+      id: "object-durable",
+      conversation_id: "chat-a",
+      conversation_key: KEY,
+      sha256: inspected.sha256,
+      byte_size: inspected.byteSize,
+      relative_path: chatAttachmentRelativePath(KEY, "object-durable"),
+      status: "reserved",
+      failure_code: null,
+      created_at_ms: 1,
+      updated_at_ms: 1,
+    };
+    await repository.reserveObject({
+      object: durable,
+      limits: {
+        attachmentsPerMessage: 5,
+        messageBytes: 100,
+        conversationBytes: 100,
+        athleteBytes: 200,
+      },
+    });
+    await repository.commitAdmission({
+      objectId: durable.id,
+      attachment: {
+        id: "attachment-durable",
+        schema_version: 1,
+        conversation_id: "chat-a",
+        object_id: durable.id,
+        kind: "document",
+        display_name: "durable.txt",
+        media_type: "text/plain",
+        extension: "txt",
+        byte_size: inspected.byteSize,
+        sha256: inspected.sha256,
+        status: "preprocessing",
+        state_json: null,
+        message_id: null,
+        created_at_ms: 2,
+        updated_at_ms: 2,
+      },
+      draftUpdatedAtMs: 2,
+    });
+    const interrupted: ChatAttachmentObjectRow = {
+      ...durable,
+      id: "object-interrupted",
+      sha256: "b".repeat(64),
+      relative_path: chatAttachmentRelativePath(KEY, "object-interrupted"),
+      status: "reserved",
+    };
+    await repository.reserveObject({
+      object: interrupted,
+      limits: {
+        attachmentsPerMessage: 5,
+        messageBytes: 100,
+        conversationBytes: 100,
+        athleteBytes: 200,
+      },
+    });
+    const orphanDir = join(archiveDir, "chat-attachments", KEY);
+    await mkdir(orphanDir, { recursive: true, mode: 0o700 });
+    const orphan = join(orphanDir, "orphan-object");
+    const youngOrphan = join(orphanDir, "young-orphan");
+    await writeFile(orphan, "orphan");
+    await writeFile(youngOrphan, "young");
+    await utimes(orphan, new Date(0), new Date(0));
+
+    await expect(managed.reconcile(repository, 1_000)).resolves.toEqual({
+      missing: 1,
+      interruptedReservations: 1,
+      orphansRemoved: 1,
+    });
+    await expect(repository.readObject("object-durable")).resolves.toMatchObject({
+      status: "failed",
+      failure_code: "managed_bytes_missing",
+    });
+    await expect(repository.readObject("object-interrupted")).resolves.toBeUndefined();
+    await expect(lstat(orphan)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(youngOrphan, "utf8")).resolves.toBe("young");
+    await expect(repository.readAttachment("attachment-durable")).resolves.toMatchObject({
+      status: "failed",
+    });
+    await store.close();
+  });
+});

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -31,9 +31,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 12", async () => {
+  it("applies the full migration list and advances user_version to 13", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 13 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -53,7 +53,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 13 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -82,11 +82,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 12", async () => {
+  it("upgrades a version-1-on-disk store to version 13", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 13 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -106,8 +106,12 @@ describe("migrator end-to-end over node:sqlite", () => {
     );
 
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 4, toVersion: 12, applied: [5, 6, 7, 8, 9, 10, 11, 12] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
+    expect(result).toEqual({
+      fromVersion: 4,
+      toVersion: 13,
+      applied: [5, 6, 7, 8, 9, 10, 11, 12, 13],
+    });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 13 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -158,29 +162,31 @@ describe("migrator end-to-end over node:sqlite", () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 6, toVersion: 12, applied: [7, 8, 9, 10, 11, 12] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
+    expect(result).toEqual({ fromVersion: 6, toVersion: 13, applied: [7, 8, 9, 10, 11, 12, 13] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 13 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 12,
-      toVersion: 12,
+      fromVersion: 13,
+      toVersion: 13,
       applied: [],
     });
   });
 
   it("preserves an existing cursor and leaves its store owner unset", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 7));
-    await store.run(
-      "INSERT INTO source_watermark(source,lane,watermark) VALUES(?,?,?)",
-      ["intervals-icu", "bulk-fit", "legacy-cursor"],
-    );
+    await store.run("INSERT INTO source_watermark(source,lane,watermark) VALUES(?,?,?)", [
+      "intervals-icu",
+      "bulk-fit",
+      "legacy-cursor",
+    ]);
 
     await runMigrations(store, MIGRATIONS);
 
-    expect(await store.get("SELECT watermark FROM source_watermark"))
-      .toEqual({ watermark: "legacy-cursor" });
+    expect(await store.get("SELECT watermark FROM source_watermark")).toEqual({
+      watermark: "legacy-cursor",
+    });
     expect(await store.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 0 });
   });
 
@@ -208,7 +214,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     await seed.setUserVersion(maximum + 1);
     await seed.close();
     const beforeNames = (await readdir(dir)).sort();
-    const beforeHash = createHash("sha256").update(await readFile(path)).digest("hex");
+    const beforeHash = createHash("sha256")
+      .update(await readFile(path))
+      .digest("hex");
 
     const refused = openSqliteStorage(path);
     const error = await runMigrations(refused, MIGRATIONS).catch((failure: unknown) => failure);
@@ -221,7 +229,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     await refused.close();
 
     expect((await readdir(dir)).sort()).toEqual(beforeNames);
-    expect(createHash("sha256").update(await readFile(path)).digest("hex")).toBe(beforeHash);
+    expect(
+      createHash("sha256")
+        .update(await readFile(path))
+        .digest("hex"),
+    ).toBe(beforeHash);
     expect(beforeNames).not.toContain("newer.db-wal");
     expect(beforeNames).not.toContain("newer.db-shm");
   });

--- a/packages/kernel-node/tests/plan-repository.test.ts
+++ b/packages/kernel-node/tests/plan-repository.test.ts
@@ -70,7 +70,9 @@ describe("Plan repositories over node:sqlite", () => {
   it("atomically stores and reads a Plan aggregate", async () => {
     await createPlanAggregateRepository(store).save(plan(), [workout()]);
     await expect(createPlanRepository(store).read(PLAN_ID)).resolves.toEqual(plan());
-    await expect(createPlanWorkoutRepository(store).listForPlan(PLAN_ID)).resolves.toEqual([workout()]);
+    await expect(createPlanWorkoutRepository(store).listForPlan(PLAN_ID)).resolves.toEqual([
+      workout(),
+    ]);
   });
 
   it("enforces the Workout foreign key and delete cascade", async () => {
@@ -92,7 +94,9 @@ describe("Plan repositories over node:sqlite", () => {
     ["inconsistent_kind", { kind: "full_plan" }],
     ["target_not_covered", { target_date_key: 20261231 }],
   ])("rejects %s with a typed invariant error", async (code, overrides) => {
-    await expect(createPlanRepository(store).upsert(plan(overrides as Partial<PlanRow>))).rejects.toMatchObject({ code });
+    await expect(
+      createPlanRepository(store).upsert(plan(overrides as Partial<PlanRow>)),
+    ).rejects.toMatchObject({ code });
   });
 
   it("migrates a version-11 store without changing existing rows", async () => {
@@ -101,8 +105,10 @@ describe("Plan repositories over node:sqlite", () => {
       await runMigrations(prior, MIGRATIONS.slice(0, 11));
       await prior.run("INSERT INTO raw_file(sha256) VALUES(?)", ["a".repeat(64)]);
       await runMigrations(prior, MIGRATIONS);
-      await expect(prior.get("PRAGMA user_version")).resolves.toEqual({ user_version: 12 });
-      await expect(prior.get("SELECT sha256 FROM raw_file")).resolves.toEqual({ sha256: "a".repeat(64) });
+      await expect(prior.get("PRAGMA user_version")).resolves.toEqual({ user_version: 13 });
+      await expect(prior.get("SELECT sha256 FROM raw_file")).resolves.toEqual({
+        sha256: "a".repeat(64),
+      });
     } finally {
       await prior.close();
     }

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -236,7 +236,7 @@ describe("sync failure repository", () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     await runMigrations(store, MIGRATIONS);
     expect(await dumpStore(store)).not.toContain("# sync_failure");
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 12 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 13 });
     expect(DUMP_TABLES).toHaveLength(39);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,20 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "filesystem/index": "src/filesystem/index.ts", "ingest/index": "src/ingest/index.ts", "capture-manifest/index": "src/capture-manifest/index.ts", "service/index": "src/service/index.ts", "coach-dev": "src/cli/coach-dev.ts" },
+  entry: {
+    index: "src/index.ts",
+    sqlite: "src/sqlite/index.ts",
+    "archive/index": "src/archive/index.ts",
+    "chat-attachments/index": "src/chat-attachments/index.ts",
+    "lock/index": "src/lock/index.ts",
+    "store-export/index": "src/store-export/index.ts",
+    "home/index": "src/home/index.ts",
+    "filesystem/index": "src/filesystem/index.ts",
+    "ingest/index": "src/ingest/index.ts",
+    "capture-manifest/index": "src/capture-manifest/index.ts",
+    "service/index": "src/service/index.ts",
+    "coach-dev": "src/cli/coach-dev.ts",
+  },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/packages/kernel/src/chat-attachments/index.ts
+++ b/packages/kernel/src/chat-attachments/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export { createChatAttachmentRepository } from "./repository.js";

--- a/packages/kernel/src/chat-attachments/repository.ts
+++ b/packages/kernel/src/chat-attachments/repository.ts
@@ -1,0 +1,604 @@
+import type { MigratorStore } from "../store/migrator.js";
+import type { Row, SqlStore } from "../store/ports.js";
+import {
+  ChatAttachmentInvariantError,
+  type ChatAttachmentCapacityLimits,
+  type ChatAttachmentDraft,
+  type ChatAttachmentDraftState,
+  type ChatAttachmentKind,
+  type ChatAttachmentObjectReservation,
+  type ChatAttachmentObjectRow,
+  type ChatAttachmentRepository,
+  type ChatAttachmentRow,
+  type ChatAttachmentStatus,
+} from "./types.js";
+
+type TransactionalStore = SqlStore & Pick<MigratorStore, "transaction">;
+
+const SHA256 = /^[0-9a-f]{64}$/u;
+const SAFE_ID = /^[A-Za-z0-9_-]{1,128}$/u;
+const EXTENSIONS = new Set([
+  "pdf",
+  "txt",
+  "csv",
+  "docx",
+  "fit",
+  "tcx",
+  "gpx",
+  "zwo",
+  "mrc",
+  "erg",
+  "png",
+  "jpg",
+  "jpeg",
+  "webp",
+]);
+const KIND_EXTENSIONS: Readonly<Record<ChatAttachmentKind, ReadonlySet<string>>> = {
+  document: new Set(["pdf", "txt", "csv", "docx"]),
+  activity: new Set(["fit", "tcx", "gpx"]),
+  workout: new Set(["zwo", "mrc", "erg"]),
+  image: new Set(["png", "jpg", "jpeg", "webp"]),
+};
+const STATUSES = new Set<ChatAttachmentStatus>([
+  "preprocessing",
+  "blocked",
+  "failed",
+  "ready",
+  "importing",
+  "imported",
+  "sent",
+]);
+const DRAFT_STATES = new Set<ChatAttachmentDraftState>([
+  "active",
+  "restored",
+  "submitting",
+  "clearing",
+]);
+
+function integer(value: number, name: string, minimum = 0): void {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new ChatAttachmentInvariantError(`invalid_${name}`, `${name} is invalid`);
+  }
+}
+
+function validateLimits(limits: ChatAttachmentCapacityLimits): void {
+  integer(limits.attachmentsPerMessage, "attachments_per_message", 1);
+  integer(limits.messageBytes, "message_bytes", 1);
+  integer(limits.conversationBytes, "conversation_bytes", 1);
+  integer(limits.athleteBytes, "athlete_bytes", 1);
+  if (
+    limits.messageBytes > limits.conversationBytes ||
+    limits.conversationBytes > limits.athleteBytes
+  ) {
+    throw new ChatAttachmentInvariantError(
+      "invalid_capacity_limits",
+      "attachment capacity limits are inconsistent",
+    );
+  }
+}
+
+function validateObject(row: ChatAttachmentObjectRow): void {
+  if (!SAFE_ID.test(row.id))
+    throw new ChatAttachmentInvariantError("invalid_object_id", "attachment object id is invalid");
+  if (row.conversation_id.length < 1 || row.conversation_id.length > 512) {
+    throw new ChatAttachmentInvariantError("invalid_conversation_id", "conversation id is invalid");
+  }
+  if (!SHA256.test(row.conversation_key) || !SHA256.test(row.sha256)) {
+    throw new ChatAttachmentInvariantError("invalid_digest", "attachment digest is invalid");
+  }
+  integer(row.byte_size, "byte_size", 1);
+  if (
+    !row.relative_path.startsWith(`chat-attachments/${row.conversation_key}/`) ||
+    row.relative_path.includes("\\") ||
+    row.relative_path.includes("..")
+  ) {
+    throw new ChatAttachmentInvariantError("invalid_relative_path", "attachment path is invalid");
+  }
+  if (row.status !== "reserved" && row.status !== "durable" && row.status !== "failed") {
+    throw new ChatAttachmentInvariantError(
+      "invalid_object_status",
+      "attachment object status is invalid",
+    );
+  }
+  if ((row.status === "failed") !== (row.failure_code !== null)) {
+    throw new ChatAttachmentInvariantError(
+      "invalid_failure",
+      "attachment object failure state is invalid",
+    );
+  }
+  integer(row.created_at_ms, "created_at_ms");
+  integer(row.updated_at_ms, "updated_at_ms");
+  if (row.updated_at_ms < row.created_at_ms) {
+    throw new ChatAttachmentInvariantError(
+      "invalid_timestamp",
+      "attachment object timestamps are invalid",
+    );
+  }
+}
+
+function validateAttachment(row: ChatAttachmentRow): void {
+  if (!SAFE_ID.test(row.id) || !SAFE_ID.test(row.object_id)) {
+    throw new ChatAttachmentInvariantError("invalid_attachment_id", "attachment id is invalid");
+  }
+  if (row.schema_version !== 1)
+    throw new ChatAttachmentInvariantError(
+      "invalid_schema_version",
+      "attachment schema version is invalid",
+    );
+  if (row.conversation_id.length < 1 || row.conversation_id.length > 512) {
+    throw new ChatAttachmentInvariantError("invalid_conversation_id", "conversation id is invalid");
+  }
+  if (!KIND_EXTENSIONS[row.kind]?.has(row.extension) || !EXTENSIONS.has(row.extension)) {
+    throw new ChatAttachmentInvariantError(
+      "invalid_extension",
+      "attachment extension does not match its kind",
+    );
+  }
+  if (
+    row.display_name.length < 1 ||
+    row.display_name.length > 512 ||
+    row.media_type.length < 1 ||
+    row.media_type.length > 256
+  ) {
+    throw new ChatAttachmentInvariantError("invalid_metadata", "attachment metadata is invalid");
+  }
+  integer(row.byte_size, "byte_size", 1);
+  if (!SHA256.test(row.sha256) || !STATUSES.has(row.status)) {
+    throw new ChatAttachmentInvariantError("invalid_attachment", "attachment row is invalid");
+  }
+  if (row.state_json !== null) {
+    try {
+      JSON.parse(row.state_json);
+    } catch {
+      throw new ChatAttachmentInvariantError(
+        "invalid_state_json",
+        "attachment state is invalid JSON",
+      );
+    }
+  }
+  integer(row.created_at_ms, "created_at_ms");
+  integer(row.updated_at_ms, "updated_at_ms");
+  if (row.updated_at_ms < row.created_at_ms) {
+    throw new ChatAttachmentInvariantError(
+      "invalid_timestamp",
+      "attachment timestamps are invalid",
+    );
+  }
+}
+
+function mapObject(row: Row): ChatAttachmentObjectRow {
+  const value: ChatAttachmentObjectRow = {
+    id: String(row.id),
+    conversation_id: String(row.conversation_id),
+    conversation_key: String(row.conversation_key),
+    sha256: String(row.sha256),
+    byte_size: Number(row.byte_size),
+    relative_path: String(row.relative_path),
+    status: String(row.status) as ChatAttachmentObjectRow["status"],
+    failure_code: row.failure_code === null ? null : String(row.failure_code),
+    created_at_ms: Number(row.created_at_ms),
+    updated_at_ms: Number(row.updated_at_ms),
+  };
+  validateObject(value);
+  return value;
+}
+
+function mapAttachment(row: Row): ChatAttachmentRow {
+  const value: ChatAttachmentRow = {
+    id: String(row.id),
+    schema_version: Number(row.schema_version) as 1,
+    conversation_id: String(row.conversation_id),
+    object_id: String(row.object_id),
+    kind: String(row.kind) as ChatAttachmentKind,
+    display_name: String(row.display_name),
+    media_type: String(row.media_type),
+    extension: String(row.extension),
+    byte_size: Number(row.byte_size),
+    sha256: String(row.sha256),
+    status: String(row.status) as ChatAttachmentStatus,
+    state_json: row.state_json === null ? null : String(row.state_json),
+    message_id: row.message_id === null ? null : String(row.message_id),
+    created_at_ms: Number(row.created_at_ms),
+    updated_at_ms: Number(row.updated_at_ms),
+  };
+  validateAttachment(value);
+  return value;
+}
+
+const OBJECT_COLUMNS =
+  "id,conversation_id,conversation_key,sha256,byte_size,relative_path,status,failure_code,created_at_ms,updated_at_ms";
+const ATTACHMENT_COLUMNS =
+  "id,schema_version,conversation_id,object_id,kind,display_name,media_type,extension,byte_size,sha256,status,state_json,message_id,created_at_ms,updated_at_ms";
+
+async function readDraft(
+  store: SqlStore,
+  conversationId: string,
+): Promise<ChatAttachmentDraft | undefined> {
+  const row = await store.get(
+    "SELECT conversation_id,schema_version,text,state,updated_at_ms FROM chat_attachment_draft WHERE conversation_id=?",
+    [conversationId],
+  );
+  if (row === undefined) return undefined;
+  const refs = await store.all(
+    "SELECT attachment_id FROM chat_attachment_draft_ref WHERE conversation_id=? ORDER BY ordinal ASC",
+    [conversationId],
+  );
+  const state = String(row.state) as ChatAttachmentDraftState;
+  if (!DRAFT_STATES.has(state) || Number(row.schema_version) !== 1) {
+    throw new ChatAttachmentInvariantError("invalid_draft", "attachment draft is invalid");
+  }
+  return {
+    schemaVersion: 1,
+    conversationId: String(row.conversation_id),
+    text: String(row.text),
+    attachmentIds: refs.map((value) => String(value.attachment_id)),
+    state,
+    updatedAtMs: Number(row.updated_at_ms),
+  };
+}
+
+async function draftCapacity(
+  store: SqlStore,
+  conversationId: string,
+): Promise<{ readonly count: number; readonly bytes: number }> {
+  const row = await store.get(
+    `SELECT COUNT(*) AS attachment_count, COALESCE(SUM(a.byte_size),0) AS total_bytes
+       FROM chat_attachment_draft_ref r
+       JOIN chat_attachment a ON a.id=r.attachment_id
+      WHERE r.conversation_id=?`,
+    [conversationId],
+  );
+  return { count: Number(row?.attachment_count ?? 0), bytes: Number(row?.total_bytes ?? 0) };
+}
+
+export function createChatAttachmentRepository(
+  store: TransactionalStore,
+): ChatAttachmentRepository {
+  let reservationTail: Promise<void> = Promise.resolve();
+  const serializeReservation = <T>(work: () => Promise<T>): Promise<T> => {
+    const result = reservationTail.then(work, work);
+    reservationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+  return {
+    async reserveObject({ object, limits }): Promise<ChatAttachmentObjectReservation> {
+      validateObject(object);
+      if (object.status !== "reserved") {
+        throw new ChatAttachmentInvariantError(
+          "invalid_object_status",
+          "new attachment object must be reserved",
+        );
+      }
+      validateLimits(limits);
+      return serializeReservation(() =>
+        store.transaction(async () => {
+          const draft = await draftCapacity(store, object.conversation_id);
+          if (
+            draft.count >= limits.attachmentsPerMessage ||
+            draft.bytes + object.byte_size > limits.messageBytes
+          )
+            return { kind: "message_limit" };
+
+          const duplicate = await store.get(
+            `SELECT ${OBJECT_COLUMNS} FROM chat_attachment_object
+            WHERE conversation_id=? AND sha256=? AND status='durable' LIMIT 1`,
+            [object.conversation_id, object.sha256],
+          );
+          if (duplicate !== undefined) return { kind: "reused", object: mapObject(duplicate) };
+
+          const conversationUsage = await store.get(
+            "SELECT COALESCE(SUM(byte_size),0) AS total FROM chat_attachment_object WHERE conversation_id=? AND status IN ('reserved','durable')",
+            [object.conversation_id],
+          );
+          if (Number(conversationUsage?.total ?? 0) + object.byte_size > limits.conversationBytes) {
+            return { kind: "storage_full", scope: "conversation" };
+          }
+          const athleteUsage = await store.get(
+            "SELECT COALESCE(SUM(byte_size),0) AS total FROM chat_attachment_object WHERE status IN ('reserved','durable')",
+          );
+          if (Number(athleteUsage?.total ?? 0) + object.byte_size > limits.athleteBytes) {
+            return { kind: "storage_full", scope: "athlete" };
+          }
+          await store.run(
+            `INSERT INTO chat_attachment_object (${OBJECT_COLUMNS}) VALUES (?,?,?,?,?,?,?,?,?,?)`,
+            [
+              object.id,
+              object.conversation_id,
+              object.conversation_key,
+              object.sha256,
+              object.byte_size,
+              object.relative_path,
+              object.status,
+              object.failure_code,
+              object.created_at_ms,
+              object.updated_at_ms,
+            ],
+          );
+          return { kind: "reserved", object };
+        }),
+      );
+    },
+
+    async commitAdmission({ objectId, attachment, draftUpdatedAtMs }) {
+      validateAttachment(attachment);
+      integer(draftUpdatedAtMs, "draft_updated_at_ms");
+      return store.transaction(async () => {
+        const object = await store.get(
+          `SELECT ${OBJECT_COLUMNS} FROM chat_attachment_object WHERE id=?`,
+          [objectId],
+        );
+        if (object === undefined)
+          throw new ChatAttachmentInvariantError("object_missing", "attachment object is missing");
+        const mapped = mapObject(object);
+        if (
+          mapped.conversation_id !== attachment.conversation_id ||
+          mapped.sha256 !== attachment.sha256 ||
+          mapped.byte_size !== attachment.byte_size
+        ) {
+          throw new ChatAttachmentInvariantError(
+            "object_mismatch",
+            "attachment metadata does not match its object",
+          );
+        }
+        if (mapped.status === "failed")
+          throw new ChatAttachmentInvariantError(
+            "object_failed",
+            "attachment object is unavailable",
+          );
+        if (mapped.status === "reserved") {
+          await store.run(
+            "UPDATE chat_attachment_object SET status='durable',updated_at_ms=? WHERE id=? AND status='reserved'",
+            [attachment.updated_at_ms, objectId],
+          );
+        }
+        await store.run(
+          `INSERT INTO chat_attachment (${ATTACHMENT_COLUMNS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+          [
+            attachment.id,
+            attachment.schema_version,
+            attachment.conversation_id,
+            attachment.object_id,
+            attachment.kind,
+            attachment.display_name,
+            attachment.media_type,
+            attachment.extension,
+            attachment.byte_size,
+            attachment.sha256,
+            attachment.status,
+            attachment.state_json,
+            attachment.message_id,
+            attachment.created_at_ms,
+            attachment.updated_at_ms,
+          ],
+        );
+        await store.run(
+          `INSERT INTO chat_attachment_draft (conversation_id,schema_version,text,state,updated_at_ms)
+           VALUES (?,1,'','active',?)
+           ON CONFLICT(conversation_id) DO UPDATE SET state='active',updated_at_ms=excluded.updated_at_ms`,
+          [attachment.conversation_id, draftUpdatedAtMs],
+        );
+        const occupied = new Set(
+          (
+            await store.all(
+              "SELECT ordinal FROM chat_attachment_draft_ref WHERE conversation_id=?",
+              [attachment.conversation_id],
+            )
+          ).map((row) => Number(row.ordinal)),
+        );
+        let ordinal = 0;
+        while (occupied.has(ordinal)) ordinal += 1;
+        await store.run(
+          "INSERT INTO chat_attachment_draft_ref(conversation_id,attachment_id,ordinal) VALUES (?,?,?)",
+          [attachment.conversation_id, attachment.id, ordinal],
+        );
+        return (await readDraft(store, attachment.conversation_id))!;
+      });
+    },
+
+    async failObject(objectId, failureCode, updatedAtMs) {
+      if (!SAFE_ID.test(objectId) || failureCode.length < 1 || failureCode.length > 128) {
+        throw new ChatAttachmentInvariantError(
+          "invalid_failure",
+          "attachment object failure is invalid",
+        );
+      }
+      integer(updatedAtMs, "updated_at_ms");
+      await store.transaction(async () => {
+        await store.run(
+          "UPDATE chat_attachment_object SET status='failed',failure_code=?,updated_at_ms=? WHERE id=?",
+          [failureCode, updatedAtMs, objectId],
+        );
+        await store.run(
+          `UPDATE chat_attachment SET status='failed',state_json=?,updated_at_ms=? WHERE object_id=?`,
+          [JSON.stringify({ stage: "storage", failureCode }), updatedAtMs, objectId],
+        );
+      });
+    },
+
+    async readObject(objectId) {
+      const row = await store.get(
+        `SELECT ${OBJECT_COLUMNS} FROM chat_attachment_object WHERE id=?`,
+        [objectId],
+      );
+      return row === undefined ? undefined : mapObject(row);
+    },
+
+    async readAttachment(attachmentId) {
+      const row = await store.get(`SELECT ${ATTACHMENT_COLUMNS} FROM chat_attachment WHERE id=?`, [
+        attachmentId,
+      ]);
+      return row === undefined ? undefined : mapAttachment(row);
+    },
+
+    readDraft: (conversationId) => readDraft(store, conversationId),
+
+    async saveDraftText({ conversationId, text, state, updatedAtMs }) {
+      if (conversationId.length < 1 || !DRAFT_STATES.has(state)) {
+        throw new ChatAttachmentInvariantError("invalid_draft", "attachment draft is invalid");
+      }
+      integer(updatedAtMs, "updated_at_ms");
+      return store.transaction(async () => {
+        const existing = await readDraft(store, conversationId);
+        if (text.length === 0 && (existing?.attachmentIds.length ?? 0) === 0) {
+          await store.run("DELETE FROM chat_attachment_draft WHERE conversation_id=?", [
+            conversationId,
+          ]);
+          return undefined;
+        }
+        await store.run(
+          `INSERT INTO chat_attachment_draft(conversation_id,schema_version,text,state,updated_at_ms)
+           VALUES (?,1,?,?,?)
+           ON CONFLICT(conversation_id) DO UPDATE SET text=excluded.text,state=excluded.state,updated_at_ms=excluded.updated_at_ms`,
+          [conversationId, text, state, updatedAtMs],
+        );
+        return readDraft(store, conversationId);
+      });
+    },
+
+    async removeDraftAttachment({ conversationId, attachmentId }) {
+      return store.transaction(async () => {
+        const attachment = await store.get(
+          `SELECT ${ATTACHMENT_COLUMNS} FROM chat_attachment WHERE id=? AND conversation_id=?`,
+          [attachmentId, conversationId],
+        );
+        if (attachment === undefined) return { draft: await readDraft(store, conversationId) };
+        const mapped = mapAttachment(attachment);
+        await store.run(
+          "DELETE FROM chat_attachment_draft_ref WHERE conversation_id=? AND attachment_id=?",
+          [conversationId, attachmentId],
+        );
+        const messageRef = await store.get(
+          "SELECT 1 AS present FROM chat_message_attachment WHERE attachment_id=? LIMIT 1",
+          [attachmentId],
+        );
+        let unreferencedObject: ChatAttachmentObjectRow | undefined;
+        if (messageRef === undefined) {
+          await store.run("DELETE FROM chat_attachment WHERE id=?", [attachmentId]);
+          const remaining = await store.get(
+            "SELECT 1 AS present FROM chat_attachment WHERE object_id=? LIMIT 1",
+            [mapped.object_id],
+          );
+          if (remaining === undefined) {
+            const object = await store.get(
+              `SELECT ${OBJECT_COLUMNS} FROM chat_attachment_object WHERE id=?`,
+              [mapped.object_id],
+            );
+            if (object !== undefined) {
+              unreferencedObject = mapObject(object);
+              await store.run("DELETE FROM chat_attachment_object WHERE id=?", [mapped.object_id]);
+            }
+          }
+        }
+        const draft = await readDraft(store, conversationId);
+        if (draft !== undefined && draft.text.length === 0 && draft.attachmentIds.length === 0) {
+          await store.run("DELETE FROM chat_attachment_draft WHERE conversation_id=?", [
+            conversationId,
+          ]);
+          return unreferencedObject === undefined ? {} : { unreferencedObject };
+        }
+        return {
+          ...(draft === undefined ? {} : { draft }),
+          ...(unreferencedObject === undefined ? {} : { unreferencedObject }),
+        };
+      });
+    },
+
+    async linkMessage({ conversationId, messageId, attachmentIds, createdAtMs }) {
+      if (
+        messageId.length < 1 ||
+        messageId.length > 512 ||
+        new Set(attachmentIds).size !== attachmentIds.length
+      ) {
+        throw new ChatAttachmentInvariantError(
+          "invalid_message_reference",
+          "message attachment reference is invalid",
+        );
+      }
+      integer(createdAtMs, "created_at_ms");
+      await store.transaction(async () => {
+        for (const [ordinal, attachmentId] of attachmentIds.entries()) {
+          const row = await store.get(
+            "SELECT 1 AS present FROM chat_attachment WHERE id=? AND conversation_id=?",
+            [attachmentId, conversationId],
+          );
+          if (row === undefined)
+            throw new ChatAttachmentInvariantError(
+              "attachment_missing",
+              "message attachment is missing",
+            );
+          await store.run(
+            `INSERT INTO chat_message_attachment(message_id,conversation_id,attachment_id,ordinal,created_at_ms)
+             VALUES (?,?,?,?,?) ON CONFLICT(message_id,attachment_id) DO NOTHING`,
+            [messageId, conversationId, attachmentId, ordinal, createdAtMs],
+          );
+        }
+      });
+    },
+
+    async listMessageAttachments(messageId) {
+      return (
+        await store.all(
+          `SELECT ${ATTACHMENT_COLUMNS.split(",")
+            .map((column) => `a.${column}`)
+            .join(",")}
+           FROM chat_message_attachment r JOIN chat_attachment a ON a.id=r.attachment_id
+          WHERE r.message_id=? ORDER BY r.ordinal ASC`,
+          [messageId],
+        )
+      ).map(mapAttachment);
+    },
+
+    async listObjects() {
+      return (
+        await store.all(
+          `SELECT ${OBJECT_COLUMNS} FROM chat_attachment_object ORDER BY created_at_ms,id`,
+        )
+      ).map(mapObject);
+    },
+
+    async markObjectMissing(objectId, updatedAtMs) {
+      await this.failObject(objectId, "managed_bytes_missing", updatedAtMs);
+    },
+
+    async cleanupConversation(conversationId) {
+      return store.transaction(async () => {
+        const objects = (
+          await store.all(
+            `SELECT ${OBJECT_COLUMNS} FROM chat_attachment_object WHERE conversation_id=? ORDER BY created_at_ms,id`,
+            [conversationId],
+          )
+        ).map(mapObject);
+        await store.run("DELETE FROM chat_message_attachment WHERE conversation_id=?", [
+          conversationId,
+        ]);
+        await store.run("DELETE FROM chat_attachment_draft WHERE conversation_id=?", [
+          conversationId,
+        ]);
+        await store.run("DELETE FROM chat_attachment WHERE conversation_id=?", [conversationId]);
+        await store.run("DELETE FROM chat_attachment_object WHERE conversation_id=?", [
+          conversationId,
+        ]);
+        return objects;
+      });
+    },
+
+    async hasObject(objectId) {
+      return (
+        (await store.get("SELECT 1 AS present FROM chat_attachment_object WHERE id=?", [
+          objectId,
+        ])) !== undefined
+      );
+    },
+
+    async deleteFailedObject(objectId) {
+      await store.run(
+        `DELETE FROM chat_attachment_object WHERE id=? AND status='failed'
+          AND NOT EXISTS (SELECT 1 FROM chat_attachment WHERE object_id=?)`,
+        [objectId, objectId],
+      );
+    },
+  };
+}

--- a/packages/kernel/src/chat-attachments/types.ts
+++ b/packages/kernel/src/chat-attachments/types.ts
@@ -1,0 +1,114 @@
+export type ChatAttachmentKind = "document" | "activity" | "workout" | "image";
+export type ChatAttachmentStatus =
+  | "preprocessing"
+  | "blocked"
+  | "failed"
+  | "ready"
+  | "importing"
+  | "imported"
+  | "sent";
+export type ChatAttachmentDraftState = "active" | "restored" | "submitting" | "clearing";
+
+export interface ChatAttachmentCapacityLimits {
+  readonly attachmentsPerMessage: number;
+  readonly messageBytes: number;
+  readonly conversationBytes: number;
+  readonly athleteBytes: number;
+}
+
+export interface ChatAttachmentObjectRow {
+  readonly id: string;
+  readonly conversation_id: string;
+  readonly conversation_key: string;
+  readonly sha256: string;
+  readonly byte_size: number;
+  readonly relative_path: string;
+  readonly status: "reserved" | "durable" | "failed";
+  readonly failure_code: string | null;
+  readonly created_at_ms: number;
+  readonly updated_at_ms: number;
+}
+
+export interface ChatAttachmentRow {
+  readonly id: string;
+  readonly schema_version: 1;
+  readonly conversation_id: string;
+  readonly object_id: string;
+  readonly kind: ChatAttachmentKind;
+  readonly display_name: string;
+  readonly media_type: string;
+  readonly extension: string;
+  readonly byte_size: number;
+  readonly sha256: string;
+  readonly status: ChatAttachmentStatus;
+  readonly state_json: string | null;
+  readonly message_id: string | null;
+  readonly created_at_ms: number;
+  readonly updated_at_ms: number;
+}
+
+export interface ChatAttachmentDraft {
+  readonly schemaVersion: 1;
+  readonly conversationId: string;
+  readonly text: string;
+  readonly attachmentIds: readonly string[];
+  readonly state: ChatAttachmentDraftState;
+  readonly updatedAtMs: number;
+}
+
+export type ChatAttachmentObjectReservation =
+  | { readonly kind: "reserved"; readonly object: ChatAttachmentObjectRow }
+  | { readonly kind: "reused"; readonly object: ChatAttachmentObjectRow }
+  | { readonly kind: "message_limit" }
+  | { readonly kind: "storage_full"; readonly scope: "conversation" | "athlete" };
+
+export interface ChatAttachmentRepository {
+  reserveObject(input: {
+    readonly object: ChatAttachmentObjectRow;
+    readonly limits: ChatAttachmentCapacityLimits;
+  }): Promise<ChatAttachmentObjectReservation>;
+  commitAdmission(input: {
+    readonly objectId: string;
+    readonly attachment: ChatAttachmentRow;
+    readonly draftUpdatedAtMs: number;
+  }): Promise<ChatAttachmentDraft>;
+  failObject(objectId: string, failureCode: string, updatedAtMs: number): Promise<void>;
+  readObject(objectId: string): Promise<ChatAttachmentObjectRow | undefined>;
+  readAttachment(attachmentId: string): Promise<ChatAttachmentRow | undefined>;
+  readDraft(conversationId: string): Promise<ChatAttachmentDraft | undefined>;
+  saveDraftText(input: {
+    readonly conversationId: string;
+    readonly text: string;
+    readonly state: ChatAttachmentDraftState;
+    readonly updatedAtMs: number;
+  }): Promise<ChatAttachmentDraft | undefined>;
+  removeDraftAttachment(input: {
+    readonly conversationId: string;
+    readonly attachmentId: string;
+  }): Promise<{
+    readonly draft?: ChatAttachmentDraft;
+    readonly unreferencedObject?: ChatAttachmentObjectRow;
+  }>;
+  linkMessage(input: {
+    readonly conversationId: string;
+    readonly messageId: string;
+    readonly attachmentIds: readonly string[];
+    readonly createdAtMs: number;
+  }): Promise<void>;
+  listMessageAttachments(messageId: string): Promise<readonly ChatAttachmentRow[]>;
+  listObjects(): Promise<readonly ChatAttachmentObjectRow[]>;
+  markObjectMissing(objectId: string, updatedAtMs: number): Promise<void>;
+  cleanupConversation(conversationId: string): Promise<readonly ChatAttachmentObjectRow[]>;
+  hasObject(objectId: string): Promise<boolean>;
+  deleteFailedObject(objectId: string): Promise<void>;
+}
+
+export class ChatAttachmentInvariantError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ChatAttachmentInvariantError";
+  }
+}

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -18,3 +18,4 @@ export * from "./sync-state-repository.js";
 export * from "./sync-failure-repository.js";
 export * from "./units-preference-repository.js";
 export * from "../planning/index.js";
+export * from "../chat-attachments/index.js";

--- a/packages/kernel/src/store/migrations/013_chat_attachments.sql
+++ b/packages/kernel/src/store/migrations/013_chat_attachments.sql
@@ -1,0 +1,94 @@
+CREATE TABLE chat_attachment_object (
+  id                TEXT PRIMARY KEY CHECK (length(id) BETWEEN 1 AND 128),
+  conversation_id   TEXT NOT NULL CHECK (length(conversation_id) BETWEEN 1 AND 512),
+  conversation_key  TEXT NOT NULL CHECK (
+    length(conversation_key) = 64 AND conversation_key NOT GLOB '*[^0-9a-f]*'
+  ),
+  sha256            TEXT NOT NULL CHECK (
+    length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*'
+  ),
+  byte_size         INTEGER NOT NULL CHECK (byte_size > 0),
+  relative_path     TEXT NOT NULL CHECK (
+    length(relative_path) BETWEEN 1 AND 512
+    AND relative_path NOT LIKE '/%'
+    AND relative_path NOT LIKE '%\\%'
+    AND relative_path NOT LIKE '%..%'
+  ),
+  status            TEXT NOT NULL CHECK (status IN ('reserved','durable','failed')),
+  failure_code      TEXT,
+  created_at_ms     INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  updated_at_ms     INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+  CHECK (
+    (status = 'failed' AND failure_code IS NOT NULL)
+    OR (status != 'failed' AND failure_code IS NULL)
+  )
+) STRICT, WITHOUT ROWID;
+
+CREATE INDEX idx_chat_attachment_object_capacity
+  ON chat_attachment_object (conversation_id, status, byte_size);
+CREATE UNIQUE INDEX idx_chat_attachment_object_live_digest
+  ON chat_attachment_object (conversation_id, sha256)
+  WHERE status IN ('reserved','durable');
+
+CREATE TABLE chat_attachment (
+  id                TEXT PRIMARY KEY CHECK (length(id) BETWEEN 1 AND 128),
+  schema_version    INTEGER NOT NULL CHECK (schema_version = 1),
+  conversation_id   TEXT NOT NULL CHECK (length(conversation_id) BETWEEN 1 AND 512),
+  object_id         TEXT NOT NULL REFERENCES chat_attachment_object(id) ON DELETE RESTRICT,
+  kind              TEXT NOT NULL CHECK (kind IN ('document','activity','workout','image')),
+  display_name      TEXT NOT NULL CHECK (length(display_name) BETWEEN 1 AND 512),
+  media_type        TEXT NOT NULL CHECK (length(media_type) BETWEEN 1 AND 256),
+  extension         TEXT NOT NULL CHECK (
+    extension IN ('pdf','txt','csv','docx','fit','tcx','gpx','zwo','mrc','erg','png','jpg','jpeg','webp')
+  ),
+  byte_size         INTEGER NOT NULL CHECK (byte_size > 0),
+  sha256            TEXT NOT NULL CHECK (
+    length(sha256) = 64 AND sha256 NOT GLOB '*[^0-9a-f]*'
+  ),
+  status            TEXT NOT NULL CHECK (
+    status IN ('preprocessing','blocked','failed','ready','importing','imported','sent')
+  ),
+  state_json        TEXT CHECK (state_json IS NULL OR json_valid(state_json)),
+  message_id        TEXT,
+  created_at_ms     INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  updated_at_ms     INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+  UNIQUE (conversation_id, id)
+) STRICT, WITHOUT ROWID;
+
+CREATE INDEX idx_chat_attachment_conversation
+  ON chat_attachment (conversation_id, created_at_ms, id);
+CREATE INDEX idx_chat_attachment_object
+  ON chat_attachment (object_id);
+
+CREATE TABLE chat_attachment_draft (
+  conversation_id   TEXT PRIMARY KEY CHECK (length(conversation_id) BETWEEN 1 AND 512),
+  schema_version    INTEGER NOT NULL CHECK (schema_version = 1),
+  text              TEXT NOT NULL,
+  state             TEXT NOT NULL CHECK (state IN ('active','restored','submitting','clearing')),
+  updated_at_ms     INTEGER NOT NULL CHECK (updated_at_ms >= 0)
+) STRICT, WITHOUT ROWID;
+
+CREATE TABLE chat_attachment_draft_ref (
+  conversation_id   TEXT NOT NULL REFERENCES chat_attachment_draft(conversation_id) ON DELETE CASCADE,
+  attachment_id     TEXT NOT NULL,
+  ordinal           INTEGER NOT NULL CHECK (ordinal BETWEEN 0 AND 4),
+  PRIMARY KEY (conversation_id, attachment_id),
+  UNIQUE (conversation_id, ordinal),
+  FOREIGN KEY (conversation_id, attachment_id)
+    REFERENCES chat_attachment(conversation_id, id) ON DELETE CASCADE
+) STRICT, WITHOUT ROWID;
+
+CREATE TABLE chat_message_attachment (
+  message_id        TEXT NOT NULL CHECK (length(message_id) BETWEEN 1 AND 512),
+  conversation_id   TEXT NOT NULL CHECK (length(conversation_id) BETWEEN 1 AND 512),
+  attachment_id     TEXT NOT NULL,
+  ordinal           INTEGER NOT NULL CHECK (ordinal BETWEEN 0 AND 4),
+  created_at_ms     INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  PRIMARY KEY (message_id, attachment_id),
+  UNIQUE (message_id, ordinal),
+  FOREIGN KEY (conversation_id, attachment_id)
+    REFERENCES chat_attachment(conversation_id, id) ON DELETE CASCADE
+) STRICT, WITHOUT ROWID;
+
+CREATE INDEX idx_chat_message_attachment_conversation
+  ON chat_message_attachment (conversation_id, message_id, ordinal);

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -10,6 +10,7 @@ import activitySourceResolver009 from "./009_activity_source_resolver.sql";
 import analyticsCurves010 from "./010_analytics_curves.sql";
 import activityAnalysisProjection011 from "./011_activity_analysis_projection.sql";
 import plan012 from "./012_plan.sql";
+import chatAttachments013 from "./013_chat_attachments.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -37,4 +38,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 10, name: "010_analytics_curves", sql: analyticsCurves010 },
   { version: 11, name: "011_activity_analysis_projection", sql: activityAnalysisProjection011 },
   { version: 12, name: "012_plan", sql: plan012 },
+  { version: 13, name: "013_chat_attachments", sql: chatAttachments013 },
 ];

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -53,6 +53,11 @@ const EXPECTED_FULL_TABLES = [
   "activity_analysis_projection",
   "plan",
   "plan_workout",
+  "chat_attachment_object",
+  "chat_attachment",
+  "chat_attachment_draft",
+  "chat_attachment_draft_ref",
+  "chat_message_attachment",
 ];
 const MIGRATION_002 = `ALTER TABLE swim_length ADD COLUMN distance_m REAL;
 
@@ -174,6 +179,7 @@ describe("001_init migration", () => {
       { version: 10, name: "010_analytics_curves" },
       { version: 11, name: "011_activity_analysis_projection" },
       { version: 12, name: "012_plan" },
+      { version: 13, name: "013_chat_attachments" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -275,7 +281,7 @@ describe("001_init migration", () => {
       .map((row) => row.name)
       .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
-    expect(names).toHaveLength(44);
+    expect(names).toHaveLength(49);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
@@ -787,8 +793,9 @@ describe("001_init migration", () => {
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_failure");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("store_owner");
-    expect(DUMP_TABLES.map(({ table }) => String(table)))
-      .not.toContain("analytics_curve_refresh_failure");
+    expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain(
+      "analytics_curve_refresh_failure",
+    );
     for (const table of [
       "analytics_curve_current",
       "analytics_curve_evidence",
@@ -851,14 +858,18 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     );
     const columns = db.prepare("PRAGMA table_info(store_owner)").all();
     expect(columns).toContainEqual(expect.objectContaining({ name: "singleton", pk: 1 }));
-    expect(columns).toContainEqual(expect.objectContaining({ name: "account_fingerprint", notnull: 1 }));
+    expect(columns).toContainEqual(
+      expect.objectContaining({ name: "account_fingerprint", notnull: 1 }),
+    );
     expect(() =>
       db!
         .prepare("INSERT INTO store_owner(singleton,account_fingerprint) VALUES(1,?)")
         .run("a".repeat(64)),
     ).not.toThrow();
     expect(() => db!.prepare("INSERT INTO store_owner VALUES(2,?)").run("b".repeat(64))).toThrow();
-    expect(() => db!.prepare("UPDATE store_owner SET account_fingerprint=?").run("b".repeat(64))).toThrow();
+    expect(() =>
+      db!.prepare("UPDATE store_owner SET account_fingerprint=?").run("b".repeat(64)),
+    ).toThrow();
     expect(() => db!.prepare("DELETE FROM store_owner").run()).toThrow();
   });
 
@@ -867,9 +878,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     expect(createHash("sha256").update(MIGRATIONS[8]!.sql).digest("hex")).toBe(
       "4fe2e7648bbb09ad62c60a86e26ac4a9e09f4c0e24882428e12ad8722f3d420c",
     );
-    expect(
-      db.prepare("PRAGMA index_info(idx_source_record_session_source)").all(),
-    ).toEqual([
+    expect(db.prepare("PRAGMA index_info(idx_source_record_session_source)").all()).toEqual([
       expect.objectContaining({ seqno: 0, name: "session_key" }),
       expect.objectContaining({ seqno: 1, name: "source" }),
       expect.objectContaining({ seqno: 2, name: "id" }),
@@ -905,24 +914,54 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     expect(createHash("sha256").update(MIGRATIONS[10]!.sql).digest("hex")).toBe(
       "b9c22b99343093655536059e68c1846b5deb8b77355a08e38013d807906e300e",
     );
-    const table = db.prepare("PRAGMA table_list").all().find(
-      (row) => (row as { name?: unknown }).name === "activity_analysis_projection",
-    ) as { strict: number; wr: number } | undefined;
+    const table = db
+      .prepare("PRAGMA table_list")
+      .all()
+      .find((row) => (row as { name?: unknown }).name === "activity_analysis_projection") as
+      | { strict: number; wr: number }
+      | undefined;
     expect(table).toMatchObject({ strict: 1, wr: 1 });
-    expect(db.prepare("PRAGMA foreign_key_list(activity_analysis_projection)").all())
-      .toContainEqual(expect.objectContaining({ table: "session", on_delete: "CASCADE" }));
-    expect(db.prepare("PRAGMA index_info(idx_activity_analysis_projection_lru)").all())
-      .toEqual([
-        expect.objectContaining({ seqno: 0, name: "accessed_epoch_s" }),
-        expect.objectContaining({ seqno: 1, name: "canonical_activity_id" }),
-        expect.objectContaining({ seqno: 2, name: "source_revision" }),
-        expect.objectContaining({ seqno: 3, name: "contract_version" }),
-        expect.objectContaining({ seqno: 4, name: "section" }),
-      ]);
-    expect(DUMP_TABLES.map(({ table: name }) => name)).toContain(
-      "activity_analysis_projection",
-    );
+    expect(
+      db.prepare("PRAGMA foreign_key_list(activity_analysis_projection)").all(),
+    ).toContainEqual(expect.objectContaining({ table: "session", on_delete: "CASCADE" }));
+    expect(db.prepare("PRAGMA index_info(idx_activity_analysis_projection_lru)").all()).toEqual([
+      expect.objectContaining({ seqno: 0, name: "accessed_epoch_s" }),
+      expect.objectContaining({ seqno: 1, name: "canonical_activity_id" }),
+      expect.objectContaining({ seqno: 2, name: "source_revision" }),
+      expect.objectContaining({ seqno: 3, name: "contract_version" }),
+      expect.objectContaining({ seqno: 4, name: "section" }),
+    ]);
+    expect(DUMP_TABLES.map(({ table: name }) => name)).toContain("activity_analysis_projection");
     expect(DERIVED_TABLES).not.toContain("activity_analysis_projection");
+  });
+
+  it("adds strict conversation-owned attachment storage", () => {
+    db = openFull();
+    const tables = db.prepare("PRAGMA table_list").all() as Array<{
+      name: string;
+      strict: number;
+      wr: number;
+    }>;
+    for (const name of [
+      "chat_attachment_object",
+      "chat_attachment",
+      "chat_attachment_draft",
+      "chat_attachment_draft_ref",
+      "chat_message_attachment",
+    ]) {
+      expect(tables.find((row) => row.name === name)).toMatchObject({ strict: 1, wr: 1 });
+    }
+    const indexes = new Set(
+      (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='index'").all() as Array<{
+          name: string;
+        }>
+      ).map(({ name }) => name),
+    );
+    expect(indexes).toContain("idx_chat_attachment_object_live_digest");
+    expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("chat_attachment");
+    expect(PURE_AUTHORED_TABLES).not.toContain("chat_attachment" as never);
   });
 
   it("omits the unreleased prior bone-stress column from the baseline schema", () => {


### PR DESCRIPTION
## Summary

- add migration 013 for conversation-owned attachment objects, drafts, and message references
- add private managed-byte storage with format admission, quota reservation, digest reuse, and crash reconciliation
- wire durable attachment admission into Coach composition while preserving drafts on rejection or storage failure
- cover relaunch recovery, cleanup, source mutation, permissions, quota races, and migration behavior

## Verification

- `pnpm check`
- `pnpm test` — 624 files passed, 5 skipped; 9,678 tests passed, 15 skipped
- focused attachment/migration suite — 46 tests passed
- `autoreview --mode local` — clean, no accepted/actionable findings; TruffleHog clean

## Scope

ATT-02 only: durable managed storage and stable attachment identities. Renderer UI, document readers, workout/activity parsing, and Chat ↔ Plan handoffs remain in later Gate 3 child PRs.
