### PR TITLE
feat(chat): import activity attachments on send

### DIFF
--- a/packages/coach/src/activity-attachment-operations.ts
+++ b/packages/coach/src/activity-attachment-operations.ts
@@ -1,0 +1,407 @@
+import { createHash } from "node:crypto";
+import type {
+  ChatAttachmentActivitySummary,
+  ChatAttachmentTurnPort,
+  ChatAttachmentTurnPreparation,
+} from "@enduragent/engine";
+import { readRepairFixerSettings, type ImportReport } from "@enduragent/kernel/ingest";
+import type {
+  ChatAttachmentObjectRow,
+  ChatAttachmentRepository,
+  ChatAttachmentRow,
+  CanonicalActivityProjection,
+  FailedChatAttachmentProjection,
+  ParsedActivityProjection,
+  SqlStore,
+} from "@enduragent/kernel/store";
+import {
+  MANAGED_ACTIVITY_PARSER_VERSION,
+  ManagedActivityReaderError,
+  type ManagedActivityExtension,
+  type ManagedActivityReader,
+  type ManagedActivitySource,
+} from "@enduragent/kernel-node/chat-attachments";
+import type { NodeImportRuntime } from "@enduragent/kernel-node/ingest";
+
+export class ActivityAttachmentTurnError extends Error {
+  constructor(readonly code: string) {
+    super("completed activity attachment could not be prepared");
+    this.name = "ActivityAttachmentTurnError";
+  }
+}
+
+export class ActivityAttachmentInterruption extends Error {
+  constructor(readonly checkpoint: string) {
+    super("simulated activity attachment interruption");
+    this.name = "ActivityAttachmentInterruption";
+  }
+}
+
+export interface ActivityAttachmentHooks {
+  readonly beforeMessageLink?: (messageId: string) => Promise<void> | void;
+  readonly beforeImport?: (attachmentId: string) => Promise<void> | void;
+  readonly afterImport?: (attachmentId: string, report: ImportReport) => Promise<void> | void;
+  readonly beforeCoachStart?: (activityIds: readonly string[]) => Promise<void> | void;
+}
+
+export interface ActivityAttachmentOperations {
+  readonly turnPort: ChatAttachmentTurnPort;
+  preprocessAdmitted(input: {
+    readonly attachment: ChatAttachmentRow;
+    readonly object: ChatAttachmentObjectRow;
+  }): Promise<void>;
+}
+
+export interface ActivityAttachmentOperationsInput {
+  readonly repository: ChatAttachmentRepository;
+  readonly reader: ManagedActivityReader;
+  readonly importer: NodeImportRuntime;
+  readonly store: SqlStore;
+  readonly runExclusive: <T>(work: () => Promise<T>) => Promise<T>;
+  readonly now?: () => number;
+  readonly hooks?: ActivityAttachmentHooks;
+}
+
+const ACTIVITY_EXTENSIONS = new Set<ManagedActivityExtension>(["fit", "tcx", "gpx"]);
+
+function json(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function parseObject(value: string | null): Record<string, unknown> {
+  if (value === null) throw new ActivityAttachmentTurnError("attachment_state_missing");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new ActivityAttachmentTurnError("attachment_state_invalid");
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ActivityAttachmentTurnError("attachment_state_invalid");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parsedProjection(attachment: ChatAttachmentRow): ParsedActivityProjection {
+  if (!ACTIVITY_EXTENSIONS.has(attachment.extension as ManagedActivityExtension)) {
+    throw new ActivityAttachmentTurnError("activity_extension_invalid");
+  }
+  const state = attachment.state_json === null ? undefined : parseObject(attachment.state_json);
+  if (state?.kind === "parsed-activity") {
+    if (
+      state.parsedActivityId !== attachment.sha256 ||
+      state.sourceFormat !== attachment.extension ||
+      typeof state.parserVersion !== "string" ||
+      state.parserVersion.length < 1
+    ) {
+      throw new ActivityAttachmentTurnError("activity_projection_invalid");
+    }
+    return state as unknown as ParsedActivityProjection;
+  }
+  return {
+    kind: "parsed-activity",
+    parsedActivityId: attachment.sha256,
+    sourceFormat: attachment.extension as ManagedActivityExtension,
+    parserVersion: MANAGED_ACTIVITY_PARSER_VERSION,
+  };
+}
+
+function canonicalProjection(attachment: ChatAttachmentRow): CanonicalActivityProjection {
+  const state = parseObject(attachment.state_json);
+  if (
+    state.kind !== "canonical-activity" ||
+    typeof state.importId !== "string" ||
+    state.importId.length < 1 ||
+    !Array.isArray(state.activityIds) ||
+    state.activityIds.length < 1 ||
+    state.activityIds.some((id) => typeof id !== "string" || id.length < 1)
+  ) {
+    throw new ActivityAttachmentTurnError("canonical_activity_projection_invalid");
+  }
+  return state as unknown as CanonicalActivityProjection;
+}
+
+function source(
+  attachment: ChatAttachmentRow,
+  object: ChatAttachmentObjectRow,
+): ManagedActivitySource {
+  if (
+    attachment.kind !== "activity" ||
+    object.id !== attachment.object_id ||
+    object.status !== "durable" ||
+    object.sha256 !== attachment.sha256 ||
+    object.byte_size !== attachment.byte_size ||
+    !ACTIVITY_EXTENSIONS.has(attachment.extension as ManagedActivityExtension)
+  ) {
+    throw new ActivityAttachmentTurnError("activity_source_invalid");
+  }
+  return {
+    objectId: object.id,
+    relativePath: object.relative_path,
+    displayName: attachment.display_name,
+    byteSize: object.byte_size,
+    sha256: object.sha256,
+    extension: attachment.extension as ManagedActivityExtension,
+  };
+}
+
+function importId(attachmentId: string, messageId: string): string {
+  return createHash("sha256")
+    .update("chat-activity-import\0", "utf8")
+    .update(attachmentId, "utf8")
+    .update("\0", "utf8")
+    .update(messageId, "utf8")
+    .digest("hex");
+}
+
+function failureCode(error: unknown): string {
+  if (error instanceof ManagedActivityReaderError) return error.reason;
+  if (error instanceof ActivityAttachmentTurnError) return error.code;
+  return "activity_import_failed";
+}
+
+export function createActivityAttachmentOperations(
+  input: ActivityAttachmentOperationsInput,
+): ActivityAttachmentOperations {
+  const now = input.now ?? Date.now;
+
+  const preprocess = async (
+    attachment: ChatAttachmentRow,
+    object: ChatAttachmentObjectRow,
+  ): Promise<ChatAttachmentRow> => {
+    if (attachment.kind !== "activity") return attachment;
+    if (attachment.status !== "preprocessing") return attachment;
+    try {
+      const result = await input.reader.read(
+        source(attachment, object),
+        await readRepairFixerSettings(input.store),
+      );
+      if (result.outcome === "quarantined") {
+        return input.repository.transitionAttachment({
+          conversationId: attachment.conversation_id,
+          attachmentId: attachment.id,
+          from: ["preprocessing"],
+          to: "failed",
+          stateJson: json({
+            stage: "parsing",
+            failureCode: result.code,
+          } satisfies FailedChatAttachmentProjection),
+          messageId: null,
+          updatedAtMs: now(),
+        });
+      }
+      return input.repository.transitionAttachment({
+        conversationId: attachment.conversation_id,
+        attachmentId: attachment.id,
+        from: ["preprocessing"],
+        to: "ready",
+        stateJson: json(result.projection),
+        messageId: null,
+        updatedAtMs: now(),
+      });
+    } catch (error) {
+      return input.repository.transitionAttachment({
+        conversationId: attachment.conversation_id,
+        attachmentId: attachment.id,
+        from: ["preprocessing"],
+        to: "failed",
+        stateJson: json({
+          stage: "parsing",
+          failureCode: failureCode(error),
+        } satisfies FailedChatAttachmentProjection),
+        messageId: null,
+        updatedAtMs: now(),
+      });
+    }
+  };
+
+  const activityIdsForReport = async (
+    report: ImportReport,
+    sha256: string,
+  ): Promise<readonly string[]> => {
+    const ids: string[] = [];
+    for (const cluster of report.clusters) {
+      if (!cluster.members.includes(sha256)) continue;
+      for (const row of await input.store.all(
+        "SELECT session_key FROM session WHERE workout_key=? ORDER BY session_seq,session_key",
+        [cluster.workout_key],
+      )) {
+        const id = String(row.session_key);
+        if (!ids.includes(id)) ids.push(id);
+      }
+    }
+    if (ids.length === 0) throw new ActivityAttachmentTurnError("canonical_activity_missing");
+    return ids;
+  };
+
+  const summarize = async (
+    attachment: ChatAttachmentRow,
+    projection: CanonicalActivityProjection,
+  ): Promise<ChatAttachmentActivitySummary> => {
+    const sessions: ChatAttachmentActivitySummary["sessions"][number][] = [];
+    for (const activityId of projection.activityIds) {
+      const row = await input.store.get(
+        `SELECT session_key,sport,start_utc,elapsed_s,distance_m
+           FROM session WHERE session_key=?`,
+        [activityId],
+      );
+      if (row === undefined) throw new ActivityAttachmentTurnError("canonical_activity_missing");
+      sessions.push({
+        activityId: String(row.session_key),
+        sport: String(row.sport),
+        startUtc: Number(row.start_utc),
+        elapsedSeconds: row.elapsed_s === null ? null : Number(row.elapsed_s),
+        distanceMeters: row.distance_m === null ? null : Number(row.distance_m),
+      });
+    }
+    if (attachment.message_id === null) {
+      throw new ActivityAttachmentTurnError("attachment_message_missing");
+    }
+    return {
+      attachmentId: attachment.id,
+      messageId: attachment.message_id,
+      activityIds: projection.activityIds,
+      sessions,
+    };
+  };
+
+  const ensureImported = async (
+    initial: ChatAttachmentRow,
+    messageId: string,
+  ): Promise<ChatAttachmentActivitySummary> => {
+    let attachment = initial;
+    if (attachment.kind !== "activity") {
+      throw new ActivityAttachmentTurnError("attachment_kind_invalid");
+    }
+    if (attachment.status === "preprocessing") {
+      const object = await input.repository.readObject(attachment.object_id);
+      if (object === undefined) throw new ActivityAttachmentTurnError("activity_source_missing");
+      attachment = await preprocess(attachment, object);
+    }
+    if (attachment.status === "failed") {
+      const state = parseObject(attachment.state_json);
+      if (state.stage !== "import") {
+        throw new ActivityAttachmentTurnError(String(state.failureCode ?? "activity_parse_failed"));
+      }
+    }
+    if (attachment.status === "ready" || attachment.status === "failed") {
+      const projection = parsedProjection(attachment);
+      attachment = await input.repository.transitionAttachment({
+        conversationId: attachment.conversation_id,
+        attachmentId: attachment.id,
+        from: ["ready", "failed"],
+        to: "importing",
+        stateJson: json(projection),
+        messageId,
+        updatedAtMs: now(),
+      });
+    }
+    if (attachment.message_id !== messageId) {
+      throw new ActivityAttachmentTurnError("attachment_message_conflict");
+    }
+    if (attachment.status === "importing") {
+      const object = await input.repository.readObject(attachment.object_id);
+      if (object === undefined) throw new ActivityAttachmentTurnError("activity_source_missing");
+      try {
+        await input.hooks?.beforeImport?.(attachment.id);
+        const prepared = await input.reader.read(
+          source(attachment, object),
+          await readRepairFixerSettings(input.store),
+        );
+        if (prepared.outcome === "quarantined") {
+          throw new ActivityAttachmentTurnError(prepared.code);
+        }
+        const report = await input.importer.importBatchWithPreparation(
+          { files: [prepared.artifact], platform_records: [] },
+          async () => prepared.prepared,
+        );
+        await input.hooks?.afterImport?.(attachment.id, report);
+        const projection: CanonicalActivityProjection = {
+          kind: "canonical-activity",
+          importId: importId(attachment.id, messageId),
+          activityIds: await activityIdsForReport(report, attachment.sha256),
+        };
+        attachment = await input.repository.transitionAttachment({
+          conversationId: attachment.conversation_id,
+          attachmentId: attachment.id,
+          from: ["importing"],
+          to: "imported",
+          stateJson: json(projection),
+          messageId,
+          updatedAtMs: now(),
+        });
+      } catch (error) {
+        if (error instanceof ActivityAttachmentInterruption) throw error;
+        await input.repository.transitionAttachment({
+          conversationId: attachment.conversation_id,
+          attachmentId: attachment.id,
+          from: ["importing"],
+          to: "failed",
+          stateJson: json({
+            stage: "import",
+            failureCode: failureCode(error),
+          } satisfies FailedChatAttachmentProjection),
+          messageId,
+          updatedAtMs: now(),
+        });
+        throw error;
+      }
+    }
+    if (attachment.status !== "imported" && attachment.status !== "sent") {
+      throw new ActivityAttachmentTurnError("activity_import_incomplete");
+    }
+    return summarize(attachment, canonicalProjection(attachment));
+  };
+
+  const turnPort: ChatAttachmentTurnPort = {
+    prepareQueuedTurn: (request): Promise<ChatAttachmentTurnPreparation> =>
+      input.runExclusive(async () => {
+        const activities: ChatAttachmentActivitySummary[] = [];
+        for (const message of request.messages) {
+          await input.hooks?.beforeMessageLink?.(message.messageId);
+          await input.repository.linkMessage({
+            conversationId: request.chatId,
+            messageId: message.messageId,
+            attachmentIds: message.attachmentIds,
+            createdAtMs: now(),
+          });
+          for (const attachment of await input.repository.listMessageAttachments(
+            message.messageId,
+          )) {
+            if (attachment.kind === "activity") {
+              activities.push(await ensureImported(attachment, message.messageId));
+            }
+          }
+        }
+        await input.hooks?.beforeCoachStart?.(
+          activities.flatMap((activity) => activity.activityIds),
+        );
+        return { activities };
+      }),
+    completeQueuedTurn: (request) =>
+      input.runExclusive(async () => {
+        for (const messageId of request.messageIds) {
+          for (const attachment of await input.repository.listMessageAttachments(messageId)) {
+            if (attachment.kind !== "activity" || attachment.status === "sent") continue;
+            if (attachment.status !== "imported") {
+              throw new ActivityAttachmentTurnError("activity_import_incomplete");
+            }
+            await input.repository.transitionAttachment({
+              conversationId: request.chatId,
+              attachmentId: attachment.id,
+              from: ["imported"],
+              to: "sent",
+              stateJson: attachment.state_json,
+              messageId,
+              updatedAtMs: now(),
+            });
+          }
+        }
+      }),
+  };
+
+  return {
+    turnPort,
+    preprocessAdmitted: ({ attachment, object }) => preprocess(attachment, object).then(() => {}),
+  };
+}

--- a/packages/coach/src/attachment-operations.ts
+++ b/packages/coach/src/attachment-operations.ts
@@ -6,6 +6,7 @@ import {
   type AttachmentAdmissionReadModel,
 } from "@enduragent/coach-contract";
 import type { ChatAttachmentRepository } from "@enduragent/kernel/store";
+import type { ChatAttachmentObjectRow, ChatAttachmentRow } from "@enduragent/kernel/store";
 import {
   ManagedAttachmentSourceError,
   chatAttachmentRelativePath,
@@ -42,6 +43,10 @@ export interface ManagedChatAttachmentOperationsInput {
   readonly runExclusive: <T>(work: () => Promise<T>) => Promise<T>;
   readonly now?: () => number;
   readonly randomId?: () => string;
+  readonly onAdmitted?: (input: {
+    readonly attachment: ChatAttachmentRow;
+    readonly object: ChatAttachmentObjectRow;
+  }) => Promise<void>;
 }
 
 const CAPACITY_LIMITS = {
@@ -159,26 +164,27 @@ export function createManagedChatAttachmentOperations(
           }
         }
 
+        const attachment: ChatAttachmentRow = {
+          id: attachmentId,
+          schema_version: 1,
+          conversation_id: request.chatId,
+          object_id: object.id,
+          kind: source.kind,
+          display_name: source.displayName,
+          media_type: source.mediaType,
+          extension: source.extension,
+          byte_size: source.byteSize,
+          sha256: source.sha256,
+          status: "preprocessing",
+          state_json: null,
+          message_id: null,
+          created_at_ms: createdAtMs,
+          updated_at_ms: now(),
+        };
         try {
           await input.repository.commitAdmission({
             objectId: object.id,
-            attachment: {
-              id: attachmentId,
-              schema_version: 1,
-              conversation_id: request.chatId,
-              object_id: object.id,
-              kind: source.kind,
-              display_name: source.displayName,
-              media_type: source.mediaType,
-              extension: source.extension,
-              byte_size: source.byteSize,
-              sha256: source.sha256,
-              status: "preprocessing",
-              state_json: null,
-              message_id: null,
-              created_at_ms: createdAtMs,
-              updated_at_ms: now(),
-            },
+            attachment,
             draftUpdatedAtMs: now(),
           });
         } catch {
@@ -195,6 +201,10 @@ export function createManagedChatAttachmentOperations(
             failureCode: "storage_failed",
             retryable: true,
           });
+        }
+        const durableObject = await input.repository.readObject(object.id);
+        if (durableObject !== undefined) {
+          await input.onAdmitted?.({ attachment, object: durableObject }).catch(() => {});
         }
         return AttachmentAdmissionReadModelSchema.parse({
           selectionId: request.selectionId,

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -67,7 +67,10 @@ import {
 } from "@enduragent/kernel/store";
 import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
 import { createAuthoredIdentity, type AthleteHome } from "@enduragent/kernel-node/home";
-import { createManagedChatAttachmentStore } from "@enduragent/kernel-node/chat-attachments";
+import {
+  createManagedActivityReader,
+  createManagedChatAttachmentStore,
+} from "@enduragent/kernel-node/chat-attachments";
 import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import type { CoachStoreWriterContext } from "./runtime.js";
 import {
@@ -150,6 +153,7 @@ import { createTrainingExportService } from "./training-export.js";
 import { serializeBoundaryError } from "./daemon/error-boundary.js";
 import { createPlanStorageService } from "./plan-storage.js";
 import { createManagedChatAttachmentOperations } from "./attachment-operations.js";
+import { createActivityAttachmentOperations } from "./activity-attachment-operations.js";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -950,21 +954,43 @@ export async function createLocalCoachComposition(
       }
     }
     const logger = createSubsystemLogger("agent", input.home.root);
-    const attachmentOperations = createManagedChatAttachmentOperations({
-      repository: createChatAttachmentRepository(input.context.store),
-      objects: createManagedChatAttachmentStore({
-        archiveDir: input.home.archiveDir,
-        kindByteLimits: {
-          document: CHAT_ATTACHMENT_LIMITS.documentBytes,
-          activity: CHAT_ATTACHMENT_LIMITS.activityBytes,
-          workout: CHAT_ATTACHMENT_LIMITS.workoutBytes,
-          image: CHAT_ATTACHMENT_LIMITS.imageBytes,
+    const attachmentRepository = createChatAttachmentRepository(input.context.store);
+    const attachmentObjects = createManagedChatAttachmentStore({
+      archiveDir: input.home.archiveDir,
+      kindByteLimits: {
+        document: CHAT_ATTACHMENT_LIMITS.documentBytes,
+        activity: CHAT_ATTACHMENT_LIMITS.activityBytes,
+        workout: CHAT_ATTACHMENT_LIMITS.workoutBytes,
+        image: CHAT_ATTACHMENT_LIMITS.imageBytes,
+      },
+      ...(dependencies.platform === undefined ? {} : { platform: dependencies.platform }),
+      now,
+    });
+    const activityAttachmentOperations = createActivityAttachmentOperations({
+      repository: attachmentRepository,
+      reader: createManagedActivityReader({
+        objects: attachmentObjects,
+        limits: {
+          activityBytes: CHAT_ATTACHMENT_LIMITS.activityBytes,
+          parserMs: CHAT_ATTACHMENT_LIMITS.parserMs,
+          parserOldGenerationMiB: CHAT_ATTACHMENT_LIMITS.parserOldGenerationMiB,
+          sessions: 256,
         },
-        ...(dependencies.platform === undefined ? {} : { platform: dependencies.platform }),
-        now,
       }),
+      importer: createNodeImportRuntime({
+        archiveDir: input.home.archiveDir,
+        store: input.context.store,
+      }),
+      store: input.context.store,
       runExclusive: (work) => runtime!.runExclusive(work),
       now,
+    });
+    const attachmentOperations = createManagedChatAttachmentOperations({
+      repository: attachmentRepository,
+      objects: attachmentObjects,
+      runExclusive: (work) => runtime!.runExclusive(work),
+      now,
+      onAdmitted: activityAttachmentOperations.preprocessAdmitted,
     });
     await attachmentOperations.reconcile();
     const planIdentity = createAuthoredIdentity(input.home.configDir, { now });
@@ -1029,6 +1055,7 @@ export async function createLocalCoachComposition(
         memory,
         planPersistence: createPlanPersistence(timezone),
         chatStore: conversationStore,
+        chatAttachments: activityAttachmentOperations.turnPort,
         transcriptWriter: conversationStore,
         coachDecisions: conversationStore,
         secrets: { resolve: resolveSecretRef },

--- a/packages/coach/tests/activity-attachment-operations.test.ts
+++ b/packages/coach/tests/activity-attachment-operations.test.ts
@@ -1,0 +1,205 @@
+import { mkdir, readFile, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { CHAT_ATTACHMENT_LIMITS } from "@enduragent/coach-contract";
+import { createChatAttachmentRepository, runMigrations } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import {
+  createManagedActivityReader,
+  createManagedChatAttachmentStore,
+} from "@enduragent/kernel-node/chat-attachments";
+import { createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import {
+  ActivityAttachmentInterruption,
+  createActivityAttachmentOperations,
+  type ActivityAttachmentHooks,
+} from "../src/activity-attachment-operations.js";
+import { createManagedChatAttachmentOperations } from "../src/attachment-operations.js";
+
+const roots: string[] = [];
+const fixturePath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../kernel-node/tests/fixtures/ingest/brick-cycling.fit",
+);
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function harness() {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "chat-activity-"));
+  roots.push(root);
+  const archiveDir = join(root, "archive");
+  await mkdir(archiveDir, { mode: 0o700 });
+  const store = openSqliteStorage(":memory:");
+  await runMigrations(store, MIGRATIONS);
+  const repository = createChatAttachmentRepository(store);
+  const objects = createManagedChatAttachmentStore({
+    archiveDir,
+    kindByteLimits: {
+      document: CHAT_ATTACHMENT_LIMITS.documentBytes,
+      activity: CHAT_ATTACHMENT_LIMITS.activityBytes,
+      workout: CHAT_ATTACHMENT_LIMITS.workoutBytes,
+      image: CHAT_ATTACHMENT_LIMITS.imageBytes,
+    },
+  });
+  const reader = createManagedActivityReader({
+    objects,
+    limits: {
+      activityBytes: CHAT_ATTACHMENT_LIMITS.activityBytes,
+      parserMs: CHAT_ATTACHMENT_LIMITS.parserMs,
+      parserOldGenerationMiB: CHAT_ATTACHMENT_LIMITS.parserOldGenerationMiB,
+      sessions: 256,
+    },
+  });
+  const importer = createNodeImportRuntime({ archiveDir, store });
+  let clock = 1_000;
+  const now = () => ++clock;
+  const create = (hooks?: ActivityAttachmentHooks) =>
+    createActivityAttachmentOperations({
+      repository,
+      reader,
+      importer,
+      store,
+      runExclusive: (work) => work(),
+      now,
+      ...(hooks === undefined ? {} : { hooks }),
+    });
+  const initial = create();
+  const attachments = createManagedChatAttachmentOperations({
+    repository,
+    objects,
+    runExclusive: (work) => work(),
+    now,
+    randomId: (() => {
+      let sequence = 0;
+      return () => `attachment-id-${++sequence}`;
+    })(),
+    onAdmitted: initial.preprocessAdmitted,
+  });
+  const staged = await objects.stagePrivateBytes({
+    displayName: "ride.fit",
+    bytes: new Uint8Array(await readFile(fixturePath)),
+  });
+  const admitted = await attachments.admit({
+    chatId: "chat-1",
+    selectionId: "selection-1",
+    source: "picker",
+    candidate: { kind: "native-path", sourcePath: staged.sourcePath },
+  });
+  expect(admitted.status).toBe("accepted");
+  if (admitted.status !== "accepted") throw new Error("fixture admission failed");
+  expect(await repository.readAttachment(admitted.attachmentId)).toMatchObject({
+    kind: "activity",
+    status: "ready",
+    state_json: expect.stringContaining("parsed-activity"),
+    message_id: null,
+  });
+  return {
+    store,
+    repository,
+    attachments,
+    attachmentId: admitted.attachmentId,
+    create,
+  };
+}
+
+const queuedTurn = {
+  chatId: "chat-1",
+  messages: [{ messageId: "message-1", attachmentIds: [] as string[] }],
+} as const;
+
+describe("completed activity attachments", () => {
+  it("imports only after Send, supplies normalized canonical summaries, and marks the attachment sent", async () => {
+    const value = await harness();
+    expect(Number((await value.store.get("SELECT COUNT(*) AS count FROM session"))?.count)).toBe(0);
+    const request = {
+      ...queuedTurn,
+      messages: [{ messageId: "message-1", attachmentIds: [value.attachmentId] }],
+    };
+    const operations = value.create();
+    const prepared = await operations.turnPort.prepareQueuedTurn(request);
+    expect(prepared.activities).toMatchObject([
+      {
+        attachmentId: value.attachmentId,
+        messageId: "message-1",
+        activityIds: [expect.any(String)],
+        sessions: [
+          {
+            activityId: expect.any(String),
+            sport: "cycling",
+            startUtc: expect.any(Number),
+          },
+        ],
+      },
+    ]);
+    expect(await value.repository.readAttachment(value.attachmentId)).toMatchObject({
+      status: "imported",
+      message_id: "message-1",
+    });
+    await operations.turnPort.completeQueuedTurn({ chatId: "chat-1", messageIds: ["message-1"] });
+    expect(await value.repository.readAttachment(value.attachmentId)).toMatchObject({
+      status: "sent",
+    });
+    await value.store.close();
+  });
+
+  it.each([
+    ["before-message-link", "beforeMessageLink", "ready", 0],
+    ["before-import", "beforeImport", "importing", 0],
+    ["after-import", "afterImport", "importing", 1],
+    ["before-coach-start", "beforeCoachStart", "imported", 1],
+  ] as const)(
+    "resumes exactly once after an interruption %s",
+    async (checkpoint, hookName, expectedStatus, expectedSessions) => {
+      const value = await harness();
+      const hook = async () => {
+        throw new ActivityAttachmentInterruption(checkpoint);
+      };
+      const interrupted = value.create({ [hookName]: hook });
+      const request = {
+        ...queuedTurn,
+        messages: [{ messageId: "message-1", attachmentIds: [value.attachmentId] }],
+      };
+      await expect(interrupted.turnPort.prepareQueuedTurn(request)).rejects.toBeInstanceOf(
+        ActivityAttachmentInterruption,
+      );
+      expect(await value.repository.readAttachment(value.attachmentId)).toMatchObject({
+        status: expectedStatus,
+      });
+      expect(Number((await value.store.get("SELECT COUNT(*) AS count FROM session"))?.count)).toBe(
+        expectedSessions,
+      );
+
+      const resumed = value.create();
+      const result = await resumed.turnPort.prepareQueuedTurn(request);
+      expect(result.activities).toHaveLength(1);
+      expect(Number((await value.store.get("SELECT COUNT(*) AS count FROM session"))?.count)).toBe(
+        1,
+      );
+      expect(await value.repository.listMessageAttachments("message-1")).toHaveLength(1);
+      await value.store.close();
+    },
+  );
+
+  it("deletes Conversation-owned bytes while retaining the imported Training activity", async () => {
+    const value = await harness();
+    await value.create().turnPort.prepareQueuedTurn({
+      ...queuedTurn,
+      messages: [{ messageId: "message-1", attachmentIds: [value.attachmentId] }],
+    });
+    const activityId = String(
+      (await value.store.get("SELECT session_key FROM session LIMIT 1"))?.session_key,
+    );
+    await value.attachments.cleanupConversation("chat-1");
+    expect(await value.repository.readAttachment(value.attachmentId)).toBeUndefined();
+    expect(
+      await value.store.get("SELECT session_key FROM session WHERE session_key=?", [activityId]),
+    ).toMatchObject({ session_key: activityId });
+    await value.store.close();
+  });
+});

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -627,6 +627,7 @@ describe("local coach composition", () => {
     });
     expect(received?.sport.id).toBe("cycling");
     expect(Object.keys(received!.ports).sort()).toEqual([
+      "chatAttachments",
       "chatStore",
       "classifyFailure",
       "coachDecisions",

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -685,7 +685,11 @@ export class CoachAgent {
   async chat(
     chatId: string,
     userMessage: string,
-    turn?: { resolvedCs?: ResolvedCs | null; referenceProvenance?: SourceProvenance },
+    turn?: {
+      resolvedCs?: ResolvedCs | null;
+      referenceProvenance?: SourceProvenance;
+      attachmentContext?: string;
+    },
     onEvent?: TurnEventHandler,
     onDecision?: (decision: CoachDecisionReadModel) => void,
     requestedTurnId?: string,
@@ -909,6 +913,10 @@ export class CoachAgent {
           archivedAt !== undefined
             ? { role: "system", content: archiveMarker(archivedAt) }
             : undefined;
+        const attachmentContextMsg: ModelMessage | undefined =
+          turn?.attachmentContext === undefined
+            ? undefined
+            : { role: "system", content: turn.attachmentContext };
 
         // Build messages array with new user message
         const userTurnMessage = setMessageProvenance(
@@ -918,6 +926,7 @@ export class CoachAgent {
         let messages: ModelMessage[] = [
           ...(summaryMsg ? [summaryMsg] : []),
           ...(archiveMarkerMsg ? [archiveMarkerMsg] : []),
+          ...(attachmentContextMsg ? [attachmentContextMsg] : []),
           ...requeued,
           ...kept,
           userTurnMessage,

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -172,6 +172,37 @@ export interface ChatStorePort {
   clearChatQueue?(chatId: string): ChatQueueSnapshot;
 }
 
+export interface ChatAttachmentActivitySummary {
+  readonly attachmentId: string;
+  readonly messageId: string;
+  readonly activityIds: readonly string[];
+  readonly sessions: readonly {
+    readonly activityId: string;
+    readonly sport: string;
+    readonly startUtc: number;
+    readonly elapsedSeconds: number | null;
+    readonly distanceMeters: number | null;
+  }[];
+}
+
+export interface ChatAttachmentTurnPreparation {
+  readonly activities: readonly ChatAttachmentActivitySummary[];
+}
+
+export interface ChatAttachmentTurnPort {
+  prepareQueuedTurn(input: {
+    readonly chatId: string;
+    readonly messages: readonly {
+      readonly messageId: string;
+      readonly attachmentIds: readonly string[];
+    }[];
+  }): Promise<ChatAttachmentTurnPreparation>;
+  completeQueuedTurn(input: {
+    readonly chatId: string;
+    readonly messageIds: readonly string[];
+  }): Promise<void>;
+}
+
 export type TranscriptConversationBoundaryReason = "explicit-reset" | "stale-reset";
 
 export interface ConversationResetInput {
@@ -404,6 +435,7 @@ export interface EngineHostPorts {
   readonly memory: MemoryStorePort;
   readonly planPersistence?: PlanPersistencePort;
   readonly chatStore: ChatStorePort;
+  readonly chatAttachments?: ChatAttachmentTurnPort;
   readonly transcriptWriter: TranscriptWriterPort;
   readonly coachDecisions?: CoachDecisionStorePort;
   readonly secrets: SecretsPort;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -7,7 +7,7 @@ import type {
 } from "@enduragent/coach-contract";
 import { CoachAgent } from "./agent/coach-agent.js";
 import { extractAccountId } from "./agent/codex/jwt.js";
-import type { EngineHostPorts } from "./host-ports.js";
+import type { ChatAttachmentActivitySummary, EngineHostPorts } from "./host-ports.js";
 import type { Sport } from "./sport.js";
 import type { ResolvedCs } from "@enduragent/kernel/reference/cs-resolution";
 import type { SourceProvenance } from "./provenance.js";
@@ -22,6 +22,9 @@ export type {
   CallerRole,
   ChatLineage,
   ChatStorePort,
+  ChatAttachmentActivitySummary,
+  ChatAttachmentTurnPort,
+  ChatAttachmentTurnPreparation,
   CoachDecisionStorePort,
   ConversationResetInput,
   EngineConfig,
@@ -94,6 +97,16 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
     queuePort("getChatQueue").call(input.ports.chatStore, chatId);
   const queueText = (items: readonly QueuedChatMessage[]): string =>
     items.map((item) => item.text).join("\n\n");
+  const activityContext = (
+    activities: readonly ChatAttachmentActivitySummary[],
+  ): string | undefined =>
+    activities.length === 0
+      ? undefined
+      : [
+          "Canonical Training activities imported for this athlete turn.",
+          "Use only these normalized local fields; raw attachment bytes were not provided.",
+          JSON.stringify(activities),
+        ].join("\n");
   const runQueue = (
     chatId: string,
     mode: "resume" | "command" | "retry",
@@ -151,11 +164,24 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
       }
       let interrupted = false;
       try {
+        const attachmentPreparation = await input.ports.chatAttachments?.prepareQueuedTurn({
+          chatId,
+          messages: selected.map((item) => ({
+            messageId: item.messageId,
+            attachmentIds: item.attachmentIds,
+          })),
+        });
+        const normalizedActivityContext =
+          attachmentPreparation === undefined
+            ? undefined
+            : activityContext(attachmentPreparation.activities);
         let decision;
         const text = await agent.chat(
           chatId,
           queueText(selected),
-          undefined,
+          normalizedActivityContext === undefined
+            ? undefined
+            : { attachmentContext: normalizedActivityContext },
           (event) => {
             if (event.type === "interrupted") interrupted = true;
             onEvent?.(event);
@@ -175,6 +201,10 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
             response: decision === undefined ? { text } : { text, decision },
           };
         }
+        await input.ports.chatAttachments?.completeQueuedTurn({
+          chatId,
+          messageIds: selected.map((item) => item.messageId),
+        });
         return {
           snapshot: queuePort("completeChatQueueClaim").call(
             input.ports.chatStore,

--- a/packages/engine/tests/chat-queue.test.ts
+++ b/packages/engine/tests/chat-queue.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import { createCoachEngine } from "../src/index.js";
 import type { EngineHostPorts, ModelTransportRequest } from "../src/host-ports.js";
+import type { ChatAttachmentTurnPort } from "../src/host-ports.js";
 import type { GenerateResult, Sport } from "../src/sport.js";
 import { baseAgentConfig } from "./helpers/base-agent-config.js";
 
@@ -29,6 +30,7 @@ function setup(
   root = mkdtempSync(join(tmpdir(), "engine-chat-queue-")),
   generate: (request: ModelTransportRequest) => Promise<GenerateResult> = async () =>
     generated("Done"),
+  chatAttachments?: ChatAttachmentTurnPort,
 ) {
   if (!roots.includes(root)) roots.push(root);
   const base = baseAgentConfig(root);
@@ -38,6 +40,7 @@ function setup(
     transcriptWriter: base.chatStore as unknown as EngineHostPorts["transcriptWriter"],
     randomId: () => `id-${++sequence}`,
     modelTransportDecorator: () => ({ generate }),
+    ...(chatAttachments === undefined ? {} : { chatAttachments }),
   };
   return {
     root,
@@ -68,6 +71,91 @@ describe("engine durable chat queue", () => {
         attachmentIds: ["attachment-2"],
       }),
     ).rejects.toThrow(/text-only/u);
+  });
+
+  it("imports queued attachments before Coach and exposes only normalized canonical activity fields", async () => {
+    const order: string[] = [];
+    const prepareQueuedTurn = vi.fn(async () => {
+      order.push("prepared");
+      return {
+        activities: [
+          {
+            attachmentId: "attachment-1",
+            messageId: "id-2",
+            activityIds: ["activity-1"],
+            sessions: [
+              {
+                activityId: "activity-1",
+                sport: "cycling",
+                startUtc: 1_777_000_000,
+                elapsedSeconds: 3_600,
+                distanceMeters: 40_000,
+              },
+            ],
+          },
+        ],
+      };
+    });
+    const completeQueuedTurn = vi.fn(async () => {
+      order.push("completed");
+    });
+    const requests: ModelTransportRequest[] = [];
+    const { engine } = setup(
+      undefined,
+      async (request) => {
+        order.push("coach");
+        requests.push(request);
+        return generated("Reviewed");
+      },
+      { prepareQueuedTurn, completeQueuedTurn },
+    );
+    await engine.enqueueChatMessage!({
+      chatId: "desktop",
+      submissionId: "submission-1",
+      text: "Review the ride",
+      attachmentIds: ["attachment-1"],
+    });
+    await expect(engine.resumeChatQueue!({ chatId: "desktop" })).resolves.toMatchObject({
+      response: { text: "Reviewed" },
+      snapshot: { items: [] },
+    });
+    expect(prepareQueuedTurn).toHaveBeenCalledWith({
+      chatId: "desktop",
+      messages: [{ messageId: "id-2", attachmentIds: ["attachment-1"] }],
+    });
+    expect(completeQueuedTurn).toHaveBeenCalledWith({
+      chatId: "desktop",
+      messageIds: ["id-2"],
+    });
+    expect(order).toEqual(["prepared", "coach", "completed"]);
+    const providerMessages = JSON.stringify(requests[0]?.options.messages);
+    expect(providerMessages).toContain("Canonical Training activities imported");
+    expect(providerMessages).toContain("activity-1");
+    expect(providerMessages).not.toContain("raw-fit-private-bytes");
+  });
+
+  it("leaves the stable queue claim retryable when attachment preparation fails before Coach", async () => {
+    const generate = vi.fn(async () => generated("Unexpected"));
+    const { engine } = setup(undefined, generate, {
+      prepareQueuedTurn: async () => {
+        throw new Error("import interrupted");
+      },
+      completeQueuedTurn: async () => {},
+    });
+    await engine.enqueueChatMessage!({
+      chatId: "desktop",
+      submissionId: "submission-1",
+      text: "Review the ride",
+      attachmentIds: ["attachment-1"],
+    });
+    await expect(engine.resumeChatQueue!({ chatId: "desktop" })).rejects.toThrow(
+      "import interrupted",
+    );
+    expect(generate).not.toHaveBeenCalled();
+    expect(await engine.getChatQueue!({ chatId: "desktop" })).toMatchObject({
+      items: [{ messageId: "id-2", attachmentIds: ["attachment-1"] }],
+      retryRequired: { queuedMessageIds: ["id-1"] },
+    });
   });
 
   it("groups consecutive ordinary messages and stops at a command barrier", async () => {

--- a/packages/kernel-node/src/chat-attachments/activity-reader-worker.ts
+++ b/packages/kernel-node/src/chat-attachments/activity-reader-worker.ts
@@ -1,0 +1,26 @@
+import { parentPort, workerData } from "node:worker_threads";
+import type { ImportArtifact, RepairFixerSettings } from "@enduragent/kernel/ingest";
+import { prepareActivityArtifact } from "../ingest/import-files.js";
+
+interface ActivityWorkerInput {
+  readonly inputPath: string;
+  readonly extension: "fit" | "tcx" | "gpx";
+  readonly bytes: Uint8Array;
+  readonly repairSettings: RepairFixerSettings;
+}
+
+async function run(input: ActivityWorkerInput): Promise<void> {
+  const artifact: ImportArtifact = {
+    input_path: input.inputPath,
+    bytes: input.bytes,
+    ext: input.extension,
+  };
+  parentPort?.postMessage({
+    ok: true,
+    result: await prepareActivityArtifact(artifact, input.repairSettings),
+  });
+}
+
+void run(workerData as ActivityWorkerInput).catch(() => {
+  parentPort?.postMessage({ ok: false, reason: "validation_failed" });
+});

--- a/packages/kernel-node/src/chat-attachments/activity-reader.ts
+++ b/packages/kernel-node/src/chat-attachments/activity-reader.ts
@@ -1,0 +1,285 @@
+import { Worker } from "node:worker_threads";
+import {
+  FIT_INGEST_VERSION,
+  normalizeRepairFixerSettings,
+  type ImportArtifact,
+  type PrepareFileResult,
+  type RepairFixerSettings,
+} from "@enduragent/kernel/ingest";
+import type { ManagedChatAttachmentStore } from "./managed-store.js";
+import type { ParsedActivityProjection } from "@enduragent/kernel/store";
+
+export type ManagedActivityExtension = "fit" | "tcx" | "gpx";
+
+export const MANAGED_ACTIVITY_PARSER_VERSION = `canonical-ingest-${FIT_INGEST_VERSION}-worker-v1`;
+
+export interface ManagedActivityReaderLimits {
+  readonly activityBytes: number;
+  readonly parserMs: number;
+  readonly parserOldGenerationMiB: number;
+  readonly sessions: number;
+}
+
+export interface ManagedActivitySource {
+  readonly objectId: string;
+  readonly relativePath: string;
+  readonly displayName: string;
+  readonly byteSize: number;
+  readonly sha256: string;
+  readonly extension: ManagedActivityExtension;
+}
+
+export type ManagedActivityReadResult =
+  | {
+      readonly outcome: "prepared";
+      readonly projection: ParsedActivityProjection;
+      readonly artifact: ImportArtifact;
+      readonly prepared: Extract<PrepareFileResult, { readonly outcome: "prepared" }>;
+    }
+  | {
+      readonly outcome: "quarantined";
+      readonly code: string;
+      readonly message: string;
+    };
+
+export type ManagedActivityReaderFailure =
+  | "integrity_mismatch"
+  | "limit_exceeded"
+  | "parser_timeout"
+  | "validation_failed"
+  | "worker_failed";
+
+export class ManagedActivityReaderError extends Error {
+  constructor(readonly reason: ManagedActivityReaderFailure) {
+    super("managed activity could not be read");
+    this.name = "ManagedActivityReaderError";
+  }
+}
+
+export interface ManagedActivityReader {
+  read(
+    source: ManagedActivitySource,
+    repairSettings: RepairFixerSettings,
+  ): Promise<ManagedActivityReadResult>;
+}
+
+export interface ManagedActivityReaderOptions {
+  readonly objects: Pick<ManagedChatAttachmentStore, "readObjectBytes">;
+  readonly limits: ManagedActivityReaderLimits;
+  readonly workerUrl?: URL;
+}
+
+interface WorkerSuccess {
+  readonly ok: true;
+  readonly result: unknown;
+}
+
+interface WorkerFailure {
+  readonly ok: false;
+  readonly reason: unknown;
+}
+
+const SHA256 = /^[0-9a-f]{64}$/u;
+const SAFE_OBJECT_ID = /^[A-Za-z0-9_-]{1,128}$/u;
+const FAILURES = new Set<ManagedActivityReaderFailure>([
+  "integrity_mismatch",
+  "limit_exceeded",
+  "parser_timeout",
+  "validation_failed",
+  "worker_failed",
+]);
+
+function positiveInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError(`${name} must be a positive safe integer`);
+  }
+}
+
+function validateLimits(limits: ManagedActivityReaderLimits): void {
+  positiveInteger(limits.activityBytes, "activityBytes");
+  positiveInteger(limits.parserMs, "parserMs");
+  positiveInteger(limits.parserOldGenerationMiB, "parserOldGenerationMiB");
+  positiveInteger(limits.sessions, "sessions");
+}
+
+function error(reason: unknown): ManagedActivityReaderError {
+  return new ManagedActivityReaderError(
+    typeof reason === "string" && FAILURES.has(reason as ManagedActivityReaderFailure)
+      ? (reason as ManagedActivityReaderFailure)
+      : "worker_failed",
+  );
+}
+
+function defaultWorkerUrl(): URL {
+  const sourceModule = import.meta.url.endsWith(".ts");
+  return new URL(
+    sourceModule ? "./activity-reader-worker.ts" : "./activity-reader-worker.js",
+    import.meta.url,
+  );
+}
+
+function validatePreparedResult(
+  value: unknown,
+  source: ManagedActivitySource,
+  limits: ManagedActivityReaderLimits,
+): PrepareFileResult {
+  if (value === null || typeof value !== "object" || !("outcome" in value)) {
+    throw error("worker_failed");
+  }
+  const candidate = value as Record<string, unknown>;
+  if (candidate.outcome === "quarantined") {
+    const quarantine = candidate.quarantine as Record<string, unknown> | undefined;
+    if (
+      quarantine === undefined ||
+      typeof quarantine.code !== "string" ||
+      quarantine.code.length < 1 ||
+      quarantine.code.length > 128 ||
+      typeof quarantine.message !== "string" ||
+      quarantine.message.length < 1 ||
+      quarantine.message.length > 2_048
+    ) {
+      throw error("worker_failed");
+    }
+    return value as PrepareFileResult;
+  }
+  if (candidate.outcome !== "prepared") throw error("worker_failed");
+  const prepared = candidate.value as Record<string, unknown> | undefined;
+  const rawFile = prepared?.raw_file as Record<string, unknown> | undefined;
+  const candidates = prepared?.candidates;
+  const summaries = prepared?.summaries;
+  const repairEvents = prepared?.repair_events;
+  if (
+    prepared === undefined ||
+    prepared.expected_address !== source.sha256 ||
+    rawFile?.sha256 !== source.sha256 ||
+    rawFile.bytes !== source.byteSize ||
+    !Array.isArray(candidates) ||
+    candidates.length < 1 ||
+    candidates.length > limits.sessions ||
+    !Array.isArray(summaries) ||
+    summaries.length !== candidates.length ||
+    !Array.isArray(repairEvents) ||
+    repairEvents.length > limits.sessions * 32
+  ) {
+    throw error("worker_failed");
+  }
+  return value as PrepareFileResult;
+}
+
+function runWorker(
+  workerUrl: URL,
+  source: ManagedActivitySource,
+  bytes: Uint8Array,
+  repairSettings: RepairFixerSettings,
+  limits: ManagedActivityReaderLimits,
+): Promise<PrepareFileResult> {
+  return new Promise((resolve, reject) => {
+    const transferable = Uint8Array.from(bytes);
+    const worker = new Worker(workerUrl, {
+      workerData: {
+        inputPath: `chat-attachment:${source.objectId}/${source.displayName}`,
+        extension: source.extension,
+        bytes: transferable,
+        repairSettings,
+      },
+      transferList: [transferable.buffer],
+      resourceLimits: { maxOldGenerationSizeMb: limits.parserOldGenerationMiB },
+    });
+    let settled = false;
+    const finish = (work: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      work();
+      void worker.terminate();
+    };
+    const timer = setTimeout(() => finish(() => reject(error("parser_timeout"))), limits.parserMs);
+    timer.unref();
+    worker.once("message", (message: WorkerSuccess | WorkerFailure) => {
+      if (message?.ok === false) {
+        finish(() => reject(error(message.reason)));
+        return;
+      }
+      if (message?.ok !== true) {
+        finish(() => reject(error("worker_failed")));
+        return;
+      }
+      try {
+        const result = validatePreparedResult(message.result, source, limits);
+        finish(() => resolve(result));
+      } catch (workerError) {
+        finish(() => reject(workerError));
+      }
+    });
+    worker.once("error", () => finish(() => reject(error("worker_failed"))));
+    worker.once("exit", () => finish(() => reject(error("worker_failed"))));
+  });
+}
+
+export function createManagedActivityReader(
+  options: ManagedActivityReaderOptions,
+): ManagedActivityReader {
+  validateLimits(options.limits);
+  const workerUrl = options.workerUrl ?? defaultWorkerUrl();
+  const reader: ManagedActivityReader = {
+    async read(
+      source: ManagedActivitySource,
+      repairSettings: RepairFixerSettings,
+    ): Promise<ManagedActivityReadResult> {
+      if (
+        !SAFE_OBJECT_ID.test(source.objectId) ||
+        source.displayName.length < 1 ||
+        source.displayName.length > 512 ||
+        !Number.isSafeInteger(source.byteSize) ||
+        source.byteSize < 1 ||
+        source.byteSize > options.limits.activityBytes ||
+        !SHA256.test(source.sha256) ||
+        (source.extension !== "fit" && source.extension !== "tcx" && source.extension !== "gpx")
+      ) {
+        throw error("limit_exceeded");
+      }
+      const normalizedSettings = normalizeRepairFixerSettings(repairSettings);
+      let bytes: Uint8Array;
+      try {
+        bytes = await options.objects.readObjectBytes({
+          relativePath: source.relativePath,
+          byteSize: source.byteSize,
+          sha256: source.sha256,
+        });
+      } catch {
+        throw error("integrity_mismatch");
+      }
+      if (bytes.byteLength !== source.byteSize) throw error("integrity_mismatch");
+      const prepared = await runWorker(
+        workerUrl,
+        source,
+        bytes,
+        normalizedSettings,
+        options.limits,
+      );
+      if (prepared.outcome === "quarantined") {
+        return {
+          outcome: "quarantined",
+          code: prepared.quarantine.code,
+          message: prepared.quarantine.message,
+        };
+      }
+      return {
+        outcome: "prepared",
+        projection: {
+          kind: "parsed-activity",
+          parsedActivityId: source.sha256,
+          sourceFormat: source.extension,
+          parserVersion: MANAGED_ACTIVITY_PARSER_VERSION,
+        },
+        artifact: {
+          input_path: `chat-attachment:${source.objectId}/${source.displayName}`,
+          bytes,
+          ext: source.extension,
+        },
+        prepared,
+      };
+    },
+  };
+  return Object.freeze(reader);
+}

--- a/packages/kernel-node/src/chat-attachments/index.ts
+++ b/packages/kernel-node/src/chat-attachments/index.ts
@@ -1,2 +1,3 @@
 export * from "./managed-store.js";
 export * from "./document-reader.js";
+export * from "./activity-reader.js";

--- a/packages/kernel-node/src/ingest/import-files.ts
+++ b/packages/kernel-node/src/ingest/import-files.ts
@@ -50,6 +50,11 @@ export interface NodeImportRuntime {
     batch: import("@enduragent/kernel/ingest").ImportBatch,
     hooks?: Pick<ImportReportDeps, "finalizeBatchInTransaction" | "measurePhase">,
   ): Promise<ImportReport>;
+  importBatchWithPreparation(
+    batch: import("@enduragent/kernel/ingest").ImportBatch,
+    prepareFile: ImportReportDeps["prepareFile"],
+    hooks?: Pick<ImportReportDeps, "finalizeBatchInTransaction" | "measurePhase">,
+  ): Promise<ImportReport>;
 }
 
 export interface SetRepairFixerEnabledOptions {
@@ -62,38 +67,92 @@ export interface SetRepairFixerEnabledOptions {
 export function createNodeCrypto(): CryptoPort {
   const subtle = globalThis.crypto.subtle;
   const toBufferSource = (view: Uint8Array): Uint8Array<ArrayBuffer> => {
-    if (view.byteOffset === 0 && view.byteLength === view.buffer.byteLength && view.buffer instanceof ArrayBuffer) {
+    if (
+      view.byteOffset === 0 &&
+      view.byteLength === view.buffer.byteLength &&
+      view.buffer instanceof ArrayBuffer
+    ) {
       return view as Uint8Array<ArrayBuffer>;
     }
-    const copy = new Uint8Array(view.length); copy.set(view); return copy;
+    const copy = new Uint8Array(view.length);
+    copy.set(view);
+    return copy;
   };
-  const key = (bytes: Uint8Array, usage: "encrypt" | "decrypt") => subtle.importKey(
-    "raw", toBufferSource(bytes), { name: "AES-GCM" }, false, [usage],
-  );
+  const key = (bytes: Uint8Array, usage: "encrypt" | "decrypt") =>
+    subtle.importKey("raw", toBufferSource(bytes), { name: "AES-GCM" }, false, [usage]);
   return {
-    async sha256(data) { return new Uint8Array(await subtle.digest("SHA-256", toBufferSource(data))); },
-    async randomBytes(length) { const value = new Uint8Array(length); globalThis.crypto.getRandomValues(value); return value; },
+    async sha256(data) {
+      return new Uint8Array(await subtle.digest("SHA-256", toBufferSource(data)));
+    },
+    async randomBytes(length) {
+      const value = new Uint8Array(length);
+      globalThis.crypto.getRandomValues(value);
+      return value;
+    },
     async pbkdf2(params) {
-      const material = await subtle.importKey("raw", toBufferSource(params.passphrase), "PBKDF2", false, ["deriveBits"]);
-      return new Uint8Array(await subtle.deriveBits({ name: "PBKDF2", hash: params.hash, salt: toBufferSource(params.salt),
-        iterations: params.iterations }, material, params.keyLengthBytes * 8));
+      const material = await subtle.importKey(
+        "raw",
+        toBufferSource(params.passphrase),
+        "PBKDF2",
+        false,
+        ["deriveBits"],
+      );
+      return new Uint8Array(
+        await subtle.deriveBits(
+          {
+            name: "PBKDF2",
+            hash: params.hash,
+            salt: toBufferSource(params.salt),
+            iterations: params.iterations,
+          },
+          material,
+          params.keyLengthBytes * 8,
+        ),
+      );
     },
     async aesGcmEncrypt(params) {
-      return new Uint8Array(await subtle.encrypt({ name: "AES-GCM", iv: toBufferSource(params.nonce),
-        additionalData: params.additionalData === undefined ? undefined : toBufferSource(params.additionalData) },
-        await key(params.key, "encrypt"), toBufferSource(params.plaintext)));
+      return new Uint8Array(
+        await subtle.encrypt(
+          {
+            name: "AES-GCM",
+            iv: toBufferSource(params.nonce),
+            additionalData:
+              params.additionalData === undefined
+                ? undefined
+                : toBufferSource(params.additionalData),
+          },
+          await key(params.key, "encrypt"),
+          toBufferSource(params.plaintext),
+        ),
+      );
     },
     async aesGcmDecrypt(params) {
-      return new Uint8Array(await subtle.decrypt({ name: "AES-GCM", iv: toBufferSource(params.nonce),
-        additionalData: params.additionalData === undefined ? undefined : toBufferSource(params.additionalData) },
-        await key(params.key, "decrypt"), toBufferSource(params.ciphertext)));
+      return new Uint8Array(
+        await subtle.decrypt(
+          {
+            name: "AES-GCM",
+            iv: toBufferSource(params.nonce),
+            additionalData:
+              params.additionalData === undefined
+                ? undefined
+                : toBufferSource(params.additionalData),
+          },
+          await key(params.key, "decrypt"),
+          toBufferSource(params.ciphertext),
+        ),
+      );
     },
   };
 }
 
-function canonical(value: unknown): string { return JSON.stringify(sortKeys(value)); }
+function canonical(value: unknown): string {
+  return JSON.stringify(sortKeys(value));
+}
 
-function concernsForSession(mapped: Awaited<ReturnType<typeof mapFitArtifact>>, sessionIndex: number): Readonly<Record<string, ConcernValue>> {
+function concernsForSession(
+  mapped: Awaited<ReturnType<typeof mapFitArtifact>>,
+  sessionIndex: number,
+): Readonly<Record<string, ConcernValue>> {
   const session = mapped.activity.sessions[sessionIndex]!;
   const concerns: Record<string, ConcernValue> = {
     "session.sport": session.sport,
@@ -102,27 +161,61 @@ function concernsForSession(mapped: Awaited<ReturnType<typeof mapFitArtifact>>, 
     "session.is_transition": session.is_transition === 1,
   };
   const optionals = [
-    ["session.sub_sport", session.sub_sport], ["session.tz_offset_s", session.tz_offset_s],
-    ["session.elapsed_s", session.elapsed_s], ["session.timer_s", session.timer_s], ["session.moving_s", session.moving_s],
-    ["session.distance_m", session.distance_m], ["session.summary_json", session.summary_json],
+    ["session.sub_sport", session.sub_sport],
+    ["session.tz_offset_s", session.tz_offset_s],
+    ["session.elapsed_s", session.elapsed_s],
+    ["session.timer_s", session.timer_s],
+    ["session.moving_s", session.moving_s],
+    ["session.distance_m", session.distance_m],
+    ["session.summary_json", session.summary_json],
   ] as const;
   for (const [key, value] of optionals) if (value !== null) concerns[key] = value;
   const laps = mapped.activity.laps.filter((lap) => lap.session_key === session.session_key);
-  if (laps.length > 0) concerns["lap[]"] = laps.map((lap): LapConcern => ({ lap_seq: lap.lap_seq, start_utc: lap.start_utc,
-    elapsed_s: lap.elapsed_s, timer_s: lap.timer_s, distance_m: lap.distance_m, summary_json: lap.summary_json }));
+  if (laps.length > 0)
+    concerns["lap[]"] = laps.map(
+      (lap): LapConcern => ({
+        lap_seq: lap.lap_seq,
+        start_utc: lap.start_utc,
+        elapsed_s: lap.elapsed_s,
+        timer_s: lap.timer_s,
+        distance_m: lap.distance_m,
+        summary_json: lap.summary_json,
+      }),
+    );
   const lapSeqByKey = new Map(laps.map((lap) => [lap.lap_key, lap.lap_seq]));
   const lengths = mapped.activity.swimLengths.filter((length) => lapSeqByKey.has(length.lap_key));
-  if (lengths.length > 0) concerns["swim_length[]"] = lengths.map((length): SwimLengthConcern => ({
-    lap_seq: lapSeqByKey.get(length.lap_key)!, length_seq: length.length_seq, start_utc: length.start_utc,
-    elapsed_s: length.elapsed_s, timer_s: length.timer_s, distance_m: length.distance_m, strokes: length.strokes,
-    stroke_type: length.stroke_type, length_type: length.length_type,
-  }));
-  const streams = mapped.activity.streams.filter((stream) => stream.session_key === session.session_key);
+  if (lengths.length > 0)
+    concerns["swim_length[]"] = lengths.map(
+      (length): SwimLengthConcern => ({
+        lap_seq: lapSeqByKey.get(length.lap_key)!,
+        length_seq: length.length_seq,
+        start_utc: length.start_utc,
+        elapsed_s: length.elapsed_s,
+        timer_s: length.timer_s,
+        distance_m: length.distance_m,
+        strokes: length.strokes,
+        stroke_type: length.stroke_type,
+        length_type: length.length_type,
+      }),
+    );
+  const streams = mapped.activity.streams.filter(
+    (stream) => stream.session_key === session.session_key,
+  );
   const time = streams.find((stream) => stream.channel === "time");
   if (time) {
-    const timestamps = decodeStream({ encoding: time.encoding, n: time.n, kind: "time", data: time.data }) as readonly number[];
+    const timestamps = decodeStream({
+      encoding: time.encoding,
+      n: time.n,
+      kind: "time",
+      data: time.data,
+    }) as readonly number[];
     for (const stream of streams) {
-      const values = decodeStream({ encoding: stream.encoding, n: stream.n, kind: stream.channel === "time" ? "time" : "value", data: stream.data });
+      const values = decodeStream({
+        encoding: stream.encoding,
+        n: stream.n,
+        kind: stream.channel === "time" ? "time" : "value",
+        data: stream.data,
+      });
       concerns[`stream:${stream.channel}`] = { timestamps: [...timestamps], values: [...values] };
     }
   }
@@ -149,7 +242,10 @@ async function prepareFit(
     });
   } catch (error) {
     if (!(error instanceof FitSourceError)) throw error;
-    return { outcome: "quarantined", quarantine: { code: `fit:${error.code}`, message: error.message } };
+    return {
+      outcome: "quarantined",
+      quarantine: { code: `fit:${error.code}`, message: error.message },
+    };
   }
   const candidates: Candidate[] = mapped.activity.sessions.map((session, index) => ({
     id: `fit:${address}:0:${index}`,
@@ -160,19 +256,38 @@ async function prepareFit(
     concerns: concernsForSession(mapped, index),
   }));
   const summaries: DedupCandidateSummary[] = candidates.map((candidate, index) => {
-    const session = mapped.activity.sessions[index]!, concerns = candidate.concerns;
+    const session = mapped.activity.sessions[index]!,
+      concerns = candidate.concerns;
     const time = concerns["stream:time"] as { readonly timestamps: readonly number[] } | undefined;
-    const duration = session.elapsed_s ?? (time ? time.timestamps[time.timestamps.length - 1]! - time.timestamps[0]! : null);
+    const duration =
+      session.elapsed_s ??
+      (time ? time.timestamps[time.timestamps.length - 1]! - time.timestamps[0]! : null);
     if (duration === null) throw new FitSourceError("invalid_numeric");
-    return { candidate_id: candidate.id, member_id: address, source_kind: "fit", source_session_seq: index,
-      sport_family: session.sport, is_transition: session.is_transition === 1, start_utc: session.start_utc,
-      duration_s: duration, distance_m: session.distance_m, file_id_manufacturer: mapped.rawFile.manufacturer,
-      file_id_serial: mapped.rawFile.file_id_serial, file_id_time_created_utc: mapped.rawFile.file_id_time_created_utc };
+    return {
+      candidate_id: candidate.id,
+      member_id: address,
+      source_kind: "fit",
+      source_session_seq: index,
+      sport_family: session.sport,
+      is_transition: session.is_transition === 1,
+      start_utc: session.start_utc,
+      duration_s: duration,
+      distance_m: session.distance_m,
+      file_id_manufacturer: mapped.rawFile.manufacturer,
+      file_id_serial: mapped.rawFile.file_id_serial,
+      file_id_time_created_utc: mapped.rawFile.file_id_time_created_utc,
+    };
   });
-  const candidateIdBySession = new Map(mapped.activity.sessions.map((session, index) => [session.session_key, candidates[index]!.id]));
+  const candidateIdBySession = new Map(
+    mapped.activity.sessions.map((session, index) => [session.session_key, candidates[index]!.id]),
+  );
   const repairEvents: PreparedRepairEvent[] = mapped.activity.repairLogs.map((event) => ({
-    candidate_id: candidateIdBySession.get(event.sessionKey)!, channel: event.channel, fixer: event.fixer,
-    changed_count: event.changedIndices.length, changed_indices_json: JSON.stringify(event.changedIndices), params_json: canonical(event.params),
+    candidate_id: candidateIdBySession.get(event.sessionKey)!,
+    channel: event.channel,
+    fixer: event.fixer,
+    changed_count: event.changedIndices.length,
+    changed_indices_json: JSON.stringify(event.changedIndices),
+    params_json: canonical(event.params),
   }));
   const { path: _path, ...raw } = mapped.rawFile;
   const value: PreparedFile = {
@@ -186,9 +301,24 @@ async function prepareFit(
   return { outcome: "prepared", value };
 }
 
-function createImportReportDeps(
-  options: NodeImportRuntimeOptions,
-): ImportReportDeps {
+async function prepareActivityArtifactWithCrypto(
+  artifact: ImportArtifact,
+  repairSettings: RepairFixerSettings,
+  crypto: CryptoPort,
+): Promise<PrepareFileResult> {
+  return artifact.ext === "fit"
+    ? prepareFit(artifact, crypto, repairSettings)
+    : prepareXmlFile(artifact.bytes, artifact.ext, { crypto });
+}
+
+export function prepareActivityArtifact(
+  artifact: ImportArtifact,
+  repairSettings: RepairFixerSettings,
+): Promise<PrepareFileResult> {
+  return prepareActivityArtifactWithCrypto(artifact, repairSettings, createNodeCrypto());
+}
+
+function createImportReportDeps(options: NodeImportRuntimeOptions): ImportReportDeps {
   const crypto = createNodeCrypto();
   const fs = nodeFileSystem();
   const archive = createArchiveManager({ archiveRoot: options.archiveDir, crypto, fs });
@@ -200,9 +330,8 @@ function createImportReportDeps(
     archive,
     store: options.store,
     hashKey,
-    prepareFile: (artifact, repairSettings) => artifact.ext === "fit"
-      ? prepareFit(artifact, crypto, repairSettings)
-      : prepareXmlFile(artifact.bytes, artifact.ext, { crypto }),
+    prepareFile: (artifact, repairSettings) =>
+      prepareActivityArtifactWithCrypto(artifact, repairSettings, crypto),
     canonicalPick,
     materializeClusterInTransaction: createMaterializeClusterInTransaction(hashKey),
     ingestVersion: FIT_INGEST_VERSION,
@@ -214,10 +343,12 @@ export async function importFilesWithReport(options: ImportFilesOptions): Promis
   const seen = new Set<string>();
   const files: ImportArtifact[] = [];
   for (const inputPath of options.inputPaths) {
-    if (typeof inputPath !== "string" || inputPath.length === 0 || seen.has(inputPath)) throw new TypeError("duplicate or invalid input path");
+    if (typeof inputPath !== "string" || inputPath.length === 0 || seen.has(inputPath))
+      throw new TypeError("duplicate or invalid input path");
     seen.add(inputPath);
     const ext = extname(inputPath).slice(1).toLowerCase();
-    if (ext !== "fit" && ext !== "tcx" && ext !== "gpx") throw new TypeError("unsupported input extension");
+    if (ext !== "fit" && ext !== "tcx" && ext !== "gpx")
+      throw new TypeError("unsupported input extension");
     files.push({ input_path: inputPath, bytes: new Uint8Array(await readFile(inputPath)), ext });
   }
   return createNodeImportRuntime(options).importBatchWithReport({ files, platform_records: [] });
@@ -241,17 +372,34 @@ export function createNodeImportRuntime(options: NodeImportRuntimeOptions): Node
     throw new TypeError("invalid node import runtime options");
   }
   const deps = createImportReportDeps(options);
+  const importWith = (
+    batch: import("@enduragent/kernel/ingest").ImportBatch,
+    prepareFile: ImportReportDeps["prepareFile"],
+    hooks?: Pick<ImportReportDeps, "finalizeBatchInTransaction" | "measurePhase">,
+  ): Promise<ImportReport> =>
+    importArtifactsIncrementally(batch, {
+      ...deps,
+      prepareFile,
+      ...(hooks?.finalizeBatchInTransaction === undefined
+        ? {}
+        : { finalizeBatchInTransaction: hooks.finalizeBatchInTransaction }),
+      ...(hooks?.measurePhase === undefined ? {} : { measurePhase: hooks.measurePhase }),
+    });
   return Object.freeze({
     archive: deps.archive,
     importBatchWithReport(
       batch: import("@enduragent/kernel/ingest").ImportBatch,
       hooks?: Pick<ImportReportDeps, "finalizeBatchInTransaction" | "measurePhase">,
     ) {
-      return importArtifactsIncrementally(batch, {
-        ...deps,
-        ...(hooks?.finalizeBatchInTransaction === undefined ? {} : { finalizeBatchInTransaction: hooks.finalizeBatchInTransaction }),
-        ...(hooks?.measurePhase === undefined ? {} : { measurePhase: hooks.measurePhase }),
-      });
+      return importWith(batch, deps.prepareFile, hooks);
+    },
+    importBatchWithPreparation(
+      batch: import("@enduragent/kernel/ingest").ImportBatch,
+      prepareFile: ImportReportDeps["prepareFile"],
+      hooks?: Pick<ImportReportDeps, "finalizeBatchInTransaction" | "measurePhase">,
+    ) {
+      if (typeof prepareFile !== "function") throw new TypeError("prepareFile must be a function");
+      return importWith(batch, prepareFile, hooks);
     },
   });
 }

--- a/packages/kernel-node/tests/activity-readers.test.ts
+++ b/packages/kernel-node/tests/activity-readers.test.ts
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtemp, rm } from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_REPAIR_FIXER_SETTINGS } from "@enduragent/kernel/ingest";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { runMigrations } from "@enduragent/kernel/store";
+import {
+  createManagedActivityReader,
+  ManagedActivityReaderError,
+  type ManagedActivityExtension,
+  type ManagedActivityReaderLimits,
+} from "@enduragent/kernel-node/chat-attachments";
+import { createNodeImportRuntime } from "../src/ingest/import-files.js";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const LIMITS: ManagedActivityReaderLimits = {
+  activityBytes: 104_857_600,
+  parserMs: 30_000,
+  parserOldGenerationMiB: 256,
+  sessions: 256,
+};
+const fixtureRoot = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "ingest");
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(name: string): Promise<Uint8Array> {
+  return new Uint8Array(await readFile(join(fixtureRoot, name)));
+}
+
+function source(bytes: Uint8Array, extension: ManagedActivityExtension) {
+  return {
+    objectId: "object-1",
+    relativePath: `chat-attachments/${"a".repeat(64)}/object-1`,
+    displayName: `ride.${extension}`,
+    byteSize: bytes.byteLength,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    extension,
+  } as const;
+}
+
+function reader(bytes: Uint8Array, limits = LIMITS, workerUrl?: URL) {
+  return createManagedActivityReader({
+    objects: { readObjectBytes: vi.fn(async () => Uint8Array.from(bytes)) },
+    limits,
+    ...(workerUrl === undefined ? {} : { workerUrl }),
+  });
+}
+
+async function failure(work: Promise<unknown>): Promise<string> {
+  try {
+    await work;
+  } catch (error) {
+    expect(error).toBeInstanceOf(ManagedActivityReaderError);
+    return (error as ManagedActivityReaderError).reason;
+  }
+  throw new Error("expected managed activity reader to reject");
+}
+
+describe("managed activity readers", () => {
+  it("ships a dedicated bounded activity worker", async () => {
+    const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+    expect(
+      (await stat(join(packageRoot, "dist/chat-attachments/activity-reader-worker.js"))).size,
+    ).toBeGreaterThan(1_000);
+  });
+
+  it.each([
+    ["brick-cycling.fit", "fit"],
+    ["fallback-cycling.tcx", "tcx"],
+    ["fallback-cycling.gpx", "gpx"],
+  ] as const)("prepares %s through the canonical decoder", async (name, extension) => {
+    const bytes = await fixture(name);
+    const result = await reader(bytes).read(
+      source(bytes, extension),
+      DEFAULT_REPAIR_FIXER_SETTINGS,
+    );
+    expect(result).toMatchObject({
+      outcome: "prepared",
+      projection: {
+        kind: "parsed-activity",
+        parsedActivityId: source(bytes, extension).sha256,
+        sourceFormat: extension,
+      },
+      artifact: { ext: extension },
+      prepared: { outcome: "prepared" },
+    });
+  });
+
+  it("feeds only worker-prepared data into the canonical importer and replays without duplicates", async () => {
+    const bytes = await fixture("brick-cycling.fit");
+    const prepared = await reader(bytes).read(source(bytes, "fit"), DEFAULT_REPAIR_FIXER_SETTINGS);
+    expect(prepared.outcome).toBe("prepared");
+    if (prepared.outcome !== "prepared") throw new Error("fixture was quarantined");
+    const root = await mkdtemp(join(tmpdir(), "activity-reader-"));
+    roots.push(root);
+    const store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    const runtime = createNodeImportRuntime({ archiveDir: join(root, "archive"), store });
+    const importPrepared = () =>
+      runtime.importBatchWithPreparation(
+        { files: [prepared.artifact], platform_records: [] },
+        async () => prepared.prepared,
+      );
+    expect((await importPrepared()).inserts.raw_file).toBe(1);
+    expect((await importPrepared()).inserts.raw_file).toBe(0);
+    expect(Number((await store.get("SELECT COUNT(*) AS count FROM session"))?.count)).toBe(1);
+    await store.close();
+  });
+
+  it("quarantines malformed activity content and isolates timeouts and managed-byte failures", async () => {
+    const malformed = new Uint8Array([12, 0, 0, 0, 0, 0, 0, 0, 46, 70, 73, 84]);
+    await expect(
+      reader(malformed).read(source(malformed, "fit"), DEFAULT_REPAIR_FIXER_SETTINGS),
+    ).resolves.toMatchObject({ outcome: "quarantined", code: expect.stringMatching(/^fit:/u) });
+
+    const bytes = await fixture("brick-cycling.fit");
+    const stalled = new URL("data:text/javascript,setInterval(() => {}, 1000)");
+    expect(
+      await failure(
+        reader(bytes, { ...LIMITS, parserMs: 20 }, stalled).read(
+          source(bytes, "fit"),
+          DEFAULT_REPAIR_FIXER_SETTINGS,
+        ),
+      ),
+    ).toBe("parser_timeout");
+    const broken = createManagedActivityReader({
+      objects: {
+        readObjectBytes: vi.fn(async () => {
+          throw new Error("private path");
+        }),
+      },
+      limits: LIMITS,
+    });
+    expect(await failure(broken.read(source(bytes, "fit"), DEFAULT_REPAIR_FIXER_SETTINGS))).toBe(
+      "integrity_mismatch",
+    );
+  });
+});

--- a/packages/kernel-node/tests/chat-attachment-repository.test.ts
+++ b/packages/kernel-node/tests/chat-attachment-repository.test.ts
@@ -200,9 +200,79 @@ describe("chat attachment repository", () => {
       createdAtMs: 6,
     });
     await expect(repository.listMessageAttachments("message-1")).resolves.toMatchObject([
-      { id: "attachment-1", object_id: "object-1" },
-      { id: "attachment-2", object_id: "object-2" },
+      { id: "attachment-1", object_id: "object-1", message_id: "message-1" },
+      { id: "attachment-2", object_id: "object-2", message_id: "message-1" },
     ]);
+  });
+
+  it("moves attachments through strict replay-safe durable states", async () => {
+    const repository = createChatAttachmentRepository(store);
+    const object = objectRow("object-1", "chat-a", "1".repeat(64));
+    await repository.reserveObject({ object, limits: LIMITS });
+    const activity = {
+      ...attachmentRow("attachment-1", object),
+      kind: "activity" as const,
+      display_name: "ride.fit",
+      media_type: "application/vnd.ant.fit",
+      extension: "fit",
+    };
+    await repository.commitAdmission({
+      objectId: object.id,
+      attachment: activity,
+      draftUpdatedAtMs: 3,
+    });
+    const parsed = JSON.stringify({ kind: "parsed-activity", parsedActivityId: "parsed-1" });
+    await expect(
+      repository.transitionAttachment({
+        conversationId: "chat-a",
+        attachmentId: "attachment-1",
+        from: ["preprocessing"],
+        to: "ready",
+        stateJson: parsed,
+        messageId: null,
+        updatedAtMs: 4,
+      }),
+    ).resolves.toMatchObject({ status: "ready", state_json: parsed, message_id: null });
+    await repository.linkMessage({
+      conversationId: "chat-a",
+      messageId: "message-1",
+      attachmentIds: ["attachment-1"],
+      createdAtMs: 5,
+    });
+    await expect(
+      repository.transitionAttachment({
+        conversationId: "chat-a",
+        attachmentId: "attachment-1",
+        from: ["ready", "failed"],
+        to: "importing",
+        stateJson: parsed,
+        messageId: "message-1",
+        updatedAtMs: 6,
+      }),
+    ).resolves.toMatchObject({ status: "importing", message_id: "message-1" });
+    await expect(
+      repository.transitionAttachment({
+        conversationId: "chat-a",
+        attachmentId: "attachment-1",
+        from: ["ready", "failed"],
+        to: "importing",
+        stateJson: parsed,
+        messageId: "message-1",
+        updatedAtMs: 6,
+      }),
+    ).resolves.toMatchObject({ status: "importing", updated_at_ms: 6 });
+
+    await expect(
+      repository.transitionAttachment({
+        conversationId: "chat-a",
+        attachmentId: "attachment-1",
+        from: ["importing"],
+        to: "imported",
+        stateJson: JSON.stringify({ kind: "canonical-activity", activityIds: ["activity-1"] }),
+        messageId: "message-2",
+        updatedAtMs: 7,
+      }),
+    ).rejects.toMatchObject({ code: "attachment_transition_conflict" });
   });
 
   it("serializes competing reservations so aggregate capacity cannot be oversubscribed", async () => {

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -1414,6 +1414,9 @@ describe("coach-dev import --report", () => {
               await Promise.all(paths.map((path) => rm(path)));
               return runtime.importBatchWithReport(batch);
             },
+            importBatchWithPreparation(batch, prepareFile, hooks) {
+              return runtime.importBatchWithPreparation(batch, prepareFile, hooks);
+            },
           };
         },
       };

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "archive/index": "src/archive/index.ts",
     "chat-attachments/index": "src/chat-attachments/index.ts",
     "chat-attachments/document-reader-worker": "src/chat-attachments/document-reader-worker.ts",
+    "chat-attachments/activity-reader-worker": "src/chat-attachments/activity-reader-worker.ts",
     "lock/index": "src/lock/index.ts",
     "store-export/index": "src/store-export/index.ts",
     "home/index": "src/home/index.ts",

--- a/packages/kernel/src/chat-attachments/repository.ts
+++ b/packages/kernel/src/chat-attachments/repository.ts
@@ -54,6 +54,17 @@ const DRAFT_STATES = new Set<ChatAttachmentDraftState>([
   "submitting",
   "clearing",
 ]);
+const STATUS_TRANSITIONS: Readonly<
+  Record<ChatAttachmentStatus, ReadonlySet<ChatAttachmentStatus>>
+> = {
+  preprocessing: new Set(["ready", "blocked", "failed"]),
+  blocked: new Set(["preprocessing"]),
+  failed: new Set(["preprocessing", "importing"]),
+  ready: new Set(["importing", "sent"]),
+  importing: new Set(["imported", "failed"]),
+  imported: new Set(["sent"]),
+  sent: new Set(),
+};
 
 function integer(value: number, name: string, minimum = 0): void {
   if (!Number.isSafeInteger(value) || value < minimum) {
@@ -534,7 +545,108 @@ export function createChatAttachmentRepository(
              VALUES (?,?,?,?,?) ON CONFLICT(message_id,attachment_id) DO NOTHING`,
             [messageId, conversationId, attachmentId, ordinal, createdAtMs],
           );
+          const linked = await store.get(
+            `UPDATE chat_attachment SET message_id=?,updated_at_ms=MAX(updated_at_ms,?)
+              WHERE id=? AND conversation_id=? AND (message_id IS NULL OR message_id=?)
+              RETURNING ${ATTACHMENT_COLUMNS}`,
+            [messageId, createdAtMs, attachmentId, conversationId, messageId],
+          );
+          if (linked === undefined) {
+            throw new ChatAttachmentInvariantError(
+              "attachment_message_conflict",
+              "attachment is already linked to another message",
+            );
+          }
         }
+      });
+    },
+
+    async transitionAttachment({
+      conversationId,
+      attachmentId,
+      from,
+      to,
+      stateJson,
+      messageId,
+      updatedAtMs,
+    }) {
+      if (
+        conversationId.length < 1 ||
+        conversationId.length > 512 ||
+        !SAFE_ID.test(attachmentId) ||
+        !STATUSES.has(to) ||
+        from.length === 0 ||
+        from.some((status) => !STATUSES.has(status)) ||
+        new Set(from).size !== from.length ||
+        (messageId !== null && (messageId.length < 1 || messageId.length > 512))
+      ) {
+        throw new ChatAttachmentInvariantError(
+          "invalid_attachment_transition",
+          "attachment transition is invalid",
+        );
+      }
+      if (stateJson !== null) {
+        try {
+          JSON.parse(stateJson);
+        } catch {
+          throw new ChatAttachmentInvariantError(
+            "invalid_state_json",
+            "attachment state is invalid JSON",
+          );
+        }
+      }
+      integer(updatedAtMs, "updated_at_ms");
+      return store.transaction(async () => {
+        const selected = await store.get(
+          `SELECT ${ATTACHMENT_COLUMNS} FROM chat_attachment WHERE id=? AND conversation_id=?`,
+          [attachmentId, conversationId],
+        );
+        if (selected === undefined) {
+          throw new ChatAttachmentInvariantError("attachment_missing", "attachment is missing");
+        }
+        const current = mapAttachment(selected);
+        if (current.status === to) {
+          if (current.state_json !== stateJson || current.message_id !== messageId) {
+            throw new ChatAttachmentInvariantError(
+              "attachment_replay_conflict",
+              "attachment transition replay conflicts with durable state",
+            );
+          }
+          return current;
+        }
+        if (
+          !from.includes(current.status) ||
+          !STATUS_TRANSITIONS[current.status].has(to) ||
+          updatedAtMs < current.updated_at_ms ||
+          (current.message_id !== null && current.message_id !== messageId)
+        ) {
+          throw new ChatAttachmentInvariantError(
+            "attachment_transition_conflict",
+            "attachment transition conflicts with durable state",
+          );
+        }
+        const updated = await store.get(
+          `UPDATE chat_attachment SET status=?,state_json=?,message_id=?,updated_at_ms=?
+            WHERE id=? AND conversation_id=? AND status=? AND updated_at_ms=?
+            RETURNING ${ATTACHMENT_COLUMNS}`,
+          [
+            to,
+            stateJson,
+            messageId,
+            updatedAtMs,
+            attachmentId,
+            conversationId,
+            current.status,
+            current.updated_at_ms,
+          ],
+        );
+        if (updated === undefined) {
+          throw new ChatAttachmentInvariantError(
+            "attachment_transition_conflict",
+            "attachment changed during transition",
+          );
+        }
+        return mapAttachment(updated);
       });
     },
 

--- a/packages/kernel/src/chat-attachments/types.ts
+++ b/packages/kernel/src/chat-attachments/types.ts
@@ -9,6 +9,24 @@ export type ChatAttachmentStatus =
   | "sent";
 export type ChatAttachmentDraftState = "active" | "restored" | "submitting" | "clearing";
 
+export interface ParsedActivityProjection {
+  readonly kind: "parsed-activity";
+  readonly parsedActivityId: string;
+  readonly sourceFormat: "fit" | "tcx" | "gpx";
+  readonly parserVersion: string;
+}
+
+export interface CanonicalActivityProjection {
+  readonly kind: "canonical-activity";
+  readonly importId: string;
+  readonly activityIds: readonly string[];
+}
+
+export interface FailedChatAttachmentProjection {
+  readonly stage: "parsing" | "import";
+  readonly failureCode: string;
+}
+
 export interface ChatAttachmentCapacityLimits {
   readonly attachmentsPerMessage: number;
   readonly messageBytes: number;
@@ -95,6 +113,15 @@ export interface ChatAttachmentRepository {
     readonly attachmentIds: readonly string[];
     readonly createdAtMs: number;
   }): Promise<void>;
+  transitionAttachment(input: {
+    readonly conversationId: string;
+    readonly attachmentId: string;
+    readonly from: readonly ChatAttachmentStatus[];
+    readonly to: ChatAttachmentStatus;
+    readonly stateJson: string | null;
+    readonly messageId: string | null;
+    readonly updatedAtMs: number;
+  }): Promise<ChatAttachmentRow>;
   listMessageAttachments(messageId: string): Promise<readonly ChatAttachmentRow[]>;
   listObjects(): Promise<readonly ChatAttachmentObjectRow[]>;
   markObjectMissing(objectId: string, updatedAtMs: number): Promise<void>;


### PR DESCRIPTION
## Summary
- preprocess admitted FIT, TCX, and GPX attachments in a bounded local worker
- durably link attachments to queued messages and import canonical Training data only on Send
- provide normalized activity context to Coach without exposing raw bytes or local paths
- recover idempotently across message-link, import, and pre-Coach interruption points

## Verification
- `pnpm check`
- `pnpm test` (9,703 passed; 15 skipped)
- focused attachment/import/queue tests (53 passed)
- `pnpm --filter @enduragent/desktop package:dir`
- `pnpm --filter @enduragent/desktop verify:package-layout`
- packaged ASAR contains `activity-reader-worker.js`
- autoreview: clean, no accepted/actionable findings