### PR TITLE
ATT-08: Recover attachment turns safely

### DIFF
--- a/.changeset/chat-attachment-recovery.md
+++ b/.changeset/chat-attachment-recovery.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Restore sent attachment cards after relaunch and harden attachment cleanup, recovery, and privacy-safe diagnostics.

--- a/apps/desktop-renderer/src/chat/hydration.ts
+++ b/apps/desktop-renderer/src/chat/hydration.ts
@@ -9,6 +9,7 @@ export interface TranscriptTurn {
   readonly completedAt: string;
   readonly athleteText: string;
   readonly coachText: string;
+  readonly attachments?: Extract<TranscriptPageEntry, { readonly kind: "turn" }>["attachments"];
 }
 
 export type TranscriptPage =
@@ -123,6 +124,7 @@ export function mergeHydratedMessages(
           text: entry.athleteText,
           delivery: "complete",
           historical: true,
+          ...(entry.attachments === undefined ? {} : { attachments: entry.attachments }),
         },
         {
           id: `history:coach:${entry.turnId}`,

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -78,6 +78,7 @@ function historicalTimeline(
             delivery: "complete",
             historical: true,
             text: entry.athleteText,
+            ...(entry.attachments === undefined ? {} : { attachments: entry.attachments }),
           },
         },
         {

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -472,6 +472,46 @@ describe("chat view adapter", () => {
     ]);
   });
 
+  it("projects persisted attachment references on a relaunched historical message", () => {
+    const published: ChatSurfaceState[] = [];
+    const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
+    const attachments = [
+      {
+        attachmentId: "attachment-1",
+        displayName: "training-notes.txt",
+        kind: "document" as const,
+        extension: "txt" as const,
+      },
+    ];
+
+    adapter.view.render(
+      EMPTY_CHAT_STATE,
+      controls({
+        hydration: {
+          status: "ready",
+          hasEarlier: false,
+          revision: 1,
+          change: "initial",
+          entries: [
+            {
+              kind: "turn",
+              turnId: "persisted-attachment",
+              completedAt: "2001-01-01T00:00:00.000Z",
+              athleteText: "Review this file",
+              coachText: "Reviewed",
+              attachments,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(published.at(-1)?.timeline[0]).toMatchObject({
+      kind: "message",
+      message: { role: "athlete", historical: true, attachments },
+    });
+  });
+
   it("keeps sending available while a turn streams and exposes the queue for the strip", () => {
     const published: ChatSurfaceState[] = [];
     const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });

--- a/apps/desktop-renderer/tests/chat-hydration.test.ts
+++ b/apps/desktop-renderer/tests/chat-hydration.test.ts
@@ -209,6 +209,30 @@ describe("chat transcript hydration", () => {
     ]);
   });
 
+  it("restores sent attachment cards on the athlete message after relaunch", () => {
+    const attached = {
+      ...turn("turn-attached"),
+      attachments: [
+        {
+          attachmentId: "attachment-1",
+          displayName: "training-notes.txt",
+          kind: "document" as const,
+          extension: "txt" as const,
+        },
+      ],
+    };
+
+    expect(mergeHydratedMessages([attached], [])).toMatchObject([
+      {
+        id: "history:athlete:turn-attached",
+        role: "athlete",
+        historical: true,
+        attachments: attached.attachments,
+      },
+      { id: "history:coach:turn-attached", role: "coach", historical: true },
+    ]);
+  });
+
   it("clears stale history and restarts from newest once after a reset signal", async () => {
     const recovery = deferred<TranscriptPage>();
     const readPage = vi

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -132,6 +132,12 @@ const CLAUDE_CLI_STATES = new Set([
   "working-area-unavailable",
 ]);
 const IMPORT_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
+const CHAT_ATTACHMENT_EXTENSIONS = {
+  document: new Set(["pdf", "txt", "csv", "docx"]),
+  activity: new Set(["fit", "tcx", "gpx"]),
+  workout: new Set(["zwo", "mrc", "erg"]),
+  image: new Set(["png", "jpg", "jpeg", "webp"]),
+} as const;
 const ACTIVITY_EXPORT_FORMATS = new Set(["fit", "gpx"]);
 const WORKOUT_ARCHIVE_FORMATS = new Set(["zwo", "mrc", "erg", "fit"]);
 const TRAINING_EXPORT_REFUSAL_REASONS = new Set([
@@ -403,6 +409,36 @@ function canonicalIsoTimestamp(value: unknown): value is string {
   }
 }
 
+function parseTranscriptAttachments(value: unknown): readonly unknown[] {
+  if (!Array.isArray(value) || value.length > 5) throw new TypeError();
+  return value.map((attachment) => {
+    if (
+      !record(attachment) ||
+      !exactKeys(attachment, ["attachmentId", "displayName", "kind", "extension"]) ||
+      typeof attachment.attachmentId !== "string" ||
+      attachment.attachmentId.length === 0 ||
+      attachment.attachmentId.length > 128 ||
+      typeof attachment.displayName !== "string" ||
+      attachment.displayName.length === 0 ||
+      attachment.displayName.length > 512 ||
+      typeof attachment.kind !== "string" ||
+      !(attachment.kind in CHAT_ATTACHMENT_EXTENSIONS) ||
+      typeof attachment.extension !== "string" ||
+      !CHAT_ATTACHMENT_EXTENSIONS[attachment.kind as keyof typeof CHAT_ATTACHMENT_EXTENSIONS].has(
+        attachment.extension as never,
+      )
+    ) {
+      throw new TypeError();
+    }
+    return {
+      attachmentId: attachment.attachmentId,
+      displayName: attachment.displayName,
+      kind: attachment.kind,
+      extension: attachment.extension,
+    };
+  });
+}
+
 function parseTranscriptPage(
   value: unknown,
   cursor: (candidate: unknown) => candidate is string = transcriptCursor,
@@ -420,9 +456,10 @@ function parseTranscriptPage(
     throw new TypeError();
   }
   const turns = value.turns.map((turn) => {
+    const turnKeys = ["turnId", "completedAt", "athleteText", "coachText"];
     if (
       !record(turn) ||
-      !exactKeys(turn, ["turnId", "completedAt", "athleteText", "coachText"]) ||
+      (!exactKeys(turn, turnKeys) && !exactKeys(turn, [...turnKeys, "attachments"])) ||
       typeof turn.turnId !== "string" ||
       turn.turnId.length === 0 ||
       !canonicalIsoTimestamp(turn.completedAt) ||
@@ -436,6 +473,9 @@ function parseTranscriptPage(
       completedAt: turn.completedAt,
       athleteText: turn.athleteText,
       coachText: turn.coachText,
+      ...(turn.attachments === undefined
+        ? {}
+        : { attachments: parseTranscriptAttachments(turn.attachments) }),
     };
   });
   if (value.status === "restart-required" && (turns.length !== 0 || value.nextCursor !== null)) {

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -491,6 +491,14 @@ ${"nonwrapping".repeat(36)}
                     completedAt: "2001-01-03T00:00:00.000Z",
                     athleteText: "Persisted athlete 3",
                     coachText: "**Persisted coach 3**",
+                    attachments: [
+                      {
+                        attachmentId: "attachment-persisted-3",
+                        displayName: "training-notes.txt",
+                        kind: "document",
+                        extension: "txt",
+                      },
+                    ],
                   },
                   {
                     turnId: "persisted-turn-4",
@@ -671,6 +679,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly athleteLiteral: boolean;
       readonly coachMarkdown: boolean;
       readonly loadEarlierHidden: boolean;
+      readonly sentAttachmentRestored: boolean;
     }>(`
       const conversation = document.querySelector(".conversation");
       const textarea = document.querySelector("#message");
@@ -709,10 +718,13 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         focusPreserved: document.activeElement === textarea,
         historySilent: allRows.every((row) => row.getAttribute("aria-live") === "off"),
         athleteLiteral:
-          allRows[4].querySelectorAll("strong").length === 0 &&
+          allRows[4].querySelector(".chat-message__text")?.querySelectorAll("strong").length === 0 &&
           allRows[4].querySelector(".chat-message__text").textContent === "Persisted athlete 3",
         coachMarkdown:
           allRows[5].querySelector("strong")?.textContent === "Persisted coach 3",
+        sentAttachmentRestored:
+          allRows[4].textContent.includes("training-notes.txt") &&
+          allRows[4].textContent.includes("TXT"),
         loadEarlierHidden: loadEarlier.hidden,
       };
     `);
@@ -727,6 +739,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       historySilent: true,
       athleteLiteral: true,
       coachMarkdown: true,
+      sentAttachmentRestored: true,
       loadEarlierHidden: true,
     });
     expect(calls.filter((call) => call.method === "getTranscriptPage")).toEqual([

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -926,6 +926,14 @@ describe("desktop preload ChatGPT auth", () => {
           completedAt: "1998-07-06T00:00:00.000Z",
           athleteText: "a",
           coachText: "b",
+          attachments: [
+            {
+              attachmentId: "attachment-1",
+              displayName: "training-notes.txt",
+              kind: "document",
+              extension: "txt",
+            },
+          ],
         },
       ],
       nextCursor: cursor,
@@ -978,6 +986,28 @@ describe("desktop preload ChatGPT auth", () => {
             completedAt: "not-a-timestamp",
             athleteText: "a",
             coachText: "b",
+          },
+        ],
+        nextCursor: null,
+      },
+      {
+        schemaVersion: 1,
+        status: "page",
+        turns: [
+          {
+            turnId: "turn-1",
+            completedAt: "1998-07-06T00:00:00.000Z",
+            athleteText: "a",
+            coachText: "b",
+            attachments: [
+              {
+                attachmentId: "attachment-1",
+                displayName: "ride.fit",
+                kind: "activity",
+                extension: "fit",
+                sourcePath: "/private/ride.fit",
+              },
+            ],
           },
         ],
         nextCursor: null,

--- a/packages/coach-contract/src/chat-attachment.ts
+++ b/packages/coach-contract/src/chat-attachment.ts
@@ -183,6 +183,16 @@ export const ChatAttachmentExtensionSchema = z.union([
 ]);
 export type ChatAttachmentExtension = z.infer<typeof ChatAttachmentExtensionSchema>;
 
+export const ChatAttachmentReferenceSchema = z
+  .object({
+    attachmentId: z.string().min(1).max(128),
+    displayName: z.string().min(1).max(512),
+    kind: ChatAttachmentKindSchema,
+    extension: ChatAttachmentExtensionSchema,
+  })
+  .strict();
+export type ChatAttachmentReference = z.infer<typeof ChatAttachmentReferenceSchema>;
+
 const ChatAttachmentComposerBaseSchema = z
   .object({
     schemaVersion: z.literal(1),

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -18,6 +18,7 @@ import {
   AdmitChatAttachmentRequestSchema,
   AttachmentAdmissionReadModelSchema,
   ChatAttachmentComposerReadModelSchema,
+  ChatAttachmentReferenceSchema,
   ChatAttachmentMutationRequestSchema,
   ClearChatAttachmentDraftRequestSchema,
   GetChatAttachmentComposerRequestSchema,
@@ -386,6 +387,7 @@ export const TranscriptPageTurnSchema = z
     athleteText: z.string(),
     coachText: z.string(),
     delivery: z.literal("interrupted").optional(),
+    attachments: z.array(ChatAttachmentReferenceSchema).max(5).optional(),
   })
   .strict();
 export type TranscriptPageTurn = z.infer<typeof TranscriptPageTurnSchema>;

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 25;
+export const PROTOCOL_VERSION = 26;

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../src/index.js";
 
 describe("chat queue contract", () => {
-  it("ships protocol 25 and rejects a blank enqueue without attachments", () => {
-    expect(PROTOCOL_VERSION).toBe(25);
+  it("ships protocol 26 and rejects a blank enqueue without attachments", () => {
+    expect(PROTOCOL_VERSION).toBe(26);
     expect(() =>
       EnqueueChatMessageRequestSchema.parse({
         chatId: "desktop",

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -151,8 +151,8 @@ describe("coach decision wire contract", () => {
     expect(parsed.entries).toHaveLength(1);
   });
 
-  it("projects resume completion explicitly at protocol 20", () => {
-    expect(PROTOCOL_VERSION).toBe(25);
+  it("projects resume completion explicitly at protocol 26", () => {
+    expect(PROTOCOL_VERSION).toBe(26);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -114,8 +114,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 24", () => {
-    expect(PROTOCOL_VERSION).toBe(25);
+  it("is 26", () => {
+    expect(PROTOCOL_VERSION).toBe(26);
   });
 
   it("requires Stop to name the exact active turn", () => {

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -421,6 +421,14 @@ describe("coach request and event projection", () => {
             completedAt: "1998-07-06T00:00:00.000Z",
             athleteText: "a",
             coachText: "b",
+            attachments: [
+              {
+                attachmentId: "attachment-1",
+                displayName: "training-notes.txt",
+                kind: "document",
+                extension: "txt",
+              },
+            ],
           },
         ],
         nextCursor: cursor,
@@ -447,6 +455,28 @@ describe("coach request and event projection", () => {
         turns: [],
         nextCursor: null,
         path: "/synthetic/private/transcript",
+      },
+      {
+        schemaVersion: 1,
+        status: "page",
+        turns: [
+          {
+            turnId: "turn-1",
+            completedAt: "1998-07-06T00:00:00.000Z",
+            athleteText: "a",
+            coachText: "b",
+            attachments: [
+              {
+                attachmentId: "attachment-1",
+                displayName: "ride.fit",
+                kind: "activity",
+                extension: "fit",
+                sourcePath: "/private/ride.fit",
+              },
+            ],
+          },
+        ],
+        nextCursor: null,
       },
     ]) {
       expect(GetTranscriptPageRpcResultSchema.safeParse(result).success).toBe(false);
@@ -1843,7 +1873,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-24 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-26 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1851,8 +1881,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 25,
-      serverProtocolVersion: 25,
+      clientProtocolVersion: 26,
+      serverProtocolVersion: 26,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1861,7 +1891,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(24);
+    expect(previous).toBe(25);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -1934,9 +1964,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 24 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 26 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(25);
+    expect(client.clientProtocolVersion).toBe(26);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2062,7 +2092,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version 25", () => {
-    expect(PROTOCOL_VERSION).toBe(25);
+  it("uses protocol version 26", () => {
+    expect(PROTOCOL_VERSION).toBe(26);
   });
 });

--- a/packages/coach/src/attachment-observability.ts
+++ b/packages/coach/src/attachment-observability.ts
@@ -1,0 +1,85 @@
+import type { LoggerPort } from "@enduragent/engine";
+import type { ChatAttachmentKind } from "@enduragent/kernel/store";
+
+export type AttachmentObservationOperation =
+  | "admission"
+  | "preprocess"
+  | "import"
+  | "cleanup"
+  | "reconcile";
+
+export type AttachmentObservationResult =
+  | "admission_unavailable"
+  | "accepted"
+  | "blocked"
+  | "empty_file"
+  | "failed"
+  | "file_too_large"
+  | "format_unsupported"
+  | "message_limit"
+  | "ready"
+  | "signature_mismatch"
+  | "storage_failed"
+  | "storage_full"
+  | "succeeded"
+  | "unsafe_source"
+  | "validation_failed";
+
+export interface AttachmentObservation {
+  readonly operation: AttachmentObservationOperation;
+  readonly kind: ChatAttachmentKind | "unknown";
+  readonly result: AttachmentObservationResult;
+  readonly byteSize?: number;
+  readonly durationMs?: number;
+  readonly count?: number;
+  readonly parserVersion?: string;
+}
+
+const SAFE_PARSER_VERSION = /^[a-z0-9][a-z0-9._-]{0,63}$/u;
+
+export function attachmentByteBucket(byteSize: number | undefined): string {
+  if (byteSize === undefined || !Number.isSafeInteger(byteSize) || byteSize < 0) return "unknown";
+  if (byteSize < 1_024) return "lt_1_kib";
+  if (byteSize < 1_048_576) return "lt_1_mib";
+  if (byteSize < 10_485_760) return "lt_10_mib";
+  if (byteSize < 104_857_600) return "lt_100_mib";
+  return "gte_100_mib";
+}
+
+export function attachmentDurationBucket(durationMs: number | undefined): string {
+  if (durationMs === undefined || !Number.isFinite(durationMs) || durationMs < 0) return "unknown";
+  if (durationMs < 10) return "lt_10_ms";
+  if (durationMs < 100) return "lt_100_ms";
+  if (durationMs < 1_000) return "lt_1_s";
+  if (durationMs < 10_000) return "lt_10_s";
+  return "gte_10_s";
+}
+
+export function attachmentCountBucket(count: number | undefined): string {
+  if (count === undefined || !Number.isSafeInteger(count) || count < 0) return "unknown";
+  if (count === 0) return "0";
+  if (count === 1) return "1";
+  if (count <= 5) return "2_5";
+  if (count <= 20) return "6_20";
+  return "gte_21";
+}
+
+export function observeChatAttachment(logger: LoggerPort, input: AttachmentObservation): void {
+  const parserVersion =
+    input.parserVersion !== undefined && SAFE_PARSER_VERSION.test(input.parserVersion)
+      ? input.parserVersion
+      : undefined;
+  try {
+    logger.info("chat_attachment_operation", {
+      operation: input.operation,
+      kind: input.kind,
+      result_code: input.result,
+      byte_bucket: attachmentByteBucket(input.byteSize),
+      duration_bucket: attachmentDurationBucket(input.durationMs),
+      count_bucket: attachmentCountBucket(input.count),
+      ...(parserVersion === undefined ? {} : { parser_version: parserVersion }),
+    });
+  } catch {
+    // Diagnostics must never break attachment admission, parsing, import, or cleanup.
+  }
+}

--- a/packages/coach/src/attachment-operations.ts
+++ b/packages/coach/src/attachment-operations.ts
@@ -12,6 +12,7 @@ import {
   chatAttachmentRelativePath,
   type ManagedChatAttachmentStore,
 } from "@enduragent/kernel-node/chat-attachments";
+import type { AttachmentObservation } from "./attachment-observability.js";
 
 function displayNameFromPath(sourcePath: string): string {
   const segments = sourcePath.split(/[\\/]/u);
@@ -56,6 +57,7 @@ export interface ManagedChatAttachmentOperationsInput {
     readonly attachment: ChatAttachmentRow;
     readonly object: ChatAttachmentObjectRow;
   }) => Promise<void>;
+  readonly observe?: (input: AttachmentObservation) => void;
 }
 
 const CAPACITY_LIMITS = {
@@ -333,16 +335,56 @@ export function createManagedChatAttachmentOperations(
     },
 
     async cleanupConversation(conversationId) {
-      await input.runExclusive(async () => {
-        const objects = await input.repository.cleanupConversation(conversationId);
-        for (const object of objects) await input.objects.removeObject(object.relative_path);
-      });
+      const startedAt = now();
+      try {
+        const count = await input.runExclusive(async () => {
+          const objects = await input.repository.cleanupConversation(conversationId);
+          for (const object of objects) await input.objects.removeObject(object.relative_path);
+          return objects.length;
+        });
+        input.observe?.({
+          operation: "cleanup",
+          kind: "unknown",
+          result: "succeeded",
+          count,
+          durationMs: now() - startedAt,
+        });
+      } catch (error) {
+        input.observe?.({
+          operation: "cleanup",
+          kind: "unknown",
+          result: "failed",
+          durationMs: now() - startedAt,
+        });
+        throw error;
+      }
     },
 
     async reconcile() {
-      await input.runExclusive(async () => {
-        await input.objects.reconcile(input.repository, CHAT_ATTACHMENT_LIMITS.orphanGraceMs);
-      });
+      const startedAt = now();
+      try {
+        const result = await input.runExclusive(() =>
+          input.objects.reconcile(input.repository, CHAT_ATTACHMENT_LIMITS.orphanGraceMs),
+        );
+        const count = result.missing + result.interruptedReservations + result.orphansRemoved;
+        if (count > 0) {
+          input.observe?.({
+            operation: "reconcile",
+            kind: "unknown",
+            result: "succeeded",
+            count,
+            durationMs: now() - startedAt,
+          });
+        }
+      } catch (error) {
+        input.observe?.({
+          operation: "reconcile",
+          kind: "unknown",
+          result: "failed",
+          durationMs: now() - startedAt,
+        });
+        throw error;
+      }
     },
   };
   return operations;

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -80,6 +80,7 @@ import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-no
 import type { CoachStoreWriterContext } from "./runtime.js";
 import {
   CHAT_ATTACHMENT_LIMITS,
+  type ChatAttachmentReference,
   type CoachEngine,
   type CoachOperations,
   type ConfigureRuntimeRpcParams,
@@ -158,6 +159,7 @@ import { createTrainingExportService } from "./training-export.js";
 import { serializeBoundaryError } from "./daemon/error-boundary.js";
 import { createPlanStorageService } from "./plan-storage.js";
 import { createManagedChatAttachmentOperations } from "./attachment-operations.js";
+import { observeChatAttachment, type AttachmentObservation } from "./attachment-observability.js";
 import { createActivityAttachmentOperations } from "./activity-attachment-operations.js";
 import { createWorkoutAttachmentOperations } from "./workout-attachment-operations.js";
 import { createManagedWorkoutReader } from "@enduragent/sport-cycling/workout-import";
@@ -964,6 +966,9 @@ export async function createLocalCoachComposition(
       }
     }
     const logger = createSubsystemLogger("agent", input.home.root);
+    const observeAttachment = (observation: AttachmentObservation): void => {
+      observeChatAttachment(logger, observation);
+    };
     const attachmentRepository = createChatAttachmentRepository(input.context.store);
     const attachmentObjects = createManagedChatAttachmentStore({
       archiveDir: input.home.archiveDir,
@@ -1062,10 +1067,57 @@ export async function createLocalCoachComposition(
       objects: attachmentObjects,
       runExclusive: (work) => runtime!.runExclusive(work),
       now,
+      observe: observeAttachment,
       onAdmitted: async (admitted) => {
-        await documentMediaAttachmentOperations.preprocessAdmitted(admitted);
-        await activityAttachmentOperations.preprocessAdmitted(admitted);
-        await workoutAttachmentOperations.preprocessAdmitted(admitted);
+        observeAttachment({
+          operation: "admission",
+          kind: admitted.attachment.kind,
+          result: "accepted",
+          byteSize: admitted.attachment.byte_size,
+          durationMs: Math.max(0, now() - admitted.attachment.created_at_ms),
+          count: 1,
+        });
+        const startedAt = now();
+        try {
+          await documentMediaAttachmentOperations.preprocessAdmitted(admitted);
+          await activityAttachmentOperations.preprocessAdmitted(admitted);
+          await workoutAttachmentOperations.preprocessAdmitted(admitted);
+          const current = await attachmentRepository.readAttachment(admitted.attachment.id);
+          let parserVersion: string | undefined;
+          if (current?.state_json !== null && current?.state_json !== undefined) {
+            try {
+              const state = JSON.parse(current.state_json) as Record<string, unknown>;
+              const candidate = state.parserVersion ?? state.readerVersion;
+              if (typeof candidate === "string") parserVersion = candidate;
+            } catch {
+              parserVersion = undefined;
+            }
+          }
+          observeAttachment({
+            operation: "preprocess",
+            kind: admitted.attachment.kind,
+            result:
+              current?.status === "ready"
+                ? "ready"
+                : current?.status === "blocked"
+                  ? "blocked"
+                  : "failed",
+            byteSize: admitted.attachment.byte_size,
+            durationMs: now() - startedAt,
+            count: 1,
+            ...(parserVersion === undefined ? {} : { parserVersion }),
+          });
+        } catch (error) {
+          observeAttachment({
+            operation: "preprocess",
+            kind: admitted.attachment.kind,
+            result: "failed",
+            byteSize: admitted.attachment.byte_size,
+            durationMs: now() - startedAt,
+            count: 1,
+          });
+          throw error;
+        }
       },
     });
     await attachmentOperations.reconcile();
@@ -1164,7 +1216,30 @@ export async function createLocalCoachComposition(
           });
         },
         prepareQueuedTurn: async (request) => {
-          const activity = await activityAttachmentOperations.turnPort.prepareQueuedTurn(request);
+          const importStartedAt = now();
+          let activity: Awaited<
+            ReturnType<typeof activityAttachmentOperations.turnPort.prepareQueuedTurn>
+          >;
+          try {
+            activity = await activityAttachmentOperations.turnPort.prepareQueuedTurn(request);
+            if (activity.activities.length > 0) {
+              observeAttachment({
+                operation: "import",
+                kind: "activity",
+                result: "succeeded",
+                durationMs: now() - importStartedAt,
+                count: activity.activities.length,
+              });
+            }
+          } catch (error) {
+            observeAttachment({
+              operation: "import",
+              kind: "activity",
+              result: "failed",
+              durationMs: now() - importStartedAt,
+            });
+            throw error;
+          }
           const documentMedia = await documentMediaAttachmentOperations.prepareLinkedTurn(request);
           const workout = await workoutAttachmentOperations.prepareLinkedTurn(request);
           const attachmentContext = [documentMedia.attachmentContext, workout.attachmentContext]
@@ -1176,8 +1251,22 @@ export async function createLocalCoachComposition(
           ]
             .filter((value): value is string => value !== undefined)
             .join("\n");
+          const attachments: ChatAttachmentReference[] = [];
+          for (const message of request.messages) {
+            for (const attachment of await attachmentRepository.listMessageAttachments(
+              message.messageId,
+            )) {
+              attachments.push({
+                attachmentId: attachment.id,
+                displayName: attachment.display_name,
+                kind: attachment.kind,
+                extension: attachment.extension as ChatAttachmentReference["extension"],
+              });
+            }
+          }
           return {
             ...activity,
+            attachments,
             nativeMedia: documentMedia.nativeMedia,
             ...(attachmentContext.length === 0 ? {} : { attachmentContext }),
             ...(untrustedAttachmentText.length === 0 ? {} : { untrustedAttachmentText }),
@@ -1669,15 +1758,42 @@ export async function createLocalCoachComposition(
         },
         dependencies.operationsDependencies,
       ),
-      admitChatAttachment: (request) => attachmentOperations.admit(request),
-      admitPastedChatAttachment: (request) => {
+      admitChatAttachment: async (request) => {
+        const startedAt = now();
+        const result = await attachmentOperations.admit(request);
+        if (result.status !== "accepted") {
+          observeAttachment({
+            operation: "admission",
+            kind: "unknown",
+            result:
+              result.status === "rejected"
+                ? result.reason
+                : result.status === "storage_failed"
+                  ? result.failureCode
+                  : "failed",
+            durationMs: now() - startedAt,
+            count: 1,
+          });
+        }
+        return result;
+      },
+      admitPastedChatAttachment: async (request) => {
+        const startedAt = now();
         const bytes = Buffer.from(request.dataBase64, "base64");
         if (
           bytes.byteLength === 0 ||
           bytes.toString("base64") !== request.dataBase64 ||
           bytes.byteLength > CHAT_ATTACHMENT_LIMITS.imageBytes
         ) {
-          return Promise.resolve({
+          observeAttachment({
+            operation: "admission",
+            kind: "unknown",
+            result: "validation_failed",
+            byteSize: bytes.byteLength,
+            durationMs: now() - startedAt,
+            count: 1,
+          });
+          return {
             selectionId: request.selectionId,
             displayName: request.displayName,
             status: "rejected" as const,
@@ -1685,14 +1801,30 @@ export async function createLocalCoachComposition(
               bytes.byteLength > CHAT_ATTACHMENT_LIMITS.imageBytes
                 ? ("file_too_large" as const)
                 : ("validation_failed" as const),
-          });
+          };
         }
-        return attachmentOperations.admitPasted({
+        const result = await attachmentOperations.admitPasted({
           chatId: request.chatId,
           selectionId: request.selectionId,
           displayName: request.displayName,
           bytes,
         });
+        if (result.status !== "accepted") {
+          observeAttachment({
+            operation: "admission",
+            kind: "image",
+            result:
+              result.status === "rejected"
+                ? result.reason
+                : result.status === "storage_failed"
+                  ? result.failureCode
+                  : "failed",
+            byteSize: bytes.byteLength,
+            durationMs: now() - startedAt,
+            count: 1,
+          });
+        }
+        return result;
       },
       getChatAttachmentComposer: (request) => attachmentComposerOperations.read(request.chatId),
       saveChatAttachmentDraftText: (request) =>

--- a/packages/coach/tests/attachment-observability.test.ts
+++ b/packages/coach/tests/attachment-observability.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LoggerPort } from "@enduragent/engine";
+import {
+  attachmentByteBucket,
+  attachmentCountBucket,
+  attachmentDurationBucket,
+  observeChatAttachment,
+} from "../src/attachment-observability.js";
+
+function logger() {
+  const info = vi.fn();
+  const value: LoggerPort = {
+    debug: vi.fn(),
+    info,
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return { value, info };
+}
+
+describe("Chat attachment observability", () => {
+  it("uses bounded buckets instead of exact sizes, durations, or counts", () => {
+    expect([0, 1_023, 1_024, 1_048_576, 10_485_760, 104_857_600].map(attachmentByteBucket)).toEqual(
+      ["lt_1_kib", "lt_1_kib", "lt_1_mib", "lt_10_mib", "lt_100_mib", "gte_100_mib"],
+    );
+    expect([0, 9, 10, 100, 1_000, 10_000].map(attachmentDurationBucket)).toEqual([
+      "lt_10_ms",
+      "lt_10_ms",
+      "lt_100_ms",
+      "lt_1_s",
+      "lt_10_s",
+      "gte_10_s",
+    ]);
+    expect([0, 1, 2, 5, 6, 20, 21].map(attachmentCountBucket)).toEqual([
+      "0",
+      "1",
+      "2_5",
+      "2_5",
+      "6_20",
+      "6_20",
+      "gte_21",
+    ]);
+  });
+
+  it("emits only the privacy-safe allowlist and drops an unsafe parser version", () => {
+    const log = logger();
+    const privateMarker = "/Users/athlete/private/ride-secret.fit";
+
+    observeChatAttachment(log.value, {
+      operation: "preprocess",
+      kind: "activity",
+      result: "ready",
+      byteSize: 4_096,
+      durationMs: 52,
+      count: 1,
+      parserVersion: privateMarker,
+    });
+
+    expect(log.info).toHaveBeenCalledWith("chat_attachment_operation", {
+      operation: "preprocess",
+      kind: "activity",
+      result_code: "ready",
+      byte_bucket: "lt_1_mib",
+      duration_bucket: "lt_100_ms",
+      count_bucket: "1",
+    });
+    expect(JSON.stringify(log.info.mock.calls)).not.toContain(privateMarker);
+  });
+
+  it("includes a validated internal parser version without accepting arbitrary fields", () => {
+    const log = logger();
+    observeChatAttachment(log.value, {
+      operation: "preprocess",
+      kind: "workout",
+      result: "ready",
+      parserVersion: "cycling-workout-v1",
+    });
+
+    expect(log.info.mock.calls[0]?.[1]).toEqual({
+      operation: "preprocess",
+      kind: "workout",
+      result_code: "ready",
+      byte_bucket: "unknown",
+      duration_bucket: "unknown",
+      count_bucket: "unknown",
+      parser_version: "cycling-workout-v1",
+    });
+  });
+
+  it("never lets a diagnostics write break attachment work", () => {
+    const value: LoggerPort = {
+      debug: vi.fn(),
+      info: vi.fn(() => {
+        throw new Error("log storage full");
+      }),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    expect(() =>
+      observeChatAttachment(value, {
+        operation: "cleanup",
+        kind: "unknown",
+        result: "succeeded",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/coach/tests/attachment-operations.test.ts
+++ b/packages/coach/tests/attachment-operations.test.ts
@@ -26,7 +26,10 @@ describe("managed Chat attachment operations", () => {
     await rm(root, { recursive: true, force: true });
   });
 
-  function createOperations(ids: readonly string[]) {
+  function createOperations(
+    ids: readonly string[],
+    observe?: Parameters<typeof createManagedChatAttachmentOperations>[0]["observe"],
+  ) {
     let index = 0;
     const repository = createChatAttachmentRepository(store);
     const objects = createManagedChatAttachmentStore({
@@ -47,6 +50,7 @@ describe("managed Chat attachment operations", () => {
         runExclusive: (work) => work(),
         now: () => 100,
         randomId: () => ids[index++]!,
+        ...(observe === undefined ? {} : { observe }),
       }),
     };
   }
@@ -265,12 +269,11 @@ describe("managed Chat attachment operations", () => {
     const secondPath = join(root, "second.txt");
     await writeFile(firstPath, "first");
     await writeFile(secondPath, "second");
-    const { operations, repository } = createOperations([
-      "object-1",
-      "attachment-1",
-      "object-2",
-      "attachment-2",
-    ]);
+    const observations: unknown[] = [];
+    const { operations, repository } = createOperations(
+      ["object-1", "attachment-1", "object-2", "attachment-2"],
+      (value) => observations.push(value),
+    );
     await operations.admit({
       chatId: "desktop",
       selectionId: "s1",
@@ -291,5 +294,22 @@ describe("managed Chat attachment operations", () => {
     await operations.cleanupConversation("desktop");
     await operations.cleanupConversation("desktop");
     await expect(repository.listObjects()).resolves.toEqual([]);
+    expect(observations).toEqual([
+      {
+        operation: "cleanup",
+        kind: "unknown",
+        result: "succeeded",
+        count: 1,
+        durationMs: 0,
+      },
+      {
+        operation: "cleanup",
+        kind: "unknown",
+        result: "succeeded",
+        count: 0,
+        durationMs: 0,
+      },
+    ]);
+    expect(JSON.stringify(observations)).not.toContain("desktop");
   });
 });

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 25 as const,
-      serverProtocolVersion: 25 as const,
+      clientProtocolVersion: 26 as const,
+      serverProtocolVersion: 26 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -304,7 +304,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(25);
+    expect(PROTOCOL_VERSION).toBe(26);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/core/src/agent/chat-queue-store.ts
+++ b/packages/core/src/agent/chat-queue-store.ts
@@ -304,10 +304,27 @@ export class ChatQueueStore {
 
   reconcile(chatId: string, completedTurnIds: ReadonlySet<string>): ChatQueueSnapshot {
     const state = this.read(chatId);
-    if (state.claim?.status !== "claimed") return this.snapshot(state);
+    if (state.claim === undefined) return this.snapshot(state);
     return completedTurnIds.has(state.claim.turnId)
       ? this.complete(chatId, state.claim.claimId)
-      : this.requireRetry(chatId, state.claim.claimId);
+      : state.claim.status === "claimed"
+        ? this.requireRetry(chatId, state.claim.claimId)
+        : this.snapshot(state);
+  }
+
+  getCompletedClaim(
+    chatId: string,
+    completedTurnIds: ReadonlySet<string>,
+  ): { readonly turnId: string; readonly messageIds: readonly string[] } | null {
+    const state = this.read(chatId);
+    if (state.claim === undefined || !completedTurnIds.has(state.claim.turnId)) return null;
+    const claimedIds = new Set(state.claim.queuedMessageIds);
+    return {
+      turnId: state.claim.turnId,
+      messageIds: state.items
+        .filter((item) => claimedIds.has(item.queuedMessageId))
+        .map((item) => item.messageId),
+    };
   }
 
   private snapshot(state: StoredQueue): ChatQueueSnapshot {

--- a/packages/core/src/agent/conversation-store.ts
+++ b/packages/core/src/agent/conversation-store.ts
@@ -48,6 +48,10 @@ export interface ConversationStorePort extends ChatStorePort, TranscriptWriterPo
   requireChatQueueRetry(chatId: string, claimId: string): ChatQueueSnapshot;
   retryChatQueueClaim(chatId: string, claimId: string, turnId: string): ChatQueueSnapshot;
   clearChatQueue(chatId: string): ChatQueueSnapshot;
+  getCompletedChatQueueClaim(chatId: string): {
+    readonly turnId: string;
+    readonly messageIds: readonly string[];
+  } | null;
   appendDecisionRequested(input: TranscriptDecisionRequestedInput): CoachDecisionReadModel;
   answerDecision(input: TranscriptDecisionAnsweredInput): CoachDecisionReadModel;
   skipDecision(input: TranscriptDecisionSkippedInput): CoachDecisionReadModel;
@@ -283,6 +287,14 @@ export class ConversationStore implements ConversationStorePort {
 
   reconcileChatQueue(chatId: string): ChatQueueSnapshot {
     return this.queueStore().reconcile(chatId, this.transcriptStore.getTerminalTurnIds(chatId));
+  }
+
+  getCompletedChatQueueClaim(chatId: string) {
+    this.recoverBeforeAccess(chatId);
+    return this.queueStore().getCompletedClaim(
+      chatId,
+      this.transcriptStore.getTerminalTurnIds(chatId),
+    );
   }
 
   private queueStore(): ChatQueueStore {

--- a/packages/core/src/agent/transcript-store.ts
+++ b/packages/core/src/agent/transcript-store.ts
@@ -26,6 +26,7 @@ import type {
   TranscriptWriterPort,
 } from "@enduragent/engine";
 import {
+  ChatAttachmentReferenceSchema,
   CoachDecisionAnswerSchema,
   CoachDecisionReadModelSchema,
   type CoachDecisionAnswer,
@@ -450,23 +451,18 @@ function parseRecordBytes(bytes: Buffer): TranscriptRecord | null {
   if (value === null || value.version !== TRANSCRIPT_SCHEMA_VERSION) return null;
 
   if (value.kind === "turn-completed" || value.kind === "turn-interrupted") {
+    const keys = ["version", "kind", "chatId", "turnId", "completedAt", "athleteText", "coachText"];
     if (
-      !hasExactKeys(value, [
-        "version",
-        "kind",
-        "chatId",
-        "turnId",
-        "completedAt",
-        "athleteText",
-        "coachText",
-      ]) ||
+      (!hasExactKeys(value, keys) && !hasExactKeys(value, [...keys, "attachments"])) ||
       typeof value.chatId !== "string" ||
       typeof value.turnId !== "string" ||
       value.turnId.length === 0 ||
       typeof value.completedAt !== "string" ||
       !isIsoTimestamp(value.completedAt) ||
       typeof value.athleteText !== "string" ||
-      typeof value.coachText !== "string"
+      typeof value.coachText !== "string" ||
+      (value.attachments !== undefined &&
+        !ChatAttachmentReferenceSchema.array().max(5).safeParse(value.attachments).success)
     ) {
       return null;
     }
@@ -638,7 +634,9 @@ function completedTurnRecord(input: TranscriptCompletedTurnInput): TranscriptCom
     typeof input.completedAt !== "string" ||
     !isIsoTimestamp(input.completedAt) ||
     typeof input.athleteText !== "string" ||
-    typeof input.coachText !== "string"
+    typeof input.coachText !== "string" ||
+    (input.attachments !== undefined &&
+      !ChatAttachmentReferenceSchema.array().max(5).safeParse(input.attachments).success)
   ) {
     throw new TypeError("Completed transcript turn is invalid.");
   }
@@ -650,6 +648,7 @@ function completedTurnRecord(input: TranscriptCompletedTurnInput): TranscriptCom
     completedAt: input.completedAt,
     athleteText: input.athleteText,
     coachText: input.coachText,
+    ...(input.attachments === undefined ? {} : { attachments: [...input.attachments] }),
   };
 }
 
@@ -906,6 +905,7 @@ function transcriptPageTurn(record: TranscriptTurnRecord): TranscriptPageTurn {
     completedAt: record.completedAt,
     athleteText: record.athleteText,
     coachText: record.coachText,
+    ...(record.attachments === undefined ? {} : { attachments: record.attachments }),
     ...(record.kind === "turn-interrupted" ? { delivery: "interrupted" as const } : {}),
   };
 }

--- a/packages/core/tests/chat-queue-store.test.ts
+++ b/packages/core/tests/chat-queue-store.test.ts
@@ -175,6 +175,21 @@ describe("ChatQueueStore", () => {
     ).toMatchObject({
       claimId: "claim-2",
     });
+
+    const retry = store();
+    retry.value.enqueue("desktop", "submission-3", "First", "message-3", "athlete-message-3");
+    retry.value.claim("desktop", {
+      claimId: "claim-3",
+      turnId: "turn-3",
+      queuedMessageIds: ["message-3"],
+    });
+    retry.value.requireRetry("desktop", "claim-3");
+    const restored = new ChatQueueStore(retry.root);
+    expect(restored.getCompletedClaim("desktop", new Set(["turn-3"]))).toEqual({
+      turnId: "turn-3",
+      messageIds: ["athlete-message-3"],
+    });
+    expect(restored.reconcile("desktop", new Set(["turn-3"])).items).toEqual([]);
   });
 
   it("fails closed on corrupt or non-private queue snapshots", () => {

--- a/packages/core/tests/transcript-store.test.ts
+++ b/packages/core/tests/transcript-store.test.ts
@@ -410,6 +410,54 @@ describe("TranscriptStore append and corruption handling", () => {
     ]);
   });
 
+  it("round-trips only safe sent-attachment references for relaunch hydration", () => {
+    const dataDir = makeDataDir();
+    const store = new TranscriptStore(dataDir);
+    const input = {
+      ...turn("chat-attachments", "turn-1", "Review this", "Reviewed"),
+      attachments: [
+        {
+          attachmentId: "attachment-1",
+          displayName: "training-notes.txt",
+          kind: "document" as const,
+          extension: "txt" as const,
+        },
+      ],
+    };
+
+    store.appendCompletedTurn(input);
+
+    expect(store.readCurrentConversation(input.chatId)).toEqual([
+      { version: 1, kind: "turn-completed", ...input },
+    ]);
+    const page = store.readCurrentConversationPage(input.chatId, { cursor: null, limit: 10 });
+    expect(page).toMatchObject({
+      status: "page",
+      turns: [{ turnId: "turn-1", attachments: input.attachments }],
+    });
+    expect(readFileSync(transcriptPath(dataDir, input.chatId), "utf8")).not.toContain(
+      "private/source/path",
+    );
+  });
+
+  it("rejects attachment transcript fields outside the strict safe reference shape", () => {
+    const store = new TranscriptStore(makeDataDir());
+    expect(() =>
+      store.appendCompletedTurn({
+        ...turn("chat-attachments-invalid", "turn-1"),
+        attachments: [
+          {
+            attachmentId: "attachment-1",
+            displayName: "ride.fit",
+            kind: "activity",
+            extension: "fit",
+            sourcePath: "/private/ride.fit",
+          },
+        ],
+      } as never),
+    ).toThrow("Completed transcript turn is invalid");
+  });
+
   it("round-trips an interrupted turn and projects its delivery on transcript pages", () => {
     const dataDir = makeDataDir();
     const store = new TranscriptStore(dataDir);

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -5,6 +5,7 @@ import type { ResolvedCs } from "@enduragent/kernel/reference/cs-resolution";
 import type {
   AnswerCoachDecisionRpcParams,
   AnswerCoachDecisionRpcResult,
+  ChatAttachmentReference,
   CoachDecisionContinuationLineage,
   CoachDecisionReadModel,
   GetCoachDecisionRpcParams,
@@ -697,6 +698,7 @@ export class CoachAgent {
       attachmentContext?: string;
       untrustedAttachmentText?: string;
       nativeMedia?: readonly ChatNativeMediaInput[];
+      attachments?: readonly ChatAttachmentReference[];
     },
     onEvent?: TurnEventHandler,
     onDecision?: (decision: CoachDecisionReadModel) => void,
@@ -1180,6 +1182,7 @@ export class CoachAgent {
                 completedAt: new Date(this.ports.now()).toISOString(),
                 athleteText: userMessage,
                 coachText: responseText,
+                ...(turn?.attachments === undefined ? {} : { attachments: turn.attachments }),
               });
               emitEvent({ type: "final-text", turnId, text: responseText });
               return responseText;
@@ -1230,6 +1233,7 @@ export class CoachAgent {
                   completedAt: new Date(this.ports.now()).toISOString(),
                   athleteText: userMessage,
                   coachText: TAINTED_BY_WRITES_MESSAGE,
+                  ...(turn?.attachments === undefined ? {} : { attachments: turn.attachments }),
                 });
                 emitEvent({ type: "final-text", turnId, text: TAINTED_BY_WRITES_MESSAGE });
                 return TAINTED_BY_WRITES_MESSAGE;
@@ -1398,6 +1402,7 @@ export class CoachAgent {
               completedAt: new Date(this.ports.now()).toISOString(),
               athleteText: userMessage,
               coachText: streamedText,
+              ...(turn?.attachments === undefined ? {} : { attachments: turn.attachments }),
             });
             this.emitTurnOutcome({
               turnId,

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -1,6 +1,7 @@
 import type {
   AttachmentCapabilitiesReadModel,
   AthleteState,
+  ChatAttachmentReference,
   ChatQueueSnapshot,
   CoachDecisionAnswer,
   CoachDecisionContinuationLineage,
@@ -171,6 +172,10 @@ export interface ChatStorePort {
   requireChatQueueRetry?(chatId: string, claimId: string): ChatQueueSnapshot;
   retryChatQueueClaim?(chatId: string, claimId: string, turnId: string): ChatQueueSnapshot;
   clearChatQueue?(chatId: string): ChatQueueSnapshot;
+  getCompletedChatQueueClaim?(chatId: string): {
+    readonly turnId: string;
+    readonly messageIds: readonly string[];
+  } | null;
 }
 
 export interface ChatAttachmentActivitySummary {
@@ -197,6 +202,7 @@ export interface ChatNativeMediaInput {
 
 export interface ChatAttachmentTurnPreparation {
   readonly activities: readonly ChatAttachmentActivitySummary[];
+  readonly attachments?: readonly ChatAttachmentReference[];
   readonly attachmentContext?: string;
   readonly untrustedAttachmentText?: string;
   readonly nativeMedia?: readonly ChatNativeMediaInput[];
@@ -240,6 +246,7 @@ export interface TranscriptCompletedTurnInput {
   readonly completedAt: string;
   readonly athleteText: string;
   readonly coachText: string;
+  readonly attachments?: readonly ChatAttachmentReference[];
 }
 
 export type TranscriptInterruptedTurnInput = TranscriptCompletedTurnInput;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -109,8 +109,16 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
       throw new Error("Durable chat queue storage is unavailable.");
     return operation as NonNullable<EngineHostPorts["chatStore"][K]>;
   };
-  const snapshot = (chatId: string): ChatQueueSnapshot =>
-    queuePort("getChatQueue").call(input.ports.chatStore, chatId);
+  const snapshot = async (chatId: string): Promise<ChatQueueSnapshot> => {
+    const completedClaim = input.ports.chatStore.getCompletedChatQueueClaim?.(chatId);
+    if (completedClaim !== undefined && completedClaim !== null) {
+      await input.ports.chatAttachments?.completeQueuedTurn({
+        chatId,
+        messageIds: completedClaim.messageIds,
+      });
+    }
+    return queuePort("getChatQueue").call(input.ports.chatStore, chatId);
+  };
   const queueText = (items: readonly QueuedChatMessage[]): string =>
     items.map((item) => item.text).join("\n\n");
   const activityContext = (
@@ -132,7 +140,7 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
     const active = queueRuns.get(chatId);
     if (active !== undefined) return active;
     const task = withQueueAuthority(chatId, async (): Promise<ChatQueueRunResult> => {
-      const before = snapshot(chatId);
+      const before = await snapshot(chatId);
       const pendingDecision = input.ports.coachDecisions?.getDecision(chatId);
       if (
         pendingDecision?.status === "unanswered" ||
@@ -217,6 +225,10 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
                 ...(attachmentPreparation?.untrustedAttachmentText === undefined
                   ? {}
                   : { untrustedAttachmentText: attachmentPreparation.untrustedAttachmentText }),
+                ...(attachmentPreparation?.attachments === undefined ||
+                attachmentPreparation.attachments.length === 0
+                  ? {}
+                  : { attachments: attachmentPreparation.attachments }),
               },
           (event) => {
             if (event.type === "interrupted") interrupted = true;

--- a/packages/engine/tests/chat-queue.test.ts
+++ b/packages/engine/tests/chat-queue.test.ts
@@ -137,13 +137,21 @@ describe("engine durable chat queue", () => {
             ],
           },
         ],
+        attachments: [
+          {
+            attachmentId: "attachment-1",
+            displayName: "morning-ride.fit",
+            kind: "activity" as const,
+            extension: "fit" as const,
+          },
+        ],
       };
     });
     const completeQueuedTurn = vi.fn(async () => {
       order.push("completed");
     });
     const requests: ModelTransportRequest[] = [];
-    const { engine } = setup(
+    const value = setup(
       undefined,
       async (request) => {
         order.push("coach");
@@ -152,13 +160,14 @@ describe("engine durable chat queue", () => {
       },
       { prepareQueuedTurn, completeQueuedTurn },
     );
-    await engine.enqueueChatMessage!({
+    const transcriptAppend = vi.spyOn(value.ports.transcriptWriter, "appendCompletedTurn");
+    await value.engine.enqueueChatMessage!({
       chatId: "desktop",
       submissionId: "submission-1",
       text: "Review the ride",
       attachmentIds: ["attachment-1"],
     });
-    await expect(engine.resumeChatQueue!({ chatId: "desktop" })).resolves.toMatchObject({
+    await expect(value.engine.resumeChatQueue!({ chatId: "desktop" })).resolves.toMatchObject({
       response: { text: "Reviewed" },
       snapshot: { items: [] },
     });
@@ -175,6 +184,18 @@ describe("engine durable chat queue", () => {
     expect(providerMessages).toContain("Canonical Training activities imported");
     expect(providerMessages).toContain("activity-1");
     expect(providerMessages).not.toContain("raw-fit-private-bytes");
+    expect(transcriptAppend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          {
+            attachmentId: "attachment-1",
+            displayName: "morning-ride.fit",
+            kind: "activity",
+            extension: "fit",
+          },
+        ],
+      }),
+    );
   });
 
   it("leaves the stable queue claim retryable when attachment preparation fails before Coach", async () => {
@@ -199,6 +220,49 @@ describe("engine durable chat queue", () => {
       items: [{ messageId: "id-2", attachmentIds: ["attachment-1"] }],
       retryRequired: { queuedMessageIds: ["id-1"] },
     });
+  });
+
+  it("recovers attachment completion after restart without sending a completed turn twice", async () => {
+    const generate = vi.fn(async () => generated("Reviewed once"));
+    const completeQueuedTurn = vi
+      .fn<ChatAttachmentTurnPort["completeQueuedTurn"]>()
+      .mockRejectedValueOnce(new Error("completion interrupted"))
+      .mockResolvedValue(undefined);
+    const chatAttachments: ChatAttachmentTurnPort = {
+      prepareQueuedTurn: async () => ({
+        activities: [],
+        attachments: [
+          {
+            attachmentId: "attachment-1",
+            displayName: "ride.fit",
+            kind: "activity",
+            extension: "fit",
+          },
+        ],
+      }),
+      completeQueuedTurn,
+    };
+    const first = setup(undefined, generate, chatAttachments);
+    const queued = await first.engine.enqueueChatMessage!({
+      chatId: "desktop",
+      submissionId: "submission-recovery",
+      text: "Review the ride",
+      attachmentIds: ["attachment-1"],
+    });
+
+    await expect(first.engine.resumeChatQueue!({ chatId: "desktop" })).rejects.toThrow(
+      "completion interrupted",
+    );
+
+    const restored = setup(first.root, generate, chatAttachments);
+    const recovered = await restored.engine.getChatQueue!({ chatId: "desktop" });
+    expect(recovered.items).toEqual([]);
+    expect(recovered).not.toHaveProperty("retryRequired");
+    expect(completeQueuedTurn).toHaveBeenNthCalledWith(2, {
+      chatId: "desktop",
+      messageIds: [queued.items[0]!.messageId],
+    });
+    expect(generate).toHaveBeenCalledTimes(1);
   });
 
   it("revalidates capability before Send and keeps provider image bytes out of history", async () => {


### PR DESCRIPTION
## Summary
- restore safe attachment cards from durable transcript pages after relaunch
- reconcile completed queue claims without resending Coach responses
- add privacy-safe attachment operation metrics and idempotent cleanup/recovery coverage

## Verification
- `pnpm check`
- `pnpm test` — 9,788 passed, 15 skipped
- 323 targeted attachment, recovery, and security tests
- desktop persisted-conversation integration test
- autoreview clean: no accepted/actionable findings