### PR TITLE
feat: add Plan Race Course flow

### DIFF
--- a/.changeset/plan-course-flow.md
+++ b/.changeset/plan-course-flow.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Add or skip a GPX/FIT Race Course while creating a Plan, recover from invalid or elevation-free files, and recalculate Drafts without changing the active Plan.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -181,6 +181,7 @@ export function bootRenderer(): Disposer {
     publishCoach: (next) => store.getState().setPlanCoach(next),
     publishDiscardConfirmation: (open) => store.getState().setPlanDiscardConfirmation(open),
     publishRevisionComposer: (open) => store.getState().setPlanRevisionComposer(open),
+    publishCoursePicker: (open) => store.getState().setPlanCoursePicker(open),
   });
   store.getState().bindPlanActions({
     open: () => planAdapter.open(),
@@ -201,6 +202,13 @@ export function bootRenderer(): Disposer {
     discardDraft: () => planAdapter.discardDraft(),
     openRevisionComposer: () => planAdapter.openRevisionComposer(),
     closeRevisionComposer: () => planAdapter.closeRevisionComposer(),
+    openCoursePicker: () => planAdapter.openCoursePicker(),
+    closeCoursePicker: () => planAdapter.closeCoursePicker(),
+    chooseCourseFile: () => planAdapter.chooseCourseFile(),
+    continueWithoutCourse: () => planAdapter.continueWithoutCourse(),
+    useCourseWithoutElevation: () => planAdapter.useCourseWithoutElevation(),
+    removeCourse: () => planAdapter.removeCourse(),
+    returnToCoach: () => planAdapter.returnToCoach(),
     retry: () => planAdapter.retry(),
   });
   planAdapter.start();

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -17,9 +17,7 @@ interface EnduragentAuth {
     readonly limit: number;
   }): Promise<DesktopTranscriptPage>;
   getPlanState(): Promise<DesktopPlanStateResult>;
-  executePlanTransition(
-    input: DesktopPlanTransitionCommand,
-  ): Promise<DesktopPlanTransitionResult>;
+  executePlanTransition(input: DesktopPlanTransitionCommand): Promise<DesktopPlanTransitionResult>;
   onPlanProgress(listener: (progress: DesktopPlanProgressEvent) => void): () => void;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
   retryFailedCredentials(): Promise<readonly CredentialSlotStatus[]>;
@@ -59,6 +57,7 @@ interface EnduragentAuth {
   acknowledgeTelegramGapWarning(): Promise<DesktopTelegramMutationResult>;
   setAppearance(appearance: "system" | "light" | "dark"): void;
   chooseImportFiles(): Promise<readonly string[]>;
+  choosePlanRaceCourseFile(): Promise<string | null>;
   exportTrainingFile(input: DesktopTrainingExportRequest): Promise<DesktopTrainingExportResult>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
   getUpdateState(): Promise<DesktopUpdateState>;

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -25,6 +25,7 @@ import { createChatViewAdapter } from "./chat.js";
 
 export interface PlanBridge {
   getPlanState(): Promise<GetPlanStateRpcResult>;
+  choosePlanRaceCourseFile(): Promise<string | null>;
   executePlanTransition(
     input: ExecutePlanTransitionRpcParams,
   ): Promise<ExecutePlanTransitionRpcResult>;
@@ -50,6 +51,13 @@ export interface PlanViewAdapter {
   discardDraft(): void;
   openRevisionComposer(): void;
   closeRevisionComposer(): void;
+  openCoursePicker(): void;
+  closeCoursePicker(): void;
+  chooseCourseFile(): void;
+  continueWithoutCourse(): void;
+  useCourseWithoutElevation(): void;
+  removeCourse(): void;
+  returnToCoach(): void;
   retry(): void;
   dispose(): void;
 }
@@ -100,6 +108,7 @@ export function createPlanViewAdapter(input: {
   readonly publishCoach: (next: ChatSurfaceState) => void;
   readonly publishDiscardConfirmation: (open: boolean) => void;
   readonly publishRevisionComposer: (open: boolean) => void;
+  readonly publishCoursePicker: (open: boolean) => void;
   readonly createCommandId?: () => string;
   readonly createMessageId?: () => string;
 }): PlanViewAdapter {
@@ -292,6 +301,27 @@ export function createPlanViewAdapter(input: {
     if (model === null) return null;
     const parsed = PlanCoachProjectionDataSchema.safeParse(model.data);
     return parsed.success ? parsed.data : null;
+  };
+
+  const attachCourse = (filePath: string, elevation: "require" | "allow-missing"): void => {
+    const data = currentCoachData();
+    if (data === null) return;
+    if (data.draft === null) {
+      void execute({
+        transitionId: "PL-T02",
+        commandId: createCommandId(),
+        conversationId: data.conversationId,
+        filePath,
+        elevation,
+      });
+      return;
+    }
+    void execute({
+      transitionId: "PL-T09",
+      commandId: createCommandId(),
+      draftId: data.draft.id,
+      course: { action: "attach", filePath, elevation },
+    });
   };
 
   const beginCoachSubmission = (message: string, includeUser: boolean): void => {
@@ -538,6 +568,65 @@ export function createPlanViewAdapter(input: {
     },
     closeRevisionComposer() {
       input.publishRevisionComposer(false);
+    },
+    openCoursePicker() {
+      input.publishCoursePicker(true);
+    },
+    closeCoursePicker() {
+      input.publishCoursePicker(false);
+    },
+    chooseCourseFile() {
+      if (active !== null) return;
+      void input.bridge
+        .choosePlanRaceCourseFile()
+        .then((filePath) => {
+          if (disposed || filePath === null) return;
+          input.publishCoursePicker(false);
+          attachCourse(filePath, "require");
+        })
+        .catch(() => undefined);
+    },
+    continueWithoutCourse() {
+      const data = currentCoachData();
+      if (data === null || active !== null) return;
+      input.publishCoursePicker(false);
+      if (data.draft === null) {
+        void execute({
+          transitionId: "PL-T03",
+          commandId: createCommandId(),
+          conversationId: data.conversationId,
+        });
+        return;
+      }
+      void execute({
+        transitionId: "PL-T09",
+        commandId: createCommandId(),
+        draftId: data.draft.id,
+        course: { action: "remove" },
+      });
+    },
+    useCourseWithoutElevation() {
+      if (active !== null || lastCommand === null) return;
+      if (lastCommand.transitionId === "PL-T02") {
+        attachCourse(lastCommand.filePath, "allow-missing");
+      } else if (lastCommand.transitionId === "PL-T09" && lastCommand.course.action === "attach") {
+        attachCourse(lastCommand.course.filePath, "allow-missing");
+      }
+    },
+    removeCourse() {
+      const data = currentCoachData();
+      if (data?.draft === null || data?.draft === undefined || active !== null) return;
+      void execute({
+        transitionId: "PL-T09",
+        commandId: createCommandId(),
+        draftId: data.draft.id,
+        course: { action: "remove" },
+      });
+    },
+    returnToCoach() {
+      if (active !== null) return;
+      lastCommand = null;
+      void refresh(false);
     },
     retry() {
       if (lastCommand === null) {

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -38,6 +38,7 @@ export interface PlanSurfaceState {
   readonly coach: ChatSurfaceState;
   readonly discardConfirmation: boolean;
   readonly revisionComposer: boolean;
+  readonly coursePicker: boolean;
 }
 
 export interface PlanActions {
@@ -58,6 +59,13 @@ export interface PlanActions {
   discardDraft(): void;
   openRevisionComposer(): void;
   closeRevisionComposer(): void;
+  openCoursePicker(): void;
+  closeCoursePicker(): void;
+  chooseCourseFile(): void;
+  continueWithoutCourse(): void;
+  useCourseWithoutElevation(): void;
+  removeCourse(): void;
+  returnToCoach(): void;
   retry(): void;
 }
 
@@ -69,6 +77,7 @@ export interface PlanSlice {
   setPlanCoach: (next: ChatSurfaceState) => void;
   setPlanDiscardConfirmation: (open: boolean) => void;
   setPlanRevisionComposer: (open: boolean) => void;
+  setPlanCoursePicker: (open: boolean) => void;
   bindPlanActions: (actions: PlanActions | null) => void;
 }
 
@@ -79,6 +88,7 @@ export const EMPTY_PLAN_SURFACE: PlanSurfaceState = Object.freeze({
   coach: EMPTY_CHAT_SURFACE,
   discardConfirmation: false,
   revisionComposer: false,
+  coursePicker: false,
 });
 
 export function planReadModel(plan: PlanSurfaceState): PlanReadModel | null {
@@ -117,6 +127,9 @@ export const createPlanSlice: StateCreator<EnduragentState, [], [], PlanSlice> =
   },
   setPlanRevisionComposer(open) {
     set((current) => ({ plan: { ...current.plan, revisionComposer: open } }));
+  },
+  setPlanCoursePicker(open) {
+    set((current) => ({ plan: { ...current.plan, coursePicker: open } }));
   },
   bindPlanActions(actions) {
     set({ planActions: actions });

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -1,9 +1,11 @@
-import { CheckCircle2, LoaderCircle, RefreshCw, TriangleAlert } from "lucide-react";
+import { CheckCircle2, LoaderCircle, MapPinned, RefreshCw, TriangleAlert } from "lucide-react";
 import { useRef, useState, type FormEvent, type ReactElement } from "react";
 import {
   PlanCoachProjectionDataSchema,
   type PlanFtpProjection,
   type PlanFtpSourceValue,
+  type PlanRaceCourseProjection,
+  type PlanRaceCourseSummary,
 } from "@enduragent/coach-contract";
 import { Button } from "../../components/ui/button.js";
 import {
@@ -63,6 +65,262 @@ function StaleNotice(props: { readonly message: string }): ReactElement {
       <TriangleAlert className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
       <p className="m-0 text-ink-2">{props.message}</p>
     </div>
+  );
+}
+
+function courseSummaryCopy(course: PlanRaceCourseSummary): string {
+  const distance = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(
+    course.distanceM / 1_000,
+  );
+  const elevation =
+    course.elevationGainM === null
+      ? "Elevation unavailable"
+      : `${Math.round(course.elevationGainM).toLocaleString()} m climbing`;
+  return `${distance} km · ${elevation}`;
+}
+
+function CourseActions(props: {
+  readonly replace?: boolean;
+  readonly routeOnly?: boolean;
+  readonly retry?: boolean;
+  readonly continueWithout?: boolean;
+  readonly remove?: boolean;
+}): ReactElement {
+  const actions = useEnduragentStore((state) => state.planActions);
+  const transition = useEnduragentStore((state) => state.plan.transition);
+  const busy = transition.status === "submitting" || transition.status === "running";
+  return (
+    <div className="flex flex-wrap justify-end gap-inset pt-inset">
+      {props.replace === true ? (
+        <Button
+          type="button"
+          variant="outline"
+          disabled={actions === null || busy}
+          onClick={() => actions?.openCoursePicker()}
+        >
+          Replace file
+        </Button>
+      ) : null}
+      {props.routeOnly === true ? (
+        <Button
+          type="button"
+          variant="outline"
+          disabled={actions === null || busy}
+          onClick={() => actions?.useCourseWithoutElevation()}
+        >
+          Use route only
+        </Button>
+      ) : null}
+      {props.retry === true ? (
+        <Button
+          type="button"
+          variant="outline"
+          disabled={actions === null || busy}
+          onClick={() => actions?.retry()}
+        >
+          Retry
+        </Button>
+      ) : null}
+      {props.continueWithout === true ? (
+        <Button
+          type="button"
+          disabled={actions === null || busy}
+          onClick={() => actions?.continueWithoutCourse()}
+        >
+          Continue without course
+        </Button>
+      ) : null}
+      {props.remove === true ? (
+        <Button
+          type="button"
+          variant="outline"
+          disabled={actions === null || busy}
+          onClick={() => actions?.removeCourse()}
+        >
+          Continue without course
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function RaceCoursePanel(props: {
+  readonly course: PlanRaceCourseProjection;
+  readonly draft: boolean;
+}): ReactElement {
+  const actions = useEnduragentStore((state) => state.planActions);
+  const transition = useEnduragentStore((state) => state.plan.transition);
+  const busy =
+    (transition.status === "submitting" || transition.status === "running") &&
+    (transition.transitionId === "PL-T02" || transition.transitionId === "PL-T09");
+  if (busy) {
+    const recalculating = props.draft && transition.transitionId === "PL-T09";
+    return (
+      <section className="flex items-start gap-row rounded-card bg-sunk p-4" aria-live="polite">
+        <LoaderCircle
+          className="mt-0.5 size-4 shrink-0 animate-spin text-primary motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+        <div className={SUPPORT_PAIR}>
+          <h3 className="m-0 text-sm font-medium">
+            {recalculating ? "Recalculating Draft" : "Reading Race Course"}
+          </h3>
+          <p className="m-0 text-ink-2">
+            {recalculating
+              ? "Your previous Draft stays available until this update is complete."
+              : "Checking route shape, distance, and elevation."}
+          </p>
+        </div>
+      </section>
+    );
+  }
+  const course = props.course;
+  if (course.status === "ready" && course.accepted !== null) {
+    return (
+      <section className="grid gap-row rounded-card bg-sunk p-4">
+        <div className="flex items-start gap-row">
+          <MapPinned className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden="true" />
+          <div className={`${SUPPORT_PAIR} min-w-0 flex-1`}>
+            <h3 className="m-0 text-sm font-medium">{course.accepted.fileName}</h3>
+            <p className="m-0 text-ink-2">{courseSummaryCopy(course.accepted)}</p>
+          </div>
+        </div>
+        <div className="flex flex-wrap justify-end gap-inset pt-inset">
+          <Button type="button" variant="outline" onClick={() => actions?.openCoursePicker()}>
+            Replace file
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() =>
+              props.draft ? actions?.removeCourse() : actions?.continueWithoutCourse()
+            }
+          >
+            Continue without course
+          </Button>
+        </div>
+      </section>
+    );
+  }
+  if (course.status === "invalid") {
+    return (
+      <section className="grid gap-row rounded-card bg-sunk p-4" role="alert">
+        <div className="flex items-start gap-row">
+          <TriangleAlert className="mt-0.5 size-4 shrink-0 text-warn" aria-hidden="true" />
+          <div className={SUPPORT_PAIR}>
+            <h3 className="m-0 text-sm font-medium">This file can’t be read</h3>
+            <p className="m-0 text-ink-2">{course.detail}</p>
+          </div>
+        </div>
+        <CourseActions replace continueWithout />
+      </section>
+    );
+  }
+  if (course.status === "missing-elevation" && course.candidate !== null) {
+    return (
+      <section className="grid gap-row rounded-card bg-sunk p-4" role="status">
+        <div className="flex items-start gap-row">
+          <TriangleAlert className="mt-0.5 size-4 shrink-0 text-warn" aria-hidden="true" />
+          <div className={SUPPORT_PAIR}>
+            <h3 className="m-0 text-sm font-medium">Route found, elevation missing</h3>
+            <p className="m-0 text-ink-2">{courseSummaryCopy(course.candidate)}</p>
+          </div>
+        </div>
+        <CourseActions replace routeOnly continueWithout />
+      </section>
+    );
+  }
+  if (course.status === "recalculation-failed") {
+    return (
+      <section className="grid gap-row rounded-card bg-sunk p-4" role="alert">
+        <div className="flex items-start gap-row">
+          <TriangleAlert className="mt-0.5 size-4 shrink-0 text-warn" aria-hidden="true" />
+          <div className={SUPPORT_PAIR}>
+            <h3 className="m-0 text-sm font-medium">Draft recalculation failed</h3>
+            <p className="m-0 text-ink-2">Your previous Draft is unchanged.</p>
+          </div>
+        </div>
+        <CourseActions retry replace continueWithout />
+      </section>
+    );
+  }
+  if (course.status === "omission-failed") {
+    return (
+      <section className="grid gap-row rounded-card bg-sunk p-4" role="alert">
+        <div className="flex items-start gap-row">
+          <TriangleAlert className="mt-0.5 size-4 shrink-0 text-warn" aria-hidden="true" />
+          <div className={SUPPORT_PAIR}>
+            <h3 className="m-0 text-sm font-medium">Couldn’t continue without a Race Course</h3>
+            <p className="m-0 text-ink-2">Nothing changed.</p>
+          </div>
+        </div>
+        <div className="flex justify-end gap-inset pt-inset">
+          <Button type="button" variant="outline" onClick={() => actions?.returnToCoach()}>
+            Back to coach
+          </Button>
+          <Button type="button" onClick={() => actions?.retry()}>
+            Retry
+          </Button>
+        </div>
+      </section>
+    );
+  }
+  return (
+    <section className="grid gap-row rounded-card bg-sunk p-4">
+      <div className={SUPPORT_PAIR}>
+        <h3 className="m-0 text-sm font-medium">Race Course · optional</h3>
+        <p className="m-0 text-ink-2">
+          {course.status === "omitted"
+            ? "This Draft stays course-agnostic."
+            : "Add a GPX or FIT file, or continue without one."}
+        </p>
+      </div>
+      <div className="flex flex-wrap justify-end gap-inset pt-inset">
+        <Button type="button" variant="outline" onClick={() => actions?.openCoursePicker()}>
+          {course.status === "omitted" ? "Add file" : "Attach GPX/FIT"}
+        </Button>
+        {course.status === "undecided" ? (
+          <Button type="button" onClick={() => actions?.continueWithoutCourse()}>
+            Continue without course
+          </Button>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function CoursePickerDialog(): ReactElement {
+  const open = useEnduragentStore((state) => state.plan.coursePicker);
+  const actions = useEnduragentStore((state) => state.planActions);
+  const cancel = useRef<HTMLButtonElement>(null);
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) actions?.closeCoursePicker();
+      }}
+    >
+      <DialogContent
+        className="w-[min(520px,calc(100vw-32px))] max-w-none gap-0 p-6 shadow-elev-4 sm:max-w-none"
+        showCloseButton={false}
+        initialFocus={cancel}
+      >
+        <DialogHeader className="gap-2.5">
+          <DialogTitle className="m-0 text-xl">Add Race Course</DialogTitle>
+          <DialogDescription className="m-0 leading-[1.5]">
+            Choose a GPX or FIT file. Your Draft stays here while it is checked.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="mx-0 mt-[22px] mb-0 flex-row justify-end border-0 bg-transparent p-0">
+          <DialogClose render={<Button ref={cancel} variant="outline" size="lg" />}>
+            Cancel
+          </DialogClose>
+          <Button type="button" size="lg" onClick={() => actions?.chooseCourseFile()}>
+            Choose file
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -414,6 +672,7 @@ function PlanCoach(): ReactElement {
         }}
       />
       <PlanQueue />
+      {data?.course === undefined ? null : <RaceCoursePanel course={data.course} draft={false} />}
       {ready ? (
         <section className="grid gap-row rounded-card bg-sunk p-4">
           <div className={SUPPORT_PAIR}>
@@ -549,6 +808,9 @@ function DraftProjection(): ReactElement {
             <strong>Ready for review</strong>
           </div>
         </div>
+        {parsed?.success === true && parsed.data.course !== undefined ? (
+          <RaceCoursePanel course={parsed.data.course} draft />
+        ) : null}
         {revisionComposer ? (
           <form className="grid gap-inset pt-row" onSubmit={submit}>
             <label className="text-sm font-medium" htmlFor="plan-draft-revision">
@@ -674,6 +936,7 @@ export function PlanView(): ReactElement {
         ) : (
           <ReadyProjection />
         )}
+        <CoursePickerDialog />
       </div>
     </Page>
   );

--- a/apps/desktop-renderer/tests/plan-adapter.test.ts
+++ b/apps/desktop-renderer/tests/plan-adapter.test.ts
@@ -33,6 +33,7 @@ function harness(
   input: {
     readonly getPlanState?: () => Promise<GetPlanStateRpcResult>;
     readonly executePlanTransition?: PlanBridge["executePlanTransition"];
+    readonly choosePlanRaceCourseFile?: PlanBridge["choosePlanRaceCourseFile"];
     readonly ids?: readonly string[];
     readonly clients?: DesktopCoachClientProvider;
     readonly messageIds?: readonly string[];
@@ -53,11 +54,15 @@ function harness(
   const executePlanTransition = vi.fn<PlanBridge["executePlanTransition"]>(
     input.executePlanTransition ?? defaultExecute,
   );
+  const choosePlanRaceCourseFile = vi.fn<PlanBridge["choosePlanRaceCourseFile"]>(
+    input.choosePlanRaceCourseFile ?? (async () => null),
+  );
   const ids = [...(input.ids ?? ["command-1", "command-2", "command-3"])];
   const messageIds = [...(input.messageIds ?? ["message-1", "message-2", "message-3"])];
   const adapter = createPlanViewAdapter({
     bridge: {
       getPlanState,
+      choosePlanRaceCourseFile,
       executePlanTransition,
       onPlanProgress(listener) {
         progressListener = listener;
@@ -83,6 +88,9 @@ function harness(
     publishRevisionComposer(open) {
       surface = { ...surface, revisionComposer: open };
     },
+    publishCoursePicker(open) {
+      surface = { ...surface, coursePicker: open };
+    },
     createCommandId: () => ids.shift() ?? "unexpected-command",
     createMessageId: () => messageIds.shift() ?? "unexpected-message",
   });
@@ -93,6 +101,7 @@ function harness(
     },
     getPlanState,
     executePlanTransition,
+    choosePlanRaceCourseFile,
     disposeProgress,
     progress(value: PlanProgressEvent) {
       progressListener?.(value);
@@ -262,6 +271,154 @@ describe("Plan view adapter", () => {
       conversationId: "00000000000000000000000001",
       source: "intervals",
       watts: null,
+    });
+  });
+
+  it("uses the native picker and resumes a route-only Course choice", async () => {
+    const summary = {
+      fileName: "route-only.gpx",
+      format: "gpx" as const,
+      pointCount: 42,
+      distanceM: 120_000,
+      elevationGainM: null,
+      elevationStatus: "unavailable" as const,
+    };
+    const initial = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S017",
+      projection: "coach",
+      data: planCoachData({
+        course: {
+          status: "undecided",
+          accepted: null,
+          candidate: null,
+          fileName: null,
+          detail: null,
+        },
+      }),
+    });
+    const missingElevation = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S067",
+      projection: "coach",
+      data: planCoachData({
+        course: {
+          status: "missing-elevation",
+          accepted: null,
+          candidate: summary,
+          fileName: null,
+          detail: null,
+        },
+      }),
+    });
+    const ready = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S016",
+      projection: "coach",
+      data: planCoachData({
+        ready: true,
+        course: {
+          status: "ready",
+          accepted: summary,
+          candidate: null,
+          fileName: null,
+          detail: null,
+        },
+      }),
+    });
+    const executePlanTransition = vi
+      .fn<PlanBridge["executePlanTransition"]>()
+      .mockResolvedValueOnce({ status: "completed", state: missingElevation })
+      .mockResolvedValueOnce({ status: "completed", state: ready });
+    const subject = harness({
+      ids: ["course-command", "route-only-command"],
+      getPlanState: async () => ({ status: "ready", state: initial }),
+      choosePlanRaceCourseFile: async () => "/tmp/route-only.gpx",
+      executePlanTransition,
+    });
+    subject.adapter.start();
+    await settle();
+
+    subject.adapter.openCoursePicker();
+    expect(subject.surface.coursePicker).toBe(true);
+    subject.adapter.chooseCourseFile();
+    await settle();
+    expect(subject.choosePlanRaceCourseFile).toHaveBeenCalledOnce();
+    expect(subject.surface.coursePicker).toBe(false);
+    expect(executePlanTransition).toHaveBeenNthCalledWith(1, {
+      transitionId: "PL-T02",
+      commandId: "course-command",
+      conversationId: "00000000000000000000000001",
+      filePath: "/tmp/route-only.gpx",
+      elevation: "require",
+    });
+
+    subject.adapter.useCourseWithoutElevation();
+    await settle();
+    expect(executePlanTransition).toHaveBeenNthCalledWith(2, {
+      transitionId: "PL-T02",
+      commandId: "route-only-command",
+      conversationId: "00000000000000000000000001",
+      filePath: "/tmp/route-only.gpx",
+      elevation: "allow-missing",
+    });
+  });
+
+  it("persists Course omission in intake and removes a Course through Draft recalculation", async () => {
+    const intake = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S017",
+      projection: "coach",
+      data: planCoachData({
+        course: {
+          status: "undecided",
+          accepted: null,
+          candidate: null,
+          fileName: null,
+          detail: null,
+        },
+      }),
+    });
+    const subject = harness({
+      ids: ["omit-command"],
+      getPlanState: async () => ({ status: "ready", state: intake }),
+    });
+    subject.adapter.start();
+    await settle();
+    subject.adapter.continueWithoutCourse();
+    await settle();
+    expect(subject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T03",
+      commandId: "omit-command",
+      conversationId: "00000000000000000000000001",
+    });
+
+    const draft = {
+      id: "00000000000000000000000002",
+      planId: "00000000000000000000000003",
+      revision: 1,
+      status: "ready" as const,
+      snapshot: {},
+    };
+    const draftState = planReadModel({
+      lifecycle: "draft",
+      scenarioId: "PL-S002",
+      projection: "draft",
+      data: planCoachData({ draft }),
+    });
+    const draftSubject = harness({
+      ids: ["remove-command"],
+      getPlanState: async () => ({ status: "ready", state: draftState }),
+    });
+    draftSubject.adapter.start();
+    await settle();
+    draftSubject.adapter.removeCourse();
+    await settle();
+    expect(draftSubject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T09",
+      commandId: "remove-command",
+      draftId: draft.id,
+      course: { action: "remove" },
     });
   });
 

--- a/apps/desktop-renderer/tests/plan-fixtures.ts
+++ b/apps/desktop-renderer/tests/plan-fixtures.ts
@@ -6,6 +6,7 @@ import type {
   PlanError,
   PlanFtpProjection,
   PlanProjectionKind,
+  PlanRaceCourseProjection,
   PlanReadModel,
 } from "@enduragent/coach-contract";
 
@@ -81,6 +82,7 @@ export function planCoachData(
       readonly text: string;
     }[];
     readonly ftp?: PlanFtpProjection | null;
+    readonly course?: PlanRaceCourseProjection;
   } = {},
 ): PlanReadModel["data"] {
   return {
@@ -101,5 +103,6 @@ export function planCoachData(
     decision: input.decision ?? null,
     draft: input.draft ?? null,
     ...(input.ftp === undefined ? {} : { ftp: input.ftp }),
+    ...(input.course === undefined ? {} : { course: input.course }),
   };
 }

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -27,6 +27,13 @@ function actions(): PlanActions {
     discardDraft: vi.fn(),
     openRevisionComposer: vi.fn(),
     closeRevisionComposer: vi.fn(),
+    openCoursePicker: vi.fn(),
+    closeCoursePicker: vi.fn(),
+    chooseCourseFile: vi.fn(),
+    continueWithoutCourse: vi.fn(),
+    useCourseWithoutElevation: vi.fn(),
+    removeCourse: vi.fn(),
+    returnToCoach: vi.fn(),
     retry: vi.fn(),
   };
 }
@@ -156,6 +163,71 @@ describe("Plan surface", () => {
     expect(planActions.submitCoach).toHaveBeenCalledWith("Four days each week.");
     await user.click(screen.getByRole("button", { name: "Create draft" }));
     expect(planActions.createDraft).toHaveBeenCalledOnce();
+  });
+
+  it("keeps Race Course selection and recovery inside the Plan surface", async () => {
+    const user = userEvent.setup();
+    const planActions = actions();
+    const initial = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S017",
+      projection: "coach",
+      data: planCoachData({
+        course: {
+          status: "undecided",
+          accepted: null,
+          candidate: null,
+          fileName: null,
+          detail: null,
+        },
+      }),
+    });
+    useEnduragentStore.setState({
+      plan: {
+        ...EMPTY_PLAN_SURFACE,
+        hydration: { status: "ready", state: initial },
+        lastReady: initial,
+      },
+      planActions,
+    });
+    render(<PlanView />);
+
+    await user.click(screen.getByRole("button", { name: "Attach GPX/FIT" }));
+    expect(planActions.openCoursePicker).toHaveBeenCalledOnce();
+    act(() => useEnduragentStore.getState().setPlanCoursePicker(true));
+    expect(screen.getByRole("heading", { name: "Add Race Course" })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus());
+    await user.click(screen.getByRole("button", { name: "Choose file" }));
+    expect(planActions.chooseCourseFile).toHaveBeenCalledOnce();
+
+    const missingElevation = planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S067",
+      projection: "coach",
+      data: planCoachData({
+        course: {
+          status: "missing-elevation",
+          accepted: null,
+          candidate: {
+            fileName: "route-only.gpx",
+            format: "gpx",
+            pointCount: 42,
+            distanceM: 120_000,
+            elevationGainM: null,
+            elevationStatus: "unavailable",
+          },
+          fileName: null,
+          detail: null,
+        },
+      }),
+    });
+    act(() => {
+      useEnduragentStore.getState().setPlanCoursePicker(false);
+      useEnduragentStore.getState().setPlanHydration({ status: "ready", state: missingElevation });
+    });
+    expect(screen.getByRole("status")).toHaveTextContent("Route found, elevation missing");
+    await user.click(screen.getByRole("button", { name: "Use route only" }));
+    expect(planActions.useCourseWithoutElevation).toHaveBeenCalledOnce();
   });
 
   it("resolves FTP with one compact whole-watts control and an Intervals refresh", async () => {

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -93,6 +93,13 @@ function stubPlanActions(): PlanActions {
     discardDraft: vi.fn(),
     openRevisionComposer: vi.fn(),
     closeRevisionComposer: vi.fn(),
+    openCoursePicker: vi.fn(),
+    closeCoursePicker: vi.fn(),
+    chooseCourseFile: vi.fn(),
+    continueWithoutCourse: vi.fn(),
+    useCourseWithoutElevation: vi.fn(),
+    removeCourse: vi.fn(),
+    returnToCoach: vi.fn(),
     retry: vi.fn(),
   };
 }

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -58,6 +58,13 @@ function stubPlanActions(): PlanActions {
     discardDraft: vi.fn(),
     openRevisionComposer: vi.fn(),
     closeRevisionComposer: vi.fn(),
+    openCoursePicker: vi.fn(),
+    closeCoursePicker: vi.fn(),
+    chooseCourseFile: vi.fn(),
+    continueWithoutCourse: vi.fn(),
+    useCourseWithoutElevation: vi.fn(),
+    removeCourse: vi.fn(),
+    returnToCoach: vi.fn(),
     retry: vi.fn(),
   };
 }

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -298,6 +298,7 @@ async function security() {
             "chatgptStatus",
             "checkForUpdates",
             "chooseImportFiles",
+            "choosePlanRaceCourseFile",
             "claudeCliRecheck",
             "claudeCliStatus",
             "credentialStatuses",

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -16,6 +16,7 @@ export const DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL =
 export const DESKTOP_PLAN_STATE_CHANNEL = "desktop:plan:get-state" as const;
 export const DESKTOP_PLAN_TRANSITION_CHANNEL = "desktop:plan:execute-transition" as const;
 export const DESKTOP_PLAN_PROGRESS_CHANNEL = "desktop:plan:progress" as const;
+export const DESKTOP_PLAN_COURSE_FILE_CHANNEL = "desktop:plan:choose-course-file" as const;
 export const DESKTOP_TRAINING_EXPORT_CHANNEL = "desktop:training:export" as const;
 export const DESKTOP_UPDATE_GET_CHANNEL = "desktop:update:get" as const;
 export const DESKTOP_UPDATE_CHECK_CHANNEL = "desktop:update:check" as const;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -449,9 +449,7 @@ async function runDesktop(): Promise<void> {
     let windowCreation: Promise<BrowserWindow> | undefined;
     const rendererNavigationTracker = createDesktopRendererNavigationTracker<BrowserWindow>();
     const currentWindow = (): BrowserWindow | null =>
-      window !== null && !window.isDestroyed() && !window.webContents.isDestroyed()
-        ? window
-        : null;
+      window !== null && !window.isDestroyed() && !window.webContents.isDestroyed() ? window : null;
     const startRendererNavigation = (
       target: BrowserWindow,
       navigationUrl: string,
@@ -681,10 +679,7 @@ async function runDesktop(): Promise<void> {
       return page;
     };
     const useActivePlanning = async <T>(
-      use: (
-        planning: DesktopPlanningClient,
-        isCurrent: () => boolean,
-      ) => Promise<T>,
+      use: (planning: DesktopPlanningClient, isCurrent: () => boolean) => Promise<T>,
     ): Promise<T> => {
       const binding = activeRuntimeBinding;
       const lifecycleState = daemonLifecycle?.snapshot();
@@ -1012,10 +1007,8 @@ async function runDesktop(): Promise<void> {
               shouldReleaseInitialRefreshForWindowEvent(
                 currentWindow(),
                 created,
-                connectionIpc?.isCurrentDocumentNavigation(
-                  created,
-                  created.webContents.getURL(),
-                ) ?? false,
+                connectionIpc?.isCurrentDocumentNavigation(created, created.webContents.getURL()) ??
+                  false,
               )
             ) {
               void initialRefreshCoordinator.releaseCurrent();
@@ -1091,9 +1084,9 @@ async function runDesktop(): Promise<void> {
     });
     disposePlanningIpc = installDesktopPlanningIpc({
       ipcMain,
+      dialog,
       currentWindow: () => mainWindow.current() ?? undefined,
-      getPlanState: (request) =>
-        useActivePlanning((planning) => planning.getPlanState(request)),
+      getPlanState: (request) => useActivePlanning((planning) => planning.getPlanState(request)),
       executePlanTransition: (request, onEvent) =>
         useActivePlanning((planning, isCurrent) =>
           planning.executePlanTransition(request, (event) => {

--- a/apps/desktop/src/main/planning-ipc.ts
+++ b/apps/desktop/src/main/planning-ipc.ts
@@ -9,14 +9,18 @@ import {
   GetPlanStateRpcParamsSchema,
   GetPlanStateRpcResultSchema,
   PlanProgressEventSchema,
+  PlanRaceCourseFileSelectionSchema,
   type ExecutePlanTransitionRpcParams,
   type ExecutePlanTransitionRpcResult,
   type GetPlanStateRpcParams,
   type GetPlanStateRpcResult,
   type PlanProgressEvent,
 } from "@enduragent/coach-contract";
-import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from "electron";
+import { homedir } from "node:os";
+import { extname, isAbsolute } from "node:path";
+import type { BrowserWindow, IpcMain, IpcMainInvokeEvent, OpenDialogOptions } from "electron";
 import {
+  DESKTOP_PLAN_COURSE_FILE_CHANNEL,
   DESKTOP_PLAN_PROGRESS_CHANNEL,
   DESKTOP_PLAN_STATE_CHANNEL,
   DESKTOP_PLAN_TRANSITION_CHANNEL,
@@ -34,6 +38,13 @@ export interface DesktopPlanningClient {
     request: ExecutePlanTransitionRpcParams,
     onEvent?: (event: PlanProgressEvent) => void,
   ): Promise<ExecutePlanTransitionRpcResult>;
+}
+
+export interface DesktopPlanningDialogPort {
+  showOpenDialog(
+    window: BrowserWindow,
+    options: OpenDialogOptions,
+  ): Promise<{ readonly canceled: boolean; readonly filePaths: readonly string[] }>;
 }
 
 export function createConnectionPlanningClient(
@@ -67,9 +78,7 @@ export function createConnectionPlanningClient(
     },
     async executePlanTransition(request, onEvent) {
       try {
-        return await call((client) =>
-          client.call("executePlanTransition", request, { onEvent }),
-        );
+        return await call((client) => client.call("executePlanTransition", request, { onEvent }));
       } catch (error) {
         if (error instanceof CoachRpcRemoteError && error.code === -32601) return unsupported;
         throw error;
@@ -81,6 +90,7 @@ export function createConnectionPlanningClient(
 export function installDesktopPlanningIpc(input: {
   readonly ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
   readonly currentWindow: () => BrowserWindow | undefined;
+  readonly dialog: DesktopPlanningDialogPort;
   readonly getPlanState: (request: GetPlanStateRpcParams) => Promise<GetPlanStateRpcResult>;
   readonly executePlanTransition: (
     request: ExecutePlanTransitionRpcParams,
@@ -110,7 +120,8 @@ export function installDesktopPlanningIpc(input: {
       if (!isTrustedConnectionRequest(event, input.currentWindow())) {
         throw new Error("untrusted desktop Planning request");
       }
-      const parsed = args.length === 1 ? ExecutePlanTransitionRpcParamsSchema.safeParse(args[0]) : undefined;
+      const parsed =
+        args.length === 1 ? ExecutePlanTransitionRpcParamsSchema.safeParse(args[0]) : undefined;
       if (parsed === undefined || !parsed.success) {
         throw new TypeError("invalid desktop Planning request");
       }
@@ -133,8 +144,43 @@ export function installDesktopPlanningIpc(input: {
       }
     },
   );
+  input.ipcMain.handle(
+    DESKTOP_PLAN_COURSE_FILE_CHANNEL,
+    async (event: IpcMainInvokeEvent, ...args: unknown[]) => {
+      const window = input.currentWindow();
+      if (!isTrustedConnectionRequest(event, window)) {
+        throw new Error("untrusted desktop Planning request");
+      }
+      if (args.length !== 0 || window === undefined) {
+        throw new TypeError("invalid desktop Planning request");
+      }
+      try {
+        const result = await input.dialog.showOpenDialog(window, {
+          defaultPath: homedir(),
+          properties: ["openFile"],
+          filters: [{ name: "Race Course", extensions: ["gpx", "fit"] }],
+        });
+        if (result.canceled) return null;
+        const path = result.filePaths[0];
+        if (
+          result.filePaths.length !== 1 ||
+          typeof path !== "string" ||
+          path.length > 4_096 ||
+          !isAbsolute(path) ||
+          ![".gpx", ".fit"].includes(extname(path).toLowerCase())
+        ) {
+          throw new TypeError("invalid Race Course selection");
+        }
+        return PlanRaceCourseFileSelectionSchema.parse(path);
+      } catch (error) {
+        if (error instanceof TypeError) throw error;
+        return null;
+      }
+    },
+  );
   return () => {
     input.ipcMain.removeHandler(DESKTOP_PLAN_STATE_CHANNEL);
     input.ipcMain.removeHandler(DESKTOP_PLAN_TRANSITION_CHANNEL);
+    input.ipcMain.removeHandler(DESKTOP_PLAN_COURSE_FILE_CHANNEL);
   };
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -4,6 +4,7 @@ import {
   ExecutePlanTransitionRpcResultSchema,
   GetPlanStateRpcResultSchema,
   PlanProgressEventSchema,
+  PlanRaceCourseFileSelectionSchema,
   PlatformAbsolutePathSchema,
   type PlanProgressEvent,
 } from "@enduragent/coach-contract";
@@ -19,6 +20,7 @@ import {
   DESKTOP_LIFECYCLE_CHANNEL,
   DESKTOP_OPEN_EXTERNAL_CHANNEL,
   DESKTOP_PLAN_PROGRESS_CHANNEL,
+  DESKTOP_PLAN_COURSE_FILE_CHANNEL,
   DESKTOP_PLAN_STATE_CHANNEL,
   DESKTOP_PLAN_TRANSITION_CHANNEL,
   DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL,
@@ -1446,6 +1448,14 @@ contextBridge.exposeInMainWorld(
       requireZeroArguments(args);
       const parsed = GetPlanStateRpcResultSchema.safeParse(
         await ipcRenderer.invoke(DESKTOP_PLAN_STATE_CHANNEL),
+      );
+      if (!parsed.success) throw new TypeError();
+      return parsed.data;
+    },
+    choosePlanRaceCourseFile: async (...args: unknown[]) => {
+      requireZeroArguments(args);
+      const parsed = PlanRaceCourseFileSelectionSchema.safeParse(
+        await ipcRenderer.invoke(DESKTOP_PLAN_COURSE_FILE_CHANNEL),
       );
       if (!parsed.success) throw new TypeError();
       return parsed.data;

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1104,6 +1104,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "chatgptStatus",
         "checkForUpdates",
         "chooseImportFiles",
+        "choosePlanRaceCourseFile",
         "claudeCliRecheck",
         "claudeCliStatus",
         "credentialStatuses",

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -966,6 +966,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       }
       textarea.value = "How should I recover?";
       textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      // A real key press occurs in a later browser task. Let React commit the
+      // controlled draft before exercising Enter so this test observes the
+      // product path instead of racing the synthetic input event.
+      await new Promise((resolve) => setTimeout(resolve, 0));
       textarea.focus();
       const streamingInputEnabled = !textarea.disabled;
       const stop = document.querySelector('[aria-label="Stop responding"]');

--- a/apps/desktop/tests/planning-ipc.test.ts
+++ b/apps/desktop/tests/planning-ipc.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/main/planning-ipc.js";
 import {
   DESKTOP_PLAN_PROGRESS_CHANNEL,
+  DESKTOP_PLAN_COURSE_FILE_CHANNEL,
   DESKTOP_PLAN_STATE_CHANNEL,
   DESKTOP_PLAN_TRANSITION_CHANNEL,
 } from "../src/main/constants.js";
@@ -79,8 +80,15 @@ function setup(
   const mainFrame = { url: RENDERER_URL };
   const webContents = { isDestroyed: () => false, mainFrame, send: vi.fn() };
   const window = { isDestroyed: () => false, webContents };
+  const dialog = {
+    showOpenDialog: vi.fn(async () => ({
+      canceled: false,
+      filePaths: ["/synthetic/almaty.gpx"],
+    })),
+  };
   const dispose = installDesktopPlanningIpc({
     ipcMain: ipcMain as never,
+    dialog,
     currentWindow: () => window as never,
     getPlanState,
     executePlanTransition: executePlanTransition as never,
@@ -91,6 +99,7 @@ function setup(
     ipcMain,
     getPlanState,
     executePlanTransition,
+    dialog,
     webContents,
     trusted: { sender: webContents, senderFrame: mainFrame },
   };
@@ -101,7 +110,9 @@ beforeEach(() => vi.clearAllMocks());
 describe("desktop Planning IPC", () => {
   it("forwards strict reads and transition commands from the trusted main frame", async () => {
     const subject = setup();
-    await expect(subject.handlers.get(DESKTOP_PLAN_STATE_CHANNEL)!(subject.trusted)).resolves.toEqual({
+    await expect(
+      subject.handlers.get(DESKTOP_PLAN_STATE_CHANNEL)!(subject.trusted),
+    ).resolves.toEqual({
       status: "ready",
       state,
     });
@@ -123,6 +134,9 @@ describe("desktop Planning IPC", () => {
       subject.handlers.get(DESKTOP_PLAN_TRANSITION_CHANNEL)!(untrusted, command),
     ).rejects.toThrow("untrusted desktop Planning request");
     await expect(
+      subject.handlers.get(DESKTOP_PLAN_COURSE_FILE_CHANNEL)!(untrusted),
+    ).rejects.toThrow("untrusted desktop Planning request");
+    await expect(
       subject.handlers.get(DESKTOP_PLAN_STATE_CHANNEL)!(subject.trusted, {}),
     ).rejects.toThrow("invalid desktop Planning request");
     await expect(
@@ -135,6 +149,31 @@ describe("desktop Planning IPC", () => {
     expect(subject.executePlanTransition).not.toHaveBeenCalled();
   });
 
+  it("returns one validated GPX or FIT Course path and keeps cancellation explicit", async () => {
+    const subject = setup();
+    await expect(
+      subject.handlers.get(DESKTOP_PLAN_COURSE_FILE_CHANNEL)!(subject.trusted),
+    ).resolves.toBe("/synthetic/almaty.gpx");
+    expect(subject.dialog.showOpenDialog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        properties: ["openFile"],
+        filters: [{ name: "Race Course", extensions: ["gpx", "fit"] }],
+      }),
+    );
+    subject.dialog.showOpenDialog.mockResolvedValueOnce({ canceled: true, filePaths: [] });
+    await expect(
+      subject.handlers.get(DESKTOP_PLAN_COURSE_FILE_CHANNEL)!(subject.trusted),
+    ).resolves.toBeNull();
+    subject.dialog.showOpenDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePaths: ["/synthetic/not-a-course.txt"],
+    });
+    await expect(
+      subject.handlers.get(DESKTOP_PLAN_COURSE_FILE_CHANNEL)!(subject.trusted),
+    ).rejects.toThrow("invalid Race Course selection");
+  });
+
   it("redacts malformed results and progress without publishing either", async () => {
     const subject = setup(
       vi.fn(async () => ({ status: "ready", state: { ...state, scenarioId: "PL-S999" } })) as never,
@@ -143,9 +182,9 @@ describe("desktop Planning IPC", () => {
         return { status: "completed" as const, state };
       }) as never,
     );
-    await expect(subject.handlers.get(DESKTOP_PLAN_STATE_CHANNEL)!(subject.trusted)).rejects.toThrow(
-      "desktop Planning unavailable",
-    );
+    await expect(
+      subject.handlers.get(DESKTOP_PLAN_STATE_CHANNEL)!(subject.trusted),
+    ).rejects.toThrow("desktop Planning unavailable");
     await expect(
       subject.handlers.get(DESKTOP_PLAN_TRANSITION_CHANNEL)!(subject.trusted, command),
     ).rejects.toThrow("desktop Planning unavailable");
@@ -187,7 +226,11 @@ describe("desktop Planning IPC", () => {
   it("removes every Planning handler during shutdown", () => {
     const subject = setup();
     subject.dispose();
-    for (const channel of [DESKTOP_PLAN_STATE_CHANNEL, DESKTOP_PLAN_TRANSITION_CHANNEL]) {
+    for (const channel of [
+      DESKTOP_PLAN_STATE_CHANNEL,
+      DESKTOP_PLAN_TRANSITION_CHANNEL,
+      DESKTOP_PLAN_COURSE_FILE_CHANNEL,
+    ]) {
       expect(subject.handlers.has(channel)).toBe(false);
       expect(subject.ipcMain.removeHandler).toHaveBeenCalledWith(channel);
     }

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -90,6 +90,7 @@ interface AuthBridge {
   removeTelegramAllowedSender(input: unknown): Promise<unknown>;
   acknowledgeTelegramGapWarning(): Promise<unknown>;
   chooseImportFiles(): Promise<readonly string[]>;
+  choosePlanRaceCourseFile(): Promise<string | null>;
   exportTrainingFile(input: unknown): Promise<unknown>;
   getUpdateState(): Promise<unknown>;
   checkForUpdates(): Promise<unknown>;
@@ -331,6 +332,7 @@ describe("desktop preload ChatGPT auth", () => {
         "chatgptLogin",
         "chatgptStatus",
         "chooseImportFiles",
+        "choosePlanRaceCourseFile",
         "claudeCliRecheck",
         "claudeCliStatus",
         "credentialStatuses",
@@ -517,6 +519,16 @@ describe("desktop preload ChatGPT auth", () => {
 
     await expect(bridge.chooseImportFiles()).resolves.toEqual(paths);
     expect(mocks.invoke).toHaveBeenCalledWith("enduragent:onboarding:choose-import-files");
+  });
+
+  it("accepts one platform-absolute Race Course path or cancellation", async () => {
+    mocks.invoke.mockResolvedValue("C:\\x\\course.GPX");
+    await expect(bridge.choosePlanRaceCourseFile()).resolves.toBe("C:\\x\\course.GPX");
+    expect(mocks.invoke).toHaveBeenCalledWith("desktop:plan:choose-course-file");
+    mocks.invoke.mockResolvedValue(null);
+    await expect(bridge.choosePlanRaceCourseFile()).resolves.toBeNull();
+    mocks.invoke.mockResolvedValue("relative/course.gpx");
+    await expect(bridge.choosePlanRaceCourseFile()).rejects.toBeInstanceOf(TypeError);
   });
 
   it.each([

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -449,6 +449,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "chatgptStatus",
       "checkForUpdates",
       "chooseImportFiles",
+      "choosePlanRaceCourseFile",
       "claudeCliRecheck",
       "claudeCliStatus",
       "credentialStatuses",

--- a/packages/coach-contract/src/planning.ts
+++ b/packages/coach-contract/src/planning.ts
@@ -266,6 +266,93 @@ export const PlanDraftProjectionSchema = z
   .strict();
 export type PlanDraftProjection = z.infer<typeof PlanDraftProjectionSchema>;
 
+export const PlanRaceCourseSummarySchema = z
+  .object({
+    fileName: z.string().min(1),
+    format: z.enum(["gpx", "fit"]),
+    pointCount: z.number().int().positive(),
+    distanceM: z.number().positive(),
+    elevationGainM: z.number().nonnegative().nullable(),
+    elevationStatus: z.enum(["available", "unavailable"]),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if ((value.elevationStatus === "available") !== (value.elevationGainM !== null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["elevationGainM"],
+        message: "Course elevation status must match its gain",
+      });
+    }
+  });
+export type PlanRaceCourseSummary = z.infer<typeof PlanRaceCourseSummarySchema>;
+
+export const PlanRaceCourseProjectionSchema = z
+  .object({
+    status: z.enum([
+      "undecided",
+      "omitted",
+      "parsing",
+      "invalid",
+      "missing-elevation",
+      "recalculating",
+      "recalculation-failed",
+      "ready",
+      "omission-failed",
+    ]),
+    accepted: PlanRaceCourseSummarySchema.nullable(),
+    candidate: PlanRaceCourseSummarySchema.nullable(),
+    fileName: z.string().min(1).nullable(),
+    detail: z.string().min(1).nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const empty =
+      value.accepted === null &&
+      value.candidate === null &&
+      value.fileName === null &&
+      value.detail === null;
+    const valid =
+      ((value.status === "undecided" || value.status === "omitted") && empty) ||
+      (value.status === "ready" &&
+        value.accepted !== null &&
+        value.candidate === null &&
+        value.fileName === null &&
+        value.detail === null) ||
+      (value.status === "parsing" &&
+        value.candidate === null &&
+        value.fileName !== null &&
+        value.detail === null) ||
+      (value.status === "invalid" &&
+        value.candidate === null &&
+        value.fileName !== null &&
+        value.detail !== null) ||
+      (value.status === "missing-elevation" &&
+        value.candidate?.elevationStatus === "unavailable" &&
+        value.fileName === null &&
+        value.detail === null) ||
+      (value.status === "recalculating" && value.fileName === null && value.detail === null) ||
+      (value.status === "recalculation-failed" &&
+        value.fileName === null &&
+        value.detail !== null) ||
+      (value.status === "omission-failed" &&
+        value.accepted === null &&
+        value.candidate === null &&
+        value.fileName === null &&
+        value.detail !== null);
+    if (!valid) {
+      context.addIssue({
+        code: "custom",
+        path: ["status"],
+        message: "Course projection fields do not match its status",
+      });
+    }
+  });
+export type PlanRaceCourseProjection = z.infer<typeof PlanRaceCourseProjectionSchema>;
+
+export const PlanRaceCourseFileSelectionSchema = PlatformAbsolutePathSchema.nullable();
+export type PlanRaceCourseFileSelection = z.infer<typeof PlanRaceCourseFileSelectionSchema>;
+
 export const PlanFtpSourceValueSchema = z
   .object({
     watts: z.number().int().min(1).max(9_999),
@@ -350,6 +437,7 @@ export const PlanCoachProjectionDataSchema = z
     decision: CoachDecisionReadModelSchema.nullable(),
     draft: PlanDraftProjectionSchema.nullable(),
     ftp: PlanFtpProjectionSchema.nullable().optional(),
+    course: PlanRaceCourseProjectionSchema.optional(),
   })
   .strict();
 export type PlanCoachProjectionData = z.infer<typeof PlanCoachProjectionDataSchema>;
@@ -420,6 +508,7 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
       commandId: CommandIdSchema,
       conversationId: EntityIdSchema,
       filePath: PlatformAbsolutePathSchema,
+      elevation: z.enum(["require", "allow-missing"]),
     })
     .strict(),
   z
@@ -497,7 +586,13 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
       commandId: CommandIdSchema,
       draftId: EntityIdSchema,
       course: z.discriminatedUnion("action", [
-        z.object({ action: z.literal("attach"), filePath: PlatformAbsolutePathSchema }).strict(),
+        z
+          .object({
+            action: z.literal("attach"),
+            filePath: PlatformAbsolutePathSchema,
+            elevation: z.enum(["require", "allow-missing"]),
+          })
+          .strict(),
         z.object({ action: z.literal("remove") }).strict(),
       ]),
     })

--- a/packages/coach-contract/tests/planning.test.ts
+++ b/packages/coach-contract/tests/planning.test.ts
@@ -7,6 +7,7 @@ import {
   PlanFtpProjectionSchema,
   PlanHydrationStateSchema,
   PlanProgressEventSchema,
+  PlanRaceCourseProjectionSchema,
   PlanScenarioIdSchema,
   PlanTransitionCommandSchema,
   type PlanTransitionCommand,
@@ -22,7 +23,13 @@ const eventId = "event-1";
 
 const commands = [
   { transitionId: "PL-T01", commandId, sourceConversationId: null },
-  { transitionId: "PL-T02", commandId, conversationId, filePath: "/tmp/course.gpx" },
+  {
+    transitionId: "PL-T02",
+    commandId,
+    conversationId,
+    filePath: "/tmp/course.gpx",
+    elevation: "require",
+  },
   { transitionId: "PL-T03", commandId, conversationId },
   { transitionId: "PL-T04", commandId, conversationId, source: "manual", watts: 282 },
   { transitionId: "PL-T05", commandId, conversationId, text: "Four days each week" },
@@ -33,7 +40,7 @@ const commands = [
     transitionId: "PL-T09",
     commandId,
     draftId,
-    course: { action: "attach", filePath: "/tmp/course.fit" },
+    course: { action: "attach", filePath: "/tmp/course.fit", elevation: "allow-missing" },
   },
   { transitionId: "PL-T10", commandId, draftId },
   { transitionId: "PL-T11", commandId, draftId, expectedRevision: 2 },
@@ -209,6 +216,52 @@ describe("planning contract", () => {
     ).toBe(true);
     expect(
       PlanFtpProjectionSchema.safeParse({ ...accepted, status: "accepted", error: {} }).success,
+    ).toBe(false);
+  });
+
+  it("keeps Race Course transition intent and projection states coherent", () => {
+    expect(
+      PlanTransitionCommandSchema.safeParse({
+        transitionId: "PL-T02",
+        commandId,
+        conversationId,
+        filePath: "/tmp/course.gpx",
+      }).success,
+    ).toBe(false);
+    const summary = {
+      fileName: "course.gpx",
+      format: "gpx" as const,
+      pointCount: 42,
+      distanceM: 120_000,
+      elevationGainM: null,
+      elevationStatus: "unavailable" as const,
+    };
+    expect(
+      PlanRaceCourseProjectionSchema.parse({
+        status: "missing-elevation",
+        accepted: null,
+        candidate: summary,
+        fileName: null,
+        detail: null,
+      }),
+    ).toMatchObject({ status: "missing-elevation", candidate: summary });
+    expect(
+      PlanRaceCourseProjectionSchema.safeParse({
+        status: "ready",
+        accepted: null,
+        candidate: summary,
+        fileName: null,
+        detail: null,
+      }).success,
+    ).toBe(false);
+    expect(
+      PlanRaceCourseProjectionSchema.safeParse({
+        status: "missing-elevation",
+        accepted: null,
+        candidate: { ...summary, elevationGainM: 900, elevationStatus: "available" },
+        fileName: null,
+        detail: null,
+      }).success,
     ).toBe(false);
   });
 

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -152,6 +152,7 @@ import {
 } from "./activity-power-heart-rate.js";
 import { createTrainingExportService } from "./training-export.js";
 import { createPlanningOperations } from "./planning-operations.js";
+import { createNodePlanRaceCourseAdapter } from "./planning-race-course.js";
 import { serializeBoundaryError } from "./daemon/error-boundary.js";
 
 interface OAuthCredential extends StoredProfile {
@@ -1567,7 +1568,7 @@ export async function createLocalCoachComposition(
         engine: reconfigurable.engine,
         identity: planningIdentity,
       },
-      { ftp },
+      { ftp, course: createNodePlanRaceCourseAdapter() },
     );
     const operations = {
       ...coachOperations,

--- a/packages/coach/src/planning-lifecycle.ts
+++ b/packages/coach/src/planning-lifecycle.ts
@@ -9,6 +9,7 @@ import {
   type PlanFtpProjection,
   type PlanLifecycle,
   type PlanProjectionKind,
+  type PlanRaceCourseProjection,
   type PlanReadModel,
   type PlanScenarioId,
   type PlanTransitionGuard,
@@ -36,6 +37,15 @@ export interface BuildPlanLifecycleReadModelInput {
   readonly draft: PlanDraftProjection | null;
   readonly ftp?: PlanFtpProjection | null;
   readonly ftpScenario?: "PL-S057" | "PL-S058" | "PL-S059" | "PL-S060" | "PL-S061" | "PL-S062";
+  readonly course?: PlanRaceCourseProjection;
+  readonly courseScenario?:
+    | "PL-S064"
+    | "PL-S065"
+    | "PL-S067"
+    | "PL-S068"
+    | "PL-S069"
+    | "PL-S070"
+    | "PL-S104";
 }
 
 const EMPTY_ATTENTION: PlanAttention = Object.freeze({
@@ -122,6 +132,37 @@ function stateKind(input: BuildPlanLifecycleReadModelInput): {
         ? "The previous Draft stays available until this update is complete."
         : "Your Draft opens automatically when it is ready.",
       transitions: [],
+    };
+  }
+  if (input.courseScenario !== undefined) {
+    const copy = {
+      "PL-S064": ["Reading Race Course", "Checking route shape, distance, and elevation."],
+      "PL-S065": ["This file can’t be read", "Choose another GPX or FIT file."],
+      "PL-S067": ["Route found, elevation missing", "Use the route only or choose another file."],
+      "PL-S068": ["Recalculating Draft", "Your previous Draft stays available."],
+      "PL-S069": ["Draft recalculation failed", "Your previous Draft is unchanged."],
+      "PL-S070": ["Race Course added", "The Draft now uses this route."],
+      "PL-S104": [
+        "Couldn’t continue without a Race Course",
+        "Nothing changed. Try again or return to your coach.",
+      ],
+    } as const;
+    const draftVisible = draft?.status === "ready" || draft?.status === "failed";
+    return {
+      scenarioId: input.courseScenario,
+      lifecycle: draftVisible
+        ? replacement
+          ? "replacement-draft"
+          : "draft"
+        : replacement
+          ? "replacement-intake"
+          : "intake",
+      projection: draftVisible ? "draft" : "coach",
+      title: copy[input.courseScenario][0],
+      summary: copy[input.courseScenario][1],
+      transitions: draftVisible
+        ? [guard("PL-T07"), guard("PL-T08"), guard("PL-T09"), guard("PL-T10"), guard("PL-T11")]
+        : [guard("PL-T02"), guard("PL-T03"), guard("PL-T04"), guard("PL-T05")],
     };
   }
   if (draft?.status === "ready" || draft?.status === "failed") {
@@ -226,6 +267,7 @@ export function buildPlanLifecycleReadModel(
     decision: input.decision,
     draft: input.draft,
     ...(input.ftp === undefined ? {} : { ftp: input.ftp }),
+    ...(input.course === undefined ? {} : { course: input.course }),
   });
   return PlanReadModelSchema.parse({
     schemaVersion: 1,

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -5,6 +5,7 @@ import {
   GetPlanStateRpcResultSchema,
   PlanDraftProjectionSchema,
   PlanFtpProjectionSchema,
+  PlanRaceCourseProjectionSchema,
   PlanProgressEventSchema,
   type ChatQueueRunResult,
   type ChatQueueSnapshot,
@@ -15,14 +16,25 @@ import {
   type PlanError,
   type PlanFtpProjection,
   type PlanProgressEvent,
+  type PlanRaceCourseProjection,
+  type PlanRaceCourseSummary,
   type PlanReadModel,
   type PlanningOperations,
   type TurnEvent,
 } from "@enduragent/coach-contract";
 import {
+  acceptParsedRaceCourse,
+  beginRaceCourseParsing,
+  beginRaceCourseRemoval,
+  completeRaceCourseRecalculation,
   executePlanFtpTransition,
+  failRaceCourseRecalculation,
+  openRaceCoursePicker,
+  rejectRaceCourseFile,
+  useRouteWithoutElevation,
   type PlanFtpAdapter,
   type PlanFtpSnapshot,
+  type RaceCourseRecalculatingState,
 } from "@enduragent/engine";
 import { buildPlanLifecycleReadModel } from "./planning-lifecycle.js";
 import {
@@ -35,9 +47,12 @@ import {
   type PlanRecord,
   type PlanRepository,
   type PlanWorkoutRecord,
+  parseRaceCourseSnapshot,
+  type RaceCourseSnapshot,
 } from "@enduragent/kernel/planning";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
 import type { CoachStoreWriterContext } from "./runtime.js";
+import type { PlanRaceCourseAdapter } from "./planning-race-course.js";
 
 const EMPTY_QUEUE: ChatQueueSnapshot = Object.freeze({
   schemaVersion: 1,
@@ -75,6 +90,18 @@ const FTP_SAVE_FAILED: PlanError = Object.freeze({
   retryable: true,
 });
 
+const COURSE_INVALID: PlanError = Object.freeze({
+  code: "invalid-input",
+  message: "This file can’t be read. Choose another GPX or FIT file.",
+  retryable: true,
+});
+
+const COURSE_RECALCULATION_FAILED: PlanError = Object.freeze({
+  code: "provider-failed",
+  message: "The Draft could not be recalculated. Your previous Draft is unchanged.",
+  retryable: true,
+});
+
 export interface PlanDraftBuild {
   readonly plan: PlanRecord;
   readonly workouts: readonly PlanWorkoutRecord[];
@@ -85,12 +112,20 @@ export interface PlanDraftBuilder {
   form(input: {
     readonly conversation: PlanConversationRecord;
     readonly turns: readonly PlanConversationTurnRecord[];
+    readonly course: RaceCourseSnapshot | null;
   }): Promise<PlanDraftBuild>;
   revise(input: {
     readonly conversation: PlanConversationRecord;
     readonly turns: readonly PlanConversationTurnRecord[];
     readonly previous: PlanDraftRevisionRecord;
     readonly instruction: string;
+    readonly course: RaceCourseSnapshot | null;
+  }): Promise<PlanDraftBuild>;
+  recalculateCourse(input: {
+    readonly conversation: PlanConversationRecord;
+    readonly turns: readonly PlanConversationTurnRecord[];
+    readonly previous: PlanDraftRevisionRecord;
+    readonly course: RaceCourseSnapshot | null;
   }): Promise<PlanDraftBuild>;
 }
 
@@ -106,6 +141,7 @@ export interface CreatePlanningOperationsDependencies {
   readonly draftBuilder?: PlanDraftBuilder;
   readonly isReady?: (input: PlanReadinessInput) => boolean | Promise<boolean>;
   readonly ftp?: PlanFtpAdapter;
+  readonly course?: PlanRaceCourseAdapter;
 }
 
 function createSerializedLane(): <T>(operation: () => Promise<T>) => Promise<T> {
@@ -166,6 +202,100 @@ function ftpProjection(
   });
 }
 
+type CourseScenario =
+  | "PL-S064"
+  | "PL-S065"
+  | "PL-S067"
+  | "PL-S068"
+  | "PL-S069"
+  | "PL-S070"
+  | "PL-S104";
+
+function courseSummary(value: RaceCourseSnapshot): PlanRaceCourseSummary {
+  return {
+    fileName: value.fileName,
+    format: value.format,
+    pointCount: value.preview.pointCount,
+    distanceM: value.preview.distanceM,
+    elevationGainM: value.preview.elevationGainM,
+    elevationStatus: value.preview.elevationStatus,
+  };
+}
+
+function courseFromJson(value: string | null): RaceCourseSnapshot | null {
+  return value === null ? null : parseRaceCourseSnapshot(JSON.parse(value) as unknown);
+}
+
+function storedCourseProjection(
+  conversation: PlanConversationRecord,
+  draft: PlanDraftRevisionRecord | undefined,
+): PlanRaceCourseProjection {
+  if (draft !== undefined && draft.status !== "discarded") {
+    const course = courseFromJson(draft.raceCourseJson);
+    return PlanRaceCourseProjectionSchema.parse(
+      course === null
+        ? { status: "omitted", accepted: null, candidate: null, fileName: null, detail: null }
+        : {
+            status: "ready",
+            accepted: courseSummary(course),
+            candidate: null,
+            fileName: null,
+            detail: null,
+          },
+    );
+  }
+  const course = courseFromJson(conversation.raceCourseJson);
+  if (conversation.courseChoiceStatus === "undecided") {
+    return PlanRaceCourseProjectionSchema.parse({
+      status: "undecided",
+      accepted: null,
+      candidate: null,
+      fileName: null,
+      detail: null,
+    });
+  }
+  return PlanRaceCourseProjectionSchema.parse(
+    course === null
+      ? { status: "omitted", accepted: null, candidate: null, fileName: null, detail: null }
+      : {
+          status: "ready",
+          accepted: courseSummary(course),
+          candidate: null,
+          fileName: null,
+          detail: null,
+        },
+  );
+}
+
+function courseProjection(input: {
+  readonly status: PlanRaceCourseProjection["status"];
+  readonly accepted?: RaceCourseSnapshot | null;
+  readonly candidate?: RaceCourseSnapshot | null;
+  readonly fileName?: string | null;
+  readonly detail?: string | null;
+}): PlanRaceCourseProjection {
+  return PlanRaceCourseProjectionSchema.parse({
+    status: input.status,
+    accepted:
+      input.accepted === undefined || input.accepted === null
+        ? null
+        : courseSummary(input.accepted),
+    candidate:
+      input.candidate === undefined || input.candidate === null
+        ? null
+        : courseSummary(input.candidate),
+    fileName: input.fileName ?? null,
+    detail: input.detail ?? null,
+  });
+}
+
+interface ReadOverrides {
+  readonly ftpScenario?: FtpScenario;
+  readonly ftpError?: PlanError | null;
+  readonly courseScenario?: CourseScenario;
+  readonly course?: PlanRaceCourseProjection;
+}
+
 function queueText(queue: ChatQueueSnapshot): string {
   const head = queue.items[0];
   if (head === undefined) return "";
@@ -197,10 +327,7 @@ export function createPlanningOperations(
   const plans = dependencies.plans ?? createPlanRepository(input.context.store);
   const enqueue = createSerializedLane();
 
-  const read = async (
-    ftpScenario?: FtpScenario,
-    ftpError: PlanError | null = null,
-  ): Promise<PlanReadModel> => {
+  const read = async (overrides: ReadOverrides = {}): Promise<PlanReadModel> => {
     const conversation = await conversations.readLatestOpenConversation();
     if (conversation === undefined) {
       return buildPlanLifecycleReadModel({
@@ -223,8 +350,9 @@ export function createPlanningOperations(
         .catch(() => null),
       dependencies.ftp?.read(),
     ]);
-    const ready = await (dependencies.isReady?.({ conversation, turns, draft }) ??
-      Promise.resolve(false));
+    const ready =
+      conversation.courseChoiceStatus !== "undecided" &&
+      (await (dependencies.isReady?.({ conversation, turns, draft }) ?? Promise.resolve(false)));
     return buildPlanLifecycleReadModel({
       conversation: {
         id: conversation.id,
@@ -237,8 +365,14 @@ export function createPlanningOperations(
       queue,
       decision,
       draft: draftProjection(draft),
-      ...(ftp === undefined ? {} : { ftp: ftpProjection(ftp, ftpScenario, ftpError) }),
-      ...(ftpScenario === undefined ? {} : { ftpScenario }),
+      ...(ftp === undefined
+        ? {}
+        : { ftp: ftpProjection(ftp, overrides.ftpScenario, overrides.ftpError ?? null) }),
+      ...(overrides.ftpScenario === undefined ? {} : { ftpScenario: overrides.ftpScenario }),
+      course: overrides.course ?? storedCourseProjection(conversation, draft),
+      ...(overrides.courseScenario === undefined
+        ? {}
+        : { courseScenario: overrides.courseScenario }),
     });
   };
 
@@ -389,6 +523,7 @@ export function createPlanningOperations(
     conversation: PlanConversationRecord,
     previous: PlanDraftRevisionRecord | undefined,
     build: PlanDraftBuild,
+    course: RaceCourseSnapshot | null,
   ): Promise<void> => {
     const timestamp = input.identity.hlcStamp().physicalMs;
     await plans.replace(build.plan, build.workouts);
@@ -396,6 +531,8 @@ export function createPlanningOperations(
     await conversations.saveConversation({
       ...conversation,
       planId: build.plan.id,
+      courseChoiceStatus: course === null ? "omitted" : "attached",
+      raceCourseJson: course === null ? null : JSON.stringify(course),
       updatedAtMs: timestamp,
       deviceId: await input.identity.deviceId(),
       hlcPhysicalMs: conversationStamp.physicalMs,
@@ -410,6 +547,7 @@ export function createPlanningOperations(
       parentRevisionId: previous?.id ?? null,
       status: "ready",
       snapshotJson: JSON.stringify(build.snapshot),
+      raceCourseJson: course === null ? null : JSON.stringify(course),
       createdAtMs: timestamp,
       updatedAtMs: timestamp,
       deviceId: await input.identity.deviceId(),
@@ -418,14 +556,30 @@ export function createPlanningOperations(
     });
   };
 
+  const saveConversationCourse = async (
+    conversation: PlanConversationRecord,
+    course: RaceCourseSnapshot | null,
+  ): Promise<void> => {
+    const stamp = input.identity.hlcStamp();
+    await conversations.saveConversation({
+      ...conversation,
+      courseChoiceStatus: course === null ? "omitted" : "attached",
+      raceCourseJson: course === null ? null : JSON.stringify(course),
+      updatedAtMs: stamp.physicalMs,
+      deviceId: await input.identity.deviceId(),
+      hlcPhysicalMs: stamp.physicalMs,
+      hlcCounter: stamp.counter,
+    });
+  };
+
   const reject = async (
     error: PlanError,
-    ftpScenario?: FtpScenario,
+    overrides: ReadOverrides = {},
   ): Promise<ExecutePlanTransitionRpcResult> =>
     ExecutePlanTransitionRpcResultSchema.parse({
       status: "rejected",
       error,
-      state: await read(ftpScenario, error),
+      state: await read({ ...overrides, ftpError: error }),
     });
 
   return {
@@ -445,6 +599,8 @@ export function createPlanningOperations(
               id: input.identity.newUlid(),
               planId: null,
               replacesPlanId: null,
+              courseChoiceStatus: "undecided",
+              raceCourseJson: null,
               status: "open",
               endedAtMs: null,
               createdAtMs: timestamp,
@@ -459,6 +615,130 @@ export function createPlanningOperations(
             status: "completed",
             state: await read(),
           });
+        }
+        if (command.transitionId === "PL-T02") {
+          if (dependencies.course === undefined) return reject(UNAVAILABLE);
+          const conversation = await conversations.readConversation(command.conversationId);
+          if (conversation === undefined || conversation.status !== "open") {
+            return reject(UNAVAILABLE);
+          }
+          const draft = await conversations.readLatestDraftRevision(conversation.id);
+          if (draft !== undefined && draft.status !== "discarded") return reject(UNAVAILABLE);
+          const accepted = courseFromJson(conversation.raceCourseJson);
+          const operationId = input.identity.newUlid();
+          deliver(onEvent, {
+            commandId: command.commandId,
+            transitionId: command.transitionId,
+            operationId,
+            phase: "running",
+            completed: 0,
+            total: 1,
+          });
+          const parsed = await dependencies.course.parse(command.filePath);
+          const picker = openRaceCoursePicker({
+            planStatus: "draft",
+            draft: null,
+            acceptedCourse: accepted,
+          });
+          const parsing = beginRaceCourseParsing(
+            picker,
+            parsed.ok ? parsed.course.fileName : parsed.fileName,
+          );
+          if (!parsed.ok) {
+            const invalid = rejectRaceCourseFile(parsing, parsed.detail);
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "failed",
+              completed: 0,
+              total: 1,
+            });
+            return reject(COURSE_INVALID, {
+              courseScenario: "PL-S065",
+              course: courseProjection({
+                status: "invalid",
+                accepted: invalid.acceptedCourse,
+                fileName: invalid.fileName,
+                detail: invalid.detail,
+              }),
+            });
+          }
+          let next = acceptParsedRaceCourse(parsing, parsed.course);
+          if (next.kind === "course-missing-elevation" && command.elevation === "require") {
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "completed",
+              completed: 1,
+              total: 1,
+            });
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read({
+                courseScenario: "PL-S067",
+                course: courseProjection({
+                  status: "missing-elevation",
+                  accepted: next.acceptedCourse,
+                  candidate: next.candidateCourse,
+                }),
+              }),
+            });
+          }
+          if (next.kind === "course-missing-elevation") next = useRouteWithoutElevation(next);
+          const ready = completeRaceCourseRecalculation(next, {
+            planStatus: "draft",
+            recalculatedDraft: null,
+          });
+          try {
+            await saveConversationCourse(conversation, ready.acceptedCourse);
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "completed",
+              completed: 1,
+              total: 1,
+            });
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read(),
+            });
+          } catch {
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "failed",
+              completed: 0,
+              total: 1,
+            });
+            return reject(PERSISTENCE_FAILED);
+          }
+        }
+        if (command.transitionId === "PL-T03") {
+          const conversation = await conversations.readConversation(command.conversationId);
+          if (conversation === undefined || conversation.status !== "open") {
+            return reject(UNAVAILABLE);
+          }
+          const draft = await conversations.readLatestDraftRevision(conversation.id);
+          if (draft !== undefined && draft.status !== "discarded") return reject(UNAVAILABLE);
+          try {
+            await saveConversationCourse(conversation, null);
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read(),
+            });
+          } catch {
+            return reject(PERSISTENCE_FAILED, {
+              courseScenario: "PL-S104",
+              course: courseProjection({
+                status: "omission-failed",
+                detail: "Couldn’t continue without a Race Course. Nothing changed.",
+              }),
+            });
+          }
         }
         if (command.transitionId === "PL-T05") {
           const operationId = input.identity.newUlid();
@@ -527,7 +807,7 @@ export function createPlanningOperations(
             });
             return ExecutePlanTransitionRpcResultSchema.parse({
               status: "completed",
-              state: await read(scenario),
+              state: await read({ ftpScenario: scenario }),
             });
           } catch {
             deliver(onEvent, {
@@ -539,8 +819,8 @@ export function createPlanningOperations(
               total: 1,
             });
             return command.source === "manual"
-              ? reject(FTP_SAVE_FAILED, "PL-S061")
-              : reject(FTP_REFRESH_FAILED, "PL-S059");
+              ? reject(FTP_SAVE_FAILED, { ftpScenario: "PL-S061" })
+              : reject(FTP_REFRESH_FAILED, { ftpScenario: "PL-S059" });
           }
         }
         if (command.transitionId === "PL-T06" || command.transitionId === "PL-T07") {
@@ -569,9 +849,21 @@ export function createPlanningOperations(
               return reject(UNAVAILABLE);
             const turns = await conversations.readTurns(conversation.id);
             const previous = await conversations.readLatestDraftRevision(conversation.id);
+            if (
+              command.transitionId === "PL-T06" &&
+              (conversation.courseChoiceStatus === "undecided" ||
+                !(await (dependencies.isReady?.({ conversation, turns, draft: previous }) ??
+                  Promise.resolve(false))))
+            ) {
+              return reject(UNAVAILABLE);
+            }
+            const course =
+              previous === undefined
+                ? courseFromJson(conversation.raceCourseJson)
+                : courseFromJson(previous.raceCourseJson);
             const build =
               command.transitionId === "PL-T06"
-                ? await dependencies.draftBuilder.form({ conversation, turns })
+                ? await dependencies.draftBuilder.form({ conversation, turns, course })
                 : previous === undefined
                   ? null
                   : await dependencies.draftBuilder.revise({
@@ -579,9 +871,10 @@ export function createPlanningOperations(
                       turns,
                       previous,
                       instruction: command.text,
+                      course,
                     });
             if (build === null) return reject(UNAVAILABLE);
-            await saveDraft(conversation, previous, build);
+            await saveDraft(conversation, previous, build, course);
             deliver(onEvent, {
               commandId: command.commandId,
               transitionId: command.transitionId,
@@ -606,6 +899,126 @@ export function createPlanningOperations(
             return reject(PERSISTENCE_FAILED);
           }
         }
+        if (command.transitionId === "PL-T09") {
+          if (dependencies.draftBuilder === undefined) return reject(UNAVAILABLE);
+          const current = await conversations.readDraftRevision(command.draftId);
+          if (current === undefined || current.status !== "ready") return reject(UNAVAILABLE);
+          const conversation = await conversations.readConversation(current.conversationId);
+          const plan = await plans.read(current.planId);
+          if (
+            conversation === undefined ||
+            conversation.status !== "open" ||
+            plan === undefined ||
+            plan.status !== "draft"
+          ) {
+            return reject(UNAVAILABLE);
+          }
+          const accepted = courseFromJson(current.raceCourseJson);
+          const picker = openRaceCoursePicker({
+            planStatus: plan.status,
+            draft: current,
+            acceptedCourse: accepted,
+          });
+          let recalculating: RaceCourseRecalculatingState<PlanDraftRevisionRecord>;
+          if (command.course.action === "remove") {
+            recalculating = beginRaceCourseRemoval(picker);
+          } else {
+            if (dependencies.course === undefined) return reject(UNAVAILABLE);
+            const parsed = await dependencies.course.parse(command.course.filePath);
+            const parsing = beginRaceCourseParsing(
+              picker,
+              parsed.ok ? parsed.course.fileName : parsed.fileName,
+            );
+            if (!parsed.ok) {
+              const invalid = rejectRaceCourseFile(parsing, parsed.detail);
+              return reject(COURSE_INVALID, {
+                courseScenario: "PL-S065",
+                course: courseProjection({
+                  status: "invalid",
+                  accepted: invalid.acceptedCourse,
+                  fileName: invalid.fileName,
+                  detail: invalid.detail,
+                }),
+              });
+            }
+            let next = acceptParsedRaceCourse(parsing, parsed.course);
+            if (
+              next.kind === "course-missing-elevation" &&
+              command.course.elevation === "require"
+            ) {
+              return ExecutePlanTransitionRpcResultSchema.parse({
+                status: "completed",
+                state: await read({
+                  courseScenario: "PL-S067",
+                  course: courseProjection({
+                    status: "missing-elevation",
+                    accepted: next.acceptedCourse,
+                    candidate: next.candidateCourse,
+                  }),
+                }),
+              });
+            }
+            if (next.kind === "course-missing-elevation") next = useRouteWithoutElevation(next);
+            recalculating = next;
+          }
+          const operationId = input.identity.newUlid();
+          deliver(onEvent, {
+            commandId: command.commandId,
+            transitionId: command.transitionId,
+            operationId,
+            phase: "running",
+            completed: 0,
+            total: 1,
+          });
+          const turns = await conversations.readTurns(conversation.id);
+          try {
+            const build = await dependencies.draftBuilder.recalculateCourse({
+              conversation,
+              turns,
+              previous: current,
+              course: recalculating.candidateCourse,
+            });
+            const ready = completeRaceCourseRecalculation(recalculating, {
+              planStatus: plan.status,
+              recalculatedDraft: build,
+            });
+            await saveDraft(conversation, current, ready.draft, ready.acceptedCourse);
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "completed",
+              completed: 1,
+              total: 1,
+            });
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read(ready.acceptedCourse === null ? {} : { courseScenario: "PL-S070" }),
+            });
+          } catch {
+            const failed = failRaceCourseRecalculation(
+              recalculating,
+              COURSE_RECALCULATION_FAILED.message,
+            );
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "failed",
+              completed: 0,
+              total: 1,
+            });
+            return reject(COURSE_RECALCULATION_FAILED, {
+              courseScenario: "PL-S069",
+              course: courseProjection({
+                status: "recalculation-failed",
+                accepted: failed.acceptedCourse,
+                candidate: failed.candidateCourse,
+                detail: failed.detail,
+              }),
+            });
+          }
+        }
         if (command.transitionId === "PL-T10") {
           try {
             const current = await conversations.readDraftRevision(command.draftId);
@@ -615,6 +1028,7 @@ export function createPlanningOperations(
             await conversations.saveDraftRevision({
               ...current,
               status: "discarded",
+              raceCourseJson: current.raceCourseJson,
               updatedAtMs: timestamp,
               deviceId: await input.identity.deviceId(),
               hlcPhysicalMs: stamp.physicalMs,

--- a/packages/coach/src/planning-race-course.ts
+++ b/packages/coach/src/planning-race-course.ts
@@ -1,0 +1,50 @@
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
+import { parseGpxCourse, type CourseRouteParseResult } from "@enduragent/kernel/ingest";
+import { createRaceCourseSnapshot, type RaceCourseSnapshot } from "@enduragent/kernel/planning";
+import { parseFitCourse } from "@enduragent/kernel-node/ingest";
+import { interpretCyclingRaceCourse } from "@enduragent/sport-cycling";
+
+export type PlanRaceCourseParseResult =
+  | { readonly ok: true; readonly course: RaceCourseSnapshot }
+  | { readonly ok: false; readonly fileName: string; readonly detail: string };
+
+export interface PlanRaceCourseAdapter {
+  parse(filePath: string): Promise<PlanRaceCourseParseResult>;
+}
+
+function failure(fileName: string, detail: string): PlanRaceCourseParseResult {
+  return Object.freeze({ ok: false, fileName, detail });
+}
+
+export function createNodePlanRaceCourseAdapter(): PlanRaceCourseAdapter {
+  return Object.freeze({
+    async parse(filePath: string) {
+      const fileName = basename(filePath);
+      try {
+        const extension = extname(filePath).toLowerCase();
+        const bytes = new Uint8Array(await readFile(filePath));
+        let parsed: CourseRouteParseResult;
+        if (extension === ".gpx") {
+          parsed = parseGpxCourse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+        } else if (extension === ".fit") {
+          parsed = await parseFitCourse(bytes);
+        } else {
+          return failure(fileName, "Choose a GPX or FIT file.");
+        }
+        if (!parsed.ok) return failure(fileName, parsed.detail);
+        const preview = interpretCyclingRaceCourse(parsed.route);
+        return Object.freeze({
+          ok: true,
+          course: createRaceCourseSnapshot({
+            fileName,
+            route: parsed.route,
+            preview,
+          }),
+        });
+      } catch {
+        return failure(fileName, "This file could not be read as a Race Course.");
+      }
+    },
+  });
+}

--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -588,7 +588,7 @@ describe("account identity", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 14 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 15 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(
         beforeWorkouts,

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -582,7 +582,7 @@ describe("coach sync composition", () => {
           return store.get("PRAGMA user_version");
         },
       );
-      expect(value).toEqual({ user_version: 14 });
+      expect(value).toEqual({ user_version: 15 });
       expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
       expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
       expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -590,7 +590,7 @@ describe("coach sync composition", () => {
       const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
       try {
         await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-          user_version: 14,
+          user_version: 15,
         });
       } finally {
         await reopened.close();

--- a/packages/coach/tests/planning-lifecycle.test.ts
+++ b/packages/coach/tests/planning-lifecycle.test.ts
@@ -99,6 +99,59 @@ describe("Plan lifecycle projection", () => {
     expect(ready.transitions.map((transition) => transition.transitionId)).toContain("PL-T06");
   });
 
+  it("projects every Race Course recovery state without hiding a ready Draft", () => {
+    const summary = {
+      fileName: "almaty-gran-fondo.gpx",
+      format: "gpx" as const,
+      pointCount: 42,
+      distanceM: 120_000,
+      elevationGainM: 1_500,
+      elevationStatus: "available" as const,
+    };
+    const draft = {
+      id: "draft-1",
+      planId: "plan-1",
+      revision: 1,
+      status: "ready" as const,
+      snapshot: {},
+    };
+    expect(
+      build({
+        draft,
+        courseScenario: "PL-S069",
+        course: {
+          status: "recalculation-failed",
+          accepted: summary,
+          candidate: { ...summary, fileName: "replacement.gpx" },
+          fileName: null,
+          detail: "Draft recalculation failed.",
+        },
+      }),
+    ).toMatchObject({
+      scenarioId: "PL-S069",
+      lifecycle: "draft",
+      projection: "draft",
+      revision: 1,
+      data: { course: { status: "recalculation-failed" } },
+    });
+    expect(
+      build({
+        courseScenario: "PL-S104",
+        course: {
+          status: "omission-failed",
+          accepted: null,
+          candidate: null,
+          fileName: null,
+          detail: "Nothing changed.",
+        },
+      }),
+    ).toMatchObject({
+      scenarioId: "PL-S104",
+      lifecycle: "intake",
+      projection: "coach",
+    });
+  });
+
   it("projects forming, revised, and discarded Draft states without losing the conversation", () => {
     expect(
       build({

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -5,13 +5,20 @@ import type {
   PlanProgressEvent,
   TurnEvent,
 } from "@enduragent/coach-contract";
-import { createPlanConversationRepository, type PlanRecord } from "@enduragent/kernel/planning";
+import {
+  createPlanConversationRepository,
+  createPlanRepository,
+  createRaceCourseSnapshot,
+  type PlanRecord,
+  type RaceCourseSnapshot,
+} from "@enduragent/kernel/planning";
 import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import type { PlanFtpAdapter, PlanFtpSnapshot } from "@enduragent/engine";
 import { createPlanningOperations, type PlanDraftBuilder } from "../src/planning-operations.js";
+import type { PlanRaceCourseAdapter } from "../src/planning-race-course.js";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
 
 const EMPTY_QUEUE: ChatQueueSnapshot = { schemaVersion: 1, revision: 0, items: [] };
@@ -73,6 +80,40 @@ function plan(id: string, timestamp: number): PlanRecord {
   };
 }
 
+function course(
+  fileName: string,
+  elevationStatus: "available" | "unavailable" = "available",
+): RaceCourseSnapshot {
+  return createRaceCourseSnapshot({
+    fileName,
+    route: {
+      format: "gpx",
+      segments: [
+        {
+          points: [
+            {
+              latitude: 43.2,
+              longitude: 76.8,
+              elevationM: elevationStatus === "available" ? 900 : null,
+            },
+            {
+              latitude: 43.3,
+              longitude: 76.9,
+              elevationM: elevationStatus === "available" ? 960 : null,
+            },
+          ],
+        },
+      ],
+    },
+    preview: {
+      pointCount: 2,
+      distanceM: 14_000,
+      elevationGainM: elevationStatus === "available" ? 60 : null,
+      elevationStatus,
+    },
+  });
+}
+
 describe("Plan operations", () => {
   let store: SqlStore & MigratorStore;
   let context: CoachStoreWriterContext;
@@ -130,7 +171,7 @@ describe("Plan operations", () => {
     );
     expect(sent).toMatchObject({
       status: "completed",
-      state: { scenarioId: "PL-S016", projection: "coach" },
+      state: { scenarioId: "PL-S017", projection: "coach" },
     });
     expect(progress.map((event) => event.phase)).toEqual([
       "queued",
@@ -151,6 +192,16 @@ describe("Plan operations", () => {
         coachText: "I found your rides.",
       },
     ]);
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T03",
+        commandId: "command-3",
+        conversationId,
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: { scenarioId: "PL-S016", projection: "coach" },
+    });
     const restored = createPlanningOperations(
       { context, engine: coach, identity: authored },
       readiness,
@@ -192,6 +243,14 @@ describe("Plan operations", () => {
           snapshot: { completeWeeks: 12, revision },
         };
       },
+      async recalculateCourse() {
+        revision += 1;
+        return {
+          plan: plan(`${"0".repeat(25)}T`, 202),
+          workouts: [],
+          snapshot: { completeWeeks: 12, revision },
+        };
+      },
     };
     const operations = createPlanningOperations(
       { context, engine: coach, identity: authored },
@@ -204,6 +263,11 @@ describe("Plan operations", () => {
     });
     if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
     const conversationId = String(started.state.data.conversationId);
+    await operations.executePlanTransition?.({
+      transitionId: "PL-T03",
+      commandId: "command-course-choice",
+      conversationId,
+    });
     const formed = await operations.executePlanTransition?.({
       transitionId: "PL-T06",
       commandId: "command-2",
@@ -370,6 +434,256 @@ describe("Plan operations", () => {
         data: { ftp: { status: "conflict", usedSource: "manual", usedWatts: 282 } },
       },
     });
+  });
+
+  it("requires an explicit Race Course choice and preserves it across relaunch", async () => {
+    const fullCourse = course("almaty-gran-fondo.gpx");
+    const routeOnly = course("route-only.gpx", "unavailable");
+    const adapter: PlanRaceCourseAdapter = {
+      parse: vi.fn(async (filePath) => {
+        if (filePath.endsWith("invalid.gpx")) {
+          return { ok: false as const, fileName: "invalid.gpx", detail: "No route found." };
+        }
+        return {
+          ok: true as const,
+          course: filePath.endsWith("route-only.gpx") ? routeOnly : fullCourse,
+        };
+      }),
+    };
+    const readiness = { isReady: () => true, course: adapter };
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: identity() },
+      readiness,
+    );
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T06",
+        commandId: "command-2",
+        conversationId,
+      }),
+    ).resolves.toMatchObject({ status: "rejected" });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T02",
+        commandId: "command-3",
+        conversationId,
+        filePath: "/tmp/invalid.gpx",
+        elevation: "require",
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      state: { scenarioId: "PL-S065", data: { course: { status: "invalid" } } },
+    });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T02",
+        commandId: "command-4",
+        conversationId,
+        filePath: "/tmp/route-only.gpx",
+        elevation: "require",
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S067",
+        data: {
+          course: { status: "missing-elevation", candidate: { elevationStatus: "unavailable" } },
+        },
+      },
+    });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T02",
+        commandId: "command-5",
+        conversationId,
+        filePath: "/tmp/route-only.gpx",
+        elevation: "allow-missing",
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S016",
+        data: { readyToCreateDraft: true, course: { status: "ready" } },
+      },
+    });
+    await expect(
+      createPlanConversationRepository(store).readConversation(conversationId),
+    ).resolves.toMatchObject({ courseChoiceStatus: "attached" });
+
+    const restored = createPlanningOperations(
+      { context, engine: engine(), identity: identity() },
+      readiness,
+    );
+    await expect(restored.getPlanState?.({})).resolves.toMatchObject({
+      status: "ready",
+      state: {
+        scenarioId: "PL-S016",
+        data: { course: { status: "ready", accepted: { fileName: "route-only.gpx" } } },
+      },
+    });
+  });
+
+  it("keeps a failed course-omission write visible and retryable", async () => {
+    const conversations = createPlanConversationRepository(store);
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: identity() },
+      { conversations, isReady: () => true },
+    );
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+    vi.spyOn(conversations, "saveConversation").mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T03",
+        commandId: "command-2",
+        conversationId,
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      error: { code: "persistence-failed", retryable: true },
+      state: { scenarioId: "PL-S104", data: { course: { status: "omission-failed" } } },
+    });
+    await expect(conversations.readConversation(conversationId)).resolves.toMatchObject({
+      courseChoiceStatus: "undecided",
+    });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T03",
+        commandId: "command-3",
+        conversationId,
+      }),
+    ).resolves.toMatchObject({ status: "completed", state: { scenarioId: "PL-S016" } });
+  });
+
+  it("recalculates a Draft atomically and rejects Course edits after activation", async () => {
+    const firstCourse = course("almaty-gran-fondo.gpx");
+    const secondCourse = course("replacement.gpx");
+    const adapter: PlanRaceCourseAdapter = {
+      parse: vi.fn(async (filePath) => ({
+        ok: true as const,
+        course: filePath.endsWith("replacement.gpx") ? secondCourse : firstCourse,
+      })),
+    };
+    let buildRevision = 0;
+    let failRecalculation = false;
+    const builder: PlanDraftBuilder = {
+      async form() {
+        buildRevision += 1;
+        return {
+          plan: plan(`${"0".repeat(25)}V`, 300),
+          workouts: [],
+          snapshot: { completeWeeks: 12, buildRevision },
+        };
+      },
+      async revise() {
+        throw new TypeError("not used");
+      },
+      async recalculateCourse() {
+        if (failRecalculation) throw new Error("builder unavailable");
+        buildRevision += 1;
+        return {
+          plan: plan(`${"0".repeat(25)}V`, 301),
+          workouts: [],
+          snapshot: { completeWeeks: 12, buildRevision },
+        };
+      },
+    };
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: identity() },
+      { course: adapter, draftBuilder: builder, isReady: () => true },
+    );
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+    await operations.executePlanTransition?.({
+      transitionId: "PL-T03",
+      commandId: "command-2",
+      conversationId,
+    });
+    const formed = await operations.executePlanTransition?.({
+      transitionId: "PL-T06",
+      commandId: "command-3",
+      conversationId,
+    });
+    if (formed?.status !== "completed") throw new TypeError("Draft did not form.");
+    const draftId = String((formed.state.data.draft as { id: string }).id);
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T09",
+        commandId: "command-4",
+        draftId,
+        course: { action: "attach", filePath: "/tmp/almaty-gran-fondo.gpx", elevation: "require" },
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S070",
+        revision: 2,
+        data: { course: { status: "ready", accepted: { fileName: "almaty-gran-fondo.gpx" } } },
+      },
+    });
+    const latest =
+      await createPlanConversationRepository(store).readLatestDraftRevision(conversationId);
+    expect(latest).toMatchObject({ revision: 2 });
+    expect(latest?.raceCourseJson).toContain("almaty-gran-fondo.gpx");
+
+    failRecalculation = true;
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T09",
+        commandId: "command-5",
+        draftId: String(latest?.id),
+        course: { action: "attach", filePath: "/tmp/replacement.gpx", elevation: "require" },
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      state: {
+        scenarioId: "PL-S069",
+        revision: 2,
+        data: {
+          course: {
+            status: "recalculation-failed",
+            accepted: { fileName: "almaty-gran-fondo.gpx" },
+            candidate: { fileName: "replacement.gpx" },
+          },
+        },
+      },
+    });
+    await expect(
+      createPlanConversationRepository(store).readLatestDraftRevision(conversationId),
+    ).resolves.toMatchObject({ revision: 2, raceCourseJson: latest?.raceCourseJson });
+
+    await createPlanRepository(store).replace(
+      { ...plan(`${"0".repeat(25)}V`, 302), status: "active" },
+      [],
+    );
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T09",
+        commandId: "command-6",
+        draftId: String(latest?.id),
+        course: { action: "remove" },
+      }),
+    ).resolves.toMatchObject({ status: "rejected", error: { code: "unavailable" } });
   });
 
   it("retries an interrupted Plan queue claim and persists the recovered turn", async () => {

--- a/packages/coach/tests/planning-race-course.test.ts
+++ b/packages/coach/tests/planning-race-course.test.ts
@@ -1,0 +1,51 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createNodePlanRaceCourseAdapter } from "../src/planning-race-course.js";
+
+const fixtures = resolve(
+  import.meta.dirname,
+  "..",
+  "..",
+  "kernel-node",
+  "tests",
+  "fixtures",
+  "ingest",
+);
+
+describe("Node Plan Race Course adapter", () => {
+  it("normalizes GPX and FIT routes through the dedicated Course path", async () => {
+    const adapter = createNodePlanRaceCourseAdapter();
+    await expect(adapter.parse(resolve(fixtures, "fallback-cycling.gpx"))).resolves.toMatchObject({
+      ok: true,
+      course: {
+        fileName: "fallback-cycling.gpx",
+        format: "gpx",
+        preview: { pointCount: expect.any(Number), distanceM: expect.any(Number) },
+      },
+    });
+    await expect(adapter.parse(resolve(fixtures, "brick-cycling.fit"))).resolves.toMatchObject({
+      ok: true,
+      course: {
+        fileName: "brick-cycling.fit",
+        format: "fit",
+        preview: { pointCount: expect.any(Number), distanceM: expect.any(Number) },
+      },
+    });
+  });
+
+  it("names unsupported and unreadable files without throwing", async () => {
+    const adapter = createNodePlanRaceCourseAdapter();
+    await expect(
+      adapter.parse(resolve(import.meta.dirname, "..", "package.json")),
+    ).resolves.toEqual({
+      ok: false,
+      fileName: "package.json",
+      detail: "Choose a GPX or FIT file.",
+    });
+    await expect(adapter.parse(resolve(fixtures, "missing.gpx"))).resolves.toEqual({
+      ok: false,
+      fileName: "missing.gpx",
+      detail: "This file could not be read as a Race Course.",
+    });
+  });
+});

--- a/packages/engine/src/planning/race-course.ts
+++ b/packages/engine/src/planning/race-course.ts
@@ -80,7 +80,11 @@ export function openRaceCoursePicker<Draft>(input: {
   readonly acceptedCourse: RaceCourseSnapshot | null;
 }): RaceCoursePickerState<Draft> {
   if (input.planStatus !== "draft") throw new RaceCourseLifecycleError("course-frozen");
-  return frozen({ kind: "course-picker", draft: input.draft, acceptedCourse: input.acceptedCourse });
+  return frozen({
+    kind: "course-picker",
+    draft: input.draft,
+    acceptedCourse: input.acceptedCourse,
+  });
 }
 
 export function beginRaceCourseParsing<Draft>(
@@ -151,7 +155,10 @@ export function useRouteWithoutElevation<Draft>(
 }
 
 export function beginRaceCourseRemoval<Draft>(
-  state: RaceCoursePickerState<Draft> | RaceCourseInvalidState<Draft> | RaceCourseMissingElevationState<Draft>,
+  state:
+    | RaceCoursePickerState<Draft>
+    | RaceCourseInvalidState<Draft>
+    | RaceCourseMissingElevationState<Draft>,
 ): RaceCourseRecalculatingState<Draft> {
   return frozen({
     kind: "course-recalculating",
@@ -185,13 +192,13 @@ export function retryRaceCourseRecalculation<Draft>(
   });
 }
 
-export function completeRaceCourseRecalculation<Draft>(
+export function completeRaceCourseRecalculation<Draft, RecalculatedDraft>(
   state: RaceCourseRecalculatingState<Draft>,
   input: {
     readonly planStatus: PlanStatus;
-    readonly recalculatedDraft: Draft;
+    readonly recalculatedDraft: RecalculatedDraft;
   },
-): RaceCourseReadyState<Draft> {
+): RaceCourseReadyState<RecalculatedDraft> {
   if (state.kind !== "course-recalculating") {
     throw new RaceCourseLifecycleError("invalid-transition");
   }

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -592,7 +592,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 14 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 15 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -31,9 +31,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 14", async () => {
+  it("applies the full migration list and advances user_version to 15", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 14 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 15 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -53,7 +53,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 14 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 15 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -82,11 +82,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 14", async () => {
+  it("upgrades a version-1-on-disk store to version 15", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 14 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 15 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -108,10 +108,10 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 4,
-      toVersion: 14,
-      applied: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+      toVersion: 15,
+      applied: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 14 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 15 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -164,21 +164,21 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 6,
-      toVersion: 14,
-      applied: [7, 8, 9, 10, 11, 12, 13, 14],
+      toVersion: 15,
+      applied: [7, 8, 9, 10, 11, 12, 13, 14, 15],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 14 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 15 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 14,
-      toVersion: 14,
+      fromVersion: 15,
+      toVersion: 15,
       applied: [],
     });
   });
 
-  it("upgrades version 11 through 14 while preserving existing rows", async () => {
+  it("upgrades version 11 through 15 while preserving existing rows", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 11));
     await store.run(
       "INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,?)",
@@ -187,14 +187,14 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 11,
-      toVersion: 14,
-      applied: [12, 13, 14],
+      toVersion: 15,
+      applied: [12, 13, 14, 15],
     });
     await expect(store.get("SELECT fixer,enabled FROM repair_fixer_settings"))
       .resolves.toEqual({ fixer: "chronoBridge", enabled: 1 });
     await expect(store.get("SELECT count(*) AS count FROM repair_fixer_settings"))
       .resolves.toEqual({ count: 1 });
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 14 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 15 });
   });
 
   it("rolls back a failed migration 12 without partial Planning tables", async () => {

--- a/packages/kernel-node/tests/plan-conversation-repository.test.ts
+++ b/packages/kernel-node/tests/plan-conversation-repository.test.ts
@@ -6,6 +6,7 @@ import {
   PlanConversationValidationError,
   createPlanConversationRepository,
   createPlanRepository,
+  createRaceCourseSnapshot,
   type PlanConversationRecord,
   type PlanConversationTurnRecord,
   type PlanDraftRevisionRecord,
@@ -53,6 +54,8 @@ function conversation(overrides: Partial<PlanConversationRecord> = {}): PlanConv
     id: CONVERSATION_ID,
     planId: null,
     replacesPlanId: null,
+    courseChoiceStatus: "undecided",
+    raceCourseJson: null,
     status: "open",
     endedAtMs: null,
     createdAtMs: 10,
@@ -89,6 +92,7 @@ function revision(overrides: Partial<PlanDraftRevisionRecord> = {}): PlanDraftRe
     parentRevisionId: null,
     status: "forming",
     snapshotJson: '{"completeWeeks":1}',
+    raceCourseJson: null,
     createdAtMs: 12,
     updatedAtMs: 12,
     deviceId: "device-1",
@@ -115,6 +119,31 @@ function sourceRequest(overrides: Partial<PlanSourceRequestRecord> = {}): PlanSo
   };
 }
 
+function raceCourseJson(): string {
+  return JSON.stringify(
+    createRaceCourseSnapshot({
+      fileName: "almaty-gran-fondo.gpx",
+      route: {
+        format: "gpx",
+        segments: [
+          {
+            points: [
+              { latitude: 43.2, longitude: 76.8, elevationM: 900 },
+              { latitude: 43.3, longitude: 76.9, elevationM: 960 },
+            ],
+          },
+        ],
+      },
+      preview: {
+        pointCount: 2,
+        distanceM: 14_000,
+        elevationGainM: 60,
+        elevationStatus: "available",
+      },
+    }),
+  );
+}
+
 describe("Plan conversation repository", () => {
   let store: SqlStore & MigratorStore;
 
@@ -134,8 +163,45 @@ describe("Plan conversation repository", () => {
     await expect(repository.readLatestOpenConversation()).resolves.toEqual(conversation());
     await expect(repository.readTurns(CONVERSATION_ID)).resolves.toEqual([]);
     await expect(repository.readSourceRequests(CONVERSATION_ID)).resolves.toEqual([]);
-    await expect(store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='messages'"))
-      .resolves.toBeUndefined();
+    await expect(
+      store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='messages'"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("persists validated Race Course choices on the conversation and Draft revision", async () => {
+    const plans = createPlanRepository(store);
+    const repository = createPlanConversationRepository(store);
+    const course = raceCourseJson();
+    await plans.replace(plan(), []);
+    const attached = conversation({
+      planId: PLAN_ID,
+      courseChoiceStatus: "attached",
+      raceCourseJson: course,
+    });
+    await repository.saveConversation(attached);
+    await repository.saveDraftRevision(revision({ status: "ready", raceCourseJson: course }));
+    await expect(repository.readConversation(CONVERSATION_ID)).resolves.toEqual(attached);
+    await expect(repository.readLatestDraftRevision(CONVERSATION_ID)).resolves.toMatchObject({
+      raceCourseJson: course,
+    });
+    await expect(
+      repository.saveConversation(
+        conversation({
+          courseChoiceStatus: "attached",
+          raceCourseJson: null,
+        }),
+      ),
+    ).rejects.toEqual(new PlanConversationValidationError("invalid-race-course"));
+    await expect(
+      repository.saveDraftRevision(
+        revision({
+          id: SECOND_REVISION_ID,
+          revision: 2,
+          parentRevisionId: REVISION_ID,
+          raceCourseJson: '{"invalid":true}',
+        }),
+      ),
+    ).rejects.toEqual(new PlanConversationValidationError("invalid-draft-revision"));
   });
 
   it("appends ordered turns idempotently and rejects gaps or changed retries", async () => {
@@ -143,12 +209,17 @@ describe("Plan conversation repository", () => {
     await repository.saveConversation(conversation());
     await expect(repository.appendTurn(turn())).resolves.toEqual(turn());
     await expect(repository.appendTurn(turn())).resolves.toEqual(turn());
-    await expect(repository.appendTurn(turn({ coachText: "Changed" })))
-      .rejects.toEqual(new PlanConversationValidationError("turn-conflict"));
-    await expect(repository.appendTurn(turn({
-      id: `${"0".repeat(25)}8`,
-      sequence: 3,
-    }))).rejects.toEqual(new PlanConversationValidationError("turn-conflict"));
+    await expect(repository.appendTurn(turn({ coachText: "Changed" }))).rejects.toEqual(
+      new PlanConversationValidationError("turn-conflict"),
+    );
+    await expect(
+      repository.appendTurn(
+        turn({
+          id: `${"0".repeat(25)}8`,
+          sequence: 3,
+        }),
+      ),
+    ).rejects.toEqual(new PlanConversationValidationError("turn-conflict"));
     const second = turn({
       id: `${"0".repeat(25)}8`,
       sequence: 2,
@@ -187,11 +258,15 @@ describe("Plan conversation repository", () => {
     await repository.saveDraftRevision(second);
     await expect(repository.readDraftRevisions(CONVERSATION_ID)).resolves.toEqual([ready, second]);
     await expect(repository.readLatestDraftRevision(CONVERSATION_ID)).resolves.toEqual(second);
-    await expect(repository.saveDraftRevision(revision({
-      id: `${"0".repeat(25)}9`,
-      revision: 2,
-      parentRevisionId: REVISION_ID,
-    }))).rejects.toEqual(new PlanConversationValidationError("draft-lineage-conflict"));
+    await expect(
+      repository.saveDraftRevision(
+        revision({
+          id: `${"0".repeat(25)}9`,
+          revision: 2,
+          parentRevisionId: REVISION_ID,
+        }),
+      ),
+    ).rejects.toEqual(new PlanConversationValidationError("draft-lineage-conflict"));
   });
 
   it("rejects a Draft parent from another Plan at the SQLite boundary", async () => {
@@ -200,18 +275,23 @@ describe("Plan conversation repository", () => {
     await plans.replace(plan(), []);
     await plans.replace(plan({ id: SECOND_PLAN_ID, name: "Second Plan" }), []);
     await repository.saveConversation(conversation({ planId: PLAN_ID }));
-    await repository.saveConversation(conversation({
-      id: SECOND_CONVERSATION_ID,
-      planId: SECOND_PLAN_ID,
-    }));
+    await repository.saveConversation(
+      conversation({
+        id: SECOND_CONVERSATION_ID,
+        planId: SECOND_PLAN_ID,
+      }),
+    );
     await repository.saveDraftRevision(revision());
-    await expect(store.run(`INSERT INTO plan_draft_revision (
+    await expect(
+      store.run(
+        `INSERT INTO plan_draft_revision (
   id, conversation_id, plan_id, revision, parent_revision_id, parent_revision, status,
   snapshot_json, created_at_ms, updated_at_ms, device_id, hlc_physical_ms, hlc_counter
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, [
-      `${"0".repeat(25)}C`,
-      SECOND_CONVERSATION_ID,
-      SECOND_PLAN_ID,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          `${"0".repeat(25)}C`,
+          SECOND_CONVERSATION_ID,
+          SECOND_PLAN_ID,
       2,
       REVISION_ID,
       1,
@@ -219,10 +299,12 @@ describe("Plan conversation repository", () => {
       '{"completeWeeks":12}',
       17,
       17,
-      "device-1",
-      17,
-      0,
-    ])).rejects.toThrow();
+          "device-1",
+          17,
+          0,
+        ],
+      ),
+    ).rejects.toThrow();
   });
 
   it("preserves the conversation and source link when its Draft is discarded", async () => {
@@ -232,14 +314,16 @@ describe("Plan conversation repository", () => {
     await repository.saveConversation(conversation({ planId: PLAN_ID }));
     await repository.appendTurn(turn());
     await repository.saveDraftRevision(revision());
-    await repository.saveDraftRevision(revision({
-      id: SECOND_REVISION_ID,
-      revision: 2,
-      parentRevisionId: REVISION_ID,
-      createdAtMs: 14,
-      updatedAtMs: 14,
-      hlcPhysicalMs: 14,
-    }));
+    await repository.saveDraftRevision(
+      revision({
+        id: SECOND_REVISION_ID,
+        revision: 2,
+        parentRevisionId: REVISION_ID,
+        createdAtMs: 14,
+        updatedAtMs: 14,
+        hlcPhysicalMs: 14,
+      }),
+    );
     await repository.createOrGetSourceRequest(sourceRequest());
 
     await plans.delete(PLAN_ID);
@@ -249,16 +333,23 @@ describe("Plan conversation repository", () => {
     );
     await expect(repository.readTurns(CONVERSATION_ID)).resolves.toEqual([turn()]);
     await expect(repository.readDraftRevisions(CONVERSATION_ID)).resolves.toEqual([]);
-    await expect(repository.readSourceRequests(CONVERSATION_ID)).resolves.toEqual([sourceRequest()]);
+    await expect(repository.readSourceRequests(CONVERSATION_ID)).resolves.toEqual([
+      sourceRequest(),
+    ]);
   });
 
   it("stores the exact source Conversation separately from the request identity", async () => {
     const repository = createPlanConversationRepository(store);
     await repository.saveConversation(conversation());
-    await expect(repository.createOrGetSourceRequest(sourceRequest())).resolves.toEqual(sourceRequest());
-    await expect(repository.createOrGetSourceRequest(sourceRequest())).resolves.toEqual(sourceRequest());
-    await expect(repository.createOrGetSourceRequest(sourceRequest({ sourceChatId: "other" })))
-      .rejects.toEqual(new PlanConversationValidationError("source-request-conflict"));
+    await expect(repository.createOrGetSourceRequest(sourceRequest())).resolves.toEqual(
+      sourceRequest(),
+    );
+    await expect(repository.createOrGetSourceRequest(sourceRequest())).resolves.toEqual(
+      sourceRequest(),
+    );
+    await expect(
+      repository.createOrGetSourceRequest(sourceRequest({ sourceChatId: "other" })),
+    ).rejects.toEqual(new PlanConversationValidationError("source-request-conflict"));
     await expect(repository.readSourceRequest(REQUEST_ID)).resolves.toEqual(sourceRequest());
   });
 
@@ -269,7 +360,9 @@ describe("Plan conversation repository", () => {
     await plans.replace(active, []);
     const replacement = conversation({ replacesPlanId: REPLACED_PLAN_ID });
     await repository.saveConversation(replacement);
-    await expect(repository.readLatestOpenReplacement(REPLACED_PLAN_ID)).resolves.toEqual(replacement);
+    await expect(repository.readLatestOpenReplacement(REPLACED_PLAN_ID)).resolves.toEqual(
+      replacement,
+    );
     await expect(plans.read(REPLACED_PLAN_ID)).resolves.toEqual(active);
   });
 
@@ -289,15 +382,18 @@ describe("Plan conversation repository", () => {
     await expect(repository.createOrGetSourceRequest(sourceRequest())).rejects.toEqual(
       new PlanConversationValidationError("conversation-ended"),
     );
-    await expect(repository.saveConversation(conversation({ updatedAtMs: 21, hlcPhysicalMs: 21 })))
-      .rejects.toEqual(new PlanConversationValidationError("conversation-conflict"));
+    await expect(
+      repository.saveConversation(conversation({ updatedAtMs: 21, hlcPhysicalMs: 21 })),
+    ).rejects.toEqual(new PlanConversationValidationError("conversation-conflict"));
     await expect(repository.saveConversation(ended)).resolves.toBeUndefined();
-    await expect(repository.saveConversation({
-      ...ended,
-      endedAtMs: 21,
-      updatedAtMs: 21,
-      hlcPhysicalMs: 21,
-    })).rejects.toEqual(new PlanConversationValidationError("conversation-conflict"));
+    await expect(
+      repository.saveConversation({
+        ...ended,
+        endedAtMs: 21,
+        updatedAtMs: 21,
+        hlcPhysicalMs: 21,
+      }),
+    ).rejects.toEqual(new PlanConversationValidationError("conversation-conflict"));
     await expect(repository.readConversation(CONVERSATION_ID)).resolves.toEqual(ended);
   });
 });

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -239,7 +239,7 @@ describe("sync failure repository", () => {
     expect(dump).not.toContain("# sync_failure");
     expect(dump).toContain("# plan_reconciliation_job");
     expect(dump).toContain("# plan_reconciliation_item");
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 14 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 15 });
     expect(DUMP_TABLES).toHaveLength(45);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");

--- a/packages/kernel/src/planning/conversation-repository.ts
+++ b/packages/kernel/src/planning/conversation-repository.ts
@@ -1,13 +1,17 @@
 import type { MigratorStore } from "../store/migrator.js";
 import type { Row, SqlStore } from "../store/ports.js";
+import { parseRaceCourseSnapshot } from "./race-course.js";
 
 export type PlanConversationStatus = "open" | "ended";
 export type PlanDraftRevisionStatus = "forming" | "ready" | "failed" | "discarded" | "approved";
+export type PlanRaceCourseChoiceStatus = "undecided" | "omitted" | "attached";
 
 export interface PlanConversationRecord {
   readonly id: string;
   readonly planId: string | null;
   readonly replacesPlanId: string | null;
+  readonly courseChoiceStatus: PlanRaceCourseChoiceStatus;
+  readonly raceCourseJson: string | null;
   readonly status: PlanConversationStatus;
   readonly endedAtMs: number | null;
   readonly createdAtMs: number;
@@ -38,6 +42,7 @@ export interface PlanDraftRevisionRecord {
   readonly parentRevisionId: string | null;
   readonly status: PlanDraftRevisionStatus;
   readonly snapshotJson: string;
+  readonly raceCourseJson: string | null;
   readonly createdAtMs: number;
   readonly updatedAtMs: number;
   readonly deviceId: string;
@@ -72,6 +77,7 @@ export type PlanConversationValidationErrorCode =
   | "invalid-turn"
   | "invalid-draft-revision"
   | "invalid-source-request"
+  | "invalid-race-course"
   | "missing-conversation"
   | "missing-source-request"
   | "conversation-ended"
@@ -126,11 +132,16 @@ function validJson(value: unknown): value is string {
   }
 }
 
-function validHlc(record: { readonly hlcPhysicalMs: number; readonly hlcCounter: number }): boolean {
-  return Number.isSafeInteger(record.hlcPhysicalMs)
-    && record.hlcPhysicalMs >= 0
-    && Number.isSafeInteger(record.hlcCounter)
-    && record.hlcCounter >= 0;
+function validHlc(record: {
+  readonly hlcPhysicalMs: number;
+  readonly hlcCounter: number;
+}): boolean {
+  return (
+    Number.isSafeInteger(record.hlcPhysicalMs) &&
+    record.hlcPhysicalMs >= 0 &&
+    Number.isSafeInteger(record.hlcCounter) &&
+    record.hlcCounter >= 0
+  );
 }
 
 function validateConversation(record: PlanConversationRecord): void {
@@ -145,24 +156,31 @@ function validateConversation(record: PlanConversationRecord): void {
   if (record.planId !== null && record.planId === record.replacesPlanId) {
     throw new PlanConversationValidationError("same-plan");
   }
+  if (
+    (record.courseChoiceStatus === "attached") !== (record.raceCourseJson !== null) ||
+    !["undecided", "omitted", "attached"].includes(record.courseChoiceStatus) ||
+    !validRaceCourseJson(record.raceCourseJson)
+  ) {
+    throw new PlanConversationValidationError("invalid-race-course");
+  }
   if (!CONVERSATION_STATUS.has(record.status)) {
     throw new PlanConversationValidationError("invalid-status");
   }
   if (
-    (record.status === "open" && endedAtMs !== null)
-    || (record.status === "ended"
-      && (!Number.isSafeInteger(endedAtMs)
-        || endedAtMs === null
-        || endedAtMs < record.createdAtMs
-        || endedAtMs > record.updatedAtMs))
+    (record.status === "open" && endedAtMs !== null) ||
+    (record.status === "ended" &&
+      (!Number.isSafeInteger(endedAtMs) ||
+        endedAtMs === null ||
+        endedAtMs < record.createdAtMs ||
+        endedAtMs > record.updatedAtMs))
   ) {
     throw new PlanConversationValidationError("invalid-ended-at");
   }
   if (
-    !Number.isSafeInteger(record.createdAtMs)
-    || record.createdAtMs < 0
-    || !Number.isSafeInteger(record.updatedAtMs)
-    || record.updatedAtMs < record.createdAtMs
+    !Number.isSafeInteger(record.createdAtMs) ||
+    record.createdAtMs < 0 ||
+    !Number.isSafeInteger(record.updatedAtMs) ||
+    record.updatedAtMs < record.createdAtMs
   ) {
     throw new PlanConversationValidationError("invalid-timestamp");
   }
@@ -174,19 +192,19 @@ function validateConversation(record: PlanConversationRecord): void {
 
 function validateTurn(record: PlanConversationTurnRecord): void {
   if (
-    !ULID.test(record.id)
-    || !ULID.test(record.conversationId)
-    || !Number.isSafeInteger(record.sequence)
-    || record.sequence <= 0
-    || typeof record.athleteText !== "string"
-    || record.athleteText.length === 0
-    || typeof record.coachText !== "string"
-    || record.coachText.length === 0
-    || !validJson(record.lineageJson)
-    || !Number.isSafeInteger(record.completedAtMs)
-    || record.completedAtMs < 0
-    || !DEVICE_ID.test(record.deviceId)
-    || !validHlc(record)
+    !ULID.test(record.id) ||
+    !ULID.test(record.conversationId) ||
+    !Number.isSafeInteger(record.sequence) ||
+    record.sequence <= 0 ||
+    typeof record.athleteText !== "string" ||
+    record.athleteText.length === 0 ||
+    typeof record.coachText !== "string" ||
+    record.coachText.length === 0 ||
+    !validJson(record.lineageJson) ||
+    !Number.isSafeInteger(record.completedAtMs) ||
+    record.completedAtMs < 0 ||
+    !DEVICE_ID.test(record.deviceId) ||
+    !validHlc(record)
   ) {
     throw new PlanConversationValidationError("invalid-turn");
   }
@@ -194,43 +212,52 @@ function validateTurn(record: PlanConversationTurnRecord): void {
 
 function validateDraftRevision(record: PlanDraftRevisionRecord): void {
   if (
-    !ULID.test(record.id)
-    || !ULID.test(record.conversationId)
-    || !ULID.test(record.planId)
-    || !Number.isSafeInteger(record.revision)
-    || record.revision <= 0
-    || (record.parentRevisionId !== null && !ULID.test(record.parentRevisionId))
-    || (record.revision === 1) !== (record.parentRevisionId === null)
-    || !DRAFT_STATUS.has(record.status)
-    || !validJson(record.snapshotJson)
-    || !Number.isSafeInteger(record.createdAtMs)
-    || record.createdAtMs < 0
-    || !Number.isSafeInteger(record.updatedAtMs)
-    || record.updatedAtMs < record.createdAtMs
-    || !Number.isSafeInteger(record.updatedAtMs)
-    || record.updatedAtMs < record.createdAtMs
-    || !DEVICE_ID.test(record.deviceId)
-    || !validHlc(record)
+    !ULID.test(record.id) ||
+    !ULID.test(record.conversationId) ||
+    !ULID.test(record.planId) ||
+    !Number.isSafeInteger(record.revision) ||
+    record.revision <= 0 ||
+    (record.parentRevisionId !== null && !ULID.test(record.parentRevisionId)) ||
+    (record.revision === 1) !== (record.parentRevisionId === null) ||
+    !DRAFT_STATUS.has(record.status) ||
+    !validJson(record.snapshotJson) ||
+    !validRaceCourseJson(record.raceCourseJson) ||
+    !Number.isSafeInteger(record.createdAtMs) ||
+    record.createdAtMs < 0 ||
+    !Number.isSafeInteger(record.updatedAtMs) ||
+    record.updatedAtMs < record.createdAtMs ||
+    !DEVICE_ID.test(record.deviceId) ||
+    !validHlc(record)
   ) {
     throw new PlanConversationValidationError("invalid-draft-revision");
   }
 }
 
+function validRaceCourseJson(value: string | null): boolean {
+  if (value === null) return true;
+  try {
+    parseRaceCourseSnapshot(JSON.parse(value) as unknown);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function validateSourceRequest(record: PlanSourceRequestRecord): void {
   if (
-    !ULID.test(record.id)
-    || !ULID.test(record.conversationId)
-    || typeof record.sourceChatId !== "string"
-    || record.sourceChatId.length === 0
-    || (record.sourceBoundaryRef !== null
-      && (typeof record.sourceBoundaryRef !== "string" || record.sourceBoundaryRef.length === 0))
-    || typeof record.sourceMessageId !== "string"
-    || record.sourceMessageId.length === 0
-    || !validJson(record.requestJson)
-    || !Number.isSafeInteger(record.createdAtMs)
-    || record.createdAtMs < 0
-    || !DEVICE_ID.test(record.deviceId)
-    || !validHlc(record)
+    !ULID.test(record.id) ||
+    !ULID.test(record.conversationId) ||
+    typeof record.sourceChatId !== "string" ||
+    record.sourceChatId.length === 0 ||
+    (record.sourceBoundaryRef !== null &&
+      (typeof record.sourceBoundaryRef !== "string" || record.sourceBoundaryRef.length === 0)) ||
+    typeof record.sourceMessageId !== "string" ||
+    record.sourceMessageId.length === 0 ||
+    !validJson(record.requestJson) ||
+    !Number.isSafeInteger(record.createdAtMs) ||
+    record.createdAtMs < 0 ||
+    !DEVICE_ID.test(record.deviceId) ||
+    !validHlc(record)
   ) {
     throw new PlanConversationValidationError("invalid-source-request");
   }
@@ -271,6 +298,8 @@ function conversationFromRow(row: Row): PlanConversationRecord {
     id: text(row, "id"),
     planId: nullableText(row, "plan_id"),
     replacesPlanId: nullableText(row, "replaces_plan_id"),
+    courseChoiceStatus: text(row, "course_choice_status") as PlanRaceCourseChoiceStatus,
+    raceCourseJson: nullableText(row, "race_course_json"),
     status: text(row, "status") as PlanConversationStatus,
     endedAtMs: nullableInteger(row, "ended_at_ms"),
     createdAtMs: integer(row, "created_at_ms"),
@@ -309,6 +338,7 @@ function draftRevisionFromRow(row: Row): PlanDraftRevisionRecord {
     parentRevisionId: nullableText(row, "parent_revision_id"),
     status: text(row, "status") as PlanDraftRevisionStatus,
     snapshotJson: text(row, "snapshot_json"),
+    raceCourseJson: nullableText(row, "race_course_json"),
     createdAtMs: integer(row, "created_at_ms"),
     updatedAtMs: integer(row, "updated_at_ms"),
     deviceId: text(row, "device_id"),
@@ -359,7 +389,8 @@ export function createPlanConversationRepository(store: PlanningStore): PlanConv
 
   const requireOpenConversation = async (id: string): Promise<PlanConversationRecord> => {
     const conversation = await readConversation(id);
-    if (conversation === undefined) throw new PlanConversationValidationError("missing-conversation");
+    if (conversation === undefined)
+      throw new PlanConversationValidationError("missing-conversation");
     if (conversation.status === "ended") {
       throw new PlanConversationValidationError("conversation-ended");
     }
@@ -379,37 +410,44 @@ export function createPlanConversationRepository(store: PlanningStore): PlanConv
             return;
           }
           if (
-            existing.createdAtMs !== record.createdAtMs
-            || existing.updatedAtMs > record.updatedAtMs
-            || existing.planId !== null && existing.planId !== record.planId
-            || existing.replacesPlanId !== record.replacesPlanId
+            existing.createdAtMs !== record.createdAtMs ||
+            existing.updatedAtMs > record.updatedAtMs ||
+            (existing.planId !== null && existing.planId !== record.planId) ||
+            existing.replacesPlanId !== record.replacesPlanId
           ) {
             throw new PlanConversationValidationError("conversation-conflict");
           }
         }
-        await store.run(`INSERT INTO plan_conversation (
-  id, plan_id, replaces_plan_id, status, ended_at_ms, created_at_ms, updated_at_ms,
-  device_id, hlc_physical_ms, hlc_counter
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        await store.run(
+          `INSERT INTO plan_conversation (
+  id, plan_id, replaces_plan_id, course_choice_status, race_course_json, status,
+  ended_at_ms, created_at_ms, updated_at_ms, device_id, hlc_physical_ms, hlc_counter
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO UPDATE SET
   plan_id = excluded.plan_id,
+  course_choice_status = excluded.course_choice_status,
+  race_course_json = excluded.race_course_json,
   status = excluded.status,
   ended_at_ms = excluded.ended_at_ms,
   updated_at_ms = excluded.updated_at_ms,
   device_id = excluded.device_id,
   hlc_physical_ms = excluded.hlc_physical_ms,
-  hlc_counter = excluded.hlc_counter`, [
-          record.id,
-          record.planId,
-          record.replacesPlanId,
-          record.status,
-          record.endedAtMs,
-          record.createdAtMs,
+  hlc_counter = excluded.hlc_counter`,
+          [
+            record.id,
+            record.planId,
+            record.replacesPlanId,
+            record.courseChoiceStatus,
+            record.raceCourseJson,
+            record.status,
+            record.endedAtMs,
+            record.createdAtMs,
           record.updatedAtMs,
-          record.deviceId,
-          record.hlcPhysicalMs,
-          record.hlcCounter,
-        ]);
+            record.deviceId,
+            record.hlcPhysicalMs,
+            record.hlcCounter,
+          ],
+        );
       });
     },
 
@@ -439,7 +477,9 @@ ON CONFLICT (id) DO UPDATE SET
       validateTurn(record);
       return store.transaction(async () => {
         await requireOpenConversation(record.conversationId);
-        const existingRow = await store.get("SELECT * FROM plan_conversation_turn WHERE id = ?", [record.id]);
+        const existingRow = await store.get("SELECT * FROM plan_conversation_turn WHERE id = ?", [
+          record.id,
+        ]);
         if (existingRow !== undefined) {
           const existing = turnFromRow(existingRow);
           if (!sameRecord(existing, record)) {
@@ -455,21 +495,24 @@ ON CONFLICT (id) DO UPDATE SET
         if (record.sequence !== expected) {
           throw new PlanConversationValidationError("turn-conflict");
         }
-        await store.run(`INSERT INTO plan_conversation_turn (
+        await store.run(
+          `INSERT INTO plan_conversation_turn (
   id, conversation_id, sequence, athlete_text, coach_text, lineage_json,
   completed_at_ms, device_id, hlc_physical_ms, hlc_counter
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, [
-          record.id,
-          record.conversationId,
-          record.sequence,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            record.id,
+            record.conversationId,
+            record.sequence,
           record.athleteText,
           record.coachText,
           record.lineageJson,
           record.completedAtMs,
-          record.deviceId,
-          record.hlcPhysicalMs,
-          record.hlcCounter,
-        ]);
+            record.deviceId,
+            record.hlcPhysicalMs,
+            record.hlcCounter,
+          ],
+        );
         return record;
       });
     },
@@ -496,19 +539,20 @@ ON CONFLICT (id) DO UPDATE SET
         const existing = await readDraftRevision(record.id);
         if (existing !== undefined) {
           if (
-            existing.conversationId !== record.conversationId
-            || existing.planId !== record.planId
-            || existing.revision !== record.revision
-            || existing.parentRevisionId !== record.parentRevisionId
-            || existing.createdAtMs !== record.createdAtMs
-            || existing.updatedAtMs > record.updatedAtMs
+            existing.conversationId !== record.conversationId ||
+            existing.planId !== record.planId ||
+            existing.revision !== record.revision ||
+            existing.parentRevisionId !== record.parentRevisionId ||
+            existing.createdAtMs !== record.createdAtMs ||
+            existing.updatedAtMs > record.updatedAtMs
           ) {
             throw new PlanConversationValidationError("draft-lineage-conflict");
           }
         } else if (record.revision === 1) {
-          const first = await store.get("SELECT id FROM plan_draft_revision WHERE plan_id = ? LIMIT 1", [
-            record.planId,
-          ]);
+          const first = await store.get(
+            "SELECT id FROM plan_draft_revision WHERE plan_id = ? LIMIT 1",
+            [record.planId],
+          );
           if (first !== undefined) {
             throw new PlanConversationValidationError("draft-lineage-conflict");
           }
@@ -519,41 +563,47 @@ ON CONFLICT (id) DO UPDATE SET
             [record.planId],
           );
           if (
-            parent === undefined
-            || parent.conversationId !== record.conversationId
-            || parent.planId !== record.planId
-            || parent.revision + 1 !== record.revision
-            || latest === undefined
-            || text(latest, "id") !== parent.id
+            parent === undefined ||
+            parent.conversationId !== record.conversationId ||
+            parent.planId !== record.planId ||
+            parent.revision + 1 !== record.revision ||
+            latest === undefined ||
+            text(latest, "id") !== parent.id
           ) {
             throw new PlanConversationValidationError("draft-lineage-conflict");
           }
         }
-        await store.run(`INSERT INTO plan_draft_revision (
+        await store.run(
+          `INSERT INTO plan_draft_revision (
   id, conversation_id, plan_id, revision, parent_revision_id, parent_revision, status,
-  snapshot_json, created_at_ms, updated_at_ms, device_id, hlc_physical_ms, hlc_counter
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  snapshot_json, race_course_json, created_at_ms, updated_at_ms, device_id, hlc_physical_ms,
+  hlc_counter
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO UPDATE SET
   status = excluded.status,
   snapshot_json = excluded.snapshot_json,
+  race_course_json = excluded.race_course_json,
   updated_at_ms = excluded.updated_at_ms,
   device_id = excluded.device_id,
   hlc_physical_ms = excluded.hlc_physical_ms,
-  hlc_counter = excluded.hlc_counter`, [
-          record.id,
-          record.conversationId,
-          record.planId,
+  hlc_counter = excluded.hlc_counter`,
+          [
+            record.id,
+            record.conversationId,
+            record.planId,
           record.revision,
           record.parentRevisionId,
-          record.parentRevisionId === null ? null : record.revision - 1,
-          record.status,
-          record.snapshotJson,
-          record.createdAtMs,
-          record.updatedAtMs,
-          record.deviceId,
-          record.hlcPhysicalMs,
-          record.hlcCounter,
-        ]);
+            record.parentRevisionId === null ? null : record.revision - 1,
+            record.status,
+            record.snapshotJson,
+            record.raceCourseJson,
+            record.createdAtMs,
+            record.updatedAtMs,
+            record.deviceId,
+            record.hlcPhysicalMs,
+            record.hlcCounter,
+          ],
+        );
       });
     },
 
@@ -586,22 +636,25 @@ ON CONFLICT (id) DO UPDATE SET
           }
           return existing;
         }
-        await store.run(`INSERT INTO plan_source_request (
+        await store.run(
+          `INSERT INTO plan_source_request (
   id, conversation_id, source_chat_id, source_boundary_ref, source_message_id,
   request_json, created_at_ms, updated_at_ms, device_id, hlc_physical_ms, hlc_counter
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, [
-          record.id,
-          record.conversationId,
-          record.sourceChatId,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            record.id,
+            record.conversationId,
+            record.sourceChatId,
           record.sourceBoundaryRef,
           record.sourceMessageId,
           record.requestJson,
           record.createdAtMs,
           record.updatedAtMs,
-          record.deviceId,
-          record.hlcPhysicalMs,
-          record.hlcCounter,
-        ]);
+            record.deviceId,
+            record.hlcPhysicalMs,
+            record.hlcCounter,
+          ],
+        );
         return record;
       });
     },
@@ -617,12 +670,12 @@ ON CONFLICT (id) DO UPDATE SET
           throw new PlanConversationValidationError("missing-source-request");
         }
         if (
-          existing.conversationId !== record.conversationId
-          || existing.sourceChatId !== record.sourceChatId
-          || existing.sourceMessageId !== record.sourceMessageId
-          || existing.requestJson !== record.requestJson
-          || existing.createdAtMs !== record.createdAtMs
-          || existing.updatedAtMs > record.updatedAtMs
+          existing.conversationId !== record.conversationId ||
+          existing.sourceChatId !== record.sourceChatId ||
+          existing.sourceMessageId !== record.sourceMessageId ||
+          existing.requestJson !== record.requestJson ||
+          existing.createdAtMs !== record.createdAtMs ||
+          existing.updatedAtMs > record.updatedAtMs
         ) {
           throw new PlanConversationValidationError("source-request-conflict");
         }
@@ -632,20 +685,23 @@ ON CONFLICT (id) DO UPDATE SET
           }
           return existing;
         }
-        await store.run(`UPDATE plan_source_request SET
+        await store.run(
+          `UPDATE plan_source_request SET
   source_boundary_ref = ?,
   updated_at_ms = ?,
   device_id = ?,
   hlc_physical_ms = ?,
   hlc_counter = ?
-WHERE id = ?`, [
-          record.sourceBoundaryRef,
-          record.updatedAtMs,
-          record.deviceId,
-          record.hlcPhysicalMs,
-          record.hlcCounter,
-          record.id,
-        ]);
+WHERE id = ?`,
+          [
+            record.sourceBoundaryRef,
+            record.updatedAtMs,
+            record.deviceId,
+            record.hlcPhysicalMs,
+            record.hlcCounter,
+            record.id,
+          ],
+        );
         return record;
       });
     },

--- a/packages/kernel/src/planning/race-course.ts
+++ b/packages/kernel/src/planning/race-course.ts
@@ -26,30 +26,36 @@ export class RaceCourseSnapshotError extends Error {
 
 function frozenRoute(route: CourseRoute): CourseRoute {
   if (
-    (route.format !== "gpx" && route.format !== "fit")
-    || route.segments.length === 0
-    || !route.segments.some((segment) => segment.points.length >= 2)
+    (route.format !== "gpx" && route.format !== "fit") ||
+    route.segments.length === 0 ||
+    !route.segments.some((segment) => segment.points.length >= 2)
   ) {
     throw new RaceCourseSnapshotError("invalid-route");
   }
   return Object.freeze({
     format: route.format,
-    segments: Object.freeze(route.segments.map((segment) => Object.freeze({
-      points: Object.freeze(segment.points.map((point) => {
-        if (
-          !Number.isFinite(point.latitude)
-          || point.latitude < -90
-          || point.latitude > 90
-          || !Number.isFinite(point.longitude)
-          || point.longitude < -180
-          || point.longitude > 180
-          || (point.elevationM !== null && !Number.isFinite(point.elevationM))
-        ) {
-          throw new RaceCourseSnapshotError("invalid-route");
-        }
-        return Object.freeze({ ...point });
-      })),
-    }))),
+    segments: Object.freeze(
+      route.segments.map((segment) =>
+        Object.freeze({
+          points: Object.freeze(
+            segment.points.map((point) => {
+              if (
+                !Number.isFinite(point.latitude) ||
+                point.latitude < -90 ||
+                point.latitude > 90 ||
+                !Number.isFinite(point.longitude) ||
+                point.longitude < -180 ||
+                point.longitude > 180 ||
+                (point.elevationM !== null && !Number.isFinite(point.elevationM))
+              ) {
+                throw new RaceCourseSnapshotError("invalid-route");
+              }
+              return Object.freeze({ ...point });
+            }),
+          ),
+        }),
+      ),
+    ),
   });
 }
 
@@ -63,14 +69,14 @@ export function createRaceCourseSnapshot(input: {
   const actualPointCount = route.segments.reduce((sum, segment) => sum + segment.points.length, 0);
   const preview = input.preview;
   if (
-    !Number.isSafeInteger(preview.pointCount)
-    || preview.pointCount !== actualPointCount
-    || !Number.isFinite(preview.distanceM)
-    || preview.distanceM <= 0
-    || (preview.elevationGainM !== null
-      && (!Number.isFinite(preview.elevationGainM) || preview.elevationGainM < 0))
-    || (preview.elevationStatus !== "available" && preview.elevationStatus !== "unavailable")
-    || (preview.elevationStatus === "available") !== (preview.elevationGainM !== null)
+    !Number.isSafeInteger(preview.pointCount) ||
+    preview.pointCount !== actualPointCount ||
+    !Number.isFinite(preview.distanceM) ||
+    preview.distanceM <= 0 ||
+    (preview.elevationGainM !== null &&
+      (!Number.isFinite(preview.elevationGainM) || preview.elevationGainM < 0)) ||
+    (preview.elevationStatus !== "available" && preview.elevationStatus !== "unavailable") ||
+    (preview.elevationStatus === "available") !== (preview.elevationGainM !== null)
   ) {
     throw new RaceCourseSnapshotError("invalid-preview");
   }
@@ -79,5 +85,39 @@ export function createRaceCourseSnapshot(input: {
     format: route.format,
     route,
     preview: Object.freeze({ ...preview }),
+  });
+}
+
+export function parseRaceCourseSnapshot(value: unknown): RaceCourseSnapshot {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new RaceCourseSnapshotError("invalid-route");
+  }
+  const input = value as Record<string, unknown>;
+  if (
+    typeof input.fileName !== "string" ||
+    input.route === null ||
+    typeof input.route !== "object" ||
+    Array.isArray(input.route) ||
+    input.preview === null ||
+    typeof input.preview !== "object" ||
+    Array.isArray(input.preview)
+  ) {
+    throw new RaceCourseSnapshotError("invalid-route");
+  }
+  const route = input.route as Record<string, unknown>;
+  const preview = input.preview as Record<string, unknown>;
+  if (!Array.isArray(route.segments)) throw new RaceCourseSnapshotError("invalid-route");
+  return createRaceCourseSnapshot({
+    fileName: input.fileName,
+    route: {
+      format: route.format as CourseRouteFormat,
+      segments: route.segments as CourseRoute["segments"],
+    },
+    preview: {
+      pointCount: preview.pointCount as number,
+      distanceM: preview.distanceM as number,
+      elevationGainM: preview.elevationGainM as number | null,
+      elevationStatus: preview.elevationStatus as RaceCoursePreview["elevationStatus"],
+    },
   });
 }

--- a/packages/kernel/src/store/migrations/015_plan_race_course.sql
+++ b/packages/kernel/src/store/migrations/015_plan_race_course.sql
@@ -1,0 +1,11 @@
+ALTER TABLE plan_conversation
+  ADD COLUMN course_choice_status TEXT NOT NULL DEFAULT 'undecided'
+  CHECK (course_choice_status IN ('undecided','omitted','attached'));
+
+ALTER TABLE plan_conversation
+  ADD COLUMN race_course_json TEXT
+  CHECK (race_course_json IS NULL OR json_valid(race_course_json));
+
+ALTER TABLE plan_draft_revision
+  ADD COLUMN race_course_json TEXT
+  CHECK (race_course_json IS NULL OR json_valid(race_course_json));

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -12,6 +12,7 @@ import activityAnalysisProjection011 from "./011_activity_analysis_projection.sq
 import planning012 from "./012_planning.sql";
 import planConversations013 from "./013_plan_conversations.sql";
 import planReconciliation014 from "./014_plan_reconciliation.sql";
+import planRaceCourse015 from "./015_plan_race_course.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -41,4 +42,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 12, name: "012_planning", sql: planning012 },
   { version: 13, name: "013_plan_conversations", sql: planConversations013 },
   { version: 14, name: "014_plan_reconciliation", sql: planReconciliation014 },
+  { version: 15, name: "015_plan_race_course", sql: planRaceCourse015 },
 ];

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -182,6 +182,7 @@ describe("001_init migration", () => {
       { version: 12, name: "012_planning" },
       { version: 13, name: "013_plan_conversations" },
       { version: 14, name: "014_plan_reconciliation" },
+      { version: 15, name: "015_plan_race_course" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -801,8 +802,9 @@ describe("001_init migration", () => {
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_failure");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("store_owner");
-    expect(DUMP_TABLES.map(({ table }) => String(table)))
-      .not.toContain("analytics_curve_refresh_failure");
+    expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain(
+      "analytics_curve_refresh_failure",
+    );
     for (const table of [
       "analytics_curve_current",
       "analytics_curve_evidence",
@@ -865,14 +867,18 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     );
     const columns = db.prepare("PRAGMA table_info(store_owner)").all();
     expect(columns).toContainEqual(expect.objectContaining({ name: "singleton", pk: 1 }));
-    expect(columns).toContainEqual(expect.objectContaining({ name: "account_fingerprint", notnull: 1 }));
+    expect(columns).toContainEqual(
+      expect.objectContaining({ name: "account_fingerprint", notnull: 1 }),
+    );
     expect(() =>
       db!
         .prepare("INSERT INTO store_owner(singleton,account_fingerprint) VALUES(1,?)")
         .run("a".repeat(64)),
     ).not.toThrow();
     expect(() => db!.prepare("INSERT INTO store_owner VALUES(2,?)").run("b".repeat(64))).toThrow();
-    expect(() => db!.prepare("UPDATE store_owner SET account_fingerprint=?").run("b".repeat(64))).toThrow();
+    expect(() =>
+      db!.prepare("UPDATE store_owner SET account_fingerprint=?").run("b".repeat(64)),
+    ).toThrow();
     expect(() => db!.prepare("DELETE FROM store_owner").run()).toThrow();
   });
 
@@ -881,9 +887,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     expect(createHash("sha256").update(MIGRATIONS[8]!.sql).digest("hex")).toBe(
       "4fe2e7648bbb09ad62c60a86e26ac4a9e09f4c0e24882428e12ad8722f3d420c",
     );
-    expect(
-      db.prepare("PRAGMA index_info(idx_source_record_session_source)").all(),
-    ).toEqual([
+    expect(db.prepare("PRAGMA index_info(idx_source_record_session_source)").all()).toEqual([
       expect.objectContaining({ seqno: 0, name: "session_key" }),
       expect.objectContaining({ seqno: 1, name: "source" }),
       expect.objectContaining({ seqno: 2, name: "id" }),
@@ -919,23 +923,24 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     expect(createHash("sha256").update(MIGRATIONS[10]!.sql).digest("hex")).toBe(
       "b9c22b99343093655536059e68c1846b5deb8b77355a08e38013d807906e300e",
     );
-    const table = db.prepare("PRAGMA table_list").all().find(
-      (row) => (row as { name?: unknown }).name === "activity_analysis_projection",
-    ) as { strict: number; wr: number } | undefined;
+    const table = db
+      .prepare("PRAGMA table_list")
+      .all()
+      .find((row) => (row as { name?: unknown }).name === "activity_analysis_projection") as
+      | { strict: number; wr: number }
+      | undefined;
     expect(table).toMatchObject({ strict: 1, wr: 1 });
-    expect(db.prepare("PRAGMA foreign_key_list(activity_analysis_projection)").all())
-      .toContainEqual(expect.objectContaining({ table: "session", on_delete: "CASCADE" }));
-    expect(db.prepare("PRAGMA index_info(idx_activity_analysis_projection_lru)").all())
-      .toEqual([
-        expect.objectContaining({ seqno: 0, name: "accessed_epoch_s" }),
-        expect.objectContaining({ seqno: 1, name: "canonical_activity_id" }),
-        expect.objectContaining({ seqno: 2, name: "source_revision" }),
-        expect.objectContaining({ seqno: 3, name: "contract_version" }),
-        expect.objectContaining({ seqno: 4, name: "section" }),
-      ]);
-    expect(DUMP_TABLES.map(({ table: name }) => name)).toContain(
-      "activity_analysis_projection",
-    );
+    expect(
+      db.prepare("PRAGMA foreign_key_list(activity_analysis_projection)").all(),
+    ).toContainEqual(expect.objectContaining({ table: "session", on_delete: "CASCADE" }));
+    expect(db.prepare("PRAGMA index_info(idx_activity_analysis_projection_lru)").all()).toEqual([
+      expect.objectContaining({ seqno: 0, name: "accessed_epoch_s" }),
+      expect.objectContaining({ seqno: 1, name: "canonical_activity_id" }),
+      expect.objectContaining({ seqno: 2, name: "source_revision" }),
+      expect.objectContaining({ seqno: 3, name: "contract_version" }),
+      expect.objectContaining({ seqno: 4, name: "section" }),
+    ]);
+    expect(DUMP_TABLES.map(({ table: name }) => name)).toContain("activity_analysis_projection");
     expect(DERIVED_TABLES).not.toContain("activity_analysis_projection");
   });
 
@@ -947,8 +952,9 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     }>;
     expect(tables.find((row) => row.name === "plan")?.strict).toBe(1);
     expect(tables.find((row) => row.name === "plan_workout")?.strict).toBe(1);
-    expect(db.prepare("PRAGMA foreign_key_list(plan_workout)").all())
-      .toContainEqual(expect.objectContaining({ table: "plan", on_delete: "CASCADE" }));
+    expect(db.prepare("PRAGMA foreign_key_list(plan_workout)").all()).toContainEqual(
+      expect.objectContaining({ table: "plan", on_delete: "CASCADE" }),
+    );
     expect(db.prepare("PRAGMA index_info(idx_plan_workout_plan_date)").all()).toEqual([
       expect.objectContaining({ seqno: 0, name: "plan_id" }),
       expect.objectContaining({ seqno: 1, name: "date_key" }),
@@ -972,8 +978,9 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     ]) {
       expect(tables.find((row) => row.name === name)?.strict).toBe(1);
     }
-    expect(db.prepare("PRAGMA foreign_key_list(plan_conversation_turn)").all())
-      .toContainEqual(expect.objectContaining({ table: "plan_conversation", on_delete: "CASCADE" }));
+    expect(db.prepare("PRAGMA foreign_key_list(plan_conversation_turn)").all()).toContainEqual(
+      expect.objectContaining({ table: "plan_conversation", on_delete: "CASCADE" }),
+    );
     expect(db.prepare("PRAGMA foreign_key_list(plan_draft_revision)").all()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ table: "plan_conversation", on_delete: "CASCADE" }),
@@ -981,14 +988,17 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
         expect.objectContaining({ table: "plan_draft_revision", on_delete: "CASCADE" }),
       ]),
     );
-    expect(db.prepare("PRAGMA foreign_key_list(plan_source_request)").all())
-      .toContainEqual(expect.objectContaining({ table: "plan_conversation", on_delete: "CASCADE" }));
-    expect(PURE_AUTHORED_TABLES).toEqual(expect.arrayContaining([
-      "plan_conversation",
-      "plan_conversation_turn",
-      "plan_draft_revision",
-      "plan_source_request",
-    ]));
+    expect(db.prepare("PRAGMA foreign_key_list(plan_source_request)").all()).toContainEqual(
+      expect.objectContaining({ table: "plan_conversation", on_delete: "CASCADE" }),
+    );
+    expect(PURE_AUTHORED_TABLES).toEqual(
+      expect.arrayContaining([
+        "plan_conversation",
+        "plan_conversation_turn",
+        "plan_draft_revision",
+        "plan_source_request",
+      ]),
+    );
   });
 
   it("omits the unreleased prior bone-stress column from the baseline schema", () => {


### PR DESCRIPTION
## Summary
- add durable optional GPX/FIT Race Course choice and projection state to Plan Coach and Draft
- parse GPX/FIT through a dedicated host adapter, including unreadable-file and missing-elevation recovery
- support Draft-only add, replace, remove, recalculation, and failure recovery without hiding the previous Draft
- add a trusted native file picker plus the prototype-derived Race Course UI

## Verification
- focused tests: 228 assertions passed
- `pnpm check` passed
- isolated autoreview passed with no actionable findings

## Limits
- Race Course changes are available only during intake or while the Plan is still a Draft; active Plans reject them
- continuing without elevation is explicit, and continuing without a course remains supported
