### PR TITLE
fix(desktop): enforce Windows release signing and provenance checks

### DIFF
--- a/.changeset/windows-release-lane-hardening.md
+++ b/.changeset/windows-release-lane-hardening.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Windows release lane: builder config accepted by electron-builder 26.15.3, workflow refuses to mark assets while Authenticode is pending, upload script binds the release tag commit, refuses drafts and prereleases, preflights the upload record, and the verifier binds the blockmap to the installer bytes.

--- a/.github/workflows/desktop-windows-release.yml
+++ b/.github/workflows/desktop-windows-release.yml
@@ -11,6 +11,18 @@ on:
         description: Verify only; never edit the release
         type: boolean
         default: true
+      authenticode:
+        description: Authenticode verification mode
+        type: choice
+        options:
+          - pending-w19
+          - verify
+        default: pending-w19
+      publisher_dn:
+        description: Exact Authenticode publisher distinguished name
+        required: false
+        type: string
+        default: ""
 
 permissions: { contents: read }
 
@@ -69,6 +81,11 @@ jobs:
           fi
           RELEASE_ID=$(printf '%s' "$RELEASE" | jq -er '.id')
           echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+      - name: Refuse to mark assets while Authenticode is pending
+        if: ${{ inputs.dry_run == false && inputs.authenticode != 'verify' }}
+        run: |
+          echo '::error::Authenticode verification is not enabled; refusing to mark assets'
+          exit 1
       - name: Download Windows assets
         env:
           GH_TOKEN: ${{ github.token }}
@@ -87,17 +104,24 @@ jobs:
         id: verify
         env:
           VERSION: ${{ inputs.version }}
+          AUTHENTICODE: ${{ inputs.authenticode }}
+          PUBLISHER_DN: ${{ inputs.publisher_dn }}
         run: |
           set -euo pipefail
-          node apps/desktop/scripts/verify-windows-release.mjs "$RUNNER_TEMP/windows-release" --version "$VERSION" --authenticode pending-w19 | tee "$RUNNER_TEMP/verify.out"
+          if [ "$AUTHENTICODE" = 'verify' ]; then
+            if [ -z "$PUBLISHER_DN" ] || [ "$PUBLISHER_DN" = 'CN=ENDURAGENT PUBLISHER DN PLACEHOLDER, O=PLACEHOLDER' ]; then
+              echo '::error::publisher_dn is required'
+              exit 1
+            fi
+            node apps/desktop/scripts/verify-windows-release.mjs "$RUNNER_TEMP/windows-release" --version "$VERSION" --authenticode verify --publisher-dn "$PUBLISHER_DN" | tee "$RUNNER_TEMP/verify.out"
+          else
+            node apps/desktop/scripts/verify-windows-release.mjs "$RUNNER_TEMP/windows-release" --version "$VERSION" --authenticode pending-w19 | tee "$RUNNER_TEMP/verify.out"
+          fi
           INSTALLER_SHA256=$(awk '/^Windows release envelope verified [0-9a-f]{64}$/{sha=$NF} END{if (sha == "") exit 1; print sha}' "$RUNNER_TEMP/verify.out")
           echo "installer_sha256=$INSTALLER_SHA256" >> "$GITHUB_OUTPUT"
-      - name: Verify Authenticode (pending W19)
-        run: |
-          set -euo pipefail
-          echo "::notice::Authenticode verification pending W19 (apps/desktop/scripts/verify-windows-authenticode.ps1 does not exist yet); the installer signature was NOT verified"
+          echo "authenticode=$AUTHENTICODE" >> "$GITHUB_OUTPUT"
       - name: Mark Windows assets verified
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry_run == false && inputs.authenticode == 'verify' && steps.verify.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ID: ${{ steps.release.outputs.release_id }}
@@ -106,7 +130,7 @@ jobs:
           set -euo pipefail
           gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$RUNNER_TEMP/release.json"
           jq -j '.body // ""' "$RUNNER_TEMP/release.json" > "$RUNNER_TEMP/release-body.txt"
-          MARKER="Windows assets verified: $INSTALLER_SHA256 (Authenticode verification pending W19)"
+          MARKER="Windows assets verified: $INSTALLER_SHA256 (Authenticode verified)"
           if grep -Fxq "$MARKER" "$RUNNER_TEMP/release-body.txt"; then
             exit 0
           fi

--- a/apps/desktop/scripts/upload-windows-release.d.mts
+++ b/apps/desktop/scripts/upload-windows-release.d.mts
@@ -16,7 +16,9 @@ export interface WindowsReleaseUploadRecord {
   readonly tag: string;
   readonly version: string;
   readonly commit: string;
+  readonly tagCommit: string;
   readonly arch: "x64";
+  readonly status: "uploaded";
   readonly authenticode: "pending-w19" | "verified";
   readonly files: readonly {
     readonly name: string;

--- a/apps/desktop/scripts/upload-windows-release.mjs
+++ b/apps/desktop/scripts/upload-windows-release.mjs
@@ -19,13 +19,17 @@ const execFileAsync = promisify(execFile);
 const defaultRepository = "yerzhansa/enduragent";
 const safeWindowsReleaseUploadMessages = new Set([
   "release tag mismatch",
+  "release tag is unresolvable",
+  "release commit mismatch",
   "Windows release upload is incomplete",
   "Authenticode verification mode is required",
   "upload record path must be absolute",
+  "upload record already exists",
+  "upload record directory is missing",
   "release repository is invalid",
 ]);
 const safeReleaseStateMessagePattern =
-  /^(?:release does not exist|release is still a draft): enduragent-desktop@[-A-Za-z0-9@._]+$/u;
+  /^(?:release does not exist|release is still a draft|release is a prerelease): enduragent-desktop@[-A-Za-z0-9@._]+$/u;
 const safeExistingAssetMessagePattern = /^Windows release asset already exists: [-A-Za-z0-9@._]+$/u;
 
 async function executeSystemFile(executable, arguments_) {
@@ -62,11 +66,13 @@ function parseRelease(stdout, tag) {
     Array.isArray(release) ||
     typeof release.tagName !== "string" ||
     typeof release.isDraft !== "boolean" ||
+    typeof release.isPrerelease !== "boolean" ||
     !Array.isArray(release.assets)
   ) {
     throw new TypeError(`release does not exist: ${tag}`);
   }
   if (release.isDraft) throw new TypeError(`release is still a draft: ${tag}`);
+  if (release.isPrerelease) throw new TypeError(`release is a prerelease: ${tag}`);
   if (release.tagName !== tag) throw new TypeError("release tag mismatch");
   return release;
 }
@@ -95,6 +101,53 @@ function releaseAssetNames(release) {
       ? [asset.name]
       : [],
   );
+}
+
+function parseGitObject(stdout) {
+  let response;
+  try {
+    response = JSON.parse(stdout);
+  } catch {
+    throw new TypeError("release tag is unresolvable");
+  }
+  const object = response?.object;
+  if (
+    object === null ||
+    typeof object !== "object" ||
+    Array.isArray(object) ||
+    (object.type !== "commit" && object.type !== "tag") ||
+    typeof object.sha !== "string" ||
+    !/^[0-9a-f]{40}$/u.test(object.sha)
+  ) {
+    throw new TypeError("release tag is unresolvable");
+  }
+  return object;
+}
+
+async function resolveTagCommit(executeFile, repository, tag) {
+  let reference;
+  try {
+    const result = await executeFile("gh-personal", [
+      "api",
+      `repos/${repository}/git/ref/tags/${tag}`,
+    ]);
+    reference = parseGitObject(result.stdout);
+  } catch {
+    throw new TypeError("release tag is unresolvable");
+  }
+  if (reference.type === "commit") return reference.sha;
+  let peeled;
+  try {
+    const result = await executeFile("gh-personal", [
+      "api",
+      `repos/${repository}/git/tags/${reference.sha}`,
+    ]);
+    peeled = parseGitObject(result.stdout);
+  } catch {
+    throw new TypeError("release tag is unresolvable");
+  }
+  if (peeled.type !== "commit") throw new TypeError("release tag is unresolvable");
+  return peeled.sha;
 }
 
 async function releaseFileRecords(verified, dependencies) {
@@ -133,52 +186,93 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
     readFile: dependencies.readFile ?? readFile,
     writeFile: dependencies.writeFile ?? writeFile,
   };
-  const verified = await verifyAssets(input.directory, {
-    version,
-    commit,
-    authenticode: input.authenticode,
-  });
   const tag = `enduragent-desktop@${version}`;
   const expectedNames = Object.values(windowsReleaseArtifactNames(version));
-  const release = await viewRelease(executeFile, tag, repository);
-  const existingNames = new Set(releaseAssetNames(release));
-  for (const name of expectedNames) {
-    if (existingNames.has(name)) {
-      throw new TypeError(`Windows release asset already exists: ${name}`);
+  if (input.record !== undefined) {
+    try {
+      await fileDependencies.writeFile(input.record, "", { flag: "wx", mode: 0o600 });
+    } catch (error) {
+      if (error?.code === "EEXIST") throw new TypeError("upload record already exists");
+      if (error?.code === "ENOENT") throw new TypeError("upload record directory is missing");
+      throw error;
     }
   }
-  await executeFile("gh-personal", [
-    "release",
-    "upload",
-    tag,
-    "--repo",
-    repository,
-    verified.paths.installer,
-    verified.paths.blockmap,
-    verified.paths.metadata,
-  ]);
-  const uploadedRelease = await viewRelease(executeFile, tag, repository);
-  const uploadedNames = new Set(releaseAssetNames(uploadedRelease));
-  if (expectedNames.some((name) => !uploadedNames.has(name))) {
-    throw new TypeError("Windows release upload is incomplete");
-  }
-  const files = Object.freeze(await releaseFileRecords(verified, fileDependencies));
-  const record = Object.freeze({
-    schemaVersion: 1,
-    tag,
-    version,
-    commit,
-    arch: "x64",
-    authenticode: verified.authenticode,
-    files,
-  });
-  if (input.record !== undefined) {
-    await fileDependencies.writeFile(input.record, `${JSON.stringify(record, null, 2)}\n`, {
-      flag: "wx",
-      mode: 0o600,
+  let uploaded = false;
+  try {
+    const verified = await verifyAssets(input.directory, {
+      version,
+      commit,
+      authenticode: input.authenticode,
     });
+    const files = Object.freeze(await releaseFileRecords(verified, fileDependencies));
+    const release = await viewRelease(executeFile, tag, repository);
+    const tagCommit = await resolveTagCommit(executeFile, repository, tag);
+    if (tagCommit !== commit) throw new TypeError("release commit mismatch");
+    const existingNames = new Set(releaseAssetNames(release));
+    for (const name of expectedNames) {
+      if (existingNames.has(name)) {
+        throw new TypeError(`Windows release asset already exists: ${name}`);
+      }
+    }
+    await executeFile("gh-personal", [
+      "release",
+      "upload",
+      tag,
+      "--repo",
+      repository,
+      verified.paths.installer,
+      verified.paths.blockmap,
+      verified.paths.metadata,
+    ]);
+    uploaded = true;
+    const uploadedRelease = await viewRelease(executeFile, tag, repository);
+    const uploadedNames = new Set(releaseAssetNames(uploadedRelease));
+    if (expectedNames.some((name) => !uploadedNames.has(name))) {
+      throw new TypeError("Windows release upload is incomplete");
+    }
+    const record = Object.freeze({
+      schemaVersion: 1,
+      tag,
+      version,
+      commit,
+      tagCommit,
+      arch: "x64",
+      status: "uploaded",
+      authenticode: verified.authenticode,
+      files,
+    });
+    if (input.record !== undefined) {
+      await fileDependencies.writeFile(input.record, `${JSON.stringify(record, null, 2)}\n`, {
+        flag: "w",
+        mode: 0o600,
+      });
+    }
+    return record;
+  } catch (error) {
+    if (input.record !== undefined) {
+      const failureRecord = {
+        schemaVersion: 1,
+        tag,
+        version,
+        commit,
+        arch: "x64",
+        status: "failed",
+        error:
+          safeWindowsReleaseUploadMessage(error) ??
+          safeWindowsReleaseVerificationMessage(error) ??
+          "Windows release upload failed",
+        uploaded,
+      };
+      try {
+        await fileDependencies.writeFile(
+          input.record,
+          `${JSON.stringify(failureRecord, null, 2)}\n`,
+          { flag: "w", mode: 0o600 },
+        );
+      } catch {}
+    }
+    throw error;
   }
-  return record;
 }
 
 function parseArguments(arguments_) {

--- a/apps/desktop/scripts/verify-windows-release.mjs
+++ b/apps/desktop/scripts/verify-windows-release.mjs
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { lstat, readFile, readdir } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gunzipSync } from "node:zlib";
@@ -14,6 +15,10 @@ import { requireStableSemVer } from "./macos-release-plan.mjs";
 import { createWindowsAuthenticodeVerifyMode } from "./verify-windows-authenticode.mjs";
 
 export const WINDOWS_UPDATER_METADATA_MAX_BYTES = 16_384;
+const BLOCKMAP_CHECKSUM_BYTES = 18;
+const scriptRequire = createRequire(import.meta.url);
+const electronBuilderRequire = createRequire(scriptRequire.resolve("electron-builder"));
+const { blake2b } = electronBuilderRequire("@noble/hashes/blake2.js");
 
 class WindowsReleaseVerificationError extends Error {
   constructor(message) {
@@ -38,6 +43,14 @@ function hasExactKeys(value, keys) {
   const actual = Object.keys(value).sort();
   const expected = [...keys].sort();
   return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function validBase64(value) {
+  if (typeof value !== "string" || value.length === 0 || value.length % 4 !== 0) return false;
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(value)) {
+    return false;
+  }
+  return Buffer.from(value, "base64").toString("base64") === value;
 }
 
 async function readRegularFile(path, label, dependencies, maximumBytes) {
@@ -126,7 +139,7 @@ function installerMetadataMatches(metadata, version, installerName, sha512, size
   );
 }
 
-function verifyBlockmap(bytes, installer, installerName) {
+function verifyBlockmap(bytes, installer) {
   if (bytes.length < 2 || bytes[0] !== 0x1f || bytes[1] !== 0x8b) {
     fail("installer blockmap is invalid");
   }
@@ -149,6 +162,7 @@ function verifyBlockmap(bytes, installer, installerName) {
   }
   const file = blockmap.files[0];
   if (
+    file.name !== "file" ||
     file.offset !== 0 ||
     !Array.isArray(file.checksums) ||
     !Array.isArray(file.sizes) ||
@@ -156,19 +170,26 @@ function verifyBlockmap(bytes, installer, installerName) {
     file.checksums.length !== file.sizes.length ||
     !file.checksums.every(
       (checksum) =>
-        typeof checksum === "string" &&
-        /^[A-Za-z0-9+/]+={0,2}$/u.test(checksum) &&
-        Buffer.from(checksum, "base64").length === 64,
+        validBase64(checksum) &&
+        Buffer.from(checksum, "base64").length === BLOCKMAP_CHECKSUM_BYTES,
     ) ||
     !file.sizes.every((size) => Number.isSafeInteger(size) && size > 0)
   ) {
     fail("installer blockmap is invalid");
   }
-  if (
-    file.name !== installerName ||
-    file.sizes.reduce((total, size) => total + size, 0) !== installer.length
-  ) {
+  if (file.sizes.reduce((total, size) => total + size, 0) !== installer.length) {
     fail("installer blockmap does not match the Windows installer");
+  }
+  let offset = file.offset;
+  for (let index = 0; index < file.sizes.length; index += 1) {
+    const size = file.sizes[index];
+    const expectedChecksum = Buffer.from(
+      blake2b(installer.subarray(offset, offset + size), { dkLen: BLOCKMAP_CHECKSUM_BYTES }),
+    ).toString("base64");
+    if (file.checksums[index] !== expectedChecksum) {
+      fail("installer blockmap does not match the Windows installer");
+    }
+    offset += size;
   }
 }
 
@@ -247,7 +268,7 @@ export async function verifyWindowsReleaseAssets(artifactDirectory, options, ove
   ) {
     fail("latest.yml does not match the Windows installer");
   }
-  verifyBlockmap(blockmap, installer, names.installer);
+  verifyBlockmap(blockmap, installer);
   if (options.appUpdateMetadata !== undefined) {
     try {
       parseWindowsReleaseUpdaterMetadata(

--- a/apps/desktop/scripts/verify-windows-release.mjs
+++ b/apps/desktop/scripts/verify-windows-release.mjs
@@ -126,7 +126,7 @@ function installerMetadataMatches(metadata, version, installerName, sha512, size
   );
 }
 
-function verifyBlockmap(bytes) {
+function verifyBlockmap(bytes, installer, installerName) {
   if (bytes.length < 2 || bytes[0] !== 0x1f || bytes[1] !== 0x8b) {
     fail("installer blockmap is invalid");
   }
@@ -136,8 +136,39 @@ function verifyBlockmap(bytes) {
   } catch {
     fail("installer blockmap is invalid");
   }
-  if (!exactObject(blockmap) || !Array.isArray(blockmap.files) || blockmap.files.length === 0) {
+  if (
+    !exactObject(blockmap) ||
+    !hasExactKeys(blockmap, ["version", "files"]) ||
+    blockmap.version !== "2" ||
+    !Array.isArray(blockmap.files) ||
+    blockmap.files.length !== 1 ||
+    !exactObject(blockmap.files[0]) ||
+    !hasExactKeys(blockmap.files[0], ["name", "offset", "checksums", "sizes"])
+  ) {
     fail("installer blockmap is invalid");
+  }
+  const file = blockmap.files[0];
+  if (
+    file.offset !== 0 ||
+    !Array.isArray(file.checksums) ||
+    !Array.isArray(file.sizes) ||
+    file.checksums.length === 0 ||
+    file.checksums.length !== file.sizes.length ||
+    !file.checksums.every(
+      (checksum) =>
+        typeof checksum === "string" &&
+        /^[A-Za-z0-9+/]+={0,2}$/u.test(checksum) &&
+        Buffer.from(checksum, "base64").length === 64,
+    ) ||
+    !file.sizes.every((size) => Number.isSafeInteger(size) && size > 0)
+  ) {
+    fail("installer blockmap is invalid");
+  }
+  if (
+    file.name !== installerName ||
+    file.sizes.reduce((total, size) => total + size, 0) !== installer.length
+  ) {
+    fail("installer blockmap does not match the Windows installer");
   }
 }
 
@@ -216,7 +247,7 @@ export async function verifyWindowsReleaseAssets(artifactDirectory, options, ove
   ) {
     fail("latest.yml does not match the Windows installer");
   }
-  verifyBlockmap(blockmap);
+  verifyBlockmap(blockmap, installer, names.installer);
   if (options.appUpdateMetadata !== undefined) {
     try {
       parseWindowsReleaseUpdaterMetadata(

--- a/apps/desktop/scripts/verify-windows-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-windows-updater-round-trip.mjs
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { gunzipSync } from "node:zlib";
 import { parse } from "yaml";
 import {
   WINDOWS_RELEASE_METADATA_NAME,
@@ -134,6 +135,42 @@ function verifyBlockmap(value) {
     value.length < 2 ||
     value[0] !== 0x1f ||
     value[1] !== 0x8b
+  ) {
+    fail("installer blockmap is invalid");
+  }
+  let blockmap;
+  try {
+    blockmap = JSON.parse(gunzipSync(value).toString("utf8"));
+  } catch {
+    fail("installer blockmap is invalid");
+  }
+  if (
+    !exactObject(blockmap) ||
+    !hasExactKeys(blockmap, ["version", "files"]) ||
+    blockmap.version !== "2" ||
+    !Array.isArray(blockmap.files) ||
+    blockmap.files.length !== 1 ||
+    !exactObject(blockmap.files[0]) ||
+    !hasExactKeys(blockmap.files[0], ["name", "offset", "checksums", "sizes"])
+  ) {
+    fail("installer blockmap is invalid");
+  }
+  const file = blockmap.files[0];
+  if (
+    typeof file.name !== "string" ||
+    file.name.length === 0 ||
+    file.offset !== 0 ||
+    !Array.isArray(file.checksums) ||
+    !Array.isArray(file.sizes) ||
+    file.checksums.length === 0 ||
+    file.checksums.length !== file.sizes.length ||
+    !file.checksums.every(
+      (checksum) =>
+        typeof checksum === "string" &&
+        /^[A-Za-z0-9+/]+={0,2}$/u.test(checksum) &&
+        Buffer.from(checksum, "base64").length === 64,
+    ) ||
+    !file.sizes.every((size) => Number.isSafeInteger(size) && size > 0)
   ) {
     fail("installer blockmap is invalid");
   }

--- a/apps/desktop/scripts/verify-windows-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-windows-updater-round-trip.mjs
@@ -9,6 +9,7 @@ import { requireGenericFeedUrl, requireStableSemVer } from "./macos-release-plan
 import { WINDOWS_UPDATER_METADATA_MAX_BYTES } from "./verify-windows-release.mjs";
 
 const maximumPublisherNameCharacters = 512;
+const blockmapChecksumBytes = 18;
 const invalidMetadataMessage = `${WINDOWS_RELEASE_METADATA_NAME} is invalid`;
 
 class WindowsUpdaterRoundTripError extends Error {
@@ -157,8 +158,7 @@ function verifyBlockmap(value) {
   }
   const file = blockmap.files[0];
   if (
-    typeof file.name !== "string" ||
-    file.name.length === 0 ||
+    file.name !== "file" ||
     file.offset !== 0 ||
     !Array.isArray(file.checksums) ||
     !Array.isArray(file.sizes) ||
@@ -166,9 +166,8 @@ function verifyBlockmap(value) {
     file.checksums.length !== file.sizes.length ||
     !file.checksums.every(
       (checksum) =>
-        typeof checksum === "string" &&
-        /^[A-Za-z0-9+/]+={0,2}$/u.test(checksum) &&
-        Buffer.from(checksum, "base64").length === 64,
+        validBase64(checksum) &&
+        Buffer.from(checksum, "base64").length === blockmapChecksumBytes,
     ) ||
     !file.sizes.every((size) => Number.isSafeInteger(size) && size > 0)
   ) {

--- a/apps/desktop/scripts/windows-release-plan.d.mts
+++ b/apps/desktop/scripts/windows-release-plan.d.mts
@@ -41,7 +41,8 @@ export interface WindowsReleaseBuilderOptions {
       { readonly provider: "generic"; readonly url: string; readonly channel: "latest" },
     ];
     readonly win: {
-      readonly publisherName: readonly [string];
+      readonly signtoolOptions: { readonly publisherName: readonly [string] };
+      readonly signExecutable: true;
       readonly verifyUpdateCodeSignature: true;
       readonly target: readonly [{ readonly target: "nsis"; readonly arch: readonly ["x64"] }];
     };

--- a/apps/desktop/scripts/windows-release-plan.mjs
+++ b/apps/desktop/scripts/windows-release-plan.mjs
@@ -64,7 +64,10 @@ function freezeBuilderOptions(desktopRoot, version, feedUrl, publisherDn) {
     extraMetadata: Object.freeze({ version, enduragentDesktopRelease: true }),
     publish,
     win: Object.freeze({
-      publisherName: Object.freeze([publisherDn]),
+      signtoolOptions: Object.freeze({
+        publisherName: Object.freeze([publisherDn]),
+      }),
+      signExecutable: true,
       verifyUpdateCodeSignature: true,
       target,
     }),

--- a/apps/desktop/tests/upload-windows-release.test.ts
+++ b/apps/desktop/tests/upload-windows-release.test.ts
@@ -73,7 +73,13 @@ function release(assets: readonly string[] = [], overrides: Record<string, unkno
   });
 }
 
-function successfulExecutor() {
+function successfulExecutor(
+  options: {
+    readonly initialAssets?: readonly string[];
+    readonly reference?: { readonly type: "commit" | "tag"; readonly sha: string };
+    readonly peeled?: { readonly type: "commit" | "tag"; readonly sha: string };
+  } = {},
+) {
   let views = 0;
   return vi.fn(async (_executable: string, arguments_: readonly string[]) => {
     if (arguments_[0] === "release" && arguments_[1] === "view") {
@@ -81,9 +87,15 @@ function successfulExecutor() {
       return {
         stdout:
           views === 1
-            ? release([`Enduragent-${version}-arm64.dmg`])
+            ? release(options.initialAssets ?? [`Enduragent-${version}-arm64.dmg`])
             : release(Object.values(verified.names)),
       };
+    }
+    if (arguments_[0] === "api" && arguments_[1]?.includes("/git/ref/tags/")) {
+      return { stdout: JSON.stringify({ object: options.reference ?? { type: "commit", sha: commit } }) };
+    }
+    if (arguments_[0] === "api" && arguments_[1]?.includes("/git/tags/")) {
+      return { stdout: JSON.stringify({ object: options.peeled ?? { type: "commit", sha: commit } }) };
     }
     return { stdout: "" };
   });
@@ -121,6 +133,10 @@ describe("Windows release upload", () => {
     expect(executeFile.mock.calls[0]).toEqual(["gh-personal", viewArguments]);
     expect(executeFile.mock.calls[1]).toEqual([
       "gh-personal",
+      ["api", `repos/${repository}/git/ref/tags/${tag}`],
+    ]);
+    expect(executeFile.mock.calls[2]).toEqual([
+      "gh-personal",
       [
         "release",
         "upload",
@@ -132,8 +148,59 @@ describe("Windows release upload", () => {
         verified.paths.metadata,
       ],
     ]);
-    expect(executeFile.mock.calls[2]).toEqual(["gh-personal", viewArguments]);
+    expect(executeFile.mock.calls[3]).toEqual(["gh-personal", viewArguments]);
     expect(executeFile.mock.calls.flat(2)).not.toContain("--clobber");
+  });
+
+  it("binds a matching lightweight release tag to the commit", async () => {
+    const result = await runWindowsReleaseUpload(input(), {
+      executeFile: successfulExecutor(),
+      verifyAssets: vi.fn(async () => verified),
+    });
+    expect(result.tagCommit).toBe(commit);
+  });
+
+  it("peels a matching annotated release tag to the commit", async () => {
+    const tagObject = "b".repeat(40);
+    const executeFile = successfulExecutor({
+      reference: { type: "tag", sha: tagObject },
+      peeled: { type: "commit", sha: commit },
+    });
+    const result = await runWindowsReleaseUpload(input(), {
+      executeFile,
+      verifyAssets: vi.fn(async () => verified),
+    });
+    expect(result.tagCommit).toBe(commit);
+    expect(executeFile.mock.calls[2]).toEqual([
+      "gh-personal",
+      ["api", `repos/${repository}/git/tags/${tagObject}`],
+    ]);
+  });
+
+  it("refuses a release tag commit mismatch before upload", async () => {
+    const executeFile = successfulExecutor({
+      reference: { type: "commit", sha: "b".repeat(40) },
+    });
+    await expect(
+      runWindowsReleaseUpload(input(), {
+        executeFile,
+        verifyAssets: vi.fn(async () => verified),
+      }),
+    ).rejects.toThrow("release commit mismatch");
+    expect(executeFile.mock.calls.flat(2)).not.toContain("upload");
+  });
+
+  it("refuses an unresolvable release tag before upload", async () => {
+    const executeFile = successfulExecutor({
+      reference: { type: "commit", sha: "short" },
+    });
+    await expect(
+      runWindowsReleaseUpload(input(), {
+        executeFile,
+        verifyAssets: vi.fn(async () => verified),
+      }),
+    ).rejects.toThrow("release tag is unresolvable");
+    expect(executeFile.mock.calls.flat(2)).not.toContain("upload");
   });
 
   it("refuses a missing or unparsable release", async () => {
@@ -154,17 +221,63 @@ describe("Windows release upload", () => {
         verifyAssets: vi.fn(async () => verified),
       }),
     ).rejects.toThrow(`release is still a draft: ${tag}`);
+    expect(executeFile.mock.calls.flat(2)).not.toContain("upload");
+  });
+
+  it("refuses a prerelease release", async () => {
+    const executeFile = vi.fn(async () => ({ stdout: release([], { isPrerelease: true }) }));
+    await expect(
+      runWindowsReleaseUpload(input(), {
+        executeFile,
+        verifyAssets: vi.fn(async () => verified),
+      }),
+    ).rejects.toThrow(`release is a prerelease: ${tag}`);
+    expect(executeFile.mock.calls.flat(2)).not.toContain("upload");
   });
 
   it("refuses pre-existing Windows assets", async () => {
     const existing = verified.names.blockmap;
-    const executeFile = vi.fn(async () => ({ stdout: release([existing]) }));
+    const executeFile = successfulExecutor({ initialAssets: [existing] });
     await expect(
       runWindowsReleaseUpload(input(), {
         executeFile,
         verifyAssets: vi.fn(async () => verified),
       }),
     ).rejects.toThrow(`Windows release asset already exists: ${existing}`);
+  });
+
+  it("refuses a pre-existing upload record before verification or GitHub access", async () => {
+    const recordPath = join(directory, "upload-record.json");
+    await writeFile(recordPath, "existing");
+    const executeFile = successfulExecutor();
+    const verifyAssets = vi.fn(async () => verified);
+    await expect(
+      runWindowsReleaseUpload(input({ record: recordPath }), { executeFile, verifyAssets }),
+    ).rejects.toThrow("upload record already exists");
+    expect(verifyAssets).not.toHaveBeenCalled();
+    expect(executeFile).not.toHaveBeenCalled();
+  });
+
+  it("writes a safe failed record when release lookup fails", async () => {
+    const recordPath = join(directory, "upload-record.json");
+    const executeFile = vi.fn(async () => Promise.reject(new Error("not found")));
+    await expect(
+      runWindowsReleaseUpload(input({ record: recordPath }), {
+        executeFile,
+        verifyAssets: vi.fn(async () => verified),
+      }),
+    ).rejects.toThrow(`release does not exist: ${tag}`);
+    expect(JSON.parse(await readFile(recordPath, "utf8"))).toEqual({
+      schemaVersion: 1,
+      tag,
+      version,
+      commit,
+      arch: "x64",
+      status: "failed",
+      error: `release does not exist: ${tag}`,
+      uploaded: false,
+    });
+    expect(executeFile.mock.calls.flat(2)).not.toContain("upload");
   });
 
   it("refuses unsupported Authenticode modes before verification or upload", async () => {
@@ -214,7 +327,9 @@ describe("Windows release upload", () => {
       tag,
       version,
       commit,
+      tagCommit: commit,
       arch: "x64",
+      status: "uploaded",
       authenticode: "pending-w19",
     });
     expect(recorded.files.map((file: { name: string }) => file.name)).toEqual([

--- a/apps/desktop/tests/windows-authenticode.test.ts
+++ b/apps/desktop/tests/windows-authenticode.test.ts
@@ -1,9 +1,9 @@
 import { createHash } from "node:crypto";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { gzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stringify } from "yaml";
 import {
@@ -26,6 +26,14 @@ const scriptPath = resolve(
 const temporaryRoots: string[] = [];
 let directory: string;
 let installerPath: string;
+
+const require = createRequire(import.meta.url);
+const electronBuilderRequire = createRequire(require.resolve("electron-builder"));
+const { buildBlockMap } = electronBuilderRequire(
+  "app-builder-lib/out/targets/blockmap/blockmap",
+) as {
+  buildBlockMap: (inputPath: string, compression: "gzip", outputPath: string) => Promise<unknown>;
+};
 
 function summary(
   overrides: Partial<WindowsAuthenticodeSummary> = {},
@@ -78,28 +86,18 @@ beforeEach(async () => {
   const names = windowsReleaseArtifactNames(version);
   installerPath = join(directory, names.installer);
   const sha512 = createHash("sha512").update(installer).digest("base64");
-  await Promise.all([
-    writeFile(installerPath, installer),
-    writeFile(
-      join(directory, names.blockmap),
-      gzipSync(
-        JSON.stringify({
-          version: "2",
-          files: [{ name: "file", offset: 0, checksums: ["x"], sizes: [1] }],
-        }),
-      ),
-    ),
-    writeFile(
-      join(directory, names.metadata),
-      stringify({
-        version,
-        files: [{ url: names.installer, sha512, size: installer.length }],
-        path: names.installer,
-        sha512,
-        releaseDate: "2026-08-25T00:00:00.000Z",
-      }),
-    ),
-  ]);
+  await writeFile(installerPath, installer);
+  await buildBlockMap(installerPath, "gzip", join(directory, names.blockmap));
+  await writeFile(
+    join(directory, names.metadata),
+    stringify({
+      version,
+      files: [{ url: names.installer, sha512, size: installer.length }],
+      path: names.installer,
+      sha512,
+      releaseDate: "2026-08-25T00:00:00.000Z",
+    }),
+  );
 });
 
 describe("Windows Authenticode decisions", () => {

--- a/apps/desktop/tests/windows-release-artifacts.test.ts
+++ b/apps/desktop/tests/windows-release-artifacts.test.ts
@@ -75,19 +75,6 @@ beforeEach(async () => {
   await writeFile(installerPath, installer);
   const blockmapPath = join(directory, names.blockmap);
   await buildBlockMap(installerPath, "gzip", blockmapPath);
-  const blockmap = JSON.parse(
-    gunzipSync(await readFile(blockmapPath)).toString("utf8"),
-  ) as BlockmapFixture;
-  blockmap.files[0].name = names.installer;
-  let offset = 0;
-  blockmap.files[0].checksums = blockmap.files[0].sizes.map((size) => {
-    const checksum = createHash("sha512")
-      .update(installer.subarray(offset, offset + size))
-      .digest("base64");
-    offset += size;
-    return checksum;
-  });
-  await writeFile(blockmapPath, gzipSync(JSON.stringify(blockmap)));
   await writeMetadata();
 });
 
@@ -209,7 +196,7 @@ describe("Windows release artifact verification", () => {
     });
     await expect(
       verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
-    ).rejects.toThrow("installer blockmap does not match the Windows installer");
+    ).rejects.toThrow("installer blockmap is invalid");
   });
 
   it("rejects a version 1 blockmap", async () => {
@@ -228,6 +215,26 @@ describe("Windows release artifact verification", () => {
     await expect(
       verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
     ).rejects.toThrow("installer blockmap is invalid");
+  });
+
+  it("rejects a blockmap with a checksum of the wrong length", async () => {
+    await updateBlockmap((value) => {
+      value.files[0].checksums[0] = Buffer.alloc(17).toString("base64");
+    });
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("installer blockmap is invalid");
+  });
+
+  it("rejects an installer whose bytes do not match the blockmap", async () => {
+    installer = Buffer.from(installer);
+    installer[0] ^= 0xff;
+    const names = windowsReleaseArtifactNames(version);
+    await writeFile(join(directory, names.installer), installer);
+    await writeMetadata();
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("installer blockmap does not match the Windows installer");
   });
 
   it("runs the pending CLI and rejects unsupported Authenticode modes", async () => {

--- a/apps/desktop/tests/windows-release-artifacts.test.ts
+++ b/apps/desktop/tests/windows-release-artifacts.test.ts
@@ -1,9 +1,10 @@
 import { createHash } from "node:crypto";
-import { mkdtemp, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { gzipSync } from "node:zlib";
+import { gunzipSync, gzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stringify } from "yaml";
 import type { VerifyWindowsReleaseOptions } from "../scripts/verify-windows-release.mjs";
@@ -20,6 +21,19 @@ const script = resolve(
 const temporaryRoots: string[] = [];
 let directory: string;
 let installer: Buffer;
+
+type BlockmapFixture = {
+  version: string;
+  files: [{ name: string; offset: number; checksums: string[]; sizes: number[] }];
+};
+
+const require = createRequire(import.meta.url);
+const electronBuilderRequire = createRequire(require.resolve("electron-builder"));
+const { buildBlockMap } = electronBuilderRequire(
+  "app-builder-lib/out/targets/blockmap/blockmap",
+) as {
+  buildBlockMap: (inputPath: string, compression: "gzip", outputPath: string) => Promise<unknown>;
+};
 
 afterEach(async () => {
   await Promise.all(
@@ -44,23 +58,36 @@ async function writeMetadata(value = metadata()) {
   await writeFile(join(directory, "latest.yml"), stringify(value));
 }
 
+async function updateBlockmap(mutator: (value: BlockmapFixture) => void) {
+  const names = windowsReleaseArtifactNames(version);
+  const path = join(directory, names.blockmap);
+  const value = JSON.parse(gunzipSync(await readFile(path)).toString("utf8")) as BlockmapFixture;
+  mutator(value);
+  await writeFile(path, gzipSync(JSON.stringify(value)));
+}
+
 beforeEach(async () => {
   directory = await mkdtemp(join(tmpdir(), "windows-release-envelope-"));
   temporaryRoots.push(directory);
   installer = Buffer.from("synthetic signed Windows installer\n");
   const names = windowsReleaseArtifactNames(version);
-  await Promise.all([
-    writeFile(join(directory, names.installer), installer),
-    writeFile(
-      join(directory, names.blockmap),
-      gzipSync(
-        JSON.stringify({
-          version: "2",
-          files: [{ name: "file", offset: 0, checksums: ["x"], sizes: [1] }],
-        }),
-      ),
-    ),
-  ]);
+  const installerPath = join(directory, names.installer);
+  await writeFile(installerPath, installer);
+  const blockmapPath = join(directory, names.blockmap);
+  await buildBlockMap(installerPath, "gzip", blockmapPath);
+  const blockmap = JSON.parse(
+    gunzipSync(await readFile(blockmapPath)).toString("utf8"),
+  ) as BlockmapFixture;
+  blockmap.files[0].name = names.installer;
+  let offset = 0;
+  blockmap.files[0].checksums = blockmap.files[0].sizes.map((size) => {
+    const checksum = createHash("sha512")
+      .update(installer.subarray(offset, offset + size))
+      .digest("base64");
+    offset += size;
+    return checksum;
+  });
+  await writeFile(blockmapPath, gzipSync(JSON.stringify(blockmap)));
   await writeMetadata();
 });
 
@@ -153,6 +180,51 @@ describe("Windows release artifact verification", () => {
   it("rejects a non-gzip installer blockmap", async () => {
     const names = windowsReleaseArtifactNames(version);
     await writeFile(join(directory, names.blockmap), "not gzip");
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("installer blockmap is invalid");
+  });
+
+  it("rejects a blockmap with the wrong total size", async () => {
+    await updateBlockmap((value) => {
+      value.files[0].sizes[0] = value.files[0].sizes[0]! + 1;
+    });
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("installer blockmap does not match the Windows installer");
+  });
+
+  it("rejects a blockmap with mismatched checksum and size counts", async () => {
+    await updateBlockmap((value) => {
+      value.files[0].checksums.push(value.files[0].checksums[0]!);
+    });
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("installer blockmap is invalid");
+  });
+
+  it("rejects a blockmap for a different installer name", async () => {
+    await updateBlockmap((value) => {
+      value.files[0].name = "different.exe";
+    });
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("installer blockmap does not match the Windows installer");
+  });
+
+  it("rejects a version 1 blockmap", async () => {
+    await updateBlockmap((value) => {
+      value.version = "1";
+    });
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
+    ).rejects.toThrow("installer blockmap is invalid");
+  });
+
+  it("rejects a blockmap with a non-base64 checksum", async () => {
+    await updateBlockmap((value) => {
+      value.files[0].checksums[0] = "!";
+    });
     await expect(
       verifyWindowsReleaseAssets(directory, { version, authenticode: "pending-w19" }),
     ).rejects.toThrow("installer blockmap is invalid");

--- a/apps/desktop/tests/windows-release-plan.test.ts
+++ b/apps/desktop/tests/windows-release-plan.test.ts
@@ -1,5 +1,11 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { stringify } from "yaml";
+import { parse, stringify } from "yaml";
+import { createWindowsDevelopmentPackagePlan } from "../scripts/windows-development-package-plan.mjs";
+import { createWindowsPackagePlan } from "../scripts/windows-package-plan.mjs";
 import {
   WINDOWS_AUTHENTICODE_PENDING,
   WINDOWS_PUBLISHER_DN_PLACEHOLDER,
@@ -13,6 +19,7 @@ import {
 
 const feedUrl = "https://github.com/yerzhansa/enduragent/releases/latest/download/";
 const commit = "a".repeat(40);
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 function planInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -116,7 +123,8 @@ describe("Windows release plan", () => {
     ]);
     expect(plan.builderOptions.publish).toBe("never");
     expect(plan.builderOptions.config.win).toEqual({
-      publisherName: [WINDOWS_PUBLISHER_DN_PLACEHOLDER],
+      signtoolOptions: { publisherName: [WINDOWS_PUBLISHER_DN_PLACEHOLDER] },
+      signExecutable: true,
       verifyUpdateCodeSignature: true,
       target: [{ target: "nsis", arch: ["x64"] }],
     });
@@ -125,12 +133,64 @@ describe("Windows release plan", () => {
     const customPlan = createWindowsReleasePlan(planInput({ publisherDn: customPublisherDn }));
     expect(customPlan.publisherDn).toBe(customPublisherDn);
     expect(customPlan.publisherDnIsPlaceholder).toBe(false);
-    expect(customPlan.builderOptions.config.win.publisherName).toEqual([customPublisherDn]);
+    expect(customPlan.builderOptions.config.win.signtoolOptions.publisherName).toEqual([
+      customPublisherDn,
+    ]);
     expect(customPlan.updaterMetadata.publisherName).toBe(customPublisherDn);
     expect(() => createWindowsReleasePlan(planInput({ publisherDn: "  " }))).toThrow(
       "Windows publisher DN is invalid",
     );
     expect(Object.isFrozen(plan)).toBe(true);
+  });
+
+  it("release config passes the electron-builder 26.15.3 schema", () => {
+    const plan = createWindowsReleasePlan(planInput());
+    const { extends: _extends, ...config } = plan.builderOptions.config;
+    const require = createRequire(import.meta.url);
+    const electronBuilderRequire = createRequire(require.resolve("electron-builder"));
+    const schema = JSON.parse(
+      readFileSync(electronBuilderRequire.resolve("app-builder-lib/scheme.json"), "utf8"),
+    );
+    try {
+      const appBuilderRequire = createRequire(
+        electronBuilderRequire.resolve("app-builder-lib/package.json"),
+      );
+      const AjvModule = appBuilderRequire("ajv");
+      const Ajv = AjvModule.default ?? AjvModule;
+      const ajv = new Ajv({ strict: false, allErrors: true });
+      const validate = ajv.compile(schema);
+      expect(validate(config), JSON.stringify(validate.errors)).toBe(true);
+    } catch (error) {
+      if (error instanceof Error && !/Cannot find module/u.test(error.message)) throw error;
+      expect(config.win).not.toHaveProperty("publisherName");
+      expect(config.win.signtoolOptions.publisherName).toEqual([
+        WINDOWS_PUBLISHER_DN_PLACEHOLDER,
+      ]);
+      expect(Object.keys(config.win).every((key) => key in schema.definitions.WindowsConfiguration.properties)).toBe(true);
+    }
+    const base = parse(readFileSync(resolve(desktopRoot, "electron-builder.yml"), "utf8"));
+    const merged = {
+      ...base,
+      ...plan.builderOptions.config,
+      win: { ...base.win, ...plan.builderOptions.config.win },
+      nsis: { ...base.nsis, ...plan.builderOptions.config.nsis },
+    };
+    expect(merged.win.signExecutable).toBe(true);
+  });
+
+  it("forceCodeSigning implies signExecutable", async () => {
+    const release = createWindowsReleasePlan(planInput());
+    expect(release.builderOptions.config.forceCodeSigning).toBe(true);
+    expect(release.builderOptions.config.win.signExecutable).toBe(true);
+    const packagePlan = await createWindowsPackagePlan(
+      { desktopRoot: "/synthetic/repository/apps/desktop" },
+      { readFile: async () => JSON.stringify({ version: "0.1.5" }) },
+    );
+    const developmentPlan = createWindowsDevelopmentPackagePlan({
+      desktopRoot: "/synthetic/repository/apps/desktop",
+    });
+    expect(packagePlan.builderOptions.config.forceCodeSigning).toBe(false);
+    expect(developmentPlan.builderOptions.config.forceCodeSigning).toBe(false);
   });
 
   it("exposes only safe planner failures", () => {

--- a/apps/desktop/tests/windows-updater-round-trip.test.ts
+++ b/apps/desktop/tests/windows-updater-round-trip.test.ts
@@ -21,7 +21,7 @@ const blockmap = gzipSync(
       {
         name: "file",
         offset: 0,
-        checksums: [createHash("sha512").update("blockmap").digest("base64")],
+        checksums: [Buffer.alloc(18, 0xab).toString("base64")],
         sizes: [1],
       },
     ],

--- a/apps/desktop/tests/windows-updater-round-trip.test.ts
+++ b/apps/desktop/tests/windows-updater-round-trip.test.ts
@@ -14,7 +14,19 @@ type RoundTripInput = Parameters<typeof verifyWindowsUpdaterRoundTrip>[0];
 
 const baselineInstaller = Buffer.from("synthetic Windows installer 0.1.5\n");
 const candidateInstaller = Buffer.from("synthetic Windows installer 0.1.6\n");
-const blockmap = gzipSync(JSON.stringify({ version: "2", files: [{ name: "file" }] }));
+const blockmap = gzipSync(
+  JSON.stringify({
+    version: "2",
+    files: [
+      {
+        name: "file",
+        offset: 0,
+        checksums: [createHash("sha512").update("blockmap").digest("base64")],
+        sizes: [1],
+      },
+    ],
+  }),
+);
 const releaseDate = "2026-08-25T00:00:00.000Z";
 const preflight: WindowsUpdaterPreflight = {
   feedUrl: "https://github.com/yerzhansa/enduragent/releases/latest/download/",


### PR DESCRIPTION
## Summary

Fixes the seven Windows release lane review findings (ADR-0063 D4/D7, local). Each finding was grounded against the worktree at `b5cb4285` before the fix.

| # | Grounded verdict | Fix |
|---|---|---|
| F1 | Confirmed. `windows-release-plan.mjs` set `win.publisherName`; app-builder-lib 26.15.3 `WindowsConfiguration` has `additionalProperties: false` and no such key, so the release config would fail schema validation. | Publisher DN moved to `win.signtoolOptions.publisherName`; `.d.mts` updated; test validates the config against `scheme.json`. |
| F2 | Confirmed. Base `electron-builder.yml` sets `win.signExecutable: false`; the release plan kept `forceCodeSigning: true` without overriding it, which `winPackager` rejects as an invalid configuration. | Release plan sets `win.signExecutable: true`. `electron-builder.yml`, `windows-package-plan.mjs`, `windows-development-package-plan.mjs` untouched (unsigned CI builds stay unsigned). |
| F3 | Confirmed. `desktop-windows-release.yml` marked assets "verified" on `dry_run=false` while Authenticode was hardcoded to `pending-w19`; the "Verify Authenticode (pending W19)" step was a false-claim echo. | New `authenticode` (`pending-w19`/`verify`) and `publisher_dn` inputs. Fail-fast step refuses `dry_run=false` unless `authenticode=verify`, placed before any download or release mutation. Stale echo step deleted. |
| F4 | Confirmed. `upload-windows-release.mjs` accepted `--commit` on trust and never compared it with the release tag. | Resolves `repos/{repo}/git/ref/tags/{tag}`, peels annotated tags via `git/tags/{sha}`, requires 40-hex shas, throws `release commit mismatch` before any upload; `tagCommit` stored in the record. |
| F5 | Confirmed. `parseRelease` refused drafts but not prereleases. | Shape check requires boolean `isPrerelease`; throws `release is a prerelease: <tag>` before any upload. |
| F6 | Confirmed. `verifyBlockmap` only checked the gzip magic and a non-empty `files` array; a blockmap for a different installer passed. | Validates version `"2"`, exact keys, one file entry, offset 0, equal-length base64 SHA-512 checksums and positive-int sizes, and binds `name` and `sum(sizes)` to the installer. Round-trip verifier applies the same shape check. |
| F7 | Confirmed. The upload record was written only after a successful upload, so a partial upload left no trace and a stale record could be silently overwritten. | Record reserved with `wx` before any remote call (`upload record already exists` / `upload record directory is missing`); all local work (verify, hashes, release view, tag binding, asset check) precedes the first `release upload`; failures write `status: "failed"` with `uploaded: <bool>`, success writes `status: "uploaded"`, mode `0o600`. |

## Limits

- `TAG_SHA_HEX_LENGTH = 40` — validate tag and peeled commit SHA-1 values
- `BLOCKMAP_VERSION = "2"` — require current blockmap schema
- `BLOCKMAP_FILE_COUNT = 1` — bind exactly one installer
- `BLOCKMAP_OFFSET = 0` — require installer-relative chunks
- `BLOCKMAP_CHECKSUM_COUNT_MIN = 1` — reject empty maps
- `BLOCKMAP_CHECKSUM_BYTES = 64` — require SHA-512-sized decoded checksums
- `BLOCKMAP_CHUNK_SIZE = 1..Number.MAX_SAFE_INTEGER` — require safe positive sizes
- `BLOCKMAP_TOTAL_BYTES = installer.length` — bind chunks to installer bytes
- `UPLOAD_RECORD_MODE = 0o600` — owner-only upload record
- `UPLOAD_RECORD_SCHEMA_VERSION = 1` — stable record format

No timeouts, retries, intervals, or size budgets added.

## Verification

- `pnpm --filter @enduragent/desktop exec vitest run tests/windows-release-plan.test.ts tests/windows-release-artifacts.test.ts tests/upload-windows-release.test.ts tests/windows-updater-round-trip.test.ts tests/windows-package-plan.test.ts tests/windows-development-package-plan.test.ts` → exit 0; 6/6 files, 72 passed, 0 failed, 1 skipped.
- Root `pnpm check` → build, typecheck, oxlint (0 errors, 20 pre-existing warnings), and all 8 `check:*` scripts clean.
- YAML parse of `desktop-windows-release.yml` → exit 0.
- Ajv validation of the release plan config against app-builder-lib 26.15.3 `scheme.json` → valid.

Acceptance criteria: AC1 pass, AC2 pass, AC3 pass, AC4 pass, AC5 pass, AC6 pass, AC7 partial, AC8 pass, AC9 partial.

- AC7 partial: the pinned `buildBlockMap` emits name `"file"` and 18-byte checksums, which conflicts with the installer-name / 64-byte contract; the positive fixture keeps real generated chunk sizes but substitutes the installer name and SHA-512 chunk digests instead of using `buildBlockMap` output verbatim.
- AC9 partial: `apps/desktop/tests/windows-updater-round-trip.test.ts` was edited outside the brief's allowlist because the F6 shape check invalidated its fixture and the file is in the mandatory gate.

## Workflow-file changes (operator review)

`.github/workflows/desktop-windows-release.yml`:

- The "Mark Windows assets verified" step now runs only when `dry_run == false && authenticode == 'verify' && steps.verify.outcome == 'success'`. Marker text is `Windows assets verified: <sha256> (Authenticode verified)`; no "pending" text can reach the release body.
- Pending mode refuses `dry_run=false` before any download or mutation (`::error::Authenticode verification is not enabled; refusing to mark assets`, `exit 1`).
- `verify` mode requires a non-placeholder `publisher_dn` and passes `--authenticode verify --publisher-dn` to the verifier.
- Only `GH_TOKEN: ${{ github.token }}` is used; `permissions` unchanged; `desktop-release.yml` untouched.

Do not merge without operator review (workflow file touched).

## Residuals

- `authenticode=verify` needs `signtool`/PowerShell, so it requires a Windows runner before first real use; `runs-on` stays `ubuntu-latest` (W19 scope).
- Blockmap positive fixture is synthetic-bound rather than verbatim `buildBlockMap` output (see AC7).


## Fix round 2

Head: `cb79a564314e94ce48f25f2eee48ddd9699de5a1`

**Blockmap validation** now matches electron-builder 26.15.3 output: single file entry named `file`, 18-byte blake2b checksums, and the blockmap is bound to the installer size.

**Checksum content binding:** implemented. Verifier review verdict: "Claim holds; could not refute."

- `apps/desktop/scripts/verify-windows-release.mjs:18` sets `BLOCKMAP_CHECKSUM_BYTES = 18`.
- `:20-21` resolves `@noble/hashes/blake2.js` through electron-builder's own require chain (`createRequire(scriptRequire.resolve("electron-builder"))`), landing on `node_modules/.pnpm/@noble+hashes@1.8.0`, the same module app-builder-lib 26.15.3 uses.
- `:142-193` `verifyBlockmap(bytes, installer)`: gzip magic check, JSON parse, exact-key structure (`version: "2"`, single file `name: "file"`, `offset: 0`, base64 18-byte checksums, positive sizes, equal-length arrays), then binds the recorded sizes and checksums to the installer bytes.

**Gate results** (worktree `scratchpad/wfix-run/wt`):

1. `pnpm check` → exit 0. All gates clean (fixture-privacy, registry-isolation, changeset-userfacing, contract-deps, package-deps with 3 allowlisted transitional WARNs, kernel-discipline, codex-schema).
2. `npx vitest run apps/desktop/tests` → exit 1.

```
 Test Files  1 failed | 97 passed | 1 skipped (99)
      Tests  1 failed | 1935 passed | 2 skipped
```

Round 2 gate found windows-authenticode.test.ts failing on the old hand-built blockmap fixture; round 3 rebuilds that fixture with real buildBlockMap output.

## Fix round 3

Head: `14b7f4cec39cffd44ef10ae67b112cff8c9efabc`

- Fixture rebuilt via app-builder-lib `buildBlockMap`.
- Targeted Windows tests green.
- Root `pnpm check` exit 0.
- One local live-Electron integration timeout (`onboarding-first-run`) observed in the orchestrator's worktree on an untouched file; CI `desktop-integration-macos` is the arbiter.
