### PR TITLE
feat(plan): add read-only planning surface

### DIFF
--- a/.changeset/chat-plan-read-models.md
+++ b/.changeset/chat-plan-read-models.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Added a read-only Plan destination and current Plan details to Chat’s Training context.
+
+Planning now owns the strict current-Plan, current-week, and Workout projection used by Desktop; Chat can navigate to the relevant Plan context but cannot mutate Plan data.

--- a/apps/desktop-renderer/src/app/views.ts
+++ b/apps/desktop-renderer/src/app/views.ts
@@ -1,5 +1,6 @@
 import {
   Activity,
+  CalendarDays,
   History,
   MessageSquare,
   Settings,
@@ -7,7 +8,7 @@ import {
 } from "lucide-react";
 import { lazy, type ComponentType, type LazyExoticComponent } from "react";
 
-export type ViewId = "chat" | "archive" | "training" | "settings";
+export type ViewId = "chat" | "archive" | "plan" | "training" | "settings";
 export type StoredViewId = ViewId;
 
 export const REACT_CHAT_REGION = "react-chat-region";
@@ -35,6 +36,15 @@ export const VIEWS: readonly ViewDefinition[] = Object.freeze([
     title: "Past chats",
     page: lazy(async () => ({
       default: (await import("../ui/archive/ArchiveView.js")).ArchiveView,
+    })),
+  },
+  {
+    id: "plan",
+    label: "Plan",
+    icon: CalendarDays,
+    title: "Plan",
+    page: lazy(async () => ({
+      default: (await import("../ui/plan/PlanView.js")).PlanView,
     })),
   },
   {

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -54,6 +54,7 @@ import {
 import { createRideImportController, subscribeToDroppedRideImports } from "./ride-import.js";
 import { createTrainingExportController } from "./training-export/controller.js";
 import { settleInitialSetupStatus } from "./initial-setup-status.js";
+import { createPlanController } from "./plan/controller.js";
 
 export type Disposer = () => void;
 
@@ -126,6 +127,17 @@ export function bootRenderer(): Disposer {
   const trainingContextController = createTrainingContextController({
     clients,
     view: trainingAdapter.view,
+  });
+  const planController = createPlanController({
+    read: () => window.enduragentAuth.getPlanningReadModel(),
+    render: (next) => store.getState().setPlanSurface(next),
+    navigate: (view) => store.getState().setActiveView(view),
+    focus: (target, returnToChat) => store.getState().setPlanFocus(target, returnToChat),
+  });
+  store.getState().bindPlanActions({
+    refresh: () => void planController.refresh(),
+    openFromChat: (target) => planController.openFromChat(target),
+    backToChat: () => planController.backToChat(),
   });
   const trainingSyncCoordinator = createTrainingSyncCoordinator({
     clients,
@@ -437,6 +449,7 @@ export function bootRenderer(): Disposer {
   );
 
   void trainingContextController.start();
+  void planController.start();
   spendController.start();
   void telegramSettingsController.activate();
   void chatController.start();
@@ -463,6 +476,7 @@ export function bootRenderer(): Disposer {
     disposed = true;
     store.getState().bindChatActions(null);
     store.getState().bindArchiveActions(null);
+    store.getState().bindPlanActions(null);
     store.getState().bindSettingsPorts(null);
     store.getState().bindSyncActions(null);
     store.getState().bindRideImportActions(null);
@@ -491,6 +505,7 @@ export function bootRenderer(): Disposer {
     archiveController.dispose();
     spendController.dispose();
     trainingContextController.dispose();
+    planController.dispose();
     rideAnalysisController.dispose();
     void clients.close();
   };

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -16,6 +16,7 @@ interface EnduragentAuth {
     readonly cursor: string | null;
     readonly limit: number;
   }): Promise<DesktopTranscriptPage>;
+  getPlanningReadModel(): Promise<DesktopPlanningReadModel>;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
   retryFailedCredentials(): Promise<readonly CredentialSlotStatus[]>;
   writeCredential(input: {
@@ -73,6 +74,7 @@ interface EnduragentAuth {
 type DesktopPlatformProjection = import("./platform-copy").DesktopPlatformProjection;
 type DesktopAttachmentAdmission = import("@enduragent/coach-contract").AttachmentAdmissionReadModel;
 type DesktopAttachmentReference = import("@enduragent/coach-contract").ChatAttachmentReference;
+type DesktopPlanningReadModel = import("@enduragent/coach-contract").PlanningReadModel;
 type CredentialRecoveryStatus = import("./onboarding/bridge").CredentialRecoveryStatus;
 type CredentialResetResult = import("./onboarding/bridge").CredentialResetResult;
 

--- a/apps/desktop-renderer/src/plan/controller.ts
+++ b/apps/desktop-renderer/src/plan/controller.ts
@@ -1,0 +1,58 @@
+import type { PlanNavigationTarget, PlanningReadModel } from "@enduragent/coach-contract";
+import type { PlanSurfaceState } from "../state/plan-slice.js";
+
+export interface PlanController {
+  start(): Promise<void>;
+  refresh(): Promise<void>;
+  openFromChat(target: PlanNavigationTarget): void;
+  backToChat(): void;
+  dispose(): void;
+}
+
+export function createPlanController(input: {
+  readonly read: () => Promise<PlanningReadModel>;
+  readonly render: (state: PlanSurfaceState) => void;
+  readonly navigate: (view: "chat" | "plan") => void;
+  readonly focus: (target: PlanNavigationTarget | null, returnToChat: boolean) => void;
+}): PlanController {
+  let disposed = false;
+  let value: PlanningReadModel | null = null;
+  let pending: Promise<void> | undefined;
+
+  const refresh = (): Promise<void> => {
+    if (pending !== undefined) return pending;
+    input.render(value === null ? { status: "loading", value: null } : { status: "ready", value });
+    const task = input
+      .read()
+      .then((next) => {
+        if (disposed) return;
+        value = next;
+        input.render({ status: "ready", value: next });
+      })
+      .catch(() => {
+        if (!disposed) input.render({ status: "unavailable", value });
+      })
+      .finally(() => {
+        if (pending === task) pending = undefined;
+      });
+    pending = task;
+    return task;
+  };
+
+  return {
+    start: refresh,
+    refresh,
+    openFromChat(target) {
+      input.focus(target, true);
+      input.navigate("plan");
+      void refresh();
+    },
+    backToChat() {
+      input.focus(null, false);
+      input.navigate("chat");
+    },
+    dispose() {
+      disposed = true;
+    },
+  };
+}

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -1,0 +1,40 @@
+import type { PlanNavigationTarget, PlanningReadModel } from "@enduragent/coach-contract";
+import type { StateCreator } from "zustand";
+import type { EnduragentState } from "./store.js";
+
+export type PlanSurfaceState =
+  | { readonly status: "loading"; readonly value: null }
+  | { readonly status: "ready"; readonly value: PlanningReadModel }
+  | { readonly status: "unavailable"; readonly value: PlanningReadModel | null };
+
+export interface PlanActions {
+  refresh(): void;
+  openFromChat(target: PlanNavigationTarget): void;
+  backToChat(): void;
+}
+
+export interface PlanSlice {
+  readonly planSurface: PlanSurfaceState;
+  readonly planFocus: PlanNavigationTarget | null;
+  readonly planReturnToChat: boolean;
+  readonly planActions: PlanActions | null;
+  setPlanSurface: (value: PlanSurfaceState) => void;
+  setPlanFocus: (value: PlanNavigationTarget | null, returnToChat: boolean) => void;
+  bindPlanActions: (actions: PlanActions | null) => void;
+}
+
+export const createPlanSlice: StateCreator<EnduragentState, [], [], PlanSlice> = (set) => ({
+  planSurface: { status: "loading", value: null },
+  planFocus: null,
+  planReturnToChat: false,
+  planActions: null,
+  setPlanSurface(value) {
+    set({ planSurface: value });
+  },
+  setPlanFocus(value, returnToChat) {
+    set({ planFocus: value, planReturnToChat: returnToChat });
+  },
+  bindPlanActions(actions) {
+    set({ planActions: actions });
+  },
+});

--- a/apps/desktop-renderer/src/state/store.ts
+++ b/apps/desktop-renderer/src/state/store.ts
@@ -30,6 +30,7 @@ import {
 import { createSyncSlice, type SyncSlice } from "./sync-slice.js";
 import { createTrainingSlice, type TrainingSlice } from "./training-slice.js";
 import { createTrainingExportSlice, type TrainingExportSlice } from "./training-export-slice.js";
+import { createPlanSlice, type PlanSlice } from "./plan-slice.js";
 
 export interface EnduragentState
   extends
@@ -37,6 +38,7 @@ export interface EnduragentState
     ArchiveSlice,
     SettingsSlice,
     TrainingSlice,
+    PlanSlice,
     TrainingExportSlice,
     ActivityAnalysisSlice,
     SyncSlice,
@@ -68,6 +70,7 @@ export const useEnduragentStore = create<EnduragentState>((set, get, api) => ({
   ...createArchiveSlice(set, get, api),
   ...createSettingsSlice(set, get, api),
   ...createTrainingSlice(set, get, api),
+  ...createPlanSlice(set, get, api),
   ...createTrainingExportSlice(set, get, api),
   ...createActivityAnalysisSlice(set, get, api),
   ...createSyncSlice(set, get, api),

--- a/apps/desktop-renderer/src/ui/chat/TrainingContextPanel.tsx
+++ b/apps/desktop-renderer/src/ui/chat/TrainingContextPanel.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { Button } from "../../components/ui/button.js";
 import { useEnduragentStore } from "../../state/store.js";
-import { formatDateLabel, formatWholeNumber } from "../../training-context/format.js";
+import { formatWholeNumber } from "../../training-context/format.js";
 
 function ContextSection(props: {
   readonly label: string;
@@ -33,10 +33,11 @@ export function TrainingContextPanel(props: {
   readonly className?: string;
 }): ReactElement {
   const training = useEnduragentStore((state) => state.training);
-  const setActiveView = useEnduragentStore((state) => state.setActiveView);
+  const planning = useEnduragentStore((state) => state.planSurface);
+  const planActions = useEnduragentStore((state) => state.planActions);
   const context = training.trainingContext;
-  const nextWorkout = context.plan.kind === "computed" ? context.plan.items[0] : undefined;
-  const upcomingCount = context.plan.kind === "computed" ? context.plan.items.length : 0;
+  const currentPlan = planning.value?.status === "ready" ? planning.value.plan : null;
+  const todayWorkout = currentPlan?.todayWorkout ?? null;
 
   return (
     <aside
@@ -61,37 +62,42 @@ export function TrainingContextPanel(props: {
         </p>
       ) : (
         <div>
-          {nextWorkout === undefined ? (
+          {todayWorkout === null ? (
             <ContextSection
-              label="Next workout"
+              label="Today"
               title={
-                context.plan.kind === "unknown"
-                  ? unavailableCopy(context.plan.reason)
-                  : "No upcoming workouts"
+                planning.status === "loading"
+                  ? "Loading Plan…"
+                  : planning.value?.status === "no-plan"
+                    ? "No current Plan"
+                    : "No workout today"
               }
             />
           ) : (
             <ContextSection
-              label="Next workout"
-              title={nextWorkout.name ?? "Cycling workout"}
-              detail={`${formatDateLabel(nextWorkout.date)} · ${nextWorkout.workoutType}`}
+              label="Today"
+              title={todayWorkout.name}
+              detail={
+                todayWorkout.durationSeconds === null
+                  ? todayWorkout.sport
+                  : `${Math.round(todayWorkout.durationSeconds / 60)} min · ${todayWorkout.sport}`
+              }
             />
           )}
 
           <ContextSection
-            label="Upcoming plan"
+            label="Current Plan"
             title={
-              context.plan.kind === "computed"
-                ? `${upcomingCount} scheduled ${upcomingCount === 1 ? "workout" : "workouts"}`
-                : unavailableCopy(context.plan.reason)
+              currentPlan === null
+                ? planning.status === "loading"
+                  ? "Loading Plan…"
+                  : "Not available yet"
+                : currentPlan.name
             }
             detail={
-              context.plan.kind === "computed" && context.plan.items.length > 1
-                ? context.plan.items
-                    .slice(1, 3)
-                    .map((item) => item.name ?? item.workoutType)
-                    .join(" · ")
-                : undefined
+              currentPlan?.currentWeek === null || currentPlan === null
+                ? undefined
+                : `Week ${currentPlan.currentWeek} of ${currentPlan.totalWeeks}${currentPlan.phase === null ? "" : ` · ${currentPlan.phase}`}`
             }
           />
 
@@ -130,17 +136,18 @@ export function TrainingContextPanel(props: {
           Showing saved context; refresh is unavailable.
         </p>
       ) : null}
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="mt-inset -ml-inset text-ink-2"
-        onClick={() => {
-          setActiveView("training");
-        }}
-      >
-        Open Training
-      </Button>
+      {currentPlan === null ? null : (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="mt-inset -ml-inset text-ink-2"
+          onClick={() => planActions?.openFromChat(currentPlan.navigation)}
+          disabled={planActions === null}
+        >
+          Open Plan
+        </Button>
+      )}
     </aside>
   );
 }

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -1,0 +1,118 @@
+import { CalendarDays, RotateCw } from "lucide-react";
+import { useEffect, type ReactElement } from "react";
+import { Button } from "../../components/ui/button.js";
+import { useEnduragentStore } from "../../state/store.js";
+import { Page } from "../shared/Page.js";
+
+function dateLabel(dateKey: number): string {
+  const value = String(dateKey);
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(
+    new Date(Date.UTC(Number(value.slice(0, 4)), Number(value.slice(4, 6)) - 1, Number(value.slice(6, 8)))),
+  );
+}
+
+function durationLabel(seconds: number | null): string | null {
+  if (seconds === null) return null;
+  return `${Math.round(seconds / 60)} min`;
+}
+
+export function PlanView(): ReactElement {
+  const surface = useEnduragentStore((state) => state.planSurface);
+  const focus = useEnduragentStore((state) => state.planFocus);
+  const returnToChat = useEnduragentStore((state) => state.planReturnToChat);
+  const actions = useEnduragentStore((state) => state.planActions);
+
+  useEffect(() => {
+    actions?.refresh();
+  }, [actions]);
+
+  return (
+    <Page
+      title="Your training plan"
+      action={
+        <div className="flex gap-2">
+          {returnToChat ? (
+            <Button variant="outline" onClick={() => actions?.backToChat()}>
+              Back to Chat
+            </Button>
+          ) : null}
+          <Button variant="outline" onClick={() => actions?.refresh()} disabled={actions === null}>
+            <RotateCw aria-hidden="true" /> Refresh
+          </Button>
+        </div>
+      }
+    >
+      <p className="mt-0 mb-5 text-sm text-ink-2">
+        Planning-owned schedule and current week. Chat can read this information but cannot change it.
+      </p>
+      {surface.status === "loading" ? (
+        <p className="text-sm text-ink-2" role="status">Loading Plan…</p>
+      ) : surface.status === "unavailable" && surface.value === null ? (
+        <section className="rounded-card border border-line bg-surface p-6">
+          <h2 className="m-0 text-base font-semibold">Plan is temporarily unavailable</h2>
+          <p className="mt-2 mb-0 text-sm text-ink-2">Your saved Plan is unchanged. Try again.</p>
+        </section>
+      ) : surface.value?.status === "no-plan" ? (
+        <section className="rounded-card border border-line bg-surface p-6">
+          <CalendarDays className="mb-3 text-ink-2" aria-hidden="true" />
+          <h2 className="m-0 text-base font-semibold">No current Plan</h2>
+          <p className="mt-2 mb-0 text-sm text-ink-2">Create and approve plans from the Plan workflow.</p>
+        </section>
+      ) : (
+        <div className="grid gap-4" data-plan-focus={focus?.focus ?? "active-plan"}>
+          {surface.status === "unavailable" ? (
+            <p className="m-0 rounded-ctl bg-warn/10 px-3 py-2 text-xs text-warn" role="status">
+              Showing the last saved Plan; refresh is unavailable.
+            </p>
+          ) : null}
+          <section className="rounded-card border border-line bg-surface p-6 shadow-elev-1">
+            <p className="m-0 text-xs font-semibold tracking-[0.06em] text-ink-2 uppercase">
+              Current Plan
+            </p>
+            <h2 className="mt-2 mb-0 text-xl font-semibold">{surface.value!.plan!.name}</h2>
+            <p className="mt-2 mb-0 text-sm text-ink-2">{surface.value!.plan!.goal || "No goal recorded"}</p>
+            <div className="mt-4 flex flex-wrap gap-2 text-xs text-ink-2">
+              <span className="rounded-pill bg-surface-2 px-3 py-1.5">
+                {surface.value!.plan!.currentWeek === null
+                  ? "Outside active dates"
+                  : `Week ${surface.value!.plan!.currentWeek} of ${surface.value!.plan!.totalWeeks}`}
+              </span>
+              {surface.value!.plan!.phase === null ? null : (
+                <span className="rounded-pill bg-surface-2 px-3 py-1.5">{surface.value!.plan!.phase}</span>
+              )}
+            </div>
+          </section>
+          <section className="rounded-card border border-line bg-surface p-6">
+            <h2 className="m-0 text-base font-semibold">Current week</h2>
+            {surface.value!.plan!.workouts.length === 0 ? (
+              <p className="mt-3 mb-0 text-sm text-ink-2">No workouts in the current Plan week.</p>
+            ) : (
+              <div className="mt-4 grid gap-2">
+                {surface.value!.plan!.workouts.map((workout) => (
+                  <article
+                    key={workout.id}
+                    className={`rounded-ctl border p-4 ${focus?.entityId === workout.id ? "border-brand bg-brand/5" : "border-line bg-surface-2"}`}
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <h3 className="m-0 text-sm font-semibold">{workout.name}</h3>
+                        <p className="mt-1 mb-0 text-xs text-ink-2">
+                          {[dateLabel(workout.dateKey), durationLabel(workout.durationSeconds), workout.sport]
+                            .filter((item) => item !== null)
+                            .join(" · ")}
+                        </p>
+                      </div>
+                      <span className="rounded-pill bg-surface px-2.5 py-1 text-xs text-ink-2">
+                        {workout.origin === "athlete" ? "Athlete" : "Coach"}
+                      </span>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+      )}
+    </Page>
+  );
+}

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -137,6 +137,10 @@ describe("chat surface", () => {
       chat: EMPTY_CHAT_SURFACE,
       firstSync: { status: "idle" },
       training: EMPTY_TRAINING_SURFACE,
+      planSurface: { status: "loading", value: null },
+      planFocus: null,
+      planReturnToChat: false,
+      planActions: null,
       chatActions: actions,
       onboarding: READY_ONBOARDING,
     });
@@ -147,6 +151,10 @@ describe("chat surface", () => {
       chat: EMPTY_CHAT_SURFACE,
       firstSync: { status: "idle" },
       training: EMPTY_TRAINING_SURFACE,
+      planSurface: { status: "loading", value: null },
+      planFocus: null,
+      planReturnToChat: false,
+      planActions: null,
       chatActions: null,
       onboarding: CLOSED_ONBOARDING,
     });
@@ -354,6 +362,57 @@ describe("chat surface", () => {
     it("projects only available workout, Load, and cycling-anchor facts", () => {
       act(() => {
         useEnduragentStore.setState({
+          planSurface: {
+            status: "ready",
+            value: {
+              schemaVersion: 1,
+              status: "ready",
+              asOfDateKey: 19980825,
+              plan: {
+                id: "plan-1",
+                name: "Eight-week consistency",
+                goal: "Build consistency",
+                lifecycle: "active",
+                startDateKey: 19980824,
+                targetDateKey: null,
+                currentWeek: 1,
+                totalWeeks: 8,
+                phase: "Base",
+                weekStartDateKey: 19980824,
+                weekEndDateKey: 19980830,
+                workouts: [
+                  {
+                    id: "workout-1",
+                    dateKey: 19980825,
+                    sport: "cycling",
+                    name: "Tempo builder",
+                    durationSeconds: 3_600,
+                    origin: "coach",
+                    navigation: { destination: "plan", focus: "workout", entityId: "workout-1" },
+                  },
+                  {
+                    id: "workout-2",
+                    dateKey: 19980827,
+                    sport: "cycling",
+                    name: "Recovery spin",
+                    durationSeconds: 2_700,
+                    origin: "coach",
+                    navigation: { destination: "plan", focus: "workout", entityId: "workout-2" },
+                  },
+                ],
+                todayWorkout: {
+                  id: "workout-1",
+                  dateKey: 19980825,
+                  sport: "cycling",
+                  name: "Tempo builder",
+                  durationSeconds: 3_600,
+                  origin: "coach",
+                  navigation: { destination: "plan", focus: "workout", entityId: "workout-1" },
+                },
+                navigation: { destination: "plan", focus: "active-plan", entityId: "plan-1" },
+              },
+            },
+          },
           training: {
             ...EMPTY_TRAINING_SURFACE,
             status: "ready",
@@ -414,8 +473,9 @@ describe("chat surface", () => {
       render(<Harness />);
       const context = screen.getByRole("complementary", { name: "Training context" });
       expect(context).toHaveTextContent("Tempo builder");
-      expect(context).toHaveTextContent("1998-08-25 · Tempo");
-      expect(context).toHaveTextContent("2 scheduled workouts");
+      expect(context).toHaveTextContent("60 min · cycling");
+      expect(context).toHaveTextContent("Eight-week consistency");
+      expect(context).toHaveTextContent("Week 1 of 8 · Base");
       expect(context).toHaveTextContent("4 cycling activities · 7 days");
       expect(context).toHaveTextContent("182 W");
       expect(context).not.toHaveTextContent(/Fitness|Fatigue|Form|Memory|Updated|Fresh 2m/u);

--- a/apps/desktop-renderer/tests/plan-controller.test.ts
+++ b/apps/desktop-renderer/tests/plan-controller.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PlanSurfaceState } from "../src/state/plan-slice.js";
+import { createPlanController } from "../src/plan/controller.js";
+
+const model = { schemaVersion: 1 as const, status: "no-plan" as const, asOfDateKey: 20260826, plan: null };
+
+describe("Plan controller", () => {
+  it("hydrates and preserves the last safe projection on refresh failure", async () => {
+    let fail = false;
+    const states: PlanSurfaceState[] = [];
+    const controller = createPlanController({
+      read: vi.fn(async () => {
+        if (fail) throw new Error("offline");
+        return model;
+      }),
+      render: (state) => states.push(state),
+      navigate: vi.fn(),
+      focus: vi.fn(),
+    });
+    await controller.start();
+    fail = true;
+    await controller.refresh();
+    expect(states.at(-1)).toEqual({ status: "unavailable", value: model });
+  });
+
+  it("records Chat return navigation without mutating Plan", () => {
+    const navigate = vi.fn();
+    const focus = vi.fn();
+    const controller = createPlanController({
+      read: vi.fn(async () => model),
+      render: vi.fn(),
+      navigate,
+      focus,
+    });
+    const target = { destination: "plan" as const, focus: "active-plan" as const, entityId: "plan-1" };
+    controller.openFromChat(target);
+    expect(focus).toHaveBeenCalledWith(target, true);
+    expect(navigate).toHaveBeenCalledWith("plan");
+    controller.backToChat();
+    expect(focus).toHaveBeenLastCalledWith(null, false);
+    expect(navigate).toHaveBeenLastCalledWith("chat");
+  });
+});

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -1,0 +1,86 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PlanningReadModel } from "@enduragent/coach-contract";
+import { useEnduragentStore } from "../src/state/store.js";
+import { PlanView } from "../src/ui/plan/PlanView.js";
+
+const model: PlanningReadModel = {
+  schemaVersion: 1,
+  status: "ready",
+  asOfDateKey: 20260826,
+  plan: {
+    id: "plan-1",
+    name: "Twelve-week base",
+    goal: "Build consistency",
+    lifecycle: "active",
+    startDateKey: 20260824,
+    targetDateKey: null,
+    currentWeek: 1,
+    totalWeeks: 12,
+    phase: "Base",
+    weekStartDateKey: 20260824,
+    weekEndDateKey: 20260830,
+    workouts: [
+      {
+        id: "workout-1",
+        dateKey: 20260826,
+        sport: "cycling",
+        name: "Tempo builder",
+        durationSeconds: 3600,
+        origin: "coach",
+        navigation: { destination: "plan", focus: "workout", entityId: "workout-1" },
+      },
+    ],
+    todayWorkout: null,
+    navigation: { destination: "plan", focus: "active-plan", entityId: "plan-1" },
+  },
+};
+
+beforeEach(() => {
+  useEnduragentStore.setState({
+    planSurface: { status: "ready", value: model },
+    planFocus: { destination: "plan", focus: "workout", entityId: "workout-1" },
+    planReturnToChat: true,
+    planActions: { refresh: vi.fn(), openFromChat: vi.fn(), backToChat: vi.fn() },
+  });
+});
+
+afterEach(() => {
+  useEnduragentStore.setState({
+    planSurface: { status: "loading", value: null },
+    planFocus: null,
+    planReturnToChat: false,
+    planActions: null,
+  });
+});
+
+describe("Plan read-only surface", () => {
+  it("renders the Planning projection and selected workout without mutation controls", () => {
+    const { container } = render(<PlanView />);
+    expect(screen.getByRole("heading", { name: "Twelve-week base" })).toBeInTheDocument();
+    expect(screen.getByText("Week 1 of 12")).toBeInTheDocument();
+    expect(screen.getByText("Base")).toBeInTheDocument();
+    const workout = screen.getByRole("article");
+    expect(within(workout).getByText("Tempo builder")).toBeInTheDocument();
+    expect(container.querySelector('[data-plan-focus="workout"]')).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /save|apply|replace/i })).not.toBeInTheDocument();
+  });
+
+  it("offers Back to Chat only for Chat-originated navigation", async () => {
+    const user = userEvent.setup();
+    render(<PlanView />);
+    await user.click(screen.getByRole("button", { name: "Back to Chat" }));
+    expect(useEnduragentStore.getState().planActions?.backToChat).toHaveBeenCalledOnce();
+
+    act(() => useEnduragentStore.setState({ planReturnToChat: false }));
+    expect(screen.queryByRole("button", { name: "Back to Chat" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the last safe Plan visible during refresh failure", () => {
+    useEnduragentStore.setState({ planSurface: { status: "unavailable", value: model } });
+    render(<PlanView />);
+    expect(screen.getByText(/Showing the last saved Plan/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Twelve-week base" })).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -309,6 +309,7 @@ async function security() {
             "exportTrainingFile",
             "getArchivedTranscriptPage",
             "getDaemonConnection",
+            "getPlanningReadModel",
             "getTranscriptPage",
             "getUpdateState",
             "initialSetupStatusSettled",

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -13,6 +13,7 @@ export const DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL =
   "desktop:list-archived-conversations" as const;
 export const DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL =
   "desktop:get-archived-transcript-page" as const;
+export const DESKTOP_PLANNING_READ_CHANNEL = "desktop:planning:read" as const;
 export const DESKTOP_TRAINING_EXPORT_CHANNEL = "desktop:training:export" as const;
 export const DESKTOP_CHAT_ATTACHMENT_PICK_CHANNEL = "desktop:chat-attachment:pick" as const;
 export const DESKTOP_CHAT_ATTACHMENT_DROP_CHANNEL = "desktop:chat-attachment:drop" as const;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -180,6 +180,11 @@ import {
   installDesktopTrainingExportIpc,
   type DesktopTrainingExporter,
 } from "./training-export-ipc.js";
+import {
+  createConnectionPlanningReader,
+  installDesktopPlanningReadIpc,
+  type DesktopPlanningReader,
+} from "./planning-read-ipc.js";
 
 bindDesktopAppUserModelId(app);
 bindWindowsUserData(app);
@@ -322,6 +327,7 @@ async function runDesktop(): Promise<void> {
   let protocolInstalled = false;
   let connectionIpc: DesktopConnectionIpcController | undefined;
   let disposeTranscriptIpc: (() => void) | undefined;
+  let disposePlanningReadIpc: (() => void) | undefined;
   let disposeChatAttachmentIpc: (() => void) | undefined;
   let disposeTrainingExportIpc: (() => void) | undefined;
   let disposeExternalLinkIpc: (() => void) | undefined;
@@ -388,6 +394,8 @@ async function runDesktop(): Promise<void> {
       connectionIpc = undefined;
       disposeTranscriptIpc?.();
       disposeTranscriptIpc = undefined;
+      disposePlanningReadIpc?.();
+      disposePlanningReadIpc = undefined;
       disposeChatAttachmentIpc?.();
       disposeChatAttachmentIpc = undefined;
       disposeTrainingExportIpc?.();
@@ -595,6 +603,7 @@ async function runDesktop(): Promise<void> {
       readonly authority: RuntimeConfigurationAuthority;
       readonly credentials: CredentialRuntimeApplication;
       readonly transcript: DesktopTranscriptReader;
+      readonly planning: DesktopPlanningReader;
       readonly trainingExporter: DesktopTrainingExporter;
       readonly chatAttachments: DesktopChatAttachmentClient;
     };
@@ -748,6 +757,7 @@ async function runDesktop(): Promise<void> {
       return {
         authority,
         transcript: createConnectionTranscriptReader(boundConnection),
+        planning: createConnectionPlanningReader(boundConnection),
         trainingExporter: createConnectionTrainingExporter(boundConnection),
         chatAttachments: createConnectionChatAttachmentClient(boundConnection),
         credentials: createCredentialRuntimeApplication({
@@ -801,6 +811,21 @@ async function runDesktop(): Promise<void> {
         throw new TypeError();
       }
       return page;
+    };
+    const readActivePlanning = async () => {
+      const binding = activeRuntimeBinding;
+      const lifecycleState = daemonLifecycle?.snapshot();
+      if (binding === undefined || lifecycleState?.status !== "ready") throw new TypeError();
+      const value = await binding.planning.getPlanningReadModel();
+      const currentLifecycleState = daemonLifecycle?.snapshot();
+      if (
+        activeRuntimeBinding !== binding ||
+        currentLifecycleState?.status !== "ready" ||
+        currentLifecycleState.generation !== lifecycleState.generation
+      ) {
+        throw new TypeError();
+      }
+      return value;
     };
     const vault = createCredentialVault({
       root: credentialRoot,
@@ -1221,6 +1246,11 @@ async function runDesktop(): Promise<void> {
         readActiveTranscript((reader) => reader.listArchivedConversations(request)),
       readArchivedPage: (request) =>
         readActiveTranscript((reader) => reader.getArchivedTranscriptPage(request)),
+    });
+    disposePlanningReadIpc = installDesktopPlanningReadIpc({
+      ipcMain,
+      currentWindow: () => mainWindow.current() ?? undefined,
+      read: readActivePlanning,
     });
     disposeTrainingExportIpc = installDesktopTrainingExportIpc({
       ipcMain,

--- a/apps/desktop/src/main/planning-read-ipc.ts
+++ b/apps/desktop/src/main/planning-read-ipc.ts
@@ -1,0 +1,58 @@
+import { connectCoachClient, type CoachClient } from "@enduragent/coach-client";
+import {
+  GetPlanningReadModelRpcResultSchema,
+  type GetPlanningReadModelRpcResult,
+} from "@enduragent/coach-contract";
+import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from "electron";
+import { DESKTOP_PLANNING_READ_CHANNEL } from "./constants.js";
+import { isTrustedConnectionRequest } from "./security.js";
+
+export interface DesktopPlanningReader {
+  getPlanningReadModel(): Promise<GetPlanningReadModelRpcResult>;
+}
+
+export function createConnectionPlanningReader(
+  connection: Readonly<{
+    url: `ws://127.0.0.1:${number}/rpc`;
+    token: string;
+    athleteHome: string;
+  }>,
+  connect: typeof connectCoachClient = connectCoachClient,
+): DesktopPlanningReader {
+  return {
+    async getPlanningReadModel() {
+      const client: CoachClient = await connect({
+        url: connection.url,
+        token: connection.token,
+        expectedAthleteHome: connection.athleteHome,
+      });
+      try {
+        return await client.call("getPlanningReadModel", {});
+      } finally {
+        await client.close();
+      }
+    },
+  };
+}
+
+export function installDesktopPlanningReadIpc(input: {
+  readonly ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
+  readonly currentWindow: () => BrowserWindow | undefined;
+  readonly read: () => Promise<GetPlanningReadModelRpcResult>;
+}): () => void {
+  input.ipcMain.handle(
+    DESKTOP_PLANNING_READ_CHANNEL,
+    async (event: IpcMainInvokeEvent, ...args: unknown[]) => {
+      if (!isTrustedConnectionRequest(event, input.currentWindow())) {
+        throw new Error("untrusted desktop Planning request");
+      }
+      if (args.length !== 0) throw new TypeError("invalid desktop Planning request");
+      try {
+        return GetPlanningReadModelRpcResultSchema.parse(await input.read());
+      } catch {
+        throw new TypeError("desktop Planning unavailable");
+      }
+    },
+  );
+  return () => input.ipcMain.removeHandler(DESKTOP_PLANNING_READ_CHANNEL);
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer, webUtils } from "electron";
 import {
   AttachmentAdmissionReadModelSchema,
   CHAT_ATTACHMENT_LIMITS,
+  GetPlanningReadModelRpcResultSchema,
   PlatformAbsolutePathSchema,
   type AttachmentAdmissionReadModel,
 } from "@enduragent/coach-contract";
@@ -18,6 +19,7 @@ import {
   DESKTOP_INITIAL_SETUP_STATUS_SETTLED_CHANNEL,
   DESKTOP_INTERVALS_PASTE_CREDENTIAL_CHANNEL,
   DESKTOP_LIFECYCLE_CHANNEL,
+  DESKTOP_PLANNING_READ_CHANNEL,
   DESKTOP_OPEN_EXTERNAL_CHANNEL,
   DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL,
   DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL,
@@ -1072,6 +1074,12 @@ function parseAttachmentAdmissions(value: unknown): readonly AttachmentAdmission
   return value.map((item) => AttachmentAdmissionReadModelSchema.parse(item));
 }
 
+function parsePlanningReadModel(value: unknown): unknown {
+  const parsed = GetPlanningReadModelRpcResultSchema.safeParse(value);
+  if (!parsed.success) throw new TypeError();
+  return parsed.data;
+}
+
 function telegramUsername(value: unknown): value is string {
   return typeof value === "string" && /^[A-Za-z][A-Za-z0-9_]{4,31}$/.test(value);
 }
@@ -1519,6 +1527,8 @@ contextBridge.exposeInMainWorld(
         archivedTranscriptCursor,
       );
     },
+    getPlanningReadModel: async () =>
+      parsePlanningReadModel(await ipcRenderer.invoke(DESKTOP_PLANNING_READ_CHANNEL)),
     credentialStatuses: async () =>
       parseStatuses(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL)),
     retryFailedCredentials: async () =>

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1185,6 +1185,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "exportTrainingFile",
         "getArchivedTranscriptPage",
         "getDaemonConnection",
+        "getPlanningReadModel",
         "getTranscriptPage",
         "getUpdateState",
         "initialSetupStatusSettled",

--- a/apps/desktop/tests/planning-read-ipc.test.ts
+++ b/apps/desktop/tests/planning-read-ipc.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({ BrowserWindow: class {} }));
+
+import {
+  createConnectionPlanningReader,
+  installDesktopPlanningReadIpc,
+} from "../src/main/planning-read-ipc.js";
+import { DESKTOP_PLANNING_READ_CHANNEL } from "../src/main/constants.js";
+import { createDesktopRendererUrl } from "../src/main/renderer-navigation.js";
+
+const RENDERER_URL = createDesktopRendererUrl("A".repeat(43));
+const model = { schemaVersion: 1 as const, status: "no-plan" as const, asOfDateKey: 20260826, plan: null };
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+function setup(read = vi.fn(async () => model)) {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: vi.fn((channel: string, handler: Handler) => handlers.set(channel, handler)),
+    removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+  };
+  const mainFrame = { url: RENDERER_URL };
+  const webContents = { isDestroyed: () => false, mainFrame };
+  const window = { isDestroyed: () => false, webContents };
+  const dispose = installDesktopPlanningReadIpc({
+    ipcMain: ipcMain as never,
+    currentWindow: () => window as never,
+    read,
+  });
+  return { handlers, ipcMain, read, dispose, trusted: { sender: webContents, senderFrame: mainFrame } };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("Desktop Planning read IPC", () => {
+  it("returns a strict projection only to the trusted renderer", async () => {
+    const subject = setup();
+    const handler = subject.handlers.get(DESKTOP_PLANNING_READ_CHANNEL)!;
+    await expect(handler(subject.trusted)).resolves.toEqual(model);
+    await expect(handler(subject.trusted, {})).rejects.toThrow("invalid desktop Planning request");
+    await expect(handler({ sender: {}, senderFrame: { url: RENDERER_URL } })).rejects.toThrow(
+      "untrusted desktop Planning request",
+    );
+    expect(subject.read).toHaveBeenCalledOnce();
+  });
+
+  it("closes the privileged Coach client after a read", async () => {
+    const client = { call: vi.fn(async () => model), close: vi.fn(async () => {}) };
+    const connect = vi.fn(async () => client);
+    const reader = createConnectionPlanningReader(
+      { url: "ws://127.0.0.1:45001/rpc", token: "s".repeat(43), athleteHome: "/athlete" },
+      connect as never,
+    );
+    await expect(reader.getPlanningReadModel()).resolves.toEqual(model);
+    expect(client.call).toHaveBeenCalledWith("getPlanningReadModel", {});
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it("removes its handler", () => {
+    const subject = setup();
+    subject.dispose();
+    expect(subject.ipcMain.removeHandler).toHaveBeenCalledWith(DESKTOP_PLANNING_READ_CHANNEL);
+  });
+});

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -59,6 +59,7 @@ interface AuthBridge {
   getTranscriptPage(input: unknown): Promise<unknown>;
   listArchivedConversations(): Promise<unknown>;
   getArchivedTranscriptPage(input: unknown): Promise<unknown>;
+  getPlanningReadModel(): Promise<unknown>;
   credentialStatuses(): Promise<unknown>;
   credentialRecoveryStatus(): Promise<unknown>;
   retryCredentialRecovery(): Promise<unknown>;
@@ -346,6 +347,7 @@ describe("desktop preload ChatGPT auth", () => {
         "getUpdateState",
         "getDaemonConnection",
         "getTranscriptPage",
+        "getPlanningReadModel",
         "initialSetupStatusSettled",
         "listArchivedConversations",
         "listTelegramAllowedSenders",
@@ -954,6 +956,23 @@ describe("desktop preload ChatGPT auth", () => {
       cursor: null,
       limit: 25,
     });
+  });
+
+  it("validates and copies the Planning-owned read model", async () => {
+    const response = {
+      schemaVersion: 1,
+      status: "no-plan",
+      asOfDateKey: 20260826,
+      plan: null,
+    };
+    mocks.invoke.mockResolvedValueOnce(response);
+    const value = await bridge.getPlanningReadModel();
+    expect(value).toEqual(response);
+    expect(value).not.toBe(response);
+    expect(mocks.invoke).toHaveBeenCalledWith("desktop:planning:read");
+
+    mocks.invoke.mockResolvedValueOnce({ ...response, athleteHome: "/private/athlete" });
+    await expect(bridge.getPlanningReadModel()).rejects.toBeInstanceOf(TypeError);
   });
 
   it("rejects malformed transcript requests before IPC and redacts malformed responses", async () => {

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -472,6 +472,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "exportTrainingFile",
       "getArchivedTranscriptPage",
       "getDaemonConnection",
+      "getPlanningReadModel",
       "getTranscriptPage",
       "getUpdateState",
       "initialSetupStatusSettled",

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -136,6 +136,7 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   listArchivedConversations: 30_000,
   getArchivedTranscriptPage: 30_000,
   getAthleteState: 30_000,
+  getPlanningReadModel: 30_000,
   getActivityAnalysis: 90_000,
   exportTrainingFile: 120_000,
   importFiles: 60 * 60_000,

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -99,6 +99,7 @@ const rpcDeadlineCases = [
   ["listArchivedConversations", {}, 30_000],
   ["getArchivedTranscriptPage", { boundaryRef: "a".repeat(64), cursor: null, limit: 25 }, 30_000],
   ["getAthleteState", {}, 30_000],
+  ["getPlanningReadModel", {}, 30_000],
   [
     "getActivityAnalysis",
     { canonicalActivityId: "a".repeat(64), sections: ["aerobic-drift"] },
@@ -920,6 +921,12 @@ describe("RPC receive and observers", () => {
           recentActivities: [],
           plannedWorkouts: [],
           wellness: {},
+        },
+        getPlanningReadModel: {
+          schemaVersion: 1,
+          status: "no-plan",
+          asOfDateKey: 20260826,
+          plan: null,
         },
         getActivityAnalysis: {
           schemaVersion: 1,

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -14,3 +14,4 @@ export * from "./platform-path.js";
 export * from "./coach-decision.js";
 export * from "./chat-queue.js";
 export * from "./chat-attachment.js";
+export * from "./planning-read.js";

--- a/packages/coach-contract/src/planning-read.ts
+++ b/packages/coach-contract/src/planning-read.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+export const PlanDateKeySchema = z.number().int().min(1_000_101).max(99_991_231);
+
+export const PlanNavigationTargetSchema = z
+  .object({
+    destination: z.literal("plan"),
+    focus: z.enum(["active-plan", "current-week", "workout"]),
+    entityId: z.string().min(1).nullable(),
+  })
+  .strict();
+export type PlanNavigationTarget = z.infer<typeof PlanNavigationTargetSchema>;
+
+export const PlanWorkoutReadModelSchema = z
+  .object({
+    id: z.string().min(1),
+    dateKey: PlanDateKeySchema,
+    sport: z.string().min(1),
+    name: z.string().min(1),
+    durationSeconds: z.number().int().nonnegative().nullable(),
+    origin: z.enum(["coach", "athlete"]),
+    navigation: PlanNavigationTargetSchema,
+  })
+  .strict();
+export type PlanWorkoutReadModel = z.infer<typeof PlanWorkoutReadModelSchema>;
+
+export const ActivePlanReadModelSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    goal: z.string(),
+    lifecycle: z.enum(["draft", "active"]),
+    startDateKey: PlanDateKeySchema,
+    targetDateKey: PlanDateKeySchema.nullable(),
+    currentWeek: z.number().int().positive().nullable(),
+    totalWeeks: z.number().int().positive(),
+    phase: z.string().min(1).nullable(),
+    weekStartDateKey: PlanDateKeySchema.nullable(),
+    weekEndDateKey: PlanDateKeySchema.nullable(),
+    workouts: z.array(PlanWorkoutReadModelSchema),
+    todayWorkout: PlanWorkoutReadModelSchema.nullable(),
+    navigation: PlanNavigationTargetSchema,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const hasWeek = value.currentWeek !== null;
+    if (hasWeek !== (value.weekStartDateKey !== null && value.weekEndDateKey !== null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["currentWeek"],
+        message: "current week and its date range must appear together",
+      });
+    }
+    if (value.todayWorkout !== null && !value.workouts.some((item) => item.id === value.todayWorkout?.id)) {
+      context.addIssue({
+        code: "custom",
+        path: ["todayWorkout"],
+        message: "today workout must belong to the current week",
+      });
+    }
+  });
+export type ActivePlanReadModel = z.infer<typeof ActivePlanReadModelSchema>;
+
+export const PlanningReadModelSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      schemaVersion: z.literal(1),
+      status: z.literal("no-plan"),
+      asOfDateKey: PlanDateKeySchema,
+      plan: z.null(),
+    })
+    .strict(),
+  z
+    .object({
+      schemaVersion: z.literal(1),
+      status: z.literal("ready"),
+      asOfDateKey: PlanDateKeySchema,
+      plan: ActivePlanReadModelSchema,
+    })
+    .strict(),
+]);
+export type PlanningReadModel = z.infer<typeof PlanningReadModelSchema>;
+
+export const GetPlanningReadModelRpcParamsSchema = z.object({}).strict();
+export type GetPlanningReadModelRpcParams = z.infer<typeof GetPlanningReadModelRpcParamsSchema>;
+export const GetPlanningReadModelRpcResultSchema = PlanningReadModelSchema;
+export type GetPlanningReadModelRpcResult = z.infer<typeof GetPlanningReadModelRpcResultSchema>;
+
+export interface PlanningReadOperations {
+  getPlanningReadModel?(
+    request: GetPlanningReadModelRpcParams,
+  ): Promise<GetPlanningReadModelRpcResult>;
+}

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -110,6 +110,11 @@ import {
   RetryQueuedTurnRequestSchema,
   RunQueuedCommandRequestSchema,
 } from "./chat-queue.js";
+import {
+  GetPlanningReadModelRpcParamsSchema,
+  GetPlanningReadModelRpcResultSchema,
+  type PlanningReadOperations,
+} from "./planning-read.js";
 
 export const JsonValueSchema = z.json();
 export type JsonValue = z.infer<typeof JsonValueSchema>;
@@ -228,6 +233,7 @@ export const COACH_RPC_METHOD_NAMES = [
   "listArchivedConversations",
   "getArchivedTranscriptPage",
   "getAthleteState",
+  "getPlanningReadModel",
   "getActivityAnalysis",
   "exportTrainingFile",
   "importFiles",
@@ -1241,6 +1247,7 @@ export interface TelegramControlOperations {
 
 export type CoachRpcService = CoachEngine &
   CoachOperations &
+  PlanningReadOperations &
   SpendOperations &
   CoachSelfTestOperations &
   TelegramControlOperations;
@@ -1452,6 +1459,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("getAthleteState"),
       params: EmptyRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("getPlanningReadModel"),
+      params: GetPlanningReadModelRpcParamsSchema,
     })
     .strict(),
   z
@@ -1956,6 +1971,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "getAthleteState",
     requestSchema: EmptyRpcParamsSchema,
     responseSchema: AthleteStateSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  getPlanningReadModel: {
+    wireName: "getPlanningReadModel",
+    requestSchema: GetPlanningReadModelRpcParamsSchema,
+    responseSchema: GetPlanningReadModelRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
   getActivityAnalysis: {

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 26;
+export const PROTOCOL_VERSION = 27;

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe("chat queue contract", () => {
   it("ships protocol 26 and rejects a blank enqueue without attachments", () => {
-    expect(PROTOCOL_VERSION).toBe(26);
+    expect(PROTOCOL_VERSION).toBe(27);
     expect(() =>
       EnqueueChatMessageRequestSchema.parse({
         chatId: "desktop",

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -152,7 +152,7 @@ describe("coach decision wire contract", () => {
   });
 
   it("projects resume completion explicitly at protocol 26", () => {
-    expect(PROTOCOL_VERSION).toBe(26);
+    expect(PROTOCOL_VERSION).toBe(27);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -115,7 +115,7 @@ describe("exit codes", () => {
 
 describe("protocol version", () => {
   it("is 26", () => {
-    expect(PROTOCOL_VERSION).toBe(26);
+    expect(PROTOCOL_VERSION).toBe(27);
   });
 
   it("requires Stop to name the exact active turn", () => {

--- a/packages/coach-contract/tests/planning-read-contract.test.ts
+++ b/packages/coach-contract/tests/planning-read-contract.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  GetPlanningReadModelRpcParamsSchema,
+  PlanningReadModelSchema,
+} from "../src/index.js";
+
+describe("Planning read contract", () => {
+  it("accepts a strict no-Plan projection", () => {
+    expect(
+      PlanningReadModelSchema.parse({
+        schemaVersion: 1,
+        status: "no-plan",
+        asOfDateKey: 20260826,
+        plan: null,
+      }),
+    ).toEqual({ schemaVersion: 1, status: "no-plan", asOfDateKey: 20260826, plan: null });
+    expect(GetPlanningReadModelRpcParamsSchema.safeParse({ extra: true }).success).toBe(false);
+  });
+
+  it("rejects a today Workout outside the current week projection", () => {
+    const workout = {
+      id: "workout-1",
+      dateKey: 20260826,
+      sport: "cycling",
+      name: "Tempo",
+      durationSeconds: 3600,
+      origin: "coach" as const,
+      navigation: { destination: "plan" as const, focus: "workout" as const, entityId: "workout-1" },
+    };
+    const value = {
+      schemaVersion: 1,
+      status: "ready",
+      asOfDateKey: 20260826,
+      plan: {
+        id: "plan-1",
+        name: "Base",
+        goal: "Consistency",
+        lifecycle: "active",
+        startDateKey: 20260824,
+        targetDateKey: null,
+        currentWeek: 1,
+        totalWeeks: 12,
+        phase: "Base",
+        weekStartDateKey: 20260824,
+        weekEndDateKey: 20260830,
+        workouts: [],
+        todayWorkout: workout,
+        navigation: { destination: "plan", focus: "active-plan", entityId: "plan-1" },
+      },
+    };
+    expect(PlanningReadModelSchema.safeParse(value).success).toBe(false);
+  });
+});

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1285,6 +1285,12 @@ describe("coach request and event projection", () => {
           plannedWorkouts: [],
           wellness: {},
         }),
+      getPlanningReadModel: async () => ({
+        schemaVersion: 1,
+        status: "no-plan" as const,
+        asOfDateKey: 20260826,
+        plan: null,
+      }),
       getActivityAnalysis: async () => {
         throw new Error("not exercised by registry exhaustiveness");
       },
@@ -1873,7 +1879,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-26 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-27 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1881,8 +1887,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 26,
-      serverProtocolVersion: 26,
+      clientProtocolVersion: 27,
+      serverProtocolVersion: 27,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1891,7 +1897,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(25);
+    expect(previous).toBe(26);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -1966,7 +1972,7 @@ describe("handshake", () => {
 
   it("accepts aligned protocol 26 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(26);
+    expect(client.clientProtocolVersion).toBe(27);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2093,6 +2099,6 @@ describe("additive protocol signals", () => {
   });
 
   it("uses protocol version 26", () => {
-    expect(PROTOCOL_VERSION).toBe(26);
+    expect(PROTOCOL_VERSION).toBe(27);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -92,6 +92,7 @@ import {
   type ListArchivedConversationsRpcParams,
   type ListArchivedConversationsRpcResult,
   type GetRuntimeConfigRpcResult,
+  type PlanningReadOperations,
   type VerifyIntervalsCredentialRpcParams,
   type VerifyIntervalsCredentialRpcResult,
 } from "@enduragent/coach-contract";
@@ -166,6 +167,7 @@ import { createManagedWorkoutReader } from "@enduragent/sport-cycling/workout-im
 import { createPersistentOpenRouterModelMetadataCache } from "./openrouter-model-metadata-cache.js";
 import { createDocumentMediaAttachmentOperations } from "./document-media-attachment-operations.js";
 import { createAttachmentComposerOperations } from "./attachment-composer-operations.js";
+import { createPlanningReadService } from "./planning-read-service.js";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -178,7 +180,7 @@ interface OAuthCredential extends StoredProfile {
 
 export interface LocalCoachComposition {
   readonly engine: CoachEngine;
-  readonly operations: CoachOperations;
+  readonly operations: CoachOperations & PlanningReadOperations;
   readonly spendMeter: SpendMeterService;
   readonly confirmations: Pick<ConfirmationGate, "peek" | "confirm" | "cancel">;
   startInitialRefresh(): Promise<void>;
@@ -1840,10 +1842,16 @@ export async function createLocalCoachComposition(
           request.workoutId,
         ),
       clearChatAttachmentDraft: (request) => attachmentComposerOperations.clear(request.chatId),
+      getPlanningReadModel: (request) =>
+        createPlanningReadService({
+          store: input.context.store,
+          timezone: activeTimezone,
+          now,
+        }).getPlanningReadModel(request),
       getActivityAnalysis: (request, signal) =>
         activityAnalysis.getActivityAnalysis(request, signal),
       exportTrainingFile: (request, signal) => trainingExport.export(request, signal),
-    } satisfies CoachOperations;
+    } satisfies CoachOperations & PlanningReadOperations;
     return {
       engine: reconfigurable.engine,
       operations,

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -34,6 +34,7 @@ import {
   serializeCoachRpcEnvelope,
   type CoachEngine,
   type CoachOperations,
+  type PlanningReadOperations,
   type CoachRpcMethodName,
   type CoachSelfTestOperations,
   type DaemonOwner,
@@ -293,7 +294,7 @@ export async function ensureDaemonToken(
 
 export interface CoachRpcServerInput {
   readonly engine: CoachEngine;
-  readonly operations: CoachOperations;
+  readonly operations: CoachOperations & PlanningReadOperations;
   readonly spend: SpendRpcHandlers;
   readonly selfTestOperations: CoachSelfTestOperations;
   readonly telegram: DesktopTelegramController;
@@ -516,6 +517,7 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "listArchivedConversations",
   "getArchivedTranscriptPage",
   "getAthleteState",
+  "getPlanningReadModel",
   "getActivityAnalysis",
   "importFiles",
   "sync",
@@ -1282,6 +1284,19 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
             try {
               COACH_RPC_METHOD_REGISTRY.getAthleteState.requestSchema.parse(generic.data.params);
               result = await input.engine.getAthleteState();
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "getPlanningReadModel":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.getPlanningReadModel.requestSchema.parse(
+                generic.data.params,
+              );
+              if (input.operations.getPlanningReadModel === undefined) {
+                throw new TypeError("Planning read operation is unavailable.");
+              }
+              result = await input.operations.getPlanningReadModel(request);
             } catch (error) {
               invocationFailure = { error };
             }

--- a/packages/coach/src/local-runner.ts
+++ b/packages/coach/src/local-runner.ts
@@ -1,4 +1,8 @@
-import type { CoachEngine, CoachOperations } from "@enduragent/coach-contract";
+import type {
+  CoachEngine,
+  CoachOperations,
+  PlanningReadOperations,
+} from "@enduragent/coach-contract";
 import type { ConfirmationGate } from "@enduragent/core";
 import { prepareAthleteHome, type AthleteHome } from "@enduragent/kernel-node/home";
 import type { WriterProtocolListener } from "@enduragent/kernel-node/lock";
@@ -10,7 +14,7 @@ import { withCoachStoreWriter } from "./runtime.js";
 export interface LocalCoachLifecycle {
   readonly home: AthleteHome;
   readonly engine: CoachEngine;
-  readonly operations: CoachOperations;
+  readonly operations: CoachOperations & PlanningReadOperations;
   readonly spendMeter: SpendMeterService;
   readonly confirmations: Pick<ConfirmationGate, "peek" | "confirm" | "cancel">;
   readonly listener: WriterProtocolListener;

--- a/packages/coach/src/planning-read-service.ts
+++ b/packages/coach/src/planning-read-service.ts
@@ -1,0 +1,140 @@
+import {
+  GetPlanningReadModelRpcParamsSchema,
+  GetPlanningReadModelRpcResultSchema,
+  type GetPlanningReadModelRpcParams,
+  type GetPlanningReadModelRpcResult,
+  type PlanWorkoutReadModel,
+} from "@enduragent/coach-contract";
+import {
+  createPlanRepository,
+  createPlanWorkoutRepository,
+  planWeekIndex,
+  planWeekRange,
+  type PlanRow,
+  type PlanWorkoutRow,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+
+export interface PlanningReadService {
+  getPlanningReadModel(
+    request: GetPlanningReadModelRpcParams,
+  ): Promise<GetPlanningReadModelRpcResult>;
+}
+
+export interface PlanningReadServiceInput {
+  readonly store: SqlStore;
+  readonly timezone: string;
+  readonly now?: () => number;
+}
+
+function todayInTimezone(nowMs: number, timezone: string): number {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = Object.fromEntries(
+    formatter.formatToParts(new Date(nowMs)).map((part) => [part.type, part.value]),
+  );
+  return Number(`${parts.year}${parts.month}${parts.day}`);
+}
+
+function record(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function phaseForWeek(plan: PlanRow, weekIndex: number | null): string | null {
+  if (weekIndex === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(plan.structure_json) as unknown;
+  } catch {
+    return null;
+  }
+  if (!record(parsed) || !Array.isArray(parsed.phases)) return null;
+  let throughWeek = 0;
+  for (const candidate of parsed.phases) {
+    if (!record(candidate)) continue;
+    const duration = candidate.durationWeeks;
+    if (!Number.isSafeInteger(duration) || Number(duration) < 1) continue;
+    throughWeek += Number(duration);
+    if (weekIndex > throughWeek) continue;
+    const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
+    if (name.length > 0) return name;
+    const focus = typeof candidate.focus === "string" ? candidate.focus.trim() : "";
+    return focus.length > 0 ? focus.replaceAll("_", " ") : null;
+  }
+  return null;
+}
+
+function workoutReadModel(row: PlanWorkoutRow): PlanWorkoutReadModel {
+  return {
+    id: row.id,
+    dateKey: row.date_key,
+    sport: row.sport,
+    name: row.name,
+    durationSeconds: row.duration_s,
+    origin: row.origin,
+    navigation: { destination: "plan", focus: "workout", entityId: row.id },
+  };
+}
+
+export function createPlanningReadService(input: PlanningReadServiceInput): PlanningReadService {
+  const plans = createPlanRepository(input.store);
+  const workouts = createPlanWorkoutRepository(input.store);
+  const now = input.now ?? Date.now;
+
+  return {
+    async getPlanningReadModel(request) {
+      GetPlanningReadModelRpcParamsSchema.parse(request);
+      const asOfDateKey = todayInTimezone(now(), input.timezone);
+      const plan = await plans.readCurrent();
+      if (plan === undefined) {
+        return GetPlanningReadModelRpcResultSchema.parse({
+          schemaVersion: 1,
+          status: "no-plan",
+          asOfDateKey,
+          plan: null,
+        });
+      }
+
+      const week = planWeekIndex(plan, asOfDateKey);
+      const currentWeek = week.kind === "inside" ? week.weekIndex : null;
+      const range = currentWeek === null ? null : planWeekRange(plan, currentWeek);
+      const planWorkouts = await workouts.listForPlan(plan.id);
+      const currentWorkouts =
+        range === null
+          ? []
+          : planWorkouts
+              .filter(
+                (workout) =>
+                  workout.date_key >= range.startDateKey && workout.date_key <= range.endDateKey,
+              )
+              .map(workoutReadModel);
+      const todayWorkout = currentWorkouts.find((workout) => workout.dateKey === asOfDateKey) ?? null;
+
+      return GetPlanningReadModelRpcResultSchema.parse({
+        schemaVersion: 1,
+        status: "ready",
+        asOfDateKey,
+        plan: {
+          id: plan.id,
+          name: plan.name,
+          goal: plan.primary_goal,
+          lifecycle: plan.status === "draft" ? "draft" : "active",
+          startDateKey: plan.start_date_key,
+          targetDateKey: plan.target_date_key,
+          currentWeek,
+          totalWeeks: plan.total_weeks,
+          phase: phaseForWeek(plan, currentWeek),
+          weekStartDateKey: range?.startDateKey ?? null,
+          weekEndDateKey: range?.endDateKey ?? null,
+          workouts: currentWorkouts,
+          todayWorkout,
+          navigation: { destination: "plan", focus: "active-plan", entityId: plan.id },
+        },
+      });
+    },
+  };
+}

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -32,6 +32,7 @@ import {
   type CoachDecisionReadModel,
   type CoachEngine,
   type CoachOperations,
+  type PlanningReadOperations,
   type SpendSummary,
   type TelegramControlSnapshot,
   type TurnEvent,
@@ -106,7 +107,7 @@ const completedDecision = {
   },
 } satisfies CoachDecisionReadModel;
 
-const operations: CoachOperations = {
+const operations: CoachOperations & PlanningReadOperations = {
   exportTrainingFile: async () => ({
     status: "exported",
     byteLength: 4_096,
@@ -172,6 +173,12 @@ const operations: CoachOperations = {
     status: "page",
     turns: [],
     nextCursor: null,
+  }),
+  getPlanningReadModel: async () => ({
+    schemaVersion: 1,
+    status: "no-plan",
+    asOfDateKey: 20260826,
+    plan: null,
   }),
   configureRuntime: async ({ llm, intervals, session }) => ({
     schemaVersion: 3,
@@ -806,6 +813,10 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       }),
       operations: {
         ...operations,
+        getPlanningReadModel: async () => {
+          calls.push("getPlanningReadModel");
+          return { schemaVersion: 1, status: "no-plan", asOfDateKey: 20260826, plan: null };
+        },
         exportTrainingFile: async (request, signal) => {
           calls.push("exportTrainingFile");
           return operations.exportTrainingFile!(request, signal);
@@ -891,6 +902,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       },
       { id: 40, method: "retryQueuedTurn", params: { chatId: "chat", claimId: "claim-1" } },
       { id: 4, method: "getAthleteState", params: {} },
+      { id: 41, method: "getPlanningReadModel", params: {} },
       {
         id: 5,
         method: "getActivityAnalysis",
@@ -927,6 +939,7 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       "runQueuedCommand:chat",
       "retryQueuedTurn:chat",
       "getAthleteState",
+      "getPlanningReadModel",
       "getActivityAnalysis",
       "exportTrainingFile",
     ]);

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 26 as const,
-      serverProtocolVersion: 26 as const,
+      clientProtocolVersion: 27 as const,
+      serverProtocolVersion: 27 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -304,7 +304,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(26);
+    expect(PROTOCOL_VERSION).toBe(27);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/coach/tests/planning-read-service.test.ts
+++ b/packages/coach/tests/planning-read-service.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createPlanRepository,
+  createPlanWorkoutRepository,
+  runMigrations,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createPlanningReadService } from "../src/planning-read-service.js";
+
+const PLAN_ID = "01J60HFQ7T0000000000000000";
+const WORKOUT_ID = "01J60HFQ7T0000000000000001";
+const NOW = Date.parse("2026-08-26T12:00:00.000Z");
+
+describe("Planning read service", () => {
+  let store: SqlStore & MigratorStore;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+  });
+
+  afterEach(async () => store.close());
+
+  it("returns an explicit no-Plan state", async () => {
+    await expect(
+      createPlanningReadService({ store, timezone: "UTC", now: () => NOW }).getPlanningReadModel({}),
+    ).resolves.toEqual({ schemaVersion: 1, status: "no-plan", asOfDateKey: 20260826, plan: null });
+  });
+
+  it("projects the current week, Planning-owned phase, and today Workout", async () => {
+    await createPlanRepository(store).upsert({
+      id: PLAN_ID,
+      origin_id: null,
+      name: "Twelve-week base",
+      primary_goal: "Build consistency",
+      start_date_key: 20260824,
+      target_date_key: null,
+      status: "active",
+      kind: "full_plan",
+      total_weeks: 12,
+      week_start_day: 1,
+      structure_json: JSON.stringify({
+        phases: [
+          { name: "Base", durationWeeks: 4 },
+          { name: "Build", durationWeeks: 8 },
+        ],
+      }),
+      created_at_ms: NOW - 1_000,
+      updated_at_ms: NOW,
+      device_id: "desktop",
+      hlc_physical_ms: NOW,
+      hlc_counter: 0,
+    });
+    await createPlanWorkoutRepository(store).upsert({
+      id: WORKOUT_ID,
+      plan_id: PLAN_ID,
+      date_key: 20260826,
+      sport: "cycling",
+      name: "Tempo builder",
+      duration_s: 3_600,
+      structure_json: "{}",
+      origin: "coach",
+      device_id: "desktop",
+      hlc_physical_ms: NOW,
+      hlc_counter: 1,
+    });
+
+    const result = await createPlanningReadService({
+      store,
+      timezone: "UTC",
+      now: () => NOW,
+    }).getPlanningReadModel({});
+
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") throw new TypeError();
+    expect(result.plan).toMatchObject({
+      id: PLAN_ID,
+      currentWeek: 1,
+      totalWeeks: 12,
+      phase: "Base",
+      weekStartDateKey: 20260824,
+      weekEndDateKey: 20260830,
+      todayWorkout: { id: WORKOUT_ID, name: "Tempo builder" },
+    });
+    expect(result.plan.workouts).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add strict Planning-owned active Plan, current-week, and workout read models
- expose the read path through daemon RPC and privileged Desktop IPC
- add the read-only Plan destination, typed Chat return navigation, and Training Context integration
- keep Plan mutation out of Chat

## Verification
- `pnpm check`
- `pnpm test` (10,134 passed; 15 skipped)
- focused Desktop integration tests (85 passed)
- autoreview clean; no accepted/actionable findings

## Integration
Targets `epic/chat-page`. This child PR does not merge the epic into `main`.