### PR TITLE
feat(plan): activate locally and reconcile calendar

### DIFF
--- a/.changeset/plan-activation-reconciliation.md
+++ b/.changeset/plan-activation-reconciliation.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Plan approval now activates locally first, then updates only today and the next six days in Intervals with visible retry and verification controls.
+
+Interrupted calendar updates resume safely after relaunch without duplicating workouts.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -213,6 +213,8 @@ export function bootRenderer(): Disposer {
     closeDatePicker: () => planAdapter.closeDatePicker(),
     recalculateStartDate: (startDate) => planAdapter.recalculateStartDate(startDate),
     approveDraft: () => planAdapter.approveDraft(),
+    reconcilePlan: () => planAdapter.reconcilePlan(),
+    verifyReconciliation: () => planAdapter.verifyReconciliation(),
     returnToCoach: () => planAdapter.returnToCoach(),
     retry: () => planAdapter.retry(),
   });

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -61,6 +61,8 @@ export interface PlanViewAdapter {
   closeDatePicker(): void;
   recalculateStartDate(startDate: string): void;
   approveDraft(): void;
+  reconcilePlan(): void;
+  verifyReconciliation(): void;
   returnToCoach(): void;
   retry(): void;
   dispose(): void;
@@ -131,6 +133,7 @@ export function createPlanViewAdapter(input: {
   let coachDecisionAnswerLabel: string | null = null;
   let coachDecisionError: string | null = null;
   let recoveringDecisionId: string | null = null;
+  let autoResumingPlanId: string | null = null;
   let active: {
     readonly commandId: string;
     readonly transitionId: PlanTransitionId;
@@ -197,7 +200,27 @@ export function createPlanViewAdapter(input: {
 
   const publishHydration = (next: PlanHydrationState): void => {
     input.publishHydration(next);
-    if (next.status === "ready" || next.status === "stale") syncCoach(next.state);
+    if (next.status === "ready" || next.status === "stale") {
+      syncCoach(next.state);
+      if (
+        next.state.scenarioId === "PL-S042" &&
+        next.state.planId !== null &&
+        autoResumingPlanId !== next.state.planId &&
+        active === null
+      ) {
+        const planId = next.state.planId;
+        autoResumingPlanId = planId;
+        queueMicrotask(() => {
+          if (disposed || active !== null) return;
+          void execute({
+            transitionId: "PL-T12",
+            commandId: createCommandId(),
+            planId,
+            mode: "reconcile",
+          });
+        });
+      }
+    }
   };
 
   const refresh = async (showLoading: boolean): Promise<void> => {
@@ -653,6 +676,26 @@ export function createPlanViewAdapter(input: {
         commandId: createCommandId(),
         draftId: data.draft.id,
         expectedRevision: data.draft.revision,
+      });
+    },
+    reconcilePlan() {
+      const model = planReadModel(input.read());
+      if (model?.planId === null || model?.planId === undefined || active !== null) return;
+      void execute({
+        transitionId: "PL-T12",
+        commandId: createCommandId(),
+        planId: model.planId,
+        mode: "reconcile",
+      });
+    },
+    verifyReconciliation() {
+      const model = planReadModel(input.read());
+      if (model?.planId === null || model?.planId === undefined || active !== null) return;
+      void execute({
+        transitionId: "PL-T12",
+        commandId: createCommandId(),
+        planId: model.planId,
+        mode: "verify",
       });
     },
     returnToCoach() {

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -70,6 +70,8 @@ export interface PlanActions {
   closeDatePicker(): void;
   recalculateStartDate(startDate: string): void;
   approveDraft(): void;
+  reconcilePlan(): void;
+  verifyReconciliation(): void;
   returnToCoach(): void;
   retry(): void;
 }

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -1,4 +1,5 @@
 import {
+  Activity,
   CalendarDays,
   CheckCircle2,
   ChevronLeft,
@@ -11,6 +12,7 @@ import {
 import { useEffect, useRef, useState, type FormEvent, type ReactElement } from "react";
 import {
   PLAN_MIN_FULL_DAYS,
+  PlanActiveProjectionDataSchema,
   PlanCoachProjectionDataSchema,
   type PlanDraftPlanProjection,
   type PlanFtpProjection,
@@ -1296,6 +1298,141 @@ function AttentionProjection(): ReactElement {
   );
 }
 
+function ActiveProjection(): ReactElement {
+  const model = useEnduragentStore((state) => planReadModel(state.plan));
+  const transition = useEnduragentStore((state) => state.plan.transition);
+  const actions = useEnduragentStore((state) => state.planActions);
+  if (model === null) return <StatusCard title="Plan" support="Refreshing your Plan…" />;
+  const parsed = PlanActiveProjectionDataSchema.safeParse(model.data);
+  if (!parsed.success) return <StatusCard title={model.title} support={model.summary} />;
+  const data = parsed.data;
+  const reconciling =
+    (transition.status === "submitting" || transition.status === "running") &&
+    transition.transitionId === "PL-T12";
+  const failed = model.reconciliation.status === "failed";
+  const verified = model.reconciliation.status === "verified";
+  const retrying = reconciling && failed;
+  const running = reconciling || model.reconciliation.status === "running";
+  const completed = model.reconciliation.created;
+  const total = model.reconciliation.total;
+  const percent = total === 0 ? 0 : Math.round((completed / total) * 100);
+  const calendarTitle = verified
+    ? `Intervals · current through ${formatCivilDate(model.reconciliation.currentThrough!)}`
+    : retrying
+      ? "Retrying Intervals update"
+      : running
+        ? model.scenarioId === "PL-S042"
+          ? "Resuming Intervals update"
+          : "Updating Intervals"
+        : failed
+          ? model.scenarioId === "PL-S041"
+            ? "Intervals still needs attention"
+            : "Intervals update needs attention"
+          : "Update Intervals for the next seven days";
+  return (
+    <div className="grid gap-6">
+      <section className="grid gap-row rounded-card bg-surface p-5 shadow-elev-1">
+        <div className="flex items-start gap-row">
+          <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-ok" aria-hidden="true" />
+          <div className={SUPPORT_PAIR}>
+            <h2 className="m-0 text-base font-semibold">
+              Plan active · week {data.weekIndex} of {data.plan.totalWeeks}
+            </h2>
+            <p className="m-0 text-ink-2">
+              {data.plan.name} · starts {formatCivilDate(data.plan.startDate)}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-start gap-row border-t border-line pt-row">
+          <Activity className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden="true" />
+          <div className={SUPPORT_PAIR}>
+            <h3 className="m-0 text-base font-semibold">
+              Today · {data.todayWorkout?.name ?? "Rest"}
+            </h3>
+            <p className="m-0 text-ink-2">
+              {data.todayWorkout?.durationS === null || data.todayWorkout === null
+                ? data.todayWorkout === null
+                  ? "No workout scheduled."
+                  : "Follow the workout details in your Plan."
+                : plannedTime(data.todayWorkout.durationS)}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section
+        className="grid gap-row rounded-card bg-surface p-5 shadow-elev-1"
+        aria-live="polite"
+      >
+        <div className="flex items-start gap-row">
+          {failed && !retrying ? (
+            <TriangleAlert className="mt-0.5 size-5 shrink-0 text-warn" aria-hidden="true" />
+          ) : verified ? (
+            <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-ok" aria-hidden="true" />
+          ) : running ? (
+            <LoaderCircle
+              className="mt-0.5 size-5 shrink-0 animate-spin text-primary"
+              aria-hidden="true"
+            />
+          ) : (
+            <CalendarDays className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden="true" />
+          )}
+          <div className={`${SUPPORT_PAIR} min-w-0 flex-1`}>
+            <h2 className="m-0 text-base font-semibold">{calendarTitle}</h2>
+            <p className="m-0 text-ink-2">
+              {total > 0
+                ? `Created ${completed} · Pending ${model.reconciliation.pending} · Failed ${model.reconciliation.failed} · Total ${total}`
+                : "Only today plus the next six civil dates will be written."}
+            </p>
+          </div>
+          {verified ? (
+            <span className="rounded-full border border-ok px-3 py-1 text-sm text-ok">
+              Verified
+            </span>
+          ) : null}
+        </div>
+        {total > 0 ? (
+          <div
+            className="h-2 overflow-hidden rounded-full bg-sunk"
+            role="progressbar"
+            aria-label="Intervals calendar update"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={percent}
+          >
+            <div className="h-full rounded-full bg-primary" style={{ width: `${percent}%` }} />
+          </div>
+        ) : null}
+        {!running && !verified ? (
+          <div className="flex flex-wrap justify-end gap-inset">
+            {failed ? (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={actions === null}
+                onClick={() => actions?.verifyReconciliation()}
+              >
+                Verify again
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              disabled={actions === null}
+              onClick={() => actions?.reconcilePlan()}
+            >
+              {failed
+                ? "Retry"
+                : model.scenarioId === "PL-S037"
+                  ? "View calendar progress"
+                  : "Update Intervals"}
+            </Button>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}
+
 function ReadyProjection(): ReactElement {
   const model = useEnduragentStore((state) => planReadModel(state.plan));
   const transition = useEnduragentStore((state) => state.plan.transition);
@@ -1309,6 +1446,7 @@ function ReadyProjection(): ReactElement {
   if (model.lifecycle === "none" || model.projection === "no-plan") return <NoPlan />;
   if (model.projection === "coach") return <PlanCoach />;
   if (model.projection === "draft") return <DraftProjection />;
+  if (model.projection === "active") return <ActiveProjection />;
   if (model.projection === "attention") return <AttentionProjection />;
   return (
     <StatusCard

--- a/apps/desktop-renderer/tests/plan-adapter.test.ts
+++ b/apps/desktop-renderer/tests/plan-adapter.test.ts
@@ -840,6 +840,66 @@ describe("Plan view adapter", () => {
     });
   });
 
+  it("dispatches retry and provider-only verification for the active Plan", async () => {
+    const state = planReadModel({
+      lifecycle: "active",
+      scenarioId: "PL-S039",
+      projection: "active",
+      planId: "00000000000000000000000003",
+    });
+    const subject = harness({
+      ids: ["retry-command", "verify-command"],
+      getPlanState: async () => ({ status: "ready", state }),
+      executePlanTransition: async () => ({ status: "completed", state }),
+    });
+    subject.adapter.start();
+    await settle();
+
+    subject.adapter.reconcilePlan();
+    await settle();
+    subject.adapter.verifyReconciliation();
+    await settle();
+
+    expect(subject.executePlanTransition).toHaveBeenNthCalledWith(1, {
+      transitionId: "PL-T12",
+      commandId: "retry-command",
+      planId: "00000000000000000000000003",
+      mode: "reconcile",
+    });
+    expect(subject.executePlanTransition).toHaveBeenNthCalledWith(2, {
+      transitionId: "PL-T12",
+      commandId: "verify-command",
+      planId: "00000000000000000000000003",
+      mode: "verify",
+    });
+  });
+
+  it("resumes an interrupted reconciliation once after hydration", async () => {
+    const state = planReadModel({
+      lifecycle: "active",
+      scenarioId: "PL-S042",
+      projection: "active",
+      planId: "00000000000000000000000003",
+    });
+    const subject = harness({
+      ids: ["resume-command"],
+      getPlanState: async () => ({ status: "ready", state }),
+      executePlanTransition: async () => ({ status: "completed", state }),
+    });
+
+    subject.adapter.start();
+    await settle();
+    await settle();
+
+    expect(subject.executePlanTransition).toHaveBeenCalledOnce();
+    expect(subject.executePlanTransition).toHaveBeenCalledWith({
+      transitionId: "PL-T12",
+      commandId: "resume-command",
+      planId: "00000000000000000000000003",
+      mode: "reconcile",
+    });
+  });
+
   it("accepts progress only for the current command, transition, and operation", async () => {
     const state = planReadModel({ lifecycle: "intake", projection: "coach" });
     const subject = harness({

--- a/apps/desktop-renderer/tests/plan-fixtures.ts
+++ b/apps/desktop-renderer/tests/plan-fixtures.ts
@@ -43,6 +43,7 @@ export function planReadModel(
     readonly title?: string;
     readonly summary?: string;
     readonly revision?: number;
+    readonly reconciliation?: PlanReadModel["reconciliation"];
     readonly data?: PlanReadModel["data"];
   } = {},
 ): PlanReadModel {
@@ -56,7 +57,7 @@ export function planReadModel(
     summary: input.summary ?? "",
     projection: input.projection ?? "no-plan",
     transitions: [{ transitionId: "PL-T01", status: "available", reason: null }],
-    reconciliation: {
+    reconciliation: input.reconciliation ?? {
       status: "not-applicable",
       created: 0,
       pending: 0,

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -37,6 +37,8 @@ function actions(): PlanActions {
     closeDatePicker: vi.fn(),
     recalculateStartDate: vi.fn(),
     approveDraft: vi.fn(),
+    reconcilePlan: vi.fn(),
+    verifyReconciliation: vi.fn(),
     returnToCoach: vi.fn(),
     retry: vi.fn(),
   };
@@ -531,6 +533,73 @@ describe("Plan surface", () => {
     expect(planActions.openDatePicker).toHaveBeenCalledOnce();
     await user.click(screen.getByRole("button", { name: "Retry" }));
     expect(planActions.retry).toHaveBeenCalledOnce();
+  });
+
+  it("keeps reconciliation failures inline on the active Plan with retry and verify actions", async () => {
+    const user = userEvent.setup();
+    const planActions = actions();
+    const state = planReadModel({
+      lifecycle: "active",
+      scenarioId: "PL-S039",
+      projection: "active",
+      planId: "00000000000000000000000003",
+      attentionCount: 1,
+      reconciliation: {
+        status: "failed",
+        created: 1,
+        pending: 0,
+        failed: 1,
+        total: 2,
+        currentThrough: null,
+        error: {
+          code: "provider-failed",
+          message: "Some workouts could not be updated in Intervals.",
+          retryable: true,
+        },
+      },
+      data: {
+        plan: {
+          id: "00000000000000000000000003",
+          name: "Gran Fondo Almaty",
+          primaryGoal: "Finish in the front half",
+          startDate: "2026-07-13",
+          targetDate: "2026-10-04",
+          kind: "full-plan",
+          totalWeeks: 12,
+          weekStartDay: 1,
+          workoutCount: 20,
+          plannedDurationS: 72_000,
+        },
+        today: "2026-08-18",
+        weekIndex: 6,
+        todayWorkout: {
+          id: "00000000000000000000000004",
+          date: "2026-08-18",
+          sport: "cycling",
+          name: "Recovery spin",
+          durationS: 2_700,
+        },
+        workouts: [],
+      },
+    });
+    useEnduragentStore.setState({
+      plan: {
+        ...EMPTY_PLAN_SURFACE,
+        hydration: { status: "ready", state },
+        lastReady: state,
+      },
+      planActions,
+    });
+
+    render(<PlanView />);
+
+    expect(screen.getByRole("heading", { name: "Plan active · week 6 of 12" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Today · Recovery spin" })).toBeInTheDocument();
+    expect(screen.getByText("Created 1 · Pending 0 · Failed 1 · Total 2")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    await user.click(screen.getByRole("button", { name: "Verify again" }));
+    expect(planActions.reconcilePlan).toHaveBeenCalledOnce();
+    expect(planActions.verifyReconciliation).toHaveBeenCalledOnce();
   });
 
   it("uses production token classes for wide, compact, Light, and Dark layouts", async () => {

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -103,6 +103,8 @@ function stubPlanActions(): PlanActions {
     closeDatePicker: vi.fn(),
     recalculateStartDate: vi.fn(),
     approveDraft: vi.fn(),
+    reconcilePlan: vi.fn(),
+    verifyReconciliation: vi.fn(),
     returnToCoach: vi.fn(),
     retry: vi.fn(),
   };

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -68,6 +68,8 @@ function stubPlanActions(): PlanActions {
     closeDatePicker: vi.fn(),
     recalculateStartDate: vi.fn(),
     approveDraft: vi.fn(),
+    reconcilePlan: vi.fn(),
+    verifyReconciliation: vi.fn(),
     returnToCoach: vi.fn(),
     retry: vi.fn(),
   };

--- a/packages/coach-contract/src/planning.ts
+++ b/packages/coach-contract/src/planning.ts
@@ -284,6 +284,28 @@ export const PlanDraftPlanProjectionSchema = z
   .strict();
 export type PlanDraftPlanProjection = z.infer<typeof PlanDraftPlanProjectionSchema>;
 
+export const PlanActiveWorkoutProjectionSchema = z
+  .object({
+    id: z.string().min(1),
+    date: TrainingExportCivilDateSchema,
+    sport: z.string().min(1),
+    name: z.string().min(1),
+    durationS: z.number().int().positive().nullable(),
+  })
+  .strict();
+export type PlanActiveWorkoutProjection = z.infer<typeof PlanActiveWorkoutProjectionSchema>;
+
+export const PlanActiveProjectionDataSchema = z
+  .object({
+    plan: PlanDraftPlanProjectionSchema,
+    today: TrainingExportCivilDateSchema,
+    weekIndex: z.number().int().positive(),
+    todayWorkout: PlanActiveWorkoutProjectionSchema.nullable(),
+    workouts: z.array(PlanActiveWorkoutProjectionSchema),
+  })
+  .strict();
+export type PlanActiveProjectionData = z.infer<typeof PlanActiveProjectionDataSchema>;
+
 export const PlanStartDateProjectionSchema = z
   .object({
     status: z.enum(["ready", "invalid", "recalculating", "failed", "updated"]),
@@ -675,6 +697,7 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
       transitionId: z.literal("PL-T12"),
       commandId: CommandIdSchema,
       planId: EntityIdSchema,
+      mode: z.enum(["reconcile", "verify"]).optional(),
     })
     .strict(),
   z

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -152,6 +152,7 @@ import {
 } from "./activity-power-heart-rate.js";
 import { createTrainingExportService } from "./training-export.js";
 import { createPlanningOperations } from "./planning-operations.js";
+import { createPlanMirrorCalendarAdapter } from "./planning-calendar.js";
 import { createNodePlanRaceCourseAdapter } from "./planning-race-course.js";
 import { serializeBoundaryError } from "./daemon/error-boundary.js";
 
@@ -1568,7 +1569,17 @@ export async function createLocalCoachComposition(
         engine: reconfigurable.engine,
         identity: planningIdentity,
       },
-      { ftp, course: createNodePlanRaceCourseAdapter(), todayDateKey: planningDateKey },
+      {
+        ftp,
+        course: createNodePlanRaceCourseAdapter(),
+        todayDateKey: planningDateKey,
+        calendar: createPlanMirrorCalendarAdapter(() => {
+          const intervals = approvedConfig().intervals;
+          return intervals.apiKey.length === 0
+            ? null
+            : makeChatClient({ apiKey: intervals.apiKey, athleteId: intervals.athleteId });
+        }),
+      },
     );
     const operations = {
       ...coachOperations,

--- a/packages/coach/src/planning-calendar.ts
+++ b/packages/coach/src/planning-calendar.ts
@@ -1,0 +1,88 @@
+import type { EventInput, IntervalsClient } from "intervals-icu-api";
+import type { PlanMirrorCalendarPort, PlanMirrorCreateInput } from "@enduragent/engine";
+
+function clientValue<T>(result: { ok: true; value: T } | { ok: false; error: unknown }): T {
+  if (!result.ok) throw new Error("Intervals calendar request failed.", { cause: result.error });
+  return result.value;
+}
+
+function dateText(dateKey: number): string {
+  const value = String(dateKey).padStart(8, "0");
+  return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+}
+
+function dateKey(value: string): number {
+  const parsed = Number(value.slice(0, 10).replaceAll("-", ""));
+  if (!Number.isSafeInteger(parsed)) throw new TypeError("Intervals returned an invalid date.");
+  return parsed;
+}
+
+function eventType(sport: string): NonNullable<EventInput["type"]> {
+  const normalized = sport.toLowerCase();
+  if (normalized.includes("cycl") || normalized.includes("bike")) return "Ride";
+  if (normalized.includes("run")) return "Run";
+  if (normalized.includes("swim")) return "Swim";
+  return "Workout";
+}
+
+function eventContent(
+  input: PlanMirrorCreateInput,
+): Pick<EventInput, "description" | "workoutDoc"> {
+  try {
+    const value = JSON.parse(input.structureJson) as Record<string, unknown>;
+    return {
+      ...(typeof value.description === "string" ? { description: value.description } : {}),
+      ...(typeof value.workoutDoc === "object" && value.workoutDoc !== null
+        ? { workoutDoc: value.workoutDoc as NonNullable<EventInput["workoutDoc"]> }
+        : {}),
+    };
+  } catch {
+    return {};
+  }
+}
+
+export function createPlanMirrorCalendarAdapter(
+  readClient: () => IntervalsClient | null,
+): PlanMirrorCalendarPort {
+  const requiredClient = (): IntervalsClient => {
+    const client = readClient();
+    if (client === null) throw new Error("Intervals credentials are required.");
+    return client;
+  };
+  const adapter: PlanMirrorCalendarPort = {
+    async listEvents(input) {
+      const events = clientValue(
+        await requiredClient().events.list({
+          oldest: dateText(input.startDateKey),
+          newest: dateText(input.endDateKey),
+          category: ["WORKOUT"],
+        }),
+      );
+      return events.map((event) => ({
+        id: event.id,
+        dateKey: dateKey(event.startDateLocal),
+        externalId: event.uid ?? null,
+      }));
+    },
+    async createEvent(input) {
+      return clientValue(
+        await requiredClient().events.create(
+          {
+            startDateLocal: `${dateText(input.dateKey)}T00:00:00`,
+            category: "WORKOUT",
+            name: input.name,
+            type: eventType(input.sport),
+            uid: input.externalId,
+            ...(input.durationS === null ? {} : { movingTime: input.durationS }),
+            ...eventContent(input),
+          },
+          { upsertOnUid: true },
+        ),
+      );
+    },
+    async deleteEvent(input) {
+      return clientValue(await requiredClient().events.delete(input.eventId));
+    },
+  };
+  return Object.freeze(adapter);
+}

--- a/packages/coach/src/planning-lifecycle.ts
+++ b/packages/coach/src/planning-lifecycle.ts
@@ -1,9 +1,11 @@
 import {
+  PlanActiveProjectionDataSchema,
   PlanCoachProjectionDataSchema,
   PlanReadModelSchema,
   type ChatQueueSnapshot,
   type CoachDecisionReadModel,
   type PlanAttention,
+  type PlanActiveProjectionData,
   type PlanCoachMessage,
   type PlanDraftProjection,
   type PlanDraftPlanProjection,
@@ -12,10 +14,21 @@ import {
   type PlanProjectionKind,
   type PlanRaceCourseProjection,
   type PlanStartDateProjection,
+  type PlanReconciliation,
   type PlanReadModel,
   type PlanScenarioId,
   type PlanTransitionGuard,
 } from "@enduragent/coach-contract";
+
+export type ActivePlanScenario =
+  | "PL-S010"
+  | "PL-S037"
+  | "PL-S038"
+  | "PL-S039"
+  | "PL-S040"
+  | "PL-S041"
+  | "PL-S042"
+  | "PL-S043";
 
 export interface PlanConversationProjection {
   readonly id: string;
@@ -311,5 +324,55 @@ export function buildPlanLifecycleReadModel(
     attention: EMPTY_ATTENTION,
     activeOperation: null,
     data,
+  });
+}
+
+export function buildActivePlanReadModel(input: {
+  readonly scenarioId: ActivePlanScenario;
+  readonly planId: string;
+  readonly revision: number;
+  readonly data: PlanActiveProjectionData;
+  readonly reconciliation: PlanReconciliation;
+}): PlanReadModel {
+  const copy = {
+    "PL-S010": ["Plan active", "Calendar update has not started."],
+    "PL-S037": ["Plan active locally", "Intervals is ready to update."],
+    "PL-S038": ["Updating Intervals", "Writing today plus the next six days."],
+    "PL-S039": ["Calendar update needs attention", "Some workouts could not be written."],
+    "PL-S040": ["Retrying calendar update", "Only unresolved workouts are being checked."],
+    "PL-S041": ["Calendar update still needs attention", "Retry or verify the provider again."],
+    "PL-S042": ["Resuming calendar update", "The interrupted update is continuing safely."],
+    "PL-S043": ["Plan active", "Intervals is current for the next seven days."],
+  } as const;
+  const athleteAction = input.scenarioId === "PL-S039" || input.scenarioId === "PL-S041";
+  const attention: PlanAttention = athleteAction
+    ? {
+        count: 1,
+        destination: "direct",
+        items: [
+          {
+            id: `reconciliation:${input.planId}`,
+            title: "Calendar update needs attention",
+            scenarioId: input.scenarioId,
+            priority: "dated",
+            affectedDate: input.data.today,
+          },
+        ],
+      }
+    : EMPTY_ATTENTION;
+  return PlanReadModelSchema.parse({
+    schemaVersion: 1,
+    scenarioId: input.scenarioId,
+    lifecycle: "active",
+    planId: input.planId,
+    revision: input.revision,
+    title: copy[input.scenarioId][0],
+    summary: copy[input.scenarioId][1],
+    projection: "active",
+    transitions: [guard("PL-T12")],
+    reconciliation: input.reconciliation,
+    attention,
+    activeOperation: null,
+    data: PlanActiveProjectionDataSchema.parse(input.data),
   });
 }

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -4,6 +4,7 @@ import {
   GetPlanStateRpcParamsSchema,
   GetPlanStateRpcResultSchema,
   PlanDraftPlanProjectionSchema,
+  PlanActiveProjectionDataSchema,
   PlanDraftProjectionSchema,
   PlanFtpProjectionSchema,
   PlanRaceCourseProjectionSchema,
@@ -15,6 +16,7 @@ import {
   type ExecutePlanTransitionRpcParams,
   type ExecutePlanTransitionRpcResult,
   type PlanDraftProjection,
+  type PlanActiveProjectionData,
   type PlanDraftPlanProjection,
   type PlanError,
   type PlanFtpProjection,
@@ -27,6 +29,7 @@ import {
   type TurnEvent,
 } from "@enduragent/coach-contract";
 import {
+  activatePlanDraft,
   acceptParsedRaceCourse,
   beginRaceCourseParsing,
   beginRaceCourseRemoval,
@@ -35,22 +38,36 @@ import {
   failRaceCourseRecalculation,
   openRaceCoursePicker,
   previewPlanStartDate,
+  projectPlanReconciliation,
+  reconcileActivePlanWindow,
   rejectRaceCourseFile,
   useRouteWithoutElevation,
+  verifyPlanMirror,
+  type PlanMirrorCalendarPort,
+  type PlanReconciliationProjection,
   type PlanFtpAdapter,
   type PlanFtpSnapshot,
   type PlanStartDatePreview,
   type RaceCourseRecalculatingState,
 } from "@enduragent/engine";
-import { buildPlanLifecycleReadModel } from "./planning-lifecycle.js";
 import {
+  buildActivePlanReadModel,
+  buildPlanLifecycleReadModel,
+  type ActivePlanScenario,
+} from "./planning-lifecycle.js";
+import {
+  addCivilDays,
   createPlanConversationRepository,
+  createPlanReconciliationRepository,
   createPlanRepository,
+  planWeekIndex,
+  PlanConversationValidationError,
   type PlanConversationRecord,
   type PlanConversationRepository,
   type PlanConversationTurnRecord,
   type PlanDraftRevisionRecord,
   type PlanRecord,
+  type PlanReconciliationRepository,
   type PlanRepository,
   type PlanWorkoutRecord,
   parseRaceCourseSnapshot,
@@ -120,6 +137,24 @@ const START_DATE_RECALCULATION_FAILED: PlanError = Object.freeze({
   retryable: true,
 });
 
+const CALENDAR_UPDATE_FAILED: PlanError = Object.freeze({
+  code: "provider-failed",
+  message: "Some workouts could not be updated in Intervals.",
+  retryable: true,
+});
+
+const CALENDAR_VERIFICATION_FAILED: PlanError = Object.freeze({
+  code: "verification-failed",
+  message: "Intervals does not match the active Plan yet.",
+  retryable: true,
+});
+
+const DRAFT_STALE: PlanError = Object.freeze({
+  code: "stale-base",
+  message: "This Draft changed before approval. Review the latest Draft.",
+  retryable: false,
+});
+
 export interface PlanDraftBuild {
   readonly plan: PlanRecord;
   readonly workouts: readonly PlanWorkoutRecord[];
@@ -167,6 +202,8 @@ export interface CreatePlanningOperationsDependencies {
   readonly isReady?: (input: PlanReadinessInput) => boolean | Promise<boolean>;
   readonly ftp?: PlanFtpAdapter;
   readonly course?: PlanRaceCourseAdapter;
+  readonly reconciliations?: PlanReconciliationRepository;
+  readonly calendar?: PlanMirrorCalendarPort;
   readonly todayDateKey?: () => number;
 }
 
@@ -257,6 +294,51 @@ function startDateProjection(input: {
       error: input.error ?? START_DATE_INVALID,
     });
   }
+}
+
+function activePlanData(input: {
+  readonly plan: PlanRecord;
+  readonly workouts: readonly PlanWorkoutRecord[];
+  readonly todayDateKey: number;
+}): PlanActiveProjectionData {
+  const plan = draftPlanProjection(input.plan, input.workouts);
+  if (plan === null) throw new TypeError("An active Plan projection requires a Plan.");
+  const week = planWeekIndex(input.plan, input.todayDateKey);
+  const weekIndex =
+    week.kind === "inside" ? week.weekIndex : week.side === "before" ? 1 : input.plan.totalWeeks;
+  const windowEndDateKey = addCivilDays(input.todayDateKey, 6);
+  const workouts = input.workouts
+    .filter(
+      (workout) => workout.dateKey >= input.todayDateKey && workout.dateKey <= windowEndDateKey,
+    )
+    .map((workout) => ({
+      id: workout.id,
+      date: dateText(workout.dateKey),
+      sport: workout.sport,
+      name: workout.name,
+      durationS: workout.durationS,
+    }));
+  return PlanActiveProjectionDataSchema.parse({
+    plan,
+    today: dateText(input.todayDateKey),
+    weekIndex,
+    todayWorkout: workouts.find((workout) => workout.date === dateText(input.todayDateKey)) ?? null,
+    workouts,
+  });
+}
+
+function activeScenario(
+  projection: PlanReconciliationProjection | null,
+  override: ActivePlanScenario | undefined,
+): ActivePlanScenario {
+  if (override !== undefined) return override;
+  if (projection === null) return "PL-S010";
+  if (projection.job.status === "pending") return "PL-S037";
+  if (projection.job.status === "verified") return "PL-S043";
+  if (projection.job.status === "running" || projection.job.status === "retrying") {
+    return "PL-S042";
+  }
+  return projection.job.failureCount > 1 ? "PL-S041" : "PL-S039";
 }
 
 function draftProjection(value: PlanDraftRevisionRecord | undefined): PlanDraftProjection | null {
@@ -395,6 +477,7 @@ interface ReadOverrides {
   readonly course?: PlanRaceCourseProjection;
   readonly dateScenario?: "PL-S046" | "PL-S048" | "PL-S050";
   readonly startDate?: PlanStartDateProjection;
+  readonly activeScenario?: ActivePlanScenario;
 }
 
 function queueText(queue: ChatQueueSnapshot): string {
@@ -426,11 +509,60 @@ export function createPlanningOperations(
   const conversations =
     dependencies.conversations ?? createPlanConversationRepository(input.context.store);
   const plans = dependencies.plans ?? createPlanRepository(input.context.store);
+  const reconciliations =
+    dependencies.reconciliations ?? createPlanReconciliationRepository(input.context.store);
   const enqueue = createSerializedLane();
+
+  const readActive = async (
+    plan: PlanRecord,
+    revision: number,
+    overrides: ReadOverrides,
+  ): Promise<PlanReadModel> => {
+    const todayDateKey = dependencies.todayDateKey?.() ?? utcTodayDateKey();
+    const [workouts, job] = await Promise.all([
+      plans.readWorkouts(plan.id),
+      reconciliations.readLatestJob(plan.id, "mirror"),
+    ]);
+    const projection =
+      job === undefined ? null : await projectPlanReconciliation(reconciliations, job);
+    const scenarioId = activeScenario(projection, overrides.activeScenario);
+    const status =
+      projection === null || projection.job.status === "pending"
+        ? "not-started"
+        : projection.job.status === "verified"
+          ? "verified"
+          : projection.job.status === "failed"
+            ? "failed"
+            : "running";
+    const verificationFailure = projection?.job.lastErrorCode === "calendar-verification-failed";
+    return buildActivePlanReadModel({
+      scenarioId,
+      planId: plan.id,
+      revision,
+      data: activePlanData({ plan, workouts, todayDateKey }),
+      reconciliation: {
+        status,
+        created: projection?.created ?? 0,
+        pending: projection?.pending ?? 0,
+        failed: projection?.failed ?? 0,
+        total: projection?.total ?? 0,
+        currentThrough:
+          projection?.job.status === "verified" ? dateText(projection.job.windowEndDateKey) : null,
+        error:
+          status === "failed"
+            ? verificationFailure
+              ? CALENDAR_VERIFICATION_FAILED
+              : CALENDAR_UPDATE_FAILED
+            : null,
+      },
+    });
+  };
 
   const read = async (overrides: ReadOverrides = {}): Promise<PlanReadModel> => {
     const conversation = await conversations.readLatestOpenConversation();
     if (conversation === undefined) {
+      const latestPlan = await plans.readLatest();
+      if (latestPlan?.status === "active") return readActive(latestPlan, 0, overrides);
       return buildPlanLifecycleReadModel({
         conversation: null,
         turns: [],
@@ -451,8 +583,12 @@ export function createPlanningOperations(
         .catch(() => null),
       dependencies.ftp?.read(),
     ]);
-    const draftPlan = draft === undefined ? undefined : await plans.read(draft.planId);
+    const projectedPlanId = draft?.planId ?? conversation.planId;
+    const draftPlan = projectedPlanId === null ? undefined : await plans.read(projectedPlanId);
     const draftWorkouts = draftPlan === undefined ? [] : await plans.readWorkouts(draftPlan.id);
+    if (draftPlan?.status === "active") {
+      return readActive(draftPlan, draft?.revision ?? 0, overrides);
+    }
     const todayDateKey = dependencies.todayDateKey?.() ?? utcTodayDateKey();
     const projectedStartDate =
       overrides.startDate ??
@@ -1268,6 +1404,140 @@ export function createPlanningOperations(
             });
           } catch {
             return reject(PERSISTENCE_FAILED);
+          }
+        }
+        if (command.transitionId === "PL-T11") {
+          const operationId = input.identity.newUlid();
+          deliver(onEvent, {
+            commandId: command.commandId,
+            transitionId: command.transitionId,
+            operationId,
+            phase: "running",
+            completed: 0,
+            total: 1,
+          });
+          try {
+            const activation = await activatePlanDraft(
+              {
+                draftRevisionId: command.draftId,
+                expectedRevision: command.expectedRevision,
+              },
+              { drafts: conversations, identity: input.identity },
+            );
+            const plan = await plans.read(activation.planId);
+            if (plan === undefined || plan.status !== "active")
+              throw new Error("Plan activation failed.");
+            const todayDateKey = dependencies.todayDateKey?.() ?? utcTodayDateKey();
+            const stamp = input.identity.hlcStamp();
+            await reconciliations
+              .createOrGetJob({
+                id: input.identity.newUlid(),
+                planId: plan.id,
+                kind: "mirror",
+                windowStartDateKey: todayDateKey,
+                windowEndDateKey: addCivilDays(todayDateKey, 6),
+                createdAtMs: stamp.physicalMs,
+              })
+              .catch(() => undefined);
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "completed",
+              completed: 1,
+              total: 1,
+            });
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read(),
+            });
+          } catch (error) {
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "failed",
+              completed: 0,
+              total: 1,
+            });
+            return reject(
+              error instanceof PlanConversationValidationError &&
+                (error.code === "stale-draft" || error.code === "plan-not-draft")
+                ? DRAFT_STALE
+                : PERSISTENCE_FAILED,
+            );
+          }
+        }
+        if (command.transitionId === "PL-T12") {
+          if (dependencies.calendar === undefined) return reject(UNAVAILABLE);
+          const plan = await plans.read(command.planId);
+          if (plan === undefined || plan.status !== "active") return reject(UNAVAILABLE);
+          const todayDateKey = dependencies.todayDateKey?.() ?? utcTodayDateKey();
+          const workouts = await plans.readWorkouts(plan.id);
+          const existingJob = await reconciliations.readLatestJob(plan.id, "mirror");
+          const existingItems =
+            existingJob === undefined ? [] : await reconciliations.readItems(existingJob.id);
+          const total = Math.max(existingItems.length, 1);
+          const operationId = input.identity.newUlid();
+          deliver(onEvent, {
+            commandId: command.commandId,
+            transitionId: command.transitionId,
+            operationId,
+            phase: "running",
+            completed: 0,
+            total,
+          });
+          try {
+            const reconcilerDependencies = {
+              repository: reconciliations,
+              calendar: dependencies.calendar,
+              identity: { newId: () => input.identity.newUlid() },
+              now: () => input.identity.hlcStamp().physicalMs,
+            };
+            const result =
+              command.mode === "verify" && existingJob !== undefined && existingItems.length > 0
+                ? await verifyPlanMirror(existingJob, reconcilerDependencies)
+                : await reconcileActivePlanWindow(
+                    { plan, workouts, todayDateKey },
+                    reconcilerDependencies,
+                  );
+            if (result.job.status === "failed") {
+              deliver(onEvent, {
+                commandId: command.commandId,
+                transitionId: command.transitionId,
+                operationId,
+                phase: "failed",
+                completed: Math.min(result.created, Math.max(result.total, 1)),
+                total: Math.max(result.total, 1),
+              });
+              const error =
+                result.job.lastErrorCode === "calendar-verification-failed"
+                  ? CALENDAR_VERIFICATION_FAILED
+                  : CALENDAR_UPDATE_FAILED;
+              return reject(error);
+            }
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "completed",
+              completed: Math.max(result.total, 1),
+              total: Math.max(result.total, 1),
+            });
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read(),
+            });
+          } catch {
+            deliver(onEvent, {
+              commandId: command.commandId,
+              transitionId: command.transitionId,
+              operationId,
+              phase: "failed",
+              completed: 0,
+              total,
+            });
+            return reject(CALENDAR_UPDATE_FAILED);
           }
         }
         return reject(UNAVAILABLE);

--- a/packages/coach/tests/planning-calendar.test.ts
+++ b/packages/coach/tests/planning-calendar.test.ts
@@ -1,0 +1,75 @@
+import type { IntervalsClient } from "intervals-icu-api";
+import { describe, expect, it, vi } from "vitest";
+import { createPlanMirrorCalendarAdapter } from "../src/planning-calendar.js";
+
+describe("Plan Intervals calendar adapter", () => {
+  it("uses provider UIDs as durable Plan workout identities", async () => {
+    const list = vi.fn(async () => ({
+      ok: true as const,
+      value: [
+        {
+          id: 42,
+          startDateLocal: "2026-08-25T00:00:00",
+          category: "WORKOUT",
+          uid: "cycling-coach:plan:plan:workout",
+        },
+      ],
+    }));
+    const create = vi.fn(async (body: unknown) => ({
+      ok: true as const,
+      value: { id: 43, ...(body as object) },
+    }));
+    const remove = vi.fn(async () => ({ ok: true as const, value: {} }));
+    const client = {
+      events: { list, create, delete: remove },
+    } as unknown as IntervalsClient;
+    const calendar = createPlanMirrorCalendarAdapter(() => client);
+
+    await expect(
+      calendar.listEvents({ startDateKey: 20260825, endDateKey: 20260831 }),
+    ).resolves.toEqual([
+      {
+        id: 42,
+        dateKey: 20260825,
+        externalId: "cycling-coach:plan:plan:workout",
+      },
+    ]);
+    await calendar.createEvent({
+      planId: "00000000000000000000000001",
+      planWorkoutId: "00000000000000000000000002",
+      dateKey: 20260826,
+      externalId: "cycling-coach:plan:plan:workout-2",
+      name: "Threshold 4×8",
+      sport: "cycling",
+      durationS: 4_800,
+      structureJson: JSON.stringify({ description: "Four threshold efforts." }),
+    });
+    await calendar.deleteEvent({ eventId: 42 });
+
+    expect(list).toHaveBeenCalledWith({
+      oldest: "2026-08-25",
+      newest: "2026-08-31",
+      category: ["WORKOUT"],
+    });
+    expect(create).toHaveBeenCalledWith(
+      {
+        startDateLocal: "2026-08-26T00:00:00",
+        category: "WORKOUT",
+        name: "Threshold 4×8",
+        type: "Ride",
+        uid: "cycling-coach:plan:plan:workout-2",
+        movingTime: 4_800,
+        description: "Four threshold efforts.",
+      },
+      { upsertOnUid: true },
+    );
+    expect(remove).toHaveBeenCalledWith(42);
+  });
+
+  it("fails closed when Intervals credentials are absent", async () => {
+    const calendar = createPlanMirrorCalendarAdapter(() => null);
+    await expect(
+      calendar.listEvents({ startDateKey: 20260825, endDateKey: 20260831 }),
+    ).rejects.toThrow("Intervals credentials are required");
+  });
+});

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -7,16 +7,18 @@ import type {
 } from "@enduragent/coach-contract";
 import {
   createPlanConversationRepository,
+  createPlanReconciliationRepository,
   createPlanRepository,
   createRaceCourseSnapshot,
   type PlanRecord,
+  type PlanWorkoutRecord,
   type RaceCourseSnapshot,
 } from "@enduragent/kernel/planning";
 import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
-import type { PlanFtpAdapter, PlanFtpSnapshot } from "@enduragent/engine";
+import type { PlanFtpAdapter, PlanFtpSnapshot, PlanMirrorCalendarPort } from "@enduragent/engine";
 import { createPlanningOperations, type PlanDraftBuilder } from "../src/planning-operations.js";
 import type { PlanRaceCourseAdapter } from "../src/planning-race-course.js";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
@@ -77,6 +79,38 @@ function plan(id: string, timestamp: number): PlanRecord {
     deviceId: "device-1",
     hlcPhysicalMs: timestamp,
     hlcCounter: 0,
+  };
+}
+
+function activationBuilder(): PlanDraftBuilder {
+  const planId = `${"0".repeat(25)}W`;
+  const workouts: PlanWorkoutRecord[] = [
+    ["X", 20260709],
+    ["Y", 20260715],
+    ["Z", 20260716],
+  ].map(([suffix, dateKey]) => ({
+    id: `${"0".repeat(25)}${suffix}`,
+    planId,
+    dateKey: dateKey as number,
+    sport: "cycling",
+    name: `Workout ${suffix}`,
+    durationS: 3_600,
+    structureJson: "{}",
+    origin: "coach",
+    deviceId: "device-1",
+    hlcPhysicalMs: 41,
+    hlcCounter: 0,
+  }));
+  return {
+    async form() {
+      return { plan: plan(planId, 40), workouts, snapshot: { weeks: 12 } };
+    },
+    async revise() {
+      return { plan: plan(planId, 40), workouts, snapshot: { weeks: 12 } };
+    },
+    async recalculateCourse() {
+      return { plan: plan(planId, 40), workouts, snapshot: { weeks: 12 } };
+    },
   };
 }
 
@@ -813,6 +847,179 @@ describe("Plan operations", () => {
     await expect(
       createPlanConversationRepository(store).readLatestDraftRevision(conversationId),
     ).resolves.toMatchObject({ revision: 2 });
+  });
+
+  it("activates locally before an idempotent seven-day Intervals reconciliation", async () => {
+    const events: Array<{ id: number; dateKey: number; externalId: string | null }> = [];
+    let createFailures = 1;
+    const calendar: PlanMirrorCalendarPort = {
+      async listEvents({ startDateKey, endDateKey }) {
+        return events.filter(
+          (event) => event.dateKey >= startDateKey && event.dateKey <= endDateKey,
+        );
+      },
+      async createEvent(value) {
+        if (createFailures > 0) {
+          createFailures -= 1;
+          throw new Error("provider failed");
+        }
+        events.push({
+          id: events.length + 1,
+          dateKey: value.dateKey,
+          externalId: value.externalId,
+        });
+      },
+      async deleteEvent({ eventId }) {
+        const index = events.findIndex((event) => event.id === eventId);
+        if (index >= 0) events.splice(index, 1);
+      },
+    };
+    const authored = identity();
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: authored },
+      {
+        draftBuilder: activationBuilder(),
+        isReady: () => true,
+        todayDateKey: () => 20260709,
+        calendar,
+      },
+    );
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+    await operations.executePlanTransition?.({
+      transitionId: "PL-T03",
+      commandId: "command-2",
+      conversationId,
+    });
+    const formed = await operations.executePlanTransition?.({
+      transitionId: "PL-T06",
+      commandId: "command-3",
+      conversationId,
+    });
+    if (formed?.status !== "completed") throw new TypeError("Draft did not form.");
+    const draft = formed.state.data.draft as { id: string; revision: number };
+
+    const activated = await operations.executePlanTransition?.({
+      transitionId: "PL-T11",
+      commandId: "command-4",
+      draftId: draft.id,
+      expectedRevision: draft.revision,
+    });
+    expect(activated).toMatchObject({
+      status: "completed",
+      state: {
+        lifecycle: "active",
+        projection: "active",
+        scenarioId: "PL-S037",
+        reconciliation: { status: "not-started" },
+      },
+    });
+    await expect(createPlanRepository(store).read(`${"0".repeat(25)}W`)).resolves.toMatchObject({
+      status: "active",
+    });
+    await expect(
+      createPlanConversationRepository(store).readDraftRevision(draft.id),
+    ).resolves.toMatchObject({ status: "approved" });
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T12",
+        commandId: "command-5",
+        planId: `${"0".repeat(25)}W`,
+        mode: "reconcile",
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      state: {
+        lifecycle: "active",
+        scenarioId: "PL-S039",
+        attention: { count: 1, destination: "direct" },
+      },
+    });
+    const reconciled = await operations.executePlanTransition?.({
+      transitionId: "PL-T12",
+      commandId: "command-6",
+      planId: `${"0".repeat(25)}W`,
+      mode: "reconcile",
+    });
+    expect(reconciled).toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S043",
+        reconciliation: { status: "verified", created: 2, total: 2 },
+        attention: { count: 0 },
+      },
+    });
+    expect(events).toHaveLength(2);
+    expect(events.map((event) => event.dateKey).sort()).toEqual([20260709, 20260715]);
+
+    const restored = createPlanningOperations(
+      { context, engine: engine(), identity: authored },
+      { todayDateKey: () => 20260709, calendar },
+    );
+    await expect(restored.getPlanState?.({})).resolves.toMatchObject({
+      status: "ready",
+      state: { scenarioId: "PL-S043", lifecycle: "active" },
+    });
+  });
+
+  it("hydrates an interrupted reconciliation as crash-resume work without attention", async () => {
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: identity() },
+      {
+        draftBuilder: activationBuilder(),
+        isReady: () => true,
+        todayDateKey: () => 20260709,
+        calendar: {
+          listEvents: async () => [],
+          createEvent: async () => {},
+          deleteEvent: async () => {},
+        },
+      },
+    );
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-1",
+      sourceConversationId: null,
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+    await operations.executePlanTransition?.({
+      transitionId: "PL-T03",
+      commandId: "command-2",
+      conversationId,
+    });
+    const formed = await operations.executePlanTransition?.({
+      transitionId: "PL-T06",
+      commandId: "command-3",
+      conversationId,
+    });
+    if (formed?.status !== "completed") throw new TypeError("Draft did not form.");
+    const draft = formed.state.data.draft as { id: string; revision: number };
+    await operations.executePlanTransition?.({
+      transitionId: "PL-T11",
+      commandId: "command-4",
+      draftId: draft.id,
+      expectedRevision: draft.revision,
+    });
+    const repository = createPlanReconciliationRepository(store);
+    const job = await repository.readLatestJob(`${"0".repeat(25)}W`, "mirror");
+    if (job === undefined) throw new TypeError("Reconciliation job missing.");
+    await repository.beginAttempt(job.id, job.updatedAtMs + 1);
+
+    await expect(operations.getPlanState?.({})).resolves.toMatchObject({
+      status: "ready",
+      state: {
+        scenarioId: "PL-S042",
+        reconciliation: { status: "running" },
+        attention: { count: 0 },
+      },
+    });
   });
 
   it("retries an interrupted Plan queue claim and persists the recovered turn", async () => {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -252,6 +252,7 @@ export {
   planMirrorExternalIdPrefix,
   projectPlanReconciliation,
   reconcileActivePlanWindow,
+  verifyPlanMirror,
   type PlanMirrorCalendarPort,
   type PlanMirrorCreateInput,
   type PlanMirrorEvent,
@@ -260,6 +261,11 @@ export {
   type PlanReconcilerDeps,
   type PlanReconcilerIdentity,
 } from "./planning/reconciler.js";
+export {
+  activatePlanDraft,
+  type ActivatePlanDraftInput,
+  type PlanActivationIdentity,
+} from "./planning/activation.js";
 export {
   RaceCourseLifecycleError,
   acceptParsedRaceCourse,

--- a/packages/engine/src/planning/activation.ts
+++ b/packages/engine/src/planning/activation.ts
@@ -1,0 +1,32 @@
+import type {
+  ApprovePlanDraftResult,
+  PlanConversationRepository,
+} from "@enduragent/kernel/planning";
+
+export interface ActivatePlanDraftInput {
+  readonly draftRevisionId: string;
+  readonly expectedRevision: number;
+}
+
+export interface PlanActivationIdentity {
+  deviceId(): Promise<string>;
+  hlcStamp(): { readonly physicalMs: number; readonly counter: number };
+}
+
+export async function activatePlanDraft(
+  input: ActivatePlanDraftInput,
+  dependencies: {
+    readonly drafts: PlanConversationRepository;
+    readonly identity: PlanActivationIdentity;
+  },
+): Promise<ApprovePlanDraftResult> {
+  const stamp = dependencies.identity.hlcStamp();
+  return dependencies.drafts.approveDraft({
+    draftRevisionId: input.draftRevisionId,
+    expectedRevision: input.expectedRevision,
+    updatedAtMs: stamp.physicalMs,
+    deviceId: await dependencies.identity.deviceId(),
+    hlcPhysicalMs: stamp.physicalMs,
+    hlcCounter: stamp.counter,
+  });
+}

--- a/packages/engine/src/planning/reconciler.ts
+++ b/packages/engine/src/planning/reconciler.ts
@@ -68,7 +68,7 @@ export interface PlanReconciliationProjection {
 }
 
 export class PlanReconciliationError extends Error {
-  readonly code: "plan-not-active" | "invalid-workout" | "invalid-provider-event";
+  readonly code: "plan-not-active" | "invalid-workout" | "invalid-provider-event" | "missing-job";
 
   constructor(code: PlanReconciliationError["code"]) {
     super(`plan reconciliation failed: ${code}`);
@@ -93,10 +93,10 @@ function groupedEvents(events: readonly PlanMirrorEvent[]): Map<string, PlanMirr
   const grouped = new Map<string, PlanMirrorEvent[]>();
   for (const event of events) {
     if (
-      !Number.isSafeInteger(event.id)
-      || event.id <= 0
-      || !Number.isSafeInteger(event.dateKey)
-      || (event.externalId !== null && typeof event.externalId !== "string")
+      !Number.isSafeInteger(event.id) ||
+      event.id <= 0 ||
+      !Number.isSafeInteger(event.dateKey) ||
+      (event.externalId !== null && typeof event.externalId !== "string")
     ) {
       throw new PlanReconciliationError("invalid-provider-event");
     }
@@ -108,10 +108,9 @@ function groupedEvents(events: readonly PlanMirrorEvent[]): Map<string, PlanMirr
   return grouped;
 }
 
-function itemError(operation: PlanReconciliationItemRecord["operation"]): Exclude<
-  PlanReconciliationErrorCode,
-  "calendar-list-failed"
-> {
+function itemError(
+  operation: PlanReconciliationItemRecord["operation"],
+): Exclude<PlanReconciliationErrorCode, "calendar-list-failed"> {
   return operation === "create" ? "calendar-create-failed" : "calendar-delete-failed";
 }
 
@@ -130,7 +129,9 @@ export async function projectPlanReconciliation(
   job: PlanReconciliationJobRecord,
 ): Promise<PlanReconciliationProjection> {
   const items = await repository.readItems(job.id);
-  const created = items.filter((item) => item.status === "created" || item.status === "verified").length;
+  const created = items.filter(
+    (item) => item.status === "created" || item.status === "verified",
+  ).length;
   const failed = items.filter((item) => item.status === "failed").length;
   const pending = items.length - created - failed;
   return Object.freeze({
@@ -189,20 +190,19 @@ async function verifyCreateItems(
     if (matches.length === 1) {
       await deps.repository.verifyItem(item.id, matches[0]!.id, deps.now());
     } else {
-      await deps.repository.failItem(
-        item.id,
-        "calendar-verification-failed",
-        deps.now(),
-      );
+      await deps.repository.failItem(item.id, "calendar-verification-failed", deps.now());
     }
   }
 }
 
-export async function reconcileActivePlanWindow(input: {
-  readonly plan: PlanRecord;
-  readonly workouts: readonly PlanWorkoutRecord[];
-  readonly todayDateKey: number;
-}, deps: PlanReconcilerDeps): Promise<PlanReconciliationProjection> {
+export async function reconcileActivePlanWindow(
+  input: {
+    readonly plan: PlanRecord;
+    readonly workouts: readonly PlanWorkoutRecord[];
+    readonly todayDateKey: number;
+  },
+  deps: PlanReconcilerDeps,
+): Promise<PlanReconciliationProjection> {
   if (input.plan.status !== "active") throw new PlanReconciliationError("plan-not-active");
   const windowEndDateKey = addCivilDays(input.todayDateKey, PLAN_MIRROR_DAYS - 1);
   const now = deps.now();
@@ -216,9 +216,11 @@ export async function reconcileActivePlanWindow(input: {
   });
   const selected = input.workouts.filter((workout) => {
     if (workout.planId !== input.plan.id) throw new PlanReconciliationError("invalid-workout");
-    return workout.origin === "coach"
-      && workout.dateKey >= input.todayDateKey
-      && workout.dateKey <= windowEndDateKey;
+    return (
+      workout.origin === "coach" &&
+      workout.dateKey >= input.todayDateKey &&
+      workout.dateKey <= windowEndDateKey
+    );
   });
   for (const workout of selected) {
     await deps.repository.prepareItem({
@@ -235,10 +237,12 @@ export async function reconcileActivePlanWindow(input: {
   const running = await deps.repository.beginAttempt(job.id, deps.now());
   let before: Map<string, PlanMirrorEvent[]>;
   try {
-    before = groupedEvents(await deps.calendar.listEvents({
-      startDateKey: input.todayDateKey,
-      endDateKey: windowEndDateKey,
-    }));
+    before = groupedEvents(
+      await deps.calendar.listEvents({
+        startDateKey: input.todayDateKey,
+        endDateKey: windowEndDateKey,
+      }),
+    );
   } catch {
     return failListedJob(deps, running);
   }
@@ -257,10 +261,12 @@ export async function reconcileActivePlanWindow(input: {
     if (workout === undefined) throw new PlanReconciliationError("invalid-workout");
     let immediate: Map<string, PlanMirrorEvent[]>;
     try {
-      immediate = groupedEvents(await deps.calendar.listEvents({
-        startDateKey: item.dateKey,
-        endDateKey: item.dateKey,
-      }));
+      immediate = groupedEvents(
+        await deps.calendar.listEvents({
+          startDateKey: item.dateKey,
+          endDateKey: item.dateKey,
+        }),
+      );
     } catch {
       return failListedJob(deps, running);
     }
@@ -293,10 +299,12 @@ export async function reconcileActivePlanWindow(input: {
   }
   let after: Map<string, PlanMirrorEvent[]>;
   try {
-    after = groupedEvents(await deps.calendar.listEvents({
-      startDateKey: input.todayDateKey,
-      endDateKey: windowEndDateKey,
-    }));
+    after = groupedEvents(
+      await deps.calendar.listEvents({
+        startDateKey: input.todayDateKey,
+        endDateKey: windowEndDateKey,
+      }),
+    );
   } catch {
     for (const item of await deps.repository.readItems(job.id)) {
       if (item.status === "running" || item.status === "created") {
@@ -309,15 +317,46 @@ export async function reconcileActivePlanWindow(input: {
   return finishJob(deps, running);
 }
 
-function cleanupExpected(event: PlanMirrorEvent): string {
-  return JSON.stringify({ eventId: event.id, dateKey: event.dateKey, externalId: event.externalId });
+export async function verifyPlanMirror(
+  job: PlanReconciliationJobRecord,
+  deps: PlanReconcilerDeps,
+): Promise<PlanReconciliationProjection> {
+  const stored = await deps.repository.readJob(job.id);
+  if (stored === undefined || stored.kind !== "mirror") {
+    throw new PlanReconciliationError("missing-job");
+  }
+  const running = await deps.repository.beginAttempt(stored.id, deps.now());
+  let events: Map<string, PlanMirrorEvent[]>;
+  try {
+    events = groupedEvents(
+      await deps.calendar.listEvents({
+        startDateKey: running.windowStartDateKey,
+        endDateKey: running.windowEndDateKey,
+      }),
+    );
+  } catch {
+    return failListedJob(deps, running);
+  }
+  await verifyCreateItems(deps, running, events);
+  return finishJob(deps, running);
 }
 
-export async function cleanupPlanMirror(input: {
-  readonly planId: string;
-  readonly todayDateKey: number;
-  readonly endDateKey: number;
-}, deps: PlanReconcilerDeps): Promise<PlanReconciliationProjection> {
+function cleanupExpected(event: PlanMirrorEvent): string {
+  return JSON.stringify({
+    eventId: event.id,
+    dateKey: event.dateKey,
+    externalId: event.externalId,
+  });
+}
+
+export async function cleanupPlanMirror(
+  input: {
+    readonly planId: string;
+    readonly todayDateKey: number;
+    readonly endDateKey: number;
+  },
+  deps: PlanReconcilerDeps,
+): Promise<PlanReconciliationProjection> {
   const startDateKey = addCivilDays(input.todayDateKey, 1);
   const now = deps.now();
   const job = await deps.repository.createOrGetJob({
@@ -331,17 +370,20 @@ export async function cleanupPlanMirror(input: {
   const running = await deps.repository.beginAttempt(job.id, deps.now());
   let before: Map<string, PlanMirrorEvent[]>;
   try {
-    before = groupedEvents(await deps.calendar.listEvents({
-      startDateKey,
-      endDateKey: input.endDateKey,
-    }));
+    before = groupedEvents(
+      await deps.calendar.listEvents({
+        startDateKey,
+        endDateKey: input.endDateKey,
+      }),
+    );
   } catch {
     return failListedJob(deps, running);
   }
   const prefix = planMirrorExternalIdPrefix(input.planId);
-  const eligible = [...before.entries()].filter(([externalId, events]) =>
-    externalId.startsWith(prefix)
-    && events.some((event) => event.dateKey >= startDateKey && event.dateKey <= input.endDateKey)
+  const eligible = [...before.entries()].filter(
+    ([externalId, events]) =>
+      externalId.startsWith(prefix) &&
+      events.some((event) => event.dateKey >= startDateKey && event.dateKey <= input.endDateKey),
   );
   for (const [externalId, events] of eligible) {
     const first = events[0]!;
@@ -375,10 +417,12 @@ export async function cleanupPlanMirror(input: {
   }
   let after: Map<string, PlanMirrorEvent[]>;
   try {
-    after = groupedEvents(await deps.calendar.listEvents({
-      startDateKey,
-      endDateKey: input.endDateKey,
-    }));
+    after = groupedEvents(
+      await deps.calendar.listEvents({
+        startDateKey,
+        endDateKey: input.endDateKey,
+      }),
+    );
   } catch {
     for (const item of await deps.repository.readItems(job.id)) {
       if (item.status === "running") {

--- a/packages/engine/tests/export-map.test.ts
+++ b/packages/engine/tests/export-map.test.ts
@@ -41,6 +41,7 @@ describe("engine public export surface", () => {
       "UNKNOWN_PROVENANCE",
       "_resetOrphanWarnCacheForTesting",
       "acceptParsedRaceCourse",
+      "activatePlanDraft",
       "applyPlanStartDatePreview",
       "beginRaceCourseParsing",
       "beginRaceCourseRemoval",
@@ -108,6 +109,7 @@ describe("engine public export surface", () => {
       "useRouteWithoutElevation",
       "validateListRange",
       "validateWorkoutCreationDate",
+      "verifyPlanMirror",
       "warnOrphanSections",
       "wrapAthleteContextFence",
     ]);

--- a/packages/engine/tests/plan-activation.test.ts
+++ b/packages/engine/tests/plan-activation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PlanConversationRepository } from "@enduragent/kernel/planning";
+import { activatePlanDraft } from "../src/index.js";
+
+describe("Plan Draft activation command", () => {
+  it("forwards revision and authored identity to the atomic repository boundary", async () => {
+    const approveDraft = vi.fn(async () => ({
+      planId: "00000000000000000000000001",
+      draft: { status: "approved" },
+    }));
+    const result = await activatePlanDraft(
+      { draftRevisionId: "00000000000000000000000002", expectedRevision: 4 },
+      {
+        drafts: { approveDraft } as unknown as PlanConversationRepository,
+        identity: {
+          deviceId: async () => "device-1",
+          hlcStamp: () => ({ physicalMs: 42, counter: 3 }),
+        },
+      },
+    );
+
+    expect(approveDraft).toHaveBeenCalledWith({
+      draftRevisionId: "00000000000000000000000002",
+      expectedRevision: 4,
+      updatedAtMs: 42,
+      deviceId: "device-1",
+      hlcPhysicalMs: 42,
+      hlcCounter: 3,
+    });
+    expect(result).toMatchObject({ planId: "00000000000000000000000001" });
+  });
+});

--- a/packages/engine/tests/plan-reconciler.test.ts
+++ b/packages/engine/tests/plan-reconciler.test.ts
@@ -15,6 +15,7 @@ import {
   planMirrorExternalId,
   projectPlanReconciliation,
   reconcileActivePlanWindow,
+  verifyPlanMirror,
   type PlanMirrorCalendarPort,
   type PlanMirrorCreateInput,
   type PlanMirrorEvent,
@@ -65,11 +66,12 @@ class MemoryReconciliationRepository implements PlanReconciliationRepository {
   readonly items = new Map<string, PlanReconciliationItemRecord>();
 
   async createOrGetJob(record: NewPlanReconciliationJob): Promise<PlanReconciliationJobRecord> {
-    const existing = [...this.jobs.values()].find((job) =>
-      job.planId === record.planId
-      && job.kind === record.kind
-      && job.windowStartDateKey === record.windowStartDateKey
-      && job.windowEndDateKey === record.windowEndDateKey
+    const existing = [...this.jobs.values()].find(
+      (job) =>
+        job.planId === record.planId &&
+        job.kind === record.kind &&
+        job.windowStartDateKey === record.windowStartDateKey &&
+        job.windowEndDateKey === record.windowEndDateKey,
     );
     if (existing !== undefined) return existing;
     const job: PlanReconciliationJobRecord = {
@@ -95,7 +97,9 @@ class MemoryReconciliationRepository implements PlanReconciliationRepository {
     planId: string,
     kind: PlanReconciliationKind,
   ): Promise<PlanReconciliationJobRecord | undefined> {
-    return [...this.jobs.values()].filter((job) => job.planId === planId && job.kind === kind).at(-1);
+    return [...this.jobs.values()]
+      .filter((job) => job.planId === planId && job.kind === kind)
+      .at(-1);
   }
 
   async beginAttempt(id: string, updatedAtMs: number): Promise<PlanReconciliationJobRecord> {
@@ -104,10 +108,13 @@ class MemoryReconciliationRepository implements PlanReconciliationRepository {
       ...current,
       status: current.status === "failed" || current.status === "retrying" ? "retrying" : "running",
       attemptCount: current.attemptCount + 1,
-      resumedCount: current.resumedCount + (current.status === "running" || current.status === "retrying" ? 1 : 0),
-      lastResumedAttempt: current.status === "running" || current.status === "retrying"
-        ? current.attemptCount + 1
-        : null,
+      resumedCount:
+        current.resumedCount +
+        (current.status === "running" || current.status === "retrying" ? 1 : 0),
+      lastResumedAttempt:
+        current.status === "running" || current.status === "retrying"
+          ? current.attemptCount + 1
+          : null,
       lastErrorCode: null,
       updatedAtMs,
       completedAtMs: null,
@@ -147,16 +154,17 @@ class MemoryReconciliationRepository implements PlanReconciliationRepository {
   }
 
   async prepareItem(record: NewPlanReconciliationItem): Promise<PlanReconciliationItemRecord> {
-    const existing = [...this.items.values()].find((item) =>
-      item.jobId === record.jobId
-      && item.operation === record.operation
-      && item.externalId === record.externalId
+    const existing = [...this.items.values()].find(
+      (item) =>
+        item.jobId === record.jobId &&
+        item.operation === record.operation &&
+        item.externalId === record.externalId,
     );
     if (existing !== undefined) {
       if (
-        existing.expectedJson !== record.expectedJson
-        || existing.dateKey !== record.dateKey
-        || existing.planWorkoutId !== record.planWorkoutId
+        existing.expectedJson !== record.expectedJson ||
+        existing.dateKey !== record.dateKey ||
+        existing.planWorkoutId !== record.planWorkoutId
       ) {
         const changed: PlanReconciliationItemRecord = {
           ...existing,
@@ -222,7 +230,12 @@ class MemoryReconciliationRepository implements PlanReconciliationRepository {
     errorCode: Exclude<PlanReconciliationErrorCode, "calendar-list-failed">,
     updatedAtMs: number,
   ): Promise<PlanReconciliationItemRecord> {
-    const item = { ...this.items.get(id)!, status: "failed" as const, lastErrorCode: errorCode, updatedAtMs };
+    const item = {
+      ...this.items.get(id)!,
+      status: "failed" as const,
+      lastErrorCode: errorCode,
+      updatedAtMs,
+    };
     this.items.set(id, item);
     return item;
   }
@@ -259,7 +272,9 @@ class MemoryCalendar implements PlanMirrorCalendarPort {
     if (this.listFailure) throw new Error("unavailable");
     this.lists.push(input);
     this.onList?.(this.lists.length);
-    return this.events.filter((event) => event.dateKey >= input.startDateKey && event.dateKey <= input.endDateKey);
+    return this.events.filter(
+      (event) => event.dateKey >= input.startDateKey && event.dateKey <= input.endDateKey,
+    );
   }
 
   async createEvent(input: PlanMirrorCreateInput) {
@@ -268,7 +283,11 @@ class MemoryCalendar implements PlanMirrorCalendarPort {
       this.createFailures -= 1;
       throw new Error("unavailable");
     }
-    this.events.push({ id: this.nextEventId++, dateKey: input.dateKey, externalId: input.externalId });
+    this.events.push({
+      id: this.nextEventId++,
+      dateKey: input.dateKey,
+      externalId: input.externalId,
+    });
   }
 
   async deleteEvent(input: { eventId: number }) {
@@ -310,10 +329,31 @@ describe("Plan reconciler", () => {
     const states: Array<readonly [PlanReconciliationJobRecord, string]> = [
       [base, "activation-local"],
       [{ ...base, status: "running", attemptCount: 1 }, "reconcile-running"],
-      [{ ...base, status: "failed", attemptCount: 1, failureCount: 1, lastErrorCode: "calendar-create-failed" }, "reconcile-failed"],
+      [
+        {
+          ...base,
+          status: "failed",
+          attemptCount: 1,
+          failureCount: 1,
+          lastErrorCode: "calendar-create-failed",
+        },
+        "reconcile-failed",
+      ],
       [{ ...base, status: "retrying", attemptCount: 2, failureCount: 1 }, "reconcile-retrying"],
-      [{ ...base, status: "failed", attemptCount: 2, failureCount: 2, lastErrorCode: "calendar-create-failed" }, "reconcile-failed-again"],
-      [{ ...base, status: "running", attemptCount: 2, resumedCount: 1, lastResumedAttempt: 2 }, "reconcile-crash-resume"],
+      [
+        {
+          ...base,
+          status: "failed",
+          attemptCount: 2,
+          failureCount: 2,
+          lastErrorCode: "calendar-create-failed",
+        },
+        "reconcile-failed-again",
+      ],
+      [
+        { ...base, status: "running", attemptCount: 2, resumedCount: 1, lastResumedAttempt: 2 },
+        "reconcile-crash-resume",
+      ],
       [{ ...base, status: "verified", attemptCount: 1, completedAtMs: 2 }, "reconcile-verified"],
     ];
     for (const [job, expected] of states) {
@@ -331,18 +371,30 @@ describe("Plan reconciler", () => {
       dateKey: today.dateKey,
       externalId: planMirrorExternalId(PLAN_ID, today.id),
     });
-    const first = await reconcileActivePlanWindow({
-      plan: plan(),
-      workouts: [today, daySix, outside],
-      todayDateKey: 20260825,
-    }, value.deps);
-    expect(first).toMatchObject({ state: "reconcile-verified", created: 2, pending: 0, failed: 0, total: 2 });
+    const first = await reconcileActivePlanWindow(
+      {
+        plan: plan(),
+        workouts: [today, daySix, outside],
+        todayDateKey: 20260825,
+      },
+      value.deps,
+    );
+    expect(first).toMatchObject({
+      state: "reconcile-verified",
+      created: 2,
+      pending: 0,
+      failed: 0,
+      total: 2,
+    });
     expect(value.calendar.creates.map((created) => created.planWorkoutId)).toEqual([daySix.id]);
-    await reconcileActivePlanWindow({
-      plan: plan(),
-      workouts: [today, daySix, outside],
-      todayDateKey: 20260825,
-    }, value.deps);
+    await reconcileActivePlanWindow(
+      {
+        plan: plan(),
+        workouts: [today, daySix, outside],
+        todayDateKey: 20260825,
+      },
+      value.deps,
+    );
     expect(value.calendar.creates).toHaveLength(1);
   });
 
@@ -358,11 +410,14 @@ describe("Plan reconciler", () => {
         });
       }
     };
-    const result = await reconcileActivePlanWindow({
-      plan: plan(),
-      workouts: [target],
-      todayDateKey: 20260825,
-    }, value.deps);
+    const result = await reconcileActivePlanWindow(
+      {
+        plan: plan(),
+        workouts: [target],
+        todayDateKey: 20260825,
+      },
+      value.deps,
+    );
     expect(result).toMatchObject({ state: "reconcile-verified", created: 1, total: 1 });
     expect(value.calendar.creates).toEqual([]);
     expect(value.calendar.lists.slice(0, 2)).toEqual([
@@ -382,11 +437,14 @@ describe("Plan reconciler", () => {
     value.calendar.onList = (call) => {
       if (call === 2) value.calendar.events.splice(0);
     };
-    const result = await reconcileActivePlanWindow({
-      plan: plan(),
-      workouts: [target],
-      todayDateKey: 20260825,
-    }, value.deps);
+    const result = await reconcileActivePlanWindow(
+      {
+        plan: plan(),
+        workouts: [target],
+        todayDateKey: 20260825,
+      },
+      value.deps,
+    );
     expect(result).toMatchObject({ state: "reconcile-failed", created: 0, failed: 1, total: 1 });
     expect(value.calendar.creates).toEqual([]);
   });
@@ -421,11 +479,14 @@ describe("Plan reconciler", () => {
     await value.repository.beginAttempt(job.id, 2);
     await value.repository.startItem(item.id, 3);
     value.calendar.events.push({ id: 42, dateKey: target.dateKey, externalId: item.externalId });
-    const result = await reconcileActivePlanWindow({
-      plan: plan(),
-      workouts: [target],
-      todayDateKey: 20260825,
-    }, value.deps);
+    const result = await reconcileActivePlanWindow(
+      {
+        plan: plan(),
+        workouts: [target],
+        todayDateKey: 20260825,
+      },
+      value.deps,
+    );
     expect(result).toMatchObject({ state: "reconcile-verified", created: 1, failed: 0 });
     expect(result.job).toMatchObject({ attemptCount: 2, resumedCount: 1 });
     expect(value.calendar.creates).toHaveLength(0);
@@ -435,13 +496,42 @@ describe("Plan reconciler", () => {
     const value = harness();
     const target = workout("01K00000000000000000000101", 20260825);
     value.calendar.createFailures = 2;
-    const first = await reconcileActivePlanWindow({ plan: plan(), workouts: [target], todayDateKey: 20260825 }, value.deps);
-    const second = await reconcileActivePlanWindow({ plan: plan(), workouts: [target], todayDateKey: 20260825 }, value.deps);
-    const third = await reconcileActivePlanWindow({ plan: plan(), workouts: [target], todayDateKey: 20260825 }, value.deps);
+    const first = await reconcileActivePlanWindow(
+      { plan: plan(), workouts: [target], todayDateKey: 20260825 },
+      value.deps,
+    );
+    const second = await reconcileActivePlanWindow(
+      { plan: plan(), workouts: [target], todayDateKey: 20260825 },
+      value.deps,
+    );
+    const third = await reconcileActivePlanWindow(
+      { plan: plan(), workouts: [target], todayDateKey: 20260825 },
+      value.deps,
+    );
     expect(first.state).toBe("reconcile-failed");
     expect(second.state).toBe("reconcile-failed-again");
     expect(third).toMatchObject({ state: "reconcile-verified", created: 1, failed: 0 });
     expect(value.calendar.creates).toHaveLength(3);
+  });
+
+  it("verifies provider state without creating another event", async () => {
+    const value = harness();
+    const target = workout("01K00000000000000000000101", 20260825);
+    value.calendar.createFailures = 1;
+    const failed = await reconcileActivePlanWindow(
+      { plan: plan(), workouts: [target], todayDateKey: 20260825 },
+      value.deps,
+    );
+    value.calendar.events.push({
+      id: 88,
+      dateKey: target.dateKey,
+      externalId: planMirrorExternalId(PLAN_ID, target.id),
+    });
+
+    const verified = await verifyPlanMirror(failed.job, value.deps);
+
+    expect(verified).toMatchObject({ state: "reconcile-verified", created: 1, failed: 0 });
+    expect(value.calendar.creates).toHaveLength(1);
   });
 
   it("cleanup preserves today and other Plans while deleting every duplicate tomorrow onward", async () => {
@@ -456,11 +546,14 @@ describe("Plan reconciler", () => {
       { id: 4, dateKey: 20260826, externalId: otherTomorrow },
       { id: 5, dateKey: 20260826, externalId: null },
     );
-    const result = await cleanupPlanMirror({
-      planId: PLAN_ID,
-      todayDateKey: 20260825,
-      endDateKey: 20260831,
-    }, value.deps);
+    const result = await cleanupPlanMirror(
+      {
+        planId: PLAN_ID,
+        todayDateKey: 20260825,
+        endDateKey: 20260831,
+      },
+      value.deps,
+    );
     expect(result).toMatchObject({ state: "reconcile-verified", created: 1, total: 1 });
     expect(value.calendar.deletes).toEqual([2, 3]);
     expect(value.calendar.events.map((event) => event.id)).toEqual([1, 4, 5]);
@@ -470,11 +563,14 @@ describe("Plan reconciler", () => {
     const value = harness();
     const active = plan();
     value.calendar.listFailure = true;
-    const result = await reconcileActivePlanWindow({
-      plan: active,
-      workouts: [workout("01K00000000000000000000101", 20260825)],
-      todayDateKey: 20260825,
-    }, value.deps);
+    const result = await reconcileActivePlanWindow(
+      {
+        plan: active,
+        workouts: [workout("01K00000000000000000000101", 20260825)],
+        todayDateKey: 20260825,
+      },
+      value.deps,
+    );
     expect(result).toMatchObject({ state: "reconcile-failed", created: 0, pending: 1, failed: 0 });
     expect(active.status).toBe("active");
     expect(value.calendar.creates).toHaveLength(0);

--- a/packages/engine/tests/scaffold.test.ts
+++ b/packages/engine/tests/scaffold.test.ts
@@ -53,6 +53,7 @@ describe("engine scaffold", () => {
       "UNKNOWN_PROVENANCE",
       "_resetOrphanWarnCacheForTesting",
       "acceptParsedRaceCourse",
+      "activatePlanDraft",
       "applyPlanStartDatePreview",
       "beginRaceCourseParsing",
       "beginRaceCourseRemoval",
@@ -120,6 +121,7 @@ describe("engine scaffold", () => {
       "useRouteWithoutElevation",
       "validateListRange",
       "validateWorkoutCreationDate",
+      "verifyPlanMirror",
       "warnOrphanSections",
       "wrapAthleteContextFence",
     ]);

--- a/packages/kernel-node/tests/plan-conversation-repository.test.ts
+++ b/packages/kernel-node/tests/plan-conversation-repository.test.ts
@@ -292,13 +292,13 @@ describe("Plan conversation repository", () => {
           `${"0".repeat(25)}C`,
           SECOND_CONVERSATION_ID,
           SECOND_PLAN_ID,
-      2,
-      REVISION_ID,
-      1,
-      "ready",
-      '{"completeWeeks":12}',
-      17,
-      17,
+          2,
+          REVISION_ID,
+          1,
+          "ready",
+          '{"completeWeeks":12}',
+          17,
+          17,
           "device-1",
           17,
           0,
@@ -395,6 +395,81 @@ describe("Plan conversation repository", () => {
       }),
     ).rejects.toEqual(new PlanConversationValidationError("conversation-conflict"));
     await expect(repository.readConversation(CONVERSATION_ID)).resolves.toEqual(ended);
+  });
+
+  it("atomically approves the latest Draft and activates its local Plan", async () => {
+    const plans = createPlanRepository(store);
+    const repository = createPlanConversationRepository(store);
+    await plans.replace(plan(), []);
+    await repository.saveConversation(
+      conversation({ planId: PLAN_ID, courseChoiceStatus: "omitted" }),
+    );
+    await repository.saveDraftRevision(revision({ status: "ready" }));
+
+    const result = await repository.approveDraft({
+      draftRevisionId: REVISION_ID,
+      expectedRevision: 1,
+      updatedAtMs: 20,
+      deviceId: "device-1",
+      hlcPhysicalMs: 20,
+      hlcCounter: 0,
+    });
+
+    expect(result).toMatchObject({ planId: PLAN_ID, draft: { status: "approved" } });
+    await expect(plans.read(PLAN_ID)).resolves.toMatchObject({ status: "active" });
+    await expect(
+      repository.approveDraft({
+        draftRevisionId: REVISION_ID,
+        expectedRevision: 1,
+        updatedAtMs: 21,
+        deviceId: "device-1",
+        hlcPhysicalMs: 21,
+        hlcCounter: 0,
+      }),
+    ).resolves.toMatchObject({ planId: PLAN_ID, draft: { status: "approved" } });
+  });
+
+  it("keeps the Draft unchanged when approval is stale or another Plan is active", async () => {
+    const plans = createPlanRepository(store);
+    const repository = createPlanConversationRepository(store);
+    await plans.replace(plan(), []);
+    await repository.saveConversation(
+      conversation({ planId: PLAN_ID, courseChoiceStatus: "omitted" }),
+    );
+    await repository.saveDraftRevision(revision({ status: "ready" }));
+    await expect(
+      repository.approveDraft({
+        draftRevisionId: REVISION_ID,
+        expectedRevision: 2,
+        updatedAtMs: 20,
+        deviceId: "device-1",
+        hlcPhysicalMs: 20,
+        hlcCounter: 0,
+      }),
+    ).rejects.toEqual(new PlanConversationValidationError("stale-draft"));
+    await plans.replace(
+      plan({
+        id: SECOND_PLAN_ID,
+        status: "active",
+        updatedAtMs: 3,
+        hlcPhysicalMs: 3,
+      }),
+      [],
+    );
+    await expect(
+      repository.approveDraft({
+        draftRevisionId: REVISION_ID,
+        expectedRevision: 1,
+        updatedAtMs: 20,
+        deviceId: "device-1",
+        hlcPhysicalMs: 20,
+        hlcCounter: 0,
+      }),
+    ).rejects.toEqual(new PlanConversationValidationError("active-plan-exists"));
+    await expect(plans.read(PLAN_ID)).resolves.toMatchObject({ status: "draft" });
+    await expect(repository.readDraftRevision(REVISION_ID)).resolves.toMatchObject({
+      status: "ready",
+    });
   });
 });
 

--- a/packages/kernel/src/planning/conversation-repository.ts
+++ b/packages/kernel/src/planning/conversation-repository.ts
@@ -64,6 +64,20 @@ export interface PlanSourceRequestRecord {
   readonly hlcCounter: number;
 }
 
+export interface ApprovePlanDraftInput {
+  readonly draftRevisionId: string;
+  readonly expectedRevision: number;
+  readonly updatedAtMs: number;
+  readonly deviceId: string;
+  readonly hlcPhysicalMs: number;
+  readonly hlcCounter: number;
+}
+
+export interface ApprovePlanDraftResult {
+  readonly planId: string;
+  readonly draft: PlanDraftRevisionRecord;
+}
+
 export type PlanConversationValidationErrorCode =
   | "invalid-id"
   | "invalid-plan-id"
@@ -85,7 +99,10 @@ export type PlanConversationValidationErrorCode =
   | "turn-conflict"
   | "draft-lineage-conflict"
   | "source-request-conflict"
-  | "plan-not-draft";
+  | "plan-not-draft"
+  | "stale-draft"
+  | "active-plan-exists"
+  | "replacement-requires-swap";
 
 export class PlanConversationValidationError extends Error {
   readonly code: PlanConversationValidationErrorCode;
@@ -109,6 +126,7 @@ export interface PlanConversationRepository {
   readDraftRevision(id: string): Promise<PlanDraftRevisionRecord | undefined>;
   readDraftRevisions(conversationId: string): Promise<readonly PlanDraftRevisionRecord[]>;
   readLatestDraftRevision(conversationId: string): Promise<PlanDraftRevisionRecord | undefined>;
+  approveDraft(input: ApprovePlanDraftInput): Promise<ApprovePlanDraftResult>;
   createOrGetSourceRequest(record: PlanSourceRequestRecord): Promise<PlanSourceRequestRecord>;
   bindSourceBoundary(record: PlanSourceRequestRecord): Promise<PlanSourceRequestRecord>;
   readSourceRequest(id: string): Promise<PlanSourceRequestRecord | undefined>;
@@ -442,7 +460,7 @@ ON CONFLICT (id) DO UPDATE SET
             record.status,
             record.endedAtMs,
             record.createdAtMs,
-          record.updatedAtMs,
+            record.updatedAtMs,
             record.deviceId,
             record.hlcPhysicalMs,
             record.hlcCounter,
@@ -504,10 +522,10 @@ ON CONFLICT (id) DO UPDATE SET
             record.id,
             record.conversationId,
             record.sequence,
-          record.athleteText,
-          record.coachText,
-          record.lineageJson,
-          record.completedAtMs,
+            record.athleteText,
+            record.coachText,
+            record.lineageJson,
+            record.completedAtMs,
             record.deviceId,
             record.hlcPhysicalMs,
             record.hlcCounter,
@@ -591,8 +609,8 @@ ON CONFLICT (id) DO UPDATE SET
             record.id,
             record.conversationId,
             record.planId,
-          record.revision,
-          record.parentRevisionId,
+            record.revision,
+            record.parentRevisionId,
             record.parentRevisionId === null ? null : record.revision - 1,
             record.status,
             record.snapshotJson,
@@ -625,6 +643,77 @@ ON CONFLICT (id) DO UPDATE SET
       return row === undefined ? undefined : draftRevisionFromRow(row);
     },
 
+    async approveDraft(input) {
+      if (
+        !ULID.test(input.draftRevisionId) ||
+        !Number.isSafeInteger(input.expectedRevision) ||
+        input.expectedRevision <= 0 ||
+        !Number.isSafeInteger(input.updatedAtMs) ||
+        input.updatedAtMs < 0 ||
+        !DEVICE_ID.test(input.deviceId) ||
+        !validHlc(input)
+      ) {
+        throw new PlanConversationValidationError("invalid-draft-revision");
+      }
+      return store.transaction(async () => {
+        const draft = await readDraftRevision(input.draftRevisionId);
+        if (draft === undefined) {
+          throw new PlanConversationValidationError("stale-draft");
+        }
+        const latest = await store.get(
+          "SELECT id FROM plan_draft_revision WHERE conversation_id = ? ORDER BY revision DESC, id DESC LIMIT 1",
+          [draft.conversationId],
+        );
+        if (
+          latest === undefined ||
+          text(latest, "id") !== draft.id ||
+          draft.revision !== input.expectedRevision
+        ) {
+          throw new PlanConversationValidationError("stale-draft");
+        }
+        const conversation = await requireOpenConversation(draft.conversationId);
+        if (conversation.replacesPlanId !== null) {
+          throw new PlanConversationValidationError("replacement-requires-swap");
+        }
+        const plan = await store.get("SELECT status FROM plan WHERE id = ?", [draft.planId]);
+        if (
+          draft.status === "approved" &&
+          plan !== undefined &&
+          text(plan, "status") === "active"
+        ) {
+          return { planId: draft.planId, draft };
+        }
+        if (draft.status !== "ready") {
+          throw new PlanConversationValidationError("stale-draft");
+        }
+        if (plan === undefined || text(plan, "status") !== "draft") {
+          throw new PlanConversationValidationError("plan-not-draft");
+        }
+        const active = await store.get("SELECT id FROM plan WHERE status = 'active' LIMIT 1");
+        if (active !== undefined && text(active, "id") !== draft.planId) {
+          throw new PlanConversationValidationError("active-plan-exists");
+        }
+        if (input.updatedAtMs < draft.updatedAtMs) {
+          throw new PlanConversationValidationError("stale-draft");
+        }
+        await store.run(
+          `UPDATE plan SET status='active',updated_at_ms=?,device_id=?,hlc_physical_ms=?,hlc_counter=?
+           WHERE id=? AND status='draft'`,
+          [input.updatedAtMs, input.deviceId, input.hlcPhysicalMs, input.hlcCounter, draft.planId],
+        );
+        await store.run(
+          `UPDATE plan_draft_revision SET status='approved',updated_at_ms=?,device_id=?,
+             hlc_physical_ms=?,hlc_counter=? WHERE id=? AND status='ready'`,
+          [input.updatedAtMs, input.deviceId, input.hlcPhysicalMs, input.hlcCounter, draft.id],
+        );
+        const approved = await readDraftRevision(draft.id);
+        if (approved === undefined || approved.status !== "approved") {
+          throw new PlanConversationValidationError("stale-draft");
+        }
+        return { planId: draft.planId, draft: approved };
+      });
+    },
+
     async createOrGetSourceRequest(record) {
       validateSourceRequest(record);
       return store.transaction(async () => {
@@ -645,11 +734,11 @@ ON CONFLICT (id) DO UPDATE SET
             record.id,
             record.conversationId,
             record.sourceChatId,
-          record.sourceBoundaryRef,
-          record.sourceMessageId,
-          record.requestJson,
-          record.createdAtMs,
-          record.updatedAtMs,
+            record.sourceBoundaryRef,
+            record.sourceMessageId,
+            record.requestJson,
+            record.createdAtMs,
+            record.updatedAtMs,
             record.deviceId,
             record.hlcPhysicalMs,
             record.hlcCounter,


### PR DESCRIPTION
## Summary
- approve a Plan Draft and activate the Plan atomically in local SQLite
- reconcile only today plus the next six civil dates with Intervals
- keep the Plan active through provider failures with retry, verify, and crash-resume states
- show inline reconciliation status and app-level attention only when athlete action is required

## Verification
- `pnpm check`
- focused Vitest: 9 files, 72 tests passed
- `git diff --check`
- isolated autoreview: clean, no accepted/actionable findings

## Scope
Child PR for the Plan Page epic. Base is `epic/plan-page`; umbrella PR #735 remains unmerged.