### PR TITLE
feat(chat): add read-only Plan reference cards

### DIFF
--- a/.changeset/chat-plan-reference-cards.md
+++ b/.changeset/chat-plan-reference-cards.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Added read-only current Plan, current week, and Workout cards to relevant Coach answers, with one Open Plan action.
+
+Plan cards are host-owned typed projections, persist only their Planning reference, re-resolve against current Plan data after relaunch, and never mutate Plan, Calendar, or Training from Chat.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -141,7 +141,9 @@ export function bootRenderer(): Disposer {
   });
   const trainingSyncCoordinator = createTrainingSyncCoordinator({
     clients,
-    refreshTrainingContext: () => trainingContextController.refresh(),
+    refreshTrainingContext: async () => {
+      await Promise.all([trainingContextController.refresh(), planController.refresh()]);
+    },
   });
   const syncAdapter = createManualSyncViewAdapter({
     publish: (next) =>
@@ -174,7 +176,9 @@ export function bootRenderer(): Disposer {
   const chatController = createChatController({
     clients,
     view: chatAdapter.view,
-    refreshTrainingContext: () => trainingContextController.refresh(),
+    refreshTrainingContext: async () => {
+      await Promise.all([trainingContextController.refresh(), planController.refresh()]);
+    },
     refreshSpend: () => spendController.refresh(),
     readTranscriptPage: (request) => window.enduragentAuth.getTranscriptPage(request),
     canChat: () => setupReady(store.getState()),

--- a/apps/desktop-renderer/src/chat/hydration.ts
+++ b/apps/desktop-renderer/src/chat/hydration.ts
@@ -10,6 +10,7 @@ export interface TranscriptTurn {
   readonly athleteText: string;
   readonly coachText: string;
   readonly attachments?: Extract<TranscriptPageEntry, { readonly kind: "turn" }>["attachments"];
+  readonly planReference?: Extract<TranscriptPageEntry, { readonly kind: "turn" }>["planReference"];
 }
 
 export type TranscriptPage =
@@ -133,6 +134,7 @@ export function mergeHydratedMessages(
           text: entry.coachText,
           delivery: entry.delivery ?? "complete",
           historical: true,
+          ...(entry.planReference === undefined ? {} : { planReference: entry.planReference }),
         },
       ];
     }

--- a/apps/desktop-renderer/src/plan/chat-card.ts
+++ b/apps/desktop-renderer/src/plan/chat-card.ts
@@ -1,0 +1,78 @@
+import {
+  PlanChatCardReadModelSchema,
+  type PlanChatCardReadModel,
+  type PlanningReadModel,
+  type PlanReferenceSelection,
+} from "@enduragent/coach-contract";
+
+export function projectPlanChatCard(
+  selection: PlanReferenceSelection,
+  planning: PlanningReadModel,
+): PlanChatCardReadModel | null {
+  if (planning.status !== "ready" || planning.plan.id !== selection.planId) return null;
+  const plan = planning.plan;
+
+  if (selection.kind === "active_plan_summary") {
+    if (plan.currentWeek === null || plan.phase === null) return null;
+    return PlanChatCardReadModelSchema.parse({
+      kind: selection.kind,
+      cardId: `plan:${plan.id}:summary`,
+      planId: plan.id,
+      title: plan.name,
+      summary: plan.goal.length === 0 ? "No goal recorded" : plan.goal,
+      lifecycle: plan.lifecycle,
+      currentWeek: plan.currentWeek,
+      totalWeeks: plan.totalWeeks,
+      phase: plan.phase,
+      action: {
+        label: "Open Plan",
+        target: { destination: "plan", focus: "active-plan", entityId: plan.id },
+      },
+    });
+  }
+
+  if (selection.kind === "current_week") {
+    if (plan.currentWeek !== selection.weekNumber || plan.phase === null) return null;
+    return PlanChatCardReadModelSchema.parse({
+      kind: selection.kind,
+      cardId: `plan:${plan.id}:week:${selection.weekNumber}`,
+      planId: plan.id,
+      title: `Week ${selection.weekNumber} of ${plan.totalWeeks}`,
+      summary: plan.phase,
+      weekNumber: selection.weekNumber,
+      totalWeeks: plan.totalWeeks,
+      phase: plan.phase,
+      workouts: plan.workouts,
+      action: {
+        label: "Open Plan",
+        target: { destination: "plan", focus: "current-week", entityId: plan.id },
+      },
+    });
+  }
+
+  const workout = plan.workouts.find((candidate) => candidate.id === selection.workoutId);
+  if (
+    workout === undefined ||
+    workout.targets == null ||
+    workout.purpose == null ||
+    workout.safetyGuardrail == null
+  ) {
+    return null;
+  }
+  return PlanChatCardReadModelSchema.parse({
+    kind: selection.kind,
+    cardId: `plan:${plan.id}:workout:${workout.id}`,
+    planId: plan.id,
+    workoutId: workout.id,
+    title: workout.name,
+    summary: workout.sport,
+    dateKey: workout.dateKey,
+    durationMinutes:
+      workout.durationSeconds === null ? null : Math.round(workout.durationSeconds / 60),
+    targets: workout.targets,
+    purpose: workout.purpose,
+    safetyGuardrail: workout.safetyGuardrail,
+    applicationState: "current",
+    action: { label: "Open Plan", target: workout.navigation },
+  });
+}

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -90,6 +90,7 @@ function historicalTimeline(
             delivery: "complete",
             historical: true,
             text: entry.coachText,
+            ...(entry.planReference === undefined ? {} : { planReference: entry.planReference }),
           },
         },
       );
@@ -186,6 +187,7 @@ export function createChatViewAdapter(input: {
       historical: message.historical === true,
       text: isStreamingCoach(message) ? "" : message.text,
       ...(message.attachments === undefined ? {} : { attachments: message.attachments }),
+      ...(message.planReference === undefined ? {} : { planReference: message.planReference }),
     }));
     const workBlocked =
       controls?.workBlocked ??

--- a/apps/desktop-renderer/src/state/chat-slice.ts
+++ b/apps/desktop-renderer/src/state/chat-slice.ts
@@ -20,6 +20,7 @@ export interface ChatMessageView {
   readonly historical: boolean;
   readonly text: string;
   readonly attachments?: ChatTranscriptMessage["attachments"];
+  readonly planReference?: ChatTranscriptMessage["planReference"];
 }
 
 export interface ChatQueuedView {
@@ -162,6 +163,7 @@ export function sameChatMessages(
       message.delivery === other.delivery &&
       message.historical === other.historical &&
       message.text === other.text &&
+      JSON.stringify(message.planReference) === JSON.stringify(other.planReference) &&
       sameAttachments(message.attachments, other.attachments)
     );
   });

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -2,6 +2,7 @@ import type {
   ChatAttachmentComposerItem,
   ChatQueueRecoveryClaim,
   ChatQueueSnapshot,
+  PlanReferenceSelection,
   TurnEvent,
 } from "@enduragent/coach-contract";
 import { isSlashCommandText } from "./chat/commands.js";
@@ -47,6 +48,7 @@ export interface ChatTranscriptMessage {
   readonly delivery: "complete" | "streaming" | "interrupted";
   readonly historical?: boolean;
   readonly attachments?: readonly ChatSentAttachment[];
+  readonly planReference?: PlanReferenceSelection;
 }
 
 export type ChatSentAttachment = Pick<
@@ -282,6 +284,17 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
             messages: hasText
               ? updateAssistant(state, next, action.event.text, "streaming")
               : state.messages,
+          };
+        }
+        case "plan-reference": {
+          const selection = action.event.selection;
+          return {
+            ...state,
+            messages: state.messages.map((message) =>
+              message.id === active.assistantMessageId
+                ? { ...message, planReference: selection }
+                : message,
+            ),
           };
         }
         case "error":

--- a/apps/desktop-renderer/src/ui/chat/PlanReferenceCard.tsx
+++ b/apps/desktop-renderer/src/ui/chat/PlanReferenceCard.tsx
@@ -1,0 +1,126 @@
+import type {
+  PlanChatCardReadModel,
+  PlanReferenceSelection,
+  PlanWorkoutReadModel,
+} from "@enduragent/coach-contract";
+import type { ReactElement, ReactNode } from "react";
+import { Button } from "../../components/ui/button.js";
+import { projectPlanChatCard } from "../../plan/chat-card.js";
+import { useEnduragentStore } from "../../state/store.js";
+
+function dateLabel(dateKey: number): string {
+  const value = String(dateKey);
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(
+    new Date(
+      Date.UTC(Number(value.slice(0, 4)), Number(value.slice(4, 6)) - 1, Number(value.slice(6, 8))),
+    ),
+  );
+}
+
+function Row(props: { readonly label: string; readonly value: ReactNode }): ReactElement {
+  return (
+    <div className="grid grid-cols-[minmax(104px,0.72fr)_minmax(0,1.28fr)] gap-4 border-t border-line px-4 py-3 first:border-t-0 max-[560px]:grid-cols-1 max-[560px]:gap-1">
+      <span className="text-xs leading-4 text-ink-2">{props.label}</span>
+      <strong className="text-right text-sm leading-5 font-semibold [overflow-wrap:anywhere] max-[560px]:text-left">
+        {props.value}
+      </strong>
+    </div>
+  );
+}
+
+function WorkoutLine(props: { readonly workout: PlanWorkoutReadModel }): ReactElement {
+  const workout = props.workout;
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3 border-t border-line px-4 py-3 first:border-t-0">
+      <div className="min-w-0">
+        <strong className="block text-sm leading-5">{workout.name}</strong>
+        <span className="mt-1 block text-xs leading-4 text-ink-2">
+          {dateLabel(workout.dateKey)} · {workout.sport}
+        </span>
+      </div>
+      <span className="text-sm leading-5 font-semibold tabular-nums">
+        {workout.durationSeconds === null
+          ? "Duration unavailable"
+          : `${Math.round(workout.durationSeconds / 60)} min`}
+      </span>
+    </div>
+  );
+}
+
+function CardBody(props: { readonly card: PlanChatCardReadModel }): ReactElement {
+  const card = props.card;
+  if (card.kind === "active_plan_summary") {
+    return (
+      <div>
+        <Row label="Current week" value={`${card.currentWeek} of ${card.totalWeeks}`} />
+        <Row label="Phase" value={card.phase} />
+        <Row label="Status" value={card.lifecycle === "active" ? "Active" : "Draft"} />
+      </div>
+    );
+  }
+  if (card.kind === "current_week") {
+    return card.workouts.length === 0 ? (
+      <p className="m-0 border-t border-line px-4 py-3 text-sm text-ink-2">
+        No workouts in this week.
+      </p>
+    ) : (
+      <div>
+        {card.workouts.map((workout) => (
+          <WorkoutLine key={workout.id} workout={workout} />
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div>
+      <Row label="Date" value={dateLabel(card.dateKey)} />
+      <Row
+        label="Duration"
+        value={card.durationMinutes === null ? "Unavailable" : `${card.durationMinutes} min`}
+      />
+      <Row label="Targets" value={card.targets} />
+      <Row label="Purpose" value={card.purpose} />
+      <Row label="Safety guardrail" value={card.safetyGuardrail} />
+    </div>
+  );
+}
+
+export function PlanReferenceCard(props: {
+  readonly selection: PlanReferenceSelection;
+}): ReactElement | null {
+  const surface = useEnduragentStore((state) => state.planSurface);
+  const actions = useEnduragentStore((state) => state.planActions);
+  const card =
+    surface.status !== "ready" || surface.value === null
+      ? null
+      : projectPlanChatCard(props.selection, surface.value);
+  if (card === null) return null;
+
+  return (
+    <section className="mt-4 min-w-0 overflow-hidden rounded-card border border-line bg-surface shadow-elev-1">
+      <header className="px-4 py-4">
+        <p className="m-0 text-xs font-semibold tracking-[0.06em] text-ink-2 uppercase">
+          {card.kind === "active_plan_summary"
+            ? "Current Plan"
+            : card.kind === "current_week"
+              ? "Current week"
+              : "Workout"}
+        </p>
+        <h3 className="mt-2 mb-0 text-base leading-6 font-semibold">{card.title}</h3>
+        <p className="mt-2 mb-0 text-sm leading-5 text-ink-2">{card.summary}</p>
+      </header>
+      <CardBody card={card} />
+      <footer className="border-t border-line px-4 py-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={actions === null}
+          onClick={() => actions?.openFromChat(card.action.target)}
+        >
+          {card.action.label}
+        </Button>
+      </footer>
+    </section>
+  );
+}

--- a/apps/desktop-renderer/src/ui/chat/Transcript.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Transcript.tsx
@@ -6,6 +6,7 @@ import { useEnduragentStore } from "../../state/store.js";
 import { AthleteMessage } from "./AthleteMessage.js";
 import { CoachMessage } from "./CoachMessage.js";
 import { HistoryControls } from "./HistoryControls.js";
+import { PlanReferenceCard } from "./PlanReferenceCard.js";
 import { StreamingMessage } from "./StreamingMessage.js";
 
 function MessageRow(props: { readonly message: ChatMessageView }): ReactElement {
@@ -66,7 +67,12 @@ function MessageRow(props: { readonly message: ChatMessageView }): ReactElement 
       ) : streaming ? (
         <StreamingMessage messageId={message.id} />
       ) : (
-        <CoachMessage text={message.text} />
+        <div className="min-w-0">
+          <CoachMessage text={message.text} />
+          {message.planReference === undefined ? null : (
+            <PlanReferenceCard selection={message.planReference} />
+          )}
+        </div>
       )}
     </article>
   );

--- a/apps/desktop-renderer/tests/plan-chat-card.test.ts
+++ b/apps/desktop-renderer/tests/plan-chat-card.test.ts
@@ -1,0 +1,87 @@
+import type { PlanningReadModel } from "@enduragent/coach-contract";
+import { describe, expect, it } from "vitest";
+import { projectPlanChatCard } from "../src/plan/chat-card.js";
+
+const model: PlanningReadModel = {
+  schemaVersion: 1,
+  status: "ready",
+  asOfDateKey: 20260826,
+  plan: {
+    id: "plan-1",
+    name: "Twelve-week base",
+    goal: "Build consistency",
+    lifecycle: "active",
+    startDateKey: 20260824,
+    targetDateKey: null,
+    currentWeek: 1,
+    totalWeeks: 12,
+    phase: "Base",
+    weekStartDateKey: 20260824,
+    weekEndDateKey: 20260830,
+    workouts: [
+      {
+        id: "workout-1",
+        dateKey: 20260826,
+        sport: "cycling",
+        name: "Tempo builder",
+        durationSeconds: 3_600,
+        targets: "3 × 8 min · 85–90% FTP",
+        purpose: "Sustainable power",
+        safetyGuardrail: "Stop if the warm-up feels wrong",
+        origin: "coach",
+        navigation: { destination: "plan", focus: "workout", entityId: "workout-1" },
+      },
+    ],
+    todayWorkout: null,
+    navigation: { destination: "plan", focus: "active-plan", entityId: "plan-1" },
+  },
+};
+
+describe("Plan Chat card projection", () => {
+  it("projects the three frozen read-only card scopes", () => {
+    expect(
+      projectPlanChatCard({ kind: "active_plan_summary", planId: "plan-1" }, model),
+    ).toMatchObject({
+      kind: "active_plan_summary",
+      title: "Twelve-week base",
+      action: { label: "Open Plan", target: { focus: "active-plan" } },
+    });
+    expect(
+      projectPlanChatCard({ kind: "current_week", planId: "plan-1", weekNumber: 1 }, model),
+    ).toMatchObject({
+      kind: "current_week",
+      workouts: [{ id: "workout-1" }],
+      action: { label: "Open Plan", target: { focus: "current-week" } },
+    });
+    expect(
+      projectPlanChatCard(
+        { kind: "workout_detail", planId: "plan-1", workoutId: "workout-1" },
+        model,
+      ),
+    ).toMatchObject({
+      kind: "workout_detail",
+      title: "Tempo builder",
+      targets: "3 × 8 min · 85–90% FTP",
+      purpose: "Sustainable power",
+      safetyGuardrail: "Stop if the warm-up feels wrong",
+      action: { label: "Open Plan", target: { focus: "workout", entityId: "workout-1" } },
+    });
+  });
+
+  it("omits stale or incomplete cards instead of synthesizing data", () => {
+    expect(projectPlanChatCard({ kind: "active_plan_summary", planId: "stale" }, model)).toBeNull();
+    expect(
+      projectPlanChatCard({ kind: "current_week", planId: "plan-1", weekNumber: 2 }, model),
+    ).toBeNull();
+    const incomplete: PlanningReadModel = {
+      ...model,
+      plan: { ...model.plan, workouts: [{ ...model.plan.workouts[0]!, safetyGuardrail: null }] },
+    };
+    expect(
+      projectPlanChatCard(
+        { kind: "workout_detail", planId: "plan-1", workoutId: "workout-1" },
+        incomplete,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop-renderer/tests/plan-reference-card.test.tsx
+++ b/apps/desktop-renderer/tests/plan-reference-card.test.tsx
@@ -1,0 +1,95 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PlanningReadModel } from "@enduragent/coach-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useEnduragentStore } from "../src/state/store.js";
+import { PlanReferenceCard } from "../src/ui/chat/PlanReferenceCard.js";
+
+const model: PlanningReadModel = {
+  schemaVersion: 1,
+  status: "ready",
+  asOfDateKey: 20260826,
+  plan: {
+    id: "plan-1",
+    name: "Twelve-week base",
+    goal: "Build consistency",
+    lifecycle: "active",
+    startDateKey: 20260824,
+    targetDateKey: null,
+    currentWeek: 1,
+    totalWeeks: 12,
+    phase: "Base",
+    weekStartDateKey: 20260824,
+    weekEndDateKey: 20260830,
+    workouts: [
+      {
+        id: "workout-1",
+        dateKey: 20260826,
+        sport: "cycling",
+        name: "Tempo builder",
+        durationSeconds: 3_600,
+        targets: "3 × 8 min · 85–90% FTP",
+        purpose: "Sustainable power",
+        safetyGuardrail: "Stop if the warm-up feels wrong",
+        origin: "coach",
+        navigation: { destination: "plan", focus: "workout", entityId: "workout-1" },
+      },
+    ],
+    todayWorkout: null,
+    navigation: { destination: "plan", focus: "active-plan", entityId: "plan-1" },
+  },
+};
+
+afterEach(() => {
+  act(() =>
+    useEnduragentStore.setState({
+      planSurface: { status: "loading", value: null },
+      planActions: null,
+    }),
+  );
+});
+
+describe("Plan reference card", () => {
+  it("renders the frozen Workout fields and opens the typed Plan destination", async () => {
+    const openFromChat = vi.fn();
+    act(() =>
+      useEnduragentStore.setState({
+        planSurface: { status: "ready", value: model },
+        planActions: { refresh: vi.fn(), openFromChat, backToChat: vi.fn() },
+      }),
+    );
+    const user = userEvent.setup();
+    render(
+      <PlanReferenceCard
+        selection={{ kind: "workout_detail", planId: "plan-1", workoutId: "workout-1" }}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Tempo builder" })).toBeInTheDocument();
+    expect(screen.getByText("3 × 8 min · 85–90% FTP")).toBeInTheDocument();
+    expect(screen.getByText("Sustainable power")).toBeInTheDocument();
+    expect(screen.getByText("Stop if the warm-up feels wrong")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /apply|save|replace/i })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Open Plan" }));
+    expect(openFromChat).toHaveBeenCalledWith({
+      destination: "plan",
+      focus: "workout",
+      entityId: "workout-1",
+    });
+  });
+
+  it("renders nothing when current Plan data cannot resolve the saved selection", () => {
+    act(() =>
+      useEnduragentStore.setState({
+        planSurface: { status: "ready", value: model },
+        planActions: { refresh: vi.fn(), openFromChat: vi.fn(), backToChat: vi.fn() },
+      }),
+    );
+    const view = render(
+      <PlanReferenceCard
+        selection={{ kind: "workout_detail", planId: "plan-1", workoutId: "missing" }}
+      />,
+    );
+    expect(view.container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/desktop-renderer/tests/turn-state.test.ts
+++ b/apps/desktop-renderer/tests/turn-state.test.ts
@@ -157,6 +157,23 @@ describe("desktop turn state", () => {
     expect(state.progress).toBe("Checking your training data…");
   });
 
+  it("binds a typed Plan reference to the active coach message", () => {
+    const state = reduceChatState(started(), {
+      type: "event",
+      requestKey: 1,
+      event: {
+        type: "plan-reference",
+        turnId: "turn-1",
+        selection: { kind: "current_week", planId: "plan-1", weekNumber: 1 },
+      },
+    });
+    expect(state.messages.at(-1)?.planReference).toEqual({
+      kind: "current_week",
+      planId: "plan-1",
+      weekNumber: 1,
+    });
+  });
+
   it.each(["", " \n\t"])(
     "does not complete or expose a whitespace-only final text %j",
     (finalText) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -2,7 +2,9 @@ import { contextBridge, ipcRenderer, webUtils } from "electron";
 import {
   AttachmentAdmissionReadModelSchema,
   CHAT_ATTACHMENT_LIMITS,
+  GetArchivedTranscriptPageRpcResultSchema,
   GetPlanningReadModelRpcResultSchema,
+  GetTranscriptPageRpcResultSchema,
   PlatformAbsolutePathSchema,
   type AttachmentAdmissionReadModel,
 } from "@enduragent/coach-contract";
@@ -138,12 +140,6 @@ const CLAUDE_CLI_STATES = new Set([
   "working-area-unavailable",
 ]);
 const IMPORT_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
-const CHAT_ATTACHMENT_EXTENSIONS = {
-  document: new Set(["pdf", "txt", "csv", "docx"]),
-  activity: new Set(["fit", "tcx", "gpx"]),
-  workout: new Set(["zwo", "mrc", "erg"]),
-  image: new Set(["png", "jpg", "jpeg", "webp"]),
-} as const;
 const ACTIVITY_EXPORT_FORMATS = new Set(["fit", "gpx"]);
 const WORKOUT_ARCHIVE_FORMATS = new Set(["zwo", "mrc", "erg", "fit"]);
 const TRAINING_EXPORT_REFUSAL_REASONS = new Set([
@@ -415,87 +411,16 @@ function canonicalIsoTimestamp(value: unknown): value is string {
   }
 }
 
-function parseTranscriptAttachments(value: unknown): readonly unknown[] {
-  if (!Array.isArray(value) || value.length > 5) throw new TypeError();
-  return value.map((attachment) => {
-    if (
-      !record(attachment) ||
-      !exactKeys(attachment, ["attachmentId", "displayName", "kind", "extension"]) ||
-      typeof attachment.attachmentId !== "string" ||
-      attachment.attachmentId.length === 0 ||
-      attachment.attachmentId.length > 128 ||
-      typeof attachment.displayName !== "string" ||
-      attachment.displayName.length === 0 ||
-      attachment.displayName.length > 512 ||
-      typeof attachment.kind !== "string" ||
-      !(attachment.kind in CHAT_ATTACHMENT_EXTENSIONS) ||
-      typeof attachment.extension !== "string" ||
-      !CHAT_ATTACHMENT_EXTENSIONS[attachment.kind as keyof typeof CHAT_ATTACHMENT_EXTENSIONS].has(
-        attachment.extension as never,
-      )
-    ) {
-      throw new TypeError();
-    }
-    return {
-      attachmentId: attachment.attachmentId,
-      displayName: attachment.displayName,
-      kind: attachment.kind,
-      extension: attachment.extension,
-    };
-  });
-}
-
 function parseTranscriptPage(
   value: unknown,
-  cursor: (candidate: unknown) => candidate is string = transcriptCursor,
+  schema: typeof GetTranscriptPageRpcResultSchema | typeof GetArchivedTranscriptPageRpcResultSchema,
 ): unknown {
-  if (
-    !record(value) ||
-    !exactKeys(value, ["schemaVersion", "status", "turns", "nextCursor"]) ||
-    value.schemaVersion !== 1 ||
-    (value.status !== "page" && value.status !== "restart-required") ||
-    !Array.isArray(value.turns) ||
-    value.turns.length > TRANSCRIPT_PAGE_MAX_TURNS ||
-    (value.nextCursor !== null && !cursor(value.nextCursor)) ||
-    textEncoder.encode(JSON.stringify(value)).byteLength > TRANSCRIPT_PAGE_MAX_RESPONSE_BYTES
-  ) {
+  if (textEncoder.encode(JSON.stringify(value)).byteLength > TRANSCRIPT_PAGE_MAX_RESPONSE_BYTES) {
     throw new TypeError();
   }
-  const turns = value.turns.map((turn) => {
-    const turnKeys = ["turnId", "completedAt", "athleteText", "coachText"];
-    if (
-      !record(turn) ||
-      (!exactKeys(turn, turnKeys) && !exactKeys(turn, [...turnKeys, "attachments"])) ||
-      typeof turn.turnId !== "string" ||
-      turn.turnId.length === 0 ||
-      !canonicalIsoTimestamp(turn.completedAt) ||
-      typeof turn.athleteText !== "string" ||
-      typeof turn.coachText !== "string"
-    ) {
-      throw new TypeError();
-    }
-    return {
-      turnId: turn.turnId,
-      completedAt: turn.completedAt,
-      athleteText: turn.athleteText,
-      coachText: turn.coachText,
-      ...(turn.attachments === undefined
-        ? {}
-        : { attachments: parseTranscriptAttachments(turn.attachments) }),
-    };
-  });
-  if (value.status === "restart-required" && (turns.length !== 0 || value.nextCursor !== null)) {
-    throw new TypeError();
-  }
-  if (value.status === "page" && turns.length === 0 && value.nextCursor !== null) {
-    throw new TypeError();
-  }
-  return {
-    schemaVersion: 1,
-    status: value.status,
-    turns,
-    nextCursor: value.nextCursor,
-  };
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) throw new TypeError();
+  return parsed.data;
 }
 
 function parseArchivedConversations(value: unknown): unknown {
@@ -1516,6 +1441,7 @@ contextBridge.exposeInMainWorld(
       const request = parseTranscriptPageRequest(input);
       return parseTranscriptPage(
         await ipcRenderer.invoke(DESKTOP_TRANSCRIPT_PAGE_CHANNEL, request),
+        GetTranscriptPageRpcResultSchema,
       );
     },
     listArchivedConversations: async () =>
@@ -1524,7 +1450,7 @@ contextBridge.exposeInMainWorld(
       const request = parseArchivedPageRequest(input);
       return parseTranscriptPage(
         await ipcRenderer.invoke(DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL, request),
-        archivedTranscriptCursor,
+        GetArchivedTranscriptPageRpcResultSchema,
       );
     },
     getPlanningReadModel: async () =>

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -958,6 +958,43 @@ describe("desktop preload ChatGPT auth", () => {
     });
   });
 
+  it("validates decision-aware transcript pages with typed Plan references", async () => {
+    const turn = {
+      turnId: "turn-1",
+      completedAt: "1998-07-06T00:00:00.000Z",
+      athleteText: "Show Tuesday",
+      coachText: "Tempo builder",
+      planReference: { kind: "workout_detail", planId: "plan-1", workoutId: "workout-1" },
+    };
+    const response = {
+      schemaVersion: 2,
+      status: "page",
+      turns: [turn],
+      entries: [{ kind: "turn", ...turn }],
+      nextCursor: null,
+    };
+    mocks.invoke.mockResolvedValueOnce(response);
+
+    await expect(bridge.getTranscriptPage({ cursor: null, limit: 25 })).resolves.toEqual(response);
+
+    mocks.invoke.mockResolvedValueOnce({
+      ...response,
+      turns: [
+        { ...turn, planReference: { ...turn.planReference, markup: "<button>Apply</button>" } },
+      ],
+      entries: [
+        {
+          kind: "turn",
+          ...turn,
+          planReference: { ...turn.planReference, markup: "<button>Apply</button>" },
+        },
+      ],
+    });
+    await expect(bridge.getTranscriptPage({ cursor: null, limit: 25 })).rejects.toBeInstanceOf(
+      TypeError,
+    );
+  });
+
   it("validates and copies the Planning-owned read model", async () => {
     const response = {
       schemaVersion: 1,

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -15,3 +15,4 @@ export * from "./coach-decision.js";
 export * from "./chat-queue.js";
 export * from "./chat-attachment.js";
 export * from "./planning-read.js";
+export * from "./plan-chat-card.js";

--- a/packages/coach-contract/src/plan-chat-card.ts
+++ b/packages/coach-contract/src/plan-chat-card.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+import {
+  ActivePlanReadModelSchema,
+  PlanDateKeySchema,
+  PlanNavigationTargetSchema,
+  PlanWorkoutReadModelSchema,
+} from "./planning-read.js";
+
+const PlanEntityIdSchema = z.string().min(1).max(256);
+
+export const PlanReferenceSelectionSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("active_plan_summary"),
+      planId: PlanEntityIdSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("current_week"),
+      planId: PlanEntityIdSchema,
+      weekNumber: z.number().int().positive(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("workout_detail"),
+      planId: PlanEntityIdSchema,
+      workoutId: PlanEntityIdSchema,
+    })
+    .strict(),
+]);
+export type PlanReferenceSelection = z.infer<typeof PlanReferenceSelectionSchema>;
+
+export const RequestPlanReferenceInputSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("active_plan_summary") }).strict(),
+  z.object({ kind: z.literal("current_week") }).strict(),
+  z
+    .object({
+      kind: z.literal("workout_detail"),
+      workoutId: PlanEntityIdSchema,
+    })
+    .strict(),
+]);
+export type RequestPlanReferenceInput = z.infer<typeof RequestPlanReferenceInputSchema>;
+
+export const PlanReferenceToolResultSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("unavailable"),
+      reason: z.enum(["no-plan", "outside-plan-dates", "workout-not-found"]),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("ready"),
+      selection: PlanReferenceSelectionSchema,
+      plan: ActivePlanReadModelSchema,
+      workout: PlanWorkoutReadModelSchema.nullable(),
+    })
+    .strict(),
+]);
+export type PlanReferenceToolResult = z.infer<typeof PlanReferenceToolResultSchema>;
+
+const OpenPlanActionSchema = z
+  .object({
+    label: z.literal("Open Plan"),
+    target: PlanNavigationTargetSchema,
+  })
+  .strict();
+
+const PlanChatCardBaseShape = {
+  cardId: z.string().min(1).max(768),
+  title: z.string().min(1).max(500),
+  summary: z.string().min(1).max(2_000),
+  action: OpenPlanActionSchema,
+};
+
+export const PlanChatCardReadModelSchema = z
+  .discriminatedUnion("kind", [
+    z
+      .object({
+        ...PlanChatCardBaseShape,
+        kind: z.literal("active_plan_summary"),
+        planId: PlanEntityIdSchema,
+        lifecycle: z.enum(["draft", "active"]),
+        currentWeek: z.number().int().positive(),
+        totalWeeks: z.number().int().positive(),
+        phase: z.string().min(1).max(500),
+      })
+      .strict(),
+    z
+      .object({
+        ...PlanChatCardBaseShape,
+        kind: z.literal("current_week"),
+        planId: PlanEntityIdSchema,
+        weekNumber: z.number().int().positive(),
+        totalWeeks: z.number().int().positive(),
+        phase: z.string().min(1).max(500),
+        workouts: z.array(PlanWorkoutReadModelSchema).max(31),
+      })
+      .strict(),
+    z
+      .object({
+        ...PlanChatCardBaseShape,
+        kind: z.literal("workout_detail"),
+        planId: PlanEntityIdSchema,
+        workoutId: PlanEntityIdSchema,
+        dateKey: PlanDateKeySchema,
+        durationMinutes: z.number().int().nonnegative().nullable(),
+        targets: z.string().min(1).max(2_000),
+        purpose: z.string().min(1).max(2_000),
+        safetyGuardrail: z.string().min(1).max(2_000),
+        applicationState: z.literal("current"),
+      })
+      .strict(),
+  ])
+  .superRefine((value, context) => {
+    const expected =
+      value.kind === "active_plan_summary"
+        ? { focus: "active-plan" as const, entityId: value.planId }
+        : value.kind === "current_week"
+          ? { focus: "current-week" as const, entityId: value.planId }
+          : { focus: "workout" as const, entityId: value.workoutId };
+    if (
+      value.action.target.focus !== expected.focus ||
+      value.action.target.entityId !== expected.entityId
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["action", "target"],
+        message: "Open Plan action must target the card's Planning entity",
+      });
+    }
+  });
+export type PlanChatCardReadModel = z.infer<typeof PlanChatCardReadModelSchema>;

--- a/packages/coach-contract/src/planning-read.ts
+++ b/packages/coach-contract/src/planning-read.ts
@@ -18,6 +18,9 @@ export const PlanWorkoutReadModelSchema = z
     sport: z.string().min(1),
     name: z.string().min(1),
     durationSeconds: z.number().int().nonnegative().nullable(),
+    targets: z.string().min(1).max(2_000).nullable().optional(),
+    purpose: z.string().min(1).max(2_000).nullable().optional(),
+    safetyGuardrail: z.string().min(1).max(2_000).nullable().optional(),
     origin: z.enum(["coach", "athlete"]),
     navigation: PlanNavigationTargetSchema,
   })
@@ -51,7 +54,10 @@ export const ActivePlanReadModelSchema = z
         message: "current week and its date range must appear together",
       });
     }
-    if (value.todayWorkout !== null && !value.workouts.some((item) => item.id === value.todayWorkout?.id)) {
+    if (
+      value.todayWorkout !== null &&
+      !value.workouts.some((item) => item.id === value.todayWorkout?.id)
+    ) {
       context.addIssue({
         code: "custom",
         path: ["todayWorkout"],

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -13,6 +13,7 @@ import {
 } from "./engine.js";
 import { TurnEventSchema, type TurnEvent } from "./turn-event.js";
 import { PlatformAbsolutePathSchema } from "./platform-path.js";
+import { PlanReferenceSelectionSchema } from "./plan-chat-card.js";
 import {
   AdmitPastedChatAttachmentRequestSchema,
   AdmitChatAttachmentRequestSchema,
@@ -394,8 +395,18 @@ export const TranscriptPageTurnSchema = z
     coachText: z.string(),
     delivery: z.literal("interrupted").optional(),
     attachments: z.array(ChatAttachmentReferenceSchema).max(5).optional(),
+    planReference: PlanReferenceSelectionSchema.optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, context) => {
+    if (value.delivery === "interrupted" && value.planReference !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["planReference"],
+        message: "interrupted turns cannot carry Plan references",
+      });
+    }
+  });
 export type TranscriptPageTurn = z.infer<typeof TranscriptPageTurnSchema>;
 
 export const TranscriptPageEntrySchema = z.discriminatedUnion("kind", [

--- a/packages/coach-contract/src/turn-event.ts
+++ b/packages/coach-contract/src/turn-event.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { CoachDecisionReadModelSchema } from "./coach-decision.js";
+import { PlanReferenceSelectionSchema } from "./plan-chat-card.js";
 
 /** Engine-internal turn failure classification (frozen field vocabulary). */
 export const TurnErrorClassSchema = z.enum([
@@ -129,6 +130,14 @@ export const DecisionRequestedEventSchema = z
     }
   });
 
+export const PlanReferenceSelectedEventSchema = z
+  .object({
+    type: z.literal("plan-reference"),
+    turnId: z.string().min(1),
+    selection: PlanReferenceSelectionSchema,
+  })
+  .strict();
+
 /**
  * Terminal shapes: a successful turn ends with `final-text` as its last event.
  * A failed turn with no committed writes ends with `error` and delivers no
@@ -146,6 +155,7 @@ export const TurnEventSchema = z.discriminatedUnion("type", [
   ErrorEventSchema,
   TextDeltaEventSchema,
   DecisionRequestedEventSchema,
+  PlanReferenceSelectedEventSchema,
 ]);
 export type TurnEvent = z.infer<typeof TurnEventSchema>;
 

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 27;
+export const PROTOCOL_VERSION = 28;

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe("chat queue contract", () => {
   it("ships protocol 26 and rejects a blank enqueue without attachments", () => {
-    expect(PROTOCOL_VERSION).toBe(27);
+    expect(PROTOCOL_VERSION).toBe(28);
     expect(() =>
       EnqueueChatMessageRequestSchema.parse({
         chatId: "desktop",

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -152,7 +152,7 @@ describe("coach decision wire contract", () => {
   });
 
   it("projects resume completion explicitly at protocol 26", () => {
-    expect(PROTOCOL_VERSION).toBe(27);
+    expect(PROTOCOL_VERSION).toBe(28);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -115,7 +115,7 @@ describe("exit codes", () => {
 
 describe("protocol version", () => {
   it("is 26", () => {
-    expect(PROTOCOL_VERSION).toBe(27);
+    expect(PROTOCOL_VERSION).toBe(28);
   });
 
   it("requires Stop to name the exact active turn", () => {

--- a/packages/coach-contract/tests/plan-chat-card.test.ts
+++ b/packages/coach-contract/tests/plan-chat-card.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  PlanChatCardReadModelSchema,
+  PlanReferenceSelectionSchema,
+  TranscriptPageTurnSchema,
+  TurnEventSchema,
+} from "../src/index.js";
+
+const selection = { kind: "workout_detail" as const, planId: "plan-1", workoutId: "workout-1" };
+
+describe("Plan Chat card contract", () => {
+  it("accepts strict persisted selections and rejects extra fields", () => {
+    expect(PlanReferenceSelectionSchema.parse(selection)).toEqual(selection);
+    expect(
+      PlanReferenceSelectionSchema.safeParse({ ...selection, markup: "<button>Apply</button>" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("requires the one Open Plan action to target the card entity", () => {
+    const card = {
+      kind: "workout_detail" as const,
+      cardId: "plan:plan-1:workout:workout-1",
+      planId: "plan-1",
+      workoutId: "workout-1",
+      title: "Tempo builder",
+      summary: "cycling",
+      dateKey: 20260826,
+      durationMinutes: 60,
+      targets: "3 × 8 min · 85–90% FTP",
+      purpose: "Sustainable power",
+      safetyGuardrail: "Stop if the warm-up feels wrong",
+      applicationState: "current" as const,
+      action: {
+        label: "Open Plan" as const,
+        target: { destination: "plan" as const, focus: "workout" as const, entityId: "workout-1" },
+      },
+    };
+    expect(PlanChatCardReadModelSchema.parse(card)).toEqual(card);
+    expect(
+      PlanChatCardReadModelSchema.safeParse({
+        ...card,
+        action: { ...card.action, target: { ...card.action.target, entityId: "workout-2" } },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("carries the same selection through live events and transcript pages", () => {
+    expect(
+      TurnEventSchema.parse({ type: "plan-reference", turnId: "turn-1", selection }),
+    ).toMatchObject({ selection });
+    expect(
+      TranscriptPageTurnSchema.parse({
+        turnId: "turn-1",
+        completedAt: "2026-08-26T00:00:00.000Z",
+        athleteText: "What is tomorrow?",
+        coachText: "Tempo builder.",
+        planReference: selection,
+      }),
+    ).toMatchObject({ planReference: selection });
+  });
+});

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1879,7 +1879,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-27 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-28 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1887,8 +1887,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 27,
-      serverProtocolVersion: 27,
+      clientProtocolVersion: 28,
+      serverProtocolVersion: 28,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1897,7 +1897,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(26);
+    expect(previous).toBe(27);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -1970,9 +1970,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 26 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 28 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(27);
+    expect(client.clientProtocolVersion).toBe(28);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2098,7 +2098,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version 26", () => {
-    expect(PROTOCOL_VERSION).toBe(27);
+  it("uses protocol version 28", () => {
+    expect(PROTOCOL_VERSION).toBe(28);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -1194,6 +1194,11 @@ export async function createLocalCoachComposition(
         config.session.resetArchiveRetentionDays,
         { platform: dependencies.platform },
       );
+      const planningReadService = createPlanningReadService({
+        store: input.context.store,
+        timezone,
+        now,
+      });
       const projectedConfig = engineConfigFromConfig(effectiveConfig);
       const attachmentCapabilityResolver = createAttachmentCapabilityResolver({
         openRouterCache: openRouterModelMetadata,
@@ -1302,6 +1307,9 @@ export async function createLocalCoachComposition(
         },
         transcriptWriter: conversationStore,
         coachDecisions: conversationStore,
+        planningRead: {
+          getPlanningReadModel: () => planningReadService.getPlanningReadModel({}),
+        },
         secrets: { resolve: resolveSecretRef },
         platform: {
           legacyClient,

--- a/packages/coach/src/planning-read-service.ts
+++ b/packages/coach/src/planning-read-service.ts
@@ -68,13 +68,42 @@ function phaseForWeek(plan: PlanRow, weekIndex: number | null): string | null {
   return null;
 }
 
+function workoutDetails(row: PlanWorkoutRow): {
+  readonly targets: string | null;
+  readonly purpose: string | null;
+  readonly safetyGuardrail: string | null;
+} {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.structure_json) as unknown;
+  } catch {
+    return { targets: null, purpose: null, safetyGuardrail: null };
+  }
+  if (!record(parsed)) return { targets: null, purpose: null, safetyGuardrail: null };
+  const details = parsed;
+  const text = (...keys: readonly string[]): string | null => {
+    for (const key of keys) {
+      const value = details[key];
+      if (typeof value === "string" && value.trim().length > 0) return value.trim();
+    }
+    return null;
+  };
+  return {
+    targets: text("targets", "target"),
+    purpose: text("purpose", "description"),
+    safetyGuardrail: text("safetyGuardrail", "safety_guardrail", "guardrail"),
+  };
+}
+
 function workoutReadModel(row: PlanWorkoutRow): PlanWorkoutReadModel {
+  const details = workoutDetails(row);
   return {
     id: row.id,
     dateKey: row.date_key,
     sport: row.sport,
     name: row.name,
     durationSeconds: row.duration_s,
+    ...details,
     origin: row.origin,
     navigation: { destination: "plan", focus: "workout", entityId: row.id },
   };
@@ -112,7 +141,8 @@ export function createPlanningReadService(input: PlanningReadServiceInput): Plan
                   workout.date_key >= range.startDateKey && workout.date_key <= range.endDateKey,
               )
               .map(workoutReadModel);
-      const todayWorkout = currentWorkouts.find((workout) => workout.dateKey === asOfDateKey) ?? null;
+      const todayWorkout =
+        currentWorkouts.find((workout) => workout.dateKey === asOfDateKey) ?? null;
 
       return GetPlanningReadModelRpcResultSchema.parse({
         schemaVersion: 1,

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -641,6 +641,7 @@ describe("local coach composition", () => {
       "now",
       "onToolsAssembled",
       "planPersistence",
+      "planningRead",
       "platform",
       "randomId",
       "readReferenceState",

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 27 as const,
-      serverProtocolVersion: 27 as const,
+      clientProtocolVersion: 28 as const,
+      serverProtocolVersion: 28 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -304,7 +304,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(27);
+    expect(PROTOCOL_VERSION).toBe(28);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/coach/tests/planning-read-service.test.ts
+++ b/packages/coach/tests/planning-read-service.test.ts
@@ -26,7 +26,9 @@ describe("Planning read service", () => {
 
   it("returns an explicit no-Plan state", async () => {
     await expect(
-      createPlanningReadService({ store, timezone: "UTC", now: () => NOW }).getPlanningReadModel({}),
+      createPlanningReadService({ store, timezone: "UTC", now: () => NOW }).getPlanningReadModel(
+        {},
+      ),
     ).resolves.toEqual({ schemaVersion: 1, status: "no-plan", asOfDateKey: 20260826, plan: null });
   });
 
@@ -61,7 +63,11 @@ describe("Planning read service", () => {
       sport: "cycling",
       name: "Tempo builder",
       duration_s: 3_600,
-      structure_json: "{}",
+      structure_json: JSON.stringify({
+        targets: "3 × 8 min · 85–90% FTP",
+        purpose: "Sustainable power",
+        safetyGuardrail: "Stop if the warm-up feels wrong",
+      }),
       origin: "coach",
       device_id: "desktop",
       hlc_physical_ms: NOW,
@@ -83,7 +89,13 @@ describe("Planning read service", () => {
       phase: "Base",
       weekStartDateKey: 20260824,
       weekEndDateKey: 20260830,
-      todayWorkout: { id: WORKOUT_ID, name: "Tempo builder" },
+      todayWorkout: {
+        id: WORKOUT_ID,
+        name: "Tempo builder",
+        targets: "3 × 8 min · 85–90% FTP",
+        purpose: "Sustainable power",
+        safetyGuardrail: "Stop if the warm-up feels wrong",
+      },
     });
     expect(result.plan.workouts).toHaveLength(1);
   });

--- a/packages/core/src/agent/transcript-store.ts
+++ b/packages/core/src/agent/transcript-store.ts
@@ -29,10 +29,13 @@ import {
   ChatAttachmentReferenceSchema,
   CoachDecisionAnswerSchema,
   CoachDecisionReadModelSchema,
+  PlanReferenceSelectionSchema,
   type CoachDecisionAnswer,
   type CoachDecisionContinuationLineage,
   type CoachDecisionOption,
   type CoachDecisionReadModel,
+  type ChatAttachmentReference,
+  type PlanReferenceSelection,
 } from "@enduragent/coach-contract";
 import {
   WindowsPrivatePathPolicyError,
@@ -241,6 +244,8 @@ export interface TranscriptPageTurn {
   readonly athleteText: string;
   readonly coachText: string;
   readonly delivery?: "interrupted";
+  readonly attachments?: ChatAttachmentReference[];
+  readonly planReference?: PlanReferenceSelection;
 }
 
 export type TranscriptPageEntry =
@@ -452,8 +457,12 @@ function parseRecordBytes(bytes: Buffer): TranscriptRecord | null {
 
   if (value.kind === "turn-completed" || value.kind === "turn-interrupted") {
     const keys = ["version", "kind", "chatId", "turnId", "completedAt", "athleteText", "coachText"];
+    const optionalKeys = [
+      ...(value.attachments === undefined ? [] : ["attachments"]),
+      ...(value.planReference === undefined ? [] : ["planReference"]),
+    ];
     if (
-      (!hasExactKeys(value, keys) && !hasExactKeys(value, [...keys, "attachments"])) ||
+      !hasExactKeys(value, [...keys, ...optionalKeys]) ||
       typeof value.chatId !== "string" ||
       typeof value.turnId !== "string" ||
       value.turnId.length === 0 ||
@@ -461,8 +470,11 @@ function parseRecordBytes(bytes: Buffer): TranscriptRecord | null {
       !isIsoTimestamp(value.completedAt) ||
       typeof value.athleteText !== "string" ||
       typeof value.coachText !== "string" ||
+      (value.kind === "turn-interrupted" && value.planReference !== undefined) ||
       (value.attachments !== undefined &&
-        !ChatAttachmentReferenceSchema.array().max(5).safeParse(value.attachments).success)
+        !ChatAttachmentReferenceSchema.array().max(5).safeParse(value.attachments).success) ||
+      (value.planReference !== undefined &&
+        !PlanReferenceSelectionSchema.safeParse(value.planReference).success)
     ) {
       return null;
     }
@@ -636,7 +648,9 @@ function completedTurnRecord(input: TranscriptCompletedTurnInput): TranscriptCom
     typeof input.athleteText !== "string" ||
     typeof input.coachText !== "string" ||
     (input.attachments !== undefined &&
-      !ChatAttachmentReferenceSchema.array().max(5).safeParse(input.attachments).success)
+      !ChatAttachmentReferenceSchema.array().max(5).safeParse(input.attachments).success) ||
+    (input.planReference !== undefined &&
+      !PlanReferenceSelectionSchema.safeParse(input.planReference).success)
   ) {
     throw new TypeError("Completed transcript turn is invalid.");
   }
@@ -649,12 +663,16 @@ function completedTurnRecord(input: TranscriptCompletedTurnInput): TranscriptCom
     athleteText: input.athleteText,
     coachText: input.coachText,
     ...(input.attachments === undefined ? {} : { attachments: [...input.attachments] }),
+    ...(input.planReference === undefined ? {} : { planReference: { ...input.planReference } }),
   };
 }
 
 function interruptedTurnRecord(
   input: TranscriptInterruptedTurnInput,
 ): TranscriptInterruptedTurnRecord {
+  if (input.planReference !== undefined) {
+    throw new TypeError("Interrupted transcript turn cannot carry a Plan reference.");
+  }
   const completed = completedTurnRecord(input);
   return { ...completed, kind: "turn-interrupted" };
 }
@@ -905,7 +923,8 @@ function transcriptPageTurn(record: TranscriptTurnRecord): TranscriptPageTurn {
     completedAt: record.completedAt,
     athleteText: record.athleteText,
     coachText: record.coachText,
-    ...(record.attachments === undefined ? {} : { attachments: record.attachments }),
+    ...(record.attachments === undefined ? {} : { attachments: [...record.attachments] }),
+    ...(record.planReference === undefined ? {} : { planReference: record.planReference }),
     ...(record.kind === "turn-interrupted" ? { delivery: "interrupted" as const } : {}),
   };
 }

--- a/packages/core/tests/transcript-store.test.ts
+++ b/packages/core/tests/transcript-store.test.ts
@@ -458,6 +458,45 @@ describe("TranscriptStore append and corruption handling", () => {
     ).toThrow("Completed transcript turn is invalid");
   });
 
+  it("round-trips one typed Plan reference for relaunch hydration", () => {
+    const dataDir = makeDataDir();
+    const store = new TranscriptStore(dataDir);
+    const input = {
+      ...turn("chat-plan-reference", "turn-1", "Show Tuesday", "Tempo builder"),
+      planReference: {
+        kind: "workout_detail" as const,
+        planId: "plan-1",
+        workoutId: "workout-1",
+      },
+    };
+
+    store.appendCompletedTurn(input);
+
+    expect(store.readCurrentConversation(input.chatId)).toEqual([
+      { version: 1, kind: "turn-completed", ...input },
+    ]);
+    expect(
+      store.readCurrentConversationPage(input.chatId, { cursor: null, limit: 10 }),
+    ).toMatchObject({
+      status: "page",
+      turns: [{ turnId: "turn-1", planReference: input.planReference }],
+    });
+  });
+
+  it("rejects arbitrary Plan-card markup in transcript records", () => {
+    const store = new TranscriptStore(makeDataDir());
+    expect(() =>
+      store.appendCompletedTurn({
+        ...turn("chat-plan-reference-invalid", "turn-1"),
+        planReference: {
+          kind: "active_plan_summary",
+          planId: "plan-1",
+          markup: "<button>Apply</button>",
+        },
+      } as never),
+    ).toThrow("Completed transcript turn is invalid");
+  });
+
   it("round-trips an interrupted turn and projects its delivery on transcript pages", () => {
     const dataDir = makeDataDir();
     const store = new TranscriptStore(dataDir);

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -89,6 +89,7 @@ import {
   decisionContinuationMessage,
   decisionRequestInput,
 } from "./coach-decision-tool.js";
+import { PLAN_REFERENCE_TOOL_NAME, createPlanReferenceTool } from "./plan-reference-tool.js";
 import { attachNativeMediaToCurrentUserMessage } from "../native-media-message.js";
 
 const MAX_OVERFLOW_ATTEMPTS = 3;
@@ -330,6 +331,7 @@ export class CoachAgent {
   private log: LoggerPort;
   private tools: ToolSet;
   private readonly decisionTool: Tool | undefined;
+  private readonly planReferenceTool: Tool | undefined;
   private systemPrompt: string;
   private tz: string;
   // Derived once from getEffectiveSections(sport): the spec'd sections with
@@ -440,10 +442,27 @@ export class CoachAgent {
           now: ports.now,
         })
       : undefined;
-    this.tools =
-      this.decisionTool === undefined
-        ? sportTools
-        : { ...sportTools, [COACH_DECISION_TOOL_NAME]: this.decisionTool };
+    this.planReferenceTool =
+      ports.planningRead === undefined
+        ? undefined
+        : this.observeToolProvenance(
+            PLAN_REFERENCE_TOOL_NAME,
+            memoizeReadTool(
+              PLAN_REFERENCE_TOOL_NAME,
+              capToolResult(
+                markUntrustedResult(createPlanReferenceTool({ planning: ports.planningRead })),
+                { maxResultTokens },
+              ),
+              (options: unknown) => getTurnContext(options)?.readToolCache,
+            ),
+          );
+    this.tools = {
+      ...sportTools,
+      ...(this.decisionTool === undefined ? {} : { [COACH_DECISION_TOOL_NAME]: this.decisionTool }),
+      ...(this.planReferenceTool === undefined
+        ? {}
+        : { [PLAN_REFERENCE_TOOL_NAME]: this.planReferenceTool }),
+    };
     ports.onToolsAssembled?.(Object.freeze(Object.keys(this.tools)));
     // systemPrompt is rebuilt at the top of every chat() call; no need to bake one here.
     this.systemPrompt = "";
@@ -1183,7 +1202,17 @@ export class CoachAgent {
                 athleteText: userMessage,
                 coachText: responseText,
                 ...(turn?.attachments === undefined ? {} : { attachments: turn.attachments }),
+                ...(ctx.planReference.selection === null
+                  ? {}
+                  : { planReference: ctx.planReference.selection }),
               });
+              if (ctx.planReference.selection !== null) {
+                emitEvent({
+                  type: "plan-reference",
+                  turnId,
+                  selection: ctx.planReference.selection,
+                });
+              }
               emitEvent({ type: "final-text", turnId, text: responseText });
               return responseText;
             } catch (err) {

--- a/packages/engine/src/agent/plan-reference-tool.ts
+++ b/packages/engine/src/agent/plan-reference-tool.ts
@@ -1,0 +1,66 @@
+import { tool, zodSchema } from "ai";
+import {
+  PlanReferenceToolResultSchema,
+  RequestPlanReferenceInputSchema,
+  type PlanReferenceSelection,
+  type RequestPlanReferenceInput,
+} from "@enduragent/coach-contract";
+import type { PlanningReadPort } from "../host-ports.js";
+import { getTurnContext } from "./turn-context.js";
+
+export const PLAN_REFERENCE_TOOL_NAME = "read_plan_reference";
+
+export function createPlanReferenceTool(input: { readonly planning: PlanningReadPort }) {
+  return tool({
+    description:
+      "Read the athlete's current saved Plan and request one standard read-only Plan card. Use active_plan_summary for Plan-level questions, current_week for week/date questions, and workout_detail only after a prior result supplied the exact workoutId.",
+    inputSchema: zodSchema(RequestPlanReferenceInputSchema),
+    execute: async (request: RequestPlanReferenceInput, options: unknown) => {
+      const readModel = await input.planning.getPlanningReadModel();
+      if (readModel.status === "no-plan") {
+        return PlanReferenceToolResultSchema.parse({ status: "unavailable", reason: "no-plan" });
+      }
+      const plan = readModel.plan;
+      let selection: PlanReferenceSelection;
+      let workout = null;
+      if (request.kind === "active_plan_summary") {
+        if (plan.currentWeek === null) {
+          return PlanReferenceToolResultSchema.parse({
+            status: "unavailable",
+            reason: "outside-plan-dates",
+          });
+        }
+        selection = { kind: request.kind, planId: plan.id };
+      } else if (request.kind === "current_week") {
+        if (plan.currentWeek === null) {
+          return PlanReferenceToolResultSchema.parse({
+            status: "unavailable",
+            reason: "outside-plan-dates",
+          });
+        }
+        selection = { kind: request.kind, planId: plan.id, weekNumber: plan.currentWeek };
+      } else {
+        workout = plan.workouts.find((candidate) => candidate.id === request.workoutId) ?? null;
+        if (workout === null) {
+          return PlanReferenceToolResultSchema.parse({
+            status: "unavailable",
+            reason: "workout-not-found",
+          });
+        }
+        selection = {
+          kind: request.kind,
+          planId: plan.id,
+          workoutId: workout.id,
+        };
+      }
+      const context = getTurnContext(options);
+      if (context?.chatId === "desktop") context.planReference.selection = selection;
+      return PlanReferenceToolResultSchema.parse({
+        status: "ready",
+        selection,
+        plan,
+        workout,
+      });
+    },
+  });
+}

--- a/packages/engine/src/agent/turn-context.ts
+++ b/packages/engine/src/agent/turn-context.ts
@@ -1,6 +1,6 @@
 import type { ResolvedCs } from "@enduragent/kernel/reference/cs-resolution";
 import { EMPTY_PROVENANCE, type SourceProvenance } from "../provenance.js";
-import type { CoachDecisionReadModel } from "@enduragent/coach-contract";
+import type { CoachDecisionReadModel, PlanReferenceSelection } from "@enduragent/coach-contract";
 
 export interface TurnWriteRecord {
   writesCommitted: number;
@@ -14,6 +14,10 @@ export interface TurnProvenanceRecord {
 export interface TurnDecisionRecord {
   requested: CoachDecisionReadModel | null;
   fallbackText: string | null;
+}
+
+export interface TurnPlanReferenceRecord {
+  selection: PlanReferenceSelection | null;
 }
 
 // Explicit per-turn state, threaded to tool execution through the
@@ -41,6 +45,7 @@ export interface TurnContext {
   /** Source labels of the reference snapshot the channel resolved this turn's anchor from. */
   readonly referenceProvenance: SourceProvenance;
   readonly decision: TurnDecisionRecord;
+  readonly planReference: TurnPlanReferenceRecord;
 }
 
 const TURN_CONTEXT_BRAND = Symbol("turn-context");
@@ -67,6 +72,7 @@ export function createTurnContext(
     provenance: { value: EMPTY_PROVENANCE },
     referenceProvenance,
     decision: { requested: null, fallbackText: null },
+    planReference: { selection: null },
   };
   return ctx;
 }

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -2,6 +2,8 @@ import type {
   AttachmentCapabilitiesReadModel,
   AthleteState,
   ChatAttachmentReference,
+  PlanningReadModel,
+  PlanReferenceSelection,
   ChatQueueSnapshot,
   CoachDecisionAnswer,
   CoachDecisionContinuationLineage,
@@ -247,6 +249,7 @@ export interface TranscriptCompletedTurnInput {
   readonly athleteText: string;
   readonly coachText: string;
   readonly attachments?: readonly ChatAttachmentReference[];
+  readonly planReference?: PlanReferenceSelection;
 }
 
 export type TranscriptInterruptedTurnInput = TranscriptCompletedTurnInput;
@@ -450,6 +453,10 @@ export interface AthleteStateReaderPort {
   getAthleteState(): Promise<AthleteState>;
 }
 
+export interface PlanningReadPort {
+  getPlanningReadModel(): Promise<PlanningReadModel>;
+}
+
 export interface ReferenceStateSnapshot {
   readonly errorState: {
     readonly mitigation?: string;
@@ -467,6 +474,7 @@ export interface EngineHostPorts {
   readonly chatStore: ChatStorePort;
   readonly chatAttachments?: ChatAttachmentTurnPort;
   readonly attachmentCapabilities?: AttachmentCapabilitiesPort;
+  readonly planningRead?: PlanningReadPort;
   readonly transcriptWriter: TranscriptWriterPort;
   readonly coachDecisions?: CoachDecisionStorePort;
   readonly secrets: SecretsPort;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -61,6 +61,7 @@ export type {
   PlatformCalendarMutationsPort,
   PlatformClientPort,
   PlanPersistencePort,
+  PlanningReadPort,
   ReferenceStateSnapshot,
   SecretRef,
   SecretsPort,

--- a/packages/engine/tests/coach-agent-transcript.test.ts
+++ b/packages/engine/tests/coach-agent-transcript.test.ts
@@ -53,6 +53,7 @@ function harness(input: {
   appendInterruptedTurn?: (turn: TranscriptInterruptedTurnInput) => void;
   config?: Partial<EngineHostPorts["config"]["session"]>;
   randomId?: () => string;
+  planningRead?: EngineHostPorts["planningRead"];
 }) {
   const dataDir = makeDataDir();
   const base = baseAgentConfig(dataDir);
@@ -81,6 +82,7 @@ function harness(input: {
       appendInterruptedTurn: input.appendInterruptedTurn ?? ((turn) => interrupted.push(turn)),
     },
     modelTransportDecorator: () => ({ generate: input.generate }),
+    ...(input.planningRead === undefined ? {} : { planningRead: input.planningRead }),
   };
   return {
     dataDir,
@@ -157,6 +159,57 @@ describe("CoachAgent transcript recording", () => {
       athleteText: "athlete retry text",
       coachText: "recovered response",
     });
+  });
+
+  it("emits and persists one Desktop Plan reference before final text", async () => {
+    const setup = harness({
+      planningRead: {
+        getPlanningReadModel: async () => ({
+          schemaVersion: 1,
+          status: "ready",
+          asOfDateKey: 20260826,
+          plan: {
+            id: "plan-1",
+            name: "Twelve-week base",
+            goal: "Build consistency",
+            lifecycle: "active",
+            startDateKey: 20260824,
+            targetDateKey: null,
+            currentWeek: 1,
+            totalWeeks: 12,
+            phase: "Base",
+            weekStartDateKey: 20260824,
+            weekEndDateKey: 20260830,
+            workouts: [],
+            todayWorkout: null,
+            navigation: { destination: "plan", focus: "active-plan", entityId: "plan-1" },
+          },
+        }),
+      },
+      generate: async (request) => {
+        const planTool = request.options.tools?.read_plan_reference;
+        if (planTool?.execute === undefined) throw new TypeError("Plan reference tool missing");
+        await (planTool.execute as (input: unknown, options: unknown) => Promise<unknown>)(
+          { kind: "active_plan_summary" },
+          { toolCallId: "tool-1", experimental_context: request.options.context },
+        );
+        return result("Your current Plan is Twelve-week base.");
+      },
+    });
+    const events: TurnEvent[] = [];
+
+    await setup.agent.chat("desktop", "Show my Plan", undefined, (event) => events.push(event));
+
+    const selection = { kind: "active_plan_summary" as const, planId: "plan-1" };
+    expect(setup.completed).toMatchObject([{ planReference: selection }]);
+    expect(events.slice(-2)).toEqual([
+      { type: "plan-reference", turnId: "turn-transcript-1", selection },
+      {
+        type: "final-text",
+        turnId: "turn-transcript-1",
+        text: "Your current Plan is Twelve-week base.",
+      },
+    ]);
   });
 
   it.each(["ENOSPC", "EACCES"])(

--- a/packages/engine/tests/plan-reference-tool.test.ts
+++ b/packages/engine/tests/plan-reference-tool.test.ts
@@ -1,0 +1,83 @@
+import type { PlanningReadModel } from "@enduragent/coach-contract";
+import { describe, expect, it, vi } from "vitest";
+import { createPlanReferenceTool } from "../src/agent/plan-reference-tool.js";
+import { createTurnContext } from "../src/agent/turn-context.js";
+
+const planning: PlanningReadModel = {
+  schemaVersion: 1,
+  status: "ready",
+  asOfDateKey: 20260826,
+  plan: {
+    id: "plan-1",
+    name: "Twelve-week base",
+    goal: "Build consistency",
+    lifecycle: "active",
+    startDateKey: 20260824,
+    targetDateKey: null,
+    currentWeek: 1,
+    totalWeeks: 12,
+    phase: "Base",
+    weekStartDateKey: 20260824,
+    weekEndDateKey: 20260830,
+    workouts: [
+      {
+        id: "workout-1",
+        dateKey: 20260826,
+        sport: "cycling",
+        name: "Tempo builder",
+        durationSeconds: 3_600,
+        targets: "3 × 8 min",
+        purpose: "Sustainable power",
+        safetyGuardrail: "Stop if the warm-up feels wrong",
+        origin: "coach",
+        navigation: { destination: "plan", focus: "workout", entityId: "workout-1" },
+      },
+    ],
+    todayWorkout: null,
+    navigation: { destination: "plan", focus: "active-plan", entityId: "plan-1" },
+  },
+};
+
+async function execute(
+  request: unknown,
+  context = createTurnContext(null, "desktop", undefined, "Show my Plan", "turn-1"),
+) {
+  const read = vi.fn(async () => planning);
+  const planTool = createPlanReferenceTool({ planning: { getPlanningReadModel: read } });
+  const result = await (planTool.execute as (input: unknown, options: unknown) => Promise<unknown>)(
+    request,
+    { experimental_context: context },
+  );
+  return { context, read, result };
+}
+
+describe("read_plan_reference tool", () => {
+  it.each([
+    ["active_plan_summary", { kind: "active_plan_summary", planId: "plan-1" }],
+    ["current_week", { kind: "current_week", planId: "plan-1", weekNumber: 1 }],
+  ] as const)("records one typed %s selection for Desktop", async (kind, selection) => {
+    const value = await execute({ kind });
+    expect(value.read).toHaveBeenCalledOnce();
+    expect(value.context.planReference.selection).toEqual(selection);
+    expect(value.result).toMatchObject({ status: "ready", selection });
+  });
+
+  it("requires the exact Planning-owned workout ID", async () => {
+    const ready = await execute({ kind: "workout_detail", workoutId: "workout-1" });
+    expect(ready.context.planReference.selection).toEqual({
+      kind: "workout_detail",
+      planId: "plan-1",
+      workoutId: "workout-1",
+    });
+    const missing = await execute({ kind: "workout_detail", workoutId: "made-up" });
+    expect(missing.result).toEqual({ status: "unavailable", reason: "workout-not-found" });
+    expect(missing.context.planReference.selection).toBeNull();
+  });
+
+  it("returns Plan data outside Desktop without recording a host card", async () => {
+    const context = createTurnContext(null, "telegram:42", undefined, "Show my Plan", "turn-1");
+    const value = await execute({ kind: "active_plan_summary" }, context);
+    expect(value.result).toMatchObject({ status: "ready" });
+    expect(context.planReference.selection).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a typed host-owned Plan reference tool for active Plan, current week, and workout details
- persist strict Plan card selections in Chat transcripts and safely re-project them against current Plan data
- render read-only Training Status C-style cards with one Open Plan action and no mutation controls

## Verification
- pnpm check
- pnpm test (10,150 passed; 15 skipped)
- autoreview --mode uncommitted (clean)

This child PR targets epic/chat-page only.