### PR TITLE
test(plan): update migration version expectations

### DIFF
--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -588,7 +588,7 @@ describe("account identity", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 16 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 17 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(
         beforeWorkouts,

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -582,7 +582,7 @@ describe("coach sync composition", () => {
           return store.get("PRAGMA user_version");
         },
       );
-      expect(value).toEqual({ user_version: 16 });
+      expect(value).toEqual({ user_version: 17 });
       expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
       expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
       expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -590,7 +590,7 @@ describe("coach sync composition", () => {
       const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
       try {
         await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-          user_version: 16,
+          user_version: 17,
         });
       } finally {
         await reopened.close();


### PR DESCRIPTION
## Summary
- update the two remaining store schema assertions from migration version 16 to 17
- align the full CI suite with the P14 workout-drift migration already merged into the Plan epic

## Proof
- pnpm exec vitest run packages/coach/tests/account-identity.test.ts packages/coach/tests/coach-sync.test.ts (47 passed)
- pnpm check
- final isolated P14 autoreview clean