### PR TITLE
fix(desktop): require Authenticode and provenance before Windows release upload

### DIFF
--- a/.changeset/windows-release-review-fixes.md
+++ b/.changeset/windows-release-review-fixes.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Windows release lane: the uploader requires local Authenticode verification and a real publisher DN before any release mutation, records partially uploaded assets on failure, and refuses an upload record inside the artifact directory; the verification workflow runs on `windows-latest` and binds the installer's sealed release commit; the updater round-trip recomputes blockmap chunk checksums against the installer bytes.

--- a/.github/workflows/desktop-windows-release.yml
+++ b/.github/workflows/desktop-windows-release.yml
@@ -32,9 +32,12 @@ concurrency:
 
 jobs:
   verify-windows-envelope:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    runs-on: windows-latest
+    timeout-minutes: 45
     permissions: { contents: write }
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -81,6 +84,20 @@ jobs:
           fi
           RELEASE_ID=$(printf '%s' "$RELEASE" | jq -er '.id')
           echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+          REF=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/enduragent-desktop@$VERSION")
+          OBJECT_TYPE=$(printf '%s' "$REF" | jq -er '.object.type')
+          OBJECT_SHA=$(printf '%s' "$REF" | jq -er '.object.sha')
+          if [ "$OBJECT_TYPE" = 'tag' ]; then
+            OBJECT_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$OBJECT_SHA" | jq -er 'select(.object.type == "commit") | .object.sha')
+          elif [ "$OBJECT_TYPE" != 'commit' ]; then
+            echo '::error::Desktop release tag is unresolvable'
+            exit 1
+          fi
+          if ! printf '%s' "$OBJECT_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo '::error::Desktop release tag is unresolvable'
+            exit 1
+          fi
+          echo "commit=$OBJECT_SHA" >> "$GITHUB_OUTPUT"
       - name: Refuse to mark assets while Authenticode is pending
         if: ${{ inputs.dry_run == false && inputs.authenticode != 'verify' }}
         run: |
@@ -92,32 +109,36 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/windows-release"
+          WORK="$(cygpath -u "$RUNNER_TEMP")/windows-release"
+          mkdir -p "$WORK"
           gh release download "enduragent-desktop@$VERSION" \
             --repo "$GITHUB_REPOSITORY" \
-            --dir "$RUNNER_TEMP/windows-release" \
+            --dir "$WORK" \
             --pattern "Enduragent-$VERSION-x64.exe" \
             --pattern "Enduragent-$VERSION-x64.exe.blockmap" \
             --pattern latest.yml
-          test "$(ls -1 "$RUNNER_TEMP/windows-release" | LC_ALL=C sort)" = "$(printf '%s\n' "Enduragent-$VERSION-x64.exe" "Enduragent-$VERSION-x64.exe.blockmap" latest.yml | LC_ALL=C sort)"
+          test "$(ls -1 "$WORK" | LC_ALL=C sort)" = "$(printf '%s\n' "Enduragent-$VERSION-x64.exe" "Enduragent-$VERSION-x64.exe.blockmap" latest.yml | LC_ALL=C sort)"
       - name: Verify Windows release envelope
         id: verify
         env:
           VERSION: ${{ inputs.version }}
           AUTHENTICODE: ${{ inputs.authenticode }}
           PUBLISHER_DN: ${{ inputs.publisher_dn }}
+          COMMIT: ${{ steps.release.outputs.commit }}
         run: |
           set -euo pipefail
+          WORK="$(cygpath -u "$RUNNER_TEMP")/windows-release"
+          WORK_WIN="$(cygpath -w "$WORK")"
           if [ "$AUTHENTICODE" = 'verify' ]; then
             if [ -z "$PUBLISHER_DN" ] || [ "$PUBLISHER_DN" = 'CN=ENDURAGENT PUBLISHER DN PLACEHOLDER, O=PLACEHOLDER' ]; then
               echo '::error::publisher_dn is required'
               exit 1
             fi
-            node apps/desktop/scripts/verify-windows-release.mjs "$RUNNER_TEMP/windows-release" --version "$VERSION" --authenticode verify --publisher-dn "$PUBLISHER_DN" | tee "$RUNNER_TEMP/verify.out"
+            node apps/desktop/scripts/verify-windows-release.mjs "$WORK_WIN" --version "$VERSION" --commit "$COMMIT" --authenticode verify --publisher-dn "$PUBLISHER_DN" | tee "$WORK/../verify.out"
           else
-            node apps/desktop/scripts/verify-windows-release.mjs "$RUNNER_TEMP/windows-release" --version "$VERSION" --authenticode pending-w19 | tee "$RUNNER_TEMP/verify.out"
+            node apps/desktop/scripts/verify-windows-release.mjs "$WORK_WIN" --version "$VERSION" --commit "$COMMIT" --authenticode pending-w19 | tee "$WORK/../verify.out"
           fi
-          INSTALLER_SHA256=$(awk '/^Windows release envelope verified [0-9a-f]{64}$/{sha=$NF} END{if (sha == "") exit 1; print sha}' "$RUNNER_TEMP/verify.out")
+          INSTALLER_SHA256=$(awk '/^Windows release envelope verified [0-9a-f]{64}$/{sha=$NF} END{if (sha == "") exit 1; print sha}' "$WORK/../verify.out")
           echo "installer_sha256=$INSTALLER_SHA256" >> "$GITHUB_OUTPUT"
           echo "authenticode=$AUTHENTICODE" >> "$GITHUB_OUTPUT"
       - name: Mark Windows assets verified
@@ -128,16 +149,17 @@ jobs:
           INSTALLER_SHA256: ${{ steps.verify.outputs.installer_sha256 }}
         run: |
           set -euo pipefail
-          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$RUNNER_TEMP/release.json"
-          jq -j '.body // ""' "$RUNNER_TEMP/release.json" > "$RUNNER_TEMP/release-body.txt"
+          TEMP="$(cygpath -u "$RUNNER_TEMP")"
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$TEMP/release.json"
+          jq -j '.body // ""' "$TEMP/release.json" > "$TEMP/release-body.txt"
           MARKER="Windows assets verified: $INSTALLER_SHA256 (Authenticode verified)"
-          if grep -Fxq "$MARKER" "$RUNNER_TEMP/release-body.txt"; then
+          if grep -Fxq "$MARKER" "$TEMP/release-body.txt"; then
             exit 0
           fi
-          printf '\n\n%s' "$MARKER" >> "$RUNNER_TEMP/release-body.txt"
-          jq -n --rawfile body "$RUNNER_TEMP/release-body.txt" '{body: $body}' > "$RUNNER_TEMP/release-patch.json"
+          printf '\n\n%s' "$MARKER" >> "$TEMP/release-body.txt"
+          jq -n --rawfile body "$TEMP/release-body.txt" '{body: $body}' > "$TEMP/release-patch.json"
           gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
-            --input "$RUNNER_TEMP/release-patch.json" >/dev/null
+            --input "$TEMP/release-patch.json" >/dev/null
       - name: Dry run summary
         if: ${{ inputs.dry_run == true }}
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,32 +181,37 @@ Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is t
 - Upload only `Enduragent-<x.y.z>-x64.exe`, `Enduragent-<x.y.z>-x64.exe.blockmap`, and `latest.yml` from the repository root on the signing host, using absolute paths:
 
   ```bash
-  node apps/desktop/scripts/upload-windows-release.mjs --version <x.y.z> --directory <absolute-artifact-dir> --commit <release-commit-sha> --authenticode pending-w19 --record <absolute-path>/windows-release-<x.y.z>.json
+  node apps/desktop/scripts/upload-windows-release.mjs --version <x.y.z> --directory <absolute-artifact-dir> --commit <release-commit-sha> --authenticode verify --publisher-dn "<PUBLISHER_DN>" --record <absolute-path>/windows-release-<x.y.z>.json
   ```
 
+- Pass `--authenticode verify` and the exact certificate subject as `--publisher-dn`. The uploader rejects every other mode and the placeholder DN.
+- Pass `--thumbprint <40-hex>` to pin the signing certificate. Omit it to accept any trusted certificate with the expected subject.
+- Run the upload on a Windows host with PowerShell 7 and `signtool.exe`. Local Authenticode verification runs before any release mutation.
+- Keep `--record` outside `--directory`. The uploader refuses a record path inside the artifact directory.
 - Omit `--record` only when no local JSON record is required.
 - Leave `--repo` unset to use `yerzhansa/enduragent`.
-- Let `upload-windows-release.mjs` run `verify-windows-release.mjs` locally.
+- Let `upload-windows-release.mjs` run `verify-windows-release.mjs` locally, including Authenticode and provenance verification.
 - Stop the upload when `enduragent-desktop@<x.y.z>` is missing or still a draft.
 - Refuse the upload when any Windows envelope asset already exists on the release.
 - Upload the verified envelope through `gh-personal release upload`.
 - Re-read the release after upload and fail unless all three assets are present.
+- Read `uploadedAssets` in a failed record before retrying. A partial upload lists the assets that became public.
 - Trigger the separate verification workflow from the repository root:
 
   ```bash
-  gh-personal workflow run desktop-windows-release.yml -f version=<x.y.z> -f dry_run=false
+  gh-personal workflow run desktop-windows-release.yml -f version=<x.y.z> -f dry_run=false -f authenticode=verify -f publisher_dn="<PUBLISHER_DN>"
   ```
 
 - Leave `dry_run` at its `true` default to verify without editing the release.
-- Pass `dry_run=false` only when the release body must record the completed verification.
-- Keep `desktop-windows-release.yml` to its single `verify-windows-envelope` job on `ubuntu-latest`.
+- Pass `dry_run=false` only when the release body must record the completed verification. The workflow refuses `dry_run=false` without `authenticode=verify` and a real `publisher_dn`.
+- Keep `desktop-windows-release.yml` to its single `verify-windows-envelope` job on `windows-latest`. `Get-AuthenticodeSignature` and `signtool.exe` exist only on Windows.
 - Reject a non-stable SemVer or a missing, draft, or prerelease `enduragent-desktop@<version>` release in `verify-windows-envelope`.
 - Require exactly `Enduragent-<version>-x64.exe`, `Enduragent-<version>-x64.exe.blockmap`, and `latest.yml` as the Windows envelope among the release assets.
 - Download only those three Windows assets in `verify-windows-envelope`.
-- Run `node apps/desktop/scripts/verify-windows-release.mjs <dir> --version <version> --authenticode pending-w19` against the downloaded envelope.
-- Print the `Authenticode verification pending` notice during verification.
-- Append `Windows assets verified: <installer sha256> (Authenticode verification pending)` to the release body only when `dry_run=false`.
+- Resolve the release tag to its commit and pass it as `--commit`.
+- Run `node apps/desktop/scripts/verify-windows-release.mjs <dir> --version <version> --commit <sha> --authenticode verify --publisher-dn <dn>` against the downloaded envelope.
+- Append `Windows assets verified: <installer sha256> (Authenticode verified)` to the release body only when `dry_run=false`.
 - Never create, move, or delete a release, tag, or asset in `desktop-windows-release.yml`.
 - Leave uploaded assets in place when verification fails.
 - Remove failed Windows assets by hand before retrying.
-- CI does not verify Authenticode yet. The workflow prints a pending notice and appends the marker with the text `(Authenticode verification pending)`.
+- Build provenance: `windows-release-plan.mjs` seals `enduragent-release-commit:<sha>` into the installer's `LegalTrademarks` version string. Verification reads it from the signed installer and compares it with `--commit`.

--- a/apps/desktop/CONTEXT.md
+++ b/apps/desktop/CONTEXT.md
@@ -83,8 +83,12 @@ The installer `.exe`, its `.blockmap`, and `latest.yml`; produced by `windows-re
 _Avoid_: Windows bundle, release files
 
 **Authenticode pending mode**:
-`WINDOWS_AUTHENTICODE_PENDING` = `pending-w19`, the only accepted `--authenticode` value until the first signed release.
+`WINDOWS_AUTHENTICODE_PENDING` = `pending-w19`, a dry-run-only `--authenticode` value for `verify-windows-release.mjs`; `upload-windows-release.mjs` accepts only `verify`.
 _Avoid_: Unsigned mode, signing bypass
+
+**Windows release provenance**:
+The `enduragent-release-commit:<sha>` string that `windows-release-plan.mjs` seals into the installer's `LegalTrademarks` version field; `verify-windows-authenticode.ps1` reads it back and `--commit` must match.
+_Avoid_: Build stamp, commit marker
 
 **Windows package inventory**:
 The exact application, resource, and asar inventories checked by `verify-windows-package.mjs`.
@@ -112,6 +116,7 @@ _Avoid_: Install directory, application directory
 - The **Release marker** admits a packaged build to `isDesktopUpdateReleaseEligible`; **Platform activation** independently decides whether update checks run on the current platform.
 - A **Windows release envelope** is produced, verified, uploaded, and round-trip-checked by its named scripts.
 - **Authenticode pending mode** does not authorise an unsigned installer for a GitHub release or the website.
+- **Windows release provenance** binds a verified installer to the release tag commit before upload.
 - The **Windows package inventory** fixes the application, resource, and asar contents accepted by package verification.
 - The athlete removes the **Windows user data directory** by hand when retained data must be erased after uninstall.
 

--- a/apps/desktop/scripts/upload-windows-release.d.mts
+++ b/apps/desktop/scripts/upload-windows-release.d.mts
@@ -6,7 +6,9 @@ export interface WindowsReleaseUploadInput {
   readonly version: string;
   readonly directory: string;
   readonly commit: string;
-  readonly authenticode: "pending-w19";
+  readonly authenticode: "verify";
+  readonly publisherDn: string;
+  readonly thumbprint?: string;
   readonly repo?: string;
   readonly record?: string;
 }
@@ -19,7 +21,7 @@ export interface WindowsReleaseUploadRecord {
   readonly tagCommit: string;
   readonly arch: "x64";
   readonly status: "uploaded";
-  readonly authenticode: "pending-w19" | "verified";
+  readonly authenticode: "verified";
   readonly files: readonly {
     readonly name: string;
     readonly size: number;

--- a/apps/desktop/scripts/upload-windows-release.mjs
+++ b/apps/desktop/scripts/upload-windows-release.mjs
@@ -1,11 +1,11 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFile, writeFile } from "node:fs/promises";
-import { isAbsolute, resolve } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import {
-  WINDOWS_AUTHENTICODE_PENDING,
+  WINDOWS_PUBLISHER_DN_PLACEHOLDER,
   requireReleaseCommit,
   windowsReleaseArtifactNames,
 } from "./windows-release-plan.mjs";
@@ -13,6 +13,10 @@ import {
   safeWindowsReleaseVerificationMessage,
   verifyWindowsReleaseAssets,
 } from "./verify-windows-release.mjs";
+import {
+  createWindowsAuthenticodeVerifyMode,
+  safeWindowsAuthenticodeMessage,
+} from "./verify-windows-authenticode.mjs";
 import { requireStableSemVer } from "./macos-release-plan.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -23,7 +27,12 @@ const safeWindowsReleaseUploadMessages = new Set([
   "release commit mismatch",
   "Windows release upload is incomplete",
   "Authenticode verification mode is required",
+  "Windows publisher DN is invalid",
+  "Authenticode thumbprint is invalid",
+  "unsigned Windows installer refused",
+  "artifact directory must be absolute",
   "upload record path must be absolute",
+  "upload record must be outside the artifact directory",
   "upload record already exists",
   "upload record directory is missing",
   "release repository is invalid",
@@ -44,6 +53,31 @@ export function safeWindowsReleaseUploadMessage(error) {
       safeExistingAssetMessagePattern.test(error.message))
     ? error.message
     : undefined;
+}
+
+function requirePublisherDn(value) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value !== value.trim() ||
+    value === WINDOWS_PUBLISHER_DN_PLACEHOLDER
+  ) {
+    throw new TypeError("Windows publisher DN is invalid");
+  }
+  return value;
+}
+
+function requireThumbprint(value) {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !/^[0-9a-f]{40}$/iu.test(value)) {
+    throw new TypeError("Authenticode thumbprint is invalid");
+  }
+  return value;
+}
+
+function recordInsideDirectory(record, directory) {
+  const path = relative(resolve(directory), resolve(record));
+  return path === "" || (path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path));
 }
 
 function requireRepository(value) {
@@ -172,13 +206,24 @@ async function releaseFileRecords(verified, dependencies) {
 export async function runWindowsReleaseUpload(input, dependencies = {}) {
   const version = requireStableSemVer(input.version);
   const commit = requireReleaseCommit(input.commit);
-  if (!isAbsolute(input.directory)) throw new TypeError("artifact directory must be absolute");
-  if (input.authenticode !== WINDOWS_AUTHENTICODE_PENDING) {
+  if (typeof input.directory !== "string" || !isAbsolute(input.directory)) {
+    throw new TypeError("artifact directory must be absolute");
+  }
+  if (input.authenticode !== "verify") {
     throw new TypeError("Authenticode verification mode is required");
   }
+  const publisherDn = requirePublisherDn(input.publisherDn);
+  const thumbprint = requireThumbprint(input.thumbprint);
+  const authenticodeMode = createWindowsAuthenticodeVerifyMode({
+    expectedPublisherDn: publisherDn,
+    expectedThumbprint: thumbprint,
+  });
   const repository = requireRepository(input.repo ?? defaultRepository);
   if (input.record !== undefined && !isAbsolute(input.record)) {
     throw new TypeError("upload record path must be absolute");
+  }
+  if (input.record !== undefined && recordInsideDirectory(input.record, input.directory)) {
+    throw new TypeError("upload record must be outside the artifact directory");
   }
   const executeFile = dependencies.executeFile ?? executeSystemFile;
   const verifyAssets = dependencies.verifyAssets ?? verifyWindowsReleaseAssets;
@@ -198,12 +243,28 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
     }
   }
   let uploaded = false;
+  let uploadedAssets = [];
+  const reconcile = async () => {
+    try {
+      const current = await viewRelease(executeFile, tag, repository);
+      const currentNames = new Set(releaseAssetNames(current));
+      uploadedAssets = expectedNames.filter((name) => currentNames.has(name));
+      uploaded = uploadedAssets.length > 0;
+    } catch {
+      uploadedAssets = null;
+      uploaded = "unknown";
+    }
+  };
   try {
     const verified = await verifyAssets(input.directory, {
       version,
       commit,
-      authenticode: input.authenticode,
+      expectedPublisherName: publisherDn,
+      authenticode: authenticodeMode,
     });
+    if (verified.authenticode !== "verified") {
+      throw new TypeError("unsigned Windows installer refused");
+    }
     const files = Object.freeze(await releaseFileRecords(verified, fileDependencies));
     const release = await viewRelease(executeFile, tag, repository);
     const tagCommit = await resolveTagCommit(executeFile, repository, tag);
@@ -214,20 +275,25 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
         throw new TypeError(`Windows release asset already exists: ${name}`);
       }
     }
-    await executeFile("gh-personal", [
-      "release",
-      "upload",
-      tag,
-      "--repo",
-      repository,
-      verified.paths.installer,
-      verified.paths.blockmap,
-      verified.paths.metadata,
-    ]);
+    try {
+      await executeFile("gh-personal", [
+        "release",
+        "upload",
+        tag,
+        "--repo",
+        repository,
+        verified.paths.installer,
+        verified.paths.blockmap,
+        verified.paths.metadata,
+      ]);
+    } catch (error) {
+      await reconcile();
+      if (uploaded !== false) throw new TypeError("Windows release upload is incomplete");
+      throw error;
+    }
     uploaded = true;
-    const uploadedRelease = await viewRelease(executeFile, tag, repository);
-    const uploadedNames = new Set(releaseAssetNames(uploadedRelease));
-    if (expectedNames.some((name) => !uploadedNames.has(name))) {
+    await reconcile();
+    if (uploadedAssets === null || uploadedAssets.length !== expectedNames.length) {
       throw new TypeError("Windows release upload is incomplete");
     }
     const record = Object.freeze({
@@ -260,8 +326,10 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
         error:
           safeWindowsReleaseUploadMessage(error) ??
           safeWindowsReleaseVerificationMessage(error) ??
+          safeWindowsAuthenticodeMessage(error) ??
           "Windows release upload failed",
         uploaded,
+        uploadedAssets,
       };
       try {
         await fileDependencies.writeFile(
@@ -275,6 +343,17 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
   }
 }
 
+const commandOptions = Object.freeze({
+  version: "version",
+  directory: "directory",
+  commit: "commit",
+  authenticode: "authenticode",
+  "publisher-dn": "publisherDn",
+  thumbprint: "thumbprint",
+  repo: "repo",
+  record: "record",
+});
+
 function parseArguments(arguments_) {
   const parsed = { repo: defaultRepository };
   for (let index = 0; index < arguments_.length; index += 2) {
@@ -284,13 +363,12 @@ function parseArguments(arguments_) {
       throw new TypeError("Windows release upload failed");
     }
     const key = name.slice(2);
-    if (!["version", "directory", "commit", "authenticode", "repo", "record"].includes(key)) {
+    const option = Object.hasOwn(commandOptions, key) ? commandOptions[key] : undefined;
+    if (option === undefined) throw new TypeError("Windows release upload failed");
+    if (Object.hasOwn(parsed, option) && option !== "repo") {
       throw new TypeError("Windows release upload failed");
     }
-    if (Object.hasOwn(parsed, key) && key !== "repo") {
-      throw new TypeError("Windows release upload failed");
-    }
-    parsed[key] = value;
+    parsed[option] = value;
   }
   return parsed;
 }
@@ -307,6 +385,7 @@ if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(
     const message =
       safeWindowsReleaseUploadMessage(error) ??
       safeWindowsReleaseVerificationMessage(error) ??
+      safeWindowsAuthenticodeMessage(error) ??
       "Windows release upload failed";
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;

--- a/apps/desktop/scripts/verify-windows-authenticode.d.mts
+++ b/apps/desktop/scripts/verify-windows-authenticode.d.mts
@@ -12,7 +12,7 @@ export interface WindowsAuthenticodeSigner {
 }
 
 export interface WindowsAuthenticodeSummary {
-  readonly schema: "windows-authenticode-verification/1";
+  readonly schema: "windows-authenticode-verification/2";
   readonly installerPath: string;
   readonly ok: boolean;
   readonly signer: WindowsAuthenticodeSigner | null;
@@ -26,6 +26,10 @@ export interface WindowsAuthenticodeSummary {
     readonly exitCode: number | null;
     readonly output: string;
   };
+  readonly versionInfo: {
+    readonly productVersion: string | null;
+    readonly legalTrademarks: string | null;
+  };
   readonly allowSelfSignedTest: boolean;
   readonly checks: readonly WindowsAuthenticodeCheck[];
 }
@@ -34,6 +38,8 @@ export interface WindowsAuthenticodeOptions {
   readonly installerPath: string;
   readonly expectedPublisherDn: string;
   readonly expectedThumbprint?: string;
+  readonly expectedCommit?: string;
+  readonly expectedVersion?: string;
   readonly allowSelfSignedTest?: boolean;
   readonly allowMissingSigntool?: boolean;
 }
@@ -59,11 +65,15 @@ export interface WindowsAuthenticodeVerifyMode {
   readonly expectedPublisherDn: string;
   readonly verify: (
     installerPath: string,
-    context: { readonly version: string; readonly publisherName?: string },
+    context: {
+      readonly version: string;
+      readonly commit: string;
+      readonly publisherName?: string;
+    },
   ) => Promise<void>;
 }
 
-export const WINDOWS_AUTHENTICODE_SUMMARY_SCHEMA: "windows-authenticode-verification/1";
+export const WINDOWS_AUTHENTICODE_SUMMARY_SCHEMA: "windows-authenticode-verification/2";
 export const WINDOWS_AUTHENTICODE_REQUIRED_CHECKS: readonly [
   "file",
   "status",
@@ -76,7 +86,10 @@ export const WINDOWS_AUTHENTICODE_REQUIRED_CHECKS: readonly [
 export function parseWindowsAuthenticodeSummary(stdout: string): WindowsAuthenticodeSummary;
 export function decideWindowsAuthenticode(
   summary: WindowsAuthenticodeSummary,
-  options: Pick<WindowsAuthenticodeOptions, "expectedPublisherDn" | "expectedThumbprint" | "allowSelfSignedTest">,
+  options: Pick<
+    WindowsAuthenticodeOptions,
+    "expectedPublisherDn" | "expectedThumbprint" | "expectedCommit" | "expectedVersion" | "allowSelfSignedTest"
+  >,
 ): VerifiedWindowsAuthenticode;
 export function verifyWindowsAuthenticode(
   options: WindowsAuthenticodeOptions,

--- a/apps/desktop/scripts/verify-windows-authenticode.mjs
+++ b/apps/desktop/scripts/verify-windows-authenticode.mjs
@@ -2,8 +2,9 @@ import { execFile } from "node:child_process";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { parseWindowsReleaseProvenance, requireReleaseCommit } from "./windows-release-plan.mjs";
 
-export const WINDOWS_AUTHENTICODE_SUMMARY_SCHEMA = "windows-authenticode-verification/1";
+export const WINDOWS_AUTHENTICODE_SUMMARY_SCHEMA = "windows-authenticode-verification/2";
 export const WINDOWS_AUTHENTICODE_REQUIRED_CHECKS = Object.freeze([
   "file",
   "status",
@@ -25,6 +26,7 @@ const safeMessages = new Set([
   "Authenticode publisher mismatch",
   "Authenticode thumbprint mismatch",
   "Authenticode chain is untrusted",
+  "Authenticode provenance mismatch",
   "signtool verification failed",
   "Authenticode summary is invalid",
   "PowerShell 7 is required for Authenticode verification",
@@ -75,6 +77,7 @@ function validSummary(summary) {
       "digestAlgorithm",
       "rfc3161",
       "signtool",
+      "versionInfo",
       "allowSelfSignedTest",
       "checks",
     ]) ||
@@ -117,6 +120,14 @@ function validSummary(summary) {
     return false;
   }
   if (
+    !exactObject(summary.versionInfo) ||
+    !hasExactKeys(summary.versionInfo, ["productVersion", "legalTrademarks"]) ||
+    !nullableString(summary.versionInfo.productVersion) ||
+    !nullableString(summary.versionInfo.legalTrademarks)
+  ) {
+    return false;
+  }
+  if (
     !Array.isArray(summary.checks) ||
     !summary.checks.every(
       (check) =>
@@ -149,22 +160,36 @@ function checkMap(summary) {
   return new Map(summary.checks.map((check) => [check.name, check]));
 }
 
-function validExpectedValues(expectedPublisherDn, expectedThumbprint) {
+function validExpectedValues(expectedPublisherDn, expectedThumbprint, expectedCommit) {
   return (
     typeof expectedPublisherDn === "string" &&
     expectedPublisherDn.length > 0 &&
     expectedPublisherDn === expectedPublisherDn.trim() &&
-    (expectedThumbprint === undefined || /^[0-9a-f]{40}$/iu.test(expectedThumbprint))
+    (expectedThumbprint === undefined || /^[0-9a-f]{40}$/iu.test(expectedThumbprint)) &&
+    (expectedCommit === undefined || /^[0-9a-f]{40}$/u.test(expectedCommit))
   );
+}
+
+function provenanceMatches(summary, expectedCommit, expectedVersion) {
+  if (expectedCommit !== undefined) {
+    if (parseWindowsReleaseProvenance(summary.versionInfo.legalTrademarks) !== expectedCommit) {
+      return false;
+    }
+  }
+  if (expectedVersion !== undefined && summary.versionInfo.productVersion !== expectedVersion) {
+    return false;
+  }
+  return true;
 }
 
 export function decideWindowsAuthenticode(
   summary,
-  { expectedPublisherDn, expectedThumbprint, allowSelfSignedTest = false },
+  { expectedPublisherDn, expectedThumbprint, expectedCommit, expectedVersion, allowSelfSignedTest = false },
 ) {
   if (
     !validSummary(summary) ||
-    !validExpectedValues(expectedPublisherDn, expectedThumbprint) ||
+    !validExpectedValues(expectedPublisherDn, expectedThumbprint, expectedCommit) ||
+    (expectedVersion !== undefined && typeof expectedVersion !== "string") ||
     typeof allowSelfSignedTest !== "boolean" ||
     summary.allowSelfSignedTest !== allowSelfSignedTest
   ) {
@@ -214,6 +239,9 @@ export function decideWindowsAuthenticode(
     fail("Authenticode chain is untrusted");
   }
   if (!checks.get("signtool").ok) fail("signtool verification failed");
+  if (!provenanceMatches(summary, expectedCommit, expectedVersion)) {
+    fail("Authenticode provenance mismatch");
+  }
   if (!checks.get("status").ok || !summary.ok || summary.checks.some((check) => !check.ok)) {
     fail("Authenticode signature is not valid");
   }
@@ -238,7 +266,11 @@ async function runWindowsAuthenticode(options, dependencies = {}) {
   if (
     !exactObject(options) ||
     !isAbsolute(options.installerPath) ||
-    !validExpectedValues(options.expectedPublisherDn, options.expectedThumbprint)
+    !validExpectedValues(
+      options.expectedPublisherDn,
+      options.expectedThumbprint,
+      options.expectedCommit,
+    )
   ) {
     fail("Authenticode summary is invalid");
   }
@@ -289,6 +321,8 @@ export async function verifyWindowsAuthenticode(options, dependencies = {}) {
   return decideWindowsAuthenticode(summary, {
     expectedPublisherDn: options.expectedPublisherDn,
     expectedThumbprint: options.expectedThumbprint,
+    expectedCommit: options.expectedCommit,
+    expectedVersion: options.expectedVersion,
     allowSelfSignedTest: options.allowSelfSignedTest ?? false,
   });
 }
@@ -311,11 +345,19 @@ export function createWindowsAuthenticodeVerifyMode(options, dependencies = {}) 
       ) {
         fail("Authenticode publisher mismatch");
       }
+      let expectedCommit;
+      try {
+        expectedCommit = requireReleaseCommit(context?.commit);
+      } catch {
+        fail("Authenticode provenance mismatch");
+      }
       await verifyWindowsAuthenticode(
         {
           installerPath,
           expectedPublisherDn,
           expectedThumbprint: options.expectedThumbprint,
+          expectedCommit,
+          expectedVersion: context.version,
           allowSelfSignedTest: options.allowSelfSignedTest,
           allowMissingSigntool: options.allowMissingSigntool,
         },
@@ -329,6 +371,7 @@ function parseArguments(arguments_) {
   let installerPath;
   let expectedPublisherDn;
   let expectedThumbprint;
+  let expectedCommit;
   let allowSelfSignedTest = false;
   let allowMissingSigntool = false;
   for (let index = 0; index < arguments_.length; index += 1) {
@@ -352,6 +395,8 @@ function parseArguments(arguments_) {
       expectedPublisherDn = value;
     } else if (argument === "--thumbprint" && expectedThumbprint === undefined) {
       expectedThumbprint = value;
+    } else if (argument === "--commit" && expectedCommit === undefined) {
+      expectedCommit = value;
     } else {
       fail("Authenticode summary is invalid");
     }
@@ -363,6 +408,7 @@ function parseArguments(arguments_) {
     installerPath: resolve(installerPath),
     expectedPublisherDn,
     expectedThumbprint,
+    expectedCommit,
     allowSelfSignedTest,
     allowMissingSigntool,
   };

--- a/apps/desktop/scripts/verify-windows-authenticode.ps1
+++ b/apps/desktop/scripts/verify-windows-authenticode.ps1
@@ -21,6 +21,7 @@ $statusMessage = $null
 $digestAlgorithm = $null
 $rfc3161 = $false
 $signtool = [ordered]@{ path = $null; exitCode = $null; output = "" }
+$versionInfo = [ordered]@{ productVersion = $null; legalTrademarks = $null }
 
 function Add-VerificationCheck {
   param([string]$Name, [bool]$Ok, [string]$Detail)
@@ -30,7 +31,7 @@ function Add-VerificationCheck {
 function Write-VerificationSummary {
   param([bool]$Ok)
   $summary = [ordered]@{
-    schema = "windows-authenticode-verification/1"
+    schema = "windows-authenticode-verification/2"
     installerPath = $resolvedInstallerPath
     ok = $Ok
     signer = $signer
@@ -40,6 +41,7 @@ function Write-VerificationSummary {
     digestAlgorithm = $digestAlgorithm
     rfc3161 = $rfc3161
     signtool = $signtool
+    versionInfo = $versionInfo
     allowSelfSignedTest = [bool]$AllowSelfSignedTest
     checks = @($checks)
   }
@@ -189,6 +191,11 @@ try {
     exit 1
   }
 
+  $fileVersionInfo = [Diagnostics.FileVersionInfo]::GetVersionInfo($resolvedInstallerPath)
+  if ($null -ne $fileVersionInfo) {
+    $versionInfo.productVersion = $fileVersionInfo.ProductVersion
+    $versionInfo.legalTrademarks = $fileVersionInfo.LegalTrademarks
+  }
   $null = Add-Type -AssemblyName System.Security.Cryptography.Pkcs
   $signature = Get-AuthenticodeSignature -LiteralPath $resolvedInstallerPath
   $status = [string]$signature.Status

--- a/apps/desktop/scripts/verify-windows-release.d.mts
+++ b/apps/desktop/scripts/verify-windows-release.d.mts
@@ -8,7 +8,11 @@ export type WindowsAuthenticodeMode =
       readonly expectedPublisherDn?: string;
       readonly verify: (
         installerPath: string,
-        context: { readonly version: string; readonly publisherName?: string },
+        context: {
+          readonly version: string;
+          readonly commit: string;
+          readonly publisherName?: string;
+        },
       ) => Promise<void>;
     };
 
@@ -48,6 +52,10 @@ export interface VerifiedWindowsReleaseAssets {
 
 export const WINDOWS_UPDATER_METADATA_MAX_BYTES: 16_384;
 export function safeWindowsReleaseVerificationMessage(error: unknown): string | undefined;
+export function checkWindowsInstallerBlockmap(
+  blockmap: Uint8Array,
+  installer: Uint8Array,
+): string | null;
 export function verifyWindowsReleaseAssets(
   artifactDirectory: string,
   options: VerifyWindowsReleaseOptions,

--- a/apps/desktop/scripts/verify-windows-release.mjs
+++ b/apps/desktop/scripts/verify-windows-release.mjs
@@ -139,15 +139,21 @@ function installerMetadataMatches(metadata, version, installerName, sha512, size
   );
 }
 
-function verifyBlockmap(bytes, installer) {
-  if (bytes.length < 2 || bytes[0] !== 0x1f || bytes[1] !== 0x8b) {
-    fail("installer blockmap is invalid");
+export function checkWindowsInstallerBlockmap(bytes, installer) {
+  if (
+    !(bytes instanceof Uint8Array) ||
+    !(installer instanceof Uint8Array) ||
+    bytes.length < 2 ||
+    bytes[0] !== 0x1f ||
+    bytes[1] !== 0x8b
+  ) {
+    return "installer blockmap is invalid";
   }
   let blockmap;
   try {
     blockmap = JSON.parse(gunzipSync(bytes).toString("utf8"));
   } catch {
-    fail("installer blockmap is invalid");
+    return "installer blockmap is invalid";
   }
   if (
     !exactObject(blockmap) ||
@@ -158,7 +164,7 @@ function verifyBlockmap(bytes, installer) {
     !exactObject(blockmap.files[0]) ||
     !hasExactKeys(blockmap.files[0], ["name", "offset", "checksums", "sizes"])
   ) {
-    fail("installer blockmap is invalid");
+    return "installer blockmap is invalid";
   }
   const file = blockmap.files[0];
   if (
@@ -175,10 +181,10 @@ function verifyBlockmap(bytes, installer) {
     ) ||
     !file.sizes.every((size) => Number.isSafeInteger(size) && size > 0)
   ) {
-    fail("installer blockmap is invalid");
+    return "installer blockmap is invalid";
   }
   if (file.sizes.reduce((total, size) => total + size, 0) !== installer.length) {
-    fail("installer blockmap does not match the Windows installer");
+    return "installer blockmap does not match the Windows installer";
   }
   let offset = file.offset;
   for (let index = 0; index < file.sizes.length; index += 1) {
@@ -187,10 +193,16 @@ function verifyBlockmap(bytes, installer) {
       blake2b(installer.subarray(offset, offset + size), { dkLen: BLOCKMAP_CHECKSUM_BYTES }),
     ).toString("base64");
     if (file.checksums[index] !== expectedChecksum) {
-      fail("installer blockmap does not match the Windows installer");
+      return "installer blockmap does not match the Windows installer";
     }
     offset += size;
   }
+  return null;
+}
+
+function verifyBlockmap(bytes, installer) {
+  const message = checkWindowsInstallerBlockmap(bytes, installer);
+  if (message !== null) fail(message);
 }
 
 function requireVersion(value) {
@@ -220,6 +232,9 @@ export async function verifyWindowsReleaseAssets(artifactDirectory, options, ove
   const version = requireVersion(options?.version);
   const commit = options?.commit === undefined ? null : requireCommit(options.commit);
   const authenticodeMode = requireAuthenticodeMode(options?.authenticode);
+  if (authenticodeMode !== WINDOWS_AUTHENTICODE_PENDING && commit === null) {
+    fail("release commit is required for Authenticode verification");
+  }
   const dependencies = {
     lstat: overrides.lstat ?? lstat,
     readdir: overrides.readdir ?? readdir,
@@ -289,6 +304,7 @@ export async function verifyWindowsReleaseAssets(artifactDirectory, options, ove
     try {
       await authenticodeMode.verify(paths.installer, {
         version,
+        commit,
         publisherName: options.expectedPublisherName,
       });
     } catch {
@@ -353,7 +369,11 @@ async function main() {
     !arguments_.allowSelfSignedTest
   ) {
     authenticodeMode = WINDOWS_AUTHENTICODE_PENDING;
-  } else if (arguments_.authenticode === "verify" && arguments_.publisherDn !== undefined) {
+  } else if (
+    arguments_.authenticode === "verify" &&
+    arguments_.publisherDn !== undefined &&
+    arguments_.commit !== undefined
+  ) {
     authenticodeMode = createWindowsAuthenticodeVerifyMode({
       expectedPublisherDn: arguments_.publisherDn,
       expectedThumbprint: arguments_.thumbprint,

--- a/apps/desktop/scripts/verify-windows-updater-round-trip.d.mts
+++ b/apps/desktop/scripts/verify-windows-updater-round-trip.d.mts
@@ -1,6 +1,6 @@
 export interface WindowsUpdaterReleaseInput {
   readonly version: string;
-  readonly installer: Uint8Array | { readonly sha512: string; readonly size: number };
+  readonly installer: Uint8Array;
   readonly blockmap?: Uint8Array;
   readonly metadata: string | Uint8Array;
 }

--- a/apps/desktop/scripts/verify-windows-updater-round-trip.mjs
+++ b/apps/desktop/scripts/verify-windows-updater-round-trip.mjs
@@ -1,15 +1,16 @@
 import { createHash } from "node:crypto";
-import { gunzipSync } from "node:zlib";
 import { parse } from "yaml";
 import {
   WINDOWS_RELEASE_METADATA_NAME,
   windowsReleaseArtifactNames,
 } from "./windows-release-plan.mjs";
 import { requireGenericFeedUrl, requireStableSemVer } from "./macos-release-plan.mjs";
-import { WINDOWS_UPDATER_METADATA_MAX_BYTES } from "./verify-windows-release.mjs";
+import {
+  WINDOWS_UPDATER_METADATA_MAX_BYTES,
+  checkWindowsInstallerBlockmap,
+} from "./verify-windows-release.mjs";
 
 const maximumPublisherNameCharacters = 512;
-const blockmapChecksumBytes = 18;
 const invalidMetadataMessage = `${WINDOWS_RELEASE_METADATA_NAME} is invalid`;
 
 class WindowsUpdaterRoundTripError extends Error {
@@ -130,49 +131,10 @@ function verifyMetadata(metadata, version, installer) {
   return installerName;
 }
 
-function verifyBlockmap(value) {
-  if (
-    !(value instanceof Uint8Array) ||
-    value.length < 2 ||
-    value[0] !== 0x1f ||
-    value[1] !== 0x8b
-  ) {
-    fail("installer blockmap is invalid");
-  }
-  let blockmap;
-  try {
-    blockmap = JSON.parse(gunzipSync(value).toString("utf8"));
-  } catch {
-    fail("installer blockmap is invalid");
-  }
-  if (
-    !exactObject(blockmap) ||
-    !hasExactKeys(blockmap, ["version", "files"]) ||
-    blockmap.version !== "2" ||
-    !Array.isArray(blockmap.files) ||
-    blockmap.files.length !== 1 ||
-    !exactObject(blockmap.files[0]) ||
-    !hasExactKeys(blockmap.files[0], ["name", "offset", "checksums", "sizes"])
-  ) {
-    fail("installer blockmap is invalid");
-  }
-  const file = blockmap.files[0];
-  if (
-    file.name !== "file" ||
-    file.offset !== 0 ||
-    !Array.isArray(file.checksums) ||
-    !Array.isArray(file.sizes) ||
-    file.checksums.length === 0 ||
-    file.checksums.length !== file.sizes.length ||
-    !file.checksums.every(
-      (checksum) =>
-        validBase64(checksum) &&
-        Buffer.from(checksum, "base64").length === blockmapChecksumBytes,
-    ) ||
-    !file.sizes.every((size) => Number.isSafeInteger(size) && size > 0)
-  ) {
-    fail("installer blockmap is invalid");
-  }
+function verifyBlockmap(value, installer) {
+  if (!(installer instanceof Uint8Array)) fail("installer blockmap requires installer bytes");
+  const message = checkWindowsInstallerBlockmap(value, installer);
+  if (message !== null) fail(message);
 }
 
 function fullDistinguishedName(value) {
@@ -219,8 +181,10 @@ export function verifyWindowsUpdaterRoundTrip(input) {
   );
 
   if (input.candidate.blockmap === undefined) fail("missing candidate installer blockmap");
-  verifyBlockmap(input.candidate.blockmap);
-  if (input.baseline.blockmap !== undefined) verifyBlockmap(input.baseline.blockmap);
+  verifyBlockmap(input.candidate.blockmap, input.candidate.installer);
+  if (input.baseline.blockmap !== undefined) {
+    verifyBlockmap(input.baseline.blockmap, input.baseline.installer);
+  }
 
   let feedUrl;
   try {

--- a/apps/desktop/scripts/windows-release-plan.d.mts
+++ b/apps/desktop/scripts/windows-release-plan.d.mts
@@ -44,6 +44,7 @@ export interface WindowsReleaseBuilderOptions {
       readonly signtoolOptions: { readonly publisherName: readonly [string] };
       readonly signExecutable: true;
       readonly verifyUpdateCodeSignature: true;
+      readonly legalTrademarks: string;
       readonly target: readonly [{ readonly target: "nsis"; readonly arch: readonly ["x64"] }];
     };
     readonly nsis: {
@@ -76,6 +77,9 @@ export const WINDOWS_RELEASE_PLATFORM: "win32";
 export const WINDOWS_RELEASE_METADATA_NAME: "latest.yml";
 export const WINDOWS_AUTHENTICODE_PENDING: "pending-w19";
 export const WINDOWS_PUBLISHER_DN_PLACEHOLDER: "CN=ENDURAGENT PUBLISHER DN PLACEHOLDER, O=PLACEHOLDER";
+export const WINDOWS_RELEASE_PROVENANCE_PREFIX: "enduragent-release-commit:";
+export function windowsReleaseProvenance(commit: string): string;
+export function parseWindowsReleaseProvenance(value: unknown): string | null;
 export function safeWindowsReleasePlanMessage(error: unknown): string | undefined;
 export function requireReleaseCommit(value: unknown): string;
 export function windowsReleaseArtifactNames(version: string): WindowsReleaseArtifactNames;

--- a/apps/desktop/scripts/windows-release-plan.mjs
+++ b/apps/desktop/scripts/windows-release-plan.mjs
@@ -30,6 +30,7 @@ export const WINDOWS_RELEASE_METADATA_NAME = "latest.yml";
 export const WINDOWS_AUTHENTICODE_PENDING = "pending-w19";
 export const WINDOWS_PUBLISHER_DN_PLACEHOLDER =
   "CN=ENDURAGENT PUBLISHER DN PLACEHOLDER, O=PLACEHOLDER";
+export const WINDOWS_RELEASE_PROVENANCE_PREFIX = "enduragent-release-commit:";
 
 function exactObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -50,7 +51,7 @@ function compareStableVersions(left, right) {
   return 0;
 }
 
-function freezeBuilderOptions(desktopRoot, version, feedUrl, publisherDn) {
+function freezeBuilderOptions(desktopRoot, version, commit, feedUrl, publisherDn) {
   const publish = Object.freeze([
     Object.freeze({ provider: "generic", url: feedUrl, channel: "latest" }),
   ]);
@@ -69,6 +70,7 @@ function freezeBuilderOptions(desktopRoot, version, feedUrl, publisherDn) {
       }),
       signExecutable: true,
       verifyUpdateCodeSignature: true,
+      legalTrademarks: windowsReleaseProvenance(commit),
       target,
     }),
     nsis: Object.freeze({
@@ -97,6 +99,18 @@ export function requireReleaseCommit(value) {
     throw new TypeError("release commit must be a full lowercase SHA-1");
   }
   return value;
+}
+
+export function windowsReleaseProvenance(commit) {
+  return `${WINDOWS_RELEASE_PROVENANCE_PREFIX}${requireReleaseCommit(commit)}`;
+}
+
+export function parseWindowsReleaseProvenance(value) {
+  if (typeof value !== "string" || !value.startsWith(WINDOWS_RELEASE_PROVENANCE_PREFIX)) {
+    return null;
+  }
+  const commit = value.slice(WINDOWS_RELEASE_PROVENANCE_PREFIX.length);
+  return /^[0-9a-f]{40}$/u.test(commit) ? commit : null;
 }
 
 export function windowsReleaseArtifactNames(version) {
@@ -253,6 +267,6 @@ export function createWindowsReleasePlan(input) {
     assetNames,
     updaterMetadata,
     authenticode: WINDOWS_AUTHENTICODE_PENDING,
-    builderOptions: freezeBuilderOptions(desktopRoot, version, feedUrl, publisherDn),
+    builderOptions: freezeBuilderOptions(desktopRoot, version, commit, feedUrl, publisherDn),
   });
 }

--- a/apps/desktop/tests/upload-windows-release.test.ts
+++ b/apps/desktop/tests/upload-windows-release.test.ts
@@ -11,6 +11,7 @@ import { windowsReleaseArtifactNames } from "../scripts/windows-release-plan.mjs
 
 const version = "0.1.5";
 const commit = "a".repeat(40);
+const publisherDn = "CN=Enduragent Test Publisher, O=Enduragent Test";
 const tag = `enduragent-desktop@${version}`;
 const repository = "yerzhansa/enduragent";
 const script = resolve(
@@ -58,7 +59,7 @@ beforeEach(async () => {
     },
     installerSha512: createHash("sha512").update(contents.installer).digest("base64"),
     installerSha256: createHash("sha256").update(contents.installer).digest("hex"),
-    authenticode: "pending-w19",
+    authenticode: "verified",
   };
 });
 
@@ -106,7 +107,8 @@ function input(overrides: Record<string, unknown> = {}) {
     version,
     directory,
     commit,
-    authenticode: "pending-w19" as const,
+    authenticode: "verify" as const,
+    publisherDn,
     ...overrides,
   };
 }
@@ -119,7 +121,8 @@ describe("Windows release upload", () => {
     expect(verifyAssets).toHaveBeenCalledWith(directory, {
       version,
       commit,
-      authenticode: "pending-w19",
+      expectedPublisherName: publisherDn,
+      authenticode: expect.objectContaining({ mode: "verify", expectedPublisherDn: publisherDn }),
     });
     const viewArguments = [
       "release",
@@ -247,7 +250,8 @@ describe("Windows release upload", () => {
   });
 
   it("refuses a pre-existing upload record before verification or GitHub access", async () => {
-    const recordPath = join(directory, "upload-record.json");
+    const recordPath = join(directory, "..", `upload-record-existing-${process.pid}.json`);
+    temporaryRoots.push(recordPath);
     await writeFile(recordPath, "existing");
     const executeFile = successfulExecutor();
     const verifyAssets = vi.fn(async () => verified);
@@ -259,7 +263,8 @@ describe("Windows release upload", () => {
   });
 
   it("writes a safe failed record when release lookup fails", async () => {
-    const recordPath = join(directory, "upload-record.json");
+    const recordPath = join(directory, "..", `upload-record-failed-${process.pid}.json`);
+    temporaryRoots.push(recordPath);
     const executeFile = vi.fn(async () => Promise.reject(new Error("not found")));
     await expect(
       runWindowsReleaseUpload(input({ record: recordPath }), {
@@ -276,15 +281,114 @@ describe("Windows release upload", () => {
       status: "failed",
       error: `release does not exist: ${tag}`,
       uploaded: false,
+      uploadedAssets: [],
     });
     expect(executeFile.mock.calls.flat(2)).not.toContain("upload");
+  });
+
+  it("records the assets that became public when a multi-asset upload fails partway", async () => {
+    const recordPath = join(directory, "..", `upload-record-${process.pid}.json`);
+    temporaryRoots.push(recordPath);
+    let views = 0;
+    const executeFile = vi.fn(async (_executable: string, arguments_: readonly string[]) => {
+      if (arguments_[0] === "release" && arguments_[1] === "view") {
+        views += 1;
+        return {
+          stdout: views === 1 ? release([]) : release([verified.names.installer, verified.names.blockmap]),
+        };
+      }
+      if (arguments_[0] === "api") {
+        return { stdout: JSON.stringify({ object: { type: "commit", sha: commit } }) };
+      }
+      throw new Error("upload interrupted");
+    });
+    await expect(
+      runWindowsReleaseUpload(input({ record: recordPath }), {
+        executeFile,
+        verifyAssets: vi.fn(async () => verified),
+      }),
+    ).rejects.toThrow("Windows release upload is incomplete");
+    expect(JSON.parse(await readFile(recordPath, "utf8"))).toMatchObject({
+      status: "failed",
+      error: "Windows release upload is incomplete",
+      uploaded: true,
+      uploadedAssets: [verified.names.installer, verified.names.blockmap],
+    });
+  });
+
+  it("records an unknown upload state when reconciliation fails after an upload error", async () => {
+    const recordPath = join(directory, "..", `upload-record-unknown-${process.pid}.json`);
+    temporaryRoots.push(recordPath);
+    let views = 0;
+    const executeFile = vi.fn(async (_executable: string, arguments_: readonly string[]) => {
+      if (arguments_[0] === "release" && arguments_[1] === "view") {
+        views += 1;
+        if (views === 1) return { stdout: release([]) };
+        throw new Error("network");
+      }
+      if (arguments_[0] === "api") {
+        return { stdout: JSON.stringify({ object: { type: "commit", sha: commit } }) };
+      }
+      throw new Error("upload interrupted");
+    });
+    await expect(
+      runWindowsReleaseUpload(input({ record: recordPath }), {
+        executeFile,
+        verifyAssets: vi.fn(async () => verified),
+      }),
+    ).rejects.toThrow("Windows release upload is incomplete");
+    expect(JSON.parse(await readFile(recordPath, "utf8"))).toMatchObject({
+      status: "failed",
+      uploaded: "unknown",
+      uploadedAssets: null,
+    });
+  });
+
+  it("refuses an upload record inside the artifact directory before touching it", async () => {
+    const executeFile = successfulExecutor();
+    const verifyAssets = vi.fn(async () => verified);
+    for (const recordPath of [join(directory, "upload-record.json"), join(directory, "..record.json")]) {
+      await expect(
+        runWindowsReleaseUpload(input({ record: recordPath }), { executeFile, verifyAssets }),
+      ).rejects.toThrow("upload record must be outside the artifact directory");
+      await expect(stat(recordPath)).rejects.toThrow();
+    }
+    expect(verifyAssets).not.toHaveBeenCalled();
+    expect(executeFile).not.toHaveBeenCalled();
+  });
+
+  it("refuses the placeholder or missing publisher DN before verification", async () => {
+    const executeFile = vi.fn(async () => ({ stdout: "" }));
+    const verifyAssets = vi.fn(async () => verified);
+    await expect(
+      runWindowsReleaseUpload(
+        input({ publisherDn: "CN=ENDURAGENT PUBLISHER DN PLACEHOLDER, O=PLACEHOLDER" }),
+        { executeFile, verifyAssets },
+      ),
+    ).rejects.toThrow("Windows publisher DN is invalid");
+    await expect(
+      runWindowsReleaseUpload(input({ publisherDn: undefined }), { executeFile, verifyAssets }),
+    ).rejects.toThrow("Windows publisher DN is invalid");
+    expect(verifyAssets).not.toHaveBeenCalled();
+    expect(executeFile).not.toHaveBeenCalled();
+  });
+
+  it("refuses an installer the verifier did not mark as Authenticode verified", async () => {
+    const executeFile = successfulExecutor();
+    await expect(
+      runWindowsReleaseUpload(input(), {
+        executeFile,
+        verifyAssets: vi.fn(async () => ({ ...verified, authenticode: "pending-w19" }) as never),
+      }),
+    ).rejects.toThrow("unsigned Windows installer refused");
+    expect(executeFile).not.toHaveBeenCalled();
   });
 
   it("refuses unsupported Authenticode modes before verification or upload", async () => {
     const executeFile = vi.fn(async () => ({ stdout: "" }));
     const verifyAssets = vi.fn(async () => verified);
     await expect(
-      runWindowsReleaseUpload(input({ authenticode: "verified" }) as never, {
+      runWindowsReleaseUpload(input({ authenticode: "pending-w19" }) as never, {
         executeFile,
         verifyAssets,
       }),
@@ -305,7 +409,9 @@ describe("Windows release upload", () => {
         "--commit",
         commit,
         "--authenticode",
-        "verified",
+        "pending-w19",
+        "--publisher-dn",
+        publisherDn,
       ],
       { encoding: "utf8" },
     );
@@ -314,7 +420,8 @@ describe("Windows release upload", () => {
   });
 
   it("writes an owner-only immutable upload record with all file hashes", async () => {
-    const recordPath = join(directory, "upload-record.json");
+    const recordPath = join(directory, "..", `upload-record-ok-${process.pid}.json`);
+    temporaryRoots.push(recordPath);
     const result = await runWindowsReleaseUpload(input({ record: recordPath }), {
       executeFile: successfulExecutor(),
       verifyAssets: vi.fn(async () => verified),
@@ -330,7 +437,7 @@ describe("Windows release upload", () => {
       tagCommit: commit,
       arch: "x64",
       status: "uploaded",
-      authenticode: "pending-w19",
+      authenticode: "verified",
     });
     expect(recorded.files.map((file: { name: string }) => file.name)).toEqual([
       verified.names.installer,

--- a/apps/desktop/tests/windows-authenticode.test.ts
+++ b/apps/desktop/tests/windows-authenticode.test.ts
@@ -19,6 +19,7 @@ import { windowsReleaseArtifactNames } from "../scripts/windows-release-plan.mjs
 const version = "0.1.5";
 const publisherDn = "CN=Enduragent Test Publisher, O=Enduragent Test";
 const thumbprint = "a".repeat(40);
+const commit = "c".repeat(40);
 const scriptPath = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../scripts/verify-windows-authenticode.ps1",
@@ -39,7 +40,7 @@ function summary(
   overrides: Partial<WindowsAuthenticodeSummary> = {},
 ): WindowsAuthenticodeSummary {
   return {
-    schema: "windows-authenticode-verification/1",
+    schema: "windows-authenticode-verification/2",
     installerPath: "/synthetic/installer.exe",
     ok: true,
     signer: {
@@ -54,6 +55,7 @@ function summary(
     digestAlgorithm: "sha256",
     rfc3161: true,
     signtool: { path: "C:\\signtool.exe", exitCode: 0, output: "verified" },
+    versionInfo: { productVersion: version, legalTrademarks: `enduragent-release-commit:${commit}` },
     allowSelfSignedTest: false,
     checks: [
       { name: "file", ok: true, detail: "regular-executable" },
@@ -158,6 +160,34 @@ describe("Windows Authenticode decisions", () => {
     ).toThrow("Authenticode chain is untrusted");
   });
 
+  it("binds the sealed provenance to the expected commit and version", () => {
+    expect(
+      decideWindowsAuthenticode(summary(), {
+        ...decisionOptions(),
+        expectedCommit: commit,
+        expectedVersion: version,
+      }).ok,
+    ).toBe(true);
+    expect(() =>
+      decideWindowsAuthenticode(summary(), {
+        ...decisionOptions(),
+        expectedCommit: "d".repeat(40),
+      }),
+    ).toThrow("Authenticode provenance mismatch");
+    expect(() =>
+      decideWindowsAuthenticode(
+        summary({ versionInfo: { productVersion: version, legalTrademarks: null } }),
+        { ...decisionOptions(), expectedCommit: commit },
+      ),
+    ).toThrow("Authenticode provenance mismatch");
+    expect(() =>
+      decideWindowsAuthenticode(summary(), { ...decisionOptions(), expectedVersion: "0.1.6" }),
+    ).toThrow("Authenticode provenance mismatch");
+    expect(() =>
+      decideWindowsAuthenticode({ ...summary(), versionInfo: undefined } as never, decisionOptions()),
+    ).toThrow("Authenticode summary is invalid");
+  });
+
   it("rejects thumbprint and signtool failures", () => {
     expect(() =>
       decideWindowsAuthenticode(
@@ -220,10 +250,19 @@ describe("Windows Authenticode decisions", () => {
     );
     const result = await verifyWindowsReleaseAssets(directory, {
       version,
+      commit,
       expectedPublisherName: publisherDn,
       authenticode,
     });
     expect(result.authenticode).toBe("verified");
+    await expect(
+      verifyWindowsReleaseAssets(directory, {
+        version,
+        commit: "d".repeat(40),
+        expectedPublisherName: publisherDn,
+        authenticode,
+      }),
+    ).rejects.toThrow("Windows installer Authenticode verification failed");
     expect(executeFile).toHaveBeenCalledWith(
       "pwsh",
       expect.arrayContaining([

--- a/apps/desktop/tests/windows-release-artifacts.test.ts
+++ b/apps/desktop/tests/windows-release-artifacts.test.ts
@@ -104,20 +104,31 @@ describe("Windows release artifact verification", () => {
     const verify = vi.fn(async () => {});
     const result = await verifyWindowsReleaseAssets(directory, {
       version,
+      commit,
       expectedPublisherName: "CN=Enduragent Test",
       authenticode: { verify },
     });
     expect(verify).toHaveBeenCalledWith(join(directory, `Enduragent-${version}-x64.exe`), {
       version,
+      commit,
       publisherName: "CN=Enduragent Test",
     });
     expect(result.authenticode).toBe("verified");
     await expect(
       verifyWindowsReleaseAssets(directory, {
         version,
+        commit,
         authenticode: { verify: vi.fn(async () => Promise.reject(new Error("signature"))) },
       }),
     ).rejects.toThrow("Windows installer Authenticode verification failed");
+  });
+
+  it("requires the release commit before running an Authenticode verifier", async () => {
+    const verify = vi.fn(async () => {});
+    await expect(
+      verifyWindowsReleaseAssets(directory, { version, authenticode: { verify } }),
+    ).rejects.toThrow("release commit is required for Authenticode verification");
+    expect(verify).not.toHaveBeenCalled();
   });
 
   it("rejects extra files and symlinked installers", async () => {

--- a/apps/desktop/tests/windows-release-plan.test.ts
+++ b/apps/desktop/tests/windows-release-plan.test.ts
@@ -126,6 +126,7 @@ describe("Windows release plan", () => {
       signtoolOptions: { publisherName: [WINDOWS_PUBLISHER_DN_PLACEHOLDER] },
       signExecutable: true,
       verifyUpdateCodeSignature: true,
+      legalTrademarks: `enduragent-release-commit:${commit}`,
       target: [{ target: "nsis", arch: ["x64"] }],
     });
     expect(plan.updaterMetadata.publisherName).toBe(WINDOWS_PUBLISHER_DN_PLACEHOLDER);

--- a/apps/desktop/tests/windows-updater-round-trip.test.ts
+++ b/apps/desktop/tests/windows-updater-round-trip.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
 import { gzipSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import { stringify } from "yaml";
@@ -12,21 +13,26 @@ import { windowsReleaseArtifactNames } from "../scripts/windows-release-plan.mjs
 
 type RoundTripInput = Parameters<typeof verifyWindowsUpdaterRoundTrip>[0];
 
+const require = createRequire(import.meta.url);
+const electronBuilderRequire = createRequire(require.resolve("electron-builder"));
+const { blake2b } = electronBuilderRequire("@noble/hashes/blake2.js") as {
+  blake2b: (input: Uint8Array, options: { dkLen: number }) => Uint8Array;
+};
 const baselineInstaller = Buffer.from("synthetic Windows installer 0.1.5\n");
 const candidateInstaller = Buffer.from("synthetic Windows installer 0.1.6\n");
-const blockmap = gzipSync(
-  JSON.stringify({
-    version: "2",
-    files: [
-      {
-        name: "file",
-        offset: 0,
-        checksums: [Buffer.alloc(18, 0xab).toString("base64")],
-        sizes: [1],
-      },
-    ],
-  }),
-);
+
+function blockmapFor(installer: Buffer, chunkSize = 16): Buffer {
+  const sizes: number[] = [];
+  const checksums: string[] = [];
+  for (let offset = 0; offset < installer.length; offset += chunkSize) {
+    const chunk = installer.subarray(offset, Math.min(offset + chunkSize, installer.length));
+    sizes.push(chunk.length);
+    checksums.push(Buffer.from(blake2b(chunk, { dkLen: 18 })).toString("base64"));
+  }
+  return gzipSync(
+    JSON.stringify({ version: "2", files: [{ name: "file", offset: 0, checksums, sizes }] }),
+  );
+}
 const releaseDate = "2026-08-25T00:00:00.000Z";
 const preflight: WindowsUpdaterPreflight = {
   feedUrl: "https://github.com/yerzhansa/enduragent/releases/latest/download/",
@@ -80,7 +86,9 @@ function release(
     installer,
     metadata: options.metadata ?? metadata(version, installer, options.metadataOverrides),
   };
-  if (options.includeBlockmap !== false) result.blockmap = options.blockmap ?? blockmap;
+  if (options.includeBlockmap !== false) {
+    result.blockmap = options.blockmap ?? blockmapFor(Buffer.from(installer));
+  }
   return result;
 }
 
@@ -149,6 +157,47 @@ const negativeScenarios: readonly {
         candidate: release("0.1.6", candidateInstaller, {
           blockmap: Buffer.from("not gzip"),
         }),
+      }),
+  },
+  {
+    name: "blockmap built from other installer bytes",
+    expected: "installer blockmap does not match the Windows installer",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6", candidateInstaller, {
+          blockmap: blockmapFor(baselineInstaller),
+        }),
+      }),
+  },
+  {
+    name: "blockmap chunk sizes covering fewer bytes than the installer",
+    expected: "installer blockmap does not match the Windows installer",
+    input: () =>
+      roundTripInput({
+        candidate: release("0.1.6", candidateInstaller, {
+          blockmap: blockmapFor(candidateInstaller.subarray(0, 1)),
+        }),
+      }),
+  },
+  {
+    name: "blockmap with a descriptor-only installer",
+    expected: "installer blockmap requires installer bytes",
+    input: () =>
+      roundTripInput({
+        candidate: release(
+          "0.1.6",
+          {
+            sha512: createHash("sha512").update(candidateInstaller).digest("base64"),
+            size: candidateInstaller.byteLength,
+          } as unknown as Uint8Array,
+          {
+            blockmap: blockmapFor(candidateInstaller),
+            metadataOverrides: {
+              sha512: createHash("sha512").update(candidateInstaller).digest("base64"),
+              size: candidateInstaller.byteLength,
+            },
+          },
+        ),
       }),
   },
   {


### PR DESCRIPTION
Addresses the 7 findings from the umbrella #757 review (2 P1, 4 P2, 1 P3).

1. **P1 — unsigned installer public before verification.** `upload-windows-release.mjs` now accepts only `--authenticode verify` with a real `--publisher-dn` (placeholder rejected, optional `--thumbprint`), runs local Authenticode + provenance verification before any release read or mutation, and refuses anything the verifier did not mark `verified`.
2. **P1 — Authenticode cannot run on ubuntu.** `desktop-windows-release.yml` runs on `windows-latest` (bash shell, `cygpath` for `RUNNER_TEMP`), resolves the release tag to its commit (lightweight or annotated) and passes `--commit` to the verifier.
3. **P2 — non-transactional multi-asset upload.** On upload failure the uploader re-reads the release and records `uploadedAssets` / `uploaded` (`true`, `false`, or `"unknown"` when the re-read fails); a partial upload fails with `Windows release upload is incomplete`.
4. **P2 — blockmap unrelated to installer bytes.** Chunk-checksum verification is now shared: `checkWindowsInstallerBlockmap` (exported from `verify-windows-release.mjs`) recomputes blake2b-18 per chunk plus total size; the round-trip requires installer bytes when a blockmap is present.
5. **P2 — unbound provenance.** `windows-release-plan.mjs` seals `enduragent-release-commit:<sha>` into electron-builder `win.legalTrademarks` (lands in the NSIS installer's version resource, `NsisTarget.js:398`). `verify-windows-authenticode.ps1` reads `FileVersionInfo.LegalTrademarks` / `ProductVersion` into a new `versionInfo` field (summary schema bumped to `windows-authenticode-verification/2`); `decideWindowsAuthenticode` fails with `Authenticode provenance mismatch` unless commit and version match. Verify mode now requires the release commit.
6. **P2 — operator command guaranteed to fail.** CONTRIBUTING upload and `workflow run` commands updated; pending-marker instructions removed; `apps/desktop/CONTEXT.md` terms updated.
7. **P3 — record inside envelope.** An upload record inside `--directory` (including `..name.json`) is rejected before the record file is created.

No new numeric limits. Verification: focused vitest suites (upload, release-artifacts, authenticode, round-trip, release-plan, package-contract) green; desktop `tsc --noEmit` green; `git diff --check` clean; independent read-only review confirmed all 7 findings fixed (its two residuals — the `..name.json` edge and the round-trip `.d.mts` union — are patched here). The `.ps1` change was not executed locally (no `pwsh` on this Mac); it runs on the `windows-latest` job.
