### PR TITLE
fix(desktop): upload exact verified Windows bytes to the latest release

### DIFF
--- a/.changeset/windows-upload-exact-bytes.md
+++ b/.changeset/windows-upload-exact-bytes.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Windows release upload: uploads read-only copies of the exact verified bytes and reconciles GitHub asset digests against them, verifies the packaged `app-update.yml` publisher and seals its digest into the installer provenance, and refuses uploads to a release that is not the repository's latest.

--- a/.github/workflows/desktop-windows-release.yml
+++ b/.github/workflows/desktop-windows-release.yml
@@ -82,6 +82,11 @@ jobs:
             echo '::error::Windows release assets are incomplete'
             exit 1
           fi
+          LATEST_TAG=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" | jq -er '.tag_name')
+          if [ "$LATEST_TAG" != "enduragent-desktop@$VERSION" ]; then
+            echo '::error::Desktop release is not the latest release'
+            exit 1
+          fi
           RELEASE_ID=$(printf '%s' "$RELEASE" | jq -er '.id')
           echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
           REF=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/enduragent-desktop@$VERSION")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,8 @@ Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is t
 - Never make `desktop-release.yml` wait for Windows.
 - Use one GitHub release per desktop version.
 - Append Windows assets after the macOS release.
-- Allow Windows to lag or skip a desktop version.
+- Append Windows assets only while `enduragent-desktop@<x.y.z>` is the repository's latest release. The updater feed is `/releases/latest/download/`, so Windows clients cannot discover assets on an older release.
+- Skip Windows for a version once a newer desktop release exists. Ship it with the next version instead.
 - State which platforms shipped in the release notes.
 - Build and sign in one `electron-builder` run on the operator's Windows VM inside an open SimplySign session.
 - Approve the single signing OTP with one phone tap.
@@ -181,20 +182,21 @@ Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is t
 - Upload only `Enduragent-<x.y.z>-x64.exe`, `Enduragent-<x.y.z>-x64.exe.blockmap`, and `latest.yml` from the repository root on the signing host, using absolute paths:
 
   ```bash
-  node apps/desktop/scripts/upload-windows-release.mjs --version <x.y.z> --directory <absolute-artifact-dir> --commit <release-commit-sha> --authenticode verify --publisher-dn "<PUBLISHER_DN>" --record <absolute-path>/windows-release-<x.y.z>.json
+  node apps/desktop/scripts/upload-windows-release.mjs --version <x.y.z> --directory <absolute-artifact-dir> --commit <release-commit-sha> --authenticode verify --publisher-dn "<PUBLISHER_DN>" --app-update-metadata <absolute-dist-dir>/win-unpacked/resources/app-update.yml --record <absolute-path>/windows-release-<x.y.z>.json
   ```
 
 - Pass `--authenticode verify` and the exact certificate subject as `--publisher-dn`. The uploader rejects every other mode and the placeholder DN.
 - Pass `--thumbprint <40-hex>` to pin the signing certificate. Omit it to accept any trusted certificate with the expected subject.
 - Run the upload on a Windows host with PowerShell 7 and `signtool.exe`. Local Authenticode verification runs before any release mutation.
+- Pass `--app-update-metadata` pointing at the packaged `win-unpacked/resources/app-update.yml` from the same build. The uploader refuses it unless `publisherName` equals `--publisher-dn`.
 - Keep `--record` outside `--directory`. The uploader refuses a record path inside the artifact directory.
 - Omit `--record` only when no local JSON record is required.
 - Leave `--repo` unset to use `yerzhansa/enduragent`.
 - Let `upload-windows-release.mjs` run `verify-windows-release.mjs` locally, including Authenticode and provenance verification.
-- Stop the upload when `enduragent-desktop@<x.y.z>` is missing or still a draft.
+- Stop the upload when `enduragent-desktop@<x.y.z>` is missing, still a draft, a prerelease, or not the latest release.
 - Refuse the upload when any Windows envelope asset already exists on the release.
-- Upload the verified envelope through `gh-personal release upload`.
-- Re-read the release after upload and fail unless all three assets are present.
+- Upload owner-only, read-only copies of the verified bytes through `gh-personal release upload`. The original artifact paths are never uploaded.
+- Re-read the release after upload and fail unless all three assets are present and each GitHub asset `digest` and size equals the uploaded bytes.
 - Read `uploadedAssets` in a failed record before retrying. A partial upload lists the assets that became public.
 - Trigger the separate verification workflow from the repository root:
 
@@ -205,7 +207,7 @@ Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is t
 - Leave `dry_run` at its `true` default to verify without editing the release.
 - Pass `dry_run=false` only when the release body must record the completed verification. The workflow refuses `dry_run=false` without `authenticode=verify` and a real `publisher_dn`.
 - Keep `desktop-windows-release.yml` to its single `verify-windows-envelope` job on `windows-latest`. `Get-AuthenticodeSignature` and `signtool.exe` exist only on Windows.
-- Reject a non-stable SemVer or a missing, draft, or prerelease `enduragent-desktop@<version>` release in `verify-windows-envelope`.
+- Reject a non-stable SemVer or a missing, draft, prerelease, or non-latest `enduragent-desktop@<version>` release in `verify-windows-envelope`.
 - Require exactly `Enduragent-<version>-x64.exe`, `Enduragent-<version>-x64.exe.blockmap`, and `latest.yml` as the Windows envelope among the release assets.
 - Download only those three Windows assets in `verify-windows-envelope`.
 - Resolve the release tag to its commit and pass it as `--commit`.
@@ -214,4 +216,4 @@ Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is t
 - Never create, move, or delete a release, tag, or asset in `desktop-windows-release.yml`.
 - Leave uploaded assets in place when verification fails.
 - Remove failed Windows assets by hand before retrying.
-- Build provenance: `windows-release-plan.mjs` seals `enduragent-release-commit:<sha>` into the installer's `LegalTrademarks` version string. Verification reads it from the signed installer and compares it with `--commit`.
+- Build provenance: `windows-release-plan.mjs` seals `enduragent-release-commit:<sha> enduragent-updater-publisher-sha256:<sha256 of publisher DN>` into the installer's `LegalTrademarks` version string. Verification reads it from the signed installer and compares it with `--commit` and `--publisher-dn`.

--- a/apps/desktop/CONTEXT.md
+++ b/apps/desktop/CONTEXT.md
@@ -87,7 +87,7 @@ _Avoid_: Windows bundle, release files
 _Avoid_: Unsigned mode, signing bypass
 
 **Windows release provenance**:
-The `enduragent-release-commit:<sha>` string that `windows-release-plan.mjs` seals into the installer's `LegalTrademarks` version field; `verify-windows-authenticode.ps1` reads it back and `--commit` must match.
+The `enduragent-release-commit:<sha> enduragent-updater-publisher-sha256:<hex>` string that `windows-release-plan.mjs` seals into the installer's `LegalTrademarks` version field; `verify-windows-authenticode.ps1` reads it back and `--commit` plus the SHA-256 of `--publisher-dn` must match.
 _Avoid_: Build stamp, commit marker
 
 **Windows package inventory**:
@@ -116,7 +116,8 @@ _Avoid_: Install directory, application directory
 - The **Release marker** admits a packaged build to `isDesktopUpdateReleaseEligible`; **Platform activation** independently decides whether update checks run on the current platform.
 - A **Windows release envelope** is produced, verified, uploaded, and round-trip-checked by its named scripts.
 - **Authenticode pending mode** does not authorise an unsigned installer for a GitHub release or the website.
-- **Windows release provenance** binds a verified installer to the release tag commit before upload.
+- **Windows release provenance** binds a verified installer to the release tag commit and the updater publisher before upload.
+- `upload-windows-release.mjs` uploads read-only copies of the verified bytes, only to the latest release, and reconciles GitHub asset digests against those bytes.
 - The **Windows package inventory** fixes the application, resource, and asar contents accepted by package verification.
 - The athlete removes the **Windows user data directory** by hand when retained data must be erased after uninstall.
 

--- a/apps/desktop/scripts/upload-windows-release.d.mts
+++ b/apps/desktop/scripts/upload-windows-release.d.mts
@@ -1,4 +1,4 @@
-import type { ObjectEncodingOptions, OpenMode } from "node:fs";
+import type { ObjectEncodingOptions, OpenMode, RmOptions } from "node:fs";
 import type { VerifiedWindowsReleaseAssets } from "./verify-windows-release.mjs";
 import type { VerifyWindowsReleaseOptions } from "./verify-windows-release.mjs";
 
@@ -8,6 +8,7 @@ export interface WindowsReleaseUploadInput {
   readonly commit: string;
   readonly authenticode: "verify";
   readonly publisherDn: string;
+  readonly appUpdateMetadata: string;
   readonly thumbprint?: string;
   readonly repo?: string;
   readonly record?: string;
@@ -41,9 +42,12 @@ export interface WindowsReleaseUploadDependencies {
   readonly readFile?: (path: string) => Promise<Buffer>;
   readonly writeFile?: (
     path: string,
-    data: string,
+    data: string | Uint8Array,
     options: ObjectEncodingOptions & { readonly mode?: OpenMode; readonly flag?: OpenMode },
   ) => Promise<void>;
+  readonly mkdtemp?: (prefix: string) => Promise<string>;
+  readonly chmod?: (path: string, mode: number) => Promise<void>;
+  readonly rm?: (path: string, options: RmOptions) => Promise<void>;
 }
 
 export function safeWindowsReleaseUploadMessage(error: unknown): string | undefined;

--- a/apps/desktop/scripts/upload-windows-release.mjs
+++ b/apps/desktop/scripts/upload-windows-release.mjs
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFile, writeFile } from "node:fs/promises";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import {
@@ -33,6 +34,10 @@ const safeWindowsReleaseUploadMessages = new Set([
   "artifact directory must be absolute",
   "upload record path must be absolute",
   "upload record must be outside the artifact directory",
+  "app-update.yml path must be absolute",
+  "app-update.yml is unreadable",
+  "release is not the latest release",
+  "Windows release asset digest mismatch",
   "upload record already exists",
   "upload record directory is missing",
   "release repository is invalid",
@@ -78,6 +83,75 @@ function requireThumbprint(value) {
 function recordInsideDirectory(record, directory) {
   const path = relative(resolve(directory), resolve(record));
   return path === "" || (path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path));
+}
+
+function parseLatestRelease(stdout) {
+  let release;
+  try {
+    release = JSON.parse(stdout);
+  } catch {
+    throw new TypeError("release is not the latest release");
+  }
+  if (!release || typeof release !== "object" || typeof release.tag_name !== "string") {
+    throw new TypeError("release is not the latest release");
+  }
+  return release.tag_name;
+}
+
+async function requireLatestRelease(executeFile, repository, tag) {
+  let result;
+  try {
+    result = await executeFile("gh-personal", ["api", `repos/${repository}/releases/latest`]);
+  } catch {
+    throw new TypeError("release is not the latest release");
+  }
+  if (parseLatestRelease(result.stdout) !== tag) {
+    throw new TypeError("release is not the latest release");
+  }
+}
+
+function parseReleaseAssets(stdout, tag) {
+  let release;
+  try {
+    release = JSON.parse(stdout);
+  } catch {
+    throw new TypeError("Windows release asset digest mismatch");
+  }
+  if (
+    !release ||
+    typeof release !== "object" ||
+    release.tag_name !== tag ||
+    !Array.isArray(release.assets)
+  ) {
+    throw new TypeError("Windows release asset digest mismatch");
+  }
+  return new Map(
+    release.assets.flatMap((asset) =>
+      asset !== null && typeof asset === "object" && typeof asset.name === "string"
+        ? [[asset.name, asset]]
+        : [],
+    ),
+  );
+}
+
+async function reconcileAssetDigests(executeFile, repository, tag, files) {
+  let result;
+  try {
+    result = await executeFile("gh-personal", ["api", `repos/${repository}/releases/tags/${tag}`]);
+  } catch {
+    throw new TypeError("Windows release asset digest mismatch");
+  }
+  const assets = parseReleaseAssets(result.stdout, tag);
+  for (const file of files) {
+    const asset = assets.get(file.name);
+    if (
+      asset === undefined ||
+      asset.size !== file.size ||
+      asset.digest !== `sha256:${file.sha256}`
+    ) {
+      throw new TypeError("Windows release asset digest mismatch");
+    }
+  }
 }
 
 function requireRepository(value) {
@@ -184,16 +258,17 @@ async function resolveTagCommit(executeFile, repository, tag) {
   return peeled.sha;
 }
 
-async function releaseFileRecords(verified, dependencies) {
+function releaseFileRecords(verified) {
   const entries = [
-    [verified.names.installer, verified.paths.installer, verified.sizes.installer],
-    [verified.names.blockmap, verified.paths.blockmap, verified.sizes.blockmap],
-    [verified.names.metadata, verified.paths.metadata, verified.sizes.metadata],
+    [verified.names.installer, verified.bytes.installer, verified.sizes.installer],
+    [verified.names.blockmap, verified.bytes.blockmap, verified.sizes.blockmap],
+    [verified.names.metadata, verified.bytes.metadata, verified.sizes.metadata],
   ];
-  return Promise.all(
-    entries.map(async ([name, path, size]) => {
-      const bytes = await dependencies.readFile(path);
-      if (bytes.length !== size) throw new TypeError("Windows release upload is incomplete");
+  return Object.freeze(
+    entries.map(([name, bytes, size]) => {
+      if (!Buffer.isBuffer(bytes) || bytes.length !== size) {
+        throw new TypeError("Windows release upload is incomplete");
+      }
       return Object.freeze({
         name,
         size,
@@ -201,6 +276,18 @@ async function releaseFileRecords(verified, dependencies) {
       });
     }),
   );
+}
+
+async function stageVerifiedBytes(verified, dependencies) {
+  const directory = await dependencies.mkdtemp(join(tmpdir(), "enduragent-windows-release-"));
+  await dependencies.chmod(directory, 0o700);
+  const paths = {};
+  for (const key of ["installer", "blockmap", "metadata"]) {
+    const path = join(directory, verified.names[key]);
+    await dependencies.writeFile(path, verified.bytes[key], { flag: "wx", mode: 0o400 });
+    paths[key] = path;
+  }
+  return Object.freeze({ directory, paths: Object.freeze(paths) });
 }
 
 export async function runWindowsReleaseUpload(input, dependencies = {}) {
@@ -225,11 +312,17 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
   if (input.record !== undefined && recordInsideDirectory(input.record, input.directory)) {
     throw new TypeError("upload record must be outside the artifact directory");
   }
+  if (typeof input.appUpdateMetadata !== "string" || !isAbsolute(input.appUpdateMetadata)) {
+    throw new TypeError("app-update.yml path must be absolute");
+  }
   const executeFile = dependencies.executeFile ?? executeSystemFile;
   const verifyAssets = dependencies.verifyAssets ?? verifyWindowsReleaseAssets;
   const fileDependencies = {
     readFile: dependencies.readFile ?? readFile,
     writeFile: dependencies.writeFile ?? writeFile,
+    mkdtemp: dependencies.mkdtemp ?? mkdtemp,
+    chmod: dependencies.chmod ?? chmod,
+    rm: dependencies.rm ?? rm,
   };
   const tag = `enduragent-desktop@${version}`;
   const expectedNames = Object.values(windowsReleaseArtifactNames(version));
@@ -244,6 +337,7 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
   }
   let uploaded = false;
   let uploadedAssets = [];
+  let staging;
   const reconcile = async () => {
     try {
       const current = await viewRelease(executeFile, tag, repository);
@@ -256,17 +350,26 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
     }
   };
   try {
+    let appUpdateMetadata;
+    try {
+      appUpdateMetadata = await fileDependencies.readFile(input.appUpdateMetadata);
+    } catch {
+      throw new TypeError("app-update.yml is unreadable");
+    }
     const verified = await verifyAssets(input.directory, {
       version,
       commit,
       expectedPublisherName: publisherDn,
+      appUpdateMetadata,
       authenticode: authenticodeMode,
     });
     if (verified.authenticode !== "verified") {
       throw new TypeError("unsigned Windows installer refused");
     }
-    const files = Object.freeze(await releaseFileRecords(verified, fileDependencies));
+    const files = releaseFileRecords(verified);
+    staging = await stageVerifiedBytes(verified, fileDependencies);
     const release = await viewRelease(executeFile, tag, repository);
+    await requireLatestRelease(executeFile, repository, tag);
     const tagCommit = await resolveTagCommit(executeFile, repository, tag);
     if (tagCommit !== commit) throw new TypeError("release commit mismatch");
     const existingNames = new Set(releaseAssetNames(release));
@@ -282,9 +385,9 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
         tag,
         "--repo",
         repository,
-        verified.paths.installer,
-        verified.paths.blockmap,
-        verified.paths.metadata,
+        staging.paths.installer,
+        staging.paths.blockmap,
+        staging.paths.metadata,
       ]);
     } catch (error) {
       await reconcile();
@@ -296,6 +399,7 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
     if (uploadedAssets === null || uploadedAssets.length !== expectedNames.length) {
       throw new TypeError("Windows release upload is incomplete");
     }
+    await reconcileAssetDigests(executeFile, repository, tag, files);
     const record = Object.freeze({
       schemaVersion: 1,
       tag,
@@ -340,6 +444,12 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
       } catch {}
     }
     throw error;
+  } finally {
+    if (staging !== undefined) {
+      try {
+        await fileDependencies.rm(staging.directory, { recursive: true, force: true });
+      } catch {}
+    }
   }
 }
 
@@ -350,6 +460,7 @@ const commandOptions = Object.freeze({
   authenticode: "authenticode",
   "publisher-dn": "publisherDn",
   thumbprint: "thumbprint",
+  "app-update-metadata": "appUpdateMetadata",
   repo: "repo",
   record: "record",
 });

--- a/apps/desktop/scripts/verify-windows-authenticode.mjs
+++ b/apps/desktop/scripts/verify-windows-authenticode.mjs
@@ -2,7 +2,11 @@ import { execFile } from "node:child_process";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { parseWindowsReleaseProvenance, requireReleaseCommit } from "./windows-release-plan.mjs";
+import {
+  parseWindowsReleaseProvenance,
+  requireReleaseCommit,
+  windowsUpdaterPublisherDigest,
+} from "./windows-release-plan.mjs";
 
 export const WINDOWS_AUTHENTICODE_SUMMARY_SCHEMA = "windows-authenticode-verification/2";
 export const WINDOWS_AUTHENTICODE_REQUIRED_CHECKS = Object.freeze([
@@ -170,9 +174,14 @@ function validExpectedValues(expectedPublisherDn, expectedThumbprint, expectedCo
   );
 }
 
-function provenanceMatches(summary, expectedCommit, expectedVersion) {
+function provenanceMatches(summary, expectedCommit, expectedVersion, expectedPublisherDn) {
   if (expectedCommit !== undefined) {
-    if (parseWindowsReleaseProvenance(summary.versionInfo.legalTrademarks) !== expectedCommit) {
+    const provenance = parseWindowsReleaseProvenance(summary.versionInfo.legalTrademarks);
+    if (
+      provenance === null ||
+      provenance.commit !== expectedCommit ||
+      provenance.publisherSha256 !== windowsUpdaterPublisherDigest(expectedPublisherDn)
+    ) {
       return false;
     }
   }
@@ -239,7 +248,7 @@ export function decideWindowsAuthenticode(
     fail("Authenticode chain is untrusted");
   }
   if (!checks.get("signtool").ok) fail("signtool verification failed");
-  if (!provenanceMatches(summary, expectedCommit, expectedVersion)) {
+  if (!provenanceMatches(summary, expectedCommit, expectedVersion, expectedPublisherDn)) {
     fail("Authenticode provenance mismatch");
   }
   if (!checks.get("status").ok || !summary.ok || summary.checks.some((check) => !check.ok)) {

--- a/apps/desktop/scripts/verify-windows-release.d.mts
+++ b/apps/desktop/scripts/verify-windows-release.d.mts
@@ -1,4 +1,4 @@
-import type { Stats } from "node:fs";
+import type { ObjectEncodingOptions, OpenMode, RmOptions, Stats } from "node:fs";
 import type { WindowsReleaseArtifactNames } from "./windows-release-plan.mjs";
 
 export type WindowsAuthenticodeMode =
@@ -28,6 +28,14 @@ export interface VerifyWindowsReleaseDependencies {
   readonly lstat?: (path: string) => Promise<Stats>;
   readonly readdir?: (path: string) => Promise<string[]>;
   readonly readFile?: (path: string) => Promise<Buffer>;
+  readonly mkdtemp?: (prefix: string) => Promise<string>;
+  readonly chmod?: (path: string, mode: number) => Promise<void>;
+  readonly writeFile?: (
+    path: string,
+    data: Uint8Array,
+    options: ObjectEncodingOptions & { readonly mode?: OpenMode; readonly flag?: OpenMode },
+  ) => Promise<void>;
+  readonly rm?: (path: string, options: RmOptions) => Promise<void>;
   readonly notice?: (message: string) => void;
 }
 
@@ -48,6 +56,11 @@ export interface VerifiedWindowsReleaseAssets {
   readonly installerSha512: string;
   readonly installerSha256: string;
   readonly authenticode: "pending-w19" | "verified";
+  readonly bytes: {
+    readonly installer: Buffer;
+    readonly blockmap: Buffer;
+    readonly metadata: Buffer;
+  };
 }
 
 export const WINDOWS_UPDATER_METADATA_MAX_BYTES: 16_384;

--- a/apps/desktop/scripts/verify-windows-release.mjs
+++ b/apps/desktop/scripts/verify-windows-release.mjs
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import { lstat, readFile, readdir } from "node:fs/promises";
+import { chmod, lstat, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { createRequire } from "node:module";
 import { isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -239,6 +240,10 @@ export async function verifyWindowsReleaseAssets(artifactDirectory, options, ove
     lstat: overrides.lstat ?? lstat,
     readdir: overrides.readdir ?? readdir,
     readFile: overrides.readFile ?? readFile,
+    mkdtemp: overrides.mkdtemp ?? mkdtemp,
+    chmod: overrides.chmod ?? chmod,
+    writeFile: overrides.writeFile ?? writeFile,
+    rm: overrides.rm ?? rm,
     notice: overrides.notice,
   };
   let directoryStat;
@@ -301,14 +306,25 @@ export async function verifyWindowsReleaseAssets(artifactDirectory, options, ove
     dependencies.notice?.("Authenticode verification is pending W19; signature not verified");
     authenticode = WINDOWS_AUTHENTICODE_PENDING;
   } else {
+    let staging;
     try {
-      await authenticodeMode.verify(paths.installer, {
+      staging = await dependencies.mkdtemp(join(tmpdir(), "enduragent-windows-verify-"));
+      await dependencies.chmod(staging, 0o700);
+      const stagedInstaller = join(staging, names.installer);
+      await dependencies.writeFile(stagedInstaller, installer, { flag: "wx", mode: 0o400 });
+      await authenticodeMode.verify(stagedInstaller, {
         version,
         commit,
         publisherName: options.expectedPublisherName,
       });
     } catch {
       fail("Windows installer Authenticode verification failed");
+    } finally {
+      if (staging !== undefined) {
+        try {
+          await dependencies.rm(staging, { recursive: true, force: true });
+        } catch {}
+      }
     }
     authenticode = "verified";
   }
@@ -325,6 +341,7 @@ export async function verifyWindowsReleaseAssets(artifactDirectory, options, ove
     installerSha512,
     installerSha256,
     authenticode,
+    bytes: Object.freeze({ installer, blockmap, metadata: metadataBytes }),
   });
 }
 

--- a/apps/desktop/scripts/windows-release-plan.d.mts
+++ b/apps/desktop/scripts/windows-release-plan.d.mts
@@ -78,8 +78,14 @@ export const WINDOWS_RELEASE_METADATA_NAME: "latest.yml";
 export const WINDOWS_AUTHENTICODE_PENDING: "pending-w19";
 export const WINDOWS_PUBLISHER_DN_PLACEHOLDER: "CN=ENDURAGENT PUBLISHER DN PLACEHOLDER, O=PLACEHOLDER";
 export const WINDOWS_RELEASE_PROVENANCE_PREFIX: "enduragent-release-commit:";
-export function windowsReleaseProvenance(commit: string): string;
-export function parseWindowsReleaseProvenance(value: unknown): string | null;
+export const WINDOWS_UPDATER_PUBLISHER_PREFIX: "enduragent-updater-publisher-sha256:";
+export interface WindowsReleaseProvenance {
+  readonly commit: string;
+  readonly publisherSha256: string;
+}
+export function windowsUpdaterPublisherDigest(publisherDn: string): string;
+export function windowsReleaseProvenance(commit: string, publisherDn: string): string;
+export function parseWindowsReleaseProvenance(value: unknown): WindowsReleaseProvenance | null;
 export function safeWindowsReleasePlanMessage(error: unknown): string | undefined;
 export function requireReleaseCommit(value: unknown): string;
 export function windowsReleaseArtifactNames(version: string): WindowsReleaseArtifactNames;

--- a/apps/desktop/scripts/windows-release-plan.mjs
+++ b/apps/desktop/scripts/windows-release-plan.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -31,6 +32,7 @@ export const WINDOWS_AUTHENTICODE_PENDING = "pending-w19";
 export const WINDOWS_PUBLISHER_DN_PLACEHOLDER =
   "CN=ENDURAGENT PUBLISHER DN PLACEHOLDER, O=PLACEHOLDER";
 export const WINDOWS_RELEASE_PROVENANCE_PREFIX = "enduragent-release-commit:";
+export const WINDOWS_UPDATER_PUBLISHER_PREFIX = "enduragent-updater-publisher-sha256:";
 
 function exactObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -70,7 +72,7 @@ function freezeBuilderOptions(desktopRoot, version, commit, feedUrl, publisherDn
       }),
       signExecutable: true,
       verifyUpdateCodeSignature: true,
-      legalTrademarks: windowsReleaseProvenance(commit),
+      legalTrademarks: windowsReleaseProvenance(commit, publisherDn),
       target,
     }),
     nsis: Object.freeze({
@@ -101,16 +103,31 @@ export function requireReleaseCommit(value) {
   return value;
 }
 
-export function windowsReleaseProvenance(commit) {
-  return `${WINDOWS_RELEASE_PROVENANCE_PREFIX}${requireReleaseCommit(commit)}`;
+export function windowsUpdaterPublisherDigest(publisherDn) {
+  if (typeof publisherDn !== "string" || publisherDn.length === 0) {
+    throw new TypeError("Windows publisher DN is invalid");
+  }
+  return createHash("sha256").update(publisherDn, "utf8").digest("hex");
+}
+
+export function windowsReleaseProvenance(commit, publisherDn) {
+  return `${WINDOWS_RELEASE_PROVENANCE_PREFIX}${requireReleaseCommit(commit)} ${WINDOWS_UPDATER_PUBLISHER_PREFIX}${windowsUpdaterPublisherDigest(publisherDn)}`;
 }
 
 export function parseWindowsReleaseProvenance(value) {
-  if (typeof value !== "string" || !value.startsWith(WINDOWS_RELEASE_PROVENANCE_PREFIX)) {
+  if (typeof value !== "string") return null;
+  const tokens = value.split(" ");
+  if (
+    tokens.length !== 2 ||
+    !tokens[0].startsWith(WINDOWS_RELEASE_PROVENANCE_PREFIX) ||
+    !tokens[1].startsWith(WINDOWS_UPDATER_PUBLISHER_PREFIX)
+  ) {
     return null;
   }
-  const commit = value.slice(WINDOWS_RELEASE_PROVENANCE_PREFIX.length);
-  return /^[0-9a-f]{40}$/u.test(commit) ? commit : null;
+  const commit = tokens[0].slice(WINDOWS_RELEASE_PROVENANCE_PREFIX.length);
+  const publisherSha256 = tokens[1].slice(WINDOWS_UPDATER_PUBLISHER_PREFIX.length);
+  if (!/^[0-9a-f]{40}$/u.test(commit) || !/^[0-9a-f]{64}$/u.test(publisherSha256)) return null;
+  return Object.freeze({ commit, publisherSha256 });
 }
 
 export function windowsReleaseArtifactNames(version) {
@@ -159,6 +176,13 @@ export function parseWindowsReleaseUpdaterMetadata(bytes, options = {}) {
   }
   const keys = ["provider", "url", "channel", "updaterCacheDirName"];
   if (exactObject(metadata) && Object.hasOwn(metadata, "publisherName")) keys.push("publisherName");
+  let publisherName;
+  if (exactObject(metadata) && Object.hasOwn(metadata, "publisherName")) {
+    publisherName =
+      Array.isArray(metadata.publisherName) && metadata.publisherName.length === 1
+        ? metadata.publisherName[0]
+        : metadata.publisherName;
+  }
   if (
     !exactObject(metadata) ||
     !hasExactKeys(metadata, keys) ||
@@ -166,9 +190,9 @@ export function parseWindowsReleaseUpdaterMetadata(bytes, options = {}) {
     metadata.channel !== "latest" ||
     metadata.updaterCacheDirName !== DESKTOP_UPDATER_CACHE_DIRECTORY ||
     (Object.hasOwn(metadata, "publisherName") &&
-      (typeof metadata.publisherName !== "string" ||
-        metadata.publisherName.length === 0 ||
-        metadata.publisherName !== metadata.publisherName.trim()))
+      (typeof publisherName !== "string" ||
+        publisherName.length === 0 ||
+        publisherName !== publisherName.trim()))
   ) {
     throw new TypeError("release updater metadata is invalid");
   }
@@ -180,7 +204,7 @@ export function parseWindowsReleaseUpdaterMetadata(bytes, options = {}) {
   }
   if (
     Object.hasOwn(options, "expectedPublisherName") &&
-    options.expectedPublisherName !== metadata.publisherName
+    options.expectedPublisherName !== publisherName
   ) {
     throw new TypeError("release updater publisher name mismatch");
   }
@@ -190,7 +214,7 @@ export function parseWindowsReleaseUpdaterMetadata(bytes, options = {}) {
     channel: "latest",
     updaterCacheDirName: DESKTOP_UPDATER_CACHE_DIRECTORY,
   };
-  if (Object.hasOwn(metadata, "publisherName")) result.publisherName = metadata.publisherName;
+  if (publisherName !== undefined) result.publisherName = publisherName;
   return Object.freeze(result);
 }
 

--- a/apps/desktop/tests/upload-windows-release.test.ts
+++ b/apps/desktop/tests/upload-windows-release.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { stringify } from "yaml";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,7 +21,12 @@ const script = resolve(
 );
 const temporaryRoots: string[] = [];
 let directory: string;
+let appUpdateMetadataPath: string;
 let verified: VerifiedWindowsReleaseAssets;
+
+function digestOf(bytes: Uint8Array) {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
 
 afterEach(async () => {
   await Promise.all(
@@ -42,10 +48,22 @@ beforeEach(async () => {
     blockmap: join(directory, names.blockmap),
     metadata: join(directory, names.metadata),
   };
+  appUpdateMetadataPath = join(directory, "..", `app-update-${process.pid}.yml`);
+  temporaryRoots.push(appUpdateMetadataPath);
   await Promise.all([
     writeFile(paths.installer, contents.installer),
     writeFile(paths.blockmap, contents.blockmap),
     writeFile(paths.metadata, contents.metadata),
+    writeFile(
+      appUpdateMetadataPath,
+      stringify({
+        provider: "generic",
+        url: "https://github.com/yerzhansa/enduragent/releases/latest/download/",
+        channel: "latest",
+        updaterCacheDirName: "@enduragentdesktop-updater",
+        publisherName: [publisherDn],
+      }),
+    ),
   ]);
   verified = {
     version,
@@ -60,8 +78,26 @@ beforeEach(async () => {
     installerSha512: createHash("sha512").update(contents.installer).digest("base64"),
     installerSha256: createHash("sha256").update(contents.installer).digest("hex"),
     authenticode: "verified",
+    bytes: contents,
   };
 });
+
+function releaseAssetsApi(names: readonly string[] = Object.values(verified.names)) {
+  const byName = new Map(
+    [
+      [verified.names.installer, verified.bytes.installer],
+      [verified.names.blockmap, verified.bytes.blockmap],
+      [verified.names.metadata, verified.bytes.metadata],
+    ] as const,
+  );
+  return JSON.stringify({
+    tag_name: tag,
+    assets: names.map((name) => {
+      const bytes = byName.get(name) ?? Buffer.from("other");
+      return { name, size: bytes.length, digest: digestOf(bytes) };
+    }),
+  });
+}
 
 function release(assets: readonly string[] = [], overrides: Record<string, unknown> = {}) {
   return JSON.stringify({
@@ -79,6 +115,9 @@ function successfulExecutor(
     readonly initialAssets?: readonly string[];
     readonly reference?: { readonly type: "commit" | "tag"; readonly sha: string };
     readonly peeled?: { readonly type: "commit" | "tag"; readonly sha: string };
+    readonly latestTag?: string;
+    readonly assetsApi?: string;
+    readonly onUpload?: (paths: readonly string[]) => Promise<void> | void;
   } = {},
 ) {
   let views = 0;
@@ -91,6 +130,16 @@ function successfulExecutor(
             ? release(options.initialAssets ?? [`Enduragent-${version}-arm64.dmg`])
             : release(Object.values(verified.names)),
       };
+    }
+    if (arguments_[0] === "release" && arguments_[1] === "upload") {
+      await options.onUpload?.(arguments_.slice(5));
+      return { stdout: "" };
+    }
+    if (arguments_[0] === "api" && arguments_[1]?.endsWith("/releases/latest")) {
+      return { stdout: JSON.stringify({ tag_name: options.latestTag ?? tag }) };
+    }
+    if (arguments_[0] === "api" && arguments_[1]?.includes("/releases/tags/")) {
+      return { stdout: options.assetsApi ?? releaseAssetsApi() };
     }
     if (arguments_[0] === "api" && arguments_[1]?.includes("/git/ref/tags/")) {
       return { stdout: JSON.stringify({ object: options.reference ?? { type: "commit", sha: commit } }) };
@@ -109,21 +158,41 @@ function input(overrides: Record<string, unknown> = {}) {
     commit,
     authenticode: "verify" as const,
     publisherDn,
+    appUpdateMetadata: appUpdateMetadataPath,
     ...overrides,
   };
 }
 
 describe("Windows release upload", () => {
   it("verifies locally, views the release, and uploads installer, blockmap, then metadata", async () => {
-    const executeFile = successfulExecutor();
+    const uploadedBytes: Buffer[] = [];
+    let uploadedPaths: readonly string[] = [];
+    const executeFile = successfulExecutor({
+      onUpload: async (paths) => {
+        uploadedPaths = paths;
+        for (const path of paths) uploadedBytes.push(await readFile(path));
+      },
+    });
     const verifyAssets = vi.fn(async () => verified);
     await runWindowsReleaseUpload(input(), { executeFile, verifyAssets });
     expect(verifyAssets).toHaveBeenCalledWith(directory, {
       version,
       commit,
       expectedPublisherName: publisherDn,
+      appUpdateMetadata: await readFile(appUpdateMetadataPath),
       authenticode: expect.objectContaining({ mode: "verify", expectedPublisherDn: publisherDn }),
     });
+    expect(uploadedPaths).toHaveLength(3);
+    expect(uploadedPaths.every((path) => !path.startsWith(directory))).toBe(true);
+    expect(uploadedPaths.map((path) => path.split(/[\\/]/u).at(-1))).toEqual(
+      Object.values(verified.names),
+    );
+    expect(uploadedBytes).toEqual([
+      verified.bytes.installer,
+      verified.bytes.blockmap,
+      verified.bytes.metadata,
+    ]);
+    await expect(stat(uploadedPaths[0]!)).rejects.toThrow();
     const viewArguments = [
       "release",
       "view",
@@ -136,23 +205,87 @@ describe("Windows release upload", () => {
     expect(executeFile.mock.calls[0]).toEqual(["gh-personal", viewArguments]);
     expect(executeFile.mock.calls[1]).toEqual([
       "gh-personal",
-      ["api", `repos/${repository}/git/ref/tags/${tag}`],
+      ["api", `repos/${repository}/releases/latest`],
     ]);
     expect(executeFile.mock.calls[2]).toEqual([
       "gh-personal",
-      [
-        "release",
-        "upload",
-        tag,
-        "--repo",
-        repository,
-        verified.paths.installer,
-        verified.paths.blockmap,
-        verified.paths.metadata,
-      ],
+      ["api", `repos/${repository}/git/ref/tags/${tag}`],
     ]);
-    expect(executeFile.mock.calls[3]).toEqual(["gh-personal", viewArguments]);
+    expect(executeFile.mock.calls[3]).toEqual([
+      "gh-personal",
+      ["release", "upload", tag, "--repo", repository, ...uploadedPaths],
+    ]);
+    expect(executeFile.mock.calls[4]).toEqual(["gh-personal", viewArguments]);
+    expect(executeFile.mock.calls[5]).toEqual([
+      "gh-personal",
+      ["api", `repos/${repository}/releases/tags/${tag}`],
+    ]);
     expect(executeFile.mock.calls.flat(2)).not.toContain("--clobber");
+    expect(executeFile.mock.calls.flat(2)).not.toContain(verified.paths.installer);
+  });
+
+  it("uploads the verified bytes even when the artifact file changes after verification", async () => {
+    const uploadedBytes: Buffer[] = [];
+    const executeFile = successfulExecutor({
+      onUpload: async (paths) => {
+        for (const path of paths) uploadedBytes.push(await readFile(path));
+      },
+    });
+    const verifyAssets = vi.fn(async () => {
+      await writeFile(verified.paths.installer, Buffer.from("TAMPERED installer"));
+      return verified;
+    });
+    await runWindowsReleaseUpload(input(), { executeFile, verifyAssets });
+    expect(uploadedBytes[0]).toEqual(verified.bytes.installer);
+    expect(await readFile(verified.paths.installer)).toEqual(Buffer.from("TAMPERED installer"));
+  });
+
+  it("refuses an upload to a release that is not the repository's latest", async () => {
+    const executeFile = successfulExecutor({ latestTag: "enduragent-desktop@0.1.6" });
+    await expect(
+      runWindowsReleaseUpload(input(), { executeFile, verifyAssets: vi.fn(async () => verified) }),
+    ).rejects.toThrow("release is not the latest release");
+    expect(executeFile.mock.calls.flat(2)).not.toContain("upload");
+  });
+
+  it("fails when a GitHub asset digest or size differs from the uploaded bytes", async () => {
+    const wrong = JSON.parse(releaseAssetsApi()) as {
+      assets: { name: string; size: number; digest: string }[];
+    };
+    wrong.assets[1]!.digest = digestOf(Buffer.from("other blockmap"));
+    const recordPath = join(directory, "..", `upload-record-digest-${process.pid}.json`);
+    temporaryRoots.push(recordPath);
+    await expect(
+      runWindowsReleaseUpload(input({ record: recordPath }), {
+        executeFile: successfulExecutor({ assetsApi: JSON.stringify(wrong) }),
+        verifyAssets: vi.fn(async () => verified),
+      }),
+    ).rejects.toThrow("Windows release asset digest mismatch");
+    expect(JSON.parse(await readFile(recordPath, "utf8"))).toMatchObject({
+      status: "failed",
+      error: "Windows release asset digest mismatch",
+      uploaded: true,
+      uploadedAssets: Object.values(verified.names),
+    });
+  });
+
+  it("requires a readable absolute app-update.yml path before verification", async () => {
+    const executeFile = successfulExecutor();
+    const verifyAssets = vi.fn(async () => verified);
+    await expect(
+      runWindowsReleaseUpload(input({ appUpdateMetadata: "relative/app-update.yml" }), {
+        executeFile,
+        verifyAssets,
+      }),
+    ).rejects.toThrow("app-update.yml path must be absolute");
+    await expect(
+      runWindowsReleaseUpload(input({ appUpdateMetadata: join(directory, "..", "missing.yml") }), {
+        executeFile,
+        verifyAssets,
+      }),
+    ).rejects.toThrow("app-update.yml is unreadable");
+    expect(verifyAssets).not.toHaveBeenCalled();
+    expect(executeFile).not.toHaveBeenCalled();
   });
 
   it("binds a matching lightweight release tag to the commit", async () => {
@@ -174,7 +307,7 @@ describe("Windows release upload", () => {
       verifyAssets: vi.fn(async () => verified),
     });
     expect(result.tagCommit).toBe(commit);
-    expect(executeFile.mock.calls[2]).toEqual([
+    expect(executeFile.mock.calls[3]).toEqual([
       "gh-personal",
       ["api", `repos/${repository}/git/tags/${tagObject}`],
     ]);
@@ -297,6 +430,9 @@ describe("Windows release upload", () => {
           stdout: views === 1 ? release([]) : release([verified.names.installer, verified.names.blockmap]),
         };
       }
+      if (arguments_[0] === "api" && arguments_[1]?.endsWith("/releases/latest")) {
+        return { stdout: JSON.stringify({ tag_name: tag }) };
+      }
       if (arguments_[0] === "api") {
         return { stdout: JSON.stringify({ object: { type: "commit", sha: commit } }) };
       }
@@ -325,6 +461,9 @@ describe("Windows release upload", () => {
         views += 1;
         if (views === 1) return { stdout: release([]) };
         throw new Error("network");
+      }
+      if (arguments_[0] === "api" && arguments_[1]?.endsWith("/releases/latest")) {
+        return { stdout: JSON.stringify({ tag_name: tag }) };
       }
       if (arguments_[0] === "api") {
         return { stdout: JSON.stringify({ object: { type: "commit", sha: commit } }) };

--- a/apps/desktop/tests/windows-authenticode.test.ts
+++ b/apps/desktop/tests/windows-authenticode.test.ts
@@ -55,7 +55,10 @@ function summary(
     digestAlgorithm: "sha256",
     rfc3161: true,
     signtool: { path: "C:\\signtool.exe", exitCode: 0, output: "verified" },
-    versionInfo: { productVersion: version, legalTrademarks: `enduragent-release-commit:${commit}` },
+    versionInfo: {
+      productVersion: version,
+      legalTrademarks: `enduragent-release-commit:${commit} enduragent-updater-publisher-sha256:${createHash("sha256").update(publisherDn).digest("hex")}`,
+    },
     allowSelfSignedTest: false,
     checks: [
       { name: "file", ok: true, detail: "regular-executable" },
@@ -184,6 +187,28 @@ describe("Windows Authenticode decisions", () => {
       decideWindowsAuthenticode(summary(), { ...decisionOptions(), expectedVersion: "0.1.6" }),
     ).toThrow("Authenticode provenance mismatch");
     expect(() =>
+      decideWindowsAuthenticode(
+        summary({
+          versionInfo: {
+            productVersion: version,
+            legalTrademarks: `enduragent-release-commit:${commit} enduragent-updater-publisher-sha256:${"0".repeat(64)}`,
+          },
+        }),
+        { ...decisionOptions(), expectedCommit: commit },
+      ),
+    ).toThrow("Authenticode provenance mismatch");
+    expect(() =>
+      decideWindowsAuthenticode(
+        summary({
+          versionInfo: {
+            productVersion: version,
+            legalTrademarks: `enduragent-release-commit:${commit}`,
+          },
+        }),
+        { ...decisionOptions(), expectedCommit: commit },
+      ),
+    ).toThrow("Authenticode provenance mismatch");
+    expect(() =>
       decideWindowsAuthenticode({ ...summary(), versionInfo: undefined } as never, decisionOptions()),
     ).toThrow("Authenticode summary is invalid");
   });
@@ -269,7 +294,7 @@ describe("Windows Authenticode decisions", () => {
         "-File",
         scriptPath,
         "-InstallerPath",
-        installerPath,
+        expect.not.stringMatching(new RegExp(`^${directory.replaceAll("\\", "\\\\")}`, "u")),
         "-ExpectedPublisherDn",
         publisherDn,
       ]),

--- a/apps/desktop/tests/windows-release-artifacts.test.ts
+++ b/apps/desktop/tests/windows-release-artifacts.test.ts
@@ -101,19 +101,31 @@ describe("Windows release artifact verification", () => {
   });
 
   it("calls an injected Authenticode verifier and fails closed on rejection", async () => {
-    const verify = vi.fn(async () => {});
+    let stagedPath = "";
+    let stagedBytes: Buffer | undefined;
+    const verify = vi.fn(async (installerPath: string) => {
+      stagedPath = installerPath;
+      stagedBytes = await readFile(installerPath);
+      await writeFile(join(directory, `Enduragent-${version}-x64.exe`), "TAMPERED");
+    });
     const result = await verifyWindowsReleaseAssets(directory, {
       version,
       commit,
       expectedPublisherName: "CN=Enduragent Test",
       authenticode: { verify },
     });
-    expect(verify).toHaveBeenCalledWith(join(directory, `Enduragent-${version}-x64.exe`), {
+    expect(verify).toHaveBeenCalledWith(expect.any(String), {
       version,
       commit,
       publisherName: "CN=Enduragent Test",
     });
+    expect(stagedPath.startsWith(directory)).toBe(false);
+    expect(stagedPath.endsWith(`Enduragent-${version}-x64.exe`)).toBe(true);
+    expect(stagedBytes).toEqual(installer);
+    await expect(readFile(stagedPath)).rejects.toThrow();
     expect(result.authenticode).toBe("verified");
+    expect(result.bytes.installer).toEqual(installer);
+    await writeFile(join(directory, `Enduragent-${version}-x64.exe`), installer);
     await expect(
       verifyWindowsReleaseAssets(directory, {
         version,

--- a/apps/desktop/tests/windows-release-plan.test.ts
+++ b/apps/desktop/tests/windows-release-plan.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
@@ -101,6 +102,18 @@ describe("Windows release plan", () => {
     expect(() =>
       parseWindowsReleaseUpdaterMetadata(stringify({ ...base, unexpected: true })),
     ).toThrow("release updater metadata is invalid");
+    expect(
+      parseWindowsReleaseUpdaterMetadata(
+        stringify({ ...base, publisherName: [WINDOWS_PUBLISHER_DN_PLACEHOLDER] }),
+        { expectedPublisherName: WINDOWS_PUBLISHER_DN_PLACEHOLDER },
+      ).publisherName,
+    ).toBe(WINDOWS_PUBLISHER_DN_PLACEHOLDER);
+    expect(() =>
+      parseWindowsReleaseUpdaterMetadata(stringify({ ...base, publisherName: ["a", "b"] })),
+    ).toThrow("release updater metadata is invalid");
+    expect(() =>
+      parseWindowsReleaseUpdaterMetadata(stringify({ ...base, publisherName: [] })),
+    ).toThrow("release updater metadata is invalid");
   });
 
   it("creates the signed NSIS builder contract with differential packaging", () => {
@@ -126,7 +139,7 @@ describe("Windows release plan", () => {
       signtoolOptions: { publisherName: [WINDOWS_PUBLISHER_DN_PLACEHOLDER] },
       signExecutable: true,
       verifyUpdateCodeSignature: true,
-      legalTrademarks: `enduragent-release-commit:${commit}`,
+      legalTrademarks: `enduragent-release-commit:${commit} enduragent-updater-publisher-sha256:${createHash("sha256").update(WINDOWS_PUBLISHER_DN_PLACEHOLDER).digest("hex")}`,
       target: [{ target: "nsis", arch: ["x64"] }],
     });
     expect(plan.updaterMetadata.publisherName).toBe(WINDOWS_PUBLISHER_DN_PLACEHOLDER);


### PR DESCRIPTION
Addresses the three findings from the umbrella #757 re-review at e9d505a3 (1×P1, 2×P2).

1. **P1 — upload the exact verified bytes.** `verifyWindowsReleaseAssets` now returns the Buffers it hashed (`bytes`) and runs Authenticode against an owner-only, read-only staged copy of those bytes (never the mutable artifact path). The uploader stages the verified bytes into its own 0o700 temp dir as 0o400 files, hashes the record from those bytes, uploads only the staged paths, and after upload reconciles every GitHub asset `digest` (`sha256:<hex>`) and size against the staged bytes (`Windows release asset digest mismatch`, recorded with `uploaded: true`). Staging is removed in `finally`.
2. **P2 — packaged updater publisher.** Two bindings: (a) the plan seals `enduragent-release-commit:<sha> enduragent-updater-publisher-sha256:<sha256(publisherDn)>` into the installer's `LegalTrademarks`; `decideWindowsAuthenticode` requires both the commit and the publisher digest of `--publisher-dn`. (b) the uploader requires `--app-update-metadata <abs path to win-unpacked/resources/app-update.yml>` and rejects it unless `publisherName` equals `--publisher-dn`. Found while verifying: electron-builder 26.15.3 emits `publisherName` as a one-element YAML list (`windowsSignToolManager.js:25` `asArray`), which `parseWindowsReleaseUpdaterMetadata` rejected — it now accepts a string or a single-element list.
3. **P2 — non-latest release.** Uploader and workflow both require `repos/<repo>/releases/latest` to be `enduragent-desktop@<version>` before any mutation (`release is not the latest release`). CONTRIBUTING no longer allows Windows to lag freely: append only while the release is latest, otherwise skip to the next version. Note: any newer GitHub release in the repo (including an npm `cycling-coach@…` release) makes the desktop release non-latest.

No new numeric limits. Verified: focused vitest (upload, release-artifacts, authenticode, round-trip, release-plan, package-contract) → 131 pass / 1 skip; desktop `tsc --noEmit` clean; oxlint clean on changed files; `git diff --check` clean; independent read-only review found two structural gaps in the first cut (Authenticode on the mutable path; list-shaped `publisherName`) — both fixed in this commit and pinned by tests. The `.ps1` is unchanged in this PR.
