### PR TITLE
fix(desktop): bound Windows release mutations against latest promotion and body edits

### DIFF
--- a/.changeset/windows-release-mutation-boundary.md
+++ b/.changeset/windows-release-mutation-boundary.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+Roll back Windows release assets when the release stops being latest during the upload and record workflow verification as a release asset instead of editing the release body.

--- a/.github/workflows/desktop-windows-release.yml
+++ b/.github/workflows/desktop-windows-release.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Refuse to mark assets while Authenticode is pending
         if: ${{ inputs.dry_run == false && inputs.authenticode != 'verify' }}
         run: |
-          echo '::error::Authenticode verification is not enabled; refusing to mark assets'
+          echo '::error::Authenticode verification is not enabled; refusing to record verification evidence'
           exit 1
       - name: Download Windows assets
         env:
@@ -169,7 +169,8 @@ jobs:
             --arg publisherDnSha256 "$PUBLISHER_SHA256" \
             '{schemaVersion: 1, tag: $tag, version: $version, commit: $commit, arch: "x64", authenticode: "verified", installerSha256: $installerSha256, publisherDnSha256: $publisherDnSha256}' \
             > "$TEMP/$EVIDENCE"
-          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" | jq -e --arg name "$EVIDENCE" '.assets[] | select(.name == $name)' >/dev/null; then
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" > "$TEMP/release.json"
+          if [ "$(jq -r --arg name "$EVIDENCE" '[.assets[] | select(.name == $name)] | length' "$TEMP/release.json")" != '0' ]; then
             gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir "$TEMP/existing" --pattern "$EVIDENCE"
             if cmp -s "$TEMP/$EVIDENCE" "$TEMP/existing/$EVIDENCE"; then
               echo "::notice::Windows verification evidence already recorded"
@@ -185,4 +186,4 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          echo "::notice::dry_run=true; release enduragent-desktop@$VERSION was verified but not marked"
+          echo "::notice::dry_run=true; release enduragent-desktop@$VERSION was verified; no evidence asset was recorded"

--- a/.github/workflows/desktop-windows-release.yml
+++ b/.github/workflows/desktop-windows-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       dry_run:
-        description: Verify only; never edit the release
+        description: Verify only; never add the evidence asset
         type: boolean
         default: true
       authenticode:
@@ -146,25 +146,39 @@ jobs:
           INSTALLER_SHA256=$(awk '/^Windows release envelope verified [0-9a-f]{64}$/{sha=$NF} END{if (sha == "") exit 1; print sha}' "$WORK/../verify.out")
           echo "installer_sha256=$INSTALLER_SHA256" >> "$GITHUB_OUTPUT"
           echo "authenticode=$AUTHENTICODE" >> "$GITHUB_OUTPUT"
-      - name: Mark Windows assets verified
+      - name: Record Windows verification evidence
         if: ${{ inputs.dry_run == false && inputs.authenticode == 'verify' && steps.verify.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_ID: ${{ steps.release.outputs.release_id }}
+          VERSION: ${{ inputs.version }}
+          COMMIT: ${{ steps.release.outputs.commit }}
+          PUBLISHER_DN: ${{ inputs.publisher_dn }}
           INSTALLER_SHA256: ${{ steps.verify.outputs.installer_sha256 }}
         run: |
           set -euo pipefail
-          TEMP="$(cygpath -u "$RUNNER_TEMP")"
-          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > "$TEMP/release.json"
-          jq -j '.body // ""' "$TEMP/release.json" > "$TEMP/release-body.txt"
-          MARKER="Windows assets verified: $INSTALLER_SHA256 (Authenticode verified)"
-          if grep -Fxq "$MARKER" "$TEMP/release-body.txt"; then
-            exit 0
+          TEMP="$(cygpath -u "$RUNNER_TEMP")/windows-evidence"
+          mkdir -p "$TEMP"
+          TAG="enduragent-desktop@$VERSION"
+          EVIDENCE="Enduragent-$VERSION-x64-verification.json"
+          PUBLISHER_SHA256=$(printf '%s' "$PUBLISHER_DN" | sha256sum | awk '{print $1}')
+          jq -nS \
+            --arg tag "$TAG" \
+            --arg version "$VERSION" \
+            --arg commit "$COMMIT" \
+            --arg installerSha256 "$INSTALLER_SHA256" \
+            --arg publisherDnSha256 "$PUBLISHER_SHA256" \
+            '{schemaVersion: 1, tag: $tag, version: $version, commit: $commit, arch: "x64", authenticode: "verified", installerSha256: $installerSha256, publisherDnSha256: $publisherDnSha256}' \
+            > "$TEMP/$EVIDENCE"
+          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" | jq -e --arg name "$EVIDENCE" '.assets[] | select(.name == $name)' >/dev/null; then
+            gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir "$TEMP/existing" --pattern "$EVIDENCE"
+            if cmp -s "$TEMP/$EVIDENCE" "$TEMP/existing/$EVIDENCE"; then
+              echo "::notice::Windows verification evidence already recorded"
+              exit 0
+            fi
+            echo '::error::Existing Windows verification evidence conflicts with this run; remove it by hand before retrying'
+            exit 1
           fi
-          printf '\n\n%s' "$MARKER" >> "$TEMP/release-body.txt"
-          jq -n --rawfile body "$TEMP/release-body.txt" '{body: $body}' > "$TEMP/release-patch.json"
-          gh api -X PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
-            --input "$TEMP/release-patch.json" >/dev/null
+          gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" "$TEMP/$EVIDENCE"
       - name: Dry run summary
         if: ${{ inputs.dry_run == true }}
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is t
 - Upload owner-only, read-only copies of the verified bytes through `gh-personal release upload`. The original artifact paths are never uploaded.
 - Re-read the release after upload and fail unless all three assets are present and each GitHub asset `digest` and size equals the uploaded bytes.
 - Re-check `releases/latest` after the digest reconciliation. When the release stopped being latest during the upload, the uploader deletes its three assets and fails with `release lost latest status during upload; Windows assets removed`. Re-run the whole Windows release for the newer version.
-- Treat a failed record with `uploaded: true` after that rollback as an incomplete upload. Remove the listed assets by hand.
+- Treat a failed record with `uploaded: true` or `uploaded: "unknown"` after that rollback as an incomplete upload. Remove the listed assets by hand; with `uploadedAssets: null`, inspect the release by hand.
 - Read `uploadedAssets` in a failed record before retrying. A partial upload lists the assets that became public.
 - Trigger the separate verification workflow from the repository root:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,8 @@ Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is t
 - Refuse the upload when any Windows envelope asset already exists on the release.
 - Upload owner-only, read-only copies of the verified bytes through `gh-personal release upload`. The original artifact paths are never uploaded.
 - Re-read the release after upload and fail unless all three assets are present and each GitHub asset `digest` and size equals the uploaded bytes.
+- Re-check `releases/latest` after the digest reconciliation. When the release stopped being latest during the upload, the uploader deletes its three assets and fails with `release lost latest status during upload; Windows assets removed`. Re-run the whole Windows release for the newer version.
+- Treat a failed record with `uploaded: true` after that rollback as an incomplete upload. Remove the listed assets by hand.
 - Read `uploadedAssets` in a failed record before retrying. A partial upload lists the assets that became public.
 - Trigger the separate verification workflow from the repository root:
 
@@ -205,15 +207,16 @@ Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is t
   ```
 
 - Leave `dry_run` at its `true` default to verify without editing the release.
-- Pass `dry_run=false` only when the release body must record the completed verification. The workflow refuses `dry_run=false` without `authenticode=verify` and a real `publisher_dn`.
+- Pass `dry_run=false` only when the completed verification must be recorded on the release. The workflow refuses `dry_run=false` without `authenticode=verify` and a real `publisher_dn`.
 - Keep `desktop-windows-release.yml` to its single `verify-windows-envelope` job on `windows-latest`. `Get-AuthenticodeSignature` and `signtool.exe` exist only on Windows.
 - Reject a non-stable SemVer or a missing, draft, prerelease, or non-latest `enduragent-desktop@<version>` release in `verify-windows-envelope`.
 - Require exactly `Enduragent-<version>-x64.exe`, `Enduragent-<version>-x64.exe.blockmap`, and `latest.yml` as the Windows envelope among the release assets.
 - Download only those three Windows assets in `verify-windows-envelope`.
 - Resolve the release tag to its commit and pass it as `--commit`.
 - Run `node apps/desktop/scripts/verify-windows-release.mjs <dir> --version <version> --commit <sha> --authenticode verify --publisher-dn <dn>` against the downloaded envelope.
-- Append `Windows assets verified: <installer sha256> (Authenticode verified)` to the release body only when `dry_run=false`.
-- Never create, move, or delete a release, tag, or asset in `desktop-windows-release.yml`.
+- Record the verification only when `dry_run=false`, as the release asset `Enduragent-<version>-x64-verification.json` (`schemaVersion`, `tag`, `version`, `commit`, `arch`, `authenticode`, `installerSha256`, `publisherDnSha256`). Never edit the release body: a body `PATCH` overwrites concurrent release-note edits.
+- Skip the upload when an identical evidence asset exists. Fail when an evidence asset with different bytes exists; remove it by hand before retrying.
+- Never create, move, or delete a release or tag in `desktop-windows-release.yml`. Never delete or replace an asset there. The evidence asset is the only asset the workflow creates.
 - Leave uploaded assets in place when verification fails.
 - Remove failed Windows assets by hand before retrying.
 - Build provenance: `windows-release-plan.mjs` seals `enduragent-release-commit:<sha> enduragent-updater-publisher-sha256:<sha256 of publisher DN>` into the installer's `LegalTrademarks` version string. Verification reads it from the signed installer and compares it with `--commit` and `--publisher-dn`.

--- a/apps/desktop/CONTEXT.md
+++ b/apps/desktop/CONTEXT.md
@@ -117,7 +117,8 @@ _Avoid_: Install directory, application directory
 - A **Windows release envelope** is produced, verified, uploaded, and round-trip-checked by its named scripts.
 - **Authenticode pending mode** does not authorise an unsigned installer for a GitHub release or the website.
 - **Windows release provenance** binds a verified installer to the release tag commit and the updater publisher before upload.
-- `upload-windows-release.mjs` uploads read-only copies of the verified bytes, only to the latest release, and reconciles GitHub asset digests against those bytes.
+- `upload-windows-release.mjs` uploads read-only copies of the verified bytes, only to the latest release, reconciles GitHub asset digests against those bytes, and removes its assets when the release stops being latest during the upload.
+- `desktop-windows-release.yml` records a completed verification as the `Enduragent-<version>-x64-verification.json` release asset and never edits the release body.
 - The **Windows package inventory** fixes the application, resource, and asar contents accepted by package verification.
 - The athlete removes the **Windows user data directory** by hand when retained data must be erased after uninstall.
 

--- a/apps/desktop/scripts/upload-windows-release.mjs
+++ b/apps/desktop/scripts/upload-windows-release.mjs
@@ -37,6 +37,7 @@ const safeWindowsReleaseUploadMessages = new Set([
   "app-update.yml path must be absolute",
   "app-update.yml is unreadable",
   "release is not the latest release",
+  "release lost latest status during upload; Windows assets removed",
   "Windows release asset digest mismatch",
   "upload record already exists",
   "upload record directory is missing",
@@ -98,15 +99,46 @@ function parseLatestRelease(stdout) {
   return release.tag_name;
 }
 
-async function requireLatestRelease(executeFile, repository, tag) {
+async function isLatestRelease(executeFile, repository, tag) {
   let result;
   try {
     result = await executeFile("gh-personal", ["api", `repos/${repository}/releases/latest`]);
   } catch {
+    return "unknown";
+  }
+  try {
+    return parseLatestRelease(result.stdout) === tag;
+  } catch {
+    return "unknown";
+  }
+}
+
+async function requireLatestRelease(executeFile, repository, tag) {
+  if ((await isLatestRelease(executeFile, repository, tag)) !== true) {
     throw new TypeError("release is not the latest release");
   }
-  if (parseLatestRelease(result.stdout) !== tag) {
-    throw new TypeError("release is not the latest release");
+}
+
+function requireAssetId(value) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError("Windows release upload is incomplete");
+  }
+  return value;
+}
+
+async function deleteReleaseAssets(executeFile, repository, assets, files) {
+  for (const file of files) {
+    const id = requireAssetId(assets.get(file.name)?.id);
+    try {
+      await executeFile("gh-personal", [
+        "api",
+        "-X",
+        "DELETE",
+        `repos/${repository}/releases/assets/${id}`,
+      ]);
+    } catch {
+      throw new TypeError("Windows release upload is incomplete");
+    }
   }
 }
 
@@ -152,6 +184,7 @@ async function reconcileAssetDigests(executeFile, repository, tag, files) {
       throw new TypeError("Windows release asset digest mismatch");
     }
   }
+  return assets;
 }
 
 function requireRepository(value) {
@@ -399,7 +432,18 @@ export async function runWindowsReleaseUpload(input, dependencies = {}) {
     if (uploadedAssets === null || uploadedAssets.length !== expectedNames.length) {
       throw new TypeError("Windows release upload is incomplete");
     }
-    await reconcileAssetDigests(executeFile, repository, tag, files);
+    const assets = await reconcileAssetDigests(executeFile, repository, tag, files);
+    const stillLatest = await isLatestRelease(executeFile, repository, tag);
+    if (stillLatest === "unknown") throw new TypeError("Windows release upload is incomplete");
+    if (stillLatest === false) {
+      try {
+        await deleteReleaseAssets(executeFile, repository, assets, files);
+      } finally {
+        await reconcile();
+      }
+      if (uploaded !== false) throw new TypeError("Windows release upload is incomplete");
+      throw new TypeError("release lost latest status during upload; Windows assets removed");
+    }
     const record = Object.freeze({
       schemaVersion: 1,
       tag,

--- a/apps/desktop/tests/upload-windows-release.test.ts
+++ b/apps/desktop/tests/upload-windows-release.test.ts
@@ -288,6 +288,19 @@ describe("Windows release upload", () => {
     expect(written.uploadedAssets).toEqual([verified.names.blockmap, verified.names.metadata]);
   });
 
+  it("refuses to delete when a GitHub asset has no numeric id", async () => {
+    const withoutIds = JSON.parse(releaseAssetsApi()) as { assets: { id?: number }[] };
+    for (const asset of withoutIds.assets) delete asset.id;
+    const executeFile = successfulExecutor({
+      latestTagAfterUpload: "enduragent-desktop@0.1.7",
+      assetsApi: JSON.stringify(withoutIds),
+    });
+    await expect(
+      runWindowsReleaseUpload(input(), { executeFile, verifyAssets: vi.fn(async () => verified) }),
+    ).rejects.toThrow("Windows release upload is incomplete");
+    expect(executeFile.mock.calls.flat(2)).not.toContain("DELETE");
+  });
+
   it("reports an incomplete upload when the post-upload latest check is unavailable", async () => {
     const base = successfulExecutor();
     let uploads = 0;

--- a/apps/desktop/tests/upload-windows-release.test.ts
+++ b/apps/desktop/tests/upload-windows-release.test.ts
@@ -92,9 +92,9 @@ function releaseAssetsApi(names: readonly string[] = Object.values(verified.name
   );
   return JSON.stringify({
     tag_name: tag,
-    assets: names.map((name) => {
+    assets: names.map((name, index) => {
       const bytes = byName.get(name) ?? Buffer.from("other");
-      return { name, size: bytes.length, digest: digestOf(bytes) };
+      return { id: 1000 + index, name, size: bytes.length, digest: digestOf(bytes) };
     }),
   });
 }
@@ -116,27 +116,45 @@ function successfulExecutor(
     readonly reference?: { readonly type: "commit" | "tag"; readonly sha: string };
     readonly peeled?: { readonly type: "commit" | "tag"; readonly sha: string };
     readonly latestTag?: string;
+    readonly latestTagAfterUpload?: string;
     readonly assetsApi?: string;
     readonly onUpload?: (paths: readonly string[]) => Promise<void> | void;
+    readonly onDelete?: (id: string) => Promise<void> | void;
   } = {},
 ) {
   let views = 0;
+  let uploads = 0;
+  const deleted: string[] = [];
   return vi.fn(async (_executable: string, arguments_: readonly string[]) => {
     if (arguments_[0] === "release" && arguments_[1] === "view") {
       views += 1;
+      const uploadedNames = Object.values(verified.names).filter(
+        (_name, index) => !deleted.includes(String(1000 + index)),
+      );
       return {
         stdout:
           views === 1
             ? release(options.initialAssets ?? [`Enduragent-${version}-arm64.dmg`])
-            : release(Object.values(verified.names)),
+            : release(uploadedNames),
       };
     }
     if (arguments_[0] === "release" && arguments_[1] === "upload") {
+      uploads += 1;
       await options.onUpload?.(arguments_.slice(5));
       return { stdout: "" };
     }
+    if (arguments_[0] === "api" && arguments_[1] === "-X" && arguments_[2] === "DELETE") {
+      const id = arguments_[3]?.split("/").at(-1) ?? "";
+      await options.onDelete?.(id);
+      deleted.push(id);
+      return { stdout: "" };
+    }
     if (arguments_[0] === "api" && arguments_[1]?.endsWith("/releases/latest")) {
-      return { stdout: JSON.stringify({ tag_name: options.latestTag ?? tag }) };
+      const latestTag =
+        uploads > 0
+          ? (options.latestTagAfterUpload ?? options.latestTag ?? tag)
+          : (options.latestTag ?? tag);
+      return { stdout: JSON.stringify({ tag_name: latestTag }) };
     }
     if (arguments_[0] === "api" && arguments_[1]?.includes("/releases/tags/")) {
       return { stdout: options.assetsApi ?? releaseAssetsApi() };
@@ -220,8 +238,68 @@ describe("Windows release upload", () => {
       "gh-personal",
       ["api", `repos/${repository}/releases/tags/${tag}`],
     ]);
+    expect(executeFile.mock.calls[6]).toEqual([
+      "gh-personal",
+      ["api", `repos/${repository}/releases/latest`],
+    ]);
+    expect(executeFile.mock.calls).toHaveLength(7);
     expect(executeFile.mock.calls.flat(2)).not.toContain("--clobber");
     expect(executeFile.mock.calls.flat(2)).not.toContain(verified.paths.installer);
+  });
+
+  it("removes the uploaded assets when the release stops being latest during the upload", async () => {
+    const record = join(directory, "..", `upload-record-rollback-${process.pid}.json`);
+    temporaryRoots.push(record);
+    const verifyAssets = vi.fn(async () => verified);
+    const executeFile = successfulExecutor({ latestTagAfterUpload: "enduragent-desktop@0.1.7" });
+    await expect(
+      runWindowsReleaseUpload(input({ record }), { executeFile, verifyAssets }),
+    ).rejects.toThrow("release lost latest status during upload; Windows assets removed");
+    const deletes = executeFile.mock.calls
+      .filter(([, arguments_]) => arguments_[1] === "-X" && arguments_[2] === "DELETE")
+      .map(([, arguments_]) => arguments_[3]);
+    expect(deletes).toEqual([
+      `repos/${repository}/releases/assets/1000`,
+      `repos/${repository}/releases/assets/1001`,
+      `repos/${repository}/releases/assets/1002`,
+    ]);
+    const written = JSON.parse(await readFile(record, "utf8"));
+    expect(written.status).toBe("failed");
+    expect(written.uploaded).toBe(false);
+    expect(written.uploadedAssets).toEqual([]);
+    expect(written.error).toBe("release lost latest status during upload; Windows assets removed");
+  });
+
+  it("reports an incomplete upload when the rollback of a non-latest release fails", async () => {
+    const record = join(directory, "..", `upload-record-rollback-fail-${process.pid}.json`);
+    temporaryRoots.push(record);
+    const verifyAssets = vi.fn(async () => verified);
+    const executeFile = successfulExecutor({
+      latestTagAfterUpload: "enduragent-desktop@0.1.7",
+      onDelete: (id) => {
+        if (id === "1001") throw new Error("boom");
+      },
+    });
+    await expect(
+      runWindowsReleaseUpload(input({ record }), { executeFile, verifyAssets }),
+    ).rejects.toThrow("Windows release upload is incomplete");
+    const written = JSON.parse(await readFile(record, "utf8"));
+    expect(written.uploaded).toBe(true);
+    expect(written.uploadedAssets).toEqual([verified.names.blockmap, verified.names.metadata]);
+  });
+
+  it("reports an incomplete upload when the post-upload latest check is unavailable", async () => {
+    const base = successfulExecutor();
+    let uploads = 0;
+    const executeFile = vi.fn(async (executable: string, arguments_: readonly string[]) => {
+      if (arguments_[0] === "release" && arguments_[1] === "upload") uploads += 1;
+      if (uploads > 0 && arguments_[1]?.endsWith("/releases/latest")) throw new Error("offline");
+      return base(executable, arguments_);
+    });
+    await expect(
+      runWindowsReleaseUpload(input(), { executeFile, verifyAssets: vi.fn(async () => verified) }),
+    ).rejects.toThrow("Windows release upload is incomplete");
+    expect(executeFile.mock.calls.flat(2)).not.toContain("DELETE");
   });
 
   it("uploads the verified bytes even when the artifact file changes after verification", async () => {


### PR DESCRIPTION
Fixes the two P2 findings from the umbrella #757 re-review.

**[P2] Latest-release check races asset upload** — `upload-windows-release.mjs` now re-checks `repos/{repo}/releases/latest` after the post-upload digest reconciliation. If the release lost latest status during the upload, the uploader deletes its three assets (`DELETE repos/{repo}/releases/assets/{id}`, ids taken from the reconciled asset list), re-reads the release, and fails with `release lost latest status during upload; Windows assets removed` (record: `status: failed`, `uploaded: false`, `uploadedAssets: []`). If any delete fails, or the post-upload latest check is unreachable, it fails with `Windows release upload is incomplete` and the record lists the assets that remain public. Windows assets therefore never persist on a non-latest release.

**[P2] Verification marker can overwrite release-note edits** — `desktop-windows-release.yml` no longer reads/patches the release body. With `dry_run=false` it uploads a deterministic evidence asset `Enduragent-<version>-x64-verification.json` (`schemaVersion, tag, version, commit, arch, authenticode, installerSha256, publisherDnSha256`). An identical existing asset is a no-op; a differing one fails the run. No `--clobber`, no body writes, so concurrent release-note edits are never lost.

Docs: CONTRIBUTING Windows release section + `apps/desktop/CONTEXT.md` invariants updated.

Limits: none added.

Verified: `vitest run` on `upload-windows-release` (26), `windows-release-artifacts`, `windows-release-plan`, `windows-parity-scenarios` (30) — all pass; `tsc --noEmit` clean; oxlint clean; workflow YAML parses; `check:changeset-userfacing` clean. The workflow step itself was not executed (needs a live release).