### PR TITLE
feat(plan): add estimated critical power

### DIFF
--- a/.changeset/plan-estimated-cp.md
+++ b/.changeset/plan-estimated-cp.md
@@ -1,0 +1,11 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/sync-intervals-icu": patch
+"@enduragent/sport-cycling": patch
+"@enduragent/coach-contract": patch
+"@enduragent/engine": patch
+"@enduragent/coach": patch
+"@enduragent/desktop-renderer": patch
+---
+
+Add display-only Estimated CP from two eligible recent measured-power efforts, including stale and unavailable states, an explanatory tooltip, evidence and route-assumption drawers, and strict isolation from FTP and Plan mutations.

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -5,6 +5,7 @@ import {
   ChevronLeft,
   ChevronRight,
   History,
+  Info,
   LoaderCircle,
   MapPinned,
   RefreshCw,
@@ -2350,6 +2351,12 @@ function formRange(readiness: PlanReadinessProjection): string {
   return `${signed(range.min)} to ${signed(range.max)}`;
 }
 
+function effortDuration(durationS: number): string {
+  const minutes = Math.floor(durationS / 60);
+  const seconds = durationS % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
 function ReadinessProjection(props: {
   readonly data: ReturnType<typeof PlanActiveProjectionDataSchema.parse>;
   readonly scenarioId: string;
@@ -2357,6 +2364,10 @@ function ReadinessProjection(props: {
   const actions = useEnduragentStore((state) => state.planActions);
   const transition = useEnduragentStore((state) => state.plan.transition);
   const readiness = props.data.readiness;
+  const [overlay, setOverlay] = useState<"cp-info" | "cp-efforts" | "route" | null>(null);
+  const cpInfoTrigger = useRef<HTMLButtonElement>(null);
+  const cpEffortsTrigger = useRef<HTMLButtonElement>(null);
+  const routeTrigger = useRef<HTMLButtonElement>(null);
   if (readiness === undefined) {
     return <StatusCard title="Race readiness" support="Readiness details are unavailable." />;
   }
@@ -2371,6 +2382,17 @@ function ReadinessProjection(props: {
           dateStyle: "medium",
           timeStyle: "short",
         }).format(new Date(readiness.form.lastSuccessfulRefreshAtMs));
+  const cp = readiness.estimatedCp;
+  const closeOverlay = (next: boolean): void => {
+    if (next) return;
+    const previous = overlay;
+    setOverlay(null);
+    requestAnimationFrame(() => {
+      if (previous === "cp-info") cpInfoTrigger.current?.focus();
+      if (previous === "cp-efforts") cpEffortsTrigger.current?.focus();
+      if (previous === "route") routeTrigger.current?.focus();
+    });
+  };
   const header = (
     <div className="flex flex-col gap-row sm:flex-row sm:items-start sm:justify-between">
       <div className={SUPPORT_PAIR}>
@@ -2471,36 +2493,69 @@ function ReadinessProjection(props: {
   }
   if (props.scenarioId === "PL-S077") {
     return (
-      <section className="grid gap-6 rounded-card bg-surface p-5 shadow-elev-1">
-        {header}
-        <div className="flex items-start gap-row border-t border-line pt-row">
-          <TriangleAlert className="mt-0.5 size-5 shrink-0 text-warn" aria-hidden="true" />
-          <div className={SUPPORT_PAIR}>
-            <h3 className="m-0 text-base font-semibold">Finish-time range changed</h3>
-            <p className="m-0 text-ink-2">
-              {readiness.courseEstimate.changedAssumption ?? "A route assumption changed."}
-            </p>
+      <>
+        <section className="grid gap-6 rounded-card bg-surface p-5 shadow-elev-1">
+          {header}
+          <div className="flex items-start gap-row border-t border-line pt-row">
+            <TriangleAlert className="mt-0.5 size-5 shrink-0 text-warn" aria-hidden="true" />
+            <div className={SUPPORT_PAIR}>
+              <h3 className="m-0 text-base font-semibold">Finish-time range changed</h3>
+              <p className="m-0 text-ink-2">
+                {readiness.courseEstimate.changedAssumption ?? "A route assumption changed."}
+              </p>
+            </div>
           </div>
-        </div>
-        <div className="grid gap-inset rounded-card bg-sunk p-row sm:grid-cols-2">
-          <div className={SUPPORT_PAIR}>
-            <span className="text-sm text-ink-2">Previous</span>
-            <strong className="text-xl">
-              {readiness.courseEstimate.previousRangeMinutes === null
-                ? "Unavailable"
-                : finishRange(readiness.courseEstimate.previousRangeMinutes)}
-            </strong>
+          <div className="grid gap-inset rounded-card bg-sunk p-row sm:grid-cols-2">
+            <div className={SUPPORT_PAIR}>
+              <span className="text-sm text-ink-2">Previous</span>
+              <strong className="text-xl">
+                {readiness.courseEstimate.previousRangeMinutes === null
+                  ? "Unavailable"
+                  : finishRange(readiness.courseEstimate.previousRangeMinutes)}
+              </strong>
+            </div>
+            <div className={SUPPORT_PAIR}>
+              <span className="text-sm text-ink-2">Updated</span>
+              <strong className="text-xl">
+                {readiness.courseEstimate.rangeMinutes === null
+                  ? "Unavailable"
+                  : finishRange(readiness.courseEstimate.rangeMinutes)}
+              </strong>
+            </div>
           </div>
-          <div className={SUPPORT_PAIR}>
-            <span className="text-sm text-ink-2">Updated</span>
-            <strong className="text-xl">
-              {readiness.courseEstimate.rangeMinutes === null
-                ? "Unavailable"
-                : finishRange(readiness.courseEstimate.rangeMinutes)}
-            </strong>
+          <div className="flex justify-end">
+            <Button
+              ref={routeTrigger}
+              type="button"
+              variant="link"
+              className="h-auto p-0"
+              onClick={() => setOverlay("route")}
+            >
+              View assumptions →
+            </Button>
           </div>
-        </div>
-      </section>
+        </section>
+        <Dialog open={overlay === "route"} onOpenChange={closeOverlay}>
+          <DialogContent className="top-0 right-0 left-auto flex h-full max-h-none w-[min(440px,calc(100%-32px))] max-w-none translate-x-0 translate-y-0 flex-col overflow-hidden rounded-none rounded-l-card border-y-0 border-r-0 p-0">
+            <DialogHeader className="grid gap-2 border-b border-line px-5 py-5 pr-16">
+              <DialogTitle>Route assumptions</DialogTitle>
+              <DialogDescription>
+                Inputs used for the course-based finish-time range.
+              </DialogDescription>
+            </DialogHeader>
+            <ul className="m-0 grid flex-1 content-start gap-row overflow-auto px-10 py-5 text-ink-2">
+              {readiness.courseEstimate.assumptions.map((assumption) => (
+                <li key={assumption}>{assumption}</li>
+              ))}
+            </ul>
+            <DialogFooter className="m-0 flex-row justify-end border-t border-line bg-surface px-5 py-row">
+              <Button type="button" onClick={() => closeOverlay(false)}>
+                Done
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </>
     );
   }
   if (props.scenarioId === "PL-S074") {
@@ -2559,51 +2614,194 @@ function ReadinessProjection(props: {
     );
   }
   return (
-    <section className="grid gap-6 rounded-card bg-surface p-5 shadow-elev-1">
-      {header}
-      <div className="grid gap-row border-t border-line pt-row md:grid-cols-3">
-        <div className={SUPPORT_PAIR}>
-          <h3 className="m-0 text-sm font-semibold">Form trajectory to race day</h3>
-          <strong className="text-2xl">
-            {readiness.form.current === null ? "Unavailable" : signed(readiness.form.current)} →{" "}
-            {formRange(readiness)}
-          </strong>
-          <p className="m-0 text-sm text-ink-2">Modeled from planned Load and normal recovery.</p>
-        </div>
-        <div className={SUPPORT_PAIR}>
-          <h3 className="m-0 text-sm font-semibold">Goal feasibility</h3>
-          <span className="self-start rounded-full border border-ok px-3 py-1 text-sm text-ok">
-            On track · with assumptions
-          </span>
-          <p className="m-0 text-sm text-ink-2">{readiness.feasibility.recommendation}</p>
-        </div>
-        <div className={SUPPORT_PAIR}>
-          <h3 className="m-0 text-sm font-semibold">Course-based finish time</h3>
-          <strong className="text-2xl">
-            {readiness.courseEstimate.rangeMinutes === null
-              ? "Unavailable"
-              : finishRange(readiness.courseEstimate.rangeMinutes)}
-          </strong>
-          <p className="m-0 text-sm text-ink-2">
-            {readiness.courseEstimate.confidence === null
-              ? "No estimate"
-              : `${readiness.courseEstimate.confidence} confidence`}
-          </p>
-        </div>
-      </div>
-      <div className="grid gap-row rounded-card bg-sunk p-row sm:grid-cols-3">
-        {[
-          ["Prescribed", readiness.evidence.prescribedDurationS],
-          ["Ridden", readiness.evidence.riddenDurationS],
-          ["Adjusted", readiness.evidence.adjustedDurationS],
-        ].map(([label, value]) => (
-          <div key={String(label)} className={SUPPORT_PAIR}>
-            <span className="text-sm text-ink-2">{label}</span>
-            <strong className="text-xl tabular-nums">{clockTime(Number(value))}</strong>
+    <>
+      <section className="grid gap-6 rounded-card bg-surface p-5 shadow-elev-1">
+        {header}
+        <div className="grid gap-row border-t border-line pt-row md:grid-cols-2">
+          <div className={SUPPORT_PAIR}>
+            <h3 className="m-0 text-sm font-semibold">Form trajectory to race day</h3>
+            <strong className="text-2xl">
+              {readiness.form.current === null ? "Unavailable" : signed(readiness.form.current)} →{" "}
+              {formRange(readiness)}
+            </strong>
+            <p className="m-0 text-sm text-ink-2">Modeled from planned Load and normal recovery.</p>
           </div>
-        ))}
-      </div>
-    </section>
+          <div className={SUPPORT_PAIR}>
+            <h3 className="m-0 text-sm font-semibold">Goal feasibility</h3>
+            <span className="self-start rounded-full border border-ok px-3 py-1 text-sm text-ok">
+              On track · with assumptions
+            </span>
+            <p className="m-0 text-sm text-ink-2">{readiness.feasibility.recommendation}</p>
+          </div>
+          <div className={SUPPORT_PAIR}>
+            <div className="flex items-center justify-between gap-inset">
+              <h3 className="m-0 text-sm font-semibold">Estimated CP</h3>
+              <div className="flex items-center gap-inset">
+                <span className="rounded-full border border-warn px-2 py-0.5 text-xs text-warn">
+                  Experimental
+                </span>
+                <Button
+                  ref={cpInfoTrigger}
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="About Estimated CP"
+                  onClick={() => setOverlay("cp-info")}
+                >
+                  <Info aria-hidden="true" />
+                </Button>
+              </div>
+            </div>
+            {cp.status === "unavailable" ? (
+              <>
+                <strong className="text-xl">
+                  {cp.unavailableReason === "mathematically-invalid"
+                    ? "Estimated CP is unavailable from the current data."
+                    : "Not enough measured power yet."}
+                </strong>
+                {cp.unavailableReason === "missing-effort" ? (
+                  <p className="m-0 text-sm text-ink-2">
+                    A short and a long recorded effort are needed from the last 6 weeks.
+                  </p>
+                ) : null}
+              </>
+            ) : (
+              <>
+                <div className="flex items-center gap-inset">
+                  <strong className="text-2xl">{cp.watts} W</strong>
+                  {cp.status === "stale" ? (
+                    <span className="rounded-full border border-warn px-2 py-0.5 text-xs text-warn">
+                      Stale
+                    </span>
+                  ) : null}
+                </div>
+                <p className="m-0 text-sm text-ink-2">
+                  {cp.status === "stale" && cp.lastSuccessfulSyncAtMs !== null
+                    ? `Last successful sync ${new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(new Date(cp.lastSuccessfulSyncAtMs))}`
+                    : cp.calculatedOn === null
+                      ? "Calculation date unavailable"
+                      : `Calculated ${formatCivilDate(cp.calculatedOn)}`}
+                </p>
+                <Button
+                  ref={cpEffortsTrigger}
+                  type="button"
+                  variant="link"
+                  className="h-auto justify-start p-0"
+                  onClick={() => setOverlay("cp-efforts")}
+                >
+                  View the 2 efforts used →
+                </Button>
+              </>
+            )}
+          </div>
+          <div className={SUPPORT_PAIR}>
+            <h3 className="m-0 text-sm font-semibold">Course-based finish time</h3>
+            <strong className="text-2xl">
+              {readiness.courseEstimate.rangeMinutes === null
+                ? "Unavailable"
+                : finishRange(readiness.courseEstimate.rangeMinutes)}
+            </strong>
+            <p className="m-0 text-sm text-ink-2">
+              {readiness.courseEstimate.confidence === null
+                ? "No estimate"
+                : `${readiness.courseEstimate.confidence} confidence`}
+            </p>
+            {readiness.courseEstimate.assumptions.length > 0 ? (
+              <Button
+                ref={routeTrigger}
+                type="button"
+                variant="link"
+                className="h-auto justify-start p-0"
+                onClick={() => setOverlay("route")}
+              >
+                View route assumptions →
+              </Button>
+            ) : null}
+          </div>
+        </div>
+        <div className="grid gap-row rounded-card bg-sunk p-row sm:grid-cols-3">
+          {[
+            ["Prescribed", readiness.evidence.prescribedDurationS],
+            ["Ridden", readiness.evidence.riddenDurationS],
+            ["Adjusted", readiness.evidence.adjustedDurationS],
+          ].map(([label, value]) => (
+            <div key={String(label)} className={SUPPORT_PAIR}>
+              <span className="text-sm text-ink-2">{label}</span>
+              <strong className="text-xl tabular-nums">{clockTime(Number(value))}</strong>
+            </div>
+          ))}
+        </div>
+      </section>
+      <Dialog open={overlay === "cp-info"} onOpenChange={closeOverlay}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Estimated CP</DialogTitle>
+            <DialogDescription>
+              Based on your best short and long power efforts from the last 6 weeks. This does not
+              change your FTP, zones, workouts, or Plan.
+            </DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={overlay === "cp-efforts"} onOpenChange={closeOverlay}>
+        <DialogContent className="top-0 right-0 left-auto flex h-full max-h-none w-[min(480px,calc(100%-32px))] max-w-none translate-x-0 translate-y-0 flex-col overflow-hidden rounded-none rounded-l-card border-y-0 border-r-0 p-0">
+          <DialogHeader className="grid gap-2 border-b border-line px-5 py-5 pr-16">
+            <DialogTitle>Power efforts used</DialogTitle>
+            <DialogDescription>Estimated CP · {cp.watts ?? "Unavailable"} W</DialogDescription>
+          </DialogHeader>
+          <div className="grid flex-1 content-start gap-row overflow-auto px-5 py-5">
+            {cp.efforts.map((effort) => (
+              <section
+                key={`${effort.activityId}-${effort.durationS}`}
+                className="grid gap-inset rounded-card bg-sunk p-row"
+              >
+                <div className="flex items-start justify-between gap-row">
+                  <strong>
+                    {effort.ride} · {formatCivilDate(effort.date)}
+                  </strong>
+                  <strong className="tabular-nums">
+                    {effortDuration(effort.durationS)} at {effort.averagePowerW} W
+                  </strong>
+                </div>
+                <p className="m-0 text-sm text-ink-2">Device · {effort.device}</p>
+              </section>
+            ))}
+            {cp.status === "unavailable" ? (
+              <p className="m-0 text-ink-2">Estimated CP evidence is unavailable.</p>
+            ) : (
+              <p className="m-0 text-ink-2">
+                These two efforts produce an Estimated CP of {cp.watts} W.
+              </p>
+            )}
+          </div>
+          <DialogFooter className="m-0 flex-row justify-end border-t border-line bg-surface px-5 py-row">
+            <Button type="button" onClick={() => closeOverlay(false)}>
+              Done
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={overlay === "route"} onOpenChange={closeOverlay}>
+        <DialogContent className="top-0 right-0 left-auto flex h-full max-h-none w-[min(440px,calc(100%-32px))] max-w-none translate-x-0 translate-y-0 flex-col overflow-hidden rounded-none rounded-l-card border-y-0 border-r-0 p-0">
+          <DialogHeader className="grid gap-2 border-b border-line px-5 py-5 pr-16">
+            <DialogTitle>Route assumptions</DialogTitle>
+            <DialogDescription>
+              Inputs used for the course-based finish-time range.
+            </DialogDescription>
+          </DialogHeader>
+          <ul className="m-0 grid flex-1 content-start gap-row overflow-auto px-10 py-5 text-ink-2">
+            {readiness.courseEstimate.assumptions.map((assumption) => (
+              <li key={assumption}>{assumption}</li>
+            ))}
+          </ul>
+          <DialogFooter className="m-0 flex-row justify-end border-t border-line bg-surface px-5 py-row">
+            <Button type="button" onClick={() => closeOverlay(false)}>
+              Done
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -1728,6 +1728,31 @@ describe("Plan surface", () => {
           changedAssumption: null,
           unavailableReason: null,
         },
+        estimatedCp: {
+          status: "available",
+          watts: 287,
+          calculatedOn: "2026-08-22",
+          lastSuccessfulSyncAtMs: 1_777_000_000_000,
+          unavailableReason: null,
+          efforts: [
+            {
+              activityId: "ride-short",
+              ride: "Tuesday Hill Repeats",
+              date: "2026-08-18",
+              durationS: 180,
+              averagePowerW: 407,
+              device: "Favero Assioma Duo",
+            },
+            {
+              activityId: "ride-long",
+              ride: "Sunday Tempo Climb",
+              date: "2026-08-09",
+              durationS: 900,
+              averagePowerW: 311,
+              device: "Garmin Rally RS200",
+            },
+          ],
+        },
         evidence: {
           prescribedDurationS: 154_800,
           riddenDurationS: 142_800,
@@ -1778,6 +1803,59 @@ describe("Plan surface", () => {
     );
     expect(screen.getByText("+1 → +4 to +9")).toBeInTheDocument();
     expect(screen.getByText("4 h 48–5 h 12")).toBeInTheDocument();
+    expect(screen.getByText("287 W")).toBeInTheDocument();
+    expect(screen.getByText("Experimental")).toBeInTheDocument();
+
+    const cpInfo = screen.getByRole("button", { name: "About Estimated CP" });
+    await user.click(cpInfo);
+    expect(
+      screen.getByText(
+        "Based on your best short and long power efforts from the last 6 weeks. This does not change your FTP, zones, workouts, or Plan.",
+      ),
+    ).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(cpInfo).toHaveFocus());
+
+    const effortsTrigger = screen.getByRole("button", { name: "View the 2 efforts used →" });
+    await user.click(effortsTrigger);
+    const effortsDrawer = screen.getByRole("dialog", { name: "Power efforts used" });
+    expect(within(effortsDrawer).getByText("3:00 at 407 W")).toBeInTheDocument();
+    expect(within(effortsDrawer).getByText("15:00 at 311 W")).toBeInTheDocument();
+    expect(within(effortsDrawer).getByText("Device · Favero Assioma Duo")).toBeInTheDocument();
+    expect(within(effortsDrawer).getByText("Device · Garmin Rally RS200")).toBeInTheDocument();
+    await user.click(within(effortsDrawer).getByRole("button", { name: "Done" }));
+    await waitFor(() => expect(effortsTrigger).toHaveFocus());
+
+    const routeTrigger = screen.getByRole("button", { name: "View route assumptions →" });
+    await user.click(routeTrigger);
+    const routeDrawer = screen.getByRole("dialog", { name: "Route assumptions" });
+    expect(within(routeDrawer).getByText("Dry roads")).toBeInTheDocument();
+    expect(within(routeDrawer).getByText("Low wind")).toBeInTheDocument();
+    await user.click(within(routeDrawer).getByRole("button", { name: "Done" }));
+    await waitFor(() => expect(routeTrigger).toHaveFocus());
+    expect(planActions.saveFtp).not.toHaveBeenCalled();
+    expect(planActions.updateDraft).not.toHaveBeenCalled();
+    expect(planActions.reconcilePlan).not.toHaveBeenCalled();
+
+    show("PL-S012", {
+      ...baseReadiness,
+      estimatedCp: {
+        status: "unavailable",
+        watts: null,
+        calculatedOn: null,
+        lastSuccessfulSyncAtMs: 1_777_000_000_000,
+        unavailableReason: "missing-effort",
+        efforts: [],
+      },
+    });
+    expect(screen.getByText("Not enough measured power yet.")).toBeInTheDocument();
+
+    show("PL-S012", {
+      ...baseReadiness,
+      estimatedCp: { ...baseReadiness.estimatedCp, status: "stale" },
+    });
+    expect(screen.getByText("Stale")).toBeInTheDocument();
+    expect(screen.getByText(/Last successful sync/u)).toBeInTheDocument();
 
     show("PL-S074", {
       ...baseReadiness,
@@ -1843,6 +1921,11 @@ describe("Plan surface", () => {
       },
     });
     expect(screen.getByText("5 h 00–5 h 28")).toBeInTheDocument();
+    const changedAssumptions = screen.getByRole("button", { name: "View assumptions →" });
+    await user.click(changedAssumptions);
+    expect(screen.getByRole("dialog", { name: "Route assumptions" })).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(changedAssumptions).toHaveFocus());
 
     show("PL-S078", {
       ...baseReadiness,

--- a/packages/coach-contract/src/planning.ts
+++ b/packages/coach-contract/src/planning.ts
@@ -470,6 +470,27 @@ export const PlanReadinessProjectionSchema = z
         unavailableReason: z.enum(["missing-course", "missing-elevation"]).nullable(),
       })
       .strict(),
+    estimatedCp: z
+      .object({
+        status: z.enum(["available", "unavailable", "stale"]),
+        watts: z.number().int().nonnegative().nullable(),
+        calculatedOn: TrainingExportCivilDateSchema.nullable(),
+        lastSuccessfulSyncAtMs: z.number().int().nonnegative().nullable(),
+        unavailableReason: z.enum(["missing-effort", "mathematically-invalid"]).nullable(),
+        efforts: z.array(
+          z
+            .object({
+              activityId: z.string().min(1),
+              ride: z.string().min(1),
+              date: TrainingExportCivilDateSchema,
+              durationS: z.number().int().positive(),
+              averagePowerW: z.number().positive(),
+              device: z.string().min(1),
+            })
+            .strict(),
+        ),
+      })
+      .strict(),
     evidence: z
       .object({
         prescribedDurationS: z.number().int().nonnegative(),
@@ -539,6 +560,46 @@ export const PlanReadinessProjectionSchema = z
         code: "custom",
         path: ["courseEstimate"],
         message: "changed course estimates require the previous range and changed assumption",
+      });
+    }
+    const cpAvailable = value.estimatedCp.status !== "unavailable";
+    const cpHasAvailableEvidence =
+      value.estimatedCp.watts !== null &&
+      value.estimatedCp.calculatedOn !== null &&
+      value.estimatedCp.efforts.length === 2;
+    const cpHasUnavailableEvidence =
+      value.estimatedCp.watts === null &&
+      value.estimatedCp.calculatedOn === null &&
+      value.estimatedCp.efforts.length === 0;
+    if ((cpAvailable && !cpHasAvailableEvidence) || (!cpAvailable && !cpHasUnavailableEvidence)) {
+      context.addIssue({
+        code: "custom",
+        path: ["estimatedCp"],
+        message: "Estimated CP value, date, and evidence must match its status",
+      });
+    }
+    if (
+      (value.estimatedCp.status === "unavailable") !==
+      (value.estimatedCp.unavailableReason !== null)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["estimatedCp", "unavailableReason"],
+        message: "unavailable Estimated CP requires a reason",
+      });
+    }
+    if (cpAvailable && value.estimatedCp.unavailableReason !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["estimatedCp", "unavailableReason"],
+        message: "available Estimated CP forbids an unavailable reason",
+      });
+    }
+    if (value.estimatedCp.status === "stale" && value.estimatedCp.lastSuccessfulSyncAtMs === null) {
+      context.addIssue({
+        code: "custom",
+        path: ["estimatedCp", "lastSuccessfulSyncAtMs"],
+        message: "stale Estimated CP requires a last successful sync time",
       });
     }
   });

--- a/packages/coach-contract/tests/planning.test.ts
+++ b/packages/coach-contract/tests/planning.test.ts
@@ -439,6 +439,31 @@ describe("planning contract", () => {
         changedAssumption: null,
         unavailableReason: null,
       },
+      estimatedCp: {
+        status: "available",
+        watts: 287,
+        calculatedOn: "1998-08-22",
+        lastSuccessfulSyncAtMs: 100,
+        unavailableReason: null,
+        efforts: [
+          {
+            activityId: "ride-short",
+            ride: "Tuesday Hill Repeats",
+            date: "1998-08-18",
+            durationS: 180,
+            averagePowerW: 407,
+            device: "Favero Assioma Duo",
+          },
+          {
+            activityId: "ride-long",
+            ride: "Sunday Tempo Climb",
+            date: "1998-08-09",
+            durationS: 900,
+            averagePowerW: 311,
+            device: "Garmin Rally RS200",
+          },
+        ],
+      },
       evidence: {
         prescribedDurationS: 154_800,
         riddenDurationS: 142_800,
@@ -450,6 +475,12 @@ describe("planning contract", () => {
       error: null,
     };
     expect(PlanReadinessProjectionSchema.parse(readiness)).toEqual(readiness);
+    expect(
+      PlanReadinessProjectionSchema.safeParse({
+        ...readiness,
+        estimatedCp: { ...readiness.estimatedCp, watts: 0 },
+      }).success,
+    ).toBe(true);
     expect(
       PlanReadinessProjectionSchema.safeParse({
         ...readiness,
@@ -465,6 +496,32 @@ describe("planning contract", () => {
       PlanReadinessProjectionSchema.safeParse({
         ...readiness,
         courseEstimate: { ...readiness.courseEstimate, rangeMinutes: null },
+      }).success,
+    ).toBe(false);
+    expect(
+      PlanReadinessProjectionSchema.safeParse({
+        ...readiness,
+        estimatedCp: { ...readiness.estimatedCp, efforts: [] },
+      }).success,
+    ).toBe(false);
+    expect(
+      PlanReadinessProjectionSchema.safeParse({
+        ...readiness,
+        estimatedCp: {
+          ...readiness.estimatedCp,
+          status: "unavailable",
+          unavailableReason: "missing-effort",
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      PlanReadinessProjectionSchema.safeParse({
+        ...readiness,
+        estimatedCp: {
+          ...readiness.estimatedCp,
+          status: "stale",
+          lastSuccessfulSyncAtMs: null,
+        },
       }).success,
     ).toBe(false);
     expect(

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -59,6 +59,7 @@ import {
 } from "@enduragent/kernel/anchors";
 import {
   createAnchorRepository,
+  createAnalyticsCurveStateReader,
   createCanonicalActivityReader,
   createIntervalsSourceRepository,
   createTrustedActivitySourceResolver,
@@ -66,6 +67,8 @@ import {
   type AnchorRepository,
 } from "@enduragent/kernel/store";
 import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
+import { createVerifiedSnapshotReader } from "@enduragent/kernel-node/archive";
+import { nodeFileSystem } from "@enduragent/kernel-node/filesystem";
 import { createAuthoredIdentity, type AthleteHome } from "@enduragent/kernel-node/home";
 import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import {
@@ -93,8 +96,10 @@ import {
 import {
   createCyclingPlanFtpAdapter,
   cyclingSport,
+  projectCyclingEstimatedCp,
   projectCyclingReadinessInput,
 } from "@enduragent/sport-cycling";
+import { projectAnalyticsCurveEvidence } from "@enduragent/sync-intervals-icu";
 import { createPersistedAthleteStateSource } from "./athlete-state-reader.js";
 import { createPowerProgressStateSource } from "./power-progress.js";
 import { createRecentRidesSource } from "./recent-rides.js";
@@ -1412,6 +1417,15 @@ export async function createLocalCoachComposition(
       store: input.context.store,
     });
     const analysisCrypto = createNodeCrypto();
+    const curveState = createAnalyticsCurveStateReader(input.context.store, (fields) => {
+      if (fields.length === 0) throw new TypeError("empty key tuple");
+      return H(analysisCrypto, ...(fields as [string | number, ...(string | number)[]]));
+    });
+    const curveSnapshots = createVerifiedSnapshotReader({
+      archiveRoot: input.home.archiveDir,
+      crypto: analysisCrypto,
+      fs: nodeFileSystem(),
+    });
     const analysisSources = createIntervalsSourceRepository(input.context.store, (fields) => {
       if (fields.length === 0) throw new TypeError("empty key tuple");
       return H(analysisCrypto, ...(fields as [string | number, ...(string | number)[]]));
@@ -1604,11 +1618,37 @@ export async function createLocalCoachComposition(
           return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
         };
         const refreshedAtMs = Date.parse(latest?.metadata.last_updated ?? "");
+        let estimatedCp = projectCyclingEstimatedCp({
+          curves: undefined,
+          calculatedOn: civil(todayDateKey),
+          lastSuccessfulSyncAtMs: null,
+          stale: false,
+        });
+        try {
+          const state = await curveState.readState();
+          if (state.current !== null) {
+            const projected = await projectAnalyticsCurveEvidence(state.current, curveSnapshots);
+            const failedAt = state.refreshFailure?.failedEpochSeconds ?? null;
+            estimatedCp = projectCyclingEstimatedCp({
+              curves: projected.sustainabilityCurves?.cycling,
+              calculatedOn: state.current.generation.frozenOn,
+              lastSuccessfulSyncAtMs: state.current.promotedEpochSeconds * 1_000,
+              stale:
+                failedAt !== null && failedAt * 1_000 >= state.current.promotedEpochSeconds * 1_000,
+            });
+            if (estimatedCp.unavailableReason === "mathematically-invalid") {
+              logger.warn("estimated_cp_mathematically_invalid");
+            }
+          }
+        } catch {
+          // Estimated CP is optional evidence; readiness remains available when it cannot load.
+        }
         return projectCyclingReadinessInput({
           today: civil(todayDateKey),
           raceDate: plan.targetDateKey === null ? null : civil(plan.targetDateKey),
           wellness: latest?.wellness_data ?? null,
           currentStatus: latest?.current_status ?? null,
+          estimatedCp,
           lastSuccessfulRefreshAtMs: Number.isFinite(refreshedAtMs) ? refreshedAtMs : null,
           workouts: workouts.map((workout) => ({
             date: civil(workout.dateKey),

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -413,6 +413,14 @@ function unavailableReadinessInput(
       changedAssumption: null,
       unavailableReason: "missing-course",
     },
+    estimatedCp: {
+      status: "unavailable",
+      watts: null,
+      calculatedOn: null,
+      lastSuccessfulSyncAtMs: null,
+      unavailableReason: "missing-effort",
+      efforts: [],
+    },
     evidence: {
       prescribedDurationS: 0,
       riddenDurationS: 0,

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -1931,6 +1931,14 @@ describe("Plan operations", () => {
         changedAssumption: null,
         unavailableReason: null,
       },
+      estimatedCp: {
+        status: "unavailable" as const,
+        watts: null,
+        calculatedOn: null,
+        lastSuccessfulSyncAtMs: null,
+        unavailableReason: "missing-effort" as const,
+        efforts: [],
+      },
       evidence: {
         prescribedDurationS: 154_800,
         riddenDurationS: 142_800,

--- a/packages/engine/src/planning/readiness.ts
+++ b/packages/engine/src/planning/readiness.ts
@@ -29,6 +29,7 @@ export interface PlanReadinessInput {
     readonly changedAssumption: string | null;
     readonly unavailableReason: "missing-course" | "missing-elevation" | null;
   };
+  readonly estimatedCp: PlanReadinessProjection["estimatedCp"];
   readonly evidence: {
     readonly prescribedDurationS: number;
     readonly riddenDurationS: number;
@@ -158,6 +159,7 @@ export function projectPlanReadiness(input: PlanReadinessInput): ProjectedPlanRe
     form,
     feasibility: projectFeasibility(input, form),
     courseEstimate: input.courseEstimate,
+    estimatedCp: input.estimatedCp,
     evidence: {
       ...input.evidence,
       missedKeyWorkouts: input.missedKeyWorkouts,

--- a/packages/engine/tests/plan-readiness.test.ts
+++ b/packages/engine/tests/plan-readiness.test.ts
@@ -31,6 +31,14 @@ function input() {
       changedAssumption: null,
       unavailableReason: null,
     },
+    estimatedCp: {
+      status: "unavailable" as const,
+      watts: null,
+      calculatedOn: null,
+      lastSuccessfulSyncAtMs: null,
+      unavailableReason: "missing-effort" as const,
+      efforts: [],
+    },
     evidence: {
       prescribedDurationS: 154_800,
       riddenDurationS: 142_800,

--- a/packages/kernel/src/reference/entry/metrics.ts
+++ b/packages/kernel/src/reference/entry/metrics.ts
@@ -3,6 +3,7 @@ export * from "../metrics/capability.js";
 export * from "../metrics/compliance-and-body.js";
 export * from "../metrics/date-helpers.js";
 export * from "../metrics/distribution.js";
+export * from "../metrics/estimated-cp.js";
 export * from "../metrics/index.js";
 export * from "../metrics/load-management.js";
 export * from "../metrics/metric-input.js";

--- a/packages/kernel/src/reference/metrics/estimated-cp.ts
+++ b/packages/kernel/src/reference/metrics/estimated-cp.ts
@@ -1,0 +1,54 @@
+export interface CriticalPowerPoint {
+  readonly durationS: number;
+  readonly averagePowerW: number;
+}
+
+export type CriticalPowerEstimate =
+  | {
+      readonly status: "available";
+      readonly cpWatts: number;
+      readonly wPrimeJ: number;
+    }
+  | {
+      readonly status: "unavailable";
+      readonly reason: "mathematically-invalid";
+    };
+
+function finitePositive(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Enduragent's display-only two-point CP calculation boundary.
+ *
+ * The caller owns evidence eligibility and duration-band selection. This
+ * function owns only the exact two-parameter equations and mathematical
+ * validity checks documented in docs/formulas/critical-power-two-parameter-model.md.
+ */
+export function estimateCriticalPower(input: {
+  readonly short: CriticalPowerPoint;
+  readonly long: CriticalPowerPoint;
+}): CriticalPowerEstimate {
+  const shortDuration = input.short.durationS;
+  const shortPower = input.short.averagePowerW;
+  const longDuration = input.long.durationS;
+  const longPower = input.long.averagePowerW;
+  if (
+    !finitePositive(shortDuration) ||
+    !finitePositive(shortPower) ||
+    !finitePositive(longDuration) ||
+    !finitePositive(longPower) ||
+    longDuration <= shortDuration ||
+    shortPower <= longPower ||
+    longPower * longDuration <= shortPower * shortDuration
+  ) {
+    return { status: "unavailable", reason: "mathematically-invalid" };
+  }
+  const denominator = longDuration - shortDuration;
+  const cpWatts = (longPower * longDuration - shortPower * shortDuration) / denominator;
+  const wPrimeJ = ((shortPower - longPower) * shortDuration * longDuration) / denominator;
+  if (!finitePositive(cpWatts) || !finitePositive(wPrimeJ)) {
+    return { status: "unavailable", reason: "mathematically-invalid" };
+  }
+  return { status: "available", cpWatts, wPrimeJ };
+}

--- a/packages/kernel/src/reference/schemas/inputs.ts
+++ b/packages/kernel/src/reference/schemas/inputs.ts
@@ -194,7 +194,7 @@ export type FtpHistoryPoint = z.infer<typeof FtpHistoryPointSchema>;
 
 /** Calendar event — planned workout for compliance/consistency metrics. */
 export const PLANNING_EVENT_CATEGORIES = ["WORKOUT", "RACE_A", "RACE_B", "RACE_C"] as const;
-export type PlanningEventCategory = typeof PLANNING_EVENT_CATEGORIES[number];
+export type PlanningEventCategory = (typeof PLANNING_EVENT_CATEGORIES)[number];
 
 const planningEventCategorySet = new Set<string>(PLANNING_EVENT_CATEGORIES);
 
@@ -223,8 +223,24 @@ export const PowerCurveEntrySchema = z.looseObject({
   id: z.string(),
   secs: z.array(z.number()),
   watts: z.array(z.number().nullable()),
+  activity_ids: z.array(z.string().nullable()).optional(),
+  start_indexes: z.array(z.number().int().nonnegative().nullable()).optional(),
 });
 export type PowerCurveEntry = z.infer<typeof PowerCurveEntrySchema>;
+
+export const PowerCurveActivitySchema = z.looseObject({
+  id: z.union([z.string(), z.number()]),
+  start_date_local: z.string(),
+  name: z.string().nullable().optional(),
+  type: z.string().nullable().optional(),
+  device_watts: z.boolean().nullable().optional(),
+  icu_ignore_power: z.boolean().nullable().optional(),
+  power_meter: z.string().nullable().optional(),
+  device_name: z.string().nullable().optional(),
+  missing_timestamps: z.boolean().nullable().optional(),
+  missing_power_samples: z.boolean().nullable().optional(),
+});
+export type PowerCurveActivity = z.infer<typeof PowerCurveActivitySchema>;
 
 /** One entry in an HR mean-max curve list. Same matching as power, but the
  *  value array is keyed `values` (HR bpm), not `watts`. */
@@ -239,6 +255,7 @@ export type HrCurveEntry = z.infer<typeof HrCurveEntrySchema>;
  *  reads via `data.get("list", [])`. */
 export const PowerCurveDataSchema = z.looseObject({
   list: z.array(PowerCurveEntrySchema),
+  activities: z.record(z.string(), PowerCurveActivitySchema).optional(),
 });
 export type PowerCurveData = z.infer<typeof PowerCurveDataSchema>;
 

--- a/packages/kernel/tests/reference-estimated-cp.test.ts
+++ b/packages/kernel/tests/reference-estimated-cp.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { estimateCriticalPower } from "../src/reference/metrics/estimated-cp.js";
+
+describe("Estimated CP formula boundary", () => {
+  it("keeps full precision for a valid two-point model", () => {
+    expect(
+      estimateCriticalPower({
+        short: { durationS: 180, averagePowerW: 407 },
+        long: { durationS: 900, averagePowerW: 311 },
+      }),
+    ).toEqual({ status: "available", cpWatts: 287, wPrimeJ: 21_600 });
+  });
+
+  it.each([
+    [
+      { durationS: 0, averagePowerW: 407 },
+      { durationS: 900, averagePowerW: 311 },
+    ],
+    [
+      { durationS: 180, averagePowerW: 300 },
+      { durationS: 900, averagePowerW: 311 },
+    ],
+    [
+      { durationS: 200, averagePowerW: 800 },
+      { durationS: 720, averagePowerW: 200 },
+    ],
+    [
+      { durationS: 900, averagePowerW: 407 },
+      { durationS: 180, averagePowerW: 311 },
+    ],
+  ])("hides mathematically invalid points", (short, long) => {
+    expect(estimateCriticalPower({ short, long })).toEqual({
+      status: "unavailable",
+      reason: "mathematically-invalid",
+    });
+  });
+});

--- a/packages/sport-cycling/src/estimated-cp.ts
+++ b/packages/sport-cycling/src/estimated-cp.ts
@@ -1,0 +1,169 @@
+import { estimateCriticalPower } from "@enduragent/kernel/reference/metrics";
+import type { SustainabilityFamilyCurves } from "@enduragent/kernel/reference/schemas";
+
+export interface CyclingEstimatedCpEffort {
+  readonly activityId: string;
+  readonly ride: string;
+  readonly date: string;
+  readonly durationS: number;
+  readonly averagePowerW: number;
+  readonly device: string;
+}
+
+export type CyclingEstimatedCpProjection =
+  | {
+      readonly status: "available" | "stale";
+      readonly watts: number;
+      readonly calculatedOn: string;
+      readonly lastSuccessfulSyncAtMs: number | null;
+      readonly unavailableReason: null;
+      readonly efforts: [CyclingEstimatedCpEffort, CyclingEstimatedCpEffort];
+    }
+  | {
+      readonly status: "unavailable";
+      readonly watts: null;
+      readonly calculatedOn: null;
+      readonly lastSuccessfulSyncAtMs: number | null;
+      readonly unavailableReason: "missing-effort" | "mathematically-invalid";
+      readonly efforts: [];
+    };
+
+interface Candidate extends CyclingEstimatedCpEffort {
+  readonly startedAt: string;
+}
+
+function device(value: {
+  readonly power_meter?: string | null;
+  readonly device_name?: string | null;
+}): string | null {
+  for (const candidate of [value.power_meter, value.device_name]) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) return candidate.trim();
+  }
+  return null;
+}
+
+function candidates(
+  curves: SustainabilityFamilyCurves | undefined,
+  minDurationS: number,
+  maxDurationS: number,
+): readonly Candidate[] {
+  if (curves === undefined) return [];
+  const result: Candidate[] = [];
+  for (const envelope of Object.values(curves.power)) {
+    const activities = envelope.activities ?? {};
+    for (const curve of envelope.list) {
+      if (
+        curve.secs.length !== curve.watts.length ||
+        curve.activity_ids === undefined ||
+        curve.activity_ids.length !== curve.secs.length
+      )
+        continue;
+      for (let index = 0; index < curve.secs.length; index += 1) {
+        const durationS = curve.secs[index];
+        const averagePowerW = curve.watts[index];
+        const activityId = curve.activity_ids[index];
+        if (
+          !Number.isSafeInteger(durationS) ||
+          durationS < minDurationS ||
+          durationS > maxDurationS ||
+          typeof averagePowerW !== "number" ||
+          !Number.isFinite(averagePowerW) ||
+          averagePowerW <= 0 ||
+          typeof activityId !== "string" ||
+          activityId.length === 0
+        )
+          continue;
+        const activity = activities[activityId];
+        if (
+          activity === undefined ||
+          activity.device_watts !== true ||
+          activity.icu_ignore_power === true ||
+          activity.missing_timestamps === true ||
+          activity.missing_power_samples === true
+        )
+          continue;
+        const powerDevice = device(activity);
+        const date = activity.start_date_local.slice(0, 10);
+        if (powerDevice === null || !/^\d{4}-\d{2}-\d{2}$/u.test(date)) continue;
+        const ride =
+          typeof activity.name === "string" && activity.name.trim().length > 0
+            ? activity.name.trim()
+            : typeof activity.type === "string" && activity.type.trim().length > 0
+              ? activity.type.trim()
+              : "Ride";
+        result.push({
+          activityId,
+          ride,
+          date,
+          startedAt: activity.start_date_local,
+          durationS,
+          averagePowerW,
+          device: powerDevice,
+        });
+      }
+    }
+  }
+  return result;
+}
+
+function best(values: readonly Candidate[]): Candidate | null {
+  return (
+    [...values].sort(
+      (left, right) =>
+        right.averagePowerW - left.averagePowerW ||
+        right.startedAt.localeCompare(left.startedAt) ||
+        right.durationS - left.durationS ||
+        left.activityId.localeCompare(right.activityId),
+    )[0] ?? null
+  );
+}
+
+function evidence(candidate: Candidate): CyclingEstimatedCpEffort {
+  return {
+    activityId: candidate.activityId,
+    ride: candidate.ride,
+    date: candidate.date,
+    durationS: candidate.durationS,
+    averagePowerW: candidate.averagePowerW,
+    device: candidate.device,
+  };
+}
+
+export function projectCyclingEstimatedCp(input: {
+  readonly curves: SustainabilityFamilyCurves | undefined;
+  readonly calculatedOn: string;
+  readonly lastSuccessfulSyncAtMs: number | null;
+  readonly stale: boolean;
+}): CyclingEstimatedCpProjection {
+  const short = best(candidates(input.curves, 120, 200));
+  const long = best(candidates(input.curves, 720, 1_200));
+  if (short === null || long === null) {
+    return {
+      status: "unavailable",
+      watts: null,
+      calculatedOn: null,
+      lastSuccessfulSyncAtMs: input.lastSuccessfulSyncAtMs,
+      unavailableReason: "missing-effort",
+      efforts: [],
+    };
+  }
+  const estimate = estimateCriticalPower({ short, long });
+  if (estimate.status === "unavailable") {
+    return {
+      status: "unavailable",
+      watts: null,
+      calculatedOn: null,
+      lastSuccessfulSyncAtMs: input.lastSuccessfulSyncAtMs,
+      unavailableReason: estimate.reason,
+      efforts: [],
+    };
+  }
+  return {
+    status: input.stale ? "stale" : "available",
+    watts: Math.round(estimate.cpWatts),
+    calculatedOn: input.calculatedOn,
+    lastSuccessfulSyncAtMs: input.lastSuccessfulSyncAtMs,
+    unavailableReason: null,
+    efforts: [evidence(short), evidence(long)],
+  };
+}

--- a/packages/sport-cycling/src/index.ts
+++ b/packages/sport-cycling/src/index.ts
@@ -29,6 +29,8 @@ export type {
 } from "./season.js";
 export { cyclingTaperRefusal, projectCyclingReadinessInput } from "./readiness.js";
 export type { CyclingReadinessSourceInput, CyclingReadinessWorkoutInput } from "./readiness.js";
+export { projectCyclingEstimatedCp } from "./estimated-cp.js";
+export type { CyclingEstimatedCpEffort, CyclingEstimatedCpProjection } from "./estimated-cp.js";
 
 export {
   serializeIntervalsWorkout,

--- a/packages/sport-cycling/src/readiness.ts
+++ b/packages/sport-cycling/src/readiness.ts
@@ -1,3 +1,5 @@
+import type { CyclingEstimatedCpProjection } from "./estimated-cp.js";
+
 export interface CyclingPlanReadinessInput {
   readonly today: string;
   readonly raceDate: string | null;
@@ -24,6 +26,7 @@ export interface CyclingPlanReadinessInput {
     readonly changedAssumption: string | null;
     readonly unavailableReason: "missing-course" | "missing-elevation" | null;
   };
+  readonly estimatedCp: CyclingEstimatedCpProjection;
   readonly evidence: {
     readonly prescribedDurationS: number;
     readonly riddenDurationS: number;
@@ -43,6 +46,7 @@ export interface CyclingReadinessSourceInput {
   readonly raceDate: string | null;
   readonly wellness: unknown;
   readonly currentStatus: unknown;
+  readonly estimatedCp: CyclingEstimatedCpProjection;
   readonly lastSuccessfulRefreshAtMs: number | null;
   readonly workouts: readonly CyclingReadinessWorkoutInput[];
 }
@@ -244,6 +248,7 @@ export function projectCyclingReadinessInput(
     raceDate: input.raceDate,
     platformSeed: platformSeed(input.wellness, input.today, input.lastSuccessfulRefreshAtMs),
     dailyLoadRanges: dailyLoadRanges(input.today, input.raceDate, input.workouts),
+    estimatedCp: input.estimatedCp,
     ...sourceFacts(input.currentStatus),
   };
 }

--- a/packages/sport-cycling/tests/estimated-cp.test.ts
+++ b/packages/sport-cycling/tests/estimated-cp.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+import type { SustainabilityFamilyCurves } from "@enduragent/kernel/reference/schemas";
+import { projectCyclingEstimatedCp } from "../src/estimated-cp.js";
+
+function curves(
+  overrides: {
+    readonly shortPower?: number;
+    readonly longPower?: number;
+    readonly includeLong?: boolean;
+    readonly ignoredShort?: boolean;
+    readonly shortDevice?: string | null;
+    readonly shortDeviceWatts?: boolean;
+    readonly shortMissingTimestamps?: boolean;
+    readonly shortMissingPowerSamples?: boolean;
+  } = {},
+): SustainabilityFamilyCurves {
+  const includeLong = overrides.includeLong ?? true;
+  return {
+    power: {
+      Ride: {
+        activities: {
+          short: {
+            id: "short",
+            start_date_local: "2026-08-18T06:00:00",
+            name: "Tuesday Hill Repeats",
+            type: "Ride",
+            device_watts: overrides.shortDeviceWatts ?? true,
+            icu_ignore_power: overrides.ignoredShort ?? false,
+            power_meter:
+              overrides.shortDevice === undefined ? "Favero Assioma Duo" : overrides.shortDevice,
+            missing_timestamps: overrides.shortMissingTimestamps ?? false,
+            missing_power_samples: overrides.shortMissingPowerSamples ?? false,
+          },
+          long: {
+            id: "long",
+            start_date_local: "2026-08-09T07:00:00",
+            name: "Sunday Tempo Climb",
+            type: "Ride",
+            device_watts: true,
+            icu_ignore_power: false,
+            device_name: "Garmin Rally RS200",
+          },
+        },
+        list: [
+          {
+            id: "r.2026-07-12.2026-08-22",
+            secs: includeLong ? [120, 180, 900] : [120, 180],
+            watts: includeLong
+              ? [
+                  overrides.shortPower ?? 390,
+                  overrides.shortPower ?? 407,
+                  overrides.longPower ?? 311,
+                ]
+              : [overrides.shortPower ?? 390, overrides.shortPower ?? 407],
+            activity_ids: includeLong ? ["short", "short", "long"] : ["short", "short"],
+            start_indexes: includeLong ? [100, 200, 300] : [100, 200],
+          },
+        ],
+      },
+      VirtualRide: { list: [], activities: {} },
+    },
+    hr: {},
+  };
+}
+
+function tieCurves(options: {
+  readonly competingStartedAt: string;
+  readonly competingDurationS: 180 | 190;
+}): SustainabilityFamilyCurves {
+  return {
+    power: {
+      Ride: {
+        activities: {
+          older: {
+            id: "older",
+            start_date_local: "2026-08-17T06:00:00",
+            name: "Older effort",
+            device_watts: true,
+            power_meter: "Meter A",
+          },
+          "newer-b": {
+            id: "newer-b",
+            start_date_local: options.competingStartedAt,
+            name: "Newer B",
+            device_watts: true,
+            power_meter: "Meter B",
+          },
+          long: {
+            id: "long",
+            start_date_local: "2026-08-16T06:00:00",
+            name: "Long effort",
+            device_watts: true,
+            power_meter: "Meter L",
+          },
+        },
+        list: [
+          {
+            id: "ride-window",
+            secs: [160, options.competingDurationS, 900],
+            watts: [407, 407, 311],
+            activity_ids: ["older", "newer-b", "long"],
+            start_indexes: [1, 2, 3],
+          },
+        ],
+      },
+      VirtualRide: {
+        activities: {
+          "newer-a": {
+            id: "newer-a",
+            start_date_local: "2026-08-18T06:00:00",
+            name: "Newer A",
+            device_watts: true,
+            device_name: "Meter C",
+          },
+        },
+        list: [
+          {
+            id: "virtual-window",
+            secs: [180],
+            watts: [407],
+            activity_ids: ["newer-a"],
+            start_indexes: [4],
+          },
+        ],
+      },
+    },
+    hr: {},
+  };
+}
+
+describe("cycling Estimated CP projection", () => {
+  it("selects one eligible effort in each band and rounds only the visible value", () => {
+    expect(
+      projectCyclingEstimatedCp({
+        curves: curves(),
+        calculatedOn: "2026-08-22",
+        lastSuccessfulSyncAtMs: 1_777_000_000_000,
+        stale: false,
+      }),
+    ).toEqual({
+      status: "available",
+      watts: 287,
+      calculatedOn: "2026-08-22",
+      lastSuccessfulSyncAtMs: 1_777_000_000_000,
+      unavailableReason: null,
+      efforts: [
+        {
+          activityId: "short",
+          ride: "Tuesday Hill Repeats",
+          date: "2026-08-18",
+          durationS: 180,
+          averagePowerW: 407,
+          device: "Favero Assioma Duo",
+        },
+        {
+          activityId: "long",
+          ride: "Sunday Tempo Climb",
+          date: "2026-08-09",
+          durationS: 900,
+          averagePowerW: 311,
+          device: "Garmin Rally RS200",
+        },
+      ],
+    });
+  });
+
+  it("keeps the last valid projection visible as stale", () => {
+    expect(
+      projectCyclingEstimatedCp({
+        curves: curves(),
+        calculatedOn: "2026-08-22",
+        lastSuccessfulSyncAtMs: 1_777_000_000_000,
+        stale: true,
+      }).status,
+    ).toBe("stale");
+  });
+
+  it("rounds a mathematically valid sub-watt result without adding a physiological minimum", () => {
+    expect(
+      projectCyclingEstimatedCp({
+        curves: curves({ shortPower: 200, longPower: 36_072 / 900 }),
+        calculatedOn: "2026-08-22",
+        lastSuccessfulSyncAtMs: null,
+        stale: false,
+      }),
+    ).toMatchObject({ status: "available", watts: 0 });
+  });
+
+  it("breaks equal-power ties by newer ride, longer duration, then stable activity id", () => {
+    const selected = (value: SustainabilityFamilyCurves): string | undefined => {
+      const result = projectCyclingEstimatedCp({
+        curves: value,
+        calculatedOn: "2026-08-22",
+        lastSuccessfulSyncAtMs: null,
+        stale: false,
+      });
+      expect(result.status).toBe("available");
+      return result.efforts[0]?.activityId;
+    };
+
+    expect(
+      selected(tieCurves({ competingStartedAt: "2026-08-18T05:00:00", competingDurationS: 190 })),
+    ).toBe("newer-a");
+    expect(
+      selected(tieCurves({ competingStartedAt: "2026-08-18T06:00:00", competingDurationS: 190 })),
+    ).toBe("newer-b");
+    expect(
+      selected(tieCurves({ competingStartedAt: "2026-08-18T06:00:00", competingDurationS: 180 })),
+    ).toBe("newer-a");
+  });
+
+  it("allows both duration bands to use the same measured ride", () => {
+    const sameRide = curves();
+    const ride = sameRide.power.Ride;
+    if (ride === undefined) throw new TypeError("Ride evidence missing.");
+    ride.list[0]!.activity_ids = ["short", "short", "short"];
+
+    const result = projectCyclingEstimatedCp({
+      curves: sameRide,
+      calculatedOn: "2026-08-22",
+      lastSuccessfulSyncAtMs: null,
+      stale: false,
+    });
+
+    expect(result.status).toBe("available");
+    expect(result.efforts.map((effort) => effort.activityId)).toEqual(["short", "short"]);
+  });
+
+  it("hides missing, unmeasured, ignored, incomplete, and mathematically invalid evidence", () => {
+    expect(
+      projectCyclingEstimatedCp({
+        curves: curves({ includeLong: false }),
+        calculatedOn: "2026-08-22",
+        lastSuccessfulSyncAtMs: null,
+        stale: false,
+      }),
+    ).toMatchObject({ status: "unavailable", unavailableReason: "missing-effort" });
+    expect(
+      projectCyclingEstimatedCp({
+        curves: curves({ ignoredShort: true }),
+        calculatedOn: "2026-08-22",
+        lastSuccessfulSyncAtMs: null,
+        stale: false,
+      }),
+    ).toMatchObject({ status: "unavailable", unavailableReason: "missing-effort" });
+    for (const hidden of [
+      curves({ shortDeviceWatts: false }),
+      curves({ shortDevice: null }),
+      curves({ shortMissingTimestamps: true }),
+      curves({ shortMissingPowerSamples: true }),
+    ]) {
+      expect(
+        projectCyclingEstimatedCp({
+          curves: hidden,
+          calculatedOn: "2026-08-22",
+          lastSuccessfulSyncAtMs: null,
+          stale: false,
+        }),
+      ).toMatchObject({ status: "unavailable", unavailableReason: "missing-effort" });
+    }
+    expect(
+      projectCyclingEstimatedCp({
+        curves: curves({ shortPower: 300, longPower: 311 }),
+        calculatedOn: "2026-08-22",
+        lastSuccessfulSyncAtMs: null,
+        stale: false,
+      }),
+    ).toMatchObject({ status: "unavailable", unavailableReason: "mathematically-invalid" });
+  });
+});

--- a/packages/sport-cycling/tests/readiness.test.ts
+++ b/packages/sport-cycling/tests/readiness.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { cyclingTaperRefusal, projectCyclingReadinessInput } from "../src/readiness.js";
 
+const estimatedCp = {
+  status: "unavailable" as const,
+  watts: null,
+  calculatedOn: null,
+  lastSuccessfulSyncAtMs: null,
+  unavailableReason: "missing-effort" as const,
+  efforts: [] as [],
+};
+
 describe("cycling readiness inputs", () => {
   it("normalizes the latest platform seed and explicit future Load ranges", () => {
     expect(
@@ -24,6 +33,7 @@ describe("cycling readiness inputs", () => {
             },
           },
         },
+        estimatedCp,
         lastSuccessfulRefreshAtMs: 1_777_000_000_000,
         workouts: [
           {
@@ -50,6 +60,7 @@ describe("cycling readiness inputs", () => {
       raceDate: "2026-08-23",
       wellness: [],
       currentStatus: null,
+      estimatedCp,
       lastSuccessfulRefreshAtMs: null,
       workouts: [{ date: "2026-08-23", name: "Ride", durationS: 3_600, structureJson: "{}" }],
     });
@@ -62,6 +73,7 @@ describe("cycling readiness inputs", () => {
       raceDate: "2026-08-23",
       wellness: [],
       currentStatus: { readiness: { courseEstimate: { status: "available" } } },
+      estimatedCp,
       lastSuccessfulRefreshAtMs: null,
       workouts: [],
     });

--- a/packages/sync-intervals-icu/src/analytics-curve-projection.ts
+++ b/packages/sync-intervals-icu/src/analytics-curve-projection.ts
@@ -23,6 +23,23 @@ interface NormalizedCurve {
   readonly id: string;
   readonly secs: readonly number[];
   readonly values: readonly (number | null)[];
+  readonly activityIds: readonly (string | null)[];
+  readonly startIndexes: readonly (number | null)[];
+  readonly activities: Readonly<Record<string, NormalizedCurveActivity>>;
+}
+
+interface NormalizedCurveActivity {
+  readonly [key: string]: unknown;
+  readonly id: string | number;
+  readonly start_date_local: string;
+  readonly name?: string | null;
+  readonly type?: string | null;
+  readonly device_watts?: boolean | null;
+  readonly icu_ignore_power?: boolean | null;
+  readonly power_meter?: string | null;
+  readonly device_name?: string | null;
+  readonly missing_timestamps?: boolean | null;
+  readonly missing_power_samples?: boolean | null;
 }
 
 export class AnalyticsCurveProjectionError extends Error {
@@ -48,29 +65,102 @@ function normalizeCurve(
   id: string,
   secs: readonly number[],
   values: readonly (number | null)[],
+  activityIds: readonly string[] | null | undefined = undefined,
+  startIndexes: readonly (number | null)[] | null | undefined = undefined,
+  activities: Readonly<Record<string, NormalizedCurveActivity>> = Object.freeze({}),
 ): NormalizedCurve {
-  if (secs.length !== values.length || secs.length > MAX_PROJECTED_AXIS_LENGTH) fail();
+  if (
+    secs.length !== values.length ||
+    secs.length > MAX_PROJECTED_AXIS_LENGTH ||
+    (activityIds !== undefined && activityIds !== null && activityIds.length !== secs.length) ||
+    (startIndexes !== undefined && startIndexes !== null && startIndexes.length !== secs.length)
+  )
+    fail();
   const projectedSecs: number[] = [];
   const projectedValues: (number | null)[] = [];
+  const projectedActivityIds: (string | null)[] = [];
+  const projectedStartIndexes: (number | null)[] = [];
   let previous = 0;
   for (let index = 0; index < secs.length; index += 1) {
     const seconds = secs[index];
     const value = values[index];
+    const activityId = activityIds?.[index] ?? null;
+    const startIndex = startIndexes?.[index] ?? null;
     if (
       !Number.isSafeInteger(seconds) ||
       seconds <= previous ||
-      (value !== null && (!Number.isFinite(value) || value < 0))
+      (value !== null && (!Number.isFinite(value) || value < 0)) ||
+      (activityId !== null && activityId.length === 0) ||
+      (startIndex !== null && (!Number.isSafeInteger(startIndex) || startIndex < 0))
     )
       fail();
     projectedSecs.push(seconds);
     projectedValues.push(value);
+    projectedActivityIds.push(activityId);
+    projectedStartIndexes.push(startIndex);
     previous = seconds;
   }
   return Object.freeze({
     id,
     secs: Object.freeze(projectedSecs),
     values: Object.freeze(projectedValues),
+    activityIds: Object.freeze(projectedActivityIds),
+    startIndexes: Object.freeze(projectedStartIndexes),
+    activities,
   });
+}
+
+function optionalText(value: unknown): string | null | undefined {
+  return value === undefined ? undefined : typeof value === "string" ? value : null;
+}
+
+function optionalBoolean(value: unknown): boolean | null | undefined {
+  return value === undefined ? undefined : typeof value === "boolean" ? value : null;
+}
+
+function normalizeActivities(
+  source: ReadonlyMap<string, Record<string, unknown>>,
+): Readonly<Record<string, NormalizedCurveActivity>> {
+  const activities: Record<string, NormalizedCurveActivity> = {};
+  for (const [key, activity] of source) {
+    const id = activity.id;
+    const startDateLocal = activity.startDateLocal;
+    if (
+      (typeof id !== "string" && typeof id !== "number") ||
+      typeof startDateLocal !== "string" ||
+      startDateLocal.length === 0
+    )
+      fail();
+    activities[key] = Object.freeze({
+      id,
+      start_date_local: startDateLocal,
+      name: optionalText(activity.name),
+      type: optionalText(activity.type),
+      device_watts: optionalBoolean(activity.deviceWatts),
+      icu_ignore_power: optionalBoolean(activity.icuIgnorePower),
+      power_meter: optionalText(activity.powerMeter),
+      device_name: optionalText(activity.deviceName),
+      missing_timestamps: optionalBoolean(activity.missingTimestamps),
+      missing_power_samples: optionalBoolean(activity.missingPowerSamples),
+    });
+  }
+  return Object.freeze(activities);
+}
+
+function optionalStringArray(value: unknown): readonly string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) fail();
+  return value;
+}
+
+function optionalIndexArray(value: unknown): readonly (number | null)[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (
+    !Array.isArray(value) ||
+    value.some((item) => item !== null && (!Number.isSafeInteger(item) || (item as number) < 0))
+  )
+    fail();
+  return value as readonly (number | null)[];
 }
 
 function selectPowerCurves(
@@ -79,13 +169,23 @@ function selectPowerCurves(
 ): readonly NormalizedCurve[] {
   const decoded = decode(AthletePowerCurveSetSchema, payload);
   if (!decoded.ok) fail();
+  const activities = normalizeActivities(decoded.value.activities);
   const seen = new Set<string>();
   const selected: NormalizedCurve[] = [];
   for (const curve of decoded.value.list) {
     if (typeof curve.id !== "string" || !selectors.has(curve.id)) continue;
     if (seen.has(curve.id)) fail();
     seen.add(curve.id);
-    selected.push(normalizeCurve(curve.id, curve.secs, curve.values));
+    selected.push(
+      normalizeCurve(
+        curve.id,
+        curve.secs,
+        curve.values,
+        optionalStringArray(curve.activity_id),
+        optionalIndexArray(curve.start_index),
+        activities,
+      ),
+    );
   }
   return Object.freeze(selected);
 }
@@ -119,16 +219,25 @@ function aggregateCurves(
   // from the explicitly separated outdoor/indoor evidence by taking the best value per duration.
   const aggregated: NormalizedCurve[] = [];
   for (const id of selectors) {
-    const bySecond = new Map<number, number | null>();
+    const bySecond = new Map<
+      number,
+      { value: number | null; activityId: string | null; startIndex: number | null }
+    >();
+    const activities: Record<string, NormalizedCurveActivity> = {};
     for (const activityType of ACTIVITY_TYPES) {
       const curve = curveById(curvesByType[activityType], id);
       if (curve === undefined) continue;
+      Object.assign(activities, curve.activities);
       for (let index = 0; index < curve.secs.length; index += 1) {
         const seconds = curve.secs[index]!;
         const value = curve.values[index] ?? null;
-        const previous = bySecond.get(seconds);
+        const previous = bySecond.get(seconds)?.value;
         if (previous === undefined || previous === null || (value !== null && value > previous)) {
-          bySecond.set(seconds, value);
+          bySecond.set(seconds, {
+            value,
+            activityId: curve.activityIds[index] ?? null,
+            startIndex: curve.startIndexes[index] ?? null,
+          });
         }
       }
     }
@@ -138,7 +247,14 @@ function aggregateCurves(
       Object.freeze({
         id,
         secs: Object.freeze(secs),
-        values: Object.freeze(secs.map((seconds) => bySecond.get(seconds) ?? null)),
+        values: Object.freeze(secs.map((seconds) => bySecond.get(seconds)?.value ?? null)),
+        activityIds: Object.freeze(
+          secs.map((seconds) => bySecond.get(seconds)?.activityId ?? null),
+        ),
+        startIndexes: Object.freeze(
+          secs.map((seconds) => bySecond.get(seconds)?.startIndex ?? null),
+        ),
+        activities: Object.freeze(activities),
       }),
     );
   }
@@ -151,13 +267,25 @@ function powerEnvelope(
   const list = curves.map((curve) => {
     const secs = [...curve.secs];
     const watts = [...curve.values];
-    const entry = { id: curve.id, secs, watts };
+    const activity_ids = [...curve.activityIds];
+    const start_indexes = [...curve.startIndexes];
+    const entry = { id: curve.id, secs, watts, activity_ids, start_indexes };
     Object.freeze(secs);
     Object.freeze(watts);
+    Object.freeze(activity_ids);
+    Object.freeze(start_indexes);
     return Object.freeze(entry);
   });
   Object.freeze(list);
-  return Object.freeze({ list });
+  const activities: Record<string, NormalizedCurveActivity> = {};
+  for (const curve of curves) {
+    for (const activityId of curve.activityIds) {
+      if (activityId !== null && curve.activities[activityId] !== undefined) {
+        activities[activityId] = curve.activities[activityId];
+      }
+    }
+  }
+  return Object.freeze({ list, activities: Object.freeze(activities) });
 }
 
 function heartRateEnvelope(

--- a/packages/sync-intervals-icu/tests/analytics-curve-projection.test.ts
+++ b/packages/sync-intervals-icu/tests/analytics-curve-projection.test.ts
@@ -118,6 +118,8 @@ describe("analytics curve evidence projection", () => {
       id: CURRENT,
       secs: [5, 60, 300, 1_200, 3_600],
       watts: [1_100, 500, 350, 280, 240],
+      activity_ids: [null, null, null, null, null],
+      start_indexes: [null, null, null, null, null],
     });
     expect(projected.hrCurves.list[0]).toEqual({
       id: CURRENT,
@@ -165,8 +167,68 @@ describe("analytics curve evidence projection", () => {
     const projected = await projectAnalyticsCurveEvidence(currentState(), reader(values));
 
     expect(projected.powerCurves.list).toHaveLength(3);
-    expect(projected.sustainabilityCurves.cycling?.power.VirtualRide).toEqual({ list: [] });
+    expect(projected.sustainabilityCurves.cycling?.power.VirtualRide).toEqual({
+      list: [],
+      activities: {},
+    });
     expect(projected.sustainabilityCurves.cycling?.hr.VirtualRide).toEqual({ list: [] });
+  });
+
+  it("preserves only selected activity and device evidence for the 42-day power curve", async () => {
+    const values = [...payloads()];
+    values[0] = {
+      activities: {
+        short: {
+          id: "short",
+          start_date_local: "2026-08-18T06:00:00",
+          name: "Tuesday Hill Repeats",
+          device_watts: true,
+          icu_ignore_power: false,
+          power_meter: "Favero Assioma Duo",
+          provider_private_field: "not-projected",
+        },
+        long: {
+          id: "long",
+          start_date_local: "2026-08-09T07:00:00",
+          name: "Sunday Tempo Climb",
+          device_watts: true,
+          icu_ignore_power: false,
+          device_name: "Garmin Rally RS200",
+        },
+        unused: {
+          id: "unused",
+          start_date_local: "2026-08-01T07:00:00",
+          device_watts: true,
+        },
+      },
+      list: [
+        {
+          ...powerCurve(SUSTAINABILITY, [180, 900], [407, 311]),
+          activity_id: ["short", "long"],
+          start_index: [120, 240],
+        },
+      ],
+    };
+    values[1] = { activities: {}, list: [] };
+    const projected = await projectAnalyticsCurveEvidence(currentState(), reader(values));
+    const power = projected.sustainabilityCurves.cycling?.power.Ride;
+    expect(power?.list[0]).toMatchObject({
+      activity_ids: ["short", "long"],
+      start_indexes: [120, 240],
+    });
+    expect(power?.activities).toEqual({
+      short: expect.objectContaining({
+        id: "short",
+        device_watts: true,
+        power_meter: "Favero Assioma Duo",
+      }),
+      long: expect.objectContaining({
+        id: "long",
+        device_watts: true,
+        device_name: "Garmin Rally RS200",
+      }),
+    });
+    expect(JSON.stringify(power)).not.toMatch(/unused|provider_private_field/);
   });
 
   it("fails closed with a path-neutral error on malformed axes or unreadable evidence", async () => {


### PR DESCRIPTION
## Summary
- add estimated critical power to Plan readiness views
- connect athlete-facing presentation with planning contracts and cycling analysis
- cover the new calculation and UI flow with focused tests

## Verification
- rebased directly onto the current Plan epic
- required CI must pass before merge