### PR TITLE
chore(lint): clear existing Oxlint warnings

### DIFF
--- a/apps/desktop-renderer/src/onboarding/lanes.ts
+++ b/apps/desktop-renderer/src/onboarding/lanes.ts
@@ -47,8 +47,8 @@ function offersProvider(
 
 export function offeredLanes(
   configuration: OnboardingLlmConfiguration | null,
-  wizard: OnboardingState,
-  currentLane: SetupLane | null = null,
+  _wizard: OnboardingState,
+  _currentLane: SetupLane | null = null,
 ): readonly SetupLane[] {
   if (configuration === null) return [];
   const lanes: SetupLane[] = [];

--- a/apps/desktop-renderer/tests/matchmedia.ts
+++ b/apps/desktop-renderer/tests/matchmedia.ts
@@ -28,5 +28,5 @@ export function matchMediaListenerCount(): number {
 
 export function setPrefersDark(value: boolean): void {
   prefersDark = value;
-  for (const listener of [...listeners]) listener();
+  for (const listener of Array.from(listeners)) listener();
 }

--- a/apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-claude-cli-lane.test.tsx
@@ -1,6 +1,6 @@
 import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { OnboardingBridge, OnboardingLlmConfiguration } from "../src/onboarding/bridge.js";
 import type { ClaudeCliState } from "../src/onboarding/constants.js";
 import { claudeCliPresentation } from "../src/onboarding/credential-presentation.js";

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -56,7 +56,7 @@ async function startElectron(flag, env, extraArgs = []) {
     pendingLine = parts.pop() ?? "";
     for (const line of parts) {
       lines.push(line);
-      for (const waiter of [...waiters]) waiter();
+      for (const waiter of waiters.slice()) waiter();
     }
   });
   child.stderr.on("data", (chunk) => {

--- a/apps/desktop/scripts/package-inventory.mjs
+++ b/apps/desktop/scripts/package-inventory.mjs
@@ -117,6 +117,12 @@ const removedMainManifestKeys = new Set([
   "devDependencies",
 ]);
 
+function trimTrailingNullCharacters(value) {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 0) end -= 1;
+  return value.slice(0, end);
+}
+
 export class PackageLayoutError extends Error {
   constructor(message) {
     super(message);
@@ -278,7 +284,9 @@ function machoIdentity(bytes, label, expectedFileType, kind) {
     if (
       command === MACH_O_SEGMENT_64_COMMAND &&
       size === MACH_O_SEGMENT_64_COMMAND_BYTES &&
-      bytes.subarray(offset + 8, offset + 24).toString("latin1").replace(/\0+$/u, "") ===
+      trimTrailingNullCharacters(
+        bytes.subarray(offset + 8, offset + 24).toString("latin1"),
+      ) ===
         MACH_O_LINK_EDIT_SEGMENT
     ) {
       if (linkEditCommand !== undefined) fail("invalid Mach-O link edit segment", label);

--- a/packages/coach-contract/src/engine.ts
+++ b/packages/coach-contract/src/engine.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { TurnEvent } from "./turn-event.js";
-import { AthleteStateSchema, type AthleteState } from "./athlete-state.js";
+import type { AthleteState } from "./athlete-state.js";
 
 export const ChatRequestSchema = z
   .object({

--- a/packages/coach/src/reference-capture-command.ts
+++ b/packages/coach/src/reference-capture-command.ts
@@ -10,7 +10,6 @@ import {
   readFile,
   realpath,
   rm,
-  stat,
   unlink,
 } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve, sep } from "node:path";
@@ -52,7 +51,7 @@ import {
   type ProducedLocalBundle,
   type VerifiedSnapshotReader,
 } from "@enduragent/kernel/reference/local-bundle";
-import { H, createIntervalsSourceRepository, runMigrations, type SqlReadStore, type SqlStore } from "@enduragent/kernel/store";
+import { H, createIntervalsSourceRepository, runMigrations, type SqlReadStore } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { createArchiveManager, createVerifiedSnapshotReader } from "@enduragent/kernel-node/archive";
 import { nodeFileSystem } from "@enduragent/kernel-node/filesystem";

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -118,15 +118,6 @@ describe("incremental backfill pages", () => {
     });
   }
 
-  function athleteHome(root: string, storeDir = root): AthleteHome {
-    return {
-      root,
-      storeDir,
-      archiveDir: join(root, "archive"),
-      configDir: join(root, "config"),
-    };
-  }
-
   it("sums dropped activity rows across pages and never counts the terminal replay twice", async () => {
     const value = await fresh();
     try {

--- a/packages/engine/src/agent/claude-cli/session.ts
+++ b/packages/engine/src/agent/claude-cli/session.ts
@@ -45,7 +45,7 @@ export type SanitizedQueryOptions = Options & {
   model: string;
 };
 
-const WINDOWS_COMMAND_UNSAFE_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f"&|<>^%!()]/u;
+const WINDOWS_COMMAND_UNSAFE_CHARACTER_PATTERN = /["&|<>^%!()]/u;
 const WINDOWS_MCP_CONFIG_FLAG = "--mcp-config";
 const WINDOWS_MCP_CONFIG_ROOT = ".enduragent";
 const WINDOWS_MCP_CONFIG_PREFIX = "claude-cli-mcp-";
@@ -105,6 +105,10 @@ function windowsMcpConfigFileSystem(
 }
 
 function safeWindowsCommandText(value: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return false;
+  }
   return !WINDOWS_COMMAND_UNSAFE_CHARACTER_PATTERN.test(value);
 }
 

--- a/packages/engine/src/agent/claude-cli/working-area.ts
+++ b/packages/engine/src/agent/claude-cli/working-area.ts
@@ -447,6 +447,7 @@ function readOwnershipToken(
   let descriptor: number | undefined;
   let token = "";
   let finalMetadata: Stats | undefined;
+  let readFailure: ClaudeWorkingAreaError | undefined;
   try {
     const nonblocking = platform === "win32" ? 0 : constants.O_NONBLOCK;
     descriptor = fileSystem.openSync(
@@ -486,17 +487,19 @@ function readOwnershipToken(
     assertFileAccess(path, fileSystem);
     finalMetadata = after;
   } catch (error) {
-    if (error instanceof ClaudeWorkingAreaError) throw error;
-    throw failure(stage, errorCode(error) === "ELOOP" ? "link-reparse" : "io-failure");
+    readFailure = error instanceof ClaudeWorkingAreaError
+      ? error
+      : failure(stage, errorCode(error) === "ELOOP" ? "link-reparse" : "io-failure");
   } finally {
     if (descriptor !== undefined) {
       try {
         fileSystem.closeSync(descriptor);
       } catch {
-        throw failure(stage, "io-failure");
+        readFailure ??= failure(stage, "io-failure");
       }
     }
   }
+  if (readFailure !== undefined) throw readFailure;
   if (finalMetadata === undefined) throw failure(stage, "identity-changed");
   return { metadata: finalMetadata, token };
 }

--- a/packages/engine/src/agent/codex-agent/mcp-endpoint.ts
+++ b/packages/engine/src/agent/codex-agent/mcp-endpoint.ts
@@ -217,7 +217,7 @@ export async function startCoachMcpEndpoint(
     close: async (): Promise<void> => {
       if (closed) return;
       closed = true;
-      for (const exchange of [...open]) {
+      for (const exchange of open) {
         open.delete(exchange);
         await exchange.transport.close();
         await exchange.server.close();

--- a/packages/engine/src/agent/prompt-fence.ts
+++ b/packages/engine/src/agent/prompt-fence.ts
@@ -45,7 +45,7 @@ export function isUntrustedEnvelope(
 // U+000A) + format (Cf) plus the explicit line/paragraph separators
 // (U+2028/U+2029, which are Zl/Zp and escape the Cc/Cf classes). Tabs are Cc
 // and are lossily stripped. Matches the reference sanitizer's semantics.
-const STRIP_INVISIBLE_RE = /[\x00-\x09\x0B-\x1F\x7F-\x9F\p{Cf}\u2028\u2029]/gu;
+const STRIP_INVISIBLE_RE = /[\p{Cc}\p{Cf}\u2028\u2029]/gu;
 
 /**
  * Neutralize an untrusted string before it is embedded in a prompt: normalize
@@ -56,7 +56,9 @@ const STRIP_INVISIBLE_RE = /[\x00-\x09\x0B-\x1F\x7F-\x9F\p{Cf}\u2028\u2029]/gu;
  * still collapses to the exact token and gets neutralized.
  */
 export function sanitizeUntrustedText(value: string): string {
-  const stripped = value.replace(/\r\n?/g, "\n").replace(STRIP_INVISIBLE_RE, "");
+  const stripped = value
+    .replace(/\r\n?/g, "\n")
+    .replace(STRIP_INVISIBLE_RE, (character) => character === "\n" ? character : "");
   let out = stripped;
   if (out.includes(ATHLETE_CONTEXT_FENCE_OPEN)) {
     out = out.split(ATHLETE_CONTEXT_FENCE_OPEN).join(FENCE_TOKEN_REPLACEMENT);

--- a/packages/engine/tests/codex-agent/mcp-endpoint.test.ts
+++ b/packages/engine/tests/codex-agent/mcp-endpoint.test.ts
@@ -274,7 +274,7 @@ describe("codex-agent MCP endpoint", () => {
           headers: {
             "content-type": "application/json",
             accept: "application/json, text/event-stream",
-            ...(variant ?? {}),
+            ...variant,
           },
           body,
         });

--- a/packages/kernel-node/tests/sqlite-adapter.test.ts
+++ b/packages/kernel-node/tests/sqlite-adapter.test.ts
@@ -30,10 +30,12 @@ describe("openSqliteStorage adapter", () => {
     await store.exec("CREATE TABLE t(a TEXT, n REAL, b BLOB)");
     await store.run("INSERT INTO t(a, n, b) VALUES (?,?,?)", ["x", 1.5, new Uint8Array([9])]);
     const got = await store.get("SELECT a, n, b FROM t");
-    expect(got?.a).toBe("x");
-    expect(got?.n).toBe(1.5);
-    expect(got?.b).toBeInstanceOf(Uint8Array);
-    expect([...(got?.b as Uint8Array)]).toEqual([9]);
+    expect(got).toBeDefined();
+    if (got === undefined) throw new Error("expected SQLite row");
+    expect(got.a).toBe("x");
+    expect(got.n).toBe(1.5);
+    expect(got.b).toBeInstanceOf(Uint8Array);
+    expect([...(got.b as Uint8Array)]).toEqual([9]);
     const all = await store.all("SELECT a FROM t");
     expect(all).toHaveLength(1);
     const none = await store.get("SELECT a FROM t WHERE a = ?", ["nope"]);

--- a/packages/kernel/src/ingest/incremental-rekey.ts
+++ b/packages/kernel/src/ingest/incremental-rekey.ts
@@ -23,7 +23,6 @@ import {
   planClusters,
   readRepairFixerSettings,
   readSelectedSourceRows,
-  readSourceRevisionState,
   sourcePresentationRow,
   type IncrementalCandidateCacheRow,
 } from "./dedup-rekey.js";
@@ -32,7 +31,7 @@ import { DEFAULT_TRANSITION_WINDOW_S } from "./brick-adjacency.js";
 import { DEFAULT_TIER3_THRESHOLDS } from "./dedup.js";
 import { FIT_INGEST_VERSION } from "./types.js";
 import { qualityRankForFile, QUALITY_RANK } from "./quality-rank.js";
-import type { FileReport, ImportArtifact, ImportBatch, ImportReport, ImportReportDeps, PreparedFile, PreparedRepairEvent } from "./import-report.js";
+import type { FileReport, ImportBatch, ImportReport, ImportReportDeps, PreparedFile, PreparedRepairEvent } from "./import-report.js";
 
 function compareText(a: string, b: string): number { return a < b ? -1 : a > b ? 1 : 0; }
 function canonical(value: unknown): string { return JSON.stringify(sortKeys(value)); }
@@ -325,7 +324,7 @@ export async function importArtifactsIncrementally(batch: ImportBatch, deps: Imp
       hydrated.set(presentation.candidate.id, presentation.candidate);
     }
   }
-  for (const [id, candidate] of allCandidateById) if (hydrateIds.has(id)) allCandidateById.set(id, hydrated.get(id)!);
+  for (const id of allCandidateById.keys()) if (hydrateIds.has(id)) allCandidateById.set(id, hydrated.get(id)!);
   const hydratedDedup = await phase(deps, "topology", async () => planDedupFromPairStates(
     [...allCandidateById.values()], [...allSummaryById.values()], confirmations, dedupPairStates(topology.dedup),
   ));

--- a/packages/kernel/tests/store-export.test.ts
+++ b/packages/kernel/tests/store-export.test.ts
@@ -5,7 +5,6 @@ import {
   decodeContainer,
   encodeContainer,
   EXPORT_WARNING,
-  EXPORT_FORMAT_VERSION,
   CONTAINER_MAGIC,
   PBKDF2_ITERATIONS,
   ExportFormatError,


### PR DESCRIPTION
## Summary
- remove unused imports, variables, and parameters
- simplify unnecessary spread operations while preserving snapshot iteration where needed
- replace control-character regex warnings without weakening sanitization
- make SQLite test narrowing explicit and prevent ownership-token close failures from masking earlier failures

## Verification
- pnpm check
- focused Vitest suite: 218 passed
- Oxlint: 0 warnings and 0 errors

No changeset: internal cleanup with no user-visible behavior change.