### PR TITLE
ci(test): shorten required test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  check:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -23,17 +23,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
-      - run: pnpm test
-      - run: pnpm s8a
-      - run: pnpm s8a --self-test
-      - name: Coverage (measure-only, per-directory)
-        run: pnpm test:coverage
-      - name: Upload coverage report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-report
-          path: coverage/
-          if-no-files-found: error
       - name: Changeset presence (warn-only)
         if: github.event_name == 'pull_request'
         run: |
@@ -48,6 +37,61 @@ jobs:
           else
             echo "::warning::No changeset found for this PR. Behavioral/user-facing changes should ship a .changeset/*.md (see .changeset/README.md). chore:/ci: PRs are exempt."
           fi
+
+  test_shards:
+    name: test shard ${{ matrix.shard }}/2
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        # Reads the exact `packageManager` pin from root package.json.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm -r build
+      - run: pnpm exec vitest run --shard=${{ matrix.shard }}/2
+
+  s8a:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        # Reads the exact `packageManager` pin from root package.json.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm -r build
+      - run: pnpm s8a
+      - run: pnpm s8a --self-test
+
+  test:
+    needs: [check, test_shards, s8a]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every test lane
+        env:
+          CHECK_RESULT: ${{ needs.check.result }}
+          SHARDS_RESULT: ${{ needs.test_shards.result }}
+          S8A_RESULT: ${{ needs.s8a.result }}
+        run: |
+          printf 'check=%s\ntest-shards=%s\ns8a=%s\n' "$CHECK_RESULT" "$SHARDS_RESULT" "$S8A_RESULT"
+          for result in "$CHECK_RESULT" "$SHARDS_RESULT" "$S8A_RESULT"; do
+            if [ "$result" != "success" ]; then
+              exit 1
+            fi
+          done
 
   smoke:
     runs-on: ubuntu-latest

--- a/apps/desktop/tests/self-test-resources.test.ts
+++ b/apps/desktop/tests/self-test-resources.test.ts
@@ -4,7 +4,7 @@ import { cp, lstat, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { METRIC_REGISTRY } from "@enduragent/kernel/reference/registry";
 import { mean, pythonSum, sampleStdev } from "@enduragent/kernel/reference/metrics";
 import { deviationMap } from "../scripts/self-test-deviations.js";
@@ -15,6 +15,9 @@ const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = resolve(desktopRoot, "../..");
 const generatedRoot = join(desktopRoot, "dist");
 const roots: string[] = [];
+let firstGeneratedMatrix: Buffer;
+let secondGeneratedMatrix: Buffer;
+let canonicalGeneratedRoot: string;
 
 afterAll(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
@@ -27,6 +30,24 @@ async function generate(): Promise<Buffer> {
   });
   return readFile(join(generatedRoot, "self-test-asar/resources/self-test/matrix.json"));
 }
+
+beforeAll(async () => {
+  firstGeneratedMatrix = await generate();
+  secondGeneratedMatrix = await generate();
+  canonicalGeneratedRoot = await mkdtemp(join(tmpdir(), "self-test-generated-"));
+  roots.push(canonicalGeneratedRoot);
+  await Promise.all([
+    cp(join(generatedRoot, "self-test-asar"), join(canonicalGeneratedRoot, "self-test-asar"), {
+      recursive: true,
+    }),
+    cp(join(generatedRoot, "self-test-runner"), join(canonicalGeneratedRoot, "self-test-runner"), {
+      recursive: true,
+    }),
+    cp(join(generatedRoot, "extra-resources"), join(canonicalGeneratedRoot, "extra-resources"), {
+      recursive: true,
+    }),
+  ]);
+});
 
 function seeded(seed: number): () => number {
   let state = seed >>> 0;
@@ -53,11 +74,9 @@ describe("packaged self-test resources", () => {
     expect([...deviationMap(source.replaceAll("\n", "\r\n"))]).toEqual(expected);
   });
 
-  it("generates a deterministic complete matrix and exact public bundle", async () => {
-    const first = await generate();
-    const second = await generate();
-    expect(second.equals(first)).toBe(true);
-    const matrix = JSON.parse(first.toString("utf8")) as {
+  it("generates a deterministic complete matrix and exact public bundle", () => {
+    expect(secondGeneratedMatrix.equals(firstGeneratedMatrix)).toBe(true);
+    const matrix = JSON.parse(firstGeneratedMatrix.toString("utf8")) as {
       fixtures: Array<{ slug: string }>;
       parityCases: Array<{ caseId: string; fixture: string; metric: string }>;
       differentialCases: Array<{ caseId: string; fixture: string; op: string }>;
@@ -74,7 +93,9 @@ describe("packaged self-test resources", () => {
         matrix.parityCases.some((parity) => parity.caseId === item.caseId),
       ),
     ).toBe(false);
-    const runner = require(join(generatedRoot, "self-test-runner/self-test-runner.cjs")) as unknown;
+    const runner = require(
+      join(canonicalGeneratedRoot, "self-test-runner/self-test-runner.cjs"),
+    ) as unknown;
     expect(Object.keys(runner as object)).toEqual(["runSelfTest"]);
   }, 30_000);
 
@@ -104,15 +125,17 @@ describe("packaged self-test resources", () => {
   }, 180_000);
 
   it("stages disjoint byte-identical resources and preserves builder inputs", async () => {
-    await generate();
     const [insideMatrix, outsideMatrix, insideChecksum, outsideChecksum, builder, bundle] =
       await Promise.all([
-        readFile(join(generatedRoot, "self-test-asar/resources/self-test/matrix.json")),
-        readFile(join(generatedRoot, "extra-resources/self-test/matrix.json")),
-        readFile(join(generatedRoot, "self-test-asar/resources/self-test/matrix.sha256")),
-        readFile(join(generatedRoot, "extra-resources/self-test/matrix.sha256")),
+        readFile(join(canonicalGeneratedRoot, "self-test-asar/resources/self-test/matrix.json")),
+        readFile(join(canonicalGeneratedRoot, "extra-resources/self-test/matrix.json")),
+        readFile(join(canonicalGeneratedRoot, "self-test-asar/resources/self-test/matrix.sha256")),
+        readFile(join(canonicalGeneratedRoot, "extra-resources/self-test/matrix.sha256")),
         readFile(join(desktopRoot, "electron-builder.yml"), "utf8"),
-        readFile(join(generatedRoot, "extra-resources/self-test/self-test-runner.cjs"), "utf8"),
+        readFile(
+          join(canonicalGeneratedRoot, "extra-resources/self-test/self-test-runner.cjs"),
+          "utf8",
+        ),
       ]);
     expect(outsideMatrix.equals(insideMatrix)).toBe(true);
     expect(outsideChecksum.equals(insideChecksum)).toBe(true);
@@ -121,11 +144,15 @@ describe("packaged self-test resources", () => {
     expect(bundle).not.toMatch(/vitest|process\.exit|process\.exitCode|console\./iu);
     const root = await mkdtemp(join(tmpdir(), "self-test-layout-"));
     roots.push(root);
-    await cp(join(generatedRoot, "self-test-asar"), join(root, "app.asar"), { recursive: true });
-    await cp(join(generatedRoot, "extra-resources/self-test"), join(root, "self-test"), {
+    await cp(join(canonicalGeneratedRoot, "self-test-asar"), join(root, "app.asar"), {
       recursive: true,
     });
-    const loaded = require(join(generatedRoot, "self-test-runner/self-test-runner.cjs")) as {
+    await cp(join(canonicalGeneratedRoot, "extra-resources/self-test"), join(root, "self-test"), {
+      recursive: true,
+    });
+    const loaded = require(
+      join(canonicalGeneratedRoot, "self-test-runner/self-test-runner.cjs"),
+    ) as {
       runSelfTest(input: { resourcesPath: string }): { ok: boolean };
     };
     expect(loaded.runSelfTest({ resourcesPath: root }).ok).toBe(true);
@@ -139,18 +166,21 @@ describe("packaged self-test resources", () => {
   ] as const)(
     "classifies %s %s corruption",
     async (location, resource, relativePath) => {
-      await generate();
       const root = await mkdtemp(join(tmpdir(), "self-test-corruption-"));
       roots.push(root);
-      await cp(join(generatedRoot, "self-test-asar"), join(root, "app.asar"), { recursive: true });
-      await cp(join(generatedRoot, "extra-resources/self-test"), join(root, "self-test"), {
+      await cp(join(canonicalGeneratedRoot, "self-test-asar"), join(root, "app.asar"), {
+        recursive: true,
+      });
+      await cp(join(canonicalGeneratedRoot, "extra-resources/self-test"), join(root, "self-test"), {
         recursive: true,
       });
       const target = join(root, relativePath);
       const bytes = await readFile(target);
       bytes[0] = bytes[0] === 97 ? 98 : 97;
       await writeFile(target, bytes);
-      const loaded = require(join(generatedRoot, "self-test-runner/self-test-runner.cjs")) as {
+      const loaded = require(
+        join(canonicalGeneratedRoot, "self-test-runner/self-test-runner.cjs"),
+      ) as {
         runSelfTest(input: { resourcesPath: string }): unknown;
       };
       expect(loaded.runSelfTest({ resourcesPath: root })).toMatchObject({

--- a/packages/coach/tests/backfill-sigkill.test.ts
+++ b/packages/coach/tests/backfill-sigkill.test.ts
@@ -9,72 +9,155 @@ import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 
 const roots: string[] = [];
-afterAll(() => { for (const root of roots) rmSync(root, { recursive: true, force: true }); });
+const children = new Set<ReturnType<typeof spawn>>();
+afterAll(async () => {
+  const active = [...children];
+  for (const child of active) {
+    if (child.pid === undefined || child.exitCode !== null || child.signalCode !== null) continue;
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+    }
+  }
+  await Promise.all(active.map((child) => waitExit(child, 5_000)));
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
 const taskRoot = process.cwd();
 const childPath = join(taskRoot, "packages/coach/tests/fixtures/backfill-child.ts");
 const loader = pathToFileURL(join(taskRoot, "node_modules/tsx/dist/loader.mjs")).href;
 
 function launch(home: string, alignment: string, point: string) {
-  return spawn(process.execPath, ["--import", loader, childPath, home, alignment, point], { detached: true, stdio: ["ignore", "pipe", "pipe"] });
+  const child = spawn(process.execPath, ["--import", loader, childPath, home, alignment, point], {
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  children.add(child);
+  child.once("exit", () => children.delete(child));
+  return child;
 }
-async function waitFor(child: ReturnType<typeof launch>, token: string, timeout = 10_000): Promise<void> {
+async function waitFor(
+  child: ReturnType<typeof launch>,
+  token: string,
+  timeout = 30_000,
+): Promise<void> {
   let output = "";
   await new Promise<void>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(`child marker timeout: ${output}`)), timeout);
-    child.stdout!.on("data", (value) => { output += String(value); if (output.includes(token)) { clearTimeout(timer); resolve(); } });
-    child.stderr!.on("data", (value) => { output += String(value); });
-    child.once("exit", (code) => { if (!output.includes(token)) { clearTimeout(timer); reject(new Error(`child exited ${code}: ${output}`)); } });
+    child.stdout!.on("data", (value) => {
+      output += String(value);
+      if (output.includes(token)) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.stderr!.on("data", (value) => {
+      output += String(value);
+    });
+    child.once("exit", (code) => {
+      if (!output.includes(token)) {
+        clearTimeout(timer);
+        reject(new Error(`child exited ${code}: ${output}`));
+      }
+    });
   });
 }
-async function waitExit(child: ReturnType<typeof launch>, timeout = 10_000): Promise<void> {
+async function waitExit(child: ReturnType<typeof spawn>, timeout = 30_000): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) return;
-  await new Promise<void>((resolve, reject) => { const timer = setTimeout(() => reject(new Error("child exit timeout")), timeout);
-    child.once("exit", () => { clearTimeout(timer); resolve(); }); });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("child exit timeout")), timeout);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
 }
 async function waitGroupExit(pid: number): Promise<void> {
   const deadline = Date.now() + 10_000;
   for (;;) {
-    try { process.kill(-pid, 0); } catch (error) { if ((error as NodeJS.ErrnoException).code === "ESRCH") return; throw error; }
+    try {
+      process.kill(-pid, 0);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+      throw error;
+    }
     if (Date.now() >= deadline) throw new Error("process group survived SIGKILL");
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
 }
 async function canonical(home: string): Promise<string> {
-  const store = openSqliteStorage(join(home, "store.db")); await runMigrations(store, MIGRATIONS);
-  const result = await dumpStore(store); await store.close(); return result;
+  const store = openSqliteStorage(join(home, "store.db"));
+  await runMigrations(store, MIGRATIONS);
+  const result = await dumpStore(store);
+  await store.close();
+  return result;
 }
 
 describe("real process-group kill and resume", () => {
-  it("kills all five transaction boundaries across four page alignments", { timeout: 240_000 }, async () => {
-    const points = ["before-begin", "after-evidence", "after-derived", "after-watermark", "after-commit"];
-    const alignments = ["empty", "exact", "before", "after"];
-    let cases = 0;
-    for (const alignment of alignments) {
-      const control = mkdtempSync(join(tmpdir(), `backfill-control-${alignment}-`)); roots.push(control);
-      const controlChild = launch(control, alignment, "none"); await waitFor(controlChild, "COMPLETED"); await waitExit(controlChild);
-      const expected = await canonical(control);
-      const controlStore = openSqliteStorage(join(control, "store.db"));
-      const expectedCount = await controlStore.get("SELECT count(*) AS n FROM raw_file"); await controlStore.close();
-      for (const point of points) {
-        const home = mkdtempSync(join(tmpdir(), `backfill-kill-${alignment}-`)); roots.push(home);
-        const child = launch(home, alignment, point); await waitFor(child, `BOUNDARY ${point}`);
-        expect(child.pid).toBeTypeOf("number"); process.kill(-child.pid!, "SIGKILL"); await waitExit(child); await waitGroupExit(child.pid!);
-        const killed = openSqliteStorage(join(home, "store.db")); await runMigrations(killed, MIGRATIONS);
-        const killedRaw = await killed.get("SELECT count(*) AS n FROM raw_file");
-        const killedWatermark = await killed.get("SELECT watermark FROM source_watermark WHERE source='intervals-icu' AND lane='bulk-fit'");
-        const committed = killedWatermark === undefined ? 0
-          : Number((JSON.parse(String(killedWatermark.watermark)) as { last_key: string }).last_key);
-        expect(committed).toBeLessThanOrEqual(Number(killedRaw!.n));
-        expect(Number(killedRaw!.n) - committed).toBeLessThanOrEqual(4);
-        await killed.close();
-        const resumed = launch(home, alignment, "none"); await waitFor(resumed, "COMPLETED"); await waitExit(resumed);
-        expect(await canonical(home)).toBe(expected);
-        const store = openSqliteStorage(join(home, "store.db"));
-        expect(await store.get("SELECT count(*) AS n FROM raw_file")).toEqual(expectedCount);
-        expect(await store.get("SELECT count(*)-count(DISTINCT sha256) AS n FROM raw_file")).toEqual({ n: 0 }); await store.close();
-        cases += 1;
+  const alignmentGroups = [
+    ["empty", "after"],
+    ["exact", "before"],
+  ] as const;
+  it.concurrent.each(alignmentGroups)(
+    "kills all five transaction boundaries for %s/%s alignments",
+    { timeout: 240_000 },
+    async (firstAlignment, secondAlignment) => {
+      const points = [
+        "before-begin",
+        "after-evidence",
+        "after-derived",
+        "after-watermark",
+        "after-commit",
+      ];
+      let cases = 0;
+      for (const alignment of [firstAlignment, secondAlignment]) {
+        const control = mkdtempSync(join(tmpdir(), `backfill-control-${alignment}-`));
+        roots.push(control);
+        const controlChild = launch(control, alignment, "none");
+        await waitFor(controlChild, "COMPLETED");
+        await waitExit(controlChild);
+        const expected = await canonical(control);
+        const controlStore = openSqliteStorage(join(control, "store.db"));
+        const expectedCount = await controlStore.get("SELECT count(*) AS n FROM raw_file");
+        await controlStore.close();
+        for (const point of points) {
+          const home = mkdtempSync(join(tmpdir(), `backfill-kill-${alignment}-`));
+          roots.push(home);
+          const child = launch(home, alignment, point);
+          await waitFor(child, `BOUNDARY ${point}`);
+          expect(child.pid).toBeTypeOf("number");
+          process.kill(-child.pid!, "SIGKILL");
+          await waitExit(child);
+          await waitGroupExit(child.pid!);
+          const killed = openSqliteStorage(join(home, "store.db"));
+          await runMigrations(killed, MIGRATIONS);
+          const killedRaw = await killed.get("SELECT count(*) AS n FROM raw_file");
+          const killedWatermark = await killed.get(
+            "SELECT watermark FROM source_watermark WHERE source='intervals-icu' AND lane='bulk-fit'",
+          );
+          const committed =
+            killedWatermark === undefined
+              ? 0
+              : Number(
+                  (JSON.parse(String(killedWatermark.watermark)) as { last_key: string }).last_key,
+                );
+          expect(committed).toBeLessThanOrEqual(Number(killedRaw!.n));
+          expect(Number(killedRaw!.n) - committed).toBeLessThanOrEqual(4);
+          await killed.close();
+          const resumed = launch(home, alignment, "none");
+          await waitFor(resumed, "COMPLETED");
+          await waitExit(resumed);
+          expect(await canonical(home)).toBe(expected);
+          const store = openSqliteStorage(join(home, "store.db"));
+          expect(await store.get("SELECT count(*) AS n FROM raw_file")).toEqual(expectedCount);
+          expect(
+            await store.get("SELECT count(*)-count(DISTINCT sha256) AS n FROM raw_file"),
+          ).toEqual({ n: 0 });
+          await store.close();
+          cases += 1;
+        }
       }
-    }
-    expect(cases).toBe(20);
-  });
+      expect(cases).toBe(10);
+    },
+  );
 });

--- a/packages/coach/tests/fixtures/backfill-child.ts
+++ b/packages/coach/tests/fixtures/backfill-child.ts
@@ -11,20 +11,34 @@ import { runBackfillPages } from "../../src/backfill.js";
 const [home, alignment = "exact", killPoint = "none"] = process.argv.slice(2);
 if (!home) throw new TypeError("home is required");
 await mkdir(home, { recursive: true });
-const base = openSqliteStorage(join(home, "store.db")); await runMigrations(base, MIGRATIONS);
+const base = openSqliteStorage(join(home, "store.db"));
+await runMigrations(base, MIGRATIONS);
 const totals: Record<string, number> = { empty: 3, exact: 4, before: 3, after: 5 };
-const total = totals[alignment]; if (total === undefined) throw new TypeError("invalid alignment");
-const fixtureNames = ["brick-cycling.fit", "brick-running.fit", "triathlon-multisport.fit",
-  "duathlon-run-bike-run.fit", "dual-developer-index.fit"] as const;
-const fixtureBytes = await Promise.all(fixtureNames.map((name) => readFile(join(process.cwd(), "packages/kernel-node/tests/fixtures/ingest", name))));
+const total = totals[alignment];
+if (total === undefined) throw new TypeError("invalid alignment");
+const fixtureNames = [
+  "brick-cycling.fit",
+  "brick-running.fit",
+  "triathlon-multisport.fit",
+  "duathlon-run-bike-run.fit",
+  "dual-developer-index.fit",
+] as const;
+const fixtureBytes = await Promise.all(
+  fixtureNames.map((name) =>
+    readFile(join(process.cwd(), "packages/kernel-node/tests/fixtures/ingest", name)),
+  ),
+);
 const fixtureEpochs = [899_585_600, 899_588_900, 899_565_600, 899_575_600, 899_625_600] as const;
-let boundaryUsed = false, committedRows = 0;
+let boundaryUsed = false,
+  committedRows = 0;
 
 async function boundary(point: string): Promise<void> {
   if (boundaryUsed || killPoint !== point) return;
   boundaryUsed = true;
   process.stdout.write(`BOUNDARY ${point} rows=${committedRows}\n`);
-  await new Promise<void>(() => { setInterval(() => {}, 1_000); });
+  await new Promise<void>((_resolve, reject) => {
+    setTimeout(() => reject(new Error(`boundary ${point} was not terminated`)), 60_000);
+  });
 }
 
 const store: SqlStore & MigratorStore = {
@@ -35,43 +49,90 @@ const store: SqlStore & MigratorStore = {
     await base.run(sql, params);
     if (sql.startsWith("INSERT INTO source_watermark")) await boundary("after-watermark");
   },
-  get: (sql, params) => base.get(sql, params), all: (sql, params) => base.all(sql, params), close: () => base.close(),
-  getUserVersion: () => base.getUserVersion(), setUserVersion: (version) => base.setUserVersion(version),
+  get: (sql, params) => base.get(sql, params),
+  all: (sql, params) => base.all(sql, params),
+  close: () => base.close(),
+  getUserVersion: () => base.getUserVersion(),
+  setUserVersion: (version) => base.setUserVersion(version),
   async transaction(work) {
     await boundary("before-begin");
     const result = await base.transaction(work);
-    const watermark = await base.get("SELECT watermark FROM source_watermark WHERE source='intervals-icu' AND lane='bulk-fit'");
-    if (watermark !== undefined) committedRows = Number((JSON.parse(String(watermark.watermark)) as { last_key: string | null }).last_key ?? total);
+    const watermark = await base.get(
+      "SELECT watermark FROM source_watermark WHERE source='intervals-icu' AND lane='bulk-fit'",
+    );
+    if (watermark !== undefined)
+      committedRows = Number(
+        (JSON.parse(String(watermark.watermark)) as { last_key: string | null }).last_key ?? total,
+      );
     await boundary("after-commit");
     return result;
   },
 };
 const node = createNodeImportRuntime({ archiveDir: join(home, "archive"), store });
-const cursor = (count: number, complete: boolean): string => JSON.stringify({ v: 1, cycle: 0,
-  window_start: "2010-01-01", window_end: "2010-12-31", last_key: String(count), complete });
+const cursor = (count: number, complete: boolean): string =>
+  JSON.stringify({
+    v: 1,
+    cycle: 0,
+    window_start: "2010-01-01",
+    window_end: "2010-12-31",
+    last_key: String(count),
+    complete,
+  });
 let emittedInitialEmpty = false;
-const source = { id: "intervals-icu", capabilities: { activities: true, streams: true, rawFiles: true, wellness: true,
-  plannedWorkoutPush: false, backfillDepth: { kind: "full-history" } },
-pull(watermark) {
-  return (async function* (): AsyncIterable<IntervalsIcuArtifact> {
-    if (alignment === "empty" && watermark.value === null && !emittedInitialEmpty) {
-      emittedInitialEmpty = true;
-      yield { kind: "checkpoint", watermark: { source: "intervals-icu", lane: "bulk-fit", value: cursor(0, false) } };
-      return;
-    }
-    const count = watermark.value === null ? 0 : Number((JSON.parse(watermark.value) as { last_key: string }).last_key);
-    const end = Math.min(total, count + 4);
-    for (let index = count; index < end; index += 1) {
-      const bytes = new Uint8Array(fixtureBytes[index]!);
-      const archiveInstant = { epochSeconds: fixtureEpochs[index]! };
-      const archive = await node.archive.writeArtifact(bytes, "fit", archiveInstant);
-      yield { kind: "raw-file", source: "intervals-icu", lane: "bulk-fit", externalId: `synthetic-${index}`,
-        archiveInstant, archive, container: null, file: { input_path: `synthetic-${index}.fit`, bytes, ext: "fit" } };
-    }
-    yield { kind: "checkpoint", watermark: { source: "intervals-icu", lane: "bulk-fit", value: cursor(end, end >= total) } };
-  })();
-} } as IntervalsIcuSource;
+const source = {
+  id: "intervals-icu",
+  capabilities: {
+    activities: true,
+    streams: true,
+    rawFiles: true,
+    wellness: true,
+    plannedWorkoutPush: false,
+    backfillDepth: { kind: "full-history" },
+  },
+  pull(watermark) {
+    return (async function* (): AsyncIterable<IntervalsIcuArtifact> {
+      if (alignment === "empty" && watermark.value === null && !emittedInitialEmpty) {
+        emittedInitialEmpty = true;
+        yield {
+          kind: "checkpoint",
+          watermark: { source: "intervals-icu", lane: "bulk-fit", value: cursor(0, false) },
+        };
+        return;
+      }
+      const count =
+        watermark.value === null
+          ? 0
+          : Number((JSON.parse(watermark.value) as { last_key: string }).last_key);
+      const end = Math.min(total, count + 4);
+      for (let index = count; index < end; index += 1) {
+        const bytes = new Uint8Array(fixtureBytes[index]!);
+        const archiveInstant = { epochSeconds: fixtureEpochs[index]! };
+        const archive = await node.archive.writeArtifact(bytes, "fit", archiveInstant);
+        yield {
+          kind: "raw-file",
+          source: "intervals-icu",
+          lane: "bulk-fit",
+          externalId: `synthetic-${index}`,
+          archiveInstant,
+          archive,
+          container: null,
+          file: { input_path: `synthetic-${index}.fit`, bytes, ext: "fit" },
+        };
+      }
+      yield {
+        kind: "checkpoint",
+        watermark: { source: "intervals-icu", lane: "bulk-fit", value: cursor(end, end >= total) },
+      };
+    })();
+  },
+} as IntervalsIcuSource;
 
-await runBackfillPages({ store, node, source, clock: { now: () => 1_300_000_000_000, monotonicNow: () => 1_000 }, batchSize: 4 });
+await runBackfillPages({
+  store,
+  node,
+  source,
+  clock: { now: () => 1_300_000_000_000, monotonicNow: () => 1_000 },
+  batchSize: 4,
+});
 await store.close();
 process.stdout.write(`COMPLETED rows=${total}\n`);


### PR DESCRIPTION
## Summary

- remove measure-only coverage from required CI while retaining the local `test:coverage` script
- run the no-coverage Vitest suite across two independent CI shards and preserve `CI / test` as the aggregate required gate
- bound the SIGKILL backfill test to two concurrent alignment groups while preserving all 20 kill scenarios and 44 subprocess launches
- generate deterministic desktop self-test resources twice, then copy the canonical output for staging and corruption cases

## Verification

- `pnpm check` — passed
- `pnpm exec vitest run packages/coach/tests/backfill-sigkill.test.ts --reporter=verbose` — passed repeatedly under Node 24; latest run 29.05s
- `pnpm --filter @enduragent/desktop test:self-test-resources` — 9 passed
- full `pnpm test` — 9,974 passed and 17 skipped in 325.60s; two untouched tests hit their five-second timeout under aggregate local load, then both passed when rerun individually
- GitHub Actions — all jobs passed; `check` 2m35s, shard 1 3m35s, shard 2 3m10s, aggregate `CI / test` passed
- `git diff --check` — passed

No changeset: test and CI infrastructure only.
