### PR TITLE
fix(chat): converge final Plan desktop QA

### DIFF
--- a/.changeset/plan-desktop-qa.md
+++ b/.changeset/plan-desktop-qa.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/coach": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: The active Plan now shows race-day Form and goal feasibility at a glance, with clearer race-week and readiness details. Ended Plans can open their saved coach conversation as read-only history.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -280,6 +280,8 @@ export function bootRenderer(): Disposer {
     verifyPlanCleanup: () => planAdapter.verifyPlanCleanup(),
     openRaceOutcome: () => planAdapter.openRaceOutcome(),
     recordRaceOutcome: (outcome) => planAdapter.recordRaceOutcome(outcome),
+    openEndedConversation: () => planAdapter.openEndedConversation(),
+    closeEndedConversation: () => planAdapter.closeEndedConversation(),
     openAttention: (attentionId) => planAdapter.openAttention(attentionId),
     returnToCoach: () => planAdapter.returnToCoach(),
     retry: () => planAdapter.retry(),

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -99,6 +99,8 @@ export interface PlanViewAdapter {
   verifyPlanCleanup(): void;
   openRaceOutcome(): void;
   recordRaceOutcome(outcome: "completed" | "not-completed"): void;
+  openEndedConversation(): void;
+  closeEndedConversation(): void;
   openAttention(attentionId: string): void;
   returnToCoach(): void;
   retry(): void;
@@ -1269,6 +1271,44 @@ export function createPlanViewAdapter(input: {
         commandId: createCommandId(),
         planId: model.planId,
         outcome,
+      });
+    },
+    openEndedConversation() {
+      const model = planReadModel(input.read());
+      if (
+        model?.planId === null ||
+        model?.planId === undefined ||
+        model.scenarioId !== "PL-S089" ||
+        active !== null
+      ) {
+        return;
+      }
+      void execute({
+        transitionId: "PL-T39",
+        commandId: createCommandId(),
+        action: "open",
+        sourceScenarioId: "PL-S089",
+        destinationScenarioId: "PL-S102",
+        returnFocusId: model.planId,
+      });
+    },
+    closeEndedConversation() {
+      const model = planReadModel(input.read());
+      if (
+        model?.planId === null ||
+        model?.planId === undefined ||
+        model.scenarioId !== "PL-S102" ||
+        active !== null
+      ) {
+        return;
+      }
+      void execute({
+        transitionId: "PL-T39",
+        commandId: createCommandId(),
+        action: "back",
+        sourceScenarioId: "PL-S102",
+        destinationScenarioId: "PL-S089",
+        returnFocusId: model.planId,
       });
     },
     openAttention(attentionId) {

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -124,6 +124,8 @@ export interface PlanActions {
   verifyPlanCleanup(): void;
   openRaceOutcome(): void;
   recordRaceOutcome(outcome: "completed" | "not-completed"): void;
+  openEndedConversation(): void;
+  closeEndedConversation(): void;
   openAttention(attentionId: string): void;
   returnToCoach(): void;
   retry(): void;

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -1086,6 +1086,32 @@ function PlanCoach(): ReactElement {
         })) ?? []);
   const decision = coach.decision ?? data?.decision ?? null;
 
+  if (model?.scenarioId === "PL-S102") {
+    return (
+      <section
+        className="grid gap-6 rounded-card bg-surface p-5 shadow-elev-1"
+        data-plan-scenario="PL-S102"
+      >
+        <div className="flex flex-col gap-row sm:flex-row sm:items-start sm:justify-between">
+          <div className={SUPPORT_PAIR}>
+            <h2 className="m-0 text-lg font-semibold">Plan conversation</h2>
+            <p className="m-0 text-ink-2">Read-only history for this ended Plan.</p>
+          </div>
+          <Button type="button" variant="outline" onClick={() => actions?.closeEndedConversation()}>
+            Back to ended Plan
+          </Button>
+        </div>
+        <div className="border-t border-line pt-row">
+          <ConversationTranscript
+            messages={messages}
+            timeline={coach.timeline}
+            historyControls={false}
+          />
+        </div>
+      </section>
+    );
+  }
+
   if (data?.ftp !== undefined && data.ftp !== null && FTP_SCENARIOS.has(model?.scenarioId ?? "")) {
     return <FtpResolution ftp={data.ftp} />;
   }
@@ -1604,8 +1630,7 @@ function DraftProjection(): ReactElement {
           <span className="rounded-chip bg-sunk px-3 py-1 text-sm text-primary">Draft</span>
         </div>
         {data?.course !== undefined ? (
-          <div className="grid gap-inset border-t border-line pt-5">
-            <h3 className="m-0 text-sm font-semibold">Race Course</h3>
+          <div className="border-t border-line pt-5">
             <RaceCoursePanel course={data.course} draft />
           </div>
         ) : null}
@@ -2245,7 +2270,13 @@ function RaceWeekProjection(props: {
               })}
             </p>
             <h3 className="m-0 text-lg font-semibold">{props.data.plan.name}</h3>
-            <p className="m-0 text-sm text-ink-2">Goal: {props.data.plan.primaryGoal}</p>
+            <p className="m-0 text-sm text-ink-2">
+              Goal: {props.data.plan.primaryGoal}
+              {props.data.readiness?.courseEstimate.rangeMinutes === null ||
+              props.data.readiness?.courseEstimate.rangeMinutes === undefined
+                ? ""
+                : ` · modeled finish ${finishRange(props.data.readiness.courseEstimate.rangeMinutes)} · with assumptions`}
+            </p>
           </div>
           {season.priority === null ? null : (
             <span className="self-start rounded-full border border-warn px-3 py-1 text-sm text-warn">
@@ -2326,7 +2357,9 @@ function RaceWeekProjection(props: {
                   </td>
                   <td
                     className={
-                      day.kind === "race" ? "px-5 py-row text-warn" : "px-5 py-row text-ink-2"
+                      day.kind === "race" || day.purpose === "Blocked"
+                        ? "px-5 py-row text-warn"
+                        : "px-5 py-row text-ink-2"
                     }
                   >
                     {day.purpose}
@@ -2349,6 +2382,62 @@ function formRange(readiness: PlanReadinessProjection): string {
   const range = readiness.form.raceRange;
   if (range === null) return "Unavailable";
   return `${signed(range.min)} to ${signed(range.max)}`;
+}
+
+function PredictionsSummary(props: {
+  readonly readiness: PlanReadinessProjection | undefined;
+}): ReactElement {
+  const actions = useEnduragentStore((state) => state.planActions);
+  const atRisk = props.readiness?.feasibility.verdict === "at-risk";
+  const verdict =
+    props.readiness === undefined
+      ? "Unavailable"
+      : atRisk
+        ? "At risk — here’s why"
+        : "On track — with assumptions";
+  return (
+    <section className="grid gap-row rounded-card bg-surface p-5 shadow-elev-1">
+      <h2 className="m-0 text-base font-semibold">Predictions</h2>
+      <div className="grid gap-row sm:grid-cols-2">
+        <div className={SUPPORT_PAIR}>
+          <p className="m-0 text-sm text-ink-2">Race-day form</p>
+          <strong className="text-2xl">
+            {props.readiness === undefined ? "Unavailable" : formRange(props.readiness)}
+          </strong>
+        </div>
+        <div className={SUPPORT_PAIR}>
+          <p className="m-0 text-sm text-ink-2">Goal feasibility</p>
+          <span
+            className={`inline-flex w-fit items-center gap-inset rounded-full border px-3 py-1 text-sm ${
+              props.readiness === undefined
+                ? "border-line-2 text-ink-2"
+                : atRisk
+                  ? "border-warn text-warn"
+                  : "border-ok text-ok"
+            }`}
+          >
+            {props.readiness === undefined ? null : atRisk ? (
+              <TriangleAlert className="size-4" aria-hidden="true" />
+            ) : (
+              <CheckCircle2 className="size-4" aria-hidden="true" />
+            )}
+            {verdict}
+          </span>
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <Button
+          id="plan-readiness-trigger"
+          type="button"
+          variant="ghost"
+          onClick={() => actions?.openReadiness()}
+        >
+          View race readiness
+          <ChevronRight className="size-4" aria-hidden="true" />
+        </Button>
+      </div>
+    </section>
+  );
 }
 
 function effortDuration(durationS: number): string {
@@ -2618,7 +2707,7 @@ function ReadinessProjection(props: {
       <section className="grid gap-6 rounded-card bg-surface p-5 shadow-elev-1">
         {header}
         <div className="grid gap-row border-t border-line pt-row md:grid-cols-2">
-          <div className={SUPPORT_PAIR}>
+          <div className={`${SUPPORT_PAIR} rounded-card bg-sunk p-4`}>
             <h3 className="m-0 text-sm font-semibold">Form trajectory to race day</h3>
             <strong className="text-2xl">
               {readiness.form.current === null ? "Unavailable" : signed(readiness.form.current)} →{" "}
@@ -2626,14 +2715,14 @@ function ReadinessProjection(props: {
             </strong>
             <p className="m-0 text-sm text-ink-2">Modeled from planned Load and normal recovery.</p>
           </div>
-          <div className={SUPPORT_PAIR}>
+          <div className={`${SUPPORT_PAIR} rounded-card bg-sunk p-4`}>
             <h3 className="m-0 text-sm font-semibold">Goal feasibility</h3>
             <span className="self-start rounded-full border border-ok px-3 py-1 text-sm text-ok">
-              On track · with assumptions
+              On track — with assumptions
             </span>
             <p className="m-0 text-sm text-ink-2">{readiness.feasibility.recommendation}</p>
           </div>
-          <div className={SUPPORT_PAIR}>
+          <div className={`${SUPPORT_PAIR} rounded-card bg-sunk p-4`}>
             <div className="flex items-center justify-between gap-inset">
               <h3 className="m-0 text-sm font-semibold">Estimated CP</h3>
               <div className="flex items-center gap-inset">
@@ -2694,7 +2783,7 @@ function ReadinessProjection(props: {
               </>
             )}
           </div>
-          <div className={SUPPORT_PAIR}>
+          <div className={`${SUPPORT_PAIR} rounded-card bg-sunk p-4`}>
             <h3 className="m-0 text-sm font-semibold">Course-based finish time</h3>
             <strong className="text-2xl">
               {readiness.courseEstimate.rangeMinutes === null
@@ -3019,15 +3108,6 @@ function ActiveProjection(): ReactElement {
           </div>
           <div className="flex flex-wrap justify-end gap-inset">
             <Button
-              id="plan-readiness-trigger"
-              type="button"
-              variant="outline"
-              onClick={() => actions?.openReadiness()}
-            >
-              <Activity className="size-4" aria-hidden="true" />
-              Race readiness
-            </Button>
-            <Button
               id="plan-season-trigger"
               type="button"
               variant="outline"
@@ -3063,6 +3143,8 @@ function ActiveProjection(): ReactElement {
           </div>
         </div>
       </section>
+
+      <PredictionsSummary readiness={data.readiness} />
 
       <section
         className="grid gap-row rounded-card bg-surface p-5 shadow-elev-1"
@@ -3755,9 +3837,22 @@ function EndedProjection(): ReactElement {
             </Button>
           </>
         ) : verified || data.raceOutcome !== null ? (
-          <Button type="button" disabled={actions === null} onClick={() => actions?.startPlan()}>
-            Start a new Plan
-          </Button>
+          <>
+            {model.scenarioId === "PL-S089" ? (
+              <Button
+                id="plan-ended-conversation-trigger"
+                type="button"
+                variant="outline"
+                disabled={actions === null}
+                onClick={() => actions?.openEndedConversation()}
+              >
+                View coach conversation
+              </Button>
+            ) : null}
+            <Button type="button" disabled={actions === null} onClick={() => actions?.startPlan()}>
+              Start a new Plan
+            </Button>
+          </>
         ) : null}
       </div>
     </section>

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -75,6 +75,8 @@ function actions(): PlanActions {
     verifyPlanCleanup: vi.fn(),
     openRaceOutcome: vi.fn(),
     recordRaceOutcome: vi.fn(),
+    openEndedConversation: vi.fn(),
+    closeEndedConversation: vi.fn(),
     openAttention: vi.fn(),
     returnToCoach: vi.fn(),
     retry: vi.fn(),
@@ -456,13 +458,26 @@ describe("Plan surface", () => {
       projection: "draft",
       planId: draft.planId,
       revision: 1,
-      data: planCoachData({ draft, plan, startDate }),
+      data: planCoachData({
+        draft,
+        plan,
+        startDate,
+        course: {
+          status: "omitted",
+          accepted: null,
+          candidate: null,
+          fileName: null,
+          detail: null,
+        },
+      }),
     });
     useEnduragentStore.setState({
       plan: { ...EMPTY_PLAN_SURFACE, hydration: { status: "ready", state }, lastReady: state },
       planActions,
     });
     render(<PlanView />);
+    expect(screen.getByRole("heading", { name: "Race Course · optional" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /^Race Course$/ })).not.toBeInTheDocument();
 
     expect(screen.getByText("58 workouts · 86 h · 12 weeks")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Change" }));
@@ -821,6 +836,83 @@ describe("Plan surface", () => {
     expect(screen.getByText("Not completed", { selector: "strong" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Start a new Plan" }));
     expect(planActions.startPlan).toHaveBeenCalledOnce();
+  });
+
+  it("opens an ended Plan conversation as read-only History", async () => {
+    const user = userEvent.setup();
+    const planActions = actions();
+    const planId = "00000000000000000000000003";
+    const plan = {
+      id: planId,
+      name: "Gran Fondo Almaty",
+      primaryGoal: "Finish in the front half",
+      startDate: "1998-07-13",
+      targetDate: "1998-10-04",
+      kind: "full-plan" as const,
+      totalWeeks: 12,
+      weekStartDay: 1,
+      workoutCount: 20,
+      plannedDurationS: 72_000,
+    };
+    const ended = planReadModel({
+      lifecycle: "ended",
+      scenarioId: "PL-S089",
+      projection: "ended",
+      planId,
+      reconciliation: {
+        status: "verified",
+        created: 0,
+        pending: 0,
+        failed: 0,
+        total: 0,
+        currentThrough: "1998-10-06",
+        error: null,
+      },
+      data: { plan, endedAtMs: 20, cleanupItems: [] },
+    });
+    useEnduragentStore.setState({
+      plan: {
+        ...EMPTY_PLAN_SURFACE,
+        hydration: { status: "ready", state: ended },
+        lastReady: ended,
+      },
+      planActions,
+    });
+    render(<PlanView />);
+
+    await user.click(screen.getByRole("button", { name: "View coach conversation" }));
+    expect(planActions.openEndedConversation).toHaveBeenCalledOnce();
+
+    const history = planReadModel({
+      lifecycle: "ended",
+      scenarioId: "PL-S102",
+      projection: "coach",
+      planId,
+      data: planCoachData({
+        messages: [
+          {
+            id: "coach-1",
+            turnId: null,
+            role: "coach",
+            text: "Let’s build this here in Plan.",
+          },
+          {
+            id: "athlete-1",
+            turnId: "turn-1",
+            role: "athlete",
+            text: "Gran Fondo Almaty on 4 October.",
+          },
+        ],
+      }),
+    });
+    act(() => useEnduragentStore.getState().setPlanHydration({ status: "ready", state: history }));
+    expect(screen.getByRole("heading", { name: "Plan conversation" })).toBeInTheDocument();
+    expect(screen.getByText("Gran Fondo Almaty on 4 October.")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: "Reply to your Plan coach" }),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Back to ended Plan" }));
+    expect(planActions.closeEndedConversation).toHaveBeenCalledOnce();
   });
 
   it("keeps replacement confirmation safe and cleanup recovery explicit", async () => {
@@ -1656,7 +1748,7 @@ describe("Plan surface", () => {
       ["2026-09-29", "Tue", "openers", "Openers · 3×1 min", 2_700, "Sharpen", "training"],
       ["2026-09-30", "Wed", "easy", "Easy endurance", 3_000, "Maintain", "training"],
       ["2026-10-01", "Thu", null, "Rest", null, "Absorb", "rest"],
-      ["2026-10-02", "Fri", "opener", "Race opener", 1_800, "Sharpen", "training"],
+      ["2026-10-02", "Fri", "opener", "Race opener", 1_800, "Blocked", "training"],
       ["2026-10-03", "Sat", "spin", "Pre-race spin", 3_600, "Prime", "training"],
       ["2026-10-04", "Sun", raceWorkoutId, "Gran Fondo Almaty", 18_000, "Race", "race"],
     ].map(([date, weekday, workoutId, name, durationS, purpose, kind]) => ({
@@ -1742,6 +1834,7 @@ describe("Plan surface", () => {
     expect(screen.getAllByText("5:00")).toHaveLength(2);
     expect(screen.getByText("8:05")).toBeInTheDocument();
     expect(screen.getByText(/Plan below is authoritative/u)).toBeInTheDocument();
+    expect(screen.getByText("Blocked")).toHaveClass("text-warn");
     expect(screen.getAllByRole("row")).toHaveLength(8);
     await user.click(screen.getByRole("button", { name: "Gran Fondo Almaty" }));
     expect(planActions.openWorkout).toHaveBeenCalledWith(raceWorkoutId);
@@ -1882,7 +1975,11 @@ describe("Plan surface", () => {
     });
     render(<PlanView />);
 
-    const trigger = screen.getByRole("button", { name: "Race readiness" });
+    expect(screen.getByRole("heading", { name: "Predictions" })).toBeInTheDocument();
+    expect(screen.getByText("Race-day form")).toBeInTheDocument();
+    expect(screen.getByText("+4 to +9")).toBeInTheDocument();
+    expect(screen.getByText("On track — with assumptions")).toBeInTheDocument();
+    const trigger = screen.getByRole("button", { name: "View race readiness" });
     await user.click(trigger);
     expect(planActions.openReadiness).toHaveBeenCalledOnce();
 
@@ -2049,7 +2146,7 @@ describe("Plan surface", () => {
     });
     act(() => useEnduragentStore.getState().setPlanHydration({ status: "ready", state: returned }));
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Race readiness" })).toHaveFocus(),
+      expect(screen.getByRole("button", { name: "View race readiness" })).toHaveFocus(),
     );
   });
 

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -100,6 +100,8 @@ function stubPlanActions(): PlanActions {
     closeDiscardConfirmation: vi.fn(),
     discardDraft: vi.fn(),
     openRevisionComposer: vi.fn(),
+    openEndedConversation: vi.fn(),
+    closeEndedConversation: vi.fn(),
     closeRevisionComposer: vi.fn(),
     openCoursePicker: vi.fn(),
     closeCoursePicker: vi.fn(),

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -64,6 +64,8 @@ function stubPlanActions(): PlanActions {
     closeDiscardConfirmation: vi.fn(),
     discardDraft: vi.fn(),
     openRevisionComposer: vi.fn(),
+    openEndedConversation: vi.fn(),
+    closeEndedConversation: vi.fn(),
     closeRevisionComposer: vi.fn(),
     openCoursePicker: vi.fn(),
     closeCoursePicker: vi.fn(),

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -10,6 +10,8 @@ import type {
   CoachOperations,
   SpendOperations,
   OperationProgressEvent,
+  PlanningOperations,
+  PlanProgressEvent,
   TelegramControlSnapshot,
   TurnEvent,
 } from "@enduragent/coach-contract";
@@ -165,6 +167,9 @@ export async function launchDesktopFixture(input: {
   readonly height: number;
   readonly colorScheme: "light" | "dark";
   readonly reducedMotion: boolean;
+  readonly executable?: string;
+  readonly applicationBundle?: string;
+  readonly hidden?: boolean;
   readonly seedConfig?: boolean;
   readonly sessionTimezonePinned?: false | "embedded" | "legacy";
   readonly extraEnv?: Readonly<Record<string, string>>;
@@ -313,7 +318,7 @@ export async function launchDesktopFixture(input: {
       >;
     },
   };
-  const operations: CoachOperations = {
+  const operations: CoachOperations & PlanningOperations = {
     async importFiles(request, onEvent) {
       const frames = await invoke("importFiles", request);
       for (const event of eventFrames(frames)) onEvent?.(event as OperationProgressEvent);
@@ -376,6 +381,18 @@ export async function launchDesktopFixture(input: {
         source: "cycling";
       };
     },
+    async getPlanState(request) {
+      return finalFrame(await invoke("getPlanState", request)) as Awaited<
+        ReturnType<NonNullable<PlanningOperations["getPlanState"]>>
+      >;
+    },
+    async executePlanTransition(request, onEvent) {
+      const frames = await invoke("executePlanTransition", request);
+      for (const event of eventFrames(frames)) onEvent?.(event as PlanProgressEvent);
+      return finalFrame(frames) as Awaited<
+        ReturnType<NonNullable<PlanningOperations["executePlanTransition"]>>
+      >;
+    },
   };
   const spend: SpendOperations = {
     async getSpendSummary(request) {
@@ -411,16 +428,25 @@ export async function launchDesktopFixture(input: {
     upgrade: rpc.handleUpgrade,
   });
   const debuggerPort = await reservePort();
-  const executable = require("electron") as string;
+  const executable =
+    input.applicationBundle === undefined
+      ? (input.executable ?? (require("electron") as string))
+      : "/usr/bin/open";
+  const applicationArgs =
+    input.applicationBundle === undefined
+      ? input.executable === undefined
+        ? [desktopRoot]
+        : []
+      : ["-n", "-W", input.applicationBundle, "--args"];
   const child = spawn(
     executable,
-    [desktopRoot, `--remote-debugging-port=${debuggerPort}`, `--user-data-dir=${userData}`],
+    [...applicationArgs, `--remote-debugging-port=${debuggerPort}`, `--user-data-dir=${userData}`],
     {
       env: {
         ...process.env,
         ...input.extraEnv,
         ENDURAGENT_HOME: athleteHome,
-        ENDURAGENT_ACCEPTANCE_HIDDEN: "1",
+        ENDURAGENT_ACCEPTANCE_HIDDEN: input.hidden === false ? "0" : "1",
         ENDURAGENT_ACCEPTANCE_CREDENTIAL_BACKEND: "memory",
         FORCE_COLOR: undefined,
         NO_COLOR: undefined,
@@ -499,7 +525,7 @@ export async function launchDesktopFixture(input: {
     await binding.close().catch(() => {});
     await rpc.close().catch(() => {});
     await lock.release().catch(() => {});
-    await rm(scratch, { recursive: true, force: true });
+    await rm(scratch, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     throw error;
   }
   return {
@@ -522,7 +548,9 @@ export async function launchDesktopFixture(input: {
         | undefined;
       if (exception !== undefined) {
         await refreshSurfaces();
-        throw new Error(String(exception.exception?.description ?? exception.text ?? "evaluation failed"));
+        throw new Error(
+          String(exception.exception?.description ?? exception.text ?? "evaluation failed"),
+        );
       }
       const remote = response.result as
         | { readonly value?: unknown; readonly description?: unknown }
@@ -568,7 +596,7 @@ export async function launchDesktopFixture(input: {
       await binding.close().catch(() => {});
       await rpc.close().catch(() => {});
       await lock.release().catch(() => {});
-      await rm(scratch, { recursive: true, force: true });
+      await rm(scratch, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       const livePids = pid !== undefined && processAlive(pid) ? [pid] : [];
       return { livePids, listenerCount: 0 };
     },

--- a/apps/desktop/tests/helpers/plan-qa-live.ts
+++ b/apps/desktop/tests/helpers/plan-qa-live.ts
@@ -1,0 +1,632 @@
+import type { DesktopFixtureScript, RunningDesktopFixture } from "./desktop-fixture.js";
+import { PlanReadModelSchema } from "@enduragent/coach-contract";
+import { launchDesktopFixture } from "./desktop-fixture.js";
+import {
+  planAttention,
+  planCoachData,
+  planReadModel,
+} from "../../../desktop-renderer/tests/plan-fixtures.js";
+
+const token = "q".repeat(43);
+const scenario = process.env.PLAN_QA_SCENARIO ?? "PL-S001";
+const planId = "plan-qa";
+
+const plan = {
+  id: planId,
+  name: "Gran Fondo Almaty",
+  primaryGoal: "Finish in the front half",
+  startDate: "1998-07-13",
+  targetDate: "1998-10-04",
+  kind: "full-plan" as const,
+  totalWeeks: 12,
+  weekStartDay: 1,
+  workoutCount: 58,
+  plannedDurationS: 309_600,
+};
+
+const workouts = [
+  ["workout-1", "1998-08-18", "Endurance", 5_400, "as-planned", false],
+  ["workout-2", "1998-08-19", "Threshold 4×8", 4_800, "adjusted", false],
+  ["workout-3", "1998-08-20", "Easy endurance", 3_000, "moved", false],
+  ["workout-4", "1998-08-21", "Recovery", 2_700, "missed", false],
+  ["workout-5", "1998-08-22", "Café ride", 7_500, "extra", false],
+  ["workout-6", "1998-08-23", "Suggested endurance", 1_800, "decision-needed", true],
+].map(([id, date, name, durationS, status, requiresConfirmation], index) => ({
+  id: String(id),
+  date: String(date),
+  sport: "cycling",
+  name: String(name),
+  durationS: Number(durationS),
+  match: {
+    kind: status === "extra" ? ("extra" as const) : ("planned" as const),
+    status: status as "as-planned" | "adjusted" | "moved" | "missed" | "extra" | "decision-needed",
+    activityId: status === "upcoming" ? null : `activity-${index + 1}`,
+    matchId: `match-${index + 1}`,
+    actualDate: String(date),
+    actualDurationS: Number(durationS),
+    requiresConfirmation: Boolean(requiresConfirmation),
+    createdAtMs: index + 1,
+  },
+}));
+
+const todayWorkout = {
+  ...workouts[3],
+  id: "today-recovery",
+  date: "1998-08-22",
+  name: "Recovery spin",
+  durationS: 2_700,
+  match: {
+    ...workouts[3]!.match,
+    activityId: "activity-today",
+    matchId: "match-today",
+    actualDate: "1998-08-22",
+    actualDurationS: 2_700,
+  },
+};
+
+const history = [
+  {
+    id: "history-adjustment",
+    kind: "proposal-applied" as const,
+    label: "Sunday adjustment applied",
+    occurredAtMs: 903_766_320_000,
+    targetWorkoutId: "workout-6",
+    before: { date: "1998-08-23", name: "Endurance", durationS: 5_400 },
+    after: { date: "1998-08-23", name: "Recovery", durationS: 1_800 },
+    weekLoadBefore: 420,
+    weekLoadAfter: 360,
+    undoStatus: "eligible" as const,
+    undoReason: null,
+  },
+  {
+    id: "history-activation",
+    kind: "activation" as const,
+    label: "Plan approved",
+    occurredAtMs: 900_331_200_000,
+    targetWorkoutId: null,
+    before: null,
+    after: null,
+    weekLoadBefore: null,
+    weekLoadAfter: null,
+    undoStatus: "none" as const,
+    undoReason: null,
+  },
+];
+
+const seasonDates = [
+  ["1998-07-13", "1998-07-19"],
+  ["1998-07-20", "1998-07-26"],
+  ["1998-07-27", "1998-08-02"],
+  ["1998-08-03", "1998-08-09"],
+  ["1998-08-10", "1998-08-16"],
+  ["1998-08-17", "1998-08-23"],
+  ["1998-08-24", "1998-08-30"],
+  ["1998-08-31", "1998-09-06"],
+  ["1998-09-07", "1998-09-13"],
+  ["1998-09-14", "1998-09-20"],
+  ["1998-09-21", "1998-09-27"],
+  ["1998-09-28", "1998-10-04"],
+] as const;
+
+const seasonWeeks = seasonDates.map(([startDate, endDate], index) => ({
+  weekIndex: index + 1,
+  startDate,
+  endDate,
+  phase: index === 11 ? "Race" : index >= 10 ? "Taper" : index === 3 ? "Recovery" : "Build",
+  purpose: index === 11 ? "Goal race" : "Follow the approved week",
+  status:
+    index === 5 ? ("current" as const) : index < 5 ? ("completed" as const) : ("planned" as const),
+  plannedDurationS: index === 11 ? 29_100 : 32_400,
+}));
+
+const raceWeek = {
+  startDate: "1998-09-28",
+  endDate: "1998-10-04",
+  raceDate: "1998-10-04",
+  trainingDurationS: 11_100,
+  raceDurationS: 18_000,
+  totalDurationS: 29_100,
+  days: [
+    ["1998-09-28", "Mon", null, "Rest", null, "Absorb", "rest"],
+    ["1998-09-29", "Tue", "race-1", "Openers · 3×1 min", 2_700, "Sharpen", "training"],
+    ["1998-09-30", "Wed", "race-2", "Easy endurance", 3_000, "Maintain", "training"],
+    ["1998-10-01", "Thu", null, "Rest", null, "Freshen", "rest"],
+    ["1998-10-02", "Fri", "race-3", "Race opener", 1_800, "Sharpen", "training"],
+    ["1998-10-03", "Sat", "race-4", "Pre-race spin", 3_600, "Prime", "training"],
+    ["1998-10-04", "Sun", "race-5", "Gran Fondo Almaty", 18_000, "Race", "race"],
+  ].map(([date, weekday, workoutId, name, durationS, purpose, kind]) => ({
+    date: String(date),
+    weekday: weekday as "Mon" | "Tue" | "Wed" | "Thu" | "Fri" | "Sat" | "Sun",
+    workoutId: workoutId === null ? null : String(workoutId),
+    name: String(name),
+    durationS: durationS === null ? null : Number(durationS),
+    purpose: String(purpose),
+    kind: kind as "training" | "rest" | "race",
+  })),
+};
+
+const activeData = {
+  plan,
+  today: "1998-08-22",
+  weekIndex: 6,
+  todayWorkout,
+  workouts,
+  matchSync: { lastSuccessfulSyncAtMs: 903_766_320_000, awaitingSync: false },
+  selectedWorkoutId: null,
+  history,
+  settings: {
+    autoApply: false,
+    weeklyReview: true,
+    updatedAtMs: 903_766_320_000,
+    selectedSetting: null,
+    error: null,
+  },
+  season: {
+    priority: "A" as const,
+    distanceKm: 120,
+    weeks: seasonWeeks,
+    constraint: {
+      weekIndex: 8,
+      title: "FTP refresh required before Build 2",
+      detail: "Later durations stay fixed; power targets wait for refreshed FTP.",
+    },
+    raceWeek,
+  },
+  readiness: {
+    form: {
+      status: "available" as const,
+      asOf: "1998-08-22",
+      current: 1,
+      raceRange: { min: 4, max: 9 },
+      assumptions: ["Planned load is completed", "Recovery remains normal"],
+      unavailableReason: null,
+      lastSuccessfulRefreshAtMs: 903_766_320_000,
+    },
+    feasibility: {
+      verdict: "on-track" as const,
+      supportedDistanceKm: { min: 115, max: 130 },
+      reasons: ["Training is consistent"],
+      recommendation: "Keep the approved taper",
+    },
+    courseEstimate: {
+      status: "available" as const,
+      rangeMinutes: { min: 288, max: 312 },
+      previousRangeMinutes: null,
+      confidence: "moderate" as const,
+      assumptions: ["Dry roads", "Low wind", "Planned fueling", "No mechanical delay"],
+      changedAssumption: null,
+      unavailableReason: null,
+    },
+    estimatedCp: {
+      status: "available" as const,
+      watts: 287,
+      calculatedOn: "1998-08-22",
+      lastSuccessfulSyncAtMs: 903_766_320_000,
+      unavailableReason: null,
+      efforts: [
+        {
+          activityId: "ride-short",
+          ride: "Tuesday Hill Repeats",
+          date: "1998-08-18",
+          durationS: 180,
+          averagePowerW: 407,
+          device: "Favero Assioma Duo",
+        },
+        {
+          activityId: "ride-long",
+          ride: "Sunday Tempo Climb",
+          date: "1998-08-09",
+          durationS: 900,
+          averagePowerW: 311,
+          device: "Garmin Rally RS200",
+        },
+      ],
+    },
+    evidence: {
+      prescribedDurationS: 154_800,
+      riddenDurationS: 142_800,
+      adjustedDurationS: 7_800,
+      missedKeyWorkouts: 0,
+      fatigue: "normal" as const,
+    },
+    taperRefusal: null,
+    error: null,
+  },
+};
+
+function modelFor(id: string) {
+  if (id === "PL-S001") return planReadModel();
+  if (id === "PL-S017" || id === "PL-S016") {
+    return planReadModel({
+      lifecycle: "intake",
+      scenarioId: id as "PL-S017" | "PL-S016",
+      projection: "coach",
+      data: planCoachData({
+        ready: id === "PL-S016",
+        course: {
+          status: "undecided",
+          accepted: null,
+          candidate: null,
+          fileName: null,
+          detail: null,
+        },
+        messages: [
+          {
+            id: "coach-1",
+            turnId: null,
+            role: "coach",
+            text: "Let’s build this here in Plan. What event are you training toward?",
+          },
+          {
+            id: "athlete-1",
+            turnId: "turn-1",
+            role: "athlete",
+            text: "Gran Fondo Almaty on 4 October. I want to finish in the front half.",
+          },
+          {
+            id: "coach-2",
+            turnId: "turn-1",
+            role: "coach",
+            text: "I found your recent rides, recovery, weekly availability, and FTP 282 W. Add a Race Course now, or keep the Draft course-agnostic.",
+          },
+        ],
+      }),
+    });
+  }
+  if (id === "PL-S003") {
+    return planReadModel({
+      lifecycle: "intake",
+      scenarioId: "PL-S003",
+      projection: "coach",
+      data: planCoachData({
+        ftp: {
+          status: "required",
+          manual: null,
+          intervalsFtp: null,
+          intervalsEftp: null,
+          usedSource: null,
+          usedWatts: null,
+          conflict: false,
+          error: null,
+        },
+      }),
+    });
+  }
+  if (id === "PL-S102") {
+    return planReadModel({
+      lifecycle: "ended",
+      scenarioId: "PL-S102",
+      projection: "coach",
+      planId,
+      data: planCoachData({
+        messages: [
+          {
+            id: "coach-history-1",
+            turnId: null,
+            role: "coach",
+            text: "Let’s build this here in Plan. What event are you training toward?",
+          },
+          {
+            id: "athlete-history-1",
+            turnId: "turn-history-1",
+            role: "athlete",
+            text: "Gran Fondo Almaty on 4 October. I want to finish in the front half.",
+          },
+          {
+            id: "coach-history-2",
+            turnId: "turn-history-1",
+            role: "coach",
+            text: "I found your recent rides, recovery, weekly availability, and FTP 282 W.",
+          },
+        ],
+      }),
+    });
+  }
+  if (["PL-S002", "PL-S031", "PL-S050", "PL-S070"].includes(id)) {
+    return planReadModel({
+      lifecycle: "draft",
+      scenarioId: id as "PL-S002" | "PL-S031" | "PL-S050" | "PL-S070",
+      projection: "draft",
+      planId,
+      revision: id === "PL-S002" ? 1 : 2,
+      data: planCoachData({
+        draft: {
+          id: "draft-qa",
+          planId,
+          revision: id === "PL-S002" ? 1 : 2,
+          status: "ready",
+          snapshot: { completeWeeks: 12 },
+        },
+        plan,
+        course: {
+          status: "omitted",
+          accepted: null,
+          candidate: null,
+          fileName: null,
+          detail: null,
+        },
+        startDate: {
+          status: id === "PL-S050" ? "updated" : "ready",
+          selectedDate: "1998-07-13",
+          today: "1998-07-13",
+          targetDate: "1998-10-04",
+          kind: "full-plan",
+          inclusiveDays: 84,
+          totalWeeks: 12,
+          raceWeekday: 0,
+          raceDayOfPlanWeek: 7,
+          error: null,
+        },
+      }),
+    });
+  }
+  if (
+    id === "PL-S014" ||
+    id === "PL-S089" ||
+    id === "PL-S094" ||
+    id === "PL-S095" ||
+    id === "PL-S096"
+  ) {
+    const cleanupFailed = id === "PL-S014";
+    return planReadModel({
+      lifecycle: "ended",
+      scenarioId: id as "PL-S014" | "PL-S089" | "PL-S094" | "PL-S095" | "PL-S096",
+      projection: "ended",
+      planId,
+      reconciliation: cleanupFailed
+        ? {
+            status: "failed",
+            created: 0,
+            pending: 0,
+            failed: 1,
+            total: 1,
+            currentThrough: null,
+            error: {
+              code: "provider-failed",
+              message: "Cleanup could not be verified.",
+              retryable: true,
+            },
+          }
+        : {
+            status: "verified",
+            created: 0,
+            pending: 0,
+            failed: 0,
+            total: 0,
+            currentThrough: "1998-10-06",
+            error: null,
+          },
+      data: {
+        plan,
+        endedAtMs: 903_766_320_000,
+        raceOutcome: id === "PL-S096" ? "not-completed" : id === "PL-S014" ? "completed" : null,
+        outcomeAvailable: id === "PL-S094" || id === "PL-S095",
+        cleanupItems: [
+          {
+            id: "cleanup-1",
+            date: "1998-08-19",
+            externalId: "external-1",
+            status: cleanupFailed ? "failed" : "verified",
+            errorCode: cleanupFailed ? "calendar-delete-failed" : null,
+          },
+        ],
+      },
+    });
+  }
+  const selectedWorkout = workouts[5];
+  const selected = id === "PL-S021" ? selectedWorkout : null;
+  const activeScenario = id as
+    | "PL-S004"
+    | "PL-S005"
+    | "PL-S006"
+    | "PL-S009"
+    | "PL-S010"
+    | "PL-S012"
+    | "PL-S013"
+    | "PL-S021"
+    | "PL-S028"
+    | "PL-S090"
+    | "PL-S091"
+    | "PL-S092"
+    | "PL-S093";
+  return {
+    ...planReadModel({
+      lifecycle: "active",
+      scenarioId: activeScenario,
+      projection: id === "PL-S028" ? "attention" : "active",
+      planId,
+      attentionCount: id === "PL-S028" ? 2 : id === "PL-S021" ? 1 : 0,
+      data: {
+        ...activeData,
+        ...(id === "PL-S009"
+          ? {
+              matchSync: {
+                lastSuccessfulSyncAtMs: 903_766_320_000,
+                awaitingSync: true,
+              },
+              season: {
+                ...activeData.season,
+                raceWeek: {
+                  ...raceWeek,
+                  days: raceWeek.days.map((day) =>
+                    day.weekday === "Fri" ? { ...day, purpose: "Blocked" } : day,
+                  ),
+                },
+              },
+            }
+          : {}),
+        ...(id === "PL-S093"
+          ? {
+              settings: {
+                ...activeData.settings,
+                selectedSetting: "auto-apply" as const,
+                error: {
+                  code: "persistence-failed" as const,
+                  message: "Could not save.",
+                  retryable: true,
+                },
+              },
+            }
+          : {}),
+        selectedWorkoutId: selected?.id ?? null,
+        selectedWorkout: selected,
+        selectedWorkoutSourceScenarioId: selected === null ? null : "PL-S004",
+      },
+    }),
+    attention: id === "PL-S028" ? planAttention(2) : planAttention(id === "PL-S021" ? 1 : 0),
+  };
+}
+
+function response(value: unknown): readonly string[] {
+  return [JSON.stringify(value)];
+}
+
+function qaModel(id: string) {
+  return PlanReadModelSchema.parse(modelFor(id));
+}
+
+let current = qaModel(scenario);
+
+function fixtureScript(): DesktopFixtureScript {
+  return {
+    onRequest(value) {
+      const request = value as {
+        readonly method: string;
+        readonly params: Record<string, unknown>;
+      };
+      if (request.method === "getPlanState") return response({ status: "ready", state: current });
+      if (request.method === "executePlanTransition") {
+        const transitionId = String(request.params.transitionId ?? "");
+        const destination = request.params.destinationScenarioId;
+        if (transitionId === "PL-T01") current = qaModel("PL-S017");
+        else if (transitionId === "PL-T05") current = qaModel("PL-S016");
+        else if (transitionId === "PL-T06") current = qaModel("PL-S002");
+        else if (transitionId === "PL-T11") current = qaModel("PL-S004");
+        else if (transitionId === "PL-T33") {
+          current =
+            current.attention.destination === "direct" ? qaModel("PL-S021") : qaModel("PL-S028");
+        } else if (transitionId === "PL-T34" || transitionId === "PL-T13") {
+          current = qaModel("PL-S021");
+        } else if (transitionId === "PL-T08") current = qaModel("PL-S050");
+        else if (transitionId === "PL-T22") current = qaModel("PL-S090");
+        else if (typeof destination === "string") current = qaModel(destination);
+        return response({ status: "completed", state: current });
+      }
+      if (request.method === "getSetupStatus") {
+        return response({
+          schemaVersion: 1,
+          intake: {
+            swim_skill_floor: null,
+            continuous_distance_capable: null,
+            open_water_comfort: null,
+            prior_bsi: false,
+            clinician_cleared: null,
+            injury_status: "none",
+          },
+          durableTrainingData: true,
+        });
+      }
+      if (request.method === "getAthleteState") {
+        return response({
+          schemaVersion: "1",
+          lastUpdated: "1998-08-22T08:00:00.000Z",
+          freshness: "fresh",
+          degraded: false,
+          lastSynced: "1998-08-22T07:55:00.000Z",
+          athleteProfile: {},
+          currentStatus: {},
+          derivedMetrics: {},
+          recentActivities: [],
+          plannedWorkouts: [],
+          wellness: {},
+          trainingContext: {
+            performanceProgress: { kind: "unavailable", reason: "not-synced" },
+            recentRides: {
+              kind: "computed",
+              asOf: "1998-08-22T08:00:00.000Z",
+              windowDays: 28,
+              items: [],
+            },
+            anchorZones: { kind: "unavailable", reason: "not-synced" },
+            cyclingLoad: { kind: "unavailable", reason: "not-synced" },
+            plan: { kind: "computed", asOf: "1998-08-22T08:00:00.000Z", items: [] },
+            adherence: { kind: "unavailable", reason: "not-synced" },
+            wellnessTrend: { kind: "unavailable", reason: "not-synced" },
+          },
+        });
+      }
+      if (request.method === "getRuntimeConfig") {
+        return response({
+          schemaVersion: 3,
+          llm: { provider: "codex-agent", model: "fixture", credential_configured: true },
+          intervals: {
+            athlete_id: "0",
+            credential_configured: true,
+            managedByEnvironment: { athleteId: false },
+          },
+          session: {
+            historyTokenBudgetRatio: 0.3,
+            idleMinutes: 0,
+            dailyResetHour: 4,
+            resetArchiveRetentionDays: 0,
+            timezone: "UTC",
+            managedByEnvironment: {
+              historyTokenBudgetRatio: false,
+              idleMinutes: false,
+              dailyResetHour: false,
+              resetArchiveRetentionDays: false,
+              timezone: false,
+            },
+          },
+        });
+      }
+      if (request.method === "getUnitsPreference")
+        return response({ value: "metric", source: "default" });
+      if (request.method === "getChatQueue")
+        return response({ schemaVersion: 1, revision: 0, items: [] });
+      if (request.method === "hasSession") return response({ hasSession: false });
+      if (request.method === "getCoachDecision") return response({ decision: null });
+      if (request.method === "getTranscriptPage") {
+        return response({ schemaVersion: 1, status: "page", turns: [], nextCursor: null });
+      }
+      if (request.method === "getSpendSummary") {
+        return response({
+          schemaVersion: 1,
+          status: "available",
+          timezone: "UTC",
+          currency: "USD",
+          today: { date: "1998-08-22", amountUsd: 0, capUsd: null },
+          month: { month: "1998-08", amountUsd: 0 },
+        });
+      }
+      throw new TypeError(`unexpected fixture method ${request.method}`);
+    },
+  };
+}
+
+let fixture: RunningDesktopFixture | undefined;
+
+async function close(): Promise<void> {
+  await fixture?.close();
+  process.exit(0);
+}
+
+fixture = await launchDesktopFixture({
+  script: fixtureScript(),
+  token,
+  ...(process.env.PLAN_QA_EXECUTABLE === undefined
+    ? {}
+    : { executable: process.env.PLAN_QA_EXECUTABLE }),
+  ...(process.env.PLAN_QA_APPLICATION === undefined
+    ? {}
+    : { applicationBundle: process.env.PLAN_QA_APPLICATION }),
+  width: Number(process.env.PLAN_QA_WIDTH ?? 1180),
+  height: Number(process.env.PLAN_QA_HEIGHT ?? 820),
+  colorScheme: process.env.PLAN_QA_THEME === "dark" ? "dark" : "light",
+  reducedMotion: true,
+  hidden: false,
+});
+
+process.on("SIGINT", () => void close());
+process.on("SIGTERM", () => void close());
+process.stdout.write(`PLAN_QA_READY ${scenario}\n`);

--- a/packages/coach/src/planning-lifecycle.ts
+++ b/packages/coach/src/planning-lifecycle.ts
@@ -383,6 +383,40 @@ export function buildPlanLifecycleReadModel(
   });
 }
 
+export function buildEndedPlanConversationReadModel(input: {
+  readonly conversation: PlanConversationProjection;
+  readonly turns: readonly PlanConversationTurnProjection[];
+  readonly planId: string;
+  readonly revision: number;
+}): PlanReadModel {
+  return PlanReadModelSchema.parse({
+    schemaVersion: 1,
+    scenarioId: "PL-S102",
+    lifecycle: "ended",
+    planId: input.planId,
+    revision: input.revision,
+    title: "Plan conversation",
+    summary: "This ended Plan conversation is read-only and remains in Plan History.",
+    projection: "coach",
+    transitions: [guard("PL-T39")],
+    reconciliation: EMPTY_RECONCILIATION,
+    attention: EMPTY_ATTENTION,
+    activeOperation: null,
+    data: PlanCoachProjectionDataSchema.parse({
+      conversationId: input.conversation.id,
+      chatId: `plan:${input.conversation.id}`,
+      sourceConversationId: input.conversation.sourceConversationId,
+      replacement: input.conversation.replacesPlanId !== null,
+      replacesPlanId: input.conversation.replacesPlanId,
+      readyToCreateDraft: false,
+      messages: messages(input.conversation.id, input.turns),
+      queue: { schemaVersion: 1, revision: 0, items: [] },
+      decision: null,
+      draft: null,
+    }),
+  });
+}
+
 export function buildActivePlanReadModel(input: {
   readonly scenarioId: ActivePlanScenario;
   readonly planId: string;
@@ -628,7 +662,9 @@ export function buildEndedPlanReadModel(input: {
     transitions: [
       ...(failed ? [guard("PL-T24")] : []),
       ...(input.reconciliation.status === "verified" ? [guard("PL-T01")] : []),
-      ...(input.scenarioId === "PL-S094" ? [guard("PL-T39")] : []),
+      ...(input.scenarioId === "PL-S089" || input.scenarioId === "PL-S094"
+        ? [guard("PL-T39")]
+        : []),
       ...(input.scenarioId === "PL-S095" ? [guard("PL-T30")] : []),
     ],
     reconciliation: input.reconciliation,

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -98,6 +98,7 @@ import {
 import { cyclingTaperRefusal, projectCyclingSeasonMetadata } from "@enduragent/sport-cycling";
 import {
   buildActivePlanReadModel,
+  buildEndedPlanConversationReadModel,
   buildEndedPlanReadModel,
   buildPlanLifecycleReadModel,
   type ActivePlanScenario,
@@ -3814,6 +3815,41 @@ export function createPlanningOperations(
           }
         }
         if (command.transitionId === "PL-T39") {
+          if (
+            command.sourceScenarioId === "PL-S089" &&
+            command.destinationScenarioId === "PL-S102"
+          ) {
+            const plan = await plans.readLatest();
+            if (plan?.status !== "ended") return reject(UNAVAILABLE);
+            const conversation = await conversations.readConversationByPlanId(plan.id);
+            if (conversation === undefined) return reject(UNAVAILABLE);
+            const turns = await conversations.readTurns(conversation.id);
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: buildEndedPlanConversationReadModel({
+                conversation: {
+                  id: conversation.id,
+                  planId: conversation.planId,
+                  replacesPlanId: conversation.replacesPlanId,
+                  sourceConversationId: null,
+                },
+                turns,
+                planId: plan.id,
+                revision: 0,
+              }),
+            });
+          }
+          if (
+            command.sourceScenarioId === "PL-S102" &&
+            command.destinationScenarioId === "PL-S089"
+          ) {
+            const plan = await plans.readLatest();
+            if (plan?.status !== "ended") return reject(UNAVAILABLE);
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read({ endedScenario: "PL-S089" }),
+            });
+          }
           if (
             command.sourceScenarioId === "PL-S081" &&
             command.destinationScenarioId === "PL-S080"

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -2674,9 +2674,37 @@ describe("Plan operations", () => {
 
   it("ends locally, preserves today and athlete events, and recovers cleanup", async () => {
     const planId = `${"0".repeat(25)}F`;
+    const conversationId = `${"0".repeat(25)}J`;
     const activePlan = { ...plan(planId, 10), status: "active" as const };
     const plans = createPlanRepository(store);
+    const conversations = createPlanConversationRepository(store);
     await plans.replace(activePlan, []);
+    await conversations.saveConversation({
+      id: conversationId,
+      planId,
+      replacesPlanId: null,
+      courseChoiceStatus: "omitted",
+      raceCourseJson: null,
+      status: "open",
+      endedAtMs: null,
+      createdAtMs: 10,
+      updatedAtMs: 10,
+      deviceId: "device-1",
+      hlcPhysicalMs: 10,
+      hlcCounter: 0,
+    });
+    await conversations.appendTurn({
+      id: `${"0".repeat(25)}K`,
+      conversationId,
+      sequence: 1,
+      athleteText: "Gran Fondo Almaty on 4 October.",
+      coachText: "I found your recent rides and FTP.",
+      lineageJson: "{}",
+      completedAtMs: 11,
+      deviceId: "device-1",
+      hlcPhysicalMs: 11,
+      hlcCounter: 0,
+    });
     const ownToday = planMirrorExternalId(planId, `${"0".repeat(25)}G`);
     const ownTomorrow = planMirrorExternalId(planId, `${"0".repeat(25)}H`);
     const events = [
@@ -2764,6 +2792,42 @@ describe("Plan operations", () => {
 
     await expect(operations.getPlanState?.({})).resolves.toMatchObject({
       status: "ready",
+      state: { lifecycle: "ended", scenarioId: "PL-S089" },
+    });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T39",
+        commandId: "command-ended-conversation",
+        action: "open",
+        sourceScenarioId: "PL-S089",
+        destinationScenarioId: "PL-S102",
+        returnFocusId: planId,
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        lifecycle: "ended",
+        scenarioId: "PL-S102",
+        projection: "coach",
+        data: {
+          messages: expect.arrayContaining([
+            expect.objectContaining({ role: "athlete", text: "Gran Fondo Almaty on 4 October." }),
+            expect.objectContaining({ role: "coach", text: "I found your recent rides and FTP." }),
+          ]),
+        },
+      },
+    });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T39",
+        commandId: "command-ended-conversation-back",
+        action: "back",
+        sourceScenarioId: "PL-S102",
+        destinationScenarioId: "PL-S089",
+        returnFocusId: planId,
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
       state: { lifecycle: "ended", scenarioId: "PL-S089" },
     });
   });


### PR DESCRIPTION
## Summary
- carry the finalized Plan packaged-desktop QA corrections into the Chat epic
- preserve active Predictions, readiness, race-week, Draft, and ended-Plan history behavior
- align the Chat epic with the final Plan implementation before persistent handoff work

## Verification
- patch is identical to the reviewed and CI-green Plan QA commit
- `pnpm check`