### PR TITLE
feat(chat): add durable Plan outbox

### DIFF
--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -588,7 +588,7 @@ describe("account identity", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 25 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 26 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(
         beforeWorkouts,

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -578,7 +578,7 @@ describe("coach sync composition", () => {
             return store.get("PRAGMA user_version");
           },
         );
-        expect(value).toEqual({ user_version: 25 });
+        expect(value).toEqual({ user_version: 26 });
         expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
         expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
         expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -586,7 +586,7 @@ describe("coach sync composition", () => {
         const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
         try {
           await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-            user_version: 25,
+            user_version: 26,
           });
         } finally {
           await reopened.close();

--- a/packages/kernel-node/tests/chat-plan-outbox-repository.test.ts
+++ b/packages/kernel-node/tests/chat-plan-outbox-repository.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createChatPlanOutboxRepository,
+  runMigrations,
+  type CreatePlanningRequestPayload,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createNodeCrypto } from "../src/ingest/import-files.js";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const REQUEST_ID = "request-1";
+
+function payload(
+  overrides: Partial<CreatePlanningRequestPayload> = {},
+): CreatePlanningRequestPayload {
+  return {
+    requestId: REQUEST_ID,
+    kind: "workout_review",
+    intent: "Review this workout before I add it to my Plan.",
+    source: {
+      chatId: "chat-1",
+      messageId: "message-1",
+      attachmentId: "attachment-1",
+    },
+    sourceSnapshot: {
+      capturedAt: "1998-08-24T08:00:00.000Z",
+      attachment: {
+        attachmentId: "attachment-1",
+        displayName: "tempo-3x12.mrc",
+        extension: "mrc",
+      },
+      selectedWorkout: {
+        setId: "set-1",
+        workoutId: "workout-1",
+        workout: {
+          name: "Tempo 3 × 12",
+          sport: "cycling",
+          durationSeconds: 3_840,
+          segments: [],
+        },
+      },
+    },
+    requestedDate: "1998-08-26",
+    ...overrides,
+  };
+}
+
+describe("Chat Plan outbox repository", () => {
+  let store: SqlStore & MigratorStore;
+  let repository: ReturnType<typeof createChatPlanOutboxRepository>;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    repository = createChatPlanOutboxRepository(store, createNodeCrypto());
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("persists one pending request before delivery and returns it for an identical retry", async () => {
+    const created = await repository.createOrGet({ payload: payload(), createdAtMs: 100 });
+    const retried = await repository.createOrGet({ payload: payload(), createdAtMs: 999 });
+
+    expect(retried).toEqual(created);
+    expect(created).toMatchObject({
+      requestId: REQUEST_ID,
+      state: "pending",
+      attemptCount: 0,
+      createdAtMs: 100,
+      updatedAtMs: 100,
+      payload: { requestId: REQUEST_ID },
+    });
+    expect(created.payloadHash).toMatch(/^[0-9a-f]{64}$/u);
+    await expect(store.get("SELECT count(*) AS count FROM chat_plan_outbox")).resolves.toEqual({
+      count: 1,
+    });
+  });
+
+  it("rejects a changed payload under the same request identifier", async () => {
+    await repository.createOrGet({ payload: payload(), createdAtMs: 100 });
+
+    await expect(
+      repository.createOrGet({
+        payload: payload({ intent: "Replace Tuesday instead." }),
+        createdAtMs: 101,
+      }),
+    ).rejects.toMatchObject({ code: "request-conflict" });
+    await expect(store.get("SELECT count(*) AS count FROM chat_plan_outbox")).resolves.toEqual({
+      count: 1,
+    });
+  });
+
+  it("persists attempts and retries the same request through failure to delivery", async () => {
+    await repository.createOrGet({ payload: payload(), createdAtMs: 100 });
+    await expect(
+      repository.beginDelivery({ requestId: REQUEST_ID, attemptedAtMs: 110 }),
+    ).resolves.toMatchObject({ state: "pending", attemptCount: 1, updatedAtMs: 110 });
+    await expect(
+      repository.markFailed({
+        requestId: REQUEST_ID,
+        failureCode: "planning_unavailable",
+        retryable: true,
+        failedAtMs: 120,
+      }),
+    ).resolves.toMatchObject({
+      state: "failed",
+      attemptCount: 1,
+      failureCode: "planning_unavailable",
+      retryable: true,
+    });
+    await expect(
+      repository.beginDelivery({ requestId: REQUEST_ID, attemptedAtMs: 130 }),
+    ).resolves.toMatchObject({ state: "pending", attemptCount: 2, updatedAtMs: 130 });
+    const delivered = await repository.markDelivered({
+      requestId: REQUEST_ID,
+      deliveredAtMs: 140,
+    });
+    expect(delivered).toMatchObject({
+      state: "delivered",
+      attemptCount: 2,
+      deliveredAtMs: 140,
+      sourceDeletedAtMs: null,
+    });
+    await expect(
+      repository.markDelivered({ requestId: REQUEST_ID, deliveredAtMs: 999 }),
+    ).resolves.toEqual(delivered);
+    await expect(repository.readRecoverable()).resolves.toEqual([]);
+  });
+
+  it("does not retry a failure marked non-retryable", async () => {
+    await repository.createOrGet({ payload: payload(), createdAtMs: 100 });
+    await repository.beginDelivery({ requestId: REQUEST_ID, attemptedAtMs: 110 });
+    await repository.markFailed({
+      requestId: REQUEST_ID,
+      failureCode: "request_conflict",
+      retryable: false,
+      failedAtMs: 120,
+    });
+
+    await expect(
+      repository.beginDelivery({ requestId: REQUEST_ID, attemptedAtMs: 130 }),
+    ).rejects.toMatchObject({ code: "non-retryable" });
+    await expect(repository.readRecoverable()).resolves.toEqual([]);
+  });
+
+  it("returns pending and retryable failed records in stable recovery order", async () => {
+    await repository.createOrGet({
+      payload: payload({ requestId: "request-1" }),
+      createdAtMs: 100,
+    });
+    await repository.createOrGet({
+      payload: payload({ requestId: "request-2" }),
+      createdAtMs: 101,
+    });
+    await repository.beginDelivery({ requestId: "request-2", attemptedAtMs: 102 });
+    await repository.markFailed({
+      requestId: "request-2",
+      failureCode: "planning_unavailable",
+      retryable: true,
+      failedAtMs: 103,
+    });
+    await repository.createOrGet({
+      payload: payload({ requestId: "request-3" }),
+      createdAtMs: 104,
+    });
+    await repository.beginDelivery({ requestId: "request-3", attemptedAtMs: 105 });
+    await repository.markFailed({
+      requestId: "request-3",
+      failureCode: "request_conflict",
+      retryable: false,
+      failedAtMs: 106,
+    });
+
+    const recoverable = await repository.readRecoverable();
+    expect(recoverable.map(({ requestId }) => requestId)).toEqual(["request-1", "request-2"]);
+  });
+
+  it("cancels an undelivered source and makes its payload irrecoverable", async () => {
+    await repository.createOrGet({ payload: payload(), createdAtMs: 100 });
+    await repository.beginDelivery({ requestId: REQUEST_ID, attemptedAtMs: 110 });
+    await repository.markFailed({
+      requestId: REQUEST_ID,
+      failureCode: "planning_unavailable",
+      retryable: true,
+      failedAtMs: 120,
+    });
+    const cancelled = await repository.cancelUndelivered({
+      requestId: REQUEST_ID,
+      cancelledAtMs: 130,
+    });
+
+    expect(cancelled).toMatchObject({
+      state: "cancelled",
+      payload: null,
+      cancelledAtMs: 130,
+      cancelReason: "source_conversation_deleted",
+    });
+    await expect(
+      repository.cancelUndelivered({ requestId: REQUEST_ID, cancelledAtMs: 999 }),
+    ).resolves.toEqual(cancelled);
+    await expect(
+      repository.beginDelivery({ requestId: REQUEST_ID, attemptedAtMs: 140 }),
+    ).rejects.toMatchObject({ code: "invalid-transition" });
+    await expect(
+      store.run("UPDATE chat_plan_outbox SET updated_at_ms = 999 WHERE request_id = ?", [
+        REQUEST_ID,
+      ]),
+    ).rejects.toThrow();
+    await expect(
+      store.run("DELETE FROM chat_plan_outbox WHERE request_id = ?", [REQUEST_ID]),
+    ).rejects.toThrow();
+  });
+
+  it("compacts a delivered source only after delivery and keeps its payload hash", async () => {
+    await repository.createOrGet({ payload: payload(), createdAtMs: 100 });
+    await expect(
+      repository.detachDeliveredSource({ requestId: REQUEST_ID, sourceDeletedAtMs: 105 }),
+    ).rejects.toMatchObject({ code: "invalid-transition" });
+    await repository.beginDelivery({ requestId: REQUEST_ID, attemptedAtMs: 110 });
+    const delivered = await repository.markDelivered({
+      requestId: REQUEST_ID,
+      deliveredAtMs: 120,
+    });
+    const detached = await repository.detachDeliveredSource({
+      requestId: REQUEST_ID,
+      sourceDeletedAtMs: 130,
+    });
+
+    expect(detached).toMatchObject({
+      state: "delivered",
+      payload: null,
+      deliveredAtMs: 120,
+      sourceDeletedAtMs: 130,
+      payloadHash: delivered.payloadHash,
+    });
+    await expect(repository.createOrGet({ payload: payload(), createdAtMs: 999 })).resolves.toEqual(
+      detached,
+    );
+    await expect(
+      store.run("UPDATE chat_plan_outbox SET updated_at_ms = 999 WHERE request_id = ?", [
+        REQUEST_ID,
+      ]),
+    ).rejects.toThrow();
+  });
+
+  it("rejects delivery before an attempt and detects a corrupted payload hash", async () => {
+    await repository.createOrGet({ payload: payload(), createdAtMs: 100 });
+    await expect(
+      repository.markDelivered({ requestId: REQUEST_ID, deliveredAtMs: 110 }),
+    ).rejects.toMatchObject({ code: "invalid-transition" });
+    await expect(
+      repository.markFailed({
+        requestId: REQUEST_ID,
+        failureCode: "planning_unavailable",
+        retryable: true,
+        failedAtMs: 110,
+      }),
+    ).rejects.toMatchObject({ code: "invalid-transition" });
+    await store.run("UPDATE chat_plan_outbox SET payload_hash = ? WHERE request_id = ?", [
+      "b".repeat(64),
+      REQUEST_ID,
+    ]);
+    await expect(repository.read(REQUEST_ID)).rejects.toMatchObject({ code: "corrupt-record" });
+  });
+});

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -598,7 +598,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 25 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -31,9 +31,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 25", async () => {
+  it("applies the full migration list and advances user_version to 26", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 25 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -53,7 +53,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 25 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -82,11 +82,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 25", async () => {
+  it("upgrades a version-1-on-disk store to version 26", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 25 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -108,10 +108,10 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 4,
-      toVersion: 25,
-      applied: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25],
+      toVersion: 26,
+      applied: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 25 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -164,21 +164,21 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 6,
-      toVersion: 25,
-      applied: [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25],
+      toVersion: 26,
+      applied: [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 25 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 25,
-      toVersion: 25,
+      fromVersion: 26,
+      toVersion: 26,
       applied: [],
     });
   });
 
-  it("upgrades version 11 through 25 while preserving existing rows", async () => {
+  it("upgrades version 11 through 26 while preserving existing rows", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 11));
     await store.run("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,?)", [
       "chronoBridge",
@@ -187,8 +187,8 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 11,
-      toVersion: 25,
-      applied: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25],
+      toVersion: 26,
+      applied: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
     });
     await expect(store.get("SELECT fixer,enabled FROM repair_fixer_settings")).resolves.toEqual({
       fixer: "chronoBridge",
@@ -197,7 +197,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     await expect(store.get("SELECT count(*) AS count FROM repair_fixer_settings")).resolves.toEqual(
       { count: 1 },
     );
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 25 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 26 });
   });
 
   it("rolls back a failed migration 12 without partial Planning tables", async () => {
@@ -319,7 +319,7 @@ describe("migrator end-to-end over node:sqlite", () => {
       ],
     );
 
-    await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
+    await expect(runMigrations(store, MIGRATIONS.slice(0, 25))).resolves.toEqual({
       fromVersion: 24,
       toVersion: 25,
       applied: [25],
@@ -356,6 +356,54 @@ describe("migrator end-to-end over node:sqlite", () => {
         "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'planning_request%' ORDER BY name",
       ),
     ).resolves.toEqual([]);
+    await expect(
+      store.all("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"),
+    ).resolves.toEqual(tablesBefore);
+  });
+
+  it("upgrades migration 25 to 26 without changing Planning request storage", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 25));
+    await store.run(
+      `INSERT INTO planning_request (
+  request_id, kind, target, intent, payload_hash, payload_json, source_status,
+  source_chat_id, source_message_id, source_attachment_id, provenance_json,
+  plan_conversation_id, proposal_id, requested_date_key, resolved_date_key,
+  lifecycle, attention, revision, created_at_ms, updated_at_ms,
+  device_id, hlc_physical_ms, hlc_counter
+) VALUES (?, 'plan_question', 'active_plan', ?, ?, ?, 'linked', ?, ?, NULL, NULL,
+  NULL, NULL, NULL, NULL, 'open', 'none', 1, 1, 1, 'device-1', 1, 0)`,
+      ["request-1", "Review next week.", "a".repeat(64), "{}", "chat-1", "message-1"],
+    );
+
+    await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
+      fromVersion: 25,
+      toVersion: 26,
+      applied: [26],
+    });
+    await expect(store.get("SELECT request_id FROM planning_request")).resolves.toEqual({
+      request_id: "request-1",
+    });
+    await expect(
+      store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='chat_plan_outbox'"),
+    ).resolves.toEqual({ name: "chat_plan_outbox" });
+    await expect(store.all("PRAGMA foreign_key_check")).resolves.toEqual([]);
+  });
+
+  it("rolls back a failed migration 26 without partial Chat outbox storage", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 25));
+    const tablesBefore = await store.all(
+      "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+    );
+    const broken = {
+      ...MIGRATIONS[25]!,
+      sql: `${MIGRATIONS[25]!.sql}\nINSERT INTO missing_table VALUES (1);`,
+    };
+
+    await expect(runMigrations(store, [...MIGRATIONS.slice(0, 25), broken])).rejects.toThrow();
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 25 });
+    await expect(
+      store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='chat_plan_outbox'"),
+    ).resolves.toBeUndefined();
     await expect(
       store.all("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"),
     ).resolves.toEqual(tablesBefore);

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -239,8 +239,8 @@ describe("sync failure repository", () => {
     expect(dump).not.toContain("# sync_failure");
     expect(dump).toContain("# plan_reconciliation_job");
     expect(dump).toContain("# plan_reconciliation_item");
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 25 });
-    expect(DUMP_TABLES).toHaveLength(57);
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
+    expect(DUMP_TABLES).toHaveLength(58);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");
     expect(DUMP_TABLES.map(({ table }) => table)).toContain("plan_reconciliation_job");
@@ -249,6 +249,7 @@ describe("sync failure repository", () => {
     expect(DUMP_TABLES.map(({ table }) => table)).toContain("plan_replacement");
     expect(DUMP_TABLES.map(({ table }) => table)).toContain("plan_race_outcome");
     expect(DUMP_TABLES.map(({ table }) => table)).toContain("plan_weekly_review");
+    expect(DUMP_TABLES.map(({ table }) => table)).toContain("chat_plan_outbox");
     expect(DERIVED_TABLES).not.toContain("sync_failure");
   });
 });

--- a/packages/kernel/src/chat-plan-outbox/index.ts
+++ b/packages/kernel/src/chat-plan-outbox/index.ts
@@ -1,0 +1,1 @@
+export * from "./repository.js";

--- a/packages/kernel/src/chat-plan-outbox/repository.ts
+++ b/packages/kernel/src/chat-plan-outbox/repository.ts
@@ -1,0 +1,474 @@
+import type { CryptoPort } from "../ports/crypto.js";
+import {
+  canonicalizeCreatePlanningRequestPayload,
+  hashCreatePlanningRequestPayload,
+  parseCreatePlanningRequestPayload,
+  type CreatePlanningRequestPayload,
+} from "../planning/request-repository.js";
+import type { MigratorStore } from "../store/migrator.js";
+import type { Row, SqlStore } from "../store/ports.js";
+
+export type ChatPlanOutboxState = "pending" | "failed" | "delivered" | "cancelled";
+
+interface ChatPlanOutboxBase {
+  readonly requestId: string;
+  readonly payloadHash: string;
+  readonly attemptCount: number;
+  readonly createdAtMs: number;
+  readonly updatedAtMs: number;
+}
+
+export type ChatPlanOutboxRecord =
+  | (ChatPlanOutboxBase & {
+      readonly state: "pending";
+      readonly payload: CreatePlanningRequestPayload;
+    })
+  | (ChatPlanOutboxBase & {
+      readonly state: "failed";
+      readonly payload: CreatePlanningRequestPayload;
+      readonly failureCode: string;
+      readonly retryable: boolean;
+    })
+  | (ChatPlanOutboxBase & {
+      readonly state: "delivered";
+      readonly payload: CreatePlanningRequestPayload | null;
+      readonly deliveredAtMs: number;
+      readonly sourceDeletedAtMs: number | null;
+    })
+  | (ChatPlanOutboxBase & {
+      readonly state: "cancelled";
+      readonly payload: null;
+      readonly cancelledAtMs: number;
+      readonly cancelReason: "source_conversation_deleted";
+    });
+
+export interface CreateChatPlanOutboxInput {
+  readonly payload: CreatePlanningRequestPayload;
+  readonly createdAtMs: number;
+}
+
+export interface BeginChatPlanDeliveryInput {
+  readonly requestId: string;
+  readonly attemptedAtMs: number;
+}
+
+export interface FailChatPlanDeliveryInput {
+  readonly requestId: string;
+  readonly failureCode: string;
+  readonly retryable: boolean;
+  readonly failedAtMs: number;
+}
+
+export interface DeliverChatPlanOutboxInput {
+  readonly requestId: string;
+  readonly deliveredAtMs: number;
+}
+
+export interface CancelChatPlanOutboxInput {
+  readonly requestId: string;
+  readonly cancelledAtMs: number;
+}
+
+export interface DetachDeliveredChatPlanSourceInput {
+  readonly requestId: string;
+  readonly sourceDeletedAtMs: number;
+}
+
+export interface ChatPlanOutboxRepository {
+  createOrGet(input: CreateChatPlanOutboxInput): Promise<ChatPlanOutboxRecord>;
+  read(requestId: string): Promise<ChatPlanOutboxRecord | undefined>;
+  readRecoverable(): Promise<readonly ChatPlanOutboxRecord[]>;
+  beginDelivery(input: BeginChatPlanDeliveryInput): Promise<ChatPlanOutboxRecord>;
+  markFailed(input: FailChatPlanDeliveryInput): Promise<ChatPlanOutboxRecord>;
+  markDelivered(input: DeliverChatPlanOutboxInput): Promise<ChatPlanOutboxRecord>;
+  cancelUndelivered(input: CancelChatPlanOutboxInput): Promise<ChatPlanOutboxRecord>;
+  detachDeliveredSource(input: DetachDeliveredChatPlanSourceInput): Promise<ChatPlanOutboxRecord>;
+}
+
+export type ChatPlanOutboxStoreErrorCode =
+  | "invalid-create"
+  | "request-conflict"
+  | "missing-outbox"
+  | "invalid-transition"
+  | "non-retryable"
+  | "corrupt-record";
+
+export class ChatPlanOutboxStoreError extends Error {
+  readonly code: ChatPlanOutboxStoreErrorCode;
+
+  constructor(code: ChatPlanOutboxStoreErrorCode) {
+    super(`chat plan outbox rejected: ${code}`);
+    this.name = "ChatPlanOutboxStoreError";
+    this.code = code;
+  }
+}
+
+type ChatPlanOutboxStore = SqlStore & Pick<MigratorStore, "transaction">;
+
+const ID = /^.{1,512}$/su;
+const SHA256 = /^[0-9a-f]{64}$/u;
+const FAILURE_CODE = /^.{1,128}$/su;
+
+function validId(value: unknown): value is string {
+  return typeof value === "string" && ID.test(value);
+}
+
+function validInstant(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function text(row: Row, key: string): string {
+  const value = row[key];
+  if (typeof value !== "string") throw new ChatPlanOutboxStoreError("corrupt-record");
+  return value;
+}
+
+function integer(row: Row, key: string): number {
+  const value = row[key];
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    throw new ChatPlanOutboxStoreError("corrupt-record");
+  }
+  return value;
+}
+
+function nullableText(row: Row, key: string): string | null {
+  const value = row[key];
+  if (value !== null && typeof value !== "string") {
+    throw new ChatPlanOutboxStoreError("corrupt-record");
+  }
+  return value;
+}
+
+function nullableInteger(row: Row, key: string): number | null {
+  const value = row[key];
+  if (value !== null && (typeof value !== "number" || !Number.isSafeInteger(value))) {
+    throw new ChatPlanOutboxStoreError("corrupt-record");
+  }
+  return value;
+}
+
+function nullableBoolean(row: Row, key: string): boolean | null {
+  const value = nullableInteger(row, key);
+  if (value === null) return null;
+  if (value !== 0 && value !== 1) throw new ChatPlanOutboxStoreError("corrupt-record");
+  return value === 1;
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    throw new ChatPlanOutboxStoreError("corrupt-record");
+  }
+}
+
+async function mapRow(crypto: CryptoPort, row: Row): Promise<ChatPlanOutboxRecord> {
+  const requestId = text(row, "request_id");
+  const state = text(row, "state") as ChatPlanOutboxState;
+  const payloadHash = text(row, "payload_hash");
+  const payloadJson = nullableText(row, "payload_json");
+  const attemptCount = integer(row, "attempt_count");
+  const failureCode = nullableText(row, "failure_code");
+  const retryable = nullableBoolean(row, "retryable");
+  const deliveredAtMs = nullableInteger(row, "delivered_at_ms");
+  const sourceDeletedAtMs = nullableInteger(row, "source_deleted_at_ms");
+  const cancelledAtMs = nullableInteger(row, "cancelled_at_ms");
+  const cancelReason = nullableText(row, "cancel_reason");
+  const createdAtMs = integer(row, "created_at_ms");
+  const updatedAtMs = integer(row, "updated_at_ms");
+  if (
+    !validId(requestId) ||
+    !SHA256.test(payloadHash) ||
+    attemptCount < 0 ||
+    !validInstant(createdAtMs) ||
+    !validInstant(updatedAtMs) ||
+    updatedAtMs < createdAtMs
+  ) {
+    throw new ChatPlanOutboxStoreError("corrupt-record");
+  }
+  let payload: CreatePlanningRequestPayload | null = null;
+  if (payloadJson !== null) {
+    try {
+      payload = parseCreatePlanningRequestPayload(parseJson(payloadJson));
+    } catch {
+      throw new ChatPlanOutboxStoreError("corrupt-record");
+    }
+    if (
+      payload.requestId !== requestId ||
+      (await hashCreatePlanningRequestPayload(crypto, payload)) !== payloadHash
+    ) {
+      throw new ChatPlanOutboxStoreError("corrupt-record");
+    }
+  }
+  const base: ChatPlanOutboxBase = Object.freeze({
+    requestId,
+    payloadHash,
+    attemptCount,
+    createdAtMs,
+    updatedAtMs,
+  });
+  if (state === "pending") {
+    if (
+      payload === null ||
+      failureCode !== null ||
+      retryable !== null ||
+      deliveredAtMs !== null ||
+      sourceDeletedAtMs !== null ||
+      cancelledAtMs !== null ||
+      cancelReason !== null
+    ) {
+      throw new ChatPlanOutboxStoreError("corrupt-record");
+    }
+    return Object.freeze({ ...base, state, payload });
+  }
+  if (state === "failed") {
+    if (
+      payload === null ||
+      attemptCount < 1 ||
+      failureCode === null ||
+      !FAILURE_CODE.test(failureCode) ||
+      retryable === null ||
+      deliveredAtMs !== null ||
+      sourceDeletedAtMs !== null ||
+      cancelledAtMs !== null ||
+      cancelReason !== null
+    ) {
+      throw new ChatPlanOutboxStoreError("corrupt-record");
+    }
+    return Object.freeze({ ...base, state, payload, failureCode, retryable });
+  }
+  if (state === "delivered") {
+    if (
+      attemptCount < 1 ||
+      failureCode !== null ||
+      retryable !== null ||
+      deliveredAtMs === null ||
+      !validInstant(deliveredAtMs) ||
+      deliveredAtMs < createdAtMs ||
+      cancelledAtMs !== null ||
+      cancelReason !== null ||
+      (sourceDeletedAtMs === null) !== (payload !== null) ||
+      (sourceDeletedAtMs !== null &&
+        (!validInstant(sourceDeletedAtMs) || sourceDeletedAtMs < deliveredAtMs))
+    ) {
+      throw new ChatPlanOutboxStoreError("corrupt-record");
+    }
+    return Object.freeze({ ...base, state, payload, deliveredAtMs, sourceDeletedAtMs });
+  }
+  if (state === "cancelled") {
+    if (
+      payload !== null ||
+      failureCode !== null ||
+      retryable !== null ||
+      deliveredAtMs !== null ||
+      sourceDeletedAtMs !== null ||
+      cancelledAtMs === null ||
+      !validInstant(cancelledAtMs) ||
+      cancelledAtMs < createdAtMs ||
+      cancelReason !== "source_conversation_deleted"
+    ) {
+      throw new ChatPlanOutboxStoreError("corrupt-record");
+    }
+    return Object.freeze({ ...base, state, payload: null, cancelledAtMs, cancelReason });
+  }
+  throw new ChatPlanOutboxStoreError("corrupt-record");
+}
+
+function validateMutation(requestId: string, instant: number): void {
+  if (!validId(requestId) || !validInstant(instant)) {
+    throw new ChatPlanOutboxStoreError("invalid-transition");
+  }
+}
+
+export function createChatPlanOutboxRepository(
+  store: ChatPlanOutboxStore,
+  crypto: CryptoPort,
+): ChatPlanOutboxRepository {
+  const read = async (requestId: string): Promise<ChatPlanOutboxRecord | undefined> => {
+    if (!validId(requestId)) throw new ChatPlanOutboxStoreError("missing-outbox");
+    const row = await store.get("SELECT * FROM chat_plan_outbox WHERE request_id = ?", [requestId]);
+    return row === undefined ? undefined : mapRow(crypto, row);
+  };
+
+  const requireRecord = async (requestId: string): Promise<ChatPlanOutboxRecord> => {
+    const record = await read(requestId);
+    if (record === undefined) throw new ChatPlanOutboxStoreError("missing-outbox");
+    return record;
+  };
+
+  return {
+    async createOrGet(input) {
+      if (!validInstant(input.createdAtMs)) {
+        throw new ChatPlanOutboxStoreError("invalid-create");
+      }
+      let payload: CreatePlanningRequestPayload;
+      try {
+        payload = parseCreatePlanningRequestPayload(input.payload);
+      } catch {
+        throw new ChatPlanOutboxStoreError("invalid-create");
+      }
+      const payloadJson = canonicalizeCreatePlanningRequestPayload(payload);
+      const payloadHash = await hashCreatePlanningRequestPayload(crypto, payload);
+      return store.transaction(async () => {
+        const existing = await read(payload.requestId);
+        if (existing !== undefined) {
+          if (
+            existing.payloadHash !== payloadHash ||
+            (existing.payload !== null &&
+              canonicalizeCreatePlanningRequestPayload(existing.payload) !== payloadJson)
+          ) {
+            throw new ChatPlanOutboxStoreError("request-conflict");
+          }
+          return existing;
+        }
+        await store.run(
+          `INSERT INTO chat_plan_outbox (
+  request_id, state, payload_json, payload_hash, attempt_count,
+  failure_code, retryable, delivered_at_ms, source_deleted_at_ms,
+  cancelled_at_ms, cancel_reason, created_at_ms, updated_at_ms
+) VALUES (?, 'pending', ?, ?, 0, NULL, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
+          [payload.requestId, payloadJson, payloadHash, input.createdAtMs, input.createdAtMs],
+        );
+        return requireRecord(payload.requestId);
+      });
+    },
+
+    read,
+
+    async readRecoverable() {
+      const rows = await store.all(
+        `SELECT request_id FROM chat_plan_outbox
+WHERE state = 'pending' OR (state = 'failed' AND retryable = 1)
+ORDER BY updated_at_ms ASC, request_id ASC`,
+      );
+      return Object.freeze(
+        await Promise.all(rows.map((row) => requireRecord(text(row, "request_id")))),
+      );
+    },
+
+    async beginDelivery(input) {
+      validateMutation(input.requestId, input.attemptedAtMs);
+      return store.transaction(async () => {
+        const current = await requireRecord(input.requestId);
+        if (current.state === "failed" && !current.retryable) {
+          throw new ChatPlanOutboxStoreError("non-retryable");
+        }
+        if (
+          (current.state !== "pending" && current.state !== "failed") ||
+          input.attemptedAtMs < current.updatedAtMs
+        ) {
+          throw new ChatPlanOutboxStoreError("invalid-transition");
+        }
+        await store.run(
+          `UPDATE chat_plan_outbox SET
+  state = 'pending', attempt_count = attempt_count + 1,
+  failure_code = NULL, retryable = NULL, updated_at_ms = ?
+WHERE request_id = ? AND state IN ('pending','failed')`,
+          [input.attemptedAtMs, input.requestId],
+        );
+        const updated = await requireRecord(input.requestId);
+        if (updated.state !== "pending" || updated.attemptCount !== current.attemptCount + 1) {
+          throw new ChatPlanOutboxStoreError("invalid-transition");
+        }
+        return updated;
+      });
+    },
+
+    async markFailed(input) {
+      validateMutation(input.requestId, input.failedAtMs);
+      if (!FAILURE_CODE.test(input.failureCode)) {
+        throw new ChatPlanOutboxStoreError("invalid-transition");
+      }
+      return store.transaction(async () => {
+        const current = await requireRecord(input.requestId);
+        if (
+          current.state === "failed" &&
+          current.failureCode === input.failureCode &&
+          current.retryable === input.retryable
+        ) {
+          return current;
+        }
+        if (
+          current.state !== "pending" ||
+          current.attemptCount < 1 ||
+          input.failedAtMs < current.updatedAtMs
+        ) {
+          throw new ChatPlanOutboxStoreError("invalid-transition");
+        }
+        await store.run(
+          `UPDATE chat_plan_outbox SET
+  state = 'failed', failure_code = ?, retryable = ?, updated_at_ms = ?
+WHERE request_id = ? AND state = 'pending' AND attempt_count > 0`,
+          [input.failureCode, input.retryable ? 1 : 0, input.failedAtMs, input.requestId],
+        );
+        return requireRecord(input.requestId);
+      });
+    },
+
+    async markDelivered(input) {
+      validateMutation(input.requestId, input.deliveredAtMs);
+      return store.transaction(async () => {
+        const current = await requireRecord(input.requestId);
+        if (current.state === "delivered") return current;
+        if (
+          current.state !== "pending" ||
+          current.attemptCount < 1 ||
+          input.deliveredAtMs < current.updatedAtMs
+        ) {
+          throw new ChatPlanOutboxStoreError("invalid-transition");
+        }
+        await store.run(
+          `UPDATE chat_plan_outbox SET
+  state = 'delivered', delivered_at_ms = ?, updated_at_ms = ?
+WHERE request_id = ? AND state = 'pending' AND attempt_count > 0`,
+          [input.deliveredAtMs, input.deliveredAtMs, input.requestId],
+        );
+        return requireRecord(input.requestId);
+      });
+    },
+
+    async cancelUndelivered(input) {
+      validateMutation(input.requestId, input.cancelledAtMs);
+      return store.transaction(async () => {
+        const current = await requireRecord(input.requestId);
+        if (current.state === "cancelled") return current;
+        if (
+          (current.state !== "pending" && current.state !== "failed") ||
+          input.cancelledAtMs < current.updatedAtMs
+        ) {
+          throw new ChatPlanOutboxStoreError("invalid-transition");
+        }
+        await store.run(
+          `UPDATE chat_plan_outbox SET
+  state = 'cancelled', payload_json = NULL, failure_code = NULL, retryable = NULL,
+  cancelled_at_ms = ?, cancel_reason = 'source_conversation_deleted', updated_at_ms = ?
+WHERE request_id = ? AND state IN ('pending','failed')`,
+          [input.cancelledAtMs, input.cancelledAtMs, input.requestId],
+        );
+        return requireRecord(input.requestId);
+      });
+    },
+
+    async detachDeliveredSource(input) {
+      validateMutation(input.requestId, input.sourceDeletedAtMs);
+      return store.transaction(async () => {
+        const current = await requireRecord(input.requestId);
+        if (current.state === "delivered" && current.sourceDeletedAtMs !== null) return current;
+        if (
+          current.state !== "delivered" ||
+          input.sourceDeletedAtMs < current.updatedAtMs ||
+          input.sourceDeletedAtMs < current.deliveredAtMs
+        ) {
+          throw new ChatPlanOutboxStoreError("invalid-transition");
+        }
+        await store.run(
+          `UPDATE chat_plan_outbox SET
+  payload_json = NULL, source_deleted_at_ms = ?, updated_at_ms = ?
+WHERE request_id = ? AND state = 'delivered' AND source_deleted_at_ms IS NULL`,
+          [input.sourceDeletedAtMs, input.sourceDeletedAtMs, input.requestId],
+        );
+        return requireRecord(input.requestId);
+      });
+    },
+  };
+}

--- a/packages/kernel/src/store/dump.ts
+++ b/packages/kernel/src/store/dump.ts
@@ -28,6 +28,7 @@ export const DUMP_TABLES = [
   { table: "analytics_curve_generation_promotion", orderBy: "generation_id" },
   { table: "anchor_history", orderBy: "id" },
   { table: "athlete", orderBy: "id" },
+  { table: "chat_plan_outbox", orderBy: "request_id" },
   { table: "dedup_confirmation", orderBy: "id" },
   { table: "field_merge_override_overlay", orderBy: "id" },
   { table: "ingest_candidate_index", orderBy: "candidate_id" },

--- a/packages/kernel/src/store/export/ports.ts
+++ b/packages/kernel/src/store/export/ports.ts
@@ -85,6 +85,7 @@ export const PURE_AUTHORED_TABLES = [
   "field_merge_override_overlay",
   "pool_size_correction_overlay",
   "dedup_confirmation",
+  "chat_plan_outbox",
   "plan",
   "plan_adaptation_ledger",
   "plan_conversation",

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -19,3 +19,4 @@ export * from "./sync-failure-repository.js";
 export * from "./units-preference-repository.js";
 export * from "../planning/index.js";
 export * from "../chat-attachments/index.js";
+export * from "../chat-plan-outbox/index.js";

--- a/packages/kernel/src/store/migrations/026_chat_plan_outbox.sql
+++ b/packages/kernel/src/store/migrations/026_chat_plan_outbox.sql
@@ -1,0 +1,92 @@
+CREATE TABLE chat_plan_outbox (
+  request_id TEXT PRIMARY KEY CHECK (length(request_id) BETWEEN 1 AND 512),
+  state TEXT NOT NULL CHECK (state IN ('pending','failed','delivered','cancelled')),
+  payload_json TEXT CHECK (payload_json IS NULL OR json_valid(payload_json)),
+  payload_hash TEXT NOT NULL
+    CHECK (
+      length(payload_hash) = 64
+      AND payload_hash = lower(payload_hash)
+      AND payload_hash NOT GLOB '*[^0-9a-f]*'
+    ),
+  attempt_count INTEGER NOT NULL CHECK (attempt_count >= 0),
+  failure_code TEXT CHECK (
+    failure_code IS NULL OR length(failure_code) BETWEEN 1 AND 128
+  ),
+  retryable INTEGER CHECK (retryable IS NULL OR retryable IN (0,1)),
+  delivered_at_ms INTEGER CHECK (delivered_at_ms IS NULL OR delivered_at_ms >= 0),
+  source_deleted_at_ms INTEGER CHECK (
+    source_deleted_at_ms IS NULL OR source_deleted_at_ms >= 0
+  ),
+  cancelled_at_ms INTEGER CHECK (cancelled_at_ms IS NULL OR cancelled_at_ms >= 0),
+  cancel_reason TEXT CHECK (
+    cancel_reason IS NULL OR cancel_reason = 'source_conversation_deleted'
+  ),
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+  CHECK (
+    (state = 'pending'
+      AND payload_json IS NOT NULL
+      AND failure_code IS NULL
+      AND retryable IS NULL
+      AND delivered_at_ms IS NULL
+      AND source_deleted_at_ms IS NULL
+      AND cancelled_at_ms IS NULL
+      AND cancel_reason IS NULL)
+    OR
+    (state = 'failed'
+      AND payload_json IS NOT NULL
+      AND attempt_count > 0
+      AND failure_code IS NOT NULL
+      AND retryable IS NOT NULL
+      AND delivered_at_ms IS NULL
+      AND source_deleted_at_ms IS NULL
+      AND cancelled_at_ms IS NULL
+      AND cancel_reason IS NULL)
+    OR
+    (state = 'delivered'
+      AND attempt_count > 0
+      AND failure_code IS NULL
+      AND retryable IS NULL
+      AND delivered_at_ms IS NOT NULL
+      AND cancelled_at_ms IS NULL
+      AND cancel_reason IS NULL
+      AND (
+        (source_deleted_at_ms IS NULL AND payload_json IS NOT NULL)
+        OR
+        (source_deleted_at_ms IS NOT NULL AND payload_json IS NULL)
+      ))
+    OR
+    (state = 'cancelled'
+      AND payload_json IS NULL
+      AND failure_code IS NULL
+      AND retryable IS NULL
+      AND delivered_at_ms IS NULL
+      AND source_deleted_at_ms IS NULL
+      AND cancelled_at_ms IS NOT NULL
+      AND cancel_reason = 'source_conversation_deleted')
+  )
+) STRICT;
+
+CREATE INDEX idx_chat_plan_outbox_recoverable
+ON chat_plan_outbox(updated_at_ms, request_id)
+WHERE state = 'pending' OR (state = 'failed' AND retryable = 1);
+
+CREATE TRIGGER chat_plan_outbox_no_delete
+BEFORE DELETE ON chat_plan_outbox
+BEGIN
+  SELECT RAISE(ABORT, 'chat plan outbox records are durable');
+END;
+
+CREATE TRIGGER chat_plan_outbox_cancelled_no_update
+BEFORE UPDATE ON chat_plan_outbox
+WHEN OLD.state = 'cancelled'
+BEGIN
+  SELECT RAISE(ABORT, 'cancelled chat plan outbox records are immutable');
+END;
+
+CREATE TRIGGER chat_plan_outbox_detached_delivered_no_update
+BEFORE UPDATE ON chat_plan_outbox
+WHEN OLD.state = 'delivered' AND OLD.source_deleted_at_ms IS NOT NULL
+BEGIN
+  SELECT RAISE(ABORT, 'detached delivered chat plan outbox records are immutable');
+END;

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -23,6 +23,7 @@ import planWeeklyReview022 from "./022_plan_weekly_review.sql";
 import planRaceOutcome023 from "./023_plan_race_outcome.sql";
 import chatAttachments024 from "./024_chat_attachments.sql";
 import planningRequests025 from "./025_planning_requests.sql";
+import chatPlanOutbox026 from "./026_chat_plan_outbox.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -63,4 +64,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 23, name: "023_plan_race_outcome", sql: planRaceOutcome023 },
   { version: 24, name: "024_chat_attachments", sql: chatAttachments024 },
   { version: 25, name: "025_planning_requests", sql: planningRequests025 },
+  { version: 26, name: "026_chat_plan_outbox", sql: chatPlanOutbox026 },
 ];

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -29,6 +29,7 @@ const EXPECTED_TABLES = [
 ];
 const EXPECTED_FULL_TABLES = [
   ...EXPECTED_TABLES,
+  "chat_plan_outbox",
   "plan",
   "plan_adaptation_ledger",
   "plan_conversation",
@@ -210,6 +211,7 @@ describe("001_init migration", () => {
       { version: 23, name: "023_plan_race_outcome" },
       { version: 24, name: "024_chat_attachments" },
       { version: 25, name: "025_planning_requests" },
+      { version: 26, name: "026_chat_plan_outbox" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -301,7 +303,7 @@ describe("001_init migration", () => {
     expect(MIGRATIONS[2]!.sql).toBe(MIGRATION_003);
   });
 
-  it("applies all migrations with exactly sixty-seven tables and no foreign-key violations", () => {
+  it("applies all migrations with exactly sixty-eight tables and no foreign-key violations", () => {
     db = openFull();
     const names = (
       db
@@ -311,7 +313,7 @@ describe("001_init migration", () => {
       .map((row) => row.name)
       .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
-    expect(names).toHaveLength(67);
+    expect(names).toHaveLength(68);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
@@ -563,6 +565,9 @@ describe("001_init migration", () => {
         "planning_request_terminal_result_no_delete",
         "planning_request_tombstone_no_update",
         "planning_request_tombstone_no_delete",
+        "chat_plan_outbox_no_delete",
+        "chat_plan_outbox_cancelled_no_update",
+        "chat_plan_outbox_detached_delivered_no_update",
       ]),
     );
 
@@ -790,6 +795,7 @@ describe("001_init migration", () => {
       { table: "analytics_curve_generation_promotion", orderBy: "generation_id" },
       { table: "anchor_history", orderBy: "id" },
       { table: "athlete", orderBy: "id" },
+      { table: "chat_plan_outbox", orderBy: "request_id" },
       { table: "dedup_confirmation", orderBy: "id" },
       { table: "field_merge_override_overlay", orderBy: "id" },
       { table: "ingest_candidate_index", orderBy: "candidate_id" },
@@ -841,7 +847,7 @@ describe("001_init migration", () => {
       { table: "workout", orderBy: "workout_key" },
       { table: "zone_set_history", orderBy: "id" },
     ]);
-    expect(DUMP_TABLES).toHaveLength(57);
+    expect(DUMP_TABLES).toHaveLength(58);
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("source_watermark");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_failure");
@@ -898,7 +904,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     }>;
     expect(tables.find((row) => row.name === "sync_failure")?.strict).toBe(1);
     expect(db.prepare("PRAGMA foreign_key_list(sync_failure)").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(57);
+    expect(DUMP_TABLES).toHaveLength(58);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(PURE_AUTHORED_TABLES).not.toContain("sync_failure");
     expect(MIXED_AUTHORED_TABLES).not.toContain("sync_failure");
@@ -957,7 +963,7 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       expect(tables.find((row) => row.name === name)?.strict).toBe(1);
     }
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
-    expect(DUMP_TABLES).toHaveLength(57);
+    expect(DUMP_TABLES).toHaveLength(58);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("analytics_curve_refresh_failure");
     expect(DERIVED_TABLES).not.toContain("analytics_curve_generation");
   });
@@ -1050,6 +1056,24 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
       ]),
     );
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+  });
+
+  it("adds strict durable Chat Plan outbox storage", () => {
+    db = openFull();
+    const table = (
+      db.prepare("PRAGMA table_list").all() as Array<{ name: string; strict: number }>
+    ).find((row) => row.name === "chat_plan_outbox");
+    expect(table?.strict).toBe(1);
+    expect(db.prepare("PRAGMA foreign_key_list(chat_plan_outbox)").all()).toEqual([]);
+    expect(
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_chat_plan_outbox_recoverable'",
+        )
+        .get(),
+    ).toEqual({ name: "idx_chat_plan_outbox_recoverable" });
+    expect(DUMP_TABLES.map(({ table: name }) => name)).toContain("chat_plan_outbox");
+    expect(PURE_AUTHORED_TABLES).toContain("chat_plan_outbox");
   });
 
   it("adds strict authored Plan and Plan Workout tables without changing planned_workout", () => {


### PR DESCRIPTION
## Summary
- persist Chat-owned Plan requests before transport
- enforce retry, delivery, cancellation, and source-deletion lifecycle rules
- include outbox records in deterministic store dumps and authored exports

## Verification
- 144 focused storage and migration tests passed
- repository-wide static checks passed
- bounded full suite: 712 files passed, 5 skipped; 10,625 tests passed, 17 skipped
- independent autoreview passed with no findings