### PR TITLE
feat(chat): deliver Plan requests safely

### DIFF
--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -176,6 +176,10 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   selfTest: 2 * 60_000,
   getPlanState: 30_000,
   executePlanTransition: 11 * 60_000,
+  createPlanningRequest: 30_000,
+  getPlanningRequest: 30_000,
+  retryPlanningRequest: 30_000,
+  resumePlanningRequests: 30_000,
 };
 
 function positiveSafeInteger(value: unknown): value is number {

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -185,6 +185,26 @@ const rpcDeadlineCases = [
     { transitionId: "PL-T01", commandId: "command-1", sourceConversationId: null },
     660_000,
   ],
+  [
+    "createPlanningRequest",
+    {
+      payload: {
+        requestId: "request-1",
+        kind: "plan_question",
+        intent: "Review the current week.",
+        source: { chatId: "chat-1", messageId: "message-1" },
+        sourceSnapshot: {
+          capturedAt: "1998-08-24T08:00:00.000Z",
+          attachment: null,
+          selectedWorkout: null,
+        },
+      },
+    },
+    30_000,
+  ],
+  ["getPlanningRequest", { requestId: "request-1" }, 30_000],
+  ["retryPlanningRequest", { requestId: "request-1" }, 30_000],
+  ["resumePlanningRequests", {}, 30_000],
 ] as const satisfies ReadonlyArray<readonly [CoachRpcMethodName, unknown, number]>;
 
 class ControllableSocket extends EventTarget {
@@ -1127,6 +1147,10 @@ describe("RPC receive and observers", () => {
           status: "unsupported-capability",
           capability: "planning",
         },
+        createPlanningRequest: { status: "rejected", reason: "invalid_request" },
+        getPlanningRequest: { status: "missing" },
+        retryPlanningRequest: { status: "missing" },
+        resumePlanningRequests: { deliveries: [] },
       };
       socket.emitMessage(
         serializeCoachRpcEnvelope({

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -17,3 +17,4 @@ export * from "./chat-queue.js";
 export * from "./chat-attachment.js";
 export * from "./planning-read.js";
 export * from "./plan-chat-card.js";
+export * from "./planning-request.js";

--- a/packages/coach-contract/src/planning-request.ts
+++ b/packages/coach-contract/src/planning-request.ts
@@ -1,0 +1,279 @@
+import { z } from "zod";
+
+const PlanningRequestIdSchema = z.string().min(1).max(512);
+const PlanningRequestInstantSchema = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+const PlanningRequestTimestampSchema = z.iso.datetime({ offset: true }).max(128);
+const PlanningRequestCivilDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/u);
+
+export const PlanningRequestKindSchema = z.enum([
+  "workout_review",
+  "plan_question",
+  "plan_change",
+  "plan_creation",
+]);
+export type PlanningRequestKind = z.infer<typeof PlanningRequestKindSchema>;
+
+export const PlanningRequestTargetSchema = z.enum(["active_plan", "draft", "plan_creation"]);
+export type PlanningRequestTarget = z.infer<typeof PlanningRequestTargetSchema>;
+
+export const CreatePlanningRequestPayloadSchema = z
+  .object({
+    requestId: PlanningRequestIdSchema,
+    kind: PlanningRequestKindSchema,
+    intent: z.string().min(1).max(20_000),
+    source: z
+      .object({
+        chatId: PlanningRequestIdSchema,
+        messageId: PlanningRequestIdSchema,
+        attachmentId: PlanningRequestIdSchema.optional(),
+      })
+      .strict(),
+    sourceSnapshot: z
+      .object({
+        capturedAt: PlanningRequestTimestampSchema,
+        attachment: z
+          .object({
+            attachmentId: PlanningRequestIdSchema,
+            displayName: z.string().min(1).max(512),
+            extension: z.enum(["zwo", "mrc", "erg"]),
+          })
+          .strict()
+          .nullable(),
+        selectedWorkout: z
+          .object({
+            setId: PlanningRequestIdSchema,
+            workoutId: PlanningRequestIdSchema,
+            workout: z.record(z.string(), z.json()),
+          })
+          .strict()
+          .nullable(),
+      })
+      .strict(),
+    requestedDate: PlanningRequestCivilDateSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (
+      value.kind === "workout_review" &&
+      (value.source.attachmentId === undefined || value.sourceSnapshot.selectedWorkout === null)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "workout review requires an attachment and selected Workout",
+      });
+    }
+    if (
+      value.sourceSnapshot.selectedWorkout !== null &&
+      value.sourceSnapshot.attachment === null
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["sourceSnapshot", "attachment"],
+        message: "selected Workout requires attachment provenance",
+      });
+    }
+    if (value.source.attachmentId !== value.sourceSnapshot.attachment?.attachmentId) {
+      context.addIssue({
+        code: "custom",
+        path: ["source", "attachmentId"],
+        message: "source attachment must match its snapshot",
+      });
+    }
+  });
+export type CreatePlanningRequestPayload = z.infer<typeof CreatePlanningRequestPayloadSchema>;
+
+const PlanningRequestTerminalResultSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("applied"),
+      resultId: PlanningRequestIdSchema,
+      completedAtMs: PlanningRequestInstantSchema,
+      title: z.string().min(1).max(512),
+      detail: z.string().min(1).max(2_000),
+      workoutRef: z
+        .object({ setId: PlanningRequestIdSchema, workoutId: PlanningRequestIdSchema })
+        .strict()
+        .nullable(),
+      planRevisionId: PlanningRequestIdSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.enum(["rejected", "ended"]),
+      resultId: PlanningRequestIdSchema,
+      completedAtMs: PlanningRequestInstantSchema,
+      title: z.string().min(1).max(512),
+      detail: z.string().min(1).max(2_000),
+      workoutRef: z
+        .object({ setId: PlanningRequestIdSchema, workoutId: PlanningRequestIdSchema })
+        .strict()
+        .nullable(),
+      planRevisionId: PlanningRequestIdSchema.nullable(),
+    })
+    .strict(),
+]);
+
+export const PlanningRequestReadModelSchema = z
+  .object({
+    requestId: PlanningRequestIdSchema,
+    kind: PlanningRequestKindSchema,
+    target: PlanningRequestTargetSchema,
+    intent: z.string().min(1).max(20_000),
+    planConversationId: PlanningRequestIdSchema.nullable(),
+    proposalId: PlanningRequestIdSchema.nullable(),
+    requestedDateKey: z.number().int().positive().nullable(),
+    resolvedDateKey: z.number().int().positive().nullable(),
+    source: z
+      .object({
+        chatId: PlanningRequestIdSchema,
+        messageId: PlanningRequestIdSchema,
+        available: z.boolean(),
+      })
+      .strict(),
+    lifecycle: z.enum(["open", "applied", "rejected", "ended"]),
+    attention: z.enum([
+      "none",
+      "needs_review",
+      "date_conflict",
+      "revalidating",
+      "stale_base",
+      "apply_failed",
+    ]),
+    revision: z.number().int().positive(),
+    createdAtMs: PlanningRequestInstantSchema,
+    updatedAtMs: PlanningRequestInstantSchema,
+    terminalResult: PlanningRequestTerminalResultSchema.nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if ((value.lifecycle === "open") !== (value.terminalResult === null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["terminalResult"],
+        message: "terminal result must match request lifecycle",
+      });
+    }
+    if (value.lifecycle !== "open" && value.terminalResult?.kind !== value.lifecycle) {
+      context.addIssue({
+        code: "custom",
+        path: ["terminalResult", "kind"],
+        message: "terminal result kind must match request lifecycle",
+      });
+    }
+    if (value.attention !== "none" && (value.lifecycle !== "open" || value.proposalId === null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["attention"],
+        message: "request attention requires an open Proposal",
+      });
+    }
+  });
+export type PlanningRequestReadModel = z.infer<typeof PlanningRequestReadModelSchema>;
+
+export const PlanningRequestDeliverySchema = z
+  .object({
+    requestId: PlanningRequestIdSchema,
+    state: z.enum(["pending", "failed", "delivered", "cancelled"]),
+    attemptCount: z.number().int().nonnegative(),
+    failureCode: z.string().min(1).max(128).nullable(),
+    retryable: z.boolean(),
+    createdAtMs: PlanningRequestInstantSchema,
+    updatedAtMs: PlanningRequestInstantSchema,
+    deliveredAtMs: PlanningRequestInstantSchema.nullable(),
+    planningRequest: PlanningRequestReadModelSchema.nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if ((value.state === "failed") !== (value.failureCode !== null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["failureCode"],
+        message: "failure code must match failed delivery state",
+      });
+    }
+    if (
+      (value.state === "pending" && !value.retryable) ||
+      ((value.state === "delivered" || value.state === "cancelled") && value.retryable)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["retryable"],
+        message: "retryability must match delivery state",
+      });
+    }
+    if ((value.state === "delivered") !== (value.deliveredAtMs !== null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["deliveredAtMs"],
+        message: "delivery timestamp must match delivered state",
+      });
+    }
+    if (value.state === "delivered" && value.planningRequest === null) {
+      context.addIssue({
+        code: "custom",
+        path: ["planningRequest"],
+        message: "delivered state requires its Planning request",
+      });
+    }
+  });
+export type PlanningRequestDelivery = z.infer<typeof PlanningRequestDeliverySchema>;
+
+export const CreatePlanningRequestRpcParamsSchema = z
+  .object({ payload: CreatePlanningRequestPayloadSchema })
+  .strict();
+export type CreatePlanningRequestRpcParams = z.infer<
+  typeof CreatePlanningRequestRpcParamsSchema
+>;
+
+export const CreatePlanningRequestRpcResultSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("accepted"), delivery: PlanningRequestDeliverySchema }).strict(),
+  z
+    .object({
+      status: z.literal("rejected"),
+      reason: z.enum(["invalid_request", "request_conflict"]),
+    })
+    .strict(),
+]);
+export type CreatePlanningRequestRpcResult = z.infer<
+  typeof CreatePlanningRequestRpcResultSchema
+>;
+
+export const GetPlanningRequestRpcParamsSchema = z
+  .object({ requestId: PlanningRequestIdSchema })
+  .strict();
+export type GetPlanningRequestRpcParams = z.infer<typeof GetPlanningRequestRpcParamsSchema>;
+
+export const GetPlanningRequestRpcResultSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("found"), delivery: PlanningRequestDeliverySchema }).strict(),
+  z.object({ status: z.literal("missing") }).strict(),
+]);
+export type GetPlanningRequestRpcResult = z.infer<typeof GetPlanningRequestRpcResultSchema>;
+
+export const RetryPlanningRequestRpcParamsSchema = GetPlanningRequestRpcParamsSchema;
+export type RetryPlanningRequestRpcParams = GetPlanningRequestRpcParams;
+export const RetryPlanningRequestRpcResultSchema = GetPlanningRequestRpcResultSchema;
+export type RetryPlanningRequestRpcResult = GetPlanningRequestRpcResult;
+
+export const ResumePlanningRequestsRpcParamsSchema = z.object({}).strict();
+export type ResumePlanningRequestsRpcParams = z.infer<
+  typeof ResumePlanningRequestsRpcParamsSchema
+>;
+export const ResumePlanningRequestsRpcResultSchema = z
+  .object({ deliveries: z.array(PlanningRequestDeliverySchema) })
+  .strict();
+export type ResumePlanningRequestsRpcResult = z.infer<
+  typeof ResumePlanningRequestsRpcResultSchema
+>;
+
+export interface PlanningRequestOperations {
+  createPlanningRequest?(
+    request: CreatePlanningRequestRpcParams,
+  ): Promise<CreatePlanningRequestRpcResult>;
+  getPlanningRequest?(request: GetPlanningRequestRpcParams): Promise<GetPlanningRequestRpcResult>;
+  retryPlanningRequest?(
+    request: RetryPlanningRequestRpcParams,
+  ): Promise<RetryPlanningRequestRpcResult>;
+  resumePlanningRequests?(
+    request: ResumePlanningRequestsRpcParams,
+  ): Promise<ResumePlanningRequestsRpcResult>;
+}

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -124,6 +124,17 @@ import {
   GetPlanningReadModelRpcResultSchema,
   type PlanningReadOperations,
 } from "./planning-read.js";
+import {
+  CreatePlanningRequestRpcParamsSchema,
+  CreatePlanningRequestRpcResultSchema,
+  GetPlanningRequestRpcParamsSchema,
+  GetPlanningRequestRpcResultSchema,
+  ResumePlanningRequestsRpcParamsSchema,
+  ResumePlanningRequestsRpcResultSchema,
+  RetryPlanningRequestRpcParamsSchema,
+  RetryPlanningRequestRpcResultSchema,
+  type PlanningRequestOperations,
+} from "./planning-request.js";
 
 export const JsonValueSchema = z.json();
 export type JsonValue = z.infer<typeof JsonValueSchema>;
@@ -277,6 +288,10 @@ export const COACH_RPC_METHOD_NAMES = [
   "selfTest",
   "getPlanState",
   "executePlanTransition",
+  "createPlanningRequest",
+  "getPlanningRequest",
+  "retryPlanningRequest",
+  "resumePlanningRequests",
 ] as const satisfies readonly (keyof CoachRpcService)[];
 
 export const CoachRpcMethodNameSchema = z.enum(COACH_RPC_METHOD_NAMES);
@@ -1269,6 +1284,7 @@ export interface TelegramControlOperations {
 export type CoachRpcService = CoachEngine &
   CoachOperations &
   PlanningReadOperations &
+  PlanningRequestOperations &
   SpendOperations &
   CoachSelfTestOperations &
   TelegramControlOperations &
@@ -1763,6 +1779,38 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       params: ExecutePlanTransitionRpcParamsSchema,
     })
     .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("createPlanningRequest"),
+      params: CreatePlanningRequestRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("getPlanningRequest"),
+      params: GetPlanningRequestRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("retryPlanningRequest"),
+      params: RetryPlanningRequestRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("resumePlanningRequests"),
+      params: ResumePlanningRequestsRpcParamsSchema,
+    })
+    .strict(),
 ]);
 export type CoachRpcRequestEnvelope = z.infer<typeof CoachRpcRequestEnvelopeSchema>;
 
@@ -2240,6 +2288,30 @@ export const COACH_RPC_METHOD_REGISTRY = {
     requestSchema: ExecutePlanTransitionRpcParamsSchema,
     responseSchema: ExecutePlanTransitionRpcResultSchema,
     eventSchema: PlanProgressEventSchema,
+  },
+  createPlanningRequest: {
+    wireName: "createPlanningRequest",
+    requestSchema: CreatePlanningRequestRpcParamsSchema,
+    responseSchema: CreatePlanningRequestRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  getPlanningRequest: {
+    wireName: "getPlanningRequest",
+    requestSchema: GetPlanningRequestRpcParamsSchema,
+    responseSchema: GetPlanningRequestRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  retryPlanningRequest: {
+    wireName: "retryPlanningRequest",
+    requestSchema: RetryPlanningRequestRpcParamsSchema,
+    responseSchema: RetryPlanningRequestRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  resumePlanningRequests: {
+    wireName: "resumePlanningRequests",
+    requestSchema: ResumePlanningRequestsRpcParamsSchema,
+    responseSchema: ResumePlanningRequestsRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
   },
 } as const satisfies CoachRpcMethodRegistryShape;
 

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 28;
+export const PROTOCOL_VERSION = 29;

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../src/index.js";
 
 describe("chat queue contract", () => {
-  it("ships protocol 26 and rejects a blank enqueue without attachments", () => {
-    expect(PROTOCOL_VERSION).toBe(28);
+  it("ships protocol 29 and rejects a blank enqueue without attachments", () => {
+    expect(PROTOCOL_VERSION).toBe(29);
     expect(() =>
       EnqueueChatMessageRequestSchema.parse({
         chatId: "desktop",

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -151,8 +151,8 @@ describe("coach decision wire contract", () => {
     expect(parsed.entries).toHaveLength(1);
   });
 
-  it("projects resume completion explicitly at protocol 26", () => {
-    expect(PROTOCOL_VERSION).toBe(28);
+  it("projects resume completion explicitly at protocol 29", () => {
+    expect(PROTOCOL_VERSION).toBe(29);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -114,8 +114,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 26", () => {
-    expect(PROTOCOL_VERSION).toBe(28);
+  it("is 29", () => {
+    expect(PROTOCOL_VERSION).toBe(29);
   });
 
   it("requires Stop to name the exact active turn", () => {

--- a/packages/coach-contract/tests/planning-request-contract.test.ts
+++ b/packages/coach-contract/tests/planning-request-contract.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  CreatePlanningRequestPayloadSchema,
+  CreatePlanningRequestRpcResultSchema,
+  PlanningRequestDeliverySchema,
+} from "../src/index.js";
+
+const payload = {
+  requestId: "request-1",
+  kind: "workout_review" as const,
+  intent: "Review this Workout before I add it to my Plan.",
+  source: {
+    chatId: "chat-1",
+    messageId: "message-1",
+    attachmentId: "attachment-1",
+  },
+  sourceSnapshot: {
+    capturedAt: "1998-08-24T08:00:00.000Z",
+    attachment: {
+      attachmentId: "attachment-1",
+      displayName: "tempo-3x12.mrc",
+      extension: "mrc" as const,
+    },
+    selectedWorkout: {
+      setId: "set-1",
+      workoutId: "workout-1",
+      workout: { name: "Tempo 3 × 12", durationSeconds: 3_840 },
+    },
+  },
+  requestedDate: "1998-08-26",
+};
+
+describe("Planning request contract", () => {
+  it("accepts the frozen by-value Workout handoff and rejects identity drift", () => {
+    expect(CreatePlanningRequestPayloadSchema.parse(payload)).toEqual(payload);
+    expect(() =>
+      CreatePlanningRequestPayloadSchema.parse({
+        ...payload,
+        source: { ...payload.source, attachmentId: "attachment-2" },
+      }),
+    ).toThrow();
+    expect(() => CreatePlanningRequestPayloadSchema.parse({ ...payload, extra: true })).toThrow();
+  });
+
+  it("keeps delivery status, retryability, and Planning acceptance aligned", () => {
+    expect(
+      PlanningRequestDeliverySchema.parse({
+        requestId: payload.requestId,
+        state: "pending",
+        attemptCount: 1,
+        failureCode: null,
+        retryable: true,
+        createdAtMs: 100,
+        updatedAtMs: 101,
+        deliveredAtMs: null,
+        planningRequest: null,
+      }),
+    ).toMatchObject({ state: "pending", retryable: true });
+    expect(() =>
+      PlanningRequestDeliverySchema.parse({
+        requestId: payload.requestId,
+        state: "delivered",
+        attemptCount: 1,
+        failureCode: null,
+        retryable: false,
+        createdAtMs: 100,
+        updatedAtMs: 101,
+        deliveredAtMs: 101,
+        planningRequest: null,
+      }),
+    ).toThrow();
+  });
+
+  it("exposes request conflicts as a bounded rejection", () => {
+    expect(
+      CreatePlanningRequestRpcResultSchema.parse({
+        status: "rejected",
+        reason: "request_conflict",
+      }),
+    ).toEqual({ status: "rejected", reason: "request_conflict" });
+  });
+});

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1403,6 +1403,13 @@ describe("coach request and event projection", () => {
         status: "unsupported-capability",
         capability: "planning",
       }),
+      createPlanningRequest: async () => ({
+        status: "rejected",
+        reason: "invalid_request",
+      }),
+      getPlanningRequest: async () => ({ status: "missing" }),
+      retryPlanningRequest: async () => ({ status: "missing" }),
+      resumePlanningRequests: async () => ({ deliveries: [] }),
     };
     expect(Object.keys(COACH_RPC_METHOD_REGISTRY)).toEqual(Object.keys(fake));
     expect(COACH_RPC_METHOD_NAMES).toEqual(Object.keys(fake));
@@ -1887,7 +1894,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-28 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-29 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1895,8 +1902,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 28,
-      serverProtocolVersion: 28,
+      clientProtocolVersion: 29,
+      serverProtocolVersion: 29,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1905,7 +1912,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(27);
+    expect(previous).toBe(28);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -1978,9 +1985,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 28 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 29 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(28);
+    expect(client.clientProtocolVersion).toBe(29);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2106,7 +2113,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version 28", () => {
-    expect(PROTOCOL_VERSION).toBe(28);
+  it("uses protocol version 29", () => {
+    expect(PROTOCOL_VERSION).toBe(29);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -62,6 +62,7 @@ import {
 } from "@enduragent/kernel/anchors";
 import {
   createAnchorRepository,
+  createChatPlanOutboxRepository,
   createChatAttachmentRepository,
   createAnalyticsCurveStateReader,
   createCanonicalActivityReader,
@@ -102,6 +103,7 @@ import {
   type ListArchivedConversationsRpcResult,
   type GetRuntimeConfigRpcResult,
   type PlanningReadOperations,
+  type PlanningRequestOperations,
   type PlanningOperations,
   type VerifyIntervalsCredentialRpcParams,
   type VerifyIntervalsCredentialRpcResult,
@@ -186,6 +188,11 @@ import { createPersistentOpenRouterModelMetadataCache } from "./openrouter-model
 import { createDocumentMediaAttachmentOperations } from "./document-media-attachment-operations.js";
 import { createAttachmentComposerOperations } from "./attachment-composer-operations.js";
 import { createPlanningReadService } from "./planning-read-service.js";
+import { createPlanningRequestDeliveryService } from "./planning-request-delivery.js";
+import {
+  createPlanningRequestRepository,
+  createPlanRepository,
+} from "@enduragent/kernel/planning";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -198,7 +205,10 @@ interface OAuthCredential extends StoredProfile {
 
 export interface LocalCoachComposition {
   readonly engine: CoachEngine;
-  readonly operations: CoachOperations & PlanningReadOperations & PlanningOperations;
+  readonly operations: CoachOperations &
+    PlanningReadOperations &
+    PlanningRequestOperations &
+    PlanningOperations;
   readonly spendMeter: SpendMeterService;
   readonly confirmations: Pick<ConfirmationGate, "peek" | "confirm" | "cancel">;
   startInitialRefresh(): Promise<void>;
@@ -1978,6 +1988,18 @@ export async function createLocalCoachComposition(
         readiness,
       },
     );
+    const planRepository = createPlanRepository(input.context.store);
+    const planningRequestOperations = createPlanningRequestDeliveryService({
+      outbox: createChatPlanOutboxRepository(input.context.store, analysisCrypto),
+      requests: createPlanningRequestRepository(input.context.store, analysisCrypto),
+      identity: planningIdentity,
+      async resolveTarget() {
+        const latest = await planRepository.readLatest();
+        if (latest?.status === "active") return "active_plan";
+        if (latest?.status === "draft") return "draft";
+        return "plan_creation";
+      },
+    });
     const operations = {
       ...coachOperations,
       admitChatAttachment: async (request) => {
@@ -2071,8 +2093,12 @@ export async function createLocalCoachComposition(
       getActivityAnalysis: (request, signal) =>
         activityAnalysis.getActivityAnalysis(request, signal),
       exportTrainingFile: (request, signal) => trainingExport.export(request, signal),
+      ...planningRequestOperations,
       ...planningOperations,
-    } satisfies CoachOperations & PlanningReadOperations & PlanningOperations;
+    } satisfies CoachOperations &
+      PlanningReadOperations &
+      PlanningRequestOperations &
+      PlanningOperations;
     return {
       engine: reconfigurable.engine,
       operations,

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -36,6 +36,7 @@ import {
   type CoachEngine,
   type CoachOperations,
   type PlanningReadOperations,
+  type PlanningRequestOperations,
   type CoachRpcMethodName,
   type CoachSelfTestOperations,
   type DaemonOwner,
@@ -296,7 +297,10 @@ export async function ensureDaemonToken(
 
 export interface CoachRpcServerInput {
   readonly engine: CoachEngine;
-  readonly operations: CoachOperations & PlanningReadOperations & PlanningOperations;
+  readonly operations: CoachOperations &
+    PlanningReadOperations &
+    PlanningRequestOperations &
+    PlanningOperations;
   readonly spend: SpendRpcHandlers;
   readonly selfTestOperations: CoachSelfTestOperations;
   readonly telegram: DesktopTelegramController;
@@ -534,6 +538,10 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "selfTest",
   "getPlanState",
   "executePlanTransition",
+  "createPlanningRequest",
+  "getPlanningRequest",
+  "retryPlanningRequest",
+  "resumePlanningRequests",
 ]);
 
 const PLAN_CHAT_RENDERER_METHODS = new Set<CoachRpcMethodName>([
@@ -1710,6 +1718,62 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                   eventFailure = { error };
                 }
               });
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "createPlanningRequest":
+            try {
+              if (input.operations.createPlanningRequest === undefined) {
+                throw new TypeError("Planning request creation is unavailable.");
+              }
+              result = await input.operations.createPlanningRequest(
+                COACH_RPC_METHOD_REGISTRY.createPlanningRequest.requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "getPlanningRequest":
+            try {
+              if (input.operations.getPlanningRequest === undefined) {
+                throw new TypeError("Planning request read is unavailable.");
+              }
+              result = await input.operations.getPlanningRequest(
+                COACH_RPC_METHOD_REGISTRY.getPlanningRequest.requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "retryPlanningRequest":
+            try {
+              if (input.operations.retryPlanningRequest === undefined) {
+                throw new TypeError("Planning request retry is unavailable.");
+              }
+              result = await input.operations.retryPlanningRequest(
+                COACH_RPC_METHOD_REGISTRY.retryPlanningRequest.requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "resumePlanningRequests":
+            try {
+              if (input.operations.resumePlanningRequests === undefined) {
+                throw new TypeError("Planning request recovery is unavailable.");
+              }
+              result = await input.operations.resumePlanningRequests(
+                COACH_RPC_METHOD_REGISTRY.resumePlanningRequests.requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
             } catch (error) {
               invocationFailure = { error };
             }

--- a/packages/coach/src/local-runner.ts
+++ b/packages/coach/src/local-runner.ts
@@ -2,6 +2,7 @@ import type {
   CoachEngine,
   CoachOperations,
   PlanningReadOperations,
+  PlanningRequestOperations,
 } from "@enduragent/coach-contract";
 import type { ConfirmationGate } from "@enduragent/core";
 import { prepareAthleteHome, type AthleteHome } from "@enduragent/kernel-node/home";
@@ -14,7 +15,7 @@ import { withCoachStoreWriter } from "./runtime.js";
 export interface LocalCoachLifecycle {
   readonly home: AthleteHome;
   readonly engine: CoachEngine;
-  readonly operations: CoachOperations & PlanningReadOperations;
+  readonly operations: CoachOperations & PlanningReadOperations & PlanningRequestOperations;
   readonly spendMeter: SpendMeterService;
   readonly confirmations: Pick<ConfirmationGate, "peek" | "confirm" | "cancel">;
   readonly listener: WriterProtocolListener;

--- a/packages/coach/src/planning-request-delivery.ts
+++ b/packages/coach/src/planning-request-delivery.ts
@@ -1,0 +1,200 @@
+import {
+  CreatePlanningRequestRpcParamsSchema,
+  CreatePlanningRequestRpcResultSchema,
+  GetPlanningRequestRpcParamsSchema,
+  GetPlanningRequestRpcResultSchema,
+  PlanningRequestDeliverySchema,
+  ResumePlanningRequestsRpcParamsSchema,
+  ResumePlanningRequestsRpcResultSchema,
+  RetryPlanningRequestRpcParamsSchema,
+  RetryPlanningRequestRpcResultSchema,
+  type PlanningRequestDelivery,
+  type PlanningRequestOperations,
+} from "@enduragent/coach-contract";
+import {
+  PlanningRequestStoreError,
+  type PlanningRequestRecord,
+  type PlanningRequestRepository,
+  type PlanningRequestTarget,
+} from "@enduragent/kernel/planning";
+import {
+  ChatPlanOutboxStoreError,
+  type ChatPlanOutboxRecord,
+  type ChatPlanOutboxRepository,
+} from "@enduragent/kernel/store";
+import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+
+export interface PlanningRequestDeliveryServiceInput {
+  readonly outbox: ChatPlanOutboxRepository;
+  readonly requests: PlanningRequestRepository;
+  readonly identity: AuthoredIdentity;
+  readonly resolveTarget: () => Promise<PlanningRequestTarget>;
+}
+
+export interface PlanningRequestDeliveryServiceDependencies {
+  readonly afterPlanningAccepted?: (request: PlanningRequestRecord) => void | Promise<void>;
+}
+
+function retryable(record: ChatPlanOutboxRecord): boolean {
+  return record.state === "pending" || (record.state === "failed" && record.retryable);
+}
+
+async function project(
+  requests: PlanningRequestRepository,
+  record: ChatPlanOutboxRecord,
+): Promise<PlanningRequestDelivery> {
+  const planningRecord = await requests.read(record.requestId);
+  const matchedPlanningRecord =
+    planningRecord?.payloadHash === record.payloadHash ? planningRecord : undefined;
+  const delivery = {
+    requestId: record.requestId,
+    state: record.state,
+    attemptCount: record.attemptCount,
+    failureCode: record.state === "failed" ? record.failureCode : null,
+    retryable: retryable(record),
+    createdAtMs: record.createdAtMs,
+    updatedAtMs: record.updatedAtMs,
+    deliveredAtMs: record.state === "delivered" ? record.deliveredAtMs : null,
+    planningRequest: matchedPlanningRecord?.request ?? null,
+  };
+  if (record.state === "delivered" && matchedPlanningRecord === undefined) {
+    throw new Error("delivered Planning request is missing");
+  }
+  return PlanningRequestDeliverySchema.parse(delivery);
+}
+
+function planningFailure(error: unknown): { readonly code: string; readonly retryable: boolean } {
+  if (error instanceof PlanningRequestStoreError) {
+    if (error.code === "request-conflict") {
+      return { code: "request_conflict", retryable: false };
+    }
+    if (error.code === "invalid-create") {
+      return { code: "invalid_request", retryable: false };
+    }
+  }
+  return { code: "planning_unavailable", retryable: true };
+}
+
+export function createPlanningRequestDeliveryService(
+  input: PlanningRequestDeliveryServiceInput,
+  dependencies: PlanningRequestDeliveryServiceDependencies = {},
+): PlanningRequestOperations {
+  const delivery = async (record: ChatPlanOutboxRecord): Promise<PlanningRequestDelivery> => {
+    if (record.state === "delivered" || record.state === "cancelled") {
+      return project(input.requests, record);
+    }
+    if (record.state === "failed" && !record.retryable) {
+      return project(input.requests, record);
+    }
+
+    const attemptedAt = input.identity.hlcStamp();
+    const pending = await input.outbox.beginDelivery({
+      requestId: record.requestId,
+      attemptedAtMs: attemptedAt.physicalMs,
+    });
+    if (pending.state !== "pending") throw new Error("Planning delivery did not begin");
+    let target: PlanningRequestTarget;
+    try {
+      target = await input.resolveTarget();
+    } catch (error) {
+      const failure = planningFailure(error);
+      const failed = await input.outbox.markFailed({
+        requestId: pending.requestId,
+        failureCode: failure.code,
+        retryable: failure.retryable,
+        failedAtMs: input.identity.hlcStamp().physicalMs,
+      });
+      return project(input.requests, failed);
+    }
+
+    let accepted: PlanningRequestRecord;
+    try {
+      const stamp = input.identity.hlcStamp();
+      accepted = await input.requests.createOrGet({
+        payload: pending.payload,
+        target,
+        createdAtMs: stamp.physicalMs,
+        deviceId: await input.identity.deviceId(),
+        hlcPhysicalMs: stamp.physicalMs,
+        hlcCounter: stamp.counter,
+      });
+    } catch (error) {
+      const failure = planningFailure(error);
+      const failed = await input.outbox.markFailed({
+        requestId: pending.requestId,
+        failureCode: failure.code,
+        retryable: failure.retryable,
+        failedAtMs: input.identity.hlcStamp().physicalMs,
+      });
+      return project(input.requests, failed);
+    }
+
+    await dependencies.afterPlanningAccepted?.(accepted);
+    const delivered = await input.outbox.markDelivered({
+      requestId: pending.requestId,
+      deliveredAtMs: input.identity.hlcStamp().physicalMs,
+    });
+    return project(input.requests, delivered);
+  };
+
+  return {
+    async createPlanningRequest(request) {
+      const parsed = CreatePlanningRequestRpcParamsSchema.parse(request);
+      let record: ChatPlanOutboxRecord;
+      try {
+        record = await input.outbox.createOrGet({
+          payload: parsed.payload,
+          createdAtMs: input.identity.hlcStamp().physicalMs,
+        });
+      } catch (error) {
+        if (error instanceof ChatPlanOutboxStoreError) {
+          if (error.code === "request-conflict") {
+            return CreatePlanningRequestRpcResultSchema.parse({
+              status: "rejected",
+              reason: "request_conflict",
+            });
+          }
+          if (error.code === "invalid-create") {
+            return CreatePlanningRequestRpcResultSchema.parse({
+              status: "rejected",
+              reason: "invalid_request",
+            });
+          }
+        }
+        throw error;
+      }
+      return CreatePlanningRequestRpcResultSchema.parse({
+        status: "accepted",
+        delivery: await delivery(record),
+      });
+    },
+
+    async getPlanningRequest(request) {
+      const parsed = GetPlanningRequestRpcParamsSchema.parse(request);
+      const record = await input.outbox.read(parsed.requestId);
+      return GetPlanningRequestRpcResultSchema.parse(
+        record === undefined
+          ? { status: "missing" }
+          : { status: "found", delivery: await project(input.requests, record) },
+      );
+    },
+
+    async retryPlanningRequest(request) {
+      const parsed = RetryPlanningRequestRpcParamsSchema.parse(request);
+      const record = await input.outbox.read(parsed.requestId);
+      return RetryPlanningRequestRpcResultSchema.parse(
+        record === undefined
+          ? { status: "missing" }
+          : { status: "found", delivery: await delivery(record) },
+      );
+    },
+
+    async resumePlanningRequests(request) {
+      ResumePlanningRequestsRpcParamsSchema.parse(request);
+      const records = await input.outbox.readRecoverable();
+      const deliveries: PlanningRequestDelivery[] = [];
+      for (const record of records) deliveries.push(await delivery(record));
+      return ResumePlanningRequestsRpcResultSchema.parse({ deliveries });
+    },
+  };
+}

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -2036,6 +2036,80 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     await client.close();
   });
 
+  it("dispatches strict Chat-to-Plan request delivery operations", async () => {
+    const token = "x".repeat(43);
+    const createPlanningRequest = vi.fn(async () => ({
+      status: "rejected" as const,
+      reason: "invalid_request" as const,
+    }));
+    const getPlanningRequest = vi.fn(async () => ({ status: "missing" as const }));
+    const retryPlanningRequest = vi.fn(async () => ({ status: "missing" as const }));
+    const resumePlanningRequests = vi.fn(async () => ({ deliveries: [] }));
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: {
+        ...operations,
+        createPlanningRequest,
+        getPlanningRequest,
+        retryPlanningRequest,
+        resumePlanningRequests,
+      },
+      token,
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+
+    const payload = {
+      requestId: "request-1",
+      kind: "plan_question",
+      intent: "Review the current week.",
+      source: { chatId: "desktop", messageId: "message-1" },
+      sourceSnapshot: {
+        capturedAt: "1998-08-24T08:00:00.000Z",
+        attachment: null,
+        selectedWorkout: null,
+      },
+    };
+    for (const request of [
+      { id: "create-request", method: "createPlanningRequest", params: { payload } },
+      { id: "get-request", method: "getPlanningRequest", params: { requestId: "request-1" } },
+      { id: "retry-request", method: "retryPlanningRequest", params: { requestId: "request-1" } },
+      { id: "resume-requests", method: "resumePlanningRequests", params: {} },
+    ]) {
+      client.ws.send(JSON.stringify({ jsonrpc: "2.0", ...request }));
+      expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+        id: request.id,
+        result:
+          request.method === "createPlanningRequest"
+            ? { status: "rejected", reason: "invalid_request" }
+            : request.method === "resumePlanningRequests"
+              ? { deliveries: [] }
+              : { status: "missing" },
+      });
+    }
+    expect(createPlanningRequest).toHaveBeenCalledWith({ payload });
+    expect(getPlanningRequest).toHaveBeenCalledWith({ requestId: "request-1" });
+    expect(retryPlanningRequest).toHaveBeenCalledWith({ requestId: "request-1" });
+    expect(resumePlanningRequests).toHaveBeenCalledWith({});
+
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "invalid-request",
+        method: "resumePlanningRequests",
+        params: { extra: true },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+      id: "invalid-request",
+      error: { code: -32602, message: "Invalid params" },
+    });
+    expect(resumePlanningRequests).toHaveBeenCalledOnce();
+    await client.close();
+  });
+
   it.each([
     {
       name: "command id",

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 28 as const,
-      serverProtocolVersion: 28 as const,
+      clientProtocolVersion: 29 as const,
+      serverProtocolVersion: 29 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -304,7 +304,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(28);
+    expect(PROTOCOL_VERSION).toBe(29);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/coach/tests/planning-request-delivery.test.ts
+++ b/packages/coach/tests/planning-request-delivery.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CreatePlanningRequestPayload } from "@enduragent/coach-contract";
+import {
+  createPlanningRequestRepository,
+  createPlanRepository,
+  type PlanRecord,
+} from "@enduragent/kernel/planning";
+import {
+  createChatPlanOutboxRepository,
+  runMigrations,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createNodeCrypto } from "@enduragent/kernel-node/ingest";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+import {
+  createPlanningRequestDeliveryService,
+  type PlanningRequestDeliveryServiceDependencies,
+} from "../src/planning-request-delivery.js";
+
+const PLAN_ID = "01J60HFQ7T0000000000000000";
+
+function requestPayload(
+  overrides: Partial<CreatePlanningRequestPayload> = {},
+): CreatePlanningRequestPayload {
+  return {
+    requestId: "request-1",
+    kind: "workout_review",
+    intent: "Review this Workout before I add it to my Plan.",
+    source: {
+      chatId: "chat-1",
+      messageId: "message-1",
+      attachmentId: "attachment-1",
+    },
+    sourceSnapshot: {
+      capturedAt: "1998-08-24T08:00:00.000Z",
+      attachment: {
+        attachmentId: "attachment-1",
+        displayName: "tempo-3x12.mrc",
+        extension: "mrc",
+      },
+      selectedWorkout: {
+        setId: "set-1",
+        workoutId: "workout-1",
+        workout: { name: "Tempo 3 × 12", sport: "cycling", durationSeconds: 3_840 },
+      },
+    },
+    requestedDate: "1998-08-26",
+    ...overrides,
+  };
+}
+
+function plan(status: PlanRecord["status"]): PlanRecord {
+  return {
+    id: PLAN_ID,
+    originId: null,
+    name: "Autumn base",
+    primaryGoal: "Build consistency",
+    startDateKey: 19980824,
+    targetDateKey: null,
+    status,
+    kind: "full_plan",
+    totalWeeks: 12,
+    weekStartDay: 1,
+    structureJson: "{}",
+    createdAtMs: 1,
+    updatedAtMs: 10,
+    deviceId: "device-1",
+    hlcPhysicalMs: 10,
+    hlcCounter: 0,
+  };
+}
+
+describe("Planning request delivery", () => {
+  let store: SqlStore & MigratorStore;
+  let instant: number;
+  let identity: AuthoredIdentity;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    instant = 100;
+    identity = {
+      deviceId: async () => "device-1",
+      newUlid: () => "01J60HFQ7T0000000000000001",
+      hlcStamp: () => ({ physicalMs: instant++, counter: 0 }),
+    };
+  });
+
+  afterEach(async () => store.close());
+
+  const service = (
+    afterPlanningAccepted?: PlanningRequestDeliveryServiceDependencies["afterPlanningAccepted"],
+  ) => {
+    const crypto = createNodeCrypto();
+    const plans = createPlanRepository(store);
+    return createPlanningRequestDeliveryService(
+      {
+        outbox: createChatPlanOutboxRepository(store, crypto),
+        requests: createPlanningRequestRepository(store, crypto),
+        identity,
+        async resolveTarget() {
+          const latest = await plans.readLatest();
+          if (latest?.status === "active") return "active_plan";
+          if (latest?.status === "draft") return "draft";
+          return "plan_creation";
+        },
+      },
+      { afterPlanningAccepted },
+    );
+  };
+
+  it.each([
+    ["active", "active_plan"],
+    ["draft", "draft"],
+    ["ended", "plan_creation"],
+  ] as const)("routes a %s Plan to %s", async (status, target) => {
+    await createPlanRepository(store).replace(plan(status), []);
+    const result = await service().createPlanningRequest!({ payload: requestPayload() });
+    expect(result.status).toBe("accepted");
+    if (result.status !== "accepted") throw new TypeError();
+    expect(result.delivery).toMatchObject({
+      state: "delivered",
+      attemptCount: 1,
+      retryable: false,
+      planningRequest: { target },
+    });
+  });
+
+  it("routes to Plan creation when no Plan exists", async () => {
+    const result = await service().createPlanningRequest!({ payload: requestPayload() });
+    expect(result.status).toBe("accepted");
+    if (result.status !== "accepted") throw new TypeError();
+    expect(result.delivery.planningRequest?.target).toBe("plan_creation");
+  });
+
+  it("retries the same request after Planning accepted before Chat acknowledged", async () => {
+    await expect(
+      service(() => {
+        throw new Error("synthetic process interruption");
+      }).createPlanningRequest!({ payload: requestPayload() }),
+    ).rejects.toThrow("synthetic process interruption");
+
+    const before = await service().getPlanningRequest!({ requestId: "request-1" });
+    expect(before).toMatchObject({
+      status: "found",
+      delivery: { state: "pending", attemptCount: 1, planningRequest: { requestId: "request-1" } },
+    });
+
+    const retried = await service().retryPlanningRequest!({ requestId: "request-1" });
+    expect(retried).toMatchObject({
+      status: "found",
+      delivery: { state: "delivered", attemptCount: 2, planningRequest: { requestId: "request-1" } },
+    });
+    expect(await createPlanningRequestRepository(store, createNodeCrypto()).readOpen()).toHaveLength(
+      1,
+    );
+  });
+
+  it("resumes persisted pending delivery and rejects conflicting reuse", async () => {
+    const crypto = createNodeCrypto();
+    await createChatPlanOutboxRepository(store, crypto).createOrGet({
+      payload: requestPayload(),
+      createdAtMs: instant++,
+    });
+    const resumed = await service().resumePlanningRequests!({});
+    expect(resumed.deliveries).toHaveLength(1);
+    expect(resumed.deliveries[0]).toMatchObject({ state: "delivered", attemptCount: 1 });
+
+    await expect(
+      service().createPlanningRequest!({
+        payload: requestPayload({ intent: "Use a different intent under the same identifier." }),
+      }),
+    ).resolves.toEqual({ status: "rejected", reason: "request_conflict" });
+  });
+
+  it("records a non-retryable failure when Planning owns a conflicting payload", async () => {
+    const crypto = createNodeCrypto();
+    await createPlanningRequestRepository(store, crypto).createOrGet({
+      payload: requestPayload({ intent: "The payload Planning accepted first." }),
+      target: "plan_creation",
+      createdAtMs: 90,
+      deviceId: "device-1",
+      hlcPhysicalMs: 90,
+      hlcCounter: 0,
+    });
+
+    const result = await service().createPlanningRequest!({ payload: requestPayload() });
+    expect(result).toMatchObject({
+      status: "accepted",
+      delivery: {
+        state: "failed",
+        failureCode: "request_conflict",
+        retryable: false,
+        planningRequest: null,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add strict Chat-to-Plan request delivery contracts and authenticated RPC methods
- persist Chat delivery before Planning intake and keep duplicate delivery idempotent
- resume pending requests and preserve the same request identity after interruption

## Verification
- focused contract, client, server, and delivery tests: 280 passed
- root pnpm check passed
- full bounded suite: 714 files passed, 5 skipped; 10,640 tests passed, 17 skipped
- bounded autoreview: clean