### PR TITLE
feat(plan): add request result lifecycle

### DIFF
--- a/packages/coach-contract/src/planning.ts
+++ b/packages/coach-contract/src/planning.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { ChatQueueSnapshotSchema } from "./chat-queue.js";
 import { CoachDecisionAnswerSchema, CoachDecisionReadModelSchema } from "./coach-decision.js";
 import { PlatformAbsolutePathSchema } from "./platform-path.js";
+import { PlanningRequestReadModelSchema } from "./planning-request.js";
 import { TrainingExportCivilDateSchema } from "./training-export.js";
 import { TurnEventSchema } from "./turn-event.js";
 
@@ -1021,6 +1022,50 @@ export const PlanCoachProjectionDataSchema = z
   .strict();
 export type PlanCoachProjectionData = z.infer<typeof PlanCoachProjectionDataSchema>;
 
+export const PlanChatOriginatedResultProjectionDataSchema = z
+  .object({
+    request: PlanningRequestReadModelSchema,
+    returnTarget: z
+      .object({
+        destination: z.literal("chat"),
+        chatId: z.string().min(1),
+        messageId: z.string().min(1),
+      })
+      .strict()
+      .nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.request.lifecycle === "open") {
+      context.addIssue({
+        code: "custom",
+        path: ["request", "lifecycle"],
+        message: "Chat-originated result requires a terminal Planning request",
+      });
+    }
+    if ((value.returnTarget !== null) !== value.request.source.available) {
+      context.addIssue({
+        code: "custom",
+        path: ["returnTarget"],
+        message: "Chat return target must match source availability",
+      });
+    }
+    if (
+      value.returnTarget !== null &&
+      (value.returnTarget.chatId !== value.request.source.chatId ||
+        value.returnTarget.messageId !== value.request.source.messageId)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["returnTarget"],
+        message: "Chat return target must match the Planning request source",
+      });
+    }
+  });
+export type PlanChatOriginatedResultProjectionData = z.infer<
+  typeof PlanChatOriginatedResultProjectionDataSchema
+>;
+
 export const PlanReadModelSchema = z
   .object({
     schemaVersion: z.literal(1),
@@ -1398,6 +1443,7 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
       transitionId: z.literal("PL-T37"),
       commandId: CommandIdSchema,
       sourceConversationId: EntityIdSchema,
+      requestId: EntityIdSchema,
     })
     .strict(),
   z

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 29;
+export const PROTOCOL_VERSION = 30;

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../src/index.js";
 
 describe("chat queue contract", () => {
-  it("ships protocol 29 and rejects a blank enqueue without attachments", () => {
-    expect(PROTOCOL_VERSION).toBe(29);
+  it("ships protocol 30 and rejects a blank enqueue without attachments", () => {
+    expect(PROTOCOL_VERSION).toBe(30);
     expect(() =>
       EnqueueChatMessageRequestSchema.parse({
         chatId: "desktop",

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -151,8 +151,8 @@ describe("coach decision wire contract", () => {
     expect(parsed.entries).toHaveLength(1);
   });
 
-  it("projects resume completion explicitly at protocol 29", () => {
-    expect(PROTOCOL_VERSION).toBe(29);
+  it("projects resume completion explicitly at protocol 30", () => {
+    expect(PROTOCOL_VERSION).toBe(30);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -114,8 +114,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 29", () => {
-    expect(PROTOCOL_VERSION).toBe(29);
+  it("is 30", () => {
+    expect(PROTOCOL_VERSION).toBe(30);
   });
 
   it("requires Stop to name the exact active turn", () => {

--- a/packages/coach-contract/tests/planning.test.ts
+++ b/packages/coach-contract/tests/planning.test.ts
@@ -23,6 +23,7 @@ const planId = "plan-1";
 const draftId = "draft-1";
 const conversationId = "conversation-1";
 const proposalId = "proposal-1";
+const requestId = "request-1";
 const workoutId = "workout-1";
 const eventId = "event-1";
 
@@ -83,9 +84,9 @@ const commands = [
     transitionId: "PL-T36",
     commandId,
     sourceConversationId: conversationId,
-    requestId: "request-1",
+    requestId,
   },
-  { transitionId: "PL-T37", commandId, sourceConversationId: conversationId },
+  { transitionId: "PL-T37", commandId, sourceConversationId: conversationId, requestId },
   { transitionId: "PL-T38", commandId, planId, proposalId, expectedRevision: 5 },
   {
     transitionId: "PL-T39",

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1894,7 +1894,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-29 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-30 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1902,8 +1902,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 29,
-      serverProtocolVersion: 29,
+      clientProtocolVersion: 30,
+      serverProtocolVersion: 30,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1912,7 +1912,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(28);
+    expect(previous).toBe(29);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -1985,9 +1985,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 29 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 30 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(29);
+    expect(client.clientProtocolVersion).toBe(30);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2113,7 +2113,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version 29", () => {
-    expect(PROTOCOL_VERSION).toBe(29);
+  it("uses protocol version 30", () => {
+    expect(PROTOCOL_VERSION).toBe(30);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -189,10 +189,7 @@ import { createDocumentMediaAttachmentOperations } from "./document-media-attach
 import { createAttachmentComposerOperations } from "./attachment-composer-operations.js";
 import { createPlanningReadService } from "./planning-read-service.js";
 import { createPlanningRequestDeliveryService } from "./planning-request-delivery.js";
-import {
-  createPlanningRequestRepository,
-  createPlanRepository,
-} from "@enduragent/kernel/planning";
+import { createPlanningRequestRepository, createPlanRepository } from "@enduragent/kernel/planning";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -1973,6 +1970,11 @@ export async function createLocalCoachComposition(
         await coachOperations.sync({});
       },
     };
+    const planRepository = createPlanRepository(input.context.store);
+    const planningRequestRepository = createPlanningRequestRepository(
+      input.context.store,
+      analysisCrypto,
+    );
     const planningOperations = createPlanningOperations(
       {
         context: input.context,
@@ -1986,12 +1988,12 @@ export async function createLocalCoachComposition(
         calendar: planCalendar,
         workoutDriftCalendar: planCalendar,
         readiness,
+        requests: planningRequestRepository,
       },
     );
-    const planRepository = createPlanRepository(input.context.store);
     const planningRequestOperations = createPlanningRequestDeliveryService({
       outbox: createChatPlanOutboxRepository(input.context.store, analysisCrypto),
-      requests: createPlanningRequestRepository(input.context.store, analysisCrypto),
+      requests: planningRequestRepository,
       identity: planningIdentity,
       async resolveTarget() {
         const latest = await planRepository.readLatest();

--- a/packages/coach/src/planning-lifecycle.ts
+++ b/packages/coach/src/planning-lifecycle.ts
@@ -1,5 +1,6 @@
 import {
   PlanActiveProjectionDataSchema,
+  PlanChatOriginatedResultProjectionDataSchema,
   PlanEndedProjectionDataSchema,
   PlanCoachProjectionDataSchema,
   PlanReadModelSchema,
@@ -7,6 +8,7 @@ import {
   type CoachDecisionReadModel,
   type PlanAttention,
   type PlanActiveProjectionData,
+  type PlanningRequestReadModel,
   type PlanEndedProjectionData,
   type PlanCoachMessage,
   type PlanDraftProjection,
@@ -413,6 +415,41 @@ export function buildEndedPlanConversationReadModel(input: {
       queue: { schemaVersion: 1, revision: 0, items: [] },
       decision: null,
       draft: null,
+    }),
+  });
+}
+
+export function buildChatOriginatedPlanResultReadModel(input: {
+  readonly request: PlanningRequestReadModel;
+  readonly planId: string | null;
+  readonly lifecycle: PlanLifecycle;
+  readonly revision: number;
+}): PlanReadModel {
+  const terminal = input.request.terminalResult;
+  if (terminal === null) throw new TypeError("Chat-originated Plan result requires completion.");
+  const returnTarget = input.request.source.available
+    ? {
+        destination: "chat" as const,
+        chatId: input.request.source.chatId,
+        messageId: input.request.source.messageId,
+      }
+    : null;
+  return PlanReadModelSchema.parse({
+    schemaVersion: 1,
+    scenarioId: "PL-S099",
+    lifecycle: input.lifecycle,
+    planId: input.planId,
+    revision: input.revision,
+    title: terminal.title,
+    summary: terminal.detail,
+    projection: "proposal",
+    transitions: [...(returnTarget === null ? [] : [guard("PL-T37")]), guard("PL-T39")],
+    reconciliation: EMPTY_RECONCILIATION,
+    attention: EMPTY_ATTENTION,
+    activeOperation: null,
+    data: PlanChatOriginatedResultProjectionDataSchema.parse({
+      request: input.request,
+      returnTarget,
     }),
   });
 }

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -98,6 +98,7 @@ import {
 import { cyclingTaperRefusal, projectCyclingSeasonMetadata } from "@enduragent/sport-cycling";
 import {
   buildActivePlanReadModel,
+  buildChatOriginatedPlanResultReadModel,
   buildEndedPlanConversationReadModel,
   buildEndedPlanReadModel,
   buildPlanLifecycleReadModel,
@@ -134,6 +135,8 @@ import {
   type PlanProposalRecord,
   type PlanProposalPremiseRecord,
   type PlanProposalRepository,
+  type PlanningRequestReadModel,
+  type PlanningRequestRepository,
   type PlanAdaptationLedgerRecord,
   type PlanAdaptationLedgerRepository,
   type PlanSetting,
@@ -375,6 +378,7 @@ export interface CreatePlanningOperationsDependencies {
   readonly workoutMatches?: PlanWorkoutMatchRepository;
   readonly workoutDrifts?: PlanWorkoutDriftRepository;
   readonly proposals?: PlanProposalRepository;
+  readonly requests?: PlanningRequestRepository;
   readonly history?: PlanAdaptationLedgerRepository;
   readonly settings?: PlanSettingsRepository;
   readonly replacements?: PlanReplacementRepository;
@@ -977,6 +981,7 @@ function courseProjection(input: {
 }
 
 interface ReadOverrides {
+  readonly sourceConversationId?: string | null;
   readonly ftpScenario?: FtpScenario;
   readonly ftpError?: PlanError | null;
   readonly courseScenario?: CourseScenario;
@@ -1037,6 +1042,7 @@ export function createPlanningOperations(
     dependencies.workoutDrifts ?? createPlanWorkoutDriftRepository(input.context.store);
   const proposalRepository =
     dependencies.proposals ?? createPlanProposalRepository(input.context.store);
+  const planningRequests = dependencies.requests;
   const historyRepository =
     dependencies.history ?? createPlanAdaptationLedgerRepository(input.context.store);
   const settingsRepository =
@@ -1515,7 +1521,7 @@ export function createPlanningOperations(
         id: conversation.id,
         planId: conversation.planId,
         replacesPlanId: conversation.replacesPlanId,
-        sourceConversationId: null,
+        sourceConversationId: overrides.sourceConversationId ?? null,
       },
       turns,
       readyToCreateDraft: ready,
@@ -1807,6 +1813,26 @@ export function createPlanningOperations(
       state: await read({ ...overrides, ftpError: error }),
     });
 
+  const chatOriginatedResult = async (
+    request: PlanningRequestReadModel,
+  ): Promise<PlanReadModel> => {
+    const latestPlan = await plans.readLatest();
+    const lifecycle: PlanReadModel["lifecycle"] =
+      latestPlan?.status === "active"
+        ? "active"
+        : latestPlan?.status === "draft"
+          ? "draft"
+          : latestPlan?.status === "ended"
+            ? "ended"
+            : "none";
+    return buildChatOriginatedPlanResultReadModel({
+      request,
+      planId: latestPlan?.id ?? null,
+      lifecycle,
+      revision: request.revision,
+    });
+  };
+
   return {
     async getPlanState(request) {
       GetPlanStateRpcParamsSchema.parse(request);
@@ -1839,6 +1865,69 @@ export function createPlanningOperations(
           return ExecutePlanTransitionRpcResultSchema.parse({
             status: "completed",
             state: await read(),
+          });
+        }
+        if (command.transitionId === "PL-T36") {
+          if (planningRequests === undefined) return reject(UNAVAILABLE);
+          const record = await planningRequests.read(command.requestId);
+          if (
+            record === undefined ||
+            record.request.source.chatId !== command.sourceConversationId
+          ) {
+            return reject(UNAVAILABLE);
+          }
+          if (record.request.lifecycle !== "open") {
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await chatOriginatedResult(record.request),
+            });
+          }
+          if (record.request.proposalId !== null) {
+            const proposal = await proposalRepository.read(record.request.proposalId);
+            const plan = proposal === undefined ? undefined : await plans.read(proposal.planId);
+            if (proposal?.status !== "proposed" || plan?.status !== "active") {
+              return reject(UNAVAILABLE);
+            }
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read({
+                activeScenario: record.request.attention === "stale_base" ? "PL-S025" : "PL-S007",
+                selectedProposalId: proposal.id,
+              }),
+            });
+          }
+          if (record.request.planConversationId !== null) {
+            const conversation = await conversations.readConversation(
+              record.request.planConversationId,
+            );
+            const current = await conversations.readLatestOpenConversation();
+            if (
+              conversation?.status !== "open" ||
+              current?.id !== record.request.planConversationId
+            ) {
+              return reject(UNAVAILABLE);
+            }
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read({ sourceConversationId: command.sourceConversationId }),
+            });
+          }
+          return reject(UNAVAILABLE);
+        }
+        if (command.transitionId === "PL-T37") {
+          if (planningRequests === undefined) return reject(UNAVAILABLE);
+          const record = await planningRequests.read(command.requestId);
+          if (
+            record === undefined ||
+            record.request.lifecycle === "open" ||
+            !record.request.source.available ||
+            record.request.source.chatId !== command.sourceConversationId
+          ) {
+            return reject(UNAVAILABLE);
+          }
+          return ExecutePlanTransitionRpcResultSchema.parse({
+            status: "completed",
+            state: await chatOriginatedResult(record.request),
           });
         }
         if (command.transitionId === "PL-T02") {
@@ -3815,6 +3904,25 @@ export function createPlanningOperations(
           }
         }
         if (command.transitionId === "PL-T39") {
+          if (
+            command.sourceScenarioId === "PL-S099" &&
+            command.destinationScenarioId === "PL-S004"
+          ) {
+            if (planningRequests === undefined) return reject(UNAVAILABLE);
+            const request = await planningRequests.read(command.returnFocusId);
+            const plan = await plans.readLatest();
+            if (
+              request === undefined ||
+              request.request.lifecycle === "open" ||
+              plan?.status !== "active"
+            ) {
+              return reject(UNAVAILABLE);
+            }
+            return ExecutePlanTransitionRpcResultSchema.parse({
+              status: "completed",
+              state: await read({ activeScenario: "PL-S004" }),
+            });
+          }
           if (
             command.sourceScenarioId === "PL-S089" &&
             command.destinationScenarioId === "PL-S102"

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 29 as const,
-      serverProtocolVersion: 29 as const,
+      clientProtocolVersion: 30 as const,
+      serverProtocolVersion: 30 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -304,7 +304,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(29);
+    expect(PROTOCOL_VERSION).toBe(30);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/coach/tests/planning-lifecycle.test.ts
+++ b/packages/coach/tests/planning-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildActivePlanReadModel,
+  buildChatOriginatedPlanResultReadModel,
   buildEndedPlanReadModel,
   buildPlanLifecycleReadModel,
 } from "../src/planning-lifecycle.js";
@@ -26,6 +27,61 @@ function build(input: Partial<Parameters<typeof buildPlanLifecycleReadModel>[0]>
 }
 
 describe("Plan lifecycle projection", () => {
+  it("projects a terminal Chat-originated result with only an exact available return", () => {
+    const request = {
+      requestId: "request-1",
+      kind: "workout_review" as const,
+      target: "active_plan" as const,
+      intent: "Add Tempo 3 × 12 to Wednesday.",
+      planConversationId: null,
+      proposalId: "proposal-1",
+      requestedDateKey: 19980825,
+      resolvedDateKey: 19980826,
+      source: { chatId: "chat-1", messageId: "message-1", available: true },
+      lifecycle: "applied" as const,
+      attention: "none" as const,
+      revision: 3,
+      createdAtMs: 10,
+      updatedAtMs: 30,
+      terminalResult: {
+        kind: "applied" as const,
+        resultId: "result-1",
+        completedAtMs: 30,
+        title: "Workout added",
+        detail: "Tempo 3 × 12 is scheduled for Wednesday.",
+        workoutRef: { setId: "set-1", workoutId: "workout-1" },
+        planRevisionId: "revision-1",
+      },
+    };
+    const available = buildChatOriginatedPlanResultReadModel({
+      request,
+      planId: "plan-1",
+      lifecycle: "active",
+      revision: 3,
+    });
+    expect(available).toMatchObject({
+      scenarioId: "PL-S099",
+      title: "Workout added",
+      summary: "Tempo 3 × 12 is scheduled for Wednesday.",
+      data: {
+        returnTarget: { destination: "chat", chatId: "chat-1", messageId: "message-1" },
+      },
+    });
+    expect(available.transitions.map((transition) => transition.transitionId)).toEqual([
+      "PL-T37",
+      "PL-T39",
+    ]);
+
+    const detached = buildChatOriginatedPlanResultReadModel({
+      request: { ...request, source: { ...request.source, available: false } },
+      planId: "plan-1",
+      lifecycle: "active",
+      revision: 4,
+    });
+    expect(detached.data.returnTarget).toBeNull();
+    expect(detached.transitions.map((transition) => transition.transitionId)).toEqual(["PL-T39"]);
+  });
+
   it("advertises only the accepted natural completion and outcome actions", () => {
     const data = {
       plan: {

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -13,6 +13,7 @@ import {
   createPlanWeeklyReviewRepository,
   createPlanWorkoutMatchRepository,
   createPlanProposalRepository,
+  createPlanningRequestRepository,
   createRaceCourseSnapshot,
   createPlanReplacementRepository,
   createPlanRaceOutcomeRepository,
@@ -26,6 +27,7 @@ import {
 import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+import { createNodeCrypto } from "@enduragent/kernel-node/ingest";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import {
   planMirrorExternalId,
@@ -322,6 +324,180 @@ describe("Plan operations", () => {
             { role: "coach", text: "I found your rides." },
           ],
         },
+      },
+    });
+  });
+
+  it("opens a terminal Chat-originated result and validates its exact return source", async () => {
+    const authored = identity();
+    const planId = `${"0".repeat(25)}P`;
+    const activePlan = {
+      ...plan(planId, 20),
+      startDateKey: 19980709,
+      targetDateKey: 19980930,
+      status: "active" as const,
+    };
+    await createPlanRepository(store).replace(activePlan, []);
+    const requests = createPlanningRequestRepository(store, createNodeCrypto());
+    const created = await requests.createOrGet({
+      payload: {
+        requestId: "request-1",
+        kind: "workout_review",
+        intent: "Add Tempo 3 × 12 to Wednesday.",
+        source: {
+          chatId: "chat-1",
+          messageId: "message-1",
+          attachmentId: "attachment-1",
+        },
+        sourceSnapshot: {
+          capturedAt: "1998-08-24T08:00:00.000Z",
+          attachment: {
+            attachmentId: "attachment-1",
+            displayName: "tempo-3x12.mrc",
+            extension: "mrc",
+          },
+          selectedWorkout: {
+            setId: "set-1",
+            workoutId: "workout-1",
+            workout: {
+              name: "Tempo 3 × 12",
+              sport: "cycling",
+              durationSeconds: 3_840,
+            },
+          },
+        },
+        requestedDate: "1998-08-26",
+      },
+      target: "active_plan",
+      createdAtMs: 30,
+      deviceId: "device-1",
+      hlcPhysicalMs: 30,
+      hlcCounter: 0,
+    });
+    await requests.complete({
+      requestId: created.request.requestId,
+      expectedRevision: created.request.revision,
+      result: {
+        kind: "applied",
+        resultId: "result-1",
+        completedAtMs: 40,
+        title: "Workout added",
+        detail: "Tempo 3 × 12 is scheduled for Wednesday.",
+        workoutRef: { setId: "set-1", workoutId: "workout-1" },
+        planRevisionId: "revision-1",
+      },
+      resolvedDateKey: 19980826,
+      updatedAtMs: 40,
+      deviceId: "device-1",
+      hlcPhysicalMs: 40,
+      hlcCounter: 0,
+    });
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: authored },
+      { requests, todayDateKey: () => 19980824 },
+    );
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T36",
+        commandId: "command-open-request",
+        sourceConversationId: "chat-1",
+        requestId: "request-1",
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S099",
+        data: {
+          returnTarget: { destination: "chat", chatId: "chat-1", messageId: "message-1" },
+        },
+      },
+    });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T37",
+        commandId: "command-return-wrong-source",
+        sourceConversationId: "chat-2",
+        requestId: "request-1",
+      }),
+    ).resolves.toMatchObject({ status: "rejected" });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T37",
+        commandId: "command-return-source",
+        sourceConversationId: "chat-1",
+        requestId: "request-1",
+      }),
+    ).resolves.toMatchObject({ status: "completed", state: { scenarioId: "PL-S099" } });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T39",
+        commandId: "command-stay-in-plan",
+        action: "done",
+        sourceScenarioId: "PL-S099",
+        destinationScenarioId: "PL-S004",
+        returnFocusId: "request-1",
+      }),
+    ).resolves.toMatchObject({ status: "completed", state: { scenarioId: "PL-S004" } });
+  });
+
+  it("reopens the exact Plan conversation bound to an unresolved Chat request", async () => {
+    const authored = identity();
+    const requests = createPlanningRequestRepository(store, createNodeCrypto());
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: authored },
+      { requests },
+    );
+    const started = await operations.executePlanTransition?.({
+      transitionId: "PL-T01",
+      commandId: "command-start-plan",
+      sourceConversationId: null,
+    });
+    if (started?.status !== "completed") throw new TypeError("Plan conversation did not start.");
+    const conversationId = String(started.state.data.conversationId);
+    const created = await requests.createOrGet({
+      payload: {
+        requestId: "request-open",
+        kind: "plan_creation",
+        intent: "Build a Plan for my autumn event.",
+        source: { chatId: "chat-open", messageId: "message-open" },
+        sourceSnapshot: {
+          capturedAt: "1998-08-24T08:00:00.000Z",
+          attachment: null,
+          selectedWorkout: null,
+        },
+      },
+      target: "plan_creation",
+      createdAtMs: 30,
+      deviceId: "device-1",
+      hlcPhysicalMs: 30,
+      hlcCounter: 0,
+    });
+    await requests.reviseOpen({
+      requestId: created.request.requestId,
+      expectedRevision: created.request.revision,
+      planConversationId: conversationId,
+      proposalId: null,
+      attention: "none",
+      resolvedDateKey: null,
+      updatedAtMs: 31,
+      deviceId: "device-1",
+      hlcPhysicalMs: 31,
+      hlcCounter: 0,
+    });
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T36",
+        commandId: "command-open-plan-request",
+        sourceConversationId: "chat-open",
+        requestId: "request-open",
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S017",
+        data: { conversationId, sourceConversationId: "chat-open" },
       },
     });
   });


### PR DESCRIPTION
## Summary
- bind Chat-originated Planning requests to existing Plan conversations and Proposals
- reopen terminal requests as immutable Plan results
- validate exact Back to Chat return targets and detached-source behavior

## Verification
- root pnpm check
- coach-contract suite: 41 files, 627 tests
- impacted Coach suite: 6 files, 151 tests
- autoreview: clean