### PR TITLE
feat(plan): add reversible workout additions

### DIFF
--- a/.changeset/plan-workout-additions.md
+++ b/.changeset/plan-workout-additions.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: A workout sent from Chat can now become a reviewable Plan addition, and the newest eligible addition can be undone from Plan history.

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -591,8 +591,10 @@ function historyProjection(input: {
     projectPlanHistoryEligibility(input).map((entry) => [entry.ledgerId, entry]),
   );
   const entries: PlanHistoryEntry[] = input.history.map((entry) => {
-    const before = parsePlanAdaptationWorkoutSnapshot(entry.beforeJson);
-    const after = parsePlanAdaptationWorkoutSnapshot(entry.afterJson);
+    const before =
+      entry.beforeJson === null ? null : parsePlanAdaptationWorkoutSnapshot(entry.beforeJson);
+    const after =
+      entry.afterJson === null ? null : parsePlanAdaptationWorkoutSnapshot(entry.afterJson);
     const undo = eligibility.get(entry.id);
     return {
       id: entry.id,
@@ -600,8 +602,14 @@ function historyProjection(input: {
       label: entry.label,
       occurredAtMs: entry.occurredAtMs,
       targetWorkoutId: entry.targetWorkoutId,
-      before: { date: dateText(before.dateKey), name: before.name, durationS: before.durationS },
-      after: { date: dateText(after.dateKey), name: after.name, durationS: after.durationS },
+      before:
+        before === null
+          ? null
+          : { date: dateText(before.dateKey), name: before.name, durationS: before.durationS },
+      after:
+        after === null
+          ? null
+          : { date: dateText(after.dateKey), name: after.name, durationS: after.durationS },
       weekLoadBefore: entry.weekLoadBefore,
       weekLoadAfter: entry.weekLoadAfter,
       undoStatus: undo?.status ?? "none",
@@ -2841,10 +2849,10 @@ export function createPlanningOperations(
                     planStructureJson: plan.structureJson,
                     planStartDate: dateText(plan.startDateKey),
                     planTotalWeeks: plan.totalWeeks,
-                    workoutDate: dateText(change.current.dateKey),
+                    workoutDate: dateText(change.next.dateKey),
                     current: {
-                      name: change.current.name,
-                      durationS: change.current.durationS,
+                      name: change.current?.name ?? "No Workout",
+                      durationS: change.current?.durationS ?? 0,
                     },
                     next: {
                       name: change.next.name,

--- a/packages/coach/tests/account-identity.test.ts
+++ b/packages/coach/tests/account-identity.test.ts
@@ -588,7 +588,7 @@ describe("account identity", () => {
     expect(baseFetch).toHaveBeenCalledOnce();
     const upgraded = openSqliteStorage(storePath);
     try {
-      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 26 });
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 27 });
       expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
       expect(await upgraded.all("SELECT * FROM workout ORDER BY workout_key")).toEqual(
         beforeWorkouts,

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -578,7 +578,7 @@ describe("coach sync composition", () => {
             return store.get("PRAGMA user_version");
           },
         );
-        expect(value).toEqual({ user_version: 26 });
+        expect(value).toEqual({ user_version: 27 });
         expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
         expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
         expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -586,7 +586,7 @@ describe("coach sync composition", () => {
         const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
         try {
           await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-            user_version: 26,
+            user_version: 27,
           });
         } finally {
           await reopened.close();

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -2023,6 +2023,154 @@ describe("Plan operations", () => {
     ).resolves.toMatchObject({ status: "completed", state: { scenarioId: "PL-S005" } });
   });
 
+  it("projects and undoes a reviewed Workout addition through Plan operations", async () => {
+    const planId = `${"0".repeat(25)}A`;
+    const existingWorkoutId = `${"0".repeat(25)}B`;
+    const addedWorkoutId = `${"0".repeat(25)}C`;
+    const proposalId = `${"0".repeat(25)}D`;
+    const activePlan: PlanRecord = {
+      ...plan(planId, 10),
+      status: "active",
+      updatedAtMs: 10,
+      hlcPhysicalMs: 10,
+    };
+    const existingWorkout: PlanWorkoutRecord = {
+      id: existingWorkoutId,
+      planId,
+      dateKey: 20260830,
+      sport: "cycling",
+      name: "Endurance",
+      durationS: 5_400,
+      structureJson: "{}",
+      origin: "coach",
+      deviceId: "device-1",
+      hlcPhysicalMs: 10,
+      hlcCounter: 0,
+    };
+    const plans = createPlanRepository(store);
+    const proposals = createPlanProposalRepository(store);
+    await plans.replace(activePlan, [existingWorkout]);
+    await proposals.save(
+      {
+        id: proposalId,
+        planId,
+        parentProposalId: null,
+        revision: 1,
+        status: "proposed",
+        title: "Add Tempo 3 × 12",
+        rationale: "Review the selected workout before adding it to the active Plan.",
+        confidence: "High",
+        mutationJson: encodePlanProposalMutation({
+          schemaVersion: 1,
+          changes: [
+            {
+              workoutId: addedWorkoutId,
+              before: null,
+              after: {
+                dateKey: 20260831,
+                sport: "cycling",
+                name: "Tempo 3 × 12",
+                durationS: 3_840,
+                structureJson: JSON.stringify({
+                  intervals: [{ repetitions: 3, durationS: 720 }],
+                }),
+              },
+            },
+          ],
+          weekLoad: { before: 420, after: 480 },
+        }),
+        baseSnapshotJson: encodePlanProposalBase(
+          capturePlanProposalBase(activePlan, [existingWorkout]),
+        ),
+        refusalReason: null,
+        createdAtMs: 20,
+        updatedAtMs: 20,
+        resolvedAtMs: null,
+        deviceId: "device-1",
+        hlcPhysicalMs: 20,
+        hlcCounter: 0,
+      },
+      [
+        {
+          id: `${"0".repeat(25)}E`,
+          proposalId,
+          sourceType: "chat-workout",
+          sourceId: "workout-selection",
+          sourceLabel: "Tempo 3 × 12 · MRC",
+          sourceDateKey: null,
+          confidence: "High",
+          snapshotJson: '{"workoutId":"tempo-3x12"}',
+          createdAtMs: 20,
+          deviceId: "device-1",
+          hlcPhysicalMs: 20,
+          hlcCounter: 0,
+        },
+      ],
+    );
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: identity() },
+      {
+        plans,
+        proposals,
+        todayDateKey: () => 20260826,
+        proposalLoadCalculator: (workouts) => (workouts.length === 1 ? 420 : 480),
+        proposalPremiseReader: {
+          async read() {
+            return '{"workoutId":"tempo-3x12"}';
+          },
+        },
+      },
+    );
+
+    const applied = await operations.executePlanTransition?.({
+      transitionId: "PL-T19",
+      commandId: "command-add-workout",
+      proposalId,
+      expectedRevision: 1,
+    });
+    expect(applied).toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S008",
+        data: {
+          history: [
+            expect.objectContaining({
+              kind: "proposal-applied",
+              before: null,
+              after: expect.objectContaining({ name: "Tempo 3 × 12", durationS: 3_840 }),
+              undoStatus: "eligible",
+            }),
+            expect.objectContaining({ kind: "activation" }),
+          ],
+        },
+      },
+    });
+    if (applied?.status !== "completed") throw new TypeError("Workout addition did not apply.");
+    const ledgerId = String(applied.state.data.selectedHistoryId);
+    await expect(plans.readWorkouts(planId)).resolves.toHaveLength(2);
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T21",
+        commandId: "command-undo-workout-addition",
+        planId,
+        ledgerId,
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S027",
+        data: {
+          history: expect.arrayContaining([
+            expect.objectContaining({ kind: "undo", after: null }),
+            expect.objectContaining({ id: ledgerId, undoStatus: "undone" }),
+          ]),
+        },
+      },
+    });
+    await expect(plans.readWorkouts(planId)).resolves.toEqual([existingWorkout]);
+  });
+
   it("opens Season and Race week without mutating persisted Plan facts", async () => {
     const planId = `${"0".repeat(25)}A`;
     const raceWorkoutId = `${"0".repeat(25)}B`;

--- a/packages/engine/src/planning/auto-apply.ts
+++ b/packages/engine/src/planning/auto-apply.ts
@@ -83,6 +83,9 @@ export function validatePlanAutoApply(input: {
   if (change === undefined || input.proposal.changes.length !== 1) {
     return { status: "approval-required", reason: "not-a-reduction" };
   }
+  if (change.current === null) {
+    return { status: "approval-required", reason: "week-structure" };
+  }
   if (
     change.next.dateKey !== change.current.dateKey ||
     change.next.sport !== change.current.sport ||

--- a/packages/engine/src/planning/history.ts
+++ b/packages/engine/src/planning/history.ts
@@ -26,7 +26,7 @@ export interface PlanHistoryEligibility {
 export interface ValidatedPlanUndo {
   readonly target: PlanAdaptationLedgerRecord;
   readonly current: PlanWorkoutRecord;
-  readonly next: PlanWorkoutRecord;
+  readonly next: PlanWorkoutRecord | null;
 }
 
 export class PlanUndoError extends Error {
@@ -55,6 +55,7 @@ function reasonForTarget(input: {
   if (input.workout === undefined) return "workout-missing";
   if (input.workout.dateKey <= input.todayDateKey) return "workout-not-future";
   if (input.workout.origin !== "coach") return "workout-not-coach-owned";
+  if (input.target.afterJson === null) return "workout-missing";
   if (currentSnapshot(input.workout) !== input.target.afterJson) return "workout-changed";
   return null;
 }
@@ -122,17 +123,21 @@ export function validatePlanUndo(input: {
     todayDateKey: input.todayDateKey,
   });
   if (reason !== null) throw new PlanUndoError("unavailable", reason);
-  const before = parsePlanAdaptationWorkoutSnapshot(target.beforeJson);
+  const before =
+    target.beforeJson === null ? null : parsePlanAdaptationWorkoutSnapshot(target.beforeJson);
   return Object.freeze({
     target,
     current: current!,
-    next: Object.freeze({
-      ...current!,
-      ...before,
-      deviceId: input.deviceId,
-      hlcPhysicalMs: input.hlcPhysicalMs,
-      hlcCounter: input.hlcCounter,
-    }),
+    next:
+      before === null
+        ? null
+        : Object.freeze({
+            ...current!,
+            ...before,
+            deviceId: input.deviceId,
+            hlcPhysicalMs: input.hlcPhysicalMs,
+            hlcCounter: input.hlcCounter,
+          }),
   });
 }
 
@@ -165,6 +170,7 @@ export async function applyValidatedPlanUndo(
       id: input.undoId,
       planId: validated.target.planId,
       targetWorkoutId: validated.target.targetWorkoutId,
+      operation: validated.target.operation === "add" ? "remove" : "update",
       kind: "undo",
       sourceId: validated.target.id,
       reversalOfId: validated.target.id,

--- a/packages/engine/src/planning/proposal.ts
+++ b/packages/engine/src/planning/proposal.ts
@@ -21,7 +21,7 @@ export interface PlanProposalWorkoutValue {
 
 export interface PlanProposalWorkoutChange {
   readonly workoutId: string;
-  readonly before: PlanProposalWorkoutValue;
+  readonly before: PlanProposalWorkoutValue | null;
   readonly after: PlanProposalWorkoutValue;
 }
 
@@ -52,7 +52,7 @@ export interface ValidatedPlanProposal {
   readonly mutation: PlanProposalMutation;
   readonly base: PlanProposalBaseSnapshot;
   readonly changes: readonly {
-    readonly current: PlanWorkoutRecord;
+    readonly current: PlanWorkoutRecord | null;
     readonly next: PlanWorkoutRecord;
   }[];
   readonly diff: readonly PlanProposalDiffLine[];
@@ -177,9 +177,9 @@ export function parsePlanProposalMutation(value: string): PlanProposalMutation {
     const workoutId = String(value.workoutId);
     if (ids.has(workoutId)) throw new PlanProposalError("invalid-mutation");
     ids.add(workoutId);
-    const before = workoutValue(value.before);
+    const before = value.before === null ? null : workoutValue(value.before);
     const after = workoutValue(value.after);
-    if (canonicalJson(before) === canonicalJson(after))
+    if (before !== null && canonicalJson(before) === canonicalJson(after))
       throw new PlanProposalError("invalid-mutation");
     return Object.freeze({ workoutId, before, after });
   });
@@ -295,6 +295,23 @@ export function projectPlanProposalDiff(
 ): readonly PlanProposalDiffLine[] {
   const lines: PlanProposalDiffLine[] = [];
   for (const change of mutation.changes) {
+    if (change.before === null) {
+      lines.push(
+        {
+          field: "date",
+          label: "Date",
+          before: "None",
+          after: String(change.after.dateKey),
+        },
+        {
+          field: "workout",
+          label: "Workout",
+          before: "None",
+          after: change.after.name,
+        },
+      );
+      continue;
+    }
     if (change.before.durationS !== change.after.durationS) {
       lines.push({
         field: "duration",
@@ -361,6 +378,29 @@ export function validatePlanProposal(input: {
   const changes = mutation.changes.map((change) => {
     const current = currentById.get(change.workoutId);
     const captured = baseById.get(change.workoutId);
+    if (change.before === null) {
+      if (
+        current !== undefined ||
+        captured !== undefined ||
+        change.after.dateKey <= input.todayDateKey ||
+        planWeekIndex(input.plan, change.after.dateKey).kind !== "inside" ||
+        input.workouts.some((workout) => workout.dateKey === change.after.dateKey)
+      ) {
+        throw new PlanProposalError("stale-base");
+      }
+      return Object.freeze({
+        current: null,
+        next: Object.freeze({
+          id: change.workoutId,
+          planId: input.plan.id,
+          ...change.after,
+          origin: "coach" as const,
+          deviceId: input.plan.deviceId,
+          hlcPhysicalMs: input.plan.hlcPhysicalMs,
+          hlcCounter: input.plan.hlcCounter,
+        }),
+      });
+    }
     if (current === undefined || captured === undefined) {
       throw new PlanProposalError("stale-base");
     }
@@ -390,7 +430,10 @@ export function validatePlanProposal(input: {
   if (mutation.weekLoad !== null) {
     if (input.calculateWeekLoad === undefined) throw new PlanProposalError("missing-capability");
     const nextById = new Map(changes.map(({ next }) => [next.id, next]));
-    const nextWorkouts = input.workouts.map((workout) => nextById.get(workout.id) ?? workout);
+    const nextWorkouts = [
+      ...input.workouts.map((workout) => nextById.get(workout.id) ?? workout),
+      ...changes.flatMap(({ current, next }) => (current === null ? [next] : [])),
+    ];
     let before: number;
     let after: number;
     try {
@@ -479,19 +522,23 @@ export async function applyValidatedPlanProposal(
     expectedPlanUpdatedAtMs: validated.base.planUpdatedAtMs,
     expectedPlanHlcPhysicalMs: validated.base.planHlcPhysicalMs,
     expectedPlanHlcCounter: validated.base.planHlcCounter,
-    expectedWorkouts: validated.changes.map(({ current }) => current),
+    expectedWorkouts: validated.changes.flatMap(({ current }) =>
+      current === null ? [] : [current],
+    ),
     mirrorJob: input.mirrorJob,
     ledger: {
       id: input.ledgerId,
       planId: input.plan.id,
-      targetWorkoutId: change.current.id,
+      targetWorkoutId: change.next.id,
+      operation: change.current === null ? "add" : "update",
       kind: "proposal-applied",
       sourceId: validated.proposal.id,
       reversalOfId: null,
       label: validated.proposal.title,
-      beforeJson: encodePlanAdaptationWorkoutSnapshot(
-        planAdaptationWorkoutSnapshot(change.current),
-      ),
+      beforeJson:
+        change.current === null
+          ? null
+          : encodePlanAdaptationWorkoutSnapshot(planAdaptationWorkoutSnapshot(change.current)),
       afterJson: encodePlanAdaptationWorkoutSnapshot(planAdaptationWorkoutSnapshot(workouts[0]!)),
       weekLoadBefore: validated.mutation.weekLoad?.before ?? null,
       weekLoadAfter: validated.mutation.weekLoad?.after ?? null,

--- a/packages/engine/src/planning/workout-drift.ts
+++ b/packages/engine/src/planning/workout-drift.ts
@@ -330,6 +330,7 @@ export async function adoptProviderWorkoutEdit(
       id: deps.identity.newId(),
       planId: value.plan.id,
       targetWorkoutId: value.workout.id,
+      operation: "update",
       kind: "drift-adopted",
       sourceId: value.drift.id,
       reversalOfId: null,

--- a/packages/engine/tests/planning/history.test.ts
+++ b/packages/engine/tests/planning/history.test.ts
@@ -63,6 +63,7 @@ function applied(overrides: Partial<PlanAdaptationLedgerRecord> = {}): PlanAdapt
     id: id(3),
     planId: PLAN_ID,
     targetWorkoutId: WORKOUT_ID,
+    operation: "update",
     kind: "proposal-applied",
     sourceId: id(8),
     reversalOfId: null,
@@ -167,6 +168,53 @@ describe("Plan history Undo policy", () => {
         undo: expect.objectContaining({
           beforeJson: target.afterJson,
           afterJson: target.beforeJson,
+        }),
+      }),
+    );
+  });
+
+  it("undoes an added Workout by requesting one atomic removal", async () => {
+    const target: PlanAdaptationLedgerRecord = {
+      ...applied(),
+      operation: "add",
+      label: "Tempo 3 × 12 added",
+      beforeJson: null,
+      afterJson: encodePlanAdaptationWorkoutSnapshot(planAdaptationWorkoutSnapshot(currentWorkout)),
+    };
+    const validated = validatePlanUndo({
+      ledgerId: target.id,
+      plan,
+      workouts: [currentWorkout],
+      history: [target],
+      todayDateKey: 20260826,
+      deviceId: "device-2",
+      hlcPhysicalMs: 30,
+      hlcCounter: 1,
+    });
+    expect(validated.next).toBeNull();
+    const reverse = vi.fn(async (input) => input.undo);
+    await applyValidatedPlanUndo(validated, {
+      repository: { reverse } as unknown as PlanAdaptationLedgerRepository,
+      plan,
+      undoId: id(5),
+      occurredAtMs: 30,
+      deviceId: "device-2",
+      hlcPhysicalMs: 30,
+      hlcCounter: 1,
+      mirrorJob: {
+        id: id(6),
+        windowStartDateKey: 20260826,
+        windowEndDateKey: 20260901,
+        createdAtMs: 30,
+      },
+    });
+    expect(reverse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextWorkout: null,
+        undo: expect.objectContaining({
+          operation: "remove",
+          beforeJson: target.afterJson,
+          afterJson: null,
         }),
       }),
     );

--- a/packages/engine/tests/planning/proposal.test.ts
+++ b/packages/engine/tests/planning/proposal.test.ts
@@ -136,9 +136,9 @@ describe("structured Plan proposals", () => {
         changes: [
           {
             workoutId: workout.id,
-            before: { ...mutation.changes[0]!.before, durationS: 1_800 },
+            before: { ...mutation.changes[0]!.before!, durationS: 1_800 },
             after: {
-              ...mutation.changes[0]!.before,
+              ...mutation.changes[0]!.before!,
               durationS: 1_830,
             },
           },
@@ -272,7 +272,7 @@ describe("structured Plan proposals", () => {
       changes: [
         {
           ...mutation.changes[0]!,
-          before: { ...mutation.changes[0]!.before, structureJson },
+          before: { ...mutation.changes[0]!.before!, structureJson },
           after: { ...mutation.changes[0]!.after, structureJson },
         },
       ],
@@ -324,6 +324,101 @@ describe("structured Plan proposals", () => {
     await expect(
       revalidatePlanProposalPremises([premise], { read: vi.fn(async () => null) }),
     ).rejects.toMatchObject({ code: "stale-base" });
+  });
+
+  it("validates a conflict-free Workout addition and sends it to the atomic apply boundary", async () => {
+    const addedWorkoutId = id(7);
+    const addition: PlanProposalMutation = {
+      schemaVersion: 1,
+      changes: [
+        {
+          workoutId: addedWorkoutId,
+          before: null,
+          after: {
+            dateKey: 20260831,
+            sport: "cycling",
+            name: "Tempo 3 × 12",
+            durationS: 3_840,
+            structureJson: JSON.stringify({ intervals: [{ repetitions: 3, durationS: 720 }] }),
+          },
+        },
+      ],
+      weekLoad: { before: 420, after: 480 },
+    };
+    const additionProposal: PlanProposalRecord = {
+      ...proposal,
+      id: id(6),
+      title: "Add Tempo 3 × 12",
+      mutationJson: encodePlanProposalMutation(addition),
+    };
+    const additionPremise = { ...premise, id: id(5), proposalId: additionProposal.id };
+    const validated = validatePlanProposal({
+      proposal: additionProposal,
+      premises: [additionPremise],
+      plan,
+      workouts: [workout],
+      todayDateKey: 20260826,
+      calculateWeekLoad: (workouts) => (workouts.length === 1 ? 420 : 480),
+    });
+    expect(validated.diff).toEqual([
+      { field: "date", label: "Date", before: "None", after: "20260831" },
+      { field: "workout", label: "Workout", before: "None", after: "Tempo 3 × 12" },
+      { field: "week-load", label: "Week load", before: "420", after: "480" },
+    ]);
+    expect(validated.changes[0]).toMatchObject({
+      current: null,
+      next: { id: addedWorkoutId, planId: plan.id, origin: "coach" },
+    });
+
+    const apply = vi.fn(async () => ({ ...additionProposal, status: "applied" as const }));
+    await applyValidatedPlanProposal(validated, {
+      repository: { apply } as unknown as PlanProposalRepository,
+      plan,
+      resolvedAtMs: 30,
+      deviceId: "device-1",
+      hlcPhysicalMs: 30,
+      hlcCounter: 0,
+      ledgerId: id(8),
+      mirrorJob: {
+        id: id(9),
+        windowStartDateKey: 20260826,
+        windowEndDateKey: 20260901,
+        createdAtMs: 30,
+      },
+    });
+    expect(apply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedWorkouts: [],
+        workouts: [expect.objectContaining({ id: addedWorkoutId, name: "Tempo 3 × 12" })],
+        ledger: expect.objectContaining({
+          operation: "add",
+          targetWorkoutId: addedWorkoutId,
+          beforeJson: null,
+        }),
+      }),
+    );
+
+    expect(() =>
+      validatePlanProposal({
+        proposal: {
+          ...additionProposal,
+          mutationJson: encodePlanProposalMutation({
+            ...addition,
+            changes: [
+              {
+                ...addition.changes[0]!,
+                after: { ...addition.changes[0]!.after, dateKey: workout.dateKey },
+              },
+            ],
+          }),
+        },
+        premises: [additionPremise],
+        plan,
+        workouts: [workout],
+        todayDateKey: 20260826,
+        calculateWeekLoad: (workouts) => (workouts.length === 1 ? 420 : 480),
+      }),
+    ).toThrowError(expect.objectContaining({ code: "stale-base" }));
   });
 
   it("applies only the validated revision through the atomic repository boundary", async () => {

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -598,7 +598,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 27 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -4,6 +4,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createPlanRepository } from "@enduragent/kernel/planning";
 import {
   DUMP_TABLES,
   createAnchorRepository,
@@ -31,9 +32,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 26", async () => {
+  it("applies the full migration list and advances user_version to 27", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 27 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -53,7 +54,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 27 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -82,11 +83,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 26", async () => {
+  it("upgrades a version-1-on-disk store to version 27", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 27 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -108,10 +109,12 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 4,
-      toVersion: 26,
-      applied: [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
+      toVersion: 27,
+      applied: [
+        5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+      ],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 27 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -164,21 +167,21 @@ describe("migrator end-to-end over node:sqlite", () => {
     const result = await runMigrations(store, MIGRATIONS);
     expect(result).toEqual({
       fromVersion: 6,
-      toVersion: 26,
-      applied: [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
+      toVersion: 27,
+      applied: [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27],
     });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 27 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 26,
-      toVersion: 26,
+      fromVersion: 27,
+      toVersion: 27,
       applied: [],
     });
   });
 
-  it("upgrades version 11 through 26 while preserving existing rows", async () => {
+  it("upgrades version 11 through 27 while preserving existing rows", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 11));
     await store.run("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,?)", [
       "chronoBridge",
@@ -187,8 +190,8 @@ describe("migrator end-to-end over node:sqlite", () => {
 
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
       fromVersion: 11,
-      toVersion: 26,
-      applied: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
+      toVersion: 27,
+      applied: [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27],
     });
     await expect(store.get("SELECT fixer,enabled FROM repair_fixer_settings")).resolves.toEqual({
       fixer: "chronoBridge",
@@ -197,7 +200,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     await expect(store.get("SELECT count(*) AS count FROM repair_fixer_settings")).resolves.toEqual(
       { count: 1 },
     );
-    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 26 });
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 27 });
   });
 
   it("rolls back a failed migration 12 without partial Planning tables", async () => {
@@ -375,7 +378,7 @@ describe("migrator end-to-end over node:sqlite", () => {
       ["request-1", "Review next week.", "a".repeat(64), "{}", "chat-1", "message-1"],
     );
 
-    await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
+    await expect(runMigrations(store, MIGRATIONS.slice(0, 26))).resolves.toEqual({
       fromVersion: 25,
       toVersion: 26,
       applied: [26],
@@ -407,6 +410,113 @@ describe("migrator end-to-end over node:sqlite", () => {
     await expect(
       store.all("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"),
     ).resolves.toEqual(tablesBefore);
+  });
+
+  it("upgrades migration 26 to 27 with reversible Plan Workout addition columns", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 26));
+    const planId = `${"0".repeat(25)}1`;
+    const workoutId = `${"0".repeat(25)}2`;
+    await createPlanRepository(store).replace(
+      {
+        id: planId,
+        originId: null,
+        name: "Migration Plan",
+        primaryGoal: "Finish",
+        startDateKey: 20260824,
+        targetDateKey: null,
+        status: "active",
+        kind: "short_race_preparation",
+        totalWeeks: 4,
+        weekStartDay: 1,
+        structureJson: "{}",
+        createdAtMs: 1,
+        updatedAtMs: 10,
+        deviceId: "device-1",
+        hlcPhysicalMs: 10,
+        hlcCounter: 0,
+      },
+      [
+        {
+          id: workoutId,
+          planId,
+          dateKey: 20260830,
+          sport: "cycling",
+          name: "Endurance",
+          durationS: 5_400,
+          structureJson: "{}",
+          origin: "coach",
+          deviceId: "device-1",
+          hlcPhysicalMs: 10,
+          hlcCounter: 0,
+        },
+      ],
+    );
+    const snapshot = JSON.stringify({
+      dateKey: 20260830,
+      sport: "cycling",
+      name: "Endurance",
+      durationS: 5_400,
+      structureJson: "{}",
+      origin: "coach",
+    });
+    await store.run(
+      `INSERT INTO plan_adaptation_ledger (
+  id, plan_id, target_workout_id, kind, source_id, reversal_of_id, label,
+  before_json, after_json, week_load_before, week_load_after, occurred_at_ms,
+  device_id, hlc_physical_ms, hlc_counter
+) VALUES (?, ?, ?, 'proposal-applied', ?, NULL, ?, ?, ?, NULL, NULL, 10, 'device-1', 10, 0)`,
+      [
+        `${"0".repeat(25)}3`,
+        planId,
+        workoutId,
+        `${"0".repeat(25)}4`,
+        "Applied",
+        snapshot,
+        snapshot,
+      ],
+    );
+
+    await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
+      fromVersion: 26,
+      toVersion: 27,
+      applied: [27],
+    });
+    const columns = await store.all("PRAGMA table_info(plan_adaptation_ledger)");
+    await expect(columns.find((column) => column.name === "operation")).toMatchObject({
+      name: "operation",
+      notnull: 1,
+    });
+    await expect(columns.find((column) => column.name === "before_json")).toMatchObject({
+      name: "before_json",
+      notnull: 0,
+    });
+    await expect(
+      store.get(
+        "SELECT operation, before_json, after_json FROM plan_adaptation_ledger WHERE target_workout_id=?",
+        [workoutId],
+      ),
+    ).resolves.toEqual({ operation: "update", before_json: snapshot, after_json: snapshot });
+    await expect(store.all("PRAGMA foreign_key_check")).resolves.toEqual([]);
+  });
+
+  it("rolls back a failed migration 27 without replacing the adaptation ledger", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 26));
+    const columnsBefore = await store.all("PRAGMA table_info(plan_adaptation_ledger)");
+    const broken = {
+      ...MIGRATIONS[26]!,
+      sql: `${MIGRATIONS[26]!.sql}\nINSERT INTO missing_table VALUES (1);`,
+    };
+
+    await expect(runMigrations(store, [...MIGRATIONS.slice(0, 26), broken])).rejects.toThrow();
+    await expect(store.get("PRAGMA user_version")).resolves.toEqual({ user_version: 26 });
+    await expect(store.all("PRAGMA table_info(plan_adaptation_ledger)")).resolves.toEqual(
+      columnsBefore,
+    );
+    await expect(
+      store.get(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='plan_adaptation_ledger_v26'",
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it("preserves an existing cursor and leaves its store owner unset", async () => {

--- a/packages/kernel-node/tests/plan-adaptation-ledger-repository.test.ts
+++ b/packages/kernel-node/tests/plan-adaptation-ledger-repository.test.ts
@@ -65,6 +65,7 @@ function appliedRecord(
     id: id(3),
     planId: PLAN_ID,
     targetWorkoutId: WORKOUT_ID,
+    operation: "update",
     kind: "proposal-applied",
     sourceId: id(8),
     reversalOfId: null,
@@ -87,6 +88,7 @@ function undoRecord(): PlanAdaptationLedgerRecord {
     id: id(4),
     planId: PLAN_ID,
     targetWorkoutId: WORKOUT_ID,
+    operation: "update",
     kind: "undo",
     sourceId: applied.id,
     reversalOfId: applied.id,
@@ -135,6 +137,67 @@ describe("Plan adaptation ledger repository", () => {
         expect.objectContaining({ id: id(3), kind: "proposal-applied" }),
       ],
     );
+  });
+
+  it("atomically removes an added Workout on Undo while preserving both history entries", async () => {
+    const repository = createPlanAdaptationLedgerRepository(store);
+    const plans = createPlanRepository(store);
+    const addedWorkout: PlanWorkoutRecord = {
+      ...appliedWorkout,
+      name: "Tempo 3 × 12",
+      durationS: 3_840,
+      structureJson: JSON.stringify({ intervals: [{ repetitions: 3, durationS: 720 }] }),
+    };
+    await plans.replace(plan, [addedWorkout]);
+    const addition: PlanAdaptationLedgerRecord = {
+      ...appliedRecord(),
+      operation: "add",
+      label: "Tempo 3 × 12 added",
+      beforeJson: null,
+      afterJson: encodePlanAdaptationWorkoutSnapshot(planAdaptationWorkoutSnapshot(addedWorkout)),
+    };
+    await repository.append(addition);
+    const undo: PlanAdaptationLedgerRecord = {
+      id: id(4),
+      planId: PLAN_ID,
+      targetWorkoutId: WORKOUT_ID,
+      operation: "remove",
+      kind: "undo",
+      sourceId: addition.id,
+      reversalOfId: addition.id,
+      label: "Tempo 3 × 12 added undone",
+      beforeJson: addition.afterJson,
+      afterJson: null,
+      weekLoadBefore: addition.weekLoadAfter,
+      weekLoadAfter: addition.weekLoadBefore,
+      occurredAtMs: 30,
+      deviceId: "device-1",
+      hlcPhysicalMs: 30,
+      hlcCounter: 0,
+    };
+
+    await expect(
+      repository.reverse({
+        targetId: addition.id,
+        expectedPlanUpdatedAtMs: 20,
+        expectedPlanHlcPhysicalMs: 20,
+        expectedPlanHlcCounter: 0,
+        expectedWorkout: addedWorkout,
+        nextWorkout: null,
+        undo,
+        mirrorJob: {
+          id: id(6),
+          windowStartDateKey: 20260826,
+          windowEndDateKey: 20260901,
+          createdAtMs: 30,
+        },
+      }),
+    ).resolves.toMatchObject({ operation: "remove", kind: "undo" });
+    await expect(plans.readWorkouts(PLAN_ID)).resolves.toEqual([]);
+    await expect(repository.readForPlan(PLAN_ID)).resolves.toEqual([
+      expect.objectContaining({ id: undo.id, operation: "remove", afterJson: null }),
+      expect.objectContaining({ id: addition.id, operation: "add", beforeJson: null }),
+    ]);
   });
 
   it("atomically restores the exact snapshot, appends one inverse, and queues reconciliation", async () => {

--- a/packages/kernel-node/tests/plan-proposal-repository.test.ts
+++ b/packages/kernel-node/tests/plan-proposal-repository.test.ts
@@ -108,6 +108,7 @@ function ledger(
     id: ledgerId,
     planId: PLAN_ID,
     targetWorkoutId: WORKOUT_ID,
+    operation: "update",
     kind: "proposal-applied",
     sourceId: proposalId,
     reversalOfId: null,
@@ -293,6 +294,77 @@ describe("Plan proposal repository", () => {
         hlcCounter: 0,
       }),
     ).rejects.toBeInstanceOf(PlanProposalValidationError);
+  });
+
+  it("atomically adds a reviewed Workout and preserves an immutable addition ledger", async () => {
+    const proposals = createPlanProposalRepository(store);
+    const plans = createPlanRepository(store);
+    const history = createPlanAdaptationLedgerRepository(store);
+    const proposalId = id(12);
+    const addedWorkout: PlanWorkoutRecord = {
+      id: id(13),
+      planId: PLAN_ID,
+      dateKey: 20260831,
+      sport: "cycling",
+      name: "Tempo 3 × 12",
+      durationS: 3_840,
+      structureJson: JSON.stringify({ intervals: [{ repetitions: 3, durationS: 720 }] }),
+      origin: "coach",
+      deviceId: "device-1",
+      hlcPhysicalMs: 40,
+      hlcCounter: 0,
+    };
+    await proposals.save(proposal(proposalId), [premise(proposalId, id(14))]);
+
+    await expect(
+      proposals.apply({
+        id: proposalId,
+        expectedPlanUpdatedAtMs: 10,
+        expectedPlanHlcPhysicalMs: 10,
+        expectedPlanHlcCounter: 0,
+        expectedWorkouts: [],
+        mirrorJob: {
+          id: id(15),
+          windowStartDateKey: 20260826,
+          windowEndDateKey: 20260901,
+          createdAtMs: 40,
+        },
+        plan: { ...plan, updatedAtMs: 40, hlcPhysicalMs: 40 },
+        workouts: [addedWorkout],
+        ledger: {
+          id: id(16),
+          planId: PLAN_ID,
+          targetWorkoutId: addedWorkout.id,
+          operation: "add",
+          kind: "proposal-applied",
+          sourceId: proposalId,
+          reversalOfId: null,
+          label: "Tempo 3 × 12 added",
+          beforeJson: null,
+          afterJson: encodePlanAdaptationWorkoutSnapshot(
+            planAdaptationWorkoutSnapshot(addedWorkout),
+          ),
+          weekLoadBefore: 420,
+          weekLoadAfter: 480,
+          occurredAtMs: 40,
+          deviceId: "device-1",
+          hlcPhysicalMs: 40,
+          hlcCounter: 0,
+        },
+        resolvedAtMs: 40,
+        deviceId: "device-1",
+        hlcPhysicalMs: 40,
+        hlcCounter: 0,
+      }),
+    ).resolves.toMatchObject({ status: "applied" });
+    await expect(plans.readWorkouts(PLAN_ID)).resolves.toEqual([workout, addedWorkout]);
+    await expect(history.readForPlan(PLAN_ID)).resolves.toEqual([
+      expect.objectContaining({
+        operation: "add",
+        targetWorkoutId: addedWorkout.id,
+        beforeJson: null,
+      }),
+    ]);
   });
 
   it("rejects apply when a workout changed without advancing the Plan timestamp", async () => {

--- a/packages/kernel-node/tests/plan-workout-drift-repository.test.ts
+++ b/packages/kernel-node/tests/plan-workout-drift-repository.test.ts
@@ -139,6 +139,7 @@ describe("Plan workout drift repository", () => {
           id: `${"0".repeat(25)}4`,
           planId: PLAN_ID,
           targetWorkoutId: WORKOUT_ID,
+          operation: "update",
           kind: "drift-adopted",
           sourceId: DRIFT_ID,
           reversalOfId: null,

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -239,7 +239,7 @@ describe("sync failure repository", () => {
     expect(dump).not.toContain("# sync_failure");
     expect(dump).toContain("# plan_reconciliation_job");
     expect(dump).toContain("# plan_reconciliation_item");
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 26 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 27 });
     expect(DUMP_TABLES).toHaveLength(58);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");

--- a/packages/kernel/src/planning/adaptation-ledger-repository.ts
+++ b/packages/kernel/src/planning/adaptation-ledger-repository.ts
@@ -4,6 +4,7 @@ import { addCivilDays } from "./date-keys.js";
 import type { PlanWorkoutOrigin, PlanWorkoutRecord } from "./repository.js";
 
 export type PlanAdaptationKind = "proposal-applied" | "drift-adopted" | "undo";
+export type PlanAdaptationOperation = "update" | "add" | "remove";
 
 export interface PlanAdaptationWorkoutSnapshot {
   readonly dateKey: number;
@@ -18,12 +19,13 @@ export interface PlanAdaptationLedgerRecord {
   readonly id: string;
   readonly planId: string;
   readonly targetWorkoutId: string;
+  readonly operation: PlanAdaptationOperation;
   readonly kind: PlanAdaptationKind;
   readonly sourceId: string;
   readonly reversalOfId: string | null;
   readonly label: string;
-  readonly beforeJson: string;
-  readonly afterJson: string;
+  readonly beforeJson: string | null;
+  readonly afterJson: string | null;
   readonly weekLoadBefore: number | null;
   readonly weekLoadAfter: number | null;
   readonly occurredAtMs: number;
@@ -42,7 +44,7 @@ export interface PlanAdaptationLedgerRepository {
     readonly expectedPlanHlcPhysicalMs: number;
     readonly expectedPlanHlcCounter: number;
     readonly expectedWorkout: PlanWorkoutRecord;
-    readonly nextWorkout: PlanWorkoutRecord;
+    readonly nextWorkout: PlanWorkoutRecord | null;
     readonly undo: PlanAdaptationLedgerRecord;
     readonly mirrorJob: {
       readonly id: string;
@@ -66,6 +68,7 @@ export class PlanAdaptationLedgerValidationError extends Error {
 const ULID = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 const DEVICE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const KINDS = new Set<unknown>(["proposal-applied", "drift-adopted", "undo"]);
+const OPERATIONS = new Set<unknown>(["update", "add", "remove"]);
 const ORIGINS = new Set<unknown>(["coach", "athlete"]);
 
 function object(value: unknown): value is Record<string, unknown> {
@@ -179,6 +182,7 @@ function validate(record: PlanAdaptationLedgerRecord): void {
     !ULID.test(record.id) ||
     !ULID.test(record.planId) ||
     !ULID.test(record.targetWorkoutId) ||
+    !OPERATIONS.has(record.operation) ||
     !KINDS.has(record.kind) ||
     record.sourceId.length === 0 ||
     (record.kind === "undo") !== (record.reversalOfId !== null) ||
@@ -199,11 +203,18 @@ function validate(record: PlanAdaptationLedgerRecord): void {
   ) {
     throw new PlanAdaptationLedgerValidationError("invalid-ledger");
   }
-  parsePlanAdaptationWorkoutSnapshot(record.beforeJson);
-  parsePlanAdaptationWorkoutSnapshot(record.afterJson);
+  if (
+    (record.operation === "update" && (record.beforeJson === null || record.afterJson === null)) ||
+    (record.operation === "add" && (record.beforeJson !== null || record.afterJson === null)) ||
+    (record.operation === "remove" && (record.beforeJson === null || record.afterJson !== null))
+  ) {
+    throw new PlanAdaptationLedgerValidationError("invalid-ledger");
+  }
+  if (record.beforeJson !== null) parsePlanAdaptationWorkoutSnapshot(record.beforeJson);
+  if (record.afterJson !== null) parsePlanAdaptationWorkoutSnapshot(record.afterJson);
 }
 
-const COLUMNS = `id, plan_id, target_workout_id, kind, source_id, reversal_of_id, label,
+const COLUMNS = `id, plan_id, target_workout_id, operation, kind, source_id, reversal_of_id, label,
 before_json, after_json, week_load_before, week_load_after, occurred_at_ms, device_id,
 hlc_physical_ms, hlc_counter`;
 
@@ -220,12 +231,13 @@ function fromRow(row: Row): PlanAdaptationLedgerRecord {
     id: text(row, "id"),
     planId: text(row, "plan_id"),
     targetWorkoutId: text(row, "target_workout_id"),
+    operation: text(row, "operation") as PlanAdaptationOperation,
     kind: text(row, "kind") as PlanAdaptationKind,
     sourceId: text(row, "source_id"),
     reversalOfId: nullableText(row, "reversal_of_id"),
     label: text(row, "label"),
-    beforeJson: text(row, "before_json"),
-    afterJson: text(row, "after_json"),
+    beforeJson: nullableText(row, "before_json"),
+    afterJson: nullableText(row, "after_json"),
     weekLoadBefore: nullableNumber(row, "week_load_before"),
     weekLoadAfter: nullableNumber(row, "week_load_after"),
     occurredAtMs: integer(row, "occurred_at_ms"),
@@ -244,11 +256,12 @@ export async function insertPlanAdaptationLedgerRecord(
   validate(record);
   await store.run(
     `INSERT INTO plan_adaptation_ledger (${COLUMNS})
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       record.id,
       record.planId,
       record.targetWorkoutId,
+      record.operation,
       record.kind,
       record.sourceId,
       record.reversalOfId,
@@ -363,8 +376,15 @@ device_id, hlc_physical_ms, hlc_counter FROM plan_workout WHERE id=? AND plan_id
           encodePlanAdaptationWorkoutSnapshot(
             planAdaptationWorkoutSnapshot(input.expectedWorkout),
           ) !== latest.afterJson ||
-          encodePlanAdaptationWorkoutSnapshot(planAdaptationWorkoutSnapshot(input.nextWorkout)) !==
-            latest.beforeJson ||
+          (latest.operation === "update" &&
+            (input.nextWorkout === null ||
+              input.undo.operation !== "update" ||
+              encodePlanAdaptationWorkoutSnapshot(
+                planAdaptationWorkoutSnapshot(input.nextWorkout),
+              ) !== latest.beforeJson)) ||
+          (latest.operation === "add" &&
+            (input.nextWorkout !== null || input.undo.operation !== "remove")) ||
+          (latest.operation !== "update" && latest.operation !== "add") ||
           input.undo.beforeJson !== latest.afterJson ||
           input.undo.afterJson !== latest.beforeJson ||
           input.undo.weekLoadBefore !== latest.weekLoadAfter ||
@@ -372,23 +392,30 @@ device_id, hlc_physical_ms, hlc_counter FROM plan_workout WHERE id=? AND plan_id
         ) {
           throw new PlanAdaptationLedgerValidationError("stale-base");
         }
-        await store.run(
-          `UPDATE plan_workout SET date_key=?, sport=?, name=?, duration_s=?, structure_json=?,
+        if (input.nextWorkout === null) {
+          await store.run("DELETE FROM plan_workout WHERE id=? AND plan_id=?", [
+            input.expectedWorkout.id,
+            input.expectedWorkout.planId,
+          ]);
+        } else {
+          await store.run(
+            `UPDATE plan_workout SET date_key=?, sport=?, name=?, duration_s=?, structure_json=?,
 origin=?, device_id=?, hlc_physical_ms=?, hlc_counter=? WHERE id=? AND plan_id=?`,
-          [
-            input.nextWorkout.dateKey,
-            input.nextWorkout.sport,
-            input.nextWorkout.name,
-            input.nextWorkout.durationS,
-            input.nextWorkout.structureJson,
-            input.nextWorkout.origin,
-            input.nextWorkout.deviceId,
-            input.nextWorkout.hlcPhysicalMs,
-            input.nextWorkout.hlcCounter,
-            input.nextWorkout.id,
-            input.nextWorkout.planId,
-          ],
-        );
+            [
+              input.nextWorkout.dateKey,
+              input.nextWorkout.sport,
+              input.nextWorkout.name,
+              input.nextWorkout.durationS,
+              input.nextWorkout.structureJson,
+              input.nextWorkout.origin,
+              input.nextWorkout.deviceId,
+              input.nextWorkout.hlcPhysicalMs,
+              input.nextWorkout.hlcCounter,
+              input.nextWorkout.id,
+              input.nextWorkout.planId,
+            ],
+          );
+        }
         await store.run(
           `UPDATE plan SET updated_at_ms=?, device_id=?, hlc_physical_ms=?, hlc_counter=? WHERE id=?`,
           [

--- a/packages/kernel/src/planning/proposal-repository.ts
+++ b/packages/kernel/src/planning/proposal-repository.ts
@@ -444,22 +444,28 @@ device_id=?, hlc_physical_ms=?, hlc_counter=? WHERE id=? AND status='proposed'`,
         input.hlcCounter < 0 ||
         input.workouts.length === 0 ||
         input.workouts.length !== 1 ||
-        input.expectedWorkouts.length !== input.workouts.length ||
+        input.expectedWorkouts.length > 1 ||
         expectedById.size !== input.expectedWorkouts.length ||
-        input.workouts.some((workout) => !expectedById.has(workout.id))
+        (input.expectedWorkouts.length === 1 &&
+          input.expectedWorkouts[0]!.id !== input.workouts[0]!.id)
       ) {
         throw new PlanProposalValidationError("invalid-proposal");
       }
-      const expectedWorkout = input.expectedWorkouts[0]!;
+      const expectedWorkout = input.expectedWorkouts[0];
       const nextWorkout = input.workouts[0]!;
       if (
         input.ledger.kind !== "proposal-applied" ||
         input.ledger.sourceId !== input.id ||
         input.ledger.reversalOfId !== null ||
         input.ledger.planId !== input.plan.id ||
-        input.ledger.targetWorkoutId !== expectedWorkout.id ||
-        input.ledger.beforeJson !==
-          encodePlanAdaptationWorkoutSnapshot(planAdaptationWorkoutSnapshot(expectedWorkout)) ||
+        input.ledger.targetWorkoutId !== nextWorkout.id ||
+        (expectedWorkout === undefined
+          ? input.ledger.operation !== "add" || input.ledger.beforeJson !== null
+          : input.ledger.operation !== "update" ||
+            input.ledger.beforeJson !==
+              encodePlanAdaptationWorkoutSnapshot(
+                planAdaptationWorkoutSnapshot(expectedWorkout),
+              )) ||
         input.ledger.afterJson !==
           encodePlanAdaptationWorkoutSnapshot(planAdaptationWorkoutSnapshot(nextWorkout))
       ) {
@@ -489,12 +495,7 @@ device_id=?, hlc_physical_ms=?, hlc_counter=? WHERE id=? AND status='proposed'`,
         }
         for (const workout of input.workouts) {
           const expected = expectedById.get(workout.id);
-          if (
-            expected === undefined ||
-            workout.planId !== input.plan.id ||
-            expected.planId !== input.plan.id ||
-            !ULID.test(workout.id)
-          ) {
+          if (workout.planId !== input.plan.id || !ULID.test(workout.id)) {
             throw new PlanProposalValidationError("invalid-proposal");
           }
           const current = await store.get(
@@ -502,6 +503,35 @@ device_id=?, hlc_physical_ms=?, hlc_counter=? WHERE id=? AND status='proposed'`,
 device_id, hlc_physical_ms, hlc_counter FROM plan_workout WHERE id=? AND plan_id=?`,
             [workout.id, input.plan.id],
           );
+          if (expected === undefined) {
+            const dateConflict = await store.get(
+              "SELECT id FROM plan_workout WHERE plan_id=? AND date_key=? LIMIT 1",
+              [input.plan.id, workout.dateKey],
+            );
+            if (current !== undefined || dateConflict !== undefined) {
+              throw new PlanProposalValidationError("stale-base");
+            }
+            await store.run(
+              `INSERT INTO plan_workout (
+  id, plan_id, date_key, sport, name, duration_s, structure_json, origin,
+  device_id, hlc_physical_ms, hlc_counter
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+              [
+                workout.id,
+                workout.planId,
+                workout.dateKey,
+                workout.sport,
+                workout.name,
+                workout.durationS,
+                workout.structureJson,
+                workout.origin,
+                workout.deviceId,
+                workout.hlcPhysicalMs,
+                workout.hlcCounter,
+              ],
+            );
+            continue;
+          }
           if (
             current === undefined ||
             text(current, "id") !== expected.id ||

--- a/packages/kernel/src/store/migrations/027_plan_workout_additions.sql
+++ b/packages/kernel/src/store/migrations/027_plan_workout_additions.sql
@@ -1,0 +1,61 @@
+ALTER TABLE plan_adaptation_ledger RENAME TO plan_adaptation_ledger_v26;
+
+CREATE TABLE plan_adaptation_ledger (
+  id TEXT PRIMARY KEY
+    CHECK (
+      length(id) = 26
+      AND id NOT GLOB '*[^0123456789ABCDEFGHJKMNPQRSTVWXYZ]*'
+    ),
+  plan_id TEXT NOT NULL REFERENCES plan(id) ON DELETE CASCADE,
+  target_workout_id TEXT NOT NULL
+    CHECK (
+      length(target_workout_id) = 26
+      AND target_workout_id NOT GLOB '*[^0123456789ABCDEFGHJKMNPQRSTVWXYZ]*'
+    ),
+  operation TEXT NOT NULL CHECK (operation IN ('update','add','remove')),
+  kind TEXT NOT NULL CHECK (kind IN ('proposal-applied','drift-adopted','undo')),
+  source_id TEXT NOT NULL CHECK (length(source_id) > 0),
+  reversal_of_id TEXT REFERENCES plan_adaptation_ledger(id) ON DELETE RESTRICT,
+  label TEXT NOT NULL CHECK (length(label) > 0),
+  before_json TEXT CHECK (before_json IS NULL OR json_valid(before_json)),
+  after_json TEXT CHECK (after_json IS NULL OR json_valid(after_json)),
+  week_load_before REAL CHECK (week_load_before IS NULL OR week_load_before >= 0),
+  week_load_after REAL CHECK (week_load_after IS NULL OR week_load_after >= 0),
+  occurred_at_ms INTEGER NOT NULL CHECK (occurred_at_ms >= 0),
+  device_id TEXT NOT NULL
+    CHECK (
+      length(device_id) BETWEEN 1 AND 128
+      AND substr(device_id, 1, 1) GLOB '[A-Za-z0-9]'
+      AND device_id NOT GLOB '*[^A-Za-z0-9._:-]*'
+    ),
+  hlc_physical_ms INTEGER NOT NULL CHECK (hlc_physical_ms >= 0),
+  hlc_counter INTEGER NOT NULL CHECK (hlc_counter >= 0),
+  CHECK (
+    (kind = 'undo' AND reversal_of_id IS NOT NULL)
+    OR (kind <> 'undo' AND reversal_of_id IS NULL)
+  ),
+  CHECK (
+    (operation = 'update' AND before_json IS NOT NULL AND after_json IS NOT NULL)
+    OR (operation = 'add' AND before_json IS NULL AND after_json IS NOT NULL)
+    OR (operation = 'remove' AND before_json IS NOT NULL AND after_json IS NULL)
+  ),
+  CHECK ((week_load_before IS NULL) = (week_load_after IS NULL)),
+  UNIQUE (reversal_of_id)
+) STRICT;
+
+INSERT INTO plan_adaptation_ledger (
+  id, plan_id, target_workout_id, operation, kind, source_id, reversal_of_id, label,
+  before_json, after_json, week_load_before, week_load_after, occurred_at_ms, device_id,
+  hlc_physical_ms, hlc_counter
+)
+SELECT
+  id, plan_id, target_workout_id, 'update', kind, source_id, reversal_of_id, label,
+  before_json, after_json, week_load_before, week_load_after, occurred_at_ms, device_id,
+  hlc_physical_ms, hlc_counter
+FROM plan_adaptation_ledger_v26
+ORDER BY occurred_at_ms, id;
+
+DROP TABLE plan_adaptation_ledger_v26;
+
+CREATE INDEX idx_plan_adaptation_ledger_plan_time
+  ON plan_adaptation_ledger (plan_id, occurred_at_ms DESC, id DESC);

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -24,6 +24,7 @@ import planRaceOutcome023 from "./023_plan_race_outcome.sql";
 import chatAttachments024 from "./024_chat_attachments.sql";
 import planningRequests025 from "./025_planning_requests.sql";
 import chatPlanOutbox026 from "./026_chat_plan_outbox.sql";
+import planWorkoutAdditions027 from "./027_plan_workout_additions.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -65,4 +66,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 24, name: "024_chat_attachments", sql: chatAttachments024 },
   { version: 25, name: "025_planning_requests", sql: planningRequests025 },
   { version: 26, name: "026_chat_plan_outbox", sql: chatPlanOutbox026 },
+  { version: 27, name: "027_plan_workout_additions", sql: planWorkoutAdditions027 },
 ];

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -212,6 +212,7 @@ describe("001_init migration", () => {
       { version: 24, name: "024_chat_attachments" },
       { version: 25, name: "025_planning_requests" },
       { version: 26, name: "026_chat_plan_outbox" },
+      { version: 27, name: "027_plan_workout_additions" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");


### PR DESCRIPTION
## Summary
- allow reviewed Proposals to add future coach-owned Workouts without bypassing Plan
- preserve immutable addition and Undo history while deleting only the undone Workout
- migrate existing adaptation history safely and keep additions out of auto-apply

## Verification
- root pnpm check
- full Vitest suite: 714 files passed, 5 skipped; 10,650 tests passed, 17 skipped
- isolated Codex autoreview: clean