### PR TITLE
feat(plan): bind chat requests to plan intake

### DIFF
--- a/.changeset/chat-plan-intake.md
+++ b/.changeset/chat-plan-intake.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/engine": patch
+"@enduragent/coach": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Workout handoffs from Chat now open the same reviewable Plan Proposal after retries or relaunch, while Draft and Plan-creation requests continue in their exact Plan conversation.
+
+Planning stores the destination artifact and request relation together, preserves date conflicts for review, and keeps delivery retryable when destination intake is temporarily unavailable.

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -189,7 +189,16 @@ import { createDocumentMediaAttachmentOperations } from "./document-media-attach
 import { createAttachmentComposerOperations } from "./attachment-composer-operations.js";
 import { createPlanningReadService } from "./planning-read-service.js";
 import { createPlanningRequestDeliveryService } from "./planning-request-delivery.js";
-import { createPlanningRequestRepository, createPlanRepository } from "@enduragent/kernel/planning";
+import {
+  createPlanConversationRepository,
+  createPlanningRequestIntakeRepository,
+  createPlanningRequestRepository,
+  createPlanRepository,
+} from "@enduragent/kernel/planning";
+import {
+  createPlanningRequestIntakeService,
+  createPlanningRequestPremiseReader,
+} from "./planning-request-intake.js";
 
 interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
@@ -1975,6 +1984,16 @@ export async function createLocalCoachComposition(
       input.context.store,
       analysisCrypto,
     );
+    const planConversationRepository = createPlanConversationRepository(input.context.store);
+    const planningRequestIntake = createPlanningRequestIntakeService({
+      requests: planningRequestRepository,
+      intake: createPlanningRequestIntakeRepository(input.context.store),
+      plans: planRepository,
+      conversations: planConversationRepository,
+      identity: planningIdentity,
+      workoutLimits,
+      todayDateKey: planningDateKey,
+    });
     const planningOperations = createPlanningOperations(
       {
         context: input.context,
@@ -1989,19 +2008,27 @@ export async function createLocalCoachComposition(
         workoutDriftCalendar: planCalendar,
         readiness,
         requests: planningRequestRepository,
+        proposalPremiseReader: createPlanningRequestPremiseReader(planningRequestRepository),
       },
     );
-    const planningRequestOperations = createPlanningRequestDeliveryService({
-      outbox: createChatPlanOutboxRepository(input.context.store, analysisCrypto),
-      requests: planningRequestRepository,
-      identity: planningIdentity,
-      async resolveTarget() {
-        const latest = await planRepository.readLatest();
-        if (latest?.status === "active") return "active_plan";
-        if (latest?.status === "draft") return "draft";
-        return "plan_creation";
+    const planningRequestOperations = createPlanningRequestDeliveryService(
+      {
+        outbox: createChatPlanOutboxRepository(input.context.store, analysisCrypto),
+        requests: planningRequestRepository,
+        identity: planningIdentity,
+        async resolveTarget() {
+          const latest = await planRepository.readLatest();
+          if (latest?.status === "active") return "active_plan";
+          if (latest?.status === "draft") return "draft";
+          return "plan_creation";
+        },
       },
-    });
+      {
+        afterPlanningAccepted: async (request) => {
+          await planningRequestIntake(request);
+        },
+      },
+    );
     const operations = {
       ...coachOperations,
       admitChatAttachment: async (request) => {

--- a/packages/coach/src/planning-request-delivery.ts
+++ b/packages/coach/src/planning-request-delivery.ts
@@ -129,7 +129,18 @@ export function createPlanningRequestDeliveryService(
       return project(input.requests, failed);
     }
 
-    await dependencies.afterPlanningAccepted?.(accepted);
+    try {
+      await dependencies.afterPlanningAccepted?.(accepted);
+    } catch (error) {
+      const failure = planningFailure(error);
+      const failed = await input.outbox.markFailed({
+        requestId: pending.requestId,
+        failureCode: failure.code,
+        retryable: failure.retryable,
+        failedAtMs: input.identity.hlcStamp().physicalMs,
+      });
+      return project(input.requests, failed);
+    }
     const delivered = await input.outbox.markDelivered({
       requestId: pending.requestId,
       deliveredAtMs: input.identity.hlcStamp().physicalMs,

--- a/packages/coach/src/planning-request-intake.ts
+++ b/packages/coach/src/planning-request-intake.ts
@@ -1,0 +1,341 @@
+import { canonicalJson } from "@enduragent/kernel/archive";
+import {
+  addCivilDays,
+  planWeekIndex,
+  type PlanConversationRecord,
+  type PlanConversationRepository,
+  type PlanProposalPremiseRecord,
+  type PlanProposalRecord,
+  type PlanRecord,
+  type PlanRepository,
+  type PlanningRequestIntakeRepository,
+  type PlanningRequestRecord,
+  type PlanningRequestRepository,
+} from "@enduragent/kernel/planning";
+import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+import {
+  capturePlanProposalBase,
+  encodePlanProposalBase,
+  encodePlanProposalMutation,
+  validatePlanProposal,
+  type PlanProposalPremiseReader,
+} from "@enduragent/engine";
+import {
+  parseNormalizedWorkoutSet,
+  type NormalizedWorkout,
+  type WorkoutParserLimits,
+} from "@enduragent/sport-cycling/workout-import";
+
+export interface PlanningRequestIntakeServiceInput {
+  readonly requests: PlanningRequestRepository;
+  readonly intake: PlanningRequestIntakeRepository;
+  readonly plans: PlanRepository;
+  readonly conversations: PlanConversationRepository;
+  readonly identity: AuthoredIdentity;
+  readonly workoutLimits: WorkoutParserLimits;
+  readonly todayDateKey: () => number;
+}
+
+function selectedWorkout(
+  record: PlanningRequestRecord,
+  limits: WorkoutParserLimits,
+): NormalizedWorkout | null {
+  const payload = record.sourceState.payload;
+  const snapshot = payload?.sourceSnapshot.selectedWorkout;
+  const attachment = payload?.sourceSnapshot.attachment;
+  if (
+    snapshot === null ||
+    snapshot === undefined ||
+    attachment === null ||
+    attachment === undefined
+  ) {
+    return null;
+  }
+  const set = parseNormalizedWorkoutSet(
+    {
+      schemaVersion: 1,
+      setId: snapshot.setId,
+      sourceFormat: attachment.extension,
+      parserVersion: "planning-request-snapshot",
+      selectedWorkoutId: snapshot.workoutId,
+      workouts: [snapshot.workout],
+      diagnostics: [],
+    },
+    limits,
+  );
+  const workout = set.workouts.find((candidate) => candidate.workoutId === snapshot.workoutId);
+  if (workout === undefined) throw new TypeError("The selected Workout snapshot is missing.");
+  return workout;
+}
+
+function chooseDate(input: {
+  readonly plan: PlanRecord;
+  readonly workouts: readonly { readonly dateKey: number }[];
+  readonly requestedDateKey: number | null;
+  readonly todayDateKey: number;
+}): {
+  readonly dateKey: number;
+  readonly attention: "needs_review" | "date_conflict";
+  readonly resolvedDateKey: number | null;
+} {
+  const occupied = new Set(input.workouts.map((workout) => workout.dateKey));
+  const requestedEligible =
+    input.requestedDateKey !== null &&
+    input.requestedDateKey > input.todayDateKey &&
+    planWeekIndex(input.plan, input.requestedDateKey).kind === "inside";
+  if (requestedEligible && input.requestedDateKey !== null) {
+    return occupied.has(input.requestedDateKey)
+      ? { dateKey: input.requestedDateKey, attention: "date_conflict", resolvedDateKey: null }
+      : {
+          dateKey: input.requestedDateKey,
+          attention: "needs_review",
+          resolvedDateKey: input.requestedDateKey,
+        };
+  }
+  let dateKey = input.plan.startDateKey;
+  if (dateKey <= input.todayDateKey) dateKey = addCivilDays(input.todayDateKey, 1);
+  while (planWeekIndex(input.plan, dateKey).kind === "inside") {
+    if (!occupied.has(dateKey)) {
+      return { dateKey, attention: "needs_review", resolvedDateKey: dateKey };
+    }
+    dateKey = addCivilDays(dateKey, 1);
+  }
+  throw new TypeError("The active Plan has no eligible date for this Workout.");
+}
+
+async function conversationFor(
+  input: PlanningRequestIntakeServiceInput,
+  record: PlanningRequestRecord,
+): Promise<{ readonly conversation: PlanConversationRecord; readonly create: boolean }> {
+  const latestPlan = await input.plans.readLatest();
+  if (
+    (record.request.target === "active_plan" && latestPlan?.status === "active") ||
+    (record.request.target === "draft" && latestPlan?.status === "draft")
+  ) {
+    const existing = await input.conversations.readConversationByPlanId(latestPlan.id);
+    if (existing !== undefined) {
+      if (existing.status !== "open") throw new TypeError("The Plan conversation has ended.");
+      return { conversation: existing, create: false };
+    }
+    const stamp = input.identity.hlcStamp();
+    return {
+      conversation: {
+        id: input.identity.newUlid(),
+        planId: latestPlan.id,
+        replacesPlanId: null,
+        courseChoiceStatus: "undecided",
+        raceCourseJson: null,
+        status: "open",
+        endedAtMs: null,
+        createdAtMs: stamp.physicalMs,
+        updatedAtMs: stamp.physicalMs,
+        deviceId: await input.identity.deviceId(),
+        hlcPhysicalMs: stamp.physicalMs,
+        hlcCounter: stamp.counter,
+      },
+      create: true,
+    };
+  }
+  const existing = await input.conversations.readLatestOpenConversation();
+  if (existing !== undefined && existing.planId === null && existing.replacesPlanId === null) {
+    return { conversation: existing, create: false };
+  }
+  const stamp = input.identity.hlcStamp();
+  return {
+    conversation: {
+      id: input.identity.newUlid(),
+      planId: null,
+      replacesPlanId: null,
+      courseChoiceStatus: "undecided",
+      raceCourseJson: null,
+      status: "open",
+      endedAtMs: null,
+      createdAtMs: stamp.physicalMs,
+      updatedAtMs: stamp.physicalMs,
+      deviceId: await input.identity.deviceId(),
+      hlcPhysicalMs: stamp.physicalMs,
+      hlcCounter: stamp.counter,
+    },
+    create: true,
+  };
+}
+
+async function bindConversation(
+  input: PlanningRequestIntakeServiceInput,
+  record: PlanningRequestRecord,
+): Promise<void> {
+  const payload = record.sourceState.payload;
+  if (payload === null) throw new TypeError("The Planning request source was compacted.");
+  const destination = await conversationFor(input, record);
+  const stamp = input.identity.hlcStamp();
+  const deviceId = await input.identity.deviceId();
+  await input.intake.accept({
+    requestId: record.request.requestId,
+    expectedRevision: record.request.revision,
+    destination: {
+      kind: "conversation",
+      conversation: destination.conversation,
+      createConversation: destination.create,
+      sourceRequest: {
+        id: input.identity.newUlid(),
+        conversationId: destination.conversation.id,
+        sourceChatId: payload.source.chatId,
+        sourceBoundaryRef: null,
+        sourceMessageId: payload.source.messageId,
+        requestJson: canonicalJson(payload),
+        createdAtMs: stamp.physicalMs,
+        updatedAtMs: stamp.physicalMs,
+        deviceId,
+        hlcPhysicalMs: stamp.physicalMs,
+        hlcCounter: stamp.counter,
+      },
+    },
+    updatedAtMs: stamp.physicalMs,
+    deviceId,
+    hlcPhysicalMs: stamp.physicalMs,
+    hlcCounter: stamp.counter,
+  });
+}
+
+async function bindProposal(
+  input: PlanningRequestIntakeServiceInput,
+  record: PlanningRequestRecord,
+  workout: NormalizedWorkout,
+): Promise<void> {
+  const payload = record.sourceState.payload;
+  const attachment = payload?.sourceSnapshot.attachment;
+  const workoutSnapshot = payload?.sourceSnapshot.selectedWorkout;
+  const plan = await input.plans.readLatest();
+  if (
+    payload === null ||
+    attachment === null ||
+    attachment === undefined ||
+    workoutSnapshot === null ||
+    workoutSnapshot === undefined ||
+    plan?.status !== "active"
+  ) {
+    throw new TypeError("The active Plan request is incomplete.");
+  }
+  const workouts = await input.plans.readWorkouts(plan.id);
+  const date = chooseDate({
+    plan,
+    workouts,
+    requestedDateKey: record.request.requestedDateKey,
+    todayDateKey: input.todayDateKey(),
+  });
+  const stamp = input.identity.hlcStamp();
+  const deviceId = await input.identity.deviceId();
+  const proposalId = input.identity.newUlid();
+  const proposal: PlanProposalRecord = {
+    id: proposalId,
+    planId: plan.id,
+    parentProposalId: null,
+    revision: 1,
+    status: "proposed",
+    title: `Add ${workout.title}`,
+    rationale: workout.purpose ?? payload.intent,
+    confidence: "Moderate",
+    mutationJson: encodePlanProposalMutation({
+      schemaVersion: 1,
+      changes: [
+        {
+          workoutId: input.identity.newUlid(),
+          before: null,
+          after: {
+            dateKey: date.dateKey,
+            sport: workout.sport,
+            name: workout.title,
+            durationS: workout.durationSeconds,
+            structureJson: canonicalJson({
+              schemaVersion: 1,
+              sourceFormat: attachment.extension,
+              setId: workoutSnapshot.setId,
+              workout,
+            }),
+          },
+        },
+      ],
+      weekLoad: null,
+    }),
+    baseSnapshotJson: encodePlanProposalBase(capturePlanProposalBase(plan, workouts)),
+    refusalReason: null,
+    createdAtMs: stamp.physicalMs,
+    updatedAtMs: stamp.physicalMs,
+    resolvedAtMs: null,
+    deviceId,
+    hlcPhysicalMs: stamp.physicalMs,
+    hlcCounter: stamp.counter,
+  };
+  const premise: PlanProposalPremiseRecord = {
+    id: input.identity.newUlid(),
+    proposalId,
+    sourceType: "planning_request",
+    sourceId: record.request.requestId,
+    sourceLabel: attachment.displayName,
+    sourceDateKey: record.request.requestedDateKey,
+    confidence: "Moderate",
+    snapshotJson: canonicalJson(payload),
+    createdAtMs: stamp.physicalMs,
+    deviceId,
+    hlcPhysicalMs: stamp.physicalMs,
+    hlcCounter: stamp.counter,
+  };
+  if (date.attention === "needs_review") {
+    validatePlanProposal({
+      proposal,
+      premises: [premise],
+      plan,
+      workouts,
+      todayDateKey: input.todayDateKey(),
+    });
+  }
+  await input.intake.accept({
+    requestId: record.request.requestId,
+    expectedRevision: record.request.revision,
+    destination: {
+      kind: "proposal",
+      proposal,
+      premises: [premise],
+      attention: date.attention,
+      resolvedDateKey: date.resolvedDateKey,
+    },
+    updatedAtMs: stamp.physicalMs,
+    deviceId,
+    hlcPhysicalMs: stamp.physicalMs,
+    hlcCounter: stamp.counter,
+  });
+}
+
+export function createPlanningRequestIntakeService(input: PlanningRequestIntakeServiceInput) {
+  return async (record: PlanningRequestRecord): Promise<PlanningRequestRecord> => {
+    if (
+      record.request.lifecycle !== "open" ||
+      record.request.planConversationId !== null ||
+      record.request.proposalId !== null
+    ) {
+      return record;
+    }
+    const workout = selectedWorkout(record, input.workoutLimits);
+    if (record.request.target === "active_plan" && workout !== null) {
+      await bindProposal(input, record, workout);
+    } else {
+      await bindConversation(input, record);
+    }
+    const accepted = await input.requests.read(record.request.requestId);
+    if (accepted === undefined) throw new TypeError("The Planning request intake was not stored.");
+    return accepted;
+  };
+}
+
+export function createPlanningRequestPremiseReader(
+  requests: PlanningRequestRepository,
+): PlanProposalPremiseReader {
+  return {
+    async read(source) {
+      if (source.sourceType !== "planning_request") return null;
+      const record = await requests.read(source.sourceId);
+      const payload = record?.sourceState.payload;
+      return payload === null || payload === undefined ? null : canonicalJson(payload);
+    },
+  };
+}

--- a/packages/coach/tests/planning-request-delivery.test.ts
+++ b/packages/coach/tests/planning-request-delivery.test.ts
@@ -137,26 +137,37 @@ describe("Planning request delivery", () => {
   });
 
   it("retries the same request after Planning accepted before Chat acknowledged", async () => {
-    await expect(
-      service(() => {
-        throw new Error("synthetic process interruption");
-      }).createPlanningRequest!({ payload: requestPayload() }),
-    ).rejects.toThrow("synthetic process interruption");
+    const interrupted = await service(() => {
+      throw new Error("synthetic process interruption");
+    }).createPlanningRequest!({ payload: requestPayload() });
+    expect(interrupted).toMatchObject({
+      status: "accepted",
+      delivery: {
+        state: "failed",
+        attemptCount: 1,
+        failureCode: "planning_unavailable",
+        retryable: true,
+      },
+    });
 
     const before = await service().getPlanningRequest!({ requestId: "request-1" });
     expect(before).toMatchObject({
       status: "found",
-      delivery: { state: "pending", attemptCount: 1, planningRequest: { requestId: "request-1" } },
+      delivery: { state: "failed", attemptCount: 1, planningRequest: { requestId: "request-1" } },
     });
 
     const retried = await service().retryPlanningRequest!({ requestId: "request-1" });
     expect(retried).toMatchObject({
       status: "found",
-      delivery: { state: "delivered", attemptCount: 2, planningRequest: { requestId: "request-1" } },
+      delivery: {
+        state: "delivered",
+        attemptCount: 2,
+        planningRequest: { requestId: "request-1" },
+      },
     });
-    expect(await createPlanningRequestRepository(store, createNodeCrypto()).readOpen()).toHaveLength(
-      1,
-    );
+    expect(
+      await createPlanningRequestRepository(store, createNodeCrypto()).readOpen(),
+    ).toHaveLength(1);
   });
 
   it("resumes persisted pending delivery and rejects conflicting reuse", async () => {

--- a/packages/coach/tests/planning-request-intake.test.ts
+++ b/packages/coach/tests/planning-request-intake.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parsePlanProposalMutation } from "@enduragent/engine";
+import {
+  createPlanConversationRepository,
+  createPlanningRequestIntakeRepository,
+  createPlanningRequestRepository,
+  createPlanProposalRepository,
+  createPlanRepository,
+  type CreatePlanningRequestPayload,
+  type PlanConversationRecord,
+  type PlanRecord,
+  type PlanWorkoutRecord,
+  type PlanningRequestTarget,
+} from "@enduragent/kernel/planning";
+import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createNodeCrypto } from "@enduragent/kernel-node/ingest";
+import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import {
+  createPlanningRequestIntakeService,
+  createPlanningRequestPremiseReader,
+} from "../src/planning-request-intake.js";
+
+const PLAN_ID = "01J60HFQ7T0000000000000000";
+const CONVERSATION_ID = "01J60HFQ7T0000000000000001";
+const WORKOUT_ID = "01J60HFQ7T0000000000000002";
+
+const workoutLimits = {
+  candidates: 8,
+  segmentsPerWorkout: 128,
+  durationSeconds: 86_400,
+  diagnostics: 32,
+  diagnosticChars: 1_000,
+  titleChars: 512,
+  purposeChars: 2_000,
+} as const;
+
+function payload(requestId = "request-1"): CreatePlanningRequestPayload {
+  return {
+    requestId,
+    kind: "workout_review",
+    intent: "Review this Workout before I add it to my Plan.",
+    source: {
+      chatId: "chat-1",
+      messageId: `message-${requestId}`,
+      attachmentId: "attachment-1",
+    },
+    sourceSnapshot: {
+      capturedAt: "1998-08-24T08:00:00.000Z",
+      attachment: {
+        attachmentId: "attachment-1",
+        displayName: "tempo-3x12.mrc",
+        extension: "mrc",
+      },
+      selectedWorkout: {
+        setId: "set-1",
+        workoutId: "workout-1",
+        workout: {
+          workoutId: "workout-1",
+          title: "Tempo 3 × 12",
+          sport: "cycling",
+          durationSeconds: 3_840,
+          purpose: "Build sustainable power.",
+          segments: [
+            {
+              segmentId: "segment-1",
+              kind: "steady",
+              seconds: 3_840,
+              power: { kind: "ftp_percent_range", low: 88, high: 92 },
+            },
+          ],
+        },
+      },
+    },
+    requestedDate: "1998-08-26",
+  };
+}
+
+function plan(status: PlanRecord["status"]): PlanRecord {
+  return {
+    id: PLAN_ID,
+    originId: null,
+    name: "Autumn base",
+    primaryGoal: "Build consistency",
+    startDateKey: 19980824,
+    targetDateKey: null,
+    status,
+    kind: "full_plan",
+    totalWeeks: 12,
+    weekStartDay: 1,
+    structureJson: "{}",
+    createdAtMs: 1,
+    updatedAtMs: 10,
+    deviceId: "device-1",
+    hlcPhysicalMs: 10,
+    hlcCounter: 0,
+  };
+}
+
+function planWorkout(dateKey: number): PlanWorkoutRecord {
+  return {
+    id: WORKOUT_ID,
+    planId: PLAN_ID,
+    dateKey,
+    sport: "cycling",
+    name: "Easy endurance",
+    durationS: 3_000,
+    structureJson: "{}",
+    origin: "coach",
+    deviceId: "device-1",
+    hlcPhysicalMs: 10,
+    hlcCounter: 0,
+  };
+}
+
+function conversation(planId: string): PlanConversationRecord {
+  return {
+    id: CONVERSATION_ID,
+    planId,
+    replacesPlanId: null,
+    courseChoiceStatus: "undecided",
+    raceCourseJson: null,
+    status: "open",
+    endedAtMs: null,
+    createdAtMs: 20,
+    updatedAtMs: 20,
+    deviceId: "device-1",
+    hlcPhysicalMs: 20,
+    hlcCounter: 0,
+  };
+}
+
+describe("Planning request intake", () => {
+  let store: SqlStore & MigratorStore;
+  let identity: AuthoredIdentity;
+  let instant: number;
+  let idCounter: number;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    instant = 100;
+    idCounter = 10;
+    identity = {
+      deviceId: async () => "device-1",
+      newUlid: () => {
+        const suffix = String(idCounter++).padStart(2, "0");
+        return `${PLAN_ID.slice(0, -2)}${suffix}`;
+      },
+      hlcStamp: () => ({ physicalMs: instant++, counter: 0 }),
+    };
+  });
+
+  afterEach(async () => store.close());
+
+  const setup = async (
+    target: PlanningRequestTarget,
+    planStatus?: PlanRecord["status"],
+    workouts: readonly PlanWorkoutRecord[] = [],
+    requestPayload: CreatePlanningRequestPayload = payload(),
+  ) => {
+    const plans = createPlanRepository(store);
+    const conversations = createPlanConversationRepository(store);
+    const requests = createPlanningRequestRepository(store, createNodeCrypto());
+    if (planStatus !== undefined) await plans.replace(plan(planStatus), workouts);
+    const record = await requests.createOrGet({
+      payload: requestPayload,
+      target,
+      createdAtMs: 50,
+      deviceId: "device-1",
+      hlcPhysicalMs: 50,
+      hlcCounter: 0,
+    });
+    const accept = createPlanningRequestIntakeService({
+      requests,
+      intake: createPlanningRequestIntakeRepository(store),
+      plans,
+      conversations,
+      identity,
+      workoutLimits,
+      todayDateKey: () => 19980824,
+    });
+    return { plans, conversations, requests, record, accept };
+  };
+
+  it("creates one reviewable addition Proposal and reopens it without duplication", async () => {
+    const context = await setup("active_plan", "active");
+    const accepted = await context.accept(context.record);
+
+    expect(accepted.request).toMatchObject({
+      proposalId: expect.any(String),
+      planConversationId: null,
+      attention: "needs_review",
+      resolvedDateKey: 19980826,
+      revision: 2,
+    });
+    const proposals = createPlanProposalRepository(store);
+    const proposal = await proposals.read(accepted.request.proposalId!);
+    expect(proposal).toMatchObject({
+      planId: PLAN_ID,
+      status: "proposed",
+      title: "Add Tempo 3 × 12",
+    });
+    expect(parsePlanProposalMutation(proposal!.mutationJson).changes[0]).toMatchObject({
+      before: null,
+      after: { dateKey: 19980826, name: "Tempo 3 × 12", durationS: 3_840 },
+    });
+    const premises = await proposals.readPremises(proposal!.id);
+    expect(premises).toHaveLength(1);
+    expect(premises[0]).toMatchObject({
+      sourceType: "planning_request",
+      sourceId: "request-1",
+      sourceLabel: "tempo-3x12.mrc",
+    });
+    await expect(
+      createPlanningRequestPremiseReader(context.requests).read({
+        sourceType: "planning_request",
+        sourceId: "request-1",
+      }),
+    ).resolves.toBe(premises[0]!.snapshotJson);
+
+    await expect(context.accept(accepted)).resolves.toEqual(accepted);
+    await expect(proposals.readOpenForPlan(PLAN_ID)).resolves.toHaveLength(1);
+  });
+
+  it("records an occupied requested date as a conflict without mutating Plan", async () => {
+    const context = await setup("active_plan", "active", [planWorkout(19980826)]);
+    const accepted = await context.accept(context.record);
+
+    expect(accepted.request).toMatchObject({
+      proposalId: expect.any(String),
+      attention: "date_conflict",
+      requestedDateKey: 19980826,
+      resolvedDateKey: null,
+    });
+    expect(await context.plans.readWorkouts(PLAN_ID)).toEqual([planWorkout(19980826)]);
+  });
+
+  it("binds a Draft request to its exact open Plan conversation", async () => {
+    const context = await setup("draft", "draft");
+    await context.conversations.saveConversation(conversation(PLAN_ID));
+    const accepted = await context.accept(context.record);
+
+    expect(accepted.request).toMatchObject({
+      planConversationId: CONVERSATION_ID,
+      proposalId: null,
+      attention: "none",
+      revision: 2,
+    });
+    const source = await context.conversations.readSourceRequests(CONVERSATION_ID);
+    expect(source).toHaveLength(1);
+    expect(source[0]).toMatchObject({
+      sourceChatId: "chat-1",
+      sourceMessageId: "message-request-1",
+    });
+  });
+
+  it("binds an active Plan question to its conversation without inventing a Proposal", async () => {
+    const question: CreatePlanningRequestPayload = {
+      requestId: "request-question",
+      kind: "plan_question",
+      intent: "How does this Workout support my current phase?",
+      source: { chatId: "chat-1", messageId: "message-question" },
+      sourceSnapshot: {
+        capturedAt: "1998-08-24T08:00:00.000Z",
+        attachment: null,
+        selectedWorkout: null,
+      },
+    };
+    const context = await setup("active_plan", "active", [planWorkout(19980825)], question);
+    await context.conversations.saveConversation(conversation(PLAN_ID));
+    const accepted = await context.accept(context.record);
+
+    expect(accepted.request).toMatchObject({
+      planConversationId: CONVERSATION_ID,
+      proposalId: null,
+      attention: "none",
+    });
+  });
+
+  it("creates one Plan-creation conversation with the selected Workout as source context", async () => {
+    const context = await setup("plan_creation");
+    const accepted = await context.accept(context.record);
+
+    expect(accepted.request).toMatchObject({
+      planConversationId: expect.any(String),
+      proposalId: null,
+      attention: "none",
+      revision: 2,
+    });
+    const conversationRecord = await context.conversations.readConversation(
+      accepted.request.planConversationId!,
+    );
+    expect(conversationRecord).toMatchObject({ planId: null, status: "open" });
+    await expect(
+      context.conversations.readSourceRequests(accepted.request.planConversationId!),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("leaves the request unbound when destination persistence rolls back", async () => {
+    const context = await setup("draft", "draft");
+    await context.conversations.saveConversation(conversation(PLAN_ID));
+    await context.conversations.createOrGetSourceRequest({
+      id: `${PLAN_ID.slice(0, -2)}10`,
+      conversationId: CONVERSATION_ID,
+      sourceChatId: "another-chat",
+      sourceBoundaryRef: null,
+      sourceMessageId: "another-message",
+      requestJson: "{}",
+      createdAtMs: 30,
+      updatedAtMs: 30,
+      deviceId: "device-1",
+      hlcPhysicalMs: 30,
+      hlcCounter: 0,
+    });
+
+    await expect(context.accept(context.record)).rejects.toThrow();
+    await expect(context.requests.read("request-1")).resolves.toMatchObject({
+      request: { planConversationId: null, proposalId: null, revision: 1 },
+    });
+    await expect(context.conversations.readSourceRequests(CONVERSATION_ID)).resolves.toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/engine/src/planning/proposal.ts
+++ b/packages/engine/src/planning/proposal.ts
@@ -227,8 +227,7 @@ function parseBase(value: string): PlanProposalBaseSnapshot {
     Number(parsed.planHlcPhysicalMs) < 0 ||
     !Number.isSafeInteger(parsed.planHlcCounter) ||
     Number(parsed.planHlcCounter) < 0 ||
-    !Array.isArray(parsed.workouts) ||
-    parsed.workouts.length === 0
+    !Array.isArray(parsed.workouts)
   ) {
     throw new PlanProposalError("invalid-base");
   }

--- a/packages/kernel/src/planning/conversation-repository.ts
+++ b/packages/kernel/src/planning/conversation-repository.ts
@@ -162,7 +162,7 @@ function validHlc(record: {
   );
 }
 
-function validateConversation(record: PlanConversationRecord): void {
+export function validatePlanConversationRecord(record: PlanConversationRecord): void {
   const endedAtMs = record.endedAtMs;
   if (!ULID.test(record.id)) throw new PlanConversationValidationError("invalid-id");
   if (record.planId !== null && !ULID.test(record.planId)) {
@@ -261,7 +261,7 @@ function validRaceCourseJson(value: string | null): boolean {
   }
 }
 
-function validateSourceRequest(record: PlanSourceRequestRecord): void {
+export function validatePlanSourceRequestRecord(record: PlanSourceRequestRecord): void {
   if (
     !ULID.test(record.id) ||
     !ULID.test(record.conversationId) ||
@@ -326,7 +326,7 @@ function conversationFromRow(row: Row): PlanConversationRecord {
     hlcPhysicalMs: integer(row, "hlc_physical_ms"),
     hlcCounter: integer(row, "hlc_counter"),
   });
-  validateConversation(record);
+  validatePlanConversationRecord(record);
   return record;
 }
 
@@ -381,7 +381,7 @@ function sourceRequestFromRow(row: Row): PlanSourceRequestRecord {
     hlcPhysicalMs: integer(row, "hlc_physical_ms"),
     hlcCounter: integer(row, "hlc_counter"),
   });
-  validateSourceRequest(record);
+  validatePlanSourceRequestRecord(record);
   return record;
 }
 
@@ -417,7 +417,7 @@ export function createPlanConversationRepository(store: PlanningStore): PlanConv
 
   return {
     async saveConversation(record) {
-      validateConversation(record);
+      validatePlanConversationRecord(record);
       await store.transaction(async () => {
         const existing = await readConversation(record.id);
         if (existing !== undefined) {
@@ -715,7 +715,7 @@ ON CONFLICT (id) DO UPDATE SET
     },
 
     async createOrGetSourceRequest(record) {
-      validateSourceRequest(record);
+      validatePlanSourceRequestRecord(record);
       return store.transaction(async () => {
         await requireOpenConversation(record.conversationId);
         const existing = await readSourceRequest(record.id);
@@ -749,7 +749,7 @@ ON CONFLICT (id) DO UPDATE SET
     },
 
     async bindSourceBoundary(record) {
-      validateSourceRequest(record);
+      validatePlanSourceRequestRecord(record);
       if (record.sourceBoundaryRef === null) {
         throw new PlanConversationValidationError("invalid-source-request");
       }

--- a/packages/kernel/src/planning/index.ts
+++ b/packages/kernel/src/planning/index.ts
@@ -13,3 +13,4 @@ export * from "./settings-repository.js";
 export * from "./weekly-review-repository.js";
 export * from "./race-outcome-repository.js";
 export * from "./request-repository.js";
+export * from "./request-intake-repository.js";

--- a/packages/kernel/src/planning/proposal-repository.ts
+++ b/packages/kernel/src/planning/proposal-repository.ts
@@ -154,7 +154,7 @@ function nullableInteger(row: Row, key: string): number | null {
   return value;
 }
 
-function validateProposal(record: PlanProposalRecord): void {
+export function validatePlanProposalRecord(record: PlanProposalRecord): void {
   const resolved = record.status !== "proposed";
   if (
     !ULID.test(record.id) ||
@@ -187,7 +187,7 @@ function validateProposal(record: PlanProposalRecord): void {
   }
 }
 
-function validatePremise(record: PlanProposalPremiseRecord): void {
+export function validatePlanProposalPremiseRecord(record: PlanProposalPremiseRecord): void {
   if (
     !ULID.test(record.id) ||
     !ULID.test(record.proposalId) ||
@@ -229,7 +229,7 @@ function proposalFromRow(row: Row): PlanProposalRecord {
     hlcPhysicalMs: integer(row, "hlc_physical_ms"),
     hlcCounter: integer(row, "hlc_counter"),
   };
-  validateProposal(record);
+  validatePlanProposalRecord(record);
   return Object.freeze(record);
 }
 
@@ -248,7 +248,7 @@ function premiseFromRow(row: Row): PlanProposalPremiseRecord {
     hlcPhysicalMs: integer(row, "hlc_physical_ms"),
     hlcCounter: integer(row, "hlc_counter"),
   };
-  validatePremise(record);
+  validatePlanProposalPremiseRecord(record);
   return Object.freeze(record);
 }
 
@@ -269,12 +269,12 @@ export function createPlanProposalRepository(store: ProposalStore): PlanProposal
 
   const repository: PlanProposalRepository = Object.freeze({
     async save(proposal: PlanProposalRecord, premises: readonly PlanProposalPremiseRecord[]) {
-      validateProposal(proposal);
+      validatePlanProposalRecord(proposal);
       if (proposal.status !== "proposed" || premises.length === 0) {
         throw new PlanProposalValidationError("invalid-proposal");
       }
       for (const premise of premises) {
-        validatePremise(premise);
+        validatePlanProposalPremiseRecord(premise);
         if (premise.proposalId !== proposal.id) {
           throw new PlanProposalValidationError("invalid-premise");
         }

--- a/packages/kernel/src/planning/request-intake-repository.ts
+++ b/packages/kernel/src/planning/request-intake-repository.ts
@@ -1,0 +1,269 @@
+import type { MigratorStore } from "../store/migrator.js";
+import type { SqlStore } from "../store/ports.js";
+import {
+  validatePlanConversationRecord,
+  validatePlanSourceRequestRecord,
+  type PlanConversationRecord,
+  type PlanSourceRequestRecord,
+} from "./conversation-repository.js";
+import {
+  validatePlanProposalPremiseRecord,
+  validatePlanProposalRecord,
+  type PlanProposalPremiseRecord,
+  type PlanProposalRecord,
+} from "./proposal-repository.js";
+import type { PlanningRequestAttention } from "./request-repository.js";
+
+export type PlanningRequestIntakeDestination =
+  | {
+      readonly kind: "conversation";
+      readonly conversation: PlanConversationRecord;
+      readonly createConversation: boolean;
+      readonly sourceRequest: PlanSourceRequestRecord;
+    }
+  | {
+      readonly kind: "proposal";
+      readonly proposal: PlanProposalRecord;
+      readonly premises: readonly PlanProposalPremiseRecord[];
+      readonly attention: Extract<PlanningRequestAttention, "needs_review" | "date_conflict">;
+      readonly resolvedDateKey: number | null;
+    };
+
+export interface AcceptPlanningRequestIntakeInput {
+  readonly requestId: string;
+  readonly expectedRevision: number;
+  readonly destination: PlanningRequestIntakeDestination;
+  readonly updatedAtMs: number;
+  readonly deviceId: string;
+  readonly hlcPhysicalMs: number;
+  readonly hlcCounter: number;
+}
+
+export class PlanningRequestIntakeStoreError extends Error {
+  readonly code: "invalid-intake" | "missing-request" | "stale-request" | "intake-conflict";
+
+  constructor(code: PlanningRequestIntakeStoreError["code"]) {
+    super(`planning request intake rejected: ${code}`);
+    this.name = "PlanningRequestIntakeStoreError";
+    this.code = code;
+  }
+}
+
+export interface PlanningRequestIntakeRepository {
+  accept(input: AcceptPlanningRequestIntakeInput): Promise<void>;
+}
+
+type IntakeStore = SqlStore & Pick<MigratorStore, "transaction">;
+
+const DEVICE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u;
+
+function validClock(input: AcceptPlanningRequestIntakeInput): boolean {
+  return (
+    input.requestId.length > 0 &&
+    Number.isSafeInteger(input.expectedRevision) &&
+    input.expectedRevision > 0 &&
+    Number.isSafeInteger(input.updatedAtMs) &&
+    input.updatedAtMs >= 0 &&
+    DEVICE_ID.test(input.deviceId) &&
+    Number.isSafeInteger(input.hlcPhysicalMs) &&
+    input.hlcPhysicalMs >= 0 &&
+    Number.isSafeInteger(input.hlcCounter) &&
+    input.hlcCounter >= 0
+  );
+}
+
+export function createPlanningRequestIntakeRepository(
+  store: IntakeStore,
+): PlanningRequestIntakeRepository {
+  return Object.freeze({
+    async accept(input: AcceptPlanningRequestIntakeInput) {
+      if (!validClock(input)) throw new PlanningRequestIntakeStoreError("invalid-intake");
+      if (input.destination.kind === "conversation") {
+        validatePlanConversationRecord(input.destination.conversation);
+        validatePlanSourceRequestRecord(input.destination.sourceRequest);
+        if (
+          input.destination.conversation.status !== "open" ||
+          input.destination.sourceRequest.conversationId !== input.destination.conversation.id
+        ) {
+          throw new PlanningRequestIntakeStoreError("invalid-intake");
+        }
+      } else {
+        validatePlanProposalRecord(input.destination.proposal);
+        if (
+          input.destination.proposal.status !== "proposed" ||
+          input.destination.premises.length === 0
+        ) {
+          throw new PlanningRequestIntakeStoreError("invalid-intake");
+        }
+        for (const premise of input.destination.premises) {
+          validatePlanProposalPremiseRecord(premise);
+          if (premise.proposalId !== input.destination.proposal.id) {
+            throw new PlanningRequestIntakeStoreError("invalid-intake");
+          }
+        }
+      }
+
+      await store.transaction(async () => {
+        const current = await store.get(
+          `SELECT lifecycle,revision,updated_at_ms,plan_conversation_id,proposal_id
+FROM planning_request WHERE request_id=?`,
+          [input.requestId],
+        );
+        if (current === undefined) throw new PlanningRequestIntakeStoreError("missing-request");
+        if (
+          current.lifecycle !== "open" ||
+          current.revision !== input.expectedRevision ||
+          typeof current.updated_at_ms !== "number" ||
+          current.updated_at_ms > input.updatedAtMs
+        ) {
+          throw new PlanningRequestIntakeStoreError("stale-request");
+        }
+        if (current.plan_conversation_id !== null || current.proposal_id !== null) {
+          throw new PlanningRequestIntakeStoreError("intake-conflict");
+        }
+
+        if (input.destination.kind === "conversation") {
+          const { conversation, sourceRequest } = input.destination;
+          const existing = await store.get(
+            "SELECT plan_id,replaces_plan_id,status FROM plan_conversation WHERE id=?",
+            [conversation.id],
+          );
+          if (input.destination.createConversation) {
+            if (existing !== undefined) {
+              throw new PlanningRequestIntakeStoreError("intake-conflict");
+            }
+            await store.run(
+              `INSERT INTO plan_conversation (
+  id,plan_id,replaces_plan_id,course_choice_status,race_course_json,status,ended_at_ms,
+  created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+              [
+                conversation.id,
+                conversation.planId,
+                conversation.replacesPlanId,
+                conversation.courseChoiceStatus,
+                conversation.raceCourseJson,
+                conversation.status,
+                conversation.endedAtMs,
+                conversation.createdAtMs,
+                conversation.updatedAtMs,
+                conversation.deviceId,
+                conversation.hlcPhysicalMs,
+                conversation.hlcCounter,
+              ],
+            );
+          } else if (
+            existing === undefined ||
+            existing.plan_id !== conversation.planId ||
+            existing.replaces_plan_id !== conversation.replacesPlanId ||
+            existing.status !== "open"
+          ) {
+            throw new PlanningRequestIntakeStoreError("intake-conflict");
+          }
+          await store.run(
+            `INSERT INTO plan_source_request (
+  id,conversation_id,source_chat_id,source_boundary_ref,source_message_id,request_json,
+  created_at_ms,updated_at_ms,device_id,hlc_physical_ms,hlc_counter
+) VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+            [
+              sourceRequest.id,
+              sourceRequest.conversationId,
+              sourceRequest.sourceChatId,
+              sourceRequest.sourceBoundaryRef,
+              sourceRequest.sourceMessageId,
+              sourceRequest.requestJson,
+              sourceRequest.createdAtMs,
+              sourceRequest.updatedAtMs,
+              sourceRequest.deviceId,
+              sourceRequest.hlcPhysicalMs,
+              sourceRequest.hlcCounter,
+            ],
+          );
+          await store.run(
+            `UPDATE planning_request SET
+  plan_conversation_id=?,revision=revision+1,updated_at_ms=?,device_id=?,
+  hlc_physical_ms=?,hlc_counter=?
+WHERE request_id=? AND lifecycle='open' AND revision=?`,
+            [
+              conversation.id,
+              input.updatedAtMs,
+              input.deviceId,
+              input.hlcPhysicalMs,
+              input.hlcCounter,
+              input.requestId,
+              input.expectedRevision,
+            ],
+          );
+          return;
+        }
+
+        const { proposal, premises } = input.destination;
+        await store.run(
+          `INSERT INTO plan_proposal (
+  id,plan_id,parent_proposal_id,revision,status,title,rationale,confidence,mutation_json,
+  base_snapshot_json,refusal_reason,created_at_ms,updated_at_ms,resolved_at_ms,device_id,
+  hlc_physical_ms,hlc_counter
+) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+          [
+            proposal.id,
+            proposal.planId,
+            proposal.parentProposalId,
+            proposal.revision,
+            proposal.status,
+            proposal.title,
+            proposal.rationale,
+            proposal.confidence,
+            proposal.mutationJson,
+            proposal.baseSnapshotJson,
+            proposal.refusalReason,
+            proposal.createdAtMs,
+            proposal.updatedAtMs,
+            proposal.resolvedAtMs,
+            proposal.deviceId,
+            proposal.hlcPhysicalMs,
+            proposal.hlcCounter,
+          ],
+        );
+        for (const premise of premises) {
+          await store.run(
+            `INSERT INTO plan_proposal_premise (
+  id,proposal_id,source_type,source_id,source_label,source_date_key,confidence,
+  snapshot_json,created_at_ms,device_id,hlc_physical_ms,hlc_counter
+) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+            [
+              premise.id,
+              premise.proposalId,
+              premise.sourceType,
+              premise.sourceId,
+              premise.sourceLabel,
+              premise.sourceDateKey,
+              premise.confidence,
+              premise.snapshotJson,
+              premise.createdAtMs,
+              premise.deviceId,
+              premise.hlcPhysicalMs,
+              premise.hlcCounter,
+            ],
+          );
+        }
+        await store.run(
+          `UPDATE planning_request SET
+  proposal_id=?,attention=?,resolved_date_key=?,revision=revision+1,updated_at_ms=?,device_id=?,
+  hlc_physical_ms=?,hlc_counter=?
+WHERE request_id=? AND lifecycle='open' AND revision=?`,
+          [
+            proposal.id,
+            input.destination.attention,
+            input.destination.resolvedDateKey,
+            input.updatedAtMs,
+            input.deviceId,
+            input.hlcPhysicalMs,
+            input.hlcCounter,
+            input.requestId,
+            input.expectedRevision,
+          ],
+        );
+      });
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- atomically bind accepted Chat planning requests to one durable Plan destination
- create reviewable workout-addition Proposals while routing Draft, creation, and general Plan requests into exact Plan conversations
- preserve retryability, date-conflict review, and idempotent relaunch behavior

## Verification
- focused Planning intake and delivery tests: 22 passed
- root pnpm check
- full suite: 715 files passed, 5 skipped; 10,656 tests passed, 17 skipped
- autoreview: clean, no accepted/actionable findings