### PR TITLE
feat(plan): commit chat request results atomically

### DIFF
--- a/.changeset/chat-plan-terminal-atomic.md
+++ b/.changeset/chat-plan-terminal-atomic.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/engine": patch
+"@enduragent/coach": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Applying or rejecting a Chat-originated Plan Proposal now records the matching Chat result atomically, so relaunch cannot show a stale or contradictory handoff.
+
+Planning keeps revised Proposals attached to their originating request, rolls back the complete Plan change when terminal-result storage fails, and leaves calendar mirroring separate from local success.

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -136,6 +136,7 @@ import {
   type PlanProposalPremiseRecord,
   type PlanProposalRepository,
   type PlanningRequestReadModel,
+  type PlanningRequestRecord,
   type PlanningRequestRepository,
   type PlanAdaptationLedgerRecord,
   type PlanAdaptationLedgerRepository,
@@ -406,6 +407,28 @@ function createSerializedLane(): <T>(operation: () => Promise<T>) => Promise<T> 
 
 function snapshot(value: string): unknown {
   return JSON.parse(value) as unknown;
+}
+
+function planningRequestWorkout(record: PlanningRequestRecord): {
+  readonly name: string;
+  readonly workoutRef: { readonly setId: string; readonly workoutId: string } | null;
+} {
+  const selected = record.sourceState.payload?.sourceSnapshot.selectedWorkout;
+  if (selected !== null && selected !== undefined) {
+    const name = selected.workout.title ?? selected.workout.name;
+    return {
+      name: typeof name === "string" && name.length > 0 ? name : "Workout",
+      workoutRef: { setId: selected.setId, workoutId: selected.workoutId },
+    };
+  }
+  const workout = record.sourceState.provenance?.workout;
+  return {
+    name: workout?.name ?? "Plan change",
+    workoutRef:
+      workout === null || workout === undefined
+        ? null
+        : { setId: workout.setId, workoutId: workout.workoutId },
+  };
 }
 
 function dateText(dateKey: number): string {
@@ -1067,6 +1090,9 @@ export function createPlanningOperations(
     reason = PROPOSAL_INVALID.message,
   ): Promise<void> => {
     const stamp = input.identity.hlcStamp();
+    const linkedRequest = await planningRequests?.readByProposalId(proposal.id);
+    const requestWorkout =
+      linkedRequest === undefined ? null : planningRequestWorkout(linkedRequest);
     await proposalRepository.resolve({
       id: proposal.id,
       status: "refused",
@@ -1075,6 +1101,29 @@ export function createPlanningOperations(
       deviceId: await input.identity.deviceId(),
       hlcPhysicalMs: stamp.physicalMs,
       hlcCounter: stamp.counter,
+      ...(linkedRequest === undefined
+        ? {}
+        : {
+            requestCompletion: {
+              requestId: linkedRequest.request.requestId,
+              expectedRevision: linkedRequest.request.revision,
+              expectedProposalId: proposal.id,
+              result: {
+                kind: "ended" as const,
+                resultId: input.identity.newUlid(),
+                completedAtMs: stamp.physicalMs,
+                title: "Proposal ended",
+                detail: `${requestWorkout!.name} was not applied; the active Plan remains unchanged.`,
+                workoutRef: requestWorkout!.workoutRef,
+                planRevisionId: null,
+              },
+              resolvedDateKey: linkedRequest.request.resolvedDateKey,
+              updatedAtMs: stamp.physicalMs,
+              deviceId: await input.identity.deviceId(),
+              hlcPhysicalMs: stamp.physicalMs,
+              hlcCounter: stamp.counter,
+            },
+          }),
     });
   };
   const parseProposalMutationOrRefuse = async (
@@ -1808,7 +1857,23 @@ export function createPlanningOperations(
       todayDateKey: dependencies.todayDateKey?.() ?? utcTodayDateKey(),
       calculateWeekLoad: dependencies.proposalLoadCalculator,
     });
-    return proposalRepository.save(next, premiseRecords);
+    const linkedRequest = await planningRequests?.readByProposalId(inputValue.current.id);
+    return proposalRepository.save(
+      next,
+      premiseRecords,
+      linkedRequest === undefined
+        ? undefined
+        : {
+            requestId: linkedRequest.request.requestId,
+            expectedRevision: linkedRequest.request.revision,
+            previousProposalId: inputValue.current.id,
+            proposalId: next.id,
+            updatedAtMs: timestamp,
+            deviceId,
+            hlcPhysicalMs: stamp.physicalMs,
+            hlcCounter: stamp.counter,
+          },
+    );
   };
 
   const reject = async (
@@ -2914,6 +2979,13 @@ export function createPlanningOperations(
                   throw new PlanProposalError("stale-base");
                 }
                 const stamp = input.identity.hlcStamp();
+                const linkedRequest = await planningRequests?.readByProposalId(proposal.id);
+                const requestWorkout =
+                  linkedRequest === undefined ? null : planningRequestWorkout(linkedRequest);
+                const appliedDateKey =
+                  linkedRequest?.request.resolvedDateKey ??
+                  current.changes[0]?.next.dateKey ??
+                  null;
                 await applyValidatedPlanProposal(current, {
                   repository: proposalRepository,
                   plan,
@@ -2922,6 +2994,32 @@ export function createPlanningOperations(
                   deviceId: await input.identity.deviceId(),
                   hlcPhysicalMs: stamp.physicalMs,
                   hlcCounter: stamp.counter,
+                  ...(linkedRequest === undefined
+                    ? {}
+                    : {
+                        requestCompletion: {
+                          requestId: linkedRequest.request.requestId,
+                          expectedRevision: linkedRequest.request.revision,
+                          expectedProposalId: proposal.id,
+                          result: {
+                            kind: "applied" as const,
+                            resultId: input.identity.newUlid(),
+                            completedAtMs: stamp.physicalMs,
+                            title: "Added to Plan",
+                            detail:
+                              appliedDateKey === null
+                                ? `${requestWorkout!.name} was added to the active Plan.`
+                                : `${requestWorkout!.name} is scheduled for ${dateText(appliedDateKey)}.`,
+                            workoutRef: requestWorkout!.workoutRef,
+                            planRevisionId: ledgerId,
+                          },
+                          resolvedDateKey: appliedDateKey,
+                          updatedAtMs: stamp.physicalMs,
+                          deviceId: await input.identity.deviceId(),
+                          hlcPhysicalMs: stamp.physicalMs,
+                          hlcCounter: stamp.counter,
+                        },
+                      }),
                   mirrorJob: {
                     id: input.identity.newUlid(),
                     windowStartDateKey: todayDateKey,
@@ -3107,6 +3205,11 @@ export function createPlanningOperations(
               calculateWeekLoad: dependencies.proposalLoadCalculator,
             });
             const stamp = input.identity.hlcStamp();
+            const linkedRequest = await planningRequests?.readByProposalId(proposal.id);
+            const requestWorkout =
+              linkedRequest === undefined ? null : planningRequestWorkout(linkedRequest);
+            const appliedDateKey =
+              linkedRequest?.request.resolvedDateKey ?? validated.changes[0]?.next.dateKey ?? null;
             await applyValidatedPlanProposal(validated, {
               repository: proposalRepository,
               plan,
@@ -3115,6 +3218,32 @@ export function createPlanningOperations(
               deviceId: await input.identity.deviceId(),
               hlcPhysicalMs: stamp.physicalMs,
               hlcCounter: stamp.counter,
+              ...(linkedRequest === undefined
+                ? {}
+                : {
+                    requestCompletion: {
+                      requestId: linkedRequest.request.requestId,
+                      expectedRevision: linkedRequest.request.revision,
+                      expectedProposalId: proposal.id,
+                      result: {
+                        kind: "applied" as const,
+                        resultId: input.identity.newUlid(),
+                        completedAtMs: stamp.physicalMs,
+                        title: "Added to Plan",
+                        detail:
+                          appliedDateKey === null
+                            ? `${requestWorkout!.name} was added to the active Plan.`
+                            : `${requestWorkout!.name} is scheduled for ${dateText(appliedDateKey)}.`,
+                        workoutRef: requestWorkout!.workoutRef,
+                        planRevisionId: ledgerId,
+                      },
+                      resolvedDateKey: appliedDateKey,
+                      updatedAtMs: stamp.physicalMs,
+                      deviceId: await input.identity.deviceId(),
+                      hlcPhysicalMs: stamp.physicalMs,
+                      hlcCounter: stamp.counter,
+                    },
+                  }),
               mirrorJob: {
                 id: input.identity.newUlid(),
                 windowStartDateKey: todayDateKey,
@@ -3223,6 +3352,9 @@ export function createPlanningOperations(
           const proposal = await proposalRepository.read(command.proposalId);
           if (proposal?.status !== "proposed") return reject(UNAVAILABLE);
           const stamp = input.identity.hlcStamp();
+          const linkedRequest = await planningRequests?.readByProposalId(proposal.id);
+          const requestWorkout =
+            linkedRequest === undefined ? null : planningRequestWorkout(linkedRequest);
           await proposalRepository.resolve({
             id: proposal.id,
             status: "rejected",
@@ -3230,6 +3362,29 @@ export function createPlanningOperations(
             deviceId: await input.identity.deviceId(),
             hlcPhysicalMs: stamp.physicalMs,
             hlcCounter: stamp.counter,
+            ...(linkedRequest === undefined
+              ? {}
+              : {
+                  requestCompletion: {
+                    requestId: linkedRequest.request.requestId,
+                    expectedRevision: linkedRequest.request.revision,
+                    expectedProposalId: proposal.id,
+                    result: {
+                      kind: "rejected" as const,
+                      resultId: input.identity.newUlid(),
+                      completedAtMs: stamp.physicalMs,
+                      title: "Proposal rejected",
+                      detail: `${requestWorkout!.name} was not applied; the active Plan remains unchanged.`,
+                      workoutRef: requestWorkout!.workoutRef,
+                      planRevisionId: null,
+                    },
+                    resolvedDateKey: linkedRequest.request.resolvedDateKey,
+                    updatedAtMs: stamp.physicalMs,
+                    deviceId: await input.identity.deviceId(),
+                    hlcPhysicalMs: stamp.physicalMs,
+                    hlcCounter: stamp.counter,
+                  },
+                }),
           });
           return ExecutePlanTransitionRpcResultSchema.parse({
             status: "completed",

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -360,7 +360,7 @@ describe("Plan operations", () => {
             setId: "set-1",
             workoutId: "workout-1",
             workout: {
-              name: "Tempo 3 × 12",
+              title: "Tempo 3 × 12",
               sport: "cycling",
               durationSeconds: 3_840,
             },
@@ -2049,6 +2049,7 @@ describe("Plan operations", () => {
     };
     const plans = createPlanRepository(store);
     const proposals = createPlanProposalRepository(store);
+    const requests = createPlanningRequestRepository(store, createNodeCrypto());
     await plans.replace(activePlan, [existingWorkout]);
     await proposals.save(
       {
@@ -2107,11 +2108,59 @@ describe("Plan operations", () => {
         },
       ],
     );
+    const request = await requests.createOrGet({
+      payload: {
+        requestId: "request-add-workout",
+        kind: "workout_review",
+        intent: "Add Tempo 3 × 12 to Monday.",
+        source: {
+          chatId: "chat-1",
+          messageId: "message-1",
+          attachmentId: "attachment-1",
+        },
+        sourceSnapshot: {
+          capturedAt: "1998-08-24T08:00:00.000Z",
+          attachment: {
+            attachmentId: "attachment-1",
+            displayName: "tempo-3x12.mrc",
+            extension: "mrc",
+          },
+          selectedWorkout: {
+            setId: "set-1",
+            workoutId: "workout-1",
+            workout: {
+              title: "Tempo 3 × 12",
+              sport: "cycling",
+              durationSeconds: 3_840,
+            },
+          },
+        },
+        requestedDate: "2026-08-31",
+      },
+      target: "active_plan",
+      createdAtMs: 30,
+      deviceId: "device-1",
+      hlcPhysicalMs: 30,
+      hlcCounter: 0,
+    });
+    await requests.reviseOpen({
+      requestId: request.request.requestId,
+      expectedRevision: request.request.revision,
+      planConversationId: null,
+      proposalId,
+      attention: "needs_review",
+      resolvedDateKey: 20260831,
+      updatedAtMs: 40,
+      deviceId: "device-1",
+      hlcPhysicalMs: 40,
+      hlcCounter: 0,
+    });
     const operations = createPlanningOperations(
       { context, engine: engine(), identity: identity() },
       {
         plans,
         proposals,
+        requests,
         todayDateKey: () => 20260826,
         proposalLoadCalculator: (workouts) => (workouts.length === 1 ? 420 : 480),
         proposalPremiseReader: {
@@ -2148,6 +2197,18 @@ describe("Plan operations", () => {
     if (applied?.status !== "completed") throw new TypeError("Workout addition did not apply.");
     const ledgerId = String(applied.state.data.selectedHistoryId);
     await expect(plans.readWorkouts(planId)).resolves.toHaveLength(2);
+    await expect(requests.read("request-add-workout")).resolves.toMatchObject({
+      request: {
+        lifecycle: "applied",
+        attention: "none",
+        terminalResult: {
+          kind: "applied",
+          title: "Added to Plan",
+          detail: "Tempo 3 × 12 is scheduled for 2026-08-31.",
+          planRevisionId: ledgerId,
+        },
+      },
+    });
 
     await expect(
       operations.executePlanTransition?.({

--- a/packages/engine/src/planning/proposal.ts
+++ b/packages/engine/src/planning/proposal.ts
@@ -504,6 +504,9 @@ export async function applyValidatedPlanProposal(
       readonly createdAtMs: number;
     };
     readonly ledgerId: string;
+    readonly requestCompletion?: Parameters<
+      PlanProposalRepository["apply"]
+    >[0]["requestCompletion"];
   },
 ): Promise<PlanProposalRecord> {
   const workouts = validated.changes.map(({ next }) =>
@@ -558,5 +561,8 @@ export async function applyValidatedPlanProposal(
     deviceId: input.deviceId,
     hlcPhysicalMs: input.hlcPhysicalMs,
     hlcCounter: input.hlcCounter,
+    ...(input.requestCompletion === undefined
+      ? {}
+      : { requestCompletion: input.requestCompletion }),
   });
 }

--- a/packages/kernel-node/tests/plan-proposal-repository.test.ts
+++ b/packages/kernel-node/tests/plan-proposal-repository.test.ts
@@ -4,6 +4,7 @@ import {
   createPlanProposalRepository,
   createPlanReconciliationRepository,
   createPlanRepository,
+  createPlanningRequestRepository,
   encodePlanAdaptationWorkoutSnapshot,
   planAdaptationWorkoutSnapshot,
   type PlanAdaptationLedgerRecord,
@@ -15,6 +16,7 @@ import {
 } from "@enduragent/kernel/planning";
 import { runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createNodeCrypto } from "../src/ingest/import-files.js";
 import { openSqliteStorage } from "../src/sqlite/index.js";
 
 const id = (suffix: number): string => String(suffix).padStart(26, "0");
@@ -121,6 +123,65 @@ function ledger(
     deviceId: "device-1",
     hlcPhysicalMs: occurredAtMs,
     hlcCounter: 0,
+  };
+}
+
+async function linkedRequest(
+  store: SqlStore & MigratorStore,
+  requestId: string,
+  proposalId: string,
+  updatedAtMs = 30,
+) {
+  const requests = createPlanningRequestRepository(store, createNodeCrypto());
+  const created = await requests.createOrGet({
+    payload: {
+      requestId,
+      kind: "workout_review",
+      intent: "Add Tempo 3 × 12 to the active Plan.",
+      source: {
+        chatId: "chat-1",
+        messageId: "message-1",
+        attachmentId: "attachment-1",
+      },
+      sourceSnapshot: {
+        capturedAt: "1998-08-24T08:00:00.000Z",
+        attachment: {
+          attachmentId: "attachment-1",
+          displayName: "tempo-3x12.mrc",
+          extension: "mrc",
+        },
+        selectedWorkout: {
+          setId: "set-1",
+          workoutId: "workout-1",
+          workout: {
+            name: "Tempo 3 × 12",
+            sport: "cycling",
+            durationSeconds: 3_840,
+          },
+        },
+      },
+      requestedDate: "2026-08-30",
+    },
+    target: "active_plan",
+    createdAtMs: 20,
+    deviceId: "device-1",
+    hlcPhysicalMs: 20,
+    hlcCounter: 0,
+  });
+  return {
+    requests,
+    record: await requests.reviseOpen({
+      requestId,
+      expectedRevision: created.request.revision,
+      planConversationId: null,
+      proposalId,
+      attention: "needs_review",
+      resolvedDateKey: 20260830,
+      updatedAtMs,
+      deviceId: "device-1",
+      hlcPhysicalMs: updatedAtMs,
+      hlcCounter: 0,
+    }),
   };
 }
 
@@ -365,6 +426,165 @@ describe("Plan proposal repository", () => {
         beforeJson: null,
       }),
     ]);
+  });
+
+  it("rolls back Plan application when the linked request cannot commit its terminal result", async () => {
+    const proposals = createPlanProposalRepository(store);
+    const plans = createPlanRepository(store);
+    const history = createPlanAdaptationLedgerRepository(store);
+    const proposalId = id(17);
+    const ledgerId = id(18);
+    const requestId = id(19);
+    const nextWorkout = {
+      ...workout,
+      name: "Recovery",
+      durationS: 1_800,
+      hlcPhysicalMs: 40,
+    };
+    await proposals.save(proposal(proposalId), [premise(proposalId, id(20))]);
+    const { requests, record } = await linkedRequest(store, requestId, proposalId);
+    const requestCompletion = {
+      requestId,
+      expectedRevision: record.request.revision,
+      expectedProposalId: proposalId,
+      result: {
+        kind: "applied" as const,
+        resultId: id(21),
+        completedAtMs: 40,
+        title: "Added to Plan",
+        detail: "Tempo 3 × 12 is scheduled for 2026-08-30.",
+        workoutRef: { setId: "set-1", workoutId: "workout-1" },
+        planRevisionId: ledgerId,
+      },
+      resolvedDateKey: 20260830,
+      updatedAtMs: 40,
+      deviceId: "device-1",
+      hlcPhysicalMs: 40,
+      hlcCounter: 0,
+    };
+    const application = {
+      id: proposalId,
+      expectedPlanUpdatedAtMs: 10,
+      expectedPlanHlcPhysicalMs: 10,
+      expectedPlanHlcCounter: 0,
+      expectedWorkouts: [workout],
+      mirrorJob: {
+        id: id(22),
+        windowStartDateKey: 20260826,
+        windowEndDateKey: 20260901,
+        createdAtMs: 40,
+      },
+      plan: { ...plan, updatedAtMs: 40, hlcPhysicalMs: 40 },
+      workouts: [nextWorkout],
+      ledger: ledger(ledgerId, proposalId, workout, nextWorkout, 40),
+      resolvedAtMs: 40,
+      deviceId: "device-1",
+      hlcPhysicalMs: 40,
+      hlcCounter: 0,
+    };
+
+    await expect(
+      proposals.apply({
+        ...application,
+        requestCompletion: {
+          ...requestCompletion,
+          expectedRevision: requestCompletion.expectedRevision + 1,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "stale-revision" });
+    await expect(plans.readWorkouts(PLAN_ID)).resolves.toEqual([workout]);
+    await expect(proposals.read(proposalId)).resolves.toMatchObject({ status: "proposed" });
+    await expect(requests.read(requestId)).resolves.toMatchObject({
+      request: { lifecycle: "open", terminalResult: null },
+    });
+    await expect(history.readForPlan(PLAN_ID)).resolves.toEqual([]);
+
+    await expect(proposals.apply({ ...application, requestCompletion })).resolves.toMatchObject({
+      status: "applied",
+    });
+    await expect(plans.readWorkouts(PLAN_ID)).resolves.toEqual([
+      expect.objectContaining({ name: "Recovery" }),
+    ]);
+    await expect(requests.read(requestId)).resolves.toMatchObject({
+      request: {
+        lifecycle: "applied",
+        attention: "none",
+        terminalResult: { kind: "applied", planRevisionId: ledgerId },
+      },
+    });
+  });
+
+  it("moves a linked request to a revised Proposal in the same transaction", async () => {
+    const proposals = createPlanProposalRepository(store);
+    const initialId = id(23);
+    const revisedId = id(24);
+    const requestId = id(25);
+    await proposals.save(proposal(initialId), [premise(initialId, id(26))]);
+    const { requests, record } = await linkedRequest(store, requestId, initialId);
+    await proposals.save(
+      proposal(revisedId, {
+        parentProposalId: initialId,
+        revision: 2,
+        createdAtMs: 40,
+        updatedAtMs: 40,
+        hlcPhysicalMs: 40,
+      }),
+      [{ ...premise(revisedId, id(27)), createdAtMs: 40, hlcPhysicalMs: 40 }],
+      {
+        requestId,
+        expectedRevision: record.request.revision,
+        previousProposalId: initialId,
+        proposalId: revisedId,
+        updatedAtMs: 40,
+        deviceId: "device-1",
+        hlcPhysicalMs: 40,
+        hlcCounter: 0,
+      },
+    );
+    await expect(proposals.read(initialId)).resolves.toMatchObject({ status: "superseded" });
+    await expect(requests.read(requestId)).resolves.toMatchObject({
+      request: { proposalId: revisedId, revision: record.request.revision + 1 },
+    });
+  });
+
+  it("rejects a Proposal and completes its linked request atomically", async () => {
+    const proposals = createPlanProposalRepository(store);
+    const proposalId = id(28);
+    const requestId = id(29);
+    await proposals.save(proposal(proposalId), [premise(proposalId, id(30))]);
+    const { requests, record } = await linkedRequest(store, requestId, proposalId);
+    await proposals.resolve({
+      id: proposalId,
+      status: "rejected",
+      resolvedAtMs: 40,
+      deviceId: "device-1",
+      hlcPhysicalMs: 40,
+      hlcCounter: 0,
+      requestCompletion: {
+        requestId,
+        expectedRevision: record.request.revision,
+        expectedProposalId: proposalId,
+        result: {
+          kind: "rejected",
+          resultId: id(31),
+          completedAtMs: 40,
+          title: "Proposal rejected",
+          detail: "Tempo 3 × 12 was not applied; the active Plan remains unchanged.",
+          workoutRef: { setId: "set-1", workoutId: "workout-1" },
+          planRevisionId: null,
+        },
+        resolvedDateKey: 20260830,
+        updatedAtMs: 40,
+        deviceId: "device-1",
+        hlcPhysicalMs: 40,
+        hlcCounter: 0,
+      },
+    });
+    await expect(proposals.read(proposalId)).resolves.toMatchObject({ status: "rejected" });
+    await expect(requests.read(requestId)).resolves.toMatchObject({
+      request: { lifecycle: "rejected", terminalResult: { kind: "rejected" } },
+    });
+    await expect(createPlanRepository(store).readWorkouts(PLAN_ID)).resolves.toEqual([workout]);
   });
 
   it("rejects apply when a workout changed without advancing the Plan timestamp", async () => {

--- a/packages/kernel/src/planning/proposal-repository.ts
+++ b/packages/kernel/src/planning/proposal-repository.ts
@@ -8,6 +8,13 @@ import {
 } from "./adaptation-ledger-repository.js";
 import { addCivilDays } from "./date-keys.js";
 import type { PlanRecord, PlanWorkoutRecord } from "./repository.js";
+import { parsePlanningRequestTerminalResult } from "./request-repository.js";
+import {
+  completePlanningRequestInTransaction,
+  linkPlanningRequestProposalInTransaction,
+  type PlanningRequestCompletionTransactionInput,
+  type PlanningRequestProposalLinkTransactionInput,
+} from "./request-transaction.js";
 
 export type PlanProposalStatus = "proposed" | "applied" | "rejected" | "superseded" | "refused";
 export type PlanProposalConfidence = "Low" | "Moderate" | "High";
@@ -51,6 +58,7 @@ export interface PlanProposalRepository {
   save(
     proposal: PlanProposalRecord,
     premises: readonly PlanProposalPremiseRecord[],
+    requestLink?: PlanningRequestProposalLinkTransactionInput,
   ): Promise<PlanProposalRecord>;
   read(id: string): Promise<PlanProposalRecord | undefined>;
   readOpenForPlan(planId: string): Promise<readonly PlanProposalRecord[]>;
@@ -63,6 +71,7 @@ export interface PlanProposalRepository {
     readonly deviceId: string;
     readonly hlcPhysicalMs: number;
     readonly hlcCounter: number;
+    readonly requestCompletion?: PlanningRequestCompletionTransactionInput;
   }): Promise<PlanProposalRecord>;
   apply(input: {
     readonly id: string;
@@ -83,6 +92,7 @@ export interface PlanProposalRepository {
     readonly deviceId: string;
     readonly hlcPhysicalMs: number;
     readonly hlcCounter: number;
+    readonly requestCompletion?: PlanningRequestCompletionTransactionInput;
   }): Promise<PlanProposalRecord>;
 }
 
@@ -268,10 +278,26 @@ export function createPlanProposalRepository(store: ProposalStore): PlanProposal
   };
 
   const repository: PlanProposalRepository = Object.freeze({
-    async save(proposal: PlanProposalRecord, premises: readonly PlanProposalPremiseRecord[]) {
+    async save(
+      proposal: PlanProposalRecord,
+      premises: readonly PlanProposalPremiseRecord[],
+      requestLink?: PlanningRequestProposalLinkTransactionInput,
+    ) {
       validatePlanProposalRecord(proposal);
       if (proposal.status !== "proposed" || premises.length === 0) {
         throw new PlanProposalValidationError("invalid-proposal");
+      }
+      if (
+        requestLink !== undefined &&
+        (proposal.parentProposalId === null ||
+          requestLink.previousProposalId !== proposal.parentProposalId ||
+          requestLink.proposalId !== proposal.id ||
+          requestLink.updatedAtMs !== proposal.updatedAtMs ||
+          requestLink.deviceId !== proposal.deviceId ||
+          requestLink.hlcPhysicalMs !== proposal.hlcPhysicalMs ||
+          requestLink.hlcCounter !== proposal.hlcCounter)
+      ) {
+        throw new PlanProposalValidationError("invalid-transition");
       }
       for (const premise of premises) {
         validatePlanProposalPremiseRecord(premise);
@@ -352,6 +378,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
             ],
           );
         }
+        if (requestLink !== undefined) {
+          await linkPlanningRequestProposalInTransaction(store, requestLink);
+        }
       });
       const stored = await read(proposal.id);
       if (stored === undefined) throw new PlanProposalValidationError("missing-proposal");
@@ -393,25 +422,49 @@ WHERE proposal_id=? ORDER BY source_type,source_id,id`,
       ) {
         throw new PlanProposalValidationError("invalid-proposal");
       }
-      const current = await read(input.id);
-      if (current === undefined) throw new PlanProposalValidationError("missing-proposal");
-      if (current.status !== "proposed" || input.resolvedAtMs < current.createdAtMs) {
+      const requestCompletion =
+        input.requestCompletion === undefined
+          ? undefined
+          : {
+              ...input.requestCompletion,
+              result: parsePlanningRequestTerminalResult(input.requestCompletion.result),
+            };
+      if (
+        requestCompletion !== undefined &&
+        (requestCompletion.expectedProposalId !== input.id ||
+          requestCompletion.updatedAtMs !== input.resolvedAtMs ||
+          requestCompletion.deviceId !== input.deviceId ||
+          requestCompletion.hlcPhysicalMs !== input.hlcPhysicalMs ||
+          requestCompletion.hlcCounter !== input.hlcCounter ||
+          (input.status === "rejected" && requestCompletion.result.kind !== "rejected") ||
+          (input.status === "refused" && requestCompletion.result.kind !== "ended"))
+      ) {
         throw new PlanProposalValidationError("invalid-transition");
       }
-      await store.run(
-        `UPDATE plan_proposal SET status=?, refusal_reason=?, updated_at_ms=?, resolved_at_ms=?,
+      await store.transaction(async () => {
+        const current = await read(input.id);
+        if (current === undefined) throw new PlanProposalValidationError("missing-proposal");
+        if (current.status !== "proposed" || input.resolvedAtMs < current.createdAtMs) {
+          throw new PlanProposalValidationError("invalid-transition");
+        }
+        await store.run(
+          `UPDATE plan_proposal SET status=?, refusal_reason=?, updated_at_ms=?, resolved_at_ms=?,
 device_id=?, hlc_physical_ms=?, hlc_counter=? WHERE id=? AND status='proposed'`,
-        [
-          input.status,
-          input.status === "refused" ? input.reason! : null,
-          input.resolvedAtMs,
-          input.resolvedAtMs,
-          input.deviceId,
-          input.hlcPhysicalMs,
-          input.hlcCounter,
-          input.id,
-        ],
-      );
+          [
+            input.status,
+            input.status === "refused" ? input.reason! : null,
+            input.resolvedAtMs,
+            input.resolvedAtMs,
+            input.deviceId,
+            input.hlcPhysicalMs,
+            input.hlcCounter,
+            input.id,
+          ],
+        );
+        if (requestCompletion !== undefined) {
+          await completePlanningRequestInTransaction(store, requestCompletion);
+        }
+      });
       const stored = await read(input.id);
       if (stored === undefined || stored.status !== input.status) {
         throw new PlanProposalValidationError("invalid-transition");
@@ -419,6 +472,13 @@ device_id=?, hlc_physical_ms=?, hlc_counter=? WHERE id=? AND status='proposed'`,
       return stored;
     },
     async apply(input: Parameters<PlanProposalRepository["apply"]>[0]) {
+      const requestCompletion =
+        input.requestCompletion === undefined
+          ? undefined
+          : {
+              ...input.requestCompletion,
+              result: parsePlanningRequestTerminalResult(input.requestCompletion.result),
+            };
       const expectedById = new Map(input.expectedWorkouts.map((workout) => [workout.id, workout]));
       if (
         !ULID.test(input.id) ||
@@ -447,7 +507,16 @@ device_id=?, hlc_physical_ms=?, hlc_counter=? WHERE id=? AND status='proposed'`,
         input.expectedWorkouts.length > 1 ||
         expectedById.size !== input.expectedWorkouts.length ||
         (input.expectedWorkouts.length === 1 &&
-          input.expectedWorkouts[0]!.id !== input.workouts[0]!.id)
+          input.expectedWorkouts[0]!.id !== input.workouts[0]!.id) ||
+        (requestCompletion !== undefined &&
+          (requestCompletion.expectedProposalId !== input.id ||
+            requestCompletion.updatedAtMs !== input.resolvedAtMs ||
+            requestCompletion.deviceId !== input.deviceId ||
+            requestCompletion.hlcPhysicalMs !== input.hlcPhysicalMs ||
+            requestCompletion.hlcCounter !== input.hlcCounter ||
+            requestCompletion.result.kind !== "applied" ||
+            requestCompletion.result.completedAtMs !== input.resolvedAtMs ||
+            requestCompletion.result.planRevisionId !== input.ledger.id))
       ) {
         throw new PlanProposalValidationError("invalid-proposal");
       }
@@ -620,6 +689,9 @@ WHERE plan_id=? AND kind='mirror' AND window_start_date_key=? AND window_end_dat
         await store.run("DELETE FROM plan_reconciliation_item WHERE job_id=?", [
           text(mirrorJobRow, "id"),
         ]);
+        if (requestCompletion !== undefined) {
+          await completePlanningRequestInTransaction(store, requestCompletion);
+        }
         const storedRow = await store.get(
           `SELECT ${PROPOSAL_COLUMNS} FROM plan_proposal WHERE id=?`,
           [input.id],

--- a/packages/kernel/src/planning/request-errors.ts
+++ b/packages/kernel/src/planning/request-errors.ts
@@ -1,0 +1,20 @@
+export type PlanningRequestStoreErrorCode =
+  | "invalid-create"
+  | "invalid-provenance"
+  | "invalid-terminal-result"
+  | "request-conflict"
+  | "missing-request"
+  | "invalid-transition"
+  | "stale-revision"
+  | "immutable-terminal"
+  | "corrupt-record";
+
+export class PlanningRequestStoreError extends Error {
+  readonly code: PlanningRequestStoreErrorCode;
+
+  constructor(code: PlanningRequestStoreErrorCode) {
+    super(`planning request rejected: ${code}`);
+    this.name = "PlanningRequestStoreError";
+    this.code = code;
+  }
+}

--- a/packages/kernel/src/planning/request-repository.ts
+++ b/packages/kernel/src/planning/request-repository.ts
@@ -5,6 +5,10 @@ import { encodeUtf8Strict } from "../store/derived-key.js";
 import type { MigratorStore } from "../store/migrator.js";
 import type { Row, SqlStore } from "../store/ports.js";
 import { addCivilDays, dateKeyFromText } from "./date-keys.js";
+import { PlanningRequestStoreError } from "./request-errors.js";
+import { completePlanningRequestInTransaction } from "./request-transaction.js";
+
+export { PlanningRequestStoreError, type PlanningRequestStoreErrorCode } from "./request-errors.js";
 
 export type PlanningRequestKind =
   | "workout_review"
@@ -202,32 +206,12 @@ export interface CompactPlanningRequestSourceInput {
 export interface PlanningRequestRepository {
   createOrGet(input: CreatePlanningRequestInput): Promise<PlanningRequestRecord>;
   read(requestId: string): Promise<PlanningRequestRecord | undefined>;
+  readByProposalId(proposalId: string): Promise<PlanningRequestRecord | undefined>;
   readOpen(): Promise<readonly PlanningRequestRecord[]>;
   reviseOpen(input: ReviseOpenPlanningRequestInput): Promise<PlanningRequestRecord>;
   complete(input: CompletePlanningRequestInput): Promise<PlanningRequestRecord>;
   detachSource(input: DetachPlanningRequestSourceInput): Promise<PlanningRequestRecord>;
   compactSource(input: CompactPlanningRequestSourceInput): Promise<PlanningRequestRecord>;
-}
-
-export type PlanningRequestStoreErrorCode =
-  | "invalid-create"
-  | "invalid-provenance"
-  | "invalid-terminal-result"
-  | "request-conflict"
-  | "missing-request"
-  | "invalid-transition"
-  | "stale-revision"
-  | "immutable-terminal"
-  | "corrupt-record";
-
-export class PlanningRequestStoreError extends Error {
-  readonly code: PlanningRequestStoreErrorCode;
-
-  constructor(code: PlanningRequestStoreErrorCode) {
-    super(`planning request rejected: ${code}`);
-    this.name = "PlanningRequestStoreError";
-    this.code = code;
-  }
 }
 
 type PlanningStore = SqlStore & Pick<MigratorStore, "transaction">;
@@ -861,6 +845,17 @@ export function createPlanningRequestRepository(
 
     read,
 
+    async readByProposalId(proposalId) {
+      if (!validId(proposalId)) throw new PlanningRequestStoreError("invalid-transition");
+      const rows = await store.all(
+        "SELECT request_id FROM planning_request WHERE proposal_id=? ORDER BY request_id ASC",
+        [proposalId],
+      );
+      if (rows.length > 1) throw new PlanningRequestStoreError("corrupt-record");
+      const row = rows[0];
+      return row === undefined ? undefined : requireRequest(text(row, "request_id"));
+    },
+
     async readOpen() {
       const rows = await store.all(
         "SELECT request_id FROM planning_request WHERE lifecycle = 'open' ORDER BY created_at_ms ASC, request_id ASC",
@@ -933,50 +928,11 @@ WHERE request_id = ? AND lifecycle = 'open' AND revision = ?`,
         ) {
           throw new PlanningRequestStoreError("invalid-terminal-result");
         }
-        const resultJson = canonicalJson(result);
-        await store.run(
-          `INSERT INTO planning_request_terminal_result (
-  request_id, result_id, kind, result_json, completed_at_ms, plan_revision_id
-) VALUES (?, ?, ?, ?, ?, ?)`,
-          [
-            input.requestId,
-            result.resultId,
-            result.kind,
-            resultJson,
-            result.completedAtMs,
-            result.planRevisionId,
-          ],
-        );
-        if (current.tombstone === null) {
-          await store.run(
-            `INSERT INTO planning_request_tombstone (
-  request_id, payload_hash, status, created_at_ms, terminal_at_ms
-) VALUES (?, ?, ?, ?, ?)`,
-            [
-              input.requestId,
-              current.payloadHash,
-              result.kind,
-              input.updatedAtMs,
-              result.completedAtMs,
-            ],
-          );
-        }
-        await store.run(
-          `UPDATE planning_request SET
-  lifecycle = ?, attention = 'none', resolved_date_key = ?, revision = revision + 1,
-  updated_at_ms = ?, device_id = ?, hlc_physical_ms = ?, hlc_counter = ?
-WHERE request_id = ? AND lifecycle = 'open' AND revision = ?`,
-          [
-            result.kind,
-            input.resolvedDateKey,
-            input.updatedAtMs,
-            input.deviceId,
-            input.hlcPhysicalMs,
-            input.hlcCounter,
-            input.requestId,
-            input.expectedRevision,
-          ],
-        );
+        await completePlanningRequestInTransaction(store, {
+          ...input,
+          expectedProposalId: current.request.proposalId,
+          result,
+        });
         const updated = await requireRequest(input.requestId);
         if (updated.request.revision !== input.expectedRevision + 1) {
           throw new PlanningRequestStoreError("stale-revision");

--- a/packages/kernel/src/planning/request-transaction.ts
+++ b/packages/kernel/src/planning/request-transaction.ts
@@ -1,0 +1,217 @@
+import { canonicalJson } from "../archive/canonical.js";
+import type { SqlStore } from "../store/ports.js";
+import { addCivilDays } from "./date-keys.js";
+import { PlanningRequestStoreError } from "./request-errors.js";
+import type { PlanningRequestTerminalResult } from "./request-repository.js";
+
+export interface PlanningRequestProposalLinkTransactionInput {
+  readonly requestId: string;
+  readonly expectedRevision: number;
+  readonly previousProposalId: string;
+  readonly proposalId: string;
+  readonly updatedAtMs: number;
+  readonly deviceId: string;
+  readonly hlcPhysicalMs: number;
+  readonly hlcCounter: number;
+}
+
+export interface PlanningRequestCompletionTransactionInput {
+  readonly requestId: string;
+  readonly expectedRevision: number;
+  readonly expectedProposalId: string | null;
+  readonly result: PlanningRequestTerminalResult;
+  readonly resolvedDateKey: number | null;
+  readonly updatedAtMs: number;
+  readonly deviceId: string;
+  readonly hlcPhysicalMs: number;
+  readonly hlcCounter: number;
+}
+
+function stringValue(value: unknown): string {
+  if (typeof value !== "string") throw new PlanningRequestStoreError("corrupt-record");
+  return value;
+}
+
+function integerValue(value: unknown): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    throw new PlanningRequestStoreError("corrupt-record");
+  }
+  return value;
+}
+
+function nullableStringValue(value: unknown): string | null {
+  if (value !== null && typeof value !== "string") {
+    throw new PlanningRequestStoreError("corrupt-record");
+  }
+  return value;
+}
+
+function validDateKey(value: number | null): boolean {
+  if (value === null) return true;
+  try {
+    addCivilDays(value, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function requireMutationClock(
+  row: Readonly<Record<string, unknown>>,
+  input: {
+    readonly updatedAtMs: number;
+    readonly hlcPhysicalMs: number;
+    readonly hlcCounter: number;
+  },
+): void {
+  const currentUpdatedAtMs = integerValue(row.updated_at_ms);
+  const currentPhysicalMs = integerValue(row.hlc_physical_ms);
+  const currentCounter = integerValue(row.hlc_counter);
+  if (
+    !Number.isSafeInteger(input.updatedAtMs) ||
+    input.updatedAtMs < currentUpdatedAtMs ||
+    !Number.isSafeInteger(input.hlcPhysicalMs) ||
+    input.hlcPhysicalMs < currentPhysicalMs ||
+    !Number.isSafeInteger(input.hlcCounter) ||
+    (input.hlcPhysicalMs === currentPhysicalMs && input.hlcCounter < currentCounter)
+  ) {
+    throw new PlanningRequestStoreError("invalid-transition");
+  }
+}
+
+export async function linkPlanningRequestProposalInTransaction(
+  store: SqlStore,
+  input: PlanningRequestProposalLinkTransactionInput,
+): Promise<void> {
+  const row = await store.get(
+    `SELECT lifecycle,proposal_id,revision,updated_at_ms,hlc_physical_ms,hlc_counter
+FROM planning_request WHERE request_id=?`,
+    [input.requestId],
+  );
+  if (row === undefined) throw new PlanningRequestStoreError("missing-request");
+  if (
+    stringValue(row.lifecycle) !== "open" ||
+    stringValue(row.proposal_id) !== input.previousProposalId
+  ) {
+    throw new PlanningRequestStoreError("invalid-transition");
+  }
+  if (integerValue(row.revision) !== input.expectedRevision) {
+    throw new PlanningRequestStoreError("stale-revision");
+  }
+  requireMutationClock(row, input);
+  await store.run(
+    `UPDATE planning_request SET proposal_id=?,revision=revision+1,updated_at_ms=?,device_id=?,
+hlc_physical_ms=?,hlc_counter=?
+WHERE request_id=? AND lifecycle='open' AND proposal_id=? AND revision=?`,
+    [
+      input.proposalId,
+      input.updatedAtMs,
+      input.deviceId,
+      input.hlcPhysicalMs,
+      input.hlcCounter,
+      input.requestId,
+      input.previousProposalId,
+      input.expectedRevision,
+    ],
+  );
+  const updated = await store.get(
+    "SELECT proposal_id,revision FROM planning_request WHERE request_id=?",
+    [input.requestId],
+  );
+  if (
+    updated === undefined ||
+    stringValue(updated.proposal_id) !== input.proposalId ||
+    integerValue(updated.revision) !== input.expectedRevision + 1
+  ) {
+    throw new PlanningRequestStoreError("stale-revision");
+  }
+}
+
+export async function completePlanningRequestInTransaction(
+  store: SqlStore,
+  input: PlanningRequestCompletionTransactionInput,
+): Promise<void> {
+  if (!validDateKey(input.resolvedDateKey)) {
+    throw new PlanningRequestStoreError("invalid-terminal-result");
+  }
+  const row = await store.get(
+    `SELECT lifecycle,proposal_id,revision,created_at_ms,updated_at_ms,hlc_physical_ms,hlc_counter,
+payload_hash FROM planning_request WHERE request_id=?`,
+    [input.requestId],
+  );
+  if (row === undefined) throw new PlanningRequestStoreError("missing-request");
+  if (
+    stringValue(row.lifecycle) !== "open" ||
+    nullableStringValue(row.proposal_id) !== input.expectedProposalId
+  ) {
+    throw new PlanningRequestStoreError("invalid-transition");
+  }
+  if (integerValue(row.revision) !== input.expectedRevision) {
+    throw new PlanningRequestStoreError("stale-revision");
+  }
+  requireMutationClock(row, input);
+  if (
+    input.result.completedAtMs < integerValue(row.created_at_ms) ||
+    input.result.completedAtMs > input.updatedAtMs
+  ) {
+    throw new PlanningRequestStoreError("invalid-terminal-result");
+  }
+  await store.run(
+    `INSERT INTO planning_request_terminal_result (
+request_id,result_id,kind,result_json,completed_at_ms,plan_revision_id
+) VALUES (?,?,?,?,?,?)`,
+    [
+      input.requestId,
+      input.result.resultId,
+      input.result.kind,
+      canonicalJson(input.result),
+      input.result.completedAtMs,
+      input.result.planRevisionId,
+    ],
+  );
+  const tombstone = await store.get(
+    "SELECT request_id FROM planning_request_tombstone WHERE request_id=?",
+    [input.requestId],
+  );
+  if (tombstone === undefined) {
+    await store.run(
+      `INSERT INTO planning_request_tombstone (
+request_id,payload_hash,status,created_at_ms,terminal_at_ms
+) VALUES (?,?,?,?,?)`,
+      [
+        input.requestId,
+        stringValue(row.payload_hash),
+        input.result.kind,
+        input.result.completedAtMs,
+        input.result.completedAtMs,
+      ],
+    );
+  }
+  await store.run(
+    `UPDATE planning_request SET lifecycle=?,attention='none',resolved_date_key=?,
+revision=revision+1,updated_at_ms=?,device_id=?,hlc_physical_ms=?,hlc_counter=?
+WHERE request_id=? AND lifecycle='open' AND proposal_id IS ? AND revision=?`,
+    [
+      input.result.kind,
+      input.resolvedDateKey,
+      input.updatedAtMs,
+      input.deviceId,
+      input.hlcPhysicalMs,
+      input.hlcCounter,
+      input.requestId,
+      input.expectedProposalId,
+      input.expectedRevision,
+    ],
+  );
+  const updated = await store.get(
+    "SELECT lifecycle,revision FROM planning_request WHERE request_id=?",
+    [input.requestId],
+  );
+  if (
+    updated === undefined ||
+    stringValue(updated.lifecycle) !== input.result.kind ||
+    integerValue(updated.revision) !== input.expectedRevision + 1
+  ) {
+    throw new PlanningRequestStoreError("stale-revision");
+  }
+}


### PR DESCRIPTION
## Summary
- keep request-backed Proposal revisions attached to the originating Chat request
- commit Plan apply, reject, or safety refusal with one immutable request result in the same transaction
- roll back workouts, Proposal state, history, and reconciliation enqueue when request completion fails

## Verification
- focused Planning repository, Engine, intake, and operations tests: 62 passed
- root pnpm check
- full suite: 715 files passed, 5 skipped; 10,659 tests passed, 17 skipped
- autoreview: clean, no accepted/actionable findings