### PR TITLE
feat(chat): add Plan handoff projection APIs

### DIFF
--- a/.changeset/chat-plan-projection-api.md
+++ b/.changeset/chat-plan-projection-api.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/coach-contract": patch
+"@enduragent/coach-client": patch
+"@enduragent/kernel": patch
+"@enduragent/coach": patch
+---
+
+Chat can securely rebuild a selected Workout handoff and restore its current Plan status after relaunch.
+
+The daemon resolves local Workout details instead of trusting renderer-provided snapshots, and durable handoffs can be listed by their source conversation.

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -177,9 +177,11 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   getPlanState: 30_000,
   executePlanTransition: 11 * 60_000,
   createPlanningRequest: 30_000,
+  createWorkoutPlanningRequest: 30_000,
   getPlanningRequest: 30_000,
   retryPlanningRequest: 30_000,
   resumePlanningRequests: 30_000,
+  listPlanningRequests: 30_000,
 };
 
 function positiveSafeInteger(value: unknown): value is number {
@@ -542,8 +544,7 @@ class CoachClientRuntime {
       if (
         progress.commandId !== request.commandId ||
         progress.transitionId !== request.transitionId ||
-        (pending.planOperationId !== undefined &&
-          progress.operationId !== pending.planOperationId)
+        (pending.planOperationId !== undefined && progress.operationId !== pending.planOperationId)
       ) {
         this.failProtocol();
         return;

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -202,9 +202,24 @@ const rpcDeadlineCases = [
     },
     30_000,
   ],
+  [
+    "createWorkoutPlanningRequest",
+    {
+      requestId: "request-workout",
+      intent: "Review Tempo 3 × 12.",
+      source: {
+        chatId: "chat-1",
+        messageId: "message-workout",
+        attachmentId: "attachment-1",
+      },
+      requestedDate: "1998-08-26",
+    },
+    30_000,
+  ],
   ["getPlanningRequest", { requestId: "request-1" }, 30_000],
   ["retryPlanningRequest", { requestId: "request-1" }, 30_000],
   ["resumePlanningRequests", {}, 30_000],
+  ["listPlanningRequests", { chatId: "chat-1" }, 30_000],
 ] as const satisfies ReadonlyArray<readonly [CoachRpcMethodName, unknown, number]>;
 
 class ControllableSocket extends EventTarget {
@@ -1148,9 +1163,11 @@ describe("RPC receive and observers", () => {
           capability: "planning",
         },
         createPlanningRequest: { status: "rejected", reason: "invalid_request" },
+        createWorkoutPlanningRequest: { status: "rejected", reason: "invalid_request" },
         getPlanningRequest: { status: "missing" },
         retryPlanningRequest: { status: "missing" },
         resumePlanningRequests: { deliveries: [] },
+        listPlanningRequests: { deliveries: [] },
       };
       socket.emitMessage(
         serializeCoachRpcEnvelope({
@@ -1770,46 +1787,49 @@ describe("RPC receive and observers", () => {
       ],
       observedEvents: 1,
     },
-  ])("fails closed on Planning $name correlation mismatches", async ({ frames, observedEvents }) => {
-    const { socket, connecting } = acceptedSocket();
-    const client = await connecting;
-    socket.sendHook = () => {};
-    const events: unknown[] = [];
-    const operation = client.call(
-      "executePlanTransition",
-      { transitionId: "PL-T01", commandId: "command-1", sourceConversationId: null },
-      { onEvent: (event) => events.push(event) },
-    );
-    for (const frame of frames) {
-      socket.emitMessage(
-        frame.kind === "progress"
-          ? serializeCoachRpcEnvelope({
-              jsonrpc: "2.0",
-              method: "coach.planProgress",
-              params: {
-                requestId: 1,
-                requestMethod: "executePlanTransition",
-                event: frame.event,
-              },
-            })
-          : serializeCoachRpcEnvelope({
-              jsonrpc: "2.0",
-              id: 1,
-              result: {
-                status: "accepted",
-                operationId: frame.operationId,
-                state: planReadModel,
-              },
-            }),
+  ])(
+    "fails closed on Planning $name correlation mismatches",
+    async ({ frames, observedEvents }) => {
+      const { socket, connecting } = acceptedSocket();
+      const client = await connecting;
+      socket.sendHook = () => {};
+      const events: unknown[] = [];
+      const operation = client.call(
+        "executePlanTransition",
+        { transitionId: "PL-T01", commandId: "command-1", sourceConversationId: null },
+        { onEvent: (event) => events.push(event) },
       );
-    }
-    await expect(operation).rejects.toBeInstanceOf(CoachClientProtocolError);
-    expect(events).toHaveLength(observedEvents);
-    expect(socket.closeCalls).toHaveLength(1);
-    const closing = client.close();
-    socket.emitClose(1002, "protocol");
-    await closing;
-  });
+      for (const frame of frames) {
+        socket.emitMessage(
+          frame.kind === "progress"
+            ? serializeCoachRpcEnvelope({
+                jsonrpc: "2.0",
+                method: "coach.planProgress",
+                params: {
+                  requestId: 1,
+                  requestMethod: "executePlanTransition",
+                  event: frame.event,
+                },
+              })
+            : serializeCoachRpcEnvelope({
+                jsonrpc: "2.0",
+                id: 1,
+                result: {
+                  status: "accepted",
+                  operationId: frame.operationId,
+                  state: planReadModel,
+                },
+              }),
+        );
+      }
+      await expect(operation).rejects.toBeInstanceOf(CoachClientProtocolError);
+      expect(events).toHaveLength(observedEvents);
+      expect(socket.closeCalls).toHaveLength(1);
+      const closing = client.close();
+      socket.emitClose(1002, "protocol");
+      await closing;
+    },
+  );
 
   it.each([-32700, -32600] as const)(
     "treats null-id protocol error %s as connection-wide",

--- a/packages/coach-contract/src/planning-request.ts
+++ b/packages/coach-contract/src/planning-request.ts
@@ -62,10 +62,7 @@ export const CreatePlanningRequestPayloadSchema = z
         message: "workout review requires an attachment and selected Workout",
       });
     }
-    if (
-      value.sourceSnapshot.selectedWorkout !== null &&
-      value.sourceSnapshot.attachment === null
-    ) {
+    if (value.sourceSnapshot.selectedWorkout !== null && value.sourceSnapshot.attachment === null) {
       context.addIssue({
         code: "custom",
         path: ["sourceSnapshot", "attachment"],
@@ -173,6 +170,16 @@ export type PlanningRequestReadModel = z.infer<typeof PlanningRequestReadModelSc
 export const PlanningRequestDeliverySchema = z
   .object({
     requestId: PlanningRequestIdSchema,
+    source: z
+      .object({
+        kind: PlanningRequestKindSchema,
+        intent: z.string().min(1).max(20_000),
+        chatId: PlanningRequestIdSchema,
+        messageId: PlanningRequestIdSchema,
+        attachmentId: PlanningRequestIdSchema.nullable(),
+      })
+      .strict()
+      .nullable(),
     state: z.enum(["pending", "failed", "delivered", "cancelled"]),
     attemptCount: z.number().int().nonnegative(),
     failureCode: z.string().min(1).max(128).nullable(),
@@ -220,10 +227,22 @@ export type PlanningRequestDelivery = z.infer<typeof PlanningRequestDeliverySche
 
 export const CreatePlanningRequestRpcParamsSchema = z
   .object({ payload: CreatePlanningRequestPayloadSchema })
-  .strict();
-export type CreatePlanningRequestRpcParams = z.infer<
-  typeof CreatePlanningRequestRpcParamsSchema
->;
+  .strict()
+  .superRefine((value, context) => {
+    if (
+      value.payload.kind === "workout_review" ||
+      value.payload.source.attachmentId !== undefined ||
+      value.payload.sourceSnapshot.attachment !== null ||
+      value.payload.sourceSnapshot.selectedWorkout !== null
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["payload"],
+        message: "Workout handoffs require trusted daemon source resolution",
+      });
+    }
+  });
+export type CreatePlanningRequestRpcParams = z.infer<typeof CreatePlanningRequestRpcParamsSchema>;
 
 export const CreatePlanningRequestRpcResultSchema = z.discriminatedUnion("status", [
   z.object({ status: z.literal("accepted"), delivery: PlanningRequestDeliverySchema }).strict(),
@@ -234,9 +253,36 @@ export const CreatePlanningRequestRpcResultSchema = z.discriminatedUnion("status
     })
     .strict(),
 ]);
-export type CreatePlanningRequestRpcResult = z.infer<
-  typeof CreatePlanningRequestRpcResultSchema
+export type CreatePlanningRequestRpcResult = z.infer<typeof CreatePlanningRequestRpcResultSchema>;
+
+export const CreateWorkoutPlanningRequestRpcParamsSchema = z
+  .object({
+    requestId: PlanningRequestIdSchema,
+    intent: z.string().min(1).max(20_000),
+    source: z
+      .object({
+        chatId: PlanningRequestIdSchema,
+        messageId: PlanningRequestIdSchema,
+        attachmentId: PlanningRequestIdSchema,
+      })
+      .strict(),
+    requestedDate: PlanningRequestCivilDateSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (
+      value.requestId === value.source.messageId ||
+      value.requestId === value.source.attachmentId ||
+      value.source.messageId === value.source.attachmentId
+    ) {
+      context.addIssue({ code: "custom", message: "Planning request identities must be distinct" });
+    }
+  });
+export type CreateWorkoutPlanningRequestRpcParams = z.infer<
+  typeof CreateWorkoutPlanningRequestRpcParamsSchema
 >;
+export const CreateWorkoutPlanningRequestRpcResultSchema = CreatePlanningRequestRpcResultSchema;
+export type CreateWorkoutPlanningRequestRpcResult = CreatePlanningRequestRpcResult;
 
 export const GetPlanningRequestRpcParamsSchema = z
   .object({ requestId: PlanningRequestIdSchema })
@@ -255,20 +301,28 @@ export const RetryPlanningRequestRpcResultSchema = GetPlanningRequestRpcResultSc
 export type RetryPlanningRequestRpcResult = GetPlanningRequestRpcResult;
 
 export const ResumePlanningRequestsRpcParamsSchema = z.object({}).strict();
-export type ResumePlanningRequestsRpcParams = z.infer<
-  typeof ResumePlanningRequestsRpcParamsSchema
->;
+export type ResumePlanningRequestsRpcParams = z.infer<typeof ResumePlanningRequestsRpcParamsSchema>;
 export const ResumePlanningRequestsRpcResultSchema = z
   .object({ deliveries: z.array(PlanningRequestDeliverySchema) })
   .strict();
-export type ResumePlanningRequestsRpcResult = z.infer<
-  typeof ResumePlanningRequestsRpcResultSchema
->;
+export type ResumePlanningRequestsRpcResult = z.infer<typeof ResumePlanningRequestsRpcResultSchema>;
+
+export const ListPlanningRequestsRpcParamsSchema = z
+  .object({ chatId: PlanningRequestIdSchema })
+  .strict();
+export type ListPlanningRequestsRpcParams = z.infer<typeof ListPlanningRequestsRpcParamsSchema>;
+export const ListPlanningRequestsRpcResultSchema = z
+  .object({ deliveries: z.array(PlanningRequestDeliverySchema) })
+  .strict();
+export type ListPlanningRequestsRpcResult = z.infer<typeof ListPlanningRequestsRpcResultSchema>;
 
 export interface PlanningRequestOperations {
   createPlanningRequest?(
     request: CreatePlanningRequestRpcParams,
   ): Promise<CreatePlanningRequestRpcResult>;
+  createWorkoutPlanningRequest?(
+    request: CreateWorkoutPlanningRequestRpcParams,
+  ): Promise<CreateWorkoutPlanningRequestRpcResult>;
   getPlanningRequest?(request: GetPlanningRequestRpcParams): Promise<GetPlanningRequestRpcResult>;
   retryPlanningRequest?(
     request: RetryPlanningRequestRpcParams,
@@ -276,4 +330,7 @@ export interface PlanningRequestOperations {
   resumePlanningRequests?(
     request: ResumePlanningRequestsRpcParams,
   ): Promise<ResumePlanningRequestsRpcResult>;
+  listPlanningRequests?(
+    request: ListPlanningRequestsRpcParams,
+  ): Promise<ListPlanningRequestsRpcResult>;
 }

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -127,8 +127,12 @@ import {
 import {
   CreatePlanningRequestRpcParamsSchema,
   CreatePlanningRequestRpcResultSchema,
+  CreateWorkoutPlanningRequestRpcParamsSchema,
+  CreateWorkoutPlanningRequestRpcResultSchema,
   GetPlanningRequestRpcParamsSchema,
   GetPlanningRequestRpcResultSchema,
+  ListPlanningRequestsRpcParamsSchema,
+  ListPlanningRequestsRpcResultSchema,
   ResumePlanningRequestsRpcParamsSchema,
   ResumePlanningRequestsRpcResultSchema,
   RetryPlanningRequestRpcParamsSchema,
@@ -289,9 +293,11 @@ export const COACH_RPC_METHOD_NAMES = [
   "getPlanState",
   "executePlanTransition",
   "createPlanningRequest",
+  "createWorkoutPlanningRequest",
   "getPlanningRequest",
   "retryPlanningRequest",
   "resumePlanningRequests",
+  "listPlanningRequests",
 ] as const satisfies readonly (keyof CoachRpcService)[];
 
 export const CoachRpcMethodNameSchema = z.enum(COACH_RPC_METHOD_NAMES);
@@ -1791,6 +1797,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
     .object({
       jsonrpc: z.literal("2.0"),
       id: JsonRpcIdSchema,
+      method: z.literal("createWorkoutPlanningRequest"),
+      params: CreateWorkoutPlanningRequestRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
       method: z.literal("getPlanningRequest"),
       params: GetPlanningRequestRpcParamsSchema,
     })
@@ -1809,6 +1823,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("resumePlanningRequests"),
       params: ResumePlanningRequestsRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("listPlanningRequests"),
+      params: ListPlanningRequestsRpcParamsSchema,
     })
     .strict(),
 ]);
@@ -2295,6 +2317,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     responseSchema: CreatePlanningRequestRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
+  createWorkoutPlanningRequest: {
+    wireName: "createWorkoutPlanningRequest",
+    requestSchema: CreateWorkoutPlanningRequestRpcParamsSchema,
+    responseSchema: CreateWorkoutPlanningRequestRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
   getPlanningRequest: {
     wireName: "getPlanningRequest",
     requestSchema: GetPlanningRequestRpcParamsSchema,
@@ -2311,6 +2339,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "resumePlanningRequests",
     requestSchema: ResumePlanningRequestsRpcParamsSchema,
     responseSchema: ResumePlanningRequestsRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  listPlanningRequests: {
+    wireName: "listPlanningRequests",
+    requestSchema: ListPlanningRequestsRpcParamsSchema,
+    responseSchema: ListPlanningRequestsRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
 } as const satisfies CoachRpcMethodRegistryShape;

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 30;
+export const PROTOCOL_VERSION = 31;

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../src/index.js";
 
 describe("chat queue contract", () => {
-  it("ships protocol 30 and rejects a blank enqueue without attachments", () => {
-    expect(PROTOCOL_VERSION).toBe(30);
+  it("ships protocol 31 and rejects a blank enqueue without attachments", () => {
+    expect(PROTOCOL_VERSION).toBe(31);
     expect(() =>
       EnqueueChatMessageRequestSchema.parse({
         chatId: "desktop",

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -151,8 +151,8 @@ describe("coach decision wire contract", () => {
     expect(parsed.entries).toHaveLength(1);
   });
 
-  it("projects resume completion explicitly at protocol 30", () => {
-    expect(PROTOCOL_VERSION).toBe(30);
+  it("projects resume completion explicitly at protocol 31", () => {
+    expect(PROTOCOL_VERSION).toBe(31);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -115,7 +115,7 @@ describe("exit codes", () => {
 
 describe("protocol version", () => {
   it("is 30", () => {
-    expect(PROTOCOL_VERSION).toBe(30);
+    expect(PROTOCOL_VERSION).toBe(31);
   });
 
   it("requires Stop to name the exact active turn", () => {

--- a/packages/coach-contract/tests/planning-request-contract.test.ts
+++ b/packages/coach-contract/tests/planning-request-contract.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   CreatePlanningRequestPayloadSchema,
+  CreatePlanningRequestRpcParamsSchema,
   CreatePlanningRequestRpcResultSchema,
+  CreateWorkoutPlanningRequestRpcParamsSchema,
+  ListPlanningRequestsRpcParamsSchema,
   PlanningRequestDeliverySchema,
 } from "../src/index.js";
 
@@ -46,6 +49,13 @@ describe("Planning request contract", () => {
     expect(
       PlanningRequestDeliverySchema.parse({
         requestId: payload.requestId,
+        source: {
+          kind: payload.kind,
+          intent: payload.intent,
+          chatId: payload.source.chatId,
+          messageId: payload.source.messageId,
+          attachmentId: payload.source.attachmentId,
+        },
         state: "pending",
         attemptCount: 1,
         failureCode: null,
@@ -59,6 +69,13 @@ describe("Planning request contract", () => {
     expect(() =>
       PlanningRequestDeliverySchema.parse({
         requestId: payload.requestId,
+        source: {
+          kind: payload.kind,
+          intent: payload.intent,
+          chatId: payload.source.chatId,
+          messageId: payload.source.messageId,
+          attachmentId: payload.source.attachmentId,
+        },
         state: "delivered",
         attemptCount: 1,
         failureCode: null,
@@ -78,5 +95,52 @@ describe("Planning request contract", () => {
         reason: "request_conflict",
       }),
     ).toEqual({ status: "rejected", reason: "request_conflict" });
+  });
+
+  it("accepts only distinct trusted Workout source identities", () => {
+    const request = {
+      requestId: "request-1",
+      intent: "Review Tempo 3 × 12.",
+      source: {
+        chatId: "chat-1",
+        messageId: "message-1",
+        attachmentId: "attachment-1",
+      },
+      requestedDate: "1998-08-26",
+    };
+    expect(CreateWorkoutPlanningRequestRpcParamsSchema.parse(request)).toEqual(request);
+    expect(() =>
+      CreateWorkoutPlanningRequestRpcParamsSchema.parse({
+        ...request,
+        source: { ...request.source, attachmentId: request.source.messageId },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects Workout snapshots through the generic renderer request", () => {
+    expect(() => CreatePlanningRequestRpcParamsSchema.parse({ payload })).toThrow();
+    expect(
+      CreatePlanningRequestRpcParamsSchema.parse({
+        payload: {
+          ...payload,
+          kind: "plan_change",
+          source: { chatId: "chat-1", messageId: "message-1" },
+          sourceSnapshot: {
+            capturedAt: payload.sourceSnapshot.capturedAt,
+            attachment: null,
+            selectedWorkout: null,
+          },
+        },
+      }).payload.kind,
+    ).toBe("plan_change");
+  });
+
+  it("lists durable handoffs for exactly one Chat", () => {
+    expect(ListPlanningRequestsRpcParamsSchema.parse({ chatId: "chat-1" })).toEqual({
+      chatId: "chat-1",
+    });
+    expect(() =>
+      ListPlanningRequestsRpcParamsSchema.parse({ chatId: "chat-1", extra: true }),
+    ).toThrow();
   });
 });

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1407,9 +1407,14 @@ describe("coach request and event projection", () => {
         status: "rejected",
         reason: "invalid_request",
       }),
+      createWorkoutPlanningRequest: async () => ({
+        status: "rejected",
+        reason: "invalid_request",
+      }),
       getPlanningRequest: async () => ({ status: "missing" }),
       retryPlanningRequest: async () => ({ status: "missing" }),
       resumePlanningRequests: async () => ({ deliveries: [] }),
+      listPlanningRequests: async () => ({ deliveries: [] }),
     };
     expect(Object.keys(COACH_RPC_METHOD_REGISTRY)).toEqual(Object.keys(fake));
     expect(COACH_RPC_METHOD_NAMES).toEqual(Object.keys(fake));
@@ -1894,7 +1899,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-30 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-31 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1902,8 +1907,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 30,
-      serverProtocolVersion: 30,
+      clientProtocolVersion: 31,
+      serverProtocolVersion: 31,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1912,7 +1917,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(29);
+    expect(previous).toBe(30);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -1985,9 +1990,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 30 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 31 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(30);
+    expect(client.clientProtocolVersion).toBe(31);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2113,7 +2118,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version 30", () => {
-    expect(PROTOCOL_VERSION).toBe(30);
+  it("uses protocol version 31", () => {
+    expect(PROTOCOL_VERSION).toBe(31);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -103,6 +103,7 @@ import {
   type ListArchivedConversationsRpcResult,
   type GetRuntimeConfigRpcResult,
   type PlanningReadOperations,
+  type CreatePlanningRequestPayload,
   type PlanningRequestOperations,
   type PlanningOperations,
   type VerifyIntervalsCredentialRpcParams,
@@ -2021,6 +2022,36 @@ export async function createLocalCoachComposition(
           if (latest?.status === "active") return "active_plan";
           if (latest?.status === "draft") return "draft";
           return "plan_creation";
+        },
+        async resolveWorkoutSource({ chatId, attachmentId }) {
+          const attachment = await attachmentRepository.readAttachment(attachmentId);
+          if (
+            attachment === undefined ||
+            attachment.conversation_id !== chatId ||
+            attachment.kind !== "workout" ||
+            (attachment.status !== "ready" && attachment.status !== "sent")
+          ) {
+            throw new TypeError("Workout attachment is unavailable.");
+          }
+          const set = await workoutAttachmentOperations.readWorkoutSet(attachmentId);
+          const workout = set.workouts.find(
+            (candidate) => candidate.workoutId === set.selectedWorkoutId,
+          );
+          if (workout === undefined) throw new TypeError("Workout selection is unavailable.");
+          return {
+            attachment: {
+              attachmentId: attachment.id,
+              displayName: attachment.display_name,
+              extension: set.sourceFormat,
+            },
+            selectedWorkout: {
+              setId: set.setId,
+              workoutId: workout.workoutId,
+              workout: JSON.parse(JSON.stringify(workout)) as NonNullable<
+                CreatePlanningRequestPayload["sourceSnapshot"]["selectedWorkout"]
+              >["workout"],
+            },
+          };
         },
       },
       {

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -539,9 +539,11 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "getPlanState",
   "executePlanTransition",
   "createPlanningRequest",
+  "createWorkoutPlanningRequest",
   "getPlanningRequest",
   "retryPlanningRequest",
   "resumePlanningRequests",
+  "listPlanningRequests",
 ]);
 
 const PLAN_CHAT_RENDERER_METHODS = new Set<CoachRpcMethodName>([
@@ -1736,6 +1738,20 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               invocationFailure = { error };
             }
             break;
+          case "createWorkoutPlanningRequest":
+            try {
+              if (input.operations.createWorkoutPlanningRequest === undefined) {
+                throw new TypeError("Workout Planning request creation is unavailable.");
+              }
+              result = await input.operations.createWorkoutPlanningRequest(
+                COACH_RPC_METHOD_REGISTRY.createWorkoutPlanningRequest.requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
           case "getPlanningRequest":
             try {
               if (input.operations.getPlanningRequest === undefined) {
@@ -1771,6 +1787,20 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               }
               result = await input.operations.resumePlanningRequests(
                 COACH_RPC_METHOD_REGISTRY.resumePlanningRequests.requestSchema.parse(
+                  generic.data.params,
+                ),
+              );
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "listPlanningRequests":
+            try {
+              if (input.operations.listPlanningRequests === undefined) {
+                throw new TypeError("Planning request list is unavailable.");
+              }
+              result = await input.operations.listPlanningRequests(
+                COACH_RPC_METHOD_REGISTRY.listPlanningRequests.requestSchema.parse(
                   generic.data.params,
                 ),
               );

--- a/packages/coach/src/planning-request-delivery.ts
+++ b/packages/coach/src/planning-request-delivery.ts
@@ -1,8 +1,12 @@
 import {
   CreatePlanningRequestRpcParamsSchema,
   CreatePlanningRequestRpcResultSchema,
+  CreateWorkoutPlanningRequestRpcParamsSchema,
+  CreateWorkoutPlanningRequestRpcResultSchema,
   GetPlanningRequestRpcParamsSchema,
   GetPlanningRequestRpcResultSchema,
+  ListPlanningRequestsRpcParamsSchema,
+  ListPlanningRequestsRpcResultSchema,
   PlanningRequestDeliverySchema,
   ResumePlanningRequestsRpcParamsSchema,
   ResumePlanningRequestsRpcResultSchema,
@@ -10,6 +14,8 @@ import {
   RetryPlanningRequestRpcResultSchema,
   type PlanningRequestDelivery,
   type PlanningRequestOperations,
+  type CreatePlanningRequestPayload,
+  type CreatePlanningRequestRpcResult,
 } from "@enduragent/coach-contract";
 import {
   PlanningRequestStoreError,
@@ -29,6 +35,15 @@ export interface PlanningRequestDeliveryServiceInput {
   readonly requests: PlanningRequestRepository;
   readonly identity: AuthoredIdentity;
   readonly resolveTarget: () => Promise<PlanningRequestTarget>;
+  readonly resolveWorkoutSource?: (input: {
+    readonly chatId: string;
+    readonly attachmentId: string;
+  }) => Promise<{
+    readonly attachment: NonNullable<CreatePlanningRequestPayload["sourceSnapshot"]["attachment"]>;
+    readonly selectedWorkout: NonNullable<
+      CreatePlanningRequestPayload["sourceSnapshot"]["selectedWorkout"]
+    >;
+  }>;
 }
 
 export interface PlanningRequestDeliveryServiceDependencies {
@@ -48,6 +63,16 @@ async function project(
     planningRecord?.payloadHash === record.payloadHash ? planningRecord : undefined;
   const delivery = {
     requestId: record.requestId,
+    source:
+      record.payload === null
+        ? null
+        : {
+            kind: record.payload.kind,
+            intent: record.payload.intent,
+            chatId: record.payload.source.chatId,
+            messageId: record.payload.source.messageId,
+            attachmentId: record.payload.source.attachmentId ?? null,
+          },
     state: record.state,
     attemptCount: record.attemptCount,
     failureCode: record.state === "failed" ? record.failureCode : null,
@@ -148,35 +173,76 @@ export function createPlanningRequestDeliveryService(
     return project(input.requests, delivered);
   };
 
+  const create = async (
+    payload: CreatePlanningRequestPayload,
+  ): Promise<CreatePlanningRequestRpcResult> => {
+    let record: ChatPlanOutboxRecord;
+    try {
+      record = await input.outbox.createOrGet({
+        payload,
+        createdAtMs: input.identity.hlcStamp().physicalMs,
+      });
+    } catch (error) {
+      if (error instanceof ChatPlanOutboxStoreError) {
+        if (error.code === "request-conflict") {
+          return CreatePlanningRequestRpcResultSchema.parse({
+            status: "rejected",
+            reason: "request_conflict",
+          });
+        }
+        if (error.code === "invalid-create") {
+          return CreatePlanningRequestRpcResultSchema.parse({
+            status: "rejected",
+            reason: "invalid_request",
+          });
+        }
+      }
+      throw error;
+    }
+    return CreatePlanningRequestRpcResultSchema.parse({
+      status: "accepted",
+      delivery: await delivery(record),
+    });
+  };
+
   return {
     async createPlanningRequest(request) {
       const parsed = CreatePlanningRequestRpcParamsSchema.parse(request);
-      let record: ChatPlanOutboxRecord;
-      try {
-        record = await input.outbox.createOrGet({
-          payload: parsed.payload,
-          createdAtMs: input.identity.hlcStamp().physicalMs,
+      return create(parsed.payload);
+    },
+
+    async createWorkoutPlanningRequest(request) {
+      const parsed = CreateWorkoutPlanningRequestRpcParamsSchema.parse(request);
+      if (input.resolveWorkoutSource === undefined) {
+        return CreateWorkoutPlanningRequestRpcResultSchema.parse({
+          status: "rejected",
+          reason: "invalid_request",
         });
-      } catch (error) {
-        if (error instanceof ChatPlanOutboxStoreError) {
-          if (error.code === "request-conflict") {
-            return CreatePlanningRequestRpcResultSchema.parse({
-              status: "rejected",
-              reason: "request_conflict",
-            });
-          }
-          if (error.code === "invalid-create") {
-            return CreatePlanningRequestRpcResultSchema.parse({
-              status: "rejected",
-              reason: "invalid_request",
-            });
-          }
-        }
-        throw error;
       }
-      return CreatePlanningRequestRpcResultSchema.parse({
-        status: "accepted",
-        delivery: await delivery(record),
+      let source: Awaited<ReturnType<NonNullable<typeof input.resolveWorkoutSource>>>;
+      try {
+        source = await input.resolveWorkoutSource({
+          chatId: parsed.source.chatId,
+          attachmentId: parsed.source.attachmentId,
+        });
+      } catch {
+        return CreateWorkoutPlanningRequestRpcResultSchema.parse({
+          status: "rejected",
+          reason: "invalid_request",
+        });
+      }
+      const capturedAtMs = input.identity.hlcStamp().physicalMs;
+      return create({
+        requestId: parsed.requestId,
+        kind: "workout_review",
+        intent: parsed.intent,
+        source: parsed.source,
+        sourceSnapshot: {
+          capturedAt: new Date(capturedAtMs).toISOString(),
+          attachment: source.attachment,
+          selectedWorkout: source.selectedWorkout,
+        },
+        ...(parsed.requestedDate === undefined ? {} : { requestedDate: parsed.requestedDate }),
       });
     },
 
@@ -206,6 +272,14 @@ export function createPlanningRequestDeliveryService(
       const deliveries: PlanningRequestDelivery[] = [];
       for (const record of records) deliveries.push(await delivery(record));
       return ResumePlanningRequestsRpcResultSchema.parse({ deliveries });
+    },
+
+    async listPlanningRequests(request) {
+      const parsed = ListPlanningRequestsRpcParamsSchema.parse(request);
+      const records = await input.outbox.readByChatId(parsed.chatId);
+      return ListPlanningRequestsRpcResultSchema.parse({
+        deliveries: await Promise.all(records.map((record) => project(input.requests, record))),
+      });
     },
   };
 }

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -2042,17 +2042,24 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       status: "rejected" as const,
       reason: "invalid_request" as const,
     }));
+    const createWorkoutPlanningRequest = vi.fn(async () => ({
+      status: "rejected" as const,
+      reason: "invalid_request" as const,
+    }));
     const getPlanningRequest = vi.fn(async () => ({ status: "missing" as const }));
     const retryPlanningRequest = vi.fn(async () => ({ status: "missing" as const }));
     const resumePlanningRequests = vi.fn(async () => ({ deliveries: [] }));
+    const listPlanningRequests = vi.fn(async () => ({ deliveries: [] }));
     const rpc = createCoachRpcServer({
       engine: engine(),
       operations: {
         ...operations,
         createPlanningRequest,
+        createWorkoutPlanningRequest,
         getPlanningRequest,
         retryPlanningRequest,
         resumePlanningRequests,
+        listPlanningRequests,
       },
       token,
       owner: "app-supervised",
@@ -2074,25 +2081,51 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     };
     for (const request of [
       { id: "create-request", method: "createPlanningRequest", params: { payload } },
+      {
+        id: "create-workout-request",
+        method: "createWorkoutPlanningRequest",
+        params: {
+          requestId: "request-workout",
+          intent: "Review Tempo 3 × 12.",
+          source: {
+            chatId: "desktop",
+            messageId: "message-workout",
+            attachmentId: "attachment-1",
+          },
+        },
+      },
       { id: "get-request", method: "getPlanningRequest", params: { requestId: "request-1" } },
       { id: "retry-request", method: "retryPlanningRequest", params: { requestId: "request-1" } },
       { id: "resume-requests", method: "resumePlanningRequests", params: {} },
+      { id: "list-requests", method: "listPlanningRequests", params: { chatId: "desktop" } },
     ]) {
       client.ws.send(JSON.stringify({ jsonrpc: "2.0", ...request }));
       expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
         id: request.id,
         result:
-          request.method === "createPlanningRequest"
+          request.method === "createPlanningRequest" ||
+          request.method === "createWorkoutPlanningRequest"
             ? { status: "rejected", reason: "invalid_request" }
-            : request.method === "resumePlanningRequests"
+            : request.method === "resumePlanningRequests" ||
+                request.method === "listPlanningRequests"
               ? { deliveries: [] }
               : { status: "missing" },
       });
     }
     expect(createPlanningRequest).toHaveBeenCalledWith({ payload });
+    expect(createWorkoutPlanningRequest).toHaveBeenCalledWith({
+      requestId: "request-workout",
+      intent: "Review Tempo 3 × 12.",
+      source: {
+        chatId: "desktop",
+        messageId: "message-workout",
+        attachmentId: "attachment-1",
+      },
+    });
     expect(getPlanningRequest).toHaveBeenCalledWith({ requestId: "request-1" });
     expect(retryPlanningRequest).toHaveBeenCalledWith({ requestId: "request-1" });
     expect(resumePlanningRequests).toHaveBeenCalledWith({});
+    expect(listPlanningRequests).toHaveBeenCalledWith({ chatId: "desktop" });
 
     client.ws.send(
       JSON.stringify({

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 30 as const,
-      serverProtocolVersion: 30 as const,
+      clientProtocolVersion: 31 as const,
+      serverProtocolVersion: 31 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -304,7 +304,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(30);
+    expect(PROTOCOL_VERSION).toBe(31);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/coach/tests/planning-request-delivery.test.ts
+++ b/packages/coach/tests/planning-request-delivery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CreatePlanningRequestPayload } from "@enduragent/coach-contract";
 import {
   createPlanningRequestRepository,
@@ -27,25 +27,16 @@ function requestPayload(
 ): CreatePlanningRequestPayload {
   return {
     requestId: "request-1",
-    kind: "workout_review",
-    intent: "Review this Workout before I add it to my Plan.",
+    kind: "plan_change",
+    intent: "Move the tempo Workout to Wednesday.",
     source: {
       chatId: "chat-1",
       messageId: "message-1",
-      attachmentId: "attachment-1",
     },
     sourceSnapshot: {
       capturedAt: "1998-08-24T08:00:00.000Z",
-      attachment: {
-        attachmentId: "attachment-1",
-        displayName: "tempo-3x12.mrc",
-        extension: "mrc",
-      },
-      selectedWorkout: {
-        setId: "set-1",
-        workoutId: "workout-1",
-        workout: { name: "Tempo 3 × 12", sport: "cycling", durationSeconds: 3_840 },
-      },
+      attachment: null,
+      selectedWorkout: null,
     },
     requestedDate: "1998-08-26",
     ...overrides,
@@ -93,6 +84,9 @@ describe("Planning request delivery", () => {
 
   const service = (
     afterPlanningAccepted?: PlanningRequestDeliveryServiceDependencies["afterPlanningAccepted"],
+    resolveWorkoutSource?: Parameters<
+      typeof createPlanningRequestDeliveryService
+    >[0]["resolveWorkoutSource"],
   ) => {
     const crypto = createNodeCrypto();
     const plans = createPlanRepository(store);
@@ -107,6 +101,7 @@ describe("Planning request delivery", () => {
           if (latest?.status === "draft") return "draft";
           return "plan_creation";
         },
+        ...(resolveWorkoutSource === undefined ? {} : { resolveWorkoutSource }),
       },
       { afterPlanningAccepted },
     );
@@ -134,6 +129,84 @@ describe("Planning request delivery", () => {
     expect(result.status).toBe("accepted");
     if (result.status !== "accepted") throw new TypeError();
     expect(result.delivery.planningRequest?.target).toBe("plan_creation");
+  });
+
+  it("builds a trusted Workout request from the selected local attachment", async () => {
+    const resolveWorkoutSource = vi.fn(async () => ({
+      attachment: {
+        attachmentId: "attachment-1",
+        displayName: "tempo-3x12.mrc",
+        extension: "mrc" as const,
+      },
+      selectedWorkout: {
+        setId: "set-1",
+        workoutId: "workout-1",
+        workout: {
+          workoutId: "workout-1",
+          title: "Tempo 3 × 12",
+          sport: "cycling",
+          durationSeconds: 3_840,
+          purpose: "Build sustainable power",
+          segments: [],
+        },
+      },
+    }));
+    const result = await service(undefined, resolveWorkoutSource).createWorkoutPlanningRequest!({
+      requestId: "request-workout",
+      intent: "Tempo 3 × 12",
+      source: {
+        chatId: "chat-1",
+        messageId: "message-workout",
+        attachmentId: "attachment-1",
+      },
+      requestedDate: "1998-08-26",
+    });
+
+    expect(result).toMatchObject({
+      status: "accepted",
+      delivery: {
+        source: {
+          kind: "workout_review",
+          intent: "Tempo 3 × 12",
+          chatId: "chat-1",
+          messageId: "message-workout",
+          attachmentId: "attachment-1",
+        },
+        state: "delivered",
+        planningRequest: {
+          requestId: "request-workout",
+          kind: "workout_review",
+          intent: "Tempo 3 × 12",
+        },
+      },
+    });
+    expect(resolveWorkoutSource).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      attachmentId: "attachment-1",
+    });
+    const record = await createPlanningRequestRepository(store, createNodeCrypto()).read(
+      "request-workout",
+    );
+    expect(record?.sourceState.payload?.sourceSnapshot).toMatchObject({
+      attachment: { displayName: "tempo-3x12.mrc" },
+      selectedWorkout: { setId: "set-1", workoutId: "workout-1" },
+    });
+  });
+
+  it("rejects a Workout request when its local source cannot be resolved", async () => {
+    const result = await service(undefined, async () => {
+      throw new Error("missing selection");
+    }).createWorkoutPlanningRequest!({
+      requestId: "request-workout",
+      intent: "Tempo 3 × 12",
+      source: {
+        chatId: "chat-1",
+        messageId: "message-workout",
+        attachmentId: "attachment-1",
+      },
+    });
+
+    expect(result).toEqual({ status: "rejected", reason: "invalid_request" });
   });
 
   it("retries the same request after Planning accepted before Chat acknowledged", async () => {
@@ -185,6 +258,31 @@ describe("Planning request delivery", () => {
         payload: requestPayload({ intent: "Use a different intent under the same identifier." }),
       }),
     ).resolves.toEqual({ status: "rejected", reason: "request_conflict" });
+  });
+
+  it("lists current handoffs for one Chat after relaunch", async () => {
+    await service().createPlanningRequest!({ payload: requestPayload() });
+    await service().createPlanningRequest!({
+      payload: requestPayload({
+        requestId: "request-2",
+        source: { chatId: "chat-2", messageId: "message-2" },
+      }),
+    });
+
+    const result = await service().listPlanningRequests!({ chatId: "chat-1" });
+    expect(result.deliveries).toHaveLength(1);
+    expect(result.deliveries[0]).toMatchObject({
+      requestId: "request-1",
+      source: {
+        kind: "plan_change",
+        intent: "Move the tempo Workout to Wednesday.",
+        chatId: "chat-1",
+        messageId: "message-1",
+        attachmentId: null,
+      },
+      state: "delivered",
+      planningRequest: { source: { chatId: "chat-1", messageId: "message-1" } },
+    });
   });
 
   it("records a non-retryable failure when Planning owns a conflicting payload", async () => {

--- a/packages/kernel-node/tests/chat-plan-outbox-repository.test.ts
+++ b/packages/kernel-node/tests/chat-plan-outbox-repository.test.ts
@@ -179,6 +179,39 @@ describe("Chat Plan outbox repository", () => {
     expect(recoverable.map(({ requestId }) => requestId)).toEqual(["request-1", "request-2"]);
   });
 
+  it("lists durable source cards for one Chat in creation order", async () => {
+    await repository.createOrGet({
+      payload: payload({ requestId: "request-2" }),
+      createdAtMs: 102,
+    });
+    await repository.createOrGet({
+      payload: payload({ requestId: "request-1" }),
+      createdAtMs: 101,
+    });
+    await repository.createOrGet({
+      payload: payload({
+        requestId: "request-other",
+        source: {
+          chatId: "chat-2",
+          messageId: "message-other",
+          attachmentId: "attachment-1",
+        },
+      }),
+      createdAtMs: 100,
+    });
+    await repository.createOrGet({
+      payload: payload({ requestId: "request-cancelled" }),
+      createdAtMs: 103,
+    });
+    await repository.cancelUndelivered({
+      requestId: "request-cancelled",
+      cancelledAtMs: 104,
+    });
+
+    const records = await repository.readByChatId("chat-1");
+    expect(records.map(({ requestId }) => requestId)).toEqual(["request-1", "request-2"]);
+  });
+
   it("cancels an undelivered source and makes its payload irrecoverable", async () => {
     await repository.createOrGet({ payload: payload(), createdAtMs: 100 });
     await repository.beginDelivery({ requestId: REQUEST_ID, attemptedAtMs: 110 });

--- a/packages/kernel/src/chat-plan-outbox/repository.ts
+++ b/packages/kernel/src/chat-plan-outbox/repository.ts
@@ -77,6 +77,7 @@ export interface DetachDeliveredChatPlanSourceInput {
 export interface ChatPlanOutboxRepository {
   createOrGet(input: CreateChatPlanOutboxInput): Promise<ChatPlanOutboxRecord>;
   read(requestId: string): Promise<ChatPlanOutboxRecord | undefined>;
+  readByChatId(chatId: string): Promise<readonly ChatPlanOutboxRecord[]>;
   readRecoverable(): Promise<readonly ChatPlanOutboxRecord[]>;
   beginDelivery(input: BeginChatPlanDeliveryInput): Promise<ChatPlanOutboxRecord>;
   markFailed(input: FailChatPlanDeliveryInput): Promise<ChatPlanOutboxRecord>;
@@ -334,6 +335,20 @@ export function createChatPlanOutboxRepository(
     },
 
     read,
+
+    async readByChatId(chatId) {
+      if (!validId(chatId)) throw new ChatPlanOutboxStoreError("missing-outbox");
+      const rows = await store.all(
+        `SELECT request_id FROM chat_plan_outbox
+WHERE payload_json IS NOT NULL
+  AND json_extract(payload_json, '$.source.chatId') = ?
+ORDER BY created_at_ms ASC, request_id ASC`,
+        [chatId],
+      );
+      return Object.freeze(
+        await Promise.all(rows.map((row) => requireRecord(text(row, "request_id")))),
+      );
+    },
 
     async readRecoverable() {
       const rows = await store.all(


### PR DESCRIPTION
Summary:
- build trusted Workout handoff snapshots in the daemon from the selected local attachment
- prevent the generic renderer RPC from submitting fabricated Workout snapshots
- list durable Plan handoffs by exact source Chat with safe card metadata for relaunch
- expose strict renderer-safe RPC methods and advance the protocol version

Verification:
- focused contract, client, daemon, delivery, and SQLite tests passed
- root pnpm check passed
- full suite: 715 files passed, 5 skipped; 10,667 tests passed, 17 skipped
- final autoreview clean with no accepted or actionable findings