### PR TITLE
fix(chat): recover plan handoffs safely

### DIFF
--- a/.changeset/chat-plan-handoff-recovery.md
+++ b/.changeset/chat-plan-handoff-recovery.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/coach": patch
+"@enduragent/kernel": patch
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Chat safely resumes unfinished Plan handoffs after relaunch. Deleting Chat attachment data keeps delivered Plan work and its compact origin record intact.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -768,6 +768,18 @@ export function createChatController(input: {
     render();
   };
 
+  const recoverPlanningRequests = async (): Promise<void> => {
+    const client = await input.clients.getClient();
+    let recoveryFailed = false;
+    try {
+      await client.call("resumePlanningRequests", {});
+    } catch {
+      recoveryFailed = true;
+    }
+    await loadPlanningRequests(client);
+    if (recoveryFailed) throw new Error("Planning request recovery failed.");
+  };
+
   const routeToPlanningRequest = (requestId: string): void => {
     const delivery = planningRequests.find((item) => item.requestId === requestId);
     if (delivery?.state !== "delivered") return;
@@ -1259,7 +1271,7 @@ export function createChatController(input: {
         render();
       }
     });
-    const planningRequestLoadTask = loadPlanningRequests().catch(() => {
+    const planningRequestLoadTask = recoverPlanningRequests().catch(() => {
       if (!disposed) {
         planningRequestsLoaded = false;
         planningRequestError = CHAT_PLANNING_REQUEST_LOAD_FAILURE_COPY;
@@ -1443,7 +1455,7 @@ export function createChatController(input: {
       }
       planningRequestError = null;
       render();
-      void loadPlanningRequests().catch(() => {
+      void recoverPlanningRequests().catch(() => {
         if (disposed) return;
         planningRequestsLoaded = false;
         planningRequestError = CHAT_PLANNING_REQUEST_LOAD_FAILURE_COPY;

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -149,6 +149,9 @@ function client(
     readonly listPlanningRequests?: () => Promise<{
       readonly deliveries: readonly PlanningRequestDelivery[];
     }>;
+    readonly resumePlanningRequests?: () => Promise<{
+      readonly deliveries: readonly PlanningRequestDelivery[];
+    }>;
     readonly createWorkoutPlanningRequest?: (
       request: CreateWorkoutPlanningRequestRpcParams,
     ) => Promise<
@@ -204,6 +207,10 @@ function client(
     if (method === "listPlanningRequests") {
       hideQueueCall();
       return (sessions.listPlanningRequests?.() ?? Promise.resolve({ deliveries: [] })) as never;
+    }
+    if (method === "resumePlanningRequests") {
+      hideQueueCall();
+      return (sessions.resumePlanningRequests?.() ?? Promise.resolve({ deliveries: [] })) as never;
     }
     if (method === "createWorkoutPlanningRequest") {
       return (sessions.createWorkoutPlanningRequest?.(
@@ -1290,6 +1297,51 @@ describe("chat controller", () => {
       }),
     );
     expect(controls.at(-1)?.planningRequests?.value).toContainEqual(delivered);
+  });
+
+  it("resumes durable Plan handoffs before restoring their Chat cards", async () => {
+    const order: string[] = [];
+    const restored = planningDelivery();
+    const resumePlanningRequests = vi.fn(async () => {
+      order.push("resume");
+      return { deliveries: [restored] };
+    });
+    const listPlanningRequests = vi.fn(async () => {
+      order.push("list");
+      return { deliveries: [restored] };
+    });
+    const fake = client(replies(), { resumePlanningRequests, listPlanningRequests });
+    const { controller, controls } = subject(fake);
+
+    await controller.start();
+
+    expect(order).toEqual(["resume", "list"]);
+    expect(resumePlanningRequests).toHaveBeenCalledOnce();
+    expect(controls.at(-1)?.planningRequests).toMatchObject({
+      loaded: true,
+      error: null,
+      value: [restored],
+    });
+  });
+
+  it("keeps the last safe Plan cards when relaunch recovery cannot deliver", async () => {
+    const restored = planningDelivery("failed");
+    const resumePlanningRequests = vi.fn(async () => {
+      throw new Error("planning unavailable");
+    });
+    const listPlanningRequests = vi.fn(async () => ({ deliveries: [restored] }));
+    const fake = client(replies(), { resumePlanningRequests, listPlanningRequests });
+    const { controller, controls } = subject(fake);
+
+    await controller.start();
+
+    expect(resumePlanningRequests).toHaveBeenCalledOnce();
+    expect(listPlanningRequests).toHaveBeenCalledOnce();
+    expect(controls.at(-1)?.planningRequests).toMatchObject({
+      loaded: false,
+      error: expect.any(String),
+      value: [restored],
+    });
   });
 
   it("retries one saved failed Plan request without changing its identity", async () => {

--- a/apps/desktop-renderer/tests/chat-hydration-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-hydration-controller.test.ts
@@ -93,6 +93,9 @@ function coachClient(input: {
       if (method === "listPlanningRequests") {
         return Promise.resolve({ deliveries: [] }) as never;
       }
+      if (method === "resumePlanningRequests") {
+        return Promise.resolve({ deliveries: [] }) as never;
+      }
       if (method === "enqueueChatMessage") {
         const value = request as { submissionId: string; text: string };
         revision += 1;
@@ -199,9 +202,10 @@ describe("chat controller transcript hydration", () => {
       expect(readTranscriptPage).toHaveBeenCalledTimes(1);
       expect(states.at(-1)?.messages).toHaveLength(2);
     });
-    expect(client.call).toHaveBeenCalledTimes(5);
+    expect(client.call).toHaveBeenCalledTimes(6);
     expect(client.call).toHaveBeenCalledWith("hasSession", { chatId: "desktop" });
     expect(client.call).toHaveBeenCalledWith("getCoachDecision", { chatId: "desktop" });
+    expect(client.call).toHaveBeenCalledWith("resumePlanningRequests", {});
     expect(client.call).toHaveBeenCalledWith("listPlanningRequests", { chatId: "desktop" });
   });
 

--- a/packages/coach/src/attachment-operations.ts
+++ b/packages/coach/src/attachment-operations.ts
@@ -57,6 +57,7 @@ export interface ManagedChatAttachmentOperationsInput {
     readonly attachment: ChatAttachmentRow;
     readonly object: ChatAttachmentObjectRow;
   }) => Promise<void>;
+  readonly beforeConversationCleanup?: (conversationId: string) => Promise<void>;
   readonly observe?: (input: AttachmentObservation) => void;
 }
 
@@ -338,6 +339,7 @@ export function createManagedChatAttachmentOperations(
       const startedAt = now();
       try {
         const count = await input.runExclusive(async () => {
+          await input.beforeConversationCleanup?.(conversationId);
           const objects = await input.repository.cleanupConversation(conversationId);
           for (const object of objects) await input.objects.removeObject(object.relative_path);
           return objects.length;

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -190,6 +190,7 @@ import { createDocumentMediaAttachmentOperations } from "./document-media-attach
 import { createAttachmentComposerOperations } from "./attachment-composer-operations.js";
 import { createPlanningReadService } from "./planning-read-service.js";
 import { createPlanningRequestDeliveryService } from "./planning-request-delivery.js";
+import { createPlanningRequestSourceCleanup } from "./planning-request-source-cleanup.js";
 import {
   createPlanConversationRepository,
   createPlanningRequestIntakeRepository,
@@ -1035,6 +1036,7 @@ export async function createLocalCoachComposition(
     const observeAttachment = (observation: AttachmentObservation): void => {
       observeChatAttachment(logger, observation);
     };
+    let cleanupPlanningRequestSources: ((conversationId: string) => Promise<void>) | undefined;
     const attachmentRepository = createChatAttachmentRepository(input.context.store);
     const attachmentObjects = createManagedChatAttachmentStore({
       archiveDir: input.home.archiveDir,
@@ -1134,6 +1136,12 @@ export async function createLocalCoachComposition(
       runExclusive: (work) => runtime!.runExclusive(work),
       now,
       observe: observeAttachment,
+      beforeConversationCleanup: async (conversationId) => {
+        if (cleanupPlanningRequestSources === undefined) {
+          throw new Error("Planning request source cleanup is unavailable.");
+        }
+        await cleanupPlanningRequestSources(conversationId);
+      },
       onAdmitted: async (admitted) => {
         observeAttachment({
           operation: "admission",
@@ -1985,6 +1993,15 @@ export async function createLocalCoachComposition(
       input.context.store,
       analysisCrypto,
     );
+    const chatPlanOutboxRepository = createChatPlanOutboxRepository(
+      input.context.store,
+      analysisCrypto,
+    );
+    cleanupPlanningRequestSources = createPlanningRequestSourceCleanup({
+      outbox: chatPlanOutboxRepository,
+      requests: planningRequestRepository,
+      identity: planningIdentity,
+    });
     const planConversationRepository = createPlanConversationRepository(input.context.store);
     const planningRequestIntake = createPlanningRequestIntakeService({
       requests: planningRequestRepository,
@@ -2014,7 +2031,7 @@ export async function createLocalCoachComposition(
     );
     const planningRequestOperations = createPlanningRequestDeliveryService(
       {
-        outbox: createChatPlanOutboxRepository(input.context.store, analysisCrypto),
+        outbox: chatPlanOutboxRepository,
         requests: planningRequestRepository,
         identity: planningIdentity,
         async resolveTarget() {

--- a/packages/coach/src/planning-request-source-cleanup.ts
+++ b/packages/coach/src/planning-request-source-cleanup.ts
@@ -1,0 +1,120 @@
+import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+import type {
+  CreatePlanningRequestPayload,
+  PlanningRequestProvenanceSnapshot,
+  PlanningRequestRecord,
+  PlanningRequestRepository,
+} from "@enduragent/kernel/planning";
+import type { ChatPlanOutboxRepository } from "@enduragent/kernel/store";
+
+export interface PlanningRequestSourceCleanupInput {
+  readonly outbox: ChatPlanOutboxRepository;
+  readonly requests: PlanningRequestRepository;
+  readonly identity: AuthoredIdentity;
+}
+
+function intentSummary(intent: string): string {
+  const normalized = intent.trim().replace(/\s+/gu, " ");
+  return (normalized.length === 0 ? "Plan request" : normalized).slice(0, 2_000);
+}
+
+function workoutSummary(
+  payload: CreatePlanningRequestPayload,
+): PlanningRequestProvenanceSnapshot["workout"] {
+  const selected = payload.sourceSnapshot.selectedWorkout;
+  if (selected === null) return null;
+  const title = selected.workout.title;
+  const sport = selected.workout.sport;
+  const durationSeconds = selected.workout.durationSeconds;
+  if (
+    typeof title !== "string" ||
+    title.length === 0 ||
+    typeof sport !== "string" ||
+    sport.length === 0 ||
+    !Number.isSafeInteger(durationSeconds) ||
+    (durationSeconds as number) <= 0
+  ) {
+    throw new TypeError("Planning request Workout provenance is unavailable.");
+  }
+  return {
+    setId: selected.setId,
+    workoutId: selected.workoutId,
+    name: title,
+    sport,
+    durationSeconds: durationSeconds as number,
+  };
+}
+
+function provenance(record: PlanningRequestRecord): PlanningRequestProvenanceSnapshot {
+  const payload = record.sourceState.payload;
+  if (payload === null) throw new TypeError("Planning request source is unavailable.");
+  return {
+    requestId: payload.requestId,
+    kind: payload.kind,
+    intentSummary: intentSummary(payload.intent),
+    source: {
+      chatId: payload.source.chatId,
+      messageId: payload.source.messageId,
+      sourceDeleted: true,
+    },
+    attachment: payload.sourceSnapshot.attachment,
+    workout: workoutSummary(payload),
+    capturedAt: payload.sourceSnapshot.capturedAt,
+  };
+}
+
+export function createPlanningRequestSourceCleanup(
+  input: PlanningRequestSourceCleanupInput,
+): (chatId: string) => Promise<void> {
+  return async (chatId) => {
+    const deviceId = await input.identity.deviceId();
+    const outboxRecords = await input.outbox.readByChatId(chatId);
+    for (const outboxRecord of outboxRecords) {
+      if (outboxRecord.state === "pending" || outboxRecord.state === "failed") {
+        const stamp = input.identity.hlcStamp();
+        await input.outbox.cancelUndelivered({
+          requestId: outboxRecord.requestId,
+          cancelledAtMs: stamp.physicalMs,
+        });
+        continue;
+      }
+      if (outboxRecord.state !== "delivered") continue;
+
+      let request = await input.requests.read(outboxRecord.requestId);
+      if (request === undefined || request.payloadHash !== outboxRecord.payloadHash) {
+        throw new TypeError("Delivered Planning request is unavailable.");
+      }
+      if (request.sourceState.status === "linked") {
+        const stamp = input.identity.hlcStamp();
+        request = await input.requests.detachSource({
+          requestId: request.request.requestId,
+          expectedRevision: request.request.revision,
+          provenance: provenance(request),
+          updatedAtMs: stamp.physicalMs,
+          deviceId,
+          hlcPhysicalMs: stamp.physicalMs,
+          hlcCounter: stamp.counter,
+        });
+      }
+      if (
+        request.request.lifecycle !== "open" &&
+        request.sourceState.status === "detached_open"
+      ) {
+        const stamp = input.identity.hlcStamp();
+        request = await input.requests.compactSource({
+          requestId: request.request.requestId,
+          expectedRevision: request.request.revision,
+          updatedAtMs: stamp.physicalMs,
+          deviceId,
+          hlcPhysicalMs: stamp.physicalMs,
+          hlcCounter: stamp.counter,
+        });
+      }
+      const stamp = input.identity.hlcStamp();
+      await input.outbox.detachDeliveredSource({
+        requestId: outboxRecord.requestId,
+        sourceDeletedAtMs: stamp.physicalMs,
+      });
+    }
+  };
+}

--- a/packages/coach/tests/attachment-operations.test.ts
+++ b/packages/coach/tests/attachment-operations.test.ts
@@ -29,6 +29,9 @@ describe("managed Chat attachment operations", () => {
   function createOperations(
     ids: readonly string[],
     observe?: Parameters<typeof createManagedChatAttachmentOperations>[0]["observe"],
+    beforeConversationCleanup?: Parameters<
+      typeof createManagedChatAttachmentOperations
+    >[0]["beforeConversationCleanup"],
   ) {
     let index = 0;
     const repository = createChatAttachmentRepository(store);
@@ -51,6 +54,7 @@ describe("managed Chat attachment operations", () => {
         now: () => 100,
         randomId: () => ids[index++]!,
         ...(observe === undefined ? {} : { observe }),
+        ...(beforeConversationCleanup === undefined ? {} : { beforeConversationCleanup }),
       }),
     };
   }
@@ -311,5 +315,34 @@ describe("managed Chat attachment operations", () => {
       },
     ]);
     expect(JSON.stringify(observations)).not.toContain("desktop");
+  });
+
+  it("keeps attachment bytes when the destination cleanup barrier fails", async () => {
+    const sourcePath = join(root, "protected.txt");
+    await writeFile(sourcePath, "preserve until Plan provenance is safe");
+    const beforeConversationCleanup = vi.fn(async () => {
+      throw new Error("destination unavailable");
+    });
+    const { operations, repository } = createOperations(
+      ["object-protected", "attachment-protected"],
+      undefined,
+      beforeConversationCleanup,
+    );
+    await operations.admit({
+      chatId: "desktop",
+      selectionId: "selection-protected",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath },
+    });
+    const object = (await repository.readObject("object-protected"))!;
+
+    await expect(operations.cleanupConversation("desktop")).rejects.toThrow(
+      "destination unavailable",
+    );
+    expect(beforeConversationCleanup).toHaveBeenCalledWith("desktop");
+    await expect(repository.readObject("object-protected")).resolves.toBeDefined();
+    await expect(
+      readFile(join(archiveDir, ...object.relative_path.split("/")), "utf8"),
+    ).resolves.toBe("preserve until Plan provenance is safe");
   });
 });

--- a/packages/coach/tests/planning-request-source-cleanup.test.ts
+++ b/packages/coach/tests/planning-request-source-cleanup.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CreatePlanningRequestPayload } from "@enduragent/coach-contract";
+import {
+  createPlanningRequestRepository,
+  type PlanningRequestTerminalResult,
+} from "@enduragent/kernel/planning";
+import {
+  createChatPlanOutboxRepository,
+  runMigrations,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createNodeCrypto } from "@enduragent/kernel-node/ingest";
+import type { AuthoredIdentity } from "@enduragent/kernel-node/home";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { createPlanningRequestSourceCleanup } from "../src/planning-request-source-cleanup.js";
+
+function payload(
+  requestId: string,
+  messageId: string,
+  overrides: Partial<CreatePlanningRequestPayload> = {},
+): CreatePlanningRequestPayload {
+  return {
+    requestId,
+    kind: "workout_review",
+    intent: "  Review Tempo 3 × 12 before adding it to the Plan.  ",
+    source: {
+      chatId: "chat-1",
+      messageId,
+      attachmentId: `attachment-${requestId}`,
+    },
+    sourceSnapshot: {
+      capturedAt: "1998-08-24T08:00:00.000Z",
+      attachment: {
+        attachmentId: `attachment-${requestId}`,
+        displayName: "tempo-3x12.mrc",
+        extension: "mrc",
+      },
+      selectedWorkout: {
+        setId: `set-${requestId}`,
+        workoutId: `workout-${requestId}`,
+        workout: {
+          title: "Tempo 3 × 12",
+          sport: "cycling",
+          durationSeconds: 3_840,
+          segments: [],
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+function terminal(requestId: string): PlanningRequestTerminalResult {
+  return {
+    kind: "applied",
+    resultId: `result-${requestId}`,
+    completedAtMs: 180,
+    title: "Workout added",
+    detail: "Tempo 3 × 12 was added to Wednesday.",
+    workoutRef: {
+      setId: `set-${requestId}`,
+      workoutId: `workout-${requestId}`,
+    },
+    planRevisionId: `revision-${requestId}`,
+  };
+}
+
+describe("Planning request source cleanup", () => {
+  let store: SqlStore & MigratorStore;
+  let instant: number;
+  let identity: AuthoredIdentity;
+
+  beforeEach(async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    instant = 200;
+    identity = {
+      deviceId: async () => "device-1",
+      newUlid: () => "01J60HFQ7T0000000000000001",
+      hlcStamp: () => ({ physicalMs: instant++, counter: 0 }),
+    };
+  });
+
+  afterEach(async () => store.close());
+
+  it("cancels undelivered sources and preserves delivered Plan truth", async () => {
+    const crypto = createNodeCrypto();
+    const outbox = createChatPlanOutboxRepository(store, crypto);
+    const requests = createPlanningRequestRepository(store, crypto);
+    const pendingPayload = payload("pending", "message-pending");
+    const failedPayload = payload("failed", "message-failed");
+    const openPayload = payload("open", "message-open");
+    const terminalPayload = payload("terminal", "message-terminal");
+
+    await outbox.createOrGet({ payload: pendingPayload, createdAtMs: 100 });
+    await outbox.createOrGet({ payload: failedPayload, createdAtMs: 101 });
+    await outbox.beginDelivery({ requestId: "failed", attemptedAtMs: 102 });
+    await outbox.markFailed({
+      requestId: "failed",
+      failureCode: "planning_unavailable",
+      retryable: true,
+      failedAtMs: 103,
+    });
+
+    for (const [createdAtMs, requestPayload] of [
+      [104, openPayload],
+      [108, terminalPayload],
+    ] as const) {
+      await outbox.createOrGet({ payload: requestPayload, createdAtMs });
+      await outbox.beginDelivery({
+        requestId: requestPayload.requestId,
+        attemptedAtMs: createdAtMs + 1,
+      });
+      await requests.createOrGet({
+        payload: requestPayload,
+        target: "active_plan",
+        createdAtMs: createdAtMs + 2,
+        deviceId: "device-1",
+        hlcPhysicalMs: createdAtMs + 2,
+        hlcCounter: 0,
+      });
+      await outbox.markDelivered({
+        requestId: requestPayload.requestId,
+        deliveredAtMs: createdAtMs + 3,
+      });
+    }
+    await requests.complete({
+      requestId: "terminal",
+      expectedRevision: 1,
+      result: terminal("terminal"),
+      resolvedDateKey: 19980826,
+      updatedAtMs: 190,
+      deviceId: "device-1",
+      hlcPhysicalMs: 190,
+      hlcCounter: 0,
+    });
+
+    await createPlanningRequestSourceCleanup({ outbox, requests, identity })("chat-1");
+
+    await expect(outbox.read("pending")).resolves.toMatchObject({
+      state: "cancelled",
+      payload: null,
+      cancelReason: "source_conversation_deleted",
+    });
+    await expect(outbox.read("failed")).resolves.toMatchObject({
+      state: "cancelled",
+      payload: null,
+      cancelReason: "source_conversation_deleted",
+    });
+    await expect(outbox.read("open")).resolves.toMatchObject({
+      state: "delivered",
+      payload: null,
+      sourceDeletedAtMs: expect.any(Number),
+    });
+    await expect(requests.read("open")).resolves.toMatchObject({
+      request: { lifecycle: "open", source: { available: false } },
+      sourceState: {
+        status: "detached_open",
+        payload: openPayload,
+        provenance: {
+          intentSummary: "Review Tempo 3 × 12 before adding it to the Plan.",
+          source: { sourceDeleted: true },
+          attachment: { displayName: "tempo-3x12.mrc" },
+          workout: {
+            name: "Tempo 3 × 12",
+            sport: "cycling",
+            durationSeconds: 3_840,
+          },
+        },
+      },
+    });
+    await expect(requests.read("terminal")).resolves.toMatchObject({
+      request: { lifecycle: "applied", source: { available: false } },
+      sourceState: {
+        status: "compacted",
+        payload: null,
+        provenance: { source: { sourceDeleted: true } },
+      },
+      tombstone: { status: "applied" },
+    });
+  });
+
+  it("is idempotent after a delivered source was detached", async () => {
+    const crypto = createNodeCrypto();
+    const outbox = createChatPlanOutboxRepository(store, crypto);
+    const requests = createPlanningRequestRepository(store, crypto);
+    const requestPayload = payload("open", "message-open");
+    await outbox.createOrGet({ payload: requestPayload, createdAtMs: 100 });
+    await outbox.beginDelivery({ requestId: "open", attemptedAtMs: 101 });
+    await requests.createOrGet({
+      payload: requestPayload,
+      target: "active_plan",
+      createdAtMs: 102,
+      deviceId: "device-1",
+      hlcPhysicalMs: 102,
+      hlcCounter: 0,
+    });
+    await outbox.markDelivered({ requestId: "open", deliveredAtMs: 103 });
+    const cleanup = createPlanningRequestSourceCleanup({ outbox, requests, identity });
+
+    await cleanup("chat-1");
+    await expect(cleanup("chat-1")).resolves.toBeUndefined();
+    await expect(requests.read("open")).resolves.toMatchObject({
+      request: { revision: 2 },
+      sourceState: { status: "detached_open" },
+    });
+  });
+});

--- a/packages/kernel-node/tests/planning-request-repository.test.ts
+++ b/packages/kernel-node/tests/planning-request-repository.test.ts
@@ -459,4 +459,41 @@ describe("Planning request repository", () => {
     expect(compacted.request.terminalResult).toEqual(terminal());
     expect(compacted.tombstone?.status).toBe("applied");
   });
+
+  it("compacts an already detached source in the terminal commit", async () => {
+    await repository.createOrGet(createInput());
+    await repository.detachSource({
+      requestId: REQUEST_ID,
+      expectedRevision: 1,
+      provenance: provenance(),
+      updatedAtMs: 200,
+      deviceId: "device-1",
+      hlcPhysicalMs: 200,
+      hlcCounter: 0,
+    });
+
+    const completed = await repository.complete({
+      requestId: REQUEST_ID,
+      expectedRevision: 2,
+      result: terminal(),
+      resolvedDateKey: 19980826,
+      updatedAtMs: 300,
+      deviceId: "device-1",
+      hlcPhysicalMs: 300,
+      hlcCounter: 0,
+    });
+
+    expect(completed.request.revision).toBe(3);
+    expect(completed.request.lifecycle).toBe("applied");
+    expect(completed.sourceState).toEqual({
+      status: "compacted",
+      identity: {
+        chatId: "chat-1",
+        messageId: "message-1",
+        attachmentId: "attachment-1",
+      },
+      payload: null,
+      provenance: provenance(),
+    });
+  });
 });

--- a/packages/kernel/src/planning/request-repository.ts
+++ b/packages/kernel/src/planning/request-repository.ts
@@ -933,8 +933,19 @@ WHERE request_id = ? AND lifecycle = 'open' AND revision = ?`,
           expectedProposalId: current.request.proposalId,
           result,
         });
+        if (current.sourceState.status === "detached_open") {
+          await store.run(
+            `UPDATE planning_request SET source_status = 'compacted', payload_json = NULL
+WHERE request_id = ? AND source_status = 'detached_open' AND revision = ?`,
+            [input.requestId, input.expectedRevision + 1],
+          );
+        }
         const updated = await requireRequest(input.requestId);
-        if (updated.request.revision !== input.expectedRevision + 1) {
+        if (
+          updated.request.revision !== input.expectedRevision + 1 ||
+          (current.sourceState.status === "detached_open" &&
+            updated.sourceState.status !== "compacted")
+        ) {
           throw new PlanningRequestStoreError("stale-revision");
         }
         return updated;


### PR DESCRIPTION
Summary:
- resume durable Chat to Plan handoffs before restoring their cards
- preserve delivered Plan work when Chat attachment data is deleted
- cancel undelivered requests and compact terminal provenance safely

Verification:
- root pnpm check
- full suite: 716 files passed, 5 skipped; 10,681 tests passed, 17 skipped
- focused recovery suite: 79 tests passed
- isolated timeout recheck: 15 tests passed
- autoreview clean with no actionable findings