### PR TITLE
feat(chat): close plan handoff acceptance

### DIFF
--- a/.changeset/chat-plan-acceptance.md
+++ b/.changeset/chat-plan-acceptance.md
@@ -1,0 +1,13 @@
+---
+"@enduragent/coach-contract": patch
+"@enduragent/kernel": patch
+"@enduragent/engine": patch
+"@enduragent/core": patch
+"@enduragent/coach": patch
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Coach answers can now offer a safe Continue in Plan card, resolve Workout date conflicts, retry failed handoffs without duplicates, and recover a Proposal when a local Plan save fails.
+
+Chat keeps typed Plan handoffs with their transcript turn, while Plan protects athlete-created Workouts and requires review before applying a new date or replacing a coach-owned Workout.

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -285,6 +285,8 @@ export function bootRenderer(): Disposer {
     approveProposal: (proposalId, expectedRevision) =>
       planAdapter.approveProposal(proposalId, expectedRevision),
     rejectProposal: (proposalId) => planAdapter.rejectProposal(proposalId),
+    resolvePlanningRequestDate: (requestId, resolution) =>
+      planAdapter.resolvePlanningRequestDate(requestId, resolution),
     openHistory: () => planAdapter.openHistory(),
     closeHistory: () => planAdapter.closeHistory(),
     undoPlanChange: (ledgerId) => planAdapter.undoPlanChange(ledgerId),
@@ -339,8 +341,9 @@ export function bootRenderer(): Disposer {
     retryAttachment: (attachmentId) => chatController.retryAttachment(attachmentId),
     selectAttachmentWorkout: (attachmentId, workoutId) =>
       chatController.selectAttachmentWorkout(attachmentId, workoutId),
-    reviewAttachmentInPlan: (attachmentId) =>
-      chatController.reviewAttachmentInPlan(attachmentId),
+    reviewAttachmentInPlan: (attachmentId) => chatController.reviewAttachmentInPlan(attachmentId),
+    continueMessageInPlan: (messageId, suggestion) =>
+      chatController.continueMessageInPlan(messageId, suggestion),
     openPlanningRequest: (requestId) => chatController.openPlanningRequest(requestId),
     retryPlanningRequest: (requestId) => chatController.retryPlanningRequest(requestId),
     retryPlanningRequestLoad: () => chatController.retryPlanningRequestLoad(),

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -16,7 +16,9 @@ import type {
   CoachDecisionReadModel,
   ChatQueueSnapshot,
   CoachTurnEventNotificationEnvelope,
+  CreatePlanningRequestRpcParams,
   CreateWorkoutPlanningRequestRpcParams,
+  PlanHandoffSuggestion,
   PlanningRequestDelivery,
   TranscriptPageEntry,
   TurnEvent,
@@ -61,7 +63,7 @@ export const CHAT_ATTACHMENT_FAILURE_COPY =
 export const CHAT_PLANNING_REQUEST_LOAD_FAILURE_COPY =
   "We couldn’t check saved Plan requests. Reconnect and try again.";
 export const CHAT_PLANNING_REQUEST_FAILURE_COPY =
-  "Plan couldn’t receive this request. The parsed workout is still here.";
+  "Plan couldn’t receive this request. Your request is preserved and nothing changed in Plan.";
 export const NEW_CONVERSATION_SUCCESS_COPY = "New conversation started.";
 export const NEW_CONVERSATION_MEMORY_WARNING_COPY =
   "New conversation started. Some recent details may not have been saved to coach memory.";
@@ -127,6 +129,7 @@ export interface ChatController {
   retryAttachment(attachmentId: string): void;
   selectAttachmentWorkout(attachmentId: string, workoutId: string): void;
   reviewAttachmentInPlan(attachmentId: string): void;
+  continueMessageInPlan(messageId: string, suggestion: PlanHandoffSuggestion): void;
   openPlanningRequest(requestId: string): void;
   retryPlanningRequest(requestId: string): void;
   retryPlanningRequestLoad(): void;
@@ -164,6 +167,16 @@ interface ActiveStopRequest {
   readonly requestKey: number;
   request(): void;
 }
+
+type PendingPlanningRequestCreate =
+  | {
+      readonly kind: "generic";
+      readonly request: CreatePlanningRequestRpcParams;
+    }
+  | {
+      readonly kind: "workout";
+      readonly request: CreateWorkoutPlanningRequestRpcParams;
+    };
 
 export function createChatController(input: {
   readonly clients: DesktopCoachClientProvider;
@@ -223,7 +236,7 @@ export function createChatController(input: {
   let planningRequestBusyId: string | null = null;
   let planningRequestError: string | null = null;
   let planningRequestFocusId: string | null = null;
-  let pendingPlanningRequestCreate: CreateWorkoutPlanningRequestRpcParams | null = null;
+  let pendingPlanningRequestCreate: PendingPlanningRequestCreate | null = null;
   let decisionContinuationTask: Promise<void> | undefined;
   let epoch = 0;
   const canChat = input.canChat ?? (() => true);
@@ -823,11 +836,9 @@ export function createChatController(input: {
       });
   };
 
-  const deliverWorkoutPlanningRequest = (
-    request: CreateWorkoutPlanningRequestRpcParams,
-  ): void => {
+  const deliverWorkoutPlanningRequest = (request: CreateWorkoutPlanningRequestRpcParams): void => {
     if (disposed || planningRequestBusyId !== null) return;
-    pendingPlanningRequestCreate = request;
+    pendingPlanningRequestCreate = { kind: "workout", request };
     planningRequestBusyId = request.requestId;
     planningRequestError = null;
     render();
@@ -848,6 +859,38 @@ export function createChatController(input: {
         planningRequestError = null;
         render();
         routeToPlanningRequest(request.requestId);
+      })
+      .catch(() => {
+        if (disposed) return;
+        planningRequestBusyId = null;
+        planningRequestError = CHAT_PLANNING_REQUEST_FAILURE_COPY;
+        render();
+      });
+  };
+
+  const deliverPlanningRequest = (request: CreatePlanningRequestRpcParams): void => {
+    if (disposed || planningRequestBusyId !== null) return;
+    pendingPlanningRequestCreate = { kind: "generic", request };
+    planningRequestBusyId = request.payload.requestId;
+    planningRequestError = null;
+    render();
+    void input.clients
+      .getClient()
+      .then((client) => client.call("createPlanningRequest", request))
+      .then((result) => {
+        if (disposed) return;
+        planningRequestBusyId = null;
+        if (result.status === "rejected") {
+          pendingPlanningRequestCreate = null;
+          planningRequestError = CHAT_PLANNING_REQUEST_FAILURE_COPY;
+          render();
+          return;
+        }
+        pendingPlanningRequestCreate = null;
+        replacePlanningRequest(result.delivery);
+        planningRequestError = null;
+        render();
+        routeToPlanningRequest(request.payload.requestId);
       })
       .catch(() => {
         if (disposed) return;
@@ -1440,6 +1483,44 @@ export function createChatController(input: {
         },
       });
     },
+    continueMessageInPlan(messageId, suggestion) {
+      if (
+        disposed ||
+        resetBlocksWork() ||
+        !planningRequestsLoaded ||
+        planningRequestBusyId !== null
+      ) {
+        return;
+      }
+      const existing = planningRequests.find(
+        (delivery) => delivery.source?.messageId === messageId && delivery.state !== "cancelled",
+      );
+      if (existing !== undefined) {
+        if (existing.state === "failed" && existing.retryable) {
+          retrySavedPlanningRequest(existing.requestId);
+        } else {
+          routeToPlanningRequest(existing.requestId);
+        }
+        return;
+      }
+      const requestId = globalThis.crypto.randomUUID();
+      deliverPlanningRequest({
+        payload: {
+          requestId,
+          kind: suggestion.kind,
+          intent: suggestion.intent,
+          source: { chatId: DESKTOP_CHAT_ID, messageId },
+          sourceSnapshot: {
+            capturedAt: new Date().toISOString(),
+            attachment: null,
+            selectedWorkout: null,
+          },
+          ...(suggestion.requestedDate === undefined
+            ? {}
+            : { requestedDate: suggestion.requestedDate }),
+        },
+      });
+    },
     openPlanningRequest(requestId) {
       if (disposed) return;
       routeToPlanningRequest(requestId);
@@ -1450,7 +1531,11 @@ export function createChatController(input: {
     retryPlanningRequestLoad() {
       if (disposed || planningRequestBusyId !== null) return;
       if (pendingPlanningRequestCreate !== null) {
-        deliverWorkoutPlanningRequest(pendingPlanningRequestCreate);
+        if (pendingPlanningRequestCreate.kind === "generic") {
+          deliverPlanningRequest(pendingPlanningRequestCreate.request);
+        } else {
+          deliverWorkoutPlanningRequest(pendingPlanningRequestCreate.request);
+        }
         return;
       }
       planningRequestError = null;

--- a/apps/desktop-renderer/src/chat/hydration.ts
+++ b/apps/desktop-renderer/src/chat/hydration.ts
@@ -11,6 +11,7 @@ export interface TranscriptTurn {
   readonly coachText: string;
   readonly attachments?: Extract<TranscriptPageEntry, { readonly kind: "turn" }>["attachments"];
   readonly planReference?: Extract<TranscriptPageEntry, { readonly kind: "turn" }>["planReference"];
+  readonly planHandoff?: Extract<TranscriptPageEntry, { readonly kind: "turn" }>["planHandoff"];
 }
 
 export type TranscriptPage =
@@ -135,6 +136,7 @@ export function mergeHydratedMessages(
           delivery: entry.delivery ?? "complete",
           historical: true,
           ...(entry.planReference === undefined ? {} : { planReference: entry.planReference }),
+          ...(entry.planHandoff === undefined ? {} : { planHandoff: entry.planHandoff }),
         },
       ];
     }

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -91,6 +91,7 @@ function historicalTimeline(
             historical: true,
             text: entry.coachText,
             ...(entry.planReference === undefined ? {} : { planReference: entry.planReference }),
+            ...(entry.planHandoff === undefined ? {} : { planHandoff: entry.planHandoff }),
           },
         },
       );
@@ -189,6 +190,7 @@ export function createChatViewAdapter(input: {
       text: input.bufferStreaming !== false && isStreamingCoach(message) ? "" : message.text,
       ...(message.attachments === undefined ? {} : { attachments: message.attachments }),
       ...(message.planReference === undefined ? {} : { planReference: message.planReference }),
+      ...(message.planHandoff === undefined ? {} : { planHandoff: message.planHandoff }),
     }));
     const workBlocked =
       controls?.workBlocked ??
@@ -244,7 +246,7 @@ export function createChatViewAdapter(input: {
     const planningRequests =
       controls?.planningRequests?.value ?? EMPTY_CHAT_SURFACE.planningRequests;
     const planningItems: ChatTranscriptItemView[] = planningRequests
-      .filter((delivery) => delivery.state === "pending" || delivery.state === "delivered")
+      .filter((delivery) => delivery.state !== "cancelled")
       .map((delivery) => ({ kind: "planning-request", delivery }));
     const timeline = [...historicalItems, ...liveItems, ...planningItems];
     const decisionBlocksWork =

--- a/apps/desktop-renderer/src/state/adapters/plan.ts
+++ b/apps/desktop-renderer/src/state/adapters/plan.ts
@@ -90,6 +90,12 @@ export interface PlanViewAdapter {
   reviseProposal(proposalId: string, text: string): void;
   approveProposal(proposalId: string, expectedRevision: number): void;
   rejectProposal(proposalId: string): void;
+  resolvePlanningRequestDate(
+    requestId: string,
+    resolution:
+      | { readonly kind: "use-date"; readonly date: string }
+      | { readonly kind: "replace-workout"; readonly workoutId: string },
+  ): void;
   openHistory(): void;
   closeHistory(): void;
   undoPlanChange(ledgerId: string): void;
@@ -1236,6 +1242,15 @@ export function createPlanViewAdapter(input: {
         ...(selectedProposalReturn === null || selectedProposalReturn === undefined
           ? {}
           : { selectedProposalReturn }),
+      });
+    },
+    resolvePlanningRequestDate(requestId, resolution) {
+      if (active !== null) return;
+      void execute({
+        transitionId: "PL-T40",
+        commandId: createCommandId(),
+        requestId,
+        resolution,
       });
     },
     openHistory() {

--- a/apps/desktop-renderer/src/state/chat-slice.ts
+++ b/apps/desktop-renderer/src/state/chat-slice.ts
@@ -5,6 +5,7 @@ import type {
   CoachDecisionAnswer,
   CoachDecisionReadModel,
   PlanningRequestDelivery,
+  PlanHandoffSuggestion,
 } from "@enduragent/coach-contract";
 import type { StateCreator } from "zustand";
 import type { TranscriptHydrationChange, TranscriptHydrationStatus } from "../chat/hydration.js";
@@ -22,6 +23,7 @@ export interface ChatMessageView {
   readonly text: string;
   readonly attachments?: ChatTranscriptMessage["attachments"];
   readonly planReference?: ChatTranscriptMessage["planReference"];
+  readonly planHandoff?: ChatTranscriptMessage["planHandoff"];
 }
 
 export interface ChatQueuedView {
@@ -94,6 +96,7 @@ export interface ChatActions {
   retryAttachment(attachmentId: string): void;
   selectAttachmentWorkout(attachmentId: string, workoutId: string): void;
   reviewAttachmentInPlan(attachmentId: string): void;
+  continueMessageInPlan(messageId: string, suggestion: PlanHandoffSuggestion): void;
   openPlanningRequest(requestId: string): void;
   retryPlanningRequest(requestId: string): void;
   retryPlanningRequestLoad(): void;
@@ -181,6 +184,7 @@ export function sameChatMessages(
       message.historical === other.historical &&
       message.text === other.text &&
       JSON.stringify(message.planReference) === JSON.stringify(other.planReference) &&
+      JSON.stringify(message.planHandoff) === JSON.stringify(other.planHandoff) &&
       sameAttachments(message.attachments, other.attachments)
     );
   });

--- a/apps/desktop-renderer/src/state/plan-slice.ts
+++ b/apps/desktop-renderer/src/state/plan-slice.ts
@@ -115,6 +115,12 @@ export interface PlanActions {
   reviseProposal(proposalId: string, text: string): void;
   approveProposal(proposalId: string, expectedRevision: number): void;
   rejectProposal(proposalId: string): void;
+  resolvePlanningRequestDate(
+    requestId: string,
+    resolution:
+      | { readonly kind: "use-date"; readonly date: string }
+      | { readonly kind: "replace-workout"; readonly workoutId: string },
+  ): void;
   openHistory(): void;
   closeHistory(): void;
   undoPlanChange(ledgerId: string): void;

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -3,6 +3,7 @@ import type {
   ChatQueueRecoveryClaim,
   ChatQueueSnapshot,
   PlanReferenceSelection,
+  PlanHandoffSuggestion,
   TurnEvent,
 } from "@enduragent/coach-contract";
 import { isSlashCommandText } from "./chat/commands.js";
@@ -49,6 +50,7 @@ export interface ChatTranscriptMessage {
   readonly historical?: boolean;
   readonly attachments?: readonly ChatSentAttachment[];
   readonly planReference?: PlanReferenceSelection;
+  readonly planHandoff?: PlanHandoffSuggestion;
 }
 
 export type ChatSentAttachment = Pick<
@@ -293,6 +295,17 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
             messages: state.messages.map((message) =>
               message.id === active.assistantMessageId
                 ? { ...message, planReference: selection }
+                : message,
+            ),
+          };
+        }
+        case "plan-handoff": {
+          const suggestion = action.event.suggestion;
+          return {
+            ...state,
+            messages: state.messages.map((message) =>
+              message.id === active.assistantMessageId
+                ? { ...message, planHandoff: suggestion }
                 : message,
             ),
           };

--- a/apps/desktop-renderer/src/ui/chat/AttachmentPanel.tsx
+++ b/apps/desktop-renderer/src/ui/chat/AttachmentPanel.tsx
@@ -1,7 +1,6 @@
 import type {
   AttachmentAdmissionReadModel,
   ChatAttachmentComposerItem,
-  PlanningRequestDelivery,
 } from "@enduragent/coach-contract";
 import {
   Activity,
@@ -87,9 +86,7 @@ function Note(props: {
 function ReadyPreview(props: { readonly attachment: ChatAttachmentComposerItem }): ReactElement {
   const actions = useEnduragentStore((state) => state.chatActions);
   const planningRequestsLoaded = useEnduragentStore((state) => state.chat.planningRequestsLoaded);
-  const planningRequestBusyId = useEnduragentStore(
-    (state) => state.chat.planningRequestBusyId,
-  );
+  const planningRequestBusyId = useEnduragentStore((state) => state.chat.planningRequestBusyId);
   const attachment = props.attachment;
   if (attachment.status !== "ready") throw new TypeError("attachment is not ready");
   if (attachment.preview.kind === "document") {
@@ -337,64 +334,15 @@ function AdmissionFailure(props: {
   );
 }
 
-function PlanningRequestFailure(props: {
-  readonly delivery: PlanningRequestDelivery;
-}): ReactElement {
-  const actions = useEnduragentStore((state) => state.chatActions);
-  const busyId = useEnduragentStore((state) => state.chat.planningRequestBusyId);
-  return (
-    <section
-      className="overflow-hidden rounded-card border border-danger/40 bg-surface shadow-elev-2"
-      role="alert"
-      data-planning-request-id={props.delivery.requestId}
-    >
-      <div className="flex min-h-14 items-center gap-3 px-4 py-2">
-        <span className="flex size-10 shrink-0 items-center justify-center rounded-md bg-bg-2 text-danger">
-          <CalendarDays className="size-5" aria-hidden="true" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <strong className="block truncate text-sm">
-            {props.delivery.source?.intent ?? "Plan request"}
-          </strong>
-          <small className="mt-1 block text-xs text-ink-2">Workout preserved</small>
-        </div>
-      </div>
-      <Note
-        tone="warning"
-        title="Plan couldn’t receive this request"
-        action={
-          props.delivery.retryable ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={actions === null || busyId !== null}
-              onClick={() => actions?.retryPlanningRequest(props.delivery.requestId)}
-            >
-              {busyId === props.delivery.requestId ? "Trying again…" : "Try again"}
-            </Button>
-          ) : undefined
-        }
-      >
-        The parsed workout and request are still here; retrying will not create a duplicate.
-      </Note>
-    </section>
-  );
-}
-
 export function AttachmentPanel(): ReactElement | null {
   const surface = useEnduragentStore((state) => state.chat);
   const actions = useEnduragentStore((state) => state.chatActions);
   const attachments = surface.attachments?.draft?.attachments ?? [];
-  const failedPlanningRequests = surface.planningRequests.filter(
-    (delivery) => delivery.state === "failed",
-  );
   if (
     attachments.length === 0 &&
     surface.attachmentAdmissions.length === 0 &&
     !surface.attachmentBusy &&
     surface.attachmentError === null &&
-    failedPlanningRequests.length === 0 &&
     surface.planningRequestError === null
   ) {
     return null;
@@ -435,9 +383,6 @@ export function AttachmentPanel(): ReactElement | null {
           </Button>
         </div>
       )}
-      {failedPlanningRequests.map((delivery) => (
-        <PlanningRequestFailure key={delivery.requestId} delivery={delivery} />
-      ))}
       {surface.attachmentAdmissions.map((admission) => (
         <AdmissionFailure key={admission.selectionId} admission={admission} />
       ))}

--- a/apps/desktop-renderer/src/ui/chat/Transcript.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Transcript.tsx
@@ -8,7 +8,7 @@ import {
   X,
 } from "lucide-react";
 import type { ReactElement } from "react";
-import type { PlanningRequestDelivery } from "@enduragent/coach-contract";
+import type { PlanHandoffSuggestion, PlanningRequestDelivery } from "@enduragent/coach-contract";
 import type {
   ChatChoiceView,
   ChatMessageView,
@@ -23,11 +23,57 @@ import { HistoryControls } from "./HistoryControls.js";
 import { PlanReferenceCard } from "./PlanReferenceCard.js";
 import { StreamingMessage } from "./StreamingMessage.js";
 
+function planHandoffSummary(suggestion: PlanHandoffSuggestion): string {
+  if (suggestion.kind === "plan_creation") {
+    return "Answer the remaining details in Plan, then review the Draft before applying it.";
+  }
+  if (suggestion.kind === "plan_change") {
+    return "Review a structured Proposal in Plan. Nothing changes until you approve it.";
+  }
+  return "Open Plan with this question and the relevant Chat context attached.";
+}
+
+function PlanHandoffCard(props: {
+  readonly messageId: string;
+  readonly suggestion: PlanHandoffSuggestion;
+}): ReactElement {
+  const actions = useEnduragentStore((state) => state.chatActions);
+  const loaded = useEnduragentStore((state) => state.chat.planningRequestsLoaded);
+  const busyId = useEnduragentStore((state) => state.chat.planningRequestBusyId);
+  return (
+    <aside className="mt-row grid gap-row rounded-card border border-line-2 bg-surface p-5 shadow-elev-1">
+      <div className="grid gap-inset">
+        <p className="m-0 text-xs font-semibold uppercase tracking-wide text-ink-2">
+          Continue in Plan
+        </p>
+        <h3 className="m-0 text-base font-semibold leading-6">{props.suggestion.title}</h3>
+        <p className="m-0 text-sm leading-5 text-ink-2">{planHandoffSummary(props.suggestion)}</p>
+      </div>
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          disabled={actions === null || !loaded || busyId !== null}
+          onClick={() => actions?.continueMessageInPlan(props.messageId, props.suggestion)}
+        >
+          Continue in Plan
+        </Button>
+      </div>
+    </aside>
+  );
+}
+
 function MessageRow(props: {
   readonly message: ChatMessageView;
   readonly bufferedStreaming: boolean;
 }): ReactElement {
   const message = props.message;
+  const sourceMessageId = message.turnId ?? message.id;
+  const handoffDelivery = useEnduragentStore((state) =>
+    state.chat.planningRequests.find(
+      (delivery) =>
+        delivery.source?.messageId === sourceMessageId && delivery.state !== "cancelled",
+    ),
+  );
   const streaming = message.role === "coach" && message.delivery === "streaming";
   const silent = message.historical || message.role === "athlete";
   const rowClassName = cn(
@@ -89,6 +135,9 @@ function MessageRow(props: {
           {message.planReference === undefined ? null : (
             <PlanReferenceCard selection={message.planReference} />
           )}
+          {message.planHandoff === undefined || handoffDelivery !== undefined ? null : (
+            <PlanHandoffCard messageId={sourceMessageId} suggestion={message.planHandoff} />
+          )}
         </div>
       )}
     </article>
@@ -128,6 +177,7 @@ function ChoiceRow(props: { readonly choice: ChatChoiceView }): ReactElement {
 
 function planningRequestStatus(delivery: PlanningRequestDelivery): string {
   if (delivery.state === "pending") return "Opening";
+  if (delivery.state === "failed") return "Couldn’t open";
   const request = delivery.planningRequest;
   if (request === null) return "Plan request";
   if (request.lifecycle === "applied") return "Added to Plan";
@@ -142,7 +192,13 @@ function planningRequestStatus(delivery: PlanningRequestDelivery): string {
 
 function planningRequestSummary(delivery: PlanningRequestDelivery): string {
   const request = delivery.planningRequest;
-  if (delivery.state === "pending") return "The workout and your Chat context are staying together.";
+  if (delivery.state === "pending")
+    return "The workout and your Chat context are staying together.";
+  if (delivery.state === "failed") {
+    return delivery.retryable
+      ? "The request is saved. Trying again will not create a duplicate."
+      : "The request could not be delivered safely.";
+  }
   if (request?.terminalResult !== null && request?.terminalResult !== undefined) {
     return request.terminalResult.detail;
   }
@@ -158,20 +214,21 @@ function planningRequestSummary(delivery: PlanningRequestDelivery): string {
   return "Review the structured Proposal in Plan; the active Plan is unchanged.";
 }
 
-function PlanningRequestRow(props: {
-  readonly delivery: PlanningRequestDelivery;
-}): ReactElement {
+function PlanningRequestRow(props: { readonly delivery: PlanningRequestDelivery }): ReactElement {
   const actions = useEnduragentStore((state) => state.chatActions);
   const busyId = useEnduragentStore((state) => state.chat.planningRequestBusyId);
   const delivery = props.delivery;
   const request = delivery.planningRequest;
   const pending = delivery.state === "pending";
+  const failed = delivery.state === "failed";
   const terminal = request !== null && request.lifecycle !== "open";
-  const buttonLabel = terminal
-    ? "Open Plan"
-    : request?.proposalId !== null && request?.proposalId !== undefined
-      ? "Review in Plan"
-      : "Continue in Plan";
+  const buttonLabel = failed
+    ? "Try again"
+    : terminal
+      ? "Open Plan"
+      : request?.proposalId !== null && request?.proposalId !== undefined
+        ? "Review in Plan"
+        : "Continue in Plan";
   return (
     <article
       className="grid gap-row rounded-card border border-line-2 bg-surface p-5 shadow-elev-1 outline-none focus-visible:ring-2 focus-visible:ring-primary"
@@ -213,8 +270,12 @@ function PlanningRequestRow(props: {
           <Button
             type="button"
             variant="outline"
-            disabled={actions === null || busyId !== null}
-            onClick={() => actions?.openPlanningRequest(delivery.requestId)}
+            disabled={actions === null || busyId !== null || (failed && !delivery.retryable)}
+            onClick={() =>
+              failed
+                ? actions?.retryPlanningRequest(delivery.requestId)
+                : actions?.openPlanningRequest(delivery.requestId)
+            }
           >
             {buttonLabel}
           </Button>

--- a/apps/desktop-renderer/src/ui/plan/PlanView.tsx
+++ b/apps/desktop-renderer/src/ui/plan/PlanView.tsx
@@ -31,6 +31,7 @@ import {
   type PlanFtpProjection,
   type PlanFtpSourceValue,
   type PlanHistoryEntry,
+  type PlanPlanningRequestContext,
   type PlanRaceCourseProjection,
   type PlanRaceCourseSummary,
   type PlanReadinessProjection,
@@ -3236,6 +3237,198 @@ function WeeklyReviewProjection(props: {
   );
 }
 
+function PlanningRequestDateConflictProjection(props: {
+  readonly context: PlanPlanningRequestContext;
+}): ReactElement {
+  const actions = useEnduragentStore((state) => state.planActions);
+  const transition = useEnduragentStore((state) => state.plan.transition);
+  const conflict = props.context.dateConflict;
+  const recommended = conflict?.recommendedDate ?? null;
+  const firstReplaceable = conflict?.workouts.find((workout) => workout.replaceable) ?? null;
+  const [choice, setChoice] = useState<"recommended" | "replace" | "custom">(
+    recommended !== null ? "recommended" : firstReplaceable !== null ? "replace" : "custom",
+  );
+  const [replacementWorkoutId, setReplacementWorkoutId] = useState(
+    firstReplaceable?.workoutId ?? null,
+  );
+  const [customDate, setCustomDate] = useState(recommended ?? conflict?.minimumDate ?? "");
+  if (conflict === null) {
+    return <StatusCard title="Plan request" support="Refreshing the current date options…" />;
+  }
+  const busy =
+    (transition.status === "submitting" || transition.status === "running") &&
+    transition.transitionId === "PL-T40";
+  const failed = transition.status === "failed" && transition.transitionId === "PL-T40";
+  const submit = (): void => {
+    if (choice === "replace" && replacementWorkoutId !== null) {
+      actions?.resolvePlanningRequestDate(props.context.request.requestId, {
+        kind: "replace-workout",
+        workoutId: replacementWorkoutId,
+      });
+      return;
+    }
+    const date = choice === "recommended" ? recommended : customDate;
+    if (date !== null && date.length > 0) {
+      actions?.resolvePlanningRequestDate(props.context.request.requestId, {
+        kind: "use-date",
+        date,
+      });
+    }
+  };
+  const selectedDate = choice === "recommended" ? recommended : customDate;
+  const primaryLabel =
+    choice === "replace" && replacementWorkoutId !== null
+      ? "Review replacement"
+      : selectedDate === null || selectedDate.length === 0
+        ? "Choose date"
+        : `Use ${formatCivilDate(selectedDate)}`;
+  return (
+    <section className="grid gap-5 rounded-card bg-surface p-5 shadow-elev-1">
+      <div className={SUPPORT_PAIR}>
+        <p className="m-0 text-xs font-semibold tracking-wide text-ink-2 uppercase">
+          Date conflict
+        </p>
+        <h2 className="m-0 text-xl font-semibold">
+          {conflict.workouts[0] === undefined
+            ? "The requested date already has a Workout"
+            : `${formatCivilDate(conflict.workouts[0].date)} already has a Workout`}
+        </h2>
+        <p className="m-0 text-ink-2">
+          Choose another date by default, or explicitly replace a future coach-owned Workout.
+        </p>
+      </div>
+      <div className="grid gap-inset">
+        {recommended === null ? null : (
+          <button
+            type="button"
+            aria-pressed={choice === "recommended"}
+            className={`grid min-h-ctl grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-row rounded-ctl border p-row text-left outline-none focus:ring-3 focus:ring-ring/25 ${
+              choice === "recommended" ? "border-primary bg-primary/10" : "border-line bg-surface"
+            }`}
+            onClick={() => setChoice("recommended")}
+          >
+            <span className="grid size-4 place-items-center rounded-full border-2 border-current">
+              {choice === "recommended" ? (
+                <span className="size-2 rounded-full bg-current" />
+              ) : null}
+            </span>
+            <span className={SUPPORT_PAIR}>
+              <strong>Use {formatCivilDate(recommended)}</strong>
+              <small className="text-ink-2">No existing Workout</small>
+            </span>
+            <span className="rounded-full bg-ok/14 px-3 py-1 text-xs font-medium text-ok">
+              Recommended
+            </span>
+          </button>
+        )}
+        {conflict.workouts.map((workout) =>
+          workout.replaceable ? (
+            <button
+              key={workout.workoutId}
+              type="button"
+              aria-pressed={choice === "replace" && replacementWorkoutId === workout.workoutId}
+              className={`grid min-h-ctl grid-cols-[auto_minmax(0,1fr)] items-center gap-row rounded-ctl border p-row text-left outline-none focus:ring-3 focus:ring-ring/25 ${
+                choice === "replace" && replacementWorkoutId === workout.workoutId
+                  ? "border-primary bg-primary/10"
+                  : "border-line bg-surface"
+              }`}
+              onClick={() => {
+                setReplacementWorkoutId(workout.workoutId);
+                setChoice("replace");
+              }}
+            >
+              <span className="grid size-4 place-items-center rounded-full border-2 border-current">
+                {choice === "replace" && replacementWorkoutId === workout.workoutId ? (
+                  <span className="size-2 rounded-full bg-current" />
+                ) : null}
+              </span>
+              <span className={SUPPORT_PAIR}>
+                <strong>Replace {workout.name}</strong>
+                <small className="text-ink-2">
+                  Future · coach-owned · {clockTime(workout.durationS)}
+                </small>
+              </span>
+            </button>
+          ) : null,
+        )}
+        <button
+          type="button"
+          aria-pressed={choice === "custom"}
+          className={`grid min-h-ctl grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-row rounded-ctl border p-row text-left outline-none focus:ring-3 focus:ring-ring/25 ${
+            choice === "custom" ? "border-primary bg-primary/10" : "border-line bg-surface"
+          }`}
+          onClick={() => setChoice("custom")}
+        >
+          <span className="grid size-4 place-items-center rounded-full border-2 border-current">
+            {choice === "custom" ? <span className="size-2 rounded-full bg-current" /> : null}
+          </span>
+          <span className={SUPPORT_PAIR}>
+            <strong>Choose another date…</strong>
+            <small className="text-ink-2">Check another day against the current Plan</small>
+          </span>
+          <CalendarDays className="size-4 text-ink-2" aria-hidden="true" />
+        </button>
+        {choice === "custom" ? (
+          <label className="grid gap-inset rounded-ctl bg-sunk p-row text-sm">
+            <span className="font-medium">Date</span>
+            <input
+              type="date"
+              min={conflict.minimumDate}
+              max={conflict.maximumDate}
+              value={customDate}
+              className="h-ctl rounded-ctl border border-line bg-surface px-3 text-sm outline-none focus:ring-3 focus:ring-ring/25"
+              onChange={(event) => setCustomDate(event.currentTarget.value)}
+            />
+          </label>
+        ) : null}
+        {conflict.workouts.map((workout) =>
+          workout.replaceable ? null : (
+            <div
+              key={workout.workoutId}
+              className="grid min-h-ctl grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-row rounded-ctl bg-sunk p-row text-ink-2"
+            >
+              <TriangleAlert className="size-4" aria-hidden="true" />
+              <span className={SUPPORT_PAIR}>
+                <strong className="text-ink">{workout.name}</strong>
+                <small>Athlete-created · cannot be replaced by Coach</small>
+              </span>
+              <span className="rounded-full bg-bg-2 px-3 py-1 text-xs font-medium">Protected</span>
+            </div>
+          ),
+        )}
+      </div>
+      {failed ? (
+        <div className="flex items-start gap-row rounded-ctl bg-warn/10 p-row" role="alert">
+          <TriangleAlert className="mt-0.5 size-4 shrink-0 text-warn" aria-hidden="true" />
+          <p className="m-0 text-sm text-ink-2">{transition.error.message}</p>
+        </div>
+      ) : null}
+      <div className="flex flex-wrap justify-end gap-inset">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={busy}
+          onClick={() => actions?.closeProposal()}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          disabled={
+            busy ||
+            actions === null ||
+            (choice === "custom" && customDate.length === 0) ||
+            (choice === "replace" && replacementWorkoutId === null)
+          }
+          onClick={submit}
+        >
+          {busy ? "Checking…" : primaryLabel}
+        </Button>
+      </div>
+    </section>
+  );
+}
+
 function ActiveProjection(): ReactElement {
   const model = useEnduragentStore((state) => planReadModel(state.plan));
   const transition = useEnduragentStore((state) => state.plan.transition);
@@ -3302,6 +3495,9 @@ function ActiveProjection(): ReactElement {
   const parsed = PlanActiveProjectionDataSchema.safeParse(model.data);
   if (!parsed.success) return <StatusCard title={model.title} support={model.summary} />;
   const data = parsed.data;
+  if (data.selectedPlanningRequest?.request.attention === "date_conflict") {
+    return <PlanningRequestDateConflictProjection context={data.selectedPlanningRequest} />;
+  }
   if (model.scenarioId === "PL-S006") {
     return <SeasonProjection data={data} />;
   }
@@ -3386,6 +3582,7 @@ function ActiveProjection(): ReactElement {
       ? null
       : ((data.proposals ?? []).find((proposal) => proposal.id === data.selectedProposalId) ??
         null);
+  const planningRequestAttention = data.selectedPlanningRequest?.request.attention ?? null;
   const proposalTargetWorkout =
     selectedProposal === null
       ? null
@@ -3913,6 +4110,28 @@ function ActiveProjection(): ReactElement {
                     Decision needed
                   </span>
                 </div>
+                {planningRequestAttention === "apply_failed" ||
+                (planningRequestAttention === "revalidating" && !proposalBusy) ? (
+                  <div
+                    className="flex items-start gap-row rounded-ctl bg-warn/10 p-row"
+                    role="alert"
+                  >
+                    <TriangleAlert
+                      className="mt-0.5 size-5 shrink-0 text-warn"
+                      aria-hidden="true"
+                    />
+                    <div className={SUPPORT_PAIR}>
+                      <p className="m-0 font-medium">
+                        {planningRequestAttention === "apply_failed"
+                          ? "We couldn’t save this change"
+                          : "The previous check was interrupted"}
+                      </p>
+                      <p className="m-0 text-sm text-ink-2">
+                        The active Plan is unchanged and this Proposal is still available.
+                      </p>
+                    </div>
+                  </div>
+                ) : null}
                 {selectedProposal.stale ? (
                   <StaleNotice message="The Plan changed before approval. Review this updated Proposal." />
                 ) : null}
@@ -3997,9 +4216,12 @@ function ActiveProjection(): ReactElement {
                     >
                       {proposalBusy
                         ? "Checking…"
-                        : selectedProposal.stale
-                          ? "Revalidate"
-                          : "Approve"}
+                        : planningRequestAttention === "apply_failed" ||
+                            planningRequestAttention === "revalidating"
+                          ? "Try again"
+                          : selectedProposal.stale
+                            ? "Revalidate"
+                            : "Approve"}
                     </Button>
                   ) : null}
                 </>

--- a/apps/desktop-renderer/tests/archive-surface.test.tsx
+++ b/apps/desktop-renderer/tests/archive-surface.test.tsx
@@ -37,6 +37,7 @@ function chatActions(): ChatActions {
     retryAttachment: vi.fn(),
     selectAttachmentWorkout: vi.fn(),
     reviewAttachmentInPlan: vi.fn(),
+    continueMessageInPlan: vi.fn(),
     openPlanningRequest: vi.fn(),
     retryPlanningRequest: vi.fn(),
     retryPlanningRequestLoad: vi.fn(),

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -11,6 +11,7 @@ import type {
   ChatAttachmentComposerReadModel,
   ChatQueueSnapshot,
   CoachTurnEventNotificationEnvelope,
+  CreatePlanningRequestRpcParams,
   CreateWorkoutPlanningRequestRpcParams,
   PlanningRequestDelivery,
   QueuedChatMessage,
@@ -158,6 +159,12 @@ function client(
       | { readonly status: "accepted"; readonly delivery: PlanningRequestDelivery }
       | { readonly status: "rejected"; readonly reason: "invalid_request" | "request_conflict" }
     >;
+    readonly createPlanningRequest?: (
+      request: CreatePlanningRequestRpcParams,
+    ) => Promise<
+      | { readonly status: "accepted"; readonly delivery: PlanningRequestDelivery }
+      | { readonly status: "rejected"; readonly reason: "invalid_request" | "request_conflict" }
+    >;
     readonly retryPlanningRequest?: () => Promise<
       | { readonly status: "found"; readonly delivery: PlanningRequestDelivery }
       | { readonly status: "missing" }
@@ -215,7 +222,10 @@ function client(
     if (method === "createWorkoutPlanningRequest") {
       return (sessions.createWorkoutPlanningRequest?.(
         request as CreateWorkoutPlanningRequestRpcParams,
-      ) ??
+      ) ?? Promise.resolve({ status: "rejected", reason: "invalid_request" })) as never;
+    }
+    if (method === "createPlanningRequest") {
+      return (sessions.createPlanningRequest?.(request as CreatePlanningRequestRpcParams) ??
         Promise.resolve({ status: "rejected", reason: "invalid_request" })) as never;
     }
     if (method === "retryPlanningRequest") {
@@ -1459,6 +1469,83 @@ describe("chat controller", () => {
       expect(openPlanningRequest).toHaveBeenCalledWith(
         "desktop",
         create.mock.calls[0]![0].requestId,
+      ),
+    );
+  });
+
+  it("retries an uncertain text-only Plan handoff with the same durable payload", async () => {
+    let attempt = 0;
+    const create = vi.fn(async (request: CreatePlanningRequestRpcParams) => {
+      attempt += 1;
+      if (attempt === 1) throw new CoachClientDisconnectedError(1006, "synthetic");
+      const payload = request.payload;
+      const delivery: PlanningRequestDelivery = {
+        requestId: payload.requestId,
+        source: {
+          kind: payload.kind,
+          intent: payload.intent,
+          chatId: payload.source.chatId,
+          messageId: payload.source.messageId,
+          attachmentId: null,
+        },
+        state: "delivered",
+        attemptCount: 2,
+        failureCode: null,
+        retryable: false,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+        deliveredAtMs: 2,
+        planningRequest: {
+          requestId: payload.requestId,
+          kind: payload.kind,
+          target: "active_plan",
+          intent: payload.intent,
+          planConversationId: null,
+          proposalId: null,
+          requestedDateKey: 20260829,
+          resolvedDateKey: null,
+          source: { chatId: "desktop", messageId: "turn-1", available: true },
+          lifecycle: "open",
+          attention: "none",
+          revision: 1,
+          createdAtMs: 1,
+          updatedAtMs: 2,
+          terminalResult: null,
+        },
+      };
+      return { status: "accepted" as const, delivery };
+    });
+    const fake = client(replies(), {
+      listPlanningRequests: async () => ({ deliveries: [] }),
+      createPlanningRequest: create,
+    });
+    const { controller, openPlanningRequest } = subject(fake);
+    await controller.start();
+
+    controller.continueMessageInPlan("turn-1", {
+      kind: "plan_change",
+      title: "Review a lighter Friday",
+      intent: "Move Friday's endurance Workout to Saturday and keep Friday easy.",
+      requestedDate: "2026-08-29",
+    });
+    await vi.waitFor(() => expect(create).toHaveBeenCalledOnce());
+    controller.retryPlanningRequestLoad();
+    await vi.waitFor(() => expect(create).toHaveBeenCalledTimes(2));
+
+    expect(create.mock.calls[1]![0]).toEqual(create.mock.calls[0]![0]);
+    expect(create.mock.calls[0]![0]).toMatchObject({
+      payload: {
+        kind: "plan_change",
+        intent: "Move Friday's endurance Workout to Saturday and keep Friday easy.",
+        source: { chatId: "desktop", messageId: "turn-1" },
+        sourceSnapshot: { attachment: null, selectedWorkout: null },
+        requestedDate: "2026-08-29",
+      },
+    });
+    await vi.waitFor(() =>
+      expect(openPlanningRequest).toHaveBeenCalledWith(
+        "desktop",
+        create.mock.calls[0]![0].payload.requestId,
       ),
     );
   });

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -36,6 +36,7 @@ function stubActions(): ChatActions {
     retryAttachment: vi.fn(),
     selectAttachmentWorkout: vi.fn(),
     reviewAttachmentInPlan: vi.fn(),
+    continueMessageInPlan: vi.fn(),
     openPlanningRequest: vi.fn(),
     retryPlanningRequest: vi.fn(),
     retryPlanningRequestLoad: vi.fn(),
@@ -970,6 +971,58 @@ describe("chat surface", () => {
       expect(screen.getByText("Added to Plan")).toBeVisible();
       await user.click(screen.getByRole("button", { name: "Open Plan" }));
       expect(actions.openPlanningRequest).toHaveBeenLastCalledWith("request-plan-1");
+    });
+
+    it("renders one host-owned text handoff and keeps Plan unchanged until continued", async () => {
+      const user = userEvent.setup();
+      const message: ChatMessageView = {
+        id: "message-live-1",
+        turnId: "turn-1",
+        role: "coach",
+        delivery: "complete",
+        historical: false,
+        text: "This change should be reviewed in Plan.",
+        planHandoff: {
+          kind: "plan_change",
+          title: "Review a lighter Friday",
+          intent: "Move Friday's endurance Workout to Saturday and keep Friday easy.",
+        },
+      };
+      setChat({
+        messages: [message],
+        planningRequestsLoaded: true,
+        timeline: [{ kind: "message", message }],
+      });
+      render(<Harness />);
+
+      expect(screen.getByRole("heading", { name: "Review a lighter Friday" })).toBeVisible();
+      expect(screen.getByText(/Nothing changes until you approve it/u)).toBeVisible();
+      await user.click(screen.getByRole("button", { name: "Continue in Plan" }));
+      expect(actions.continueMessageInPlan).toHaveBeenCalledWith("turn-1", message.planHandoff);
+    });
+
+    it("shows a retry action for a safely saved failed Plan handoff", async () => {
+      const user = userEvent.setup();
+      const delivered = planningDelivery("open");
+      const failed: PlanningRequestDelivery = {
+        ...delivered,
+        state: "failed",
+        failureCode: "planning_unavailable",
+        retryable: true,
+        deliveredAtMs: null,
+        planningRequest: null,
+      };
+      setChat({
+        planningRequests: [failed],
+        planningRequestsLoaded: true,
+        timeline: [{ kind: "planning-request", delivery: failed }],
+      });
+      render(<Harness />);
+
+      expect(screen.getByText("Couldn’t open")).toBeVisible();
+      expect(screen.getAllByText(/will not create a duplicate/u)).not.toHaveLength(0);
+      await user.click(screen.getByRole("button", { name: "Try again" }));
+      expect(actions.retryPlanningRequest).toHaveBeenCalledWith(failed.requestId);
     });
 
     it("shows model-incompatible image recovery and retryable parser failure", async () => {

--- a/apps/desktop-renderer/tests/plan-surface.test.tsx
+++ b/apps/desktop-renderer/tests/plan-surface.test.tsx
@@ -81,6 +81,7 @@ function actions(): PlanActions {
     openEndedConversation: vi.fn(),
     closeEndedConversation: vi.fn(),
     openAttention: vi.fn(),
+    resolvePlanningRequestDate: vi.fn(),
     returnToCoach: vi.fn(),
     retry: vi.fn(),
   };
@@ -1829,6 +1830,43 @@ describe("Plan surface", () => {
     await user.click(revalidate);
     expect(planActions.approveProposal).toHaveBeenLastCalledWith(revisedProposalId, 2);
 
+    const applyFailedState = {
+      ...state,
+      data: {
+        ...currentData,
+        selectedPlanningRequest: {
+          request: {
+            requestId: "request-plan-1",
+            kind: "plan_change" as const,
+            target: "active_plan" as const,
+            intent: "Make Friday easier.",
+            planConversationId: null,
+            proposalId,
+            requestedDateKey: null,
+            resolvedDateKey: null,
+            source: { chatId: "desktop", messageId: "turn-1", available: true },
+            lifecycle: "open" as const,
+            attention: "apply_failed" as const,
+            revision: 3,
+            createdAtMs: 1,
+            updatedAtMs: 3,
+            terminalResult: null,
+          },
+          dateConflict: null,
+        },
+      },
+    };
+    act(() => {
+      useEnduragentStore.getState().setPlanHydration({
+        status: "ready",
+        state: applyFailedState,
+      });
+    });
+    expect(await screen.findByText("We couldn’t save this change")).toBeInTheDocument();
+    expect(screen.getByText(/active Plan is unchanged/u)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(planActions.approveProposal).toHaveBeenLastCalledWith(proposalId, 1);
+
     const unavailableState = {
       ...state,
       transitions: state.transitions.filter(
@@ -1874,6 +1912,126 @@ describe("Plan surface", () => {
     expect(await screen.findByRole("heading", { name: "Proposal rejected" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Back to Plan" }));
     expect(planActions.closeProposal).toHaveBeenCalledTimes(2);
+  });
+
+  it("offers safe alternatives for a Chat-originated date conflict", async () => {
+    const user = userEvent.setup();
+    const planActions = actions();
+    const planId = "00000000000000000000000003";
+    const proposalId = "00000000000000000000000005";
+    const requestId = "request-plan-date";
+    const state = {
+      ...planReadModel({
+        lifecycle: "active",
+        scenarioId: "PL-S007",
+        projection: "active",
+        planId,
+        data: {
+          plan: {
+            id: planId,
+            name: "Gran Fondo Almaty",
+            primaryGoal: "Finish in the front half",
+            startDate: "2026-07-13",
+            targetDate: "2026-10-04",
+            kind: "full-plan",
+            totalWeeks: 12,
+            weekStartDay: 1,
+            workoutCount: 20,
+            plannedDurationS: 72_000,
+          },
+          today: "2026-08-26",
+          weekIndex: 7,
+          todayWorkout: null,
+          workouts: [],
+          selectedWorkoutId: null,
+          selectedProposalId: proposalId,
+          proposals: [],
+          selectedPlanningRequest: {
+            request: {
+              requestId,
+              kind: "workout_review",
+              target: "active_plan",
+              intent: "Add Tempo 3 × 12 to Monday.",
+              planConversationId: null,
+              proposalId,
+              requestedDateKey: 20260831,
+              resolvedDateKey: null,
+              source: { chatId: "desktop", messageId: "turn-1", available: true },
+              lifecycle: "open",
+              attention: "date_conflict",
+              revision: 2,
+              createdAtMs: 1,
+              updatedAtMs: 2,
+              terminalResult: null,
+            },
+            dateConflict: {
+              recommendedDate: "2026-09-01",
+              minimumDate: "2026-08-27",
+              maximumDate: "2026-10-04",
+              workouts: [
+                {
+                  workoutId: "workout-coach",
+                  date: "2026-08-31",
+                  name: "Easy endurance",
+                  durationS: 3_000,
+                  ownership: "coach",
+                  replaceable: true,
+                },
+                {
+                  workoutId: "workout-athlete",
+                  date: "2026-08-31",
+                  name: "Club ride",
+                  durationS: 4_200,
+                  ownership: "athlete",
+                  replaceable: false,
+                },
+              ],
+            },
+          },
+        },
+      }),
+      transitions: [
+        { transitionId: "PL-T40" as const, status: "available" as const, reason: null },
+      ],
+    };
+    useEnduragentStore.setState({
+      plan: {
+        ...EMPTY_PLAN_SURFACE,
+        hydration: { status: "ready", state },
+        lastReady: state,
+      },
+      planActions,
+    });
+    render(<PlanView />);
+
+    expect(
+      screen.getByRole("heading", { name: /Aug 31, 2026 already has a Workout/u }),
+    ).toBeVisible();
+    expect(screen.getByText("Protected")).toBeVisible();
+    expect(screen.queryByRole("button", { name: /Replace Club ride/u })).not.toBeInTheDocument();
+    const recommendedButtons = screen.getAllByRole("button", { name: /Use Sep 1, 2026/u });
+    await user.click(recommendedButtons[recommendedButtons.length - 1]!);
+    expect(planActions.resolvePlanningRequestDate).toHaveBeenCalledWith(requestId, {
+      kind: "use-date",
+      date: "2026-09-01",
+    });
+
+    await user.click(screen.getByRole("button", { name: /Replace Easy endurance/u }));
+    await user.click(screen.getByRole("button", { name: "Review replacement" }));
+    expect(planActions.resolvePlanningRequestDate).toHaveBeenLastCalledWith(requestId, {
+      kind: "replace-workout",
+      workoutId: "workout-coach",
+    });
+
+    await user.click(screen.getByRole("button", { name: /Choose another date/u }));
+    const date = screen.getByLabelText("Date");
+    await user.clear(date);
+    await user.type(date, "2026-09-02");
+    await user.click(screen.getByRole("button", { name: /Use Sep 2, 2026/u }));
+    expect(planActions.resolvePlanningRequestDate).toHaveBeenLastCalledWith(requestId, {
+      kind: "use-date",
+      date: "2026-09-02",
+    });
   });
 
   it("shows the outside-edit comparison and exposes explicit adopt or restore choices", async () => {

--- a/apps/desktop-renderer/tests/shell.test.tsx
+++ b/apps/desktop-renderer/tests/shell.test.tsx
@@ -66,6 +66,7 @@ function stubActions(): ChatActions {
     retryAttachment: vi.fn(),
     selectAttachmentWorkout: vi.fn(),
     reviewAttachmentInPlan: vi.fn(),
+    continueMessageInPlan: vi.fn(),
     openPlanningRequest: vi.fn(),
     retryPlanningRequest: vi.fn(),
     retryPlanningRequestLoad: vi.fn(),
@@ -159,6 +160,7 @@ function stubPlanActions(): PlanActions {
     openRaceOutcome: vi.fn(),
     recordRaceOutcome: vi.fn(),
     openAttention: vi.fn(),
+    resolvePlanningRequestDate: vi.fn(),
     returnToCoach: vi.fn(),
     retry: vi.fn(),
   };

--- a/apps/desktop-renderer/tests/sidebar-surface.test.tsx
+++ b/apps/desktop-renderer/tests/sidebar-surface.test.tsx
@@ -30,6 +30,7 @@ function stubActions(): ChatActions {
     retryAttachment: vi.fn(),
     selectAttachmentWorkout: vi.fn(),
     reviewAttachmentInPlan: vi.fn(),
+    continueMessageInPlan: vi.fn(),
     openPlanningRequest: vi.fn(),
     retryPlanningRequest: vi.fn(),
     retryPlanningRequestLoad: vi.fn(),
@@ -123,6 +124,7 @@ function stubPlanActions(): PlanActions {
     openRaceOutcome: vi.fn(),
     recordRaceOutcome: vi.fn(),
     openAttention: vi.fn(),
+    resolvePlanningRequestDate: vi.fn(),
     returnToCoach: vi.fn(),
     retry: vi.fn(),
   };

--- a/apps/desktop/tests/helpers/plan-qa-scenario-registry.ts
+++ b/apps/desktop/tests/helpers/plan-qa-scenario-registry.ts
@@ -1122,6 +1122,8 @@ export function resolvePlanQaTransition(
       return destination("PL-S100");
     case "PL-T38":
       return destination("PL-S101");
+    case "PL-T40":
+      return destination("PL-S007");
     case "PL-T39": {
       if (options.destinationScenarioId === undefined) {
         throw new TypeError("PL-T39 requires a destinationScenarioId");

--- a/packages/coach-contract/src/plan-chat-card.ts
+++ b/packages/coach-contract/src/plan-chat-card.ts
@@ -8,6 +8,24 @@ import {
 
 const PlanEntityIdSchema = z.string().min(1).max(256);
 
+export const PlanHandoffSuggestionSchema = z
+  .object({
+    kind: z.enum(["plan_question", "plan_change", "plan_creation"]),
+    title: z.string().min(1).max(500),
+    intent: z.string().min(1).max(20_000),
+    requestedDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/u)
+      .optional(),
+  })
+  .strict();
+export type PlanHandoffSuggestion = z.infer<typeof PlanHandoffSuggestionSchema>;
+
+export const PlanHandoffToolResultSchema = z
+  .object({ status: z.literal("ready"), suggestion: PlanHandoffSuggestionSchema })
+  .strict();
+export type PlanHandoffToolResult = z.infer<typeof PlanHandoffToolResultSchema>;
+
 export const PlanReferenceSelectionSchema = z.discriminatedUnion("kind", [
   z
     .object({

--- a/packages/coach-contract/src/planning.ts
+++ b/packages/coach-contract/src/planning.ts
@@ -46,6 +46,7 @@ export const PLAN_TRANSITION_IDS = [
   "PL-T37",
   "PL-T38",
   "PL-T39",
+  "PL-T40",
 ] as const;
 
 export const PLAN_MIN_FULL_DAYS = 84 as const;
@@ -753,6 +754,51 @@ export const PlanProposalReturnSchema = z
   .strict();
 export type PlanProposalReturn = z.infer<typeof PlanProposalReturnSchema>;
 
+export const PlanPlanningRequestContextSchema = z
+  .object({
+    request: PlanningRequestReadModelSchema,
+    dateConflict: z
+      .object({
+        recommendedDate: TrainingExportCivilDateSchema.nullable(),
+        minimumDate: TrainingExportCivilDateSchema,
+        maximumDate: TrainingExportCivilDateSchema,
+        workouts: z.array(
+          z
+            .object({
+              workoutId: z.string().min(1),
+              date: TrainingExportCivilDateSchema,
+              name: z.string().min(1),
+              durationS: z.number().int().nonnegative(),
+              ownership: z.enum(["coach", "athlete"]),
+              replaceable: z.boolean(),
+            })
+            .strict()
+            .superRefine((value, context) => {
+              if (value.replaceable !== (value.ownership === "coach")) {
+                context.addIssue({
+                  code: "custom",
+                  path: ["replaceable"],
+                  message: "only coach-owned conflict workouts are replaceable",
+                });
+              }
+            }),
+        ),
+      })
+      .strict()
+      .nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if ((value.request.attention === "date_conflict") !== (value.dateConflict !== null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["dateConflict"],
+        message: "date conflict details must match request attention",
+      });
+    }
+  });
+export type PlanPlanningRequestContext = z.infer<typeof PlanPlanningRequestContextSchema>;
+
 export const PlanActiveProjectionDataSchema = z
   .object({
     plan: PlanDraftPlanProjectionSchema,
@@ -774,6 +820,7 @@ export const PlanActiveProjectionDataSchema = z
     proposals: z.array(PlanProposalProjectionSchema).optional(),
     selectedProposalId: z.string().min(1).nullable().optional(),
     selectedProposalReturn: PlanProposalReturnSchema.nullable().optional(),
+    selectedPlanningRequest: PlanPlanningRequestContextSchema.nullable().optional(),
     proposalRevisionText: z.string().nullable().optional(),
     history: z.array(PlanHistoryEntrySchema).optional(),
     selectedHistoryId: z.string().min(1).nullable().optional(),
@@ -1556,6 +1603,27 @@ export const PlanTransitionCommandSchema = z.discriminatedUnion("transitionId", 
       destinationScenarioId: PlanScenarioIdSchema,
       returnFocusId: EntityIdSchema,
       selectedProposalReturn: PlanProposalReturnSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      transitionId: z.literal("PL-T40"),
+      commandId: CommandIdSchema,
+      requestId: EntityIdSchema,
+      resolution: z.discriminatedUnion("kind", [
+        z
+          .object({
+            kind: z.literal("use-date"),
+            date: TrainingExportCivilDateSchema,
+          })
+          .strict(),
+        z
+          .object({
+            kind: z.literal("replace-workout"),
+            workoutId: EntityIdSchema,
+          })
+          .strict(),
+      ]),
     })
     .strict(),
 ]);

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -13,7 +13,7 @@ import {
 } from "./engine.js";
 import { TurnEventSchema, type TurnEvent } from "./turn-event.js";
 import { PlatformAbsolutePathSchema } from "./platform-path.js";
-import { PlanReferenceSelectionSchema } from "./plan-chat-card.js";
+import { PlanHandoffSuggestionSchema, PlanReferenceSelectionSchema } from "./plan-chat-card.js";
 import {
   AdmitPastedChatAttachmentRequestSchema,
   AdmitChatAttachmentRequestSchema,
@@ -427,14 +427,18 @@ export const TranscriptPageTurnSchema = z
     delivery: z.literal("interrupted").optional(),
     attachments: z.array(ChatAttachmentReferenceSchema).max(5).optional(),
     planReference: PlanReferenceSelectionSchema.optional(),
+    planHandoff: PlanHandoffSuggestionSchema.optional(),
   })
   .strict()
   .superRefine((value, context) => {
-    if (value.delivery === "interrupted" && value.planReference !== undefined) {
+    if (
+      value.delivery === "interrupted" &&
+      (value.planReference !== undefined || value.planHandoff !== undefined)
+    ) {
       context.addIssue({
         code: "custom",
-        path: ["planReference"],
-        message: "interrupted turns cannot carry Plan references",
+        path: ["planHandoff"],
+        message: "interrupted turns cannot carry Plan metadata",
       });
     }
   });

--- a/packages/coach-contract/src/turn-event.ts
+++ b/packages/coach-contract/src/turn-event.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { CoachDecisionReadModelSchema } from "./coach-decision.js";
-import { PlanReferenceSelectionSchema } from "./plan-chat-card.js";
+import { PlanHandoffSuggestionSchema, PlanReferenceSelectionSchema } from "./plan-chat-card.js";
 
 /** Engine-internal turn failure classification (frozen field vocabulary). */
 export const TurnErrorClassSchema = z.enum([
@@ -138,6 +138,14 @@ export const PlanReferenceSelectedEventSchema = z
   })
   .strict();
 
+export const PlanHandoffRequestedEventSchema = z
+  .object({
+    type: z.literal("plan-handoff"),
+    turnId: z.string().min(1),
+    suggestion: PlanHandoffSuggestionSchema,
+  })
+  .strict();
+
 /**
  * Terminal shapes: a successful turn ends with `final-text` as its last event.
  * A failed turn with no committed writes ends with `error` and delivers no
@@ -156,6 +164,7 @@ export const TurnEventSchema = z.discriminatedUnion("type", [
   TextDeltaEventSchema,
   DecisionRequestedEventSchema,
   PlanReferenceSelectedEventSchema,
+  PlanHandoffRequestedEventSchema,
 ]);
 export type TurnEvent = z.infer<typeof TurnEventSchema>;
 

--- a/packages/coach-contract/tests/plan-chat-card.test.ts
+++ b/packages/coach-contract/tests/plan-chat-card.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
   PlanChatCardReadModelSchema,
+  PlanHandoffSuggestionSchema,
   PlanReferenceSelectionSchema,
   TranscriptPageTurnSchema,
   TurnEventSchema,
 } from "../src/index.js";
 
 const selection = { kind: "workout_detail" as const, planId: "plan-1", workoutId: "workout-1" };
+const handoff = {
+  kind: "plan_change" as const,
+  title: "Review a lighter Friday",
+  intent: "Move Friday's endurance Workout to Saturday and keep Friday easy.",
+};
 
 describe("Plan Chat card contract", () => {
   it("accepts strict persisted selections and rejects extra fields", () => {
@@ -58,5 +64,25 @@ describe("Plan Chat card contract", () => {
         planReference: selection,
       }),
     ).toMatchObject({ planReference: selection });
+  });
+
+  it("carries one strict Plan handoff suggestion through live events and transcript pages", () => {
+    expect(PlanHandoffSuggestionSchema.parse(handoff)).toEqual(handoff);
+    expect(
+      PlanHandoffSuggestionSchema.safeParse({ ...handoff, markup: "<button>Apply</button>" })
+        .success,
+    ).toBe(false);
+    expect(
+      TurnEventSchema.parse({ type: "plan-handoff", turnId: "turn-1", suggestion: handoff }),
+    ).toMatchObject({ suggestion: handoff });
+    expect(
+      TranscriptPageTurnSchema.parse({
+        turnId: "turn-1",
+        completedAt: "2026-08-26T00:00:00.000Z",
+        athleteText: "Can we move Friday?",
+        coachText: "Review this change in Plan.",
+        planHandoff: handoff,
+      }),
+    ).toMatchObject({ planHandoff: handoff });
   });
 });

--- a/packages/coach-contract/tests/planning.test.ts
+++ b/packages/coach-contract/tests/planning.test.ts
@@ -107,6 +107,12 @@ const commands = [
     destinationScenarioId: "PL-S021",
     returnFocusId: "workout-row-1",
   },
+  {
+    transitionId: "PL-T40",
+    commandId,
+    requestId,
+    resolution: { kind: "use-date", date: "1998-08-26" },
+  },
 ] satisfies PlanTransitionCommand[];
 
 const state = {

--- a/packages/coach/src/planning-lifecycle.ts
+++ b/packages/coach/src/planning-lifecycle.ts
@@ -661,6 +661,9 @@ export function buildActivePlanReadModel(input: {
       ...(input.scenarioId === "PL-S083" ? [guard("PL-T27")] : []),
       ...(input.scenarioId === "PL-S085" ? [guard("PL-T28")] : []),
       guard("PL-T39"),
+      ...(input.data.selectedPlanningRequest?.request.attention === "date_conflict"
+        ? [guard("PL-T40")]
+        : []),
     ],
     reconciliation: input.reconciliation,
     attention,

--- a/packages/coach/src/planning-operations.ts
+++ b/packages/coach/src/planning-operations.ts
@@ -145,6 +145,7 @@ import {
   type PlanProposalPremiseRecord,
   type PlanProposalRepository,
   type PlanningRequestReadModel,
+  type PlanningRequestAttention,
   type PlanningRequestRecord,
   type PlanningRequestRepository,
   type PlanAdaptationLedgerRecord,
@@ -795,6 +796,7 @@ function activePlanData(input: {
   readonly proposals: readonly PlanProposalProjection[];
   readonly selectedProposalId?: string | null;
   readonly selectedProposalReturn?: PlanProposalReturn | null;
+  readonly selectedPlanningRequest?: PlanActiveProjectionData["selectedPlanningRequest"];
   readonly proposalRevisionText?: string | null;
   readonly history: readonly PlanHistoryEntry[];
   readonly selectedHistoryId?: string | null;
@@ -971,6 +973,7 @@ function activePlanData(input: {
     proposals: input.proposals,
     selectedProposalId: input.selectedProposalId ?? null,
     selectedProposalReturn: input.selectedProposalReturn ?? null,
+    selectedPlanningRequest: input.selectedPlanningRequest ?? null,
     proposalRevisionText: input.proposalRevisionText ?? null,
     history: input.history,
     selectedHistoryId: input.selectedHistoryId ?? null,
@@ -1005,6 +1008,61 @@ function activeScenario(
     return "PL-S042";
   }
   return projection.job.failureCount > 1 ? "PL-S041" : "PL-S039";
+}
+
+function selectedPlanningRequestContext(input: {
+  readonly record: PlanningRequestRecord | undefined;
+  readonly plan: PlanRecord;
+  readonly workouts: readonly PlanWorkoutRecord[];
+  readonly todayDateKey: number;
+}): PlanActiveProjectionData["selectedPlanningRequest"] {
+  const record = input.record;
+  if (record === undefined) return null;
+  if (record.request.attention !== "date_conflict") {
+    return { request: record.request, dateConflict: null };
+  }
+  const requestedDateKey = record.request.requestedDateKey;
+  if (requestedDateKey === null) throw new TypeError("A date conflict requires a requested date.");
+  const minimumDateKey = Math.max(input.plan.startDateKey, addCivilDays(input.todayDateKey, 1));
+  const maximumDateKey =
+    input.plan.targetDateKey ??
+    addCivilDays(input.plan.startDateKey, input.plan.totalWeeks * 7 - 1);
+  const occupied = new Set(input.workouts.map((workout) => workout.dateKey));
+  let recommendedDateKey: number | null = null;
+  for (let dateKey = addCivilDays(requestedDateKey, 1); dateKey <= maximumDateKey; ) {
+    if (!occupied.has(dateKey)) {
+      recommendedDateKey = dateKey;
+      break;
+    }
+    dateKey = addCivilDays(dateKey, 1);
+  }
+  if (recommendedDateKey === null) {
+    for (let dateKey = minimumDateKey; dateKey < requestedDateKey; ) {
+      if (!occupied.has(dateKey)) {
+        recommendedDateKey = dateKey;
+        break;
+      }
+      dateKey = addCivilDays(dateKey, 1);
+    }
+  }
+  return {
+    request: record.request,
+    dateConflict: {
+      recommendedDate: recommendedDateKey === null ? null : dateText(recommendedDateKey),
+      minimumDate: dateText(minimumDateKey),
+      maximumDate: dateText(maximumDateKey),
+      workouts: input.workouts
+        .filter((workout) => workout.dateKey === requestedDateKey)
+        .map((workout) => ({
+          workoutId: workout.id,
+          date: dateText(workout.dateKey),
+          name: workout.name,
+          durationS: workout.durationS ?? 0,
+          ownership: workout.origin,
+          replaceable: workout.origin === "coach" && workout.dateKey > input.todayDateKey,
+        })),
+    },
+  };
 }
 
 function draftProjection(value: PlanDraftRevisionRecord | undefined): PlanDraftProjection | null {
@@ -1638,6 +1696,16 @@ export function createPlanningOperations(
               (proposal) => proposal.id !== overrides.proposalOverride!.id,
             ),
           ];
+    const selectedRequestRecord =
+      overrides.selectedProposalId === undefined || overrides.selectedProposalId === null
+        ? undefined
+        : await planningRequests?.readByProposalId(overrides.selectedProposalId);
+    const selectedPlanningRequest = selectedPlanningRequestContext({
+      record: selectedRequestRecord,
+      plan,
+      workouts,
+      todayDateKey,
+    });
     const readiness =
       overrides.readiness ??
       projectPlanReadiness(
@@ -1665,6 +1733,7 @@ export function createPlanningOperations(
         proposals: mergedProposalProjections,
         selectedProposalId: overrides.selectedProposalId,
         selectedProposalReturn: overrides.selectedProposalReturn,
+        selectedPlanningRequest,
         proposalRevisionText: overrides.proposalRevisionText,
         history: historyProjection({ plan, workouts, history: historyRows, todayDateKey }),
         selectedHistoryId: overrides.selectedHistoryId,
@@ -2188,6 +2257,8 @@ export function createPlanningOperations(
     readonly plan: PlanRecord;
     readonly workouts: readonly PlanWorkoutRecord[];
     readonly instruction: string;
+    readonly requestAttention?: PlanningRequestAttention;
+    readonly requestResolvedDateKey?: number | null;
   }): Promise<PlanProposalRecord> => {
     if (dependencies.proposalReviser === undefined)
       throw new Error("Proposal revision unavailable.");
@@ -2252,12 +2323,37 @@ export function createPlanningOperations(
             expectedRevision: linkedRequest.request.revision,
             previousProposalId: inputValue.current.id,
             proposalId: next.id,
+            attention: inputValue.requestAttention ?? "needs_review",
+            resolvedDateKey:
+              inputValue.requestResolvedDateKey ?? linkedRequest.request.resolvedDateKey,
             updatedAtMs: timestamp,
             deviceId,
             hlcPhysicalMs: stamp.physicalMs,
             hlcCounter: stamp.counter,
           },
     );
+  };
+
+  const revisePlanningRequestAttention = async (
+    record: PlanningRequestRecord,
+    attention: PlanningRequestAttention,
+    proposalId = record.request.proposalId,
+    resolvedDateKey = record.request.resolvedDateKey,
+  ): Promise<PlanningRequestRecord> => {
+    if (planningRequests === undefined) return record;
+    const stamp = input.identity.hlcStamp();
+    return planningRequests.reviseOpen({
+      requestId: record.request.requestId,
+      expectedRevision: record.request.revision,
+      planConversationId: record.request.planConversationId,
+      proposalId,
+      attention,
+      resolvedDateKey,
+      updatedAtMs: stamp.physicalMs,
+      deviceId: await input.identity.deviceId(),
+      hlcPhysicalMs: stamp.physicalMs,
+      hlcCounter: stamp.counter,
+    });
   };
 
   const reject = async (
@@ -2376,6 +2472,140 @@ export function createPlanningOperations(
             });
           }
           return reject(UNAVAILABLE);
+        }
+        if (command.transitionId === "PL-T40") {
+          if (planningRequests === undefined) return reject(UNAVAILABLE);
+          const record = await planningRequests.read(command.requestId);
+          if (
+            record === undefined ||
+            record.request.lifecycle !== "open" ||
+            record.request.attention !== "date_conflict" ||
+            record.request.proposalId === null
+          ) {
+            return reject(UNAVAILABLE);
+          }
+          const proposal = await proposalRepository.read(record.request.proposalId);
+          if (proposal?.status !== "proposed") return reject(UNAVAILABLE);
+          const [plan, workouts, premises] = await Promise.all([
+            plans.read(proposal.planId),
+            plans.readWorkouts(proposal.planId),
+            proposalRepository.readPremises(proposal.id),
+          ]);
+          if (plan?.status !== "active") return reject(UNAVAILABLE);
+          const mutation = parsePlanProposalMutation(proposal.mutationJson);
+          const change = mutation.changes[0];
+          if (mutation.changes.length !== 1 || change === undefined || change.before !== null) {
+            return reject(UNAVAILABLE);
+          }
+          const todayDateKey = dependencies.todayDateKey?.() ?? utcTodayDateKey();
+          let resolvedDateKey: number;
+          let nextChange: PlanProposalMutation["changes"][number];
+          if (command.resolution.kind === "use-date") {
+            resolvedDateKey = dateKeyFromText(command.resolution.date);
+            if (
+              resolvedDateKey <= todayDateKey ||
+              planWeekIndex(plan, resolvedDateKey).kind !== "inside" ||
+              workouts.some((workout) => workout.dateKey === resolvedDateKey)
+            ) {
+              return reject({
+                code: "conflict",
+                message: "That date is no longer available. Choose another date.",
+                retryable: true,
+              });
+            }
+            nextChange = {
+              ...change,
+              after: { ...change.after, dateKey: resolvedDateKey },
+            };
+          } else {
+            const replacementWorkoutId = command.resolution.workoutId;
+            const existing = workouts.find((workout) => workout.id === replacementWorkoutId);
+            if (
+              existing === undefined ||
+              existing.origin !== "coach" ||
+              existing.dateKey <= todayDateKey ||
+              existing.dateKey !== record.request.requestedDateKey
+            ) {
+              return reject({
+                code: "conflict",
+                message: "That Workout is protected and cannot be replaced.",
+                retryable: false,
+              });
+            }
+            resolvedDateKey = existing.dateKey;
+            nextChange = {
+              workoutId: existing.id,
+              before: {
+                dateKey: existing.dateKey,
+                sport: existing.sport,
+                name: existing.name,
+                durationS: existing.durationS,
+                structureJson: existing.structureJson,
+              },
+              after: { ...change.after, dateKey: existing.dateKey },
+            };
+          }
+          const stamp = input.identity.hlcStamp();
+          const timestamp = stamp.physicalMs;
+          const deviceId = await input.identity.deviceId();
+          const next: PlanProposalRecord = {
+            ...proposal,
+            id: input.identity.newUlid(),
+            parentProposalId: proposal.id,
+            revision: proposal.revision + 1,
+            mutationJson: encodePlanProposalMutation({
+              schemaVersion: 1,
+              changes: [nextChange],
+              weekLoad: mutation.weekLoad,
+            }),
+            baseSnapshotJson: encodePlanProposalBase(capturePlanProposalBase(plan, workouts)),
+            createdAtMs: timestamp,
+            updatedAtMs: timestamp,
+            deviceId,
+            hlcPhysicalMs: stamp.physicalMs,
+            hlcCounter: stamp.counter,
+          };
+          const nextPremises = premises.map((premise) => ({
+            ...premise,
+            id: input.identity.newUlid(),
+            proposalId: next.id,
+            createdAtMs: timestamp,
+            deviceId,
+            hlcPhysicalMs: stamp.physicalMs,
+            hlcCounter: stamp.counter,
+          }));
+          try {
+            validatePlanProposal({
+              proposal: next,
+              premises: nextPremises,
+              plan,
+              workouts,
+              todayDateKey,
+              calculateWeekLoad: dependencies.proposalLoadCalculator,
+            });
+            await proposalRepository.save(next, nextPremises, {
+              requestId: record.request.requestId,
+              expectedRevision: record.request.revision,
+              previousProposalId: proposal.id,
+              proposalId: next.id,
+              attention: "needs_review",
+              resolvedDateKey,
+              updatedAtMs: timestamp,
+              deviceId,
+              hlcPhysicalMs: stamp.physicalMs,
+              hlcCounter: stamp.counter,
+            });
+          } catch {
+            return reject({
+              code: "conflict",
+              message: "The Plan changed while checking that date. Review the latest options.",
+              retryable: true,
+            });
+          }
+          return ExecutePlanTransitionRpcResultSchema.parse({
+            status: "completed",
+            state: await read({ activeScenario: "PL-S007", selectedProposalId: next.id }),
+          });
         }
         if (command.transitionId === "PL-T37") {
           if (planningRequests === undefined) return reject(UNAVAILABLE);
@@ -3685,6 +3915,18 @@ export function createPlanningOperations(
           if (mutation.weekLoad !== null && dependencies.proposalLoadCalculator === undefined) {
             return reject(UNAVAILABLE);
           }
+          let linkedRequest = await planningRequests?.readByProposalId(proposal.id);
+          if (linkedRequest !== undefined) {
+            try {
+              linkedRequest = await revisePlanningRequestAttention(linkedRequest, "revalidating");
+            } catch {
+              return reject(PERSISTENCE_FAILED, {
+                activeScenario: "PL-S007",
+                selectedProposalId: proposal.id,
+                selectedProposalReturn: command.selectedProposalReturn,
+              });
+            }
+          }
           const operationId = input.identity.newUlid();
           deliver(onEvent, {
             commandId: command.commandId,
@@ -3695,6 +3937,7 @@ export function createPlanningOperations(
             total: 1,
           });
           const ledgerId = input.identity.newUlid();
+          let validationCompleted = false;
           try {
             await revalidatePlanProposalPremises(premises, premiseReader);
             const todayDateKey = dependencies.todayDateKey?.() ?? utcTodayDateKey();
@@ -3706,8 +3949,8 @@ export function createPlanningOperations(
               todayDateKey,
               calculateWeekLoad: dependencies.proposalLoadCalculator,
             });
+            validationCompleted = true;
             const stamp = input.identity.hlcStamp();
-            const linkedRequest = await planningRequests?.readByProposalId(proposal.id);
             const requestWorkout =
               linkedRequest === undefined ? null : planningRequestWorkout(linkedRequest);
             const appliedDateKey =
@@ -3755,6 +3998,11 @@ export function createPlanningOperations(
             });
           } catch (error) {
             if (error instanceof PlanProposalError && error.code === "missing-capability") {
+              if (linkedRequest !== undefined) {
+                await revisePlanningRequestAttention(linkedRequest, "needs_review").catch(
+                  () => undefined,
+                );
+              }
               deliver(onEvent, {
                 commandId: command.commandId,
                 transitionId: command.transitionId,
@@ -3795,10 +4043,17 @@ export function createPlanningOperations(
                     workouts: latestWorkouts,
                     instruction:
                       "Revalidate this Proposal against the current Plan and source data without changing the athlete's intent.",
+                    requestAttention: "stale_base",
                   });
                 } catch {
                   current = proposal;
                 }
+              }
+              if (linkedRequest !== undefined && current.id === proposal.id) {
+                linkedRequest = await revisePlanningRequestAttention(
+                  linkedRequest,
+                  "stale_base",
+                ).catch(() => linkedRequest);
               }
               const currentPremises = await proposalRepository.readPremises(current.id);
               const projected = proposalProjection({
@@ -3834,7 +4089,24 @@ export function createPlanningOperations(
               completed: 0,
               total: 1,
             });
-            return reject(PROPOSAL_INVALID, {
+            if (!validationCompleted) {
+              if (linkedRequest !== undefined) {
+                await revisePlanningRequestAttention(linkedRequest, "needs_review").catch(
+                  () => undefined,
+                );
+              }
+              return reject(PROPOSAL_INVALID, {
+                activeScenario: "PL-S007",
+                selectedProposalId: proposal.id,
+                selectedProposalReturn: command.selectedProposalReturn,
+              });
+            }
+            if (linkedRequest !== undefined) {
+              await revisePlanningRequestAttention(linkedRequest, "apply_failed").catch(
+                () => undefined,
+              );
+            }
+            return reject(PERSISTENCE_FAILED, {
               activeScenario: "PL-S007",
               selectedProposalId: proposal.id,
               selectedProposalReturn: command.selectedProposalReturn,

--- a/packages/coach/tests/planning-operations.test.ts
+++ b/packages/coach/tests/planning-operations.test.ts
@@ -3065,6 +3065,318 @@ describe("Plan operations", () => {
     await expect(plans.readWorkouts(planId)).resolves.toEqual([existingWorkout]);
   });
 
+  it("resolves Chat date conflicts without replacing protected Workouts", async () => {
+    const planId = `${"0".repeat(25)}P`;
+    const coachWorkoutId = `${"0".repeat(25)}W`;
+    const athleteWorkoutId = `${"0".repeat(25)}X`;
+    const importedWorkoutId = `${"0".repeat(25)}Y`;
+    const activePlan: PlanRecord = { ...plan(planId, 10), status: "active" };
+    const coachWorkout: PlanWorkoutRecord = {
+      id: coachWorkoutId,
+      planId,
+      dateKey: 20260831,
+      sport: "cycling",
+      name: "Easy endurance",
+      durationS: 3_000,
+      structureJson: "{}",
+      origin: "coach",
+      deviceId: "device-1",
+      hlcPhysicalMs: 10,
+      hlcCounter: 0,
+    };
+    const athleteWorkout: PlanWorkoutRecord = {
+      ...coachWorkout,
+      id: athleteWorkoutId,
+      name: "Club ride",
+      origin: "athlete",
+    };
+    const plans = createPlanRepository(store);
+    const proposals = createPlanProposalRepository(store);
+    const requests = createPlanningRequestRepository(store, createNodeCrypto());
+    await plans.replace(activePlan, [coachWorkout, athleteWorkout]);
+    const seed = async (input: {
+      readonly requestId: string;
+      readonly proposalId: string;
+      readonly premiseId: string;
+      readonly chatId: string;
+      readonly messageId: string;
+      readonly timestamp: number;
+    }): Promise<void> => {
+      await proposals.save(
+        {
+          id: input.proposalId,
+          planId,
+          parentProposalId: null,
+          revision: 1,
+          status: "proposed",
+          title: "Add Tempo 3 × 12",
+          rationale: "Review the selected Workout before changing the active Plan.",
+          confidence: "High",
+          mutationJson: encodePlanProposalMutation({
+            schemaVersion: 1,
+            changes: [
+              {
+                workoutId: importedWorkoutId,
+                before: null,
+                after: {
+                  dateKey: 20260831,
+                  sport: "cycling",
+                  name: "Tempo 3 × 12",
+                  durationS: 3_840,
+                  structureJson: "{}",
+                },
+              },
+            ],
+            weekLoad: null,
+          }),
+          baseSnapshotJson: encodePlanProposalBase(
+            capturePlanProposalBase(activePlan, [coachWorkout, athleteWorkout]),
+          ),
+          refusalReason: null,
+          createdAtMs: input.timestamp,
+          updatedAtMs: input.timestamp,
+          resolvedAtMs: null,
+          deviceId: "device-1",
+          hlcPhysicalMs: input.timestamp,
+          hlcCounter: 0,
+        },
+        [
+          {
+            id: input.premiseId,
+            proposalId: input.proposalId,
+            sourceType: "chat-workout",
+            sourceId: "workout-selection",
+            sourceLabel: "Tempo 3 × 12 · MRC",
+            sourceDateKey: null,
+            confidence: "High",
+            snapshotJson: '{"workoutId":"tempo-3x12"}',
+            createdAtMs: input.timestamp,
+            deviceId: "device-1",
+            hlcPhysicalMs: input.timestamp,
+            hlcCounter: 0,
+          },
+        ],
+      );
+      const request = await requests.createOrGet({
+        payload: {
+          requestId: input.requestId,
+          kind: "workout_review",
+          intent: "Add Tempo 3 × 12 to Monday.",
+          source: {
+            chatId: input.chatId,
+            messageId: input.messageId,
+            attachmentId: `${input.requestId}-attachment`,
+          },
+          sourceSnapshot: {
+            capturedAt: "1998-08-24T08:00:00.000Z",
+            attachment: {
+              attachmentId: `${input.requestId}-attachment`,
+              displayName: "tempo-3x12.mrc",
+              extension: "mrc",
+            },
+            selectedWorkout: {
+              setId: `${input.requestId}-set`,
+              workoutId: `${input.requestId}-workout`,
+              workout: { title: "Tempo 3 × 12", sport: "cycling", durationSeconds: 3_840 },
+            },
+          },
+          requestedDate: "2026-08-31",
+        },
+        target: "active_plan",
+        createdAtMs: input.timestamp + 1,
+        deviceId: "device-1",
+        hlcPhysicalMs: input.timestamp + 1,
+        hlcCounter: 0,
+      });
+      await requests.reviseOpen({
+        requestId: input.requestId,
+        expectedRevision: request.request.revision,
+        planConversationId: null,
+        proposalId: input.proposalId,
+        attention: "date_conflict",
+        resolvedDateKey: null,
+        updatedAtMs: input.timestamp + 2,
+        deviceId: "device-1",
+        hlcPhysicalMs: input.timestamp + 2,
+        hlcCounter: 0,
+      });
+    };
+    await seed({
+      requestId: "request-date",
+      proposalId: `${"0".repeat(25)}M`,
+      premiseId: `${"0".repeat(25)}R`,
+      chatId: "chat-date",
+      messageId: "message-date",
+      timestamp: 20,
+    });
+    const authored = identity();
+    const operations = createPlanningOperations(
+      { context, engine: engine(), identity: authored },
+      { plans, proposals, requests, todayDateKey: () => 20260826 },
+    );
+
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T36",
+        commandId: "command-open-date-conflict",
+        sourceConversationId: "chat-date",
+        requestId: "request-date",
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S007",
+        data: {
+          selectedPlanningRequest: {
+            dateConflict: {
+              recommendedDate: "2026-09-01",
+              workouts: expect.arrayContaining([
+                expect.objectContaining({ workoutId: coachWorkoutId, replaceable: true }),
+                expect.objectContaining({ workoutId: athleteWorkoutId, replaceable: false }),
+              ]),
+            },
+          },
+        },
+      },
+    });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T40",
+        commandId: "command-protected-date-conflict",
+        requestId: "request-date",
+        resolution: { kind: "replace-workout", workoutId: athleteWorkoutId },
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      error: { code: "conflict", retryable: false },
+    });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T40",
+        commandId: "command-use-recommended-date",
+        requestId: "request-date",
+        resolution: { kind: "use-date", date: "2026-09-01" },
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      state: {
+        scenarioId: "PL-S007",
+        data: {
+          selectedPlanningRequest: {
+            request: { attention: "needs_review", resolvedDateKey: 20260901 },
+            dateConflict: null,
+          },
+        },
+      },
+    });
+    const dateRequest = await requests.read("request-date");
+    expect(dateRequest?.request).toMatchObject({
+      attention: "needs_review",
+      resolvedDateKey: 20260901,
+    });
+    const dateProposal =
+      dateRequest?.request.proposalId === null || dateRequest === undefined
+        ? undefined
+        : await proposals.read(dateRequest.request.proposalId);
+    expect(JSON.parse(dateProposal?.mutationJson ?? "{}")).toMatchObject({
+      changes: [{ after: { dateKey: 20260901 } }],
+    });
+
+    await seed({
+      requestId: "request-replace",
+      proposalId: `${"0".repeat(25)}N`,
+      premiseId: `${"0".repeat(25)}S`,
+      chatId: "chat-replace",
+      messageId: "message-replace",
+      timestamp: 50,
+    });
+    await expect(
+      operations.executePlanTransition?.({
+        transitionId: "PL-T40",
+        commandId: "command-replace-coach-workout",
+        requestId: "request-replace",
+        resolution: { kind: "replace-workout", workoutId: coachWorkoutId },
+      }),
+    ).resolves.toMatchObject({ status: "completed", state: { scenarioId: "PL-S007" } });
+    const replaceRequest = await requests.read("request-replace");
+    const replaceProposal =
+      replaceRequest?.request.proposalId === null || replaceRequest === undefined
+        ? undefined
+        : await proposals.read(replaceRequest.request.proposalId);
+    expect(JSON.parse(replaceProposal?.mutationJson ?? "{}")).toMatchObject({
+      changes: [
+        {
+          workoutId: coachWorkoutId,
+          before: { name: "Easy endurance" },
+          after: { name: "Tempo 3 × 12", dateKey: 20260831 },
+        },
+      ],
+    });
+
+    if (dateProposal === undefined) throw new TypeError("Resolved date Proposal missing.");
+    const beforeFailedApply = await plans.readWorkouts(planId);
+    const failingOperations = createPlanningOperations(
+      { context, engine: engine(), identity: authored },
+      {
+        plans,
+        proposals: {
+          ...proposals,
+          apply: async () => {
+            throw new TypeError("synthetic local save failure");
+          },
+        },
+        requests,
+        todayDateKey: () => 20260826,
+        proposalPremiseReader: { read: async () => '{"workoutId":"tempo-3x12"}' },
+      },
+    );
+    await expect(
+      failingOperations.executePlanTransition?.({
+        transitionId: "PL-T19",
+        commandId: "command-failed-date-apply",
+        proposalId: dateProposal.id,
+        expectedRevision: dateProposal.revision,
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      error: { code: "persistence-failed", retryable: true },
+      state: {
+        scenarioId: "PL-S007",
+        data: {
+          selectedPlanningRequest: {
+            request: { attention: "apply_failed" },
+          },
+        },
+      },
+    });
+    await expect(plans.readWorkouts(planId)).resolves.toEqual(beforeFailedApply);
+    await expect(requests.read("request-date")).resolves.toMatchObject({
+      request: { lifecycle: "open", attention: "apply_failed" },
+    });
+
+    const recoveringOperations = createPlanningOperations(
+      { context, engine: engine(), identity: authored },
+      {
+        plans,
+        proposals,
+        requests,
+        todayDateKey: () => 20260826,
+        proposalPremiseReader: { read: async () => '{"workoutId":"tempo-3x12"}' },
+      },
+    );
+    await expect(
+      recoveringOperations.executePlanTransition?.({
+        transitionId: "PL-T19",
+        commandId: "command-retry-date-apply",
+        proposalId: dateProposal.id,
+        expectedRevision: dateProposal.revision,
+      }),
+    ).resolves.toMatchObject({ status: "completed", state: { scenarioId: "PL-S008" } });
+    await expect(requests.read("request-date")).resolves.toMatchObject({
+      request: { lifecycle: "applied", attention: "none" },
+    });
+  });
+
   it("opens Season and Race week without mutating persisted Plan facts", async () => {
     const planId = `${"0".repeat(25)}A`;
     const raceWorkoutId = `${"0".repeat(25)}B`;

--- a/packages/core/src/agent/transcript-store.ts
+++ b/packages/core/src/agent/transcript-store.ts
@@ -30,6 +30,7 @@ import {
   CoachDecisionAnswerSchema,
   CoachDecisionReadModelSchema,
   PlanReferenceSelectionSchema,
+  PlanHandoffSuggestionSchema,
   PlanIntakePatchSchema,
   type CoachDecisionAnswer,
   type CoachDecisionContinuationLineage,
@@ -37,6 +38,7 @@ import {
   type CoachDecisionReadModel,
   type ChatAttachmentReference,
   type PlanReferenceSelection,
+  type PlanHandoffSuggestion,
   type PlanIntakePatch,
 } from "@enduragent/coach-contract";
 import {
@@ -250,6 +252,7 @@ export interface TranscriptPageTurn {
   readonly delivery?: "interrupted";
   readonly attachments?: ChatAttachmentReference[];
   readonly planReference?: PlanReferenceSelection;
+  readonly planHandoff?: PlanHandoffSuggestion;
 }
 
 export type TranscriptPageEntry =
@@ -461,6 +464,7 @@ function parseRecordBytes(bytes: Buffer): TranscriptRecord | null {
     const optionalKeys = [
       ...(value.attachments === undefined ? [] : ["attachments"]),
       ...(value.planReference === undefined ? [] : ["planReference"]),
+      ...(value.planHandoff === undefined ? [] : ["planHandoff"]),
     ];
     if (
       !hasExactKeys(value, [...keys, ...optionalKeys]) ||
@@ -472,10 +476,13 @@ function parseRecordBytes(bytes: Buffer): TranscriptRecord | null {
       typeof value.athleteText !== "string" ||
       typeof value.coachText !== "string" ||
       (value.kind === "turn-interrupted" && value.planReference !== undefined) ||
+      (value.kind === "turn-interrupted" && value.planHandoff !== undefined) ||
       (value.attachments !== undefined &&
         !ChatAttachmentReferenceSchema.array().max(5).safeParse(value.attachments).success) ||
       (value.planReference !== undefined &&
-        !PlanReferenceSelectionSchema.safeParse(value.planReference).success)
+        !PlanReferenceSelectionSchema.safeParse(value.planReference).success) ||
+      (value.planHandoff !== undefined &&
+        !PlanHandoffSuggestionSchema.safeParse(value.planHandoff).success)
     ) {
       return null;
     }
@@ -680,7 +687,9 @@ function completedTurnRecord(input: TranscriptCompletedTurnInput): TranscriptCom
     (input.attachments !== undefined &&
       !ChatAttachmentReferenceSchema.array().max(5).safeParse(input.attachments).success) ||
     (input.planReference !== undefined &&
-      !PlanReferenceSelectionSchema.safeParse(input.planReference).success)
+      !PlanReferenceSelectionSchema.safeParse(input.planReference).success) ||
+    (input.planHandoff !== undefined &&
+      !PlanHandoffSuggestionSchema.safeParse(input.planHandoff).success)
   ) {
     throw new TypeError("Completed transcript turn is invalid.");
   }
@@ -694,14 +703,15 @@ function completedTurnRecord(input: TranscriptCompletedTurnInput): TranscriptCom
     coachText: input.coachText,
     ...(input.attachments === undefined ? {} : { attachments: [...input.attachments] }),
     ...(input.planReference === undefined ? {} : { planReference: { ...input.planReference } }),
+    ...(input.planHandoff === undefined ? {} : { planHandoff: { ...input.planHandoff } }),
   };
 }
 
 function interruptedTurnRecord(
   input: TranscriptInterruptedTurnInput,
 ): TranscriptInterruptedTurnRecord {
-  if (input.planReference !== undefined) {
-    throw new TypeError("Interrupted transcript turn cannot carry a Plan reference.");
+  if (input.planReference !== undefined || input.planHandoff !== undefined) {
+    throw new TypeError("Interrupted transcript turn cannot carry Plan metadata.");
   }
   const completed = completedTurnRecord(input);
   return { ...completed, kind: "turn-interrupted" };
@@ -955,6 +965,7 @@ function transcriptPageTurn(record: TranscriptTurnRecord): TranscriptPageTurn {
     coachText: record.coachText,
     ...(record.attachments === undefined ? {} : { attachments: [...record.attachments] }),
     ...(record.planReference === undefined ? {} : { planReference: record.planReference }),
+    ...(record.planHandoff === undefined ? {} : { planHandoff: record.planHandoff }),
     ...(record.kind === "turn-interrupted" ? { delivery: "interrupted" as const } : {}),
   };
 }

--- a/packages/core/tests/transcript-store.test.ts
+++ b/packages/core/tests/transcript-store.test.ts
@@ -483,6 +483,31 @@ describe("TranscriptStore append and corruption handling", () => {
     });
   });
 
+  it("round-trips one typed Plan handoff for relaunch hydration", () => {
+    const dataDir = makeDataDir();
+    const store = new TranscriptStore(dataDir);
+    const input = {
+      ...turn("chat-plan-handoff", "turn-1", "Can we move Friday?", "Review it in Plan."),
+      planHandoff: {
+        kind: "plan_change" as const,
+        title: "Review a lighter Friday",
+        intent: "Move Friday's endurance Workout to Saturday and keep Friday easy.",
+      },
+    };
+
+    store.appendCompletedTurn(input);
+
+    expect(store.readCurrentConversation(input.chatId)).toEqual([
+      { version: 1, kind: "turn-completed", ...input },
+    ]);
+    expect(
+      store.readCurrentConversationPage(input.chatId, { cursor: null, limit: 10 }),
+    ).toMatchObject({
+      status: "page",
+      turns: [{ turnId: "turn-1", planHandoff: input.planHandoff }],
+    });
+  });
+
   it("rejects arbitrary Plan-card markup in transcript records", () => {
     const store = new TranscriptStore(makeDataDir());
     expect(() =>

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -99,6 +99,7 @@ import {
   decisionRequestInput,
 } from "./coach-decision-tool.js";
 import { PLAN_REFERENCE_TOOL_NAME, createPlanReferenceTool } from "./plan-reference-tool.js";
+import { PLAN_HANDOFF_TOOL_NAME, createPlanHandoffTool } from "./plan-handoff-tool.js";
 import { attachNativeMediaToCurrentUserMessage } from "../native-media-message.js";
 import { createPlanIntakeTool, PLAN_INTAKE_TOOL_NAME } from "./plan-intake-tool.js";
 import { assertPlanCoachReplyAuthority } from "./plan-coach-authority.js";
@@ -361,6 +362,7 @@ export class CoachAgent {
   private chatStore: ChatStorePort;
   private log: LoggerPort;
   private tools: ToolSet;
+  private readonly desktopTools: ToolSet;
   private readonly planTools: ToolSet;
   private readonly decisionTool: Tool | undefined;
   private readonly planReferenceTool: Tool | undefined;
@@ -377,6 +379,7 @@ export class CoachAgent {
   // skills, tool schemas, model, and the compile-time rule-block set), so it is
   // computed once on first use and reused for every turn of the process.
   private templateHash?: string;
+  private desktopTemplateHash?: string;
   private planTemplateHash?: string;
   private readonly activeChatTurns = new Map<
     string,
@@ -495,6 +498,12 @@ export class CoachAgent {
         ? {}
         : { [PLAN_REFERENCE_TOOL_NAME]: this.planReferenceTool }),
     };
+    this.desktopTools = {
+      ...this.tools,
+      [PLAN_HANDOFF_TOOL_NAME]: capToolResult(markUntrustedResult(createPlanHandoffTool()), {
+        maxResultTokens,
+      }),
+    };
     const planIntakeTool = createPlanIntakeTool();
     this.planTools = {
       ...(this.decisionTool === undefined ? {} : { [COACH_DECISION_TOOL_NAME]: this.decisionTool }),
@@ -506,11 +515,16 @@ export class CoachAgent {
   }
 
   private toolsForChat(chatId: string): ToolSet {
-    return chatId.startsWith("plan:") ? this.planTools : this.tools;
+    if (chatId.startsWith("plan:")) return this.planTools;
+    return chatId === "desktop" ? this.desktopTools : this.tools;
   }
 
   private templateHashForChat(chatId: string, tools: ToolSet): string {
-    const current = chatId.startsWith("plan:") ? this.planTemplateHash : this.templateHash;
+    const current = chatId.startsWith("plan:")
+      ? this.planTemplateHash
+      : chatId === "desktop"
+        ? this.desktopTemplateHash
+        : this.templateHash;
     if (current !== undefined) return current;
     const value = computeTemplateHash({
       soul: chatId.startsWith("plan:") ? PLAN_COACH_AUTHORITY_RULES : this.sport.soul,
@@ -524,6 +538,7 @@ export class CoachAgent {
       model: this.config.llm.model,
     });
     if (chatId.startsWith("plan:")) this.planTemplateHash = value;
+    else if (chatId === "desktop") this.desktopTemplateHash = value;
     else this.templateHash = value;
     return value;
   }
@@ -1274,6 +1289,9 @@ export class CoachAgent {
                   ...(ctx.planReference.selection === null
                     ? {}
                     : { planReference: ctx.planReference.selection }),
+                  ...(ctx.planHandoff.suggestion === null
+                    ? {}
+                    : { planHandoff: ctx.planHandoff.suggestion }),
                 });
               }
               if (ctx.planIntake.patch !== null) onPlanIntake?.(ctx.planIntake.patch);
@@ -1282,6 +1300,13 @@ export class CoachAgent {
                   type: "plan-reference",
                   turnId,
                   selection: ctx.planReference.selection,
+                });
+              }
+              if (ctx.planHandoff.suggestion !== null) {
+                emitEvent({
+                  type: "plan-handoff",
+                  turnId,
+                  suggestion: ctx.planHandoff.suggestion,
                 });
               }
               emitEvent({ type: "final-text", turnId, text: responseText });

--- a/packages/engine/src/agent/plan-handoff-tool.ts
+++ b/packages/engine/src/agent/plan-handoff-tool.ts
@@ -1,0 +1,27 @@
+import { tool, zodSchema } from "ai";
+import {
+  PlanHandoffSuggestionSchema,
+  PlanHandoffToolResultSchema,
+  type PlanHandoffSuggestion,
+} from "@enduragent/coach-contract";
+import { getTurnContext } from "./turn-context.js";
+
+export const PLAN_HANDOFF_TOOL_NAME = "request_plan_handoff";
+
+export function createPlanHandoffTool() {
+  return tool({
+    description:
+      "Request one host-owned Continue in Plan card when the athlete's text needs Plan-native creation or structured review. This does not change Plan.",
+    inputSchema: zodSchema(PlanHandoffSuggestionSchema),
+    execute: async (request: PlanHandoffSuggestion, options: unknown) => {
+      const suggestion = PlanHandoffSuggestionSchema.parse(request);
+      const context = getTurnContext(options);
+      const selected =
+        context?.chatId === "desktop" ? (context.planHandoff.suggestion ?? suggestion) : suggestion;
+      if (context?.chatId === "desktop" && context.planHandoff.suggestion === null) {
+        context.planHandoff.suggestion = selected;
+      }
+      return PlanHandoffToolResultSchema.parse({ status: "ready", suggestion: selected });
+    },
+  });
+}

--- a/packages/engine/src/agent/turn-context.ts
+++ b/packages/engine/src/agent/turn-context.ts
@@ -3,6 +3,7 @@ import { EMPTY_PROVENANCE, type SourceProvenance } from "../provenance.js";
 import type {
   CoachDecisionReadModel,
   PlanIntakePatch,
+  PlanHandoffSuggestion,
   PlanReferenceSelection,
 } from "@enduragent/coach-contract";
 
@@ -22,6 +23,10 @@ export interface TurnDecisionRecord {
 
 export interface TurnPlanReferenceRecord {
   selection: PlanReferenceSelection | null;
+}
+
+export interface TurnPlanHandoffRecord {
+  suggestion: PlanHandoffSuggestion | null;
 }
 
 export interface TurnPlanIntakeRecord {
@@ -54,6 +59,7 @@ export interface TurnContext {
   readonly referenceProvenance: SourceProvenance;
   readonly decision: TurnDecisionRecord;
   readonly planReference: TurnPlanReferenceRecord;
+  readonly planHandoff: TurnPlanHandoffRecord;
   readonly planIntake: TurnPlanIntakeRecord;
 }
 
@@ -82,6 +88,7 @@ export function createTurnContext(
     referenceProvenance,
     decision: { requested: null, fallbackText: null },
     planReference: { selection: null },
+    planHandoff: { suggestion: null },
     planIntake: { patch: null },
   };
   return ctx;

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -9,6 +9,7 @@ import type {
   CoachDecisionContinuationLineage,
   CoachDecisionReadModel,
   PlanIntakePatch,
+  PlanHandoffSuggestion,
   RequestUserDecisionInput,
   RequestUserDecisionResult,
 } from "@enduragent/coach-contract";
@@ -255,6 +256,7 @@ export interface TranscriptCompletedTurnInput {
   readonly coachText: string;
   readonly attachments?: readonly ChatAttachmentReference[];
   readonly planReference?: PlanReferenceSelection;
+  readonly planHandoff?: PlanHandoffSuggestion;
 }
 
 export type TranscriptInterruptedTurnInput = TranscriptCompletedTurnInput;

--- a/packages/engine/tests/coach-agent-transcript.test.ts
+++ b/packages/engine/tests/coach-agent-transcript.test.ts
@@ -212,6 +212,44 @@ describe("CoachAgent transcript recording", () => {
     ]);
   });
 
+  it("emits and persists one Desktop Plan handoff before final text", async () => {
+    const setup = harness({
+      generate: async (request) => {
+        const handoffTool = request.options.tools?.request_plan_handoff;
+        if (handoffTool?.execute === undefined) throw new TypeError("Plan handoff tool missing");
+        await (handoffTool.execute as (input: unknown, options: unknown) => Promise<unknown>)(
+          {
+            kind: "plan_change",
+            title: "Review a lighter Friday",
+            intent: "Move Friday's endurance Workout to Saturday and keep Friday easy.",
+          },
+          { toolCallId: "tool-1", experimental_context: request.options.context },
+        );
+        return result("I prepared a safe Plan review.");
+      },
+    });
+    const events: TurnEvent[] = [];
+
+    await setup.agent.chat("desktop", "Can we move Friday?", undefined, (event) =>
+      events.push(event),
+    );
+
+    const suggestion = {
+      kind: "plan_change" as const,
+      title: "Review a lighter Friday",
+      intent: "Move Friday's endurance Workout to Saturday and keep Friday easy.",
+    };
+    expect(setup.completed).toMatchObject([{ planHandoff: suggestion }]);
+    expect(events.slice(-2)).toEqual([
+      { type: "plan-handoff", turnId: "turn-transcript-1", suggestion },
+      {
+        type: "final-text",
+        turnId: "turn-transcript-1",
+        text: "I prepared a safe Plan review.",
+      },
+    ]);
+  });
+
   it.each(["ENOSPC", "EACCES"])(
     "keeps final delivery exact and single when the transcript writer throws %s",
     async (code) => {

--- a/packages/engine/tests/plan-handoff-tool.test.ts
+++ b/packages/engine/tests/plan-handoff-tool.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { createPlanHandoffTool } from "../src/agent/plan-handoff-tool.js";
+import { createTurnContext } from "../src/agent/turn-context.js";
+
+const suggestion = {
+  kind: "plan_change" as const,
+  title: "Review a lighter Friday",
+  intent: "Move Friday's endurance Workout to Saturday and keep Friday easy.",
+  requestedDate: "2026-08-29",
+};
+
+async function execute(chatId: string, request: unknown = suggestion) {
+  const context = createTurnContext(null, chatId, undefined, "Can we move Friday?", "turn-1");
+  const handoffTool = createPlanHandoffTool();
+  const result = await (
+    handoffTool.execute as (input: unknown, options: unknown) => Promise<unknown>
+  )(request, { toolCallId: "tool-1", experimental_context: context });
+  return { context, result };
+}
+
+describe("request_plan_handoff tool", () => {
+  it("records one strict host-owned suggestion for Desktop", async () => {
+    const value = await execute("desktop");
+    expect(value.context.planHandoff.suggestion).toEqual(suggestion);
+    expect(value.result).toEqual({ status: "ready", suggestion });
+  });
+
+  it("returns the suggestion without recording a host card outside Desktop", async () => {
+    const value = await execute("telegram:42");
+    expect(value.context.planHandoff.suggestion).toBeNull();
+    expect(value.result).toEqual({ status: "ready", suggestion });
+  });
+
+  it("rejects arbitrary markup fields", async () => {
+    await expect(
+      execute("desktop", { ...suggestion, markup: "<button>Apply</button>" }),
+    ).rejects.toThrow();
+  });
+
+  it("keeps the first Desktop suggestion when the model calls twice", async () => {
+    const context = createTurnContext(null, "desktop", undefined, "Can we move Friday?", "turn-1");
+    const handoffTool = createPlanHandoffTool();
+    const executeTool = handoffTool.execute as (
+      input: unknown,
+      options: unknown,
+    ) => Promise<unknown>;
+    const options = { toolCallId: "tool-1", experimental_context: context };
+    await executeTool(suggestion, options);
+    const second = await executeTool(
+      { ...suggestion, title: "A different card", intent: "A different request." },
+      options,
+    );
+    expect(context.planHandoff.suggestion).toEqual(suggestion);
+    expect(second).toEqual({ status: "ready", suggestion });
+  });
+});

--- a/packages/kernel-node/tests/plan-proposal-repository.test.ts
+++ b/packages/kernel-node/tests/plan-proposal-repository.test.ts
@@ -535,6 +535,8 @@ describe("Plan proposal repository", () => {
         expectedRevision: record.request.revision,
         previousProposalId: initialId,
         proposalId: revisedId,
+        attention: "stale_base",
+        resolvedDateKey: 20260831,
         updatedAtMs: 40,
         deviceId: "device-1",
         hlcPhysicalMs: 40,
@@ -543,7 +545,12 @@ describe("Plan proposal repository", () => {
     );
     await expect(proposals.read(initialId)).resolves.toMatchObject({ status: "superseded" });
     await expect(requests.read(requestId)).resolves.toMatchObject({
-      request: { proposalId: revisedId, revision: record.request.revision + 1 },
+      request: {
+        proposalId: revisedId,
+        attention: "stale_base",
+        resolvedDateKey: 20260831,
+        revision: record.request.revision + 1,
+      },
     });
   });
 

--- a/packages/kernel/src/planning/request-transaction.ts
+++ b/packages/kernel/src/planning/request-transaction.ts
@@ -3,12 +3,15 @@ import type { SqlStore } from "../store/ports.js";
 import { addCivilDays } from "./date-keys.js";
 import { PlanningRequestStoreError } from "./request-errors.js";
 import type { PlanningRequestTerminalResult } from "./request-repository.js";
+import type { PlanningRequestAttention } from "./request-repository.js";
 
 export interface PlanningRequestProposalLinkTransactionInput {
   readonly requestId: string;
   readonly expectedRevision: number;
   readonly previousProposalId: string;
   readonly proposalId: string;
+  readonly attention: PlanningRequestAttention;
+  readonly resolvedDateKey: number | null;
   readonly updatedAtMs: number;
   readonly deviceId: string;
   readonly hlcPhysicalMs: number;
@@ -83,6 +86,9 @@ export async function linkPlanningRequestProposalInTransaction(
   store: SqlStore,
   input: PlanningRequestProposalLinkTransactionInput,
 ): Promise<void> {
+  if (!validDateKey(input.resolvedDateKey) || input.attention === "none") {
+    throw new PlanningRequestStoreError("invalid-transition");
+  }
   const row = await store.get(
     `SELECT lifecycle,proposal_id,revision,updated_at_ms,hlc_physical_ms,hlc_counter
 FROM planning_request WHERE request_id=?`,
@@ -100,11 +106,13 @@ FROM planning_request WHERE request_id=?`,
   }
   requireMutationClock(row, input);
   await store.run(
-    `UPDATE planning_request SET proposal_id=?,revision=revision+1,updated_at_ms=?,device_id=?,
+    `UPDATE planning_request SET proposal_id=?,attention=?,resolved_date_key=?,revision=revision+1,updated_at_ms=?,device_id=?,
 hlc_physical_ms=?,hlc_counter=?
 WHERE request_id=? AND lifecycle='open' AND proposal_id=? AND revision=?`,
     [
       input.proposalId,
+      input.attention,
+      input.resolvedDateKey,
       input.updatedAtMs,
       input.deviceId,
       input.hlcPhysicalMs,


### PR DESCRIPTION
## Summary
- add a host-owned Continue in Plan handoff for text-only coaching requests
- preserve request identity through failed, uncertain, and relaunched delivery
- resolve Workout date conflicts safely and protect athlete-created Workouts
- keep failed Proposal application recoverable without changing the active Plan

## Verification
- root `pnpm check`
- full `pnpm test`: 724 files passed, 5 skipped; 10,771 tests passed, 17 skipped
- focused acceptance suite: 11 files and 336 tests passed
- autoreview clean with no accepted or actionable findings

User-facing: Coach can safely continue relevant advice in Plan, retry preserved requests, resolve Workout date conflicts, and recover from a failed local Plan save.