### PR TITLE
fix(desktop): resolve chat UI QA findings

### DIFF
--- a/.changeset/chat-ui-qa-fixes.md
+++ b/.changeset/chat-ui-qa-fixes.md
@@ -1,0 +1,11 @@
+---
+"@enduragent/coach-contract": patch
+"@enduragent/coach-client": patch
+"@enduragent/kernel": patch
+"@enduragent/core": patch
+"@enduragent/coach": patch
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Past chats can now be permanently deleted with clear confirmation while imported activities and Plan work stay intact. Chat also keeps its safety note visible when cards stack up, orders those cards consistently, and closes the compact Training context drawer reliably from the keyboard.

--- a/apps/desktop-renderer/src/archive/controller.ts
+++ b/apps/desktop-renderer/src/archive/controller.ts
@@ -17,6 +17,7 @@ export interface ArchivedConversationList {
 
 export type ArchiveListStatus = "idle" | "loading" | "ready" | "failed";
 export type ArchiveReadingStatus = "loading" | "ready" | "failed" | "unavailable";
+export type ArchiveDeletionStatus = "confirming" | "deleting" | "failed";
 
 export interface ArchiveReadingState {
   readonly boundaryRef: string;
@@ -26,11 +27,22 @@ export interface ArchiveReadingState {
   readonly hasEarlier: boolean;
 }
 
+export interface ArchiveDeletionState {
+  readonly boundaryRef: string;
+  readonly status: ArchiveDeletionStatus;
+}
+
+export interface DeleteArchivedConversationResult {
+  readonly schemaVersion: 1;
+  readonly status: "deleted" | "not-found";
+}
+
 export interface ArchiveViewState {
   readonly listStatus: ArchiveListStatus;
   readonly conversations: readonly ArchivedConversationEntry[];
   readonly truncated: boolean;
   readonly reading: ArchiveReadingState | null;
+  readonly deletion: ArchiveDeletionState | null;
 }
 
 export interface ArchiveView {
@@ -43,6 +55,9 @@ export interface ArchiveController {
   close(): void;
   loadEarlier(): Promise<void>;
   retry(): Promise<void>;
+  requestDeletion(boundaryRef: string): void;
+  cancelDeletion(): void;
+  confirmDeletion(): Promise<void>;
   dispose(): void;
 }
 
@@ -51,6 +66,7 @@ export const EMPTY_ARCHIVE_SURFACE: ArchiveViewState = Object.freeze({
   conversations: Object.freeze([]),
   truncated: false,
   reading: null,
+  deletion: null,
 });
 
 function uniqueTurns(
@@ -72,13 +88,16 @@ export function createArchiveController(input: {
     readonly cursor: string | null;
     readonly limit: number;
   }) => Promise<TranscriptPage>;
+  readonly deleteConversation: (boundaryRef: string) => Promise<DeleteArchivedConversationResult>;
   readonly view: ArchiveView;
 }): ArchiveController {
   let state = EMPTY_ARCHIVE_SURFACE;
   let disposed = false;
   let readerEpoch = 0;
+  let listEpoch = 0;
   let listTask: Promise<void> | undefined;
   let pageTask: Promise<void> | undefined;
+  let deletionTask: Promise<void> | undefined;
   let nextCursor: string | null = null;
   let failedCursor: string | null | undefined;
 
@@ -95,11 +114,12 @@ export function createArchiveController(input: {
   const loadList = (): Promise<void> => {
     if (disposed) return Promise.resolve();
     if (listTask !== undefined) return listTask;
+    const requestEpoch = listEpoch;
     publish({ ...state, listStatus: "loading" });
     const pending = (async () => {
       try {
         const listed = await input.listConversations();
-        if (disposed) return;
+        if (disposed || listEpoch !== requestEpoch) return;
         publish({
           ...state,
           listStatus: "ready",
@@ -107,7 +127,9 @@ export function createArchiveController(input: {
           truncated: listed.truncated,
         });
       } catch {
-        if (!disposed) publish({ ...state, listStatus: "failed" });
+        if (!disposed && listEpoch === requestEpoch) {
+          publish({ ...state, listStatus: "failed" });
+        }
       }
     })();
     listTask = pending;
@@ -173,7 +195,7 @@ export function createArchiveController(input: {
       return loadList();
     },
     open(boundaryRef) {
-      if (disposed) return Promise.resolve();
+      if (disposed || state.deletion?.status === "deleting") return Promise.resolve();
       readerEpoch += 1;
       pageTask = undefined;
       nextCursor = null;
@@ -181,6 +203,7 @@ export function createArchiveController(input: {
       const entry = state.conversations.find((value) => value.boundaryRef === boundaryRef);
       publish({
         ...state,
+        deletion: null,
         reading: {
           boundaryRef,
           boundaryAt: entry?.boundaryAt ?? null,
@@ -192,12 +215,14 @@ export function createArchiveController(input: {
       return loadPage(boundaryRef, null);
     },
     close() {
-      if (disposed || state.reading === null) return;
+      if (disposed || state.reading === null || state.deletion?.status === "deleting") {
+        return;
+      }
       readerEpoch += 1;
       pageTask = undefined;
       nextCursor = null;
       failedCursor = undefined;
-      publish({ ...state, reading: null });
+      publish({ ...state, reading: null, deletion: null });
     },
     loadEarlier() {
       const reading = state.reading;
@@ -214,11 +239,62 @@ export function createArchiveController(input: {
       }
       return state.listStatus === "failed" ? loadList() : Promise.resolve();
     },
+    requestDeletion(boundaryRef) {
+      if (disposed || deletionTask !== undefined || state.reading?.boundaryRef !== boundaryRef) {
+        return;
+      }
+      publish({ ...state, deletion: { boundaryRef, status: "confirming" } });
+    },
+    cancelDeletion() {
+      if (disposed || state.deletion === null || state.deletion.status === "deleting") return;
+      publish({ ...state, deletion: null });
+    },
+    confirmDeletion() {
+      if (disposed) return Promise.resolve();
+      if (deletionTask !== undefined) return deletionTask;
+      const deletion = state.deletion;
+      if (deletion === null || deletion.status === "deleting") return Promise.resolve();
+      const boundaryRef = deletion.boundaryRef;
+      publish({ ...state, deletion: { boundaryRef, status: "deleting" } });
+      const pending = (async () => {
+        try {
+          await input.deleteConversation(boundaryRef);
+          if (disposed || state.deletion?.boundaryRef !== boundaryRef) return;
+          readerEpoch += 1;
+          pageTask = undefined;
+          nextCursor = null;
+          failedCursor = undefined;
+          listEpoch += 1;
+          listTask = undefined;
+          publish({
+            ...state,
+            listStatus: "idle",
+            conversations: state.conversations.filter(
+              (conversation) => conversation.boundaryRef !== boundaryRef,
+            ),
+            reading: null,
+            deletion: null,
+          });
+          await loadList();
+        } catch {
+          if (!disposed && state.deletion?.boundaryRef === boundaryRef) {
+            publish({ ...state, deletion: { boundaryRef, status: "failed" } });
+          }
+        }
+      })();
+      deletionTask = pending;
+      void pending.finally(() => {
+        if (deletionTask === pending) deletionTask = undefined;
+      });
+      return pending;
+    },
     dispose() {
       disposed = true;
       readerEpoch += 1;
+      listEpoch += 1;
       listTask = undefined;
       pageTask = undefined;
+      deletionTask = undefined;
     },
   };
 }

--- a/apps/desktop-renderer/src/boot.ts
+++ b/apps/desktop-renderer/src/boot.ts
@@ -314,6 +314,8 @@ export function bootRenderer(): Disposer {
   const archiveController = createArchiveController({
     listConversations: () => window.enduragentAuth.listArchivedConversations(),
     readPage: (request) => window.enduragentAuth.getArchivedTranscriptPage(request),
+    deleteConversation: (boundaryRef) =>
+      window.enduragentAuth.deleteArchivedConversation(boundaryRef),
     view: archiveAdapter.view,
   });
   store.getState().bindArchiveActions({
@@ -322,6 +324,9 @@ export function bootRenderer(): Disposer {
     close: () => archiveController.close(),
     loadEarlier: () => void archiveController.loadEarlier(),
     retry: () => void archiveController.retry(),
+    requestDeletion: (boundaryRef) => archiveController.requestDeletion(boundaryRef),
+    cancelDeletion: () => archiveController.cancelDeletion(),
+    confirmDeletion: () => void archiveController.confirmDeletion(),
   });
 
   const firstSyncController = createFirstSyncController({

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -11,6 +11,7 @@ interface EnduragentAuth {
     readonly limit: number;
   }): Promise<DesktopTranscriptPage>;
   listArchivedConversations(): Promise<DesktopArchivedConversationList>;
+  deleteArchivedConversation(boundaryRef: string): Promise<DesktopArchivedConversationDeleteResult>;
   getArchivedTranscriptPage(input: {
     readonly boundaryRef: string;
     readonly cursor: string | null;
@@ -159,6 +160,11 @@ interface DesktopArchivedConversationList {
   readonly schemaVersion: 1;
   readonly conversations: readonly DesktopArchivedConversationSummary[];
   readonly truncated: boolean;
+}
+
+interface DesktopArchivedConversationDeleteResult {
+  readonly schemaVersion: 1;
+  readonly status: "deleted" | "not-found";
 }
 
 type DesktopTranscriptPage =

--- a/apps/desktop-renderer/src/state/archive-slice.ts
+++ b/apps/desktop-renderer/src/state/archive-slice.ts
@@ -8,6 +8,9 @@ export interface ArchiveActions {
   close(): void;
   loadEarlier(): void;
   retry(): void;
+  requestDeletion(boundaryRef: string): void;
+  cancelDeletion(): void;
+  confirmDeletion(): void;
 }
 
 export interface ArchiveSlice {

--- a/apps/desktop-renderer/src/ui/archive/ArchiveView.tsx
+++ b/apps/desktop-renderer/src/ui/archive/ArchiveView.tsx
@@ -1,13 +1,27 @@
-import { useEffect, type ReactElement } from "react";
+import { useEffect, useRef, type ReactElement } from "react";
 import type { ArchiveReadingState } from "../../archive/controller.js";
 import type { TranscriptTurn } from "../../chat/hydration.js";
 import { Button } from "../../components/ui/button.js";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../../components/ui/dialog.js";
 import { useEnduragentStore } from "../../state/store.js";
 import { AthleteMessage } from "../chat/AthleteMessage.js";
 import { CoachMessage } from "../chat/CoachMessage.js";
 import { Page } from "../shared/Page.js";
 import {
   ARCHIVE_BACK_COPY,
+  ARCHIVE_DELETE_COPY,
+  ARCHIVE_DELETE_DESCRIPTION,
+  ARCHIVE_DELETE_FAILURE_COPY,
+  ARCHIVE_DELETE_TITLE,
   ARCHIVE_EMPTY_CONVERSATION_COPY,
   ARCHIVE_EMPTY_COPY,
   ARCHIVE_LIST_FAILURE_COPY,
@@ -117,9 +131,14 @@ function ArchiveList(): ReactElement {
 
 function ArchiveReader(props: { readonly reading: ArchiveReadingState }): ReactElement {
   const actions = useEnduragentStore((state) => state.archiveActions);
+  const deletion = useEnduragentStore((state) => state.archive.deletion);
+  const cancelDelete = useRef<HTMLButtonElement>(null);
   const reading = props.reading;
   const failed = reading.status === "failed";
   const unavailable = reading.status === "unavailable";
+  const deleteOpen = deletion?.boundaryRef === reading.boundaryRef;
+  const deletePending = deleteOpen && deletion.status === "deleting";
+  const deleteFailed = deleteOpen && deletion.status === "failed";
 
   return (
     <>
@@ -139,6 +158,71 @@ function ArchiveReader(props: { readonly reading: ArchiveReadingState }): ReactE
         <p className={`${NOTE_CLASS} archive-reading-when mb-0`}>
           {reading.boundaryAt === null ? "" : archiveTimestampCopy(reading.boundaryAt)}
         </p>
+        <Dialog
+          open={deleteOpen}
+          onOpenChange={(open) => {
+            if (open) actions?.requestDeletion(reading.boundaryRef);
+            else if (!deletePending) actions?.cancelDeletion();
+          }}
+        >
+          <DialogTrigger
+            render={
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                className="archive-delete ml-auto"
+                disabled={actions === null}
+              />
+            }
+          >
+            {ARCHIVE_DELETE_COPY}
+          </DialogTrigger>
+          <DialogContent
+            className="archive-delete-dialog w-[min(460px,calc(100vw-32px))] max-w-none gap-0 p-6 shadow-elev-4 sm:max-w-none"
+            showCloseButton={false}
+            initialFocus={cancelDelete}
+            aria-busy={deletePending ? "true" : undefined}
+          >
+            <DialogHeader className="gap-2.5">
+              <DialogTitle className="m-0 text-xl">{ARCHIVE_DELETE_TITLE}</DialogTitle>
+              <DialogDescription className="m-0 leading-[1.5]">
+                {ARCHIVE_DELETE_DESCRIPTION}
+                {deleteFailed ? (
+                  <span className="mt-2 block text-destructive" role="alert">
+                    {ARCHIVE_DELETE_FAILURE_COPY}
+                  </span>
+                ) : null}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="mx-0 mt-[22px] mb-0 flex-row justify-end border-0 bg-transparent p-0">
+              <DialogClose
+                render={
+                  <Button
+                    ref={cancelDelete}
+                    type="button"
+                    variant="outline"
+                    size="lg"
+                    disabled={deletePending}
+                  />
+                }
+              >
+                Cancel
+              </DialogClose>
+              <Button
+                type="button"
+                variant="destructive-solid"
+                size="lg"
+                disabled={deletePending}
+                onClick={() => {
+                  actions?.confirmDeletion();
+                }}
+              >
+                {deleteFailed ? ARCHIVE_RETRY_COPY : ARCHIVE_DELETE_COPY}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
       <p className={`${NOTE_CLASS} archive-note`}>{ARCHIVE_READ_ONLY_NOTE}</p>
       <p

--- a/apps/desktop-renderer/src/ui/archive/copy.ts
+++ b/apps/desktop-renderer/src/ui/archive/copy.ts
@@ -11,6 +11,11 @@ export const ARCHIVE_BACK_COPY = "All past chats";
 export const ARCHIVE_LOAD_EARLIER_COPY = "Load earlier messages";
 export const ARCHIVE_RETRY_COPY = "Try again";
 export const ARCHIVE_EMPTY_CONVERSATION_COPY = "This conversation has no readable messages.";
+export const ARCHIVE_DELETE_COPY = "Delete conversation";
+export const ARCHIVE_DELETE_TITLE = "Delete this conversation?";
+export const ARCHIVE_DELETE_DESCRIPTION =
+  "This permanently removes this past conversation and its original attachments from this computer. Imported activities in Training and work in Plan stay.";
+export const ARCHIVE_DELETE_FAILURE_COPY = "Deletion could not finish. Try again to complete it.";
 
 export function archiveReasonCopy(reason: "explicit-reset" | "stale-reset"): string {
   return reason === "explicit-reset" ? "You started a new conversation" : "Closed after a break";

--- a/apps/desktop-renderer/src/ui/chat/ChatView.tsx
+++ b/apps/desktop-renderer/src/ui/chat/ChatView.tsx
@@ -15,6 +15,7 @@ import {
   DialogContent,
   DialogDescription,
   DialogTitle,
+  DialogTrigger,
 } from "../../components/ui/dialog.js";
 import { Composer, type ComposerHandle } from "./Composer.js";
 import { AttachmentPanel } from "./AttachmentPanel.js";
@@ -58,9 +59,7 @@ export function ChatView(): ReactElement {
   const hydrationStatus = useEnduragentStore((state) => state.chat.hydrationStatus);
   const hasEarlier = useEnduragentStore((state) => state.chat.hydrationHasEarlier);
   const workBlocked = useEnduragentStore((state) => state.chat.workBlocked);
-  const planningRequestFocusId = useEnduragentStore(
-    (state) => state.chat.planningRequestFocusId,
-  );
+  const planningRequestFocusId = useEnduragentStore((state) => state.chat.planningRequestFocusId);
   const actions = useEnduragentStore((state) => state.chatActions);
   const mountedView = useRef(activeView);
 
@@ -144,16 +143,40 @@ export function ChatView(): ReactElement {
     >
       <header className="flex items-center justify-between border-b border-line px-[calc(var(--inset)*3)] max-[760px]:px-[calc(var(--inset)*2)]">
         <h1 className="m-0 text-sm font-semibold">Chat</h1>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label={contextExpanded ? "Hide training context" : "Show training context"}
-          aria-expanded={contextExpanded}
-          onClick={toggleContext}
-        >
-          {contextExpanded && !compact ? <PanelRightClose /> : <PanelRightOpen />}
-        </Button>
+        {compact ? (
+          <Dialog open={contextDrawerOpen} onOpenChange={setContextDrawerOpen}>
+            <DialogTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={contextExpanded ? "Hide training context" : "Show training context"}
+                />
+              }
+            >
+              <PanelRightOpen />
+            </DialogTrigger>
+            <DialogContent className="top-0 right-0 left-auto h-full max-h-none w-[min(320px,calc(100%-32px))] max-w-none translate-x-0 translate-y-0 content-start overflow-auto rounded-none rounded-l-card border-y-0 border-r-0 p-0">
+              <DialogTitle className="sr-only">Training context</DialogTitle>
+              <DialogDescription className="sr-only">
+                Training data available to Coach.
+              </DialogDescription>
+              <TrainingContextPanel className="h-full border-l-0 pt-12" />
+            </DialogContent>
+          </Dialog>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={contextExpanded ? "Hide training context" : "Show training context"}
+            aria-expanded={contextExpanded}
+            onClick={toggleContext}
+          >
+            {contextExpanded ? <PanelRightClose /> : <PanelRightOpen />}
+          </Button>
+        )}
       </header>
       <div
         className={`chat-layout row-start-2 grid min-h-0 min-w-0 ${contextOpen && !compact ? "grid-cols-[minmax(0,1fr)_300px]" : "grid-cols-[minmax(0,1fr)]"}`}
@@ -171,44 +194,32 @@ export function ChatView(): ReactElement {
               <FirstSyncCard />
             </div>
           </main>
-          <div className="composer-wrap z-2 bg-bg bg-[linear-gradient(transparent,var(--bg)_22%)] px-[max(24px,calc((100%-720px)/2))] pt-[calc(var(--inset)*3)] pb-row max-[760px]:px-[calc(var(--inset)*2)]">
-            <div className="chat-notice-host empty:hidden">
-              <p
-                className="new-conversation-status m-0 text-sm text-ink-2 not-empty:px-3.5 not-empty:pb-inset"
-                role="status"
-                aria-live="polite"
-              >
-                {announcement ?? ""}
-              </p>
-              <SpendNotice />
-              <Notice />
-              <RetryBar />
+          <div className="composer-wrap z-2 grid max-h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto] overflow-hidden bg-bg bg-[linear-gradient(transparent,var(--bg)_22%)] px-[max(24px,calc((100%-720px)/2))] pt-[calc(var(--inset)*3)] pb-row max-[760px]:px-[calc(var(--inset)*2)]">
+            <div className="composer-projections min-h-0 overflow-y-auto overscroll-contain empty:hidden">
+              <div className="chat-notice-host empty:hidden">
+                <p
+                  className="new-conversation-status m-0 text-sm text-ink-2 not-empty:px-3.5 not-empty:pb-inset"
+                  role="status"
+                  aria-live="polite"
+                >
+                  {announcement ?? ""}
+                </p>
+                <SpendNotice />
+                <Notice />
+                <RetryBar />
+              </div>
+              <div className="mb-2.5 empty:hidden">
+                <CoachDecisionPanel onCustomOpenChange={setCustomDecisionOpen} />
+              </div>
+              <AttachmentPanel />
+              <QueuedMessages />
             </div>
-            <div className="mb-2.5 empty:hidden">
-              <CoachDecisionPanel onCustomOpenChange={setCustomDecisionOpen} />
-            </div>
-            <QueuedMessages />
-            <AttachmentPanel />
             <Composer handle={composer} hidden={decisionCustomOpen} />
             <p className="mt-inset mb-0 text-center text-xs text-ink-3">{CHAT_DISCLAIMER}</p>
           </div>
         </div>
         {contextOpen && !compact ? <TrainingContextPanel /> : null}
       </div>
-      <Dialog
-        open={compact && contextDrawerOpen}
-        onOpenChange={(open) => {
-          setContextDrawerOpen(open);
-        }}
-      >
-        <DialogContent className="top-0 right-0 left-auto h-full max-h-none w-[min(320px,calc(100%-32px))] max-w-none translate-x-0 translate-y-0 content-start overflow-auto rounded-none rounded-l-card border-y-0 border-r-0 p-0">
-          <DialogTitle className="sr-only">Training context</DialogTitle>
-          <DialogDescription className="sr-only">
-            Training data available to Coach.
-          </DialogDescription>
-          <TrainingContextPanel className="h-full border-l-0 pt-12" />
-        </DialogContent>
-      </Dialog>
       <NewConversationDialog
         onComposerReset={() => {
           composer.current?.reset();

--- a/apps/desktop-renderer/src/ui/chat/CoachDecisionPanel.tsx
+++ b/apps/desktop-renderer/src/ui/chat/CoachDecisionPanel.tsx
@@ -93,6 +93,7 @@ export function CoachDecisionPanel(props: {
     if (decision?.status !== "unanswered" || phase !== "idle") return;
     const onShortcut = (event: KeyboardEvent): void => {
       if (event.defaultPrevented) return;
+      if (document.querySelector('[role="dialog"]') !== null) return;
       if (event.key === "Escape") {
         event.preventDefault();
         skipDecision(decision.decisionId);

--- a/apps/desktop-renderer/tests/archive-controller.test.ts
+++ b/apps/desktop-renderer/tests/archive-controller.test.ts
@@ -69,11 +69,16 @@ function harness(input: {
     readonly cursor: string | null;
     readonly limit: number;
   }) => Promise<TranscriptPage>;
+  readonly deleteConversation?: (
+    boundaryRef: string,
+  ) => Promise<{ readonly schemaVersion: 1; readonly status: "deleted" | "not-found" }>;
 }) {
   const states: ArchiveViewState[] = [];
   const controller = createArchiveController({
     listConversations: input.listConversations ?? (async () => list()),
     readPage: input.readPage ?? (async () => page(["turn-1"])),
+    deleteConversation:
+      input.deleteConversation ?? (async () => ({ schemaVersion: 1, status: "deleted" })),
     view: {
       render(state) {
         states.push(state);
@@ -385,5 +390,128 @@ describe("archive controller reader", () => {
     expect(subject.current().reading).toMatchObject({ boundaryRef: NEWER, status: "ready" });
     expect(subject.current().reading?.turns.map((turn) => turn.turnId)).toEqual(["turn-9"]);
     expect(readPage).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("archive controller deletion", () => {
+  it.each(["deleted", "not-found"] as const)(
+    "treats %s as success, closes the reader, and refetches the whole list",
+    async (status) => {
+      const listConversations = vi
+        .fn<() => Promise<ArchivedConversationList>>()
+        .mockResolvedValueOnce(list(true))
+        .mockResolvedValueOnce({
+          schemaVersion: 1,
+          conversations: [list().conversations[1]!],
+          truncated: false,
+        });
+      const deleteConversation = vi.fn(async () => ({ schemaVersion: 1 as const, status }));
+      const subject = harness({ listConversations, deleteConversation });
+
+      await subject.controller.refresh();
+      await subject.controller.open(NEWER);
+      subject.controller.requestDeletion(NEWER);
+      expect(subject.current().deletion).toEqual({
+        boundaryRef: NEWER,
+        status: "confirming",
+      });
+
+      await subject.controller.confirmDeletion();
+
+      expect(deleteConversation).toHaveBeenCalledOnce();
+      expect(deleteConversation).toHaveBeenCalledWith(NEWER);
+      expect(listConversations).toHaveBeenCalledTimes(2);
+      expect(subject.current()).toMatchObject({
+        listStatus: "ready",
+        truncated: false,
+        reading: null,
+        deletion: null,
+      });
+      expect(subject.current().conversations.map((entry) => entry.boundaryRef)).toEqual([OLDER]);
+    },
+  );
+
+  it("keeps a failed deletion open for an explicit retry", async () => {
+    const deleteConversation = vi
+      .fn<
+        () => Promise<{
+          readonly schemaVersion: 1;
+          readonly status: "deleted" | "not-found";
+        }>
+      >()
+      .mockRejectedValueOnce(new Error("unavailable"))
+      .mockResolvedValueOnce({ schemaVersion: 1, status: "deleted" });
+    const subject = harness({ deleteConversation });
+
+    await subject.controller.refresh();
+    await subject.controller.open(NEWER);
+    subject.controller.requestDeletion(NEWER);
+    await subject.controller.confirmDeletion();
+
+    expect(subject.current().reading?.boundaryRef).toBe(NEWER);
+    expect(subject.current().deletion).toEqual({ boundaryRef: NEWER, status: "failed" });
+
+    await subject.controller.confirmDeletion();
+
+    expect(deleteConversation).toHaveBeenCalledTimes(2);
+    expect(subject.current().reading).toBeNull();
+    expect(subject.current().deletion).toBeNull();
+  });
+
+  it("cancels confirmation but cannot dismiss or duplicate an in-flight deletion", async () => {
+    let release!: () => void;
+    const pendingDelete = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const deleteConversation = vi.fn(async () => {
+      await pendingDelete;
+      return { schemaVersion: 1 as const, status: "deleted" as const };
+    });
+    const subject = harness({ deleteConversation });
+
+    await subject.controller.refresh();
+    await subject.controller.open(NEWER);
+    subject.controller.requestDeletion(NEWER);
+    subject.controller.cancelDeletion();
+    expect(subject.current().deletion).toBeNull();
+
+    subject.controller.requestDeletion(NEWER);
+    const first = subject.controller.confirmDeletion();
+    const second = subject.controller.confirmDeletion();
+    subject.controller.cancelDeletion();
+    subject.controller.close();
+
+    expect(first).toBe(second);
+    expect(deleteConversation).toHaveBeenCalledOnce();
+    expect(subject.current().deletion).toEqual({ boundaryRef: NEWER, status: "deleting" });
+    expect(subject.current().reading?.boundaryRef).toBe(NEWER);
+
+    release();
+    await first;
+    expect(subject.current().reading).toBeNull();
+  });
+
+  it("ignores a deletion completion after disposal", async () => {
+    let release!: () => void;
+    const pendingDelete = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const subject = harness({
+      deleteConversation: async () => {
+        await pendingDelete;
+        return { schemaVersion: 1, status: "deleted" };
+      },
+    });
+
+    await subject.controller.refresh();
+    await subject.controller.open(NEWER);
+    subject.controller.requestDeletion(NEWER);
+    const deletion = subject.controller.confirmDeletion();
+    const beforeDispose = subject.current();
+    subject.controller.dispose();
+    release();
+    await deletion;
+
+    expect(subject.current()).toBe(beforeDispose);
   });
 });

--- a/apps/desktop-renderer/tests/archive-surface.test.tsx
+++ b/apps/desktop-renderer/tests/archive-surface.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -23,6 +23,9 @@ function archiveActions(): ArchiveActions {
     close: vi.fn(),
     loadEarlier: vi.fn(),
     retry: vi.fn(),
+    requestDeletion: vi.fn(),
+    cancelDeletion: vi.fn(),
+    confirmDeletion: vi.fn(),
   };
 }
 
@@ -77,6 +80,7 @@ const LISTED: ArchiveViewState = {
   ],
   truncated: false,
   reading: null,
+  deletion: null,
 };
 
 function reading(patch: Partial<ArchiveReadingState> = {}): ArchiveViewState {
@@ -261,6 +265,79 @@ describe("past chats reader", () => {
       "This conversation is no longer available.",
     );
     expect(region.querySelector("button.archive-retry")).toHaveAttribute("hidden");
+  });
+
+  it("explains permanent deletion, focuses Cancel, and restores the trigger on Escape", async () => {
+    const user = userEvent.setup();
+    let actions!: ArchiveActions;
+    const requestDeletion = vi.fn((boundaryRef: string) => {
+      set(
+        {
+          ...reading(),
+          deletion: { boundaryRef, status: "confirming" },
+        },
+        actions,
+      );
+    });
+    const cancelDeletion = vi.fn(() => {
+      set(reading(), actions);
+    });
+    actions = { ...archiveActions(), requestDeletion, cancelDeletion };
+    render(<ArchiveView />);
+    set(reading(), actions);
+
+    const trigger = screen.getByRole("button", { name: "Delete conversation" });
+    await user.click(trigger);
+
+    expect(requestDeletion).toHaveBeenCalledWith(NEWER);
+    const dialog = screen.getByRole("dialog", { name: "Delete this conversation?" });
+    expect(dialog).toHaveTextContent(
+      "This permanently removes this past conversation and its original attachments from this computer. Imported activities in Training and work in Plan stay.",
+    );
+    const buttons = within(dialog).getAllByRole("button");
+    expect(buttons.map((button) => button.textContent)).toEqual(["Cancel", "Delete conversation"]);
+    await waitFor(() => expect(buttons[0]).toHaveFocus());
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(cancelDeletion).toHaveBeenCalledOnce();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("keeps deletion modal while busy and offers an explicit retry after failure", async () => {
+    const user = userEvent.setup();
+    const actions = archiveActions();
+    render(<ArchiveView />);
+    set(
+      {
+        ...reading(),
+        deletion: { boundaryRef: NEWER, status: "deleting" },
+      },
+      actions,
+    );
+
+    let dialog = screen.getByRole("dialog", { name: "Delete this conversation?" });
+    expect(dialog).toHaveAttribute("aria-busy", "true");
+    expect(within(dialog).getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(within(dialog).getByRole("button", { name: "Delete conversation" })).toBeDisabled();
+    await user.keyboard("{Escape}");
+    expect(screen.getByRole("dialog", { name: "Delete this conversation?" })).toBeInTheDocument();
+    expect(actions.cancelDeletion).not.toHaveBeenCalled();
+
+    set(
+      {
+        ...reading(),
+        deletion: { boundaryRef: NEWER, status: "failed" },
+      },
+      actions,
+    );
+    dialog = screen.getByRole("dialog", { name: "Delete this conversation?" });
+    expect(within(dialog).getByRole("alert")).toHaveTextContent(
+      "Deletion could not finish. Try again to complete it.",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "Try again" }));
+    expect(actions.confirmDeletion).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -428,6 +428,50 @@ describe("chat surface", () => {
       expect(screen.getByRole("button", { name: "Show training context" })).toBeInTheDocument();
     });
 
+    it("keeps compact drawer focus trapped and lets Escape restore its trigger", async () => {
+      vi.stubGlobal(
+        "ResizeObserver",
+        class {
+          constructor(private readonly callback: ResizeObserverCallback) {}
+
+          observe(): void {
+            this.callback(
+              [{ contentRect: { width: 760 } } as ResizeObserverEntry],
+              this as unknown as ResizeObserver,
+            );
+          }
+
+          disconnect(): void {}
+
+          unobserve(): void {}
+        },
+      );
+      const user = userEvent.setup();
+      setChat({ decision: unansweredDecision(), sendDisabled: true, inputDisabled: false });
+
+      try {
+        render(<Harness />);
+        const trigger = await screen.findByRole("button", { name: "Show training context" });
+        await user.click(trigger);
+        const dialog = screen.getByRole("dialog", { name: "Training context" });
+
+        expect(dialog.contains(document.activeElement)).toBe(true);
+        await user.tab();
+        await user.tab();
+        await user.tab({ shift: true });
+        await user.tab({ shift: true });
+        expect(dialog).toBeInTheDocument();
+        expect(trigger).not.toHaveFocus();
+        await user.keyboard("{Escape}");
+
+        await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+        expect(trigger).toHaveFocus();
+        expect(actions.skipDecision).not.toHaveBeenCalled();
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
     it("projects only available workout, Load, and cycling-anchor facts", () => {
       act(() => {
         useEnduragentStore.setState({
@@ -695,7 +739,51 @@ describe("chat surface", () => {
       expect(form?.nextElementSibling).toBe(disclaimer);
       expect(disclaimer.parentElement).toHaveClass("composer-wrap");
       expect(disclaimer.parentElement).toHaveClass("bg-bg");
+      expect(disclaimer.parentElement).toHaveClass("max-h-full", "overflow-hidden");
       expect(disclaimer).toHaveClass("mt-inset", "text-xs");
+      expect(document.querySelector(".composer-projections")).toHaveClass(
+        "min-h-0",
+        "overflow-y-auto",
+        "overscroll-contain",
+      );
+    });
+
+    it("orders decision, attachment, and queued work before the composer", () => {
+      setChat({
+        decision: unansweredDecision(),
+        sendDisabled: true,
+        inputDisabled: false,
+        attachmentBusy: true,
+        queued: [{ id: "queued-1", text: "Later work", command: false, restored: false }],
+      });
+      render(<Harness />);
+
+      const projections = document.querySelector(".composer-projections");
+      const decision = screen
+        .getByText("Coach needs your answer")
+        .closest("section")?.parentElement;
+      const attachment = screen.getByText("Adding files…").parentElement;
+      const queue = screen.getByRole("region", { name: "Queued messages, 1 queued message" });
+      const form = composer().closest("form");
+
+      if (
+        !(projections instanceof HTMLElement) ||
+        !(decision instanceof HTMLElement) ||
+        !(attachment instanceof HTMLElement) ||
+        !(form instanceof HTMLFormElement)
+      ) {
+        throw new TypeError("Composer projections are incomplete.");
+      }
+      expect(decision.parentElement).toBe(projections);
+      expect(attachment.parentElement).toBe(projections);
+      expect(queue.parentElement).toBe(projections);
+      expect(
+        decision.compareDocumentPosition(attachment) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      expect(
+        attachment.compareDocumentPosition(queue) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      expect(projections.nextElementSibling).toBe(form);
     });
 
     it("focuses the enabled composer when Chat mounts after required setup", () => {

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -304,6 +304,7 @@ async function security() {
             "claudeCliStatus",
             "credentialRecoveryStatus",
             "credentialStatuses",
+            "deleteArchivedConversation",
             "deleteCredential",
             "disableTelegram",
             "enableTelegram",

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -11,6 +11,8 @@ export const DESKTOP_INITIAL_SETUP_STATUS_SETTLED_CHANNEL =
 export const DESKTOP_TRANSCRIPT_PAGE_CHANNEL = "desktop:get-transcript-page" as const;
 export const DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL =
   "desktop:list-archived-conversations" as const;
+export const DESKTOP_DELETE_ARCHIVED_CONVERSATION_CHANNEL =
+  "desktop:delete-archived-conversation" as const;
 export const DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL =
   "desktop:get-archived-transcript-page" as const;
 export const DESKTOP_PLANNING_READ_CHANNEL = "desktop:planning:read" as const;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -811,7 +811,7 @@ async function runDesktop(): Promise<void> {
       const binding = activeRuntimeBinding;
       const lifecycleState = daemonLifecycle?.snapshot();
       if (binding === undefined || lifecycleState?.status !== "ready") throw new TypeError();
-      const page = await read(binding.transcript);
+      const value = await read(binding.transcript);
       const currentLifecycleState = daemonLifecycle?.snapshot();
       if (
         activeRuntimeBinding !== binding ||
@@ -820,7 +820,7 @@ async function runDesktop(): Promise<void> {
       ) {
         throw new TypeError();
       }
-      return page;
+      return value;
     };
     const readActivePlanning = async () => {
       const binding = activeRuntimeBinding;
@@ -1272,6 +1272,8 @@ async function runDesktop(): Promise<void> {
       readPage: (request) => readActiveTranscript((reader) => reader.getTranscriptPage(request)),
       readArchivedConversations: (request) =>
         readActiveTranscript((reader) => reader.listArchivedConversations(request)),
+      deleteArchivedConversation: (request) =>
+        readActiveTranscript((reader) => reader.deleteArchivedConversation(request)),
       readArchivedPage: (request) =>
         readActiveTranscript((reader) => reader.getArchivedTranscriptPage(request)),
     });
@@ -1290,7 +1292,7 @@ async function runDesktop(): Promise<void> {
           planning.executePlanTransition(request, (event) => {
             if (isCurrent()) onEvent(event);
           }),
-         ),
+        ),
     });
     disposeTrainingExportIpc = installDesktopTrainingExportIpc({
       ipcMain,

--- a/apps/desktop/src/main/transcript-ipc.ts
+++ b/apps/desktop/src/main/transcript-ipc.ts
@@ -1,11 +1,15 @@
 import { connectCoachClient, type CoachClient } from "@enduragent/coach-client";
 import {
+  DeleteArchivedConversationRpcParamsSchema,
+  DeleteArchivedConversationRpcResultSchema,
   GetArchivedTranscriptPageRpcParamsSchema,
   GetArchivedTranscriptPageRpcResultSchema,
   GetTranscriptPageRpcParamsSchema,
   GetTranscriptPageRpcResultSchema,
   ListArchivedConversationsRpcParamsSchema,
   ListArchivedConversationsRpcResultSchema,
+  type DeleteArchivedConversationRpcParams,
+  type DeleteArchivedConversationRpcResult,
   type GetArchivedTranscriptPageRpcParams,
   type GetArchivedTranscriptPageRpcResult,
   type GetTranscriptPageRpcParams,
@@ -18,6 +22,7 @@ import type { ZodType } from "zod";
 import {
   DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL,
   DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL,
+  DESKTOP_DELETE_ARCHIVED_CONVERSATION_CHANNEL,
   DESKTOP_TRANSCRIPT_PAGE_CHANNEL,
 } from "./constants.js";
 import { isTrustedConnectionRequest } from "./security.js";
@@ -27,6 +32,9 @@ export interface DesktopTranscriptReader {
   listArchivedConversations(
     request: ListArchivedConversationsRpcParams,
   ): Promise<ListArchivedConversationsRpcResult>;
+  deleteArchivedConversation(
+    request: DeleteArchivedConversationRpcParams,
+  ): Promise<DeleteArchivedConversationRpcResult>;
   getArchivedTranscriptPage(
     request: GetArchivedTranscriptPageRpcParams,
   ): Promise<GetArchivedTranscriptPageRpcResult>;
@@ -58,6 +66,9 @@ export function createConnectionTranscriptReader(
     },
     listArchivedConversations(request) {
       return call((client) => client.call("listArchivedConversations", request));
+    },
+    deleteArchivedConversation(request) {
+      return call((client) => client.call("deleteArchivedConversation", request));
     },
     getArchivedTranscriptPage(request) {
       return call((client) => client.call("getArchivedTranscriptPage", request));
@@ -98,6 +109,9 @@ export function installDesktopTranscriptIpc(input: {
   readonly readArchivedConversations: (
     request: ListArchivedConversationsRpcParams,
   ) => Promise<ListArchivedConversationsRpcResult>;
+  readonly deleteArchivedConversation: (
+    request: DeleteArchivedConversationRpcParams,
+  ) => Promise<DeleteArchivedConversationRpcResult>;
   readonly readArchivedPage: (
     request: GetArchivedTranscriptPageRpcParams,
   ) => Promise<GetArchivedTranscriptPageRpcResult>;
@@ -105,6 +119,7 @@ export function installDesktopTranscriptIpc(input: {
   const channels = [
     DESKTOP_TRANSCRIPT_PAGE_CHANNEL,
     DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL,
+    DESKTOP_DELETE_ARCHIVED_CONVERSATION_CHANNEL,
     DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL,
   ] as const;
   input.ipcMain.handle(
@@ -125,6 +140,16 @@ export function installDesktopTranscriptIpc(input: {
       ListArchivedConversationsRpcResultSchema,
       input.readArchivedConversations,
       0,
+    ),
+  );
+  input.ipcMain.handle(
+    DESKTOP_DELETE_ARCHIVED_CONVERSATION_CHANNEL,
+    readHandler(
+      input.currentWindow,
+      DeleteArchivedConversationRpcParamsSchema,
+      DeleteArchivedConversationRpcResultSchema,
+      input.deleteArchivedConversation,
+      1,
     ),
   );
   input.ipcMain.handle(

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer, webUtils } from "electron";
 import {
   AttachmentAdmissionReadModelSchema,
   CHAT_ATTACHMENT_LIMITS,
+  DeleteArchivedConversationRpcResultSchema,
   GetArchivedTranscriptPageRpcResultSchema,
   GetPlanningReadModelRpcResultSchema,
   GetTranscriptPageRpcResultSchema,
@@ -35,6 +36,7 @@ import {
   DESKTOP_PLAN_TRANSITION_CHANNEL,
   DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL,
   DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL,
+  DESKTOP_DELETE_ARCHIVED_CONVERSATION_CHANNEL,
   DESKTOP_TRANSCRIPT_PAGE_CHANNEL,
   DESKTOP_TELEGRAM_ACKNOWLEDGE_GAP_WARNING_CHANNEL,
   DESKTOP_TELEGRAM_ADD_ALLOWED_SENDER_CHANNEL,
@@ -1467,6 +1469,17 @@ contextBridge.exposeInMainWorld(
     },
     listArchivedConversations: async () =>
       parseArchivedConversations(await ipcRenderer.invoke(DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL)),
+    deleteArchivedConversation: async (value: unknown, ...args: unknown[]) => {
+      requireZeroArguments(args);
+      if (!boundaryRef(value)) throw new TypeError();
+      const result = DeleteArchivedConversationRpcResultSchema.safeParse(
+        await ipcRenderer.invoke(DESKTOP_DELETE_ARCHIVED_CONVERSATION_CHANNEL, {
+          boundaryRef: value,
+        }),
+      );
+      if (!result.success) throw new TypeError();
+      return result.data;
+    },
     getArchivedTranscriptPage: async (input: unknown) => {
       const request = parseArchivedPageRequest(input);
       return parseTranscriptPage(

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -19,6 +19,7 @@ const hasLoopback = await new Promise<boolean>((resolveAvailability) => {
 });
 
 const token = "t".repeat(43);
+const archivedBoundaryRef = "a".repeat(64);
 const transcriptCursorBytes = Buffer.alloc(114);
 transcriptCursorBytes[0] = 1;
 const transcriptCursor = transcriptCursorBytes.toString("base64url");
@@ -182,6 +183,7 @@ function makeScript(
   let hasSession = false;
   let lastSynced: string = athleteState.lastSynced;
   let queueRevision = 0;
+  let archivedDeleted = false;
   let queueItems: Array<{
     queuedMessageId: string;
     messageId: string;
@@ -524,6 +526,44 @@ ${"nonwrapping".repeat(36)}
           nextCursor: cursor === null ? transcriptCursor : null,
         });
       }
+      if (request.method === "listArchivedConversations") {
+        return response({
+          schemaVersion: 1,
+          conversations: archivedDeleted
+            ? []
+            : [
+                {
+                  boundaryRef: archivedBoundaryRef,
+                  boundaryAt: "2001-01-05T08:00:00.000Z",
+                  reason: "explicit-reset",
+                  turnCount: 1,
+                },
+              ],
+          truncated: false,
+        });
+      }
+      if (request.method === "getArchivedTranscriptPage") {
+        return response({
+          schemaVersion: 1,
+          status: archivedDeleted ? "restart-required" : "page",
+          turns: archivedDeleted
+            ? []
+            : [
+                {
+                  turnId: "archived-turn-1",
+                  completedAt: "2001-01-05T07:00:00.000Z",
+                  athleteText: "How did that block go?",
+                  coachText: "The block was consistent.",
+                },
+              ],
+          nextCursor: null,
+        });
+      }
+      if (request.method === "deleteArchivedConversation") {
+        const status = archivedDeleted ? "not-found" : "deleted";
+        archivedDeleted = true;
+        return response({ schemaVersion: 1, status });
+      }
       if (request.method === "resetSession") {
         hasSession = false;
         queueItems = [];
@@ -676,6 +716,50 @@ async function launch(input: {
     }
   `);
   return { fixture, calls };
+}
+
+async function stackedProjectionGeometry(fixture: RunningDesktopFixture): Promise<{
+  readonly attachmentIssue: boolean;
+  readonly planningIssue: boolean;
+  readonly composerWithinViewport: boolean;
+  readonly disclaimerWithinViewport: boolean;
+  readonly projectionsScrollLocally: boolean;
+  readonly disclaimerStableAfterProjectionScroll: boolean;
+  readonly footerOrder: boolean;
+  readonly documentVerticalOverflow: boolean;
+}> {
+  return fixture.evaluate(`
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const composerWrap = document.querySelector(".composer-wrap");
+    const projections = document.querySelector(".composer-projections");
+    const composer = composerWrap?.querySelector("form");
+    const disclaimer = composerWrap?.querySelector(":scope > p:last-child");
+    if (!(composerWrap instanceof HTMLElement) || !(projections instanceof HTMLElement) ||
+        !(composer instanceof HTMLFormElement) || !(disclaimer instanceof HTMLElement)) {
+      throw new Error("stacked composer surface is incomplete");
+    }
+    const text = composerWrap.textContent ?? "";
+    const wrapRect = composerWrap.getBoundingClientRect();
+    const disclaimerBefore = disclaimer.getBoundingClientRect();
+    projections.scrollTop = projections.scrollHeight;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    const disclaimerAfter = disclaimer.getBoundingClientRect();
+    return {
+      attachmentIssue: text.includes("We couldn’t update that attachment. Your message draft is preserved."),
+      planningIssue: text.includes("We couldn’t check saved Plan requests. Reconnect and try again."),
+      composerWithinViewport: wrapRect.top >= 0 && wrapRect.bottom <= window.innerHeight,
+      disclaimerWithinViewport:
+        disclaimerAfter.top >= 0 && disclaimerAfter.bottom <= window.innerHeight,
+      projectionsScrollLocally: getComputedStyle(projections).overflowY === "auto",
+      disclaimerStableAfterProjectionScroll:
+        Math.abs(disclaimerBefore.top - disclaimerAfter.top) < 1 &&
+        Math.abs(disclaimerBefore.bottom - disclaimerAfter.bottom) < 1,
+      footerOrder:
+        projections.nextElementSibling === composer && composer.nextElementSibling === disclaimer,
+      documentVerticalOverflow:
+        document.documentElement.scrollHeight > document.documentElement.clientHeight,
+    };
+  `);
 }
 
 afterEach(async () => {
@@ -1185,6 +1269,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "claudeCliStatus",
         "credentialRecoveryStatus",
         "credentialStatuses",
+        "deleteArchivedConversation",
         "deleteCredential",
         "disableTelegram",
         "enableTelegram",
@@ -1316,6 +1401,28 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       finalTranscriptClearsComposer: true,
     });
     expect(readingRoom.composerHeight).toBeGreaterThan(0);
+    await fixture.setViewport(1180, 820);
+    expect(await stackedProjectionGeometry(fixture)).toEqual({
+      attachmentIssue: true,
+      planningIssue: true,
+      composerWithinViewport: true,
+      disclaimerWithinViewport: true,
+      projectionsScrollLocally: true,
+      disclaimerStableAfterProjectionScroll: true,
+      footerOrder: true,
+      documentVerticalOverflow: false,
+    });
+    await fixture.setViewport(760, 820);
+    expect(await stackedProjectionGeometry(fixture)).toEqual({
+      attachmentIssue: true,
+      planningIssue: true,
+      composerWithinViewport: true,
+      disclaimerWithinViewport: true,
+      projectionsScrollLocally: true,
+      disclaimerStableAfterProjectionScroll: true,
+      footerOrder: true,
+      documentVerticalOverflow: false,
+    });
     await fixture.setViewport(720, 800);
     const compact = await fixture.evaluate<{
       readonly documentOverflow: boolean;
@@ -1334,8 +1441,6 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         document.querySelector('[aria-label="Show training context"]')?.click();
         await new Promise((resolve) => requestAnimationFrame(resolve));
         const contextDrawerOpened = document.querySelector('[data-slot="dialog-content"] .training-context') !== null;
-        document.querySelector('[data-slot="dialog-close"]')?.click();
-        await new Promise((resolve) => requestAnimationFrame(resolve));
         conversation.scrollTop = conversation.scrollHeight;
         const composerRect = composer.getBoundingClientRect();
         const finalTranscriptItem = [...document.querySelectorAll(".chat-message, .chat-notice, .chat-retry")]
@@ -1362,6 +1467,29 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       finalTranscriptClearsComposer: true,
     });
     expect(compact.composerHeight).toBeGreaterThan(0);
+    await fixture.pressKey("Tab");
+    await fixture.pressKey("Tab");
+    await fixture.pressKey("Tab", { shift: true });
+    await fixture.pressKey("Escape");
+    expect(
+      await fixture.evaluate<{
+        readonly drawerClosed: boolean;
+        readonly triggerFocused: boolean;
+      }>(`
+        const closeDeadline = Date.now() + 2000;
+        while (
+          document.querySelector('[data-slot="dialog-content"]') !== null &&
+          Date.now() < closeDeadline
+        ) {
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+        const trigger = document.querySelector('[aria-label="Show training context"]');
+        return {
+          drawerClosed: document.querySelector('[data-slot="dialog-content"]') === null,
+          triggerFocused: document.activeElement === trigger,
+        };
+      `),
+    ).toEqual({ drawerClosed: true, triggerFocused: true });
     const reset = await fixture.evaluate<{
       readonly enabledBefore: boolean;
       readonly dialogOpen: boolean;
@@ -2084,10 +2212,120 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     fixtures.splice(fixtures.indexOf(fixture), 1);
   }, 90_000);
 
+  it("deletes one opened past chat through the native confirmation flow", async () => {
+    const { fixture, calls } = await launch({
+      width: 1180,
+      height: 820,
+      reducedMotion: false,
+    });
+    const confirmation = await fixture.evaluate<{
+      readonly entryOpened: boolean;
+      readonly dialogOpen: boolean;
+      readonly cancelFocused: boolean;
+      readonly actionOrder: readonly string[];
+      readonly impactCopy: string;
+    }>(`
+      const archiveNavigation = Array.from(
+        document.querySelectorAll('nav[aria-label="Main navigation"] button'),
+      ).find((entry) => entry.textContent?.includes("Past chats"));
+      archiveNavigation?.click();
+      const entryDeadline = Date.now() + 5000;
+      let entry = document.querySelector("button.archive-entry");
+      while (entry === null && Date.now() < entryDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        entry = document.querySelector("button.archive-entry");
+      }
+      entry?.click();
+      const readerDeadline = Date.now() + 5000;
+      let trigger = document.querySelector("button.archive-delete");
+      while (trigger === null && Date.now() < readerDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        trigger = document.querySelector("button.archive-delete");
+      }
+      trigger?.click();
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      const dialog = document.querySelector(".archive-delete-dialog");
+      const buttons = Array.from(dialog?.querySelectorAll("button") ?? []);
+      return {
+        entryOpened: document.querySelector('[aria-label="Past conversation"]') !== null,
+        dialogOpen: dialog !== null,
+        cancelFocused: document.activeElement === buttons[0],
+        actionOrder: buttons.map((button) => button.textContent?.trim() ?? ""),
+        impactCopy: dialog?.textContent ?? "",
+      };
+    `);
+    expect(confirmation).toEqual({
+      entryOpened: true,
+      dialogOpen: true,
+      cancelFocused: true,
+      actionOrder: ["Cancel", "Delete conversation"],
+      impactCopy: expect.stringContaining("Imported activities in Training and work in Plan stay."),
+    });
+
+    await fixture.pressKey("Escape");
+    expect(
+      await fixture.evaluate<{
+        readonly dialogClosed: boolean;
+        readonly triggerFocused: boolean;
+      }>(`
+        const closeDeadline = Date.now() + 2000;
+        while (
+          document.querySelector(".archive-delete-dialog") !== null &&
+          Date.now() < closeDeadline
+        ) {
+          await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+        const trigger = document.querySelector("button.archive-delete");
+        return {
+          dialogClosed: document.querySelector(".archive-delete-dialog") === null,
+          triggerFocused: document.activeElement === trigger,
+        };
+      `),
+    ).toEqual({ dialogClosed: true, triggerFocused: true });
+
+    expect(
+      await fixture.evaluate<{
+        readonly dialogClosed: boolean;
+        readonly listEmpty: boolean;
+      }>(`
+        document.querySelector("button.archive-delete")?.click();
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        const dialog = document.querySelector(".archive-delete-dialog");
+        Array.from(dialog?.querySelectorAll("button") ?? [])
+          .find((button) => button.textContent?.trim() === "Delete conversation")
+          ?.click();
+        const deleteDeadline = Date.now() + 5000;
+        while (
+          (document.querySelector(".archive-delete-dialog") !== null ||
+            document.querySelector(".archive-empty")?.hasAttribute("hidden")) &&
+          Date.now() < deleteDeadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        return {
+          dialogClosed: document.querySelector(".archive-delete-dialog") === null,
+          listEmpty:
+            document.querySelector(".archive-empty")?.hasAttribute("hidden") === false &&
+            document.querySelector("button.archive-entry") === null,
+        };
+      `),
+    ).toEqual({ dialogClosed: true, listEmpty: true });
+    expect(calls.filter((call) => call.method === "deleteArchivedConversation")).toEqual([
+      {
+        jsonrpc: "2.0",
+        method: "deleteArchivedConversation",
+        params: { boundaryRef: archivedBoundaryRef },
+      },
+    ]);
+    expect(calls.filter((call) => call.method === "listArchivedConversations")).toHaveLength(2);
+    expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
+    fixtures.splice(fixtures.indexOf(fixture), 1);
+  }, 90_000);
+
   it("keeps the dark Reading room usable at wide and compact viewports", async () => {
     const { fixture } = await launch({
-      width: 1440,
-      height: 900,
+      width: 1180,
+      height: 820,
       reducedMotion: false,
       colorScheme: "dark",
     });
@@ -2119,8 +2357,28 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       disclaimerCentered: true,
       contextVisible: true,
     });
+    expect(await stackedProjectionGeometry(fixture)).toEqual({
+      attachmentIssue: true,
+      planningIssue: true,
+      composerWithinViewport: true,
+      disclaimerWithinViewport: true,
+      projectionsScrollLocally: true,
+      disclaimerStableAfterProjectionScroll: true,
+      footerOrder: true,
+      documentVerticalOverflow: false,
+    });
 
-    await fixture.setViewport(720, 800);
+    await fixture.setViewport(760, 820);
+    expect(await stackedProjectionGeometry(fixture)).toEqual({
+      attachmentIssue: true,
+      planningIssue: true,
+      composerWithinViewport: true,
+      disclaimerWithinViewport: true,
+      projectionsScrollLocally: true,
+      disclaimerStableAfterProjectionScroll: true,
+      footerOrder: true,
+      documentVerticalOverflow: false,
+    });
     expect(
       await fixture.evaluate<{
         readonly overflow: boolean;

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -40,6 +40,7 @@ export interface RunningDesktopFixture {
   evaluate<T>(source: string): Promise<T>;
   screenshot(path: string): Promise<void>;
   setViewport(width: number, height: number): Promise<void>;
+  pressKey(key: "Escape" | "Tab", options?: { readonly shift?: boolean }): Promise<void>;
   readCapturedSurface(name: "location" | "console" | "stdout" | "stderr" | "dom"): string;
   close(): Promise<{
     readonly livePids: readonly number[];
@@ -354,6 +355,11 @@ export async function launchDesktopFixture(input: {
         ReturnType<CoachOperations["getArchivedTranscriptPage"]>
       >;
     },
+    async deleteArchivedConversation(request) {
+      return finalFrame(await invoke("deleteArchivedConversation", request)) as Awaited<
+        ReturnType<CoachOperations["deleteArchivedConversation"]>
+      >;
+    },
     async getActivityAnalysis(request) {
       return finalFrame(await invoke("getActivityAnalysis", request)) as Awaited<
         ReturnType<NonNullable<CoachOperations["getActivityAnalysis"]>>
@@ -576,6 +582,29 @@ export async function launchDesktopFixture(input: {
         height,
         deviceScaleFactor: 1,
         mobile: false,
+      });
+      await refreshSurfaces();
+    },
+    async pressKey(key, options) {
+      if (closed || cdp === undefined) throw new Error("desktop fixture is closed");
+      const virtualKeyCode = key === "Tab" ? 9 : 27;
+      const code = key === "Tab" ? "Tab" : "Escape";
+      const modifiers = options?.shift === true ? 8 : 0;
+      await cdp.call("Input.dispatchKeyEvent", {
+        type: "keyDown",
+        key,
+        code,
+        windowsVirtualKeyCode: virtualKeyCode,
+        nativeVirtualKeyCode: virtualKeyCode,
+        modifiers,
+      });
+      await cdp.call("Input.dispatchKeyEvent", {
+        type: "keyUp",
+        key,
+        code,
+        windowsVirtualKeyCode: virtualKeyCode,
+        nativeVirtualKeyCode: virtualKeyCode,
+        modifiers,
       });
       await refreshSurfaces();
     },

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -58,6 +58,7 @@ interface AuthBridge {
   initialSetupStatusSettled(input: unknown): Promise<unknown>;
   getTranscriptPage(input: unknown): Promise<unknown>;
   listArchivedConversations(): Promise<unknown>;
+  deleteArchivedConversation(boundaryRef: unknown): Promise<unknown>;
   getArchivedTranscriptPage(input: unknown): Promise<unknown>;
   getPlanningReadModel(): Promise<unknown>;
   getPlanState(): Promise<unknown>;
@@ -345,6 +346,7 @@ describe("desktop preload ChatGPT auth", () => {
         "claudeCliStatus",
         "credentialStatuses",
         "credentialRecoveryStatus",
+        "deleteArchivedConversation",
         "deleteCredential",
         "disableTelegram",
         "enableTelegram",
@@ -1278,6 +1280,43 @@ describe("desktop preload ChatGPT auth", () => {
     await expect(
       bridge.getArchivedTranscriptPage({ boundaryRef: BOUNDARY_REF, cursor: null, limit: 25 }),
     ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("validates archived conversation deletion at both sides of IPC", async () => {
+    const deleted = { schemaVersion: 1, status: "deleted" };
+    mocks.invoke.mockResolvedValueOnce(deleted);
+
+    const result = await bridge.deleteArchivedConversation(BOUNDARY_REF);
+    expect(result).toEqual(deleted);
+    expect(result).not.toBe(deleted);
+    expect(mocks.invoke).toHaveBeenCalledWith("desktop:delete-archived-conversation", {
+      boundaryRef: BOUNDARY_REF,
+    });
+
+    mocks.invoke.mockClear();
+    for (const boundaryRef of [BOUNDARY_REF.toUpperCase(), "a".repeat(63), "z".repeat(64), null]) {
+      await expect(bridge.deleteArchivedConversation(boundaryRef)).rejects.toBeInstanceOf(
+        TypeError,
+      );
+    }
+    await expect(
+      (bridge.deleteArchivedConversation as (...args: unknown[]) => Promise<unknown>)(
+        BOUNDARY_REF,
+        "extra",
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+
+    for (const response of [
+      { schemaVersion: 2, status: "deleted" },
+      { schemaVersion: 1, status: "missing" },
+      { schemaVersion: 1, status: "not-found", path: "/private/transcript" },
+    ]) {
+      mocks.invoke.mockResolvedValueOnce(response);
+      await expect(bridge.deleteArchivedConversation(BOUNDARY_REF)).rejects.toBeInstanceOf(
+        TypeError,
+      );
+    }
   });
 
   it("returns strict copied update states from zero-argument channels", async () => {

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -467,6 +467,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "claudeCliStatus",
       "credentialRecoveryStatus",
       "credentialStatuses",
+      "deleteArchivedConversation",
       "deleteCredential",
       "disableTelegram",
       "enableTelegram",

--- a/apps/desktop/tests/transcript-ipc.test.ts
+++ b/apps/desktop/tests/transcript-ipc.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL,
   DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL,
+  DESKTOP_DELETE_ARCHIVED_CONVERSATION_CHANNEL,
   DESKTOP_TRANSCRIPT_PAGE_CHANNEL,
 } from "../src/main/constants.js";
 import { createDesktopRendererUrl } from "../src/main/renderer-navigation.js";
@@ -55,6 +56,10 @@ function setup(
   readPage = vi.fn(async () => page),
   readArchivedConversations = vi.fn(async () => conversations),
   readArchivedPage = vi.fn(async () => page),
+  deleteArchivedConversation = vi.fn(async () => ({
+    schemaVersion: 1 as const,
+    status: "deleted" as const,
+  })),
 ) {
   const handlers = new Map<string, Handler>();
   const ipcMain = {
@@ -69,6 +74,7 @@ function setup(
     currentWindow: () => window as never,
     readPage,
     readArchivedConversations,
+    deleteArchivedConversation,
     readArchivedPage,
   });
   return {
@@ -78,6 +84,7 @@ function setup(
     readPage,
     readArchivedConversations,
     readArchivedPage,
+    deleteArchivedConversation,
     trusted: { sender: webContents, senderFrame: mainFrame },
   };
 }
@@ -237,11 +244,56 @@ describe("desktop transcript IPC", () => {
     ).rejects.toThrow("desktop transcript unavailable");
   });
 
+  it("deletes one strict archived conversation from the trusted main frame", async () => {
+    const subject = setup();
+    const handler = subject.handlers.get(DESKTOP_DELETE_ARCHIVED_CONVERSATION_CHANNEL)!;
+
+    await expect(handler(subject.trusted, { boundaryRef: BOUNDARY_REF })).resolves.toEqual({
+      schemaVersion: 1,
+      status: "deleted",
+    });
+    expect(subject.deleteArchivedConversation).toHaveBeenCalledWith({
+      boundaryRef: BOUNDARY_REF,
+    });
+
+    for (const args of [
+      [],
+      [{}],
+      [{ boundaryRef: BOUNDARY_REF.toUpperCase() }],
+      [{ boundaryRef: BOUNDARY_REF, extra: true }],
+      [{ boundaryRef: BOUNDARY_REF }, { extra: true }],
+    ]) {
+      await expect(handler(subject.trusted, ...args)).rejects.toThrow(
+        "invalid desktop transcript request",
+      );
+    }
+    await expect(
+      handler({ sender: {}, senderFrame: { url: RENDERER_URL } }, { boundaryRef: BOUNDARY_REF }),
+    ).rejects.toThrow("untrusted desktop transcript request");
+    expect(subject.deleteArchivedConversation).toHaveBeenCalledOnce();
+
+    const malformed = setup(
+      undefined,
+      undefined,
+      undefined,
+      vi.fn(async () => ({ schemaVersion: 1 as const, status: "missing" as never })),
+    );
+    await expect(
+      malformed.handlers.get(DESKTOP_DELETE_ARCHIVED_CONVERSATION_CHANNEL)!(malformed.trusted, {
+        boundaryRef: BOUNDARY_REF,
+      }),
+    ).rejects.toThrow("desktop transcript unavailable");
+  });
+
   it("uses one deadline-aware client per archived read and closes it", async () => {
     const client = {
-      call: vi.fn(async (method: string) =>
-        method === "listArchivedConversations" ? conversations : page,
-      ),
+      call: vi.fn(async (method: string) => {
+        if (method === "listArchivedConversations") return conversations;
+        if (method === "deleteArchivedConversation") {
+          return { schemaVersion: 1 as const, status: "deleted" as const };
+        }
+        return page;
+      }),
       close: vi.fn(async () => {}),
     };
     const connect = vi.fn(async () => client);
@@ -255,16 +307,22 @@ describe("desktop transcript IPC", () => {
     );
 
     await expect(reader.listArchivedConversations({})).resolves.toEqual(conversations);
+    await expect(reader.deleteArchivedConversation({ boundaryRef: BOUNDARY_REF })).resolves.toEqual(
+      { schemaVersion: 1, status: "deleted" },
+    );
     await expect(
       reader.getArchivedTranscriptPage({ boundaryRef: BOUNDARY_REF, cursor: null, limit: 25 }),
     ).resolves.toEqual(page);
     expect(client.call).toHaveBeenNthCalledWith(1, "listArchivedConversations", {});
-    expect(client.call).toHaveBeenNthCalledWith(2, "getArchivedTranscriptPage", {
+    expect(client.call).toHaveBeenNthCalledWith(2, "deleteArchivedConversation", {
+      boundaryRef: BOUNDARY_REF,
+    });
+    expect(client.call).toHaveBeenNthCalledWith(3, "getArchivedTranscriptPage", {
       boundaryRef: BOUNDARY_REF,
       cursor: null,
       limit: 25,
     });
-    expect(client.close).toHaveBeenCalledTimes(2);
+    expect(client.close).toHaveBeenCalledTimes(3);
   });
 
   it("removes every transcript channel during shutdown", () => {
@@ -273,6 +331,7 @@ describe("desktop transcript IPC", () => {
     for (const channel of [
       DESKTOP_TRANSCRIPT_PAGE_CHANNEL,
       DESKTOP_ARCHIVED_CONVERSATIONS_CHANNEL,
+      DESKTOP_DELETE_ARCHIVED_CONVERSATION_CHANNEL,
       DESKTOP_ARCHIVED_TRANSCRIPT_PAGE_CHANNEL,
     ]) {
       expect(subject.handlers.has(channel)).toBe(false);

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -139,6 +139,7 @@ const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
   hasSession: 30_000,
   getTranscriptPage: 30_000,
   listArchivedConversations: 30_000,
+  deleteArchivedConversation: 30_000,
   getArchivedTranscriptPage: 30_000,
   getAthleteState: 30_000,
   getPlanningReadModel: 30_000,

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -120,6 +120,7 @@ const rpcDeadlineCases = [
   ["hasSession", { chatId: "chat-1" }, 30_000],
   ["getTranscriptPage", { cursor: null, limit: 25 }, 30_000],
   ["listArchivedConversations", {}, 30_000],
+  ["deleteArchivedConversation", { boundaryRef: "a".repeat(64) }, 30_000],
   ["getArchivedTranscriptPage", { boundaryRef: "a".repeat(64), cursor: null, limit: 25 }, 30_000],
   ["getAthleteState", {}, 30_000],
   ["getPlanningReadModel", {}, 30_000],
@@ -967,6 +968,10 @@ describe("RPC receive and observers", () => {
           conversations: [],
           truncated: false,
         },
+        deleteArchivedConversation: {
+          schemaVersion: 1,
+          status: "deleted",
+        },
         getArchivedTranscriptPage: {
           schemaVersion: 1,
           status: "page",
@@ -1217,6 +1222,12 @@ describe("RPC receive and observers", () => {
       truncated: false,
     });
     await expect(
+      client.call("deleteArchivedConversation", { boundaryRef: "a".repeat(64) }),
+    ).resolves.toEqual({
+      schemaVersion: 1,
+      status: "deleted",
+    });
+    await expect(
       client.call("getArchivedTranscriptPage", {
         boundaryRef: "a".repeat(64),
         cursor: null,
@@ -1268,7 +1279,7 @@ describe("RPC receive and observers", () => {
       llm: { provider: "anthropic", model: "synthetic-model" },
     });
     expect(received.map((value) => (value as { id: number }).id)).toEqual([
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
     ]);
     expect(received.map((value) => (value as { method: string }).method)).toEqual([
       "chat",
@@ -1281,6 +1292,7 @@ describe("RPC receive and observers", () => {
       "resumeCoachDecision",
       "getTranscriptPage",
       "listArchivedConversations",
+      "deleteArchivedConversation",
       "getArchivedTranscriptPage",
       "getAthleteState",
       "importFiles",
@@ -1298,7 +1310,7 @@ describe("RPC receive and observers", () => {
       value: "imperial",
       source: "cycling",
     });
-    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([19, 20]);
+    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([20, 21]);
     expect(received.slice(-2).map((value) => (value as { method: string }).method)).toEqual([
       "getUnitsPreference",
       "setUnitsPreference",
@@ -1372,7 +1384,7 @@ describe("RPC receive and observers", () => {
     await expect(client.call("setDailySpendCap", { dailyCapUsd: 0.75 })).resolves.toMatchObject({
       dailyCapUsd: 0.75,
     });
-    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([39, 40]);
+    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([40, 41]);
     expect(received.slice(-2).map((value) => (value as { method: string }).method)).toEqual([
       "getSpendSummary",
       "setDailySpendCap",
@@ -1381,7 +1393,7 @@ describe("RPC receive and observers", () => {
       client.call("verify_intervals_credential", { api_key: "placeholder" }),
     ).resolves.toEqual({ approval: "a".repeat(64) });
     expect(received.at(-1)).toMatchObject({
-      id: 41,
+      id: 42,
       method: "verify_intervals_credential",
       params: { api_key: "placeholder" },
     });

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -255,6 +255,7 @@ export const COACH_RPC_METHOD_NAMES = [
   "resumeCoachDecision",
   "getTranscriptPage",
   "listArchivedConversations",
+  "deleteArchivedConversation",
   "getArchivedTranscriptPage",
   "getAthleteState",
   "getPlanningReadModel",
@@ -633,6 +634,25 @@ export const ListArchivedConversationsRpcResultSchema = z
   });
 export type ListArchivedConversationsRpcResult = z.infer<
   typeof ListArchivedConversationsRpcResultSchema
+>;
+
+export const DeleteArchivedConversationRpcParamsSchema = z
+  .object({
+    boundaryRef: ArchivedConversationBoundaryRefSchema,
+  })
+  .strict();
+export type DeleteArchivedConversationRpcParams = z.infer<
+  typeof DeleteArchivedConversationRpcParamsSchema
+>;
+
+export const DeleteArchivedConversationRpcResultSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    status: z.enum(["deleted", "not-found"]),
+  })
+  .strict();
+export type DeleteArchivedConversationRpcResult = z.infer<
+  typeof DeleteArchivedConversationRpcResultSchema
 >;
 
 export const AbsoluteImportPathSchema = PlatformAbsolutePathSchema;
@@ -1242,6 +1262,9 @@ export interface CoachOperations {
   listArchivedConversations(
     request: ListArchivedConversationsRpcParams,
   ): Promise<ListArchivedConversationsRpcResult>;
+  deleteArchivedConversation(
+    request: DeleteArchivedConversationRpcParams,
+  ): Promise<DeleteArchivedConversationRpcResult>;
   getArchivedTranscriptPage(
     request: GetArchivedTranscriptPageRpcParams,
   ): Promise<GetArchivedTranscriptPageRpcResult>;
@@ -1491,6 +1514,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("listArchivedConversations"),
       params: ListArchivedConversationsRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("deleteArchivedConversation"),
+      params: DeleteArchivedConversationRpcParamsSchema,
     })
     .strict(),
   z
@@ -2091,6 +2122,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "listArchivedConversations",
     requestSchema: ListArchivedConversationsRpcParamsSchema,
     responseSchema: ListArchivedConversationsRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  deleteArchivedConversation: {
+    wireName: "deleteArchivedConversation",
+    requestSchema: DeleteArchivedConversationRpcParamsSchema,
+    responseSchema: DeleteArchivedConversationRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
   getArchivedTranscriptPage: {

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 31;
+export const PROTOCOL_VERSION = 32;

--- a/packages/coach-contract/tests/chat-queue-contract.test.ts
+++ b/packages/coach-contract/tests/chat-queue-contract.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../src/index.js";
 
 describe("chat queue contract", () => {
-  it("ships protocol 31 and rejects a blank enqueue without attachments", () => {
-    expect(PROTOCOL_VERSION).toBe(31);
+  it("ships protocol 32 and rejects a blank enqueue without attachments", () => {
+    expect(PROTOCOL_VERSION).toBe(32);
     expect(() =>
       EnqueueChatMessageRequestSchema.parse({
         chatId: "desktop",

--- a/packages/coach-contract/tests/coach-decision-contract.test.ts
+++ b/packages/coach-contract/tests/coach-decision-contract.test.ts
@@ -151,8 +151,8 @@ describe("coach decision wire contract", () => {
     expect(parsed.entries).toHaveLength(1);
   });
 
-  it("projects resume completion explicitly at protocol 31", () => {
-    expect(PROTOCOL_VERSION).toBe(31);
+  it("projects resume completion explicitly at protocol 32", () => {
+    expect(PROTOCOL_VERSION).toBe(32);
     expect(
       ResumeCoachDecisionRpcResultSchema.parse({
         resumed: true,

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -114,8 +114,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 30", () => {
-    expect(PROTOCOL_VERSION).toBe(31);
+  it("is 32", () => {
+    expect(PROTOCOL_VERSION).toBe(32);
   });
 
   it("requires Stop to name the exact active turn", () => {

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -19,6 +19,8 @@ import {
   ConfigureRuntimeRpcParamsSchema,
   ConfigureRuntimeRpcResultSchema,
   ConfigureTelegramRpcParamsSchema,
+  DeleteArchivedConversationRpcParamsSchema,
+  DeleteArchivedConversationRpcResultSchema,
   DeleteTelegramWebhookRpcParamsSchema,
   GetRuntimeConfigRpcParamsSchema,
   GetRuntimeConfigRpcResultSchema,
@@ -328,6 +330,12 @@ describe("coach request and event projection", () => {
       { jsonrpc: "2.0", id: 16, method: "listArchivedConversations", params: {} },
       {
         jsonrpc: "2.0",
+        id: 38,
+        method: "deleteArchivedConversation",
+        params: { boundaryRef: BOUNDARY_REF },
+      },
+      {
+        jsonrpc: "2.0",
         id: 17,
         method: "getArchivedTranscriptPage",
         params: { boundaryRef: BOUNDARY_REF, cursor: null, limit: 25 },
@@ -561,6 +569,28 @@ describe("coach request and event projection", () => {
     expect(ListArchivedConversationsRpcParamsSchema.safeParse({ chatId: "desktop" }).success).toBe(
       false,
     );
+    expect(DeleteArchivedConversationRpcParamsSchema.parse({ boundaryRef: BOUNDARY_REF })).toEqual({
+      boundaryRef: BOUNDARY_REF,
+    });
+    for (const request of [
+      { boundaryRef: BOUNDARY_REF.toUpperCase() },
+      { boundaryRef: BOUNDARY_REF, chatId: "desktop" },
+      {},
+    ]) {
+      expect(DeleteArchivedConversationRpcParamsSchema.safeParse(request).success).toBe(false);
+    }
+    for (const status of ["deleted", "not-found"] as const) {
+      expect(DeleteArchivedConversationRpcResultSchema.parse({ schemaVersion: 1, status })).toEqual(
+        { schemaVersion: 1, status },
+      );
+    }
+    for (const result of [
+      { schemaVersion: 2, status: "deleted" },
+      { schemaVersion: 1, status: "missing" },
+      { schemaVersion: 1, status: "deleted", boundaryRef: BOUNDARY_REF },
+    ]) {
+      expect(DeleteArchivedConversationRpcResultSchema.safeParse(result).success).toBe(false);
+    }
   });
 
   it("rejects every nested non-JSON resolvedCs value at every wire boundary", () => {
@@ -1265,6 +1295,10 @@ describe("coach request and event projection", () => {
         conversations: [],
         truncated: false,
       }),
+      deleteArchivedConversation: async () => ({
+        schemaVersion: 1,
+        status: "deleted" as const,
+      }),
       getArchivedTranscriptPage: async () => ({
         schemaVersion: 1,
         status: "page",
@@ -1446,6 +1480,12 @@ describe("coach request and event projection", () => {
       wireName: "listArchivedConversations",
       requestSchema: ListArchivedConversationsRpcParamsSchema,
       responseSchema: ListArchivedConversationsRpcResultSchema,
+      eventSchema: NoRpcEventSchema,
+    });
+    expect(COACH_RPC_METHOD_REGISTRY.deleteArchivedConversation).toEqual({
+      wireName: "deleteArchivedConversation",
+      requestSchema: DeleteArchivedConversationRpcParamsSchema,
+      responseSchema: DeleteArchivedConversationRpcResultSchema,
       eventSchema: NoRpcEventSchema,
     });
     expect(COACH_RPC_METHOD_REGISTRY.getArchivedTranscriptPage).toEqual({
@@ -1639,6 +1679,7 @@ describe("coach request and event projection", () => {
       "hasSession",
       "getTranscriptPage",
       "listArchivedConversations",
+      "deleteArchivedConversation",
       "getArchivedTranscriptPage",
       "getAthleteState",
       "saveIntake",
@@ -1899,7 +1940,7 @@ describe("coach request and event projection", () => {
 });
 
 describe("handshake", () => {
-  it("round trips a protocol-31 accepted frame with its authenticated home and renderer capability", () => {
+  it("round trips a protocol-32 accepted frame with its authenticated home and renderer capability", () => {
     const accepted = createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION, {
       ...acceptedHandshakeBinding,
     });
@@ -1907,8 +1948,8 @@ describe("handshake", () => {
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual({
       type: "handshake",
       status: "accepted",
-      clientProtocolVersion: 31,
-      serverProtocolVersion: 31,
+      clientProtocolVersion: 32,
+      serverProtocolVersion: 32,
       owner: "service-managed",
       athleteHome: "/synthetic/athlete",
       rendererCapability: "A".repeat(43),
@@ -1917,7 +1958,7 @@ describe("handshake", () => {
 
   it("refuses a previous-protocol client with a version-mismatch frame instead of a parse error", () => {
     const previous = PROTOCOL_VERSION - 1;
-    expect(previous).toBe(30);
+    expect(previous).toBe(31);
     expect(() =>
       createAcceptedServerHandshakeFrame("service-managed", previous, {
         ...acceptedHandshakeBinding,
@@ -1990,9 +2031,9 @@ describe("handshake", () => {
     }
   });
 
-  it("accepts aligned protocol 31 peers and classifies mismatches in both directions", () => {
+  it("accepts aligned protocol 32 peers and classifies mismatches in both directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
-    expect(client.clientProtocolVersion).toBe(31);
+    expect(client.clientProtocolVersion).toBe(32);
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
     const accepted = createAcceptedServerHandshakeFrame(
       "service-managed",
@@ -2118,7 +2159,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version 31", () => {
-    expect(PROTOCOL_VERSION).toBe(31);
+  it("uses protocol version 32", () => {
+    expect(PROTOCOL_VERSION).toBe(32);
   });
 });

--- a/packages/coach/src/attachment-operations.ts
+++ b/packages/coach/src/attachment-operations.ts
@@ -43,6 +43,7 @@ export interface ManagedChatAttachmentOperations {
   saveDraftText(conversationId: string, text: string): Promise<void>;
   retryDraftAttachment(conversationId: string, attachmentId: string): Promise<void>;
   clearDraft(conversationId: string): Promise<void>;
+  cleanupAttachments(conversationId: string, attachmentIds: readonly string[]): Promise<void>;
   cleanupConversation(conversationId: string): Promise<void>;
   reconcile(): Promise<void>;
 }
@@ -333,6 +334,40 @@ export function createManagedChatAttachmentOperations(
           updatedAtMs: now(),
         });
       });
+    },
+
+    async cleanupAttachments(conversationId, attachmentIds) {
+      const startedAt = now();
+      try {
+        const count = await input.runExclusive(async () => {
+          const objects = await input.repository.prepareAttachmentCleanup({
+            conversationId,
+            attachmentIds,
+          });
+          for (const object of objects) await input.objects.removeObject(object.relative_path);
+          await input.repository.finalizeAttachmentCleanup({
+            conversationId,
+            attachmentIds,
+            removedObjectIds: objects.map((object) => object.id),
+          });
+          return attachmentIds.length;
+        });
+        input.observe?.({
+          operation: "cleanup",
+          kind: "unknown",
+          result: "succeeded",
+          count,
+          durationMs: now() - startedAt,
+        });
+      } catch (error) {
+        input.observe?.({
+          operation: "cleanup",
+          kind: "unknown",
+          result: "failed",
+          durationMs: now() - startedAt,
+        });
+        throw error;
+      }
     },
 
     async cleanupConversation(conversationId) {

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -589,6 +589,9 @@ function createReconfigurableRuntimeBundle(initial: RuntimeBundle): {
   readonly getArchivedTranscriptPage: (
     request: GetArchivedTranscriptPageRpcParams,
   ) => Promise<GetArchivedTranscriptPageRpcResult>;
+  readonly withChatStore: <T>(
+    operation: (store: ConversationStorePort) => Promise<T>,
+  ) => Promise<T>;
   replace<T>(
     prepare: () => T | Promise<T>,
     commit: (prepared: T) => RuntimeBundle | Promise<RuntimeBundle>,
@@ -659,6 +662,7 @@ function createReconfigurableRuntimeBundle(initial: RuntimeBundle): {
       run(async (bundle) =>
         bundle.chatStore.readArchivedConversationPage("desktop", boundaryRef, request),
       ),
+    withChatStore: (operation) => run((bundle) => operation(bundle.chatStore)),
     async replace(prepare, commit) {
       pendingReplacements += 1;
       const previousAdmission = admission;
@@ -1042,7 +1046,9 @@ export async function createLocalCoachComposition(
     const observeAttachment = (observation: AttachmentObservation): void => {
       observeChatAttachment(logger, observation);
     };
-    let cleanupPlanningRequestSources: ((conversationId: string) => Promise<void>) | undefined;
+    let cleanupPlanningRequestSources:
+      | ReturnType<typeof createPlanningRequestSourceCleanup>
+      | undefined;
     const attachmentRepository = createChatAttachmentRepository(input.context.store);
     const attachmentObjects = createManagedChatAttachmentStore({
       archiveDir: input.home.archiveDir,
@@ -1829,6 +1835,26 @@ export async function createLocalCoachComposition(
         readTranscriptPage: (request) => reconfigurable.getTranscriptPage(request),
         readArchivedConversations: (request) => reconfigurable.listArchivedConversations(request),
         readArchivedTranscriptPage: (request) => reconfigurable.getArchivedTranscriptPage(request),
+        deleteArchivedConversation: ({ boundaryRef }) =>
+          reconfigurable.withChatStore(async (chatStore) => {
+            const manifest = chatStore.inspectArchivedConversation("desktop", boundaryRef);
+            if (manifest === null) {
+              return { schemaVersion: 1, status: "not-found" };
+            }
+            if (cleanupPlanningRequestSources === undefined) {
+              throw new Error("Planning request source cleanup is unavailable.");
+            }
+            await cleanupPlanningRequestSources("desktop", {
+              messageIds: manifest.turnIds,
+              attachmentIds: manifest.attachmentIds,
+            });
+            await attachmentOperations.cleanupAttachments("desktop", manifest.attachmentIds);
+            const deleted = chatStore.finalizeArchivedConversationDeletion("desktop", manifest);
+            return {
+              schemaVersion: 1,
+              status: deleted ? "deleted" : "not-found",
+            };
+          }),
         applyRuntimeConfig,
         verifyIntervalsCredential,
         intervalsVerificationPending,

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -521,6 +521,7 @@ const RENDERER_RPC_METHODS = new Set<CoachRpcMethodName>([
   "hasSession",
   "getTranscriptPage",
   "listArchivedConversations",
+  "deleteArchivedConversation",
   "getArchivedTranscriptPage",
   "getAthleteState",
   "getPlanningReadModel",
@@ -1294,6 +1295,17 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                   generic.data.params,
                 );
               result = await input.operations.listArchivedConversations(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "deleteArchivedConversation":
+            try {
+              const request =
+                COACH_RPC_METHOD_REGISTRY.deleteArchivedConversation.requestSchema.parse(
+                  generic.data.params,
+                );
+              result = await input.operations.deleteArchivedConversation(request);
             } catch (error) {
               invocationFailure = { error };
             }

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -1,6 +1,8 @@
 import {
   ConfigureRuntimeRpcParamsSchema,
   ConfigureRuntimeRpcResultSchema,
+  DeleteArchivedConversationRpcParamsSchema,
+  DeleteArchivedConversationRpcResultSchema,
   GetArchivedTranscriptPageRpcParamsSchema,
   GetArchivedTranscriptPageRpcResultSchema,
   GetRuntimeConfigRpcParamsSchema,
@@ -27,6 +29,8 @@ import {
   type ConfigureRuntimeRpcParams,
   type ConfigureRuntimeRpcRefusalReason,
   type ConfigureRuntimeRpcResult,
+  type DeleteArchivedConversationRpcParams,
+  type DeleteArchivedConversationRpcResult,
   type GetArchivedTranscriptPageRpcParams,
   type GetArchivedTranscriptPageRpcResult,
   type GetRuntimeConfigRpcParams,
@@ -83,6 +87,9 @@ export interface CreateCoachOperationsInput {
   readonly readArchivedTranscriptPage?: (
     request: GetArchivedTranscriptPageRpcParams,
   ) => Promise<GetArchivedTranscriptPageRpcResult>;
+  readonly deleteArchivedConversation?: (
+    request: DeleteArchivedConversationRpcParams,
+  ) => Promise<DeleteArchivedConversationRpcResult>;
   readonly applyRuntimeConfig: (
     request: ConfigureRuntimeRpcParams,
     signal: AbortSignal,
@@ -333,6 +340,17 @@ export function createCoachOperations(
       return input
         .readArchivedTranscriptPage(parsedRequest)
         .then((result) => GetArchivedTranscriptPageRpcResultSchema.parse(result));
+    },
+    deleteArchivedConversation(
+      request: DeleteArchivedConversationRpcParams,
+    ): Promise<DeleteArchivedConversationRpcResult> {
+      const parsedRequest = DeleteArchivedConversationRpcParamsSchema.parse(request);
+      if (input.deleteArchivedConversation === undefined) {
+        throw new TypeError("Archived conversation deletion is unavailable.");
+      }
+      return input
+        .deleteArchivedConversation(parsedRequest)
+        .then((result) => DeleteArchivedConversationRpcResultSchema.parse(result));
     },
     configureRuntime(
       request: ConfigureRuntimeRpcParams,

--- a/packages/coach/src/planning-request-source-cleanup.ts
+++ b/packages/coach/src/planning-request-source-cleanup.ts
@@ -13,6 +13,11 @@ export interface PlanningRequestSourceCleanupInput {
   readonly identity: AuthoredIdentity;
 }
 
+export interface PlanningRequestSourceCleanupTarget {
+  readonly messageIds: readonly string[];
+  readonly attachmentIds: readonly string[];
+}
+
 function intentSummary(intent: string): string {
   const normalized = intent.trim().replace(/\s+/gu, " ");
   return (normalized.length === 0 ? "Plan request" : normalized).slice(0, 2_000);
@@ -65,11 +70,20 @@ function provenance(record: PlanningRequestRecord): PlanningRequestProvenanceSna
 
 export function createPlanningRequestSourceCleanup(
   input: PlanningRequestSourceCleanupInput,
-): (chatId: string) => Promise<void> {
-  return async (chatId) => {
+): (chatId: string, target?: PlanningRequestSourceCleanupTarget) => Promise<void> {
+  return async (chatId, target) => {
     const deviceId = await input.identity.deviceId();
     const outboxRecords = await input.outbox.readByChatId(chatId);
+    const messageIds = target === undefined ? undefined : new Set(target.messageIds);
+    const attachmentIds = target === undefined ? undefined : new Set(target.attachmentIds);
     for (const outboxRecord of outboxRecords) {
+      const selected =
+        target === undefined ||
+        (outboxRecord.payload !== null &&
+          (messageIds?.has(outboxRecord.payload.source.messageId) === true ||
+            (outboxRecord.payload.source.attachmentId !== undefined &&
+              attachmentIds?.has(outboxRecord.payload.source.attachmentId) === true)));
+      if (!selected) continue;
       if (outboxRecord.state === "pending" || outboxRecord.state === "failed") {
         const stamp = input.identity.hlcStamp();
         await input.outbox.cancelUndelivered({
@@ -96,10 +110,7 @@ export function createPlanningRequestSourceCleanup(
           hlcCounter: stamp.counter,
         });
       }
-      if (
-        request.request.lifecycle !== "open" &&
-        request.sourceState.status === "detached_open"
-      ) {
+      if (request.request.lifecycle !== "open" && request.sourceState.status === "detached_open") {
         const stamp = input.identity.hlcStamp();
         request = await input.requests.compactSource({
           requestId: request.request.requestId,

--- a/packages/coach/tests/activity-attachment-operations.test.ts
+++ b/packages/coach/tests/activity-attachment-operations.test.ts
@@ -195,7 +195,7 @@ describe("completed activity attachments", () => {
     const activityId = String(
       (await value.store.get("SELECT session_key FROM session LIMIT 1"))?.session_key,
     );
-    await value.attachments.cleanupConversation("chat-1");
+    await value.attachments.cleanupAttachments("chat-1", [value.attachmentId]);
     expect(await value.repository.readAttachment(value.attachmentId)).toBeUndefined();
     expect(
       await value.store.get("SELECT session_key FROM session WHERE session_key=?", [activityId]),

--- a/packages/coach/tests/attachment-operations.test.ts
+++ b/packages/coach/tests/attachment-operations.test.ts
@@ -317,6 +317,96 @@ describe("managed Chat attachment operations", () => {
     expect(JSON.stringify(observations)).not.toContain("desktop");
   });
 
+  it("removes only selected archived attachments and preserves shared bytes", async () => {
+    const sourcePath = join(root, "shared.txt");
+    await writeFile(sourcePath, "shared conversation bytes");
+    const { operations, repository } = createOperations([
+      "object-shared",
+      "attachment-archived",
+      "object-unused",
+      "attachment-retained",
+    ]);
+    const request = {
+      chatId: "desktop",
+      source: "picker" as const,
+      candidate: { kind: "native-path" as const, sourcePath },
+    };
+    await operations.admit({ ...request, selectionId: "selection-archived" });
+    await repository.linkMessage({
+      conversationId: "desktop",
+      messageId: "turn-archived",
+      attachmentIds: ["attachment-archived"],
+      createdAtMs: 101,
+    });
+    await operations.admit({ ...request, selectionId: "selection-retained" });
+    await repository.linkMessage({
+      conversationId: "desktop",
+      messageId: "turn-retained",
+      attachmentIds: ["attachment-retained"],
+      createdAtMs: 102,
+    });
+    const object = (await repository.readObject("object-shared"))!;
+    const objectPath = join(archiveDir, ...object.relative_path.split("/"));
+
+    await operations.cleanupAttachments("desktop", ["attachment-archived"]);
+    await expect(repository.readAttachment("attachment-archived")).resolves.toBeUndefined();
+    await expect(repository.listMessageAttachments("turn-archived")).resolves.toEqual([]);
+    await expect(repository.readAttachment("attachment-retained")).resolves.toMatchObject({
+      object_id: "object-shared",
+    });
+    await expect(readFile(objectPath, "utf8")).resolves.toBe("shared conversation bytes");
+
+    await operations.cleanupAttachments("desktop", ["attachment-retained"]);
+    await operations.cleanupAttachments("desktop", ["attachment-retained"]);
+    await expect(repository.readObject("object-shared")).resolves.toBeUndefined();
+    await expect(readFile(objectPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("keeps targeted metadata when physical byte removal fails", async () => {
+    const sourcePath = join(root, "retry-cleanup.txt");
+    await writeFile(sourcePath, "retry this cleanup");
+    const repository = createChatAttachmentRepository(store);
+    const objects = createManagedChatAttachmentStore({
+      archiveDir,
+      kindByteLimits: { document: 100, activity: 100, workout: 100, image: 100 },
+    });
+    const ids = ["object-retry", "attachment-retry"];
+    const admitting = createManagedChatAttachmentOperations({
+      repository,
+      objects,
+      runExclusive: (work) => work(),
+      randomId: () => ids.shift()!,
+    });
+    await admitting.admit({
+      chatId: "desktop",
+      selectionId: "selection-retry",
+      source: "picker",
+      candidate: { kind: "native-path", sourcePath },
+    });
+    await repository.linkMessage({
+      conversationId: "desktop",
+      messageId: "turn-retry",
+      attachmentIds: ["attachment-retry"],
+      createdAtMs: 101,
+    });
+    const failing = createManagedChatAttachmentOperations({
+      repository,
+      objects: {
+        ...objects,
+        removeObject: vi.fn(async () => {
+          throw new Error("managed storage unavailable");
+        }),
+      },
+      runExclusive: (work) => work(),
+    });
+
+    await expect(failing.cleanupAttachments("desktop", ["attachment-retry"])).rejects.toThrow(
+      "managed storage unavailable",
+    );
+    await expect(repository.readAttachment("attachment-retry")).resolves.toBeDefined();
+    await expect(repository.readObject("object-retry")).resolves.toBeDefined();
+  });
+
   it("keeps attachment bytes when the destination cleanup barrier fails", async () => {
     const sourcePath = join(root, "protected.txt");
     await writeFile(sourcePath, "preserve until Plan provenance is safe");

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -95,6 +95,7 @@ const operations: CoachOperations = {
     conversations: [],
     truncated: false,
   }),
+  deleteArchivedConversation: async () => ({ schemaVersion: 1, status: "deleted" }),
   getArchivedTranscriptPage: async () => ({
     schemaVersion: 1,
     status: "page",

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -711,6 +711,71 @@ describe("local coach composition", () => {
     await lifecycle.close();
   });
 
+  it("deletes one archived Desktop conversation through the application operation", async () => {
+    const home = await freshHome();
+    const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
+    const lineage = {
+      templateHash: "template",
+      assembledHash: "assembled",
+      provider: "synthetic",
+      model: "synthetic",
+      lineageVersion: "1",
+    };
+    const seedArchivedTurn = (turnId: string, boundaryAt: string): void => {
+      engineInput.ports.chatStore.appendTurn("desktop", turnId, `coach-${turnId}`, lineage);
+      engineInput.ports.transcriptWriter.appendCompletedTurn({
+        chatId: "desktop",
+        turnId,
+        completedAt: boundaryAt,
+        athleteText: turnId,
+        coachText: `coach-${turnId}`,
+      });
+      engineInput.ports.chatStore.resetConversation({
+        chatId: "desktop",
+        boundaryAt,
+        reason: "explicit-reset",
+      });
+    };
+    seedArchivedTurn("turn-first", "1998-07-06T00:00:01.000Z");
+    seedArchivedTurn("turn-second", "1998-07-06T00:00:02.000Z");
+    const archive = await lifecycle.operations.listArchivedConversations({});
+    const firstBoundary = await Promise.all(
+      archive.conversations.map(async (conversation) => ({
+        boundaryRef: conversation.boundaryRef,
+        page: await lifecycle.operations.getArchivedTranscriptPage({
+          boundaryRef: conversation.boundaryRef,
+          cursor: null,
+          limit: 25,
+        }),
+      })),
+    ).then((entries) =>
+      entries.find(({ page }) => page.turns.some((turn) => turn.turnId === "turn-first")),
+    );
+    if (firstBoundary === undefined) throw new Error("Expected the first archived conversation.");
+
+    await expect(
+      lifecycle.operations.deleteArchivedConversation({
+        boundaryRef: firstBoundary.boundaryRef,
+      }),
+    ).resolves.toEqual({ schemaVersion: 1, status: "deleted" });
+    await expect(
+      lifecycle.operations.deleteArchivedConversation({
+        boundaryRef: firstBoundary.boundaryRef,
+      }),
+    ).resolves.toEqual({ schemaVersion: 1, status: "not-found" });
+    await expect(lifecycle.operations.listArchivedConversations({})).resolves.toMatchObject({
+      conversations: [{ turnCount: 1 }],
+    });
+    await expect(
+      lifecycle.operations.getArchivedTranscriptPage({
+        boundaryRef: firstBoundary.boundaryRef,
+        cursor: null,
+        limit: 25,
+      }),
+    ).resolves.toMatchObject({ status: "restart-required", turns: [] });
+    await lifecycle.close();
+  });
+
   it.each([
     { skewHours: -2, expiresFromServerNowMs: -60 * 60_000, rejectedByServer: true },
     { skewHours: 2, expiresFromServerNowMs: 60 * 60_000, rejectedByServer: false },

--- a/packages/coach/tests/daemon-handshake.test.ts
+++ b/packages/coach/tests/daemon-handshake.test.ts
@@ -308,6 +308,7 @@ describe.skipIf(!hasLoopback)("production peer observations", () => {
           conversations: [],
           truncated: false,
         }),
+        deleteArchivedConversation: async () => ({ schemaVersion: 1, status: "deleted" }),
         getArchivedTranscriptPage: async () => ({
           schemaVersion: 1,
           status: "page",

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -194,6 +194,10 @@ const operations: CoachOperations & PlanningReadOperations = {
     conversations: [],
     truncated: false,
   }),
+  deleteArchivedConversation: async () => ({
+    schemaVersion: 1,
+    status: "deleted",
+  }),
   getArchivedTranscriptPage: async () => ({
     schemaVersion: 1,
     status: "page",
@@ -1723,9 +1727,18 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       ],
       nextCursor: null,
     }));
+    const deleteArchivedConversation = vi.fn(async () => ({
+      schemaVersion: 1 as const,
+      status: "deleted" as const,
+    }));
     const rpc = createCoachRpcServer({
       engine: engine(),
-      operations: { ...operations, listArchivedConversations, getArchivedTranscriptPage },
+      operations: {
+        ...operations,
+        listArchivedConversations,
+        deleteArchivedConversation,
+        getArchivedTranscriptPage,
+      },
       token,
       owner: "app-supervised",
     });
@@ -1763,6 +1776,40 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       cursor: null,
       limit: 25,
     });
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "archive-delete",
+        method: "deleteArchivedConversation",
+        params: { boundaryRef },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "archive-delete",
+      result: { schemaVersion: 1, status: "deleted" },
+    });
+    expect(deleteArchivedConversation).toHaveBeenCalledWith({ boundaryRef });
+
+    const renderer = await openSocket(rpc);
+    renderer.ws.send(
+      JSON.stringify(
+        createClientHandshakeFrame(TEST_RENDERER_CAPABILITY_BYTES.toString("base64url")),
+      ),
+    );
+    await renderer.frames.next();
+    renderer.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "renderer-archive-delete",
+        method: "deleteArchivedConversation",
+        params: { boundaryRef },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await renderer.frames.next())).toMatchObject({
+      id: "renderer-archive-delete",
+      result: { schemaVersion: 1, status: "deleted" },
+    });
 
     for (const [index, params] of [
       {},
@@ -1799,8 +1846,29 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       id: "archive-list-invalid",
       error: { code: -32602, message: "Invalid params" },
     });
+    for (const [index, params] of [
+      {},
+      { boundaryRef: boundaryRef.toUpperCase() },
+      { boundaryRef, chatId: "other" },
+    ].entries()) {
+      client.ws.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: `archive-delete-invalid-${index}`,
+          method: "deleteArchivedConversation",
+          params,
+        }),
+      );
+      expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+        jsonrpc: "2.0",
+        id: `archive-delete-invalid-${index}`,
+        error: { code: -32602, message: "Invalid params" },
+      });
+    }
     expect(listArchivedConversations).toHaveBeenCalledTimes(1);
+    expect(deleteArchivedConversation).toHaveBeenCalledTimes(2);
     expect(getArchivedTranscriptPage).toHaveBeenCalledTimes(1);
+    await renderer.close();
     await client.close();
   });
 

--- a/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
+++ b/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
@@ -225,6 +225,7 @@ async function startRpc(coachEngine: CoachEngine): Promise<RunningRpc> {
         conversations: [],
         truncated: false,
       }),
+      deleteArchivedConversation: async () => ({ schemaVersion: 1, status: "deleted" }),
       getArchivedTranscriptPage: async () => ({
         schemaVersion: 1,
         status: "page",

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -85,8 +85,8 @@ describe("service-aware arbitration", () => {
     const handshake = vi.fn(async () => ({
       type: "handshake" as const,
       status: "accepted" as const,
-      clientProtocolVersion: 31 as const,
-      serverProtocolVersion: 31 as const,
+      clientProtocolVersion: 32 as const,
+      serverProtocolVersion: 32 as const,
       owner: "service-managed" as const,
       athleteHome: home.root,
       rendererCapability,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -93,6 +93,7 @@ const operations: CoachOperations = {
     conversations: [],
     truncated: false,
   }),
+  deleteArchivedConversation: async () => ({ schemaVersion: 1, status: "deleted" }),
   getArchivedTranscriptPage: async () => ({
     schemaVersion: 1,
     status: "page",
@@ -304,7 +305,7 @@ afterEach(async () => {
 
 describe("enduragent executable composition", () => {
   it("starts initial refresh through one authenticated control socket and closes it", async () => {
-    expect(PROTOCOL_VERSION).toBe(31);
+    expect(PROTOCOL_VERSION).toBe(32);
     const startInitialRefresh = vi.fn(async () => ({ status: "accepted" as const }));
     const close = vi.fn(async () => {});
     const openControl = vi.fn(async () => ({ startInitialRefresh, close }));

--- a/packages/coach/tests/enduragent-redaction.test.ts
+++ b/packages/coach/tests/enduragent-redaction.test.ts
@@ -184,6 +184,7 @@ describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
               conversations: [],
               truncated: false,
             }),
+            deleteArchivedConversation: async () => ({ schemaVersion: 1, status: "deleted" }),
             getArchivedTranscriptPage: async () => ({
               schemaVersion: 1,
               status: "page",

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -95,6 +95,7 @@ const operations: CoachOperations = {
     conversations: [],
     truncated: false,
   }),
+  deleteArchivedConversation: async () => ({ schemaVersion: 1, status: "deleted" }),
   getArchivedTranscriptPage: async () => ({
     schemaVersion: 1,
     status: "page",

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -57,9 +57,7 @@ function promiseGate(): { readonly promise: Promise<void>; release(): void } {
 }
 
 function operationRuntime(
-  runWindowAfter: (
-    work: (signal: AbortSignal) => Promise<void>,
-  ) => Promise<
+  runWindowAfter: (work: (signal: AbortSignal) => Promise<void>) => Promise<
     Omit<Awaited<ReturnType<LocalStoreRuntime["runWindowAfter"]>>, "droppedActivities"> & {
       readonly droppedActivities?: DroppedActivities;
     }
@@ -148,6 +146,10 @@ describe("coach operations", () => {
       turns: [],
       nextCursor: null,
     }));
+    const deleteArchivedConversation = vi.fn(async () => ({
+      schemaVersion: 1 as const,
+      status: "deleted" as const,
+    }));
     const wiring = {
       home,
       context: context(),
@@ -160,6 +162,7 @@ describe("coach operations", () => {
       ...wiring,
       readArchivedConversations,
       readArchivedTranscriptPage,
+      deleteArchivedConversation,
     });
 
     await expect(operations.listArchivedConversations({})).resolves.toEqual({
@@ -197,12 +200,22 @@ describe("coach operations", () => {
     expect(() => operations.listArchivedConversations({ chatId: "other" } as never)).toThrow();
     expect(readArchivedConversations).toHaveBeenCalledOnce();
     expect(readArchivedTranscriptPage).toHaveBeenCalledOnce();
+    await expect(operations.deleteArchivedConversation({ boundaryRef })).resolves.toEqual({
+      schemaVersion: 1,
+      status: "deleted",
+    });
+    expect(deleteArchivedConversation).toHaveBeenCalledWith({ boundaryRef });
+    expect(() =>
+      operations.deleteArchivedConversation({ boundaryRef: "invalid" } as never),
+    ).toThrow();
+    expect(deleteArchivedConversation).toHaveBeenCalledOnce();
 
     const unwired = createCoachOperations(wiring);
     expect(() => unwired.listArchivedConversations({})).toThrow(TypeError);
     expect(() =>
       unwired.getArchivedTranscriptPage({ boundaryRef, cursor: null, limit: 25 }),
     ).toThrow(TypeError);
+    expect(() => unwired.deleteArchivedConversation({ boundaryRef })).toThrow(TypeError);
   });
 
   it("imports synthetic activity files through the live store and deduplicates reruns", async () => {
@@ -527,7 +540,10 @@ describe("coach operations", () => {
       published: true,
       referenceSucceeded: false,
       requests: { store: 2, reference: 1, total: 3 },
-      droppedActivities: { overall: { total: 0, visible: 0, restrictions: [], other: 0 }, recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 } },
+      droppedActivities: {
+        overall: { total: 0, visible: 0, restrictions: [], other: 0 },
+        recent7Days: { total: 0, visible: 0, restrictions: [], other: 0 },
+      },
     });
     expect(importFiles).toHaveBeenCalledTimes(1);
     expect(runWindowAfter).toHaveBeenCalledTimes(1);
@@ -623,7 +639,12 @@ describe("coach operations", () => {
   });
 
   it("reports pending verification instead of a completed keyless sync", async () => {
-    const backfill = vi.fn(async () => ({ pages: 0, artifacts: 0, reports: [], droppedActivityRows: { sourceRestricted: 0, other: 0 } }));
+    const backfill = vi.fn(async () => ({
+      pages: 0,
+      artifacts: 0,
+      reports: [],
+      droppedActivityRows: { sourceRestricted: 0, other: 0 },
+    }));
     const pending = { value: true };
     const operations = createCoachOperations(
       {
@@ -663,7 +684,12 @@ describe("coach operations", () => {
     };
     const backfill = vi.fn(async () => {
       trace.push("backfill");
-      return { pages: 1, artifacts: 1, reports: [], droppedActivityRows: { sourceRestricted: 60, other: 2 } };
+      return {
+        pages: 1,
+        artifacts: 1,
+        reports: [],
+        droppedActivityRows: { sourceRestricted: 60, other: 2 },
+      };
     });
     const runWindowAfter = vi.fn(async (work: (signal: AbortSignal) => Promise<void>) => {
       trace.push("admitted");
@@ -770,7 +796,12 @@ describe("coach operations", () => {
     ] as const;
     for (const options of pairs) {
       const events: unknown[] = [];
-      const backfill = vi.fn(async () => ({ pages: 1, artifacts: 0, reports: [], droppedActivityRows: { sourceRestricted: 0, other: 0 } }));
+      const backfill = vi.fn(async () => ({
+        pages: 1,
+        artifacts: 0,
+        reports: [],
+        droppedActivityRows: { sourceRestricted: 0, other: 0 },
+      }));
       const refresh = vi.fn();
       const runtime = {
         credentials: intervalsCredentials(options.apiKey, options.athleteId),
@@ -821,7 +852,12 @@ describe("coach operations", () => {
       const refresh = vi.fn();
       const backfill = vi.fn(async () => {
         if (failurePoint === "backfill") throw new Error("synthetic backfill failure");
-        return { pages: 1, artifacts: 1, reports: [], droppedActivityRows: { sourceRestricted: 60, other: 2 } };
+        return {
+          pages: 1,
+          artifacts: 1,
+          reports: [],
+          droppedActivityRows: { sourceRestricted: 60, other: 2 },
+        };
       });
       const runtime = {
         intervals: intervalsCredentials(
@@ -877,7 +913,12 @@ describe("coach operations", () => {
         ]);
         attempt += 1;
         if (attempt === 1) throw new Error("synthetic interruption");
-        return { pages: 1, artifacts: 0, reports: [], droppedActivityRows: { sourceRestricted: 0, other: 0 } };
+        return {
+          pages: 1,
+          artifacts: 0,
+          reports: [],
+          droppedActivityRows: { sourceRestricted: 0, other: 0 },
+        };
       });
       const runtime = {
         intervals: intervalsCredentials(

--- a/packages/coach/tests/planning-request-source-cleanup.test.ts
+++ b/packages/coach/tests/planning-request-source-cleanup.test.ts
@@ -207,4 +207,83 @@ describe("Planning request source cleanup", () => {
       sourceState: { status: "detached_open" },
     });
   });
+
+  it("cleans only sources selected by archived turn or attachment", async () => {
+    const crypto = createNodeCrypto();
+    const outbox = createChatPlanOutboxRepository(store, crypto);
+    const requests = createPlanningRequestRepository(store, crypto);
+    const selectedPending = payload("selected-pending", "turn-selected");
+    const unrelatedPending = payload("unrelated-pending", "turn-retained");
+    const selectedDelivered = payload("selected-delivered", "message-not-selected", {
+      source: {
+        chatId: "chat-1",
+        messageId: "message-not-selected",
+        attachmentId: "attachment-selected",
+      },
+      sourceSnapshot: {
+        ...payload("selected-delivered", "message-not-selected").sourceSnapshot,
+        attachment: {
+          attachmentId: "attachment-selected",
+          displayName: "tempo-3x12.mrc",
+          extension: "mrc",
+        },
+      },
+    });
+    const unrelatedDelivered = payload("unrelated-delivered", "message-retained");
+
+    await outbox.createOrGet({ payload: selectedPending, createdAtMs: 100 });
+    await outbox.createOrGet({ payload: unrelatedPending, createdAtMs: 101 });
+    for (const [createdAtMs, requestPayload] of [
+      [102, selectedDelivered],
+      [106, unrelatedDelivered],
+    ] as const) {
+      await outbox.createOrGet({ payload: requestPayload, createdAtMs });
+      await outbox.beginDelivery({
+        requestId: requestPayload.requestId,
+        attemptedAtMs: createdAtMs + 1,
+      });
+      await requests.createOrGet({
+        payload: requestPayload,
+        target: "active_plan",
+        createdAtMs: createdAtMs + 2,
+        deviceId: "device-1",
+        hlcPhysicalMs: createdAtMs + 2,
+        hlcCounter: 0,
+      });
+      await outbox.markDelivered({
+        requestId: requestPayload.requestId,
+        deliveredAtMs: createdAtMs + 3,
+      });
+    }
+
+    const cleanup = createPlanningRequestSourceCleanup({ outbox, requests, identity });
+    await cleanup("chat-1", {
+      messageIds: ["turn-selected"],
+      attachmentIds: ["attachment-selected"],
+    });
+
+    await expect(outbox.read("selected-pending")).resolves.toMatchObject({
+      state: "cancelled",
+      payload: null,
+    });
+    await expect(outbox.read("unrelated-pending")).resolves.toMatchObject({
+      state: "pending",
+      payload: unrelatedPending,
+    });
+    await expect(outbox.read("selected-delivered")).resolves.toMatchObject({
+      state: "delivered",
+      payload: null,
+    });
+    await expect(requests.read("selected-delivered")).resolves.toMatchObject({
+      sourceState: { status: "detached_open" },
+    });
+    await expect(outbox.read("unrelated-delivered")).resolves.toMatchObject({
+      state: "delivered",
+      payload: unrelatedDelivered,
+      sourceDeletedAtMs: null,
+    });
+    await expect(requests.read("unrelated-delivered")).resolves.toMatchObject({
+      sourceState: { status: "linked" },
+    });
+  });
 });

--- a/packages/coach/tests/serve.test.ts
+++ b/packages/coach/tests/serve.test.ts
@@ -99,6 +99,7 @@ const operations: CoachOperations = {
     conversations: [],
     truncated: false,
   }),
+  deleteArchivedConversation: async () => ({ schemaVersion: 1, status: "deleted" }),
   getArchivedTranscriptPage: async () => ({
     schemaVersion: 1,
     status: "page",

--- a/packages/core/src/agent/chat-store.ts
+++ b/packages/core/src/agent/chat-store.ts
@@ -1025,6 +1025,78 @@ export class ChatStore {
     this.pruneArchives(chatId, "reset");
   }
 
+  deleteResetArchive(chatId: string, boundaryRef: string, boundaryAt: string): boolean {
+    if (
+      typeof chatId !== "string" ||
+      !/^[a-f0-9]{64}$/.test(boundaryRef) ||
+      typeof boundaryAt !== "string" ||
+      Number.isNaN(Date.parse(boundaryAt)) ||
+      new Date(boundaryAt).toISOString() !== boundaryAt
+    ) {
+      throw new TypeError("Reset archive deletion metadata is invalid.");
+    }
+    const path = `${this.filePath(chatId)}.reset.${boundaryAt.replace(/:/g, "-")}.${boundaryRef}`;
+    return this.withSessionsDirectory((directoryDescriptor) => {
+      let beforeOpen: import("node:fs").Stats;
+      try {
+        beforeOpen = lstatSync(path);
+      } catch (error) {
+        if (isMissing(error)) {
+          this.assertSessionsDirectoryStable(directoryDescriptor);
+          return false;
+        }
+        throw error;
+      }
+      if (!this.isPrivateFile(beforeOpen, 1)) {
+        throw this.unsafeTarget("Reset archive target is unsafe.");
+      }
+      let descriptor: number;
+      try {
+        descriptor =
+          this.platform === "win32"
+            ? this.openWindowsSessionFile(directoryDescriptor, path, constants.O_RDONLY)
+            : openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException | undefined)?.code;
+        if (code === "ELOOP" || code === "EISDIR" || code === "ENOTDIR") {
+          throw this.unsafeTarget("Reset archive target is unsafe.");
+        }
+        throw error;
+      }
+      try {
+        const opened = fstatSync(descriptor);
+        const current = lstatSync(path);
+        if (
+          !this.isPrivateFile(opened, 1) ||
+          !this.isPrivateFile(current, 1) ||
+          !sameIdentity(identity(beforeOpen), identity(opened)) ||
+          !sameIdentity(identity(opened), identity(current))
+        ) {
+          throw this.unsafeTarget("Reset archive target is unsafe.");
+        }
+        if (this.platform === "win32") {
+          assertWindowsPrivateFileBinding(
+            this.windowsDirectoryBinding!,
+            path,
+            windowsPrivatePathIdentity(opened),
+          );
+        }
+        this.assertSessionsDirectoryStable(directoryDescriptor);
+        try {
+          unlinkSync(path);
+        } catch (error) {
+          throw this.platform === "win32"
+            ? classifyWindowsPrivatePathFailure("rename", error)
+            : error;
+        }
+        this.syncDirectory(directoryDescriptor);
+        return true;
+      } finally {
+        closeSync(descriptor);
+      }
+    }, "rename");
+  }
+
   archivePreCompact(chatId: string): void {
     const path = this.filePath(chatId);
     if (!this.sessionExists(path)) return;

--- a/packages/core/src/agent/conversation-store.ts
+++ b/packages/core/src/agent/conversation-store.ts
@@ -10,8 +10,10 @@ import type {
 } from "@enduragent/engine";
 import { archiveAndResetDurably, ChatStore } from "./chat-store.js";
 import {
+  ArchivedConversationDeletionConflictError,
   TranscriptBoundaryTargetUnchangedError,
   TranscriptStore,
+  type ArchivedConversationDeletionManifest,
   type ArchivedConversationList,
   type ResetIntentRecord,
   type TranscriptTurnRecord,
@@ -69,6 +71,14 @@ export interface ConversationStorePort extends ChatStorePort, TranscriptWriterPo
     boundaryRef: string,
     request: TranscriptPageRequest,
   ): TranscriptPageResult;
+  inspectArchivedConversation(
+    chatId: string,
+    boundaryRef: string,
+  ): ArchivedConversationDeletionManifest | null;
+  finalizeArchivedConversationDeletion(
+    chatId: string,
+    manifest: ArchivedConversationDeletionManifest,
+  ): boolean;
   reconcileChatQueue(chatId: string): ChatQueueSnapshot;
 }
 
@@ -226,6 +236,24 @@ export class ConversationStore implements ConversationStorePort {
     request: TranscriptPageRequest,
   ) {
     return this.transcriptStore.readArchivedConversationPage(chatId, boundaryRef, request);
+  }
+
+  inspectArchivedConversation(chatId: string, boundaryRef: string) {
+    return this.transcriptStore.inspectArchivedConversation(chatId, boundaryRef);
+  }
+
+  finalizeArchivedConversationDeletion(
+    chatId: string,
+    manifest: ArchivedConversationDeletionManifest,
+  ): boolean {
+    this.recoverBeforeAccess(chatId);
+    const current = this.transcriptStore.inspectArchivedConversation(chatId, manifest.boundaryRef);
+    if (current === null) return false;
+    if (JSON.stringify(current) !== JSON.stringify(manifest)) {
+      throw new ArchivedConversationDeletionConflictError();
+    }
+    this.chatStore.deleteResetArchive(chatId, manifest.boundaryRef, manifest.boundaryAt);
+    return this.transcriptStore.finalizeArchivedConversationDeletion(chatId, manifest);
   }
 
   getChatQueue(chatId: string): ChatQueueSnapshot {

--- a/packages/core/src/agent/transcript-store.ts
+++ b/packages/core/src/agent/transcript-store.ts
@@ -12,6 +12,7 @@ import {
   readFileSync,
   readdirSync,
   readSync,
+  renameSync,
   unlinkSync,
   writeSync,
   type Stats,
@@ -83,6 +84,7 @@ type TranscriptWrite = (
 
 interface TranscriptStoreHooks {
   readonly write?: TranscriptWrite;
+  readonly rename?: typeof renameSync;
   readonly syncFile?: (descriptor: number) => void;
   readonly syncDirectory?: (descriptor: number) => void;
   readonly beforeExistingFileOpen?: (path: string) => void;
@@ -332,6 +334,15 @@ export interface ArchivedConversationList {
   readonly truncated: boolean;
 }
 
+export interface ArchivedConversationDeletionManifest {
+  readonly schemaVersion: 1;
+  readonly boundaryRef: string;
+  readonly boundaryAt: string;
+  readonly turnIds: string[];
+  readonly attachmentIds: string[];
+  readonly manifestHash: string;
+}
+
 interface IndexedTranscriptTurn {
   readonly record: Exclude<TranscriptRecord, TranscriptConversationBoundaryRecord>;
   readonly start: number;
@@ -347,8 +358,19 @@ interface CurrentTranscriptWindow {
 
 interface ArchivedTranscriptSegment {
   readonly boundary: TranscriptConversationBoundaryRecord;
+  readonly start: number;
   readonly boundaryEnd: number;
   readonly turns: readonly IndexedTranscriptTurn[];
+  readonly trusted: boolean;
+}
+
+export class ArchivedConversationDeletionConflictError extends Error {
+  readonly code = "ARCHIVED_CONVERSATION_DELETION_CONFLICT";
+
+  constructor() {
+    super("Archived conversation changed before deletion completed.");
+    this.name = "ArchivedConversationDeletionConflictError";
+  }
 }
 
 interface DecodedTranscriptCursor {
@@ -862,6 +884,7 @@ function parseArchivedSegments(contents: Buffer, chatId: string): ArchivedTransc
   const segments: ArchivedTranscriptSegment[] = [];
   let trusted = true;
   let turns: IndexedTranscriptTurn[] = [];
+  let segmentStart = 0;
   let lineStart = 0;
   for (let index = 0; index < contents.length; index += 1) {
     if (contents[index] !== 0x0a) continue;
@@ -875,7 +898,14 @@ function parseArchivedSegments(contents: Buffer, chatId: string): ArchivedTransc
       continue;
     }
     if (record.kind === "conversation-boundary") {
-      segments.push({ boundary: record, boundaryEnd: lineStart, turns });
+      segments.push({
+        boundary: record,
+        start: segmentStart,
+        boundaryEnd: lineStart,
+        turns,
+        trusted,
+      });
+      segmentStart = lineStart;
       trusted = true;
       turns = [];
     } else if (trusted) {
@@ -883,6 +913,77 @@ function parseArchivedSegments(contents: Buffer, chatId: string): ArchivedTransc
     }
   }
   return segments;
+}
+
+function archivedConversationManifest(
+  contents: Buffer,
+  segment: ArchivedTranscriptSegment,
+): ArchivedConversationDeletionManifest {
+  if (!segment.trusted) {
+    throw new Error("Archived conversation cannot be safely inspected.");
+  }
+  const turnIds = new Set<string>();
+  const attachmentIds = new Set<string>();
+  for (const { record } of segment.turns) {
+    if ("turnId" in record && typeof record.turnId === "string") {
+      turnIds.add(record.turnId);
+    }
+    if (
+      (record.kind === "turn-completed" || record.kind === "turn-interrupted") &&
+      record.attachments !== undefined
+    ) {
+      for (const attachment of record.attachments) attachmentIds.add(attachment.attachmentId);
+    }
+  }
+  return {
+    schemaVersion: 1,
+    boundaryRef: segment.boundary.resetId,
+    boundaryAt: segment.boundary.boundaryAt,
+    turnIds: [...turnIds],
+    attachmentIds: [...attachmentIds],
+    manifestHash: createHash("sha256")
+      .update(contents.subarray(segment.start, segment.boundaryEnd))
+      .digest("hex"),
+  };
+}
+
+function isArchivedConversationDeletionManifest(
+  value: unknown,
+): value is ArchivedConversationDeletionManifest {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    hasExactKeys(record, [
+      "schemaVersion",
+      "boundaryRef",
+      "boundaryAt",
+      "turnIds",
+      "attachmentIds",
+      "manifestHash",
+    ]) &&
+    record.schemaVersion === 1 &&
+    typeof record.boundaryRef === "string" &&
+    RESET_ID_PATTERN.test(record.boundaryRef) &&
+    typeof record.boundaryAt === "string" &&
+    isIsoTimestamp(record.boundaryAt) &&
+    Array.isArray(record.turnIds) &&
+    record.turnIds.every((turnId) => typeof turnId === "string" && turnId.length > 0) &&
+    new Set(record.turnIds).size === record.turnIds.length &&
+    Array.isArray(record.attachmentIds) &&
+    record.attachmentIds.every(
+      (attachmentId) => typeof attachmentId === "string" && attachmentId.length > 0,
+    ) &&
+    new Set(record.attachmentIds).size === record.attachmentIds.length &&
+    typeof record.manifestHash === "string" &&
+    RESET_ID_PATTERN.test(record.manifestHash)
+  );
+}
+
+function sameArchivedConversationDeletionManifest(
+  left: ArchivedConversationDeletionManifest,
+  right: ArchivedConversationDeletionManifest,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function selectArchivedSegment(
@@ -1742,6 +1843,130 @@ export class TranscriptStore implements TranscriptWriterPort {
         closeSync(descriptor);
       }
     });
+  }
+
+  inspectArchivedConversation(
+    chatId: string,
+    boundaryRef: string,
+  ): ArchivedConversationDeletionManifest | null {
+    if (
+      typeof chatId !== "string" ||
+      typeof boundaryRef !== "string" ||
+      !RESET_ID_PATTERN.test(boundaryRef)
+    ) {
+      throw new TypeError("Archived conversation inspection request is invalid.");
+    }
+    return this.withDirectory((directoryDescriptor) => {
+      const path = this.transcriptPath(chatId);
+      const descriptor = this.openExistingFile(directoryDescriptor, path, constants.O_RDONLY, true);
+      if (descriptor === null) return null;
+      try {
+        const contents = this.readSnapshot(directoryDescriptor, descriptor, path);
+        if (this.platform === "win32") this.assertWindowsTranscriptContent(contents, chatId);
+        const segments = parseArchivedSegments(contents, chatId);
+        if (new Set(segments.map(({ boundary }) => boundary.resetId)).size !== segments.length) {
+          throw this.unsafeTarget("Transcript contains duplicate reset boundaries.");
+        }
+        const target = this.selectArchivedSegment(segments, boundaryRef);
+        this.assertOpenedFileSafe(descriptor);
+        this.assertDirectoryStable(directoryDescriptor);
+        return target === null ? null : archivedConversationManifest(contents, target);
+      } finally {
+        closeSync(descriptor);
+      }
+    });
+  }
+
+  finalizeArchivedConversationDeletion(
+    chatId: string,
+    manifest: ArchivedConversationDeletionManifest,
+  ): boolean {
+    if (typeof chatId !== "string" || !isArchivedConversationDeletionManifest(manifest)) {
+      throw new TypeError("Archived conversation deletion request is invalid.");
+    }
+    return this.withDirectory((directoryDescriptor) => {
+      const path = this.transcriptPath(chatId);
+      const tempPath = this.deletionTempPath(chatId, manifest.boundaryRef);
+      this.unlinkPrivateFileIfPresent(directoryDescriptor, tempPath, 1);
+      const descriptor = this.openExistingFile(directoryDescriptor, path, constants.O_RDONLY, true);
+      if (descriptor === null) return false;
+      let tempDescriptor: number | null = null;
+      let renamed = false;
+      try {
+        const beforeSnapshot = fstatSync(descriptor);
+        const contents = this.readSnapshot(directoryDescriptor, descriptor, path);
+        if (this.platform === "win32") this.assertWindowsTranscriptContent(contents, chatId);
+        const source = fstatSync(descriptor);
+        if (
+          !sameIdentity(identity(beforeSnapshot), identity(source)) ||
+          beforeSnapshot.size !== source.size ||
+          beforeSnapshot.mtimeMs !== source.mtimeMs ||
+          beforeSnapshot.ctimeMs !== source.ctimeMs ||
+          source.size !== contents.length
+        ) {
+          throw new ArchivedConversationDeletionConflictError();
+        }
+        const segments = parseArchivedSegments(contents, chatId);
+        if (new Set(segments.map(({ boundary }) => boundary.resetId)).size !== segments.length) {
+          throw this.unsafeTarget("Transcript contains duplicate reset boundaries.");
+        }
+        const target = this.selectArchivedSegment(segments, manifest.boundaryRef);
+        if (target === null) {
+          this.assertOpenedFileSafe(descriptor);
+          this.assertDirectoryStable(directoryDescriptor);
+          return false;
+        }
+        const current = archivedConversationManifest(contents, target);
+        if (!sameArchivedConversationDeletionManifest(current, manifest)) {
+          throw new ArchivedConversationDeletionConflictError();
+        }
+        const replacement = Buffer.concat([
+          contents.subarray(0, target.start),
+          contents.subarray(target.boundaryEnd),
+        ]);
+        if (this.platform === "win32") this.assertWindowsTranscriptSize(replacement.length);
+        tempDescriptor = this.openNewFile(directoryDescriptor, tempPath, 0, false);
+        this.writeComplete(tempDescriptor, replacement);
+        this.syncFile(tempDescriptor);
+        if (fstatSync(tempDescriptor).size !== replacement.length) {
+          throw this.unsafeTarget("Transcript replacement was incomplete.");
+        }
+        this.assertOpenedPathSafe(directoryDescriptor, descriptor, path);
+        const sourceCurrent = fstatSync(descriptor);
+        if (
+          !sameIdentity(identity(source), identity(sourceCurrent)) ||
+          source.size !== sourceCurrent.size ||
+          source.mtimeMs !== sourceCurrent.mtimeMs ||
+          source.ctimeMs !== sourceCurrent.ctimeMs
+        ) {
+          throw new ArchivedConversationDeletionConflictError();
+        }
+        try {
+          (this.hooks.rename ?? renameSync)(tempPath, path);
+        } catch (error) {
+          throw this.platform === "win32"
+            ? classifyWindowsPrivatePathFailure("rename", error)
+            : error;
+        }
+        renamed = true;
+        this.assertOpenedPathSafe(directoryDescriptor, tempDescriptor, path);
+        this.syncDirectory(directoryDescriptor);
+        this.assertOpenedPathSafe(directoryDescriptor, tempDescriptor, path);
+        return true;
+      } catch (error) {
+        if (!renamed) {
+          try {
+            this.unlinkPrivateFileIfPresent(directoryDescriptor, tempPath, 1);
+          } catch {}
+        }
+        throw this.platform === "win32"
+          ? classifyWindowsPrivatePathFailure("content-write", error)
+          : error;
+      } finally {
+        if (tempDescriptor !== null) closeSync(tempDescriptor);
+        closeSync(descriptor);
+      }
+    }, "content-write");
   }
 
   createResetIntent(input: ResetIntentRecord): void {
@@ -2679,6 +2904,10 @@ export class TranscriptStore implements TranscriptWriterPort {
 
   private transcriptPath(chatId: string): string {
     return join(this.transcriptsDir, `${this.chatDigest(chatId)}.jsonl`);
+  }
+
+  private deletionTempPath(chatId: string, resetId: string): string {
+    return join(this.transcriptsDir, `${this.chatDigest(chatId)}.${resetId}.delete.tmp`);
   }
 
   private intentPath(chatId: string): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -132,9 +132,11 @@ export {
   MAX_TRANSCRIPT_PAGE_RESPONSE_BYTES,
   MAX_TRANSCRIPT_PAGE_TURNS,
   MAX_TRANSCRIPT_RECORD_BYTES,
+  ArchivedConversationDeletionConflictError,
   UnsafeTranscriptTargetError,
 } from "./agent/transcript-store.js";
 export type {
+  ArchivedConversationDeletionManifest,
   ArchivedConversationList,
   ArchivedConversationSummary,
   TranscriptPageRequest,

--- a/packages/core/tests/conversation-store.test.ts
+++ b/packages/core/tests/conversation-store.test.ts
@@ -26,6 +26,8 @@ import { WindowsPrivatePathPolicyError } from "../src/io/windows-private-path-po
 
 const roots: string[] = [];
 const RESET_ID = "c".repeat(64);
+const RESET_ID_A = "a".repeat(64);
+const RESET_ID_B = "b".repeat(64);
 
 function makeDataDir(): string {
   const path = mkdtempSync(join(tmpdir(), "conversation-store-"));
@@ -228,6 +230,101 @@ describe("ConversationStore reset transaction recovery", () => {
         .turns.map((record) => record.turnId),
     ).toEqual(["turn-3"]);
     expect(readFileSync(transcriptPath(dataDir, chatId))).toEqual(before);
+  });
+
+  it("deletes only the selected archived session after validating its transcript manifest", () => {
+    const dataDir = makeDataDir();
+    const chatId = "delete-one-archive";
+    const chat = new ChatStore(dataDir);
+    const transcript = new TranscriptStore(dataDir);
+    const resetIds = [RESET_ID_A, RESET_ID_B, RESET_ID];
+    const store = new ConversationStore(chat, transcript, () => resetIds.shift()!);
+    const boundaries = [
+      "2026-07-22T01:00:00.000Z",
+      "2026-07-22T02:00:00.000Z",
+      "2026-07-22T03:00:00.000Z",
+    ];
+    for (let index = 0; index < boundaries.length; index += 1) {
+      store.appendTurn(chatId, `athlete-${index + 1}`, `coach-${index + 1}`, LINEAGE);
+      store.appendCompletedTurn({
+        chatId,
+        turnId: `turn-${index + 1}`,
+        completedAt: `2026-07-22T00:00:0${index}.000Z`,
+        athleteText: `athlete-${index + 1}`,
+        coachText: `coach-${index + 1}`,
+      });
+      store.resetConversation({
+        chatId,
+        boundaryAt: boundaries[index]!,
+        reason: "explicit-reset",
+      });
+    }
+    store.appendTurn(chatId, "athlete-current", "coach-current", LINEAGE);
+    store.appendCompletedTurn({
+      chatId,
+      turnId: "turn-current",
+      completedAt: "2026-07-22T04:00:00.000Z",
+      athleteText: "athlete-current",
+      coachText: "coach-current",
+    });
+    const manifest = store.inspectArchivedConversation(chatId, RESET_ID_B)!;
+
+    expect(store.finalizeArchivedConversationDeletion(chatId, manifest)).toBe(true);
+    expect(store.finalizeArchivedConversationDeletion(chatId, manifest)).toBe(false);
+    expect(resetArchives(dataDir, chatId).sort()).toEqual(
+      [
+        `${sessionName(chatId)}.jsonl.reset.${boundaries[0]!.replace(/:/g, "-")}.${RESET_ID_A}`,
+        `${sessionName(chatId)}.jsonl.reset.${boundaries[2]!.replace(/:/g, "-")}.${RESET_ID}`,
+      ].sort(),
+    );
+    expect(existsSync(sessionPath(dataDir, chatId))).toBe(true);
+    expect(
+      store.listArchivedConversations(chatId).conversations.map(({ boundaryRef }) => boundaryRef),
+    ).toEqual([RESET_ID, RESET_ID_A]);
+    expect(store.readCurrentConversation(chatId).map(({ turnId }) => turnId)).toEqual([
+      "turn-current",
+    ]);
+  });
+
+  it("keeps the exact session archive when transcript inspection becomes stale", () => {
+    const dataDir = makeDataDir();
+    const chatId = "stale-delete-manifest";
+    const chat = new ChatStore(dataDir);
+    const transcript = new TranscriptStore(dataDir);
+    const store = new ConversationStore(chat, transcript, () => RESET_ID_A);
+    store.appendTurn(chatId, "athlete", "coach", LINEAGE);
+    store.appendCompletedTurn({
+      chatId,
+      turnId: "turn-1",
+      completedAt: "2026-07-22T00:00:00.000Z",
+      athleteText: "athlete",
+      coachText: "coach",
+    });
+    store.resetConversation({
+      chatId,
+      boundaryAt: "2026-07-22T01:00:00.000Z",
+      reason: "explicit-reset",
+    });
+    const manifest = store.inspectArchivedConversation(chatId, RESET_ID_A)!;
+    const path = transcriptPath(dataDir, chatId);
+    writeFileSync(
+      path,
+      readFileSync(path, "utf8").replace('"athleteText":"athlete"', '"athleteText":"changed"'),
+      { mode: 0o600 },
+    );
+
+    expect(() => store.finalizeArchivedConversationDeletion(chatId, manifest)).toThrow(
+      "Archived conversation changed before deletion completed.",
+    );
+    expect(
+      existsSync(
+        join(
+          dataDir,
+          "sessions",
+          `${sessionName(chatId)}.jsonl.reset.2026-07-22T01-00-00.000Z.${RESET_ID_A}`,
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("fences a pagination cursor after the reset transaction completes", () => {

--- a/packages/core/tests/transcript-store.test.ts
+++ b/packages/core/tests/transcript-store.test.ts
@@ -37,6 +37,7 @@ import { WindowsPrivatePathPolicyError } from "../src/io/windows-private-path-po
 const roots: string[] = [];
 const RESET_ID_A = "a".repeat(64);
 const RESET_ID_B = "b".repeat(64);
+const RESET_ID_C = "c".repeat(64);
 
 function makeDataDir(): string {
   const path = mkdtempSync(join(tmpdir(), "transcript-store-"));
@@ -372,6 +373,129 @@ describe("TranscriptStore archived conversation reads", () => {
     store.readArchivedConversationPage(chatId, RESET_ID_A, { cursor: null, limit: 5 });
 
     expect(readFileSync(transcriptPath(dataDir, chatId))).toEqual(before);
+  });
+});
+
+describe("TranscriptStore archived conversation deletion", () => {
+  it("inspects and deletes the oldest, middle, and newest segments without changing current", () => {
+    const dataDir = makeDataDir();
+    const chatId = "archive-delete-order";
+    const store = new TranscriptStore(dataDir);
+    const append = (turnId: string, attachmentId: string) =>
+      store.appendCompletedTurn({
+        ...turn(chatId, turnId),
+        attachments: [
+          {
+            attachmentId,
+            displayName: `${attachmentId}.txt`,
+            kind: "document" as const,
+            extension: "txt" as const,
+          },
+        ],
+      });
+    append("turn-1", "attachment-1");
+    store.ensureConversationBoundary(intent(chatId, RESET_ID_A));
+    append("turn-2", "attachment-2");
+    store.ensureConversationBoundary(intent(chatId, RESET_ID_B));
+    append("turn-3", "attachment-3");
+    store.ensureConversationBoundary(intent(chatId, RESET_ID_C));
+    append("turn-4", "attachment-current");
+
+    const middle = store.inspectArchivedConversation(chatId, RESET_ID_B);
+    expect(middle).toMatchObject({
+      schemaVersion: 1,
+      boundaryRef: RESET_ID_B,
+      boundaryAt: "2026-07-22T01:00:00.000Z",
+      turnIds: ["turn-2"],
+      attachmentIds: ["attachment-2"],
+      manifestHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    expect(store.finalizeArchivedConversationDeletion(chatId, middle!)).toBe(true);
+    expect(
+      store.listArchivedConversations(chatId).conversations.map((item) => item.boundaryRef),
+    ).toEqual([RESET_ID_C, RESET_ID_A]);
+    expect(
+      store
+        .readArchivedConversationPage(chatId, RESET_ID_A, { cursor: null, limit: 10 })
+        .turns.map(({ turnId }) => turnId),
+    ).toEqual(["turn-1"]);
+    expect(
+      store
+        .readArchivedConversationPage(chatId, RESET_ID_C, { cursor: null, limit: 10 })
+        .turns.map(({ turnId }) => turnId),
+    ).toEqual(["turn-3"]);
+
+    const oldest = store.inspectArchivedConversation(chatId, RESET_ID_A);
+    expect(store.finalizeArchivedConversationDeletion(chatId, oldest!)).toBe(true);
+    expect(
+      store.listArchivedConversations(chatId).conversations.map((item) => item.boundaryRef),
+    ).toEqual([RESET_ID_C]);
+
+    const newest = store.inspectArchivedConversation(chatId, RESET_ID_C);
+    expect(store.finalizeArchivedConversationDeletion(chatId, newest!)).toBe(true);
+    expect(store.listArchivedConversations(chatId)).toEqual({
+      schemaVersion: 1,
+      conversations: [],
+      truncated: false,
+    });
+    expect(store.readCurrentConversation(chatId).map(({ turnId }) => turnId)).toEqual(["turn-4"]);
+    expect(readFileSync(transcriptPath(dataDir, chatId), "utf8")).toContain("attachment-current");
+    expect(readFileSync(transcriptPath(dataDir, chatId), "utf8")).not.toContain("attachment-1");
+    expect(readFileSync(transcriptPath(dataDir, chatId), "utf8")).not.toContain("attachment-2");
+    expect(readFileSync(transcriptPath(dataDir, chatId), "utf8")).not.toContain("attachment-3");
+  });
+
+  it("makes not-found finalization idempotent and invalidates a deleted segment cursor", () => {
+    const dataDir = makeDataDir();
+    const chatId = "archive-delete-idempotent";
+    const store = new TranscriptStore(dataDir);
+    store.appendCompletedTurn(turn(chatId, "turn-1"));
+    store.appendCompletedTurn(turn(chatId, "turn-2"));
+    store.ensureConversationBoundary(intent(chatId, RESET_ID_A));
+    store.appendCompletedTurn(turn(chatId, "turn-3"));
+    const page = store.readArchivedConversationPage(chatId, RESET_ID_A, {
+      cursor: null,
+      limit: 1,
+    });
+    const manifest = store.inspectArchivedConversation(chatId, RESET_ID_A)!;
+
+    expect(page.nextCursor).not.toBeNull();
+    expect(store.finalizeArchivedConversationDeletion(chatId, manifest)).toBe(true);
+    expect(store.inspectArchivedConversation(chatId, RESET_ID_A)).toBeNull();
+    expect(store.finalizeArchivedConversationDeletion(chatId, manifest)).toBe(false);
+    expect(
+      store.finalizeArchivedConversationDeletion("missing", {
+        ...manifest,
+        boundaryRef: RESET_ID_B,
+      }),
+    ).toBe(false);
+    expect(() =>
+      store.readArchivedConversationPage(chatId, RESET_ID_A, {
+        cursor: page.nextCursor,
+        limit: 1,
+      }),
+    ).toThrow(TypeError);
+    expect(store.readCurrentConversation(chatId).map(({ turnId }) => turnId)).toEqual(["turn-3"]);
+  });
+
+  it("rejects a manifest when the selected archived bytes changed", () => {
+    const dataDir = makeDataDir();
+    const chatId = "archive-delete-conflict";
+    const store = new TranscriptStore(dataDir);
+    store.appendCompletedTurn(turn(chatId, "turn-1"));
+    store.ensureConversationBoundary(intent(chatId, RESET_ID_A));
+    const manifest = store.inspectArchivedConversation(chatId, RESET_ID_A)!;
+    const path = transcriptPath(dataDir, chatId);
+    writeFileSync(
+      path,
+      readFileSync(path, "utf8").replace('"athleteText":"athlete"', '"athleteText":"changed"'),
+      { mode: 0o600 },
+    );
+
+    expect(() => store.finalizeArchivedConversationDeletion(chatId, manifest)).toThrow(
+      "Archived conversation changed before deletion completed.",
+    );
+    expect(store.listArchivedConversations(chatId).conversations).toHaveLength(1);
   });
 });
 

--- a/packages/kernel/src/chat-attachments/repository.ts
+++ b/packages/kernel/src/chat-attachments/repository.ts
@@ -177,6 +177,20 @@ function validateAttachment(row: ChatAttachmentRow): void {
   }
 }
 
+function validateCleanupIds(conversationId: string, ids: readonly string[], name: string): void {
+  if (
+    conversationId.length < 1 ||
+    conversationId.length > 512 ||
+    ids.some((id) => !SAFE_ID.test(id)) ||
+    new Set(ids).size !== ids.length
+  ) {
+    throw new ChatAttachmentInvariantError(
+      `invalid_${name}`,
+      `attachment ${name.replaceAll("_", " ")} is invalid`,
+    );
+  }
+}
+
 function mapObject(row: Row): ChatAttachmentObjectRow {
   const value: ChatAttachmentObjectRow = {
     id: String(row.id),
@@ -745,6 +759,58 @@ export function createChatAttachmentRepository(
 
     async markObjectMissing(objectId, updatedAtMs) {
       await this.failObject(objectId, "managed_bytes_missing", updatedAtMs);
+    },
+
+    async prepareAttachmentCleanup({ conversationId, attachmentIds }) {
+      validateCleanupIds(conversationId, attachmentIds, "cleanup_target");
+      if (attachmentIds.length === 0) return [];
+      const placeholders = attachmentIds.map(() => "?").join(",");
+      return (
+        await store.all(
+          `SELECT ${OBJECT_COLUMNS.split(",")
+            .map((column) => `o.${column}`)
+            .join(",")}
+             FROM chat_attachment_object o
+            WHERE o.conversation_id=?
+              AND EXISTS (
+                SELECT 1 FROM chat_attachment selected
+                 WHERE selected.object_id=o.id
+                   AND selected.conversation_id=?
+                   AND selected.id IN (${placeholders})
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM chat_attachment retained
+                 WHERE retained.object_id=o.id
+                   AND retained.id NOT IN (${placeholders})
+              )
+            ORDER BY o.created_at_ms,o.id`,
+          [conversationId, conversationId, ...attachmentIds, ...attachmentIds],
+        )
+      ).map(mapObject);
+    },
+
+    async finalizeAttachmentCleanup({ conversationId, attachmentIds, removedObjectIds }) {
+      validateCleanupIds(conversationId, attachmentIds, "cleanup_target");
+      validateCleanupIds(conversationId, removedObjectIds, "removed_object_ids");
+      if (attachmentIds.length === 0 && removedObjectIds.length === 0) return;
+      await store.transaction(async () => {
+        if (attachmentIds.length > 0) {
+          const placeholders = attachmentIds.map(() => "?").join(",");
+          await store.run(
+            `DELETE FROM chat_attachment
+              WHERE conversation_id=? AND id IN (${placeholders})`,
+            [conversationId, ...attachmentIds],
+          );
+        }
+        for (const objectId of removedObjectIds) {
+          await store.run(
+            `DELETE FROM chat_attachment_object
+              WHERE id=? AND conversation_id=?
+                AND NOT EXISTS (SELECT 1 FROM chat_attachment WHERE object_id=?)`,
+            [objectId, conversationId, objectId],
+          );
+        }
+      });
     },
 
     async cleanupConversation(conversationId) {

--- a/packages/kernel/src/chat-attachments/types.ts
+++ b/packages/kernel/src/chat-attachments/types.ts
@@ -167,6 +167,15 @@ export interface ChatAttachmentRepository {
   listMessageAttachments(messageId: string): Promise<readonly ChatAttachmentRow[]>;
   listObjects(): Promise<readonly ChatAttachmentObjectRow[]>;
   markObjectMissing(objectId: string, updatedAtMs: number): Promise<void>;
+  prepareAttachmentCleanup(input: {
+    readonly conversationId: string;
+    readonly attachmentIds: readonly string[];
+  }): Promise<readonly ChatAttachmentObjectRow[]>;
+  finalizeAttachmentCleanup(input: {
+    readonly conversationId: string;
+    readonly attachmentIds: readonly string[];
+    readonly removedObjectIds: readonly string[];
+  }): Promise<void>;
   cleanupConversation(conversationId: string): Promise<readonly ChatAttachmentObjectRow[]>;
   hasObject(objectId: string): Promise<boolean>;
   deleteFailedObject(objectId: string): Promise<void>;


### PR DESCRIPTION
## Summary

- keep the Chat safety note and composer visible while stacked cards scroll locally
- order decision, attachment, and queue cards consistently and restore reliable compact-drawer keyboard dismissal
- add confirmed single-conversation deletion across the renderer, hardened desktop bridge, RPC contract, Plan provenance cleanup, attachment cleanup, and durable archive storage

## Verification

- workspace build, package checks, root typecheck, lint, privacy, dependency, kernel, changeset, and wire-schema gates
- 28 changed test files: 834 passing
- real Electron Chat and Past chats acceptance: 7 passing
- hardened desktop bridge integration: 3 passing

## Changeset

Added for all affected published packages.