### PR TITLE
fix(core): deduplicate version ping telemetry

### DIFF
--- a/.changeset/dedupe-version-pings.md
+++ b/.changeset/dedupe-version-pings.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Automatic update checks now contact Enduragent at most once per day per installation, while repeated update commands reuse recent results.
+
+Persist the daily telemetry attempt before sending it, route manual version checks directly to npm, and share successful or in-progress version lookups.

--- a/README.md
+++ b/README.md
@@ -160,9 +160,11 @@ Keychain. If secure storage is unavailable, the app refuses to save the key rath
 in the clear.
 
 **What does leave.** Your prompt and the training numbers in it go to the model provider you
-chose. Your intervals.icu key goes to intervals.icu. The self-hosted Telegram bot checks
-`ping.enduragent.icu` for a newer version on startup and daily — no athlete data, no credentials;
-set `CYCLING_COACH_NO_UPDATE_CHECK=1` to switch it off. The desktop app never makes that request.
+chose. Your intervals.icu key goes to intervals.icu. The self-hosted Telegram bot may contact
+`ping.enduragent.icu` at startup and on its daily timer, but at most once per installation in any
+24 hours — no athlete data, no credentials; set `CYCLING_COACH_NO_UPDATE_CHECK=1` to switch it off.
+Manual commands never initiate telemetry. Version lookups use npm; `/whatsnew` also queries GitHub
+for release notes. The desktop app never makes that request.
 
 Full policy: [enduragent.icu/privacy.html](https://enduragent.icu/privacy.html).
 

--- a/guides/privacy.md
+++ b/guides/privacy.md
@@ -13,11 +13,11 @@ Access to a self-hosted Telegram bot is limited to an allowlist you control — 
 
 ### Update checks & usage counting
 
-To check whether a newer version exists, Cycling Coach makes one background HTTPS request to `ping.enduragent.icu`. That endpoint returns the latest published version (the same answer `registry.npmjs.org` gives) and records an anonymous usage count so the project can see roughly how many instances are running across install channels. The count contains no personal information.
+As part of its background version-check behavior, Cycling Coach can make an HTTPS request to `ping.enduragent.icu`. That endpoint returns the latest published version (the same answer `registry.npmjs.org` gives) and records an anonymous usage count so the project can see roughly how many instances are running across install channels. The count contains no personal information.
 
-The check runs on Telegram-mode startup and again every 24 hours (so a long-running deployment learns about new releases without a restart). The same request powers the "update available" notification and the `/whatsnew` and `/update` commands. In development and test the bot talks to `registry.npmjs.org` directly instead; if the `ping.enduragent.icu` endpoint is ever unreachable, the bot silently falls back to `registry.npmjs.org`, so update checks keep working either way.
+The bot attempts telemetry on Telegram-mode startup and again every 24 hours, but a timestamp in the installation data directory limits it to at most once in any 24-hour period even across restarts. The timestamp is saved before the request, so a crash or an unreachable endpoint cannot retry telemetry for 24 hours. If the endpoint is unavailable or rate-limited, the bot silently falls back to `registry.npmjs.org` for the version result.
 
-Set `CYCLING_COACH_NO_UPDATE_CHECK=1` to disable the automatic background checks (both the startup check and the daily re-check). The operator-initiated `/update` and `/whatsnew` commands still query the endpoint — those are explicit requests, not background checks (and `/whatsnew` also reaches the GitHub Releases API for release notes). In managed container deploys, `/update` does not run npm; image hosts update by redeploying the container image.
+Set `CYCLING_COACH_NO_UPDATE_CHECK=1` to disable the automatic background checks (both the startup check and the daily re-check). The operator-initiated `/update` and `/whatsnew` commands never initiate telemetry; their version lookups use `registry.npmjs.org` and reuse a recent or already-running result. `/whatsnew` also reaches the GitHub Releases API for release notes. In managed container deploys, `/update` does not run npm; image hosts update by redeploying the container image.
 
 Desktop does not fetch release notes in the background. Choosing **What’s new** explicitly contacts
 `registry.npmjs.org` for the latest published version and the GitHub Releases API for that exact

--- a/packages/core/src/channels/npm-telegram-host.ts
+++ b/packages/core/src/channels/npm-telegram-host.ts
@@ -8,6 +8,7 @@ import { formatSnapshotRaw } from "../reference/sync/snapshot-debug.js";
 import { provenanceForLatestSection } from "../reference/source-provenance.js";
 import {
   checkForUpdate,
+  checkForUpdateWithDailyTelemetry,
   getCurrentVersion,
   getKnownTelegramChatIds,
   getLastNotifiedVersion,
@@ -56,7 +57,7 @@ export function createNpmTelegramHost(input: CreateNpmTelegramHostInput): Telegr
     version: async () =>
       `${input.binary.displayName} v${getCurrentVersion(input.binary.binaryName)}`,
     whatsNew: async () => {
-      const info = await checkForUpdate(input.binary.binaryName, input.dataDir);
+      const info = await checkForUpdate(input.binary.binaryName);
       return info === null
         ? ({ kind: "unavailable" } as const)
         : ({
@@ -75,7 +76,7 @@ export function createNpmTelegramHost(input: CreateNpmTelegramHostInput): Telegr
         ...releaseBase,
         updatePolicy: "npm-self-update" as const,
         binaryName: input.binary.binaryName,
-        check: () => checkForUpdate(input.binary.binaryName, input.dataDir),
+        check: () => checkForUpdate(input.binary.binaryName),
         install: async (version: string) => selfUpdate(input.binary.binaryName, version),
       };
   const reference = input.reference;
@@ -134,7 +135,7 @@ export async function notifyNpmTelegramUpdate(
   binary: BinaryConfig,
 ): Promise<void> {
   try {
-    const info = await checkForUpdate(binary.binaryName, dataDir);
+    const info = await checkForUpdateWithDailyTelemetry(binary.binaryName, dataDir);
     if (!info?.updateAvailable || getLastNotifiedVersion(dataDir) === info.latest) return;
 
     const allowed = loadAllowedSenders(dataDir);

--- a/packages/core/src/updater.ts
+++ b/packages/core/src/updater.ts
@@ -1,10 +1,12 @@
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { binaryEnvVar } from "./binary.js";
 import { enumerateTelegramSessions } from "./channels/telegram-sessions.js";
+import { atomicWriteFileSync } from "./io/atomic-write-file-sync.js";
+import { withInterprocessFileLockSync } from "./io/interprocess-file-lock-sync.js";
 
 export interface UpdateInfo {
   current: string;
@@ -110,6 +112,22 @@ export function getCurrentVersion(binaryName: string): string {
 const NPM_REGISTRY = "https://registry.npmjs.org";
 const PING_ENDPOINT = "https://ping.enduragent.icu/v1/check";
 const INSTANCE_ID_FILE = "instance-id";
+const LAST_VERSION_PING_AT_FILE = "last-version-ping-at";
+const VERSION_PING_LOCK = ".version-ping.lock";
+const VERSION_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
+const VERSION_PING_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+interface CachedUpdateInfo {
+  readonly cachedAt: number;
+  readonly info: UpdateInfo;
+}
+
+interface ActiveUpdateCheck {
+  readonly promise: Promise<UpdateInfo | null>;
+}
+
+const updateInfoCache = new Map<string, CachedUpdateInfo>();
+const activeUpdateChecks = new Map<string, ActiveUpdateCheck>();
 
 function isDevOrTest(): boolean {
   return process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
@@ -134,8 +152,7 @@ export function getInstanceId(dataDir: string): string {
   return id;
 }
 
-export function buildCheckUrl(binaryName: string, dataDir?: string): string {
-  if (isDevOrTest()) return `${NPM_REGISTRY}/${binaryName}/latest`;
+export function buildVersionPingUrl(binaryName: string, dataDir?: string): string {
   const params = new URLSearchParams({
     bin: binaryName,
     version: getCurrentVersion(binaryName),
@@ -145,39 +162,131 @@ export function buildCheckUrl(binaryName: string, dataDir?: string): string {
   return `${PING_ENDPOINT}?${params}`;
 }
 
-export async function checkForUpdate(
-  binaryName: string,
-  dataDir?: string,
-): Promise<UpdateInfo | null> {
+export function buildCheckUrl(binaryName: string, dataDir?: string): string {
+  if (isDevOrTest()) return `${NPM_REGISTRY}/${binaryName}/latest`;
+  return buildVersionPingUrl(binaryName, dataDir);
+}
+
+function getCachedUpdateInfo(binaryName: string): UpdateInfo | null {
+  const cached = updateInfoCache.get(binaryName);
+  if (cached === undefined) return null;
+  const age = Date.now() - cached.cachedAt;
+  if (age >= 0 && age < VERSION_CHECK_CACHE_TTL_MS) return cached.info;
+  updateInfoCache.delete(binaryName);
+  return null;
+}
+
+function rememberUpdateInfo(binaryName: string, info: UpdateInfo | null): UpdateInfo | null {
+  if (info !== null) {
+    updateInfoCache.set(binaryName, {
+      cachedAt: Date.now(),
+      info,
+    });
+  }
+  return info;
+}
+
+async function fetchUpdateInfo(binaryName: string, url: string): Promise<UpdateInfo | null> {
   const current = getCurrentVersion(binaryName);
-  const parse = async (res: Response): Promise<UpdateInfo | null> => {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
     if (!res.ok) return null;
-    const data = (await res.json()) as { version: string };
+    const data = (await res.json()) as { version?: unknown };
+    if (typeof data.version !== "string") return null;
     return {
       current,
       latest: data.version,
       updateAvailable: isUpdateAvailable(data.version, current),
     };
-  };
-  try {
-    const res = await fetch(buildCheckUrl(binaryName, dataDir), {
-      signal: AbortSignal.timeout(5000),
-    });
-    const info = await parse(res);
-    if (info) return info;
-  } catch {
-    // fall through to npm fallback
-  }
-  // In dev/test the primary request WAS npm — don't retry the same host.
-  if (isDevOrTest()) return null;
-  try {
-    const res = await fetch(`${NPM_REGISTRY}/${binaryName}/latest`, {
-      signal: AbortSignal.timeout(5000),
-    });
-    return await parse(res);
   } catch {
     return null;
   }
+}
+
+function startActiveUpdateCheck(
+  binaryName: string,
+  task: () => Promise<UpdateInfo | null>,
+): Promise<UpdateInfo | null> {
+  let operation: ActiveUpdateCheck;
+  const promise = Promise.resolve()
+    .then(task)
+    .then((info) => rememberUpdateInfo(binaryName, info))
+    .finally(() => {
+      if (activeUpdateChecks.get(binaryName) === operation) {
+        activeUpdateChecks.delete(binaryName);
+      }
+    });
+  operation = { promise };
+  activeUpdateChecks.set(binaryName, operation);
+  return promise;
+}
+
+function readLastPingAt(path: string): number | null {
+  try {
+    const timestamp = Date.parse(readFileSync(path, "utf-8").trim());
+    return Number.isFinite(timestamp) ? timestamp : null;
+  } catch {
+    return null;
+  }
+}
+
+function claimDailyVersionPing(dataDir: string): boolean {
+  try {
+    mkdirSync(dataDir, { recursive: true });
+    return withInterprocessFileLockSync(join(dataDir, VERSION_PING_LOCK), () => {
+      const now = Date.now();
+      const statePath = join(dataDir, LAST_VERSION_PING_AT_FILE);
+      const lastPingAt = readLastPingAt(statePath);
+      if (lastPingAt !== null && now - lastPingAt < VERSION_PING_INTERVAL_MS) return false;
+      atomicWriteFileSync(statePath, `${new Date(now).toISOString()}\n`);
+      return true;
+    });
+  } catch {
+    return false;
+  }
+}
+
+async function fetchTelemetryUpdate(
+  binaryName: string,
+  dataDir: string,
+  priorResult?: UpdateInfo | null,
+): Promise<UpdateInfo | null> {
+  const pingResult = await fetchUpdateInfo(binaryName, buildVersionPingUrl(binaryName, dataDir));
+  if (pingResult !== null) return pingResult;
+  if (priorResult !== undefined) return priorResult;
+  const cached = getCachedUpdateInfo(binaryName);
+  if (cached !== null) return cached;
+  return fetchUpdateInfo(binaryName, `${NPM_REGISTRY}/${binaryName}/latest`);
+}
+
+export function checkForUpdate(binaryName: string, _dataDir?: string): Promise<UpdateInfo | null> {
+  const active = activeUpdateChecks.get(binaryName);
+  if (active !== undefined) return active.promise;
+  const cached = getCachedUpdateInfo(binaryName);
+  if (cached !== null) return Promise.resolve(cached);
+  return startActiveUpdateCheck(binaryName, () =>
+    fetchUpdateInfo(binaryName, `${NPM_REGISTRY}/${binaryName}/latest`),
+  );
+}
+
+export function checkForUpdateWithDailyTelemetry(
+  binaryName: string,
+  dataDir: string,
+): Promise<UpdateInfo | null> {
+  if (isDevOrTest() || !claimDailyVersionPing(dataDir)) return checkForUpdate(binaryName);
+  const active = activeUpdateChecks.get(binaryName);
+  if (active === undefined) {
+    return startActiveUpdateCheck(binaryName, () => fetchTelemetryUpdate(binaryName, dataDir));
+  }
+  return startActiveUpdateCheck(binaryName, async () => {
+    const priorResult = await active.promise;
+    return fetchTelemetryUpdate(binaryName, dataDir, priorResult);
+  });
+}
+
+export function __resetVersionCheckStateForTesting(): void {
+  updateInfoCache.clear();
+  activeUpdateChecks.clear();
 }
 
 /**

--- a/packages/core/tests/npm-telegram-host.test.ts
+++ b/packages/core/tests/npm-telegram-host.test.ts
@@ -11,6 +11,16 @@ const install = vi.fn();
 const getKnownTelegramChatIds = vi.fn((): string[] => []);
 const getLastNotifiedVersion = vi.fn((): string | null => null);
 const setLastNotifiedVersion = vi.fn();
+const checkForUpdate = vi.fn(async () => ({
+  current: "2026.8.1",
+  latest: "2026.8.2",
+  updateAvailable: true,
+}));
+const checkForUpdateWithDailyTelemetry = vi.fn(async () => ({
+  current: "2026.8.1",
+  latest: "2026.8.2",
+  updateAvailable: true,
+}));
 
 beforeEach(() => {
   dataDir = mkdtempSync(join(tmpdir(), "npm-telegram-host-"));
@@ -21,16 +31,15 @@ beforeEach(() => {
   getLastNotifiedVersion.mockReset();
   getLastNotifiedVersion.mockReturnValue(null);
   setLastNotifiedVersion.mockReset();
+  checkForUpdate.mockClear();
+  checkForUpdateWithDailyTelemetry.mockClear();
   vi.resetModules();
   vi.doMock("../src/updater.js", async () => {
     const actual = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
     return {
       ...actual,
-      checkForUpdate: vi.fn(async () => ({
-        current: "2026.8.1",
-        latest: "2026.8.2",
-        updateAvailable: true,
-      })),
+      checkForUpdate,
+      checkForUpdateWithDailyTelemetry,
       getCurrentVersion: vi.fn(() => "2026.8.1"),
       getKnownTelegramChatIds,
       getLastNotifiedVersion,
@@ -142,6 +151,8 @@ describe("createNpmTelegramHost", () => {
     await expect(host.release.check()).resolves.toMatchObject({ latest: "2026.8.2" });
     await host.release.install("2026.8.2");
     expect(install).toHaveBeenCalledWith("cycling-coach", "2026.8.2");
+    expect(checkForUpdate).toHaveBeenCalledTimes(2);
+    expect(checkForUpdateWithDailyTelemetry).not.toHaveBeenCalled();
   });
 
   it("makes managed deployment policy structurally incapable of installing", async () => {
@@ -178,6 +189,8 @@ describe("createNpmTelegramHost", () => {
 
     await notifyNpmTelegramUpdate({ sendMessage }, dataDir, cyclingBinary);
 
+    expect(checkForUpdateWithDailyTelemetry).toHaveBeenCalledWith("cycling-coach", dataDir);
+    expect(checkForUpdate).not.toHaveBeenCalled();
     expect(sendMessage.mock.calls.map(([chatId]) => chatId)).toEqual(["73", "74"]);
     expect(setLastNotifiedVersion).toHaveBeenCalledOnce();
     expect(setLastNotifiedVersion).toHaveBeenCalledWith(dataDir, "2026.8.2");

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -348,7 +348,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
       return {
         ...real,
-        checkForUpdate: vi.fn(async () => ({
+        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
           current: "2026.5.5",
           latest: "2026.5.10",
           updateAvailable: true,
@@ -395,7 +395,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
       return {
         ...real,
-        checkForUpdate: vi.fn(async () => ({
+        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
           current: "2026.5.5",
           latest: "2026.5.10",
           updateAvailable: true,
@@ -433,7 +433,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
       return {
         ...real,
-        checkForUpdate: vi.fn(async () => ({
+        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
           current: "2026.5.5",
           latest: "2026.5.10",
           updateAvailable: true,
@@ -467,7 +467,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
       return {
         ...real,
-        checkForUpdate: vi.fn(async () => ({
+        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
           current: "2026.5.5",
           latest: "2026.5.10",
           updateAvailable: true,
@@ -493,7 +493,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
       return {
         ...real,
-        checkForUpdate: vi.fn(async () => ({
+        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
           current: "2026.5.5",
           latest: "2026.5.10",
           updateAvailable: true,
@@ -525,7 +525,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
       return {
         ...real,
-        checkForUpdate: vi.fn(async () => ({
+        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
           current: "2026.5.5",
           latest: "2026.5.10",
           updateAvailable: true,

--- a/packages/core/tests/telegram-generation-lifecycle.test.ts
+++ b/packages/core/tests/telegram-generation-lifecycle.test.ts
@@ -867,7 +867,7 @@ describe("Telegram polling generation release", () => {
       const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
       return {
         ...real,
-        checkForUpdate: vi.fn(async () => ({
+        checkForUpdateWithDailyTelemetry: vi.fn(async () => ({
           current: "2026.5.5",
           latest: "2026.5.10",
           updateAvailable: true,

--- a/packages/core/tests/updater.test.ts
+++ b/packages/core/tests/updater.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  __resetVersionCheckStateForTesting,
   buildCheckUrl,
   buildSelfUpdateCommand,
+  buildVersionPingUrl,
   checkForUpdate,
+  checkForUpdateWithDailyTelemetry,
   getCurrentVersion,
   getInstanceId,
   isManagedDeploy,
@@ -144,7 +147,7 @@ describe("isManagedDeploy", () => {
   });
 });
 
-describe("buildCheckUrl", () => {
+describe("buildVersionPingUrl", () => {
   let dataDir: string;
 
   beforeEach(() => {
@@ -158,7 +161,7 @@ describe("buildCheckUrl", () => {
 
   it("builds the ping URL with exactly bin, version, channel, instance when a dataDir is given (production)", () => {
     vi.stubEnv("NODE_ENV", "production");
-    const url = new URL(buildCheckUrl("cycling-coach", dataDir));
+    const url = new URL(buildVersionPingUrl("cycling-coach", dataDir));
     expect(`${url.origin}${url.pathname}`).toBe("https://ping.enduragent.icu/v1/check");
     expect([...url.searchParams.keys()].sort()).toEqual(["bin", "channel", "instance", "version"]);
     expect(url.searchParams.get("bin")).toBe("cycling-coach");
@@ -169,7 +172,7 @@ describe("buildCheckUrl", () => {
 
   it("omits the instance param when no dataDir is given (production)", () => {
     vi.stubEnv("NODE_ENV", "production");
-    const url = new URL(buildCheckUrl("cycling-coach"));
+    const url = new URL(buildVersionPingUrl("cycling-coach"));
     expect(url.searchParams.has("instance")).toBe(false);
     expect([...url.searchParams.keys()].sort()).toEqual(["bin", "channel", "version"]);
   });
@@ -177,22 +180,20 @@ describe("buildCheckUrl", () => {
   it("channel is docker under CYCLING_COACH_MANAGED_DEPLOY=1 (production)", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("CYCLING_COACH_MANAGED_DEPLOY", "1");
-    expect(new URL(buildCheckUrl("cycling-coach")).searchParams.get("channel")).toBe("docker");
-  });
-
-  it("returns the plain npm registry URL under NODE_ENV=development", () => {
-    vi.stubEnv("NODE_ENV", "development");
-    expect(buildCheckUrl("cycling-coach", dataDir)).toBe(
-      "https://registry.npmjs.org/cycling-coach/latest",
+    expect(new URL(buildVersionPingUrl("cycling-coach")).searchParams.get("channel")).toBe(
+      "docker",
     );
   });
 
-  it("returns the plain npm registry URL under NODE_ENV=test", () => {
-    vi.stubEnv("NODE_ENV", "test");
-    expect(buildCheckUrl("cycling-coach", dataDir)).toBe(
-      "https://registry.npmjs.org/cycling-coach/latest",
-    );
-  });
+  it.each(["development", "test"])(
+    "keeps the buildCheckUrl compatibility API npm-only in %s",
+    (nodeEnv) => {
+      vi.stubEnv("NODE_ENV", nodeEnv);
+      expect(buildCheckUrl("cycling-coach", dataDir)).toBe(
+        "https://registry.npmjs.org/cycling-coach/latest",
+      );
+    },
+  );
 });
 
 describe("getInstanceId", () => {
@@ -230,8 +231,10 @@ describe("getInstanceId", () => {
 
 describe("checkForUpdate", () => {
   afterEach(() => {
+    __resetVersionCheckStateForTesting();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
+    vi.useRealTimers();
   });
 
   // The CYCLING_COACH_NO_UPDATE_CHECK opt-out gates only the automatic
@@ -253,49 +256,352 @@ describe("checkForUpdate", () => {
     }
   });
 
-  it("falls back to the npm registry when the ping endpoint fails (production)", async () => {
+  it("queries npm without telemetry in production", async () => {
     vi.stubEnv("NODE_ENV", "production");
     const urls: string[] = [];
     const fetchMock = vi.fn(async (input: string) => {
       urls.push(input);
-      if (urls.length === 1) throw new Error("ping endpoint down");
       return { ok: true, json: async () => ({ version: "2026.5.10" }) };
     });
     vi.stubGlobal("fetch", fetchMock);
     const info = await checkForUpdate("cycling-coach");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(urls[0]).toContain("ping.enduragent.icu");
-    expect(urls[1]).toBe("https://registry.npmjs.org/cycling-coach/latest");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(urls).toEqual(["https://registry.npmjs.org/cycling-coach/latest"]);
     expect(info?.latest).toBe("2026.5.10");
   });
 
-  it("returns null (never throws) when both hosts fail (production)", async () => {
+  it("keeps the optional dataDir argument npm-only for compatibility", async () => {
     vi.stubEnv("NODE_ENV", "production");
+    const urls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string) => {
+        urls.push(input);
+        return { ok: true, json: async () => ({ version: "2026.5.10" }) };
+      }),
+    );
+
+    await checkForUpdate("cycling-coach", "/unused/compatibility/path");
+    expect(urls).toEqual(["https://registry.npmjs.org/cycling-coach/latest"]);
+  });
+
+  it("shares one in-progress npm request", async () => {
+    let resolveFetch:
+      | ((value: { ok: boolean; json: () => Promise<{ version: string }> }) => void)
+      | undefined;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<{ ok: boolean; json: () => Promise<{ version: string }> }>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = checkForUpdate("cycling-coach");
+    const second = checkForUpdate("cycling-coach");
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    resolveFetch?.({
+      ok: true,
+      json: async () => ({ version: "2026.5.10" }),
+    });
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ latest: "2026.5.10" }),
+      expect.objectContaining({ latest: "2026.5.10" }),
+    ]);
+  });
+
+  it("reuses successful results for five minutes and refreshes at expiry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("1998-08-29T04:00:00.000Z"));
+    const versions = ["2026.5.10", "2026.5.11"];
     const fetchMock = vi.fn(async () => {
-      throw new Error("network down");
+      const version = versions.shift();
+      return { ok: true, json: async () => ({ version }) };
     });
     vi.stubGlobal("fetch", fetchMock);
-    const info = await checkForUpdate("cycling-coach");
-    expect(info).toBeNull();
+
+    await expect(checkForUpdate("cycling-coach")).resolves.toMatchObject({
+      latest: "2026.5.10",
+    });
+    vi.advanceTimersByTime(5 * 60 * 1000 - 1);
+    await expect(checkForUpdate("cycling-coach")).resolves.toMatchObject({
+      latest: "2026.5.10",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    await expect(checkForUpdate("cycling-coach")).resolves.toMatchObject({
+      latest: "2026.5.11",
+    });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  // vitest sets NODE_ENV=test globally, so no ping.enduragent.icu URL is
-  // ever constructed and the primary (npm) failure does NOT retry the same host.
-  it("never constructs a ping.enduragent.icu URL under NODE_ENV=test", async () => {
-    expect(process.env.NODE_ENV).toBe("test");
-    expect(buildCheckUrl("cycling-coach", "/tmp/does-not-matter")).not.toContain(
-      "ping.enduragent.icu",
-    );
-    const urls: string[] = [];
-    const fetchMock = vi.fn(async (input: string) => {
-      urls.push(input);
+  it("refreshes after a wall-clock rollback", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("1998-08-29T04:00:00.000Z"));
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ version: "2026.5.10" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await checkForUpdate("cycling-coach");
+    vi.setSystemTime(new Date("1998-08-29T03:00:00.000Z"));
+    await checkForUpdate("cycling-coach");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache failed checks", async () => {
+    const fetchMock = vi.fn(async () => {
       throw new Error("offline");
     });
     vi.stubGlobal("fetch", fetchMock);
-    const info = await checkForUpdate("cycling-coach", "/tmp/does-not-matter");
-    expect(info).toBeNull();
+
+    await expect(checkForUpdate("cycling-coach")).resolves.toBeNull();
+    await expect(checkForUpdate("cycling-coach")).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("checkForUpdateWithDailyTelemetry", () => {
+  let base: string;
+  let dataDir: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "cc-version-ping-"));
+    dataDir = join(base, "data");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("1998-08-29T04:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    __resetVersionCheckStateForTesting();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it("persists lastPingAt before contacting the telemetry endpoint", async () => {
+    const statePath = join(dataDir, "last-version-ping-at");
+    const fetchMock = vi.fn(async (input: string) => {
+      expect(input).toContain("ping.enduragent.icu");
+      expect(readFileSync(statePath, "utf-8")).toBe("1998-08-29T04:00:00.000Z\n");
+      return { ok: true, json: async () => ({ version: "2026.5.10" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(checkForUpdateWithDailyTelemetry("cycling-coach", dataDir)).resolves.toMatchObject(
+      { latest: "2026.5.10" },
+    );
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(urls.every((u) => !u.includes("ping.enduragent.icu"))).toBe(true);
+    expect(existsSync(join(dataDir, "instance-id"))).toBe(true);
+  });
+
+  it("suppresses telemetry across restarts until the exact 24-hour boundary", async () => {
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (input: string) => {
+      urls.push(input);
+      return { ok: true, json: async () => ({ version: "2026.5.10" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await checkForUpdateWithDailyTelemetry("cycling-coach", dataDir);
+    __resetVersionCheckStateForTesting();
+    vi.setSystemTime(new Date("1998-08-30T03:59:59.999Z"));
+    await checkForUpdateWithDailyTelemetry("cycling-coach", dataDir);
+    __resetVersionCheckStateForTesting();
+    vi.setSystemTime(new Date("1998-08-30T04:00:00.000Z"));
+    await checkForUpdateWithDailyTelemetry("cycling-coach", dataDir);
+
+    expect(urls.map((url) => new URL(url).hostname)).toEqual([
+      "ping.enduragent.icu",
+      "registry.npmjs.org",
+      "ping.enduragent.icu",
+    ]);
+  });
+
+  it("keeps a failed ping suppressed and falls back to npm", async () => {
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (input: string) => {
+      urls.push(input);
+      if (input.includes("ping.enduragent.icu")) throw new Error("endpoint down");
+      return { ok: true, json: async () => ({ version: "2026.5.10" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(checkForUpdateWithDailyTelemetry("cycling-coach", dataDir)).resolves.toMatchObject(
+      { latest: "2026.5.10" },
+    );
+    __resetVersionCheckStateForTesting();
+    vi.advanceTimersByTime(60 * 60 * 1000);
+    await checkForUpdateWithDailyTelemetry("cycling-coach", dataDir);
+
+    expect(urls.filter((url) => url.includes("ping.enduragent.icu"))).toHaveLength(1);
+    expect(urls.filter((url) => url.includes("registry.npmjs.org"))).toHaveLength(2);
+  });
+
+  it("keeps a rate-limited ping suppressed and falls back to npm", async () => {
+    const statePath = join(dataDir, "last-version-ping-at");
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (input: string) => {
+      urls.push(input);
+      if (input.includes("ping.enduragent.icu")) return { ok: false };
+      return { ok: true, json: async () => ({ version: "2026.5.10" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(checkForUpdateWithDailyTelemetry("cycling-coach", dataDir)).resolves.toMatchObject(
+      { latest: "2026.5.10" },
+    );
+    expect(readFileSync(statePath, "utf-8")).toBe("1998-08-29T04:00:00.000Z\n");
+
+    __resetVersionCheckStateForTesting();
+    vi.advanceTimersByTime(60 * 60 * 1000);
+    await expect(checkForUpdateWithDailyTelemetry("cycling-coach", dataDir)).resolves.toMatchObject(
+      { latest: "2026.5.10" },
+    );
+
+    expect(urls.map((url) => new URL(url).hostname)).toEqual([
+      "ping.enduragent.icu",
+      "registry.npmjs.org",
+      "registry.npmjs.org",
+    ]);
+    expect(readFileSync(statePath, "utf-8")).toBe("1998-08-29T04:00:00.000Z\n");
+  });
+
+  it("fails closed to npm when lastPingAt cannot be persisted", async () => {
+    const blocker = join(base, "blocker");
+    writeFileSync(blocker, "x");
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (input: string) => {
+      urls.push(input);
+      return { ok: true, json: async () => ({ version: "2026.5.10" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      checkForUpdateWithDailyTelemetry("cycling-coach", join(blocker, "data")),
+    ).resolves.toMatchObject({ latest: "2026.5.10" });
+    expect(urls).toEqual(["https://registry.npmjs.org/cycling-coach/latest"]);
+  });
+
+  it("replaces malformed state before pinging", async () => {
+    mkdirSync(dataDir, { recursive: true });
+    const statePath = join(dataDir, "last-version-ping-at");
+    writeFileSync(statePath, "not-json");
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (input: string) => {
+      urls.push(input);
+      expect(readFileSync(statePath, "utf-8")).toBe("1998-08-29T04:00:00.000Z\n");
+      return { ok: true, json: async () => ({ version: "2026.5.10" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await checkForUpdateWithDailyTelemetry("cycling-coach", dataDir);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(new URL(urls[0] ?? "").hostname).toBe("ping.enduragent.icu");
+  });
+
+  it("treats a future lastPingAt as not due", async () => {
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, "last-version-ping-at"), "1998-08-30T04:00:00.000Z\n");
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (input: string) => {
+      urls.push(input);
+      return { ok: true, json: async () => ({ version: "2026.5.10" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await checkForUpdateWithDailyTelemetry("cycling-coach", dataDir);
+    expect(urls).toEqual(["https://registry.npmjs.org/cycling-coach/latest"]);
+  });
+
+  it("shares one telemetry request between concurrent daily checks", async () => {
+    let resolveFetch:
+      | ((value: { ok: boolean; json: () => Promise<{ version: string }> }) => void)
+      | undefined;
+    const fetchMock = vi.fn(
+      (_input: string) =>
+        new Promise<{ ok: boolean; json: () => Promise<{ version: string }> }>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = checkForUpdateWithDailyTelemetry("cycling-coach", dataDir);
+    const second = checkForUpdateWithDailyTelemetry("cycling-coach", dataDir);
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("ping.enduragent.icu");
+    resolveFetch?.({
+      ok: true,
+      json: async () => ({ version: "2026.5.10" }),
+    });
+    const expected = {
+      current: getCurrentVersion("cycling-coach"),
+      latest: "2026.5.10",
+      updateAvailable: isUpdateAvailable("2026.5.10", getCurrentVersion("cycling-coach")),
+    };
+    await expect(Promise.all([first, second])).resolves.toEqual([expected, expected]);
+  });
+
+  it("queues due telemetry behind an active npm check", async () => {
+    let resolveNpm:
+      | ((value: { ok: boolean; json: () => Promise<{ version: string }> }) => void)
+      | undefined;
+    const urls: string[] = [];
+    const fetchMock = vi.fn((input: string) => {
+      urls.push(input);
+      if (input.includes("registry.npmjs.org")) {
+        return new Promise<{ ok: boolean; json: () => Promise<{ version: string }> }>((resolve) => {
+          resolveNpm = resolve;
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ version: "2026.5.11" }),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const manual = checkForUpdate("cycling-coach");
+    await Promise.resolve();
+    const daily = checkForUpdateWithDailyTelemetry("cycling-coach", dataDir);
+    const joined = checkForUpdate("cycling-coach");
+    await Promise.resolve();
+    expect(urls).toEqual(["https://registry.npmjs.org/cycling-coach/latest"]);
+
+    resolveNpm?.({
+      ok: true,
+      json: async () => ({ version: "2026.5.10" }),
+    });
+    await expect(manual).resolves.toMatchObject({ latest: "2026.5.10" });
+    await expect(Promise.all([daily, joined])).resolves.toEqual([
+      expect.objectContaining({ latest: "2026.5.11" }),
+      expect.objectContaining({ latest: "2026.5.11" }),
+    ]);
+    expect(urls.map((url) => new URL(url).hostname)).toEqual([
+      "registry.npmjs.org",
+      "ping.enduragent.icu",
+    ]);
+  });
+
+  it.each(["development", "test"])("skips telemetry and persistence in %s", async (nodeEnv) => {
+    vi.stubEnv("NODE_ENV", nodeEnv);
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (input: string) => {
+      urls.push(input);
+      return { ok: true, json: async () => ({ version: "2026.5.10" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await checkForUpdateWithDailyTelemetry("cycling-coach", dataDir);
+    expect(urls).toEqual(["https://registry.npmjs.org/cycling-coach/latest"]);
+    expect(existsSync(join(dataDir, "last-version-ping-at"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- persist the daily telemetry timestamp atomically before the network request and suppress further attempts for 24 hours across restarts and processes
- keep manual version commands npm-only while caching successful checks for five minutes and sharing in-progress requests
- fall back to npm after network errors or WAF rate limits without retrying telemetry, while leaving the existing WAF rule unchanged

## Verification

- focused updater and Telegram tests: 92 passed
- full repository check: passed
- full test suite: 10,813 passed, 17 skipped
- autoreview --mode branch --base origin/main: clean, no accepted or actionable findings