### PR TITLE
fix(desktop): repair Telegram setup and isolate development

### DIFF
--- a/.changeset/telegram-create-dev-isolation.md
+++ b/.changeset/telegram-create-dev-isolation.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Telegram setup now always offers Create when no verified bot is connected, and Create repairs stale local Telegram setup from another athlete home.
+
+Add a disposable macOS development launcher that binds fresh Electron and athlete data roots before the visible unsigned app starts.

--- a/apps/desktop-renderer/src/ui/onboarding/TelegramRow.tsx
+++ b/apps/desktop-renderer/src/ui/onboarding/TelegramRow.tsx
@@ -37,7 +37,7 @@ interface TelegramAttempt {
 
 type TelegramIdentity =
   | { readonly kind: "verified"; readonly username: string }
-  | { readonly kind: "missing" | "unknown" };
+  | { readonly kind: "missing" };
 
 const persistedTelegramAttempts = new WeakMap<TelegramSettingsPort, TelegramAttempt>();
 
@@ -52,14 +52,7 @@ function identity(telegram: TelegramControlStatus | null): TelegramIdentity {
   if (telegram?.credentialConfigured === true && telegram.bot.state !== "unconfigured") {
     return { kind: "verified", username: telegram.bot.username };
   }
-  if (
-    telegram?.credentialConfigured === false &&
-    telegram.bot.state === "unconfigured" &&
-    (telegram.channel.state === "disabled" || telegram.channel.state === "waiting-for-credential")
-  ) {
-    return { kind: "missing" };
-  }
-  return { kind: "unknown" };
+  return { kind: "missing" };
 }
 
 function sameFeedback(
@@ -133,7 +126,7 @@ function restoreAttempt(
     if (sameFeedback(feedback, attempt.feedback)) return attempt;
     const currentIdentity = identity(current?.telegram ?? null);
     if (attempt.action === "remove" && currentIdentity.kind === "missing") return attempt;
-    return currentIdentity.kind === "unknown" ? attempt : persistAttempt(port, null);
+    return persistAttempt(port, null);
   }
   if (attempt.phase === "requested" && sameFeedback(feedback, attempt.feedbackBefore)) {
     return persistAttempt(port, null);
@@ -182,13 +175,10 @@ export function TelegramRow(): ReactElement {
   const telegram = current?.telegram ?? null;
   const feedback = current?.feedback ?? null;
   const currentIdentity = identity(telegram);
-  const authoritativeIdentity = useRef<"verified" | "missing" | null>(
-    currentIdentity.kind === "unknown" ? null : currentIdentity.kind,
-  );
+  const authoritativeIdentity = useRef<"verified" | "missing">(currentIdentity.kind);
   const verifiedUsername = currentIdentity.kind === "verified" ? currentIdentity.username : null;
   const username = verifiedUsername ?? attempt?.verifiedUsernameBefore ?? null;
   const configured = username !== null;
-  const identityUnknown = currentIdentity.kind === "unknown";
   const loading = state.status === "closed" || state.status === "loading";
   const busy = loading || settingsMutationActive(settings) || state.status === "working";
   const credentialMutationBlocked = credentialChangesBlocked(settings.credentials, false);
@@ -199,7 +189,7 @@ export function TelegramRow(): ReactElement {
     attempt?.phase === "settled" &&
     attempt.feedback?.tone === "warning" &&
     sameFeedback(feedback, attempt.feedback);
-  const mutationUnsafe = identityUnknown || authoritativeCheckRequired;
+  const mutationUnsafe = authoritativeCheckRequired;
   const panelId = "onboarding-telegram-panel";
 
   useEffect(() => {
@@ -212,7 +202,6 @@ export function TelegramRow(): ReactElement {
   }, [panel, setupReadyForFocus]);
 
   useEffect(() => {
-    if (currentIdentity.kind === "unknown") return;
     const previous = authoritativeIdentity.current;
     authoritativeIdentity.current = currentIdentity.kind;
     if (previous === currentIdentity.kind) return;
@@ -262,7 +251,7 @@ export function TelegramRow(): ReactElement {
         attempt.feedback?.tone === "warning" &&
         feedbackChanged &&
         ((attempt.action === "remove" && currentIdentity.kind === "missing") ||
-          (attempt.action === "paste-token" && currentIdentity.kind !== "unknown"));
+          attempt.action === "paste-token");
       if (recoveredFromUncertain) {
         persistAttempt(port, null);
         setAttempt(null);
@@ -276,7 +265,7 @@ export function TelegramRow(): ReactElement {
         }
         return;
       }
-      if (feedbackChanged && currentIdentity.kind !== "unknown") {
+      if (feedbackChanged) {
         persistAttempt(port, null);
         setAttempt(null);
         setPanelFeedback(null);
@@ -454,19 +443,7 @@ export function TelegramRow(): ReactElement {
         }
         announce={panel === "token" ? "Telegram bot setup opened below this row." : ""}
         trailing={
-          identityUnknown && !configured && panel === "closed" ? (
-            <Button
-              ref={trigger}
-              type="button"
-              variant="ghost"
-              size="sm"
-              data-setup-trigger="telegram"
-              disabled={busy}
-              onClick={checkAgain}
-            >
-              Check again
-            </Button>
-          ) : configured ? (
+          configured ? (
             <Button
               ref={trigger}
               type="button"

--- a/apps/desktop-renderer/tests/onboarding-telegram-row.test.tsx
+++ b/apps/desktop-renderer/tests/onboarding-telegram-row.test.tsx
@@ -352,7 +352,7 @@ describe("setup gate Telegram row", () => {
   it.each([
     ["a closed control fallback", CLOSED_UNCONFIGURED],
     ["a redacted saved credential", REDACTED_CONFIGURED],
-  ] as const)("requires a fresh status before token mutation for %s", async (_label, status) => {
+  ] as const)("offers Create for %s", async (_label, status) => {
     const user = userEvent.setup();
     const port = setTelegramSettings(readyTelegramSettings(status));
     const wizard = mountWizard({
@@ -360,14 +360,13 @@ describe("setup gate Telegram row", () => {
     });
     await wizard.open();
 
-    expect(screen.queryByRole("button", { name: "Create Telegram bot" })).toBeNull();
+    const create = screen.getByRole("button", { name: "Create Telegram bot" });
+    expect(create).toBeVisible();
     expect(screen.queryByRole("button", { name: "Delete the Telegram connection" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Use copied token" })).toBeNull();
-    await user.click(screen.getByRole("button", { name: "Check again" }));
-    expect(port.retry).toHaveBeenCalledOnce();
-    expect(port.pasteToken).not.toHaveBeenCalled();
-    publishTelegram(readyTelegramSettings(UNCONFIGURED));
-    expect(screen.getByRole("button", { name: "Create Telegram bot" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Check again" })).toBeNull();
+    await user.click(create);
+    await user.click(screen.getByRole("button", { name: "Use copied token" }));
+    expect(port.pasteToken).toHaveBeenCalledOnce();
 
     wizard.controller.dispose();
   });

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,6 +6,7 @@
   "main": "out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
+    "dev:isolated": "node scripts/interactive-development.mjs",
     "build": "electron-vite build",
     "check": "tsc --noEmit",
     "package:dir": "pnpm build:self-test-resources && electron-vite build && node scripts/development-package-plan.mjs",

--- a/apps/desktop/scripts/interactive-development.d.mts
+++ b/apps/desktop/scripts/interactive-development.d.mts
@@ -1,0 +1,39 @@
+export interface InteractiveDevelopmentPlanInput {
+  readonly platform: NodeJS.Platform;
+  readonly desktopRoot: string;
+  readonly scratchRoot: string;
+  readonly nodeExecutable: string;
+  readonly packageManagerScript: string;
+  readonly environment: Readonly<Record<string, string | undefined>>;
+}
+
+export interface InteractiveDevelopmentPlan {
+  readonly command: "/usr/bin/caffeinate";
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly environment: Readonly<Record<string, string | undefined>>;
+  readonly scratchRoot: string;
+  readonly athleteHome: string;
+  readonly userData: string;
+}
+
+export function createInteractiveDevelopmentPlan(
+  input: InteractiveDevelopmentPlanInput,
+): InteractiveDevelopmentPlan;
+
+export function selectInteractiveDevelopmentTemporaryRoot(
+  platform: NodeJS.Platform,
+  configuredRoot?: string,
+): string;
+
+export function runInteractiveDevelopment(
+  input?: Readonly<{
+    platform?: NodeJS.Platform;
+    desktopRoot?: string;
+    temporaryRoot?: string;
+    nodeExecutable?: string;
+    packageManagerScript?: string;
+    environment?: Readonly<Record<string, string | undefined>>;
+  }>,
+  dependencies?: Readonly<Record<string, unknown>>,
+): Promise<number>;

--- a/apps/desktop/scripts/interactive-development.mjs
+++ b/apps/desktop/scripts/interactive-development.mjs
@@ -1,0 +1,123 @@
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const canonicalDesktopRoot = resolve(scriptDirectory, "..");
+const SCRATCH_PREFIX = "enduragent-desktop-development-";
+
+export function selectInteractiveDevelopmentTemporaryRoot(platform, configuredRoot) {
+  return configuredRoot ?? (platform === "darwin" ? "/tmp" : tmpdir());
+}
+
+function requiredAbsolutePath(value, name) {
+  if (typeof value !== "string" || !isAbsolute(value)) {
+    throw new TypeError(`${name} must be absolute`);
+  }
+  return value;
+}
+
+export function createInteractiveDevelopmentPlan(input) {
+  if (input.platform !== "darwin") {
+    throw new TypeError("interactive desktop development requires macOS");
+  }
+  const desktopRoot = requiredAbsolutePath(input.desktopRoot, "desktop root");
+  const scratchRoot = requiredAbsolutePath(input.scratchRoot, "scratch root");
+  const nodeExecutable = requiredAbsolutePath(input.nodeExecutable, "Node executable");
+  const packageManagerScript = requiredAbsolutePath(
+    input.packageManagerScript,
+    "package manager script",
+  );
+  const athleteHome = join(scratchRoot, "athlete-home");
+  const userData = join(scratchRoot, "electron-user-data");
+  const environment = { ...input.environment };
+  delete environment.ENDURAGENT_ACCEPTANCE_HIDDEN;
+  delete environment.ELECTRON_CLI_ARGS;
+  Object.assign(environment, {
+    ENDURAGENT_HOME: athleteHome,
+    ENDURAGENT_DEVELOPMENT_USER_DATA: userData,
+    ENDURAGENT_ACCEPTANCE_CREDENTIAL_BACKEND: "memory",
+    ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT: "1",
+  });
+  return Object.freeze({
+    command: "/usr/bin/caffeinate",
+    args: Object.freeze([
+      "-dimsu",
+      nodeExecutable,
+      packageManagerScript,
+      "exec",
+      "electron-vite",
+      "dev",
+    ]),
+    cwd: desktopRoot,
+    environment: Object.freeze(environment),
+    scratchRoot,
+    athleteHome,
+    userData,
+  });
+}
+
+export async function runInteractiveDevelopment(input = {}, dependencies = {}) {
+  const platform = input.platform ?? process.platform;
+  const packageManagerScript = input.packageManagerScript ?? process.env.npm_execpath;
+  if (packageManagerScript === undefined) {
+    throw new TypeError("package manager script is unavailable");
+  }
+  const resolveTemporaryRoot = dependencies.realpath ?? realpath;
+  const createTemporaryRoot = dependencies.mkdtemp ?? mkdtemp;
+  const createDirectory = dependencies.mkdir ?? mkdir;
+  const removeDirectory = dependencies.rm ?? rm;
+  const launch = dependencies.spawn ?? spawn;
+  const temporaryRoot = await resolveTemporaryRoot(
+    selectInteractiveDevelopmentTemporaryRoot(platform, input.temporaryRoot),
+  );
+  const scratchRoot = await createTemporaryRoot(join(temporaryRoot, SCRATCH_PREFIX));
+  try {
+    const plan = createInteractiveDevelopmentPlan({
+      platform,
+      desktopRoot: input.desktopRoot ?? canonicalDesktopRoot,
+      scratchRoot,
+      nodeExecutable: input.nodeExecutable ?? process.execPath,
+      packageManagerScript,
+      environment: input.environment ?? process.env,
+    });
+    await Promise.all([
+      createDirectory(plan.athleteHome, { mode: 0o700 }),
+      createDirectory(plan.userData, { mode: 0o700 }),
+    ]);
+    const child = launch(plan.command, plan.args, {
+      cwd: plan.cwd,
+      env: plan.environment,
+      stdio: "inherit",
+    });
+    const forwardInterrupt = () => child.kill("SIGINT");
+    const forwardTermination = () => child.kill("SIGTERM");
+    process.once("SIGINT", forwardInterrupt);
+    process.once("SIGTERM", forwardTermination);
+    try {
+      return await new Promise((resolveExit, reject) => {
+        child.once("error", reject);
+        child.once("exit", (code, signal) => resolveExit(code === 0 && signal === null ? 0 : 1));
+      });
+    } finally {
+      process.off("SIGINT", forwardInterrupt);
+      process.off("SIGTERM", forwardTermination);
+    }
+  } finally {
+    await removeDirectory(scratchRoot, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  if (process.argv.length !== 2) throw new TypeError("arguments are not supported");
+  process.exitCode = await runInteractiveDevelopment();
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(() => {
+    process.stderr.write("interactive desktop development failed\n");
+    process.exitCode = 1;
+  });
+}

--- a/apps/desktop/src/main/acceptance-credential-backend.ts
+++ b/apps/desktop/src/main/acceptance-credential-backend.ts
@@ -63,12 +63,12 @@ export function resolveAcceptanceCredentialBackend(input: {
   readonly disposableContext: boolean;
   readonly readPackageJson?: (path: string) => string;
 }): AcceptanceCredentialBackend | undefined {
-  if (!input.hidden) return undefined;
   if (!input.isPackaged) {
-    return input.backend === "memory"
+    return input.backend === "memory" && input.disposableContext
       ? { kind: "memory", key: randomBytes(KEYCHAIN_KEY_BYTES) }
       : undefined;
   }
+  if (!input.hidden) return undefined;
   if (
     input.backend !== "file" ||
     !input.disposableContext ||

--- a/apps/desktop/src/main/development-user-data.ts
+++ b/apps/desktop/src/main/development-user-data.ts
@@ -1,0 +1,57 @@
+import { isAbsolute, normalize } from "node:path";
+import type { App } from "electron";
+
+export const DEVELOPMENT_USER_DATA_ENV = "ENDURAGENT_DEVELOPMENT_USER_DATA" as const;
+
+export type DevelopmentUserDataDecision =
+  | Readonly<{ kind: "no-op" }>
+  | Readonly<{ kind: "bind"; path: string }>;
+
+export type DevelopmentUserDataAppPort = Pick<App, "setPath">;
+
+export interface DevelopmentUserDataDecisionInput {
+  readonly platform: NodeJS.Platform;
+  readonly isPackaged: boolean;
+  readonly environment: Readonly<Record<string, string | undefined>>;
+}
+
+function validAbsolutePath(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value === value.trim() &&
+    !value.includes("\0") &&
+    isAbsolute(value) &&
+    normalize(value) === value
+  );
+}
+
+export function decideDevelopmentUserDataBinding(
+  input: DevelopmentUserDataDecisionInput,
+): DevelopmentUserDataDecision {
+  const path = input.environment[DEVELOPMENT_USER_DATA_ENV];
+  if (path === undefined) return Object.freeze({ kind: "no-op" });
+  if (
+    input.platform !== "darwin" ||
+    input.isPackaged ||
+    input.environment.ENDURAGENT_ACCEPTANCE_CREDENTIAL_BACKEND !== "memory" ||
+    input.environment.ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT !== "1" ||
+    !validAbsolutePath(path)
+  ) {
+    throw new TypeError("isolated development user data binding refused");
+  }
+  return Object.freeze({ kind: "bind", path });
+}
+
+export function bindDevelopmentUserData(
+  app: DevelopmentUserDataAppPort,
+  options: Partial<DevelopmentUserDataDecisionInput> = {},
+): DevelopmentUserDataDecision {
+  const decision = decideDevelopmentUserDataBinding({
+    platform: options.platform ?? process.platform,
+    isPackaged: options.isPackaged ?? false,
+    environment: options.environment ?? process.env,
+  });
+  if (decision.kind === "bind") app.setPath("userData", decision.path);
+  return decision;
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,5 @@
 import "./keychain-binding-probe-deprecation.js";
+import { bindDevelopmentUserData } from "./development-user-data.js";
 import { bindWindowsUserData } from "./windows-user-data.js";
 import {
   createAcceptanceKeychainTransport,
@@ -192,6 +193,7 @@ import {
 } from "./planning-read-ipc.js";
 
 bindDesktopAppUserModelId(app);
+bindDevelopmentUserData(app, { isPackaged: app.isPackaged });
 bindWindowsUserData(app);
 startDesktopCrashReporter({ crashReporter });
 installDesktopCrashTelemetry({ app });

--- a/apps/desktop/src/main/telegram-control.ts
+++ b/apps/desktop/src/main/telegram-control.ts
@@ -205,14 +205,12 @@ function resolveDesiredRecord(
     return { state: "known", desiredState: value.enabled ? "enabled" : "disabled" };
   }
   if (value.state === "missing") return { state: "known", desiredState: "disabled" };
+  if (value.state === "wrong-home") return { state: "known", desiredState: "disabled" };
   const desiredState = daemonSnapshot?.channel.desiredState ?? "enabled";
   return {
     state: "repair-required",
     desiredState,
-    errorCode:
-      value.state === "wrong-home"
-        ? "telegram-home-mismatch"
-        : "telegram-settings-storage-uncertain",
+    errorCode: "telegram-settings-storage-uncertain",
   };
 }
 
@@ -454,7 +452,14 @@ export function createTelegramControlCoordinator(
         daemonSnapshot?.pairing ?? UNPAIRED,
       );
     }
-    if (profile.state === "wrong-home") return failure(desiredState, "telegram-home-mismatch");
+    if (profile.state === "wrong-home") {
+      return {
+        channel: DISABLED_CHANNEL,
+        bot: UNCONFIGURED_BOT,
+        pairing: UNPAIRED,
+        credentialConfigured: false,
+      };
+    }
     if (profile.state === "re-prompt") {
       return failure(
         desiredState,
@@ -815,11 +820,12 @@ export function createTelegramControlCoordinator(
       const checked = await checkedBinding();
       if ("result" in checked) return checked.result;
       const profileStatus = await input.vault.profileStatus();
-      const profileRefusal = profileStatusRefusal(profileStatus);
-      if (profileRefusal !== undefined) return refused(profileRefusal);
       if (profileStatus.state === "uncertain") return uncertain();
-      if (profileStatus.state === "wrong-home") return refused("storage-failed");
-      if (replacement && profileStatus.state !== "configured") return refused("invalid-state");
+      if (replacement) {
+        const profileRefusal = profileStatusRefusal(profileStatus);
+        if (profileRefusal !== undefined) return refused(profileRefusal);
+        if (profileStatus.state !== "configured") return refused("invalid-state");
+      }
       if (!replacement && profileStatus.state === "configured") return refused("invalid-state");
       const prior = replacement ? await captureProfile(checked.active) : undefined;
       if (replacement && prior?.state === "uncertain") return uncertain();

--- a/apps/desktop/src/main/telegram-ipc.ts
+++ b/apps/desktop/src/main/telegram-ipc.ts
@@ -252,7 +252,10 @@ export function installDesktopTelegramIpc(input: {
   readonly isTrusted: (event: Pick<IpcMainInvokeEvent, "sender" | "senderFrame">) => boolean;
   readonly coordinator: TelegramControlCoordinator;
   readonly vault: Pick<TelegramCredentialVault, "profileStatus">;
-  readonly power: Pick<DesktopTelegramPowerLifecycle, "warning" | "acknowledgeWarning">;
+  readonly power: Pick<
+    DesktopTelegramPowerLifecycle,
+    "warning" | "resetForCreate" | "acknowledgeWarning"
+  >;
 }): () => Promise<void> {
   let accepting = true;
   let closePromise: Promise<void> | undefined;
@@ -375,9 +378,19 @@ export function installDesktopTelegramIpc(input: {
               current: closedSnapshot(),
             } as const;
           }
-          return profile.state === "configured" || profile.state === "re-prompt"
-            ? input.coordinator.replace(captured.token)
-            : input.coordinator.configure(captured.token);
+          if (profile.state === "configured") {
+            return input.coordinator.replace(captured.token);
+          }
+          const result = await input.coordinator.configure(captured.token);
+          if (
+            result.outcome === "applied" ||
+            (result.outcome === "refused" &&
+              result.reason === "webhook-removal-required" &&
+              result.current.credentialConfigured)
+          ) {
+            await input.power.resetForCreate();
+          }
+          return result;
         });
       },
     ],

--- a/apps/desktop/src/main/telegram-power.ts
+++ b/apps/desktop/src/main/telegram-power.ts
@@ -44,6 +44,7 @@ export type TelegramPowerMonitorPort = Pick<PowerMonitor, "on" | "off">;
 export interface DesktopTelegramPowerLifecycle {
   start(): Promise<TelegramGapWarning>;
   warning(): Promise<TelegramGapWarning>;
+  resetForCreate(): Promise<TelegramGapWarning>;
   acknowledgeWarning(): Promise<TelegramGapWarning>;
   close(): Promise<void>;
 }
@@ -751,6 +752,16 @@ export function createDesktopTelegramPowerLifecycle(
     warning() {
       if (closed) return Promise.resolve(cached);
       return serialize(samplePollingHealth);
+    },
+    resetForCreate() {
+      if (closed) return Promise.resolve(cached);
+      return serialize(async () => {
+        if (closed) return cached;
+        const result = await writeState(emptyState(athleteHome));
+        if (closed || result !== "durably-committed") return cached;
+        scopeMismatch = false;
+        return publish(CLEAR_WARNING);
+      });
     },
     acknowledgeWarning() {
       if (closed) return Promise.resolve(cached);

--- a/apps/desktop/tests/acceptance-credential-backend.test.ts
+++ b/apps/desktop/tests/acceptance-credential-backend.test.ts
@@ -37,15 +37,31 @@ afterEach(async () => {
 });
 
 describe("acceptance credential backend eligibility", () => {
-  it("allows an explicitly requested development memory backend", () => {
+  it("allows an explicitly requested visible development memory backend", () => {
     const readPackageJson = vi.fn(() => {
       throw new Error("must not read");
     });
-    const selected = eligibility({ isPackaged: false, backend: "memory", readPackageJson });
+    const selected = eligibility({
+      isPackaged: false,
+      hidden: false,
+      backend: "memory",
+      readPackageJson,
+    });
     expect(selected?.kind).toBe("memory");
     if (selected?.kind !== "memory") throw new Error("memory backend was not selected");
     expect(selected.key).toHaveLength(32);
     expect(readPackageJson).not.toHaveBeenCalled();
+  });
+
+  it("rejects a persistent development memory backend", () => {
+    expect(
+      eligibility({
+        isPackaged: false,
+        hidden: false,
+        backend: "memory",
+        disposableContext: false,
+      }),
+    ).toBeUndefined();
   });
 
   it("allows the marked packaged Telegram acceptance app", () => {

--- a/apps/desktop/tests/development-user-data.test.ts
+++ b/apps/desktop/tests/development-user-data.test.ts
@@ -1,0 +1,93 @@
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEVELOPMENT_USER_DATA_ENV,
+  bindDevelopmentUserData,
+  decideDevelopmentUserDataBinding,
+} from "../src/main/development-user-data.js";
+
+const path = join("/private", "tmp", "enduragent-development", "electron-user-data");
+const authorizedEnvironment = {
+  [DEVELOPMENT_USER_DATA_ENV]: path,
+  ENDURAGENT_ACCEPTANCE_CREDENTIAL_BACKEND: "memory",
+  ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT: "1",
+};
+
+describe("isolated development user data binding", () => {
+  it("binds a visible unpackaged macOS app to the authorized disposable profile", () => {
+    expect(
+      decideDevelopmentUserDataBinding({
+        platform: "darwin",
+        isPackaged: false,
+        environment: authorizedEnvironment,
+      }),
+    ).toEqual({ kind: "bind", path });
+
+    const setPath = vi.fn();
+    expect(
+      bindDevelopmentUserData(
+        { setPath },
+        {
+          platform: "darwin",
+          isPackaged: false,
+          environment: authorizedEnvironment,
+        },
+      ),
+    ).toEqual({ kind: "bind", path });
+    expect(setPath).toHaveBeenCalledOnce();
+    expect(setPath).toHaveBeenCalledWith("userData", path);
+  });
+
+  it("does nothing when the isolated launcher did not request a profile", () => {
+    const setPath = vi.fn();
+    expect(
+      bindDevelopmentUserData(
+        { setPath },
+        {
+          platform: "darwin",
+          isPackaged: false,
+          environment: {},
+        },
+      ),
+    ).toEqual({ kind: "no-op" });
+    expect(setPath).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a packaged app", { isPackaged: true }],
+    ["a non-macOS app", { platform: "linux" as const }],
+    [
+      "a persistent credential context",
+      {
+        environment: {
+          ...authorizedEnvironment,
+          ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT: undefined,
+        },
+      },
+    ],
+    [
+      "a non-memory credential backend",
+      {
+        environment: {
+          ...authorizedEnvironment,
+          ENDURAGENT_ACCEPTANCE_CREDENTIAL_BACKEND: "file",
+        },
+      },
+    ],
+    [
+      "a relative profile path",
+      {
+        environment: { ...authorizedEnvironment, [DEVELOPMENT_USER_DATA_ENV]: "relative/profile" },
+      },
+    ],
+  ])("refuses %s", (_label, override) => {
+    expect(() =>
+      decideDevelopmentUserDataBinding({
+        platform: "darwin",
+        isPackaged: false,
+        environment: authorizedEnvironment,
+        ...override,
+      }),
+    ).toThrow("isolated development user data binding refused");
+  });
+});

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -454,6 +454,7 @@ export async function launchDesktopFixture(input: {
         ENDURAGENT_HOME: athleteHome,
         ENDURAGENT_ACCEPTANCE_HIDDEN: input.hidden === false ? "0" : "1",
         ENDURAGENT_ACCEPTANCE_CREDENTIAL_BACKEND: "memory",
+        ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT: "1",
         FORCE_COLOR: undefined,
         NO_COLOR: undefined,
         CLICOLOR_FORCE: undefined,

--- a/apps/desktop/tests/interactive-development.test.ts
+++ b/apps/desktop/tests/interactive-development.test.ts
@@ -1,0 +1,67 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createInteractiveDevelopmentPlan,
+  selectInteractiveDevelopmentTemporaryRoot,
+} from "../scripts/interactive-development.mjs";
+
+const desktopRoot = join("/private", "tmp", "enduragent", "apps", "desktop");
+const scratchRoot = join("/private", "tmp", "enduragent-desktop-development-fixture");
+const nodeExecutable = join("/opt", "homebrew", "bin", "node");
+const packageManagerScript = join("/private", "tmp", "corepack", "pnpm.cjs");
+
+function plan(overrides: Partial<Parameters<typeof createInteractiveDevelopmentPlan>[0]> = {}) {
+  return createInteractiveDevelopmentPlan({
+    platform: "darwin",
+    desktopRoot,
+    scratchRoot,
+    nodeExecutable,
+    packageManagerScript,
+    environment: {
+      ENDURAGENT_ACCEPTANCE_HIDDEN: "1",
+      ELECTRON_CLI_ARGS: '["--user-data-dir=/shared/profile"]',
+      SYNTHETIC: "preserved",
+    },
+    ...overrides,
+  });
+}
+
+describe("interactive desktop development plan", () => {
+  it("uses the short macOS temporary root required by local daemon sockets", () => {
+    expect(selectInteractiveDevelopmentTemporaryRoot("darwin")).toBe("/tmp");
+    expect(selectInteractiveDevelopmentTemporaryRoot("darwin", "/private/tmp/selected")).toBe(
+      "/private/tmp/selected",
+    );
+  });
+
+  it("pairs fresh athlete and Electron roots with visible temporary credentials", () => {
+    const value = plan();
+
+    expect(value).toEqual({
+      command: "/usr/bin/caffeinate",
+      args: ["-dimsu", nodeExecutable, packageManagerScript, "exec", "electron-vite", "dev"],
+      cwd: desktopRoot,
+      environment: {
+        SYNTHETIC: "preserved",
+        ENDURAGENT_HOME: join(scratchRoot, "athlete-home"),
+        ENDURAGENT_DEVELOPMENT_USER_DATA: join(scratchRoot, "electron-user-data"),
+        ENDURAGENT_ACCEPTANCE_CREDENTIAL_BACKEND: "memory",
+        ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT: "1",
+      },
+      scratchRoot,
+      athleteHome: join(scratchRoot, "athlete-home"),
+      userData: join(scratchRoot, "electron-user-data"),
+    });
+    expect(value.athleteHome).not.toBe(value.userData);
+  });
+
+  it.each([
+    ["a non-macOS platform", { platform: "linux" as const }],
+    ["a relative desktop root", { desktopRoot: "apps/desktop" }],
+    ["a relative scratch root", { scratchRoot: "scratch" }],
+    ["a relative Node executable", { nodeExecutable: "node" }],
+    ["a relative package manager script", { packageManagerScript: "pnpm.cjs" }],
+  ])("refuses %s", (_label, override) => {
+    expect(() => plan(override)).toThrow();
+  });
+});

--- a/apps/desktop/tests/telegram-control.test.ts
+++ b/apps/desktop/tests/telegram-control.test.ts
@@ -2771,11 +2771,6 @@ describe("Telegram main-process control coordinator", () => {
       "telegram-settings-storage-uncertain" as const,
     ],
     [
-      "wrong-home",
-      { state: "wrong-home", enabled: false } as const,
-      "telegram-home-mismatch" as const,
-    ],
-    [
       "re-prompt",
       { state: "re-prompt", enabled: false } as const,
       "telegram-settings-storage-uncertain" as const,
@@ -2815,6 +2810,59 @@ describe("Telegram main-process control coordinator", () => {
       expectNoTelegramMutation(reconcileRuntime);
     },
   );
+
+  it("projects another athlete home's Telegram state as Create and replaces it only on configure", async () => {
+    const statusRuntime = harness({
+      configured: false,
+      enabled: false,
+      daemonSnapshot: {
+        channel: { desiredState: "disabled", state: "disabled" },
+        bot: { state: "unconfigured" },
+        pairing: { state: "unpaired" },
+      },
+    });
+    vi.mocked(statusRuntime.vault.desiredState).mockResolvedValueOnce({
+      state: "wrong-home",
+      enabled: false,
+    });
+    vi.mocked(statusRuntime.vault.profileStatus).mockResolvedValueOnce({ state: "wrong-home" });
+
+    await expect(statusRuntime.coordinator.status()).resolves.toEqual({
+      channel: { desiredState: "disabled", state: "disabled" },
+      bot: { state: "unconfigured" },
+      pairing: { state: "unpaired" },
+      credentialConfigured: false,
+    });
+    expectNoTelegramMutation(statusRuntime);
+
+    const createRuntime = harness({
+      configured: false,
+      enabled: false,
+      daemonSnapshot: snapshot(
+        { desiredState: "disabled", state: "disabled" },
+        { username: OTHER_USERNAME, pairing: { state: "unpaired" } },
+      ),
+    });
+    vi.mocked(createRuntime.vault.desiredState).mockResolvedValueOnce({
+      state: "wrong-home",
+      enabled: false,
+    });
+    vi.mocked(createRuntime.vault.profileStatus).mockResolvedValueOnce({ state: "wrong-home" });
+
+    await expect(createRuntime.coordinator.configure(REPLACEMENT_TOKEN)).resolves.toMatchObject({
+      outcome: "applied",
+      current: {
+        channel: { desiredState: "disabled", state: "disabled" },
+        bot: { state: "ready", username: OTHER_USERNAME },
+        credentialConfigured: true,
+      },
+    });
+    expect(createRuntime.vault.replaceProfile).toHaveBeenCalledOnce();
+    expect(createRuntime.vault.setDesiredState).toHaveBeenCalledWith(false);
+    expect(createRuntime.binding.configureTelegram).toHaveBeenCalledWith({
+      token: REPLACEMENT_TOKEN,
+    });
+  });
 
   it("projects repair-required settings conservatively without a trustworthy daemon snapshot", async () => {
     const runtime = harness();

--- a/apps/desktop/tests/telegram-ipc.test.ts
+++ b/apps/desktop/tests/telegram-ipc.test.ts
@@ -156,6 +156,7 @@ function setup(
   };
   const power = {
     warning: vi.fn(async (): Promise<TelegramGapWarning> => ({ state: "clear" })),
+    resetForCreate: vi.fn(async (): Promise<TelegramGapWarning> => ({ state: "clear" })),
     acknowledgeWarning: vi.fn(async (): Promise<TelegramGapWarning> => ({ state: "clear" })),
   };
   const dispose = installDesktopTelegramIpc({
@@ -289,6 +290,7 @@ describe("Desktop Telegram IPC", () => {
     expect(runtime.trace).toEqual(["read", "clear", `configure:${TOKEN}`]);
     expect(runtime.coordinator.configure).toHaveBeenCalledWith(TOKEN);
     expect(runtime.coordinator.replace).not.toHaveBeenCalled();
+    expect(runtime.power.resetForCreate).toHaveBeenCalledOnce();
   });
 
   it("selects replacement only after clipboard capture when a credential exists", async () => {
@@ -299,13 +301,14 @@ describe("Desktop Telegram IPC", () => {
     expect(runtime.trace).toEqual(["read", "clear", `replace:${TOKEN}`]);
     expect(runtime.coordinator.configure).not.toHaveBeenCalled();
     expect(runtime.coordinator.replace).toHaveBeenCalledWith(TOKEN);
+    expect(runtime.power.resetForCreate).not.toHaveBeenCalled();
   });
 
   for (const [run, reason, available, backend] of [
     [it, "encryption-unavailable" as const, false, undefined],
     [it.skipIf(process.platform === "win32"), "unsafe-backend" as const, true, "basic_text"],
   ] as const) {
-    run(`routes a reopened real-vault ${reason} paste through replacement`, async () => {
+    run(`routes a reopened real-vault ${reason} paste through Create`, async () => {
       const base = await mkdtemp(join(await realpath(tmpdir()), "telegram-ipc-secure-storage-"));
       try {
         const homePath = join(base, "athlete-home");
@@ -341,7 +344,7 @@ describe("Desktop Telegram IPC", () => {
         });
         await expect(reopened.profileStatus()).resolves.toEqual({ state: "re-prompt", reason });
         const runtime = setup({ configured: true, vault: reopened });
-        vi.mocked(runtime.coordinator.replace).mockResolvedValueOnce({
+        vi.mocked(runtime.coordinator.configure).mockResolvedValueOnce({
           outcome: "refused",
           reason,
           current: snapshot(true),
@@ -352,8 +355,9 @@ describe("Desktop Telegram IPC", () => {
           reason,
           current: ipcSnapshot(true),
         });
-        expect(runtime.coordinator.replace).toHaveBeenCalledWith(TOKEN);
-        expect(runtime.coordinator.configure).not.toHaveBeenCalled();
+        expect(runtime.coordinator.configure).toHaveBeenCalledWith(TOKEN);
+        expect(runtime.coordinator.replace).not.toHaveBeenCalled();
+        expect(runtime.power.resetForCreate).not.toHaveBeenCalled();
       } finally {
         await rm(base, { recursive: true, force: true });
       }

--- a/apps/desktop/tests/telegram-power.test.ts
+++ b/apps/desktop/tests/telegram-power.test.ts
@@ -678,6 +678,15 @@ describe("Desktop Telegram power lifecycle", () => {
       state: "possible-message-loss",
     });
     expect(JSON.parse(await readFile(target, "utf8"))).toEqual(wrongHomeRecord);
+    await expect(wrongHome.resetForCreate()).resolves.toEqual({ state: "clear" });
+    expect(JSON.parse(await readFile(target, "utf8"))).toEqual({
+      schemaVersion: 2,
+      athleteHome: files.athleteHome,
+      gapStartedAt: null,
+      lastSuccessfulPollAt: null,
+      suspendedAt: null,
+      warningDetectedAt: null,
+    });
     await wrongHome.close();
 
     if (process.platform !== "win32") {


### PR DESCRIPTION
## Summary
- show Telegram Create whenever no verified bot is connected, and repair stale athlete-home state only after an explicit valid Create
- add a canonical isolated macOS development launcher with fresh paired data roots and temporary in-memory credentials
- require disposable hidden desktop fixtures to explicitly authorize temporary credential storage

## Verification
- pnpm check
- pnpm test (726 files passed; 10,814 tests passed; expected skips only)
- focused desktop and renderer tests (245 passed before the full suite)
- Electron runtime smoke
- live macOS UI QA through pnpm --filter @enduragent/desktop dev:isolated
- final autoreview: clean, no accepted/actionable findings