### PR TITLE
fix(desktop): separate chat retry from queue

### DIFF
--- a/.changeset/chat-retry-queue-spacing.md
+++ b/.changeset/chat-retry-queue-spacing.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Stopped Coach responses now keep Retry clearly grouped with the interruption message and separated from queued messages.

--- a/apps/desktop-renderer/src/ui/chat/Notice.tsx
+++ b/apps/desktop-renderer/src/ui/chat/Notice.tsx
@@ -40,7 +40,7 @@ export function RetryBar(): ReactElement {
   return (
     <Button
       type="button"
-      className="chat-retry justify-self-start"
+      className="chat-retry mt-row mb-row justify-self-start"
       variant="outline"
       size="sm"
       hidden={!interrupted || retryRequired !== null}

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -1411,6 +1411,35 @@ describe("chat surface", () => {
       expect(retry().hidden).toBe(true);
     });
 
+    it("groups interrupted recovery above later queued messages", () => {
+      setChat({
+        notice: "Response stopped. Your partial response is preserved.",
+        interrupted: true,
+        queued: [
+          {
+            id: "queued-1",
+            text: "Also account for Sunday’s long ride.",
+            command: false,
+            restored: false,
+          },
+          { id: "queued-2", text: "/status", command: true, restored: false },
+        ],
+      });
+      render(<Harness />);
+
+      const host = document.querySelector(".chat-notice-host");
+      const queue = screen.getByRole("region", { name: "Queued messages, 2 queued messages" });
+      if (!(host instanceof HTMLElement)) throw new TypeError("notice host missing");
+
+      expect(host).toContainElement(notice());
+      expect(host).toContainElement(retry());
+      expect(queue).not.toContainElement(retry());
+      expect(retry()).toHaveClass("mt-row", "mb-row");
+      expect(
+        retry().compareDocumentPosition(queue) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+
     it("keeps the retry bar inert until the chat actions are bound", () => {
       act(() => {
         useEnduragentStore.setState({ chatActions: null });


### PR DESCRIPTION
Summary
- Add tokenized spacing above and below the ordinary Retry action so interruption recovery reads as one group before queued messages.
- Leave the durable queue-owned retry behavior and message state contracts unchanged.
- Add focused regression coverage and a user-facing changeset.

Validation
- 74 focused desktop-renderer chat tests passed.
- Desktop renderer check passed.
- Dependency, renderer, and desktop builds passed.
- 7 Electron chat-panel integration tests passed.
- Changeset user-facing validation passed.
- Initial and final autoreview passes were clean.
- Initial and final visible UI QA passed in light and dark themes at wide and 760px layouts, including keyboard order and the real stop/retry/queue flow.