### PR TITLE
feat(desktop): add installation heartbeat

### DIFF
--- a/.changeset/report-desktop-installations.md
+++ b/.changeset/report-desktop-installations.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/desktop": patch
+---
+
+User-facing: Official Desktop releases now send a once-daily installation heartbeat containing only the fixed Enduragent Desktop product label, a random installation ID, app version, and platform. Set `ENDURAGENT_NO_USAGE_PING=1` before launch to disable it without disabling update checks.

--- a/README.md
+++ b/README.md
@@ -148,23 +148,28 @@ local estimate, not a billing control — set limits with your provider too.
 
 ## Your data stays on your device
 
-There is no Enduragent account, no server holding your training history, and no analytics in the
-product. Nowhere for us to look, because we did not build the place to look.
+There is no Enduragent account, no server holding your training history, and no behavioral
+analytics in the product. Nowhere for us to look at your rides or conversations, because we did
+not build the place to look.
 
-**Files you can open.** Everything lives under `~/.enduragent`: a local SQLite store, an archive
-of the raw data it read, plain-Markdown memory files, and your transcripts. Delete the folder and
-it is gone.
+**Files you can open.** Your athlete data lives under `~/.enduragent`: a local SQLite store, an
+archive of the raw data it read, plain-Markdown memory files, and your transcripts. Desktop also
+keeps preferences, its random installation UUID, and encrypted credentials under
+`~/Library/Application Support/Enduragent` on macOS or `%LOCALAPPDATA%\Enduragent` on Windows.
+Delete both locations to remove all locally stored Enduragent data.
 
 **Keys encrypted at rest.** API keys are encrypted with macOS secure storage, keyed from your
 Keychain. If secure storage is unavailable, the app refuses to save the key rather than writing it
 in the clear.
 
 **What does leave.** Your prompt and the training numbers in it go to the model provider you
-chose. Your intervals.icu key goes to intervals.icu. The self-hosted Telegram bot may contact
-`ping.enduragent.icu` at startup and on its daily timer, but at most once per installation in any
-24 hours — no athlete data, no credentials; set `CYCLING_COACH_NO_UPDATE_CHECK=1` to switch it off.
-Manual commands never initiate telemetry. Version lookups use npm; `/whatsnew` also queries GitHub
-for release notes. The desktop app never makes that request.
+chose. Your intervals.icu key goes to intervals.icu. The self-hosted Telegram bot and official
+Desktop releases may contact `ping.enduragent.icu` at startup and on a daily timer, but at most
+once per installation in any 24 hours. The request contains the product, version, install channel,
+and a random installation UUID — no athlete data, messages, or credentials. Set
+`CYCLING_COACH_NO_UPDATE_CHECK=1` for the bot or `ENDURAGENT_NO_USAGE_PING=1` for Desktop to switch
+it off. Manual commands never initiate telemetry; Desktop update checks remain separate and go
+directly to GitHub.
 
 Full policy: [enduragent.icu/privacy.html](https://enduragent.icu/privacy.html).
 

--- a/apps/desktop/CONTEXT.md
+++ b/apps/desktop/CONTEXT.md
@@ -71,7 +71,7 @@ _Avoid_: Recovery snapshot, startup status
 ## Windows release and updater
 
 **Release marker**:
-`enduragentDesktopRelease: true` in the packaged `package.json`; required by `isDesktopUpdateReleaseEligible`.
+`enduragentDesktopRelease: true` in the packaged `package.json`; required by `isOfficialDesktopRelease` and therefore by `isDesktopUpdateReleaseEligible`.
 _Avoid_: Release flag, Windows marker
 
 **Platform activation**:
@@ -113,7 +113,7 @@ _Avoid_: Install directory, application directory
 - When the encryption key is missing and only unverified envelopes survive, **Credential recovery** may replace one slot while preserving every other artifact.
 - An **Orphan encryption key** may be removed without losing a credential.
 - **Recovery status** is derived from both vaults whenever it is requested.
-- The **Release marker** admits a packaged build to `isDesktopUpdateReleaseEligible`; **Platform activation** independently decides whether update checks run on the current platform.
+- The **Release marker** admits a packaged build to `isOfficialDesktopRelease`; **Platform activation** independently decides whether update checks run on the current platform.
 - A **Windows release envelope** is produced, verified, uploaded, and round-trip-checked by its named scripts.
 - **Authenticode pending mode** does not authorise an unsigned installer for a GitHub release or the website.
 - **Windows release provenance** binds a verified installer to the release tag commit, updater publisher, and canonical packaged updater metadata before upload; the uploader compares the supplied `app-update.yml` bytes with the digest sealed in the signed installer.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -4,6 +4,12 @@
 
 The desktop app uses its own SemVer from `apps/desktop/package.json` and releases under `enduragent-desktop@<version>`; desktop releases never publish or bump the npm package. The protected macOS workflow signs with Developer ID, notarizes with Apple, verifies the DMG, ZIP, blockmap, and `latest-mac.yml`, runs the signed update round trip, and makes the tested release the updater feed only after those checks pass.
 
+Official releases send a separate installation heartbeat to `ping.enduragent.icu` at startup and
+on a daily timer, limited to one attempt per installation in any 24-hour period. It contains only
+the fixed product label `enduragent-desktop`, a random persisted installation UUID, the app
+version, and the platform channel; set
+`ENDURAGENT_NO_USAGE_PING=1` before launch to disable it without disabling GitHub update checks.
+
 ## Windows
 
 Windows targets Windows 11 x64 with the per-user, one-click `Enduragent-<version>-x64.exe` installer, its `.blockmap`, and `latest.yml`; the installer requests no elevation, adds a Start Menu shortcut but no desktop shortcut, and ships only with an Authenticode signature from `<PUBLISHER_NAME>`, although SmartScreen can still prompt while a new publisher identity builds reputation. Windows assets are appended to the existing desktop release, may lag or skip a version, and never hold the macOS release; update checks use the same generic GitHub release feed and switch on with the first signed release. Closing the main window keeps the app running in the tray until it is explicitly quit, while uninstalling retains `%LOCALAPPDATA%\Enduragent` for the athlete to remove by hand. Follow the operator runbook in `CONTRIBUTING.md`.

--- a/apps/desktop/src/main/desktop-usage-ping-state.ts
+++ b/apps/desktop/src/main/desktop-usage-ping-state.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "node:crypto";
+import { constants, type Stats } from "node:fs";
+import { lstat, mkdir, open, readdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  bindWindowsPrivateDirectory,
+  classifyWindowsPrivatePathDurability,
+  type WindowsPrivateDirectoryBinding,
+} from "@enduragent/core";
+import { durableAtomicReplace, syncDirectory } from "./durable-atomic-replace.js";
+import {
+  readWindowsPrivateFile,
+  WindowsPrivateFileMaximumBytesExceededError,
+} from "./windows-private-file.js";
+
+export const DESKTOP_USAGE_PING_STATE_FILE_NAME = "desktop-usage-ping.json" as const;
+export const DESKTOP_USAGE_PING_STATE_DIRECTORY_MODE = 0o700;
+export const DESKTOP_USAGE_PING_STATE_FILE_MODE = 0o600;
+export const DESKTOP_USAGE_PING_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+
+const MAX_DESKTOP_USAGE_PING_STATE_BYTES = 256;
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+interface DesktopUsagePingStateRecord {
+  readonly schemaVersion: 1;
+  readonly instanceId: string;
+  readonly lastAttemptAt: number;
+}
+
+type StoredDesktopUsagePingState =
+  | Readonly<{ status: "missing" | "corrupt" }>
+  | Readonly<{ status: "ready"; record: DesktopUsagePingStateRecord }>;
+
+export type DesktopUsagePingClaim =
+  | Readonly<{ status: "claimed"; instanceId: string }>
+  | Readonly<{ status: "deferred"; retryAfterMs: number }>
+  | Readonly<{ status: "unavailable" }>;
+
+export interface DesktopUsagePingStateStore {
+  claimAttempt(now: number): Promise<DesktopUsagePingClaim>;
+}
+
+function permissions(mode: number): number {
+  return mode & 0o777;
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function assertOwner(metadata: Stats, mode: number): void {
+  if (
+    metadata.isSymbolicLink() ||
+    permissions(metadata.mode) !== mode ||
+    (typeof process.getuid === "function" && metadata.uid !== process.getuid())
+  ) {
+    throw new TypeError("unsafe desktop usage ping path");
+  }
+}
+
+function validInstanceId(value: unknown): value is string {
+  return typeof value === "string" && UUID_V4_PATTERN.test(value);
+}
+
+function parseState(contents: string): DesktopUsagePingStateRecord | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    return undefined;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (
+    keys.length !== 3 ||
+    keys[0] !== "instanceId" ||
+    keys[1] !== "lastAttemptAt" ||
+    keys[2] !== "schemaVersion" ||
+    record.schemaVersion !== 1 ||
+    !validInstanceId(record.instanceId) ||
+    !Number.isSafeInteger(record.lastAttemptAt) ||
+    (record.lastAttemptAt as number) < 0
+  ) {
+    return undefined;
+  }
+  return {
+    schemaVersion: 1,
+    instanceId: record.instanceId,
+    lastAttemptAt: record.lastAttemptAt as number,
+  };
+}
+
+export function createDesktopUsagePingStateStore(input: {
+  readonly root: string;
+  readonly platform?: NodeJS.Platform;
+  readonly createInstanceId?: () => string;
+  readonly openFile?: typeof open;
+  readonly syncDirectory?: (root: string) => Promise<void>;
+}): DesktopUsagePingStateStore {
+  const platform = input.platform ?? process.platform;
+  const createInstanceId = input.createInstanceId ?? randomUUID;
+  const synchronizeDirectory = input.syncDirectory ?? syncDirectory;
+  const target = join(input.root, DESKTOP_USAGE_PING_STATE_FILE_NAME);
+  let pending: Promise<void> = Promise.resolve();
+
+  const serialize = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = pending.then(operation);
+    pending = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  const synchronizeDirectoryIfSupported = async (root: string): Promise<void> => {
+    if (
+      platform === "win32" &&
+      classifyWindowsPrivatePathDurability("directory-sync").kind === "unavailable"
+    ) {
+      return;
+    }
+    await synchronizeDirectory(root);
+  };
+
+  const prepareRoot = async (): Promise<WindowsPrivateDirectoryBinding | undefined> => {
+    let created = false;
+    let metadata: Stats;
+    try {
+      metadata = await lstat(input.root);
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+      await mkdir(input.root, {
+        recursive: true,
+        mode: DESKTOP_USAGE_PING_STATE_DIRECTORY_MODE,
+      });
+      created = true;
+      metadata = await lstat(input.root);
+    }
+    if (!metadata.isDirectory()) throw new TypeError("invalid desktop usage ping root");
+    const windowsDirectory =
+      platform === "win32"
+        ? bindWindowsPrivateDirectory(dirname(input.root), input.root)
+        : undefined;
+    if (platform !== "win32") {
+      assertOwner(metadata, DESKTOP_USAGE_PING_STATE_DIRECTORY_MODE);
+    }
+    if (created) await synchronizeDirectoryIfSupported(dirname(input.root));
+    const prefix = `.${DESKTOP_USAGE_PING_STATE_FILE_NAME}.`;
+    let removed = false;
+    for (const entry of await readdir(input.root)) {
+      if (
+        entry.startsWith(prefix) &&
+        entry.endsWith(".tmp") &&
+        /^[A-Za-z0-9-]{1,128}$/.test(entry.slice(prefix.length, -4))
+      ) {
+        await rm(join(input.root, entry), { force: true });
+        removed = true;
+      }
+    }
+    if (removed) await synchronizeDirectoryIfSupported(input.root);
+    return windowsDirectory;
+  };
+
+  const readState = async (
+    windowsDirectory: WindowsPrivateDirectoryBinding | undefined,
+  ): Promise<StoredDesktopUsagePingState> => {
+    if (platform === "win32") {
+      let snapshot;
+      try {
+        snapshot = await readWindowsPrivateFile({
+          directory: windowsDirectory!,
+          path: target,
+          maximumBytes: MAX_DESKTOP_USAGE_PING_STATE_BYTES,
+          openFile: input.openFile,
+        });
+      } catch (error) {
+        if (error instanceof WindowsPrivateFileMaximumBytesExceededError) {
+          return { status: "corrupt" };
+        }
+        throw error;
+      }
+      if (snapshot === undefined) return { status: "missing" };
+      const contents = snapshot.contents.toString("utf8");
+      snapshot.contents.fill(0);
+      const record = parseState(contents);
+      return record === undefined ? { status: "corrupt" } : { status: "ready", record };
+    }
+    let before: Stats;
+    try {
+      before = await lstat(target);
+    } catch (error) {
+      if (isMissing(error)) return { status: "missing" };
+      throw error;
+    }
+    if (!before.isFile()) throw new TypeError("invalid desktop usage ping state file");
+    assertOwner(before, DESKTOP_USAGE_PING_STATE_FILE_MODE);
+    if (before.size > MAX_DESKTOP_USAGE_PING_STATE_BYTES) return { status: "corrupt" };
+    const handle = await (input.openFile ?? open)(
+      target,
+      constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+    );
+    try {
+      const opened = await handle.stat();
+      if (
+        !opened.isFile() ||
+        opened.dev !== before.dev ||
+        opened.ino !== before.ino ||
+        opened.size > MAX_DESKTOP_USAGE_PING_STATE_BYTES
+      ) {
+        throw new TypeError("desktop usage ping state changed while opening");
+      }
+      assertOwner(opened, DESKTOP_USAGE_PING_STATE_FILE_MODE);
+      const contents = await handle.readFile({ encoding: "utf8" });
+      const afterRead = await handle.stat();
+      if (
+        Buffer.byteLength(contents, "utf8") > MAX_DESKTOP_USAGE_PING_STATE_BYTES ||
+        afterRead.dev !== opened.dev ||
+        afterRead.ino !== opened.ino ||
+        afterRead.size !== opened.size ||
+        afterRead.mtimeMs !== opened.mtimeMs ||
+        afterRead.ctimeMs !== opened.ctimeMs
+      ) {
+        throw new TypeError("desktop usage ping state changed while reading");
+      }
+      const record = parseState(contents);
+      return record === undefined ? { status: "corrupt" } : { status: "ready", record };
+    } finally {
+      await handle.close();
+    }
+  };
+
+  const writeState = (record: DesktopUsagePingStateRecord) =>
+    durableAtomicReplace({
+      root: input.root,
+      fileName: DESKTOP_USAGE_PING_STATE_FILE_NAME,
+      contents: `${JSON.stringify(record)}\n`,
+      mode: DESKTOP_USAGE_PING_STATE_FILE_MODE,
+      platform,
+      openFile: input.openFile,
+      syncDirectory: synchronizeDirectory,
+    });
+
+  return {
+    claimAttempt(now) {
+      return serialize(async () => {
+        if (!Number.isSafeInteger(now) || now < 0) return { status: "unavailable" };
+        try {
+          const windowsDirectory = await prepareRoot();
+          const existing = await readState(windowsDirectory);
+          if (existing.status === "ready") {
+            const elapsed = now - existing.record.lastAttemptAt;
+            if (elapsed < 0) {
+              return { status: "deferred", retryAfterMs: DESKTOP_USAGE_PING_INTERVAL_MS };
+            }
+            if (elapsed < DESKTOP_USAGE_PING_INTERVAL_MS) {
+              return {
+                status: "deferred",
+                retryAfterMs: DESKTOP_USAGE_PING_INTERVAL_MS - elapsed,
+              };
+            }
+            const outcome = await writeState({ ...existing.record, lastAttemptAt: now });
+            if (outcome.state !== "durably-committed") return { status: "unavailable" };
+            return { status: "claimed", instanceId: existing.record.instanceId };
+          }
+          const instanceId = createInstanceId();
+          if (!validInstanceId(instanceId)) return { status: "unavailable" };
+          const outcome = await writeState({ schemaVersion: 1, instanceId, lastAttemptAt: now });
+          if (outcome.state !== "durably-committed") return { status: "unavailable" };
+          return { status: "claimed", instanceId };
+        } catch {
+          return { status: "unavailable" };
+        }
+      });
+    },
+  };
+}

--- a/apps/desktop/src/main/desktop-usage-ping.ts
+++ b/apps/desktop/src/main/desktop-usage-ping.ts
@@ -1,0 +1,166 @@
+import { isStableDesktopVersion } from "./desktop-version.js";
+import {
+  DESKTOP_USAGE_PING_INTERVAL_MS,
+  type DesktopUsagePingStateStore,
+} from "./desktop-usage-ping-state.js";
+
+export const DESKTOP_USAGE_PING_ENDPOINT = "https://ping.enduragent.icu/v1/ping" as const;
+export const DESKTOP_USAGE_PING_TIMEOUT_MS = 5_000;
+
+export type DesktopUsagePingChannel = "macos" | "windows";
+
+export interface DesktopUsagePingRequest {
+  (url: string, init: RequestInit): Promise<unknown>;
+}
+
+export interface DesktopUsagePingController {
+  start(): Promise<void>;
+  close(): void;
+}
+
+interface TimerHandle {
+  unref(): void;
+}
+
+function validChannel(channel: string): channel is DesktopUsagePingChannel {
+  return channel === "macos" || channel === "windows";
+}
+
+export function desktopUsagePingChannelForPlatform(
+  platform: NodeJS.Platform,
+): DesktopUsagePingChannel | undefined {
+  if (platform === "darwin") return "macos";
+  if (platform === "win32") return "windows";
+  return undefined;
+}
+
+export function createDesktopUsagePingController(input: {
+  readonly releaseEligible: boolean;
+  readonly version: string;
+  readonly channel: DesktopUsagePingChannel;
+  readonly state: DesktopUsagePingStateStore;
+  readonly request: DesktopUsagePingRequest;
+  readonly now?: () => number;
+  readonly setTimeout?: (callback: () => void, timeout: number) => TimerHandle;
+  readonly clearTimeout?: (handle: TimerHandle) => void;
+}): DesktopUsagePingController {
+  const active =
+    input.releaseEligible && isStableDesktopVersion(input.version) && validChannel(input.channel);
+  const now = input.now ?? Date.now;
+  const scheduleTimeout =
+    input.setTimeout ??
+    ((callback, timeout) => globalThis.setTimeout(callback, timeout) as TimerHandle);
+  const unscheduleTimeout =
+    input.clearTimeout ??
+    ((handle) => globalThis.clearTimeout(handle as ReturnType<typeof globalThis.setTimeout>));
+  let started = false;
+  let closed = false;
+  let scheduled: TimerHandle | undefined;
+  let requestController: AbortController | undefined;
+  let inFlight: Promise<void> | undefined;
+
+  const clearScheduled = (): void => {
+    if (scheduled === undefined) return;
+    try {
+      unscheduleTimeout(scheduled);
+    } catch {}
+    scheduled = undefined;
+  };
+
+  const schedule = (delay: number): void => {
+    if (closed || !active) return;
+    clearScheduled();
+    const boundedDelay =
+      Number.isSafeInteger(delay) && delay > 0 && delay <= DESKTOP_USAGE_PING_INTERVAL_MS
+        ? delay
+        : DESKTOP_USAGE_PING_INTERVAL_MS;
+    try {
+      const handle = scheduleTimeout(() => {
+        if (scheduled === handle) scheduled = undefined;
+        void run();
+      }, boundedDelay);
+      scheduled = handle;
+      handle.unref();
+    } catch {}
+  };
+
+  const send = async (instanceId: string): Promise<void> => {
+    if (closed) return;
+    const controller = new AbortController();
+    requestController = controller;
+    let deadline: TimerHandle | undefined;
+    try {
+      deadline = scheduleTimeout(() => controller.abort(), DESKTOP_USAGE_PING_TIMEOUT_MS);
+      deadline.unref();
+      await input.request(DESKTOP_USAGE_PING_ENDPOINT, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          product: "enduragent-desktop",
+          version: input.version,
+          channel: input.channel,
+          instance: instanceId,
+        }),
+        credentials: "omit",
+        redirect: "error",
+        cache: "no-store",
+        signal: controller.signal,
+      });
+    } catch {
+    } finally {
+      if (deadline !== undefined) {
+        try {
+          unscheduleTimeout(deadline);
+        } catch {}
+      }
+      if (requestController === controller) requestController = undefined;
+    }
+  };
+
+  const perform = async (): Promise<void> => {
+    let claim;
+    try {
+      claim = await input.state.claimAttempt(now());
+    } catch {
+      claim = { status: "unavailable" } as const;
+    }
+    if (closed) return;
+    if (claim.status === "deferred") {
+      schedule(claim.retryAfterMs);
+      return;
+    }
+    if (claim.status === "unavailable") {
+      schedule(DESKTOP_USAGE_PING_INTERVAL_MS);
+      return;
+    }
+    await send(claim.instanceId);
+    schedule(DESKTOP_USAGE_PING_INTERVAL_MS);
+  };
+
+  const run = (): Promise<void> => {
+    if (closed || !active) return Promise.resolve();
+    if (inFlight !== undefined) return inFlight;
+    let operation: Promise<void>;
+    operation = perform()
+      .catch(() => undefined)
+      .finally(() => {
+        if (inFlight === operation) inFlight = undefined;
+      });
+    inFlight = operation;
+    return operation;
+  };
+
+  return {
+    start() {
+      if (started || closed || !active) return Promise.resolve();
+      started = true;
+      return run();
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      clearScheduled();
+      requestController?.abort();
+    },
+  };
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -23,6 +23,7 @@ import {
   dialog,
   ipcMain,
   nativeTheme,
+  net,
   powerMonitor,
   safeStorage,
   session,
@@ -152,9 +153,14 @@ import {
   installDesktopTerminationSignalHandler,
 } from "./quit-coordinator.js";
 import { createDesktopUpdateController } from "./update-controller.js";
-import { isDesktopUpdateReleaseEligible } from "./update-eligibility.js";
+import { isDesktopUpdateReleaseEligible, isOfficialDesktopRelease } from "./update-eligibility.js";
 import { installDesktopUpdateIpc } from "./update-ipc.js";
 import { createDesktopUpdateVersionFloor } from "./update-version-floor.js";
+import {
+  createDesktopUsagePingController,
+  desktopUsagePingChannelForPlatform,
+} from "./desktop-usage-ping.js";
+import { createDesktopUsagePingStateStore } from "./desktop-usage-ping-state.js";
 import {
   createTelegramControlCoordinator,
   type TelegramDaemonBinding,
@@ -383,6 +389,26 @@ async function runDesktop(): Promise<void> {
     },
     requestQuit: () => app.quit(),
   });
+  const desktopUsagePingChannel = desktopUsagePingChannelForPlatform(process.platform);
+  const desktopUsagePingController =
+    desktopUsagePingChannel === undefined
+      ? undefined
+      : createDesktopUsagePingController({
+          releaseEligible:
+            !desktopAcceptanceHidden &&
+            environment.ENDURAGENT_NO_USAGE_PING !== "1" &&
+            isOfficialDesktopRelease({
+              isPackaged: app.isPackaged,
+              platform: process.platform,
+              securitySmokeMode,
+              appPath: app.getAppPath(),
+              currentVersion: app.getVersion(),
+            }),
+          version: app.getVersion(),
+          channel: desktopUsagePingChannel,
+          state: createDesktopUsagePingStateStore({ root: desktopPreferencesRoot }),
+          request: (url, init) => net.fetch(url, init),
+        });
   const shutdown = (): Promise<void> => {
     shutdownPromise ??= (async () => {
       const closingResidency = residency;
@@ -422,6 +448,7 @@ async function runDesktop(): Promise<void> {
       await closeTelegramCoordinator?.();
       closeTelegramCoordinator = undefined;
       await reportSecuritySmokeShutdownStage("telegram-coordinator-closed");
+      desktopUsagePingController?.close();
       updateController.close();
       disposeOnboarding?.();
       disposeOnboarding = undefined;
@@ -1401,6 +1428,7 @@ async function runDesktop(): Promise<void> {
     }
     const initialWindow = desktopStartedInBackground ? undefined : await mainWindow.show();
     void updateController.start();
+    void desktopUsagePingController?.start();
 
     if (securitySmokeMode) {
       if (initialWindow === undefined) throw new TypeError("security smoke requires a window");

--- a/apps/desktop/src/main/update-eligibility.ts
+++ b/apps/desktop/src/main/update-eligibility.ts
@@ -9,20 +9,19 @@ export type DesktopUpdatePlatform = (typeof DESKTOP_UPDATE_SUPPORTED_PLATFORMS)[
 export const DESKTOP_UPDATE_PLATFORM_ACTIVATION: Readonly<Record<DesktopUpdatePlatform, boolean>> =
   Object.freeze({ darwin: true, win32: false });
 
-export function isDesktopUpdateReleaseEligible(input: {
+interface OfficialDesktopReleaseInput {
   readonly isPackaged: boolean;
   readonly platform: NodeJS.Platform;
   readonly securitySmokeMode: boolean;
   readonly appPath: string;
   readonly currentVersion: string;
   readonly readPackageJson?: (path: string) => string;
-  readonly platformActivation?: Readonly<Record<DesktopUpdatePlatform, boolean>>;
-}): boolean {
-  const platformActivation = input.platformActivation ?? DESKTOP_UPDATE_PLATFORM_ACTIVATION;
+}
+
+export function isOfficialDesktopRelease(input: OfficialDesktopReleaseInput): boolean {
   if (
     !input.isPackaged ||
     !DESKTOP_UPDATE_SUPPORTED_PLATFORMS.includes(input.platform as DesktopUpdatePlatform) ||
-    platformActivation[input.platform as DesktopUpdatePlatform] !== true ||
     input.securitySmokeMode ||
     !isStableDesktopVersion(input.currentVersion)
   ) {
@@ -46,4 +45,19 @@ export function isDesktopUpdateReleaseEligible(input: {
   } catch {
     return false;
   }
+}
+
+export function isDesktopUpdateReleaseEligible(
+  input: OfficialDesktopReleaseInput & {
+    readonly platformActivation?: Readonly<Record<DesktopUpdatePlatform, boolean>>;
+  },
+): boolean {
+  const platformActivation = input.platformActivation ?? DESKTOP_UPDATE_PLATFORM_ACTIVATION;
+  if (
+    !DESKTOP_UPDATE_SUPPORTED_PLATFORMS.includes(input.platform as DesktopUpdatePlatform) ||
+    platformActivation[input.platform as DesktopUpdatePlatform] !== true
+  ) {
+    return false;
+  }
+  return isOfficialDesktopRelease(input);
 }

--- a/apps/desktop/tests/desktop-usage-ping-state.test.ts
+++ b/apps/desktop/tests/desktop-usage-ping-state.test.ts
@@ -1,0 +1,249 @@
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createDesktopUsagePingStateStore,
+  DESKTOP_USAGE_PING_INTERVAL_MS,
+  DESKTOP_USAGE_PING_STATE_DIRECTORY_MODE,
+  DESKTOP_USAGE_PING_STATE_FILE_MODE,
+  DESKTOP_USAGE_PING_STATE_FILE_NAME,
+} from "../src/main/desktop-usage-ping-state.js";
+
+const FIRST_INSTANCE_ID = "10000000-0000-4000-8000-000000000001";
+const SECOND_INSTANCE_ID = "20000000-0000-4000-9000-000000000002";
+const UPPERCASE_INSTANCE_ID = "ABCDEFAB-CDEF-4ABC-8ABC-ABCDEFABCDEF";
+const temporaryRoots: string[] = [];
+const posixIt = it.skipIf(process.platform === "win32");
+
+async function temporaryStateRoot(): Promise<string> {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-usage-ping-state-"));
+  temporaryRoots.push(temporaryRoot);
+  return join(temporaryRoot, "desktop-preferences-v1");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("desktop usage ping state", () => {
+  it("persists one installation identifier and a daily claim across restarts", async () => {
+    const root = await temporaryStateRoot();
+    const target = join(root, DESKTOP_USAGE_PING_STATE_FILE_NAME);
+    const firstProcess = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => FIRST_INSTANCE_ID,
+    });
+
+    await expect(firstProcess.claimAttempt(1_000)).resolves.toEqual({
+      status: "claimed",
+      instanceId: FIRST_INSTANCE_ID,
+    });
+    await expect(readFile(target, "utf8")).resolves.toBe(
+      `${JSON.stringify({
+        schemaVersion: 1,
+        instanceId: FIRST_INSTANCE_ID,
+        lastAttemptAt: 1_000,
+      })}\n`,
+    );
+    if (process.platform !== "win32") {
+      expect((await lstat(root)).mode & 0o777).toBe(DESKTOP_USAGE_PING_STATE_DIRECTORY_MODE);
+      expect((await lstat(target)).mode & 0o777).toBe(DESKTOP_USAGE_PING_STATE_FILE_MODE);
+    }
+
+    const restartedProcess = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => SECOND_INSTANCE_ID,
+    });
+    await expect(restartedProcess.claimAttempt(1_001)).resolves.toEqual({
+      status: "deferred",
+      retryAfterMs: DESKTOP_USAGE_PING_INTERVAL_MS - 1,
+    });
+    await expect(
+      restartedProcess.claimAttempt(1_000 + DESKTOP_USAGE_PING_INTERVAL_MS),
+    ).resolves.toEqual({ status: "claimed", instanceId: FIRST_INSTANCE_ID });
+  });
+
+  it("serializes concurrent claims so only one attempt is accepted", async () => {
+    const root = await temporaryStateRoot();
+    const state = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => FIRST_INSTANCE_ID,
+    });
+
+    const claims = await Promise.all([state.claimAttempt(10_000), state.claimAttempt(10_000)]);
+
+    expect(claims).toEqual([
+      { status: "claimed", instanceId: FIRST_INSTANCE_ID },
+      { status: "deferred", retryAfterMs: DESKTOP_USAGE_PING_INTERVAL_MS },
+    ]);
+  });
+
+  it("replaces corrupt state durably before returning a new identifier", async () => {
+    const root = await temporaryStateRoot();
+    const target = join(root, DESKTOP_USAGE_PING_STATE_FILE_NAME);
+    const initial = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => FIRST_INSTANCE_ID,
+    });
+    await initial.claimAttempt(1_000);
+    await writeFile(target, "not-json\n");
+    await chmod(target, DESKTOP_USAGE_PING_STATE_FILE_MODE);
+
+    const recovered = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => SECOND_INSTANCE_ID,
+    });
+    await expect(recovered.claimAttempt(2_000)).resolves.toEqual({
+      status: "claimed",
+      instanceId: SECOND_INSTANCE_ID,
+    });
+    await expect(readFile(target, "utf8")).resolves.toBe(
+      `${JSON.stringify({
+        schemaVersion: 1,
+        instanceId: SECOND_INSTANCE_ID,
+        lastAttemptAt: 2_000,
+      })}\n`,
+    );
+  });
+
+  it("never returns an ephemeral identifier when persistence is uncertain", async () => {
+    const root = await temporaryStateRoot();
+    await mkdir(root, { mode: DESKTOP_USAGE_PING_STATE_DIRECTORY_MODE });
+    await chmod(root, DESKTOP_USAGE_PING_STATE_DIRECTORY_MODE);
+    const state = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => FIRST_INSTANCE_ID,
+      syncDirectory: async () => {
+        throw new Error("synthetic directory sync failure");
+      },
+    });
+
+    await expect(state.claimAttempt(1_000)).resolves.toEqual({ status: "unavailable" });
+  });
+
+  it("waits a full interval when the stored wall clock is in the future", async () => {
+    const root = await temporaryStateRoot();
+    const state = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => FIRST_INSTANCE_ID,
+    });
+    await state.claimAttempt(10_000);
+
+    await expect(state.claimAttempt(9_999)).resolves.toEqual({
+      status: "deferred",
+      retryAfterMs: DESKTOP_USAGE_PING_INTERVAL_MS,
+    });
+  });
+
+  it("refuses invalid clocks and generated identifiers without writing state", async () => {
+    const root = await temporaryStateRoot();
+    const state = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => "not-a-uuid",
+    });
+
+    await expect(state.claimAttempt(Number.NaN)).resolves.toEqual({ status: "unavailable" });
+    await expect(state.claimAttempt(1_000)).resolves.toEqual({ status: "unavailable" });
+    await expect(
+      readFile(join(root, DESKTOP_USAGE_PING_STATE_FILE_NAME), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("refuses a non-canonical uppercase installation identifier", async () => {
+    const root = await temporaryStateRoot();
+    const state = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => UPPERCASE_INSTANCE_ID,
+    });
+
+    await expect(state.claimAttempt(1_000)).resolves.toEqual({ status: "unavailable" });
+    await expect(
+      readFile(join(root, DESKTOP_USAGE_PING_STATE_FILE_NAME), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  posixIt("recovers oversized state only through a bounded durable replacement", async () => {
+    const root = await temporaryStateRoot();
+    const target = join(root, DESKTOP_USAGE_PING_STATE_FILE_NAME);
+    await mkdir(root, { mode: DESKTOP_USAGE_PING_STATE_DIRECTORY_MODE });
+    await chmod(root, DESKTOP_USAGE_PING_STATE_DIRECTORY_MODE);
+    await writeFile(target, "x".repeat(257), { mode: DESKTOP_USAGE_PING_STATE_FILE_MODE });
+    await chmod(target, DESKTOP_USAGE_PING_STATE_FILE_MODE);
+    const state = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => FIRST_INSTANCE_ID,
+    });
+
+    await expect(state.claimAttempt(1_000)).resolves.toEqual({
+      status: "claimed",
+      instanceId: FIRST_INSTANCE_ID,
+    });
+    expect((await readFile(target)).byteLength).toBeLessThanOrEqual(256);
+  });
+
+  posixIt("refuses unsafe file permissions and symbolic links", async () => {
+    const root = await temporaryStateRoot();
+    const target = join(root, DESKTOP_USAGE_PING_STATE_FILE_NAME);
+    const initial = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => FIRST_INSTANCE_ID,
+    });
+    await initial.claimAttempt(1_000);
+    const originalContents = await readFile(target, "utf8");
+    await chmod(target, 0o644);
+
+    const unsafePermissions = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => SECOND_INSTANCE_ID,
+    });
+    await expect(
+      unsafePermissions.claimAttempt(1_000 + DESKTOP_USAGE_PING_INTERVAL_MS),
+    ).resolves.toEqual({ status: "unavailable" });
+    await expect(readFile(target, "utf8")).resolves.toBe(originalContents);
+
+    const linked = join(root, "linked-desktop-usage-ping.json");
+    await rm(target);
+    await writeFile(linked, originalContents, { mode: DESKTOP_USAGE_PING_STATE_FILE_MODE });
+    await chmod(linked, DESKTOP_USAGE_PING_STATE_FILE_MODE);
+    await symlink(linked, target);
+    const unsafeLink = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => SECOND_INSTANCE_ID,
+    });
+
+    await expect(unsafeLink.claimAttempt(1_000 + DESKTOP_USAGE_PING_INTERVAL_MS)).resolves.toEqual({
+      status: "unavailable",
+    });
+    expect((await lstat(target)).isSymbolicLink()).toBe(true);
+    await expect(readFile(linked, "utf8")).resolves.toBe(originalContents);
+  });
+
+  it("uses the Windows private-file policy without requiring directory sync", async () => {
+    const root = await temporaryStateRoot();
+    const createWindowsState = () =>
+      createDesktopUsagePingStateStore({
+        root,
+        platform: "win32",
+        createInstanceId: () => FIRST_INSTANCE_ID,
+        syncDirectory: async () => {
+          throw new Error("Windows directory sync must remain unavailable");
+        },
+      });
+
+    await expect(createWindowsState().claimAttempt(1_000)).resolves.toEqual({
+      status: "claimed",
+      instanceId: FIRST_INSTANCE_ID,
+    });
+    const target = join(root, DESKTOP_USAGE_PING_STATE_FILE_NAME);
+    await chmod(root, 0o777);
+    await chmod(target, 0o666);
+
+    await expect(createWindowsState().claimAttempt(1_001)).resolves.toEqual({
+      status: "deferred",
+      retryAfterMs: DESKTOP_USAGE_PING_INTERVAL_MS - 1,
+    });
+  });
+});

--- a/apps/desktop/tests/desktop-usage-ping-wiring.test.ts
+++ b/apps/desktop/tests/desktop-usage-ping-wiring.test.ts
@@ -1,0 +1,40 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("desktop usage ping wiring", () => {
+  it("starts only after desktop residency and the initial window barrier", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+    const preferences = source.indexOf("const desktopPreferencesRoot = join(");
+    const construction = source.indexOf("const desktopUsagePingController =");
+    const residency = source.indexOf("await residency.start();");
+    const initialWindow = source.indexOf("const initialWindow =");
+    const start = source.indexOf("void desktopUsagePingController?.start();");
+    const securitySmoke = source.indexOf("if (securitySmokeMode) {", start);
+
+    expect(preferences).toBeGreaterThan(-1);
+    expect(construction).toBeGreaterThan(preferences);
+    expect(start).toBeGreaterThan(residency);
+    expect(start).toBeGreaterThan(initialWindow);
+    expect(securitySmoke).toBeGreaterThan(start);
+  });
+
+  it("gates the heartbeat and closes it through centralized shutdown", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+    const channel = source.indexOf("const desktopUsagePingChannel =");
+    const construction = source.indexOf("const desktopUsagePingController =");
+    const shutdown = source.indexOf("const shutdown =", construction);
+    const block = source.slice(channel, shutdown);
+    const close = source.indexOf("desktopUsagePingController?.close();", shutdown);
+    const updateClose = source.indexOf("updateController.close();", shutdown);
+
+    expect(block).toContain("desktopUsagePingChannelForPlatform(process.platform)");
+    expect(block).toContain("!desktopAcceptanceHidden");
+    expect(block).toContain('environment.ENDURAGENT_NO_USAGE_PING !== "1"');
+    expect(block).toContain("isOfficialDesktopRelease({");
+    expect(block).toContain("securitySmokeMode,");
+    expect(block).toContain("request: (url, init) => net.fetch(url, init)");
+    expect(close).toBeGreaterThan(shutdown);
+    expect(updateClose).toBeGreaterThan(close);
+  });
+});

--- a/apps/desktop/tests/desktop-usage-ping.test.ts
+++ b/apps/desktop/tests/desktop-usage-ping.test.ts
@@ -1,0 +1,307 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDesktopUsagePingController,
+  DESKTOP_USAGE_PING_ENDPOINT,
+  DESKTOP_USAGE_PING_TIMEOUT_MS,
+  desktopUsagePingChannelForPlatform,
+} from "../src/main/desktop-usage-ping.js";
+import {
+  createDesktopUsagePingStateStore,
+  DESKTOP_USAGE_PING_INTERVAL_MS,
+  DESKTOP_USAGE_PING_STATE_FILE_NAME,
+  type DesktopUsagePingClaim,
+  type DesktopUsagePingStateStore,
+} from "../src/main/desktop-usage-ping-state.js";
+
+const INSTANCE_ID = "10000000-0000-4000-8000-000000000001";
+const temporaryRoots: string[] = [];
+
+interface TestTimerHandle {
+  unref(): void;
+}
+
+function fakeTimers() {
+  const scheduled = new Map<TestTimerHandle, Readonly<{ callback: () => void; timeout: number }>>();
+  const handles: TestTimerHandle[] = [];
+  const setTimeout = vi.fn((callback: () => void, timeout: number): TestTimerHandle => {
+    const handle = { unref: vi.fn() };
+    handles.push(handle);
+    scheduled.set(handle, { callback, timeout });
+    return handle;
+  });
+  const clearTimeout = vi.fn((handle: TestTimerHandle) => {
+    scheduled.delete(handle);
+  });
+  const latest = (timeout: number): TestTimerHandle | undefined => {
+    let match: TestTimerHandle | undefined;
+    for (const [handle, entry] of scheduled) {
+      if (entry.timeout === timeout) match = handle;
+    }
+    return match;
+  };
+  const fire = (handle: TestTimerHandle): void => {
+    const entry = scheduled.get(handle);
+    if (entry === undefined) throw new Error("timer is not scheduled");
+    scheduled.delete(handle);
+    entry.callback();
+  };
+  return {
+    clearTimeout,
+    fireLatest(timeout: number) {
+      const handle = latest(timeout);
+      if (handle === undefined) throw new Error(`no timer scheduled for ${timeout}`);
+      fire(handle);
+    },
+    handles,
+    latest,
+    pending: () => [...scheduled.values()],
+    setTimeout,
+  };
+}
+
+function stateReturning(...claims: DesktopUsagePingClaim[]): DesktopUsagePingStateStore {
+  const claimAttempt = vi.fn(async () => claims.shift() ?? { status: "unavailable" as const });
+  return { claimAttempt };
+}
+
+async function temporaryStateRoot(): Promise<string> {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), "desktop-usage-ping-controller-"));
+  temporaryRoots.push(temporaryRoot);
+  return join(temporaryRoot, "desktop-preferences-v1");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("desktop usage ping controller", () => {
+  it("claims durable state before sending the exact desktop payload", async () => {
+    const root = await temporaryStateRoot();
+    const target = join(root, DESKTOP_USAGE_PING_STATE_FILE_NAME);
+    const state = createDesktopUsagePingStateStore({
+      root,
+      createInstanceId: () => INSTANCE_ID,
+    });
+    const timers = fakeTimers();
+    const request = vi.fn(async (_url: string, init: RequestInit) => {
+      const persisted = JSON.parse(await readFile(target, "utf8")) as Record<string, unknown>;
+      expect(persisted.lastAttemptAt).toBe(12_345);
+      expect(init.signal?.aborted).toBe(false);
+    });
+    const controller = createDesktopUsagePingController({
+      releaseEligible: true,
+      version: "0.1.5",
+      channel: "macos",
+      state,
+      request,
+      now: () => 12_345,
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    await controller.start();
+
+    expect(request).toHaveBeenCalledOnce();
+    const [url, init] = request.mock.calls[0]!;
+    expect(url).toBe(DESKTOP_USAGE_PING_ENDPOINT);
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        product: "enduragent-desktop",
+        version: "0.1.5",
+        channel: "macos",
+        instance: INSTANCE_ID,
+      }),
+      credentials: "omit",
+      redirect: "error",
+      cache: "no-store",
+    });
+    expect(timers.setTimeout).toHaveBeenCalledWith(
+      expect.any(Function),
+      DESKTOP_USAGE_PING_TIMEOUT_MS,
+    );
+    expect(timers.pending()).toEqual([
+      expect.objectContaining({ timeout: DESKTOP_USAGE_PING_INTERVAL_MS }),
+    ]);
+    expect(timers.handles.every((handle) => vi.mocked(handle.unref).mock.calls.length === 1)).toBe(
+      true,
+    );
+    controller.close();
+  });
+
+  it("defers until the persisted daily window expires without sending", async () => {
+    const state = stateReturning({ status: "deferred", retryAfterMs: 7_000 });
+    const timers = fakeTimers();
+    const request = vi.fn();
+    const controller = createDesktopUsagePingController({
+      releaseEligible: true,
+      version: "0.1.5",
+      channel: "macos",
+      state,
+      request,
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    await controller.start();
+
+    expect(request).not.toHaveBeenCalled();
+    expect(timers.pending()).toEqual([expect.objectContaining({ timeout: 7_000 })]);
+    controller.close();
+  });
+
+  it("waits until the next daily window after request or storage failures", async () => {
+    const requestFailureState = stateReturning({ status: "claimed", instanceId: INSTANCE_ID });
+    const requestFailureTimers = fakeTimers();
+    const request = vi.fn(async () => {
+      throw new Error("synthetic request failure");
+    });
+    const requestFailureController = createDesktopUsagePingController({
+      releaseEligible: true,
+      version: "0.1.5",
+      channel: "macos",
+      state: requestFailureState,
+      request,
+      setTimeout: requestFailureTimers.setTimeout,
+      clearTimeout: requestFailureTimers.clearTimeout,
+    });
+
+    await expect(requestFailureController.start()).resolves.toBeUndefined();
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(requestFailureTimers.pending()).toEqual([
+      expect.objectContaining({ timeout: DESKTOP_USAGE_PING_INTERVAL_MS }),
+    ]);
+
+    const unavailableState = stateReturning({ status: "unavailable" });
+    const unavailableTimers = fakeTimers();
+    const unavailableRequest = vi.fn();
+    const unavailableController = createDesktopUsagePingController({
+      releaseEligible: true,
+      version: "0.1.5",
+      channel: "macos",
+      state: unavailableState,
+      request: unavailableRequest,
+      setTimeout: unavailableTimers.setTimeout,
+      clearTimeout: unavailableTimers.clearTimeout,
+    });
+
+    await unavailableController.start();
+
+    expect(unavailableRequest).not.toHaveBeenCalled();
+    expect(unavailableTimers.pending()).toEqual([
+      expect.objectContaining({ timeout: DESKTOP_USAGE_PING_INTERVAL_MS }),
+    ]);
+    requestFailureController.close();
+    unavailableController.close();
+  });
+
+  it("aborts a request after five seconds and does not overlap starts", async () => {
+    const state = stateReturning({ status: "claimed", instanceId: INSTANCE_ID });
+    const timers = fakeTimers();
+    let requestSignal: AbortSignal | undefined;
+    const request = vi.fn(
+      async (_url: string, init: RequestInit): Promise<void> =>
+        new Promise((_resolve, reject) => {
+          requestSignal = init.signal ?? undefined;
+          requestSignal?.addEventListener("abort", () => reject(new Error("aborted")), {
+            once: true,
+          });
+        }),
+    );
+    const controller = createDesktopUsagePingController({
+      releaseEligible: true,
+      version: "0.1.5",
+      channel: "macos",
+      state,
+      request,
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    const firstStart = controller.start();
+    await controller.start();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    timers.fireLatest(DESKTOP_USAGE_PING_TIMEOUT_MS);
+    await firstStart;
+
+    expect(requestSignal?.aborted).toBe(true);
+    expect(state.claimAttempt).toHaveBeenCalledOnce();
+    expect(timers.pending()).toEqual([
+      expect.objectContaining({ timeout: DESKTOP_USAGE_PING_INTERVAL_MS }),
+    ]);
+    controller.close();
+  });
+
+  it("closes idempotently, clears the daily timer, and aborts an active request", async () => {
+    const state = stateReturning({ status: "claimed", instanceId: INSTANCE_ID });
+    const timers = fakeTimers();
+    let requestSignal: AbortSignal | undefined;
+    const request = vi.fn(
+      async (_url: string, init: RequestInit): Promise<void> =>
+        new Promise((_resolve, reject) => {
+          requestSignal = init.signal ?? undefined;
+          requestSignal?.addEventListener("abort", () => reject(new Error("closed")), {
+            once: true,
+          });
+        }),
+    );
+    const controller = createDesktopUsagePingController({
+      releaseEligible: true,
+      version: "0.1.5",
+      channel: "macos",
+      state,
+      request,
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    const started = controller.start();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    controller.close();
+    controller.close();
+    await started;
+
+    expect(requestSignal?.aborted).toBe(true);
+    expect(timers.pending()).toEqual([]);
+    await controller.start();
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing when release eligibility or payload validation fails", async () => {
+    for (const releaseEligible of [false, true]) {
+      const state = stateReturning({ status: "claimed", instanceId: INSTANCE_ID });
+      const timers = fakeTimers();
+      const request = vi.fn();
+      const controller = createDesktopUsagePingController({
+        releaseEligible,
+        version: releaseEligible ? "not-a-release-version" : "0.1.5",
+        channel: "macos",
+        state,
+        request,
+        setTimeout: timers.setTimeout,
+        clearTimeout: timers.clearTimeout,
+      });
+
+      await controller.start();
+
+      expect(state.claimAttempt).not.toHaveBeenCalled();
+      expect(request).not.toHaveBeenCalled();
+      expect(timers.pending()).toEqual([]);
+    }
+  });
+});
+
+describe("desktop usage ping channel", () => {
+  it("maps only supported desktop platforms", () => {
+    expect(desktopUsagePingChannelForPlatform("darwin")).toBe("macos");
+    expect(desktopUsagePingChannelForPlatform("win32")).toBe("windows");
+    expect(desktopUsagePingChannelForPlatform("linux")).toBeUndefined();
+  });
+});

--- a/apps/desktop/tests/update-eligibility.test.ts
+++ b/apps/desktop/tests/update-eligibility.test.ts
@@ -4,6 +4,7 @@ import {
   DESKTOP_UPDATE_PLATFORM_ACTIVATION,
   DESKTOP_UPDATE_SUPPORTED_PLATFORMS,
   isDesktopUpdateReleaseEligible,
+  isOfficialDesktopRelease,
   type DesktopUpdatePlatform,
 } from "../src/main/update-eligibility.js";
 
@@ -22,6 +23,51 @@ function eligibility(
     ...overrides,
   });
 }
+
+function officialEligibility(
+  overrides: Partial<Parameters<typeof isOfficialDesktopRelease>[0]> = {},
+): boolean {
+  return isOfficialDesktopRelease({
+    isPackaged: true,
+    platform: "darwin",
+    securitySmokeMode: false,
+    appPath,
+    currentVersion: "0.1.0",
+    readPackageJson: () => JSON.stringify({ version: "0.1.0", enduragentDesktopRelease: true }),
+    ...overrides,
+  });
+}
+
+describe("official desktop release eligibility", () => {
+  it("accepts marked macOS and Windows packages independently of updater activation", () => {
+    expect(officialEligibility({ platform: "darwin" })).toBe(true);
+    expect(officialEligibility({ platform: "win32" })).toBe(true);
+  });
+
+  it.each([
+    { isPackaged: false },
+    { platform: "linux" as const },
+    { securitySmokeMode: true },
+    { currentVersion: "0.1.0-beta.1" },
+  ])("rejects a non-release runtime: %o", (runtime) => {
+    const readPackageJson = vi.fn(() => {
+      throw new Error("must not read");
+    });
+    expect(officialEligibility({ ...runtime, readPackageJson })).toBe(false);
+    expect(readPackageJson).not.toHaveBeenCalled();
+  });
+
+  it("requires the exact release marker and matching packaged version", () => {
+    expect(
+      officialEligibility({ readPackageJson: () => JSON.stringify({ version: "0.1.0" }) }),
+    ).toBe(false);
+    expect(
+      officialEligibility({
+        readPackageJson: () => JSON.stringify({ version: "0.1.1", enduragentDesktopRelease: true }),
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("desktop update release eligibility", () => {
   it("keeps Windows supported but inactive by default", () => {

--- a/guides/privacy.md
+++ b/guides/privacy.md
@@ -1,23 +1,39 @@
 # Privacy
 
 The full policy, covering both the website and the software, is at
-<https://enduragent.icu/privacy.html>. This page covers the one background request the self-hosted
-bot makes.
+<https://enduragent.icu/privacy.html>. This page covers the minimal background installation
+heartbeats made by the self-hosted bot and official Desktop releases.
 
 Your training data stays on your machine. There is no Enduragent account, no server of ours that
-holds your training history, and no analytics in the product. Your prompt and the training numbers
-in it go to the model provider you chose; your intervals.icu key goes to intervals.icu.
+holds your training history, and no behavioral analytics in the product. Your prompt and the
+training numbers in it go to the model provider you chose; your intervals.icu key goes to
+intervals.icu.
 
 Access to a self-hosted Telegram bot is limited to an allowlist you control — see
 [telegram.md](./telegram.md).
 
 ### Update checks & usage counting
 
-As part of its background version-check behavior, Cycling Coach can make an HTTPS request to `ping.enduragent.icu`. That endpoint returns the latest published version (the same answer `registry.npmjs.org` gives) and records an anonymous usage count so the project can see roughly how many instances are running across install channels. The count contains no personal information.
+As part of its background version-check behavior, Cycling Coach can make an HTTPS request to `ping.enduragent.icu`. That endpoint returns the latest published version (the same answer `registry.npmjs.org` gives) and records a pseudonymous installation count so the project can see roughly how many instances are running across install channels. The request contains no athlete data, message content, or credentials.
 
 The bot attempts telemetry on Telegram-mode startup and again every 24 hours, but a timestamp in the installation data directory limits it to at most once in any 24-hour period even across restarts. The timestamp is saved before the request, so a crash or an unreachable endpoint cannot retry telemetry for 24 hours. If the endpoint is unavailable or rate-limited, the bot silently falls back to `registry.npmjs.org` for the version result.
 
 Set `CYCLING_COACH_NO_UPDATE_CHECK=1` to disable the automatic background checks (both the startup check and the daily re-check). The operator-initiated `/update` and `/whatsnew` commands never initiate telemetry; their version lookups use `registry.npmjs.org` and reuse a recent or already-running result. `/whatsnew` also reaches the GitHub Releases API for release notes. In managed container deploys, `/update` does not run npm; image hosts update by redeploying the container image.
+
+An official Desktop release separately attempts an HTTPS installation heartbeat at startup and on
+its daily timer. A timestamp in the Desktop preferences directory limits it to at most once in any
+24-hour period across restarts and is saved before the request, so an unavailable endpoint is not
+retried until the next daily opportunity. The request contains only `enduragent-desktop`, the app
+version, the platform channel (`macos` or `windows`), and a random UUID generated once and stored in
+that preferences directory. It contains no athlete data, message content, credentials,
+configuration, hardware identifier, or feature activity. Set `ENDURAGENT_NO_USAGE_PING=1` before
+launch to disable it; disabled and unofficial builds create no heartbeat state.
+
+The heartbeat endpoint stores those four fields, a count, and the time the request was received for
+up to three months so the project can estimate active installations. Like any HTTPS service, its
+hosting provider can receive ordinary network metadata such as an IP address and user agent. The
+Desktop updater remains separate: it checks the public GitHub release feed directly and never
+depends on the heartbeat endpoint.
 
 Desktop does not fetch release notes in the background. Choosing **What’s new** explicitly contacts
 `registry.npmjs.org` for the latest published version and the GitHub Releases API for that exact


### PR DESCRIPTION
## Summary

- Add a best-effort daily installation heartbeat for official stable Desktop packages on macOS and Windows.
- Persist one random installation UUID and durably claim each attempt before networking so restarts and failures do not cause immediate retries.
- Keep heartbeat eligibility independent from updater activation, add the `ENDURAGENT_NO_USAGE_PING=1` opt-out, and disclose the exact payload and local storage behavior.

## Request contract

Desktop sends `POST https://ping.enduragent.icu/v1/ping` with exactly `product`, `version`, `channel`, and a persisted lowercase UUID v4 `instance`. The request omits credentials, rejects redirects, bypasses caches, and silently ignores failures.

The heartbeat runs only in marked, packaged, stable releases. Development, prerelease, security-smoke, hidden-acceptance, unsupported-platform, and opted-out runs create no heartbeat state.

## Limits

- Heartbeat cadence: `86,400,000 ms` — at most one attempt per rolling 24-hour window across restarts.
- Network deadline: `5,000 ms` — the heartbeat must never delay normal Desktop use.
- State-file maximum: `256 bytes` — reject unexpected or expanded local state.
- POSIX directory/file modes: `0700` / `0600` — keep the installation UUID private to the local user.
- Temporary-file suffix: `1–128` safe characters — bound recovery cleanup without broad file matching.

## Validation

- `pnpm check` — passed.
- `pnpm exec vitest run apps/desktop/tests/desktop-usage-ping-state.test.ts apps/desktop/tests/desktop-usage-ping.test.ts apps/desktop/tests/desktop-usage-ping-wiring.test.ts apps/desktop/tests/update-eligibility.test.ts` — 44 tests passed.
- Packaged macOS end-to-end test — one `enduragent-desktop` Analytics Engine row recorded; relaunch recorded no duplicate.
- Codex autoreview against `origin/main` — clean, no accepted/actionable findings.

The production Worker endpoint is already deployed and verified.
