### PR TITLE
fix(chat): recover durable queue after disconnect

### DIFF
--- a/.changeset/recover-chat-queue-retry.md
+++ b/.changeset/recover-chat-queue-retry.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/engine": patch
+"@enduragent/coach": patch
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Stopping a Chat response or losing connection now keeps the interrupted message retryable and sends later queued messages once, in order.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -158,9 +158,27 @@ interface QueuedRetry {
   readonly token: object;
 }
 
+type ChatQueueCall =
+  | {
+      readonly method: "runQueuedCommand";
+      readonly queuedMessageId: string;
+      readonly queuedMessageIds: readonly string[];
+    }
+  | {
+      readonly method: "retryQueuedTurn";
+      readonly claimId: string;
+      readonly queuedMessageIds: readonly string[];
+    }
+  | { readonly method: "resumeChatQueue"; readonly queuedMessageIds: readonly string[] };
+
+interface InterruptedQueueOrigin {
+  readonly requestKey: number;
+  readonly call: ChatQueueCall;
+}
+
 interface ChatRun {
   readonly task: Promise<void>;
-  completed(): boolean;
+  shouldDrain(): boolean;
 }
 
 interface ActiveStopRequest {
@@ -209,6 +227,7 @@ export function createChatController(input: {
   let activeTask: Promise<void> | undefined;
   const outstandingChatTasks = new Set<Promise<void>>();
   let queuedRetry: QueuedRetry | undefined;
+  let interruptedQueueOrigin: InterruptedQueueOrigin | undefined;
   let retryClient: CoachClient | undefined;
   let probeTask: Promise<void> | undefined;
   let resetTask: Promise<void> | undefined;
@@ -354,25 +373,15 @@ export function createChatController(input: {
     userMessage: string,
     includeUser: boolean,
     reconnect: boolean,
-    queueCall?:
-      | {
-          readonly method: "runQueuedCommand";
-          readonly queuedMessageId: string;
-          readonly queuedMessageIds: readonly string[];
-        }
-      | {
-          readonly method: "retryQueuedTurn";
-          readonly claimId: string;
-          readonly queuedMessageIds: readonly string[];
-        }
-      | { readonly method: "resumeChatQueue"; readonly queuedMessageIds: readonly string[] },
+    queueCall?: ChatQueueCall,
     attachments: readonly ChatSentAttachment[] = [],
+    reconnectQueueOrigin?: ChatQueueCall,
   ): ChatRun => {
     epoch += 1;
     const requestKey = Number(nextId("request").slice("request-".length));
     const userMessageId = nextId("message");
     const assistantMessageId = nextId("message");
-    let completed = false;
+    let shouldDrain = false;
     reduce({
       type: "submit",
       requestKey,
@@ -384,6 +393,8 @@ export function createChatController(input: {
     });
     let callStarted = false;
     const task = (async () => {
+      const immutableQueueOrigin = queueCall ?? reconnectQueueOrigin;
+      let activeQueueCall = immutableQueueOrigin;
       let boundRequestId: string | number | undefined;
       let boundTurnId: string | undefined;
       let pendingEnvelope: CoachTurnEventNotificationEnvelope | undefined;
@@ -400,6 +411,12 @@ export function createChatController(input: {
       let stopRequested = false;
       let stopTask: Promise<void> | undefined;
       const current = (): boolean => !disposed && state.activeTurn?.requestKey === requestKey;
+      const preserveInterruptedQueueOrigin = (): void => {
+        interruptedQueueOrigin =
+          immutableQueueOrigin === undefined
+            ? undefined
+            : { requestKey, call: immutableQueueOrigin };
+      };
       const failProtocol = (): void => {
         if (protocolFault) return;
         protocolFault = true;
@@ -429,6 +446,40 @@ export function createChatController(input: {
           client = await input.clients.getClient();
         }
         if (!current()) return;
+        if (reconnect || reconnectQueueOrigin !== undefined) {
+          const snapshot = await refreshQueue(client);
+          if (reconnectQueueOrigin !== undefined) {
+            const originIds = reconnectQueueOrigin.queuedMessageIds;
+            const matchesOrigin = (ids: readonly string[]): boolean =>
+              ids.length === originIds.length && ids.every((id, index) => id === originIds[index]);
+            const recovery = snapshot.retryRequired;
+            if (recovery !== undefined && matchesOrigin(recovery.queuedMessageIds)) {
+              activeQueueCall = {
+                method: "retryQueuedTurn",
+                claimId: recovery.claimId,
+                queuedMessageIds: recovery.queuedMessageIds,
+              };
+            } else if (
+              recovery === undefined &&
+              matchesOrigin(
+                snapshot.items.slice(0, originIds.length).map((item) => item.queuedMessageId),
+              )
+            ) {
+              activeQueueCall = reconnectQueueOrigin;
+            } else if (
+              recovery === undefined &&
+              originIds.every((id) => !snapshot.items.some((item) => item.queuedMessageId === id))
+            ) {
+              interruptedQueueOrigin = undefined;
+              reduce({ type: "discard-submission", requestKey });
+              shouldDrain = true;
+              return;
+            } else {
+              throw new CoachClientProtocolError();
+            }
+          }
+        }
+        if (!current()) return;
         callStarted = true;
         const callOptions = {
           signal: callAbortController.signal,
@@ -436,7 +487,7 @@ export function createChatController(input: {
             if (!current() || protocolFault) return;
             if (
               envelope.method !== "coach.turnEvent" ||
-              envelope.params.requestMethod !== (queueCall?.method ?? "chat") ||
+              envelope.params.requestMethod !== (activeQueueCall?.method ?? "chat") ||
               envelope.params.turnId.length === 0
             ) {
               failProtocol();
@@ -484,8 +535,8 @@ export function createChatController(input: {
                 return;
               }
               startSeen = true;
-              if (queueCall !== undefined) {
-                reduce({ type: "queue-claimed", ids: queueCall.queuedMessageIds });
+              if (activeQueueCall !== undefined) {
+                reduce({ type: "queue-claimed", ids: activeQueueCall.queuedMessageIds });
               }
             }
             let appendDelta: ChatAppendDelta | undefined;
@@ -543,18 +594,21 @@ export function createChatController(input: {
           },
         } satisfies CoachClientCallOptions<"chat">;
         const queuedResult =
-          queueCall?.method === "resumeChatQueue"
+          activeQueueCall?.method === "resumeChatQueue"
             ? await client.call("resumeChatQueue", { chatId: DESKTOP_CHAT_ID }, callOptions)
-            : queueCall?.method === "runQueuedCommand"
+            : activeQueueCall?.method === "runQueuedCommand"
               ? await client.call(
                   "runQueuedCommand",
-                  { chatId: DESKTOP_CHAT_ID, queuedMessageId: queueCall.queuedMessageId },
+                  {
+                    chatId: DESKTOP_CHAT_ID,
+                    queuedMessageId: activeQueueCall.queuedMessageId,
+                  },
                   callOptions,
                 )
-              : queueCall?.method === "retryQueuedTurn"
+              : activeQueueCall?.method === "retryQueuedTurn"
                 ? await client.call(
                     "retryQueuedTurn",
-                    { chatId: DESKTOP_CHAT_ID, claimId: queueCall.claimId },
+                    { chatId: DESKTOP_CHAT_ID, claimId: activeQueueCall.claimId },
                     callOptions,
                   )
                 : undefined;
@@ -573,7 +627,14 @@ export function createChatController(input: {
           queuedResult.response === undefined &&
           boundTurnId === undefined
         ) {
+          interruptedQueueOrigin = undefined;
           reduce({ type: "discard-submission", requestKey });
+          shouldDrain =
+            activeQueueCall?.method === "retryQueuedTurn" &&
+            queuedResult.snapshot.retryRequired === undefined &&
+            activeQueueCall.queuedMessageIds.every(
+              (id) => !queuedResult.snapshot.items.some((item) => item.queuedMessageId === id),
+            );
           return;
         }
         if (interruptedText !== undefined) {
@@ -586,12 +647,14 @@ export function createChatController(input: {
           ) {
             retryClient = client;
             retryReconnect = true;
+            preserveInterruptedQueueOrigin();
             reduce({ type: "interrupt", requestKey, copy: CHAT_PROTOCOL_FAILURE_COPY });
             return;
           }
           retryClient = undefined;
           retryReconnect = false;
-          completed = true;
+          preserveInterruptedQueueOrigin();
+          shouldDrain = true;
           return;
         }
         if (requestedDecision !== undefined) {
@@ -604,9 +667,11 @@ export function createChatController(input: {
             retryClient = client;
             retryReconnect = true;
             decision = null;
+            preserveInterruptedQueueOrigin();
             reduce({ type: "interrupt", requestKey, copy: CHAT_PROTOCOL_FAILURE_COPY });
             return;
           }
+          interruptedQueueOrigin = undefined;
           reduce({ type: "discard", requestKey });
           return;
         }
@@ -621,20 +686,23 @@ export function createChatController(input: {
         ) {
           retryClient = client;
           retryReconnect = true;
+          preserveInterruptedQueueOrigin();
           reduce({ type: "interrupt", requestKey, copy: CHAT_PROTOCOL_FAILURE_COPY });
           return;
         }
         if (!/\S/u.test(finalText)) {
           retryClient = client;
           retryReconnect = true;
+          preserveInterruptedQueueOrigin();
           reduce({ type: "interrupt", requestKey, copy: CHAT_EMPTY_RESPONSE_COPY });
           return;
         }
+        interruptedQueueOrigin = undefined;
         reduce({ type: "complete", requestKey });
-        completed = state.status === "idle" && state.activeTurn?.requestKey === requestKey;
+        shouldDrain = state.status === "idle" && state.activeTurn?.requestKey === requestKey;
       } catch (error) {
         if (!current()) return;
-        if (queueCall !== undefined && client !== undefined) {
+        if (activeQueueCall !== undefined && client !== undefined) {
           try {
             applyQueueSnapshot(await client.call("getChatQueue", { chatId: DESKTOP_CHAT_ID }));
           } catch {}
@@ -642,6 +710,7 @@ export function createChatController(input: {
         if (protocolFault || error instanceof CoachClientProtocolError) {
           retryClient = client;
           retryReconnect = true;
+          preserveInterruptedQueueOrigin();
           reduce({ type: "interrupt", requestKey, copy: CHAT_PROTOCOL_FAILURE_COPY });
         } else if (
           error instanceof CoachClientDisconnectedError ||
@@ -650,8 +719,10 @@ export function createChatController(input: {
         ) {
           retryClient = client;
           retryReconnect = true;
+          preserveInterruptedQueueOrigin();
           reduce({ type: "interrupt", requestKey, copy: CHAT_CONNECTION_INTERRUPTED_COPY });
         } else {
+          interruptedQueueOrigin = undefined;
           reduce({ type: "fail", requestKey, copy: CHAT_FAILURE_COPY });
         }
       } finally {
@@ -676,32 +747,22 @@ export function createChatController(input: {
       }
       if (released) render();
     });
-    return { task, completed: () => completed };
+    return { task, shouldDrain: () => shouldDrain };
   };
 
   const dispatch = (
     userMessage: string,
     includeUser: boolean,
     reconnect: boolean,
+    queueOrigin?: ChatQueueCall,
   ): Promise<void> => {
-    const chatRun = run(userMessage, includeUser, reconnect);
-    return chatRun.task.then(() => (chatRun.completed() ? drain() : undefined));
+    const chatRun = run(userMessage, includeUser, reconnect, undefined, [], queueOrigin);
+    return chatRun.task.then(() => (chatRun.shouldDrain() ? drain() : undefined));
   };
 
   const dispatchQueue = (
     userMessage: string,
-    queueCall:
-      | {
-          readonly method: "runQueuedCommand";
-          readonly queuedMessageId: string;
-          readonly queuedMessageIds: readonly string[];
-        }
-      | {
-          readonly method: "retryQueuedTurn";
-          readonly claimId: string;
-          readonly queuedMessageIds: readonly string[];
-        }
-      | { readonly method: "resumeChatQueue"; readonly queuedMessageIds: readonly string[] },
+    queueCall: ChatQueueCall,
     includeUser = true,
   ): Promise<void> => {
     const attachments = queueCall.queuedMessageIds
@@ -709,7 +770,7 @@ export function createChatController(input: {
       .map((id) => attachmentSummaries.get(id))
       .filter((attachment): attachment is ChatSentAttachment => attachment !== undefined);
     const chatRun = run(userMessage, includeUser, false, queueCall, attachments);
-    return chatRun.task.then(() => (chatRun.completed() ? drain() : undefined));
+    return chatRun.task.then(() => (chatRun.shouldDrain() ? drain() : undefined));
   };
 
   const answerLabel = (
@@ -740,14 +801,15 @@ export function createChatController(input: {
     return decision;
   };
 
-  const refreshQueue = async (client?: CoachClient): Promise<void> => {
+  const refreshQueue = async (client?: CoachClient): Promise<ChatQueueSnapshot> => {
     const activeClient = client ?? (await input.clients.getClient());
     const snapshot = await activeClient.call("getChatQueue", { chatId: DESKTOP_CHAT_ID });
-    if (disposed) return;
+    if (disposed) return snapshot;
     applyQueueSnapshot(snapshot);
     queueLoaded = true;
     queueLoadError = null;
     render();
+    return snapshot;
   };
 
   const refreshAttachments = async (client?: CoachClient): Promise<void> => {
@@ -1653,8 +1715,13 @@ export function createChatController(input: {
         return activeTask ?? Promise.resolve();
       }
       const { requestKey, userMessage } = state.activeTurn;
+      const queueOrigin =
+        interruptedQueueOrigin?.requestKey === requestKey ? interruptedQueueOrigin.call : undefined;
       if (queuedRetry?.requestKey === requestKey) return queuedRetry.promise;
-      if (activeTask === undefined) return dispatch(userMessage, false, retryReconnect);
+      if (activeTask === undefined) {
+        interruptedQueueOrigin = undefined;
+        return dispatch(userMessage, false, retryReconnect, queueOrigin);
+      }
       const currentTask = activeTask;
       const token = {};
       const pending = currentTask
@@ -1667,7 +1734,8 @@ export function createChatController(input: {
           ) {
             return;
           }
-          return dispatch(userMessage, false, retryReconnect);
+          interruptedQueueOrigin = undefined;
+          return dispatch(userMessage, false, retryReconnect, queueOrigin);
         })
         .finally(() => {
           if (queuedRetry?.token === token) {
@@ -1756,6 +1824,7 @@ export function createChatController(input: {
           sequence += 1;
           retryClient = undefined;
           queuedRetry = undefined;
+          interruptedQueueOrigin = undefined;
           decision = null;
           decisionLoaded = true;
           decisionLoadError = null;
@@ -1836,6 +1905,7 @@ export function createChatController(input: {
     dispose() {
       disposed = true;
       activeStopRequest = undefined;
+      interruptedQueueOrigin = undefined;
       hydrator.dispose();
       decision = null;
       epoch += 1;

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -173,16 +173,29 @@ function client(
 ): CoachClient {
   let queueRevision = 0;
   const queued: QueuedChatMessage[] = [];
+  let retryRequired: ChatQueueSnapshot["retryRequired"];
+  let claimSequence = 0;
   const snapshot = (): ChatQueueSnapshot => ({
     schemaVersion: 1,
     revision: queueRevision,
     items: queued.map((item, position) => ({ ...item, position })),
+    ...(retryRequired === undefined ? {} : { retryRequired }),
   });
   const acknowledge = (items: readonly QueuedChatMessage[]): void => {
     const ids = new Set(items.map((item) => item.queuedMessageId));
     for (let index = queued.length - 1; index >= 0; index -= 1) {
       if (ids.has(queued[index]!.queuedMessageId)) queued.splice(index, 1);
     }
+    queueRevision += 1;
+  };
+  const requireRetry = (items: readonly QueuedChatMessage[], turnId: string): void => {
+    const ids = items.map((item) => item.queuedMessageId);
+    retryRequired = {
+      claimId: retryRequired?.claimId ?? `claim-${++claimSequence}`,
+      queuedMessageIds: ids,
+      turnId,
+      status: "retry-required",
+    };
     queueRevision += 1;
   };
   const call = vi.fn((method, request, options) => {
@@ -282,18 +295,37 @@ function client(
       acknowledge(queued.filter((item) => item.queuedMessageId === value.queuedMessageId));
       return Promise.resolve(snapshot()) as never;
     }
-    if (method === "resumeChatQueue" || method === "runQueuedCommand") {
+    if (
+      method === "resumeChatQueue" ||
+      method === "runQueuedCommand" ||
+      method === "retryQueuedTurn"
+    ) {
       hideQueueCall();
-      const head = queued[0];
-      if (head === undefined) return Promise.resolve({ snapshot: snapshot() }) as never;
-      const commandIndex = queued.findIndex((item) => item.kind === "slash-command");
-      const group =
-        head.kind === "slash-command"
+      const group = (() => {
+        if (method === "retryQueuedTurn") {
+          const claimId = (request as { claimId: string }).claimId;
+          if (retryRequired?.claimId !== claimId) return [];
+          const ids = new Set(retryRequired.queuedMessageIds);
+          return queued.filter((item) => ids.has(item.queuedMessageId));
+        }
+        const head = queued[0];
+        if (head === undefined) return [];
+        const commandIndex = queued.findIndex((item) => item.kind === "slash-command");
+        return head.kind === "slash-command"
           ? [head]
           : queued.slice(0, commandIndex === -1 ? queued.length : commandIndex);
+      })();
+      if (group.length === 0) return Promise.resolve({ snapshot: snapshot() }) as never;
+      let turnId = retryRequired?.turnId ?? "turn-1";
+      let interrupted = false;
       const queueOptions = {
         ...(options as CoachClientCallOptions<"chat">),
         requestMethod: method,
+        onEvent(event: TurnEvent) {
+          turnId = event.turnId;
+          if (event.type === "interrupted") interrupted = true;
+          (options as CoachClientCallOptions<"chat"> | undefined)?.onEvent?.(event);
+        },
       };
       const response = call(
         "chat",
@@ -302,11 +334,16 @@ function client(
       ) as Promise<{ text: string }>;
       return response.then(
         (value) => {
-          acknowledge(group);
+          if (interrupted) {
+            requireRetry(group, turnId);
+          } else {
+            retryRequired = undefined;
+            acknowledge(group);
+          }
           return { snapshot: snapshot(), response: value };
         },
         (error: unknown) => {
-          acknowledge(group);
+          requireRetry(group, turnId);
           throw error;
         },
       ) as never;
@@ -659,7 +696,8 @@ describe("chat controller", () => {
     });
     expect(firstOptions?.signal?.aborted).toBe(false);
 
-    await controller.retryInterrupted();
+    expect(states.at(-1)?.retryRequired?.claimId).toBe("claim-1");
+    await controller.retryQueuedTurn("claim-1");
 
     expect(provider.reconnect).not.toHaveBeenCalled();
     expect(states.at(-1)?.messages.at(-1)).toMatchObject({
@@ -971,27 +1009,27 @@ describe("chat controller", () => {
   });
 
   it("preserves a disconnected draft and retries explicitly without duplicating the user row", async () => {
-    const first = client(async (_request, options) => {
-      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
-      throw new CoachClientDisconnectedError(1006, "synthetic");
-    });
-    const second = client(async (_request, options) => {
+    let attempt = 0;
+    const fake = client(async (_request, options) => {
+      attempt += 1;
+      if (attempt === 1) {
+        deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+        throw new CoachClientDisconnectedError(1006, "synthetic");
+      }
       deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
       options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { text: "Recovered" } });
       return { text: "Recovered" };
     });
-    const { controller, provider, states, refresh } = subject(first, second);
+    const { controller, provider, states, refresh } = subject(fake);
     await controller.submit("Same message");
     expect(states.at(-1)?.progress).toBe(CHAT_CONNECTION_INTERRUPTED_COPY);
-    const retry = controller.retryInterrupted();
+    expect(states.at(-1)?.retryRequired?.claimId).toBe("claim-1");
+    const retry = controller.retryQueuedTurn("claim-1");
     expect(states.at(-1)?.progress).toBe(CHAT_WORKING_COPY);
     expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
     await retry;
-    expect(provider.reconnect).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(second.call).mock.calls[0]?.[1]).toEqual({
-      chatId: "desktop",
-      message: "Same message",
-    });
+    expect(provider.reconnect).not.toHaveBeenCalled();
+    expect(chatMessages(fake)).toEqual(["Same message", "Same message"]);
     expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
     expect(refresh).toHaveBeenCalledTimes(2);
   });
@@ -1002,11 +1040,13 @@ describe("chat controller", () => {
   ])(
     "preserves a draft after $name and makes one new call only on explicit retry",
     async (failure) => {
-      const first = client(async (_request, options) => {
-        deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
-        throw failure;
-      });
-      const second = client(async (_request, options) => {
+      let attempt = 0;
+      const fake = client(async (_request, options) => {
+        attempt += 1;
+        if (attempt === 1) {
+          deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+          throw failure;
+        }
         deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
         options?.onTerminalEnvelope?.({
           jsonrpc: "2.0",
@@ -1015,20 +1055,21 @@ describe("chat controller", () => {
         });
         return { text: "Recovered" };
       });
-      const { controller, provider, states } = subject(first, second);
+      const { controller, provider, states } = subject(fake);
 
       await controller.submit("Same message");
 
       expect(states.at(-1)?.status).toBe("interrupted");
       expect(states.at(-1)?.progress).toBe(CHAT_CONNECTION_INTERRUPTED_COPY);
       expect(states.at(-1)?.messages.at(-1)?.text).toBe("Partial");
-      expect(first.call).toHaveBeenCalledTimes(1);
-      expect(second.call).not.toHaveBeenCalled();
+      expect(chatMessages(fake)).toHaveLength(1);
       expect(provider.reconnect).not.toHaveBeenCalled();
 
-      await controller.retryInterrupted();
+      expect(states.at(-1)?.retryRequired?.claimId).toBe("claim-1");
+      await controller.retryQueuedTurn("claim-1");
 
-      expect(second.call).toHaveBeenCalledTimes(1);
+      expect(chatMessages(fake)).toHaveLength(2);
+      expect(provider.reconnect).not.toHaveBeenCalled();
       expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(
         1,
       );
@@ -1036,36 +1077,22 @@ describe("chat controller", () => {
     },
   );
 
-  it("reuses a shared recovered client when retrying a stale interrupted turn", async () => {
-    let current: CoachClient;
-    const recovered = client(async (_request, options) => {
+  it("retries a durable interrupted turn through the current client", async () => {
+    let attempt = 0;
+    const fake = client(async (_request, options) => {
+      attempt += 1;
+      if (attempt === 1) throw new CoachClientDisconnectedError(1006, "synthetic");
       deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
       options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { text: "Recovered" } });
       return { text: "Recovered" };
     });
-    const failed = client(async () => {
-      current = recovered;
-      throw new CoachClientDisconnectedError(1006, "synthetic");
-    });
-    current = failed;
-    const provider: DesktopCoachClientProvider = {
-      getClient: vi.fn(async () => current),
-      reconnect: vi.fn(async () => recovered),
-      close: vi.fn(async () => {}),
-    };
-    const states: ChatState[] = [];
-    const controller = createChatController({
-      clients: provider,
-      view: { render: (state) => states.push(structuredClone(state)) },
-      refreshTrainingContext: vi.fn(async () => {}),
-      refreshSpend: vi.fn(async () => {}),
-      initialQueueSnapshot: { schemaVersion: 1, revision: 0, items: [] },
-    });
+    const { controller, provider, states } = subject(fake);
     await controller.submit("Same message");
     await vi.waitFor(() => expect(states.at(-1)?.status).toBe("interrupted"));
-    await controller.retryInterrupted();
+    expect(states.at(-1)?.retryRequired?.claimId).toBe("claim-1");
+    await controller.retryQueuedTurn("claim-1");
     expect(provider.reconnect).not.toHaveBeenCalled();
-    expect(recovered.call).toHaveBeenCalledTimes(1);
+    expect(chatMessages(fake)).toHaveLength(2);
     expect(states.at(-1)?.messages.at(-1)?.text).toBe("Recovered");
   });
 
@@ -1075,11 +1102,13 @@ describe("chat controller", () => {
       release = resolve;
     });
     let refreshCalls = 0;
-    const first = client(async (_request, options) => {
-      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
-      throw new CoachClientDisconnectedError(1006, "synthetic");
-    });
-    const second = client(async (_request, options) => {
+    let attempt = 0;
+    const fake = client(async (_request, options) => {
+      attempt += 1;
+      if (attempt === 1) {
+        deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+        throw new CoachClientDisconnectedError(1006, "synthetic");
+      }
       deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
       options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { text: "Recovered" } });
       return { text: "Recovered" };
@@ -1089,8 +1118,8 @@ describe("chat controller", () => {
       interrupted = resolve;
     });
     const provider: DesktopCoachClientProvider = {
-      getClient: vi.fn(async () => first),
-      reconnect: vi.fn(async () => second),
+      getClient: vi.fn(async () => fake),
+      reconnect: vi.fn(async () => fake),
       close: vi.fn(async () => {}),
     };
     let latestState = EMPTY_CHAT_STATE;
@@ -1111,15 +1140,16 @@ describe("chat controller", () => {
     });
     const submission = controller.submit("Same message");
     await interruptedState;
-    const retry = controller.retryInterrupted();
-    const duplicate = controller.retryInterrupted();
+    expect(latestState.retryRequired?.claimId).toBe("claim-1");
+    const retry = controller.retryQueuedTurn("claim-1");
+    const duplicate = controller.retryQueuedTurn("claim-1");
     expect(latestState.progress).toBe(CHAT_WORKING_COPY);
     expect(latestState.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
     expect(controller.openNewConversation()).toBe(false);
     release();
     await Promise.all([submission, retry, duplicate]);
-    expect(provider.reconnect).toHaveBeenCalledTimes(1);
-    expect(second.call).toHaveBeenCalledTimes(1);
+    expect(provider.reconnect).not.toHaveBeenCalled();
+    expect(chatMessages(fake)).toHaveLength(2);
   });
 
   it("allows one in-flight call and treats client protocol rejection as explicit-retry state", async () => {
@@ -1800,33 +1830,35 @@ describe("chat controller", () => {
     );
   });
 
-  it("blocks submit and retry while confirmation is open, then cancel permits retry", async () => {
-    const interrupted = client(async (_request, options) => {
-      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
-      throw new CoachClientDisconnectedError(1006, "synthetic");
-    });
-    const recovered = client(async (_request, options) => {
+  it("blocks new conversation until durable retry resolves, then confirmation blocks submit", async () => {
+    let attempt = 0;
+    const fake = client(async (_request, options) => {
+      attempt += 1;
+      if (attempt === 1) {
+        deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+        throw new CoachClientDisconnectedError(1006, "synthetic");
+      }
       deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
       options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { text: "Recovered" } });
       return { text: "Recovered" };
     });
-    const { controller } = subject(interrupted, recovered);
+    const { controller, states } = subject(fake);
     await controller.submit("Original");
+    expect(controller.openNewConversation()).toBe(false);
+    expect(states.at(-1)?.retryRequired?.claimId).toBe("claim-1");
+    await controller.retryQueuedTurn("claim-1");
     expect(controller.openNewConversation()).toBe(true);
-    vi.mocked(interrupted.call).mockClear();
+    vi.mocked(fake.call).mockClear();
 
     await Promise.all([controller.submit("Blocked"), controller.retryInterrupted()]);
-    expect(interrupted.call).not.toHaveBeenCalled();
-    expect(recovered.call).not.toHaveBeenCalled();
+    expect(fake.call).not.toHaveBeenCalled();
 
     controller.cancelNewConversation();
     expect(controller.openNewConversation()).toBe(true);
     controller.cancelNewConversation();
-    await controller.retryInterrupted();
-    expect(recovered.call).toHaveBeenCalledTimes(1);
-    expect(
-      vi.mocked(interrupted.call).mock.calls.filter(([method]) => method === "resetSession"),
-    ).toEqual([]);
+    expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession")).toEqual(
+      [],
+    );
   });
 
   it.each([
@@ -1921,26 +1953,36 @@ describe("chat controller", () => {
     ).toHaveLength(0);
   });
 
-  it("preserves interrupted retry ownership after an uncertain reset", async () => {
-    const interrupted = client(
+  it("blocks reset while a durable retry is unresolved and preserves retry ownership", async () => {
+    let attempt = 0;
+    const fake = client(
       async (_request, options) => {
-        deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
-        throw new CoachClientDisconnectedError(1006, "synthetic");
+        attempt += 1;
+        if (attempt === 1) {
+          deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+          throw new CoachClientDisconnectedError(1006, "synthetic");
+        }
+        deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
+        options?.onTerminalEnvelope?.({
+          jsonrpc: "2.0",
+          id: 2,
+          result: { text: "Recovered" },
+        });
+        return { text: "Recovered" };
       },
       { resetSession: async () => Promise.reject(new Error("uncertain")) },
     );
-    const recovered = client(async (_request, options) => {
-      deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
-      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { text: "Recovered" } });
-      return { text: "Recovered" };
-    });
-    const { controller, provider, states } = subject(interrupted, recovered);
+    const { controller, provider, states } = subject(fake);
     await controller.submit("Original");
-    expect(controller.openNewConversation()).toBe(true);
+    expect(controller.openNewConversation()).toBe(false);
     await controller.confirmNewConversation();
-    await controller.retryInterrupted();
+    expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession")).toEqual(
+      [],
+    );
+    expect(states.at(-1)?.retryRequired?.claimId).toBe("claim-1");
+    await controller.retryQueuedTurn("claim-1");
 
-    expect(provider.reconnect).toHaveBeenCalledTimes(1);
+    expect(provider.reconnect).not.toHaveBeenCalled();
     expect(states.at(-1)?.messages.at(-1)?.text).toBe("Recovered");
   });
 
@@ -1949,13 +1991,7 @@ describe("chat controller", () => {
     const resetGate = new Promise<{ memoryFlushed: boolean }>((resolve) => {
       settleReset = resolve;
     });
-    const fake = client(
-      async (_request, options) => {
-        deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
-        throw new CoachClientDisconnectedError(1006, "synthetic");
-      },
-      { resetSession: async () => resetGate },
-    );
+    const fake = client(replies(), { resetSession: async () => resetGate });
     const { controller } = subject(fake);
     await controller.submit("Original");
     expect(controller.openNewConversation()).toBe(true);

--- a/apps/desktop-renderer/tests/chat-queue-recovery.test.ts
+++ b/apps/desktop-renderer/tests/chat-queue-recovery.test.ts
@@ -6,6 +6,7 @@ import type {
   TurnEvent,
 } from "@enduragent/coach-contract";
 import type { CoachClient, CoachClientCallOptions } from "@enduragent/coach-client";
+import { CoachClientDisconnectedError } from "@enduragent/coach-client";
 import {
   CHAT_QUEUE_REMOVE_FAILURE_COPY,
   createChatController,
@@ -16,10 +17,12 @@ import type { ChatState } from "../src/turn-state.js";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((settle) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((settle, fail) => {
     resolve = settle;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function notification(
@@ -42,10 +45,14 @@ function deliver(
   options.onEvent?.(event);
 }
 
-function harness(client: CoachClient, canChat: () => boolean = () => true) {
+function harness(
+  client: CoachClient,
+  canChat: () => boolean = () => true,
+  clientProvider?: DesktopCoachClientProvider,
+) {
   const states: ChatState[] = [];
   const controls: ChatViewControls[] = [];
-  const provider: DesktopCoachClientProvider = {
+  const provider: DesktopCoachClientProvider = clientProvider ?? {
     getClient: vi.fn(async () => client),
     reconnect: vi.fn(async () => client),
     close: vi.fn(async () => {}),
@@ -62,7 +69,76 @@ function harness(client: CoachClient, canChat: () => boolean = () => true) {
     refreshSpend: async () => {},
     canChat,
   });
-  return { controller, states, controls };
+  return { controller, states, controls, provider };
+}
+
+function ordinaryQueueItem(
+  id: number,
+  text: string,
+  position: number,
+): ChatQueueSnapshot["items"][number] {
+  return {
+    queuedMessageId: `queued-${id}`,
+    messageId: `message-${id}`,
+    submissionId: `submission-${id}`,
+    text,
+    kind: "ordinary",
+    attachmentIds: [],
+    position,
+    restored: false,
+  };
+}
+
+function disconnectedQueueHarness(
+  recovered: CoachClient,
+  enqueueSnapshots: readonly ChatQueueSnapshot[],
+) {
+  const activeRun = deferred<ChatQueueRunResult>();
+  let activeOptions: CoachClientCallOptions<"chat"> | undefined;
+  let disconnected = false;
+  let enqueueCount = 0;
+  const failed: CoachClient = {
+    handshake: {} as CoachClient["handshake"],
+    call: vi.fn((method, _request, options) => {
+      if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+      if (method === "hasSession") return Promise.resolve({ hasSession: false }) as never;
+      if (method === "getChatQueue") {
+        return disconnected
+          ? (Promise.reject(new CoachClientDisconnectedError(1006, "lost")) as never)
+          : (Promise.resolve({ schemaVersion: 1, revision: 0, items: [] }) as never);
+      }
+      if (method === "enqueueChatMessage") {
+        const snapshot = enqueueSnapshots[enqueueCount];
+        enqueueCount += 1;
+        if (snapshot === undefined) throw new TypeError("Unexpected enqueue");
+        return Promise.resolve(snapshot) as never;
+      }
+      if (method === "resumeChatQueue") {
+        activeOptions = options as CoachClientCallOptions<"chat">;
+        return activeRun.promise as never;
+      }
+      throw new TypeError(String(method));
+    }),
+    close: vi.fn(async () => {}),
+  };
+  let providerClient = failed;
+  const provider: DesktopCoachClientProvider = {
+    getClient: vi.fn(async () => providerClient),
+    reconnect: vi.fn(async () => {
+      providerClient = recovered;
+      return recovered;
+    }),
+    close: vi.fn(async () => {}),
+  };
+  const subject = harness(failed, () => true, provider);
+  return {
+    ...subject,
+    activeOptions: () => activeOptions,
+    disconnect() {
+      disconnected = true;
+      activeRun.reject(new CoachClientDisconnectedError(1006, "lost"));
+    },
+  };
 }
 
 describe("durable chat queue controller", () => {
@@ -622,83 +698,696 @@ describe("durable chat queue controller", () => {
     expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
   });
 
-  it("keeps later messages queued when Stop creates retry-required recovery", async () => {
-    const run = deferred<ChatQueueRunResult>();
-    let options: CoachClientCallOptions<"chat"> | undefined;
-    const items = [
-      {
-        queuedMessageId: "queued-1",
-        messageId: "message-1",
-        submissionId: "submission-1",
-        text: "First",
-        kind: "ordinary" as const,
-        attachmentIds: [],
-        position: 0,
-        restored: false,
-      },
-      {
-        queuedMessageId: "queued-2",
-        messageId: "message-2",
-        submissionId: "submission-2",
-        text: "/later",
-        kind: "slash-command" as const,
-        attachmentIds: [],
-        position: 1,
-        restored: true,
-      },
-    ];
-    const client: CoachClient = {
+  it("does not replay a queue-origin turn after the recovered queue shows it completed", async () => {
+    const head = ordinaryQueueItem(1, "First", 0);
+    const recoveredMethods: string[] = [];
+    const recovered: CoachClient = {
       handshake: {} as CoachClient["handshake"],
-      call: vi.fn((method, _request, callOptions) => {
-        if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
-        if (method === "hasSession") return Promise.resolve({ hasSession: false }) as never;
-        if (method === "getChatQueue")
-          return Promise.resolve({ schemaVersion: 1, revision: 2, items }) as never;
+      call: vi.fn((method) => {
+        recoveredMethods.push(method);
+        if (method === "getChatQueue") {
+          return Promise.resolve({ schemaVersion: 1, revision: 3, items: [] }) as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states, provider, activeOptions, disconnect } = disconnectedQueueHarness(
+      recovered,
+      [{ schemaVersion: 1, revision: 1, items: [head] }],
+    );
+    await controller.start();
+    await expect(controller.submit("First")).resolves.toBe(true);
+    await vi.waitFor(() => expect(activeOptions()).toBeDefined());
+    deliver("resumeChatQueue", activeOptions()!, {
+      type: "turn-start",
+      turnId: "turn-1",
+      chatId: "desktop",
+    });
+    deliver("resumeChatQueue", activeOptions()!, {
+      type: "text_delta",
+      turnId: "turn-1",
+      delta: "Partial",
+    });
+
+    disconnect();
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("interrupted"));
+    await controller.retryInterrupted();
+
+    expect(provider.reconnect).toHaveBeenCalledTimes(1);
+    expect(recoveredMethods).toEqual(["getChatQueue"]);
+    expect(states.at(-1)?.status).toBe("idle");
+    expect(states.at(-1)?.queued).toEqual([]);
+    expect(
+      states.at(-1)?.messages.map((message) => ({
+        role: message.role,
+        text: message.text,
+        delivery: message.delivery,
+      })),
+    ).toEqual([
+      { role: "athlete", text: "First", delivery: "complete" },
+      { role: "coach", text: "Partial", delivery: "interrupted" },
+    ]);
+  });
+
+  it("resumes a queue-origin turn when recovery still shows its exact unclaimed head", async () => {
+    const head = ordinaryQueueItem(1, "First", 0);
+    const recoveredMethods: string[] = [];
+    const recovered: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method, _request, options) => {
+        recoveredMethods.push(method);
+        if (method === "getChatQueue") {
+          return Promise.resolve({ schemaVersion: 1, revision: 3, items: [head] }) as never;
+        }
         if (method === "resumeChatQueue") {
-          options = callOptions as CoachClientCallOptions<"chat">;
-          deliver("resumeChatQueue", options, {
+          const resumeOptions = options as CoachClientCallOptions<"chat">;
+          deliver("resumeChatQueue", resumeOptions, {
+            type: "turn-start",
+            turnId: "turn-2",
+            chatId: "desktop",
+          });
+          deliver("resumeChatQueue", resumeOptions, {
+            type: "final-text",
+            turnId: "turn-2",
+            text: "Recovered",
+          });
+          resumeOptions.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: {} });
+          return Promise.resolve({
+            snapshot: { schemaVersion: 1, revision: 5, items: [] },
+            response: { text: "Recovered" },
+          }) as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states, provider, activeOptions, disconnect } = disconnectedQueueHarness(
+      recovered,
+      [{ schemaVersion: 1, revision: 1, items: [head] }],
+    );
+    await controller.start();
+    await expect(controller.submit("First")).resolves.toBe(true);
+    await vi.waitFor(() => expect(activeOptions()).toBeDefined());
+    deliver("resumeChatQueue", activeOptions()!, {
+      type: "turn-start",
+      turnId: "turn-1",
+      chatId: "desktop",
+    });
+    deliver("resumeChatQueue", activeOptions()!, {
+      type: "text_delta",
+      turnId: "turn-1",
+      delta: "Partial",
+    });
+
+    disconnect();
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("interrupted"));
+    await controller.retryInterrupted();
+
+    expect(provider.reconnect).toHaveBeenCalledTimes(1);
+    expect(recoveredMethods).toEqual(["getChatQueue", "resumeChatQueue"]);
+    expect(recoveredMethods).not.toContain("chat");
+    expect(states.at(-1)?.queued).toEqual([]);
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+    expect(
+      states
+        .at(-1)
+        ?.messages.filter((message) => message.role === "coach")
+        .map((message) => ({ text: message.text, delivery: message.delivery })),
+    ).toEqual([
+      { text: "Partial", delivery: "interrupted" },
+      { text: "Recovered", delivery: "complete" },
+    ]);
+  });
+
+  it("drains later ordinary work when a promoted exact retry is already resolved", async () => {
+    const head = ordinaryQueueItem(1, "First", 0);
+    const later = ordinaryQueueItem(2, "Later", 1);
+    const recoveredMethods: string[] = [];
+    const recovered: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method, request, options) => {
+        recoveredMethods.push(method);
+        if (method === "getChatQueue") {
+          return Promise.resolve({
+            schemaVersion: 1,
+            revision: 5,
+            items: [head, later],
+            retryRequired: {
+              claimId: "claim-1",
+              queuedMessageIds: [head.queuedMessageId],
+              turnId: "turn-1",
+              status: "retry-required",
+            },
+          }) as never;
+        }
+        if (method === "retryQueuedTurn") {
+          expect(request).toEqual({ chatId: "desktop", claimId: "claim-1" });
+          return Promise.resolve({
+            snapshot: {
+              schemaVersion: 1,
+              revision: 7,
+              items: [{ ...later, position: 0 }],
+            },
+          }) as never;
+        }
+        if (method === "resumeChatQueue") {
+          const resumeOptions = options as CoachClientCallOptions<"chat">;
+          deliver("resumeChatQueue", resumeOptions, {
             type: "turn-start",
             turnId: "turn-3",
             chatId: "desktop",
           });
-          return run.promise as never;
+          deliver("resumeChatQueue", resumeOptions, {
+            type: "final-text",
+            turnId: "turn-3",
+            text: "Later reply",
+          });
+          resumeOptions.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 3, result: {} });
+          return Promise.resolve({
+            snapshot: { schemaVersion: 1, revision: 9, items: [] },
+            response: { text: "Later reply" },
+          }) as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states, provider, activeOptions, disconnect } = disconnectedQueueHarness(
+      recovered,
+      [
+        { schemaVersion: 1, revision: 1, items: [head] },
+        { schemaVersion: 1, revision: 3, items: [head, later] },
+      ],
+    );
+    await controller.start();
+    await expect(controller.submit("First")).resolves.toBe(true);
+    await vi.waitFor(() => expect(activeOptions()).toBeDefined());
+    deliver("resumeChatQueue", activeOptions()!, {
+      type: "turn-start",
+      turnId: "turn-1",
+      chatId: "desktop",
+    });
+    deliver("resumeChatQueue", activeOptions()!, {
+      type: "text_delta",
+      turnId: "turn-1",
+      delta: "Partial",
+    });
+    await expect(controller.submit("Later")).resolves.toBe(true);
+
+    disconnect();
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("interrupted"));
+    await controller.retryInterrupted();
+
+    expect(provider.reconnect).toHaveBeenCalledTimes(1);
+    expect(recoveredMethods).toEqual(["getChatQueue", "retryQueuedTurn", "resumeChatQueue"]);
+    expect(recoveredMethods).not.toContain("chat");
+    expect(states.at(-1)?.queued).toEqual([]);
+    expect(
+      states
+        .at(-1)
+        ?.messages.filter((message) => message.role === "athlete")
+        .map((message) => message.text),
+    ).toEqual(["First", "Later"]);
+    expect(
+      states
+        .at(-1)
+        ?.messages.filter((message) => message.role === "coach")
+        .map((message) => ({ text: message.text, delivery: message.delivery })),
+    ).toEqual([
+      { text: "Partial", delivery: "interrupted" },
+      { text: "Later reply", delivery: "complete" },
+    ]);
+  });
+
+  it("does not drain when a response-less exact retry leaves its claim unresolved", async () => {
+    const head = ordinaryQueueItem(1, "First", 0);
+    const later = ordinaryQueueItem(2, "Later", 1);
+    const retryRequired = {
+      claimId: "claim-1",
+      queuedMessageIds: [head.queuedMessageId],
+      turnId: "turn-1",
+      status: "retry-required" as const,
+    };
+    const recoveredMethods: string[] = [];
+    const recovered: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method) => {
+        recoveredMethods.push(method);
+        if (method === "getChatQueue") {
+          return Promise.resolve({
+            schemaVersion: 1,
+            revision: 5,
+            items: [head, later],
+            retryRequired,
+          }) as never;
         }
         if (method === "retryQueuedTurn") {
-          const retryOptions = callOptions as CoachClientCallOptions<"chat">;
+          return Promise.resolve({
+            snapshot: {
+              schemaVersion: 1,
+              revision: 6,
+              items: [head, later],
+              retryRequired,
+            },
+          }) as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states, activeOptions, disconnect } = disconnectedQueueHarness(recovered, [
+      { schemaVersion: 1, revision: 1, items: [head] },
+      { schemaVersion: 1, revision: 3, items: [head, later] },
+    ]);
+    await controller.start();
+    await expect(controller.submit("First")).resolves.toBe(true);
+    await vi.waitFor(() => expect(activeOptions()).toBeDefined());
+    deliver("resumeChatQueue", activeOptions()!, {
+      type: "turn-start",
+      turnId: "turn-1",
+      chatId: "desktop",
+    });
+    deliver("resumeChatQueue", activeOptions()!, {
+      type: "text_delta",
+      turnId: "turn-1",
+      delta: "Partial",
+    });
+    await expect(controller.submit("Later")).resolves.toBe(true);
+
+    disconnect();
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("interrupted"));
+    await controller.retryInterrupted();
+
+    expect(recoveredMethods).toEqual(["getChatQueue", "retryQueuedTurn"]);
+    expect(states.at(-1)?.retryRequired).toMatchObject({ claimId: "claim-1" });
+    expect(states.at(-1)?.queued.map((item) => item.text)).toEqual(["First", "Later"]);
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+    expect(states.at(-1)?.messages.at(-1)).toMatchObject({
+      role: "coach",
+      text: "Partial",
+      delivery: "interrupted",
+    });
+  });
+
+  it("reconciles a disconnected queue claim before retrying and drains later work once", async () => {
+    const activeRun = deferred<ChatQueueRunResult>();
+    let activeOptions: CoachClientCallOptions<"chat"> | undefined;
+    let disconnected = false;
+    let enqueueCount = 0;
+    const head = {
+      queuedMessageId: "queued-1",
+      messageId: "message-1",
+      submissionId: "submission-1",
+      text: "First",
+      kind: "ordinary" as const,
+      attachmentIds: [],
+      position: 0,
+      restored: false,
+    };
+    const laterOne = {
+      queuedMessageId: "queued-2",
+      messageId: "message-2",
+      submissionId: "submission-2",
+      text: "Later one",
+      kind: "ordinary" as const,
+      attachmentIds: [],
+      position: 1,
+      restored: false,
+    };
+    const laterTwo = {
+      queuedMessageId: "queued-3",
+      messageId: "message-3",
+      submissionId: "submission-3",
+      text: "Later two",
+      kind: "ordinary" as const,
+      attachmentIds: [],
+      position: 2,
+      restored: false,
+    };
+    const failed: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method, _request, options) => {
+        if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+        if (method === "hasSession") return Promise.resolve({ hasSession: false }) as never;
+        if (method === "getChatQueue") {
+          return disconnected
+            ? (Promise.reject(new CoachClientDisconnectedError(1006, "lost")) as never)
+            : (Promise.resolve({ schemaVersion: 1, revision: 0, items: [] }) as never);
+        }
+        if (method === "enqueueChatMessage") {
+          enqueueCount += 1;
+          return Promise.resolve(
+            enqueueCount === 1
+              ? { schemaVersion: 1, revision: 1, items: [head] }
+              : enqueueCount === 2
+                ? { schemaVersion: 1, revision: 3, items: [head, laterOne] }
+                : { schemaVersion: 1, revision: 4, items: [head, laterOne, laterTwo] },
+          ) as never;
+        }
+        if (method === "resumeChatQueue") {
+          activeOptions = options as CoachClientCallOptions<"chat">;
+          return activeRun.promise as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const recoveredMethods: string[] = [];
+    const recovered: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method, request, options) => {
+        recoveredMethods.push(method);
+        if (method === "getChatQueue") {
+          return Promise.resolve({
+            schemaVersion: 1,
+            revision: 5,
+            items: [head, laterOne, laterTwo],
+            retryRequired: {
+              claimId: "claim-1",
+              queuedMessageIds: [head.queuedMessageId],
+              turnId: "turn-1",
+              status: "retry-required",
+            },
+          }) as never;
+        }
+        if (method === "retryQueuedTurn") {
+          expect(request).toEqual({ chatId: "desktop", claimId: "claim-1" });
+          const retryOptions = options as CoachClientCallOptions<"chat">;
           deliver("retryQueuedTurn", retryOptions, {
             type: "turn-start",
-            turnId: "turn-4",
+            turnId: "turn-2",
             chatId: "desktop",
           });
           deliver("retryQueuedTurn", retryOptions, {
             type: "final-text",
-            turnId: "turn-4",
+            turnId: "turn-2",
             text: "Recovered",
           });
-          retryOptions.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 4, result: {} });
+          retryOptions.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: {} });
           return Promise.resolve({
-            snapshot: { schemaVersion: 1, revision: 6, items: [items[1]!] },
+            snapshot: {
+              schemaVersion: 1,
+              revision: 7,
+              items: [
+                { ...laterOne, position: 0 },
+                { ...laterTwo, position: 1 },
+              ],
+            },
             response: { text: "Recovered" },
           }) as never;
         }
-        if (method === "stopChat") {
-          const interrupted = {
-            type: "interrupted",
+        if (method === "resumeChatQueue") {
+          const laterOptions = options as CoachClientCallOptions<"chat">;
+          deliver("resumeChatQueue", laterOptions, {
+            type: "turn-start",
             turnId: "turn-3",
             chatId: "desktop",
+          });
+          deliver("resumeChatQueue", laterOptions, {
+            type: "final-text",
+            turnId: "turn-3",
+            text: "Later reply",
+          });
+          laterOptions.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 3, result: {} });
+          return Promise.resolve({
+            snapshot: { schemaVersion: 1, revision: 9, items: [] },
+            response: { text: "Later reply" },
+          }) as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    let providerClient = failed;
+    const provider: DesktopCoachClientProvider = {
+      getClient: vi.fn(async () => providerClient),
+      reconnect: vi.fn(async () => {
+        providerClient = recovered;
+        return recovered;
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(failed, () => true, provider);
+    await controller.start();
+    await expect(controller.submit("First")).resolves.toBe(true);
+    await vi.waitFor(() => expect(activeOptions).toBeDefined());
+    deliver("resumeChatQueue", activeOptions!, {
+      type: "turn-start",
+      turnId: "turn-1",
+      chatId: "desktop",
+    });
+    deliver("resumeChatQueue", activeOptions!, {
+      type: "text_delta",
+      turnId: "turn-1",
+      delta: "Partial",
+    });
+    await expect(controller.submit("Later one")).resolves.toBe(true);
+    await expect(controller.submit("Later two")).resolves.toBe(true);
+    expect(states.at(-1)?.queued.map((item) => item.text)).toEqual(["Later one", "Later two"]);
+
+    disconnected = true;
+    activeRun.reject(new CoachClientDisconnectedError(1006, "lost"));
+    await vi.waitFor(() => expect(states.at(-1)?.status).toBe("interrupted"));
+    expect(states.at(-1)?.messages.at(-1)).toMatchObject({
+      role: "coach",
+      text: "Partial",
+      delivery: "interrupted",
+    });
+    expect(states.at(-1)?.retryRequired).toBeNull();
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+
+    await controller.retryInterrupted();
+
+    expect(provider.reconnect).toHaveBeenCalledTimes(1);
+    expect(recoveredMethods).toEqual(["getChatQueue", "retryQueuedTurn", "resumeChatQueue"]);
+    expect(recoveredMethods).not.toContain("chat");
+    expect(states.at(-1)?.queued).toEqual([]);
+    expect(
+      states
+        .at(-1)
+        ?.messages.filter((message) => message.role === "athlete")
+        .map((message) => message.text),
+    ).toEqual(["First", "Later one\n\nLater two"]);
+    expect(
+      states
+        .at(-1)
+        ?.messages.filter((message) => message.role === "coach")
+        .map((message) => ({ text: message.text, delivery: message.delivery })),
+    ).toEqual([
+      { text: "Partial", delivery: "interrupted" },
+      { text: "Recovered", delivery: "complete" },
+      { text: "Later reply", delivery: "complete" },
+    ]);
+  });
+
+  it("reconciles a generic queue failure to the queue-aware retry path", async () => {
+    let queueReads = 0;
+    const head = {
+      queuedMessageId: "queued-1",
+      messageId: "message-1",
+      submissionId: "submission-1",
+      text: "First",
+      kind: "ordinary" as const,
+      attachmentIds: [],
+      position: 0,
+      restored: false,
+    };
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method, _request, options) => {
+        if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+        if (method === "hasSession") return Promise.resolve({ hasSession: false }) as never;
+        if (method === "getChatQueue") {
+          queueReads += 1;
+          return Promise.resolve(
+            queueReads === 1
+              ? { schemaVersion: 1, revision: 0, items: [] }
+              : {
+                  schemaVersion: 1,
+                  revision: 3,
+                  items: [head],
+                  retryRequired: {
+                    claimId: "claim-1",
+                    queuedMessageIds: [head.queuedMessageId],
+                    turnId: "turn-1",
+                    status: "retry-required",
+                  },
+                },
+          ) as never;
+        }
+        if (method === "enqueueChatMessage") {
+          return Promise.resolve({ schemaVersion: 1, revision: 1, items: [head] }) as never;
+        }
+        if (method === "resumeChatQueue") {
+          const runOptions = options as CoachClientCallOptions<"chat">;
+          deliver("resumeChatQueue", runOptions, {
+            type: "turn-start",
+            turnId: "turn-1",
+            chatId: "desktop",
+          });
+          deliver("resumeChatQueue", runOptions, {
+            type: "text_delta",
+            turnId: "turn-1",
+            delta: "Partial",
+          });
+          runOptions.onTerminalEnvelope?.({
+            jsonrpc: "2.0",
+            id: 1,
+            error: { code: -32603, message: "Internal error" },
+          });
+          return Promise.reject(new Error("terminal failure")) as never;
+        }
+        if (method === "retryQueuedTurn") {
+          const retryOptions = options as CoachClientCallOptions<"chat">;
+          deliver("retryQueuedTurn", retryOptions, {
+            type: "turn-start",
+            turnId: "turn-2",
+            chatId: "desktop",
+          });
+          deliver("retryQueuedTurn", retryOptions, {
+            type: "final-text",
+            turnId: "turn-2",
+            text: "Recovered",
+          });
+          retryOptions.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: {} });
+          return Promise.resolve({
+            snapshot: { schemaVersion: 1, revision: 5, items: [] },
+            response: { text: "Recovered" },
+          }) as never;
+        }
+        throw new TypeError(String(method));
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, states } = harness(client);
+    await controller.start();
+    await expect(controller.submit("First")).resolves.toBe(true);
+    await vi.waitFor(() => expect(states.at(-1)?.retryRequired?.claimId).toBe("claim-1"));
+
+    expect(states.at(-1)?.status).toBe("idle");
+    expect(states.at(-1)?.queued.map((item) => item.text)).toEqual(["First"]);
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+    expect(states.at(-1)?.messages.at(-1)).toMatchObject({
+      role: "coach",
+      text: "Partial",
+      delivery: "interrupted",
+    });
+
+    await controller.retryQueuedTurn("claim-1");
+
+    expect(
+      vi.mocked(client.call).mock.calls.filter(([method]) => method === "retryQueuedTurn"),
+    ).toHaveLength(1);
+    expect(vi.mocked(client.call).mock.calls.some(([method]) => method === "chat")).toBe(false);
+    expect(states.at(-1)?.queued).toEqual([]);
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+  });
+
+  it("preserves Stop recovery and drains ordinary work queued during streaming", async () => {
+    const activeRun = deferred<ChatQueueRunResult>();
+    let activeOptions: CoachClientCallOptions<"chat"> | undefined;
+    let enqueueCount = 0;
+    let resumeCount = 0;
+    const head = {
+      queuedMessageId: "queued-1",
+      messageId: "message-1",
+      submissionId: "submission-1",
+      text: "First",
+      kind: "ordinary" as const,
+      attachmentIds: [],
+      position: 0,
+      restored: false,
+    };
+    const laterOne = {
+      queuedMessageId: "queued-2",
+      messageId: "message-2",
+      submissionId: "submission-2",
+      text: "Later one",
+      kind: "ordinary" as const,
+      attachmentIds: [],
+      position: 1,
+      restored: false,
+    };
+    const laterTwo = {
+      queuedMessageId: "queued-3",
+      messageId: "message-3",
+      submissionId: "submission-3",
+      text: "Later two",
+      kind: "ordinary" as const,
+      attachmentIds: [],
+      position: 2,
+      restored: false,
+    };
+    const client: CoachClient = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn((method, request, options) => {
+        if (method === "getCoachDecision") return Promise.resolve({ decision: null }) as never;
+        if (method === "hasSession") return Promise.resolve({ hasSession: false }) as never;
+        if (method === "getChatQueue") {
+          return Promise.resolve({ schemaVersion: 1, revision: 0, items: [] }) as never;
+        }
+        if (method === "enqueueChatMessage") {
+          enqueueCount += 1;
+          return Promise.resolve(
+            enqueueCount === 1
+              ? { schemaVersion: 1, revision: 1, items: [head] }
+              : enqueueCount === 2
+                ? { schemaVersion: 1, revision: 3, items: [head, laterOne] }
+                : { schemaVersion: 1, revision: 4, items: [head, laterOne, laterTwo] },
+          ) as never;
+        }
+        if (method === "resumeChatQueue") {
+          resumeCount += 1;
+          const runOptions = options as CoachClientCallOptions<"chat">;
+          if (resumeCount === 1) {
+            activeOptions = runOptions;
+            deliver("resumeChatQueue", runOptions, {
+              type: "turn-start",
+              turnId: "turn-1",
+              chatId: "desktop",
+            });
+            deliver("resumeChatQueue", runOptions, {
+              type: "text_delta",
+              turnId: "turn-1",
+              delta: "Partial",
+            });
+            return activeRun.promise as never;
+          }
+          deliver("resumeChatQueue", runOptions, {
+            type: "turn-start",
+            turnId: "turn-3",
+            chatId: "desktop",
+          });
+          deliver("resumeChatQueue", runOptions, {
+            type: "final-text",
+            turnId: "turn-3",
+            text: "Later reply",
+          });
+          runOptions.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 3, result: {} });
+          return Promise.resolve({
+            snapshot: { schemaVersion: 1, revision: 9, items: [] },
+            response: { text: "Later reply" },
+          }) as never;
+        }
+        if (method === "stopChat") {
+          expect(request).toEqual({ chatId: "desktop", turnId: "turn-1" });
+          deliver("resumeChatQueue", activeOptions!, {
+            type: "interrupted",
+            turnId: "turn-1",
+            chatId: "desktop",
             text: "Partial",
-          } as const;
-          deliver("resumeChatQueue", options!, interrupted);
-          options!.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 3, result: {} });
-          run.resolve({
+          });
+          activeOptions!.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: {} });
+          activeRun.resolve({
             snapshot: {
               schemaVersion: 1,
-              revision: 4,
-              items,
+              revision: 5,
+              items: [head, laterOne, laterTwo],
               retryRequired: {
                 claimId: "claim-1",
-                queuedMessageIds: ["queued-1"],
-                turnId: "turn-3",
+                queuedMessageIds: [head.queuedMessageId],
+                turnId: "turn-1",
                 status: "retry-required",
               },
             },
@@ -706,27 +1395,81 @@ describe("durable chat queue controller", () => {
           });
           return Promise.resolve({ stopped: true }) as never;
         }
+        if (method === "retryQueuedTurn") {
+          expect(request).toEqual({ chatId: "desktop", claimId: "claim-1" });
+          const retryOptions = options as CoachClientCallOptions<"chat">;
+          deliver("retryQueuedTurn", retryOptions, {
+            type: "turn-start",
+            turnId: "turn-2",
+            chatId: "desktop",
+          });
+          deliver("retryQueuedTurn", retryOptions, {
+            type: "final-text",
+            turnId: "turn-2",
+            text: "Recovered",
+          });
+          retryOptions.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: {} });
+          return Promise.resolve({
+            snapshot: {
+              schemaVersion: 1,
+              revision: 7,
+              items: [
+                { ...laterOne, position: 0 },
+                { ...laterTwo, position: 1 },
+              ],
+            },
+            response: { text: "Recovered" },
+          }) as never;
+        }
         throw new TypeError(String(method));
       }),
       close: vi.fn(async () => {}),
     };
     const { controller, states } = harness(client);
-    const active = controller.resume();
-    await vi.waitFor(() => expect(options).toBeDefined());
+    await controller.start();
+    await expect(controller.submit("First")).resolves.toBe(true);
+    await vi.waitFor(() => expect(activeOptions).toBeDefined());
+    await expect(controller.submit("Later one")).resolves.toBe(true);
+    await expect(controller.submit("Later two")).resolves.toBe(true);
+    expect(states.at(-1)?.queued.map((item) => item.text)).toEqual(["Later one", "Later two"]);
+
     controller.stop();
-    await active;
+    await vi.waitFor(() => expect(states.at(-1)?.retryRequired?.claimId).toBe("claim-1"));
     expect(states.at(-1)?.status).toBe("interrupted");
-    expect(states.at(-1)?.queued.map((item) => item.text)).toEqual(["First", "/later"]);
-    expect(states.at(-1)?.retryRequired).toMatchObject({ claimId: "claim-1" });
-    expect(
-      vi.mocked(client.call).mock.calls.filter(([method]) => method === "resumeChatQueue"),
-    ).toHaveLength(1);
+    expect(states.at(-1)?.messages.at(-1)).toMatchObject({
+      role: "coach",
+      text: "Partial",
+      delivery: "interrupted",
+    });
+    expect(states.at(-1)?.queued.map((item) => item.text)).toEqual([
+      "First",
+      "Later one",
+      "Later two",
+    ]);
 
     await controller.retryQueuedTurn("claim-1");
-    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
-    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")[0]?.text).toBe(
-      "First",
-    );
-    expect(states.at(-1)?.queued.map((item) => item.text)).toEqual(["/later"]);
+
+    expect(resumeCount).toBe(2);
+    expect(
+      vi.mocked(client.call).mock.calls.filter(([method]) => method === "retryQueuedTurn"),
+    ).toHaveLength(1);
+    expect(vi.mocked(client.call).mock.calls.some(([method]) => method === "chat")).toBe(false);
+    expect(states.at(-1)?.queued).toEqual([]);
+    expect(
+      states
+        .at(-1)
+        ?.messages.filter((message) => message.role === "athlete")
+        .map((message) => message.text),
+    ).toEqual(["First", "Later one\n\nLater two"]);
+    expect(
+      states
+        .at(-1)
+        ?.messages.filter((message) => message.role === "coach")
+        .map((message) => ({ text: message.text, delivery: message.delivery })),
+    ).toEqual([
+      { text: "Partial", delivery: "interrupted" },
+      { text: "Recovered", delivery: "complete" },
+      { text: "Later reply", delivery: "complete" },
+    ]);
   });
 });

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -1,5 +1,8 @@
 import { createServer, type Server } from "node:http";
 import { createServer as createNetServer } from "node:net";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Writable } from "node:stream";
 import { performance } from "node:perf_hooks";
 import { describe, expect, it, vi } from "vitest";
@@ -8,6 +11,23 @@ import {
   connectCoachClient,
   type CoachClient,
 } from "@enduragent/coach-client";
+import {
+  Memory,
+  classifyFailure,
+  createConversationStore,
+  createMissingPlatformCalendarMutations,
+  engineConfigFromConfig,
+  extractRetryAfterMs,
+  type Config,
+} from "@enduragent/core";
+import {
+  createCoachEngine,
+  type EngineHostPorts,
+  type ModelTransportDecorator,
+  type ModelTransportRequest,
+} from "@enduragent/engine";
+import type { GenerateResult } from "@enduragent/engine/sport";
+import { cyclingSport } from "@enduragent/sport-cycling";
 import {
   CoachRemoteError,
   connectCoachVerbTransport,
@@ -256,6 +276,187 @@ async function closeTransport(transport: CoachVerbTransport | undefined): Promis
 }
 
 describe.skipIf(!hasLoopback)("CLI verbs over real RPC framing", () => {
+  it("recovers a detached active queue claim and drains later ordinary work once", async () => {
+    const dataDir = await mkdtemp(join(await realpath(tmpdir()), "coach-queue-rpc-"));
+    await mkdir(join(dataDir, "memory"), { recursive: true });
+    const requests: ModelTransportRequest[] = [];
+    let started!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const generated = (text: string): GenerateResult => {
+      const usage = {
+        inputTokens: 1,
+        outputTokens: 1,
+        totalTokens: 2,
+        inputTokenDetails: { noCacheTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+        outputTokenDetails: { textTokens: 1, reasoningTokens: 0 },
+      };
+      return { text, toolCalls: [], finishReason: "stop", usage, totalUsage: usage, steps: 1 };
+    };
+    const modelTransportDecorator: ModelTransportDecorator = () => ({
+      generate(request): Promise<GenerateResult> {
+        requests.push(request);
+        if (requests.length === 1) {
+          request.options.onTextDelta?.("Partial");
+          started();
+          return new Promise<GenerateResult>((_resolve, reject) => {
+            request.options.signal?.addEventListener("abort", () => reject(new Error("stopped")), {
+              once: true,
+            });
+          });
+        }
+        return Promise.resolve(generated(requests.length === 2 ? "Recovered" : "Later reply"));
+      },
+    });
+    const config: Config = {
+      dataSource: "platform",
+      llm: {
+        provider: "openai-codex",
+        model: "gpt-5.4",
+        apiKey: "",
+        authProfile: "openai-codex",
+      },
+      intervals: { apiKey: "", athleteId: "0" },
+      telegram: { botToken: "" },
+      session: {
+        historyTokenBudgetRatio: 0.3,
+        idleMinutes: 0,
+        dailyResetHour: 4,
+        resetArchiveRetentionDays: 0,
+        timezone: "UTC",
+      },
+      contextWindowTokens: 272_000,
+      dataDir,
+    };
+    const conversation = createConversationStore(dataDir);
+    let idSequence = 0;
+    const ports: EngineHostPorts = {
+      config: engineConfigFromConfig(config),
+      memory: new Memory(dataDir, "UTC"),
+      chatStore: conversation,
+      transcriptWriter: conversation,
+      coachDecisions: conversation,
+      secrets: { resolve: async () => "" },
+      platform: {
+        legacyClient: null,
+        athleteData: undefined,
+        calendarMutations: createMissingPlatformCalendarMutations(),
+      },
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+      usage: { append: () => {} },
+      stateReader: {
+        getAthleteState: async () => {
+          throw new Error("Athlete state is unavailable in this test.");
+        },
+      },
+      readReferenceState: () => ({ errorState: null, latest: null }),
+      getAccessToken: async () => "token",
+      classifyFailure,
+      extractRetryAfterMs,
+      now: () => 0,
+      randomId: () => `rpc-queue-${++idSequence}`,
+      modelTransportDecorator,
+    };
+    const queueEngine = createCoachEngine({ sport: cyclingSport, ports });
+    const running = await startRpc(queueEngine);
+    const clients: CoachClient[] = [];
+    const chatId = "desktop";
+    let firstTurnId: string | undefined;
+    try {
+      const first = await connectCoachClient({ url: running.url, token });
+      clients.push(first);
+      await first.call("enqueueChatMessage", {
+        chatId,
+        submissionId: "submission-first",
+        text: "First",
+      });
+      const firstEvents: TurnEvent[] = [];
+      const firstRun = first.call(
+        "resumeChatQueue",
+        { chatId },
+        {
+          onEvent: (event) => {
+            firstEvents.push(event);
+            if (event.type === "turn-start") firstTurnId = event.turnId;
+          },
+        },
+      );
+      const firstOutcome = firstRun.catch((error: unknown) => error);
+      await firstStarted;
+      await vi.waitFor(() =>
+        expect(firstEvents.map((event) => event.type)).toEqual(["turn-start", "text_delta"]),
+      );
+      expect(firstTurnId).toBeDefined();
+      expect(firstEvents[1]).toMatchObject({ type: "text_delta", delta: "Partial" });
+      await first.call("enqueueChatMessage", {
+        chatId,
+        submissionId: "submission-later-one",
+        text: "Later one",
+      });
+      await first.call("enqueueChatMessage", {
+        chatId,
+        submissionId: "submission-later-two",
+        text: "Later two",
+      });
+
+      const serverObservedDisconnect = running.nextClientDisconnect();
+      await first.close();
+      await serverObservedDisconnect;
+      expect(await firstOutcome).toBeInstanceOf(CoachClientDisconnectedError);
+
+      const recovered = await connectCoachClient({ url: running.url, token });
+      clients.push(recovered);
+      const recovery = await recovered.call("getChatQueue", { chatId });
+      expect(recovery.items.map((item) => item.text)).toEqual(["First", "Later one", "Later two"]);
+      expect(recovery.retryRequired).toMatchObject({
+        queuedMessageIds: [recovery.items[0]!.queuedMessageId],
+        status: "retry-required",
+      });
+
+      const retryEvents: TurnEvent[] = [];
+      const retried = await recovered.call(
+        "retryQueuedTurn",
+        { chatId, claimId: recovery.retryRequired!.claimId },
+        { onEvent: (event) => retryEvents.push(event) },
+      );
+      expect(retried.response?.text).toBe("Recovered");
+      expect(retried.snapshot.retryRequired).toBeUndefined();
+      expect(retried.snapshot.items.map((item) => item.text)).toEqual(["Later one", "Later two"]);
+      expect(retryEvents.map((event) => event.type)).toEqual(["turn-start", "final-text"]);
+      expect(retryEvents[0]?.turnId).not.toBe(firstTurnId);
+
+      const laterEvents: TurnEvent[] = [];
+      const drained = await recovered.call(
+        "resumeChatQueue",
+        { chatId },
+        { onEvent: (event) => laterEvents.push(event) },
+      );
+      expect(drained.response?.text).toBe("Later reply");
+      expect(drained.snapshot.items).toEqual([]);
+      expect(laterEvents.map((event) => event.type)).toEqual(["turn-start", "final-text"]);
+      const userMessages = requests.map(
+        (request) =>
+          request.options.messages?.at(-1) as { readonly role: string; readonly content: string },
+      );
+      expect(userMessages.map((message) => message.role)).toEqual(["user", "user", "user"]);
+      expect(userMessages.map((message) => message.content.split("\nCurrent time:", 1)[0])).toEqual(
+        ["First", "First", "Later one\n\nLater two"],
+      );
+    } finally {
+      if (firstTurnId !== undefined) {
+        await queueEngine.stopChat?.({ chatId, turnId: firstTurnId }).catch(() => undefined);
+      }
+      await closeServer(running, clients);
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it("runs all five verbs, preserves stream envelopes, and serves warm state under 500 ms", async () => {
     const chatCalls: Parameters<CoachEngine["chat"]>[0][] = [];
     const getAthleteState = vi.fn<CoachEngine["getAthleteState"]>(async () => state);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -95,6 +95,10 @@ export interface CreateCoachEngineInput {
 export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
   const agent = new CoachAgent(input.sport, input.ports);
   const queueRuns = new Map<string, Promise<ChatQueueRunResult>>();
+  const queueRetryRuns = new Map<
+    string,
+    { readonly claimId: string; readonly task: Promise<ChatQueueRunResult> }
+  >();
   const deferredPlanTurns = new Map<string, DeferredPlanTurn>();
   const deferredKey = (chatId: string, turnId: string): string => `${chatId}:${turnId}`;
   const queueAuthorities = new Map<string, Promise<void>>();
@@ -151,7 +155,27 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
     onEvent: ((event: TurnEvent) => void) | undefined,
   ): Promise<ChatQueueRunResult> => {
     const active = queueRuns.get(chatId);
-    if (active !== undefined) return active;
+    if (active !== undefined) {
+      if (mode !== "retry" || exactId === undefined) return active;
+      const existing = queueRetryRuns.get(chatId);
+      if (existing?.claimId === exactId) return existing.task;
+      if (existing !== undefined) return snapshot(chatId).then((value) => ({ snapshot: value }));
+      const task = (async (): Promise<ChatQueueRunResult> => {
+        const before = await snapshot(chatId);
+        const recovery = before.retryRequired;
+        if (recovery === undefined || recovery.claimId !== exactId) return { snapshot: before };
+        agent.stopChat(chatId, recovery.turnId);
+        await active.catch(() => undefined);
+        if (queueRuns.get(chatId) === active) queueRuns.delete(chatId);
+        return runQueue(chatId, "retry", exactId, onEvent);
+      })();
+      queueRetryRuns.set(chatId, { claimId: exactId, task });
+      const release = (): void => {
+        if (queueRetryRuns.get(chatId)?.task === task) queueRetryRuns.delete(chatId);
+      };
+      void task.then(release, release);
+      return task;
+    }
     const task = withQueueAuthority(chatId, async (): Promise<ChatQueueRunResult> => {
       const before = await snapshot(chatId);
       const pendingDecision = input.ports.coachDecisions?.getDecision(chatId);
@@ -305,6 +329,13 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
       if (queueRuns.get(chatId) === task) queueRuns.delete(chatId);
     };
     void task.then(release, release);
+    if (mode === "retry" && exactId !== undefined && queueRetryRuns.get(chatId) === undefined) {
+      queueRetryRuns.set(chatId, { claimId: exactId, task });
+      const releaseRetry = (): void => {
+        if (queueRetryRuns.get(chatId)?.task === task) queueRetryRuns.delete(chatId);
+      };
+      void task.then(releaseRetry, releaseRetry);
+    }
     return task;
   };
   return {

--- a/packages/engine/tests/chat-queue.test.ts
+++ b/packages/engine/tests/chat-queue.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TurnEvent } from "@enduragent/coach-contract";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import { createCoachEngine } from "../src/index.js";
 import type { EngineHostPorts, ModelTransportRequest } from "../src/host-ports.js";
@@ -462,6 +463,166 @@ describe("engine durable chat queue", () => {
 
     expect(await engine.getChatQueue!({ chatId: "desktop" })).toMatchObject({ items: [] });
     expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("hands an active recovery claim to a fresh retry before later ordinary work", async () => {
+    let announceStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      announceStarted = resolve;
+    });
+    const requests: ModelTransportRequest[] = [];
+    const generate = vi.fn((request: ModelTransportRequest): Promise<GenerateResult> => {
+      requests.push(request);
+      if (requests.length === 1) {
+        request.options.onTextDelta?.("Partial");
+        announceStarted();
+        return new Promise<GenerateResult>((_resolve, reject) => {
+          request.options.signal?.addEventListener("abort", () => reject(new Error("stopped")), {
+            once: true,
+          });
+        });
+      }
+      return Promise.resolve(generated(requests.length === 2 ? "Recovered" : "Later reply"));
+    });
+    const { engine } = setup(undefined, generate);
+    await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s1", text: "First" });
+    const activeEvents: TurnEvent[] = [];
+    const running = engine.resumeChatQueue!({ chatId: "desktop" }, (event) =>
+      activeEvents.push(event),
+    );
+    await started;
+    await engine.enqueueChatMessage!({
+      chatId: "desktop",
+      submissionId: "s2",
+      text: "Later 1",
+    });
+    await engine.enqueueChatMessage!({
+      chatId: "desktop",
+      submissionId: "s3",
+      text: "Later 2",
+    });
+
+    const recovery = await engine.getChatQueue!({ chatId: "desktop" });
+    expect(recovery.items.map((item) => item.text)).toEqual(["First", "Later 1", "Later 2"]);
+    expect(recovery.retryRequired).toMatchObject({
+      queuedMessageIds: [recovery.items[0]!.queuedMessageId],
+    });
+
+    const retryEvents: TurnEvent[] = [];
+    const retrying = engine.retryQueuedTurn!(
+      { chatId: "desktop", claimId: recovery.retryRequired!.claimId },
+      (event) => retryEvents.push(event),
+    );
+    await expect(running).resolves.toMatchObject({
+      response: { text: "Partial" },
+      snapshot: { retryRequired: { claimId: recovery.retryRequired!.claimId } },
+    });
+    const retried = await retrying;
+    expect(retried.response?.text).toBe("Recovered");
+    expect(retried.snapshot.items.map((item) => item.text)).toEqual(["Later 1", "Later 2"]);
+    expect(retried.snapshot.retryRequired).toBeUndefined();
+    const firstTurnId = activeEvents.find((event) => event.type === "turn-start")?.turnId;
+    const retryTurnId = retryEvents.find((event) => event.type === "turn-start")?.turnId;
+    expect(retryTurnId).toBeDefined();
+    expect(retryTurnId).not.toBe(firstTurnId);
+    expect(retryEvents.map((event) => event.type)).toEqual(["turn-start", "final-text"]);
+
+    const later = await engine.resumeChatQueue!({ chatId: "desktop" });
+    expect(later.response?.text).toBe("Later reply");
+    expect(later.snapshot.items).toEqual([]);
+    expect(requests[1]?.options.messages?.at(-1)).toMatchObject({
+      role: "user",
+      content: expect.stringContaining("First"),
+    });
+    expect(requests[2]?.options.messages?.at(-1)).toMatchObject({
+      role: "user",
+      content: expect.stringContaining("Later 1\n\nLater 2"),
+    });
+    expect(generate).toHaveBeenCalledTimes(3);
+  });
+
+  it("coalesces a duplicate retry after its turn starts and preserves different-claim behavior", async () => {
+    const failure = new Error("terminal queue failure");
+    let announceRetryStarted!: () => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      announceRetryStarted = resolve;
+    });
+    let completeRetry!: () => void;
+    let attempts = 0;
+    const generate = vi.fn((request: ModelTransportRequest): Promise<GenerateResult> => {
+      attempts += 1;
+      if (attempts === 1) return Promise.reject(failure);
+      return new Promise<GenerateResult>((resolve, reject) => {
+        completeRetry = () => resolve(generated("Recovered"));
+        request.options.signal?.addEventListener("abort", () => reject(new Error("restarted")), {
+          once: true,
+        });
+        announceRetryStarted();
+      });
+    });
+    const { engine } = setup(undefined, generate);
+    await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s1", text: "Queued" });
+    await expect(engine.resumeChatQueue!({ chatId: "desktop" })).rejects.toBe(failure);
+    const recovery = await engine.getChatQueue!({ chatId: "desktop" });
+
+    const retryEvents: TurnEvent[] = [];
+    const first = engine.retryQueuedTurn!(
+      { chatId: "desktop", claimId: recovery.retryRequired!.claimId },
+      (event) => retryEvents.push(event),
+    );
+    await retryStarted;
+    const duplicateEvents: TurnEvent[] = [];
+    const duplicate = engine.retryQueuedTurn!(
+      { chatId: "desktop", claimId: recovery.retryRequired!.claimId },
+      (event) => duplicateEvents.push(event),
+    );
+    expect(duplicate).toBe(first);
+
+    const different = engine.retryQueuedTurn!({ chatId: "desktop", claimId: "stale-claim" });
+    expect(different).not.toBe(first);
+    await expect(different).resolves.toMatchObject({
+      snapshot: { retryRequired: { claimId: recovery.retryRequired!.claimId } },
+    });
+
+    completeRetry();
+    const [firstResult, duplicateResult] = await Promise.all([first, duplicate]);
+    expect(duplicateResult).toBe(firstResult);
+    expect(firstResult).toMatchObject({ response: { text: "Recovered" }, snapshot: { items: [] } });
+    expect(retryEvents.filter((event) => event.type === "turn-start")).toHaveLength(1);
+    expect(retryEvents.filter((event) => event.type === "final-text")).toHaveLength(1);
+    expect(duplicateEvents).toEqual([]);
+    expect(generate).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a thrown queue claim unchanged while direct chat succeeds", async () => {
+    const failure = new Error("terminal queue failure");
+    let attempts = 0;
+    const generate = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) throw failure;
+      return generated(attempts === 2 ? "Direct reply" : "Recovered");
+    });
+    const { engine } = setup(undefined, generate);
+    await engine.enqueueChatMessage!({ chatId: "desktop", submissionId: "s1", text: "Queued" });
+
+    await expect(engine.resumeChatQueue!({ chatId: "desktop" })).rejects.toBe(failure);
+    const beforeDirect = await engine.getChatQueue!({ chatId: "desktop" });
+    expect(beforeDirect.retryRequired).toMatchObject({
+      queuedMessageIds: [beforeDirect.items[0]!.queuedMessageId],
+    });
+
+    await expect(engine.chat({ chatId: "desktop", message: "Independent" })).resolves.toEqual({
+      text: "Direct reply",
+    });
+    expect(await engine.getChatQueue!({ chatId: "desktop" })).toEqual(beforeDirect);
+
+    await expect(
+      engine.retryQueuedTurn!({
+        chatId: "desktop",
+        claimId: beforeDirect.retryRequired!.claimId,
+      }),
+    ).resolves.toMatchObject({ response: { text: "Recovered" }, snapshot: { items: [] } });
+    expect(generate).toHaveBeenCalledTimes(3);
   });
 
   it("Stop marks only the active claim retry-required and never drains the command behind it", async () => {


### PR DESCRIPTION
## Root cause

After a queued Chat turn lost its renderer WebSocket, the controller queried recovery state through the already failed client and swallowed that second error. The ordinary Retry path then reconnected but had forgotten that the interrupted turn came from the durable queue, so it could call direct Chat and strand or duplicate the saved claim. The engine also returned the old in-flight queue Promise to a fresh retry RPC, which meant the new connection had no matching event stream.

## Change

- Preserve immutable queue origin across renderer interruption and reconcile it on the fresh client before choosing an RPC route.
- Retry the exact recovery claim, resume an exact unclaimed head, or settle locally when the old run already completed; never fall through to direct Chat for queue-origin work.
- Drain later ordinary messages only after authoritative queue progress, once and in order.
- Hand an active engine claim to the fresh retry event subscriber and coalesce duplicate same-claim retries.
- Retain failed and stopped queue heads as retry-required while direct Chat remains isolated from queue claims.

User-facing: Stopping a Chat response or losing connection now keeps the interrupted message retryable and sends later queued messages once, in order.

## Verification

- 90 focused engine, renderer, controller, and real-WebSocket RPC tests passed after rebasing onto main.
- Root pnpm check passed, including type, lint, fixture privacy, changeset, dependency, and schema gates.
- Full Vitest run: 10,831 passed; six unrelated parallel-load timeouts all passed in isolated reruns, 23 of 23.
- Autoreview passed with a clean credential scan and no accepted blocking findings.
- Visible built-Electron Stop and Retry QA passed at 1180 by 820: one athlete head, preserved Partial response, exact retry claim, zero direct Chat calls, and one ordered tail drain with no clipping or overlap.