### PR TITLE
ci(actions): remove epic branch push runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, desktop, "epic/**"]
+    branches: [main, desktop]
   pull_request:
     branches: [main, desktop, "epic/**"]
 


### PR DESCRIPTION
## Summary

- stop full CI from running on pushes to `epic/**`
- preserve push CI for `main` and `desktop`
- preserve pull-request CI for `main`, `desktop`, and `epic/**`

## Verification

- validated the workflow trigger structure and confirmed epic PR coverage remains
- `git diff --check`
- autoreview clean: no accepted or actionable findings

## Expected impact

Feature-to-epic, feature-to-main, and epic-to-main pull requests keep their checks. The additional post-merge epic push run is removed.