### PR TITLE
ci(actions): reduce hosted runner usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,59 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  check:
+  desktop-scope:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    outputs:
+      native: ${{ steps.scope.outputs.native }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          native=false
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+            native=true
+          elif ! git diff --quiet "$BASE_SHA" HEAD -- \
+            apps/desktop \
+            apps/desktop-renderer \
+            packages/coach \
+            packages/coach-cli \
+            packages/coach-client \
+            packages/coach-contract \
+            packages/core \
+            packages/engine \
+            packages/kernel \
+            packages/kernel-node \
+            packages/sport-cycling \
+            packages/sync-intervals-icu \
+            package.json \
+            pnpm-lock.yaml \
+            pnpm-workspace.yaml \
+            tsconfig.check.json \
+            .github/workflows/ci.yml; then
+            native=true
+          fi
+          printf 'native=%s\n' "$native" >> "$GITHUB_OUTPUT"
+
+  check:
+    needs: desktop-scope
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    outputs:
+      smoke: ${{ steps.package_smoke.outputs.result }}
+    steps:
+      - name: Require Desktop scope detection
+        if: needs.desktop-scope.result != 'success'
+        run: exit 1
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         # Reads the exact `packageManager` pin from root package.json.
@@ -23,6 +71,28 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm check
+      - name: Test workspace on Linux
+        run: |
+          pnpm exec vitest run --shard=1/2
+          pnpm exec vitest run --shard=2/2
+      - run: pnpm s8a
+      - run: pnpm s8a --self-test
+      - id: package_smoke
+        name: Pack and smoke cycling-coach
+        run: |
+          set -euo pipefail
+          PACKAGE=cycling-coach
+          PACK_DIR="/tmp/smoke-pack-$PACKAGE"
+          mkdir -p "$PACK_DIR"
+          pnpm --dir "packages/$PACKAGE" pack --pack-destination "$PACK_DIR"
+          TARBALL=$(find "$PACK_DIR" -maxdepth 1 -name '*.tgz' -print -quit)
+          pnpm check:published-package -- "$TARBALL"
+          mkdir -p "/tmp/smoke-consumer-$PACKAGE"
+          cd "/tmp/smoke-consumer-$PACKAGE"
+          npm init -y > /dev/null
+          npm install "$TARBALL" --ignore-scripts
+          timeout 30 node "node_modules/$PACKAGE/dist/index.js" --help
+          printf 'result=success\n' >> "$GITHUB_OUTPUT"
       - name: Changeset presence (warn-only)
         if: github.event_name == 'pull_request'
         run: |
@@ -37,151 +107,150 @@ jobs:
           else
             echo "::warning::No changeset found for this PR. Behavioral/user-facing changes should ship a .changeset/*.md (see .changeset/README.md). chore:/ci: PRs are exempt."
           fi
-
-  test_shards:
-    name: test shard ${{ matrix.shard }}/2
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        # Reads the exact `packageManager` pin from root package.json.
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - id: desktop_e2e
+        name: Test Desktop E2E on Linux
+        if: needs.desktop-scope.outputs.native == 'true'
+        continue-on-error: true
+        run: |
+          pnpm --filter @enduragent/desktop exec playwright install-deps chromium
+          xvfb-run -a pnpm --filter @enduragent/desktop test:e2e
+      - name: Upload Desktop E2E artifacts
+        if: steps.desktop_e2e.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm -r build
-      - run: pnpm exec vitest run --shard=${{ matrix.shard }}/2
-
-  s8a:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        # Reads the exact `packageManager` pin from root package.json.
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm -r build
-      - run: pnpm s8a
-      - run: pnpm s8a --self-test
+          name: desktop-e2e-linux-artifacts
+          path: |
+            apps/desktop/playwright-report/
+            apps/desktop/test-results/
+          if-no-files-found: warn
 
   test:
-    needs: [check, test_shards, s8a]
+    needs: check
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require every test lane
+      - name: Require consolidated Linux checks
         env:
           CHECK_RESULT: ${{ needs.check.result }}
-          SHARDS_RESULT: ${{ needs.test_shards.result }}
-          S8A_RESULT: ${{ needs.s8a.result }}
         run: |
-          printf 'check=%s\ntest-shards=%s\ns8a=%s\n' "$CHECK_RESULT" "$SHARDS_RESULT" "$S8A_RESULT"
-          for result in "$CHECK_RESULT" "$SHARDS_RESULT" "$S8A_RESULT"; do
-            if [ "$result" != "success" ]; then
-              exit 1
-            fi
-          done
+          printf 'check=%s\n' "$CHECK_RESULT"
+          test "$CHECK_RESULT" = success
 
   smoke:
+    needs: check
+    if: ${{ always() }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm -r build
-      - name: Pack and smoke cycling-coach
-        # Mirrors release.yml's smoke gate: install the packed tarball into a
-        # fresh consumer and run the bundled binary. Runs on every PR (including
-        # the Version PR) and on main, so a broken published bundle — e.g. an ESM
-        # dynamic-require of a Node builtin that only surfaces in the packed
-        # artifact, not in `pnpm test` — is caught before merge, not at release.
-        # cycling-coach is the only publishable binary (ADR-0009); extend when
-        # running-coach / duathlon-coach graduate.
-        # --ignore-scripts skips the full dependency tree, so this smoke no longer proves postinstall behavior.
+      - name: Require package smoke evidence
+        env:
+          CHECK_RESULT: ${{ needs.check.result }}
+          SMOKE_RESULT: ${{ needs.check.outputs.smoke }}
         run: |
-          set -euo pipefail
-          PACKAGE=cycling-coach
-          PACK_DIR="/tmp/smoke-pack-$PACKAGE"
-          mkdir -p "$PACK_DIR"
-          pnpm --dir "packages/$PACKAGE" pack --pack-destination "$PACK_DIR"
-          TARBALL=$(find "$PACK_DIR" -maxdepth 1 -name '*.tgz' -print -quit)
-          pnpm check:published-package -- "$TARBALL"
-          mkdir -p "/tmp/smoke-consumer-$PACKAGE"
-          cd "/tmp/smoke-consumer-$PACKAGE"
-          npm init -y > /dev/null
-          npm install "$TARBALL" --ignore-scripts
-          timeout 30 node "node_modules/$PACKAGE/dist/index.js" --help
+          printf 'check=%s\nsmoke=%s\n' "$CHECK_RESULT" "$SMOKE_RESULT"
+          test "$CHECK_RESULT" = success
+          test "$SMOKE_RESULT" = success
 
   secrets-macos:
-    runs-on: macos-latest
-    env:
-      CI: macos
+    needs: [desktop-scope, desktop-packaged-native]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        # Reads the exact `packageManager` pin from root package.json.
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile --no-runtime
-      - name: Verify Node 22 compatibility runtime
+      - name: Require scoped macOS Keychain test
         env:
-          PNPM_SHIM_BYPASS: "1"
+          SCOPE_RESULT: ${{ needs.desktop-scope.result }}
+          NATIVE_SCOPE: ${{ needs.desktop-scope.outputs.native }}
+          NATIVE_RESULT: ${{ needs.desktop-packaged-native.result }}
         run: |
-          node_version="$(pnpm --filter @enduragent/core exec node -p 'process.version')"
-          printf 'Test runtime: %s\n' "$node_version"
-          case "$node_version" in
-            v22.*) ;;
-            *) exit 1 ;;
-          esac
-      - run: pnpm --filter @enduragent/core exec vitest run tests/secrets
-        env:
-          PNPM_SHIM_BYPASS: "1"
+          printf 'scope=%s\nnative=%s\nvalidation=%s\n' "$SCOPE_RESULT" "$NATIVE_SCOPE" "$NATIVE_RESULT"
+          test "$SCOPE_RESULT" = success
+          if [ "$NATIVE_SCOPE" = true ]; then
+            test "$NATIVE_RESULT" = success
+          else
+            test "$NATIVE_RESULT" = skipped
+          fi
 
   desktop-packaged-self-test:
+    needs: [desktop-scope, desktop-packaged-native]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require scoped Desktop package validation
+        env:
+          SCOPE_RESULT: ${{ needs.desktop-scope.result }}
+          NATIVE_SCOPE: ${{ needs.desktop-scope.outputs.native }}
+          NATIVE_RESULT: ${{ needs.desktop-packaged-native.result }}
+        run: |
+          printf 'scope=%s\nnative=%s\nvalidation=%s\n' "$SCOPE_RESULT" "$NATIVE_SCOPE" "$NATIVE_RESULT"
+          test "$SCOPE_RESULT" = success
+          if [ "$NATIVE_SCOPE" = true ]; then
+            test "$NATIVE_RESULT" = success
+          else
+            test "$NATIVE_RESULT" = skipped
+          fi
+
+  desktop-packaged-native:
+    needs: desktop-scope
+    if: needs.desktop-scope.outputs.native == 'true'
     runs-on: macos-latest
     timeout-minutes: 30
     env:
       CI: macos
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
       - run: test "$(uname -m)" = "arm64"
       - run: pnpm install --frozen-lockfile
-      - name: Build Desktop
-        run: pnpm --filter @enduragent/desktop... build
-      - name: Test Desktop IME composition
-        run: pnpm --filter @enduragent/desktop exec vitest run tests/chat-panels.integration.test.ts --testNamePattern "preserves IME composition until committed Enter"
-      - run: pnpm --filter @enduragent/desktop test:packaged-self-test
+      - name: Build Desktop dependencies
+        run: pnpm --filter "@enduragent/desktop^..." build
+      - name: Prepare Desktop package
+        run: pnpm --filter @enduragent/desktop package:dir
+      - name: Test Desktop integrations on macOS
+        run: pnpm --filter @enduragent/desktop exec vitest run tests/onboarding-first-run.integration.test.ts tests/spend-meter.integration.test.ts tests/chat-panels.integration.test.ts --maxWorkers=1
+      - name: Test Desktop E2E on macOS
+        run: pnpm --filter @enduragent/desktop test:e2e
+      - name: Upload Desktop E2E artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-e2e-macos-artifacts
+          path: |
+            apps/desktop/playwright-report/
+            apps/desktop/test-results/
+          if-no-files-found: warn
+      - name: Test prepared Desktop package
+        run: pnpm --filter @enduragent/desktop test:packaged-self-test --prepared-package
       - run: pnpm --filter @enduragent/desktop verify:package-layout
       - run: pnpm --filter @enduragent/desktop run smoke:security -- --mode=packaged --output=/tmp/desktop-security-packaged
       - run: pnpm --filter @enduragent/desktop package:telegram-acceptance
       - run: pnpm --filter @enduragent/desktop test:telegram-packaged
         env:
           ENDURAGENT_DISPOSABLE_SAFE_STORAGE_CONTEXT: "1"
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+      - name: Verify Node 22 compatibility runtime
+        run: |
+          node_version="$(node -p 'process.version')"
+          printf 'Test runtime: %s\n' "$node_version"
+          case "$node_version" in
+            v22.*) ;;
+            *) exit 1 ;;
+          esac
+      - name: Test macOS Keychain secrets
+        working-directory: packages/core
+        run: node ../../node_modules/vitest/vitest.mjs run tests/secrets
 
   windows-desktop-package:
+    needs: desktop-scope
+    if: needs.desktop-scope.outputs.native == 'true'
     runs-on: windows-latest
     timeout-minutes: 45
     env:
@@ -196,93 +265,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build Desktop dependencies
         run: pnpm --filter "@enduragent/desktop^..." build
-      - name: Run Windows package contract tests
-        run: pnpm exec vitest run apps/desktop/tests/windows-package-layout.test.ts apps/desktop/tests/windows-package-plan.test.ts apps/desktop/tests/windows-installed-package.test.ts apps/desktop/tests/windows-parity-contract.test.ts --maxWorkers=1
       - name: Build and verify unsigned x64 NSIS package
         run: pnpm --filter @enduragent/desktop package:win
       - name: Install, test, and uninstall unsigned x64 NSIS package
         run: pnpm --filter @enduragent/desktop test:windows-installed-self-test --github-hosted --signature-policy unsigned-private
-
-  desktop-integration-macos:
-    runs-on: macos-latest
-    timeout-minutes: 30
-    continue-on-error: true
-    env:
-      CI: macos
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: test "$(uname -m)" = "arm64"
-      - run: pnpm install --frozen-lockfile
-      - name: Build Desktop
-        run: pnpm --filter @enduragent/desktop... build
-      - name: Test Darwin desktop integrations
-        run: pnpm --filter @enduragent/desktop exec vitest run tests/onboarding-first-run.integration.test.ts tests/spend-meter.integration.test.ts tests/chat-panels.integration.test.ts --maxWorkers=1
-
-  desktop-e2e-scope:
-    runs-on: ubuntu-latest
-    outputs:
-      run: ${{ steps.scope.outputs.run }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          fetch-depth: 0
-      - id: scope
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-        run: |
-          run=false
-          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
-            run=true
-          elif ! git diff --quiet "$BASE_SHA" HEAD -- \
-            apps/desktop \
-            apps/desktop-renderer \
-            packages/coach \
-            packages/coach-client \
-            packages/coach-contract \
-            packages/core \
-            packages/kernel \
-            packages/kernel-node \
-            package.json \
-            pnpm-lock.yaml \
-            pnpm-workspace.yaml \
-            tsconfig.check.json \
-            .github/workflows/ci.yml; then
-            run=true
-          fi
-          printf 'run=%s\n' "$run" >> "$GITHUB_OUTPUT"
-
-  desktop-e2e-macos:
-    needs: desktop-e2e-scope
-    if: needs.desktop-e2e-scope.outputs.run == 'true'
-    runs-on: macos-latest
-    timeout-minutes: 20
-    continue-on-error: true
-    env:
-      CI: macos
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: test "$(uname -m)" = "arm64"
-      - run: pnpm install --frozen-lockfile
-      - name: Build Desktop
-        run: pnpm --filter @enduragent/desktop... build
-      - name: Test Desktop E2E
-        run: pnpm --filter @enduragent/desktop test:e2e
-      - name: Upload Desktop E2E artifacts
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: desktop-e2e-artifacts
-          path: |
-            apps/desktop/playwright-report/
-            apps/desktop/test-results/
-          if-no-files-found: warn

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 30
     concurrency:
       group: publish-image-${{ github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -97,3 +97,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=cycling-coach
+          cache-to: type=gha,mode=max,scope=cycling-coach

--- a/apps/desktop/scripts/verify-packaged-self-test.d.mts
+++ b/apps/desktop/scripts/verify-packaged-self-test.d.mts
@@ -1,0 +1,1 @@
+export declare function shouldPrepareDevelopmentPackage(arguments_: readonly string[]): boolean;

--- a/apps/desktop/scripts/verify-packaged-self-test.mjs
+++ b/apps/desktop/scripts/verify-packaged-self-test.mjs
@@ -19,6 +19,12 @@ const repositoryRoot = resolve(desktopRoot, "../..");
 const cliEntry = join(repositoryRoot, "packages/coach/dist/enduragent.js");
 const developmentPackagePlan = createDevelopmentPackagePlan({ desktopRoot });
 
+export function shouldPrepareDevelopmentPackage(arguments_) {
+  if (arguments_.length === 0) return true;
+  if (arguments_.length === 1 && arguments_[0] === "--prepared-package") return false;
+  throw new TypeError("arguments are not supported");
+}
+
 function delay(ms) {
   return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
 }
@@ -275,9 +281,10 @@ async function runApplicationCase(input) {
 
 async function main() {
   checked(process.platform === "darwin", "packaged self-test verification requires macOS");
-  checked(process.argv.length === 2, "arguments are not supported");
-  await runChecked("pnpm", ["--filter", "@enduragent/desktop...", "build"]);
-  await runChecked("pnpm", ["--filter", "@enduragent/desktop", "package:dir"]);
+  if (shouldPrepareDevelopmentPackage(process.argv.slice(2))) {
+    await runChecked("pnpm", ["--filter", "@enduragent/desktop...", "build"]);
+    await runChecked("pnpm", ["--filter", "@enduragent/desktop", "package:dir"]);
+  }
   const { SelfTestCommandTerminalSchema } = await import("@enduragent/coach-contract");
   const base = await realpath("/tmp");
   const scratch = await mkdtemp(join(base, "ea7-"));
@@ -352,4 +359,6 @@ async function main() {
   }
 }
 
-await main();
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/apps/desktop/tests/ci-cost-contract.test.ts
+++ b/apps/desktop/tests/ci-cost-contract.test.ts
@@ -1,0 +1,78 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function job(workflow: string, name: string): string {
+  const section = workflow.split(`  ${name}:\n`)[1]?.split(/\r?\n  [a-z0-9_-]+:\r?\n/u)[0];
+  if (section === undefined) throw new TypeError(`workflow job ${name} is missing`);
+  return section;
+}
+
+describe("CI cost contract", () => {
+  let ci = "";
+  let image = "";
+
+  beforeAll(async () => {
+    [ci, image] = await Promise.all([
+      readFile(join(repositoryRoot, ".github/workflows/ci.yml"), "utf8"),
+      readFile(join(repositoryRoot, ".github/workflows/publish-image.yml"), "utf8"),
+    ]);
+  });
+
+  it("consolidates Linux validation into one prepared workspace", () => {
+    const check = job(ci, "check");
+    expect(check.match(/pnpm install --frozen-lockfile/gu)).toHaveLength(1);
+    expect(check).toContain("run: pnpm check");
+    expect(check).toContain("pnpm exec vitest run --shard=1/2");
+    expect(check).toContain("pnpm exec vitest run --shard=2/2");
+    expect(check).toContain("run: pnpm s8a");
+    expect(check).toContain("Pack and smoke cycling-coach");
+    expect(check).toContain("xvfb-run -a pnpm --filter @enduragent/desktop test:e2e");
+    expect(ci).not.toContain("test_shards:");
+    expect(ci).not.toMatch(/^  s8a:/mu);
+  });
+
+  it("runs one scoped macOS job and preserves required status names", () => {
+    const native = job(ci, "desktop-packaged-native");
+    const packagedStatus = job(ci, "desktop-packaged-self-test");
+    const secretsStatus = job(ci, "secrets-macos");
+    expect(ci.match(/runs-on: macos-latest/gu)).toHaveLength(1);
+    expect(native).toContain("needs: desktop-scope");
+    expect(native).toContain("package:dir");
+    expect(native).toContain("--prepared-package");
+    expect(native).not.toContain("-- --prepared-package");
+    expect(native).toContain("Test Desktop integrations on macOS");
+    expect(native).toContain("tests/onboarding-first-run.integration.test.ts");
+    expect(native).toContain("tests/spend-meter.integration.test.ts");
+    expect(native).toContain("tests/chat-panels.integration.test.ts");
+    expect(native).toContain("Test Desktop E2E on macOS");
+    expect(native).toContain("test:e2e");
+    expect(native).toContain("desktop-e2e-macos-artifacts");
+    expect(native).toContain("Test macOS Keychain secrets");
+    expect(native).toContain("node_version=\"$(node -p 'process.version')\"");
+    expect(native).toContain("node ../../node_modules/vitest/vitest.mjs run tests/secrets");
+    expect(native).not.toContain("@enduragent/core exec node");
+    expect(packagedStatus).toContain("runs-on: ubuntu-latest");
+    expect(secretsStatus).toContain("runs-on: ubuntu-latest");
+    expect(ci).not.toContain("desktop-integration-macos:");
+    expect(ci).not.toContain("desktop-e2e-macos:");
+  });
+
+  it("scopes Windows packaging and leaves synthetic contracts on Linux", () => {
+    const windows = job(ci, "windows-desktop-package");
+    expect(windows).toContain("needs: desktop-scope");
+    expect(windows).toContain("needs.desktop-scope.outputs.native == 'true'");
+    expect(windows).toContain("package:win");
+    expect(windows).toContain("test:windows-installed-self-test");
+    expect(windows).not.toContain("vitest run");
+  });
+
+  it("caches Docker layers and cancels obsolete image builds", () => {
+    expect(image).toContain("cancel-in-progress: true");
+    expect(image).toContain("cache-from: type=gha,scope=cycling-coach");
+    expect(image).toContain("cache-to: type=gha,mode=max,scope=cycling-coach");
+  });
+});

--- a/apps/desktop/tests/verify-packaged-self-test.test.ts
+++ b/apps/desktop/tests/verify-packaged-self-test.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { shouldPrepareDevelopmentPackage } from "../scripts/verify-packaged-self-test.mjs";
+
+describe("packaged self-test preparation", () => {
+  it("builds by default and reuses an explicitly prepared package", () => {
+    expect(shouldPrepareDevelopmentPackage([])).toBe(true);
+    expect(shouldPrepareDevelopmentPackage(["--prepared-package"])).toBe(false);
+  });
+
+  it.each([{ arguments_: ["--unknown"] }, { arguments_: ["--prepared-package", "extra"] }])(
+    "rejects unsupported arguments $arguments_",
+    ({ arguments_ }) => {
+      expect(() => shouldPrepareDevelopmentPackage(arguments_)).toThrow(
+        "arguments are not supported",
+      );
+    },
+  );
+});

--- a/apps/desktop/tests/windows-parity-contract.test.ts
+++ b/apps/desktop/tests/windows-parity-contract.test.ts
@@ -70,12 +70,13 @@ describe("Windows parity automation contract", () => {
       ) ?? [];
     const windowsJob = workflow
       .split("  windows-desktop-package:")[1]
-      ?.split(/\r?\n  desktop-integration-macos:/u)[0];
+      ?.split(/\r?\n  [a-z0-9_-]+:/u)[0];
+    const linuxCheckJob = workflow.split("  check:")[1]?.split(/\r?\n  [a-z0-9_-]+:/u)[0];
     expect(packageCommands).toHaveLength(1);
     expect(installedCommands).toHaveLength(1);
-    expect(windowsJob).toContain(
-      "pnpm exec vitest run apps/desktop/tests/windows-package-layout.test.ts apps/desktop/tests/windows-package-plan.test.ts apps/desktop/tests/windows-installed-package.test.ts apps/desktop/tests/windows-parity-contract.test.ts --maxWorkers=1",
-    );
+    expect(linuxCheckJob).toContain("pnpm exec vitest run --shard=1/2");
+    expect(linuxCheckJob).toContain("pnpm exec vitest run --shard=2/2");
+    expect(windowsJob).not.toContain("Run Windows package contract tests");
     expect(windowsJob).not.toContain("pnpm exec vitest run apps/desktop/tests ");
     expect(windowsJob).not.toContain("@enduragent/desktop-renderer test");
     expect(workflow.indexOf(packageCommands[0]!)).toBeLessThan(


### PR DESCRIPTION
## Summary

- consolidate Linux build, tests, S8A, and package smoke into one prepared workspace while preserving required `test` and `smoke` statuses
- run Desktop E2E on Linux for scoped PRs and move the full macOS integration/E2E suite to one daily or manual job
- scope native macOS and Windows packaging to Desktop dependency changes, fold the Node 22 Keychain test into the macOS job, and reuse its prepared package
- keep Windows-only NSIS build/install/uninstall checks while leaving platform-independent contracts in the Linux shards
- cache Docker BuildKit layers and cancel obsolete CI and image builds

## Required checks

The existing `test`, `smoke`, `secrets-macos`, and `desktop-packaged-self-test` status names remain present. Cheap Ubuntu wrappers propagate the consolidated/native results so the active main ruleset does not need to change.

## Validation

- workflow YAML parse and `git diff --check`
- 150 focused workflow, package, and Windows contract tests
- full workspace build and package TypeScript checks
- root type check and oxlint
- fixture privacy, dependency, trademark, registry, kernel, changeset, and schema checks
- S8A replay and self-test
- autoreview clean with no accepted/actionable findings

No changeset: infrastructure-only.