### PR TITLE
fix(chat): recover repeated queue disconnects

### DIFF
--- a/.changeset/recover-chat-retry-relaunch.md
+++ b/.changeset/recover-chat-retry-relaunch.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/core": patch
+"@enduragent/engine": patch
+"@enduragent/coach": patch
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Chat recovery now survives repeated connection losses without duplicating your message after relaunch, while preserving every partial and completed Coach response.

--- a/apps/desktop-renderer/src/archive/controller.ts
+++ b/apps/desktop-renderer/src/archive/controller.ts
@@ -73,10 +73,11 @@ function uniqueTurns(
   incoming: readonly TranscriptTurn[],
   existing: readonly TranscriptTurn[],
 ): readonly TranscriptTurn[] {
-  const seen = new Set(existing.map((turn) => turn.turnId));
+  const seen = new Set(existing.map((turn) => JSON.stringify(turn)));
   return incoming.filter((turn) => {
-    if (seen.has(turn.turnId)) return false;
-    seen.add(turn.turnId);
+    const key = JSON.stringify(turn);
+    if (seen.has(key)) return false;
+    seen.add(key);
     return true;
   });
 }

--- a/apps/desktop-renderer/src/chat/hydration.ts
+++ b/apps/desktop-renderer/src/chat/hydration.ts
@@ -9,6 +9,7 @@ export interface TranscriptTurn {
   readonly completedAt: string;
   readonly athleteText: string;
   readonly coachText: string;
+  readonly delivery?: "interrupted";
   readonly attachments?: Extract<TranscriptPageEntry, { readonly kind: "turn" }>["attachments"];
   readonly planReference?: Extract<TranscriptPageEntry, { readonly kind: "turn" }>["planReference"];
   readonly planHandoff?: Extract<TranscriptPageEntry, { readonly kind: "turn" }>["planHandoff"];
@@ -79,10 +80,11 @@ function uniqueTurns(
   incoming: readonly TranscriptTurn[],
   existing: readonly TranscriptTurn[] = [],
 ): readonly TranscriptTurn[] {
-  const seen = new Set(existing.map((turn) => turn.turnId));
+  const seen = new Set(existing.map((turn) => JSON.stringify(turn)));
   return incoming.filter((turn) => {
-    if (seen.has(turn.turnId)) return false;
-    seen.add(turn.turnId);
+    const key = JSON.stringify(turn);
+    if (seen.has(key)) return false;
+    seen.add(key);
     return true;
   });
 }
@@ -115,9 +117,26 @@ export function mergeHydratedMessages(
   );
   const projectedEntries: readonly TranscriptPageEntry[] =
     entries.length > 0 ? entries : turns.map((turn) => ({ kind: "turn", ...turn }));
+  const turnAttempts = new Map<string, number>();
   const history = projectedEntries.flatMap((entry): readonly ChatTranscriptMessage[] => {
     if (entry.kind === "turn") {
       if (liveTurnIds.has(entry.turnId)) return [];
+      const attempt = (turnAttempts.get(entry.turnId) ?? 0) + 1;
+      turnAttempts.set(entry.turnId, attempt);
+      const coach: ChatTranscriptMessage = {
+        id:
+          attempt === 1
+            ? `history:coach:${entry.turnId}`
+            : `history:coach:${entry.turnId}:attempt:${attempt}`,
+        turnId: entry.turnId,
+        role: "coach",
+        text: entry.coachText,
+        delivery: entry.delivery ?? "complete",
+        historical: true,
+        ...(entry.planReference === undefined ? {} : { planReference: entry.planReference }),
+        ...(entry.planHandoff === undefined ? {} : { planHandoff: entry.planHandoff }),
+      };
+      if (attempt > 1) return [coach];
       return [
         {
           id: `history:athlete:${entry.turnId}`,
@@ -128,16 +147,7 @@ export function mergeHydratedMessages(
           historical: true,
           ...(entry.attachments === undefined ? {} : { attachments: entry.attachments }),
         },
-        {
-          id: `history:coach:${entry.turnId}`,
-          turnId: entry.turnId,
-          role: "coach",
-          text: entry.coachText,
-          delivery: entry.delivery ?? "complete",
-          historical: true,
-          ...(entry.planReference === undefined ? {} : { planReference: entry.planReference }),
-          ...(entry.planHandoff === undefined ? {} : { planHandoff: entry.planHandoff }),
-        },
+        coach,
       ];
     }
     if (
@@ -208,7 +218,10 @@ export function createTranscriptHydrator(input: {
       mode === "initial"
         ? uniqueTurns(page.turns)
         : [...uniqueTurns(page.turns, snapshot.turns), ...snapshot.turns];
-    const pageEntries = page.schemaVersion === 2 ? page.entries : [];
+    const pageEntries: readonly TranscriptPageEntry[] =
+      page.schemaVersion === 2
+        ? page.entries
+        : page.turns.map((turn) => ({ kind: "turn", ...turn }));
     const entries =
       mode === "initial"
         ? uniqueEntries(pageEntries)

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -65,11 +65,14 @@ function historicalTimeline(
   liveDecisionIds: ReadonlySet<string>,
 ): readonly ChatTranscriptItemView[] {
   const requested = new Map<string, CoachDecisionReadModel>();
+  const turnAttempts = new Map<string, number>();
   const timeline: ChatTranscriptItemView[] = [];
   for (const entry of entries) {
     if (entry.kind === "turn") {
-      timeline.push(
-        {
+      const attempt = (turnAttempts.get(entry.turnId) ?? 0) + 1;
+      turnAttempts.set(entry.turnId, attempt);
+      if (attempt === 1) {
+        timeline.push({
           kind: "message",
           message: {
             id: `history:athlete:${entry.turnId}`,
@@ -80,21 +83,24 @@ function historicalTimeline(
             text: entry.athleteText,
             ...(entry.attachments === undefined ? {} : { attachments: entry.attachments }),
           },
+        });
+      }
+      timeline.push({
+        kind: "message",
+        message: {
+          id:
+            attempt === 1
+              ? `history:coach:${entry.turnId}`
+              : `history:coach:${entry.turnId}:attempt:${attempt}`,
+          turnId: entry.turnId,
+          role: "coach",
+          delivery: entry.delivery ?? "complete",
+          historical: true,
+          text: entry.coachText,
+          ...(entry.planReference === undefined ? {} : { planReference: entry.planReference }),
+          ...(entry.planHandoff === undefined ? {} : { planHandoff: entry.planHandoff }),
         },
-        {
-          kind: "message",
-          message: {
-            id: `history:coach:${entry.turnId}`,
-            turnId: entry.turnId,
-            role: "coach",
-            delivery: "complete",
-            historical: true,
-            text: entry.coachText,
-            ...(entry.planReference === undefined ? {} : { planReference: entry.planReference }),
-            ...(entry.planHandoff === undefined ? {} : { planHandoff: entry.planHandoff }),
-          },
-        },
-      );
+      });
       continue;
     }
     const decisionId =

--- a/apps/desktop-renderer/src/ui/archive/ArchiveView.tsx
+++ b/apps/desktop-renderer/src/ui/archive/ArchiveView.tsx
@@ -41,19 +41,25 @@ import {
 const NOTE_CLASS = "mb-3.5 text-sm text-ink-2";
 const ACTION_CLASS = "justify-self-start [&[hidden]]:hidden";
 
-function TurnRows(props: { readonly turn: TranscriptTurn }): ReactElement {
+function TurnRows(props: {
+  readonly turn: TranscriptTurn;
+  readonly includeAthlete: boolean;
+}): ReactElement {
   return (
     <>
-      <article
-        className="archive-message archive-message--athlete grid min-w-0 max-w-[78%] justify-self-end gap-[7px] rounded-card rounded-br-ctl border border-line bg-surface px-4 py-3 shadow-elev-1"
-        data-turn-id={props.turn.turnId}
-      >
-        <p className="m-0 text-xs font-medium text-ink-3">You</p>
-        <AthleteMessage text={props.turn.athleteText} />
-      </article>
+      {props.includeAthlete ? (
+        <article
+          className="archive-message archive-message--athlete grid min-w-0 max-w-[78%] justify-self-end gap-[7px] rounded-card rounded-br-ctl border border-line bg-surface px-4 py-3 shadow-elev-1"
+          data-turn-id={props.turn.turnId}
+        >
+          <p className="m-0 text-xs font-medium text-ink-3">You</p>
+          <AthleteMessage text={props.turn.athleteText} />
+        </article>
+      ) : null}
       <article
         className="archive-message archive-message--coach grid min-w-0 max-w-[78%] justify-self-start gap-[7px] font-[var(--f-prose)] text-base leading-[1.6] tracking-[0.002em]"
         data-turn-id={props.turn.turnId}
+        data-delivery={props.turn.delivery ?? "complete"}
       >
         <p className="m-0 text-xs font-medium text-ink-3">Coach</p>
         <CoachMessage text={props.turn.coachText} />
@@ -139,6 +145,12 @@ function ArchiveReader(props: { readonly reading: ArchiveReadingState }): ReactE
   const deleteOpen = deletion?.boundaryRef === reading.boundaryRef;
   const deletePending = deleteOpen && deletion.status === "deleting";
   const deleteFailed = deleteOpen && deletion.status === "failed";
+  const attempts = new Map<string, number>();
+  const projectedTurns = reading.turns.map((turn) => {
+    const attempt = (attempts.get(turn.turnId) ?? 0) + 1;
+    attempts.set(turn.turnId, attempt);
+    return { turn, attempt };
+  });
 
   return (
     <>
@@ -274,8 +286,12 @@ function ArchiveReader(props: { readonly reading: ArchiveReadingState }): ReactE
         {ARCHIVE_EMPTY_CONVERSATION_COPY}
       </p>
       <section className="archive-thread grid gap-6" aria-label="Past conversation" aria-live="off">
-        {reading.turns.map((turn) => (
-          <TurnRows key={turn.turnId} turn={turn} />
+        {projectedTurns.map(({ turn, attempt }) => (
+          <TurnRows
+            key={`${turn.turnId}:attempt:${attempt}`}
+            turn={turn}
+            includeAthlete={attempt === 1}
+          />
         ))}
       </section>
     </>

--- a/apps/desktop-renderer/tests/archive-controller.test.ts
+++ b/apps/desktop-renderer/tests/archive-controller.test.ts
@@ -260,7 +260,7 @@ describe("archive controller reader", () => {
     expect(subject.current().conversations).toHaveLength(2);
   });
 
-  it("drops duplicate turn ids while prepending an earlier page", async () => {
+  it("drops exact duplicate turns while prepending an overlapping earlier page", async () => {
     const readPage = vi.fn(async (request: { readonly cursor: string | null }) =>
       request.cursor === null ? page(["turn-2"], "cursor-1") : page(["turn-1", "turn-2"]),
     );
@@ -273,6 +273,35 @@ describe("archive controller reader", () => {
     expect(subject.current().reading?.turns.map((turn) => turn.turnId)).toEqual([
       "turn-1",
       "turn-2",
+    ]);
+  });
+
+  it("preserves distinct delivery attempts that share one logical turn id", async () => {
+    const interrupted = {
+      ...page(["turn-recovered"]).turns[0]!,
+      coachText: "Partial",
+      delivery: "interrupted" as const,
+    };
+    const recovered = {
+      ...page(["turn-recovered"]).turns[0]!,
+      completedAt: "1998-07-19T07:01:00.000Z",
+      coachText: "Recovered",
+    };
+    const subject = harness({
+      readPage: async () => ({
+        schemaVersion: 1,
+        status: "page",
+        turns: [interrupted, recovered],
+        nextCursor: null,
+      }),
+    });
+
+    await subject.controller.refresh();
+    await subject.controller.open(NEWER);
+
+    expect(subject.current().reading?.turns).toMatchObject([
+      { turnId: "turn-recovered", coachText: "Partial", delivery: "interrupted" },
+      { turnId: "turn-recovered", coachText: "Recovered" },
     ]);
   });
 

--- a/apps/desktop-renderer/tests/archive-surface.test.tsx
+++ b/apps/desktop-renderer/tests/archive-surface.test.tsx
@@ -229,6 +229,32 @@ describe("past chats reader", () => {
     expect(actions.open).not.toHaveBeenCalled();
   });
 
+  it("renders one athlete row and every Coach attempt for a recovered logical turn", () => {
+    const actions = archiveActions();
+    render(<ArchiveView />);
+    const first = reading().reading!.turns[0]!;
+    set(
+      reading({
+        turns: [
+          { ...first, coachText: "Partial", delivery: "interrupted" },
+          {
+            ...first,
+            completedAt: "1998-07-19T07:01:00.000Z",
+            coachText: "Recovered",
+          },
+        ],
+      }),
+      actions,
+    );
+
+    const thread = screen.getByRole("region", { name: "Past conversation" });
+    expect(thread.querySelectorAll(".archive-message--athlete")).toHaveLength(1);
+    expect(thread.querySelectorAll(".archive-message--coach")).toHaveLength(2);
+    expect(thread.querySelectorAll('[data-delivery="interrupted"]')).toHaveLength(1);
+    expect(thread).toHaveTextContent("Partial");
+    expect(thread).toHaveTextContent("Recovered");
+  });
+
   it("pages earlier messages and blocks the pill while a page is in flight", async () => {
     const user = userEvent.setup();
     const actions = archiveActions();

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -517,6 +517,73 @@ describe("chat view adapter", () => {
     });
   });
 
+  it("projects one historical athlete row and every Coach retry attempt", () => {
+    const published: ChatSurfaceState[] = [];
+    const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
+    const interrupted = {
+      kind: "turn" as const,
+      turnId: "persisted-retry",
+      completedAt: "2001-01-01T00:00:00.000Z",
+      athleteText: "First",
+      coachText: "Partial",
+      delivery: "interrupted" as const,
+    };
+
+    adapter.view.render(
+      EMPTY_CHAT_STATE,
+      controls({
+        hydration: {
+          status: "ready",
+          hasEarlier: false,
+          revision: 1,
+          change: "initial",
+          entries: [
+            interrupted,
+            {
+              kind: "turn",
+              turnId: "persisted-retry",
+              completedAt: "2001-01-01T00:01:00.000Z",
+              athleteText: "First",
+              coachText: "Recovered",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(
+      published.at(-1)?.timeline.map((item) =>
+        item.kind === "message"
+          ? {
+              id: item.message.id,
+              role: item.message.role,
+              text: item.message.text,
+              delivery: item.message.delivery,
+            }
+          : { kind: item.kind },
+      ),
+    ).toEqual([
+      {
+        id: "history:athlete:persisted-retry",
+        role: "athlete",
+        text: "First",
+        delivery: "complete",
+      },
+      {
+        id: "history:coach:persisted-retry",
+        role: "coach",
+        text: "Partial",
+        delivery: "interrupted",
+      },
+      {
+        id: "history:coach:persisted-retry:attempt:2",
+        role: "coach",
+        text: "Recovered",
+        delivery: "complete",
+      },
+    ]);
+  });
+
   it("keeps sending available while a turn streams and exposes the queue for the strip", () => {
     const published: ChatSurfaceState[] = [];
     const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });

--- a/apps/desktop-renderer/tests/chat-hydration.test.ts
+++ b/apps/desktop-renderer/tests/chat-hydration.test.ts
@@ -157,6 +157,33 @@ describe("chat transcript hydration", () => {
     expect(snapshots.at(-1)).toMatchObject({ nextCursor: null, change: "prepend" });
   });
 
+  it("deduplicates exact records across overlapping pages without collapsing retry attempts", async () => {
+    const interrupted = {
+      ...turn("turn-recovered"),
+      coachText: "Partial",
+      delivery: "interrupted" as const,
+    };
+    const recovered = {
+      ...turn("turn-recovered"),
+      completedAt: "2001-01-01T00:01:00.000Z",
+      coachText: "Recovered",
+    };
+    const readPage = vi
+      .fn()
+      .mockResolvedValueOnce(page([recovered, turn("turn-later")], "older"))
+      .mockResolvedValueOnce(page([interrupted, recovered], null));
+    const { hydrator, snapshots } = subject(readPage);
+
+    await hydrator.start();
+    await hydrator.loadEarlier();
+
+    expect(snapshots.at(-1)?.turns.map(({ turnId, coachText }) => [turnId, coachText])).toEqual([
+      ["turn-recovered", "Partial"],
+      ["turn-recovered", "Recovered"],
+      ["turn-later", "Coach turn-later"],
+    ]);
+  });
+
   it("deduplicates a hydrated turn against live rows by turn identity", () => {
     const live: readonly ChatTranscriptMessage[] = [
       {
@@ -206,6 +233,159 @@ describe("chat transcript hydration", () => {
         delivery: "interrupted",
         historical: true,
       },
+    ]);
+  });
+
+  it("relaunches a recovered durable turn with one athlete row and every Coach attempt", async () => {
+    const interrupted = {
+      ...turn("turn-recovered"),
+      athleteText: "First",
+      coachText: "Partial",
+      delivery: "interrupted" as const,
+    };
+    const recovered = {
+      ...turn("turn-recovered"),
+      completedAt: "2001-01-01T00:01:00.000Z",
+      athleteText: "First",
+      coachText: "Recovered",
+    };
+    const later = {
+      ...turn("turn-later"),
+      completedAt: "2001-01-01T00:02:00.000Z",
+      athleteText: "Later one\n\nLater two",
+      coachText: "Later reply",
+    };
+    const { hydrator, snapshots } = subject(async () =>
+      page([interrupted, recovered, later], null),
+    );
+
+    await hydrator.start();
+
+    expect(mergeHydratedMessages(snapshots.at(-1)!.turns, [])).toMatchObject([
+      { role: "athlete", text: "First", delivery: "complete" },
+      { role: "coach", text: "Partial", delivery: "interrupted" },
+      { role: "coach", text: "Recovered", delivery: "complete" },
+      { role: "athlete", text: "Later one\n\nLater two", delivery: "complete" },
+      { role: "coach", text: "Later reply", delivery: "complete" },
+    ]);
+  });
+
+  it("projects schema-v2 retry entries with one athlete row and unique Coach rows", async () => {
+    const interrupted = {
+      kind: "turn" as const,
+      ...turn("turn-recovered-v2"),
+      athleteText: "First",
+      coachText: "Partial",
+      delivery: "interrupted" as const,
+    };
+    const recovered = {
+      kind: "turn" as const,
+      ...turn("turn-recovered-v2"),
+      completedAt: "2001-01-01T00:01:00.000Z",
+      athleteText: "First",
+      coachText: "Recovered",
+    };
+    const readPage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        schemaVersion: 2,
+        status: "page",
+        turns: [recovered],
+        entries: [recovered],
+        nextCursor: "older",
+      })
+      .mockResolvedValueOnce({
+        schemaVersion: 2,
+        status: "page",
+        turns: [interrupted, recovered],
+        entries: [interrupted, recovered],
+        nextCursor: null,
+      });
+    const { hydrator, snapshots } = subject(readPage);
+
+    await hydrator.start();
+    await hydrator.loadEarlier();
+
+    expect(
+      mergeHydratedMessages(snapshots.at(-1)!.turns, [], snapshots.at(-1)!.entries).map(
+        ({ id, role, text, delivery }) => ({ id, role, text, delivery }),
+      ),
+    ).toEqual([
+      {
+        id: "history:athlete:turn-recovered-v2",
+        role: "athlete",
+        text: "First",
+        delivery: "complete",
+      },
+      {
+        id: "history:coach:turn-recovered-v2",
+        role: "coach",
+        text: "Partial",
+        delivery: "interrupted",
+      },
+      {
+        id: "history:coach:turn-recovered-v2:attempt:2",
+        role: "coach",
+        text: "Recovered",
+        delivery: "complete",
+      },
+    ]);
+  });
+
+  it("preserves newer schema-v1 retry turns after an older schema-v2 page loads", async () => {
+    const interrupted = {
+      ...turn("turn-recovered-mixed"),
+      athleteText: "First",
+      coachText: "Partial",
+      delivery: "interrupted" as const,
+    };
+    const recovered = {
+      ...turn("turn-recovered-mixed"),
+      completedAt: "2001-01-01T00:01:00.000Z",
+      athleteText: "First",
+      coachText: "Recovered",
+    };
+    const later = {
+      ...turn("turn-later-mixed"),
+      completedAt: "2001-01-01T00:02:00.000Z",
+      athleteText: "Later one\n\nLater two",
+      coachText: "Later reply",
+    };
+    const older = {
+      kind: "turn" as const,
+      ...turn("turn-older-mixed"),
+      athleteText: "Older",
+      coachText: "Older reply",
+    };
+    const readPage = vi
+      .fn()
+      .mockResolvedValueOnce(page([interrupted, recovered, later], "older"))
+      .mockResolvedValueOnce({
+        schemaVersion: 2,
+        status: "page",
+        turns: [older],
+        entries: [older],
+        nextCursor: null,
+      });
+    const { hydrator, snapshots } = subject(readPage);
+
+    await hydrator.start();
+    await hydrator.loadEarlier();
+
+    expect(
+      mergeHydratedMessages([], [], snapshots.at(-1)!.entries).map(({ role, text, delivery }) => ({
+        role,
+        text,
+        delivery,
+      })),
+    ).toEqual([
+      { role: "athlete", text: "Older", delivery: "complete" },
+      { role: "coach", text: "Older reply", delivery: "complete" },
+      { role: "athlete", text: "First", delivery: "complete" },
+      { role: "coach", text: "Partial", delivery: "interrupted" },
+      { role: "coach", text: "Recovered", delivery: "complete" },
+      { role: "athlete", text: "Later one\n\nLater two", delivery: "complete" },
+      { role: "coach", text: "Later reply", delivery: "complete" },
     ]);
   });
 

--- a/apps/desktop/tests/chat-recovery-relaunch.integration.test.ts
+++ b/apps/desktop/tests/chat-recovery-relaunch.integration.test.ts
@@ -65,6 +65,11 @@ const queuedMessageText = "Also preserve my easy Friday ride.";
 const requestId = "request-recovery";
 const attachmentDraftText = "Compare this workout with my current week.";
 const decisionQuestion = "Which priority should guide the next workout?";
+const recoveredAthleteText = "Keep the first recovery message.";
+const recoveredPartialText = "Partial recovery guidance.";
+const recoveredCoachText = "Recovered recovery guidance.";
+const laterAthleteText = "Later one\n\nLater two";
+const laterCoachText = "Later reply.";
 const fixtures: RunningDesktopFixture[] = [];
 const backends: RecoveryBackend[] = [];
 const scratchPaths: string[] = [];
@@ -159,6 +164,14 @@ class RecoveryBackend {
         this.calls.push(request);
         if (request.method === "getChatQueue") {
           return response(this.requireConversation().getChatQueue(chatId));
+        }
+        if (request.method === "getTranscriptPage") {
+          return response(
+            this.requireConversation().readCurrentConversationPage(chatId, {
+              cursor: request.params.cursor === null ? null : String(request.params.cursor),
+              limit: Number(request.params.limit),
+            }),
+          );
         }
         if (request.method === "getCoachDecision") {
           return response({ decision: this.requireConversation().getDecision(chatId) });
@@ -276,6 +289,30 @@ class RecoveryBackend {
       queuedMessageId,
       "message-queue-recovery",
     );
+    if (conversation.appendInterruptedTurn === undefined) {
+      throw new TypeError("interrupted transcript persistence is unavailable");
+    }
+    conversation.appendInterruptedTurn({
+      chatId,
+      turnId: "turn-chat-recovery",
+      completedAt: "1998-08-24T07:57:00.000Z",
+      athleteText: recoveredAthleteText,
+      coachText: recoveredPartialText,
+    });
+    conversation.appendCompletedTurn({
+      chatId,
+      turnId: "turn-chat-recovery",
+      completedAt: "1998-08-24T07:58:00.000Z",
+      athleteText: recoveredAthleteText,
+      coachText: recoveredCoachText,
+    });
+    conversation.appendCompletedTurn({
+      chatId,
+      turnId: "turn-chat-later",
+      completedAt: "1998-08-24T07:59:00.000Z",
+      athleteText: laterAthleteText,
+      coachText: laterCoachText,
+    });
     conversation.appendDecisionRequested({
       turnId: "turn-decision-recovery",
       toolCallId: "tool-decision-recovery",
@@ -418,11 +455,30 @@ async function readRecoverySurface(fixture: RunningDesktopFixture) {
     readonly sendDisabled: boolean;
     readonly inputDisabled: boolean;
     readonly projectionOrder: readonly string[];
+    readonly recoveryTranscript: readonly {
+      readonly role: "athlete" | "coach";
+      readonly text: string;
+      readonly delivery: string | null;
+    }[];
   }>(`
     const question = ${JSON.stringify(decisionQuestion)};
     const queueText = ${JSON.stringify(queuedMessageText)};
     const draftText = ${JSON.stringify(attachmentDraftText)};
     const requestId = ${JSON.stringify(requestId)};
+    const recoveryTexts = new Set(${JSON.stringify([
+      recoveredAthleteText,
+      recoveredPartialText,
+      recoveredCoachText,
+      laterAthleteText,
+      laterCoachText,
+    ])});
+    const expectedRecoveryTexts = ${JSON.stringify([
+      recoveredAthleteText,
+      recoveredPartialText,
+      recoveredCoachText,
+      laterAthleteText,
+      laterCoachText,
+    ])};
     const deadline = Date.now() + 10000;
     let decision;
     let attachment;
@@ -437,6 +493,9 @@ async function readRecoverySurface(fixture: RunningDesktopFixture) {
       queue = document.querySelector("section.chat-queue");
       plan = document.querySelector('[data-planning-request-id="' + requestId + '"]');
       composer = document.querySelector("#message");
+      const recoveryTranscript = [...document.querySelectorAll("article.chat-message")]
+        .map((element) => element.querySelector(".chat-message__text")?.textContent?.trim() ?? "")
+        .filter((text) => recoveryTexts.has(text));
       if (
         decision instanceof HTMLElement &&
         attachment instanceof HTMLElement &&
@@ -444,7 +503,8 @@ async function readRecoverySurface(fixture: RunningDesktopFixture) {
         queue.textContent?.includes(queueText) &&
         plan instanceof HTMLElement &&
         composer instanceof HTMLTextAreaElement &&
-        composer.value === draftText
+        composer.value === draftText &&
+        JSON.stringify(recoveryTranscript) === JSON.stringify(expectedRecoveryTexts)
       ) break;
       await new Promise((resolve) => setTimeout(resolve, 20));
     }
@@ -465,6 +525,16 @@ async function readRecoverySurface(fixture: RunningDesktopFixture) {
       .map((element) =>
         element === decision ? "decision" : element === attachment ? "attachment" : "queue",
       );
+    const recoveryTranscript = [...document.querySelectorAll("article.chat-message")]
+      .flatMap((element) => {
+        const text = element.querySelector(".chat-message__text")?.textContent?.trim() ?? "";
+        if (!recoveryTexts.has(text)) return [];
+        return [{
+          role: element.classList.contains("chat-message--athlete") ? "athlete" : "coach",
+          text,
+          delivery: element.getAttribute("data-delivery"),
+        }];
+      });
     return {
       questionCount: [...document.querySelectorAll(".composer-projections section")].filter(
         (element) => element.textContent?.includes(question),
@@ -484,6 +554,7 @@ async function readRecoverySurface(fixture: RunningDesktopFixture) {
       sendDisabled: send.disabled,
       inputDisabled: composer.disabled,
       projectionOrder,
+      recoveryTranscript,
     };
   `);
 }
@@ -580,6 +651,13 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)(
         sendDisabled: true,
         inputDisabled: false,
         projectionOrder: ["decision", "attachment", "queue"],
+        recoveryTranscript: [
+          { role: "athlete", text: recoveredAthleteText, delivery: "complete" },
+          { role: "coach", text: recoveredPartialText, delivery: "interrupted" },
+          { role: "coach", text: recoveredCoachText, delivery: "complete" },
+          { role: "athlete", text: laterAthleteText, delivery: "complete" },
+          { role: "coach", text: laterCoachText, delivery: "complete" },
+        ],
       });
       const firstRecovery = await backend.snapshot();
       expect(firstRecovery).toMatchObject({

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -276,7 +276,7 @@ async function closeTransport(transport: CoachVerbTransport | undefined): Promis
 }
 
 describe.skipIf(!hasLoopback)("CLI verbs over real RPC framing", () => {
-  it("recovers a detached active queue claim and drains later ordinary work once", async () => {
+  it("replays an active exact retry after a second disconnect and drains later work once", async () => {
     const dataDir = await mkdtemp(join(await realpath(tmpdir()), "coach-queue-rpc-"));
     await mkdir(join(dataDir, "memory"), { recursive: true });
     const requests: ModelTransportRequest[] = [];
@@ -284,6 +284,11 @@ describe.skipIf(!hasLoopback)("CLI verbs over real RPC framing", () => {
     const firstStarted = new Promise<void>((resolve) => {
       started = resolve;
     });
+    let announceRetryStarted!: () => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      announceRetryStarted = resolve;
+    });
+    let finishRetry: (() => void) | undefined;
     const generated = (text: string): GenerateResult => {
       const usage = {
         inputTokens: 1,
@@ -306,7 +311,18 @@ describe.skipIf(!hasLoopback)("CLI verbs over real RPC framing", () => {
             });
           });
         }
-        return Promise.resolve(generated(requests.length === 2 ? "Recovered" : "Later reply"));
+        if (requests.length === 2) {
+          announceRetryStarted();
+          return new Promise<GenerateResult>((resolve, reject) => {
+            finishRetry = () => resolve(generated("Recovered"));
+            request.options.signal?.addEventListener(
+              "abort",
+              () => reject(new Error("retry stopped")),
+              { once: true },
+            );
+          });
+        }
+        return Promise.resolve(generated("Later reply"));
       },
     });
     const config: Config = {
@@ -364,12 +380,13 @@ describe.skipIf(!hasLoopback)("CLI verbs over real RPC framing", () => {
       modelTransportDecorator,
     };
     const queueEngine = createCoachEngine({ sport: cyclingSport, ports });
+    const directChat = vi.spyOn(queueEngine, "chat");
     const running = await startRpc(queueEngine);
     const clients: CoachClient[] = [];
     const chatId = "desktop";
     let firstTurnId: string | undefined;
     try {
-      const first = await connectCoachClient({ url: running.url, token });
+      const first = await connectCoachClient({ url: running.url, token, closeTimeoutMs: 250 });
       clients.push(first);
       await first.call("enqueueChatMessage", {
         chatId,
@@ -410,9 +427,13 @@ describe.skipIf(!hasLoopback)("CLI verbs over real RPC framing", () => {
       await serverObservedDisconnect;
       expect(await firstOutcome).toBeInstanceOf(CoachClientDisconnectedError);
 
-      const recovered = await connectCoachClient({ url: running.url, token });
-      clients.push(recovered);
-      const recovery = await recovered.call("getChatQueue", { chatId });
+      const retryClient = await connectCoachClient({
+        url: running.url,
+        token,
+        closeTimeoutMs: 250,
+      });
+      clients.push(retryClient);
+      const recovery = await retryClient.call("getChatQueue", { chatId });
       expect(recovery.items.map((item) => item.text)).toEqual(["First", "Later one", "Later two"]);
       expect(recovery.retryRequired).toMatchObject({
         queuedMessageIds: [recovery.items[0]!.queuedMessageId],
@@ -420,16 +441,46 @@ describe.skipIf(!hasLoopback)("CLI verbs over real RPC framing", () => {
       });
 
       const retryEvents: TurnEvent[] = [];
-      const retried = await recovered.call(
+      const retryRun = retryClient.call(
         "retryQueuedTurn",
         { chatId, claimId: recovery.retryRequired!.claimId },
         { onEvent: (event) => retryEvents.push(event) },
       );
+      const retryOutcome = retryRun.catch((error: unknown) => error);
+      await retryStarted;
+      await vi.waitFor(() =>
+        expect(retryEvents.map((event) => event.type)).toEqual(["turn-start"]),
+      );
+      expect(retryEvents[0]?.turnId).toBe(firstTurnId);
+
+      const serverObservedRetryDisconnect = running.nextClientDisconnect();
+      const retryClosing = retryClient.close();
+      expect(await retryOutcome).toBeInstanceOf(CoachClientDisconnectedError);
+      await serverObservedRetryDisconnect;
+      await retryClosing;
+
+      const recovered = await connectCoachClient({ url: running.url, token, closeTimeoutMs: 250 });
+      clients.push(recovered);
+      const replayedEvents: TurnEvent[] = [];
+      const retriedRun = recovered.call(
+        "retryQueuedTurn",
+        { chatId, claimId: recovery.retryRequired!.claimId },
+        { onEvent: (event) => replayedEvents.push(event) },
+      );
+      await vi.waitFor(() =>
+        expect(replayedEvents.map((event) => event.type)).toEqual(["turn-start"]),
+      );
+      expect(replayedEvents[0]).toEqual(retryEvents[0]);
+      expect(requests).toHaveLength(2);
+      if (finishRetry === undefined) throw new Error("retry model did not start");
+      finishRetry();
+      const retried = await retriedRun;
       expect(retried.response?.text).toBe("Recovered");
       expect(retried.snapshot.retryRequired).toBeUndefined();
       expect(retried.snapshot.items.map((item) => item.text)).toEqual(["Later one", "Later two"]);
-      expect(retryEvents.map((event) => event.type)).toEqual(["turn-start", "final-text"]);
-      expect(retryEvents[0]?.turnId).not.toBe(firstTurnId);
+      expect(retryEvents.map((event) => event.type)).toEqual(["turn-start"]);
+      expect(replayedEvents.map((event) => event.type)).toEqual(["turn-start", "final-text"]);
+      expect(replayedEvents[0]).toEqual(retryEvents[0]);
 
       const laterEvents: TurnEvent[] = [];
       const drained = await recovered.call(
@@ -448,7 +499,41 @@ describe.skipIf(!hasLoopback)("CLI verbs over real RPC framing", () => {
       expect(userMessages.map((message) => message.content.split("\nCurrent time:", 1)[0])).toEqual(
         ["First", "First", "Later one\n\nLater two"],
       );
+      expect(directChat).not.toHaveBeenCalled();
+      expect(requests).toHaveLength(3);
+
+      const relaunched = createConversationStore(dataDir);
+      const persisted = relaunched.readCurrentConversationPage(chatId, { cursor: null, limit: 10 });
+      expect(
+        persisted.turns.map(({ turnId, athleteText, coachText, delivery }) => ({
+          turnId,
+          athleteText,
+          coachText,
+          delivery,
+        })),
+      ).toEqual([
+        {
+          turnId: firstTurnId,
+          athleteText: "First",
+          coachText: "Partial",
+          delivery: "interrupted",
+        },
+        {
+          turnId: firstTurnId,
+          athleteText: "First",
+          coachText: "Recovered",
+          delivery: undefined,
+        },
+        {
+          turnId: expect.any(String),
+          athleteText: "Later one\n\nLater two",
+          coachText: "Later reply",
+          delivery: undefined,
+        },
+      ]);
+      expect(persisted.turns[2]?.turnId).not.toBe(firstTurnId);
     } finally {
+      finishRetry?.();
       if (firstTurnId !== undefined) {
         await queueEngine.stopChat?.({ chatId, turnId: firstTurnId }).catch(() => undefined);
       }

--- a/packages/core/src/agent/transcript-store.ts
+++ b/packages/core/src/agent/transcript-store.ts
@@ -1163,12 +1163,12 @@ function encodedPageBytes(result: TranscriptPageResult): number {
   return Buffer.byteLength(JSON.stringify(result), "utf8");
 }
 
-function transcriptDecisionId(
+function transcriptUnitKey(
   record: Exclude<TranscriptRecord, TranscriptConversationBoundaryRecord>,
-): string | null {
+): string {
   return record.kind === "turn-completed" || record.kind === "turn-interrupted"
-    ? null
-    : record.decisionId;
+    ? `turn:${record.turnId}`
+    : `decision:${record.decisionId}`;
 }
 
 function decisionReadModels(
@@ -1266,13 +1266,9 @@ function backwardPage(
   let selected: readonly IndexedTranscriptTurn[] = [];
   let selectedUnits = 0;
   while (index >= 0 && selectedUnits < limit) {
-    const decisionId = transcriptDecisionId(turns[index]!.record);
+    const unitKey = transcriptUnitKey(turns[index]!.record);
     let unitStart = index;
-    while (
-      decisionId !== null &&
-      unitStart > 0 &&
-      transcriptDecisionId(turns[unitStart - 1]!.record) === decisionId
-    ) {
+    while (unitStart > 0 && transcriptUnitKey(turns[unitStart - 1]!.record) === unitKey) {
       unitStart -= 1;
     }
     const tentative = [...turns.slice(unitStart, index + 1), ...selected];
@@ -1745,12 +1741,19 @@ export class TranscriptStore implements TranscriptWriterPort {
             boundaryRef: segment.boundary.resetId,
             boundaryAt: segment.boundary.boundaryAt,
             reason: segment.boundary.reason,
-            turnCount: segment.turns.filter(
-              ({ record }) =>
-                record.kind === "turn-completed" ||
-                record.kind === "turn-interrupted" ||
-                record.kind === "decision-requested",
-            ).length,
+            turnCount: new Set(
+              segment.turns.flatMap(({ record }) => {
+                if (record.kind === "turn-completed" || record.kind === "turn-interrupted") {
+                  return [`turn:${record.turnId}`];
+                }
+                if (record.kind !== "decision-requested") return [];
+                return [
+                  record.turnId === undefined
+                    ? `decision:${record.decisionId}`
+                    : `turn:${record.turnId}`,
+                ];
+              }),
+            ).size,
           })),
           truncated: newestFirst.length > selected.length,
         };

--- a/packages/core/tests/transcript-store.test.ts
+++ b/packages/core/tests/transcript-store.test.ts
@@ -174,6 +174,38 @@ describe("TranscriptStore archived conversation reads", () => {
     expect(existsSync(transcriptPath(dataDir, "missing"))).toBe(false);
   });
 
+  it("counts and pages archived recovery attempts as one logical turn", () => {
+    const dataDir = makeDataDir();
+    const chatId = "archive-recovered-turn";
+    const store = new TranscriptStore(dataDir);
+    store.appendCompletedTurn(turn(chatId, "turn-1"));
+    store.appendInterruptedTurn(turn(chatId, "turn-2", "First", "Partial"));
+    store.appendCompletedTurn({
+      ...turn(chatId, "turn-2", "First", "Recovered"),
+      completedAt: "1998-07-22T00:01:00.000Z",
+    });
+    store.ensureConversationBoundary(intent(chatId, RESET_ID_A));
+
+    expect(store.listArchivedConversations(chatId).conversations[0]?.turnCount).toBe(2);
+    const newest = store.readArchivedConversationPage(chatId, RESET_ID_A, {
+      cursor: null,
+      limit: 1,
+    });
+    expect(newest.turns.map(({ turnId, coachText }) => [turnId, coachText])).toEqual([
+      ["turn-2", "Partial"],
+      ["turn-2", "Recovered"],
+    ]);
+    expect(newest.nextCursor).not.toBeNull();
+    expect(
+      store
+        .readArchivedConversationPage(chatId, RESET_ID_A, {
+          cursor: newest.nextCursor,
+          limit: 1,
+        })
+        .turns.map(({ turnId }) => turnId),
+    ).toEqual(["turn-1"]);
+  });
+
   it("caps the listed boundaries at the newest two hundred and reports truncation", () => {
     const dataDir = makeDataDir();
     const chatId = "archive-cap";
@@ -712,6 +744,30 @@ describe("TranscriptStore append and corruption handling", () => {
     });
     expect(oldest.turns.map((record) => record.turnId)).toEqual(["turn-1"]);
     expect(oldest.nextCursor).toBeNull();
+  });
+
+  it("keeps current recovery attempts together as one pagination unit", () => {
+    const dataDir = makeDataDir();
+    const chatId = "paginated-recovered-turn";
+    const store = new TranscriptStore(dataDir);
+    store.appendCompletedTurn(turn(chatId, "turn-1"));
+    store.appendInterruptedTurn(turn(chatId, "turn-2", "First", "Partial"));
+    store.appendCompletedTurn({
+      ...turn(chatId, "turn-2", "First", "Recovered"),
+      completedAt: "1998-07-22T00:01:00.000Z",
+    });
+
+    const newest = store.readCurrentConversationPage(chatId, { cursor: null, limit: 1 });
+    expect(newest.turns.map(({ turnId, coachText }) => [turnId, coachText])).toEqual([
+      ["turn-2", "Partial"],
+      ["turn-2", "Recovered"],
+    ]);
+    expect(newest.nextCursor).not.toBeNull();
+    expect(
+      store
+        .readCurrentConversationPage(chatId, { cursor: newest.nextCursor, limit: 1 })
+        .turns.map(({ turnId }) => turnId),
+    ).toEqual(["turn-1"]);
   });
 
   it("keeps a cursor snapshot stable while completed turns append concurrently", () => {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -92,13 +92,17 @@ export interface CreateCoachEngineInput {
   readonly ports: EngineHostPorts;
 }
 
+interface QueueRetryRun {
+  readonly claimId: string;
+  readonly task: Promise<ChatQueueRunResult>;
+  readonly events: TurnEvent[];
+  readonly subscribers: Set<(event: TurnEvent) => void>;
+}
+
 export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
   const agent = new CoachAgent(input.sport, input.ports);
   const queueRuns = new Map<string, Promise<ChatQueueRunResult>>();
-  const queueRetryRuns = new Map<
-    string,
-    { readonly claimId: string; readonly task: Promise<ChatQueueRunResult> }
-  >();
+  const queueRetryRuns = new Map<string, QueueRetryRun>();
   const deferredPlanTurns = new Map<string, DeferredPlanTurn>();
   const deferredKey = (chatId: string, turnId: string): string => `${chatId}:${turnId}`;
   const queueAuthorities = new Map<string, Promise<void>>();
@@ -148,18 +152,48 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
           "Use only these normalized local fields; raw attachment bytes were not provided.",
           JSON.stringify(activities),
         ].join("\n");
+  const subscribeQueueRetry = (
+    run: QueueRetryRun,
+    onEvent: ((event: TurnEvent) => void) | undefined,
+  ): void => {
+    if (onEvent === undefined) return;
+    if (run.subscribers.has(onEvent)) return;
+    for (const event of run.events) {
+      try {
+        onEvent(event);
+      } catch {}
+    }
+    run.subscribers.add(onEvent);
+  };
+  const publishQueueRetry = (run: QueueRetryRun, event: TurnEvent): void => {
+    run.events.push(event);
+    const subscribers = Array.from(run.subscribers);
+    for (const subscriber of subscribers) {
+      try {
+        subscriber(event);
+      } catch {}
+    }
+  };
   const runQueue = (
     chatId: string,
     mode: "resume" | "command" | "retry",
     exactId: string | undefined,
     onEvent: ((event: TurnEvent) => void) | undefined,
+    retryRunOverride?: QueueRetryRun,
   ): Promise<ChatQueueRunResult> => {
     const active = queueRuns.get(chatId);
     if (active !== undefined) {
       if (mode !== "retry" || exactId === undefined) return active;
       const existing = queueRetryRuns.get(chatId);
-      if (existing?.claimId === exactId) return existing.task;
+      if (existing?.claimId === exactId) {
+        subscribeQueueRetry(existing, onEvent);
+        return existing.task;
+      }
       if (existing !== undefined) return snapshot(chatId).then((value) => ({ snapshot: value }));
+      const events: TurnEvent[] = [];
+      const subscribers = new Set<(event: TurnEvent) => void>();
+      if (onEvent !== undefined) subscribers.add(onEvent);
+      let retryRun!: QueueRetryRun;
       const task = (async (): Promise<ChatQueueRunResult> => {
         const before = await snapshot(chatId);
         const recovery = before.retryRequired;
@@ -167,15 +201,23 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
         agent.stopChat(chatId, recovery.turnId);
         await active.catch(() => undefined);
         if (queueRuns.get(chatId) === active) queueRuns.delete(chatId);
-        return runQueue(chatId, "retry", exactId, onEvent);
+        if (queueRetryRuns.get(chatId) === retryRun) queueRetryRuns.delete(chatId);
+        return runQueue(chatId, "retry", exactId, undefined, retryRun);
       })();
-      queueRetryRuns.set(chatId, { claimId: exactId, task });
+      retryRun = { claimId: exactId, task, events, subscribers };
+      queueRetryRuns.set(chatId, retryRun);
       const release = (): void => {
         if (queueRetryRuns.get(chatId)?.task === task) queueRetryRuns.delete(chatId);
       };
       void task.then(release, release);
       return task;
     }
+    const retryEvents = retryRunOverride?.events ?? [];
+    const retrySubscribers = retryRunOverride?.subscribers ?? new Set<(event: TurnEvent) => void>();
+    if (mode === "retry" && onEvent !== undefined && retryRunOverride === undefined) {
+      retrySubscribers.add(onEvent);
+    }
+    let retryRun = retryRunOverride;
     const task = withQueueAuthority(chatId, async (): Promise<ChatQueueRunResult> => {
       const before = await snapshot(chatId);
       const pendingDecision = input.ports.coachDecisions?.getDecision(chatId);
@@ -193,7 +235,7 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
         const recovery = before.retryRequired;
         if (recovery === undefined || recovery.claimId !== exactId) return { snapshot: before };
         claimId = recovery.claimId;
-        turnId = input.ports.randomId();
+        turnId = recovery.turnId;
         selected = before.items.slice(0, recovery.queuedMessageIds.length);
         queuePort("retryChatQueueClaim").call(input.ports.chatStore, chatId, claimId, turnId);
       } else {
@@ -270,7 +312,8 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
               },
           (event) => {
             if (event.type === "interrupted") interrupted = true;
-            onEvent?.(event);
+            if (retryRun === undefined) onEvent?.(event);
+            else publishQueueRetry(retryRun, event);
           },
           (requested) => {
             decision = requested;
@@ -330,9 +373,10 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
     };
     void task.then(release, release);
     if (mode === "retry" && exactId !== undefined && queueRetryRuns.get(chatId) === undefined) {
-      queueRetryRuns.set(chatId, { claimId: exactId, task });
+      retryRun ??= { claimId: exactId, task, events: retryEvents, subscribers: retrySubscribers };
+      queueRetryRuns.set(chatId, retryRun);
       const releaseRetry = (): void => {
-        if (queueRetryRuns.get(chatId)?.task === task) queueRetryRuns.delete(chatId);
+        if (queueRetryRuns.get(chatId) === retryRun) queueRetryRuns.delete(chatId);
       };
       void task.then(releaseRetry, releaseRetry);
     }

--- a/packages/engine/tests/chat-queue.test.ts
+++ b/packages/engine/tests/chat-queue.test.ts
@@ -524,7 +524,7 @@ describe("engine durable chat queue", () => {
     const firstTurnId = activeEvents.find((event) => event.type === "turn-start")?.turnId;
     const retryTurnId = retryEvents.find((event) => event.type === "turn-start")?.turnId;
     expect(retryTurnId).toBeDefined();
-    expect(retryTurnId).not.toBe(firstTurnId);
+    expect(retryTurnId).toBe(firstTurnId);
     expect(retryEvents.map((event) => event.type)).toEqual(["turn-start", "final-text"]);
 
     const later = await engine.resumeChatQueue!({ chatId: "desktop" });
@@ -566,17 +566,36 @@ describe("engine durable chat queue", () => {
     const recovery = await engine.getChatQueue!({ chatId: "desktop" });
 
     const retryEvents: TurnEvent[] = [];
+    const collectRetryEvent = (event: TurnEvent): void => {
+      retryEvents.push(event);
+    };
     const first = engine.retryQueuedTurn!(
       { chatId: "desktop", claimId: recovery.retryRequired!.claimId },
-      (event) => retryEvents.push(event),
+      collectRetryEvent,
     );
     await retryStarted;
+    const sameSubscriber = engine.retryQueuedTurn!(
+      { chatId: "desktop", claimId: recovery.retryRequired!.claimId },
+      collectRetryEvent,
+    );
+    expect(sameSubscriber).toBe(first);
+    expect(retryEvents.map((event) => event.type)).toEqual(["turn-start"]);
     const duplicateEvents: TurnEvent[] = [];
     const duplicate = engine.retryQueuedTurn!(
       { chatId: "desktop", claimId: recovery.retryRequired!.claimId },
       (event) => duplicateEvents.push(event),
     );
     expect(duplicate).toBe(first);
+    expect(duplicateEvents.map((event) => event.type)).toEqual(["turn-start"]);
+    const throwingSubscriber = vi.fn(() => {
+      throw new Error("detached subscriber");
+    });
+    expect(() =>
+      engine.retryQueuedTurn!(
+        { chatId: "desktop", claimId: recovery.retryRequired!.claimId },
+        throwingSubscriber,
+      ),
+    ).not.toThrow();
 
     const different = engine.retryQueuedTurn!({ chatId: "desktop", claimId: "stale-claim" });
     expect(different).not.toBe(first);
@@ -590,7 +609,9 @@ describe("engine durable chat queue", () => {
     expect(firstResult).toMatchObject({ response: { text: "Recovered" }, snapshot: { items: [] } });
     expect(retryEvents.filter((event) => event.type === "turn-start")).toHaveLength(1);
     expect(retryEvents.filter((event) => event.type === "final-text")).toHaveLength(1);
-    expect(duplicateEvents).toEqual([]);
+    expect(duplicateEvents.map((event) => event.type)).toEqual(["turn-start", "final-text"]);
+    expect(duplicateEvents).toEqual(retryEvents);
+    expect(throwingSubscriber).toHaveBeenCalledTimes(2);
     expect(generate).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Summary

- replay buffered retry events to every reconnecting RPC caller without starting another model attempt
- preserve the original turn identity across interrupted and completed durable attempts
- project relaunch and archive history as one athlete message with every Coach attempt in order
- keep retry attempts together across transcript pagination

## Verification

- 241 focused chat recovery tests
- root pnpm check
- autoreview clean; overall correctness 0.96
- visible Electron durable relaunch QA, including a second relaunch
- targeted formatter check for all changed files

User-facing: Chat recovery now survives repeated connection losses without duplicating your message after relaunch, while preserving every partial and completed Coach response.