### PR TITLE
fix(chat): restore stopped decision continuations

### DIFF
--- a/.changeset/restore-stopped-decision-continuations.md
+++ b/.changeset/restore-stopped-decision-continuations.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/desktop-renderer": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Chat now restores a stopped Coach decision response without a blank message or completed styling, and waits to show the saved choice until its continuation finishes.

--- a/apps/desktop-renderer/src/chat/hydration.ts
+++ b/apps/desktop-renderer/src/chat/hydration.ts
@@ -138,15 +138,19 @@ export function mergeHydratedMessages(
       };
       if (attempt > 1) return [coach];
       return [
-        {
-          id: `history:athlete:${entry.turnId}`,
-          turnId: entry.turnId,
-          role: "athlete",
-          text: entry.athleteText,
-          delivery: "complete",
-          historical: true,
-          ...(entry.attachments === undefined ? {} : { attachments: entry.attachments }),
-        },
+        ...(/\S/u.test(entry.athleteText) || (entry.attachments?.length ?? 0) > 0
+          ? [
+              {
+                id: `history:athlete:${entry.turnId}`,
+                turnId: entry.turnId,
+                role: "athlete" as const,
+                text: entry.athleteText,
+                delivery: "complete" as const,
+                historical: true,
+                ...(entry.attachments === undefined ? {} : { attachments: entry.attachments }),
+              },
+            ]
+          : []),
         coach,
       ];
     }

--- a/apps/desktop-renderer/src/state/adapters/chat.ts
+++ b/apps/desktop-renderer/src/state/adapters/chat.ts
@@ -65,13 +65,20 @@ function historicalTimeline(
   liveDecisionIds: ReadonlySet<string>,
 ): readonly ChatTranscriptItemView[] {
   const requested = new Map<string, CoachDecisionReadModel>();
+  const answered = new Map<
+    string,
+    Extract<TranscriptPageEntry, { readonly kind: "decision-answered" }>
+  >();
   const turnAttempts = new Map<string, number>();
   const timeline: ChatTranscriptItemView[] = [];
   for (const entry of entries) {
     if (entry.kind === "turn") {
       const attempt = (turnAttempts.get(entry.turnId) ?? 0) + 1;
       turnAttempts.set(entry.turnId, attempt);
-      if (attempt === 1) {
+      if (
+        attempt === 1 &&
+        (/\S/u.test(entry.athleteText) || (entry.attachments?.length ?? 0) > 0)
+      ) {
         timeline.push({
           kind: "message",
           message: {
@@ -123,23 +130,7 @@ function historicalTimeline(
       continue;
     }
     if (entry.kind === "decision-answered") {
-      const source = requested.get(entry.decisionId);
-      const answer = entry.answer;
-      const label =
-        answer.kind === "custom"
-          ? answer.text
-          : (source?.options.find((option) => option.id === answer.optionId)?.label ??
-            "Saved choice");
-      timeline.push({
-        kind: "choice",
-        choice: {
-          id: entry.decisionId,
-          label,
-          consequence: answer.kind === "custom" ? null : entry.consequence,
-          skipped: false,
-          historical: true,
-        },
-      });
+      answered.set(JSON.stringify([entry.decisionId, entry.continuationId]), entry);
       continue;
     }
     if (entry.kind === "decision-skipped") {
@@ -155,7 +146,28 @@ function historicalTimeline(
       });
       continue;
     }
-    if (entry.kind === "decision-continuation-completed" && /\S/u.test(entry.coachText)) {
+    if (entry.kind === "decision-continuation-completed") {
+      const savedAnswer = answered.get(JSON.stringify([entry.decisionId, entry.continuationId]));
+      if (savedAnswer !== undefined) {
+        const source = requested.get(entry.decisionId);
+        const answer = savedAnswer.answer;
+        const label =
+          answer.kind === "custom"
+            ? answer.text
+            : (source?.options.find((option) => option.id === answer.optionId)?.label ??
+              "Saved choice");
+        timeline.push({
+          kind: "choice",
+          choice: {
+            id: entry.decisionId,
+            label,
+            consequence: answer.kind === "custom" ? null : savedAnswer.consequence,
+            skipped: false,
+            historical: true,
+          },
+        });
+      }
+      if (!/\S/u.test(entry.coachText)) continue;
       timeline.push({
         kind: "message",
         message: {
@@ -295,12 +307,13 @@ export function createChatViewAdapter(input: {
       planningRequestFocusId: controls?.planningRequests?.focusId ?? null,
       timeline: sameChatTimeline(published.timeline, timeline) ? published.timeline : timeline,
       status: state.status,
-      notice:
-        state.activeTurn?.error?.athleteMessage ??
-        (state.status === "streaming" ? null : state.progress),
+      notice: decisionBlocksWork
+        ? null
+        : (state.activeTurn?.error?.athleteMessage ??
+          (state.status === "streaming" ? null : state.progress)),
       coachProgress:
         state.status === "streaming" && state.activeTurn?.error === null ? state.progress : null,
-      interrupted: state.status === "interrupted",
+      interrupted: state.status === "interrupted" && !decisionBlocksWork,
       workBlocked,
       sendDisabled:
         workBlocked || decisionBlocksWork || decisionUnavailable || attachmentUnavailable,

--- a/apps/desktop-renderer/src/ui/chat/CoachDecisionPanel.tsx
+++ b/apps/desktop-renderer/src/ui/chat/CoachDecisionPanel.tsx
@@ -145,6 +145,39 @@ export function CoachDecisionPanel(props: {
   }
 
   if (
+    decision?.status === "answered" &&
+    decision.continuation.status === "pending" &&
+    error !== null
+  ) {
+    return (
+      <section
+        className="grid gap-inset rounded-card border border-line bg-surface p-4 shadow-elev-2"
+        aria-live="polite"
+      >
+        <div className="grid gap-[calc(var(--inset)/2)]">
+          <strong className="text-sm font-medium leading-5">Your choice is saved</strong>
+          <p className="m-0 text-xs leading-4 text-ink-2">{answerLabel ?? "Your answer"}</p>
+          <p className="m-0 text-xs leading-4 text-danger" role="alert">
+            {error}
+          </p>
+        </div>
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!available}
+            onClick={() => {
+              retryDecision();
+            }}
+          >
+            Try again
+          </Button>
+        </div>
+      </section>
+    );
+  }
+
+  if (
     decision !== null &&
     (phase !== "idle" ||
       (decision.status === "answered" && decision.continuation.status === "pending"))

--- a/apps/desktop-renderer/tests/chat-adapter.test.tsx
+++ b/apps/desktop-renderer/tests/chat-adapter.test.tsx
@@ -391,6 +391,225 @@ describe("chat view adapter", () => {
     ]);
   });
 
+  it("keeps a stopped decision continuation visibly pending during failed hydration", () => {
+    const published: ChatSurfaceState[] = [];
+    const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
+    const decision = {
+      decisionId: "decision-stopped",
+      chatId: "desktop",
+      messageId: "message-stopped",
+      question: "Choose tomorrow’s priority.",
+      status: "unanswered" as const,
+      options: [
+        {
+          id: "recovery",
+          label: "Prioritize recovery",
+          description: "Choose an easy day.",
+          recommended: true,
+          consequence: "Tomorrow becomes a recovery day.",
+        },
+        {
+          id: "tempo",
+          label: "Keep tempo",
+          description: "Keep the planned workout.",
+          recommended: false,
+          consequence: "Tomorrow keeps tempo.",
+        },
+      ],
+    };
+
+    adapter.view.render(
+      EMPTY_CHAT_STATE,
+      controls({
+        hydration: {
+          status: "ready",
+          hasEarlier: false,
+          revision: 1,
+          change: "initial",
+          entries: [
+            {
+              kind: "decision-requested",
+              recordedAt: "1998-08-24T08:00:00.000Z",
+              athleteText: "What should I do tomorrow?",
+              decision,
+            },
+            {
+              kind: "decision-answered",
+              recordedAt: "1998-08-24T08:01:00.000Z",
+              decisionId: decision.decisionId,
+              answer: { kind: "option", optionId: "recovery" },
+              consequence: "Tomorrow becomes a recovery day.",
+              continuationId: "continuation-stopped",
+            },
+            {
+              kind: "turn",
+              turnId: "turn-stopped",
+              completedAt: "1998-08-24T08:02:00.000Z",
+              athleteText: "",
+              coachText: "Keep tomorrow easy while",
+              delivery: "interrupted",
+            },
+          ],
+        },
+        decisionLoadError: "Reconnect to restore the saved choice.",
+      }),
+    );
+
+    expect(published.at(-1)?.timeline).toEqual([
+      {
+        kind: "message",
+        message: {
+          id: "history:decision-athlete:decision-stopped",
+          role: "athlete",
+          delivery: "complete",
+          historical: true,
+          text: "What should I do tomorrow?",
+        },
+      },
+      {
+        kind: "message",
+        message: {
+          id: "history:coach:turn-stopped",
+          turnId: "turn-stopped",
+          role: "coach",
+          delivery: "interrupted",
+          historical: true,
+          text: "Keep tomorrow easy while",
+        },
+      },
+    ]);
+    expect(published.at(-1)).toMatchObject({ sendDisabled: true, inputDisabled: false });
+  });
+
+  it("places a saved choice immediately before its completed continuation", () => {
+    const published: ChatSurfaceState[] = [];
+    const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
+    const decision = {
+      decisionId: "decision-stopped",
+      chatId: "desktop",
+      messageId: "message-stopped",
+      question: "Choose tomorrow’s priority.",
+      status: "unanswered" as const,
+      options: [
+        {
+          id: "recovery",
+          label: "Prioritize recovery",
+          description: "Choose an easy day.",
+          recommended: true,
+          consequence: "Tomorrow becomes a recovery day.",
+        },
+      ],
+    };
+
+    adapter.view.render(
+      EMPTY_CHAT_STATE,
+      controls({
+        hydration: {
+          status: "ready",
+          hasEarlier: false,
+          revision: 1,
+          change: "initial",
+          entries: [
+            {
+              kind: "decision-requested",
+              recordedAt: "1998-08-24T08:00:00.000Z",
+              athleteText: "What should I do tomorrow?",
+              decision,
+            },
+            {
+              kind: "decision-answered",
+              recordedAt: "1998-08-24T08:01:00.000Z",
+              decisionId: decision.decisionId,
+              answer: { kind: "option", optionId: "recovery" },
+              consequence: "Tomorrow becomes a recovery day.",
+              continuationId: "continuation-stopped",
+            },
+            {
+              kind: "turn",
+              turnId: "turn-stopped",
+              completedAt: "1998-08-24T08:02:00.000Z",
+              athleteText: "",
+              coachText: "Keep tomorrow easy while",
+              delivery: "interrupted",
+            },
+            {
+              kind: "decision-continuation-completed",
+              recordedAt: "1998-08-24T08:03:00.000Z",
+              completedAt: "1998-08-24T08:03:00.000Z",
+              decisionId: decision.decisionId,
+              continuationId: "continuation-stopped",
+              turnId: "turn-resumed",
+              coachText: "Keep tomorrow easy, then reassess.",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(
+      published.at(-1)?.timeline.map((item) => {
+        if (item.kind === "choice") return "choice";
+        if (item.kind === "planning-request") return "planning-request";
+        return item.message.role === "athlete" ? "athlete" : item.message.delivery;
+      }),
+    ).toEqual(["athlete", "interrupted", "choice", "complete"]);
+  });
+
+  it("suppresses generic interrupted recovery while a decision continuation is pending", () => {
+    const published: ChatSurfaceState[] = [];
+    const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });
+    let stopped = reduceChatState(EMPTY_CHAT_STATE, {
+      type: "submit",
+      requestKey: 1,
+      userMessage: "",
+      userMessageId: "unused-athlete",
+      assistantMessageId: "decision-continuation",
+      includeUser: false,
+    });
+    stopped = reduceChatState(stopped, {
+      type: "event",
+      requestKey: 1,
+      event: {
+        type: "interrupted",
+        turnId: "turn-stopped",
+        chatId: "desktop",
+        text: "Keep tomorrow easy while",
+      },
+    });
+
+    adapter.view.render(
+      stopped,
+      controls({
+        decision: {
+          value: {
+            decisionId: "decision-stopped",
+            chatId: "desktop",
+            messageId: "message-stopped",
+            question: "Choose tomorrow’s priority.",
+            status: "answered",
+            options: [],
+            answer: { kind: "custom", text: "Protect recovery" },
+            consequence: "Protect recovery.",
+            continuation: {
+              continuationId: "continuation-stopped",
+              status: "pending",
+            },
+          },
+          phase: "recovering",
+          answerLabel: "Protect recovery",
+          error: "Response stopped. Your partial response is preserved.",
+        },
+      }),
+    );
+
+    expect(published.at(-1)).toMatchObject({
+      status: "interrupted",
+      interrupted: false,
+      notice: null,
+      sendDisabled: true,
+    });
+  });
+
   it("deduplicates a live decision when its persisted entries hydrate later", () => {
     const published: ChatSurfaceState[] = [];
     const adapter = createChatViewAdapter({ publish: (next) => published.push(next) });

--- a/apps/desktop-renderer/tests/chat-hydration.test.ts
+++ b/apps/desktop-renderer/tests/chat-hydration.test.ts
@@ -332,6 +332,25 @@ describe("chat transcript hydration", () => {
     ]);
   });
 
+  it("does not restore an empty athlete row for an interrupted decision continuation", () => {
+    const interrupted = {
+      ...turn("turn-decision-stopped"),
+      athleteText: "",
+      delivery: "interrupted" as const,
+    };
+
+    expect(mergeHydratedMessages([interrupted], [])).toEqual([
+      {
+        id: "history:coach:turn-decision-stopped",
+        turnId: "turn-decision-stopped",
+        role: "coach",
+        text: "Coach turn-decision-stopped",
+        delivery: "interrupted",
+        historical: true,
+      },
+    ]);
+  });
+
   it("preserves newer schema-v1 retry turns after an older schema-v2 page loads", async () => {
     const interrupted = {
       ...turn("turn-recovered-mixed"),

--- a/apps/desktop-renderer/tests/chat-surface.test.tsx
+++ b/apps/desktop-renderer/tests/chat-surface.test.tsx
@@ -327,6 +327,41 @@ describe("chat surface", () => {
       expect(screen.getByText(/was saved before Enduragent reopened/u)).toBeVisible();
     });
 
+    it("shows a settled retry state when a saved continuation stops", async () => {
+      const user = userEvent.setup();
+      const pending: CoachDecisionReadModel = {
+        ...unansweredDecision(),
+        status: "answered",
+        answer: { kind: "option", optionId: "recovery" },
+        consequence: "Tomorrow becomes a recovery day.",
+        continuation: { continuationId: "continuation-1", status: "pending" },
+      };
+      setChat({
+        decision: pending,
+        decisionPhase: "recovering",
+        decisionAnswerLabel: "Prioritize recovery",
+        decisionError: "Response stopped. Your partial response is preserved.",
+        sendDisabled: true,
+        inputDisabled: false,
+      });
+      render(<Harness />);
+
+      const title = screen.getByText("Your choice is saved");
+      const panel = title.closest("section");
+      expect(panel).not.toBeNull();
+      expect(panel).not.toHaveAttribute("aria-busy");
+      expect(panel?.querySelector(".animate-spin")).toBeNull();
+      expect(screen.getByText("Prioritize recovery")).toBeVisible();
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Response stopped. Your partial response is preserved.",
+      );
+      expect(screen.queryByText(/before Enduragent reopened/u)).toBeNull();
+      expect(screen.queryByText("Finishing your saved choice…")).toBeNull();
+
+      await user.click(screen.getByRole("button", { name: "Try again" }));
+      expect(actions.retryDecision).toHaveBeenCalledOnce();
+    });
+
     it("surfaces a decision hydration failure with a reconnect action", async () => {
       const user = userEvent.setup();
       setChat({

--- a/apps/desktop/tests/chat-decision-continuation.integration.test.ts
+++ b/apps/desktop/tests/chat-decision-continuation.integration.test.ts
@@ -1,0 +1,955 @@
+import { createServer } from "node:net";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AnswerCoachDecisionRpcParams,
+  CoachDecisionReadModel,
+  CoachEngine,
+  ResumeCoachDecisionRpcParams,
+  StopChatRequest,
+} from "@enduragent/coach-contract";
+import {
+  Memory,
+  classifyFailure,
+  createConversationStore,
+  createMissingPlatformCalendarMutations,
+  extractRetryAfterMs,
+  type ConversationStorePort,
+} from "@enduragent/core";
+import {
+  createCoachEngine,
+  type EngineHostPorts,
+  type ModelTransportRequest,
+} from "@enduragent/engine";
+import type { GenerateResult, Sport } from "@enduragent/engine/sport";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  launchDesktopFixture,
+  visibleQaCheckpoint,
+  type DesktopFixtureScript,
+  type RunningDesktopFixture,
+} from "./helpers/desktop-fixture.js";
+import { createPlanQaFixtureScript } from "./helpers/plan-qa-live.js";
+
+const hasLoopback = await new Promise<boolean>((resolveAvailability) => {
+  const server = createServer();
+  server.once("error", () => resolveAvailability(false));
+  server.listen({ host: "127.0.0.1", port: 0 }, () => {
+    server.close(() => resolveAvailability(true));
+  });
+});
+
+const token = "d".repeat(43);
+const chatId = "desktop";
+const decisionId = "decision-continuation-recovery";
+const decisionMessageId = "message-decision-continuation-recovery";
+const decisionRequestTurnId = "turn-decision-continuation-request";
+const decisionToolCallId = "tool-decision-continuation-request";
+const continuationId = "continuation-decision-recovery";
+const interruptedTurnId = "turn-decision-interrupted";
+const resumedTurnId = "turn-decision-resumed";
+const athleteText = "Which workout priority should guide tomorrow?";
+const question = "What should guide tomorrow’s workout?";
+const choiceLabel = "Protect recovery";
+const choiceConsequence = "Tomorrow stays controlled for recovery.";
+const partialText = "Keep tomorrow controlled while your legs";
+const completedText = "Keep tomorrow controlled, then reassess after the recovery ride.";
+const loadFailureCopy = "We couldn’t check for a saved Coach question. Reconnect and try again.";
+const attachmentErrorCopy = "We couldn’t update that attachment. Your message draft is preserved.";
+const fixtures: RunningDesktopFixture[] = [];
+const backends: DecisionContinuationBackend[] = [];
+const scratchPaths: string[] = [];
+
+const emptyAttachmentComposer = {
+  schemaVersion: 1,
+  capabilities: {
+    schemaVersion: 1,
+    active: { provider: "codex-agent", model: "fixture", transport: "codex-agent" },
+    documents: { enabled: true, extensions: ["pdf", "txt", "csv", "docx"] },
+    completedActivities: { enabled: true, extensions: ["fit", "tcx", "gpx"] },
+    plannedWorkouts: { enabled: true, extensions: ["zwo", "erg", "mrc"] },
+    images: {
+      enabled: false,
+      mediaTypes: [],
+      reason: "transport_incompatible",
+      source: "transport_blocked",
+      checkedAt: "1998-08-22T08:00:00.000Z",
+    },
+  },
+  draft: null,
+} as const;
+
+interface ScriptRequest {
+  readonly jsonrpc: "2.0";
+  readonly method: string;
+  readonly params: Record<string, unknown>;
+}
+
+function response(value: unknown): readonly string[] {
+  return [JSON.stringify(value)];
+}
+
+function generated(text: string): GenerateResult {
+  return {
+    text,
+    toolCalls: [],
+    finishReason: "stop",
+    usage: {
+      inputTokens: 1,
+      outputTokens: 1,
+      totalTokens: 2,
+      inputTokenDetails: { noCacheTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      outputTokenDetails: { textTokens: 1, reasoningTokens: 0 },
+    },
+  };
+}
+
+const decisionSport = {
+  id: "cycling",
+  soul: "",
+  skills: {},
+  sessionClusterGapMinutes: 30,
+  memorySections: [],
+  mustPreserveTokens: [],
+  intervalsActivityTypes: [],
+  athleteProfileSchema: {},
+  tools: () => [],
+} as unknown as Sport;
+
+class DecisionContinuationBackend {
+  readonly calls: ScriptRequest[] = [];
+  readonly script: DesktopFixtureScript;
+  decisionLoadFailures = 0;
+  providerCalls = 0;
+  private conversation: ConversationStorePort | undefined;
+  private engine: CoachEngine | undefined;
+  private failNextDecisionLoad = false;
+  private instant = Date.UTC(1998, 7, 24, 8);
+  private idSequence = 0;
+
+  constructor(private readonly conversationDir: string) {
+    const base = createPlanQaFixtureScript("PL-S004");
+    this.script = {
+      onRequest: async (value) => {
+        const request = value as ScriptRequest;
+        this.calls.push(request);
+        if (request.method === "getCoachDecision") {
+          if (this.failNextDecisionLoad) {
+            this.failNextDecisionLoad = false;
+            this.decisionLoadFailures += 1;
+            throw new Error("synthetic decision hydration failure");
+          }
+          return response(
+            await this.requireEngine().getCoachDecision({
+              chatId: String(request.params.chatId),
+            }),
+          );
+        }
+        if (request.method === "stopChat") {
+          const stopChat = this.requireEngine().stopChat;
+          if (stopChat === undefined) throw new TypeError("stopChat is unavailable");
+          return response(
+            await stopChat({
+              chatId: String(request.params.chatId),
+              turnId: String(request.params.turnId),
+            }),
+          );
+        }
+        if (request.method === "getChatQueue") {
+          return response(this.requireConversation().getChatQueue(chatId));
+        }
+        if (request.method === "getChatAttachmentComposer") {
+          return response(emptyAttachmentComposer);
+        }
+        if (request.method === "hasSession") {
+          return response(await this.requireEngine().hasSession({ chatId }));
+        }
+        if (request.method === "getTranscriptPage") {
+          const cursor = request.params.cursor;
+          const limit = request.params.limit;
+          if ((cursor !== null && typeof cursor !== "string") || typeof limit !== "number") {
+            throw new TypeError("invalid transcript page request");
+          }
+          return response(
+            this.requireConversation().readCurrentConversationPage(chatId, { cursor, limit }),
+          );
+        }
+        if (
+          request.method === "resumePlanningRequests" ||
+          request.method === "listPlanningRequests"
+        ) {
+          return response({ deliveries: [] });
+        }
+        return base.onRequest(value);
+      },
+      onStreamRequest: async (value, emitFrame) => {
+        const request = value as ScriptRequest;
+        this.calls.push(request);
+        if (request.method === "answerCoachDecision") {
+          const result = await this.requireEngine().answerCoachDecision(
+            request.params as unknown as AnswerCoachDecisionRpcParams,
+            (event) => emitFrame(JSON.stringify(event)),
+          );
+          return JSON.stringify(result);
+        }
+        if (request.method === "resumeCoachDecision") {
+          const result = await this.requireEngine().resumeCoachDecision(
+            request.params as unknown as ResumeCoachDecisionRpcParams,
+            (event) => emitFrame(JSON.stringify(event)),
+          );
+          return JSON.stringify(result);
+        }
+        throw new TypeError(`unexpected live fixture method ${request.method}`);
+      },
+    };
+  }
+
+  async open(): Promise<void> {
+    await mkdir(this.conversationDir, { recursive: true, mode: 0o700 });
+    const conversation = createConversationStore(this.conversationDir);
+    this.conversation = conversation;
+    const ports: EngineHostPorts = {
+      config: {
+        dataSource: "platform",
+        llm: {
+          provider: "openai-codex",
+          model: "fixture",
+          apiKey: "",
+          authProfile: "openai-codex",
+        },
+        session: {
+          historyTokenBudgetRatio: 0.3,
+          idleMinutes: 0,
+          dailyResetHour: 4,
+          resetArchiveRetentionDays: 0,
+          timezone: "UTC",
+        },
+        contextWindowTokens: 272_000,
+        compactContextWindowTokens: 272_000,
+      },
+      memory: new Memory(this.conversationDir, "UTC"),
+      chatStore: conversation,
+      transcriptWriter: conversation,
+      coachDecisions: conversation,
+      secrets: { resolve: async () => "" },
+      platform: {
+        legacyClient: null,
+        athleteData: undefined,
+        calendarMutations: createMissingPlatformCalendarMutations(),
+      },
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+      usage: { append: () => {} },
+      stateReader: {
+        getAthleteState: async () => {
+          throw new TypeError("athlete state is unavailable in this fixture");
+        },
+      },
+      readReferenceState: () => ({ errorState: null, latest: null }),
+      getAccessToken: async () => "token",
+      classifyFailure,
+      extractRetryAfterMs,
+      now: () => ++this.instant,
+      randomId: () => this.nextId(),
+      modelTransportDecorator: () => ({
+        generate: (request) => this.generate(request),
+      }),
+    };
+    this.engine = createCoachEngine({ sport: decisionSport, ports });
+  }
+
+  seedDecision(): CoachDecisionReadModel {
+    return this.requireConversation().appendDecisionRequested({
+      turnId: decisionRequestTurnId,
+      toolCallId: decisionToolCallId,
+      athleteText,
+      requestedAt: "1998-08-24T08:00:00.000Z",
+      decision: {
+        status: "unanswered",
+        decisionId,
+        chatId,
+        messageId: decisionMessageId,
+        question,
+        options: [
+          {
+            id: "recovery",
+            label: choiceLabel,
+            description: "Keep the next session controlled.",
+            recommended: true,
+            consequence: choiceConsequence,
+          },
+          {
+            id: "tempo",
+            label: "Keep tempo",
+            description: "Retain the planned tempo work.",
+            recommended: false,
+            consequence: "Tomorrow keeps the planned tempo work.",
+          },
+        ],
+      },
+    });
+  }
+
+  async reopen(failDecisionLoad: boolean): Promise<void> {
+    this.conversation = undefined;
+    this.engine = undefined;
+    await this.open();
+    this.failNextDecisionLoad = failDecisionLoad;
+  }
+
+  close(): void {
+    this.conversation = undefined;
+    this.engine = undefined;
+  }
+
+  snapshot() {
+    return {
+      decision: this.requireConversation().getDecision(chatId),
+      transcript: this.requireConversation().readCurrentConversationPage(chatId, {
+        cursor: null,
+        limit: 25,
+      }),
+    };
+  }
+
+  private async generate(request: ModelTransportRequest): Promise<GenerateResult> {
+    this.providerCalls += 1;
+    if (this.providerCalls === 1) {
+      request.options.onTextDelta?.(partialText);
+      await new Promise<void>((_resolve, reject) => {
+        const signal = request.options.signal;
+        const rejectAbort = (): void => reject(signal?.reason ?? new Error("aborted"));
+        if (signal?.aborted === true) rejectAbort();
+        else signal?.addEventListener("abort", rejectAbort, { once: true });
+      });
+      throw new TypeError("interrupted provider call did not abort");
+    }
+    if (this.providerCalls !== 2) throw new TypeError("unexpected decision continuation call");
+    request.options.onTextDelta?.(completedText);
+    return generated(completedText);
+  }
+
+  private nextId(): string {
+    const ids = [continuationId, interruptedTurnId, resumedTurnId];
+    const id = ids[this.idSequence++];
+    if (id === undefined) throw new TypeError("unexpected engine identifier request");
+    return id;
+  }
+
+  private requireConversation(): ConversationStorePort {
+    if (this.conversation === undefined) throw new TypeError("conversation store is closed");
+    return this.conversation;
+  }
+
+  private requireEngine(): CoachEngine {
+    if (this.engine === undefined) throw new TypeError("coach engine is closed");
+    return this.engine;
+  }
+}
+
+async function captureEvidence(fixture: RunningDesktopFixture, name: string): Promise<void> {
+  const directory = process.env.DEC_02_EVIDENCE_DIR;
+  if (directory === undefined) return;
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await fixture.screenshot(join(directory, `${name}.png`));
+}
+
+async function checkpoint(fixture: RunningDesktopFixture, name: string): Promise<void> {
+  await captureEvidence(fixture, name);
+  await visibleQaCheckpoint(name);
+}
+
+async function readDecisionPrompt(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly questionCount: number;
+    readonly recommendedCount: number;
+    readonly sendDisabled: boolean;
+    readonly inputDisabled: boolean;
+  }>(`
+    const question = ${JSON.stringify(question)};
+    const choice = ${JSON.stringify(choiceLabel)};
+    const deadline = Date.now() + 10000;
+    let panel;
+    while (Date.now() < deadline) {
+      panel = [...document.querySelectorAll(".composer-projections section")].find(
+        (element) => element.textContent?.includes(question),
+      );
+      if (panel instanceof HTMLElement) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(panel instanceof HTMLElement)) throw new Error("decision prompt missing");
+    const send = document.querySelector('button[aria-label="Send message"]');
+    const input = document.querySelector("textarea#message");
+    if (!(send instanceof HTMLButtonElement)) throw new Error("send action missing");
+    if (!(input instanceof HTMLTextAreaElement)) throw new Error("chat input missing");
+    const recommended = [...panel.querySelectorAll("button")].filter(
+      (button) => button.textContent?.includes(choice) && button.textContent?.includes("Recommended"),
+    );
+    return {
+      questionCount: [...document.querySelectorAll(".composer-projections section")].filter(
+        (element) => element.textContent?.includes(question),
+      ).length,
+      recommendedCount: recommended.length,
+      sendDisabled: send.disabled,
+      inputDisabled: input.disabled,
+    };
+  `);
+}
+
+async function chooseAndReadPartial(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly partialCount: number;
+    readonly stopCount: number;
+    readonly status: string | null;
+    readonly choiceCount: number;
+  }>(`
+    const choice = ${JSON.stringify(choiceLabel)};
+    const partial = ${JSON.stringify(partialText)};
+    const option = [...document.querySelectorAll(".composer-projections button")].find(
+      (button) => button.textContent?.includes(choice),
+    );
+    if (!(option instanceof HTMLButtonElement)) throw new Error("recommended option missing");
+    option.click();
+    const deadline = Date.now() + 10000;
+    while (Date.now() < deadline) {
+      const coachRows = [...document.querySelectorAll(".chat-message--coach")];
+      const stop = document.querySelector('button[aria-label="Stop responding"]');
+      if (
+        coachRows.some((row) => row.textContent?.includes(partial)) &&
+        stop instanceof HTMLButtonElement
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return {
+      partialCount: [...document.querySelectorAll(".chat-message--coach")].filter(
+        (row) => row.textContent?.includes(partial),
+      ).length,
+      stopCount: document.querySelectorAll('button[aria-label="Stop responding"]').length,
+      status: document.querySelector(".conversation")?.getAttribute("data-chat-status") ?? null,
+      choiceCount: document.querySelectorAll('[aria-label="Choice consequence"]').length,
+    };
+  `);
+}
+
+async function stopAndReadInterrupted(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly stoppedCopyCount: number;
+    readonly status: string | null;
+    readonly partialDelivery: string | null;
+    readonly athleteCount: number;
+    readonly blankAthleteCount: number;
+    readonly choiceCount: number;
+    readonly genericRetryCount: number;
+    readonly decisionRetryCount: number;
+    readonly prematureReopenCopyCount: number;
+    readonly busyRecoveryCount: number;
+    readonly attachmentErrorCount: number;
+  }>(`
+    const partial = ${JSON.stringify(partialText)};
+    const stoppedCopy = "Response stopped. Your partial response is preserved.";
+    const attachmentError = ${JSON.stringify(attachmentErrorCopy)};
+    const stop = document.querySelector('button[aria-label="Stop responding"]');
+    if (!(stop instanceof HTMLButtonElement)) throw new Error("stop action missing");
+    stop.click();
+    const deadline = Date.now() + 10000;
+    while (Date.now() < deadline) {
+      const status = document.querySelector(".conversation")?.getAttribute("data-chat-status");
+      const alert = [...document.querySelectorAll('[role="alert"]')].find(
+        (element) => element.textContent?.includes(stoppedCopy),
+      );
+      const buttons = [...document.querySelectorAll("button")];
+      const decisionRetry = buttons.find(
+        (button) => !button.hidden && button.textContent?.trim() === "Try again",
+      );
+      const genericRetry = buttons.find(
+        (button) => !button.hidden && button.textContent?.trim() === "Retry message",
+      );
+      if (
+        status === "interrupted" &&
+        alert instanceof HTMLElement &&
+        decisionRetry instanceof HTMLButtonElement &&
+        genericRetry === undefined
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const partialRow = [...document.querySelectorAll(".chat-message--coach")].find(
+      (row) => row.textContent?.includes(partial),
+    );
+    const athleteRows = [...document.querySelectorAll(".chat-message--athlete")];
+    const buttons = [...document.querySelectorAll("button")];
+    const recoverySections = [...document.querySelectorAll(".composer-projections section")].filter(
+      (section) => section.textContent?.includes(${JSON.stringify(choiceLabel)}),
+    );
+    return {
+      stoppedCopyCount: [...document.querySelectorAll('[role="alert"]')].filter(
+        (element) => element.textContent?.includes(stoppedCopy),
+      ).length,
+      status: document.querySelector(".conversation")?.getAttribute("data-chat-status") ?? null,
+      partialDelivery: partialRow?.getAttribute("data-delivery") ?? null,
+      athleteCount: athleteRows.length,
+      blankAthleteCount: athleteRows.filter(
+        (row) => !row.querySelector(".chat-message__text")?.textContent?.trim(),
+      ).length,
+      choiceCount: document.querySelectorAll('[aria-label="Choice consequence"]').length,
+      genericRetryCount: buttons.filter(
+        (button) => !button.hidden && button.textContent?.trim() === "Retry message",
+      ).length,
+      decisionRetryCount: buttons.filter(
+        (button) => !button.hidden && button.textContent?.trim() === "Try again",
+      ).length,
+      prematureReopenCopyCount: recoverySections.filter((section) =>
+        section.textContent?.includes("was saved before Enduragent reopened"),
+      ).length,
+      busyRecoveryCount: recoverySections.filter(
+        (section) => section.getAttribute("aria-busy") === "true",
+      ).length,
+      attachmentErrorCount: [...document.querySelectorAll('[role="alert"]')].filter(
+        (element) => element.textContent?.includes(attachmentError),
+      ).length,
+    };
+  `);
+}
+
+async function readLoadFailure(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly reconnectCount: number;
+    readonly loadFailureCount: number;
+    readonly sendDisabled: boolean;
+    readonly inputDisabled: boolean;
+    readonly choiceCount: number;
+    readonly athleteCount: number;
+    readonly blankAthleteCount: number;
+    readonly partialCount: number;
+    readonly partialDelivery: string | null;
+    readonly newChatDisabled: boolean;
+    readonly attachmentErrorCount: number;
+  }>(`
+    const failure = ${JSON.stringify(loadFailureCopy)};
+    const partial = ${JSON.stringify(partialText)};
+    const attachmentError = ${JSON.stringify(attachmentErrorCopy)};
+    const deadline = Date.now() + 10000;
+    let reconnect;
+    let partialRow;
+    while (Date.now() < deadline) {
+      reconnect = [...document.querySelectorAll(".composer-projections button")].find(
+        (button) => button.textContent?.trim() === "Reconnect",
+      );
+      partialRow = [...document.querySelectorAll(".chat-message--coach")].find(
+        (row) => row.textContent?.includes(partial),
+      );
+      if (reconnect instanceof HTMLButtonElement && partialRow instanceof HTMLElement) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(reconnect instanceof HTMLButtonElement)) throw new Error("Reconnect action missing");
+    if (!(partialRow instanceof HTMLElement)) throw new Error("interrupted response missing");
+    const send = document.querySelector('button[aria-label="Send message"]');
+    const input = document.querySelector("textarea#message");
+    const newChat = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "New chat",
+    );
+    if (!(send instanceof HTMLButtonElement)) throw new Error("send action missing");
+    if (!(input instanceof HTMLTextAreaElement)) throw new Error("chat input missing");
+    if (!(newChat instanceof HTMLButtonElement)) throw new Error("New chat action missing");
+    const athleteRows = [...document.querySelectorAll(".chat-message--athlete")];
+    return {
+      reconnectCount: [...document.querySelectorAll(".composer-projections button")].filter(
+        (button) => button.textContent?.trim() === "Reconnect",
+      ).length,
+      loadFailureCount: [...document.querySelectorAll('[role="alert"]')].filter(
+        (element) => element.textContent?.includes(failure),
+      ).length,
+      sendDisabled: send.disabled,
+      inputDisabled: input.disabled,
+      choiceCount: document.querySelectorAll('[aria-label="Choice consequence"]').length,
+      athleteCount: athleteRows.length,
+      blankAthleteCount: athleteRows.filter(
+        (row) => !row.querySelector(".chat-message__text")?.textContent?.trim(),
+      ).length,
+      partialCount: [...document.querySelectorAll(".chat-message--coach")].filter(
+        (row) => row.textContent?.includes(partial),
+      ).length,
+      partialDelivery: partialRow.getAttribute("data-delivery"),
+      newChatDisabled: newChat.disabled,
+      attachmentErrorCount: [...document.querySelectorAll('[role="alert"]')].filter(
+        (element) => element.textContent?.includes(attachmentError),
+      ).length,
+    };
+  `);
+}
+
+async function reconnectAndReadCompleted(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly partialCount: number;
+    readonly completedCount: number;
+    readonly partialDelivery: string | null;
+    readonly completedDelivery: string | null;
+    readonly athleteCount: number;
+    readonly blankAthleteCount: number;
+    readonly choiceCount: number;
+    readonly consequenceCount: number;
+    readonly sendDisabled: boolean;
+    readonly reconnectCount: number;
+    readonly timelineOrder: readonly string[];
+    readonly attachmentErrorCount: number;
+  }>(`
+    const partial = ${JSON.stringify(partialText)};
+    const completed = ${JSON.stringify(completedText)};
+    const consequence = ${JSON.stringify(choiceConsequence)};
+    const attachmentError = ${JSON.stringify(attachmentErrorCopy)};
+    const reconnect = [...document.querySelectorAll(".composer-projections button")].find(
+      (button) => button.textContent?.trim() === "Reconnect",
+    );
+    if (!(reconnect instanceof HTMLButtonElement)) throw new Error("Reconnect action missing");
+    reconnect.click();
+    const deadline = Date.now() + 10000;
+    let completedRow;
+    while (Date.now() < deadline) {
+      completedRow = [...document.querySelectorAll(".chat-message--coach")].find(
+        (row) => row.textContent?.includes(completed),
+      );
+      const choice = document.querySelector('[aria-label="Choice consequence"]');
+      const send = document.querySelector('button[aria-label="Send message"]');
+      if (
+        completedRow instanceof HTMLElement &&
+        choice instanceof HTMLElement &&
+        send instanceof HTMLButtonElement &&
+        !send.disabled
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(completedRow instanceof HTMLElement)) throw new Error("resumed response missing");
+    const partialRow = [...document.querySelectorAll(".chat-message--coach")].find(
+      (row) => row.textContent?.includes(partial),
+    );
+    if (!(partialRow instanceof HTMLElement)) throw new Error("interrupted response missing");
+    const send = document.querySelector('button[aria-label="Send message"]');
+    if (!(send instanceof HTMLButtonElement)) throw new Error("send action missing");
+    const athleteRows = [...document.querySelectorAll(".chat-message--athlete")];
+    const timelineOrder = [...document.querySelectorAll(".chat-messages article")].map((row) => {
+      if (row.getAttribute("aria-label") === "Choice consequence") return "choice";
+      if (row.classList.contains("chat-message--athlete")) return "athlete";
+      if (row.textContent?.includes(partial)) return "partial";
+      if (row.textContent?.includes(completed)) return "completed";
+      return "other";
+    });
+    return {
+      partialCount: [...document.querySelectorAll(".chat-message--coach")].filter(
+        (row) => row.textContent?.includes(partial),
+      ).length,
+      completedCount: [...document.querySelectorAll(".chat-message--coach")].filter(
+        (row) => row.textContent?.includes(completed),
+      ).length,
+      partialDelivery: partialRow.getAttribute("data-delivery"),
+      completedDelivery: completedRow.getAttribute("data-delivery"),
+      athleteCount: athleteRows.length,
+      blankAthleteCount: athleteRows.filter(
+        (row) => !row.querySelector(".chat-message__text")?.textContent?.trim(),
+      ).length,
+      choiceCount: document.querySelectorAll('[aria-label="Choice consequence"]').length,
+      consequenceCount: [...document.querySelectorAll('[aria-label="Choice consequence"]')].filter(
+        (row) => row.textContent?.includes(consequence),
+      ).length,
+      sendDisabled: send.disabled,
+      reconnectCount: [...document.querySelectorAll(".composer-projections button")].filter(
+        (button) => button.textContent?.trim() === "Reconnect",
+      ).length,
+      timelineOrder,
+      attachmentErrorCount: [...document.querySelectorAll('[role="alert"]')].filter(
+        (element) => element.textContent?.includes(attachmentError),
+      ).length,
+    };
+  `);
+}
+
+async function readCompleted(fixture: RunningDesktopFixture) {
+  return fixture.evaluate<{
+    readonly partialCount: number;
+    readonly completedCount: number;
+    readonly partialDelivery: string | null;
+    readonly completedDelivery: string | null;
+    readonly athleteCount: number;
+    readonly blankAthleteCount: number;
+    readonly choiceCount: number;
+    readonly consequenceCount: number;
+    readonly sendDisabled: boolean;
+    readonly reconnectCount: number;
+    readonly timelineOrder: readonly string[];
+    readonly attachmentErrorCount: number;
+  }>(`
+    const partial = ${JSON.stringify(partialText)};
+    const completed = ${JSON.stringify(completedText)};
+    const consequence = ${JSON.stringify(choiceConsequence)};
+    const attachmentError = ${JSON.stringify(attachmentErrorCopy)};
+    const deadline = Date.now() + 10000;
+    let partialRow;
+    let completedRow;
+    while (Date.now() < deadline) {
+      const rows = [...document.querySelectorAll(".chat-message--coach")];
+      partialRow = rows.find((row) => row.textContent?.includes(partial));
+      completedRow = rows.find((row) => row.textContent?.includes(completed));
+      const choice = document.querySelector('[aria-label="Choice consequence"]');
+      if (
+        partialRow instanceof HTMLElement &&
+        completedRow instanceof HTMLElement &&
+        choice instanceof HTMLElement
+      ) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    if (!(partialRow instanceof HTMLElement)) throw new Error("interrupted response missing");
+    if (!(completedRow instanceof HTMLElement)) throw new Error("completed response missing");
+    const send = document.querySelector('button[aria-label="Send message"]');
+    if (!(send instanceof HTMLButtonElement)) throw new Error("send action missing");
+    const athleteRows = [...document.querySelectorAll(".chat-message--athlete")];
+    const timelineOrder = [...document.querySelectorAll(".chat-messages article")].map((row) => {
+      if (row.getAttribute("aria-label") === "Choice consequence") return "choice";
+      if (row.classList.contains("chat-message--athlete")) return "athlete";
+      if (row.textContent?.includes(partial)) return "partial";
+      if (row.textContent?.includes(completed)) return "completed";
+      return "other";
+    });
+    return {
+      partialCount: [...document.querySelectorAll(".chat-message--coach")].filter(
+        (row) => row.textContent?.includes(partial),
+      ).length,
+      completedCount: [...document.querySelectorAll(".chat-message--coach")].filter(
+        (row) => row.textContent?.includes(completed),
+      ).length,
+      partialDelivery: partialRow.getAttribute("data-delivery"),
+      completedDelivery: completedRow.getAttribute("data-delivery"),
+      athleteCount: athleteRows.length,
+      blankAthleteCount: athleteRows.filter(
+        (row) => !row.querySelector(".chat-message__text")?.textContent?.trim(),
+      ).length,
+      choiceCount: document.querySelectorAll('[aria-label="Choice consequence"]').length,
+      consequenceCount: [...document.querySelectorAll('[aria-label="Choice consequence"]')].filter(
+        (row) => row.textContent?.includes(consequence),
+      ).length,
+      sendDisabled: send.disabled,
+      reconnectCount: [...document.querySelectorAll(".composer-projections button")].filter(
+        (button) => button.textContent?.trim() === "Reconnect",
+      ).length,
+      timelineOrder,
+      attachmentErrorCount: [...document.querySelectorAll('[role="alert"]')].filter(
+        (element) => element.textContent?.includes(attachmentError),
+      ).length,
+    };
+  `);
+}
+
+afterEach(async () => {
+  await Promise.all(fixtures.splice(0).map((fixture) => fixture.close()));
+  for (const backend of backends.splice(0)) backend.close();
+  await Promise.all(
+    scratchPaths
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })),
+  );
+});
+
+describe.skipIf(process.platform !== "darwin" || !hasLoopback)(
+  "Chat decision continuation relaunch",
+  () => {
+    it(
+      "stops, restores, reconnects, and completes one durable decision continuation",
+      async () => {
+        const scratch = await mkdtemp(
+          join(await realpath(tmpdir()), "chat-decision-continuation-"),
+        );
+        scratchPaths.push(scratch);
+        const backend = new DecisionContinuationBackend(join(scratch, "conversation"));
+        backends.push(backend);
+        await backend.open();
+        expect(backend.seedDecision()).toMatchObject({
+          status: "unanswered",
+          decisionId,
+          messageId: decisionMessageId,
+        });
+
+        const fixture = await launchDesktopFixture({
+          script: backend.script,
+          token,
+          width: 1180,
+          height: 820,
+          colorScheme: "light",
+          reducedMotion: true,
+          hidden: process.env.DEC_02_VISIBLE === "1" ? false : true,
+          routeChatAttachmentComposer: true,
+        });
+        fixtures.push(fixture);
+
+        expect(await readDecisionPrompt(fixture)).toEqual({
+          questionCount: 1,
+          recommendedCount: 1,
+          sendDisabled: true,
+          inputDisabled: false,
+        });
+        expect(await chooseAndReadPartial(fixture)).toEqual({
+          partialCount: 1,
+          stopCount: 1,
+          status: "streaming",
+          choiceCount: 0,
+        });
+        expect(backend.snapshot().decision).toMatchObject({
+          status: "answered",
+          decisionId,
+          answer: { kind: "option", optionId: "recovery" },
+          consequence: choiceConsequence,
+          continuation: { status: "pending", continuationId },
+        });
+
+        expect(await stopAndReadInterrupted(fixture)).toEqual({
+          stoppedCopyCount: 1,
+          status: "interrupted",
+          partialDelivery: "interrupted",
+          athleteCount: 1,
+          blankAthleteCount: 0,
+          choiceCount: 0,
+          genericRetryCount: 0,
+          decisionRetryCount: 1,
+          prematureReopenCopyCount: 0,
+          busyRecoveryCount: 0,
+          attachmentErrorCount: 0,
+        });
+        await checkpoint(fixture, "dec-02-stopped-continuation");
+        const interrupted = backend.snapshot();
+        expect(interrupted.decision).toMatchObject({
+          status: "answered",
+          decisionId,
+          continuation: { status: "pending", continuationId },
+        });
+        expect(interrupted.transcript).toMatchObject({
+          schemaVersion: 2,
+          status: "page",
+          entries: [
+            {
+              kind: "decision-requested",
+              athleteText,
+              decision: { decisionId, messageId: decisionMessageId },
+            },
+            {
+              kind: "decision-answered",
+              decisionId,
+              continuationId,
+              answer: { kind: "option", optionId: "recovery" },
+            },
+            {
+              kind: "turn",
+              turnId: interruptedTurnId,
+              athleteText: "",
+              coachText: partialText,
+              delivery: "interrupted",
+            },
+          ],
+        });
+        expect(backend.providerCalls).toBe(1);
+
+        await fixture.relaunch(() => backend.reopen(true));
+        const failedLoad = await readLoadFailure(fixture);
+        await checkpoint(fixture, "dec-02-reconnect-required");
+        expect(failedLoad).toEqual({
+          reconnectCount: 1,
+          loadFailureCount: 1,
+          sendDisabled: true,
+          inputDisabled: false,
+          choiceCount: 0,
+          athleteCount: 1,
+          blankAthleteCount: 0,
+          partialCount: 1,
+          partialDelivery: "interrupted",
+          newChatDisabled: true,
+          attachmentErrorCount: 0,
+        });
+        expect(backend.decisionLoadFailures).toBe(1);
+        expect(backend.providerCalls).toBe(1);
+        expect(backend.calls.filter(({ method }) => method === "resumeCoachDecision")).toHaveLength(
+          0,
+        );
+
+        const completedSurface = await reconnectAndReadCompleted(fixture);
+        await checkpoint(fixture, "dec-02-resumed-continuation");
+        expect(completedSurface).toEqual({
+          partialCount: 1,
+          completedCount: 1,
+          partialDelivery: "interrupted",
+          completedDelivery: "complete",
+          athleteCount: 1,
+          blankAthleteCount: 0,
+          choiceCount: 1,
+          consequenceCount: 1,
+          sendDisabled: false,
+          reconnectCount: 0,
+          timelineOrder: ["athlete", "partial", "choice", "completed"],
+          attachmentErrorCount: 0,
+        });
+        const completed = backend.snapshot();
+        expect(completed.decision).toMatchObject({
+          status: "answered",
+          decisionId,
+          continuation: {
+            status: "completed",
+            continuationId,
+            turnId: resumedTurnId,
+            coachText: completedText,
+          },
+        });
+        expect(completed.transcript).toMatchObject({
+          schemaVersion: 2,
+          status: "page",
+          entries: [
+            { kind: "decision-requested", decision: { decisionId } },
+            { kind: "decision-answered", decisionId, continuationId },
+            { kind: "turn", turnId: interruptedTurnId, delivery: "interrupted" },
+            {
+              kind: "decision-continuation-completed",
+              decisionId,
+              continuationId,
+              turnId: resumedTurnId,
+              coachText: completedText,
+            },
+          ],
+        });
+        expect(backend.providerCalls).toBe(2);
+
+        await fixture.relaunch(() => backend.reopen(false));
+        const cleanRelaunch = await readCompleted(fixture);
+        await checkpoint(fixture, "dec-02-clean-relaunch");
+        expect(cleanRelaunch).toEqual(completedSurface);
+        expect(backend.snapshot().decision).toEqual(completed.decision);
+        expect(backend.providerCalls).toBe(2);
+        expect(backend.decisionLoadFailures).toBe(1);
+
+        const answerCalls = backend.calls.filter(({ method }) => method === "answerCoachDecision");
+        const stopCalls = backend.calls.filter(({ method }) => method === "stopChat");
+        const resumeCalls = backend.calls.filter(({ method }) => method === "resumeCoachDecision");
+        const decisionReads = backend.calls.filter(({ method }) => method === "getCoachDecision");
+        expect(answerCalls).toHaveLength(1);
+        expect(answerCalls[0]?.params).toEqual({
+          chatId,
+          decisionId,
+          answer: { kind: "option", optionId: "recovery" },
+        } satisfies AnswerCoachDecisionRpcParams);
+        expect(stopCalls).toHaveLength(1);
+        expect(stopCalls[0]?.params).toEqual({
+          chatId,
+          turnId: interruptedTurnId,
+        } satisfies StopChatRequest);
+        expect(resumeCalls).toHaveLength(1);
+        expect(resumeCalls[0]?.params).toEqual({
+          chatId,
+          decisionId,
+        } satisfies ResumeCoachDecisionRpcParams);
+        expect(decisionReads).toHaveLength(4);
+        expect(decisionReads.every(({ params }) => params.chatId === chatId)).toBe(true);
+
+        expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
+        fixtures.splice(fixtures.indexOf(fixture), 1);
+      },
+      process.env.DEC_02_VISIBLE === "1" ? 600_000 : 150_000,
+    );
+  },
+);

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -182,6 +182,20 @@ export function processAlive(pid: number): boolean {
   }
 }
 
+export async function visibleQaCheckpoint(name: string): Promise<void> {
+  const gateDirectory = process.env.ENDURAGENT_VISIBLE_QA_GATE_DIR;
+  if (gateDirectory === undefined) return;
+  if (!/^[a-z0-9-]+$/.test(name)) throw new TypeError("invalid visible QA checkpoint name");
+  await mkdir(gateDirectory, { recursive: true, mode: 0o700 });
+  await writeFile(join(gateDirectory, `${name}.ready`), "ready\n", { mode: 0o600 });
+  const releasePath = join(gateDirectory, `${name}.release`);
+  const deadline = Date.now() + 600_000;
+  while (!existsSync(releasePath)) {
+    if (Date.now() >= deadline) throw new Error(`visible QA checkpoint timed out: ${name}`);
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 50));
+  }
+}
+
 export async function stopProcess(child: ChildProcess): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) return;
   child.kill("SIGTERM");


### PR DESCRIPTION
## Summary

- Restore interrupted Coach continuations for saved decisions after reconnect or relaunch.
- Keep the saved choice and continuation ordering authoritative while recovery is active.

## Proof

- Focused decision, hydration, renderer, and desktop tests passed.
- Full desktop dependency, renderer, and Electron build passed.
- Four visible macOS recovery checkpoints passed at 1180×820.
- Final isolated Codex autoreview reported no actionable findings.